### PR TITLE
Reduce DOM bookkeeping nodes in benchmark-heavy trees

### DIFF
--- a/.changeset/calm-ranges-rest.md
+++ b/.changeset/calm-ranges-rest.md
@@ -1,0 +1,7 @@
+---
+'octane': patch
+---
+
+Reduce client DOM bookkeeping for anchored lists, inactive conditionals,
+`@empty` bodies, and compiler-proven single-root component or conditional keyed
+items while preserving the existing SSR and hydration range protocol.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -124,6 +124,16 @@ after printing its normal tables:
   ssr-throughput is time-budgeted: its knob is a per-config seconds value and
   `--quick` passes the harness's own `--quick`.
 
+The DOM-heavy browser suites use `lib/dom-nodes.mjs` to publish a deterministic
+census alongside timings. `nodes_*`, `elements_*`, `text_*`, `comments_*`,
+`empty_text_*`, and `whitespace_text_*` are zero-variance operations suitable
+for ratio guards; detailed comment-payload and parent-element histograms live
+under `meta.dom`. Count the fixture root (`#main`, with `#app` fallback) unless
+the behavior intentionally escapes it: portal-swarm records both `#main` and
+the whole body so target-side portal ranges stay visible. Keep visible
+elements/text as independent guards—a lower total obtained by dropping
+user-visible content is a correctness failure, not an optimization.
+
 The runner keys everything (result files, baselines, ratio guards) by the
 **manifest suite name**, not the JSON's internal `suite` field — so the deopt
 variants (`dbmon-deopt`, `js-framework-deopt`), which reuse a base harness via a

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -191,5 +191,153 @@
     "reference": "ripple",
     "maxRatio": 1.5,
     "note": "update vs ripple: measured 1.09x on record 2026-07-09."
+  },
+  {
+    "suite": "js-framework",
+    "op": "nodes_1k",
+    "target": "octane-tsrx",
+    "reference": "react",
+    "maxRatio": 1.01,
+    "note": "Deterministic DOM census at 1k rows. Marker reuse leaves Octane at 10074 vs React 10072 nodes (2026-07-13); catches structural-node regressions without timing noise."
+  },
+  {
+    "suite": "js-framework",
+    "op": "elements_1k",
+    "target": "octane-tsrx",
+    "reference": "react",
+    "minRatio": 1.0,
+    "maxRatio": 1.0,
+    "note": "Semantic control for the node census: equivalent fixtures must render exactly the same 8051 elements."
+  },
+  {
+    "suite": "js-framework",
+    "op": "text_1k",
+    "target": "octane-tsrx",
+    "reference": "react",
+    "minRatio": 1.0,
+    "maxRatio": 1.0,
+    "note": "Semantic control for the node census: equivalent fixtures must render exactly the same 2021 text nodes."
+  },
+  {
+    "suite": "js-framework-deopt",
+    "op": "nodes_1k",
+    "target": "octane-tsrx-naive",
+    "reference": "octane-tsrx",
+    "minRatio": 1.0,
+    "maxRatio": 1.0,
+    "note": "A stamped sole-component row must share its host boundary: TSRX naive and tuned now both render 10074 nodes instead of the naive fixture carrying 2000 extra comments."
+  },
+  {
+    "suite": "js-framework-deopt",
+    "op": "nodes_1k",
+    "target": "octane-jsx-naive",
+    "reference": "octane-tsrx",
+    "minRatio": 1.0,
+    "maxRatio": 1.0,
+    "note": "Return-JSX single-root stamping plus keyed boundary sharing removes the JSX naive fixture's 4000 extra comments; its DOM shape must stay equal to tuned."
+  },
+  {
+    "suite": "todomvc",
+    "op": "nodes_100",
+    "target": "octane-tsrx",
+    "reference": "react",
+    "maxRatio": 1.2,
+    "note": "100-item TodoMVC DOM census: Octane 730 vs React 623 nodes after dormant-if/list-anchor elision (1.172x, 2026-07-13)."
+  },
+  {
+    "suite": "todomvc",
+    "op": "elements_100",
+    "target": "octane-tsrx",
+    "reference": "react",
+    "minRatio": 1.0,
+    "maxRatio": 1.0,
+    "note": "Semantic control: equivalent TodoMVC states render exactly 517 elements."
+  },
+  {
+    "suite": "todomvc",
+    "op": "text_100",
+    "target": "octane-tsrx",
+    "reference": "react",
+    "minRatio": 1.0,
+    "maxRatio": 1.0,
+    "note": "Semantic control: equivalent TodoMVC states render exactly 106 text nodes."
+  },
+  {
+    "suite": "chat-stream",
+    "op": "nodes_conv",
+    "target": "octane-tsrx",
+    "reference": "react",
+    "maxRatio": 1.32,
+    "note": "Mixed chat conversation census: Octane 104 vs React 80 nodes after host-vs-host keyed-item boundary sharing (1.30x, 2026-07-13)."
+  },
+  {
+    "suite": "chat-stream",
+    "op": "elements_conv",
+    "target": "octane-tsrx",
+    "reference": "react",
+    "minRatio": 1.0,
+    "maxRatio": 1.0,
+    "note": "Semantic control: equivalent chat states render exactly 55 elements."
+  },
+  {
+    "suite": "chat-stream",
+    "op": "text_conv",
+    "target": "octane-tsrx",
+    "reference": "react",
+    "minRatio": 1.0,
+    "maxRatio": 1.0,
+    "note": "Semantic control: equivalent chat states render exactly 25 text nodes."
+  },
+  {
+    "suite": "portal-swarm",
+    "op": "nodes_closed_main",
+    "target": "octane-tsrx",
+    "reference": "react",
+    "maxRatio": 1.33,
+    "note": "Closed portal swarm #main census: Octane 2622 vs React 2014 nodes after component-item and dormant-if elision (1.302x, 2026-07-13)."
+  },
+  {
+    "suite": "portal-swarm",
+    "op": "elements_closed_main",
+    "target": "octane-tsrx",
+    "reference": "react",
+    "minRatio": 1.0,
+    "maxRatio": 1.0,
+    "note": "Semantic control: closed portal fixtures render exactly 1411 elements under #main."
+  },
+  {
+    "suite": "portal-swarm",
+    "op": "text_closed_main",
+    "target": "octane-tsrx",
+    "reference": "react",
+    "minRatio": 1.0,
+    "maxRatio": 1.0,
+    "note": "Semantic control: closed portal fixtures render exactly 603 text nodes under #main."
+  },
+  {
+    "suite": "portal-swarm",
+    "op": "nodes_open_body",
+    "target": "octane-tsrx",
+    "reference": "react",
+    "maxRatio": 1.38,
+    "note": "Open portal swarm whole-body census retains load-bearing foreign target pairs: Octane 7025 vs React 5217 nodes (1.347x, 2026-07-13)."
+  },
+  {
+    "suite": "portal-swarm",
+    "op": "elements_open_body",
+    "target": "octane-tsrx",
+    "reference": "react",
+    "minRatio": 1.0,
+    "maxRatio": 1.0,
+    "note": "Semantic control: open portal fixtures render exactly 3412 elements across main and foreign targets."
+  },
+  {
+    "suite": "portal-swarm",
+    "op": "text_open_body",
+    "target": "octane-tsrx",
+    "reference": "react",
+    "minRatio": 1.0,
+    "maxRatio": 1.0,
+    "note": "Semantic control: open portal fixtures render exactly 1805 text nodes across main and foreign targets."
   }
 ]

--- a/benchmarks/chat-stream/run.mjs
+++ b/benchmarks/chat-stream/run.mjs
@@ -27,6 +27,7 @@
 
 import fs from 'node:fs';
 import { chromium } from 'playwright';
+import { censusDomNodes, deterministicCount } from '../lib/dom-nodes.mjs';
 import { summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
 
 const ITER = parseInt(process.argv[2] || '8', 10);
@@ -225,15 +226,16 @@ async function runTarget(t) {
 		results[op.name] = summarizeSamples(samples);
 	}
 
-	// DOM-weight tripwire at steady state (conv0's 10 mixed messages).
+	// Full steady-state DOM shape (conv0's 10 mixed messages).
 	await ensureState(page, 'reset');
-	const comments = await page.evaluate(() => {
-		const w = document.createTreeWalker(document.body, NodeFilter.SHOW_COMMENT);
-		let n = 0;
-		while (w.nextNode()) n++;
-		return n;
-	});
-	results.comments_conv = { median: comments, min: comments, samples: [comments] };
+	const dom = await page.evaluate(censusDomNodes, '#main');
+	results.nodes_conv = deterministicCount(dom.total);
+	results.elements_conv = deterministicCount(dom.elements);
+	results.text_conv = deterministicCount(dom.text);
+	results.comments_conv = deterministicCount(dom.comments);
+	results.empty_text_conv = deterministicCount(dom.emptyText);
+	results.whitespace_text_conv = deterministicCount(dom.whitespaceText);
+	results.__dom = dom;
 
 	await browser.close();
 	return results;
@@ -259,9 +261,16 @@ async function runTarget(t) {
 		}
 		console.log(row.join('| '));
 	}
-	{
-		const row = ['#cmnts'.padEnd(13)];
-		for (const c of cols) row.push(String(all[c].comments_conv.median).padEnd(W));
+	for (const [label, op] of [
+		['#nodes', 'nodes_conv'],
+		['#elems', 'elements_conv'],
+		['#text', 'text_conv'],
+		['#cmnts', 'comments_conv'],
+		['#empty', 'empty_text_conv'],
+		['#ws', 'whitespace_text_conv'],
+	]) {
+		const row = [label.padEnd(13)];
+		for (const c of cols) row.push(String(all[c][op].median).padEnd(W));
 		console.log(row.join('| '));
 	}
 
@@ -273,13 +282,16 @@ async function runTarget(t) {
 			targets: TARGETS.map((t) => ({
 				name: t.name,
 				ops: Object.fromEntries(
-					Object.entries(all[t.name]).map(([name, r]) => [
-						name,
-						r.score == null
-							? { median: r.median, min: r.min, samples: r.samples.length }
-							: timingStatForJson(r),
-					]),
+					Object.entries(all[t.name])
+						.filter(([name]) => name !== '__dom')
+						.map(([name, r]) => [
+							name,
+							r.score == null
+								? { median: r.median, min: r.min, samples: r.samples.length }
+								: timingStatForJson(r),
+						]),
 				),
+				meta: { dom: all[t.name].__dom },
 			})),
 		};
 		fs.writeFileSync(process.env.BENCH_JSON, JSON.stringify(payload, null, '\t') + '\n');

--- a/benchmarks/js-framework/run.mjs
+++ b/benchmarks/js-framework/run.mjs
@@ -28,6 +28,7 @@
 
 import fs from 'node:fs';
 import { chromium } from 'playwright';
+import { censusDomNodes, deterministicCount } from '../lib/dom-nodes.mjs';
 import { scoreOf, summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
 
 const ITER = parseInt(process.argv[2] || '8', 10);
@@ -156,18 +157,18 @@ async function runTarget(t) {
 		results[op.name] = summarizeSamples(samples);
 	}
 
-	// M0 of docs/comment-marker-elision-plan.md: comment-node DOM weight at
-	// steady state (1,000 rows mounted). Deterministic per framework build
-	// (median === min), and cross-framework comparable — solid/ripple anchor
-	// dynamic positions on comments too. Ratchets down as elision phases land.
+	// Full steady-state DOM shape. Tracking element/text counts beside comments
+	// prevents a bookkeeping optimization from gaming the metric by replacing a
+	// comment with an invisible text node or dropping user-visible output.
 	await ensureState(page, 'rows');
-	const comments = await page.evaluate(() => {
-		const w = document.createTreeWalker(document.body, NodeFilter.SHOW_COMMENT);
-		let n = 0;
-		while (w.nextNode()) n++;
-		return n;
-	});
-	results.comments_1k = { median: comments, min: comments, samples: [comments] };
+	const dom = await page.evaluate(censusDomNodes, '#main');
+	results.nodes_1k = deterministicCount(dom.total);
+	results.elements_1k = deterministicCount(dom.elements);
+	results.text_1k = deterministicCount(dom.text);
+	results.comments_1k = deterministicCount(dom.comments);
+	results.empty_text_1k = deterministicCount(dom.emptyText);
+	results.whitespace_text_1k = deterministicCount(dom.whitespaceText);
+	results.__dom = dom;
 
 	await browser.close();
 	return results;
@@ -193,9 +194,16 @@ async function runTarget(t) {
 		}
 		console.log(row.join('| '));
 	}
-	{
-		const row = ['#cmnts'.padEnd(8)];
-		for (const c of cols) row.push(String(all[c].comments_1k.median).padEnd(W));
+	for (const [label, op] of [
+		['#nodes', 'nodes_1k'],
+		['#elems', 'elements_1k'],
+		['#text', 'text_1k'],
+		['#cmnts', 'comments_1k'],
+		['#empty', 'empty_text_1k'],
+		['#ws', 'whitespace_text_1k'],
+	]) {
+		const row = [label.padEnd(8)];
+		for (const c of cols) row.push(String(all[c][op].median).padEnd(W));
 		console.log(row.join('| '));
 	}
 
@@ -227,13 +235,16 @@ async function runTarget(t) {
 			targets: TARGETS.map((t) => ({
 				name: t.name,
 				ops: Object.fromEntries(
-					Object.entries(all[t.name]).map(([name, r]) => [
-						name,
-						r.score == null
-							? { median: r.median, min: r.min, samples: r.samples.length }
-							: timingStatForJson(r),
-					]),
+					Object.entries(all[t.name])
+						.filter(([name]) => name !== '__dom')
+						.map(([name, r]) => [
+							name,
+							r.score == null
+								? { median: r.median, min: r.min, samples: r.samples.length }
+								: timingStatForJson(r),
+						]),
 				),
+				meta: { dom: all[t.name].__dom },
 			})),
 		};
 		fs.writeFileSync(process.env.BENCH_JSON, JSON.stringify(payload, null, '\t') + '\n');

--- a/benchmarks/lib/dom-nodes.mjs
+++ b/benchmarks/lib/dom-nodes.mjs
@@ -1,0 +1,65 @@
+// Deterministic DOM-shape instrumentation shared by the browser benchmarks.
+// Pass this function directly to Playwright's page.evaluate: it is deliberately
+// self-contained because the browser receives only the serialized function.
+export function censusDomNodes(rootSelector = '#main') {
+	const root =
+		rootSelector === 'body'
+			? document.body
+			: document.querySelector(rootSelector) ||
+				(rootSelector === '#main' ? document.querySelector('#app') : null);
+	if (root === null) throw new Error(`DOM census root not found: ${rootSelector}`);
+
+	let total = 0;
+	let elements = 0;
+	let text = 0;
+	let comments = 0;
+	let emptyText = 0;
+	let whitespaceText = 0;
+	const commentsByData = Object.create(null);
+	const commentParents = Object.create(null);
+	const walker = document.createTreeWalker(root, NodeFilter.SHOW_ALL);
+	while (walker.nextNode()) {
+		const node = walker.currentNode;
+		total++;
+		if (node.nodeType === Node.ELEMENT_NODE) {
+			elements++;
+		} else if (node.nodeType === Node.TEXT_NODE) {
+			text++;
+			const value = node.nodeValue || '';
+			if (value.length === 0) emptyText++;
+			else if (value.trim().length === 0) whitespaceText++;
+		} else if (node.nodeType === Node.COMMENT_NODE) {
+			comments++;
+			const data = node.nodeValue || '';
+			commentsByData[data] = (commentsByData[data] || 0) + 1;
+			const parent = node.parentElement;
+			const parentKey =
+				parent === null
+					? '(non-element)'
+					: parent.localName +
+						(parent.id ? '#' + parent.id : '') +
+						(parent.classList.length ? '.' + [...parent.classList].join('.') : '');
+			commentParents[parentKey] = (commentParents[parentKey] || 0) + 1;
+		}
+	}
+
+	const sortedEntries = (record) =>
+		Object.fromEntries(
+			Object.entries(record).sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])),
+		);
+	return {
+		root: root === document.body ? 'body' : root.id ? '#' + root.id : rootSelector,
+		total,
+		elements,
+		text,
+		comments,
+		emptyText,
+		whitespaceText,
+		commentsByData: sortedEntries(commentsByData),
+		commentParents: sortedEntries(commentParents),
+	};
+}
+
+export function deterministicCount(value) {
+	return { median: value, min: value, samples: [value] };
+}

--- a/benchmarks/portal-swarm/run.mjs
+++ b/benchmarks/portal-swarm/run.mjs
@@ -53,6 +53,7 @@
 
 import { chromium } from 'playwright';
 import fs from 'node:fs';
+import { censusDomNodes, deterministicCount } from '../lib/dom-nodes.mjs';
 import { scoreOf, summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
 
 const ITER = parseInt(process.argv[2] || '20', 10);
@@ -93,6 +94,20 @@ const OPS = [
 	'open_close_cycle',
 	'open_close_distinct',
 	'dispatch_through_portal',
+];
+const DOM_OPS = [
+	'nodes_closed_main',
+	'elements_closed_main',
+	'text_closed_main',
+	'comments_closed_main',
+	'nodes_open_main',
+	'comments_open_main',
+	'nodes_open_body',
+	'elements_open_body',
+	'text_open_body',
+	'comments_open_body',
+	'empty_text_open_body',
+	'whitespace_text_open_body',
 ];
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
@@ -387,6 +402,30 @@ async function measureDispatch(browser, url) {
 	return summarize(samples);
 }
 
+// Portals split their DOM between #main and foreign targets under body. Record
+// both scopes while closed and open so site placeholders and target-owned
+// ranges stay attributable.
+async function measureDomShape(browser, url) {
+	const { ctx, page } = await freshPage(browser, url);
+	await page.evaluate(async () => {
+		const r = window.__mount();
+		if (r && typeof r.then === 'function') await r;
+	});
+	const closedMain = await page.evaluate(censusDomNodes, '#main');
+	await page.evaluate(async () => {
+		const r = window.__openAll();
+		if (r && typeof r.then === 'function') await r;
+	});
+	const openMain = await page.evaluate(censusDomNodes, '#main');
+	const openBody = await page.evaluate(censusDomNodes, 'body');
+	await page.evaluate(async () => {
+		const r = window.__closeAll();
+		if (r && typeof r.then === 'function') await r;
+	});
+	await ctx.close();
+	return { closedMain, openMain, openBody };
+}
+
 async function runTarget(t) {
 	const browser = await chromium.launch({
 		headless: true,
@@ -420,6 +459,8 @@ async function runTarget(t) {
 	const open_close_distinct = await measureCycle(browser, t.url, true);
 	console.error(`  → dispatch_through_portal`);
 	const dispatch_through_portal = await measureDispatch(browser, t.url);
+	console.error(`  → DOM census (closed/open, main/body)`);
+	const dom = await measureDomShape(browser, t.url);
 	await browser.close();
 	return {
 		results: {
@@ -431,6 +472,18 @@ async function runTarget(t) {
 			open_close_cycle,
 			open_close_distinct,
 			dispatch_through_portal,
+			nodes_closed_main: deterministicCount(dom.closedMain.total),
+			elements_closed_main: deterministicCount(dom.closedMain.elements),
+			text_closed_main: deterministicCount(dom.closedMain.text),
+			comments_closed_main: deterministicCount(dom.closedMain.comments),
+			nodes_open_main: deterministicCount(dom.openMain.total),
+			comments_open_main: deterministicCount(dom.openMain.comments),
+			nodes_open_body: deterministicCount(dom.openBody.total),
+			elements_open_body: deterministicCount(dom.openBody.elements),
+			text_open_body: deterministicCount(dom.openBody.text),
+			comments_open_body: deterministicCount(dom.openBody.comments),
+			empty_text_open_body: deterministicCount(dom.openBody.emptyText),
+			whitespace_text_open_body: deterministicCount(dom.openBody.whitespaceText),
 		},
 		meta: {
 			gates: 'pass',
@@ -438,6 +491,7 @@ async function runTarget(t) {
 			sections: SECTIONS,
 			portalsAtOpenAll: SECTIONS * N,
 			hitsPerDispatchSample: N,
+			dom,
 		},
 	};
 }
@@ -450,10 +504,17 @@ function writeBenchJson(all, failed) {
 		targets: TARGETS.filter((t) => all[t.name]).map((t) => ({
 			name: t.name,
 			ops: Object.fromEntries(
-				OPS.filter((op) => all[t.name].results[op]).map((op) => {
-					const r = all[t.name].results[op];
-					return [op, timingStatForJson(r)];
-				}),
+				[...OPS, ...DOM_OPS]
+					.filter((op) => all[t.name].results[op])
+					.map((op) => {
+						const r = all[t.name].results[op];
+						return [
+							op,
+							r.score == null
+								? { median: r.median, min: r.min, samples: r.samples.length }
+								: timingStatForJson(r),
+						];
+					}),
 			),
 			meta: all[t.name].meta,
 		})),
@@ -487,6 +548,11 @@ for (const op of OPS) {
 		const r = all[c].results[op];
 		row.push(`${fmt(r.median)} (min ${fmt(r.min)}, sd ${fmt(r.stddev)})`.padEnd(W));
 	}
+	console.log(row.join('| '));
+}
+for (const op of DOM_OPS) {
+	const row = [op.padEnd(23)];
+	for (const c of cols) row.push(String(all[c].results[op].median).padEnd(W));
 	console.log(row.join('| '));
 }
 

--- a/benchmarks/todomvc/run.mjs
+++ b/benchmarks/todomvc/run.mjs
@@ -27,6 +27,7 @@
 
 import fs from 'node:fs';
 import { chromium } from 'playwright';
+import { censusDomNodes, deterministicCount } from '../lib/dom-nodes.mjs';
 import { summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
 
 const ITER = parseInt(process.argv[2] || '8', 10);
@@ -280,16 +281,17 @@ async function runTarget(t) {
 		results[op.name] = summarizeSamples(samples);
 	}
 
-	// DOM-weight tripwire at steady state (100 todos mounted) — comparable
-	// across frameworks, deterministic per build (median === min).
+	// Full steady-state DOM shape (100 todos mounted). Element/text counts are
+	// semantic controls beside the bookkeeping-node total.
 	await ensureState(page, 'items');
-	const comments = await page.evaluate(() => {
-		const w = document.createTreeWalker(document.body, NodeFilter.SHOW_COMMENT);
-		let n = 0;
-		while (w.nextNode()) n++;
-		return n;
-	});
-	results.comments_100 = { median: comments, min: comments, samples: [comments] };
+	const dom = await page.evaluate(censusDomNodes, '#main');
+	results.nodes_100 = deterministicCount(dom.total);
+	results.elements_100 = deterministicCount(dom.elements);
+	results.text_100 = deterministicCount(dom.text);
+	results.comments_100 = deterministicCount(dom.comments);
+	results.empty_text_100 = deterministicCount(dom.emptyText);
+	results.whitespace_text_100 = deterministicCount(dom.whitespaceText);
+	results.__dom = dom;
 
 	await browser.close();
 	return results;
@@ -315,9 +317,16 @@ async function runTarget(t) {
 		}
 		console.log(row.join('| '));
 	}
-	{
-		const row = ['#cmnts'.padEnd(13)];
-		for (const c of cols) row.push(String(all[c].comments_100.median).padEnd(W));
+	for (const [label, op] of [
+		['#nodes', 'nodes_100'],
+		['#elems', 'elements_100'],
+		['#text', 'text_100'],
+		['#cmnts', 'comments_100'],
+		['#empty', 'empty_text_100'],
+		['#ws', 'whitespace_text_100'],
+	]) {
+		const row = [label.padEnd(13)];
+		for (const c of cols) row.push(String(all[c][op].median).padEnd(W));
 		console.log(row.join('| '));
 	}
 
@@ -330,13 +339,16 @@ async function runTarget(t) {
 			targets: TARGETS.map((t) => ({
 				name: t.name,
 				ops: Object.fromEntries(
-					Object.entries(all[t.name]).map(([name, r]) => [
-						name,
-						r.score == null
-							? { median: r.median, min: r.min, samples: r.samples.length }
-							: timingStatForJson(r),
-					]),
+					Object.entries(all[t.name])
+						.filter(([name]) => name !== '__dom')
+						.map(([name, r]) => [
+							name,
+							r.score == null
+								? { median: r.median, min: r.min, samples: r.samples.length }
+								: timingStatForJson(r),
+						]),
 				),
+				meta: { dom: all[t.name].__dom },
 			})),
 		};
 		fs.writeFileSync(process.env.BENCH_JSON, JSON.stringify(payload, null, '\t') + '\n');

--- a/docs/comment-marker-elision-plan.md
+++ b/docs/comment-marker-elision-plan.md
@@ -1,6 +1,6 @@
 # Comment-Marker Elision Plan — fewer `<!--[-->`s when they carry no information
 
-Status: M0-M4 LANDED (2026-07-09; see each phase's note). Follow-up to the
+Status: M0-M5 LANDED (2026-07-13; see each phase's note). Follow-up to the
 website Elements-panel report
 (a 40-deep run of `<!--[-->` before `.shell`, ~2,100 comment nodes on the home
 page). Companion to docs/compiled-output-optimization-plan.md — this is the
@@ -317,20 +317,102 @@ M2; SSR emission and hydration adoption untouched):**
   **12,061**. Cumulative from the 2,122 / 17,381 start: **−31%** on both.
   Ceilings ratcheted to 1,680 / 415 / 13,800 / 195.
 
+### M5 — Benchmark-fixture client ranges and a general DOM census
+
+**M5 LANDED 2026-07-13.** This phase started from production builds of the
+representative benchmark fixtures and counted every descendant of the fixture
+root by `nodeType`. That separates user-visible elements/text from Octane's
+comment bookkeeping and avoids treating another framework's whitespace text as
+equivalent to a range marker.
+
+| Fixture state | Octane before | Octane after | React / Preact | Visible elements/text |
+| --- | ---: | ---: | ---: | --- |
+| js-framework, 1,000 rows | 10,075 (3 comments) | **10,074 (2)** | 10,072 (0) | 8,051 / 2,021, exact |
+| TodoMVC, 100 todos | 933 (310 comments) | **730 (107)** | 623 (0) | 517 / 106, exact |
+| chat-stream, 10 messages / 21 segments | 158 (78 comments) | **104 (24)** | 80 (0) | 55 / 25, exact |
+| portal-swarm, 600 closed cards | 3,826 (1,812 comments) | **2,622 (608)** | 2,014 (0) | 1,411 / 603, exact |
+| portal-swarm, all portals open (whole body) | 8,229 (3,012 comments) | **7,025 (1,808)** | 5,217 (0) | 3,412 / 1,805, exact |
+
+The same js-framework fixture authored through the generic return-JSX paths
+lost its cliff: the naive TSRX variant went from 2,003 comments to **2**, and
+the naive JSX variant from 4,003 to **2**, matching the tuned fixture's DOM
+shape. Solid and Svelte are still reported separately by the harness because
+their compiled output deliberately uses extra text/comment nodes in several
+fixtures; element and meaningful-text equality is the semantic comparison.
+
+The attribution and changes are deliberately narrow:
+
+- `compile.js` (`makeForCall` + `planJsx`) now proves sole keyed-item roots for
+  direct hosts, a component definition with exactly one unconditional host
+  return, and an `@if/@else` whose every reachable arm is exactly one host.
+  Imported components use the existing immutable `$$singleRoot` definition
+  stamp. A missing branch, fragment, spread, children override, key, early
+  return, or unknown/dynamic callee declines the optimization.
+- `runtime.ts` (`forBlock`) reuses a compiler-owned trailing `<!>` as the
+  list's closing marker, and an active `@empty` body borrows the list's outer
+  range rather than nesting another pair. Hydration adopts the established
+  server range unchanged.
+- `runtime.ts` (`renderBranchSlot`) leaves an inactive client-only branch on
+  its existing insertion anchor and re-enters the self-marked one-host regime
+  when it becomes active. When a sole-root branch is also a keyed-item
+  boundary, replacements update every exact borrower; an empty result or a
+  transition commit promotes that shared boundary to one durable pair.
+- `runtime.server.ts` / the compiler's SSR emitters were intentionally not
+  changed. Hydratable HTML keeps the current balanced range protocol, and the
+  client continues to adopt legacy/current server output. Eliminating server
+  item ranges needs a versioned, symmetric SSR + hydration change and is not
+  bundled into this low-risk client optimization.
+- Portals keep their target-side pair (1,200 comments for 600 open portals),
+  which is used for target ownership, event propagation, update insertion, and
+  teardown. Suspense/`@try` streaming boundaries, transition WIP pairs,
+  `<Activity>` ranges, multi-root keyed items, order-bearing value-hole
+  anchors, and adjacent-text SSR separators also remain load-bearing.
+
+`benchmarks/lib/dom-nodes.mjs` is the regression surface: js-framework,
+TodoMVC, chat-stream, and portal-swarm now emit deterministic `nodes_*`,
+`elements_*`, `text_*`, `comments_*`, `empty_text_*`, and
+`whitespace_text_*` operations plus comment-payload/parent histograms in
+`meta.dom`. Ratio guards cap total nodes while requiring Octane's visible
+element/text counts to equal React's. Portal-swarm records both the fixture
+root and whole-body census so target-side portal ranges cannot disappear from
+the accounting.
+
+The implementation plan was ordered by invariant risk: instrument first;
+reuse already-owned anchors/ranges; extend the existing single-root proof;
+then test keyed identity, state/effects/events/refs through the full suite,
+branch replacement, transitions, SSR adoption, and mismatch recovery. The
+SSR/hydration wire format and foreign-target/streaming boundaries stay a
+separate follow-up. Normal production comparisons kept the affected work
+competitive: js-framework `run` 1.8 ms vs React 6.5 / Solid 1.7; TodoMVC
+`add100` 2.7 ms vs React 13.8 / Solid 2.1; chat `streamFine` 1.4 ms vs React
+7.2 / Solid 3.2; portal mount/open 2.4/1.3 ms vs React 3.8/1.5. Fewer nodes
+also shorten range walks and reduce DOM memory.
+
+The exact size cost, measured against an isolated current-main worktree with
+the same toolchain, is small but non-zero. The fixed codegen corpus grows
+121,122 → 121,280 raw bytes, 63,229 → 63,337 minified, and 23,205 → 23,247
+gzip (**+42 B / +0.18% gzip**). The js-framework production bundle grows
+28,884 → 28,889 B gzip (+5 B); control-flow-heavy TodoMVC grows 28,972 →
+29,115 (+143 B / +0.49%), and chat-stream 29,223 → 29,358 (+135 B / +0.46%).
+That is the boundary-propagation/runtime proof cost paid by apps that use the
+optimized paths; the matching js-framework, TodoMVC, and chat states lose 1,
+203, and 54 live nodes respectively, while closed portal-swarm loses 1,204.
+
 **Still open (small or order-constrained — diminishing returns):**
 
 1. Multi-hole hosts: the remaining ~684 empty anchors on `/` are
    order-bearing (`<g>{a}{b}</g>` — siblings need stable positions); eliding
    them needs per-hole neighbor bookkeeping. Biggest remaining bucket.
 2. Component-bearing `it` pairs (145 on `/`) — required borrow ranges today.
-3. Sole-root @if/@switch construct inherit + children-render-fn /
-   value-position sole roots (M3 leftovers; 4 `if` pairs on home).
-4. SSR-side symmetry for the M2/M4 owns-parent regimes (hydrated pages keep
-   server pairs the client mount wouldn't mint).
+3. Sole-root `@switch` construct inherit + children-render-fn /
+   value-position sole roots (M3 leftovers).
+4. SSR-side symmetry for the M2/M4/M5 client regimes (hydrated pages keep
+   server item/component pairs the client mount would not mint). This must be
+   designed as one SSR-emission + hydration-adoption protocol change.
 
 ### Ordering & expected effect
 
-M0 → M1 → M2 → M3. Home-page projection: M2 removes ~1,600 (chart + rows),
+M0 → M1 → M2 → M3 → M4 → M5. Home-page projection: M2 removes ~1,600 (chart + rows),
 M3 removes ~39 of the 40-deep prefix and every wrapper pair page-wide
 (≈300 of the 392 SSR-pair comments), M1 covers client-rendered leaves.
 Target: **2,122 → under ~400**, root prefix 40 → ≤ 3.
@@ -350,14 +432,14 @@ Target: **2,122 → under ~400**, root prefix 40 → ≤ 3.
 
 ## 6. Open questions
 
-1. M3 for `@if` branch pairs too (slot pair inherits, branch pair remains as
-   the swap range) — or both when the branch is also sole-child? Proposal:
-   slot pair only in v1; branch pairs carry swap semantics.
+1. M5 now elides client-only inactive `@if` pairs and lets a guaranteed
+   host-vs-host branch share a keyed-item boundary. General sole-root
+   `@if`/`@switch` inheritance still needs a symmetric SSR/hydration design.
 2. Should `mountItem` under hydration ALSO skip adopting per-item pairs when
    the server (post-M3 compiler) stopped emitting them for singleRoot @for
    bodies? Natural extension of M3's flag to `ssrEmitFor` — folds the last
    big pair population on SSR'd list pages. Proposal: yes, same mechanism,
    after M3 core proves out.
-3. Empty-pair elision (6 on the home page) — an empty block still needs an
-   insertion anchor unless its position is recoverable from siblings; not
-   worth special-casing in v1.
+3. Empty branches still need one insertion anchor unless their position is
+   recoverable from siblings. M5 removes the redundant pair but deliberately
+   retains that single anchor.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -1224,6 +1224,78 @@ function isReturnJsxFunction(node) {
 	);
 }
 
+/** True when `node` is one plain lowercase host element (never a component/fragment). */
+function isPlainHostRoot(node) {
+	return (
+		node != null &&
+		(node.type === 'JSXElement' || node.type === 'Element') &&
+		!isComponentTag(node) &&
+		typeof (node.id?.name ?? node.openingElement?.name?.name) === 'string'
+	);
+}
+
+function statementsOf(node) {
+	if (node == null) return [];
+	return node.type === 'BlockStatement' ? node.body || [] : [node];
+}
+
+function isIfDirective(node) {
+	return node?.type === 'IfStatement' || node?.type === 'JSXIfExpression';
+}
+
+/**
+ * A directive @if/@else whose every reachable arm emits exactly one plain
+ * host. The chosen tag may change, but the item always owns one element; the
+ * runtime propagates a branch replacement to enclosing shared boundaries.
+ */
+function isSingleHostIfRoot(node) {
+	if (!isIfDirective(node) || node.alternate == null) return false;
+	const armIsSingleHost = (arm) => {
+		if (isIfDirective(arm)) return isSingleHostIfRoot(arm);
+		const render = statementsOf(arm).filter((s) => isJsxNode(s) || isIfDirective(s));
+		return render.length === 1 && isPlainHostRoot(render[0]);
+	};
+	return armIsSingleHost(node.consequent) && armIsSingleHost(node.alternate);
+}
+
+/**
+ * Prove that a component always returns one host element.
+ *
+ * TSRX's `@{}` form carries that output as `body.render`. Ordinary TSX keeps a
+ * real `return`; accept only a final host-element return and reject any other
+ * component-level return (including one nested in control flow). Nested
+ * callbacks are separate functions and do not affect the component's shape.
+ */
+function singleHostComponentRoot(node) {
+	if (node?.body?.type === 'JSXCodeBlock') return isPlainHostRoot(node.body.render);
+	if (node?.body?.type !== 'BlockStatement') return false;
+	const stmts = node.body.body || [];
+	const final = stmts[stmts.length - 1];
+	if (!final || final.type !== 'ReturnStatement' || !isPlainHostRoot(final.argument)) return false;
+
+	let returns = 0;
+	const seen = new WeakSet();
+	const walk = (n) => {
+		if (!n || typeof n !== 'object') return;
+		if (seen.has(n)) return;
+		seen.add(n);
+		if (
+			n !== node &&
+			(n.type === 'FunctionDeclaration' ||
+				n.type === 'FunctionExpression' ||
+				n.type === 'ArrowFunctionExpression')
+		)
+			return;
+		if (n.type === 'ReturnStatement') returns++;
+		for (const key in n) {
+			if (AST_WALK_SKIP_KEYS.has(key)) continue;
+			walk(n[key]);
+		}
+	};
+	walk(node.body);
+	return returns === 1;
+}
+
 // Arrow-function component shape: `const X = (props) => @{…}` (and the `export`
 // variant). @tsrx/core parses the `@{…}` arrow body as a JSXCodeBlock, but the
 // rest of the compiler keys on FunctionDeclaration. Convert a single-declarator
@@ -1533,13 +1605,23 @@ export function compile(source, filename, options) {
 	//   unknown-call walker doesn't flag it.
 	for (const node of ast.body) {
 		let compNode = null;
-		if (isComponentFunction(node)) compNode = node;
-		else if (node.type === 'ExportDefaultDeclaration' && isComponentFunction(node.declaration))
+		if (isComponentFunction(node) || isReturnJsxFunction(node)) compNode = node;
+		else if (
+			node.type === 'ExportDefaultDeclaration' &&
+			(isComponentFunction(node.declaration) || isReturnJsxFunction(node.declaration))
+		)
 			compNode = node.declaration;
-		else if (node.type === 'ExportNamedDeclaration' && isComponentFunction(node.declaration))
+		else if (
+			node.type === 'ExportNamedDeclaration' &&
+			(isComponentFunction(node.declaration) || isReturnJsxFunction(node.declaration))
+		)
 			compNode = node.declaration;
 		if (compNode && compNode.id) {
-			ctx.componentInfo.set(compNode.id.name, { eligible: false, node: compNode });
+			ctx.componentInfo.set(compNode.id.name, {
+				eligible: false,
+				node: compNode,
+				returnJsx: isReturnJsxFunction(compNode),
+			});
 		}
 	}
 	for (const [, info] of ctx.componentInfo) {
@@ -1552,7 +1634,10 @@ export function compile(source, filename, options) {
 		const root = { type: 'BlockStatement', body: stmts };
 		const free = collectFreeIdentifiers(root, locals);
 		// Hookless check.
-		let eligible = true;
+		// Return-JSX functions reconcile their returned descriptor through
+		// renderBlock. componentSlotLite intentionally ignores return values, so
+		// these functions may participate in output-shape proofs but never lite.
+		let eligible = !info.returnJsx;
 		for (const n of free) {
 			if (
 				HOOK_NAMES.has(n) ||
@@ -1634,12 +1719,7 @@ export function compile(source, filename, options) {
 		// `componentSlot` needs no `comp`/`/comp` markers (singleRoot path), exactly
 		// like a single-root `@for` item. (Output-shape based — independent of which
 		// hooks it calls.)
-		const render = compNode.body.render;
-		info.singleRoot =
-			render != null &&
-			(render.type === 'JSXElement' || render.type === 'Element') &&
-			!isComponentTag(render) &&
-			typeof (render.id?.name ?? render.openingElement?.name?.name) === 'string';
+		info.singleRoot = singleHostComponentRoot(compNode);
 	}
 
 	let body = '';
@@ -6352,7 +6432,8 @@ function planJsx(jsxNodesRaw, ctx, componentName, inlinedSubs, parentNs = 'html'
 			(fc.singleRoot ? 2 : 0) |
 			(fc.depEligible ? 4 : 0) |
 			(fc.indexIndependent ? 8 : 0);
-		// Arg layout: forBlock(__s, slot, host, items, keyFn, body, flags?, deps?, emptyBody?, anchor?).
+		// Arg layout: forBlock(__s, slot, host, items, keyFn, body, flags?, deps?,
+		// emptyBody?, anchor?, ownEnd?).
 		// Optional args backfill positionally: `flags`/`deps` placeholders
 		// (`0`/`undefined`) when only `emptyHelper` ('null' literal when no
 		// `@empty` branch) or the anchor is present, and a `null` empty-body
@@ -6365,7 +6446,11 @@ function planJsx(jsxNodesRaw, ctx, componentName, inlinedSubs, parentNs = 'html'
 		// helpers captured anything, not only for the dep-pure promotion. A deps
 		// arg forces the flags placeholder too (positional alignment).
 		const hasDeps = fc.depNames.length > 0;
-		const flagsPart = flags || hasDeps || hasEmpty || hasAnchor ? ', ' + (flags || 0) : '';
+		const flagsExpr = fc.singleRootExpr
+			? `(${flags} | (${fc.singleRootExpr}.$$singleRoot === true ? 2 : 0))`
+			: String(flags || 0);
+		const flagsPart =
+			flags || fc.singleRootExpr || hasDeps || hasEmpty || hasAnchor ? ', ' + flagsExpr : '';
 		const depsPart = hasDeps
 			? `, [${fc.depNames.join(', ')}]`
 			: hasEmpty || hasAnchor
@@ -6373,9 +6458,13 @@ function planJsx(jsxNodesRaw, ctx, componentName, inlinedSubs, parentNs = 'html'
 				: '';
 		const emptyPart = hasEmpty ? `, ${fc.emptyHelper}` : hasAnchor ? ', null' : '';
 		const anchorPart = hasAnchor ? `, ${anchorExpr}` : '';
+		// A dedicated template `<!>` is already a durable comment at exactly the
+		// list's trailing boundary. Let forBlock reuse it as its end marker instead
+		// of retaining it beside a newly-created `/for` comment.
+		const ownEndPart = fc.anchorVar ? ', true' : '';
 		pushAfter(
 			fc.id,
-			`  _$forBlock(__s, ${slotIndex}, ${hostExpr}, ${fc.itemsExpr}, ${fc.keyHelper}, ${fc.bodyHelper}${flagsPart}${depsPart}${emptyPart}${anchorPart});`,
+			`  _$forBlock(__s, ${slotIndex}, ${hostExpr}, ${fc.itemsExpr}, ${fc.keyHelper}, ${fc.bodyHelper}${flagsPart}${depsPart}${emptyPart}${anchorPart}${ownEndPart});`,
 		);
 	}
 	for (const ic of ifCalls) {
@@ -8711,7 +8800,11 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 	// itself as the block boundary. For a 1000-row keyed list this removes 2000
 	// Comment nodes from the parent — meaningful paint-time savings when the
 	// parent is laid out per child (e.g. <tbody> in js-framework-benchmark).
+	// In addition to a direct host root, accept only narrowly-proven sole
+	// component and host-vs-host conditional roots; all other shapes keep item
+	// ranges.
 	let singleRoot = false;
+	let singleRootExpr = null;
 	{
 		const jsxChildren = subStmts.filter((s) => isJsxNode(s));
 		if (jsxChildren.length === 1) {
@@ -8719,8 +8812,40 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 			// Old IR uses `Element`; new TSRX AST uses `JSXElement`. Both qualify
 			// for the singleRoot fast path so long as the tag is lowercase (so the
 			// row itself is the block-boundary host, no Comment markers needed).
-			if ((c.type === 'Element' || c.type === 'JSXElement') && !isComponentTag(c))
+			if (isSingleHostIfRoot(c)) {
 				singleRoot = true;
+			} else if (isPlainHostRoot(c)) {
+				singleRoot = true;
+			} else if ((c.type === 'Element' || c.type === 'JSXElement') && isComponentTag(c)) {
+				// A sole component item can share the component's proven host root as
+				// its keyed boundary. Keep the same conservative call-site exclusions
+				// as componentSlot's singleRoot path. Imported bindings are immutable,
+				// so resolve their definition-site stamp once per parent render.
+				const tagName = c.openingElement?.name || c.id || c.name;
+				const bare =
+					tagName &&
+					(tagName.type === 'Identifier' || tagName.type === 'JSXIdentifier') &&
+					typeof tagName.name === 'string';
+				const attrs = c.attributes || c.openingElement?.attributes || [];
+				const hasSpread = attrs.some(
+					(a) => a.type === 'SpreadAttribute' || a.type === 'JSXSpreadAttribute',
+				);
+				const hasKeyOrChildren = attrs.some((a) => {
+					const n = a.name?.name || a.name;
+					return n === 'key' || n === 'children';
+				});
+				const hasChildren = (c.children || []).length > 0;
+				if (bare && !hasSpread && !hasKeyOrChildren && !hasChildren) {
+					const compName = tagName.name;
+					const local = ctx.componentInfo?.get(compName);
+					if (local?.singleRoot === true) singleRoot = true;
+					else if (ctx.importedNames?.has(compName)) singleRootExpr = compName;
+				}
+			}
+		}
+		if (jsxChildren.length === 0) {
+			const controls = subStmts.filter((s) => isIfDirective(s));
+			if (controls.length === 1 && isSingleHostIfRoot(controls[0])) singleRoot = true;
 		}
 	}
 
@@ -8732,6 +8857,7 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 		bodyHelper: itemHelperName,
 		pure,
 		singleRoot,
+		singleRootExpr,
 		// The env union doubles as the deps array: emitted whenever the helpers
 		// capture anything (Phase 2 — the runtime stamps it as block.extra), and
 		// ALSO compared for the dep-pure survivor short-circuit when depEligible.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -12051,6 +12051,39 @@ interface BranchSlot {
 }
 
 /**
+ * A sole-root control-flow block may share its element boundary with one or
+ * more enclosing sole-root blocks (for example a branch directly inside a
+ * keyed item). When the inner branch replaces that element, keep every exact
+ * borrower pointed at the new element/range so keyed moves and later teardown
+ * never retain a detached boundary.
+ */
+function replaceSharedBlockBoundary(
+	parent: Block | null,
+	oldStart: Node | null,
+	oldEnd: Node | null,
+	newStart: Node | null,
+	newEnd: Node | null,
+): void {
+	if (oldStart === null || oldEnd === null) return;
+	let block = parent;
+	while (block !== null && block.startMarker === oldStart && block.endMarker === oldEnd) {
+		block.startMarker = newStart;
+		block.endMarker = newEnd;
+		block = block.parentBlock;
+	}
+}
+
+function sharesBlockBoundary(parent: Block | null, start: Node | null, end: Node | null): boolean {
+	return (
+		parent !== null &&
+		start !== null &&
+		end !== null &&
+		parent.startMarker === start &&
+		parent.endMarker === end
+	);
+}
+
+/**
  * The shared branch-swap core. When `next` differs from the mounted branch:
  * under a transition, render `body` off-screen and COMMIT it in place (adopting
  * the WIP markers — see below); otherwise tear the old branch down and mount
@@ -12078,6 +12111,15 @@ function renderBranchSlot(
 ): void {
 	const parentBlock = parentScope.block;
 	if (next !== state.branch) {
+		// A markerless branch may share its host boundary with a nested sole-root
+		// branch. The nested branch updates Block markers when it replaces that
+		// host, but this slot's cached `end` is intentionally not part of the Block
+		// chain. Follow the live block boundary for positioning/probing so an outer
+		// swap never inserts relative to a detached former root.
+		const liveEnd =
+			state.start === null && state.block !== null && state.block.endMarker !== null
+				? state.block.endMarker
+				: state.end;
 		// Off-screen swap (React WIP model): on a TRANSITION swap to a new branch that may
 		// suspend, render it off-screen FIRST without tearing down the old branch. If it
 		// suspends, dispose + route to the enclosing tryBlock so its transition hold keeps
@@ -12094,17 +12136,20 @@ function renderBranchSlot(
 			!hydrating &&
 			parentBlock.currentRenderMode === 'transition'
 		) {
-			// Commit path requires the marker regime (state.end !== null): renderOffscreen
+			// Commit path requires a live branch boundary: renderOffscreen
 			// inserts the wip pair AFTER its reference node, which matches "right after the
 			// old end marker" — but in the anchor regime the legacy path mounts BEFORE the
 			// anchor, so committing there would land the branch on the wrong side of the
 			// anchor's trailing static siblings. Anchor-regime swaps keep the legacy
 			// in-place path below.
-			if (state.end !== null) {
+			if (liveEnd !== null) {
+				const oldBlock = state.block;
+				const oldBlockStart = oldBlock.startMarker;
+				const oldBlockEnd = oldBlock.endMarker;
 				const r = renderOffscreen(
 					parentBlock,
 					domParent,
-					state.end,
+					liveEnd,
 					body,
 					undefined,
 					'control-flow',
@@ -12133,6 +12178,7 @@ function renderBranchSlot(
 				state.end = r.wip.end;
 				state.block = r.wip.block;
 				state.branch = next;
+				replaceSharedBlockBoundary(parentBlock, oldBlockStart, oldBlockEnd, r.wip.start, r.wip.end);
 				// Adopted pair is now the slot's durable boundary (see NEXT-swap note above).
 				r.wip.block.exclusiveMarkers = true;
 				spliceWipCapture(r.wip);
@@ -12142,8 +12188,11 @@ function renderBranchSlot(
 		// Position for the new branch: just after the current branch's trailing node,
 		// or the slot anchor on first mount. Captured BEFORE teardown (a self-marked
 		// branch's trailing node is removed by it).
-		const after: Node | null = state.end !== null ? state.end.nextSibling : state.anchor;
-		const firstMount = state.branch === -1;
+		const after: Node | null = liveEnd !== null ? liveEnd.nextSibling : state.anchor;
+		const oldBlock = state.block;
+		const oldBlockStart = oldBlock?.startMarker ?? null;
+		const oldBlockEnd = oldBlock?.endMarker ?? null;
+		const oldBoundaryShared = sharesBlockBoundary(parentBlock, oldBlockStart, oldBlockEnd);
 		if (state.block) {
 			unmountBlock(state.block);
 			state.block = null;
@@ -12199,8 +12248,10 @@ function renderBranchSlot(
 					);
 				removeRange(state.start.nextSibling, state.end);
 			}
-		} else if (firstMount && body) {
-			// First client mount — pick the boundary by what the branch renders.
+		} else if (body) {
+			// Markerless client mount — pick the boundary by what the branch renders.
+			// This applies both on first mount and after an anchor-only empty arm:
+			// a single host can self-mark without first manufacturing a pair.
 			const before = after ? after.previousSibling : domParent.lastChild;
 			const b = createBlock(
 				'control-flow',
@@ -12223,6 +12274,7 @@ function renderBranchSlot(
 				b.startMarker = first;
 				b.endMarker = first;
 				state.end = first;
+				replaceSharedBlockBoundary(parentBlock, oldBlockStart, oldBlockEnd, first, first);
 			} else {
 				// Multi-node (or rendered nothing) — mint markers around the content.
 				const s = document.createComment(marker);
@@ -12234,22 +12286,26 @@ function renderBranchSlot(
 				b.exclusiveMarkers = true;
 				state.start = s;
 				state.end = e;
+				replaceSharedBlockBoundary(parentBlock, oldBlockStart, oldBlockEnd, s, e);
 			}
+		} else if (!oldBoundaryShared) {
+			// A truly empty client arm needs only its existing insertion anchor.
+			// Keep the markerless regime so a later empty → single-host transition
+			// can self-mark directly. Hydration never enters here: it adopted the
+			// server's outer slot pair above.
+			state.anchor = after;
+			state.end = null;
 		} else {
-			// Swap away from a self-marked branch, or an empty branch: mint stable
-			// markers at the position so the slot has a boundary from here on.
+			// An enclosing sole-root block borrowed the old element. Empty output
+			// cannot self-delimit, so promote both the slot and every exact borrower
+			// to one shared pair rather than leaving an ancestor on a detached node.
 			const s = document.createComment(marker);
 			const e = document.createComment('/' + marker);
 			domParent.insertBefore(s, after);
 			domParent.insertBefore(e, after);
 			state.start = s;
 			state.end = e;
-			if (body) {
-				const b = createBlock('control-flow', parentBlock, domParent, s, e, body, undefined, env);
-				b.exclusiveMarkers = true;
-				state.block = b;
-				renderBlock(b);
-			}
+			replaceSharedBlockBoundary(parentBlock, oldBlockStart, oldBlockEnd, s, e);
 		}
 	} else if (state.block) {
 		// Same branch — re-render in place with this render's env snapshot.
@@ -12760,6 +12816,10 @@ export function forBlock<T>(
 	deps?: any[],
 	emptyBody?: ComponentBody | null,
 	anchor?: Node | null,
+	// The compiler created `anchor` as this call site's dedicated `<!>`
+	// placeholder. Reuse it as the durable closing boundary instead of keeping
+	// both that placeholder and a newly-created `/for` comment.
+	ownEnd?: boolean,
 ): void {
 	// flags bitfield: bit 0 = pure (auto-memo), bit 1 = singleRoot (skip per-item
 	// Comment markers), bit 2 = depEligible (compare `deps` to cachedDeps and
@@ -12790,13 +12850,19 @@ export function forBlock<T>(
 			hydrateNode = start.nextSibling;
 		} else {
 			start = document.createComment('for');
-			end = document.createComment('/for');
 			// insertBefore(_, null) === appendChild — covers both end-of-parent and
 			// mid-range insertion (when a static sibling follows this @for in mixed
 			// children, the compiler emits a `<!>` anchor at the @for's source-order
 			// index and threads it here so the markers land BEFORE the sibling).
-			domParent.insertBefore(start, anchor ?? null);
-			domParent.insertBefore(end, anchor ?? null);
+			if (ownEnd === true && anchor?.nodeType === 8) {
+				end = anchor as Comment;
+				end.data = '/for';
+				domParent.insertBefore(start, end);
+			} else {
+				end = document.createComment('/for');
+				domParent.insertBefore(start, anchor ?? null);
+				domParent.insertBefore(end, anchor ?? null);
+			}
 		}
 		state = {
 			__kind: 'forBlockSlot',
@@ -12835,8 +12901,6 @@ export function forBlock<T>(
 			state.emptyBlock.extra = state.env;
 			renderBlock(state.emptyBlock);
 		} else {
-			const bStart = document.createComment('empty');
-			const bEnd = document.createComment('/empty');
 			// When the SERVER rendered a populated list but the client is empty now, the
 			// content inside the @for range is item blocks (`<!--[-->`), not the @empty body
 			// — a STRUCTURAL mismatch. Discard the server items and build @empty fresh with
@@ -12850,31 +12914,27 @@ export function forBlock<T>(
 				if (mmLoc)
 					warnHydrationStructuralMismatch(mmLoc, 'an empty list (@empty)', 'a populated list');
 				removeRange(state.start.nextSibling, state.end);
-				domParent.insertBefore(bStart, state.end);
-				domParent.insertBefore(bEnd, state.end);
 				suspendForEmpty = true;
 			} else if (hydrating) {
-				// The server rendered the @empty content directly inside the adopted
-				// `<!--[-->…<!--]-->` range — bracket it (don't insert at the end +
-				// re-mount, which would move the adopted content) and point the cursor
-				// at it so the empty body's clone() adopts the server DOM.
-				domParent.insertBefore(bStart, state.start.nextSibling);
-				domParent.insertBefore(bEnd, state.end);
-				hydrateNode = bStart.nextSibling;
-			} else {
-				domParent.insertBefore(bStart, state.end);
-				domParent.insertBefore(bEnd, state.end);
+				// The server already rendered the @empty content directly inside the
+				// adopted outer range. The empty body borrows that range and adopts from
+				// its first child; no redundant inner pair is necessary.
+				hydrateNode = state.start.nextSibling;
 			}
 			const b = createBlock(
 				'control-flow',
 				parentBlock,
 				domParent,
-				bStart,
-				bEnd,
+				state.start,
+				state.end,
 				emptyBody,
 				undefined,
 				state.env,
 			);
+			// The outer ForSlot owns these comments. Empty-body teardown clears only
+			// their contents so the slot remains a stable insertion boundary for the
+			// next empty → items transition.
+			b.exclusiveMarkers = true;
 			state.emptyBlock = b;
 			const savedHydrating = hydrating;
 			if (suspendForEmpty) hydrating = false;

--- a/packages/octane/tests/_fixtures/marker-shape.tsrx
+++ b/packages/octane/tests/_fixtures/marker-shape.tsrx
@@ -1,4 +1,12 @@
-import { useState, createElement, createContext, useContext, Suspense } from 'octane';
+import {
+	useState,
+	useEffect,
+	createElement,
+	createContext,
+	useContext,
+	Suspense,
+	startTransition,
+} from 'octane';
 import { ExtLeaf } from './marker-shape-ext.tsrx';
 
 // Marker-shape corpus (M0 of docs/comment-marker-elision-plan.md): one
@@ -135,6 +143,102 @@ export function ListMulti(props: { items: string[] }) @{
 	</ul>
 }
 
+// (c2) A keyed list whose item body is a sole component call. SingleItem's
+// definition proves one host root, so the item block and component slot share
+// that <li> boundary. MultiItem is the conservative negative control.
+function SingleItem(props: {
+	value: string;
+	onEffect?: (entry: string) => void;
+	onRef?: (value: string, node: HTMLLIElement | null) => void;
+}) @{
+	const [n, setN] = useState(0);
+	useEffect(() => {
+		props.onEffect?.('mount:' + props.value);
+		return () => props.onEffect?.('cleanup:' + props.value);
+	}, []);
+	<li
+		class="component-item"
+		data-value={props.value}
+		ref={(node) => props.onRef?.(props.value, node)}
+	>
+		<button class="increment" onClick={() => setN(n + 1)}>
+			{props.value + ':' + n}
+		</button>
+	</li>
+}
+function MultiItem(props: { value: string }) @{
+	<>
+		<li class="component-a">{props.value}</li>
+		<li class="component-b">
+			{props.value + '!'}
+		</li>
+	</>
+}
+export function ListComponent(props: {
+	items: string[];
+	onEffect?: (entry: string) => void;
+	onRef?: (value: string, node: HTMLLIElement | null) => void;
+}) @{
+	<ul class="lc">
+		@for (const it of props.items; key it) {
+			<SingleItem value={it} onEffect={props.onEffect} onRef={props.onRef} />
+		}
+	</ul>
+}
+export function ListComponentMulti(props: { items: string[] }) @{
+	<ul class="lcm">
+		@for (const it of props.items; key it) {
+			<MultiItem value={it} />
+		}
+	</ul>
+}
+
+export function ListConditional(props: { items: Array<{ id: string; code: boolean }> }) @{
+	<div class="conditional-list">
+		@for (const it of props.items; key it.id) {
+			@if (it.code) {
+				<pre class="conditional-item" data-id={it.id}>
+					{'code:' + it.id}
+				</pre>
+			} @else {
+				<p class="conditional-item" data-id={it.id}>
+					{'text:' + it.id}
+				</p>
+			}
+		}
+	</div>
+}
+
+// Missing @else means the item can be empty, so it cannot use an element as a
+// permanent keyed boundary.
+export function ListConditionalEmpty(props: { items: Array<{ id: string; show: boolean }> }) @{
+	<div class="conditional-empty-list">
+		@for (const it of props.items; key it.id) {
+			@if (it.show) {
+				<span class="maybe-item" data-id={it.id}>{it.id}</span>
+			}
+		}
+	</div>
+}
+
+export function TransitionConditionalList() @{
+	const [code, setCode] = useState(false);
+	<div class="transition-conditional">
+		<button class="transition-flip" onClick={() => startTransition(() => setCode(!code))}>
+			flip
+		</button>
+		<div class="transition-items">
+			@for (const id of ['x']; key id) {
+				@if (code) {
+					<pre class="transition-item">code</pre>
+				} @else {
+					<p class="transition-item">text</p>
+				}
+			}
+		</div>
+	</div>
+}
+
 // (d) @if/@else with a single-element branch (self-marks on the client).
 export function Branch(props: { on: boolean }) @{
 	<div class="br">
@@ -144,6 +248,34 @@ export function Branch(props: { on: boolean }) @{
 			<p class="no">no</p>
 		}
 	</div>
+}
+
+// (d2) No @else: an inactive client branch keeps only the compiler's existing
+// insertion anchor, then self-marks its host while active and returns to that
+// one-anchor representation when inactive again.
+export function BranchEmpty(props: { on: boolean; hit?: () => void }) @{
+	<div class="be">
+		<i class="before">before</i>
+		@if (props.on) {
+			<button class="active" onClick={props.hit}>active</button>
+		}
+		<i class="after">after</i>
+	</div>
+}
+
+// Nested sole-root branches share the same element boundary. Replacing the
+// inner arm must update the outer block's borrowed boundary too.
+export function NestedBranch(props: { outer: boolean; inner: boolean }) @{
+	<section class="nb">
+		@if (props.outer) {
+			@if (props.inner) {
+				<strong class="inner-a">A</strong>
+			} @else {
+				<em class="inner-b">B</em>
+			}
+		}
+		<span class="tail">tail</span>
+	</section>
 }
 
 // (e) De-opt descriptor tree — a value-position createElement host whose

--- a/packages/octane/tests/hydration/mismatch-value.test.ts
+++ b/packages/octane/tests/hydration/mismatch-value.test.ts
@@ -26,7 +26,10 @@ function serverModule(fixture: string, file: string): Record<string, any> {
 		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
-	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');
+	// Preserve the module-local binding as well as exposing it. Compiled modules
+	// may attach definition metadata (for example `$$singleRoot`) after an
+	// exported function declaration, exactly as native ESM permits.
+	code = code.replace(/export function (\w+)/g, 'const $1 = __exports.$1 = function $1');
 	return new Function('__rt', '__exports', code + '\nreturn __exports;')(ServerRT, {});
 }
 
@@ -39,7 +42,7 @@ function devClientModule(fixture: string, file: string): Record<string, any> {
 		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
-	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');
+	code = code.replace(/export function (\w+)/g, 'const $1 = __exports.$1 = function $1');
 	return new Function('__rt', '__exports', code + '\nreturn __exports;')(ClientRT, {});
 }
 

--- a/packages/octane/tests/marker-shape.test.ts
+++ b/packages/octane/tests/marker-shape.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { compile } from 'octane/compiler';
-import { createRoot, hydrateRoot, flushSync } from '../src/index.js';
+import { createRoot, hydrateRoot, flushSync, act } from '../src/index.js';
 import * as ServerRT from 'octane/server';
 import {
 	Chain,
@@ -14,7 +14,14 @@ import {
 	AliasSusp,
 	ListSingle,
 	ListMulti,
+	ListComponent,
+	ListComponentMulti,
+	ListConditional,
+	ListConditionalEmpty,
+	TransitionConditionalList,
 	Branch,
+	BranchEmpty,
+	NestedBranch,
 	Deopt,
 } from './_fixtures/marker-shape.tsrx';
 
@@ -233,33 +240,233 @@ describe('marker-shape pins (M0) — exact comment counts per minting regime', (
 
 	it('(b) keyed @for, single-root items: client elides item pairs, SSR keeps them', () => {
 		const props = { items: ['a', 'b', 'c'] };
-		// Client: the template's <!> position anchor (1) + the <!--for--> slot
-		// pair (2) = 3; items self-mark (forBlock singleRoot) = 0. SSR: outer
+		// Client: the template's <!> position anchor is reused as the for slot's
+		// end, so the outer range costs 2; items self-mark = 0. SSR: outer
 		// for-slot pair (2) + one pair PER ITEM (3×2=6) = 8 — the server always
 		// pairs items (open question 2 of the plan). Hydration adopts all
 		// server pairs (no template anchor — the server emits none) = 8.
-		expect(counts('ListSingle', ListSingle, props)).toEqual({ client: 3, ssr: 8, hydrate: 8 });
+		expect(counts('ListSingle', ListSingle, props)).toEqual({ client: 2, ssr: 8, hydrate: 8 });
 	});
 
 	it('(b2) keyed @for, @empty branch active', () => {
-		// Client: template anchor (1) + for-slot pair (2) + <!--empty--> branch
-		// pair (2) = 5. SSR emits ONLY the outer for-slot pair with the @empty
-		// content inline = 2. Hydration adopts the outer pair and mints the
-		// client's empty-branch pair around the adopted content = 4 — a known
-		// client/server asymmetry (the branch pair is client bookkeeping).
+		// The client reuses its template anchor as the outer range end and the
+		// @empty block borrows that range. SSR already emits the empty content
+		// directly inside the same outer pair; hydration now adopts it unchanged.
 		expect(counts('ListSingle', ListSingle, { items: [] })).toEqual({
-			client: 5,
+			client: 2,
 			ssr: 2,
-			hydrate: 4,
+			hydrate: 2,
 		});
 	});
 
 	it('(c) keyed @for, multi-root items: item pairs on BOTH sides', () => {
 		const props = { items: ['a', 'b'] };
-		// Client: template anchor (1) + for-slot pair (2) + per-item <!--it-->
-		// pairs (2×2=4) = 7 (multi-root items can't self-mark). SSR: for-slot
+		// Client: reused-anchor for-slot pair (2) + per-item <!--it-->
+		// pairs (2×2=4) = 6 (multi-root items can't self-mark). SSR: for-slot
 		// pair (2) + per-item pairs (4) = 6 (no template anchor). Hydrate: 6.
-		expect(counts('ListMulti', ListMulti, props)).toEqual({ client: 7, ssr: 6, hydrate: 6 });
+		expect(counts('ListMulti', ListMulti, props)).toEqual({ client: 6, ssr: 6, hydrate: 6 });
+	});
+
+	it('(c2) keyed sole-component items share only proven single-host roots', () => {
+		const props = { items: ['a', 'b', 'c'] };
+		// SingleItem: client outer pair only. The server protocol remains
+		// conservative and keeps both an item pair and component frame per row;
+		// hydration adopts those established ranges.
+		expect(counts('ListComponent', ListComponent, props)).toEqual({
+			client: 2,
+			ssr: 14,
+			hydrate: 14,
+		});
+		// MultiItem is not stamped singleRoot, so every client item retains its
+		// pair; the sole nested component borrows it. SSR keeps both established
+		// ranges and hydration adopts them.
+		expect(counts('ListComponentMulti', ListComponentMulti, props)).toEqual({
+			client: 8,
+			ssr: 14,
+			hydrate: 14,
+		});
+	});
+
+	it('(c2b) markerless component items preserve identity, state, effects, refs, and events', async () => {
+		const effects: string[] = [];
+		const refs: string[] = [];
+		const onEffect = (entry: string) => effects.push(entry);
+		const onRef = (value: string, node: HTMLLIElement | null) =>
+			refs.push(`${node === null ? 'detach' : 'attach'}:${value}`);
+		const root = createRoot(container);
+		root.render(ListComponent, { items: ['a', 'b', 'c'], onEffect, onRef });
+		await act(() => {});
+		const rows = new Map(
+			[...container.querySelectorAll<HTMLElement>('.component-item')].map((row) => [
+				row.dataset.value,
+				row,
+			]),
+		);
+		expect(domComments(container)).toBe(2);
+		expect(effects).toEqual(['mount:a', 'mount:b', 'mount:c']);
+		expect(refs).toEqual(['attach:a', 'attach:b', 'attach:c']);
+		(rows.get('b')!.querySelector('.increment') as HTMLButtonElement).click();
+		expect(rows.get('b')!.textContent).toBe('b:1');
+
+		flushSync(() => root.render(ListComponent, { items: ['c', 'b', 'a'], onEffect, onRef }));
+		const reordered = [...container.querySelectorAll<HTMLElement>('.component-item')];
+		expect(reordered).toEqual([rows.get('c'), rows.get('b'), rows.get('a')]);
+		expect(rows.get('b')!.textContent).toBe('b:1');
+		expect(domComments(container)).toBe(2);
+
+		flushSync(() => root.render(ListComponent, { items: ['c', 'a'], onEffect, onRef }));
+		await act(() => {});
+		expect(container.querySelector('[data-value="b"]')).toBeNull();
+		expect([...container.querySelectorAll('.component-item')]).toEqual([
+			rows.get('c'),
+			rows.get('a'),
+		]);
+		expect(effects).toContain('cleanup:b');
+		expect(refs).toContain('detach:b');
+		root.unmount();
+		await act(() => {});
+		expect(effects).toEqual(expect.arrayContaining(['cleanup:a', 'cleanup:b', 'cleanup:c']));
+		expect(refs).toEqual(expect.arrayContaining(['detach:a', 'detach:b', 'detach:c']));
+	});
+
+	it('(c2c) component-item server ranges still hydrate and reorder in place', () => {
+		const props = { items: ['a', 'b', 'c'] };
+		const { html } = ServerRT.renderToString(server.ListComponent, props);
+		container.innerHTML = html;
+		const rows = new Map(
+			[...container.querySelectorAll<HTMLElement>('.component-item')].map((row) => [
+				row.dataset.value,
+				row,
+			]),
+		);
+		const root = hydrateRoot(container, ListComponent, props);
+		expect(container.querySelector('[data-value="a"]')).toBe(rows.get('a'));
+		expect(domComments(container)).toBe(14);
+		flushSync(() => root.render(ListComponent, { items: ['c', 'a', 'b'] }));
+		expect([...container.querySelectorAll<HTMLElement>('.component-item')]).toEqual([
+			rows.get('c'),
+			rows.get('a'),
+			rows.get('b'),
+		]);
+		root.unmount();
+	});
+
+	it('(c4) keyed host-vs-host @if items share the active element boundary', () => {
+		const items = [
+			{ id: 'a', code: false },
+			{ id: 'b', code: true },
+			{ id: 'c', code: false },
+		];
+		expect(counts('ListConditional', ListConditional, { items })).toEqual({
+			client: 2,
+			ssr: 20,
+			hydrate: 20,
+		});
+		expect(
+			counts('ListConditionalEmpty', ListConditionalEmpty, {
+				items: items.map((item) => ({ id: item.id, show: false })),
+			}),
+		).toEqual({ client: 8, ssr: 14, hydrate: 14 });
+	});
+
+	it('(c4b) conditional item boundaries follow branch swaps and keyed moves', () => {
+		const root = createRoot(container);
+		root.render(ListConditional, {
+			items: [
+				{ id: 'a', code: false },
+				{ id: 'b', code: true },
+			],
+		});
+		const oldA = container.querySelector('[data-id="a"]');
+		const oldB = container.querySelector('[data-id="b"]');
+		expect(oldA?.localName).toBe('p');
+		expect(oldB?.localName).toBe('pre');
+		expect(domComments(container)).toBe(2);
+
+		flushSync(() =>
+			root.render(ListConditional, {
+				items: [
+					{ id: 'a', code: true },
+					{ id: 'b', code: false },
+				],
+			}),
+		);
+		const newA = container.querySelector('[data-id="a"]');
+		const newB = container.querySelector('[data-id="b"]');
+		expect(newA?.localName).toBe('pre');
+		expect(newB?.localName).toBe('p');
+		expect(newA).not.toBe(oldA);
+		expect(newB).not.toBe(oldB);
+		expect(domComments(container)).toBe(2);
+
+		flushSync(() =>
+			root.render(ListConditional, {
+				items: [
+					{ id: 'b', code: false },
+					{ id: 'a', code: true },
+				],
+			}),
+		);
+		expect([...container.querySelectorAll('.conditional-item')]).toEqual([newB, newA]);
+		expect(domComments(container)).toBe(2);
+		root.unmount();
+	});
+
+	it('(c4c) transition branch commits promote the shared item to one durable pair', async () => {
+		const root = createRoot(container);
+		root.render(TransitionConditionalList, {});
+		expect(container.querySelector('.transition-item')?.localName).toBe('p');
+		expect(domComments(container)).toBe(2);
+
+		await act(() => (container.querySelector('.transition-flip') as HTMLButtonElement).click());
+		expect(container.querySelector('.transition-item')?.localName).toBe('pre');
+		// Off-screen transition commits intentionally retain their WIP pair. The
+		// item and branch share it, so this is one pair rather than nested pairs.
+		expect(domComments(container)).toBe(4);
+		root.unmount();
+		expect(container.innerHTML).toBe('');
+	});
+
+	it('(c4d) hydrated conditional items retain server ranges across swaps', () => {
+		const initial = {
+			items: [
+				{ id: 'a', code: false },
+				{ id: 'b', code: true },
+			],
+		};
+		const { html } = ServerRT.renderToString(server.ListConditional, initial);
+		container.innerHTML = html;
+		const serverA = container.querySelector('[data-id="a"]');
+		const root = hydrateRoot(container, ListConditional, initial);
+		expect(container.querySelector('[data-id="a"]')).toBe(serverA);
+
+		flushSync(() =>
+			root.render(ListConditional, {
+				items: [
+					{ id: 'a', code: true },
+					{ id: 'b', code: false },
+				],
+			}),
+		);
+		const newA = container.querySelector('[data-id="a"]');
+		const newB = container.querySelector('[data-id="b"]');
+		expect(newA?.localName).toBe('pre');
+		expect(newB?.localName).toBe('p');
+		expect(newA).not.toBe(serverA);
+		// The first post-hydration arm swap retires each adopted inner branch
+		// pair; the branch then borrows its durable outer slot range.
+		expect(domComments(container)).toBe(10);
+
+		flushSync(() =>
+			root.render(ListConditional, {
+				items: [
+					{ id: 'b', code: false },
+					{ id: 'a', code: true },
+				],
+			}),
+		);
+		expect([...container.querySelectorAll('.conditional-item')]).toEqual([newB, newA]);
+		root.unmount();
 	});
 
 	it('(d) @if single-element branch: client self-marks everything', () => {
@@ -267,6 +474,80 @@ describe('marker-shape pins (M0) — exact comment counts per minting regime', (
 		// template's <!> anchor — only that anchor remains = 1. SSR: if-slot
 		// pair + taken-branch pair = 4. Hydration adopts both server pairs = 4.
 		expect(counts('Branch', Branch, { on: true })).toEqual({ client: 1, ssr: 4, hydrate: 4 });
+	});
+
+	it('(d2) inactive @if uses one anchor and stays markerless through toggles', () => {
+		expect(counts('BranchEmpty', BranchEmpty, { on: false })).toEqual({
+			client: 1,
+			ssr: 2,
+			hydrate: 2,
+		});
+
+		const hit = vi.fn();
+		const root = createRoot(container);
+		root.render(BranchEmpty, { on: false, hit });
+		const before = container.querySelector('.before');
+		const after = container.querySelector('.after');
+		expect(domComments(container)).toBe(1);
+		flushSync(() => root.render(BranchEmpty, { on: true, hit }));
+		const active = container.querySelector('.active') as HTMLButtonElement;
+		expect(active).not.toBeNull();
+		expect(domComments(container)).toBe(1);
+		active.click();
+		expect(hit).toHaveBeenCalledTimes(1);
+		expect(container.querySelector('.before')).toBe(before);
+		expect(container.querySelector('.after')).toBe(after);
+		flushSync(() => root.render(BranchEmpty, { on: false, hit }));
+		expect(container.querySelector('.active')).toBeNull();
+		expect(domComments(container)).toBe(1);
+		expect(container.querySelector('.before')).toBe(before);
+		expect(container.querySelector('.after')).toBe(after);
+		root.unmount();
+	});
+
+	it('(d3) nested self-marked branches refresh every shared ancestor boundary', () => {
+		const root = createRoot(container);
+		root.render(NestedBranch, { outer: true, inner: true });
+		expect(container.querySelector('.inner-a')?.textContent).toBe('A');
+		flushSync(() => root.render(NestedBranch, { outer: true, inner: false }));
+		expect(container.querySelector('.inner-a')).toBeNull();
+		expect(container.querySelector('.inner-b')?.textContent).toBe('B');
+		flushSync(() => root.render(NestedBranch, { outer: false, inner: false }));
+		expect(container.querySelector('.inner-b')).toBeNull();
+		expect(container.querySelector('.tail')?.textContent).toBe('tail');
+		flushSync(() => root.render(NestedBranch, { outer: true, inner: true }));
+		expect(container.querySelector('.inner-a')?.textContent).toBe('A');
+		expect([...container.querySelector('.nb')!.children].map((node) => node.className)).toEqual([
+			'inner-a',
+			'tail',
+		]);
+		root.unmount();
+		expect(container.innerHTML).toBe('');
+	});
+
+	it('(c3) ordinary return-JSX functions receive only narrow single-root stamps', () => {
+		const positive = compile(
+			`export default function Row(props) { const x = props.x; return <li>{x}</li>; }`,
+			'row.tsx',
+		).code;
+		expect(positive).toContain('Row.$$singleRoot = true;');
+
+		const earlyReturn = compile(
+			`export default function Row(props) { if (!props.x) return null; return <li>{props.x}</li>; }`,
+			'row-early.tsx',
+		).code;
+		expect(earlyReturn).not.toContain('Row.$$singleRoot = true;');
+		const fragment = compile(
+			`export default function Row() { return <><li>a</li><li>b</li></>; }`,
+			'row-fragment.tsx',
+		).code;
+		expect(fragment).not.toContain('Row.$$singleRoot = true;');
+
+		const consumer = compile(
+			`import Row from './row'; export function List(props) @{ <ul>@for (const x of props.items; key x.id) { <Row x={x}/> }</ul> }`,
+			'list.tsrx',
+		).code;
+		expect(consumer).toContain('Row.$$singleRoot === true ? 2 : 0');
 	});
 
 	it('(e) de-opt descriptor tree: hostElementBody + nested childSlot pairs', () => {


### PR DESCRIPTION
## Summary

- reuse compiler-owned list anchors as closing boundaries, let `@empty` borrow the outer list range, and keep inactive client conditionals on their existing insertion anchor
- let keyed items share narrowly proven single-host component or complete host-vs-host conditional boundaries, including safe propagation across branch swaps and transition commits
- add exact DOM-shape/behavior/hydration regression coverage, a shared benchmark DOM census, ratio guards, design documentation, and an `octane` patch changeset

## Production DOM census

Counts are descendants of the fixture root (whole body for the open-portal row):

| State | Before | After | React / Preact |
| --- | ---: | ---: | ---: |
| js-framework, 1,000 rows | 10,075 (3 comments) | **10,074 (2)** | 10,072 (0) |
| TodoMVC, 100 todos | 933 (310) | **730 (107)** | 623 (0) |
| chat-stream, 10 messages / 21 segments | 158 (78) | **104 (24)** | 80 (0) |
| portal-swarm, 600 closed cards | 3,826 (1,812) | **2,622 (608)** | 2,014 (0) |
| portal-swarm, all open / whole body | 8,229 (3,012) | **7,025 (1,808)** | 5,217 (0) |

Equivalent Octane/React/Preact fixtures retain exact element and meaningful-text counts. The naive js-framework TSRX/JSX variants now match tuned Octane at 2 comments instead of 2,003/4,003.

## Invariants and tradeoffs

SSR emission and the hydration wire protocol are intentionally unchanged. Portal target pairs, Suspense/`@try` streaming boundaries, transition WIP pairs, Activity ranges, multi-root keyed items, order-bearing holes, and adjacent-text separators remain load-bearing.

Focused coverage asserts keyed identity and state, effect cleanup, refs, events, branch replacement/order, transitions, SSR output, and hydration adoption/reorder. The fixed codegen corpus costs +42 B gzip (+0.18%); production gzip grows +5 B for js-framework and about +0.5% for TodoMVC/chat. Normal timing comparisons remain competitive (for example js-framework run 1.8 ms vs React 6.5 / Solid 1.7).

## Validation

- `pnpm test` — 800 files, 6,435 passed; 8 expected failures and 2 existing skips
- focused marker/hydration/control-flow tests in both dev and production compile modes
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm changeset:check`
- website project — 36/36; real-browser dev/prod hydration e2e — 11/11
- normal production comparisons for codegen-size, bundle-size, js-framework, js-framework-deopt, TodoMVC, chat-stream, and portal-swarm
- `--quick --ratios` for the affected structural suites — 21 guards passed

The normal combined run also surfaces two stale total-bundle ratio ceilings already breached by current main (Octane/Ripple and Octane/Solid); this patch does not relax those unrelated guards.

Context only: #55 added the Preact/Svelte website benchmark presentation and is now merged. This PR does not modify that work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core client reconciliation (`forBlock`, branch swaps, shared keyed boundaries) where teardown, reorder, transitions, and hydration adoption bugs would surface as subtle DOM corruption; mitigated by expanded marker-shape and hydration tests plus deterministic census ratio guards.
> 
> **Overview**
> This patch **lands M5** of the comment-marker elision work: fewer client-side comment/range nodes in benchmark-heavy trees while **SSR emission and hydration wire format stay unchanged**.
> 
> **Runtime (`forBlock`, `renderBranchSlot`):** `@for` can **reuse the compiler’s trailing `<!>`** as the list’s `/for` end instead of adding another comment; **`@empty` borrows the outer list range** instead of nesting an `empty` pair. Inactive client-only **`@if` arms keep a single insertion anchor** (no dormant pair); active sole-host branches **self-mark** again. **`replaceSharedBlockBoundary`** propagates boundary updates when nested sole-root branches or keyed items **share one element range**, including transition commits that promote to a durable pair.
> 
> **Compiler (`compile.js`):** Narrow static proofs widen **`singleRoot` keyed `@for` items**—plain host roots, **single unconditional host-return components** (incl. return-JSX), and **`@if/@else` where every arm is one host**—plus runtime **`$$singleRoot`** for imported components. Emits **`ownEnd`** on anchored `forBlock` calls.
> 
> **Benchmarks & CI:** New **`benchmarks/lib/dom-nodes.mjs`** drives full DOM censuses (`nodes_*`, `elements_*`, `text_*`, etc.) in js-framework, TodoMVC, chat-stream, and portal-swarm; **`ratios.json`** adds structural guards so optimizations can’t trade comments for missing visible output. Docs/changeset mark **M5 landed**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c7db9c99ebef8d058599966e73cb52c4b25235a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->