### PR TITLE
Add compiler-driven current-state getters

### DIFF
--- a/.changeset/fresh-state-getters.md
+++ b/.changeset/fresh-state-getters.md
@@ -1,0 +1,7 @@
+---
+'octane': patch
+---
+
+Add compiler-driven third-tuple current-state getters to `useState` and
+`useReducer`. Getter-free destructures retain the existing runtime path, while
+observed or escaped tuples receive a stable thunk that reads the latest state.

--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -130,6 +130,12 @@ these toward React without checking `docs/react-parity-migration-plan.md`:
   extract a child component — each item then renders in its own scope. `use()`
   and `useContext` are exempt (call-order / context-identity keyed, not
   slot-keyed).
+- **State hooks expose a compiler-driven current-state getter.** `useState` and
+  `useReducer` have a stable third tuple member (`[state, update, getState]`) that
+  reads the latest scheduled hook-cell value. The compiler emits its specialized
+  runtime helper only when tuple index 2 can be observed; ordinary two-item
+  destructures retain the existing allocation-free path. Escaped or ambiguous
+  tuples conservatively receive the complete three-item shape.
 - **Controlled `value`/`checked` with native events.** Controlled form components
   follow React's semantics exactly (2026-07-08) — the prop drives the DOM property
   and reasserts on every commit and after discrete events; `defaultValue`/

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -125,6 +125,12 @@ these toward React without checking `docs/react-parity-migration-plan.md`:
   extract a child component — each item then renders in its own scope. `use()`
   and `useContext` are exempt (call-order / context-identity keyed, not
   slot-keyed).
+- **State hooks expose a compiler-driven current-state getter.** `useState` and
+  `useReducer` have a stable third tuple member (`[state, update, getState]`) that
+  reads the latest scheduled hook-cell value. The compiler emits its specialized
+  runtime helper only when tuple index 2 can be observed; ordinary two-item
+  destructures retain the existing allocation-free path. Escaped or ambiguous
+  tuples conservatively receive the complete three-item shape.
 - **Controlled `value`/`checked` with native events.** Controlled form components
   follow React's semantics exactly (2026-07-08) — the prop drives the DOM property
   and reasserts on every commit and after discrete events; `defaultValue`/

--- a/.rulesync/rules/project.md
+++ b/.rulesync/rules/project.md
@@ -132,6 +132,12 @@ these toward React without checking `docs/react-parity-migration-plan.md`:
   extract a child component — each item then renders in its own scope. `use()`
   and `useContext` are exempt (call-order / context-identity keyed, not
   slot-keyed).
+- **State hooks expose a compiler-driven current-state getter.** `useState` and
+  `useReducer` have a stable third tuple member (`[state, update, getState]`) that
+  reads the latest scheduled hook-cell value. The compiler emits its specialized
+  runtime helper only when tuple index 2 can be observed; ordinary two-item
+  destructures retain the existing allocation-free path. Escaped or ambiguous
+  tuples conservatively receive the complete three-item shape.
 - **Controlled `value`/`checked` with native events.** Controlled form components
   follow React's semantics exactly (2026-07-08) — the prop drives the DOM property
   and reasserts on every commit and after discrete events; `defaultValue`/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,12 @@ these toward React without checking `docs/react-parity-migration-plan.md`:
   extract a child component — each item then renders in its own scope. `use()`
   and `useContext` are exempt (call-order / context-identity keyed, not
   slot-keyed).
+- **State hooks expose a compiler-driven current-state getter.** `useState` and
+  `useReducer` have a stable third tuple member (`[state, update, getState]`) that
+  reads the latest scheduled hook-cell value. The compiler emits its specialized
+  runtime helper only when tuple index 2 can be observed; ordinary two-item
+  destructures retain the existing allocation-free path. Escaped or ambiguous
+  tuples conservatively receive the complete three-item shape.
 - **Controlled `value`/`checked` with native events.** Controlled form components
   follow React's semantics exactly (2026-07-08) — the prop drives the DOM property
   and reasserts on every commit and after discrete events; `defaultValue`/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,12 @@ these toward React without checking `docs/react-parity-migration-plan.md`:
   extract a child component — each item then renders in its own scope. `use()`
   and `useContext` are exempt (call-order / context-identity keyed, not
   slot-keyed).
+- **State hooks expose a compiler-driven current-state getter.** `useState` and
+  `useReducer` have a stable third tuple member (`[state, update, getState]`) that
+  reads the latest scheduled hook-cell value. The compiler emits its specialized
+  runtime helper only when tuple index 2 can be observed; ordinary two-item
+  destructures retain the existing allocation-free path. Escaped or ambiguous
+  tuples conservatively receive the complete three-item shape.
 - **Controlled `value`/`checked` with native events.** Controlled form components
   follow React's semantics exactly (2026-07-08) — the prop drives the DOM property
   and reasserts on every commit and after discrete events; `defaultValue`/

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -129,6 +129,12 @@ these toward React without checking `docs/react-parity-migration-plan.md`:
   extract a child component — each item then renders in its own scope. `use()`
   and `useContext` are exempt (call-order / context-identity keyed, not
   slot-keyed).
+- **State hooks expose a compiler-driven current-state getter.** `useState` and
+  `useReducer` have a stable third tuple member (`[state, update, getState]`) that
+  reads the latest scheduled hook-cell value. The compiler emits its specialized
+  runtime helper only when tuple index 2 can be observed; ordinary two-item
+  destructures retain the existing allocation-free path. Escaped or ambiguous
+  tuples conservatively receive the complete three-item shape.
 - **Controlled `value`/`checked` with native events.** Controlled form components
   follow React's semantics exactly (2026-07-08) — the prop drives the DOM property
   and reasserts on every commit and after discrete events; `defaultValue`/

--- a/README.md
+++ b/README.md
@@ -250,6 +250,29 @@ export function Timer() @{
 }
 ```
 
+`useState` and `useReducer` also expose an optional third tuple member: a stable
+getter for the hook's latest state. It is useful in async callbacks and other
+long-lived closures where capturing the render's state value would go stale:
+
+```jsx
+export function SaveButton() @{
+  const [draft, setDraft, getDraft] = useState('');
+
+  const saveLater = async () => {
+    await waitForConnection();
+    await save(getDraft()); // the latest draft, not the render that started this callback
+  };
+
+  <button onClick={saveLater}>{'Save ' + draft}</button>
+}
+```
+
+The compiler emits a getter-enabled hook only when the third tuple member can
+be observed. Ordinary `[state, setState]` and `[state, dispatch]` destructures
+keep the existing two-item runtime path and allocate no getter. The getter reads
+the latest scheduled hook value, which may be newer than the currently committed
+DOM during a pending render.
+
 ### Conditional hooks
 
 Unlike React, a hook can sit behind a guard or after an early `return`:

--- a/docs/bindings-status.md
+++ b/docs/bindings-status.md
@@ -38,7 +38,7 @@ upstream version.
 
 ## @octanejs/base-ui
 
-[`packages/base-ui`](../packages/base-ui) `0.1.1` — ports `@base-ui/react@1.6.0`. Status data: [`packages/base-ui/status.json`](../packages/base-ui/status.json).
+[`packages/base-ui`](../packages/base-ui) `0.1.2` — ports `@base-ui/react@1.6.0`. Status data: [`packages/base-ui/status.json`](../packages/base-ui/status.json).
 
 Alpha, in progress: the foundation + overlay infrastructure and the first component set (Dialog, AlertDialog, Popover open-path) landed, ported at full fidelity and differential-verified against the real `@base-ui/react`.
 
@@ -53,7 +53,7 @@ See also: [`docs/base-ui-migration-plan.md`](base-ui-migration-plan.md)
 
 ## @octanejs/floating-ui
 
-[`packages/floating-ui`](../packages/floating-ui) `0.1.2` — ports `@floating-ui/react@0.27.19`. Status data: [`packages/floating-ui/status.json`](../packages/floating-ui/status.json).
+[`packages/floating-ui`](../packages/floating-ui) `0.1.3` — ports `@floating-ui/react@0.27.19`. Status data: [`packages/floating-ui/status.json`](../packages/floating-ui/status.json).
 
 Positioning (`useFloating`, ref-aware `arrow`, the `@floating-ui/dom` middleware re-exports, the floating tree), the full interaction-hook set (`useInteractions`, `useHover` + `safePolygon`, `useClick`, `useFocus`, `useDismiss`, `useRole`, `useClientPoint`, `useListNavigation`, `useTypeahead`), the component layer (`FloatingPortal`, `FloatingOverlay`, `FloatingFocusManager`, `FloatingArrow`, `FloatingList`, `Composite`), and transitions + `FloatingDelayGroup`.
 
@@ -67,7 +67,7 @@ SSR / hydration: No dedicated SSR/hydration tests.
 
 ## @octanejs/hook-form
 
-[`packages/hook-form`](../packages/hook-form) `0.1.0` — ports `react-hook-form@7.81.0`. Status data: [`packages/hook-form/status.json`](../packages/hook-form/status.json).
+[`packages/hook-form`](../packages/hook-form) `0.1.1` — ports `react-hook-form@7.81.0`. Status data: [`packages/hook-form/status.json`](../packages/hook-form/status.json).
 
 Complete port of react-hook-form 7.81.0 (upstream commit b7df98c2) with the upstream test suite ported: `useForm`, `useController`, `useFieldArray`, `useFormState`, `useWatch`, `useFormContext`/`FormProvider`, schema resolvers, and all validation modes.
 
@@ -82,7 +82,7 @@ See also: [`docs/octanejs-hook-form-plan.md`](octanejs-hook-form-plan.md)
 
 ## @octanejs/jotai
 
-[`packages/jotai`](../packages/jotai) `0.1.0` — ports `jotai@2.20.1`. Status data: [`packages/jotai/status.json`](../packages/jotai/status.json).
+[`packages/jotai`](../packages/jotai) `0.1.1` — ports `jotai@2.20.1`. Status data: [`packages/jotai/status.json`](../packages/jotai/status.json).
 
 Complete 1:1 port: the framework-agnostic vanilla core (`jotai/vanilla`, `/vanilla/utils`, `/vanilla/internals`) is reused verbatim; the React layer (`Provider`, `useStore`, `useAtom`, `useAtomValue`, `useSetAtom`) and `react/utils` (`useResetAtom`, `useReducerAtom`, `useAtomCallback`, `useHydrateAtoms`) are ported onto octane hooks, preserving upstream's useReducer force-update + effect-subscription implementation, async atoms via octane's `use()`.
 
@@ -94,7 +94,7 @@ SSR / hydration: No SSR-specific surface; `useHydrateAtoms` is ported and usable
 
 ## @octanejs/lexical
 
-[`packages/lexical`](../packages/lexical) `0.1.2` — ports `@lexical/react@0.46.0`. Status data: [`packages/lexical/status.json`](../packages/lexical/status.json).
+[`packages/lexical`](../packages/lexical) `0.1.3` — ports `@lexical/react@0.46.0`. Status data: [`packages/lexical/status.json`](../packages/lexical/status.json).
 
 35 of 39 `@lexical/react` modules ported: composer + contexts, the editable surface, plain/rich text, and the full plugin/menu set (history, lists + check-list, links, tables, markdown shortcuts, the typeahead/node-menu/context-menu family, draggable-block, character-limit, …) plus the `useLexical*` hooks.
 
@@ -109,7 +109,7 @@ SSR / hydration: No dedicated SSR/hydration tests.
 
 ## @octanejs/mdx
 
-[`packages/mdx`](../packages/mdx) `0.1.0` — ports `@mdx-js/mdx@3.1.1`. Status data: [`packages/mdx/status.json`](../packages/mdx/status.json).
+[`packages/mdx`](../packages/mdx) `0.1.1` — ports `@mdx-js/mdx@3.1.1`. Status data: [`packages/mdx/status.json`](../packages/mdx/status.json).
 
 The full compile-don't-interpret pipeline: `.mdx`/`.md` → `@mdx-js/mdx` (reused verbatim) → octane compiler, via the `octaneMdx()` Vite plugin plus the `./compile` and `./server` entries; `@mdx-js/react`'s provider layer (`MDXProvider`/`useMDXComponents`) is ported onto octane context. The octane website runs on it.
 
@@ -123,7 +123,7 @@ See also: [`docs/mdx-migration-plan.md`](mdx-migration-plan.md)
 
 ## @octanejs/motion
 
-[`packages/motion`](../packages/motion) `0.1.2` — ports `motion@12.40.0`. Status data: [`packages/motion/status.json`](../packages/motion/status.json).
+[`packages/motion`](../packages/motion) `0.1.3` — ports `motion@12.40.0`. Status data: [`packages/motion/status.json`](../packages/motion/status.json).
 
 Core surface: `motion.<tag>` (animate, gestures, variants with propagation/stagger, drag, layout basics), `AnimatePresence`, `MotionConfig`, and the motion-value hooks (`useMotionValue`, `useScroll`, `useTransform`, `useSpring`, `useAnimate`, `useMotionValueEvent`); motion-dom's animation engine and gesture primitives are reused verbatim.
 
@@ -138,7 +138,7 @@ SSR / hydration: No SSR-specific surface; no dedicated SSR tests.
 
 ## @octanejs/radix
 
-[`packages/radix`](../packages/radix) `0.1.2` — ports `radix-ui@1.6.1`. Status data: [`packages/radix/status.json`](../packages/radix/status.json).
+[`packages/radix`](../packages/radix) `0.1.3` — ports `radix-ui@1.6.1`. Status data: [`packages/radix/status.json`](../packages/radix/status.json).
 
 Complete against the unified `radix-ui@1.6.1` component surface — all primitives (incl. Dialog, the Menu/DropdownMenu/ContextMenu family, Popover, Tooltip, Select, NavigationMenu, Toast, Menubar, Slider, the form controls, and OneTimePasswordField/PasswordToggleField) plus the composition/state/overlay foundations — verified by a differential suite (same fixtures through octane and the real radix-ui, byte-identical DOM).
 
@@ -153,7 +153,7 @@ See also: [`docs/radix-migration-plan.md`](radix-migration-plan.md)
 
 ## @octanejs/recharts
 
-[`packages/recharts`](../packages/recharts) `0.1.0` — ports `recharts@3.9.2`. Status data: [`packages/recharts/status.json`](../packages/recharts/status.json).
+[`packages/recharts`](../packages/recharts) `0.1.1` — ports `recharts@3.9.2`. Status data: [`packages/recharts/status.json`](../packages/recharts/status.json).
 
 Partial (phases 0–1 of 5): the static `BarChart`/`LineChart` pipeline end-to-end (`isAnimationActive={false}`), byte-identical to upstream in the differential rig; the Redux/RTK state layer, `Surface`/`Layer`, and the pure shape set are in place.
 
@@ -169,7 +169,7 @@ See also: [`docs/recharts-port-plan.md`](recharts-port-plan.md)
 
 ## @octanejs/redux
 
-[`packages/redux`](../packages/redux) `0.1.0` — ports `react-redux@9.3.0`. Status data: [`packages/redux/status.json`](../packages/redux/status.json).
+[`packages/redux`](../packages/redux) `0.1.1` — ports `react-redux@9.3.0`. Status data: [`packages/redux/status.json`](../packages/redux/status.json).
 
 The hooks + `Provider` surface of react-redux 9.3.0 (`useSelector`, `useDispatch`, `useStore`, and the custom-context factory variants) on octane's `useSyncExternalStore`; works with any Redux 5 / Redux Toolkit store. Export parity is pinned by test.
 
@@ -182,7 +182,7 @@ SSR / hydration: No SSR-specific surface; no dedicated SSR tests.
 
 ## @octanejs/stylex
 
-[`packages/stylex`](../packages/stylex) `0.1.2` — ports `@stylexjs/stylex@0.19.0`. Status data: [`packages/stylex/status.json`](../packages/stylex/status.json).
+[`packages/stylex`](../packages/stylex) `0.1.3` — ports `@stylexjs/stylex@0.19.0`. Status data: [`packages/stylex/status.json`](../packages/stylex/status.json).
 
 Full compile-time integration: re-exports the StyleX runtime API (`create`, `props`, `attrs`, `keyframes`, `defineVars`, `createTheme`) and registers as an import source; the `/vite` plugin runs the StyleX compiler over octane's compiled output and emits one static atomic stylesheet (`virtual:stylex.css`) with zero StyleX runtime in the bundle.
 
@@ -195,7 +195,7 @@ SSR / hydration: Works under SSR — the stylesheet is static and server markup 
 
 ## @octanejs/tanstack-query
 
-[`packages/tanstack-query`](../packages/tanstack-query) `0.1.2` — ports `@tanstack/react-query@5.101.0`. Status data: [`packages/tanstack-query/status.json`](../packages/tanstack-query/status.json).
+[`packages/tanstack-query`](../packages/tanstack-query) `0.1.3` — ports `@tanstack/react-query@5.101.0`. Status data: [`packages/tanstack-query/status.json`](../packages/tanstack-query/status.json).
 
 Complete: 58/58 runtime exports plus the full TypeScript surface; the export surface is byte-identical to upstream in both directions (locked by test), and `@tanstack/query-core` is re-exported verbatim.
 
@@ -209,7 +209,7 @@ See also: [`docs/tanstack-parity-audit.md`](tanstack-parity-audit.md)
 
 ## @octanejs/tanstack-router
 
-[`packages/tanstack-router`](../packages/tanstack-router) `0.1.2` — ports `@tanstack/react-router@1.170.16`. Status data: [`packages/tanstack-router/status.json`](../packages/tanstack-router/status.json).
+[`packages/tanstack-router`](../packages/tanstack-router) `0.1.3` — ports `@tanstack/react-router@1.170.16`. Status data: [`packages/tanstack-router/status.json`](../packages/tanstack-router/status.json).
 
 Code-based routing at full binding parity (2026-07-06 gap-closure sweep): the full Match pipeline, router lifecycle events, the complete read-hook family, full-parity `Link` (preloading, masking, `activeProps`), `useBlocker`/`Block`, `Await`/`defer`, scroll restoration, lazy routes, not-found handling, and search-param validation/middleware — differential-verified byte-equal vs the real `@tanstack/react-router`.
 
@@ -226,7 +226,7 @@ See also: [`docs/tanstack-parity-audit.md`](tanstack-parity-audit.md)
 
 ## @octanejs/tanstack-table
 
-[`packages/tanstack-table`](../packages/tanstack-table) `0.1.0` — ports `@tanstack/react-table@8.21.3`. Status data: [`packages/tanstack-table/status.json`](../packages/tanstack-table/status.json).
+[`packages/tanstack-table`](../packages/tanstack-table) `0.1.1` — ports `@tanstack/react-table@8.21.3`. Status data: [`packages/tanstack-table/status.json`](../packages/tanstack-table/status.json).
 
 Complete 1:1 port: the framework-agnostic `@tanstack/table-core` (createTable + all feature row models) is reused verbatim; the ~100-line React adapter (`useReactTable`, `flexRender`) is transcribed onto octane hooks, preserving upstream's useState-based state wiring.
 
@@ -240,7 +240,7 @@ SSR / hydration: No SSR-specific surface; table-core is pure computation.
 
 ## @octanejs/tanstack-virtual
 
-[`packages/tanstack-virtual`](../packages/tanstack-virtual) `0.1.0` — ports `@tanstack/react-virtual@3.14.5`. Status data: [`packages/tanstack-virtual/status.json`](../packages/tanstack-virtual/status.json).
+[`packages/tanstack-virtual`](../packages/tanstack-virtual) `0.1.1` — ports `@tanstack/react-virtual@3.14.5`. Status data: [`packages/tanstack-virtual/status.json`](../packages/tanstack-virtual/status.json).
 
 Complete 1:1 port: the framework-agnostic `@tanstack/virtual-core` (Virtualizer + observers + windowing math) is reused verbatim; the React adapter (`useVirtualizer`, `useWindowVirtualizer`, incl. `useFlushSync` and the experimental `directDomUpdates` surface) is transcribed onto octane hooks, preserving upstream's force-update + flushSync-on-sync-scroll wiring and layout-effect lifecycle.
 
@@ -254,7 +254,7 @@ SSR / hydration: SSR-safe: `useIsomorphicLayoutEffect` degrades to `useEffect` w
 
 ## @octanejs/testing-library
 
-[`packages/testing-library`](../packages/testing-library) `0.1.0` — ports `@testing-library/react` (unpinned). Status data: [`packages/testing-library/status.json`](../packages/testing-library/status.json).
+[`packages/testing-library`](../packages/testing-library) `0.1.1` — ports `@testing-library/react` (unpinned). Status data: [`packages/testing-library/status.json`](../packages/testing-library/status.json).
 
 `render`/`rerender`/`cleanup`/`renderHook` + `act` over the verbatim `@testing-library/dom` (every query, `screen`, `within`, `waitFor`, `fireEvent`, `prettyDOM`, `configure`), with commit timing wired to octane's scheduler via the dom-library's `eventWrapper`/`asyncWrapper` config.
 
@@ -271,7 +271,7 @@ See also: [`docs/testing-library-migration-plan.md`](testing-library-migration-p
 
 ## @octanejs/zustand
 
-[`packages/zustand`](../packages/zustand) `0.1.2` — ports `zustand@5.0.14`. Status data: [`packages/zustand/status.json`](../packages/zustand/status.json).
+[`packages/zustand`](../packages/zustand) `0.1.3` — ports `zustand@5.0.14`. Status data: [`packages/zustand/status.json`](../packages/zustand/status.json).
 
 Complete 1:1 port: the framework-agnostic vanilla store is reused verbatim; `create`/`useStore`, `shallow`/`useShallow`, the traditional equality-fn variants, and all middleware (persist, devtools, subscribeWithSelector, combine, redux).
 

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -18,6 +18,20 @@ renders in its own scope. `use()` and `useContext` are exempt (they are
 call-order / context-identity keyed, not slot-keyed), so they may sit in plain
 loops.
 
+## `useState` / `useReducer` current-state getters
+
+Both state hooks have an Octane-only third tuple member: a stable zero-argument
+function that reads the hook's latest state (`const [state, update, getState] =
+useState(initial)`). This replaces the common React pattern of synchronizing a
+ref solely so delayed or async callbacks can avoid a stale render closure.
+
+The getter reads the latest scheduled hook-cell value and does not subscribe or
+render. During pending work it can therefore be newer than the currently
+committed DOM. The compiler removes the getter entirely when it can prove tuple
+index 2 is unobserved, so ordinary two-item destructuring retains the existing
+runtime path and allocation profile. Escaped or ambiguous tuples conservatively
+receive the complete three-item shape.
+
 ## Native events, no synthetic event system
 
 Events are real, delegated DOM events (`onClick`, `onInput`, `onSubmit`) —

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "typecheck": "tsgo --noEmit -p packages/octane/tsconfig.json && tsgo --noEmit -p packages/vite-plugin-octane/tsconfig.typecheck.json && tsgo --noEmit -p packages/adapter-vercel/tsconfig.typecheck.json && tsgo --noEmit -p packages/zustand/tsconfig.json && tsgo --noEmit -p packages/jotai/tsconfig.json && tsgo --noEmit -p packages/tanstack-query/tsconfig.json && tsgo --noEmit -p packages/recharts/tsconfig.json && tsgo --noEmit -p packages/redux/tsconfig.json && tsgo --noEmit -p packages/hook-form/tsconfig.json && tsgo --noEmit -p packages/hook-form/typetests/tsconfig.json && tsgo --noEmit -p packages/motion/tsconfig.json && tsgo --noEmit -p packages/stylex/tsconfig.json && tsgo --noEmit -p packages/tanstack-router/tsconfig.json && tsgo --noEmit -p packages/tanstack-table/tsconfig.json && tsgo --noEmit -p packages/tanstack-virtual/tsconfig.json && tsgo --noEmit -p packages/lexical/tsconfig.json && tsgo --noEmit -p packages/floating-ui/tsconfig.json && tsgo --noEmit -p packages/radix/tsconfig.json && tsgo --noEmit -p packages/base-ui/tsconfig.json && tsgo --noEmit -p packages/testing-library/tsconfig.json && tsgo --noEmit -p packages/mdx/tsconfig.json && tsgo --noEmit -p website/tsconfig.json",
     "changeset": "changeset && pnpm changeset:check",
     "changeset:check": "node scripts/check-changesets.js",
-    "changeset:version": "pnpm changeset:check && changeset version",
+    "changeset:version": "pnpm changeset:check && changeset version && pnpm bindings:status",
     "changeset:publish": "pnpm changeset:check && changeset publish",
     "prepare": "rulesync generate || true",
     "rules:generate": "rulesync generate",

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -575,7 +575,7 @@ function collectComponentLocals(componentNode) {
  * memoising on.
  *
  * Stability sources:
- *   - useState / useReducer setters (second destructured slot)
+ *   - useState / useReducer setters and state getters (second/third slots)
  *   - useRef returns (the ref object itself, not .current)
  *   - useCallback / useEffectEvent returns
  *   - Arrows previously declared in this body whose free vars are themselves
@@ -605,8 +605,20 @@ function computeStableLocals(statements, componentLocals) {
 					decl.id.elements[1].type === 'Identifier'
 				) {
 					stable.add(decl.id.elements[1].name);
-					continue;
 				}
+				// [_, _, getX] = useState(...) — the compiler-generated getter
+				// closes over the hook cell and is stable for that cell's lifetime.
+				if (
+					(callName === 'useState' || callName === 'useReducer') &&
+					decl.id.type === 'ArrayPattern' &&
+					decl.id.elements &&
+					decl.id.elements.length >= 3 &&
+					decl.id.elements[2] &&
+					decl.id.elements[2].type === 'Identifier'
+				) {
+					stable.add(decl.id.elements[2].name);
+				}
+				if (callName === 'useState' || callName === 'useReducer') continue;
 				// x = useRef(...) / useCallback(...) / useEffectEvent(...) — the
 				// return value is stable for the lifetime of the component.
 				if (
@@ -4152,7 +4164,86 @@ function rejectHookInJsLoop(loop, ctx, componentName) {
 	walk(loop);
 }
 
+const STATE_GETTER_HELPERS = {
+	useState: '__useStateWithGetter',
+	useReducer: '__useReducerWithGetter',
+};
+
+function arrayPatternObservesStateGetter(pattern) {
+	const elements = pattern.elements || [];
+	if (elements[2] != null) return true;
+	// A rest before/at index 2 observes the getter even without an explicit
+	// third binding: `[state, ...rest]` includes both update and getState.
+	for (let i = 0; i <= 2 && i < elements.length; i++) {
+		if (elements[i]?.type === 'RestElement') return true;
+	}
+	return false;
+}
+
+function isTransparentStateTupleWrapper(node, child) {
+	if (!node) return false;
+	if (
+		node.type === 'TSAsExpression' ||
+		node.type === 'TSTypeAssertion' ||
+		node.type === 'TSNonNullExpression' ||
+		node.type === 'ParenthesizedExpression' ||
+		node.type === 'ChainExpression'
+	) {
+		return node.expression === child;
+	}
+	return false;
+}
+
+// Source-level useState/useReducer tuples have a third getState member. Mark
+// calls that can observe it so rewriteHookCalls can select a specialized helper;
+// the ordinary two-item runtime path remains byte-for-byte for proven-dead
+// getters. Any escaping/ambiguous tuple is conservative and gets the full shape.
+function markStateGetterUsage(root) {
+	const ancestors = [];
+	function walk(node) {
+		if (node == null || typeof node !== 'object') return;
+		if (Array.isArray(node)) {
+			for (const child of node) walk(child);
+			return;
+		}
+		if (
+			node.type === 'CallExpression' &&
+			node.callee?.type === 'Identifier' &&
+			STATE_GETTER_HELPERS[node.callee.name]
+		) {
+			let child = node;
+			let i = ancestors.length - 1;
+			while (i >= 0 && isTransparentStateTupleWrapper(ancestors[i], child)) {
+				child = ancestors[i--];
+			}
+			const parent = i >= 0 ? ancestors[i] : null;
+			let observed = true;
+			if (parent?.type === 'VariableDeclarator' && parent.init === child) {
+				observed = parent.id.type !== 'ArrayPattern' || arrayPatternObservesStateGetter(parent.id);
+			} else if (parent?.type === 'AssignmentExpression' && parent.right === child) {
+				observed =
+					parent.left.type !== 'ArrayPattern' || arrayPatternObservesStateGetter(parent.left);
+			} else if (parent?.type === 'MemberExpression' && parent.object === child) {
+				const p = parent.property;
+				const index = parent.computed && p?.type === 'Literal' ? Number(p.value) : NaN;
+				observed = index !== 0 && index !== 1;
+			} else if (parent?.type === 'ExpressionStatement') {
+				observed = false;
+			}
+			node._octaneStateGetter = observed;
+		}
+		ancestors.push(node);
+		for (const key in node) {
+			if (AST_WALK_SKIP_KEYS.has(key) || key === '_octaneStateGetter') continue;
+			walk(node[key]);
+		}
+		ancestors.pop();
+	}
+	walk(root);
+}
+
 function rewriteHookCalls(node, ctx, componentName) {
+	markStateGetterUsage(node);
 	return mapAst(node, (n) => {
 		// A plain JS loop must not contain slot-keyed hook calls — reject before
 		// slotting. (A template `@for` is also a ForOfStatement; its JSX body tells
@@ -4183,6 +4274,7 @@ function rewriteHookCalls(node, ctx, componentName) {
 			const isCustom = /^use[A-Z]/.test(name) && name !== 'useContext';
 			const isServerUse = name === 'use' && ctx.mode === 'server';
 			if (isBuiltin || isCustom || isServerUse) {
+				const getterHelper = n._octaneStateGetter ? STATE_GETTER_HELPERS[name] : null;
 				// A builtin hook call site is USER code (the user's own identifier), so
 				// its import stays bare — EXCEPT compiler-inserted calls (auto-callback's
 				// `useCallback`), whose callee is renamed to the `_$` alias below so a
@@ -4190,6 +4282,7 @@ function rewriteHookCalls(node, ctx, componentName) {
 				if (isBuiltin) {
 					if (n.callee._octaneGenerated) ctx.runtimeNeeded.add(name);
 					else ctx.userRuntimeNames.add(name);
+					if (getterHelper !== null) ctx.runtimeNeeded.add(getterHelper);
 				}
 				if (isServerUse) ctx.userRuntimeNames.add('use');
 				const debug = isServerUse
@@ -4226,9 +4319,12 @@ function rewriteHookCalls(node, ctx, componentName) {
 				}
 				return {
 					...n,
-					callee: n.callee._octaneGenerated
-						? { type: 'Identifier', name: rtAlias(name) }
-						: n.callee,
+					callee:
+						getterHelper !== null
+							? { type: 'Identifier', name: rtAlias(getterHelper) }
+							: n.callee._octaneGenerated
+								? { type: 'Identifier', name: rtAlias(name) }
+								: n.callee,
 					arguments: [...args, { type: 'Identifier', name: symVar }],
 				};
 			}

--- a/packages/octane/src/compiler/slot-hooks.js
+++ b/packages/octane/src/compiler/slot-hooks.js
@@ -37,6 +37,80 @@ function octaneHookLocals(ast) {
 	return importsHook ? locals : null;
 }
 
+const STATE_GETTER_HELPERS = {
+	useState: '__useStateWithGetter',
+	useReducer: '__useReducerWithGetter',
+};
+
+function arrayPatternObservesStateGetter(pattern) {
+	const elements = pattern.elements || [];
+	if (elements[2] != null) return true;
+	for (let i = 0; i <= 2 && i < elements.length; i++) {
+		if (elements[i]?.type === 'RestElement') return true;
+	}
+	return false;
+}
+
+function isTransparentStateTupleWrapper(node, child) {
+	return (
+		(node?.type === 'TSAsExpression' ||
+			node?.type === 'TSTypeAssertion' ||
+			node?.type === 'TSNonNullExpression' ||
+			node?.type === 'ParenthesizedExpression' ||
+			node?.type === 'ChainExpression') &&
+		node.expression === child
+	);
+}
+
+// Mark base-hook calls whose source tuple can observe index 2. Direct fixed
+// destructures that omit it keep the existing two-item runtime path; escaped or
+// otherwise ambiguous tuples conservatively receive the full getter-enabled shape.
+function collectStateGetterCalls(ast, locals) {
+	const calls = new WeakSet();
+	const ancestors = [];
+	function walk(node) {
+		if (node == null || typeof node !== 'object') return;
+		if (Array.isArray(node)) {
+			for (const child of node) walk(child);
+			return;
+		}
+		if (node.type === 'CallExpression' && node.callee?.type === 'Identifier') {
+			const imported = locals.get(node.callee.name);
+			if (STATE_GETTER_HELPERS[imported]) {
+				let child = node;
+				let i = ancestors.length - 1;
+				while (i >= 0 && isTransparentStateTupleWrapper(ancestors[i], child)) {
+					child = ancestors[i--];
+				}
+				const parent = i >= 0 ? ancestors[i] : null;
+				let observed = true;
+				if (parent?.type === 'VariableDeclarator' && parent.init === child) {
+					observed =
+						parent.id.type !== 'ArrayPattern' || arrayPatternObservesStateGetter(parent.id);
+				} else if (parent?.type === 'AssignmentExpression' && parent.right === child) {
+					observed =
+						parent.left.type !== 'ArrayPattern' || arrayPatternObservesStateGetter(parent.left);
+				} else if (parent?.type === 'MemberExpression' && parent.object === child) {
+					const p = parent.property;
+					const index = parent.computed && p?.type === 'Literal' ? Number(p.value) : NaN;
+					observed = index !== 0 && index !== 1;
+				} else if (parent?.type === 'ExpressionStatement') {
+					observed = false;
+				}
+				if (observed) calls.add(node);
+			}
+		}
+		ancestors.push(node);
+		for (const key in node) {
+			if (key === 'type' || key === 'start' || key === 'end' || key === 'loc') continue;
+			walk(node[key]);
+		}
+		ancestors.pop();
+	}
+	walk(ast);
+	return calls;
+}
+
 // DFS in SOURCE ORDER, allocating a hook's slot id BEFORE descending into its args
 // — identical pre-order to rewriteHookCalls, so a base hook nested as an argument
 // (e.g. in a deps array) gets its own stable id. Collects insertion edits + the
@@ -86,6 +160,17 @@ function walk(node, fnName, st) {
 				// trailing commas / whitespace before `)` stay valid.
 				st.edits.push({ pos: node.arguments[node.arguments.length - 1].end, text: ', ' + sym });
 			}
+			if (st.getterCalls.has(node) && STATE_GETTER_HELPERS[imported]) {
+				let helper = st.getterHelpers.get(imported);
+				if (helper === undefined) {
+					const base = `_$${STATE_GETTER_HELPERS[imported]}`;
+					helper = base;
+					let suffix = 0;
+					while (st.source.includes(helper)) helper = `${base}$${++suffix}`;
+					st.getterHelpers.set(imported, helper);
+				}
+				st.edits.push({ pos: node.callee.start, end: node.callee.end, text: helper });
+			}
 		}
 	}
 
@@ -123,6 +208,9 @@ export function slotHooks(source, id, options) {
 
 	const st = {
 		locals,
+		source,
+		getterCalls: collectStateGetterCalls(ast, locals),
+		getterHelpers: new Map(),
 		filename: id,
 		hmr: !!(options && options.hmr),
 		hash: hookSlotHash(id),
@@ -136,7 +224,9 @@ export function slotHooks(source, id, options) {
 	// Apply insertions right-to-left so earlier offsets stay valid.
 	st.edits.sort((a, b) => b.pos - a.pos);
 	let code = source;
-	for (const e of st.edits) code = code.slice(0, e.pos) + e.text + code.slice(e.pos);
+	for (const e of st.edits) {
+		code = code.slice(0, e.pos) + e.text + code.slice(e.end === undefined ? e.pos : e.end);
+	}
 
 	// APPEND the slot consts (rather than prepend) so every original line number
 	// stays put — this pass emits no source map, so aligned lines are what keep
@@ -144,7 +234,13 @@ export function slotHooks(source, id, options) {
 	// side-effect-free and the consts are read only inside function bodies (which
 	// run after the module is fully evaluated, including cross-module imports), so
 	// trailing placement has no TDZ hazard for any valid hook usage.
-	const block = st.decls.join('\n') + '\n';
+	const helperImport =
+		st.getterHelpers.size === 0
+			? ''
+			: `import { ${[...st.getterHelpers]
+					.map(([hook, local]) => `${STATE_GETTER_HELPERS[hook]} as ${local}`)
+					.join(', ')} } from 'octane';\n`;
+	const block = helperImport + st.decls.join('\n') + '\n';
 	code = code.endsWith('\n') ? code + block : code + '\n' + block;
 	return { code, map: null };
 }

--- a/packages/octane/src/index.ts
+++ b/packages/octane/src/index.ts
@@ -81,6 +81,8 @@ export {
 
 	// ── 2. Semi-public: compiler-emitted / binding-infrastructure helpers ─────
 	// (the compiled-output ↔ runtime contract; also used by @octanejs/* bindings)
+	__useStateWithGetter,
+	__useReducerWithGetter,
 	// Module-load "this module uses <ViewTransition>" hint (view-transitions plan).
 	__vtSeen,
 	template,

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -975,6 +975,8 @@ interface HookRec {
 	queue: unknown[];
 	/** Stable dispatch identity across the re-render passes (as on the client). */
 	dispatch: (action: unknown) => void;
+	/** Allocated only for compiler-proven third-tuple consumers. */
+	getter?: () => unknown;
 }
 interface HookPass {
 	/** Slot → occurrence-indexed records, persisting across this body's passes. */
@@ -1010,10 +1012,14 @@ function stateHook<S, A>(
 	reducer: (s: S, a: A) => S,
 	create: () => S,
 	slot: unknown,
-): [S, (action: A) => void] {
+	withGetter = false,
+): [S, (action: A) => void, (() => S)?] {
 	const hp = HOOK_PASS;
 	// Defensive: a hook invoked outside any component body — single-pass shape.
-	if (hp === null) return [create(), NOOP];
+	if (hp === null) {
+		const value = create();
+		return withGetter ? [value, NOOP, () => value] : [value, NOOP];
+	}
 	const key: symbol | string =
 		typeof slot === 'symbol' || typeof slot === 'string' ? slot : (PENDING_SLOT ?? NO_SLOT);
 	const n = hp.occ.get(key) ?? 0;
@@ -1042,7 +1048,9 @@ function stateHook<S, A>(
 		rec.queue = [];
 		rec.value = v;
 	}
-	return [rec.value as S, rec.dispatch as (action: A) => void];
+	if (!withGetter) return [rec.value as S, rec.dispatch as (action: A) => void];
+	const getter = (rec.getter ??= () => rec.value) as () => S;
+	return [rec.value as S, rec.dispatch as (action: A) => void, getter];
 }
 
 // Invoke a component body, re-invoking while render-phase dispatches fired
@@ -1907,12 +1915,25 @@ export function lazy<C>(load: () => PromiseLike<{ default: C } | C>): C {
 export function useState<T>(
 	initial: T | (() => T),
 	slot?: symbol | string,
-): [T, (next: any) => void] {
+): [T, (next: any) => void, () => T] {
 	return stateHook<T, any>(
 		basicStateReducer as (s: T, a: any) => T,
 		() => (typeof initial === 'function' ? (initial as () => T)() : initial),
 		slot,
-	);
+	) as [T, (next: any) => void, () => T];
+}
+
+/** Compiler-emitted useState variant for a tuple whose third member is observed. */
+export function __useStateWithGetter<T>(
+	initial: T | (() => T),
+	slot?: symbol | string,
+): [T, (next: any) => void, () => T] {
+	return stateHook<T, any>(
+		basicStateReducer as (s: T, a: any) => T,
+		() => (typeof initial === 'function' ? (initial as () => T)() : initial),
+		slot,
+		true,
+	) as [T, (next: any) => void, () => T];
 }
 
 export function useReducer<S, A, I = S>(
@@ -1922,14 +1943,31 @@ export function useReducer<S, A, I = S>(
 	// without one the slot itself sits third (`useReducer(r, arg, slot)`).
 	initOrSlot?: ((arg: I) => S) | symbol | string,
 	maybeSlot?: symbol | string,
-): [S, (action: A) => void] {
+): [S, (action: A) => void, () => S] {
 	const init = typeof initOrSlot === 'function' ? initOrSlot : undefined;
 	const slot = init !== undefined ? maybeSlot : initOrSlot;
 	return stateHook<S, A>(
 		reducer,
 		() => (init ? init(initialArg) : (initialArg as unknown as S)),
 		slot,
-	);
+	) as [S, (action: A) => void, () => S];
+}
+
+/** Compiler-emitted useReducer variant for a tuple whose third member is observed. */
+export function __useReducerWithGetter<S, A, I = S>(
+	reducer: (s: S, a: A) => S,
+	initialArg: I,
+	initOrSlot?: ((arg: I) => S) | symbol | string,
+	maybeSlot?: symbol | string,
+): [S, (action: A) => void, () => S] {
+	const init = typeof initOrSlot === 'function' ? initOrSlot : undefined;
+	const slot = init !== undefined ? maybeSlot : initOrSlot;
+	return stateHook<S, A>(
+		reducer,
+		() => (init ? init(initialArg) : (initialArg as unknown as S)),
+		slot,
+		true,
+	) as [S, (action: A) => void, () => S];
 }
 
 export function useEffect(): void {}

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -3045,12 +3045,14 @@ function resolveSlot(slot: symbol | undefined): symbol | undefined {
 interface StateSlot<T> {
 	value: T;
 	setter: (next: T | ((prev: T) => T)) => void;
+	/** Allocated only for compiler-proven third-tuple consumers. */
+	getter?: () => T;
 }
 
-export function useState<T>(
-	initial: T | (() => T),
-	slot?: symbol,
-): [T, (next: T | ((prev: T) => T)) => void] {
+type StateSetter<T> = (next: T | ((prev: T) => T)) => void;
+type StateTuple<T> = [T, StateSetter<T>, () => T];
+
+export function useState<T>(initial: T | (() => T), slot?: symbol): StateTuple<T> {
 	// ABI: the compiler appends the slot as the LAST argument, so a zero-arg
 	// `useState()` (state starts undefined — React parity) arrives as
 	// `useState(slot)` with the symbol in the initial-value position. Same
@@ -3078,15 +3080,44 @@ export function useState<T>(
 		};
 		ensureHooks(scope).set(slot, s);
 	}
-	return [s.value, s.setter];
+	// Source-level useState returns a third `getState` tuple member. The compiler
+	// keeps this lean two-item path only when it can prove index 2 is unobserved;
+	// observable/escaping tuples are lowered to __useStateWithGetter below.
+	return [s.value, s.setter] as unknown as StateTuple<T>;
 }
+
+/** Compiler-emitted useState variant for a tuple whose third member is observed. */
+export function __useStateWithGetter<T>(initial: T | (() => T), slot?: symbol): StateTuple<T> {
+	// Mirror useState's zero-argument trailing-slot ABI before delegating so we
+	// can look the resulting cell up by the same effective slot afterwards.
+	if (slot === undefined && typeof initial === 'symbol') {
+		slot = initial as unknown as symbol;
+		initial = undefined as T;
+	}
+	const pair = useState(initial, slot);
+	const resolved = resolveSlot(slot);
+	if (resolved === undefined) missingSlot('useState');
+	const s = CURRENT_SCOPE!.hooks!.get(resolved) as StateSlot<T>;
+	const getter = s.getter ?? (s.getter = () => s.value);
+	return [pair[0], pair[1], getter];
+}
+
+interface ReducerSlot<S, A> {
+	value: S;
+	dispatch: (action: A) => void;
+	reducer: (state: S, action: A) => S;
+	/** Allocated only for compiler-proven third-tuple consumers. */
+	getter?: () => S;
+}
+
+type ReducerTuple<S, A> = [S, (action: A) => void, () => S];
 
 export function useReducer<S, A, I = S>(
 	reducer: (s: S, a: A) => S,
 	initialArg: I,
 	initOrSlot?: ((arg: I) => S) | symbol,
 	slot?: symbol,
-): [S, (action: A) => void] {
+): ReducerTuple<S, A> {
 	// The compiler appends the hook slot symbol as the final argument. So the
 	// React 2-arg form `useReducer(reducer, initialState)` arrives as
 	// `(reducer, initialState, slot)` and the lazy 3-arg form
@@ -3103,9 +3134,7 @@ export function useReducer<S, A, I = S>(
 	if (slot === undefined) missingSlot('useReducer');
 	const scope = CURRENT_SCOPE!;
 	const block = CURRENT_BLOCK!;
-	let s = scope.hooks?.get(slot) as
-		| { value: S; dispatch: (a: A) => void; reducer: (s: S, a: A) => S }
-		| undefined;
+	let s = scope.hooks?.get(slot) as ReducerSlot<S, A> | undefined;
 	if (s === undefined) {
 		// React parity: the initial state is `initialArg` used AS-IS. Lazy
 		// initialization happens ONLY when the third `init` argument is supplied
@@ -3129,7 +3158,25 @@ export function useReducer<S, A, I = S>(
 		// Allow reducer reference to update across renders.
 		s.reducer = reducer;
 	}
-	return [s.value, s.dispatch];
+	// See useState: the compiler selects __useReducerWithGetter whenever the
+	// source can observe the third tuple member.
+	return [s.value, s.dispatch] as unknown as ReducerTuple<S, A>;
+}
+
+/** Compiler-emitted useReducer variant for a tuple whose third member is observed. */
+export function __useReducerWithGetter<S, A, I = S>(
+	reducer: (s: S, a: A) => S,
+	initialArg: I,
+	initOrSlot?: ((arg: I) => S) | symbol,
+	slot?: symbol,
+): ReducerTuple<S, A> {
+	const resolvedInput = typeof initOrSlot === 'symbol' ? initOrSlot : slot;
+	const pair = useReducer(reducer, initialArg, initOrSlot, slot);
+	const resolved = resolveSlot(resolvedInput);
+	if (resolved === undefined) missingSlot('useReducer');
+	const s = CURRENT_SCOPE!.hooks!.get(resolved) as ReducerSlot<S, A>;
+	const getter = s.getter ?? (s.getter = () => s.value);
+	return [pair[0], pair[1], getter];
 }
 
 function depsChanged(prev: any[] | undefined, next: any[] | undefined): boolean {

--- a/packages/octane/src/server/index.ts
+++ b/packages/octane/src/server/index.ts
@@ -41,6 +41,8 @@ export {
 	// Hooks (server semantics)
 	useState,
 	useReducer,
+	__useStateWithGetter,
+	__useReducerWithGetter,
 	useEffect,
 	useLayoutEffect,
 	useInsertionEffect,

--- a/packages/octane/tests/_fixtures/state-getter.tsrx
+++ b/packages/octane/tests/_fixtures/state-getter.tsrx
@@ -1,0 +1,39 @@
+import { useReducer, useState } from 'octane';
+
+export function StateGetter(props) @{
+	const [count, setCount, getCount] = useState(props.initial);
+	props.observeGetter(getCount);
+	const update = () => {
+		setCount((n) => n + 1);
+		props.observeValue(getCount());
+		setCount((n) => n + 1);
+		props.observeValue(getCount());
+	};
+	<button id="state" onClick={update}>
+		{count as string}
+	</button>
+}
+
+export function ReducerGetter(props) @{
+	const [count, dispatch, getCount] = useReducer(
+		(state: number, amount: number) => state + amount * props.step,
+		props.initial,
+		(seed: number) => seed * 10,
+	);
+	props.observeGetter(getCount);
+	const update = () => {
+		dispatch(2);
+		props.observeValue(getCount());
+	};
+	<button id="reducer" onClick={update}>
+		{count as string}
+	</button>
+}
+
+export function ServerGetter() @{
+	const [count, setCount, getCount] = useState(0);
+	if (count < 2) setCount(count + 1);
+	<span>
+		{'Count: ' + getCount()}
+	</span>
+}

--- a/packages/octane/tests/auto-callback.test.ts
+++ b/packages/octane/tests/auto-callback.test.ts
@@ -36,6 +36,19 @@ describe('auto-callback transform — stable-closure arrows wrap in useCallback'
 		expect(code).toMatch(/import\s*\{[^}]*useCallback[^}]*\}\s*from\s*['"]octane['"]/);
 	});
 
+	it('stable arrow over a state getter wraps and includes the getter in deps', () => {
+		const code = c(`
+      import { useState } from 'octane';
+      export function Counter() @{
+        const [count, setCount, getCount] = useState(0);
+        const read = () => getCount();
+        <button onClick={read}>{count as string}</button>
+      }
+    `);
+		expect(code).toMatch(/const\s+read\s*=\s*_\$useCallback\s*\(/);
+		expect(code).toMatch(/_\$useCallback\s*\([\s\S]*?,\s*\[\s*getCount\s*\]/);
+	});
+
 	it('arrow that closes only over a prop is NOT rewrapped', () => {
 		const code = c(`
       export function Hi(props) @{

--- a/packages/octane/tests/external-hook-slot.test.ts
+++ b/packages/octane/tests/external-hook-slot.test.ts
@@ -104,7 +104,7 @@ describe('vite plugin gate routing', () => {
 	const plugin = octane({ exclude: ['/packages/zustand/src/'] });
 	// the transform doesn't need a real plugin `this` for the client paths
 	const run = (code: string, id: string) => (plugin.transform as any).call({}, code, id);
-	const HOOK = `import { useState } from 'octane';\nexport const f = () => useState(0);`;
+	const HOOK = `import { useState } from 'octane';\nexport const f = () => { const [state, setState] = useState(0); return [state, setState]; };`;
 
 	it('.ts with an octane hook → surgical slot pass', () => {
 		expect(run(HOOK, '/app/h.ts')?.code).toMatch(/useState\(0, _h\$\d+\)/);
@@ -145,7 +145,7 @@ describe('manifest-declared manual hook slots', () => {
 	// actual manifests.
 	const plugin = octane();
 	const run = (code: string, id: string) => (plugin.transform as any).call({}, code, id);
-	const HOOK = `import { useState } from 'octane';\nexport const f = () => useState(0);`;
+	const HOOK = `import { useState } from 'octane';\nexport const f = () => { const [state, setState] = useState(0); return [state, setState]; };`;
 
 	it('skips files under a directory declared manual', () => {
 		const id = join(process.cwd(), 'packages/zustand/src/__probe__.ts');

--- a/packages/octane/tests/state-getter.test.ts
+++ b/packages/octane/tests/state-getter.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+import { compile } from 'octane/compiler';
+import * as ServerRuntime from 'octane/server';
+import { mount } from './_helpers';
+import { ReducerGetter, StateGetter } from './_fixtures/state-getter.tsrx';
+import { slotHooks } from '../src/compiler/slot-hooks.js';
+import { useReducer, useState } from '../src/index.js';
+
+function assertStateGetterTypes(): void {
+	const [, , getState] = useState(0, Symbol.for('type.state'));
+	const state: number = getState();
+	const [, , getReduced] = useReducer(
+		(value: number, amount: number) => value + amount,
+		0,
+		Symbol.for('type.reducer'),
+	);
+	const reduced: number = getReduced();
+	void state;
+	void reduced;
+}
+void assertStateGetterTypes;
+
+describe('compiler-driven state getters', () => {
+	it('keeps the existing hook path when tuple index 2 is provably unobserved', () => {
+		const source = `
+      import { useState, useReducer } from 'octane';
+      export function App() @{
+        const [state, setState] = useState(0);
+        const [reduced, dispatch] = useReducer((s, a) => s + a, 0);
+        <p>{state + reduced + ''}</p>
+      }
+    `;
+		for (const mode of ['client', 'server'] as const) {
+			const code = compile(source, 'lean-state.tsrx', { mode }).code;
+			expect(code).not.toContain('__useStateWithGetter');
+			expect(code).not.toContain('__useReducerWithGetter');
+			expect(code).toMatch(/useState\(0, _h\$\d+\)/);
+			expect(code).toMatch(/useReducer\([^;]+, _h\$\d+\)/);
+		}
+	});
+
+	it('selects getter helpers for third bindings and escaped tuples', () => {
+		const source = `
+      import { useState, useReducer } from 'octane';
+      export function Direct() @{
+        const [state, setState, getState] = useState(0);
+        const [reduced, dispatch, getReduced] = useReducer((s, a) => s + a, 0);
+        <p>{getState() + getReduced() + ''}</p>
+      }
+      export function Escaped() { return useState(0); }
+    `;
+		for (const mode of ['client', 'server'] as const) {
+			const code = compile(source, 'getter-state.tsrx', { mode }).code;
+			expect(code).toContain('__useStateWithGetter as _$__useStateWithGetter');
+			expect(code).toContain('__useReducerWithGetter as _$__useReducerWithGetter');
+			expect(code).toMatch(/_\$__useStateWithGetter\(0, _h\$\d+\)/);
+			expect(code).toMatch(/_\$__useReducerWithGetter\([^;]+, _h\$\d+\)/);
+		}
+	});
+
+	it('classifies static tuple indexing and rest destructuring', () => {
+		const code = compile(
+			`
+        import { useState } from 'octane';
+        export function First() @{
+          const first = useState(0)[0];
+          <p>{first as string}</p>
+        }
+        export function Third() @{
+          const getState = useState(0)[2];
+          <p>{getState() as string}</p>
+        }
+        export function Rest() @{
+          const [state, ...rest] = useState(0);
+          <p>{state + rest.length + ''}</p>
+        }
+      `,
+			'tuple-state.tsrx',
+		).code;
+		expect(code).toMatch(/const first = useState\(0, _h\$\d+\)\[0\]/);
+		expect(code).toMatch(/const getState = _\$__useStateWithGetter\(0, _h\$\d+\)\[2\]/);
+		expect(code).toMatch(/\[state, \.\.\.rest\] = _\$__useStateWithGetter\(0, _h\$\d+\)/);
+	});
+
+	it('handles aliases and preserves the surgical TypeScript pass', () => {
+		const source = `import { useState as state } from 'octane';
+export function useValue() {
+  const [value, setValue, getValue] = state<number>(0);
+  return { value, setValue, getValue };
+}`;
+		const code = slotHooks(source, 'state-getter.ts')!.code;
+		expect(code).toMatch(/_\$__useStateWithGetter<number>\(0, _h\$\d+\)/);
+		expect(code).toContain(
+			"import { __useStateWithGetter as _$__useStateWithGetter } from 'octane';",
+		);
+		expect(code).not.toContain('state<number>');
+	});
+});
+
+describe('state getter runtime semantics', () => {
+	it('reads sequential useState updates immediately and stays stable', () => {
+		const values: number[] = [];
+		const getters: Array<() => number> = [];
+		const r = mount(StateGetter, {
+			initial: 0,
+			observeValue: (value: number) => values.push(value),
+			observeGetter: (getter: () => number) => getters.push(getter),
+		});
+		r.click('#state');
+		expect(values).toEqual([1, 2]);
+		expect(r.find('#state').textContent).toBe('2');
+		expect(getters.length).toBeGreaterThan(1);
+		expect(getters.every((getter) => getter === getters[0])).toBe(true);
+		expect(getters[0]()).toBe(2);
+		r.unmount();
+	});
+
+	it('reads useReducer dispatches immediately and uses the latest reducer', () => {
+		const values: number[] = [];
+		const getters: Array<() => number> = [];
+		const props = {
+			initial: 1,
+			step: 1,
+			observeValue: (value: number) => values.push(value),
+			observeGetter: (getter: () => number) => getters.push(getter),
+		};
+		const r = mount(ReducerGetter, props);
+		expect(r.find('#reducer').textContent).toBe('10');
+		r.update(ReducerGetter, { ...props, step: 3 });
+		r.click('#reducer');
+		expect(values).toEqual([16]);
+		expect(r.find('#reducer').textContent).toBe('16');
+		expect(getters.every((getter) => getter === getters[0])).toBe(true);
+		expect(getters[0]()).toBe(16);
+		r.unmount();
+	});
+
+	it('tracks the converged render-phase state on the server', () => {
+		const source = `
+      import { useState } from 'octane';
+      export function App() @{
+        const [count, setCount, getCount] = useState(0);
+        if (count < 2) setCount(count + 1);
+        <span>{'Count: ' + getCount()}</span>
+      }
+    `;
+		let code = compile(source, 'server-getter.tsrx', { mode: 'server' }).code;
+		code = code.replace(
+			/import\s*\{([^}]*)\}\s*from\s*['"]octane(?:\/server)?['"];?/g,
+			(_match, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
+		);
+		code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
+		const mod = new Function('__rt', '__exports', code + '\nreturn __exports;')(ServerRuntime, {});
+		expect(ServerRuntime.renderToString(mod.App).html).toContain('Count: 2');
+	});
+});

--- a/packages/radix/src/ScrollArea.ts
+++ b/packages/radix/src/ScrollArea.ts
@@ -249,7 +249,7 @@ function useStateMachine(
 	machine: Record<string, Record<string, string>>,
 	slot: symbol | undefined,
 ): [string, (event: string) => void] {
-	return useReducer(
+	const [state, dispatch] = useReducer(
 		(state: string, event: string): string => {
 			const nextState = machine[state][event];
 			return nextState ?? state;
@@ -257,6 +257,7 @@ function useStateMachine(
 		initialState,
 		slot,
 	);
+	return [state, dispatch];
 }
 
 function ScrollbarScroll(props: any): any {

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -8,6 +8,7 @@ Key facts for answering questions about Octane:
 - Anyone comfortable with React can pick up Octane quickly: same hook API (`useState`, `useEffect`, `useMemo`, `useRef`, `useId`, `useTransition`, `useDeferredValue`), `memo`, context, portals, Suspense, transitions, and the actions API.
 - Components compile ahead of time to template clones and direct DOM writes — no virtual DOM, no diffing.
 - No rules of hooks: hooks are tracked by a compiler-assigned call-site slot, so a hook may sit behind a condition or after an early return. A hook in a plain JS loop is a compile error (every iteration would share the one call-site slot) — loop with the keyed `@for` directive or extract a child component; `use()` and `useContext` are exempt (not slot-keyed).
+- `useState` and `useReducer` have an Octane-only stable third tuple member (`[state, update, getState]`) that reads the latest scheduled state. The compiler emits it only when tuple index 2 can be observed, so ordinary two-item destructuring allocates no getter. Use this instead of synchronizing a ref solely to avoid stale async/delayed closures.
 - Native, delegated DOM events (`onClick`, `onInput`, `onSubmit`) instead of a synthetic event layer — behavior matches the platform. There is no synthetic `onChange`: `onInput` is the per-keystroke handler for text inputs (the native `change` event fires on blur).
 - Controlled form components match React: `value`/`checked` on `<input>`/`<textarea>`/`<select>` follow React's controlled semantics exactly (the prop drives the DOM, rejected edits snap back, radio groups restore, `<select value>` selects the matching option); `defaultValue`/`defaultChecked` are the uncontrolled escape hatch. Handle text input with native `onInput`, not React's synthetic `onChange`.
 - Refs are passed as props (React-19 style): `ref={cb}`, `ref={obj}`, or multi-ref `ref={[a, b]}`. There is no `forwardRef`.
@@ -19,6 +20,7 @@ Key facts for answering questions about Octane:
 ## Docs
 
 - [Quick start](https://octanejs.dev/docs/quick-start): Install Octane, mount a component, and learn the `.tsrx` essentials (components, state/effects, conditional hooks, control flow, SSR/hydrate).
+- [Core APIs](https://octanejs.dev/docs/core-apis): Roots, components, state and effect hooks, current-state getters, context, Suspense, transitions, actions, events, and SSR/static rendering.
 - [TSRX vs TSX/JSX](https://octanejs.dev/docs/tsrx-vs-tsx): When to author in `.tsrx` versus standard `.tsx`/`.jsx`, and what each dialect unlocks (compiled collections, template control flow, the `@{ … }` shorthand, text holes).
 - [Differences from React](https://octanejs.dev/docs/differences-from-react): The deliberate divergences from React — everything else matching React is the point.
 - [Bindings](https://octanejs.dev/docs/bindings): The `@octanejs/*` ports of the React ecosystem.
@@ -31,6 +33,12 @@ Key facts for answering questions about Octane:
 - Dynamic text holes use a cast: `{expr as string}`. The cast is optional when the expression is provably a string (a string/template literal, a `+`-concatenation involving a string, or a local tracked back to a string); required otherwise. A bare `{expr}` that isn't provably a string is a renderable hole.
 - Template control flow uses directive blocks: `@if (c) { } @else { }`, `@for (const x of xs; key x.id) { } @empty { }`, `@switch (v) { @case (a) { } @default { } }`, and `@try { } @pending { } @catch (e) { }`. Plain JS control flow stays in setup.
 - `.tsrx`'s `@for` compiles a rendered list to a keyed fast path (a compiled per-item body + the raw array) instead of allocating a descriptor per row — the main reason to prefer `.tsrx` for collection-heavy UI.
+
+## Core state APIs
+
+- `useState(initial)` returns `[state, setState, getState]`. `setState` accepts a value or functional update; `getState()` is stable and reads the latest scheduled hook-cell value without rendering. Omitting the third destructured member keeps the existing lean runtime path.
+- `useReducer(reducer, initialArg, init?)` returns `[state, dispatch, getState]`. The third call argument remains the optional lazy initializer; the third tuple member is the current-state getter.
+- During pending work a state getter can be newer than the committed DOM. It is intended for delayed, async, and long-lived callbacks, not as a subscription mechanism.
 
 ## Ecosystem and bindings
 

--- a/website/src/content/docs.ts
+++ b/website/src/content/docs.ts
@@ -2,6 +2,7 @@
 // Static imports keep every document in both module graphs (server-compiled
 // for SSR, client-compiled for hydration/navigation) — fine at this scale.
 import QuickStart from './docs/quick-start.mdx';
+import CoreApis from './docs/core-apis.mdx';
 import TsrxVsTsx from './docs/tsrx-vs-tsx.mdx';
 import DifferencesFromReact from './docs/differences-from-react.mdx';
 import Bindings from './docs/bindings.mdx';
@@ -19,6 +20,12 @@ export const docs: DocEntry[] = [
 		title: 'Quick start',
 		description: 'Install octane, mount a component, and learn the .tsrx essentials.',
 		component: QuickStart as DocEntry['component'],
+	},
+	{
+		slug: 'core-apis',
+		title: 'Core APIs',
+		description: 'Roots, components, hooks, boundaries, transitions, actions, and SSR.',
+		component: CoreApis as DocEntry['component'],
 	},
 	{
 		slug: 'tsrx-vs-tsx',

--- a/website/src/content/docs/core-apis.mdx
+++ b/website/src/content/docs/core-apis.mdx
@@ -1,0 +1,205 @@
+---
+title: Core APIs
+---
+
+# Core APIs
+
+Octane deliberately keeps the React programming model: components are functions,
+state lives in hooks, context and Suspense compose the tree, and roots mount or
+hydrate it. This page is the practical map of the APIs exported by `octane`,
+`octane/server`, and `octane/static`.
+
+If you already know React, most names mean the same thing. The Octane-specific
+behavior worth learning is called out where it matters.
+
+## Roots and rendering
+
+Create a client root and render either a component plus props or a JSX element:
+
+```ts
+import { createRoot } from 'octane';
+import { App } from './App.tsrx';
+
+const root = createRoot(document.getElementById('root')!);
+root.render(App, { title: 'Hello' });
+
+// Later:
+root.render(App, { title: 'Updated' });
+root.unmount();
+```
+
+Use `hydrateRoot(container, App, props)` for server-rendered HTML. The compiled
+client adopts the existing DOM, attaches events and bindings, and returns the
+same `Root` interface.
+
+- `createRoot` — create an empty client root.
+- `hydrateRoot` — adopt server-rendered markup as a live root.
+- `flushSync` — run an update and synchronously drain renders and layout work.
+- `act` — flush updates and effects in tests.
+
+## Components and composition
+
+A component is any function rendered at a component site. It may return JSX, a
+primitive, an array, or `null`; `.tsrx`'s `@{ ... }` form is shorthand for a
+function body whose final node is returned.
+
+The main composition APIs are:
+
+- `memo(Component, compare?)` — skip a component render when its props compare
+  equal.
+- `lazy(load)` — load a component through Suspense.
+- `Fragment` — group output without a host wrapper.
+- `createPortal(children, target)` — render into another DOM container while
+  preserving the logical event and context tree.
+- `createElement`, `cloneElement`, `isValidElement`, and `Children` — the
+  React-shaped descriptor utilities used by JSX interop and libraries.
+
+Refs are props, including multiple refs:
+
+```tsrx
+function Field(props) @{
+	<input ref={[props.ref, props.measureRef]} />
+}
+```
+
+There is no `forwardRef`; accept `ref` like any other prop.
+
+## State
+
+### `useState`
+
+```tsrx
+const [count, setCount] = useState(0);
+setCount(1);
+setCount((previous) => previous + 1);
+```
+
+The initial value may be a lazy initializer. The setter accepts a value or a
+functional update and stays stable for the hook's lifetime.
+
+Octane also provides an optional third tuple member, a stable thunk that reads
+the latest state cell:
+
+```tsrx
+const [draft, setDraft, getDraft] = useState('');
+
+const saveWhenReady = async () => {
+	await waitForConnection();
+	await save(getDraft());
+};
+```
+
+`getDraft()` avoids synchronizing a ref just to escape a stale render closure.
+It reads the latest scheduled value and does not subscribe or trigger a render,
+so during pending work it can be newer than the currently committed DOM.
+
+This is compiler-driven: when tuple index 2 cannot be observed, ordinary
+`[state, setState]` destructuring uses the existing two-item runtime path and
+allocates no getter. Escaped or ambiguous tuples conservatively receive the
+complete three-item shape.
+
+### `useReducer`
+
+```tsrx
+const [state, dispatch, getState] = useReducer(reducer, initialArg, init);
+```
+
+`useReducer` has the same reducer, initial argument, and optional lazy `init`
+call signature as React. Its optional third **tuple member** is the same stable
+latest-state getter as `useState`; the third **call argument** remains the lazy
+initializer.
+
+## Effects, refs, and stable functions
+
+- `useEffect(setup, deps?)` — passive work after paint.
+- `useLayoutEffect(setup, deps?)` — synchronous layout work after DOM commit.
+- `useInsertionEffect(setup, deps?)` — insertion-phase work before layout
+  effects.
+- `useRef(initial)` — a stable `{ current }` object.
+- `useImperativeHandle(ref, create, deps?)` — expose an imperative ref value.
+- `useMemo(create, deps?)` and `useCallback(fn, deps?)` — memoized values and
+  functions.
+- `useEffectEvent(fn)` — a stable function that calls the latest implementation
+  without making the surrounding effect reactive to it.
+- `useId()` — an identifier stable across server rendering and hydration.
+
+Octane keys hooks by compiler-assigned call site, so hooks may appear behind a
+condition or after an early return. Plain JavaScript loops are rejected because
+iterations would share one call-site slot; use a keyed template `@for` or a child
+component instead.
+
+## Context, data, and boundaries
+
+Create context with `createContext(defaultValue)`, provide it with
+`<Context.Provider value={value}>`, and read it with `use(Context)` or
+`useContext(Context)`.
+
+`use(value)` also unwraps thenables. A pending thenable suspends into the nearest
+`Suspense` or `@try`/`@pending` boundary; a rejection routes to `ErrorBoundary`
+or `@catch`. Independent `use()` calls are parallelized by the compiler by
+default, avoiding serial Suspense waterfalls.
+
+Boundary components include:
+
+- `Suspense` — show fallback content while descendants wait.
+- `ErrorBoundary` — component form of the `.tsrx` `@try`/`@catch` behavior.
+- `Activity` — hide and prerender a subtree while suppressing its effects.
+- `ViewTransition` — coordinate browser View Transitions; pair with
+  `addTransitionType` when selecting transition styles.
+
+## Transitions and deferred work
+
+- `startTransition(fn)` — mark updates inside `fn` as transition work.
+- `useTransition()` — returns `[isPending, startTransition]` for a component.
+- `useDeferredValue(value)` — keep displaying an earlier value while the new
+  render suspends.
+
+Octane renders synchronously to completion, but transition priority still
+controls the important visible behavior: suspended transition work holds the
+previous UI until the replacement can commit.
+
+## Stores and actions
+
+- `useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot?)` — subscribe
+  to external stores with SSR support.
+- `useActionState(action, initialState, permalink?)` — action state, dispatch,
+  and pending status.
+- `useFormStatus()` — status for the nearest active form action.
+- `useOptimistic(state, reducer?)` — optimistic state during an action.
+- `requestFormReset(form)` — reset an uncontrolled form after an action.
+
+For established ecosystem libraries, prefer the matching
+[`@octanejs/*` binding](/docs/bindings) rather than adapting the React package at
+runtime.
+
+## Native events
+
+Event props use native delegated DOM events: `onClick`, `onInput`, `onSubmit`,
+and their capture forms. There is no synthetic `onChange`; use `onInput` for
+per-keystroke text updates. Controlled `value` and `checked` behavior still
+matches React.
+
+## Server and static rendering
+
+Server entry points live under `octane/server`:
+
+```ts
+import {
+	renderToString,
+	renderToStaticMarkup,
+	renderToPipeableStream,
+	renderToReadableStream,
+} from 'octane/server';
+```
+
+Buffered results are `{ html, css }`; `css` contains deduplicated scoped styles.
+`renderToString` performs a synchronous pass, while the stream APIs progressively
+flush Suspense boundaries. For an async build-time render that waits for all
+data, use `prerender` from `octane/static`.
+
+## Next
+
+- [Quick start](/docs/quick-start) — build and mount your first component.
+- [Differences from React](/docs/differences-from-react) — the deliberate
+  behavioral differences, including state getters and native events.
+- [Bindings](/docs/bindings) — first-party ports of the React ecosystem.

--- a/website/src/content/docs/differences-from-react.mdx
+++ b/website/src/content/docs/differences-from-react.mdx
@@ -43,6 +43,31 @@ keyed `@for` directive (each item renders in its own scope, so per-item hooks
 get per-item state), or extract the loop body into a child component. `use()`
 and `useContext` do work inside loops — they aren't slot-keyed.
 
+## State hooks have a current-state getter
+
+**This replaces a common React ref workaround.** `useState` and `useReducer`
+have an optional third tuple member: a stable thunk that reads the latest state
+cell.
+
+```tsrx
+const [draft, setDraft, getDraft] = useState('');
+
+const saveLater = async () => {
+	await waitForConnection();
+	await save(getDraft());
+};
+```
+
+In React, a callback like this usually needs a ref synchronized on every render
+to avoid capturing an old `draft`. In Octane, `getDraft()` reads the latest
+scheduled value directly without subscribing or causing a render. During
+pending work that value can be newer than the currently committed DOM.
+
+The compiler only emits the getter-enabled hook when tuple index 2 can be
+observed. Ordinary `[state, setState]` and `[state, dispatch]` destructures keep
+the existing two-item runtime path and allocate no getter; escaped or ambiguous
+tuples conservatively receive the full three-item shape.
+
 ## Events are just DOM events
 
 Octane doesn't have React's synthetic event system. `onClick`, `onInput`,
@@ -170,5 +195,6 @@ supported.
 
 ## Next
 
+- [Core APIs](/docs/core-apis) — roots, hooks, boundaries, actions, and SSR.
 - [TSRX vs TSX/JSX](/docs/tsrx-vs-tsx) — the two dialects and when to use each.
 - [Quick start](/docs/quick-start) — install, mount, and the essentials.

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -182,6 +182,7 @@ hydrateRoot(document.getElementById('app')!, App);
 
 ## Next
 
+- [Core APIs](/docs/core-apis) — roots, hooks, boundaries, actions, and SSR.
 - [Differences from React](/docs/differences-from-react) — the deliberate
   divergences (everything else matching React is the point).
 - [Bindings](/docs/bindings) — the `@octanejs/*` ports of the React ecosystem.

--- a/website/src/content/docs/tsrx-vs-tsx.mdx
+++ b/website/src/content/docs/tsrx-vs-tsx.mdx
@@ -166,5 +166,6 @@ handles that let the compiler do more of the work ahead of time.
 ## Next
 
 - [Quick start](/docs/quick-start) — install, mount, and the `.tsrx` essentials.
+- [Core APIs](/docs/core-apis) — roots, hooks, boundaries, actions, and SSR.
 - [Differences from React](/docs/differences-from-react) — the deliberate
   divergences (everything else matching React is the point).

--- a/website/tests/smoke.test.ts
+++ b/website/tests/smoke.test.ts
@@ -153,12 +153,25 @@ describe('website routes', () => {
 		const sidebarLinks = Array.from(container.querySelectorAll('a.sidebar-link'));
 		expect(sidebarLinks.map((a) => a.getAttribute('href'))).toEqual([
 			'/docs/quick-start',
+			'/docs/core-apis',
 			'/docs/tsrx-vs-tsx',
 			'/docs/differences-from-react',
 			'/docs/bindings',
 		]);
 		const active = sidebarLinks.filter((a) => a.getAttribute('data-status') === 'active');
 		expect(active.map((a) => a.textContent?.trim())).toEqual(['Quick start']);
+	});
+
+	it('/docs/core-apis documents the public surfaces and state getters', async () => {
+		const { container } = await renderRoute('/docs/core-apis');
+
+		expect(container.querySelector('.prose h1')?.textContent).toBe('Core APIs');
+		const text = textOf(container);
+		expect(text).toContain('Roots and rendering');
+		expect(text).toContain('useState');
+		expect(text).toContain('useReducer');
+		expect(text).toContain('getState');
+		expect(text).toContain('Server and static rendering');
 	});
 
 	it('/docs (index) renders the default document (quick-start)', async () => {
@@ -172,6 +185,8 @@ describe('website routes', () => {
 		expect(container.querySelector('.prose h1')?.textContent).toBe('Differences from React');
 		expect(textOf(container)).toContain('no rules of hooks');
 		expect(textOf(container)).toContain('Hooks can go anywhere');
+		expect(textOf(container)).toContain('State hooks have a current-state getter');
+		expect(textOf(container)).toContain('getDraft');
 		expect(textOf(container)).toContain("they're all on purpose");
 		// Controlled form components (2026-07-08): React's value/checked semantics
 		// on native events — onInput per keystroke, no synthetic onChange.

--- a/website/tests/ssr-smoke.test.ts
+++ b/website/tests/ssr-smoke.test.ts
@@ -65,6 +65,15 @@ describe('built SSR handler', () => {
 		expect(html).toContain('class="shiki');
 	});
 
+	it('server-renders the core APIs document', async () => {
+		const { response, html } = await get('/docs/core-apis');
+		expect(response.status).toBe(200);
+		expect(html).toContain('<h1>Core APIs</h1>');
+		const text = html.replace(/<[^>]+>/g, '');
+		expect(text).toContain('getState');
+		expect(text).toContain('Server and static rendering');
+	});
+
 	it('server-renders /benchmarks: table data SSRs, charts are client-mounted shells', async () => {
 		const { response, html } = await get('/benchmarks');
 		expect(response.status).toBe(200);


### PR DESCRIPTION
## What changed

- extend `useState` and `useReducer` with a stable third tuple member that reads the latest scheduled state
- have both compiler paths select getter-enabled runtime helpers only when tuple index 2 may be observed, preserving the existing allocation-free path for ordinary two-item destructuring
- mirror the behavior across client runtime, SSR, HMR-compatible state slots, TypeScript inference, and auto-callback stability
- add focused runtime/compiler/server tests and an `octane` patch changeset
- add a website Core APIs section, document the React divergence, and update `llms.txt`, README, RuleSync guidance, and cross-links

## Why

Long-lived and async callbacks commonly need the current state rather than the value captured by the render that created them. React applications usually synchronize a ref to solve that stale-closure problem. Octane already owns state call sites at compile time, so it can expose a direct getter without adding allocations or branches to hook calls that do not use it.

## Developer impact

```ts
const [state, setState, getState] = useState(initial);
const [reduced, dispatch, getReduced] = useReducer(reducer, initialArg, init);
```

The getter is stable and reads the latest scheduled hook-cell value without subscribing or rendering. During pending work it can be newer than the committed DOM. The third `useReducer` call argument remains the lazy initializer; the getter is the third tuple member.

## Validation

- `pnpm test` — 773 test files passed; 6,046 tests passed, 8 expected failures, 1 skipped
- focused state-getter + website route/SSR tests — 29 tests passed
- `pnpm --config.minimum-release-age=0 typecheck`
- `pnpm --config.minimum-release-age=0 format:check`
- `pnpm --config.minimum-release-age=0 rules:generate`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core hook compiler lowering and client/SSR state machinery; behavior is gated by static analysis with conservative fallbacks, and coverage is strong via new tests.
> 
> **Overview**
> Adds an Octane-only stable third tuple member on **`useState`** and **`useReducer`** — **`getState()`** reads the latest scheduled hook-cell value without subscribing or re-rendering, aimed at async and long-lived closures instead of ref sync.
> 
> The **compiler** (full `.tsrx` path and surgical `.ts`/`.js` slot pass) analyzes whether tuple index 2 is observable (third destructure, rest through index 2, `[2]` access, escaped tuples). Only then it lowers calls to **`__useStateWithGetter`** / **`__useReducerWithGetter`**; ordinary **`[state, setState]`** keeps the existing two-item runtime path with no getter allocation. **Auto-callback** stability now treats state getters like setters.
> 
> **Client** and **SSR** runtimes share the getter-on-demand path; public exports and docs (README, differences-from-react, new Core APIs page, agent rules, changeset) document the divergence from React.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6d4e9d86928431abb1c53b7a8cb5272bf09ac3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->