### PR TITLE
Simplify homepage feature cards

### DIFF
--- a/website/src/pages/Home.tsrx
+++ b/website/src/pages/Home.tsrx
@@ -10,7 +10,6 @@ import { HOME_SUMMARY } from '../content/benchmarks.ts';
 
 const FEATURES = [
 	{
-		eyebrow: 'Compiler-owned reactivity',
 		title: 'Hooks without the homework',
 		body: 'Write the closure and move on. Octane infers dependencies for effects, ' +
 			'memos, callbacks, and imperative handles; hook call sites stay safe behind ' +
@@ -18,14 +17,12 @@ const FEATURES = [
 			'signals to get, with the hooks model you already know.',
 	},
 	{
-		eyebrow: 'Async by construction',
 		title: 'Suspense without waterfalls',
 		body: 'Independent use() resources start together instead of serially ' +
 			'suspending through the tree. Descendant fetch plans warm early, and ' +
 			'streaming SSR flushes each ready boundary without waiting for the slowest one.',
 	},
 	{
-		eyebrow: 'Compiled rendering',
 		title: 'No virtual DOM. No diff tax.',
 		body: 'TSRX lowers templates to clones and direct DOM writes, while keyed @for ' +
 			'blocks compile to a dedicated minimal-move path. Standard .tsx works too, ' +
@@ -34,7 +31,6 @@ const FEATURES = [
 		linkLabel: 'tsrx.dev',
 	},
 	{
-		eyebrow: 'React knowledge, upgraded',
 		title: 'Change the import. Keep the model.',
 		body: 'Hooks, memo, context, portals, transitions, actions, controlled forms, ' +
 			'and Suspense behave the way you expect. Native events and refs-as-props ' +
@@ -83,9 +79,6 @@ export function Home() @{
 		<section class="features">
 			@for (const feature of FEATURES; key feature.title) {
 				<article class="card">
-					<p class="card-eyebrow">
-						{feature.eyebrow as string}
-					</p>
 					<h3 class="card-title">
 						{feature.title as string}
 					</h3>
@@ -299,30 +292,6 @@ export function Home() @{
 				border-radius: 1rem;
 				padding: 1.5rem;
 				overflow: hidden;
-				transition:
-					transform 0.18s ease,
-					border-color 0.18s ease,
-					box-shadow 0.18s ease;
-			}
-			.card::before {
-				content: '';
-				position: absolute;
-				inset: 0 0 auto;
-				height: 2px;
-				background: linear-gradient(90deg, #ff415a, #ff8a78 55%, transparent);
-			}
-			.card:hover {
-				transform: translateY(-3px);
-				border-color: rgba(255, 101, 122, 0.3);
-				box-shadow: 0 16px 30px rgba(0, 0, 0, 0.18);
-			}
-			.card-eyebrow {
-				margin: 0 0 0.85rem;
-				color: #ff657a;
-				font-size: 0.68rem;
-				font-weight: 800;
-				letter-spacing: 0.11em;
-				text-transform: uppercase;
 			}
 			.card-title {
 				margin: 0 0 0.75rem;

--- a/website/tests/smoke.test.ts
+++ b/website/tests/smoke.test.ts
@@ -66,6 +66,7 @@ describe('website routes', () => {
 		expect(container.querySelector('pre.shiki')).toBeTruthy();
 		const featureCards = container.querySelectorAll('.features article.card');
 		expect(featureCards).toHaveLength(4);
+		expect(container.querySelector('.card-eyebrow')).toBeNull();
 		expect(container.textContent).toContain('Hooks without the homework');
 		expect(findLink(container, '/docs/bindings')).toBeTruthy();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Marketing copy and CSS-only homepage changes with a matching smoke assertion; no runtime or API impact.
> 
> **Overview**
> Homepage feature cards are **simplified** by dropping the small uppercase **eyebrow** labels above each title and the extra visual chrome around the cards.
> 
> The `FEATURES` data no longer includes `eyebrow`, the template no longer renders `.card-eyebrow`, and scoped styles drop the top accent bar (`::before`), hover lift/shadow, and eyebrow typography. Titles, body copy, and optional links are unchanged. The home route smoke test now asserts **no** `.card-eyebrow` is present while still expecting four cards and the same headline copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cc3433e6deeb6b994cb8e206fd4a45437e57159. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->