### PR TITLE
compiler: classify `_`/`$`-prefixed identifier JSX tags as component references

### DIFF
--- a/.changeset/identifier-tag-classification.md
+++ b/.changeset/identifier-tag-classification.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Identifier JSX tags that don't start with a lowercase ASCII letter — `<_Inner/>`, `<$Inner/>` — now compile as component REFERENCES (`createElement(_Inner, …)`), matching JSX semantics (Babel/TS `isCompatTag`). Previously only `/^[A-Z]/` tags were components, so `_`/`$`-prefixed tags miscompiled to host string tags (`createElement('_Inner', …)`) on the client and invalid-tag errors or literal `<_inner>` markup on the server. Lowercase and dashed tags (`<div>`, `<my-element>`) stay host tags.

--- a/packages/mdx/src/compile.ts
+++ b/packages/mdx/src/compile.ts
@@ -19,20 +19,15 @@
  * The only adaptation between the two compilers is `recmaOctaneAdapter`, a tiny
  * ESTree pass over MDX's output:
  *
- *  1. MDX names its body component `_createMdxContent`. octane's JSX lowering
- *     treats an identifier tag as a component only when it starts with an
- *     UPPERCASE letter, so the layout branch's `<_createMdxContent {...props}/>`
- *     would lower to `createElement('_createMdxContent', …)` — a host STRING
- *     tag (JSX semantics say a `_`-starting identifier is a component
- *     reference; Babel/TS agree). The pass renames it to `MDX$CreateMdxContent`.
- *     This is a documented workaround for an octane compiler gap — drop the
- *     rename once `<_Foo/>` compiles as a component reference.
- *  2. MDX's no-layout branch CALLS `_createMdxContent(props)` directly, which
+ *  1. MDX's no-layout branch CALLS `_createMdxContent(props)` directly, which
  *     bypasses octane's `(props, __s, __extra)` component ABI (the server body
  *     would run with `__s === undefined` and lean on scope-recovery). The pass
- *     rewrites the bare call to `<MDX$CreateMdxContent {...props}/>` so both
+ *     rewrites the bare call to `<_createMdxContent {...props}/>` so both
  *     branches mount through the component machinery on client AND server.
- *  3. SERVER mode only: MDX renders markdown elements through its components
+ *     (The layout branch's `<_createMdxContent {...props}/>` tag needs no help:
+ *     octane classifies `_`-starting identifier tags as component references,
+ *     per JSX semantics.)
+ *  2. SERVER mode only: MDX renders markdown elements through its components
  *     mapping — `<_components.h1>` — whose value is a host tag STRING unless
  *     overridden. octane's CLIENT lowering of a member-expression tag is a
  *     `createElement` descriptor, which the runtime's de-opt renderer accepts
@@ -168,10 +163,7 @@ function octaneStage(jsxSource: string, id: string, options: CompileMdxOptions):
 // recmaOctaneAdapter — the ESTree pass described in the module doc.
 // ─────────────────────────────────────────────────────────────────────────────
 
-const MDX_BODY_SOURCE_NAME = '_createMdxContent';
-// Capitalized (octane component tag) + `$` (never produced by MDX's own
-// name-mangling and implausible as a user export from a document).
-const MDX_BODY_NAME = 'MDX$CreateMdxContent';
+const MDX_BODY_NAME = '_createMdxContent';
 
 function recmaOctaneAdapter(options?: { mode?: 'client' | 'server' }) {
 	const server = options?.mode === 'server';
@@ -191,28 +183,20 @@ function isNode(value: unknown): value is EstreeNode {
 // Visit `node` (post-decision, pre-recursion): return a replacement node to
 // swap in (recursed into by the caller), or null to keep the node and recurse.
 function adaptNode(node: EstreeNode, server: boolean): EstreeNode | null {
-	// (2) `_createMdxContent(props)` → `<MDX$CreateMdxContent {...props}/>`.
-	// Matched BEFORE the rename visits the callee identifier below.
+	// (1) `_createMdxContent(props)` → `<_createMdxContent {...props}/>`.
 	if (
 		node.type === 'CallExpression' &&
 		isNode(node.callee) &&
 		node.callee.type === 'Identifier' &&
-		node.callee.name === MDX_BODY_SOURCE_NAME &&
+		node.callee.name === MDX_BODY_NAME &&
 		Array.isArray(node.arguments) &&
 		node.arguments.length <= 1 &&
 		(node.arguments.length === 0 || isNode(node.arguments[0]))
 	) {
 		return jsxSelfClosing(MDX_BODY_NAME, (node.arguments[0] as EstreeNode) ?? null);
 	}
-	// (1) Rename every reference (declaration id, JSX tag, plain identifier).
-	if (
-		(node.type === 'Identifier' || node.type === 'JSXIdentifier') &&
-		node.name === MDX_BODY_SOURCE_NAME
-	) {
-		node.name = MDX_BODY_NAME;
-	}
 	if (server) {
-		// (3) `_components.*` elements in JSX-CHILD position → `{<element/>}`
+		// (2) `_components.*` elements in JSX-CHILD position → `{<element/>}`
 		// expression holes (see module doc). Wrapping edits the PARENT's children
 		// array, so an already-wrapped element (now behind an expression
 		// container) is never re-wrapped.

--- a/packages/mdx/tests/compile.test.ts
+++ b/packages/mdx/tests/compile.test.ts
@@ -15,20 +15,16 @@ describe('compileMdxSync', () => {
 		expect(code).toContain('export default');
 	});
 
-	it('renames MDX body identifiers so no `_`-prefixed component tags remain', () => {
-		// octane compiler gap: a `<_foo/>` identifier tag lowers to a host STRING
-		// tag (JSX semantics make any non-lowercase-start identifier a component
-		// reference) — the recma adapter renames `_createMdxContent` around it.
+	it('mounts the MDX body through the component machinery in both branches', () => {
 		const { code } = compileMdxSync('# hi\n', '/docs/doc.mdx');
-		expect(code).toContain('MDX$CreateMdxContent');
-		expect(code).not.toContain('_createMdxContent');
 		// The no-layout branch mounts through the component machinery (the bare
 		// `_createMdxContent(props)` call was rewritten to JSX and lowered to a
-		// descriptor) — no direct call that would bypass the
+		// descriptor — `<_createMdxContent/>` is a component REFERENCE per JSX
+		// semantics) — no direct call that would bypass the
 		// `(props, __s, __extra)` ABI.
-		expect(code).toContain('_$createElement(MDX$CreateMdxContent');
+		expect(code).toContain('_$createElement(_createMdxContent');
 		// …and the emitted ternary-else direct-call shape is gone.
-		expect(code).not.toContain(': MDX$CreateMdxContent(');
+		expect(code).not.toContain(': _createMdxContent(');
 	});
 
 	it('emits SERVER codegen with mode: server', () => {

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -6000,7 +6000,12 @@ function isComponentTag(node) {
 	// codegen path as `<Foo>` / `<ctx.Provider>`.
 	if (name.type === 'JSXExpressionContainer' && name.isDynamic === true) return true;
 	if (name.type === 'Identifier' || name.type === 'JSXIdentifier') {
-		return typeof name.name === 'string' && /^[A-Z]/.test(name.name);
+		if (typeof name.name !== 'string') return false;
+		// JSX semantics (Babel/TS `isCompatTag`): an identifier tag is a HOST
+		// string tag only when it starts with a lowercase ASCII letter (or isn't
+		// a plain identifier, e.g. `<my-element>`); everything else — `<Foo>`,
+		// `<_Inner>`, `<$Inner>` — is a component REFERENCE.
+		return !/^[a-z]/.test(name.name) && !name.name.includes('-');
 	}
 	return false;
 }

--- a/packages/octane/tests/component-tag-names.test.ts
+++ b/packages/octane/tests/component-tag-names.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { compile } from 'octane/compiler';
+
+// JSX host-vs-component classification for identifier tags. JSX semantics
+// (Babel/TS `isCompatTag`, ESTree) treat an identifier tag as a HOST string
+// tag only when it starts with a lowercase ASCII letter — `_`- and
+// `$`-prefixed identifiers are component REFERENCES: `<_Inner/>` must lower
+// to `createElement(_Inner, …)`, never `createElement('_Inner', …)`.
+
+const client = (src: string): string => compile(src, 'App.tsrx').code;
+const server = (src: string): string => compile(src, 'App.tsrx', { mode: 'server' }).code;
+
+const APP = (tag: string) => `
+  function Inner() @{ <span>{'x'}</span> }
+  export function App() {
+    const ${tag} = Inner;
+    return <${tag}/>;
+  }
+`;
+
+describe('identifier JSX tags — host vs component classification', () => {
+	it('`<_Inner/>` is a component reference in client mode', () => {
+		const out = client(APP('_Inner'));
+		expect(out).toContain('createElement(_Inner,');
+		expect(out).not.toMatch(/['"<]_Inner\b/); // no string tag, no template HTML
+	});
+
+	it('`<_Inner/>` is a component reference in server mode', () => {
+		const out = server(APP('_Inner'));
+		expect(out).toContain('ssrComponent(__s, _Inner,');
+		expect(out).not.toMatch(/['"<]_Inner\b/);
+	});
+
+	it('`<$Inner/>` is a component reference in client mode', () => {
+		const out = client(APP('$Inner'));
+		expect(out).toContain('createElement($Inner,');
+		expect(out).not.toMatch(/['"<]\$Inner/);
+	});
+
+	it('`<$Inner/>` is a component reference in server mode', () => {
+		const out = server(APP('$Inner'));
+		expect(out).toContain('ssrComponent(__s, $Inner,');
+		expect(out).not.toMatch(/['"<]\$Inner/);
+	});
+
+	it('lowercase and dashed tags stay host tags', () => {
+		const src = `export function App() @{ <div><my-element/></div> }`;
+		expect(client(src)).toContain('<my-element>');
+		expect(server(src)).toContain('<my-element>');
+	});
+});


### PR DESCRIPTION
## What changed

`isComponentTag` in `packages/octane/src/compiler/compile.js` classified an identifier JSX tag as a component only when it matched `/^[A-Z]/`. JSX semantics (Babel/TypeScript's `isCompatTag`, ESTree) say an identifier tag is a **host** string tag only when it starts with a lowercase ASCII letter — anything else, including `_`- and `$`-prefixed identifiers, is a component **reference**.

Before this fix, `<_Inner/>` miscompiled in both modes:
- client: `_$template("<_Inner></_Inner>")` — a host template that renders a literal `<_inner>` element
- server: baked into the static HTML string as literal `<_Inner>` markup (or an `Invalid tag: _Inner` throw via `ssrHostElement`'s `VALID_TAG_NAME` guard on non-static paths)

Now both modes emit a component reference: `_$createElement(_Inner, {})` / `_$ssrComponent(__s, _Inner, {})`. Lowercase and dashed tags (`<div>`, `<my-element>`) stay host tags, matching Babel (a dashed tag is not a valid JS identifier, so it can never be a reference).

`isComponentTag` is the single decision point — the client lowering, `jsxElementToCreateElement`, and the server emitter all route through it. I audited the compiler for other case-based host-vs-component checks and found none (the remaining `/^[A-Z]/` uses are event-name and `use[A-Z]` hook detection).

## @octanejs/mdx simplification

The gap was found while building the MDX binding: MDX names its body component `_createMdxContent`, and `recmaOctaneAdapter` renamed it to `MDX$CreateMdxContent` purely to dodge this miscompile. That rename is now dropped. The bare-call→JSX rewrite (`_createMdxContent(props)` → `<_createMdxContent {...props}/>`) is kept — that adaptation exists for octane's `(props, __s, __extra)` component ABI, not for tag classification.

## Tests

- New `packages/octane/tests/component-tag-names.test.ts`: `<_Inner/>` and `<$Inner/>` compile as component references in client and server modes; lowercase/dashed tags remain host tags.
- `packages/mdx/tests/compile.test.ts` updated for the dropped rename (asserts the body mounts via `_$createElement(_createMdxContent, …)` with no direct-call shape).
- Changeset added (`octane` patch).

Full `pnpm test` (312 files, 2205 passed + 5 pre-existing expected fails), `pnpm typecheck`, and `pnpm format:check` are all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the central `isComponentTag` gate used by client and server codegen, so misclassification could affect any JSX with non-lowercase identifier tags; scope is narrow and covered by new tests.
> 
> **Overview**
> **Octane’s JSX lowering** now treats identifier tags as **host** elements only when the name starts with a lowercase ASCII letter and has no dash—aligned with Babel/TS `isCompatTag`. Tags like `<_Inner/>` and `<$Inner/>` compile to component references (`createElement` / `ssrComponent`) instead of string host tags or broken SSR.
> 
> **@octanejs/mdx** drops the `recmaOctaneAdapter` rename from `_createMdxContent` to `MDX$CreateMdxContent`; the bare-call→JSX rewrite for the no-layout branch is unchanged for the component ABI.
> 
> New **`component-tag-names`** tests cover client/server; MDX compile tests expect `_createMdxContent` in emitted code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59c57d31f14acb72efd977c78f103c9f170fa2f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->