### PR TITLE
Support Activity SSR and optimize mobile Lighthouse

### DIFF
--- a/.changeset/quiet-activities-render.md
+++ b/.changeset/quiet-activities-render.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Support server rendering and hydration for React-compatible `<Activity>` boundaries, including omitted hidden content and preserved offscreen client state.

--- a/docs/ssr.md
+++ b/docs/ssr.md
@@ -130,6 +130,11 @@ and the resolved server function share one SSR runtime.
 - Server-compiled components are string emitters: static HTML interleaved with
   helper calls for dynamic holes, wrapped in `<!--[-->`/`<!--]-->` hydration
   markers that the client cursor walks during `hydrateRoot`.
+- `<Activity mode="visible">` renders its children normally. A hidden Activity
+  does not evaluate or serialize its children on the server; hydratable output
+  retains only an empty internal range so `hydrateRoot` can build the preserved
+  hidden client tree without disturbing neighboring server DOM. Static markup
+  emits nothing for the hidden Activity.
 - Suspense: an unresolved `use(thenable)` renders the nearest `@pending`
   fallback and suspends the pass. `prerender` awaits what suspended, caches the
   resolved values, and re-renders. To avoid re-serializing the whole static bulk

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -2195,7 +2195,8 @@ export function compile(source, filename, options) {
 		// Server (SSR) codegen: static markup + dynamic holes + control flow +
 		// nested components + scoped CSS, emitted as HTML-string-building bodies
 		// (with hydration markers) importing the server runtime from 'octane/server'.
-		// Only `<Activity>` and fragment refs are rejected.
+		// Fragment refs remain client-only because there is no server-side DOM range
+		// object for their imperative API.
 		return compileServer(source, filename, options);
 	}
 	const ast = parseModule(source, filename);
@@ -2727,8 +2728,8 @@ export function compile(source, filename, options) {
 // the hydration markers (`constants.ts`) the client `hydrateRoot` adopts. The
 // client path (template/clone + bindings) is left completely untouched.
 //
-// Still rejected with a clear diagnostic (see ssrUnsupported): `<Activity>` and
-// fragment refs (`<Fragment ref={…}>`).
+// Still rejected with a clear diagnostic (see ssrUnsupported): fragment refs
+// (`<Fragment ref={…}>`).
 // ===========================================================================
 
 function ssrUnsupported(what) {
@@ -3153,7 +3154,7 @@ function ssrEmitNode(node, ctx, name, inlinedSubs, parentNs, cssHash, nlGuard = 
 		case 'SwitchStatement':
 			return ssrEmitSwitch(node, ctx, name, inlinedSubs, parentNs, cssHash);
 		case 'ActivityStatement':
-			return ssrUnsupported('`<Activity>`');
+			return ssrEmitActivity(node, ctx, name, inlinedSubs, parentNs, cssHash);
 		case 'FragmentStart':
 		case 'FragmentEnd':
 			return ssrUnsupported('fragment refs (`<Fragment ref={…}>`)');
@@ -3661,6 +3662,19 @@ function ssrEmitIf(node, ctx, name, inlinedSubs, parentNs, cssHash) {
 	const thenInner = `_$ssrArm("then", () => _$ssrBlock(${thenSub.fnName}(undefined, __s)))`;
 	const elseInner = node.alternate ? `_$ssrArm("else", () => _$ssrBlock(${elseCall}))` : "''";
 	return `_$ssrBlock(_$ssrControl("${ssrControlKey('if', node)}", () => ((${testExpr}) ? ${thenInner} : ${elseInner})))`;
+}
+
+function ssrEmitActivity(node, ctx, name, inlinedSubs, parentNs, cssHash) {
+	// React's server contract renders visible content and omits hidden content
+	// entirely. Keep the body behind a thunk so a hidden Activity does not execute
+	// child components/hooks or start descendant data work on the server.
+	const modeExpr = node.mode ? printExpr(rewriteHookCalls(node.mode, ctx, name)) : "'visible'";
+	const bodySub = ssrCompileSub(node.children || [], ctx, '__sactivity', [], cssHash, parentNs);
+	inlinedSubs.push(bodySub.fn + ';');
+	ctx.runtimeNeeded.add('ssrActivity');
+	ctx.runtimeNeeded.add('ssrControl');
+	ctx.runtimeNeeded.add('ssrArm');
+	return `_$ssrControl("${ssrControlKey('activity', node)}", () => _$ssrActivity(${modeExpr}, () => _$ssrArm("visible", () => ${bodySub.fnName}(undefined, __s))))`;
 }
 
 function ssrEmitFor(node, ctx, name, inlinedSubs, parentNs, cssHash) {

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -15,9 +15,8 @@
  * server renderer does — effects no-op, memo runs once, ids are deterministic).
  * Every dynamic site is
  * wrapped in the hydration markers (`constants.ts`) the client `hydrateRoot`
- * cursor adopts. Events and refs are dropped (no DOM on the server); `<Activity>`
- * and fragment refs (`<Fragment ref={…}>`) are rejected by the compiler in
- * server mode.
+ * cursor adopts. Events and refs are dropped (no DOM on the server); fragment
+ * refs (`<Fragment ref={…}>`) are rejected by the compiler in server mode.
  */
 
 // ---------------------------------------------------------------------------
@@ -207,6 +206,13 @@ const ELEMENT_TAG = Symbol.for('octane.element');
 // a portal flowing through props/children to `ssrChild` leaves its site anchor
 // instead of tripping the plain-object child throw.
 const PORTAL_TAG = Symbol.for('octane.portal');
+
+/**
+ * React-19 `<Activity>` sentinel. Server-compiled template sites lower directly
+ * to `ssrActivity`; this export keeps `import { Activity } from 'octane'`
+ * resolvable after the server compiler retargets it to `octane/server`.
+ */
+export const Activity: unique symbol = Symbol.for('octane.Activity');
 
 interface ElementDescriptor {
 	$$kind: typeof ELEMENT_TAG;
@@ -717,6 +723,18 @@ function ssrDescriptorContent(v: unknown, scope: SSRScope): string {
  */
 export function ssrBlock(content: string): string {
 	return MARKERS ? BLOCK_OPEN + content + BLOCK_CLOSE : content;
+}
+
+/**
+ * Server half of `<Activity mode="visible"|"hidden">`.
+ *
+ * Visible content renders inside one hydratable range. Hidden content is not
+ * evaluated and serializes as an empty range (or an empty string for static
+ * markup), matching React's server behavior while leaving the client a stable
+ * range to adopt and populate offscreen during hydration.
+ */
+export function ssrActivity(mode: string, render: () => string): string {
+	return ssrBlock(mode === 'hidden' ? '' : render());
 }
 
 /**

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -4700,6 +4700,13 @@ let hydrating = false;
 // templates the cursor is just the adopted root and the old raw path-walk
 // (`_root.firstChild.nextSibling…`) still resolves bindings correctly.
 let hydrateNode: Node | null = null;
+// Hidden server Activities serialize as empty ranges. Their client trees must
+// mount only AFTER the server-rendered siblings finish hydrating: mounting one
+// inline would consume root-local useId counters ahead of those siblings even
+// though the server never visited the hidden tree. hydrateRoot drains this
+// root-local queue at the end of its synchronous adoption pass with hydration
+// suspended, still before returning the live Root.
+let hydrationDeferredActivities: Array<() => void> | null = null;
 // Server-resolved `use(thenable)` values (SSR Phase 4), parsed from the inline
 // `<script data-octane-suspense>` in `hydrateRoot()` and consumed in render
 // order by `useThenable` so a hydrating boundary returns synchronously. Both are
@@ -5074,7 +5081,7 @@ function isTextSeparator(node: Node | null): node is Comment {
 
 /**
  * Resolve the server `<!--[-->` a control-flow slot (try / if / for / switch /
- * component) should ADOPT during hydration.
+ * Activity / component) should ADOPT during hydration.
  *
  * Two shapes reach here:
  *  - `anchor` IS the open marker — the slot sat at a `<!>` placeholder among
@@ -13091,10 +13098,21 @@ export function activityBlock(
 	let state = parentScope.slots[slotKey] as ActivitySlot | undefined;
 
 	if (state === undefined) {
-		const bStart = document.createComment('activity');
-		const bEnd = document.createComment('/activity');
-		domParent.insertBefore(bStart, anchor ?? null);
-		domParent.insertBefore(bEnd, anchor ?? null);
+		let bStart: Comment;
+		let bEnd: Comment;
+		// Hydration: visible Activities carry their server-rendered body inside one
+		// generic block range; hidden Activities carry the same EMPTY range because
+		// their body was intentionally skipped on the server. Adopt either shape.
+		const open = resolveHydrationOpen(anchor ?? null, domParent);
+		if (open !== null) {
+			bStart = open;
+			bEnd = matchingClose(open);
+		} else {
+			bStart = document.createComment('activity');
+			bEnd = document.createComment('/activity');
+			domParent.insertBefore(bStart, anchor ?? null);
+			domParent.insertBefore(bEnd, anchor ?? null);
+		}
 		const b = createBlock(
 			'control-flow',
 			parentBlock,
@@ -13114,6 +13132,31 @@ export function activityBlock(
 		};
 		parentScope.slots[slotKey] = state;
 		registerSlot(parentScope, state);
+		const adopted = open !== null;
+		const serverRangeEmpty = adopted && bStart.nextSibling === bEnd;
+		if (adopted && !serverRangeEmpty) hydrateNode = bStart.nextSibling;
+		// A hidden server Activity has no body to hydrate. Mount its client tree
+		// freshly between the adopted markers with hydration suspended; this builds
+		// preserved state/DOM without making descendants consume unrelated server
+		// nodes. The same recovery handles a visible client over hidden server HTML.
+		const savedHydrating = hydrating;
+		if (serverRangeEmpty && savedHydrating) {
+			b.inactive = wantHidden;
+			state.hidden = wantHidden;
+			hydrationDeferredActivities!.push(() => {
+				if (b.disposed) return;
+				const wasHydrating = hydrating;
+				hydrating = false;
+				try {
+					renderBlock(b);
+				} finally {
+					hydrating = wasHydrating;
+				}
+				if (state!.hidden) hideActivityRange(state!);
+			});
+			hydrateNode = bEnd.nextSibling;
+			return;
+		}
 		if (wantHidden) {
 			// Mount while hidden: render children (creates state + DOM) but no
 			// effects — mark inactive BEFORE the render so enqueueEffect skips them.
@@ -13124,6 +13167,7 @@ export function activityBlock(
 		} else {
 			renderBlock(b);
 		}
+		if (adopted && savedHydrating) hydrateNode = bEnd.nextSibling;
 		return;
 	}
 
@@ -15121,6 +15165,8 @@ export function hydrateRoot(
 	rootBlock.idState = idState;
 	hydrationHasAdjacentRangePair = false;
 	hydrating = true;
+	const deferredActivities: Array<() => void> = [];
+	hydrationDeferredActivities = deferredActivities;
 	const liteRanges = new WeakMap<Scope, HydratedLiteRange>();
 	hydratedLiteRanges = liteRanges;
 	let hydrationCompleted = false;
@@ -15154,6 +15200,14 @@ export function hydrateRoot(
 	hydrateNode = firstNode;
 	try {
 		renderBlock(rootBlock);
+		// Empty server Activity ranges deliberately had no body to adopt. Mount
+		// those preserved client trees only after every server-rendered sibling has
+		// consumed its useId/seed positions, with hydration suspended for the new DOM.
+		if (deferredActivities.length !== 0) {
+			hydrating = false;
+			for (let i = 0; i < deferredActivities.length; i++) deferredActivities[i]();
+			hydrating = true;
+		}
 		hydrationCompleted = true;
 		shouldCoalesceRanges = hydrationHasAdjacentRangePair;
 	} finally {
@@ -15162,6 +15216,7 @@ export function hydrateRoot(
 		hydrateNode = null;
 		hydrationSeeds = null;
 		hydrationSeedCursor = 0;
+		hydrationDeferredActivities = null;
 		hydratedLiteRanges = null;
 	}
 	if (hydrationCompleted && shouldCoalesceRanges) coalesceHydratedRanges(rootBlock, liteRanges);

--- a/packages/octane/src/server/index.ts
+++ b/packages/octane/src/server/index.ts
@@ -78,6 +78,7 @@ export {
 	// Suspense / error boundaries as JSX components (alongside the @try directive)
 	Suspense,
 	ErrorBoundary,
+	Activity,
 	// Transparent server twin of the client ViewTransition boundary (client-only
 	// behavior; SSR annotations are view-transitions plan Phase 5).
 	ViewTransition,
@@ -117,6 +118,7 @@ export {
 	ssrOption,
 	ssrComponent,
 	ssrBlock,
+	ssrActivity,
 	ssrForBlock,
 	ssrControl,
 	ssrArm,

--- a/packages/octane/tests/hydration/_fixtures/activity.tsrx
+++ b/packages/octane/tests/hydration/_fixtures/activity.tsrx
@@ -1,0 +1,49 @@
+import { Activity, useEffect, useId, useState } from 'octane';
+
+function StatefulChild(props) @{
+	const [count, setCount] = useState(0);
+	props.onRender?.();
+	useEffect(() => {
+		props.onEffect?.('mount');
+		return () => props.onEffect?.('cleanup');
+	}, []);
+	<button id={props.id} onClick={() => setCount((value) => value + 1)}>
+		{props.id + ':' + count}
+	</button>
+}
+
+export function ActivityHydration(props) @{
+	<section id="activity-host">
+		<Activity mode={props.mode}>
+			<StatefulChild id="activity-child" onRender={props.onRender} onEffect={props.onEffect} />
+		</Activity>
+		<span id="activity-tail">{'tail'}</span>
+	</section>
+}
+
+export function NestedActivityHydration(props) @{
+	<div id="nested-activity-host">
+		<Activity mode={props.outer}>
+			<span id="outer-before">{'before'}</span>
+			<Activity mode={props.inner}>
+				<StatefulChild id="inner-child" onEffect={props.onEffect} />
+			</Activity>
+			<span id="outer-after">{'after'}</span>
+		</Activity>
+		<i id="nested-tail">{'tail'}</i>
+	</div>
+}
+
+function IdChild(props) @{
+	const id = useId();
+	<span class={props.className} id={id}>{id}</span>
+}
+
+export function ActivityIdHydration() @{
+	<div id="activity-id-host">
+		<Activity mode="hidden">
+			<IdChild className="hidden-id" />
+		</Activity>
+		<IdChild className="visible-id" />
+	</div>
+}

--- a/packages/octane/tests/hydration/activity-hydrate.test.ts
+++ b/packages/octane/tests/hydration/activity-hydrate.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { compile } from 'octane/compiler';
+import { flushSync, hydrateRoot } from '../../src/index.js';
+import { flushEffects } from '../_helpers.js';
+import * as ServerRT from 'octane/server';
+import {
+	ActivityHydration,
+	ActivityIdHydration,
+	NestedActivityHydration,
+} from './_fixtures/activity.tsrx';
+
+const FIXTURE = join(process.cwd(), 'packages/octane/tests/hydration/_fixtures/activity.tsrx');
+
+function serverModule(): Record<string, any> {
+	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'activity.tsrx', { mode: 'server' });
+	code = code.replace(
+		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
+	);
+	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
+	const fn = new Function('__rt', '__exports', code + '\nreturn __exports;');
+	return fn(ServerRT, {});
+}
+
+const server = serverModule();
+let container: HTMLElement;
+
+beforeEach(() => {
+	container = document.createElement('div');
+	document.body.appendChild(container);
+});
+
+afterEach(() => container.remove());
+
+describe('hydrateRoot — <Activity>', () => {
+	it('adopts visible server content and keeps it interactive', () => {
+		const effects: string[] = [];
+		const { html } = ServerRT.renderToString(server.ActivityHydration, {
+			mode: 'visible',
+			onEffect: (value: string) => effects.push(value),
+		});
+		container.innerHTML = html;
+		const button = container.querySelector('#activity-child') as HTMLButtonElement;
+
+		const root = hydrateRoot(container, ActivityHydration, {
+			mode: 'visible',
+			onEffect: (value: string) => effects.push(value),
+		});
+		flushSync(() => {});
+		flushEffects();
+
+		expect(container.querySelector('#activity-child')).toBe(button);
+		expect(effects).toEqual(['mount']);
+		flushSync(() => button.click());
+		expect(button.textContent).toBe('activity-child:1');
+		root.unmount();
+	});
+
+	it('hydrates a hidden empty server range into preserved offscreen client state', () => {
+		const effects: string[] = [];
+		const props = {
+			mode: 'hidden',
+			onEffect: (value: string) => effects.push(value),
+		};
+		const { html } = ServerRT.renderToString(server.ActivityHydration, props);
+		expect(html).not.toContain('activity-child');
+		container.innerHTML = html;
+
+		const root = hydrateRoot(container, ActivityHydration, props);
+		flushSync(() => {});
+		const button = container.querySelector('#activity-child') as HTMLButtonElement;
+		expect(button).not.toBeNull();
+		expect(button.style.display).toBe('none');
+		expect(effects).toEqual([]);
+
+		flushSync(() => button.click());
+		expect(button.textContent).toBe('activity-child:1');
+		expect(button.style.display).toBe('none');
+
+		root.render(ActivityHydration, { ...props, mode: 'visible' });
+		flushSync(() => {});
+		flushEffects();
+		expect(container.querySelector('#activity-child')).toBe(button);
+		expect(button.style.display).toBe('');
+		expect(button.textContent).toBe('activity-child:1');
+		expect(effects).toEqual(['mount']);
+		root.unmount();
+	});
+
+	it('adopts visible server DOM when the client initially hides it', () => {
+		const { html } = ServerRT.renderToString(server.ActivityHydration, {
+			mode: 'visible',
+		});
+		container.innerHTML = html;
+		const button = container.querySelector('#activity-child') as HTMLButtonElement;
+
+		const root = hydrateRoot(container, ActivityHydration, { mode: 'hidden' });
+		flushSync(() => {});
+		expect(container.querySelector('#activity-child')).toBe(button);
+		expect(button.style.display).toBe('none');
+
+		root.render(ActivityHydration, { mode: 'visible' });
+		flushSync(() => {});
+		expect(container.querySelector('#activity-child')).toBe(button);
+		expect(button.style.display).toBe('');
+		root.unmount();
+	});
+
+	it('keeps the hydration cursor aligned across a nested hidden Activity', () => {
+		const { html } = ServerRT.renderToString(server.NestedActivityHydration, {
+			outer: 'visible',
+			inner: 'hidden',
+		});
+		expect(html).toContain('outer-before');
+		expect(html).not.toContain('inner-child');
+		container.innerHTML = html;
+		const before = container.querySelector('#outer-before');
+		const after = container.querySelector('#outer-after');
+		const tail = container.querySelector('#nested-tail');
+
+		const root = hydrateRoot(container, NestedActivityHydration, {
+			outer: 'visible',
+			inner: 'hidden',
+		});
+		flushSync(() => {});
+		const inner = container.querySelector('#inner-child') as HTMLButtonElement;
+		expect(inner.style.display).toBe('none');
+		expect(container.querySelector('#outer-before')).toBe(before);
+		expect(container.querySelector('#outer-after')).toBe(after);
+		expect(container.querySelector('#nested-tail')).toBe(tail);
+
+		root.render(NestedActivityHydration, { outer: 'visible', inner: 'visible' });
+		flushSync(() => {});
+		expect(container.querySelector('#inner-child')).toBe(inner);
+		expect(inner.style.display).toBe('');
+		root.unmount();
+	});
+
+	it('defers hidden prerendering until visible siblings consume their server useId positions', () => {
+		const { html } = ServerRT.renderToString(server.ActivityIdHydration);
+		container.innerHTML = html;
+		const visible = container.querySelector('.visible-id') as HTMLElement;
+		const serverId = visible.id;
+
+		const root = hydrateRoot(container, ActivityIdHydration);
+		const hidden = container.querySelector('.hidden-id') as HTMLElement;
+		expect(container.querySelector('.visible-id')).toBe(visible);
+		expect(visible.id).toBe(serverId);
+		expect(hidden.id).not.toBe(serverId);
+		expect(hidden.style.display).toBe('none');
+		root.unmount();
+	});
+});

--- a/packages/octane/tests/ssr.test.ts
+++ b/packages/octane/tests/ssr.test.ts
@@ -117,17 +117,48 @@ describe('SSR Phase 1 — semantics', () => {
 		expect(Object.keys(out).sort()).toEqual(['css', 'html']);
 	});
 
-	it('still rejects truly-unsupported server constructs (e.g. <Activity>)', () => {
-		// Control flow is supported as of Phase 3; Activity is not.
+	it('renders visible Activity content and skips hidden Activity work', async () => {
+		const activity = evalServer(
+			`
+				import { Activity } from 'octane';
+				function Child(props) @{
+					props.onRender();
+					<span class="activity-child">{'child'}</span>
+				}
+				export function C(props) @{
+					<Activity mode={props.mode}><Child onRender={props.onRender} /></Activity>
+				}
+			`,
+			'activity-ssr.tsrx',
+		);
+		const onRender = vi.fn();
+		const visible = await RT.renderToString(activity.C, { mode: 'visible', onRender });
+		expect(visible.html).toContain('<span class="activity-child">child</span>');
+		expect(visible.html).toContain('<!--[-->');
+		expect(onRender).toHaveBeenCalledTimes(1);
+
+		onRender.mockClear();
+		const hidden = await RT.renderToString(activity.C, { mode: 'hidden', onRender });
+		expect(hidden.html).not.toContain('activity-child');
+		expect(hidden.html).toContain('<!--[--><!--]-->');
+		expect(onRender).not.toHaveBeenCalled();
+
+		expect(RT.renderToStaticMarkup(activity.C, { mode: 'visible', onRender }).html).toBe(
+			'<span class="activity-child">child</span>',
+		);
+		onRender.mockClear();
+		expect(RT.renderToStaticMarkup(activity.C, { mode: 'hidden', onRender }).html).toBe('');
+		expect(onRender).not.toHaveBeenCalled();
+	});
+
+	it('still rejects server-side Fragment refs', () => {
 		expect(() =>
 			compile(
-				`export function C(p) @{ <Activity mode="hidden"><span>{'a'}</span></Activity> }`,
-				'c.tsrx',
-				{
-					mode: 'server',
-				},
+				`export function C(p) @{ <Fragment ref={p.ref}><span>{'a'}</span></Fragment> }`,
+				'fragment-ref.tsrx',
+				{ mode: 'server' },
 			),
-		).toThrow(/does not support `<Activity>`/);
+		).toThrow(/does not support fragment refs/);
 	});
 });
 

--- a/website/index.html
+++ b/website/index.html
@@ -64,7 +64,7 @@
 			::selection {
 				background: rgba(255, 65, 90, 0.45);
 			}
-			/* Shiki emits `<pre class="shiki github-dark">` with inline token colors;
+			/* Shiki emits a themed `<pre class="shiki …">` with inline token colors;
 			   normalize its frame to the site's code panel. */
 			pre.shiki {
 				background: var(--code-bg) !important;

--- a/website/mdx-options.ts
+++ b/website/mdx-options.ts
@@ -27,8 +27,8 @@ export const websiteMdxOptions = {
 		[
 			rehypeShiki,
 			{
-				// Dark-first site — match the code panel.
-				theme: 'github-dark',
+				// Dark-first site — use GitHub's accessible high-contrast token set.
+				theme: 'github-dark-high-contrast',
 				// Explicit `langs` replaces shiki's all-bundled default set: list the
 				// fence languages the site actually uses, plus the TSRX grammar twice —
 				// once under its own name ("TSRX") and once lowercased so ```tsrx

--- a/website/src/app/router.ts
+++ b/website/src/app/router.ts
@@ -2,14 +2,23 @@
 // two environments: the server builds a per-request router over a memory
 // history (see router-server.ts), the client builds a singleton over the
 // browser history (router-client.ts).
-import { createRouter, createRootRoute, createRoute } from '@octanejs/tanstack-router';
+import {
+	createRouter,
+	createRootRoute,
+	createRoute,
+	lazyRouteComponent,
+} from '@octanejs/tanstack-router';
 import { Layout } from '../components/Layout.tsrx';
 import { Home } from '../pages/Home.tsrx';
-import { Benchmarks } from '../pages/Benchmarks.tsrx';
-import { Playground } from '../pages/Playground.tsrx';
-import { DocsLayout } from '../pages/DocsLayout.tsrx';
-import { DocPage } from '../pages/DocPage.tsrx';
-import { NotFound } from '../pages/NotFound.tsrx';
+
+// The home route stays eager because it is the site's dominant entry point.
+// Everything else is a route chunk, so landing on / does not download the
+// playground/compiler, the docs corpus, or the full Recharts benchmark stack.
+const Benchmarks = lazyRouteComponent(() => import('../pages/Benchmarks.tsrx'), 'Benchmarks');
+const Playground = lazyRouteComponent(() => import('../pages/Playground.tsrx'), 'Playground');
+const DocsLayout = lazyRouteComponent(() => import('../pages/DocsLayout.tsrx'), 'DocsLayout');
+const DocPage = lazyRouteComponent(() => import('../pages/DocPage.tsrx'), 'DocPage');
+const NotFound = lazyRouteComponent(() => import('../pages/NotFound.tsrx'), 'NotFound');
 
 export interface RouterEnv {
 	/** A history instance (memory on the server, browser default on the client). */

--- a/website/src/components/DeferredBenchBars.tsrx
+++ b/website/src/components/DeferredBenchBars.tsrx
@@ -1,0 +1,54 @@
+// Keep the home-page chart out of the startup path without giving up the full
+// Recharts experience. SSR and hydration render the dependency-free SVG/table.
+// Shortly before the section scrolls into view, Activity reveals a lazy chart;
+// when it leaves the near-viewport range, Activity preserves that chart while a
+// same-size static fallback keeps the document geometry stable.
+import { Activity, lazy, useEffect, useRef, useState } from 'octane';
+import type { BenchCard } from '../content/benchmarks.ts';
+import { HomeBenchBars } from './HomeBenchBars.tsrx';
+
+const LazyBenchBars = lazy(
+	() => import('./BenchBars.tsrx').then((module) => ({ default: module.BenchBars })),
+);
+
+export function DeferredBenchBars(props: { card: BenchCard; width?: number }) @{
+	const hostRef = useRef<HTMLDivElement | null>(null);
+	const [isNear, setIsNear] = useState(false);
+	const [hasLoaded, setHasLoaded] = useState(false);
+
+	useEffect(() => {
+		const host = hostRef.current;
+		if (!host || typeof IntersectionObserver === 'undefined') {
+			setIsNear(true);
+			setHasLoaded(true);
+			return;
+		}
+		const observer = new IntersectionObserver((entries) => {
+			const near = entries[0]?.isIntersecting === true;
+			setIsNear(near);
+			if (near) setHasLoaded(true);
+		}, { rootMargin: '400px 0px' });
+		observer.observe(host);
+		return () => observer.disconnect();
+	});
+
+	<div class="deferred-bench" ref={hostRef}>
+		@if (!isNear) {
+			<HomeBenchBars card={props.card} />
+		}
+		<Activity mode={isNear && hasLoaded ? 'visible' : 'hidden'}>
+			@if (hasLoaded) {
+				@try {
+					<LazyBenchBars card={props.card} showValues={true} width={props.width ?? 1100} />
+				} @pending {
+					<HomeBenchBars card={props.card} />
+				}
+			}
+		</Activity>
+		<style>
+			.deferred-bench {
+				min-width: 0;
+			}
+		</style>
+	</div>
+}

--- a/website/src/components/HomeBenchBars.tsrx
+++ b/website/src/components/HomeBenchBars.tsrx
@@ -1,0 +1,245 @@
+// A dependency-free version of the home-page benchmark overview. The full
+// /benchmarks route uses Recharts for its richer charts; this below-the-fold
+// teaser stays static so charting and state-management runtimes are not part
+// of the home page's hydration path. The exact data remains available in the
+// native details/table immediately below the SVG.
+import type { BenchCard, BenchRow, SeriesDef } from '../content/benchmarks.ts';
+
+const CHART_WIDTH = 1100;
+const LABEL_WIDTH = 170;
+const PLOT_WIDTH = 820;
+// Match BenchBars' Recharts geometry so swapping the fallback in place does
+// not shift the document when it approaches the viewport.
+const BAR_HEIGHT = 11;
+const BAR_GAP = 2;
+const GROUP_GAP = 16;
+
+function fmtX(value: unknown): string {
+	const number =
+		typeof value === 'number' ? value : Number(value);
+	if (!Number.isFinite(number)) return '—';
+	if (number >= 10) return Math.round(number) + '×';
+	if (number >= 1) {
+		return (number === Math.round(number) ? String(number) : number.toFixed(1)) + '×';
+	}
+	return number.toFixed(2) + '×';
+}
+
+function maxValue(card: BenchCard): number {
+	let max = 1;
+	for (const row of card.rows) {
+		for (const series of card.series) {
+			const value = row[series.key];
+			if (typeof value === 'number') max = Math.max(max, value);
+		}
+	}
+	return max;
+}
+
+function barWidth(value: number, max: number): number {
+	return Math.max(2, (value / max) * PLOT_WIDTH);
+}
+
+function indexedRows(card: BenchCard): Array<{ row: BenchRow; index: number }> {
+	return card.rows.map((row, index) => ({ row, index }));
+}
+
+function indexedSeries(card: BenchCard): Array<{ series: SeriesDef; index: number }> {
+	return card.series.map((series, index) => ({ series, index }));
+}
+
+export function HomeBenchBars(props: { card: BenchCard }) @{
+	const { card } = props;
+	const rows = indexedRows(card);
+	const series = indexedSeries(card);
+	const groupHeight = card.series.length * (BAR_HEIGHT + BAR_GAP) + GROUP_GAP;
+	const chartHeight = card.rows.length * groupHeight + 24;
+	const max = maxValue(card);
+	<figure class="bench-card">
+		<figcaption class="bench-card-head">
+			<span class="bench-card-title">
+				{card.title as string}
+			</span>
+			<span class="bench-card-desc">
+				{card.description as string}
+			</span>
+		</figcaption>
+		<div class="bench-key-row" aria-hidden="true">
+			@for (const entry of series; key entry.series.key) {
+				<span class="bench-key">
+					<span class="bench-swatch" style={'background:' + entry.series.color}></span>
+					{entry.series.label as string}
+				</span>
+			}
+		</div>
+		<div class="bench-plot" aria-hidden="true">
+			<svg
+				class="home-bench-chart"
+				width={CHART_WIDTH}
+				height={chartHeight}
+				viewBox={'0 0 ' + CHART_WIDTH + ' ' + chartHeight}
+				focusable="false"
+			>
+				@for (const rowEntry of rows; key rowEntry.row.op) {
+					<>
+						<text
+							class="op-label"
+							x={LABEL_WIDTH - 12}
+							y={rowEntry.index * groupHeight + 14}
+							text-anchor="end"
+						>
+							{rowEntry.row.op as string}
+						</text>
+						@for (const seriesEntry of series; key seriesEntry.series.key) {
+							@if (typeof rowEntry.row[seriesEntry.series.key] === 'number') {
+								<>
+									<rect
+										x={LABEL_WIDTH}
+										y={rowEntry.index * groupHeight + seriesEntry.index * (BAR_HEIGHT + BAR_GAP) +
+											3}
+										width={barWidth(rowEntry.row[seriesEntry.series.key] as number, max)}
+										height={BAR_HEIGHT}
+										rx="3"
+										fill={seriesEntry.series.color}
+									></rect>
+									<text
+										class="value-label"
+										x={LABEL_WIDTH + barWidth(rowEntry.row[seriesEntry.series.key] as number, max) +
+											7}
+										y={rowEntry.index * groupHeight + seriesEntry.index * (BAR_HEIGHT + BAR_GAP) +
+											11}
+									>{fmtX(rowEntry.row[seriesEntry.series.key])}</text>
+								</>
+							}
+						}
+					</>
+				}
+			</svg>
+		</div>
+		<details class="bench-table">
+			<summary>Data table (× vs Octane, geometric mean across operations)</summary>
+			<table>
+				<thead>
+					<tr>
+						<th scope="col">operation</th>
+						@for (const entry of series; key entry.series.key) {
+							<th scope="col">
+								{entry.series.label as string}
+							</th>
+						}
+					</tr>
+				</thead>
+				<tbody>
+					@for (const rowEntry of rows; key rowEntry.row.op) {
+						<tr>
+							<th scope="row">
+								{rowEntry.row.op as string}
+							</th>
+							@for (const seriesEntry of series; key seriesEntry.series.key) {
+								<td>{fmtX(rowEntry.row[seriesEntry.series.key])}</td>
+							}
+						</tr>
+					}
+				</tbody>
+			</table>
+		</details>
+		<style>
+			.bench-card {
+				margin: 0;
+				background: #2b3138;
+				border: 1px solid rgba(255, 255, 255, 0.08);
+				border-radius: 12px;
+				padding: 1.25rem 1.25rem 0.75rem;
+				display: flex;
+				flex-direction: column;
+				gap: 0.75rem;
+				min-width: 0;
+			}
+			.bench-card-head {
+				display: flex;
+				flex-direction: column;
+				gap: 0.3rem;
+			}
+			.bench-card-title {
+				font-weight: 600;
+				color: #f6f7f9;
+				font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+				font-size: 0.95rem;
+			}
+			.bench-card-desc {
+				color: #99a1b3;
+				font-size: 0.85rem;
+				line-height: 1.45;
+			}
+			.bench-key-row {
+				display: flex;
+				flex-wrap: wrap;
+				gap: 0.4rem 1rem;
+			}
+			.bench-key {
+				display: inline-flex;
+				align-items: center;
+				gap: 0.4rem;
+				color: #99a1b3;
+				font-size: 0.8rem;
+			}
+			.bench-swatch {
+				width: 10px;
+				height: 10px;
+				border-radius: 3px;
+				display: inline-block;
+			}
+			.bench-plot,
+			.bench-table {
+				overflow-x: auto;
+			}
+			.home-bench-chart {
+				display: block;
+				max-width: none;
+			}
+			.op-label,
+			.value-label {
+				fill: #99a1b3;
+				font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+				font-size: 11px;
+			}
+			.bench-table {
+				border-top: 1px solid rgba(255, 255, 255, 0.08);
+				padding-top: 0.5rem;
+			}
+			.bench-table summary {
+				color: #99a1b3;
+				font-size: 0.8rem;
+				cursor: pointer;
+			}
+			.bench-table summary:hover {
+				color: #f6f7f9;
+			}
+			.bench-table table {
+				width: 100%;
+				min-width: max-content;
+				border-collapse: collapse;
+				margin: 0.6rem 0 0.4rem;
+				font-size: 0.8rem;
+				font-variant-numeric: tabular-nums;
+			}
+			.bench-table th,
+			.bench-table td {
+				text-align: right;
+				padding: 0.25rem 0.5rem;
+				color: #f6f7f9;
+				border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+				white-space: nowrap;
+			}
+			.bench-table thead th {
+				color: #99a1b3;
+				font-weight: 500;
+			}
+			.bench-table th[scope='row'] {
+				text-align: left;
+				color: #99a1b3;
+				font-weight: 400;
+			}
+		</style>
+	</figure>
+}

--- a/website/src/content/benchmarks.ts
+++ b/website/src/content/benchmarks.ts
@@ -388,48 +388,7 @@ export const OCTANE_CARDS: BenchCard[] = [];
 	});
 }
 
-// ---------------------------------------------------------------------------
-// Home-page summary — EVERY cross-framework suite on one normalized scale:
-// per suite and framework, the geometric mean of per-operation
-// (framework score ÷ octane-tsrx score). Octane is the 1× reference bar.
-// Ops without a measurement on either side — or with a sub-timer-resolution
-// 0 score — are skipped for that pair (geomean over the valid ops).
-// ---------------------------------------------------------------------------
-const SUMMARY_SERIES = FRAMEWORKS.filter((f) =>
-	['octane-tsrx', 'react', 'preact', 'solid', 'svelte', 'ripple', 'vue-vapor'].includes(f.key),
-);
-
-function geomeanVsOctane(card: BenchCard, key: string): number | undefined {
-	const ratios: number[] = [];
-	for (const row of card.rows) {
-		const octane = row['octane-tsrx'];
-		const value = row[key];
-		if (typeof octane === 'number' && octane > 0 && typeof value === 'number' && value > 0) {
-			ratios.push(value / octane);
-		}
-	}
-	if (ratios.length === 0) return undefined;
-	return Math.exp(ratios.reduce((sum, r) => sum + Math.log(r), 0) / ratios.length);
-}
-
-export const HOME_SUMMARY: BenchCard = (() => {
-	const rows: BenchRow[] = FRAMEWORK_CARDS.map((card) => {
-		const row: BenchRow = { op: card.id, 'octane-tsrx': 1 };
-		for (const s of SUMMARY_SERIES) {
-			if (s.key === 'octane-tsrx') continue;
-			const gm = geomeanVsOctane(card, s.key);
-			if (gm !== undefined) row[s.key] = gm;
-		}
-		return row;
-	});
-	return {
-		id: 'home-summary',
-		title: 'Every suite, normalized',
-		description:
-			'Geometric mean of per-operation benchmark scores, relative to Octane. Lower is better.',
-		series: SUMMARY_SERIES,
-		rows,
-		iterations: 0,
-		format: 'x',
-	};
-})();
+// The home page consumes a compact checked-in snapshot rather than pulling
+// every raw baseline into its client chunk. Its smoke test recomputes the
+// snapshot from FRAMEWORK_CARDS and catches drift.
+export { HOME_SUMMARY } from './home-benchmark.ts';

--- a/website/src/content/home-benchmark.ts
+++ b/website/src/content/home-benchmark.ts
@@ -1,0 +1,201 @@
+// Compact, checked-in home-page benchmark summary. Keep this separate from
+// `benchmarks.ts`: that module imports every raw baseline used by the full
+// /benchmarks page, while the home page only needs these normalized ratios.
+// The website smoke test recomputes this snapshot from FRAMEWORK_CARDS so a
+// changed baseline cannot silently leave the lighter home-page data stale.
+import type { BenchCard, BenchRow, SeriesDef } from './benchmarks.ts';
+
+const SUMMARY_SERIES: SeriesDef[] = [
+	{ key: 'octane-tsrx', label: 'Octane (.tsrx)', color: '#ff415a' },
+	{ key: 'react', label: 'React 19', color: '#1e93b0' },
+	{ key: 'preact', label: 'Preact 10', color: '#7478fb' },
+	{ key: 'solid', label: 'Solid 2.0 beta', color: '#1baf7a' },
+	{ key: 'svelte', label: 'Svelte 5', color: '#f57547' },
+	{ key: 'ripple', label: 'Ripple 0.3', color: '#9085e9' },
+	{ key: 'vue-vapor', label: 'Vue Vapor 3.6', color: '#e06ec4' },
+];
+
+export const HOME_SUMMARY: BenchCard = {
+	id: 'home-summary',
+	title: 'Every suite, normalized',
+	description:
+		'Geometric mean of per-operation benchmark scores, relative to Octane. Lower is better.',
+	series: SUMMARY_SERIES,
+	rows: [
+		{
+			op: 'js-framework',
+			'octane-tsrx': 1,
+			react: 2.638476513470999,
+			preact: 2.465063603778609,
+			solid: 1.1034246057346453,
+			svelte: 1.7081736428319363,
+			ripple: 1.1000965710727728,
+			'vue-vapor': 1.0006065498931602,
+		},
+		{
+			op: 'todomvc',
+			'octane-tsrx': 1,
+			react: 3.775843050546698,
+			preact: 4.254925544483783,
+			solid: 1.8242964756691702,
+			svelte: 1.3025900039570693,
+			ripple: 1.1922017977593637,
+			'vue-vapor': 1.529131557776048,
+		},
+		{
+			op: 'chat-stream',
+			'octane-tsrx': 1,
+			react: 3.103352169148047,
+			preact: 3.925550907312265,
+			solid: 1.1502652290705133,
+			svelte: 1.5881463262189783,
+			ripple: 1.180637656045611,
+			'vue-vapor': 0.9047709913228571,
+		},
+		{
+			op: 'js-framework-reorder',
+			'octane-tsrx': 1,
+			react: 2.873567113713346,
+			preact: 6.294075911033476,
+			solid: 1.662699267217151,
+			svelte: 2.238030127767983,
+			ripple: 1.5618949257503176,
+			'vue-vapor': 2.101208701819501,
+		},
+		{
+			op: 'dbmon',
+			'octane-tsrx': 1,
+			react: 1.9861638689547045,
+			preact: 2.5292434157627492,
+			solid: 2.6411925402039573,
+			svelte: 1.3177465470402894,
+			ripple: 1.273712017495525,
+			'vue-vapor': 1.1574821783555265,
+		},
+		{
+			op: 'effectful-list',
+			'octane-tsrx': 1,
+			react: 2.354245326068542,
+			preact: 5.127593543436272,
+			solid: 0.6946315525721587,
+			svelte: 0.8596431896063168,
+			ripple: 1.1217605808389748,
+			'vue-vapor': 0.8995496824493224,
+		},
+		{
+			op: 'memo-wall',
+			'octane-tsrx': 1,
+			react: 2.029245095468859,
+			preact: 2.458141887959391,
+			solid: 0.25280885564071065,
+			svelte: 0.6518266516283755,
+			ripple: 1.0838076870657005,
+			'vue-vapor': 0.22033043111352227,
+		},
+		{
+			op: 'recursive-context',
+			'octane-tsrx': 1,
+			react: 1.579140602480428,
+			preact: 1.6475929608212019,
+			solid: 1.0940719862811685,
+			svelte: 2.223083684016549,
+			ripple: 1.0620499784478001,
+			'vue-vapor': 1.0158786278279055,
+		},
+		{
+			op: 'signal-favoring',
+			'octane-tsrx': 1,
+			react: 7.40016992337849,
+			preact: 6.316812937679984,
+			solid: 0.7553507994945552,
+			svelte: 1.0919247403492898,
+			ripple: 0.3298102614161704,
+			'vue-vapor': 0.3982495677331262,
+		},
+		{
+			op: 'portal-swarm',
+			'octane-tsrx': 1,
+			react: 1.2311853981691683,
+			preact: 1.3834504963517578,
+			solid: 0.46512882844164016,
+			svelte: 1.2985599726380654,
+			ripple: 0.8247197191741089,
+			'vue-vapor': 0.9552103357273674,
+		},
+		{
+			op: 'async-waterfall',
+			'octane-tsrx': 1,
+			react: 12.323339460972882,
+			preact: 9.354838868712097,
+			solid: 0.9615611182974193,
+			svelte: 0.9631436220635455,
+			ripple: 0.944777199084522,
+		},
+		{
+			op: 'news',
+			'octane-tsrx': 1,
+			react: 1.4996697478122107,
+			preact: 1.1902014119730424,
+			solid: 0.932768262077367,
+			svelte: 0.5136015900919331,
+			ripple: 0.4864694857826731,
+			'vue-vapor': 0.6252071657374646,
+		},
+		{
+			op: 'streaming-ssr',
+			'octane-tsrx': 1,
+			react: 1.4131065295900815,
+			preact: 1.324327364877235,
+			solid: 4.513390573982908,
+			ripple: 1.257568386372009,
+		},
+		{
+			op: 'bundle-size',
+			'octane-tsrx': 1,
+			react: 0.9016499908468174,
+			preact: 0.5241231546520693,
+			solid: 0.6391550821731882,
+			svelte: 0.7421281350723717,
+			ripple: 0.7041097632363424,
+			'vue-vapor': 0.7094376934894691,
+		},
+		{
+			op: 'ssr-throughput',
+			'octane-tsrx': 1,
+			react: 3.0682659634581966,
+			preact: 2.845113414933771,
+			solid: 1.9402758649449858,
+			svelte: 1.2165674941247773,
+			ripple: 1.0837830908022226,
+			'vue-vapor': 1.1116467153973832,
+		},
+	],
+	iterations: 0,
+	format: 'x',
+};
+
+function geomeanVsOctane(card: BenchCard, key: string): number | undefined {
+	const ratios: number[] = [];
+	for (const row of card.rows) {
+		const octane = row['octane-tsrx'];
+		const value = row[key];
+		if (typeof octane === 'number' && octane > 0 && typeof value === 'number' && value > 0) {
+			ratios.push(value / octane);
+		}
+	}
+	if (ratios.length === 0) return undefined;
+	return Math.exp(ratios.reduce((sum, ratio) => sum + Math.log(ratio), 0) / ratios.length);
+}
+
+export function createHomeSummary(cards: BenchCard[]): BenchCard {
+	const rows: BenchRow[] = cards.map((card) => {
+		const row: BenchRow = { op: card.id, 'octane-tsrx': 1 };
+		for (const series of SUMMARY_SERIES) {
+			if (series.key === 'octane-tsrx') continue;
+			const geomean = geomeanVsOctane(card, series.key);
+			if (geomean !== undefined) row[series.key] = geomean;
+		}
+		return row;
+	});
+	return { ...HOME_SUMMARY, rows };
+}

--- a/website/src/pages/Home.tsrx
+++ b/website/src/pages/Home.tsrx
@@ -5,8 +5,8 @@
 // /benchmarks.
 import { Link } from '@octanejs/tanstack-router';
 import CodeSample from '../content/home-sample.mdx';
-import { BenchBars } from '../components/BenchBars.tsrx';
-import { HOME_SUMMARY } from '../content/benchmarks.ts';
+import { DeferredBenchBars } from '../components/DeferredBenchBars.tsrx';
+import { HOME_SUMMARY } from '../content/home-benchmark.ts';
 
 const FEATURES = [
 	{
@@ -53,8 +53,7 @@ export function Home() @{
 					>{'Inferno'}</a>
 					{', carrying its performance-first goal forward: React’s hooks, Suspense ' +
 						'and actions, compiled ahead of time. No virtual DOM. No rules of hooks. ' +
-						'No hand-maintained dependency arrays. Octane\'s compiler does all the heavy lifting.' +
-						'captures for you.'}
+						'No hand-maintained dependency arrays. Octane\'s compiler does all the heavy lifting for you.'}
 				</p>
 				<div class="hero-actions">
 					<Link to="/docs/quick-start" class="btn-primary">Get started</Link>
@@ -75,9 +74,9 @@ export function Home() @{
 		<section class="features">
 			@for (const feature of FEATURES; key feature.title) {
 				<article class="card">
-					<h3 class="card-title">
+					<h2 class="card-title">
 						{feature.title as string}
-					</h3>
+					</h2>
 					<p class="card-body">
 						{feature.body as string}
 					</p>
@@ -120,7 +119,7 @@ export function Home() @{
 				<Link to="/benchmarks" class="bench-all">All suites →</Link>
 			</div>
 			<div class="bench-grid">
-				<BenchBars card={HOME_SUMMARY} showValues={true} width={1100} />
+				<DeferredBenchBars card={HOME_SUMMARY} width={1100} />
 			</div>
 			<p class="bench-note">
 				{'Ratios are geometric means over each suite’s per-operation checked-in benchmark scores ('}
@@ -183,7 +182,7 @@ export function Home() @{
 			}
 			.hero-actions :global(a.btn-primary) {
 				background: #ff415a;
-				color: #f4eee8;
+				color: #16181d;
 				font-weight: 600;
 				padding: 0.7rem 1.4rem;
 				border-radius: 9999px;
@@ -336,6 +335,11 @@ export function Home() @{
 				color: #99a1b3;
 				font-size: 0.925rem;
 				max-width: 24rem;
+			}
+			.proven-label :global(a),
+			.bench-note :global(a) {
+				text-decoration: underline;
+				text-underline-offset: 0.16em;
 			}
 			.bench {
 				border-top: 1px solid rgba(255, 255, 255, 0.1);

--- a/website/tests/smoke.test.ts
+++ b/website/tests/smoke.test.ts
@@ -8,6 +8,7 @@ import { makeRouter } from '../src/app/router.ts';
 import { compactChartRows } from '../src/components/BenchBars.tsrx';
 import { docs, defaultDoc, docGroups } from '../src/content/docs.ts';
 import { FRAMEWORK_CARDS, HOME_SUMMARY, OCTANE_CARDS } from '../src/content/benchmarks.ts';
+import { createHomeSummary } from '../src/content/home-benchmark.ts';
 
 afterEach(cleanup);
 
@@ -32,6 +33,8 @@ async function renderRoute(url: string) {
 
 describe('website routes', () => {
 	it('publishes Preact and Svelte measurements for every supported comparison', () => {
+		expect(HOME_SUMMARY).toEqual(createHomeSummary(FRAMEWORK_CARDS));
+
 		for (const card of FRAMEWORK_CARDS) {
 			const keys = card.series.map((series) => series.key);
 			expect(keys, card.id).toContain('preact');

--- a/website/tests/ssr-hydration.e2e.test.ts
+++ b/website/tests/ssr-hydration.e2e.test.ts
@@ -203,7 +203,11 @@ async function loadRoute(base: string, path: string) {
 	return { page, errors, main, comments: bodyDom.comments, bodyDom, mainDom };
 }
 
-function assertCountedHydrationMarkers(bodyDom: DomNodeCensus, mainDom: DomNodeCensus): void {
+function assertCountedHydrationMarkers(
+	bodyDom: DomNodeCensus,
+	mainDom: DomNodeCensus,
+	expectedLeadingLogical: number,
+): void {
 	// Counted comments reduce physical DOM nodes while preserving the logical
 	// open/close multiplicity the hydration cursor consumes.
 	expect(bodyDom.hydrationMarkersLogical).toBeGreaterThan(bodyDom.hydrationMarkersPhysical);
@@ -211,11 +215,12 @@ function assertCountedHydrationMarkers(bodyDom: DomNodeCensus, mainDom: DomNodeC
 	expect(bodyDom.hydrationMarkerMaxMultiplicity).toBeGreaterThan(1);
 
 	// Every website route shares the router/provider prefix that motivated this
-	// protocol. Nineteen logical opens compact to five physical comments: the
-	// remaining splits are the independent Suspense frame/try range plus the
-	// shorter route-content span, not redundant wrapper bookkeeping.
+	// protocol. The eager home route has nineteen logical opens; route-level lazy
+	// components add one Suspense range, for twenty. Both compact to five physical
+	// comments: the remaining splits are independent Suspense frame/try ranges and
+	// the shorter route-content span, not redundant wrapper bookkeeping.
 	expect(mainDom.leadingHydrationStartsPhysical).toBe(5);
-	expect(mainDom.leadingHydrationStartsLogical).toBe(19);
+	expect(mainDom.leadingHydrationStartsLogical).toBe(expectedLeadingLogical);
 }
 
 async function waitForLocatorText(
@@ -265,7 +270,7 @@ describe.sequential('website dev-SSR → hydration (real browser)', () => {
 				expect(main.length).toBeGreaterThan(0);
 				// DOM-weight ratchet (see COMMENT_CEILINGS).
 				expect(comments).toBeLessThanOrEqual(COMMENT_CEILINGS[route]);
-				assertCountedHydrationMarkers(bodyDom, mainDom);
+				assertCountedHydrationMarkers(bodyDom, mainDom, route === '/' ? 19 : 20);
 			} finally {
 				await page.close();
 			}
@@ -462,7 +467,7 @@ describe.sequential('website production build → hydration (octane-preview)', (
 		try {
 			expect(errors).toEqual([]);
 			expect(main.length).toBeGreaterThan(0);
-			assertCountedHydrationMarkers(bodyDom, mainDom);
+			assertCountedHydrationMarkers(bodyDom, mainDom, route === '/' ? 19 : 20);
 		} finally {
 			await page.close();
 		}


### PR DESCRIPTION
## Summary

- add server compiler/runtime support for `<Activity>`, including visible rendering, hidden child elision, static markup, hydration adoption, nested Activities, and hydration-safe `useId` ordering
- keep the homepage chart dependency-free during SSR/startup, then reveal the lazy Recharts implementation near the viewport and preserve it with Activity
- split non-home routes so docs, playground, and benchmark code are not shipped on the homepage
- fix Lighthouse accessibility findings for contrast, color-only links, and heading order
- add Activity SSR/hydration coverage, documentation, and a patch changeset

## Why

The homepage loaded the full router corpus and charting stack on startup, which left roughly 97 KiB of avoidable JavaScript in the mobile Lighthouse trace. Activity was a natural fit for the below-the-fold chart, but Octane's server compiler explicitly rejected it, so it could not participate in a real SSR/hydration route.

This adds the missing SSR contract and uses a static, accessible chart until the interactive chart approaches the viewport.

## Impact

- deployment-like mobile Lighthouse: **100 Performance / 100 Accessibility / 100 Best Practices / 100 SEO**
- simulated mobile FCP: **1.3 s**
- simulated mobile LCP: **1.7 s**
- Total Blocking Time: **0 ms**
- homepage router JavaScript reduced from about **918 KB** to **134 KB** raw
- Recharts is not requested on initial page load

## Validation

- `pnpm test` — 893 files, 7,020 tests passed
- `pnpm typecheck`
- `pnpm format:check`
- production website build
- real-browser dev SSR and production preview hydration suite
- browser verification of Activity reveal/hide preservation and deferred Recharts loading
- Lighthouse 13.4.0 mobile run through deployment-like gzip delivery

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Core hydration and `useId` ordering changes are subtle and affect the SSR contract, though covered by new unit and e2e tests; website routing/lazy-loading is lower risk.
> 
> **Overview**
> **`<Activity>` is now supported in server mode** instead of being rejected: visible children render with hydratable block markers; `mode="hidden"` skips child evaluation on the server (empty range for hydration, nothing for static markup). The client adopts server ranges, **defers mounting hidden offscreen trees until after sibling hydration** (preserving `useId` order), and handles visible/hidden mismatches between server and client.
> 
> The **marketing site** lazy-loads non-home routes, moves the home benchmark summary into a **checked-in snapshot** (`home-benchmark.ts`), and replaces the always-on Recharts chart with a **static SVG/table fallback** that swaps to lazy Recharts inside `<Activity>` near the viewport. Small **accessibility** tweaks (contrast, link underlines, heading levels) and updated SSR e2e expectations for lazy-route Suspense markers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8521d40cba33f2fc8603979e46e8bb4da968e29e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->