### PR TITLE
fixes

### DIFF
--- a/website/src/pages/Home.tsrx
+++ b/website/src/pages/Home.tsrx
@@ -10,31 +10,35 @@ import { HOME_SUMMARY } from '../content/benchmarks.ts';
 
 const FEATURES = [
 	{
+		eyebrow: 'Compiler-owned reactivity',
 		title: 'Hooks without the homework',
-		body: 'Write the closure and move on. Octane infers dependencies for effects, ' +
-			'memos, callbacks, and imperative handles; hook call sites stay safe behind ' +
-			'conditions and early returns. The no-bookkeeping DX people reach for ' +
-			'signals to get, with the hooks model you already know.',
+		body: 'No dependency arrays and no rules of hooks. The compiler tracks what ' +
+			'your effects, memos and callbacks actually use, and hooks can sit behind ' +
+			'conditions or early returns. You keep the hooks you know — the ' +
+			'bookkeeping is gone.',
 	},
 	{
+		eyebrow: 'Async by default',
 		title: 'Suspense without waterfalls',
-		body: 'Independent use() resources start together instead of serially ' +
-			'suspending through the tree. Descendant fetch plans warm early, and ' +
-			'streaming SSR flushes each ready boundary without waiting for the slowest one.',
+		body: 'Independent use() calls start together instead of suspending one at a ' +
+			'time down the tree. Nested fetches warm up early, and streaming SSR sends ' +
+			'each boundary as soon as it’s ready — not when the slowest one is.',
 	},
 	{
-		title: 'No virtual DOM. No diff tax.',
-		body: 'TSRX lowers templates to clones and direct DOM writes, while keyed @for ' +
-			'blocks compile to a dedicated minimal-move path. Standard .tsx works too, ' +
-			'so optimization is a per-component choice rather than a rewrite.',
+		eyebrow: 'Compiled rendering',
+		title: 'No virtual DOM.',
+		body: 'Templates compile to cloned nodes and direct DOM writes, and keyed ' +
+			'@for lists move the fewest nodes possible. Plain .tsx still works, so you ' +
+			'can adopt .tsrx one component at a time.',
 		href: 'https://tsrx.dev',
 		linkLabel: 'tsrx.dev',
 	},
 	{
+		eyebrow: 'React knowledge, upgraded',
 		title: 'Change the import. Keep the model.',
-		body: 'Hooks, memo, context, portals, transitions, actions, controlled forms, ' +
-			'and Suspense behave the way you expect. Native events and refs-as-props ' +
-			'remove legacy layers, while 17 first-party bindings bring the ecosystem.',
+		body: 'Hooks, memo, context, portals, transitions, actions, controlled forms ' +
+			'and Suspense all behave the way you expect. Events are native, refs are ' +
+			'just props, and 17 first-party bindings cover the libraries you already use.',
 	},
 ];
 
@@ -42,7 +46,6 @@ export function Home() @{
 	<div class="home">
 		<section class="hero">
 			<div class="hero-copy">
-				<p class="hero-kicker">Compiler-first UI for TypeScript</p>
 				<h1 class="hero-title">
 					{'React’s programming model, '}
 					<span class="hero-accent">compiled</span>
@@ -79,6 +82,9 @@ export function Home() @{
 		<section class="features">
 			@for (const feature of FEATURES; key feature.title) {
 				<article class="card">
+					<p class="card-eyebrow">
+						{feature.eyebrow as string}
+					</p>
 					<h3 class="card-title">
 						{feature.title as string}
 					</h3>
@@ -123,17 +129,13 @@ export function Home() @{
 				<h2 id="bench-heading" class="bench-title">Measured, not vibes</h2>
 				<Link to="/benchmarks" class="bench-all">All suites →</Link>
 			</div>
-			<p class="bench-sub">
-				Cross-framework browser, SSR, async and shipped-bytes suites on one scale: each framework’s
-				cost relative to Octane (1×), lower is better.
-			</p>
 			<div class="bench-grid">
-				<BenchBars card={HOME_SUMMARY} width={1100} />
+				<BenchBars card={HOME_SUMMARY} showValues={true} width={1100} />
 			</div>
 			<p class="bench-note">
 				{'Ratios are geometric means over each suite’s per-operation checked-in benchmark scores ('}
 				<code>benchmarks/baselines/local</code>
-				{'), Octane .tsrx vs React 19.2, Preact 10, Solid 2.0 beta, Svelte 5, Ripple 0.3 and Vue Vapor 3.6 beta. Reproduce with '}
+				{'), Octane .tsrx vs React 19.2, Solid 2.0 beta, Ripple 0.3 and Vue Vapor 3.6 beta. Reproduce with '}
 				<code>pnpm bench:all -- --quick --ratios</code>
 				{', or see '}
 				<Link to="/benchmarks">absolute per-operation numbers for the charted suites</Link>
@@ -292,6 +294,30 @@ export function Home() @{
 				border-radius: 1rem;
 				padding: 1.5rem;
 				overflow: hidden;
+				transition:
+					transform 0.18s ease,
+					border-color 0.18s ease,
+					box-shadow 0.18s ease;
+			}
+			.card::before {
+				content: '';
+				position: absolute;
+				inset: 0 0 auto;
+				height: 2px;
+				background: linear-gradient(90deg, #ff415a, #ff8a78 55%, transparent);
+			}
+			.card:hover {
+				transform: translateY(-3px);
+				border-color: rgba(255, 101, 122, 0.3);
+				box-shadow: 0 16px 30px rgba(0, 0, 0, 0.18);
+			}
+			.card-eyebrow {
+				margin: 0 0 0.85rem;
+				color: #ff657a;
+				font-size: 0.68rem;
+				font-weight: 800;
+				letter-spacing: 0.11em;
+				text-transform: uppercase;
 			}
 			.card-title {
 				margin: 0 0 0.75rem;

--- a/website/tests/smoke.test.ts
+++ b/website/tests/smoke.test.ts
@@ -66,7 +66,7 @@ describe('website routes', () => {
 		expect(container.querySelector('pre.shiki')).toBeTruthy();
 		const featureCards = container.querySelectorAll('.features article.card');
 		expect(featureCards).toHaveLength(4);
-		expect(container.querySelector('.card-eyebrow')).toBeNull();
+		expect(container.querySelectorAll('.features .card-eyebrow')).toHaveLength(4);
 		expect(container.textContent).toContain('Hooks without the homework');
 		expect(findLink(container, '/docs/bindings')).toBeTruthy();
 

--- a/website/tests/ssr-hydration.e2e.test.ts
+++ b/website/tests/ssr-hydration.e2e.test.ts
@@ -39,8 +39,13 @@ const ROUTES = ['/', '/docs', '/benchmarks', '/playground', '/view-transitions']
 // `/` + `/benchmarks` re-based 2026-07-13 after every comparative chart gained
 // Preact/Svelte series and streaming-ssr joined the page (measured / 2,210 ·
 // /benchmarks 22,621). The ceilings retain roughly 15% headroom.
+//
+// `/` re-based again 2026-07-13 after the home summary chart turned on
+// showValues (a value label on every bar — ~7 series × 14 suites of small
+// recharts label trees; measured / 2,929): real content growth, not marker
+// minting.
 const COMMENT_CEILINGS: Record<string, number> = {
-	'/': 2550,
+	'/': 3380,
 	'/docs': 415,
 	'/benchmarks': 26100,
 	'/playground': 195,

--- a/website/tests/ssr-smoke.test.ts
+++ b/website/tests/ssr-smoke.test.ts
@@ -59,7 +59,9 @@ describe('built SSR handler', () => {
 		// and the template carries the built hydrate script.
 		expect(html).toContain('"entry":"/src/app/App.tsrx"');
 		expect(html).toContain('"preHydrate":"/src/app/router-client.ts"');
-		expect(html).toMatch(/<script type="module"[^>]*src="\/assets\/[^"]+\.js"/);
+		expect(html).toMatch(
+			/<script(?=[^>]*\bdata-octane-hydrate\b)(?=[^>]*\btype="module")(?=[^>]*\bsrc="\/assets\/[^"]+\.js")[^>]*>/,
+		);
 	});
 
 	it('server-renders an MDX doc through the bundle (Shiki output included)', async () => {

--- a/website/tests/ssr-smoke.test.ts
+++ b/website/tests/ssr-smoke.test.ts
@@ -59,9 +59,7 @@ describe('built SSR handler', () => {
 		// and the template carries the built hydrate script.
 		expect(html).toContain('"entry":"/src/app/App.tsrx"');
 		expect(html).toContain('"preHydrate":"/src/app/router-client.ts"');
-		expect(html).toMatch(
-			/<script(?=[^>]*\bdata-octane-hydrate\b)(?=[^>]*\btype="module")(?=[^>]*\bsrc="\/assets\/[^"]+\.js")[^>]*>/,
-		);
+		expect(html).toMatch(/<script type="module"[^>]*src="\/assets\/[^"]+\.js"/);
 	});
 
 	it('server-renders an MDX doc through the bundle (Shiki output included)', async () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Copy, styling, and test ceiling tweaks on the marketing homepage only; no runtime or auth changes.
> 
> **Overview**
> **Homepage marketing and layout refresh** on `Home.tsrx`: each feature card gets an uppercase **eyebrow** label and tighter body copy; the hero **kicker** line is removed; cards gain a top accent bar, hover lift, and eyebrow styling.
> 
> The **“Measured, not vibes”** section drops the explanatory subparagraph, turns on **`showValues`** on the home summary `BenchBars` chart (numeric labels on every bar), and narrows the benchmark footnote to React, Solid, Ripple, and Vue Vapor (Preact/Svelte no longer listed there).
> 
> Tests follow the UI: smoke expects four `.card-eyebrow` elements; SSR hydration raises the `/` **comment-node ceiling** (2550 → 3380) to account for the denser chart markup from value labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfc8880353ac1f37fc0cf25a69c0b3c4fcc41c09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->