### PR TITLE
Fix Three unmount callback signaling

### DIFF
--- a/.changeset/calm-three-unmounts.md
+++ b/.changeset/calm-three-unmounts.md
@@ -1,0 +1,5 @@
+---
+'@octanejs/three': patch
+---
+
+Only invoke `unmountComponentAtNode` callbacks after root teardown completes successfully.

--- a/packages/three/README.md
+++ b/packages/three/README.md
@@ -135,8 +135,9 @@ root.store.getState().advance(1 / 60);
 Direct-root scheduling uses Octane's public `act` and `flushSync` semantics.
 Call `root.unmount()` directly, or use
 `unmountComponentAtNode(canvas, optionalCallback)` to remove the root registered
-for either canvas kind. Teardown synchronously disconnects events and XR,
-clears the animation loop, releases scene resources, and disposes the renderer.
+for either canvas kind. The optional callback runs synchronously only after
+teardown completes successfully. Teardown disconnects events and XR, clears the
+animation loop, releases scene resources, and disposes the renderer.
 
 Tests can inject the WebGL-free deterministic harness from
 `@octanejs/three/testing`; it drives the same root, host commits, hooks, and

--- a/packages/three/src/core/root.ts
+++ b/packages/three/src/core/root.ts
@@ -784,11 +784,8 @@ export function unmountComponentAtNode<TCanvas extends CanvasLike>(
 ): void {
 	const record = roots.get(canvas);
 	if (record === undefined) return;
-	try {
-		record.root.unmount();
-	} finally {
-		callback?.(canvas);
-	}
+	record.root.unmount();
+	callback?.(canvas);
 }
 
 export interface ThreeBoundaryMount {

--- a/packages/three/tests/root.test.ts
+++ b/packages/three/tests/root.test.ts
@@ -116,6 +116,37 @@ describe('Three root configuration', () => {
 		expect(callback).toHaveBeenCalledOnce();
 	});
 
+	it('does not report a successful removal when teardown fails', async () => {
+		const canvas = document.createElement('canvas');
+		const renderer = createRenderer(canvas);
+		const root = testRoot(canvas);
+		let failDisconnect = false;
+		const manager = {
+			priority: 1,
+			enabled: true,
+			disconnect: vi.fn(() => {
+				if (failDisconnect) throw new Error('event disconnect failed');
+			}),
+		};
+		await root.configure({
+			gl: renderer,
+			size: { width: 32, height: 32 },
+			frameloop: 'never',
+			events: () => manager,
+		});
+		root.render(RootScene, { name: 'failing-unmount', groupRef: () => {} });
+		const callback = vi.fn();
+		failDisconnect = true;
+
+		expect(() => unmountComponentAtNode(canvas, callback)).toThrow('event disconnect failed');
+		expect(callback).not.toHaveBeenCalled();
+		expect(root.store.getState().scene.children).toEqual([]);
+		expect(renderer.dispose).toHaveBeenCalledOnce();
+
+		unmountComponentAtNode(canvas, callback);
+		expect(callback).not.toHaveBeenCalled();
+	});
+
 	it('configures public defaults and activates only after the scene commits', async () => {
 		const canvas = document.createElement('canvas');
 		const renderer = createRenderer(canvas);


### PR DESCRIPTION
## Summary

- invoke `unmountComponentAtNode` callbacks only after root teardown returns successfully
- preserve teardown error propagation without emitting a false completion signal
- add a public regression that injects an event-manager disconnect failure and verifies host cleanup, renderer disposal, and registry removal still complete
- document the success-only callback contract and add a patch changeset

## Root cause

The callback introduced in #126 was placed in a `finally` block. That made it run even when `root.unmount()` threw, allowing callers to interpret a partially failed teardown as a successful removal.

This addresses the unresolved [review feedback on #126](https://github.com/octanejs/octane/pull/126#discussion_r3599530166).

## Validation

- `pnpm three:test` — 24 files, 121 tests
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm changeset:check`

The regression was also run against the original `finally` implementation and failed because the callback was invoked once.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow lifecycle signaling fix for an optional callback; teardown behavior is unchanged aside from not emitting a false success signal.
> 
> **Overview**
> Fixes **`unmountComponentAtNode`** so its optional callback runs only when **`root.unmount()`** finishes without throwing. The callback was previously in a **`finally`** block (from #126), so callers could treat a failed teardown as a successful removal.
> 
> The implementation now calls **`callback?.(canvas)`** only after **`unmount()`** returns. Teardown errors still propagate; the README states the callback is synchronous and **success-only**. A regression test simulates an event-manager **`disconnect`** failure and asserts the callback is skipped while host cleanup and renderer disposal still run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00c3bd69c14d3111b27aa0d1f19853286241378b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->