### PR TITLE
tiptap: fix CI flake — guard useEditor's deferred destroy against environment teardown

### DIFF
--- a/packages/tiptap/src/useEditor.ts
+++ b/packages/tiptap/src/useEditor.ts
@@ -205,7 +205,20 @@ class EditorInstanceManager {
 		const currentInstanceId = this.instanceId;
 		const currentEditor = this.editor;
 
+		// Re-arming replaces any pending destruction timer so two can never race.
+		clearTimeout(this.scheduledDestructionTimeout);
 		this.scheduledDestructionTimeout = setTimeout(() => {
+			this.scheduledDestructionTimeout = undefined;
+
+			// This timer outlives the owning component by a tick, so it can fire
+			// after the DOM environment the editor lives in is gone (e.g. a test
+			// runner disposing jsdom between files). Touching the editor then would
+			// crash inside prosemirror-view's `window` access, and there is nothing
+			// left to release anyway.
+			if (typeof window === 'undefined') {
+				return;
+			}
+
 			if (this.isComponentMounted && this.instanceId === currentInstanceId) {
 				currentEditor?.setOptions(this.options.current);
 				return;

--- a/packages/tiptap/tests/unit/editor.test.ts
+++ b/packages/tiptap/tests/unit/editor.test.ts
@@ -74,4 +74,35 @@ describe('@octanejs/tiptap useEditor', () => {
 		expect(replacementEditor.isDestroyed).toBe(true);
 		expect(destroys.at(-1)).toBe('replacement');
 	});
+
+	it('tolerates the deferred destroy firing after the environment is torn down', () => {
+		vi.useFakeTimers();
+		const noop = () => {};
+		const editors: any[] = [];
+		const result = mount(LifecycleEditor as any, {
+			onEditor: (editor: any) => editors.push(editor),
+			onMount: noop,
+			onUnmount: noop,
+			onDestroy: noop,
+			onUpdate: noop,
+			dependency: 'only',
+			label: 'torn-down',
+		});
+		settle();
+		expect(editors.at(-1)).toBeTruthy();
+
+		result.unmount();
+		flushEffects();
+
+		// Unmount defers the final Editor.destroy by a timer tick. A test runner
+		// can dispose the jsdom environment inside that window (the `window`
+		// global disappears), and the late destroy must not surface an unhandled
+		// error from prosemirror-view's window access.
+		vi.stubGlobal('window', undefined);
+		try {
+			expect(() => vi.runAllTimers()).not.toThrow();
+		} finally {
+			vi.unstubAllGlobals();
+		}
+	});
 });


### PR DESCRIPTION
## Problem

`useEditor`'s `EditorInstanceManager.scheduleDestroy()` (ported verbatim from `@tiptap/react` 3.28.0, which carries the identical race) arms a 1ms `setTimeout` as the **final** destroy path on unmount, so the timer always outlives the owning component. When vitest tears down the jsdom environment inside that window, the late `Editor.destroy()` → prosemirror-view teardown dereferences the deleted `window` global and surfaces an unhandled `ReferenceError: window is not defined`.

Observed as a flaky "Unhandled Errors / Uncaught Exception" on test shard Node 24 4/4 in https://github.com/octanejs/octane/actions/runs/29587779052, passing on the next identical-code run — a teardown race, not a code regression.

## Fix

In `packages/tiptap/src/useEditor.ts`:

- `scheduleDestroy()` clears any pending destruction timer before re-arming, so two timers can never race, and the callback resets the stored handle once it fires.
- The timer callback no-ops when `typeof window === 'undefined'` at fire time — the environment the editor lived in is gone, so there is nothing left to release and touching the editor would only crash. Normal unmount destruction (environment still alive) is unchanged.

## Regression test

`packages/tiptap/tests/unit/editor.test.ts` mounts a `useEditor` consumer under fake timers, unmounts it, stubs `window` away to simulate the runner's environment teardown, then runs the pending timers and asserts no throw. Verified both directions: with the source fix stashed it fails with the CI crash signature (`Cannot read properties of undefined (reading 'setTimeout')` from the destroy chain); with the fix it passes.

## Validation

- `vitest run packages/tiptap` — 7 files / 14 tests pass, no unhandled-errors line
- `pnpm format:check` — clean
- `pnpm typecheck` — clean

No changeset (binding bugfix; changesets are reserved for `octane` / `@octanejs/vite-plugin`) and no `status.json` change (no scope change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow lifecycle guard in test/teardown edge cases; normal browser unmount behavior is preserved when `window` exists.
> 
> **Overview**
> Fixes a flaky CI failure where `useEditor`'s deferred `Editor.destroy()` (1ms timer on unmount) could run after vitest/jsdom tore down `window`, causing prosemirror-view to throw an unhandled `ReferenceError`.
> 
> **`EditorInstanceManager.scheduleDestroy()`** now clears any pending timer before scheduling a new one (avoids racing timers) and clears the stored handle when the callback runs. If `typeof window === 'undefined'` when the timer fires, the callback returns without touching the editor—normal destroy when the environment is still alive is unchanged.
> 
> Adds a unit test that unmounts a `useEditor` consumer, stubs `window` away, runs pending timers, and asserts no throw.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a9a871e34988b210a93647a91eb10ad3e794e0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->