### PR TITLE
Stabilize website SSR and add DEV nesting diagnostics

### DIFF
--- a/.changeset/neat-ssr-layouts.md
+++ b/.changeset/neat-ssr-layouts.md
@@ -1,0 +1,9 @@
+---
+'octane': patch
+'@octanejs/app-core': patch
+'@octanejs/vite-plugin': patch
+---
+
+Report browser-repaired HTML nesting with authored locations during development SSR, and collect module style-map CSS while rendering so server and hydrated layouts use the same styles.
+
+Negotiate streaming gzip in the built-in Node HTTP transport for eligible SSR and static text responses, including the `octane-preview` path.

--- a/docs/ssr.md
+++ b/docs/ssr.md
@@ -188,6 +188,13 @@ your own `entry-server.ts` around `prerender()` or the streaming renderers and
 serialize any app data (for example a dehydrated query-client cache) into your
 own inline script.
 
+Development SSR validates native HTML element nesting while it renders,
+including relationships that cross component boundaries. When the browser
+would repair a placement before hydration (for example, a `<div>` inside a
+`<p>`), Octane reports both authored locations in the server console. The check
+targets parser repairs rather than the complete HTML content model, never adds
+diagnostics to returned markup, and is removed from production compilation.
+
 On the server, page and layout props also receive `state`, the same
 request-scoped `Context.state` Map middleware populated. It is deliberately not
 serialized; browser hydration receives only `{ params, url }`.
@@ -202,7 +209,9 @@ it to the await-everything `prerender`. A deploy adapter (e.g.
 `adapter: vercel()` in octane.config.ts emits Vercel's Build Output API under
 `.vercel/output` after the build. Request abort signals reach both render modes;
 the built-in Node bridge also waits for `drain` and cancels the render when the
-response socket closes.
+response socket closes. Its HTTP transport negotiates streaming gzip for
+eligible SSR and static text responses while preserving HEAD, partial,
+pre-encoded, `no-transform`, and non-compressible responses.
 
 ### Root boundaries, server functions, and CSP
 

--- a/packages/app-core/src/server/node-http.js
+++ b/packages/app-core/src/server/node-http.js
@@ -12,7 +12,121 @@
 import http from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
-import { Readable } from 'node:stream';
+import { Duplex, pipeline, Readable } from 'node:stream';
+import { constants as zlibConstants, createGzip } from 'node:zlib';
+
+const MIN_COMPRESSION_BYTES = 1024;
+
+/**
+ * Read one request header in the comma-joined form HTTP negotiation expects.
+ * @param {import('node:http').IncomingMessage} request
+ * @param {string} name
+ * @returns {string | null}
+ */
+function getRequestHeader(request, name) {
+	const value = request.headers[name];
+	if (value === undefined) return null;
+	return Array.isArray(value) ? value.join(',') : value;
+}
+
+/**
+ * Return the client's quality for one content coding. An explicit coding wins
+ * over `*`, including an explicit `q=0` exclusion.
+ * @param {string | null} header
+ * @param {string} coding
+ */
+function encodingQuality(header, coding) {
+	if (header === null || header.trim() === '') return 0;
+	/** @type {number | null} */
+	let exact = null;
+	/** @type {number | null} */
+	let wildcard = null;
+	for (const entry of header.split(',')) {
+		const [rawToken, ...parameters] = entry.split(';');
+		const token = rawToken.trim().toLowerCase();
+		if (token !== coding && token !== '*') continue;
+
+		let quality = 1;
+		for (const parameter of parameters) {
+			const match = /^\s*q\s*=\s*([^\s]+)\s*$/i.exec(parameter);
+			if (!match) continue;
+			// RFC 9110 qvalues are 0..1 with at most three fractional digits.
+			quality = /^(?:0(?:\.\d{0,3})?|1(?:\.0{0,3})?)$/.test(match[1]) ? Number(match[1]) : 0;
+		}
+
+		if (token === coding && exact === null) exact = quality;
+		if (token === '*' && wildcard === null) wildcard = quality;
+	}
+	return exact ?? wildcard ?? 0;
+}
+
+/** @param {string | null} contentType */
+function isCompressibleContentType(contentType) {
+	if (!contentType) return false;
+	const type = contentType.split(';', 1)[0].trim().toLowerCase();
+	if (type === 'text/event-stream') return false;
+	if (type.startsWith('text/')) return true;
+	if (type === 'image/svg+xml') return true;
+	if (type === 'application/wasm') return true;
+	if (type === 'font/ttf' || type === 'font/otf') return true;
+	if (type.endsWith('+json') || type.endsWith('+xml')) return true;
+	return (
+		type === 'application/json' ||
+		type === 'application/javascript' ||
+		type === 'application/x-javascript' ||
+		type === 'application/xml' ||
+		type === 'application/xhtml+xml' ||
+		type === 'application/rss+xml' ||
+		type === 'application/atom+xml'
+	);
+}
+
+/** @param {Headers} headers */
+function appendAcceptEncodingVary(headers) {
+	const vary = headers.get('Vary');
+	if (!vary) {
+		headers.set('Vary', 'Accept-Encoding');
+		return;
+	}
+	if (vary.trim() === '*') return;
+	if (vary.split(',').some((value) => value.trim().toLowerCase() === 'accept-encoding')) {
+		return;
+	}
+	headers.set('Vary', `${vary}, Accept-Encoding`);
+}
+
+/**
+ * Decide whether this representation is eligible for negotiated gzip. Eligible
+ * identity responses still gain `Vary: Accept-Encoding`, so shared caches do
+ * not reuse them for gzip-capable clients.
+ *
+ * @param {import('node:http').IncomingMessage} request
+ * @param {number} status
+ * @param {Headers} headers
+ * @param {boolean} hasBody
+ */
+function shouldGzip(request, status, headers, hasBody) {
+	const method = (request.method || 'GET').toUpperCase();
+	if (!hasBody || method === 'HEAD') return false;
+	if (status < 200 || status === 204 || status === 205 || status === 206 || status === 304) {
+		return false;
+	}
+	if (getRequestHeader(request, 'range') !== null || headers.has('Content-Range')) return false;
+	if (headers.has('Content-Encoding')) return false;
+	if (/(?:^|,)\s*no-transform\s*(?:,|$)/i.test(headers.get('Cache-Control') || '')) {
+		return false;
+	}
+	if (!isCompressibleContentType(headers.get('Content-Type'))) return false;
+
+	const rawLength = headers.get('Content-Length');
+	if (rawLength !== null) {
+		const length = Number(rawLength);
+		if (Number.isFinite(length) && length < MIN_COMPRESSION_BYTES) return false;
+	}
+
+	appendAcceptEncodingVary(headers);
+	return encodingQuality(getRequestHeader(request, 'accept-encoding'), 'gzip') > 0;
+}
 
 /**
  * Convert a Node.js IncomingMessage to a Web Request.
@@ -70,13 +184,40 @@ export function nodeRequestToWebRequest(nodeRequest) {
  * @param {Response} webResponse
  */
 export async function sendWebResponse(nodeResponse, webResponse) {
+	return sendWebResponseForRequest(nodeResponse, webResponse);
+}
+
+/**
+ * The built-in server supplies the request so this transport layer can
+ * negotiate compression. Serverless adapters keep calling `sendWebResponse`
+ * without transport compression because their host owns content encoding.
+ *
+ * @param {import('node:http').ServerResponse} nodeResponse
+ * @param {Response} webResponse
+ * @param {import('node:http').IncomingMessage} [nodeRequest]
+ */
+async function sendWebResponseForRequest(nodeResponse, webResponse, nodeRequest) {
+	const headers = new Headers(webResponse.headers);
+	/** @type {ReadableStream<Uint8Array> | null} */
+	let body = webResponse.body;
+	if (nodeRequest && body && shouldGzip(nodeRequest, webResponse.status, headers, true)) {
+		headers.set('Content-Encoding', 'gzip');
+		headers.delete('Content-Length');
+		// Sync-flush each input chunk so an SSR shell stays progressively
+		// observable instead of waiting for the final segment to close gzip.
+		const gzip = Duplex.toWeb(createGzip({ flush: zlibConstants.Z_SYNC_FLUSH }));
+		body = body.pipeThrough(
+			/** @type {ReadableWritablePair<Uint8Array, Uint8Array>} */ (/** @type {unknown} */ (gzip)),
+		);
+	}
+
 	nodeResponse.statusCode = webResponse.status;
 	if (webResponse.statusText) nodeResponse.statusMessage = webResponse.statusText;
-	webResponse.headers.forEach((value, key) => {
+	headers.forEach((value, key) => {
 		nodeResponse.setHeader(key, value);
 	});
-	if (webResponse.body) {
-		const reader = webResponse.body.getReader();
+	if (body) {
+		const reader = body.getReader();
 		let disconnected = nodeResponse.destroyed;
 		let disconnectReason = new Error('The client disconnected while streaming the response.');
 		/** @type {Promise<void> | null} */
@@ -207,17 +348,35 @@ export function serveStaticFile(req, res, staticDir) {
 	if (!stat.isFile()) return false;
 
 	const ext = path.extname(filePath).toLowerCase();
+	const headers = new Headers({
+		'Content-Type': MIME_TYPES[ext] || 'application/octet-stream',
+		'Content-Length': String(stat.size),
+		'Cache-Control':
+			pathname.startsWith('/assets/') || pathname.startsWith('/static/')
+				? 'public, max-age=31536000, immutable'
+				: 'public, max-age=0, must-revalidate',
+	});
+	const gzip = shouldGzip(req, 200, headers, method !== 'HEAD');
+	if (gzip) {
+		headers.set('Content-Encoding', 'gzip');
+		headers.delete('Content-Length');
+	}
+
 	res.statusCode = 200;
-	res.setHeader('Content-Type', MIME_TYPES[ext] || 'application/octet-stream');
-	res.setHeader('Content-Length', stat.size);
-	res.setHeader(
-		'Cache-Control',
-		pathname.startsWith('/assets/') || pathname.startsWith('/static/')
-			? 'public, max-age=31536000, immutable'
-			: 'public, max-age=0, must-revalidate',
-	);
+	res.setHeader('Content-Type', /** @type {string} */ (headers.get('Content-Type')));
+	const contentLength = headers.get('Content-Length');
+	if (contentLength !== null) res.setHeader('Content-Length', contentLength);
+	res.setHeader('Cache-Control', /** @type {string} */ (headers.get('Cache-Control')));
+	const contentEncoding = headers.get('Content-Encoding');
+	if (contentEncoding !== null) res.setHeader('Content-Encoding', contentEncoding);
+	const vary = headers.get('Vary');
+	if (vary !== null) res.setHeader('Vary', vary);
 	if (method === 'HEAD') {
 		res.end();
+	} else if (gzip) {
+		pipeline(fs.createReadStream(filePath), createGzip(), res, (error) => {
+			if (error && !res.destroyed) res.destroy(error);
+		});
 	} else {
 		fs.createReadStream(filePath).pipe(res);
 	}
@@ -240,7 +399,7 @@ export function createNodeServer(handler, options = {}) {
 		(async () => {
 			if (staticDir && serveStaticFile(req, res, staticDir)) return;
 			const response = await handler(nodeRequestToWebRequest(req));
-			await sendWebResponse(res, response);
+			await sendWebResponseForRequest(res, response, req);
 		})().catch((error) => {
 			console.error('[octane] Request error:', error);
 			if (!res.headersSent) {

--- a/packages/app-core/tests/node-http.test.ts
+++ b/packages/app-core/tests/node-http.test.ts
@@ -1,8 +1,11 @@
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { request } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { serveStaticFile } from '../src/server/node-http.js';
+import { once } from 'node:events';
+import { createGunzip, gunzipSync } from 'node:zlib';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createNodeServer, serveStaticFile } from '../src/server/node-http.js';
 
 describe('serveStaticFile cache policy', () => {
 	let root: string;
@@ -40,5 +43,252 @@ describe('serveStaticFile cache policy', () => {
 
 	it('keeps root public files revalidatable', () => {
 		expect(cacheControl('/robots.txt')).toBe('public, max-age=0, must-revalidate');
+	});
+});
+
+describe('built-in Node server response compression', () => {
+	const html = `<main>${'Octane streaming HTML. '.repeat(160)}</main>`;
+	const staticJavaScript = `export const value = ${JSON.stringify('compressible '.repeat(180))};\n`;
+	let root: string;
+	let origin: string;
+	let transport: ReturnType<typeof createNodeServer>;
+	let listener: import('node:http').Server;
+	let segmentGate: PromiseWithResolvers<void> | null = null;
+
+	beforeAll(async () => {
+		root = mkdtempSync(join(tmpdir(), 'octane-node-compression-'));
+		mkdirSync(join(root, 'assets'), { recursive: true });
+		writeFileSync(join(root, 'assets/app-123.js'), staticJavaScript);
+
+		transport = createNodeServer(
+			(request) => {
+				const pathname = new URL(request.url).pathname;
+				if (pathname === '/stream') {
+					if (!segmentGate) throw new Error('stream gate was not initialized');
+					const gate = segmentGate;
+					const encoder = new TextEncoder();
+					return new Response(
+						new ReadableStream<Uint8Array>({
+							start(controller) {
+								controller.enqueue(encoder.encode('shell'));
+								void gate.promise.then(() => {
+									controller.enqueue(encoder.encode('segment'));
+									controller.close();
+								});
+							},
+						}),
+						{ headers: { 'Content-Type': 'text/html; charset=utf-8' } },
+					);
+				}
+				if (pathname === '/small') {
+					const body = 'small response';
+					return new Response(body, {
+						headers: {
+							'Content-Type': 'text/plain; charset=utf-8',
+							'Content-Length': String(Buffer.byteLength(body)),
+						},
+					});
+				}
+				if (pathname === '/image') {
+					const body = new Uint8Array(2048);
+					return new Response(body, {
+						headers: {
+							'Content-Type': 'image/png',
+							'Content-Length': String(body.byteLength),
+						},
+					});
+				}
+				if (pathname === '/encoded') {
+					return new Response('pre-encoded representation', {
+						headers: {
+							'Content-Type': 'text/plain; charset=utf-8',
+							'Content-Encoding': 'br',
+						},
+					});
+				}
+				if (pathname === '/no-transform') {
+					return new Response(html, {
+						headers: {
+							'Content-Type': 'text/html; charset=utf-8',
+							'Cache-Control': 'public, no-transform, max-age=60',
+						},
+					});
+				}
+				if (pathname === '/partial') {
+					return new Response(html.slice(0, 128), {
+						status: 206,
+						headers: {
+							'Content-Type': 'text/html; charset=utf-8',
+							'Content-Range': `bytes 0-127/${Buffer.byteLength(html)}`,
+						},
+					});
+				}
+				return new Response(html, {
+					headers: {
+						'Content-Type': 'text/html; charset=utf-8',
+						Vary:
+							pathname === '/vary-star'
+								? '*'
+								: pathname === '/vary-existing'
+									? 'Origin, accept-encoding'
+									: 'Origin',
+					},
+				});
+			},
+			{ staticDir: root },
+		);
+		listener = transport.listen(0);
+		await once(listener, 'listening');
+		const address = listener.address();
+		if (!address || typeof address === 'string') throw new Error('Node test server has no port');
+		origin = `http://127.0.0.1:${address.port}`;
+	});
+
+	afterAll(async () => {
+		const closed = once(listener, 'close');
+		transport.close();
+		await closed;
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	function get(
+		pathname: string,
+		options: { method?: string; headers?: Record<string, string> } = {},
+	) {
+		return new Promise<{
+			status: number;
+			headers: import('node:http').IncomingHttpHeaders;
+			body: Buffer;
+		}>((resolve, reject) => {
+			const outgoing = request(
+				origin + pathname,
+				{
+					method: options.method ?? 'GET',
+					headers: { Connection: 'close', ...options.headers },
+				},
+				(response) => {
+					const chunks: Buffer[] = [];
+					response.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+					response.on('end', () => {
+						resolve({
+							status: response.statusCode ?? 0,
+							headers: response.headers,
+							body: Buffer.concat(chunks),
+						});
+					});
+				},
+			);
+			outgoing.on('error', reject);
+			outgoing.end();
+		});
+	}
+
+	it('gzip-streams SSR and static text without buffering their original length', async () => {
+		const rendered = await get('/', { headers: { 'Accept-Encoding': 'gzip' } });
+		expect(rendered.status).toBe(200);
+		expect(rendered.headers['content-encoding']).toBe('gzip');
+		expect(rendered.headers['content-length']).toBeUndefined();
+		expect(rendered.headers.vary).toBe('Origin, Accept-Encoding');
+		expect(gunzipSync(rendered.body).toString()).toBe(html);
+
+		const asset = await get('/assets/app-123.js', {
+			headers: { 'Accept-Encoding': 'gzip' },
+		});
+		expect(asset.status).toBe(200);
+		expect(asset.headers['content-encoding']).toBe('gzip');
+		expect(asset.headers['content-length']).toBeUndefined();
+		expect(asset.headers.vary).toBe('Accept-Encoding');
+		expect(asset.headers['cache-control']).toBe('public, max-age=31536000, immutable');
+		expect(gunzipSync(asset.body).toString()).toBe(staticJavaScript);
+	});
+
+	it('flushes each compressed SSR wave before a later segment resolves', async () => {
+		segmentGate = Promise.withResolvers<void>();
+		const shellObserved = Promise.withResolvers<void>();
+		const responseHeaders = Promise.withResolvers<import('node:http').IncomingHttpHeaders>();
+		let output = '';
+		const completed = new Promise<string>((resolve, reject) => {
+			const outgoing = request(
+				origin + '/stream',
+				{ headers: { Connection: 'close', 'Accept-Encoding': 'gzip' } },
+				(response) => {
+					responseHeaders.resolve(response.headers);
+					const gunzip = createGunzip();
+					gunzip.on('data', (chunk) => {
+						output += chunk.toString();
+						if (output.includes('shell')) shellObserved.resolve();
+					});
+					gunzip.on('end', () => resolve(output));
+					gunzip.on('error', reject);
+					response.pipe(gunzip);
+				},
+			);
+			outgoing.on('error', reject);
+			outgoing.end();
+		});
+
+		const timeout = setTimeout(
+			() => shellObserved.reject(new Error('compressed shell did not flush')),
+			1000,
+		);
+		try {
+			await shellObserved.promise;
+			expect((await responseHeaders.promise)['content-encoding']).toBe('gzip');
+			expect(output).toBe('shell');
+		} finally {
+			clearTimeout(timeout);
+			segmentGate.resolve();
+		}
+		expect(await completed).toBe('shellsegment');
+		segmentGate = null;
+	});
+
+	it('honors qvalues and keeps cache variants distinct for identity responses', async () => {
+		const excluded = await get('/', {
+			headers: { 'Accept-Encoding': 'gzip;q=0, *;q=1' },
+		});
+		expect(excluded.headers['content-encoding']).toBeUndefined();
+		expect(excluded.headers.vary).toBe('Origin, Accept-Encoding');
+		expect(excluded.body.toString()).toBe(html);
+
+		const wildcard = await get('/', { headers: { 'Accept-Encoding': '*;q=0.5' } });
+		expect(wildcard.headers['content-encoding']).toBe('gzip');
+		expect(gunzipSync(wildcard.body).toString()).toBe(html);
+
+		const varyStar = await get('/vary-star', {
+			headers: { 'Accept-Encoding': 'gzip' },
+		});
+		expect(varyStar.headers['content-encoding']).toBe('gzip');
+		expect(varyStar.headers.vary).toBe('*');
+
+		const varyExisting = await get('/vary-existing', {
+			headers: { 'Accept-Encoding': 'gzip' },
+		});
+		expect(varyExisting.headers['content-encoding']).toBe('gzip');
+		expect(varyExisting.headers.vary).toBe('Origin, accept-encoding');
+	});
+
+	it('leaves small, noncompressible, transformed, partial, range, and HEAD responses intact', async () => {
+		for (const pathname of ['/small', '/image', '/encoded', '/no-transform', '/partial']) {
+			const response = await get(pathname, { headers: { 'Accept-Encoding': 'gzip' } });
+			expect(response.headers['content-encoding']).toBe(pathname === '/encoded' ? 'br' : undefined);
+			expect(response.headers.vary).toBeUndefined();
+		}
+
+		const ranged = await get('/assets/app-123.js', {
+			headers: { 'Accept-Encoding': 'gzip', Range: 'bytes=0-99' },
+		});
+		expect(ranged.status).toBe(200);
+		expect(ranged.headers['content-encoding']).toBeUndefined();
+		expect(ranged.headers['content-length']).toBe(String(Buffer.byteLength(staticJavaScript)));
+		expect(ranged.body.toString()).toBe(staticJavaScript);
+
+		const head = await get('/assets/app-123.js', {
+			method: 'HEAD',
+			headers: { 'Accept-Encoding': 'gzip' },
+		});
+		expect(head.headers['content-encoding']).toBeUndefined();
+		expect(head.headers['content-length']).toBe(String(Buffer.byteLength(staticJavaScript)));
+		expect(head.body).toHaveLength(0);
 	});
 });

--- a/packages/octane/src/compiler/bundler.js
+++ b/packages/octane/src/compiler/bundler.js
@@ -545,7 +545,10 @@ class OctaneBundlerCompiler {
 		}
 		const requestedHmr = normalizeHmrDialect(options.hmr ?? this.defaults.hmr);
 		const hmr = environment === 'server' ? false : requestedHmr;
-		const dev = environment === 'server' ? false : (options.dev ?? this.defaults.dev ?? !!hmr);
+		// Server HMR stays disabled, but integrations may explicitly request DEV
+		// server diagnostics (Vite does this for `serve`). With no explicit value,
+		// server transforms retain their established production default.
+		const dev = options.dev ?? this.defaults.dev ?? (environment === 'client' && !!hmr);
 		// Profiling is a client-runtime build specialization, deliberately independent
 		// of both HMR and dev hydration diagnostics. Server transforms stay byte-for-
 		// byte identical even when a shared client/server bundler configuration opts in.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -3047,8 +3047,10 @@ function instrumentProfileComponents(ast, ctx) {
  * @param {string} source
  * @param {string} filename
  * @param {{ hmr?: boolean | 'vite' | 'webpack', mode?: 'client' | 'server', dev?: boolean, profile?: boolean, profileFilename?: string, renderer?: { id: string, module: string, target: 'dom' | 'universal', server?: string }, rendererBoundaries?: Readonly<Record<string, Readonly<Record<string, { ownerRenderer: string, childRenderer: string, prop: string, server?: string }>>>>, rendererRegistry?: Readonly<Record<string, { module: string, target: 'dom' | 'universal', server?: string }>>, clientOnlyImports?: readonly unknown[] }} [options] —
- *   `dev: true` emits dev-only hydration source-location metadata (per-component
- *   `__s.locs`/`__s.locFile`); strictly gated so production output is byte-identical.
+ *   `dev: true` emits client hydration source-location metadata (per-component
+ *   `__s.locs`/`__s.locFile`) and, in server mode, source-located native-element
+ *   scopes for invalid HTML nesting diagnostics. Both are strictly gated so
+ *   production output carries no diagnostic calls or metadata.
  *   `hmr: true` (backwards-compatible shorthand for `hmr: 'vite'`) wraps each
  *   exported component in `hmr(Component)` and emits Vite
  *   `import.meta.hot.accept(...)` wiring. `hmr: 'webpack'` emits Rspack/webpack
@@ -3882,6 +3884,7 @@ function compileServer(source, filename, options) {
 		usedCompilerNames: collectIdentifierNames(ast),
 		mode: 'server',
 		hmr: false, // SSR never hot-swaps in place; client/server production slot shapes stay aligned
+		dev: !!(options && options.dev),
 		// SSR MIRROR of the parallel-`use()` pipeline (docs/suspense-parallel-use-
 		// plan.md Phase 5): the same memoize (Pass A) + hoist/batch (Pass B)
 		// transforms run on server bodies, emitting `_$puMemo`/`_$puBatch` — the
@@ -3897,6 +3900,7 @@ function compileServer(source, filename, options) {
 		userRuntimeDefaults: new Set(),
 		hoistedHelpers: [],
 		cssInjections: [],
+		moduleCssInjections: [],
 		currentComponentLocals: null,
 		knownStringLocals: null, // Set<string> of provably-string locals (text-hole inference)
 		nextHookSymId: 0,
@@ -3915,6 +3919,20 @@ function compileServer(source, filename, options) {
 	// M3 inherit-range exclusion set — must match the client compile's
 	// (see inheritSoleCompRoot; both modes read the same import declarations).
 	ctx._octaneBoundaryNames = collectOctaneBoundaryNames(ast.body);
+
+	// Style maps are module values and can be referenced by a component declared
+	// before the map itself. Lower every top-level map before compiling any
+	// component, then activate the module's sheets from each component body so
+	// injectStyle runs while a render-local CSS collector exists. This mirrors the
+	// client module's eager registration without retaining CSS globally on the
+	// server (which would leak unrelated imports and request history into output).
+	for (const node of ast.body) {
+		applyStyleMap(node, ctx);
+		if (node.type === 'ExportNamedDeclaration' && node.declaration) {
+			applyStyleMap(node.declaration, ctx);
+		}
+	}
+	ctx.moduleCssInjections = ctx.cssInjections.slice();
 
 	let body = emitServerModulePrelude(serverModuleInfo, ctx);
 	for (const node of ast.body) {
@@ -3943,10 +3961,6 @@ function compileServer(source, filename, options) {
 			// User imports from 'octane' resolve to the server runtime instead.
 			addUserImportSpecifiers(ctx, node);
 		} else {
-			applyStyleMap(node, ctx);
-			if (node.type === 'ExportNamedDeclaration' && node.declaration) {
-				applyStyleMap(node.declaration, ctx);
-			}
 			body += printNode(rewriteJsxValues(node, ctx)) + '\n';
 		}
 	}
@@ -3993,7 +4007,9 @@ function compileServerComponent(node, ctx) {
 	// active server render collects CSS only for components it actually renders).
 	const beforeCss = ctx.cssInjections.length;
 	const cssHash = applyCssScoping(node, ctx);
-	const cssEntries = ctx.cssInjections.slice(beforeCss);
+	const cssEntries = [...ctx.moduleCssInjections, ...ctx.cssInjections.slice(beforeCss)].sort(
+		(a, b) => a.order - b.order,
+	);
 
 	const prevLocals = ctx.currentComponentLocals;
 	const prevKnownStr = ctx.knownStringLocals;
@@ -4401,10 +4417,23 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash, compone
 	// Wrap the assembled string in an IIFE that binds the spread temps when any
 	// exist (so the temp names resolve); otherwise return the bare concatenation.
 	const finalize = () => {
-		const body = parts.join(' + ');
-		if (spreadTemps.length === 0) return body;
-		const decls = spreadTemps.map((t) => `const ${t.tempName} = (${t.argExpr});`).join(' ');
-		return `(() => { ${decls} return ${body}; })()`;
+		let body = parts.join(' + ');
+		if (spreadTemps.length > 0) {
+			const decls = spreadTemps.map((t) => `const ${t.tempName} = (${t.argExpr});`).join(' ');
+			body = `(() => { ${decls} return ${body}; })()`;
+		}
+		if (!ctx.dev) return body;
+
+		// Keep the element active while its children execute so the server runtime
+		// can validate parser-repaired relationships through component boundaries.
+		// Production output takes the branch above: no helper import, source string,
+		// callback, or runtime work.
+		const loc = node.loc && node.loc.start;
+		const source = loc
+			? JSON.stringify(`${ctx.mapSourceName}:${loc.line}:${loc.column}`)
+			: 'void 0';
+		ctx.runtimeNeeded.add('ssrElement');
+		return `_$ssrElement(${JSON.stringify(tag)}, ${source}, () => (${body}))`;
 	};
 
 	for (let attrI = 0; attrI < attrs.length; attrI++) {
@@ -5186,7 +5215,7 @@ function applyStyleMap(stmt, ctx) {
 		analyzeCss(sheet);
 		prepareStylesheetForRender(sheet, true);
 		const css = renderStylesheets([sheet]);
-		ctx.cssInjections.push({ hash, css });
+		ctx.cssInjections.push({ hash, css, order: styleNode.start ?? stmt.start ?? 0 });
 		ctx.runtimeNeeded.add('injectStyle');
 		// Replace the JSXStyleElement init with the class-map ObjectExpression.
 		decl.init = createStyleClassMapFromStylesheet(sheet);
@@ -5307,7 +5336,11 @@ function applyCssScoping(componentNode, ctx) {
 		prepareStylesheetForRender(sheet);
 	}
 	const css = renderStylesheets(styleSheets);
-	ctx.cssInjections.push({ hash: cssHash, css });
+	ctx.cssInjections.push({
+		hash: cssHash,
+		css,
+		order: styleSheets[0]?.start ?? componentNode.start ?? 0,
+	});
 	ctx.runtimeNeeded.add('injectStyle');
 	// Mutate the render tree: add hash class to every native element AND
 	// strip JSXStyleElement nodes (annotateWithHash returns null for them when
@@ -5349,7 +5382,7 @@ function compileComponent(node, ctx, options) {
 		prepareStylesheetForRender(node.css);
 		const css = renderStylesheets([node.css]);
 		cssHash = node.css.hash;
-		ctx.cssInjections.push({ hash: cssHash, css });
+		ctx.cssInjections.push({ hash: cssHash, css, order: node.start ?? 0 });
 		ctx.runtimeNeeded.add('injectStyle');
 	}
 

--- a/packages/octane/src/compiler/vite.js
+++ b/packages/octane/src/compiler/vite.js
@@ -242,9 +242,10 @@ export function octane(options = {}) {
 				const result = compiler.transform(code, id, {
 					environment: server ? 'server' : 'client',
 					hmr: !server && hmrEnabled ? 'vite' : false,
-					// Preserve the existing Vite gate: source locations are emitted only
-					// for a client serve transform where HMR is active.
-					dev: !server && !!hmrEnabled,
+					// DEV server transforms also carry SSR-only diagnostics. HMR itself
+					// remains client-only; an explicit `hmr: false` keeps both transforms
+					// on the production compiler path.
+					dev: !!hmrEnabled,
 					profile: !server && profileEnabled,
 					parallelUse: options.parallelUse,
 					collectVoidComponentExports:

--- a/packages/octane/src/html-tree-validation.ts
+++ b/packages/octane/src/html-tree-validation.ts
@@ -1,0 +1,203 @@
+/**
+ * HTML parser-repair rules used by DEV SSR nesting diagnostics.
+ *
+ * This is intentionally narrower than the full HTML content model: it only
+ * lists placements the browser repairs while parsing serialized HTML, because
+ * those repairs can change the DOM before hydration. Adapted from Svelte's
+ * html-tree-validation module, which Ripple also uses.
+ *
+ * Copyright (c) 2016-2025 Svelte Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+type ChildRule =
+	| { direct: readonly string[] }
+	| { descendant: readonly string[]; resetBy?: readonly string[] }
+	| { only: readonly string[] };
+
+const autoclosingChildren: Record<string, ChildRule> = {
+	li: { direct: ['li'] },
+	dt: { descendant: ['dt', 'dd'], resetBy: ['dl'] },
+	dd: { descendant: ['dt', 'dd'], resetBy: ['dl'] },
+	p: {
+		descendant: [
+			'address',
+			'article',
+			'aside',
+			'blockquote',
+			'div',
+			'dl',
+			'fieldset',
+			'footer',
+			'form',
+			'h1',
+			'h2',
+			'h3',
+			'h4',
+			'h5',
+			'h6',
+			'header',
+			'hgroup',
+			'hr',
+			'main',
+			'menu',
+			'nav',
+			'ol',
+			'p',
+			'pre',
+			'section',
+			'table',
+			'ul',
+		],
+	},
+	rt: { descendant: ['rt', 'rp'] },
+	rp: { descendant: ['rt', 'rp'] },
+	optgroup: { descendant: ['optgroup'] },
+	option: { descendant: ['option', 'optgroup'] },
+	thead: { direct: ['tbody', 'tfoot'] },
+	tbody: { direct: ['tbody', 'tfoot'] },
+	tfoot: { direct: ['tbody'] },
+	tr: { direct: ['tr', 'tbody'] },
+	td: { direct: ['td', 'th', 'tr'] },
+	th: { direct: ['td', 'th', 'tr'] },
+};
+
+const disallowedChildren: Record<string, ChildRule> = {
+	...autoclosingChildren,
+	form: { descendant: ['form'] },
+	a: { descendant: ['a'] },
+	button: { descendant: ['button'] },
+	h1: { descendant: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] },
+	h2: { descendant: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] },
+	h3: { descendant: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] },
+	h4: { descendant: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] },
+	h5: { descendant: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] },
+	h6: { descendant: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] },
+	tr: { only: ['th', 'td', 'style', 'script', 'template'] },
+	tbody: { only: ['tr', 'style', 'script', 'template'] },
+	thead: { only: ['tr', 'style', 'script', 'template'] },
+	tfoot: { only: ['tr', 'style', 'script', 'template'] },
+	colgroup: { only: ['col', 'template'] },
+	table: {
+		only: ['caption', 'colgroup', 'tbody', 'thead', 'tfoot', 'style', 'script', 'template'],
+	},
+	head: {
+		only: [
+			'base',
+			'basefont',
+			'bgsound',
+			'link',
+			'meta',
+			'title',
+			'noscript',
+			'noframes',
+			'style',
+			'script',
+			'template',
+		],
+	},
+	html: { only: ['head', 'body', 'frameset'] },
+	frameset: { only: ['frame'] },
+	'#document': { only: ['html'] },
+};
+
+function elementLabel(tag: string, location?: string): string {
+	return location ? `\`<${tag}>\` (${location})` : `\`<${tag}>\``;
+}
+
+/** Return a diagnostic when `childTag` causes an ancestor to be repaired. */
+export function invalidHtmlNestingWithAncestor(
+	childTag: string,
+	ancestors: string[],
+	childLocation?: string,
+	ancestorLocation?: string,
+): string | null {
+	if (childTag.includes('-')) return null;
+
+	const ancestorTag = ancestors[ancestors.length - 1];
+	const disallowed = disallowedChildren[ancestorTag];
+	if (!disallowed) return null;
+
+	if ('resetBy' in disallowed && disallowed.resetBy) {
+		for (let i = ancestors.length - 2; i >= 0; i--) {
+			const ancestor = ancestors[i];
+			if (ancestor.includes('-')) return null;
+			if (disallowed.resetBy.includes(ancestor)) return null;
+		}
+	}
+
+	if ('descendant' in disallowed && disallowed.descendant.includes(childTag)) {
+		return `${elementLabel(childTag, childLocation)} cannot be a descendant of ${elementLabel(ancestorTag, ancestorLocation)}`;
+	}
+
+	return null;
+}
+
+/** Return a diagnostic when `childTag` causes its direct parent to be repaired. */
+export function invalidHtmlNestingWithParent(
+	childTag: string,
+	parentTag: string,
+	childLocation?: string,
+	parentLocation?: string,
+): string | null {
+	if (childTag.includes('-') || parentTag.includes('-')) return null;
+	if (parentTag === 'template') return null;
+
+	const disallowed = disallowedChildren[parentTag];
+	const child = elementLabel(childTag, childLocation);
+	const parent = elementLabel(parentTag, parentLocation);
+
+	if (disallowed) {
+		if ('direct' in disallowed && disallowed.direct.includes(childTag)) {
+			return `${child} cannot be a direct child of ${parent}`;
+		}
+		if ('descendant' in disallowed && disallowed.descendant.includes(childTag)) {
+			return `${child} cannot be a child of ${parent}`;
+		}
+		if ('only' in disallowed && !disallowed.only.includes(childTag)) {
+			const allowed = disallowed.only.map((tag) => `\`<${tag}>\``).join(', ');
+			return `${child} cannot be a child of ${parent}. \`<${parentTag}>\` only allows these children: ${allowed}`;
+		}
+		if ('only' in disallowed) return null;
+	}
+
+	switch (childTag) {
+		case 'body':
+		case 'caption':
+		case 'col':
+		case 'colgroup':
+		case 'frameset':
+		case 'frame':
+		case 'head':
+		case 'html':
+			return `${child} cannot be a child of ${parent}`;
+		case 'thead':
+		case 'tbody':
+		case 'tfoot':
+			return `${child} must be the child of a \`<table>\`, not ${parent}`;
+		case 'td':
+		case 'th':
+			return `${child} must be the child of a \`<tr>\`, not ${parent}`;
+		case 'tr':
+			return `${child} must be the child of a \`<thead>\`, \`<tbody>\`, or \`<tfoot>\`, not ${parent}`;
+		default:
+			return null;
+	}
+}

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -54,6 +54,10 @@ import {
 // Shared client/SSR CSS helpers (single source in css.ts so class strings and
 // hyphenated style keys stay byte-equal across the two runtimes).
 import { normalizeClass, styleName } from './css.js';
+import {
+	invalidHtmlNestingWithAncestor,
+	invalidHtmlNestingWithParent,
+} from './html-tree-validation.js';
 import { sanitizeURL, sanitizeURLAttribute } from './sanitize-url.js';
 export { normalizeClass };
 
@@ -61,6 +65,16 @@ interface SSRScope {
 	parent: SSRScope | null;
 	/** Context Provider values stamped on this scope (lazily allocated). */
 	$$ctxValues: Map<unknown, unknown> | null;
+}
+
+type ParserNamespace = 'html' | 'svg' | 'mathml';
+
+interface SsrElementContext {
+	tag: string;
+	parent: SsrElementContext | null;
+	namespace: ParserNamespace;
+	childrenNamespace: ParserNamespace;
+	location?: string;
 }
 
 type ServerComponent = (props: any, scope: SSRScope, extra?: any) => string;
@@ -169,6 +183,15 @@ let CURRENT_PARENT_SCOPE: SSRScope | null = null;
 // alone cannot distinguish a child rendered at the same position in an @try's
 // content and pending arms, even though those are separate client block scopes.
 let ASYNC_SCOPE = '';
+// DEV SSR HTML-parser context. Compiler-emitted ssrElement wrappers keep native
+// elements on this stack while their children execute, including through
+// component calls. The warning set is render-local and shared by canonical
+// retries, so one authored relationship reports once without leaking between
+// requests. Discovery passes leave it null because their output is discarded.
+let CURRENT_SSR_ELEMENT: SsrElementContext | null = null;
+// null = validation disabled (outside a canonical render / discovery pass),
+// undefined = enabled but no warning set allocated yet.
+let SSR_NESTING_WARNINGS: Set<string> | null | undefined = null;
 
 // Walk a frame to its dotted path ('' for the root). Memoized per frame.
 function framePath(f: Frame): string {
@@ -200,6 +223,102 @@ function nextChildSegment(frame: Frame): number {
 
 function ssrScope(parent: SSRScope | null): SSRScope {
 	return { parent, $$ctxValues: null };
+}
+
+function ssrElementNamespaces(
+	tag: string,
+	parent: SsrElementContext | null,
+): { namespace: ParserNamespace; childrenNamespace: ParserNamespace } {
+	const inherited = parent?.childrenNamespace ?? FRAME?.namespace ?? 'html';
+	const namespace: ParserNamespace =
+		tag === 'svg'
+			? 'svg'
+			: tag === 'math'
+				? 'mathml'
+				: inherited === 'html' && SVG_ONLY_TAGS.has(tag)
+					? 'svg'
+					: inherited;
+	const childrenNamespace: ParserNamespace =
+		tag === 'foreignObject'
+			? 'html'
+			: tag === 'svg'
+				? 'svg'
+				: tag === 'math'
+					? 'mathml'
+					: inherited === 'html' && SVG_ONLY_TAGS.has(tag)
+						? 'svg'
+						: inherited;
+	return { namespace, childrenNamespace };
+}
+
+function reportInvalidHtmlNesting(message: string): void {
+	const warning =
+		'Octane SSR invalid HTML nesting: ' +
+		message +
+		'\n\nThe browser will repair this HTML before hydration. This can shift content and cause a hydration mismatch.';
+	let seen = SSR_NESTING_WARNINGS;
+	if (seen === null) return;
+	if (seen === undefined) {
+		seen = new Set();
+		SSR_NESTING_WARNINGS = seen;
+		if (RESOLVED !== null) RESOLVED.nestingWarnings = seen;
+	}
+	if (seen.has(warning)) return;
+	seen.add(warning);
+	console.error(warning);
+}
+
+/** Compiler ABI: validate and scope one native element during a DEV SSR render. */
+export function ssrElement(
+	tag: string,
+	location: string | undefined,
+	render: () => string,
+): string {
+	if (process.env.NODE_ENV === 'production' || SSR_NESTING_WARNINGS === null) return render();
+
+	const parent = CURRENT_SSR_ELEMENT;
+	const { namespace, childrenNamespace } = ssrElementNamespaces(tag, parent);
+	const semanticTag = tag.toLowerCase();
+	const element: SsrElementContext = {
+		tag: semanticTag,
+		parent,
+		namespace,
+		childrenNamespace,
+		location,
+	};
+
+	// Foreign-content parsing is independent of the HTML repair rules. Stop at
+	// that boundary; <foreignObject> children naturally start a fresh HTML chain.
+	if (namespace === 'html' && parent?.namespace === 'html') {
+		const parentMessage = invalidHtmlNestingWithParent(
+			semanticTag,
+			parent.tag,
+			location,
+			parent.location,
+		);
+		if (parentMessage !== null) reportInvalidHtmlNesting(parentMessage);
+
+		let ancestor = parent.parent;
+		const ancestors = [parent.tag];
+		while (ancestor !== null && ancestor.namespace === 'html') {
+			ancestors.push(ancestor.tag);
+			const ancestorMessage = invalidHtmlNestingWithAncestor(
+				semanticTag,
+				ancestors,
+				location,
+				ancestor.location,
+			);
+			if (ancestorMessage !== null) reportInvalidHtmlNesting(ancestorMessage);
+			ancestor = ancestor.parent;
+		}
+	}
+
+	CURRENT_SSR_ELEMENT = element;
+	try {
+		return render();
+	} finally {
+		CURRENT_SSR_ELEMENT = parent;
+	}
 }
 
 const NOOP = (): void => {};
@@ -3423,6 +3542,8 @@ type ResolvedMap = Map<string, SuspenseOutcome> & {
 	/** Cross-pass fallback ids for transient object keys at one lexical position. */
 	asyncPositionIdentities: Map<string, number>;
 	nextAsyncIdentity: number;
+	/** Lazily allocated DEV SSR invalid-nesting warnings reported by this render. */
+	nestingWarnings?: Set<string>;
 	pu: {
 		created: Map<string, { deps: unknown[]; value: unknown }>;
 		resolvedT: Map<PromiseLike<unknown>, SuspenseOutcome>;
@@ -3478,6 +3599,8 @@ interface Ambient {
 	props: any;
 	parentScope: SSRScope | null;
 	asyncScope: string;
+	ssrElement: SsrElementContext | null;
+	nestingWarnings: Set<string> | null | undefined;
 	vtTrySeq: number;
 	vtHasCandidates: boolean;
 	vtStack: Array<{ candidate: VtSsrCandidate; consumed: boolean }>;
@@ -3499,6 +3622,8 @@ function saveAmbient(): Ambient {
 		props: CURRENT_PROPS,
 		parentScope: CURRENT_PARENT_SCOPE,
 		asyncScope: ASYNC_SCOPE,
+		ssrElement: CURRENT_SSR_ELEMENT,
+		nestingWarnings: SSR_NESTING_WARNINGS,
 		vtTrySeq: VT_SSR_TRY_SEQ,
 		vtHasCandidates: VT_SSR_HAS_CANDIDATES,
 		vtStack: VT_SSR_STACK.map((candidate) => ({ candidate, consumed: candidate.consumed })),
@@ -3520,6 +3645,8 @@ function restoreAmbient(a: Ambient): void {
 	CURRENT_PROPS = a.props;
 	CURRENT_PARENT_SCOPE = a.parentScope;
 	ASYNC_SCOPE = a.asyncScope;
+	CURRENT_SSR_ELEMENT = a.ssrElement;
+	SSR_NESTING_WARNINGS = a.nestingWarnings;
 	VT_SSR_TRY_SEQ = a.vtTrySeq;
 	VT_SSR_HAS_CANDIDATES = a.vtHasCandidates;
 	VT_SSR_STACK.length = 0;
@@ -3560,6 +3687,8 @@ function runFullFramedPass(
 	const serial = (SERIAL = [] as unknown[]);
 	const deferred = (DEFERRED = [] as Job[]);
 	RESOLVED = resolved;
+	CURRENT_SSR_ELEMENT = null;
+	SSR_NESTING_WARNINGS = resolved.nestingWarnings;
 	const root = ssrScope(null);
 	CURRENT_SCOPE = root;
 	// A root frame so use() keys resolve; the root component is the fallback
@@ -3639,6 +3768,8 @@ function runDiscoveryRound(
 	SERIAL = [] as unknown[];
 	const deferred = (DEFERRED = [] as Job[]);
 	RESOLVED = resolved;
+	CURRENT_SSR_ELEMENT = null;
+	SSR_NESTING_WARNINGS = null;
 	FRAME = null;
 	CURRENT_COMP = null;
 	CURRENT_PROPS = null;

--- a/packages/octane/src/server/index.ts
+++ b/packages/octane/src/server/index.ts
@@ -119,6 +119,7 @@ export {
 	ssrTextareaValue,
 	ssrSelectScope,
 	ssrOption,
+	ssrElement,
 	ssrComponent,
 	ssrComponentNS,
 	ssrInNamespace,

--- a/packages/octane/tests/_fixtures/ssr-invalid-nesting.tsrx
+++ b/packages/octane/tests/_fixtures/ssr-invalid-nesting.tsrx
@@ -1,0 +1,88 @@
+export function Valid() @{
+	<main>
+		<p>valid</p>
+		<table>
+			<tbody>
+				<tr>
+					<td>cell</td>
+				</tr>
+			</tbody>
+		</table>
+	</main>
+}
+
+export function Direct() @{
+	<p>
+		<div>direct</div>
+	</p>
+}
+
+function InnerButton() @{
+	<button>inner</button>
+}
+
+function ButtonWrapper() @{
+	<section>
+		<InnerButton />
+	</section>
+}
+
+export function CrossComponent() @{
+	<button>
+		<ButtonWrapper />
+	</button>
+}
+
+export function InvalidTable() @{
+	<table>
+		<tr>
+			<td>cell</td>
+		</tr>
+	</table>
+}
+
+export function CustomElementBoundary() @{
+	<x-shell>
+		<tr>
+			<td>custom</td>
+		</tr>
+	</x-shell>
+}
+
+export function SvgNestedLinks() @{
+	<svg>
+		<a>
+			<a>svg</a>
+		</a>
+	</svg>
+}
+
+export function ForeignObjectHtml() @{
+	<svg>
+		<foreignObject>
+			<p>
+				<div>html</div>
+			</p>
+		</foreignObject>
+	</svg>
+}
+
+export function Repeat(props) @{
+	<section>
+		@for (const item of props.items; key item) {
+			<p>
+				<div>
+					{item as string}
+				</div>
+			</p>
+		}
+	</section>
+}
+
+export function NestedRenderIsolation(props) @{
+	<button data-nested={props.renderNested()}>
+		<section>
+			<button>outer</button>
+		</section>
+	</button>
+}

--- a/packages/octane/tests/ssr-invalid-nesting.test.ts
+++ b/packages/octane/tests/ssr-invalid-nesting.test.ts
@@ -1,0 +1,149 @@
+import { resolve } from 'node:path';
+import { compile } from 'octane/compiler';
+import { octane } from 'octane/compiler/vite';
+import { renderToString } from 'octane/server';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { loadServerFixture } from './_server-fixture';
+
+const fixture = resolve(__dirname, '_fixtures/ssr-invalid-nesting.tsrx');
+const dev = loadServerFixture(fixture, { compileOptions: { dev: true } });
+const prod = loadServerFixture(fixture, { compileOptions: { dev: false } });
+
+function errors() {
+	return vi.spyOn(console, 'error').mockImplementation(() => {});
+}
+
+function messageAt(spy: ReturnType<typeof errors>, index = 0): string {
+	return String(spy.mock.calls[index]?.[0]);
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe('DEV SSR invalid HTML nesting', () => {
+	it('leaves valid HTML unchanged and silent', () => {
+		const spy = errors();
+		const { html } = renderToString(dev.Valid);
+
+		expect(html).toContain(
+			'<main><p>valid</p><table><tbody><tr><td>cell</td></tr></tbody></table></main>',
+		);
+		expect(spy).not.toHaveBeenCalled();
+	});
+
+	it('reports a direct parser-repaired relationship with both source locations', () => {
+		const spy = errors();
+		const { html } = renderToString(dev.Direct);
+
+		expect(html).toContain('<p><div>direct</div></p>');
+		expect(spy).toHaveBeenCalledTimes(1);
+		const warning = messageAt(spy);
+		expect(warning).toContain('Octane SSR invalid HTML nesting:');
+		expect(warning).toContain('`<div>`');
+		expect(warning).toContain('cannot be a child of `<p>`');
+		expect(warning).toContain('The browser will repair this HTML before hydration');
+		expect(warning.match(/ssr-invalid-nesting\.tsrx:\d+:\d+/g)).toHaveLength(2);
+	});
+
+	it('tracks transparent component boundaries when checking ancestors', () => {
+		const spy = errors();
+		renderToString(dev.CrossComponent);
+
+		expect(spy).toHaveBeenCalledTimes(1);
+		const warning = messageAt(spy);
+		expect(warning).toContain('`<button>`');
+		expect(warning).toContain('cannot be a descendant of `<button>`');
+		expect(warning.match(/ssr-invalid-nesting\.tsrx:\d+:\d+/g)).toHaveLength(2);
+	});
+
+	it('reports table markup the HTML parser will repair', () => {
+		const spy = errors();
+		renderToString(dev.InvalidTable);
+
+		expect(spy).toHaveBeenCalledTimes(1);
+		expect(messageAt(spy)).toContain('`<table>` only allows these children');
+	});
+
+	it('respects custom-element and SVG parsing boundaries', () => {
+		const spy = errors();
+		renderToString(dev.CustomElementBoundary);
+		renderToString(dev.SvgNestedLinks);
+
+		expect(spy).not.toHaveBeenCalled();
+	});
+
+	it('resumes HTML validation inside SVG foreignObject', () => {
+		const spy = errors();
+		renderToString(dev.ForeignObjectHtml);
+
+		expect(spy).toHaveBeenCalledTimes(1);
+		expect(messageAt(spy)).toContain('cannot be a child of `<p>`');
+	});
+
+	it('deduplicates a repeated authored relationship within one render', () => {
+		const spy = errors();
+		renderToString(dev.Repeat, { items: ['a', 'b', 'c'] });
+
+		expect(spy).toHaveBeenCalledTimes(1);
+	});
+
+	it('uses a fresh warning set for each render', () => {
+		const spy = errors();
+		renderToString(dev.Direct);
+		renderToString(dev.Direct);
+
+		expect(spy).toHaveBeenCalledTimes(2);
+	});
+
+	it('restores the outer element context after a nested server render', () => {
+		const spy = errors();
+		renderToString(dev.NestedRenderIsolation, {
+			renderNested: () => renderToString(dev.Direct).html,
+		});
+
+		expect(spy).toHaveBeenCalledTimes(2);
+		const warnings = spy.mock.calls.map((call) => String(call[0]));
+		expect(warnings.some((warning) => warning.includes('cannot be a child of `<p>`'))).toBe(true);
+		expect(
+			warnings.some((warning) => warning.includes('cannot be a descendant of `<button>`')),
+		).toBe(true);
+	});
+
+	it('emits no validation call or warning when server DEV is disabled', () => {
+		const spy = errors();
+		const source = 'export function App() @{ <p><div>prod</div></p> }';
+		const compiled = compile(source, 'App.tsrx', { mode: 'server', dev: false }).code;
+
+		expect(compiled).not.toContain('ssrElement');
+		expect(renderToString(prod.Direct).html).toContain('<p><div>direct</div></p>');
+		expect(spy).not.toHaveBeenCalled();
+	});
+});
+
+describe('Vite DEV SSR compiler gate', () => {
+	async function transform(command: 'serve' | 'build'): Promise<string> {
+		const plugin = octane({ ssr: true });
+		const root = process.cwd();
+		(plugin.config as any)({ root });
+		(plugin.configResolved as any)({
+			root,
+			command,
+			define: { __OCTANE_PROFILE_ENABLED__: 'false' },
+			build: { ssr: true },
+		});
+		return (
+			await (plugin.transform as any).call(
+				{},
+				'export function App() @{ <p><div>vite</div></p> }',
+				resolve(root, 'src/App.tsrx'),
+				{ ssr: true },
+			)
+		).code;
+	}
+
+	it('enables nesting instrumentation for serve and removes it for build', async () => {
+		expect(await transform('serve')).toContain('ssrElement');
+		expect(await transform('build')).not.toContain('ssrElement');
+	});
+});

--- a/packages/octane/tests/ssr.test.ts
+++ b/packages/octane/tests/ssr.test.ts
@@ -29,6 +29,7 @@ const fixture = (name: string) => readFileSync(join(FIXTURES, `${name}.tsrx`), '
 const basic = evalServer(fixture('basic'), 'basic.tsrx');
 const ssr = evalServer(fixture('ssr'), 'ssr.tsrx');
 const spreadHooks = evalServer(fixture('spread-hook-args'), 'spread-hook-args.tsrx');
+const styleMap = evalServer(fixture('style-map'), 'style-map.tsrx');
 
 describe('SSR Phase 1 — basic fixtures', () => {
 	it('renders static markup, dynamic text, and attributes', async () => {
@@ -94,6 +95,32 @@ describe('SSR Phase 1 — ssr fixture (style / spread / innerHTML / components /
 		expect(out).toMatchSnapshot('Scoped');
 		expect(out.css).toContain('.box.tsrx-');
 		expect(out.html).toContain('class="box tsrx-');
+	});
+
+	it('collects module style-map CSS while rendering a component that uses the map', () => {
+		const out = RT.renderToString(styleMap.Picker, { kind: 'red' });
+		expect(out.css).toContain('.red.tsrx-');
+		expect(out.css).toContain('color: rgb(200, 0, 0)');
+		expect(out.html).toMatch(/class="[^"]*\btsrx-[^"]+"/);
+		expect(out.html).toMatch(/class="[^"]*\bred\b[^"]*"/);
+	});
+
+	it('preserves source-order cascade when a style map follows its component', () => {
+		const mod = evalServer(
+			`
+				export function Card() @{
+					<>
+						<style>.tone { color: blue; }</style>
+						<div class={theme.tone}>{'card'}</div>
+					</>
+				}
+				const theme = <style>.tone { color: red; }</style>;
+			`,
+			'style-map-order.tsrx',
+		);
+		const { css } = RT.renderToString(mod.Card);
+		expect(css.indexOf('color: blue')).toBeGreaterThan(-1);
+		expect(css.indexOf('color: red')).toBeGreaterThan(css.indexOf('color: blue'));
 	});
 });
 

--- a/website/index.html
+++ b/website/index.html
@@ -23,6 +23,7 @@
 				--accent: #ff415a;
 				--accent-hover: #ff5d72;
 				--accent-text: #ff5d72;
+				--on-accent: #16181d;
 				--border: rgba(255, 255, 255, 0.1);
 				color-scheme: dark;
 			}

--- a/website/src/components/BenchmarkExplorer.tsrx
+++ b/website/src/components/BenchmarkExplorer.tsrx
@@ -8,13 +8,12 @@
 //   2. a heatmap of the whole grid, toggleable between "vs Octane" (raw) and
 //      "vs fastest" (each row re-baselined to its fastest framework).
 //
-// The interactive views are client-mounted over an accessible SSR data table
-// (the BenchBars / /benchmarks-chart pattern): the server and first client
-// render are the plain table, so hydration adopts identical DOM, then the
-// chart + heatmap swap in on mount. No-JS and crawlers still get every number.
+// Both views are deterministic from the checked-in matrix, so the server and
+// client render the same controls, chart, and accessible data table. Hydration
+// can therefore adopt the complete explorer without changing page geometry.
 // The cursor-following tooltip is positioned imperatively through a ref, so a
 // mousemove never re-renders the 100-cell grid.
-import { useEffect, useMemo, useRef, useState } from 'octane';
+import { useMemo, useRef, useState } from 'octane';
 import type { BenchCard } from '../content/benchmarks.ts';
 
 // ×-vs-Octane ratios: 12.3 → "12×", 2.64 → "2.6×", 1 → "1×", 0.9 → "0.90×".
@@ -72,15 +71,6 @@ export function BenchmarkExplorer(props: { card: BenchCard }) @{
 	const [suite, setSuite] = useState(card.rows[0].op as string);
 	const [mode, setMode] = useState('A' as 'A' | 'B');
 	const [hovered, setHovered] = useState(null as Tip | null);
-
-	// The interactive views (dynamic tints, bar widths, a cursor-following
-	// tooltip) are client-mounted over an accessible SSR data table — the same
-	// shape BenchBars and every /benchmarks chart use. The server and the first
-	// client render are the plain table, so hydration adopts identical DOM with
-	// no dynamic-style mismatch; the chart + heatmap swap in on mount. No-JS and
-	// crawlers still get every number.
-	const [mounted, setMounted] = useState(false);
-	useEffect(() => setMounted(true), []);
 
 	const toggleFramework = (key: string) => {
 		const next = new Set(selected);
@@ -239,275 +229,238 @@ export function BenchmarkExplorer(props: { card: BenchCard }) @{
 	const hide = () => setHovered(null);
 
 	<div class="bx" onMouseMove={onMove}>
-		@if (mounted) {
-			<>
-				<div class="bx-panel">
-					<div class="bx-controls">
-						<div class="bx-ctl">
-							<span class="bx-ctl-label" id="bx-fw-label">frameworks</span>
-							<div class="bx-chips" role="group" aria-labelledby="bx-fw-label">
-								@for (const s of card.series; key s.key) {
-									<button
-										type="button"
-										class={['bx-chip', { 'bx-chip-on': selected.has(s.key) }]}
-										aria-pressed={selected.has(s.key)}
-										onClick={() => toggleFramework(s.key)}
-									>
-										<span class="bx-swatch" style={'background:' + s.color}></span>
-										{s.label as string}
-									</button>
-								}
-							</div>
-						</div>
-						<div class="bx-ctl">
-							<span class="bx-ctl-label" id="bx-suite-label">suite</span>
-							<div class="bx-suites" role="group" aria-labelledby="bx-suite-label">
-								@for (const r of card.rows; key r.op) {
-									<button
-										type="button"
-										class={['bx-suite', { 'bx-suite-on': r.op === suite }]}
-										aria-pressed={r.op === suite}
-										onClick={() => setSuite(r.op as string)}
-									>
-										{r.op as string}
-									</button>
-								}
-							</div>
+		<>
+			<div class="bx-panel">
+				<div class="bx-controls">
+					<div class="bx-ctl">
+						<span class="bx-ctl-label" id="bx-fw-label">frameworks</span>
+						<div class="bx-chips" role="group" aria-labelledby="bx-fw-label">
+							@for (const s of card.series; key s.key) {
+								<button
+									type="button"
+									class={['bx-chip', { 'bx-chip-on': selected.has(s.key) }]}
+									aria-pressed={selected.has(s.key)}
+									onClick={() => toggleFramework(s.key)}
+								>
+									<span class="bx-swatch" style={'background:' + s.color}></span>
+									{s.label as string}
+								</button>
+							}
 						</div>
 					</div>
-
-					<div
-						class="bx-plot"
-						role="img"
-						aria-label={'Bar chart for the ' + suite + ' suite, × vs Octane, lower is better'}
-					>
-						<div
-							class="bx-refline"
-							style={'left:calc(var(--bx-label) + (100% - var(--bx-label)) * ' + bars.refFraction +
-								')'}
-						>
-							<span class="bx-refcap">1× Octane</span>
+					<div class="bx-ctl">
+						<span class="bx-ctl-label" id="bx-suite-label">suite</span>
+						<div class="bx-suites" role="group" aria-labelledby="bx-suite-label">
+							@for (const r of card.rows; key r.op) {
+								<button
+									type="button"
+									class={['bx-suite', { 'bx-suite-on': r.op === suite }]}
+									aria-pressed={r.op === suite}
+									onClick={() => setSuite(r.op as string)}
+								>
+									{r.op as string}
+								</button>
+							}
 						</div>
-						@for (const item of bars.present; key item.key) {
-							<div
-								class="bx-row"
-								onMouseEnter={(e: MouseEvent) => show(e, {
-									fw: item.label,
-									suite,
-									primary: fmtX(item.value) + ' vs Octane',
-									secondary: item.value < 0.98
-										? 'faster than Octane'
-										: item.value > 1.02
-											? 'slower than Octane'
-											: 'matches Octane',
-									fastest: '',
-								})}
-								onMouseLeave={hide}
-							>
-								<span class="bx-row-label">
-									{item.label as string}
-								</span>
-								<div class="bx-track">
-									<div
-										class="bx-fill"
-										style={'width:' + (item.value / bars.scaleMax) * 100 + '%;background:' +
-											item.color}
-									></div>
-									<span
-										class={[
-											'bx-val',
-											item.value / bars.scaleMax > 0.62 ? 'bx-val-in' : 'bx-val-out',
-										]}
-										style={'left:' + (item.value / bars.scaleMax) * 100 + '%'}
-									>
-										{fmtX(item.value) as string}
-									</span>
-								</div>
-							</div>
-						}
-						@for (const item of bars.missing; key item.key) {
-							<div class="bx-row bx-row-empty">
-								<span class="bx-row-label">
-									{item.label as string}
-								</span>
-								<div class="bx-track">
-									<span class="bx-val bx-val-out bx-muted" style="left:0">{'—'}</span>
-								</div>
-							</div>
-						}
-						@if (bars.present.length === 0 && bars.missing.length === 0) {
-							<p class="bx-empty">Select at least one framework to compare.</p>
-						}
 					</div>
 				</div>
 
-				<div class="bx-panel">
-					<div class="bx-heat-head">
-						<span class="bx-ctl-label">all suites</span>
-						<div class="bx-seg" role="group" aria-label="Heatmap normalization">
-							<button
-								type="button"
-								class={['bx-seg-btn', { 'bx-seg-on': mode === 'A' }]}
-								aria-pressed={mode === 'A'}
-								onClick={() => setMode('A')}
-							>
-								vs Octane
-							</button>
-							<button
-								type="button"
-								class={['bx-seg-btn', { 'bx-seg-on': mode === 'B' }]}
-								aria-pressed={mode === 'B'}
-								onClick={() => setMode('B')}
-							>
-								vs fastest
-							</button>
-						</div>
+				<div
+					class="bx-plot"
+					role="img"
+					aria-label={'Bar chart for the ' + suite + ' suite, × vs Octane, lower is better'}
+				>
+					<div
+						class="bx-refline"
+						style={'left:calc(var(--bx-label) + (100% - var(--bx-label)) * ' + bars.refFraction +
+							')'}
+					>
+						<span class="bx-refcap">1× Octane</span>
 					</div>
+					@for (const item of bars.present; key item.key) {
+						<div
+							class="bx-row"
+							onMouseEnter={(e: MouseEvent) => show(e, {
+								fw: item.label,
+								suite,
+								primary: fmtX(item.value) + ' vs Octane',
+								secondary: item.value < 0.98
+									? 'faster than Octane'
+									: item.value > 1.02
+										? 'slower than Octane'
+										: 'matches Octane',
+								fastest: '',
+							})}
+							onMouseLeave={hide}
+						>
+							<span class="bx-row-label">
+								{item.label as string}
+							</span>
+							<div class="bx-track">
+								<div
+									class="bx-fill"
+									style={'width:' + (item.value / bars.scaleMax) * 100 + '%;background:' +
+										item.color}
+								></div>
+								<span
+									class={['bx-val', item.value / bars.scaleMax > 0.62 ? 'bx-val-in' : 'bx-val-out']}
+									style={'left:' + (item.value / bars.scaleMax) * 100 + '%'}
+								>
+									{fmtX(item.value) as string}
+								</span>
+							</div>
+						</div>
+					}
+					@for (const item of bars.missing; key item.key) {
+						<div class="bx-row bx-row-empty">
+							<span class="bx-row-label">
+								{item.label as string}
+							</span>
+							<div class="bx-track">
+								<span class="bx-val bx-val-out bx-muted" style="left:0">{'—'}</span>
+							</div>
+						</div>
+					}
+					@if (bars.present.length === 0 && bars.missing.length === 0) {
+						<p class="bx-empty">Select at least one framework to compare.</p>
+					}
+				</div>
+			</div>
 
-					<div class="bx-heat-scroll">
-						<table class="bx-heat">
-							<thead>
-								<tr>
-									<th scope="col" class="bx-corner">suite</th>
-									@for (const s of card.series; key s.key) {
-										<th scope="col">
-											<span class="bx-th">
-												<span class="bx-swatch" style={'background:' + s.color}></span>
-												{s.label as string}
-											</span>
-										</th>
-									}
-								</tr>
-							</thead>
-							<tbody>
-								@for (const r of heat.rows; key r.op) {
-									<tr>
-										<th scope="row" class="bx-rowhead">
-											{r.op as string}
-										</th>
-										@for (const cell of r.cells; key cell.key) {
-											@switch (cell.kind) {
-												@case 'null': {
-													<td class="bx-cell bx-cell-null" aria-label="no data">{'—'}</td>
-												}
-												@case 'ref': {
-													<td class="bx-cell bx-cell-ref">
-														{cell.text as string}
-													</td>
-												}
-												@default: {
-													<td
-														class={['bx-cell', { 'bx-cell-fastest': cell.isFastest }]}
-														style={'background:' + cell.tint}
-														onMouseEnter={(e: MouseEvent) => show(e, {
-															fw: cell.label,
-															suite: cell.suite,
-															primary: cell.primary,
-															secondary: cell.secondary,
-															fastest: cell.fastest,
-														})}
-														onMouseLeave={hide}
-													>
-														{cell.text as string}
-													</td>
-												}
-											}
-										}
-									</tr>
+			<div class="bx-panel">
+				<div class="bx-heat-head">
+					<span class="bx-ctl-label">all suites</span>
+					<div class="bx-seg" role="group" aria-label="Heatmap normalization">
+						<button
+							type="button"
+							class={['bx-seg-btn', { 'bx-seg-on': mode === 'A' }]}
+							aria-pressed={mode === 'A'}
+							onClick={() => setMode('A')}
+						>
+							vs Octane
+						</button>
+						<button
+							type="button"
+							class={['bx-seg-btn', { 'bx-seg-on': mode === 'B' }]}
+							aria-pressed={mode === 'B'}
+							onClick={() => setMode('B')}
+						>
+							vs fastest
+						</button>
+					</div>
+				</div>
+
+				<div class="bx-heat-scroll">
+					<table class="bx-heat">
+						<thead>
+							<tr>
+								<th scope="col" class="bx-corner">suite</th>
+								@for (const s of card.series; key s.key) {
+									<th scope="col">
+										<span class="bx-th">
+											<span class="bx-swatch" style={'background:' + s.color}></span>
+											{s.label as string}
+										</span>
+									</th>
 								}
-							</tbody>
-							<tfoot>
+							</tr>
+						</thead>
+						<tbody>
+							@for (const r of heat.rows; key r.op) {
 								<tr>
-									<th scope="row" class="bx-rowhead bx-geo-head">geomean</th>
-									@for (const g of heat.geoRow; key g.key) {
+									<th scope="row" class="bx-rowhead">
+										{r.op as string}
+									</th>
+									@for (const cell of r.cells; key cell.key) {
 										<td
-											class={['bx-cell', 'bx-geo', { 'bx-cell-ref': g.isRef }]}
-											style={g.tint ? 'background:' + g.tint : ''}
+											class={[
+												'bx-cell',
+												{
+													'bx-cell-null': cell.kind === 'null',
+													'bx-cell-ref': cell.kind === 'ref',
+													'bx-cell-fastest': cell.isFastest,
+												},
+											]}
+											style={cell.kind === 'data' ? 'background:' + cell.tint : undefined}
+											aria-label={cell.kind === 'null' ? 'no data' : undefined}
+											onMouseEnter={(e: MouseEvent) => {
+												if (cell.kind === 'data') show(e, {
+													fw: cell.label,
+													suite: cell.suite,
+													primary: cell.primary,
+													secondary: cell.secondary,
+													fastest: cell.fastest,
+												});
+											}}
+											onMouseLeave={() => {
+												if (cell.kind === 'data') hide();
+											}}
 										>
-											{g.text as string}
+											{cell.text as string}
 										</td>
 									}
 								</tr>
-							</tfoot>
-						</table>
-					</div>
-					<p class="bx-caption">
-						{mode === 'A'
-							? 'Each cell is that framework’s score relative to Octane (1×), geometric mean across the suite’s operations. Green is faster, red is slower.'
-							: 'Each row is re-baselined so its fastest framework is 1×; every other cell is a multiple of that fastest time. The outlined cell wins the row.'}
-					</p>
-					<div class="bx-legend">
-						<span class="bx-legend-item">
-							<span class="bx-legend-label">Faster</span>
-							<span class="bx-legend-scale" aria-hidden="true"></span>
-							<span class="bx-legend-label">Slower</span>
-						</span>
-						<span class="bx-legend-item">
-							<span class="bx-legend-swatch" aria-hidden="true"></span>
-							Octane = 1× baseline
-						</span>
-					</div>
-				</div>
-
-				@if (hovered) {
-					<div class="bx-tip" role="tooltip" ref={mountTip}>
-						<div class="bx-tip-head">
-							<span class="bx-tip-fw">
-								{hovered.fw as string}
-							</span>
-							<span class="bx-tip-suite">
-								{hovered.suite as string}
-							</span>
-						</div>
-						<div class="bx-tip-primary">
-							{hovered.primary as string}
-						</div>
-						@if (hovered.secondary) {
-							<div class="bx-tip-sec">
-								{hovered.secondary as string}
-							</div>
-						}
-						@if (hovered.fastest) {
-							<div class="bx-tip-fast">
-								{'fastest: ' + hovered.fastest}
-							</div>
-						}
-					</div>
-				}
-			</>
-		} @else {
-			<div class="bx-panel bx-fallback">
-				<table class="bx-fallback-table">
-					<caption
-						class="bx-fallback-cap"
-					>{'× vs Octane — geometric mean across each suite’s operations. Lower is better.'}</caption>
-					<thead>
-						<tr>
-							<th scope="col">suite</th>
-							@for (const s of card.series; key s.key) {
-								<th scope="col">
-									{s.label as string}
-								</th>
 							}
-						</tr>
-					</thead>
-					<tbody>
-						@for (const r of grid; key r.op) {
+						</tbody>
+						<tfoot>
 							<tr>
-								<th scope="row">
-									{r.op as string}
-								</th>
-								@for (const c of r.cells; key c.key) {
-									<td>
-										{(c.raw == null ? '—' : fmtX(c.raw)) as string}
+								<th scope="row" class="bx-rowhead bx-geo-head">geomean</th>
+								@for (const g of heat.geoRow; key g.key) {
+									<td
+										class={['bx-cell', 'bx-geo', { 'bx-cell-ref': g.isRef }]}
+										style={g.tint ? 'background:' + g.tint : ''}
+									>
+										{g.text as string}
 									</td>
 								}
 							</tr>
-						}
-					</tbody>
-				</table>
+						</tfoot>
+					</table>
+				</div>
+				<p class="bx-caption">
+					{mode === 'A'
+						? 'Each cell is that framework’s score relative to Octane (1×), geometric mean across the suite’s operations. Green is faster, red is slower.'
+						: 'Each row is re-baselined so its fastest framework is 1×; every other cell is a multiple of that fastest time. The outlined cell wins the row.'}
+				</p>
+				<div class="bx-legend">
+					<span class="bx-legend-item">
+						<span class="bx-legend-label">Faster</span>
+						<span class="bx-legend-scale" aria-hidden="true"></span>
+						<span class="bx-legend-label">Slower</span>
+					</span>
+					<span class="bx-legend-item">
+						<span class="bx-legend-swatch" aria-hidden="true"></span>
+						Octane = 1× baseline
+					</span>
+				</div>
 			</div>
-		}
+
+			@if (hovered) {
+				<div class="bx-tip" role="tooltip" ref={mountTip}>
+					<div class="bx-tip-head">
+						<span class="bx-tip-fw">
+							{hovered.fw as string}
+						</span>
+						<span class="bx-tip-suite">
+							{hovered.suite as string}
+						</span>
+					</div>
+					<div class="bx-tip-primary">
+						{hovered.primary as string}
+					</div>
+					@if (hovered.secondary) {
+						<div class="bx-tip-sec">
+							{hovered.secondary as string}
+						</div>
+					}
+					@if (hovered.fastest) {
+						<div class="bx-tip-fast">
+							{'fastest: ' + hovered.fastest}
+						</div>
+					}
+				</div>
+			}
+		</>
 
 		<style>
 			.bx {
@@ -524,44 +477,6 @@ export function BenchmarkExplorer(props: { card: BenchCard }) @{
 				padding: 1.25rem;
 			}
 
-			/* SSR / no-JS fallback: the full matrix as a plain accessible table.
-			   Swapped for the interactive views on mount. */
-			.bx-fallback {
-				overflow-x: auto;
-			}
-			.bx-fallback-table {
-				border-collapse: collapse;
-				width: 100%;
-				min-width: max-content;
-				font-variant-numeric: tabular-nums;
-			}
-			.bx-fallback-cap {
-				caption-side: top;
-				text-align: left;
-				color: var(--text-secondary);
-				font-size: 0.8rem;
-				line-height: 1.5;
-				margin-bottom: 0.75rem;
-			}
-			.bx-fallback-table th,
-			.bx-fallback-table td {
-				padding: 0.35rem 0.6rem;
-				text-align: right;
-				border-bottom: 1px solid var(--border);
-				font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-				font-size: 0.78rem;
-				color: var(--text);
-				white-space: nowrap;
-			}
-			.bx-fallback-table thead th {
-				color: var(--text-secondary);
-				font-weight: 500;
-			}
-			.bx-fallback-table th[scope='row'] {
-				text-align: left;
-				color: var(--text-secondary);
-				font-weight: 400;
-			}
 			.bx-ctl-label {
 				display: block;
 				font-size: 0.7rem;
@@ -653,7 +568,7 @@ export function BenchmarkExplorer(props: { card: BenchCard }) @{
 			}
 			.bx-suite-on {
 				background: rgba(255, 65, 90, 0.16);
-				color: var(--accent-text);
+				color: var(--text);
 			}
 
 			/* Bar chart */

--- a/website/src/components/CoreApiDemo.tsrx
+++ b/website/src/components/CoreApiDemo.tsrx
@@ -82,7 +82,7 @@ const demoStyles = <style>
 	}
 	.primary {
 		background: var(--accent);
-		color: white;
+		color: var(--on-accent);
 	}
 	.secondary {
 		border-color: var(--border);

--- a/website/src/components/DocsSearch.tsrx
+++ b/website/src/components/DocsSearch.tsrx
@@ -17,10 +17,6 @@ import { loadSearchIndex, searchDocs } from '../lib/docs-search.ts';
 import type { SearchGroup, SearchRecord } from '../lib/docs-search.ts';
 import searchUrl from '../assets/search.svg';
 
-function isMac(): boolean {
-	return typeof navigator !== 'undefined' && /mac/i.test(navigator.platform);
-}
-
 interface DialogProps {
 	onClose: () => void;
 }
@@ -406,11 +402,9 @@ function SearchDialog(props: DialogProps) @{
 
 export function DocsSearch() @{
 	const [open, setOpen] = useState(false);
-	const [mac, setMac] = useState(false);
 
 	// ⌘K / Ctrl-K from anywhere, and `/` when the user is not already typing.
 	useEffect(() => {
-		setMac(isMac());
 		const onKey = (event: KeyboardEvent) => {
 			// contentEditable surfaces (e.g. the CodeMirror editor on /playground) are
 			// typing targets too — otherwise `/` there opens the palette instead of
@@ -432,16 +426,19 @@ export function DocsSearch() @{
 	});
 
 	<>
-		<button type="button" class="search-trigger" onClick={() => setOpen(true)}>
+		<button
+			type="button"
+			class="search-trigger"
+			aria-label="Search documentation"
+			onClick={() => setOpen(true)}
+		>
 			<span
 				class="search-trigger-icon"
 				style={'--icon:url("' + searchUrl + '")'}
 				aria-hidden="true"
 			></span>
 			<span class="search-trigger-label">Search docs</span>
-			<kbd class="search-trigger-kbd">
-				{mac ? '⌘K' : 'Ctrl K'}
-			</kbd>
+			<kbd class="search-trigger-kbd">⌘/Ctrl K</kbd>
 		</button>
 		@if (open) {
 			<SearchDialogPortal onClose={() => setOpen(false)} />
@@ -485,6 +482,16 @@ export function DocsSearch() @{
 				font-family: inherit;
 				font-size: 0.7rem;
 				line-height: 1.4;
+			}
+			.search-trigger-label,
+			.search-trigger-kbd {
+				white-space: nowrap;
+			}
+			/* Keep the fixed-height header compact before the icon-only breakpoint. */
+			@media (max-width: 960px) {
+				.search-trigger-kbd {
+					display: none;
+				}
 			}
 			/* Below the nav breakpoint the trigger collapses to its icon. */
 			@media (max-width: 720px) {

--- a/website/src/components/Header.tsrx
+++ b/website/src/components/Header.tsrx
@@ -43,7 +43,7 @@ export function Header() @{
 					</svg>
 				</button>
 				<Link to="/" class="wordmark" aria-label="Octane home">
-					<img src={logoUrl} alt="Octane" class="wordmark-img" />
+					<img src={logoUrl} alt="Octane" class="wordmark-img" width="123" height="30" />
 				</Link>
 				<nav
 					id="site-nav"

--- a/website/src/components/PortalEventDemo.tsrx
+++ b/website/src/components/PortalEventDemo.tsrx
@@ -93,7 +93,7 @@ export function PortalEventDemo() @{
 				border: 1px solid transparent;
 				border-radius: 999px;
 				background: var(--accent);
-				color: var(--text);
+				color: var(--on-accent);
 				font: inherit;
 				font-size: 0.82rem;
 				font-weight: 700;

--- a/website/src/components/ViewTransitionsDemo.tsrx
+++ b/website/src/components/ViewTransitionsDemo.tsrx
@@ -134,7 +134,7 @@ export function ViewTransitionsDemo() @{
 			}
 			.vtdemo-btn {
 				background: #ff415a;
-				color: #f4eee8;
+				color: var(--on-accent);
 				font-weight: 600;
 				border: none;
 				padding: 0.5rem 1.1rem;

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -14,8 +14,9 @@ title: Quick start
 <aside className="doc-callout note">
 	<p className="doc-callout-title">Before you begin</p>
 	<p>
-		This guide starts with an existing Vite project and requires Node.js 22 or newer. Octane is
-		currently alpha software, so pin versions when you use it in a real project.
+		{
+			'This guide starts with an existing Vite project and requires Node.js 22 or newer. Octane is currently alpha software, so pin versions when you use it in a real project.'
+		}
 	</p>
 </aside>
 

--- a/website/src/lib/docs-search.ts
+++ b/website/src/lib/docs-search.ts
@@ -9,8 +9,6 @@
 // document's lede record (no hash). Each record keeps its paragraphs and code
 // lines as separate blocks so a result can list the individual matching lines
 // under its section heading, rather than one flattened blob.
-import { docs } from '../content/docs.ts';
-
 export interface SearchBlock {
 	text: string;
 	/** Came from a ``` fence — rendered monospace. */
@@ -68,12 +66,20 @@ function slugOf(path: string): string {
 
 /** Strip JSX/HTML tags and markdown syntax off a run of prose. */
 function cleanProse(raw: string): string {
-	return raw
-		.replace(/<[^>]+>/g, ' ')
-		.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
-		.replace(/[`*_>#|]/g, ' ')
-		.replace(/\s+/g, ' ')
-		.trim();
+	return (
+		raw
+			// MDX callouts use a string expression when plain Markdown would create a
+			// nested paragraph inside an authored <p>. Keep the authored sentence in
+			// search results without exposing the expression braces or quotes.
+			.replace(/\{\s*(['"`])((?:\\.|(?!\1)[\s\S])*)\1\s*\}/g, (_match, _quote, value: string) =>
+				value.replace(/\\(['"`\\])/g, '$1'),
+			)
+			.replace(/<[^>]+>/g, ' ')
+			.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+			.replace(/[`*_>#|]/g, ' ')
+			.replace(/\s+/g, ' ')
+			.trim()
+	);
 }
 
 /**
@@ -150,15 +156,17 @@ let indexPromise: Promise<SearchRecord[]> | null = null;
 /** Build (once) and return the flat section index. Safe to call repeatedly. */
 export function loadSearchIndex(): Promise<SearchRecord[]> {
 	if (!indexPromise) {
-		indexPromise = Promise.all(
-			Object.entries(rawDocs).map(async ([path, load]) => {
-				const slug = slugOf(path);
-				const order = docs.findIndex((d) => d.slug === slug);
-				const doc = order === -1 ? undefined : docs[order];
-				const rank = order === -1 ? docs.length : order;
-				return recordsFor(slug, doc?.title ?? slug, rank, await load());
-			}),
-		).then((groups) => groups.flat());
+		indexPromise = import('../content/docs.ts').then(({ docs }) =>
+			Promise.all(
+				Object.entries(rawDocs).map(async ([path, load]) => {
+					const slug = slugOf(path);
+					const order = docs.findIndex((d) => d.slug === slug);
+					const doc = order === -1 ? undefined : docs[order];
+					const rank = order === -1 ? docs.length : order;
+					return recordsFor(slug, doc?.title ?? slug, rank, await load());
+				}),
+			).then((groups) => groups.flat()),
+		);
 	}
 	return indexPromise;
 }

--- a/website/src/pages/home/sections/Explorer.tsrx
+++ b/website/src/pages/home/sections/Explorer.tsrx
@@ -4,7 +4,7 @@
 // can feed it the full grid next.
 import { Link } from '@octanejs/tanstack-router';
 import { BenchmarkExplorer } from '../../../components/BenchmarkExplorer.tsrx';
-import { HOME_SUMMARY } from '../../../content/benchmarks.ts';
+import { HOME_SUMMARY } from '../../../content/home-benchmark.ts';
 
 export function Explorer() @{
 	<section class="explorer" aria-labelledby="explorer-heading">

--- a/website/src/pages/home/sections/Features.tsrx
+++ b/website/src/pages/home/sections/Features.tsrx
@@ -29,9 +29,9 @@ export function Features() @{
 		@for (const feature of FEATURES; key feature.title) {
 			<article class="card">
 				<header class="card-head">
-					<h3 class="card-title">
+					<h2 class="card-title">
 						{feature.title as string}
-					</h3>
+					</h2>
 				</header>
 				<div class="card-content">
 					<p class="card-body">

--- a/website/src/pages/home/sections/Hero.tsrx
+++ b/website/src/pages/home/sections/Hero.tsrx
@@ -118,7 +118,7 @@ export function Hero() @{
 			}
 			.hero-actions :global(a.btn-primary) {
 				background: var(--accent);
-				color: var(--text);
+				color: var(--on-accent);
 				font-weight: 600;
 				padding: 0.7rem 1.4rem;
 				border-radius: 9999px;

--- a/website/src/pages/not-found/NotFound.tsrx
+++ b/website/src/pages/not-found/NotFound.tsrx
@@ -29,7 +29,7 @@ export function NotFound() @{
 			}
 			.notfound :global(a.notfound-home) {
 				background: #ff415a;
-				color: #f4eee8;
+				color: var(--on-accent);
 				font-weight: 600;
 				padding: 0.7rem 1.4rem;
 				border-radius: 9999px;

--- a/website/tests/benchmark-explorer.test.ts
+++ b/website/tests/benchmark-explorer.test.ts
@@ -1,18 +1,19 @@
 // The benchmark explorer's two linked views over the checked-in ×-vs-Octane
-// matrix (HOME_SUMMARY). These drive the mounted, interactive views the way a
+// matrix (HOME_SUMMARY). These drive the interactive views the way a
 // reader does: choosing frameworks and a suite for the bar chart, re-baselining
-// the heatmap, and hovering for the custom tooltip. The SSR/no-JS fallback
-// table is covered by the SSR suites; here we assert the client behavior.
+// the heatmap, and hovering for the custom tooltip. SSR parity is covered by
+// the real-browser suite; here we assert the client behavior.
 import { describe, it, expect, afterEach } from 'vitest';
 import { cleanup, fireEvent, render, waitFor } from '@octanejs/testing-library';
 import { BenchmarkExplorer } from '../src/components/BenchmarkExplorer.tsrx';
-import { HOME_SUMMARY } from '../src/content/benchmarks.ts';
+import { HOME_SUMMARY } from '../src/content/home-benchmark.ts';
 
 afterEach(cleanup);
 
 async function mountExplorer() {
 	const utils = render(BenchmarkExplorer as any, { props: { card: HOME_SUMMARY } });
-	// Interactive views are mount-gated; wait for the bar plot to swap in.
+	// The plot is present from the first render; waitFor also flushes the test
+	// renderer before the interaction assertions below.
 	await waitFor(() => expect(utils.container.querySelector('.bx-plot')).toBeTruthy());
 	const { container } = utils;
 	const barLabels = () =>

--- a/website/tests/docs-search.test.ts
+++ b/website/tests/docs-search.test.ts
@@ -47,6 +47,18 @@ describe('docs search index', () => {
 			}
 		}
 	});
+
+	it('shows string-expression callout prose without MDX syntax', async () => {
+		const index = await loadSearchIndex();
+		const [result] = searchDocs(index, 'Node.js 22');
+		const snippets = result.lines.map((line) => line.parts.map((part) => part.text).join(''));
+
+		expect(result.slug).toBe('quick-start');
+		expect(snippets.join(' ')).toContain(
+			'requires Node.js 22 or newer. Octane is currently alpha software',
+		);
+		expect(snippets.join(' ')).not.toMatch(/[{}]/);
+	});
 });
 
 describe('docs search ranking', () => {

--- a/website/tests/smoke.test.ts
+++ b/website/tests/smoke.test.ts
@@ -128,21 +128,20 @@ describe('website routes', () => {
 		);
 		expect(homeSections).toEqual(['hero', 'features', 'proven', 'why', 'explorer']);
 
-		// The home page stages the interactive benchmark explorer over the checked-in
+		// The home page renders the interactive benchmark explorer from the checked-in
 		// ×-vs-Octane summary (HOME_SUMMARY). The explorer's own interactions live in
 		// benchmark-explorer.test.ts; here assert the section composes and the summary
-		// reaches the mounted views.
+		// reaches both deterministic views.
 		const explorer = container.querySelector('section.explorer')!;
 		expect(explorer).toBeTruthy();
 		expect(explorer.querySelector('#explorer-heading')?.textContent?.trim()).toBeTruthy();
 		expect(findLink(explorer, '/benchmarks')).toBeTruthy();
 		const bx = explorer.querySelector('.bx')!;
 		expect(bx).toBeTruthy();
-		// Interactive views are mount-gated: the SSR fallback table swaps for the bar
-		// chart + heatmap on mount. Wait for the plot, then assert every suite row of
-		// the summary reaches the heatmap.
+		// Both views are present from the first render so SSR and hydration share the
+		// same geometry. Assert every suite row reaches the heatmap.
 		await waitFor(() => {
-			if (!bx.querySelector('.bx-plot')) throw new Error('explorer not mounted');
+			if (!bx.querySelector('.bx-plot')) throw new Error('explorer plot missing');
 		});
 		expect(bx.querySelectorAll('.bx-heat tbody tr')).toHaveLength(HOME_SUMMARY.rows.length);
 

--- a/website/tests/ssr-hydration.e2e.test.ts
+++ b/website/tests/ssr-hydration.e2e.test.ts
@@ -159,6 +159,52 @@ async function loadRoute(base: string, path: string) {
 	return { page, errors, main };
 }
 
+interface RouteGeometry {
+	bodyHeight: number;
+	footerTop: number;
+	explorerHeight: number | null;
+	calloutHeight: number | null;
+	calloutFollowingTop: number | null;
+	searchWidth: number;
+}
+
+async function measureRouteGeometry(
+	base: string,
+	path: string,
+	javaScriptEnabled: boolean,
+): Promise<RouteGeometry> {
+	const context = await browser.newContext({
+		javaScriptEnabled,
+		viewport: { width: 1440, height: 900 },
+	});
+	const page = await context.newPage();
+	try {
+		await page.goto(base + path, { waitUntil: 'load' });
+		await page.evaluate(async (hydrated) => {
+			await document.fonts.ready;
+			if (!hydrated) return;
+			await new Promise<void>((resolve) =>
+				requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+			);
+		}, javaScriptEnabled);
+		return await page.evaluate(() => {
+			const rect = (selector: string) => document.querySelector(selector)?.getBoundingClientRect();
+			const callout = document.querySelector('.doc-callout');
+			const following = callout?.nextElementSibling?.getBoundingClientRect();
+			return {
+				bodyHeight: document.body.getBoundingClientRect().height,
+				footerTop: rect('footer')?.top ?? -1,
+				explorerHeight: rect('section.explorer .bx')?.height ?? null,
+				calloutHeight: callout?.getBoundingClientRect().height ?? null,
+				calloutFollowingTop: following?.top ?? null,
+				searchWidth: rect('.search-trigger')?.width ?? -1,
+			};
+		});
+	} finally {
+		await context.close();
+	}
+}
+
 async function waitForLocatorText(
 	locator: import('playwright').Locator,
 	expected: string,
@@ -225,16 +271,15 @@ describe.sequential('website dev-SSR → hydration (real browser)', () => {
 		},
 	);
 
-	it('the homepage benchmark explorer hydrates its SSR fallback into the interactive views', async () => {
+	it('the homepage benchmark explorer preserves its complete SSR view through hydration', async () => {
 		const { page, errors } = await loadRoute(`http://localhost:${DEV_PORT}`, '/');
 		try {
 			const explorer = page.locator('section.explorer .bx');
 			await explorer.waitFor();
 
-			// SSR ships the accessible fallback data table; hydration adopts it in
-			// place (identical DOM, no mismatch), then the mount effect swaps in the
-			// interactive bar chart + heatmap. Wait for the plot to prove the swap ran.
-			await page.locator('.bx-plot').waitFor();
+			// The bar chart and heatmap are already present in SSR output. Keeping them
+			// through hydration prevents the large footer jump the fallback swap caused.
+			expect(await page.locator('.bx-plot').count()).toBe(1);
 			expect(await page.locator('.bx-heat').count()).toBe(1);
 			expect(await page.locator('.bx-fallback-table').count()).toBe(0);
 
@@ -475,6 +520,23 @@ describe.sequential('website production build → hydration (octane-preview)', (
 			expect(main.length).toBeGreaterThan(0);
 		} finally {
 			await page.close();
+		}
+	});
+
+	it('keeps no-JS SSR and hydrated layout geometry identical', { timeout: 30_000 }, async () => {
+		const base = `http://localhost:${PREVIEW_PORT}`;
+		for (const route of ['/', '/docs', '/docs/core-apis']) {
+			const noJs = await measureRouteGeometry(base, route, false);
+			const hydrated = await measureRouteGeometry(base, route, true);
+			for (const key of Object.keys(noJs) as (keyof RouteGeometry)[]) {
+				const serverValue = noJs[key];
+				const clientValue = hydrated[key];
+				if (serverValue === null || clientValue === null) {
+					expect(clientValue, `${route} ${key}`).toBe(serverValue);
+				} else {
+					expect(Math.abs(clientValue - serverValue), `${route} ${key}`).toBeLessThan(1);
+				}
+			}
 		}
 	});
 

--- a/website/tests/ssr-smoke.test.ts
+++ b/website/tests/ssr-smoke.test.ts
@@ -92,6 +92,9 @@ describe('built SSR handler', () => {
 		expect(classCount(html, 'shiki')).toBeGreaterThan(0);
 	});
 
+	// This route deliberately renders every chart and accessible data table; give
+	// that full integration path headroom beyond the generic unit-test timeout on
+	// slower CI runners.
 	it('server-renders /benchmarks with complete Visx charts and table data', async () => {
 		const { response, html } = await get('/benchmarks');
 		const cards = [...FRAMEWORK_CARDS, ...OCTANE_CARDS];
@@ -117,7 +120,7 @@ describe('built SSR handler', () => {
 		expect(classCount(html, 'bench-table')).toBe(cards.length);
 		expect(classCount(html, 'bench-plot-shell')).toBe(0);
 		expect(classCount(html, 'recharts-wrapper')).toBe(0);
-	});
+	}, 15_000);
 
 	it('SSRs the not-found page through the catch-all with a real 404', async () => {
 		const { response, html } = await get('/definitely/not/a/page');

--- a/website/tests/ssr-smoke.test.ts
+++ b/website/tests/ssr-smoke.test.ts
@@ -56,11 +56,11 @@ describe('built SSR handler', () => {
 		expect(response.headers.get('content-type')).toBe('text/html; charset=utf-8');
 		expect(html).toContain('<main');
 		expect(classCount(html, 'home')).toBeGreaterThan(0);
-		// The home benchmark explorer server-renders its accessible fallback data
-		// table (the interactive bar chart + heatmap swap in on mount); no client-only
-		// chart shell or charting-library markup is emitted server-side, so no-JS and
-		// crawlers still get every number.
-		expect(classCount(html, 'bx-fallback-table')).toBe(1);
+		// The complete explorer is deterministic server markup: no-JS, hydration,
+		// crawlers, and the interactive client all start from the same geometry.
+		expect(classCount(html, 'bx-fallback-table')).toBe(0);
+		expect(classCount(html, 'bx-plot')).toBe(1);
+		expect(classCount(html, 'bx-heat')).toBe(1);
 		expect(classCount(html, 'visx-bar')).toBe(0);
 		expect(classCount(html, 'home-bench-chart')).toBe(0);
 		expect(classCount(html, 'deferred-bench')).toBe(0);


### PR DESCRIPTION
## Summary

- eliminate SSR-to-hydration layout shifts by rendering the complete benchmark explorer on the server, collecting module style-map CSS during SSR, and keeping docs/header markup deterministic
- reduce the initial website payload and address Lighthouse accessibility findings by lazy-loading the docs search index, loading only the home benchmark summary, correcting heading order and contrast, and labeling controls
- add DEV SSR diagnostics for browser-repaired HTML nesting, including authored source locations, relationships across component boundaries, render-local deduplication, and production compile-time elision
- negotiate streaming gzip for eligible SSR and static text responses in the built-in Node transport and `octane-preview`
- add regression coverage, documentation, and a patch changeset

## Root cause

The website's server output used a compact benchmark fallback that was replaced after hydration, while module-level style maps were only registered on the client. Invalid paragraph markup was also repaired by the browser before hydration. Separately, the home entry eagerly imported benchmark and docs data, and the preview transport served text assets without compression.

Together these caused observable layout movement between no-JS and hydrated renders and held the Lighthouse performance/accessibility categories below 100.

## Impact

No-JS and hydrated geometry now matches exactly on the homepage and representative docs routes. Development SSR reports invalid HTML placements before they can become hydration mismatches, without changing returned HTML or production output. The normal production preview now serves compressed text responses and the homepage reaches 100 in every Lighthouse category.

## Validation

- Lighthouse 13.4.0 default-mobile: three independent `100/100/100/100` runs; median LCP 1.728s, TBT 0ms, CLS 0
- real-browser DEV/prod SSR hydration suite: 25/25 passed
- DEV SSR invalid-nesting coverage: 22/22 passed across normal and production compiler projects
- focused Node transport and website SSR smoke coverage: 13/13 passed
- `pnpm typecheck`
- `pnpm format:check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core SSR codegen/runtime and the default Node response path (compression + caching headers); behavior is gated for production nesting and covered by new tests, but transport and CSS ordering affect all preview users.
> 
> **Overview**
> Aligns **server and hydrated website layout** by SSR-rendering the full benchmark explorer (no post-mount swap), collecting **module style-map CSS** during server renders in source order, and tightening docs/header markup, contrast, and lazy-loaded search data.
> 
> Adds **development-only SSR HTML nesting checks**: the server compiler wraps native elements with `ssrElement`, the runtime reports browser parser repairs (including across components) with authored file locations, dedupes per render, and **strips the instrumentation from production** builds; Vite `serve` enables server `dev` diagnostics without server HMR.
> 
> The **built-in Node HTTP transport** negotiates **streaming gzip** for eligible SSR and static text responses (`Accept-Encoding`, `Vary`, size/type guards) while skipping HEAD, range, pre-encoded, and `no-transform` cases; `octane-preview` uses the same path.
> 
> Docs, changesets, and broad regression tests cover compression, nesting, style maps, and no-JS vs hydrated geometry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 373fcf5b8929ac399e5c92388dac6f4aa943382f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->