### PR TITLE
Fix Three portal injected-state updates

### DIFF
--- a/.changeset/calm-portals-sync.md
+++ b/.changeset/calm-portals-sync.md
@@ -1,0 +1,5 @@
+---
+"@octanejs/three": patch
+---
+
+Apply updated Three portal state in the accepted render while keeping rejected portal renders isolated.

--- a/packages/three/src/core/hooks.ts
+++ b/packages/three/src/core/hooks.ts
@@ -17,7 +17,9 @@ import {
 import { getThreeEventStore, getThreeInstance, type Instance } from './driver.js';
 import {
 	getRootObjectStore,
+	readRootStoreRenderSnapshot,
 	RootStoreContext,
+	RootStoreRenderSnapshotContext,
 	useRootStoreSelector,
 	type RenderCallback,
 	type RootState,
@@ -86,6 +88,7 @@ export function useThree<T = RootState>(...args: unknown[]): T {
 	const selector = (typeof userArgs[0] === 'function' ? userArgs[0] : identity) as Selector<T>;
 	const equalityFn = (typeof userArgs[1] === 'function' ? userArgs[1] : Object.is) as EqualityFn<T>;
 	const store = useStore();
+	const renderSnapshot = useContext(RootStoreRenderSnapshotContext);
 	const cache = useRef<
 		| {
 				readonly state: RootState;
@@ -96,7 +99,7 @@ export function useThree<T = RootState>(...args: unknown[]): T {
 	>(undefined, subSlot(slot, 'useThree:cache'));
 
 	const getSnapshot = (): T => {
-		const state = store.getState();
+		const state = readRootStoreRenderSnapshot(store, renderSnapshot);
 		const previous = cache.current;
 		if (
 			previous !== undefined &&

--- a/packages/three/src/core/portal.ts
+++ b/packages/three/src/core/portal.ts
@@ -25,10 +25,13 @@ import {
 import type { ComputeFunction, EventManager } from './events.js';
 import {
 	createPortalStore,
+	readRootStoreRenderSnapshot,
 	RootStoreContext,
+	RootStoreRenderSnapshotContext,
 	updateCamera,
 	type RootState,
 	type RootStore,
+	type RootStoreRenderSnapshot,
 	type Size,
 } from './store.js';
 
@@ -49,23 +52,55 @@ interface PortalProps {
 	readonly state?: InjectState;
 }
 
-interface PortalOptions {
-	readonly events: InjectState['events'];
-	readonly size: Partial<Size> | undefined;
+interface PortalPlan {
+	readonly parent: RootState;
+	readonly inject: InjectState;
+	readonly state: RootState;
+	readonly view: RootStoreRenderSnapshot;
+	readonly injectedKeys: ReadonlySet<string>;
+	readonly injectedEventKeys: ReadonlySet<string>;
 }
 
 interface PortalLayer {
 	readonly store: RootStore;
 	readonly target: ThreePortalTargetBinding;
-	readonly sync: (parent: RootState, options: PortalOptions) => void;
-	readonly commitCamera: (parent: RootState, options: PortalOptions) => void;
+	readonly stage: (parent: RootState, state: InjectState) => PortalPlan;
+	readonly commit: (plan: PortalPlan) => void;
 }
 
-const PORTAL_OPTIONS = Symbol('octane.three.portal.options');
-const PORTAL_OPTIONS_COMMIT = Symbol('octane.three.portal.options-commit');
+const EMPTY_INJECT_STATE = Object.freeze({}) as InjectState;
+const PORTAL_STATE = Symbol('octane.three.portal.state');
+const PORTAL_STATE_COMMIT = Symbol('octane.three.portal.state-commit');
 const PORTAL_LAYER = Symbol('octane.three.portal.layer');
-const PORTAL_CAMERA_COMMIT = Symbol('octane.three.portal.camera-commit');
 const PORTAL_SUBSCRIPTION = Symbol('octane.three.portal.subscription');
+
+function shallowEqual(left: object, right: object): boolean {
+	const leftKeys = Object.keys(left);
+	const rightKeys = Object.keys(right);
+	if (leftKeys.length !== rightKeys.length) return false;
+	return leftKeys.every(
+		(key) =>
+			Object.prototype.hasOwnProperty.call(right, key) &&
+			Object.is((left as Record<string, unknown>)[key], (right as Record<string, unknown>)[key]),
+	);
+}
+
+function reuseShallow<T extends object>(previous: T, next: T): T {
+	return shallowEqual(previous, next) ? previous : next;
+}
+
+function resetRemovedKeys(
+	target: Record<string, unknown>,
+	previousKeys: ReadonlySet<string>,
+	next: Readonly<Record<string, unknown>>,
+	fallback: Readonly<Record<string, unknown>>,
+): void {
+	for (const key of previousKeys) {
+		if (Object.prototype.hasOwnProperty.call(next, key)) continue;
+		if (Object.prototype.hasOwnProperty.call(fallback, key)) target[key] = fallback[key];
+		else delete target[key];
+	}
+}
 
 function getWorldMatrixSnapshot(object: THREE.Object3D): THREE.Matrix4 {
 	if (object.matrixWorldAutoUpdate === false) return object.matrixWorld.clone();
@@ -98,82 +133,154 @@ function snapshotCamera<T extends THREE.Camera>(camera: T): T {
 function createLayer(
 	previousRoot: RootStore,
 	container: THREE.Object3D,
+	parentState: RootState,
 	state: InjectState,
-	options: PortalOptions,
 ): PortalLayer {
-	const { events: _events, size: _size, ...rest } = state;
+	const { events: _events, size: _size, ...initialRest } = state;
 	const raycaster = new THREE.Raycaster();
 	const pointer = new THREE.Vector2();
 	const target = createThreePortalTargetBinding(container);
 	const store = createPortalStore({
-		...previousRoot.getState(),
-		...rest,
+		...parentState,
+		...initialRest,
 		// A managed portal target may be reconstructed without changing the
 		// authored target handle. The driver advances the shared binding to the
 		// accepted replacement, and subsequent parent-state mirrors retain it.
 		scene: target.current as THREE.Scene,
 	} as RootState);
-
-	const sync = (parent: RootState, currentOptions: PortalOptions) => {
+	let injectedKeys = new Set<string>();
+	let injectedEventKeys = new Set<string>();
+	let cameraCommit:
+		| {
+				readonly camera: RootState['camera'];
+				readonly width: number;
+				readonly height: number;
+				readonly manual: boolean | undefined;
+		  }
+		| undefined;
+	const setEvents = (events: Partial<EventManager<any>>) => {
 		store.setState((local) => {
-			let viewport: Partial<RootState['viewport']> | undefined;
-			if (local.camera != null && currentOptions.size !== undefined) {
-				const size = {
-					...parent.size,
-					...currentOptions.size,
-				} as Size;
-				viewport = parent.viewport.getCurrentViewport(
-					snapshotCamera(local.camera),
-					new THREE.Vector3(),
-					size,
-				);
-			}
-			return {
-				...parent,
-				...local,
-				scene: target.current as THREE.Scene,
-				raycaster,
-				pointer,
-				mouse: pointer,
-				previousRoot,
-				events: {
-					...parent.events,
-					...local.events,
-					...currentOptions.events,
-				} as EventManager<any>,
-				size: {
-					...parent.size,
-					...currentOptions.size,
-				},
-				viewport: {
-					...parent.viewport,
-					...viewport,
-				},
-				setEvents(events: Partial<EventManager<any>>) {
-					store.setState((value) => ({
-						events: { ...value.events, ...events },
-					}));
-				},
-			};
+			const next = { ...local.events, ...events } as EventManager<any>;
+			return shallowEqual(local.events, next) ? local : { events: next };
 		});
 	};
-	const commitCamera = (parent: RootState, currentOptions: PortalOptions) => {
+
+	const stage = (parent: RootState, currentState: InjectState): PortalPlan => {
+		const { events, size, ...rest } = currentState;
+		const nextInjectedKeys = new Set(Object.keys(rest));
+		const nextInjectedEventKeys = new Set(Object.keys(events ?? {}));
 		const local = store.getState();
+		const inherited = { ...parent, ...local } as RootState & Record<string, unknown>;
+		resetRemovedKeys(
+			inherited,
+			injectedKeys,
+			rest as Readonly<Record<string, unknown>>,
+			parent as unknown as Readonly<Record<string, unknown>>,
+		);
+		Object.assign(inherited, rest);
+
+		const localEvents = { ...local.events } as Record<string, unknown>;
+		resetRemovedKeys(
+			localEvents,
+			injectedEventKeys,
+			(events ?? {}) as Readonly<Record<string, unknown>>,
+			parent.events as unknown as Readonly<Record<string, unknown>>,
+		);
+		const nextEvents = reuseShallow(local.events, {
+			...parent.events,
+			...localEvents,
+			...events,
+		} as EventManager<any>);
+		const nextSize = reuseShallow(local.size, { ...parent.size, ...size } as Size);
+		let viewport: Partial<RootState['viewport']> | undefined;
+		if (inherited.camera != null && size !== undefined) {
+			viewport = parent.viewport.getCurrentViewport(
+				snapshotCamera(inherited.camera),
+				new THREE.Vector3(),
+				nextSize,
+			);
+		}
+		const nextViewport = reuseShallow(local.viewport, {
+			...parent.viewport,
+			...viewport,
+		});
+		const candidate = {
+			...inherited,
+			set: local.set,
+			get: local.get,
+			scene: target.current as THREE.Scene,
+			raycaster,
+			pointer,
+			mouse: pointer,
+			previousRoot,
+			events: nextEvents,
+			size: nextSize,
+			viewport: nextViewport,
+			setEvents,
+		} as RootState;
+		const next = shallowEqual(local, candidate) ? local : candidate;
+		return {
+			parent,
+			inject: currentState,
+			state: next,
+			view: { store, current: next },
+			injectedKeys: nextInjectedKeys,
+			injectedEventKeys: nextInjectedEventKeys,
+		};
+	};
+	const commitCamera = (plan: PortalPlan) => {
+		const camera = plan.state.camera;
+		if (camera == null || plan.inject.size === undefined || camera === plan.parent.camera) {
+			cameraCommit = undefined;
+			return;
+		}
+		const size = {
+			...plan.parent.size,
+			...plan.inject.size,
+		} as Size;
 		if (
-			local.camera == null ||
-			currentOptions.size === undefined ||
-			local.camera === parent.camera
+			cameraCommit?.camera === camera &&
+			cameraCommit.width === size.width &&
+			cameraCommit.height === size.height &&
+			cameraCommit.manual === camera.manual
 		) {
 			return;
 		}
-		updateCamera(local.camera, {
-			...parent.size,
-			...currentOptions.size,
-		} as Size);
+		updateCamera(camera, size);
+		cameraCommit = {
+			camera,
+			width: size.width,
+			height: size.height,
+			manual: camera.manual,
+		};
+	};
+	const commit = (plan: PortalPlan) => {
+		try {
+			// The driver advances the binding during the accepted host commit.
+			// The staged state is attempt-owned, so reasserting that target here
+			// cannot leak through a render that preparation rejects.
+			plan.state.scene = target.current as THREE.Scene;
+			commitCamera(plan);
+			if (store.getState() !== plan.state) store.setState(plan.state, true);
+			injectedKeys = new Set(plan.injectedKeys);
+			injectedEventKeys = new Set(plan.injectedEventKeys);
+		} finally {
+			plan.view.current = null;
+		}
 	};
 
-	sync(previousRoot.getState(), options);
-	return { store, target, sync, commitCamera };
+	// A new layer has no previously accepted state that can be exposed. Seed its
+	// private store during construction so imperative `useStore().getState()`
+	// reads are complete even before the first accepted insertion commit. Camera
+	// mutations remain deferred until acceptance.
+	const initialPlan = stage(parentState, state);
+	initialPlan.state.scene = target.current as THREE.Scene;
+	store.setState(initialPlan.state, true);
+	injectedKeys = new Set(initialPlan.injectedKeys);
+	injectedEventKeys = new Set(initialPlan.injectedEventKeys);
+	initialPlan.view.current = null;
+
+	return { store, target, stage, commit };
 }
 
 const Portal = defineUniversalComponent<PortalProps>('three', (props) => {
@@ -186,32 +293,28 @@ const Portal = defineUniversalComponent<PortalProps>('three', (props) => {
 	if (activeStore === null) {
 		throw new Error('R3F: createPortal can only be used within the Canvas component!');
 	}
-	const options = { events: props.state?.events, size: props.state?.size };
-	const optionsRef = useRef<PortalOptions>(options, PORTAL_OPTIONS);
-	useInsertionEffect(
-		() => {
-			optionsRef.current = options;
-		},
-		[options.events, options.size],
-		PORTAL_OPTIONS_COMMIT,
-	);
+	const parentView = useContext(RootStoreRenderSnapshotContext);
+	const parentState = readRootStoreRenderSnapshot(activeStore, parentView);
+	const state = props.state ?? EMPTY_INJECT_STATE;
+	const stateRef = useRef<InjectState>(state, PORTAL_STATE);
 	const layer = useMemo(
-		() => createLayer(activeStore, props.container, props.state ?? {}, options),
+		() => createLayer(activeStore, props.container, parentState, state),
 		[activeStore, props.container],
 		PORTAL_LAYER,
 	);
+	const plan = layer.stage(parentState, state);
 	useInsertionEffect(
 		() => {
-			layer.commitCamera(activeStore.getState(), optionsRef.current);
+			layer.commit(plan);
+			stateRef.current = state;
 		},
-		[activeStore, layer],
-		PORTAL_CAMERA_COMMIT,
+		null,
+		PORTAL_STATE_COMMIT,
 	);
 	useLayoutEffect(
 		() => {
-			return activeStore.subscribe((state) => {
-				layer.sync(state, optionsRef.current);
-				layer.commitCamera(state, optionsRef.current);
+			return activeStore.subscribe((parent) => {
+				layer.commit(layer.stage(parent, stateRef.current));
 			});
 		},
 		[activeStore, layer],
@@ -219,9 +322,11 @@ const Portal = defineUniversalComponent<PortalProps>('three', (props) => {
 	);
 
 	return universalContext(RootStoreContext, layer.store, () =>
-		createUniversalPortal(
-			props.children,
-			createThreePortalTarget(props.container, layer.store, layer.target),
+		universalContext(RootStoreRenderSnapshotContext, plan.view, () =>
+			createUniversalPortal(
+				props.children,
+				createThreePortalTarget(props.container, layer.store, layer.target),
+			),
 		),
 	);
 });

--- a/packages/three/src/core/store.ts
+++ b/packages/three/src/core/store.ts
@@ -6,7 +6,13 @@
  * components. Zustand remains the framework-neutral storage primitive.
  */
 import * as THREE from 'three';
-import { createContext, useRef, useSyncExternalStore, withSlot } from 'octane/universal';
+import {
+	createContext,
+	useContext,
+	useRef,
+	useSyncExternalStore,
+	withSlot,
+} from 'octane/universal';
 import { createStore as createVanillaStore, type StoreApi } from 'zustand/vanilla';
 import type {
 	DomEvent,
@@ -453,6 +459,31 @@ interface SelectionCell<T> {
 	value: T;
 }
 
+/**
+ * Render-attempt-local state exposed by a portal without mutating its live
+ * store. An accepted portal commit clears `current`, after which consumers
+ * resume reading the store itself.
+ *
+ * This is package-private plumbing for the Three renderer. It is exported from
+ * this module so the portal and hook implementations can share it, but it is
+ * intentionally absent from the package's public barrel.
+ */
+export interface RootStoreRenderSnapshot {
+	readonly store: RootStore;
+	current: RootState | null;
+}
+
+export const RootStoreRenderSnapshotContext = createContext<RootStoreRenderSnapshot | null>(null);
+
+export function readRootStoreRenderSnapshot(
+	store: RootStore,
+	snapshot: RootStoreRenderSnapshot | null,
+): RootState {
+	return snapshot?.store === store && snapshot.current !== null
+		? snapshot.current
+		: store.getState();
+}
+
 /** Universal-hook selector used by the callable store and `useThree`. */
 export function useRootStoreSelector<T>(
 	store: RootStore,
@@ -460,12 +491,13 @@ export function useRootStoreSelector<T>(
 	equalityFn: (previous: T, next: T) => boolean = Object.is,
 	slot?: unknown,
 ): T {
+	const renderSnapshot = useContext(RootStoreRenderSnapshotContext);
 	const run = (nested: boolean): T => {
 		const cell = nested
 			? useRef<SelectionCell<T>>({ initialized: false, value: undefined as T }, 'selection')
 			: useRef<SelectionCell<T>>({ initialized: false, value: undefined as T });
 		const snapshot = () => {
-			const next = selector(store.getState());
+			const next = selector(readRootStoreRenderSnapshot(store, renderSnapshot));
 			if (!cell.current.initialized || !equalityFn(cell.current.value, next)) {
 				cell.current = { initialized: true, value: next };
 			}

--- a/packages/three/tests/portal.test.ts
+++ b/packages/three/tests/portal.test.ts
@@ -193,6 +193,108 @@ describe('Three portals', () => {
 		expect(root.store.getState().size).toEqual({ width: 100, height: 50, top: 6, left: 8 });
 	});
 
+	it('applies accepted injected-state updates to the existing portal enclave immediately', async () => {
+		const target = new THREE.Group();
+		const targetRefs = refs();
+		const layouts: LayoutObservation[] = [];
+		const onLayout = (value: LayoutObservation) => layouts.push(value);
+		const onFrame = () => {};
+		const firstCamera = new THREE.PerspectiveCamera(40, 1, 0.1, 100);
+		firstCamera.position.z = 4;
+		const firstControls = new THREE.EventDispatcher();
+		const firstCompute = (_event: DomEvent, _state: RootState) => {};
+		const root = await createThreeTestRenderer(PortalScene, {
+			...baseProps(target, targetRefs),
+			portalState: {
+				camera: firstCamera,
+				controls: firstControls,
+				flat: false,
+				size: { width: 240, height: 120, top: 1, left: 2 },
+				events: { enabled: true, priority: 8, compute: firstCompute },
+			},
+			onLayout,
+			onFrame,
+		});
+		mountedTestRoots.push(root);
+
+		const enclave = layouts.at(-1)!.store;
+		const portalMesh = targetRefs.mesh!;
+		const firstProjection = firstCamera.projectionMatrix.clone();
+		const nextCamera = new THREE.PerspectiveCamera(60, 1, 0.1, 100);
+		nextCamera.position.z = 9;
+		const nextProjection = nextCamera.projectionMatrix.clone();
+		const nextControls = new THREE.EventDispatcher();
+		const nextCompute = (_event: DomEvent, _state: RootState) => {};
+
+		root.update(PortalScene, {
+			...baseProps(target, targetRefs),
+			portalState: {
+				camera: nextCamera,
+				controls: nextControls,
+				flat: true,
+				size: { width: 360, height: 120, top: 5, left: 6 },
+				events: { enabled: false, priority: 0, compute: nextCompute },
+			},
+			onLayout,
+			onFrame,
+		});
+
+		const state = enclave.getState();
+		const committedLayout = layouts.at(-1)!;
+		expect(targetRefs.mesh).toBe(portalMesh);
+		expect(getRootState(portalMesh)).toBe(state);
+		expect(committedLayout.store).toBe(enclave);
+		expect(committedLayout.state).toBe(state);
+		expect(committedLayout.cameraAspect).toBe(3);
+		expect(state.scene).toBe(target);
+		expect(state.camera).toBe(nextCamera);
+		expect(state.controls).toBe(nextControls);
+		expect(state.flat).toBe(true);
+		expect(state.events.enabled).toBe(false);
+		expect(state.events.priority).toBe(0);
+		expect(state.events.compute).toBe(nextCompute);
+		expect(state.size).toEqual({ width: 360, height: 120, top: 5, left: 6 });
+		expect(state.viewport.aspect).toBe(3);
+		expect(state.viewport.distance).toBeCloseTo(9);
+		expect(state.viewport.height).toBeCloseTo(2 * Math.tan(Math.PI / 6) * 9);
+		expect(state.viewport.width).toBeCloseTo(state.viewport.height * 3);
+		expect(nextCamera.aspect).toBe(3);
+		expect(nextCamera.projectionMatrix.equals(nextProjection)).toBe(false);
+		expect(firstCamera.aspect).toBe(2);
+		expect(firstCamera.projectionMatrix.equals(firstProjection)).toBe(true);
+
+		const parentState = root.store.getState();
+		root.update(PortalScene, {
+			...baseProps(target, targetRefs),
+			portalState: { events: { priority: 4 } },
+			onLayout,
+			onFrame,
+		});
+
+		const fallbackState = enclave.getState();
+		const fallbackLayout = layouts.at(-1)!;
+		expect(targetRefs.mesh).toBe(portalMesh);
+		expect(fallbackLayout.store).toBe(enclave);
+		expect(fallbackLayout.state).toBe(fallbackState);
+		expect(fallbackLayout.cameraAspect).toBe(
+			(parentState.camera as THREE.PerspectiveCamera).aspect,
+		);
+		expect(fallbackState.scene).toBe(target);
+		expect(fallbackState.camera).toBe(parentState.camera);
+		expect(fallbackState.controls).toBe(parentState.controls);
+		expect(fallbackState.flat).toBe(parentState.flat);
+		expect(fallbackState.size).toEqual(parentState.size);
+		expect(fallbackState.viewport).toMatchObject({
+			width: parentState.viewport.width,
+			height: parentState.viewport.height,
+			aspect: parentState.viewport.aspect,
+			distance: parentState.viewport.distance,
+		});
+		expect(fallbackState.events.enabled).toBe(parentState.events.enabled);
+		expect(fallbackState.events.priority).toBe(4);
+		expect(fallbackState.events.compute).toBe(parentState.events.compute);
+	});
+
 	it('routes portal handlers through the outer event scope and tears down only owned children', async () => {
 		vi.useFakeTimers();
 		const target = new THREE.Group();
@@ -506,24 +608,34 @@ describe('Three portals', () => {
 		let lowMesh: THREE.Mesh | null = null;
 		let highMesh: THREE.Mesh | null = null;
 		const log: string[] = [];
-		const computations: Array<{ state: RootState; previous: RootState | undefined }> = [];
-		const compute = (event: DomEvent, state: RootState, previous?: RootState) => {
-			computations.push({ state, previous });
-			state.pointer.set(
-				(event.offsetX / state.size.width) * 2 - 1,
-				-(event.offsetY / state.size.height) * 2 + 1,
-			);
-			state.raycaster.setFromCamera(state.pointer, state.camera);
-		};
+		const computations: Array<{
+			name: string;
+			state: RootState;
+			previous: RootState | undefined;
+		}> = [];
+		const createCompute =
+			(name: string) => (event: DomEvent, state: RootState, previous?: RootState) => {
+				computations.push({ name, state, previous });
+				state.pointer.set(
+					(event.offsetX / state.size.width) * 2 - 1,
+					-(event.offsetY / state.size.height) * 2 + 1,
+				);
+				state.raycaster.setFromCamera(state.pointer, state.camera);
+			};
+		const initialCompute = createCompute('initial');
+		const lowRef = (value: THREE.Mesh | null) => (lowMesh = value);
+		const highRef = (value: THREE.Mesh | null) => (highMesh = value);
+		const onLowPointerDown = () => log.push('low');
+		const onHighPointerDown = () => log.push('high');
 		root.render(PortalEventLayersScene, {
 			lowTarget,
 			highTarget,
 			lowState: { camera, events: { priority: 1 } },
-			highState: { camera, events: { priority: 10, compute } },
-			lowRef: (value: THREE.Mesh | null) => (lowMesh = value),
-			highRef: (value: THREE.Mesh | null) => (highMesh = value),
-			onLowPointerDown: () => log.push('low'),
-			onHighPointerDown: () => log.push('high'),
+			highState: { camera, events: { enabled: true, priority: 10, compute: initialCompute } },
+			lowRef,
+			highRef,
+			onLowPointerDown,
+			onHighPointerDown,
 		});
 		lowTarget.updateMatrixWorld(true);
 		highTarget.updateMatrixWorld(true);
@@ -531,15 +643,55 @@ describe('Three portals', () => {
 		dispatchPointer(canvas, 'pointerdown', 50, 50);
 		expect(log).toEqual(['high', 'low']);
 		expect(computations).toHaveLength(1);
+		expect(computations[0].name).toBe('initial');
 		expect(computations[0].state).toBe(getRootState(highMesh!));
 		expect(computations[0].previous).toBe(root.store.getState());
 
 		log.length = 0;
-		getRootState(highMesh!)!.setEvents({ enabled: false });
+		const updatedCompute = createCompute('updated');
+		root.render(PortalEventLayersScene, {
+			lowTarget,
+			highTarget,
+			lowState: { camera, events: { priority: 1 } },
+			highState: { camera, events: { enabled: true, priority: 0, compute: updatedCompute } },
+			lowRef,
+			highRef,
+			onLowPointerDown,
+			onHighPointerDown,
+		});
+		expect(getRootState(highMesh!)!.events.enabled).toBe(true);
+		expect(getRootState(highMesh!)!.events.priority).toBe(0);
+		expect(getRootState(highMesh!)!.events.compute).toBe(updatedCompute);
+		dispatchPointer(canvas, 'pointerdown', 50, 50);
+		expect(log).toEqual(['low', 'high']);
+		expect(computations.map(({ name }) => name)).toEqual(['initial', 'updated']);
+
+		log.length = 0;
+		const disabledCompute = createCompute('disabled');
+		root.render(PortalEventLayersScene, {
+			lowTarget,
+			highTarget,
+			lowState: { camera, events: { priority: 1 } },
+			highState: { camera, events: { enabled: false, priority: 20, compute: disabledCompute } },
+			lowRef,
+			highRef,
+			onLowPointerDown,
+			onHighPointerDown,
+		});
+		expect(getRootState(highMesh!)!.events.enabled).toBe(false);
+		expect(getRootState(highMesh!)!.events.priority).toBe(20);
+		expect(getRootState(highMesh!)!.events.compute).toBe(disabledCompute);
 		dispatchPointer(canvas, 'pointerdown', 50, 50);
 		expect(log).toEqual(['low']);
-		expect(computations).toHaveLength(1);
+		expect(computations.map(({ name }) => name)).toEqual(['initial', 'updated']);
 		expect(getRootState(lowMesh!)!.previousRoot).toBe(root.store);
+
+		log.length = 0;
+		getRootState(highMesh!)!.setEvents({ enabled: true });
+		expect(getRootState(highMesh!)!.events.enabled).toBe(true);
+		dispatchPointer(canvas, 'pointerdown', 50, 50);
+		expect(log).toEqual(['high', 'low']);
+		expect(computations.map(({ name }) => name)).toEqual(['initial', 'updated', 'disabled']);
 	});
 
 	it('routes child errors to the authored boundary and cleans up portal-owned effects', async () => {
@@ -570,6 +722,94 @@ describe('Three portals', () => {
 		expect(root.scene.children.map((child) => child.name)).toEqual(['caught:portal-owned-boom']);
 		expect(fallback?.name).toBe('caught:portal-owned-boom');
 		expect(effects).toEqual(['mount', 'cleanup']);
+	});
+
+	it('does not publish injected state from a rejected portal transaction', async () => {
+		const foreignTarget = new THREE.Group();
+		const owner = await createThreeTestRenderer(PortalScene, baseProps(foreignTarget));
+		mountedTestRoots.push(owner);
+
+		const lowTarget = new THREE.Group();
+		const highTarget = new THREE.Group();
+		let lowMesh: THREE.Mesh | null = null;
+		let highMesh: THREE.Mesh | null = null;
+		const lowRef = (value: THREE.Mesh | null) => (lowMesh = value);
+		const highRef = (value: THREE.Mesh | null) => (highMesh = value);
+		const onLowPointerDown = () => {};
+		const onHighPointerDown = () => {};
+		const acceptedCamera = new THREE.PerspectiveCamera(45, 1, 0.1, 100);
+		acceptedCamera.position.z = 5;
+		const acceptedControls = new THREE.EventDispatcher();
+		const acceptedCompute = (_event: DomEvent, _state: RootState) => {};
+		const acceptedState = {
+			camera: acceptedCamera,
+			controls: acceptedControls,
+			flat: false,
+			size: { width: 200, height: 100, top: 1, left: 2 },
+			events: { enabled: true, priority: 6, compute: acceptedCompute },
+		};
+		const root = await createThreeTestRenderer(PortalEventLayersScene, {
+			lowTarget,
+			highTarget,
+			lowState: acceptedState,
+			highState: { camera: acceptedCamera, events: { priority: 1 } },
+			lowRef,
+			highRef,
+			onLowPointerDown,
+			onHighPointerDown,
+		});
+		mountedTestRoots.push(root);
+
+		const acceptedLowMesh = lowMesh!;
+		const acceptedHighMesh = highMesh!;
+		const rejectedCamera = new THREE.PerspectiveCamera(70, 1, 0.1, 100);
+		rejectedCamera.position.z = 11;
+		const rejectedProjection = rejectedCamera.projectionMatrix.clone();
+		const rejectedControls = new THREE.EventDispatcher();
+		const rejectedCompute = (_event: DomEvent, _state: RootState) => {};
+		const rejectedState = {
+			camera: rejectedCamera,
+			controls: rejectedControls,
+			flat: true,
+			size: { width: 400, height: 100, top: 7, left: 8 },
+			events: { enabled: false, priority: 0, compute: rejectedCompute },
+		};
+
+		expect(() =>
+			root.update(PortalEventLayersScene, {
+				lowTarget,
+				highTarget: foreignTarget,
+				lowState: rejectedState,
+				highState: { camera: acceptedCamera, events: { priority: 1 } },
+				lowRef,
+				highRef,
+				onLowPointerDown,
+				onHighPointerDown,
+			}),
+		).toThrow(/leased by another root/);
+
+		const assertAcceptedState = () => {
+			const state = getRootState(acceptedLowMesh)!;
+			expect(state.camera).toBe(acceptedCamera);
+			expect(state.controls).toBe(acceptedControls);
+			expect(state.flat).toBe(false);
+			expect(state.size).toEqual({ width: 200, height: 100, top: 1, left: 2 });
+			expect(state.events.enabled).toBe(true);
+			expect(state.events.priority).toBe(6);
+			expect(state.events.compute).toBe(acceptedCompute);
+		};
+		assertAcceptedState();
+		expect(lowTarget.children).toEqual([acceptedLowMesh]);
+		expect(highTarget.children).toEqual([acceptedHighMesh]);
+		expect(rejectedCamera.aspect).toBe(1);
+		expect(rejectedCamera.projectionMatrix.equals(rejectedProjection)).toBe(true);
+
+		// A rejected render must not leave a staged injection visible to the
+		// accepted layer when its parent store next mirrors state.
+		root.store.getState().setSize(640, 320, 9, 10);
+		assertAcceptedState();
+		expect(rejectedCamera.aspect).toBe(1);
+		expect(rejectedCamera.projectionMatrix.equals(rejectedProjection)).toBe(true);
 	});
 
 	it('rejects invalid and cross-root targets without mutating either scene', async () => {


### PR DESCRIPTION
## Summary

- stage portal injection changes for the current render and publish them only after the Three host transaction is accepted
- expose the staged snapshot to portal `useThree` and selector consumers while retaining the stable live store identity
- update and remove camera, size, event, and other injected overrides without leaking rejected renders
- add behavioral coverage for same-commit state, native event layers, fallback removal, and rejected transactions

Follow-up to #113.

## Validation

- `pnpm --config.verify-deps-before-run=warn three:test` (19 files, 104 tests)
- Three source and public API typechecks
- `pnpm --config.verify-deps-before-run=warn format:check`
- `pnpm --config.verify-deps-before-run=warn changeset:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core portal state mirroring, camera mutation timing, and hook snapshot reads—behavioral changes in event layers and rejected renders, though scoped to `@octanejs/three` with expanded portal tests.
> 
> **Overview**
> Three portals now **stage** `createPortal` / portal `state` overrides for the current render and **write them to the enclave store only on an accepted host commit**, so failed or cross-root transactions cannot mutate cameras, size, events, or other injected fields.
> 
> A render-attempt **`RootStoreRenderSnapshot`** is threaded through portal children: **`useThree`**, **`useStore(selector)`**, and **`useRootStoreSelector`** read the staged snapshot while `current` is set, then fall back to the live Zustand store after commit. Portal logic was refactored from incremental `sync` to **`stage` / `commit` plans**, including **reverting removed injection keys** to the parent root and **deferring `updateCamera`** until acceptance.
> 
> Tests cover same-commit injection updates, event-layer priority/compute/enabled changes via re-render, partial override fallback, and **rejected portal renders** not leaving staged state visible after parent store updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24aaadcf8d38d100b3d72424f2f2d473c71e16eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->