### PR TITLE
Rewrite the homepage Why section copy in the react.dev voice

### DIFF
--- a/website/src/pages/home/sections/Why.tsrx
+++ b/website/src/pages/home/sections/Why.tsrx
@@ -23,36 +23,32 @@ export function Why() @{
 			<div class="why-main">
 				<div class="why-grid">
 					<div class="why-row">
-						<h3 class="why-question">Why should someone adopt Octane today?</h3>
+						<h3 class="why-question">Why would I move my app to Octane?</h3>
 						<div class="why-answers">
 							<p class="why-answer">
-								{'Because adoption should build on what you already know. Octane keeps the ' +
-									'component-and-hooks mental model familiar, so developers carry over their ' +
-									'hard-won intuition.'}
+								{'Octane components are the components you already write. They are plain ' +
+									'functions with hooks, props, and context. If you know React, you know ' +
+									'Octane. Your instincts about where state lives and how data flows carry ' +
+									'over on day one.'}
 							</p>
 							<p class="why-answer">
-								{'For the large proportion of React codebases centered on function components ' +
-									'and hooks, that continuity also makes migration especially straightforward for ' +
-									'AI agents: they can preserve the app’s component boundaries and reasoning instead ' +
-									'of redesigning it around a new reactive model. Begin with standard TSX, then opt ' +
-									'into TSRX one component at a time; fewer rules and dependency lists let related ' +
-									'code stay together. Octane changes the machinery beneath your app without asking ' +
-									'everyone who works on it to start over.'}
+								{'You don’t have to rewrite your app to adopt it. Keep your existing TSX, ' +
+									'move components to TSRX one at a time, and ship the whole way. Components ' +
+									'keep their shape along the way, so AI agents can migrate an app too, ' +
+									'without redesigning it around a new reactive model.'}
 							</p>
 						</div>
 					</div>
 
 					<div class="why-row">
-						<h3 class="why-question">Why isn't Octane's rendering powered by signals?</h3>
+						<h3 class="why-question">Why isn't Octane built on signals?</h3>
 						<div class="why-answers">
 							<p class="why-answer">
-								{'Signals are good. They make updates wonderfully precise, and you can still use ' +
-									'them in an Octane app when that model fits the problem. But powering the framework ' +
-									'with signals would make them more than an optional tool; they would become part of ' +
-									'how every application represents and reads state. Octane makes a different trade: ' +
-									'components stay as familiar functions you can read from top to bottom, while the ' +
-									'compiler and runtime carry the complexity instead of spreading it through the ' +
-									'application.'}
+								{'Signals are a good tool, and you can still use them in an Octane app when ' +
+									'they fit. But a framework built on signals makes every app represent and ' +
+									'read state the signals way. Octane keeps components as plain functions ' +
+									'that read from top to bottom. The compiler does the extra work, so your ' +
+									'code doesn’t have to.'}
 							</p>
 						</div>
 					</div>
@@ -60,9 +56,9 @@ export function Why() @{
 
 				<blockquote class="why-coda">
 					<strong>The trade holds up.</strong>
-					{' Signals still win the workloads built for them, but across the checked-in ' +
-						'suites below, Octane’s tightly tuned compiler and runtime largely keep pace — ' +
-						'without asking you to rewire how you think. '}
+					{' Signals still win the workloads built for them. Across the checked-in ' +
+						'suites below, Octane keeps pace without asking you to rewire how you ' +
+						'think. '}
 					<Link to="/docs/tsrx-vs-tsx">See what TSRX adds →</Link>
 				</blockquote>
 			</div>

--- a/website/tests/smoke.test.ts
+++ b/website/tests/smoke.test.ts
@@ -150,8 +150,8 @@ describe('website routes', () => {
 			question.textContent?.trim(),
 		);
 		expect(whyQuestions).toEqual([
-			'Why should someone adopt Octane today?',
-			"Why isn't Octane's rendering powered by signals?",
+			'Why would I move my app to Octane?',
+			"Why isn't Octane built on signals?",
 		]);
 		expect(why.querySelector('.why-coda')?.textContent?.trim()).toBeTruthy();
 		expect(findLink(why, '/docs/tsrx-vs-tsx')).toBeTruthy();


### PR DESCRIPTION
## What

Feedback on the homepage was that the "Why" section (adopt today / why not signals) was too text-heavy and read as AI-generated. This rewrites the two answers and the coda at roughly half the length, styled after react.dev's homepage prose (pulled from the live site, not from memory): short declarative sentences, second-person address, "you don't have to…" reassurance framing, and benefit-closing lines. No em dashes anywhere in the rendered copy.

- Questions retitled: "Why would I move my app to Octane?" / "Why isn't Octane built on signals?"
- Answers rewritten, e.g. "If you know React, you know Octane." and "The compiler does the extra work, so your code doesn't have to."
- Coda tightened to two plain sentences.
- `website/tests/smoke.test.ts` pins the question headings, so it's updated to match.

## Validation

- Website vitest project green (smoke test pins the new headings).
- `pnpm typecheck` and repo-wide `pnpm format:check` pass.
- Playwright run against the dev server confirms the new copy renders with no page errors, no hydration warnings, and no em dashes in the section's rendered text.

Website-only, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Website marketing text and test expectations only; no runtime, API, or security impact.
> 
> **Overview**
> **Homepage “Why” section** copy is rewritten to be shorter and more direct (react.dev-style: second person, plain sentences, no em dashes).
> 
> Both FAQ headings change: adoption becomes **“Why would I move my app to Octane?”** and signals becomes **“Why isn't Octane built on signals?”** The two answer blocks and the **“The trade holds up.”** coda are tightened while keeping the same points (React familiarity, incremental TSRX migration, optional signals, benchmark parity).
> 
> `website/tests/smoke.test.ts` updates the pinned `.why-question` strings so route smoke still matches the rendered headings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 574373953c0274fc2e2af58bae03f8424cf0625e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->