### PR TITLE
Complete React parity Wave 3

### DIFF
--- a/.changeset/clear-selector-slots.md
+++ b/.changeset/clear-selector-slots.md
@@ -1,0 +1,5 @@
+---
+'@octanejs/redux': patch
+---
+
+Fix `useSyncExternalStoreWithSelector` calls that omit `isEqual` so the compiler's trailing hook slot is not interpreted as the optional comparator.

--- a/.changeset/steady-store-schedules.md
+++ b/.changeset/steady-store-schedules.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Bound recursive effect setup/cleanup, ref, root-render, and external-store update chains with recoverable maximum-depth errors while preserving finite chains and wide independent batches. Keep `act()` scopes balanced when a synchronous drain rejects, report cross-component render updates in development, and preserve the implicit bailout when a compiled component returns unchanged `children`.

--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -169,10 +169,13 @@ these toward React without checking `docs/react-parity-migration-plan.md`:
   batch replay counts, or prefetch behavior toward React
   (docs/suspense-parallel-use-plan.md). True data dependencies stay sequential;
   unwrap order, hydration-seed order, and rejection routing match React.
-- **Root component entry point and safe external-DOM cleanup.** In addition to
-  `root.render(<App />)`, Octane intentionally supports `root.render(App, props)`.
-  A root whose managed DOM was externally removed unmounts safely instead of
-  surfacing the browser's incidental `NotFoundError` for an already-detached node.
+- **Synchronous first root mount, component entry point, and safe cleanup.** The
+  first `root.render()` mounts synchronously, so render-then-unmount in one outer
+  batch can expose intermediate DOM that React's concurrent root elides. In
+  addition to `root.render(<App />)`, Octane intentionally supports
+  `root.render(App, props)`. A root whose managed DOM was externally removed
+  unmounts safely instead of surfacing the browser's incidental `NotFoundError`
+  for an already-detached node.
 - **`lazy()` accepts bare components and component-form boundaries.** React's
   module `{ default }` shape works, and Octane additionally accepts a component
   directly from the loader. Suspense and ViewTransition are ordinary Octane

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -164,10 +164,13 @@ these toward React without checking `docs/react-parity-migration-plan.md`:
   batch replay counts, or prefetch behavior toward React
   (docs/suspense-parallel-use-plan.md). True data dependencies stay sequential;
   unwrap order, hydration-seed order, and rejection routing match React.
-- **Root component entry point and safe external-DOM cleanup.** In addition to
-  `root.render(<App />)`, Octane intentionally supports `root.render(App, props)`.
-  A root whose managed DOM was externally removed unmounts safely instead of
-  surfacing the browser's incidental `NotFoundError` for an already-detached node.
+- **Synchronous first root mount, component entry point, and safe cleanup.** The
+  first `root.render()` mounts synchronously, so render-then-unmount in one outer
+  batch can expose intermediate DOM that React's concurrent root elides. In
+  addition to `root.render(<App />)`, Octane intentionally supports
+  `root.render(App, props)`. A root whose managed DOM was externally removed
+  unmounts safely instead of surfacing the browser's incidental `NotFoundError`
+  for an already-detached node.
 - **`lazy()` accepts bare components and component-form boundaries.** React's
   module `{ default }` shape works, and Octane additionally accepts a component
   directly from the loader. Suspense and ViewTransition are ordinary Octane

--- a/.rulesync/rules/project.md
+++ b/.rulesync/rules/project.md
@@ -171,10 +171,13 @@ these toward React without checking `docs/react-parity-migration-plan.md`:
   batch replay counts, or prefetch behavior toward React
   (docs/suspense-parallel-use-plan.md). True data dependencies stay sequential;
   unwrap order, hydration-seed order, and rejection routing match React.
-- **Root component entry point and safe external-DOM cleanup.** In addition to
-  `root.render(<App />)`, Octane intentionally supports `root.render(App, props)`.
-  A root whose managed DOM was externally removed unmounts safely instead of
-  surfacing the browser's incidental `NotFoundError` for an already-detached node.
+- **Synchronous first root mount, component entry point, and safe cleanup.** The
+  first `root.render()` mounts synchronously, so render-then-unmount in one outer
+  batch can expose intermediate DOM that React's concurrent root elides. In
+  addition to `root.render(<App />)`, Octane intentionally supports
+  `root.render(App, props)`. A root whose managed DOM was externally removed
+  unmounts safely instead of surfacing the browser's incidental `NotFoundError`
+  for an already-detached node.
 - **`lazy()` accepts bare components and component-form boundaries.** React's
   module `{ default }` shape works, and Octane additionally accepts a component
   directly from the loader. Suspense and ViewTransition are ordinary Octane

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,10 +175,13 @@ these toward React without checking `docs/react-parity-migration-plan.md`:
   batch replay counts, or prefetch behavior toward React
   (docs/suspense-parallel-use-plan.md). True data dependencies stay sequential;
   unwrap order, hydration-seed order, and rejection routing match React.
-- **Root component entry point and safe external-DOM cleanup.** In addition to
-  `root.render(<App />)`, Octane intentionally supports `root.render(App, props)`.
-  A root whose managed DOM was externally removed unmounts safely instead of
-  surfacing the browser's incidental `NotFoundError` for an already-detached node.
+- **Synchronous first root mount, component entry point, and safe cleanup.** The
+  first `root.render()` mounts synchronously, so render-then-unmount in one outer
+  batch can expose intermediate DOM that React's concurrent root elides. In
+  addition to `root.render(<App />)`, Octane intentionally supports
+  `root.render(App, props)`. A root whose managed DOM was externally removed
+  unmounts safely instead of surfacing the browser's incidental `NotFoundError`
+  for an already-detached node.
 - **`lazy()` accepts bare components and component-form boundaries.** React's
   module `{ default }` shape works, and Octane additionally accepts a component
   directly from the loader. Suspense and ViewTransition are ordinary Octane

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,10 +164,13 @@ these toward React without checking `docs/react-parity-migration-plan.md`:
   batch replay counts, or prefetch behavior toward React
   (docs/suspense-parallel-use-plan.md). True data dependencies stay sequential;
   unwrap order, hydration-seed order, and rejection routing match React.
-- **Root component entry point and safe external-DOM cleanup.** In addition to
-  `root.render(<App />)`, Octane intentionally supports `root.render(App, props)`.
-  A root whose managed DOM was externally removed unmounts safely instead of
-  surfacing the browser's incidental `NotFoundError` for an already-detached node.
+- **Synchronous first root mount, component entry point, and safe cleanup.** The
+  first `root.render()` mounts synchronously, so render-then-unmount in one outer
+  batch can expose intermediate DOM that React's concurrent root elides. In
+  addition to `root.render(<App />)`, Octane intentionally supports
+  `root.render(App, props)`. A root whose managed DOM was externally removed
+  unmounts safely instead of surfacing the browser's incidental `NotFoundError`
+  for an already-detached node.
 - **`lazy()` accepts bare components and component-form boundaries.** React's
   module `{ default }` shape works, and Octane additionally accepts a component
   directly from the loader. Suspense and ViewTransition are ordinary Octane

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -175,10 +175,13 @@ these toward React without checking `docs/react-parity-migration-plan.md`:
   batch replay counts, or prefetch behavior toward React
   (docs/suspense-parallel-use-plan.md). True data dependencies stay sequential;
   unwrap order, hydration-seed order, and rejection routing match React.
-- **Root component entry point and safe external-DOM cleanup.** In addition to
-  `root.render(<App />)`, Octane intentionally supports `root.render(App, props)`.
-  A root whose managed DOM was externally removed unmounts safely instead of
-  surfacing the browser's incidental `NotFoundError` for an already-detached node.
+- **Synchronous first root mount, component entry point, and safe cleanup.** The
+  first `root.render()` mounts synchronously, so render-then-unmount in one outer
+  batch can expose intermediate DOM that React's concurrent root elides. In
+  addition to `root.render(<App />)`, Octane intentionally supports
+  `root.render(App, props)`. A root whose managed DOM was externally removed
+  unmounts safely instead of surfacing the browser's incidental `NotFoundError`
+  for an already-detached node.
 - **`lazy()` accepts bare components and component-form boundaries.** React's
   module `{ default }` shape works, and Octane additionally accepts a component
   directly from the loader. Suspense and ViewTransition are ordinary Octane

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -188,6 +188,11 @@ compiled-component entry point, `root.render(App, props)`, which avoids creating
 an element descriptor at application bootstrap. A bare function passed to
 `root.render` is therefore intentional, not an invalid-child warning.
 
+The first `root.render()` mounts synchronously. React's concurrent root queues
+its initial mount, so a render followed by an unmount in the same surrounding
+batch exposes no intermediate DOM there; Octane may expose the mounted DOM
+before its synchronous unmount leaves the same empty final state.
+
 After `root.unmount()`, the root is permanently closed. If outside code removes
 some of a root's managed DOM first, unmount still performs safe cleanup instead
 of surfacing the browser's incidental `NotFoundError` from removing an already

--- a/docs/react-parity-coverage.md
+++ b/docs/react-parity-coverage.md
@@ -11,16 +11,16 @@ This report separates distinct Octane tests, React upstream scenarios, renderer/
 
 | Measure | Count |
 | --- | ---: |
-| Normal core cases | 2,480 |
-| ↳ conformance | 1,171 |
-| ↳ differential | 136 |
+| Normal core cases | 2,591 |
+| ↳ conformance | 1,219 |
+| ↳ differential | 137 |
 | ↳ hydration | 135 |
-| ↳ other runtime/compiler/SSR | 1,038 |
+| ↳ other runtime/compiler/SSR | 1,100 |
 | Profiling-only cases | 14 |
-| Distinct core cases including profiling | 2,494 |
-| Production-compile reruns of normal core | 2,480 |
-| All workspace executions | 7,584 |
-| React-source-attributed file upper bound | 1,154 cases in 72 files |
+| Distinct core cases including profiling | 2,605 |
+| Production-compile reruns of normal core | 2,591 |
+| All workspace executions | 7,813 |
+| React-source-attributed file upper bound | 1,202 cases in 74 files |
 
 The production project reruns the same normal core cases in another compile mode; it is not another set of conformance ports. The React-source-attributed definition is: Every collected normal-core case in a local file containing at least one React upstream *-test.js or *-test.ts filename citation; this is a generous file-level upper bound, not a one-to-one port count. Counts were measured on 2026-07-15.
 
@@ -85,8 +85,8 @@ Every concrete case in either pinned inventory has exactly one ledger dispositio
 
 | Baseline | Cases | Untriaged | Planned | In progress | Covered | Documented | Blocked |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| stable | 5,345 | 4,449 | 655 | 0 | 194 | 47 | 0 |
-| canary | 5,413 | 4,506 | 660 | 0 | 200 | 47 | 0 |
+| stable | 5,345 | 4,449 | 594 | 0 | 236 | 66 | 0 |
+| canary | 5,413 | 4,506 | 596 | 0 | 240 | 71 | 0 |
 
 Classifications are `portable`, `adaptable`, `divergence`, and `non_goal`. A covered case requires live local test evidence; divergence and non-goal dispositions require a rationale.
 
@@ -102,8 +102,8 @@ Suite policies are machine-readable in `react-upstreams.json`; the first matchin
 | Fragment reconciliation | 29 / 29 | 29 / 29 | high | covered | runtime | Twenty-eight fragment identity and reconciliation cases have exact-title client and production-compile evidence; React's internal lazy-to-element shape has a documented non-goal disposition and executable component-module adaptation. |
 | Element and Children APIs | 111 / 111 | 111 / 111 | high | covered | public API | Ninety-five public Children, element creation, clone, validation, iterable, thenable, key, ref, freezing, and function-default-prop cases have executable evidence; sixteen React owner/component-stack, legacy-transform, class, and private-element diagnostics are documented non-goals. |
 | Lazy components | 40 / 40 | 41 / 41 | high | covered | runtime | Nineteen lazy resolution, rejection, function-component default-prop, memo, identity, and reorder cases have executable evidence; three ergonomic/component-form differences and twenty unsupported class, forwardRef, legacy-root, owner-stack, or exotic-type cases have durable documented dispositions. |
-| External stores | 19 / 19 | 19 / 19 | high | planned | runtime | Port store mutation, snapshot consistency, selector, error, and hydration outcomes. |
-| Update reconciliation | 42 / 42 | 45 / 45 | high | planned | runtime | Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes. |
+| External stores | 19 / 19 | 19 / 19 | high | covered | runtime | Seventeen snapshot, notification, selector, error, and hydration outcomes have executable evidence; React 17 legacy-shim timing and selector invocation-count optimization are documented non-goals. |
+| Update reconciliation | 42 / 42 | 45 / 45 | high | covered | runtime | Twenty-five function/hook batching, ordering, deletion, re-entry, and loop-stability outcomes have executable evidence; synchronous first-mount timing is an executable documented divergence and twenty-one class, legacy, Fiber, or owner-stack cases are documented non-goals. |
 | Fizz streaming | 207 / 207 | 207 / 207 | high | planned | SSR + hydration | Filter and port applicable streaming, abort, error, shell, resource, and hydration behavior. |
 | Server integration matrix | 387 / 1,569 | 389 / 1,579 | high | planned | SSR + hydration | Build the client, buffered SSR, streaming SSR, matching hydration, and mismatch-recovery matrix. |
 | React repository lint rules | 5 / 5 | 5 / 5 | low | documented | tooling | React's internal ESLint RuleTester fixtures validate repository tooling, not observable UI framework behavior in Octane. |
@@ -112,7 +112,7 @@ Suite policies are machine-readable in `react-upstreams.json`; the first matchin
 
 1. **Wave 1 — critical blockers (completed 2026-07-15):** Effect Event semantics and shared untrusted-URL sanitization are implemented, ported, and linked to executable ledger evidence.
 2. **Wave 2 — public API and reconciliation (completed 2026-07-15):** supported root, fragment, element/Children, and lazy-component outcomes have live evidence; excluded outcomes have durable divergence/non-goal dispositions.
-3. **Wave 3 — scheduling and stores:** update reconciliation and external-store consistency.
+3. **Wave 3 — scheduling and stores (completed 2026-07-15):** supported update-reconciliation and external-store outcomes have live evidence; excluded class, legacy, Fiber-policy, and optimization-only cases have durable dispositions.
 4. **Wave 4 — server matrix:** applicable Fizz streaming cases, then the five-mode server integration matrix.
 5. **Residual audit:** assign risk and a durable disposition to every remaining untriaged case, with canary drift reviewed continuously.
 

--- a/docs/react-parity-migration-plan.md
+++ b/docs/react-parity-migration-plan.md
@@ -71,6 +71,7 @@ explain the old plan; they are no longer current scope decisions.
 | Class components, `createClass`, `this.refs`, string refs | Octane has no class components. *Port the underlying reconciler/effect OUTCOME via function components + hooks where the behavior is renderer-level.* |
 | `componentDidCatch` / `getDerivedStateFromError` mechanics | Octane uses `@try`/`@catch`. Port the catch OUTCOME, not the lifecycle. |
 | Legacy / sync mode, legacy roots | Octane is concurrent-root only. |
+| Initial concurrent-root mount batching | **Intentional divergence.** Octane's first `root.render()` mounts synchronously. A render followed by `root.unmount()` in the same surrounding batch can therefore expose intermediate DOM before the synchronous unmount leaves an empty final state; React's concurrent root can elide that mount. |
 | Rules-of-hooks enforcement, hook-order warnings | **Intentional divergence** — Octane tracks hooks by call site; conditional hooks are legal. |
 | Omitted dependency arrays | **Intentional divergence** — for effect-family hooks, `useMemo`, `useCallback`, and `useImperativeHandle`, omission asks the compiler to infer dependencies from lexical captures. Explicit arrays retain React semantics; `null` is the explicit every-render/recompute form. |
 | StrictMode double-invoke of effects/render | Octane has no StrictMode (verified: no `StrictMode`/double-invoke in runtime). |

--- a/packages/octane/audit/react-conformance-ledger.json
+++ b/packages/octane/audit/react-conformance-ledger.json
@@ -291,15 +291,15 @@
     },
     {
       "caseId": "react-case-v1:012b8690ce728b06acea",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "warns about potential infinite loop if there's a synchronous render phase update on another component",
       "baselines": ["canary"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Canary-only replacement for the stable sync loop case, gated by experimental enableInfiniteRenderLoopDetection and asserting warn-vs-throw policy. Cover the stable function loop outcome instead."
     },
     {
       "caseId": "react-case-v1:013009de95bc28c93593",
@@ -678,15 +678,15 @@
     },
     {
       "caseId": "react-case-v1:02cfe64f15536cb00824",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "does not re-render if state update is null",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Returning null from a class setState updater means no update; useState(null) is valid state in hooks, so copying this would be incorrect."
     },
     {
       "caseId": "react-case-v1:02d6a7aeb3a14f412454",
@@ -4188,7 +4188,7 @@
     },
     {
       "caseId": "react-case-v1:150bad2ce41d37c321fa",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js",
       "title": "uses the latest getSnapshot, even if it changed in the same batch as a store update",
@@ -4196,7 +4196,14 @@
       "classification": "portable",
       "owner": "runtime",
       "workstream": "External stores",
-      "rationale": "Port store mutation, snapshot consistency, selector, error, and hydration outcomes."
+      "rationale": "Executable stable/canary ports cover snapshot selection, notification deduplication, render-to-commit consistency, errors, hydration, and public with-selector behavior.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/external-store-shared.test.ts",
+          "testName": "uses the latest getSnapshot, even if it changed in the same batch as a store update",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:150c5be0e58f4643717e",
@@ -5144,15 +5151,15 @@
     },
     {
       "caseId": "react-case-v1:1a544b805a00a3ec0f15",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "does not update one component twice in a batch (#2410)",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "The regression is expressed entirely through class forceUpdate, UNSAFE_componentWillUpdate, and class commit callbacks. Generic overlapping parent/child coalescing is already covered."
     },
     {
       "caseId": "react-case-v1:1a6127eadc07efb813c7",
@@ -5291,7 +5298,7 @@
     },
     {
       "caseId": "react-case-v1:1af9005f386e214b9c95",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js",
       "title": "basic usage",
@@ -5299,7 +5306,14 @@
       "classification": "portable",
       "owner": "runtime",
       "workstream": "External stores",
-      "rationale": "Port store mutation, snapshot consistency, selector, error, and hydration outcomes."
+      "rationale": "Executable stable/canary ports cover snapshot selection, notification deduplication, render-to-commit consistency, errors, hydration, and public with-selector behavior.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/external-store-shared.test.ts",
+          "testName": "basic usage",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:1af9f6d3987b85fe5cfc",
@@ -6259,15 +6273,15 @@
     },
     {
       "caseId": "react-case-v1:1fb74dc87f631c307023",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "warns about potential infinite loop if there's an async render phase update on another component",
       "baselines": ["canary"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Canary-only transition warning policy is gated by React’s experimental loop detector and phase classification. Octane has no lanes/flag."
     },
     {
       "caseId": "react-case-v1:1fbd097cd25c532caa14",
@@ -6347,7 +6361,7 @@
     },
     {
       "caseId": "react-case-v1:2003c68b13ee3d6ea04d",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "should not reconcile children passed via props",
@@ -6355,7 +6369,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Executable function/hook adaptations cover batching, cross-root commit ordering, deletion, re-entry, bounded nested updates and recovery, finite and wide batches, and cross-component render diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "should not reconcile children passed via props",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:200db26f06a04208267b",
@@ -8053,15 +8074,22 @@
     },
     {
       "caseId": "react-case-v1:288a6dfd3c7551aca302",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "can have nested updates if they do not cross the limit",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "portable",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Executable function/hook adaptations cover batching, cross-root commit ordering, deletion, re-entry, bounded nested updates and recovery, finite and wide batches, and cross-component render diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "can have nested updates if they do not cross the limit",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:288ac1015253ed5c72ca",
@@ -8845,15 +8873,22 @@
     },
     {
       "caseId": "react-case-v1:2d1116918edc6c7795fb",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js",
       "title": "selector can throw on update",
       "baselines": ["canary", "stable"],
-      "classification": "portable",
+      "classification": "adaptable",
       "owner": "runtime",
       "workstream": "External stores",
-      "rationale": "Port store mutation, snapshot consistency, selector, error, and hydration outcomes."
+      "rationale": "Executable stable/canary ports cover snapshot selection, notification deduplication, render-to-commit consistency, errors, hydration, and public with-selector behavior.",
+      "evidence": [
+        {
+          "file": "packages/redux/tests/conformance/external-store-shared.test.ts",
+          "testName": "selector can throw on update",
+          "modes": ["client"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:2d1716f9e65c5fad1c9b",
@@ -9377,15 +9412,22 @@
     },
     {
       "caseId": "react-case-v1:30417bc18598f473bdb0",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "should batch parent/child state updates together",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "portable",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Executable function/hook adaptations cover batching, cross-root commit ordering, deletion, re-entry, bounded nested updates and recovery, finite and wide batches, and cross-component render diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "should batch parent/child state updates together",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:30475fe693989f9e8b26",
@@ -9405,15 +9447,22 @@
     },
     {
       "caseId": "react-case-v1:3059161b7fb41f4d9157",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "can have many updates inside useEffect without triggering a warning",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "portable",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Executable function/hook adaptations cover batching, cross-root commit ordering, deletion, re-entry, bounded nested updates and recovery, finite and wide batches, and cross-component render diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "can have many updates inside useEffect without triggering a warning",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:307b65bc1696b8488364",
@@ -9461,15 +9510,15 @@
     },
     {
       "caseId": "react-case-v1:30b73e228199cd33b2ea",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "throws in forceUpdate if the update callback is not a function",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "forceUpdate and its callback argument have no Octane API counterpart."
     },
     {
       "caseId": "react-case-v1:30caf56b4bf6331b3444",
@@ -9541,7 +9590,7 @@
     },
     {
       "caseId": "react-case-v1:314a7c6decf226ef7b5f",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "handles reentrant mounting in synchronous mode",
@@ -9549,7 +9598,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Executable function/hook adaptations cover batching, cross-root commit ordering, deletion, re-entry, bounded nested updates and recovery, finite and wide batches, and cross-component render diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "handles reentrant mounting in synchronous mode",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:315aad2bf54299e97eaa",
@@ -11255,15 +11311,15 @@
     },
     {
       "caseId": "react-case-v1:38f452e55923410eac93",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "should queue updates from during mount",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "The behavior depends entirely on UNSAFE_componentWillMount scheduling another class instance’s setState."
     },
     {
       "caseId": "react-case-v1:390d5e656eec6583357b",
@@ -11363,7 +11419,7 @@
     },
     {
       "caseId": "react-case-v1:395d8195007062e53883",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js",
       "title": "basic server hydration",
@@ -11371,19 +11427,26 @@
       "classification": "portable",
       "owner": "runtime",
       "workstream": "External stores",
-      "rationale": "Port store mutation, snapshot consistency, selector, error, and hydration outcomes."
+      "rationale": "Executable stable/canary ports cover snapshot selection, notification deduplication, render-to-commit consistency, errors, hydration, and public with-selector behavior.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/external-store-shared.test.ts",
+          "testName": "basic server hydration",
+          "modes": ["client", "server-string", "hydrate-match", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:3961b29e6075b30c9435",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "throws when sync render-phase update loop is detected with force-throw enabled",
       "baselines": ["canary"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Experimental force-throw feature-flag behavior for React’s sync nested-update detector is not an Octane public contract."
     },
     {
       "caseId": "react-case-v1:3966f5d39e963ba1cd4b",
@@ -11467,15 +11530,22 @@
     },
     {
       "caseId": "react-case-v1:39bbdbd31719bc62c73b",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "does not fall into an infinite update loop with useLayoutEffect",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "portable",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Executable function/hook adaptations cover batching, cross-root commit ordering, deletion, re-entry, bounded nested updates and recovery, finite and wide batches, and cross-component render diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "does not fall into an infinite update loop with useLayoutEffect",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:39d42099bcf41e05cbff",
@@ -12077,15 +12147,15 @@
     },
     {
       "caseId": "react-case-v1:3cf6ae075fd28517b64e",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "does not fall into an infinite update loop",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "This is the class componentDidMount/componentDidUpdate version of the infinite layout-update loop. The function-hook case is separately in scope."
     },
     {
       "caseId": "react-case-v1:3cf6cbcf26e63fcdf593",
@@ -12707,15 +12777,15 @@
     },
     {
       "caseId": "react-case-v1:3febfdef511f15bedff2",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "should flush updates in the correct order",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Exact order depends on class componentDidUpdate and setState completion callbacks, APIs Octane intentionally omits. Hook layout/passive scheduling has separate tests."
     },
     {
       "caseId": "react-case-v1:3ff3cc5a90632de29ea5",
@@ -12899,16 +12969,16 @@
     },
     {
       "caseId": "react-case-v1:40cb0cdb675fae5718b6",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js",
       "title": null,
       "titleExpression": "\"compares to current state before bailing out, even when there's a \" + 'mutation in between the sync and passive effects'",
       "baselines": ["canary", "stable"],
-      "classification": "portable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "External stores",
-      "rationale": "Port store mutation, snapshot consistency, selector, error, and hydration outcomes."
+      "rationale": "Upstream explicitly gates this to the React 17 userspace shim and legacy-root passive-subscription timing. Octane has concurrent roots and a native hook only."
     },
     {
       "caseId": "react-case-v1:40dfbc063f18aa97a8d0",
@@ -13248,15 +13318,15 @@
     },
     {
       "caseId": "react-case-v1:42ddffc6ca56d78effb9",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "throws when phase-spawn update loop is detected with force-throw enabled",
       "baselines": ["canary"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Experimental force-throw behavior for React’s PHASE_SPAWN lane category is Fiber/lane-internal and excluded."
     },
     {
       "caseId": "react-case-v1:42e0d0a720f59f2dce1d",
@@ -13392,7 +13462,7 @@
     },
     {
       "caseId": "react-case-v1:4361d0e4ad6f14410581",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "can schedule ridiculously many updates within the same batch without triggering a maximum update error",
@@ -13400,7 +13470,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Executable function/hook adaptations cover batching, cross-root commit ordering, deletion, re-entry, bounded nested updates and recovery, finite and wide batches, and cross-component render diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "can schedule ridiculously many updates within the same batch without triggering a maximum update error",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:436a8ac885670ed9cb1b",
@@ -14261,7 +14338,7 @@
     },
     {
       "caseId": "react-case-v1:4819254bd8c822ccd2b6",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "prevents infinite update loop triggered by synchronous updates in useEffect",
@@ -14269,7 +14346,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Executable function/hook adaptations cover batching, cross-root commit ordering, deletion, re-entry, bounded nested updates and recovery, finite and wide batches, and cross-component render diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "prevents infinite update loop triggered by synchronous updates in useEffect",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:4820f3ea782530be714d",
@@ -14892,7 +14976,7 @@
     },
     {
       "caseId": "react-case-v1:4b31ccedd7fb9e7e7b0c",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "can render ridiculously large number of roots without triggering infinite update loop error",
@@ -14900,7 +14984,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Executable function/hook adaptations cover batching, cross-root commit ordering, deletion, re-entry, bounded nested updates and recovery, finite and wide batches, and cross-component render diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "can render 1200 roots without triggering an infinite update loop error",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:4b3bbdd7989478d513b5",
@@ -17955,15 +18046,22 @@
     },
     {
       "caseId": "react-case-v1:5b2fcaf876ab1b4785a6",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "mounts and unmounts are batched",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "divergence",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Octane intentionally mounts the first root render synchronously, so it may expose intermediate DOM that React's concurrent batch elides; the executable test asserts Octane's synchronous mount and the same empty final state after unmount.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "synchronously mounts and unmounts inside one outer batch",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:5b3a32b47b9c454e51ac",
@@ -20106,7 +20204,7 @@
     },
     {
       "caseId": "react-case-v1:65cdee02baf0042eef36",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "does not infinite loop if there's an async render phase update on another component",
@@ -20114,7 +20212,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Executable function/hook adaptations cover batching, cross-root commit ordering, deletion, re-entry, bounded nested updates and recovery, finite and wide batches, and cross-component render diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "does not infinite loop if there's an async render phase update on another component",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:65e40cd7ad7a9d7334bb",
@@ -25107,15 +25212,15 @@
     },
     {
       "caseId": "react-case-v1:8064ce5579b96e6b3698",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "warns about a deferred infinite update loop with useEffect",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "The assertion is React’s DEV warning plus native debug stack and captureOwnerStack formatting. Octane does not expose owner-stack diagnostics; generic passive-effect loop termination can be covered without this case."
     },
     {
       "caseId": "react-case-v1:8065dbc4dabf42f2e8d3",
@@ -26027,15 +26132,15 @@
     },
     {
       "caseId": "react-case-v1:85588cc2ffa7d100e98f",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "should flush updates in the correct order across roots",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "The case is a nested-root class componentDidMount/forceUpdate ordering test. forceUpdate and class mount callbacks are unsupported."
     },
     {
       "caseId": "react-case-v1:858364b169d839c51e10",
@@ -26120,15 +26225,15 @@
     },
     {
       "caseId": "react-case-v1:861305e35d561a623682",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "delays sync updates inside hidden subtrees in Concurrent Mode",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "This uses unstable_LegacyHidden and Concurrent lane deferral. Octane has Activity, not LegacyHidden or React lanes."
     },
     {
       "caseId": "react-case-v1:8613109d899016e1844a",
@@ -27829,15 +27934,15 @@
     },
     {
       "caseId": "react-case-v1:8e29c094776a25bcaf70",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "should queue nested updates",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "The update is triggered from UNSAFE_componentWillUpdate and class forceUpdate across roots; it is lifecycle mechanics, not a hook renderer contract."
     },
     {
       "caseId": "react-case-v1:8e32f918dbc3820f6eb8",
@@ -27853,7 +27958,7 @@
     },
     {
       "caseId": "react-case-v1:8e43f4883750df5ff7b4",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js",
       "title": "getSnapshot can return NaN without infinite loop warning",
@@ -27861,7 +27966,14 @@
       "classification": "portable",
       "owner": "runtime",
       "workstream": "External stores",
-      "rationale": "Port store mutation, snapshot consistency, selector, error, and hydration outcomes."
+      "rationale": "Executable stable/canary ports cover snapshot selection, notification deduplication, render-to-commit consistency, errors, hydration, and public with-selector behavior.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/external-store-shared.test.ts",
+          "testName": "getSnapshot can return NaN without infinite loop warning",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:8e54381aaf6471956648",
@@ -28140,15 +28252,22 @@
     },
     {
       "caseId": "react-case-v1:8fbd3294cbf6f8ce284b",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js",
       "title": "handles errors thrown by getSnapshot",
       "baselines": ["canary", "stable"],
-      "classification": "portable",
+      "classification": "adaptable",
       "owner": "runtime",
       "workstream": "External stores",
-      "rationale": "Port store mutation, snapshot consistency, selector, error, and hydration outcomes."
+      "rationale": "Executable stable/canary ports cover snapshot selection, notification deduplication, render-to-commit consistency, errors, hydration, and public with-selector behavior.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/external-store-shared.test.ts",
+          "testName": "handles errors thrown by getSnapshot",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:8fcc601cdbebdccd4964",
@@ -28585,15 +28704,22 @@
     },
     {
       "caseId": "react-case-v1:921c892a933afeb4c1a1",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "does not infinite loop if there's a synchronous render phase update on another component",
       "baselines": ["stable"],
-      "classification": "adaptable",
+      "classification": "portable",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Executable function/hook adaptations cover batching, cross-root commit ordering, deletion, re-entry, bounded nested updates and recovery, finite and wide batches, and cross-component render diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "does not infinite loop if there's a synchronous render phase update on another component",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:9230ff165a89361a34c5",
@@ -29549,15 +29675,15 @@
     },
     {
       "caseId": "react-case-v1:97a11eaf7bbfedaa1f21",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "does not update one component twice in a batch (#6371)",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "The case combines componentDidMount, componentWillUnmount, forceUpdate, and a class-only subscription pattern."
     },
     {
       "caseId": "react-case-v1:97acaa3261f711c00f18",
@@ -29792,15 +29918,15 @@
     },
     {
       "caseId": "react-case-v1:993a6da91f202a9118f7",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "throws in setState if the update callback is not a function",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Validating the optional class setState callback argument has no Octane API counterpart."
     },
     {
       "caseId": "react-case-v1:99510f761a2cc59e1e75",
@@ -30477,15 +30603,15 @@
     },
     {
       "caseId": "react-case-v1:9d58a572916355e57ca8",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "should flow updates correctly",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "This matrix asserts UNSAFE_componentWillUpdate/componentDidUpdate ordering and owner/class instance relationships. Hook effect order is covered independently."
     },
     {
       "caseId": "react-case-v1:9d5a92ed5f849bc2bcd5",
@@ -30561,7 +30687,7 @@
     },
     {
       "caseId": "react-case-v1:9d9a8dcb09d1b80e010f",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "resets the update counter for unrelated updates",
@@ -30569,7 +30695,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Executable function/hook adaptations cover batching, cross-root commit ordering, deletion, re-entry, bounded nested updates and recovery, finite and wide batches, and cross-component render diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "resets the update counter for unrelated updates",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:9da92f652156161a9906",
@@ -30641,7 +30774,7 @@
     },
     {
       "caseId": "react-case-v1:9e00734362096fac8b7f",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js",
       "title": "does not bail out if the previous update hasn't finished yet",
@@ -30649,7 +30782,14 @@
       "classification": "portable",
       "owner": "runtime",
       "workstream": "External stores",
-      "rationale": "Port store mutation, snapshot consistency, selector, error, and hydration outcomes."
+      "rationale": "Executable stable/canary ports cover snapshot selection, notification deduplication, render-to-commit consistency, errors, hydration, and public with-selector behavior.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/external-store-shared.test.ts",
+          "testName": "does not bail out if the previous update hasn't finished yet",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:9e0dd4edeca9c46246c9",
@@ -30669,7 +30809,7 @@
     },
     {
       "caseId": "react-case-v1:9e2a9659f89d9f9a1a58",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "does not call render after a component as been deleted",
@@ -30677,7 +30817,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Executable function/hook adaptations cover batching, cross-root commit ordering, deletion, re-entry, bounded nested updates and recovery, finite and wide batches, and cross-component render diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "does not call render after a component as been deleted",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:9e41641ad7534b61bb1f",
@@ -31226,15 +31373,22 @@
     },
     {
       "caseId": "react-case-v1:a10d104c6e31a1965abd",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js",
       "title": "compares selection to rendered selection even if selector changes",
       "baselines": ["canary", "stable"],
-      "classification": "portable",
+      "classification": "adaptable",
       "owner": "runtime",
       "workstream": "External stores",
-      "rationale": "Port store mutation, snapshot consistency, selector, error, and hydration outcomes."
+      "rationale": "Executable stable/canary ports cover snapshot selection, notification deduplication, render-to-commit consistency, errors, hydration, and public with-selector behavior.",
+      "evidence": [
+        {
+          "file": "packages/redux/tests/conformance/external-store-shared.test.ts",
+          "testName": "compares selection to rendered selection even if selector changes",
+          "modes": ["client"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:a1121b8d91f78be424ed",
@@ -32360,15 +32514,22 @@
     },
     {
       "caseId": "react-case-v1:a6b8e80ea67e620352d6",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "should batch state and props together",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "portable",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Executable function/hook adaptations cover batching, cross-root commit ordering, deletion, re-entry, bounded nested updates and recovery, finite and wide batches, and cross-component render diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "should batch state and props together",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:a6ca21c6fafb87a5f450",
@@ -32433,15 +32594,15 @@
     },
     {
       "caseId": "react-case-v1:a73369e6a71614e6a4c3",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js",
       "title": "memoized selectors are only called once per update",
       "baselines": ["canary", "stable"],
-      "classification": "portable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "External stores",
-      "rationale": "Port store mutation, snapshot consistency, selector, error, and hydration outcomes."
+      "rationale": "The exact upstream oracle is selector invocation count, an optimization/side-effect observation. Octane testing rules forbid pinning helper call counts absent a public guarantee; semantic selection reuse and bailout are covered by the isEqual and changing-selector cases."
     },
     {
       "caseId": "react-case-v1:a7451cc9802474b43c1b",
@@ -32853,15 +33014,22 @@
     },
     {
       "caseId": "react-case-v1:a927b0369daf43871303",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "should batch state when updating state twice",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "portable",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Executable function/hook adaptations cover batching, cross-root commit ordering, deletion, re-entry, bounded nested updates and recovery, finite and wide batches, and cross-component render diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "should batch state when updating state twice",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:a947fc1a0904cd13806c",
@@ -34526,15 +34694,15 @@
     },
     {
       "caseId": "react-case-v1:b2c508f39a50c8f1f2a3",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "should batch forceUpdate together",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "forceUpdate, shouldComponentUpdate bypass, and class update callbacks do not exist in Octane."
     },
     {
       "caseId": "react-case-v1:b2c70cdfd69af03c1744",
@@ -34670,7 +34838,7 @@
     },
     {
       "caseId": "react-case-v1:b3476240bad3064ce955",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "does not fall into an infinite error loop",
@@ -34678,7 +34846,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Executable function/hook adaptations cover batching, cross-root commit ordering, deletion, re-entry, bounded nested updates and recovery, finite and wide batches, and cross-component render diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "does not fall into an infinite error loop",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:b35380e216bdfeca08d6",
@@ -34913,15 +35088,22 @@
     },
     {
       "caseId": "react-case-v1:b4905d0d2039aca03d43",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "should batch child/parent state updates together",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "portable",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Executable function/hook adaptations cover batching, cross-root commit ordering, deletion, re-entry, bounded nested updates and recovery, finite and wide batches, and cross-component render diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "should batch child/parent state updates together",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:b49e9c982e2e800c63f6",
@@ -36001,15 +36183,22 @@
     },
     {
       "caseId": "react-case-v1:b9258e4c605f4a2be1e1",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js",
       "title": "isEqual can throw on update",
       "baselines": ["canary", "stable"],
-      "classification": "portable",
+      "classification": "adaptable",
       "owner": "runtime",
       "workstream": "External stores",
-      "rationale": "Port store mutation, snapshot consistency, selector, error, and hydration outcomes."
+      "rationale": "Executable stable/canary ports cover snapshot selection, notification deduplication, render-to-commit consistency, errors, hydration, and public with-selector behavior.",
+      "evidence": [
+        {
+          "file": "packages/redux/tests/conformance/external-store-shared.test.ts",
+          "testName": "isEqual can throw on update",
+          "modes": ["client"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:b942e5b2c9ad90c83d9f",
@@ -36370,15 +36559,22 @@
     },
     {
       "caseId": "react-case-v1:bb95fb5e096cd338fac8",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "should batch state when updating two different states",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "portable",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Executable function/hook adaptations cover batching, cross-root commit ordering, deletion, re-entry, bounded nested updates and recovery, finite and wide batches, and cross-component render diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "should batch state when updating two different states",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:bbba7967ad7b749d323f",
@@ -38916,7 +39112,7 @@
     },
     {
       "caseId": "react-case-v1:c75fc76336e1a6b66f8d",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js",
       "title": "regression test for #23150",
@@ -38924,7 +39120,14 @@
       "classification": "portable",
       "owner": "runtime",
       "workstream": "External stores",
-      "rationale": "Port store mutation, snapshot consistency, selector, error, and hydration outcomes."
+      "rationale": "Executable stable/canary ports cover snapshot selection, notification deduplication, render-to-commit consistency, errors, hydration, and public with-selector behavior.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/external-store-shared.test.ts",
+          "testName": "regression test for #23150",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:c761671d55f3a2a0379a",
@@ -39971,7 +40174,7 @@
     },
     {
       "caseId": "react-case-v1:cc3ee924cf06ec02b0ae",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "prevents infinite update loop triggered by too many updates in ref callbacks",
@@ -39979,7 +40182,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Executable function/hook adaptations cover batching, cross-root commit ordering, deletion, re-entry, bounded nested updates and recovery, finite and wide batches, and cross-component render diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "prevents infinite update loop triggered by too many updates in ref callbacks",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:cc4374d3a0bce010d25b",
@@ -42175,7 +42385,7 @@
     },
     {
       "caseId": "react-case-v1:d76e94c3098c790dc750",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js",
       "title": "mutating the store in between render and commit when getSnapshot has changed",
@@ -42183,7 +42393,14 @@
       "classification": "portable",
       "owner": "runtime",
       "workstream": "External stores",
-      "rationale": "Port store mutation, snapshot consistency, selector, error, and hydration outcomes."
+      "rationale": "Executable stable/canary ports cover snapshot selection, notification deduplication, render-to-commit consistency, errors, hydration, and public with-selector behavior.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/external-store-shared.test.ts",
+          "testName": "mutating the store in between render and commit when getSnapshot has changed",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:d777a4de4ef1970e5ec6",
@@ -42445,7 +42662,7 @@
     },
     {
       "caseId": "react-case-v1:d8b6faff61583902381c",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "uses correct base state for setState inside render phase",
@@ -42453,7 +42670,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Executable function/hook adaptations cover batching, cross-root commit ordering, deletion, re-entry, bounded nested updates and recovery, finite and wide batches, and cross-component render diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "uses correct base state for setState inside render phase",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:d8d42281a83467c3bf65",
@@ -42844,15 +43068,15 @@
     },
     {
       "caseId": "react-case-v1:db2834183c82bdbcd15f",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "should support chained state updates",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "The assertion is specifically about class setState callbacks chaining further setState callbacks. Octane has no class callback API; hook updater ordering is separately covered."
     },
     {
       "caseId": "react-case-v1:db35180f5eefc2e76eda",
@@ -42936,7 +43160,7 @@
     },
     {
       "caseId": "react-case-v1:db96157f51b336e314bc",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js",
       "title": "selecting a specific value inside getSnapshot",
@@ -42944,7 +43168,14 @@
       "classification": "portable",
       "owner": "runtime",
       "workstream": "External stores",
-      "rationale": "Port store mutation, snapshot consistency, selector, error, and hydration outcomes."
+      "rationale": "Executable stable/canary ports cover snapshot selection, notification deduplication, render-to-commit consistency, errors, hydration, and public with-selector behavior.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/external-store-shared.test.ts",
+          "testName": "selecting a specific value inside getSnapshot",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:dba34354327ffe9c93a3",
@@ -43991,7 +44222,7 @@
     },
     {
       "caseId": "react-case-v1:e115e784dc3897990d33",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "can recover after falling into an infinite update loop",
@@ -43999,7 +44230,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Executable function/hook adaptations cover batching, cross-root commit ordering, deletion, re-entry, bounded nested updates and recovery, finite and wide batches, and cross-component render diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "can recover after falling into an infinite update loop",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:e11ca0da960c4e4a104c",
@@ -44375,7 +44613,7 @@
     },
     {
       "caseId": "react-case-v1:e300153ea2f9cd040ecd",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js",
       "title": "Infinite loop if getSnapshot keeps returning new reference",
@@ -44383,7 +44621,14 @@
       "classification": "portable",
       "owner": "runtime",
       "workstream": "External stores",
-      "rationale": "Port store mutation, snapshot consistency, selector, error, and hydration outcomes."
+      "rationale": "Executable stable/canary ports cover snapshot selection, notification deduplication, render-to-commit consistency, errors, hydration, and public with-selector behavior.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/external-store-shared.test.ts",
+          "testName": "Infinite loop if getSnapshot keeps returning new reference",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:e30d123da05420ee5d75",
@@ -44729,7 +44974,7 @@
     },
     {
       "caseId": "react-case-v1:e4a27c81b84de4a1b0db",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "should queue mount-ready handlers across different roots",
@@ -44737,7 +44982,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Executable function/hook adaptations cover batching, cross-root commit ordering, deletion, re-entry, bounded nested updates and recovery, finite and wide batches, and cross-component render diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "should queue mount-ready handlers across different roots",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:e4b0dc62a93b17f53418",
@@ -44773,15 +45025,22 @@
     },
     {
       "caseId": "react-case-v1:e4e6ed2e35d7cd27514a",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "synchronously renders hidden subtrees",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "portable",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Executable function/hook adaptations cover batching, cross-root commit ordering, deletion, re-entry, bounded nested updates and recovery, finite and wide batches, and cross-component render diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "synchronously renders hidden subtrees",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:e4eaca47bdc5959ffa49",
@@ -45696,15 +45955,22 @@
     },
     {
       "caseId": "react-case-v1:e9f56c8bfa7737a4c533",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js",
       "title": "Using isEqual to bailout",
       "baselines": ["canary", "stable"],
-      "classification": "portable",
+      "classification": "adaptable",
       "owner": "runtime",
       "workstream": "External stores",
-      "rationale": "Port store mutation, snapshot consistency, selector, error, and hydration outcomes."
+      "rationale": "Executable stable/canary ports cover snapshot selection, notification deduplication, render-to-commit consistency, errors, hydration, and public with-selector behavior.",
+      "evidence": [
+        {
+          "file": "packages/redux/tests/conformance/external-store-shared.test.ts",
+          "testName": "Using isEqual to bailout",
+          "modes": ["client"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:ea1957d3e444c7e254ab",
@@ -45955,15 +46221,15 @@
     },
     {
       "caseId": "react-case-v1:eb3f36d77660a212d183",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "warns instead of throwing when infinite Suspense ping loop is detected via enableInfiniteRenderLoopDetection during commit phase",
       "baselines": ["canary"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "This canary case explicitly tests Fiber Suspense ping listener order, CommitContext, and an experimental detector instrumentation flag. Those internals are excluded."
     },
     {
       "caseId": "react-case-v1:eb4654fc3d7eab26c9ce",
@@ -46191,15 +46457,15 @@
     },
     {
       "caseId": "react-case-v1:ec729db758f571b8169f",
-      "status": "planned",
-      "risk": "high",
+      "status": "documented",
+      "risk": "low",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "calls componentWillReceiveProps setState callback properly",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Explicit componentWillReceiveProps plus class setState callback semantics are unsupported legacy React APIs."
     },
     {
       "caseId": "react-case-v1:ec792363aa773e23f7a0",
@@ -46407,7 +46673,7 @@
     },
     {
       "caseId": "react-case-v1:ed9c50190e3b2085dd2a",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js",
       "title": "skips re-rendering if nothing changes",
@@ -46415,7 +46681,14 @@
       "classification": "portable",
       "owner": "runtime",
       "workstream": "External stores",
-      "rationale": "Port store mutation, snapshot consistency, selector, error, and hydration outcomes."
+      "rationale": "Executable stable/canary ports cover snapshot selection, notification deduplication, render-to-commit consistency, errors, hydration, and public with-selector behavior.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/external-store-shared.test.ts",
+          "testName": "skips re-rendering if nothing changes",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:edafd6b26b92c7198b8a",
@@ -46773,7 +47046,7 @@
     },
     {
       "caseId": "react-case-v1:ef1a5a03e90eba813dc6",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js",
       "title": "switch to a different store",
@@ -46781,7 +47054,14 @@
       "classification": "portable",
       "owner": "runtime",
       "workstream": "External stores",
-      "rationale": "Port store mutation, snapshot consistency, selector, error, and hydration outcomes."
+      "rationale": "Executable stable/canary ports cover snapshot selection, notification deduplication, render-to-commit consistency, errors, hydration, and public with-selector behavior.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/external-store-shared.test.ts",
+          "testName": "switch to a different store",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:ef1dae51aa167893dbae",
@@ -47902,7 +48182,7 @@
     },
     {
       "caseId": "react-case-v1:f4c3e9775075af6327fb",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js",
       "title": "mutating the store in between render and commit when getSnapshot has _not_ changed",
@@ -47910,7 +48190,14 @@
       "classification": "portable",
       "owner": "runtime",
       "workstream": "External stores",
-      "rationale": "Port store mutation, snapshot consistency, selector, error, and hydration outcomes."
+      "rationale": "Executable stable/canary ports cover snapshot selection, notification deduplication, render-to-commit consistency, errors, hydration, and public with-selector behavior.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/external-store-shared.test.ts",
+          "testName": "mutating the store in between render and commit when getSnapshot has _not_ changed",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:f4cdbc269065737169a9",
@@ -48224,7 +48511,7 @@
     },
     {
       "caseId": "react-case-v1:f67f682f8a1732873b45",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "should update children even if parent blocks updates",
@@ -48232,7 +48519,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Executable function/hook adaptations cover batching, cross-root commit ordering, deletion, re-entry, bounded nested updates and recovery, finite and wide batches, and cross-component render diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "should update children even if parent blocks updates",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:f68b7dcd084a30c019ff",
@@ -48568,7 +48862,7 @@
     },
     {
       "caseId": "react-case-v1:f8747626519510e7f140",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactUpdates-test.js",
       "title": "does not fall into mutually recursive infinite update loop with same container",
@@ -48576,7 +48870,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Executable function/hook adaptations cover batching, cross-root commit ordering, deletion, re-entry, bounded nested updates and recovery, finite and wide batches, and cross-component render diagnostics.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "does not fall into mutually recursive infinite update loop with same container",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:f896a076e6319fdadb78",

--- a/packages/octane/audit/react-conformance-ledger.schema.json
+++ b/packages/octane/audit/react-conformance-ledger.schema.json
@@ -81,7 +81,7 @@
       "additionalProperties": false,
       "required": ["file", "testName"],
       "properties": {
-        "file": { "type": "string", "pattern": "^packages/octane/tests/" },
+        "file": { "type": "string", "pattern": "^packages/[^/]+/tests/" },
         "testName": { "type": "string", "minLength": 1 },
         "modes": {
           "type": "array",

--- a/packages/octane/audit/react-upstreams.json
+++ b/packages/octane/audit/react-upstreams.json
@@ -116,20 +116,20 @@
       "workstream": "External stores",
       "filePattern": "/useSyncExternalStoreShared-test\\.js$",
       "risk": "high",
-      "status": "planned",
+      "status": "covered",
       "classification": "portable",
       "owner": "runtime",
-      "rationale": "Port store mutation, snapshot consistency, selector, error, and hydration outcomes."
+      "rationale": "Seventeen snapshot, notification, selector, error, and hydration outcomes have executable evidence; React 17 legacy-shim timing and selector invocation-count optimization are documented non-goals."
     },
     {
       "id": "update-reconciliation",
       "workstream": "Update reconciliation",
       "filePattern": "/ReactUpdates[^/]*-test(?:\\.internal)?\\.js$",
       "risk": "high",
-      "status": "planned",
+      "status": "covered",
       "classification": "adaptable",
       "owner": "runtime",
-      "rationale": "Port renderer-observable update ordering, batching, interruption, and reconciliation outcomes."
+      "rationale": "Twenty-five function/hook batching, ordering, deletion, re-entry, and loop-stability outcomes have executable evidence; synchronous first-mount timing is an executable documented divergence and twenty-one class, legacy, Fiber, or owner-stack cases are documented non-goals."
     },
     {
       "id": "fizz-streaming",
@@ -163,19 +163,19 @@
     }
   ],
   "octaneSuiteBaseline": {
-    "normalCoreCases": 2480,
+    "normalCoreCases": 2591,
     "normalCoreBreakdown": {
-      "conformance": 1171,
-      "differential": 136,
+      "conformance": 1219,
+      "differential": 137,
       "hydration": 135,
-      "other": 1038
+      "other": 1100
     },
     "profilingOnlyCases": 14,
-    "distinctCoreCasesIncludingProfiling": 2494,
-    "productionModeReruns": 2480,
-    "allWorkspaceExecutions": 7584,
-    "reactSourceAttributedFileUpperBound": 1154,
-    "reactSourceAttributedFiles": 72,
+    "distinctCoreCasesIncludingProfiling": 2605,
+    "productionModeReruns": 2591,
+    "allWorkspaceExecutions": 7813,
+    "reactSourceAttributedFileUpperBound": 1202,
+    "reactSourceAttributedFiles": 74,
     "reactSourceAttributedDefinition": "Every collected normal-core case in a local file containing at least one React upstream *-test.js or *-test.ts filename citation; this is a generous file-level upper bound, not a one-to-one port count.",
     "measuredOn": "2026-07-15"
   }

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -515,6 +515,12 @@ export interface Block extends Scope {
 	 */
 	drainStamp: number;
 	drainRenders: number;
+	/** True when the queued render came from a different component's render body. */
+	crossRenderUpdate: boolean;
+	/** Commit-callback loop guard, scoped to one externally-started update chain. */
+	nestedUpdateChain: number;
+	nestedUpdateCount: number;
+	nestedUpdateError: boolean;
 	/**
 	 * useEffectEvent updates publish only for the latest render of this block that
 	 * completed. Zero means this block has never called useEffectEvent. Keeping the
@@ -592,10 +598,19 @@ const RENDERER_REGION_DOM_BINDINGS = new WeakMap<
 >();
 const DOM_ROOT_DISPOSERS = new WeakMap<Block, () => void>();
 // Public root diagnostics need to distinguish an ordinary imperative unmount
-// from one requested by an effect body while the commit lifecycle is active.
+// from one requested by an effect setup/cleanup while commit lifecycle work is active.
 // Passive effects may drain outside `inFlush`, so that scheduler flag alone is
 // insufficient for the observable root warning.
 let EFFECT_BODY_DEPTH = 0;
+// Callback refs are commit-phase callbacks too. Track them separately from
+// effect callbacks so an attach that repeatedly schedules its owner participates
+// in the same bounded nested-update policy without conflating arbitrary commit
+// plumbing (notably useSyncExternalStore consistency checks) with user callbacks.
+let REF_CALLBACK_DEPTH = 0;
+// Store consistency checks are commit-spawned updates as well. Keeping a
+// distinct depth lets unstable getSnapshot values share the nested-update guard
+// without pretending the store check itself is a user effect or ref callback.
+let STORE_SYNC_DEPTH = 0;
 // Octane discovers deletion destroys while reconciling a parent, but those
 // callbacks are semantically mutation-phase work. Effect Events may be called
 // from them even though CURRENT_SCOPE still reflects the eager parent render.
@@ -607,6 +622,18 @@ function runEffectLifecycleCallback(callback: Cleanup): void {
 		callback();
 	} finally {
 		EFFECT_EVENT_LIFECYCLE_DEPTH--;
+	}
+}
+
+// Layout/passive/insertion cleanups are commit callbacks just like their setup
+// bodies. Keep their scheduled updates in the same bounded nested-update chain,
+// while leaving runEffectLifecycleCallback's Effect Event permission intact.
+function runEffectCleanupCallback(callback: Cleanup): void {
+	EFFECT_BODY_DEPTH++;
+	try {
+		runEffectLifecycleCallback(callback);
+	} finally {
+		EFFECT_BODY_DEPTH--;
 	}
 }
 
@@ -797,6 +824,12 @@ let DEFERRED_SPAWN = false;
  */
 let TRANSITION_PENDING_COUNT = 0;
 const TRANSITION_LISTENERS = new Set<() => void>();
+// useTransition/useOptimistic listeners are runtime-owned publication work.
+// When a transition boundary changes the pending count while another component
+// is rendering, their scheduled refreshes must not be diagnosed as userland
+// cross-component render updates. Keep this depth scoped to listener invocation;
+// startTransition's user callback runs only after tickTransitionCount returns.
+let TRANSITION_LISTENER_PUBLISH_DEPTH = 0;
 
 // ── Global commit coordination (entangled transitions) ──────────────────────
 // React commits a transition's whole tree atomically: when one startTransition
@@ -1273,12 +1306,17 @@ function vtWouldWrapResume(): boolean {
 function tickTransitionCount(delta: number): void {
 	TRANSITION_PENDING_COUNT += delta;
 	if (TRANSITION_PENDING_COUNT < 0) TRANSITION_PENDING_COUNT = 0;
-	for (const fn of TRANSITION_LISTENERS) {
-		try {
-			fn();
-		} catch (err) {
-			console.error(err);
+	TRANSITION_LISTENER_PUBLISH_DEPTH++;
+	try {
+		for (const fn of TRANSITION_LISTENERS) {
+			try {
+				fn();
+			} catch (err) {
+				console.error(err);
+			}
 		}
+	} finally {
+		TRANSITION_LISTENER_PUBLISH_DEPTH--;
 	}
 }
 
@@ -1444,6 +1482,50 @@ export function setIsOctaneActEnvironment(value: boolean): void {
 	IS_OCTANE_ACT_ENVIRONMENT = value;
 }
 
+const NESTED_UPDATE_LIMIT = 50;
+const ACT_DRAIN_LIMIT = NESTED_UPDATE_LIMIT + 50;
+let UPDATE_CHAIN_ID = 0;
+
+function inNestedUpdateCallback(): boolean {
+	return EFFECT_BODY_DEPTH > 0 || REF_CALLBACK_DEPTH > 0 || STORE_SYNC_DEPTH > 0;
+}
+
+class MaximumUpdateDepthError extends Error {}
+
+function maximumUpdateDepthError(): Error {
+	return new MaximumUpdateDepthError(
+		'Maximum update depth exceeded. Octane limits the number of nested updates to prevent infinite loops.',
+	);
+}
+
+let CROSS_RENDER_WARNINGS: WeakMap<ComponentBody, WeakSet<ComponentBody>> | null = null;
+
+function componentName(block: Block): string {
+	let body = block.body as ComponentBody & { displayName?: string };
+	// A displayName assigned to the public wrapper is user-authored and wins
+	// over the wrapped body's fallback name.
+	if (body.displayName) return body.displayName;
+	// The dev compiler installs an identity-stable HMR wrapper around exported
+	// components. Diagnostics should name the authored body it delegates to, not
+	// the generated `wrapper` implementation.
+	const hmr = (body as any)[HMR] as HmrMeta | undefined;
+	if (hmr !== undefined) body = hmr.fn as typeof body;
+	return body.displayName || body.name || 'Unknown';
+}
+
+function warnCrossComponentRenderUpdate(target: Block, source: Block): void {
+	if (process.env.NODE_ENV === 'production') return;
+	const warnings = (CROSS_RENDER_WARNINGS ??= new WeakMap());
+	let sources = warnings.get(target.body);
+	if (sources === undefined) warnings.set(target.body, (sources = new WeakSet()));
+	if (sources.has(source.body)) return;
+	sources.add(source.body);
+	console.error(
+		`Cannot update a component (\`${componentName(target)}\`) while rendering a different component ` +
+			`(\`${componentName(source)}\`). Move the update out of the rendering component body.`,
+	);
+}
+
 function scheduleRender(block: Block): void {
 	if (block.disposed) return;
 	// Test-env warning: a state update happened with no flushSync or act()
@@ -1477,6 +1559,12 @@ function scheduleRender(block: Block): void {
 	// transition priority (and useDeferredValue in the replay doesn't defer) —
 	// per ReactDeferredValue-test.js:232.
 	const renderPhaseSelf = CURRENT_BLOCK === block;
+	const renderPhaseOther =
+		CURRENT_BLOCK !== null && !renderPhaseSelf && TRANSITION_LISTENER_PUBLISH_DEPTH === 0;
+	if (renderPhaseOther) {
+		block.crossRenderUpdate = true;
+		warnCrossComponentRenderUpdate(block, CURRENT_BLOCK!);
+	}
 	const mode: 'urgent' | 'transition' =
 		TRANSITION_DEPTH > 0 ||
 		(renderPhaseSelf && block.currentRenderMode === 'transition') ||
@@ -1490,6 +1578,24 @@ function scheduleRender(block: Block): void {
 			block.pendingDeferred = false;
 		}
 		return;
+	}
+	if (inNestedUpdateCallback()) {
+		if (block.nestedUpdateChain !== UPDATE_CHAIN_ID) {
+			block.nestedUpdateChain = UPDATE_CHAIN_ID;
+			block.nestedUpdateCount = 0;
+		}
+		if (++block.nestedUpdateCount > NESTED_UPDATE_LIMIT) block.nestedUpdateError = true;
+	} else if (CURRENT_BLOCK === null) {
+		// A user/root update starts a new chain. This prevents fifty unrelated
+		// events, roots, or wide-batch members from sharing the recursion budget
+		// while preserving the count across scheduler drains for callback-scheduled
+		// work. Updates scheduled while rendering inherit the active chain: otherwise an
+		// effect -> render-phase update -> effect cycle could reset its budget on
+		// every pass. Pure render-phase loops retain the separate drain guard below.
+		UPDATE_CHAIN_ID++;
+		block.nestedUpdateChain = UPDATE_CHAIN_ID;
+		block.nestedUpdateCount = 0;
+		block.nestedUpdateError = false;
 	}
 	block.pending = true;
 	block.pendingMode = mode;
@@ -1548,10 +1654,21 @@ function drainQueue(): { err: any } | null {
 		const block = QUEUE[i];
 		// Skip if an ancestor's cascade already re-rendered this block this flush
 		// (renderBlock cleared its `pending`) — avoids a redundant standalone render.
-		if (!block.pending) continue;
+		// A max-depth flag is not redundant work, however: it must still surface
+		// after an ancestor coalesces the flagged child's pending render.
+		if (!block.pending && !block.nestedUpdateError) continue;
 		block.pending = false;
-		if (block.disposed) continue;
+		if (block.disposed) {
+			block.nestedUpdateError = false;
+			continue;
+		}
+		const crossRenderUpdate = block.crossRenderUpdate;
+		block.crossRenderUpdate = false;
 		try {
+			if (block.nestedUpdateError) {
+				block.nestedUpdateError = false;
+				throw maximumUpdateDepthError();
+			}
 			// An update to a block inside a SUSPENSE-HIDDEN subtree (its boundary's
 			// try content is soft-detached into savedDom while the fallback shows):
 			// don't render it in place — its geometry is detached, and a fresh mount
@@ -1570,9 +1687,11 @@ function drainQueue(): { err: any } | null {
 			// ErrorBoundary, like React's equivalent) instead of hanging.
 			if (block.drainStamp === drainId) {
 				if (++block.drainRenders > RENDER_PHASE_UPDATE_LIMIT) {
-					throw new Error(
-						'Too many re-renders. Octane limits the number of renders to prevent an infinite loop.',
-					);
+					throw crossRenderUpdate
+						? maximumUpdateDepthError()
+						: new Error(
+								'Too many re-renders. Octane limits the number of renders to prevent an infinite loop.',
+							);
 				}
 			} else {
 				block.drainStamp = drainId;
@@ -1971,17 +2090,17 @@ export function flushSync<T>(fn: () => T): T {
 			// renders. While `syncFlush` is set, scheduleRender pushes to QUEUE without arming a
 			// microtask. React's flushSync drains such layout-effect cascades SYNCHRONOUSLY —
 			// needed so derived layout state (e.g. a presence/exit-animation gate) is committed
-			// before flushSync returns. But octane also deliberately FORGIVES non-convergent
-			// cascades (an unstable `useSyncExternalStore` getSnapshot re-scheduling its component
-			// from every layout pass — React throws "maximum update depth"/"getSnapshot should be
-			// cached"; octane must neither hang nor burst-render). Discriminate by CONVERGENCE:
+			// before flushSync returns. Non-convergent commit cascades (for example an
+			// unstable `useSyncExternalStore` snapshot or an every-render layout update)
+			// must not monopolize this synchronous stack. Discriminate by CONVERGENCE:
 			// keep draining while each pass schedules only blocks not yet seen in this flushSync
 			// (a finite cascade propagating through the tree — it exhausts quickly since
 			// Object.is-equal setStates bail); the moment a block re-schedules ITSELF a second
 			// time, the cascade is non-convergent — stop and hand the remainder to the async
-			// scheduler, which advances it lazily (one render per microtask), exactly the
-			// pre-existing behavior divergent stores rely on. LAYOUT_CASCADE_LIMIT backstops
-			// pathological wide-but-finite chains.
+			// scheduler. Commit-spawned updates retain their per-chain count across those
+			// microtasks and surface MaximumUpdateDepthError at the bounded limit instead of
+			// starving the event loop. LAYOUT_CASCADE_LIMIT backstops pathological
+			// wide-but-finite chains.
 			if (QUEUE.length > 0) {
 				const seen = new Set<Block>(QUEUE);
 				let defer = false;
@@ -2083,8 +2202,14 @@ function drainRefDetaches(): void {
 	const q = refDetachQueue.splice(0);
 	for (let i = 0; i < q.length; i += 3) {
 		try {
-			attachRef(q[i], null, q[i + 1]);
+			REF_CALLBACK_DEPTH++;
+			try {
+				attachRef(q[i], null, q[i + 1]);
+			} finally {
+				REF_CALLBACK_DEPTH--;
+			}
 		} catch (err) {
+			if (err instanceof MaximumUpdateDepthError) throw err;
 			// A throwing ref detach must not abort the commit (the remaining detaches
 			// + attaches still run) — route to the deletion's boundary like React.
 			const handler = q[i + 2] as ((e: any) => void) | null;
@@ -2108,8 +2233,14 @@ function drainRefAttaches(): void {
 		// resurrecting an object ref the cleanup just nulled.
 		if (blockSubtreeDisposed(r.block)) continue;
 		try {
-			r.fn();
+			REF_CALLBACK_DEPTH++;
+			try {
+				r.fn();
+			} finally {
+				REF_CALLBACK_DEPTH--;
+			}
 		} catch (err) {
+			if (err instanceof MaximumUpdateDepthError) throw err;
 			const handler = findTryHandler(r.block);
 			if (handler) handler(err);
 			else console.error(err);
@@ -2261,7 +2392,7 @@ function drainEffectEventUpdates(): void {
  * dev warning is suppressed (see `IS_OCTANE_ACT_ENVIRONMENT` and
  * `setIsOctaneActEnvironment`).
  *
- * The async double-loop (5 microtask ticks × up to 50 outer iterations)
+ * The async double-loop (5 microtask ticks × up to ACT_DRAIN_LIMIT iterations)
  * drains cascades like `use(promise)` → status flip → retry → renderBlock
  * that wouldn't settle in a single tick.
  */
@@ -2278,13 +2409,13 @@ export function act<T>(fn: () => T | Promise<T>): Promise<T> {
 		return (async () => {
 			try {
 				const value = await (result as Promise<T>);
-				for (let i = 0; i < 50; i++) {
+				for (let i = 0; i < ACT_DRAIN_LIMIT; i++) {
 					for (let j = 0; j < 5; j++) await Promise.resolve();
 					drainPassiveEffects();
 					if (!hasPendingWork()) return value;
 				}
 				throw new Error(
-					'act(): scheduler did not stabilize after 50 iterations — likely an infinite render loop',
+					`act(): scheduler did not stabilize after ${ACT_DRAIN_LIMIT} iterations — likely an infinite render loop`,
 				);
 			} finally {
 				actScopeDepth--;
@@ -2298,35 +2429,40 @@ export function act<T>(fn: () => T | Promise<T>): Promise<T> {
 	// the callback queued (an in-flight thenable from `use(promise)`, an
 	// awaited async validation) can't be reached synchronously; the returned
 	// promise continues the async drain for callers that DO await.
-	for (let i = 0; i < 50; i++) {
-		// A transition-lane drain that would be wrapped in a view transition must
-		// route through flush() — flushSync is the urgent path and deliberately
-		// SKIPS the wrap. Under the test mock, startViewTransition runs its update
-		// callback synchronously, so this stays a synchronous drain; a REAL async
-		// startViewTransition under sync act() cannot be awaited here (use the
-		// async act form, which drains through the scheduled microtask flush).
-		if (vtWouldWrap()) flush();
-		else flushSync(() => {});
-		drainPassiveEffects();
-		if (!hasPendingWork()) break;
-		if (i === 49) {
-			actScopeDepth--;
-			return Promise.reject(
-				new Error(
-					'act(): scheduler did not stabilize after 50 iterations — likely an infinite render loop',
-				),
-			);
+	try {
+		for (let i = 0; i < ACT_DRAIN_LIMIT; i++) {
+			// A transition-lane drain that would be wrapped in a view transition must
+			// route through flush() — flushSync is the urgent path and deliberately
+			// SKIPS the wrap. Under the test mock, startViewTransition runs its update
+			// callback synchronously, so this stays a synchronous drain; a REAL async
+			// startViewTransition under sync act() cannot be awaited here (use the
+			// async act form, which drains through the scheduled microtask flush).
+			if (vtWouldWrap()) flush();
+			else flushSync(() => {});
+			drainPassiveEffects();
+			if (!hasPendingWork()) break;
+			if (i === ACT_DRAIN_LIMIT - 1) {
+				throw new Error(
+					`act(): scheduler did not stabilize after ${ACT_DRAIN_LIMIT} iterations — likely an infinite render loop`,
+				);
+			}
 		}
+	} catch (err) {
+		// Flush/commit failures follow the same thenable contract as callback
+		// failures. Balance the scope here because the async continuation below
+		// is never created on this path.
+		actScopeDepth--;
+		return Promise.reject(err);
 	}
 	return (async () => {
 		try {
-			for (let i = 0; i < 50; i++) {
+			for (let i = 0; i < ACT_DRAIN_LIMIT; i++) {
 				for (let j = 0; j < 5; j++) await Promise.resolve();
 				drainPassiveEffects();
 				if (!hasPendingWork()) return result as T;
 			}
 			throw new Error(
-				'act(): scheduler did not stabilize after 50 iterations — likely an infinite render loop',
+				`act(): scheduler did not stabilize after ${ACT_DRAIN_LIMIT} iterations — likely an infinite render loop`,
 			);
 		} finally {
 			actScopeDepth--;
@@ -2373,8 +2509,9 @@ function fireEffectCleanup(e: PendingEffect): void {
 		const cleanup = slot.cleanup;
 		slot.cleanup = undefined;
 		try {
-			cleanup();
+			runEffectCleanupCallback(cleanup);
 		} catch (err) {
+			if (err instanceof MaximumUpdateDepthError) throw err;
 			const handler = findTryHandler(e.scope.block);
 			if (handler) handler(err);
 			else console.error(err);
@@ -2386,16 +2523,17 @@ function fireEffectCleanup(e: PendingEffect): void {
 function runEffectBody(e: PendingEffect): void {
 	let cleanup: void | Cleanup;
 	try {
-		if (process.env.NODE_ENV !== 'production') EFFECT_BODY_DEPTH++;
+		EFFECT_BODY_DEPTH++;
 		try {
 			// Spread deps as positional args (see PendingEffect.args). A no-deps
 			// effect has args === undefined, so the body is called with zero args.
 			// eslint-disable-next-line prefer-spread
 			cleanup = e.fn.apply(null, (e.args ?? []) as []);
 		} finally {
-			if (process.env.NODE_ENV !== 'production') EFFECT_BODY_DEPTH--;
+			EFFECT_BODY_DEPTH--;
 		}
 	} catch (err) {
+		if (err instanceof MaximumUpdateDepthError) throw err;
 		// Route effect errors to the nearest enclosing tryBlock, if any.
 		const handler = findTryHandler(e.scope.block);
 		if (handler) handler(err);
@@ -2547,8 +2685,9 @@ function drainDeferredPassiveUnmounts(): void {
 	const q = pendingPassiveUnmounts.splice(0);
 	for (let i = 0; i < q.length; i += 2) {
 		try {
-			(q[i] as Cleanup)();
+			runEffectCleanupCallback(q[i] as Cleanup);
 		} catch (err) {
+			if (err instanceof MaximumUpdateDepthError) throw err;
 			const handler = q[i + 1] as ((err: any) => void) | null;
 			if (handler !== null) handler(err);
 			else console.error(err);
@@ -2581,14 +2720,19 @@ function drainStoreSyncs(): void {
 	// synchronously re-enter this drain; it must see only entries queued AFTER this
 	// point, never re-process the batch we already own.
 	const q = storeSyncQueue.splice(0);
-	for (let i = 0; i < q.length; i++) {
-		const inst = q[i];
-		inst.queued = false;
-		// Skip a consumer whose block was unmounted, or hidden by <Activity>, between
-		// enqueue and now — same guards the effect drains apply to effects.
-		if (inst.block.disposed || inInactiveSubtree(inst.block)) continue;
-		inst.value = inst.pending;
-		if (checkStoreChanged(inst)) inst.forceUpdate();
+	STORE_SYNC_DEPTH++;
+	try {
+		for (let i = 0; i < q.length; i++) {
+			const inst = q[i];
+			inst.queued = false;
+			// Skip a consumer whose block was unmounted, or hidden by <Activity>, between
+			// enqueue and now — same guards the effect drains apply to effects.
+			if (inst.block.disposed || inInactiveSubtree(inst.block)) continue;
+			inst.value = inst.pending;
+			if (checkStoreChanged(inst)) inst.forceUpdate();
+		}
+	} finally {
+		STORE_SYNC_DEPTH--;
 	}
 }
 
@@ -2686,6 +2830,10 @@ class BlockImpl {
 	// Render-loop guard bookkeeping (see the Block interface).
 	drainStamp: number;
 	drainRenders: number;
+	crossRenderUpdate: boolean;
+	nestedUpdateChain: number;
+	nestedUpdateCount: number;
+	nestedUpdateError: boolean;
 	effectEventRenderVersion: number;
 	effectEventCompletedVersion: number;
 	// De-opt host node managed by this Block (deoptItemBody / hostElementBody), reused
@@ -2756,6 +2904,10 @@ class BlockImpl {
 		this.__thenableIdx = 0;
 		this.drainStamp = 0;
 		this.drainRenders = 0;
+		this.crossRenderUpdate = false;
+		this.nestedUpdateChain = -1;
+		this.nestedUpdateCount = 0;
+		this.nestedUpdateError = false;
 		this.effectEventRenderVersion = 0;
 		this.effectEventCompletedVersion = 0;
 		this.deoptNode = null;
@@ -3383,7 +3535,7 @@ function unmountScope(scope: Scope, detachDom: boolean = true): void {
 				if (!passiveScheduled) schedulePassiveFlush();
 			} else {
 				try {
-					runEffectLifecycleCallback(cleanup);
+					runEffectCleanupCallback(cleanup);
 				} catch (err) {
 					reportTeardownError(err);
 				}
@@ -9958,10 +10110,10 @@ interface ChildSlot {
 	block: Block | null;
 	text: Text | null;
 	currentComp: ComponentBody | null;
-	// True when `currentComp` is a bare render-FUNCTION child (a `.tsrx` `{children}`
-	// body, whose identity changes every render) rather than a stable component
-	// reference. Lets the reconcile swap the block body in place by SLOT instead of
-	// re-mounting on every identity change (which loops when effects re-render).
+	// True when `currentComp` is a render-FUNCTION child rather than a component
+	// reference. Render bodies can change identity every parent render, so reconcile
+	// them by SLOT. Tagged compiler children additionally bail when the SAME function
+	// is passed through unchanged (see the component path below).
 	currentIsBodyFn: boolean;
 	// Non-null while the slot is rendering an ARRAY value via the de-opt keyed
 	// list path (reuses reconcileKeyed). Torn down when the value stops being an
@@ -11729,6 +11881,25 @@ export function childSlot(
 		// loops unboundedly). Component switches arrive as DESCRIPTORS (comp = value.type),
 		// never as a bare function, so this never short-circuits a real component swap.
 		if (isBodyFn && state.block !== null && state.currentIsBodyFn) {
+			// Compiler-generated children are render functions too, so a fresh parent
+			// render must still swap their body in place (preserving descendant state).
+			// But an identity-equal tagged function is the exact same cached child value:
+			// take React's implicit same-element bailout, with lazy context propagation.
+			const taggedChildren = isChildrenBlock(comp);
+			const wasImplicitlyArmed = state.block.$$implicitBail;
+			if (taggedChildren && !wasImplicitlyArmed) {
+				// The slot previously hosted an arbitrary render function. Arm before
+				// rendering the tagged body so its context reads stamp this block.
+				state.block.$$implicitBail = true;
+				state.block.memoInChain = true;
+			}
+			if (
+				wasImplicitlyArmed &&
+				taggedChildren &&
+				comp === state.currentComp &&
+				tryImplicitBail(state.block)
+			)
+				return;
 			state.block.body = comp;
 			renderBlock(state.block);
 			state.currentComp = comp;
@@ -11893,8 +12064,9 @@ export function childSlot(
 		// must stamp ancestors (memoInChain, like memo blocks) for the bail's lazy
 		// consumer refresh to be sound. Set BEFORE renderBlock so the first render
 		// stamps. Body-fn children re-create identity per render — no bail is ever
-		// possible, so they skip the stamping cost.
-		if (!isBodyFn) {
+		// possible, so untagged ones skip the stamping cost. Tagged compiler children
+		// can be passed through with stable identity and therefore need the same stamps.
+		if (!isBodyFn || isChildrenBlock(comp)) {
 			b.$$implicitBail = true;
 			b.memoInChain = true;
 		}
@@ -12181,6 +12353,9 @@ function tryMemoBail(block: Block, comp: any, props: any): boolean {
 // bailing it could strand consumers. Returns true when the update was handled.
 function tryImplicitBail(block: Block): boolean {
 	if (block.$$implicitBail !== true) return false;
+	// A first attempt that suspended or threw has no committed output to reuse.
+	// Its identity-equal retry must execute until this Block mounts successfully.
+	if (!block.mounted) return false;
 	if (ctxDirectChanged(block)) return false;
 	if (ctxDepsChanged(block)) refreshContextConsumers(block);
 	restampCtxDeps(block);
@@ -14761,8 +14936,9 @@ function deactivateScope(scope: Scope): void {
 					// no cleanup and won't re-run it.
 					e.cleanup = undefined;
 					try {
-						runEffectLifecycleCallback(cleanup);
+						runEffectCleanupCallback(cleanup);
 					} catch (err) {
+						if (err instanceof MaximumUpdateDepthError) throw err;
 						const handler = findTryHandler(scope.block);
 						if (handler !== null) handler(err);
 						else console.error(err);
@@ -16547,6 +16723,8 @@ function makeRoot(
 ): Root {
 	let root!: Root;
 	let unmounted = false;
+	let nestedRootRenderChain = -1;
+	let nestedRootRenderCount = 0;
 	const registerRootDisposer = (block: Block): void => {
 		let disposing = false;
 		DOM_ROOT_DISPOSERS.set(block, () => {
@@ -16562,6 +16740,26 @@ function makeRoot(
 	root = {
 		render(bodyOrElement: unknown, props?: any) {
 			if (unmounted) throw new Error('Cannot update an unmounted root.');
+			if (inNestedUpdateCallback() || CURRENT_BLOCK !== null) {
+				if (nestedRootRenderChain !== UPDATE_CHAIN_ID) {
+					nestedRootRenderChain = UPDATE_CHAIN_ID;
+					nestedRootRenderCount = 0;
+				}
+				if (++nestedRootRenderCount > NESTED_UPDATE_LIMIT) {
+					// Surface the failure through the ordinary render-error path on the
+					// next drain. Throwing directly here could be swallowed by effect
+					// error routing or unwind an active render replacement half-finished.
+					if (rootBlock !== null && !rootBlock.disposed) {
+						rootBlock.nestedUpdateError = true;
+						scheduleRender(rootBlock);
+					}
+					return;
+				}
+			} else {
+				UPDATE_CHAIN_ID++;
+				nestedRootRenderChain = UPDATE_CHAIN_ID;
+				nestedRootRenderCount = 0;
+			}
 			// React-style `render(<App foo={x}/>)` arrives as an element descriptor:
 			// unwrap to (type, props). The `render(body, props)` form passes through.
 			let body: ComponentBody;
@@ -16598,7 +16796,12 @@ function makeRoot(
 			// Same component as the live root (incl. a just-hydrated root): update
 			// props in place and schedule. This is a NORMAL client render — `hydrating`
 			// is already false, so renderBlock reuses the adopted DOM, not rebuilds it.
-			if (rootBlock && currentBody === body && Object.is(currentKey, nextKey)) {
+			if (
+				rootBlock &&
+				!rootBlock.disposed &&
+				currentBody === body &&
+				Object.is(currentKey, nextKey)
+			) {
 				rootBlock.props = props;
 				if (typeof __OCTANE_PROFILE_ENABLED__ !== 'undefined' && __OCTANE_PROFILE_ENABLED__)
 					__profileSchedule(rootBlock, 'root-render');
@@ -16661,6 +16864,18 @@ function makeRoot(
 		unmount() {
 			if (arguments.length > 0) warnRootUnmountArgument();
 			if (unmounted) return;
+			// A public, externally initiated unmount is a new update boundary. Its
+			// effect cleanups may schedule other live roots, and must not inherit a
+			// nearly-exhausted chain from earlier work. Nested unmounts during an
+			// active render/commit lifecycle keep the current chain instead.
+			if (
+				!inFlush &&
+				CURRENT_BLOCK === null &&
+				!inNestedUpdateCallback() &&
+				EFFECT_EVENT_LIFECYCLE_DEPTH === 0
+			) {
+				UPDATE_CHAIN_ID++;
+			}
 			if (
 				process.env.NODE_ENV !== 'production' &&
 				(inFlush ||

--- a/packages/octane/tests/_fixtures/act-warning.tsrx
+++ b/packages/octane/tests/_fixtures/act-warning.tsrx
@@ -1,4 +1,4 @@
-import { useState } from 'octane';
+import { useLayoutEffect, useState } from 'octane';
 
 // Exposes its `setN` via a module-level shim so tests can fire updates from
 // outside the component body — exactly the situation `act()` warns about.
@@ -13,4 +13,14 @@ export default function Counter() @{
 	<div class="c">
 		{n as number}
 	</div>
+}
+
+export function ActLayoutLoop() @{
+	const [value, setValue] = useState(0);
+	useLayoutEffect(() => {
+		setValue((current) => current + 1);
+	}, null);
+	<span>
+		{value as number}
+	</span>
 }

--- a/packages/octane/tests/act.test.ts
+++ b/packages/octane/tests/act.test.ts
@@ -5,9 +5,9 @@
 //   - the warning text mirrors React's so port-from-React tests recognise it
 //   - act() always returns a Promise; awaits drain microtasks + passive effects to quiescence
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { act, flushSync, setIsOctaneActEnvironment } from '../src/index.js';
+import { act, createRoot, flushSync, setIsOctaneActEnvironment } from '../src/index.js';
 import { mount } from './_helpers';
-import Counter, { bump } from './_fixtures/act-warning.tsrx';
+import Counter, { ActLayoutLoop, bump } from './_fixtures/act-warning.tsrx';
 
 describe('act() — React-parity contract', () => {
 	let errSpy: ReturnType<typeof vi.spyOn>;
@@ -82,7 +82,7 @@ describe('act() — React-parity contract', () => {
 		r.unmount();
 	});
 
-	it('actScopeDepth is correctly decremented on exception (warning still suppressed after throw)', async () => {
+	it('callback failure releases the act scope and restores outside-act warnings', async () => {
 		setIsOctaneActEnvironment(true);
 		const r = mount(Counter);
 		errSpy.mockClear();
@@ -96,6 +96,32 @@ describe('act() — React-parity contract', () => {
 		flushSync(() => {});
 		expect(errSpy).toHaveBeenCalled();
 		r.unmount();
+	});
+
+	it('a synchronous drain failure releases the act scope before rejecting', async () => {
+		setIsOctaneActEnvironment(true);
+		const counter = mount(Counter);
+		const loopContainer = document.createElement('div');
+		document.body.appendChild(loopContainer);
+		const loopRoot = createRoot(loopContainer);
+		errSpy.mockClear();
+
+		await expect(act(() => loopRoot.render(ActLayoutLoop))).rejects.toThrow(
+			/Maximum update depth exceeded/,
+		);
+
+		// A post-failure update is outside act. If the synchronous error leaked the
+		// scope depth, this diagnostic would remain incorrectly suppressed.
+		errSpy.mockClear();
+		bump();
+		flushSync(() => {});
+		expect(errSpy.mock.calls.some(([message]) => String(message).includes('not wrapped'))).toBe(
+			true,
+		);
+
+		loopRoot.unmount();
+		loopContainer.remove();
+		counter.unmount();
 	});
 
 	it('nested act() — inner failure does not unbalance the outer scope', async () => {

--- a/packages/octane/tests/conformance/_fixtures/external-store-shared.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/external-store-shared.tsrx
@@ -1,0 +1,229 @@
+import { useEffect, useLayoutEffect, useState, useSyncExternalStore } from 'octane';
+
+export function createExternalStore(initialState) {
+	let currentState = initialState;
+	const listeners = new Set();
+	return {
+		set(nextState) {
+			currentState = nextState;
+			for (const listener of [...listeners]) listener();
+		},
+		subscribe(listener) {
+			listeners.add(listener);
+			return () => listeners.delete(listener);
+		},
+		getState() {
+			return currentState;
+		},
+		getSubscriberCount() {
+			return listeners.size;
+		},
+	};
+}
+
+export const controls = {
+	setStore: null,
+	setStep: null,
+	setGetSnapshot: null,
+};
+
+export function BasicReader(props) @{
+	const value = useSyncExternalStore(props.store.subscribe, props.store.getState);
+	useLayoutEffect(() => {
+		if (props.commitProbe) props.commitProbe.value = value;
+	}, null);
+	<span id="basic-store-value">
+		{value as string}
+	</span>
+}
+
+export function SwappableReader(props) @{
+	const [store, setStore] = useState(props.store);
+	controls.setStore = setStore;
+	const value = useSyncExternalStore(store.subscribe, store.getState);
+	<span id="swappable-store-value">
+		{value as string}
+	</span>
+}
+
+function SelectedA(props) @{
+	const value = useSyncExternalStore(props.store.subscribe, () => props.store.getState().a);
+	useLayoutEffect(() => {
+		props.probe.value = 'A' + value;
+	}, null);
+	<span id="selected-a">
+		{'A' + value}
+	</span>
+}
+
+function SelectedB(props) @{
+	const value = useSyncExternalStore(props.store.subscribe, () => props.store.getState().b);
+	useLayoutEffect(() => {
+		props.probe.value = 'B' + value;
+	}, null);
+	<span id="selected-b">
+		{'B' + value}
+	</span>
+}
+
+export function SelectedPair(props) @{
+	<div>
+		<SelectedA store={props.store} probe={props.aProbe} />
+		<SelectedB store={props.store} probe={props.bProbe} />
+	</div>
+}
+
+function CommitMutator(props) @{
+	const value = useSyncExternalStore(props.store.subscribe, props.store.getState);
+	useLayoutEffect(() => {
+		if (props.step === 1) {
+			props.store.set({ a: value.a, b: 2 });
+		}
+	}, [props.step]);
+	<span hidden />
+}
+
+function ChangingSelection(props) @{
+	const label =
+		props.step === 0 ? 'A' : 'B';
+	const getSnapshot =
+		props.step === 0 ? props.getSnapshotA : props.getSnapshotB;
+	const value = useSyncExternalStore(props.store.subscribe, getSnapshot);
+	<span id="commit-selection">
+		{label + value}
+	</span>
+}
+
+export function SelectionChangeDuringCommit(props) @{
+	const [step, setStep] = useState(0);
+	controls.setStep = setStep;
+	<div>
+		<CommitMutator store={props.store} step={step} />
+		<ChangingSelection
+			store={props.store}
+			step={step}
+			getSnapshotA={props.getSnapshotA}
+			getSnapshotB={props.getSnapshotB}
+		/>
+	</div>
+}
+
+function StableSelection(props) @{
+	const value = useSyncExternalStore(props.store.subscribe, props.getSnapshotA);
+	useLayoutEffect(() => {
+		if (props.commitProbe.lastStep === props.step) {
+			props.commitProbe.repeatedStep = props.step;
+		} else {
+			props.commitProbe.lastStep = props.step;
+		}
+	}, null);
+	<span id="stable-commit-selection">
+		{'A' + value}
+	</span>
+}
+
+export function StableSelectionDuringCommit(props) @{
+	const [step, setStep] = useState(0);
+	controls.setStep = setStep;
+	<div>
+		<CommitMutator store={props.store} step={step} />
+		<StableSelection
+			store={props.store}
+			getSnapshotA={props.getSnapshotA}
+			step={step}
+			commitProbe={props.commitProbe}
+		/>
+	</div>
+}
+
+function ResettingReader(props) @{
+	const value = useSyncExternalStore(props.store.subscribe, props.store.getState);
+	useLayoutEffect(() => {
+		if (value === 1) {
+			props.store.set(0);
+		}
+	}, [value]);
+	<span class="reset-reader">
+		{value as string}
+	</span>
+}
+
+function PlainReader(props) @{
+	const value = useSyncExternalStore(props.store.subscribe, props.store.getState);
+	<span class="plain-reader">
+		{value as string}
+	</span>
+}
+
+export function ResetDuringCommit(props) @{
+	<div id="reset-pair">
+		<ResettingReader store={props.store} />
+		<PlainReader store={props.store} />
+	</div>
+}
+
+export function LatestSnapshotReader(props) @{
+	const [getSnapshot, setGetSnapshot] = useState(() => props.getSnapshotA);
+	controls.setGetSnapshot = setGetSnapshot;
+	const value = useSyncExternalStore(props.store.subscribe, getSnapshot);
+	<span id="latest-snapshot">
+		{value as string}
+	</span>
+}
+
+function ThrowingSnapshotReader(props) @{
+	const value = useSyncExternalStore(props.store.subscribe, () => {
+		const state = props.store.getState();
+		if (state.throwInGetSnapshot) throw new Error('Error in getSnapshot');
+		return state.value;
+	});
+	<span id="throwing-snapshot-value">
+		{value as string}
+	</span>
+}
+
+export function SnapshotErrorBoundary(props) @{
+	@try {
+		<ThrowingSnapshotReader store={props.store} />
+	} @catch (error) {
+		<span id="snapshot-error">
+			{error.message as string}
+		</span>
+	}
+}
+
+export function UncachedSnapshotReader(props) @{
+	const value = useSyncExternalStore(props.store.subscribe, () => ({}));
+	<span id="uncached-snapshot">{JSON.stringify(value)}</span>
+}
+
+export function NumberSnapshotReader(props) @{
+	const value = useSyncExternalStore(
+		props.store.subscribe,
+		() => parseInt(props.store.getState(), 10),
+	);
+	<span id="number-snapshot">
+		{value as string}
+	</span>
+}
+
+export function DerivedSnapshotReader(props) @{
+	const value = useSyncExternalStore(props.store.subscribe, props.store.getState);
+	const [derivedValue, setDerivedValue] = useState(value);
+	useEffect(() => {}, []);
+	if (derivedValue !== value.toUpperCase()) setDerivedValue(value.toUpperCase());
+	<span id="derived-snapshot">
+		{derivedValue as string}
+	</span>
+}
+
+export function HydrationStoreReader(props) @{
+	const value = useSyncExternalStore(
+		props.store.subscribe,
+		props.store.getState,
+		props.store.getServerState,
+	);
+	<div id="hydrated-store" ref={props.hostRef}>
+		{value as string}
+	</div>
+}

--- a/packages/octane/tests/conformance/_fixtures/update-reconciliation.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/update-reconciliation.tsrx
@@ -1,0 +1,546 @@
+import {
+	createContext,
+	flushSync,
+	memo,
+	use,
+	useContext,
+	useEffect,
+	useLayoutEffect,
+	useReducer,
+	useState,
+} from 'octane';
+
+let _setFirst: any = null;
+let _setSecond: any = null;
+let _setParent: any = null;
+let _setChild: any = null;
+let _setCrossRootA: any = null;
+let _setCrossRootB: any = null;
+let _setDeleteParent: any = null;
+let _setDeleteChild: any = null;
+let _setMemoChild: any = null;
+let _setNestedEffectStep: any = null;
+let _setFiniteLayoutStep: any = null;
+let _setFunctionSwitchMode: any = null;
+let _bumpFunctionSwitch: any = null;
+let _setFunctionSwitchContext: any = null;
+let _bumpExternalUnmountTarget: any = null;
+
+export function setFirst(value: any) {
+	_setFirst(value);
+}
+export function setSecond(value: any) {
+	_setSecond(value);
+}
+export function setParent(value: any) {
+	_setParent(value);
+}
+export function setChild(value: any) {
+	_setChild(value);
+}
+export function setCrossRootA(value: any) {
+	_setCrossRootA(value);
+}
+export function setCrossRootB(value: any) {
+	_setCrossRootB(value);
+}
+export function setDeleteParent(value: any) {
+	_setDeleteParent(value);
+}
+export function setDeleteChild(value: any) {
+	_setDeleteChild(value);
+}
+export function setMemoChild(value: any) {
+	_setMemoChild(value);
+}
+export function setNestedEffectStep(value: any) {
+	_setNestedEffectStep(value);
+}
+export function setFiniteLayoutStep(value: any) {
+	_setFiniteLayoutStep(value);
+}
+export function showTaggedFunctionChildren() {
+	_setFunctionSwitchMode(true);
+}
+export function bumpFunctionSwitch() {
+	_bumpFunctionSwitch((value: number) => value + 1);
+}
+export function setFunctionSwitchContext(value: string) {
+	_setFunctionSwitchContext(value);
+}
+export function bumpExternalUnmountTarget() {
+	_bumpExternalUnmountTarget((value: number) => value + 1);
+}
+
+export function BatchedPair(props) @{
+	const [first, setFirst] = useState(0);
+	const [second, setSecond] = useState(0);
+	_setFirst = setFirst;
+	_setSecond = setSecond;
+	useLayoutEffect(() => {
+		props.log(`${props.label}:${first},${second}`);
+	}, [props.label, first, second]);
+	<div id="pair" data-label={props.label as string}>
+		<span id="first">
+			{first as number}
+		</span>
+		<span id="second">
+			{second as number}
+		</span>
+	</div>
+}
+
+function BatchedChild(props) @{
+	const [child, setChild] = useState(0);
+	_setChild = setChild;
+	useLayoutEffect(() => {
+		props.log(`child:${props.parent},${child}`);
+	}, [props.parent, child]);
+	<span id="child-value">{`${props.parent},${child}`}</span>
+}
+
+export function BatchedParentChild(props) @{
+	const [parent, setParent] = useState(0);
+	_setParent = setParent;
+	useLayoutEffect(() => {
+		props.log(`parent:${parent}`);
+	}, [parent]);
+	<div id="parent-value">
+		{parent as number}
+		<BatchedChild parent={parent} log={props.log} />
+	</div>
+}
+
+function MemoChild(props) @{
+	const [value, setValue] = useState(0);
+	_setMemoChild = setValue;
+	useLayoutEffect(() => {
+		props.log(`child:${value}`);
+	}, [value]);
+	<span id="memo-child">
+		{value as number}
+	</span>
+}
+
+function MemoParentBody(props) @{
+	useLayoutEffect(() => {
+		props.log(`parent:${props.label}`);
+	}, null);
+	<div id="memo-parent">
+		<MemoChild log={props.log} />
+	</div>
+}
+
+const MemoParent = memo(MemoParentBody);
+
+export function MemoParentHost(props) @{
+	const [tick, setTick] = useState(0);
+	<div data-tick={tick as number}>
+		<button id="memo-parent-update" onClick={() => setTick(tick + 1)}>{'parent'}</button>
+		<MemoParent label="stable" log={props.log} />
+	</div>
+}
+
+function StableBottom(props) @{
+	useLayoutEffect(() => {
+		props.log('bottom');
+	}, null);
+	<span id="stable-bottom">{'stable'}</span>
+}
+
+function StableMiddle(props) {
+	const [step, setStep] = useState(0);
+	useLayoutEffect(() => {
+		props.log(`middle:${step}`);
+		if (step === 0) setStep(1);
+	}, [step]);
+	return props.children;
+}
+
+export function StableChildrenHost(props) @{
+	<StableMiddle log={props.log}>
+		<StableBottom log={props.log} />
+	</StableMiddle>
+}
+
+function StableRetryLeaf(props) {
+	const value = use(props.promise);
+	return <span id="stable-retry-value">
+		{value as string}
+	</span>;
+}
+
+function StableRetryShell(props) @{
+	<>
+		@try {
+			<>
+				{props.children}
+			</>
+		} @pending {
+			<span id="stable-retry-pending">{'loading'}</span>
+		}
+	</>
+}
+
+export function StableChildrenSuspenseRetry(props) @{
+	<StableRetryShell>
+		<StableRetryLeaf promise={props.promise} />
+	</StableRetryShell>
+}
+
+const FunctionSwitchContext = createContext('initial');
+
+function FunctionSwitchConsumer(props) @{
+	const value = useContext(FunctionSwitchContext);
+	useLayoutEffect(() => {
+		props.log(`switch-consumer:${value}`);
+	}, null);
+	<span id="function-switch-consumer">{value}</span>
+}
+
+function FunctionSwitchPassthrough(props) {
+	const [, setTick] = useState(0);
+	_bumpFunctionSwitch = setTick;
+	return props.tagged ? props.taggedChild : props.initialChild;
+}
+
+function FunctionSwitchShell(props) @{
+	const [tagged, setTagged] = useState(false);
+	const [value, setValue] = useState('initial');
+	_setFunctionSwitchMode = setTagged;
+	_setFunctionSwitchContext = setValue;
+	<FunctionSwitchContext.Provider value={value}>
+		<FunctionSwitchPassthrough
+			tagged={tagged}
+			taggedChild={props.children}
+			initialChild={props.initialChild}
+		/>
+	</FunctionSwitchContext.Provider>
+}
+
+export function FunctionToTaggedChildrenHost(props) @{
+	<FunctionSwitchShell initialChild={() => <span id="function-switch-initial">{'initial'}</span>}>
+		<FunctionSwitchConsumer log={props.log} />
+	</FunctionSwitchShell>
+}
+
+export function CrossRootA(props) @{
+	const [value, setValue] = useState(0);
+	_setCrossRootA = setValue;
+	useLayoutEffect(() => {
+		if (value === 1) props.log(`a-sees:${props.other.textContent}`);
+	}, [value]);
+	<span id="cross-a">{`A${value}`}</span>
+}
+
+export function CrossRootB() @{
+	const [value, setValue] = useState(0);
+	_setCrossRootB = setValue;
+	<span id="cross-b">{`B${value}`}</span>
+}
+
+function DeleteChild(props) @{
+	const [value, setValue] = useState(0);
+	_setDeleteChild = setValue;
+	useLayoutEffect(() => {
+		props.log(`child:${value}`);
+	}, [value]);
+	<span id="delete-child">
+		{value as number}
+	</span>
+}
+
+export function DeletePendingChild(props) @{
+	const [show, setShow] = useState(true);
+	_setDeleteParent = setShow;
+	<div>
+		{show ? <DeleteChild log={props.log} /> : <span id="deleted">{'deleted'}</span>}
+	</div>
+}
+
+export function ReentrantEditor(props) @{
+	useLayoutEffect(() => {
+		if (!props.rendered) props.onChange();
+	}, [props.rendered]);
+	<div id="editor">
+		{props.text as string}
+	</div>
+}
+
+const _renderPhaseBases: string[] = [];
+
+export function resetRenderPhaseBases() {
+	_renderPhaseBases.length = 0;
+}
+export function getRenderPhaseBases() {
+	return _renderPhaseBases.slice();
+}
+
+export function RenderPhaseBaseState() @{
+	const [step, setStep] = useState(0);
+	const memoizedStep = step;
+	setStep((baseStep: number) => {
+		_renderPhaseBases.push(`base:${baseStep},memoized:${memoizedStep}`);
+		return baseStep === 0 ? 1 : baseStep;
+	});
+	<span id="render-phase-base">
+		{step as number}
+	</span>
+}
+
+export function HiddenSubtree(props) @{
+	<div id="hidden-owner" hidden>
+		<span id="hidden-value">
+			{props.value as string}
+		</span>
+	</div>
+}
+
+export function IndependentCell(props) @{
+	const [value, setValue] = useState(0);
+	useEffect(() => {
+		if (props.trigger) setValue(1);
+	}, [props.trigger]);
+	<span class="independent-cell">
+		{value as number}
+	</span>
+}
+
+export function ManyRootsSpawner(props) @{
+	useLayoutEffect(() => {
+		props.spawn();
+	}, []);
+	<span id="root-spawner">{'spawned'}</span>
+}
+
+function BatchCell(props) @{
+	const [value, setValue] = useState(0);
+	props.capture(props.id, setValue);
+	<span class="batch-cell" data-id={props.id as number}>
+		{value as number}
+	</span>
+}
+
+export function ManyBatchCells(props) @{
+	<div id="many-batch-cells">
+		@for (const id of props.ids; key id) {
+			<BatchCell id={id} capture={props.capture} />
+		}
+	</div>
+}
+
+export function LayoutEffectLoop() @{
+	const [step, setStep] = useState(0);
+	useLayoutEffect(() => {
+		setStep((value: number) => value + 1);
+	}, null);
+	<span>
+		{step as number}
+	</span>
+}
+
+export function LayoutCleanupLoop() @{
+	const [step, setStep] = useState(0);
+	useLayoutEffect(() => {
+		return () => setStep((value: number) => value + 1);
+	}, [step]);
+	useLayoutEffect(() => {
+		setStep(1);
+	}, []);
+	<span>
+		{step as number}
+	</span>
+}
+
+export function PassiveCleanupLoop() @{
+	const [step, setStep] = useState(0);
+	useEffect(() => {
+		return () => setStep((value: number) => value + 1);
+	}, [step]);
+	useEffect(() => {
+		setStep(1);
+	}, []);
+	<span>
+		{step as number}
+	</span>
+}
+
+export function MixedLayoutRenderLoop() @{
+	const [step, setStep] = useState(0);
+	const [derived, setDerived] = useState(-1);
+	if (derived !== step) setDerived(step);
+	useLayoutEffect(() => {
+		setStep((value: number) => value + 1);
+	}, [derived]);
+	<span>{`${step}:${derived}`}</span>
+}
+
+function CoalescedLoopChild(props) @{
+	const [step, setStep] = useState(0);
+	useLayoutEffect(() => {
+		if (step < 50) {
+			setStep(step + 1);
+		} else if (step === 50) {
+			props.bumpParent();
+			setStep(51);
+		}
+	}, null);
+	<span>{`${props.parent}:${step}`}</span>
+}
+
+export function CoalescedParentChildLoop() @{
+	const [parent, setParent] = useState(0);
+	<CoalescedLoopChild parent={parent} bumpParent={() => setParent((value: number) => value + 1)} />
+}
+
+function CrossComponentLoopChild(props) {
+	props.update((value: number) => value + 1);
+	return null;
+}
+
+export function CrossComponentRenderLoop() @{
+	const [, setValue] = useState(0);
+	<CrossComponentLoopChild update={setValue} />
+}
+
+function CrossComponentAsyncLoopChild(props) {
+	props.update((value: number) => value + 1);
+	return null;
+}
+
+export function CrossComponentAsyncRenderLoop() @{
+	const [, setValue] = useState(0);
+	<CrossComponentAsyncLoopChild update={setValue} />
+}
+
+export function NestedEffectUpdates(props) @{
+	const [step, setStep] = useState(0);
+	_setNestedEffectStep = setStep;
+	useEffect(() => {
+		if (step < props.limit) setStep((value: number) => value + 1);
+	}, null);
+	<span id="nested-effect-step">
+		{step as number}
+	</span>
+}
+
+export function ExternalUnmountCleanupSource(props) @{
+	useLayoutEffect(() => {
+		return () => props.bumpTarget();
+	}, []);
+	<span id="external-unmount-source">{'source'}</span>
+}
+
+export function ExternalUnmountTarget() @{
+	const [step, setStep] = useState(0);
+	_bumpExternalUnmountTarget = setStep;
+	useEffect(() => {
+		if (step < 50) setStep((value: number) => value + 1);
+	}, null);
+	<span id="external-unmount-target">
+		{step as number}
+	</span>
+}
+
+export function ManyUpdatesInOneEffect() @{
+	const [step, setStep] = useState(0);
+	useEffect(() => {
+		for (let i = 0; i < 1000; i++) setStep((value: number) => value + 1);
+	}, []);
+	<span id="many-effect-updates">
+		{step as number}
+	</span>
+}
+
+export function SynchronousPassiveEffectLoop() @{
+	const [step, setStep] = useState(0);
+	useEffect(() => {
+		flushSync(() => setStep(step + 1));
+	}, [step]);
+	<span>
+		{step as number}
+	</span>
+}
+
+export function RefCallbackLoop() @{
+	const [count, dispatch] = useReducer((value: number) => value + 1, 0);
+	<div
+		ref={() => {
+			for (let i = 0; i < 50; i++) dispatch(1);
+		}}
+	>
+		{count as number}
+	</div>
+}
+
+export function FiniteLayoutChain(props) @{
+	const [step, setStep] = useState(0);
+	_setFiniteLayoutStep = setStep;
+	useLayoutEffect(() => {
+		if (step < props.limit) setStep((value: number) => value + 1);
+	}, null);
+	<span id="finite-layout-step">
+		{step as number}
+	</span>
+}
+
+export function OneStepLayoutUpdate() @{
+	const [step, setStep] = useState(0);
+	useLayoutEffect(() => {
+		if (step === 0) setStep(1);
+	}, null);
+	<span id="one-step-layout">
+		{step as number}
+	</span>
+}
+
+function AlwaysThrows() @{
+	throw new Error('error loop');
+	<span>{'unreachable'}</span>
+}
+
+function RemountAfterError(props) @{
+	useLayoutEffect(() => {
+		props.remount();
+	}, []);
+	<span data-error={props.message as string}>{'recovering'}</span>
+}
+
+export function ErrorRecoveryLoop() @{
+	const [attempt, setAttempt] = useState(0);
+	<div data-attempt={attempt as number}>
+		@try {
+			<AlwaysThrows key={attempt} />
+		} @catch (err) {
+			<RemountAfterError
+				key={attempt}
+				message={err.message}
+				remount={() => setAttempt((value: number) => value + 1)}
+			/>
+		}
+	</div>
+}
+
+export function RootLoopA(props) @{
+	useLayoutEffect(() => {
+		props.swap('b');
+	}, []);
+	<span>{'a'}</span>
+}
+
+export function RootLoopB(props) @{
+	useLayoutEffect(() => {
+		props.swap('a');
+	}, []);
+	<span>{'b'}</span>
+}
+
+export function RenderRootLoopA(props) @{
+	props.swap('b');
+	<span>{'render-a'}</span>
+}
+
+export function RenderRootLoopB(props) @{
+	props.swap('a');
+	<span>{'render-b'}</span>
+}

--- a/packages/octane/tests/conformance/external-store-shared.test.ts
+++ b/packages/octane/tests/conformance/external-store-shared.test.ts
@@ -1,0 +1,277 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { act, createRoot, drainPassiveEffects, flushSync, hydrateRoot } from '../../src/index.js';
+import * as ServerRuntime from 'octane/server';
+import { flushEffects, mount } from '../_helpers.js';
+import { loadServerFixture } from '../_server-fixture.js';
+import {
+	BasicReader,
+	DerivedSnapshotReader,
+	HydrationStoreReader,
+	LatestSnapshotReader,
+	NumberSnapshotReader,
+	ResetDuringCommit,
+	SelectedPair,
+	SelectionChangeDuringCommit,
+	SnapshotErrorBoundary,
+	StableSelectionDuringCommit,
+	SwappableReader,
+	UncachedSnapshotReader,
+	controls,
+	createExternalStore,
+} from './_fixtures/external-store-shared.tsrx';
+
+const FIXTURE = 'packages/octane/tests/conformance/_fixtures/external-store-shared.tsrx';
+const server = loadServerFixture(FIXTURE);
+const looseContainers: HTMLElement[] = [];
+
+afterEach(() => {
+	for (const container of looseContainers.splice(0)) container.remove();
+	controls.setStore = null;
+	controls.setStep = null;
+	controls.setGetSnapshot = null;
+});
+
+function flushStoreUpdate(run: () => void): void {
+	flushSync(run);
+	flushEffects();
+}
+
+describe('Shared useSyncExternalStore behavior', () => {
+	// Per useSyncExternalStoreShared-test.js:133 (stable and canary).
+	it('basic usage', () => {
+		const store = createExternalStore('Initial');
+		const root = mount(BasicReader, { store });
+		flushEffects();
+		expect(root.find('#basic-store-value').textContent).toBe('Initial');
+		expect(store.getSubscriberCount()).toBe(1);
+
+		flushStoreUpdate(() => store.set('Updated'));
+		expect(root.find('#basic-store-value').textContent).toBe('Updated');
+		root.unmount();
+	});
+
+	// Per useSyncExternalStoreShared-test.js:152 (stable and canary).
+	it('skips re-rendering if nothing changes', () => {
+		const store = createExternalStore('Initial');
+		const commitProbe = { value: '' };
+		const root = mount(BasicReader, { store, commitProbe });
+		flushEffects();
+		expect(commitProbe.value).toBe('Initial');
+
+		commitProbe.value = 'untouched';
+		flushStoreUpdate(() => store.set('Initial'));
+		// The Object.is-equal snapshot does not commit another render: an explicit
+		// every-render layout probe remains untouched.
+		expect(commitProbe.value).toBe('untouched');
+		expect(root.find('#basic-store-value').textContent).toBe('Initial');
+		root.unmount();
+	});
+
+	// Per useSyncExternalStoreShared-test.js:174 (stable and canary).
+	it('switch to a different store', () => {
+		const storeA = createExternalStore(0);
+		const storeB = createExternalStore(0);
+		const root = mount(SwappableReader, { store: storeA });
+		flushEffects();
+
+		flushStoreUpdate(() => storeA.set(1));
+		expect(root.find('#swappable-store-value').textContent).toBe('1');
+
+		flushStoreUpdate(() => {
+			storeA.set(2);
+			controls.setStore(storeB);
+		});
+		expect(root.find('#swappable-store-value').textContent).toBe('0');
+		expect(storeA.getSubscriberCount()).toBe(0);
+		expect(storeB.getSubscriberCount()).toBe(1);
+
+		flushStoreUpdate(() => storeA.set(3));
+		expect(root.find('#swappable-store-value').textContent).toBe('0');
+		flushStoreUpdate(() => storeB.set(1));
+		expect(root.find('#swappable-store-value').textContent).toBe('1');
+		root.unmount();
+	});
+
+	// Per useSyncExternalStoreShared-test.js:224 (stable and canary).
+	it('selecting a specific value inside getSnapshot', () => {
+		const store = createExternalStore({ a: 0, b: 0 });
+		const aProbe = { value: '' };
+		const bProbe = { value: '' };
+		const root = mount(SelectedPair, { store, aProbe, bProbe });
+		flushEffects();
+		expect(aProbe.value).toBe('A0');
+		expect(bProbe.value).toBe('B0');
+
+		aProbe.value = 'untouched';
+		bProbe.value = 'untouched';
+		flushStoreUpdate(() => store.set({ a: 0, b: 1 }));
+		expect(root.container.textContent).toBe('A0B1');
+		expect(aProbe.value).toBe('untouched');
+		expect(bProbe.value).toBe('B1');
+
+		aProbe.value = 'untouched';
+		bProbe.value = 'untouched';
+		flushStoreUpdate(() => store.set({ a: 1, b: 1 }));
+		expect(root.container.textContent).toBe('A1B1');
+		expect(aProbe.value).toBe('A1');
+		expect(bProbe.value).toBe('untouched');
+		root.unmount();
+	});
+
+	// Per useSyncExternalStoreShared-test.js:324 (stable and canary).
+	it('mutating the store in between render and commit when getSnapshot has changed', () => {
+		const store = createExternalStore({ a: 1, b: 1 });
+		const getSnapshotA = () => store.getState().a;
+		const getSnapshotB = () => store.getState().b;
+		const root = mount(SelectionChangeDuringCommit, {
+			store,
+			getSnapshotA,
+			getSnapshotB,
+		});
+		flushEffects();
+		expect(root.find('#commit-selection').textContent).toBe('A1');
+
+		flushSync(() => controls.setStep(1));
+		expect(root.find('#commit-selection').textContent).toBe('B2');
+		expect(store.getState()).toEqual({ a: 1, b: 2 });
+		root.unmount();
+	});
+
+	// Per useSyncExternalStoreShared-test.js:389 (stable and canary).
+	it('mutating the store in between render and commit when getSnapshot has _not_ changed', () => {
+		const store = createExternalStore({ a: 1, b: 1 });
+		const getSnapshotA = () => store.getState().a;
+		const commitProbe = { lastStep: null as number | null, repeatedStep: null as number | null };
+		const root = mount(StableSelectionDuringCommit, {
+			store,
+			getSnapshotA,
+			commitProbe,
+		});
+		flushEffects();
+		expect(root.find('#stable-commit-selection').textContent).toBe('A1');
+		expect(commitProbe).toEqual({ lastStep: 0, repeatedStep: null });
+
+		flushSync(() => controls.setStep(1));
+		expect(root.find('#stable-commit-selection').textContent).toBe('A1');
+		expect(store.getState()).toEqual({ a: 1, b: 2 });
+		// The parent step causes one required commit. Since B changed but the selected
+		// A snapshot did not, the store notification must not cause a second step-1 commit.
+		expect(commitProbe).toEqual({ lastStep: 1, repeatedStep: null });
+		root.unmount();
+	});
+
+	// Per useSyncExternalStoreShared-test.js:454 (stable and canary).
+	it("does not bail out if the previous update hasn't finished yet", () => {
+		const store = createExternalStore(0);
+		const root = mount(ResetDuringCommit, { store });
+		flushEffects();
+		expect(root.find('#reset-pair').textContent).toBe('00');
+
+		flushSync(() => store.set(1));
+		expect(root.find('#reset-pair').textContent).toBe('00');
+		expect(store.getState()).toBe(0);
+		root.unmount();
+	});
+
+	// Per useSyncExternalStoreShared-test.js:494 (stable and canary).
+	it('uses the latest getSnapshot, even if it changed in the same batch as a store update', () => {
+		const store = createExternalStore({ a: 0, b: 0 });
+		const getSnapshotA = () => store.getState().a;
+		const getSnapshotB = () => store.getState().b;
+		const root = mount(LatestSnapshotReader, { store, getSnapshotA });
+		flushEffects();
+		expect(root.find('#latest-snapshot').textContent).toBe('0');
+
+		flushStoreUpdate(() => {
+			controls.setGetSnapshot(() => getSnapshotB);
+			store.set({ a: 1, b: 2 });
+		});
+		expect(root.find('#latest-snapshot').textContent).toBe('2');
+		root.unmount();
+	});
+
+	// Per useSyncExternalStoreShared-test.js:529 (stable and canary). React's
+	// class ErrorBoundary is adapted to Octane's function-component @try/@catch.
+	it('handles errors thrown by getSnapshot', () => {
+		const store = createExternalStore({ value: 0, throwInGetSnapshot: false });
+		const root = mount(SnapshotErrorBoundary, { store });
+		flushEffects();
+		expect(root.find('#throwing-snapshot-value').textContent).toBe('0');
+
+		flushStoreUpdate(() => store.set({ value: 1, throwInGetSnapshot: true }));
+		expect(root.find('#snapshot-error').textContent).toBe('Error in getSnapshot');
+		expect(store.getSubscriberCount()).toBe(0);
+		root.unmount();
+	});
+
+	// Per useSyncExternalStoreShared-test.js:615 (stable and canary).
+	it('Infinite loop if getSnapshot keeps returning new reference', async () => {
+		const store = createExternalStore({});
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		looseContainers.push(container);
+		const root = createRoot(container);
+
+		await expect(async () => {
+			await act(() => root.render(UncachedSnapshotReader, { store }));
+		}).rejects.toThrow(/Maximum update depth exceeded/);
+		root.unmount();
+	});
+
+	// Per useSyncExternalStoreShared-test.js:652 (stable), :656 (canary).
+	it('getSnapshot can return NaN without infinite loop warning', () => {
+		const store = createExternalStore('not a number');
+		const root = mount(NumberSnapshotReader, { store });
+		flushEffects();
+		expect(root.find('#number-snapshot').textContent).toBe('NaN');
+
+		flushStoreUpdate(() => store.set(123));
+		expect(root.find('#number-snapshot').textContent).toBe('123');
+		flushStoreUpdate(() => store.set('not a number'));
+		expect(root.find('#number-snapshot').textContent).toBe('NaN');
+		root.unmount();
+	});
+
+	// Per useSyncExternalStoreShared-test.js:797 (stable), :801 (canary).
+	it('basic server hydration', () => {
+		const store = {
+			...createExternalStore('client'),
+			getServerState: () => 'server',
+		};
+		const { html } = ServerRuntime.renderToString(server.HydrationStoreReader, {
+			store,
+			hostRef: null,
+		});
+		expect(html).toBe('<div id="hydrated-store">server</div>');
+
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		looseContainers.push(container);
+		container.innerHTML = html;
+		const serverNode = container.firstElementChild;
+		const hostRef = { current: null as Element | null };
+		const root = hydrateRoot(container, HydrationStoreReader, { store, hostRef });
+		expect(container.firstElementChild).toBe(serverNode);
+		expect(container.textContent).toBe('server');
+
+		flushSync(() => {});
+		drainPassiveEffects();
+		flushSync(() => {});
+		expect(container.firstElementChild).toBe(serverNode);
+		expect(hostRef.current).toBe(serverNode);
+		expect(container.textContent).toBe('client');
+		root.unmount();
+	});
+
+	// Per useSyncExternalStoreShared-test.js:849 (stable), :858 (canary).
+	it('regression test for #23150', () => {
+		const store = createExternalStore('Initial');
+		const root = mount(DerivedSnapshotReader, { store });
+		flushEffects();
+		expect(root.find('#derived-snapshot').textContent).toBe('INITIAL');
+
+		flushStoreUpdate(() => store.set('Updated'));
+		expect(root.find('#derived-snapshot').textContent).toBe('UPDATED');
+		root.unmount();
+	});
+});

--- a/packages/octane/tests/conformance/update-reconciliation.test.ts
+++ b/packages/octane/tests/conformance/update-reconciliation.test.ts
@@ -1,0 +1,572 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, createRoot, flushSync, startTransition, type Root } from '../../src/index.js';
+import { createLog, mount } from '../_helpers';
+import * as Fixture from './_fixtures/update-reconciliation.tsrx';
+
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((res) => {
+		resolve = res;
+	});
+	return { promise, resolve };
+}
+
+function ownedContainer(): HTMLElement {
+	const container = document.createElement('div');
+	document.body.appendChild(container);
+	return container;
+}
+
+function removeRoot(root: Root, container: HTMLElement): void {
+	root.unmount();
+	container.remove();
+}
+
+beforeEach(() => {
+	Fixture.resetRenderPhaseBases();
+});
+
+describe('ReactUpdates update reconciliation', () => {
+	// Per ReactUpdates-test.js:69.
+	it('should batch state when updating state twice', () => {
+		const log = createLog();
+		const r = mount(Fixture.BatchedPair, { label: 'initial', log: log.push });
+		expect(log.drain()).toEqual(['initial:0,0']);
+
+		flushSync(() => {
+			Fixture.setFirst(1);
+			Fixture.setFirst(2);
+			expect(r.find('#first').textContent).toBe('0');
+		});
+
+		expect(r.find('#first').textContent).toBe('2');
+		expect(log.drain()).toEqual(['initial:2,0']);
+		r.unmount();
+	});
+
+	// Per ReactUpdates-test.js:106.
+	it('should batch state when updating two different states', () => {
+		const log = createLog();
+		const r = mount(Fixture.BatchedPair, { label: 'initial', log: log.push });
+		log.clear();
+
+		flushSync(() => {
+			Fixture.setFirst(1);
+			Fixture.setSecond(2);
+			expect(r.find('#pair').textContent).toBe('00');
+		});
+
+		expect(r.find('#pair').textContent).toBe('12');
+		expect(log.drain()).toEqual(['initial:1,2']);
+		r.unmount();
+	});
+
+	// Per ReactUpdates-test.js:155.
+	it('should batch state and props together', () => {
+		const log = createLog();
+		const container = ownedContainer();
+		const root = createRoot(container);
+		root.render(Fixture.BatchedPair, { label: 'old', log: log.push });
+		flushSync(() => {});
+		log.clear();
+
+		flushSync(() => {
+			root.render(Fixture.BatchedPair, { label: 'new', log: log.push });
+			Fixture.setSecond(2);
+			expect(container.querySelector('#pair')!.getAttribute('data-label')).toBe('old');
+			expect(container.querySelector('#second')!.textContent).toBe('0');
+		});
+
+		expect(container.querySelector('#pair')!.getAttribute('data-label')).toBe('new');
+		expect(container.querySelector('#second')!.textContent).toBe('2');
+		expect(log.drain()).toEqual(['new:0,2']);
+		removeRoot(root, container);
+	});
+
+	// Per ReactUpdates-test.js:201.
+	it('should batch parent/child state updates together', () => {
+		const log = createLog();
+		const r = mount(Fixture.BatchedParentChild, { log: log.push });
+		log.clear();
+
+		flushSync(() => {
+			Fixture.setParent(1);
+			Fixture.setChild(2);
+			expect(r.find('#child-value').textContent).toBe('0,0');
+		});
+
+		expect(r.find('#child-value').textContent).toBe('1,2');
+		expect(log.drain()).toEqual(['child:1,2', 'parent:1']);
+		r.unmount();
+	});
+
+	// Per ReactUpdates-test.js:268.
+	it('should batch child/parent state updates together', () => {
+		const log = createLog();
+		const r = mount(Fixture.BatchedParentChild, { log: log.push });
+		log.clear();
+
+		flushSync(() => {
+			Fixture.setChild(2);
+			Fixture.setParent(1);
+			expect(r.find('#child-value').textContent).toBe('0,0');
+		});
+
+		expect(r.find('#child-value').textContent).toBe('1,2');
+		expect(log.drain()).toEqual(['child:1,2', 'parent:1']);
+		r.unmount();
+	});
+
+	// Per ReactUpdates-test.js:437. Function-component adaptation: memo is the
+	// supported bailout boundary; a descendant's own state remains independent.
+	it('should update children even if parent blocks updates', () => {
+		const log = createLog();
+		const r = mount(Fixture.MemoParentHost, { log: log.push });
+		expect(log.drain()).toEqual(['child:0', 'parent:stable']);
+
+		r.click('#memo-parent-update');
+		expect(log.drain()).toEqual([]);
+		flushSync(() => Fixture.setMemoChild(1));
+		expect(r.find('#memo-child').textContent).toBe('1');
+		expect(log.drain()).toEqual(['child:1']);
+		r.unmount();
+	});
+
+	// Per ReactUpdates-test.js:484. Function-component adaptation: the middle
+	// component performs a hook update while returning the same child descriptor.
+	it('should not reconcile children passed via props', () => {
+		const log = createLog();
+		const r = mount(Fixture.StableChildrenHost, { log: log.push });
+		expect(r.find('#stable-bottom').textContent).toBe('stable');
+		expect(log.drain()).toEqual(['bottom', 'middle:0', 'middle:1']);
+		r.unmount();
+	});
+
+	// Per ReactUpdates-test.js:484. An identity-stable children value that
+	// suspended on its first attempt has no committed output to bail out to.
+	it('retries an uncommitted stable children block after suspension', async () => {
+		const pending = deferred<string>();
+		const r = mount(Fixture.StableChildrenSuspenseRetry, {
+			promise: pending.promise,
+		});
+		expect(r.find('#stable-retry-pending').textContent).toBe('loading');
+
+		await act(() => pending.resolve('ready'));
+		expect(r.find('#stable-retry-value').textContent).toBe('ready');
+		r.unmount();
+	});
+
+	// Per ReactUpdates-test.js:484. A return slot can begin as an arbitrary render
+	// function and later receive compiler-tagged children; the tagged body must then
+	// gain same-value bailout and lazy context propagation without losing its slot.
+	it('arms implicit bailout when a render function switches to tagged children', () => {
+		const log = createLog();
+		const r = mount(Fixture.FunctionToTaggedChildrenHost, { log: log.push });
+		expect(r.find('#function-switch-initial').textContent).toBe('initial');
+		expect(log.drain()).toEqual([]);
+
+		flushSync(() => Fixture.showTaggedFunctionChildren());
+		expect(r.find('#function-switch-consumer').textContent).toBe('initial');
+		expect(log.drain()).toEqual(['switch-consumer:initial']);
+
+		flushSync(() => Fixture.bumpFunctionSwitch());
+		expect(log.drain()).toEqual([]);
+
+		flushSync(() => Fixture.setFunctionSwitchContext('changed'));
+		expect(r.find('#function-switch-consumer').textContent).toBe('changed');
+		expect(log.drain()).toEqual(['switch-consumer:changed']);
+		r.unmount();
+	});
+
+	// Per ReactUpdates-test.js:664. Function-component adaptation: layout work
+	// for one root observes all DOM mutations from the shared render batch.
+	it('should queue mount-ready handlers across different roots', () => {
+		const log = createLog();
+		const a = ownedContainer();
+		const b = ownedContainer();
+		const rootA = createRoot(a);
+		const rootB = createRoot(b);
+		rootA.render(Fixture.CrossRootA, { other: b, log: log.push });
+		rootB.render(Fixture.CrossRootB);
+		flushSync(() => {});
+		log.clear();
+
+		flushSync(() => {
+			Fixture.setCrossRootA(1);
+			Fixture.setCrossRootB(1);
+		});
+
+		expect(a.textContent).toBe('A1');
+		expect(b.textContent).toBe('B1');
+		expect(log.drain()).toEqual(['a-sees:B1']);
+		removeRoot(rootA, a);
+		removeRoot(rootB, b);
+	});
+
+	// Per ReactUpdates-test.js:992. Hook adaptation: a child update queued before
+	// its parent's removal must not resurrect or commit the deleted child.
+	it('does not call render after a component as been deleted', () => {
+		const log = createLog();
+		const r = mount(Fixture.DeletePendingChild, { log: log.push });
+		expect(log.drain()).toEqual(['child:0']);
+
+		flushSync(() => {
+			Fixture.setDeleteChild(1);
+			Fixture.setDeleteParent(false);
+		});
+
+		expect(r.findAll('#delete-child')).toHaveLength(0);
+		expect(r.find('#deleted').textContent).toBe('deleted');
+		expect(log.drain()).toEqual([]);
+		r.unmount();
+	});
+
+	// Per ReactUpdates-test.js:1303. useLayoutEffect is the function-component
+	// mount-ready equivalent of the source componentDidMount callback.
+	it('handles reentrant mounting in synchronous mode', () => {
+		const container = ownedContainer();
+		const root = createRoot(container);
+		let onChangeCalls = 0;
+		const onChange = () => {
+			onChangeCalls++;
+			root.render(Fixture.ReentrantEditor, {
+				text: 'hello',
+				rendered: true,
+				onChange,
+			});
+		};
+
+		root.render(Fixture.ReentrantEditor, { text: 'hello', rendered: false, onChange });
+		flushSync(() => {});
+		expect(container.textContent).toBe('hello');
+		expect(onChangeCalls).toBe(1);
+
+		flushSync(() => {
+			root.render(Fixture.ReentrantEditor, {
+				text: 'goodbye',
+				rendered: true,
+				onChange,
+			});
+		});
+		expect(container.textContent).toBe('goodbye');
+		expect(onChangeCalls).toBe(1);
+		removeRoot(root, container);
+	});
+
+	// Per ReactUpdates-test.js:1348.
+	// OCTANE DIVERGENCE: first root mounts are synchronous; final teardown is
+	// still synchronous and leaves no mounted output.
+	it('synchronously mounts and unmounts inside one outer batch', () => {
+		const container = ownedContainer();
+		const root = createRoot(container);
+		root.render('Hello');
+		expect(container.textContent).toBe('Hello');
+		root.unmount();
+		expect(container.textContent).toBe('');
+		container.remove();
+	});
+
+	// Per ReactUpdates-test.js:1362. Hook adaptation: each render-phase updater
+	// sees the latest pending base state, including the converged replay.
+	it('uses correct base state for setState inside render phase', () => {
+		const r = mount(Fixture.RenderPhaseBaseState);
+		expect(r.find('#render-phase-base').textContent).toBe('1');
+		expect(Fixture.getRenderPhaseBases()).toEqual(['base:0,memoized:0', 'base:1,memoized:1']);
+		r.unmount();
+	});
+
+	// Per ReactUpdates-test.js:1413.
+	it('synchronously renders hidden subtrees', () => {
+		const r = mount(Fixture.HiddenSubtree, { value: 'first' });
+		expect((r.find('#hidden-owner') as HTMLElement).hidden).toBe(true);
+		expect(r.find('#hidden-value').textContent).toBe('first');
+		r.update(Fixture.HiddenSubtree, { value: 'second' });
+		expect(r.find('#hidden-value').textContent).toBe('second');
+		r.unmount();
+	});
+
+	// Per ReactUpdates-test.js:1509. Preserve the source's full 1,200 independent
+	// roots created from one mount-ready callback.
+	it('can render 1200 roots without triggering an infinite update loop error', async () => {
+		const roots: Root[] = [];
+		const containers: HTMLElement[] = [];
+		const spawnerContainer = ownedContainer();
+		const spawnerRoot = createRoot(spawnerContainer);
+		await act(() => {
+			spawnerRoot.render(Fixture.ManyRootsSpawner, {
+				spawn() {
+					for (let i = 0; i < 1200; i++) {
+						const container = ownedContainer();
+						const root = createRoot(container);
+						root.render(Fixture.IndependentCell, { trigger: i === 1199 });
+						roots.push(root);
+						containers.push(container);
+					}
+				},
+			});
+		});
+		expect(roots).toHaveLength(1200);
+		expect(containers.slice(0, -1).every((container) => container.textContent === '0')).toBe(true);
+		expect(containers.at(-1)!.textContent).toBe('1');
+
+		for (let i = 0; i < roots.length; i++) removeRoot(roots[i], containers[i]);
+		removeRoot(spawnerRoot, spawnerContainer);
+	});
+
+	// Per ReactUpdates-test.js:1638.
+	it('does not fall into an infinite update loop with useLayoutEffect', async () => {
+		const container = ownedContainer();
+		const root = createRoot(container);
+		await expect(async () => {
+			await act(() => root.render(Fixture.LayoutEffectLoop));
+		}).rejects.toThrow(/Maximum update depth exceeded/);
+		removeRoot(root, container);
+	});
+
+	// Per ReactUpdates-test.js:1638. Dependency-change cleanups are commit
+	// callbacks too; both layout and passive cleanup-driven loops are bounded.
+	it('prevents infinite update loops triggered by effect cleanup callbacks', async () => {
+		for (const Body of [Fixture.LayoutCleanupLoop, Fixture.PassiveCleanupLoop]) {
+			const container = ownedContainer();
+			const root = createRoot(container);
+			await expect(async () => {
+				await act(() => root.render(Body));
+			}).rejects.toThrow(/Maximum update depth exceeded/);
+			removeRoot(root, container);
+		}
+	});
+
+	// Per ReactUpdates-test.js:1638. A render-phase synchronization nested inside
+	// a layout-driven chain inherits that chain instead of refreshing its budget.
+	it('keeps the update budget across mixed layout and render-phase updates', async () => {
+		const container = ownedContainer();
+		const root = createRoot(container);
+		await expect(async () => {
+			await act(() => root.render(Fixture.MixedLayoutRenderLoop));
+		}).rejects.toThrow(/Maximum update depth exceeded/);
+		removeRoot(root, container);
+	});
+
+	// Per ReactUpdates-test.js:1638. An ancestor-first wave may render a flagged
+	// child before its queue entry; coalescing the render must not swallow the error.
+	it('surfaces a flagged child after its pending render is coalesced by its parent', async () => {
+		const container = ownedContainer();
+		const root = createRoot(container);
+		await expect(async () => {
+			await act(() => root.render(Fixture.CoalescedParentChildLoop));
+		}).rejects.toThrow(/Maximum update depth exceeded/);
+		removeRoot(root, container);
+	});
+
+	// Per ReactUpdates-test.js:1553. Function-component adaptation: a failed
+	// nested chain does not spend the budget of later independent finite work.
+	it('resets the update counter for unrelated updates', async () => {
+		const container = ownedContainer();
+		const root = createRoot(container);
+		await expect(async () => {
+			await act(() => root.render(Fixture.FiniteLayoutChain, { limit: 55 }));
+		}).rejects.toThrow(/Maximum update depth exceeded/);
+
+		await act(() => root.render(Fixture.FiniteLayoutChain, { limit: 45 }));
+		expect(container.querySelector('#finite-layout-step')!.textContent).toBe('45');
+		await act(() => Fixture.setFiniteLayoutStep(0));
+		expect(container.querySelector('#finite-layout-step')!.textContent).toBe('45');
+
+		await expect(async () => {
+			await act(() => {
+				root.render(Fixture.FiniteLayoutChain, { limit: 55 });
+				Fixture.setFiniteLayoutStep(0);
+			});
+		}).rejects.toThrow(/Maximum update depth exceeded/);
+		removeRoot(root, container);
+	});
+
+	// Per ReactUpdates-test.js:1656. Function-component adaptation: an errored
+	// root can alternate between a runaway layout effect and finite content.
+	it('can recover after falling into an infinite update loop', async () => {
+		const container = ownedContainer();
+		const root = createRoot(container);
+		await expect(async () => {
+			await act(() => root.render(Fixture.LayoutEffectLoop));
+		}).rejects.toThrow(/Maximum update depth exceeded/);
+		await act(() => root.render(Fixture.OneStepLayoutUpdate));
+		expect(container.querySelector('#one-step-layout')!.textContent).toBe('1');
+
+		await expect(async () => {
+			await act(() => root.render(Fixture.LayoutEffectLoop));
+		}).rejects.toThrow(/Maximum update depth exceeded/);
+		await act(() => root.render(Fixture.OneStepLayoutUpdate));
+		expect(container.querySelector('#one-step-layout')!.textContent).toBe('1');
+		removeRoot(root, container);
+	});
+
+	// Per ReactUpdates-test.js:1704. Function-component adaptation: mount-ready
+	// callbacks replace the same root with each other until the runtime bounds it.
+	it('does not fall into mutually recursive infinite update loop with same container', async () => {
+		const container = ownedContainer();
+		const root = createRoot(container);
+		const swap = (target: 'a' | 'b') => {
+			root.render(target === 'a' ? Fixture.RootLoopA : Fixture.RootLoopB, { swap });
+		};
+		await expect(async () => {
+			await act(() => root.render(Fixture.RootLoopA, { swap }));
+		}).rejects.toThrow(/Maximum update depth exceeded/);
+		removeRoot(root, container);
+	});
+
+	// Per ReactUpdates-test.js:1704. Root replacements initiated directly during
+	// render are part of the active chain and must terminate before stack overflow.
+	it('does not stack overflow on mutually recursive render-phase root replacement', async () => {
+		const container = ownedContainer();
+		const root = createRoot(container);
+		const swap = (target: 'a' | 'b') => {
+			root.render(target === 'a' ? Fixture.RenderRootLoopA : Fixture.RenderRootLoopB, {
+				swap,
+			});
+		};
+		await expect(async () => {
+			await act(() => root.render(Fixture.RenderRootLoopA, { swap }));
+		}).rejects.toThrow(/Maximum update depth exceeded/);
+		removeRoot(root, container);
+	});
+
+	// Per ReactUpdates-test.js:1733. Function-component adaptation: repeated
+	// @try recovery/remount work is bounded like any other commit-phase loop.
+	it('does not fall into an infinite error loop', async () => {
+		const container = ownedContainer();
+		const root = createRoot(container);
+		await expect(async () => {
+			await act(() => root.render(Fixture.ErrorRecoveryLoop));
+		}).rejects.toThrow(/Maximum update depth exceeded/);
+		removeRoot(root, container);
+	});
+
+	// Per stable ReactUpdates-test.js:1807. Canary's warning-only/force-throw
+	// feature-flag split is an internal policy; Octane always terminates the loop.
+	it("does not infinite loop if there's a synchronous render phase update on another component", async () => {
+		const container = ownedContainer();
+		const root = createRoot(container);
+		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			await expect(async () => {
+				await act(() => flushSync(() => root.render(Fixture.CrossComponentRenderLoop)));
+			}).rejects.toThrow(/Maximum update depth exceeded/);
+			if (process.env.NODE_ENV !== 'production') {
+				expect(error).toHaveBeenCalledWith(
+					'Cannot update a component (`CrossComponentRenderLoop`) while rendering a different ' +
+						'component (`CrossComponentLoopChild`). Move the update out of the rendering component body.',
+				);
+			}
+		} finally {
+			error.mockRestore();
+			removeRoot(root, container);
+		}
+	});
+
+	// Per stable ReactUpdates-test.js:1838.
+	it("does not infinite loop if there's an async render phase update on another component", async () => {
+		const container = ownedContainer();
+		const root = createRoot(container);
+		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			await expect(async () => {
+				await act(() => {
+					startTransition(() => root.render(Fixture.CrossComponentAsyncRenderLoop));
+				});
+			}).rejects.toThrow(/Maximum update depth exceeded/);
+			if (process.env.NODE_ENV !== 'production') {
+				expect(error).toHaveBeenCalledWith(
+					'Cannot update a component (`CrossComponentAsyncRenderLoop`) while rendering a different ' +
+						'component (`CrossComponentAsyncLoopChild`). Move the update out of the rendering component body.',
+				);
+			}
+		} finally {
+			error.mockRestore();
+			removeRoot(root, container);
+		}
+	});
+
+	// Per ReactUpdates-test.js:1912.
+	it('can have nested updates if they do not cross the limit', async () => {
+		const container = ownedContainer();
+		const root = createRoot(container);
+		await act(() => root.render(Fixture.NestedEffectUpdates, { limit: 50 }));
+		expect(container.querySelector('#nested-effect-step')!.textContent).toBe('50');
+		await act(() => Fixture.setNestedEffectStep(0));
+		expect(container.querySelector('#nested-effect-step')!.textContent).toBe('50');
+		removeRoot(root, container);
+	});
+
+	// Per ReactUpdates-test.js:1912. An external root unmount is a fresh update
+	// boundary: its cleanup may advance a different root after that root completed
+	// an exactly-at-the-limit chain without inheriting the old budget.
+	it('resets the nested-update chain before external root unmount cleanups', async () => {
+		const sourceContainer = ownedContainer();
+		const sourceRoot = createRoot(sourceContainer);
+		sourceRoot.render(Fixture.ExternalUnmountCleanupSource, {
+			bumpTarget: Fixture.bumpExternalUnmountTarget,
+		});
+		flushSync(() => {});
+
+		const targetContainer = ownedContainer();
+		const targetRoot = createRoot(targetContainer);
+		await act(() => targetRoot.render(Fixture.ExternalUnmountTarget));
+		expect(targetContainer.querySelector('#external-unmount-target')!.textContent).toBe('50');
+
+		sourceRoot.unmount();
+		sourceContainer.remove();
+		await act(() => {});
+		expect(targetContainer.querySelector('#external-unmount-target')!.textContent).toBe('51');
+
+		removeRoot(targetRoot, targetContainer);
+	});
+
+	// Per ReactUpdates-test.js:1942.
+	it('can have many updates inside useEffect without triggering a warning', async () => {
+		const container = ownedContainer();
+		const root = createRoot(container);
+		await act(() => root.render(Fixture.ManyUpdatesInOneEffect));
+		expect(container.querySelector('#many-effect-updates')!.textContent).toBe('1000');
+		removeRoot(root, container);
+	});
+
+	// Per ReactUpdates-test.js:1965.
+	it('prevents infinite update loop triggered by synchronous updates in useEffect', async () => {
+		const container = ownedContainer();
+		const root = createRoot(container);
+		await expect(async () => {
+			await act(() => root.render(Fixture.SynchronousPassiveEffectLoop));
+		}).rejects.toThrow(/Maximum update depth exceeded/);
+		removeRoot(root, container);
+	});
+
+	// Per ReactUpdates-test.js:2010 (stable), :2266 (canary).
+	it('prevents infinite update loop triggered by too many updates in ref callbacks', async () => {
+		const container = ownedContainer();
+		const root = createRoot(container);
+		await expect(async () => {
+			await act(() => root.render(Fixture.RefCallbackLoop));
+		}).rejects.toThrow(/Maximum update depth exceeded/);
+		removeRoot(root, container);
+	});
+
+	// Per ReactUpdates-test.js:1769. Function-component adaptation: a wide batch
+	// is not a recursive update chain, even when it contains far more than the cap.
+	it('can schedule ridiculously many updates within the same batch without triggering a maximum update error', () => {
+		const setters: Array<(value: number) => void> = [];
+		const ids = Array.from({ length: 1200 }, (_, id) => id);
+		const r = mount(Fixture.ManyBatchCells, {
+			ids,
+			capture(id: number, setter: (value: number) => void) {
+				setters[id] = setter;
+			},
+		});
+
+		flushSync(() => {
+			for (const setter of setters) setter(1);
+		});
+		expect(r.findAll('.batch-cell')).toHaveLength(1200);
+		expect(r.findAll('.batch-cell').every((node) => node.textContent === '1')).toBe(true);
+		r.unmount();
+	});
+});

--- a/packages/octane/tests/transitions.test.ts
+++ b/packages/octane/tests/transitions.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { mount, act, createLog } from './_helpers';
 import { flushSync } from '../src/index.js';
 import {
@@ -67,20 +67,30 @@ describe('useTransition — keeps prior DOM during suspended transition', () => 
 		expect(r.find('#pending').textContent).toBe('idle');
 		expect(r.findAll('#fallback')).toHaveLength(0);
 
-		// Swap inside startTransition. d2 is still pending — the render suspends
-		// but DOM stays mounted (no fallback) and isPending flips true.
-		r.click('#swap');
-		expect(r.find('#value').textContent).toBe('one'); // OLD value held
-		expect(r.findAll('#fallback')).toHaveLength(0); // no fallback flash
-		expect(r.find('#pending').textContent).toBe('pending');
+		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			// Swap inside startTransition. d2 is still pending — the render suspends
+			// but DOM stays mounted (no fallback) and isPending flips true.
+			r.click('#swap');
+			expect(r.find('#value').textContent).toBe('one'); // OLD value held
+			expect(r.findAll('#fallback')).toHaveLength(0); // no fallback flash
+			expect(r.find('#pending').textContent).toBe('pending');
 
-		// Resolve d2 — DOM updates to new value, isPending returns to idle.
-		await act(() => {
-			d2.resolve('two');
-		});
-		expect(r.find('#value').textContent).toBe('two');
-		expect(r.find('#pending').textContent).toBe('idle');
-		r.unmount();
+			// Resolve d2 — DOM updates to new value, isPending returns to idle.
+			await act(() => {
+				d2.resolve('two');
+			});
+			expect(r.find('#value').textContent).toBe('two');
+			expect(r.find('#pending').textContent).toBe('idle');
+			expect(
+				error.mock.calls.filter(([message]) =>
+					String(message).includes('Cannot update a component'),
+				),
+			).toEqual([]);
+		} finally {
+			error.mockRestore();
+			r.unmount();
+		}
 	});
 
 	it('initial mount that suspends — even inside a transition — still shows fallback', async () => {

--- a/packages/redux/src/utils/useSyncExternalStoreWithSelector.ts
+++ b/packages/redux/src/utils/useSyncExternalStoreWithSelector.ts
@@ -4,7 +4,7 @@
 // selection matches the previous one, the previous REFERENCE is kept so the
 // store's uSES doesn't re-render.
 import { useSyncExternalStore, useRef, useMemo, useEffect } from 'octane';
-import { subSlot } from '../internal';
+import { splitSlot, subSlot } from '../internal';
 
 const objectIs: (x: unknown, y: unknown) => boolean =
 	typeof Object.is === 'function'
@@ -16,9 +16,14 @@ export function useSyncExternalStoreWithSelector<Snapshot, Selection>(
 	getSnapshot: () => Snapshot,
 	getServerSnapshot: undefined | null | (() => Snapshot),
 	selector: (snapshot: Snapshot) => Selection,
-	isEqual?: (a: Selection, b: Selection) => boolean,
-	slot?: symbol,
+	...rest: [isEqual?: (a: Selection, b: Selection) => boolean, slot?: symbol]
 ): Selection {
+	// A compiled direct call that omits the optional equality function arrives as
+	// `[slot]`, while binding-internal calls arrive as `[isEqual, slot]`. Split the
+	// compiler-owned tail before interpreting the user argument so a Symbol can
+	// never be mistaken for an equality function.
+	const [userArgs, slot] = splitSlot(rest);
+	const isEqual = userArgs[0] as ((a: Selection, b: Selection) => boolean) | undefined;
 	const instRef = useRef<{ hasValue: boolean; value: Selection | null } | null>(
 		null,
 		subSlot(slot, 'ws:inst'),

--- a/packages/redux/tests/_fixtures/external-store-shared.tsrx
+++ b/packages/redux/tests/_fixtures/external-store-shared.tsrx
@@ -1,0 +1,168 @@
+import { useSyncExternalStoreWithSelector } from '@octanejs/redux';
+import { useLayoutEffect } from 'octane';
+
+export function createExternalStore(initialState) {
+	let currentState = initialState;
+	const listeners = new Set();
+	return {
+		set(nextState) {
+			currentState = nextState;
+			for (const listener of [...listeners]) listener();
+		},
+		subscribe(listener) {
+			listeners.add(listener);
+			return () => listeners.delete(listener);
+		},
+		getState() {
+			return currentState;
+		},
+	};
+}
+
+function selectA(state) {
+	return state.a;
+}
+
+export function SelectedValueReader(props) @{
+	const value = useSyncExternalStoreWithSelector(
+		props.store.subscribe,
+		props.store.getState,
+		null,
+		selectA,
+	);
+	<span id="selected-value">
+		{value as number}
+	</span>
+}
+
+function selectAObject(state) {
+	return { value: state.a };
+}
+
+function selectBObject(state) {
+	return { value: state.b };
+}
+
+function equalSelection(left, right) {
+	return left.value === right.value;
+}
+
+function EqualityA(props) @{
+	const selection = useSyncExternalStoreWithSelector(
+		props.store.subscribe,
+		props.store.getState,
+		null,
+		selectAObject,
+		equalSelection,
+	);
+	useLayoutEffect(() => {
+		props.probe.value = 'A' + selection.value;
+	}, null);
+	<span id="equality-a">
+		{'A' + selection.value}
+	</span>
+}
+
+function EqualityB(props) @{
+	const selection = useSyncExternalStoreWithSelector(
+		props.store.subscribe,
+		props.store.getState,
+		null,
+		selectBObject,
+		equalSelection,
+	);
+	useLayoutEffect(() => {
+		props.probe.value = 'B' + selection.value;
+	}, null);
+	<span id="equality-b">
+		{'B' + selection.value}
+	</span>
+}
+
+export function EqualityPair(props) @{
+	<div>
+		<EqualityA store={props.store} probe={props.aProbe} />
+		<EqualityB store={props.store} probe={props.bProbe} />
+	</div>
+}
+
+export function ChangingSelectorReader(props) @{
+	const inlineSelector = (state) => ({
+		items: [...state.items, 'C'],
+		selectedAtStep: props.step,
+	});
+	const selection = useSyncExternalStoreWithSelector(
+		props.store.subscribe,
+		props.store.getState,
+		null,
+		inlineSelector,
+		(left, right) =>
+			left.items.length === right.items.length &&
+				left.items.every((item, index) => item === right.items[index]),
+	);
+	useLayoutEffect(() => {
+		props.selectionProbe.value = selection.items.join(',') + '|selected:' +
+		selection.selectedAtStep;
+	}, [selection]);
+	<div>
+		<span id="changing-selection">
+			{selection.items.join(',') + '|selected:' + selection.selectedAtStep}
+		</span>
+		<span id="changing-selector-step">
+			{props.step as string}
+		</span>
+	</div>
+}
+
+function ThrowingSelectorReader(props) @{
+	const value = useSyncExternalStoreWithSelector(
+		props.store.subscribe,
+		props.store.getState,
+		null,
+		(state) => {
+			if (typeof state.a !== 'string') throw new TypeError('Malformed state');
+			return state.a.toUpperCase();
+		},
+	);
+	<span id="selector-value">
+		{value as string}
+	</span>
+}
+
+export function SelectorErrorBoundary(props) @{
+	@try {
+		<ThrowingSelectorReader store={props.store} />
+	} @catch (error) {
+		<span id="selector-error">
+			{error.message as string}
+		</span>
+	}
+}
+
+function ThrowingEqualityReader(props) @{
+	const value = useSyncExternalStoreWithSelector(
+		props.store.subscribe,
+		props.store.getState,
+		null,
+		(state) => state.a,
+		(left, right) => {
+			if (typeof left !== 'string' || typeof right !== 'string') {
+				throw new TypeError('Malformed state');
+			}
+			return left.trim() === right.trim();
+		},
+	);
+	<span id="equality-value">
+		{value as string}
+	</span>
+}
+
+export function EqualityErrorBoundary(props) @{
+	@try {
+		<ThrowingEqualityReader store={props.store} />
+	} @catch (error) {
+		<span id="equality-error">
+			{error.message as string}
+		</span>
+	}
+}

--- a/packages/redux/tests/conformance/external-store-shared.test.ts
+++ b/packages/redux/tests/conformance/external-store-shared.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { flushSync } from 'octane';
+import { flushEffects, mount } from '../_helpers.js';
+import {
+	ChangingSelectorReader,
+	EqualityErrorBoundary,
+	EqualityPair,
+	SelectedValueReader,
+	SelectorErrorBoundary,
+	createExternalStore,
+} from '../_fixtures/external-store-shared.tsrx';
+
+function updateStore(run: () => void): void {
+	flushSync(run);
+	flushEffects();
+}
+
+describe('useSyncExternalStoreWithSelector shared behavior', () => {
+	// Regression discovered while adapting useSyncExternalStoreShared-test.js:682:
+	// compiled calls without isEqual must not mistake the trailing hook slot for it.
+	it('updates selected output when the optional equality function is omitted', () => {
+		const store = createExternalStore({ a: 0, b: 0 });
+		const root = mount(SelectedValueReader, { store });
+		flushEffects();
+		expect(root.find('#selected-value').textContent).toBe('0');
+
+		updateStore(() => store.set({ a: 1, b: 0 }));
+		expect(root.find('#selected-value').textContent).toBe('1');
+		root.unmount();
+	});
+
+	// Per useSyncExternalStoreShared-test.js:726 (stable), :730 (canary).
+	it('Using isEqual to bailout', () => {
+		const store = createExternalStore({ a: 0, b: 0 });
+		const aProbe = { value: '' };
+		const bProbe = { value: '' };
+		const root = mount(EqualityPair, { store, aProbe, bProbe });
+		flushEffects();
+		expect(root.find('#equality-a').textContent).toBe('A0');
+		expect(root.find('#equality-b').textContent).toBe('B0');
+		expect(aProbe.value).toBe('A0');
+		expect(bProbe.value).toBe('B0');
+
+		aProbe.value = 'untouched';
+		bProbe.value = 'untouched';
+		updateStore(() => store.set({ a: 0, b: 1 }));
+		expect(root.find('#equality-a').textContent).toBe('A0');
+		expect(root.find('#equality-b').textContent).toBe('B1');
+		expect(aProbe.value).toBe('untouched');
+		expect(bProbe.value).toBe('B1');
+
+		aProbe.value = 'untouched';
+		bProbe.value = 'untouched';
+		updateStore(() => store.set({ a: 1, b: 1 }));
+		expect(root.find('#equality-a').textContent).toBe('A1');
+		expect(root.find('#equality-b').textContent).toBe('B1');
+		expect(aProbe.value).toBe('A1');
+		expect(bProbe.value).toBe('untouched');
+		root.unmount();
+	});
+
+	// Per useSyncExternalStoreShared-test.js:873 (stable), :882 (canary).
+	it('compares selection to rendered selection even if selector changes', () => {
+		const store = createExternalStore({ items: ['A', 'B'] });
+		const selectionProbe = { value: '' };
+		const root = mount(ChangingSelectorReader, { store, step: 0, selectionProbe });
+		flushEffects();
+		expect(root.find('#changing-selection').textContent).toBe('A,B,C|selected:0');
+		expect(selectionProbe.value).toBe('A,B,C|selected:0');
+
+		selectionProbe.value = 'untouched';
+		root.update(ChangingSelectorReader, { store, step: 1, selectionProbe });
+		flushEffects();
+		// isEqual treats the fresh inline selector's items as the same selection, so
+		// the previous selection remains visible and its dependent effect stays quiet.
+		expect(root.find('#changing-selection').textContent).toBe('A,B,C|selected:0');
+		expect(selectionProbe.value).toBe('untouched');
+		expect(root.find('#changing-selector-step').textContent).toBe('1');
+		root.unmount();
+	});
+
+	// Per useSyncExternalStoreShared-test.js:980 (stable), :989 (canary). React's
+	// class ErrorBoundary is adapted to Octane's function-component @try/@catch.
+	it('selector can throw on update', () => {
+		const store = createExternalStore({ a: 'a' });
+		const root = mount(SelectorErrorBoundary, { store });
+		flushEffects();
+		expect(root.find('#selector-value').textContent).toBe('A');
+
+		updateStore(() => store.set({}));
+		expect(root.find('#selector-error').textContent).toBe('Malformed state');
+		root.unmount();
+	});
+
+	// Per useSyncExternalStoreShared-test.js:1028 (stable), :1037 (canary). React's
+	// class ErrorBoundary is adapted to Octane's function-component @try/@catch.
+	it('isEqual can throw on update', () => {
+		const store = createExternalStore({ a: 'A' });
+		const root = mount(EqualityErrorBoundary, { store });
+		flushEffects();
+		expect(root.find('#equality-value').textContent).toBe('A');
+
+		updateStore(() => store.set({}));
+		expect(root.find('#equality-error').textContent).toBe('Malformed state');
+		root.unmount();
+	});
+});

--- a/scripts/react-parity/inventory-lib.mjs
+++ b/scripts/react-parity/inventory-lib.mjs
@@ -1022,6 +1022,10 @@ const EVIDENCE_MODES = new Set([
 	'production-compile',
 ]);
 
+function isWorkspaceTestEvidence(file) {
+	return typeof file === 'string' && /^packages\/[^/]+\/tests\//.test(file);
+}
+
 export function validateLedger(ledger, inventories, repoRoot, upstreams) {
 	const errors = [];
 	if (ledger?.schemaVersion !== 1 || !Array.isArray(ledger?.entries)) {
@@ -1076,10 +1080,20 @@ export function validateLedger(ledger, inventories, repoRoot, upstreams) {
 					entry.risk !== 'unassessed' &&
 					typeof entry.rationale === 'string' &&
 					entry.rationale.trim().length > 0;
-				for (const name of ['classification', 'risk']) {
-					if (entry[name] !== policy[name] && !hasDocumentedPolicyOverride)
-						errors.push(`Priority case ${entry.caseId} does not satisfy ${policy.id} ${name}.`);
-				}
+				const hasCoveredPortabilityAssessment =
+					entry.status === 'covered' &&
+					['portable', 'adaptable'].includes(entry.classification) &&
+					['portable', 'adaptable'].includes(policy.classification);
+				if (
+					entry.classification !== policy.classification &&
+					!hasDocumentedPolicyOverride &&
+					!hasCoveredPortabilityAssessment
+				)
+					errors.push(
+						`Priority case ${entry.caseId} does not satisfy ${policy.id} classification.`,
+					);
+				if (entry.risk !== policy.risk && !hasDocumentedPolicyOverride)
+					errors.push(`Priority case ${entry.caseId} does not satisfy ${policy.id} risk.`);
 				for (const name of ['owner', 'workstream']) {
 					if (entry[name] !== policy[name])
 						errors.push(`Priority case ${entry.caseId} does not satisfy ${policy.id} ${name}.`);
@@ -1131,7 +1145,7 @@ export function validateLedger(ledger, inventories, repoRoot, upstreams) {
 				if (!EVIDENCE_KEYS.has(key))
 					errors.push(`${entry.caseId} evidence has unknown field ${key}.`);
 			}
-			if (typeof evidence.file !== 'string' || !evidence.file.startsWith('packages/octane/tests/'))
+			if (!isWorkspaceTestEvidence(evidence.file))
 				errors.push(`${entry.caseId} evidence has invalid file.`);
 			if (typeof evidence.testName !== 'string' || !evidence.testName.trim())
 				errors.push(`${entry.caseId} evidence has invalid testName.`);
@@ -1282,7 +1296,7 @@ export function renderCoverageReport({ upstreams, inventories, ledger }) {
 	markdown += `\n### Migration sequence and exit criteria\n\n`;
 	markdown += `1. **Wave 1 — critical blockers (completed 2026-07-15):** Effect Event semantics and shared untrusted-URL sanitization are implemented, ported, and linked to executable ledger evidence.\n`;
 	markdown += `2. **Wave 2 — public API and reconciliation (completed 2026-07-15):** supported root, fragment, element/Children, and lazy-component outcomes have live evidence; excluded outcomes have durable divergence/non-goal dispositions.\n`;
-	markdown += `3. **Wave 3 — scheduling and stores:** update reconciliation and external-store consistency.\n`;
+	markdown += `3. **Wave 3 — scheduling and stores (completed 2026-07-15):** supported update-reconciliation and external-store outcomes have live evidence; excluded class, legacy, Fiber-policy, and optimization-only cases have durable dispositions.\n`;
 	markdown += `4. **Wave 4 — server matrix:** applicable Fizz streaming cases, then the five-mode server integration matrix.\n`;
 	markdown += `5. **Residual audit:** assign risk and a durable disposition to every remaining untriaged case, with canary drift reviewed continuously.\n\n`;
 	markdown += `A case exits the queue only as \`covered\` with live local evidence, or as a \`documented\` divergence/non-goal with rationale. Committed conformance work must remain executable; \`skip\`, \`todo\`, and expected-failure placeholders are not completion states.\n\n`;

--- a/scripts/react-parity/inventory-lib.test.mjs
+++ b/scripts/react-parity/inventory-lib.test.mjs
@@ -356,6 +356,36 @@ describe('React parity validators', () => {
 		}
 	});
 
+	test('allows covered priority cases to refine portable versus adaptable classification', () => {
+		const root = mkdtempSync(path.join(os.tmpdir(), 'octane-react-ledger-portability-'));
+		try {
+			const { inventory, upstreams, entry } = priorityValidatorFixture();
+			const relativeFile = 'packages/octane/tests/example.test.ts';
+			mkdirSync(path.dirname(path.join(root, relativeFile)), { recursive: true });
+			writeFileSync(path.join(root, relativeFile), `it('portable behavior', () => {});\n`);
+			const errors = validateLedger(
+				{
+					schemaVersion: 1,
+					entries: [
+						{
+							...entry,
+							status: 'covered',
+							classification: 'portable',
+							evidence: [{ file: relativeFile, testName: 'portable behavior' }],
+						},
+					],
+				},
+				[inventory],
+				root,
+				upstreams,
+			);
+
+			assert.deepEqual(errors, []);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	test('rejects priority classification and risk overrides outside a documented disposition', () => {
 		for (const status of ['planned', 'covered']) {
 			const { inventory, upstreams, entry } = priorityValidatorFixture();
@@ -474,6 +504,30 @@ describe('React parity validators', () => {
 			);
 			assert(errors.some((error) => error.includes('evidence test is stale')));
 			assert(errors.some((error) => error.includes('evidence has invalid file')));
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test('accepts evidence from first-party workspace package tests', () => {
+		const root = mkdtempSync(path.join(os.tmpdir(), 'octane-react-ledger-binding-'));
+		try {
+			const { inventory, upstreams, entry } = validatorFixture();
+			const relativeFile = 'packages/redux/tests/conformance/selector.test.ts';
+			mkdirSync(path.dirname(path.join(root, relativeFile)), { recursive: true });
+			writeFileSync(path.join(root, relativeFile), `it('selector stays current', () => {});\n`);
+			const covered = {
+				...entry,
+				status: 'covered',
+				classification: 'adaptable',
+				risk: 'low',
+				evidence: [{ file: relativeFile, testName: 'selector stays current' }],
+			};
+
+			assert.deepEqual(
+				validateLedger({ schemaVersion: 1, entries: [covered] }, [inventory], root, upstreams),
+				[],
+			);
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Summary

Completes React parity Wave 3 against the pinned stable and canary React sources:

- audits all 66 union cases from `useSyncExternalStoreShared-test.js` and `ReactUpdates-test.js`
- records 42 covered cases, one executable intentional divergence, and 23 documented non-goals
- adds external-store conformance coverage in core and Redux, including hydration, subscription, selector, equality, error, and mutation behavior
- adds update/reconciliation coverage for batching, render-phase updates, effects, refs, roots, error recovery, depth limits, and 1,200-root/wide-batch stress cases
- fixes the Redux omitted-`isEqual` slot bug and strengthens Octane's recursive-update guards, `act()` cleanup, cross-component render warnings, compiled-child bailouts, and errored-root recovery
- updates the parity ledger, generated coverage report, RuleSync guidance, intentional-divergence docs, and package changesets

Class components, legacy React roots, lifecycle APIs, `forceUpdate`, Fiber/lane internals, and other legacy or implementation-specific cases remain explicit non-goals. This PR does not add legacy React support.

## Why

React's repositories contain more than 5,000 test registrations, but raw counts include renderer internals, legacy APIs, duplicated build modes, and unsupported product surfaces. Wave 3 converts the supported public behavior into executable Octane evidence while keeping intentional divergences and non-goals explicit.

The measured Octane inventory is now 2,591 normal core tests and 7,813 total project executions. The broad React-source attribution heuristic reports an upper bound of 1,202 tests across 74 files; the generated ledger remains the source of truth for case-level parity.

## Validation

- `pnpm --config.minimum-release-age=0 test` — 944 files, 7,813 tests passed
- `pnpm --config.minimum-release-age=0 typecheck`
- `pnpm --config.minimum-release-age=0 format:check`
- `pnpm react-parity:test` — 27 tests passed
- `pnpm react-parity:check` — stable 5,345 / canary 5,413 current
- `pnpm test:markers:check`
- `pnpm parity:gaps:check` — zero pins
- website SSR/hydration E2E — 24/24 passed in isolation and in the full suite

The local minimum-release-age override was only needed because current `main` already pins the same-day TSRX releases from #96; no supply-chain policy was changed by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core scheduling, `root.render`/`act()`, external-store commit sync, and nested-update limits—behavior that every app update path depends on.
> 
> **Overview**
> Completes **React parity Wave 3** by closing the **External stores** and **Update reconciliation** workstreams: dozens of upstream `ReactUpdates` and `useSyncExternalStoreShared` cases are now **covered** with new conformance suites (Octane core plus Redux selector paths), **documented non-goals** for class/legacy/Fiber-only cases, and one **executable divergence** for synchronous first-root mount/unmount batching.
> 
> **Runtime** gains bounded **maximum update depth** for effect/ref/store-sync/root-render chains (recoverable errors, wide batches still allowed), **dev warnings** for cross-component render-phase updates, **`act()` scope cleanup** when a synchronous drain throws, and **implicit bailout** for stable identity **tagged compiler `children`**. Parity ledger schema now accepts evidence under any `packages/*/tests/`.
> 
> **Redux** fixes **`useSyncExternalStoreWithSelector`** when `isEqual` is omitted so the compiler hook slot is not treated as the comparator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dfd393bcc170975c3bf0d287c12c767ab3c014c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->