### PR TITLE
Refresh the website for all 29 first-party bindings

### DIFF
--- a/scripts/generate-bindings-status.mjs
+++ b/scripts/generate-bindings-status.mjs
@@ -8,7 +8,8 @@ import { getBindingPackages } from './workspace-packages.mjs';
 // machine-readable packages/<name>/status.json next to each binding's
 // package.json; this script merges those with the package.json name/version
 // and renders one table so repo-level prose never has to guess at (or
-// over-group) the very different maturity levels of the bindings.
+// over-group) the very different maturity levels of the bindings. It also
+// verifies the website's curated directory includes every binding exactly once.
 //
 //   node scripts/generate-bindings-status.mjs           # (re)write the table
 //   node scripts/generate-bindings-status.mjs --check   # exit 1 if stale
@@ -34,6 +35,7 @@ import { getBindingPackages } from './workspace-packages.mjs';
 
 const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const OUT = path.join(REPO, 'docs/bindings-status.md');
+const WEBSITE_DIRECTORY = path.join(REPO, 'website/src/content/bindings.json');
 const CHECK = process.argv.includes('--check');
 
 const errors = [];
@@ -68,6 +70,76 @@ for (const workspacePackage of getBindingPackages()) {
 	}
 
 	rows.push({ dir, pkg, status });
+}
+
+let websiteCategories;
+try {
+	websiteCategories = JSON.parse(readFileSync(WEBSITE_DIRECTORY, 'utf8'));
+} catch (e) {
+	errors.push(`website/src/content/bindings.json is not valid JSON: ${e.message}`);
+}
+
+if (websiteCategories != null && !Array.isArray(websiteCategories)) {
+	errors.push('website/src/content/bindings.json must be an array of binding categories');
+} else if (websiteCategories) {
+	const websiteBindings = [];
+	const websiteCategoryTitles = new Set();
+	for (const [index, category] of websiteCategories.entries()) {
+		const label = `website/src/content/bindings.json category ${index + 1}`;
+		if (!category || typeof category !== 'object') {
+			errors.push(`${label} must be an object`);
+			continue;
+		}
+		if (typeof category.title !== 'string' || !category.title.trim()) {
+			errors.push(`${label} needs a non-empty "title"`);
+		} else if (websiteCategoryTitles.has(category.title)) {
+			errors.push(
+				`website/src/content/bindings.json uses category title "${category.title}" more than once`,
+			);
+		} else {
+			websiteCategoryTitles.add(category.title);
+		}
+		if (typeof category.description !== 'string' || !category.description.trim())
+			errors.push(`${label} needs a non-empty "description"`);
+		if (!Array.isArray(category.packages) || category.packages.length === 0) {
+			errors.push(`${label} needs a non-empty "packages" array`);
+			continue;
+		}
+		for (const packageName of category.packages) {
+			if (typeof packageName !== 'string') {
+				errors.push(`${label} package names must be strings`);
+				continue;
+			}
+			websiteBindings.push(packageName);
+		}
+	}
+
+	const seenWebsiteBindings = new Set();
+	for (const packageName of websiteBindings) {
+		if (seenWebsiteBindings.has(packageName))
+			errors.push(`website/src/content/bindings.json lists ${packageName} more than once`);
+		seenWebsiteBindings.add(packageName);
+	}
+
+	const bindingPackages = new Set(rows.map(({ pkg }) => pkg.name));
+	const bindingDirectories = new Map(rows.map(({ dir, pkg }) => [pkg.name, dir]));
+	for (const packageName of bindingPackages) {
+		if (!seenWebsiteBindings.has(packageName))
+			errors.push(`website/src/content/bindings.json is missing ${packageName}`);
+	}
+	for (const packageName of seenWebsiteBindings) {
+		if (!bindingPackages.has(packageName)) {
+			errors.push(`website/src/content/bindings.json lists unknown binding ${packageName}`);
+			continue;
+		}
+		const derivedDirectory = packageName.slice('@octanejs/'.length);
+		const workspaceDirectory = bindingDirectories.get(packageName);
+		if (derivedDirectory !== workspaceDirectory) {
+			errors.push(
+				`website binding links derive directory "${derivedDirectory}" from ${packageName}, but its workspace directory is "${workspaceDirectory}"`,
+			);
+		}
+	}
 }
 
 if (errors.length) {

--- a/website/src/components/BindingsDirectory.tsrx
+++ b/website/src/components/BindingsDirectory.tsrx
@@ -1,0 +1,125 @@
+// The bindings docs directory. Its editorial groups and package inventory live
+// in content/bindings.json so the docs, homepage counts, and status check share
+// one site-level source of truth.
+import { BINDING_CATEGORIES, bindingRepositoryHref } from '../content/bindings.ts';
+
+export function BindingsDirectory() @{
+	<>
+		<div class="binding-directory">
+			@for (const category of BINDING_CATEGORIES; key category.title) {
+				<section class="binding-card">
+					<header class="binding-card-head">
+						<h3>
+							{category.title as string}
+						</h3>
+						<span class="binding-count">
+							{category.packages.length +
+								(category.packages.length === 1 ? ' binding' : ' bindings')}
+						</span>
+					</header>
+					<p class="binding-description">
+						{category.description as string}
+					</p>
+					<ul class="binding-list">
+						@for (const packageName of category.packages; key packageName) {
+							<li>
+								<a class="binding-link" href={bindingRepositoryHref(packageName)}>
+									<code>
+										{packageName as string}
+									</code>
+								</a>
+							</li>
+						}
+					</ul>
+				</section>
+			}
+		</div>
+
+		<style>
+			.binding-directory {
+				display: grid;
+				grid-template-columns: repeat(2, minmax(0, 1fr));
+				gap: 0.85rem;
+				margin: 1.5rem 0;
+			}
+			.binding-card {
+				padding: 1.1rem;
+				border: 1px solid var(--border);
+				border-radius: 0.9rem;
+				background: rgba(255, 255, 255, 0.025);
+			}
+			.binding-card-head {
+				display: flex;
+				align-items: baseline;
+				justify-content: space-between;
+				gap: 0.75rem;
+				margin-bottom: 0.55rem;
+			}
+			.binding-card-head h3 {
+				margin: 0;
+				font-size: 1rem;
+			}
+			.binding-count {
+				flex: none;
+				padding: 0.15rem 0.45rem;
+				border: 1px solid rgba(255, 93, 114, 0.24);
+				border-radius: 999px;
+				background: rgba(255, 65, 90, 0.08);
+				color: #ff9baa;
+				font-size: 0.7rem;
+				font-weight: 750;
+				letter-spacing: 0.02em;
+				white-space: nowrap;
+			}
+			.binding-card .binding-description {
+				margin: 0 0 0.85rem;
+				color: var(--text-secondary);
+				font-size: 0.82rem;
+				line-height: 1.45;
+			}
+			.binding-list {
+				display: flex;
+				flex-wrap: wrap;
+				gap: 0.45rem;
+				list-style: none;
+				margin: 0;
+				padding: 0;
+			}
+			.binding-list li {
+				margin: 0;
+				padding: 0;
+			}
+			.binding-link {
+				display: inline-flex;
+				max-width: 100%;
+				border: 1px solid var(--border);
+				border-radius: 0.5rem;
+				background: var(--code-bg);
+				text-decoration: none;
+				transition:
+					border-color 0.15s,
+					background 0.15s;
+			}
+			.binding-link:hover {
+				border-color: rgba(255, 93, 114, 0.55);
+				background: rgba(255, 65, 90, 0.08);
+			}
+			.binding-card .binding-link code {
+				overflow: hidden;
+				max-width: 100%;
+				padding: 0.35rem 0.5rem;
+				border: 0;
+				background: transparent;
+				color: #ff8b9b;
+				font-size: 0.75rem;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+			}
+			@media (max-width: 640px) {
+				.binding-directory {
+					grid-template-columns: 1fr;
+				}
+			}
+		</style>
+	</>
+}

--- a/website/src/content/bindings.json
+++ b/website/src/content/bindings.json
@@ -1,0 +1,68 @@
+[
+  {
+    "title": "Shared state",
+    "description": "Small stores, atoms, Redux, RTK Query, and TanStack Store.",
+    "packages": [
+      "@octanejs/zustand",
+      "@octanejs/jotai",
+      "@octanejs/redux",
+      "@octanejs/redux-toolkit",
+      "@octanejs/tanstack-store"
+    ]
+  },
+  {
+    "title": "Data and routing",
+    "description": "GraphQL, server state, live IndexedDB data, type-safe routes, and React Router-style APIs.",
+    "packages": [
+      "@octanejs/apollo-client",
+      "@octanejs/dexie",
+      "@octanejs/tanstack-query",
+      "@octanejs/tanstack-router",
+      "@octanejs/remix-router"
+    ]
+  },
+  {
+    "title": "UI and interaction",
+    "description": "Primitives, positioning, motion, drag and drop, toasts, and icons.",
+    "packages": [
+      "@octanejs/radix",
+      "@octanejs/base-ui",
+      "@octanejs/floating-ui",
+      "@octanejs/motion",
+      "@octanejs/dnd-kit",
+      "@octanejs/sonner",
+      "@octanejs/lucide"
+    ]
+  },
+  {
+    "title": "Forms and content",
+    "description": "Forms, rich-text editing, MDX, and translations.",
+    "packages": [
+      "@octanejs/hook-form",
+      "@octanejs/tanstack-form",
+      "@octanejs/lexical",
+      "@octanejs/mdx",
+      "@octanejs/i18next"
+    ]
+  },
+  {
+    "title": "Data-heavy screens",
+    "description": "Tables, large virtual lists, charts, and visualization primitives.",
+    "packages": [
+      "@octanejs/tanstack-table",
+      "@octanejs/tanstack-virtual",
+      "@octanejs/recharts",
+      "@octanejs/visx"
+    ]
+  },
+  {
+    "title": "Web 3D",
+    "description": "Technical-preview, React Three Fiber-style scene graphs on Octane's universal renderer.",
+    "packages": ["@octanejs/three"]
+  },
+  {
+    "title": "Styling and tests",
+    "description": "Compiled StyleX and DOM-first component tests.",
+    "packages": ["@octanejs/stylex", "@octanejs/testing-library"]
+  }
+]

--- a/website/src/content/bindings.ts
+++ b/website/src/content/bindings.ts
@@ -1,0 +1,22 @@
+// The website's curated view of the binding inventory. The status generator
+// verifies every package with a status.json appears exactly once here, so this
+// editorial grouping and every count derived from it stay in sync with the repo.
+import bindingCategories from './bindings.json';
+
+export interface BindingCategory {
+	title: string;
+	description: string;
+	packages: string[];
+}
+
+export const BINDING_CATEGORIES = bindingCategories satisfies BindingCategory[];
+
+export const BINDING_COUNT = BINDING_CATEGORIES.reduce(
+	(total, category) => total + category.packages.length,
+	0,
+);
+
+export function bindingRepositoryHref(packageName: string): string {
+	const directory = packageName.slice('@octanejs/'.length);
+	return `https://github.com/octanejs/octane/tree/main/packages/${directory}`;
+}

--- a/website/src/content/docs.ts
+++ b/website/src/content/docs.ts
@@ -8,6 +8,7 @@ import TsrxVsTsx from './docs/tsrx-vs-tsx.mdx';
 import DifferencesFromReact from './docs/differences-from-react.mdx';
 import Bindings from './docs/bindings.mdx';
 import Profiling from './docs/profiling.mdx';
+import { BINDING_CATEGORIES, BINDING_COUNT } from './bindings.ts';
 
 export interface DocEntry {
 	slug: string;
@@ -15,6 +16,7 @@ export interface DocEntry {
 	description: string;
 	group: 'Start here' | 'Learn Octane' | 'Explore';
 	sections?: readonly DocSection[];
+	searchTerms?: readonly string[];
 	component: (props?: Record<string, unknown>) => unknown;
 }
 
@@ -122,8 +124,13 @@ export const docs: DocEntry[] = [
 	{
 		slug: 'bindings',
 		title: 'Bindings',
-		description: 'Find Octane bindings for state, data fetching, routing, UI, forms, and more.',
+		description: `Browse all ${BINDING_COUNT} Octane bindings for state, data, routing, UI, forms, and more.`,
 		group: 'Explore',
+		searchTerms: BINDING_CATEGORIES.flatMap((category) => [
+			category.title,
+			category.description,
+			...category.packages,
+		]),
 		sections: [
 			{ id: 'find-a-binding', title: 'Find a binding' },
 			{ id: 'install-and-use', title: 'Install and use' },

--- a/website/src/content/docs/bindings.mdx
+++ b/website/src/content/docs/bindings.mdx
@@ -2,12 +2,15 @@
 title: Bindings
 ---
 
+import { BindingsDirectory } from '../../components/BindingsDirectory.tsrx';
+import { BINDING_COUNT } from '../bindings.ts';
+
 <div className="doc-hero">
-	<p className="doc-eyebrow">Bring your favourite libraries</p>
+	<p className="doc-eyebrow">{BINDING_COUNT + ' first-party bindings'}</p>
 	<h1>Bindings</h1>
 	<p className="doc-lede">
 		{
-			'A binding connects a library’s hooks and components to Octane. You keep the library’s familiar ideas and APIs; the binding replaces its React-facing layer.'
+			'Keep the APIs you know across state, data, routing, UI, forms, charts, 3D, and more. Each binding replaces a library’s React-facing layer with one built for Octane.'
 		}
 	</p>
 </div>
@@ -25,180 +28,13 @@ title: Bindings
 
 Moving an existing app? Start with the libraries it already uses. Starting fresh? Pick
 the group that matches the problem, then learn the library itself from its upstream
-documentation.
+documentation. The directory covers every first-party binding in the repository.
 
-<div className="doc-card-grid">
-	<section className="doc-card">
-		<h3>Shared state</h3>
-		<ul>
-			<li>
-				<a href="https://github.com/octanejs/octane/tree/main/packages/zustand">
-					<code>@octanejs/zustand</code>
-				</a>
-				{' / '}
-				<a href="https://github.com/octanejs/octane/tree/main/packages/jotai">
-					<code>@octanejs/jotai</code>
-				</a>
-				{' / '}
-				<a href="https://github.com/octanejs/octane/tree/main/packages/redux">
-					<code>@octanejs/redux</code>
-				</a>
-				{' / '}
-				<a href="https://github.com/octanejs/octane/tree/main/packages/redux-toolkit">
-					<code>@octanejs/redux-toolkit</code>
-				</a>
-				{' / '}
-				<a href="https://github.com/octanejs/octane/tree/main/packages/tanstack-store">
-					<code>@octanejs/tanstack-store</code>
-				</a>
-				<span>Small stores, atoms, Redux, RTK Query, and TanStack Store.</span>
-			</li>
-		</ul>
-	</section>
-	<section className="doc-card">
-		<h3>Data and routing</h3>
-		<ul>
-			<li>
-				<a href="https://github.com/octanejs/octane/tree/main/packages/apollo-client">
-					<code>@octanejs/apollo-client</code>
-				</a>
-				{' / '}
-				<a href="https://github.com/octanejs/octane/tree/main/packages/tanstack-query">
-					<code>@octanejs/tanstack-query</code>
-				</a>
-				{' / '}
-				<a href="https://github.com/octanejs/octane/tree/main/packages/tanstack-router">
-					<code>@octanejs/tanstack-router</code>
-				</a>
-				{' / '}
-				<a href="https://github.com/octanejs/octane/tree/main/packages/remix-router">
-					<code>@octanejs/remix-router</code>
-				</a>
-				<span>GraphQL, server data, type-safe routes, and React Router-style APIs.</span>
-			</li>
-		</ul>
-	</section>
-	<section className="doc-card">
-		<h3>UI and interaction</h3>
-		<ul>
-			<li>
-				<a href="https://github.com/octanejs/octane/tree/main/packages/radix">
-					<code>@octanejs/radix</code>
-				</a>
-				{' / '}
-				<a href="https://github.com/octanejs/octane/tree/main/packages/base-ui">
-					<code>@octanejs/base-ui</code>
-				</a>
-				{' / '}
-				<a href="https://github.com/octanejs/octane/tree/main/packages/floating-ui">
-					<code>@octanejs/floating-ui</code>
-				</a>
-				{' / '}
-				<a href="https://github.com/octanejs/octane/tree/main/packages/motion">
-					<code>@octanejs/motion</code>
-				</a>
-				{' / '}
-				<a href="https://github.com/octanejs/octane/tree/main/packages/dnd-kit">
-					<code>@octanejs/dnd-kit</code>
-				</a>
-				{' / '}
-				<a href="https://github.com/octanejs/octane/tree/main/packages/sonner">
-					<code>@octanejs/sonner</code>
-				</a>
-				{' / '}
-				<a href="https://github.com/octanejs/octane/tree/main/packages/lucide">
-					<code>@octanejs/lucide</code>
-				</a>
-				<span>Primitives, positioning, motion, drag and drop, toasts, and icons.</span>
-			</li>
-		</ul>
-	</section>
-	<section className="doc-card">
-		<h3>Forms and content</h3>
-		<ul>
-			<li>
-				<a href="https://github.com/octanejs/octane/tree/main/packages/hook-form">
-					<code>@octanejs/hook-form</code>
-				</a>
-				{' / '}
-				<a href="https://github.com/octanejs/octane/tree/main/packages/tanstack-form">
-					<code>@octanejs/tanstack-form</code>
-				</a>
-				{' / '}
-				<a href="https://github.com/octanejs/octane/tree/main/packages/lexical">
-					<code>@octanejs/lexical</code>
-				</a>
-				{' / '}
-				<a href="https://github.com/octanejs/octane/tree/main/packages/mdx">
-					<code>@octanejs/mdx</code>
-				</a>
-				{' / '}
-				<a href="https://github.com/octanejs/octane/tree/main/packages/i18next">
-					<code>@octanejs/i18next</code>
-				</a>
-				<span>Forms, rich-text editing, MDX, and translations.</span>
-			</li>
-		</ul>
-	</section>
-	<section className="doc-card">
-		<h3>Data-heavy screens</h3>
-		<ul>
-			<li>
-				<a href="https://github.com/octanejs/octane/tree/main/packages/tanstack-table">
-					<code>@octanejs/tanstack-table</code>
-				</a>
-				{' / '}
-				<a href="https://github.com/octanejs/octane/tree/main/packages/tanstack-virtual">
-					<code>@octanejs/tanstack-virtual</code>
-				</a>
-				{' / '}
-				<a href="https://github.com/octanejs/octane/tree/main/packages/recharts">
-					<code>@octanejs/recharts</code>
-				</a>
-				{' / '}
-				<a href="https://github.com/octanejs/octane/tree/main/packages/visx">
-					<code>@octanejs/visx</code>
-				</a>
-				<span>
-					Tables, large virtual lists, charts, and visualization primitives. Recharts is currently
-					partial; Visx exposes the complete current 4.x web surface.
-				</span>
-			</li>
-		</ul>
-	</section>
-	<section className="doc-card">
-		<h3>Web 3D</h3>
-		<ul>
-			<li>
-				<a href="https://github.com/octanejs/octane/tree/main/packages/three">
-					<code>@octanejs/three</code>
-				</a>
-				<span>
-					React Three Fiber-compatible scene graphs on Octane's universal renderer. The package is
-					currently experimental and delivered in milestones.
-				</span>
-			</li>
-		</ul>
-	</section>
-	<section className="doc-card">
-		<h3>Styling and tests</h3>
-		<ul>
-			<li>
-				<a href="https://github.com/octanejs/octane/tree/main/packages/stylex">
-					<code>@octanejs/stylex</code>
-				</a>
-				{' / '}
-				<a href="https://github.com/octanejs/octane/tree/main/packages/testing-library">
-					<code>@octanejs/testing-library</code>
-				</a>
-				<span>Compiled StyleX and DOM-first component tests.</span>
-			</li>
-		</ul>
-	</section>
-</div>
+<BindingsDirectory />
 
-Base UI is currently alpha. Follow each package link for its README and exact supported
-surface.
+Maturity ranges from complete ports to scoped, partial, and technical-preview bindings.
+Follow each package link for its README, then use the status table below for the exact
+supported surface and SSR coverage.
 
 <h2 id="install-and-use">Install it, then change the import</h2>
 
@@ -233,7 +69,8 @@ things:
 
 The generated
 [bindings status table](https://github.com/octanejs/octane/blob/main/docs/bindings-status.md)
-answers those questions for all 26 first-party bindings and is checked in CI.
+answers those questions for all {BINDING_COUNT + ' first-party bindings'} and is checked
+in CI.
 
 <aside className="doc-callout tip">
 	<p className="doc-callout-title">App tooling is a separate layer</p>

--- a/website/src/lib/docs-search.ts
+++ b/website/src/lib/docs-search.ts
@@ -163,7 +163,18 @@ export function loadSearchIndex(): Promise<SearchRecord[]> {
 					const order = docs.findIndex((d) => d.slug === slug);
 					const doc = order === -1 ? undefined : docs[order];
 					const rank = order === -1 ? docs.length : order;
-					return recordsFor(slug, doc?.title ?? slug, rank, await load());
+					const records = recordsFor(slug, doc?.title ?? slug, rank, await load());
+					if (doc?.searchTerms?.length) {
+						const target =
+							records.find((record) => record.id === doc.sections?.[0]?.id) ?? records[0];
+						if (target) {
+							const block = { text: doc.searchTerms.join(' · '), code: false };
+							target.blocks.push(block);
+							target.text += ' ' + block.text;
+							target.haystack += ' ' + block.text.toLowerCase();
+						}
+					}
+					return records;
 				}),
 			).then((groups) => groups.flat()),
 		);

--- a/website/src/pages/home/sections/Features.tsrx
+++ b/website/src/pages/home/sections/Features.tsrx
@@ -1,4 +1,6 @@
 // The four feature cards — a title over a plain-text blurb.
+import { BINDING_COUNT } from '../../../content/bindings.ts';
+
 const FEATURES = [
 	{
 		title: 'No rules of hooks',
@@ -19,8 +21,9 @@ const FEATURES = [
 	{
 		title: 'Familiar model',
 		body: 'Hooks, memo, context, portals, transitions, actions, controlled forms and Suspense all ' +
-			'behave the way you expect. Events are native, refs are just props, and 25 first-party ' +
-			'bindings cover the libraries you already use.',
+			'behave the way you expect. Events are native, refs are just props, and ' +
+			BINDING_COUNT +
+			' first-party bindings cover the libraries you already use.',
 	},
 ];
 

--- a/website/src/pages/home/sections/Proven.tsrx
+++ b/website/src/pages/home/sections/Proven.tsrx
@@ -1,5 +1,6 @@
 // The "proven" stat strip: three numbers that back the claims above.
 import { Link } from '@octanejs/tanstack-router';
+import { BINDING_COUNT } from '../../../content/bindings.ts';
 
 export function Proven() @{
 	<section class="proven">
@@ -22,10 +23,12 @@ export function Proven() @{
 			</span>
 		</div>
 		<div class="proven-stat">
-			<span class="proven-number">25</span>
+			<span class="proven-number">
+				{BINDING_COUNT + ''}
+			</span>
 			<span class="proven-label">
-				{'ecosystem ports — Zustand, TanStack Query & Router, Radix, Lucide, '}
-				<Link to="/docs/bindings">Recharts and more</Link>
+				{'first-party ecosystem bindings for state, data, routing, UI, forms, charts, 3D, '}
+				<Link to="/docs/bindings">and more</Link>
 			</span>
 		</div>
 

--- a/website/tests/docs-search.test.ts
+++ b/website/tests/docs-search.test.ts
@@ -85,6 +85,16 @@ describe('docs search ranking', () => {
 		expect(top.id).toBe('install');
 	});
 
+	it('finds packages supplied by the curated bindings directory', async () => {
+		const index = await loadSearchIndex();
+		const [top] = searchDocs(index, '@octanejs/dexie');
+		const snippets = top.lines.map((line) => line.parts.map((part) => part.text).join(''));
+
+		expect(top.slug).toBe('bindings');
+		expect(top.id).toBe('find-a-binding');
+		expect(snippets.join(' ')).toContain('@octanejs/dexie');
+	});
+
 	it('requires every term to match, and ignores queries shorter than two characters', async () => {
 		const index = await loadSearchIndex();
 

--- a/website/tests/smoke.test.ts
+++ b/website/tests/smoke.test.ts
@@ -6,6 +6,7 @@ import { render, waitFor, cleanup } from '@octanejs/testing-library';
 import { RouterProvider, createMemoryHistory } from '@octanejs/tanstack-router';
 import { makeRouter } from '../src/app/router.ts';
 import { docs, defaultDoc, docGroups } from '../src/content/docs.ts';
+import { BINDING_CATEGORIES, BINDING_COUNT } from '../src/content/bindings.ts';
 import {
 	FRAMEWORK_CARDS,
 	HOME_SUMMARY,
@@ -114,6 +115,12 @@ describe('website routes', () => {
 			expect(stat.querySelector('.proven-number')?.textContent?.trim()).toBeTruthy();
 			expect(stat.querySelector('.proven-label')?.textContent?.trim()).toBeTruthy();
 		}
+		const ecosystemStat = provenStats.at(-1)!;
+		expect(ecosystemStat.querySelector('.proven-number')?.textContent).toBe(String(BINDING_COUNT));
+		expect(ecosystemStat.querySelector('.proven-label')?.textContent).toContain(
+			'first-party ecosystem bindings',
+		);
+		expect(findLink(ecosystemStat, '/docs/bindings')).toBeTruthy();
 
 		// The decision section frames the evidence below with two questions and a coda
 		// that links out to what TSRX adds.
@@ -256,46 +263,20 @@ describe('website routes', () => {
 
 	it('/docs/bindings links every first-party binding', async () => {
 		const { container } = await renderRoute('/docs/bindings');
-		const packages = [
-			'zustand',
-			'jotai',
-			'redux',
-			'redux-toolkit',
-			'tanstack-store',
-			'apollo-client',
-			'tanstack-query',
-			'tanstack-router',
-			'remix-router',
-			'radix',
-			'base-ui',
-			'floating-ui',
-			'motion',
-			'dnd-kit',
-			'sonner',
-			'lucide',
-			'hook-form',
-			'tanstack-form',
-			'lexical',
-			'mdx',
-			'i18next',
-			'tanstack-table',
-			'tanstack-virtual',
-			'recharts',
-			'visx',
-			'three',
-			'stylex',
-			'testing-library',
-		];
+		const packages = BINDING_CATEGORIES.flatMap((category) => category.packages);
 
 		const packageLinks = Array.from(
-			container.querySelectorAll<HTMLAnchorElement>('.doc-card a[href*="/packages/"]'),
+			container.querySelectorAll<HTMLAnchorElement>('.binding-directory a[href*="/packages/"]'),
 		);
-		expect(packageLinks).toHaveLength(packages.length);
+		expect(packageLinks).toHaveLength(BINDING_COUNT);
+		expect(container.querySelector('.doc-eyebrow')?.textContent).toBe(
+			`${BINDING_COUNT} first-party bindings`,
+		);
 		for (const packageName of packages) {
-			const link = packageLinks.find((candidate) =>
-				candidate.getAttribute('href')?.endsWith(`/packages/${packageName}`),
-			);
-			expect(link?.textContent).toBe(`@octanejs/${packageName}`);
+			const directory = packageName.slice('@octanejs/'.length);
+			const href = `https://github.com/octanejs/octane/tree/main/packages/${directory}`;
+			const link = packageLinks.find((candidate) => candidate.getAttribute('href') === href);
+			expect(link?.textContent).toBe(packageName);
 		}
 	});
 


### PR DESCRIPTION
## What changed

- add one curated inventory for all 29 first-party bindings, including `@octanejs/dexie`
- rebuild `/docs/bindings` as a responsive, counted directory grouped by job
- update the homepage feature copy and ecosystem stat from 25 to 29
- make every binding name discoverable through docs search
- extend `bindings:status:check` to reject missing, duplicate, unknown, or incorrectly linked website entries
- cover the visible count, exact package links, and binding search behavior

## Why

The website had drifted behind the repository: the homepage claimed 25 bindings, the docs copy claimed 26, and the bindings directory omitted Dexie even though the generated status inventory contains 29 packages.

This change removes the duplicated hand-maintained counts and makes the existing status check enforce that the curated website inventory remains complete and link-safe.

## Impact

Visitors can scan the full ecosystem by use case, follow every package directly, and find package names such as `@octanejs/dexie` through docs search. Future binding additions now fail CI until the website directory is updated.

## Validation

- `pnpm bindings:status:check`
- `pnpm exec tsgo --noEmit -p website/tsconfig.json`
- `pnpm exec vitest run website/tests/docs-search.test.ts website/tests/smoke.test.ts --reporter=verbose` (23 passed)
- website SSR smoke tests (7 passed)
- `pnpm --dir website build`
- production preview DOM and visual inspection of `/` and `/docs/bindings`
- `pnpm format:check`
- `git diff --check`
