### PR TITLE
Harden release PR creation against transient GitHub API failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,34 @@ jobs:
 
       - name: Create or update release pull request
         id: changesets
+        continue-on-error: true
+        uses: changesets/action@v1
+        with:
+          github-token: ${{ github.token }}
+          version: pnpm changeset:version
+          commit: Version Packages
+          title: Version Packages
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      # A failed action leaves its generated changes and local release branch behind.
+      # Restore the triggering commit so the retry can recreate that branch cleanly.
+      - name: Restore checkout before retry
+        if: steps.changesets.outcome == 'failure'
+        run: |
+          git reset --hard "$GITHUB_SHA"
+          git clean -fd
+          git checkout --detach "$GITHUB_SHA"
+          if git show-ref --verify --quiet "refs/heads/changeset-release/${GITHUB_REF_NAME}"; then
+            git branch --delete --force "changeset-release/${GITHUB_REF_NAME}"
+          fi
+
+      - name: Wait before retrying the GitHub API
+        if: steps.changesets.outcome == 'failure'
+        run: sleep 15
+
+      - name: Retry creating or updating the release pull request
+        if: steps.changesets.outcome == 'failure'
         uses: changesets/action@v1
         with:
           github-token: ${{ github.token }}


### PR DESCRIPTION
## What changed

- allow the first `changesets/action` release-PR attempt to fail softly
- restore the triggering checkout and remove the action's temporary local release branch
- wait briefly, then retry the release-PR action once
- keep a repeated failure fatal

## Why

Release PR run 29539740636 completed dependency installation and version generation, then GitHub returned its server-error “Unicorn” HTML page to the action's first pull-request API request. The preceding release runs were healthy, indicating a transient GitHub API failure rather than a versioning regression.

The cleanup is required because `changesets/action@v1` leaves generated changes and a local `changeset-release/main` branch behind after a failed attempt. Resetting to the triggering SHA makes the retry deterministic while preserving the remote release branch for the action to update.

## Impact

Transient GitHub API failures during release-PR creation get one self-healing retry. Persistent failures still fail the workflow, and publishing remains unchanged.

## Validation

- `pnpm format:check`
- `git diff --check`
- YAML parse with Ruby Psych
- simulated the failed-action workspace state in a temporary clone and verified cleanup leaves a clean detached checkout with the local release branch removed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to release-PR creation with git cleanup and a single retry; no application or publish-path changes.
> 
> **Overview**
> The **Release PR** workflow now tolerates a single failed `changesets/action` run instead of failing the job immediately.
> 
> The first release-PR step uses **`continue-on-error: true`** and an **`id`** so later steps can branch on **`steps.changesets.outcome`**. On failure, the workflow **hard-resets** the workspace to **`GITHUB_SHA`**, **cleans** untracked files, checks out a **detached** head, and **deletes** the local **`changeset-release/${GITHUB_REF_NAME}`** branch if the action left one behind. After a **15s** pause, it runs **`changesets/action@v1`** again with the same version/commit/title settings. A second failure still fails the workflow; **publish** is untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e1aa6c0ce241cf17b8ffee180a99cdd7537e90d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->