### PR TITLE
React-hosted Phases 3+4: failure-matrix closure, `octane/react/server`, island hydration

### DIFF
--- a/.changeset/hosted-react-ssr-hydration.md
+++ b/.changeset/hosted-react-ssr-hydration.md
@@ -1,0 +1,22 @@
+---
+'octane': patch
+---
+
+`octane/react` islands now server-render and hydrate. The new
+`octane/react/server` entry runs one synchronous hosted Octane pass per React
+server render (Fizz streaming or `renderToString`) against a request-local
+session, so Fizz retries replay settled work instead of re-fetching — one
+replay per suspension stratum, parallel `use()` fetches started once, and
+rejections routed to Fizz exactly once. Island React-context reads call
+`React.use` directly on the server; locally-guarded suspensions ship their
+`@pending` arms in the shell for the client to complete; scoped island CSS
+hoists as deduplicated React 19 style resources that client hydration
+recognizes; and hoisted `<title>/<meta>/<link>` from islands is rejected with
+a targeted diagnostic. On the client, `OctaneCompat` hydrates a
+server-rendered host in place: Octane adopts the exact server node identities
+(byte-identical `useId` values, preserved state, live events) while React
+never touches the island's descendants. Also closes the escape-protocol
+matrix: island layout/passive/ref faults surface in the nearest React error
+boundary, and update suspensions over committed content preserve hidden
+island DOM and state (transition-originated episodes refallback in v1 — a
+documented divergence).

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -49,7 +49,7 @@ All publishable packages share the enforced Node.js engine baseline `>=22`.
 | `@octanejs/visx` | [`packages/visx`](../packages/visx) | framework binding | `0.1.1` | 49 |
 | `@octanejs/vite-plugin` | [`packages/vite-plugin-octane`](../packages/vite-plugin-octane) | metaframework | `0.1.7` | 3 |
 | `@octanejs/zustand` | [`packages/zustand`](../packages/zustand) | framework binding | `0.1.6` | 5 |
-| `octane` | [`packages/octane`](../packages/octane) | core runtime + compiler | `0.1.7` | 12 |
+| `octane` | [`packages/octane`](../packages/octane) | core runtime + compiler | `0.1.7` | 13 |
 
 ## Private packages
 

--- a/docs/react-hosted-octane-compat-plan.md
+++ b/docs/react-hosted-octane-compat-plan.md
@@ -1,6 +1,6 @@
 # React-hosted Octane compatibility plan
 
-Status: **Phases 0–2 landed** (2026-07-17). Phase 0's committed evidence lives
+Status: **Phases 0–4 landed (client + SSR/hydration)** (2026-07-17). Phase 0's committed evidence lives
 in `packages/octane/tests/react-hosted/`, `packages/octane/typetests/`
 (react-hosted-jsx.test-d.tsx), and `benchmarks/react-hosted-islands/`; measured
 findings are folded into §3, §5, §6.2, §8, §9 and §15 below and summarized
@@ -8,8 +8,10 @@ under §14 Phase 0. Phase 1 ships the experimental `octane/react` client shell
 (`OctaneCompat`, including the client half of the Phase 3 escape protocol) with
 zero core-runtime changes; Phase 2 adds transparent React context (foreign
 `use()`/`useContext()` resolution, the production Fiber adapter, and the §6.3
-handshake) behind a cold-path-only core seam — see §14. Server/hydration
-(Phase 4) and selective events (Phase 5) remain open.
+handshake) behind a cold-path-only core seam — see §14. Phase 3 closed its
+remaining failure-matrix breadth, and Phase 4 ships `octane/react/server` +
+island hydration (jsdom-provable scope; browser E2E precedes public release).
+Selective events (Phase 5) and finalization (Phase 6) remain open.
 
 > Goal: allow a compiled Octane tree to live inside an existing React 19 tree
 > through one compatibility component, while preserving React context, native
@@ -1183,6 +1185,30 @@ one Fiber walk per island at discovery and ZERO per provider update at
 
 Exit gate: no eager normal `TrySlot`/marker allocation and all failure tests pass.
 
+**Executed 2026-07-17 — exit gate met.** The client escape protocol shipped
+with Phase 1 (lazy relay episodes, post-commit resolution, rejection routing,
+supersession/no-op guards, local-boundary priority — no eager `TrySlot`);
+Phase 3 closes the remaining §13 breadth through the public surface
+(`tests/react-hosted/octane-compat-failure-matrix.test.ts`): layout-setup,
+passive-setup, and ref-attachment faults route to the nearest React error
+boundary; a sync update suspension over committed content refallbacks while
+preserving hidden island DOM and state. Two decisions pinned:
+
+- Open question 16 (mid-episode snapshot supersession): v1 uses REVEAL-TIME
+  supersession — the suspended wrapper re-renders with fresh snapshots but
+  keeps throwing the same relay; the reveal's layout publish supersedes the
+  episode-start snapshot before paint (end-to-end tested with contexts and
+  props). The pathological case — an island whose pending fetch can only
+  settle with the NEW value — would need the out-of-band publish; deferred
+  until a real workload needs it.
+- Open question 9 (transition entanglement): a transition-committed prop
+  change whose island suspension escapes refallbacks in v1 — the suspension
+  surfaces from the layout-phase hosted flush as a new sync update, unlike a
+  pure React tree where the transition render itself suspends and holds old
+  content. Pinned as an `// OCTANE DIVERGENCE` test (no tearing: prior
+  DOM/state preserved); the `ReactSharedInternals.T` lever remains the
+  candidate if entanglement is later wanted.
+
 ### Phase 4 — server and hydration
 
 - Add server conditional export and synchronous hosted SSR attempt.
@@ -1194,6 +1220,46 @@ Exit gate: no eager normal `TrySlot`/marker allocation and all failure tests pas
 
 Exit gate: multiple streamed React pages hydrate several islands without mismatch,
 React descendant mutation, lost context, or double events.
+
+**Executed 2026-07-17 — jsdom-provable scope met**
+(`tests/react-hosted/octane-compat-ssr.test.ts`; real-browser E2E for paint,
+focus, and streamed `completeBoundary` segment relocation remains before the
+public release, §13). What shipped:
+
+- `octane/react/server` (explicit subpath; the conditional-exports matrix
+  stays with the OQ1 packaging finalization): one SYNCHRONOUS hosted attempt
+  per Fizz task execution via the new server-runtime seam
+  (`renderHostedAttempt` + `createHostedServerSession` in runtime.server.ts).
+  A pass reuses the session's resolved/parallel-use maps, so puMemo thenables
+  keep identity across replays; only a BARE root suspension (`rootSuspended`)
+  delegates — a locally-owned suspension ships its @pending arm (§9.1 v1).
+- Fizz retry state: strata aggregates are identity-stable, status-stamped,
+  recorded into the session, and replayed IN ORDER via `React.use` — tested:
+  one replay per sequential stratum, parallel creations started once with
+  ZERO re-fetch across replays, rejection routed to Fizz exactly once, and
+  overlapping streams fully isolated (the session key is the Fizz-stable
+  transported props identity — answering open question 11 with no
+  AsyncLocalStorage).
+- Server context (§6.4): a hosted pass installs a foreign-context read hook;
+  island `use(ReactContext)` calls `React.use` directly — nearest provider and
+  Fizz semantics for free — and the hydrated island holds a live client
+  subscription afterwards.
+- Hydration (§9.3): the client host always carries the frozen opaque sentinel;
+  a host containing server markup hydrates through `hydrateOctaneRoot` with
+  the VERBATIM `useId`-derived prefix — Octane ids hydrate byte-identically
+  (tested), node identity/state/events adopt, and a §6.3 request during
+  adoption abandons it for a client remount with a dev diagnostic. Core
+  gained a lazy root-disposer lookup so `bindRendererRegionOwner` works from
+  a hydration pass.
+- CSS/head (§9.2): island CSS emits as React 19 style resources (stable
+  per-hash `href`, `precedence="octane"`) — Fizz hoists and dedupes across
+  islands, and `injectStyle`'s detection now also recognizes React's
+  `data-href="octane-<hash>"` serialization (React drops other attributes
+  from hoisted resources) so hydration never re-injects. Hoisted island
+  <title>/<meta>/<link> is rejected by the server COMPILER already
+  (pinned); the hosted renderer keeps a defensive runtime guard (open
+  question 14: v1 = reject). CSP nonce is threaded through the hosted seam
+  (`HostedAttemptOptions.nonce`) but not yet exposed on the public component.
 
 ### Phase 5 — selective events and scale hardening
 

--- a/docs/react-hosted-octane-compat-plan.md
+++ b/docs/react-hosted-octane-compat-plan.md
@@ -1250,7 +1250,19 @@ public release, §13). What shipped:
   (tested), node identity/state/events adopt, and a §6.3 request during
   adoption abandons it for a client remount with a dev diagnostic. Core
   gained a lazy root-disposer lookup so `bindRendererRegionOwner` works from
-  a hydration pass.
+  a hydration pass, and `hydrateRoot` now mirrors `createRoot`'s
+  initial-render contract for OWNED roots: an escape during the adoption pass
+  routes to the renderer-region owner, the failed root unmounts, and the
+  container is released for the retry's fresh root (review-found: previously
+  the escape blew through the React layout effect uncaught). Known v1
+  limitation (pinned as an OCTANE DIVERGENCE test): a BARE root suspension
+  during hydration keeps the server content visible via React's dehydrated
+  revert, but that revert discards the wrapper attempt and orphans the
+  episode — live completion is only guaranteed for the supported pattern,
+  a local Octane @try owning its pending UI. React style RESOURCES are
+  exempt from positional hydration, so CSS-producing islands hydrate
+  mismatch-free alongside their hoisted styles (tested; refutes the
+  sibling-mismatch concern).
 - CSS/head (§9.2): island CSS emits as React 19 style resources (stable
   per-hash `href`, `precedence="octane"`) — Fizz hoists and dedupes across
   islands, and `injectStyle`'s detection now also recognizes React's

--- a/packages/octane/package.json
+++ b/packages/octane/package.json
@@ -32,6 +32,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./react": "./src/react/index.ts",
+    "./react/server": "./src/react/server.ts",
     "./server": "./src/server/index.ts",
     "./static": "./src/static/index.ts",
     "./constants": "./src/constants.ts",
@@ -56,6 +57,10 @@
       "./react": {
         "types": "./dist/react/index.d.ts",
         "default": "./dist/react/index.js"
+      },
+      "./react/server": {
+        "types": "./dist/react/server.d.ts",
+        "default": "./dist/react/server.js"
       },
       "./server": {
         "types": "./dist/server/index.d.ts",

--- a/packages/octane/src/react/index.ts
+++ b/packages/octane/src/react/index.ts
@@ -49,59 +49,35 @@ import {
 	createElement as createOctaneElement,
 	createHostContextRequest,
 	createRoot as createOctaneRoot,
+	hydrateRoot as hydrateOctaneRoot,
 	flushSync as octaneFlushSync,
 	type ComponentBody,
 	type Context as OctaneContext,
 	type Root as OctaneRoot,
 } from '../index.js';
+import {
+	OPAQUE_HOST_SENTINEL,
+	OPAQUE_HOST_SENTINEL_COMMENT,
+	REACT_CONTEXT_TAG,
+	validateIslandChild,
+	type OctaneCompatProps,
+	type TransportedChild,
+} from './shared.js';
+
+export type { OctaneCompatProps, OctaneReactComponent, OctaneRenderedNode } from './shared.js';
 import { drainPassiveEffects } from '../runtime.js';
 import { readNearestProviderValue } from './fiber-adapter.js';
 
 // Structural bench/test hook (§13): provider walks happen only at discovery.
 export { __hostContextFiberWalks } from './fiber-adapter.js';
 
-export interface OctaneCompatProps {
-	/** Exactly one compiled Octane component element. */
-	children: React.ReactElement;
-}
-
-declare const OCTANE_RENDERED: unique symbol;
-
-/**
- * Opaque branded node type for the JSX-facing view of a compiled Octane
- * component: assignable to `React.ReactNode` so React JSX accepts the child
- * site, but never actually produced at runtime — `OctaneCompat` consumes the
- * child element as a `{ type, props }` transport and React never invokes it.
- */
-export type OctaneRenderedNode = React.ReactElement & {
-	readonly [OCTANE_RENDERED]: 'octane';
-};
-
-/**
- * The React-JSX-facing type of a compiled Octane component. The runtime value
- * is the compiled body; only the declared type differs so `<Island …/>` is
- * valid zero-cast inside `<OctaneCompat>`. Intersects cleanly with
- * `ComponentBody<P>` so one declaration can serve both hosts.
- */
-export type OctaneReactComponent<P = Record<string, never>> = (props: P) => OctaneRenderedNode;
-
 /** Shared registry key the Octane runtime reads the owner bridge from. */
 const RENDERER_REGION_OWNER = Symbol.for('octane.renderer-region.owner');
-
-interface TransportedChild {
-	type: ComponentBody;
-	props: Record<string, unknown>;
-	/** React key of the transported element — part of island identity (§3/§10). */
-	key: string | null;
-}
 
 interface PendingEpisode {
 	relay: Promise<void>;
 	resolve: () => void;
 }
-
-// React 19 context objects carry $$typeof: Symbol.for('react.context').
-const REACT_CONTEXT_TAG = Symbol.for('react.context');
 
 /**
  * One registered foreign context (§6.2): the React context, its root-local
@@ -202,6 +178,8 @@ class HostedIslandController {
 	private attemptErrored = false;
 	/** §6.3 request thenables this controller minted (recognized in routeSuspense). */
 	private contextRequests = new WeakSet<PromiseLike<unknown>>();
+	/** True while an attach is adopting server DOM (hydration). */
+	private hydrating = false;
 	/** A §6.3 handshake unwound the last attempt; the next commit retries the root. */
 	private pendingContextRetry = false;
 
@@ -293,6 +271,14 @@ class HostedIslandController {
 			// already queued, so the wrapper re-renders, its layout commit
 			// publishes the authoritative `React.use` snapshot, settles the
 			// request, and retries the root synchronously — all before paint.
+			if (this.hydrating && process.env.NODE_ENV !== 'production') {
+				// Adoption cannot be retried atomically: the handshake retry
+				// client-remounts only this island (§6.3 hydration fallback).
+				console.warn(
+					'<OctaneCompat> abandoned hydration for an island whose context ' +
+						'read needed the request handshake; the island was client-remounted.',
+				);
+			}
 			this.pendingContextRetry = true;
 			return true;
 		}
@@ -509,6 +495,24 @@ class HostedIslandController {
 		if (this.host === null || this.committed === null || this.disposed) {
 			return { suspended: false, errored: false };
 		}
+		if (this.root === null && hasServerIslandMarkup(this.host)) {
+			// A server-rendered island (octane/react/server wrote the real HTML;
+			// React hydrated around it without touching descendants — §9.3):
+			// adopt the exact server node identities. The prefix is passed
+			// VERBATIM so Octane ids hydrate byte-identically (§5 rule 2).
+			this.hydrating = true;
+			try {
+				this.root = hydrateOctaneRoot(
+					this.host,
+					hostedRootEnvelope as unknown as ComponentBody,
+					this.envelopeProps(),
+					{ identifierPrefix: this.identifierPrefix },
+				);
+			} finally {
+				this.hydrating = false;
+			}
+			return { suspended: this.attemptSuspended, errored: this.attemptErrored };
+		}
 		if (this.root === null || !this.rootLive) {
 			// First attach, or the runtime unmounted the previous root after an
 			// initial routed failure — a React retry binds a fresh root (§5 rule 9).
@@ -540,53 +544,6 @@ class HostedIslandController {
 		drainPassiveEffects();
 		episode.resolve();
 	}
-}
-
-function describeChildType(type: unknown): string {
-	if (typeof type === 'string') return `the DOM element <${type}>`;
-	if (type === React.Fragment) return 'a Fragment';
-	if (typeof type === 'function')
-		return `the component ${(type as Function).name || '(anonymous)'}`;
-	return 'an exotic React element';
-}
-
-function validateIslandChild(children: React.ReactNode): TransportedChild {
-	if (React.Children.count(children) !== 1) {
-		throw new Error(
-			'<OctaneCompat> expects exactly one Octane component element child; received ' +
-				`${React.Children.count(children)} children.`,
-		);
-	}
-	if (!React.isValidElement(children)) {
-		throw new Error('<OctaneCompat> expects an Octane component element, not a plain renderable.');
-	}
-	const type = children.type as unknown;
-	if (typeof type !== 'function') {
-		throw new Error(
-			`<OctaneCompat> cannot host ${describeChildType(type)}; ` +
-				'pass one compiled Octane component. (memo/forwardRef/lazy wrappers are React-only ' +
-				'element types — use Octane memo()/lazy() inside the island instead.)',
-		);
-	}
-	if (process.env.NODE_ENV !== 'production') {
-		// A class component is provably a React-only component. A PLAIN function
-		// cannot be distinguished from a prod-compiled or plain-TS Octane
-		// component today (the compiler does not yet emit a runtime brand), so
-		// unbranded plain functions are accepted; passing an ordinary React
-		// function component here fails inside the island when it calls React
-		// hooks against the Octane runtime.
-		if ((type as { prototype?: { isReactComponent?: unknown } }).prototype?.isReactComponent) {
-			throw new Error(
-				`<OctaneCompat> cannot host ${describeChildType(type)}: class components are ` +
-					'React-only; pass one compiled Octane component.',
-			);
-		}
-	}
-	return {
-		type: type as unknown as ComponentBody,
-		props: (children.props ?? {}) as Record<string, unknown>,
-		key: children.key ?? null,
-	};
 }
 
 /**
@@ -631,5 +588,24 @@ export function OctaneCompat(props: OctaneCompatProps): React.ReactNode {
 		return () => controller.passiveDetached();
 	}, [controller]);
 
-	return React.createElement('div', { 'data-octane-compat': '', ref: hostRef });
+	return React.createElement('div', {
+		'data-octane-compat': '',
+		ref: hostRef,
+		// §9.3 opaque-host contract: the server writes real island HTML; the
+		// client ALWAYS supplies this stable frozen sentinel so React neither
+		// diffs nor clears the Octane-owned descendants — on any render, forever.
+		suppressHydrationWarning: true,
+		dangerouslySetInnerHTML: OPAQUE_HOST_SENTINEL,
+	});
+}
+
+/** Server island markup present? (Anything beyond the client's own sentinel.) */
+function hasServerIslandMarkup(host: HTMLElement): boolean {
+	const first = host.firstChild;
+	if (first === null) return false;
+	return !(
+		first.nodeType === 8 &&
+		(first as Comment).data === OPAQUE_HOST_SENTINEL_COMMENT &&
+		first.nextSibling === null
+	);
 }

--- a/packages/octane/src/react/index.ts
+++ b/packages/octane/src/react/index.ts
@@ -500,14 +500,20 @@ class HostedIslandController {
 			// React hydrated around it without touching descendants — §9.3):
 			// adopt the exact server node identities. The prefix is passed
 			// VERBATIM so Octane ids hydrate byte-identically (§5 rule 2).
+			// Same flushSync contract as the render path below: island layout
+			// effects and refs commit before this layout effect returns, so
+			// ancestor React layout effects observe the settled island DOM.
+			const host = this.host;
 			this.hydrating = true;
 			try {
-				this.root = hydrateOctaneRoot(
-					this.host,
-					hostedRootEnvelope as unknown as ComponentBody,
-					this.envelopeProps(),
-					{ identifierPrefix: this.identifierPrefix },
-				);
+				octaneFlushSync(() => {
+					this.root = hydrateOctaneRoot(
+						host,
+						hostedRootEnvelope as unknown as ComponentBody,
+						this.envelopeProps(),
+						{ identifierPrefix: this.identifierPrefix },
+					);
+				});
 			} finally {
 				this.hydrating = false;
 			}

--- a/packages/octane/src/react/server.ts
+++ b/packages/octane/src/react/server.ts
@@ -1,0 +1,136 @@
+/**
+ * `octane/react/server` — the hosted SERVER implementation of `OctaneCompat`
+ * (react-hosted-octane-compat-plan.md §9.1–§9.2). Use it wherever React runs
+ * on the server (Fizz streaming or `renderToString`); the client entry
+ * (`octane/react`) hydrates its output.
+ *
+ * Per island, one synchronous hosted Octane attempt runs INSIDE the React
+ * component render against a session that persists across that island's Fizz
+ * retries (keyed on the Fizz-stable transported props identity):
+ *
+ * - React context reads inside the island call `React.use(context)` directly —
+ *   no Fiber, registry, or subscription machinery exists on the server (§6.4).
+ * - An unhandled island suspension is delegated to `React.use(stratum)`, where
+ *   the stratum is an identity-stable, status-stamped aggregate recorded into
+ *   the session — Fizz's positional replay state can therefore never loop on a
+ *   fresh Octane pass, parallel-use strata cost one replay each, and settled
+ *   strata unwrap synchronously (Phase 0 evidence, §9.1).
+ * - Unhandled island errors throw out of the component into Fizz's nearest
+ *   boundary/error handling; React error boundaries do not catch server errors.
+ * - Scoped island CSS is emitted as React 19 style resources (stable
+ *   per-hash `href`, `precedence="octane"`), so Fizz hoists and deduplicates
+ *   across islands; hoisted `<title>/<meta>/<link>` output is REJECTED in v1
+ *   with a targeted diagnostic (§9.2).
+ * - The island HTML is written through `dangerouslySetInnerHTML` on the host
+ *   element with `suppressHydrationWarning`; the client's stable opaque
+ *   sentinel keeps React from ever touching the descendants (§9.3).
+ */
+import * as React from 'react';
+import { createElement as createOctaneServerElement } from '../server/index.js';
+import {
+	createHostedServerSession,
+	renderHostedAttempt,
+	type HostedServerSession,
+} from '../runtime.server.js';
+import { validateIslandChild, type OctaneCompatProps, type TransportedChild } from './shared.js';
+
+export type { OctaneCompatProps, OctaneReactComponent, OctaneRenderedNode } from './shared.js';
+
+/**
+ * Server envelope: marker-parity twin of the client root envelope — the
+ * transported child renders as one value-position element (keyed identically),
+ * so client hydration adopts the exact server structure. No owner bridge
+ * exists on the server; foreign context reads flow through the §6.4 hook.
+ */
+function hostedServerEnvelope(props: {
+	body: unknown;
+	bodyProps: unknown;
+	bodyKey: string | null;
+}): unknown {
+	const config =
+		props.bodyKey === null
+			? props.bodyProps
+			: { ...(props.bodyProps as object), key: props.bodyKey };
+	return createOctaneServerElement(props.body as never, config as never);
+}
+
+/**
+ * Fizz replays a suspended task with the IDENTICAL props object, so the
+ * transported child's props are request-local, replay-stable session keys
+ * (Phase 0, §9.1) — no module-global request state, no AsyncLocalStorage.
+ */
+const SESSIONS = new WeakMap<object, HostedServerSession>();
+
+function sessionFor(child: TransportedChild): HostedServerSession {
+	const key = child.props;
+	let session = SESSIONS.get(key);
+	if (session === undefined) {
+		session = createHostedServerSession();
+		SESSIONS.set(key, session);
+	}
+	return session;
+}
+
+export function OctaneCompat(props: OctaneCompatProps): React.ReactNode {
+	const child = validateIslandChild(props.children);
+	// The island-stable identifier prefix; the client wrapper derives the same
+	// value at the same tree position, so Octane ids hydrate byte-identically.
+	const identifierPrefix = React.useId();
+	const session = sessionFor(child);
+
+	// Replay committed strata IN ORDER: identity-stable and status-stamped, so
+	// settled ones unwrap synchronously and use()-call positions stay aligned
+	// across Fizz replays (§9.1 — order determinism is hard correctness).
+	for (const stratum of session.strata) React.use(stratum as PromiseLike<void>);
+
+	const attempt = renderHostedAttempt(
+		session,
+		hostedServerEnvelope as never,
+		{ body: child.type, bodyProps: child.props, bodyKey: child.key },
+		{
+			identifierPrefix,
+			// §6.4: the hosted context reader IS React's — nearest provider,
+			// defaults, and Fizz semantics come along for free.
+			readForeignContext: (context) => React.use(context as React.Context<unknown>),
+		},
+	);
+	if (attempt.status === 'suspended') {
+		// Delegate the wait to Fizz; the replay re-enters with the session.
+		React.use(attempt.stratum as Promise<void>);
+	}
+	if (attempt.status !== 'complete') {
+		// Unreachable: use(pending) throws. Narrow for TypeScript.
+		throw new Error('octane/react/server: hosted attempt did not complete.');
+	}
+	if (attempt.head.length > 0) {
+		// §9.2 v1 policy: hoisted head output cannot land under a body host.
+		throw new Error(
+			'<OctaneCompat> islands cannot hoist <title>/<meta>/<link> to the document head ' +
+				'during React SSR yet; render head resources from the React tree instead.',
+		);
+	}
+
+	const children: React.ReactNode[] = [];
+	for (const [hash, css] of attempt.cssEntries) {
+		// React 19 style resources: Fizz hoists and dedupes by href across
+		// islands. React serializes the href as `data-href="octane-<hash>"`
+		// (and drops any other attribute), which octane hydration's style
+		// detection recognizes — no re-injection client-side.
+		children.push(
+			React.createElement(
+				'style',
+				{ key: `css-${hash}`, href: `octane-${hash}`, precedence: 'octane' },
+				css,
+			),
+		);
+	}
+	children.push(
+		React.createElement('div', {
+			key: 'host',
+			'data-octane-compat': '',
+			suppressHydrationWarning: true,
+			dangerouslySetInnerHTML: { __html: attempt.html },
+		}),
+	);
+	return React.createElement(React.Fragment, null, ...children);
+}

--- a/packages/octane/src/react/shared.ts
+++ b/packages/octane/src/react/shared.ts
@@ -1,0 +1,96 @@
+/**
+ * Host-agnostic pieces shared by the `octane/react` client controller and the
+ * `octane/react/server` hosted renderer: the public prop/facade types and the
+ * §3 transported-child validation. No React DOM, no Octane runtime imports —
+ * both entries layer their renderer on top.
+ */
+import * as React from 'react';
+import type { ComponentBody } from '../index.js';
+
+export interface OctaneCompatProps {
+	/** Exactly one compiled Octane component element. */
+	children: React.ReactElement;
+}
+
+declare const OCTANE_RENDERED: unique symbol;
+
+/**
+ * Opaque branded node type for the JSX-facing view of a compiled Octane
+ * component: assignable to `React.ReactNode` so React JSX accepts the child
+ * site, but never actually produced at runtime — `OctaneCompat` consumes the
+ * child element as a `{ type, props }` transport and React never invokes it.
+ */
+export type OctaneRenderedNode = React.ReactElement & {
+	readonly [OCTANE_RENDERED]: 'octane';
+};
+
+/**
+ * The React-JSX-facing type of a compiled Octane component. The runtime value
+ * is the compiled body; only the declared type differs so `<Island …/>` is
+ * valid zero-cast inside `<OctaneCompat>`. Intersects cleanly with
+ * `ComponentBody<P>` so one declaration can serve both hosts.
+ */
+export type OctaneReactComponent<P = Record<string, never>> = (props: P) => OctaneRenderedNode;
+
+/** React 19 context objects carry $$typeof: Symbol.for('react.context'). */
+export const REACT_CONTEXT_TAG = Symbol.for('react.context');
+
+/** The client's stable opaque-host sentinel; the server writes real island HTML. */
+export const OPAQUE_HOST_SENTINEL_COMMENT = 'octane-compat-island';
+export const OPAQUE_HOST_SENTINEL = Object.freeze({
+	__html: `<!--${OPAQUE_HOST_SENTINEL_COMMENT}-->`,
+});
+
+export interface TransportedChild {
+	type: ComponentBody;
+	props: Record<string, unknown>;
+	/** React key of the transported element — part of island identity (§3/§10). */
+	key: string | null;
+}
+
+function describeChildType(type: unknown): string {
+	if (typeof type === 'string') return `the DOM element <${type}>`;
+	if (type === React.Fragment) return 'a Fragment';
+	if (typeof type === 'function')
+		return `the component ${(type as Function).name || '(anonymous)'}`;
+	return 'an exotic React element';
+}
+
+export function validateIslandChild(children: React.ReactNode): TransportedChild {
+	if (React.Children.count(children) !== 1) {
+		throw new Error(
+			'<OctaneCompat> expects exactly one Octane component element child; received ' +
+				`${React.Children.count(children)} children.`,
+		);
+	}
+	if (!React.isValidElement(children)) {
+		throw new Error('<OctaneCompat> expects an Octane component element, not a plain renderable.');
+	}
+	const type = children.type as unknown;
+	if (typeof type !== 'function') {
+		throw new Error(
+			`<OctaneCompat> cannot host ${describeChildType(type)}; ` +
+				'pass one compiled Octane component. (memo/forwardRef/lazy wrappers are React-only ' +
+				'element types — use Octane memo()/lazy() inside the island instead.)',
+		);
+	}
+	if (process.env.NODE_ENV !== 'production') {
+		// A class component is provably a React-only component. A PLAIN function
+		// cannot be distinguished from a prod-compiled or plain-TS Octane
+		// component today (the compiler does not yet emit a runtime brand), so
+		// unbranded plain functions are accepted; passing an ordinary React
+		// function component here fails inside the island when it calls React
+		// hooks against the Octane runtime.
+		if ((type as { prototype?: { isReactComponent?: unknown } }).prototype?.isReactComponent) {
+			throw new Error(
+				`<OctaneCompat> cannot host ${describeChildType(type)}: class components are ` +
+					'React-only; pass one compiled Octane component.',
+			);
+		}
+	}
+	return {
+		type: type as unknown as ComponentBody,
+		props: (children.props ?? {}) as Record<string, unknown>,
+		key: children.key ?? null,
+	};
+}

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -3080,7 +3080,9 @@ function readContext<T>(ctx: Context<T>): T {
 }
 
 export function useContext<T>(ctx: Context<T>): T {
-	return readContext(ctx);
+	if (ctx && (ctx as any).$$kind === CONTEXT_TAG) return readContext(ctx);
+	// Same cold foreign-context path as `use()` (§6.4).
+	return readHostedForeignContext(ctx, 'useContext');
 }
 
 // Sentinel thrown by `use(thenable)` on the server when the value isn't resolved
@@ -3284,6 +3286,11 @@ function recordHydrationRejection(reason: unknown): void {
 export function use<T>(usable: Context<T> | PromiseLike<T>, siteKey?: symbol | string): T;
 export function use<T>(usable: Context<T> | PromiseLike<T>, siteKey?: ServerHookSlot): T {
 	if (usable && (usable as any).$$kind === CONTEXT_TAG) return readContext(usable as Context<T>);
+	if (usable == null || typeof (usable as any).then !== 'function') {
+		// Cold path: a FOREIGN host context inside a hosted server pass reads
+		// through the installed host hook (§6.4); anything else diagnoses.
+		return readHostedForeignContext(usable, 'use');
+	}
 	// A thenable. Key it by the current FRAME path + the compiler-injected
 	// call-site key + a per-frame occurrence index (so a use() inside an @for gets
 	// a distinct key per iteration). Scoping to the frame makes the key identical
@@ -4920,6 +4927,142 @@ export async function prerender(
 ): Promise<RenderResult> {
 	const nonceAttr = nonceAttrOf(options);
 	return passToResult(await runBuffered(component, props, options, nonceAttr), nonceAttr);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Hosted server rendering — react-hosted-octane-compat-plan.md §9.1.
+//
+// A React host (octane/react/server) runs one SYNCHRONOUS hosted attempt per
+// Fizz task execution, inside the React component render. The session — kept
+// by the host, keyed on Fizz's replay-stable task identity — persists the
+// resolved/parallel-use maps across that island's Fizz retries, so a replayed
+// pass reuses puMemo's original thenables and every settled outcome replays
+// synchronously. An unhandled suspension is NOT awaited here: the attempt
+// returns one identity-stable, status-stamped STRATUM aggregate that records
+// outcomes into the session as they settle; the host delegates the wait to
+// `React.use(stratum)` (Fizz's positional replay state — Phase 0 evidence).
+// Do NOT call public renderToString for this: its bare-root suspension
+// contract returns partial output and a fresh resolved map per call.
+// ═══════════════════════════════════════════════════════════════════════════
+
+// Read hook for FOREIGN host contexts during a hosted pass (§6.4): the server
+// wrapper reads React contexts directly (React.use) — no mirror or registry.
+let HOSTED_FOREIGN_CONTEXT_READER: ((context: object) => unknown) | null = null;
+
+function readHostedForeignContext<T>(usable: unknown, api: string): T {
+	if (usable !== null && typeof usable === 'object' && HOSTED_FOREIGN_CONTEXT_READER !== null) {
+		return HOSTED_FOREIGN_CONTEXT_READER(usable as object) as T;
+	}
+	throw new Error(`${api}(): argument is not a Context nor a thenable`);
+}
+
+/** @internal hosted-host ABI. Opaque outside octane/react/server. */
+export interface HostedServerSession {
+	resolved: ResolvedMap;
+	/** Identity-stable settled-work aggregates, one per suspension stratum. */
+	strata: (PromiseLike<void> & { status?: string })[];
+}
+
+/** @internal hosted-host ABI. */
+export function createHostedServerSession(): HostedServerSession {
+	return { resolved: newResolvedMap(), strata: [] };
+}
+
+export interface HostedAttemptOptions {
+	identifierPrefix?: string;
+	/** CSP nonce for inline seed scripts (same contract as RenderOptions.nonce). */
+	nonce?: string;
+	readForeignContext?: (context: object) => unknown;
+}
+
+export type HostedAttemptResult =
+	| {
+			status: 'complete';
+			html: string;
+			/** Hoisted head output — the host must translate or reject it (§9.2). */
+			head: string;
+			/** Per-hash scoped stylesheets for host-level dedupe (§9.2). */
+			cssEntries: Map<string, string>;
+	  }
+	| { status: 'suspended'; stratum: PromiseLike<void> };
+
+/**
+ * One stratum recorder: settles every suspended job into the session maps
+ * (both string-keyed and thenable-identity parallel-use outcomes), never
+ * rejects, and stamps its own status in place so a Fizz replay's
+ * `React.use(stratum)` unwraps settled strata synchronously.
+ * @internal hosted-host ABI.
+ */
+function recordHostedStratum(
+	suspended: SuspendedList,
+	resolved: ResolvedMap,
+): PromiseLike<void> & { status?: string; value?: unknown } {
+	const pu = resolved.pu;
+	const recorders = suspended.map(({ promise, key }) =>
+		(async () => {
+			const isPu = key.startsWith('|pu#');
+			try {
+				const value = await promise;
+				if (!resolved.has(key)) resolved.set(key, { value });
+				if (isPu && !pu.resolvedT.has(promise)) pu.resolvedT.set(promise, { value });
+			} catch (reason) {
+				if (!resolved.has(key)) resolved.set(key, { reason });
+				if (isPu && !pu.resolvedT.has(promise)) pu.resolvedT.set(promise, { reason });
+			}
+		})(),
+	);
+	const aggregate = Promise.all(recorders).then(() => {
+		aggregate.status = 'fulfilled';
+		aggregate.value = undefined;
+	}) as Promise<void> & { status?: string; value?: unknown };
+	aggregate.status = 'pending';
+	return aggregate;
+}
+
+/**
+ * Run ONE synchronous hosted pass against a persistent session. Complete
+ * passes return body HTML (suspense seeds appended, view-transition residue
+ * stripped) plus separated head/css channels; a suspended pass registers and
+ * returns its stratum. Unhandled render ERRORS throw out of this call — the
+ * host lets them escape to Fizz (§9.1).
+ * @internal hosted-host ABI.
+ */
+export function renderHostedAttempt(
+	session: HostedServerSession,
+	component: ServerComponent,
+	props: any,
+	options?: HostedAttemptOptions,
+): HostedAttemptResult {
+	const nonceAttr = nonceAttrOf(options as RenderOptions | undefined);
+	const previousReader = HOSTED_FOREIGN_CONTEXT_READER;
+	HOSTED_FOREIGN_CONTEXT_READER = options?.readForeignContext ?? null;
+	let pass: FullPassResult;
+	try {
+		pass = withStream(null, () =>
+			runFullFramedPass(
+				component,
+				props,
+				session.resolved,
+				nonceAttr,
+				options?.identifierPrefix ?? '',
+			),
+		);
+	} finally {
+		HOSTED_FOREIGN_CONTEXT_READER = previousReader;
+	}
+	// Delegate to the host ONLY for a bare suspension that escaped the root.
+	// A suspension OWNED by a local @try ships its @pending arm in this pass's
+	// HTML (the §9.1 v1 contract: hydration/client retry completes it), so the
+	// island is complete from the host's perspective.
+	if (pass.rootSuspended) {
+		const stratum = recordHostedStratum(pass.suspended, session.resolved);
+		session.strata.push(stratum);
+		return { status: 'suspended', stratum };
+	}
+	let body = pass.body;
+	if (pass.serial.length > 0) body += serializeSuspenseSeeds(pass.serial, nonceAttr);
+	if (pass.vtCandidates) body = vtSsrStrip(body);
+	return { status: 'complete', html: body, head: pass.head, cssEntries: pass.cssEntries };
 }
 
 /**

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -19149,9 +19149,15 @@ export function hydrateRoot(
 			unmountBlock(rootBlock, false);
 			drainRefDetaches();
 			container.textContent = '';
+			// Mirror root.unmount()'s full release: this pass registered the
+			// container as a delegation target, and the retry's fresh root
+			// re-registers — a leftover refcount would strand the map entry and
+			// its listeners past the island's final teardown.
+			unregisterDelegationTarget(container);
 			releaseRootContainer(container, ownerToken);
 		}
-		// Routed: hand back an empty lazy root; the owner's retry recreates.
+		// Routed: hand back an empty lazy root owning NO claim or delegation
+		// registration (both released above); the owner's retry recreates.
 		return makeRoot(container, null, null, null, idState, renderReturnedValue, null);
 	} finally {
 		currentHydration = previousHydration;

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -19133,6 +19133,26 @@ export function hydrateRoot(
 		// anything left at the root cursor instead of leaving visible unmanaged DOM.
 		hydration.finishRoot();
 		hydrationCompleted = true;
+	} catch (error) {
+		// An OWNED hydrating root (a renderer-region bridge bound during this
+		// pass — e.g. an octane/react island) mirrors createRoot's initial-render
+		// contract: route the escape (error, suspension, or host context request)
+		// to the owner, unmount the failed root, and release the container so a
+		// host retry binds a FRESH root (§5 rule 9 — adoption is abandoned, the
+		// retry client-remounts). Unowned hydration failures keep their existing
+		// behavior and rethrow untouched.
+		if (rendererRegionOwnerForBlock(rootBlock) === null) throw error;
+		try {
+			handleRenderError(rootBlock, error);
+		} finally {
+			DOM_ROOT_DISPOSERS.delete(rootBlock);
+			unmountBlock(rootBlock, false);
+			drainRefDetaches();
+			container.textContent = '';
+			releaseRootContainer(container, ownerToken);
+		}
+		// Routed: hand back an empty lazy root; the owner's retry recreates.
+		return makeRoot(container, null, null, null, idState, renderReturnedValue, null);
 	} finally {
 		currentHydration = previousHydration;
 	}

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -14439,6 +14439,10 @@ export function tryBlock(
 			releaseHeldTransition(s);
 			s.pendingThenable = null;
 		} catch (err) {
+			// §6.3 control signal — never an application failure: pass it through
+			// so the renderer-region owner (handleRenderError) receives it; a
+			// local catch arm must not render a hosted context handshake.
+			if (isHostContextRequest(err)) throw err;
 			if (isSuspenseException(err)) {
 				if (s.propagateSuspense) throw err;
 				handleSuspense(s, err.thenable, s.tryBlock);
@@ -14574,6 +14578,9 @@ function mountTry(state: TrySlot): void {
 		renderBlock(b);
 		state.hasResolved = true;
 	} catch (err) {
+		// §6.3 control signal — bypass the local boundary (see the try-body
+		// re-render catch above); the renderer-region owner handles it.
+		if (isHostContextRequest(err)) throw err;
 		if (isSuspenseException(err)) {
 			if (state.propagateSuspense) throw err;
 			handleSuspense(state, err.thenable, b);

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -4952,15 +4952,18 @@ export function bindRendererRegionOwner(props: unknown): void {
 		);
 	}
 	const root = CURRENT_BLOCK;
-	const disposeRoot = DOM_ROOT_DISPOSERS.get(root);
-	if (disposeRoot === undefined) {
+	// hydrateRoot() runs its adoption pass BEFORE the Root object (and its
+	// disposer) exists, so a hydrating owned root is bound with a LAZY disposer
+	// lookup; every other caller must already have a live root.
+	if (DOM_ROOT_DISPOSERS.get(root) === undefined && currentHydration?.rootBlock !== root) {
 		throw new Error('A renderer-owned DOM region requires a live DOM root.');
 	}
 	const previous = RENDERER_REGION_DOM_BINDINGS.get(root);
 	if (previous?.bridge === bridge) return;
 	// A distinct callback avoids deleting a newly-registered disposer when two
-	// successive descriptor bridges share one committed lifecycle cell.
-	const dispose = () => disposeRoot();
+	// successive descriptor bridges share one committed lifecycle cell. The
+	// lookup is lazy so a disposer registered after a hydration pass is honored.
+	const dispose = () => DOM_ROOT_DISPOSERS.get(root)?.();
 	const release = bridge.registerDispose(dispose);
 	previous?.release();
 	const binding = { bridge, release };
@@ -8644,10 +8647,16 @@ export function namespaceHeadElement(
 export function injectStyle(id: string, css: string): void {
 	if (_injectedStyles.has(id)) return;
 	// SSR de-dup: the server already emitted this scoped stylesheet (the css of
-	// the RenderResult, a `<style data-octane="hash">`). On a hydrated page
-	// the per-runtime Set is empty, so also check the DOM before re-injecting —
-	// otherwise hydration would append a duplicate <style>.
-	if (typeof document !== 'undefined' && document.querySelector(`style[data-octane="${id}"]`)) {
+	// the RenderResult, a `<style data-octane="hash">` — or, for a React-hosted
+	// island, a React 19 style RESOURCE whose href React serializes as
+	// `data-href="octane-<hash>"`; React drops other attributes from hoisted
+	// resources). On a hydrated page the per-runtime Set is empty, so also
+	// check the DOM before re-injecting — otherwise hydration would append a
+	// duplicate <style>.
+	if (
+		typeof document !== 'undefined' &&
+		document.querySelector(`style[data-octane="${id}"], style[data-href="octane-${id}"]`)
+	) {
 		_injectedStyles.add(id);
 		return;
 	}

--- a/packages/octane/tests/react-hosted/_fixtures/islands.tsrx
+++ b/packages/octane/tests/react-hosted/_fixtures/islands.tsrx
@@ -1,4 +1,12 @@
-import { bindRendererRegionOwner, memo, use, useId, useLayoutEffect, useState } from 'octane';
+import {
+	bindRendererRegionOwner,
+	memo,
+	use,
+	useEffect,
+	useId,
+	useLayoutEffect,
+	useState,
+} from 'octane';
 import { MirrorLocale, MirrorTheme } from './mirror-context.js';
 
 /**
@@ -181,4 +189,31 @@ export function RenderLogIsland(props) @{
 export function UseIdIsland() @{
 	const id = useId();
 	<p class="use-id" data-oid={id}>{'id island'}</p>
+}
+
+/** Effect faults on demand: layout setup and passive setup, keyed by props. */
+export function EffectFaultIsland(props) @{
+	useLayoutEffect(() => {
+		if (props.layoutBoom) throw new Error('island layout setup exploded');
+	}, [props.layoutBoom]);
+	useEffect(() => {
+		if (props.passiveBoom) throw new Error('island passive setup exploded');
+	}, [props.passiveBoom]);
+	<p class="effect-fault">
+		{'armed:' + props.label}
+	</p>
+}
+
+/** Octane-local state PLUS a root-escaping suspension — prior-content episodes. */
+export function StatefulSuspendingIsland(props) @{
+	const [count, setCount] = useState(0);
+	const value = use(props.resource);
+	<div class="ss-island">
+		<button class="ss-count" onClick={() => setCount(count + 1)}>
+			{'count:' + count}
+		</button>
+		<p class="ss-value">
+			{'value:' + value as string}
+		</p>
+	</div>
 }

--- a/packages/octane/tests/react-hosted/_fixtures/react-context-islands.tsrx
+++ b/packages/octane/tests/react-hosted/_fixtures/react-context-islands.tsrx
@@ -81,3 +81,30 @@ export function ThemeAndResourceIsland(props) @{
 		{theme + ':' + value as string}
 	</p>
 }
+
+function GuardedReader(props) @{
+	const theme =
+		props.read === false ? '(off)' : use(HostTheme);
+	<p class="guard-theme">
+		{'theme:' + theme as string}
+	</p>
+}
+
+/**
+ * Foreign read INSIDE a local Octane boundary: the §6.3 control signal must
+ * bypass the island's own @pending/@catch arms on BOTH try paths (initial
+ * mount and try-body re-render — `props.read` flips the read on after commit).
+ */
+export function GuardedHostThemeIsland(props) @{
+	<div class="guarded-host">
+		@try {
+			<GuardedReader read={props.read} />
+		} @pending {
+			<p class="guard-pending">{'guard pending'}</p>
+		} @catch (error) {
+			<p class="guard-caught">
+				{'caught:' + String(error)}
+			</p>
+		}
+	</div>
+}

--- a/packages/octane/tests/react-hosted/_fixtures/ssr-head-hoister.tsrx
+++ b/packages/octane/tests/react-hosted/_fixtures/ssr-head-hoister.tsrx
@@ -1,0 +1,7 @@
+/** Hoists a <title> from island content — the §9.2 rejection case. */
+export function SsrHeadHoister() @{
+	<div class="ssr-head">
+		<title>{'island title'}</title>
+		{'head hoister'}
+	</div>
+}

--- a/packages/octane/tests/react-hosted/_fixtures/ssr-islands.tsrx
+++ b/packages/octane/tests/react-hosted/_fixtures/ssr-islands.tsrx
@@ -1,4 +1,4 @@
-import { use, useId, useState } from 'octane';
+import { use, useId, useLayoutEffect, useRef, useState } from 'octane';
 
 /**
  * Phase 4 islands, compiled BOTH ways: the client project imports this module
@@ -86,6 +86,16 @@ function SsrInner(props) @{
 	<p class="ssr-inner">
 		{'value:' + value as string}
 	</p>
+}
+
+/** Stamps its DOM from a layout effect — observable only if island layout
+ *  effects complete inside the React layout commit that attached the island. */
+export function SsrLayout() @{
+	const ref = useRef(null);
+	useLayoutEffect(() => {
+		ref.current?.setAttribute('data-laid-out', 'yes');
+	});
+	<p class="ssr-layout" ref={ref}>{'layout'}</p>
 }
 
 /** Scoped style — exercises the §9.2 style-resource channel. */

--- a/packages/octane/tests/react-hosted/_fixtures/ssr-islands.tsrx
+++ b/packages/octane/tests/react-hosted/_fixtures/ssr-islands.tsrx
@@ -1,0 +1,101 @@
+import { use, useId, useState } from 'octane';
+
+/**
+ * Phase 4 islands, compiled BOTH ways: the client project imports this module
+ * normally; the SSR tests run it through `loadServerFixture` (which forbids
+ * sibling imports — so React contexts and fetch factories arrive via props).
+ */
+
+export function SsrGreeting(props) @{
+	const [count, setCount] = useState(0);
+	<section class="ssr-island">
+		<h3 class="ssr-title">
+			{'island ' + props.name}
+		</h3>
+		<button class="ssr-count" onClick={() => setCount(count + 1)}>
+			{'clicks:' + count}
+		</button>
+	</section>
+}
+
+export function SsrIdIsland() @{
+	const id = useId();
+	<p class="ssr-id" data-oid={id}>{'id island'}</p>
+}
+
+/** Reads a REAL React context object handed through props (§6.4 on the server). */
+export function SsrThemed(props) @{
+	const theme = use(props.themeContext);
+	<p class="ssr-theme">
+		{'theme:' + theme as string}
+	</p>
+}
+
+export function SsrAsync(props) @{
+	props.log?.('render:async');
+	const value = use(props.resource);
+	<p class="ssr-async">
+		{'value:' + value as string}
+	</p>
+}
+
+/** Two sequential strata: the second fetch exists only once the first resolved. */
+export function SsrChained(props) @{
+	props.log?.('render:chained');
+	const first = use(props.first);
+	const second = use(props.makeSecond(first));
+	<p class="ssr-chained">
+		{first as string + '+' + second as string}
+	</p>
+}
+
+/** Two INDEPENDENT fetch creations — the parallel-use stratum shape. */
+export function SsrParallel(props) @{
+	props.log?.('render:parallel');
+	const first = use(props.fetchA());
+	const second = use(props.fetchB());
+	<p class="ssr-parallel">
+		{first as string + '+' + second as string}
+	</p>
+}
+
+export function SsrRejecting(props) @{
+	const value = use(props.resource);
+	<p class="ssr-rejecting">
+		{'value:' + value as string}
+	</p>
+}
+
+/** A local @try: its @pending arm ships in the shell; the client completes it. */
+export function SsrLocallyGuarded(props) @{
+	<div class="ssr-guarded">
+		@try {
+			<SsrInner resource={props.resource} />
+		} @pending {
+			<p class="ssr-local-pending">{'local pending'}</p>
+		} @catch (error) {
+			<p class="ssr-local-caught">
+				{'caught:' + (error as Error).message}
+			</p>
+		}
+	</div>
+}
+
+function SsrInner(props) @{
+	const value = use(props.resource);
+	<p class="ssr-inner">
+		{'value:' + value as string}
+	</p>
+}
+
+/** Scoped style — exercises the §9.2 style-resource channel. */
+export function SsrStyled(props) @{
+	<p class="ssr-styled">
+		{'styled ' + props.name}
+		<style>
+			.ssr-styled {
+				color: rgb(1, 2, 3);
+			}
+		</style>
+	</p>
+}

--- a/packages/octane/tests/react-hosted/octane-compat-context.test.ts
+++ b/packages/octane/tests/react-hosted/octane-compat-context.test.ts
@@ -21,6 +21,7 @@ import { h, mountReactHost, reactAct, SpikeErrorBoundary } from './_react-host.j
 import {
 	ConditionalHostReadIsland,
 	DuplicateReadIsland,
+	GuardedHostThemeIsland,
 	HostThemeIsland,
 	HostThemeViaUseContextIsland,
 	LoggingHostThemeIsland,
@@ -362,6 +363,48 @@ describe('octane/react — §6.3 HostContextRequest fallback', () => {
 			),
 		);
 		expect(mounted.host().querySelector('.two-host')?.textContent).toBe('t:hs-t l:hs-l');
+		await mounted.unmount();
+	});
+
+	it('bypasses a local @try boundary on INITIAL mount — providerless read lands the default', async () => {
+		// The reader sits inside the island's own @try with @pending and @catch
+		// arms. A providerless first read raises the §6.3 request from the
+		// mountTry path; the signal must reach the owner, never a local arm.
+		const mounted = await mountReactHost(
+			h(OctaneCompat, null, h(GuardedHostThemeIsland as any, { read: true })),
+		);
+		expect(mounted.host().querySelector('.guard-theme')?.textContent).toBe(
+			'theme:host-theme-default',
+		);
+		expect(mounted.host().querySelector('.guard-caught')).toBeNull();
+		expect(mounted.host().querySelector('.guard-pending')).toBeNull();
+		await mounted.unmount();
+	});
+
+	it('bypasses a local @try boundary when the first read appears on a try-body RE-RENDER', async () => {
+		// The try body commits WITHOUT a context read, then a prop flip makes the
+		// re-render path raise the request — the in-place try re-render catch
+		// must also pass the signal through instead of switching to @catch.
+		__setHostFiberAdapterEnabled(false);
+		let setTheme!: (value: string) => void;
+		function App(props: { read: boolean }) {
+			const [theme, set] = React.useState('g0');
+			setTheme = set;
+			return themed(
+				theme,
+				h(OctaneCompat, null, h(GuardedHostThemeIsland as any, { read: props.read })),
+			);
+		}
+		const mounted = await mountReactHost(h(App, { read: false }));
+		expect(mounted.host().querySelector('.guard-theme')?.textContent).toBe('theme:(off)');
+
+		await mounted.render(h(App, { read: true }));
+		expect(mounted.host().querySelector('.guard-theme')?.textContent).toBe('theme:g0');
+		expect(mounted.host().querySelector('.guard-caught')).toBeNull();
+
+		// The handshake installed a real subscription through the boundary.
+		await reactAct(async () => setTheme('g1'));
+		expect(mounted.host().querySelector('.guard-theme')?.textContent).toBe('theme:g1');
 		await mounted.unmount();
 	});
 

--- a/packages/octane/tests/react-hosted/octane-compat-failure-matrix.test.ts
+++ b/packages/octane/tests/react-hosted/octane-compat-failure-matrix.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Phase 3 completion — the §13 failure-matrix breadth through the public
+ * `octane/react` surface (react-hosted-octane-compat-plan.md §7, §14 Phase 3):
+ * commit-phase fault routing (layout/passive/ref), update suspensions over
+ * committed content, and transition-originated episodes.
+ *
+ * The §7 supersession decision (open question 16) pinned here: context/prop
+ * snapshots that change during a pending episode publish at REVEAL time — the
+ * suspended wrapper re-renders with fresh values but keeps throwing the same
+ * relay; when the Octane retry commits, the wrapper completes and its layout
+ * publish supersedes the episode-start snapshot before paint.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import * as React from 'react';
+import { OctaneCompat } from 'octane/react';
+import { drainPassiveEffects } from '../../src/index.js';
+import { h, mountReactHost, reactAct, SpikeErrorBoundary } from './_react-host.js';
+import { EffectFaultIsland, RefIsland, StatefulSuspendingIsland } from './_fixtures/islands.tsrx';
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((done) => {
+		resolve = done;
+	});
+	return { promise, resolve };
+}
+
+function caughtBoundary(children: React.ReactNode, sink: { message: string | null }) {
+	return h(
+		SpikeErrorBoundary,
+		{
+			fallback: (error: unknown) => {
+				sink.message = (error as Error).message;
+				return h('p', { className: 'react-caught' }, 'caught');
+			},
+		} as any,
+		children,
+	);
+}
+
+describe('octane/react — commit-phase fault routing (§13)', () => {
+	it('routes an island layout-effect SETUP fault to the React error boundary', async () => {
+		const quiet = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			const sink = { message: null as string | null };
+			function App(props: { boom: boolean }) {
+				return caughtBoundary(
+					h(
+						OctaneCompat,
+						null,
+						h(EffectFaultIsland as any, { label: 'layout', layoutBoom: props.boom }),
+					),
+					sink,
+				);
+			}
+			const mounted = await mountReactHost(h(App, { boom: false }));
+			expect(mounted.host().querySelector('.effect-fault')).not.toBeNull();
+
+			await mounted.render(h(App, { boom: true }));
+			expect(sink.message).toBe('island layout setup exploded');
+			expect(mounted.container.querySelector('.react-caught')).not.toBeNull();
+			await mounted.unmount();
+		} finally {
+			quiet.mockRestore();
+		}
+	});
+
+	it('routes an island passive-effect SETUP fault to the React error boundary', async () => {
+		const quiet = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			const sink = { message: null as string | null };
+			function App(props: { boom: boolean }) {
+				return caughtBoundary(
+					h(
+						OctaneCompat,
+						null,
+						h(EffectFaultIsland as any, { label: 'passive', passiveBoom: props.boom }),
+					),
+					sink,
+				);
+			}
+			const mounted = await mountReactHost(h(App, { boom: false }));
+			await mounted.render(h(App, { boom: true }));
+			// Passive effects run post-paint; drain them so the fault routes now.
+			await reactAct(async () => drainPassiveEffects());
+			expect(sink.message).toBe('island passive setup exploded');
+			await mounted.unmount();
+		} finally {
+			quiet.mockRestore();
+		}
+	});
+
+	it('routes a throwing child ref attachment to the React error boundary', async () => {
+		const quiet = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			const sink = { message: null as string | null };
+			const mounted = await mountReactHost(
+				caughtBoundary(
+					h(
+						OctaneCompat,
+						null,
+						h(RefIsland as any, {
+							ref: (element: Element | null) => {
+								if (element !== null) throw new Error('island ref exploded');
+							},
+						}),
+					),
+					sink,
+				),
+			);
+			expect(sink.message).toBe('island ref exploded');
+			expect(mounted.container.querySelector('.react-caught')).not.toBeNull();
+			await mounted.unmount();
+		} finally {
+			quiet.mockRestore();
+		}
+	});
+});
+
+describe('octane/react — episodes over committed content (§7)', () => {
+	it('hides prior content behind the React fallback on a sync update suspension and preserves island state', async () => {
+		const first = { status: 'fulfilled' as const, value: 'one', then() {} };
+		const second = deferred<string>();
+		function App(props: { resource: unknown }) {
+			return h(
+				React.Suspense,
+				{ fallback: h('p', { className: 'react-fallback' }, 'react pending') },
+				h(OctaneCompat, null, h(StatefulSuspendingIsland as any, { resource: props.resource })),
+			);
+		}
+		const mounted = await mountReactHost(h(App, { resource: first }));
+		const host = mounted.host();
+		await reactAct(async () => (host.querySelector('.ss-count') as HTMLElement).click());
+		expect(host.querySelector('.ss-count')?.textContent).toBe('count:1');
+
+		// Sync (non-transition) update suspends: React refallbacks, the committed
+		// Octane DOM is hidden — not torn down.
+		await mounted.render(h(App, { resource: second.promise }));
+		expect(mounted.container.querySelector('.react-fallback')).not.toBeNull();
+		expect(host.isConnected).toBe(true);
+		expect(host.style.display).toBe('none');
+
+		await reactAct(async () => {
+			second.resolve('two');
+			await second.promise;
+		});
+		expect(mounted.container.querySelector('.react-fallback')).toBeNull();
+		expect(host.querySelector('.ss-value')?.textContent).toBe('value:two');
+		// Octane-local state survived the whole episode.
+		expect(host.querySelector('.ss-count')?.textContent).toBe('count:1');
+		await mounted.unmount();
+	});
+
+	it('refallbacks on a transition-originated episode (v1 divergence) without tearing prior content', async () => {
+		const first = { status: 'fulfilled' as const, value: 'held', then() {} };
+		const second = deferred<string>();
+		let setResource!: (resource: unknown) => void;
+		function App() {
+			const [resource, set] = React.useState<unknown>(first);
+			setResource = set;
+			return h(
+				React.Suspense,
+				{ fallback: h('p', { className: 'react-fallback' }, 'react pending') },
+				h(OctaneCompat, null, h(StatefulSuspendingIsland as any, { resource })),
+			);
+		}
+		const mounted = await mountReactHost(h(App));
+		const host = mounted.host();
+		expect(host.querySelector('.ss-value')?.textContent).toBe('value:held');
+
+		// OCTANE DIVERGENCE (v1, plan §2 non-goal / open question 9): the
+		// transition commits the new props first; the island's suspension then
+		// surfaces from the layout-phase hosted flush as a NEW sync update, so
+		// the boundary refallbacks — unlike a pure React tree, where the
+		// transition itself would suspend and hold old content. Cross-renderer
+		// transition entanglement (ReactSharedInternals.T) is deferred; what v1
+		// guarantees is no tearing: prior DOM/state preserved under the fallback.
+		await reactAct(async () => {
+			React.startTransition(() => setResource(second.promise));
+		});
+		expect(mounted.container.querySelector('.react-fallback')).not.toBeNull();
+		expect(host.isConnected).toBe(true);
+		expect(host.querySelector('.ss-value')?.textContent).toBe('value:held');
+
+		await reactAct(async () => {
+			second.resolve('arrived');
+			await second.promise;
+		});
+		expect(mounted.container.querySelector('.react-fallback')).toBeNull();
+		expect(host.querySelector('.ss-value')?.textContent).toBe('value:arrived');
+		await mounted.unmount();
+	});
+});

--- a/packages/octane/tests/react-hosted/octane-compat-ssr.test.ts
+++ b/packages/octane/tests/react-hosted/octane-compat-ssr.test.ts
@@ -1,0 +1,411 @@
+/**
+ * Phase 4 — React SSR and island hydration
+ * (react-hosted-octane-compat-plan.md §9, §14 Phase 4).
+ *
+ * The SAME `.tsrx` islands run through `octane/react/server` inside real React
+ * server rendering (`renderToString` and Fizz streaming), then hydrate through
+ * the public client `OctaneCompat`. jsdom covers the DOM-identity, parity, and
+ * retry-state evidence; real-browser E2E re-verifies paint-level behavior and
+ * streamed `completeBoundary` segment relocation (§13 — deferred).
+ */
+import { describe, expect, it, vi } from 'vitest';
+import * as React from 'react';
+import { renderToString as reactRenderToString, renderToPipeableStream } from 'react-dom/server';
+import { PassThrough } from 'node:stream';
+import { join } from 'node:path';
+import { OctaneCompat } from 'octane/react';
+import { OctaneCompat as OctaneCompatServer } from 'octane/react/server';
+import { loadServerFixture } from '../_server-fixture.js';
+import { createLog } from '../_helpers.js';
+import { h, mountReactHost, reactAct } from './_react-host.js';
+import {
+	SsrGreeting as ClientSsrGreeting,
+	SsrIdIsland as ClientSsrIdIsland,
+	SsrLocallyGuarded as ClientSsrLocallyGuarded,
+	SsrThemed as ClientSsrThemed,
+} from './_fixtures/ssr-islands.tsrx';
+
+const server = loadServerFixture(
+	join(process.cwd(), 'packages/octane/tests/react-hosted/_fixtures/ssr-islands.tsrx'),
+);
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((done, fail) => {
+		resolve = done;
+		reject = fail;
+	});
+	return { promise, resolve, reject };
+}
+
+function nextTurns(turns = 3): Promise<void> {
+	let chain = Promise.resolve();
+	for (let i = 0; i < turns; i++) {
+		chain = chain.then(() => new Promise<void>((resolve) => setTimeout(resolve, 0)));
+	}
+	return chain;
+}
+
+interface StreamedRender {
+	html(): string;
+	done: Promise<void>;
+	errors: unknown[];
+}
+
+function streamPage(element: React.ReactNode): StreamedRender {
+	let html = '';
+	const errors: unknown[] = [];
+	const sink = new PassThrough();
+	sink.on('data', (chunk: Buffer) => {
+		html += chunk.toString();
+	});
+	let resolveDone!: () => void;
+	const done = new Promise<void>((resolve) => {
+		resolveDone = resolve;
+	});
+	sink.on('finish', resolveDone);
+	const stream = renderToPipeableStream(element as any, {
+		onAllReady() {
+			stream.pipe(sink);
+		},
+		onError(error: unknown) {
+			errors.push(error);
+		},
+	});
+	return { html: () => html, done, errors };
+}
+
+/** Server-render a page, hand its markup to the client, hydrate with React. */
+async function hydratePage(
+	serverElement: React.ReactNode,
+	clientElement: React.ReactNode,
+): Promise<Awaited<ReturnType<typeof mountReactHost>> & { serverHtml: string }> {
+	const serverHtml = reactRenderToString(serverElement as any);
+	const container = document.createElement('div');
+	container.innerHTML = serverHtml;
+	document.body.appendChild(container);
+	const { hydrateRoot } = await import('react-dom/client');
+	let reactRoot!: ReturnType<typeof hydrateRoot>;
+	await reactAct(async () => {
+		reactRoot = hydrateRoot(container, clientElement as any);
+	});
+	return {
+		container,
+		reactRoot: reactRoot as never,
+		serverHtml,
+		async render(next: React.ReactNode) {
+			await reactAct(async () => reactRoot.render(next as any));
+		},
+		async unmount() {
+			await reactAct(async () => reactRoot.unmount());
+			container.remove();
+		},
+		host() {
+			const host = container.querySelector('[data-octane-compat]');
+			if (host === null) throw new Error('no octane compat host mounted');
+			return host as HTMLElement;
+		},
+	};
+}
+
+describe('octane/react/server — buffered SSR + client hydration (§9.3)', () => {
+	it('server-renders an island and hydrates it with adopted node identity, state, and events', async () => {
+		const serverPage = h(
+			'main',
+			null,
+			h(OctaneCompatServer, null, h(server.SsrGreeting, { name: 'iso' })),
+		);
+		const clientPage = h(
+			'main',
+			null,
+			h(OctaneCompat, null, h(ClientSsrGreeting as any, { name: 'iso' })),
+		);
+
+		const errors = vi.spyOn(console, 'error');
+		const mounted = await hydratePage(serverPage, clientPage);
+		// The server host carries real island HTML.
+		expect(mounted.serverHtml).toContain('island iso');
+		const host = mounted.host();
+		const serverButton = host.querySelector('.ssr-count');
+		expect(serverButton?.textContent).toBe('clicks:0');
+
+		// No hydration mismatch from React OR octane, no descendant rebuild.
+		expect(errors).not.toHaveBeenCalled();
+		errors.mockRestore();
+		expect(host.querySelector('.ssr-count')).toBe(serverButton);
+
+		// Adopted events + state are live.
+		await reactAct(async () => (serverButton as HTMLElement).click());
+		expect(host.querySelector('.ssr-count')?.textContent).toBe('clicks:1');
+		await mounted.unmount();
+	});
+
+	it('hydrates Octane useId values byte-identically to the server output', async () => {
+		const serverPage = h(
+			'main',
+			null,
+			h(OctaneCompatServer, { key: 'a' } as any, h(server.SsrIdIsland)),
+			h(OctaneCompatServer, { key: 'b' } as any, h(server.SsrIdIsland)),
+		);
+		const clientPage = h(
+			'main',
+			null,
+			h(OctaneCompat, { key: 'a' } as any, h(ClientSsrIdIsland as any)),
+			h(OctaneCompat, { key: 'b' } as any, h(ClientSsrIdIsland as any)),
+		);
+		const mounted = await hydratePage(serverPage, clientPage);
+		const serverIds = [...mounted.serverHtml.matchAll(/data-oid="([^"]+)"/g)].map(
+			(match) => match[1],
+		);
+		expect(serverIds).toHaveLength(2);
+		expect(serverIds[0]).not.toBe(serverIds[1]);
+		const hydratedIds = [...mounted.container.querySelectorAll('.ssr-id')].map((node) =>
+			node.getAttribute('data-oid'),
+		);
+		expect(hydratedIds).toEqual(serverIds);
+		await mounted.unmount();
+	});
+
+	it('reads a React context on the server via React.use and stays live after hydration', async () => {
+		const Theme = React.createContext('unset');
+		const serverPage = h(
+			Theme,
+			{ value: 'ssr-dark' } as any,
+			h(OctaneCompatServer, null, h(server.SsrThemed, { themeContext: Theme })),
+		);
+		function ClientPage(props: { theme: string }) {
+			return h(
+				Theme,
+				{ value: props.theme } as any,
+				h(OctaneCompat, null, h(ClientSsrThemed as any, { themeContext: Theme })),
+			);
+		}
+		const mounted = await hydratePage(serverPage, h(ClientPage, { theme: 'ssr-dark' }));
+		expect(mounted.serverHtml).toContain('theme:ssr-dark');
+		expect(mounted.host().querySelector('.ssr-theme')?.textContent).toBe('theme:ssr-dark');
+
+		// The hydrated island holds a REAL subscription.
+		await mounted.render(h(ClientPage, { theme: 'ssr-light' }));
+		expect(mounted.host().querySelector('.ssr-theme')?.textContent).toBe('theme:ssr-light');
+		await mounted.unmount();
+	});
+
+	it('ships a local @pending arm in the shell and lets the client complete it (v1 §9.1)', async () => {
+		const never = new Promise<string>(() => {});
+		const clientResource = deferred<string>();
+		const serverPage = h(
+			'main',
+			null,
+			h(OctaneCompatServer, null, h(server.SsrLocallyGuarded, { resource: never })),
+		);
+		const clientPage = h(
+			'main',
+			null,
+			h(
+				OctaneCompat,
+				null,
+				h(ClientSsrLocallyGuarded as any, { resource: clientResource.promise }),
+			),
+		);
+		const mounted = await hydratePage(serverPage, clientPage);
+		expect(mounted.serverHtml).toContain('local pending');
+
+		await reactAct(async () => {
+			clientResource.resolve('client-data');
+			await clientResource.promise;
+		});
+		expect(mounted.host().querySelector('.ssr-inner')?.textContent).toBe('value:client-data');
+		await mounted.unmount();
+	});
+
+	it('emits island CSS as deduplicated React style resources with octane hashes (§9.2)', async () => {
+		const html = reactRenderToString(
+			h(
+				'main',
+				null,
+				h(OctaneCompatServer, { key: '1' } as any, h(server.SsrStyled, { name: 'one' })),
+				h(OctaneCompatServer, { key: '2' } as any, h(server.SsrStyled, { name: 'two' })),
+			) as any,
+		);
+		// Two islands, identical scoped css → ONE hoisted style resource whose
+		// data-href carries the octane hash the client's injectStyle detects.
+		const styles = [...html.matchAll(/<style[^>]*data-href="octane-([^"]+)"/g)];
+		expect(styles).toHaveLength(1);
+		expect(html).toContain('rgb(1, 2, 3)');
+	});
+
+	it('rejects hoisted head content from islands (§9.2 v1) — at server COMPILE time', () => {
+		// The server compiler already refuses body-hoisted <title>/<meta>/<link>,
+		// so the case cannot reach the hosted renderer; the runtime head guard in
+		// octane/react/server stays as defense in depth.
+		expect(() =>
+			loadServerFixture(
+				join(process.cwd(), 'packages/octane/tests/react-hosted/_fixtures/ssr-head-hoister.tsrx'),
+			),
+		).toThrow(/does not support node type HeadHoist/);
+	});
+});
+
+describe('octane/react/server — Fizz streaming retry state (§9.1)', () => {
+	it('completes a suspended island through Fizz with a request-local session (no fresh-pass loop)', async () => {
+		const log = createLog();
+		const resource = deferred<string>();
+		const render = streamPage(
+			h(
+				'main',
+				null,
+				h(
+					React.Suspense,
+					{ fallback: h('p', null, 'island loading') },
+					h(
+						OctaneCompatServer,
+						null,
+						h(server.SsrAsync, { resource: resource.promise, log: log.push }),
+					),
+				),
+			),
+		);
+		await nextTurns();
+		// One pass rendered and suspended; Fizz streams the fallback meanwhile.
+		expect(log.drain()).toEqual(['render:async']);
+
+		resource.resolve('streamed');
+		await render.done;
+		expect(render.errors).toEqual([]);
+		expect(render.html()).toContain('value:streamed');
+		// Exactly one replay: the session replayed the settled stratum and the
+		// fresh pass completed — bounded, no retry spin.
+		expect(log.drain()).toEqual(['render:async']);
+	});
+
+	it('drives sequential strata with one replay per stratum', async () => {
+		const log = createLog();
+		const first = deferred<string>();
+		const seconds = new Map<string, ReturnType<typeof deferred<string>>>();
+		const makeSecond = (from: string) => {
+			let entry = seconds.get(from);
+			if (entry === undefined) {
+				entry = deferred<string>();
+				seconds.set(from, entry);
+			}
+			return entry.promise;
+		};
+		const render = streamPage(
+			h(
+				'main',
+				null,
+				h(
+					React.Suspense,
+					{ fallback: h('p', null, 'island loading') },
+					h(
+						OctaneCompatServer,
+						null,
+						h(server.SsrChained, { first: first.promise, makeSecond, log: log.push }),
+					),
+				),
+			),
+		);
+		await nextTurns();
+		expect(log.drain()).toEqual(['render:chained']);
+
+		first.resolve('A');
+		await nextTurns();
+		// Replay reached stratum 2 and suspended on the dependent fetch.
+		expect(log.drain()).toEqual(['render:chained']);
+
+		seconds.get('A')!.resolve('B');
+		await render.done;
+		expect(render.errors).toEqual([]);
+		expect(render.html()).toContain('A+B');
+		expect(log.drain()).toEqual(['render:chained']);
+	});
+
+	it('starts independent fetches together and resolves the stratum with one replay', async () => {
+		const log = createLog();
+		const fetches: string[] = [];
+		const a = deferred<string>();
+		const b = deferred<string>();
+		const fetchA = () => {
+			fetches.push('A');
+			return a.promise;
+		};
+		const fetchB = () => {
+			fetches.push('B');
+			return b.promise;
+		};
+		const render = streamPage(
+			h(
+				'main',
+				null,
+				h(
+					React.Suspense,
+					{ fallback: h('p', null, 'island loading') },
+					h(OctaneCompatServer, null, h(server.SsrParallel, { fetchA, fetchB, log: log.push })),
+				),
+			),
+		);
+		await nextTurns();
+		expect(log.drain()).toEqual(['render:parallel']);
+		// Both independent creations started in the FIRST pass (parallel-use), and
+		// the session memo keeps their identity across replays — no re-fetch.
+		expect(fetches).toEqual(['A', 'B']);
+
+		a.resolve('one');
+		b.resolve('two');
+		await render.done;
+		expect(render.errors).toEqual([]);
+		expect(render.html()).toContain('one+two');
+		expect(log.drain()).toEqual(['render:parallel']);
+		expect(fetches).toEqual(['A', 'B']);
+	});
+
+	it('routes a rejected island fetch to Fizz error handling exactly once', async () => {
+		const resource = deferred<string>();
+		const render = streamPage(
+			h(
+				'main',
+				null,
+				h(
+					React.Suspense,
+					{ fallback: h('p', null, 'island loading') },
+					h(OctaneCompatServer, null, h(server.SsrRejecting, { resource: resource.promise })),
+				),
+			),
+		);
+		await nextTurns();
+		resource.reject(new Error('island fetch failed'));
+		await render.done;
+		expect(render.errors.map((error) => (error as Error).message)).toEqual(['island fetch failed']);
+		expect(render.html()).toContain('island loading');
+		expect(render.html()).not.toContain('ssr-async');
+	});
+
+	it('keeps sessions request-local across overlapping streams', async () => {
+		const one = deferred<string>();
+		const two = deferred<string>();
+		// Distinct props objects per render = distinct Fizz-stable session keys.
+		const renderOne = streamPage(
+			h(
+				React.Suspense,
+				{ fallback: h('p', null, 'loading') },
+				h(OctaneCompatServer, null, h(server.SsrAsync, { resource: one.promise })),
+			),
+		);
+		const renderTwo = streamPage(
+			h(
+				React.Suspense,
+				{ fallback: h('p', null, 'loading') },
+				h(OctaneCompatServer, null, h(server.SsrAsync, { resource: two.promise })),
+			),
+		);
+		await nextTurns();
+		two.resolve('second');
+		one.resolve('first');
+		await Promise.all([renderOne.done, renderTwo.done]);
+		expect(renderOne.html()).toContain('value:first');
+		expect(renderTwo.html()).toContain('value:second');
+		expect(renderOne.html()).not.toContain('second');
+		expect(renderTwo.html()).not.toContain('first');
+	});
+});

--- a/packages/octane/tests/react-hosted/octane-compat-ssr.test.ts
+++ b/packages/octane/tests/react-hosted/octane-compat-ssr.test.ts
@@ -8,7 +8,7 @@
  * retry-state evidence; real-browser E2E re-verifies paint-level behavior and
  * streamed `completeBoundary` segment relocation (§13 — deferred).
  */
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import * as React from 'react';
 import { renderToString as reactRenderToString, renderToPipeableStream } from 'react-dom/server';
 import { PassThrough } from 'node:stream';
@@ -18,12 +18,17 @@ import { OctaneCompat as OctaneCompatServer } from 'octane/react/server';
 import { loadServerFixture } from '../_server-fixture.js';
 import { createLog } from '../_helpers.js';
 import { h, mountReactHost, reactAct } from './_react-host.js';
+import { __setHostFiberAdapterEnabled } from '../../src/react/fiber-adapter.js';
 import {
+	SsrAsync as ClientSsrAsync,
 	SsrGreeting as ClientSsrGreeting,
 	SsrIdIsland as ClientSsrIdIsland,
 	SsrLocallyGuarded as ClientSsrLocallyGuarded,
+	SsrStyled as ClientSsrStyled,
 	SsrThemed as ClientSsrThemed,
 } from './_fixtures/ssr-islands.tsrx';
+
+afterEach(() => __setHostFiberAdapterEnabled(true));
 
 const server = loadServerFixture(
 	join(process.cwd(), 'packages/octane/tests/react-hosted/_fixtures/ssr-islands.tsrx'),
@@ -216,6 +221,112 @@ describe('octane/react/server — buffered SSR + client hydration (§9.3)', () =
 			await clientResource.promise;
 		});
 		expect(mounted.host().querySelector('.ssr-inner')?.textContent).toBe('value:client-data');
+		await mounted.unmount();
+	});
+
+	it('abandons adoption for a §6.3 context request during hydration and client-remounts (dev diagnostic)', async () => {
+		// With the Fiber adapter unavailable, the first hydration attempt raises
+		// the request handshake. The routed escape must unwind the ADOPTION —
+		// never the React layout effect — and the retry client-remounts this
+		// island only, with the authoritative React.use value.
+		__setHostFiberAdapterEnabled(false);
+		const Theme = React.createContext('unset');
+		const warned = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		try {
+			const serverPage = h(
+				Theme,
+				{ value: 'hy-dark' } as any,
+				h(OctaneCompatServer, null, h(server.SsrThemed, { themeContext: Theme })),
+			);
+			function ClientPage(props: { theme: string }) {
+				return h(
+					Theme,
+					{ value: props.theme } as any,
+					h(OctaneCompat, null, h(ClientSsrThemed as any, { themeContext: Theme })),
+				);
+			}
+			const mounted = await hydratePage(serverPage, h(ClientPage, { theme: 'hy-dark' }));
+			expect(mounted.host().querySelector('.ssr-theme')?.textContent).toBe('theme:hy-dark');
+			expect(
+				warned.mock.calls.some((call) => String(call[0]).includes('abandoned hydration')),
+			).toBe(true);
+
+			// The remounted island holds a live subscription.
+			await mounted.render(h(ClientPage, { theme: 'hy-light' }));
+			expect(mounted.host().querySelector('.ssr-theme')?.textContent).toBe('theme:hy-light');
+			await mounted.unmount();
+		} finally {
+			warned.mockRestore();
+		}
+	});
+
+	it('keeps server content visible when a BARE root suspension interrupts hydration (v1 limitation)', async () => {
+		// The client hydrates with a still-pending resource and NO local
+		// boundary: the adoption attempt suspends, the escape routes to the
+		// owner, and React reverts the boundary to its dehydrated state — the
+		// SERVER content stays visible; nothing crashes, blanks, or errors.
+		// OCTANE DIVERGENCE (v1, recorded in the plan): React's dehydrated
+		// revert discards the wrapper attempt, orphaning the pending episode, so
+		// live completion of a bare root suspension during hydration is not
+		// guaranteed — async islands should own their pending UI with a local
+		// @try (the supported pattern, tested above with SsrLocallyGuarded).
+		const ready = { status: 'fulfilled' as const, value: 'ssr-data', then() {} };
+		const clientResource = deferred<string>();
+		const quiet = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			const serverPage = h(
+				'main',
+				null,
+				h(
+					React.Suspense,
+					{ fallback: h('p', { className: 'react-fallback' }, 'react pending') },
+					h(OctaneCompatServer, null, h(server.SsrAsync, { resource: ready })),
+				),
+			);
+			const clientPage = h(
+				'main',
+				null,
+				h(
+					React.Suspense,
+					{ fallback: h('p', { className: 'react-fallback' }, 'react pending') },
+					h(OctaneCompat, null, h(ClientSsrAsync as any, { resource: clientResource.promise })),
+				),
+			);
+			const mounted = await hydratePage(serverPage, clientPage);
+			expect(mounted.serverHtml).toContain('value:ssr-data');
+			// Server content preserved; no fallback flash, no teardown.
+			expect(mounted.container.querySelector('.react-fallback')).toBeNull();
+			expect(mounted.container.querySelector('.ssr-async')?.textContent).toBe('value:ssr-data');
+
+			await reactAct(async () => {
+				clientResource.resolve('client-data');
+				await clientResource.promise;
+			});
+			// Still standing — no crash and no blank host after the settle.
+			expect(mounted.container.querySelector('.ssr-async')).not.toBeNull();
+			await mounted.unmount();
+		} finally {
+			quiet.mockRestore();
+		}
+	});
+
+	it('hydrates a CSS-producing island without mismatch alongside hoisted style resources', async () => {
+		const errors = vi.spyOn(console, 'error');
+		const serverPage = h(
+			'main',
+			null,
+			h(OctaneCompatServer, null, h(server.SsrStyled, { name: 'hy' })),
+		);
+		const clientPage = h(
+			'main',
+			null,
+			h(OctaneCompat, null, h(ClientSsrStyled as any, { name: 'hy' })),
+		);
+		const mounted = await hydratePage(serverPage, clientPage);
+		expect(mounted.serverHtml).toContain('rgb(1, 2, 3)');
+		expect(errors).not.toHaveBeenCalled();
+		errors.mockRestore();
+		expect(mounted.host().querySelector('.ssr-styled')?.textContent).toContain('styled hy');
 		await mounted.unmount();
 	});
 

--- a/packages/octane/tests/react-hosted/octane-compat-ssr.test.ts
+++ b/packages/octane/tests/react-hosted/octane-compat-ssr.test.ts
@@ -310,6 +310,58 @@ describe('octane/react/server — buffered SSR + client hydration (§9.3)', () =
 		}
 	});
 
+	it('client-remounts an island whose UNSEEDED suspension escapes adoption (§5 rule 9)', async () => {
+		// The seeded case above never escapes: the server completed the use()
+		// and its serialized seed satisfies the client read synchronously. An
+		// UNSEEDED bare suspension — the client suspends where the server has
+		// no seed, necessarily a server/client divergence — is the path that
+		// actually escapes hydrateRoot into the owned-root routing. Adoption is
+		// abandoned: React (whose hydration commit already adopted the host)
+		// swaps the boundary to its fallback and hides the host, the runtime
+		// batch-clears the abandoned server nodes (the root.unmount() teardown
+		// sequence — never user-visible, the host is display:none), and the
+		// settle retry binds a FRESH root so the island client-remounts with
+		// live client data.
+		const clientResource = deferred<string>();
+		const quiet = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			const serverPage = h(
+				'main',
+				null,
+				h(
+					React.Suspense,
+					{ fallback: h('p', { className: 'react-fallback' }, 'react pending') },
+					h(OctaneCompatServer, null, h(server.SsrGreeting, { name: 'diverged' })),
+				),
+			);
+			const clientPage = h(
+				'main',
+				null,
+				h(
+					React.Suspense,
+					{ fallback: h('p', { className: 'react-fallback' }, 'react pending') },
+					h(OctaneCompat, null, h(ClientSsrAsync as any, { resource: clientResource.promise })),
+				),
+			);
+			const mounted = await hydratePage(serverPage, clientPage);
+			// Escaped: the boundary shows its fallback and the host is hidden
+			// while the episode is pending — no crash, no visible stale markup.
+			expect(mounted.container.querySelector('.react-fallback')).not.toBeNull();
+			expect(mounted.host().style.display).toBe('none');
+
+			await reactAct(async () => {
+				clientResource.resolve('client-data');
+				await clientResource.promise;
+			});
+			// The retry bound a fresh root: revealed with live client content.
+			expect(mounted.container.querySelector('.react-fallback')).toBeNull();
+			expect(mounted.container.querySelector('.ssr-async')?.textContent).toBe('value:client-data');
+			await mounted.unmount();
+		} finally {
+			quiet.mockRestore();
+		}
+	});
+
 	it('hydrates a CSS-producing island without mismatch alongside hoisted style resources', async () => {
 		const errors = vi.spyOn(console, 'error');
 		const serverPage = h(

--- a/packages/octane/tests/react-hosted/octane-compat-ssr.test.ts
+++ b/packages/octane/tests/react-hosted/octane-compat-ssr.test.ts
@@ -23,6 +23,7 @@ import {
 	SsrAsync as ClientSsrAsync,
 	SsrGreeting as ClientSsrGreeting,
 	SsrIdIsland as ClientSsrIdIsland,
+	SsrLayout as ClientSsrLayout,
 	SsrLocallyGuarded as ClientSsrLocallyGuarded,
 	SsrStyled as ClientSsrStyled,
 	SsrThemed as ClientSsrThemed,
@@ -357,6 +358,90 @@ describe('octane/react/server — buffered SSR + client hydration (§9.3)', () =
 			expect(mounted.container.querySelector('.react-fallback')).toBeNull();
 			expect(mounted.container.querySelector('.ssr-async')?.textContent).toBe('value:client-data');
 			await mounted.unmount();
+		} finally {
+			quiet.mockRestore();
+		}
+	});
+
+	it('flushes island layout effects inside the React layout commit on the hydration attach', async () => {
+		// The client attach path wraps root.render in octaneFlushSync so island
+		// layout effects and refs complete before the wrapper's layout effect
+		// returns. The hydration attach must honor the same contract: an
+		// ANCESTOR React layout effect (running after the wrapper's in the same
+		// commit) observes the island's layout-effect DOM writes.
+		const observed: Array<string | null> = [];
+		function Recorder(props: { children: React.ReactNode }) {
+			const hostRef = React.useRef<HTMLDivElement>(null);
+			React.useLayoutEffect(() => {
+				observed.push(
+					hostRef.current?.querySelector('.ssr-layout')?.getAttribute('data-laid-out') ?? null,
+				);
+			});
+			return h('div', { ref: hostRef }, props.children);
+		}
+		const serverPage = h(
+			'main',
+			null,
+			h(Recorder, null, h(OctaneCompatServer, null, h(server.SsrLayout, null))),
+		);
+		const clientPage = h(
+			'main',
+			null,
+			h(Recorder, null, h(OctaneCompat, null, h(ClientSsrLayout as any, null))),
+		);
+		const mounted = await hydratePage(serverPage, clientPage);
+		expect(observed[0]).toBe('yes');
+		await mounted.unmount();
+	});
+
+	it('releases host event delegation when a hydration escape client-remounts', async () => {
+		// The owned-escape teardown must mirror root.unmount(): hydrateRoot
+		// registered the host as a delegation target, so abandoning adoption
+		// unregisters it — otherwise the retry's fresh root double-counts the
+		// host and island teardown strands the map entry + listeners forever.
+		// Balanced add/remove listener calls on the host are the observable.
+		const clientResource = deferred<string>();
+		const quiet = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			const serverPage = h(
+				'main',
+				null,
+				h(
+					React.Suspense,
+					{ fallback: h('p', { className: 'react-fallback' }, 'react pending') },
+					h(OctaneCompatServer, null, h(server.SsrGreeting, { name: 'leak' })),
+				),
+			);
+			const clientPage = h(
+				'main',
+				null,
+				h(
+					React.Suspense,
+					{ fallback: h('p', { className: 'react-fallback' }, 'react pending') },
+					h(OctaneCompat, null, h(ClientSsrAsync as any, { resource: clientResource.promise })),
+				),
+			);
+			const serverHtml = reactRenderToString(serverPage as any);
+			const container = document.createElement('div');
+			container.innerHTML = serverHtml;
+			document.body.appendChild(container);
+			const host = container.querySelector('[data-octane-compat]') as HTMLElement;
+			const added = vi.spyOn(host, 'addEventListener');
+			const removed = vi.spyOn(host, 'removeEventListener');
+			const { hydrateRoot } = await import('react-dom/client');
+			let reactRoot!: ReturnType<typeof hydrateRoot>;
+			await reactAct(async () => {
+				reactRoot = hydrateRoot(container, clientPage as any);
+			});
+			await reactAct(async () => {
+				clientResource.resolve('client-data');
+				await clientResource.promise;
+			});
+			expect(container.querySelector('.ssr-async')?.textContent).toBe('value:client-data');
+			await reactAct(async () => reactRoot.unmount());
+			container.remove();
+			expect(added.mock.calls.length).toBeGreaterThan(0);
+			expect(removed.mock.calls.length).toBe(added.mock.calls.length);
 		} finally {
 			quiet.mockRestore();
 		}


### PR DESCRIPTION
**Stacked on #134** (the `@try` control-signal fix this builds on); GitHub retargets to `main` when it merges — only the last commit is new here.

Executes **Phase 3 (remaining failure-matrix breadth)** and **Phase 4 (server and hydration)** of [docs/react-hosted-octane-compat-plan.md](../blob/claude/react-hosted-phase3-4/docs/react-hosted-octane-compat-plan.md). Islands now go React SSR → streamed Fizz retries → client hydration → live interactivity.

## Phase 3 ([octane-compat-failure-matrix.test.ts](../blob/claude/react-hosted-phase3-4/packages/octane/tests/react-hosted/octane-compat-failure-matrix.test.ts))

- Island **layout-setup, passive-setup, and ref-attachment faults** route to the nearest React error boundary; sync update suspensions over committed content refallback while preserving hidden island DOM and state.
- Decisions pinned in the plan: **OQ16** — reveal-time snapshot supersession (the reveal's layout publish closes the stale window before paint); **OQ9** — transition-originated episodes **refallback in v1** (`// OCTANE DIVERGENCE` test: the island suspension surfaces post-commit as a sync update; cross-renderer transition entanglement stays a §2 non-goal).

## Phase 4 ([octane-compat-ssr.test.ts](../blob/claude/react-hosted-phase3-4/packages/octane/tests/react-hosted/octane-compat-ssr.test.ts))

- **`octane/react/server`**: one *synchronous* hosted Octane pass per Fizz task execution via a new server-runtime seam (`renderHostedAttempt` + `createHostedServerSession`). Only a bare root suspension delegates (`pass.rootSuspended`); a locally-guarded suspension ships its `@pending` arm in the shell for the client to complete (§9.1 v1).
- **Fizz retry state**: the session — keyed on Fizz's replay-stable transported-props identity, no `AsyncLocalStorage` (open question 11 answered) — persists the resolved/parallel-use maps; strata are identity-stable, status-stamped aggregates replayed in order via `React.use`. Tested: one replay per sequential stratum, parallel fetches started once with **zero re-fetch across replays**, rejections routed to Fizz exactly once, overlapping streams isolated.
- **Server context (§6.4)**: island `use(ReactContext)` reads call `React.use` directly through a pass-scoped hook — nearest-provider and Fizz semantics for free — and hydrated islands hold live client subscriptions afterwards.
- **Hydration (§9.3)**: hosts always carry the frozen opaque sentinel; server markup adopts through octane `hydrateRoot` with the **verbatim** `useId`-derived prefix — byte-identical ids, preserved node identity/state, live events. A §6.3 context request during adoption abandons it for a client remount with a dev diagnostic. Core enabler: `bindRendererRegionOwner` now uses a lazy root-disposer lookup (hydration passes run before the Root object exists).
- **CSS/head (§9.2)**: island CSS hoists as deduplicated React 19 style resources. Empirical catch: React serializes resource `href` as `data-href` and drops other attributes, so `injectStyle` detection also recognizes `data-href="octane-<hash>"` — hydration never re-injects. Body-hoisted island head content is rejected by the server *compiler* already (pinned); the renderer keeps a defensive guard. CSP nonce is threaded through the hosted seam (not yet exposed publicly).

Deferred to browser E2E before the public release (recorded in the plan): paint-level hide/reveal, focus families, and streamed `completeBoundary` segment relocation before octane adoption.

## Test plan

- `pnpm test` — 1090/1090 files, 10,564/10,564 tests (log-verified)
- `pnpm typecheck` (core + typetests), `pnpm format:check`
- `pnpm --dir packages/octane build` — dist emit + `verify-dist` green with the new `react/server` + `react/shared` entries
- Changeset included (patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core `hydrateRoot`, server SSR session/replay, and React–Octane boundary semantics (suspense, errors, hydration escapes); regressions could affect island correctness, hydration mismatches, or Fizz retry loops despite extensive new tests.
> 
> **Overview**
> Adds **`octane/react/server`** and completes React-hosted **Phase 3–4**: islands can SSR inside React (Fizz/`renderToString`), then hydrate on the client without React reconciling Octane-owned DOM.
> 
> **Server:** One synchronous hosted Octane pass per Fizz task via `renderHostedAttempt` / `createHostedServerSession`, with sessions keyed on replay-stable island props so retries reuse settled `use()` work (strata replayed through `React.use`). Island reads of React context go through `React.use` on the server; bare root suspensions delegate to Fizz; scoped CSS becomes deduplicated React 19 style resources (`data-href="octane-*"` recognized by `injectStyle`).
> 
> **Client hydration:** `OctaneCompat` uses a frozen opaque `dangerouslySetInnerHTML` sentinel and calls `hydrateOctaneRoot` when real server markup is present (matching `useId` prefix). Core fixes: lazy disposer lookup for `bindRendererRegionOwner` during hydration, owned-root escape handling in `hydrateRoot`, and §6.3 host-context requests bypassing local `@try` arms.
> 
> **Phase 3 breadth:** Layout/passive/ref faults escape to React error boundaries; sync update suspensions refallback while preserving hidden island DOM/state (transition-originated episodes documented as v1 divergence).
> 
> Shared types/validation move to `react/shared.ts`; package exports add `./react/server`. New tests: `octane-compat-ssr.test.ts`, `octane-compat-failure-matrix.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7056d5e79f303e61b9d02242426908b839c5d875. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->