### PR TITLE
Fix TSRX Prettier expression parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,13 +13,14 @@
     "url": "git+https://github.com/octanejs/octane.git"
   },
   "scripts": {
-    "test": "pnpm --dir packages/visx compile:check && pnpm --dir packages/visx types:check && vitest run",
+    "test": "pnpm format:tsrx:test && pnpm --dir packages/visx compile:check && pnpm --dir packages/visx types:check && vitest run",
     "build": "pnpm --filter octane build",
     "bench": "pnpm --filter @benchmarks/news bench",
     "bench:all": "node benchmarks/bench.mjs",
     "bench:svelte-check": "pnpm --filter './benchmarks/**/svelte' exec svelte-check --workspace .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "format:tsrx:test": "node --test scripts/tsrx-prettier.test.mjs",
     "typecheck": "tsgo --noEmit -p packages/octane/tsconfig.json && tsgo --noEmit -p packages/app-core/tsconfig.typecheck.json && tsgo --noEmit -p packages/rspack-plugin-octane/tsconfig.typecheck.json && tsgo --noEmit -p packages/rsbuild-plugin-octane/tsconfig.typecheck.json && tsgo --noEmit -p packages/vite-plugin-octane/tsconfig.typecheck.json && tsgo --noEmit -p packages/adapter-vercel/tsconfig.typecheck.json && tsgo --noEmit -p packages/zustand/tsconfig.json && tsgo --noEmit -p packages/jotai/tsconfig.json && tsgo --noEmit -p packages/i18next/tsconfig.json && tsgo --noEmit -p packages/tanstack-query/tsconfig.json && tsgo --noEmit -p packages/apollo-client/tsconfig.json && tsgo --noEmit -p packages/apollo-client/typetests/tsconfig.json && tsgo --noEmit -p packages/recharts/tsconfig.json && tsgo --noEmit -p packages/visx/tsconfig.json && tsgo --noEmit -p packages/lucide/tsconfig.json && tsgo --noEmit -p packages/redux/tsconfig.json && tsgo --noEmit -p packages/redux-toolkit/tsconfig.json && tsgo --noEmit -p packages/redux-toolkit/typetests/tsconfig.json && tsgo --noEmit -p packages/remix-router/tsconfig.json && tsgo --noEmit -p packages/hook-form/tsconfig.json && tsgo --noEmit -p packages/hook-form/typetests/tsconfig.json && tsgo --noEmit -p packages/motion/tsconfig.json && tsgo --noEmit -p packages/dnd-kit/tsconfig.json && tsgo --noEmit -p packages/dnd-kit/typetests/tsconfig.json && tsgo --noEmit -p packages/stylex/tsconfig.json && tsgo --noEmit -p packages/tanstack-router/tsconfig.json && tsgo --noEmit -p packages/tanstack-table/tsconfig.json && tsgo --noEmit -p packages/tanstack-virtual/tsconfig.json && tsgo --noEmit -p packages/lexical/tsconfig.json && tsgo --noEmit -p packages/floating-ui/tsconfig.json && tsgo --noEmit -p packages/radix/tsconfig.json && tsgo --noEmit -p packages/base-ui/tsconfig.json && tsgo --noEmit -p packages/sonner/tsconfig.json && tsgo --noEmit -p packages/testing-library/tsconfig.json && tsgo --noEmit -p packages/mdx/tsconfig.json && tsgo --noEmit -p packages/octane-evals/tsconfig.json && tsgo --noEmit -p website/tsconfig.json && pnpm examples:typecheck",
     "examples:catalog": "node scripts/examples-catalog.mjs",
     "examples:catalog:check": "node scripts/examples-catalog.mjs --check",

--- a/patches/@tsrx__core@0.1.38.patch
+++ b/patches/@tsrx__core@0.1.38.patch
@@ -1,0 +1,29 @@
+diff --git a/src/plugin.js b/src/plugin.js
+index 9f4bd720b47ab4d16ec1b9fa72e7d565657c0577..e87b2b029492ce5c48d805f2c670ed38f70bf9f9 100644
+--- a/src/plugin.js
++++ b/src/plugin.js
+@@ -4419,2 +4419,22 @@ export function TSRXPlugin(config) {
+-				if (!is_fragment && open.selfClosing) {
+-					this.#path.pop();
++				if (!is_fragment && open.selfClosing) {
++					this.#path.pop();
++
++					// A self-closing element in EXPRESSION position has no children,
++					// but the lookahead after its `/>` was read while this element was
++					// still the current template node (jsx_parseOpeningElementAt's
++					// expect(jsxTagEnd) advances one token) — so unless the very next
++					// character closed the expression immediately, the lexer committed
++					// to a jsxText token spanning everything up to the next `<`/`{`.
++					// The standard prettier shape `=> (\n  <div />\n)` then dies with
++					// Unexpected token at the `)`. Rewind and re-lex that lookahead in
++					// script mode. nextToken() (not next()) keeps lastTok* pointing at
++					// the `/>` so the element's finishNode range stays correct.
++					const parentAfterSelfClose = this.#path.at(-1);
++					if (
++						!this.#isNativeTemplateNode(parentAfterSelfClose) &&
++						this.type === tstt.jsxText
++					) {
++						this.pos = this.start;
++						this.exprAllowed = false;
++						this.nextToken();
++					}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -602,6 +602,7 @@ overrides:
 
 patchedDependencies:
   '@tsrx/core@0.1.37': 0b7535578a1327e33019974cc015cbaafbd88bc4a1f60997c23bfb979cd7a081
+  '@tsrx/core@0.1.38': a8a44e624bbfe3b4650f7ada014ec420ed663f99f1327b86e5e9044087ecbfc7
 
 importers:
 
@@ -11208,7 +11209,7 @@ snapshots:
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 
-  '@tsrx/core@0.1.38':
+  '@tsrx/core@0.1.38(patch_hash=a8a44e624bbfe3b4650f7ada014ec420ed663f99f1327b86e5e9044087ecbfc7)':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@noble/hashes': 2.2.0
@@ -11225,7 +11226,7 @@ snapshots:
 
   '@tsrx/prettier-plugin@0.3.95(prettier@3.8.4)':
     dependencies:
-      '@tsrx/core': 0.1.38
+      '@tsrx/core': 0.1.38(patch_hash=a8a44e624bbfe3b4650f7ada014ec420ed663f99f1327b86e5e9044087ecbfc7)
       prettier: 3.8.4
     transitivePeerDependencies:
       - '@typescript-eslint/types'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -264,3 +264,4 @@ catalogs:
 
 patchedDependencies:
   '@tsrx/core@0.1.37': patches/@tsrx__core@0.1.37.patch
+  '@tsrx/core@0.1.38': patches/@tsrx__core@0.1.38.patch

--- a/scripts/tsrx-prettier.test.mjs
+++ b/scripts/tsrx-prettier.test.mjs
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import * as tsrxPlugin from '@tsrx/prettier-plugin';
+import { format } from 'prettier';
+
+const options = {
+	parser: 'tsrx',
+	plugins: [tsrxPlugin],
+	useTabs: true,
+	tabWidth: 2,
+	singleQuote: true,
+	jsxSingleQuote: false,
+	printWidth: 100,
+	bracketSameLine: false,
+};
+
+async function expectStableFormat(input, expected) {
+	const formatted = await format(input, options);
+	assert.equal(formatted, expected);
+	assert.equal(await format(formatted, options), expected);
+}
+
+describe('TSRX Prettier formatting', () => {
+	test('formats a return-position self-closing element and Fragment ternary', async () => {
+		const input = `function ElementToFragment(condition) {
+	return condition ? (
+		<Item />
+	) : (
+		<>
+			<Item />
+		</>
+	);
+}
+`;
+		const expected = `function ElementToFragment(condition) {
+	return condition
+		? <Item />
+		: <>
+				<Item />
+			</>;
+}
+`;
+
+		await expectStableFormat(input, expected);
+	});
+
+	test('formats a return-position self-closing element and array ternary', async () => {
+		const input = `function ElementToArray(condition) {
+	return condition ? (
+		<Item />
+	) : (
+		[<Item />]
+	);
+}
+`;
+		const expected = `function ElementToArray(condition) {
+	return condition ? <Item /> : [<Item />];
+}
+`;
+
+		await expectStableFormat(input, expected);
+	});
+
+	test('formats a multiline parenthesized self-closing JSX expression', async () => {
+		const input = `const parenthesized = (
+	<Item />
+);
+`;
+		const expected = `const parenthesized = <Item />;
+`;
+
+		await expectStableFormat(input, expected);
+	});
+
+	test('preserves text after a self-closing child inside a template', async () => {
+		const input = `const nested = <div>
+	<Item />
+	tail
+</div>;
+`;
+
+		await expectStableFormat(input, input);
+	});
+});


### PR DESCRIPTION
## Summary

- apply Octane's existing self-closing JSX lexer fix to the `@tsrx/core@0.1.38` copy used by `@tsrx/prettier-plugin`
- add public `prettier.format()` regressions for return-position Fragment and array ternaries, the minimal parenthesized expression, idempotence, and genuine template-child text
- remove PR #91's temporary `.prettierignore` exception and commit the formatter's canonical output for its fragment reconciliation fixture
- run the focused formatter suite from the repository test command

## Root cause

`@tsrx/prettier-plugin@0.3.95` delegates parsing to its own `@tsrx/core@0.1.38`, while Octane's compiler resolves the already-patched `@tsrx/core@0.1.37`. The opening-tag parser advances beyond a self-closing `/>` while that element is still the current template node, so trailing whitespace in an expression such as:

```tsrx
const value = (
	<Item />
);
```

is incorrectly committed as `jsxText`. The following script delimiter (`)`, `]`, `:`, or `;`) is then rejected. The patch rewinds only that stale lookahead and re-lexes it in script mode; a native-template parent remains untouched so real child text keeps its existing semantics.

## Phase 2 fixture

PR #91 merged while this fix was being prepared. This branch is rebased onto that merge, deletes the explanatory comment and fixture entry from `.prettierignore`, and formats `packages/octane/tests/conformance/_fixtures/fragment-reconciliation.tsrx` successfully. A second formatting pass is byte-identical, and all 30 fragment reconciliation cases still pass.

## Validation

- `pnpm format:tsrx:test` (4 passing)
- `vitest run packages/octane/tests/conformance/fragment-reconciliation.test.ts --project octane --reporter=verbose` (30 passing)
- real Phase 2 fixture format + byte-identical second pass
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm install --frozen-lockfile`
- `git diff --check origin/main...HEAD`

No changeset: this affects repository formatter tooling rather than a published Octane package surface.
