### PR TITLE
Compiler: emit runtime helpers under shadow-proof `_$` aliases

### DIFF
--- a/.changeset/helper-shadowing-aliased-imports.md
+++ b/.changeset/helper-shadowing-aliased-imports.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Compiler-emitted runtime helpers can no longer be shadowed by user bindings. Generated code used to import and call helpers by their bare names (`setText`, `htext`, `clone`, `template`, …), so a user binding with the same name inside a component silently hijacked the generated call — `const [text, setText] = useState('')` (React's most common naming for text state) broke the text-hole update and stored a DOM Text node in state, and a module-level `const template = …` was a duplicate-declaration SyntaxError against the prelude import. The compiler now imports every generated-code helper under a collision-proof alias (`import { setText as _$setText } from 'octane'`) and references it as `_$setText(…)`, on both the client and server (`octane/server`) codegen paths — covering all emitted helpers (text/attr/style/class/spread setters, block helpers, refs, `createElement`, `withSlot`, `normalizeClass`, HMR wiring, and the `ssr*` family). Names the user's own code references — their preserved `octane` import specifiers (including `x as y` renames, which previously lost the alias) and slotted base-hook call sites — stay un-aliased.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -100,6 +100,48 @@ function rejectVoidElementContent(tag, node, ctx) {
 	);
 }
 
+// Compiler-generated code references runtime helpers under a collision-proof
+// `_$` alias — `import { setText as _$setText } from 'octane'` + `_$setText(…)`
+// — because generated statements are interleaved with USER statements inside
+// the component function, where a user binding with the same name would
+// silently shadow a bare helper (`const [text, setText] = useState('')` is the
+// canonical collision). Every name in `ctx.runtimeNeeded` is emitted aliased;
+// names the user's own code references (their preserved `octane` import
+// specifiers + slotted base-hook call sites) live in `ctx.userRuntimeNames`
+// and stay un-aliased. A name can appear in both (two import specifiers of
+// the same export — valid JS).
+export function rtAlias(name) {
+	return '_$' + name;
+}
+
+// Merge one import list: user specifiers verbatim (preserving `x as y`
+// aliases) + every generated-code helper aliased to `_$name`.
+function buildRuntimeImport(ctx, moduleName) {
+	const specifiers = new Set(ctx.userRuntimeNames);
+	for (const n of ctx.runtimeNeeded) specifiers.add(`${n} as ${rtAlias(n)}`);
+	if (specifiers.size === 0) return '';
+	return `import { ${[...specifiers].sort().join(', ')} } from '${moduleName}';\n\n`;
+}
+
+// Record a user `import { … } from 'octane'` declaration's specifiers so the
+// merged prelude import re-exposes exactly the local names the user's code
+// references (including `imported as local` renames).
+function addUserImportSpecifiers(ctx, node) {
+	for (const sp of node.specifiers || []) {
+		if (
+			sp.type === 'ImportSpecifier' &&
+			sp.imported?.name &&
+			sp.local?.name &&
+			sp.imported.name !== sp.local.name
+		) {
+			ctx.userRuntimeNames.add(`${sp.imported.name} as ${sp.local.name}`);
+			continue;
+		}
+		const name = sp.imported?.name || sp.local?.name;
+		if (name) ctx.userRuntimeNames.add(name);
+	}
+}
+
 export const HOOK_NAMES = new Set([
 	'useState',
 	'useReducer',
@@ -495,7 +537,10 @@ function rewriteAutoCallback(stmt, stable, componentLocals, ctx) {
 			...decl,
 			init: {
 				type: 'CallExpression',
-				callee: { type: 'Identifier', name: 'useCallback' },
+				// `_octaneGenerated` tells rewriteHookCalls (which slots this call next)
+				// that the callee is compiler-inserted — it renames it to the shadow-proof
+				// `_$useCallback` alias instead of treating it as a user identifier.
+				callee: { type: 'Identifier', name: 'useCallback', _octaneGenerated: true },
 				arguments: [
 					arrow,
 					{
@@ -1161,7 +1206,8 @@ export function compile(source, filename, options) {
 		filename,
 		mode,
 		dev: devEnabled,
-		runtimeNeeded: new Set(),
+		runtimeNeeded: new Set(), // helpers referenced by GENERATED code — imported as `name as _$name`
+		userRuntimeNames: new Set(), // specifiers USER code references — imported verbatim
 		hoistedTemplates: [], // { name, html }
 		hoistedHelpers: [], // raw JS strings (sub-components, hook Symbols, key fns)
 		delegatedEvents: new Set(), // bubble event names seen in JSX — auto-emits delegateEvents(...)
@@ -1394,10 +1440,7 @@ export function compile(source, filename, options) {
 		} else if (node.type === 'ImportDeclaration' && node.source.value === 'octane') {
 			// Preserve ALL user-imported names from octane (Portal, createContext,
 			// use, custom helpers, etc.) — merged into the single prelude import.
-			for (const sp of node.specifiers || []) {
-				const name = sp.imported?.name || sp.local?.name;
-				if (name) ctx.runtimeNeeded.add(name);
-			}
+			addUserImportSpecifiers(ctx, node);
 		} else {
 			// Style maps: rewrite `const x = <style>…</style>` before printing — the
 			// initialiser becomes an ObjectExpression with hashed class names, and
@@ -1443,14 +1486,14 @@ export function compile(source, filename, options) {
 	// import list includes `hmr` / `HMR` when needed.
 	const delegateCall =
 		(ctx.delegatedEvents.size > 0
-			? `delegateEvents(${JSON.stringify([...ctx.delegatedEvents].sort())});\n`
+			? `_$delegateEvents(${JSON.stringify([...ctx.delegatedEvents].sort())});\n`
 			: '') +
 		(ctx.capturedEvents.size > 0
-			? `delegateCaptureEvents(${JSON.stringify([...ctx.capturedEvents].sort())});\n`
+			? `_$delegateCaptureEvents(${JSON.stringify([...ctx.capturedEvents].sort())});\n`
 			: '') +
 		(ctx.delegatedEvents.size > 0 || ctx.capturedEvents.size > 0 ? '\n' : '');
 	const styleInjections = ctx.cssInjections
-		.map((i) => `injectStyle(${JSON.stringify(i.hash)}, ${JSON.stringify(i.css)});`)
+		.map((i) => `_$injectStyle(${JSON.stringify(i.hash)}, ${JSON.stringify(i.css)});`)
 		.join('\n');
 	const styleBlock = styleInjections ? styleInjections + '\n\n' : '';
 	const templates = ctx.hoistedTemplates
@@ -1458,7 +1501,7 @@ export function compile(source, filename, options) {
 			const args = [JSON.stringify(t.html)];
 			if (t.ns || t.frag) args.push(String(t.ns | 0));
 			if (t.frag) args.push(String(t.frag | 0));
-			return `const ${t.name} = template(${args.join(', ')});`;
+			return `const ${t.name} = _$template(${args.join(', ')});`;
 		})
 		.join('\n');
 	const templatesBlock = templates ? templates + '\n\n' : '';
@@ -1481,7 +1524,7 @@ export function compile(source, filename, options) {
 		const updates = hmrComponents
 			.map((c) => {
 				const accessor = c.exportKind === 'default' ? 'module.default' : `module.${c.name}`;
-				return `    ${c.name}[HMR].update(${accessor});`;
+				return `    ${c.name}[_$HMR].update(${accessor});`;
 			})
 			.join('\n');
 		hmrBlock =
@@ -1494,10 +1537,7 @@ export function compile(source, filename, options) {
 	}
 
 	// Built after HMR wiring so the import list includes `hmr`/`HMR` when needed.
-	const finalRuntimeImport =
-		ctx.runtimeNeeded.size > 0
-			? `import { ${[...ctx.runtimeNeeded].sort().join(', ')} } from 'octane';\n\n`
-			: '';
+	const finalRuntimeImport = buildRuntimeImport(ctx, 'octane');
 
 	// Everything before `body` in the output — shifts every body segment's
 	// generated line down by the prelude's line count.
@@ -1550,7 +1590,8 @@ function compileServer(source, filename, options) {
 	const ctx = {
 		filename,
 		mode: 'server',
-		runtimeNeeded: new Set(),
+		runtimeNeeded: new Set(), // helpers referenced by GENERATED code — imported as `name as _$name`
+		userRuntimeNames: new Set(), // specifiers USER code references — imported verbatim
 		hoistedHelpers: [],
 		cssInjections: [],
 		currentComponentLocals: null,
@@ -1583,10 +1624,7 @@ function compileServer(source, filename, options) {
 			body += compileServerComponent({ ...node.declaration, default: true }, ctx) + '\n\n';
 		} else if (node.type === 'ImportDeclaration' && node.source.value === 'octane') {
 			// User imports from 'octane' resolve to the server runtime instead.
-			for (const sp of node.specifiers || []) {
-				const name = sp.imported?.name || sp.local?.name;
-				if (name) ctx.runtimeNeeded.add(name);
-			}
+			addUserImportSpecifiers(ctx, node);
 		} else {
 			applyStyleMap(node, ctx);
 			if (node.type === 'ExportNamedDeclaration' && node.declaration) {
@@ -1596,10 +1634,7 @@ function compileServer(source, filename, options) {
 		}
 	}
 
-	const runtimeImport =
-		ctx.runtimeNeeded.size > 0
-			? `import { ${[...ctx.runtimeNeeded].sort().join(', ')} } from 'octane/server';\n\n`
-			: '';
+	const runtimeImport = buildRuntimeImport(ctx, 'octane/server');
 	const helpers = ctx.hoistedHelpers.length ? ctx.hoistedHelpers.join('\n') + '\n\n' : '';
 	const code = runtimeImport + helpers + body;
 	// Minimal (valid, empty-mapping) source map. SSR source maps are a later
@@ -1718,7 +1753,7 @@ function ssrCompileBody(node, ctx, name, cssHash, cssEntries, parentNs = 'html')
 		ctx.runtimeNeeded.add('injectStyle');
 		cssLines =
 			cssEntries
-				.map((e) => `  injectStyle(${JSON.stringify(e.hash)}, ${JSON.stringify(e.css)});`)
+				.map((e) => `  _$injectStyle(${JSON.stringify(e.hash)}, ${JSON.stringify(e.css)});`)
 				.join('\n') + '\n';
 	}
 	// `ssrHeadEl(…)` side-effect statements (one per hoisted head element), like injectStyle.
@@ -1761,7 +1796,7 @@ function ssrEmitNode(node, ctx, name, inlinedSubs, parentNs, cssHash) {
 			// rewrite, so key it here too (else it collides with sibling/nested use()).
 			if (isKnownStringExpression(expr, ctx.knownStringLocals)) {
 				ctx.runtimeNeeded.add('ssrText');
-				return `ssrText(${printExpr(resolveStyleExpr(rewriteHookCalls(expr, ctx, name), cssHash))})`;
+				return `_$ssrText(${printExpr(resolveStyleExpr(rewriteHookCalls(expr, ctx, name), cssHash))})`;
 			}
 			ctx.runtimeNeeded.add('ssrChild');
 			// rewriteJsxValues lowers any JSX embedded in the expression (e.g.
@@ -1769,7 +1804,7 @@ function ssrEmitNode(node, ctx, name, inlinedSubs, parentNs, cssHash) {
 			// createElement(...) descriptors — exactly like ssrEmitTsrxExpression and
 			// the client makeChildCall. Without it the raw JSX leaks into the emitted
 			// ssrChild(...) call as unparseable source.
-			return `ssrChild(${printExpr(resolveStyleExpr(rewriteJsxValues(rewriteHookCalls(expr, ctx, name), ctx), cssHash))}, __s)`;
+			return `_$ssrChild(${printExpr(resolveStyleExpr(rewriteJsxValues(rewriteHookCalls(expr, ctx, name), ctx), cssHash))}, __s)`;
 		}
 		case 'Element':
 			if (isComponentTag(node)) return ssrEmitComponent(node, ctx, name, inlinedSubs, cssHash);
@@ -1840,7 +1875,7 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash) {
 				tempName: tmp,
 				argExpr: printExprWithTsrx(attr.argument, ctx, name, inlinedSubs),
 			});
-			parts.push(`ssrSpread(${tmp})`);
+			parts.push(`_$ssrSpread(${tmp})`);
 			// The spread may carry `dangerouslySetInnerHTML` — record it as a raw-HTML
 			// source (at this source position) so it participates in last-wins ordering.
 			htmlSources.push(`(${tmp} != null ? ${tmp}.dangerouslySetInnerHTML : void 0)`);
@@ -1888,7 +1923,7 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash) {
 			}
 			flush();
 			ctx.runtimeNeeded.add('ssrStyle');
-			parts.push(`ssrStyle(${printExprWithTsrx(inner, ctx, name, inlinedSubs)})`);
+			parts.push(`_$ssrStyle(${printExprWithTsrx(inner, ctx, name, inlinedSubs)})`);
 			continue;
 		}
 
@@ -1921,7 +1956,7 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash) {
 			ctx.runtimeNeeded.add('ssrAttr');
 			const outName = tag === 'form' ? 'action' : 'formaction';
 			parts.push(
-				`ssrAttr(${JSON.stringify(outName)}, ((__v) => (typeof __v === 'function' ? null : __v))(${printExprWithTsrx(inner, ctx, name, inlinedSubs)}))`,
+				`_$ssrAttr(${JSON.stringify(outName)}, ((__v) => (typeof __v === 'function' ? null : __v))(${printExprWithTsrx(inner, ctx, name, inlinedSubs)}))`,
 			);
 			continue;
 		}
@@ -1930,7 +1965,7 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash) {
 		flush();
 		ctx.runtimeNeeded.add('ssrAttr');
 		parts.push(
-			`ssrAttr(${JSON.stringify(attrName)}, ${printExprWithTsrx(inner, ctx, name, inlinedSubs)})`,
+			`_$ssrAttr(${JSON.stringify(attrName)}, ${printExprWithTsrx(inner, ctx, name, inlinedSubs)})`,
 		);
 	}
 
@@ -1959,7 +1994,7 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash) {
 		!isKnownStringExpression(onlyChild0.expression, ctx.knownStringLocals)
 	) {
 		ctx.runtimeNeeded.add('ssrChildText');
-		childrenExpr = `ssrChildText(${printExpr(resolveStyleExpr(rewriteJsxValues(rewriteHookCalls(onlyChild0.expression, ctx, name), ctx), cssHash))}, __s)`;
+		childrenExpr = `_$ssrChildText(${printExpr(resolveStyleExpr(rewriteJsxValues(rewriteHookCalls(onlyChild0.expression, ctx, name), ctx), cssHash))}, __s)`;
 	} else {
 		childrenExpr = ssrEmitNodes(normChildren, ctx, name, inlinedSubs, childNs, cssHash);
 	}
@@ -1968,7 +2003,7 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash) {
 		// at runtime (last source wins); otherwise the children render.
 		ctx.runtimeNeeded.add('ssrInnerHtml');
 		flush();
-		parts.push(`(ssrInnerHtml([${htmlSources.join(', ')}]) ?? (${childrenExpr}))`);
+		parts.push(`(_$ssrInnerHtml([${htmlSources.join(', ')}]) ?? (${childrenExpr}))`);
 	} else if (childrenExpr !== "''") {
 		flush();
 		parts.push(childrenExpr);
@@ -2048,14 +2083,14 @@ function ssrEmitComponent(node, ctx, name, inlinedSubs, cssHash) {
 		}
 	}
 	ctx.runtimeNeeded.add('ssrComponent');
-	return `ssrComponent(__s, ${compExpr}, { ${propParts.join(', ')} })`;
+	return `_$ssrComponent(__s, ${compExpr}, { ${propParts.join(', ')} })`;
 }
 
 // ---------------------------------------------------------------------------
 // Server control flow — @if/@for/@switch/@try lowered to HTML-string builders.
 // Each branch/item/case body is compiled (via ssrCompileSub) into a server
 // sub-function returning a string, and the chosen branch's output is wrapped in
-// `ssrBlock(…)` (BLOCK_OPEN/BLOCK_CLOSE markers) so a future client hydrate
+// `_$ssrBlock(…)` (BLOCK_OPEN/BLOCK_CLOSE markers) so a future client hydrate
 // cursor can find the boundaries. Expressions (test/items/discriminant) are
 // printed and evaluated at render time.
 // ---------------------------------------------------------------------------
@@ -2093,9 +2128,9 @@ function ssrEmitIf(node, ctx, name, inlinedSubs, parentNs, cssHash) {
 	// taken branch's content. The client adopts BOTH on hydration (slot = outer,
 	// branch = inner) so no comment markers are inserted — byte-for-byte, exactly
 	// like @for. The not-taken arm emits no inner range (just `''`).
-	const thenInner = `ssrBlock(${thenSub.fnName}(undefined, __s))`;
-	const elseInner = node.alternate ? `ssrBlock(${elseCall})` : "''";
-	return `ssrBlock((${testExpr}) ? ${thenInner} : ${elseInner})`;
+	const thenInner = `_$ssrBlock(${thenSub.fnName}(undefined, __s))`;
+	const elseInner = node.alternate ? `_$ssrBlock(${elseCall})` : "''";
+	return `_$ssrBlock((${testExpr}) ? ${thenInner} : ${elseInner})`;
 }
 
 function ssrEmitFor(node, ctx, name, inlinedSubs, parentNs, cssHash) {
@@ -2115,11 +2150,11 @@ function ssrEmitFor(node, ctx, name, inlinedSubs, parentNs, cssHash) {
 	}
 	ctx.runtimeNeeded.add('ssrBlock');
 	const mapper = node.index
-		? `(__it, __i) => ssrBlock(${itemSub.fnName}(__it, __i, __s))`
-		: `(__it) => ssrBlock(${itemSub.fnName}(__it, __s))`;
+		? `(__it, __i) => _$ssrBlock(${itemSub.fnName}(__it, __i, __s))`
+		: `(__it) => _$ssrBlock(${itemSub.fnName}(__it, __s))`;
 	// Eager: render every item now and join. No keyed reconciliation server-side;
 	// each item gets its own block marker for a future hydrate to match.
-	return `ssrBlock((() => { const __items = Array.from((${itemsExpr}) ?? []); return __items.length === 0 ? ${emptyCall} : __items.map(${mapper}).join(''); })())`;
+	return `_$ssrBlock((() => { const __items = Array.from((${itemsExpr}) ?? []); return __items.length === 0 ? ${emptyCall} : __items.map(${mapper}).join(''); })())`;
 }
 
 function ssrEmitSwitch(node, ctx, name, inlinedSubs, parentNs, cssHash) {
@@ -2132,13 +2167,13 @@ function ssrEmitSwitch(node, ctx, name, inlinedSubs, parentNs, cssHash) {
 		inlinedSubs.push(sub.fn + ';');
 		// Inner ssrBlock wraps the matched case's content (see ssrEmitIf) so the
 		// client adopts it as the branch range during hydration (no inserted markers).
-		if (c.test == null) defaultCall = `ssrBlock(${sub.fnName}(undefined, __s))`;
-		else arms.push(`__d === (${printExpr(c.test)}) ? ssrBlock(${sub.fnName}(undefined, __s))`);
+		if (c.test == null) defaultCall = `_$ssrBlock(${sub.fnName}(undefined, __s))`;
+		else arms.push(`__d === (${printExpr(c.test)}) ? _$ssrBlock(${sub.fnName}(undefined, __s))`);
 	}
 	ctx.runtimeNeeded.add('ssrBlock');
 	// First case matching by strict-equality wins (no JS fall-through); else default.
 	const selector = arms.length ? `${arms.join(' : ')} : ${defaultCall}` : defaultCall;
-	return `ssrBlock((() => { const __d = (${discExpr}); return ${selector}; })())`;
+	return `_$ssrBlock((() => { const __d = (${discExpr}); return ${selector}; })())`;
 }
 
 function ssrEmitTry(node, ctx, name, inlinedSubs, parentNs, cssHash) {
@@ -2176,7 +2211,7 @@ function ssrEmitTry(node, ctx, name, inlinedSubs, parentNs, cssHash) {
 	// inline try/catch emit for buffered renders (hydration compatibility).
 	// `siteKey` is a stable source-position hash so a boundary keeps its identity
 	// across streaming passes (the runtime adds the frame path per instance).
-	return `ssrTry(__s, "${ssrTryKey(node)}", ${trySub.fnName}, ${pendFnName}, ${catchFnName})`;
+	return `_$ssrTry(__s, "${ssrTryKey(node)}", ${trySub.fnName}, ${pendFnName}, ${catchFnName})`;
 }
 
 // Deterministic per-boundary site key for ssrTry — same scheme as headKey:
@@ -2208,13 +2243,13 @@ function ssrEmitTsrxExpression(node, ctx, name, inlinedSubs, cssHash) {
 		expr.callee.name === 'createPortal'
 	) {
 		ctx.runtimeNeeded.add('ssrPortal');
-		return 'ssrPortal()';
+		return '_$ssrPortal()';
 	}
 	ctx.runtimeNeeded.add('ssrChild');
 	// rewriteHookCalls first (key any `use(thenable)` in the hole — it bypasses the
 	// setup rewrite), then rewriteJsxValues (lower nested JSX to createElement).
 	const lowered = rewriteJsxValues(rewriteHookCalls(expr, ctx, name), ctx);
-	return `ssrChild(${printExpr(resolveStyleExpr(lowered, cssHash))}, __s)`;
+	return `_$ssrChild(${printExpr(resolveStyleExpr(lowered, cssHash))}, __s)`;
 }
 
 // ===========================================================================
@@ -2308,7 +2343,7 @@ function wrapScopedClassExprs(node, ctx) {
 					) {
 						attr.value.expression = {
 							type: 'CallExpression',
-							callee: { type: 'Identifier', name: 'normalizeClass' },
+							callee: { type: 'Identifier', name: '_$normalizeClass' },
 							arguments: [expr],
 							optional: false,
 						};
@@ -2448,7 +2483,7 @@ function compileComponent(node, ctx, options) {
 	// function-name identity by NAMING the inner FunctionExpression — `hmr`
 	// returns a wrapper that delegates to whatever fn is currently committed,
 	// and `module.Foo[HMR].update(...)` swaps it on each accept.
-	const valueExpr = hmrWrap && isExported ? `hmr(${fn})` : fn;
+	const valueExpr = hmrWrap && isExported ? `_$hmr(${fn})` : fn;
 	if (isDefault) {
 		return `const ${name} = ${valueExpr};\nexport default ${name};`;
 	}
@@ -2638,8 +2673,15 @@ function rewriteHookCalls(node, ctx, componentName) {
 			const isCustom = /^use[A-Z]/.test(name) && name !== 'useContext';
 			const isServerUse = name === 'use' && ctx.mode === 'server';
 			if (isBuiltin || isCustom || isServerUse) {
-				if (isBuiltin) ctx.runtimeNeeded.add(name);
-				if (isServerUse) ctx.runtimeNeeded.add('use');
+				// A builtin hook call site is USER code (the user's own identifier), so
+				// its import stays bare — EXCEPT compiler-inserted calls (auto-callback's
+				// `useCallback`), whose callee is renamed to the `_$` alias below so a
+				// user binding of the same name can't shadow it.
+				if (isBuiltin) {
+					if (n.callee._octaneGenerated) ctx.runtimeNeeded.add(name);
+					else ctx.userRuntimeNames.add(name);
+				}
+				if (isServerUse) ctx.userRuntimeNames.add('use');
 				const debug = isServerUse
 					? `${componentName}.use#${ctx.nextHookSymId}`
 					: `${componentName}.${name}#${ctx.nextHookSymId}`;
@@ -2662,7 +2704,7 @@ function rewriteHookCalls(node, ctx, componentName) {
 					ctx.runtimeNeeded.add('withSlot');
 					return {
 						type: 'CallExpression',
-						callee: { type: 'Identifier', name: 'withSlot' },
+						callee: { type: 'Identifier', name: '_$withSlot' },
 						arguments: [
 							{ type: 'Identifier', name: symVar },
 							n.callee,
@@ -2674,6 +2716,9 @@ function rewriteHookCalls(node, ctx, componentName) {
 				}
 				return {
 					...n,
+					callee: n.callee._octaneGenerated
+						? { type: 'Identifier', name: rtAlias(name) }
+						: n.callee,
 					arguments: [...args, { type: 'Identifier', name: symVar }],
 				};
 			}
@@ -3082,7 +3127,7 @@ function lowerHostFragment(node, ctx, compInlinedSubs, parentNs = 'html', cssHas
 	ctx.runtimeNeeded.add('createElement');
 	return {
 		type: 'CallExpression',
-		callee: { type: 'Identifier', name: 'createElement' },
+		callee: { type: 'Identifier', name: '_$createElement' },
 		arguments: [
 			{ type: 'Identifier', name: fragName },
 			{ type: 'ObjectExpression', properties: holeProps },
@@ -3278,7 +3323,7 @@ function jsxElementToCreateElement(node, ctx) {
 	}
 	return {
 		type: 'CallExpression',
-		callee: { type: 'Identifier', name: 'createElement' },
+		callee: { type: 'Identifier', name: '_$createElement' },
 		arguments: args,
 		optional: false,
 	};
@@ -3427,7 +3472,7 @@ function emitHeadClient(headNodes, ctx, slotBase) {
 	// Each hoisted head element gets a dense scope slot (after the body's constructs);
 	// the content `key` stays as a later arg for SSR-adoption matching.
 	return headNodes
-		.map((h, i) => `  headBlock(__s, ${slotBase + i}, ${headElementArgs(h, i)});`)
+		.map((h, i) => `  _$headBlock(__s, ${slotBase + i}, ${headElementArgs(h, i)});`)
 		.join('\n');
 }
 
@@ -3437,7 +3482,7 @@ function emitHeadClient(headNodes, ctx, slotBase) {
 function emitHeadServer(headNodes, ctx) {
 	if (!headNodes.length) return '';
 	ctx.runtimeNeeded.add('ssrHeadEl');
-	return headNodes.map((h, i) => `  ssrHeadEl(${headElementArgs(h, i)});`).join('\n') + '\n';
+	return headNodes.map((h, i) => `  _$ssrHeadEl(${headElementArgs(h, i)});`).join('\n') + '\n';
 }
 
 /**
@@ -4085,7 +4130,7 @@ function planJsx(jsxNodesRaw, ctx, componentName, inlinedSubs, parentNs = 'html'
 			const lc = devLoc(ctx, jsxNodes[0]);
 			if (lc) cloneLoc = `, ${JSON.stringify(`${ctx.mapSourceName}:${lc[0]}:${lc[1]}`)}`;
 		}
-		mountLines.push(`    const _root = clone(${tpl}${cloneLoc});`);
+		mountLines.push(`    const _root = _$clone(${tpl}${cloneLoc});`);
 		elementVars = new Map();
 		let varCounter = 0;
 		// Does this template contain a control-flow / component / portal hole? If so
@@ -4140,7 +4185,7 @@ function planJsx(jsxNodesRaw, ctx, componentName, inlinedSubs, parentNs = 'html'
 				// raw `.nextSibling` for hole-free templates. sibVar already resolves to the
 				// (k−sibSteps)-th child, so n steps across lands on the k-th.
 				if (hasHoles) {
-					step = `sibling(${sibVar}, ${sibSteps})`;
+					step = `_$sibling(${sibVar}, ${sibSteps})`;
 				} else {
 					step = sibVar;
 					for (let i = 0; i < sibSteps; i++) step += '.nextSibling';
@@ -4429,7 +4474,7 @@ function planJsx(jsxNodesRaw, ctx, componentName, inlinedSubs, parentNs = 'html'
 		const anchorPart = hasAnchor ? `, ${anchorExpr}` : '';
 		pushAfter(
 			fc.id,
-			`  forBlock(__s, ${slotIndex}, ${hostExpr}, ${fc.itemsExpr}, ${fc.keyHelper}, ${fc.bodyHelper}${flagsPart}${depsPart}${emptyPart}${anchorPart});`,
+			`  _$forBlock(__s, ${slotIndex}, ${hostExpr}, ${fc.itemsExpr}, ${fc.keyHelper}, ${fc.bodyHelper}${flagsPart}${depsPart}${emptyPart}${anchorPart});`,
 		);
 	}
 	for (const ic of ifCalls) {
@@ -4442,7 +4487,7 @@ function planJsx(jsxNodesRaw, ctx, componentName, inlinedSubs, parentNs = 'html'
 			ctx.runtimeNeeded.add('activityBlock');
 			pushAfter(
 				ic.id,
-				`  activityBlock(__s, ${slotIndex}, ${hostExpr}, (${ic.modeExpr}), ${ic.thenHelper}${anchorArg});`,
+				`  _$activityBlock(__s, ${slotIndex}, ${hostExpr}, (${ic.modeExpr}), ${ic.thenHelper}${anchorArg});`,
 			);
 			continue;
 		}
@@ -4450,7 +4495,7 @@ function planJsx(jsxNodesRaw, ctx, componentName, inlinedSubs, parentNs = 'html'
 		const elseArg = ic.elseHelper || 'null';
 		pushAfter(
 			ic.id,
-			`  ifBlock(__s, ${slotIndex}, ${hostExpr}, (${ic.condExpr}), ${ic.thenHelper}, ${elseArg}${anchorArg});`,
+			`  _$ifBlock(__s, ${slotIndex}, ${hostExpr}, (${ic.condExpr}), ${ic.thenHelper}, ${elseArg}${anchorArg});`,
 		);
 	}
 	for (const cc of compCalls) {
@@ -4470,7 +4515,7 @@ function planJsx(jsxNodesRaw, ctx, componentName, inlinedSubs, parentNs = 'html'
 				ctx.runtimeNeeded.add('childTextHole');
 				pushAfter(
 					cc.id,
-					`  { const _v = (${cc.valueExpr}); if (_b._chp$${cc.id} !== _v) { _b._chp$${cc.id} = _v; const _t = _b._chv$${cc.id}; if (_t != null && typeof _v !== 'object' && typeof _v !== 'function') setText(_t, _v); else _b._chv$${cc.id} = childTextHole(__s, ${slotIndex}, ${hostExpr}, _v, _t); } }`,
+					`  { const _v = (${cc.valueExpr}); if (_b._chp$${cc.id} !== _v) { _b._chp$${cc.id} = _v; const _t = _b._chv$${cc.id}; if (_t != null && typeof _v !== 'object' && typeof _v !== 'function') _$setText(_t, _v); else _b._chv$${cc.id} = _$childTextHole(__s, ${slotIndex}, ${hostExpr}, _v, _t); } }`,
 				);
 				continue;
 			}
@@ -4484,7 +4529,7 @@ function planJsx(jsxNodesRaw, ctx, componentName, inlinedSubs, parentNs = 'html'
 				const anchorArg = anchorExpr === 'null' ? '' : `, ${anchorExpr}`;
 				pushAfter(
 					cc.id,
-					`  textSlot(__s, ${slotIndex}, ${hostExpr}, ${cc.valueExpr}${anchorArg});`,
+					`  _$textSlot(__s, ${slotIndex}, ${hostExpr}, ${cc.valueExpr}${anchorArg});`,
 				);
 				continue;
 			}
@@ -4501,7 +4546,7 @@ function planJsx(jsxNodesRaw, ctx, componentName, inlinedSubs, parentNs = 'html'
 			const ownEndArg = cc.anchorVar ? ', true' : '';
 			pushAfter(
 				cc.id,
-				`  { const _v = (${cc.valueExpr}); if (_b._chp$${cc.id} !== _v) { _b._chp$${cc.id} = _v; const _t = _b._chv$${cc.id}; if (_t != null && typeof _v !== 'object' && typeof _v !== 'function') setText(_t, _v); else _b._chv$${cc.id} = textHole(__s, ${slotIndex}, ${hostExpr}, _v, ${anchorExpr}${ownEndArg}); } }`,
+				`  { const _v = (${cc.valueExpr}); if (_b._chp$${cc.id} !== _v) { _b._chp$${cc.id} = _v; const _t = _b._chv$${cc.id}; if (_t != null && typeof _v !== 'object' && typeof _v !== 'function') _$setText(_t, _v); else _b._chv$${cc.id} = _$textHole(__s, ${slotIndex}, ${hostExpr}, _v, ${anchorExpr}${ownEndArg}); } }`,
 			);
 			continue;
 		}
@@ -4518,7 +4563,7 @@ function planJsx(jsxNodesRaw, ctx, componentName, inlinedSubs, parentNs = 'html'
 			const anchorArg = liteAnchor ? `, ${liteAnchor}` : '';
 			pushAfter(
 				cc.id,
-				`  componentSlotLite(__s, ${slotIndex}, ${hostExpr}, ${cc.compExpr}, ${cc.propsExpr}${anchorArg});`,
+				`  _$componentSlotLite(__s, ${slotIndex}, ${hostExpr}, ${cc.compExpr}, ${cc.propsExpr}${anchorArg});`,
 			);
 			continue;
 		}
@@ -4547,7 +4592,7 @@ function planJsx(jsxNodesRaw, ctx, componentName, inlinedSubs, parentNs = 'html'
 		}
 		pushAfter(
 			cc.id,
-			`  componentSlot(__s, ${slotIndex}, ${hostExpr}, ${cc.compExpr}, ${cc.propsExpr}${anchorArg}${keyArg}${singleRootArg});`,
+			`  _$componentSlot(__s, ${slotIndex}, ${hostExpr}, ${cc.compExpr}, ${cc.propsExpr}${anchorArg}${keyArg}${singleRootArg});`,
 		);
 	}
 	for (const pc of ctx._portalCalls) {
@@ -4556,7 +4601,7 @@ function planJsx(jsxNodesRaw, ctx, componentName, inlinedSubs, parentNs = 'html'
 		ctx.runtimeNeeded.add('portal');
 		pushAfter(
 			pc.id,
-			`  portal(__s, ${slotIndex}, ${pc.targetExpr}, ${pc.bodyExpr}, ${pc.propsExpr}, ${hostExpr});`,
+			`  _$portal(__s, ${slotIndex}, ${pc.targetExpr}, ${pc.bodyExpr}, ${pc.propsExpr}, ${hostExpr});`,
 		);
 	}
 	// Restore the outer plan's portal-call list — pairs with the save above.
@@ -4571,7 +4616,7 @@ function planJsx(jsxNodesRaw, ctx, componentName, inlinedSubs, parentNs = 'html'
 		const tryAnchorArg = tryAnchor ? `, ${tryAnchor}` : '';
 		pushAfter(
 			tc.id,
-			`  tryBlock(__s, ${slotIndex}, ${hostExpr}, ${tc.tryHelper}, ${tc.catchHelper}, ${tc.pendingHelper}${tryAnchorArg});`,
+			`  _$tryBlock(__s, ${slotIndex}, ${hostExpr}, ${tc.tryHelper}, ${tc.catchHelper}, ${tc.pendingHelper}${tryAnchorArg});`,
 		);
 	}
 	for (const sc of ctx._switchCalls) {
@@ -4584,7 +4629,7 @@ function planJsx(jsxNodesRaw, ctx, componentName, inlinedSubs, parentNs = 'html'
 		const anchorArg = switchAnchor ? `, ${switchAnchor}` : '';
 		pushAfter(
 			sc.id,
-			`  switchBlock(__s, ${slotIndex}, ${hostExpr}, (${sc.discExpr}), ${sc.casesArrayExpr}, ${sc.defaultHelper}${anchorArg});`,
+			`  _$switchBlock(__s, ${slotIndex}, ${hostExpr}, (${sc.discExpr}), ${sc.casesArrayExpr}, ${sc.defaultHelper}${anchorArg});`,
 		);
 	}
 	// Restore the outer plan's switch-call list — pairs with the save above.
@@ -4663,7 +4708,7 @@ function emitBindingMount(b, elVar) {
 			// hydration mismatch re-render).
 			return `    {
       const _v = ${E};
-      _b._txt$${b.id} = htext(${elVar}, _v);
+      _b._txt$${b.id} = _$htext(${elVar}, _v);
       _b._prev$${b.id} = _v;
     }`;
 		}
@@ -4686,14 +4731,14 @@ function emitBindingMount(b, elVar) {
 			// htextSwap coerces the value itself, so the mount is a bare call.
 			return `    {
       const _v = ${E};
-      _b._txt$${b.id} = htextSwap(${elVar}, _v);
+      _b._txt$${b.id} = _$htextSwap(${elVar}, _v);
       _b._prev$${b.id} = _v;
     }`;
 		}
 		case 'attr': {
 			return `    {
       const _v = ${E};
-      setAttribute(${elVar}, ${JSON.stringify(b.name)}, _v);
+      _$setAttribute(${elVar}, ${JSON.stringify(b.name)}, _v);
       _b._el$${b.id} = ${elVar};
       _b._prev$${b.id} = _v;
     }`;
@@ -4702,7 +4747,7 @@ function emitBindingMount(b, elVar) {
 			// On SVG/MathML hosts the `className` property is read-only — fall back
 			// to setAttribute. Compile-time choice, zero runtime branching.
 			const setter =
-				b.ns && b.ns !== 'html' ? `setClassAttr(${elVar}, _v)` : `setClassName(${elVar}, _v)`;
+				b.ns && b.ns !== 'html' ? `_$setClassAttr(${elVar}, _v)` : `_$setClassName(${elVar}, _v)`;
 			return `    {
       const _v = ${E};
       ${setter};
@@ -4713,7 +4758,7 @@ function emitBindingMount(b, elVar) {
 		case 'style': {
 			return `    {
       const _v = ${E};
-      setStyle(${elVar}, _v, undefined);
+      _$setStyle(${elVar}, _v, undefined);
       _b._el$${b.id} = ${elVar};
       _b._sty$${b.id} = _v;
     }`;
@@ -4728,10 +4773,10 @@ function emitBindingMount(b, elVar) {
 			// element's deferred attach — commit-phase detach batches the two).
 			return `    {
       const _v = ${E};
-      setSpread(${elVar}, _v, undefined, __s);
+      _$setSpread(${elVar}, _v, undefined, __s);
       _b._el$${b.id} = ${elVar};
       _b._sp$${b.id} = _v;
-      __s.cleanups.push(() => { const _sp = _b._sp$${b.id}; if (_sp != null && _sp.ref != null) queueRefDetach(_sp.ref, _b._el$${b.id}); });
+      __s.cleanups.push(() => { const _sp = _b._sp$${b.id}; if (_sp != null && _sp.ref != null) _$queueRefDetach(_sp.ref, _b._el$${b.id}); });
     }`;
 		}
 		case 'event': {
@@ -4744,7 +4789,7 @@ function emitBindingMount(b, elVar) {
 			// function identity on update.
 			return `    {
       const _v = ${E};
-      setFormAction(${elVar}, ${JSON.stringify(b.name)}, _v, undefined);
+      _$setFormAction(${elVar}, ${JSON.stringify(b.name)}, _v, undefined);
       _b._el$${b.id} = ${elVar};
       _b._prev$${b.id} = _v;
     }`;
@@ -4780,8 +4825,8 @@ function emitBindingMount(b, elVar) {
       const _r = (${b.expr});
       _b._ref$${b.id} = _r;
       _b._el$${b.id} = ${elVar};
-      queueRefAttach(__s, () => attachRef(_r, _b._el$${b.id}));
-      __s.cleanups.push(() => queueRefDetach(_b._ref$${b.id}, _b._el$${b.id}));
+      _$queueRefAttach(__s, () => _$attachRef(_r, _b._el$${b.id}));
+      __s.cleanups.push(() => _$queueRefDetach(_b._ref$${b.id}, _b._el$${b.id}));
     }`;
 		}
 		case 'fragmentRef': {
@@ -4793,7 +4838,7 @@ function emitBindingMount(b, elVar) {
 			// the ref + destroys the instance on unmount.
 			return `    {
       const _r = (${b.expr});
-      _b._fi$${b.id} = mountFragmentRef(__s, ${elVar}, ${b.endElVar}, _r);
+      _b._fi$${b.id} = _$mountFragmentRef(__s, ${elVar}, ${b.endElVar}, _r);
     }`;
 		}
 	}
@@ -4805,27 +4850,27 @@ function emitBindingUpdate(b) {
 	switch (b.kind) {
 		case 'textOnlyChild':
 		case 'text': {
-			return `    { const _v = ${E}; if (_b._prev$${b.id} !== _v) { setText(_b._txt$${b.id}, _v); _b._prev$${b.id} = _v; } }`;
+			return `    { const _v = ${E}; if (_b._prev$${b.id} !== _v) { _$setText(_b._txt$${b.id}, _v); _b._prev$${b.id} = _v; } }`;
 		}
 		case 'htmlOnlyChild': {
 			const coerce = b.knownString ? '_v' : 'String(_v)';
 			return `    { const _v = ${E}; if (_b._prev$${b.id} !== _v) { _b._el$${b.id}.innerHTML = (_v == null ? '' : ${coerce}); _b._prev$${b.id} = _v; } }`;
 		}
 		case 'attr': {
-			return `    { const _v = ${E}; if (_b._prev$${b.id} !== _v) { setAttribute(_b._el$${b.id}, ${JSON.stringify(b.name)}, _v); _b._prev$${b.id} = _v; } }`;
+			return `    { const _v = ${E}; if (_b._prev$${b.id} !== _v) { _$setAttribute(_b._el$${b.id}, ${JSON.stringify(b.name)}, _v); _b._prev$${b.id} = _v; } }`;
 		}
 		case 'class': {
 			const setter =
 				b.ns && b.ns !== 'html'
-					? `setClassAttr(_b._el$${b.id}, _v)`
-					: `setClassName(_b._el$${b.id}, _v)`;
+					? `_$setClassAttr(_b._el$${b.id}, _v)`
+					: `_$setClassName(_b._el$${b.id}, _v)`;
 			return `    { const _v = ${E}; if (_b._prev$${b.id} !== _v) { ${setter}; _b._prev$${b.id} = _v; } }`;
 		}
 		case 'style': {
 			// Object styles need per-prop diffing — call setStyle even when the
 			// reference is unchanged it'd just no-op via the internal diff. We DO
 			// skip identity matches to avoid the call overhead.
-			return `    { const _v = ${E}; if (_b._sty$${b.id} !== _v) { setStyle(_b._el$${b.id}, _v, _b._sty$${b.id}); _b._sty$${b.id} = _v; } }`;
+			return `    { const _v = ${E}; if (_b._sty$${b.id} !== _v) { _$setStyle(_b._el$${b.id}, _v, _b._sty$${b.id}); _b._sty$${b.id} = _v; } }`;
 		}
 		case 'spread': {
 			// setSpread does its own per-key diffing internally and handles cleanup
@@ -4834,13 +4879,13 @@ function emitBindingUpdate(b) {
 			// `__s` rides along on updates too so a spread-supplied ref's attach is
 			// deferred to commit (after all queued detaches) — same phasing as the
 			// direct `ref` binding above.
-			return `    { const _v = ${E}; if (_b._sp$${b.id} !== _v) { setSpread(_b._el$${b.id}, _v, _b._sp$${b.id}, __s); _b._sp$${b.id} = _v; } }`;
+			return `    { const _v = ${E}; if (_b._sp$${b.id} !== _v) { _$setSpread(_b._el$${b.id}, _v, _b._sp$${b.id}, __s); _b._sp$${b.id} = _v; } }`;
 		}
 		case 'event': {
 			return `    _b._el$${b.id}[${JSON.stringify(b.slotKey)}] = (${b.expr});`;
 		}
 		case 'formAction': {
-			return `    { const _v = ${E}; if (_b._prev$${b.id} !== _v) { setFormAction(_b._el$${b.id}, ${JSON.stringify(b.name)}, _v, _b._prev$${b.id}); _b._prev$${b.id} = _v; } }`;
+			return `    { const _v = ${E}; if (_b._prev$${b.id} !== _v) { _$setFormAction(_b._el$${b.id}, ${JSON.stringify(b.name)}, _v, _b._prev$${b.id}); _b._prev$${b.id} = _v; } }`;
 		}
 		case 'event-bundle': {
 			// Diff fn + each arg against the per-slot cache. Only rebuild + assign
@@ -4880,8 +4925,8 @@ function emitBindingUpdate(b) {
       const _r = (${b.expr});
       if (_r !== _b._ref$${b.id}) {
         const _old = _b._ref$${b.id};
-        if (_old != null) queueRefDetach(_old, _b._el$${b.id});
-        if (_r != null) queueRefAttach(__s, () => attachRef(_r, _b._el$${b.id}));
+        if (_old != null) _$queueRefDetach(_old, _b._el$${b.id});
+        if (_r != null) _$queueRefAttach(__s, () => _$attachRef(_r, _b._el$${b.id}));
         _b._ref$${b.id} = _r;
       }
     }`;
@@ -4897,8 +4942,8 @@ function emitBindingUpdate(b) {
       const _r = (${b.expr});
       const _fi = _b._fi$${b.id};
       if (_fi && _r !== _fi._currentRef) {
-        if (_fi._currentRef != null) queueRefDetach(_fi._currentRef, _fi);
-        if (_r != null) queueRefAttach(__s, () => attachRef(_r, _fi));
+        if (_fi._currentRef != null) _$queueRefDetach(_fi._currentRef, _fi);
+        if (_r != null) _$queueRefAttach(__s, () => _$attachRef(_r, _fi));
         _fi._currentRef = _r;
       }
     }`;
@@ -6527,8 +6572,8 @@ function walkExprH(rootVar, path) {
 	let expr = rootVar;
 	for (let i = 0; i < path.length; i++) {
 		const idx = path[i];
-		expr = `child(${expr})`;
-		if (idx > 0) expr = `sibling(${expr}, ${idx})`;
+		expr = `_$child(${expr})`;
+		if (idx > 0) expr = `_$sibling(${expr}, ${idx})`;
 	}
 	return expr;
 }

--- a/packages/octane/tests/_fixtures/helper-shadowing.tsrx
+++ b/packages/octane/tests/_fixtures/helper-shadowing.tsrx
@@ -1,0 +1,91 @@
+// Regression fixtures for compiler-helper shadowing: every component (or the
+// module scope) declares a user binding named after a runtime helper the
+// compiled output calls. Generated code references helpers via collision-proof
+// `_$` aliases (`import { setText as _$setText } from 'octane'`), so these
+// bindings must never hijack it. `const [text, setText] = useState('')` is the
+// canonical collision — React's most common naming for text state.
+import { useState } from 'octane';
+
+// Module-scope collisions: with bare helper imports these were duplicate-
+// declaration SyntaxErrors against the prelude's `import { template, clone,
+// delegateEvents }` (this module needs all three).
+function template(s: string): string {
+	return s + '!';
+}
+const clone = (s: string) => s + s;
+const delegateEvents = 'not-the-runtime';
+
+export function ShadowSetText() @{
+	const [text, setText] = useState('');
+	<div>
+		<button id="st-btn" onClick={() => setText('xyz')}>{'go'}</button>
+		<span id="st-label">
+			{text as string}
+		</span>
+	</div>
+}
+
+// `htext` shadows the mount-path text helper (create+append the text node).
+export function ShadowHtext(props: { value: string }) @{
+	const htext = props.value;
+	<span id="ht-label">
+		{htext as string}
+	</span>
+}
+
+// Locals named after the attr/style/class/walk helpers used by this template.
+export function ShadowUpdateHelpers() @{
+	const [n, bump] = useState(0);
+	const setAttribute = 'data-' + n;
+	const setStyle =
+		n > 0 ? 'red' : 'blue';
+	const setClassName = 'c' + n;
+	const normalizeClass = 'n' + n;
+	const child = 'kid-' + n;
+	const sibling = 'sib-' + n;
+	<div>
+		<button id="u-btn" onClick={() => bump(n + 1)}>{'go'}</button>
+		<span id="u-attr" title={setAttribute}>
+			{child as string}
+			{' '}
+			{sibling as string}
+		</span>
+		<i id="u-style" style={{ color: setStyle }} class={setClassName}>{'x'}</i>
+		<b id="u-class" class={[normalizeClass]}>{'y'}</b>
+	</div>
+}
+
+function Row(props: { label: string }) @{
+	<li>
+		{props.label as string}
+	</li>
+}
+
+// Locals named after the control-flow / component-slot helpers.
+export function ShadowBlocks() @{
+	const [on, setOn] = useState(true);
+	const ifBlock = 'yes';
+	const forBlock = [{ id: 'a' }, { id: 'b' }];
+	const componentSlot = '-row';
+	<div>
+		<button id="b-btn" onClick={() => setOn(!on)}>{'t'}</button>
+		@if (on) {
+			<em id="b-if">
+				{ifBlock as string}
+			</em>
+		}
+		<ul id="b-list">
+			@for (const x of forBlock; key x.id) {
+				<Row label={x.id + componentSlot} />
+			}
+		</ul>
+	</div>
+}
+
+export function ShadowModuleScope() @{
+	<p id="m-label">
+		{template(clone('ab')) as string}
+		{' '}
+		{delegateEvents as string}
+	</p>
+}

--- a/packages/octane/tests/auto-callback.test.ts
+++ b/packages/octane/tests/auto-callback.test.ts
@@ -12,6 +12,10 @@ import { compile } from 'octane/compiler';
 //
 // Audited path: rewriteAutoCallback in compile.js (around lines 174-279)
 // plus the source-order walk in compileComponent (~lines 816-820).
+//
+// The compiler-inserted callee is the shadow-proof alias `_$useCallback`
+// (imported as `useCallback as _$useCallback`) so a user binding named
+// `useCallback` can't hijack the generated wrap.
 
 const c = (src: string): string => compile(src, 'auto-cb.tsrx').code;
 
@@ -27,8 +31,8 @@ describe('auto-callback transform — stable-closure arrows wrap in useCallback'
         <button onClick={reset}>{count as string}</button>
       }
     `);
-		expect(code).toMatch(/const\s+reset\s*=\s*useCallback\s*\(/);
-		expect(code).toMatch(/useCallback\s*\([\s\S]*?,\s*\[\s*setCount\s*\]/);
+		expect(code).toMatch(/const\s+reset\s*=\s*_\$useCallback\s*\(/);
+		expect(code).toMatch(/_\$useCallback\s*\([\s\S]*?,\s*\[\s*setCount\s*\]/);
 		expect(code).toMatch(/import\s*\{[^}]*useCallback[^}]*\}\s*from\s*['"]octane['"]/);
 	});
 
@@ -40,7 +44,7 @@ describe('auto-callback transform — stable-closure arrows wrap in useCallback'
       }
     `);
 		expect(code).toMatch(/const\s+greet\s*=\s*\(/);
-		expect(code).not.toMatch(/const\s+greet\s*=\s*useCallback/);
+		expect(code).not.toMatch(/const\s+greet\s*=\s*(_\$)?useCallback/);
 	});
 
 	it('transitive stability: arrow b calling stable arrow a is also wrapped', () => {
@@ -53,8 +57,8 @@ describe('auto-callback transform — stable-closure arrows wrap in useCallback'
         <button onClick={b}>{'go'}</button>
       }
     `);
-		expect(code).toMatch(/const\s+a\s*=\s*useCallback\([\s\S]*?,\s*\[\s*setX\s*\]/);
-		expect(code).toMatch(/const\s+b\s*=\s*useCallback\([\s\S]*?,\s*\[\s*a\s*\]/);
+		expect(code).toMatch(/const\s+a\s*=\s*_\$useCallback\([\s\S]*?,\s*\[\s*setX\s*\]/);
+		expect(code).toMatch(/const\s+b\s*=\s*_\$useCallback\([\s\S]*?,\s*\[\s*a\s*\]/);
 	});
 
 	it('useRef return is stable; .current accesses do NOT add deps', () => {
@@ -66,7 +70,7 @@ describe('auto-callback transform — stable-closure arrows wrap in useCallback'
         <input ref={r} onClick={focus} />
       }
     `);
-		expect(code).toMatch(/const\s+focus\s*=\s*useCallback\([\s\S]*?,\s*\[\s*r\s*\]/);
+		expect(code).toMatch(/const\s+focus\s*=\s*_\$useCallback\([\s\S]*?,\s*\[\s*r\s*\]/);
 	});
 
 	it('idempotency: user-authored useCallback is not re-wrapped', () => {
@@ -78,7 +82,7 @@ describe('auto-callback transform — stable-closure arrows wrap in useCallback'
         <button onClick={cb}>{'go'}</button>
       }
     `);
-		expect(code).not.toMatch(/useCallback\s*\(\s*useCallback/);
+		expect(code).not.toMatch(/(_\$)?useCallback\s*\(\s*useCallback/);
 	});
 
 	it('useState VALUE (first tuple element) is NOT stable; closure over it bails', () => {
@@ -90,7 +94,7 @@ describe('auto-callback transform — stable-closure arrows wrap in useCallback'
         <button onClick={read}>{count as string}</button>
       }
     `);
-		expect(code).not.toMatch(/const\s+read\s*=\s*useCallback/);
+		expect(code).not.toMatch(/const\s+read\s*=\s*(_\$)?useCallback/);
 	});
 
 	it('destructured useRef return is NOT stable (only Identifier-bound stays)', () => {
@@ -102,7 +106,7 @@ describe('auto-callback transform — stable-closure arrows wrap in useCallback'
         <button onClick={fn}>{'x'}</button>
       }
     `);
-		expect(code).not.toMatch(/const\s+fn\s*=\s*useCallback/);
+		expect(code).not.toMatch(/const\s+fn\s*=\s*(_\$)?useCallback/);
 	});
 
 	it("module-level identifier doesn't block rewrite and is not added to deps", () => {
@@ -115,7 +119,7 @@ describe('auto-callback transform — stable-closure arrows wrap in useCallback'
         <button onClick={fn}>{'z'}</button>
       }
     `);
-		expect(code).toMatch(/const\s+fn\s*=\s*useCallback\([\s\S]*?,\s*\[\s*setX\s*\]/);
+		expect(code).toMatch(/const\s+fn\s*=\s*_\$useCallback\([\s\S]*?,\s*\[\s*setX\s*\]/);
 		expect(code).not.toMatch(/\[\s*setX\s*,\s*ZERO\s*\]/);
 	});
 
@@ -133,7 +137,7 @@ describe('auto-callback transform — stable-closure arrows wrap in useCallback'
     `);
 		// The for-body inline arrow may be optimized as an event-bundle but should
 		// NOT be hoisted into a useCallback at component-body scope.
-		expect(code).not.toMatch(/const\s+click\s*=\s*useCallback/);
+		expect(code).not.toMatch(/const\s+click\s*=\s*(_\$)?useCallback/);
 	});
 
 	it('mixed stable + unstable closure (prop reference inside arrow) bails', () => {
@@ -145,6 +149,6 @@ describe('auto-callback transform — stable-closure arrows wrap in useCallback'
         <button onClick={fn}>{'x'}</button>
       }
     `);
-		expect(code).not.toMatch(/const\s+fn\s*=\s*useCallback/);
+		expect(code).not.toMatch(/const\s+fn\s*=\s*(_\$)?useCallback/);
 	});
 });

--- a/packages/octane/tests/clsx-class.test.ts
+++ b/packages/octane/tests/clsx-class.test.ts
@@ -150,7 +150,7 @@ function evalModule(mode: 'server' | 'client', rt: unknown): Record<string, any>
 	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'clsx-class.tsrx', { mode });
 	code = code.replace(
 		new RegExp(`import\\s*\\{([^}]*)\\}\\s*from\\s*['"]${src}['"];?`, 'g'),
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');

--- a/packages/octane/tests/conformance/_fixtures/hooks-arity.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/hooks-arity.tsrx
@@ -34,10 +34,9 @@ export function StableRefAcrossRenderPhase(props) @{
 
 // Per ReactDOMHooks-test.js:157 — a state update scheduled from within an
 // event handler must not be (eagerly) bailed out: the label re-renders with
-// the input's text. (Named inputText/setInputText rather than React's
-// text/setText: a user binding called `setText` currently shadows the
-// compiler-emitted runtime helper of the same name — real bug, tracked
-// separately — and this test targets the event-update heuristic, not that.)
+// the input's text. (Naming the binding `setText` is safe nowadays — the
+// compiler imports its helpers under `_$` aliases; helper-shadowing.test.ts
+// pins that — this fixture just predates the fix.)
 export function InputEventUpdate(props) @{
 	const [inputText, setInputText] = useState('');
 	<div>

--- a/packages/octane/tests/conformance/css-properties.test.ts
+++ b/packages/octane/tests/conformance/css-properties.test.ts
@@ -45,7 +45,7 @@ function evalServerModule(): Record<string, any> {
 	});
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');

--- a/packages/octane/tests/conformance/dom-component-ssr.test.ts
+++ b/packages/octane/tests/conformance/dom-component-ssr.test.ts
@@ -14,7 +14,7 @@ function evalServer(source: string, file: string): Record<string, any> {
 	let { code } = compile(source, file, { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');

--- a/packages/octane/tests/conformance/event-listener.test.ts
+++ b/packages/octane/tests/conformance/event-listener.test.ts
@@ -540,7 +540,7 @@ describe('ReactDOMEventListener — scroll (not emulated upward)', () => {
 			let { code } = compile(readFileSync(FIX, 'utf8'), FILE, { mode: 'server' });
 			code = code.replace(
 				/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-				'const {$1} = __rt;',
+				(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 			);
 			code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 			code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');
@@ -548,7 +548,10 @@ describe('ReactDOMEventListener — scroll (not emulated upward)', () => {
 		};
 		const clientModule = (): Record<string, any> => {
 			let { code } = compile(readFileSync(FIX, 'utf8'), FILE, { mode: 'client' });
-			code = code.replace(/import\s*\{([^}]*)\}\s*from\s*['"]octane['"];?/g, 'const {$1} = __rt;');
+			code = code.replace(
+				/import\s*\{([^}]*)\}\s*from\s*['"]octane['"];?/g,
+				(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
+			);
 			code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 			code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');
 			return new Function('__rt', '__exports', code + '\nreturn __exports;')(ClientRT, {});

--- a/packages/octane/tests/conformance/hydration-mismatch.test.ts
+++ b/packages/octane/tests/conformance/hydration-mismatch.test.ts
@@ -36,7 +36,7 @@ function serverModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIX, 'utf8'), FILE, { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');
@@ -44,7 +44,10 @@ function serverModule(): Record<string, any> {
 }
 function devClientModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIX, 'utf8'), FILE, { mode: 'client', dev: true });
-	code = code.replace(/import\s*\{([^}]*)\}\s*from\s*['"]octane['"];?/g, 'const {$1} = __rt;');
+	code = code.replace(
+		/import\s*\{([^}]*)\}\s*from\s*['"]octane['"];?/g,
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
+	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');
 	return new Function('__rt', '__exports', code + '\nreturn __exports;')(ClientRT, {});

--- a/packages/octane/tests/conformance/ssr-serialization.test.ts
+++ b/packages/octane/tests/conformance/ssr-serialization.test.ts
@@ -161,7 +161,7 @@ function evalMod(rt: any, opts: any): Record<string, any> {
 	let { code } = compile(SRC, FILE, opts);
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane(?:\/server)?['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');

--- a/packages/octane/tests/conformance/ssr-server-semantics.test.ts
+++ b/packages/octane/tests/conformance/ssr-server-semantics.test.ts
@@ -145,7 +145,7 @@ function evalMod(rt: any, opts: any): Record<string, any> {
 	let { code } = compile(SRC, FILE, opts);
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane(?:\/server)?['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');

--- a/packages/octane/tests/conformance/useid-determinism.test.ts
+++ b/packages/octane/tests/conformance/useid-determinism.test.ts
@@ -27,7 +27,7 @@ function evalServer(source: string, file: string): Record<string, any> {
 	let { code } = compile(source, file, { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export default (\w+);?/g, '__exports.default = $1;');

--- a/packages/octane/tests/conformance/user-input-hydration.test.ts
+++ b/packages/octane/tests/conformance/user-input-hydration.test.ts
@@ -27,7 +27,7 @@ function serverModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIX, 'utf8'), FILE, { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');
@@ -35,7 +35,10 @@ function serverModule(): Record<string, any> {
 }
 function devClientModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIX, 'utf8'), FILE, { mode: 'client', dev: true });
-	code = code.replace(/import\s*\{([^}]*)\}\s*from\s*['"]octane['"];?/g, 'const {$1} = __rt;');
+	code = code.replace(
+		/import\s*\{([^}]*)\}\s*from\s*['"]octane['"];?/g,
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
+	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');
 	return new Function('__rt', '__exports', code + '\nreturn __exports;')(ClientRT, {});

--- a/packages/octane/tests/control-fold.test.ts
+++ b/packages/octane/tests/control-fold.test.ts
@@ -14,7 +14,7 @@ function serverModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'control-fold.tsrx', { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export function (\w+)/g, 'const $1 = __exports.$1 = function $1');

--- a/packages/octane/tests/for-fold.test.ts
+++ b/packages/octane/tests/for-fold.test.ts
@@ -12,7 +12,7 @@ function serverModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'for-fold.tsrx', { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export function (\w+)/g, 'const $1 = __exports.$1 = function $1');

--- a/packages/octane/tests/helper-shadowing.test.ts
+++ b/packages/octane/tests/helper-shadowing.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { compile } from 'octane/compiler';
+import { mount } from './_helpers';
+import {
+	ShadowSetText,
+	ShadowHtext,
+	ShadowUpdateHelpers,
+	ShadowBlocks,
+	ShadowModuleScope,
+} from './_fixtures/helper-shadowing.tsrx';
+
+// User bindings named after compiler-emitted runtime helpers (setText, htext,
+// clone, template, setAttribute, …) must not shadow generated code. The
+// compiler imports every generated-code helper under a `_$` alias
+// (`import { setText as _$setText } from 'octane'`), so the user's binding and
+// the helper coexist. `const [text, setText] = useState('')` is the canonical
+// collision — pre-fix, the click below left the span empty AND stored a DOM
+// Text node in state (the generated `setText(_b._txt$…, _v)` resolved to the
+// user's state setter).
+
+describe('helper shadowing — user bindings named after runtime helpers', () => {
+	it('state setter named setText: DOM text updates and state stays a string', () => {
+		const r = mount(ShadowSetText);
+		expect(r.find('#st-label').textContent).toBe('');
+		r.click('#st-btn');
+		expect(r.find('#st-label').textContent).toBe('xyz');
+		// A second click must be a no-op re-render (same string), not a loop of
+		// Text-node states.
+		r.click('#st-btn');
+		expect(r.find('#st-label').textContent).toBe('xyz');
+		r.unmount();
+	});
+
+	it('local named htext: mount-path text helper still runs', () => {
+		const r = mount(ShadowHtext, { value: 'hello' });
+		expect(r.find('#ht-label').textContent).toBe('hello');
+		r.update(ShadowHtext, { value: 'world' });
+		expect(r.find('#ht-label').textContent).toBe('world');
+		r.unmount();
+	});
+
+	it('locals named setAttribute/setStyle/setClassName/normalizeClass/child/sibling', () => {
+		const r = mount(ShadowUpdateHelpers);
+		expect(r.find('#u-attr').getAttribute('title')).toBe('data-0');
+		expect(r.find('#u-attr').textContent).toBe('kid-0 sib-0');
+		expect((r.find('#u-style') as HTMLElement).style.color).toBe('blue');
+		expect(r.find('#u-style').className).toBe('c0');
+		expect(r.find('#u-class').className).toBe('n0');
+		r.click('#u-btn');
+		expect(r.find('#u-attr').getAttribute('title')).toBe('data-1');
+		expect(r.find('#u-attr').textContent).toBe('kid-1 sib-1');
+		expect((r.find('#u-style') as HTMLElement).style.color).toBe('red');
+		expect(r.find('#u-style').className).toBe('c1');
+		expect(r.find('#u-class').className).toBe('n1');
+		r.unmount();
+	});
+
+	it('locals named ifBlock/forBlock/componentSlot: control flow still works', () => {
+		const r = mount(ShadowBlocks);
+		expect(r.find('#b-if').textContent).toBe('yes');
+		expect(r.findAll('#b-list li').map((li) => li.textContent)).toEqual(['a-row', 'b-row']);
+		r.click('#b-btn');
+		expect(r.container.querySelector('#b-if')).toBe(null);
+		r.click('#b-btn');
+		expect(r.find('#b-if').textContent).toBe('yes');
+		r.unmount();
+	});
+
+	it('module-level template/clone/delegateEvents bindings coexist with the prelude', () => {
+		// Pre-fix this was a duplicate-declaration SyntaxError at module load
+		// (user `function template` vs the prelude's bare `import { template }`).
+		const r = mount(ShadowModuleScope);
+		expect(r.find('#m-label').textContent).toBe('abab! not-the-runtime');
+		r.unmount();
+	});
+
+	it('emits helpers aliased and preserves user import specifiers verbatim', () => {
+		const src = `
+      import { useState, flushSync as fs } from 'octane';
+      export function T() @{
+        const [text, setText] = useState('');
+        <button onClick={() => fs(() => setText('x'))}>{text as string}</button>
+      }
+    `;
+		const { code } = compile(src, 'shadow-emit.tsrx');
+		// Generated references use the alias…
+		expect(code).toMatch(/import\s*\{[^}]*setText as _\$setText[^}]*\}\s*from\s*['"]octane['"]/);
+		expect(code).toMatch(/_\$setText\(_b\._txt\$\d+, _v\)/);
+		// …while the user's names (including their rename) stay bare.
+		expect(code).toMatch(/import\s*\{[^}]*flushSync as fs[^}]*\}/);
+		expect(code).toMatch(/import\s*\{[^}]*\buseState\b[^}]*\}/);
+		// The generated text-update call must NOT be the bare (shadowable) name.
+		expect(code).not.toMatch(/[^$\w.]setText\(_b\._txt/);
+
+		const server = compile(src, 'shadow-emit.tsrx', { mode: 'server' }).code;
+		expect(server).toMatch(
+			/import\s*\{[^}]*ssrText as _\$ssrText[^}]*\}\s*from\s*['"]octane\/server['"]/,
+		);
+		expect(server).toMatch(/_\$ssrText\(text\)/);
+	});
+});

--- a/packages/octane/tests/hmr.test.ts
+++ b/packages/octane/tests/hmr.test.ts
@@ -147,11 +147,11 @@ describe('hmr — runtime wrapper', () => {
 		const { code } = compile(src, 'file.tsrx', { hmr: true });
 		// Stable Symbol.for-based hook slot (so re-imports get the same identity).
 		expect(code).toMatch(/Symbol\.for\("octane:file\.tsrx:Foo\.useState#0"\)/);
-		// Inline HMR wrapping on the exported component.
-		expect(code).toMatch(/export const Foo = hmr\(function Foo/);
+		// Inline HMR wrapping on the exported component (shadow-proof `_$` alias).
+		expect(code).toMatch(/export const Foo = _\$hmr\(function Foo/);
 		// Vite-shaped accept block.
 		expect(code).toMatch(/if \(import\.meta\.hot\)/);
-		expect(code).toMatch(/Foo\[HMR\]\.update\(module\.Foo\)/);
+		expect(code).toMatch(/Foo\[_\$HMR\]\.update\(module\.Foo\)/);
 	});
 
 	it('hmr option off → no wrapping, no accept block', async () => {

--- a/packages/octane/tests/hydration/control-hydrate.test.ts
+++ b/packages/octane/tests/hydration/control-hydrate.test.ts
@@ -16,7 +16,7 @@ function serverModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'control.tsrx', { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	const fn = new Function('__rt', '__exports', code + '\nreturn __exports;');

--- a/packages/octane/tests/hydration/emptyfor-hydrate.test.ts
+++ b/packages/octane/tests/hydration/emptyfor-hydrate.test.ts
@@ -17,7 +17,7 @@ function serverModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'emptyfor.tsrx', { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	const fn = new Function('__rt', '__exports', code + '\nreturn __exports;');

--- a/packages/octane/tests/hydration/for-hydrate.test.ts
+++ b/packages/octane/tests/hydration/for-hydrate.test.ts
@@ -16,7 +16,7 @@ function serverModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'forlist.tsrx', { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	const fn = new Function('__rt', '__exports', code + '\nreturn __exports;');

--- a/packages/octane/tests/hydration/head-hydrate.test.ts
+++ b/packages/octane/tests/hydration/head-hydrate.test.ts
@@ -24,7 +24,7 @@ function serverModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIXTURE, 'utf8'), FIXTURE, { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	return new Function('__rt', '__exports', code + '\nreturn __exports;')(ServerRT, {});

--- a/packages/octane/tests/hydration/hydration.test.ts
+++ b/packages/octane/tests/hydration/hydration.test.ts
@@ -21,7 +21,7 @@ function serverModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'leaf.tsrx', { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	const fn = new Function('__rt', '__exports', code + '\nreturn __exports;');

--- a/packages/octane/tests/hydration/lite-hydrate.test.ts
+++ b/packages/octane/tests/hydration/lite-hydrate.test.ts
@@ -15,7 +15,7 @@ function serverModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'lite.tsrx', { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	const fn = new Function('__rt', '__exports', code + '\nreturn __exports;');

--- a/packages/octane/tests/hydration/map-hydrate.test.ts
+++ b/packages/octane/tests/hydration/map-hydrate.test.ts
@@ -18,7 +18,7 @@ function serverModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'map-list.tsx', { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');

--- a/packages/octane/tests/hydration/markerless-text-hydrate.test.ts
+++ b/packages/octane/tests/hydration/markerless-text-hydrate.test.ts
@@ -20,7 +20,7 @@ function serverModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'markerless-text.tsx', { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');

--- a/packages/octane/tests/hydration/mismatch-structural.test.ts
+++ b/packages/octane/tests/hydration/mismatch-structural.test.ts
@@ -26,7 +26,7 @@ function serverModule(fixture: string, file: string): Record<string, any> {
 	let { code } = compile(readFileSync(fixture, 'utf8'), file, { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');
@@ -35,7 +35,10 @@ function serverModule(fixture: string, file: string): Record<string, any> {
 
 function devClientModule(fixture: string, file: string): Record<string, any> {
 	let { code } = compile(readFileSync(fixture, 'utf8'), file, { mode: 'client', dev: true });
-	code = code.replace(/import\s*\{([^}]*)\}\s*from\s*['"]octane['"];?/g, 'const {$1} = __rt;');
+	code = code.replace(
+		/import\s*\{([^}]*)\}\s*from\s*['"]octane['"];?/g,
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
+	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');
 	return new Function('__rt', '__exports', code + '\nreturn __exports;')(ClientRT, {});
@@ -46,7 +49,10 @@ function devClientModule(fixture: string, file: string): Record<string, any> {
 // the warning is dev-gated.
 function prodClientModule(fixture: string, file: string): Record<string, any> {
 	let { code } = compile(readFileSync(fixture, 'utf8'), file, { mode: 'client' });
-	code = code.replace(/import\s*\{([^}]*)\}\s*from\s*['"]octane['"];?/g, 'const {$1} = __rt;');
+	code = code.replace(
+		/import\s*\{([^}]*)\}\s*from\s*['"]octane['"];?/g,
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
+	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');
 	return new Function('__rt', '__exports', code + '\nreturn __exports;')(ClientRT, {});

--- a/packages/octane/tests/hydration/mismatch-value.test.ts
+++ b/packages/octane/tests/hydration/mismatch-value.test.ts
@@ -23,7 +23,7 @@ function serverModule(fixture: string, file: string): Record<string, any> {
 	let { code } = compile(readFileSync(fixture, 'utf8'), file, { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');
@@ -34,7 +34,10 @@ function serverModule(fixture: string, file: string): Record<string, any> {
 // component's htext/setAttribute see the SAME `hydrating` flag that hydrateRoot sets).
 function devClientModule(fixture: string, file: string): Record<string, any> {
 	let { code } = compile(readFileSync(fixture, 'utf8'), file, { mode: 'client', dev: true });
-	code = code.replace(/import\s*\{([^}]*)\}\s*from\s*['"]octane['"];?/g, 'const {$1} = __rt;');
+	code = code.replace(
+		/import\s*\{([^}]*)\}\s*from\s*['"]octane['"];?/g,
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
+	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');
 	return new Function('__rt', '__exports', code + '\nreturn __exports;')(ClientRT, {});

--- a/packages/octane/tests/hydration/mixed-frag-hydrate.test.ts
+++ b/packages/octane/tests/hydration/mixed-frag-hydrate.test.ts
@@ -19,7 +19,7 @@ function serverModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'mixed-frag.tsrx', { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	const fn = new Function('__rt', '__exports', code + '\nreturn __exports;');

--- a/packages/octane/tests/hydration/nested-hydrate.test.ts
+++ b/packages/octane/tests/hydration/nested-hydrate.test.ts
@@ -17,7 +17,7 @@ function serverModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'nested.tsrx', { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	const fn = new Function('__rt', '__exports', code + '\nreturn __exports;');

--- a/packages/octane/tests/hydration/provider-ssr-hydrate.test.ts
+++ b/packages/octane/tests/hydration/provider-ssr-hydrate.test.ts
@@ -20,7 +20,7 @@ function serverModule(file: string): Record<string, any> {
 	});
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');

--- a/packages/octane/tests/hydration/renderable-hydrate.test.ts
+++ b/packages/octane/tests/hydration/renderable-hydrate.test.ts
@@ -25,7 +25,7 @@ function serverModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'renderable.tsrx', { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	const fn = new Function('__rt', '__exports', code + '\nreturn __exports;');

--- a/packages/octane/tests/hydration/server-withslot.test.ts
+++ b/packages/octane/tests/hydration/server-withslot.test.ts
@@ -25,7 +25,8 @@ function serverModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'server-withslot.tsrx', { mode: 'server' });
 	// Capture the import name list so we can assert every name resolves on ServerRT.
 	const importLine = code.match(/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/);
-	const names = importLine![1].split(',').map((s) => s.trim());
+	// Specifiers may be aliased (`ssrText as _$ssrText`) — the EXPORT is the left name.
+	const names = importLine![1].split(',').map((s) => s.trim().split(' as ')[0]);
 	for (const n of names) {
 		if ((ServerRT as any)[n] === undefined) {
 			throw new Error(`octane/server is missing the compiler-emitted import: ${n}`);
@@ -33,7 +34,7 @@ function serverModule(): Record<string, any> {
 	}
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	const fn = new Function('__rt', '__exports', code + '\nreturn __exports;');

--- a/packages/octane/tests/hydration/suspense-hydrate.test.ts
+++ b/packages/octane/tests/hydration/suspense-hydrate.test.ts
@@ -19,7 +19,7 @@ function serverModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'ssr-suspense.tsrx', { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	const fn = new Function('__rt', '__exports', code + '\nreturn __exports;');

--- a/packages/octane/tests/hydration/text-sibling-hydrate.test.ts
+++ b/packages/octane/tests/hydration/text-sibling-hydrate.test.ts
@@ -18,7 +18,7 @@ function serverModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'text-sibling.tsrx', { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	return new Function('__rt', '__exports', code + '\nreturn __exports;')(ServerRT, {});

--- a/packages/octane/tests/hydration/try-hydrate.test.ts
+++ b/packages/octane/tests/hydration/try-hydrate.test.ts
@@ -17,7 +17,7 @@ function serverModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'tryboundary.tsrx', { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	const fn = new Function('__rt', '__exports', code + '\nreturn __exports;');

--- a/packages/octane/tests/hydration/trycomponent-hydrate.test.ts
+++ b/packages/octane/tests/hydration/trycomponent-hydrate.test.ts
@@ -19,7 +19,7 @@ function serverModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'trycomponent.tsrx', { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	const fn = new Function('__rt', '__exports', code + '\nreturn __exports;');

--- a/packages/octane/tests/hydration/tryif-spread-hydrate.test.ts
+++ b/packages/octane/tests/hydration/tryif-spread-hydrate.test.ts
@@ -19,7 +19,7 @@ function serverModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'tryif-spread.tsrx', { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');

--- a/packages/octane/tests/hydration/value-jsx-hydrate.test.ts
+++ b/packages/octane/tests/hydration/value-jsx-hydrate.test.ts
@@ -16,7 +16,7 @@ function serverModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'value-jsx.tsrx', { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	const fn = new Function('__rt', '__exports', code + '\nreturn __exports;');

--- a/packages/octane/tests/jsx-context-children-ssr.test.ts
+++ b/packages/octane/tests/jsx-context-children-ssr.test.ts
@@ -16,7 +16,7 @@ function evalServer(source: string, file: string): Record<string, any> {
 	let { code } = compile(source, file, { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');

--- a/packages/octane/tests/known-string-holes.test.ts
+++ b/packages/octane/tests/known-string-holes.test.ts
@@ -137,7 +137,7 @@ function serverModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'known-string.tsrx', { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	const fn = new Function('__rt', '__exports', code + '\nreturn __exports;');

--- a/packages/octane/tests/lazy.test.ts
+++ b/packages/octane/tests/lazy.test.ts
@@ -137,7 +137,7 @@ function evalServer(source: string, file: string): Record<string, any> {
 	let { code } = compile(source, file, { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');

--- a/packages/octane/tests/non-jsx-return.test.ts
+++ b/packages/octane/tests/non-jsx-return.test.ts
@@ -12,7 +12,7 @@ function serverModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'non-jsx-return.tsrx', { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	const fn = new Function('__rt', '__exports', code + '\nreturn __exports;');

--- a/packages/octane/tests/render-prop.test.ts
+++ b/packages/octane/tests/render-prop.test.ts
@@ -35,6 +35,6 @@ describe('render-prop children (bare-JSX arrow)', () => {
 			'export function App() @{ <Provide>{(v) => (<span class="rendered">{v as string}</span>)}</Provide> }';
 		const { code } = compile(src, 'rp-paren.tsrx', { mode: 'client' });
 		expect(code).not.toMatch(/<span/); // no raw (unlowered) JSX leaked
-		expect(code).toContain('(v) => createElement');
+		expect(code).toContain('(v) => _$createElement');
 	});
 });

--- a/packages/octane/tests/ssr-control.test.ts
+++ b/packages/octane/tests/ssr-control.test.ts
@@ -15,7 +15,7 @@ function evalServer(source: string, file: string): Record<string, any> {
 	let { code } = compile(source, file, { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	const fn = new Function('__rt', '__exports', code + '\nreturn __exports;');

--- a/packages/octane/tests/ssr-render-apis.test.ts
+++ b/packages/octane/tests/ssr-render-apis.test.ts
@@ -13,7 +13,7 @@ function evalServer(source: string, file: string): Record<string, any> {
 	let { code } = compile(source, file, { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');

--- a/packages/octane/tests/ssr-render-options.test.ts
+++ b/packages/octane/tests/ssr-render-options.test.ts
@@ -16,7 +16,7 @@ function evalServer(source: string, file: string): Record<string, any> {
 	let { code } = compile(source, file, { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	const fn = new Function('__rt', '__exports', code + '\nreturn __exports;');

--- a/packages/octane/tests/ssr-suspense-discovery.test.ts
+++ b/packages/octane/tests/ssr-suspense-discovery.test.ts
@@ -15,7 +15,7 @@ function evalServer(source: string, file: string): Record<string, any> {
 	let { code } = compile(source, file, { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	const fn = new Function('__rt', '__exports', code + '\nreturn __exports;');

--- a/packages/octane/tests/ssr-suspense.test.ts
+++ b/packages/octane/tests/ssr-suspense.test.ts
@@ -17,7 +17,7 @@ function evalServer(source: string, file: string): Record<string, any> {
 	let { code } = compile(source, file, { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	const fn = new Function('__rt', '__exports', code + '\nreturn __exports;');

--- a/packages/octane/tests/ssr-tsx-children.test.ts
+++ b/packages/octane/tests/ssr-tsx-children.test.ts
@@ -37,7 +37,7 @@ describe('.tsx return-form component children — server matches client (descrip
 		const code = serverCode(RETURN_FORM);
 		// children must be a createElement(Inner, …) descriptor — matching the client —
 		// so `{props.children}` → ssrChild(descriptor) is ONE block, like childSlot.
-		expect(code).toMatch(/"children":\s*\(createElement\(\s*Inner/);
+		expect(code).toMatch(/"children":\s*\(_\$createElement\(\s*Inner/);
 		// It must NOT wrap children in a __schildren render-fn (that adds a block).
 		expect(code).not.toMatch(/"children":\s*__schildren/);
 	});

--- a/packages/octane/tests/ssr.test.ts
+++ b/packages/octane/tests/ssr.test.ts
@@ -16,7 +16,7 @@ function evalServer(source: string, file: string): Record<string, any> {
 	// Bind the server-runtime import to the live module, and capture exports.
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export default (\w+);?/g, '__exports.default = $1;');

--- a/packages/octane/tests/streaming-ssr.test.ts
+++ b/packages/octane/tests/streaming-ssr.test.ts
@@ -17,7 +17,7 @@ function serverModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'ssr-suspense.tsrx', { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');

--- a/packages/octane/tests/style-px.test.ts
+++ b/packages/octane/tests/style-px.test.ts
@@ -70,7 +70,7 @@ function evalModule(mode: 'server' | 'client', rt: unknown): Record<string, any>
 	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'style-px.tsrx', { mode });
 	code = code.replace(
 		new RegExp(`import\\s*\\{([^}]*)\\}\\s*from\\s*['"]${src}['"];?`, 'g'),
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');

--- a/packages/octane/tests/switch-fold.test.ts
+++ b/packages/octane/tests/switch-fold.test.ts
@@ -12,7 +12,7 @@ function serverModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'switch-fold.tsrx', { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export function (\w+)/g, 'const $1 = __exports.$1 = function $1');

--- a/packages/octane/tests/try-fold.test.ts
+++ b/packages/octane/tests/try-fold.test.ts
@@ -12,7 +12,7 @@ function serverModule(): Record<string, any> {
 	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'try-fold.tsrx', { mode: 'server' });
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		'const {$1} = __rt;',
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export function (\w+)/g, 'const $1 = __exports.$1 = function $1');


### PR DESCRIPTION
## What

The TSRX compiler emitted runtime helper imports by bare name (`import { clone, delegateEvents, htext, setText, template } from 'octane'`) and called them unprefixed in generated code. Since generated statements are interleaved with user statements inside the component function, a user binding with the same name silently shadowed the helper:

```tsx
export function T(props) @{
	const [text, setText] = useState('');   // ← THE most common React naming
	<div>
		<button id="btn" onClick={() => setText('xyz')}>{'go'}</button>
		<span id="label">{text as string}</span>
	</div>
}
```

The compiled update path `setText(_b._txt$1, _v)` resolved to the user's state setter, so clicking the button (a) never updated the span and (b) called the user's setState with a DOM **Text node**, storing it as state and spawning an extra render. Module-scope collisions (`const template = …`) were worse: a duplicate-declaration SyntaxError against the prelude import.

## Fix

- **Every compiler-generated helper reference now uses a collision-proof `_$` alias** (Solid-style): `import { setText as _$setText } from 'octane'` + `_$setText(…)`. All emitted identifiers were audited and converted, on both client and server (`octane/server`) codegen paths: text/attr/style/class/spread/formAction setters, `htext`/`htextSwap`/`textHole`/`childTextHole`, `clone`/`template`/`child`/`sibling`, block helpers (`ifBlock`, `forBlock`, `switchBlock`, `tryBlock`, `activityBlock`, `componentSlot(Lite)`, `textSlot`, `portal`, `headBlock`), ref helpers (`attachRef`, `queueRefAttach/Detach`, `mountFragmentRef`), `createElement`, `withSlot`, `normalizeClass`, `delegateEvents`/`delegateCaptureEvents`, `injectStyle`, HMR wiring (`hmr`/`HMR`), and the whole `ssr*` family.
- **Names the user's own code references stay bare**: preserved `octane` import specifiers and slotted base-hook call sites (`useState(…)` remains the user's identifier). The split lives in `ctx.runtimeNeeded` (generated → aliased) vs the new `ctx.userRuntimeNames` (user → verbatim). A name in both sets emits both specifiers (valid ESM).
- Side fix: user import renames (`import { flushSync as fs }`) are now preserved — the old merge dropped the local alias, which would have emitted an import the user's code never references.
- The auto-callback pass flags its inserted `useCallback` callee (`_octaneGenerated`) so hook slotting renames it to `_$useCallback` while user-authored hook calls are untouched.

## Tests

- New `tests/helper-shadowing.test.ts` + fixture: the exact `setText` repro (DOM updates, state stays a string), `htext` as a local, locals named `setAttribute`/`setStyle`/`setClassName`/`normalizeClass`/`child`/`sibling` and `ifBlock`/`forBlock`/`componentSlot`, module-level `template`/`clone`/`delegateEvents`, plus emit-shape assertions (aliased helpers, bare user specifiers, client + server). **All 6 fail against the pre-fix compiler.**
- ~45 SSR/hydration tests eval compiled output by rewriting `import {…}` into destructuring; those rewrites are now alias-aware (`x as _$x` → `x: _$x`). Five assertion tests (`auto-callback`, `hmr`, `render-prop`, `ssr-tsx-children`, `server-withslot`) updated to the new emitted shape.
- Swept all 787 fixture compilations (client dev/prod/hmr + server) for leftover bare helper references — the only remaining bare names are user-authored code, as intended.
- The `hooks-arity.tsrx` fixture comment that documented the workaround (`inputText` instead of `text`) now points at the fix.

## Reviewer notes

- The `_$` prefix can theoretically still collide with a user binding literally named `_$setText` — accepted, same trade-off as Solid's dom-expressions.
- Changeset included (`octane`, patch).
- Validation: `pnpm test` (297 files, 2069 passed, 33 pinned expected-fails), `pnpm typecheck`, `pnpm format:check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all client/server codegen emission paths and prelude imports—high blast radius, but behavior is narrowly scoped to import/call naming with broad test coverage.
> 
> **Overview**
> Fixes a bug where **compiler-generated calls to `octane` runtime helpers could resolve to user bindings** with the same name inside a component (e.g. `const [text, setText] = useState('')` hijacking `setText` on text-hole updates). Module-level names like `template` could also **duplicate-declare** against the prelude import.
> 
> **Generated code** now imports and calls every compiler-emitted helper via a **`_$` prefix** (`import { setText as _$setText }` and `_$setText(…)`), on both **client** and **`octane/server`** paths (setters, blocks, SSR helpers, HMR, `createElement`, etc.). **User-facing names stay bare**: preserved `octane` import specifiers (including **`import { x as y }` renames**, which the old merge dropped) and normal hook call sites go into a separate **`userRuntimeNames`** set merged verbatim into the prelude import.
> 
> Compiler-inserted **`useCallback`** from auto-callback is tagged so its callee becomes **`_$useCallback`** while user-authored hooks are unchanged. Tests add **helper-shadowing** coverage and update eval harnesses to understand aliased imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fa75c294bcf0bd0b11a5d628a6113afee611579. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->