### PR TITLE
octane: pass the §6.3 context control signal through local `@try` catch paths

### DIFF
--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -14439,6 +14439,10 @@ export function tryBlock(
 			releaseHeldTransition(s);
 			s.pendingThenable = null;
 		} catch (err) {
+			// §6.3 control signal — never an application failure: pass it through
+			// so the renderer-region owner (handleRenderError) receives it; a
+			// local catch arm must not render a hosted context handshake.
+			if (isHostContextRequest(err)) throw err;
 			if (isSuspenseException(err)) {
 				if (s.propagateSuspense) throw err;
 				handleSuspense(s, err.thenable, s.tryBlock);
@@ -14574,6 +14578,9 @@ function mountTry(state: TrySlot): void {
 		renderBlock(b);
 		state.hasResolved = true;
 	} catch (err) {
+		// §6.3 control signal — bypass the local boundary (see the try-body
+		// re-render catch above); the renderer-region owner handles it.
+		if (isHostContextRequest(err)) throw err;
 		if (isSuspenseException(err)) {
 			if (state.propagateSuspense) throw err;
 			handleSuspense(state, err.thenable, b);

--- a/packages/octane/tests/react-hosted/_fixtures/react-context-islands.tsrx
+++ b/packages/octane/tests/react-hosted/_fixtures/react-context-islands.tsrx
@@ -81,3 +81,30 @@ export function ThemeAndResourceIsland(props) @{
 		{theme + ':' + value as string}
 	</p>
 }
+
+function GuardedReader(props) @{
+	const theme =
+		props.read === false ? '(off)' : use(HostTheme);
+	<p class="guard-theme">
+		{'theme:' + theme as string}
+	</p>
+}
+
+/**
+ * Foreign read INSIDE a local Octane boundary: the §6.3 control signal must
+ * bypass the island's own @pending/@catch arms on BOTH try paths (initial
+ * mount and try-body re-render — `props.read` flips the read on after commit).
+ */
+export function GuardedHostThemeIsland(props) @{
+	<div class="guarded-host">
+		@try {
+			<GuardedReader read={props.read} />
+		} @pending {
+			<p class="guard-pending">{'guard pending'}</p>
+		} @catch (error) {
+			<p class="guard-caught">
+				{'caught:' + String(error)}
+			</p>
+		}
+	</div>
+}

--- a/packages/octane/tests/react-hosted/octane-compat-context.test.ts
+++ b/packages/octane/tests/react-hosted/octane-compat-context.test.ts
@@ -21,6 +21,7 @@ import { h, mountReactHost, reactAct, SpikeErrorBoundary } from './_react-host.j
 import {
 	ConditionalHostReadIsland,
 	DuplicateReadIsland,
+	GuardedHostThemeIsland,
 	HostThemeIsland,
 	HostThemeViaUseContextIsland,
 	LoggingHostThemeIsland,
@@ -362,6 +363,48 @@ describe('octane/react — §6.3 HostContextRequest fallback', () => {
 			),
 		);
 		expect(mounted.host().querySelector('.two-host')?.textContent).toBe('t:hs-t l:hs-l');
+		await mounted.unmount();
+	});
+
+	it('bypasses a local @try boundary on INITIAL mount — providerless read lands the default', async () => {
+		// The reader sits inside the island's own @try with @pending and @catch
+		// arms. A providerless first read raises the §6.3 request from the
+		// mountTry path; the signal must reach the owner, never a local arm.
+		const mounted = await mountReactHost(
+			h(OctaneCompat, null, h(GuardedHostThemeIsland as any, { read: true })),
+		);
+		expect(mounted.host().querySelector('.guard-theme')?.textContent).toBe(
+			'theme:host-theme-default',
+		);
+		expect(mounted.host().querySelector('.guard-caught')).toBeNull();
+		expect(mounted.host().querySelector('.guard-pending')).toBeNull();
+		await mounted.unmount();
+	});
+
+	it('bypasses a local @try boundary when the first read appears on a try-body RE-RENDER', async () => {
+		// The try body commits WITHOUT a context read, then a prop flip makes the
+		// re-render path raise the request — the in-place try re-render catch
+		// must also pass the signal through instead of switching to @catch.
+		__setHostFiberAdapterEnabled(false);
+		let setTheme!: (value: string) => void;
+		function App(props: { read: boolean }) {
+			const [theme, set] = React.useState('g0');
+			setTheme = set;
+			return themed(
+				theme,
+				h(OctaneCompat, null, h(GuardedHostThemeIsland as any, { read: props.read })),
+			);
+		}
+		const mounted = await mountReactHost(h(App, { read: false }));
+		expect(mounted.host().querySelector('.guard-theme')?.textContent).toBe('theme:(off)');
+
+		await mounted.render(h(App, { read: true }));
+		expect(mounted.host().querySelector('.guard-theme')?.textContent).toBe('theme:g0');
+		expect(mounted.host().querySelector('.guard-caught')).toBeNull();
+
+		// The handshake installed a real subscription through the boundary.
+		await reactAct(async () => setTheme('g1'));
+		expect(mounted.host().querySelector('.guard-theme')?.textContent).toBe('theme:g1');
 		await mounted.unmount();
 	});
 


### PR DESCRIPTION
Follow-up to #132, carrying the fix for the Bugbot finding there ([thread](https://github.com/octanejs/octane/pull/132#discussion_r3602145818)) — the finding was addressed on the PR branch but #132 merged moments before the fix commit could be pushed, so it lands here unchanged.

**Bug**: `HostContextRequest` (the §6.3 hosted-context handshake signal) was recognized only in `handleRenderError`, but `mountTry` and the try-body in-place re-render catch subtree throws synchronously and routed everything non-suspense to `switchToCatch`. A foreign React-context read inside an island's `@try` therefore rendered the local `@catch` arm with the control signal as its "error", and the authoritative React value never arrived.

**Fix**: both `@try` catch sites rethrow the control signal so it reaches the renderer-region owner; `renderOffscreen`'s captured errors already rethrow through these same paths, so the transition route is covered transitively.

**Tests**: regression coverage for both sites — a providerless first read inside an island `@try` on initial mount, and a first read appearing on a try-body re-render with the Fiber adapter disabled — each verified failing pre-fix with the signal swallowed by the `@catch` arm.

## Test plan

- Full suite green at this exact tree (1086 files / 10,532 tests — the pre-merge PR branch with this fix was byte-identical to main + this commit), plus targeted react-hosted/try-catch suites re-run on the cherry-picked branch
- `pnpm typecheck`, `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `@try` error routing in the runtime; scope is narrow (one control-signal check before existing suspense/catch logic) but affects hosted React island boundaries.
> 
> **Overview**
> Fixes hosted React context reads that run **inside an island’s own `@try`**: the §6.3 `HostContextRequest` control signal was only handled in `handleRenderError`, while synchronous throws from **`mountTry`** and the **try-body re-render** path were treated as real errors and routed to **`switchToCatch`**, so `@catch` could render with the handshake object instead of the owner completing the read.
> 
> **`runtime.ts`** now **rethrows** `isHostContextRequest(err)` at both `@try` catch sites so the signal reaches the renderer-region owner (same behavior as `handleRenderError`); suspense and normal errors are unchanged.
> 
> Adds **`GuardedHostThemeIsland`** and tests for **initial mount** (providerless read) and **try-body re-render** (read enabled after commit, Fiber adapter off) asserting the theme resolves and **`@catch` / `@pending` stay empty**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07f6f3bb31a802b2aeb3989af7b971ac0c371d2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->