### PR TITLE
compiler: self-declarative hand-slot-forwarding via package.json manifests

### DIFF
--- a/.changeset/hook-slots-manifest.md
+++ b/.changeset/hook-slots-manifest.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+compiler/vite: hand-slot-forwarding libraries are now self-declarative. A binding whose plain `.ts`/`.js` sources forward hook slots themselves declares `"octane": { "hookSlots": { "manual": ["src"] } }` in its own package.json, and the plugin's surgical hook-slotting pass skips files under the declared directories automatically (nearest-manifest lookup, cached per directory) — no more repeating `exclude` path lists in every Vite/Vitest config that aliases workspace sources. The scope is a directory list rather than the whole package so a binding's own test files stay auto-slotted. The `exclude` option remains as an ad-hoc escape hatch.

--- a/docs/project-analysis-concerns.md
+++ b/docs/project-analysis-concerns.md
@@ -248,6 +248,21 @@ improvement is to make hand-slot-forwarding self-declarative (package metadata,
 a source pragma, or a plugin option exported by the binding) and consume one
 shared exclusion definition in tests, website, examples, and builds.
 
+**Resolved (2026-07-10):** hand-slot-forwarding is now self-declarative. Each
+such binding carries `"octane": { "hookSlots": { "manual": ["src"] } }` in its own
+`package.json`; the compiler plugin's surgical pass walks to the nearest
+manifest and skips files under the declared directories automatically (cached
+per directory), so the trait travels with the package into every consumer. The
+scope is a directory list — not the whole package — because a binding's own
+test files must stay auto-slotted. All repeated `exclude`
+path lists were deleted from the root Vitest projects, `website/vite.config.ts`,
+and the examples; the option survives only as an ad-hoc escape hatch.
+`packages/octane/tests/external-hook-slot.test.ts` pins the declaration
+registry (currently: base-ui, floating-ui, lexical, mdx, motion, radix, stylex,
+tanstack-query, tanstack-router, testing-library, zustand — redux/recharts/
+hook-form are auto-slotted by design) and covers the skip/slot behavior in both
+dev and prod compile modes via the `octane-prod` project.
+
 ## 7. Marker protocol remains a major complexity center
 
 Severity: medium; current work is measured and well tested.

--- a/docs/testing-library-migration-plan.md
+++ b/docs/testing-library-migration-plan.md
@@ -42,8 +42,9 @@ Octane hooks are keyed by compiler-assigned call-site slots, and a plain-`.ts`
 harness is outside the compiler:
 
 - the harness component's own hooks use **explicit `Symbol.for` slots**, and the
-  package's `src/` is **excluded from the auto-slotting pass** in
-  `vitest.config.js` (published node_modules are skipped automatically);
+  package **declares `"octane": { "hookSlots": { "manual": ["src"] } }` in its package.json**
+  so the auto-slotting pass skips its sources everywhere (published
+  node_modules are skipped automatically);
 - the user's hook callback is invoked through **`withSlot`**, so a slotless
   binding hook (`renderHook(() => useStore(api))`) resolves an identity via the
   path stack; callbacks the compiler did slot fold their explicit slots into the

--- a/examples/hacker-news/jsx/vite.config.ts
+++ b/examples/hacker-news/jsx/vite.config.ts
@@ -29,17 +29,13 @@ export default defineConfig({
 
 	plugins: [
 		octaneServerAlias(),
-		// Full-compile the app's `.tsx`/`.tsrx`, but DON'T re-slot the binding
-		// packages' hand-written slot-forwarding `.ts` sources (they already forward
-		// hook slots themselves). The shared app `.ts` files (hooks/routes) are NOT
-		// excluded, so their octane hook call-sites still get slotted.
-		octane({
-			exclude: [
-				'/packages/tanstack-router/src/',
-				'/packages/stylex/src/',
-				'/packages/tanstack-query/src/',
-			],
-		}),
+		// Full-compile the app's `.tsx`/`.tsrx`. The binding packages'
+		// hand-written slot-forwarding `.ts` sources declare
+		// `"octane": { "hookSlots": { "manual": ["src"] } }` in their package.json, so the
+		// plugin skips re-slotting them automatically. The shared app `.ts` files
+		// (hooks/routes) carry no declaration, so their octane hook call-sites
+		// still get slotted.
+		octane(),
 		stylex(),
 	],
 

--- a/examples/hacker-news/tsrx/vite.config.ts
+++ b/examples/hacker-news/tsrx/vite.config.ts
@@ -29,17 +29,13 @@ export default defineConfig({
 
 	plugins: [
 		octaneServerAlias(),
-		// Full-compile the app's `.tsx`/`.tsrx`, but DON'T re-slot the binding
-		// packages' hand-written slot-forwarding `.ts` sources (they already forward
-		// hook slots themselves). The shared app `.ts` files (hooks/routes) are NOT
-		// excluded, so their octane hook call-sites still get slotted.
-		octane({
-			exclude: [
-				'/packages/tanstack-router/src/',
-				'/packages/stylex/src/',
-				'/packages/tanstack-query/src/',
-			],
-		}),
+		// Full-compile the app's `.tsx`/`.tsrx`. The binding packages'
+		// hand-written slot-forwarding `.ts` sources declare
+		// `"octane": { "hookSlots": { "manual": ["src"] } }` in their package.json, so the
+		// plugin skips re-slotting them automatically. The shared app `.ts` files
+		// (hooks/routes) carry no declaration, so their octane hook call-sites
+		// still get slotted.
+		octane(),
 		stylex(),
 	],
 

--- a/examples/lexical-playground/vite.config.ts
+++ b/examples/lexical-playground/vite.config.ts
@@ -3,9 +3,11 @@ import { octane } from 'octane/compiler/vite';
 
 export default defineConfig({
 	// The octane plugin compiles `.tsrx` everywhere EXCEPT @octanejs/lexical's own
-	// `.ts` hooks (which forward hook slots manually — same exclude the vitest config
-	// uses). The package's `.tsrx` components still compile.
-	plugins: [octane({ exclude: ['/packages/lexical/src/'] })],
+	// `.ts` hooks — they forward hook slots manually, declared via
+	// `"octane": { "hookSlots": { "manual": ["src"] } }` in the package's package.json, so the
+	// plugin skips them automatically. The package's `.tsrx` components still
+	// compile.
+	plugins: [octane()],
 	optimizeDeps: { exclude: ['octane', 'octane/compiler', '@octanejs/lexical'] },
 	resolve: {
 		// Resolve @octanejs/lexical's per-subpath `.tsrx`/`.ts` modules (mirrors the

--- a/packages/base-ui/package.json
+++ b/packages/base-ui/package.json
@@ -3,6 +3,13 @@
   "version": "0.1.1",
   "license": "MIT",
   "type": "module",
+  "octane": {
+    "hookSlots": {
+      "manual": [
+        "src"
+      ]
+    }
+  },
   "description": "Base UI (@base-ui/react) for the octane renderer — headless, accessible, unstyled UI primitives ported from base-ui.com at full fidelity.",
   "author": {
     "name": "Dominic Gannaway",

--- a/packages/floating-ui/package.json
+++ b/packages/floating-ui/package.json
@@ -3,6 +3,13 @@
   "version": "0.1.2",
   "license": "MIT",
   "type": "module",
+  "octane": {
+    "hookSlots": {
+      "manual": [
+        "src"
+      ]
+    }
+  },
   "description": "Floating UI bindings for the octane renderer — a port of @floating-ui/react (positioning + interactions + focus management) on top of the framework-agnostic @floating-ui/dom.",
   "author": {
     "name": "Dominic Gannaway",

--- a/packages/lexical/package.json
+++ b/packages/lexical/package.json
@@ -3,6 +3,13 @@
   "version": "0.1.2",
   "license": "MIT",
   "type": "module",
+  "octane": {
+    "hookSlots": {
+      "manual": [
+        "src"
+      ]
+    }
+  },
   "description": "Lexical bindings for the octane renderer — reuses the framework-agnostic @lexical/* core and reimplements the @lexical/react layer on octane's hooks.",
   "author": {
     "name": "Dominic Gannaway",

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -3,6 +3,13 @@
   "version": "0.1.0",
   "license": "MIT",
   "type": "module",
+  "octane": {
+    "hookSlots": {
+      "manual": [
+        "src"
+      ]
+    }
+  },
   "description": "MDX for the octane renderer — compiles .mdx/.md through @mdx-js/mdx to JSX source and then through octane/compiler, so documents render as real compiled octane components (templates, not runtime descriptors); ships the @mdx-js/react provider layer (MDXProvider/useMDXComponents) ported onto octane context.",
   "author": {
     "name": "Dominic Gannaway",

--- a/packages/motion/package.json
+++ b/packages/motion/package.json
@@ -3,6 +3,13 @@
   "version": "0.1.2",
   "license": "MIT",
   "type": "module",
+  "octane": {
+    "hookSlots": {
+      "manual": [
+        "src"
+      ]
+    }
+  },
   "description": "Framer Motion bindings for the octane renderer — reuses motion-dom's animation engine, swaps the React components for octane host components.",
   "author": {
     "name": "Dominic Gannaway",

--- a/packages/octane/src/compiler/vite.js
+++ b/packages/octane/src/compiler/vite.js
@@ -18,19 +18,83 @@
  *     hoisted parallel starts, batched unwrap, fetch-tree warming —
  *     docs/suspense-parallel-use-plan.md). ON by default (client mode); pass
  *     `false` to opt out and restore React-timing waterfall semantics.
+ *   - `exclude`: ad-hoc path fragments the `.ts`/`.js` hook-slotting pass must
+ *     skip. Rarely needed — a library whose sources hand-forward hook slots
+ *     declares `"octane": { "hookSlots": { "manual": ["src"] } }` in its own package.json
+ *     and is skipped automatically (see hasManualHookSlots below).
  */
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { compile } from './compile.js';
 import { slotHooks } from './slot-hooks.js';
+
+// A binding whose `.ts`/`.js` sources hand-forward hook slots (explicit slot
+// symbols / subSlot composition) declares it ONCE in its own package.json,
+// listing the package-relative directories those sources live in:
+//
+//   "octane": { "hookSlots": { "manual": ["src"] } }
+//
+// The surgical slot pass walks up from each candidate file to the NEAREST
+// package.json and skips the file when it sits under a declared directory — so
+// the trait travels with the package into every consumer (root vitest
+// projects, the website, examples, builds) instead of being repeated as
+// per-config `exclude` path lists that can drift. The scope is a directory
+// list (not the whole package) because the package's OWN test files must stay
+// auto-slotted: hook callbacks written inline in tests rely on their
+// call-site slots. Manifest lookups are cached per directory; the cache is
+// module-level so all plugin instances (e.g. the many vitest projects) share
+// it.
+const manifestRuleCache = new Map();
+
+function nearestManualHookSlotRule(fileDir) {
+	const missed = [];
+	let dir = fileDir;
+	let rule = null;
+	for (;;) {
+		if (manifestRuleCache.has(dir)) {
+			rule = manifestRuleCache.get(dir);
+			break;
+		}
+		missed.push(dir);
+		let pkg = null;
+		try {
+			pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'));
+		} catch {
+			// no manifest in this directory (or unreadable) — keep walking up
+		}
+		if (pkg !== null) {
+			// Nearest manifest wins — a package without the declaration is
+			// auto-slotted; don't let an outer (e.g. monorepo root) manifest speak
+			// for it.
+			const manual = pkg.octane?.hookSlots?.manual;
+			rule = Array.isArray(manual) ? { root: dir, dirs: manual } : null;
+			break;
+		}
+		const parent = dirname(dir);
+		if (parent === dir) break; // filesystem root, no manifest anywhere
+		dir = parent;
+	}
+	for (const d of missed) manifestRuleCache.set(d, rule);
+	return rule;
+}
+
+function hasManualHookSlots(file) {
+	const rule = nearestManualHookSlotRule(dirname(file));
+	if (rule === null) return false;
+	return rule.dirs.some((d) => file.startsWith(rule.root + '/' + d.replace(/\/+$/, '') + '/'));
+}
 
 export function octane(options = {}) {
 	let hmrEnabled = options.hmr;
 	// An explicit override of the per-module SSR auto-detection (true → always
 	// server, false → always client). `undefined` keeps auto-detection.
 	const forceSsr = options.ssr;
-	// Path fragments to skip in the plain `.ts`/`.js` hook-slotting pass — for
-	// hand-written library bindings that forward slots themselves (which would
-	// otherwise be double-slotted). In a real app these live in node_modules and
-	// are skipped automatically; this is for monorepo / aliased-to-source setups.
+	// Ad-hoc path fragments to skip in the plain `.ts`/`.js` hook-slotting pass.
+	// Hand-slot-forwarding bindings should NOT need this: they self-declare via
+	// `"octane": { "hookSlots": { "manual": ["src"] } }` in their package.json (see
+	// hasManualHookSlots above), and published bindings live in node_modules and
+	// are skipped automatically. This option remains as an escape hatch for
+	// sources that can't carry a manifest declaration.
 	const excludePaths = options.exclude ?? [];
 	return {
 		name: 'octane',
@@ -66,13 +130,15 @@ export function octane(options = {}) {
 			// Plain `.ts`/`.js` can't be re-emitted (esrap can't print arbitrary TS), so a
 			// custom hook living there gets the SURGICAL, hook-only pass: only octane base
 			// hook calls are edited; every other byte passes through. Skip node_modules
-			// (published bindings ship pre-slotted), the `// octane-no-slot` opt-out, and
-			// any configured exclude path. Cheap import pre-check before parsing.
+			// (published bindings ship pre-slotted), the `// octane-no-slot` opt-out, any
+			// configured exclude path, and packages whose manifest declares manual hook
+			// slots. Cheap import pre-check before parsing (and before touching the fs).
 			if ((file.endsWith('.ts') || file.endsWith('.js')) && !file.endsWith('.d.ts')) {
 				if (file.includes('/node_modules/')) return null;
 				if (/\/\/\s*octane-no-slot\b/.test(code)) return null;
 				if (excludePaths.some((p) => file.includes(p))) return null;
 				if (!/from\s*['"]octane['"]/.test(code)) return null;
+				if (hasManualHookSlots(file)) return null;
 				// Same HMR gate as the full compiler: dev serve gets Symbol.for
 				// (registry identity survives re-import), builds/SSR get Symbol().
 				const ssr =

--- a/packages/octane/tests/external-hook-slot.test.ts
+++ b/packages/octane/tests/external-hook-slot.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { mount } from './_helpers';
 import { slotHooks } from '../src/compiler/slot-hooks.js';
@@ -133,5 +133,71 @@ describe('vite plugin gate routing', () => {
 	it('honors the // octane-no-slot opt-out and skips non-octane files', () => {
 		expect(run(`// octane-no-slot\n${HOOK}`, '/app/binding.ts')).toBeNull();
 		expect(run(`export const x = 1;`, '/app/plain.ts')).toBeNull();
+	});
+});
+
+describe('manifest-declared manual hook slots', () => {
+	// Bindings whose `.ts` sources hand-forward hook slots declare
+	// `"octane": { "hookSlots": { "manual": ["src"] } }` in their OWN
+	// package.json; the plugin finds the nearest manifest and skips the surgical
+	// pass for files under the declared directories — no per-config `exclude`
+	// lists. These transforms use REAL workspace paths so the walk hits the
+	// actual manifests.
+	const plugin = octane();
+	const run = (code: string, id: string) => (plugin.transform as any).call({}, code, id);
+	const HOOK = `import { useState } from 'octane';\nexport const f = () => useState(0);`;
+
+	it('skips files under a directory declared manual', () => {
+		const id = join(process.cwd(), 'packages/zustand/src/__probe__.ts');
+		expect(run(HOOK, id)).toBeNull();
+	});
+
+	it("still slots the declaring package's OWN test files (scope is src, not the package)", () => {
+		// Inline hook callbacks in a binding's tests rely on call-site slots —
+		// the declaration must not swallow the whole package directory.
+		const id = join(process.cwd(), 'packages/testing-library/tests/__probe__.ts');
+		expect(run(HOOK, id)?.code).toMatch(/useState\(0, _h\$\d+\)/);
+	});
+
+	it('still slots packages without the declaration (redux is auto-slotted)', () => {
+		const id = join(process.cwd(), 'packages/redux/src/__probe__.ts');
+		expect(run(HOOK, id)?.code).toMatch(/useState\(0, _h\$\d+\)/);
+	});
+
+	it('still slots app files outside any declaring package', () => {
+		const id = join(process.cwd(), 'packages/octane/tests/_fixtures/__probe__.ts');
+		expect(run(HOOK, id)?.code).toMatch(/useState\(0, _h\$\d+\)/);
+	});
+
+	it('the declaration registry matches the hand-slot-forwarding bindings exactly', () => {
+		// The definitive list. Adding a binding here without the manifest flag (or
+		// removing the flag from a listed one) means its sources double-slot the
+		// moment ANOTHER project imports them — the exact drift the declaration
+		// exists to prevent. Auto-slotted by design (no flag): redux, recharts,
+		// hook-form.
+		const packagesDir = join(process.cwd(), 'packages');
+		const declared = readdirSync(packagesDir)
+			.filter((dir) => {
+				try {
+					const pkg = JSON.parse(readFileSync(join(packagesDir, dir, 'package.json'), 'utf8'));
+					return Array.isArray(pkg.octane?.hookSlots?.manual);
+				} catch {
+					return false;
+				}
+			})
+			.sort();
+		expect(declared).toEqual([
+			'base-ui',
+			'floating-ui',
+			'lexical',
+			'mdx',
+			'motion',
+			'radix',
+			'stylex',
+			'tanstack-query',
+			'tanstack-router',
+			'testing-library',
+			'zustand',
+		]);
 	});
 });

--- a/packages/radix/package.json
+++ b/packages/radix/package.json
@@ -3,6 +3,13 @@
   "version": "0.1.2",
   "license": "MIT",
   "type": "module",
+  "octane": {
+    "hookSlots": {
+      "manual": [
+        "src"
+      ]
+    }
+  },
   "description": "Radix UI Primitives for the octane renderer — a port of @radix-ui/react (headless, accessible UI primitives) on octane's hooks, built on the same @octanejs/floating-ui substrate.",
   "author": {
     "name": "Dominic Gannaway",

--- a/packages/stylex/package.json
+++ b/packages/stylex/package.json
@@ -3,6 +3,13 @@
   "version": "0.1.2",
   "license": "MIT",
   "type": "module",
+  "octane": {
+    "hookSlots": {
+      "manual": [
+        "src"
+      ]
+    }
+  },
   "description": "StyleX bindings for the octane renderer — reuses StyleX's framework-agnostic compiler core and routes the generated atomic CSS through octane's stylesheet channel (client dedupe + SSR render().css).",
   "author": {
     "name": "Dominic Gannaway",

--- a/packages/tanstack-query/package.json
+++ b/packages/tanstack-query/package.json
@@ -3,6 +3,13 @@
   "version": "0.1.2",
   "license": "MIT",
   "type": "module",
+  "octane": {
+    "hookSlots": {
+      "manual": [
+        "src"
+      ]
+    }
+  },
   "description": "TanStack Query bindings for the octane renderer — reuses @tanstack/query-core and swaps the React binding for octane's hooks.",
   "author": {
     "name": "Dominic Gannaway",

--- a/packages/tanstack-router/package.json
+++ b/packages/tanstack-router/package.json
@@ -3,6 +3,13 @@
   "version": "0.1.2",
   "license": "MIT",
   "type": "module",
+  "octane": {
+    "hookSlots": {
+      "manual": [
+        "src"
+      ]
+    }
+  },
   "description": "TanStack Router bindings for the octane renderer — reuses @tanstack/router-core and swaps the React binding for octane's hooks.",
   "author": {
     "name": "Dominic Gannaway",

--- a/packages/testing-library/package.json
+++ b/packages/testing-library/package.json
@@ -3,6 +3,13 @@
   "version": "0.1.0",
   "license": "MIT",
   "type": "module",
+  "octane": {
+    "hookSlots": {
+      "manual": [
+        "src"
+      ]
+    }
+  },
   "description": "React Testing Library for the octane renderer — reuses the framework-agnostic @testing-library/dom verbatim and ports only react-testing-library's thin React layer (render/cleanup/renderHook) onto octane's createRoot + act.",
   "author": {
     "name": "Dominic Gannaway",

--- a/packages/vite-plugin-octane/src/index.js
+++ b/packages/vite-plugin-octane/src/index.js
@@ -696,12 +696,12 @@ export function octane(inlineOptions = {}) {
 		},
 	};
 
-	// Forward compiler options. `exclude` lists path fragments the compiler's
-	// `.ts`/`.js` hook-slotting pass must skip — hand-slot-forwarding library
-	// sources that would otherwise be double-slotted. Published bindings live in
-	// node_modules and are skipped automatically; this matters for monorepo /
-	// aliased-to-source setups where pnpm symlinks resolve @octanejs/* imports
-	// to `packages/*/src` paths.
+	// Forward compiler options. `exclude` lists ad-hoc path fragments the
+	// compiler's `.ts`/`.js` hook-slotting pass must skip. Hand-slot-forwarding
+	// bindings should not need it: they declare
+	// `"octane": { "hookSlots": { "manual": ["src"] } }` in their own package.json and the
+	// compiler plugin skips them via a nearest-manifest lookup (published
+	// bindings live in node_modules and are skipped outright).
 	const compilerOptions = {};
 	if (inlineOptions.hmr !== undefined) compilerOptions.hmr = inlineOptions.hmr;
 	if (inlineOptions.exclude !== undefined) compilerOptions.exclude = inlineOptions.exclude;

--- a/packages/zustand/package.json
+++ b/packages/zustand/package.json
@@ -3,6 +3,13 @@
   "version": "0.1.2",
   "license": "MIT",
   "type": "module",
+  "octane": {
+    "hookSlots": {
+      "manual": [
+        "src"
+      ]
+    }
+  },
   "description": "zustand bindings for the octane renderer — reuses zustand's framework-agnostic vanilla store and swaps the React binding for octane's useSyncExternalStore.",
   "author": {
     "name": "Dominic Gannaway",

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -21,16 +21,17 @@ export default defineConfig({
 					globals: false,
 				},
 				plugins: [
-					octane({
-						// The parallel-use pipeline (memoized creations, batched unwrap,
-						// fetch-tree warming) runs at its DEFAULT (on). Tests that pin
-						// the opt-out output call compile() with `parallelUse: false`.
-						exclude: [
-							'/packages/zustand/src/',
-							'/packages/tanstack-query/src/',
-							'/packages/motion/src/',
-						],
-					}),
+					// The parallel-use pipeline (memoized creations, batched unwrap,
+					// fetch-tree warming) runs at its DEFAULT (on). Tests that pin
+					// the opt-out output call compile() with `parallelUse: false`.
+					//
+					// No `exclude` lists anywhere in this config: bindings whose `.ts`
+					// sources hand-forward hook slots declare
+					// `"octane": { "hookSlots": { "manual": ["src"] } }` in their own package.json and
+					// the plugin skips them automatically (nearest-manifest lookup) — the
+					// same declaration covers every project below, the website, examples,
+					// and builds.
+					octane(),
 				],
 			},
 			{
@@ -54,16 +55,7 @@ export default defineConfig({
 					// prod, like React's prod bundle): they conditionalize on this.
 					env: { OCTANE_TEST_COMPILE_MODE: 'prod' },
 				},
-				plugins: [
-					octane({
-						hmr: false,
-						exclude: [
-							'/packages/zustand/src/',
-							'/packages/tanstack-query/src/',
-							'/packages/motion/src/',
-						],
-					}),
-				],
+				plugins: [octane({ hmr: false })],
 			},
 			{
 				test: {
@@ -75,15 +67,7 @@ export default defineConfig({
 					globalSetup: ['packages/zustand/tests/differential/_setup.ts'],
 					globals: false,
 				},
-				plugins: [
-					octane({
-						exclude: [
-							'/packages/zustand/src/',
-							'/packages/tanstack-query/src/',
-							'/packages/motion/src/',
-						],
-					}),
-				],
+				plugins: [octane()],
 				// `@octanejs/zustand` is the package under test; alias the public name
 				// (and its subpaths) to source so fixtures import it exactly as a consumer
 				// would (and the differential React side rewrites the same specifiers to
@@ -113,15 +97,7 @@ export default defineConfig({
 					globalSetup: ['packages/tanstack-query/tests/differential/_setup.ts'],
 					globals: false,
 				},
-				plugins: [
-					octane({
-						exclude: [
-							'/packages/zustand/src/',
-							'/packages/tanstack-query/src/',
-							'/packages/motion/src/',
-						],
-					}),
-				],
+				plugins: [octane()],
 				resolve: {
 					alias: [
 						{
@@ -145,15 +121,7 @@ export default defineConfig({
 					globalSetup: ['packages/redux/tests/differential/_setup.ts'],
 					globals: false,
 				},
-				plugins: [
-					octane({
-						exclude: [
-							'/packages/zustand/src/',
-							'/packages/tanstack-query/src/',
-							'/packages/motion/src/',
-						],
-					}),
-				],
+				plugins: [octane()],
 				resolve: {
 					alias: [
 						{
@@ -191,17 +159,9 @@ export default defineConfig({
 				},
 				// hook-form's `.ts` hooks are auto-slotted (same as redux); the
 				// testing-library the ported suite mounts through is NOT (its harness
-				// calls hooks with explicit slot symbols).
-				plugins: [
-					octane({
-						exclude: [
-							'/packages/zustand/src/',
-							'/packages/tanstack-query/src/',
-							'/packages/motion/src/',
-							'/packages/testing-library/src/',
-						],
-					}),
-				],
+				// calls hooks with explicit slot symbols — declared in its package.json,
+				// so the plugin skips it automatically).
+				plugins: [octane()],
 				resolve: {
 					alias: [
 						{
@@ -234,15 +194,7 @@ export default defineConfig({
 					environment: 'node',
 					globals: false,
 				},
-				plugins: [
-					octane({
-						exclude: [
-							'/packages/zustand/src/',
-							'/packages/tanstack-query/src/',
-							'/packages/motion/src/',
-						],
-					}),
-				],
+				plugins: [octane()],
 				resolve: {
 					alias: [
 						{
@@ -292,15 +244,7 @@ export default defineConfig({
 						},
 					},
 				},
-				plugins: [
-					octane({
-						exclude: [
-							'/packages/zustand/src/',
-							'/packages/tanstack-query/src/',
-							'/packages/motion/src/',
-						],
-					}),
-				],
+				plugins: [octane()],
 				resolve: {
 					alias: [
 						{
@@ -333,16 +277,7 @@ export default defineConfig({
 					globalSetup: ['packages/tanstack-router/tests/differential/_setup.ts'],
 					globals: false,
 				},
-				plugins: [
-					octane({
-						exclude: [
-							'/packages/zustand/src/',
-							'/packages/tanstack-query/src/',
-							'/packages/motion/src/',
-							'/packages/tanstack-router/src/',
-						],
-					}),
-				],
+				plugins: [octane()],
 				resolve: {
 					alias: [
 						{
@@ -363,15 +298,7 @@ export default defineConfig({
 					environment: 'jsdom',
 					globals: false,
 				},
-				plugins: [
-					octane({
-						exclude: [
-							'/packages/zustand/src/',
-							'/packages/tanstack-query/src/',
-							'/packages/motion/src/',
-						],
-					}),
-				],
+				plugins: [octane()],
 				resolve: {
 					alias: [
 						{
@@ -395,20 +322,7 @@ export default defineConfig({
 					globalSetup: ['packages/lexical/tests/differential/_setup.ts'],
 					globals: false,
 				},
-				plugins: [
-					octane({
-						exclude: [
-							'/packages/zustand/src/',
-							'/packages/tanstack-query/src/',
-							'/packages/motion/src/',
-							'/packages/lexical/src/',
-							// @octanejs/floating-ui's hooks forward the caller's slot via subSlot;
-							// like its own project, they must skip the auto-slotting pass when a
-							// lexical .tsrx (e.g. LexicalNodeContextMenuPlugin) imports them.
-							'/packages/floating-ui/src/',
-						],
-					}),
-				],
+				plugins: [octane()],
 				resolve: {
 					// `.tsrx` is added so extensionless subpath imports
 					// (`@octanejs/lexical/LexicalComposer`) resolve to a `.tsrx` component
@@ -444,17 +358,7 @@ export default defineConfig({
 				// octane() compiles the `.tsrx` fixtures; stylex() (enforce:'post') then
 				// runs the StyleX compiler over that output, replacing stylex.* calls with
 				// atomic class names. `dev:false` keeps class names deterministic for tests.
-				plugins: [
-					octane({
-						exclude: [
-							'/packages/zustand/src/',
-							'/packages/tanstack-query/src/',
-							'/packages/motion/src/',
-							'/packages/stylex/src/',
-						],
-					}),
-					stylex({ dev: false }),
-				],
+				plugins: [octane(), stylex({ dev: false })],
 				resolve: {
 					alias: [
 						{
@@ -478,19 +382,11 @@ export default defineConfig({
 					environment: 'jsdom',
 					globals: false,
 				},
-				// floating-ui's `.ts` hooks forward the caller's slot via subSlot, so they
-				// must be EXCLUDED from the auto-slotting pass (the `.tsx` fixtures that call
-				// them are full-compiled and inject the trailing slot).
-				plugins: [
-					octane({
-						exclude: [
-							'/packages/zustand/src/',
-							'/packages/tanstack-query/src/',
-							'/packages/motion/src/',
-							'/packages/floating-ui/src/',
-						],
-					}),
-				],
+				// floating-ui's `.ts` hooks forward the caller's slot via subSlot — its
+				// package.json declares manual hook slots, so the auto-slotting pass skips
+				// them (the `.tsx` fixtures that call them are full-compiled and inject the
+				// trailing slot).
+				plugins: [octane()],
 				resolve: {
 					alias: [
 						{
@@ -514,21 +410,12 @@ export default defineConfig({
 					globalSetup: ['packages/radix/tests/differential/_setup.ts'],
 					globals: false,
 				},
-				// radix's `.ts` foundation forwards the caller's slot via subSlot, so it must
-				// be EXCLUDED from the auto-slotting pass (the `.tsx` fixtures that call it are
-				// full-compiled and inject the trailing slot) — as must @octanejs/floating-ui,
-				// which radix's Popper builds on.
-				plugins: [
-					octane({
-						exclude: [
-							'/packages/zustand/src/',
-							'/packages/tanstack-query/src/',
-							'/packages/motion/src/',
-							'/packages/radix/src/',
-							'/packages/floating-ui/src/',
-						],
-					}),
-				],
+				// radix's `.ts` foundation forwards the caller's slot via subSlot (as does
+				// @octanejs/floating-ui, which radix's Popper builds on) — both declare
+				// manual hook slots in their package.json, so the auto-slotting pass skips
+				// them (the `.tsx` fixtures that call them are full-compiled and inject the
+				// trailing slot).
+				plugins: [octane()],
 				resolve: {
 					alias: [
 						{
@@ -556,20 +443,11 @@ export default defineConfig({
 					globalSetup: ['packages/base-ui/tests/differential/_setup.ts'],
 					globals: false,
 				},
-				// base-ui's `.ts` foundation forwards the caller's slot via subSlot, so it must
-				// be EXCLUDED from the auto-slotting pass — as must @octanejs/floating-ui, which
-				// base-ui's overlays build on.
-				plugins: [
-					octane({
-						exclude: [
-							'/packages/zustand/src/',
-							'/packages/tanstack-query/src/',
-							'/packages/motion/src/',
-							'/packages/base-ui/src/',
-							'/packages/floating-ui/src/',
-						],
-					}),
-				],
+				// base-ui's `.ts` foundation forwards the caller's slot via subSlot (as does
+				// @octanejs/floating-ui, which base-ui's overlays build on) — both declare
+				// manual hook slots in their package.json, so the auto-slotting pass skips
+				// them.
+				plugins: [octane()],
 				resolve: {
 					alias: [
 						{
@@ -595,19 +473,10 @@ export default defineConfig({
 					globals: false,
 				},
 				// The binding's `.ts` sources call hooks with EXPLICIT slot symbols
-				// (renderHook's harness component), so they must be EXCLUDED from the
-				// auto-slotting pass; the test files themselves stay included so hook
-				// callbacks written inline in tests get their call-site slots.
-				plugins: [
-					octane({
-						exclude: [
-							'/packages/zustand/src/',
-							'/packages/tanstack-query/src/',
-							'/packages/motion/src/',
-							'/packages/testing-library/src/',
-						],
-					}),
-				],
+				// (renderHook's harness component) — declared in its package.json, so the
+				// auto-slotting pass skips them; the test files themselves stay included so
+				// hook callbacks written inline in tests get their call-site slots.
+				plugins: [octane()],
 				resolve: {
 					alias: [
 						{
@@ -631,21 +500,11 @@ export default defineConfig({
 				// octaneMdx() owns `.mdx`/`.md` (it runs the FULL pipeline — @mdx-js/mdx →
 				// octane compile — and returns final JS); octane() compiles the `.tsrx`
 				// fixtures embedded in documents and the test files. The binding's own
-				// `.ts` sources call hooks with EXPLICIT slot symbols, so they are
-				// excluded from the auto-slotting pass — as is @octanejs/testing-library,
-				// which the tests mount through.
-				plugins: [
-					octaneMdx(),
-					octane({
-						exclude: [
-							'/packages/zustand/src/',
-							'/packages/tanstack-query/src/',
-							'/packages/motion/src/',
-							'/packages/mdx/src/',
-							'/packages/testing-library/src/',
-						],
-					}),
-				],
+				// `.ts` sources call hooks with EXPLICIT slot symbols (as does
+				// @octanejs/testing-library, which the tests mount through) — both declare
+				// manual hook slots in their package.json, so the auto-slotting pass skips
+				// them.
+				plugins: [octaneMdx(), octane()],
 				resolve: {
 					alias: [
 						{
@@ -715,20 +574,11 @@ export default defineConfig({
 				// The website app stack: octaneMdx() compiles the site's .mdx documents
 				// (same shared options — Shiki + tsrx langAlias — the app itself uses);
 				// octane() compiles the .tsrx pages and slots hooks in app .ts files.
-				// The bindings' own `.ts` sources hand-forward slots, so they are
-				// excluded from the auto-slotting pass (same reasoning as the projects
-				// above). Package imports (@octanejs/tanstack-router, octane, …) resolve through
-				// website/node_modules workspace links — no aliases needed.
-				plugins: [
-					octaneMdx(websiteMdxOptions),
-					octane({
-						exclude: [
-							'/packages/tanstack-router/src/',
-							'/packages/mdx/src/',
-							'/packages/testing-library/src/',
-						],
-					}),
-				],
+				// The bindings' own hand-slot-forwarding `.ts` sources are skipped via
+				// their package.json declarations. Package imports (@octanejs/tanstack-router,
+				// octane, …) resolve through website/node_modules workspace links — no
+				// aliases needed.
+				plugins: [octaneMdx(websiteMdxOptions), octane()],
 			},
 		],
 	},

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -28,17 +28,16 @@ export default defineConfig({
 		octaneServerAlias(),
 		// octaneMdx() owns `.mdx` (full pipeline: @mdx-js/mdx → octane compile,
 		// with Shiki highlighting via rehype); octane() owns `.tsrx`/`.ts` and the
-		// metaframework (dev SSR + routing + hydrate). `exclude` skips the
-		// hook-slotting pass for the workspace bindings' hand-slot-forwarding
-		// sources — pnpm symlinks resolve them to /packages/*/src, not
-		// node_modules (mirrors the root vitest config).
+		// metaframework (dev SSR + routing + hydrate). The workspace bindings'
+		// hand-slot-forwarding sources (pnpm symlinks resolve them to
+		// /packages/*/src, not node_modules) declare
+		// `"octane": { "hookSlots": { "manual": ["src"] } }` in their package.json, so the
+		// hook-slotting pass skips them automatically — no exclude list needed.
+		// @octanejs/recharts + @octanejs/redux carry no declaration and DO compile
+		// through the pass (explicit subSlot tags compose with it), unlike
+		// router/mdx.
 		octaneMdx(websiteMdxOptions),
-		// NOTE: @octanejs/recharts + @octanejs/redux are NOT excluded from the
-		// hook-slotting pass — their own test projects compile them through it
-		// (explicit subSlot tags compose with the pass), unlike router/mdx.
-		octane({
-			exclude: ['/packages/tanstack-router/src/', '/packages/mdx/src/'],
-		}),
+		octane(),
 	],
 
 	// The workspace bindings ship raw TS — Vite must transform them for the SSR


### PR DESCRIPTION
## What

Resolves `docs/project-analysis-concerns.md` §6: the hand-slot-forwarding exclusion lists repeated across every Vitest project, the website config, and the examples are replaced by a single self-declarative mechanism.

A binding whose plain `.ts`/`.js` sources forward hook slots themselves now declares it once in its **own** `package.json`:

```json
"octane": { "hookSlots": { "manual": ["src"] } }
```

The compiler plugin's surgical hook-slotting pass walks from each candidate file to the **nearest** `package.json` (cached per directory, shared across plugin instances) and skips files under the declared directories. The declaration travels with the package into every consumer — root vitest projects, the website, examples, builds — so a new binding can no longer work in its own project yet be double-slotted when imported by another.

## Changes

- **`packages/octane/src/compiler/vite.js`** — nearest-manifest lookup (`hasManualHookSlots`), gated behind the existing cheap checks so the fs walk only runs for files that would actually be slotted. The `exclude` option survives as an ad-hoc escape hatch.
- **11 binding manifests flagged**: base-ui, floating-ui, lexical, mdx, motion, radix, stylex, tanstack-query, tanstack-router, testing-library, zustand. (redux, recharts, hook-form are auto-slotted by design and carry no flag.)
- **All 18 repeated `exclude` arrays deleted** from `vitest.config.js`, plus the lists in `website/vite.config.ts`, both hacker-news example configs, and the lexical playground.
- **Tests** (`packages/octane/tests/external-hook-slot.test.ts`): declared-dir files skipped; a flagged package's own `tests/` files still slotted; undeclared packages (redux) still slotted; and a registry pin asserting the exact set of flagged manifests, so silently dropping or adding a declaration fails the suite. Runs in both the dev and `octane-prod` projects, covering the `Symbol.for` vs `Symbol()` slot split that motivated the concern.

## Reviewer notes

- The scope is a **directory list, not the whole package** — this is load-bearing. A first package-wide cut broke 53 testing-library tests because the bindings' own test files must stay auto-slotted (inline `renderHook(() => …)` callbacks rely on call-site slots). The `["src"]` scope matches the old `/packages/*/src/` excludes exactly.
- Nearest manifest wins: a package without the flag is auto-slotted; an outer (monorepo root) manifest can't speak for it.
- Published bindings in `node_modules` were already skipped outright; this only affects monorepo / aliased-to-source setups.
- Full suite (747 files / 5,820 tests, incl. the website's real production build + e2e projects), `typecheck`, `format:check`, and `changeset:check` all pass. Changeset added for `octane` (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compiler hook-slotting behavior for all monorepo/aliased binding sources; incorrect manifests or lookup bugs could cause double-slotting or missed slots, though tests and a registry pin reduce drift risk.
> 
> **Overview**
> Hand-slot-forwarding bindings no longer rely on duplicated `octane({ exclude: [...] })` lists in Vitest, the website, and examples. Each binding that forwards hook slots in plain `.ts`/`.js` now declares **`"octane": { "hookSlots": { "manual": ["src"] } }`** in its own **`package.json`** (11 packages updated).
> 
> The Vite compiler plugin walks up to the **nearest** manifest, caches rules per directory, and skips the surgical `.ts`/`.js` hook-slot pass for files under those directories—after the existing cheap gates (no `octane` import, etc.). Scope is **`src` only** so each package’s **`tests/`** still get auto-slotted. The **`exclude`** option remains an escape hatch.
> 
> Repeated exclude arrays are removed from **`vitest.config.js`**, **`website/vite.config.ts`**, hacker-news and lexical example configs, and related comments/docs are updated. **`external-hook-slot.test.ts`** adds manifest behavior coverage and pins the exact set of declaring packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b900c2f4c805ba1499fb38359f8d5314e752c8bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->