### PR TITLE
mcp: sync server knowledge with current main

### DIFF
--- a/.changeset/mcp-server-current-main.md
+++ b/.changeset/mcp-server-current-main.md
@@ -1,0 +1,5 @@
+---
+'@octanejs/mcp-server': patch
+---
+
+Refresh the MCP server's repository knowledge to current main: `octane_benchmark` drives the unified runner (`node benchmarks/bench.mjs`) with the full 18-suite manifest and a `quick` smoke-pass option; path triage and validation planning cover the Vercel deploy adapter, the evals package, the metaframework plugins, and the website with their vitest projects; the React-API compatibility map corrects stale entries (`lazy` and `useDebugValue` exist, `renderToStaticMarkup` and the streaming `renderToPipeableStream`/`renderToReadableStream` ship under `octane/server`); and the bundled skills reflect controlled inputs matching React, compiler-inferred dependency arrays, the hooks-in-loops compile error, streaming SSR, the production SSR build (`octane-preview`, `@octanejs/adapter-vercel`), and the full bindings table.

--- a/packages/octane-mcp-server/README.md
+++ b/packages/octane-mcp-server/README.md
@@ -60,11 +60,11 @@ maintainer tools):
 
 Scans a React package (by name from `node_modules`, or any source directory by
 path) for React API usage and returns an Octane compatibility report: which
-APIs map one-to-one, which need rewrites (`forwardRef`, `useDebugValue`,
-`lazy`, class components, synthetic `onChange`), whether a framework-agnostic
-core can be reused verbatim, whether an official `@octanejs/*` binding already
-exists, an overall verdict (`bridgeable`, `bridgeable-with-rewrites`,
-`needs-rework`), and a step-by-step plan.
+APIs map one-to-one, which need rewrites (`forwardRef`, class components,
+synthetic `onChange`, `react-dom/server` imports), whether a
+framework-agnostic core can be reused verbatim, whether an official
+`@octanejs/*` binding already exists, an overall verdict (`bridgeable`,
+`bridgeable-with-rewrites`, `needs-rework`), and a step-by-step plan.
 
 ```json
 { "package": "jotai", "projectRoot": "/path/to/my-app" }
@@ -101,7 +101,8 @@ invariants, and validation commands.
 ### `octane_triage_paths`
 
 Classifies repository-relative paths by Octane area (compiler, core runtime,
-SSR, ecosystem binding, mcp-server, benchmark, docs, RuleSync source).
+SSR, ecosystem binding, vite-plugin, deploy adapter, evals, website,
+mcp-server, benchmark, docs, RuleSync source).
 
 ### `octane_validate_plan`
 
@@ -114,8 +115,11 @@ optionally writes the generated Vitest skeleton to an output file.
 
 ### `octane_benchmark`
 
-Runs a known benchmark workspace (`news`, `js-framework`, `recursive-context`,
-`signal-favoring`, `dbmon`) or all benchmarks.
+Runs benchmark suites through the unified runner (`node benchmarks/bench.mjs`):
+one manifest suite by name (`js-framework`, `todomvc`, `chat-stream`, `dbmon`,
+`news`, `ssr-throughput`, `streaming-ssr`, `codegen-size`, `bundle-size`, …) or
+every suite with `all`; `quick` selects the reduced-iteration smoke pass. The
+suite list mirrors the runner manifest and `node benchmarks/bench.mjs --list`.
 
 ### `octane_issue_context`
 

--- a/packages/octane-mcp-server/skills/bridge-react-package.md
+++ b/packages/octane-mcp-server/skills/bridge-react-package.md
@@ -24,8 +24,20 @@ of bridging by hand:
 | `@floating-ui/react` | `@octanejs/floating-ui` |
 | `radix-ui` | `@octanejs/radix` |
 | `react-i18next` | `@octanejs/i18next` |
+| `react-hook-form` | `@octanejs/hook-form` |
+| `@base-ui-components/react` | `@octanejs/base-ui` |
+| `@dnd-kit/react` | `@octanejs/dnd-kit` |
+| `sonner` | `@octanejs/sonner` |
+| `recharts` | `@octanejs/recharts` |
+| `@react-three/fiber` | `@octanejs/three` |
+| `@visx/*` | `@octanejs/visx` |
+| `react-redux` | `@octanejs/redux` |
+| `@reduxjs/toolkit` | `@octanejs/redux-toolkit` |
+| `@testing-library/react` | `@octanejs/testing-library` |
+| `@mdx-js/react` | `@octanejs/mdx` |
 
-For anything else, run the `octane_bridge_react_package` tool to get a scan of the
+The `octane_bindings` tool returns the same map machine-readably. For anything
+else, run the `octane_bridge_react_package` tool to get a scan of the
 package's React API usage and a tailored plan, then follow the workflow below.
 
 ## Mental model
@@ -60,23 +72,22 @@ So a bridge never means "run the React package unchanged". It means:
    `useCallback`, `useRef`, `useContext`, `useId`, `useImperativeHandle`,
    `useSyncExternalStore` (full React 19 shape, including `getServerSnapshot`),
    `useTransition`, `useDeferredValue`, `useActionState`, `useOptimistic`,
-   `useEffectEvent`, `use`, `startTransition`, `memo`, `createContext`,
-   `Suspense`, `createPortal`, `flushSync`, `createRoot`, `hydrateRoot`.
-   Everything imports from `octane` (no separate `react-dom`).
+   `useEffectEvent`, `useDebugValue` (accepted no-op), `use`, `startTransition`,
+   `memo`, `lazy` (also accepts a bare component from the loader),
+   `createContext`, `Suspense`, `createPortal`, `flushSync`, `createRoot`,
+   `hydrateRoot`. Everything imports from `octane` (no separate `react-dom`);
+   server rendering imports from `octane/server`, including the streaming
+   `renderToPipeableStream`/`renderToReadableStream`.
 
 3. **Handle the gaps:**
    - `forwardRef`: does not exist. Accept `ref` as a normal prop (React 19
      style) and drop the wrapper.
-   - `useDebugValue`: shim as a no-op.
-   - `lazy`: use dynamic `import()` plus `use()` inside a `Suspense` boundary.
    - Class components: rewrite as function components. Error boundary classes
      become `<ErrorBoundary>` or the `@try { } @catch (e) { }` directive.
    - Synthetic `onChange` on text inputs: use native `onInput`. Octane events
-     are native and delegated.
-   - Controlled inputs: Octane inputs are uncontrolled and native; `value` and
-     `checked` are plain attributes. Port controlled-input logic to
-     read-from-DOM plus explicit writes, or keep state in the store and write
-     the attribute on change.
+     are native and delegated. Controlled `value`/`checked` follow React's
+     semantics (the prop drives the DOM property and reasserts on commits), so
+     controlled-input logic ports unchanged apart from the event name.
    - StrictMode double-invoke: does not exist; delete test expectations that
      count double renders.
 
@@ -118,7 +129,7 @@ So a bridge never means "run the React package unchanged". It means:
 
 - `bridgeable`: only same-name hooks used; a mechanical rename of imports to
   `octane` plus a `.tsrx` re-author of components is enough.
-- `bridgeable-with-rewrites`: needs the `forwardRef` / `useDebugValue` / `lazy` /
-  event rewrites above, but no architectural blockers.
-- `needs-rework`: class components, `renderToPipeableStream`, `findDOMNode`, or
-  React internals. Bridge the core, redesign the binding.
+- `bridgeable-with-rewrites`: needs the `forwardRef` / event / `react-dom/server`
+  import rewrites above, but no architectural blockers.
+- `needs-rework`: class components, `findDOMNode`, or React internals. Bridge
+  the core, redesign the binding.

--- a/packages/octane-mcp-server/skills/migrate-react-component.md
+++ b/packages/octane-mcp-server/skills/migrate-react-component.md
@@ -43,10 +43,10 @@ locals, early returns) stays above it.
 | Error boundary class | `<ErrorBoundary>` or `@try { } @catch (e) { }` |
 | `forwardRef((props, ref) => ...)` | plain function; `ref` arrives as a prop |
 | `<input onChange={...}>` | `<input onInput={...}>` (native event) |
-| controlled `value={state}` | uncontrolled; `value` is a plain attribute, read the DOM in handlers |
+| controlled `value={state}` | keep it — React's controlled semantics apply; pair with `onInput` |
 | `className={clsx(...)}` | `class={[...]}` composes clsx-style natively |
-| `useDebugValue(x)` | delete it |
-| `React.lazy(() => import(...))` | dynamic `import()` + `use()` under Suspense |
+| `useDebugValue(x)` | keep or delete — present as an accepted no-op |
+| `React.lazy(() => import(...))` | `lazy()` works as-is (and also accepts a bare component from the loader) |
 | `defaultProps` | parameter defaults / destructuring defaults |
 
 ## Text holes
@@ -64,8 +64,12 @@ treated as a renderable (component, element, coerced primitive).
 ## Hooks
 
 The hook API matches React, and there are no rules of hooks: a hook may sit
-behind a condition, after an early return, or in a loop, because identity comes
-from the call site, not call order.
+behind a condition or after an early return, because identity comes from the
+call site, not call order. The one exception is a plain JS loop — a slot-keyed
+hook there is a compile error (every iteration would share one call-site slot);
+use the keyed `@for` directive or extract a child component. Dependency arrays
+may be omitted: the compiler infers them from lexical captures (explicit arrays
+keep React's exact behavior; `null` means every render).
 
 ```tsx
 export function Panel(props) @{

--- a/packages/octane-mcp-server/skills/react-divergences.md
+++ b/packages/octane-mcp-server/skills/react-divergences.md
@@ -3,23 +3,55 @@
 Use this when behavior differs from React and you need to decide whether it is a
 bug or by design. Do not "fix" these toward React.
 
-## No rules of hooks
+## No rules of hooks — except plain JS loops
 
 Hooks are tracked by compiler-assigned call-site slot, not call order. A hook may
-sit behind a condition, after an early return, or in a loop. Code that relies on
-hook-order errors firing does not apply.
+sit behind a condition or after an early return; code that relies on hook-order
+errors firing does not apply. The one restriction: a slot-keyed hook inside a
+plain JS loop is a **compile error** (every iteration would share the one
+call-site slot). Loop with the keyed `@for` template directive or extract a
+child component instead. `use()` and `useContext` are exempt (call-order /
+context-identity keyed, not slot-keyed).
 
-## No controlled components, no synthetic onChange
+## Dependency arrays are compiler-inferred when omitted
 
-`value` and `checked` are plain attributes; inputs are uncontrolled and native.
-There is no per-keystroke synthetic `onChange`; use native `onInput`. React's
-controlled-input value-reassertion model does not exist and must not be added.
+Omitting the array on `useEffect`, `useLayoutEffect`, `useInsertionEffect`,
+`useMemo`, `useCallback`, or `useImperativeHandle` does not mean "every render"
+— the compiler derives dependencies from lexical captures, omitting stable hook
+results (state setters/dispatchers, refs, state getters, `useEffectEvent`
+results). Explicit arrays keep React's exact behavior and are never rewritten;
+`null` explicitly means run or recompute after every render.
+
+## State hooks expose a current-state getter
+
+`useState` and `useReducer` have a stable third tuple member
+(`[state, update, getState]`) that reads the latest scheduled hook-cell value.
+Ordinary two-item destructures keep the allocation-free React shape.
+
+## Controlled inputs match React — on native events
+
+Controlled `value`/`checked` follow React's semantics exactly: the prop drives
+the DOM property and reasserts on every commit and after discrete events;
+`defaultValue`/`defaultChecked` are the uncontrolled escape hatch. But there is
+no synthetic event layer: `onInput` is the per-keystroke handler for text
+controls, and native `change` fires on blur/commit. Do not add a synthetic
+`onChange` normalization.
 
 ## Native delegated events
 
 `onClick`, `onInput`, `onSubmit` etc. are real DOM events via delegation, not a
 synthetic layer. Timing, bubbling, and `event.target` semantics match the
 platform, not React's wrapper.
+
+## Parallel `use()` — no suspense waterfalls
+
+The compiler (on by default; `parallelUse: false` opts out) memoizes `use()`
+argument creations per call site, starts provably-independent fetches together,
+suspends once per stratum, and prefetches independent descendant fetch trees.
+React runs the same code as a serial waterfall — do not "fix" fetch-start
+timing, batch replay counts, or prefetch behavior toward React. True data
+dependencies stay sequential; unwrap order, hydration-seed order, and rejection
+routing match React.
 
 ## Keyed reconciler moves differ
 
@@ -28,6 +60,20 @@ The final DOM and survivor node identity are guaranteed identical to React; the
 set of physically moved nodes is not. Tests asserting which nodes moved will
 diverge; tests asserting final order and identity will pass.
 
+## Synchronous first root mount and root API extensions
+
+The first `root.render()` mounts synchronously, so render-then-unmount in one
+outer batch can expose intermediate DOM that React's concurrent root elides.
+`root.render(App, props)` is supported alongside `root.render(<App />)`. A root
+whose managed DOM was externally removed unmounts safely instead of throwing
+the browser's incidental `NotFoundError`.
+
+## `lazy()` accepts bare components
+
+React's `{ default }` module shape works, and Octane additionally accepts a
+component directly from the loader. Suspense and ViewTransition are ordinary
+components, so wrapping them in `lazy()` is valid; nested lazy wrappers are not.
+
 ## class / className composes clsx-style
 
 Strings, numbers, arrays, objects, and nesting compose into a class string;
@@ -35,11 +81,10 @@ falsy parts drop out. React coerces an array to `"a,b"`; Octane yields `"a b"`.
 
 ## Not present at all
 
-- Class components.
+- Class components (rewrite as function components).
 - Server Components / `'use client'` / `'use server'`.
 - StrictMode double-invoke (renders and effects run once).
 - `forwardRef` (refs are props, React 19 style).
-- `useDebugValue` (shim as no-op).
 - SuspenseList, Profiler, findDOMNode.
 
 ## Everything else matches
@@ -47,4 +92,4 @@ falsy parts drop out. React coerces an array to `"a,b"`; Octane yields `"a b"`.
 Observable hook, effect, Suspense, and transition semantics match React,
 including effect ordering (child-first on mount, parent-first cleanup on
 deletion), `Object.is` state bailouts, batching, and `useId` stability across
-server render and hydration.
+server render and hydration. `useDebugValue` exists as an accepted no-op.

--- a/packages/octane-mcp-server/skills/setup-ssr.md
+++ b/packages/octane-mcp-server/skills/setup-ssr.md
@@ -4,9 +4,11 @@ Use this when adding server-side rendering to an Octane app.
 
 ## The API
 
-The entry points mirror React: `octane/server` (`react-dom/server`) has
-`renderToString` (sync) and `renderToStaticMarkup`; `octane/static`
-(`react-dom/static`) has `prerender` (async, awaits Suspense data). All return
+The entry points mirror React. `octane/server` (`react-dom/server`) has
+`renderToString` (sync), `renderToStaticMarkup` (non-hydratable), and the two
+streaming renderers `renderToPipeableStream` (Node streams) and
+`renderToReadableStream` (web streams); `octane/static` (`react-dom/static`)
+has `prerender` (async, awaits Suspense data). The buffered renderers return
 `{ html, css }`.
 
 ```ts
@@ -28,8 +30,21 @@ const { html, css } = await prerender(App, props, {
   leaves `@pending` fallbacks in place; use `prerender` to await the data.
 - Options are optional: `nonce` stamps CSP nonces on the emitted inline tags (all
   renderers); `signal` aborts a suspended render with the request and `timeoutMs`
-  bounds how long a `use(thenable)` may take to settle (async `prerender`; global
+  bounds how long a `use(thenable)` may take to settle (async renders; global
   default via `setSsrSuspenseTimeout`); `onError` observes render errors.
+
+### Streaming
+
+`renderToPipeableStream(App, props?, options?)` returns `{ pipe, abort }`; the
+shell — the full page with `@pending` fallbacks for anything still suspended —
+flushes immediately, then each Suspense boundary streams out of order as a
+hidden segment plus an inline swap script when its data settles.
+`renderToReadableStream` is the same engine over web streams: it resolves with
+a `ReadableStream<Uint8Array>` once the shell is ready and rejects on a shell
+error; consume the stream concurrently rather than awaiting its `allReady`
+promise first. `StreamOptions` extends `RenderOptions` with `onShellReady()`,
+`onShellError(err)`, and `onAllReady()`. `hydrateRoot` adopts streamed-in DOM
+byte-for-byte, including per-boundary `use()` value or rejection seeds.
 
 On the client:
 
@@ -43,24 +58,31 @@ hydration-stable; the client adopts server DOM instead of rebuilding it.
 
 ## Two integration paths
 
-1. **Vite plugin (dev SSR + routing)**: `@octanejs/vite-plugin` matches routes
-   from `octane.config.ts`, renders pages into `index.html` at
-   `<!--ssr-head-->` / `<!--ssr-body-->`, and wires hydration automatically.
-   Production server output is not generated yet; for production SSR today use
-   path 2.
+1. **Vite plugin (routing + dev and production SSR)**: `@octanejs/vite-plugin`
+   matches routes from `octane.config.ts`, streams pages with
+   `renderToReadableStream()` into `index.html` around `<!--ssr-head-->` /
+   `<!--ssr-body-->`, and wires hydration automatically. In production,
+   `vite build` emits hashed client assets in `dist/client` plus a
+   self-contained SSR server at `dist/server/entry.js` (exports
+   `handler`/`nodeHandler`; preview with `octane-preview`);
+   `server.render: 'buffered'` switches it to the await-everything `prerender`.
+   A deploy adapter can restructure the output for a host — for example
+   `adapter: vercel()` from `@octanejs/adapter-vercel` emits Vercel's Build
+   Output API.
 2. **Custom server**: write `entry-server.ts` exporting a function that calls
-   `prerender()` (or `renderToString()`) and splices the result into your HTML template, and
-   `entry-client.ts` calling `hydrateRoot`. Serialize app data (for example a
-   dehydrated query-client cache) into your own inline JSON script and read it
-   before hydrating.
+   `prerender()` (or `renderToString()`, or a streaming renderer) and splices
+   the result into your HTML template, and `entry-client.ts` calling
+   `hydrateRoot`. Serialize app data (for example a dehydrated query-client
+   cache) into your own inline JSON script and read it before hydrating.
 
 ## Data and Suspense on the server
 
 `use(promise)` suspends a pass; `prerender()` awaits it and re-renders, so
 `@try { } @pending { }` boundaries resolve to their success arm in the emitted
-HTML. Resolved values serialize into the seed script and hydration consumes
-them without re-fetching. For query-style data, prefetch into a cache before
-rendering and dehydrate it yourself.
+HTML, while the streaming renderers flush the fallback in the shell and stream
+the resolved boundary behind it. Resolved values serialize into the seed script
+and hydration consumes them without re-fetching. For query-style data, prefetch
+into a cache before rendering and dehydrate it yourself.
 
 ## Constraints to remember
 
@@ -68,6 +90,11 @@ rendering and dehydrate it yourself.
   `useSyncExternalStore` uses `getServerSnapshot`.
 - Server components must be compiled by the Octane compiler in server mode;
   you cannot feed client-compiled output to the renderers.
-- Output is buffered, not streamed: send it as one response.
+- Hydration adopts the whole tree in one synchronous pass (no selective or
+  progressive hydration), and head elements hoisted from inside a streamed
+  Suspense boundary are re-created on hydration rather than shipped in the
+  stream.
 - Render errors reject the promise unless an `ErrorBoundary`/`@catch` inside
   the tree handles them; map rejections to HTTP status codes in your server.
+  With streaming, a recoverable error inside Suspense content keeps the emitted
+  fallback and marks only that boundary for client rendering.

--- a/packages/octane-mcp-server/src/bridge.js
+++ b/packages/octane-mcp-server/src/bridge.js
@@ -167,8 +167,14 @@ export const REACT_API_MAP = {
 		status: 'rewrite',
 		note: 'No forwardRef. Rewrite to React 19 refs-as-props: accept ref as a normal prop.',
 	},
-	useDebugValue: { status: 'rewrite', note: 'Not present. Shim as a no-op.' },
-	lazy: { status: 'rewrite', note: 'Not present. Use dynamic import plus use()/Suspense.' },
+	useDebugValue: {
+		status: 'same',
+		note: 'Supported as an accepted no-op (devtools-only label; there is no DevTools integration).',
+	},
+	lazy: {
+		status: 'same',
+		note: "Supported. Accepts React's { default } module shape and additionally a bare component from the loader; wrapping Suspense or ViewTransition in lazy() is valid (nested lazy wrappers are not).",
+	},
 	Component: {
 		status: 'unsupported',
 		note: 'No class components. Rewrite as a function component.',
@@ -188,13 +194,17 @@ export const REACT_API_MAP = {
 		status: 'rewrite',
 		note: 'Use renderToString() from octane/server (sync) or prerender() from octane/static (async, awaits Suspense); both return { html, css }.',
 	},
+	renderToStaticMarkup: {
+		status: 'rewrite',
+		note: 'Use renderToStaticMarkup() from octane/server (clean, non-hydratable HTML; returns { html, css }).',
+	},
 	renderToPipeableStream: {
-		status: 'unsupported',
-		note: 'No streaming SSR yet. Use render() from octane/server.',
+		status: 'rewrite',
+		note: 'Supported natively: import renderToPipeableStream from octane/server (Octane argument convention: component, props?, options?; returns { pipe, abort } with onShellReady/onShellError/onAllReady StreamOptions).',
 	},
 	renderToReadableStream: {
-		status: 'unsupported',
-		note: 'No streaming SSR yet. Use render() from octane/server.',
+		status: 'rewrite',
+		note: 'Supported natively: import renderToReadableStream from octane/server (Octane argument convention; resolves with a ReadableStream once the shell is ready, same StreamOptions).',
 	},
 	onChange: {
 		status: 'rewrite',

--- a/packages/octane-mcp-server/src/bridge.test.js
+++ b/packages/octane-mcp-server/src/bridge.test.js
@@ -104,6 +104,34 @@ describe('bridgeReport', () => {
 		expect(report.plan.join('\n')).toContain('forwardRef');
 	});
 
+	it('lazy plus Suspense stays bridgeable', async () => {
+		const root = await mkdtemp(join(tmpdir(), 'octane-bridge-'));
+		await writeFakePackage(root, 'lazy-lib', {
+			'index.js': `
+				import { lazy, Suspense } from 'react';
+				export const Panel = lazy(() => import('./panel.js'));
+				export { Suspense };
+			`,
+		});
+		const report = await bridgeReport({ packageName: 'lazy-lib', projectRoot: root });
+		expect(report.apis.find((row) => row.name === 'lazy').status).toBe('same');
+		expect(report.verdict).toBe('bridgeable');
+	});
+
+	it('routes streaming SSR entry points to octane/server as a rewrite', async () => {
+		const root = await mkdtemp(join(tmpdir(), 'octane-bridge-'));
+		await writeFakePackage(root, 'streamer', {
+			'index.js': `
+				import { renderToPipeableStream } from 'react-dom/server';
+				export const ssr = (el) => renderToPipeableStream(el);
+			`,
+		});
+		const report = await bridgeReport({ packageName: 'streamer', projectRoot: root });
+		expect(report.apis.find((row) => row.name === 'renderToPipeableStream').status).toBe('rewrite');
+		expect(report.verdict).toBe('bridgeable-with-rewrites');
+		expect(report.plan.join('\n')).toContain('octane/server');
+	});
+
 	it('reports class components as needs-rework', async () => {
 		const root = await mkdtemp(join(tmpdir(), 'octane-bridge-'));
 		await writeFakePackage(root, 'classy', {

--- a/packages/octane-mcp-server/src/index.js
+++ b/packages/octane-mcp-server/src/index.js
@@ -33,13 +33,29 @@ export const REPO_SKILLS = {
 	triage: '.ai/skills/triage.md',
 };
 
-const BENCHMARKS = {
-	dbmon: '@benchmarks/dbmon',
-	'js-framework': 'octane-js-framework-benchmarks',
-	news: '@benchmarks/news',
-	'recursive-context': '@benchmarks/recursive-context',
-	'signal-favoring': '@benchmarks/signal-favoring',
-};
+// Suite names from the unified runner manifest (`SUITES` in
+// benchmarks/bench.mjs; `node benchmarks/bench.mjs --list` prints the same
+// set). index.test.js keeps this list in sync with the runner.
+export const BENCHMARK_SUITES = [
+	'js-framework',
+	'js-framework-reorder',
+	'todomvc',
+	'chat-stream',
+	'dbmon',
+	'recursive-context',
+	'signal-favoring',
+	'news',
+	'effectful-list',
+	'memo-wall',
+	'portal-swarm',
+	'ssr-throughput',
+	'streaming-ssr',
+	'dbmon-deopt',
+	'js-framework-deopt',
+	'async-waterfall',
+	'codegen-size',
+	'bundle-size',
+];
 
 const DEFAULT_TIMEOUT_MS = 120_000;
 
@@ -63,12 +79,15 @@ export function areaForPath(path) {
 	if (path.startsWith('packages/rspack-plugin-octane/')) return 'rspack-plugin';
 	if (path.startsWith('packages/rsbuild-plugin-octane/')) return 'rsbuild-plugin';
 	if (path.startsWith('packages/vite-plugin-octane/')) return 'vite-plugin';
+	if (path.startsWith('packages/adapter-vercel/')) return 'deploy-adapter';
+	if (path.startsWith('packages/octane-evals/')) return 'evals';
 	if (path.startsWith('packages/octane-mcp-server/')) return 'mcp-server';
 	const packageMatch = path.match(/^packages\/([^/]+)\//);
 	if (packageMatch && KNOWN_BINDING_PACKAGE_DIRS.has(packageMatch[1])) {
 		return 'ecosystem-binding';
 	}
 	if (path.startsWith('benchmarks/')) return 'benchmark';
+	if (path.startsWith('website/')) return 'website';
 	if (path.startsWith('.rulesync/')) return 'rulesync-source';
 	if (path.startsWith('.ai/') || path.startsWith('.codex/') || path.startsWith('.claude/')) {
 		return 'agent-instructions';
@@ -105,15 +124,49 @@ export function validationFor(paths, taskKind) {
 			'./node_modules/.bin/vitest run packages/octane-mcp-server --project octane-mcp-server',
 		);
 	}
+	if (areas.has('evals')) {
+		commands.add(
+			'./node_modules/.bin/vitest run packages/octane-evals/tests --project octane-evals',
+		);
+	}
+	if (areas.has('website')) {
+		commands.add('./node_modules/.bin/vitest run website/tests --project website');
+	}
+	if (areas.has('metaframework-core')) {
+		commands.add('./node_modules/.bin/vitest run packages/app-core/tests --project app-core');
+	}
+	if (areas.has('rspack-plugin')) {
+		commands.add(
+			'./node_modules/.bin/vitest run packages/rspack-plugin-octane/tests --project rspack-plugin',
+		);
+	}
+	if (areas.has('rsbuild-plugin')) {
+		commands.add(
+			'./node_modules/.bin/vitest run packages/rsbuild-plugin-octane/tests --project rsbuild-plugin',
+		);
+	}
+	if (areas.has('vite-plugin')) {
+		commands.add(
+			'./node_modules/.bin/vitest run packages/vite-plugin-octane/tests --project vite-plugin',
+		);
+	}
+	if (areas.has('deploy-adapter')) {
+		commands.add(
+			'./node_modules/.bin/vitest run packages/adapter-vercel/tests --project adapter-vercel',
+		);
+	}
 	if (
 		areas.has('metaframework-core') ||
 		areas.has('rspack-plugin') ||
 		areas.has('rsbuild-plugin') ||
-		areas.has('vite-plugin')
+		areas.has('vite-plugin') ||
+		areas.has('deploy-adapter')
 	) {
 		commands.add('pnpm typecheck');
 	}
-	if (areas.has('benchmark') || taskKind === 'performance') commands.add('pnpm bench');
+	if (areas.has('benchmark') || taskKind === 'performance') {
+		commands.add('node benchmarks/bench.mjs --quick --ratios');
+	}
 	if (taskKind === 'api' || taskKind === 'core' || taskKind === 'package')
 		commands.add('pnpm typecheck');
 	commands.add('pnpm format:check');
@@ -182,15 +235,14 @@ export async function scaffoldReactPort(repoRoot, input) {
 }
 
 export async function runBenchmark(repoRoot, input) {
-	const args =
-		input.benchmark === 'all'
-			? ['bench']
-			: ['--filter', BENCHMARKS[input.benchmark], 'run', 'bench'];
-	const result = await runCommand('pnpm', args, {
+	const args = ['benchmarks/bench.mjs'];
+	if (input.benchmark && input.benchmark !== 'all') args.push(input.benchmark);
+	if (input.quick) args.push('--quick');
+	const result = await runCommand(process.execPath, args, {
 		cwd: repoRoot,
-		timeoutMs: input.timeoutMs ?? 300_000,
+		timeoutMs: input.timeoutMs ?? 600_000,
 	});
-	return { command: ['pnpm', ...args], benchmark: input.benchmark, ...result };
+	return { command: [process.execPath, ...args], benchmark: input.benchmark, ...result };
 }
 
 export async function issueContext(repoRoot, input) {
@@ -264,7 +316,7 @@ function registerUserTools(server, repoRoot, repoMode) {
 		{
 			title: 'Bridge a React package to Octane',
 			description:
-				'Scan a React package (from node_modules by name, or any source directory by path) for React API usage and return an Octane compatibility report: which APIs map 1:1, which need rewrites (forwardRef, useDebugValue, lazy, class components), whether a framework-agnostic core can be reused verbatim, whether an official @octanejs binding already exists, and a step-by-step bridge plan. Follow up with the bridge-react-package skill for the full workflow.',
+				'Scan a React package (from node_modules by name, or any source directory by path) for React API usage and return an Octane compatibility report: which APIs map 1:1, which need rewrites (forwardRef, class components, synthetic onChange, react-dom/server imports), whether a framework-agnostic core can be reused verbatim, whether an official @octanejs binding already exists, and a step-by-step bridge plan. Follow up with the bridge-react-package skill for the full workflow.',
 			inputSchema: {
 				package: z
 					.string()
@@ -389,9 +441,10 @@ function registerRepoTools(server, repoRoot) {
 		{
 			title: 'Run Octane benchmark',
 			description:
-				'Run one of the known Octane benchmark workspaces, or all benchmarks via pnpm bench.',
+				'Run benchmark suites through the unified runner (node benchmarks/bench.mjs): one manifest suite by name, or every suite with "all". Set quick for the reduced-iteration smoke pass.',
 			inputSchema: {
-				benchmark: z.enum(['all', ...Object.keys(BENCHMARKS)]).default('all'),
+				benchmark: z.enum(['all', ...BENCHMARK_SUITES]).default('all'),
+				quick: z.boolean().default(false),
 				timeoutMs: z.number().int().positive().optional(),
 			},
 		},

--- a/packages/octane-mcp-server/src/index.test.js
+++ b/packages/octane-mcp-server/src/index.test.js
@@ -6,8 +6,10 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
 	areaForPath,
+	BENCHMARK_SUITES,
 	BUNDLED_SKILLS,
 	isOctaneRepo,
+	runCommand,
 	scaffoldReactPort,
 	validationFor,
 } from './index.js';
@@ -23,8 +25,47 @@ describe('@octanejs/mcp-server helpers', () => {
 		expect(areaForPath('packages/zustand/src/index.ts')).toBe('ecosystem-binding');
 		expect(areaForPath('packages/radix/src/index.ts')).toBe('ecosystem-binding');
 		expect(areaForPath('packages/octane-mcp-server/src/index.js')).toBe('mcp-server');
+		expect(areaForPath('packages/adapter-vercel/src/index.ts')).toBe('deploy-adapter');
+		expect(areaForPath('packages/octane-evals/tools/run.mjs')).toBe('evals');
+		expect(areaForPath('website/src/pages/index.tsrx')).toBe('website');
 		expect(areaForPath('benchmarks/news/run.mjs')).toBe('benchmark');
 		expect(areaForPath('.rulesync/rules/project.md')).toBe('rulesync-source');
+	});
+
+	it('recommends the adapter, evals, and website test projects', () => {
+		const commands = validationFor(
+			[
+				'packages/adapter-vercel/src/index.ts',
+				'packages/octane-evals/tools/run.mjs',
+				'website/src/pages/index.tsrx',
+			],
+			'feature',
+		);
+
+		expect(commands).toContain(
+			'./node_modules/.bin/vitest run packages/adapter-vercel/tests --project adapter-vercel',
+		);
+		expect(commands).toContain(
+			'./node_modules/.bin/vitest run packages/octane-evals/tests --project octane-evals',
+		);
+		expect(commands).toContain('./node_modules/.bin/vitest run website/tests --project website');
+		expect(commands).toContain('pnpm typecheck');
+	});
+
+	it('keeps the benchmark suite list in sync with the unified runner manifest', async () => {
+		// BENCHMARK_SUITES is hand-maintained in index.js; the runner manifest in
+		// benchmarks/bench.mjs is the source of truth. --list prints one suite
+		// name per line, in manifest order.
+		const repoRoot = resolve(PACKAGE_ROOT, '../..');
+		const result = await runCommand(process.execPath, ['benchmarks/bench.mjs', '--list'], {
+			cwd: repoRoot,
+		});
+		expect(result.code).toBe(0);
+		const suites = result.stdout
+			.split('\n')
+			.map((line) => line.trim())
+			.filter((line) => line && line !== 'Available suites:');
+		expect(suites).toEqual(BENCHMARK_SUITES);
 	});
 
 	it('classifies every maintained binding and recommends its test project', () => {


### PR DESCRIPTION
## Summary

The MCP server's hardcoded repository knowledge had fallen several waves behind main. This PR brings it current — extracted from the `react-compat-poc` branch, minus everything that depends on the React bridge packages (those MCP updates land with that branch).

- **Benchmarks**: `octane_benchmark` knew 5 suites and drove them through per-package `pnpm --filter` scripts (its "all" mode ran the root `pnpm bench`, which today only runs `news`). It now drives the unified runner (`node benchmarks/bench.mjs`) with the full 18-suite manifest plus a `quick` smoke-pass flag, and a new test keeps the list in sync with `bench.mjs --list`. Validation planning recommends `node benchmarks/bench.mjs --quick --ratios` (the CI gate) instead of `pnpm bench`.
- **Path triage / validation**: `packages/adapter-vercel`, `packages/octane-evals`, and `website/` no longer fall through to `repo-tooling`; they and the metaframework plugins now recommend their actual vitest projects (`adapter-vercel`, `octane-evals`, `website`, `app-core`, `rspack-plugin`, `rsbuild-plugin`, `vite-plugin`) instead of just `pnpm typecheck`.
- **React API map** (feeds `octane_bridge_react_package`): `lazy` and `useDebugValue` were claimed "not present" — both exist now (`lazy` also accepts a bare component from the loader). `renderToStaticMarkup` gets an entry, and the streaming `renderToPipeableStream`/`renderToReadableStream` move from `unsupported` ("No streaming SSR yet") to `rewrite` pointing at `octane/server`'s native streaming entry points.
- **Bundled skills** were teaching the opposite of current behavior: "no controlled components" (controlled inputs now match React exactly), "hooks may sit in a loop" (now a compile error — use `@for`), "output is buffered, not streamed", and "production server output is not generated yet" (the vite-plugin emits a self-contained SSR bundle, `octane-preview`, and the Vercel adapter exists). All four corrected, the divergences skill now covers inferred dependency arrays / the state-getter tuple member / parallel `use()` / sync first mount, and the bridge skill's binding table gains the 11 bindings it was missing (hook-form, base-ui, dnd-kit, sonner, recharts, three, visx, redux, redux-toolkit, testing-library, mdx).

Skills stay bundled in the package (`files: ["src", "skills", …]`), so `npx @octanejs/mcp-server` keeps serving them in any project.

## Validation

- `./node_modules/.bin/vitest run packages/octane-mcp-server --project octane-mcp-server` — 23 passed (4 new: benchmark-manifest sync, new area/validation coverage, lazy verdict, streaming-SSR rewrite verdict)
- `pnpm format:check` — clean