### PR TITLE
feat: add basic agent skills and MCP scaffold

### DIFF
--- a/.ai/project-map.md
+++ b/.ai/project-map.md
@@ -1,0 +1,60 @@
+# Octane project map for agents
+
+Octane is a private pnpm monorepo for a TypeScript-first UI framework that keeps a React-shaped authoring/API model while compiling `.tsrx`/JSX ahead of time.
+
+## Authoritative sources
+
+Always prefer current source over summaries:
+
+- `README.md` — positioning, quick start, `.tsrx` syntax, public examples.
+- `AGENTS.md` and `.rulesync/rules/project.md` — shared agent rules. This repo uses RuleSync, so update `.rulesync/rules/` then run `pnpm rules:generate` when changing generated references.
+- `packages/octane/src/runtime.ts` — client runtime: rendering, hooks, scheduler, events, refs, context, portals, Suspense/transitions, keyed reconciler.
+- `packages/octane/src/runtime.server.ts` and `packages/octane/src/server/index.ts` — SSR and hydration-facing server runtime.
+- `packages/octane/src/compiler/` — TSRX compiler and Vite/Volar integration.
+- `packages/octane/src/index.ts` and `packages/octane/src/constants.ts` — public client API.
+- `docs/react-parity-migration-plan.md` — React parity goals, intentional divergences, test migration strategy.
+- `docs/react-library-compat-plan.md` — strategy for porting React ecosystem bindings into Octane packages.
+- `vitest.config.js` — test projects, aliases, compiler/plugin exclusions.
+- `package.json`, `pnpm-workspace.yaml` — workspace scripts and package layout.
+
+## Workspace layout
+
+- `packages/octane/` (`octane`) — core runtime, compiler, SSR, tests.
+- `packages/vite-plugin-octane/` (`@octanejs/vite-plugin`) — optional metaframework/plugin surface.
+- `packages/{zustand,query,motion,stylex,router,lexical,floating-ui}/` — Octane ports/bindings for React ecosystem libraries.
+- `benchmarks/` — perf harnesses: news, js-framework, recursive-context, signal-favoring, dbmon.
+- `examples/`, `playground/` — runnable apps and manual validation.
+- `scripts/scaffold-react-port.mjs` — creates React test-port skeletons with in/out-of-scope triage.
+
+## Validation commands
+
+Prefer the smallest validation that covers the change:
+
+```bash
+pnpm test
+pnpm typecheck
+pnpm format:check
+pnpm rules:generate
+./node_modules/.bin/vitest run packages/octane/tests/<file>.test.ts --reporter=verbose
+```
+
+Run targeted package tests by project/file, e.g.:
+
+```bash
+./node_modules/.bin/vitest run packages/zustand/tests --project zustand
+./node_modules/.bin/vitest run packages/octane/tests/differential/basic.test.ts --project octane
+```
+
+## Core invariants
+
+- Octane is React-shaped, not React-cloned. Check documented intentional divergences before changing behavior.
+- Hooks use compiler-injected call-site slots; conditional/loop hooks are valid.
+- Events are native delegated DOM events, not React synthetic events.
+- No controlled-input reassertion model; `value`/`checked` are attributes.
+- Keyed reconciliation is LIS-based; final DOM and node identity matter more than matching React's move set.
+- `class`/`className` compose clsx-style.
+- No class components, StrictMode double invoke, Server Components, or React synthetic event layer.
+
+## Changesets
+
+Add a changeset for user-facing package changes. Skip for docs-only, tests-only, and internal tooling changes. While Octane is alpha `0.x`, use patch releases unless maintainers say otherwise.

--- a/.ai/skills/bug-hunter.md
+++ b/.ai/skills/bug-hunter.md
@@ -1,0 +1,57 @@
+# Skill: Octane bug hunter
+
+Use this to find, reproduce, minimize, and fix a suspected Octane bug.
+
+## Read first
+
+- `.ai/project-map.md`
+- `AGENTS.md`
+- Owning source and nearby tests
+- `docs/react-parity-migration-plan.md` before assuming React mismatch is a bug
+
+## Workflow
+
+1. **State the suspected behavior**
+   - Expected behavior, actual behavior, package, environment, and reproduction path.
+   - Decide whether the issue concerns runtime, compiler, SSR/hydration, Vite plugin, or an ecosystem binding.
+
+2. **Reproduce before fixing**
+   - Add or locate the smallest failing test/fixture.
+   - For compiler/runtime behavior, prefer `packages/octane/tests/_fixtures/*.tsrx` plus a focused `*.test.ts`.
+   - For React parity, cite source React tests and use conformance/differential conventions.
+   - For ecosystem packages, use that package's `tests/` harness.
+
+3. **Minimize**
+   - Remove unrelated props, effects, timing, and DOM.
+   - Keep `.tsrx` fixtures tiny.
+   - Confirm the test fails for the intended reason, not setup/aliasing/jsdom.
+
+4. **Localize**
+   - Runtime: inspect `packages/octane/src/runtime.ts` comments and closest tests.
+   - Compiler: inspect `packages/octane/src/compiler/compile.js` and emitted output if needed.
+   - SSR: inspect `runtime.server.ts`, `server/index.ts`, hydration tests.
+   - Bindings: compare existing package patterns and upstream React binding behavior.
+
+5. **Patch carefully**
+   - Preserve documented intentional divergences.
+   - Prefer fixing owning source over weakening tests.
+   - Add regression coverage that would fail on the old behavior.
+   - Keep changes minimal and idiomatic.
+
+6. **Validate**
+   - Run the new failing test until it passes.
+   - Run nearby affected tests.
+   - If runtime/compiler changed, consider wider `packages/octane/tests` or `pnpm test` depending on scope.
+   - Run `pnpm typecheck` when TS/API surfaces changed.
+
+7. **Report**
+   - Root cause.
+   - Files changed.
+   - Tests added/updated and commands run.
+   - Any remaining risks or intentional divergences.
+
+## Common traps
+
+- React synthetic `onChange`, controlled inputs, StrictMode double invoke, class components, and React.Children are not bugs by default.
+- Differential `innerHTML` cannot catch render counts, effect timing, refs, focus, or node move sets.
+- jsdom layout/focus limitations can masquerade as library bugs.

--- a/.ai/skills/create-a-pr.md
+++ b/.ai/skills/create-a-pr.md
@@ -1,0 +1,70 @@
+# Skill: Create an Octane PR
+
+Use this when asked to prepare a branch and pull request for an Octane change.
+
+## Preflight
+
+1. Ensure working tree state is understood:
+   ```bash
+   git status --short --branch
+   git diff --stat
+   ```
+2. Read `.ai/project-map.md` and `AGENTS.md`.
+3. Confirm no unrelated local changes are included.
+
+## Branch and implementation hygiene
+
+- Branch names: `fix/<short-topic>`, `feat/<short-topic>`, `docs/<short-topic>`, or `test/<short-topic>`.
+- Keep commits focused.
+- Add changesets for user-facing package changes; skip docs-only/test-only/internal tooling.
+- If changing RuleSync source, edit `.rulesync/rules/*` and run `pnpm rules:generate`.
+
+## Validation checklist
+
+Run the smallest meaningful set and record results:
+
+```bash
+pnpm format:check
+pnpm typecheck
+pnpm test
+```
+
+Targeted alternatives are acceptable for small changes, but PR body must say what was and was not run.
+
+## PR body template
+
+```md
+## Summary
+- ...
+
+## Why
+- ...
+
+## Changes
+- ...
+
+## Validation
+- [ ] `pnpm format:check`
+- [ ] `pnpm typecheck`
+- [ ] `pnpm test`
+- [ ] targeted tests: ...
+
+## Risk / follow-ups
+- ...
+```
+
+## Create PR with GitHub CLI
+
+```bash
+git checkout -b <branch>
+git add <files>
+git commit -m "<type>: <summary>"
+git push -u origin <branch>
+gh pr create --fill
+```
+
+If using `gh pr create --body-file`, write the PR body to a temp file and pass it explicitly.
+
+## Final response
+
+Return PR URL, branch, commit summary, and validation evidence.

--- a/.ai/skills/handle-issue.md
+++ b/.ai/skills/handle-issue.md
@@ -1,0 +1,68 @@
+# Skill: Handle an Octane GitHub issue
+
+Use this to inspect an issue, triage it, propose a solution, and optionally implement it.
+
+## Inputs
+
+- Issue number or URL.
+- Optional scope constraints: triage-only, propose-only, implement, or create PR.
+
+## Workflow
+
+1. **Fetch issue context**
+   ```bash
+   gh issue view <number> --json number,title,body,author,labels,state,comments,assignees,milestone,url
+   ```
+   If linked PRs/commits are mentioned, inspect them too.
+
+2. **Classify**
+   - bug, feature, docs, test gap, performance, parity gap, ecosystem binding, question.
+   - affected area: core runtime, compiler, SSR/hydration, Vite plugin, binding package, benchmarks/docs.
+   - severity and likely user impact.
+
+3. **Check project rules**
+   - Read `.ai/project-map.md`, `AGENTS.md`, and relevant docs.
+   - For React-behavior issues, check `docs/react-parity-migration-plan.md` and classify intentional divergence vs bug.
+
+4. **Reproduce or validate claim**
+   - Prefer a minimal failing test or fixture.
+   - If not reproducible, document missing info and ask targeted questions.
+   - Avoid broad rewrites before there is a failing test.
+
+5. **Propose solution**
+   Include:
+   - root-cause hypothesis
+   - files likely to change
+   - test plan
+   - compatibility/divergence considerations
+   - risk level
+
+6. **Optional implementation**
+   - Follow `bug-hunter.md` for bugs.
+   - Follow `react-library-port.md` for binding/compat issues.
+   - Follow `octane-core-extend.md` for runtime/compiler extensions.
+
+7. **Issue response template**
+
+```md
+Thanks — I triaged this as <classification> affecting <area>.
+
+Findings:
+- ...
+
+Likely cause:
+- ...
+
+Proposed fix:
+- ...
+
+Validation plan:
+- ...
+
+Notes:
+- ...
+```
+
+8. **Labels/comments**
+   - Use `gh issue edit`/`gh issue comment` only when asked or when operating autonomously with permission.
+   - Do not close issues without maintainer instruction unless explicitly authorized.

--- a/.ai/skills/octane-core-extend.md
+++ b/.ai/skills/octane-core-extend.md
@@ -1,0 +1,58 @@
+# Skill: Extend Octane core
+
+Use this when changing core runtime, compiler, AST/TSRX transforms, SSR, hydration, or public `octane` APIs.
+
+## Read first
+
+- `.ai/project-map.md`
+- `AGENTS.md`
+- `README.md`
+- `docs/react-parity-migration-plan.md`
+- Owning source comments and nearby tests
+
+## Decide owner
+
+- Client behavior/hooks/events/refs/scheduler/context/Suspense/transitions/reconciler: `packages/octane/src/runtime.ts`
+- SSR/server render: `packages/octane/src/runtime.server.ts`, `packages/octane/src/server/index.ts`
+- Compiler/AST/TSRX lowering/Vite/Volar: `packages/octane/src/compiler/*`
+- Public API: `packages/octane/src/index.ts`, `constants.ts`, README/types/tests
+- Vite metaframework behavior: `packages/vite-plugin-octane/*`
+
+## Compiler/AST workflow
+
+1. Add a minimal `.tsrx` or `.tsx` fixture under `packages/octane/tests/_fixtures/`.
+2. Add a focused test that asserts either runtime behavior or emitted behavior through the public compiler path.
+3. Inspect `compile.js` and any `@tsrx/core` AST assumptions.
+4. Preserve source-location/dev diagnostics where applicable.
+5. Ensure generated code still works with hook-slot injection and server/client paths.
+
+## Runtime workflow
+
+1. Add a regression test before patching.
+2. Identify whether behavior is mount, update, deletion, hydration, event delegation, scheduling, or effect flushing.
+3. Read nearby runtime comments; treat them as design spec.
+4. Preserve intentional divergences from React.
+5. For React parity, use conformance or differential harness appropriately.
+
+## Public API workflow
+
+1. Update exports and tests.
+2. Update README/docs if user-facing.
+3. Add changeset unless docs/test-only.
+4. Consider ecosystem binding impacts and aliases in `vitest.config.js`.
+
+## Validation
+
+- New/changed targeted tests.
+- Nearby core tests.
+- `pnpm typecheck` for API/compiler TS changes.
+- `pnpm test` for broad runtime/compiler changes when feasible.
+
+## Risk checks
+
+- Does the change alter hook slot stability?
+- Does it change SSR/hydration consistency?
+- Does it change event semantics from native to synthetic? If yes, likely wrong.
+- Does it add React controlled-input behavior? If yes, likely intentional divergence violation.
+- Does keyed reconciliation preserve final DOM and survivor identity?
+- Are `tsrx` and `tsx/jsx` paths both considered?

--- a/.ai/skills/performance-audit.md
+++ b/.ai/skills/performance-audit.md
@@ -1,0 +1,65 @@
+# Skill: Octane performance audit
+
+Use this to investigate performance regressions, benchmark results, scheduler/reconciler overhead, compiler output quality, or ecosystem binding perf.
+
+## Read first
+
+- `.ai/project-map.md`
+- Benchmark README in the affected `benchmarks/*` directory
+- `packages/octane/src/runtime.ts` comments for runtime-level changes
+- Existing benchmark scripts in `benchmarks/*/package.json` and `run.mjs`
+
+## Workflow
+
+1. **Define target**
+   - Scenario: mount, update, keyed reorder, context, effects, Suspense, hydration, SSR, binding package.
+   - Metric: runtime duration, allocations, DOM operations, bundle size, compiler output size, benchmark score.
+   - Baseline: current `main`, previous commit, React, Solid/Ripple comparison, or documented expectation.
+
+2. **Choose harness**
+   - Existing benchmarks: `benchmarks/news`, `js-framework`, `recursive-context`, `signal-favoring`, `dbmon`.
+   - Micro regression: focused Vitest with counters/logging.
+   - Compiler output: inspect emitted JS from `compile.js`/Vite transform.
+   - Browser-only perf: use Playwright or benchmark harness if available.
+
+3. **Run baseline and candidate**
+   - Warm up.
+   - Run multiple iterations.
+   - Record environment and command.
+   - Avoid mixing dependency install/build changes with code changes.
+
+4. **Diagnose**
+   - Runtime hot paths: scheduler queues, effect flushing, keyed reconciliation, event delegation, context propagation, refs.
+   - Compiler hot paths: unnecessary deopts, over-broad dynamic regions, missed folding, slot churn, repeated closures.
+   - Binding hot paths: excessive subscriptions, selector equality failures, layout-effect loops.
+
+5. **Patch or report**
+   - Prefer measurable changes with a regression test/benchmark note.
+   - Preserve correctness over micro-optimizations.
+   - Document tradeoffs and residual risk.
+
+## Report template
+
+```md
+## Performance audit
+- Target: ...
+- Baseline command/result: ...
+- Candidate command/result: ...
+- Delta: ...
+
+## Findings
+- ...
+
+## Recommendation
+- ...
+
+## Validation
+- ...
+```
+
+## Common pitfalls
+
+- jsdom is poor for layout/paint measurements.
+- Differential `innerHTML` tests prove correctness, not performance.
+- React and Octane may perform different physical DOM move sets while producing identical final DOM.
+- Compiler output changes can shift runtime cost; inspect both layers.

--- a/.ai/skills/react-library-port.md
+++ b/.ai/skills/react-library-port.md
@@ -1,0 +1,69 @@
+# Skill: React-like package bridge/port into Octane compatibility
+
+Use this when asked to port or bridge a React ecosystem package into Octane, add an `@octanejs/*` binding, or evaluate whether a React package can run on Octane.
+
+## Mental model
+
+Do **not** assume React component code can run unchanged. Octane is compiler-first:
+
+- React JSX output and slotless hook calls are not valid Octane component runtime input.
+- Reuse framework-agnostic cores unchanged.
+- Re-implement thin React bindings with Octane hooks.
+- Re-author representative UI tests/fixtures in `.tsrx` and compare behavior to React when possible.
+
+Read first:
+
+1. `.ai/project-map.md`
+2. `docs/react-library-compat-plan.md`
+3. `docs/react-parity-migration-plan.md`
+4. Existing closest binding in `packages/{zustand,query,motion,stylex,router,lexical,floating-ui}/`
+5. `vitest.config.js` aliases/exclusions for existing binding packages
+
+## Workflow
+
+1. **Classify the target library**
+   - Find its vanilla/core package or pure internal layer.
+   - Identify the React binding surface: hooks, components, providers, portals, refs, event handling.
+   - Note unsupported React assumptions: class components, `forwardRef`, synthetic events, controlled inputs, StrictMode-only behavior, React internals.
+
+2. **Create or update package shape**
+   - New ports belong under `packages/<name>/` with `package.json`, `src/`, `tests/`, `tsconfig.json`, and README.
+   - Public package should normally be `@octanejs/<name>`.
+   - Add workspace/test aliases in `vitest.config.js` following existing packages.
+   - Add catalog dependencies to `pnpm-workspace.yaml` only when needed.
+
+3. **Reuse core, reimplement binding**
+   - Prefer importing the target's vanilla/core package unchanged.
+   - Implement hooks with Octane equivalents: `useSyncExternalStore`, `useState`, `useReducer`, `useEffect`, `useLayoutEffect`, `useMemo`, `useCallback`, `useRef`, `useContext`, `createContext`, `createPortal`, `flushSync`, `use`.
+   - `useDebugValue` can be a no-op shim unless devtools behavior is explicitly in scope.
+   - Rewrite `forwardRef` to React 19 refs-as-props (`ref` is a prop in Octane).
+   - For cross-file custom hooks imported by `.tsrx`, check whether the compiler must auto-slot them or whether the package source should be excluded and forward slots via `subSlot` like `floating-ui`.
+
+4. **Build test strategy**
+   - DOM output over event sequences: use differential tests where the same `.tsrx` fixture runs in Octane and React.
+   - Render-count, subscription, effect-order, bailout, and ref lifecycle: use Octane-only conformance tests.
+   - Keyed reorder node identity: use identity helpers; do not rely on `innerHTML`.
+   - Async/Suspense: make timer/microtask draining explicit and deterministic.
+   - Cite upstream tests when porting behavior.
+
+5. **Triage divergence**
+   - Classify each failure as:
+     - Octane bug
+     - Intentional divergence
+     - Environment/jsdom artifact
+     - Porting/test harness issue
+   - Record genuine gaps in docs or tests before changing runtime/compiler.
+
+6. **Validate**
+   - Run package-specific tests first.
+   - Run affected core tests if touching `packages/octane`.
+   - Run `pnpm typecheck` for API/package changes.
+   - Run `pnpm format:check` or format changed files.
+
+## Deliverables
+
+- `packages/<name>/src/*` binding implementation.
+- Tests that prove core workflows and document known gaps.
+- README with compatibility status and intentional differences.
+- Changeset if user-facing package behavior changed.
+- Optional update to `docs/react-library-compat-plan.md` scorecard.

--- a/.ai/skills/triage.md
+++ b/.ai/skills/triage.md
@@ -1,0 +1,47 @@
+# Skill: Octane triage
+
+Use this for quick classification of issues, failures, test output, or proposed work.
+
+## Triage dimensions
+
+- **Area:** runtime, compiler, SSR/hydration, Vite plugin, binding package, docs, tests, benchmark, tooling.
+- **Type:** bug, feature, parity gap, intentional divergence, performance, flaky test, environment artifact, documentation.
+- **Severity:** blocker, high, medium, low.
+- **Confidence:** confirmed, likely, unknown, cannot reproduce.
+- **Next action:** reproduce, write test, patch, document, defer, ask for info.
+
+## Steps
+
+1. Read `.ai/project-map.md`.
+2. Inspect the concrete files/test output/issue text.
+3. Compare against documented intentional divergences.
+4. Identify the smallest owner and validation command.
+5. Return a concise triage card.
+
+## Triage card template
+
+```md
+## Triage
+- Area: ...
+- Type: ...
+- Severity: ...
+- Confidence: ...
+
+## Evidence
+- ...
+
+## Likely owner
+- Files/packages: ...
+
+## Proposed next step
+- ...
+
+## Validation
+- ...
+```
+
+## Label suggestions
+
+- `area:runtime`, `area:compiler`, `area:ssr`, `area:hydration`, `area:vite`, `area:bindings`, `area:docs`, `area:perf`
+- `type:bug`, `type:feature`, `type:parity`, `type:divergence`, `type:flaky`, `type:question`
+- `priority:blocker`, `priority:high`, `priority:medium`, `priority:low`

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,20 @@
+# Claude references for Octane
+
+Start with `../CLAUDE.md`, then use `../.ai/project-map.md` and the task-specific skill files in `../.ai/skills/`.
+
+## Task routing
+
+- Port React-like package to Octane: `.ai/skills/react-library-port.md`
+- Find/fix bug: `.ai/skills/bug-hunter.md`
+- Create PR: `.ai/skills/create-a-pr.md`
+- Handle GitHub issue: `.ai/skills/handle-issue.md`
+- Extend runtime/compiler/core: `.ai/skills/octane-core-extend.md`
+- Triage unknown work/failure: `.ai/skills/triage.md`
+- Audit performance: `.ai/skills/performance-audit.md`
+
+## Repository reminders
+
+- Octane is compiler-first and React-shaped, not React runtime-compatible.
+- `.tsrx` fixtures are preferred for UI behavior tests.
+- Existing differential harness compares final `innerHTML`; use conformance tests for lifecycle/render-count/ref timing.
+- RuleSync owns generated agent docs.

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,0 +1,27 @@
+# Codex references for Octane
+
+Use these repository-local references when operating with Codex or other coding agents.
+
+## Load order
+
+1. `../AGENTS.md`
+2. `../.ai/project-map.md`
+3. Relevant skill in `../.ai/skills/`
+4. Owning source/tests
+
+## Skills
+
+- React ecosystem/package porting: `../.ai/skills/react-library-port.md`
+- Bug hunting/regression fixing: `../.ai/skills/bug-hunter.md`
+- PR creation: `../.ai/skills/create-a-pr.md`
+- Issue handling: `../.ai/skills/handle-issue.md`
+- Core/compiler/runtime extension: `../.ai/skills/octane-core-extend.md`
+- General triage: `../.ai/skills/triage.md`
+- Performance audit: `../.ai/skills/performance-audit.md`
+
+## Hard rules
+
+- Do not hand-edit generated agent references (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`, `.cursor/rules/project.mdc`). Edit `.rulesync/rules/` and run `pnpm rules:generate`.
+- Do not assume React behavior is automatically desired. Check intentional divergences.
+- Add failing tests before fixes whenever possible.
+- Prefer targeted validation, but report exactly what ran.

--- a/packages/octane-mcp-server/README.md
+++ b/packages/octane-mcp-server/README.md
@@ -1,38 +1,119 @@
 # @octanejs/mcp-server
 
-Local MCP server concept/scaffold for Octane-aware coding agents.
+MCP server for Octane-aware coding agents.
 
-The goal is to expose safe, high-value repository operations without needing a human to remember file paths, validation commands, or triage conventions.
+It exposes repository-specific context, skills, triage helpers, validation planning, and selected automation wrappers so agents can work on Octane without re-discovering package ownership, test harnesses, or common workflows.
 
-## Initial tools
+## Install
 
-- `octane_project_map` — returns package map, source ownership, validation commands, and skill paths.
-- `octane_skill` — returns one of the repository skills from `.ai/skills`.
-- `octane_validate_plan` — recommends validation commands for changed paths/task kind.
-- `octane_triage_paths` — classifies changed paths by repo area and likely owner.
+```bash
+npm install -g @octanejs/mcp-server
+```
 
-## Run locally
+For local development inside this repository:
 
 ```bash
 pnpm --filter @octanejs/mcp-server start
 ```
 
-Example moxxy registration after dependencies are installed:
+Set `OCTANE_REPO_ROOT` when the server is launched outside the repository root:
 
 ```bash
-moxxy mcp add octane --stdio --command pnpm --args --filter,@octanejs/mcp-server,start --cwd /path/to/octane
+OCTANE_REPO_ROOT=/path/to/octane octane-mcp-server
 ```
 
-Or register manually as stdio:
+## MCP transport
 
-- command: `pnpm`
-- args: `--filter`, `@octanejs/mcp-server`, `start`
-- cwd: repository root
+The server uses stdio transport.
 
-## Future tool ideas
+Generic client configuration:
 
-- `octane_run_validation` — guarded execution of targeted tests/typecheck/format.
-- `octane_scaffold_react_port` — wrapper around `scripts/scaffold-react-port.mjs`.
-- `octane_issue_context` — fetch and classify GitHub issues via `gh`.
-- `octane_create_changeset` — guided changeset creation for package changes.
-- `octane_benchmark` — run known benchmark harnesses with structured output.
+```json
+{
+  "mcpServers": {
+    "octane": {
+      "command": "octane-mcp-server",
+      "env": {
+        "OCTANE_REPO_ROOT": "/path/to/octane"
+      }
+    }
+  }
+}
+```
+
+Local workspace configuration:
+
+```json
+{
+  "mcpServers": {
+    "octane": {
+      "command": "pnpm",
+      "args": ["--filter", "@octanejs/mcp-server", "start"],
+      "cwd": "/path/to/octane"
+    }
+  }
+}
+```
+
+## Tools
+
+### `octane_project_map`
+
+Returns `.ai/project-map.md` with package layout, authoritative sources, invariants, and validation commands.
+
+### `octane_skill`
+
+Returns one of the repository-local skills from `.ai/skills`:
+
+- `react-library-port`
+- `bug-hunter`
+- `create-a-pr`
+- `handle-issue`
+- `octane-core-extend`
+- `triage`
+- `performance-audit`
+
+### `octane_triage_paths`
+
+Classifies repository-relative paths by Octane area, such as compiler, core runtime, SSR, ecosystem binding, benchmark, docs, or RuleSync source.
+
+### `octane_validate_plan`
+
+Recommends validation commands for changed paths and task kind.
+
+### `octane_scaffold_react_port`
+
+Runs `scripts/scaffold-react-port.mjs` for an upstream React test file and optionally writes the generated Vitest skeleton to an output file.
+
+Input:
+
+```json
+{
+  "reactTestFile": "../react/packages/react-reconciler/src/__tests__/ReactHooks-test.js",
+  "outFile": "packages/octane/tests/conformance/react-hooks-ported.test.ts"
+}
+```
+
+### `octane_benchmark`
+
+Runs a known benchmark workspace or all benchmarks.
+
+Supported benchmark names:
+
+- `all`
+- `news`
+- `js-framework`
+- `recursive-context`
+- `signal-favoring`
+- `dbmon`
+
+### `octane_issue_context`
+
+Uses GitHub CLI (`gh`) to fetch an issue and returns structured issue context plus lightweight triage hints. This requires the caller's environment to have `gh` installed and authenticated for the Octane repository.
+
+## Development
+
+```bash
+pnpm --filter @octanejs/mcp-server test
+pnpm --filter @octanejs/mcp-server start
+```

--- a/packages/octane-mcp-server/README.md
+++ b/packages/octane-mcp-server/README.md
@@ -1,0 +1,38 @@
+# @octanejs/mcp-server
+
+Local MCP server concept/scaffold for Octane-aware coding agents.
+
+The goal is to expose safe, high-value repository operations without needing a human to remember file paths, validation commands, or triage conventions.
+
+## Initial tools
+
+- `octane_project_map` — returns package map, source ownership, validation commands, and skill paths.
+- `octane_skill` — returns one of the repository skills from `.ai/skills`.
+- `octane_validate_plan` — recommends validation commands for changed paths/task kind.
+- `octane_triage_paths` — classifies changed paths by repo area and likely owner.
+
+## Run locally
+
+```bash
+pnpm --filter @octanejs/mcp-server start
+```
+
+Example moxxy registration after dependencies are installed:
+
+```bash
+moxxy mcp add octane --stdio --command pnpm --args --filter,@octanejs/mcp-server,start --cwd /path/to/octane
+```
+
+Or register manually as stdio:
+
+- command: `pnpm`
+- args: `--filter`, `@octanejs/mcp-server`, `start`
+- cwd: repository root
+
+## Future tool ideas
+
+- `octane_run_validation` — guarded execution of targeted tests/typecheck/format.
+- `octane_scaffold_react_port` — wrapper around `scripts/scaffold-react-port.mjs`.
+- `octane_issue_context` — fetch and classify GitHub issues via `gh`.
+- `octane_create_changeset` — guided changeset creation for package changes.
+- `octane_benchmark` — run known benchmark harnesses with structured output.

--- a/packages/octane-mcp-server/package.json
+++ b/packages/octane-mcp-server/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@octanejs/mcp-server",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Local MCP server exposing Octane repository automation for coding agents.",
+  "bin": {
+    "octane-mcp-server": "src/index.js"
+  },
+  "scripts": {
+    "start": "node src/index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.21.0",
+    "zod": "^4.4.3"
+  }
+}

--- a/packages/octane-mcp-server/package.json
+++ b/packages/octane-mcp-server/package.json
@@ -1,17 +1,40 @@
 {
   "name": "@octanejs/mcp-server",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.1.0",
   "type": "module",
-  "description": "Local MCP server exposing Octane repository automation for coding agents.",
+  "description": "MCP server exposing Octane repository automation for coding agents.",
+  "license": "MIT",
+  "author": {
+    "name": "Dominic Gannaway",
+    "email": "dg@domgan.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/octanejs/octane.git",
+    "directory": "packages/octane-mcp-server"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "src",
+    "README.md"
+  ],
   "bin": {
     "octane-mcp-server": "src/index.js"
   },
+  "exports": {
+    ".": "./src/index.js"
+  },
   "scripts": {
-    "start": "node src/index.js"
+    "start": "node src/index.js",
+    "test": "cd ../.. && vitest run --project octane-mcp-server"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.21.0",
     "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "vitest": "catalog:default"
   }
 }

--- a/packages/octane-mcp-server/src/index.js
+++ b/packages/octane-mcp-server/src/index.js
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+const repoRoot = resolve(process.env.OCTANE_REPO_ROOT || process.cwd());
+
+const SKILLS = {
+  'react-library-port': '.ai/skills/react-library-port.md',
+  'bug-hunter': '.ai/skills/bug-hunter.md',
+  'create-a-pr': '.ai/skills/create-a-pr.md',
+  'handle-issue': '.ai/skills/handle-issue.md',
+  'octane-core-extend': '.ai/skills/octane-core-extend.md',
+  triage: '.ai/skills/triage.md',
+  'performance-audit': '.ai/skills/performance-audit.md',
+};
+
+function text(content) {
+  return { content: [{ type: 'text', text: content }] };
+}
+
+function areaForPath(path) {
+  if (path.startsWith('packages/octane/src/compiler/')) return 'compiler';
+  if (path.startsWith('packages/octane/src/runtime') || path === 'packages/octane/src/index.ts') return 'core-runtime';
+  if (path.startsWith('packages/octane/src/server/') || path.includes('runtime.server')) return 'ssr';
+  if (path.startsWith('packages/octane/tests/')) return 'core-tests';
+  if (path.startsWith('packages/vite-plugin-octane/')) return 'vite-plugin';
+  if (/^packages\/(zustand|query|motion|stylex|router|lexical|floating-ui)\//.test(path)) return 'ecosystem-binding';
+  if (path.startsWith('benchmarks/')) return 'benchmark';
+  if (path.startsWith('docs/') || path.endsWith('.md')) return 'docs';
+  if (path.startsWith('.ai/') || path.startsWith('.codex/') || path.startsWith('.claude/')) return 'agent-instructions';
+  if (path.startsWith('.rulesync/')) return 'rulesync-source';
+  return 'repo-tooling';
+}
+
+function validationFor(paths, taskKind) {
+  const areas = new Set(paths.map(areaForPath));
+  const commands = new Set();
+
+  if (areas.has('rulesync-source')) commands.add('pnpm rules:generate');
+  if (areas.has('core-runtime') || areas.has('compiler') || areas.has('ssr') || areas.has('core-tests')) {
+    commands.add('./node_modules/.bin/vitest run packages/octane/tests --project octane');
+  }
+  if (areas.has('ecosystem-binding')) {
+    for (const path of paths) {
+      const match = path.match(/^packages\/([^/]+)\//);
+      if (match) commands.add(`./node_modules/.bin/vitest run packages/${match[1]}/tests --project ${match[1]}`);
+    }
+  }
+  if (areas.has('vite-plugin')) commands.add('pnpm typecheck');
+  if (areas.has('benchmark') || taskKind === 'performance') commands.add('pnpm bench');
+  if (taskKind === 'api' || taskKind === 'core' || taskKind === 'package') commands.add('pnpm typecheck');
+  commands.add('pnpm format:check');
+
+  return [...commands];
+}
+
+const server = new McpServer({ name: 'octane', version: '0.0.0' });
+
+server.registerTool(
+  'octane_project_map',
+  {
+    title: 'Octane project map',
+    description: 'Return Octane repository map, source ownership, validation commands, and skill paths.',
+    inputSchema: {},
+  },
+  async () => {
+    const projectMap = await readFile(resolve(repoRoot, '.ai/project-map.md'), 'utf8');
+    return text(projectMap);
+  },
+);
+
+server.registerTool(
+  'octane_skill',
+  {
+    title: 'Octane skill',
+    description: 'Return a repository-local Octane agent skill by name.',
+    inputSchema: {
+      name: z.enum(Object.keys(SKILLS)),
+    },
+  },
+  async ({ name }) => {
+    const body = await readFile(resolve(repoRoot, SKILLS[name]), 'utf8');
+    return text(body);
+  },
+);
+
+server.registerTool(
+  'octane_triage_paths',
+  {
+    title: 'Triage Octane paths',
+    description: 'Classify changed paths by Octane repo area.',
+    inputSchema: {
+      paths: z.array(z.string()).describe('Repository-relative paths'),
+    },
+  },
+  async ({ paths }) => {
+    const rows = paths.map((path) => ({ path, area: areaForPath(path) }));
+    return text(JSON.stringify({ repoRoot, paths: rows }, null, 2));
+  },
+);
+
+server.registerTool(
+  'octane_validate_plan',
+  {
+    title: 'Octane validation plan',
+    description: 'Recommend validation commands for changed paths and task kind.',
+    inputSchema: {
+      paths: z.array(z.string()).default([]).describe('Repository-relative changed paths'),
+      taskKind: z
+        .enum(['bug', 'feature', 'docs', 'test', 'performance', 'core', 'compiler', 'package', 'api', 'unknown'])
+        .default('unknown'),
+    },
+  },
+  async ({ paths, taskKind }) => {
+    return text(JSON.stringify({ repoRoot, taskKind, commands: validationFor(paths, taskKind) }, null, 2));
+  },
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/packages/octane-mcp-server/src/index.js
+++ b/packages/octane-mcp-server/src/index.js
@@ -1,123 +1,346 @@
 #!/usr/bin/env node
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { z } from 'zod';
+import { spawn } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { z } from 'zod';
 
-const repoRoot = resolve(process.env.OCTANE_REPO_ROOT || process.cwd());
+const __filename = fileURLToPath(import.meta.url);
 
-const SKILLS = {
-  'react-library-port': '.ai/skills/react-library-port.md',
-  'bug-hunter': '.ai/skills/bug-hunter.md',
-  'create-a-pr': '.ai/skills/create-a-pr.md',
-  'handle-issue': '.ai/skills/handle-issue.md',
-  'octane-core-extend': '.ai/skills/octane-core-extend.md',
-  triage: '.ai/skills/triage.md',
-  'performance-audit': '.ai/skills/performance-audit.md',
+export const SKILLS = {
+	'bug-hunter': '.ai/skills/bug-hunter.md',
+	'create-a-pr': '.ai/skills/create-a-pr.md',
+	'handle-issue': '.ai/skills/handle-issue.md',
+	'octane-core-extend': '.ai/skills/octane-core-extend.md',
+	'performance-audit': '.ai/skills/performance-audit.md',
+	'react-library-port': '.ai/skills/react-library-port.md',
+	triage: '.ai/skills/triage.md',
 };
 
-function text(content) {
-  return { content: [{ type: 'text', text: content }] };
+const BENCHMARKS = {
+	dbmon: '@benchmarks/dbmon',
+	'js-framework': 'octane-js-framework-benchmarks',
+	news: '@benchmarks/news',
+	'recursive-context': '@benchmarks/recursive-context',
+	'signal-favoring': '@benchmarks/signal-favoring',
+};
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+export function text(content) {
+	return { content: [{ type: 'text', text: content }] };
 }
 
-function areaForPath(path) {
-  if (path.startsWith('packages/octane/src/compiler/')) return 'compiler';
-  if (path.startsWith('packages/octane/src/runtime') || path === 'packages/octane/src/index.ts') return 'core-runtime';
-  if (path.startsWith('packages/octane/src/server/') || path.includes('runtime.server')) return 'ssr';
-  if (path.startsWith('packages/octane/tests/')) return 'core-tests';
-  if (path.startsWith('packages/vite-plugin-octane/')) return 'vite-plugin';
-  if (/^packages\/(zustand|query|motion|stylex|router|lexical|floating-ui)\//.test(path)) return 'ecosystem-binding';
-  if (path.startsWith('benchmarks/')) return 'benchmark';
-  if (path.startsWith('docs/') || path.endsWith('.md')) return 'docs';
-  if (path.startsWith('.ai/') || path.startsWith('.codex/') || path.startsWith('.claude/')) return 'agent-instructions';
-  if (path.startsWith('.rulesync/')) return 'rulesync-source';
-  return 'repo-tooling';
+export function areaForPath(path) {
+	if (path.startsWith('packages/octane/src/compiler/')) return 'compiler';
+	if (path.startsWith('packages/octane/src/server/') || path.includes('runtime.server'))
+		return 'ssr';
+	if (path.startsWith('packages/octane/src/runtime') || path === 'packages/octane/src/index.ts') {
+		return 'core-runtime';
+	}
+	if (path.startsWith('packages/octane/tests/')) return 'core-tests';
+	if (path.startsWith('packages/vite-plugin-octane/')) return 'vite-plugin';
+	if (/^packages\/(zustand|query|motion|stylex|router|lexical|floating-ui)\//.test(path)) {
+		return 'ecosystem-binding';
+	}
+	if (path.startsWith('benchmarks/')) return 'benchmark';
+	if (path.startsWith('.rulesync/')) return 'rulesync-source';
+	if (path.startsWith('.ai/') || path.startsWith('.codex/') || path.startsWith('.claude/')) {
+		return 'agent-instructions';
+	}
+	if (path.startsWith('docs/') || path.endsWith('.md')) return 'docs';
+	return 'repo-tooling';
 }
 
-function validationFor(paths, taskKind) {
-  const areas = new Set(paths.map(areaForPath));
-  const commands = new Set();
+export function validationFor(paths, taskKind) {
+	const areas = new Set(paths.map(areaForPath));
+	const commands = new Set();
 
-  if (areas.has('rulesync-source')) commands.add('pnpm rules:generate');
-  if (areas.has('core-runtime') || areas.has('compiler') || areas.has('ssr') || areas.has('core-tests')) {
-    commands.add('./node_modules/.bin/vitest run packages/octane/tests --project octane');
-  }
-  if (areas.has('ecosystem-binding')) {
-    for (const path of paths) {
-      const match = path.match(/^packages\/([^/]+)\//);
-      if (match) commands.add(`./node_modules/.bin/vitest run packages/${match[1]}/tests --project ${match[1]}`);
-    }
-  }
-  if (areas.has('vite-plugin')) commands.add('pnpm typecheck');
-  if (areas.has('benchmark') || taskKind === 'performance') commands.add('pnpm bench');
-  if (taskKind === 'api' || taskKind === 'core' || taskKind === 'package') commands.add('pnpm typecheck');
-  commands.add('pnpm format:check');
+	if (areas.has('rulesync-source')) commands.add('pnpm rules:generate');
+	if (
+		areas.has('core-runtime') ||
+		areas.has('compiler') ||
+		areas.has('ssr') ||
+		areas.has('core-tests')
+	) {
+		commands.add('./node_modules/.bin/vitest run packages/octane/tests --project octane');
+	}
+	if (areas.has('ecosystem-binding')) {
+		for (const path of paths) {
+			const match = path.match(/^packages\/([^/]+)\//);
+			if (match)
+				commands.add(
+					`./node_modules/.bin/vitest run packages/${match[1]}/tests --project ${match[1]}`,
+				);
+		}
+	}
+	if (areas.has('vite-plugin')) commands.add('pnpm typecheck');
+	if (areas.has('benchmark') || taskKind === 'performance') commands.add('pnpm bench');
+	if (taskKind === 'api' || taskKind === 'core' || taskKind === 'package')
+		commands.add('pnpm typecheck');
+	commands.add('pnpm format:check');
 
-  return [...commands];
+	return [...commands];
 }
 
-const server = new McpServer({ name: 'octane', version: '0.0.0' });
+export function runCommand(command, args, options = {}) {
+	const cwd = options.cwd ?? process.cwd();
+	const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
-server.registerTool(
-  'octane_project_map',
-  {
-    title: 'Octane project map',
-    description: 'Return Octane repository map, source ownership, validation commands, and skill paths.',
-    inputSchema: {},
-  },
-  async () => {
-    const projectMap = await readFile(resolve(repoRoot, '.ai/project-map.md'), 'utf8');
-    return text(projectMap);
-  },
-);
+	return new Promise((resolvePromise) => {
+		const child = spawn(command, args, {
+			cwd,
+			env: { ...process.env, ...options.env },
+			stdio: ['ignore', 'pipe', 'pipe'],
+		});
+		let stdout = '';
+		let stderr = '';
+		let settled = false;
+		const timer = setTimeout(() => {
+			if (settled) return;
+			settled = true;
+			child.kill('SIGTERM');
+			resolvePromise({
+				code: null,
+				signal: 'SIGTERM',
+				stdout,
+				stderr: `${stderr}\nCommand timed out after ${timeoutMs}ms`,
+			});
+		}, timeoutMs);
 
-server.registerTool(
-  'octane_skill',
-  {
-    title: 'Octane skill',
-    description: 'Return a repository-local Octane agent skill by name.',
-    inputSchema: {
-      name: z.enum(Object.keys(SKILLS)),
-    },
-  },
-  async ({ name }) => {
-    const body = await readFile(resolve(repoRoot, SKILLS[name]), 'utf8');
-    return text(body);
-  },
-);
+		child.stdout.on('data', (chunk) => {
+			stdout += chunk;
+		});
+		child.stderr.on('data', (chunk) => {
+			stderr += chunk;
+		});
+		child.on('error', (error) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			resolvePromise({ code: null, signal: null, stdout, stderr: `${stderr}\n${error.message}` });
+		});
+		child.on('close', (code, signal) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			resolvePromise({ code, signal, stdout, stderr });
+		});
+	});
+}
 
-server.registerTool(
-  'octane_triage_paths',
-  {
-    title: 'Triage Octane paths',
-    description: 'Classify changed paths by Octane repo area.',
-    inputSchema: {
-      paths: z.array(z.string()).describe('Repository-relative paths'),
-    },
-  },
-  async ({ paths }) => {
-    const rows = paths.map((path) => ({ path, area: areaForPath(path) }));
-    return text(JSON.stringify({ repoRoot, paths: rows }, null, 2));
-  },
-);
+function commandResult(result) {
+	return text(JSON.stringify(result, null, 2));
+}
 
-server.registerTool(
-  'octane_validate_plan',
-  {
-    title: 'Octane validation plan',
-    description: 'Recommend validation commands for changed paths and task kind.',
-    inputSchema: {
-      paths: z.array(z.string()).default([]).describe('Repository-relative changed paths'),
-      taskKind: z
-        .enum(['bug', 'feature', 'docs', 'test', 'performance', 'core', 'compiler', 'package', 'api', 'unknown'])
-        .default('unknown'),
-    },
-  },
-  async ({ paths, taskKind }) => {
-    return text(JSON.stringify({ repoRoot, taskKind, commands: validationFor(paths, taskKind) }, null, 2));
-  },
-);
+export async function scaffoldReactPort(repoRoot, input) {
+	const args = ['scripts/scaffold-react-port.mjs', input.reactTestFile];
+	if (input.outFile) args.push('--out', input.outFile);
+	const result = await runCommand(process.execPath, args, {
+		cwd: repoRoot,
+		timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+	});
+	return { command: [process.execPath, ...args], ...result };
+}
 
-const transport = new StdioServerTransport();
-await server.connect(transport);
+export async function runBenchmark(repoRoot, input) {
+	const args =
+		input.benchmark === 'all'
+			? ['bench']
+			: ['--filter', BENCHMARKS[input.benchmark], 'run', 'bench'];
+	const result = await runCommand('pnpm', args, {
+		cwd: repoRoot,
+		timeoutMs: input.timeoutMs ?? 300_000,
+	});
+	return { command: ['pnpm', ...args], benchmark: input.benchmark, ...result };
+}
+
+export async function issueContext(repoRoot, input) {
+	const fields =
+		'number,title,body,author,labels,state,comments,assignees,milestone,url,createdAt,updatedAt';
+	const result = await runCommand('gh', ['issue', 'view', String(input.issue), '--json', fields], {
+		cwd: repoRoot,
+		timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+	});
+	if (result.code !== 0)
+		return { command: ['gh', 'issue', 'view', String(input.issue), '--json', fields], ...result };
+
+	let issue;
+	try {
+		issue = JSON.parse(result.stdout);
+	} catch (error) {
+		return {
+			command: ['gh', 'issue', 'view', String(input.issue), '--json', fields],
+			parseError: error.message,
+			...result,
+		};
+	}
+
+	const body = `${issue.title}\n${issue.body ?? ''}`.toLowerCase();
+	const labels = issue.labels?.map((label) => label.name) ?? [];
+	const suggestedArea =
+		body.includes('compiler') || body.includes('tsrx')
+			? 'compiler'
+			: body.includes('hydration')
+				? 'hydration'
+				: body.includes('ssr')
+					? 'ssr'
+					: body.includes('performance') || body.includes('perf')
+						? 'performance'
+						: 'triage-needed';
+	return {
+		command: ['gh', 'issue', 'view', String(input.issue), '--json', fields],
+		issue,
+		triage: {
+			suggestedArea,
+			labels,
+			state: issue.state,
+			url: issue.url,
+		},
+	};
+}
+
+export function createServer(options = {}) {
+	const repoRoot = resolve(options.repoRoot || process.env.OCTANE_REPO_ROOT || process.cwd());
+	const server = new McpServer({ name: 'octane', version: '0.1.0' });
+
+	server.registerTool(
+		'octane_project_map',
+		{
+			title: 'Octane project map',
+			description:
+				'Return Octane repository map, source ownership, validation commands, and skill paths.',
+			inputSchema: {},
+		},
+		async () => {
+			const projectMap = await readFile(resolve(repoRoot, '.ai/project-map.md'), 'utf8');
+			return text(projectMap);
+		},
+	);
+
+	server.registerTool(
+		'octane_skill',
+		{
+			title: 'Octane skill',
+			description: 'Return a repository-local Octane agent skill by name.',
+			inputSchema: {
+				name: z.enum(Object.keys(SKILLS)),
+			},
+		},
+		async ({ name }) => {
+			const body = await readFile(resolve(repoRoot, SKILLS[name]), 'utf8');
+			return text(body);
+		},
+	);
+
+	server.registerTool(
+		'octane_triage_paths',
+		{
+			title: 'Triage Octane paths',
+			description: 'Classify changed paths by Octane repo area.',
+			inputSchema: {
+				paths: z.array(z.string()).describe('Repository-relative paths'),
+			},
+		},
+		async ({ paths }) => {
+			const rows = paths.map((path) => ({ path, area: areaForPath(path) }));
+			return text(JSON.stringify({ repoRoot, paths: rows }, null, 2));
+		},
+	);
+
+	server.registerTool(
+		'octane_validate_plan',
+		{
+			title: 'Octane validation plan',
+			description: 'Recommend validation commands for changed paths and task kind.',
+			inputSchema: {
+				paths: z.array(z.string()).default([]).describe('Repository-relative changed paths'),
+				taskKind: z
+					.enum([
+						'bug',
+						'feature',
+						'docs',
+						'test',
+						'performance',
+						'core',
+						'compiler',
+						'package',
+						'api',
+						'unknown',
+					])
+					.default('unknown'),
+			},
+		},
+		async ({ paths, taskKind }) => {
+			return text(
+				JSON.stringify({ repoRoot, taskKind, commands: validationFor(paths, taskKind) }, null, 2),
+			);
+		},
+	);
+
+	server.registerTool(
+		'octane_scaffold_react_port',
+		{
+			title: 'Scaffold React test port',
+			description: 'Run scripts/scaffold-react-port.mjs for a React upstream test file.',
+			inputSchema: {
+				reactTestFile: z
+					.string()
+					.describe('Path to the upstream React test file, relative to repo root or absolute.'),
+				outFile: z
+					.string()
+					.optional()
+					.describe('Optional output file for the generated Vitest skeleton.'),
+				timeoutMs: z.number().int().positive().optional(),
+			},
+		},
+		async (input) => commandResult(await scaffoldReactPort(repoRoot, input)),
+	);
+
+	server.registerTool(
+		'octane_benchmark',
+		{
+			title: 'Run Octane benchmark',
+			description:
+				'Run one of the known Octane benchmark workspaces, or all benchmarks via pnpm bench.',
+			inputSchema: {
+				benchmark: z.enum(['all', ...Object.keys(BENCHMARKS)]).default('all'),
+				timeoutMs: z.number().int().positive().optional(),
+			},
+		},
+		async (input) => commandResult(await runBenchmark(repoRoot, input)),
+	);
+
+	server.registerTool(
+		'octane_issue_context',
+		{
+			title: 'Fetch Octane issue context',
+			description:
+				'Fetch a GitHub issue with gh and return structured context plus lightweight triage hints.',
+			inputSchema: {
+				issue: z
+					.union([z.number().int().positive(), z.string()])
+					.describe('Issue number or URL accepted by gh issue view.'),
+				timeoutMs: z.number().int().positive().optional(),
+			},
+		},
+		async (input) => commandResult(await issueContext(repoRoot, input)),
+	);
+
+	return server;
+}
+
+export async function main() {
+	const server = createServer();
+	const transport = new StdioServerTransport();
+	await server.connect(transport);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === __filename) {
+	main().catch((error) => {
+		console.error(error);
+		process.exit(1);
+	});
+}

--- a/packages/octane-mcp-server/src/index.test.js
+++ b/packages/octane-mcp-server/src/index.test.js
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { areaForPath, scaffoldReactPort, validationFor } from './index.js';
+
+describe('@octanejs/mcp-server helpers', () => {
+	it('classifies Octane repository paths', () => {
+		expect(areaForPath('packages/octane/src/compiler/compile.js')).toBe('compiler');
+		expect(areaForPath('packages/octane/src/runtime.ts')).toBe('core-runtime');
+		expect(areaForPath('packages/octane/src/runtime.server.ts')).toBe('ssr');
+		expect(areaForPath('packages/zustand/src/index.ts')).toBe('ecosystem-binding');
+		expect(areaForPath('benchmarks/news/run.mjs')).toBe('benchmark');
+		expect(areaForPath('.rulesync/rules/project.md')).toBe('rulesync-source');
+	});
+
+	it('recommends validation commands from changed paths', () => {
+		const commands = validationFor(
+			[
+				'packages/octane/src/runtime.ts',
+				'packages/zustand/src/index.ts',
+				'.rulesync/rules/project.md',
+			],
+			'core',
+		);
+
+		expect(commands).toContain('pnpm rules:generate');
+		expect(commands).toContain(
+			'./node_modules/.bin/vitest run packages/octane/tests --project octane',
+		);
+		expect(commands).toContain(
+			'./node_modules/.bin/vitest run packages/zustand/tests --project zustand',
+		);
+		expect(commands).toContain('pnpm typecheck');
+		expect(commands).toContain('pnpm format:check');
+	});
+
+	it('runs the React port scaffolder wrapper', async () => {
+		const repoRoot = await mkdtemp(join(tmpdir(), 'octane-mcp-test-'));
+		await mkdir(join(repoRoot, 'scripts'), { recursive: true });
+		await mkdir(join(repoRoot, 'react'), { recursive: true });
+		await writeFile(
+			join(repoRoot, 'scripts/scaffold-react-port.mjs'),
+			"import { writeFileSync } from 'node:fs';\nconst out = process.argv[process.argv.indexOf('--out') + 1];\nwriteFileSync(out, 'generated');\nconsole.log('ok');\n",
+		);
+		await writeFile(join(repoRoot, 'react/source-test.js'), "it('works', () => {});\n");
+
+		const result = await scaffoldReactPort(repoRoot, {
+			reactTestFile: 'react/source-test.js',
+			outFile: 'ported.test.ts',
+		});
+
+		expect(result.code).toBe(0);
+		expect(result.stdout).toContain('ok');
+		await expect(readFile(join(repoRoot, 'ported.test.ts'), 'utf8')).resolves.toBe('generated');
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -845,6 +845,15 @@ importers:
         specifier: catalog:default
         version: 4.1.9(@types/node@24.13.2)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.48.0))
 
+  packages/octane-mcp-server:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.21.0
+        version: 1.29.0(zod@4.4.3)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+
   packages/query:
     dependencies:
       '@tanstack/query-core':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -853,6 +853,10 @@ importers:
       zod:
         specifier: ^4.4.3
         version: 4.4.3
+    devDependencies:
+      vitest:
+        specifier: catalog:default
+        version: 4.1.9(@types/node@24.13.2)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.48.0))
 
   packages/query:
     dependencies:

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -260,6 +260,14 @@ export default defineConfig({
 					],
 				},
 			},
+			{
+				test: {
+					name: 'octane-mcp-server',
+					include: ['packages/octane-mcp-server/src/**/*.test.js'],
+					environment: 'node',
+					globals: false,
+				},
+			},
 		],
 	},
 });


### PR DESCRIPTION
## Summary
- Add repository-local `.ai` project map and task skills for React-library porting, bug hunting, PR creation, issue handling, core extension, triage, and performance audits.
- Add `.codex` and `.claude` references pointing agents to the shared skill files.
- Scaffold `@octanejs/mcp-server` with initial read-only Octane-aware MCP tools for project map, skill loading, path triage, and validation planning.

## Validation
- `pnpm install --lockfile-only`
- `pnpm install --filter @octanejs/mcp-server --ignore-scripts`
- `node --check packages/octane-mcp-server/src/index.js`
- `pnpm --filter @octanejs/mcp-server start` smoke-tested successfully

## Notes
- The MCP server currently exposes safe/read-only planning tools only; execution tools can be added in follow-up PRs.
