### PR TITLE
octane: glob publish-build entry points + verify dist imports

### DIFF
--- a/.changeset/build-entrypoint-guard.md
+++ b/.changeset/build-entrypoint-guard.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Publish build: entry points are now globbed from `src/` instead of hand-listed — the hand-maintained list had silently drifted (css.ts, server/rpc.ts, static/index.ts were missing, so `dist/runtime.js`, `octane/server`, and `octane/static` shipped with unresolvable relative imports). A new post-build guard (`scripts/verify-dist.mjs`, also run in CI) makes the class of bug impossible to ship: every emitted dist module's relative imports must resolve (including the verbatim-copied `dist/compiler/`), every `publishConfig` export target must exist, and every published entry point must import cleanly in plain Node — otherwise the build fails.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,14 @@ jobs:
       - name: Check parity-gap index is current
         run: pnpm parity:gaps:check
 
+      # The publish build otherwise only runs at prepack, so a broken dist
+      # (an entry point missing from the build, an unresolvable relative
+      # import in dist/ or the verbatim-copied compiler/) would ship silently.
+      # build.mjs ends with verify-dist.mjs: every emitted module's imports
+      # must resolve and every publishConfig export must import in plain Node.
+      - name: Build octane package and verify dist
+        run: pnpm build
+
   typecheck:
     runs-on: ubuntu-latest
 

--- a/packages/octane/scripts/build.mjs
+++ b/packages/octane/scripts/build.mjs
@@ -9,11 +9,18 @@
 //   2. The compiler is already plain `.js` (its only deps are `@tsrx/core` + `esrap`) — copy
 //      it verbatim.
 //   3. Type declarations (`tsc --emitDeclarationOnly`) alongside the JS.
+//
+// Entry points are GLOBBED from `src/`, not hand-listed — a hand-maintained list
+// silently drifted before (css.ts, server/rpc.ts, static/index.ts were missing and
+// dist shipped with unresolvable imports). verify-dist.mjs backstops the build:
+// every emitted module's relative imports must resolve, every publishConfig export
+// must exist, and every entry point must import cleanly in plain Node.
 import { build } from 'esbuild';
 import { execFileSync } from 'node:child_process';
-import { cpSync, rmSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { cpSync, readdirSync, rmSync } from 'node:fs';
+import { dirname, join, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { smokeDist, verifyDist } from './verify-dist.mjs';
 
 const pkgDir = join(dirname(fileURLToPath(import.meta.url)), '..');
 const root = join(pkgDir, '..', '..');
@@ -22,14 +29,19 @@ const dist = join(pkgDir, 'dist');
 
 rmSync(dist, { recursive: true, force: true });
 
+// Every .ts module plus any shared plain-JS modules, except the compiler dir
+// (already plain .js — copied verbatim below).
+const entryPoints = readdirSync(src, { recursive: true })
+	.filter(
+		(f) =>
+			(f.endsWith('.ts') || f.endsWith('.js')) &&
+			!f.endsWith('.d.ts') &&
+			!f.startsWith(`compiler${sep}`),
+	)
+	.map((f) => join(src, f));
+
 await build({
-	entryPoints: [
-		join(src, 'index.ts'),
-		join(src, 'runtime.ts'),
-		join(src, 'runtime.server.ts'),
-		join(src, 'constants.ts'),
-		join(src, 'server/index.ts'),
-	],
+	entryPoints,
 	outdir: dist,
 	outbase: src,
 	format: 'esm',
@@ -44,4 +56,7 @@ execFileSync(join(root, 'node_modules/.bin/tsc'), ['-p', join(pkgDir, 'tsconfig.
 	stdio: 'inherit',
 });
 
-console.log('octane: built dist/ (runtime JS + .d.ts + compiler)');
+await verifyDist(pkgDir);
+smokeDist(pkgDir);
+
+console.log('octane: built dist/ (runtime JS + .d.ts + compiler) — imports verified');

--- a/packages/octane/scripts/verify-dist.mjs
+++ b/packages/octane/scripts/verify-dist.mjs
@@ -1,0 +1,95 @@
+// Post-build guard for the published `octane` package. The esbuild entry list in
+// build.mjs used to be hand-maintained and silently drifted from `src/` (css.ts,
+// server/rpc.ts, and static/index.ts went missing): dist shipped with unresolvable
+// relative imports and nothing failed until a consumer imported the package. Entry
+// points are now globbed, and this walker backstops the whole class of bug —
+// including the verbatim-copied `dist/compiler/` — by failing the build instead of
+// the consumer. Runs from build.mjs (so `prepack` can never publish a broken dist)
+// and standalone against an existing dist: `node scripts/verify-dist.mjs`.
+import { build } from 'esbuild';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+function publishedExportTargets(pkgDir) {
+	const pkg = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8'));
+	const targets = new Set();
+	for (const value of Object.values(pkg.publishConfig.exports)) {
+		if (typeof value === 'string') targets.add(value);
+		else for (const path of Object.values(value)) targets.add(path);
+	}
+	return [...targets];
+}
+
+export async function verifyDist(pkgDir) {
+	const dist = join(pkgDir, 'dist');
+
+	// Every publishConfig export target must exist. A missing entry module is a
+	// root that nothing else imports, so the import walk below cannot see it —
+	// this is exactly how the missing static/index.ts shipped unnoticed.
+	const missing = publishedExportTargets(pkgDir).filter((p) => !existsSync(join(pkgDir, p)));
+	if (missing.length > 0) {
+		throw new Error(
+			`octane dist verify: publishConfig.exports targets missing from the build:\n` +
+				missing.map((p) => `  ${p}`).join('\n'),
+		);
+	}
+
+	// Every relative import in every emitted .js module must resolve to a file.
+	// esbuild in bundle mode is the resolver (a real parser, not a regex, and it
+	// follows dynamic import() literals too): each dist module is its own entry,
+	// bare specifiers stay external (they are declared dependencies, present at
+	// install time), and *.json covers the `../package.json` attribute import
+	// (package.json is always included in the tarball).
+	const jsFiles = readdirSync(dist, { recursive: true })
+		.filter((f) => f.endsWith('.js'))
+		.map((f) => join(dist, f));
+	try {
+		await build({
+			entryPoints: jsFiles,
+			bundle: true,
+			write: false,
+			outdir: join(pkgDir, '.verify-dist-noop'), // never written (write: false); esbuild requires an outdir for multiple entries
+			format: 'esm',
+			platform: 'neutral',
+			packages: 'external',
+			external: ['*.json'],
+			logLevel: 'silent',
+		});
+	} catch (error) {
+		const details = (error.errors ?? [{ text: String(error) }])
+			.map((e) => `  ${e.location ? `${e.location.file}:${e.location.line}: ` : ''}${e.text}`)
+			.join('\n');
+		throw new Error(`octane dist verify: unresolvable imports in dist:\n${details}`);
+	}
+}
+
+// Import each published entry point in a fresh plain-Node process — the same
+// resolution a consumer gets, catching anything static analysis can't (a module
+// that throws at init, a bad package.json attribute import, …).
+export function smokeDist(pkgDir) {
+	const entries = publishedExportTargets(pkgDir).filter((p) => p.endsWith('.js'));
+	for (const entry of entries) {
+		const url = pathToFileURL(join(pkgDir, entry)).href;
+		// Explicit exit(0): the client runtime's module init keeps the event loop
+		// alive (scheduler channel), so a bare top-level import would hang forever.
+		execFileSync(
+			process.execPath,
+			[
+				'--input-type=module',
+				'-e',
+				`import(${JSON.stringify(url)}).then(() => process.exit(0), (e) => { console.error(e); process.exit(1); });`,
+			],
+			{ stdio: ['ignore', 'ignore', 'inherit'], cwd: pkgDir },
+		);
+	}
+	return entries;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	const pkgDir = join(dirname(fileURLToPath(import.meta.url)), '..');
+	await verifyDist(pkgDir);
+	const entries = smokeDist(pkgDir);
+	console.log(`octane: dist verified (all imports resolve; smoke-imported ${entries.join(', ')})`);
+}

--- a/packages/octane/tsconfig.build.json
+++ b/packages/octane/tsconfig.build.json
@@ -7,12 +7,6 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": [
-    "./src/index.ts",
-    "./src/runtime.ts",
-    "./src/runtime.server.ts",
-    "./src/constants.ts",
-    "./src/server/index.ts"
-  ],
+  "include": ["./src/**/*.ts"],
   "exclude": ["node_modules", "tests", "dist"]
 }


### PR DESCRIPTION
The esbuild entry list in build.mjs (and the tsconfig.build.json include) was hand-maintained and silently drifted from src/: css.ts, server/rpc.ts, and static/index.ts were missing, so the published dist/runtime.js, octane/server, and octane/static shipped with unresolvable relative imports and nothing failed at build time.

Fix the drift and make the class of bug unshippable:

- build.mjs derives entryPoints by globbing src/ (.ts + shared plain .js, minus .d.ts and the verbatim-copied compiler/); tsconfig.build.json include is globbed the same way for declaration emit.
- New scripts/verify-dist.mjs runs at the end of every build (and standalone): every publishConfig export target must exist (a missing entry module is a root nothing imports, so an import walk alone cannot see it), every relative import in every emitted dist .js — including dist/compiler/ — must resolve (esbuild bundle-mode walk, bare specifiers external), and every published entry point must import cleanly in a plain-Node child process (explicit exit: the runtime's scheduler keeps the event loop alive after import).
- CI: the lint job now runs `pnpm build`, since the publish build otherwise only ran at prepack.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to octane’s publish build, verification scripts, and CI; they reduce release risk rather than altering runtime behavior for in-repo dev consumers.
> 
> **Overview**
> **Publish builds for `octane` no longer rely on a hand-maintained entry list.** `build.mjs` and `tsconfig.build.json` now glob all `src/**/*.ts` (and shared `.js` outside `compiler/`) so new modules like `css.ts`, `server/rpc.ts`, and `static/index.ts` cannot be omitted from `dist/` again.
> 
> **A post-build guard (`scripts/verify-dist.mjs`) runs at the end of every `build.mjs` run** (including `prepack`): it checks that every `publishConfig.exports` file exists, that relative imports resolve across all emitted `dist/**/*.js` (including copied `dist/compiler/`), and that each published `.js` entry imports successfully in a plain Node child process (with explicit `process.exit` so the client runtime’s scheduler does not hang CI).
> 
> **CI lint now runs `pnpm build`**, so broken dist would fail on PRs instead of only at publish time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 674bcfd58ea07f30b2fece7dc8d2d0eacee8cd89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->