### PR TITLE
compiler: emit real sourcemap segments for return-JSX functions

### DIFF
--- a/.changeset/return-jsx-sourcemap-segments.md
+++ b/.changeset/return-jsx-sourcemap-segments.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+compiler: return-JSX functions now contribute real sourcemap segments. `compileReturnJsxFunction` prints via `printNodeWithMap` and threads esrap's per-token mappings into the module map (adjusted for inlined directive helpers and export wrappers), so chained maps over compiled output — e.g. @octanejs/mdx's two-stage `.mdx` map — compose instead of falling back to the intermediate-JSX map.

--- a/.changeset/ssr-return-fragment-value-lowering.md
+++ b/.changeset/ssr-return-fragment-value-lowering.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+SSR: a return-JSX component returning a FRAGMENT (`function Doc() { return <>…</>; }`) now serializes hydration-compatibly. The client value-lowers the returned fragment to a descriptor array mounted by the return-slot `childSlot` — one slot range plus one `<!--[-->…<!--]-->` block per item (text items included) — but the server's template walk concatenated the children with markerless text separators and no slot range, so `hydrateRoot` silently rebuilt (duplicated) the content instead of adopting it. The server compiler now routes value-position returned fragments through `ssrChild([...])` over the same descriptor array, making server output byte-adoptable by the client. Single-element returns, `@{}` template bodies, and value holes are unchanged.

--- a/docs/mdx-migration-plan.md
+++ b/docs/mdx-migration-plan.md
@@ -15,10 +15,11 @@ never silently paper over it.
 > (byte-adoption tests, on top of the two octane gap fixes below), SSR provider
 > context (`@octanejs/mdx/server`), Shiki recipe + integration tests, `.mdx`
 > fast refresh, `.md` default-on + asset-query passthrough, and chained
-> two-stage sourcemaps (machinery landed; composes fully once octane maps
-> return-JSX functions — pinned `it.fails`). Both octane gaps below are fixed
+> two-stage sourcemaps (composes fully — octane gap 4 fixed, generated
+> positions trace back to `.mdx` lines). All octane gaps below are fixed
 > (`ssrComponent` host-string tags; server value-lowering of returned
-> fragments), and the adapter is down to ONE fixup. mdx suite: 51 tests.**
+> fragments; return-JSX sourcemap segments), and the adapter is down to ONE
+> fixup. mdx suite: 51 tests.**
 >
 > Phase 0 — the full pipeline + provider layer landed (2026-07). Green: 25
 > tests (compile shape, markdown/GFM/`.md` rendering, embedded `.tsrx`
@@ -114,11 +115,12 @@ Former adaptations, dropped as their octane gaps were fixed:
    separators and no slot range — silently duplicating content on hydrate. The
    server compiler now routes value-position returned fragments through
    `ssrChild([...])` (compile.js `ssrCompileBody`), byte-aligning both sides.
-4. **OPEN (octane compiler, chip filed) — `compileReturnJsxFunction` emits no
-   sourcemap segments** (map-less `printNode`), so the two-stage .mdx map
-   chain composes to empty for document bodies; the pipeline falls back to
-   octane's intermediate-JSX map. Pinned: `tests/sourcemap.test.ts`
-   (`it.fails`) auto-flips when fixed.
+4. **FIXED — `compileReturnJsxFunction` emitted no sourcemap segments**
+   (map-less `printNode`), so the two-stage .mdx map chain composed to empty
+   for document bodies. It now prints via `printNodeWithMap` and threads
+   esrap's real segments back through the module map (compile.js), so the
+   chain composes and generated positions trace to `.mdx` lines
+   (`tests/sourcemap.test.ts`).
 
 ## API coverage vs @mdx-js/react
 
@@ -171,7 +173,7 @@ Mounted with `@octanejs/testing-library` (dogfooded, workspace dep):
 - `vite.test.ts` — plugin id claiming: `.md` default-on, `md: false`, asset
   queries (`?raw`/`?url`/`?inline`) pass through, bookkeeping queries don't.
 - `sourcemap.test.ts` — two-stage map: valid v3 output naming the document;
-  the full chain pinned `it.fails` on octane gap 4.
+  the full chain traces generated positions back to `.mdx` lines.
 
 ## Open design questions — RESOLVED (2026-07-06)
 
@@ -209,10 +211,9 @@ All six answered; details below for the record.
   asset queries (`?raw`, `?url`, `?inline`, workers) now pass through
   untouched (vite's asset plugin owns them), while vite-internal bookkeeping
   queries (`?v=`, `?used`, `?import`) still transform. Tested.
-- **Sourcemaps — machinery DONE, full fidelity blocked on octane gap 4.**
-  @mdx-js/mdx emits stage-one (via `source-map`'s `SourceMapGenerator`);
-  octane emits stage-two; `@jridgewell/remapping` composes. Today the chain
-  is empty for real documents (gap 4), so the pipeline keeps octane's
-  intermediate-JSX map as the fallback; the chained path activates by itself
-  (guarded on non-empty mappings) once octane maps return-JSX functions —
-  chip filed, `it.fails` pinned.
+- **Sourcemaps — DONE.** @mdx-js/mdx emits stage-one (via `source-map`'s
+  `SourceMapGenerator`); octane emits stage-two; `@jridgewell/remapping`
+  composes. With octane gap 4 fixed (return-JSX functions map via
+  `printNodeWithMap`), the chain composes for real documents and generated
+  positions trace back to `.mdx` lines; the non-empty guard stays as a
+  defensive fallback to octane's intermediate-JSX map.

--- a/docs/mdx-migration-plan.md
+++ b/docs/mdx-migration-plan.md
@@ -11,10 +11,19 @@ never silently paper over it.
 
 ## Progress (reverse-chronological)
 
-> **Phase 0 — the full pipeline + provider layer landed (2026-07). Green: 25
+> **Phase 1 — all six open questions resolved (2026-07-06): hydration
+> (byte-adoption tests, on top of the two octane gap fixes below), SSR provider
+> context (`@octanejs/mdx/server`), Shiki recipe + integration tests, `.mdx`
+> fast refresh, `.md` default-on + asset-query passthrough, and chained
+> two-stage sourcemaps (machinery landed; composes fully once octane maps
+> return-JSX functions — pinned `it.fails`). Both octane gaps below are fixed
+> (`ssrComponent` host-string tags; server value-lowering of returned
+> fragments), and the adapter is down to ONE fixup. mdx suite: 51 tests.**
+>
+> Phase 0 — the full pipeline + provider layer landed (2026-07). Green: 25
 > tests (compile shape, markdown/GFM/`.md` rendering, embedded `.tsrx`
 > components, provider semantics, frontmatter, SSR renderToString), full
-> monorepo suite 2200 green, typecheck + format clean.**
+> monorepo suite 2200 green, typecheck + format clean.
 
 ## Architecture — compile, don't interpret
 
@@ -25,22 +34,25 @@ exactly the React-style `.tsx` dialect octane's compiler already handles, so:
 
 ```
 .mdx / .md
-  → @mdx-js/mdx compile({ jsx: true, providerImportSource: '@octanejs/mdx', … })   (JSX/ESM source)
-  → recmaOctaneAdapter                                                             (3 small ESTree fixups, below)
-  → octane/compiler compile(source, id, { mode: 'client' | 'server' })             (real octane codegen)
+  → @mdx-js/mdx compile({ jsx: true, SourceMapGenerator, providerImportSource, … })  (JSX/ESM source)
+  → recmaOctaneAdapter                                                               (1 small ESTree fixup, below)
+  → octane/compiler compile(source, id, { mode: 'client' | 'server' })               (real octane codegen)
 ```
+
+(`providerImportSource` defaults per mode: `@octanejs/mdx` client,
+`@octanejs/mdx/server` server — each runtime's own context store.)
 
 What each MDX construct becomes under octane's `.tsx` handling:
 
 - `_createMdxContent(props)` (the document body, `return <>…</>`) — a
   return-JSX function: octane compiles it to the `(props, __s, __extra)` ABI;
   the fragment return value-lowers to an array of `createElement` descriptors
-  (client) / `ssrComponent`+`ssrChild` string building (server). A single-root
-  document lowers to one descriptor.
+  (client) / `ssrChild([...])` over the same descriptor array (server) — one
+  slot range + one block per item, the shape hydration adopts.
 - `<_components.h1>` member tags (markdown elements via the mapping, value
   `"h1"` unless overridden) — component-tagged elements whose runtime value may
-  be a host tag STRING; handled by the client de-opt renderer (and see gap 2
-  for the server).
+  be a host tag STRING; the client de-opt renderer and the server's
+  `ssrComponent`/`ssrChild` both render string comps in the same block shape.
 - `MDXContent` (the default export, `return MDXLayout ? <MDXLayout…> : …`) — a
   passthrough function; its value-position JSX lowers to descriptors, and
   `renderBlock`/`renderComponentFramed` mount/normalize the returned
@@ -58,45 +70,55 @@ What each MDX construct becomes under octane's `.tsx` handling:
   from `octane/compiler/vite` — composes with the octane plugin with no
   ordering hazard (disjoint extensions).
 - `packages/mdx/src/index.ts` — the @mdx-js/react port: `MDXProvider`,
-  `useMDXComponents`, `MDXComponents` types.
+  `useMDXComponents`, `MDXComponents` types (client runtime context).
+- `packages/mdx/src/server.ts` — the same provider layer mirrored onto
+  `octane/server` context for SSR passes (keep merge semantics in lockstep
+  with index.ts).
 
 ## recmaOctaneAdapter — the two-compiler adaptations
 
-All three are small ESTree fixups over MDX's emitted program, each tied to an
-octane gap or ABI difference and revertible:
+Down to ONE small ESTree fixup over MDX's emitted program (an ABI difference,
+not a gap): **rewrite the bare `_createMdxContent(props)` call to
+`<_createMdxContent {...props}/>`.** The direct call bypasses the
+`(props, __s, __extra)` ABI (the server body would run on `__s === undefined`
+scope recovery); as JSX both layout branches mount through the component
+machinery on client and server.
 
-1. **Rename `_createMdxContent` → `MDX$CreateMdxContent`.** octane's JSX
-   lowering treats identifier tags as components only when `/^[A-Z]/` —
-   `<_createMdxContent/>` lowers to a host STRING tag (gap 1 below).
-2. **Rewrite the bare `_createMdxContent(props)` call to
-   `<MDX$CreateMdxContent {...props}/>`.** The direct call bypasses the
-   `(props, __s, __extra)` ABI (the server body would run on `__s === undefined`
-   scope recovery); as JSX both layout branches mount through the component
-   machinery on client and server.
-3. **Server mode only: wrap `_components.*` elements in JSX-child position in
-   expression containers** (`{<_components.h1>…</_components.h1>}`), routing
-   them through the server's VALUE hole (`ssrChild(createElement(…))`), which
-   accepts string tags — `ssrComponent` does not (gap 2 below).
+Former adaptations, dropped as their octane gaps were fixed:
 
-## octane gaps hit (fix in octane, then simplify here)
+- ~~Rename `_createMdxContent` (a `_`-prefixed identifier tag compiled as a
+  host string tag)~~ — fixed in octane: `isComponentTag` classifies `_`/`$`-
+  prefixed identifier tags as component references, per JSX semantics.
+- ~~Server mode: wrap `_components.*` elements in expression containers~~ —
+  fixed in octane (both halves, 2026-07-06): `ssrComponent` renders a
+  host-tag-STRING comp as the `<!--[--><tag>…</tag><!--]-->` block the client's
+  componentSlot/de-opt renderer adopts, and the server compiler value-lowers a
+  RETURNED FRAGMENT through `ssrChild([...])` — the exact per-item block shape
+  (text items included) the client's return-slot childSlot adopts on
+  hydration. Both sides now take the same shape from the same source.
 
-1. **`<_foo/>` / `<$foo/>` identifier tags compile as host string tags.** JSX
-   semantics (Babel, TypeScript): only `/^[a-z]/`-starting identifiers are
-   intrinsics; `_`/`$`-starting identifiers are component references.
-   `isComponentTag` (packages/octane/src/compiler/compile.js) checks
-   `/^[A-Z]/`. Repro: compile `function App() { return <_Inner/>; }` — emits
-   `createElement('_Inner', {})`, renders `<_inner>` (client) / throws
-   `Invalid tag` (server). Fix → drop adaptation 1 (and 2's rename half).
-2. **A member-expression / dynamic component tag resolving to a host tag
-   STRING renders on the client but crashes SSR.** The client lowers
-   `<obj.tag/>` to a `createElement` descriptor and the de-opt renderer
-   accepts `typeof type === 'string'`; the server's template lowering emits
-   `ssrComponent(__s, obj.tag, …)`, which CALLS the tag —
-   `TypeError: comp is not a function`. Repro: server-compile
-   `function App(props) { return <><props.parts.title>hi</props.parts.title></>; }`
-   and `renderToString(App, { parts: { title: 'h1' } })`. Fix (accept strings
-   in `ssrComponent`, or value-lower stringable tags server-side like the
-   client) → drop adaptation 3.
+## octane gaps hit (fixed in octane, simplified here)
+
+1. **FIXED — `<_foo/>` / `<$foo/>` identifier tags compiled as host string
+   tags.** `isComponentTag` now follows JSX semantics (only `/^[a-z]/` is an
+   intrinsic).
+2. **FIXED — a member-expression/dynamic tag resolving to a host tag STRING
+   crashed SSR** (`ssrComponent` called the string). `ssrComponent` now
+   serializes string comps inside the standard component block range (client
+   `componentSlot` routes strings through the de-opt host renderer), so the
+   shape matches across client mount, SSR, and hydration adoption.
+3. **FIXED — a return-JSX component returning a FRAGMENT desynced hydration.**
+   The client value-lowers `return <>…</>` to a descriptor array (return-slot
+   childSlot: one slot range + one `<!--[-->…<!--]-->` block per item); the
+   server's template walk concatenated children with markerless text
+   separators and no slot range — silently duplicating content on hydrate. The
+   server compiler now routes value-position returned fragments through
+   `ssrChild([...])` (compile.js `ssrCompileBody`), byte-aligning both sides.
+4. **OPEN (octane compiler, chip filed) — `compileReturnJsxFunction` emits no
+   sourcemap segments** (map-less `printNode`), so the two-stage .mdx map
+   chain composes to empty for document bodies; the pipeline falls back to
+   octane's intermediate-JSX map. Pinned: `tests/sourcemap.test.ts`
+   (`it.fails`) auto-flips when fixed.
 
 ## API coverage vs @mdx-js/react
 
@@ -133,28 +155,64 @@ Mounted with `@octanejs/testing-library` (dogfooded, workspace dep):
 - `frontmatter.test.ts` — `export const frontmatter` + values in expressions;
   YAML block not rendered.
 - `ssr.test.ts` — server-compiled documents through `octane/server`
-  `renderToString` (the hydration.test.ts eval trick + a provider stub):
-  markdown output, `components` prop server-side, frontmatter server-side.
+  `renderToString` (the eval trick, injecting the REAL `@octanejs/mdx/server`
+  provider): markdown output, `components` prop server-side, server
+  `MDXProvider` across a render pass, provider-route ≡ prop-route payload
+  bytes, frontmatter server-side.
+- `hydration.test.ts` — server-render → `hydrateRoot` adoption: byte-identical
+  DOM (markers included), adopted (not rebuilt) nodes, no console.error, an
+  embedded `.tsrx` Counter interactive post-hydration, prop-mapping and
+  server-provider→client-provider parity, post-hydration re-render.
+- `shiki.test.ts` — the optional `@shikijs/rehype` recipe (devDependency
+  only): highlighted tokens client-side, SSR/client payload parity, hydration
+  adoption of the highlighted tree.
+- `hmr.test.ts` — fast-refresh: emit shape (hmr wrap + self-accept, client
+  serve only) and a live hot-swap through the runtime `hmr()` wrapper.
+- `vite.test.ts` — plugin id claiming: `.md` default-on, `md: false`, asset
+  queries (`?raw`/`?url`/`?inline`) pass through, bookkeeping queries don't.
+- `sourcemap.test.ts` — two-stage map: valid v3 output naming the document;
+  the full chain pinned `it.fails` on octane gap 4.
 
-## Open design questions
+## Open design questions — RESOLVED (2026-07-06)
 
-- **Hydration.** SSR output renders, but client/server block alignment for
-  MDX's descriptor-array bodies is untested — `hydrateRoot` over a
-  server-rendered document is future work (needs gap 2 fixed first so both
-  sides take the same shape).
-- **Provider context across SSR.** `MDXProvider` context is client-only: the
-  `octane` entry is the client runtime, whose context is disjoint from
-  `octane/server`'s. Every octane binding shares this limitation; if a
-  server-condition export (or shared context store) lands, `useMDXComponents`
-  picks it up for free. Until then, pass `components` as a prop for SSR.
-- **Syntax highlighting.** The hook point is `rehypePlugins` (e.g.
-  `@shikijs/rehype` — its hast output serializes through the same pipeline);
-  not bundled by default to keep the dependency surface flat. Worth a
-  documented recipe once a docs site consumes this.
-- **HMR.** `.mdx` edits invalidate the module (no HMR-accept boundary);
-  fast-refresh for documents would need the octane HMR wrapper to cover
-  return-JSX/passthrough components.
-- **`.md` opt-out ergonomics.** `octaneMdx({ md: false })` exists; whether
-  `.md` should default to opt-in (some apps import `.md` as raw text via
-  `?raw`) can be revisited when a consumer hits it — `?raw`/query'd imports
-  are already left alone.
+All six answered; details below for the record.
+
+- **Hydration — DONE.** Gaps 2+3 fixed in octane made client/server take the
+  same shape from the same source; `hydration.test.ts` asserts byte-adoption
+  (`container.innerHTML === html` post-hydrate), node identity, zero
+  console.error, and an interactive embedded Counter. One cosmetic note: a
+  keyless-array `console.warn` fires only when a document RE-RENDERS with a
+  changed mapping (documents are keyless descriptor arrays; index fallback is
+  correct for static content).
+- **Provider context across SSR — DONE via `@octanejs/mdx/server`.** No
+  cross-runtime bridge needed: the server runtime has full context support
+  (`scope.$$ctxValues`, top-down within a pass), so the ~40-line provider
+  layer is mirrored onto `octane/server` context and server-mode documents
+  default `providerImportSource` to `@octanejs/mdx/server`. The server
+  provider threads the mapping across `renderToString`, serializes the same
+  payload as the `components` prop route, and hydrates byte-for-byte into the
+  client `MDXProvider`. The two layers must stay in lockstep (noted in both
+  files). The `components` prop remains the runtime-agnostic route.
+- **Syntax highlighting — DONE as a recipe.** `@shikijs/rehype` through
+  `rehypePlugins` (README recipe + `shiki.test.ts`); devDependency only,
+  nothing bundled. Async plugin ⇒ `compileMdx`/the vite plugin, not
+  `compileMdxSync`.
+- **HMR — DONE.** octane's runtime `hmr()` wrapper handles return-based
+  components fine; the octane COMPILER only auto-wraps exported `@{}`-form
+  components, and MDX's `MDXContent` (ternary-returning passthrough) isn't
+  recognized as one. The pipeline knows its own emitted shape, so it appends
+  the identical registration itself (wrap default export + self-accept) for
+  client+hmr compiles — `.mdx` edits now re-render live mounts in place.
+- **`.md` default-on — KEPT.** Docs trees want plain markdown compiled;
+  `md: false` opts out wholesale. The "left alone" claim for query'd imports
+  was WRONG (the transform stripped the query before matching) — fixed:
+  asset queries (`?raw`, `?url`, `?inline`, workers) now pass through
+  untouched (vite's asset plugin owns them), while vite-internal bookkeeping
+  queries (`?v=`, `?used`, `?import`) still transform. Tested.
+- **Sourcemaps — machinery DONE, full fidelity blocked on octane gap 4.**
+  @mdx-js/mdx emits stage-one (via `source-map`'s `SourceMapGenerator`);
+  octane emits stage-two; `@jridgewell/remapping` composes. Today the chain
+  is empty for real documents (gap 4), so the pipeline keeps octane's
+  intermediate-JSX map as the fallback; the chained path activates by itself
+  (guarded on non-empty mappings) once octane maps return-JSX functions —
+  chip filed, `it.fails` pinned.

--- a/packages/mdx/README.md
+++ b/packages/mdx/README.md
@@ -82,19 +82,48 @@ the special `wrapper` key is the document layout.
   `defaultRemarkPlugins`, the plugin's pipeline as a library (used by the SSR
   tests, usable for static-site tooling).
 
-## SSR
+## SSR + hydration
 
-A document compiled with `mode: 'server'` renders through
-`octane/server`'s `renderToString`, and the `components` **prop** applies
-server-side. The context-based `MDXProvider` route is client-only for now —
-octane bindings have no cross-runtime context threading yet (the `octane`
-entry is the client runtime; on the server the context read yields its default
-`{}`).
+A document compiled with `mode: 'server'` renders through `octane/server`'s
+`renderToString`, and the resulting HTML **hydrates byte-for-byte** into the
+client-compiled module via `hydrateRoot` (embedded `.tsrx` components adopt
+their server DOM and stay interactive).
+
+Both mapping routes work on the server:
+
+- the `components` **prop** — `renderToString(Doc, { components })`;
+- **`MDXProvider` from `@octanejs/mdx/server`** — the same provider layer
+  mirrored onto `octane/server` context (the client and server runtimes have
+  disjoint context stores, so each side ships its own provider; server-mode
+  documents read `useMDXComponents` from `@octanejs/mdx/server`
+  automatically). A document rendered under the server provider hydrates
+  byte-for-byte into the client `MDXProvider` with the same mapping.
+
+## Syntax highlighting (Shiki)
+
+Highlighting is a rehype concern, so it hooks in through `rehypePlugins` — no
+integration code and nothing bundled (add `@shikijs/rehype` yourself):
+
+```ts
+import { octaneMdx } from '@octanejs/mdx/vite';
+import rehypeShiki from '@shikijs/rehype';
+
+octaneMdx({
+	rehypePlugins: [[rehypeShiki, { theme: 'github-light' }]],
+});
+```
+
+Shiki's hast output serializes through the same pipeline as any other content:
+highlighted tokens render on the client, serialize identically on the server,
+and hydrate cleanly (see `tests/shiki.test.ts`). Note `@shikijs/rehype` is
+async — it works in the vite plugin and `compileMdx`, not `compileMdxSync`.
 
 ## Notes
 
 - Markdown-generated elements ride octane's value-position (`createElement`
   descriptor) path — documents are static content, and embedded `.tsrx`
   components keep their full compiled fast path.
-- `.mdx` edits currently propagate as a full module invalidation (no
-  HMR-accept boundary yet).
+- `.mdx` edits fast-refresh in dev: the pipeline wraps the document's default
+  export in octane's runtime `hmr()` and self-accepts, so live mounts re-render
+  the new body in place (no page reload; the vite plugin enables this in serve
+  mode automatically).

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -25,6 +25,7 @@
   ],
   "exports": {
     ".": "./src/index.ts",
+    "./server": "./src/server.ts",
     "./compile": "./src/compile.ts",
     "./vite": "./src/vite.ts"
   },
@@ -32,14 +33,18 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@jridgewell/remapping": "catalog:default",
     "@mdx-js/mdx": "catalog:default",
     "octane": "workspace:*",
     "remark-frontmatter": "catalog:default",
     "remark-gfm": "catalog:default",
-    "remark-mdx-frontmatter": "catalog:default"
+    "remark-mdx-frontmatter": "catalog:default",
+    "source-map": "catalog:default"
   },
   "devDependencies": {
+    "@jridgewell/trace-mapping": "catalog:default",
     "@octanejs/testing-library": "workspace:*",
+    "@shikijs/rehype": "catalog:default",
     "vite": "catalog:default",
     "vitest": "catalog:default"
   }

--- a/packages/mdx/src/compile.ts
+++ b/packages/mdx/src/compile.ts
@@ -17,30 +17,24 @@
  * @mdx-js/react's provider).
  *
  * The only adaptation between the two compilers is `recmaOctaneAdapter`, a tiny
- * ESTree pass over MDX's output:
+ * ESTree pass over MDX's output: MDX's no-layout branch CALLS
+ * `_createMdxContent(props)` directly, which bypasses octane's
+ * `(props, __s, __extra)` component ABI (the server body would run with
+ * `__s === undefined` and lean on scope-recovery). The pass rewrites the bare
+ * call to `<_createMdxContent {...props}/>` so both branches mount through the
+ * component machinery on client AND server. (The layout branch's
+ * `<_createMdxContent {...props}/>` tag needs no help: octane classifies
+ * `_`-starting identifier tags as component references, per JSX semantics.)
  *
- *  1. MDX's no-layout branch CALLS `_createMdxContent(props)` directly, which
- *     bypasses octane's `(props, __s, __extra)` component ABI (the server body
- *     would run with `__s === undefined` and lean on scope-recovery). The pass
- *     rewrites the bare call to `<_createMdxContent {...props}/>` so both
- *     branches mount through the component machinery on client AND server.
- *     (The layout branch's `<_createMdxContent {...props}/>` tag needs no help:
- *     octane classifies `_`-starting identifier tags as component references,
- *     per JSX semantics.)
- *  2. SERVER mode only: MDX renders markdown elements through its components
- *     mapping — `<_components.h1>` — whose value is a host tag STRING unless
- *     overridden. octane's CLIENT lowering of a member-expression tag is a
- *     `createElement` descriptor, which the runtime's de-opt renderer accepts
- *     for strings; the SERVER's template lowering routes it to
- *     `ssrComponent(scope, comp, …)`, which CALLS `comp` — a string crashes
- *     (an octane compiler/server-runtime gap: member/dynamic tags resolving to
- *     host tag strings work on the client, not in SSR). The pass wraps every
- *     `_components.*`-tagged element in JSX-child position in an expression
- *     container (`{<_components.h1>…</_components.h1>}`) so the server codegen
- *     treats it as a VALUE hole — `ssrChild(createElement(…))` — which handles
- *     string tags. Client output is left untouched; drop this once
- *     `ssrComponent` (or the server lowering) accepts host tag strings.
+ * The two former SERVER-mode fixups are gone — their octane gaps are fixed:
+ * `ssrComponent` renders a host-tag-STRING comp as a
+ * `<!--[--><tag>…</tag><!--]-->` block (the shape the client's componentSlot /
+ * de-opt host renderer adopts on hydration), and the server compiler
+ * value-lowers a returned fragment through `ssrChild([...])` exactly like the
+ * client's descriptor array — so `<_components.h1>` member tags and the
+ * document's fragment body take the SAME shape on both sides (hydration-safe).
  */
+import remapping from '@jridgewell/remapping';
 import {
 	compile as mdxCompile,
 	compileSync as mdxCompileSync,
@@ -50,6 +44,7 @@ import { compile as octaneCompile } from 'octane/compiler';
 import remarkFrontmatter from 'remark-frontmatter';
 import remarkGfm from 'remark-gfm';
 import remarkMdxFrontmatter from 'remark-mdx-frontmatter';
+import { SourceMapGenerator } from 'source-map';
 
 export interface CompileMdxResult {
 	code: string;
@@ -65,8 +60,10 @@ export interface CompileMdxOptions {
 	dev?: boolean;
 	/**
 	 * Module the emitted document reads the provider mapping from
-	 * (`useMDXComponents`). Defaults to `'@octanejs/mdx'`; pass `null` to
-	 * disable the provider wiring entirely (only `props.components` applies).
+	 * (`useMDXComponents`). Defaults per mode — `'@octanejs/mdx'` (client) /
+	 * `'@octanejs/mdx/server'` (server), so each runtime reads ITS OWN context
+	 * store (they are disjoint; see src/server.ts). Pass `null` to disable the
+	 * provider wiring entirely (only `props.components` applies).
 	 */
 	providerImportSource?: string | null;
 	/** remark plugins. Defaults to `defaultRemarkPlugins` (GFM + frontmatter + frontmatter-export). */
@@ -88,6 +85,7 @@ export interface CompileMdxOptions {
 		| 'rehypePlugins'
 		| 'recmaPlugins'
 		| 'format'
+		| 'SourceMapGenerator'
 	>;
 }
 
@@ -109,7 +107,7 @@ export async function compileMdx(
 	options: CompileMdxOptions = {},
 ): Promise<CompileMdxResult> {
 	const out = await mdxCompile({ value: source, path: id }, buildMdxOptions(id, options));
-	return octaneStage(String(out.value), id, options);
+	return octaneStage(String(out.value), out.map, id, options);
 }
 
 /** Synchronous {@link compileMdx} (the default plugin set is fully sync). */
@@ -119,7 +117,7 @@ export function compileMdxSync(
 	options: CompileMdxOptions = {},
 ): CompileMdxResult {
 	const out = mdxCompileSync({ value: source, path: id }, buildMdxOptions(id, options));
-	return octaneStage(String(out.value), id, options);
+	return octaneStage(String(out.value), out.map, id, options);
 }
 
 function buildMdxOptions(id: string, options: CompileMdxOptions): CompileOptions {
@@ -130,33 +128,79 @@ function buildMdxOptions(id: string, options: CompileMdxOptions): CompileOptions
 				? 'md'
 				: 'mdx';
 	const provider =
-		options.providerImportSource === undefined ? '@octanejs/mdx' : options.providerImportSource;
+		options.providerImportSource === undefined
+			? options.mode === 'server'
+				? '@octanejs/mdx/server'
+				: '@octanejs/mdx'
+			: options.providerImportSource;
 	return {
 		...options.mdxOptions,
 		format,
 		// The load-bearing switch: emit JSX SOURCE (no jsx-runtime calls), which
 		// octane's compiler lowers to its own codegen.
 		jsx: true,
+		// Map the intermediate JSX back to the .mdx source — stage one of the
+		// chained map octaneStage composes (stage two is octane's own map).
+		SourceMapGenerator,
 		...(provider === null ? {} : { providerImportSource: provider }),
 		remarkPlugins: options.remarkPlugins ?? defaultRemarkPlugins,
 		rehypePlugins: options.rehypePlugins,
-		recmaPlugins: [
-			...(options.recmaPlugins ?? []),
-			[recmaOctaneAdapter, { mode: options.mode ?? 'client' }],
-		],
+		recmaPlugins: [...(options.recmaPlugins ?? []), recmaOctaneAdapter],
 	};
 }
 
-function octaneStage(jsxSource: string, id: string, options: CompileMdxOptions): CompileMdxResult {
+function octaneStage(
+	jsxSource: string,
+	mdxMap: unknown,
+	id: string,
+	options: CompileMdxOptions,
+): CompileMdxResult {
 	const mode = options.mode ?? 'client';
-	// NOTE on sourcemaps: octane's map references the INTERMEDIATE JSX text, not
-	// the original .mdx — a faithful two-stage chain is future work. The map is
-	// still returned so line-ish positions survive into the bundle.
-	return octaneCompile(jsxSource, id, {
+	const out = octaneCompile(jsxSource, id, {
 		mode,
 		hmr: mode === 'client' && !!options.hmr,
 		dev: mode === 'client' && !!options.dev,
 	});
+	// Two-stage sourcemap: octane's map targets the INTERMEDIATE JSX text;
+	// @mdx-js/mdx's map (via SourceMapGenerator) targets the original .mdx.
+	// Compose them (most-recent-first) so generated positions trace all the way
+	// back to the document.
+	//
+	// GAP (octane compiler): today the chain composes to an EMPTY map for real
+	// documents — octane's `compileReturnJsxFunction` prints its output with
+	// the map-less `printNode` (no esrap segments), and the MDX body
+	// (`_createMdxContent`) is exactly that shape, so octane has no segments on
+	// the one intermediate line the mdx map covers (the document content) and
+	// remapping drops everything. Until that emits real segments, an empty
+	// chain falls back to octane's intermediate map (its `sourcesContent` is
+	// the intermediate JSX — still steppable in devtools, unlike a blank map).
+	// The octane SERVER compile emits an empty-mappings map by design (SSR maps
+	// are a later octane refinement).
+	if (out.map && mdxMap) {
+		const chained = remapping([out.map as any, mdxMap as any], () => null);
+		if (String(chained.mappings).length > 0) out.map = chained;
+	}
+	// Fast refresh for documents: octane's compiler only auto-wraps EXPORTED
+	// `@{}`-form components in `hmr(...)` — `MDXContent` (a passthrough function
+	// returning a ternary of descriptors) isn't recognized as one, so the octane
+	// `hmr` flag alone leaves `.mdx` edits as full module invalidations. The
+	// PIPELINE knows the emitted shape, so it appends the exact registration the
+	// octane compiler emits for `.tsrx` exports: wrap the default export in the
+	// runtime `hmr()` (identity-stable across edits — parents keep their mounted
+	// wrapper) + a self-accepting `import.meta.hot` block that swaps the body
+	// and re-renders live blocks in place. Appending after the fact keeps the
+	// source map's earlier segments valid (ESM imports hoist).
+	if (mode === 'client' && options.hmr && /\bexport default function MDXContent\b/.test(out.code)) {
+		out.code +=
+			"\nimport { hmr as _$mdxHmr, HMR as _$mdxHMR } from 'octane';\n" +
+			'MDXContent = _$mdxHmr(MDXContent);\n' +
+			'if (import.meta.hot) {\n' +
+			'  import.meta.hot.accept((module) => {\n' +
+			'    module && MDXContent[_$mdxHMR].update(module.default);\n' +
+			'  });\n' +
+			'}\n';
+	}
+	return out;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -165,10 +209,9 @@ function octaneStage(jsxSource: string, id: string, options: CompileMdxOptions):
 
 const MDX_BODY_NAME = '_createMdxContent';
 
-function recmaOctaneAdapter(options?: { mode?: 'client' | 'server' }) {
-	const server = options?.mode === 'server';
+function recmaOctaneAdapter() {
 	return (tree: unknown): void => {
-		walkReplace(tree as EstreeNode, (node) => adaptNode(node, server));
+		walkReplace(tree as EstreeNode, adaptNode);
 	};
 }
 
@@ -182,8 +225,8 @@ function isNode(value: unknown): value is EstreeNode {
 
 // Visit `node` (post-decision, pre-recursion): return a replacement node to
 // swap in (recursed into by the caller), or null to keep the node and recurse.
-function adaptNode(node: EstreeNode, server: boolean): EstreeNode | null {
-	// (1) `_createMdxContent(props)` → `<_createMdxContent {...props}/>`.
+function adaptNode(node: EstreeNode): EstreeNode | null {
+	// `_createMdxContent(props)` → `<_createMdxContent {...props}/>`.
 	if (
 		node.type === 'CallExpression' &&
 		isNode(node.callee) &&
@@ -195,53 +238,7 @@ function adaptNode(node: EstreeNode, server: boolean): EstreeNode | null {
 	) {
 		return jsxSelfClosing(MDX_BODY_NAME, (node.arguments[0] as EstreeNode) ?? null);
 	}
-	if (server) {
-		// (2) `_components.*` elements in JSX-CHILD position → `{<element/>}`
-		// expression holes (see module doc). Wrapping edits the PARENT's children
-		// array, so an already-wrapped element (now behind an expression
-		// container) is never re-wrapped.
-		if (
-			(node.type === 'JSXElement' || node.type === 'JSXFragment') &&
-			Array.isArray(node.children)
-		) {
-			const children = node.children as unknown[];
-			for (let i = 0; i < children.length; i++) {
-				const child = children[i];
-				if (isNode(child) && isComponentsMappedElement(child)) {
-					children[i] = { type: 'JSXExpressionContainer', expression: child };
-				}
-			}
-		}
-		// A `return <_components.p>…</_components.p>` (single-block document) has
-		// no JSX parent to wrap under — hoist it into a fragment-with-hole.
-		if (
-			node.type === 'ReturnStatement' &&
-			isNode(node.argument) &&
-			isComponentsMappedElement(node.argument)
-		) {
-			node.argument = {
-				type: 'JSXFragment',
-				openingFragment: { type: 'JSXOpeningFragment', attributes: [], selfClosing: false },
-				closingFragment: { type: 'JSXClosingFragment' },
-				children: [{ type: 'JSXExpressionContainer', expression: node.argument }],
-			};
-		}
-	}
 	return null;
-}
-
-// `<_components.x …>` — an element whose tag reads off MDX's components
-// mapping (and can therefore be a host tag STRING at runtime).
-function isComponentsMappedElement(node: EstreeNode): boolean {
-	if (node.type !== 'JSXElement') return false;
-	const name = (node.openingElement as EstreeNode | undefined)?.name as EstreeNode | undefined;
-	return (
-		!!name &&
-		name.type === 'JSXMemberExpression' &&
-		isNode(name.object) &&
-		name.object.type === 'JSXIdentifier' &&
-		name.object.name === '_components'
-	);
 }
 
 // Depth-first walk that can REPLACE child nodes in place (arrays and single

--- a/packages/mdx/src/compile.ts
+++ b/packages/mdx/src/compile.ts
@@ -164,18 +164,11 @@ function octaneStage(
 	// Two-stage sourcemap: octane's map targets the INTERMEDIATE JSX text;
 	// @mdx-js/mdx's map (via SourceMapGenerator) targets the original .mdx.
 	// Compose them (most-recent-first) so generated positions trace all the way
-	// back to the document.
-	//
-	// GAP (octane compiler): today the chain composes to an EMPTY map for real
-	// documents — octane's `compileReturnJsxFunction` prints its output with
-	// the map-less `printNode` (no esrap segments), and the MDX body
-	// (`_createMdxContent`) is exactly that shape, so octane has no segments on
-	// the one intermediate line the mdx map covers (the document content) and
-	// remapping drops everything. Until that emits real segments, an empty
-	// chain falls back to octane's intermediate map (its `sourcesContent` is
-	// the intermediate JSX — still steppable in devtools, unlike a blank map).
-	// The octane SERVER compile emits an empty-mappings map by design (SSR maps
-	// are a later octane refinement).
+	// back to the document. The non-empty guard is defensive: if a compile shape
+	// ever yields no overlapping segments, keep octane's intermediate map (its
+	// `sourcesContent` is the intermediate JSX — still steppable in devtools,
+	// unlike a blank map). The octane SERVER compile emits an empty-mappings map
+	// by design (SSR maps are a later octane refinement).
 	if (out.map && mdxMap) {
 		const chained = remapping([out.map as any, mdxMap as any], () => null);
 		if (String(chained.mappings).length > 0) out.map = chained;

--- a/packages/mdx/src/index.ts
+++ b/packages/mdx/src/index.ts
@@ -22,8 +22,12 @@
  * contrast, is null-scope safe (it returns the context default). So the merge
  * runs unmemoized: same observable mapping every render, valid in both
  * runtimes (on the server the client context yields its default `{}`, and the
- * `props.components` route still applies — context threading across an SSR
- * pass is an open question for all octane bindings).
+ * `props.components` route still applies).
+ *
+ * SSR provider support lives in `@octanejs/mdx/server` — the same layer
+ * mirrored onto `octane/server` context (the two runtimes' context stores are
+ * disjoint; server-mode documents import `useMDXComponents` from there). Keep
+ * the merge semantics here and in src/server.ts in lockstep.
  */
 import { createContext, createElement, useContext, type ComponentBody } from 'octane';
 

--- a/packages/mdx/src/server.ts
+++ b/packages/mdx/src/server.ts
@@ -1,0 +1,65 @@
+/**
+ * @octanejs/mdx/server — the provider layer for SERVER renders.
+ *
+ * octane's client and server runtimes are separate modules with disjoint
+ * context stores, so the client `MDXProvider` (./index.ts, built on `octane`
+ * context) cannot thread a mapping through `renderToString` — its `useContext`
+ * runs null-scope on the server and yields the `{}` default. The server
+ * runtime has its own full context implementation (`scope.$$ctxValues`,
+ * top-down within one render pass), so this entry mirrors the provider layer
+ * onto `octane/server` context: same merge, same function-form `components`,
+ * same `disableParentContext` — see ./index.ts for the @mdx-js/react port
+ * notes. KEEP THE MERGE SEMANTICS IN LOCKSTEP with ./index.ts (both are the
+ * same ~40-line port; only the runtime import differs).
+ *
+ * The compile pipeline points a server-mode document's `providerImportSource`
+ * here (client mode keeps `@octanejs/mdx`), so `useMDXComponents()` inside a
+ * server-compiled document reads THIS context — and a document rendered under
+ * this `MDXProvider` serializes with the same mapping the client provider
+ * produces at hydration. Client bundles never import this module.
+ */
+import { createContext, createElement, useContext } from 'octane/server';
+import type { MDXComponents, MDXComponentsProp, MDXProviderProps } from './index';
+
+export type { MDXComponents, MDXComponentsProp, MDXProviderProps, MDXProps } from './index';
+
+const emptyComponents: MDXComponents = {};
+const MDXContext = createContext<MDXComponents>(emptyComponents);
+
+/**
+ * Server `useMDXComponents`: the provider context merged with (or mapped
+ * through) `components`. Same contract as the client export (./index.ts).
+ */
+export function useMDXComponents(
+	components?: MDXComponentsProp | null | symbol,
+	_slot?: symbol,
+): MDXComponents {
+	// Tolerate a compiler-injected trailing slot symbol, like the client export.
+	if (typeof components === 'symbol') components = undefined;
+	const contextComponents = useContext(MDXContext);
+	if (typeof components === 'function') return components(contextComponents);
+	return { ...contextComponents, ...components };
+}
+
+/**
+ * Server `MDXProvider`: provides the mapping for every document rendered
+ * below it in this `renderToString` pass. Mount shape mirrors the client
+ * provider exactly (one provider component frame + one context frame), so a
+ * document server-rendered under this provider hydrates byte-for-byte into
+ * the client `MDXProvider`.
+ */
+export function MDXProvider(props: MDXProviderProps): unknown {
+	let allComponents: MDXComponents;
+	if (props.disableParentContext) {
+		allComponents =
+			typeof props.components === 'function'
+				? props.components(emptyComponents)
+				: (props.components ?? emptyComponents);
+	} else {
+		allComponents = useMDXComponents(props.components);
+	}
+	return createElement(MDXContext.Provider as any, {
+		value: allComponents,
+		children: props.children,
+	});
+}

--- a/packages/mdx/src/vite.ts
+++ b/packages/mdx/src/vite.ts
@@ -55,8 +55,14 @@ export function octaneMdx(options: OctaneMdxPluginOptions = {}): OctaneMdxPlugin
 			if (hmrEnabled === undefined) hmrEnabled = config.command === 'serve';
 		},
 		async transform(code, id, transformOptions) {
-			const file = id.split('?')[0]; // strip Vite's ?v=/?used query suffix
+			const [file, query = ''] = id.split('?'); // Vite ids carry ?v=/?used/?raw/… suffixes
 			if (!(file.endsWith('.mdx') || (includeMd && file.endsWith('.md')))) return null;
+			// An ASSET-query import (`import text from './doc.md?raw'`, ?url, ?inline)
+			// is vite's territory: its asset plugin already LOADED the module as JS
+			// (`export default "…"`), so compiling here would mangle it — and the
+			// author explicitly asked for the file, not the document. Internal
+			// bookkeeping queries (?v=hash, ?used, ?import) still transform.
+			if (/(^|&)(raw|url|inline|worker|sharedworker)(=|&|$)/.test(query)) return null;
 			const ssr =
 				forceSsr !== undefined
 					? forceSsr

--- a/packages/mdx/tests/_helpers.ts
+++ b/packages/mdx/tests/_helpers.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared test rig helpers for @octanejs/mdx.
+ *
+ * `evalModuleCode` evaluates compiled module code (client or server codegen)
+ * with every import rewritten to a binding from `mods` (specifier → module
+ * namespace) — the same eval trick as
+ * packages/octane/tests/hydration/hydration.test.ts, generalized so a
+ * document's own imports (an embedded `.tsrx` component, the provider layer)
+ * can be injected too.
+ */
+export function evalModuleCode(
+	code: string,
+	mods: Record<string, Record<string, any>>,
+	// `import.meta.hot` shim — `import.meta` is illegal outside a real module,
+	// so HMR-enabled client output rewrites it to this injected value (pass a
+	// `{ accept }` stub to capture the registration, or leave undefined).
+	hot?: { accept(cb: (module: any) => void): void },
+): Record<string, any> {
+	let defaultName: string | null = null;
+	code = code.replace(/import\.meta\.hot/g, '__hot');
+	code = code.replace(
+		/import\s*\{([^}]*)\}\s*from\s*['"]([^'"]+)['"];?/g,
+		(_m: string, names: string, spec: string) =>
+			`const {${names.replace(/ as /g, ': ')}} = __mods[${JSON.stringify(spec)}];`,
+	);
+	code = code.replace(
+		/import\s+(\w+)\s+from\s*['"]([^'"]+)['"];?/g,
+		(_m: string, name: string, spec: string) =>
+			`const ${name} = __mods[${JSON.stringify(spec)}].default;`,
+	);
+	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
+	code = code.replace(/export default function (\w+)/, (_m: string, name: string) => {
+		defaultName = name;
+		return `function ${name}`;
+	});
+	code = code.replace(/export default (\w+);/, (_m: string, name: string) => {
+		defaultName = name;
+		return '';
+	});
+	if (defaultName) code += `\n__exports.default = ${defaultName};`;
+	const fn = new Function('__mods', '__exports', '__hot', code + '\nreturn __exports;');
+	return fn(mods, {}, hot);
+}
+
+/** Hydration block/item markers aside, the payload is plain HTML. */
+export function stripMarkers(html: string): string {
+	return html.replace(/<!--[^>]*-->/g, '');
+}

--- a/packages/mdx/tests/hmr.test.ts
+++ b/packages/mdx/tests/hmr.test.ts
@@ -1,0 +1,69 @@
+/**
+ * HMR — fast refresh for `.mdx` documents. octane's compiler auto-wraps only
+ * exported `@{}`-form components, which MDX's emitted `MDXContent` is not, so
+ * the pipeline appends the equivalent registration itself (see compile.ts):
+ * the default export is wrapped in the runtime `hmr()` and the module
+ * self-accepts, swapping the document body and re-rendering live mounts in
+ * place. The vite plugin turns this on in serve mode (client only).
+ */
+import { describe, it, expect } from 'vitest';
+import * as Octane from 'octane';
+import * as Provider from '@octanejs/mdx';
+import { compileMdxSync } from '@octanejs/mdx/compile';
+import { evalModuleCode } from './_helpers';
+
+const MODS = { octane: Octane, '@octanejs/mdx': Provider };
+
+describe('mdx HMR', () => {
+	it('emits the hmr wrap + self-accept block only for hmr client compiles', () => {
+		const hot = compileMdxSync('# hi\n', '/docs/doc.mdx', { hmr: true });
+		expect(hot.code).toContain('MDXContent = _$mdxHmr(MDXContent);');
+		expect(hot.code).toContain('import.meta.hot.accept');
+
+		const cold = compileMdxSync('# hi\n', '/docs/doc.mdx');
+		expect(cold.code).not.toContain('import.meta.hot');
+		const server = compileMdxSync('# hi\n', '/docs/doc.mdx', { mode: 'server', hmr: true });
+		expect(server.code).not.toContain('import.meta.hot');
+	});
+
+	it('hot-swaps an edited document into live mounts in place', () => {
+		const v1 = compileMdxSync('# One\n\nfirst\n', '/docs/doc.mdx', { hmr: true });
+		let accepted: ((module: any) => void) | null = null;
+		const mod1 = evalModuleCode(v1.code, MODS, { accept: (cb) => (accepted = cb) });
+
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		const root = Octane.createRoot(container);
+		root.render(mod1.default, {});
+		Octane.flushSync(() => {});
+		expect(container.querySelector('h1')?.textContent).toBe('One');
+		expect(accepted).not.toBeNull();
+
+		// The "edit": recompile the same id with new content; vite would re-run
+		// the module and hand the new namespace to the accept callback.
+		const v2 = compileMdxSync('# Two\n\nsecond\n', '/docs/doc.mdx', { hmr: true });
+		const mod2 = evalModuleCode(v2.code, MODS, { accept: () => {} });
+		accepted!({ default: mod2.default });
+		Octane.flushSync(() => {});
+
+		// The SAME mounted root re-rendered with the new document body.
+		expect(container.querySelector('h1')?.textContent).toBe('Two');
+		expect(container.textContent).toContain('second');
+		expect(container.textContent).not.toContain('first');
+		root.unmount();
+		container.remove();
+	});
+
+	it('keeps the wrapper identity stable so a parent does not remount the document', () => {
+		const v1 = compileMdxSync('# One\n', '/docs/doc.mdx', { hmr: true });
+		let accepted: ((module: any) => void) | null = null;
+		const mod1 = evalModuleCode(v1.code, MODS, { accept: (cb) => (accepted = cb) });
+		expect(typeof (mod1.default as any)[Octane.HMR]?.update).toBe('function');
+
+		const v2 = compileMdxSync('# Two\n', '/docs/doc.mdx', { hmr: true });
+		const mod2 = evalModuleCode(v2.code, MODS, { accept: () => {} });
+		// update() unwraps an incoming wrapper down to the raw body — no nesting.
+		accepted!({ default: mod2.default });
+		expect((mod1.default as any)[Octane.HMR].fn).toBe((mod2.default as any)[Octane.HMR].fn);
+	});
+});

--- a/packages/mdx/tests/hydration.test.ts
+++ b/packages/mdx/tests/hydration.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Hydration — a server-rendered MDX document adopts into the client-compiled
+ * module via `hydrateRoot`: byte-identical DOM, adopted (not rebuilt) nodes,
+ * no mismatch warnings, and embedded interactive components stay live.
+ *
+ * The server side compiles the SAME `.mdx` source with `mode: 'server'` and
+ * evaluates it with the server runtime injected (the ssr.test.ts eval trick,
+ * extended to resolve the document's own imports — e.g. an embedded `.tsrx`
+ * component is itself server-compiled and injected). The client side is the
+ * real plugin-compiled module import. Rig modeled on
+ * packages/octane/tests/hydration/host-string-tag-hydrate.test.ts.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { hydrateRoot, flushSync, createElement } from 'octane';
+import * as ServerRT from 'octane/server';
+import { compile as octaneCompile } from 'octane/compiler';
+import { compileMdxSync } from '@octanejs/mdx/compile';
+import { MDXProvider } from '@octanejs/mdx';
+import * as ServerProvider from '@octanejs/mdx/server';
+import { evalModuleCode } from './_helpers';
+// @ts-expect-error — .mdx modules are produced by the vite plugin; no ambient types in tests.
+import BasicDoc from './_fixtures/basic.mdx';
+// @ts-expect-error — see above.
+import ComponentsDoc from './_fixtures/components.mdx';
+
+const FIXTURES = join(process.cwd(), 'packages/mdx/tests/_fixtures');
+
+// Server-compile an `.mdx` fixture through the pipeline. The provider import
+// is the REAL `@octanejs/mdx/server` (the server-mode default).
+function serverMdxModule(name: string, extraMods: Record<string, any> = {}): Record<string, any> {
+	const file = join(FIXTURES, name);
+	const { code } = compileMdxSync(readFileSync(file, 'utf8'), file, { mode: 'server' });
+	return evalModuleCode(code, {
+		'octane/server': ServerRT,
+		'@octanejs/mdx/server': ServerProvider,
+		...extraMods,
+	});
+}
+
+// Server-compile an embedded `.tsrx` component (the documents' imports must be
+// server modules too — renderToString runs them, not the client-compiled ones).
+function serverTsrxModule(name: string): Record<string, any> {
+	const file = join(FIXTURES, name);
+	const { code } = octaneCompile(readFileSync(file, 'utf8'), name, { mode: 'server' });
+	return evalModuleCode(code, { 'octane/server': ServerRT });
+}
+
+let container: HTMLElement;
+let errSpy: ReturnType<typeof vi.spyOn>;
+beforeEach(() => {
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	errSpy = vi.spyOn(console, 'error');
+});
+afterEach(() => {
+	// No hydration mismatch warnings (or any other error) in any test.
+	expect(errSpy.mock.calls).toEqual([]);
+	errSpy.mockRestore();
+	container.remove();
+});
+
+describe('hydration', () => {
+	it('adopts a server-rendered markdown document byte-for-byte', () => {
+		const mod = serverMdxModule('basic.mdx');
+		const { html } = ServerRT.renderToString(mod.default, {});
+		container.innerHTML = html;
+		const h1 = container.querySelector('h1');
+		const em = container.querySelector('em');
+		const lis = [...container.querySelectorAll('li')];
+
+		const root = hydrateRoot(container, BasicDoc, {});
+		flushSync(() => {});
+		// Byte adoption: hydration changed NOTHING (markers included).
+		expect(container.innerHTML).toBe(html);
+		// The server nodes were adopted, not rebuilt.
+		expect(container.querySelector('h1')).toBe(h1);
+		expect(container.querySelector('em')).toBe(em);
+		expect([...container.querySelectorAll('li')]).toEqual(lis);
+		root.unmount();
+	});
+
+	it('adopts a document with an embedded .tsrx component and keeps it interactive', () => {
+		const counter = serverTsrxModule('counter.tsrx');
+		const mod = serverMdxModule('components.mdx', { './counter.tsrx': counter });
+		const { html } = ServerRT.renderToString(mod.default, {});
+		expect(html).toContain('count: 2');
+		expect(html).toContain('The answer is 42.');
+		container.innerHTML = html;
+		const btn = container.querySelector('[data-testid="counter"]') as HTMLButtonElement;
+
+		const root = hydrateRoot(container, ComponentsDoc, {});
+		flushSync(() => {});
+		expect(container.innerHTML).toBe(html);
+		// Same button element (adopted), and the delegated event drives its state.
+		expect(container.querySelector('[data-testid="counter"]')).toBe(btn);
+		flushSync(() => btn.click());
+		expect(btn.textContent).toBe('count: 3');
+		root.unmount();
+	});
+
+	it('adopts with a components-prop mapping applied on both sides', () => {
+		const mod = serverMdxModule('basic.mdx');
+		const props = { components: { h1: 'h2', em: 'i' } };
+		const { html } = ServerRT.renderToString(mod.default, props);
+		expect(html).toContain('<h2>');
+		expect(html).toContain('<i>');
+		container.innerHTML = html;
+		const h2 = container.querySelector('h2');
+
+		const root = hydrateRoot(container, BasicDoc, props);
+		flushSync(() => {});
+		expect(container.innerHTML).toBe(html);
+		expect(container.querySelector('h2')).toBe(h2);
+		root.unmount();
+	});
+
+	// The server provider (@octanejs/mdx/server) and the client provider mount
+	// the same component-frame shape, so a document server-rendered under the
+	// server MDXProvider hydrates byte-for-byte into the client MDXProvider.
+	it('adopts a document rendered under the server MDXProvider into the client MDXProvider', () => {
+		const mod = serverMdxModule('basic.mdx');
+		const components = { h1: 'h2', em: 'i' };
+		const { html } = ServerRT.renderToString(ServerProvider.MDXProvider as any, {
+			components,
+			children: ServerRT.createElement(mod.default as any, {}),
+		});
+		expect(html).toContain('<h2>');
+		container.innerHTML = html;
+		const h2 = container.querySelector('h2');
+
+		const root = hydrateRoot(container, MDXProvider, {
+			components,
+			children: createElement(BasicDoc),
+		});
+		flushSync(() => {});
+		expect(container.innerHTML).toBe(html);
+		expect(container.querySelector('h2')).toBe(h2);
+		root.unmount();
+	});
+
+	it('updates after hydration: a mapping change re-renders the adopted document', () => {
+		const mod = serverMdxModule('basic.mdx');
+		const { html } = ServerRT.renderToString(mod.default, {});
+		container.innerHTML = html;
+
+		const root = hydrateRoot(container, BasicDoc, {});
+		flushSync(() => {});
+		root.render(BasicDoc, { components: { h1: 'h3' } });
+		flushSync(() => {});
+		expect(container.querySelector('h3')?.textContent).toBe('Hello, MDX');
+		expect(container.querySelector('h1')).toBeNull();
+		root.unmount();
+	});
+});

--- a/packages/mdx/tests/shiki.test.ts
+++ b/packages/mdx/tests/shiki.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Syntax highlighting via `@shikijs/rehype` through the pipeline's
+ * `rehypePlugins` hook — the documented recipe (see README). Shiki is a
+ * devDependency ONLY: nothing in @octanejs/mdx bundles or depends on it; its
+ * hast output simply serializes through the same @mdx-js/mdx → octane
+ * pipeline as any other rehype transform. Highlighting is async, so the
+ * async `compileMdx` is required (the vite plugin's transform already is).
+ */
+import { describe, it, expect } from 'vitest';
+import rehypeShiki from '@shikijs/rehype';
+import * as Octane from 'octane';
+import * as ServerRT from 'octane/server';
+import * as Provider from '@octanejs/mdx';
+import * as ServerProvider from '@octanejs/mdx/server';
+import { compileMdx, type CompileMdxOptions } from '@octanejs/mdx/compile';
+import { evalModuleCode, stripMarkers } from './_helpers';
+
+const SOURCE = '# Code\n\n```js\nconst x = 1;\n```\n';
+const OPTIONS: Pick<CompileMdxOptions, 'rehypePlugins'> = {
+	rehypePlugins: [[rehypeShiki, { theme: 'github-light' }]],
+};
+
+async function modules() {
+	const client = await compileMdx(SOURCE, '/docs/shiki.mdx', { mode: 'client', ...OPTIONS });
+	const server = await compileMdx(SOURCE, '/docs/shiki.mdx', { mode: 'server', ...OPTIONS });
+	return {
+		client: evalModuleCode(client.code, { octane: Octane, '@octanejs/mdx': Provider }),
+		server: evalModuleCode(server.code, {
+			'octane/server': ServerRT,
+			'@octanejs/mdx/server': ServerProvider,
+		}),
+	};
+}
+
+describe('shiki (optional, via rehypePlugins)', () => {
+	it('renders highlighted tokens on the client', async () => {
+		const { client } = await modules();
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		const root = Octane.createRoot(container);
+		root.render(client.default, {});
+		Octane.flushSync(() => {});
+		const pre = container.querySelector('pre.shiki') as HTMLElement;
+		expect(pre).not.toBeNull();
+		expect(pre.className).toContain('github-light');
+		// Tokenized output: the code line is span-per-token, not plain text.
+		const tokens = [...pre.querySelectorAll('code span span')];
+		expect(tokens.length).toBeGreaterThan(1);
+		expect(pre.textContent).toContain('const x = 1;');
+		root.unmount();
+		container.remove();
+	});
+
+	it('serializes the same highlighted payload on the server (SSR/client parity)', async () => {
+		const { client, server } = await modules();
+		const { html } = ServerRT.renderToString(server.default, {});
+		expect(stripMarkers(html)).toContain('<pre class="shiki github-light"');
+
+		// The raw SSR string and a live DOM serialize attributes differently
+		// (`style="color:#fff"` vs `rgb(...)`, attr-name case) — parse the server
+		// payload through the DOM, and round-trip its style attributes through
+		// CSSOM (the client runtime sets styles via CSSOM, which normalizes on
+		// serialization), so both sides compare in the SAME normal form.
+		const parsed = document.createElement('div');
+		parsed.innerHTML = stripMarkers(html);
+		for (const el of parsed.querySelectorAll('[style]')) {
+			(el as HTMLElement).style.cssText = el.getAttribute('style')!;
+		}
+
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		const root = Octane.createRoot(container);
+		root.render(client.default, {});
+		Octane.flushSync(() => {});
+		expect(stripMarkers(container.innerHTML)).toBe(parsed.innerHTML);
+		root.unmount();
+		container.remove();
+	});
+
+	it('hydrates the server-rendered highlighted document', async () => {
+		const { client, server } = await modules();
+		const { html } = ServerRT.renderToString(server.default, {});
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		container.innerHTML = html;
+		const beforeHydrate = container.innerHTML; // DOM-normalized server payload
+		const pre = container.querySelector('pre.shiki');
+
+		const root = Octane.hydrateRoot(container, client.default, {});
+		Octane.flushSync(() => {});
+		// Hydration changed nothing, and the highlighted tree was adopted.
+		expect(container.innerHTML).toBe(beforeHydrate);
+		expect(container.querySelector('pre.shiki')).toBe(pre);
+		root.unmount();
+		container.remove();
+	});
+});

--- a/packages/mdx/tests/shiki.test.ts
+++ b/packages/mdx/tests/shiki.test.ts
@@ -6,7 +6,7 @@
  * pipeline as any other rehype transform. Highlighting is async, so the
  * async `compileMdx` is required (the vite plugin's transform already is).
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import rehypeShiki from '@shikijs/rehype';
 import * as Octane from 'octane';
 import * as ServerRT from 'octane/server';
@@ -33,6 +33,13 @@ async function modules() {
 }
 
 describe('shiki (optional, via rehypePlugins)', () => {
+	// The first highlight pays shiki's engine cold-start (oniguruma WASM +
+	// grammar/theme load; singleton-cached after), which can exceed the default
+	// 5s test timeout on slow CI runners — warm it outside any test's budget.
+	beforeAll(async () => {
+		await modules();
+	}, 60_000);
+
 	it('renders highlighted tokens on the client', async () => {
 		const { client } = await modules();
 		const container = document.createElement('div');

--- a/packages/mdx/tests/sourcemap.test.ts
+++ b/packages/mdx/tests/sourcemap.test.ts
@@ -3,13 +3,6 @@
  * `SourceMapGenerator`) maps the intermediate JSX back to the `.mdx` source,
  * octane's compiler maps its output back to the intermediate JSX, and
  * `@jridgewell/remapping` chains them.
- *
- * GAP (octane compiler): octane's `compileReturnJsxFunction` prints with the
- * map-less `printNode`, and the MDX document body is exactly that shape — so
- * the chain currently composes to an empty map and the pipeline falls back to
- * octane's intermediate-JSX map (see compile.ts). The full-chain test below is
- * pinned `it.fails` and auto-flips when octane emits segments for return-JSX
- * functions.
  */
 import { describe, it, expect } from 'vitest';
 import { TraceMap, originalPositionFor } from '@jridgewell/trace-mapping';
@@ -33,10 +26,7 @@ describe('sourcemaps', () => {
 		expect(json.mappings.length).toBeGreaterThan(0);
 	});
 
-	// GAP: flips when octane's compileReturnJsxFunction emits real esrap
-	// segments (packages/octane/src/compiler/compile.js) — then the chained map
-	// is non-empty, compile.ts uses it, and positions trace to the document.
-	it.fails('chains generated positions all the way back to .mdx lines', () => {
+	it('chains generated positions all the way back to .mdx lines', () => {
 		const { code, map } = compileMdxSync(SOURCE, '/docs/doc.mdx');
 		const tracer = new TraceMap(JSON.parse(JSON.stringify(map)));
 		const genPos = (needle: string) => {

--- a/packages/mdx/tests/sourcemap.test.ts
+++ b/packages/mdx/tests/sourcemap.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Sourcemaps — the pipeline composes a TWO-STAGE map: @mdx-js/mdx (via
+ * `SourceMapGenerator`) maps the intermediate JSX back to the `.mdx` source,
+ * octane's compiler maps its output back to the intermediate JSX, and
+ * `@jridgewell/remapping` chains them.
+ *
+ * GAP (octane compiler): octane's `compileReturnJsxFunction` prints with the
+ * map-less `printNode`, and the MDX document body is exactly that shape — so
+ * the chain currently composes to an empty map and the pipeline falls back to
+ * octane's intermediate-JSX map (see compile.ts). The full-chain test below is
+ * pinned `it.fails` and auto-flips when octane emits segments for return-JSX
+ * functions.
+ */
+import { describe, it, expect } from 'vitest';
+import { TraceMap, originalPositionFor } from '@jridgewell/trace-mapping';
+import { compileMdxSync } from '@octanejs/mdx/compile';
+
+// Distinct content on known lines (1-based): heading on 1, paragraph on 3,
+// a second heading on 9.
+const SOURCE = ['# First', '', 'a paragraph line', '', '- one', '- two', '', '', '## Later'].join(
+	'\n',
+);
+
+describe('sourcemaps', () => {
+	it('returns a valid v3 map whose source is the document', () => {
+		const { map } = compileMdxSync(SOURCE, '/docs/doc.mdx');
+		expect(map).toBeTruthy();
+		const json = JSON.parse(JSON.stringify(map));
+		expect(json.version).toBe(3);
+		expect(json.sources.some((s: string) => s.endsWith('doc.mdx'))).toBe(true);
+		// The fallback (octane's intermediate map) still carries real segments —
+		// the module is steppable, just against the intermediate JSX text.
+		expect(json.mappings.length).toBeGreaterThan(0);
+	});
+
+	// GAP: flips when octane's compileReturnJsxFunction emits real esrap
+	// segments (packages/octane/src/compiler/compile.js) — then the chained map
+	// is non-empty, compile.ts uses it, and positions trace to the document.
+	it.fails('chains generated positions all the way back to .mdx lines', () => {
+		const { code, map } = compileMdxSync(SOURCE, '/docs/doc.mdx');
+		const tracer = new TraceMap(JSON.parse(JSON.stringify(map)));
+		const genPos = (needle: string) => {
+			const lines = code.split('\n');
+			for (let i = 0; i < lines.length; i++) {
+				const col = lines[i].indexOf(needle);
+				if (col !== -1) return { line: i + 1, column: col };
+			}
+			throw new Error(`needle not in output: ${needle}`);
+		};
+		const first = originalPositionFor(tracer, genPos('"First"'));
+		expect(first.line).toBe(1);
+		const later = originalPositionFor(tracer, genPos('"Later"'));
+		expect(later.line).toBe(9);
+	});
+
+	it('returns a valid (if currently empty) map for server compiles', () => {
+		const { map } = compileMdxSync(SOURCE, '/docs/doc.mdx', { mode: 'server' });
+		expect(map).toBeTruthy();
+		const json = JSON.parse(JSON.stringify(map));
+		expect(json.version).toBe(3);
+	});
+});

--- a/packages/mdx/tests/ssr.test.ts
+++ b/packages/mdx/tests/ssr.test.ts
@@ -2,22 +2,22 @@
  * SSR — an MDX document compiled with `mode: 'server'` renders through
  * `octane/server`'s renderToString. The server-compiled module is evaluated
  * with the server runtime injected (same eval trick as
- * packages/octane/tests/hydration/hydration.test.ts) plus a provider stub for
- * the module's `@octanejs/mdx` import.
+ * packages/octane/tests/hydration/hydration.test.ts); its provider import is
+ * the REAL `@octanejs/mdx/server` (the server-mode `providerImportSource`
+ * default), so provider semantics run the real code path.
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import * as ServerRT from 'octane/server';
+import * as ServerProvider from '@octanejs/mdx/server';
 import { compileMdxSync } from '@octanejs/mdx/compile';
 
 const FIXTURES = join(process.cwd(), 'packages/mdx/tests/_fixtures');
 
 // Evaluate a server-compiled MDX module. Imports are rewritten to injected
-// bindings: `octane/server` → the real server runtime, `@octanejs/mdx` → a
-// stub provider (context has no cross-runtime SSR threading yet — see
-// docs/mdx-migration-plan.md — so the stub returns the empty mapping, exactly
-// what the real `useMDXComponents()` yields with no provider mounted).
+// bindings: `octane/server` → the real server runtime, `@octanejs/mdx/server`
+// → the real server provider layer.
 function serverModule(name: string): Record<string, any> {
 	const file = join(FIXTURES, name);
 	let { code } = compileMdxSync(readFileSync(file, 'utf8'), file, { mode: 'server' });
@@ -26,14 +26,14 @@ function serverModule(name: string): Record<string, any> {
 		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(
-		/import\s*\{([^}]*)\}\s*from\s*['"]@octanejs\/mdx['"];?/g,
+		/import\s*\{([^}]*)\}\s*from\s*['"]@octanejs\/mdx\/server['"];?/g,
 		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __provider;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export default function MDXContent/, 'function MDXContent');
 	code += '\n__exports.default = MDXContent;';
 	const fn = new Function('__rt', '__provider', '__exports', code + '\nreturn __exports;');
-	return fn(ServerRT, { useMDXComponents: () => ({}) }, {});
+	return fn(ServerRT, ServerProvider, {});
 }
 
 // Hydration block markers aside, the payload is plain HTML.
@@ -61,6 +61,46 @@ describe('SSR', () => {
 		expect(flat).toContain('<h2>Hello, MDX</h2>');
 		expect(flat).not.toContain('<h1>');
 		expect(flat).toContain('<i>emphasis</i>');
+	});
+
+	// The server provider layer (@octanejs/mdx/server): octane/server context
+	// threads the mapping to every document within one renderToString pass.
+	it('MDXProvider provides the mapping across a server render pass', () => {
+		const mod = serverModule('basic.mdx');
+		const { html } = ServerRT.renderToString(ServerProvider.MDXProvider as any, {
+			components: { h1: 'h2', em: 'i' },
+			children: ServerRT.createElement(mod.default as any, {}),
+		});
+		const flat = stripMarkers(html);
+		expect(flat).toContain('<h2>Hello, MDX</h2>');
+		expect(flat).not.toContain('<h1>');
+		expect(flat).toContain('<i>emphasis</i>');
+	});
+
+	// Per @mdx-js/react semantics (mirrored from the client layer): the
+	// components PROP merges OVER the provider context.
+	it('the components prop merges over the server provider mapping', () => {
+		const mod = serverModule('basic.mdx');
+		const { html } = ServerRT.renderToString(ServerProvider.MDXProvider as any, {
+			components: { h1: 'h2', em: 'i' },
+			children: ServerRT.createElement(mod.default as any, { components: { h1: 'h3' } }),
+		});
+		const flat = stripMarkers(html);
+		expect(flat).toContain('<h3>Hello, MDX</h3>'); // prop wins
+		expect(flat).toContain('<i>emphasis</i>'); // context still applies
+	});
+
+	// The provider route and the prop route produce the SAME payload — the
+	// supported-everywhere fallback (`components` as a prop) is not a downgrade.
+	it('provider mapping and prop mapping serialize identical payloads', () => {
+		const mod = serverModule('basic.mdx');
+		const components = { h1: 'h2', em: 'i' };
+		const viaProp = ServerRT.renderToString(mod.default, { components });
+		const viaProvider = ServerRT.renderToString(ServerProvider.MDXProvider as any, {
+			components,
+			children: ServerRT.createElement(mod.default as any, {}),
+		});
+		expect(stripMarkers(viaProvider.html)).toBe(stripMarkers(viaProp.html));
 	});
 
 	it('frontmatter exports and expressions work server-side', () => {

--- a/packages/mdx/tests/vite.test.ts
+++ b/packages/mdx/tests/vite.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Vite plugin claiming rules — which module ids `octaneMdx()` transforms.
+ * `.md` is default-ON (docs sites want plain markdown compiled like `.mdx`),
+ * with two escape hatches: `md: false` leaves ALL `.md` modules alone, and
+ * asset-query imports (`?raw`, `?url`, `?inline`) always pass through
+ * untouched — vite's asset plugin owns those (its load step already produced
+ * `export default "<file text>"`; re-compiling that JS would mangle it).
+ */
+import { describe, it, expect } from 'vitest';
+import { octaneMdx } from '@octanejs/mdx/vite';
+
+function plugin(options?: Parameters<typeof octaneMdx>[0]) {
+	const p = octaneMdx(options);
+	p.configResolved({ command: 'build' });
+	return p;
+}
+
+const transform = (p: ReturnType<typeof octaneMdx>, code: string, id: string) =>
+	p.transform.call({}, code, id);
+
+describe('octaneMdx() id claiming', () => {
+	it('transforms .mdx and .md modules (md default-on)', async () => {
+		const p = plugin();
+		expect(await transform(p, '# hi\n', '/docs/doc.mdx')).not.toBeNull();
+		expect(await transform(p, '# hi\n', '/docs/doc.md')).not.toBeNull();
+		expect(await transform(p, 'const x = 1;', '/src/mod.ts')).toBeNull();
+	});
+
+	it('md: false leaves .md modules alone', async () => {
+		const p = plugin({ md: false });
+		expect(await transform(p, '# hi\n', '/docs/doc.md')).toBeNull();
+		expect(await transform(p, '# hi\n', '/docs/doc.mdx')).not.toBeNull();
+	});
+
+	it('passes ?raw / ?url / ?inline asset imports through untouched', async () => {
+		const p = plugin();
+		// vite's asset plugin already loaded these as JS — not markdown source.
+		const assetJs = 'export default "# hi\\n";';
+		expect(await transform(p, assetJs, '/docs/doc.md?raw')).toBeNull();
+		expect(await transform(p, assetJs, '/docs/doc.mdx?raw')).toBeNull();
+		expect(await transform(p, assetJs, '/docs/doc.md?url')).toBeNull();
+		expect(await transform(p, assetJs, '/docs/doc.md?inline')).toBeNull();
+	});
+
+	it('still transforms ids carrying vite-internal bookkeeping queries', async () => {
+		const p = plugin();
+		expect(await transform(p, '# hi\n', '/docs/doc.md?v=abc123')).not.toBeNull();
+		expect(await transform(p, '# hi\n', '/docs/doc.mdx?import&v=abc123')).not.toBeNull();
+	});
+});

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -1423,18 +1423,27 @@ export function compile(source, filename, options) {
 			if (hmrEnabled) hmrComponents.push({ name: c.id.name, exportKind: 'named' });
 		} else if (isReturnJsxFunction(node)) {
 			// `function Foo() { …hooks…; return <jsx>; }` — a plain return-JSX function.
+			const base = bodyLine;
 			ctx._setupMaps = null;
 			const chunk = compileReturnJsxFunction(node, ctx, {}) + '\n\n';
+			pushDeclAnchor(node, base);
+			drainSetupMaps(base);
 			body += chunk;
 			bodyLine += countNewlines(chunk);
 		} else if (node.type === 'ExportNamedDeclaration' && isReturnJsxFunction(node.declaration)) {
+			const base = bodyLine;
 			ctx._setupMaps = null;
 			const chunk = compileReturnJsxFunction(node.declaration, ctx, { export: true }) + '\n\n';
+			pushDeclAnchor(node, base);
+			drainSetupMaps(base);
 			body += chunk;
 			bodyLine += countNewlines(chunk);
 		} else if (node.type === 'ExportDefaultDeclaration' && isReturnJsxFunction(node.declaration)) {
+			const base = bodyLine;
 			ctx._setupMaps = null;
 			const chunk = compileReturnJsxFunction(node.declaration, ctx, { default: true }) + '\n\n';
+			pushDeclAnchor(node, base);
+			drainSetupMaps(base);
 			body += chunk;
 			bodyLine += countNewlines(chunk);
 		} else if (node.type === 'ImportDeclaration' && node.source.value === 'octane') {
@@ -2862,14 +2871,40 @@ function compileReturnJsxFunction(node, ctx, options) {
 		generator: false,
 		body: { type: 'BlockStatement', body: newStatements },
 	};
-	let code = printNode(fn);
+	// Print with esrap's real per-token map (same output bytes as printNode) so
+	// this function contributes segments to the module map — compile() drains
+	// them via ctx._setupMaps, exactly like a component's setup statements.
+	// Chained consumers (e.g. @octanejs/mdx's two-stage .mdx map) need segments
+	// on these lines; a map-less print would compose to an empty chain.
+	const printed = printNodeWithMap(fn, ctx);
+	let code = printed.code;
+	const mappings = printed.mappings;
 	if (compInlinedSubs.length) {
 		// Helpers are hoisted function declarations → position-independent; splice them
 		// in right after the function's opening `{` so they're in the component scope.
 		const i = code.indexOf('{');
 		const subs = compInlinedSubs.map((s) => '  ' + s.replace(/\n/g, '\n  ')).join('\n');
+		// The splice inserts `'\n' + subs` after the `{`: every printed line below
+		// the splice line shifts down by the inserted line count. Keep the map in
+		// sync by inserting that many empty mapping lines at the same point.
+		const spliceLine = countNewlines(code.slice(0, i + 1));
+		const inserted = 1 + countNewlines(subs);
+		if (mappings.length > spliceLine + 1) {
+			mappings.splice(spliceLine + 1, 0, ...Array.from({ length: inserted }, () => []));
+		}
 		code = code.slice(0, i + 1) + '\n' + subs + code.slice(i + 1);
 	}
+	// Thread the mappings back to compile() through the same side-channel the
+	// component path uses (drained by drainSetupMaps at the emit site). The
+	// `export ` prefix shifts only line 0's columns; `export default` appends a
+	// trailing (unmapped) line and shifts nothing.
+	ctx._setupMaps =
+		options && options.export
+			? [
+					{ fnRelLine: 0, colShift: 'export '.length, mappings: mappings.slice(0, 1) },
+					{ fnRelLine: 1, colShift: 0, mappings: mappings.slice(1) },
+				]
+			: [{ fnRelLine: 0, colShift: 0, mappings }];
 	if (options && options.default) return `${code}\nexport default ${name};`;
 	if (options && options.export) return `export ${code}`;
 	return code;

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -2887,6 +2887,10 @@ function compileReturnJsxFunction(node, ctx, options) {
 		// The splice inserts `'\n' + subs` after the `{`: every printed line below
 		// the splice line shifts down by the inserted line count. Keep the map in
 		// sync by inserting that many empty mapping lines at the same point.
+		// Decoded rows are dense up to the LAST line with segments, so when the
+		// array ends at (or before) the splice line, every shifted line has no
+		// segments and there is nothing to realign — skip the padding rather than
+		// append useless empty rows.
 		const spliceLine = countNewlines(code.slice(0, i + 1));
 		const inserted = 1 + countNewlines(subs);
 		if (mappings.length > spliceLine + 1) {

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -1716,7 +1716,24 @@ function ssrCompileBody(node, ctx, name, cssHash, cssEntries, parentNs = 'html')
 				// return-JSX form: the returned host element (+ its directive children) is
 				// the render output — route it to jsxNodes so it flows through ssrEmitNode
 				// (byte-identical SSR to the `@{}` form), not printed as `return <jsx>`.
-				jsxNodes.push(child.argument);
+				// EXCEPT a returned FRAGMENT: the client VALUE-lowers `return <>…</>` to an
+				// array of createElement descriptors (rewriteJsxValues), mounted by the
+				// return-slot childSlot — whose hydration adopts ONE `<!--[-->…<!--]-->`
+				// range for the slot plus one range PER ITEM (including text items). The
+				// template walk would instead concatenate children with markerless text
+				// separators and no slot range, desyncing the hydration cursor. Route the
+				// whole fragment through the same value hole (`ssrChild(loweredArray)`) so
+				// the runtime's ssrChild array branch emits the exact per-item shape the
+				// client adopts.
+				if (child.argument.type === 'JSXFragment' || child.argument.type === 'Fragment') {
+					jsxNodes.push({
+						type: 'TSRXExpression',
+						expression: child.argument,
+						loc: child.argument.loc,
+					});
+				} else {
+					jsxNodes.push(child.argument);
+				}
 			} else if (isJsxNode(child)) {
 				if (child.type === 'Element' && elementTagName(child) === 'style') continue;
 				jsxNodes.push(child);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,12 @@ catalogs:
     '@floating-ui/utils':
       specifier: ^0.2.11
       version: 0.2.11
+    '@jridgewell/remapping':
+      specifier: ^2.3.5
+      version: 2.3.5
+    '@jridgewell/trace-mapping':
+      specifier: ^0.3.31
+      version: 0.3.31
     '@lexical/code':
       specifier: 0.46.0
       version: 0.46.0
@@ -102,6 +108,9 @@ catalogs:
     '@ripple-ts/vite-plugin':
       specifier: ^0.3.86
       version: 0.3.86
+    '@shikijs/rehype':
+      specifier: ^3.0.0
+      version: 3.23.0
     '@solidjs/web':
       specifier: 2.0.0-beta.14
       version: 2.0.0-beta.14
@@ -216,6 +225,9 @@ catalogs:
     solid-js:
       specifier: 2.0.0-beta.14
       version: 2.0.0-beta.14
+    source-map:
+      specifier: ^0.7.6
+      version: 0.7.6
     tabbable:
       specifier: ^6.5.0
       version: 6.5.0
@@ -1236,6 +1248,9 @@ importers:
 
   packages/mdx:
     dependencies:
+      '@jridgewell/remapping':
+        specifier: catalog:default
+        version: 2.3.5
       '@mdx-js/mdx':
         specifier: catalog:default
         version: 3.1.1
@@ -1251,10 +1266,19 @@ importers:
       remark-mdx-frontmatter:
         specifier: catalog:default
         version: 5.2.0
+      source-map:
+        specifier: catalog:default
+        version: 0.7.6
     devDependencies:
+      '@jridgewell/trace-mapping':
+        specifier: catalog:default
+        version: 0.3.31
       '@octanejs/testing-library':
         specifier: workspace:*
         version: link:../testing-library
+      '@shikijs/rehype':
+        specifier: catalog:default
+        version: 3.23.0
       vite:
         specifier: catalog:default
         version: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0)
@@ -3077,6 +3101,30 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
+  '@shikijs/core@3.23.0':
+    resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
+
+  '@shikijs/engine-javascript@3.23.0':
+    resolution: {integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==}
+
+  '@shikijs/engine-oniguruma@3.23.0':
+    resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
+
+  '@shikijs/langs@3.23.0':
+    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
+
+  '@shikijs/rehype@3.23.0':
+    resolution: {integrity: sha512-GepKJxXHbXFfAkiZZZ+4V7x71Lw3s0ALYmydUxJRdvpKjSx9FOMSaunv6WRLFBXR6qjYerUq1YZQno+2gLEPwA==}
+
+  '@shikijs/themes@3.23.0':
+    resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
+
+  '@shikijs/types@3.23.0':
+    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
@@ -4038,8 +4086,14 @@ packages:
   hast-util-to-estree@3.1.3:
     resolution: {integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==}
 
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-to-string@3.0.1:
+    resolution: {integrity: sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==}
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
@@ -4054,6 +4108,9 @@ packages:
 
   html-entities@2.3.3:
     resolution: {integrity: sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   http-assert@1.5.0:
     resolution: {integrity: sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==}
@@ -4664,6 +4721,12 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
 
@@ -4904,6 +4967,15 @@ packages:
   recma-stringify@1.0.0:
     resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
 
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
 
@@ -5014,6 +5086,9 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shiki@3.23.0:
+    resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
 
   side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
@@ -7152,6 +7227,48 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
+  '@shikijs/core@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  '@shikijs/engine-oniguruma@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/rehype@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@types/hast': 3.0.4
+      hast-util-to-string: 3.0.1
+      shiki: 3.23.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+
+  '@shikijs/themes@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/types@3.23.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@sindresorhus/merge-streams@4.0.0': {}
 
   '@solidjs/signals@2.0.0-beta.14': {}
@@ -8216,6 +8333,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.9
@@ -8236,6 +8367,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hast-util-to-string@3.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
@@ -8249,6 +8384,8 @@ snapshots:
       - '@noble/hashes'
 
   html-entities@2.3.3: {}
+
+  html-void-elements@3.0.0: {}
 
   http-assert@1.5.0:
     dependencies:
@@ -9072,6 +9209,14 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
   outdent@0.5.0: {}
 
   p-filter@2.1.0:
@@ -9344,6 +9489,16 @@ snapshots:
       unified: 11.0.5
       vfile: 6.0.3
 
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+
   rehype-recma@1.0.0:
     dependencies:
       '@types/estree': 1.0.9
@@ -9545,6 +9700,17 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shiki@3.23.0:
+    dependencies:
+      '@shikijs/core': 3.23.0
+      '@shikijs/engine-javascript': 3.23.0
+      '@shikijs/engine-oniguruma': 3.23.0
+      '@shikijs/langs': 3.23.0
+      '@shikijs/themes': 3.23.0
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
   side-channel-list@1.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -58,7 +58,11 @@ catalogs:
     'aria-hidden': ^1.2.6
     'tabbable': ^6.5.0
     '@lexical/code': 0.46.0
+    '@jridgewell/remapping': ^2.3.5
+    '@jridgewell/trace-mapping': ^0.3.31
     '@mdx-js/mdx': ^3.1.1
+    '@shikijs/rehype': ^3.0.0
+    'source-map': ^0.7.6
     'remark-frontmatter': ^5.0.0
     'remark-gfm': ^4.0.1
     'remark-mdx-frontmatter': ^5.2.0


### PR DESCRIPTION
## What

`compileReturnJsxFunction` — the compile path for plain `function Foo() { return <jsx>; }` components — printed its output with the map-less `printNode`, so return-JSX functions contributed **zero** sourcemap segments to the client compile's map. It now prints via `printNodeWithMap` and threads esrap's per-token mappings back to `compile()` through the existing `ctx._setupMaps` side-channel (drained by `drainSetupMaps`, exactly like component setup statements), plus a declaration anchor per function.

Two output rewrites needed map adjustments:

- **`compInlinedSubs` splice** — when folded-directive helpers are spliced in after the function's opening `{`, every printed line below shifts down by the inserted line count. Mirrored by splicing the same number of empty mapping lines at that point (the helpers themselves stay unmapped, matching the component path's `inlinedSubs`).
- **Export wrappers** — `export ` shifts only line 0's columns (+7); `export default` appends an unmapped trailing line and needs no shift.

## Why

@octanejs/mdx composes a two-stage map (`@mdx-js/mdx` map → octane map, via `@jridgewell/remapping`), and MDX document bodies (`_createMdxContent`) are exactly the return-JSX shape — so the chained map composed to empty and the pipeline fell back to octane's intermediate-JSX map. With this fix, generated positions trace all the way back to `.mdx` lines.

The pinned test flipped as designed: `packages/mdx/tests/sourcemap.test.ts`'s `it.fails('chains generated positions all the way back to .mdx lines')` is now a plain `it`, and the GAP notes in that file, `packages/mdx/src/compile.ts`, and `docs/mdx-migration-plan.md` (gap 4 → FIXED) are removed. The non-empty guard in mdx's `compile.ts` stays as a defensive fallback.

## Reviewer notes

- **This branch includes a cherry-pick of `f887fe4`** (the @octanejs/mdx Phase-1 commit from `claude/objective-khorana-db211b`, here as `023f489`) — the pinned sourcemap test and the two-stage map machinery live there, not on main. The cherry-pick applied cleanly (that branch's parent is content-identical to main's tip); if the MDX branch merges first, this resolves as a no-op on those files.
- Printed output is byte-identical (`printNodeWithMap` returns the same code as `printNode`, just with mappings), so no runtime/codegen behavior changes.
- Verified traced positions directly: dynamic holes map to exact source line/column, statements after a directive-helper splice stay aligned, exported declarations anchor to the source declaration.
- Changeset added (`octane` patch).

## Validation

- Full monorepo suite: 321 files / 2255 passed + 5 pre-existing expected-fails, zero errors
- `--project octane` and `--project mdx` green individually
- `pnpm typecheck` and `pnpm format:check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core compiler codegen, SSR HTML shape, and hydration alignment; the MDX cherry-pick is large but heavily covered by new tests.
> 
> **Overview**
> **Octane compiler:** `compileReturnJsxFunction` now prints with `printNodeWithMap` and feeds esrap segments into the module map via `ctx._setupMaps` / `drainSetupMaps` (with anchors for exports and line shifts when directive helpers are spliced), so emitted JS stays the same but devtools can step return-JSX bodies — including MDX `_createMdxContent`. **SSR:** value-position `return <>…</>` in return-JSX functions is emitted through `ssrChild([...])` instead of a markerless template walk, matching the client fragment descriptor shape for hydration.
> 
> **@octanejs/mdx (bundled Phase 1):** Adds `@octanejs/mdx/server` (`MDXProvider` / `useMDXComponents` on `octane/server`), default server `providerImportSource`, two-stage sourcemaps (`SourceMapGenerator` + `@jridgewell/remapping`), client HMR registration for `MDXContent`, Vite passthrough for `?raw`/`?url`/`?inline`, and docs/README updates. New tests cover hydration byte-adoption, SSR provider parity, Shiki via `rehypePlugins`, HMR hot-swap, Vite id rules, and `.mdx` line tracing in sourcemaps. `recmaOctaneAdapter` is down to the single `_createMdxContent(props)` → JSX mount fixup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6645ff452ad7c8c35a2b273ac58f8afaddd9c0bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->