### PR TITLE
Coalesce redundant hydration range comments

### DIFF
--- a/.changeset/fair-comments-count.md
+++ b/.changeset/fair-comments-count.md
@@ -1,0 +1,6 @@
+---
+'octane': patch
+---
+
+Reduce hydrated DOM bookkeeping by coalescing exactly coextensive range pairs
+into counted comments while preserving independent ownership boundaries.

--- a/benchmarks/lib/dom-nodes.d.mts
+++ b/benchmarks/lib/dom-nodes.d.mts
@@ -1,0 +1,27 @@
+export interface DomNodeCensus {
+	root: string;
+	total: number;
+	elements: number;
+	text: number;
+	comments: number;
+	emptyText: number;
+	whitespaceText: number;
+	hydrationMarkersPhysical: number;
+	hydrationMarkersLogical: number;
+	hydrationMarkersCounted: number;
+	hydrationMarkerMaxMultiplicity: number;
+	leadingHydrationStartsPhysical: number;
+	leadingHydrationStartsLogical: number;
+	commentsByData: Record<string, number>;
+	commentParents: Record<string, number>;
+}
+
+export function censusDomNodes(rootSelector?: string): DomNodeCensus;
+
+export interface DeterministicCount {
+	median: number;
+	min: number;
+	samples: number[];
+}
+
+export function deterministicCount(value: number): DeterministicCount;

--- a/benchmarks/lib/dom-nodes.mjs
+++ b/benchmarks/lib/dom-nodes.mjs
@@ -9,12 +9,33 @@ export function censusDomNodes(rootSelector = '#main') {
 				(rootSelector === '#main' ? document.querySelector('#app') : null);
 	if (root === null) throw new Error(`DOM census root not found: ${rootSelector}`);
 
+	// Hydration range comments use `[` / `]` for one logical boundary and
+	// `[N` / `]N` for N >= 2 coincident boundaries sharing one physical Comment.
+	// Keep this parser inside the census function: Playwright serializes only
+	// this function when it is passed directly to page.evaluate.
+	const parseHydrationMarker = (data) => {
+		const kind = data.charCodeAt(0);
+		if (kind !== 91 && kind !== 93) return null; // `[` / `]`
+		if (data.length === 1) return { start: kind === 91, multiplicity: 1, counted: false };
+		const encoded = data.slice(1);
+		// Canonical positive decimal integer: reject zero, signs, decimals,
+		// whitespace, leading zeroes, and values beyond exact JS integer range.
+		if (!/^[1-9]\d*$/.test(encoded)) return null;
+		const multiplicity = Number(encoded);
+		if (!Number.isSafeInteger(multiplicity) || multiplicity < 2) return null;
+		return { start: kind === 91, multiplicity, counted: true };
+	};
+
 	let total = 0;
 	let elements = 0;
 	let text = 0;
 	let comments = 0;
 	let emptyText = 0;
 	let whitespaceText = 0;
+	let hydrationMarkersPhysical = 0;
+	let hydrationMarkersLogical = 0;
+	let hydrationMarkersCounted = 0;
+	let hydrationMarkerMaxMultiplicity = 0;
 	const commentsByData = Object.create(null);
 	const commentParents = Object.create(null);
 	const walker = document.createTreeWalker(root, NodeFilter.SHOW_ALL);
@@ -31,6 +52,15 @@ export function censusDomNodes(rootSelector = '#main') {
 		} else if (node.nodeType === Node.COMMENT_NODE) {
 			comments++;
 			const data = node.nodeValue || '';
+			const hydrationMarker = parseHydrationMarker(data);
+			if (hydrationMarker !== null) {
+				hydrationMarkersPhysical++;
+				hydrationMarkersLogical += hydrationMarker.multiplicity;
+				if (hydrationMarker.counted) hydrationMarkersCounted++;
+				if (hydrationMarker.multiplicity > hydrationMarkerMaxMultiplicity) {
+					hydrationMarkerMaxMultiplicity = hydrationMarker.multiplicity;
+				}
+			}
 			commentsByData[data] = (commentsByData[data] || 0) + 1;
 			const parent = node.parentElement;
 			const parentKey =
@@ -41,6 +71,19 @@ export function censusDomNodes(rootSelector = '#main') {
 						(parent.classList.length ? '.' + [...parent.classList].join('.') : '');
 			commentParents[parentKey] = (commentParents[parentKey] || 0) + 1;
 		}
+	}
+
+	// The website regression that motivated counted markers is a run of logical
+	// opens at the start of <main>. Report both physical comments and decoded
+	// logical depth so coalescing is visible without mistaking it for lost ranges.
+	let leadingHydrationStartsPhysical = 0;
+	let leadingHydrationStartsLogical = 0;
+	for (let node = root.firstChild; node !== null; node = node.nextSibling) {
+		if (node.nodeType !== Node.COMMENT_NODE) break;
+		const marker = parseHydrationMarker(node.nodeValue || '');
+		if (marker === null || !marker.start) break;
+		leadingHydrationStartsPhysical++;
+		leadingHydrationStartsLogical += marker.multiplicity;
 	}
 
 	const sortedEntries = (record) =>
@@ -55,6 +98,12 @@ export function censusDomNodes(rootSelector = '#main') {
 		comments,
 		emptyText,
 		whitespaceText,
+		hydrationMarkersPhysical,
+		hydrationMarkersLogical,
+		hydrationMarkersCounted,
+		hydrationMarkerMaxMultiplicity,
+		leadingHydrationStartsPhysical,
+		leadingHydrationStartsLogical,
 		commentsByData: sortedEntries(commentsByData),
 		commentParents: sortedEntries(commentParents),
 	};

--- a/benchmarks/news/run.mjs
+++ b/benchmarks/news/run.mjs
@@ -26,6 +26,7 @@ import { createServer as createHttp } from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { censusDomNodes } from '../lib/dom-nodes.mjs';
 import { summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -147,20 +148,24 @@ for (let i = 0; i < WARMUP + ITER; i++) {
 const ctx = await browser.newContext();
 const page = await ctx.newPage();
 await page.goto(`http://localhost:${PORT}/`, { waitUntil: 'load' });
+const domBeforeHydration = await page.evaluate(censusDomNodes, '#app');
 const check = await page.evaluate(async () => {
 	const root = document.getElementById('app');
-	// hydrate() consumes + REMOVES the server's suspense seed
-	// (<script data-octane-suspense>) from the container, so comparing raw
-	// innerHTML before/after would report a false rebuild for any app that
-	// emitted that script. Exclude it from both sides; the no-rebuild check is
-	// about the rendered tree, not the seed.
-	const stripSeed = (html) =>
-		html.replace(/<script[^>]*\bdata-octane-suspense\b[^>]*>[\s\S]*?<\/script>/g, '');
-	const before = stripSeed(root.innerHTML);
+	// Hydration consumes its suspense seed and Octane may coalesce redundant
+	// protocol comments after every host/text node has been adopted. Compare the
+	// semantic tree without either bookkeeping form, and separately pin a host
+	// node's identity so a byte-identical rebuild cannot pass this gate.
+	const stripBookkeeping = (html) =>
+		html
+			.replace(/<script[^>]*\bdata-octane-suspense\b[^>]*>[\s\S]*?<\/script>/g, '')
+			.replace(/<!--(?:\[|\]|\[(?:[2-9]\d*|1\d+)|\](?:[2-9]\d*|1\d+))-->/g, '');
+	const before = stripBookkeeping(root.innerHTML);
+	const firstCard = root.querySelector('article.card');
 	window.__hydrate();
 	await new Promise((r) => requestAnimationFrame(r));
 	const cards = root.querySelectorAll('article.card').length;
-	const noRebuild = stripSeed(root.innerHTML) === before; // hydration adopted, didn't rebuild
+	const noRebuild =
+		stripBookkeeping(root.innerHTML) === before && root.querySelector('article.card') === firstCard;
 	const cls0 = root.querySelector('header.masthead').className;
 	root.querySelector('#theme').click();
 	// Let the framework's reactive update flush before reading the result:
@@ -170,6 +175,7 @@ const check = await page.evaluate(async () => {
 	const cls1 = root.querySelector('header.masthead').className;
 	return { cards, noRebuild, toggled: cls0 !== cls1 };
 });
+const domAfterHydration = await page.evaluate(censusDomNodes, '#app');
 await ctx.close();
 await browser.close();
 await new Promise((r) => httpServer.close(r));
@@ -204,7 +210,12 @@ if (process.env.BENCH_JSON) {
 					ssr_render: timingStatForJson(ssr),
 					hydrate: timingStatForJson(hyd),
 				},
-				meta: { htmlBytes, cards: check.cards },
+				meta: {
+					htmlBytes,
+					cards: check.cards,
+					domBeforeHydration,
+					domAfterHydration,
+				},
 			},
 		],
 	};

--- a/docs/comment-marker-elision-plan.md
+++ b/docs/comment-marker-elision-plan.md
@@ -1,6 +1,6 @@
 # Comment-Marker Elision Plan — fewer `<!--[-->`s when they carry no information
 
-Status: M0-M5 LANDED (2026-07-13; see each phase's note). Follow-up to the
+Status: M0-M6 LANDED (2026-07-13; see each phase's note). Follow-up to the
 website Elements-panel report
 (a 40-deep run of `<!--[-->` before `.shell`, ~2,100 comment nodes on the home
 page). Companion to docs/compiled-output-optimization-plan.md — this is the
@@ -398,6 +398,90 @@ That is the boundary-propagation/runtime proof cost paid by apps that use the
 optimized paths; the matching js-framework, TodoMVC, and chat states lose 1,
 203, and 54 live nodes respectively, while closed portal-swarm loses 1,204.
 
+### M6 — Post-hydration counted range coalescing
+
+**M6 IMPLEMENTED 2026-07-13.** Hydratable SSR deliberately keeps emitting the
+established, explicit `<!--[-->…<!--]-->` wire format. Once hydration has
+successfully adopted that tree, the client now compacts only nested ranges
+that are proven to have exactly the same extent. A stack of `N` coextensive
+pairs becomes one counted pair, `<!--[N-->…<!--]N-->`; `N` records logical
+ownership multiplicity for diagnostics while the DOM contains only two
+physical boundary nodes.
+
+The proof is deliberately runtime- and ownership-aware rather than a textual
+comment rewrite:
+
+- compaction walks the hydrated Block/Scope ownership graph bottom-up and
+  requires one live range-bearing child plus exact DOM adjacency
+  (`outer.start.nextSibling === inner.start` and
+  `inner.end.nextSibling === outer.end`);
+- every owner is retargeted to the retained pair, with the inner owners marked
+  as borrowers so teardown, replacement, transitions, and reconciliation do
+  not remove a shared endpoint;
+- compiler-proven sole renderable-child wrappers carry an explicit flag so
+  binding-bag bookkeeping cannot obscure the otherwise exact runtime proof;
+- keyed component boundaries, keyed-list outer ranges, Suspense/`@try`,
+  `<Activity>`, portals, fragment refs, and non-coextensive control flow remain
+  physical barriers. Independent keyed items and active try bodies may still
+  compact internally without merging across their ownership boundary;
+- counted payloads use a canonical positive-safe-integer grammar, and range
+  matching still treats a counted marker as one physical nesting level. The
+  multiplicity is metadata, not an instruction to skip or synthesize DOM.
+
+That final point is why the safe representation is a counted **pair**, not one
+comment total: mutable ownership still needs both a start and an end insertion
+boundary. On the website's shared router prefix, 19 logical opening ranges are
+now represented by five physical opening comments; the other four endpoints
+start ranges with genuinely different spans and cannot be merged without
+changing teardown or insertion semantics.
+
+Production website measurements against a clean worktree at the same
+`origin/main` commit (after hydration and a 400 ms settle) were:
+
+| Route | All body comments | Octane range comments | Shared `<main>` prefix |
+| --- | ---: | ---: | ---: |
+| `/` | 2,439 → **2,315** (−124) | 542 → **418** | 19 → **5 physical / 19 logical** |
+| `/docs` | 383 → **227** (−156) | 382 → **226** | 19 → **5 / 19** |
+| `/benchmarks` | 18,213 → **18,079** (−134) | 2,824 → **2,690** | 19 → **5 / 19** |
+| `/playground` | 165 → **69** (−96) | 164 → **68** | 19 → **5 / 19** |
+| `/view-transitions` | 189 → **81** (−108) | 188 → **80** | 19 → **5 / 19** |
+
+Raw SSR comment counts are unchanged (`/` 545, `/docs` 383,
+`/benchmarks` 2,861, `/playground` 167, `/view-transitions` 189). This keeps
+streaming, old server output, and hydration recovery unambiguous; the saving is
+applied only after successful client adoption. The general DOM census now
+reports physical and logical hydration markers, counted-marker count, maximum
+multiplicity, and physical/logical leading opens so future regressions remain
+visible independently of user-visible elements and text.
+
+Hydration records whether range matching encountered any physically adjacent
+pair before considering compaction. Roots without one skip the ownership walk;
+eligible roots pay one hydration-only, linear walk plus the comment removals.
+Normal client mounts, SSR output, and steady-state update traversal do not run
+the compactor. Focused coverage pins adoption identity, events/state, branch
+replacement, keyed reorder identity, direct- and return-position Suspense
+barriers, mismatch recovery, streaming scanning, and both development and
+production compilation.
+
+The production `news` hydration benchmark is a useful overhead control because
+its 52 independent pairs have no coextensive adjacency to remove, so the new
+candidate guard skips the ownership walk: its census stays at 763 nodes / 104
+physical and logical hydration comments before and after. Across 20 fresh-page
+samples, Octane TSRX hydration measured 1.30 ms on this branch versus 1.3125 ms
+on the clean-main run (1.30 ms median and 1.40 ms p95 in both). Treat that
+0.0125 ms difference as noise, not a claimed speedup; the result shows no
+measurable no-op regression. In the branch's same uncontended run, React
+measured 2.40 ms, Preact 1.70 ms, Solid 1.70 ms, and Svelte 1.3875 ms. Adoption
+identity, 50-card content, and interaction gates all passed.
+
+The deterministic size tradeoff is modest: the fixed compiled corpus grows by
+51 raw / 37 minified / **1 gzip byte**. The production TSRX js-framework
+bundle grows 29,682 → 30,017 gzip bytes (**+335 B / +1.13%**), almost entirely
+in the framework chunk (the app chunk shrinks by 2 B); the JSX fixture grows
+29,689 → 30,041 (**+352 B / +1.19%**). TodoMVC and chat grow 358 B / 379 B
+gzip. This is the counted-marker parser, ownership proof, and no-op guard cost;
+normal app codegen is effectively unchanged.
+
 **Still open (small or order-constrained — diminishing returns):**
 
 1. Multi-hole hosts: the remaining ~684 empty anchors on `/` are
@@ -406,16 +490,21 @@ optimized paths; the matching js-framework, TodoMVC, and chat states lose 1,
 2. Component-bearing `it` pairs (145 on `/`) — required borrow ranges today.
 3. Sole-root `@switch` construct inherit + children-render-fn /
    value-position sole roots (M3 leftovers).
-4. SSR-side symmetry for the M2/M4/M5 client regimes (hydrated pages keep
-   server item/component pairs the client mount would not mint). This must be
-   designed as one SSR-emission + hydration-adoption protocol change.
+4. SSR payload size: M6 removes redundant nodes only after successful
+   hydration. Omitting them from the wire would require a versioned,
+   server/client-symmetric encoding and streaming compatibility; it is not
+   needed to obtain the live-DOM reduction.
 
-### Ordering & expected effect
+### Ordering & measured effect
 
-M0 → M1 → M2 → M3 → M4 → M5. Home-page projection: M2 removes ~1,600 (chart + rows),
-M3 removes ~39 of the 40-deep prefix and every wrapper pair page-wide
-(≈300 of the 392 SSR-pair comments), M1 covers client-rendered leaves.
-Target: **2,122 → under ~400**, root prefix 40 → ≤ 3.
+M0 → M1 → M2 → M3 → M4 → M5 → M6. M1-M5 remove ranges at the
+compiler/runtime source for client-created content; M6 complements them by
+compacting redundant ranges that must remain explicit in the SSR wire format.
+The original home-page report's 40-opening wrapper prefix fell to 19 before
+M6 and now occupies five opening comments while preserving all 19 logical
+owners. The remaining page-wide comments are predominantly chart-internal,
+order-bearing anchors or independent ownership ranges rather than a redundant
+coextensive wrapper stack.
 
 ## 5. Test & perf strategy
 

--- a/packages/mdx/tests/hydration.test.ts
+++ b/packages/mdx/tests/hydration.test.ts
@@ -1,7 +1,7 @@
 /**
  * Hydration — a server-rendered MDX document adopts into the client-compiled
- * module via `hydrateRoot`: byte-identical DOM, adopted (not rebuilt) nodes,
- * no mismatch warnings, and embedded interactive components stay live.
+ * module via `hydrateRoot`: logically equivalent DOM, adopted (not rebuilt)
+ * nodes, no mismatch warnings, and embedded interactive components stay live.
  *
  * The server side compiles the SAME `.mdx` source with `mode: 'server'` and
  * evaluates it with the server runtime injected (the ssr.test.ts eval trick,
@@ -26,6 +26,13 @@ import BasicDoc from './_fixtures/basic.mdx';
 import ComponentsDoc from './_fixtures/components.mdx';
 
 const FIXTURES = join(process.cwd(), 'packages/mdx/tests/_fixtures');
+
+const expandCountedHydrationMarkers = (html: string) =>
+	html.replace(/<!--([\[\]])([1-9]\d*)-->/g, (whole, marker: string, raw: string) => {
+		const multiplicity = Number(raw);
+		if (!Number.isSafeInteger(multiplicity) || multiplicity < 2) return whole;
+		return `<!--${marker}-->`.repeat(multiplicity);
+	});
 
 // Server-compile an `.mdx` fixture through the pipeline. The provider import
 // is the REAL `@octanejs/mdx/server` (the server-mode default).
@@ -117,8 +124,8 @@ describe('hydration', () => {
 	});
 
 	// The server provider (@octanejs/mdx/server) and the client provider mount
-	// the same component-frame shape, so a document server-rendered under the
-	// server MDXProvider hydrates byte-for-byte into the client MDXProvider.
+	// the same logical component-frame shape. Hydration may store an exactly
+	// coextensive prefix as a counted pair after adopting every document node.
 	it('adopts a document rendered under the server MDXProvider into the client MDXProvider', () => {
 		const mod = serverMdxModule('basic.mdx');
 		const components = { h1: 'h2', em: 'i' };
@@ -135,7 +142,7 @@ describe('hydration', () => {
 			children: createElement(BasicDoc),
 		});
 		flushSync(() => {});
-		expect(container.innerHTML).toBe(html);
+		expect(expandCountedHydrationMarkers(container.innerHTML)).toBe(html);
 		expect(container.querySelector('h2')).toBe(h2);
 		root.unmount();
 	});

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -6697,6 +6697,16 @@ function planJsx(jsxNodesRaw, ctx, componentName, inlinedSubs, parentNs = 'html'
 	// by construction; the stamped cc emits componentSlot(..., inherit=true).
 	const inheritRoot = ctx._inheritBody === true && inheritSoleCompRoot(jsxNodes, ctx);
 	ctx._inheritBody = false;
+	// Hydration range compaction: a bare renderable hole that is the ENTIRE body
+	// (the common `SafeFragment` / `{children}` pass-through shape) is provably
+	// coextensive with its component block. Unlike M3 component inheritance we
+	// keep the explicit SSR pair for backward-compatible hydration, then stamp
+	// the client ChildSlot so the post-hydration pass may borrow the outer pair.
+	const coalesceChildRoot =
+		jsxNodes.length === 1 &&
+		((jsxNodes[0].type === 'Text' &&
+			!isKnownStringExpression(jsxNodes[0].expression, ctx.knownStringLocals)) ||
+			jsxNodes[0].type === 'TSRXExpression');
 	// Top-level control-flow directives (@if/@for/@switch/@try/<Activity>). In a
 	// body that ALSO has static template roots, each construct emits a `<!>`
 	// anchor at its child index (mirroring the in-element mixed-children path)
@@ -6767,6 +6777,9 @@ function planJsx(jsxNodesRaw, ctx, componentName, inlinedSubs, parentNs = 'html'
 		// pushed first, before makeCompCall returns to the root push).
 		if (inheritRoot && compCalls.length > 0) {
 			compCalls[compCalls.length - 1].inheritRange = true;
+		}
+		if (coalesceChildRoot && compCalls.length > 0) {
+			compCalls[compCalls.length - 1].coalesceRange = true;
 		}
 		// Advance the child index only when the node actually contributed template
 		// HTML (an element / text / `<!>` anchor). Component calls and un-anchored
@@ -7327,9 +7340,14 @@ function planJsx(jsxNodesRaw, ctx, componentName, inlinedSubs, parentNs = 'html'
 				// primitive into a text slot; delegates to `childSlot` otherwise).
 				ctx.runtimeNeeded.add('textSlot');
 				const anchorArg = anchorExpr === 'null' ? '' : `, ${anchorExpr}`;
+				const coalesceArg = cc.coalesceRange
+					? anchorArg
+						? ', undefined, true'
+						: ', undefined, undefined, true'
+					: '';
 				pushAfter(
 					cc.id,
-					`  _$textSlot(__s, ${slotIndex}, ${hostExpr}, ${cc.valueExpr}${anchorArg});`,
+					`  _$textSlot(__s, ${slotIndex}, ${hostExpr}, ${cc.valueExpr}${anchorArg}${coalesceArg});`,
 				);
 				continue;
 			}
@@ -7348,11 +7366,12 @@ function planJsx(jsxNodesRaw, ctx, componentName, inlinedSubs, parentNs = 'html'
 			// When the slot has its OWN `<!>` placeholder, tell textHole/childSlot to
 			// reuse it as the end marker (no second comment minted) — `ownEnd`.
 			const ownEndArg = cc.anchorVar ? ', true' : '';
+			const coalesceArg = cc.coalesceRange ? (cc.anchorVar ? ', true' : ', undefined, true') : '';
 			const chp = `_b.${bag.letter(`_chp$${cc.id}`)}`;
 			const chv = `_b.${bag.letter(`_chv$${cc.id}`)}`;
 			pushAfter(
 				cc.id,
-				`  { const _v = (${cc.valueExpr}); const _o = _v !== null && (typeof _v === 'object' || typeof _v === 'function'); if (_o || ${chp} !== _v) { ${chp} = _v; const _t = ${chv}; if (_t != null && !_o && _v !== null) _$setText(_t, _v); else ${chv} = _$textHole(__s, ${slotIndex}, ${hostExpr}, _v, ${anchorExpr}${ownEndArg}); } }`,
+				`  { const _v = (${cc.valueExpr}); const _o = _v !== null && (typeof _v === 'object' || typeof _v === 'function'); if (_o || ${chp} !== _v) { ${chp} = _v; const _t = ${chv}; if (_t != null && !_o && _v !== null) _$setText(_t, _v); else ${chv} = _$textHole(__s, ${slotIndex}, ${hostExpr}, _v, ${anchorExpr}${ownEndArg}${coalesceArg}); } }`,
 			);
 			continue;
 		}
@@ -7416,9 +7435,12 @@ function planJsx(jsxNodesRaw, ctx, componentName, inlinedSubs, parentNs = 'html'
 			if (anchorArg === '') anchorArg = ', undefined';
 			singleRootArg = cc.singleRoot ? ', undefined, true' : ', undefined, 2';
 		}
+		// Persist key ownership separately from the current key VALUE so
+		// `key={undefined}` remains an independent reconciliation boundary.
+		const keyedArg = cc.keyExpr != null ? ', undefined, undefined, true' : '';
 		pushAfter(
 			cc.id,
-			`  _$componentSlot(__s, ${slotIndex}, ${hostExpr}, ${cc.compExpr}, ${cc.propsExpr}${anchorArg}${keyArg}${singleRootArg});`,
+			`  _$componentSlot(__s, ${slotIndex}, ${hostExpr}, ${cc.compExpr}, ${cc.propsExpr}${anchorArg}${keyArg}${singleRootArg}${keyedArg});`,
 		);
 	}
 	for (const pc of ctx._portalCalls) {

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -3715,6 +3715,10 @@ export function ssrTry(
 // boundary errored (hydration client-renders it via mismatch recovery).
 const STREAM_RUNTIME_JS =
 	'(function(){var d=document;var S=window.$OCTS=window.$OCTS||{};' +
+	// Legacy `[` / `]` means one physical range; `[N` / `]N` is canonical only
+	// for safe integer N >= 2. Keep this in sync with hydrationMarkerMultiplicity.
+	'var M=function(v,c){if(v===c)return 1;if(!v||v.charAt(0)!==c)return 0;' +
+	'var s=v.slice(1),n=+s;return n>=2&&Number.isSafeInteger(n)&&String(n)===s;};' +
 	'window.$OCTRC=function(id){' +
 	"var t=d.querySelector('template[" +
 	STREAM_BOUNDARY_ATTR +
@@ -3729,7 +3733,7 @@ const STREAM_RUNTIME_JS =
 	'if(sd){S[id]=sd.textContent;sd.parentNode.removeChild(sd);}' +
 	'var n=t.nextSibling,depth=1;' +
 	'while(n){var x=n.nextSibling,v=n.nodeType===8?n.data:null;' +
-	'if(v==="[")depth++;else if(v==="]"){depth--;if(depth===0)break;}' +
+	'if(M(v,"["))depth++;else if(M(v,"]")){depth--;if(depth===0)break;}' +
 	'n.parentNode.removeChild(n);n=x;}' +
 	'var p=t.parentNode;' +
 	'while(s.firstChild)p.insertBefore(s.firstChild,n);' +

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -229,9 +229,8 @@ function describeHydrationNode(node: Node | null): string {
 	if (node.nodeType === 1) return `<${(node as Element).localName}>`;
 	if (node.nodeType === 3) return `text ${JSON.stringify((node as Text).nodeValue)}`;
 	if (node.nodeType === 8) {
-		const d = (node as Comment).data;
-		if (d === HYDRATION_START) return 'a control-flow block';
-		if (d === HYDRATION_END) return 'the end of the parent block (fewer nodes than expected)';
+		if (isBlockOpen(node)) return 'a control-flow block';
+		if (isBlockClose(node)) return 'the end of the parent block (fewer nodes than expected)';
 		return 'a comment';
 	}
 	return 'a node';
@@ -2585,6 +2584,8 @@ export function renderBlock(block: Block): void {
 					block.endMarker,
 					d.key ?? undefined,
 					true,
+					undefined,
+					hydrating && KEYED_ELEMENT_DESCRIPTORS.has(d),
 				);
 			} else {
 				childSlot(block, 0, block.parentNode, out, block.endMarker);
@@ -2619,13 +2620,17 @@ function disposeReturnSlot(block: Block, state: any): void {
 		}
 		// Fires the content's cleanups and sweeps the nodes between the markers.
 		clearChildContent(state);
-		(state.start as ChildNode | null)?.remove();
-		(state.end as ChildNode | null)?.remove();
+		if (!state.borrowed) {
+			(state.start as ChildNode | null)?.remove();
+			(state.end as ChildNode | null)?.remove();
+		}
 	} else {
 		// componentSlotSlot — unmountBlock removes its DOM (incl. any owned markers).
 		if (state.block) unmountBlock(state.block, true);
-		(state.start as ChildNode | null)?.remove?.();
-		(state.end as ChildNode | null)?.remove?.();
+		if (!state.inherited) {
+			(state.start as ChildNode | null)?.remove?.();
+			(state.end as ChildNode | null)?.remove?.();
+		}
 	}
 	const reg = block._slots;
 	if (reg !== null) {
@@ -2689,6 +2694,7 @@ export function componentSlotLite<P>(
 	let scope = parentScope.slots[slotKey] as Scope | undefined;
 	// The server `<!--]-->` this call adopted as its range end (hydration first
 	// render only) — consumed by the post-body cursor advance below.
+	let adoptedOpen: Comment | null = null;
 	let adoptedClose: Node | null = null;
 	if (scope === undefined) {
 		scope = new ScopeImpl(parentScope, parentScope.block);
@@ -2704,6 +2710,7 @@ export function componentSlotLite<P>(
 			// cursor at the content so the body's clone() adopts the server DOM, and
 			// use `<!--]-->` as the insert anchor so the body's
 			// `insertBefore(content, endMarker)` is a no-op (content already there).
+			adoptedOpen = anchor as Comment;
 			endMarker = matchingClose(anchor as Node);
 			adoptedClose = endMarker;
 			hydrateNode = (anchor as Node).nextSibling;
@@ -2720,12 +2727,19 @@ export function componentSlotLite<P>(
 			let open: Node | null = hydrateNode;
 			if (open === null || open.parentNode !== host) open = host.firstChild;
 			if (open !== null && isBlockOpen(open)) {
+				adoptedOpen = open;
 				endMarker = matchingClose(open);
 				adoptedClose = endMarker;
 				hydrateNode = open.nextSibling;
 			}
 		}
 		scope.block = new LiteBlockImpl(host, endMarker, parentScope.block) as unknown as Block;
+		if (adoptedOpen !== null && adoptedClose !== null) {
+			hydratedLiteRanges?.set(scope, {
+				start: adoptedOpen,
+				end: adoptedClose as Comment,
+			});
+		}
 		parentScope.slots[slotKey] = scope;
 		// Register on parent.children so unmountScope(parent) walks into us.
 		parentScope.children.push({ key: slotKey, scope });
@@ -4495,6 +4509,22 @@ let hydrateNode: Node | null = null;
 // constant-fold away with the rest of the hydration path in client-only builds.
 let hydrationSeeds: unknown[] | null = null;
 let hydrationSeedCursor = 0;
+// Set while adopting a root when a matched range is physically wrapped by an
+// exactly-adjacent marker pair. The post-hydration ownership walk can only
+// remove comments in that shape, so roots without one skip the pass entirely.
+let hydrationHasAdjacentRangePair = false;
+
+/**
+ * Lite component calls deliberately allocate no CompSlot/Block range owner,
+ * but hydration still adopts their server frame pair. Keep that pair in an
+ * ephemeral map for the one post-hydration compaction pass; the live lite
+ * scope only needs its end marker re-pointed if the pair is borrowed.
+ */
+interface HydratedLiteRange {
+	start: Comment;
+	end: Comment;
+}
+let hydratedLiteRanges: WeakMap<Scope, HydratedLiteRange> | null = null;
 
 /**
  * Parse a seed-JSON payload (the shell's `data-octane-suspense` script or a
@@ -4585,7 +4615,7 @@ export function clone<T extends Node>(node: T, loc?: string): T {
 					describeHydrationNode(hydrateNode),
 				);
 			const stale = hydrateNode;
-			if (stale.nodeType === 8 && (stale as Comment).data === HYDRATION_END) {
+			if (isBlockClose(stale)) {
 				// The server rendered NOTHING at this slot (the cursor sits on the ENCLOSING
 				// block's close marker — e.g. a client-only `@if` branch the server left empty).
 				// Build fresh but consume nothing: don't remove the close marker (it delimits the
@@ -4795,9 +4825,43 @@ export function htextSwap(posNode: Node | null, value: unknown): Text {
 // hydration path DCE-folds away for client-only builds.
 // ---------------------------------------------------------------------------
 
-/** True if `node` is a server block-open marker `<!--[-->`. */
+/**
+ * Decode a hydration range marker. Legacy `[` / `]` comments have
+ * multiplicity one; hydration-time range compaction writes `[N` / `]N` for
+ * N >= 2 exactly-coextensive logical ranges sharing one physical pair. The
+ * count is metadata — DOM navigation still treats the comment as ONE physical
+ * nesting level. Non-canonical payloads are ordinary user comments.
+ */
+function hydrationMarkerMultiplicity(data: string, open: boolean): number {
+	const marker = open ? HYDRATION_START : HYDRATION_END;
+	if (data === marker) return 1;
+	if (data.length < 2 || data.charCodeAt(0) !== marker.charCodeAt(0)) return 0;
+	// Canonical positive decimal: no signs, whitespace, zero, or leading zeroes.
+	const first = data.charCodeAt(1);
+	if (first < 49 || first > 57) return 0;
+	let value = first - 48;
+	for (let i = 2; i < data.length; i++) {
+		const digit = data.charCodeAt(i) - 48;
+		if (digit < 0 || digit > 9) return 0;
+		value = value * 10 + digit;
+		if (!Number.isSafeInteger(value)) return 0;
+	}
+	// Multiplicity one has exactly one canonical spelling: the legacy marker.
+	return value >= 2 ? value : 0;
+}
+
+/** True if `node` is a legacy or counted block-open marker. */
 function isBlockOpen(node: Node | null): node is Comment {
-	return node !== null && node.nodeType === 8 && (node as Comment).data === HYDRATION_START;
+	if (node === null || node.nodeType !== 8) return false;
+	const data = (node as Comment).data;
+	return data === HYDRATION_START || hydrationMarkerMultiplicity(data, true) > 1;
+}
+
+/** True if `node` is a legacy or counted block-close marker. */
+function isBlockClose(node: Node | null): node is Comment {
+	if (node === null || node.nodeType !== 8) return false;
+	const data = (node as Comment).data;
+	return data === HYDRATION_END || hydrationMarkerMultiplicity(data, false) > 1;
 }
 
 /**
@@ -4842,10 +4906,31 @@ function matchingClose(open: Node): Comment {
 	for (;;) {
 		if (node.nodeType === 8) {
 			const data = (node as Comment).data;
-			if (data === HYDRATION_END) {
-				if (depth === 0) return node as Comment;
+			let close = data === HYDRATION_END;
+			let nestedOpen = data === HYDRATION_START;
+			if (!close && !nestedOpen && data.length > 1) {
+				const first = data.charCodeAt(0);
+				if (first === HYDRATION_END.charCodeAt(0)) {
+					close = hydrationMarkerMultiplicity(data, false) > 1;
+				} else if (first === HYDRATION_START.charCodeAt(0)) {
+					nestedOpen = hydrationMarkerMultiplicity(data, true) > 1;
+				}
+			}
+			if (close) {
+				if (depth === 0) {
+					const found = node as Comment;
+					if (
+						hydrating &&
+						!hydrationHasAdjacentRangePair &&
+						isBlockOpen(open.previousSibling) &&
+						isBlockClose(found.nextSibling)
+					) {
+						hydrationHasAdjacentRangePair = true;
+					}
+					return found;
+				}
 				depth -= 1;
-			} else if (data === HYDRATION_START) {
+			} else if (nestedOpen) {
 				depth += 1;
 			}
 		}
@@ -7906,6 +7991,12 @@ export function createPortal(
 // `root.render(<App foo={next}/>)` updates props while keeping `type` identity.
 // ---------------------------------------------------------------------------
 const ELEMENT_TAG = Symbol.for('octane.element');
+// ElementDescriptor.key intentionally matches React's public shape (`null` for
+// both no key and a nullish key), so preserve compiler-visible key PRESENCE out
+// of band. This lets hydration keep an explicit `key={undefined}` as an
+// independent reconciliation boundary without adding an observable descriptor
+// field or penalizing unkeyed descriptors with extra object shape.
+const KEYED_ELEMENT_DESCRIPTORS = new WeakSet<object>();
 export interface ElementDescriptor<P = any> {
 	$$kind: typeof ELEMENT_TAG;
 	// A compiled ComponentBody (the fast/common case, e.g. `root.render(<App/>)`)
@@ -7973,7 +8064,15 @@ export function createElement<P>(
 		}
 		if (addChildren) p.children = kids;
 	}
-	return { $$kind: ELEMENT_TAG, type, props: p as P, key, children: kids ?? null };
+	const descriptor: ElementDescriptor<P> = {
+		$$kind: ELEMENT_TAG,
+		type,
+		props: p as P,
+		key,
+		children: kids ?? null,
+	};
+	if (stripKey) KEYED_ELEMENT_DESCRIPTORS.add(descriptor);
+	return descriptor;
 }
 function isElementDescriptor(v: any): v is ElementDescriptor {
 	return v != null && v.$$kind === ELEMENT_TAG;
@@ -8038,7 +8137,20 @@ export function cloneElement<P>(
 	// and never fold them into props (the de-opt reconciler owns them) — mirror createElement.
 	if (typeof element.type === 'function') props.children = kids;
 	else if ('children' in props) delete props.children;
-	return { $$kind: ELEMENT_TAG, type: element.type, props, key, children: kids ?? null };
+	const descriptor: ElementDescriptor<P> = {
+		$$kind: ELEMENT_TAG,
+		type: element.type,
+		props,
+		key,
+		children: kids ?? null,
+	};
+	if (
+		KEYED_ELEMENT_DESCRIPTORS.has(element) ||
+		(config != null && Object.prototype.hasOwnProperty.call(config, 'key'))
+	) {
+		KEYED_ELEMENT_DESCRIPTORS.add(descriptor);
+	}
+	return descriptor;
 }
 
 // Visit each leaf of `children` (flattening arrays), passing empties through as `null`.
@@ -8135,6 +8247,8 @@ interface CompSlot {
 	// `key=undefined` doesn't spuriously remount. Compared with Object.is so
 	// NaN keys are stable and 0 / -0 are distinguished.
 	prevKey: any;
+	/** The call site supplied `key=`, even when its current value is undefined. */
+	keyed: boolean;
 }
 
 const NO_KEY: unique symbol = Symbol('NO_KEY');
@@ -8169,6 +8283,9 @@ export function componentSlot(
 	// in the compiler stamps both sides from the same AST). Declined at
 	// runtime when the parent block has no coherent borrowable regime.
 	inherit?: boolean,
+	// Compiler call-site bit: unlike the key value, this distinguishes an
+	// explicit `key={undefined}` from an unkeyed call.
+	hasKey?: boolean,
 ): void {
 	const parentBlock = parentScope.block;
 	// A STRING comp: a dynamic JSX tag — `<props.parts.title>`, `<Tag/>` with
@@ -8284,10 +8401,12 @@ export function componentSlot(
 			block: null,
 			currentComp: null,
 			prevKey: NO_KEY,
+			keyed: hasKey === true || key !== undefined,
 		};
 		parentScope.slots[slotKey] = state;
 		registerSlot(parentScope, state);
 	}
+	if (hasKey === true || key !== undefined) state.keyed = true;
 	// Key-driven remount: when the compiler emitted a key arg AND its value
 	// changed since last render, force `comp !== state.currentComp` semantics
 	// even if the component identity is unchanged. Null out currentComp so the
@@ -8503,6 +8622,14 @@ interface ChildSlot {
 	 * marked regime; hydration never enters it (adoption wins at mount).
 	 */
 	ownerHost: Element | null;
+	/**
+	 * Hydration compaction: this slot's pair is borrowed from its sole-range
+	 * parent. Teardown may clear between the comments but must never remove the
+	 * comments themselves.
+	 */
+	borrowed: boolean;
+	/** Compiler proof that this renderable hole is the body's entire output. */
+	compactable: boolean;
 	block: Block | null;
 	text: Text | null;
 	currentComp: ComponentBody | null;
@@ -9357,6 +9484,8 @@ function deoptItemBody(item: any, scope: Scope): void {
 				start: block.startMarker as Comment,
 				end: block.endMarker as Comment,
 				ownerHost: null,
+				borrowed: true,
+				compactable: false,
 				block: null,
 				text: null,
 				currentComp: null,
@@ -9389,6 +9518,8 @@ function deoptItemBody(item: any, scope: Scope): void {
 				start: block.startMarker as Comment,
 				end: block.endMarker as Comment,
 				ownerHost: null,
+				borrowed: true,
+				compactable: false,
 				block: null,
 				text: null,
 				currentComp: null,
@@ -9793,6 +9924,9 @@ export function childSlot(
 	// element clears). De-opt hosts (hostElementBody/hostComponent) pass their
 	// element here; ignored under hydration (server-pair adoption wins).
 	ownsHost?: Element,
+	// Compiler proof that this renderable hole is the body's entire output.
+	// Used only by the post-hydration exact-range compactor.
+	compactable?: boolean,
 ): void {
 	const parentBlock = parentScope.block;
 	// A LONE PURE-HOST descriptor (host/text-only subtree — no components, no
@@ -9853,6 +9987,8 @@ export function childSlot(
 			start,
 			end,
 			ownerHost: (!hydrating ? (ownsHost ?? null) : null) as Element | null,
+			borrowed: false,
+			compactable: compactable === true,
 			block: null,
 			text: null,
 			currentComp: null,
@@ -9864,6 +10000,7 @@ export function childSlot(
 		parentScope.slots[slotKey] = state;
 		registerSlot(parentScope, state);
 	}
+	if (compactable === true) state.compactable = true;
 
 	// Consume the pure-host → blocks upgrade handoff: this is the upgraded
 	// block's owns-parent children slot (its FIRST render), and the element's
@@ -10175,15 +10312,22 @@ export function childSlot(
 				if (r.error) throw r.error;
 				throw new SuspenseException(r.suspended);
 			}
-			// Completed → commit: tear down old (sweeps state.start..state.end; the WIP sits
-			// OUTSIDE that range so it's untouched), then move the WIP into the slot range.
-			// Synchronous, so there is no painted blank between the two.
-			clearChildContent(state);
-			commitOffscreen(r.wip, state.end!);
-			state.block = r.wip.block;
-			state.currentComp = comp;
-			state.currentIsBodyFn = isBodyFn;
-			return;
+			if (state.borrowed) {
+				// The retained pair belongs to a coextensive parent range. Probe for
+				// suspension, discard, then use the in-place mount below; committing
+				// a nested WIP pair would split the compacted ownership graph.
+				disposeWip(r.wip);
+			} else {
+				// Completed → commit: tear down old (sweeps state.start..state.end; the WIP sits
+				// OUTSIDE that range so it's untouched), then move the WIP into the slot range.
+				// Synchronous, so there is no painted blank between the two.
+				clearChildContent(state);
+				commitOffscreen(r.wip, state.end!);
+				state.block = r.wip.block;
+				state.currentComp = comp;
+				state.currentIsBodyFn = isBodyFn;
+				return;
+			}
 		}
 		// PURE-HOST → BLOCKS UPGRADE (adopt, don't rebuild): the slot's last render
 		// was a raw pure-host tree (state.hostNode), and this render the SAME-TAG
@@ -10214,6 +10358,7 @@ export function childSlot(
 			state.currentComp = comp;
 			state.currentIsBodyFn = false;
 			const b = createBlock('dynamic', parentBlock, domParent, state.start, state.end, comp, props);
+			if (state.borrowed) b.exclusiveMarkers = true;
 			b.$$implicitBail = true;
 			b.memoInChain = true;
 			b.deoptNode = el;
@@ -10244,6 +10389,7 @@ export function childSlot(
 			domParent.insertBefore(state.start, state.end);
 		}
 		const b = createBlock('dynamic', parentBlock, domParent, state.start, state.end, comp, props);
+		if (state.borrowed) b.exclusiveMarkers = true;
 		// Arm React's implicit same-element bailout: value-position mounts are the
 		// sites that can receive a CACHED descriptor back (provider children, `.ts`
 		// binding trees, `return children` passthroughs), so their context reads
@@ -10315,10 +10461,11 @@ export function textSlot(
 	value: unknown,
 	anchor?: Node | null,
 	ownEnd?: boolean,
+	compactable?: boolean,
 ): void {
 	const vt = typeof value;
 	if (vt === 'object' || vt === 'function') {
-		childSlot(parentScope, slotKey, domParent, value, anchor, ownEnd);
+		childSlot(parentScope, slotKey, domParent, value, anchor, ownEnd, undefined, compactable);
 		return;
 	}
 	const state = parentScope.slots[slotKey] as ChildSlot | undefined;
@@ -10333,7 +10480,7 @@ export function textSlot(
 		// non-text content (block / array / host node / portal) — let the full
 		// classifier handle it (it also tears the outgoing mode down, e.g. a
 		// portal's foreign-target content).
-		childSlot(parentScope, slotKey, domParent, value, anchor, ownEnd);
+		childSlot(parentScope, slotKey, domParent, value, anchor, ownEnd, undefined, compactable);
 		return;
 	}
 	// Hot path: primitive into a text/empty slot (markerless single Text node).
@@ -10366,8 +10513,9 @@ export function textHole(
 	value: unknown,
 	anchor?: Node | null,
 	ownEnd?: boolean,
+	compactable?: boolean,
 ): Text | null {
-	childSlot(parentScope, slotKey, domParent, value, anchor, ownEnd);
+	childSlot(parentScope, slotKey, domParent, value, anchor, ownEnd, undefined, compactable);
 	const state = parentScope.slots[slotKey] as ChildSlot;
 	return state.block === null && state.forSlot === null && state.hostNode === null
 		? state.text
@@ -12270,6 +12418,8 @@ interface BranchSlot {
 	anchor: Node | null;
 	start: Comment | null;
 	end: Node | null;
+	/** Hydration compaction borrowed this slot's pair from its sole-range parent. */
+	borrowed: boolean;
 	branch: number;
 	block: Block | null;
 }
@@ -12384,29 +12534,44 @@ function renderBranchSlot(
 					if (r.error) throw r.error;
 					throw new SuspenseException(r.suspended);
 				}
-				r.wip.start.data = marker;
-				r.wip.end.data = '/' + marker;
-				// Tear down the old branch. A borrowed-marker branch (exclusiveMarkers=true)
-				// keeps oldStart/oldEnd; a self-marked branch removes its element. The wip
-				// pair was inserted after `probeAfter` (state.end/anchor) and stays put.
-				const oldStart = state.start;
-				const oldEnd = state.end;
-				unmountBlock(state.block);
-				// Orphaned old slot markers (borrowed regime) — nothing references them once
-				// the old block is dead; remove so only the adopted wip pair bounds the slot.
-				if (oldStart !== null) {
-					oldStart.remove();
-					(oldEnd as ChildNode | null)?.remove();
+				// A hydration-compacted branch borrows a pair that still belongs to
+				// its parent (and possibly several outer wrapper states). Probe for
+				// suspension off-screen, then discard and use the in-place path below;
+				// adopting the WIP pair would strand every outer owner on removed
+				// comments. This mirrors componentSlot's inherited transition path.
+				if (state.borrowed) {
+					disposeWip(r.wip);
+				} else {
+					r.wip.start.data = marker;
+					r.wip.end.data = '/' + marker;
+					// Tear down the old branch. A borrowed-marker branch (exclusiveMarkers=true)
+					// keeps oldStart/oldEnd; a self-marked branch removes its element. The wip
+					// pair was inserted after `probeAfter` (state.end/anchor) and stays put.
+					const oldStart = state.start;
+					const oldEnd = state.end;
+					unmountBlock(state.block);
+					// Orphaned old slot markers (borrowed regime) — nothing references them once
+					// the old block is dead; remove so only the adopted wip pair bounds the slot.
+					if (oldStart !== null) {
+						oldStart.remove();
+						(oldEnd as ChildNode | null)?.remove();
+					}
+					state.start = r.wip.start;
+					state.end = r.wip.end;
+					state.block = r.wip.block;
+					state.branch = next;
+					replaceSharedBlockBoundary(
+						parentBlock,
+						oldBlockStart,
+						oldBlockEnd,
+						r.wip.start,
+						r.wip.end,
+					);
+					// Adopted pair is now the slot's durable boundary (see NEXT-swap note above).
+					r.wip.block.exclusiveMarkers = true;
+					spliceWipCapture(r.wip);
+					return;
 				}
-				state.start = r.wip.start;
-				state.end = r.wip.end;
-				state.block = r.wip.block;
-				state.branch = next;
-				replaceSharedBlockBoundary(parentBlock, oldBlockStart, oldBlockEnd, r.wip.start, r.wip.end);
-				// Adopted pair is now the slot's durable boundary (see NEXT-swap note above).
-				r.wip.block.exclusiveMarkers = true;
-				spliceWipCapture(r.wip);
-				return;
 			}
 		}
 		// Position for the new branch: just after the current branch's trailing node,
@@ -12583,7 +12748,15 @@ export function ifBlock(
 			start = open;
 			end = matchingClose(open);
 		}
-		state = { __kind: 'ifBlockSlot', anchor: anchor ?? null, start, end, branch: -1, block: null };
+		state = {
+			__kind: 'ifBlockSlot',
+			anchor: anchor ?? null,
+			start,
+			end,
+			borrowed: false,
+			branch: -1,
+			block: null,
+		};
 		parentScope.slots[slotKey] = state;
 		registerSlot(parentScope, state);
 	}
@@ -12971,6 +13144,7 @@ export function switchBlock(
 			anchor: anchor ?? null,
 			start,
 			end,
+			borrowed: false,
 			branch: -1,
 			block: null,
 		};
@@ -14101,6 +14275,348 @@ function lis(arr: Int32Array): number[] {
 }
 
 // ---------------------------------------------------------------------------
+// Post-hydration exact-range compaction
+// ---------------------------------------------------------------------------
+
+type CoalescedRangeOwner = CompSlot | ChildSlot | BranchSlot;
+
+interface HydrationRangeGroup {
+	start: Comment;
+	end: Comment;
+	/** Number of logical hydration ranges represented by this physical pair. */
+	depth: number;
+	blocks: Block[];
+	liteScopes: Scope[];
+	owners: CoalescedRangeOwner[];
+}
+
+/** True when a compiled ref manifest contains a `<Fragment ref>` binding. */
+function scopeHasFragmentRef(scope: Scope): boolean {
+	const fields = scope.refFields;
+	if (fields === null) return false;
+	for (let i = 0; i < fields.length; i += 3) {
+		if (fields[i] === 'f') return true;
+	}
+	return false;
+}
+
+/**
+ * Collapse only ranges whose runtime ownership graph and DOM positions both
+ * prove they are exactly coextensive. SSR deliberately stays on the legacy
+ * explicit-pair protocol: hydration first adopts every range unambiguously,
+ * then this one-shot pass redirects inner owners to the retained outer pair and
+ * removes the redundant comments. Suspense/try, Activity, portals, and list
+ * outer ranges are traversal barriers; keyed item ranges remain independently
+ * movable, though wrapper-only descendants may compact inside each item pair.
+ */
+function coalesceHydratedRanges(
+	rootBlock: Block,
+	liteRanges: WeakMap<Scope, HydratedLiteRange>,
+): void {
+	const blockGroups = new WeakMap<Block, HydrationRangeGroup>();
+	const scopeGroups = new WeakMap<Scope, HydrationRangeGroup>();
+	const ownerGroups = new WeakMap<object, HydrationRangeGroup>();
+	const seenBlocks = new WeakSet<Block>();
+	const seenScopes = new WeakSet<Scope>();
+
+	function makeGroup(
+		startNode: Node | null,
+		endNode: Node | null,
+		block?: Block,
+		liteScope?: Scope,
+		owner?: CoalescedRangeOwner,
+	): HydrationRangeGroup | null {
+		if (!isBlockOpen(startNode) || !isBlockClose(endNode) || startNode === endNode) return null;
+		if (startNode.parentNode === null || startNode.parentNode !== endNode.parentNode) return null;
+		const openDepth = hydrationMarkerMultiplicity(startNode.data, true);
+		const closeDepth = hydrationMarkerMultiplicity(endNode.data, false);
+		if (openDepth === 0 || openDepth !== closeDepth) return null;
+		const group: HydrationRangeGroup = {
+			start: startNode,
+			end: endNode,
+			depth: openDepth,
+			blocks: block === undefined ? [] : [block],
+			liteScopes: liteScope === undefined ? [] : [liteScope],
+			owners: owner === undefined ? [] : [owner],
+		};
+		if (block !== undefined) blockGroups.set(block, group);
+		if (liteScope !== undefined) scopeGroups.set(liteScope, group);
+		if (owner !== undefined) ownerGroups.set(owner, group);
+		return group;
+	}
+
+	function appendUnique<T>(target: T[], source: T[]): void {
+		for (let i = 0; i < source.length; i++) {
+			if (target.indexOf(source[i]) === -1) target.push(source[i]);
+		}
+	}
+
+	function remapGroup(from: HydrationRangeGroup, to: HydrationRangeGroup): void {
+		for (let i = 0; i < from.blocks.length; i++) blockGroups.set(from.blocks[i], to);
+		for (let i = 0; i < from.liteScopes.length; i++) scopeGroups.set(from.liteScopes[i], to);
+		for (let i = 0; i < from.owners.length; i++) ownerGroups.set(from.owners[i], to);
+	}
+
+	function writeMultiplicity(group: HydrationRangeGroup): void {
+		group.start.data = group.depth === 1 ? HYDRATION_START : HYDRATION_START + String(group.depth);
+		group.end.data = group.depth === 1 ? HYDRATION_END : HYDRATION_END + String(group.depth);
+	}
+
+	/** Merge bookkeeping for two runtime owners that already share one pair. */
+	function unifySharedPair(
+		outer: HydrationRangeGroup,
+		inner: HydrationRangeGroup,
+	): HydrationRangeGroup {
+		if (outer === inner) return outer;
+		outer.depth = Math.max(outer.depth, inner.depth);
+		appendUnique(outer.blocks, inner.blocks);
+		appendUnique(outer.liteScopes, inner.liteScopes);
+		appendUnique(outer.owners, inner.owners);
+		remapGroup(inner, outer);
+		writeMultiplicity(outer);
+		return outer;
+	}
+
+	function rangesAreExactlyNested(outer: HydrationRangeGroup, inner: HydrationRangeGroup): boolean {
+		return (
+			outer.start.parentNode !== null &&
+			outer.start.parentNode === inner.start.parentNode &&
+			outer.end.parentNode === outer.start.parentNode &&
+			inner.end.parentNode === outer.start.parentNode &&
+			outer.start.nextSibling === inner.start &&
+			inner.end.nextSibling === outer.end
+		);
+	}
+
+	/** Redirect every inner runtime owner before removing its redundant pair. */
+	function borrowInnerRange(outer: HydrationRangeGroup, inner: HydrationRangeGroup): void {
+		for (let i = 0; i < inner.blocks.length; i++) {
+			const block = inner.blocks[i];
+			block.startMarker = outer.start;
+			block.endMarker = outer.end;
+			block.exclusiveMarkers = true;
+		}
+		for (let i = 0; i < inner.liteScopes.length; i++) {
+			inner.liteScopes[i].block.endMarker = outer.end;
+		}
+		for (let i = 0; i < inner.owners.length; i++) {
+			const owner = inner.owners[i];
+			owner.start = outer.start;
+			owner.end = outer.end;
+			if (owner.__kind === 'componentSlotSlot') {
+				owner.inherited = true;
+			} else if (owner.__kind === 'childSlot') {
+				owner.borrowed = true;
+				if (owner.forSlot !== null) {
+					owner.forSlot.start = outer.start;
+					owner.forSlot.end = outer.end;
+				}
+			} else {
+				owner.borrowed = true;
+			}
+		}
+	}
+
+	function mergeExactRanges(
+		outer: HydrationRangeGroup,
+		inner: HydrationRangeGroup,
+	): HydrationRangeGroup {
+		if (outer === inner) return outer;
+		if (outer.start === inner.start && outer.end === inner.end) {
+			return unifySharedPair(outer, inner);
+		}
+		if (!rangesAreExactlyNested(outer, inner)) return outer;
+		const mergedDepth = outer.depth + inner.depth;
+		// Both inputs were decoded as safe integers, but their sum may not be. Keep
+		// both physical pairs rather than minting metadata the protocol cannot parse.
+		if (!Number.isSafeInteger(mergedDepth)) return outer;
+		borrowInnerRange(outer, inner);
+		inner.start.remove();
+		inner.end.remove();
+		outer.depth = mergedDepth;
+		appendUnique(outer.blocks, inner.blocks);
+		appendUnique(outer.liteScopes, inner.liteScopes);
+		appendUnique(outer.owners, inner.owners);
+		remapGroup(inner, outer);
+		writeMultiplicity(outer);
+		return outer;
+	}
+
+	function attachOwner(group: HydrationRangeGroup | null, owner: CoalescedRangeOwner): void {
+		if (group === null) return;
+		if (group.owners.indexOf(owner) === -1) group.owners.push(owner);
+		ownerGroups.set(owner, group);
+	}
+
+	function isBoundaryComponent(owner: CompSlot): boolean {
+		return (
+			owner.currentComp === Suspense ||
+			owner.currentComp === ErrorBoundary ||
+			owner.currentComp === ViewTransition
+		);
+	}
+
+	function mayBorrowCandidate(value: any): boolean {
+		if (value === null || typeof value !== 'object') return false;
+		const kind = value.__kind;
+		if (kind === 'componentSlotSlot') {
+			const owner = value as CompSlot;
+			return (
+				owner.block !== null &&
+				!owner.keyed &&
+				!isBoundaryComponent(owner) &&
+				!scopeHasFragmentRef(owner.block)
+			);
+		}
+		if (kind === 'childSlot') {
+			const owner = value as ChildSlot;
+			return (
+				owner.block !== null &&
+				owner.forSlot === null &&
+				owner.portal === null &&
+				owner.currentComp !== Suspense &&
+				owner.currentComp !== ErrorBoundary &&
+				owner.currentComp !== ViewTransition &&
+				!scopeHasFragmentRef(owner.block)
+			);
+		}
+		if (kind === 'ifBlockSlot' || kind === 'switchBlockSlot') {
+			const owner = value as BranchSlot;
+			return owner.block === null || !scopeHasFragmentRef(owner.block);
+		}
+		return liteRanges.has(value as Scope) && !scopeHasFragmentRef(value as Scope);
+	}
+
+	function mappedGroup(value: any): HydrationRangeGroup | undefined {
+		if (value === null || typeof value !== 'object') return undefined;
+		return ownerGroups.get(value) ?? scopeGroups.get(value as Scope);
+	}
+
+	/**
+	 * A packed one-entry scope is the runtime proof for a sole output range.
+	 * Template pass-through holes also carry a compiler proof because slot 0 is
+	 * their binding bag; no DOM-only inference is made for arbitrary empty holes.
+	 */
+	function soleRangeCandidate(scope: Scope): HydrationRangeGroup | null {
+		let only: any = undefined;
+		let count = 0;
+		const slots = scope.slots;
+		for (let i = 0; i < slots.length; i++) {
+			if (slots[i] === undefined) continue;
+			only = slots[i];
+			count++;
+			if (count > 1) break;
+		}
+		if (count === 1 && mayBorrowCandidate(only)) {
+			const group = mappedGroup(only);
+			if (group !== undefined) return group;
+		}
+
+		const registered = scope._slots;
+		if (
+			registered !== null &&
+			registered.length === 1 &&
+			scope.children.length === 0 &&
+			registered[0].__kind === 'childSlot' &&
+			(registered[0] as ChildSlot).compactable &&
+			mayBorrowCandidate(registered[0])
+		) {
+			return ownerGroups.get(registered[0]) ?? null;
+		}
+		return null;
+	}
+
+	function compactScopeRange(scope: Scope, own: HydrationRangeGroup | null): void {
+		visitScopeContents(scope);
+		if (own === null || scopeHasFragmentRef(scope)) return;
+		const candidate = soleRangeCandidate(scope);
+		if (candidate !== null) mergeExactRanges(own, candidate);
+	}
+
+	function visitBlock(block: Block, owner?: CoalescedRangeOwner): HydrationRangeGroup | null {
+		if (seenBlocks.has(block)) {
+			const existing = blockGroups.get(block) ?? null;
+			if (owner !== undefined) attachOwner(existing, owner);
+			return existing;
+		}
+		seenBlocks.add(block);
+		const own = makeGroup(block.startMarker, block.endMarker, block, undefined, owner);
+		compactScopeRange(block, own);
+		return blockGroups.get(block) ?? own;
+	}
+
+	function visitNestedScope(scope: Scope): HydrationRangeGroup | null {
+		if (seenScopes.has(scope)) return scopeGroups.get(scope) ?? null;
+		seenScopes.add(scope);
+		const range = liteRanges.get(scope);
+		const own =
+			range === undefined ? null : makeGroup(range.start, range.end, undefined, scope, undefined);
+		compactScopeRange(scope, own);
+		return scopeGroups.get(scope) ?? own;
+	}
+
+	function visitForSlot(state: ForSlot): void {
+		for (let block = state.head; block !== null; block = block.nextSibling) visitBlock(block);
+		if (state.emptyBlock !== null) visitBlock(state.emptyBlock);
+	}
+
+	function visitBranchSlot(state: BranchSlot): void {
+		const inner = state.block === null ? null : visitBlock(state.block);
+		const outer = makeGroup(state.start, state.end, undefined, undefined, state);
+		if (outer !== null && inner !== null && !scopeHasFragmentRef(state.block!)) {
+			mergeExactRanges(outer, inner);
+		}
+	}
+
+	function visitSlot(state: any): void {
+		const kind = state.__kind;
+		if (kind === 'componentSlotSlot') {
+			if (state.block !== null) visitBlock(state.block, state as CompSlot);
+			return;
+		}
+		if (kind === 'childSlot') {
+			const child = state as ChildSlot;
+			if (child.block !== null) visitBlock(child.block, child);
+			if (child.forSlot !== null) visitForSlot(child.forSlot);
+			if (child.portal?.block != null) visitBlock(child.portal.block);
+			return;
+		}
+		if (kind === 'ifBlockSlot' || kind === 'switchBlockSlot') {
+			visitBranchSlot(state as BranchSlot);
+			return;
+		}
+		if (kind === 'forBlockSlot') {
+			visitForSlot(state as ForSlot);
+			return;
+		}
+		if (kind === 'trySlotSlot') {
+			const visible = state.block as Block | null;
+			const persistent = state.tryBlock as Block | null;
+			if (visible !== null) visitBlock(visible);
+			if (persistent !== null && persistent !== visible) visitBlock(persistent);
+			return;
+		}
+		if (kind === 'activityBlockSlot' || kind === 'portalSlotSlot') {
+			if (state.block !== null) visitBlock(state.block);
+			return;
+		}
+		// Internal host-children scopes may carry a markerless Block. Traverse it
+		// for descendants, but never expose the wrapper itself as a candidate.
+		if (state.block != null) visitBlock(state.block);
+	}
+
+	function visitScopeContents(scope: Scope): void {
+		const children = scope.children;
+		for (let i = 0; i < children.length; i++) visitNestedScope(children[i].scope);
+		const registered = scope._slots;
+		if (registered === null) return;
+		for (let i = 0; i < registered.length; i++) visitSlot(registered[i]);
+	}
+
+	visitBlock(rootBlock);
+}
+
+// ---------------------------------------------------------------------------
 // Public root API — React-DOM parity
 // ---------------------------------------------------------------------------
 
@@ -14276,7 +14792,12 @@ export function hydrateRoot(
 		next: 0,
 	};
 	rootBlock.idState = idState;
+	hydrationHasAdjacentRangePair = false;
 	hydrating = true;
+	const liteRanges = new WeakMap<Scope, HydratedLiteRange>();
+	hydratedLiteRanges = liteRanges;
+	let hydrationCompleted = false;
+	let shouldCoalesceRanges = false;
 	// The root-local counter starts at zero, matching the server render carrying
 	// the same identifierPrefix. Other roots cannot perturb hydration ordering.
 	// Adopt server-serialized use(thenable) values, if any: pull them out of the
@@ -14306,12 +14827,17 @@ export function hydrateRoot(
 	hydrateNode = firstNode;
 	try {
 		renderBlock(rootBlock);
+		hydrationCompleted = true;
+		shouldCoalesceRanges = hydrationHasAdjacentRangePair;
 	} finally {
 		hydrating = false;
+		hydrationHasAdjacentRangePair = false;
 		hydrateNode = null;
 		hydrationSeeds = null;
 		hydrationSeedCursor = 0;
+		hydratedLiteRanges = null;
 	}
+	if (hydrationCompleted && shouldCoalesceRanges) coalesceHydratedRanges(rootBlock, liteRanges);
 	// Commit effects on the next microtask flush (same as createRoot's first render).
 	if (!syncFlush && !scheduled) {
 		scheduled = true;

--- a/packages/octane/tests/benchmark-dom-census.test.ts
+++ b/packages/octane/tests/benchmark-dom-census.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { censusDomNodes } from '../../../benchmarks/lib/dom-nodes.mjs';
+
+describe('benchmark DOM census — counted hydration markers', () => {
+	it('counts legacy and N >= 2 forms while ignoring numeric multiplicity one', () => {
+		const root = document.createElement('div');
+		root.id = 'marker-census';
+		document.body.appendChild(root);
+		try {
+			for (const data of ['[', ']', '[2', ']2', '[1', ']1']) {
+				root.appendChild(document.createComment(data));
+			}
+			const census = censusDomNodes('#marker-census');
+			expect(census.hydrationMarkersPhysical).toBe(4);
+			expect(census.hydrationMarkersLogical).toBe(6);
+			expect(census.hydrationMarkersCounted).toBe(2);
+			expect(census.hydrationMarkerMaxMultiplicity).toBe(2);
+		} finally {
+			root.remove();
+		}
+	});
+});

--- a/packages/octane/tests/conformance/ssr-serialization.test.ts
+++ b/packages/octane/tests/conformance/ssr-serialization.test.ts
@@ -215,11 +215,22 @@ function hydrate(name: string, props?: any) {
 	return { html, before, after: container.innerHTML };
 }
 
-// Assert the case hydrates as a pure adoption: byte-stable DOM, no mismatch warns.
+// Expand counted post-hydration markers back to their logically equivalent
+// legacy wire representation. This preserves the old byte-stability assertion
+// without requiring redundant physical Comment nodes to survive adoption.
+const expandCountedHydrationMarkers = (html: string) =>
+	html.replace(/<!--([\[\]])([1-9]\d*)-->/g, (whole, marker: string, raw: string) => {
+		const multiplicity = Number(raw);
+		if (!Number.isSafeInteger(multiplicity) || multiplicity < 2) return whole;
+		return `<!--${marker}-->`.repeat(multiplicity);
+	});
+
+// Assert the case hydrates as a pure adoption: logically byte-stable DOM and no
+// mismatch warnings. Counted marker pairs expand to the exact server protocol.
 function expectCleanHydrate(name: string, props?: any) {
 	const r = hydrate(name, props);
 	expect(warns()).toEqual([]);
-	expect(r.after).toBe(r.before);
+	expect(expandCountedHydrationMarkers(r.after)).toBe(r.before);
 	return r;
 }
 
@@ -533,17 +544,17 @@ describe('conformance: SSR serialization — component hierarchies (Elements)', 
 		expectCleanHydrate('SingleHier');
 	});
 
-	// Nested `{children}` component chains hydrate byte-stably: the server emits
+	// Nested `{children}` component chains hydrate protocol-stably: the server emits
 	// one `<!--[-->…<!--]-->` range per layer (children-fn block AND nested
 	// component block), the client childSlot/componentSlot/componentSlotLite each
 	// adopt their own range, and every slot advances the hydration cursor past
-	// its adopted close marker so SIBLING slots (MultiHier) adopt the right range
-	// instead of re-adopting a previous sibling's root.
-	it('hydrates component hierarchies byte-stably (Per :657/:677)', () => {
+	// its adopted close marker so SIBLING slots (MultiHier) adopt the right range.
+	// Exactly-coextensive pairs may then share a counted physical pair.
+	it('hydrates component hierarchies with logical protocol stability (Per :657/:677)', () => {
 		const one = hydrate('SingleHier');
-		expect(one.after).toBe(one.before);
+		expect(expandCountedHydrationMarkers(one.after)).toBe(one.before);
 		const multi = hydrate('MultiHier');
-		expect(multi.after).toBe(multi.before);
+		expect(expandCountedHydrationMarkers(multi.after)).toBe(multi.before);
 	});
 
 	it('renders multi-child hierarchies of components (Per :677)', () => {

--- a/packages/octane/tests/hydration/_fixtures/coalesced-fragment-barrier.tsrx
+++ b/packages/octane/tests/hydration/_fixtures/coalesced-fragment-barrier.tsrx
@@ -1,0 +1,15 @@
+import { Fragment } from 'octane';
+
+function FragmentLeaf(props: { fragmentRef: { current: unknown } }) @{
+	<Fragment ref={props.fragmentRef}>
+		<button class="fragment-barrier-button">fragment</button>
+	</Fragment>
+}
+
+function FragmentMiddle(props: { fragmentRef: { current: unknown } }) {
+	return <FragmentLeaf fragmentRef={props.fragmentRef} />;
+}
+
+export function FragmentBarrier(props: { fragmentRef: { current: unknown } }) {
+	return <FragmentMiddle fragmentRef={props.fragmentRef} />;
+}

--- a/packages/octane/tests/hydration/_fixtures/coalesced-markers.tsrx
+++ b/packages/octane/tests/hydration/_fixtures/coalesced-markers.tsrx
@@ -1,0 +1,116 @@
+import { Suspense, useState } from 'octane';
+
+// Plain return-JSX wrappers intentionally do not receive the compiler's M3
+// sole-`@{}` inheritance stamp. SSR therefore emits one logical component
+// range per layer. Those ranges are exactly coextensive and are the canonical
+// hydration-time coalescing case.
+function InteractiveLeaf(props: { label: string; className: string }) {
+	const [count, setCount] = useState(0);
+	return <button class={props.className} onClick={() => setCount(count + 1)}>
+		{props.label + ':' + count}
+	</button>;
+}
+
+function InteractiveMiddle(props: { label: string; className: string }) {
+	return <InteractiveLeaf label={props.label} className={props.className} />;
+}
+
+function InteractiveOuter(props: { label: string; className: string }) {
+	return <InteractiveMiddle label={props.label} className={props.className} />;
+}
+
+// SafeFragment-style template pass-through. Its binding bag contains a sole
+// renderable-hole slot, so the compiler supplies the additional proof needed
+// for that slot to join an exactly coextensive hydrated range group.
+function PassThrough(props: { children?: unknown }) @{
+	<>
+		{props.children}
+	</>
+}
+
+export function WrapperChain() @{
+	<section class="wrapper-chain">
+		<PassThrough>
+			<InteractiveOuter label="wrapped" className="wrapper-button" />
+		</PassThrough>
+	</section>
+}
+
+function KeyedReturnMiddle(props: { itemKey?: string }) {
+	return <InteractiveLeaf key={props.itemKey} label="keyed" className="keyed-return-button" />;
+}
+
+export function KeyedReturnWrapper(props: { itemKey?: string }) {
+	return <KeyedReturnMiddle itemKey={props.itemKey} />;
+}
+
+function BranchLeaf(props: { count: number; onClick: () => void }) {
+	return <button class="branch-button" onClick={props.onClick}>
+		{'branch:' + props.count}
+	</button>;
+}
+
+function BranchMiddle(props: { count: number; onClick: () => void }) {
+	return <BranchLeaf count={props.count} onClick={props.onClick} />;
+}
+
+export function SwappingBranch(props: { active: boolean }) @{
+	const [count, setCount] = useState(0);
+	<section class="swapping-branch">
+		@if (props.active) {
+			<BranchMiddle count={count} onClick={() => setCount(count + 1)} />
+		} @else {
+			<p class="branch-off">off</p>
+		}
+	</section>
+}
+
+type Row = { id: string };
+
+function StatefulRow(props: { row: Row }) {
+	const [count, setCount] = useState(0);
+	return <li class="coalesced-row" data-id={props.row.id}>
+		<button class="row-button" onClick={() => setCount(count + 1)}>
+			{props.row.id + ':' + count}
+		</button>
+	</li>;
+}
+
+function RowWrapper(props: { row: Row }) {
+	return <StatefulRow row={props.row} />;
+}
+
+export function KeyedWrapperList(props: { rows: Row[] }) @{
+	<ul class="coalesced-list">
+		@for (const row of props.rows; key row.id) {
+			<RowWrapper row={row} />
+		}
+	</ul>
+}
+
+export function SuspenseWrapperChain() @{
+	<section class="suspense-wrapper-chain">
+		<Suspense fallback={<i class="pending">pending</i>}>
+			<PassThrough>
+				<InteractiveOuter label="ready" className="suspense-button" />
+			</PassThrough>
+		</Suspense>
+	</section>
+}
+
+// A plain return-based component hands this Suspense descriptor back to
+// renderBlock, whose return slot routes it through childSlot. Keeping the
+// builtin out of the component's direct template is important to this case.
+function ReturnedSuspenseValue() {
+	return <Suspense fallback={<i class="returned-pending">pending</i>}>
+		<PassThrough>
+			<InteractiveOuter label="returned" className="returned-suspense-button" />
+		</PassThrough>
+	</Suspense>;
+}
+
+export function ReturnedSuspenseChildSlot() @{
+	<section class="returned-suspense-child-slot">
+		<ReturnedSuspenseValue />
+	</section>
+}

--- a/packages/octane/tests/hydration/_marker-summary.ts
+++ b/packages/octane/tests/hydration/_marker-summary.ts
@@ -1,0 +1,56 @@
+type ProtocolMarker = {
+	data: string;
+	kind: 'open' | 'close';
+	multiplicity: number;
+};
+
+function protocolMarker(data: string): ProtocolMarker | null {
+	if (data === '[') return { data, kind: 'open', multiplicity: 1 };
+	if (data === ']') return { data, kind: 'close', multiplicity: 1 };
+	const match = /^(\[|\])([1-9]\d*)$/.exec(data);
+	if (match === null) return null;
+	const multiplicity = Number(match[2]);
+	if (!Number.isSafeInteger(multiplicity) || multiplicity < 2) return null;
+	return {
+		data,
+		kind: match[1] === '[' ? 'open' : 'close',
+		multiplicity,
+	};
+}
+
+/** Summarize legacy and counted hydration comments while validating balance. */
+export function hydrationMarkerSummary(root: Node) {
+	const walker = document.createTreeWalker(root, NodeFilter.SHOW_COMMENT);
+	const markers: ProtocolMarker[] = [];
+	let node: Node | null;
+	while ((node = walker.nextNode()) !== null) {
+		const marker = protocolMarker((node as Comment).data);
+		if (marker !== null) markers.push(marker);
+	}
+
+	let logicalPairs = 0;
+	const stack: number[] = [];
+	for (const marker of markers) {
+		if (marker.kind === 'open') {
+			stack.push(marker.multiplicity);
+			logicalPairs += marker.multiplicity;
+			continue;
+		}
+		const openMultiplicity = stack.pop();
+		if (openMultiplicity !== marker.multiplicity) {
+			throw new Error(
+				`Unbalanced hydration marker ${marker.data}; matching open multiplicity was ${String(openMultiplicity)}`,
+			);
+		}
+	}
+	if (stack.length !== 0) throw new Error('Unclosed hydration marker');
+
+	const opens = markers.filter((marker) => marker.kind === 'open');
+	return {
+		data: markers.map((marker) => marker.data),
+		logicalPairs,
+		physicalPairs: opens.length,
+		countedPairs: opens.filter((marker) => marker.multiplicity > 1).length,
+		singletonPairs: opens.filter((marker) => marker.multiplicity === 1).length,
+	};
+}

--- a/packages/octane/tests/hydration/coalesced-markers.test.ts
+++ b/packages/octane/tests/hydration/coalesced-markers.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { compile } from 'octane/compiler';
+import { hydrateRoot, flushSync } from '../../src/index.js';
+import * as ServerRT from 'octane/server';
+import {
+	KeyedReturnWrapper,
+	KeyedWrapperList,
+	ReturnedSuspenseChildSlot,
+	SuspenseWrapperChain,
+	SwappingBranch,
+	WrapperChain,
+} from './_fixtures/coalesced-markers.tsrx';
+import { FragmentBarrier } from './_fixtures/coalesced-fragment-barrier.tsrx';
+import { hydrationMarkerSummary } from './_marker-summary.js';
+
+const FIXTURE = join(
+	process.cwd(),
+	'packages/octane/tests/hydration/_fixtures/coalesced-markers.tsrx',
+);
+
+function serverModule(): Record<string, any> {
+	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'coalesced-markers.tsrx', {
+		mode: 'server',
+	});
+	code = code.replace(
+		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
+	);
+	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
+	return new Function('__rt', '__exports', code + '\nreturn __exports;')(ServerRT, {});
+}
+
+const server = serverModule();
+
+function renderServer(name: string, props: any): string {
+	return ServerRT.renderToString(server[name], props).html;
+}
+
+let container: HTMLElement;
+beforeEach(() => {
+	container = document.createElement('div');
+	document.body.appendChild(container);
+});
+afterEach(() => container.remove());
+
+describe('hydrateRoot — coalesced counted hydration ranges', () => {
+	it('coalesces sole-output wrappers while retaining logical depth and adopted state', () => {
+		container.innerHTML = renderServer('WrapperChain', {});
+		const section = container.querySelector('.wrapper-chain')!;
+		const serverButton = section.querySelector('.wrapper-button') as HTMLButtonElement;
+		const before = hydrationMarkerSummary(section);
+		expect(before.logicalPairs).toBeGreaterThan(1);
+		expect(before.physicalPairs).toBe(before.logicalPairs);
+
+		const root = hydrateRoot(container, WrapperChain, {});
+		const after = hydrationMarkerSummary(section);
+		expect(after.logicalPairs).toBe(before.logicalPairs);
+		expect(after.physicalPairs).toBe(1);
+		expect(after.data).toEqual(['[' + before.logicalPairs, ']' + before.logicalPairs]);
+		expect(section.querySelector('.wrapper-button')).toBe(serverButton);
+
+		flushSync(() => serverButton.click());
+		expect(section.querySelector('.wrapper-button')).toBe(serverButton);
+		expect(serverButton.textContent).toBe('wrapped:1');
+		expect(hydrationMarkerSummary(section)).toEqual(after);
+		root.unmount();
+	});
+
+	it('materializes a shared branch range safely when the active arm swaps', () => {
+		container.innerHTML = renderServer('SwappingBranch', { active: true });
+		const section = container.querySelector('.swapping-branch')!;
+		const serverButton = section.querySelector('.branch-button') as HTMLButtonElement;
+		const before = hydrationMarkerSummary(section);
+
+		const root = hydrateRoot(container, SwappingBranch, { active: true });
+		const after = hydrationMarkerSummary(section);
+		expect(after.logicalPairs).toBe(before.logicalPairs);
+		expect(after.physicalPairs).toBe(1);
+		expect(after.countedPairs).toBe(1);
+		expect(section.querySelector('.branch-button')).toBe(serverButton);
+
+		flushSync(() => serverButton.click());
+		expect(serverButton.textContent).toBe('branch:1');
+		flushSync(() => root.render(SwappingBranch, { active: false }));
+		expect(section.querySelector('.branch-button')).toBeNull();
+		expect(section.querySelector('.branch-off')?.textContent).toBe('off');
+		expect(serverButton.isConnected).toBe(false);
+
+		flushSync(() => root.render(SwappingBranch, { active: true }));
+		const replacement = section.querySelector('.branch-button') as HTMLButtonElement;
+		expect(replacement).not.toBe(serverButton);
+		expect(replacement.textContent).toBe('branch:1');
+		flushSync(() => replacement.click());
+		expect(replacement.textContent).toBe('branch:2');
+		root.unmount();
+	});
+
+	it('keeps return-position key ownership when its current value is undefined', () => {
+		container.innerHTML = renderServer('KeyedReturnWrapper', { itemKey: undefined });
+		const serverButton = container.querySelector('.keyed-return-button');
+		const before = hydrationMarkerSummary(container);
+		expect(before.logicalPairs).toBeGreaterThan(1);
+
+		const root = hydrateRoot(container, KeyedReturnWrapper, { itemKey: undefined });
+		const after = hydrationMarkerSummary(container);
+		expect(after.logicalPairs).toBe(before.logicalPairs);
+		expect(after.physicalPairs).toBe(before.physicalPairs);
+		expect(after.countedPairs).toBe(0);
+		expect(container.querySelector('.keyed-return-button')).toBe(serverButton);
+		root.unmount();
+	});
+
+	it('keeps keyed item ownership independent while compacting wrapper descendants', () => {
+		const rows = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+		container.innerHTML = renderServer('KeyedWrapperList', { rows });
+		const list = container.querySelector('.coalesced-list')!;
+		const serverRows = new Map(
+			[...list.querySelectorAll<HTMLElement>('.coalesced-row')].map((row) => [row.dataset.id, row]),
+		);
+		const before = hydrationMarkerSummary(list);
+
+		const root = hydrateRoot(container, KeyedWrapperList, { rows });
+		const after = hydrationMarkerSummary(list);
+		expect(after.logicalPairs).toBe(before.logicalPairs);
+		// Each keyed item keeps one distinct physical ownership pair. Its counted
+		// payload also records the coextensive descendant wrappers; no pair is
+		// shared across items or with the outer @for range.
+		expect(after.countedPairs).toBe(rows.length);
+		expect(after.singletonPairs).toBe(1);
+		expect(after.physicalPairs).toBe(rows.length + 1);
+		for (const row of rows) {
+			expect(list.querySelector(`[data-id="${row.id}"]`)).toBe(serverRows.get(row.id));
+		}
+
+		const bButton = serverRows.get('b')!.querySelector('.row-button') as HTMLButtonElement;
+		flushSync(() => bButton.click());
+		expect(bButton.textContent).toBe('b:1');
+
+		const reordered = [rows[2], rows[1], rows[0]];
+		flushSync(() => root.render(KeyedWrapperList, { rows: reordered }));
+		expect([...list.querySelectorAll('.coalesced-row')]).toEqual([
+			serverRows.get('c'),
+			serverRows.get('b'),
+			serverRows.get('a'),
+		]);
+		expect(bButton.textContent).toBe('b:1');
+		expect(hydrationMarkerSummary(list)).toEqual(after);
+		root.unmount();
+	});
+
+	it('retains an independent physical Suspense boundary around a compact descendant chain', () => {
+		container.innerHTML = renderServer('SuspenseWrapperChain', {});
+		const section = container.querySelector('.suspense-wrapper-chain')!;
+		const serverButton = section.querySelector('.suspense-button');
+		const before = hydrationMarkerSummary(section);
+
+		const root = hydrateRoot(container, SuspenseWrapperChain, {});
+		const after = hydrationMarkerSummary(section);
+		expect(after.logicalPairs).toBe(before.logicalPairs);
+		expect(after.countedPairs).toBeGreaterThanOrEqual(1);
+		expect(after.physicalPairs).toBeLessThan(after.logicalPairs);
+		// The whole coextensive-looking run must not become a single counted
+		// pair: Suspense/try bookkeeping needs its own movable physical range.
+		expect(after.physicalPairs).toBeGreaterThan(1);
+		expect(after.singletonPairs).toBeGreaterThanOrEqual(1);
+		expect(section.querySelector('.suspense-button')).toBe(serverButton);
+		root.unmount();
+	});
+
+	it('keeps a returned value-position Suspense builtin as a physical childSlot barrier', () => {
+		container.innerHTML = renderServer('ReturnedSuspenseChildSlot', {});
+		const section = container.querySelector('.returned-suspense-child-slot')!;
+		const serverButton = section.querySelector('.returned-suspense-button') as HTMLButtonElement;
+		const before = hydrationMarkerSummary(section);
+		expect(before.physicalPairs).toBe(before.logicalPairs);
+
+		const root = hydrateRoot(container, ReturnedSuspenseChildSlot, {});
+		const after = hydrationMarkerSummary(section);
+		expect(after.logicalPairs).toBe(before.logicalPairs);
+		expect(after.physicalPairs).toBeLessThan(after.logicalPairs);
+		// The returned descriptor is classified by childSlot. Even though its
+		// ranges are exactly coextensive, Suspense must retain an independent
+		// singleton pair around the compactable descendant ownership chain.
+		expect(after.countedPairs).toBeGreaterThanOrEqual(1);
+		expect(after.singletonPairs).toBeGreaterThanOrEqual(1);
+		expect(after.physicalPairs).toBeGreaterThan(1);
+		expect(section.querySelector('.returned-suspense-button')).toBe(serverButton);
+		expect(section.querySelector('.returned-pending')).toBeNull();
+
+		flushSync(() => serverButton.click());
+		expect(section.querySelector('.returned-suspense-button')).toBe(serverButton);
+		expect(serverButton.textContent).toBe('returned:1');
+		expect(hydrationMarkerSummary(section)).toEqual(after);
+		root.unmount();
+	});
+
+	it('keeps a fragment-ref-bearing component frame as an independent range', () => {
+		// Fragment refs are intentionally unsupported by server compilation today,
+		// so spell the byte-equivalent hydratable shape explicitly: the two return-
+		// component frames surround the persistent <!--frag--> template markers.
+		container.innerHTML =
+			'<!--[--><!--[--><!--frag-->' +
+			'<button class="fragment-barrier-button">fragment</button>' +
+			'<!--/frag--><!--]--><!--]-->';
+		const serverButton = container.querySelector('.fragment-barrier-button');
+		const fragmentRef: { current: unknown } = { current: null };
+
+		const root = hydrateRoot(container, FragmentBarrier, { fragmentRef });
+		flushSync(() => {});
+		const after = hydrationMarkerSummary(container);
+		expect(after.physicalPairs).toBe(2);
+		expect(after.countedPairs).toBe(0);
+		expect(container.querySelector('.fragment-barrier-button')).toBe(serverButton);
+		expect(fragmentRef.current).not.toBeNull();
+		root.unmount();
+	});
+
+	it('keeps both pairs when their combined multiplicity would exceed a safe integer', () => {
+		container.innerHTML = renderServer('WrapperChain', {});
+		const section = container.querySelector('.wrapper-chain')!;
+		const markers = Array.from(section.childNodes).filter(
+			(node): node is Comment => node.nodeType === Node.COMMENT_NODE,
+		);
+		expect(markers.length).toBeGreaterThan(2);
+		const max = String(Number.MAX_SAFE_INTEGER);
+		markers[0].data = '[' + max;
+		markers[markers.length - 1].data = ']' + max;
+
+		const root = hydrateRoot(container, WrapperChain, {});
+		const after = Array.from(section.childNodes).filter(
+			(node): node is Comment => node.nodeType === Node.COMMENT_NODE,
+		);
+		// The inner wrapper run may compact among itself, but it must not be folded
+		// into MAX_SAFE_INTEGER and produce an unparseable `[9007199254740992`.
+		expect(after).toHaveLength(4);
+		expect(after[0]).toBe(markers[0]);
+		expect(after[0].data).toBe('[' + max);
+		expect(after[after.length - 1]).toBe(markers[markers.length - 1]);
+		expect(after[after.length - 1].data).toBe(']' + max);
+		root.unmount();
+	});
+
+	it('uses the legacy spelling as the only canonical multiplicity-one marker', () => {
+		const probe = document.createElement('div');
+		for (const data of ['[1', ']1', '[', ']', '[2', ']2']) {
+			probe.appendChild(document.createComment(data));
+		}
+		expect(hydrationMarkerSummary(probe).data).toEqual(['[', ']', '[2', ']2']);
+	});
+});

--- a/packages/octane/tests/hydration/mismatch-structural.test.ts
+++ b/packages/octane/tests/hydration/mismatch-structural.test.ts
@@ -5,6 +5,7 @@ import { compile } from 'octane/compiler';
 import * as ClientRT from '../../src/index.js';
 import { hydrateRoot, flushSync } from '../../src/index.js';
 import * as ServerRT from 'octane/server';
+import { hydrationMarkerSummary } from './_marker-summary.js';
 
 // P3 — STRUCTURAL hydration mismatch: the server DOM's SHAPE differs from what the client
 // renders (a swapped @if/@switch branch, a changed tag, a different @for list length). The
@@ -200,24 +201,40 @@ describe('hydrateRoot — STRUCTURAL mismatch (detect + rebuild + cursor stays a
 		expect(warns()).toEqual([]); // prod: recovery without the dev warning
 	});
 
-	it('PROD build: matching branch adopts unchanged (structural check has no false positives)', async () => {
+	it('PROD build: matching branch adopts hosts without a false-positive mismatch', async () => {
 		const clientProd = prodClientModule(CONTROL, 'control.tsrx');
 		const { html } = await ServerRT.renderToString(server.Toggle, { on: true });
 		container.innerHTML = html;
-		const before = container.innerHTML;
+		const toggle = container.querySelector('#toggle')!;
+		const button = container.querySelector('#hit')!;
+		const before = hydrationMarkerSummary(toggle);
 		hydrateRoot(container, clientProd.Toggle, { on: true });
 		flushSync(() => {});
-		expect(container.innerHTML).toBe(before);
+		expect(container.querySelector('#toggle')).toBe(toggle);
+		expect(container.querySelector('#hit')).toBe(button);
+		expect(button.textContent).toBe('on:0');
+		const after = hydrationMarkerSummary(toggle);
+		expect(after.logicalPairs).toBe(before.logicalPairs);
+		expect(after.physicalPairs).toBeLessThan(before.physicalPairs);
+		expect(after.countedPairs).toBe(1);
 		expect(warns()).toEqual([]);
 	});
 
-	it('no warning + adopted unchanged when the branch matches', async () => {
+	it('no warning + adopted hosts when the branch matches', async () => {
 		const { html } = await ServerRT.renderToString(server.Toggle, { on: true });
 		container.innerHTML = html;
-		const before = container.innerHTML;
+		const toggle = container.querySelector('#toggle')!;
+		const button = container.querySelector('#hit')!;
+		const before = hydrationMarkerSummary(toggle);
 		hydrateRoot(container, clientDev.Toggle, { on: true });
 		flushSync(() => {});
-		expect(container.innerHTML).toBe(before);
+		expect(container.querySelector('#toggle')).toBe(toggle);
+		expect(container.querySelector('#hit')).toBe(button);
+		expect(button.textContent).toBe('on:0');
+		const after = hydrationMarkerSummary(toggle);
+		expect(after.logicalPairs).toBe(before.logicalPairs);
+		expect(after.physicalPairs).toBeLessThan(before.physicalPairs);
+		expect(after.countedPairs).toBe(1);
 		expect(warns()).toEqual([]);
 	});
 

--- a/packages/octane/tests/hydration/provider-ssr-hydrate.test.ts
+++ b/packages/octane/tests/hydration/provider-ssr-hydrate.test.ts
@@ -6,6 +6,7 @@ import { hydrateRoot, flushSync } from '../../src/index.js';
 import * as ServerRT from 'octane/server';
 import { App } from '../_fixtures/ssr-provider.tsx';
 import { ProviderApp } from '../_fixtures/jsx-context-children.tsx';
+import { hydrationMarkerSummary } from './_marker-summary.js';
 
 // Round-trip SSR→hydrate for `.tsx` `<Ctx.Provider>` with descriptor children.
 // Regression for two server bugs:
@@ -41,11 +42,16 @@ describe('hydration — .tsx <Context.Provider> descriptor children', () => {
 		expect(html).toContain('class="leaf"');
 		expect(html).toContain('provided'); // children NOT dropped (bug 1)
 		container.innerHTML = html;
-		const before = container.innerHTML;
+		const leaf = container.querySelector('.leaf')!;
+		const before = hydrationMarkerSummary(container);
 		const root = hydrateRoot(container, App as any, {});
 		flushSync(() => {});
-		expect(container.innerHTML).toBe(before); // adopted, not rebuilt
-		expect(container.querySelector('.leaf')!.textContent).toBe('provided');
+		expect(container.querySelector('.leaf')).toBe(leaf); // adopted, not rebuilt
+		expect(leaf.textContent).toBe('provided');
+		const after = hydrationMarkerSummary(container);
+		expect(after.logicalPairs).toBe(before.logicalPairs);
+		expect(after.physicalPairs).toBeLessThan(before.physicalPairs);
+		expect(after.countedPairs).toBeGreaterThanOrEqual(1);
 		root.unmount();
 	});
 
@@ -54,19 +60,26 @@ describe('hydration — .tsx <Context.Provider> descriptor children', () => {
 	// `hostElementBody` → `childSlot` → the de-opt keyed list, which ADOPTS markers on
 	// hydration. The client now adopts the server host node (instead of building fresh),
 	// and the server emits the matching childSlot/forSlot/component block nesting
-	// (`ssrDeoptBlockChildren`) — so this round-trips byte-for-byte.
+	// (`ssrDeoptBlockChildren`) — so this round-trips without rebuilding hosts;
+	// hydration may compact exactly-coextensive protocol ranges afterward.
 	it('hydrates a de-opt host with a component-list child without mismatch', async () => {
 		const dserver = serverModule('packages/octane/tests/_fixtures/jsx-context-children.tsx');
 		const { html } = await ServerRT.renderToString(dserver.ProviderApp, {});
 		container.innerHTML = html;
-		const before = container.innerHTML;
+		const wrap = container.querySelector('.wrap')!;
+		const leaves = [...container.querySelectorAll('.leaf')];
+		const before = hydrationMarkerSummary(container);
 		const root = hydrateRoot(container, ProviderApp as any, {});
 		flushSync(() => {});
-		expect(container.innerHTML).toBe(before); // adopted, not rebuilt
-		expect(container.querySelectorAll('.leaf').length).toBe(2);
-		for (const el of container.querySelectorAll('.leaf')) {
+		expect(container.querySelector('.wrap')).toBe(wrap);
+		expect([...container.querySelectorAll('.leaf')]).toEqual(leaves);
+		for (const el of leaves) {
 			expect(el.textContent).toBe('provided');
 		}
+		const after = hydrationMarkerSummary(container);
+		expect(after.logicalPairs).toBe(before.logicalPairs);
+		expect(after.physicalPairs).toBeLessThan(before.physicalPairs);
+		expect(after.countedPairs).toBeGreaterThanOrEqual(1);
 		root.unmount();
 	});
 });

--- a/packages/octane/tests/hydration/trycomponent-hydrate.test.ts
+++ b/packages/octane/tests/hydration/trycomponent-hydrate.test.ts
@@ -6,6 +6,7 @@ import { hydrateRoot, flushSync } from '../../src/index.js';
 import * as ServerRT from 'octane/server';
 import { prerender } from 'octane/static';
 import { TryFor, TryComponent, TryComponentFor, MatchShape } from './_fixtures/trycomponent.tsrx';
+import { hydrationMarkerSummary } from './_marker-summary.js';
 
 // SSR Phase 6 — hydration of a @try whose SUCCESS-arm body is a COMPONENT (the
 // router `Match` shape: `@try { <Comp/> } @pending { … }`). The server resolves
@@ -39,6 +40,16 @@ const items = [
 	{ id: 2, name: 'Beta' },
 ];
 
+function expectCompactedInsideTry(before: ReturnType<typeof hydrationMarkerSummary>, root: Node) {
+	const after = hydrationMarkerSummary(root);
+	expect(after.logicalPairs).toBe(before.logicalPairs);
+	expect(after.physicalPairs).toBeLessThan(before.physicalPairs);
+	expect(after.countedPairs).toBeGreaterThanOrEqual(1);
+	// The @try/Suspense range remains a separate physical barrier while its
+	// exactly-coextensive component descendant may share a counted pair.
+	expect(after.singletonPairs).toBeGreaterThanOrEqual(1);
+}
+
 describe('hydrateRoot — @try with a component body (router Match shape)', () => {
 	// Shape (a): @try { @for } — the body is a @for directly (a sole-hole arm).
 	it('(a) adopts a @try whose body is a @for directly (no throw, no rebuild)', async () => {
@@ -70,7 +81,7 @@ describe('hydrateRoot — @try with a component body (router Match shape)', () =
 		});
 		container.innerHTML = html;
 		const wrapper = container.querySelector('#try-comp') as HTMLElement;
-		const before = wrapper.outerHTML;
+		const before = hydrationMarkerSummary(wrapper);
 		const leaf = container.querySelector('.leaf') as HTMLElement;
 		expect(leaf).not.toBeNull();
 		expect(leaf.textContent).toBe('hello');
@@ -80,7 +91,8 @@ describe('hydrateRoot — @try with a component body (router Match shape)', () =
 
 		// The component subtree was ADOPTED (same node), no rebuild, no @pending.
 		expect(container.querySelector('.leaf')).toBe(leaf);
-		expect((container.querySelector('#try-comp') as HTMLElement).outerHTML).toBe(before);
+		expect(container.querySelector('#try-comp')).toBe(wrapper);
+		expectCompactedInsideTry(before, wrapper);
 		expect(container.querySelector('.loading')).toBeNull();
 		expect(container.querySelector('.leaf')!.textContent).toBe('hello');
 		expect(container.querySelector('script[data-octane-suspense]')).toBeNull();
@@ -94,7 +106,7 @@ describe('hydrateRoot — @try with a component body (router Match shape)', () =
 		});
 		container.innerHTML = html;
 		const wrapper = container.querySelector('#try-comp-for') as HTMLElement;
-		const before = wrapper.outerHTML;
+		const before = hydrationMarkerSummary(wrapper);
 		const ul = container.querySelector('ul.list-leaf') as HTMLElement;
 		const rows = [...container.querySelectorAll('li.row')];
 		expect(rows.length).toBe(2);
@@ -106,7 +118,8 @@ describe('hydrateRoot — @try with a component body (router Match shape)', () =
 		// Adopted: same <ul>, same <li> instances, no rebuild, no @pending.
 		expect(container.querySelector('ul.list-leaf')).toBe(ul);
 		expect([...container.querySelectorAll('li.row')]).toEqual(rows);
-		expect((container.querySelector('#try-comp-for') as HTMLElement).outerHTML).toBe(before);
+		expect(container.querySelector('#try-comp-for')).toBe(wrapper);
+		expectCompactedInsideTry(before, wrapper);
 		expect(container.querySelector('.loading')).toBeNull();
 		expect(container.querySelector('script[data-octane-suspense]')).toBeNull();
 		root.unmount();
@@ -119,7 +132,7 @@ describe('hydrateRoot — @try with a component body (router Match shape)', () =
 		});
 		container.innerHTML = html;
 		const wrapper = container.querySelector('#match') as HTMLElement;
-		const before = wrapper.outerHTML;
+		const before = hydrationMarkerSummary(wrapper);
 		const matched = container.querySelector('.matched') as HTMLElement;
 		expect(matched).not.toBeNull();
 		expect(matched.textContent).toBe('route');
@@ -129,7 +142,8 @@ describe('hydrateRoot — @try with a component body (router Match shape)', () =
 		flushSync(() => {});
 
 		expect(container.querySelector('.matched')).toBe(matched);
-		expect((container.querySelector('#match') as HTMLElement).outerHTML).toBe(before);
+		expect(container.querySelector('#match')).toBe(wrapper);
+		expectCompactedInsideTry(before, wrapper);
 		expect(container.querySelector('.fallback')).toBeNull();
 		expect(container.querySelector('script[data-octane-suspense]')).toBeNull();
 		root.unmount();

--- a/packages/octane/tests/marker-shape.test.ts
+++ b/packages/octane/tests/marker-shape.test.ts
@@ -31,8 +31,8 @@ import {
 //   client — fresh createRoot mount (client minting regimes incl. the
 //            existing elisions: forBlock singleRoot items, branch self-mark)
 //   ssr    — the server HTML string (pairs are emitted UNCONDITIONALLY today)
-//   hydrate— server HTML adopted by hydrateRoot (adoption keeps every server
-//            pair, so hydrated counts ≥ client counts)
+//   hydrate— server HTML adopted by hydrateRoot, then exactly-coextensive
+//            logical ranges share one counted physical pair (`[N` / `]N`)
 // The counts are the CURRENT contract, with the arithmetic in comments. The
 // elision phases (M1-M3) are EXPECTED to lower them — edit deliberately, and
 // keep client/ssr/hydrate mutually consistent when you do.
@@ -174,10 +174,10 @@ describe('marker-shape pins (M0) — exact comment counts per minting regime', (
 	it('(a9) ALIASED boundary builtin declines at RUNTIME on both sides', () => {
 		// `const S = Suspense` dodges the compile-time name exclusion — the site
 		// is stamped, and componentSlot + ssrComponent both decline by identity,
-		// keeping the frame pair (and Suspense's own boundary bookkeeping) on
-		// both sides. A one-sided decline would desync hydration here; hydrate
-		// matching ssr proves the pairs adopted cleanly.
-		expect(counts('AliasSusp', AliasSusp, {})).toEqual({ client: 6, ssr: 8, hydrate: 8 });
+		// keeping the frame pair (and Suspense's own boundary bookkeeping) on both
+		// sides. Hydration compacts one coextensive descendant range but preserves
+		// the independent Suspense boundary: 8 server comments → 6 live comments.
+		expect(counts('AliasSusp', AliasSusp, {})).toEqual({ client: 6, ssr: 8, hydrate: 6 });
 	});
 
 	it('(a5) chain hydration ADOPTS the server DOM (same node, no mismatch)', () => {
@@ -271,19 +271,20 @@ describe('marker-shape pins (M0) — exact comment counts per minting regime', (
 		const props = { items: ['a', 'b', 'c'] };
 		// SingleItem: client outer pair only. The server protocol remains
 		// conservative and keeps both an item pair and component frame per row;
-		// hydration adopts those established ranges.
+		// hydration adopts them, then stores both logical depths on one counted
+		// physical item pair: outer pair (2) + three item pairs (3×2) = 8.
 		expect(counts('ListComponent', ListComponent, props)).toEqual({
 			client: 2,
 			ssr: 14,
-			hydrate: 14,
+			hydrate: 8,
 		});
 		// MultiItem is not stamped singleRoot, so every client item retains its
 		// pair; the sole nested component borrows it. SSR keeps both established
-		// ranges and hydration adopts them.
+		// logical ranges and hydration coalesces each exact per-item pair.
 		expect(counts('ListComponentMulti', ListComponentMulti, props)).toEqual({
 			client: 8,
 			ssr: 14,
-			hydrate: 14,
+			hydrate: 8,
 		});
 	});
 
@@ -341,7 +342,7 @@ describe('marker-shape pins (M0) — exact comment counts per minting regime', (
 		);
 		const root = hydrateRoot(container, ListComponent, props);
 		expect(container.querySelector('[data-value="a"]')).toBe(rows.get('a'));
-		expect(domComments(container)).toBe(14);
+		expect(domComments(container)).toBe(8);
 		flushSync(() => root.render(ListComponent, { items: ['c', 'a', 'b'] }));
 		expect([...container.querySelectorAll<HTMLElement>('.component-item')]).toEqual([
 			rows.get('c'),
@@ -360,13 +361,13 @@ describe('marker-shape pins (M0) — exact comment counts per minting regime', (
 		expect(counts('ListConditional', ListConditional, { items })).toEqual({
 			client: 2,
 			ssr: 20,
-			hydrate: 20,
+			hydrate: 8,
 		});
 		expect(
 			counts('ListConditionalEmpty', ListConditionalEmpty, {
 				items: items.map((item) => ({ id: item.id, show: false })),
 			}),
-		).toEqual({ client: 8, ssr: 14, hydrate: 14 });
+		).toEqual({ client: 8, ssr: 14, hydrate: 8 });
 	});
 
 	it('(c4b) conditional item boundaries follow branch swaps and keyed moves', () => {
@@ -453,9 +454,9 @@ describe('marker-shape pins (M0) — exact comment counts per minting regime', (
 		expect(newA?.localName).toBe('pre');
 		expect(newB?.localName).toBe('p');
 		expect(newA).not.toBe(serverA);
-		// The first post-hydration arm swap retires each adopted inner branch
-		// pair; the branch then borrows its durable outer slot range.
-		expect(domComments(container)).toBe(10);
+		// Each branch and keyed item already shares one counted physical range;
+		// the arm swap updates that logical group without adding nested pairs.
+		expect(domComments(container)).toBe(6);
 
 		flushSync(() =>
 			root.render(ListConditional, {
@@ -472,8 +473,9 @@ describe('marker-shape pins (M0) — exact comment counts per minting regime', (
 	it('(d) @if single-element branch: client self-marks everything', () => {
 		// Client: the single-element branch self-marks AND the if slot rides the
 		// template's <!> anchor — only that anchor remains = 1. SSR: if-slot
-		// pair + taken-branch pair = 4. Hydration adopts both server pairs = 4.
-		expect(counts('Branch', Branch, { on: true })).toEqual({ client: 1, ssr: 4, hydrate: 4 });
+		// pair + taken-branch pair = 4. Hydration adopts both logical ranges on
+		// one counted physical pair = 2.
+		expect(counts('Branch', Branch, { on: true })).toEqual({ client: 1, ssr: 4, hydrate: 2 });
 	});
 
 	it('(d2) inactive @if uses one anchor and stays markerless through toggles', () => {

--- a/packages/octane/tests/streaming-ssr.test.ts
+++ b/packages/octane/tests/streaming-ssr.test.ts
@@ -136,6 +136,42 @@ describe('renderToPipeableStream — chunk protocol', () => {
 		expect(shell).not.toContain('streamed!');
 	});
 
+	it('balances canonical counted markers in the inline segment swap runtime', async () => {
+		const d = deferred<string>();
+		const c = collector();
+		const { pipe } = ServerRT.renderToPipeableStream(server.Boundary, { promise: d.promise });
+		pipe(c.dest);
+		const shell = c.chunks[0];
+		d.resolve('done');
+		await c.ended;
+
+		// Install the real emitted runtime, then exercise it against a compacted
+		// enclosing boundary. The counted close is the scanner's stopping node; a
+		// legacy-only parser runs past it and deletes the trailing sibling/segment.
+		container.innerHTML = shell;
+		const runtimeScript = Array.from(container.querySelectorAll('script')).find((script) =>
+			(script.textContent || '').includes('$OCTRC=function'),
+		);
+		expect(runtimeScript).toBeDefined();
+		// eslint-disable-next-line no-eval
+		(0, eval)(runtimeScript!.textContent || '');
+		container.innerHTML =
+			'<!--[2--><template data-oct-b="counted"></template>' +
+			'<i class="counted-fallback">loading</i><!--]2-->' +
+			'<p class="after-counted">after</p>' +
+			'<div hidden data-oct-s="counted"><b class="counted-ready">ready</b></div>';
+
+		(window as any).$OCTRC('counted');
+		expect(container.querySelector('.counted-fallback')).toBeNull();
+		expect(container.querySelector('.counted-ready')?.textContent).toBe('ready');
+		expect(container.querySelector('.after-counted')?.textContent).toBe('after');
+		expect(container.querySelector('[data-oct-s]')).toBeNull();
+		const comments = Array.from(container.childNodes)
+			.filter((node): node is Comment => node.nodeType === Node.COMMENT_NODE)
+			.map((node) => node.data);
+		expect(comments).toEqual(['[2', 'oct-seed:counted', ']2']);
+	});
+
 	it('streams independent sibling boundaries as separate segments', async () => {
 		const a = deferred<string>();
 		const b = deferred<string>();

--- a/website/tests/ssr-hydration.e2e.test.ts
+++ b/website/tests/ssr-hydration.e2e.test.ts
@@ -16,6 +16,7 @@ import { spawn, type ChildProcess } from 'node:child_process';
 import { rmSync } from 'node:fs';
 import { createServer } from 'node:net';
 import { join } from 'node:path';
+import { censusDomNodes, type DomNodeCensus } from '../../benchmarks/lib/dom-nodes.mjs';
 
 const WEBSITE = join(process.cwd(), 'website');
 const ROUTES = ['/', '/docs', '/benchmarks', '/playground', '/view-transitions'];
@@ -163,8 +164,8 @@ async function stop(child: ChildProcess | undefined): Promise<void> {
 	if (child.exitCode === null) signalGroup('SIGKILL');
 }
 
-// Load `path`, collecting console errors + page errors; returns the filtered
-// error list and the rendered <main> text.
+// Load `path`, collecting console errors + page errors; returns the rendered
+// <main> text plus deterministic whole-body / main DOM censuses.
 async function loadRoute(base: string, path: string) {
 	const page = await browser!.newPage();
 	const errors: string[] = [];
@@ -175,13 +176,25 @@ async function loadRoute(base: string, path: string) {
 	await page.goto(base + path, { waitUntil: 'networkidle' });
 	await page.waitForTimeout(400); // hydration commit + recovery warnings
 	const main = (await page.evaluate(() => document.querySelector('main')?.textContent)) ?? '';
-	const comments = await page.evaluate(() => {
-		const w = document.createTreeWalker(document.body, NodeFilter.SHOW_COMMENT);
-		let n = 0;
-		while (w.nextNode()) n++;
-		return n;
-	});
-	return { page, errors, main, comments };
+	const bodyDom = await page.evaluate(censusDomNodes, 'body');
+	const mainDom = await page.evaluate(censusDomNodes, 'main');
+	// Keep the legacy scalar for the existing COMMENT_CEILINGS assertion.
+	return { page, errors, main, comments: bodyDom.comments, bodyDom, mainDom };
+}
+
+function assertCountedHydrationMarkers(bodyDom: DomNodeCensus, mainDom: DomNodeCensus): void {
+	// Counted comments reduce physical DOM nodes while preserving the logical
+	// open/close multiplicity the hydration cursor consumes.
+	expect(bodyDom.hydrationMarkersLogical).toBeGreaterThan(bodyDom.hydrationMarkersPhysical);
+	expect(bodyDom.hydrationMarkersCounted).toBeGreaterThan(0);
+	expect(bodyDom.hydrationMarkerMaxMultiplicity).toBeGreaterThan(1);
+
+	// Every website route shares the router/provider prefix that motivated this
+	// protocol. Nineteen logical opens compact to five physical comments: the
+	// remaining splits are the independent Suspense frame/try range plus the
+	// shorter route-content span, not redundant wrapper bookkeeping.
+	expect(mainDom.leadingHydrationStartsPhysical).toBe(5);
+	expect(mainDom.leadingHydrationStartsLogical).toBe(19);
 }
 
 async function waitForLocatorText(
@@ -226,7 +239,7 @@ describe.sequential('website dev-SSR → hydration (real browser)', () => {
 		{ timeout: 30_000 },
 		async (route, ctx) => {
 			if (!browser) return ctx.skip();
-			const { page, errors, main, comments } = await loadRoute(
+			const { page, errors, main, comments, bodyDom, mainDom } = await loadRoute(
 				`http://localhost:${DEV_PORT}`,
 				route,
 			);
@@ -238,6 +251,7 @@ describe.sequential('website dev-SSR → hydration (real browser)', () => {
 				expect(main.length).toBeGreaterThan(0);
 				// DOM-weight ratchet (see COMMENT_CEILINGS).
 				expect(comments).toBeLessThanOrEqual(COMMENT_CEILINGS[route]);
+				assertCountedHydrationMarkers(bodyDom, mainDom);
 			} finally {
 				await page.close();
 			}
@@ -268,10 +282,14 @@ describe.sequential('website production build → hydration (octane-preview)', (
 
 	it.for(ROUTES)('%s renders and runs with no errors', { timeout: 30_000 }, async (route, ctx) => {
 		if (!browser) return ctx.skip();
-		const { page, errors, main } = await loadRoute(`http://localhost:${PREVIEW_PORT}`, route);
+		const { page, errors, main, bodyDom, mainDom } = await loadRoute(
+			`http://localhost:${PREVIEW_PORT}`,
+			route,
+		);
 		try {
 			expect(errors).toEqual([]);
 			expect(main.length).toBeGreaterThan(0);
+			assertCountedHydrationMarkers(bodyDom, mainDom);
 		} finally {
 			await page.close();
 		}


### PR DESCRIPTION
## Summary

- keep the explicit `<!--[-->…<!--]-->` SSR wire format, then coalesce only exactly coextensive hydrated ownership ranges into counted `<!--[N-->…<!--]N-->` pairs after successful adoption
- redirect every retained runtime owner to the shared pair while preserving keyed reconciliation, Suspense/try/error/view-transition boundaries, portals, fragment refs, transitions, mismatch recovery, effects, refs, events, and node identity
- preserve explicit key presence even for `key={undefined}`, recognize canonical counted markers in hydration and streamed segment scanning, and reject unsafe/non-canonical multiplicities
- skip the ownership walk entirely when hydration did not observe a physically adjacent range pair
- add physical/logical DOM census instrumentation, stronger benchmark identity/interaction gates, focused DOM-shape/behavior/streaming regressions, design documentation, and an `octane` patch changeset

A counted **pair** is intentional rather than one comment total: mutable ranges still require separate start and end insertion/teardown boundaries. Only ranges with exactly the same span share those endpoints.

## Website impact

Production build at `d173805`, after hydration and a 400 ms settle, compared with a clean worktree at the same `main` commit:

| Route | All body comments | Physical Octane range comments | Shared `<main>` leading opens |
| --- | ---: | ---: | ---: |
| `/` | 2,439 → **2,315** (−124) | 542 → **418** | 19 → **5 physical / 19 logical** |
| `/docs` | 383 → **227** (−156) | 382 → **226** | 19 → **5 / 19** |
| `/benchmarks` | 18,213 → **18,079** (−134) | 2,824 → **2,690** | 19 → **5 / 19** |
| `/playground` | 165 → **69** (−96) | 164 → **68** | 19 → **5 / 19** |
| `/view-transitions` | 189 → **81** (−108) | 188 → **80** | 19 → **5 / 19** |

Raw SSR comment counts are unchanged (`545 / 383 / 2,861 / 167 / 189` respectively). The remaining four leading splits have genuinely different spans or ownership and are intentionally retained. Maximum website multiplicity is 9.

## Safety model

The compactor walks the adopted Block/Scope graph bottom-up only after range matching has observed a candidate, and merges only when:

1. the scope has one eligible live range-bearing output (or the compiler stamped a sole renderable-child wrapper), and
2. DOM adjacency proves exact coextension: `outer.start.nextSibling === inner.start` and `inner.end.nextSibling === outer.end`.

Before removing the inner pair it retargets Blocks, lite scopes, component/child/branch owners, and embedded list state to the retained endpoints with borrowed-marker semantics. Keyed components/items, list outer ranges, Suspense/try/ErrorBoundary/ViewTransition, Activity, portals, fragment refs, and non-coextensive control flow remain barriers. Count sums are safe-integer guarded. A return/value-position Suspense regression specifically covers the `childSlot` boundary path.

## Performance and size

The uncontended 20-iteration production news benchmark is a no-op overhead control: its 52 independent pairs have no compactable adjacency, so it remains 763 nodes / 104 physical and logical hydration comments before and after, and the new guard skips the ownership walk.

- Octane TSRX hydration: **1.3000 ms** vs **1.3125 ms** on clean main; median **1.30 ms** and p95 **1.40 ms** in both runs
- Octane JSX hydration: **1.5500 ms** vs **1.5750 ms**; treat both small differences as noise, not claimed speedups
- same branch run: React 2.40 ms, Preact 1.70 ms, Solid 1.70 ms, Svelte 1.3875 ms
- all eight targets preserved the 50-card tree, host identity, and interactivity gates

Deterministic size deltas:

- fixed compiled corpus: **+1 B gzip** (+51 raw / +37 minified)
- TSRX js-framework bundle: 29,682 → 30,017 B gzip (**+335 B / +1.13%**; app chunk −2 B, framework chunk +337 B)
- JSX js-framework bundle: 29,689 → 30,041 B gzip (**+352 B / +1.19%**)
- TodoMVC / chat: +358 B / +379 B gzip

## Validation

- `pnpm test` — 815 files; 6,667 passed, 8 expected failures, 2 skipped
- focused changed suites in `octane` + `octane-prod` — 180/180 passed
- `website/tests/ssr-hydration.e2e.test.ts` — dev SSR, production preview, client navigation, and playground; 12/12 passed
- `pnpm typecheck`
- repository-wide `pnpm format:check`
- `pnpm changeset:check`
- `git diff --check`
- `node benchmarks/bench.mjs codegen-size bundle-size news` — all harnesses exited 0; news ran 8 targets × 20 iterations with every correctness gate passing

## Context

The framework-comparison website work in #55 motivated keeping website node counts and cross-framework comparisons visible. This PR is separate and does not modify that PR or its worktree.
