### PR TITLE
Add changeset for the vyre→octane rename release

### DIFF
--- a/.changeset/rename-vyre-to-octane.md
+++ b/.changeset/rename-vyre-to-octane.md
@@ -1,0 +1,6 @@
+---
+"octane-ts": patch
+"@octane-ts/vite-plugin": patch
+---
+
+Rename the project from `vyre` to `octane`. The runtime now publishes as `octane-ts` and the Vite metaframework plugin as `@octane-ts/vite-plugin`. Identifiers inherited from the Ripple fork were also renamed to Octane (e.g. `setIsRippleActEnvironment` → `setIsOctaneActEnvironment`, the metaframework `ripple()` plugin → `octane()`, and the `ripple.config.ts` convention → `octane.config.ts`). References to the upstream Ripple framework and its `@ripple-ts`/`@tsrx` packages are unchanged.


### PR DESCRIPTION
Patch bump for octane-ts and @octane-ts/vite-plugin so the Changesets action opens a Version Packages PR (0.1.0 → 0.1.1).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-metadata only; no application or library code changes in this diff.
> 
> **Overview**
> Adds a **Changesets** entry (`.changeset/rename-vyre-to-octane.md`) that requests **patch** bumps for `octane-ts` and `@octane-ts/vite-plugin`, so the Changesets workflow can open a Version Packages PR (e.g. 0.1.0 → 0.1.1).
> 
> The changeset note documents the rename from `vyre` to `octane` (package names, `octane()` plugin, `octane.config.ts`, and Octane-specific identifiers), while leaving upstream Ripple / `@ripple-ts` / `@tsrx` references as-is.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb9ad826fecb8cb7f549cda95b0dda505a48d40c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->