### PR TITLE
@octanejs/router: render notFoundComponent (TanStack not-found parity)

### DIFF
--- a/.changeset/router-not-found-rendering.md
+++ b/.changeset/router-not-found-rendering.md
@@ -1,0 +1,5 @@
+---
+'@octanejs/router': patch
+---
+
+Not-found rendering, per TanStack Router semantics. An unknown URL now renders the not-found UI inside the layout chrome: router-core flags one match `globalNotFound` (the deepest fuzzy-matched route with children by default, the root with `notFoundMode: 'root'`), that route's component still renders, and its `<Outlet/>` renders the not-found UI instead of a child match. A loader/beforeLoad that throws `notFound()` renders the boundary route's not-found UI in place of its component (`status === 'notFound'`), with the NotFoundError spread onto it (`notFound({ data })` arrives as the `data` prop). Component resolution matches react-router's `renderRouteNotFound`: route `notFoundComponent` → router `defaultNotFoundComponent` → the generic `<p>Not Found</p>`. Previously `notFoundComponent` was accepted but never rendered — an unknown URL showed the layout with an empty outlet.

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -61,7 +61,10 @@ Included: `createRouter`, `createRootRoute`, `createRoute`, `RouterProvider`,
 `Outlet`, `Link`, `Navigate`, `useRouter`, `useRouterState`, `useLocation`,
 `useParams`, `useSearch`, `useLoaderData`, `useMatches`, `useNavigate`,
 **`ScrollRestoration`**, **`Await`/`useAwaited` + `defer` (streaming deferred data)**,
-and **`lazyRouteComponent` (lazy/code-split route components)**, plus the full
+and **`lazyRouteComponent` (lazy/code-split route components)**, and **not-found
+rendering** (`notFoundComponent`/`defaultNotFoundComponent`/`notFoundMode` — an
+unknown URL or a loader throwing `notFound()` renders the not-found UI inside the
+layout, per TanStack's fuzzy/root boundary rules), plus the full
 `@tanstack/router-core` re-export (`redirect`, `notFound`, history, search helpers,
 types).
 

--- a/packages/router/src/Match.tsrx
+++ b/packages/router/src/Match.tsrx
@@ -3,11 +3,15 @@
 // own match id via `matchContext` so a nested `<Outlet/>` can chain to the next
 // match. The route component is wrapped in a `@try`/`@pending` Suspense boundary
 // (the route's pendingComponent is the fallback) so lazy components and
-// `use(deferred)` suspend gracefully. v1 renders the happy path; error/not-found
-// boundaries arrive next.
+// `use(deferred)` suspend gracefully. A match that resolved with
+// `status === 'notFound'` (its loader threw `notFound()`) renders the route's
+// not-found UI instead of its component, per react-router's MatchInner; the
+// unknown-URL (`globalNotFound`) case is handled by `<Outlet/>`. Error boundaries
+// arrive next.
 import { useStore } from './useStore.ts';
 import { useRouter, matchContext } from './context.ts';
 import { Outlet } from './Outlet.tsrx';
+import { RouteNotFound } from './RouteNotFound.tsrx';
 
 export function Match(props) @{
 	const router = useRouter();
@@ -19,10 +23,14 @@ export function Match(props) @{
 
 	<matchContext.Provider value={props.matchId}>
 		@try {
-			@if (Comp) {
-				<Comp />
+			@if (match.status === 'notFound') {
+				<RouteNotFound routeId={match.routeId} error={match.error} />
 			} @else {
-				<Outlet />
+				@if (Comp) {
+					<Comp />
+				} @else {
+					<Outlet />
+				}
 			}
 		} @pending {
 			@if (Pending) {

--- a/packages/router/src/Outlet.tsrx
+++ b/packages/router/src/Outlet.tsrx
@@ -2,20 +2,35 @@
 // `matchContext`, finds the NEXT id in the match-id chain, and renders its `<Match/>`
 // — the pull-based descent that replaces a top-down state diff. Renders nothing at
 // a leaf.
+//
+// Not-found (react-router's Outlet, same order): when the URL matched no route,
+// router-core flags ONE match `globalNotFound` — with the default
+// `notFoundMode: 'fuzzy'` the deepest fuzzy-matched route that has children, with
+// `notFoundMode: 'root'` the root. That match still renders its own component
+// (the layout), and its `<Outlet/>` renders the not-found UI INSTEAD of a child
+// match — so the 404 lands inside the layout chrome.
 import { useContext } from 'octane';
 import { useStore } from './useStore.ts';
 import { useRouter, matchContext } from './context.ts';
 import { Match } from './Match.tsrx';
+import { RouteNotFound } from './RouteNotFound.tsrx';
 
 export function Outlet() @{
 	const router = useRouter();
 	const parentId = useContext(matchContext);
+	const parentStore = router.stores.matchStores.get(parentId);
+	const parentRouteId = useStore(parentStore, (m) => m?.routeId);
+	const globalNotFound = useStore(parentStore, (m) => m?.globalNotFound ?? false);
 	const childId = useStore(router.stores.matchesId, (ids) => {
 		const i = ids.indexOf(parentId);
 		return i >= 0 ? ids[i + 1] : undefined;
 	});
 
-	@if (childId) {
-		<Match matchId={childId} />
+	@if (globalNotFound) {
+		<RouteNotFound routeId={parentRouteId} />
+	} @else {
+		@if (childId) {
+			<Match matchId={childId} />
+		}
 	}
 }

--- a/packages/router/src/RouteNotFound.tsrx
+++ b/packages/router/src/RouteNotFound.tsrx
@@ -1,0 +1,23 @@
+// Renders a route's not-found UI — the port of react-router's
+// `renderRouteNotFound` (+ its `DefaultGlobalNotFound`). Resolution order matches
+// upstream: the route's own `notFoundComponent`, else the router-level
+// `defaultNotFoundComponent`, else TanStack's generic `<p>Not Found</p>` (the
+// upstream dev-only console.warn is not ported — repo policy: functional outcomes
+// only). Rendered from two places, mirroring react-router: `<Outlet/>` when its
+// match is flagged `globalNotFound` (the URL matched no route), and `<Match/>`
+// when the match resolved with `status === 'notFound'` (a loader threw
+// `notFound()`). Upstream spreads the NotFoundError onto the component, so a
+// `notFound({ data })` payload arrives as the `data` prop.
+import { useRouter } from './context.ts';
+
+export function RouteNotFound(props) @{
+	const router = useRouter();
+	const route = router.routesById[props.routeId];
+	const NotFound = route.options.notFoundComponent ?? router.options.defaultNotFoundComponent;
+
+	@if (NotFound) {
+		<NotFound {...props.error ?? {}} />
+	} @else {
+		<p>Not Found</p>
+	}
+}

--- a/packages/router/tests/_fixtures/not-found.tsrx
+++ b/packages/router/tests/_fixtures/not-found.tsrx
@@ -1,0 +1,109 @@
+import {
+	createRouter,
+	createRootRoute,
+	createRoute,
+	createMemoryHistory,
+	Outlet,
+	notFound,
+} from '@octanejs/router';
+
+// Root layout + a nested posts layout, so not-found UI can land at either level.
+function RootLayout() @{
+	<div class="root">
+		<Outlet />
+	</div>
+}
+
+function IndexPage() @{
+	<h1 class="index">{'Index'}</h1>
+}
+
+function PostsLayout() @{
+	<section class="posts">
+		<h2>{'Posts'}</h2>
+		<Outlet />
+	</section>
+}
+
+function PostsIndex() @{
+	<p class="posts-index">{'All posts'}</p>
+}
+
+// Loader-thrown notFound: `/item/missing` 404s with a data payload, other ids load.
+function ItemPage() @{
+	<p class="item">{'Item'}</p>
+}
+
+function RootNotFound() @{
+	<p class="root-notfound">{'Root not found'}</p>
+}
+
+function PostsNotFound() @{
+	<p class="posts-notfound">{'Posts not found'}</p>
+}
+
+function DefaultNotFound() @{
+	<p class="default-notfound">{'Default not found'}</p>
+}
+
+// The NotFoundError is spread onto the component (react-router's
+// renderRouteNotFound), so `notFound({ data })` arrives as the `data` prop.
+function ItemNotFound(props) @{
+	<p class="item-notfound">
+		{'Missing item ' + props.data.id}
+	</p>
+}
+
+export interface NotFoundRouterOptions {
+	/** Give the root route a notFoundComponent (default true). */
+	rootNotFound?: boolean;
+	/** Give the posts layout route its own notFoundComponent (default false). */
+	postsNotFound?: boolean;
+	/** Set a router-level defaultNotFoundComponent (default false). */
+	defaultNotFound?: boolean;
+	/** router-core's notFoundMode ('fuzzy' is TanStack's default). */
+	notFoundMode?: 'fuzzy' | 'root';
+}
+
+// A fresh router (+ fresh route tree) per call so tests don't share router state.
+export function makeRouter(initial: string, opts: NotFoundRouterOptions = {}) {
+	const rootRoute = createRootRoute({
+		component: RootLayout,
+		notFoundComponent: opts.rootNotFound ?? true ? RootNotFound : undefined,
+	});
+	const indexRoute = createRoute({
+		getParentRoute: () => rootRoute,
+		path: '/',
+		component: IndexPage,
+	});
+	const postsRoute = createRoute({
+		getParentRoute: () => rootRoute,
+		path: 'posts',
+		component: PostsLayout,
+		notFoundComponent: opts.postsNotFound ? PostsNotFound : undefined,
+	});
+	const postsIndexRoute = createRoute({
+		getParentRoute: () => postsRoute,
+		path: '/',
+		component: PostsIndex,
+	});
+	const itemRoute = createRoute({
+		getParentRoute: () => rootRoute,
+		path: 'item/$id',
+		component: ItemPage,
+		notFoundComponent: ItemNotFound,
+		loader: ({ params }: any) => {
+			if (params.id === 'missing') throw notFound({ data: { id: params.id } });
+		},
+	});
+	return createRouter({
+		routeTree: rootRoute.addChildren([
+			indexRoute,
+			postsRoute.addChildren([postsIndexRoute]),
+			itemRoute,
+		]),
+		history: createMemoryHistory({ initialEntries: [initial] }),
+		defaultNotFoundComponent: opts.defaultNotFound ? DefaultNotFound : undefined,
+		notFoundMode: opts.notFoundMode,
+	});
+}

--- a/packages/router/tests/conformance/not-found.test.ts
+++ b/packages/router/tests/conformance/not-found.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { mount, nextPaint } from '../_helpers';
+import { RouterProvider } from '@octanejs/router';
+import { makeRouter } from '../_fixtures/not-found.tsrx';
+
+async function flush() {
+	for (let i = 0; i < 5; i++) {
+		await new Promise((r) => setTimeout(r, 0));
+		await nextPaint();
+	}
+}
+
+// TanStack Router not-found semantics (per @tanstack/react-router's Outlet /
+// MatchInner / renderRouteNotFound):
+// - An unknown URL flags ONE match `globalNotFound` — with the default
+//   `notFoundMode: 'fuzzy'` the deepest fuzzy-matched route that HAS children,
+//   with `notFoundMode: 'root'` the root. That match still renders its own
+//   component (the layout); its <Outlet/> renders the not-found UI instead of a
+//   child match.
+// - The rendered component resolves route `notFoundComponent` →
+//   router `defaultNotFoundComponent` → TanStack's generic `<p>Not Found</p>`.
+// - A loader/beforeLoad that throws `notFound()` resolves the boundary in
+//   router-core (`status: 'notFound'` on the boundary match) and the
+//   NotFoundError is spread onto the component (`data` prop).
+describe('@octanejs/router not-found', () => {
+	it('an unknown URL renders the root notFoundComponent inside the root layout', async () => {
+		const router = makeRouter('/definitely/not/a/page');
+		await router.load();
+		const r = mount(RouterProvider as any, { router });
+		await flush();
+
+		expect(r.findAll('.root').length).toBe(1); // layout chrome stays up
+		expect(r.findAll('.root-notfound').length).toBe(1); // 404 in its Outlet
+		expect(r.find('.root-notfound').textContent).toBe('Root not found');
+		expect(r.findAll('.index').length).toBe(0);
+		r.unmount();
+	});
+
+	it('falls back to the router defaultNotFoundComponent when the route has none', async () => {
+		const router = makeRouter('/nope', { rootNotFound: false, defaultNotFound: true });
+		await router.load();
+		const r = mount(RouterProvider as any, { router });
+		await flush();
+
+		expect(r.findAll('.default-notfound').length).toBe(1);
+		r.unmount();
+	});
+
+	it('falls back to the generic <p>Not Found</p> when nothing is configured', async () => {
+		const router = makeRouter('/nope', { rootNotFound: false });
+		await router.load();
+		const r = mount(RouterProvider as any, { router });
+		await flush();
+
+		expect(r.find('.root').textContent).toBe('Not Found');
+		expect(r.find('.root').querySelector('p')).not.toBe(null);
+		r.unmount();
+	});
+
+	it('fuzzy mode (default) 404s at the nearest matched route with children', async () => {
+		const router = makeRouter('/posts/nope', { postsNotFound: true });
+		await router.load();
+		const r = mount(RouterProvider as any, { router });
+		await flush();
+
+		expect(r.findAll('.posts').length).toBe(1); // posts layout renders too
+		expect(r.findAll('.posts-notfound').length).toBe(1); // 404 in ITS Outlet
+		expect(r.findAll('.posts-index').length).toBe(0);
+		expect(r.findAll('.root-notfound').length).toBe(0); // root 404 not used
+		r.unmount();
+	});
+
+	it("notFoundMode: 'root' 404s at the root even for a nested unknown URL", async () => {
+		const router = makeRouter('/posts/nope', { postsNotFound: true, notFoundMode: 'root' });
+		await router.load();
+		const r = mount(RouterProvider as any, { router });
+		await flush();
+
+		expect(r.findAll('.root-notfound').length).toBe(1);
+		expect(r.findAll('.posts').length).toBe(0); // root's Outlet short-circuits
+		r.unmount();
+	});
+
+	it("a loader's notFound() renders the route's notFoundComponent with its data", async () => {
+		const router = makeRouter('/item/missing');
+		await router.load();
+		const r = mount(RouterProvider as any, { router });
+		await flush();
+
+		expect(r.findAll('.item').length).toBe(0); // route component replaced
+		expect(r.find('.item-notfound').textContent).toBe('Missing item missing');
+		r.unmount();
+	});
+
+	it('navigating unknown → known clears the not-found UI (and back again)', async () => {
+		const router = makeRouter('/');
+		await router.load();
+		const r = mount(RouterProvider as any, { router });
+		await flush();
+		expect(r.findAll('.index').length).toBe(1);
+
+		await router.navigate({ to: '/definitely/not/a/page' });
+		await flush();
+		expect(r.findAll('.root-notfound').length).toBe(1);
+		expect(r.findAll('.index').length).toBe(0);
+
+		await router.navigate({ to: '/' });
+		await flush();
+		expect(r.findAll('.root-notfound').length).toBe(0);
+		expect(r.findAll('.index').length).toBe(1);
+		r.unmount();
+	});
+});

--- a/website/tests/smoke.test.ts
+++ b/website/tests/smoke.test.ts
@@ -119,14 +119,10 @@ describe('website routes', () => {
 		}
 	});
 
-	// GAP (@octanejs/router): `createRootRoute({ notFoundComponent })` is
-	// accepted but never rendered — the port's <Match> renders only the happy
-	// path ("error/not-found boundaries arrive next", Match.tsrx). Until that
-	// lands, an unknown URL renders the root layout with an empty outlet. This
-	// test pins the current behavior so it flips when the router adds support.
-	it('an unknown route renders the layout shell (notFoundComponent is a router gap)', async () => {
+	it('an unknown route renders the root notFoundComponent inside the layout', async () => {
 		const { container } = await renderRoute('/definitely/not/a/page');
-		expect(container.querySelector('.navlinks')).toBeTruthy(); // layout up, no crash
-		expect(textOf(container)).not.toContain('Page not found'); // flips when router supports it
+		expect(container.querySelector('.navlinks')).toBeTruthy(); // layout chrome stays up
+		expect(textOf(container)).toContain('Page not found'); // NotFound page in the outlet
+		expect(container.querySelector('a.notfound-home')?.getAttribute('href')).toBe('/');
 	});
 });


### PR DESCRIPTION
createRootRoute({ notFoundComponent }) was accepted but never rendered — an unknown URL showed the layout with an empty outlet. Port the react-router render sites: <Outlet/> renders the not-found UI in place of a child match when its parent match is flagged globalNotFound (fuzzy/root boundary comes from router-core), and <Match/> renders it in place of the route component when a loader/beforeLoad threw notFound() (status === 'notFound'). New RouteNotFound.tsrx ports renderRouteNotFound's resolution chain (route notFoundComponent → defaultNotFoundComponent → generic <p>Not Found</p>) and spreads the NotFoundError so notFound({ data }) arrives as the data prop.

Adds router conformance tests for both paths + fuzzy/root modes, and flips the website's pinned 404 smoke test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core match-tree rendering for all navigations and 404s; behavior is well-tested but affects every route outlet.
> 
> **Overview**
> **`@octanejs/router` now actually renders not-found UI** — `notFoundComponent` / `defaultNotFoundComponent` were accepted before but never shown (unknown URLs left an empty outlet inside the layout).
> 
> A new **`RouteNotFound`** helper picks the UI in TanStack order: route `notFoundComponent` → router `defaultNotFoundComponent` → generic `<p>Not Found</p>`, and spreads loader **`notFound()`** errors onto the component (`data` from `notFound({ data })`).
> 
> **`<Outlet/>`** renders that UI instead of a child when the parent match is **`globalNotFound`** (unknown URL; fuzzy vs `notFoundMode: 'root'` still comes from router-core). **`<Match/>`** swaps the route component for the same UI when the match **`status === 'notFound'`**.
> 
> Conformance tests cover both paths, fallbacks, fuzzy/root boundaries, and navigation; the website smoke test now expects the real 404 page in the layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8eb8d71d2c984565b68a7eaea52b10abb9192de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->