### PR TITLE
useFormStatus: activate for startTransition inside a preventDefault-ed submit

### DIFF
--- a/.changeset/manual-form-status.md
+++ b/.changeset/manual-form-status.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+`useFormStatus` now activates for the manual-action idiom (React parity): a `startTransition` called synchronously during a form's submit dispatch whose default was prevented (`onSubmit={e => { e.preventDefault(); startTransition(async () => …) }}`) publishes pending status to that form until every such transition settles. Previously only the intercepted `<form action={fn}>` path published form status. A plain async handler (no transition) or a non-prevented submit still never activates it, and the manual and intercepted paths share the same pending counter so overlapping submissions coalesce.

--- a/docs/parity-gaps.md
+++ b/docs/parity-gaps.md
@@ -12,12 +12,7 @@ converted to a plain `it`, and this index must be regenerated
 since-fixed behavior or intentional platform differences. Only the pins below
 are live gaps.
 
-**5 active pin(s).**
-
-## packages/octane/tests/conformance/form-actions-extra.test.ts
-
-- **activates for startTransition inside a preventDefault-ed submit (Per :2021/:2078)**
-  - GAP: Per ReactDOMForm-test.js:2021/:2078 — React ACTIVATES useFormStatus when startTransition is called inside a preventDefault-ed submit event (the manual-action idiom). In octane, form status is published ONLY by the intercepted `<form action={fn}>` path (handleFormSubmit → setFormStatus in runtime.ts); a transition started during a submit event dispatch never reaches the form. Likely fix: handleFormSubmit-adjacent tracking — when a transition starts synchronously during a form's submit dispatch whose default was prevented, publish pending status to that form until it settles.
+**4 active pin(s).**
 
 ## packages/octane/tests/conformance/insertion-effect-order.test.ts
 

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -5548,6 +5548,21 @@ function dispatchDelegated(event: Event): void {
 	const targetOnly = TARGET_ONLY_DELEGATED.has(event.type);
 	_dispatchDepth++;
 	let node = event.target as any;
+	// A submit dispatch targeting a form opens the manual-action useFormStatus
+	// window (see publishManualFormPending): handlers' startTransition calls
+	// register on the record; the walk's end decides whether to publish.
+	const prevSubmitRec = ACTIVE_SUBMIT_DISPATCH;
+	const submitRec: SubmitDispatchRec | null =
+		event.type === 'submit' && node != null && node.nodeName === 'FORM'
+			? {
+					form: node as HTMLFormElement,
+					event: event as SubmitEvent,
+					transitions: 0,
+					published: false,
+					intercepted: false,
+				}
+			: null;
+	if (submitRec !== null) ACTIVE_SUBMIT_DISPATCH = submitRec;
 	try {
 		// CAPTURE_DELEGATED types have BOTH dispatchers attached as capture-phase
 		// listeners on the same root, so same-node registration ORDER — not phase —
@@ -5582,6 +5597,12 @@ function dispatchDelegated(event: Event): void {
 			}
 		}
 	} finally {
+		if (submitRec !== null) {
+			ACTIVE_SUBMIT_DISPATCH = prevSubmitRec;
+			// Before the depth drop + discrete flush, so a published pending status
+			// commits in this event's flush window (like handleFormSubmit's does).
+			publishManualFormPending(submitRec);
+		}
 		clearCurrentTarget(event);
 		_dispatchDepth--;
 		maybeFlushDiscrete(event.type);
@@ -5663,6 +5684,68 @@ function setFormStatus(form: HTMLFormElement, status: FormStatus): void {
 	FORM_STATUS.set(form, status);
 	const ls = FORM_STATUS_LISTENERS.get(form);
 	if (ls) for (const l of ls) l();
+}
+
+// ---------------------------------------------------------------------------
+// Manual-action useFormStatus activation (React parity — FormActionEventPlugin):
+// besides the intercepted `<form action={fn}>` path, React publishes pending
+// status when startTransition is called synchronously during a form's submit
+// dispatch whose default was prevented (the `onSubmit={e => { e.preventDefault();
+// startTransition(async () => …) }}` idiom). React entangles the pending state
+// with the transitions the event scheduled (currentEventTransitionLane);
+// octane's equivalent is a per-dispatch record: dispatchDelegated opens it for
+// a submit event targeting a form, startTransition registers on it, and when
+// the walk ends with the default prevented (and the intercepted path didn't
+// claim the submit) pending status is published until every registered
+// transition settles. Shares handleFormSubmit's `$$pendingSubmits` counter so
+// overlapping manual and intercepted submissions coalesce to one idle flip.
+// ---------------------------------------------------------------------------
+
+interface SubmitDispatchRec {
+	form: HTMLFormElement;
+	event: SubmitEvent;
+	/** Transitions started synchronously during this dispatch, not yet settled. */
+	transitions: number;
+	/** Pending status was published for this dispatch (manual-action path). */
+	published: boolean;
+	/** handleFormSubmit ran for this dispatch — status is its responsibility. */
+	intercepted: boolean;
+}
+
+let ACTIVE_SUBMIT_DISPATCH: SubmitDispatchRec | null = null;
+
+// Runs when the submit dispatch's handler walk finishes (dispatchDelegated).
+function publishManualFormPending(rec: SubmitDispatchRec): void {
+	if (rec.intercepted || rec.transitions === 0 || !rec.event.defaultPrevented) return;
+	const form = rec.form;
+	let data: FormData | null = null;
+	try {
+		data = new FormData(form);
+		const submitter = rec.event.submitter as HTMLInputElement | null;
+		if (submitter && submitter.name) data.append(submitter.name, submitter.value ?? '');
+	} catch {
+		/* jsdom quirks — status still activates with data: null */
+	}
+	const fa = form as any;
+	fa.$$pendingSubmits = (fa.$$pendingSubmits || 0) + 1;
+	rec.published = true;
+	setFormStatus(form, {
+		pending: true,
+		data,
+		method: form.method || 'get',
+		// React reports the form's action PROP here; octane's equivalents are the
+		// intercept function ($$formAction) or the plain attribute.
+		action: (fa.$$formAction as FormStatus['action']) ?? form.getAttribute('action'),
+	});
+}
+
+// Runs once per registered transition, on settle (fulfil, reject, or sync throw).
+function settleSubmitTransition(rec: SubmitDispatchRec): void {
+	rec.transitions--;
+	if (rec.transitions !== 0 || !rec.published) return;
+	const fa = rec.form as any;
+	fa.$$pendingSubmits = Math.max(0, (fa.$$pendingSubmits || 1) - 1);
+	if (fa.$$pendingSubmits === 0) setFormStatus(rec.form, IDLE_FORM_STATUS);
 }
 
 // Forms whose reset was requested during a transition/action window, applied
@@ -5764,6 +5847,11 @@ function handleFormSubmit(form: HTMLFormElement, event: Event): void {
 		(submitter && (submitter as any).$$formAction) || ((form as any).$$formAction as unknown);
 	if (typeof action !== 'function') return; // native submit / no function action
 	event.preventDefault();
+	// This submit is the intercepted-action path's responsibility — suppress the
+	// manual startTransition activation for the same dispatch (the action's own
+	// transition would otherwise double-publish through the record).
+	if (ACTIVE_SUBMIT_DISPATCH !== null && ACTIVE_SUBMIT_DISPATCH.form === form)
+		ACTIVE_SUBMIT_DISPATCH.intercepted = true;
 
 	const data = new FormData(form);
 	// Include the activating submitter's name/value (FormData(form, submitter)
@@ -10316,6 +10404,12 @@ export function startTransition(fn: () => void | Promise<unknown>): void {
 	// Bump the priority flag FIRST so any scheduleRender calls fired by the
 	// listener notification (and by fn itself) are tagged as transition.
 	TRANSITION_DEPTH++;
+	// A transition started synchronously during a form's submit dispatch
+	// entangles with that form's status (manual-action useFormStatus activation —
+	// see publishManualFormPending). Registered here; every settle path below
+	// notifies the record exactly once.
+	const submitRec = ACTIVE_SUBMIT_DISPATCH;
+	if (submitRec !== null) submitRec.transitions++;
 	let result: unknown;
 	try {
 		tickTransitionCount(+1);
@@ -10326,6 +10420,7 @@ export function startTransition(fn: () => void | Promise<unknown>): void {
 		}
 	} catch (err) {
 		tickTransitionCount(-1);
+		if (submitRec !== null) settleSubmitTransition(submitRec);
 		// Don't strand resets queued before the throw — they'd fire on an unrelated
 		// later transition's settle otherwise. (flushFormResets self-guards if an
 		// outer transition window is still open.)
@@ -10348,6 +10443,7 @@ export function startTransition(fn: () => void | Promise<unknown>): void {
 			settled = true;
 			ASYNC_TRANSITION_COUNT--;
 			tickTransitionCount(-1);
+			if (submitRec !== null) settleSubmitTransition(submitRec);
 			// The action window (may have) closed — apply queued requestFormReset()s.
 			flushFormResets();
 		};
@@ -10359,6 +10455,7 @@ export function startTransition(fn: () => void | Promise<unknown>): void {
 		// count themselves via handleSuspense, so the net count stays > 0.
 		queueMicrotask(() => {
 			tickTransitionCount(-1);
+			if (submitRec !== null) settleSubmitTransition(submitRec);
 			flushFormResets();
 		});
 	}

--- a/packages/octane/tests/conformance/_fixtures/form-actions-extra.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/form-actions-extra.tsrx
@@ -37,8 +37,8 @@ function StatusOut(props) @{
 	</span>
 }
 
-// Manual onSubmit: preventDefault + startTransition(async). React activates
-// useFormStatus for this shape; the octane port pins the current behavior.
+// Manual onSubmit: preventDefault + startTransition(async). Activates
+// useFormStatus (React parity — the manual-action idiom).
 export function ManualTransitionForm(props) @{
 	const [, startFormTransition] = useTransition();
 	<form

--- a/packages/octane/tests/conformance/form-actions-extra.test.ts
+++ b/packages/octane/tests/conformance/form-actions-extra.test.ts
@@ -16,10 +16,11 @@ import {
 //     START until the previous one finishes) and error handling (@try/@catch is
 //     octane's error boundary; an errored action does NOT cancel the queue —
 //     octane divergence, pinned in actions.test.ts for sync throws).
-//   * the useFormStatus ACTIVATION rule — in octane, pending is published ONLY by
-//     the intercepted `<form action={fn}>` submit path (handleFormSubmit in
-//     runtime.ts); React additionally activates it for a startTransition inside a
-//     preventDefault-ed onSubmit.
+//   * the useFormStatus ACTIVATION rule — pending is published by the intercepted
+//     `<form action={fn}>` submit path (handleFormSubmit in runtime.ts) AND, like
+//     React, for a startTransition inside a preventDefault-ed onSubmit
+//     (publishManualFormPending); never for a plain async handler or a
+//     non-prevented submit.
 //
 // Covered by existing suites (not re-ported):
 //   * basic dispatch/pending/state commit + sequential threading —
@@ -203,46 +204,33 @@ describe('conformance: useActionState error handling (ReactDOMForm)', () => {
 });
 
 describe('conformance: useFormStatus activation rule (ReactDOMForm)', () => {
-	// GAP: Per ReactDOMForm-test.js:2021/:2078 — React ACTIVATES useFormStatus
-	// when startTransition is called inside a preventDefault-ed submit event
-	// (the manual-action idiom). In octane, form status is published ONLY by the
-	// intercepted `<form action={fn}>` path (handleFormSubmit → setFormStatus in
-	// runtime.ts); a transition started during a submit event dispatch never
-	// reaches the form. Likely fix: handleFormSubmit-adjacent tracking — when a
-	// transition starts synchronously during a form's submit dispatch whose
-	// default was prevented, publish pending status to that form until it settles.
-	it.fails(
-		'activates for startTransition inside a preventDefault-ed submit (Per :2021/:2078)',
-		async () => {
-			const gate = deferred();
-			const r = mount(ManualTransitionForm as any, {
-				value: 'Initial',
-				wait: () => gate.promise,
-			});
-			try {
-				flushSync(() => {});
-				expect(r.find('#out').textContent).toBe('Initial');
+	// Per ReactDOMForm-test.js:2021/:2078 — React ACTIVATES useFormStatus when
+	// startTransition is called inside a preventDefault-ed submit event (the
+	// manual-action idiom). Octane matches: a transition started synchronously
+	// during a form's submit dispatch whose default was prevented publishes
+	// pending status to that form until the transition settles
+	// (publishManualFormPending in runtime.ts).
+	it('activates for startTransition inside a preventDefault-ed submit (Per :2021/:2078)', async () => {
+		const gate = deferred();
+		const r = mount(ManualTransitionForm as any, {
+			value: 'Initial',
+			wait: () => gate.promise,
+		});
+		flushSync(() => {});
+		expect(r.find('#out').textContent).toBe('Initial');
 
-				submit(r.container);
-				await Promise.resolve();
-				await Promise.resolve();
-				flushSync(() => {});
-				// React: the form switches into a pending state.
-				expect(r.find('#out').textContent).toBe('Initial (pending...)');
+		submit(r.container);
+		await Promise.resolve();
+		await Promise.resolve();
+		flushSync(() => {});
+		// React: the form switches into a pending state.
+		expect(r.find('#out').textContent).toBe('Initial (pending...)');
 
-				gate.resolve();
-				await settle();
-				expect(r.find('#out').textContent).toBe('Initial');
-			} finally {
-				// This test is expected to fail mid-flight (see the GAP note) — the
-				// in-flight transition and mounted form MUST still be drained, or the
-				// leaked async-transition window corrupts the tests that follow.
-				gate.resolve();
-				await settle();
-				r.unmount();
-			}
-		},
-	);
+		gate.resolve();
+		await settle();
+		expect(r.find('#out').textContent).toBe('Initial');
+		r.unmount();
+	});
 
 	// Per :2089/:2146 — a plain async event handler (no transition) never
 	// activates useFormStatus. Octane matches.


### PR DESCRIPTION
## What

Closes the parity gap pinned at `packages/octane/tests/conformance/form-actions-extra.test.ts` (Per ReactDOMForm-test.js:2021/:2078): React activates `useFormStatus` when `startTransition` is called inside a preventDefault-ed submit handler (the manual-action idiom — `onSubmit={e => { e.preventDefault(); startTransition(async () => …) }}`). Octane previously published form status only through the intercepted `<form action={fn}>` path.

## How

Form-scoped submit/transition tracking in `runtime.ts`, mirroring React's `FormActionEventPlugin` + `currentEventTransitionLane` entanglement:

- `dispatchDelegated` opens an `ACTIVE_SUBMIT_DISPATCH` record for a `submit` event targeting a `<form>`, and closes it when the handler walk ends.
- `startTransition` registers on the open record when called synchronously during that dispatch and notifies it exactly once on settle (async promise settle, sync microtask, or sync throw).
- If the walk ends with `event.defaultPrevented`, ≥1 registered transition, and no interception, `publishManualFormPending` publishes `{ pending: true, data, method, action }` to that form — before the discrete flush, so the flip commits in the same event window — and the status returns to idle when the last registered transition settles.
- The manual path shares `handleFormSubmit`'s `$$pendingSubmits` counter, so overlapping manual and intercepted submissions coalesce into a single idle flip; `handleFormSubmit` marks the record `intercepted` so the action path's own transition never double-publishes.

Activation stays per-form and per-dispatch — the process-global async-transition window is untouched. A plain async handler (no transition) and a non-prevented submit still never activate, which the two neighboring conformance tests pin.

## Reviewer notes

- The `it.fails` pin is flipped to a passing `it` (its drain-on-failure `finally` scaffolding is no longer needed); `docs/parity-gaps.md` regenerated via `pnpm parity:gaps` (5 → 4 pins).
- Patch changeset for `octane` included.
- Validation: conformance file passes in dev and prod compile modes (16/16); full `pnpm test` green (747 files, 5812 passed, 16 expected-fail pins); `pnpm typecheck` and `pnpm format:check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches event dispatch, `startTransition`, and form status in the core runtime; behavior is scoped to form submit + transition entanglement and is covered by conformance tests.
> 
> **Overview**
> **`useFormStatus`** now goes pending for the manual-action pattern (`onSubmit` → `preventDefault` → synchronous **`startTransition`**) to match React, not only for intercepted **`<form action={fn}>`** submits.
> 
> The runtime tracks each form **`submit`** during delegated dispatch: **`startTransition`** calls in that window register on the record; when handlers finish with default prevented and at least one transition (and the intercepted path did not take the submit), **`publishManualFormPending`** sets pending status with **FormData** until those transitions settle. **`handleFormSubmit`** marks the same dispatch as intercepted so action transitions do not double-publish; manual and intercepted paths share **`$$pendingSubmits`** so overlapping work clears idle once.
> 
> The former **`it.fails`** conformance pin is a passing test; parity gap count **5 → 4**; patch changeset for **`octane`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f76e43bde6aa60a654f9c6adc630debf999aeafa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->