### PR TITLE
useDeferredValue parity: deferred-lane bit, render-phase priority inh…

### DIFF
--- a/.changeset/deferred-value-deferred-lane.md
+++ b/.changeset/deferred-value-deferred-lane.md
@@ -1,0 +1,23 @@
+---
+'octane': patch
+---
+
+`useDeferredValue` React-parity fixes (closes the five gaps pinned from
+ReactDeferredValue-test.js) via a "deferred lane" bit on the scheduler:
+
+- **Render-phase updates inherit the in-progress render's priority**: a
+  setState fired while the same component's body is rendering replays at the
+  current pass's priority (and deferred bit) instead of always urgent — so a
+  transition render that syncs state from props no longer makes
+  `useDeferredValue` defer in the replay (both values commit in one pass).
+- **Only the first `useDeferredValue` level defers**: the spawned deferred
+  swap tags its re-render pass as deferred (`Block.currentRenderDeferred`); a
+  `useDeferredValue(value, initialValue)` MOUNTING inside that pass adopts the
+  final value directly instead of waterfalling its own preview — the outer
+  preview already covered the loading state (React's anti-waterfall rule).
+- **Hidden `<Activity>` trees behave like fresh mounts for the hook**: a value
+  change while hidden re-renders the NEW preview state (prerender keeps up);
+  revealing hidden→visible with a different value shows the preview first
+  (with `initialValue`) or adopts the new value immediately (without) — the
+  hidden tree's committed value never flashes on reveal. Revealing with an
+  identical value still skips the preview (prerender payoff, unchanged).

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -328,6 +328,19 @@ export interface Block extends Scope {
 	/** The render mode in effect during the body's *current* execution. */
 	currentRenderMode: 'urgent' | 'transition' | null;
 	/**
+	 * "Deferred lane" bit riding alongside pendingMode: true when the next
+	 * scheduled render was spawned by useDeferredValue's deferred swap. Read &
+	 * cleared with pendingMode when the render is dispatched.
+	 */
+	pendingDeferred: boolean;
+	/**
+	 * True while the body executes inside a useDeferredValue-spawned deferred
+	 * pass (inherited by nested renders, like currentRenderMode). Drives React's
+	 * anti-waterfall rule: only the FIRST useDeferredValue level defers — a hook
+	 * mounting inside an already-deferred pass adopts its final value directly.
+	 */
+	currentRenderDeferred: boolean;
+	/**
 	 * Set on a block inside a HIDDEN `<Activity>` subtree. While inactive, the
 	 * block still renders (state + DOM are produced/updated) but its effects do
 	 * NOT run (enqueueEffect skips when any ancestor is inactive); on reveal the
@@ -440,6 +453,15 @@ let TRANSITION_DEPTH = 0;
  * would need AsyncContext, which isn't available in the browser target.
  */
 let ASYNC_TRANSITION_COUNT = 0;
+/**
+ * True only while useDeferredValue's spawned swap dispatches its re-render
+ * (the microtask's startTransition(scheduleRender) call — see
+ * spawnDeferredSwap). scheduleRender copies it onto the scheduled block as
+ * `pendingDeferred`: the "deferred lane" bit that lets a useDeferredValue
+ * mounting inside that pass skip its own preview state (React's
+ * anti-waterfall — only the first level defers).
+ */
+let DEFERRED_SPAWN = false;
 /**
  * Outstanding transition WORK count — incremented when startTransition fires,
  * decremented when its renders commit (and again for any tryBlock that holds
@@ -642,14 +664,31 @@ function scheduleRender(block: Block): void {
 	// Capture the caller's priority — setters inside startTransition() see
 	// TRANSITION_DEPTH > 0 and tag the render as 'transition'. An urgent setter
 	// arriving for a block already queued at 'transition' upgrades it.
+	// A RENDER-PHASE self-update (setState while this block's own body is on the
+	// stack — CURRENT_BLOCK is only non-null inside renderBlock) inherits the
+	// in-progress render's priority AND deferred bit instead of defaulting to
+	// urgent. React parity: render-phase updates render in the current pass's
+	// lanes, so a transition render that syncs state from props replays at
+	// transition priority (and useDeferredValue in the replay doesn't defer) —
+	// per ReactDeferredValue-test.js:232.
+	const renderPhaseSelf = CURRENT_BLOCK === block;
 	const mode: 'urgent' | 'transition' =
-		TRANSITION_DEPTH > 0 || ASYNC_TRANSITION_COUNT > 0 ? 'transition' : 'urgent';
+		TRANSITION_DEPTH > 0 ||
+		ASYNC_TRANSITION_COUNT > 0 ||
+		(renderPhaseSelf && block.currentRenderMode === 'transition')
+			? 'transition'
+			: 'urgent';
+	const deferred = DEFERRED_SPAWN || (renderPhaseSelf && block.currentRenderDeferred);
 	if (block.pending) {
-		if (mode === 'urgent') block.pendingMode = 'urgent';
+		if (mode === 'urgent') {
+			block.pendingMode = 'urgent';
+			block.pendingDeferred = false;
+		}
 		return;
 	}
 	block.pending = true;
 	block.pendingMode = mode;
+	block.pendingDeferred = deferred;
 	QUEUE.push(block);
 	if (syncFlush) return;
 	if (!scheduled) {
@@ -1227,6 +1266,8 @@ class BlockImpl {
 	mounted: boolean;
 	pendingMode: 'urgent' | 'transition' | null;
 	currentRenderMode: 'urgent' | 'transition' | null;
+	pendingDeferred: boolean;
+	currentRenderDeferred: boolean;
 	inactive: boolean;
 	// Hooks + cleanups (per-block state).
 	hooks: Map<symbol, any> | null;
@@ -1303,6 +1344,8 @@ class BlockImpl {
 		this.mounted = false;
 		this.pendingMode = null;
 		this.currentRenderMode = null;
+		this.pendingDeferred = false;
+		this.currentRenderDeferred = false;
 		this.inactive = false;
 		this.hooks = null;
 		this.cleanups = [];
@@ -1416,7 +1459,15 @@ export function renderBlock(block: Block): void {
 	// if, for, comp slots) called synchronously inside an outer body should
 	// run at the outer body's priority so transitions propagate down naturally.
 	block.currentRenderMode = block.pendingMode ?? prevBlock?.currentRenderMode ?? 'urgent';
+	// The deferred bit rides the same channel: explicit when this block was
+	// scheduled with a mode (pendingMode set), otherwise inherited from the
+	// enclosing render so it reaches components mounting inside a deferred pass.
+	block.currentRenderDeferred =
+		block.pendingMode !== null
+			? block.pendingDeferred
+			: (prevBlock?.currentRenderDeferred ?? false);
 	block.pendingMode = null;
+	block.pendingDeferred = false;
 	try {
 		const out = (block.body as (p: any, s: Scope, e: any) => unknown)(
 			block.props,
@@ -8200,6 +8251,37 @@ interface DeferredSlot<T> {
 	next: T; // latest pending value
 	scheduled: boolean;
 	block: Block;
+	/**
+	 * Whether this slot's LAST render ran inside a hidden <Activity>/suspended
+	 * subtree. Revealing a hidden tree is a fresh mount for this hook (React:
+	 * the prerendered tree has no on-screen "previous" value to defer to), so
+	 * the first visible render after hidden re-runs mount semantics.
+	 */
+	wasHidden: boolean;
+}
+
+/**
+ * Schedule the deferred current→next swap on a microtask. The re-render runs
+ * at transition priority — it can be interrupted by urgent updates and won't
+ * tear down the prior DOM if the swapped-in value suspends. DEFERRED_SPAWN
+ * tags the pass as a DEFERRED render (Block.pendingDeferred) so a
+ * useDeferredValue mounting inside it adopts its final value directly instead
+ * of waterfalling its own preview (React: only the first level defers).
+ */
+function spawnDeferredSwap<T>(s: DeferredSlot<T>): void {
+	s.scheduled = true;
+	queueMicrotask(() => {
+		if (!s.scheduled || s.block.disposed) return;
+		s.scheduled = false;
+		if (Object.is(s.current, s.next)) return;
+		s.current = s.next;
+		DEFERRED_SPAWN = true;
+		try {
+			startTransition(() => scheduleRender(s.block));
+		} finally {
+			DEFERRED_SPAWN = false;
+		}
+	});
 }
 
 export function useDeferredValue<T>(value: T, ...rest: any[]): T {
@@ -8215,36 +8297,47 @@ export function useDeferredValue<T>(value: T, ...rest: any[]): T {
 	const hasInitial = rest.length >= 2;
 	const scope = CURRENT_SCOPE!;
 	const block = CURRENT_BLOCK!;
+	const hidden = inInactiveSubtree(block);
 	let s = scope.hooks?.get(slot) as DeferredSlot<T> | undefined;
 	if (s === undefined) {
-		if (hasInitial) {
+		if (hasInitial && !block.currentRenderDeferred) {
 			// First render returns the user's initialValue; if it differs from
 			// `value`, schedule a deferred re-render to swap to `value`. Mirrors
 			// React's "useDeferredValue with initialValue" contract: a UI that
 			// wants to show stable initial content while the expensive `value`
 			// computation settles in the background.
-			s = { current: initialValue as T, next: value, scheduled: false, block };
+			s = { current: initialValue as T, next: value, scheduled: false, block, wasHidden: hidden };
 			ensureHooks(scope).set(slot, s);
-			if (!Object.is(initialValue as T, value)) {
-				s.scheduled = true;
-				queueMicrotask(() => {
-					if (!s!.scheduled || s!.block.disposed) return;
-					s!.scheduled = false;
-					s!.current = s!.next;
-					// Same transition priority as the steady-state deferral below: the
-					// initialValue→value swap can be interrupted by urgent updates and
-					// won't tear down the initial DOM if the swapped-in value suspends.
-					startTransition(() => scheduleRender(s!.block));
-				});
-			}
+			if (!Object.is(initialValue as T, value)) spawnDeferredSwap(s);
 			return initialValue as T;
 		}
-		s = { current: value, next: value, scheduled: false, block };
+		// No initialValue — or mounting INSIDE an already-spawned deferred pass,
+		// where the OUTER preview already covered the loading state, so the final
+		// value is adopted directly (React's anti-waterfall: only the first
+		// useDeferredValue level defers — ReactDeferredValue-test.js:564).
+		s = { current: value, next: value, scheduled: false, block, wasHidden: hidden };
 		ensureHooks(scope).set(slot, s);
 		return value;
 	}
 	s.next = value;
+	const wasHidden = s.wasHidden;
+	s.wasHidden = hidden;
 	if (Object.is(s.current, value)) return s.current;
+	// Hidden-prerender update, or the first render after a hidden→visible
+	// reveal: React treats the (re)appearing tree as a fresh mount for this
+	// hook — there is no on-screen "previous" value to defer to
+	// (ReactDeferredValue-test.js:746/:848/:894). Re-run mount semantics:
+	// show the NEW preview and spawn the swap, or adopt the value directly
+	// when there is no initialValue (or this is already a deferred pass).
+	if (hidden || wasHidden) {
+		if (hasInitial && !block.currentRenderDeferred && !Object.is(initialValue as T, value)) {
+			s.current = initialValue as T;
+			if (!s.scheduled) spawnDeferredSwap(s);
+			return initialValue as T;
+		}
+		s.current = value;
+		return value;
+	}
 	// If the CURRENT render is already at transition priority, don't defer —
 	// commit the new value immediately. Matches React's `useDeferredValue does
 	// not defer during a transition` semantics — both Original and Deferred
@@ -8253,18 +8346,7 @@ export function useDeferredValue<T>(value: T, ...rest: any[]): T {
 		s.current = value;
 		return value;
 	}
-	if (!s.scheduled) {
-		s.scheduled = true;
-		queueMicrotask(() => {
-			s!.scheduled = false;
-			if (s!.block.disposed || Object.is(s!.current, s!.next)) return;
-			s!.current = s!.next;
-			// Re-render at transition priority — matches React's contract that the
-			// deferred-value commit can be interrupted by urgent updates and won't
-			// tear down the prior DOM if it suspends.
-			startTransition(() => scheduleRender(s!.block));
-		});
-	}
+	if (!s.scheduled) spawnDeferredSwap(s);
 	return s.current;
 }
 

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -8275,12 +8275,19 @@ function spawnDeferredSwap<T>(s: DeferredSlot<T>): void {
 		s.scheduled = false;
 		if (Object.is(s.current, s.next)) return;
 		s.current = s.next;
-		DEFERRED_SPAWN = true;
-		try {
-			startTransition(() => scheduleRender(s.block));
-		} finally {
-			DEFERRED_SPAWN = false;
-		}
+		// Set the flag INSIDE the callback so it wraps only the scheduleRender
+		// for the deferred block: startTransition synchronously notifies
+		// useTransition listeners (tickTransitionCount) BEFORE running fn, and
+		// those listeners scheduleRender their own blocks — which must NOT be
+		// tagged as deferred passes.
+		startTransition(() => {
+			DEFERRED_SPAWN = true;
+			try {
+				scheduleRender(s.block);
+			} finally {
+				DEFERRED_SPAWN = false;
+			}
+		});
 	});
 }
 

--- a/packages/octane/tests/_fixtures/transitions.tsrx
+++ b/packages/octane/tests/_fixtures/transitions.tsrx
@@ -235,6 +235,44 @@ export function DeferredValueInTransition() @{
 }
 
 // ---------------------------------------------------------------------------
+// Regression: the deferred-swap "deferred lane" tag applies ONLY to the
+// deferred block's own re-render. startTransition notifies useTransition
+// listeners synchronously (tickTransitionCount) around running its callback;
+// a probe re-rendered by that notification mounts a fresh useDeferredValue,
+// which must still show its preview — it is NOT part of the deferred pass.
+// ---------------------------------------------------------------------------
+function ListenerPreviewProbe(props) @{
+	const text = useDeferredValue('Final', 'Preview');
+	props.log('render:' + text);
+	<span id="probe">
+		{text as string}
+	</span>
+}
+
+function TransitionPendingProbe(props) @{
+	const [isPending] = useTransition();
+	<div>
+		@if (isPending) {
+			<ListenerPreviewProbe log={props.log} />
+		} @else {
+			<span id="probe-idle">{'idle'}</span>
+		}
+	</div>
+}
+
+export function DeferredSpawnListenerApp(props) @{
+	const [value, setValue] = useState(1);
+	props.expose(setValue);
+	const deferredValue = useDeferredValue(value);
+	<div>
+		<span id="deferred">
+			{'Deferred: ' + deferredValue}
+		</span>
+		<TransitionPendingProbe log={props.log} />
+	</div>
+}
+
+// ---------------------------------------------------------------------------
 // Urgent supersede: a transition suspends on promise B, then an urgent
 // setter swaps to promise C (already-resolved). The transition should be
 // DISCARDED — isPending flips false, C is shown, and when B eventually

--- a/packages/octane/tests/conformance/deferred-value.test.ts
+++ b/packages/octane/tests/conformance/deferred-value.test.ts
@@ -114,34 +114,27 @@ describe('conformance: useDeferredValue (ReactDeferredValue-test.js)', () => {
 		r.unmount();
 	});
 
-	it.fails(
-		"works if there's a render phase update (does not defer during a transition)",
-		async () => {
-			// Per ReactDeferredValue-test.js:232 — the same component updated inside
-			// a TRANSITION must commit Original and Deferred in the SAME pass ("if it
-			// updates during a transition, it doesn't defer").
-			//
-			// GAP: a render-phase setState in octane schedules a plain (urgent)
-			// re-render instead of inheriting the in-progress render's transition
-			// priority (React render-phase updates inherit the current render lanes).
-			// The replayed body therefore sees currentRenderMode !== 'transition' and
-			// defers, committing the deferred value one microtask later. The direct
-			// (non-render-phase) shape has no such gap — see the :108 port above.
-			let setValue!: (v: number) => void;
-			const r = mount(RenderPhaseDeferredHost, { expose: (s: any) => (setValue = s) });
-			await act(() => {});
-			expect(r.find('#deferred').textContent).toBe('Deferred: 1');
+	it("works if there's a render phase update (does not defer during a transition)", async () => {
+		// Per ReactDeferredValue-test.js:232 — the same component updated inside
+		// a TRANSITION must commit Original and Deferred in the SAME pass ("if it
+		// updates during a transition, it doesn't defer"). The render-phase
+		// setState replay inherits the in-progress render's transition priority
+		// (scheduleRender's render-phase self-update path), so the replayed body
+		// sees currentRenderMode === 'transition' and commits directly.
+		let setValue!: (v: number) => void;
+		const r = mount(RenderPhaseDeferredHost, { expose: (s: any) => (setValue = s) });
+		await act(() => {});
+		expect(r.find('#deferred').textContent).toBe('Deferred: 1');
 
-			flushSync(() => startTransition(() => setValue(2)));
-			const original = r.find('#original').textContent;
-			const deferred = r.find('#deferred').textContent;
-			await act(() => {});
-			r.unmount();
-			expect(original).toBe('Original: 2');
-			// React commits the deferred value in the same render as the original.
-			expect(deferred).toBe('Deferred: 2');
-		},
-	);
+		flushSync(() => startTransition(() => setValue(2)));
+		const original = r.find('#original').textContent;
+		const deferred = r.find('#deferred').textContent;
+		await act(() => {});
+		r.unmount();
+		expect(original).toBe('Original: 2');
+		// React commits the deferred value in the same render as the original.
+		expect(deferred).toBe('Deferred: 2');
+	});
 
 	it('regression test: during urgent update, reuse previous value, not initial value', async () => {
 		// Per ReactDeferredValue-test.js:298 — after a TRANSITION commit moved the
@@ -152,10 +145,8 @@ describe('conformance: useDeferredValue (ReactDeferredValue-test.js)', () => {
 		await act(() => {});
 		expect(r.find('#deferred').textContent).toBe('Deferred: 1');
 
-		// Non-urgent update. (React commits both in one pass; octane's
-		// render-phase-update transition gap — pinned in the :232 it.fails above —
-		// adds a microtask before the deferred value lands, so settle with act()
-		// before the step this regression test actually targets.)
+		// Non-urgent update: both values commit in one pass (the render-phase
+		// replay inherits the transition priority — see the :232 port above).
 		flushSync(() => startTransition(() => setValue(2)));
 		expect(r.find('#original').textContent).toBe('Original: 2');
 		await act(() => {});
@@ -219,35 +210,24 @@ describe('conformance: useDeferredValue (ReactDeferredValue-test.js)', () => {
 		r.unmount();
 	});
 
-	it.fails(
-		'if there are multiple useDeferredValues in the same tree, only the first level defers; subsequent ones go straight to the final value, to avoid a waterfall',
-		async () => {
-			// Per ReactDeferredValue-test.js:564 — a useDeferredValue hook MOUNTED
-			// inside the spawned deferred render must skip its own preview state and
-			// go straight to the final value (React intentionally differs from nested
-			// Suspense here: the OUTER preview already covered the loading state).
-			//
-			// GAP: octane's useDeferredValue mount path always returns initialValue
-			// and spawns its own deferred swap — it does not know it is rendering
-			// inside an already-spawned deferred pass (there is no "deferred lane"
-			// bit on the render, only the transition flag, and mount ignores both).
-			// So the inner hook renders 'Content Preview' first: a preview waterfall
-			// React avoids. Fix hypothesis: thread an "is deferred render" flag from
-			// the useDeferredValue-spawned startTransition(scheduleRender) into
-			// mount-with-initialValue (and reveal-from-hidden), committing the final
-			// value directly there.
-			const log = createLog();
-			const r = mount(WaterfallApp, { log: log.push });
-			expect(r.find('#app-preview').textContent).toBe('App Preview');
-			await act(() => {});
-			const entries = log.drain();
-			const finalHtml = r.find('#content').textContent;
-			r.unmount();
-			expect(finalHtml).toBe('Content');
-			// React never renders the inner preview — this is the failing assertion.
-			expect(entries).not.toContain('render:Content Preview');
-		},
-	);
+	it('if there are multiple useDeferredValues in the same tree, only the first level defers; subsequent ones go straight to the final value, to avoid a waterfall', async () => {
+		// Per ReactDeferredValue-test.js:564 — a useDeferredValue hook MOUNTED
+		// inside the spawned deferred render must skip its own preview state and
+		// go straight to the final value (React intentionally differs from nested
+		// Suspense here: the OUTER preview already covered the loading state).
+		// The spawned swap tags its pass with the "deferred lane" bit
+		// (Block.currentRenderDeferred), which the mount path reads.
+		const log = createLog();
+		const r = mount(WaterfallApp, { log: log.push });
+		expect(r.find('#app-preview').textContent).toBe('App Preview');
+		await act(() => {});
+		const entries = log.drain();
+		const finalHtml = r.find('#content').textContent;
+		r.unmount();
+		expect(finalHtml).toBe('Content');
+		// React never renders the inner preview.
+		expect(entries).not.toContain('render:Content Preview');
+	});
 
 	it("regression: useDeferredValue's initial value argument works even if an unrelated transition is suspended", async () => {
 		// Per ReactDeferredValue-test.js:611 — while screen A's final value is
@@ -274,18 +254,11 @@ describe('conformance: useDeferredValue (ReactDeferredValue-test.js)', () => {
 		r.unmount();
 	});
 
-	it.fails('useDeferredValue can prerender the initial value inside a hidden tree', async () => {
+	it('useDeferredValue can prerender the initial value inside a hidden tree', async () => {
 		// Per ReactDeferredValue-test.js:746 — updating a HIDDEN prerendered tree
-		// should switch to prerendering the NEW preview state (revealing a hidden
-		// tree is treated like a fresh mount, so the preview must exist).
-		//
-		// GAP: octane's useDeferredValue slot is oblivious to Activity visibility.
-		// An update while hidden takes the steady-state path: it returns the
-		// previous committed value ('A'), then swaps straight to the final value
-		// ('B') on the deferred microtask — the new preview state is never
-		// rendered. Fix hypothesis: when the owning block is inside a hidden
-		// Activity subtree, treat a changed value like a fresh mount (render
-		// initialValue, then spawn the swap).
+		// switches to prerendering the NEW preview state (revealing a hidden tree
+		// is treated like a fresh mount, so the preview must exist). A changed
+		// value while inside a hidden subtree re-runs mount semantics.
 		const log = createLog();
 		const r = mount(ActivityDeferredContainer, { text: 'A', shouldShow: false, log: log.push });
 		await act(() => {});
@@ -317,58 +290,43 @@ describe('conformance: useDeferredValue (ReactDeferredValue-test.js)', () => {
 		r.unmount();
 	});
 
-	it.fails(
-		'useDeferredValue does not skip the preview state when revealing a hidden tree if the final value is different from the currently rendered one',
-		async () => {
-			// Per ReactDeferredValue-test.js:848 — revealing with a DIFFERENT value
-			// cannot bail: React treats the reveal as a fresh mount and shows the
-			// preview state first, then the final value.
-			//
-			// GAP: same root cause as the hidden-prerender case — octane's slot
-			// ignores the hidden→visible transition and takes the steady-state defer
-			// path, briefly showing the PREVIOUS committed value ('A') instead of the
-			// new preview ('Preview [B]').
-			const log = createLog();
-			const r = mount(ActivityDeferredContainer, { text: 'A', shouldShow: false, log: log.push });
-			await act(() => {});
-			log.clear();
+	it('useDeferredValue does not skip the preview state when revealing a hidden tree if the final value is different from the currently rendered one', async () => {
+		// Per ReactDeferredValue-test.js:848 — revealing with a DIFFERENT value
+		// cannot bail: React treats the reveal as a fresh mount and shows the
+		// preview state first, then the final value.
+		const log = createLog();
+		const r = mount(ActivityDeferredContainer, { text: 'A', shouldShow: false, log: log.push });
+		await act(() => {});
+		log.clear();
 
-			r.update(ActivityDeferredContainer, { text: 'B', shouldShow: true, log: log.push });
-			const intermediate = r.find('#app').textContent;
-			await act(() => {});
-			const finalText = r.find('#app').textContent;
-			r.unmount();
-			expect(finalText).toBe('B');
-			// React first commits the preview state — this is the failing assertion.
-			expect(intermediate).toBe('Preview [B]');
-		},
-	);
+		r.update(ActivityDeferredContainer, { text: 'B', shouldShow: true, log: log.push });
+		const intermediate = r.find('#app').textContent;
+		await act(() => {});
+		const finalText = r.find('#app').textContent;
+		r.unmount();
+		expect(finalText).toBe('B');
+		// React first commits the preview state.
+		expect(intermediate).toBe('Preview [B]');
+	});
 
-	it.fails(
-		'useDeferredValue does not show "previous" value when revealing a hidden tree (no initial value)',
-		async () => {
-			// Per ReactDeferredValue-test.js:894 — updating and revealing a hidden
-			// tree in the same (sync) update must show the NEW value immediately:
-			// conceptually this is a new tree, so there is no "previous" value to
-			// defer to.
-			//
-			// GAP: octane's slot keeps the hidden tree's committed value and defers
-			// the urgent update as usual, so 'A' flashes before the microtask commits
-			// 'B'. Fix hypothesis: reveal-from-hidden (like mount) should adopt the
-			// incoming value directly.
-			const log = createLog();
-			const r = mount(ActivityNoInitialContainer, { text: 'A', shouldShow: false, log: log.push });
-			await act(() => {});
-			expect(log.drain()).toEqual(['render:A']);
+	it('useDeferredValue does not show "previous" value when revealing a hidden tree (no initial value)', async () => {
+		// Per ReactDeferredValue-test.js:894 — updating and revealing a hidden
+		// tree in the same (sync) update must show the NEW value immediately:
+		// conceptually this is a new tree, so there is no "previous" value to
+		// defer to. Reveal-from-hidden (like mount) adopts the incoming value
+		// directly when there is no initialValue.
+		const log = createLog();
+		const r = mount(ActivityNoInitialContainer, { text: 'A', shouldShow: false, log: log.push });
+		await act(() => {});
+		expect(log.drain()).toEqual(['render:A']);
 
-			r.update(ActivityNoInitialContainer, { text: 'B', shouldShow: true, log: log.push });
-			const intermediate = r.find('#app').textContent;
-			await act(() => {});
-			r.unmount();
-			// React commits B in the same sync update.
-			expect(intermediate).toBe('B');
-		},
-	);
+		r.update(ActivityNoInitialContainer, { text: 'B', shouldShow: true, log: log.push });
+		const intermediate = r.find('#app').textContent;
+		await act(() => {});
+		r.unmount();
+		// React commits B in the same sync update.
+		expect(intermediate).toBe('B');
+	});
 });
 
 // ============================================================================
@@ -378,10 +336,9 @@ describe('conformance: useDeferredValue (ReactDeferredValue-test.js)', () => {
 //   :171 "does not defer during a transition" — COVERED-BY-EXISTING:
 //        transitions.test.ts:361 ('useDeferredValue does NOT defer when called
 //        during a transition render') + suspense.test.ts:425 (urgent deferral).
-//   :232 "works if there's a render phase update" — PORTED as two tests: the
-//        urgent path passes; the no-defer-during-transition half is it.fails
-//        (// GAP: render-phase setState re-renders urgently instead of
-//        inheriting the in-progress transition priority).
+//   :232 "works if there's a render phase update" — PORTED as two tests
+//        (urgent path + no-defer-during-transition; both pass — render-phase
+//        setState inherits the in-progress render's priority).
 //   :298 "regression test: during urgent update, reuse previous value, not
 //        initial value" — PORTED (passes).
 //   :374 "supports initialValue argument" — PORTED (passes).
@@ -399,23 +356,25 @@ describe('conformance: useDeferredValue (ReactDeferredValue-test.js)', () => {
 //        Suspense boundary (see :407), and choosing between two parked
 //        in-flight renders is time-slicing choreography; octane's deferred
 //        swap supersedes the initial value as soon as its microtask runs.
-//   :564 "only the first level defers…" — PORTED as it.fails (// GAP: no
-//        "deferred render" bit; mount always shows initialValue → waterfall).
+//   :564 "only the first level defers…" — PORTED (passes; the spawned swap
+//        tags its pass with Block.currentRenderDeferred and the mount path
+//        adopts the final value directly inside such a pass).
 //   :611 "initial value argument works even if an unrelated transition is
 //        suspended" — PORTED (passes).
 //   :653 "avoids a useDeferredValue waterfall when separated by a Suspense
-//        boundary" — same single gap as :564 (the first-level-only skip);
-//        subsumed by the :564 it.fails pin, not separately ported.
+//        boundary" — same single behavior as :564 (the first-level-only
+//        skip); subsumed by the :564 port, not separately ported.
 //   :699 "can spawn a deferred task while prerendering a hidden tree" — N/A:
 //        depends on Suspense pre-warming inside a hidden prerender (offscreen
 //        lanes); the non-suspending halves are pinned by the :746/:808 ports.
-//   :746 "can prerender the initial value inside a hidden tree" — PORTED as
-//        it.fails (// GAP: hidden-tree update doesn't re-show the preview).
+//   :746 "can prerender the initial value inside a hidden tree" — PORTED
+//        (passes; a changed value inside a hidden subtree re-runs mount
+//        semantics for the slot).
 //   :808 "skips the preview state when revealing a hidden tree if the final
 //        value is referentially identical" — PORTED (passes).
 //   :848 "does not skip the preview state when revealing a hidden tree if the
-//        final value is different" — PORTED as it.fails (// GAP: reveal is not
-//        treated as a fresh mount; previous value flashes).
+//        final value is different" — PORTED (passes; reveal-from-hidden is
+//        treated as a fresh mount for the slot).
 //   :894 "does not show 'previous' value when revealing a hidden tree (no
-//        initial value)" — PORTED as it.fails (// GAP: same reveal root cause).
+//        initial value)" — PORTED (passes; same fresh-mount reveal rule).
 // ============================================================================

--- a/packages/octane/tests/transitions.test.ts
+++ b/packages/octane/tests/transitions.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { mount, act } from './_helpers';
+import { mount, act, createLog } from './_helpers';
+import { flushSync } from '../src/index.js';
 import {
 	TransitionBasics,
+	DeferredSpawnListenerApp,
 	TransitionKeepsDom,
 	StandaloneStartTransition,
 	DeferredValueWithSuspense,
@@ -372,6 +374,37 @@ describe('Transitions — multiple-suspend edge cases', () => {
 		expect(r.find('#original').textContent).toBe('Original: 2');
 		expect(r.find('#deferred').textContent).toBe('Deferred: 2'); // NOT 1!
 		r.unmount();
+	});
+
+	it("deferred-swap 'deferred lane' tag does not leak to useTransition listener renders", async () => {
+		// Regression (PR review): spawnDeferredSwap's DEFERRED_SPAWN flag must
+		// wrap ONLY the scheduleRender for the deferred block. startTransition
+		// synchronously notifies useTransition listeners (tickTransitionCount)
+		// before running its callback; those listeners scheduleRender their own
+		// blocks. If the flag covered the whole startTransition call, the
+		// probe's render would be tagged as a deferred pass and a
+		// useDeferredValue mounting in it would wrongly skip its preview state.
+		const log = createLog();
+		let setValue!: (v: number) => void;
+		const r = mount(DeferredSpawnListenerApp, {
+			expose: (s: any) => (setValue = s),
+			log: log.push,
+		});
+		await act(() => {});
+		expect(r.find('#deferred').textContent).toBe('Deferred: 1');
+		expect(r.find('#probe-idle').textContent).toBe('idle');
+
+		// Urgent update → useDeferredValue defers and spawns its swap. The swap's
+		// startTransition flips isPending true, mounting the probe's inner
+		// useDeferredValue in the SAME flush as the deferred pass.
+		flushSync(() => setValue(2));
+		expect(r.find('#deferred').textContent).toBe('Deferred: 1');
+		await act(() => {});
+		expect(r.find('#deferred').textContent).toBe('Deferred: 2');
+		const entries = log.drain();
+		r.unmount();
+		// The probe is NOT part of the deferred pass — its preview must render.
+		expect(entries[0]).toBe('render:Preview');
 	});
 });
 


### PR DESCRIPTION
…eritance, hidden-tree fresh-mount semantics

Closes the five ReactDeferredValue-test.js gaps pinned in conformance/deferred-value.test.ts:

- Render-phase self-updates (setState while the block's own body is on the stack) inherit the in-progress render's priority and deferred bit instead of defaulting to urgent, so a transition render that syncs state from props commits both the original and deferred values in one pass (:232).
- The spawned deferred swap tags its pass with a "deferred lane" bit (Block.pendingDeferred / currentRenderDeferred, inherited like the render mode); useDeferredValue mounting inside that pass adopts the final value directly instead of waterfalling its own preview (:564).
- The slot tracks hidden <Activity>/suspended subtrees (wasHidden): a value change while hidden re-runs mount semantics (new preview prerendered, :746), and reveal-with-a-different-value shows the preview first (:848) or adopts the value immediately when there is no initialValue (:894). Identical-value reveals still skip the preview (:808 unchanged).

All five pins flipped from it.fails to it; accounting block updated; changeset added (patch).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core render scheduling and hook commit semantics in `runtime.ts`, but changes are narrowly scoped to deferred-value parity with expanded conformance and regression coverage.
> 
> **Overview**
> Brings **`useDeferredValue`** in line with React 19 by threading a **deferred lane** through the scheduler (`pendingDeferred` / `currentRenderDeferred`, set only while `spawnDeferredSwap` schedules its block) so nested hooks in that pass skip their own preview (anti-waterfall).
> 
> **`scheduleRender`** now treats render-phase self-updates as inheriting the in-progress render’s transition priority and deferred bit, so transition replays commit original and deferred values together.
> 
> Deferred slots track **hidden `<Activity>`** subtrees (`wasHidden`): updates while hidden and reveal-with-new-value follow **fresh-mount** preview/adopt rules instead of flashing the old committed value.
> 
> Five conformance tests move from `it.fails` to passing; a new test ensures the deferred-lane flag does not tag **`useTransition`** listener re-renders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcfb5b461954ec57443e67c4e236f8e800c1f0fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->