### PR TITLE
Streaming SSR: per-boundary wave settling instead of settle-all rounds

### DIFF
--- a/.changeset/streaming-per-boundary-waves.md
+++ b/.changeset/streaming-per-boundary-waves.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Streaming SSR now delivers each Suspense boundary's segment at its OWN resolve time. The round loop in `renderToPipeableStream` / `renderToReadableStream` used to settle a round with `Promise.all` over every suspended thenable, so on a staggered data schedule the earliest boundary's HTML was held until the slowest sibling landed (one giant tail chunk). Rounds are now WAVES: await the first unresolved settle, coalesce everything else that lands in the same event-loop turn (one `setImmediate`/`setTimeout(0)` yield plus microtask drains), re-pass, flush newly-done segments, repeat — so simultaneous resolutions still share a single re-pass (the all-fast case stays at ~2 passes) while staggered boundaries stream as they arrive. `MAX_SUSPENSE_PASSES` accordingly now bounds CONSECUTIVE passes that complete no boundary (one pass per resolution wave is legitimate, not a runaway); waterfall-depth and nondeterministic-key runaways still trip it. Buffered `prerender` settling is unchanged.

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -1185,7 +1185,7 @@ const MAX_SUSPENSE_PASSES = 50;
 
 // Wall-clock bound on a single suspense await. MAX_SUSPENSE_PASSES caps the
 // NUMBER of re-render passes, but it's checked BEFORE the await — so a thenable
-// that never settles would leave `Promise.all` (and the request) hung forever.
+// that never settles would leave the settle await (and the request) hung forever.
 // This deadline races that await so a stuck thenable fails the render instead.
 // 0 disables the deadline (await indefinitely). Configurable for tests/hosts.
 let SUSPENSE_TIMEOUT_MS = 10_000;
@@ -1405,28 +1405,16 @@ function runDiscoveryRound(
 	return { suspended, deferred };
 }
 
-// Await everything a pass/round surfaced; cache each outcome in `resolved` by its
-// key. Only render-local state is touched across the await. Raced against the
-// settle deadline (`timeoutMs`; 0 disables) so a thenable that never settles
-// fails the render instead of hanging the request forever, and against the
-// caller's AbortSignal so a dead request stops rendering.
-async function settleSuspended(
-	suspended: SuspendedList,
-	resolved: ResolvedMap,
+// Race a settle await against the deadline (`timeoutMs`; 0 disables) so a
+// thenable that never settles fails the render instead of hanging the request
+// forever, and against the caller's AbortSignal so a dead request stops
+// rendering.
+async function raceSettleGuards(
+	work: Promise<unknown>,
 	timeoutMs: number,
 	signal: AbortSignal | undefined,
 ): Promise<void> {
-	const settleAll = Promise.all(
-		suspended.map(async ({ promise, key }) => {
-			if (resolved.has(key)) return;
-			try {
-				resolved.set(key, { value: await promise });
-			} catch (reason) {
-				resolved.set(key, { reason });
-			}
-		}),
-	);
-	const racers: Promise<unknown>[] = [settleAll];
+	const racers: Promise<unknown>[] = [work];
 	let timer: ReturnType<typeof setTimeout> | undefined;
 	let removeAbort: (() => void) | undefined;
 	if (timeoutMs > 0) {
@@ -1455,10 +1443,91 @@ async function settleSuspended(
 		);
 	}
 	try {
-		await (racers.length === 1 ? settleAll : Promise.race(racers));
+		await (racers.length === 1 ? work : Promise.race(racers));
 	} finally {
 		clearTimeout(timer);
 		removeAbort?.();
+	}
+}
+
+// Await everything a pass/round surfaced; cache each outcome in `resolved` by
+// its key. Only render-local state is touched across the await. This is the
+// BUFFERED pipeline's settle — nothing ships until everything resolves, so one
+// settle-all per waterfall level is the fewest possible passes. The streaming
+// pipeline uses settleFirstOfWave instead, so an early boundary isn't held
+// hostage by a slow sibling.
+async function settleSuspended(
+	suspended: SuspendedList,
+	resolved: ResolvedMap,
+	timeoutMs: number,
+	signal: AbortSignal | undefined,
+): Promise<void> {
+	const settleAll = Promise.all(
+		suspended.map(async ({ promise, key }) => {
+			if (resolved.has(key)) return;
+			try {
+				resolved.set(key, { value: await promise });
+			} catch (reason) {
+				resolved.set(key, { reason });
+			}
+		}),
+	);
+	await raceSettleGuards(settleAll, timeoutMs, signal);
+}
+
+// One macrotask turn. Settlements triggered by the same event-loop turn (N
+// timers expiring at the same deadline, a batch of IO completions) arrive as
+// SEPARATE callbacks with a full microtask drain between each, so a
+// microtask-only yield after the first settle cannot see the rest of the
+// burst. setImmediate (Node) runs after the whole timers/poll phase — i.e.
+// after every callback of the burst — with no timer clamp; setTimeout(0) is
+// the portable fallback (edge runtimes without setImmediate).
+const yieldMacrotask: () => Promise<void> =
+	typeof setImmediate === 'function'
+		? () => new Promise((resolve) => setImmediate(resolve))
+		: () => new Promise((resolve) => setTimeout(resolve, 0));
+
+// The STREAMING settle: await only until the FIRST unresolved thenable
+// settles, then coalesce — one macrotask yield plus microtask drains — so
+// everything else that landed in the same event-loop wave records into
+// `resolved` too. The caller re-passes once per WAVE: on a staggered schedule
+// the earliest boundary flushes at its own resolve time instead of waiting for
+// the slowest sibling (a settle-all here held EVERY segment until the last
+// thenable landed), while simultaneous resolutions still share one re-pass
+// instead of costing a pass each.
+async function settleFirstOfWave(
+	suspended: SuspendedList,
+	resolved: ResolvedMap,
+	timeoutMs: number,
+	signal: AbortSignal | undefined,
+): Promise<void> {
+	const recorders: Promise<void>[] = [];
+	for (const { promise, key } of suspended) {
+		if (resolved.has(key)) continue;
+		recorders.push(
+			(async () => {
+				try {
+					const value = await promise;
+					if (!resolved.has(key)) resolved.set(key, { value });
+				} catch (reason) {
+					if (!resolved.has(key)) resolved.set(key, { reason });
+				}
+			})(),
+		);
+	}
+	if (recorders.length === 0) return;
+	await raceSettleGuards(Promise.race(recorders), timeoutMs, signal);
+	// The winning recorder has recorded. Yield one macrotask so the rest of
+	// this turn's burst fires, then drain microtasks while settlements keep
+	// recording (a chained/non-native thenable needs an extra tick or two);
+	// stop as soon as a drain adds nothing — stragglers get the next wave.
+	await yieldMacrotask();
+	let size = resolved.size;
+	for (;;) {
+		await Promise.resolve();
+		await Promise.resolve();
+		if (resolved.size === size) return;
+		size = resolved.size;
 	}
 }
 
@@ -1607,13 +1676,17 @@ export function renderToStaticMarkup(
 //      registers itself (keyed by frame path, so the id is stable across
 //      passes). The shell flushes immediately (styles + head + body + shell
 //      seeds + the inline swap runtime).
-//   2. Each ROUND: await the suspended thenables (settleSuspended), re-run a
-//      full pass against the now-warmer RESOLVED cache. `ssrTry` captures each
-//      registered boundary's freshly-rendered content + its `use()` seed slice;
-//      newly-completed boundaries flush as hidden segments
+//   2. Each WAVE: await the FIRST suspended thenable to settle — coalescing
+//      anything else that lands in the same event-loop turn
+//      (settleFirstOfWave) — then re-run a full pass against the now-warmer
+//      RESOLVED cache. `ssrTry` captures each registered boundary's
+//      freshly-rendered content + its `use()` seed slice; newly-completed
+//      boundaries flush as hidden segments
 //      `<div hidden data-oct-s="N">…` followed by `<script>$OCTRC("N")</script>`
-//      which swaps the content into the boundary's live range. Rounds repeat
-//      until no boundary is pending (bounded by MAX_SUSPENSE_PASSES).
+//      which swaps the content into the boundary's live range. Waves repeat
+//      until no boundary is pending (MAX_SUSPENSE_PASSES bounds CONSECUTIVE
+//      passes that complete no boundary — one pass per resolution wave is the
+//      design, not a runaway, so flushing a segment resets the counter).
 //
 // A registered boundary ALWAYS returns its pending form (template + fallback)
 // to the surrounding pass — its real content ships ONLY via its own segment, so
@@ -1631,8 +1704,10 @@ export function renderToStaticMarkup(
 //
 // Intentional scope notes (documented divergences from React Fizz):
 //   - No selective hydration (octane has no synthetic event replay system).
-//   - Per-ROUND full re-passes rather than per-boundary incremental renders —
-//     the same cost model as `prerender`, reusing its cache + discovery engine.
+//   - Per-WAVE full re-passes rather than per-boundary incremental renders —
+//     each resolution wave costs one full pass (reusing `prerender`'s cache +
+//     discovery engine), buying per-boundary delivery: a boundary streams at
+//     its own resolve time, not at the round's slowest sibling.
 //   - Head elements hoisted from INSIDE a streamed boundary don't ship in the
 //     stream (the shell's head already flushed); the client re-creates them on
 //     hydration via headBlock.
@@ -1883,18 +1958,25 @@ async function runStream(
 	sink.shellReady();
 
 	let suspended = pass.suspended;
+	// `attempt` counts CONSECUTIVE passes that completed no boundary. One pass
+	// per resolution wave is the design (10 staggered cards legitimately take
+	// ~10 passes), so this bound can't cap TOTAL passes the way the buffered
+	// loop does — flushing a segment resets it. It still trips on what it's
+	// for: an intra-boundary waterfall deeper than MAX (parity with the
+	// buffered bound) and the nondeterministic-key runaway, which never
+	// completes its boundary.
 	let attempt = 0;
 	while ([...stream.boundaries.values()].some((b) => b.state === 'pending')) {
 		try {
 			signal?.throwIfAborted();
 			if (++attempt > MAX_SUSPENSE_PASSES) {
 				throw new Error(
-					'octane SSR: exceeded ' +
+					'octane SSR: ' +
 						MAX_SUSPENSE_PASSES +
-						' streaming passes — a use(thenable) never resolved.',
+						' consecutive streaming passes completed no boundary — a use(thenable) never resolved.',
 				);
 			}
-			await settleSuspended(suspended, resolved, timeoutMs, signal);
+			await settleFirstOfWave(suspended, resolved, timeoutMs, signal);
 			pass = withStream(stream, () => runFullFramedPass(component, props, resolved, nonceAttr));
 			suspended = pass.suspended;
 		} catch (err) {
@@ -1921,6 +2003,7 @@ async function runStream(
 		const done = [...stream.boundaries.values()]
 			.filter((b) => b.state === 'done' && !flushedSegments.has(b.id))
 			.sort((a, b) => a.id - b.id);
+		if (done.length > 0) attempt = 0; // boundary progress — this wave was legitimate
 		for (const b of done) {
 			flushedSegments.add(b.id);
 			chunk += segmentChunk(b, nonceAttr);

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -1526,9 +1526,15 @@ async function settleFirstOfWave(
 	for (;;) {
 		await Promise.resolve();
 		await Promise.resolve();
-		if (resolved.size === size) return;
+		if (resolved.size === size) break;
 		size = resolved.size;
 	}
+	// The coalesce yields sit OUTSIDE the guarded race, so an abort landing in
+	// that window would otherwise hand back a normally-"settled" wave — and the
+	// caller would spend a full pass (and possibly flush segments, or even
+	// report allReady) on a dead request. Surface it here; the caller's catch
+	// then marks pending boundaries errored exactly as a mid-race abort does.
+	signal?.throwIfAborted();
 }
 
 // The await-everything render core. Runs full canonical passes interleaved with

--- a/packages/octane/tests/streaming-ssr.test.ts
+++ b/packages/octane/tests/streaming-ssr.test.ts
@@ -219,6 +219,37 @@ describe('renderToPipeableStream — chunk protocol', () => {
 		expect(tail).toContain('nope');
 	});
 
+	it('abort landing during a wave coalesce cancels the pass — no post-abort segment', async () => {
+		const d = deferred<string>();
+		const c = collector();
+		const onError = vi.fn();
+		const events: string[] = [];
+		const { pipe, abort } = ServerRT.renderToPipeableStream(
+			server.Boundary,
+			{ promise: d.promise },
+			{ onError, onAllReady: () => events.push('all') },
+		);
+		pipe(c.dest);
+		// Land the abort INSIDE the wave's coalesce window: resolve now (the
+		// resolution wins the guarded race), then abort on the same macrotask
+		// channel the coalesce yield uses. Our callback is queued BEFORE the
+		// wave schedules its own yield (that happens a few microtasks from
+		// now), so it runs first — after the race settled, before the wave
+		// returns. The wave must still surface the abort instead of spending a
+		// pass, flushing the segment, and firing allReady on a dead request.
+		d.resolve('too late');
+		const afterRaceSettles =
+			typeof setImmediate === 'function' ? setImmediate : (fn: () => void) => setTimeout(fn, 0);
+		afterRaceSettles(() => abort(new Error('gone')));
+		await c.ended;
+		const tail = c.chunks.slice(1).join('');
+		expect(tail).not.toContain('data-oct-s=');
+		expect(tail).not.toContain('too late');
+		expect(tail).toContain('$OCTRX("0")');
+		expect(events).not.toContain('all');
+		expect(onError).toHaveBeenCalled();
+	});
+
 	it('abort marks pending boundaries errored and ends the stream', async () => {
 		const d = deferred<string>();
 		const c = collector();

--- a/packages/octane/tests/streaming-ssr.test.ts
+++ b/packages/octane/tests/streaming-ssr.test.ts
@@ -130,6 +130,62 @@ describe('renderToPipeableStream — chunk protocol', () => {
 		expect(tail).toContain('beta');
 	});
 
+	it('streams each boundary at its own resolve time, not the wave-set slowest', async () => {
+		// REAL timers on purpose (no vi.useFakeTimers): the assertion is about
+		// wall-clock chunk arrival. Margins are generous so CI jitter can't flip
+		// it — the early chunk must land in [EARLY, LATE - 50], i.e. long before
+		// the late boundary's data even resolves.
+		const EARLY = 20;
+		const LATE = 250;
+		const a = new Promise<string>((r) => setTimeout(() => r('alpha'), EARLY));
+		const b = new Promise<string>((r) => setTimeout(() => r('beta'), LATE));
+		const arrivals: { chunk: string; at: number }[] = [];
+		let end!: () => void;
+		const ended = new Promise<void>((res) => (end = res));
+		const t0 = performance.now();
+		const { pipe } = ServerRT.renderToPipeableStream(server.Siblings, { a, b });
+		pipe({
+			write: (chunk: string) => arrivals.push({ chunk, at: performance.now() - t0 }),
+			end: () => end(),
+		});
+		await ended;
+
+		// Shell + one segment chunk PER boundary. The old settle-all round held
+		// alpha's segment until beta landed and shipped both in ONE chunk.
+		expect(arrivals).toHaveLength(3);
+		const [, first, second] = arrivals;
+		expect(first.chunk).toContain('data-oct-s="0"');
+		expect(first.chunk).toContain('alpha');
+		expect(first.chunk).not.toContain('beta');
+		expect(second.chunk).toContain('data-oct-s="1"');
+		expect(second.chunk).toContain('beta');
+		expect(first.at).toBeGreaterThanOrEqual(EARLY - 5); // not before its data
+		expect(first.at).toBeLessThan(LATE - 50); // on the wire while beta still pends
+		expect(second.at).toBeGreaterThanOrEqual(LATE - 5);
+	});
+
+	it('coalesces resolutions landing in the same wave into one chunk/pass', async () => {
+		let ra!: (v: string) => void;
+		let rb!: (v: string) => void;
+		const a = new Promise<string>((r) => (ra = r));
+		const b = new Promise<string>((r) => (rb = r));
+		// Both settle in the SAME event-loop turn → they must share one re-pass
+		// and flush as one chunk, not cost a wave (and a full pass) each.
+		setTimeout(() => {
+			ra('alpha');
+			rb('beta');
+		}, 10);
+		const c = collector();
+		const { pipe } = ServerRT.renderToPipeableStream(server.Siblings, { a, b });
+		pipe(c.dest);
+		await c.ended;
+		expect(c.chunks).toHaveLength(2); // shell + ONE coalesced segment chunk
+		expect(c.chunks[1]).toContain('data-oct-s="0"');
+		expect(c.chunks[1]).toContain('data-oct-s="1"');
+		expect(c.chunks[1]).toContain('alpha');
+		expect(c.chunks[1]).toContain('beta');
+	});
+
 	it('streams a nested boundary parent-first', async () => {
 		const outer = deferred<string>();
 		const inner = deferred<string>();


### PR DESCRIPTION
## What

`runStream` (behind `renderToPipeableStream` / `renderToReadableStream`) settled each round with `Promise.all` over **every** suspended thenable before re-passing. On a staggered data schedule (the streaming-ssr bench: 10 cards resolving at 5, 10, …, 50ms) that held the earliest card's HTML until the slowest sibling landed — card 0 hit the wire at ~51ms in one giant tail chunk (`chunkCount 2`), while React/Solid/Ripple stream it at ~5–6ms.

Rounds are now **waves** (`settleFirstOfWave`):

1. Race the first unresolved thenable to settle.
2. Coalesce everything else that lands in the same event-loop turn: one `setImmediate` yield (`setTimeout(0)` fallback for edge runtimes) plus microtask drains. The macrotask yield is load-bearing — same-deadline timers fire as *separate* callbacks with a full microtask drain between each, so a microtask-only drain would miss the burst and turn the all-fast scenario into one full pass per card.
3. Re-pass, flush newly-done segments, repeat.

`MAX_SUSPENSE_PASSES` in the streaming loop now bounds **consecutive passes that complete no boundary** — one pass per resolution wave is the design, not a runaway, so flushing a segment resets the counter. It still trips on what it exists for: waterfalls deeper than MAX (parity with the buffered bound) and the nondeterministic-key runaway, which never completes its boundary. The per-await `SUSPENSE_TIMEOUT_MS` deadline is unchanged and still guards never-settling thenables.

Buffered `prerender` keeps settle-all (shared guard racing extracted into `raceSettleGuards`): nothing ships until everything resolves there, so one settle per waterfall level is already the fewest passes.

## Tests

Two new tests in `packages/octane/tests/streaming-ssr.test.ts`, real timers by design (the assertion is about wall-clock chunk arrival), generous margins for CI jitter:

- **Chunk timing**: boundaries resolving at 20ms / 250ms must produce shell + two *separate* segment chunks, with the early chunk arriving in [15ms, 200ms] — on the wire long before the late boundary's data resolves. (Old behavior: one tail chunk after 250ms.)
- **Coalescing**: two promises resolved in the same event-loop turn must share one re-pass and flush as one chunk.

All existing streaming/hydration tests pass unchanged, including the out-of-order sibling hydration test — which now exercises genuinely out-of-order segment arrival (`s=1` in an earlier chunk than `s=0`).

## Benchmarks (streaming-ssr, 5 iters/scenario)

| scenario | metric | before | after | React Fizz |
|---|---|---|---|---|
| staggered | chunkCount | 2 | **11** | 12 |
| staggered | totalTime | ~51.3ms | ~50.8ms (schedule-floored) | ~50.9ms |
| staggered | shellTTFB | 0.25ms | **0.18ms** | 0.41ms |
| all-fast | chunkCount | 2 | 2 (coalesced) | 7 |
| all-fast | renders/s | ~656 | ~642 (noise-level) | ~520 |

`ssr-throughput` (buffered path) re-run: unchanged (news-50 octane still ~5x React/Solid, waterfall pass scaling normal).

Note: the streaming-ssr bench suite itself is still uncommitted local work from another session; numbers above came from running it against this branch's runtime.

## Reviewer notes

- The tradeoff is up to one full re-pass per resolution wave instead of one per settle-all round — each wave costs one pass of the whole tree (octane's documented streaming cost model), buying per-boundary delivery latency. The coalescing bounds this: simultaneous resolutions share a pass.
- `pnpm test` (306 files / 2176 passed / 5 expected-fail pins), `pnpm typecheck`, `pnpm format:check` all green. Changeset included (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core streaming SSR timing, abort handling, and pass-limit semantics; behavior change is intentional but could affect chunk ordering and edge cases around concurrent settlements and request cancellation.
> 
> **Overview**
> Streaming SSR (`renderToPipeableStream` / `renderToReadableStream`) no longer waits for **every** suspended `use(thenable)` in a round before re-passing and flushing. **`runStream`** now uses **`settleFirstOfWave`**: race the first settlement, coalesce same-turn siblings via a macrotask yield (`setImmediate` / `setTimeout(0)`) plus microtask drains, re-render, and flush segments—so staggered boundaries ship in separate chunks at their own resolve times while simultaneous resolutions still share one pass/chunk.
> 
> Shared timeout/abort racing is factored into **`raceSettleGuards`**; buffered **`prerender`** still uses **`settleSuspended`** (`Promise.all`). The streaming loop’s **`MAX_SUSPENSE_PASSES`** guard now counts **consecutive** passes with no boundary completed (reset when a segment flushes), and **`signal.throwIfAborted()`** runs after wave coalesce so abort during that window does not flush success segments.
> 
> Tests cover per-boundary chunk timing, same-wave coalescing, and abort-during-coalesce; changeset documents the patch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea99d438af53e7471bc8d3ac73a1a21edbcc24d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->