### PR TITLE
Render dynamic host-tag strings through componentSlot (client + SSR +…

### DIFF
--- a/.changeset/host-string-tags-component-slot.md
+++ b/.changeset/host-string-tags-component-slot.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Dynamic JSX tags that resolve to a host tag STRING at runtime (`<props.parts.title>` with `{ parts: { title: 'h1' } }`, `<Tag/>` with `const Tag = 'h1'`) now render correctly in template position. Previously the client's `componentSlot` created a block whose body was the string and crashed in `renderBlock` ("not a function"); the server likewise tried to invoke the string. Both now route the string comp through the host-element machinery: the client renders it via the de-opt host renderer (props/refs/events applied, the compiled `children` render-fn mounted as a block inside the element), and the server serializes `<!--[--><tag>…children block…</tag><!--]-->` so hydration adopts the element in place. Same tag across renders patches the element in place; a tag change or a string↔component flip tears down and remounts (React's element-type semantics). Value-position string tags (`.tsx` returns) were already handled and are unchanged.

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -693,7 +693,17 @@ function renderComponentFramed(
 }
 
 /** Render a child component into the string: fresh scope + frame, body → HTML. */
-export function ssrComponent(parent: SSRScope, comp: ServerComponent, props: any): string {
+export function ssrComponent(parent: SSRScope, comp: ServerComponent | string, props: any): string {
+	// A STRING comp: a dynamic JSX tag — `<props.parts.title>`, `<Tag/>` with
+	// `const Tag = 'h1'`, `<{expr}/>` — that resolved to a HOST tag name at
+	// runtime. Serialize the host element inside the SAME one-block range a
+	// component occupies, so the client's componentSlot adopts the range
+	// uniformly on hydration. A `children` render-fn routes through
+	// ssrHostElement → ssrDescriptorContent's function branch into its own inner
+	// block — the shape the client's hostElementBody → childSlot adopts.
+	if (typeof comp === 'string') {
+		return ssrBlock(ssrHostElement(comp, props, props != null ? props.children : null, parent));
+	}
 	const pf = FRAME;
 	// A fresh child frame: its `seg` is the parent's next child index (built into
 	// the path so sibling instances of the same component get distinct keys). `pf`

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -5488,7 +5488,11 @@ interface CompSlot {
 	anchor: Node | null;
 	singleRoot: boolean;
 	block: Block | null;
-	currentComp: ComponentBody | null;
+	// The component identity last rendered: a ComponentBody, or a host tag STRING
+	// (a dynamic JSX tag that resolved to e.g. 'h1' — see the string-comp branch
+	// in componentSlot). Compared with `!==` either way, so 'h1'→'h1' updates in
+	// place while 'h1'→'h2' / string↔function flips tear down and remount.
+	currentComp: ComponentBody | string | null;
 	// Last-render `key` value. Sentinel `NO_KEY` when the slot was created
 	// without a key arg, or when the prior render didn't supply one — so a
 	// first render with `key=undefined` followed by a subsequent render with
@@ -5513,13 +5517,36 @@ export function componentSlot(
 	parentScope: Scope,
 	slotKey: number,
 	domParent: Node,
-	comp: ComponentBody,
+	comp: ComponentBody | string,
 	props: any,
 	anchor?: Node | null,
 	key?: any,
 	singleRoot?: boolean,
 ): void {
 	const parentBlock = parentScope.block;
+	// A STRING comp: a dynamic JSX tag — `<props.parts.title>`, `<Tag/>` with
+	// `const Tag = 'h1'`, `<{expr}/>` — that resolved to a HOST tag name at
+	// runtime. Render it as a host element through the stable de-opt renderer:
+	// the block's body is `hostElementBody` and its props a host DESCRIPTOR
+	// carrying the tag + props + the compiled `children` render-fn (which
+	// hostElementBody's childSlot renders as its own Block). That matches the
+	// server's emission (ssrComponent's string branch → ssrHostElement), so
+	// hydration adopts `<!--[--><tag>…children block…</tag><!--]-->` uniformly.
+	// Identity below still compares the raw `comp` string: same tag → update in
+	// place (props patched, children reconciled); a different tag or a
+	// string↔function flip → tear down + remount (React's element-type reset).
+	let body = comp as ComponentBody;
+	let renderProps = props;
+	if (typeof comp === 'string') {
+		body = hostElementBody as unknown as ComponentBody;
+		renderProps = {
+			$$kind: ELEMENT_TAG,
+			type: comp,
+			props,
+			key: null,
+			children: props != null ? props.children : null,
+		} satisfies ElementDescriptor;
+	}
 	let state = parentScope.slots[slotKey] as CompSlot | undefined;
 	if (state === undefined) {
 		let start: Comment | null;
@@ -5600,7 +5627,7 @@ export function componentSlot(
 				// pair sits exactly where the old range was — no DOM move needed. We rename
 				// the comments rather than replacing them: descendant slots inside the WIP
 				// (e.g. a return-slot childSlot) may anchor on `wip.end`, so it must survive.
-				const r = renderOffscreen(parentBlock, domParent, state.end, comp, props);
+				const r = renderOffscreen(parentBlock, domParent, state.end, body, renderProps);
 				if (r.suspended || r.error) {
 					disposeWip(r.wip);
 					if (r.error) throw r.error;
@@ -5625,7 +5652,7 @@ export function componentSlot(
 			// then fall through to the legacy singleRoot swap below.
 			const probeAfter = state.end ?? state.anchor;
 			if (probeAfter !== null) {
-				const r = renderOffscreen(parentBlock, domParent, probeAfter, comp, props);
+				const r = renderOffscreen(parentBlock, domParent, probeAfter, body, renderProps);
 				disposeWip(r.wip);
 				if (r.error) throw r.error;
 				if (r.suspended) throw new SuspenseException(r.suspended);
@@ -5664,7 +5691,15 @@ export function componentSlot(
 			// nothing, so we leave start/end null and unmountBlock no-ops for it
 			// (rather than capturing a stale sibling).
 			const before = state.anchor ? state.anchor.previousSibling : domParent.lastChild;
-			const b = createBlock('dynamic', parentBlock, domParent, null, state.anchor, comp, props);
+			const b = createBlock(
+				'dynamic',
+				parentBlock,
+				domParent,
+				null,
+				state.anchor,
+				body,
+				renderProps,
+			);
 			state.block = b;
 			try {
 				renderBlock(b);
@@ -5676,15 +5711,24 @@ export function componentSlot(
 				}
 			}
 		} else {
-			const b = createBlock('dynamic', parentBlock, domParent, state.start, state.end, comp, props);
+			const b = createBlock(
+				'dynamic',
+				parentBlock,
+				domParent,
+				state.start,
+				state.end,
+				body,
+				renderProps,
+			);
 			state.block = b;
 			renderBlock(b);
 		}
 	} else if (state.block) {
 		// `memo(Component)` — skip the body when new props shallow-equal the
-		// committed props (React.memo's contract; see tryMemoBail).
+		// committed props (React.memo's contract; see tryMemoBail). A string comp
+		// is never memo-wrapped, so it falls through to the re-render below.
 		if (tryMemoBail(state.block, comp, props)) return;
-		state.block.props = props;
+		state.block.props = renderProps;
 		renderBlock(state.block);
 	}
 	// Hydration: advance the cursor PAST this component's adopted range so the next

--- a/packages/octane/tests/_fixtures/host-string-tag-diff.tsrx
+++ b/packages/octane/tests/_fixtures/host-string-tag-diff.tsrx
@@ -1,0 +1,25 @@
+import { useState } from 'octane';
+
+// Differential fixture: JSX tags that resolve to a HOST tag STRING at runtime
+// (React renders these natively via createElement(tag); Octane's componentSlot
+// must produce byte-identical HTML through the de-opt host path).
+
+export function TagSwitcher() @{
+	const [tag, setTag] = useState('h1');
+	const [n, setN] = useState(0);
+	const Tag = tag;
+	<div class="wrap">
+		<button id="flip" onClick={() => setTag(tag === 'h1' ? 'h2' : 'h1')}>{'flip'}</button>
+		<button id="bump" onClick={() => setN(n + 1)}>{'bump'}</button>
+		<Tag id="t" class={'c' + n}>{`n:${n}`}</Tag>
+		<span class="after">{'after'}</span>
+	</div>
+}
+
+export function MemberTag(props) @{
+	<div class="wrap">
+		<props.parts.title id="t">
+			{props.text as string}
+		</props.parts.title>
+	</div>
+}

--- a/packages/octane/tests/differential/host-string-tag.test.ts
+++ b/packages/octane/tests/differential/host-string-tag.test.ts
@@ -1,0 +1,44 @@
+import { describe, it } from 'vitest';
+import { mountDifferential } from './_rig.js';
+import { resolve } from 'node:path';
+
+// Differential pin for JSX tags that resolve to a HOST tag STRING at runtime
+// (`<Tag/>` with `const Tag = 'h1'`, `<props.parts.title>`). React renders
+// these natively (createElement('h1')); Octane routes them through
+// componentSlot's string-comp branch → the de-opt host renderer. The DOM must
+// match byte-for-byte across mount, in-place updates, and tag flips.
+
+const FIXTURE = resolve(__dirname, '../_fixtures/host-string-tag-diff.tsrx');
+
+describe('differential: host-string-tag-diff.tsrx', () => {
+	it('TagSwitcher: mount, update in place, flip tag, update again', async () => {
+		const d = await mountDifferential(FIXTURE, 'TagSwitcher');
+		await d.step('mount (h1, n:0)', () => {});
+		await d.step('bump → n:1 patched in place', async (i, r) => {
+			await i.click('#bump');
+			await r.click('#bump');
+		});
+		await d.step('flip → h2 replaces h1', async (i, r) => {
+			await i.click('#flip');
+			await r.click('#flip');
+		});
+		await d.step('bump after flip → h2 patched', async (i, r) => {
+			await i.click('#bump');
+			await r.click('#bump');
+		});
+		await d.step('flip back → h1', async (i, r) => {
+			await i.click('#flip');
+			await r.click('#flip');
+		});
+		d.unmount();
+	});
+
+	it('MemberTag: member-expression tag renders the host element', async () => {
+		const d = await mountDifferential(FIXTURE, 'MemberTag', {
+			parts: { title: 'h3' },
+			text: 'Hi',
+		});
+		await d.step('mount (h3)', () => {});
+		d.unmount();
+	});
+});

--- a/packages/octane/tests/hydration/_fixtures/host-string-tag.tsrx
+++ b/packages/octane/tests/hydration/_fixtures/host-string-tag.tsrx
@@ -1,0 +1,44 @@
+// Template-position JSX tags that resolve to a HOST tag STRING at runtime —
+// a member expression (`<props.parts.title>`), a variable (`<Tag/>` with
+// `const Tag = 'h1'`), or a string↔component flip. The compiler can't know the
+// tag statically, so these lower to componentSlot; the runtime must render the
+// string comp as a host element (client) / serialize it host-style (server).
+
+export function Card(props) @{
+	<div id="card">
+		<props.parts.title id="t" class={props.klass}>
+			{props.text as string}
+		</props.parts.title>
+	</div>
+}
+
+export function Counter(props) @{
+	const [n, setN] = useState(0);
+	<button id="counter" onClick={() => setN(n + 1)}>{`count:${n}`}</button>
+}
+
+// Variable tag wrapping a component child — the children render-fn must mount
+// the component as a real Block inside the dynamic host element.
+export function Wrap(props) @{
+	const Tag = props.tag;
+	<section id="wrap">
+		<Tag id="inner">
+			<Counter />
+		</Tag>
+	</section>
+}
+
+// Dynamic tag with events + ref on the tag itself.
+export function Clicky(props) @{
+	const Tag = props.tag;
+	<div id="cl">
+		<Tag id="btn" ref={props.tagRef} onClick={props.onPick}>{'pick'}</Tag>
+	</div>
+}
+
+// Childless dynamic tag (void-element friendly on the server).
+export function Bare(props) @{
+	<div id="bare">
+		<props.tag data-x="1" />
+	</div>
+}

--- a/packages/octane/tests/hydration/host-string-tag-hydrate.test.ts
+++ b/packages/octane/tests/hydration/host-string-tag-hydrate.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { compile } from 'octane/compiler';
+import { createRoot, hydrateRoot, flushSync } from '../../src/index.js';
+import * as ServerRT from 'octane/server';
+import { Card, Wrap, Clicky, Bare } from './_fixtures/host-string-tag.tsrx';
+
+// Template-position dynamic tags that resolve to a HOST tag STRING at runtime
+// (`<props.parts.title>`, `<Tag/>` with `const Tag = 'h1'`). These lower to
+// componentSlot; the runtime renders the string comp as a host element via the
+// de-opt host machinery (hostElementBody) — mirroring the server's
+// `<!--[--><tag>…children block…</tag><!--]-->` emission so hydration adopts.
+
+const FIXTURE = join(
+	process.cwd(),
+	'packages/octane/tests/hydration/_fixtures/host-string-tag.tsrx',
+);
+function serverModule(): Record<string, any> {
+	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'host-string-tag.tsrx', {
+		mode: 'server',
+	});
+	code = code.replace(
+		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
+	);
+	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
+	const fn = new Function('__rt', '__exports', code + '\nreturn __exports;');
+	return fn(ServerRT, {});
+}
+const server = serverModule();
+
+let container: HTMLElement;
+beforeEach(() => {
+	container = document.createElement('div');
+	document.body.appendChild(container);
+});
+afterEach(() => container.remove());
+
+function mount(body: any, props?: any) {
+	const root = createRoot(container);
+	root.render(body, props);
+	flushSync(() => {});
+	return root;
+}
+
+describe('host string tags — client mount', () => {
+	it('renders a member-expression tag as a host element with props + text child', () => {
+		const root = mount(Card, { parts: { title: 'h1' }, text: 'Hi', klass: 'big' });
+		const t = container.querySelector('#card > h1#t') as HTMLElement;
+		expect(t).not.toBeNull();
+		expect(t.textContent).toBe('Hi');
+		expect(t.className).toBe('big');
+		root.unmount();
+	});
+
+	it('renders a component child inside a variable host tag, interactive', () => {
+		const root = mount(Wrap, { tag: 'article' });
+		const btn = container.querySelector('#wrap > article#inner button#counter')!;
+		expect(btn.textContent).toBe('count:0');
+		flushSync(() => (btn as HTMLButtonElement).click());
+		expect(btn.textContent).toBe('count:1');
+		root.unmount();
+	});
+
+	it('renders a childless dynamic tag', () => {
+		const root = mount(Bare, { tag: 'hr' });
+		expect(container.querySelector('#bare > hr')).not.toBeNull();
+		root.unmount();
+	});
+
+	it('fires delegated events and attaches/detaches the ref on the dynamic tag', () => {
+		const seen: (Element | null)[] = [];
+		let picked = 0;
+		const root = mount(Clicky, {
+			tag: 'button',
+			tagRef: (el: Element | null) => seen.push(el),
+			onPick: () => picked++,
+		});
+		const btn = container.querySelector('#cl > button#btn') as HTMLButtonElement;
+		expect(seen).toEqual([btn]);
+		flushSync(() => btn.click());
+		expect(picked).toBe(1);
+		root.unmount();
+		expect(seen).toEqual([btn, null]);
+	});
+});
+
+describe('host string tags — updates', () => {
+	it('same tag string → patches the SAME element in place (props + text)', () => {
+		const root = createRoot(container);
+		root.render(Card, { parts: { title: 'h1' }, text: 'a', klass: 'x' });
+		flushSync(() => {});
+		const el = container.querySelector('#t') as HTMLElement;
+		expect(el.tagName).toBe('H1');
+		root.render(Card, { parts: { title: 'h1' }, text: 'b', klass: 'y' });
+		flushSync(() => {});
+		expect(container.querySelector('#t')).toBe(el); // reused, not remounted
+		expect(el.textContent).toBe('b');
+		expect(el.className).toBe('y');
+		root.unmount();
+	});
+
+	it('tag flip h1 → h2 → remounts the element (fresh children state)', () => {
+		const root = createRoot(container);
+		root.render(Wrap, { tag: 'h1' });
+		flushSync(() => {});
+		const btn = container.querySelector('#wrap > h1 #counter') as HTMLButtonElement;
+		flushSync(() => btn.click());
+		expect(btn.textContent).toBe('count:1');
+		root.render(Wrap, { tag: 'h2' });
+		flushSync(() => {});
+		expect(container.querySelector('#wrap > h1')).toBeNull();
+		const btn2 = container.querySelector('#wrap > h2 #counter') as HTMLButtonElement;
+		expect(btn2).not.toBe(btn);
+		// React element-type semantics: the children remounted with fresh state.
+		expect(btn2.textContent).toBe('count:0');
+		root.unmount();
+	});
+
+	it('flips string → component → string', () => {
+		const AsComp = (props: any, scope: any) => {
+			// A plain runtime component: render its children body directly.
+			(props.children as any)(undefined, scope, undefined);
+		};
+		const root = createRoot(container);
+		root.render(Card, { parts: { title: 'em' }, text: 'x' });
+		flushSync(() => {});
+		expect(container.querySelector('#card > em#t')).not.toBeNull();
+		root.render(Card, { parts: { title: AsComp }, text: 'x' });
+		flushSync(() => {});
+		// The component renders only the children text — no host wrapper.
+		expect(container.querySelector('#card > em')).toBeNull();
+		expect(container.querySelector('#card')!.textContent).toBe('x');
+		root.render(Card, { parts: { title: 'strong' }, text: 'x' });
+		flushSync(() => {});
+		expect(container.querySelector('#card > strong#t')!.textContent).toBe('x');
+		root.unmount();
+	});
+
+	it('moves a ref between elements on tag flip', () => {
+		const log: (string | null)[] = [];
+		const ref = (el: Element | null) => log.push(el === null ? null : el.tagName);
+		const root = createRoot(container);
+		root.render(Clicky, { tag: 'b', tagRef: ref, onPick: () => {} });
+		flushSync(() => {});
+		expect(log).toEqual(['B']);
+		root.render(Clicky, { tag: 'i', tagRef: ref, onPick: () => {} });
+		flushSync(() => {});
+		expect(log).toEqual(['B', null, 'I']);
+		root.unmount();
+	});
+});
+
+describe('host string tags — hydration', () => {
+	it('SSR emits the host element inside one component block range', async () => {
+		const { html } = await ServerRT.renderToString(server.Card, {
+			parts: { title: 'h1' },
+			text: 'Hi',
+			klass: 'big',
+		});
+		// One component block range wraps the host element; the children render-fn
+		// output carries its own inner block (the shape hostElementBody's childSlot
+		// adopts on the client).
+		expect(html).toContain(
+			'<div id="card"><!--[--><h1 id="t" class="big"><!--[-->Hi<!--]--></h1><!--]--></div>',
+		);
+	});
+
+	it('adopts the server host element + text (no rebuild)', async () => {
+		const props = { parts: { title: 'h1' }, text: 'Hi', klass: 'big' };
+		const { html } = await ServerRT.renderToString(server.Card, props);
+		container.innerHTML = html;
+		const el = container.querySelector('#t') as HTMLElement;
+		const root = hydrateRoot(container, Card, props);
+		flushSync(() => {});
+		expect(container.querySelector('#t')).toBe(el); // adopted, not rebuilt
+		expect(el.textContent).toBe('Hi');
+		root.unmount();
+	});
+
+	it('adopts a component child inside the dynamic host and keeps it interactive', async () => {
+		const { html } = await ServerRT.renderToString(server.Wrap, { tag: 'article' });
+		expect(html).toContain('count:0');
+		container.innerHTML = html;
+		const inner = container.querySelector('#inner') as HTMLElement;
+		const btn = container.querySelector('#counter') as HTMLButtonElement;
+		const root = hydrateRoot(container, Wrap, { tag: 'article' });
+		flushSync(() => {});
+		expect(container.querySelector('#inner')).toBe(inner); // adopted host element
+		expect(container.querySelector('#counter')).toBe(btn); // adopted component DOM
+		flushSync(() => btn.click());
+		expect(btn.textContent).toBe('count:1');
+		root.unmount();
+	});
+
+	it('attaches the ref + events to the ADOPTED element', async () => {
+		const seen: (Element | null)[] = [];
+		let picked = 0;
+		const { html } = await ServerRT.renderToString(server.Clicky, { tag: 'button' });
+		container.innerHTML = html;
+		const btn = container.querySelector('#btn') as HTMLButtonElement;
+		const root = hydrateRoot(container, Clicky, {
+			tag: 'button',
+			tagRef: (el: Element | null) => seen.push(el),
+			onPick: () => picked++,
+		});
+		flushSync(() => {});
+		expect(seen).toEqual([btn]);
+		flushSync(() => btn.click());
+		expect(picked).toBe(1);
+		root.unmount();
+	});
+
+	it('updates after hydration: same-tag patch, then tag flip remount', async () => {
+		const { html } = await ServerRT.renderToString(server.Card, {
+			parts: { title: 'h1' },
+			text: 'a',
+			klass: 'x',
+		});
+		container.innerHTML = html;
+		const el = container.querySelector('#t') as HTMLElement;
+		const root = hydrateRoot(container, Card, { parts: { title: 'h1' }, text: 'a', klass: 'x' });
+		flushSync(() => {});
+		root.render(Card, { parts: { title: 'h1' }, text: 'b', klass: 'y' });
+		flushSync(() => {});
+		expect(container.querySelector('#t')).toBe(el); // adopted element patched in place
+		expect(el.textContent).toBe('b');
+		expect(el.className).toBe('y');
+		root.render(Card, { parts: { title: 'h3' }, text: 'c', klass: 'y' });
+		flushSync(() => {});
+		expect(container.querySelector('#card > h3#t')!.textContent).toBe('c');
+		expect(container.querySelector('#card > h1')).toBeNull();
+		root.unmount();
+	});
+
+	it('hydrates a childless dynamic (void) tag', async () => {
+		const { html } = await ServerRT.renderToString(server.Bare, { tag: 'hr' });
+		container.innerHTML = html;
+		const hr = container.querySelector('#bare > hr');
+		expect(hr).not.toBeNull();
+		const root = hydrateRoot(container, Bare, { tag: 'hr' });
+		flushSync(() => {});
+		expect(container.querySelector('#bare > hr')).toBe(hr);
+		root.unmount();
+	});
+});

--- a/packages/octane/tests/ssr-host-string-tags.test.ts
+++ b/packages/octane/tests/ssr-host-string-tags.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { compile } from 'octane/compiler';
+import * as RT from 'octane/server';
+
+// SSR of JSX tags that resolve to a HOST tag STRING at runtime. Two regimes:
+//   - TEMPLATE position (`@{ … }` body): `<props.parts.title>` lowers to
+//     `ssrComponent(__s, props.parts.title, …)` — the string branch serializes
+//     the host element inside the component's one-block range, so the client's
+//     componentSlot adopts it uniformly on hydration.
+//   - VALUE position (`.tsx` return / `{expr}` hole): the de-opt descriptor
+//     path (`ssrChild` → `ssrHostElement`) — already string-aware.
+
+const FIXTURE = join(
+	process.cwd(),
+	'packages/octane/tests/hydration/_fixtures/host-string-tag.tsrx',
+);
+
+function evalServer(source: string, file: string): Record<string, any> {
+	let { code } = compile(source, file, { mode: 'server' });
+	code = code.replace(
+		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
+	);
+	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
+	const fn = new Function('__rt', '__exports', code + '\nreturn __exports;');
+	return fn(RT, {});
+}
+
+const mod = evalServer(readFileSync(FIXTURE, 'utf8'), 'host-string-tag.tsrx');
+
+describe('SSR host string tags — template position', () => {
+	it('serializes a member-expression tag as a host element in one block range', async () => {
+		const { html } = await RT.renderToString(mod.Card, {
+			parts: { title: 'h1' },
+			text: 'Hi',
+			klass: 'big',
+		});
+		expect(html).toBe(
+			'<div id="card"><!--[--><h1 id="t" class="big"><!--[-->Hi<!--]--></h1><!--]--></div>',
+		);
+	});
+
+	it('serializes a variable tag wrapping a component child (nested block)', async () => {
+		const { html } = await RT.renderToString(mod.Wrap, { tag: 'article' });
+		expect(html).toContain('<article id="inner">');
+		expect(html).toContain('count:0');
+		// The component child inside the dynamic host carries its own block range.
+		expect(html).toMatch(/<article id="inner"><!--\[-->.*<!--\]--><\/article>/);
+	});
+
+	it('serializes a childless dynamic VOID tag self-closed', async () => {
+		const { html } = await RT.renderToString(mod.Bare, { tag: 'hr' });
+		expect(html).toBe('<div id="bare"><!--[--><hr data-x="1"/><!--]--></div>');
+	});
+
+	it('drops event/ref props from the serialized element', async () => {
+		const { html } = await RT.renderToString(mod.Clicky, { tag: 'button' });
+		expect(html).toContain('<button id="btn">');
+		expect(html).not.toContain('onPick');
+		expect(html).not.toContain('onClick');
+		expect(html).not.toContain('ref=');
+	});
+
+	it('emits NO hydration markers under renderToStaticMarkup', async () => {
+		const { html } = await RT.renderToStaticMarkup(mod.Card, {
+			parts: { title: 'h2' },
+			text: 'Hi',
+			klass: null,
+		});
+		expect(html).toBe('<div id="card"><h2 id="t">Hi</h2></div>');
+	});
+
+	it('rejects an invalid (markup-injecting) tag like React', async () => {
+		await expect(async () =>
+			RT.renderToString(mod.Card, {
+				parts: { title: 'div><img src=x onerror=alert(1)>' },
+				text: 'x',
+			}),
+		).rejects.toThrow(/Invalid tag/);
+	});
+});


### PR DESCRIPTION
… hydration)

A template-position JSX tag that resolves to a host tag STRING at runtime (<props.parts.title> with { parts: { title: 'h1' } }, <Tag/> with const Tag = 'h1') lowers to componentSlot, which created a 'dynamic' block whose body was the string — renderBlock's block.body(...) then threw "not a function" on both fresh mounts and hydration. The server's ssrComponent likewise tried to invoke the string.

Client: componentSlot now routes a string comp through the existing de-opt host renderer — body = hostElementBody, props = a host ElementDescriptor carrying the tag + props + the compiled children render-fn — so prop diffing, delegated events, commit-phase refs, and hydration adoption all come from the proven machinery. Identity still compares the raw string: same tag patches the element in place; a tag change or string<->function flip tears down and remounts (React's element-type reset). The transition off-screen (WIP) paths are rerouted too so they can't invoke the string.

Server: ssrComponent serializes a string comp as
<!--[--><tag>...children block...</tag><!--]--> via ssrBlock(ssrHostElement), the exact shape the client's componentSlot + hostElementBody adopt on hydration (VALID_TAG_NAME still rejects injection-unsafe tags).

Tests: client mount/update/hydration (hydration/host-string-tag-hydrate), SSR shapes (ssr-host-string-tags), and a differential fixture proving byte-equal HTML vs real React across mount, in-place bumps, and tag flips.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `componentSlot` and `ssrComponent` reconciliation/hydration paths, but the change is a narrow branch for string comps reusing existing host machinery; value-position behavior is unchanged.
> 
> **Overview**
> **Template-position JSX** whose tag is a **runtime host string** (`<Tag/>` with `Tag = 'h1'`, `<props.parts.title>`, etc.) no longer crashes: `componentSlot` / `ssrComponent` used to treat the tag string as a component body and fail with **"not a function"**.
> 
> **Client:** When `comp` is a string, `componentSlot` routes through the existing **de-opt host** path (`hostElementBody` + an `ElementDescriptor`), including WIP/off-screen transition renders. Slot identity still uses the raw tag string—**same tag** patches in place; **tag change** or **string ↔ component** remounts like React.
> 
> **Server:** `ssrComponent` serializes string comps as `<!--[--><tag>…children…</tag><!--]-->` via `ssrHostElement`, matching what hydration adopts.
> 
> **Tests:** Hydration, SSR markup, and React differential coverage for mount, updates, tag flips, refs/events, and nested component children.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d44629adfd9f4fd0316034b4dd02acb4ba39a5d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->