### PR TITLE
Fix user-app starter verifier CI timeout

### DIFF
--- a/packages/octane-evals/tests/user-app-corpus.test.ts
+++ b/packages/octane-evals/tests/user-app-corpus.test.ts
@@ -11,7 +11,9 @@ const repositoryRoot = join(packageRoot, '..', '..');
 const corpusRoot = join(packageRoot, 'datasets', 'train', 'user-apps-v1');
 const generatorTimeoutMs = 10_000;
 const gradingCommandTimeoutMs = 20_000;
-const starterVerificationTimeoutMs = 25_000;
+// The verifier gives its nested Vitest run 60 seconds, so this wrapper must leave
+// enough time for that timeout to surface its own actionable error under CI load.
+const starterVerificationTimeoutMs = 70_000;
 
 interface UserAppCatalog {
 	environment: {
@@ -206,5 +208,5 @@ describe('public user-app training corpus', () => {
 			timeout: starterVerificationTimeoutMs,
 			killSignal: 'SIGKILL',
 		});
-	}, 30_000);
+	}, 75_000);
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only timeout and comment changes; no production or grading logic affected.
> 
> **Overview**
> **Fixes CI flakes** where the corpus test *"keeps every incomplete starter behaviorally unresolved"* was killed before the nested verifier could finish under load.
> 
> The test’s `execFileSync` timeout for `verify-user-app-starters.mjs` is raised from **25s to 70s**, and the Vitest case timeout from **30s to 75s**, so the wrapper outlives the script’s **60s** nested Vitest run and failures surface from the verifier instead of a premature `SIGKILL`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eba6802e927f94d3be5b08e83115038999f97022. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->