### PR TITLE
Fix mid-render @catch unwind DOM corruption + hot-server duplicate module instances

### DIFF
--- a/.changeset/hot-server-single-instance.md
+++ b/.changeset/hot-server-single-instance.md
@@ -1,0 +1,5 @@
+---
+"@octanejs/vite-plugin": patch
+---
+
+Dev-server hydrate entry now maps route entries, layouts, preHydrate, and root boundaries as literal dynamic imports (as production already did), so they load through Vite's import analysis and share module-instance identity with the page's own import chain. Previously the analysis-hidden fallback import fetched timestamp-less URLs after an HMR invalidation, creating duplicate browser module instances (e.g. two app-router singletons) that broke hydration on every reload until the dev server restarted.

--- a/.changeset/proud-boundaries-unwind.md
+++ b/.changeset/proud-boundaries-unwind.md
@@ -1,0 +1,5 @@
+---
+"octane": patch
+---
+
+Error boundaries no longer corrupt the DOM when a @catch arm rethrows mid-render: the rethrown error now unwinds the live render stack before the outer boundary switches arms (previously the outer switch swept insertion anchors out from under still-mounting frames, producing an insertBefore NotFoundError that replaced the original error and could blank the page). During hydration, a client-built @catch arm also discards the slot's leftover server DOM, parks the adoption cursor past the slot, and renders with adoption suspended, so sibling content keeps hydrating cleanly instead of mis-adopting.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -14660,6 +14660,24 @@ function switchToCatch(state: TrySlot, err: any, adoptedStart?: Node, adoptedEnd
 	const bStart = adoptedStart ?? document.createComment('catch-b');
 	const bEnd = adoptedEnd ?? document.createComment('/catch-b');
 	if (!adopting) {
+		if (hydration !== null) {
+			// Hydrating, but the server rendered a DIFFERENT arm in this slot (the
+			// try body threw on the CLIENT), so the catch arm is a client-fresh
+			// build. The aborted try adoption consumed only part of the server range
+			// and its teardown removed only the nodes its own block had claimed —
+			// discard whatever server content is left inside the slot and park the
+			// cursor on the slot's close marker so FOLLOWING siblings keep adopting
+			// from an aligned position (same convention as the abandoned-adoption
+			// pending swap). Only an adopted slot pair bounds server DOM; a slot
+			// that minted fresh markers under hydration owns no server range.
+			if (hydration.isClose(state.end)) {
+				removeRange(state.start.nextSibling, state.end);
+				hydration.node = state.end;
+			}
+			// Client-built replacement markers survive root-remainder sweeps.
+			hydration.markFresh(bStart);
+			hydration.markFresh(bEnd);
+		}
 		state.domParent.insertBefore(bStart, state.end);
 		state.domParent.insertBefore(bEnd, state.end);
 	} else if (hydration !== null) {
@@ -14679,7 +14697,11 @@ function switchToCatch(state: TrySlot, err: any, adoptedStart?: Node, adoptedEnd
 	b.idState = state.idState;
 	state.block = b;
 	try {
-		renderBlock(b);
+		// A client-fresh catch build during hydration must not read the adoption
+		// cursor — the server rendered the try arm here, so adopting would consume
+		// (and warn about) another slot's server DOM. Suspend for the subtree.
+		if (!adopting && hydration !== null) hydration.suspend(() => renderBlock(b));
+		else renderBlock(b);
 	} catch (e2) {
 		// Catch body itself threw — bubble to next enclosing tryBlock.
 		const rethrowsHydrationReason = hydrationRejection && Object.is(e2, caughtError);
@@ -14689,10 +14711,25 @@ function switchToCatch(state: TrySlot, err: any, adoptedStart?: Node, adoptedEnd
 			state.block = null;
 		}
 		const propagated = rethrowsHydrationReason ? err : e2;
-		// An exact rethrow of the raw catch reason must retain the private hydration
-		// token while the render stack unwinds. The outer mountTry can then adopt its
-		// own server catch range instead of rebuilding it.
-		if (rethrowsHydrationReason && CURRENT_BLOCK !== null) throw propagated;
+		// Mid-render (a component render stack is live) with an outer boundary to
+		// take the error: RETHROW instead of delegating synchronously — the same
+		// rule as the no-catch-arm path above. The outer boundary's switch sweeps
+		// the DOM of every frame between this boundary and itself; delegating here
+		// and returning would let those still-on-stack frames keep rendering into
+		// the swept range (stale anchors → NotFoundError, and the bookkeeping
+		// error would REPLACE the original). The rethrow unwinds them; the outer
+		// boundary catches it at its own tryBlock frame. A hydration-rejection
+		// rethrow additionally retains the private hydration token so the outer
+		// mountTry can adopt its own server catch range instead of rebuilding it
+		// — that rethrow stays unconditional (hydrateRoot owns the unwind). With
+		// NO outer handler the error must not escape to the render caller: fall
+		// through to the console.error surface below (the boundary's content is
+		// already torn down — no content, no fallback).
+		if (
+			CURRENT_BLOCK !== null &&
+			(rethrowsHydrationReason || findTryHandler(state.parentBlock) !== null)
+		)
+			throw propagated;
 		const parent = findTryHandler(state.parentBlock);
 		if (parent) parent(propagated);
 		else console.error('catch body threw, no outer tryBlock:', e2);

--- a/packages/octane/tests/_fixtures/boundary-unwind.tsrx
+++ b/packages/octane/tests/_fixtures/boundary-unwind.tsrx
@@ -55,6 +55,20 @@ function Rethrow(props) {
 	throw props.err;
 }
 
+// The router MatchesInner shape: the outer boundary's try arm mounts an @if
+// whose branch renders the rethrowing inner boundary. The rethrown error must
+// unwind PAST the @if's still-live mount frames before the outer boundary
+// switches arms — a synchronous outer switch would sweep the @if's insertion
+// anchors while its mount is still on the stack, and the resulting DOM
+// bookkeeping error would REPLACE the original error.
+export function RethrowingCatchUnderIf(props) @{
+	<ErrorBoundary fallback={(e) => 'outer:' + (e as Error).message}>
+		@if (props.on) {
+			<InnerRethrow bang={props.bang} />
+		}
+	</ErrorBoundary>
+}
+
 // A suspending leaf under passthroughs + a host, with the boundary ABOVE them:
 // fallback → content swap must not corrupt DOM bookkeeping (and any teardown
 // error must not escape into the resolver's caller — the router loader-pipeline

--- a/packages/octane/tests/boundary-unwind.test.ts
+++ b/packages/octane/tests/boundary-unwind.test.ts
@@ -3,6 +3,7 @@ import { mount, nextPaint } from './_helpers';
 import {
 	DeepThrowHost,
 	RethrowingCatch,
+	RethrowingCatchUnderIf,
 	DeepSuspenseHost,
 	StateFlipHost,
 } from './_fixtures/boundary-unwind.tsrx';
@@ -29,6 +30,22 @@ describe('boundary unwinding through nested components and hosts', () => {
 	it('a catch branch that rethrows forwards the ORIGINAL error to the outer boundary', () => {
 		const r = mount(RethrowingCatch, { bang: true });
 		expect(r.container.textContent).toContain('outer:deep-boom');
+		r.unmount();
+	});
+
+	// The router MatchesInner shape: the rethrown error crosses an @if whose
+	// branch mount is still on the stack. The outer boundary must report the
+	// ORIGINAL error — not a DOM bookkeeping error from switching arms while the
+	// @if's insertion anchors were being swept out from under it.
+	it('a rethrowing catch under an in-progress @if mount forwards the ORIGINAL error', () => {
+		const r = mount(RethrowingCatchUnderIf, { on: true, bang: true });
+		expect(r.container.textContent).toContain('outer:deep-boom');
+		r.unmount();
+	});
+
+	it('the @if-wrapped inner boundary renders normally when nothing throws', () => {
+		const r = mount(RethrowingCatchUnderIf, { on: true, bang: false });
+		expect(r.find('.ok').textContent).toBe('ok');
 		r.unmount();
 	});
 

--- a/packages/octane/tests/hydration/_fixtures/trycatch-client-error.tsrx
+++ b/packages/octane/tests/hydration/_fixtures/trycatch-client-error.tsrx
@@ -1,0 +1,98 @@
+import { useState } from 'octane';
+
+// Hydration recovery for @try/@catch: the server rendered the SUCCESS arm, but on
+// the client the try body throws during hydration (the website analogue: a route
+// module fails to import on a hot dev server). The boundary must mount its @catch
+// arm without crashing and without disturbing the sibling DOM around the slot.
+
+function Inner(props) @{
+	if (props.boom) throw new Error('boom');
+	const [n, setN] = useState(0);
+	<button id="ok" onClick={() => setN(n + 1)}>
+		{'ok:' + n}
+	</button>
+}
+
+export function Page(props) @{
+	<div id="page">
+		<h1 id="before">Title</h1>
+		@try {
+			<Inner boom={props.boom} />
+		} @catch (err, reset) {
+			<div class="err">
+				<span class="msg">
+					{'caught:' + err.message}
+				</span>
+				<button class="retry" onClick={() => reset()}>
+					retry
+				</button>
+			</div>
+		}
+		<p id="after">after</p>
+	</div>
+}
+
+// The router pipeline shape from the live report (tanstack-router's global
+// CatchBoundary > @if > Match > CatchNotFound): the outer boundary's try arm is
+// an @if whose branch renders an INNER boundary whose @catch RETHROWS every
+// error (the notFound-forwarding shape). The rethrown error must reach the
+// OUTER @catch intact — during hydration adoption AND on a later reset()
+// re-mount while the leaf still throws (a route module that stays broken).
+function RethrowView(props) {
+	throw props.err;
+}
+
+function InnerRethrow(props) @{
+	@try {
+		<Inner boom={props.boom} />
+	} @catch (err) {
+		<RethrowView err={err} />
+	}
+}
+
+export function RouterShape(props) @{
+	<div id="router">
+		<h1 id="before">Title</h1>
+		@try {
+			@if (props.show) {
+				<InnerRethrow boom={props.boom} />
+			}
+		} @catch (err, reset) {
+			<div class="outer-err">
+				<span class="msg">
+					{'outer:' + err.message}
+				</span>
+				<button class="retry" onClick={() => reset()}>
+					retry
+				</button>
+			</div>
+		}
+		<p id="after">after</p>
+	</div>
+}
+
+// The router Match shape from the live report: TWO nested boundaries (root route +
+// leaf route), the inner one owning the throwing component. The inner boundary
+// catches; the outer boundary and its surrounding DOM must survive.
+export function NestedPage(props) @{
+	<div id="nested">
+		<h1 id="before">Title</h1>
+		@try {
+			<section class="outer">
+				@try {
+					<Inner boom={props.boom} />
+				} @catch (err) {
+					<div class="inner-err">
+						{'inner:' + err.message}
+					</div>
+				}
+				<span id="outer-tail">tail</span>
+			</section>
+		} @catch (err) {
+			<div class="outer-err">
+				{'outer:' + err.message}
+			</div>
+		}
+		<p id="after">after</p>
+	</div>
+}

--- a/packages/octane/tests/hydration/trycatch-client-error.test.ts
+++ b/packages/octane/tests/hydration/trycatch-client-error.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { compile } from 'octane/compiler';
+import { hydrateRoot, flushSync } from '../../src/index.js';
+import * as ServerRT from 'octane/server';
+import { Page, NestedPage, RouterShape } from './_fixtures/trycatch-client-error.tsrx';
+
+// The server rendered a @try's SUCCESS arm, but on the client the try body throws
+// during hydration (the live report: a route module failed to import on a hot dev
+// server, so the router's CatchBoundary had to mount its error UI mid-hydration).
+// The boundary must switch to its @catch arm without crashing and without eating
+// DOM outside the slot: previously a rethrowing inner @catch made the outer
+// boundary switch arms synchronously while the frames between them were still
+// mounting (stale anchors → an insertBefore NotFoundError that REPLACED the real
+// error and blanked the page), and the client-built catch arm consumed the
+// misaligned adoption cursor (false structural mismatches + sibling DOM swept).
+
+const FIXTURE = join(
+	process.cwd(),
+	'packages/octane/tests/hydration/_fixtures/trycatch-client-error.tsrx',
+);
+
+function serverModule(): Record<string, any> {
+	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'trycatch-client-error.tsrx', {
+		mode: 'server',
+	});
+	code = code.replace(
+		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
+	);
+	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
+	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');
+	const fn = new Function('__rt', '__exports', code + '\nreturn __exports;');
+	return fn(ServerRT, {});
+}
+const server = serverModule();
+
+let container: HTMLElement;
+let errSpy: ReturnType<typeof vi.spyOn>;
+beforeEach(() => {
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+	container.remove();
+	errSpy.mockRestore();
+});
+
+describe('hydrateRoot — try body throws during hydration, @catch mounts', () => {
+	it('mounts the @catch arm, keeps surrounding DOM, and no exception escapes', async () => {
+		const { html } = await ServerRT.renderToString(server.Page, { boom: false });
+		expect(html).toContain('<button id="ok"');
+		container.innerHTML = html;
+
+		// Hydrate with boom:true → the try body throws while adopting the server DOM.
+		let root!: ReturnType<typeof hydrateRoot>;
+		expect(() => {
+			root = hydrateRoot(container, Page, { boom: true });
+			flushSync(() => {});
+		}).not.toThrow();
+
+		// The @catch arm is mounted with the caught error...
+		const msg = container.querySelector('.msg');
+		expect(msg).not.toBeNull();
+		expect(msg!.textContent).toBe('caught:boom');
+		// ...the stale success arm is gone (not duplicated)...
+		expect(container.querySelector('#ok')).toBeNull();
+		// ...and the DOM around the boundary survived intact.
+		expect(container.querySelector('#page')).not.toBeNull();
+		expect(container.querySelector('#before')!.textContent).toBe('Title');
+		expect(container.querySelector('#after')!.textContent).toBe('after');
+		root.unmount();
+	});
+
+	it('the mounted @catch arm is interactive: reset() re-renders the try body', async () => {
+		const { html } = await ServerRT.renderToString(server.Page, { boom: false });
+		container.innerHTML = html;
+
+		const root = hydrateRoot(container, Page, { boom: false });
+		flushSync(() => {});
+		// Server and client agree here — the success arm was adopted.
+		const ok = container.querySelector('#ok') as HTMLButtonElement;
+		expect(ok).not.toBeNull();
+		flushSync(() => ok.click());
+		expect(ok.textContent).toBe('ok:1');
+		root.unmount();
+	});
+
+	it('nested boundaries (router Match shape): the INNER @catch mounts, outer content survives', async () => {
+		const { html } = await ServerRT.renderToString(server.NestedPage, { boom: false });
+		expect(html).toContain('<button id="ok"');
+		container.innerHTML = html;
+
+		let root!: ReturnType<typeof hydrateRoot>;
+		expect(() => {
+			root = hydrateRoot(container, NestedPage, { boom: true });
+			flushSync(() => {});
+		}).not.toThrow();
+
+		// The inner boundary caught — its catch UI is up, the outer one is not.
+		const inner = container.querySelector('.inner-err');
+		expect(inner).not.toBeNull();
+		expect(inner!.textContent).toBe('inner:boom');
+		expect(container.querySelector('.outer-err')).toBeNull();
+		expect(container.querySelector('#ok')).toBeNull();
+		// The outer boundary's own content and the page around it survived.
+		expect(container.querySelector('section.outer')).not.toBeNull();
+		expect(container.querySelector('#outer-tail')!.textContent).toBe('tail');
+		expect(container.querySelector('#before')!.textContent).toBe('Title');
+		expect(container.querySelector('#after')!.textContent).toBe('after');
+		root.unmount();
+	});
+
+	// The live report's full pipeline: outer boundary > @if > inner boundary whose
+	// @catch RETHROWS. The rethrow crosses the @if's still-live mount frames — the
+	// outer arm switch must not sweep the @if's anchors while its mount is still on
+	// the stack (that produced an insertBefore NotFoundError that REPLACED the real
+	// error and blanked the page).
+	it('router shape: a rethrowing inner @catch reaches the outer @catch during hydration', async () => {
+		const { html } = await ServerRT.renderToString(server.RouterShape, {
+			show: true,
+			boom: false,
+		});
+		expect(html).toContain('<button id="ok"');
+		container.innerHTML = html;
+
+		let root!: ReturnType<typeof hydrateRoot>;
+		expect(() => {
+			root = hydrateRoot(container, RouterShape, { show: true, boom: true });
+			flushSync(() => {});
+		}).not.toThrow();
+
+		const msg = container.querySelector('.msg');
+		expect(msg).not.toBeNull();
+		expect(msg!.textContent).toBe('outer:boom');
+		expect(container.querySelector('#ok')).toBeNull();
+		expect(container.querySelector('#before')!.textContent).toBe('Title');
+		expect(container.querySelector('#after')!.textContent).toBe('after');
+		root.unmount();
+	});
+
+	it('router shape: reset() while the leaf still throws re-catches the ORIGINAL error (no crash)', async () => {
+		// The website sequence: hydration mounted the outer catch UI, then the
+		// boundary resets (the router's loadedAt reset key rolls) and the re-mounted
+		// try body throws AGAIN because the route module is still broken.
+		const { html } = await ServerRT.renderToString(server.RouterShape, {
+			show: true,
+			boom: false,
+		});
+		container.innerHTML = html;
+
+		let root!: ReturnType<typeof hydrateRoot>;
+		expect(() => {
+			root = hydrateRoot(container, RouterShape, { show: true, boom: true });
+			flushSync(() => {});
+		}).not.toThrow();
+		const retry = container.querySelector('.retry') as HTMLButtonElement;
+		expect(retry).not.toBeNull();
+
+		// Client-side re-mount of the try arm — the leaf throws, the inner catch
+		// rethrows, and the outer catch must show the ORIGINAL error again.
+		expect(() => flushSync(() => retry.click())).not.toThrow();
+		const msg = container.querySelector('.msg');
+		expect(msg).not.toBeNull();
+		expect(msg!.textContent).toBe('outer:boom');
+		expect(container.querySelector('#before')!.textContent).toBe('Title');
+		expect(container.querySelector('#after')!.textContent).toBe('after');
+		root.unmount();
+	});
+});

--- a/packages/vite-plugin-octane/src/index.js
+++ b/packages/vite-plugin-octane/src/index.js
@@ -169,6 +169,31 @@ function has_route_config(config) {
 }
 
 /**
+ * Every module path the server can name in #__octane_data — page entries,
+ * layouts, the preHydrate hook, and root boundaries. The generated hydrate
+ * entry maps each as a LITERAL `() => import('/src/…')`. Production needs the
+ * map so Rollup chunks and hashes the modules; dev needs it so the imports go
+ * through Vite's import analysis and share URL identity with every other
+ * importer (see the hydrate-entry load hook).
+ *
+ * @param {ResolvedOctaneConfig | null} config
+ * @returns {string[]}
+ */
+function collect_hydrate_module_paths(config) {
+	if (!has_route_config(config)) return [];
+	const cfg = /** @type {ResolvedOctaneConfig} */ (config);
+	const entries = cfg.router.routes
+		.filter((r) => r.type === 'render')
+		.flatMap((r) => [get_route_entry_path(/** @type {RenderRoute} */ (r).entry), r.layout]);
+	if (cfg.router.preHydrate) entries.push(cfg.router.preHydrate);
+	entries.push(
+		get_route_entry_path(cfg.rootBoundary.pending),
+		get_route_entry_path(cfg.rootBoundary.catch),
+	);
+	return [...new Set(entries.filter((e) => typeof e === 'string'))];
+}
+
+/**
  * The recommended Octane Vite integration. With no octane.config.ts it behaves
  * as a compiler plugin inside a normal Vite SPA; configured routes activate the
  * metaframework layer.
@@ -319,16 +344,7 @@ export function octane(inlineOptions = {}) {
 		buildStart() {
 			if (!isBuild || isSSRBuild || !has_route_config(buildOctaneConfig)) return;
 			serverModuleModules.clear();
-			const cfg = /** @type {ResolvedOctaneConfig} */ (buildOctaneConfig);
-			const entries = cfg.router.routes
-				.filter((r) => r.type === 'render')
-				.flatMap((r) => [get_route_entry_path(/** @type {RenderRoute} */ (r).entry), r.layout]);
-			if (cfg.router.preHydrate) entries.push(cfg.router.preHydrate);
-			entries.push(
-				get_route_entry_path(cfg.rootBoundary.pending),
-				get_route_entry_path(cfg.rootBoundary.catch),
-			);
-			staticEntries = [...new Set(entries.filter((e) => typeof e === 'string'))];
+			staticEntries = collect_hydrate_module_paths(buildOctaneConfig);
 		},
 
 		async configResolved(resolvedConfig) {
@@ -352,16 +368,29 @@ export function octane(inlineOptions = {}) {
 				return create_adapter_browser_stub_source();
 			}
 			if (id === RESOLVED_VIRTUAL_HYDRATE_ID) {
-				// Dev: dynamic import() of the route entry works through Vite, so the
-				// static import map stays empty (the codegen falls back to a dynamic
-				// import per entry). Production builds pass the routes' module paths
-				// (collected in buildStart) so Rollup bundles them.
+				// Production builds pass the routes' module paths (collected in
+				// buildStart) so Rollup bundles them. Dev ALSO needs the literal map —
+				// not for chunking (dev serves any module by URL) but for MODULE
+				// IDENTITY on a hot server: the codegen's fallback `dynamicImport(path)`
+				// is hidden from Vite's import analysis, so it fetches the BARE url
+				// while the page's own import chain fetches the analyzed url (`?import`
+				// for non-JS extensions, `?t=` stamps after an HMR invalidation). Two
+				// urls = two browser module instances — e.g. two app-router singletons,
+				// where preHydrate commits matches on one and the page renders the
+				// empty other, breaking hydration on every reload until the dev server
+				// restarts. Literal `import('/src/…')` entries go through import
+				// analysis and share url identity with every other importer.
+				let entries = staticEntries;
+				if (!isBuild) {
+					const loaded = octaneConfig ?? (await loadStartupConfig(root))?.config ?? null;
+					entries = collect_hydrate_module_paths(loaded);
+				}
 				const file = write_project_generated_file(
 					config,
 					'client-entry.js',
 					create_client_entry_source({
 						configPath: to_vite_root_import(getOctaneConfigPath(root), root),
-						staticEntries,
+						staticEntries: entries,
 					}),
 				);
 				return fs.readFileSync(file, 'utf-8');

--- a/website/tests/ssr-hydration.e2e.test.ts
+++ b/website/tests/ssr-hydration.e2e.test.ts
@@ -14,7 +14,7 @@
 // with the exact setup command when it is missing.
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { spawn, type ChildProcess } from 'node:child_process';
-import { rmSync } from 'node:fs';
+import { readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { createServer } from 'node:net';
 import { join } from 'node:path';
 
@@ -491,6 +491,62 @@ describe.sequential('website dev-SSR → hydration (real browser)', () => {
 			await page.close();
 		}
 	}, 30_000);
+
+	// HOT-server regression: editing app modules (HMR update + ssr page reload)
+	// stamps `?t=` cache-busting timestamps onto the modules' importer chains.
+	// The generated hydrate entry must keep loading the SAME browser module
+	// instances as the page's own import chain afterwards — a bare
+	// (analysis-hidden) dynamic import fetched timestamp-less URLs, splitting
+	// the app-router singleton in two (preHydrate committed matches on one
+	// instance, the page rendered the empty other) and breaking hydration on
+	// EVERY reload until the dev server was restarted. Touching router.ts — a
+	// plain .ts module with no self-accepting HMR handler — deterministically
+	// propagates the invalidation up the client chain; the route module edit is
+	// the shape from the original report. Deliberately LAST in this describe:
+	// the invalidation stamps persist in the dev server for the rest of its life.
+	it('hydrates cleanly on reload after HMR edits (hot server)', async () => {
+		const files = [
+			join(WEBSITE, 'src/pages/benchmarks/Benchmarks.tsrx'),
+			join(WEBSITE, 'src/app/router.ts'),
+		];
+		const originals = files.map((f) => readFileSync(f, 'utf8'));
+		const restore = () => files.forEach((f, i) => writeFileSync(f, originals[i]));
+		try {
+			// Prime the dev server's client + SSR module graphs and keep the page —
+			// with its live HMR websocket — OPEN while editing (the editing-session
+			// shape: the route is on screen while its files are edited). A plain
+			// navigation: this first visit may race Vite's dependency-optimization
+			// reload, which is irrelevant to the assertion below.
+			const primer = await browser.newPage();
+			await primer.goto(`http://localhost:${DEV_PORT}/benchmarks`, { waitUntil: 'networkidle' });
+
+			// Touch each file — every write triggers the paired `(client) hmr
+			// update` / full-reload + `(ssr) page reload` invalidations.
+			for (let i = 0; i < files.length; i++) {
+				writeFileSync(files[i], originals[i] + `\n// e2e-hmr-touch ${i}\n`);
+				await new Promise((r) => setTimeout(r, 700));
+			}
+			restore();
+			await new Promise((r) => setTimeout(r, 700));
+			await primer.close();
+
+			// A FULL reload after the edits must hydrate the route cleanly. Let the
+			// module fetches + preHydrate router load finish before judging —
+			// hydration (and its mismatch warnings) lands well after `load` here.
+			const { page, errors, main } = await loadRoute(`http://localhost:${DEV_PORT}`, '/benchmarks');
+			try {
+				await page.waitForLoadState('networkidle');
+				await page.waitForTimeout(500);
+				const real = errors.filter((e) => !e.includes('Failed to load resource'));
+				expect(real).toEqual([]);
+				expect(main).toContain('Benchmark');
+			} finally {
+				await page.close();
+			}
+		} finally {
+			restore();
+		}
+	}, 45_000);
 });
 
 describe.sequential('website production build → hydration (octane-preview)', () => {


### PR DESCRIPTION
## Symptom

After a few HMR edits to a route file, the website dev server's next page load hydration-mismatched at the router's CatchBoundary, recovery crashed with `NotFoundError: Failed to execute 'insertBefore' on 'Node'` (replacing the original error), and the page went blank until the dev server was restarted. Reported independently twice; reproduced in a real browser.

## Root causes

**1. Runtime — `switchToCatch` corrupted live-render DOM when a `@catch` arm rethrows.** The "catch body itself threw" path delegated the error to the outer boundary's handler synchronously while a component render stack was still live. The outer boundary's arm switch sweeps the DOM of every frame between the throw site and itself, so the still-on-stack frames (e.g. `renderBranchSlot`'s post-render marker minting for `@if (matchId)` in tanstack-router's `MatchesInner`) kept rendering into the swept range → `insertBefore` NotFoundError that replaced the original error. The sibling no-catch-arm path already had the correct rethrow-while-mid-render rule; this path only applied it to hydration-rejection tokens. Now gated so an error escaping every boundary still surfaces via `console.error` (preserving the error-handling-heuristics conformance contract).

**1b. Runtime, hydration leg.** A client-built `@catch` arm during hydration (server rendered the try arm) rendered with the adoption cursor active and misaligned: false structural-mismatch warnings, and mismatch recovery consumed server DOM belonging to *other* slots (in the test, an `<h1>` sibling outside the boundary was destroyed). Fixed: discard leftovers inside the slot's adopted range, park the cursor on the slot's close marker, `markFresh` the minted pair, render the catch body under `hydration.suspend`.

**2. Vite plugin — duplicate module instances on a hot dev server.** The generated dev hydrate entry imported entry/preHydrate/layout modules via an analysis-hidden bare dynamic import. After an HMR invalidation Vite stamps `?t=` onto the page's import chain, so the same module loaded at two URLs = two browser instances. Two `clientRouter` singletons: preHydrate committed matches on one, the page rendered the empty other → hydration mismatch at `Matches.tsrx:53:3` on every reload until restart (verified: `/src/app/router-client.ts` and `/src/app/router-client.ts?t=…` both fetched pre-fix). Dev now passes the same literal static import map production already had, so all entry imports go through import analysis and share URL identity.

## Test-first evidence (red → green)

- `packages/octane/tests/hydration/trycatch-client-error.test.ts` (new, 5 tests): the router pipeline shape red with `expected 'outer:The child can not be found…' to be 'outer:boom'`; the hydration case red with the out-of-boundary `#before` destroyed. Green after, in both the octane and octane-prod vitest projects.
- `packages/octane/tests/boundary-unwind.test.ts` (extended): a rethrowing catch under an in-progress `@if` mount forwards the ORIGINAL error — red with the replaced-error symptom, proving the unwind bug is reachable **outside hydration** on a plain client mount.
- `website/tests/ssr-hydration.e2e.test.ts` (new case): edits `Benchmarks.tsrx` and non-self-accepting `router.ts` on a live dev server, then asserts the next reload hydrates cleanly — red with the fix stashed (exact `Matches.tsrx:53:3` mismatch), green twice with it.
- Real-browser rounds: 5×(3 edits + hard reload) — mismatch every round pre-fix, clean every round post-fix. Blocking the route module now shows the error card with the *original* fetch error instead of a blank page.

## Validation

- `pnpm test`: 991 files / 8,454 tests passed.
- `pnpm typecheck`, `pnpm format:check`: clean.
- Standalone `website/tests/ssr-hydration.e2e.test.ts`: 26/26.

Changesets included for `octane` and `@octanejs/vite-plugin` (patch).

## Known follow-ups (not in this PR)

- The transient `Failed to fetch dynamically imported module …?import&t=` race itself (same URL serves 200 moments later) — not reproducible in 5 scripted rounds; `lazyRouteComponent` already auto-reloads once on module-not-found, and with this PR the failure degrades to a visible, recoverable error card instead of a dead page. Pointer: `packages/tanstack-router/src/lazyRouteComponent.ts` + Vite soft-invalidation timing.
- Latent same-class hazard: `dispatchTeardownErrors` → `findTryHandler` → `switchToCatch` (runtime.ts ~3526) can also invoke a boundary switch synchronously mid-render if an effect cleanup throws during an unmount inside a live render. Confirmed by inspection, not reproduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core `@try/@catch` and hydration DOM adoption in `runtime.ts` plus dev hydrate codegen—high blast radius, though scoped fixes with strong regression coverage.
> 
> **Overview**
> Fixes two regressions that could blank the site after HMR or when nested error boundaries rethrow during render.
> 
> **Octane runtime (`switchToCatch`):** When a `@catch` body rethrows while an outer boundary still has live mount frames (e.g. `@if` under a router-style boundary), the error is **rethrown** to unwind the stack instead of synchronously handing off to the outer handler—so the outer arm switch no longer sweeps DOM anchors still in use (`insertBefore` / replaced original error). During hydration, if the server rendered the try arm but the client throws, the catch arm now **clears leftover server DOM in the slot**, aligns the adoption cursor, marks fresh boundary markers, and **renders the catch subtree with adoption suspended** so siblings keep hydrating.
> 
> **`@octanejs/vite-plugin`:** Dev-generated hydrate entry now uses the same **literal dynamic-import map** as production (`collect_hydrate_module_paths` for routes, layouts, `preHydrate`, root boundaries), so post-HMR `?t=` URLs match the page’s import chain and singletons (e.g. client router) aren’t loaded twice.
> 
> Adds unit/hydration tests (`boundary-unwind`, `trycatch-client-error`) and a website e2e that reloads after touching route/router files on a hot dev server. Patch changesets for `octane` and `@octanejs/vite-plugin`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e74441cfc0bd38d00225091c84350aa5247366f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->