### PR TITLE
Document and verify deferred hydration usage

### DIFF
--- a/docs/deferred-hydration.md
+++ b/docs/deferred-hydration.md
@@ -50,7 +50,7 @@ The complete component surface is:
 | `split` | `boolean` | Compiler-split the direct children into a deferred chunk. Defaults to `true`. |
 | `prefetch` | `HydrationPrefetchStrategy \| HydrationPrefetchFunction` | Start loading the split chunk or run custom preparation before hydration. |
 | `fallback` | renderable | Client-only loading UI for a later client mount or suspension. |
-| `onHydrated` | `() => void` | Called once after the preserved child DOM becomes interactive. |
+| `onHydrated` | `() => void` | Called once after the child successfully commits on the client. |
 | `children` | renderable | The subtree rendered on the server and deferred on the client. |
 
 `HydrateOptions` is exported from `octane/hydration` for reusable option objects:
@@ -95,7 +95,9 @@ synchronously on the client.
 ```tsrx
 <Hydrate
 	when={() =>
-		navigator.connection?.saveData ? interaction({ events: 'click' }) : visible()
+		window.matchMedia('(pointer: coarse)').matches
+			? interaction({ events: 'click' })
+			: visible()
 	}
 >
 	<Recommendations />
@@ -159,7 +161,9 @@ not turn deferred JavaScript into an eager dependency.
 ### `prefetch`
 
 A strategy-form prefetch loads the generated child chunk early without making
-the boundary interactive:
+the boundary interactive. It accepts `load()`, `idle()`, `visible()`, `media()`,
+or `interaction()`; `condition()`, `never()`, and function-form strategies are
+activation-only.
 
 ```tsrx
 import { idle, interaction } from 'octane/hydration';
@@ -189,8 +193,8 @@ The procedural context contains:
 
 - `preload()`, which loads the generated child chunk or resolves immediately
   with `split={false}`;
-- `waitFor(strategy)`, which resolves with `'prefetch'`, `'hydrate'`, or
-  `'abort'`;
+- `waitFor(strategy)`, which accepts the same five prefetch strategies and
+  resolves with `'prefetch'`, `'hydrate'`, or `'abort'`;
 - `signal`, an `AbortSignal` for cancelable work; and
 - `element`, the persistent boundary `<div>`.
 
@@ -216,7 +220,8 @@ resolvable single-use `const` spread from the server output. Shared or dynamic
 spread objects are left intact because rewriting them could change observable
 JavaScript behavior; keep their fallback values safe to evaluate on the server.
 
-`onHydrated` runs once after the child has hydrated successfully on the client.
+`onHydrated` runs once after the child successfully commits on the client,
+whether the boundary adopts preserved server DOM or mounts client-only.
 
 ## Correctness and nesting
 

--- a/packages/vite-plugin-octane/tests/_fixtures/app/src/Page.tsrx
+++ b/packages/vite-plugin-octane/tests/_fixtures/app/src/Page.tsrx
@@ -1,9 +1,10 @@
-import { Hydrate, use, useState } from 'octane';
-import { interaction } from 'octane/hydration';
+import { Hydrate, use, useEffect, useState } from 'octane';
+import { interaction, load, media } from 'octane/hydration';
 import { RpcProbe } from './Rpc.tsx';
 import { Canvas } from '@fixture/object-canvas';
 import { Scene } from './Scene.object.tsrx';
 import { DeferredHydrationProof } from './deferred-hydration.tsrx';
+import { PrefetchedHydrationProof } from './prefetched-hydration.tsrx';
 
 export const fixturePageModuleState = { rendered: false };
 
@@ -18,6 +19,22 @@ import { fixtureRpc } from 'server';
 let pendingFixture: Promise<string> | undefined;
 function loadPendingFixture() {
 	return pendingFixture ??= new Promise((resolve) => setTimeout(() => resolve('ready'), 10));
+}
+
+function UnsplitHydrationProof() @{
+	const [active, setActive] = useState(false);
+	const [clicks, setClicks] = useState(0);
+	useEffect(() => {
+		setActive(true);
+	}, []);
+	<button
+		class="vite-unsplit-hydration-proof"
+		data-active={active ? 'true' : 'false'}
+		data-clicks={String(clicks)}
+		onClick={() => setClicks((count) => count + 1)}
+	>
+		vite-unsplit-hydration-proof
+	</button>
 }
 
 // A page with a dynamic text hole, a param read, and an event handler — enough
@@ -48,6 +65,12 @@ export function Page(props: { params: Record<string, string>; url: string }) @{
 		</Canvas>
 		<Hydrate when={interaction({ events: 'click' })}>
 			<DeferredHydrationProof />
+		</Hydrate>
+		<Hydrate when={media('(min-width: 2000px)')} prefetch={load()}>
+			<PrefetchedHydrationProof />
+		</Hydrate>
+		<Hydrate when={media('(min-width: 2100px)')} split={false}>
+			<UnsplitHydrationProof />
 		</Hydrate>
 	</main>
 }

--- a/packages/vite-plugin-octane/tests/_fixtures/app/src/prefetched-hydration.tsrx
+++ b/packages/vite-plugin-octane/tests/_fixtures/app/src/prefetched-hydration.tsrx
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'octane';
+
+export function PrefetchedHydrationProof() @{
+	const [active, setActive] = useState(false);
+	const [clicks, setClicks] = useState(0);
+	useEffect(() => {
+		setActive(true);
+	}, []);
+	<button
+		class="vite-prefetched-hydration-proof"
+		data-active={active ? 'true' : 'false'}
+		data-clicks={String(clicks)}
+		onClick={() => setClicks((count) => count + 1)}
+	>
+		vite-prefetched-hydration-chunk-proof
+	</button>
+}

--- a/packages/vite-plugin-octane/tests/production.test.ts
+++ b/packages/vite-plugin-octane/tests/production.test.ts
@@ -184,8 +184,16 @@ describe('production SSR build', () => {
 					.readFileSync(path.join(clientRoot, file), 'utf8')
 					.includes('vite-deferred-hydration-chunk-proof'),
 		);
+		const prefetchedJavaScript = listFiles(clientRoot).find(
+			(file) =>
+				file.endsWith('.js') &&
+				fs
+					.readFileSync(path.join(clientRoot, file), 'utf8')
+					.includes('vite-prefetched-hydration-chunk-proof'),
+		);
 		expect(deferredCss).toBeTruthy();
 		expect(deferredJavaScript).toBeTruthy();
+		expect(prefetchedJavaScript).toBeTruthy();
 
 		for (const url of ['/', '/pages/hello']) {
 			const prodResponse = await handler(new Request(`http://localhost${url}`));
@@ -209,6 +217,8 @@ describe('production SSR build', () => {
 			expect(prodHtml).toContain(`<link rel="stylesheet" href="/${deferredCss}">`);
 			expect(prodHtml).not.toContain(`src="/${deferredJavaScript}"`);
 			expect(prodHtml).not.toContain(`<link rel="modulepreload" href="/${deferredJavaScript}">`);
+			expect(prodHtml).not.toContain(`src="/${prefetchedJavaScript}"`);
+			expect(prodHtml).not.toContain(`<link rel="modulepreload" href="/${prefetchedJavaScript}">`);
 		}
 	});
 
@@ -233,7 +243,11 @@ describe('production SSR build', () => {
 				const page = await browser.newPage();
 				const errors: string[] = [];
 				const requests: string[] = [];
-				page.on('request', (request) => requests.push(request.url()));
+				const scriptRequests: string[] = [];
+				page.on('request', (request) => {
+					requests.push(request.url());
+					if (request.resourceType() === 'script') scriptRequests.push(request.url());
+				});
 				await page.addInitScript(() => {
 					const fixture = globalThis as typeof globalThis & {
 						__fixtureCspViolations?: string[];
@@ -305,6 +319,81 @@ describe('production SSR build', () => {
 								.includes('vite-deferred-hydration-chunk-proof')
 						);
 					};
+					const isPrefetchedChunkRequest = (requestUrl: string) => {
+						const request = new URL(requestUrl);
+						if (target.name === 'development') {
+							return request.pathname === '/src/prefetched-hydration.tsrx';
+						}
+						return (
+							request.pathname.startsWith('/assets/') &&
+							request.pathname.endsWith('.js') &&
+							fs
+								.readFileSync(path.join(distDir, 'client', request.pathname), 'utf8')
+								.includes('vite-prefetched-hydration-chunk-proof')
+						);
+					};
+					await expect.poll(() => requests.some(isPrefetchedChunkRequest)).toBe(true);
+					const prefetchedProof = page.locator('.vite-prefetched-hydration-proof');
+					const prefetchedServerNode = await prefetchedProof.elementHandle();
+					expect(prefetchedServerNode).not.toBeNull();
+					expect(
+						await prefetchedProof.evaluate((element) => ({
+							active: element.getAttribute('data-active'),
+							clicks: element.getAttribute('data-clicks'),
+							text: element.textContent?.trim(),
+						})),
+					).toEqual({
+						active: 'false',
+						clicks: '0',
+						text: 'vite-prefetched-hydration-chunk-proof',
+					});
+					await prefetchedProof.click();
+					expect(await prefetchedProof.getAttribute('data-active')).toBe('false');
+					expect(await prefetchedProof.getAttribute('data-clicks')).toBe('0');
+					const prefetchedChunkRequestsBeforeActivation = requests.filter(isPrefetchedChunkRequest);
+					await page.setViewportSize({ width: 2050, height: 720 });
+					await expect
+						.poll(async () => {
+							return {
+								active: await prefetchedProof.getAttribute('data-active'),
+								sameNode: await prefetchedServerNode!.evaluate(
+									(node) => node === document.querySelector('.vite-prefetched-hydration-proof'),
+								),
+							};
+						})
+						.toEqual({ active: 'true', sameNode: true });
+					await prefetchedProof.click();
+					await expect.poll(() => prefetchedProof.getAttribute('data-clicks')).toBe('1');
+					expect(requests.filter(isPrefetchedChunkRequest)).toEqual(
+						prefetchedChunkRequestsBeforeActivation,
+					);
+					const unsplitProof = page.locator('.vite-unsplit-hydration-proof');
+					const unsplitServerNode = await unsplitProof.elementHandle();
+					expect(unsplitServerNode).not.toBeNull();
+					expect(await unsplitProof.getAttribute('data-active')).toBe('false');
+					expect(await unsplitProof.getAttribute('data-clicks')).toBe('0');
+					await unsplitProof.click();
+					expect(await unsplitProof.getAttribute('data-active')).toBe('false');
+					expect(await unsplitProof.getAttribute('data-clicks')).toBe('0');
+					const scriptRequestsBeforeUnsplitActivation = [...scriptRequests];
+					await page.setViewportSize({ width: 2200, height: 720 });
+					await expect
+						.poll(async () => ({
+							active: await unsplitProof.getAttribute('data-active'),
+							sameNode: await unsplitServerNode!.evaluate(
+								(node) => node === document.querySelector('.vite-unsplit-hydration-proof'),
+							),
+						}))
+						.toEqual({ active: 'true', sameNode: true });
+					await page.evaluate(
+						() =>
+							new Promise<void>((resolve) =>
+								requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+							),
+					);
+					expect(scriptRequests).toEqual(scriptRequestsBeforeUnsplitActivation);
+					await unsplitProof.click();
+					await expect.poll(() => unsplitProof.getAttribute('data-clicks')).toBe('1');
 					const deferredBefore = await page.evaluate(() => {
 						const fixture = globalThis as typeof globalThis & {
 							__fixtureDeferredHydrationClicks?: number;

--- a/website-mcp/src/content/docs.ts
+++ b/website-mcp/src/content/docs.ts
@@ -9,6 +9,7 @@
 import { docsMeta } from '../../../website/src/content/docs-meta.ts';
 import ssrMd from '../../../docs/ssr.md?raw';
 import reactDifferencesMd from '../../../docs/differences-from-react.md?raw';
+import deferredHydrationMd from '../../../docs/deferred-hydration.md?raw';
 
 export interface McpDocSection {
 	id: string;
@@ -99,10 +100,20 @@ const websiteDocs: McpDoc[] = docsMeta.map((meta) => {
 	}
 }
 
-// Deep-dive documents that only exist in the repository. The divergence
-// reference gets a '-reference' suffix so it never collides with the website's
-// reader-friendly differences-from-react page.
+// Deep-dive documents that only exist in the repository use a '-reference'
+// suffix when their subject also appears in a reader-friendly website guide.
 const repoDocs: McpDoc[] = [
+	{
+		slug: 'deferred-hydration-reference',
+		title: 'Deferred hydration (full reference)',
+		description:
+			'The complete Hydrate reference: activation strategies, compiler splitting, prefetching, fallbacks, and nesting behavior.',
+		group: 'Explore',
+		source: 'repo',
+		url: 'https://github.com/octanejs/octane/blob/main/docs/deferred-hydration.md',
+		sections: markdownSections(deferredHydrationMd),
+		markdown: deferredHydrationMd,
+	},
 	{
 		slug: 'ssr',
 		title: 'Server-side rendering (deep dive)',

--- a/website-mcp/tests/content.test.ts
+++ b/website-mcp/tests/content.test.ts
@@ -22,6 +22,7 @@ describe('docs snapshot', () => {
 			(doc) => doc.slug,
 		);
 		expect(new Set(snapshotWebsiteSlugs)).toEqual(new Set(websiteDocs));
+		expect(DOC_SLUGS).toContain('deferred-hydration-reference');
 		expect(DOC_SLUGS).toContain('ssr');
 		expect(DOC_SLUGS).toContain('differences-from-react-reference');
 	});
@@ -35,11 +36,13 @@ describe('docs snapshot', () => {
 	});
 
 	it('sections the repo markdown docs by their ## headings', () => {
+		const deferredHydration = docBySlug('deferred-hydration-reference')!;
 		const ssr = docBySlug('ssr')!;
 		const reference = docBySlug('differences-from-react-reference')!;
+		expect(deferredHydration.sections.length).toBeGreaterThanOrEqual(3);
 		expect(ssr.sections.length).toBeGreaterThanOrEqual(5);
 		expect(reference.sections.length).toBeGreaterThanOrEqual(15);
-		for (const section of [...ssr.sections, ...reference.sections]) {
+		for (const section of [...deferredHydration.sections, ...ssr.sections, ...reference.sections]) {
 			expect(section.id).toMatch(/^[a-z0-9][a-z0-9-]*$/);
 		}
 	});
@@ -89,6 +92,15 @@ describe('skills snapshot', () => {
 describe('llms text', () => {
 	it('serves the website llms.txt verbatim', async () => {
 		expect(LLMS_TXT).toBe(await readFile(join(repoRoot, 'website/public/llms.txt'), 'utf8'));
+		for (const marker of [
+			'## Deferred hydration',
+			'<Hydrate when={visible',
+			'split={false}',
+			'prefetch={idle()}',
+			'onHydrated',
+		]) {
+			expect(LLMS_TXT).toContain(marker);
+		}
 	});
 
 	it('llms-full.txt extends llms.txt with the whole docs corpus', () => {

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -15,6 +15,7 @@ Key facts for answering questions about Octane:
 - Refs are passed as props (React-19 style): `ref={cb}`, `ref={obj}`, or multi-ref `ref={[a, b]}`. There is no `forwardRef`.
 - `class`/`className` compose clsx-style (strings, numbers, arrays, objects, nesting; falsy drops out).
 - Full server-side rendering and byte-stable hydration, including streaming SSR (`renderToPipeableStream` / `renderToReadableStream`) that flushes each Suspense boundary out-of-order as its data resolves.
+- `<Hydrate>` can leave initial server HTML visible but inert until `load()`, idle time, visibility, a media query, interaction, an application condition, or never. Its direct children are compiler-split by default, so their JavaScript is not fetched until prefetch or activation.
 - No class components, no Server Components, no StrictMode double-invoke.
 - Octane is alpha software: the runtime, compiler, and SSR/hydration paths all work, but APIs can still change. The core suite has 3,500+ distinct behavioral tests; production-compiler executions rerun the normal cases and are not additional unique coverage. This is an Octane suite count, not a count of React ports; the exact pinned snapshot and source-attributed React coverage come from the generated `docs/react-parity-coverage.md` ledger report.
 
@@ -23,7 +24,7 @@ Key facts for answering questions about Octane:
 - [Quick start](https://octanejs.dev/docs/quick-start): Install Octane, mount a component, and learn the `.tsrx` essentials (components, state/effects, conditional hooks, control flow, SSR/hydrate).
 - [Build tools](https://octanejs.dev/docs/build-tools): Configure the recommended Vite integration or the matching Rspack and Rsbuild plugins, including routing, SSR, hydration, production, and preview.
 - [Profiling](https://octanejs.dev/docs/profiling): Enable `profile: true` with Vite, Rspack, or Rsbuild to inspect component render/DOM time, self time, render counts, causes, bails, scheduling delay, and Chrome trace data.
-- [Core APIs](https://octanejs.dev/docs/core-apis): Roots, components, state and effect hooks, current-state getters, context, Suspense, transitions, actions, events, and SSR/static rendering.
+- [Core APIs](https://octanejs.dev/docs/core-apis): Roots, components, state and effect hooks, current-state getters, context, Suspense, deferred hydration and code splitting, transitions, actions, events, and SSR/static rendering.
 - [TSRX vs TSX/JSX](https://octanejs.dev/docs/tsrx-vs-tsx): When to author in `.tsrx` versus standard `.tsx`/`.jsx`, and what each dialect unlocks (compiled collections, template control flow, the `@{ … }` shorthand, text holes).
 - [Differences from React](https://octanejs.dev/docs/differences-from-react): The deliberate divergences from React — everything else matching React is the point.
 - [Bindings](https://octanejs.dev/docs/bindings): The `@octanejs/*` ports of the React ecosystem.
@@ -36,6 +37,64 @@ Key facts for answering questions about Octane:
 - Dynamic text holes use a cast: `{expr as string}`. The cast is optional when the expression is provably a string (a string/template literal, a `+`-concatenation involving a string, or a local tracked back to a string); required otherwise. A bare `{expr}` that isn't provably a string is a renderable hole.
 - Template control flow uses directive blocks: `@if (c) { } @else { }`, `@for (const x of xs; key x.id) { } @empty { }`, `@switch (v) { @case (a) { } @default { } }`, and `@try { } @pending { } @catch (e) { }`. Plain JS control flow stays in setup.
 - `.tsrx`'s `@for` compiles a rendered list to a keyed fast path (a compiled per-item body + the raw array) instead of allocating a descriptor per row — the main reason to prefer `.tsrx` for collection-heavy UI.
+
+## Deferred hydration
+
+`Hydrate` is an experimental core API for initial server-rendered content. It preserves visible server HTML while postponing component execution, refs, effects, and events. A boundary first mounted after the app is already running renders normally on the client.
+
+Import the component from `octane` and strategies from `octane/hydration`:
+
+```tsrx
+import { Hydrate } from 'octane';
+import { visible } from 'octane/hydration';
+
+export function ProductPage() @{
+	<Hydrate when={visible({ rootMargin: '400px' })}>
+		<Reviews />
+	</Hydrate>
+}
+```
+
+Every boundary makes three performance decisions:
+
+- `when` (required) controls when preserved server HTML becomes interactive. Available strategies are `load()`, `idle({ timeout? })`, `visible({ rootMargin?, threshold? })`, `media(query)`, `interaction({ events? })`, `condition(booleanOrGetter)`, and `never()`. `interaction()` replays the triggering event. A function form such as `when={() => window.matchMedia('(pointer: coarse)').matches ? interaction() : visible()}` may choose a strategy from client-only information; it is not called on the server and must return synchronously.
+- `split` defaults to `true`. The compiler extracts direct children into a generated chunk, and Vite/Rsbuild do not eagerly module-preload that JavaScript. Use the literal `split={false}` when the code is already required elsewhere or a separate request is not worthwhile:
+
+```tsrx
+import { idle } from 'octane/hydration';
+
+<Hydrate when={idle()} split={false}>
+	<SmallBadge />
+</Hydrate>
+```
+
+- `prefetch` starts the split chunk or custom preparation before `when` activates the boundary. Strategy prefetching accepts `load()`, `idle()`, `visible()`, `media()`, or `interaction()`; `condition()`, `never()`, and function-form strategies are activation-only. A strategy prefetch loads code but leaves the DOM inert:
+
+```tsrx
+import { idle, interaction } from 'octane/hydration';
+
+<Hydrate when={interaction()} prefetch={idle()}>
+	<RecommendationEditor />
+</Hydrate>
+```
+
+A procedural prefetch can prepare code and data. Awaited work blocks activation if `when` resolves first; `signal` aborts when the boundary is removed:
+
+```tsrx
+<Hydrate
+	when={visible()}
+	prefetch={async ({ preload, signal }) => {
+		await preload();
+		await warmReviews({ signal });
+	}}
+>
+	<Reviews />
+</Hydrate>
+```
+
+The procedural context also exposes `waitFor(strategy)` for the same five prefetch strategies and the persistent boundary `element`. Procedural prefetch works with either split mode; strategy prefetch requires splitting.
+
+The remaining public props are `fallback`, client-only loading UI for a later client mount or suspension, and `onHydrated`, called once after the child successfully commits on the client, including a client-only mount. Initial server HTML remains visible while its strategy or first activation suspension waits; `fallback` does not replace it. `children` is the server-rendered subtree. See the [Core APIs guide](https://octanejs.dev/docs/core-apis#deferred-hydration) and [complete deferred hydration reference](https://github.com/octanejs/octane/blob/main/docs/deferred-hydration.md).
 
 ## Core state APIs
 

--- a/website/src/content/docs-meta.ts
+++ b/website/src/content/docs-meta.ts
@@ -52,7 +52,7 @@ export const docsMeta: DocMeta[] = [
 		slug: 'core-apis',
 		title: 'Core APIs',
 		description:
-			'Learn how components, state, events, context, effects, async UI, and rendering fit together.',
+			'Learn how components, state, events, context, effects, async UI, deferred hydration, and rendering fit together.',
 		group: 'Learn Octane',
 		sections: [
 			{ id: 'mental-model', title: 'The mental model' },
@@ -62,6 +62,7 @@ export const docsMeta: DocMeta[] = [
 			{ id: 'context', title: 'Sharing data' },
 			{ id: 'refs-and-effects', title: 'Refs and effects' },
 			{ id: 'async-ui', title: 'Loading data and code' },
+			{ id: 'deferred-hydration', title: 'Deferred hydration' },
 			{ id: 'responsive-updates', title: 'Responsive updates' },
 			{ id: 'roots-and-rendering', title: 'Roots and rendering' },
 			{ id: 'server-rendering', title: 'Server rendering' },

--- a/website/src/content/docs/core-apis.mdx
+++ b/website/src/content/docs/core-apis.mdx
@@ -94,8 +94,13 @@ attach event handlers such as `onClick`, and let Octane keep the page in sync.
 		<strong>Wait for data</strong>
 		<span>Boundaries make loading and errors visible.</span>
 	</a>
-	<a href="#roots-and-rendering">
+	<a href="#deferred-hydration">
 		<span className="topic-number">06</span>
+		<strong>Defer startup work</strong>
+		<span>Server HTML can become interactive later.</span>
+	</a>
+	<a href="#roots-and-rendering">
+		<span className="topic-number">07</span>
 		<strong>Start the app</strong>
 		<span>A root connects Octane to your HTML.</span>
 	</a>
@@ -576,6 +581,197 @@ component's code only when it is needed.
 	</div>
 </details>
 
+<h2 id="deferred-hydration">Deferred hydration</h2>
+
+`Hydrate` keeps useful server-rendered HTML visible while delaying the component work,
+effects, and events that make that subtree interactive. By default, the compiler also
+moves the direct children into a separate JavaScript chunk, so the browser does not
+fetch that code until the boundary is prefetched or activated.
+
+```tsrx
+import { Hydrate } from 'octane';
+import { visible } from 'octane/hydration';
+
+export function ProductPage() @{
+	<main>
+		<ProductHero />
+		<Hydrate when={visible({ rootMargin: '400px' })}>
+			<Reviews />
+		</Hydrate>
+	</main>
+}
+```
+
+The server still renders `Reviews`. During initial hydration its HTML stays visible but
+dormant. When the boundary approaches the viewport, Octane loads the generated child
+chunk, adopts the same DOM in place, then enables refs, effects, and events.
+
+`Hydrate` is experimental and applies only to matching server HTML in the initial
+document. A boundary first mounted after the app is already running renders normally on
+the client.
+
+### The three performance decisions
+
+| Prop       | Default  | Decision                                                     |
+| ---------- | -------- | ------------------------------------------------------------ |
+| `when`     | required | When the preserved server HTML becomes interactive.          |
+| `split`    | `true`   | Whether the compiler creates a deferred child chunk.         |
+| `prefetch` | none     | Whether code or data preparation starts before `when` fires. |
+
+<h3 id="hydrate-when">
+	Choose the trigger with <code>when</code>
+</h3>
+
+Import hydration strategies from `octane/hydration`. Use the trigger that matches how
+soon the content needs to respond:
+
+| Strategy                               | Example use                                            |
+| -------------------------------------- | ------------------------------------------------------ |
+| `load()`                               | Hydrate with the initial app hydration.                |
+| `idle({ timeout? })`                   | Hydrate when the browser is idle.                      |
+| `visible({ rootMargin?, threshold? })` | Hydrate near or inside the viewport.                   |
+| `media(query)`                         | Hydrate when a media query matches.                    |
+| `interaction({ events? })`             | Hydrate on intent and replay the triggering event.     |
+| `condition(booleanOrGetter)`           | Hydrate after an application condition becomes truthy. |
+| `never()`                              | Keep the initial server HTML permanently static.       |
+
+```tsrx
+import { Hydrate } from 'octane';
+import { condition, idle, interaction, load, media, never, visible } from 'octane/hydration';
+
+export function StrategyExamples(props: { hasConsent: boolean }) @{
+	<>
+		<Hydrate when={load()}>
+			<SiteHeader />
+		</Hydrate>
+		<Hydrate when={idle()}>
+			<RelatedArticles />
+		</Hydrate>
+		<Hydrate when={visible()}>
+			<Reviews />
+		</Hydrate>
+		<Hydrate when={media('(min-width: 64rem)')}>
+			<DesktopChart />
+		</Hydrate>
+		<Hydrate when={interaction({ events: ['focusin', 'click'] })}>
+			<Editor />
+		</Hydrate>
+		<Hydrate when={condition(props.hasConsent)}>
+			<PersonalizedOffers />
+		</Hydrate>
+		<Hydrate when={never()}>
+			<LegalArchive />
+		</Hydrate>
+	</>
+}
+```
+
+The function form chooses a strategy from browser-only information. Octane never calls
+it on the server, and it must return a strategy synchronously:
+
+```tsrx
+import { interaction, visible } from 'octane/hydration';
+
+<Hydrate when={() => window.matchMedia('(pointer: coarse)').matches ? interaction() : visible()}>
+	<Recommendations />
+</Hydrate>
+```
+
+<h3 id="hydrate-split">
+	Control the child chunk with <code>split</code>
+</h3>
+
+Splitting is on by default; this boundary defers both component execution and the
+`HeavyReviewsWidget` JavaScript:
+
+```tsrx
+<Hydrate when={visible()}>
+	<HeavyReviewsWidget />
+</Hydrate>
+```
+
+Use the literal `split={false}` when that code is already needed elsewhere or a separate
+chunk would cost more than it saves. Hydration still waits for `when`:
+
+```tsrx
+<Hydrate when={idle()} split={false}>
+	<SmallBadge />
+</Hydrate>
+```
+
+The compiler can split direct JSX children and capture ordinary lexical values. Move
+hooks and other setup into a child component, or opt out of splitting.
+
+<h3 id="hydrate-prefetch">
+	Prepare before activation with <code>prefetch</code>
+</h3>
+
+A strategy-form prefetch downloads the generated child chunk early without making the
+server HTML interactive. Here the browser may fetch the editor while idle, but the
+editor still activates only after interaction:
+
+```tsrx
+import { idle, interaction } from 'octane/hydration';
+
+<Hydrate when={interaction()} prefetch={idle()}>
+	<RecommendationEditor />
+</Hydrate>
+```
+
+Strategy prefetching accepts `load()`, `idle()`, `visible()`, `media()`, or
+`interaction()`. Conditions, `never()`, and the function form are activation-only
+strategies.
+
+A procedural prefetch can warm data as well as code. Awaited work blocks activation if
+`when` fires first; the `signal` is aborted if the boundary goes away:
+
+```tsrx
+<Hydrate
+	when={visible()}
+	prefetch={async ({ preload, signal }) => {
+		await preload();
+		await warmReviews({ signal });
+	}}
+>
+	<Reviews />
+</Hydrate>
+```
+
+Procedural prefetch also works with `split={false}`; in that mode `preload()` resolves
+immediately. Its `waitFor(strategy)` helper accepts the same five prefetch strategies.
+Strategy-form prefetch requires splitting because its job is to fetch the generated
+child chunk.
+
+### Fallbacks, completion, and the complete prop surface
+
+`fallback` is client-only loading UI for a boundary mounted later on the client whose
+child suspends. It does not replace the preserved server HTML while an initial boundary
+waits. `onHydrated` runs once after the child successfully commits on the client,
+whether the boundary adopts preserved server DOM or mounts client-only:
+
+```tsrx
+<Hydrate
+	when={visible()}
+	fallback={<ReviewsSkeleton />}
+	onHydrated={() => markReviewsInteractive()}
+>
+	<Reviews />
+</Hydrate>
+```
+
+| Prop         | Type                                                  | Purpose                                                 |
+| ------------ | ----------------------------------------------------- | ------------------------------------------------------- |
+| `when`       | `HydrationStrategy \| (() => HydrationStrategy)`      | Required activation trigger.                            |
+| `split`      | `boolean`                                             | Generate a deferred child chunk; defaults to `true`.    |
+| `prefetch`   | strategy or `({ preload, waitFor, signal, element })` | Prepare the split chunk or application resources early. |
+| `fallback`   | renderable                                            | Loading UI for a later client-only mount or suspension. |
+| `onHydrated` | `() => void`                                          | Called once after the child successfully commits.       |
+| `children`   | renderable                                            | The subtree rendered on the server and deferred.        |
+
+For compiler constraints, nesting behavior, event details, and the full procedural
+context, read the
+[deferred hydration guide](https://github.com/octanejs/octane/blob/main/docs/deferred-hydration.md).
+
 <h2 id="responsive-updates">Responsive updates and actions</h2>
 
 Some updates should feel immediate, such as typing. Others may reveal UI that needs to
@@ -947,6 +1143,10 @@ handlers; return here when you have a specific problem to solve.
 	<section className="api-index-card">
 		<h3>Load and reveal UI</h3>
 		<ul>
+			<li>
+				<code>Hydrate</code>
+				<span>Keep server HTML dormant and load its behavior on demand.</span>
+			</li>
 			<li>
 				<code>Suspense</code>
 				<span>Show a fallback while descendants wait.</span>

--- a/website/tests/core-apis-docs.test.ts
+++ b/website/tests/core-apis-docs.test.ts
@@ -43,7 +43,7 @@ describe('Core APIs documentation', () => {
 			expect(container.querySelector(`h2#${section.id}`)).toBeTruthy();
 		}
 
-		expect(container.querySelectorAll('.topic-grid a')).toHaveLength(6);
+		expect(container.querySelectorAll('.topic-grid a')).toHaveLength(7);
 		expect(container.querySelectorAll('[data-demo]')).toHaveLength(9);
 		for (const id of [
 			'state',
@@ -60,6 +60,9 @@ describe('Core APIs documentation', () => {
 		}
 		for (const id of [
 			'use-sync-external-store',
+			'hydrate-when',
+			'hydrate-split',
+			'hydrate-prefetch',
 			'use-transition',
 			'use-deferred-value',
 			'view-transitions',
@@ -91,6 +94,9 @@ describe('Core APIs documentation', () => {
 		expect(highlightedSource.some((source) => source.includes('renderToString(App'))).toBe(true);
 		for (const sourceMarker of [
 			'export function NetworkStatus()',
+			'<Hydrate when={visible({ rootMargin:',
+			'<Hydrate when={idle()} split={false}>',
+			'<Hydrate when={interaction()} prefetch={idle()}>',
 			'const [isPending, startTransition] = useTransition();',
 			'const deferredQuery = useDeferredValue(query);',
 			'<ViewTransition enter="notice-in" exit="notice-out">',
@@ -112,6 +118,9 @@ describe('Core APIs documentation', () => {
 		expect(groupedApiCodeCount('useContext')).toBe(2);
 		expect(groupedApiCodeCount('addTransitionType')).toBe(2);
 		expect(groupedApiCodeCount('isChildrenBlock')).toBe(3);
+		expect(
+			apiRows.some((row) => row.querySelector(':scope > code')?.textContent === 'Hydrate'),
+		).toBe(true);
 
 		const active = container.querySelector(
 			'a.sidebar-link[href="/docs/core-apis"][data-status="active"]',

--- a/website/tests/docs-search.test.ts
+++ b/website/tests/docs-search.test.ts
@@ -77,6 +77,15 @@ describe('docs search ranking', () => {
 		expect(top.lines.some((line) => line.code)).toBe(true);
 	});
 
+	it('deep links deferred hydration searches to the Hydrate guide', async () => {
+		const index = await loadSearchIndex();
+		const [top] = searchDocs(index, 'deferred hydration');
+
+		expect(top).toBeDefined();
+		expect(top.slug).toBe('core-apis');
+		expect(top.id).toBe('deferred-hydration');
+	});
+
 	it('ranks a heading match above an incidental prose mention', async () => {
 		const index = await loadSearchIndex();
 		const [top] = searchDocs(index, 'install');

--- a/website/tests/ssr-smoke.test.ts
+++ b/website/tests/ssr-smoke.test.ts
@@ -90,6 +90,8 @@ describe('built SSR handler', () => {
 		expect(classCount(html, 'on-this-page')).toBeGreaterThan(0);
 		expect(classCount(html, 'demo')).toBeGreaterThan(0);
 		expect(classCount(html, 'shiki')).toBeGreaterThan(0);
+		expect(html).toContain('id="deferred-hydration"');
+		expect(html).toContain('Deferred hydration');
 	});
 
 	// This route deliberately renders every chart and accessible data table; give


### PR DESCRIPTION
## Summary

- add a Deferred hydration section to the Core APIs website with examples for when, split, prefetch, every strategy, fallback, and onHydrated
- teach llms.txt about Hydrate and include the full deferred-hydration guide in the MCP/llms-full corpus
- extend the Vite browser fixture to prove split prefetch timing and split={false} request behavior in development and production

## Validation

- pnpm typecheck
- pnpm format:check
- vitest: Vite production browser suite (13 tests)
- vitest: Core APIs docs, docs search, SSR smoke, and website MCP content (37 tests)

Follow-up to #139, which merged while this documentation audit was in progress.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and integration-test changes only; no runtime or compiler behavior is modified in this diff.
> 
> **Overview**
> Adds **deferred hydration** documentation across the site, MCP corpus, and `llms.txt`, and extends the Vite production browser fixture to exercise prefetch and `split={false}` behavior.
> 
> The **Core APIs** guide gains a full **Deferred hydration** section (`when`, `split`, `prefetch`, strategies, `fallback`, `onHydrated`), topic-grid/TOC updates, and **`Hydrate`** in the API index. **`docs/deferred-hydration.md`** is tightened (e.g. `onHydrated` wording, prefetch strategy limits, `when` example). **`website/public/llms.txt`** and **MCP** now ship **`deferred-hydration-reference`** from the repo guide; **docs search** deep-links “deferred hydration” to `core-apis#deferred-hydration`.
> 
> **Vite fixture** adds `prefetch={load()}` + media `when`, `split={false}` unsplit proof, and Playwright checks that prefetched chunks load before activation without extra requests, and that unsplit boundaries hydrate without new script fetches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e18d52432112388f8efa60c47d6ee35f79ee0f7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->