### PR TITLE
fix ssr-hydration e2e: never test a port-squatting foreign server

### DIFF
--- a/website/tests/ssr-hydration.e2e.test.ts
+++ b/website/tests/ssr-hydration.e2e.test.ts
@@ -14,12 +14,27 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { rmSync } from 'node:fs';
+import { createServer } from 'node:net';
 import { join } from 'node:path';
 
 const WEBSITE = join(process.cwd(), 'website');
 const ROUTES = ['/', '/docs', '/benchmarks', '/playground'];
-const DEV_PORT = 5299;
-const PREVIEW_PORT = 5300;
+
+// A fresh ephemeral port per run — NEVER a fixed one. With a fixed port, a
+// leftover server from an earlier run (or another checkout) already listening
+// there makes the spawned `--strictPort` server die instantly while
+// waitForHttp happily connects to the imposter — and the suite silently
+// asserts against foreign code. That exact failure mode shipped a red main.
+function getFreePort(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const srv = createServer();
+		srv.once('error', reject);
+		srv.listen(0, '127.0.0.1', () => {
+			const { port } = srv.address() as import('node:net').AddressInfo;
+			srv.close(() => resolve(port));
+		});
+	});
+}
 
 // One shared browser; `null` means Chromium isn't available → tests skip.
 let chromium: typeof import('playwright').chromium | null = null;
@@ -43,31 +58,64 @@ afterAll(async () => {
 	await browser?.close();
 });
 
-function waitForHttp(url: string, timeoutMs: number): Promise<void> {
+// Spawn a server in its OWN process group so stop() can kill the whole tree.
+// `pnpm exec …` is a wrapper: signalling just the wrapper can orphan the real
+// node server underneath, which then squats the port for every later run.
+function spawnServer(args: string[]): ChildProcess {
+	return spawn('pnpm', args, { cwd: WEBSITE, stdio: 'ignore', detached: true });
+}
+
+// Wait until the SPAWNED server answers. Rejects the moment the child exits —
+// without that, a startup death (port conflict, build error) is invisible and
+// the probe loop can end up talking to some other process entirely.
+function waitForServer(child: ChildProcess, url: string, timeoutMs: number): Promise<void> {
 	const deadline = Date.now() + timeoutMs;
 	return new Promise((resolve, reject) => {
+		let settled = false;
+		const onExit = (code: number | null) => {
+			settled = true;
+			reject(new Error(`server for ${url} exited with code ${code} before listening`));
+		};
+		child.once('exit', onExit);
 		const probe = async () => {
+			if (settled) return;
 			try {
 				const res = await fetch(url);
-				if (res.status < 500) return resolve();
+				if (res.status < 500) {
+					settled = true;
+					child.off('exit', onExit);
+					return resolve();
+				}
 			} catch {
 				// not up yet
 			}
-			if (Date.now() > deadline) return reject(new Error(`server at ${url} never came up`));
+			if (Date.now() > deadline) {
+				settled = true;
+				child.off('exit', onExit);
+				return reject(new Error(`server at ${url} never came up`));
+			}
 			setTimeout(probe, 250);
 		};
 		probe();
 	});
 }
 
+// Kill the child's whole process group (see spawnServer), SIGKILL fallback.
 async function stop(child: ChildProcess | undefined): Promise<void> {
-	if (!child || child.exitCode !== null) return;
-	child.kill('SIGTERM');
+	if (!child || child.pid === undefined || child.exitCode !== null) return;
+	const signalGroup = (sig: NodeJS.Signals) => {
+		try {
+			process.kill(-child.pid!, sig);
+		} catch {
+			child.kill(sig); // group already gone — signal the child directly
+		}
+	};
+	signalGroup('SIGTERM');
 	await new Promise((r) => {
 		child.once('exit', r);
 		setTimeout(r, 3000);
 	});
-	if (child.exitCode === null) child.kill('SIGKILL');
+	if (child.exitCode === null) signalGroup('SIGKILL');
 }
 
 // Load `path`, collecting console errors + page errors; returns the filtered
@@ -87,17 +135,16 @@ async function loadRoute(base: string, path: string) {
 
 describe.sequential('website dev-SSR → hydration (real browser)', () => {
 	let server: ChildProcess;
+	let DEV_PORT: number;
 
 	beforeAll(async () => {
 		if (!browser) return;
+		DEV_PORT = await getFreePort();
 		// Fresh optimize-deps cache → deterministic cold start (the warmup pass
 		// below absorbs the one-time "Outdated Optimize Dep" reload).
 		rmSync(join(WEBSITE, 'node_modules/.vite'), { recursive: true, force: true });
-		server = spawn('pnpm', ['exec', 'vite', '--port', String(DEV_PORT), '--strictPort'], {
-			cwd: WEBSITE,
-			stdio: 'ignore',
-		});
-		await waitForHttp(`http://localhost:${DEV_PORT}/`, 60_000);
+		server = spawnServer(['exec', 'vite', '--port', String(DEV_PORT), '--strictPort']);
+		await waitForServer(server, `http://localhost:${DEV_PORT}/`, 60_000);
 		// Warmup pass: let vite discover + optimize every route's deps so the
 		// assertion pass sees steady-state dev behavior.
 		for (const route of ROUTES) {
@@ -131,20 +178,19 @@ describe.sequential('website dev-SSR → hydration (real browser)', () => {
 
 describe.sequential('website production build → hydration (octane-preview)', () => {
 	let server: ChildProcess;
+	let PREVIEW_PORT: number;
 
 	beforeAll(async () => {
 		if (!browser) return;
+		PREVIEW_PORT = await getFreePort();
 		await new Promise<void>((resolve, reject) => {
 			const build = spawn('pnpm', ['exec', 'vite', 'build'], { cwd: WEBSITE, stdio: 'ignore' });
 			build.once('exit', (code) =>
 				code === 0 ? resolve() : reject(new Error(`vite build exited ${code}`)),
 			);
 		});
-		server = spawn('pnpm', ['exec', 'octane-preview', '--port', String(PREVIEW_PORT)], {
-			cwd: WEBSITE,
-			stdio: 'ignore',
-		});
-		await waitForHttp(`http://localhost:${PREVIEW_PORT}/`, 30_000);
+		server = spawnServer(['exec', 'octane-preview', '--port', String(PREVIEW_PORT)]);
+		await waitForServer(server, `http://localhost:${PREVIEW_PORT}/`, 30_000);
 	}, 180_000);
 
 	afterAll(async () => {

--- a/website/tests/ssr-hydration.e2e.test.ts
+++ b/website/tests/ssr-hydration.e2e.test.ts
@@ -82,6 +82,17 @@ function waitForServer(child: ChildProcess, url: string, timeoutMs: number): Pro
 			try {
 				const res = await fetch(url);
 				if (res.status < 500) {
+					// An HTTP answer proves something listens on the port — not that
+					// it's OUR child: it may have died mid-fetch with its 'exit'
+					// dispatch still queued while a foreign process answers. Give the
+					// exit event a beat to land, then require the child to be alive.
+					await new Promise((r) => setTimeout(r, 50));
+					if (settled) return; // onExit rejected meanwhile
+					if (child.exitCode !== null || child.signalCode !== null) {
+						settled = true;
+						child.off('exit', onExit);
+						return reject(new Error(`server at ${url} answered but the spawned process is dead`));
+					}
 					settled = true;
 					child.off('exit', onExit);
 					return resolve();


### PR DESCRIPTION
The suite spawned its servers on fixed ports (5299/5300). A leftover server from an earlier run — pnpm-exec wrapper trees orphan the real node process when stop() signals only the direct child — squatted the port, the spawned --strictPort vite died instantly on EADDRINUSE (hidden by stdio:'ignore'), and waitForHttp connected to the imposter. The suite then asserted against whatever checkout the zombie was serving, reporting a phantom hydration mismatch (Matches.tsrx:53) that the actual code under test never produced.

Harden the harness (no assertion loosened):
- pick a fresh ephemeral port per suite via getFreePort()
- waitForServer rejects the moment the spawned child exits, so a startup death fails loudly instead of probing a stranger
- spawn detached and kill the whole process group in stop(), so wrapper trees can't leak orphans again

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only harness changes in `ssr-hydration.e2e.test.ts`; no production app or auth/data paths affected.
> 
> **Overview**
> Fixes a **false-red** failure mode where the SSR hydration e2e suite could pass HTTP checks against a **foreign** server on a fixed port while the intended Vite/preview child had already exited (e.g. `--strictPort` + `EADDRINUSE`).
> 
> The harness now picks an **ephemeral port** per run via `getFreePort()`, spawns servers **detached** in their own process group, and **`waitForServer`** fails fast if the spawned child exits (with a short post-fetch check that the child is still alive). **`stop()`** signals the **whole process group** so `pnpm exec` wrapper trees cannot leave orphan Node listeners squatting ports. **Assertion strictness is unchanged**—only startup/teardown reliability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b0cf1bcb61c50b1a0a94e9d427b74914e3a3b7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->