### PR TITLE
Add React parity Wave 2 conformance ports

### DIFF
--- a/.changeset/fuzzy-lions-rest.md
+++ b/.changeset/fuzzy-lions-rest.md
@@ -1,0 +1,5 @@
+---
+"octane": patch
+---
+
+Align root lifecycle, Fragment and iterable reconciliation, element and Children APIs, and lazy function-component resolution with the pinned React 19 conformance cases. Class components, legacy roots, `forwardRef`, and other unsupported React-only surfaces remain explicit non-goals.

--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -169,11 +169,20 @@ these toward React without checking `docs/react-parity-migration-plan.md`:
   batch replay counts, or prefetch behavior toward React
   (docs/suspense-parallel-use-plan.md). True data dependencies stay sequential;
   unwrap order, hydration-seed order, and rejection routing match React.
+- **Root component entry point and safe external-DOM cleanup.** In addition to
+  `root.render(<App />)`, Octane intentionally supports `root.render(App, props)`.
+  A root whose managed DOM was externally removed unmounts safely instead of
+  surfacing the browser's incidental `NotFoundError` for an already-detached node.
+- **`lazy()` accepts bare components and component-form boundaries.** React's
+  module `{ default }` shape works, and Octane additionally accepts a component
+  directly from the loader. Suspense and ViewTransition are ordinary Octane
+  components, so wrapping them in `lazy()` is valid; nested lazy wrappers are not.
 - **`class` / `className` compose clsx-style.** Strings, numbers, arrays, objects,
   and nesting all compose into a class string (falsy drops out), at every apply site
   (client, spread, SVG, scoped `<style>`, SSR) via `normalizeClass`. React coerces an
   array `className` to `"a,b"`; Octane yields `"a b"`. A plain string is the fast path.
-- **No class components, no Server Components, no StrictMode double-invoke.**
+- **No class components, legacy `ReactDOM.render` roots, Server Components, or
+  StrictMode double-invoke.**
 - Octane otherwise matches React's observable hook/effect/Suspense/transition
   semantics — including effect ordering (child-first on mount, parent-first cleanup
   on deletion) and `useId` stability across server/client hydration.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -164,11 +164,20 @@ these toward React without checking `docs/react-parity-migration-plan.md`:
   batch replay counts, or prefetch behavior toward React
   (docs/suspense-parallel-use-plan.md). True data dependencies stay sequential;
   unwrap order, hydration-seed order, and rejection routing match React.
+- **Root component entry point and safe external-DOM cleanup.** In addition to
+  `root.render(<App />)`, Octane intentionally supports `root.render(App, props)`.
+  A root whose managed DOM was externally removed unmounts safely instead of
+  surfacing the browser's incidental `NotFoundError` for an already-detached node.
+- **`lazy()` accepts bare components and component-form boundaries.** React's
+  module `{ default }` shape works, and Octane additionally accepts a component
+  directly from the loader. Suspense and ViewTransition are ordinary Octane
+  components, so wrapping them in `lazy()` is valid; nested lazy wrappers are not.
 - **`class` / `className` compose clsx-style.** Strings, numbers, arrays, objects,
   and nesting all compose into a class string (falsy drops out), at every apply site
   (client, spread, SVG, scoped `<style>`, SSR) via `normalizeClass`. React coerces an
   array `className` to `"a,b"`; Octane yields `"a b"`. A plain string is the fast path.
-- **No class components, no Server Components, no StrictMode double-invoke.**
+- **No class components, legacy `ReactDOM.render` roots, Server Components, or
+  StrictMode double-invoke.**
 - Octane otherwise matches React's observable hook/effect/Suspense/transition
   semantics — including effect ordering (child-first on mount, parent-first cleanup
   on deletion) and `useId` stability across server/client hydration.

--- a/.prettierignore
+++ b/.prettierignore
@@ -17,6 +17,11 @@ packages/visx/**/*.tsrx.d.ts
 # upstream React-shaped TypeScript/JSX constructs used by the Visx port.
 packages/visx/**/*.tsrx
 
+# The fragment conformance fixture intentionally mirrors React's nested
+# return-position JSX Fragment/array ternaries, which the current TSRX Prettier
+# parser cannot parse even though the compiler accepts and executes them.
+packages/octane/tests/conformance/_fixtures/fragment-reconciliation.tsrx
+
 # Generated bench datasets (written by benchmarks/news/gen.mjs)
 benchmarks/news/*/src/data.js
 

--- a/.rulesync/rules/project.md
+++ b/.rulesync/rules/project.md
@@ -171,11 +171,20 @@ these toward React without checking `docs/react-parity-migration-plan.md`:
   batch replay counts, or prefetch behavior toward React
   (docs/suspense-parallel-use-plan.md). True data dependencies stay sequential;
   unwrap order, hydration-seed order, and rejection routing match React.
+- **Root component entry point and safe external-DOM cleanup.** In addition to
+  `root.render(<App />)`, Octane intentionally supports `root.render(App, props)`.
+  A root whose managed DOM was externally removed unmounts safely instead of
+  surfacing the browser's incidental `NotFoundError` for an already-detached node.
+- **`lazy()` accepts bare components and component-form boundaries.** React's
+  module `{ default }` shape works, and Octane additionally accepts a component
+  directly from the loader. Suspense and ViewTransition are ordinary Octane
+  components, so wrapping them in `lazy()` is valid; nested lazy wrappers are not.
 - **`class` / `className` compose clsx-style.** Strings, numbers, arrays, objects,
   and nesting all compose into a class string (falsy drops out), at every apply site
   (client, spread, SVG, scoped `<style>`, SSR) via `normalizeClass`. React coerces an
   array `className` to `"a,b"`; Octane yields `"a b"`. A plain string is the fast path.
-- **No class components, no Server Components, no StrictMode double-invoke.**
+- **No class components, legacy `ReactDOM.render` roots, Server Components, or
+  StrictMode double-invoke.**
 - Octane otherwise matches React's observable hook/effect/Suspense/transition
   semantics — including effect ordering (child-first on mount, parent-first cleanup
   on deletion) and `useId` stability across server/client hydration.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,11 +175,20 @@ these toward React without checking `docs/react-parity-migration-plan.md`:
   batch replay counts, or prefetch behavior toward React
   (docs/suspense-parallel-use-plan.md). True data dependencies stay sequential;
   unwrap order, hydration-seed order, and rejection routing match React.
+- **Root component entry point and safe external-DOM cleanup.** In addition to
+  `root.render(<App />)`, Octane intentionally supports `root.render(App, props)`.
+  A root whose managed DOM was externally removed unmounts safely instead of
+  surfacing the browser's incidental `NotFoundError` for an already-detached node.
+- **`lazy()` accepts bare components and component-form boundaries.** React's
+  module `{ default }` shape works, and Octane additionally accepts a component
+  directly from the loader. Suspense and ViewTransition are ordinary Octane
+  components, so wrapping them in `lazy()` is valid; nested lazy wrappers are not.
 - **`class` / `className` compose clsx-style.** Strings, numbers, arrays, objects,
   and nesting all compose into a class string (falsy drops out), at every apply site
   (client, spread, SVG, scoped `<style>`, SSR) via `normalizeClass`. React coerces an
   array `className` to `"a,b"`; Octane yields `"a b"`. A plain string is the fast path.
-- **No class components, no Server Components, no StrictMode double-invoke.**
+- **No class components, legacy `ReactDOM.render` roots, Server Components, or
+  StrictMode double-invoke.**
 - Octane otherwise matches React's observable hook/effect/Suspense/transition
   semantics — including effect ordering (child-first on mount, parent-first cleanup
   on deletion) and `useId` stability across server/client hydration.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,11 +164,20 @@ these toward React without checking `docs/react-parity-migration-plan.md`:
   batch replay counts, or prefetch behavior toward React
   (docs/suspense-parallel-use-plan.md). True data dependencies stay sequential;
   unwrap order, hydration-seed order, and rejection routing match React.
+- **Root component entry point and safe external-DOM cleanup.** In addition to
+  `root.render(<App />)`, Octane intentionally supports `root.render(App, props)`.
+  A root whose managed DOM was externally removed unmounts safely instead of
+  surfacing the browser's incidental `NotFoundError` for an already-detached node.
+- **`lazy()` accepts bare components and component-form boundaries.** React's
+  module `{ default }` shape works, and Octane additionally accepts a component
+  directly from the loader. Suspense and ViewTransition are ordinary Octane
+  components, so wrapping them in `lazy()` is valid; nested lazy wrappers are not.
 - **`class` / `className` compose clsx-style.** Strings, numbers, arrays, objects,
   and nesting all compose into a class string (falsy drops out), at every apply site
   (client, spread, SVG, scoped `<style>`, SSR) via `normalizeClass`. React coerces an
   array `className` to `"a,b"`; Octane yields `"a b"`. A plain string is the fast path.
-- **No class components, no Server Components, no StrictMode double-invoke.**
+- **No class components, legacy `ReactDOM.render` roots, Server Components, or
+  StrictMode double-invoke.**
 - Octane otherwise matches React's observable hook/effect/Suspense/transition
   semantics — including effect ordering (child-first on mount, parent-first cleanup
   on deletion) and `useId` stability across server/client hydration.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -175,11 +175,20 @@ these toward React without checking `docs/react-parity-migration-plan.md`:
   batch replay counts, or prefetch behavior toward React
   (docs/suspense-parallel-use-plan.md). True data dependencies stay sequential;
   unwrap order, hydration-seed order, and rejection routing match React.
+- **Root component entry point and safe external-DOM cleanup.** In addition to
+  `root.render(<App />)`, Octane intentionally supports `root.render(App, props)`.
+  A root whose managed DOM was externally removed unmounts safely instead of
+  surfacing the browser's incidental `NotFoundError` for an already-detached node.
+- **`lazy()` accepts bare components and component-form boundaries.** React's
+  module `{ default }` shape works, and Octane additionally accepts a component
+  directly from the loader. Suspense and ViewTransition are ordinary Octane
+  components, so wrapping them in `lazy()` is valid; nested lazy wrappers are not.
 - **`class` / `className` compose clsx-style.** Strings, numbers, arrays, objects,
   and nesting all compose into a class string (falsy drops out), at every apply site
   (client, spread, SVG, scoped `<style>`, SSR) via `normalizeClass`. React coerces an
   array `className` to `"a,b"`; Octane yields `"a b"`. A plain string is the fast path.
-- **No class components, no Server Components, no StrictMode double-invoke.**
+- **No class components, legacy `ReactDOM.render` roots, Server Components, or
+  StrictMode double-invoke.**
 - Octane otherwise matches React's observable hook/effect/Suspense/transition
   semantics — including effect ordering (child-first on mount, parent-first cleanup
   on deletion) and `useId` stability across server/client hydration.

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -181,6 +181,30 @@ vite plugin for React-timing waterfall semantics). Idiomatic sequential
   thenable ("uncached promise" dev warning), and a replay that discovers a new
   pending `use()` behind a data dependency gets a dev waterfall diagnostic.
 
+## Root component entry points and container ownership
+
+`root.render(<App />)` is React-compatible. Octane also retains its original
+compiled-component entry point, `root.render(App, props)`, which avoids creating
+an element descriptor at application bootstrap. A bare function passed to
+`root.render` is therefore intentional, not an invalid-child warning.
+
+After `root.unmount()`, the root is permanently closed. If outside code removes
+some of a root's managed DOM first, unmount still performs safe cleanup instead
+of surfacing the browser's incidental `NotFoundError` from removing an already
+detached node.
+
+## `lazy()` module resolution
+
+Like React, `lazy(load)` accepts a thenable that resolves to a module object with
+a `default` component. Octane additionally accepts a bare component as the
+resolved value, making named dynamic imports usable without a default-export
+shim. Nested lazy wrappers are rejected.
+
+React's Suspense and ViewTransition values are exotic element types and React
+rejects wrapping them in `lazy()`. Octane exposes those boundaries as ordinary
+component functions, so a lazy wrapper preserves their normal component
+behavior.
+
 ## Errors: `@try` / `@catch`, not class boundaries
 
 `@catch (err, reset)` (and the JSX `<ErrorBoundary>`) replaces class
@@ -203,9 +227,9 @@ rather than throwing.
 
 ## Not implemented (by design)
 
-Class components, Server Components/RSC, `StrictMode` double-invoke,
+Class components, legacy `ReactDOM.render` roots, Server Components/RSC, `StrictMode` double-invoke,
 `Profiler`, `SuspenseList`, `forwardRef`/`createRef` (refs are props),
-`useDebugValue` is a no-op, `cache()`, `React.Children` beyond the basics.
+`useDebugValue` is a no-op, and `cache()`.
 Resource hints ARE supported
 (`preload`/`preinit`/`preconnect`/`prefetchDNS`). React-19 custom-element
 listener semantics ARE supported (a function-valued lowercase `on*` prop on a

--- a/docs/react-parity-coverage.md
+++ b/docs/react-parity-coverage.md
@@ -11,16 +11,16 @@ This report separates distinct Octane tests, React upstream scenarios, renderer/
 
 | Measure | Count |
 | --- | ---: |
-| Normal core cases | 2,260 |
-| ↳ conformance | 985 |
+| Normal core cases | 2,480 |
+| ↳ conformance | 1,171 |
 | ↳ differential | 136 |
 | ↳ hydration | 135 |
-| ↳ other runtime/compiler/SSR | 1,004 |
+| ↳ other runtime/compiler/SSR | 1,038 |
 | Profiling-only cases | 14 |
-| Distinct core cases including profiling | 2,274 |
-| Production-compile reruns of normal core | 2,260 |
-| All workspace executions | 7,135 |
-| React-source-attributed file upper bound | 968 cases in 68 files |
+| Distinct core cases including profiling | 2,494 |
+| Production-compile reruns of normal core | 2,480 |
+| All workspace executions | 7,584 |
+| React-source-attributed file upper bound | 1,154 cases in 72 files |
 
 The production project reruns the same normal core cases in another compile mode; it is not another set of conformance ports. The React-source-attributed definition is: Every collected normal-core case in a local file containing at least one React upstream *-test.js or *-test.ts filename citation; this is a generous file-level upper bound, not a one-to-one port count. Counts were measured on 2026-07-15.
 
@@ -85,8 +85,8 @@ Every concrete case in either pinned inventory has exactly one ledger dispositio
 
 | Baseline | Cases | Untriaged | Planned | In progress | Covered | Documented | Blocked |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| stable | 5,345 | 4,449 | 862 | 0 | 29 | 5 | 0 |
-| canary | 5,413 | 4,506 | 868 | 0 | 34 | 5 | 0 |
+| stable | 5,345 | 4,449 | 655 | 0 | 194 | 47 | 0 |
+| canary | 5,413 | 4,506 | 660 | 0 | 200 | 47 | 0 |
 
 Classifications are `portable`, `adaptable`, `divergence`, and `non_goal`. A covered case requires live local test evidence; divergence and non-goal dispositions require a rationale.
 
@@ -98,10 +98,10 @@ Suite policies are machine-readable in `react-upstreams.json`; the first matchin
 | --- | ---: | ---: | --- | --- | --- | --- |
 | Effect Event semantics | 12 / 12 | 17 / 17 | critical | covered | runtime | Executable stable/canary adaptations cover fresh wrapper identity, render-call guards, commit-time publication, effect ordering, Activity/context integration, and suspended or failed renders. |
 | Untrusted URL security | 17 / 77 | 17 / 77 | critical | covered | runtime + SSR | An executable render-mode matrix covers one shared javascript: URL sanitizer across client, compiler-baked literals, SSR, streaming, updates, SVG, forms, and hydration. |
-| Root semantics | 27 / 27 | 27 / 27 | high | planned | runtime | Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals. |
-| Fragment reconciliation | 29 / 29 | 29 / 29 | high | planned | runtime | Expand fragment reconciliation, ref, nesting, and top-level outcome coverage. |
-| Element and Children APIs | 111 / 111 | 111 / 111 | high | planned | public API | Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API. |
-| Lazy components | 40 / 40 | 41 / 41 | high | planned | runtime | Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage. |
+| Root semantics | 27 / 27 | 27 / 27 | high | covered | runtime | Twenty-five public root cases have exact-title client and production-compile evidence; the component-body render entry point and safe teardown after external DOM removal are executable, documented divergences. |
+| Fragment reconciliation | 29 / 29 | 29 / 29 | high | covered | runtime | Twenty-eight fragment identity and reconciliation cases have exact-title client and production-compile evidence; React's internal lazy-to-element shape has a documented non-goal disposition and executable component-module adaptation. |
+| Element and Children APIs | 111 / 111 | 111 / 111 | high | covered | public API | Ninety-five public Children, element creation, clone, validation, iterable, thenable, key, ref, freezing, and function-default-prop cases have executable evidence; sixteen React owner/component-stack, legacy-transform, class, and private-element diagnostics are documented non-goals. |
+| Lazy components | 40 / 40 | 41 / 41 | high | covered | runtime | Nineteen lazy resolution, rejection, function-component default-prop, memo, identity, and reorder cases have executable evidence; three ergonomic/component-form differences and twenty unsupported class, forwardRef, legacy-root, owner-stack, or exotic-type cases have durable documented dispositions. |
 | External stores | 19 / 19 | 19 / 19 | high | planned | runtime | Port store mutation, snapshot consistency, selector, error, and hydration outcomes. |
 | Update reconciliation | 42 / 42 | 45 / 45 | high | planned | runtime | Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes. |
 | Fizz streaming | 207 / 207 | 207 / 207 | high | planned | SSR + hydration | Filter and port applicable streaming, abort, error, shell, resource, and hydration behavior. |
@@ -111,7 +111,7 @@ Suite policies are machine-readable in `react-upstreams.json`; the first matchin
 ### Migration sequence and exit criteria
 
 1. **Wave 1 — critical blockers (completed 2026-07-15):** Effect Event semantics and shared untrusted-URL sanitization are implemented, ported, and linked to executable ledger evidence.
-2. **Wave 2 — public API and reconciliation:** root, fragment, element/Children, and lazy-component outcomes.
+2. **Wave 2 — public API and reconciliation (completed 2026-07-15):** supported root, fragment, element/Children, and lazy-component outcomes have live evidence; excluded outcomes have durable divergence/non-goal dispositions.
 3. **Wave 3 — scheduling and stores:** update reconciliation and external-store consistency.
 4. **Wave 4 — server matrix:** applicable Fizz streaming cases, then the five-mode server integration matrix.
 5. **Residual audit:** assign risk and a durable disposition to every remaining untriaged case, with canary drift reviewed continuously.

--- a/packages/octane/audit/react-conformance-ledger.json
+++ b/packages/octane/audit/react-conformance-ledger.json
@@ -73,7 +73,7 @@
     },
     {
       "caseId": "react-case-v1:0040ee109c2d9cc29995",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMRoot-test.js",
       "title": "unmount is synchronous",
@@ -81,7 +81,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Root semantics",
-      "rationale": "Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals."
+      "rationale": "Executable stable/canary adaptations cover public createRoot, update, unmount, diagnostics, hydration, and scheduling outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "unmount is synchronous",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:00417ef0d20973d29585",
@@ -141,7 +148,7 @@
     },
     {
       "caseId": "react-case-v1:00a1d9019f87cac3d372",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should be called for each child in an iterable with keys",
@@ -149,7 +156,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should be called for each child in an iterable with keys",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:00a73765389f79a84d74",
@@ -461,7 +475,7 @@
     },
     {
       "caseId": "react-case-v1:01c885866e67e3932dcc",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMRoot-test.js",
       "title": "does not warn when creating second root after first one is unmounted",
@@ -469,7 +483,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Root semantics",
-      "rationale": "Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals."
+      "rationale": "Executable stable/canary adaptations cover public createRoot, update, unmount, diagnostics, hydration, and scheduling outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "does not warn when creating second root after first one is unmounted",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:01cba0092be00969ab52",
@@ -845,7 +866,7 @@
     },
     {
       "caseId": "react-case-v1:03b8ee0bccbb3be1c2d8",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementValidator-test.internal.js",
       "title": "does not warn when the element is directly in rest args",
@@ -853,7 +874,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "does not warn when the element is directly in rest args",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:03c5b429cc6d9e380838",
@@ -1101,7 +1129,7 @@
     },
     {
       "caseId": "react-case-v1:053526483b93f2addfdc",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactFragment-test.js",
       "title": "should render a single child via noop renderer",
@@ -1109,7 +1137,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Executable stable/canary adaptations cover fragment rendering, iterable children, keyed identity, nesting transitions, and top-level reorder outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "should render a single child via noop renderer",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:05363ffb8348eeb27169",
@@ -1233,15 +1268,15 @@
     },
     {
       "caseId": "react-case-v1:05e39cbc1f702263036d",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react/src/__tests__/ReactCreateElement-test.js",
       "title": "do not warn about outdated JSX transform if `key` is present",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Octane compiles .tsrx directly and does not implement React's classic/outdated JSX transform detection, so transform-specific diagnostics are outside its public runtime surface."
     },
     {
       "caseId": "react-case-v1:05f35862e4d7ecce8332",
@@ -1338,7 +1373,7 @@
     },
     {
       "caseId": "react-case-v1:0674695cf827513dbc50",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementClone-test.js",
       "title": "does not fail if config has no prototype",
@@ -1346,7 +1381,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "does not fail if config has no prototype",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:067c0932c4d069bd27b5",
@@ -1748,7 +1790,7 @@
     },
     {
       "caseId": "react-case-v1:081c741a5c8fe9f2f3ac",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should be called for each child in nested structure with mapping",
@@ -1756,7 +1798,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should be called for each child in nested structure with mapping",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:081f28f3503795422f1f",
@@ -1921,7 +1970,7 @@
     },
     {
       "caseId": "react-case-v1:08de6d4c718bf18546fa",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "mount and reorder",
@@ -1929,7 +1978,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Executable stable/canary adaptations cover lazy module resolution, rejection, default props, memo/ref-as-prop behavior, keyed identity, and supported boundary validation.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/lazy-components.test.ts",
+          "testName": "mount and reorder",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:08ecc099725de5ec0d82",
@@ -2142,15 +2198,15 @@
     },
     {
       "caseId": "react-case-v1:0a26524a41cf4b3fc57b",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "resolves props for class component without defaultProps",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Octane intentionally does not support class components; lazy function-component prop forwarding is covered independently without adapting this class-specific case."
     },
     {
       "caseId": "react-case-v1:0a2cb4ac2aabe7258b6b",
@@ -2326,7 +2382,7 @@
     },
     {
       "caseId": "react-case-v1:0b216aa6b10e0e3e99fe",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactFragment-test.js",
       "title": "should render an iterable via noop renderer",
@@ -2334,7 +2390,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Executable stable/canary adaptations cover fragment rendering, iterable children, keyed identity, nesting transitions, and top-level reorder outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "should render an iterable via noop renderer",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:0b243940ca2aafa104c8",
@@ -2354,7 +2417,7 @@
     },
     {
       "caseId": "react-case-v1:0b3b187478b8ab0dab78",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "throws if promise rejects",
@@ -2362,7 +2425,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Executable stable/canary adaptations cover lazy module resolution, rejection, default props, memo/ref-as-prop behavior, keyed identity, and supported boundary validation.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/lazy-components.test.ts",
+          "testName": "throws if promise rejects",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:0b46a00584da3422b926",
@@ -2782,7 +2852,7 @@
     },
     {
       "caseId": "react-case-v1:0d0011ae7ad741da6aa8",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementClone-test.js",
       "title": "should steal the ref if a new ref is specified",
@@ -2790,7 +2860,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should steal the ref if a new ref is specified",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:0d04ee2d81d65f027ca0",
@@ -2966,7 +3043,7 @@
     },
     {
       "caseId": "react-case-v1:0dcd4521f908ef05bd17",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "does not warn for flattened static children without keys",
@@ -2974,7 +3051,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "does not warn for flattened static children without keys",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:0dce14f5640634f3c9ea",
@@ -3449,7 +3533,7 @@
     },
     {
       "caseId": "react-case-v1:10dbe1d3dccaff3db485",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementClone-test.js",
       "title": "does not warn when the array contains a non-element",
@@ -3457,7 +3541,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "does not warn when the array contains a non-element",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:10de32fddda8d25ada5c",
@@ -3721,7 +3812,7 @@
     },
     {
       "caseId": "react-case-v1:12f7bc80cdab9b42814d",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactFragment-test.js",
       "title": "should preserve state of children nested at same level",
@@ -3729,7 +3820,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Executable stable/canary adaptations cover fragment rendering, iterable children, keyed identity, nesting transitions, and top-level reorder outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "should preserve state of children nested at same level",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:1301def7db52f42b39ea",
@@ -3959,7 +4057,7 @@
     },
     {
       "caseId": "react-case-v1:1448132785f947bcca4c",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementClone-test.js",
       "title": "throws an error if passed undefined",
@@ -3967,7 +4065,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "throws an error if passed undefined",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:14490a0f466d4fb3287f",
@@ -4351,7 +4456,7 @@
     },
     {
       "caseId": "react-case-v1:16768357591101014e88",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactFragment-test.js",
       "title": "should preserve state when it does not change positions",
@@ -4359,7 +4464,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Executable stable/canary adaptations cover fragment rendering, iterable children, keyed identity, nesting transitions, and top-level reorder outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "should preserve state when it does not change positions",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:167f6f616740d55a5b71",
@@ -4736,15 +4848,15 @@
     },
     {
       "caseId": "react-case-v1:189ee70958472962e69e",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react/src/__tests__/ReactElementValidator-test.internal.js",
       "title": "warns for fragments with illegal attributes",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Octane does not carry React owner metadata or its owner-aware Fragment illegal-prop warning stack; supported Fragment rendering and key behavior are covered elsewhere."
     },
     {
       "caseId": "react-case-v1:18b7fd9c5566dfb780ee",
@@ -4968,7 +5080,7 @@
     },
     {
       "caseId": "react-case-v1:19f90e2d76051dbc4f85",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "can reject synchronously without suspending",
@@ -4976,7 +5088,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Executable stable/canary adaptations cover lazy module resolution, rejection, default props, memo/ref-as-prop behavior, keyed identity, and supported boundary validation.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/lazy-components.test.ts",
+          "testName": "can reject synchronously without suspending",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:1a07f85c4f812b844f6b",
@@ -5541,7 +5660,7 @@
     },
     {
       "caseId": "react-case-v1:1cc08e43b954ece6d880",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactFragment-test.js",
       "title": "should not preserve state when switching a nested keyed fragment to a passthrough component",
@@ -5549,7 +5668,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Executable stable/canary adaptations cover fragment rendering, iterable children, keyed identity, nesting transitions, and top-level reorder outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "should not preserve state when switching a nested keyed fragment to a passthrough component",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:1cd2326e4396d898d4f5",
@@ -5618,7 +5744,7 @@
     },
     {
       "caseId": "react-case-v1:1d5078e7397819d72a42",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementValidator-test.internal.js",
       "title": "__self and __source are treated as normal props",
@@ -5626,7 +5752,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "__self and __source are treated as normal props",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:1d56d12c68a8c1fc183c",
@@ -5807,7 +5940,7 @@
     },
     {
       "caseId": "react-case-v1:1e1e32f15a6120163a3e",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should combine keys when map returns an array",
@@ -5815,7 +5948,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should combine keys when map returns an array",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:1e22df50132f8ed5d393",
@@ -5859,7 +5999,7 @@
     },
     {
       "caseId": "react-case-v1:1e593eb9691ac90666c0",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactCreateElement-test.js",
       "title": "is indistinguishable from a plain object",
@@ -5867,7 +6007,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "is indistinguishable from a plain object",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:1e5afd6c2afaa8caf71a",
@@ -6492,15 +6639,15 @@
     },
     {
       "caseId": "react-case-v1:216348ffac2b5bbbb9dc",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react/src/__tests__/ReactCreateElement-test.js",
       "title": "should warn when `key` is being accessed on composite element",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Octane does not install React's development-only props.key warning getter; element key behavior is covered through public createElement and cloneElement outcomes."
     },
     {
       "caseId": "react-case-v1:217df39c272a603b47bf",
@@ -6512,7 +6659,7 @@
     },
     {
       "caseId": "react-case-v1:2183840b74058cd6cbde",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "throws with a useful error when wrapping Fragment with lazy()",
@@ -6520,7 +6667,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Executable stable/canary adaptations cover lazy module resolution, rejection, default props, memo/ref-as-prop behavior, keyed identity, and supported boundary validation.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/lazy-components.test.ts",
+          "testName": "throws with a useful error when wrapping Fragment with lazy()",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:218e1aeb487808e15400",
@@ -7607,7 +7761,7 @@
     },
     {
       "caseId": "react-case-v1:27474abd1a29855c8cf8",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should return 0 for null children",
@@ -7615,7 +7769,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should return 0 for null children",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:2758acc3655fa4a72a14",
@@ -7763,7 +7924,7 @@
     },
     {
       "caseId": "react-case-v1:2810242bb31f4da0aa93",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactCreateElement-test.js",
       "title": "returns a complete element according to spec",
@@ -7771,7 +7932,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "returns a complete element according to spec",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:2810b3c516982072d12c",
@@ -7807,7 +7975,7 @@
     },
     {
       "caseId": "react-case-v1:28317151718d4686f9b2",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "warns for keys for arrays at the top level",
@@ -7815,11 +7983,18 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "warns for keys for arrays at the top level",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:28347300c63cf841c820",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactCreateElement-test.js",
       "title": "returns an immutable element",
@@ -7827,7 +8002,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "returns an immutable element",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:2845aa2e55f80e2d9594",
@@ -7899,7 +8081,7 @@
     },
     {
       "caseId": "react-case-v1:28b80e12d105fc389acd",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should return 0 for undefined children",
@@ -7907,7 +8089,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should return 0 for undefined children",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:28bd0b1ea372873c99df",
@@ -8208,15 +8397,22 @@
     },
     {
       "caseId": "react-case-v1:2a5e0e9389d2b28f93fd",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMRoot-test.js",
       "title": "throws if unmounting a root that has had its contents removed",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "divergence",
       "owner": "runtime",
       "workstream": "Root semantics",
-      "rationale": "Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals."
+      "rationale": "Octane deliberately treats external container mutation as safe cleanup during unmount instead of surfacing React's incidental DOM NotFoundError; the exact-title executable test pins the supported outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "throws if unmounting a root that has had its contents removed",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:2a771a01be4054c8474b",
@@ -8307,7 +8503,7 @@
     },
     {
       "caseId": "react-case-v1:2aef4c06f6e2c8bb8b19",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementClone-test.js",
       "title": "warns for keys for arrays of elements in rest args",
@@ -8315,7 +8511,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "warns for keys for arrays of elements in rest args",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:2b0e637598b2c9598f71",
@@ -8607,7 +8810,7 @@
     },
     {
       "caseId": "react-case-v1:2cfdcdf0926fe0a73d01",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactCreateElement-test.js",
       "title": "throws when adding a prop (in dev) after element creation",
@@ -8615,7 +8818,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "throws when adding a prop (in dev) after element creation",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:2d016c5d9ef55f38e755",
@@ -9123,15 +9333,15 @@
     },
     {
       "caseId": "react-case-v1:2fe3e42b5e7d51ae8f03",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react/src/__tests__/ReactElementValidator-test.internal.js",
       "title": "warns for keys for arrays with no owner or parent info",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "This case exists to pin React's owner/parent context in a development warning. Octane emits a framework-native missing-key diagnostic without React owner metadata; top-level array warning behavior is covered separately."
     },
     {
       "caseId": "react-case-v1:2feda8828e3cdbf2adb3",
@@ -9427,7 +9637,7 @@
     },
     {
       "caseId": "react-case-v1:31cc4e6330fe4ad6c769",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementClone-test.js",
       "title": "should ignore key and ref warning getters",
@@ -9435,7 +9645,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should ignore key and ref warning getters",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:31d2e83cfbe6d1e6a866",
@@ -9455,7 +9672,7 @@
     },
     {
       "caseId": "react-case-v1:31de56d8b2a3f5ade2c9",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should render React.lazy after suspending",
@@ -9463,11 +9680,18 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should render React.lazy after suspending",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:31ed490dfa49477466a0",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactCreateElement-test.js",
       "title": "extracts null key",
@@ -9475,7 +9699,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "extracts null key",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:31fad0b1a9209f4f402d",
@@ -9543,7 +9774,7 @@
     },
     {
       "caseId": "react-case-v1:327b387b32476db12e48",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactFragment-test.js",
       "title": "should not preserve state between array nested in fragment and double nested fragment",
@@ -9551,7 +9782,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Executable stable/canary adaptations cover fragment rendering, iterable children, keyed identity, nesting transitions, and top-level reorder outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "should not preserve state between array nested in fragment and double nested fragment",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:328716634d69c5cbcc47",
@@ -9571,7 +9809,7 @@
     },
     {
       "caseId": "react-case-v1:3293849d3a13be603069",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMRoot-test.js",
       "title": "supports hydration",
@@ -9579,7 +9817,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Root semantics",
-      "rationale": "Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals."
+      "rationale": "Executable stable/canary adaptations cover public createRoot, update, unmount, diagnostics, hydration, and scheduling outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "supports hydration",
+          "modes": ["client", "server-string", "hydrate-match", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:32a5b9e0e627f717fb22",
@@ -9643,7 +9888,7 @@
     },
     {
       "caseId": "react-case-v1:32cabd2f75347c15bb9f",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactFragment-test.js",
       "title": "should preserve state with reordering in multiple levels",
@@ -9651,7 +9896,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Executable stable/canary adaptations cover fragment rendering, iterable children, keyed identity, nesting transitions, and top-level reorder outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "should preserve state with reordering in multiple levels",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:32ce0858d73f7ae49c47",
@@ -9795,7 +10047,7 @@
     },
     {
       "caseId": "react-case-v1:331ca6ecddc5cb4735dd",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMRoot-test.js",
       "title": "should reuse markup if rendering to the same target twice",
@@ -9803,7 +10055,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Root semantics",
-      "rationale": "Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals."
+      "rationale": "Executable stable/canary adaptations cover public createRoot, update, unmount, diagnostics, hydration, and scheduling outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "should reuse markup if rendering to the same target twice",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:3320c4fd7e448df44f6f",
@@ -9925,7 +10184,7 @@
     },
     {
       "caseId": "react-case-v1:3398f999100ebd7682fc",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactCreateElement-test.js",
       "title": "extracts key from the rest of the props",
@@ -9933,7 +10192,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "extracts key from the rest of the props",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:3398fe507987163e2acb",
@@ -10209,7 +10475,7 @@
     },
     {
       "caseId": "react-case-v1:34e5a8272d6f7311f0a1",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should use the same key for a cloned element with key",
@@ -10217,7 +10483,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should use the same key for a cloned element with key",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:34e7282c2eedd021bf10",
@@ -10825,7 +11098,7 @@
     },
     {
       "caseId": "react-case-v1:385e4df97a045fee6a29",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "can resolve synchronously without suspending",
@@ -10833,7 +11106,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Executable stable/canary adaptations cover lazy module resolution, rejection, default props, memo/ref-as-prop behavior, keyed identity, and supported boundary validation.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/lazy-components.test.ts",
+          "testName": "can resolve synchronously without suspending",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:38636c8bde44f93e9b39",
@@ -10913,7 +11193,7 @@
     },
     {
       "caseId": "react-case-v1:38b2d27c704f1d9c1d88",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should escape keys",
@@ -10921,11 +11201,18 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should escape keys",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:38bd29a65eedf5431366",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should traverse children of different kinds",
@@ -10933,7 +11220,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should traverse children of different kinds",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:38c876473b7200fe58fd",
@@ -12477,7 +12771,7 @@
     },
     {
       "caseId": "react-case-v1:4022db77121212f30a78",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should support identity for simple",
@@ -12485,7 +12779,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should support identity for simple",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:4026952d914b0d101326",
@@ -12680,7 +12981,7 @@
     },
     {
       "caseId": "react-case-v1:414869eb83147e5bb7e4",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementValidator-test.internal.js",
       "title": "does not warn for keys when passing children down",
@@ -12688,7 +12989,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "does not warn for keys when passing children down",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:4171a65670ff8912a4a1",
@@ -13112,7 +13420,7 @@
     },
     {
       "caseId": "react-case-v1:43a16ca4e9b90c596d73",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "throws with a useful error when wrapping Activity with lazy()",
@@ -13120,7 +13428,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Executable stable/canary adaptations cover lazy module resolution, rejection, default props, memo/ref-as-prop behavior, keyed identity, and supported boundary validation.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/lazy-components.test.ts",
+          "testName": "throws with a useful error when wrapping Activity with lazy()",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:43aff7a569894794f95a",
@@ -13320,7 +13635,7 @@
     },
     {
       "caseId": "react-case-v1:44e435de960daf173ec4",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactTopLevelFragment-test.js",
       "title": "should preserve state in a reorder",
@@ -13328,7 +13643,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Executable stable/canary adaptations cover fragment rendering, iterable children, keyed identity, nesting transitions, and top-level reorder outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "should preserve state in a reorder",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:44ec343eca7007c135d8",
@@ -13785,7 +14107,7 @@
     },
     {
       "caseId": "react-case-v1:471fcb63ad887bbe73fb",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMRoot-test.js",
       "title": "warn if no children passed to hydrateRoot",
@@ -13793,7 +14115,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Root semantics",
-      "rationale": "Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals."
+      "rationale": "Executable stable/canary adaptations cover public createRoot, update, unmount, diagnostics, hydration, and scheduling outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "warn if no children passed to hydrateRoot",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:473b85228c624e1eea70",
@@ -13833,7 +14162,7 @@
     },
     {
       "caseId": "react-case-v1:47899b37f97008d1d115",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should support Portal components",
@@ -13841,7 +14170,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should support Portal components",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:47940cd1b652b13f6273",
@@ -14217,15 +14553,22 @@
     },
     {
       "caseId": "react-case-v1:4967f31fbc6eee26f3ef",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "throws with a useful error when wrapping Suspense with lazy()",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "divergence",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "React represents Suspense as an exotic element type and rejects it through lazy(); Octane's Suspense boundary is an ordinary component function, so lazy wrapping is valid. The combined executable test pins the component-form boundary contract.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/lazy-components.test.ts",
+          "testName": "allows lazy wrappers around component-form framework boundaries",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:49687b26cc623aa81106",
@@ -14409,15 +14752,15 @@
     },
     {
       "caseId": "react-case-v1:4a85b0a78c889902bd9e",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "resolves props for class component with defaultProps",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Octane intentionally does not support class components; applicable function-component default-prop behavior is covered independently without adapting this class-specific case."
     },
     {
       "caseId": "react-case-v1:4a8a3dca8582fb4c1b6a",
@@ -14689,7 +15032,7 @@
     },
     {
       "caseId": "react-case-v1:4bdc30045438074c8339",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactFragment-test.js",
       "title": "should not preserve state of children when the keys are different",
@@ -14697,7 +15040,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Executable stable/canary adaptations cover fragment rendering, iterable children, keyed identity, nesting transitions, and top-level reorder outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "should not preserve state of children when the keys are different",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:4bdddf3f1424563d179d",
@@ -14717,7 +15067,7 @@
     },
     {
       "caseId": "react-case-v1:4be1e7da30b7b7f1eb62",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "warns for mapped list children without keys",
@@ -14725,7 +15075,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "warns for mapped list children without keys",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:4beab319412534c97063",
@@ -14745,15 +15102,22 @@
     },
     {
       "caseId": "react-case-v1:4bf918846620c6dc28b4",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "throws with a useful error when wrapping ViewTransition with lazy()",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "divergence",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "React represents ViewTransition as an exotic element type and rejects it through lazy(); Octane's ViewTransition boundary is an ordinary component function, so lazy wrapping is valid. The combined executable test pins the component-form boundary contract.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/lazy-components.test.ts",
+          "testName": "allows lazy wrappers around component-form framework boundaries",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:4bf994cf8c80e5c81c7b",
@@ -15002,7 +15366,7 @@
     },
     {
       "caseId": "react-case-v1:4d132de006b56eca4a63",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should render cached Promises after suspending",
@@ -15010,7 +15374,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should render cached Promises after suspending",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:4d1ca8631d2b62aea083",
@@ -15022,15 +15393,15 @@
     },
     {
       "caseId": "react-case-v1:4d1ed7b900dd15e96c30",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react/src/__tests__/ReactElementValidator-test.internal.js",
       "title": "does not warn when using DOM node as children",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "This case depends on a React class lifecycle passing an imperative DOM node as a child; Octane intentionally has no class components and DOM nodes are not declarative children."
     },
     {
       "caseId": "react-case-v1:4d2ce427f252b418ceb8",
@@ -15266,7 +15637,7 @@
     },
     {
       "caseId": "react-case-v1:4eed09a355b85ddd687f",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementClone-test.js",
       "title": "should clone a DOM component with new props",
@@ -15274,7 +15645,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should clone a DOM component with new props",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:4efdb0c6e62fbfda83ac",
@@ -15302,7 +15680,7 @@
     },
     {
       "caseId": "react-case-v1:4f1c92efcbf81d6695c9",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactCreateElement-test.js",
       "title": "merges rest arguments onto the children prop in an array",
@@ -15310,7 +15688,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "merges rest arguments onto the children prop in an array",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:4f47033971eaa4f2c735",
@@ -15754,15 +16139,15 @@
     },
     {
       "caseId": "react-case-v1:51a465b344f54da722b7",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "resolves defaultProps without breaking memoization",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "The upstream oracle depends on a descendant class instance updating through setState while its lazy class parent stays memoized. Octane has no class instances; function-component lazy memo behavior is covered independently."
     },
     {
       "caseId": "react-case-v1:51a5da0e74e27617ff56",
@@ -15970,7 +16355,7 @@
     },
     {
       "caseId": "react-case-v1:52db8586767f8c76542b",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactTopLevelFragment-test.js",
       "title": "preserves state if an implicit key slot switches from/to null",
@@ -15978,7 +16363,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Executable stable/canary adaptations cover fragment rendering, iterable children, keyed identity, nesting transitions, and top-level reorder outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "preserves state if an implicit key slot switches from/to null",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:52dddf34e93deb9cb890",
@@ -16267,7 +16659,7 @@
     },
     {
       "caseId": "react-case-v1:548e9f85dd5d2b4da0b8",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactCreateElement-test.js",
       "title": "does not override children if no rest args are provided",
@@ -16275,7 +16667,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "does not override children if no rest args are provided",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:5490e1b0cedba668967b",
@@ -16732,7 +17131,7 @@
     },
     {
       "caseId": "react-case-v1:5733408eeeb95b6954d0",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactFragment-test.js",
       "title": "should preserve state between double nested fragment and double nested array",
@@ -16740,7 +17139,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Executable stable/canary adaptations cover fragment rendering, iterable children, keyed identity, nesting transitions, and top-level reorder outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "should preserve state between double nested fragment and double nested array",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:5733817cff74c2cb7870",
@@ -16952,7 +17358,7 @@
     },
     {
       "caseId": "react-case-v1:5874032f1b83167d07d2",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "does not throw on children without `_store`",
@@ -16960,7 +17366,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "does not throw on children without `_store`",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:58776ec898262d66312c",
@@ -17475,7 +17888,7 @@
     },
     {
       "caseId": "react-case-v1:5ad26c3c77da070b2c73",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementValidator-test.internal.js",
       "title": "should not enumerate enumerable numbers (#4776)",
@@ -17483,7 +17896,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should not enumerate enumerable numbers (#4776)",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:5ad3bd7f54fc7ed78ae2",
@@ -17700,15 +18120,15 @@
     },
     {
       "caseId": "react-case-v1:5c25e8acc9cfbba05ae3",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react/src/__tests__/ReactElementValidator-test.internal.js",
       "title": "includes the owner name when passing null, undefined, boolean, or number",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Octane's compiler diagnoses invalid TSRX element types at authoring time and does not reproduce React's runtime owner-stack diagnostics, so this internal validator case is outside the runtime API."
     },
     {
       "caseId": "react-case-v1:5c29073ad416dd802d20",
@@ -17788,7 +18208,7 @@
     },
     {
       "caseId": "react-case-v1:5c736a657f89608bdf90",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactCreateElement-test.js",
       "title": "throws when changing a prop (in dev) after element creation",
@@ -17796,7 +18216,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "throws when changing a prop (in dev) after element creation",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:5c85b544cb3c18424290",
@@ -18511,7 +18938,7 @@
     },
     {
       "caseId": "react-case-v1:600afe76a837905e0254",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMRoot-test.js",
       "title": "warns when given a symbol",
@@ -18519,7 +18946,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Root semantics",
-      "rationale": "Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals."
+      "rationale": "Executable stable/canary adaptations cover public createRoot, update, unmount, diagnostics, hydration, and scheduling outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "warns when given a symbol",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:60108ee2261f493b2392",
@@ -19101,7 +19535,7 @@
     },
     {
       "caseId": "react-case-v1:62e2e74df813d4d851cc",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementClone-test.js",
       "title": "throws an error if passed null",
@@ -19109,7 +19543,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "throws an error if passed null",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:62e44353cdca659e6a60",
@@ -19285,7 +19726,7 @@
     },
     {
       "caseId": "react-case-v1:63ba6bbbb279f77458ec",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementClone-test.js",
       "title": "should transfer children",
@@ -19293,7 +19734,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should transfer children",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:63db65ab2afa9c875d2e",
@@ -19425,7 +19873,7 @@
     },
     {
       "caseId": "react-case-v1:646448c14fa003ab5292",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should retain key across two mappings with conditions",
@@ -19433,7 +19881,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should retain key across two mappings with conditions",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:648d0312f36f794c9e7e",
@@ -19445,7 +19900,7 @@
     },
     {
       "caseId": "react-case-v1:648f7ae5cf2f156eb356",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMRoot-test.js",
       "title": "throws if an unmounted root is updated",
@@ -19453,7 +19908,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Root semantics",
-      "rationale": "Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals."
+      "rationale": "Executable stable/canary adaptations cover public createRoot, update, unmount, diagnostics, hydration, and scheduling outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "throws if an unmounted root is updated",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:64b0302b36f99bfef030",
@@ -19609,7 +20071,7 @@
     },
     {
       "caseId": "react-case-v1:65b4a0a31508ee68bb69",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "warns for cloned list children without keys",
@@ -19617,7 +20079,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "warns for cloned list children without keys",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:65bb483b12bbcd3fe266",
@@ -19727,7 +20196,7 @@
     },
     {
       "caseId": "react-case-v1:663286a1ba0538cd8d23",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMRoot-test.js",
       "title": "can be immediately unmounted",
@@ -19735,7 +20204,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Root semantics",
-      "rationale": "Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals."
+      "rationale": "Executable stable/canary adaptations cover public createRoot, update, unmount, diagnostics, hydration, and scheduling outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "can be immediately unmounted",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:6634f15e6e71a554f419",
@@ -20125,7 +20601,7 @@
     },
     {
       "caseId": "react-case-v1:68afbcb24b4563035c4f",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactTopLevelFragment-test.js",
       "title": "should preserve state when switching from a single child",
@@ -20133,7 +20609,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Executable stable/canary adaptations cover fragment rendering, iterable children, keyed identity, nesting transitions, and top-level reorder outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "should preserve state when switching from a single child",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:68bba1082f1a05d64237",
@@ -20331,7 +20814,7 @@
     },
     {
       "caseId": "react-case-v1:698d65cb8b798db9d134",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactCreateElement-test.js",
       "title": "ignores undefined key and ref",
@@ -20339,7 +20822,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "ignores undefined key and ref",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:6993a6f9497290290a45",
@@ -20447,7 +20937,7 @@
     },
     {
       "caseId": "react-case-v1:6a023dd71345d51207f9",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should be called for each child in an iterable without keys",
@@ -20455,7 +20945,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should be called for each child in an iterable without keys",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:6a118182e89c83bba17e",
@@ -20483,15 +20980,22 @@
     },
     {
       "caseId": "react-case-v1:6a5a67ac8183a1752b22",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactFragment-test.js",
       "title": "should preserve state of children when adding a fragment wrapped in Lazy",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "React's internal test resolves lazy() to an already-created element, outside lazy()'s documented component-module contract. Octane's executable adaptation resolves a valid component module and pins the resulting identity boundary.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "should preserve state of children when adding a fragment wrapped in Lazy",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:6a5e296316cae0311cf2",
@@ -20604,7 +21108,7 @@
     },
     {
       "caseId": "react-case-v1:6b06ca6740783b378cdd",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMRoot-test.js",
       "title": "warns if creating a root on the document.body",
@@ -20612,7 +21116,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Root semantics",
-      "rationale": "Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals."
+      "rationale": "Executable stable/canary adaptations cover public createRoot, update, unmount, diagnostics, hydration, and scheduling outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "warns if creating a root on the document.body",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:6b0956104592730f7f32",
@@ -20860,7 +21371,7 @@
     },
     {
       "caseId": "react-case-v1:6c5d1d6d227c390e42a3",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should return 1 for single child",
@@ -20868,7 +21379,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should return 1 for single child",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:6c5f744996137959a90a",
@@ -21697,7 +22215,7 @@
     },
     {
       "caseId": "react-case-v1:71439264ad7935345ab5",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "renders a lazy context provider",
@@ -21705,7 +22223,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Executable stable/canary adaptations cover lazy module resolution, rejection, default props, memo/ref-as-prop behavior, keyed identity, and supported boundary validation.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/lazy-components.test.ts",
+          "testName": "renders a lazy context provider",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:714efec82c6d2c57f4b1",
@@ -21930,7 +22455,7 @@
     },
     {
       "caseId": "react-case-v1:725d3a3f2cc9b6c6fc4c",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "throws with a useful error when wrapping lazy() multiple times",
@@ -21938,7 +22463,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Executable stable/canary adaptations cover lazy module resolution, rejection, default props, memo/ref-as-prop behavior, keyed identity, and supported boundary validation.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/lazy-components.test.ts",
+          "testName": "throws with a useful error when wrapping lazy() multiple times",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:726507d0c86b44b547a3",
@@ -21974,7 +22506,7 @@
     },
     {
       "caseId": "react-case-v1:72b0f75f26631bd02b77",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should pass key to returned component",
@@ -21982,7 +22514,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should pass key to returned component",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:72da13c5c38817f5f1a3",
@@ -22161,7 +22700,7 @@
     },
     {
       "caseId": "react-case-v1:73acaa4011f61c5bb15d",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "does not warn for mapped static children without keys",
@@ -22169,7 +22708,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "does not warn for mapped static children without keys",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:73afbbcb7403ad697d86",
@@ -22831,7 +23377,7 @@
     },
     {
       "caseId": "react-case-v1:77718f78a460228c41d0",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementClone-test.js",
       "title": "should accept children as rest arguments",
@@ -22839,7 +23385,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should accept children as rest arguments",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:7777109fd7bf4a108f7c",
@@ -23031,7 +23584,7 @@
     },
     {
       "caseId": "react-case-v1:78e1eb55365bf5a70980",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should count the number of children in flat structure",
@@ -23039,7 +23592,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should count the number of children in flat structure",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:78e9921333ed98163466",
@@ -23296,7 +23856,7 @@
     },
     {
       "caseId": "react-case-v1:7a674f0d090b7b1ab5ba",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactFragment-test.js",
       "title": "should not preserve state in non-top-level fragment nesting",
@@ -23304,7 +23864,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Executable stable/canary adaptations cover fragment rendering, iterable children, keyed identity, nesting transitions, and top-level reorder outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "should not preserve state in non-top-level fragment nesting",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:7a6b80ea6e353ff81a8e",
@@ -23324,7 +23891,7 @@
     },
     {
       "caseId": "react-case-v1:7a7abaf6de1fd5ad70a0",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactFragment-test.js",
       "title": "should render zero children via noop renderer",
@@ -23332,7 +23899,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Executable stable/canary adaptations cover fragment rendering, iterable children, keyed identity, nesting transitions, and top-level reorder outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "should render zero children via noop renderer",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:7a8a2128c1f32e880b79",
@@ -23360,7 +23934,7 @@
     },
     {
       "caseId": "react-case-v1:7ade55698f5a16ffbac2",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactFragment-test.js",
       "title": "should not preserve state when switching to a keyed fragment to an array",
@@ -23368,7 +23942,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Executable stable/canary adaptations cover fragment rendering, iterable children, keyed identity, nesting transitions, and top-level reorder outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "should not preserve state when switching to a keyed fragment to an array",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:7ae65ba89d86ab6a973a",
@@ -23553,7 +24134,7 @@
     },
     {
       "caseId": "react-case-v1:7be55812c41565ea733d",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactCreateElement-test.js",
       "title": "should normalize props with default values",
@@ -23561,7 +24142,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should normalize props with default values",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:7bf268961b4a9e4b318a",
@@ -23935,7 +24523,7 @@
     },
     {
       "caseId": "react-case-v1:7e06213efc229d2b0fb4",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMRoot-test.js",
       "title": "renders children",
@@ -23943,7 +24531,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Root semantics",
-      "rationale": "Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals."
+      "rationale": "Executable stable/canary adaptations cover public createRoot, update, unmount, diagnostics, hydration, and scheduling outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "renders children",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:7e148b34059b18cc4e8d",
@@ -24391,7 +24986,7 @@
     },
     {
       "caseId": "react-case-v1:7ff61dc246fbdbec0221",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactTopLevelFragment-test.js",
       "title": "should not preserve state when switching to a nested array",
@@ -24399,11 +24994,18 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Executable stable/canary adaptations cover fragment rendering, iterable children, keyed identity, nesting transitions, and top-level reorder outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "should not preserve state when switching to a nested array",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:7ffe38742949cfe14bf3",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementClone-test.js",
       "title": "should ignore undefined key and ref",
@@ -24411,11 +25013,18 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should ignore undefined key and ref",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:8001a4cfac5de984e382",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementValidator-test.internal.js",
       "title": "does not warns for arrays of elements with keys",
@@ -24423,7 +25032,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "does not warns for arrays of elements with keys",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:800287e9078a1735c540",
@@ -24804,7 +25420,7 @@
     },
     {
       "caseId": "react-case-v1:81e6c07670c087307286",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementClone-test.js",
       "title": "should overwrite props",
@@ -24812,7 +25428,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should overwrite props",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:81f8a2c7c3dadbcf6696",
@@ -25082,15 +25705,15 @@
     },
     {
       "caseId": "react-case-v1:83bc5fb898d3660bd1d6",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "resolves defaultProps without breaking bailout due to unchanged props and state, #17151",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "The upstream oracle uses class-instance setState(null) bailout semantics. Octane has no class instances; lazy memo behavior is covered by an Octane-native comparator and render-body regression."
     },
     {
       "caseId": "react-case-v1:83c8789f5f13605cdd23",
@@ -25175,7 +25798,7 @@
     },
     {
       "caseId": "react-case-v1:846d32bae19289484cab",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should not throw if key provided is a dupe with array key",
@@ -25183,7 +25806,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should not throw if key provided is a dupe with array key",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:846f9010bf8141440adf",
@@ -26020,15 +26650,15 @@
     },
     {
       "caseId": "react-case-v1:88a8f59a44aba4d682b3",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "should error with a component stack naming the resolved component",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Octane does not implement React's owner/component-stack development-warning machinery; lazy resolution and rejection behavior is covered separately at the public error boundary."
     },
     {
       "caseId": "react-case-v1:88aa12afdfb8fedd0ff1",
@@ -26084,7 +26714,7 @@
     },
     {
       "caseId": "react-case-v1:89354f515e26186d5cd9",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactCreateElement-test.js",
       "title": "does not fail if config has no prototype",
@@ -26092,7 +26722,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "does not fail if config has no prototype",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:8935c0b52a281f626d57",
@@ -26199,19 +26836,19 @@
     },
     {
       "caseId": "react-case-v1:897eb49aa9e7d51af058",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "mount and reorder lazy elements",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "React's internal lazy-element shape resolves lazy() to an already-created element, outside lazy()'s documented component-module contract; Octane covers lazy component types instead."
     },
     {
       "caseId": "react-case-v1:8981292cdce7e13df7ea",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactTopLevelFragment-test.js",
       "title": "should render a simple fragment at the top of a component",
@@ -26219,7 +26856,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Executable stable/canary adaptations cover fragment rendering, iterable children, keyed identity, nesting transitions, and top-level reorder outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "should render a simple fragment at the top of a component",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:898289f79caab82ab74c",
@@ -26247,7 +26891,7 @@
     },
     {
       "caseId": "react-case-v1:8997e062201bf4d318c7",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactCreateElement-test.js",
       "title": "does not warn for NaN props",
@@ -26255,7 +26899,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "does not warn for NaN props",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:89a04b8eb84716b3f52b",
@@ -26519,7 +27170,7 @@
     },
     {
       "caseId": "react-case-v1:8b5ee2e919c19b3d21ed",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMRoot-test.js",
       "title": "warns if a callback parameter is provided to render",
@@ -26527,7 +27178,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Root semantics",
-      "rationale": "Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals."
+      "rationale": "Executable stable/canary adaptations cover public createRoot, update, unmount, diagnostics, hydration, and scheduling outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "warns if a callback parameter is provided to render",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:8b73c621c14841620617",
@@ -26739,7 +27397,7 @@
     },
     {
       "caseId": "react-case-v1:8bf86305f17bb32e81d8",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactCreateElement-test.js",
       "title": "allows static methods to be called using the type property",
@@ -26747,7 +27405,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "allows static methods to be called using the type property",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:8bf906062774bdadae81",
@@ -26909,7 +27574,7 @@
     },
     {
       "caseId": "react-case-v1:8d16b6246281b3738914",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should throw on object",
@@ -26917,7 +27582,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should throw on object",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:8d199c92ded439e0ff24",
@@ -27377,7 +28049,7 @@
     },
     {
       "caseId": "react-case-v1:8f4d2ad4bbdeb821ec8f",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactFragment-test.js",
       "title": "should not preserve state between array nested in fragment and double nested array",
@@ -27385,7 +28057,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Executable stable/canary adaptations cover fragment rendering, iterable children, keyed identity, nesting transitions, and top-level reorder outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "should not preserve state between array nested in fragment and double nested array",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:8f5be31a9605505cf85b",
@@ -27745,15 +28424,22 @@
     },
     {
       "caseId": "react-case-v1:914b0e63bd4005832b0b",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "does not support arbitrary promises, only module objects",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "divergence",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Octane deliberately accepts a loader that resolves directly to a component as an ergonomic named-import extension; React requires a {default: Component} module object.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/lazy-components.test.ts",
+          "testName": "does not support arbitrary promises, only module objects",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:91595833bef962686e74",
@@ -27773,7 +28459,7 @@
     },
     {
       "caseId": "react-case-v1:9181b63208a7dc5530f8",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementClone-test.js",
       "title": "should clone a composite component with new props",
@@ -27781,7 +28467,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should clone a composite component with new props",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:91923e8fe80aeb88020b",
@@ -27813,7 +28506,7 @@
     },
     {
       "caseId": "react-case-v1:91b468f04e320db6f6e1",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactCreateElement-test.js",
       "title": "coerces the key to a string",
@@ -27821,7 +28514,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "coerces the key to a string",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:91bee10dd3ef3a29b743",
@@ -27909,7 +28609,7 @@
     },
     {
       "caseId": "react-case-v1:9234c9426fc1b4c0f4c4",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementClone-test.js",
       "title": "should shallow clone children",
@@ -27917,7 +28617,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should shallow clone children",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:923d3cebaf80a51d1b5b",
@@ -28170,7 +28877,7 @@
     },
     {
       "caseId": "react-case-v1:93ce09f9f869c7e27348",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactFragment-test.js",
       "title": "should not preserve state of children if nested 2 levels with siblings",
@@ -28178,7 +28885,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Executable stable/canary adaptations cover fragment rendering, iterable children, keyed identity, nesting transitions, and top-level reorder outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "should not preserve state of children if nested 2 levels with siblings",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:93e4f280f2ef042b107d",
@@ -28242,7 +28956,7 @@
     },
     {
       "caseId": "react-case-v1:94391465b1867f684669",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "throws with a useful error when wrapping Context with lazy()",
@@ -28250,7 +28964,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Executable stable/canary adaptations cover lazy module resolution, rejection, default props, memo/ref-as-prop behavior, keyed identity, and supported boundary validation.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/lazy-components.test.ts",
+          "testName": "throws with a useful error when wrapping Context with lazy()",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:945fcef6caadf802bfa3",
@@ -28609,19 +29330,19 @@
     },
     {
       "caseId": "react-case-v1:96487633d1ec1c0ab6b6",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react/src/__tests__/ReactElementValidator-test.internal.js",
       "title": "warns for keys with component stack info",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Octane intentionally has no React owner/component-stack diagnostic machinery. The portable missing-key warning is executable; exact component-stack text and ownership are non-goals."
     },
     {
       "caseId": "react-case-v1:96606206277447ed5c3d",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMRoot-test.js",
       "title": "warns if a callback parameter is provided to unmount",
@@ -28629,7 +29350,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Root semantics",
-      "rationale": "Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals."
+      "rationale": "Executable stable/canary adaptations cover public createRoot, update, unmount, diagnostics, hydration, and scheduling outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "warns if a callback parameter is provided to unmount",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:966c53db471d73db6cab",
@@ -28866,15 +29594,15 @@
     },
     {
       "caseId": "react-case-v1:97e1630437a809672e39",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "sets defaultProps for modern lifecycles",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Octane intentionally has no class components or class lifecycle methods, so React's lazy defaultProps checks tied specifically to class lifecycles are outside scope."
     },
     {
       "caseId": "react-case-v1:97e46bb856479176a895",
@@ -28966,7 +29694,7 @@
     },
     {
       "caseId": "react-case-v1:98a548f23f6279b12887",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementValidator-test.internal.js",
       "title": "warns for keys for iterables of elements in rest args",
@@ -28974,7 +29702,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "warns for keys for iterables of elements in rest args",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:98ad717d01cf7244288f",
@@ -28990,7 +29725,7 @@
     },
     {
       "caseId": "react-case-v1:98b53d16b2e480bae6bc",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactFragment-test.js",
       "title": "should render multiple children via noop renderer",
@@ -28998,7 +29733,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Executable stable/canary adaptations cover fragment rendering, iterable children, keyed identity, nesting transitions, and top-level reorder outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "should render multiple children via noop renderer",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:98c276448864e06398c2",
@@ -29230,7 +29972,7 @@
     },
     {
       "caseId": "react-case-v1:9a65a1ca906893e0c8e4",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should be called for each child in array",
@@ -29238,7 +29980,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should be called for each child in array",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:9a66667fc889ee56b862",
@@ -29430,15 +30179,15 @@
     },
     {
       "caseId": "react-case-v1:9b79995d7971a8bf3266",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react/src/__tests__/ReactCreateElement-test.js",
       "title": "preserves the owner on the element",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Octane element descriptors intentionally omit React's private _owner metadata, so owner preservation is not part of the public contract."
     },
     {
       "caseId": "react-case-v1:9b83b197ff06b213c636",
@@ -29514,7 +30263,7 @@
     },
     {
       "caseId": "react-case-v1:9bff9663aefd1000d08b",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMRoot-test.js",
       "title": "unmounts children",
@@ -29522,7 +30271,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Root semantics",
-      "rationale": "Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals."
+      "rationale": "Executable stable/canary adaptations cover public createRoot, update, unmount, diagnostics, hydration, and scheduling outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "unmounts children",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:9c01e5b8f8a191269832",
@@ -29534,7 +30290,7 @@
     },
     {
       "caseId": "react-case-v1:9c198a1f261b2d0312a4",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should treat single arrayless child as being in array",
@@ -29542,7 +30298,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should treat single arrayless child as being in array",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:9c1c0b90e3a13c1d75ea",
@@ -30419,7 +31182,7 @@
     },
     {
       "caseId": "react-case-v1:a0fe23418ae0fd7d616d",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMRoot-test.js",
       "title": "warn if a object is passed to root.render(...)",
@@ -30427,7 +31190,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Root semantics",
-      "rationale": "Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals."
+      "rationale": "Executable stable/canary adaptations cover public createRoot, update, unmount, diagnostics, hydration, and scheduling outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "warn if a object is passed to root.render(...)",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:a0feb66fb123fda1915e",
@@ -30468,7 +31238,7 @@
     },
     {
       "caseId": "react-case-v1:a1121b8d91f78be424ed",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "resolves props for inner memo component without defaultProps",
@@ -30476,7 +31246,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Executable stable/canary adaptations cover lazy module resolution, rejection, default props, memo/ref-as-prop behavior, keyed identity, and supported boundary validation.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/lazy-components.test.ts",
+          "testName": "resolves props for inner memo component without defaultProps",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:a1150f0521f08cf1d2ff",
@@ -30681,7 +31458,7 @@
     },
     {
       "caseId": "react-case-v1:a23eb08c8d1aa87d84ba",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMRoot-test.js",
       "title": "clears existing children",
@@ -30689,7 +31466,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Root semantics",
-      "rationale": "Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals."
+      "rationale": "Executable stable/canary adaptations cover public createRoot, update, unmount, diagnostics, hydration, and scheduling outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "clears existing children",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:a24dadfddb7019db4e87",
@@ -30709,15 +31493,15 @@
     },
     {
       "caseId": "react-case-v1:a269c47cdc8f2eaaf42b",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react/src/__tests__/ReactCreateElement-test.js",
       "title": "warns if outdated JSX transform is detected",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Octane compiles .tsrx directly and does not implement React's classic/outdated JSX transform detection, so transform-specific diagnostics are outside its public runtime surface."
     },
     {
       "caseId": "react-case-v1:a27290ccb4c9ddd6b077",
@@ -31013,7 +31797,7 @@
     },
     {
       "caseId": "react-case-v1:a409d30e3869a2e24c92",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should allow extension of native prototypes",
@@ -31021,7 +31805,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should allow extension of native prototypes",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:a409dbb59d757f6f2b22",
@@ -31186,7 +31977,7 @@
     },
     {
       "caseId": "react-case-v1:a4c5ff8476335ded1827",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactCreateElement-test.js",
       "title": "should use default prop value when removing a prop",
@@ -31194,7 +31985,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should use default prop value when removing a prop",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:a4da6ec9fb6c7360bf05",
@@ -31222,15 +32020,15 @@
     },
     {
       "caseId": "react-case-v1:a527ded5829618477cc8",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react/src/__tests__/ReactElementValidator-test.internal.js",
       "title": "warns for keys for arrays of elements with no owner info",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "This case distinguishes React's owner-aware warning context when no owner is available. Octane emits a framework-native missing-key diagnostic without React owner metadata; array warning behavior is covered separately."
     },
     {
       "caseId": "react-case-v1:a52c6c7e687bdf1b1def",
@@ -31519,7 +32317,7 @@
     },
     {
       "caseId": "react-case-v1:a6a4374cde7f38d4d412",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "suspends until module has loaded",
@@ -31527,7 +32325,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Executable stable/canary adaptations cover lazy module resolution, rejection, default props, memo/ref-as-prop behavior, keyed identity, and supported boundary validation.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/lazy-components.test.ts",
+          "testName": "suspends until module has loaded",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:a6a83e0d3397728818ac",
@@ -31724,15 +32529,15 @@
     },
     {
       "caseId": "react-case-v1:a7ecdd9f0e2d815e29f1",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react/src/__tests__/ReactCreateElement-test.js",
       "title": "should warn when `key` is being accessed on a host element",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Octane does not install React's development-only props.key warning getter; element key behavior is covered through public createElement and cloneElement outcomes."
     },
     {
       "caseId": "react-case-v1:a7f03453708f218ad937",
@@ -31768,7 +32573,7 @@
     },
     {
       "caseId": "react-case-v1:a808dac25c951f7c6611",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementValidator-test.internal.js",
       "title": "does not call lazy initializers eagerly",
@@ -31776,7 +32581,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "does not call lazy initializers eagerly",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:a80d4f3b3c725a45c328",
@@ -31796,7 +32608,7 @@
     },
     {
       "caseId": "react-case-v1:a8149af9f28bad3dcddd",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "warns for flattened list children without keys",
@@ -31804,7 +32616,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "warns for flattened list children without keys",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:a814eddeb61204336783",
@@ -31816,7 +32635,7 @@
     },
     {
       "caseId": "react-case-v1:a81dfdc6f4e80d6f6001",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactCreateElement-test.js",
       "title": "merges an additional argument onto the children prop",
@@ -31824,7 +32643,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "merges an additional argument onto the children prop",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:a834fbb5b79b312121ac",
@@ -31840,7 +32666,7 @@
     },
     {
       "caseId": "react-case-v1:a839a4442f6c960bade8",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMRoot-test.js",
       "title": "should not warn if mounting into non-empty node",
@@ -31848,7 +32674,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Root semantics",
-      "rationale": "Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals."
+      "rationale": "Executable stable/canary adaptations cover public createRoot, update, unmount, diagnostics, hydration, and scheduling outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "should not warn if mounting into non-empty node",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:a84ac10b9377058e69c3",
@@ -32032,7 +32865,7 @@
     },
     {
       "caseId": "react-case-v1:a947fc1a0904cd13806c",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMRoot-test.js",
       "title": "should unmount and remount if the key changes",
@@ -32040,7 +32873,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Root semantics",
-      "rationale": "Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals."
+      "rationale": "Executable stable/canary adaptations cover public createRoot, update, unmount, diagnostics, hydration, and scheduling outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "should unmount and remount if the key changes",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:a948a22fee9cc1607e58",
@@ -32385,15 +33225,15 @@
     },
     {
       "caseId": "react-case-v1:abb321d6fbaf85f393b8",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "resolves props for forwardRef component without defaultProps",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Octane uses React 19-style refs as ordinary component props and intentionally has no forwardRef wrapper API; lazy ref-as-prop behavior is covered independently."
     },
     {
       "caseId": "react-case-v1:abb8cb4e8c483c3341a7",
@@ -32617,7 +33457,7 @@
     },
     {
       "caseId": "react-case-v1:aca3108bcfe418d060fe",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMRoot-test.js",
       "title": "warns if updating a root that has had its contents removed",
@@ -32625,7 +33465,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Root semantics",
-      "rationale": "Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals."
+      "rationale": "Executable stable/canary adaptations cover public createRoot, update, unmount, diagnostics, hydration, and scheduling outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "warns if updating a root that has had its contents removed",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:acbcdf7face5a2f5a5d0",
@@ -32813,7 +33660,7 @@
     },
     {
       "caseId": "react-case-v1:ade987c8634d60112d76",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMRoot-test.js",
       "title": "errors if container is a comment node",
@@ -32821,7 +33668,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Root semantics",
-      "rationale": "Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals."
+      "rationale": "Executable stable/canary adaptations cover public createRoot, update, unmount, diagnostics, hydration, and scheduling outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "errors if container is a comment node",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:adece72adeefea53f884",
@@ -32885,7 +33739,7 @@
     },
     {
       "caseId": "react-case-v1:ae2590af4539dcc0cecb",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementClone-test.js",
       "title": "should override children if undefined is provided as an argument",
@@ -32893,7 +33747,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should override children if undefined is provided as an argument",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:ae39bdc4c8223885d123",
@@ -32958,7 +33819,7 @@
     },
     {
       "caseId": "react-case-v1:ae669195252ab8254f8f",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should be called for each child in nested structure",
@@ -32966,7 +33827,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should be called for each child in nested structure",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:ae75c9240d07f51f649e",
@@ -32998,7 +33866,7 @@
     },
     {
       "caseId": "react-case-v1:ae95cc480fbc3013929f",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should retain key across two mappings",
@@ -33006,7 +33874,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should retain key across two mappings",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:aea5279965d59af8b11f",
@@ -33182,7 +34057,7 @@
     },
     {
       "caseId": "react-case-v1:afc539cb21d04d62d098",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactFragment-test.js",
       "title": "should preserve state between top-level fragments",
@@ -33190,7 +34065,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Executable stable/canary adaptations cover fragment rendering, iterable children, keyed identity, nesting transitions, and top-level reorder outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "should preserve state between top-level fragments",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:afcdae11604e81e2ff33",
@@ -33246,7 +34128,7 @@
     },
     {
       "caseId": "react-case-v1:b006bc32b17874ed1b09",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactCreateElement-test.js",
       "title": "ignores key and ref warning getters",
@@ -33254,19 +34136,26 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "ignores key and ref warning getters",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:b01255402f8261a35e21",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "supports class and forwardRef components",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Octane intentionally supports neither class components nor forwardRef; refs are ordinary component props and that modern contract is tested independently."
     },
     {
       "caseId": "react-case-v1:b0190653bbf8bb2e7f50",
@@ -33578,7 +34467,7 @@
     },
     {
       "caseId": "react-case-v1:b1ebb624c856ed40ef75",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "does not warn when there are keys on elements in a fragment",
@@ -33586,7 +34475,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "does not warn when there are keys on elements in a fragment",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:b1fc12436cf6f0b20c1e",
@@ -33866,7 +34762,7 @@
     },
     {
       "caseId": "react-case-v1:b3c43ca1c8181e8bd2ed",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementClone-test.js",
       "title": "should support keys and refs",
@@ -33874,7 +34770,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should support keys and refs",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:b3d41f1ef261a2219770",
@@ -34022,7 +34925,7 @@
     },
     {
       "caseId": "react-case-v1:b49e9c982e2e800c63f6",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactFragment-test.js",
       "title": "should not preserve state when switching a nested unkeyed fragment to a passthrough component",
@@ -34030,7 +34933,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Executable stable/canary adaptations cover fragment rendering, iterable children, keyed identity, nesting transitions, and top-level reorder outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "should not preserve state when switching a nested unkeyed fragment to a passthrough component",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:b4b1d7f63629e027f375",
@@ -34459,7 +35369,7 @@
     },
     {
       "caseId": "react-case-v1:b652def6594750a71a90",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "does not warn for cloned static children without keys",
@@ -34467,7 +35377,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "does not warn for cloned static children without keys",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:b6540b0aae5ae2307d4e",
@@ -34578,7 +35495,7 @@
     },
     {
       "caseId": "react-case-v1:b6c7a1806b7eae2fff08",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactFragment-test.js",
       "title": "should preserve state between top level fragment and array",
@@ -34586,7 +35503,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Executable stable/canary adaptations cover fragment rendering, iterable children, keyed identity, nesting transitions, and top-level reorder outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "should preserve state between top level fragment and array",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:b6d3f4885ea3d5e066ea",
@@ -34663,7 +35587,7 @@
     },
     {
       "caseId": "react-case-v1:b7b73f247e0a875b61b0",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "resolves props for outer memo component without defaultProps",
@@ -34671,11 +35595,18 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Executable stable/canary adaptations cover lazy module resolution, rejection, default props, memo/ref-as-prop behavior, keyed identity, and supported boundary validation.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/lazy-components.test.ts",
+          "testName": "resolves props for outer memo component without defaultProps",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:b7bc6958f16571fec6a0",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMRoot-test.js",
       "title": "warn if a container is passed to root.render(...)",
@@ -34683,7 +35614,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Root semantics",
-      "rationale": "Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals."
+      "rationale": "Executable stable/canary adaptations cover public createRoot, update, unmount, diagnostics, hydration, and scheduling outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "warn if a container is passed to root.render(...)",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:b7df36f304adc2dfd519",
@@ -34831,7 +35769,7 @@
     },
     {
       "caseId": "react-case-v1:b854030955174f64bbd5",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "renders a lazy context provider without value prop",
@@ -34839,7 +35777,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Executable stable/canary adaptations cover lazy module resolution, rejection, default props, memo/ref-as-prop behavior, keyed identity, and supported boundary validation.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/lazy-components.test.ts",
+          "testName": "renders a lazy context provider without value prop",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:b85b93d1f628d154ea5a",
@@ -35378,7 +36323,7 @@
     },
     {
       "caseId": "react-case-v1:bb52433bffc54f7109ee",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementClone-test.js",
       "title": "does not warns for arrays of elements with keys",
@@ -35386,7 +36331,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "does not warns for arrays of elements with keys",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:bb6363cf0e8126a1f8f6",
@@ -36101,7 +37053,7 @@
     },
     {
       "caseId": "react-case-v1:be9fb48e2839f7add113",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMRoot-test.js",
       "title": "warn if JSX passed to createRoot",
@@ -36109,7 +37061,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Root semantics",
-      "rationale": "Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals."
+      "rationale": "Executable stable/canary adaptations cover public createRoot, update, unmount, diagnostics, hydration, and scheduling outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "warn if JSX passed to createRoot",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:bea592a31d269ae9f177",
@@ -36354,7 +37313,7 @@
     },
     {
       "caseId": "react-case-v1:c01ab7b0564c336d6ca4",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMRoot-test.js",
       "title": "warns if root is unmounted inside an effect",
@@ -36362,7 +37321,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Root semantics",
-      "rationale": "Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals."
+      "rationale": "Executable stable/canary adaptations cover public createRoot, update, unmount, diagnostics, hydration, and scheduling outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "warns if root is unmounted inside an effect",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:c027582a00903fe34b65",
@@ -36740,7 +37706,7 @@
     },
     {
       "caseId": "react-case-v1:c2469f939ce42de162c7",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "resolves defaultProps, on mount and update",
@@ -36748,7 +37714,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Executable stable/canary adaptations cover lazy module resolution, rejection, default props, memo/ref-as-prop behavior, keyed identity, and supported boundary validation.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/lazy-components.test.ts",
+          "testName": "applies live defaultProps from a resolved function component",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:c26617fbf50c3d3a8619",
@@ -36764,15 +37737,15 @@
     },
     {
       "caseId": "react-case-v1:c26f77101d53423e8e4d",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "sets defaultProps for legacy lifecycles",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Octane intentionally has no class components or class lifecycle methods, so React's lazy defaultProps checks tied specifically to class lifecycles are outside scope."
     },
     {
       "caseId": "react-case-v1:c27379ca0336039c7b93",
@@ -36956,15 +37929,15 @@
     },
     {
       "caseId": "react-case-v1:c3106a59d1702b5772fd",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "throws with a useful error when wrapping TracingMarker with lazy()",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Octane does not expose React's TracingMarker element type, so wrapping it with lazy() is outside the supported public surface."
     },
     {
       "caseId": "react-case-v1:c3171fb981367043a06b",
@@ -37044,7 +38017,7 @@
     },
     {
       "caseId": "react-case-v1:c383adc023993358762f",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementClone-test.js",
       "title": "does not warn when the element is directly in rest args",
@@ -37052,7 +38025,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "does not warn when the element is directly in rest args",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:c38a3313663a49bffffd",
@@ -37703,15 +38683,15 @@
     },
     {
       "caseId": "react-case-v1:c649888bd434b8af09a7",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react/src/__tests__/ReactElementValidator-test.internal.js",
       "title": "does not blow up with inlined children",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "This case constructs React's private $$typeof element marker shape, which Octane neither exposes nor accepts as public element input."
     },
     {
       "caseId": "react-case-v1:c6501d417b928fe641d0",
@@ -38076,7 +39056,7 @@
     },
     {
       "caseId": "react-case-v1:c7fb56348ad7ca4a099e",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactCreateElement-test.js",
       "title": "allows a string to be passed as the type",
@@ -38084,7 +39064,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "allows a string to be passed as the type",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:c806a1ba47aabe9ef2d2",
@@ -38209,7 +39196,7 @@
     },
     {
       "caseId": "react-case-v1:c8ade1c441a114046e82",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "warns for keys for arrays of elements in a fragment",
@@ -38217,7 +39204,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "warns for keys for arrays of elements in a fragment",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:c8b52eea47da3da90156",
@@ -38806,7 +39800,7 @@
     },
     {
       "caseId": "react-case-v1:cb5e9d22b6c2182ed779",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "throws with a useful error when wrapping createPortal with lazy()",
@@ -38814,7 +39808,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Executable stable/canary adaptations cover lazy module resolution, rejection, default props, memo/ref-as-prop behavior, keyed identity, and supported boundary validation.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/lazy-components.test.ts",
+          "testName": "throws with a useful error when wrapping createPortal with lazy()",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:cb635869d732a3f63d30",
@@ -39078,7 +40079,7 @@
     },
     {
       "caseId": "react-case-v1:cceb476b42aaf13a9bd9",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should be called for each child",
@@ -39086,19 +40087,26 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should be called for each child",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:cd0079e32c46940e3ac8",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react/src/__tests__/ReactElementValidator-test.internal.js",
       "title": "should give context for errors in nested components.",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "The asserted behavior is React's nested owner/component-stack context for a development warning. Octane's portable missing-key warning is covered, but React owner-stack attribution is intentionally not implemented."
     },
     {
       "caseId": "react-case-v1:cd10b879a7d9e5d70064",
@@ -39126,15 +40134,15 @@
     },
     {
       "caseId": "react-case-v1:cd2970b814ec7dd542e3",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react/src/__tests__/ReactElementValidator-test.internal.js",
       "title": "does not blow up on key warning with undefined type",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Octane's compiler diagnoses invalid TSRX element types at authoring time and does not reproduce React's runtime owner-stack diagnostics, so this internal validator case is outside the runtime API."
     },
     {
       "caseId": "react-case-v1:cd2e6d7b7bd74733d0ea",
@@ -39154,7 +40162,7 @@
     },
     {
       "caseId": "react-case-v1:cd4608a90f7edff100a4",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should flatten children to an array",
@@ -39162,7 +40170,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should flatten children to an array",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:cd5546f2e340ff2e956d",
@@ -39346,7 +40361,7 @@
     },
     {
       "caseId": "react-case-v1:ce4ca1d46c4e9aea7feb",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "multiple lazy components",
@@ -39354,7 +40369,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Executable stable/canary adaptations cover lazy module resolution, rejection, default props, memo/ref-as-prop behavior, keyed identity, and supported boundary validation.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/lazy-components.test.ts",
+          "testName": "multiple lazy components",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:ce521ff7d7500d9af810",
@@ -39382,7 +40404,7 @@
     },
     {
       "caseId": "react-case-v1:ce835a755751eb86c58f",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "resolves props for function component without defaultProps",
@@ -39390,7 +40412,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Executable stable/canary adaptations cover lazy module resolution, rejection, default props, memo/ref-as-prop behavior, keyed identity, and supported boundary validation.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/lazy-components.test.ts",
+          "testName": "resolves props for function component without defaultProps",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:ce92daaca5fc7a514794",
@@ -40246,15 +41275,15 @@
     },
     {
       "caseId": "react-case-v1:d334be1249a94b4e63f9",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react/src/__tests__/ReactElementValidator-test.internal.js",
       "title": "warns for keys for arrays of elements with owner info",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "This case specifically asserts React owner attribution in the missing-key warning. Octane emits framework-native wording and intentionally carries no React owner metadata."
     },
     {
       "caseId": "react-case-v1:d338c2396f29166cf4f9",
@@ -40450,7 +41479,7 @@
     },
     {
       "caseId": "react-case-v1:d441a1a74818614a830c",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should invoke callback with the right context",
@@ -40458,7 +41487,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should invoke callback with the right context",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:d446763c93468079cb82",
@@ -41044,7 +42080,7 @@
     },
     {
       "caseId": "react-case-v1:d713b8e63c46e8d6bbf8",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should count the number of children in nested structure",
@@ -41052,7 +42088,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should count the number of children in nested structure",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:d71400207ed364388c30",
@@ -41144,7 +42187,7 @@
     },
     {
       "caseId": "react-case-v1:d777a4de4ef1970e5ec6",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMRoot-test.js",
       "title": "warns when creating two roots managing the same container",
@@ -41152,7 +42195,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Root semantics",
-      "rationale": "Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals."
+      "rationale": "Executable stable/canary adaptations cover public createRoot, update, unmount, diagnostics, hydration, and scheduling outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "warns when creating two roots managing the same container",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:d77fc3b017604e22b350",
@@ -41344,7 +42394,7 @@
     },
     {
       "caseId": "react-case-v1:d8870032773bcf7ec94e",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactFragment-test.js",
       "title": "should preserve state of children with 1 level nesting",
@@ -41352,7 +42402,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Executable stable/canary adaptations cover fragment rendering, iterable children, keyed identity, nesting transitions, and top-level reorder outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "should preserve state of children with 1 level nesting",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:d896ffd5097f17bd9080",
@@ -41528,7 +42585,7 @@
     },
     {
       "caseId": "react-case-v1:d994241ab670a820ce56",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMRoot-test.js",
       "title": "should render different components in same root",
@@ -41536,7 +42593,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Root semantics",
-      "rationale": "Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals."
+      "rationale": "Executable stable/canary adaptations cover public createRoot, update, unmount, diagnostics, hydration, and scheduling outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "should render different components in same root",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:d996c8fb23ed1d9b5056",
@@ -42150,7 +43214,7 @@
     },
     {
       "caseId": "react-case-v1:dc95718190e5f3039624",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactCreateElement-test.js",
       "title": "does not reuse the original config object",
@@ -42158,7 +43222,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "does not reuse the original config object",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:dc9699369ef2ce0542bd",
@@ -42402,15 +43473,15 @@
     },
     {
       "caseId": "react-case-v1:de1fb8644eb7ccff5764",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react/src/__tests__/ReactElementValidator-test.internal.js",
       "title": "gives a helpful error when passing invalid types",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Octane's compiler diagnoses invalid TSRX element types at authoring time and does not reproduce React's runtime owner-stack diagnostics, so this internal validator case is outside the runtime API."
     },
     {
       "caseId": "react-case-v1:de205862ba818d136751",
@@ -42474,7 +43545,7 @@
     },
     {
       "caseId": "react-case-v1:deb847be5b40842bacea",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementValidator-test.internal.js",
       "title": "warns for keys for arrays of elements in rest args",
@@ -42482,7 +43553,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "warns for keys for arrays of elements in rest args",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:dec878ab451b91c5439b",
@@ -42554,7 +43632,7 @@
     },
     {
       "caseId": "react-case-v1:df1cbdaeabf1155f96a8",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementValidator-test.internal.js",
       "title": "does not warn when the array contains a non-element",
@@ -42562,7 +43640,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "does not warn when the array contains a non-element",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:df1d48e2ec69ff4604b6",
@@ -42638,7 +43723,7 @@
     },
     {
       "caseId": "react-case-v1:df690859ab30d7daa697",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactCreateElement-test.js",
       "title": "does not extract ref from the rest of the props",
@@ -42646,7 +43731,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "does not extract ref from the rest of the props",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:df6be62e603a77c561f5",
@@ -43332,7 +44424,7 @@
     },
     {
       "caseId": "react-case-v1:e32b891c9f5f3e368bf2",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactFragment-test.js",
       "title": "should not preserve state between unkeyed and keyed fragment",
@@ -43340,7 +44432,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Executable stable/canary adaptations cover fragment rendering, iterable children, keyed identity, nesting transitions, and top-level reorder outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "should not preserve state between unkeyed and keyed fragment",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:e33278893a93d903ad64",
@@ -43592,19 +44691,26 @@
     },
     {
       "caseId": "react-case-v1:e480e2af8a5d692646a3",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "throws with a useful error when wrapping Context.Consumer with lazy()",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Octane exposes context providers and useContext but intentionally has no Context.Consumer element API; the exact-title executable adaptation records that the absent value is rejected as an invalid lazy target.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/lazy-components.test.ts",
+          "testName": "throws with a useful error when wrapping Context.Consumer with lazy()",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:e49f8694a59e89242184",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementValidator-test.internal.js",
       "title": "does not warns for iterable elements with keys",
@@ -43612,7 +44718,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "does not warns for iterable elements with keys",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:e4a27c81b84de4a1b0db",
@@ -44026,15 +45139,15 @@
     },
     {
       "caseId": "react-case-v1:e722028f2094b74acf36",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "mount and reorder lazy types (legacy mode)",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Octane has no React legacy root mode; the supported root's equivalent lazy-type identity and reorder behavior is covered by the executable non-legacy case."
     },
     {
       "caseId": "react-case-v1:e72bd0aadc61462dcadd",
@@ -44254,7 +45367,7 @@
     },
     {
       "caseId": "react-case-v1:e89ceb5c2356b8ef57c3",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should throw on regex",
@@ -44262,7 +45375,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should throw on regex",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:e89ec2335370046b4e43",
@@ -44744,7 +45864,7 @@
     },
     {
       "caseId": "react-case-v1:ead2128f43792f58b908",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementClone-test.js",
       "title": "should keep the original ref if it is not overridden",
@@ -44752,7 +45872,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should keep the original ref if it is not overridden",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:ead36c67320efe538973",
@@ -44972,15 +46099,15 @@
     },
     {
       "caseId": "react-case-v1:ebdd6ba7debad55b8a9c",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "should error with a component stack containing Lazy if unresolved",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Octane does not implement React's owner/component-stack development-warning machinery; lazy resolution and rejection behavior is covered separately at the public error boundary."
     },
     {
       "caseId": "react-case-v1:ebe29ae9ad80b009f6bd",
@@ -45189,7 +46316,7 @@
     },
     {
       "caseId": "react-case-v1:ed0ddffc762a4b347dd7",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactFragment-test.js",
       "title": "should not preserve state when switching a nested keyed array to a passthrough component",
@@ -45197,7 +46324,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Executable stable/canary adaptations cover fragment rendering, iterable children, keyed identity, nesting transitions, and top-level reorder outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "should not preserve state when switching a nested keyed array to a passthrough component",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:ed1c6d7f8919f272f69f",
@@ -45412,15 +46546,15 @@
     },
     {
       "caseId": "react-case-v1:ee4eb9e9baf830a651dd",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "resolves defaultProps without breaking bailout in PureComponent, #17151",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Octane intentionally has no PureComponent or class state model; lazy memo comparator behavior is covered by the function-component memo API instead."
     },
     {
       "caseId": "react-case-v1:ee556fb1fb3664761fd5",
@@ -45569,7 +46703,7 @@
     },
     {
       "caseId": "react-case-v1:eee98f9d29993315b74e",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "mount and reorder lazy types",
@@ -45577,7 +46711,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Executable stable/canary adaptations cover lazy module resolution, rejection, default props, memo/ref-as-prop behavior, keyed identity, and supported boundary validation.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/lazy-components.test.ts",
+          "testName": "mount and reorder lazy types",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:eeea02c580a31c5e36e3",
@@ -45613,7 +46754,7 @@
     },
     {
       "caseId": "react-case-v1:ef192547bf36c3f06f79",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should not enumerate enumerable numbers (#4776)",
@@ -45621,7 +46762,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should not enumerate enumerable numbers (#4776)",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:ef1a5a03e90eba813dc6",
@@ -45710,7 +46858,7 @@
     },
     {
       "caseId": "react-case-v1:ef9230e0daa57f0568f1",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactFragment-test.js",
       "title": "should preserve state between array nested in fragment and fragment",
@@ -45718,7 +46866,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Executable stable/canary adaptations cover fragment rendering, iterable children, keyed identity, nesting transitions, and top-level reorder outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "should preserve state between array nested in fragment and fragment",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:ef97140c64ba6605488b",
@@ -45918,15 +47073,15 @@
     },
     {
       "caseId": "react-case-v1:f06e860beb0fb8c88d0b",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "throws with a useful error when wrapping SuspenseList with lazy()",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Octane does not expose React's SuspenseList element type, so wrapping it with lazy() is outside the supported public surface."
     },
     {
       "caseId": "react-case-v1:f076a188a59af0db3f2e",
@@ -45998,7 +47153,7 @@
     },
     {
       "caseId": "react-case-v1:f0ccfc8c2293fd59b4e6",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactCreateElement-test.js",
       "title": "overrides children if null is provided as an argument",
@@ -46006,7 +47161,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "overrides children if null is provided as an argument",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:f0cd19e697f740fc3ffa",
@@ -46342,7 +47504,7 @@
     },
     {
       "caseId": "react-case-v1:f265fe2aae18d3226dce",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should use the same key for a cloned element",
@@ -46350,7 +47512,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should use the same key for a cloned element",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:f27454b18c9a0b50631a",
@@ -46697,15 +47866,15 @@
     },
     {
       "caseId": "react-case-v1:f47192f7bbd802835289",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "includes lazy-loaded component in warning stack",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Octane does not implement React's owner/component-stack development-warning machinery; lazy resolution and rejection behavior is covered separately at the public error boundary."
     },
     {
       "caseId": "react-case-v1:f4b55896ea4ddefdf30a",
@@ -46821,7 +47990,7 @@
     },
     {
       "caseId": "react-case-v1:f5374de863aa97b74106",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactFragment-test.js",
       "title": "should not preserve state of children if nested 2 levels without siblings",
@@ -46829,7 +47998,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Fragment reconciliation",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Executable stable/canary adaptations cover fragment rendering, iterable children, keyed identity, nesting transitions, and top-level reorder outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-reconciliation.test.ts",
+          "testName": "should not preserve state of children if nested 2 levels without siblings",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:f53830682ea2601b95c6",
@@ -46929,15 +48105,22 @@
     },
     {
       "caseId": "react-case-v1:f5d0c712a232b938e52a",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMRoot-test.js",
       "title": "warns when given a function",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "divergence",
       "owner": "runtime",
       "workstream": "Root semantics",
-      "rationale": "Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals."
+      "rationale": "Octane's documented root.render(Component, props) extension accepts component bodies directly, so a function is a valid render target rather than a React-style warning; the exact-title executable test pins the extension.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "warns when given a function",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:f5d510580fda86af1cc6",
@@ -47069,15 +48252,15 @@
     },
     {
       "caseId": "react-case-v1:f68e77099f07e35e9136",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "throws with a useful error when wrapping Profiler with lazy()",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Octane does not expose React's Profiler element type, so wrapping it with lazy() is outside the supported public surface."
     },
     {
       "caseId": "react-case-v1:f6abd5d7b2b8da5e23ca",
@@ -47133,15 +48316,15 @@
     },
     {
       "caseId": "react-case-v1:f6e6cda249e787f0f976",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "mount and reorder lazy elements (legacy mode)",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "React's internal lazy-element shape resolves lazy() to an already-created element, outside lazy()'s documented component-module contract; Octane covers lazy component types instead."
     },
     {
       "caseId": "react-case-v1:f70db35ed1bc92268653",
@@ -47982,7 +49165,7 @@
     },
     {
       "caseId": "react-case-v1:fbfe6ea6fe6d803b3d6c",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMRoot-test.js",
       "title": "throws a good message on invalid containers",
@@ -47990,7 +49173,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Root semantics",
-      "rationale": "Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals."
+      "rationale": "Executable stable/canary adaptations cover public createRoot, update, unmount, diagnostics, hydration, and scheduling outcomes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "throws a good message on invalid containers",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:fc053249e9e9762a66cd",
@@ -48150,7 +49340,7 @@
     },
     {
       "caseId": "react-case-v1:fceca4ec13451361305e",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementClone-test.js",
       "title": "should transfer the key property",
@@ -48158,7 +49348,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should transfer the key property",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:fcffd8546f00e6b29585",
@@ -48178,15 +49375,15 @@
     },
     {
       "caseId": "react-case-v1:fd0e10cbca2f4dceb4f0",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "throws with a useful error when wrapping StrictMode with lazy()",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Octane does not expose React's StrictMode element type, so wrapping it with lazy() is outside the supported public surface."
     },
     {
       "caseId": "react-case-v1:fd0e247368ef6b86356a",
@@ -48542,7 +49739,7 @@
     },
     {
       "caseId": "react-case-v1:fef19c0576dce1aa9208",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactElementClone-test.js",
       "title": "should extract null key and ref",
@@ -48550,7 +49747,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should extract null key and ref",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:fefc540b422f8b0fa4d7",
@@ -48562,7 +49766,7 @@
     },
     {
       "caseId": "react-case-v1:fefe88b249a26e348142",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react/src/__tests__/ReactChildren-test.js",
       "title": "should treat single child in array as expected",
@@ -48570,7 +49774,14 @@
       "classification": "adaptable",
       "owner": "public API",
       "workstream": "Element and Children APIs",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Executable stable/canary adaptations cover public Children traversal and key rebasing, element creation and cloning, default props, iterable handling, and portable missing-key diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/element-children-api.test.ts",
+          "testName": "should treat single child in array as expected",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:ff114ece9ead8dd66ab0",
@@ -48635,7 +49846,7 @@
     },
     {
       "caseId": "react-case-v1:ff98d2eb26578d0d1a72",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js",
       "title": "throws with a useful error when wrapping invalid type with lazy()",
@@ -48643,7 +49854,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Lazy components",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Executable stable/canary adaptations cover lazy module resolution, rejection, default props, memo/ref-as-prop behavior, keyed identity, and supported boundary validation.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/lazy-components.test.ts",
+          "testName": "throws with a useful error when wrapping invalid type with lazy()",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:ffa5750e9f0140c80bec",

--- a/packages/octane/audit/react-upstreams.json
+++ b/packages/octane/audit/react-upstreams.json
@@ -76,40 +76,40 @@
       "workstream": "Root semantics",
       "filePattern": "/ReactDOMRoot[^/]*-test(?:\\.internal)?\\.js$",
       "risk": "high",
-      "status": "planned",
+      "status": "covered",
       "classification": "adaptable",
       "owner": "runtime",
-      "rationale": "Port public createRoot, update, unmount, error, and scheduling outcomes while filtering renderer internals."
+      "rationale": "Twenty-five public root cases have exact-title client and production-compile evidence; the component-body render entry point and safe teardown after external DOM removal are executable, documented divergences."
     },
     {
       "id": "fragments",
       "workstream": "Fragment reconciliation",
       "filePattern": "/React(?:TopLevel)?Fragment[^/]*-test(?:\\.internal)?\\.js$",
       "risk": "high",
-      "status": "planned",
+      "status": "covered",
       "classification": "adaptable",
       "owner": "runtime",
-      "rationale": "Expand fragment reconciliation, ref, nesting, and top-level outcome coverage."
+      "rationale": "Twenty-eight fragment identity and reconciliation cases have exact-title client and production-compile evidence; React's internal lazy-to-element shape has a documented non-goal disposition and executable component-module adaptation."
     },
     {
       "id": "element-children-api",
       "workstream": "Element and Children APIs",
       "filePattern": "/React(?:Children|CreateElement|Element|ElementClone)[^/]*-test(?:\\.internal)?\\.js$",
       "risk": "high",
-      "status": "planned",
+      "status": "covered",
       "classification": "adaptable",
       "owner": "public API",
-      "rationale": "Audit and port observable Children, element creation, JSX-element, and clone behavior against Octane's public API."
+      "rationale": "Ninety-five public Children, element creation, clone, validation, iterable, thenable, key, ref, freezing, and function-default-prop cases have executable evidence; sixteen React owner/component-stack, legacy-transform, class, and private-element diagnostics are documented non-goals."
     },
     {
       "id": "lazy",
       "workstream": "Lazy components",
       "filePattern": "/ReactLazy[^/]*-test(?:\\.internal)?\\.js$",
       "risk": "high",
-      "status": "planned",
+      "status": "covered",
       "classification": "adaptable",
       "owner": "runtime",
-      "rationale": "Expand lazy resolution, rejection, retry, default-export, and Suspense interaction coverage."
+      "rationale": "Nineteen lazy resolution, rejection, function-component default-prop, memo, identity, and reorder cases have executable evidence; three ergonomic/component-form differences and twenty unsupported class, forwardRef, legacy-root, owner-stack, or exotic-type cases have durable documented dispositions."
     },
     {
       "id": "external-store",
@@ -163,19 +163,19 @@
     }
   ],
   "octaneSuiteBaseline": {
-    "normalCoreCases": 2260,
+    "normalCoreCases": 2480,
     "normalCoreBreakdown": {
-      "conformance": 985,
+      "conformance": 1171,
       "differential": 136,
       "hydration": 135,
-      "other": 1004
+      "other": 1038
     },
     "profilingOnlyCases": 14,
-    "distinctCoreCasesIncludingProfiling": 2274,
-    "productionModeReruns": 2260,
-    "allWorkspaceExecutions": 7135,
-    "reactSourceAttributedFileUpperBound": 968,
-    "reactSourceAttributedFiles": 68,
+    "distinctCoreCasesIncludingProfiling": 2494,
+    "productionModeReruns": 2480,
+    "allWorkspaceExecutions": 7584,
+    "reactSourceAttributedFileUpperBound": 1154,
+    "reactSourceAttributedFiles": 72,
     "reactSourceAttributedDefinition": "Every collected normal-core case in a local file containing at least one React upstream *-test.js or *-test.ts filename citation; this is a generous file-level upper bound, not a one-to-one port count.",
     "measuredOn": "2026-07-15"
   }

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -225,9 +225,45 @@ interface ElementDescriptor {
 	// React-style `key`, lifted out of props (consulted by the client's de-opt list
 	// path on hydration; the server only renders it into markup).
 	key: any;
+	// React 19 ref-as-prop plus the deprecated element-level alias.
+	ref: any;
 	// `createElement(type, props, ...children)` children for the host form; `null`
 	// for the component-value form (children flow through the component's props).
 	children: any;
+}
+
+function hasElementConfigKey(config: any): boolean {
+	if (config == null || (typeof config !== 'object' && typeof config !== 'function')) return false;
+	const own = Object.getOwnPropertyDescriptor(config, 'key');
+	if (own?.get != null && (own.get as any).isReactWarning) return false;
+	return config.key !== undefined;
+}
+
+function copyElementConfig(config: any): any {
+	const props: any = {};
+	if (config == null) return props;
+	for (const name in config) {
+		if (name !== 'key' && Object.prototype.hasOwnProperty.call(config, name)) {
+			props[name] = config[name];
+		}
+	}
+	return props;
+}
+
+function applyElementDefaultProps(type: any, props: any): void {
+	const defaults = type?.defaultProps;
+	if (defaults == null) return;
+	for (const name in defaults) {
+		if (props[name] === undefined) props[name] = defaults[name];
+	}
+}
+
+function finalizeElementDescriptor(descriptor: ElementDescriptor): ElementDescriptor {
+	if (process.env.NODE_ENV !== 'production') {
+		Object.freeze(descriptor.props);
+		Object.freeze(descriptor);
+	}
+	return descriptor;
 }
 
 // Server `createElement(type, props, ...children)` — produces the SAME descriptor
@@ -241,28 +277,24 @@ export function createElement(
 	...children: any[]
 ): ElementDescriptor {
 	const src = (props ?? null) as any;
-	const key = src != null && src.key != null ? src.key : null;
-	const kids =
-		children.length > 0 ? (children.length === 1 ? children[0] : children) : src?.children;
+	const key = hasElementConfigKey(src) ? '' + src.key : null;
+	let kids = children.length > 0 ? (children.length === 1 ? children[0] : children) : src?.children;
+	if (children.length > 1 && process.env.NODE_ENV !== 'production') Object.freeze(children);
 	// Lift `key` OUT of props (React semantics — key is never a real prop), and mirror
 	// positional children into `props.children` for the same React element shape as the
 	// client runtime. Positional children override an explicit `props.children`.
-	let p = src ?? {};
-	const stripKey = src != null && 'key' in src;
-	const addChildren = children.length > 0;
-	if (stripKey || addChildren) {
-		// Manual copy-minus-key, NOT spread + delete: `delete` drops the object
-		// into V8 dictionary mode, slowing every later for-in over these props
-		// (mirrors the client createElement; own-key guard matches spread).
-		p = {};
-		if (src != null) {
-			for (const k in src) {
-				if (k !== 'key' && Object.prototype.hasOwnProperty.call(src, k)) p[k] = src[k];
-			}
-		}
-		if (addChildren) p.children = kids;
-	}
-	return { $$kind: ELEMENT_TAG, type, props: p, key, children: kids ?? null };
+	const p = copyElementConfig(src);
+	if (children.length > 0) p.children = kids;
+	applyElementDefaultProps(type, p);
+	kids = p.children;
+	return finalizeElementDescriptor({
+		$$kind: ELEMENT_TAG,
+		type,
+		props: p,
+		key,
+		ref: p.ref !== undefined ? p.ref : null,
+		children: kids ?? null,
+	});
 }
 
 // Server half of the client runtime's `positionalChildren` (see runtime.ts): the
@@ -308,12 +340,13 @@ export function cloneElement(
 			'cloneElement: the first argument must be an element (from createElement / JSX).',
 		);
 	}
-	const props: any = { ...(element.props as any) };
+	const props = copyElementConfig(element.props);
 	let key = element.key;
 	if (config != null) {
-		if (config.key !== undefined && config.key !== null) key = config.key;
+		if (hasElementConfigKey(config)) key = '' + config.key;
 		for (const name in config) {
 			if (name === 'key') continue;
+			if (name === 'ref' && config.ref === undefined) continue;
 			if (Object.prototype.hasOwnProperty.call(config, name)) props[name] = config[name];
 		}
 	}
@@ -327,53 +360,214 @@ export function cloneElement(
 		// No new children: reuse `config.children` (now merged into props) or the original.
 		kids = 'children' in props ? props.children : element.children;
 	}
-	if (kids !== undefined) props.children = kids;
-	return { $$kind: ELEMENT_TAG, type: element.type, props, key, children: kids ?? null };
+	if (n > 0) props.children = kids;
+	return finalizeElementDescriptor({
+		$$kind: ELEMENT_TAG,
+		type: element.type,
+		props,
+		key,
+		ref: props.ref !== undefined ? props.ref : null,
+		children: kids ?? null,
+	});
 }
 
-// Visit each leaf of `children` (flattening arrays), passing empties through as
-// `null`. Matches the client runtime's `traverseChildren` (see runtime.ts).
-function traverseChildren(children: any, fn: (child: any, index: number) => void): number {
-	if (children == null) return 0;
-	let index = 0;
-	const walk = (node: any): void => {
-		if (Array.isArray(node)) {
-			for (let i = 0; i < node.length; i++) walk(node[i]);
-			return;
+function cloneAndReplaceElementKey(element: ElementDescriptor, key: string): ElementDescriptor {
+	return finalizeElementDescriptor({
+		$$kind: ELEMENT_TAG,
+		type: element.type,
+		props: element.props,
+		key,
+		ref: element.ref,
+		children: element.children,
+	});
+}
+
+function escapeElementKey(key: string): string {
+	return '$' + key.replace(/[=:]/g, (match) => (match === '=' ? '=0' : '=2'));
+}
+
+function escapeMappedElementKey(key: string): string {
+	return key.replace(/\/+/g, '$&/');
+}
+
+function childElementKey(child: any, index: number): string {
+	return child != null && typeof child === 'object' && child.key != null
+		? escapeElementKey('' + child.key)
+		: index.toString(36);
+}
+
+function childrenIterator(children: any): (() => Iterator<any>) | null {
+	if (children == null || typeof children !== 'object') return null;
+	const iterator =
+		(typeof Symbol === 'function' && (children as any)[Symbol.iterator]) ||
+		(children as any)['@@iterator'];
+	return typeof iterator === 'function' ? iterator : null;
+}
+
+interface ChildrenThenable<T = any> extends PromiseLike<T> {
+	status?: 'pending' | 'fulfilled' | 'rejected';
+	value?: T;
+	reason?: any;
+}
+
+function resolveChildrenThenable(thenable: ChildrenThenable): any {
+	// Inside an SSR pass, route through use() so the active @try/Suspense
+	// boundary receives the private sentinel and render() records the promise for
+	// a retry. A direct public Children call has no such boundary: track the
+	// thenable in React's public shape and throw the pending thenable itself,
+	// never leaking Octane's server-only sentinel to userland.
+	if (FRAME !== null) return use(thenable);
+	if (thenable.status === undefined) {
+		thenable.status = 'pending';
+		thenable.then(
+			(value) => {
+				thenable.status = 'fulfilled';
+				thenable.value = value;
+			},
+			(reason) => {
+				thenable.status = 'rejected';
+				thenable.reason = reason;
+			},
+		);
+	}
+	if (thenable.status === 'fulfilled') return thenable.value;
+	if (thenable.status === 'rejected') throw thenable.reason;
+	throw thenable;
+}
+
+function invalidChildError(child: object): Error {
+	const rendered = String(child);
+	const found =
+		rendered === '[object Object]'
+			? 'object with keys {' + Object.keys(child).join(', ') + '}'
+			: rendered;
+	return new Error(
+		'Objects are not valid as an Octane child (found: ' +
+			found +
+			'). If you meant to render a collection of children, use an array instead.',
+	);
+}
+
+function mapIntoChildren(
+	children: any,
+	out: any[],
+	escapedPrefix: string,
+	nameSoFar: string,
+	callback: (child: any) => any,
+): number {
+	let type = typeof children;
+	if (type === 'undefined' || type === 'boolean') {
+		children = null;
+		type = 'object';
+	}
+	const isLeaf =
+		children === null ||
+		type === 'string' ||
+		type === 'number' ||
+		type === 'bigint' ||
+		isElementDescriptor(children) ||
+		(children != null && children.$$kind === PORTAL_TAG);
+	if (isLeaf) {
+		const child = children;
+		let mapped = callback(child);
+		const childKey = nameSoFar === '' ? '.' + childElementKey(child, 0) : nameSoFar;
+		if (Array.isArray(mapped)) {
+			mapIntoChildren(mapped, out, escapeMappedElementKey(childKey) + '/', '', (value) => value);
+		} else if (mapped != null) {
+			if (isElementDescriptor(mapped)) {
+				const mappedKey = mapped.key;
+				mapped = cloneAndReplaceElementKey(
+					mapped,
+					escapedPrefix +
+						(mappedKey != null && (!child || child.key !== mappedKey)
+							? escapeMappedElementKey('' + mappedKey) + '/'
+							: '') +
+						childKey,
+				);
+			}
+			out.push(mapped);
 		}
-		fn(node == null || typeof node === 'boolean' ? null : node, index++);
-	};
-	walk(children);
-	return index;
+		return 1;
+	}
+
+	let count = 0;
+	const nextPrefix = nameSoFar === '' ? '.' : nameSoFar + ':';
+	if (Array.isArray(children)) {
+		for (let i = 0; i < children.length; i++) {
+			const child = children[i];
+			count += mapIntoChildren(
+				child,
+				out,
+				escapedPrefix,
+				nextPrefix + childElementKey(child, i),
+				callback,
+			);
+		}
+		return count;
+	}
+
+	const iterator = childrenIterator(children);
+	if (iterator !== null) {
+		const cursor = iterator.call(children);
+		let step: IteratorResult<any>;
+		let i = 0;
+		while (!(step = cursor.next()).done) {
+			const child = step.value;
+			count += mapIntoChildren(
+				child,
+				out,
+				escapedPrefix,
+				nextPrefix + childElementKey(child, i++),
+				callback,
+			);
+		}
+		return count;
+	}
+
+	if (type === 'object') {
+		if (typeof children.then === 'function') {
+			return mapIntoChildren(
+				resolveChildrenThenable(children),
+				out,
+				escapedPrefix,
+				nameSoFar,
+				callback,
+			);
+		}
+		throw invalidChildError(children);
+	}
+	return 0;
 }
 
 // Server half of the client runtime's React-compatible `Children` — identical
 // pure descriptor-value logic (see runtime.ts for the semantics comments).
 export const Children = {
-	forEach(children: any, fn: (child: any, index: number) => void): void {
-		traverseChildren(children, fn);
+	forEach(children: any, fn: (child: any, index: number) => void, context?: any): void {
+		if (children == null) return;
+		let index = 0;
+		mapIntoChildren(children, [], '', '', (child) => {
+			fn.call(context, child, index++);
+			return null;
+		});
 	},
-	map<T>(children: any, fn: (child: any, index: number) => T): T[] | null | undefined {
+	map<T>(
+		children: any,
+		fn: (child: any, index: number) => T,
+		context?: any,
+	): T[] | null | undefined {
 		if (children == null) return children as null | undefined;
 		const out: T[] = [];
-		traverseChildren(children, (child, i) => {
-			const mapped = fn(child, i);
-			if (Array.isArray(mapped)) {
-				for (const m of mapped) if (m != null && typeof m !== 'boolean') out.push(m as T);
-			} else if (mapped != null && typeof mapped !== 'boolean') {
-				out.push(mapped);
-			}
-		});
+		let index = 0;
+		mapIntoChildren(children, out, '', '', (child) => fn.call(context, child, index++));
 		return out;
 	},
 	count(children: any): number {
-		return traverseChildren(children, () => {});
+		if (children == null) return 0;
+		return mapIntoChildren(children, [], '', '', () => null);
 	},
 	toArray(children: any): any[] {
 		const out: any[] = [];
-		traverseChildren(children, (child) => {
-			if (child != null) out.push(child);
-		});
+		if (children != null) mapIntoChildren(children, out, '', '', (child) => child);
 		return out;
 	},
 	only<T>(children: T): T {
@@ -2419,6 +2613,45 @@ export function warmChild(comp: any, props: any): void {
 // lives on the wrapper itself (module-level, like the client), so the key only
 // has to be unique per lazy() call — not per frame like use()'s data keys.
 let LAZY_ID = 0;
+const LAZY_COMPONENT = Symbol.for('octane.lazy');
+
+function lazyResolvedProps(comp: ServerComponent, props: any): any {
+	const defaults = (comp as any).defaultProps;
+	if (defaults == null || typeof defaults !== 'object') return props;
+	let resolved = props;
+	for (const key of Object.keys(defaults)) {
+		if (props == null || props[key] === undefined) {
+			if (resolved === props) resolved = props == null ? {} : { ...props };
+			resolved[key] = defaults[key];
+		}
+	}
+	return resolved;
+}
+
+function resolveLazyModule(mod: any): ServerComponent {
+	let comp = mod;
+	if (mod != null) {
+		const defaultExport = mod.default;
+		if (defaultExport !== undefined) comp = defaultExport;
+	}
+	if (typeof comp !== 'function' || (comp as any)[LAZY_COMPONENT] === true) {
+		throw new Error(
+			'lazy: expected the load() promise to resolve to a component function or a ' +
+				"module with a component as its default export, got '" +
+				((comp as any)?.[LAZY_COMPONENT] === true ? 'lazy component' : typeof comp) +
+				"'",
+		);
+	}
+	return comp as ServerComponent;
+}
+
+function callLazyComponent(mod: any, props: any, scope: SSRScope, extra?: any): unknown {
+	// Resolve `.default` at render time. If an accessor throws, a later render
+	// reads it again without re-running the already-fulfilled loader, matching the
+	// client and React payload semantics.
+	const comp = resolveLazyModule(mod);
+	return comp(lazyResolvedProps(comp, props), scope, extra);
+}
 
 /**
  * React's `lazy(load)` — the server mirror of the client wrapper. Unresolved,
@@ -2431,36 +2664,44 @@ let LAZY_ID = 0;
  */
 export function lazy<C>(load: () => PromiseLike<{ default: C } | C>): C {
 	let status: 'uninitialized' | 'pending' | 'fulfilled' | 'rejected' = 'uninitialized';
-	let result: any = null; // fulfilled → component; rejected → the reason
+	let result: any = null; // fulfilled → module value; rejected → the reason
 	let promise: PromiseLike<unknown> | null = null;
 	const key = '|lazy#' + LAZY_ID++;
 	const lazyWrapper = (props: any, scope: SSRScope, extra?: any): unknown => {
-		if (status === 'fulfilled') return (result as ServerComponent)(props, scope, extra);
+		if (status === 'fulfilled') {
+			return callLazyComponent(result as ServerComponent, props, scope, extra);
+		}
 		if (status === 'rejected') throw result;
 		if (status === 'uninitialized') {
-			status = 'pending';
-			promise = load();
-			promise.then(
-				(mod: any) => {
-					const comp = mod != null && mod.default !== undefined ? mod.default : mod;
-					if (typeof comp !== 'function') {
-						status = 'rejected';
-						result = new Error(
-							'lazy: expected the load() promise to resolve to a component function or a ' +
-								"module with a component as its default export, got '" +
-								typeof comp +
-								"'",
-						);
-					} else {
-						status = 'fulfilled';
-						result = comp;
-					}
-				},
-				(err: any) => {
-					status = 'rejected';
-					result = err;
-				},
-			);
+			try {
+				const loaded = load();
+				promise = loaded;
+				loaded.then(
+					(mod: any) => {
+						if (status === 'uninitialized' || status === 'pending') {
+							status = 'fulfilled';
+							result = mod;
+						}
+					},
+					(err: any) => {
+						if (status === 'uninitialized' || status === 'pending') {
+							status = 'rejected';
+							result = err;
+						}
+					},
+				);
+			} catch (error) {
+				// Do not publish a pending payload until loader and subscription setup
+				// both complete. Synchronous failures are retried on the next render.
+				if (status === 'uninitialized') promise = null;
+				throw error;
+			}
+			if (status === 'uninitialized') status = 'pending';
+			const settledStatus = status as 'pending' | 'fulfilled' | 'rejected';
+			if (settledStatus === 'fulfilled') {
+				return callLazyComponent(result as ServerComponent, props, scope, extra);
+			}
+			if (settledStatus === 'rejected') throw result;
 		}
 		// Same suspend bookkeeping as use(thenable), minus the SERIAL seed push.
 		if (SUSPENDED !== null) SUSPENDED.push({ promise: promise!, key });
@@ -2476,6 +2717,7 @@ export function lazy<C>(load: () => PromiseLike<{ default: C } | C>): C {
 		}
 		throw SSR_SUSPENSE;
 	};
+	Object.defineProperty(lazyWrapper, LAZY_COMPONENT, { value: true });
 	return lazyWrapper as unknown as C;
 }
 

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -572,6 +572,11 @@ interface PendingEffect {
 
 let CURRENT_SCOPE: Scope | null = null;
 let CURRENT_BLOCK: Block | null = null;
+// Public root diagnostics need to distinguish an ordinary imperative unmount
+// from one requested by an effect body while the commit lifecycle is active.
+// Passive effects may drain outside `inFlush`, so that scheduler flag alone is
+// insufficient for the observable root warning.
+let EFFECT_BODY_DEPTH = 0;
 // Octane discovers deletion destroys while reconciling a parent, but those
 // callbacks are semantically mutation-phase work. Effect Events may be called
 // from them even though CURRENT_SCOPE still reflects the eager parent render.
@@ -2354,10 +2359,15 @@ function fireEffectCleanup(e: PendingEffect): void {
 function runEffectBody(e: PendingEffect): void {
 	let cleanup: void | Cleanup;
 	try {
-		// Spread deps as positional args (see PendingEffect.args). A no-deps
-		// effect has args === undefined, so the body is called with zero args.
-		// eslint-disable-next-line prefer-spread
-		cleanup = e.fn.apply(null, (e.args ?? []) as []);
+		if (process.env.NODE_ENV !== 'production') EFFECT_BODY_DEPTH++;
+		try {
+			// Spread deps as positional args (see PendingEffect.args). A no-deps
+			// effect has args === undefined, so the body is called with zero args.
+			// eslint-disable-next-line prefer-spread
+			cleanup = e.fn.apply(null, (e.args ?? []) as []);
+		} finally {
+			if (process.env.NODE_ENV !== 'production') EFFECT_BODY_DEPTH--;
+		}
 	} catch (err) {
 		// Route effect errors to the nearest enclosing tryBlock, if any.
 		const handler = findTryHandler(e.scope.block);
@@ -2944,6 +2954,7 @@ function renderReturnedValue(block: Block, out: unknown): void {
 	const useSingleRoot =
 		out !== null &&
 		(out as any).$$kind === ELEMENT_TAG &&
+		(out as any).key == null &&
 		typeof (out as any).type === 'function' &&
 		(out as any).type.$$singleRoot === true;
 	// The private return slot holds EITHER a componentSlotSlot (singleRoot
@@ -4949,6 +4960,21 @@ function adoptWarmValue(slot: HookSlot, deps: any[]): any {
 // lazy — React's code-splitting component wrapper.
 // ---------------------------------------------------------------------------
 
+const LAZY_COMPONENT = Symbol.for('octane.lazy');
+
+function lazyResolvedProps(comp: ComponentBody<any>, props: any): any {
+	const defaults = (comp as any).defaultProps;
+	if (defaults == null || typeof defaults !== 'object') return props;
+	let resolved = props;
+	for (const key of Object.keys(defaults)) {
+		if (props == null || props[key] === undefined) {
+			if (resolved === props) resolved = props == null ? {} : { ...props };
+			resolved[key] = defaults[key];
+		}
+	}
+	return resolved;
+}
+
 /**
  * Resolve a lazy module payload to its component. Accepts React's canonical
  * `{ default: Component }` (a dynamic `import()` namespace) and — as a
@@ -4956,12 +4982,16 @@ function adoptWarmValue(slot: HookSlot, deps: any[]): any {
  * import('./x').then((m) => m.Named))` works without a `{ default }` shim.
  */
 function resolveLazyModule(mod: any): ComponentBody<any> {
-	const comp = mod != null && mod.default !== undefined ? mod.default : mod;
-	if (typeof comp !== 'function') {
+	let comp = mod;
+	if (mod != null) {
+		const defaultExport = mod.default;
+		if (defaultExport !== undefined) comp = defaultExport;
+	}
+	if (typeof comp !== 'function' || (comp as any)[LAZY_COMPONENT] === true) {
 		throw new Error(
 			'lazy: expected the load() promise to resolve to a component function or a ' +
 				"module with a component as its default export, got '" +
-				typeof comp +
+				((comp as any)?.[LAZY_COMPONENT] === true ? 'lazy component' : typeof comp) +
 				"'",
 		);
 	}
@@ -4987,40 +5017,98 @@ function resolveLazyModule(mod: any): ComponentBody<any> {
  */
 export function lazy<C extends ComponentBody<any>>(load: () => PromiseLike<{ default: C } | C>): C {
 	let status: 'uninitialized' | 'pending' | 'fulfilled' | 'rejected' = 'uninitialized';
-	let result: any = null; // fulfilled → component; rejected → the reason
+	let result: any = null; // fulfilled → module value; rejected → the reason
 	let thenable: TrackedThenable<any> | null = null;
-	const lazyWrapper = (props: any, scope: Scope, extra: any): unknown => {
-		if (status === 'fulfilled') return (result as ComponentBody<any>)(props, scope, extra);
+	let profiledComponent: ComponentBody<any> | null = null;
+	let memoMetadataInstalled = false;
+	let lazyWrapper!: ComponentBody<any>;
+
+	const callResolvedComponent = (props: any, scope: Scope, extra: any): unknown => {
+		// Keep the module object, rather than only its current `.default` value. A
+		// throwing/accessor default export is a render-time failure in React: a later
+		// render reads it again without re-running the loader.
+		const comp = resolveLazyModule(result);
+		if ((comp as any).__memo === true) {
+			// The lazy wrapper owns the live Block, so a resolved memo wrapper would
+			// otherwise be tail-called below the place where componentSlot performs its
+			// bailout. Publish equivalent metadata on this wrapper once the module has
+			// resolved. The comparator resolves defaultProps at the same public boundary
+			// as the component invocation.
+			if (!memoMetadataInstalled) {
+				(lazyWrapper as any).__memo = true;
+				(lazyWrapper as any).__compare = (prev: any, next: any): boolean => {
+					const current = resolveLazyModule(result);
+					const compare = (current as any).__compare as
+						| ((previous: any, incoming: any) => boolean)
+						| undefined;
+					const previous = lazyResolvedProps(current, prev);
+					const incoming = lazyResolvedProps(current, next);
+					return compare ? compare(previous, incoming) : shallowEqualProps(previous, incoming);
+				};
+				memoMetadataInstalled = true;
+			}
+			// The Block was created while the payload was unresolved, before it could
+			// inherit memo metadata. Arm context dependency stamping before executing
+			// the resolved memo body.
+			scope.block.memoInChain = true;
+		}
+		if (
+			profiledComponent !== comp &&
+			typeof __OCTANE_PROFILE_ENABLED__ !== 'undefined' &&
+			__OCTANE_PROFILE_ENABLED__
+		) {
+			__profileComponentSource(lazyWrapper, comp);
+			profiledComponent = comp;
+		}
+		return comp(lazyResolvedProps(comp, props), scope, extra);
+	};
+
+	lazyWrapper = (props: any, scope: Scope, extra: any): unknown => {
+		if (status === 'fulfilled') {
+			return callResolvedComponent(props, scope, extra);
+		}
 		if (status === 'rejected') throw result;
 		if (status === 'uninitialized') {
-			status = 'pending';
-			const p = load();
-			thenable = p as TrackedThenable<any>;
-			p.then(
-				(mod: any) => {
-					// This handler was attached FIRST, so by the time the boundary's retry
-					// listener fires the payload is already fulfilled/rejected and the
-					// re-render takes the synchronous branch above.
-					try {
-						result = resolveLazyModule(mod);
-						// Profiling resolves metadata through the loaded component without
-						// wrapping it or changing the lazy wrapper's stable identity.
-						if (typeof __OCTANE_PROFILE_ENABLED__ !== 'undefined' && __OCTANE_PROFILE_ENABLED__)
-							__profileComponentSource(lazyWrapper, result);
-						status = 'fulfilled';
-					} catch (err) {
-						result = err;
-						status = 'rejected';
-					}
-				},
-				(err: any) => {
-					result = err;
-					status = 'rejected';
-				},
-			);
+			try {
+				const p = load();
+				thenable = p as TrackedThenable<any>;
+				p.then(
+					(mod: any) => {
+						// This handler was attached FIRST, so by the time the boundary's retry
+						// listener fires the payload is already fulfilled/rejected and the
+						// re-render takes the synchronous branch above.
+						if (status === 'uninitialized' || status === 'pending') {
+							result = mod;
+							status = 'fulfilled';
+						}
+					},
+					(err: any) => {
+						if (status === 'uninitialized' || status === 'pending') {
+							result = err;
+							status = 'rejected';
+						}
+					},
+				);
+			} catch (error) {
+				// React does not publish Pending until both load() and `.then(...)`
+				// registration return. A synchronous throw is therefore retryable on the
+				// next render instead of poisoning the wrapper with a null thenable.
+				if (status === 'uninitialized') thenable = null;
+				throw error;
+			}
+			if (status === 'uninitialized') status = 'pending';
+			// PromiseLike is permitted to settle while `then` is registering. Match
+			// React's synchronous-thenable contract: render or throw immediately rather
+			// than briefly committing a fallback (or leaving partial sibling work).
+			const settledStatus = status as 'pending' | 'fulfilled' | 'rejected';
+			if (settledStatus === 'fulfilled') {
+				return callResolvedComponent(props, scope, extra);
+			}
+			if (settledStatus === 'rejected') throw result;
 		}
 		throw new SuspenseException(thenable!);
 	};
+	Object.defineProperty(lazyWrapper, LAZY_COMPONENT, { value: true });
 	return lazyWrapper as unknown as C;
 }
 
@@ -8801,20 +8889,61 @@ const ELEMENT_TAG = Symbol.for('octane.element');
 // independent reconciliation boundary without adding an observable descriptor
 // field or penalizing unkeyed descriptors with extra object shape.
 const KEYED_ELEMENT_DESCRIPTORS = new WeakSet<object>();
+// Children.map/toArray synthesize stable traversal keys. Keep the original
+// missing-key validation state out of band so rebasing an unkeyed element from
+// a dynamic collection does not accidentally silence the renderer warning.
+const ELEMENTS_MISSING_LIST_KEY = new WeakSet<object>();
 export interface ElementDescriptor<P = any> {
 	$$kind: typeof ELEMENT_TAG;
 	// A compiled ComponentBody (the fast/common case, e.g. `root.render(<App/>)`)
 	// OR a host tag string (`'li'`) — the latter is produced when host JSX appears
 	// at a VALUE position (a `.map(...)` callback, a function return, an array
 	// literal) and is rendered by the runtime de-opt path (see `renderDeopt`).
-	type: ComponentBody<P> | string;
+	type: ComponentBody<P> | string | typeof Fragment;
 	props: P;
 	// React-style `key`, lifted out of props. Consulted by the de-opt list path
 	// when this descriptor is an item of an array child.
 	key: any;
+	// React 19 treats refs as ordinary props. Keep the deprecated element-level
+	// alias too so code which still inspects `element.ref` observes the same value.
+	ref: any;
 	// Children passed to `createElement(type, props, ...children)` (host de-opt).
 	// `null` for the component-value form (children flow through the component).
 	children: any;
+}
+
+function hasElementConfigKey(config: any): boolean {
+	if (config == null || (typeof config !== 'object' && typeof config !== 'function')) return false;
+	const own = Object.getOwnPropertyDescriptor(config, 'key');
+	// React's development-only props.key warning getter is not a real key. This
+	// matters when an element's props object is fed back into createElement.
+	if (own?.get != null && (own.get as any).isReactWarning) return false;
+	return config.key !== undefined;
+}
+
+function copyElementConfig(config: any): any {
+	const props: any = {};
+	if (config == null) return props;
+	for (const name in config) {
+		if (name !== 'key' && hasOwnProp.call(config, name)) props[name] = config[name];
+	}
+	return props;
+}
+
+function applyElementDefaultProps(type: any, props: any): void {
+	const defaults = type?.defaultProps;
+	if (defaults == null) return;
+	for (const name in defaults) {
+		if (props[name] === undefined) props[name] = defaults[name];
+	}
+}
+
+function finalizeElementDescriptor<P>(descriptor: ElementDescriptor<P>): ElementDescriptor<P> {
+	if (process.env.NODE_ENV !== 'production') {
+		Object.freeze(descriptor.props);
+		Object.freeze(descriptor);
+	}
+	return descriptor;
 }
 // React-shape `createElement(type, props, ...children)`. Two-arg calls
 // (`createElement(Comp, props)`) stay the component-value form the compiler emits
@@ -8822,19 +8951,23 @@ export interface ElementDescriptor<P = any> {
 // host descriptor for the runtime de-opt renderer. `key` is lifted out of props
 // (React semantics — `key` is never a real prop).
 export function createElement<P>(
-	type: ComponentBody<P> | string,
+	type: ComponentBody<P> | string | typeof Fragment,
 	props?: P,
 	...children: any[]
 ): ElementDescriptor<P> {
 	const src = (props ?? null) as any;
-	const key = src != null && src.key != null ? src.key : null;
+	const hasKey = hasElementConfigKey(src);
+	const key = hasKey ? '' + src.key : null;
 	const hasPositional = children.length > 0;
-	const kids = hasPositional ? (children.length === 1 ? children[0] : children) : src?.children;
+	let kids = hasPositional ? (children.length === 1 ? children[0] : children) : src?.children;
 	// Multiple positional children → a fresh array of FIXED siblings (never reordered).
 	// Tag it so the de-opt list keys them by index without the missing-key warning that
 	// is meant for `.map()` results. (A single child is passed through as-is — a lone
 	// `.map()` array stays untagged and keeps the warning.)
-	if (children.length > 1) POSITIONAL_CHILDREN.add(children);
+	if (children.length > 1) {
+		POSITIONAL_CHILDREN.add(children);
+		if (process.env.NODE_ENV !== 'production') Object.freeze(children);
+	}
 	// Build the descriptor's props WITHOUT mutating the caller's object, with `key`
 	// lifted OUT of props (React semantics — `key` is never a real prop).
 	//
@@ -8846,37 +8979,25 @@ export function createElement<P>(
 	// clone/render-prop patterns in React ecosystem bindings preserve host children.
 	// Positional children override an explicit `props.children`, matching React.
 	//
-	// We copy-on-write: a fresh props object is allocated only when there's a `key` to
-	// strip or positional children to fold in, so the compiler's hot 2-arg
-	// `createElement(Comp, props)` path stays allocation-free and never touches the
-	// caller's object.
-	const stripKey = src != null && 'key' in src;
-	const addChildren = hasPositional;
-	let p: any = src ?? {};
-	if (stripKey || addChildren) {
-		// Manual copy-minus-key, NOT `{...src}` + `delete p.key`: deleting a
-		// property drops the object into V8 dictionary mode (no enum cache),
-		// which makes every later for-in/spread over these props slow — memo's
-		// shallowEqualProps measurably regressed on value-position rows with it.
-		p = {};
-		if (src != null) {
-			// hasOwn guard: spread copies OWN enumerable keys only; for-in would
-			// also pick up inherited enumerables.
-			for (const k in src) {
-				if (k !== 'key' && hasOwnProp.call(src, k)) p[k] = (src as any)[k];
-			}
-		}
-		if (addChildren) p.children = kids;
-	}
+	// createElement is callable userland API, so it must snapshot config even on
+	// the common two-argument path. Mutating the caller's object after creation
+	// must not retroactively mutate the element.
+	const keyWasProvided =
+		src != null && (typeof src === 'object' || typeof src === 'function') && 'key' in src;
+	const p = copyElementConfig(src);
+	if (hasPositional) p.children = kids;
+	applyElementDefaultProps(type, p);
+	kids = p.children;
 	const descriptor: ElementDescriptor<P> = {
 		$$kind: ELEMENT_TAG,
 		type,
 		props: p as P,
 		key,
+		ref: p.ref !== undefined ? p.ref : null,
 		children: kids ?? null,
 	};
-	if (stripKey) KEYED_ELEMENT_DESCRIPTORS.add(descriptor);
-	return descriptor;
+	if (keyWasProvided) KEYED_ELEMENT_DESCRIPTORS.add(descriptor);
+	return finalizeElementDescriptor(descriptor);
 }
 function isElementDescriptor(v: any): v is ElementDescriptor {
 	return v != null && v.$$kind === ELEMENT_TAG;
@@ -8917,13 +9038,18 @@ export function cloneElement<P>(
 			'cloneElement: the first argument must be an element (from createElement / JSX).',
 		);
 	}
-	const props: any = { ...(element.props as any) };
+	const props = copyElementConfig(element.props);
 	let key = element.key;
+	let hasKeyOverride = false;
 	if (config != null) {
-		if (config.key !== undefined && config.key !== null) key = config.key;
+		hasKeyOverride = hasElementConfigKey(config);
+		if (hasKeyOverride) key = '' + config.key;
 		for (const name in config) {
 			if (name === 'key') continue;
-			if (Object.prototype.hasOwnProperty.call(config, name)) props[name] = config[name];
+			// React 19 keeps refs as props, but cloneElement treats an explicitly
+			// undefined ref as absent for backwards compatibility.
+			if (name === 'ref' && config.ref === undefined) continue;
+			if (hasOwnProp.call(config, name)) props[name] = config[name];
 		}
 	}
 	const n = children.length;
@@ -8937,15 +9063,13 @@ export function cloneElement<P>(
 		// No new children: reuse `config.children` (now merged into props) or the original.
 		kids = 'children' in props ? props.children : element.children;
 	}
-	// Components read `props.children`; host descriptors carry children on the descriptor
-	// and never fold them into props (the de-opt reconciler owns them) — mirror createElement.
-	if (typeof element.type === 'function') props.children = kids;
-	else if ('children' in props) delete props.children;
+	if (n > 0) props.children = kids;
 	const descriptor: ElementDescriptor<P> = {
 		$$kind: ELEMENT_TAG,
 		type: element.type,
 		props,
 		key,
+		ref: props.ref !== undefined ? props.ref : null,
 		children: kids ?? null,
 	};
 	if (
@@ -8954,54 +9078,208 @@ export function cloneElement<P>(
 	) {
 		KEYED_ELEMENT_DESCRIPTORS.add(descriptor);
 	}
-	return descriptor;
+	// A mapped/toArray descriptor retains its missing-key provenance when it is
+	// cloned unchanged. Supplying a real replacement key fixes that diagnostic,
+	// just as React.cloneElement(mappedChild, {key}) does.
+	if (ELEMENTS_MISSING_LIST_KEY.has(element) && !hasKeyOverride) {
+		ELEMENTS_MISSING_LIST_KEY.add(descriptor);
+	}
+	return finalizeElementDescriptor(descriptor);
 }
 
-// Visit each leaf of `children` (flattening arrays), passing empties through as `null`.
-// A top-level nullish `children` visits nothing (React returns 0). Returns the visit count.
-function traverseChildren(children: any, fn: (child: any, index: number) => void): number {
-	if (children == null) return 0;
-	let index = 0;
-	const walk = (node: any): void => {
-		if (Array.isArray(node)) {
-			for (let i = 0; i < node.length; i++) walk(node[i]);
-			return;
-		}
-		fn(node == null || typeof node === 'boolean' ? null : node, index++);
+function cloneAndReplaceElementKey(element: ElementDescriptor, key: string): ElementDescriptor {
+	const descriptor: ElementDescriptor = {
+		$$kind: ELEMENT_TAG,
+		type: element.type,
+		props: element.props,
+		key,
+		ref: element.ref,
+		children: element.children,
 	};
-	walk(children);
-	return index;
+	KEYED_ELEMENT_DESCRIPTORS.add(descriptor);
+	if (ELEMENTS_MISSING_LIST_KEY.has(element)) ELEMENTS_MISSING_LIST_KEY.add(descriptor);
+	return finalizeElementDescriptor(descriptor);
+}
+
+function escapeElementKey(key: string): string {
+	return '$' + key.replace(/[=:]/g, (match) => (match === '=' ? '=0' : '=2'));
+}
+
+function escapeMappedElementKey(key: string): string {
+	return key.replace(/\/+/g, '$&/');
+}
+
+function childElementKey(child: any, index: number): string {
+	return child != null && typeof child === 'object' && child.key != null
+		? escapeElementKey('' + child.key)
+		: index.toString(36);
+}
+
+function childrenIterator(children: any): (() => Iterator<any>) | null {
+	// React's getIteratorFn deliberately accepts objects only. Functions are
+	// ignored children even when userland attaches Symbol.iterator to one.
+	if (children == null || typeof children !== 'object') return null;
+	const iterator =
+		(typeof Symbol === 'function' && (children as any)[Symbol.iterator]) ||
+		(children as any)['@@iterator'];
+	return typeof iterator === 'function' ? iterator : null;
+}
+
+function resolveChildrenThenable(thenable: TrackedThenable): any {
+	// During a component render, use the same tracked call-order storage and
+	// Suspense sentinel as use(). This lets a cached promise in Children.map
+	// suspend and replay through the nearest Octane boundary.
+	if (CURRENT_BLOCK !== null) return useThenable(thenable);
+	trackThenable(thenable);
+	if (thenable.status === 'fulfilled') return thenable.value;
+	if (thenable.status === 'rejected') throw thenable.reason;
+	throw thenable;
+}
+
+function invalidChildError(child: object): Error {
+	const rendered = String(child);
+	const found =
+		rendered === '[object Object]'
+			? 'object with keys {' + Object.keys(child).join(', ') + '}'
+			: rendered;
+	return new Error(
+		'Objects are not valid as an Octane child (found: ' +
+			found +
+			'). If you meant to render a collection of children, use an array instead.',
+	);
+}
+
+function mapIntoChildren(
+	children: any,
+	out: any[],
+	escapedPrefix: string,
+	nameSoFar: string,
+	callback: (child: any) => any,
+	validateKey = false,
+): number {
+	let type = typeof children;
+	if (type === 'undefined' || type === 'boolean') {
+		children = null;
+		type = 'object';
+	}
+
+	const isLeaf =
+		children === null ||
+		type === 'string' ||
+		type === 'number' ||
+		type === 'bigint' ||
+		isElementDescriptor(children) ||
+		(children != null && children.$$kind === PORTAL_TAG);
+	if (isLeaf) {
+		const child = children;
+		let mapped = callback(child);
+		const childKey = nameSoFar === '' ? '.' + childElementKey(child, 0) : nameSoFar;
+		if (Array.isArray(mapped)) {
+			mapIntoChildren(mapped, out, escapeMappedElementKey(childKey) + '/', '', (value) => value);
+		} else if (mapped != null) {
+			if (isElementDescriptor(mapped)) {
+				const mappedKey = mapped.key;
+				mapped = cloneAndReplaceElementKey(
+					mapped,
+					escapedPrefix +
+						(mappedKey != null && (!child || child.key !== mappedKey)
+							? escapeMappedElementKey('' + mappedKey) + '/'
+							: '') +
+						childKey,
+				);
+				if (validateKey && isElementDescriptor(child) && child.key == null) {
+					ELEMENTS_MISSING_LIST_KEY.add(mapped);
+				}
+			}
+			out.push(mapped);
+		}
+		return 1;
+	}
+
+	let count = 0;
+	const nextPrefix = nameSoFar === '' ? '.' : nameSoFar + ':';
+	if (Array.isArray(children)) {
+		const validateItems = validateKey || !POSITIONAL_CHILDREN.has(children);
+		for (let i = 0; i < children.length; i++) {
+			const child = children[i];
+			count += mapIntoChildren(
+				child,
+				out,
+				escapedPrefix,
+				nextPrefix + childElementKey(child, i),
+				callback,
+				validateItems,
+			);
+		}
+		return count;
+	}
+
+	const iterator = childrenIterator(children);
+	if (iterator !== null) {
+		const cursor = iterator.call(children);
+		let step: IteratorResult<any>;
+		let i = 0;
+		while (!(step = cursor.next()).done) {
+			const child = step.value;
+			count += mapIntoChildren(
+				child,
+				out,
+				escapedPrefix,
+				nextPrefix + childElementKey(child, i++),
+				callback,
+				true,
+			);
+		}
+		return count;
+	}
+
+	if (type === 'object') {
+		if (typeof children.then === 'function') {
+			return mapIntoChildren(
+				resolveChildrenThenable(children),
+				out,
+				escapedPrefix,
+				nameSoFar,
+				callback,
+				validateKey,
+			);
+		}
+		throw invalidChildError(children);
+	}
+	return 0;
 }
 
 export const Children = {
-	/** Iterate children, flattening arrays; empties are visited as `null` (React parity). */
-	forEach(children: any, fn: (child: any, index: number) => void): void {
-		traverseChildren(children, fn);
+	/** Iterate children, flattening collections; empties are visited as `null`. */
+	forEach(children: any, fn: (child: any, index: number) => void, context?: any): void {
+		if (children == null) return;
+		let index = 0;
+		mapIntoChildren(children, [], '', '', (child) => {
+			fn.call(context, child, index++);
+			return null;
+		});
 	},
-	/** Map children to a flat array; empty inputs are visited, empty results are dropped. */
-	map<T>(children: any, fn: (child: any, index: number) => T): T[] | null | undefined {
+	/** Map children to a flat, React-keyed array; empty results are dropped. */
+	map<T>(
+		children: any,
+		fn: (child: any, index: number) => T,
+		context?: any,
+	): T[] | null | undefined {
 		if (children == null) return children as null | undefined;
 		const out: T[] = [];
-		traverseChildren(children, (child, i) => {
-			const mapped = fn(child, i);
-			if (Array.isArray(mapped)) {
-				for (const m of mapped) if (m != null && typeof m !== 'boolean') out.push(m as T);
-			} else if (mapped != null && typeof mapped !== 'boolean') {
-				out.push(mapped);
-			}
-		});
+		let index = 0;
+		mapIntoChildren(children, out, '', '', (child) => fn.call(context, child, index++));
 		return out;
 	},
 	/** Number of children `map`/`forEach` would visit (empties included, like React). */
 	count(children: any): number {
-		return traverseChildren(children, () => {});
+		if (children == null) return 0;
+		return mapIntoChildren(children, [], '', '', () => null);
 	},
-	/** Flatten children into an array, dropping `null`/`undefined`/boolean entries. */
+	/** Flatten children into a React-keyed array, dropping empty entries. */
 	toArray(children: any): any[] {
 		const out: any[] = [];
-		traverseChildren(children, (child) => {
-			if (child != null) out.push(child);
-		});
+		if (children != null) mapIntoChildren(children, out, '', '', (child) => child);
 		return out;
 	},
 	/** Assert `children` is a single element and return it (`React.Children.only`). */
@@ -9170,6 +9448,7 @@ function componentSlotImpl(
 			type: comp,
 			props,
 			key: null,
+			ref: props != null && props.ref !== undefined ? props.ref : null,
 			children: props != null ? props.children : null,
 		} satisfies ElementDescriptor;
 	}
@@ -9758,21 +10037,37 @@ function clearChildContent(state: ChildSlot): void {
 // path) so their hooks/state reconcile too.
 // ---------------------------------------------------------------------------
 
-let _deoptKeyWarned = false;
+// React dedupes missing-key diagnostics by render owner/source. Octane does not
+// carry owner stacks, so use the closest durable equivalent: once per rendering
+// Block. This avoids both global suppression (one list hiding every later bug)
+// and repeated warnings from updates of the same component instance.
+const DEOPT_KEY_WARNED_BLOCKS = new WeakSet<object>();
+let DEOPT_KEY_WARNED_WITHOUT_BLOCK = false;
 function deoptKey(item: any, index: number): any {
-	if (item != null && item.$$kind === ELEMENT_TAG && item.key != null) return item.key;
-	// React parity: unkeyed array children fall back to the index, with a one-time
-	// dev warning. (Suppressed during hydration adoption — markers drive matching.)
-	if (process.env.NODE_ENV !== 'production' && !_deoptKeyWarned && activeHydration() === null) {
-		_deoptKeyWarned = true;
-		console.warn(
-			'Octane: each element in an array child should have a unique "key" prop ' +
-				'(e.g. `items.map((x) => <li key={x.id}>…</li>)`). Falling back to the array ' +
-				'index, which can reconcile incorrectly on reorder — for keyed lists prefer ' +
-				'`@for (...; key ...)`.',
-		);
+	const element = item != null && item.$$kind === ELEMENT_TAG;
+	if (element && item.key != null && !ELEMENTS_MISSING_LIST_KEY.has(item)) return item.key;
+	// React parity: unkeyed array children fall back to the index, with a deduplicated
+	// dev warning. Only ELEMENTS need keys: empty slots, primitives, and nested
+	// iterables are legal list members and must not produce a missing-key warning.
+	// (Suppressed during hydration adoption — markers drive matching.)
+	if (element && process.env.NODE_ENV !== 'production' && activeHydration() === null) {
+		const owner = CURRENT_BLOCK;
+		const warned =
+			owner === null
+				? DEOPT_KEY_WARNED_WITHOUT_BLOCK
+				: DEOPT_KEY_WARNED_BLOCKS.has(owner as object);
+		if (!warned) {
+			if (owner === null) DEOPT_KEY_WARNED_WITHOUT_BLOCK = true;
+			else DEOPT_KEY_WARNED_BLOCKS.add(owner as object);
+			console.warn(
+				'Octane: each element in an array child should have a unique "key" prop ' +
+					'(e.g. `items.map((x) => <li key={x.id}>…</li>)`). Missing keys can reconcile ' +
+					'incorrectly on reorder — for keyed lists prefer ' +
+					'`@for (...; key ...)`.',
+			);
+		}
 	}
-	return index;
+	return element && item.key != null ? item.key : index;
 }
 
 // `createElement(tag, props, a, b, …)` collapses MULTIPLE positional children into a
@@ -10049,47 +10344,138 @@ function setDeoptDesc(el: Element, d: ElementDescriptor): void {
 	(el as Element & DeoptStamped)[DEOPT_DESC] = d;
 }
 
-// Flatten a possibly-nested array child into one item per LEAF, KEEPING empties
-// (they occupy an index slot; see the childSlot array branch). Distinct from
-// flattenDeoptChildren below, which serves the raw host-children reconciler and
-// DROPS empties.
-function flattenChildItems(out: any[], v: any[]): void {
-	for (let i = 0; i < v.length; i++) {
-		const item = v[i];
-		if (Array.isArray(item)) flattenChildItems(out, item);
-		else out.push(item);
+type DeoptWrapperKind = 'array' | 'fragment';
+
+interface PreparedDeoptList {
+	items: any[];
+	keys: any[];
+}
+
+function isFragmentDescriptor(value: any): value is ElementDescriptor {
+	return isElementDescriptor(value) && value.type === Fragment;
+}
+
+function fragmentDescriptorChildren(value: ElementDescriptor): any[] {
+	const children = value.children;
+	if (children == null) return [];
+	return Array.isArray(children) ? children : [children];
+}
+
+function deoptWrapperKind(value: any[]): DeoptWrapperKind {
+	return POSITIONAL_CHILDREN.has(value as object) ? 'fragment' : 'array';
+}
+
+function scopedDeoptKey(
+	path: readonly (string | number)[],
+	item: any,
+	index: number,
+	key: any,
+): string {
+	// Reconciliation keys are an internal encoding, not raw user strings. Encode
+	// both wrapper path and leaf-key KIND so an implicit index 0 cannot alias an
+	// explicit key="0", and a user key that resembles a serialized wrapper path
+	// cannot alias a nested child. JSON quoting makes arbitrary user strings data,
+	// never structure, while remaining stable across renders without an intern map.
+	const explicit = isElementDescriptor(item) && item.key != null;
+	return JSON.stringify([path, explicit ? 'key' : 'index', explicit ? String(key) : index]);
+}
+
+// Flatten arrays and Fragment descriptors to renderable leaves while retaining
+// React's public state-preservation boundaries in their reconciliation keys.
+// One top-level array/Fragment layer is transparent; a nested wrapper with the
+// opposite kind is also transparent when it is the sole child. Equal adjacent
+// wrappers form a real boundary. This is the observable rule behind React's
+// single-child <-> Fragment/array preservation and its two-level remount cases.
+function flattenReactChildContainer(
+	outItems: any[],
+	outKeys: any[],
+	children: any[],
+	kind: DeoptWrapperKind,
+	path: readonly (string | number)[],
+): void {
+	const keyFn = kind === 'fragment' ? deoptKeyPositional : deoptKey;
+	const count = children.length;
+	for (let i = 0; i < count; i++) {
+		const item = children[i];
+		if (isFragmentDescriptor(item)) {
+			const nested = fragmentDescriptorChildren(item);
+			if (item.key != null) {
+				flattenReactChildContainer(outItems, outKeys, nested, 'fragment', [
+					...path,
+					'keyed-fragment',
+					item.key,
+				]);
+			} else {
+				const nestedPath =
+					kind === 'fragment'
+						? [...path, 'wrapper', count === 1 ? 0 : i]
+						: count === 1
+							? path
+							: [...path, 'position', i, 'fragment'];
+				flattenReactChildContainer(outItems, outKeys, nested, 'fragment', nestedPath);
+			}
+			continue;
+		}
+		if (Array.isArray(item)) {
+			const nestedKind = deoptWrapperKind(item);
+			const nestedPath =
+				nestedKind === kind
+					? [...path, 'wrapper', count === 1 ? 0 : i]
+					: count === 1
+						? path
+						: [...path, 'position', i, nestedKind];
+			flattenReactChildContainer(outItems, outKeys, item, nestedKind, nestedPath);
+			continue;
+		}
+		outItems.push(item);
+		outKeys.push(scopedDeoptKey(path, item, i, keyFn(item, i)));
 	}
 }
 
-// Flatten a MIXED children array (fragment leaves + nested `.map()` arrays)
-// into sibling items WITH React's identity semantics: each top-level position
-// is its own reconciliation slot, and a nested array's leaves are keyed WITHIN
-// that slot (compound `<pos>:<innerKey>` keys, like React's `.$` implicit-key
-// prefixes). Without this, flat positional indices shift every sibling's
-// implicit key when a nested list changes length — remounting stable siblings
-// React would keep (e.g. `<>{items.map(...)}<button/></>`: the button must not
-// remount on append). Empties are kept as items (see the childSlot array-path
-// comment). Keys land in `outKeys`, parallel to `outItems`.
-function flattenChildItemsKeyed(
-	outItems: any[],
-	outKeys: any[],
-	v: any[],
-	keyFn: (item: any, index: number) => any,
-	prefix: string,
-): void {
-	for (let i = 0; i < v.length; i++) {
-		const item = v[i];
-		if (Array.isArray(item)) {
-			// A nested array is a `.map()` result (or fragment) — its OWN slot.
-			// Inner unkeyed leaves fall back to their index within the array
-			// (deoptKey's warning already fired at the outer level if relevant).
-			flattenChildItemsKeyed(outItems, outKeys, item, deoptKeyPositional, prefix + i + ':');
-		} else {
-			outItems.push(item);
-			const k = keyFn(item, i);
-			outKeys.push(prefix === '' ? k : prefix + String(k));
-		}
+function prepareDeoptList(
+	value: any,
+	forceSingle: boolean = false,
+	includeKeyedSingle: boolean = true,
+): PreparedDeoptList | null {
+	const items: any[] = [];
+	const keys: any[] = [];
+	if (isFragmentDescriptor(value)) {
+		const path = value.key == null ? [] : ['keyed-fragment', value.key];
+		flattenReactChildContainer(items, keys, fragmentDescriptorChildren(value), 'fragment', path);
+		return { items, keys };
 	}
+	if (Array.isArray(value)) {
+		flattenReactChildContainer(items, keys, value, deoptWrapperKind(value), []);
+		return { items, keys };
+	}
+	if (includeKeyedSingle && isElementDescriptor(value) && value.key != null) {
+		items.push(value);
+		keys.push(scopedDeoptKey([], value, 0, value.key));
+		return { items, keys };
+	}
+	if (forceSingle) {
+		items.push(value);
+		keys.push(scopedDeoptKey([], value, 0, deoptKeyPositional(value, 0)));
+		return { items, keys };
+	}
+	return null;
+}
+
+function iterableChildArray(value: any): any[] | null {
+	if (
+		value == null ||
+		typeof value === 'string' ||
+		Array.isArray(value) ||
+		isElementDescriptor(value)
+	)
+		return null;
+	const iterator = childrenIterator(value);
+	if (iterator === null) return null;
+	const out: any[] = [];
+	const cursor = iterator.call(value);
+	let step: IteratorResult<any>;
+	while (!(step = cursor.next()).done) out.push(step.value);
+	return out;
 }
 
 // Flatten a descriptor's `children` (a single value, or a possibly-nested array —
@@ -10117,6 +10503,7 @@ function flattenDeoptChildren(out: any[], v: any): void {
 function flattenDeoptChildrenKeyed(outVals: any[], outKeys: any[], v: any, prefix: string): void {
 	if (v == null || v === false || v === true || v === '') return;
 	if (Array.isArray(v)) {
+		const keyForItem = POSITIONAL_CHILDREN.has(v) ? deoptKeyPositional : deoptKey;
 		for (let i = 0; i < v.length; i++) {
 			const item = v[i];
 			if (Array.isArray(item)) {
@@ -10125,7 +10512,7 @@ function flattenDeoptChildrenKeyed(outVals: any[], outKeys: any[], v: any, prefi
 				// empty — consumes its position, emits nothing
 			} else {
 				outVals.push(item);
-				const k = item.$$kind === ELEMENT_TAG && item.key != null ? item.key : i;
+				const k = keyForItem(item, i);
 				outKeys.push(prefix === '' ? k : prefix + String(k));
 			}
 		}
@@ -10467,7 +10854,20 @@ function deoptItemBody(item: any, scope: Scope): void {
 			detachDeoptTreeRefs(transfer, null);
 			transfer.parentNode.removeChild(transfer);
 		}
-		childSlot(scope, 0, block.parentNode, item, block.endMarker);
+		// The surrounding list already consumed this descriptor's key. Suppress
+		// the keyed-single list normalization in the nested slot or the same
+		// descriptor would recursively wrap itself forever.
+		childSlot(
+			scope,
+			0,
+			block.parentNode,
+			item,
+			block.endMarker,
+			undefined,
+			undefined,
+			undefined,
+			false,
+		);
 		return;
 	}
 	// Switching Blocks → pure: unmount the childSlot content the Blocks path mounted
@@ -10532,6 +10932,10 @@ function descNeedsBlocks(value: any): boolean {
 		return false;
 	}
 	if (value.$$kind === ELEMENT_TAG) {
+		// A Fragment descriptor is reconciled by childSlot's fragment-aware list
+		// path. If it appears below a host descriptor, keep that host on the Block
+		// path so the Fragment boundary is not mistaken for a raw host node.
+		if (value.type === Fragment) return true;
 		// A component descriptor (function `type`) always needs a Block; a host
 		// descriptor needs one only if its own children do (recurse).
 		return typeof value.type === 'function' || descNeedsBlocks(value.children);
@@ -10599,7 +11003,8 @@ function hostElementBody(d: ElementDescriptor, block: Block): void {
 		// rather than mis-adopt). Recovery runs in dev + prod; the warning is dev-only.
 		if (process.env.NODE_ENV !== 'production') {
 			const mmLoc = (hydration.node.parentNode as any)?.__oct_loc;
-			if (mmLoc) hydration.warnStructural(mmLoc, `<${d.type}>`, hydration.describe(hydration.node));
+			if (mmLoc)
+				hydration.warnStructural(mmLoc, `<${String(d.type)}>`, hydration.describe(hydration.node));
 		}
 		const stale = hydration.node;
 		if (hydration.isOpen(stale)) {
@@ -10809,18 +11214,11 @@ function buildDeoptAdoptQueue(
 	start: Comment,
 	end: Comment,
 ): Array<{ key: any; node: Node }> {
-	const oldArr = Array.isArray(oldChildren) ? oldChildren : [oldChildren];
-	const keyFn = !Array.isArray(oldChildren)
-		? deoptKeyPositional
-		: POSITIONAL_CHILDREN.has(oldChildren as object)
-			? deoptKeyPositional
-			: deoptKey;
 	// SAME flatten + keying as the childSlot array path (incl. compound
 	// slot-scoped keys for nested arrays) — the queue's keys must match the
 	// keys the incoming items will get, or nothing adopts.
-	const items: any[] = [];
-	const keys: any[] = [];
-	flattenChildItemsKeyed(items, keys, oldArr, keyFn, '');
+	const prepared = prepareDeoptList(oldChildren, true)!;
+	const { items, keys } = prepared;
 	const queue: Array<{ key: any; node: Node }> = [];
 	let cursor: Node | null = start.nextSibling;
 	for (let i = 0; i < items.length; i++) {
@@ -10860,14 +11258,21 @@ export function childSlot(
 	// Compiler proof that this renderable hole is the body's entire output.
 	// Used only by the post-hydration exact-range compactor.
 	compactable?: boolean,
+	// Internal: a de-opt list item has already consumed its element key, so its
+	// nested child slot must render the descriptor directly rather than wrap it
+	// in another one-item list.
+	includeKeyedSingle: boolean = true,
 ): void {
 	const parentBlock = parentScope.block;
 	const hydration = activeHydration();
+	const iterable = iterableChildArray(value);
+	if (iterable !== null) value = iterable;
+	const preparedList = prepareDeoptList(value, false, includeKeyedSingle);
 	// A LONE PURE-HOST descriptor (host/text-only subtree — no components, no
 	// portals, no render functions). Computed once per call: the slot init below
 	// uses it to pick the ANCHORLESS regime, the promotion after it to detect a
 	// mode flip out of that regime, and the classifier to route the value.
-	const pureHost = isHostDescriptor(value) && !descNeedsBlocks(value);
+	const pureHost = preparedList === null && isHostDescriptor(value) && !descNeedsBlocks(value);
 	let state = parentScope.slots[slotKey] as ChildSlot | undefined;
 	if (state === undefined) {
 		let start: Comment | null;
@@ -11003,9 +11408,10 @@ export function childSlot(
 		return;
 	}
 
-	// Array child → de-opt keyed list (sound: handles `.map()` results, arrays
-	// through props, and any array-valued child uniformly, by RUNTIME type).
-	if (Array.isArray(value)) {
+	// Arrays, iterables, Fragment descriptors, and a lone explicitly-keyed
+	// element share one keyed-list regime. Keeping a keyed single child in this
+	// regime is what lets it retain state when a sibling is added around it.
+	if (preparedList !== null) {
 		if (state.forSlot === null) {
 			// Drop any prior block/text content — EXCEPT while hydrating, where the
 			// server emitted one `<!--[-->…<!--]-->` range per item between our adopted
@@ -11047,33 +11453,8 @@ export function childSlot(
 				state.forSlot.adopt = buildDeoptAdoptQueue(upgradeChildren, state.start, state.end!);
 			}
 		}
-		// A NESTED array member is a fragment (React parity): its leaves render as
-		// SIBLING items of this list, one item per leaf. Flatten before keying —
-		// without this a nested-array item reaches deoptItemBody as an array, which
-		// the pure host reconciler renders as NOTHING (content silently dropped).
-		// Empties (null/false) are KEPT as items: they occupy an index slot (React's
-		// array-diff semantics) and mirror the server's one-`<!--[-->…<!--]-->`-per-
-		// leaf emission (ssrChildItem serializes an empty leaf as an EMPTY block),
-		// so hydration adopts item ranges 1:1. The positional-key choice is made on
-		// the ORIGINAL array — the flattened copy is a fresh, untagged allocation.
-		const keyFn = POSITIONAL_CHILDREN.has(value as object) ? deoptKeyPositional : deoptKey;
-		let items: any[] = value;
-		let flatKeys: any[] | null = null;
-		for (let i = 0; i < items.length; i++) {
-			if (Array.isArray(items[i])) {
-				// Compound slot-scoped keys (React identity semantics): the nested
-				// array's leaves key WITHIN their top-level position, so a length
-				// change in one list never shifts a SIBLING's implicit key (which
-				// would remount it) — see flattenChildItemsKeyed.
-				const fi: any[] = [];
-				const fk: any[] = [];
-				flattenChildItemsKeyed(fi, fk, value, keyFn, '');
-				items = fi;
-				flatKeys = fk;
-				break;
-			}
-		}
-		const getKey = flatKeys === null ? keyFn : (_item: any, i: number) => flatKeys[i];
+		const { items, keys } = preparedList;
+		const getKey = (_item: any, i: number) => keys[i];
 		// singleRoot=2 (marker-elision M4): pure single-element items self-mark —
 		// no `it` pair per item — resolved per item value in mountItem; shape
 		// flips promote to a minted pair in place (deoptItemBody).
@@ -11624,6 +12005,10 @@ function refreshContextConsumers(block: Block): void {
 // diffing against it next time is what makes the memo terminate.
 function tryMemoBail(block: Block, comp: any, props: any): boolean {
 	if ((comp as any).__memo !== true) return false;
+	// A memo body that suspended or threw on its initial attempt has no committed
+	// props/output to reuse. This also makes lazy-resolved memo metadata safe to
+	// publish during that attempt: the retry must execute until the Block mounts.
+	if (!block.mounted) return false;
 	const compare = (comp as any).__compare as ((prev: any, next: any) => boolean) | undefined;
 	// React.memo's optional comparator: returns true when props are equal
 	// (→ skip the render). Falls back to a shallow Object.is comparison.
@@ -11772,6 +12157,17 @@ export function memo<P>(
 		return component(props, scope, extra);
 	}
 	(memoWrapper as any).__memo = true;
+	// `createElement(memo(Component), …)` and `lazy(() => ({default:
+	// memo(Component)}))` resolve defaults at the public wrapper boundary. Keep the
+	// property live so a component that updates its defaultProps between renders
+	// has the same observable behavior through memo as it does directly.
+	Object.defineProperty(memoWrapper, 'defaultProps', {
+		configurable: true,
+		get: () => (component as any).defaultProps,
+		set: (value) => {
+			(component as any).defaultProps = value;
+		},
+	});
 	if (typeof __OCTANE_PROFILE_ENABLED__ !== 'undefined' && __OCTANE_PROFILE_ENABLED__)
 		__profileComponentSource(memoWrapper, component);
 	if (arePropsEqual) (memoWrapper as any).__compare = arePropsEqual;
@@ -14707,37 +15103,56 @@ function reconcileKeyed<T>(
 		// fresh — the unconsumed nodes are swept by the caller.
 		const adopt = state.adopt;
 		let prev: Block | null = null;
-		for (let i = 0; i < newLen; i++) {
-			const item = items[i];
-			const key = getKey(item, i);
-			let adoptNode: Node | null = null;
-			let anchor: Node = state.end;
-			if (adopt !== null && adopt.length !== 0) {
-				if (adopt[0].key === key) adoptNode = adopt.shift()!.node;
-				else anchor = adopt[0].node;
+		const mounted: Block[] = [];
+		try {
+			for (let i = 0; i < newLen; i++) {
+				const item = items[i];
+				const key = getKey(item, i);
+				let adoptNode: Node | null = null;
+				let anchor: Node = state.end;
+				if (adopt !== null && adopt.length !== 0) {
+					if (adopt[0].key === key) adoptNode = adopt.shift()!.node;
+					else anchor = adopt[0].node;
+				}
+				const block = mountItem(
+					parentBlock,
+					parentNode,
+					anchor,
+					item,
+					i,
+					itemBody,
+					state,
+					singleRoot,
+					ssrMarkerless,
+					adoptNode,
+				);
+				mounted.push(block);
+				oldItems.set(key, block);
+				block.key = key;
+				block.prevSibling = prev;
+				block.nextSibling = null;
+				if (prev) prev.nextSibling = block;
+				else state.head = block;
+				prev = block;
 			}
-			const block = mountItem(
-				parentBlock,
-				parentNode,
-				anchor,
-				item,
-				i,
-				itemBody,
-				state,
-				singleRoot,
-				ssrMarkerless,
-				adoptNode,
-			);
-			oldItems.set(key, block);
-			block.key = key;
-			block.prevSibling = prev;
-			block.nextSibling = null;
-			if (prev) prev.nextSibling = block;
-			else state.head = block;
-			prev = block;
+			state.tail = prev;
+			state.size = newLen;
+		} catch (error) {
+			// A list item may suspend while mounting (most visibly a lazy
+			// component). None of this empty->fill pass has committed yet: discard
+			// every completed prefix item, while mountItem discards the throwing
+			// item itself. A retry then starts from a genuinely empty list instead
+			// of duplicating the completed prefix and overwriting its Map entry.
+			for (let i = mounted.length - 1; i >= 0; i--) {
+				const block = mounted[i];
+				oldItems.delete(block.key);
+				unmountBlock(block, true);
+			}
+			state.head = null;
+			state.tail = null;
+			state.size = 0;
+			throw error;
 		}
-		state.tail = prev;
-		state.size = newLen;
 		return;
 	}
 	// Fast path: clear all.
@@ -15413,7 +15828,15 @@ function mountItem<T>(
 	block.forSlot = forSlot;
 	block.itemIndex = index;
 	if (adoptNode !== null) block.deoptNode = adoptNode;
-	renderBlock(block);
+	try {
+		renderBlock(block);
+	} catch (error) {
+		// The caller cannot receive/register a Block whose initial render threw.
+		// Remove its owned range and hook scopes now; a Suspense retry will mount
+		// it afresh as part of the list transaction.
+		unmountBlock(block, true);
+		throw error;
+	}
 	return block;
 }
 
@@ -15835,7 +16258,17 @@ export interface Root {
 	 * Re-rendering with the same component (`type`/body) updates props in place;
 	 * a different component tears down and remounts.
 	 */
-	render(element: ElementDescriptor): void;
+	render(
+		element:
+			| ElementDescriptor
+			| string
+			| number
+			| bigint
+			| boolean
+			| null
+			| undefined
+			| readonly unknown[],
+	): void;
 	render(body: ComponentBody, props?: any): void;
 	unmount(): void;
 }
@@ -15846,6 +16279,97 @@ export interface RootOptions {
 	 * client-root namespace; hydrateRoot uses it verbatim to match server output.
 	 */
 	identifierPrefix?: string;
+}
+
+// One live public root owns a container at a time. React still returns a second
+// root for a duplicate createRoot call, but publishes a diagnostic because two
+// independent owners can otherwise race over the same DOM. Tokens make release
+// safe when an older duplicate root unmounts after the newer one was created.
+let ROOT_CONTAINER_OWNERS: WeakMap<Element, object> | null = null;
+
+// Generic public renderables (host descriptors, strings, null, and so on) run
+// through the ordinary return-value reconciler. Compiled component bodies stay
+// on the direct fast path and retain Octane's body+props root overload.
+const ROOT_RENDERABLE_BODY = ((value: unknown) =>
+	value === undefined ? null : value) as ComponentBody;
+const EMPTY_ROOT_BODY = (() => undefined) as ComponentBody;
+
+function assertValidRootContainer(container: unknown): asserts container is Element {
+	if (container === null || typeof container !== 'object' || (container as Node).nodeType !== 1) {
+		throw new Error('Target container is not a DOM element.');
+	}
+}
+
+function claimRootContainer(container: Element): object | null {
+	if (process.env.NODE_ENV === 'production') return null;
+	const owners = (ROOT_CONTAINER_OWNERS ??= new WeakMap());
+	if (owners.has(container)) {
+		console.error(
+			'You are calling createRoot() on a container that has already been passed to ' +
+				'createRoot() before. Instead, call root.render() on the existing root instead if ' +
+				'you want to update it.',
+		);
+	}
+	const token = {};
+	owners.set(container, token);
+	return token;
+}
+
+function releaseRootContainer(container: Element, token: object | null): void {
+	if (token !== null && ROOT_CONTAINER_OWNERS?.get(container) === token) {
+		ROOT_CONTAINER_OWNERS.delete(container);
+	}
+}
+
+function warnCreateRootElementOption(options: RootOptions | undefined): RootOptions | undefined {
+	if (isElementDescriptor(options)) {
+		if (process.env.NODE_ENV !== 'production') {
+			console.error(
+				'You passed a JSX element to createRoot. You probably meant to call root.render instead. ' +
+					'Example usage:\n\n  let root = createRoot(domContainer);\n  root.render(<App />);',
+			);
+		}
+		return undefined;
+	}
+	return options;
+}
+
+function warnRootRenderSecondArgument(second: unknown, container: Element): void {
+	if (process.env.NODE_ENV === 'production') return;
+	if (typeof second === 'function') {
+		console.error(
+			'does not support the second callback argument. To execute a side effect after ' +
+				'rendering, declare it in a component body with useEffect().',
+		);
+	} else if (second === container) {
+		console.error(
+			"You passed a container to the second argument of root.render(...). You don't need to " +
+				'pass it again since you already passed it to create the root.',
+		);
+	} else {
+		console.error(
+			'You passed a second argument to root.render(...) but it only accepts one argument.',
+		);
+	}
+}
+
+function warnRootUnmountArgument(): void {
+	if (process.env.NODE_ENV !== 'production') {
+		console.error(
+			'does not support a callback argument. To execute a side effect after rendering, ' +
+				'declare it in a component body with useEffect().',
+		);
+	}
+}
+
+function warnRootLifecycleUnmount(): void {
+	if (process.env.NODE_ENV !== 'production') {
+		console.error(
+			'Attempted to synchronously unmount a root while Octane was already rendering. ' +
+				'Octane cannot finish unmounting the root until the current render has completed, ' +
+				'which may lead to a race condition.',
+		);
+	}
 }
 
 // Shared Root factory behind both `createRoot` and `hydrateRoot`. The
@@ -15861,26 +16385,52 @@ function makeRoot(
 	container: Element,
 	rootBlock: Block | null,
 	currentBody: ComponentBody | null,
+	currentKey: any,
 	idState: RootIdState,
 	outputHandler: OutputHandler | null,
+	ownerToken: object | null,
 ): Root {
+	let unmounted = false;
 	return {
-		render(bodyOrElement: ComponentBody | ElementDescriptor, props?: any) {
+		render(bodyOrElement: unknown, props?: any) {
+			if (unmounted) throw new Error('Cannot update an unmounted root.');
 			// React-style `render(<App foo={x}/>)` arrives as an element descriptor:
 			// unwrap to (type, props). The `render(body, props)` form passes through.
 			let body: ComponentBody;
+			let nextKey: any = null;
 			if (isElementDescriptor(bodyOrElement)) {
-				// At a root, the descriptor is always a component value (`render(<App/>)`),
-				// never a host tag — host descriptors only arise at child positions.
-				body = bodyOrElement.type as ComponentBody;
-				props = bodyOrElement.props;
+				if (arguments.length > 1) warnRootRenderSecondArgument(props, container);
+				nextKey = bodyOrElement.key ?? null;
+				if (typeof bodyOrElement.type === 'function') {
+					body = bodyOrElement.type as ComponentBody;
+					props = bodyOrElement.props;
+				} else {
+					// Host JSX at a root is a normal React renderable. Feed the whole
+					// descriptor to the return-value reconciler instead of calling its tag.
+					body = ROOT_RENDERABLE_BODY;
+					props = bodyOrElement;
+				}
+			} else if (typeof bodyOrElement === 'function') {
+				// OCTANE API: a compiled component body plus props is a supported root
+				// overload, unlike React where a bare function is an invalid child.
+				body = bodyOrElement as ComponentBody;
 			} else {
-				body = bodyOrElement;
+				body = ROOT_RENDERABLE_BODY;
+				if (typeof bodyOrElement === 'symbol') {
+					if (process.env.NODE_ENV !== 'production') {
+						console.error(
+							`Symbols are not valid as an Octane child.\n  root.render(${String(bodyOrElement)})`,
+						);
+					}
+					props = null;
+				} else {
+					props = bodyOrElement;
+				}
 			}
 			// Same component as the live root (incl. a just-hydrated root): update
 			// props in place and schedule. This is a NORMAL client render — `hydrating`
 			// is already false, so renderBlock reuses the adopted DOM, not rebuilds it.
-			if (rootBlock && currentBody === body) {
+			if (rootBlock && currentBody === body && Object.is(currentKey, nextKey)) {
 				rootBlock.props = props;
 				if (typeof __OCTANE_PROFILE_ENABLED__ !== 'undefined' && __OCTANE_PROFILE_ENABLED__)
 					__profileSchedule(rootBlock, 'root-render');
@@ -15891,6 +16441,7 @@ function makeRoot(
 				unmountBlock(rootBlock);
 				rootBlock = null;
 				currentBody = null;
+				currentKey = null;
 			}
 			while (container.firstChild) container.removeChild(container.firstChild);
 			rootBlock = createBlock(
@@ -15908,6 +16459,7 @@ function makeRoot(
 				__profileTrackComponent(rootBlock, body);
 			rootBlock.idState = idState;
 			currentBody = body;
+			currentKey = nextKey;
 			// React parity: render() inside a transition never commits synchronously
 			// — schedule at transition priority so the commit is view-transition-
 			// wrappable (boundaries mounting WITH the initial content enter-animate,
@@ -15930,21 +16482,40 @@ function makeRoot(
 			}
 		},
 		unmount() {
-			if (rootBlock) {
-				// Skip the per-Block DOM walk recursion (~3 removeChild ops × every
-				// Block in the tree). Run cleanups + scope teardown only, then clear
-				// the container in one shot. Portals self-detach during the recursive
-				// teardown because their DOM lives in a foreign target — see the
-				// portalSlotSlot branch in unmountScope.
-				unmountBlock(rootBlock, /*detachDom*/ false);
-				// Root unmount runs outside any flush, so no commit follows — drain the
-				// teardown ref detaches queued above directly.
-				drainRefDetaches();
-				container.textContent = '';
-				rootBlock = null;
-				currentBody = null;
+			if (arguments.length > 0) warnRootUnmountArgument();
+			if (unmounted) return;
+			if (
+				process.env.NODE_ENV !== 'production' &&
+				(inFlush ||
+					CURRENT_BLOCK !== null ||
+					EFFECT_BODY_DEPTH > 0 ||
+					EFFECT_EVENT_LIFECYCLE_DEPTH > 0)
+			) {
+				warnRootLifecycleUnmount();
 			}
-			unregisterDelegationTarget(container);
+			unmounted = true;
+			try {
+				if (rootBlock) {
+					// Skip the per-Block DOM walk recursion (~3 removeChild ops × every
+					// Block in the tree). Run cleanups + scope teardown only, then clear
+					// the container in one shot. Portals self-detach during the recursive
+					// teardown because their DOM lives in a foreign target — see the
+					// portalSlotSlot branch in unmountScope. This also deliberately makes
+					// unmount safe after external DOM removal instead of surfacing the
+					// renderer-specific NotFoundError React happens to expose.
+					unmountBlock(rootBlock, /*detachDom*/ false);
+					// Root unmount runs outside any flush, so no commit follows — drain the
+					// teardown ref detaches queued above directly.
+					drainRefDetaches();
+					container.textContent = '';
+					rootBlock = null;
+					currentBody = null;
+					currentKey = null;
+				}
+			} finally {
+				unregisterDelegationTarget(container);
+				releaseRootContainer(container, ownerToken);
+			}
 		},
 	};
 }
@@ -15954,6 +16525,9 @@ function createRootWithOutputHandler(
 	options: RootOptions | undefined,
 	outputHandler: OutputHandler | null,
 ): Root {
+	assertValidRootContainer(container);
+	options = warnCreateRootElementOption(options);
+	const ownerToken = claimRootContainer(container);
 	// Register the container as an event-delegation target up front. Listeners
 	// for all currently-known delegated events attach now; any new event types
 	// registered later (via `delegateEvents`) will back-attach automatically.
@@ -15963,11 +16537,13 @@ function createRootWithOutputHandler(
 		container,
 		null,
 		null,
+		null,
 		{
 			prefix: (options?.identifierPrefix ?? '') + 'r' + (nextClientRootId++).toString(36) + '-',
 			next: 0,
 		},
 		outputHandler,
+		ownerToken,
 	);
 }
 
@@ -16012,16 +16588,37 @@ export function hydrateRoot(
 	propsOrOptions?: any,
 	rootOptions?: RootOptions,
 ): Root {
+	assertValidRootContainer(container);
 	let body: ComponentBody;
 	let props: any;
+	let rootKey: any = null;
 	if (isElementDescriptor(bodyOrElement)) {
-		body = bodyOrElement.type as ComponentBody;
-		props = bodyOrElement.props;
+		rootKey = bodyOrElement.key ?? null;
+		if (typeof bodyOrElement.type === 'function') {
+			body = bodyOrElement.type as ComponentBody;
+			props = bodyOrElement.props;
+		} else {
+			body = ROOT_RENDERABLE_BODY;
+			props = bodyOrElement;
+		}
 		rootOptions = propsOrOptions as RootOptions | undefined;
-	} else {
+	} else if (bodyOrElement === undefined) {
+		if (process.env.NODE_ENV !== 'production') {
+			console.error(
+				'Must provide initial children as second argument to hydrateRoot. ' +
+					'Example usage: hydrateRoot(domContainer, <App />)',
+			);
+		}
+		body = EMPTY_ROOT_BODY;
+		props = undefined;
+	} else if (typeof bodyOrElement === 'function') {
 		body = bodyOrElement;
 		props = propsOrOptions;
+	} else {
+		body = ROOT_RENDERABLE_BODY;
+		props = bodyOrElement;
 	}
+	const ownerToken = claimRootContainer(container);
 	registerDelegationTarget(container);
 	const rootBlock = createBlock(
 		'root',
@@ -16100,7 +16697,7 @@ export function hydrateRoot(
 	// the root behaves exactly like a `createRoot` root — a `.render()` with the
 	// same component updates props on the adopted DOM (same-body fast path), a
 	// different component tears down and remounts.
-	return makeRoot(container, rootBlock, body, idState, renderReturnedValue);
+	return makeRoot(container, rootBlock, body, rootKey, idState, renderReturnedValue, ownerToken);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/octane/tests/clone-children.test.ts
+++ b/packages/octane/tests/clone-children.test.ts
@@ -67,8 +67,10 @@ describe('Children', () => {
 	const c = createElement('i', { key: 'c' }, 'c');
 
 	it('toArray flattens nested arrays and drops nullish/boolean', () => {
-		expect(Children.toArray([a, null, [b, false, [c]], undefined])).toEqual([a, b, c]);
-		expect(Children.toArray(a)).toEqual([a]);
+		const flattened = Children.toArray([a, null, [b, false, [c]], undefined]);
+		expect(flattened.map((child) => child.key)).toEqual(['.$a', '.2:$b', '.2:2:$c']);
+		expect(flattened.map((child) => child.props.children)).toEqual(['a', 'b', 'c']);
+		expect(Children.toArray(a)[0]).toMatchObject({ key: '.$a', type: 'i' });
 		expect(Children.toArray(null)).toEqual([]);
 	});
 
@@ -85,7 +87,8 @@ describe('Children', () => {
 			seen.push([child, i]);
 			return child; // null child → null result → dropped
 		});
-		expect(out).toEqual([a, b]);
+		expect(out?.map((child) => child.key)).toEqual(['.$a', '.$b']);
+		expect(out?.map((child) => child.props.children)).toEqual(['a', 'b']);
 		expect(seen).toEqual([
 			[a, 0],
 			[null, 1],

--- a/packages/octane/tests/conformance/_fixtures/element-children-api.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/element-children-api.tsrx
@@ -1,0 +1,44 @@
+import { Children, cloneElement, createElement } from 'octane';
+
+function MappedPromise(props) {
+	return Children.map([props.value], (child) => cloneElement(child, { children: 'hi' }));
+}
+
+export function PromiseChildrenHost(props) @{
+	<>
+		@try {
+			<MappedPromise value={props.value} />
+		} @pending {
+			<span class="children-pending">{'Loading...'}</span>
+		} @catch (error) {
+			<span class="children-error">
+				{String(error.message) as string}
+			</span>
+		}
+	</>
+}
+
+function MappedLazy(props) {
+	const child = createElement(props.component, { key: 'hi' });
+	return Children.map([child], (value) => cloneElement(value, { children: 'hi' }));
+}
+
+export function LazyChildrenHost(props) @{
+	<>
+		@try {
+			<MappedLazy component={props.component} />
+		} @pending {
+			<span class="children-pending">{'Loading...'}</span>
+		} @catch (error) {
+			<span class="children-error">
+				{String(error.message) as string}
+			</span>
+		}
+	</>
+}
+
+export function LazyChild(props) @{
+	<div class="lazy-child">
+		{String(props.children) as string}
+	</div>
+}

--- a/packages/octane/tests/conformance/_fixtures/fragment-reconciliation.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/fragment-reconciliation.tsrx
@@ -1,0 +1,392 @@
+import { Fragment, createElement, lazy, useState } from 'octane';
+
+function Stateful(props) @{
+	const [instance] = useState(() => props.allocate());
+	<span class="stateful" data-instance={instance as string}>Hello</span>
+}
+
+function Passthrough(props) {
+	return props.children;
+}
+
+function LazyFragmentBody(props) {
+	return (
+		<>
+			<Stateful key="a" allocate={props.allocate} />
+			<div key="b">World</div>
+		</>
+	);
+}
+
+const LazyFragment = lazy(async () => ({ default: LazyFragmentBody }));
+
+export function RenderSingleFragment() {
+	return (
+		<>
+			<span>foo</span>
+		</>
+	);
+}
+
+export function RenderEmptyFragment() {
+	return <></>;
+}
+
+export function RenderMultipleFragmentChildren() {
+	return (
+		<>
+			{'hello '}
+			<span>world</span>
+		</>
+	);
+}
+
+export function RenderIterableFragmentChildren() {
+	return new Set([
+		createElement('span', { key: 'a', class: 'iterable-a' }, 'hi'),
+		createElement('span', { key: 'b', class: 'iterable-b' }, 'bye'),
+	]);
+}
+
+export function OneLevelNesting(props) {
+	return props.condition ? (
+		<Stateful key="a" allocate={props.allocate} />
+	) : (
+		<>
+			<Stateful key="a" allocate={props.allocate} />
+			<div key="b">World</div>
+		</>
+	);
+}
+
+export function TopLevelFragments(props) {
+	return props.condition ? (
+		<>
+			<Stateful allocate={props.allocate} />
+		</>
+	) : (
+		<>
+			<Stateful allocate={props.allocate} />
+		</>
+	);
+}
+
+export function NestedAtSameLevel(props) {
+	return props.condition ? (
+		<>
+			<>
+				<>
+					<Stateful key="a" allocate={props.allocate} />
+				</>
+			</>
+		</>
+	) : (
+		<>
+			<>
+				<>
+					<div />
+					<Stateful key="a" allocate={props.allocate} />
+				</>
+			</>
+		</>
+	);
+}
+
+export function NonTopLevelNesting(props) {
+	return props.condition ? (
+		<>
+			<>
+				<Stateful key="a" allocate={props.allocate} />
+			</>
+		</>
+	) : (
+		<>
+			<Stateful key="a" allocate={props.allocate} />
+		</>
+	);
+}
+
+export function TwoLevelsWithoutSiblings(props) {
+	return props.condition ? (
+		<Stateful key="a" allocate={props.allocate} />
+	) : (
+		<>
+			<>
+				<Stateful key="a" allocate={props.allocate} />
+			</>
+		</>
+	);
+}
+
+export function TwoLevelsWithSiblings(props) {
+	return props.condition ? (
+		<Stateful key="a" allocate={props.allocate} />
+	) : (
+		<>
+			<>
+				<Stateful key="a" allocate={props.allocate} />
+			</>
+			<div class="sibling" />
+		</>
+	);
+}
+
+export function ArrayInFragmentToFragment(props) {
+	return props.condition ? (
+		<>
+			<Stateful key="a" allocate={props.allocate} />
+		</>
+	) : (
+		<>{[<Stateful key="a" allocate={props.allocate} />]}</>
+	);
+}
+
+export function TopLevelFragmentToArray(props) {
+	return props.condition
+		? [<Stateful key="a" allocate={props.allocate} />]
+		: <><Stateful key="a" allocate={props.allocate} /></>;
+}
+
+export function ArrayInFragmentToDoubleFragment(props) {
+	return props.condition ? (
+		<>{[<Stateful key="a" allocate={props.allocate} />]}</>
+	) : (
+		<>
+			<>
+				<Stateful key="a" allocate={props.allocate} />
+			</>
+		</>
+	);
+}
+
+export function ArrayInFragmentToDoubleArray(props) {
+	return props.condition
+		? <>{[<Stateful key="a" allocate={props.allocate} />]}</>
+		: [[<Stateful key="a" allocate={props.allocate} />]];
+}
+
+export function DoubleFragmentToDoubleArray(props) {
+	return props.condition ? (
+		<>
+			<>
+				<Stateful key="a" allocate={props.allocate} />
+			</>
+		</>
+	) : (
+		[[<Stateful key="a" allocate={props.allocate} />]]
+	);
+}
+
+export function DifferentFragmentKeys(props) {
+	return props.condition ? (
+		<Fragment key="a">
+			<Stateful allocate={props.allocate} />
+		</Fragment>
+	) : (
+		<Fragment key="b">
+			<Stateful allocate={props.allocate} />
+			<span>World</span>
+		</Fragment>
+	);
+}
+
+export function KeyedToUnkeyedFragment(props) {
+	return props.condition ? (
+		<Fragment key="a">
+			<Stateful allocate={props.allocate} />
+		</Fragment>
+	) : (
+		<>
+			<Stateful allocate={props.allocate} />
+		</>
+	);
+}
+
+export function NestedImplicitAndExplicitZeroKeys(props) {
+	return props.condition ? (
+		<>
+			<>
+				<Stateful allocate={props.allocate} />
+				<Stateful key="0" allocate={props.allocate} />
+			</>
+		</>
+	) : (
+		<>
+			<>
+				<Stateful key="0" allocate={props.allocate} />
+			</>
+		</>
+	);
+}
+
+export function ReorderAcrossLevels(props) {
+	return props.condition ? (
+		<div>
+			<Fragment key="c">
+				<span>foo</span>
+				<div key="b">
+					<Stateful key="a" allocate={props.allocate} />
+				</div>
+			</Fragment>
+			<span>boop</span>
+		</div>
+	) : (
+		<div>
+			<span>beep</span>
+			<Fragment key="c">
+				<div key="b">
+					<Stateful key="a" allocate={props.allocate} />
+				</div>
+				<span>bar</span>
+			</Fragment>
+		</div>
+	);
+}
+
+export function KeyedFragmentToArray(props) {
+	return props.condition ? (
+		<div>
+			<Fragment key="foo">
+				<Stateful allocate={props.allocate} />
+			</Fragment>
+			<span />
+		</div>
+	) : (
+		<div>
+			{[<Stateful allocate={props.allocate} />]}
+			<span />
+		</div>
+	);
+}
+
+export function NestedUnkeyedFragmentToPassthrough(props) {
+	return props.condition ? (
+		<>
+			<>
+				<Stateful allocate={props.allocate} />
+			</>
+		</>
+	) : (
+		<>
+			<Passthrough>
+				<Stateful allocate={props.allocate} />
+			</Passthrough>
+		</>
+	);
+}
+
+export function NestedKeyedFragmentToPassthrough(props) {
+	return props.condition ? (
+		<>
+			<Fragment key="a">
+				<Stateful allocate={props.allocate} />
+			</Fragment>
+		</>
+	) : (
+		<>
+			<Passthrough>
+				<Stateful allocate={props.allocate} />
+			</Passthrough>
+		</>
+	);
+}
+
+export function NestedKeyedArrayToPassthrough(props) {
+	return props.condition ? (
+		<>{[<Stateful key="a" allocate={props.allocate} />]}</>
+	) : (
+		<>
+			<Passthrough>
+				<Stateful allocate={props.allocate} />
+			</Passthrough>
+		</>
+	);
+}
+
+export function SamePositions(props) {
+	return props.condition
+		? [
+				<span key="s" />,
+				<>
+					<Stateful allocate={props.allocate} />
+				</>,
+			]
+		: [
+				<span key="s" />,
+				<>
+					<Stateful allocate={props.allocate} />
+				</>,
+			];
+}
+
+export function AddLazyFragment(props) {
+	return props.condition ? (
+		<Stateful key="a" allocate={props.allocate} />
+	) : (
+		<LazyFragment allocate={props.allocate} />
+	);
+}
+
+export function AddLazyFragmentBoundary(props) @{
+	@try {
+		<AddLazyFragment condition={props.condition} allocate={props.allocate} />
+	} @pending {
+		<p class="lazy-pending">loading</p>
+	}
+}
+
+export function TopLevelSimpleFragment() {
+	return [
+		<div key="a">Hello</div>,
+		<div key="b">World</div>,
+	];
+}
+
+export function TopLevelSingleToArray(props) {
+	return props.condition ? (
+		<Stateful key="a" allocate={props.allocate} />
+	) : (
+		[
+			<Stateful key="a" allocate={props.allocate} />,
+			<div key="b">World</div>,
+		]
+	);
+}
+
+export function TopLevelSingleToNestedArray(props) {
+	return props.condition ? (
+		<Stateful key="a" allocate={props.allocate} />
+	) : (
+		[
+			[
+				<Stateful key="a" allocate={props.allocate} />,
+				<div key="b">World</div>,
+			],
+			<div key="c" />,
+		]
+	);
+}
+
+export function TopLevelImplicitNullSlot(props) {
+	return props.condition
+		? [null, <Stateful key="a" allocate={props.allocate} />]
+		: [
+				<div key="b">Hello</div>,
+				<Stateful key="a" allocate={props.allocate} />,
+			];
+}
+
+export function TopLevelNestedReorder(props) {
+	return props.condition
+		? [[
+				<div key="b">World</div>,
+				<Stateful key="a" allocate={props.allocate} />,
+			]]
+		: [
+				[
+					<Stateful key="a" allocate={props.allocate} />,
+					<div key="b">World</div>,
+				],
+				<div key="c" />,
+			];
+}

--- a/packages/octane/tests/conformance/_fixtures/lazy-components.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/lazy-components.tsrx
@@ -1,0 +1,122 @@
+import { createElement, useContext, useLayoutEffect, useState } from 'octane';
+
+export function LazyText(props) @{
+	<span class="lazy-value">
+		{String(props.text) as string}
+	</span>
+}
+
+export function LazyAdd(props) {
+	return String(props.inner + props.outer);
+}
+
+export function LazyMemoProbe(props) @{
+	props.onRender(props.value);
+	<span class="lazy-memo-probe">
+		{String(props.value) as string}
+	</span>
+}
+
+export const LazyDefaultText = (props) => <span class="lazy-default">{String(props.text)}</span>;
+LazyDefaultText.defaultProps = { text: 'default' };
+
+export function LazyStatefulItem(props) @{
+	const [count, setCount] = useState(0);
+	useLayoutEffect(() => {
+		props.log?.('mount:' + props.label);
+		return () => props.log?.('unmount:' + props.label);
+	}, []);
+	<button
+		class="lazy-item"
+		data-id={props.id as string}
+		onClick={() => setCount((value) => value + 1)}
+	>
+		{props.label + ':' + count as string}
+	</button>
+}
+
+export function LazyRefTarget(props) @{
+	<div class="lazy-ref" ref={props.ref}>
+		{props.label as string}
+	</div>
+}
+
+export function LazyHost(props) @{
+	const Component = props.comp;
+	<>
+		@try {
+			<Component {...props.childProps} />
+		} @pending {
+			<div class="lazy-fallback">{'Loading...'}</div>
+		} @catch (error) {
+			<div class="lazy-error">
+				{'Error: ' + error.message as string}
+			</div>
+		}
+	</>
+}
+
+export function LazyPairHost(props) @{
+	const First = props.first;
+	const Second = props.second;
+	<>
+		@try {
+			<div class="lazy-pair">
+				<First text="A" />
+				<Second text="B" />
+			</div>
+		} @pending {
+			<div class="lazy-fallback">{'Loading...'}</div>
+		} @catch (error) {
+			<div class="lazy-error">
+				{'Error: ' + error.message as string}
+			</div>
+		}
+	</>
+}
+
+export function LazyListHost(props) @{
+	const children = props.items.map(
+		(item) => createElement(item.comp, {
+			key: item.key,
+			id: item.key,
+			label: item.label,
+			log: props.log,
+		}),
+	);
+	<>
+		@try {
+			<div class="lazy-list">{children}</div>
+		} @pending {
+			<div class="lazy-fallback">{'Loading...'}</div>
+		} @catch (error) {
+			<div class="lazy-error">
+				{'Error: ' + error.message as string}
+			</div>
+		}
+	</>
+}
+
+function LazyContextConsumer(props) @{
+	const value = useContext(props.context);
+	<span class="lazy-context">
+		{String(value) as string}
+	</span>
+}
+
+export function LazyProviderHost(props) @{
+	const Provider = props.provider;
+	<>
+		@try {
+			<Provider value={props.value}>
+				<LazyContextConsumer context={props.context} />
+			</Provider>
+		} @pending {
+			<div class="lazy-fallback">{'Loading...'}</div>
+		} @catch (error) {
+			<div class="lazy-error">
+				{'Error: ' + error.message as string}
+			</div>
+		}
+	</>
+}

--- a/packages/octane/tests/conformance/_fixtures/root-semantics.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/root-semantics.tsrx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'octane';
+
+export function TextRoot(props) @{
+	<div id="text-root">
+		{props.text as string}
+	</div>
+}
+
+export function DivRoot() @{
+	<div id="div-root">{'div'}</div>
+}
+
+export function SpanRoot() @{
+	<span id="span-root">{'span'}</span>
+}
+
+export function OrderedChildren(props) @{
+	<div id="ordered-root">
+		<span>
+			{props.first as string}
+		</span>
+		<span>
+			{props.second as string}
+		</span>
+	</div>
+}
+
+export function HydrationRoot(props) @{
+	<div id="hydration-root">
+		<span class={props.className}>
+			{props.text as string}
+		</span>
+	</div>
+}
+
+export function KeyedRoot(props) @{
+	const [initialText] = useState(props.text);
+	useEffect(() => {
+		props.log('Mount');
+		return () => props.log('Unmount');
+	}, []);
+	<span id="keyed-root">
+		{props.text + ':' + initialText as string}
+	</span>
+}
+
+export function EffectUnmountRoot(props) @{
+	useEffect(() => {
+		if (props.step === 2) props.unmountOtherRoot();
+	}, [props.step]);
+	<span id="effect-root">{'Hi'}</span>
+}

--- a/packages/octane/tests/conformance/element-children-api.test.ts
+++ b/packages/octane/tests/conformance/element-children-api.test.ts
@@ -1,0 +1,1066 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	Children,
+	cloneElement,
+	createElement,
+	createPortal,
+	createRoot,
+	flushSync,
+	isValidElement,
+	lazy,
+} from 'octane';
+import { act, mount } from '../_helpers.js';
+import {
+	LazyChild,
+	LazyChildrenHost,
+	PromiseChildrenHost,
+} from './_fixtures/element-children-api.tsrx';
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((res) => {
+		resolve = res;
+	});
+	return { promise, resolve };
+}
+
+function valuesIterable(values: any[]): any {
+	return {
+		'@@iterator'() {
+			let index = 0;
+			return {
+				next() {
+					return index < values.length
+						? { value: values[index++], done: false }
+						: { value: undefined, done: true };
+				},
+			};
+		},
+	};
+}
+
+function RenderValue(props: { value: any }): any {
+	return props.value;
+}
+
+function missingKeyWarnings(run: () => void): string[] {
+	const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+	try {
+		run();
+		return warn.mock.calls
+			.map((call) => String(call[0]))
+			.filter((call) => call.includes('unique "key"'));
+	} finally {
+		warn.mockRestore();
+	}
+}
+
+describe('ReactChildren public behavior', () => {
+	// Per ReactChildren-test.js:25.
+	it('should support identity for simple', () => {
+		const context = {};
+		const child = createElement('span', { key: 'simple' });
+		const seen: any[] = [];
+		Children.forEach(
+			child,
+			function (this: any, value, index) {
+				seen.push([this, value, index]);
+			},
+			context,
+		);
+		const mapped = Children.map(
+			child,
+			function (this: any, value) {
+				expect(this).toBe(context);
+				return value;
+			},
+			context,
+		)!;
+		expect(seen).toEqual([[context, child, 0]]);
+		expect(mapped[0]).not.toBe(child);
+		expect((mapped[0] as any).key).toBe('.$simple');
+	});
+
+	// Per ReactChildren-test.js:50.
+	it('should support Portal components', () => {
+		const portal = createPortal(createElement('span'), document.createElement('div'));
+		const seen: any[] = [];
+		Children.forEach(portal, (child, index) => seen.push([child, index]));
+		expect(seen).toEqual([[portal, 0]]);
+		expect(Children.map(portal, (child) => child)).toEqual([portal]);
+	});
+
+	// Per ReactChildren-test.js:75.
+	it('should treat single arrayless child as being in array', () => {
+		const child = createElement('span');
+		const mapped = Children.map(child, (value) => value)!;
+		expect(mapped).toHaveLength(1);
+		expect((mapped[0] as any).key).toBe('.0');
+	});
+
+	// Per ReactChildren-test.js:96.
+	it('should treat single child in array as expected', () => {
+		const child = createElement('span', { key: 'simple' });
+		const mapped = Children.map([child], (value) => value)!;
+		expect(mapped).toHaveLength(1);
+		expect((mapped[0] as any).key).toBe('.$simple');
+	});
+
+	// Per ReactChildren-test.js:117.
+	it('should be called for each child', () => {
+		const children = [createElement('div', { key: 'zero' }), null, createElement('div')];
+		const seen: any[] = [];
+		Children.forEach(children, (child, index) => seen.push([child, index]));
+		expect(seen).toEqual([
+			[children[0], 0],
+			[null, 1],
+			[children[2], 2],
+		]);
+		expect(Children.map(children, (child) => child)).toHaveLength(2);
+	});
+
+	// Per ReactChildren-test.js:165.
+	it('should traverse children of different kinds', () => {
+		const div = createElement('div', { key: 'div' });
+		const span = createElement('span', { key: 'span' });
+		const children = [div, [[span]], 'string', 1234, true, false, null, undefined, 9n];
+		const seen: any[] = [];
+		Children.forEach(children, (child) => seen.push(child));
+		expect(seen).toEqual([div, span, 'string', 1234, null, null, null, null, 9n]);
+		expect(Children.toArray(children).map((child: any) => child.type ?? child)).toEqual([
+			'div',
+			'span',
+			'string',
+			1234,
+			9n,
+		]);
+	});
+
+	// Per ReactChildren-test.js:225.
+	it('should be called for each child in nested structure', () => {
+		const a = createElement('i', { key: 'a' });
+		const b = createElement('i', { key: 'b' });
+		const c = createElement('i', { key: 'c' });
+		const seen: any[] = [];
+		Children.forEach(
+			[
+				[a, null, b],
+				[null, c],
+			],
+			(child, index) => seen.push([child, index]),
+		);
+		expect(seen).toEqual([
+			[a, 0],
+			[null, 1],
+			[b, 2],
+			[null, 3],
+			[c, 4],
+		]);
+	});
+
+	// Per ReactChildren-test.js:268.
+	it('should retain key across two mappings', () => {
+		const children = [createElement('div', { key: 'zero' }), createElement('div', { key: 'one' })];
+		const once = Children.map(children, (child) => child)! as any[];
+		const twice = Children.map(once, (child) => child)! as any[];
+		expect(once.map((child) => child.key)).toEqual(['.$zero', '.$one']);
+		expect(twice.map((child) => child.key)).toEqual(['.$.$zero', '.$.$one']);
+	});
+
+	// Per ReactChildren-test.js:305.
+	it('should be called for each child in an iterable without keys', () => {
+		const children = [createElement('div'), createElement('div'), createElement('div')];
+		const seen: any[] = [];
+		const mapped = Children.map(valuesIterable(children), (child, index) => {
+			seen.push([child, index]);
+			return child;
+		})! as any[];
+		expect(seen).toEqual(children.map((child, index) => [child, index]));
+		expect(mapped.map((child) => child.key)).toEqual(['.0', '.1', '.2']);
+	});
+
+	// Per ReactChildren-test.js:366.
+	it('should be called for each child in an iterable with keys', () => {
+		const children = [1, 2, 3].map((n) => createElement('div', { key: '#' + n }));
+		const mapped = Children.map(valuesIterable(children), (child) => child)! as any[];
+		expect(mapped.map((child) => child.key)).toEqual(['.$#1', '.$#2', '.$#3']);
+	});
+
+	// Per ReactChildren-test.js:414 and ReactElementValidator-test.internal.js:459.
+	it('should not enumerate enumerable numbers (#4776)', () => {
+		const prototype = Number.prototype as any;
+		prototype['@@iterator'] = () => {
+			throw new Error('number iterator called');
+		};
+		try {
+			expect(Children.toArray([5, 12, 13])).toEqual([5, 12, 13]);
+		} finally {
+			delete prototype['@@iterator'];
+		}
+	});
+
+	// Per ReactChildren-test.js:459.
+	it('should allow extension of native prototypes', () => {
+		(String.prototype as any).key = 'octane';
+		(Number.prototype as any).key = 'rocks';
+		try {
+			expect(Children.toArray(['a', 13])).toEqual(['a', 13]);
+		} finally {
+			delete (String.prototype as any).key;
+			delete (Number.prototype as any).key;
+		}
+	});
+
+	// Per ReactChildren-test.js:414. React only treats objects as iterable
+	// child collections; a function remains a non-renderable child even when
+	// userland attaches an iterator to it.
+	it('does not traverse callable iterables', () => {
+		const callable = Object.assign(function callable() {}, {
+			*[Symbol.iterator]() {
+				yield createElement('i');
+			},
+		});
+		const callback = vi.fn((child) => child);
+		expect(Children.toArray(callable)).toEqual([]);
+		expect(Children.count(callable)).toBe(0);
+		expect(Children.map(callable, callback)).toEqual([]);
+		expect(callback).not.toHaveBeenCalled();
+	});
+
+	// Per ReactChildren-test.js:500.
+	it('should pass key to returned component', () => {
+		const child = createElement('span', { key: 'simple' });
+		const mapped = Children.map(child, (value) => createElement('div', null, value))! as any[];
+		expect(mapped[0].key).toBe('.$simple');
+		expect(mapped[0].props.children).toBe(child);
+	});
+
+	// Per ReactChildren-test.js:516.
+	it('should invoke callback with the right context', () => {
+		const context = { label: 'scope' };
+		const values: any[] = [];
+		Children.forEach(
+			[1, 2],
+			function (this: any, child) {
+				values.push([this, child]);
+			},
+			context,
+		);
+		expect(values).toEqual([
+			[context, 1],
+			[context, 2],
+		]);
+	});
+
+	// Per ReactChildren-test.js:541.
+	it('should be called for each child in array', () => {
+		const original = [
+			createElement('div', { key: 'keyZero' }),
+			null,
+			createElement('div', { key: 'keyTwo' }),
+			null,
+			createElement('div', { key: 'keyFour' }),
+		];
+		const replacements = [
+			createElement('div', { key: 'giraffe' }),
+			null,
+			createElement('div'),
+			createElement('span'),
+			createElement('div', { key: 'keyFour' }),
+		];
+		const mapped = Children.map(original, (_child, index) => replacements[index])! as any[];
+		expect(mapped.map((child) => child.key)).toEqual([
+			'giraffe/.$keyZero',
+			'.$keyTwo',
+			'.3',
+			'.$keyFour',
+		]);
+	});
+
+	// Per ReactChildren-test.js:603.
+	it('should be called for each child in nested structure with mapping', () => {
+		const zero = createElement('div', { key: 'keyZero' });
+		const two = createElement('div', { key: 'keyTwo' });
+		const four = createElement('div', { key: 'keyFour' });
+		const five = createElement('div', { key: 'keyFive' });
+		const mapped = Children.map([[[zero, null, two], [null, four], five]], (child) => {
+			if (child === zero) return createElement('div', { key: 'giraffe' });
+			if (child === two || child === five) return createElement('div');
+			return child;
+		})! as any[];
+		expect(mapped.map((child) => child.key)).toEqual([
+			'giraffe/.0:0:$keyZero',
+			'.0:0:$keyTwo',
+			'.0:1:$keyFour',
+			'.0:$keyFive',
+		]);
+	});
+
+	// Per ReactChildren-test.js:676.
+	it('should retain key across two mappings with conditions', () => {
+		const children = [
+			createElement('div', { key: 'keyZero' }),
+			createElement('div', { key: 'keyOne' }),
+		];
+		const first = Children.map(children, (_child, index) =>
+			index === 0 ? createElement('div', { key: 'giraffe' }) : createElement('div'),
+		)! as any[];
+		const second = Children.map(first, (_child, index) =>
+			index === 0 ? createElement('div', { key: 'giraffe' }) : createElement('div'),
+		)! as any[];
+		expect(first.map((child) => child.key)).toEqual(['giraffe/.$keyZero', '.$keyOne']);
+		expect(second.map((child) => child.key)).toEqual(['giraffe/.$giraffe/.$keyZero', '.$.$keyOne']);
+	});
+
+	// Per ReactChildren-test.js:717.
+	it('should not throw if key provided is a dupe with array key', () => {
+		expect(() =>
+			Children.map([createElement('div'), createElement('div', { key: '0' })], () => null),
+		).not.toThrow();
+	});
+
+	// Per ReactChildren-test.js:737.
+	it('should use the same key for a cloned element', () => {
+		const child = createElement('div');
+		const mapped = Children.map(child, (value) => value)! as any[];
+		const cloned = Children.map(child, (value) => cloneElement(value))! as any[];
+		expect(mapped[0].key).toBe(cloned[0].key);
+	});
+
+	// Per ReactChildren-test.js:757.
+	it('should use the same key for a cloned element with key', () => {
+		const child = createElement('div', { key: 'unique' });
+		const mapped = Children.map(child, (value) => value)! as any[];
+		const cloned = Children.map(child, (value) => cloneElement(value, { key: 'unique' }))! as any[];
+		expect(mapped[0].key).toBe(cloned[0].key);
+	});
+
+	// Per ReactChildren-test.js:777.
+	it('should return 0 for null children', () => {
+		expect(Children.count(null)).toBe(0);
+	});
+
+	// Per ReactChildren-test.js:782.
+	it('should return 0 for undefined children', () => {
+		expect(Children.count(undefined)).toBe(0);
+	});
+
+	// Per ReactChildren-test.js:787.
+	it('should return 1 for single child', () => {
+		expect(Children.count(createElement('span'))).toBe(1);
+	});
+
+	// Per ReactChildren-test.js:794.
+	it('should count the number of children in flat structure', () => {
+		expect(Children.count([createElement('div'), null, createElement('div'), null])).toBe(4);
+	});
+
+	// Per ReactChildren-test.js:814.
+	it('should count the number of children in nested structure', () => {
+		expect(Children.count([[[createElement('div'), null], [createElement('div')]], null])).toBe(4);
+	});
+
+	// Per ReactChildren-test.js:829.
+	it('should flatten children to an array', () => {
+		const flattened = Children.toArray([
+			[createElement('div', { key: 'apple' }), createElement('div', { key: 'banana' })],
+			[createElement('div', { key: 'banana' }), createElement('div', { key: 'deli' })],
+		]) as any[];
+		expect(flattened).toHaveLength(4);
+		expect(flattened[1].key).toContain('banana');
+		expect(flattened[2].key).toContain('banana');
+		expect(flattened[1].key).not.toBe(flattened[2].key);
+		expect(Children.toArray([1, 'two', null, undefined, true])).toEqual([1, 'two']);
+	});
+
+	// Per ReactChildren-test.js:895, :944, :987 and :1197. Static siblings are
+	// passed positionally, so React and Octane both treat them as already valid.
+	it('does not warn for mapped static children without keys', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		const parent = createElement('div', null, createElement('i'), createElement('b'));
+		const mapped = Children.map(parent.props.children, (child) =>
+			createElement('span', null, child),
+		);
+		const result = mount(RenderValue as any, { value: mapped });
+		expect(warn.mock.calls.some((call) => String(call[0]).includes('unique "key"'))).toBe(false);
+		result.unmount();
+		warn.mockRestore();
+	});
+
+	// Per ReactChildren-test.js:944.
+	it('does not warn for cloned static children without keys', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		const parent = createElement('div', null, createElement('i'), createElement('b'));
+		const cloned = Children.map(parent.props.children, (child) => cloneElement(child));
+		const result = mount(RenderValue as any, { value: cloned });
+		expect(warn.mock.calls.some((call) => String(call[0]).includes('unique "key"'))).toBe(false);
+		result.unmount();
+		warn.mockRestore();
+	});
+
+	// Per ReactChildren-test.js:987.
+	it('does not warn for flattened static children without keys', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		const parent = createElement('div', null, createElement('i'), createElement('b'));
+		const flattened = Children.toArray(parent.props.children);
+		const result = mount(RenderValue as any, { value: flattened });
+		expect(warn.mock.calls.some((call) => String(call[0]).includes('unique "key"'))).toBe(false);
+		result.unmount();
+		warn.mockRestore();
+	});
+
+	// Per ReactChildren-test.js:1197.
+	it('does not warn when there are keys on elements in a fragment', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		const result = mount(RenderValue as any, {
+			value: [createElement('div', { key: 'foo' }), createElement('div', { key: 'bar' })],
+		});
+		expect(warn.mock.calls.some((call) => String(call[0]).includes('unique "key"'))).toBe(false);
+		result.unmount();
+		warn.mockRestore();
+	});
+
+	// Per ReactChildren-test.js:866. Octane intentionally emits framework-native
+	// wording rather than React owner stacks.
+	it('warns for mapped list children without keys', () => {
+		const warnings = missingKeyWarnings(() => {
+			const mapped = Children.map([createElement('i')], () => createElement('b'));
+			const result = mount(RenderValue as any, { value: createElement('main', null, mapped) });
+			result.unmount();
+		});
+		expect(warnings).toHaveLength(1);
+	});
+
+	// Per ReactChildren-test.js:918.
+	it('warns for cloned list children without keys', () => {
+		const warnings = missingKeyWarnings(() => {
+			const cloned = Children.map([createElement('i')], (child) => cloneElement(child));
+			const result = mount(RenderValue as any, { value: cloned });
+			result.unmount();
+		});
+		expect(warnings).toHaveLength(1);
+	});
+
+	// Per ReactChildren-test.js:965.
+	it('warns for flattened list children without keys', () => {
+		const warnings = missingKeyWarnings(() => {
+			const flattened = Children.toArray([createElement('i')]);
+			const result = mount(RenderValue as any, { value: flattened });
+			result.unmount();
+		});
+		expect(warnings).toHaveLength(1);
+	});
+
+	// Per ReactChildren-test.js:1176. React's source component is a class only
+	// because that is how the test observes its returned array; the portable
+	// contract is covered with an Octane function component.
+	it('warns for keys for arrays of elements in a fragment', () => {
+		function ComponentReturningArray(): any {
+			return [createElement('i'), createElement('b')];
+		}
+		const warnings = missingKeyWarnings(() => {
+			const result = mount(ComponentReturningArray);
+			result.unmount();
+		});
+		expect(warnings).toHaveLength(1);
+	});
+
+	// Per ReactChildren-test.js:1211.
+	it('warns for keys for arrays at the top level', () => {
+		const warnings = missingKeyWarnings(() => {
+			const container = document.createElement('div');
+			document.body.appendChild(container);
+			const root = createRoot(container);
+			try {
+				root.render([createElement('i'), createElement('b')] as any);
+				flushSync(() => {});
+			} finally {
+				root.unmount();
+				container.remove();
+			}
+		});
+		expect(warnings).toHaveLength(1);
+	});
+
+	// A mapped element with no source key should warn until the consumer gives
+	// it a real key. React.cloneElement treats that override as resolving the
+	// validation failure rather than carrying the old provenance forever.
+	it('does not warn after an explicit clone key fixes a mapped child', () => {
+		const warnings = missingKeyWarnings(() => {
+			const mapped = Children.toArray([createElement('i')])[0];
+			const fixed = cloneElement(mapped, { key: 'fixed' });
+			const result = mount(RenderValue as any, { value: [fixed] });
+			result.unmount();
+		});
+		expect(warnings).toEqual([]);
+	});
+
+	// Per ReactChildren-test.js:1004. Octane descriptors never depend on React's
+	// development-only `_store`, including after freezing and key rebasing.
+	it('does not throw on children without `_store`', () => {
+		const child = createElement('div');
+		expect('_store' in (child as any)).toBe(false);
+		expect(() => Children.toArray([child])).not.toThrow();
+	});
+
+	// Per ReactChildren-test.js:1029.
+	it('should escape keys', () => {
+		const mapped = Children.map(
+			[createElement('div', { key: '1' }), createElement('div', { key: '1=::=2' })],
+			(child) => child,
+		)! as any[];
+		expect(mapped.map((child) => child.key)).toEqual(['.$1', '.$1=0=2=2=02']);
+	});
+
+	// Per ReactChildren-test.js:1048.
+	it('should combine keys when map returns an array', () => {
+		const mapped = Children.map(
+			[createElement('div', { key: 'a' }), false, createElement('p')],
+			(child) => [
+				createElement('span', { key: 'x' }),
+				null,
+				child,
+				child && cloneElement(child, { key: 'z' }),
+				createElement('hr'),
+			],
+		)! as any[];
+		expect(mapped.map((child) => child.key)).toEqual([
+			'.$a/.$x',
+			'.$a/.$a',
+			'.$a/.$z',
+			'.$a/.4',
+			'.1/.$x',
+			'.1/.4',
+			'.2/.$x',
+			'.2/.2',
+			'.2/.$z',
+			'.2/.4',
+		]);
+	});
+
+	// Per ReactChildren-test.js:1116.
+	it('should throw on object', () => {
+		expect(() => Children.forEach({ a: 1, b: 2 }, () => {})).toThrow(/object with keys \{a, b\}/);
+	});
+
+	// Per ReactChildren-test.js:1129. React's lazy node is an object; Octane's
+	// lazy value is a callable component, so the equivalent public element is a
+	// descriptor for that wrapper. Both suspend before Children.map can clone it.
+	it('should render React.lazy after suspending', async () => {
+		const module = deferred<{ default: typeof LazyChild }>();
+		const Lazy = lazy(() => module.promise);
+		const result = mount(LazyChildrenHost, { component: Lazy });
+		expect(result.find('.children-pending').textContent).toBe('Loading...');
+		await act(() => module.resolve({ default: LazyChild }));
+		expect(result.find('.lazy-child').textContent).toBe('hi');
+		result.unmount();
+	});
+
+	// Per ReactChildren-test.js:1145.
+	it('should render cached Promises after suspending', async () => {
+		const value = deferred<any>();
+		const result = mount(PromiseChildrenHost, { value: value.promise });
+		expect(result.find('.children-pending').textContent).toBe('Loading...');
+		await act(() => value.resolve(createElement('div', { key: 'hi' }, 'before')));
+		expect(result.find('div').textContent).toBe('hi');
+		result.unmount();
+	});
+
+	// Per ReactChildren-test.js:1161.
+	it('should throw on regex', () => {
+		expect(() => Children.forEach(/abc/, () => {})).toThrow(/\/abc\//);
+	});
+});
+
+describe('ReactCreateElement public behavior', () => {
+	function Component(_props: any): null {
+		return null;
+	}
+
+	// Per ReactCreateElement-test.js:42 and :98.
+	it('returns a complete element according to spec', () => {
+		const element = createElement(Component);
+		expect(element.type).toBe(Component);
+		expect(element.key).toBe(null);
+		expect(element.ref).toBe(null);
+		expect(element.props).toEqual({});
+		expect(isValidElement(element)).toBe(true);
+		expect(Object.isFrozen(element)).toBe(true);
+		expect(Object.isFrozen(element.props)).toBe(true);
+	});
+
+	// Per ReactCreateElement-test.js:98.
+	it('allows a string to be passed as the type', () => {
+		const element = createElement('div');
+		expect(element).toMatchObject({ type: 'div', key: null, ref: null, props: {} });
+	});
+
+	// Per ReactCreateElement-test.js:110, :348 and :380.
+	it('returns an immutable element', () => {
+		const element = createElement('div', { className: 'before' });
+		expect(() => ((element as any).type = 'span')).toThrow();
+		expect(() => ((element.props as any).className = 'after')).toThrow();
+		expect(() => ((element.props as any).added = true)).toThrow();
+	});
+
+	// Per ReactCreateElement-test.js:119.
+	it('does not reuse the original config object', () => {
+		const config = { foo: 1 };
+		const element = createElement(Component, config);
+		config.foo = 2;
+		expect(element.props.foo).toBe(1);
+		expect(element.props).not.toBe(config);
+	});
+
+	// Per ReactCreateElement-test.js:127.
+	it('does not fail if config has no prototype', () => {
+		const config = Object.create(null, { foo: { value: 1, enumerable: true } });
+		expect(createElement(Component, config).props.foo).toBe(1);
+	});
+
+	// Per ReactCreateElement-test.js:133.
+	it('extracts key from the rest of the props', () => {
+		const element = createElement(Component, { key: '12', foo: '56' } as any);
+		expect(element.key).toBe('12');
+		expect(element.props).toEqual({ foo: '56' });
+	});
+
+	// Per ReactCreateElement-test.js:145.
+	it('does not extract ref from the rest of the props', () => {
+		const ref = { current: null };
+		const element = createElement(Component, { key: '12', ref, foo: '56' } as any);
+		expect(element.ref).toBe(ref);
+		expect(element.props).toEqual({ ref, foo: '56' });
+	});
+
+	// Per ReactCreateElement-test.js:169.
+	it('extracts null key', () => {
+		const element = createElement(Component, { key: null, foo: '12' } as any);
+		expect(element.key).toBe('null');
+		expect(element.props).toEqual({ foo: '12' });
+	});
+
+	// Per ReactCreateElement-test.js:183.
+	it('ignores undefined key and ref', () => {
+		const element = createElement(Component, { key: undefined, ref: undefined, foo: '56' } as any);
+		expect(element.key).toBe(null);
+		expect(element.ref).toBe(null);
+		expect(element.props.foo).toBe('56');
+	});
+
+	// Per ReactCreateElement-test.js:200.
+	it('ignores key and ref warning getters', () => {
+		const props: any = {};
+		const keyGetter: any = () => undefined;
+		keyGetter.isReactWarning = true;
+		const refGetter: any = () => undefined;
+		refGetter.isReactWarning = true;
+		Object.defineProperty(props, 'key', { enumerable: false, get: keyGetter });
+		Object.defineProperty(props, 'ref', { enumerable: false, get: refGetter });
+		const element = createElement('div', props);
+		expect(element.key).toBe(null);
+		expect(element.ref).toBe(null);
+	});
+
+	// Per ReactCreateElement-test.js:207.
+	it('coerces the key to a string', () => {
+		expect(createElement(Component, { key: 12 } as any).key).toBe('12');
+	});
+
+	// Per ReactCreateElement-test.js:244.
+	it('merges an additional argument onto the children prop', () => {
+		expect(createElement(Component, { children: 'text' } as any, 1).props.children).toBe(1);
+	});
+
+	// Per ReactCreateElement-test.js:256.
+	it('does not override children if no rest args are provided', () => {
+		expect(createElement(Component, { children: 'text' } as any).props.children).toBe('text');
+	});
+
+	// Per ReactCreateElement-test.js:263.
+	it('overrides children if null is provided as an argument', () => {
+		expect(createElement(Component, { children: 'text' } as any, null).props.children).toBe(null);
+	});
+
+	// Per ReactCreateElement-test.js:274.
+	it('merges rest arguments onto the children prop in an array', () => {
+		const children = createElement(Component, null as any, 1, 2, 3).props.children as any[];
+		expect(children).toEqual([1, 2, 3]);
+		expect(Object.isFrozen(children)).toBe(true);
+	});
+
+	// Per ReactCreateElement-test.js:282.
+	it('allows static methods to be called using the type property', () => {
+		(Component as any).answer = () => 42;
+		expect((createElement(Component).type as any).answer()).toBe(42);
+	});
+
+	// Per ReactCreateElement-test.js:294.
+	it('is indistinguishable from a plain object', () => {
+		expect(createElement('div').constructor).toBe({}.constructor);
+	});
+
+	// Per ReactCreateElement-test.js:300 and :324. Octane has no class components;
+	// the same public defaultProps normalization is exercised with a function.
+	it('should normalize props with default values', () => {
+		(Component as any).defaultProps = { fruit: 'persimmon', nullable: 'default' };
+		try {
+			expect(createElement(Component).props).toMatchObject({
+				fruit: 'persimmon',
+				nullable: 'default',
+			});
+			expect(
+				createElement(Component, { fruit: 'mango', nullable: null } as any).props,
+			).toMatchObject({
+				fruit: 'mango',
+				nullable: null,
+			});
+			expect(createElement(Component, { fruit: undefined } as any).props.fruit).toBe('persimmon');
+		} finally {
+			delete (Component as any).defaultProps;
+		}
+	});
+
+	// Per ReactCreateElement-test.js:300. The class-instance update in React is
+	// class-specific; Octane preserves the public removal/defaulting contract on
+	// each function-component element creation.
+	it('should use default prop value when removing a prop', () => {
+		function Fruit(props: { fruit?: string }): any {
+			return createElement('span', { className: 'fruit' }, String(props.fruit));
+		}
+		function FruitHost(props: { childProps: { fruit?: string } }): any {
+			return createElement(Fruit, props.childProps);
+		}
+		(Fruit as any).defaultProps = { fruit: 'persimmon' };
+		try {
+			const result = mount(FruitHost, { childProps: { fruit: 'mango' } });
+			expect(result.find('.fruit').textContent).toBe('mango');
+			result.update(FruitHost, { childProps: {} });
+			expect(result.find('.fruit').textContent).toBe('persimmon');
+			result.unmount();
+		} finally {
+			delete (Fruit as any).defaultProps;
+		}
+	});
+
+	// Per ReactCreateElement-test.js:348.
+	it('throws when changing a prop (in dev) after element creation', () => {
+		const element = createElement('div', { className: 'moo' });
+		expect(() => ((element.props as any).className = 'quack')).toThrow();
+		expect(element.props.className).toBe('moo');
+	});
+
+	// Per ReactCreateElement-test.js:380.
+	it('throws when adding a prop (in dev) after element creation', () => {
+		const element = createElement('div');
+		expect(() => ((element.props as any).className = 'quack')).toThrow();
+		expect((element.props as any).className).toBe(undefined);
+	});
+
+	// Per ReactCreateElement-test.js:412.
+	it('does not warn for NaN props', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		expect(createElement(Component, { value: Number.NaN } as any).props.value).toBeNaN();
+		expect(warn).not.toHaveBeenCalled();
+		warn.mockRestore();
+	});
+});
+
+describe('ReactElementClone public behavior', () => {
+	function Composite(props: any): any {
+		return createElement('div', { className: props.className, ref: props.ref }, props.children);
+	}
+
+	// Per ReactElementClone-test.js:37.
+	it('should clone a DOM component with new props', () => {
+		const clone = cloneElement(createElement('div', { className: 'child' }), { className: 'xyz' });
+		const result = mount(RenderValue as any, { value: clone });
+		expect(result.find('div').className).toBe('xyz');
+		result.unmount();
+	});
+
+	// Per ReactElementClone-test.js:65.
+	it('should clone a composite component with new props', () => {
+		const clone = cloneElement(createElement(Composite, { className: 'child' }), {
+			className: 'xyz',
+		});
+		const result = mount(RenderValue as any, { value: clone });
+		expect(result.find('div').className).toBe('xyz');
+		result.unmount();
+	});
+
+	// Per ReactElementClone-test.js:95.
+	it('does not fail if config has no prototype', () => {
+		const config = Object.create(null, { foo: { value: 1, enumerable: true } });
+		expect(cloneElement(createElement('div'), config).props.foo).toBe(1);
+	});
+
+	// Per ReactElementClone-test.js:100.
+	it('should keep the original ref if it is not overridden', () => {
+		const ref = { current: null as Element | null };
+		const clone = cloneElement(createElement('div', { ref }), { className: 'xyz' });
+		const result = mount(RenderValue as any, { value: clone });
+		expect(ref.current).toBe(result.find('div'));
+		result.unmount();
+	});
+
+	// Per ReactElementClone-test.js:130.
+	it('should transfer the key property', () => {
+		expect(cloneElement(createElement(Composite), { key: 'xyz' }).key).toBe('xyz');
+	});
+
+	// Per ReactElementClone-test.js:140 and :154.
+	it('should transfer children', () => {
+		const child = createElement('span', null, 'xyz');
+		const original = createElement(Composite, null as any, child);
+		const clone = cloneElement(original, {});
+		expect(clone.props.children).toBe(child);
+		expect(cloneElement(original, { children: 'next' }).props.children).toBe('next');
+	});
+
+	// Per ReactElementClone-test.js:154.
+	it('should shallow clone children', () => {
+		const child = createElement('span', null, 'xyz');
+		const clone = cloneElement(createElement(Composite, null as any, child), {});
+		expect(clone.props.children).toBe(child);
+	});
+
+	// Per ReactElementClone-test.js:168.
+	it('should accept children as rest arguments', () => {
+		const clone = cloneElement(
+			createElement(Composite, null as any, 'old'),
+			{ children: 'config' },
+			createElement('div'),
+			createElement('span'),
+		);
+		expect(clone.props.children).toHaveLength(2);
+		expect(clone.props.children.map((child: any) => child.type)).toEqual(['div', 'span']);
+		expect(Object.isFrozen(clone.props.children)).toBe(false);
+		clone.props.children.push(createElement('i'));
+		expect(clone.props.children.map((child: any) => child.type)).toEqual(['div', 'span', 'i']);
+	});
+
+	// Per ReactElementClone-test.js:185.
+	it('should override children if undefined is provided as an argument', () => {
+		const original = createElement(Composite, { children: 'text' } as any);
+		expect(cloneElement(original, {}, undefined).props.children).toBe(undefined);
+	});
+
+	// Per ReactElementClone-test.js:205.
+	it('should support keys and refs', () => {
+		const ref = { current: null as Element | null };
+		const clone = cloneElement(createElement('span', { key: 'abc' }), { key: 'xyz', ref });
+		const result = mount(RenderValue as any, { value: clone });
+		expect(clone.key).toBe('xyz');
+		expect(clone.props.ref).toBe(ref);
+		expect(ref.current).toBe(result.find('span'));
+		result.unmount();
+	});
+
+	// Per ReactElementClone-test.js:242.
+	it('should steal the ref if a new ref is specified', () => {
+		const oldRef = { current: null as Element | null };
+		const nextRef = { current: null as Element | null };
+		const clone = cloneElement(createElement('span', { ref: oldRef }), { ref: nextRef });
+		const result = mount(RenderValue as any, { value: clone });
+		expect(oldRef.current).toBe(null);
+		expect(nextRef.current).toBe(result.find('span'));
+		result.unmount();
+	});
+
+	// Per ReactElementClone-test.js:278.
+	it('should overwrite props', () => {
+		expect(
+			cloneElement(createElement(Composite, { myprop: 'abc' }), { myprop: 'xyz' }).props.myprop,
+		).toBe('xyz');
+	});
+
+	// Per ReactElementClone-test.js:306.
+	it('does not warns for arrays of elements with keys', () => {
+		const warnings = missingKeyWarnings(() => {
+			const clone = cloneElement(createElement('div'), null, [
+				createElement('div', { key: '#1' }),
+				createElement('div', { key: '#2' }),
+			]);
+			const result = mount(RenderValue as any, { value: clone });
+			result.unmount();
+		});
+		expect(warnings).toEqual([]);
+	});
+
+	// Per ReactElementClone-test.js:315.
+	it('does not warn when the element is directly in rest args', () => {
+		const warnings = missingKeyWarnings(() => {
+			const clone = cloneElement(
+				createElement('div'),
+				null,
+				createElement('i'),
+				createElement('b'),
+			);
+			const result = mount(RenderValue as any, { value: clone });
+			result.unmount();
+		});
+		expect(warnings).toEqual([]);
+	});
+
+	// Per ReactElementClone-test.js:322.
+	it('does not warn when the array contains a non-element', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		cloneElement(createElement('div'), null, [{}, {}]);
+		expect(warn).not.toHaveBeenCalled();
+		warn.mockRestore();
+	});
+
+	// Per ReactElementClone-test.js:294.
+	it('warns for keys for arrays of elements in rest args', () => {
+		const warnings = missingKeyWarnings(() => {
+			const clone = cloneElement(createElement('div'), null, [
+				createElement('i'),
+				createElement('b'),
+			]);
+			const result = mount(RenderValue as any, { value: clone });
+			result.unmount();
+		});
+		expect(warnings).toHaveLength(1);
+	});
+
+	// Per ReactElementClone-test.js:326.
+	it('should ignore key and ref warning getters', () => {
+		const base = createElement('div');
+		const clone = cloneElement(base, base.props);
+		expect(clone.key).toBe(null);
+		expect(clone.ref).toBe(null);
+	});
+
+	// Per ReactElementClone-test.js:333.
+	it('should ignore undefined key and ref', () => {
+		const ref = { current: null };
+		const base = createElement(Composite, { key: '12', ref, foo: '56' } as any);
+		const clone = cloneElement(base, { key: undefined, ref: undefined, foo: 'ef' });
+		expect(clone.key).toBe('12');
+		expect(clone.ref).toBe(ref);
+		expect(clone.props).toMatchObject({ foo: 'ef', ref });
+	});
+
+	// Per ReactElementClone-test.js:366.
+	it('should extract null key and ref', () => {
+		const base = createElement(Composite, { key: '12', ref: '34', foo: '56' } as any);
+		const clone = cloneElement(base, { key: null, ref: null, foo: 'ef' });
+		expect(clone.key).toBe('null');
+		expect(clone.ref).toBe(null);
+		expect(clone.props).toMatchObject({ foo: 'ef', ref: null });
+	});
+
+	// Per ReactElementClone-test.js:388 and :395.
+	it('throws an error if passed null', () => {
+		expect(() => cloneElement(null as any)).toThrow(/must be an element/);
+		expect(() => cloneElement(undefined as any)).toThrow(/must be an element/);
+	});
+
+	// Per ReactElementClone-test.js:395.
+	it('throws an error if passed undefined', () => {
+		expect(() => cloneElement(undefined as any)).toThrow(/must be an element/);
+	});
+});
+
+describe('ReactElementValidator portable outcomes', () => {
+	// Per ReactElementValidator-test.internal.js:39. The React source uses a
+	// class only as a child passthrough; an Octane function covers the public
+	// createElement/rest-children behavior without adding class semantics.
+	it('warns for keys for arrays of elements in rest args', () => {
+		function Passthrough(props: { children?: any }): any {
+			return props.children;
+		}
+		const warnings = missingKeyWarnings(() => {
+			const value = createElement(Passthrough, null as any, [
+				createElement('i'),
+				createElement('b'),
+			]);
+			const result = mount(RenderValue as any, { value });
+			result.unmount();
+		});
+		expect(warnings).toHaveLength(1);
+	});
+
+	// Per ReactElementValidator-test.internal.js:166.
+	it('warns for keys for iterables of elements in rest args', () => {
+		const warnings = missingKeyWarnings(() => {
+			const result = mount(RenderValue as any, {
+				value: valuesIterable([createElement('i'), createElement('b')]),
+			});
+			result.unmount();
+		});
+		expect(warnings).toHaveLength(1);
+	});
+
+	// Per ReactElementValidator-test.internal.js:145.
+	it('does not warn for keys when passing children down', () => {
+		const warnings = missingKeyWarnings(() => {
+			const value = createElement('div', null, createElement('span'), createElement('span'));
+			const result = mount(RenderValue as any, { value });
+			result.unmount();
+		});
+		expect(warnings).toEqual([]);
+	});
+
+	// Per ReactElementValidator-test.internal.js:194.
+	it('does not warns for arrays of elements with keys', () => {
+		const warnings = missingKeyWarnings(() => {
+			const value = createElement('div', null, [
+				createElement('i', { key: '1' }),
+				createElement('i', { key: '2' }),
+			]);
+			const result = mount(RenderValue as any, { value });
+			result.unmount();
+		});
+		expect(warnings).toEqual([]);
+	});
+
+	// Per ReactElementValidator-test.internal.js:201.
+	it('does not warns for iterable elements with keys', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		createElement(
+			'div',
+			null,
+			valuesIterable([createElement('i', { key: '1' }), createElement('i', { key: '2' })]),
+		);
+		expect(warn).not.toHaveBeenCalled();
+		warn.mockRestore();
+	});
+
+	// Per ReactElementValidator-test.internal.js:222.
+	it('does not warn when the element is directly in rest args', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		createElement('div', null, createElement('i'), createElement('b'));
+		expect(warn).not.toHaveBeenCalled();
+		warn.mockRestore();
+	});
+
+	// Per ReactElementValidator-test.internal.js:231.
+	it('does not warn when the array contains a non-element', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		createElement('div', null, [{}, {}]);
+		expect(warn).not.toHaveBeenCalled();
+		warn.mockRestore();
+	});
+
+	// Per ReactElementValidator-test.internal.js:500. Octane lazy values are
+	// callable component wrappers; creating their descriptor must stay lazy.
+	it('does not call lazy initializers eagerly', async () => {
+		const { lazy } = await import('octane');
+		let called = false;
+		const Lazy = lazy(() => {
+			called = true;
+			return new Promise(() => {});
+		});
+		createElement(Lazy);
+		expect(called).toBe(false);
+	});
+
+	// Per ReactElementValidator-test.internal.js:510. Octane's compiler uses
+	// createElement as its modern value-position target, so these remain props.
+	it('__self and __source are treated as normal props', () => {
+		const element = createElement('div', { __self: 'Hello ', __source: 'world!' } as any);
+		expect(element.props.__self + element.props.__source).toBe('Hello world!');
+	});
+});

--- a/packages/octane/tests/conformance/fragment-reconciliation.test.ts
+++ b/packages/octane/tests/conformance/fragment-reconciliation.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it, vi } from 'vitest';
+import { act } from 'octane';
+import { mount } from '../_helpers';
+import * as Fixture from './_fixtures/fragment-reconciliation.tsrx';
+
+type Scenario = (props: { condition: boolean; allocate: () => string }) => unknown;
+
+function exerciseStateTransition(component: Scenario, preserve: boolean) {
+	let nextInstance = 0;
+	const allocate = () => String(++nextInstance);
+	const r = mount(component as any, { condition: true, allocate });
+	const first = r.find('.stateful').getAttribute('data-instance');
+
+	r.update(component as any, { condition: false, allocate });
+	const second = r.find('.stateful').getAttribute('data-instance');
+
+	r.update(component as any, { condition: true, allocate });
+	const third = r.find('.stateful').getAttribute('data-instance');
+
+	if (preserve) {
+		expect([first, second, third]).toEqual(['1', '1', '1']);
+	} else {
+		expect([first, second, third]).toEqual(['1', '2', '3']);
+	}
+	r.unmount();
+}
+
+describe('React Fragment reconciliation conformance', () => {
+	// Per ReactFragment-test.js:29.
+	it('should render a single child via noop renderer', () => {
+		const r = mount(Fixture.RenderSingleFragment);
+		expect(r.find('span').textContent).toBe('foo');
+		expect(r.findAll('span')).toHaveLength(1);
+		r.unmount();
+	});
+
+	// Per ReactFragment-test.js:42.
+	it('should render zero children via noop renderer', () => {
+		const r = mount(Fixture.RenderEmptyFragment);
+		expect(r.container.textContent).toBe('');
+		expect(r.container.children).toHaveLength(0);
+		r.unmount();
+	});
+
+	// Per ReactFragment-test.js:51.
+	it('should render multiple children via noop renderer', () => {
+		const r = mount(Fixture.RenderMultipleFragmentChildren);
+		expect(r.container.textContent).toBe('hello world');
+		expect(r.find('span').textContent).toBe('world');
+		r.unmount();
+	});
+
+	// Per ReactFragment-test.js:68.
+	it('should render an iterable via noop renderer', () => {
+		const r = mount(Fixture.RenderIterableFragmentChildren);
+		expect(r.findAll('span').map((node) => node.textContent)).toEqual(['hi', 'bye']);
+		r.unmount();
+	});
+
+	// Per ReactFragment-test.js:84.
+	it('should preserve state of children with 1 level nesting', () => {
+		exerciseStateTransition(Fixture.OneLevelNesting, true);
+	});
+
+	// Per ReactFragment-test.js:129.
+	it('should preserve state between top-level fragments', () => {
+		exerciseStateTransition(Fixture.TopLevelFragments, true);
+	});
+
+	// Per ReactFragment-test.js:170.
+	it('should preserve state of children nested at same level', () => {
+		exerciseStateTransition(Fixture.NestedAtSameLevel, true);
+	});
+
+	// Per ReactFragment-test.js:225.
+	it('should not preserve state in non-top-level fragment nesting', () => {
+		exerciseStateTransition(Fixture.NonTopLevelNesting, false);
+	});
+
+	// Per ReactFragment-test.js:268.
+	it('should not preserve state of children if nested 2 levels without siblings', () => {
+		exerciseStateTransition(Fixture.TwoLevelsWithoutSiblings, false);
+	});
+
+	// Per ReactFragment-test.js:309.
+	it('should not preserve state of children if nested 2 levels with siblings', () => {
+		exerciseStateTransition(Fixture.TwoLevelsWithSiblings, false);
+	});
+
+	// Per ReactFragment-test.js:356.
+	it('should preserve state between array nested in fragment and fragment', () => {
+		exerciseStateTransition(Fixture.ArrayInFragmentToFragment, true);
+	});
+
+	// Per ReactFragment-test.js:395.
+	it('should preserve state between top level fragment and array', () => {
+		exerciseStateTransition(Fixture.TopLevelFragmentToArray, true);
+	});
+
+	// Per ReactFragment-test.js:434.
+	it('should not preserve state between array nested in fragment and double nested fragment', () => {
+		exerciseStateTransition(Fixture.ArrayInFragmentToDoubleFragment, false);
+	});
+
+	// Per ReactFragment-test.js:475.
+	it('should not preserve state between array nested in fragment and double nested array', () => {
+		exerciseStateTransition(Fixture.ArrayInFragmentToDoubleArray, false);
+	});
+
+	// Per ReactFragment-test.js:512.
+	it('should preserve state between double nested fragment and double nested array', () => {
+		exerciseStateTransition(Fixture.DoubleFragmentToDoubleArray, true);
+	});
+
+	// Per ReactFragment-test.js:553.
+	it('should not preserve state of children when the keys are different', () => {
+		exerciseStateTransition(Fixture.DifferentFragmentKeys, false);
+	});
+
+	// Per ReactFragment-test.js:600.
+	it('should not preserve state between unkeyed and keyed fragment', () => {
+		exerciseStateTransition(Fixture.KeyedToUnkeyedFragment, false);
+	});
+
+	// ReactFragment-test.js:553/:600 require implicit positions and explicit keys
+	// to remain distinct identities, even when their textual forms are both "0".
+	it('does not alias an implicit index with an explicit numeric-looking key', () => {
+		let nextInstance = 0;
+		const allocate = () => String(++nextInstance);
+		const r = mount(Fixture.NestedImplicitAndExplicitZeroKeys, {
+			condition: true,
+			allocate,
+		});
+		expect(r.findAll('.stateful').map((node) => node.getAttribute('data-instance'))).toEqual([
+			'1',
+			'2',
+		]);
+
+		r.update(Fixture.NestedImplicitAndExplicitZeroKeys, { condition: false, allocate });
+		expect(r.findAll('.stateful').map((node) => node.getAttribute('data-instance'))).toEqual(['2']);
+
+		r.update(Fixture.NestedImplicitAndExplicitZeroKeys, { condition: true, allocate });
+		expect(r.findAll('.stateful').map((node) => node.getAttribute('data-instance'))).toEqual([
+			'3',
+			'2',
+		]);
+		r.unmount();
+	});
+
+	// Per ReactFragment-test.js:641.
+	it('should preserve state with reordering in multiple levels', () => {
+		exerciseStateTransition(Fixture.ReorderAcrossLevels, true);
+	});
+
+	// Per ReactFragment-test.js:710.
+	it('should not preserve state when switching to a keyed fragment to an array', () => {
+		const warning = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		exerciseStateTransition(Fixture.KeyedFragmentToArray, false);
+		expect(warning).toHaveBeenCalledWith(expect.stringContaining('unique "key" prop'));
+	});
+
+	// Per ReactFragment-test.js:775.
+	it('should not preserve state when switching a nested unkeyed fragment to a passthrough component', () => {
+		exerciseStateTransition(Fixture.NestedUnkeyedFragmentToPassthrough, false);
+	});
+
+	// Per ReactFragment-test.js:824.
+	it('should not preserve state when switching a nested keyed fragment to a passthrough component', () => {
+		exerciseStateTransition(Fixture.NestedKeyedFragmentToPassthrough, false);
+	});
+
+	// Per ReactFragment-test.js:873.
+	it('should not preserve state when switching a nested keyed array to a passthrough component', () => {
+		exerciseStateTransition(Fixture.NestedKeyedArrayToPassthrough, false);
+	});
+
+	// Per ReactFragment-test.js:918.
+	it('should preserve state when it does not change positions', () => {
+		exerciseStateTransition(Fixture.SamePositions, true);
+	});
+
+	// Per ReactFragment-test.js:984.
+	// UPSTREAM NON-GOAL: React's internal renderer test resolves lazy() to an
+	// element, outside the documented lazy() contract. This adaptation uses a
+	// component module; adding that component is an identity boundary and remounts.
+	it('should preserve state of children when adding a fragment wrapped in Lazy', async () => {
+		let nextInstance = 0;
+		const allocate = () => String(++nextInstance);
+		const r = mount(Fixture.AddLazyFragmentBoundary as any, { condition: true, allocate });
+		expect(r.find('.stateful').getAttribute('data-instance')).toBe('1');
+		r.update(Fixture.AddLazyFragmentBoundary as any, { condition: false, allocate });
+		await act(() => Promise.resolve());
+		expect(r.find('.stateful').getAttribute('data-instance')).toBe('2');
+		r.unmount();
+	});
+});
+
+describe('React top-level Fragment reconciliation conformance', () => {
+	// Per ReactTopLevelFragment-test.js:29.
+	it('should render a simple fragment at the top of a component', () => {
+		const r = mount(Fixture.TopLevelSimpleFragment);
+		expect(r.findAll('div').map((node) => node.textContent)).toEqual(['Hello', 'World']);
+		r.unmount();
+	});
+
+	// Per ReactTopLevelFragment-test.js:37.
+	it('should preserve state when switching from a single child', () => {
+		exerciseStateTransition(Fixture.TopLevelSingleToArray, true);
+	});
+
+	// Per ReactTopLevelFragment-test.js:69.
+	it('should not preserve state when switching to a nested array', () => {
+		exerciseStateTransition(Fixture.TopLevelSingleToNestedArray, false);
+	});
+
+	// Per ReactTopLevelFragment-test.js:101.
+	it('preserves state if an implicit key slot switches from/to null', () => {
+		exerciseStateTransition(Fixture.TopLevelImplicitNullSlot, true);
+	});
+
+	// Per ReactTopLevelFragment-test.js:138.
+	it('should preserve state in a reorder', () => {
+		exerciseStateTransition(Fixture.TopLevelNestedReorder, true);
+	});
+});

--- a/packages/octane/tests/conformance/lazy-components.test.ts
+++ b/packages/octane/tests/conformance/lazy-components.test.ts
@@ -1,0 +1,559 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	Activity,
+	Fragment,
+	Suspense,
+	ViewTransition,
+	createContext,
+	createPortal,
+	lazy,
+	memo,
+} from 'octane';
+import * as ServerRuntime from 'octane/server';
+import { act, mount } from '../_helpers';
+import { loadServerFixture } from '../_server-fixture.js';
+import {
+	LazyAdd,
+	LazyDefaultText,
+	LazyHost,
+	LazyListHost,
+	LazyMemoProbe,
+	LazyPairHost,
+	LazyProviderHost,
+	LazyRefTarget,
+	LazyStatefulItem,
+	LazyText,
+} from './_fixtures/lazy-components.tsrx';
+
+const server = loadServerFixture(
+	'packages/octane/tests/conformance/_fixtures/lazy-components.tsrx',
+);
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (reason: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+}
+
+function fulfilled<T>(value: T): PromiseLike<T> {
+	return {
+		then(onFulfilled) {
+			return fulfilled(onFulfilled!(value));
+		},
+	};
+}
+
+function rejected(reason: unknown): PromiseLike<never> {
+	return {
+		then(_onFulfilled, onRejected) {
+			if (onRejected) onRejected(reason);
+			return rejected(reason);
+		},
+	};
+}
+
+function lazyModule<T>(component: T) {
+	return fulfilled({ default: component });
+}
+
+describe('ReactLazy public conformance', () => {
+	// Per ReactLazy-test.internal.js:90 (React canary b740af2).
+	it('suspends until module has loaded', async () => {
+		const module = deferred<{ default: typeof LazyText }>();
+		const load = vi.fn(() => module.promise);
+		const Lazy = lazy(load);
+		const root = mount(LazyHost, { comp: Lazy, childProps: { text: 'Hi' } });
+		expect(root.find('.lazy-fallback').textContent).toBe('Loading...');
+		expect(load).toHaveBeenCalledTimes(1);
+
+		await act(() => module.resolve({ default: LazyText }));
+		expect(root.find('.lazy-value').textContent).toBe('Hi');
+		root.update(LazyHost, { comp: Lazy, childProps: { text: 'Hi again' } });
+		expect(root.find('.lazy-value').textContent).toBe('Hi again');
+		expect(load).toHaveBeenCalledTimes(1);
+		root.unmount();
+	});
+
+	// Per ReactLazy-test.internal.js:119 (React canary b740af2).
+	it('renders a lazy context provider', async () => {
+		const context = createContext('default');
+		const module = deferred<{ default: typeof context.Provider }>();
+		const LazyProvider = lazy(() => module.promise);
+		const root = mount(LazyProviderHost, {
+			provider: LazyProvider,
+			context,
+			value: 'Hi',
+		});
+		expect(root.find('.lazy-fallback').textContent).toBe('Loading...');
+
+		await act(() => module.resolve({ default: context.Provider }));
+		expect(root.find('.lazy-context').textContent).toBe('Hi');
+		root.update(LazyProviderHost, {
+			provider: LazyProvider,
+			context,
+			value: 'Hi again',
+		});
+		expect(root.find('.lazy-context').textContent).toBe('Hi again');
+		root.unmount();
+	});
+
+	// Per ReactLazy-test.internal.js:157 (React canary b740af2).
+	it('can resolve synchronously without suspending', () => {
+		const Lazy = lazy(() => lazyModule(LazyText));
+		const root = mount(LazyHost, { comp: Lazy, childProps: { text: 'Hi' } });
+		expect(root.findAll('.lazy-fallback')).toHaveLength(0);
+		expect(root.find('.lazy-value').textContent).toBe('Hi');
+		root.unmount();
+	});
+
+	// Per ReactLazy-test.internal.js:178 (React canary b740af2).
+	it('can reject synchronously without suspending', () => {
+		const Lazy = lazy(() => rejected(new Error('oh no')));
+		const root = mount(LazyHost, { comp: Lazy });
+		expect(root.findAll('.lazy-fallback')).toHaveLength(0);
+		expect(root.find('.lazy-error').textContent).toBe('Error: oh no');
+		root.unmount();
+	});
+
+	// Per ReactLazy.js:70-180 (React canary b740af2): loader setup does not
+	// transition the payload until loader and subscription setup complete.
+	it('retries a loader that throws before returning a thenable', () => {
+		let attempts = 0;
+		const Lazy = lazy(() => {
+			attempts++;
+			if (attempts === 1) throw new Error('load exploded');
+			return lazyModule(LazyText);
+		});
+		const first = mount(LazyHost, { comp: Lazy, childProps: { text: 'first' } });
+		expect(first.find('.lazy-error').textContent).toBe('Error: load exploded');
+		first.unmount();
+
+		const recovered = mount(LazyHost, { comp: Lazy, childProps: { text: 'recovered' } });
+		expect(recovered.find('.lazy-value').textContent).toBe('recovered');
+		expect(attempts).toBe(2);
+		recovered.unmount();
+	});
+
+	// Per ReactLazy.js:70-180 (React canary b740af2).
+	it('retries when thenable subscription throws synchronously', () => {
+		let attempts = 0;
+		const Lazy = lazy(() => {
+			attempts++;
+			if (attempts === 1) {
+				return {
+					then() {
+						throw new Error('subscription exploded');
+					},
+				} as any;
+			}
+			return lazyModule(LazyText);
+		});
+		const first = mount(LazyHost, { comp: Lazy, childProps: { text: 'first' } });
+		expect(first.find('.lazy-error').textContent).toBe('Error: subscription exploded');
+		first.unmount();
+
+		const recovered = mount(LazyHost, { comp: Lazy, childProps: { text: 'recovered' } });
+		expect(recovered.find('.lazy-value').textContent).toBe('recovered');
+		expect(attempts).toBe(2);
+		recovered.unmount();
+	});
+
+	// Per ReactLazy.js:183-223 (React canary b740af2): the fulfilled module is
+	// cached, while its default export is resolved during each render.
+	it('retries a fulfilled module default getter without reloading', () => {
+		let reads = 0;
+		const load = vi.fn(() =>
+			fulfilled({
+				get default() {
+					reads++;
+					if (reads === 1) throw new Error('default exploded');
+					return LazyText;
+				},
+			}),
+		);
+		const Lazy = lazy(load);
+		const first = mount(LazyHost, { comp: Lazy, childProps: { text: 'first' } });
+		expect(first.find('.lazy-error').textContent).toBe('Error: default exploded');
+		first.unmount();
+
+		const recovered = mount(LazyHost, { comp: Lazy, childProps: { text: 'recovered' } });
+		expect(recovered.find('.lazy-value').textContent).toBe('recovered');
+		expect(load).toHaveBeenCalledTimes(1);
+		expect(reads).toBe(2);
+		recovered.unmount();
+	});
+
+	// Per ReactLazy-test.internal.js:212 (React canary b740af2).
+	it('multiple lazy components', async () => {
+		const first = deferred<{ default: typeof LazyText }>();
+		const second = deferred<{ default: typeof LazyText }>();
+		const LazyFirst = lazy(() => first.promise);
+		const LazySecond = lazy(() => second.promise);
+		const root = mount(LazyPairHost, { first: LazyFirst, second: LazySecond });
+		expect(root.find('.lazy-fallback').textContent).toBe('Loading...');
+
+		await act(() => first.resolve({ default: LazyText }));
+		expect(root.find('.lazy-fallback').textContent).toBe('Loading...');
+		await act(() => second.resolve({ default: LazyText }));
+		expect(root.find('.lazy-pair').textContent).toBe('AB');
+		root.unmount();
+	});
+
+	// Per ReactLazy-test.internal.js:247 (React canary b740af2).
+	it('does not support arbitrary promises, only module objects', async () => {
+		// OCTANE DIVERGENCE: Octane deliberately accepts a bare component from
+		// load(), which keeps named dynamic imports ergonomic without a default shim.
+		const Lazy = lazy(() => Promise.resolve(LazyText));
+		const root = mount(LazyHost, { comp: Lazy, childProps: { text: 'bare' } });
+		await act(async () => {});
+		expect(root.find('.lazy-value').textContent).toBe('bare');
+		root.unmount();
+	});
+
+	// Per ReactLazy-test.internal.js:294 (React canary b740af2).
+	it('throws if promise rejects', async () => {
+		const module = deferred<{ default: typeof LazyText }>();
+		const error = new Error('Bad network');
+		const Lazy = lazy(() => module.promise);
+		const root = mount(LazyHost, { comp: Lazy });
+		await act(() => module.reject(error));
+		expect(root.find('.lazy-error').textContent).toBe('Error: Bad network');
+		root.unmount();
+	});
+
+	// Per ReactLazy-test.internal.js:322 (React canary b740af2).
+	it('mount and reorder', async () => {
+		const a = deferred<{ default: typeof LazyStatefulItem }>();
+		const b = deferred<{ default: typeof LazyStatefulItem }>();
+		const LazyA = lazy(() => a.promise);
+		const LazyB = lazy(() => b.promise);
+		const log: string[] = [];
+		const props = {
+			items: [
+				{ key: 'A', label: 'A', comp: LazyA },
+				{ key: 'B', label: 'B', comp: LazyB },
+			],
+			log: (entry: string) => log.push(entry),
+		};
+		const root = mount(LazyListHost, props);
+		await act(() => a.resolve({ default: LazyStatefulItem }));
+		await act(() => b.resolve({ default: LazyStatefulItem }));
+		root.click('[data-id="A"]');
+		const aNode = root.find('[data-id="A"]');
+		expect(aNode.textContent).toBe('A:1');
+
+		root.update(LazyListHost, { ...props, items: [...props.items].reverse() });
+		expect(root.find('.lazy-list').textContent).toBe('B:0A:1');
+		expect(root.find('[data-id="A"]')).toBe(aNode);
+		expect(log).toEqual(['mount:A', 'mount:B']);
+		root.unmount();
+	});
+
+	// Per ReactLazy-test.internal.js:394 (React canary b740af2).
+	// Octane-native function-component coverage; this is not evidence for the
+	// upstream class lifecycle cases.
+	it('applies live defaultProps from a resolved function component', () => {
+		const original = LazyDefaultText.defaultProps;
+		const Lazy = lazy(() => lazyModule(LazyDefaultText));
+		const root = mount(LazyHost, { comp: Lazy, childProps: {} });
+		try {
+			expect(root.find('.lazy-default').textContent).toBe('default');
+
+			LazyDefaultText.defaultProps = { text: 'updated default' };
+			root.update(LazyHost, { comp: Lazy, childProps: {} });
+			expect(root.find('.lazy-default').textContent).toBe('updated default');
+		} finally {
+			LazyDefaultText.defaultProps = original;
+			root.unmount();
+		}
+	});
+
+	// Octane-native memo analogue of ReactLazy-test.internal.js:1229 (React
+	// canary b740af2); it does not claim PureComponent/class support.
+	it('preserves the comparator when lazy resolves to an Octane memo component', () => {
+		const renders: string[] = [];
+		const onRender = (value: string) => renders.push(value);
+		const compare = vi.fn((previous: any, incoming: any) => previous.value === incoming.value);
+		const Lazy = lazy(() => lazyModule(memo(LazyMemoProbe, compare)));
+		const root = mount(LazyHost, {
+			comp: Lazy,
+			childProps: { value: 'A', onRender },
+		});
+		expect(renders).toEqual(['A']);
+
+		root.update(LazyHost, {
+			comp: Lazy,
+			childProps: { value: 'A', onRender },
+		});
+		expect(compare).toHaveBeenCalledTimes(1);
+		expect(renders).toEqual(['A']);
+
+		root.update(LazyHost, {
+			comp: Lazy,
+			childProps: { value: 'B', onRender },
+		});
+		expect(compare).toHaveBeenCalledTimes(2);
+		expect(renders).toEqual(['A', 'B']);
+		expect(root.find('.lazy-memo-probe').textContent).toBe('B');
+		root.unmount();
+	});
+
+	const invalidCases: Array<[string, unknown]> = [
+		// Per ReactLazy-test.internal.js:739 (React canary b740af2).
+		['throws with a useful error when wrapping invalid type with lazy()', 42],
+		// Per ReactLazy-test.internal.js:765 (React canary b740af2).
+		['throws with a useful error when wrapping Fragment with lazy()', Fragment],
+		// Per ReactLazy-test.internal.js:792 (React canary b740af2).
+		[
+			'throws with a useful error when wrapping createPortal with lazy()',
+			createPortal(null, document.createElement('div')),
+		],
+		// Per ReactLazy-test.internal.js:926 (React canary b740af2).
+		['throws with a useful error when wrapping Context.Consumer with lazy()', undefined],
+		// Per ReactLazy-test.internal.js:1007 (React canary b740af2).
+		['throws with a useful error when wrapping Activity with lazy()', Activity],
+	];
+
+	for (const [title, value] of invalidCases) {
+		it(title, () => {
+			const Lazy = lazy(() => fulfilled({ default: value as any }));
+			const root = mount(LazyHost, { comp: Lazy });
+			expect(root.find('.lazy-error').textContent).toContain('lazy: expected');
+			root.unmount();
+		});
+	}
+
+	// Per ReactLazy-test.internal.js:861 (React stable 6117d7c).
+	it('throws with a useful error when wrapping Context with lazy()', () => {
+		const context = createContext(null);
+		const Lazy = lazy(() => fulfilled({ default: context as any }));
+		const root = mount(LazyHost, { comp: Lazy });
+		expect(root.find('.lazy-error').textContent).toContain('lazy: expected');
+		root.unmount();
+	});
+
+	// Per ReactLazy-test.internal.js:899 (React canary b740af2).
+	it('renders a lazy context provider without value prop', () => {
+		const context = createContext('default');
+		const LazyProvider = lazy(() => lazyModule(context.Provider));
+		const root = mount(LazyProviderHost, {
+			provider: LazyProvider,
+			context,
+			value: 'provided',
+		});
+		expect(root.find('.lazy-context').textContent).toBe('provided');
+		root.unmount();
+	});
+
+	// Per ReactLazy-test.internal.js:1060 (React canary b740af2).
+	it('throws with a useful error when wrapping lazy() multiple times', () => {
+		const Inner = lazy(() => lazyModule(LazyText));
+		const Outer = lazy(() => lazyModule(Inner));
+		const root = mount(LazyHost, { comp: Outer, childProps: { text: 'nested' } });
+		expect(root.find('.lazy-error').textContent).toContain('lazy: expected');
+		root.unmount();
+	});
+
+	// Per ReactLazy-test.internal.js:1091 (React canary b740af2).
+	it('resolves props for function component without defaultProps', () => {
+		const Lazy = lazy(() => lazyModule(LazyAdd));
+		const root = mount(LazyHost, {
+			comp: Lazy,
+			childProps: { inner: '2', outer: '2' },
+		});
+		expect(root.container.textContent).toBe('22');
+		root.update(LazyHost, { comp: Lazy, childProps: { inner: false, outer: false } });
+		expect(root.container.textContent).toBe('0');
+		root.unmount();
+	});
+
+	// OCTANE DIVERGENCE: Octane has no forwardRef API. This protects the documented
+	// React 19 ref-as-prop function-component contract and is not evidence for the
+	// upstream forwardRef row at ReactLazy-test.internal.js:1195.
+	it('forwards ref-as-prop through a resolved function component', () => {
+		const ref = { current: null as Element | null };
+		const Lazy = lazy(() => lazyModule(LazyRefTarget));
+		const root = mount(LazyHost, {
+			comp: Lazy,
+			childProps: { label: 'ref target', ref },
+		});
+		expect(ref.current).toBe(root.find('.lazy-ref'));
+		root.unmount();
+		expect(ref.current).toBeNull();
+	});
+
+	// Per ReactLazy-test.internal.js:1229 (React canary b740af2).
+	it('resolves props for outer memo component without defaultProps', () => {
+		const Lazy = lazy(() => lazyModule(memo(LazyAdd)));
+		const root = mount(LazyHost, {
+			comp: Lazy,
+			childProps: { inner: 'outer', outer: ' memo' },
+		});
+		expect(root.container.textContent).toBe('outer memo');
+		root.unmount();
+	});
+
+	// Per ReactLazy-test.internal.js:1262 (React canary b740af2).
+	it('resolves props for inner memo component without defaultProps', () => {
+		const LazyMemo = memo(lazy(() => lazyModule(LazyAdd)));
+		const root = mount(LazyHost, {
+			comp: LazyMemo,
+			childProps: { inner: 'inner', outer: ' memo' },
+		});
+		expect(root.container.textContent).toBe('inner memo');
+		root.unmount();
+	});
+
+	// Per ReactLazy-test.internal.js:1454 (React canary b740af2).
+	it('mount and reorder lazy types', () => {
+		const LazyA = lazy(() => lazyModule(LazyStatefulItem));
+		const LazyB = lazy(() => lazyModule(LazyStatefulItem));
+		const LazyA2 = lazy(() => lazyModule(LazyStatefulItem));
+		const LazyB2 = lazy(() => lazyModule(LazyStatefulItem));
+		const log: string[] = [];
+		const root = mount(LazyListHost, {
+			items: [
+				{ key: 'A', label: 'A', comp: LazyA },
+				{ key: 'B', label: 'B', comp: LazyB },
+			],
+			log: (entry: string) => log.push(entry),
+		});
+		expect(root.find('.lazy-list').textContent).toBe('A:0B:0');
+
+		root.update(LazyListHost, {
+			items: [
+				{ key: 'B', label: 'b', comp: LazyB2 },
+				{ key: 'A', label: 'a', comp: LazyA2 },
+			],
+			log: (entry: string) => log.push(entry),
+		});
+		expect(root.find('.lazy-list').textContent).toBe('b:0a:0');
+		expect(log.slice(0, 2)).toEqual(['mount:A', 'mount:B']);
+		expect(log.slice(2).sort()).toEqual(['unmount:A', 'unmount:B', 'mount:a', 'mount:b'].sort());
+		root.unmount();
+	});
+
+	// React rejects framework sentinels here because its built-ins are exotic
+	// element types. Octane's component-form boundaries are ordinary functions,
+	// so wrapping them preserves their public behavior.
+	// OCTANE DIVERGENCE: Per ReactLazy-test.internal.js:873/:981.
+	it('allows lazy wrappers around component-form framework boundaries', () => {
+		for (const boundary of [Suspense, ViewTransition]) {
+			expect(typeof boundary).toBe('function');
+			expect(typeof lazy(() => lazyModule(boundary))).toBe('function');
+		}
+	});
+});
+
+describe('lazy server regression coverage', () => {
+	it('renders a synchronously fulfilled lazy module without a fallback pass', () => {
+		const Lazy = ServerRuntime.lazy(() => lazyModule(server.LazyText));
+		const { html } = ServerRuntime.renderToString(server.LazyHost, {
+			comp: Lazy,
+			childProps: { text: 'server' },
+		});
+		expect(html).toContain('<span class="lazy-value">server</span>');
+		expect(html).not.toContain('Loading...');
+	});
+
+	it('applies a resolved server component defaultProps on every render', () => {
+		const Lazy = ServerRuntime.lazy(() => lazyModule(server.LazyDefaultText));
+		const { html } = ServerRuntime.renderToString(server.LazyHost, {
+			comp: Lazy,
+			childProps: {},
+		});
+		expect(html).toContain('<span class="lazy-default">default</span>');
+	});
+
+	it('rejects a nested server lazy wrapper', () => {
+		const Inner = ServerRuntime.lazy(() => lazyModule(server.LazyText));
+		const Outer = ServerRuntime.lazy(() => lazyModule(Inner));
+		const { html } = ServerRuntime.renderToString(server.LazyHost, {
+			comp: Outer,
+			childProps: { text: 'nested' },
+		});
+		expect(html).toContain('Error: lazy: expected');
+	});
+
+	// Server mirror of ReactLazy.js:70-180's transactional loader setup.
+	it('retries a server loader that throws synchronously', () => {
+		let attempts = 0;
+		const Lazy = ServerRuntime.lazy(() => {
+			attempts++;
+			if (attempts === 1) throw new Error('server load exploded');
+			return lazyModule(server.LazyText);
+		});
+		const first = ServerRuntime.renderToString(server.LazyHost, {
+			comp: Lazy,
+			childProps: { text: 'first' },
+		});
+		expect(first.html).toContain('Error: server load exploded');
+
+		const second = ServerRuntime.renderToString(server.LazyHost, {
+			comp: Lazy,
+			childProps: { text: 'recovered' },
+		});
+		expect(second.html).toContain('<span class="lazy-value">recovered</span>');
+		expect(attempts).toBe(2);
+	});
+
+	// Server mirror of ReactLazy.js:70-180's transactional subscription setup.
+	it('retries a server thenable whose subscription throws synchronously', () => {
+		let attempts = 0;
+		const Lazy = ServerRuntime.lazy(() => {
+			attempts++;
+			if (attempts === 1) {
+				return {
+					then() {
+						throw new Error('server subscription exploded');
+					},
+				} as any;
+			}
+			return lazyModule(server.LazyText);
+		});
+		const first = ServerRuntime.renderToString(server.LazyHost, {
+			comp: Lazy,
+			childProps: { text: 'first' },
+		});
+		expect(first.html).toContain('Error: server subscription exploded');
+
+		const second = ServerRuntime.renderToString(server.LazyHost, {
+			comp: Lazy,
+			childProps: { text: 'recovered' },
+		});
+		expect(second.html).toContain('<span class="lazy-value">recovered</span>');
+		expect(attempts).toBe(2);
+	});
+
+	// Server mirror of ReactLazy.js:183-223's render-time default resolution.
+	it('retries a server module default getter without reloading', () => {
+		let reads = 0;
+		const load = vi.fn(() =>
+			fulfilled({
+				get default() {
+					reads++;
+					if (reads === 1) throw new Error('server default exploded');
+					return server.LazyText;
+				},
+			}),
+		);
+		const Lazy = ServerRuntime.lazy(load);
+		const first = ServerRuntime.renderToString(server.LazyHost, {
+			comp: Lazy,
+			childProps: { text: 'first' },
+		});
+		expect(first.html).toContain('Error: server default exploded');
+
+		const second = ServerRuntime.renderToString(server.LazyHost, {
+			comp: Lazy,
+			childProps: { text: 'recovered' },
+		});
+		expect(second.html).toContain('<span class="lazy-value">recovered</span>');
+		expect(load).toHaveBeenCalledTimes(1);
+		expect(reads).toBe(2);
+	});
+});

--- a/packages/octane/tests/conformance/root-semantics.test.ts
+++ b/packages/octane/tests/conformance/root-semantics.test.ts
@@ -1,0 +1,411 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	createElement,
+	createRoot,
+	flushSync,
+	hydrateRoot,
+	type ComponentBody,
+	type Root,
+} from '../../src/index.js';
+import * as ServerRuntime from 'octane/server';
+import { flushEffects } from '../_helpers.js';
+import { loadServerFixture } from '../_server-fixture.js';
+import * as client from './_fixtures/root-semantics.tsrx';
+
+const FIXTURE = 'packages/octane/tests/conformance/_fixtures/root-semantics.tsrx';
+const server = loadServerFixture(FIXTURE);
+
+let container: HTMLDivElement;
+let roots: Root[];
+let containers: HTMLElement[];
+
+beforeEach(() => {
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	roots = [];
+	containers = [container];
+});
+
+afterEach(() => {
+	for (let i = roots.length - 1; i >= 0; i--) roots[i].unmount();
+	for (const owned of containers) owned.remove();
+});
+
+function trackRoot(root: Root): Root {
+	roots.push(root);
+	return root;
+}
+
+function makeContainer(): HTMLDivElement {
+	const owned = document.createElement('div');
+	document.body.appendChild(owned);
+	containers.push(owned);
+	return owned;
+}
+
+function render(root: Root, body: ComponentBody, props?: any): void {
+	flushSync(() => root.render(body, props));
+}
+
+function captureConsoleErrors<T>(run: () => T): { result: T; messages: string[] } {
+	const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+	try {
+		const result = run();
+		return {
+			result,
+			messages: error.mock.calls.map((call) => call.map(String).join(' ')),
+		};
+	} finally {
+		error.mockRestore();
+	}
+}
+
+describe('ReactDOMRoot public conformance', () => {
+	// Per ReactDOMRoot-test.js:44 (stable), :44 (canary).
+	it('renders children', () => {
+		const root = trackRoot(createRoot(container));
+		flushSync(() => (root.render as any)(createElement('div', { id: 'child' }, 'Hi')));
+		expect(container.querySelector('#child')?.textContent).toBe('Hi');
+		expect(container.textContent).toBe('Hi');
+	});
+
+	// Per ReactDOMRoot-test.js:51 (stable), :51 (canary).
+	it('warns if a callback parameter is provided to render', () => {
+		const callback = vi.fn();
+		const root = trackRoot(createRoot(container));
+		const element = createElement(client.TextRoot, { text: 'Hi' });
+		const { messages } = captureConsoleErrors(() =>
+			flushSync(() => (root.render as any)(element, callback)),
+		);
+		expect(messages).toEqual([
+			'does not support the second callback argument. To execute a side effect after ' +
+				'rendering, declare it in a component body with useEffect().',
+		]);
+		expect(callback).not.toHaveBeenCalled();
+		expect(container.textContent).toBe('Hi');
+	});
+
+	// Per ReactDOMRoot-test.js:66 (stable), :63 (canary).
+	it('warn if a object is passed to root.render(...)', () => {
+		const root = trackRoot(createRoot(container));
+		const element = createElement(client.TextRoot, { text: 'Child' });
+		const { messages } = captureConsoleErrors(() =>
+			flushSync(() => (root.render as any)(element, {})),
+		);
+		expect(messages).toEqual([
+			'You passed a second argument to root.render(...) but it only accepts one argument.',
+		]);
+		expect(container.textContent).toBe('Child');
+	});
+
+	// Per ReactDOMRoot-test.js:84 (stable), :76 (canary).
+	it('warn if a container is passed to root.render(...)', () => {
+		const root = trackRoot(createRoot(container));
+		const element = createElement(client.TextRoot, { text: 'Child' });
+		const { messages } = captureConsoleErrors(() =>
+			flushSync(() => (root.render as any)(element, container)),
+		);
+		expect(messages).toEqual([
+			"You passed a container to the second argument of root.render(...). You don't need to " +
+				'pass it again since you already passed it to create the root.',
+		]);
+		expect(container.textContent).toBe('Child');
+	});
+
+	// Per ReactDOMRoot-test.js:103 (stable), :90 (canary).
+	it('warns if a callback parameter is provided to unmount', () => {
+		const callback = vi.fn();
+		const root = trackRoot(createRoot(container));
+		render(root, client.TextRoot, { text: 'Hi' });
+		const { messages } = captureConsoleErrors(() => (root.unmount as any)(callback));
+		expect(messages).toEqual([
+			'does not support a callback argument. To execute a side effect after rendering, ' +
+				'declare it in a component body with useEffect().',
+		]);
+		expect(callback).not.toHaveBeenCalled();
+		expect(container.textContent).toBe('');
+	});
+
+	// Per ReactDOMRoot-test.js:119 (stable), :103 (canary).
+	it('unmounts children', () => {
+		const root = trackRoot(createRoot(container));
+		render(root, client.TextRoot, { text: 'Hi' });
+		expect(container.textContent).toBe('Hi');
+		root.unmount();
+		expect(container.textContent).toBe('');
+	});
+
+	// Per ReactDOMRoot-test.js:129 (stable), :113 (canary).
+	it('can be immediately unmounted', () => {
+		const root = trackRoot(createRoot(container));
+		expect(root.unmount()).toBeUndefined();
+		expect(() => root.render(client.TextRoot, { text: 'late' })).toThrow(
+			'Cannot update an unmounted root.',
+		);
+	});
+
+	// Per ReactDOMRoot-test.js:136 (stable), :120 (canary).
+	it('supports hydration', () => {
+		const props = { className: 'server', text: 'Hello' };
+		const { html } = ServerRuntime.renderToString(server.HydrationRoot, props);
+
+		const clientOnlyContainer = makeContainer();
+		clientOnlyContainer.innerHTML = html;
+		const replacedServerNode = clientOnlyContainer.firstElementChild;
+		const clientOnlyRoot = trackRoot(createRoot(clientOnlyContainer));
+		render(clientOnlyRoot, client.HydrationRoot, props);
+		expect(clientOnlyContainer.firstElementChild).not.toBe(replacedServerNode);
+
+		container.innerHTML = html;
+		const adoptedServerNode = container.firstElementChild;
+		const hydratedRoot = trackRoot(hydrateRoot(container, client.HydrationRoot, props));
+		flushSync(() => {});
+		expect(container.firstElementChild).toBe(adoptedServerNode);
+		expect(container.querySelector('span')?.textContent).toBe('Hello');
+	});
+
+	// Per ReactDOMRoot-test.js:189 (stable), :173 (canary).
+	it('clears existing children', () => {
+		container.innerHTML = '<div>a</div><div>b</div>';
+		const stale = Array.from(container.children);
+		const root = trackRoot(createRoot(container));
+		render(root, client.OrderedChildren, { first: 'c', second: 'd' });
+		expect(container.textContent).toBe('cd');
+		expect(stale.every((node) => !node.isConnected)).toBe(true);
+		render(root, client.OrderedChildren, { first: 'd', second: 'c' });
+		expect(container.textContent).toBe('dc');
+	});
+
+	// Per ReactDOMRoot-test.js:210 (stable), :194 (canary).
+	it('throws a good message on invalid containers', () => {
+		const element = createElement(client.TextRoot, { text: 'Hi' });
+		expect(() => createRoot(element as any)).toThrow('Target container is not a DOM element.');
+	});
+
+	// Per ReactDOMRoot-test.js:216 (stable), :200 (canary).
+	it('warns when creating two roots managing the same container', () => {
+		const { messages } = captureConsoleErrors(() => {
+			trackRoot(createRoot(container));
+			trackRoot(createRoot(container));
+		});
+		expect(messages).toEqual([
+			'You are calling createRoot() on a container that has already been passed ' +
+				'to createRoot() before. Instead, call root.render() on the existing root instead if ' +
+				'you want to update it.',
+		]);
+	});
+
+	// Per ReactDOMRoot-test.js:229 (stable), :210 (canary).
+	it('does not warn when creating second root after first one is unmounted', () => {
+		const first = trackRoot(createRoot(container));
+		first.unmount();
+		const { result: second, messages } = captureConsoleErrors(() => createRoot(container));
+		trackRoot(second);
+		expect(messages).toEqual([]);
+		render(second, client.TextRoot, { text: 'new owner' });
+		expect(container.textContent).toBe('new owner');
+	});
+
+	// Per ReactDOMRoot-test.js:236 (stable), :217 (canary).
+	it('warns if creating a root on the document.body', () => {
+		// The upstream case now explicitly expects no diagnostic when Float is on.
+		const { result: root, messages } = captureConsoleErrors(() => createRoot(document.body));
+		trackRoot(root);
+		expect(messages).toEqual([]);
+		root.unmount();
+	});
+
+	// Per ReactDOMRoot-test.js:241 (stable), :222 (canary).
+	it('warns if updating a root that has had its contents removed', () => {
+		const root = trackRoot(createRoot(container));
+		render(root, client.TextRoot, { text: 'Hi' });
+		container.textContent = '';
+		const { messages } = captureConsoleErrors(() =>
+			flushSync(() => root.render(client.TextRoot, { text: 'updated' })),
+		);
+		// The upstream feature gates disable this legacy diagnostic; the update is
+		// accepted and the root remains usable regardless of whether an implementation
+		// repairs the externally-detached node during that same update.
+		expect(messages).toEqual([]);
+		render(root, client.SpanRoot);
+		expect(container.querySelector('#span-root')?.textContent).toBe('span');
+	});
+
+	// Per ReactDOMRoot-test.js:252 (stable), :233 (canary).
+	it('should render different components in same root', () => {
+		const root = trackRoot(createRoot(container));
+		render(root, client.DivRoot);
+		expect(container.firstElementChild?.tagName).toBe('DIV');
+		render(root, client.SpanRoot);
+		expect(container.firstElementChild?.tagName).toBe('SPAN');
+	});
+
+	// Per ReactDOMRoot-test.js:267 (stable), :248 (canary).
+	it('should not warn if mounting into non-empty node', () => {
+		container.innerHTML = '<div id="old"></div>';
+		const { result: root, messages } = captureConsoleErrors(() => {
+			const created = createRoot(container);
+			flushSync(() => created.render(client.DivRoot));
+			return created;
+		});
+		trackRoot(root);
+		expect(messages).toEqual([]);
+		expect(container.querySelector('#old')).toBeNull();
+		expect(container.querySelector('#div-root')).not.toBeNull();
+	});
+
+	// Per ReactDOMRoot-test.js:277 (stable), :258 (canary).
+	it('should reuse markup if rendering to the same target twice', () => {
+		const root = trackRoot(createRoot(container));
+		render(root, client.DivRoot);
+		const firstElement = container.firstElementChild;
+		render(root, client.DivRoot);
+		expect(container.firstElementChild).toBe(firstElement);
+	});
+
+	// Per ReactDOMRoot-test.js:290 (stable), :271 (canary).
+	it('should unmount and remount if the key changes', () => {
+		const log: string[] = [];
+		const root = trackRoot(createRoot(container));
+		const keyed = (key: string, text: string) =>
+			createElement(client.KeyedRoot, { key, text, log: (entry: string) => log.push(entry) });
+
+		flushSync(() => root.render(keyed('A', 'orange')));
+		flushEffects();
+		const orange = container.querySelector('#keyed-root');
+		expect(orange?.textContent).toBe('orange:orange');
+		expect(log.splice(0)).toEqual(['Mount']);
+
+		flushSync(() => root.render(keyed('B', 'green')));
+		flushEffects();
+		const green = container.querySelector('#keyed-root');
+		expect(green).not.toBe(orange);
+		expect(green?.textContent).toBe('green:green');
+		expect(log.splice(0)).toEqual(['Unmount', 'Mount']);
+
+		flushSync(() => root.render(keyed('B', 'blue')));
+		flushEffects();
+		expect(container.querySelector('#keyed-root')).toBe(green);
+		expect(green?.textContent).toBe('blue:green');
+		expect(log).toEqual([]);
+	});
+
+	// Per ReactDOMRoot-test.js:326 (stable), :307 (canary).
+	it('throws if unmounting a root that has had its contents removed', () => {
+		const root = trackRoot(createRoot(container));
+		render(root, client.TextRoot, { text: 'Hi' });
+		container.textContent = '';
+		// OCTANE DIVERGENCE: root teardown owns the container as a whole and is
+		// deliberately safe after external DOM removal. React's NotFoundError is an
+		// incidental result of its per-host-node deletion path, not a useful contract.
+		expect(() => root.unmount()).not.toThrow();
+		expect(container.textContent).toBe('');
+	});
+
+	// Per ReactDOMRoot-test.js:340 (stable), :321 (canary).
+	it('unmount is synchronous', () => {
+		const root = trackRoot(createRoot(container));
+		flushSync(() => root.render('Hi'));
+		expect(container.textContent).toBe('Hi');
+		root.unmount();
+		// No scheduler drain is needed: the managed DOM is gone before return.
+		expect(container.textContent).toBe('');
+	});
+
+	// Per ReactDOMRoot-test.js:354 (stable), :335 (canary).
+	it('throws if an unmounted root is updated', () => {
+		const root = trackRoot(createRoot(container));
+		flushSync(() => root.render('Hi'));
+		root.unmount();
+		expect(() => root.render("I'm back")).toThrow('Cannot update an unmounted root.');
+	});
+
+	// Per ReactDOMRoot-test.js:368 (stable), :349 (canary).
+	it('warns if root is unmounted inside an effect', () => {
+		const otherContainer = makeContainer();
+		const otherRoot = trackRoot(createRoot(otherContainer));
+		render(otherRoot, client.TextRoot, { text: 'Other root' });
+
+		const root = trackRoot(createRoot(container));
+		render(root, client.EffectUnmountRoot, {
+			step: 1,
+			unmountOtherRoot: () => otherRoot.unmount(),
+		});
+		flushEffects();
+
+		const { messages } = captureConsoleErrors(() => {
+			flushSync(() =>
+				root.render(client.EffectUnmountRoot, {
+					step: 2,
+					unmountOtherRoot: () => otherRoot.unmount(),
+				}),
+			);
+			flushEffects();
+		});
+		expect(messages).toEqual([
+			'Attempted to synchronously unmount a root while Octane was already rendering. ' +
+				'Octane cannot finish unmounting the root until the current render has completed, ' +
+				'which may lead to a race condition.',
+		]);
+		expect(otherContainer.textContent).toBe('');
+	});
+
+	// Per ReactDOMRoot-test.js:400 (stable), :381 (canary).
+	it('errors if container is a comment node', () => {
+		const comment = document.createComment('react-mount-point-unstable');
+		expect(() => createRoot(comment as any)).toThrow('Target container is not a DOM element.');
+		expect(() => hydrateRoot(comment as any, client.HydrationRoot, {})).toThrow(
+			'Target container is not a DOM element.',
+		);
+	});
+
+	// Per ReactDOMRoot-test.js:414 (stable), :395 (canary).
+	it('warn if no children passed to hydrateRoot', () => {
+		const { result: root, messages } = captureConsoleErrors(() => (hydrateRoot as any)(container));
+		trackRoot(root);
+		expect(messages).toEqual([
+			'Must provide initial children as second argument to hydrateRoot. ' +
+				'Example usage: hydrateRoot(domContainer, <App />)',
+		]);
+		expect(container.textContent).toBe('');
+	});
+
+	// Per ReactDOMRoot-test.js:425 (stable), :403 (canary).
+	it('warn if JSX passed to createRoot', () => {
+		const element = createElement(client.TextRoot, { text: 'not options' });
+		const { result: root, messages } = captureConsoleErrors(() =>
+			createRoot(container, element as any),
+		);
+		trackRoot(root);
+		expect(messages).toEqual([
+			'You passed a JSX element to createRoot. You probably meant to call root.render instead. ' +
+				'Example usage:\n\n  let root = createRoot(domContainer);\n  root.render(<App />);',
+		]);
+		render(root, client.TextRoot, { text: 'Child' });
+		expect(container.textContent).toBe('Child');
+	});
+
+	// Per ReactDOMRoot-test.js:445 (stable), :418 (canary).
+	it('warns when given a function', () => {
+		const root = trackRoot(createRoot(container));
+		// OCTANE DIVERGENCE: root.render(Component, props) is Octane's documented
+		// allocation-free root API, so a bare compiled function is rendered rather
+		// than treated as an invalid child value.
+		const { messages } = captureConsoleErrors(() =>
+			flushSync(() => root.render(client.TextRoot, { text: 'function component' })),
+		);
+		expect(messages).toEqual([]);
+		expect(container.textContent).toBe('function component');
+	});
+
+	// Per ReactDOMRoot-test.js:466 (stable), :436 (canary).
+	it('warns when given a symbol', () => {
+		const root = trackRoot(createRoot(container));
+		const value = Symbol('foo');
+		const { messages } = captureConsoleErrors(() => flushSync(() => (root.render as any)(value)));
+		expect(messages).toEqual([
+			'Symbols are not valid as an Octane child.\n  root.render(Symbol(foo))',
+		]);
+		expect(container.textContent).toBe('');
+	});
+});

--- a/packages/octane/tests/ssr-element-utils.test.ts
+++ b/packages/octane/tests/ssr-element-utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as Server from 'octane/server';
 
 // `octane/server` must export the React-compatible element utilities the
@@ -17,9 +17,21 @@ const {
 	renderToStaticMarkup,
 } = Server as any;
 
+function captureThrown(run: () => unknown): unknown {
+	try {
+		run();
+	} catch (error) {
+		return error;
+	}
+	throw new Error('Expected callback to throw');
+}
+
 describe('octane/server element utilities', () => {
 	it('isValidElement recognizes server createElement descriptors only', () => {
-		expect(isValidElement(createElement('li', { class: 'row' }, 'x'))).toBe(true);
+		const element = createElement('li', { class: 'row' }, 'x');
+		expect(isValidElement(element)).toBe(true);
+		expect(Object.isFrozen(element)).toBe(true);
+		expect(Object.isFrozen(element.props)).toBe(true);
 		expect(isValidElement({ type: 'li', props: {} })).toBe(false);
 		expect(isValidElement(null)).toBe(false);
 		expect(isValidElement('li')).toBe(false);
@@ -42,7 +54,13 @@ describe('octane/server element utilities', () => {
 	it('positional children replace the originals; none passed keeps them', () => {
 		const base = createElement('g', null, 'one');
 		expect(cloneElement(base, null, 'two').children).toBe('two');
-		expect(cloneElement(base, null, 'a', 'b').children).toEqual(['a', 'b']);
+		const clonedChildren = cloneElement(base, null, 'a', 'b').children;
+		expect(clonedChildren).toEqual(['a', 'b']);
+		expect(Object.isFrozen(clonedChildren)).toBe(false);
+		clonedChildren.push('c');
+		expect(clonedChildren).toEqual(['a', 'b', 'c']);
+		const createdChildren = createElement('g', null, 'a', 'b').children;
+		expect(Object.isFrozen(createdChildren)).toBe(true);
 		expect(cloneElement(base, { 'data-x': '1' }).children).toBe('one');
 	});
 
@@ -62,13 +80,65 @@ describe('octane/server element utilities', () => {
 		// 5 visited leaves (null and false ARE visited, as `null` — React parity).
 		const kids = [createElement('a'), null, [createElement('b'), false], 'txt'];
 		expect(Children.count(kids)).toBe(5);
-		expect(Children.toArray(kids).length).toBe(3);
+		const flattened = Children.toArray(kids);
+		expect(flattened.length).toBe(3);
+		expect(Object.isFrozen(flattened[0])).toBe(true);
+		expect(Object.isFrozen(flattened[0].props)).toBe(true);
 		const mapped = Children.map(kids, (c: unknown) => (c == null ? null : 'x'));
 		expect(mapped).toEqual(['x', 'x', 'x']);
 		expect(Children.map(null, () => 'x')).toBe(null);
 		const only = createElement('g');
 		expect(Children.only(only)).toBe(only);
 		expect(() => Children.only([only])).toThrow(/single element/);
+	});
+
+	it('Children ignores callable iterables like the client and React', () => {
+		const callable = Object.assign(function callable() {}, {
+			*[Symbol.iterator]() {
+				yield createElement('i');
+			},
+		});
+		const callback = vi.fn((child) => child);
+		expect(Children.toArray(callable)).toEqual([]);
+		expect(Children.count(callable)).toBe(0);
+		expect(Children.map(callable, callback)).toEqual([]);
+		expect(callback).not.toHaveBeenCalled();
+	});
+
+	it('Children direct calls unwrap fulfilled and rejected promises without leaking SSR state', async () => {
+		const pending = new Promise(() => {});
+		expect(captureThrown(() => Children.toArray(pending))).toBe(pending);
+
+		const fulfilled = Promise.resolve(createElement('i', { key: 'ready' }));
+		expect(captureThrown(() => Children.toArray(fulfilled))).toBe(fulfilled);
+		await fulfilled;
+		const resolved = Children.toArray(fulfilled);
+		expect(resolved).toHaveLength(1);
+		expect(resolved[0].type).toBe('i');
+
+		const reason = new Error('no children');
+		const rejected = Promise.reject(reason);
+		expect(captureThrown(() => Children.toArray(rejected))).toBe(rejected);
+		await rejected.catch(() => {});
+		expect(captureThrown(() => Children.toArray(rejected))).toBe(reason);
+	});
+
+	it('Children promises keep SSR boundary suspension bookkeeping during render', () => {
+		const promise = new Promise(() => {});
+		const App = (props: { promise: Promise<unknown> }, scope: unknown) =>
+			(Server as any).ssrTry(
+				scope,
+				'children-promise',
+				() => {
+					Children.toArray(props.promise);
+					return '<strong>ready</strong>';
+				},
+				() => '<em>loading</em>',
+				null,
+			);
+		const { html } = renderToStaticMarkup(App, { promise });
+		expect(html).toContain('<em>loading</em>');
+		expect(html).not.toContain('<strong>ready</strong>');
 	});
 
 	it('createPortal descriptors SSR as a bare site anchor (content is client-side)', () => {

--- a/scripts/react-parity/inventory-lib.mjs
+++ b/scripts/react-parity/inventory-lib.mjs
@@ -1069,7 +1069,18 @@ export function validateLedger(ledger, inventories, repoRoot, upstreams) {
 			if (policy) {
 				if (entry.status === 'untriaged')
 					errors.push(`Priority case ${entry.caseId} may not remain untriaged.`);
-				for (const name of ['classification', 'risk', 'owner', 'workstream']) {
+				const hasDocumentedPolicyOverride =
+					entry.status === 'documented' &&
+					(entry.classification === 'divergence' || entry.classification === 'non_goal') &&
+					LEDGER_RISKS.has(entry.risk) &&
+					entry.risk !== 'unassessed' &&
+					typeof entry.rationale === 'string' &&
+					entry.rationale.trim().length > 0;
+				for (const name of ['classification', 'risk']) {
+					if (entry[name] !== policy[name] && !hasDocumentedPolicyOverride)
+						errors.push(`Priority case ${entry.caseId} does not satisfy ${policy.id} ${name}.`);
+				}
+				for (const name of ['owner', 'workstream']) {
 					if (entry[name] !== policy[name])
 						errors.push(`Priority case ${entry.caseId} does not satisfy ${policy.id} ${name}.`);
 				}
@@ -1270,7 +1281,7 @@ export function renderCoverageReport({ upstreams, inventories, ledger }) {
 	}
 	markdown += `\n### Migration sequence and exit criteria\n\n`;
 	markdown += `1. **Wave 1 — critical blockers (completed 2026-07-15):** Effect Event semantics and shared untrusted-URL sanitization are implemented, ported, and linked to executable ledger evidence.\n`;
-	markdown += `2. **Wave 2 — public API and reconciliation:** root, fragment, element/Children, and lazy-component outcomes.\n`;
+	markdown += `2. **Wave 2 — public API and reconciliation (completed 2026-07-15):** supported root, fragment, element/Children, and lazy-component outcomes have live evidence; excluded outcomes have durable divergence/non-goal dispositions.\n`;
 	markdown += `3. **Wave 3 — scheduling and stores:** update reconciliation and external-store consistency.\n`;
 	markdown += `4. **Wave 4 — server matrix:** applicable Fizz streaming cases, then the five-mode server integration matrix.\n`;
 	markdown += `5. **Residual audit:** assign risk and a durable disposition to every remaining untriaged case, with canary drift reviewed continuously.\n\n`;

--- a/scripts/react-parity/inventory-lib.test.mjs
+++ b/scripts/react-parity/inventory-lib.test.mjs
@@ -262,6 +262,32 @@ function validatorFixture() {
 	return { inventory, upstreams, entry };
 }
 
+function priorityValidatorFixture() {
+	const fixture = validatorFixture();
+	fixture.upstreams.triagePolicies = [
+		{
+			id: 'example-policy',
+			filePattern: '/Example-test\\.js$',
+			status: 'planned',
+			classification: 'adaptable',
+			risk: 'high',
+			owner: 'runtime',
+			workstream: 'Example behavior',
+			rationale: 'Exercise the observable example behavior.',
+		},
+	];
+	fixture.entry = {
+		...fixture.entry,
+		status: 'planned',
+		classification: 'adaptable',
+		risk: 'high',
+		owner: 'runtime',
+		workstream: 'Example behavior',
+		rationale: 'Exercise the observable example behavior.',
+	};
+	return fixture;
+}
+
 describe('React parity validators', () => {
 	test('rejects duplicate, missing, and unknown ledger IDs', () => {
 		const { inventory, upstreams, entry } = validatorFixture();
@@ -303,6 +329,127 @@ describe('React parity validators', () => {
 		);
 
 		assert(errors.some((error) => error.includes('must be triaged')));
+	});
+
+	test('allows documented priority cases to override classification and risk', () => {
+		for (const classification of ['divergence', 'non_goal']) {
+			const { inventory, upstreams, entry } = priorityValidatorFixture();
+			const errors = validateLedger(
+				{
+					schemaVersion: 1,
+					entries: [
+						{
+							...entry,
+							status: 'documented',
+							classification,
+							risk: 'low',
+							rationale: 'This supported surface intentionally differs from React.',
+						},
+					],
+				},
+				[inventory],
+				process.cwd(),
+				upstreams,
+			);
+
+			assert.deepEqual(errors, []);
+		}
+	});
+
+	test('rejects priority classification and risk overrides outside a documented disposition', () => {
+		for (const status of ['planned', 'covered']) {
+			const { inventory, upstreams, entry } = priorityValidatorFixture();
+			const errors = validateLedger(
+				{
+					schemaVersion: 1,
+					entries: [
+						{
+							...entry,
+							status,
+							classification: 'divergence',
+							risk: 'low',
+							rationale: 'This is not a documented disposition.',
+						},
+					],
+				},
+				[inventory],
+				process.cwd(),
+				upstreams,
+			);
+
+			assert(
+				errors.includes(
+					`Priority case ${entry.caseId} does not satisfy example-policy classification.`,
+				),
+			);
+			assert(
+				errors.includes(`Priority case ${entry.caseId} does not satisfy example-policy risk.`),
+			);
+		}
+	});
+
+	test('rejects malformed documented priority overrides and preserves policy ownership', () => {
+		const malformedCases = [
+			{
+				classification: 'divergence',
+				risk: 'low',
+				rationale: '',
+			},
+			{
+				classification: 'portable',
+				risk: 'low',
+				rationale: 'A portable classification is not an intentional override.',
+			},
+			{
+				classification: 'non_goal',
+				risk: 'unassessed',
+				rationale: 'A documented disposition must carry an assessed risk.',
+			},
+		];
+
+		for (const malformed of malformedCases) {
+			const { inventory, upstreams, entry } = priorityValidatorFixture();
+			const errors = validateLedger(
+				{
+					schemaVersion: 1,
+					entries: [{ ...entry, ...malformed, status: 'documented' }],
+				},
+				[inventory],
+				process.cwd(),
+				upstreams,
+			);
+
+			assert(
+				errors.some((error) =>
+					error.startsWith(`Priority case ${entry.caseId} does not satisfy example-policy`),
+				),
+			);
+		}
+
+		const { inventory, upstreams, entry } = priorityValidatorFixture();
+		const ownershipErrors = validateLedger(
+			{
+				schemaVersion: 1,
+				entries: [
+					{
+						...entry,
+						status: 'documented',
+						classification: 'divergence',
+						risk: 'low',
+						owner: 'someone else',
+						rationale: 'The classification is intentional, but ownership cannot drift.',
+					},
+				],
+			},
+			[inventory],
+			process.cwd(),
+			upstreams,
+		);
+		assert(
+			ownershipErrors.includes(
+				`Priority case ${entry.caseId} does not satisfy example-policy owner.`,
+			),
+		);
 	});
 
 	test('rejects missing and renamed local evidence without throwing on malformed evidence', () => {


### PR DESCRIPTION
## Summary

- complete React parity Wave 2 across root semantics, Fragment reconciliation, Element/Children APIs, and lazy function components
- give all 209 pinned stable/canary cases a durable disposition: 167 supported cases, 5 intentional divergences, and 37 explicit non-goals
- add executable client, production-compile, SSR, and differential coverage for the supported Octane surface
- update the parity validator, generated coverage report, public differences documentation, RuleSync guidance, and patch changeset

## Wave 2 disposition

- Root semantics: 25 covered, 2 documented divergences
- Fragment reconciliation: 28 covered, 1 documented non-goal
- Element and Children APIs: 95 covered, 16 documented non-goals
- Lazy components: 19 covered, 3 documented divergences, 20 documented non-goals

Class components, `PureComponent`, legacy `ReactDOM.render` roots, `forwardRef`, React owner/component-stack internals, and unsupported exotic element types remain out of scope by design. This PR does not add compatibility shims for them.

## Runtime and API work

- enforce root container ownership diagnostics, closed-root behavior, root key identity, safe synchronous teardown, host/primitive root values, and hydration update semantics
- support Fragment and iterable flattening with state-preserving unkeyed transitions, keyed identity boundaries, transactional suspended mounts, and collision-proof scoped keys
- align `createElement`, `cloneElement`, and `Children` traversal for key escaping/rebasing, refs, default props, iterable/thenable handling, development freezing, and portable missing-key diagnostics
- make lazy function-component loading transactional across loader/subscription/default-getter failures, including synchronous thenables, SSR, live function `defaultProps`, and resolved Octane `memo` comparators

## Test impact

Phase 2 adds 186 conformance registrations plus 3 focused API/SSR regressions. Normal tests are rerun under the production compiler, adding 378 workspace executions.

Current latest-main totals:

- normal core: 2,480
- production-compile reruns: 2,480
- profiling-only: 14
- all workspace executions: 7,584
- React-source-attributed upper bound: 1,154 cases across 72 files

The pinned React inventories remain unchanged: stable has 5,345 declarations / 6,603 minimum registrations; canary has 5,413 / 6,679.

## Validation

- `pnpm test` — 927 files, 7,584 tests passed
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm react-parity:test`
- `pnpm react-parity:check`
- `pnpm test:markers:check`
- `pnpm parity:gaps:check`
- `pnpm rules:check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wave 2 targets core root lifecycle, reconciliation, public element APIs, and lazy loading; the changeset signals runtime behavior changes, though this diff slice is mostly parity docs and generated reports.
> 
> **Overview**
> Completes **React parity Wave 2** for roots, Fragment/iterable reconciliation, element/`Children` APIs, and lazy function components, with a patch **changeset** describing alignment to pinned React 19 cases and explicit non-goals (class components, legacy roots, `forwardRef`, etc.).
> 
> **Documentation and tooling** now record Wave 2 as done: `docs/react-parity-coverage.md` and `packages/octane/audit/react-upstreams.json` bump conformance/test counts (e.g. 2,480 normal core cases, 7,584 workspace executions) and mark the four Wave 2 workstreams **covered**, with ledger-style rationales for supported vs documented divergence/non-goal cases. `docs/differences-from-react.md` adds sections on `root.render(App, props)`, safe unmount after external DOM removal, and expanded `lazy()` resolution (bare components, lazy-wrapped Suspense/ViewTransition). Shared agent guidance (RuleSync → `AGENTS.md`, `CLAUDE.md`, etc.) mirrors those contracts and calls out legacy `ReactDOM.render` as unsupported.
> 
> **Formatting:** `.prettierignore` excludes the fragment reconciliation conformance fixture whose JSX shape the TSRX Prettier parser cannot parse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 660c6f5ab81215586ab65fbfacde2d4da635410f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->