### PR TITLE
Mount lone pure-host descriptors anchorless (container.firstChild par…

### DIFF
--- a/.changeset/wild-plums-repeat.md
+++ b/.changeset/wild-plums-repeat.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+A lone pure-host descriptor at a value position (e.g. `createElement('div')` returned from a pass-through component or rendered at a root) now mounts ANCHORLESS — no comment markers, the element self-delimits, mirroring the singleRoot component regime. `container.firstChild` is the element itself (React/RTL parity) instead of a comment anchor. A later render that flips the slot's value to another mode (text, null, array, component, portal) promotes the slot to the marked regime in place.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -5688,6 +5688,12 @@ export function componentSlot(
 // ElementDescriptor) or a single Text node (primitive). A value whose mode
 // flips across renders tears the old content down — cleanups fire, content
 // nodes are removed — and rebuilds in place, keeping the markers.
+//
+// Exception: a client mount whose FIRST value is a lone pure-host descriptor
+// (e.g. `createElement('div')` returned from a component, or rendered at a
+// root) is ANCHORLESS — no markers at all, the element self-delimits (`end`
+// is null; mirrors componentSlot's singleRoot regime). A later mode flip
+// promotes the slot to the marked regime by minting the pair in place.
 
 interface ChildSlot {
 	__kind: 'childSlot';
@@ -5699,7 +5705,17 @@ interface ChildSlot {
 	 * hydration (adopted from the server's `<!--[-->`).
 	 */
 	start: Comment | null;
-	end: Comment;
+	/**
+	 * Upper-bound marker / insertion anchor. Null in ANCHORLESS mode: a client
+	 * mount whose first value is a LONE PURE-HOST descriptor mints NO markers at
+	 * all — the element self-delimits (mirroring componentSlot's singleRoot
+	 * regime), so a host descriptor returned at a root / return slot IS
+	 * `container.firstChild` (React parity). A later render that flips the
+	 * value's mode promotes the slot to the marked regime by minting the pair
+	 * on demand around the host node (see childSlot). Non-null in every other
+	 * regime (and always after hydration).
+	 */
+	end: Comment | null;
 	block: Block | null;
 	text: Text | null;
 	currentComp: ComponentBody | null;
@@ -5848,10 +5864,17 @@ function clearChildContent(state: ChildSlot): void {
 		}
 	} else if (state.text !== null) {
 		// Client text path: a single tracked Text node, no start marker to sweep.
-		// (A pure-host node never appears here: the pure-host branch of childSlot
-		// mints `start` before it ever sets `hostNode`, so a live hostNode is
-		// always swept by the marker-range branch above.)
+		// (A MARKED pure-host node never appears here: the marked host branch of
+		// childSlot mints `start` before it ever sets `hostNode`, so a live marked
+		// hostNode is always swept by the marker-range branch above.)
 		state.text.remove();
+	} else if (state.hostNode !== null && state.hostNode.parentNode !== null) {
+		// ANCHORLESS pure-host slot (end === null, no markers): remove the
+		// self-delimiting node directly — the marker sweep above has nothing to
+		// anchor on. Reached via disposeReturnSlot's kind-flip teardown; childSlot's
+		// own mode flips promote to markers before ever clearing.
+		detachDeoptTreeRefs(state.hostNode, null);
+		state.hostNode.parentNode.removeChild(state.hostNode);
 	}
 	state.text = null;
 	state.currentComp = null;
@@ -6609,10 +6632,15 @@ export function childSlot(
 	ownEnd?: boolean,
 ): void {
 	const parentBlock = parentScope.block;
+	// A LONE PURE-HOST descriptor (host/text-only subtree — no components, no
+	// portals, no render functions). Computed once per call: the slot init below
+	// uses it to pick the ANCHORLESS regime, the promotion after it to detect a
+	// mode flip out of that regime, and the classifier to route the value.
+	const pureHost = isHostDescriptor(value) && !descNeedsBlocks(value);
 	let state = parentScope.slots[slotKey] as ChildSlot | undefined;
 	if (state === undefined) {
 		let start: Comment | null;
-		let end: Comment;
+		let end: Comment | null;
 		if (hydrating && isBlockOpen(anchor ?? null)) {
 			// Hydration (nested hole): the anchor resolved via child/sibling to the
 			// server's `<!--[-->`. Adopt that `<!--[-->…<!--]-->` range as our markers
@@ -6635,6 +6663,15 @@ export function childSlot(
 			// insertBefore per `{expr}` hole (no separate end marker minted).
 			start = null;
 			end = anchor as Comment;
+		} else if (!hydrating && pureHost) {
+			// ANCHORLESS client mount: the value is a lone pure-host descriptor, so
+			// the element self-delimits — mint NO markers at all (mirrors
+			// componentSlot's singleRoot regime). This is what makes a host
+			// descriptor at a root / return slot land as `container.firstChild`
+			// (React parity) instead of `<!----><el/><!---->`. A later render whose
+			// value flips mode promotes to the marked regime (see below).
+			start = null;
+			end = null;
 		} else {
 			// Client mount: a SINGLE end anchor. A text/empty hole tracks its own
 			// `Text` node (no start needed); the component path lazily mints a start
@@ -6657,6 +6694,30 @@ export function childSlot(
 		};
 		parentScope.slots[slotKey] = state;
 		registerSlot(parentScope, state);
+	}
+
+	// ANCHORLESS → marked promotion: the slot was created markerless for a lone
+	// pure-host value (init above). The moment a render flips the value to
+	// anything else (component / array / portal / text / null), mint the marker
+	// pair on demand around the current host node, so every path below sees the
+	// normal marked regime — the childSlot analogue of the singleRoot shape-flip
+	// handling in disposeReturnSlot. One-way: once marked, the slot stays marked.
+	if (state.end === null && !pureHost) {
+		const start = document.createComment('');
+		const end = document.createComment('');
+		const host = state.hostNode;
+		if (host !== null && host.parentNode !== null) {
+			const p = host.parentNode;
+			p.insertBefore(start, host);
+			p.insertBefore(end, host.nextSibling);
+		} else {
+			// Defensive — anchorless is only entered after a successful pure-host
+			// render, so a live host should always exist. Pin at the call's anchor.
+			domParent.insertBefore(start, anchor ?? null);
+			domParent.insertBefore(end, anchor ?? null);
+		}
+		state.start = start;
+		state.end = end;
 	}
 
 	// Portal descriptor → render its body into a foreign target; the slot's own
@@ -6704,7 +6765,8 @@ export function childSlot(
 			state.forSlot = {
 				__kind: 'forBlockSlot',
 				start: state.start,
-				end: state.end,
+				// Non-null: an anchorless slot was promoted to markers above.
+				end: state.end!,
 				items: new Map(),
 				head: null,
 				tail: null,
@@ -6750,11 +6812,32 @@ export function childSlot(
 	let props: any = {};
 	let isBodyFn = false;
 	if (isHostDescriptor(value)) {
-		if (!descNeedsBlocks(value)) {
+		if (pureHost) {
 			// Pure host/text → reconcile in place, REUSING the existing node so DOM
 			// state survives a re-render. Switching in from a component/text first
 			// tears that down (also nulls a stale hostNode).
 			if (state.block !== null || state.text !== null) clearChildContent(state);
+			if (state.end === null) {
+				// ANCHORLESS: no markers — the element self-delimits, so reconcile
+				// straight against the tracked node. A same-tag value patches it in
+				// place; an incompatible one is rebuilt at the old node's position
+				// (first render inserts at the call's anchor). `reconcileDeoptNode`
+				// always yields a node for a host descriptor; the null checks are
+				// shape-parity with the marked path below.
+				const prev = state.hostNode;
+				const node = reconcileDeoptNode(prev, value, parentBlock);
+				if (node !== prev) {
+					if (prev !== null && prev.parentNode !== null) {
+						if (node !== null) prev.parentNode.insertBefore(node, prev);
+						detachDeoptTreeRefs(prev, null);
+						prev.parentNode.removeChild(prev);
+					} else if (node !== null) {
+						domParent.insertBefore(node, anchor ?? null);
+					}
+				}
+				state.hostNode = node;
+				return;
+			}
 			if (state.start === null) {
 				state.start = document.createComment('');
 				domParent.insertBefore(state.start, state.end);
@@ -6822,8 +6905,10 @@ export function childSlot(
 		// one off-screen and HOLD the old until it's ready, instead of clearing the old
 		// before the new suspends (which would blank the boundary). Only when there's
 		// committed old content to hold; urgent + hydration keep the legacy path below.
+		// (`state.end` is non-null on this path: a live block implies the marked
+		// regime — anchorless slots never hold a Block.)
 		if (state.block !== null && !hydrating && parentBlock.currentRenderMode === 'transition') {
-			const r = renderOffscreen(parentBlock, domParent, state.end, comp, props);
+			const r = renderOffscreen(parentBlock, domParent, state.end!, comp, props);
 			if (r.suspended || r.error) {
 				// Discard the partial; the OLD content was never touched, so it stays live.
 				// Re-throw so the enclosing tryBlock's existing catch holds the old content
@@ -6838,7 +6923,7 @@ export function childSlot(
 			// OUTSIDE that range so it's untouched), then move the WIP into the slot range.
 			// Synchronous, so there is no painted blank between the two.
 			clearChildContent(state);
-			commitOffscreen(r.wip, state.end);
+			commitOffscreen(r.wip, state.end!);
 			state.block = r.wip.block;
 			state.currentComp = comp;
 			state.currentIsBodyFn = isBodyFn;
@@ -6876,7 +6961,8 @@ export function childSlot(
 		renderBlock(b);
 		// Advance the cursor past this child's adopted range so a following sibling
 		// hole adopts the right node (mirrors componentSlot's post-render advance).
-		if (hydrating) hydrateNode = state.end.nextSibling;
+		// (Hydration always adopts a marker pair, so `state.end` is non-null here.)
+		if (hydrating) hydrateNode = state.end!.nextSibling;
 		return;
 	}
 

--- a/packages/octane/tests/_fixtures/anchorless-host.tsrx
+++ b/packages/octane/tests/_fixtures/anchorless-host.tsrx
@@ -1,0 +1,50 @@
+import { createElement, createPortal } from 'octane';
+
+// A compiled single-root component: returning `<Solo/>` from a plain function
+// takes renderBlock's markerless componentSlotSlot return path — the OTHER
+// return-slot kind, so flipping host ⇄ Solo exercises disposeReturnSlot on an
+// ANCHORLESS childSlot.
+function Solo(props) @{
+	<p class="solo">
+		{props.label as string}
+	</p>
+}
+
+// Return-slot flipper. `mode === 'host'` returns a LONE PURE-HOST descriptor —
+// the anchorless childSlot regime — and every other mode flips the slot into a
+// different content kind (text / null / de-opt array / singleRoot component /
+// host-with-component-children / portal), which must promote the slot to
+// markers in place without losing its position between the <b> siblings.
+function Flipper(props) {
+	const mode = props.mode;
+	if (mode === 'host') {
+		return createElement('div', { id: 'host', ref: props.hostRef }, 'host');
+	}
+	if (mode === 'text') {
+		return 'plain';
+	}
+	if (mode === 'null') {
+		return null;
+	}
+	if (mode === 'array') {
+		return [createElement('i', { key: 'a' }, 'a'), createElement('i', { key: 'b' }, 'b')];
+	}
+	if (mode === 'comp') {
+		return <Solo label="solo" />;
+	}
+	if (mode === 'hostcomp') {
+		return createElement('div', { id: 'hc' }, createElement(Solo, { label: 'deep' }));
+	}
+	if (mode === 'portal') {
+		return createPortal(Solo, props.target, { label: 'portal' });
+	}
+	return null;
+}
+
+export function App(props) @{
+	<section class="root">
+		<b>{'A'}</b>
+		<Flipper mode={props.mode} target={props.target} hostRef={props.hostRef} />
+		<b>{'B'}</b>
+	</section>
+}

--- a/packages/octane/tests/anchorless-host.test.ts
+++ b/packages/octane/tests/anchorless-host.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from './_helpers';
+import { createElement } from '../src/index.js';
+import { App } from './_fixtures/anchorless-host.tsrx';
+
+// A LONE PURE-HOST descriptor at a value position (a pass-through component's
+// return, a host descriptor rendered at a root) mounts ANCHORLESS — no comment
+// markers, the element self-delimits (childSlot's analogue of componentSlot's
+// singleRoot regime). RTL's `container.firstChild` idiom depends on this. When
+// a later render flips the slot's value to any other mode, the slot promotes
+// to the normal marked regime in place.
+
+// React-style pass-through: whatever `children` value it's given is what the
+// root renders — this is exactly @octanejs/testing-library's ValueRoot shim.
+const Pass = (props: any) => props.children;
+
+describe('anchorless lone pure-host value', () => {
+	it('mounts with NO comment anchors — container.firstChild IS the element', () => {
+		const r = mount(Pass, { children: createElement('div', { id: 'a' }, 'hello') });
+		expect(r.container.innerHTML).toBe('<div id="a">hello</div>');
+		expect(r.container.firstChild).toBe(r.find('#a'));
+		r.unmount();
+	});
+
+	it('reconciles a same-tag re-render in place (node identity survives)', () => {
+		const r = mount(Pass, { children: createElement('div', { id: 'a' }, 'one') });
+		const node = r.container.firstChild;
+		r.update(Pass, { children: createElement('div', { id: 'b' }, 'two') });
+		expect(r.container.firstChild).toBe(node);
+		expect(r.container.innerHTML).toBe('<div id="b">two</div>');
+		r.unmount();
+	});
+
+	it('rebuilds on a tag flip, still anchorless', () => {
+		const r = mount(Pass, { children: createElement('div', undefined, 'div') });
+		r.update(Pass, { children: createElement('span', undefined, 'span') });
+		expect(r.container.innerHTML).toBe('<span>span</span>');
+		r.unmount();
+	});
+
+	it('attaches the ref on mount and detaches it when the value flips away', () => {
+		const ref: { current: Element | null } = { current: null };
+		const r = mount(Pass, { children: createElement('div', { ref }) });
+		expect(ref.current).toBe(r.container.firstChild);
+		r.update(Pass, { children: 'text' });
+		expect(ref.current).toBe(null);
+		expect(r.container.textContent).toBe('text');
+		r.unmount();
+	});
+
+	it('detaches the ref on root unmount', () => {
+		const ref: { current: Element | null } = { current: null };
+		const r = mount(Pass, { children: createElement('div', { ref }) });
+		expect(ref.current).not.toBe(null);
+		r.unmount();
+		expect(ref.current).toBe(null);
+		expect(r.container.innerHTML).toBe('');
+	});
+});
+
+// The promotion cases: an anchorless slot whose value flips mode must mint its
+// marker pair IN PLACE — content stays between the fixture's <b>A</b>/<b>B</b>
+// siblings — and flipping back to a host renders correctly in the (now marked)
+// regime. `section.textContent` proves both content and document order.
+describe('anchorless → marked promotion on mode flips', () => {
+	function flipRoundTrip(mode: string, expected: string, target?: HTMLElement) {
+		const r = mount(App, { mode: 'host', target });
+		expect(r.find('section').textContent).toBe('AhostB');
+		expect(r.container.querySelector('#host')).not.toBe(null);
+
+		r.update(App, { mode, target });
+		expect(r.container.querySelector('#host')).toBe(null); // old node swept
+		expect(r.find('section').textContent).toBe(expected);
+
+		r.update(App, { mode: 'host', target });
+		expect(r.find('section').textContent).toBe('AhostB');
+		expect(r.container.querySelector('#host')).not.toBe(null);
+		r.unmount();
+	}
+
+	it('host → text → host', () => flipRoundTrip('text', 'AplainB'));
+	it('host → null → host', () => flipRoundTrip('null', 'AB'));
+	it('host → keyed array → host', () => flipRoundTrip('array', 'AabB'));
+
+	// Return-slot KIND flip: childSlot (anchorless host) ⇄ componentSlotSlot
+	// (singleRoot `<Solo/>`) — exercises disposeReturnSlot's teardown of an
+	// anchorless childSlot (no markers to sweep; the node itself is removed).
+	it('host → singleRoot component → host', () => flipRoundTrip('comp', 'AsoloB'));
+
+	// Host WITH component children needs Blocks → the component path, not the
+	// raw reconciler; the anchorless slot promotes and mounts it as a Block.
+	it('host → host-with-component-children → host', () => flipRoundTrip('hostcomp', 'AdeepB'));
+
+	it('host → portal → host (content moves to the foreign target and back)', () => {
+		const target = document.createElement('aside');
+		document.body.appendChild(target);
+		try {
+			const r = mount(App, { mode: 'host', target });
+			expect(r.find('section').textContent).toBe('AhostB');
+
+			r.update(App, { mode: 'portal', target });
+			expect(r.container.querySelector('#host')).toBe(null);
+			expect(r.find('section').textContent).toBe('AB'); // slot itself is empty
+			expect(target.querySelector('.solo')!.textContent).toBe('portal');
+
+			r.update(App, { mode: 'host', target });
+			expect(target.querySelector('.solo')).toBe(null); // portal torn down
+			expect(r.find('section').textContent).toBe('AhostB');
+			r.unmount();
+		} finally {
+			target.remove();
+		}
+	});
+});

--- a/packages/testing-library/README.md
+++ b/packages/testing-library/README.md
@@ -76,11 +76,12 @@ React-specific remappings:
   drain via dom-testing-library's `eventWrapper`, so non-discrete/programmatic
   events also commit — with their `useEffect` cascades — before `fireEvent`
   returns (the equivalent of RTL's `act()` around each dispatch).
-- **Host elements at the root render between comment anchors.**
+- **Host elements at the root are `container.firstChild`, like RTL.**
   `render(createElement('div', …))` goes through octane's value-position
-  renderer, so `container.firstChild` is a comment node — use
-  `container.firstElementChild` (or just queries). Component roots
-  (`render(App, …)`) mount their template directly, no anchors.
+  renderer, which mounts a lone host element anchorless (the element
+  self-delimits, no comment markers) — so RTL's `container.firstChild` idiom
+  works as-is. Component roots (`render(App, …)`) mount their template
+  directly, also without anchors.
 - **`renderHook` and hook slots.** Octane hooks are keyed by compiler-assigned
   call-site slots. Hook callbacks written in your test files Just Work — the
   vite plugin's surgical pass slots base-hook calls in plain `.ts`, and

--- a/packages/testing-library/tests/render.test.ts
+++ b/packages/testing-library/tests/render.test.ts
@@ -17,10 +17,9 @@ describe('render', () => {
 	// Per react-testing-library src/__tests__/render.js:28 ("renders div into document")
 	it('renders a host element into the document', () => {
 		const { container } = render(createElement('div', { id: 'whatever' }, 'hello'));
-		// DIVERGENCE (documented in the README): a host descriptor at the root
-		// renders through octane's value-position path, which brackets it with
-		// comment anchors — so it's `firstElementChild`, not RTL's `firstChild`.
-		expect(container.firstElementChild!.id).toBe('whatever');
+		// A lone host descriptor at the root renders ANCHORLESS (no comment
+		// markers), so RTL's ubiquitous `container.firstChild` idiom holds.
+		expect((container.firstChild as HTMLElement).id).toBe('whatever');
 		expect(container.textContent).toBe('hello');
 		expect(document.body.contains(container)).toBe(true);
 	});


### PR DESCRIPTION
…ity)

A bare host descriptor at a value position — e.g. root.render() of a pass-through component returning createElement('div') — used to mount between childSlot's comment anchors (<!----><div></div><!---->), so RTL's ubiquitous container.firstChild idiom hit a comment node.

childSlot now has an ANCHORLESS regime, mirroring componentSlot's singleRoot path: a client mount whose first value is a lone pure-host descriptor (no component/portal/function descendants) mints no markers at all — the element self-delimits and IS container.firstChild. When a later render flips the slot's value to any other mode (text, null, array, component, portal), the slot promotes to the marked regime by minting the marker pair in place around the host node; disposeReturnSlot and clearChildContent learned to tear down an anchorless host directly. Hydration and ownEnd-placeholder slots are unchanged.

Flips the pinned @octanejs/testing-library test to assert RTL's container.firstChild directly and updates its README divergence note.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `childSlot` DOM lifecycle in `runtime.ts`, but the change is narrowly scoped to a new client-mount path with hydration unchanged and broad new regression tests.
> 
> **Overview**
> **Lone pure-host values in `childSlot` no longer get comment anchor wrappers on client mount**, so `container.firstChild` is the element (React/RTL parity) instead of a `<!-- -->` node.
> 
> `childSlot` gains an **ANCHORLESS** regime when the first client value is a pure host descriptor (`isHostDescriptor` and not `descNeedsBlocks`): `start`/`end` stay null and the host reconciles in place. **Later mode flips** (text, null, array, component, portal, etc.) **promote** the slot to the usual marked `<!--[-->`/`<!--]-->` pair around the existing node; **`clearChildContent`** can also remove an anchorless host directly when return-slot kind flips via **`disposeReturnSlot`**. Hydration and `ownEnd` placeholder slots are unchanged.
> 
> Adds **`anchorless-host`** fixture/tests and updates **`@octanejs/testing-library`** README and **`render.test`** to assert `container.firstChild` instead of documenting anchor divergence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 203bcee82d40bbbea11a9a54954a656c12f7a714. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->