### PR TITLE
Streaming SSR: native external-HTML injection (StreamOptions.injection)

### DIFF
--- a/.changeset/ssr-stream-injection.md
+++ b/.changeset/ssr-stream-injection.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Streaming SSR: add `StreamOptions.injection` (`StreamInjectionSource`) — merge a live stream of externally-produced HTML (e.g. a framework's data `<script>` tags) natively into `renderToPipeableStream` / `renderToReadableStream` output. Injected HTML is emitted verbatim, in push order, each drain as its own chunk strictly between tag-complete renderer chunks — never before the shell; for document renders the `</body></html>` tail is held and written last, and the stream closes only once rendering is complete and the source's `done` promise settles. Without the option, streamed output is unchanged.

--- a/docs/ssr-stream-injection-plan.md
+++ b/docs/ssr-stream-injection-plan.md
@@ -1,0 +1,202 @@
+# SSR stream injection — native external-HTML merging for streamed renders
+
+Status: CORE API IMPLEMENTED (2026-07-18) — `StreamOptions.injection`
+(`StreamInjectionSource`) landed in `runtime.server.ts` with contract tests in
+`packages/octane/tests/streaming-ssr-injection.test.ts` (both compile modes)
+and a flat streaming-ssr benchmark for the no-injection path; user docs in
+`docs/ssr.md`. Open question 2 resolved as proposed: the tail is held ONLY
+when `injection` is present. Remaining phases: the styles-in-head + auto-
+doctype adjacent gaps below, and switching `@octanejs/tanstack-start`'s
+vendored stream path onto the native API (which also restores out-of-order
+streaming for document renders — the current upstream transform buffers every
+post-shell chunk into its 64 KiB-capped tail until both streams end).
+Requested by: TanStack team feedback via the `@tanstack/octane-start` integration
+(2026-07-18).
+
+## The ask
+
+TanStack Start merges two HTML sources into one response stream: the render
+framework's SSR stream, and the router's data stream (`<script>` tags carrying
+serialized loader data, streamed-promise resolutions, and hydration metadata
+that materialize over time as loaders settle). Today that merge happens
+OUTSIDE the framework, by decoding the framework's byte stream and re-parsing
+it as text to find safe insertion points. The ask: let a framework hand octane
+a live source of `<script>` HTML and have octane merge it natively — octane
+already knows its own tag boundaries, so the text re-parsing is pure overhead.
+
+## What the external merge does today (upstream TanStack)
+
+`@tanstack/router-core/ssr/server` `transformStreamWithRouter`
+(dist/esm/ssr/transformStreamWithRouter.js) pipes octane's stream through a
+transform that:
+
+1. Decodes bytes → text (`TextDecoder`, re-encoding on write).
+2. Scans every chunk BACKWARDS for the last complete closing tag
+   (`findHtmlBoundary`) so injected scripts never land mid-tag, keeping a
+   `leftover` buffer (capped 2 KiB) for partial tags split across chunks.
+3. Detects `</body>` and holds everything from it onward as a `pendingTail`
+   (capped 64 KiB) so injected scripts always land inside `<body>` — octane's
+   shell chunk contains the FULL document including `</body></html>`, and
+   octane's own suspense segments stream after `</html>`, so the transform
+   effectively restructures octane's output around the tail.
+4. Flushes router HTML queued by `serverSsr.onInjectedHtml` at each safe
+   boundary (event-driven, capped 16 MiB), plus a `$tsr-stream-barrier`
+   marker protocol that holds scripts until a marker rendered by the app has
+   flushed.
+5. Closes only when BOTH the app stream is done AND router serialization is
+   finished (`onSerializationFinished`), then emits leftover + pending scripts
+   + the held tail. Serialization/lifetime timeouts guard the wait.
+
+On top of that, `@tanstack/octane-router/ssr/renderRouterToStream.ts` runs two
+MORE text-level transforms working around missing octane hooks:
+
+- `relocateLeadingOctaneStylesToHead` — octane emits renderer-owned scoped
+  `<style data-octane>` blocks BEFORE the markup; for a full document that
+  puts them before `<html>`, so the transform holds them and re-inserts after
+  the opening `<head>` (bounded 64 KiB document-prefix buffer).
+- `prependDoctype` — octane never emits `<!DOCTYPE html>`.
+
+## Why octane can do this natively, cheaply
+
+Octane's streaming engine (`runtime.server.ts`, `runStream`, ~line 5913) is
+pass-based and writes discrete chunks through a single `StreamSink`:
+
+- the shell chunk (leading styles + head + body + seeds + swap runtime),
+- one chunk per resolution wave (new styles + completed boundary segments),
+- terminal degraded-boundary markers.
+
+Every `sink.write` boundary is tag-complete BY CONSTRUCTION — octane
+concatenates whole elements; a chunk can never end mid-tag. So "find a safe
+insertion point" is free: every point between two sink writes is safe. The
+three pieces of information the external transform reconstructs by parsing —
+tag boundaries, the `</body>` position, and end-of-render — are all first-class
+facts inside `runStream`.
+
+## Proposed API (octane extension tier, not React parity)
+
+React has no equivalent (Fizz owns its data injection internally), so this is
+an octane-only extension on the existing `StreamOptions`, exported under
+`octane/server`:
+
+```ts
+export interface StreamInjectionSource {
+	/**
+	 * Pull queued HTML (concatenated, verbatim). Called by the renderer at
+	 * every emission boundary; return '' when nothing is queued.
+	 */
+	take(): string;
+	/**
+	 * The source notifies when new HTML is queued. The renderer then flushes
+	 * promptly as its own chunk — even when no render output is pending.
+	 * Returns an unsubscribe function; the renderer unsubscribes on
+	 * completion, abort, and error.
+	 */
+	subscribe(notify: () => void): () => void;
+	/**
+	 * The renderer holds the document tail (`</body></html>` for document
+	 * renders) and the stream close until this settles. A rejection aborts
+	 * the stream through the existing fatal path.
+	 */
+	done: Promise<void>;
+}
+
+interface StreamOptions {
+	// ...existing: signal, nonce, onError, onShellReady, onAllReady, ...
+	injection?: StreamInjectionSource;
+}
+```
+
+Renderer contract:
+
+1. **Placement** — injected HTML is emitted verbatim, in push order, as its own
+   chunks strictly BETWEEN renderer chunks, and (for document renders) before
+   the held `</body></html>` tail. Never interleaved inside a renderer chunk.
+2. **Tail holding** — when the shell renders a document (`<html>`/`<body>`
+   detected at generation time, not by re-parsing), the closing
+   `</body></html>` is split out of the shell chunk and written last: after
+   the final wave AND after `injection.done` settles. Suspense segments —
+   which today stream after `</html>` — consequently move INSIDE body, which
+   is also strictly more correct HTML. Fragment renders have no tail; injected
+   chunks simply append between renderer chunks, and `done` still gates close.
+3. **Liveness** — a `subscribe` notification triggers a flush through the same
+   serialized write path as render output (total order, backpressure through
+   the existing sink pressure gate). When the render finishes first, the
+   stream stays open draining injections until `done`; `signal` abort and the
+   existing timeout guards still bound the wait, and the terminal path drains
+   a final `take()` before the tail so late scripts aren't dropped.
+4. **Errors** — `done` rejection or a `take()`/`subscribe` throw routes through
+   the existing fatal path (degraded-boundary markers + `sink.fatal`), after
+   unsubscribing.
+
+### Adjacent gaps to close in the same change (both currently worked around by
+### text transforms in octane-router)
+
+- **Styles-in-head**: when the shell pass renders a document with a `<head>`,
+  emit renderer-owned `<style data-octane>` blocks inside it instead of before
+  `<html>` (this is where the styles belong; the pre-markup position only
+  serves fragment roots, which keep the current behavior).
+- **Doctype**: emit `<!DOCTYPE html>` automatically when the root element is
+  `<html>` (React Fizz parity).
+
+With those, `@tanstack/octane-start`'s stream path reduces to: render with
+`injection` wired to `serverSsr` (push on `onInjectedHtml`, resolve `done` on
+`onSerializationFinished`, keep their barrier/timeout policy upstream of the
+source), and the entire `transformStreamWithRouter` +
+`relocateLeadingOctaneStylesToHead` + `prependDoctype` pipeline disappears for
+octane. The bot/buffered path (`prerender` + `finalizeBufferedHtml` splicing)
+is out of scope here but could later accept a buffered variant (a single
+`take()` at finalize before the tail).
+
+## Implementation sketch
+
+All inside `packages/octane/src/runtime.server.ts`:
+
+- `runStream` gains an injection drain: a `drainInjection()` that `take()`s and
+  writes through a small promise-chained writer shared with the wave loop
+  (total write order; the loop currently awaits `sink.write` inline, so the
+  chain is the one new mechanism — out-of-band notifies must not interleave
+  with an in-flight wave write).
+- Shell emission: for document renders, split the tail before writing
+  (`pass.body` generation can carry the split point out of the emitter so no
+  string scanning is needed; a one-time `lastIndexOf('</body>')` on the shell
+  string is the fallback and is still O(shell) once, not O(stream)).
+- Drain points: after the shell write, after each wave write, on notify, and
+  terminally before the tail in both the success and fatal paths.
+- Completion: `sink.allReady()`/close waits on `Promise.all`-style composition
+  of the wave loop and `injection.done`, still guarded by `signal` and the
+  existing MAX/timeout machinery.
+- Both public sinks (`renderToPipeableStream`, `renderToReadableStream`)
+  inherit the behavior unchanged — the feature lives entirely in `runStream`
+  + shell assembly.
+
+## Validation plan (core-engineering.md discipline)
+
+- Contract tests in `packages/octane/tests/streaming-ssr` territory: ordering
+  (injected between chunks, never inside), document tail held until `done`,
+  fragment renders, notify-while-idle flushes, done-before-render /
+  render-before-done, abort mid-injection, `done` rejection, backpressure
+  (injection respects sink pressure), nonce untouched on injected content.
+- A document-render streaming test (none exists today — current streaming
+  tests are fragment-focused) pinning tail placement + segments-inside-body.
+- Differential proof at the Start layer: drive the website through a
+  `serverSsr`-backed injection source and byte-compare against the current
+  `transformStreamWithRouter` output (modulo segment placement now being
+  inside `<body>`, which hydration must and does tolerate — covered by the
+  existing website e2e).
+- Perf: `benchmarks/streaming-ssr` + `benchmarks/ssr-throughput` before/after
+  for the no-injection path (must be flat — the feature must cost nothing when
+  `injection` is absent), plus a website-route measurement for the injected
+  path (expected win: removes decode→scan→re-encode of the full stream).
+
+## Open questions
+
+1. Should `injection` also gate `onAllReady` (React's semantics for "document
+   fully ready") or only the close? Proposal: gate close only; `onAllReady`
+   stays render-complete (documented).
+2. Segment placement moving inside `<body>` changes streamed-HTML shape for
+   ALL document renders (even without injection) if tail-holding is
+   unconditional. Proposal: hold the tail only when `injection` is present, to
+   keep the no-injection byte shape identical until measured separately.
+3. Whether TanStack's barrier protocol wants a first-class hook ("notify me
+   when the shell was accepted by the transport") — `onShellReady` already
+   fires at that point, so probably no new API is needed.

--- a/docs/ssr.md
+++ b/docs/ssr.md
@@ -95,13 +95,35 @@ use the same keyed hydration ranges as arrays. A thenable that settles while it
 is first subscribed is unwrapped in that render without publishing a fallback.
 
 `StreamOptions` extends `RenderOptions` with `onShellReady()`,
-`onShellError(err)`, and `onAllReady()`. A recoverable error in Suspense content
-reaches `onError`, preserves the emitted fallback, and marks only that boundary
-for client rendering. Calling `abort(reason)` reports the reason for each
-abandoned pending task, preserves emitted fallbacks for client recovery, closes
-the destination, and invokes `onAllReady` once as the terminal readiness
-notification; an unpublished shell still fails only once through
+`onShellError(err)`, `onAllReady()`, and `injection`. A recoverable error in
+Suspense content reaches `onError`, preserves the emitted fallback, and marks
+only that boundary for client rendering. Calling `abort(reason)` reports the
+reason for each abandoned pending task, preserves emitted fallbacks for client
+recovery, closes the destination, and invokes `onAllReady` once as the terminal
+readiness notification; an unpublished shell still fails only once through
 `onShellError`.
+
+#### `injection?: StreamInjectionSource` (Octane extension)
+
+Merge a live stream of externally-produced HTML — typically framework data
+`<script>` tags materializing as loaders settle (e.g. TanStack Start's data
+stream) — into the response natively, instead of re-parsing the emitted HTML
+for safe insertion points. The source is
+`{ take(): string; subscribe(notify) => unsubscribe; done: Promise<void> }`:
+the renderer `take()`s queued HTML and emits it verbatim, in push order, each
+drain as its own transport chunk strictly **between** renderer chunks (every
+such boundary is tag-complete by construction) — never before the shell.
+
+When the shell is a document (`… </body></html>`), the closing tail is split
+out and written **last**: injected chunks and streamed Suspense segments land
+inside `<body>`, and the stream — tail included — closes only once rendering
+is complete **and** `done` has settled, so late data scripts are never
+dropped. `subscribe` notifications drain promptly even while the render is
+idle awaiting `done`; bound the wait with `signal` (a source that never
+settles `done` holds the response open). A `done` rejection fails the stream
+through the same degraded terminal path as `abort`. Without `injection`,
+streamed output is byte-identical to previous releases (measured flat on the
+streaming-ssr benchmark).
 
 ### `renderToReadableStream(component, props?, options?)` — `octane/server`
 

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -5837,10 +5837,47 @@ interface StreamSink {
 	fatal(err: unknown): void;
 }
 
+/**
+ * A live source of externally-produced HTML (typically framework data
+ * `<script>` tags materializing as loaders settle) merged natively into a
+ * streamed render. Octane emits injected HTML verbatim, in push order, each
+ * drain as its own transport chunk strictly BETWEEN renderer chunks — never
+ * before the shell, and (for document renders) before the held
+ * `</body></html>` tail. The stream stays open until `done` settles.
+ *
+ * This is an Octane extension (React's Fizz owns its data injection
+ * internally); it exists so frameworks like TanStack Start can merge their
+ * data stream without re-parsing the HTML byte stream for safe insertion
+ * points — every boundary between renderer chunks is tag-complete by
+ * construction.
+ */
+export interface StreamInjectionSource {
+	/**
+	 * Pull all queued HTML (concatenated, verbatim). Called at emission
+	 * boundaries and after `subscribe` notifications; return '' when empty.
+	 */
+	take(): string;
+	/**
+	 * The source notifies when new HTML is queued; the renderer then drains
+	 * promptly — even while the render itself is idle awaiting `done`.
+	 * Returns an unsubscribe function; the renderer unsubscribes on
+	 * completion, abort, and failure.
+	 */
+	subscribe(notify: () => void): () => void;
+	/**
+	 * The renderer holds the document tail and the stream close until this
+	 * settles. A rejection fails the stream through the fatal path (after the
+	 * shell, mirroring abort: degraded terminal completion).
+	 */
+	done: Promise<void>;
+}
+
 export interface StreamOptions extends RenderOptions {
 	onShellReady?: () => void;
 	onShellError?: (err: unknown) => void;
 	onAllReady?: () => void;
+	/** Merge externally-produced HTML into the stream (see StreamInjectionSource). */
+	injection?: StreamInjectionSource;
 }
 
 function withStream<T>(stream: StreamState | null, fn: () => T): T {
@@ -5851,6 +5888,18 @@ function withStream<T>(stream: StreamState | null, fn: () => T): T {
 	} finally {
 		STREAM = prev;
 	}
+}
+
+// For document renders under external injection, the closing `</body></html>`
+// is split out of the shell and held until both the render and the injection
+// source finish. De-opt block markers interleave with the closing tags
+// (`</body><!--]--></html><!--]-->`), so a true document suffix is `</body>`
+// followed by nothing but comments/whitespace and one `</html>`.
+const DOCUMENT_TAIL_RE = /^<\/body>(?:\s|<!--[^]*?-->)*<\/html>(?:\s|<!--[^]*?-->)*$/;
+function documentTailStart(body: string): number {
+	const index = body.lastIndexOf('</body>');
+	if (index === -1) return -1;
+	return DOCUMENT_TAIL_RE.test(body.slice(index)) ? index : -1;
 }
 
 function segmentChunk(b: StreamBoundary, nonceAttr: string): string {
@@ -5947,6 +5996,77 @@ async function runStream(
 			stream.activePassBoundaryKeys = previousBoundaryKeys;
 		}
 	};
+	// ── External injection (cold path: every hook below no-ops when absent) ──
+	const injection = options?.injection;
+	// Early fatal paths can return before `done` is awaited; observe it up
+	// front so a later rejection never surfaces as an unhandled rejection.
+	if (injection !== undefined) injection.done.then(NOOP, NOOP);
+	let injectionUnsubscribe: (() => void) | undefined;
+	let injectionFailure: unknown;
+	let injectionFailed = false;
+	let signalInjectionFailure: (() => void) | undefined;
+	const failInjection = (err: unknown): void => {
+		if (injectionFailed) return;
+		injectionFailed = true;
+		injectionFailure = err;
+		signalInjectionFailure?.();
+	};
+	// Injection drains interleave with render writes from OUTSIDE the wave
+	// loop (subscribe notifications can fire while the loop awaits a wave or
+	// the done promise). A single promise chain gives all writes a total
+	// order while each write still surfaces its own backpressure/failure to
+	// its caller. Without injection, writes go to the sink directly — the
+	// established path, no chain, no extra microtasks.
+	let writeChain: Promise<void> | null = injection === undefined ? null : Promise.resolve();
+	const write: (chunk: string, terminal?: boolean) => void | Promise<void> =
+		injection === undefined
+			? (chunk, terminal) => sink.write(chunk, terminal)
+			: (chunk, terminal) => {
+					const operation = writeChain!.then(() => sink.write(chunk, terminal));
+					writeChain = operation.then(NOOP, NOOP);
+					return operation;
+				};
+	const drainInjection = (): void | Promise<void> => {
+		if (injection === undefined || injectionFailed) return;
+		let html: string;
+		try {
+			html = injection.take();
+		} catch (err) {
+			failInjection(err);
+			return;
+		}
+		if (!html) return;
+		return write(html);
+	};
+	const notifyInjection = (): void => {
+		const drained = drainInjection();
+		// A transport failure here is re-observed by the next awaited render
+		// write (or the completion wait); the notify path only must not
+		// produce an unhandled rejection.
+		if (drained !== undefined) drained.catch(NOOP);
+	};
+	/** Resolves when `done` settles; rejects on abort, take() failure, or done rejection. */
+	const waitForInjectionDone = (): Promise<void> =>
+		new Promise<void>((resolve, reject) => {
+			let settled = false;
+			const finish = (fn: () => void): void => {
+				if (settled) return;
+				settled = true;
+				signal?.removeEventListener('abort', onAbort);
+				signalInjectionFailure = undefined;
+				fn();
+			};
+			const onAbort = (): void => finish(() => reject(signal!.reason));
+			signalInjectionFailure = () => finish(() => reject(injectionFailure));
+			if (injectionFailed) return finish(() => reject(injectionFailure));
+			if (signal?.aborted) return onAbort();
+			signal?.addEventListener('abort', onAbort, { once: true });
+			injection!.done.then(
+				() => finish(resolve),
+				(err) => finish(() => reject(err)),
+			);
+		});
+
 	const emittedCss = new Set<string>();
 	const flushedSegments = new Set<string>();
 	const observedDone = new Set<string>();
@@ -5994,15 +6114,15 @@ async function runStream(
 		if (errors.length === 0) return;
 		let chunk = '';
 		for (const boundary of errors) chunk += boundaryErrorChunk(boundary, nonceAttr);
-		const write = sink.write(chunk);
+		const errorWrite = write(chunk);
 		const markFlushed = (): void => {
 			for (const boundary of errors) boundary.errorFlushed = true;
 		};
-		if (write === undefined) {
+		if (errorWrite === undefined) {
 			markFlushed();
 			return;
 		}
-		return write.then(markFlushed);
+		return errorWrite.then(markFlushed);
 	};
 
 	let pass: FullPassResult;
@@ -6058,13 +6178,30 @@ async function runStream(
 			escapeEntireInlineStyleContent(sheet) +
 			'</style>';
 	}
-	shell += pass.head + pass.body;
+	// Under external injection a document's closing tail is split out of the
+	// shell and written LAST — injected chunks and streamed segments then land
+	// inside <body> before it (streamed segments otherwise trail `</html>`,
+	// which browsers reparent but external merge layers must not re-parse
+	// around). The tail carries only closing tags + block markers, so it needs
+	// no vt stripping. Without injection the shell shape is unchanged.
+	let heldDocumentTail = '';
+	if (injection !== undefined) {
+		const tailStart = documentTailStart(pass.body);
+		if (tailStart !== -1) {
+			heldDocumentTail = pass.body.slice(tailStart);
+			shell += pass.head + pass.body.slice(0, tailStart);
+		} else {
+			shell += pass.head + pass.body;
+		}
+	} else {
+		shell += pass.head + pass.body;
+	}
 	if (pass.serial.length > 0) shell += serializeSuspenseSeeds(pass.serial, nonceAttr);
 	const anyPending = stream.boundaries.size > 0;
 	if (anyPending)
 		shell += '<script ' + STREAM_SCRIPT_ATTR + nonceAttr + '>' + STREAM_RUNTIME_JS + '</script>';
 	try {
-		const shellWrite = sink.write(pass.vtCandidates ? vtSsrStrip(shell) : shell);
+		const shellWrite = write(pass.vtCandidates ? vtSsrStrip(shell) : shell);
 		if (shellWrite !== undefined) await shellWrite;
 	} catch (err) {
 		options?.onError?.(err);
@@ -6072,6 +6209,17 @@ async function runStream(
 		return;
 	}
 	sink.shellReady();
+	if (injection !== undefined) {
+		// Subscribe only once the shell is on the wire: injected HTML must never
+		// precede it. HTML queued before this point is picked up by the initial
+		// drain below.
+		try {
+			injectionUnsubscribe = injection.subscribe(notifyInjection);
+		} catch (err) {
+			failInjection(err);
+		}
+		notifyInjection();
+	}
 
 	let suspended = pass.suspended;
 	// `attempt` counts CONSECUTIVE passes that completed no boundary. One pass
@@ -6091,7 +6239,7 @@ async function runStream(
 		if (initiallyDone.length > 0) {
 			let chunk = '';
 			for (const boundary of initiallyDone) chunk += segmentChunk(boundary, nonceAttr);
-			const segmentWrite = sink.write(pass.vtCandidates ? vtSsrStrip(chunk) : chunk);
+			const segmentWrite = write(pass.vtCandidates ? vtSsrStrip(chunk) : chunk);
 			if (segmentWrite !== undefined) await segmentWrite;
 			for (const boundary of initiallyDone) {
 				flushedSegments.add(boundary.id);
@@ -6149,7 +6297,7 @@ async function runStream(
 			const done = reachableDoneSegments();
 			for (const b of done) chunk += segmentChunk(b, nonceAttr);
 			if (chunk !== '') {
-				const segmentWrite = sink.write(pass.vtCandidates ? vtSsrStrip(chunk) : chunk);
+				const segmentWrite = write(pass.vtCandidates ? vtSsrStrip(chunk) : chunk);
 				if (segmentWrite !== undefined) await segmentWrite;
 				// A boundary isn't considered flushed until the transport accepted its
 				// chunk through any active backpressure gate.
@@ -6172,16 +6320,55 @@ async function runStream(
 		for (const b of stream.boundaries.values()) {
 			if (!flushedSegments.has(b.id) && !b.errorFlushed) tail += boundaryErrorChunk(b, nonceAttr);
 		}
+		// Best-effort well-formedness under injection: the held document tail
+		// still closes <body>/<html> after the degraded-boundary markers.
+		if (heldDocumentTail !== '') tail += heldDocumentTail;
 		if (tail !== '') {
 			try {
-				const terminalWrite = sink.write(tail, true);
+				const terminalWrite = write(tail, true);
 				if (terminalWrite !== undefined) await terminalWrite;
 			} catch {
 				// The transport is already gone; there is nowhere to send recovery.
 			}
 		}
+		injectionUnsubscribe?.();
 		sink.fatal(err);
 		return;
+	}
+	if (injection !== undefined) {
+		// Rendering is complete but the injection source may still be producing
+		// (subscribe notifications keep draining through the write chain while
+		// we wait). The stream — and a document's held tail — close only once
+		// `done` settles; abort and source failures route through the same
+		// degraded terminal path as a mid-render abort.
+		try {
+			await waitForInjectionDone();
+			const finalDrain = drainInjection();
+			if (finalDrain !== undefined) await finalDrain;
+			if (injectionFailed) throw injectionFailure;
+			if (heldDocumentTail !== '') {
+				// Cleared before awaiting: a post-acceptance rejection (abort racing
+				// the drain wait) must not resend the tail through the catch below.
+				const tailChunk = heldDocumentTail;
+				heldDocumentTail = '';
+				const tailWrite = write(tailChunk);
+				if (tailWrite !== undefined) await tailWrite;
+			}
+		} catch (err) {
+			options?.onError?.(err);
+			if (heldDocumentTail !== '') {
+				try {
+					const terminalWrite = write(heldDocumentTail, true);
+					if (terminalWrite !== undefined) await terminalWrite;
+				} catch {
+					// The transport is already gone; there is nowhere to send the tail.
+				}
+			}
+			injectionUnsubscribe?.();
+			sink.fatal(err);
+			return;
+		}
+		injectionUnsubscribe?.();
 	}
 	sink.allReady();
 }

--- a/packages/octane/src/server/index.ts
+++ b/packages/octane/src/server/index.ts
@@ -35,6 +35,7 @@ export {
 	type RenderResult,
 	type RenderOptions,
 	type StreamOptions,
+	type StreamInjectionSource,
 	setSsrSuspenseTimeout,
 	getSsrSuspenseTimeout,
 	EXTERNAL_HYDRATION_PROMISE,

--- a/packages/octane/tests/_fixtures/ssr-injection.tsrx
+++ b/packages/octane/tests/_fixtures/ssr-injection.tsrx
@@ -1,0 +1,35 @@
+import { createElement, use } from 'octane';
+
+// Streaming SSR external-injection fixtures: a fragment root and a
+// full-document root, each with one @try boundary suspending on a promise
+// prop. The document shell (html/head/body) is built with createElement — the
+// same shape framework document components use (authored `<head>` is not
+// supported in .tsrx; head elements hoist) — which is exactly the surface
+// external `<script>` injection merges into.
+
+function Inner(props) @{
+	const value = use(props.promise);
+	<p id="inner">
+		{value as string}
+	</p>
+}
+
+export function FragmentApp(props) @{
+	<div id="app">
+		<p>shell</p>
+		@try {
+			<Inner promise={props.promise} />
+		} @pending {
+			<p id="pending">loading</p>
+		}
+	</div>
+}
+
+export function DocumentApp(props) {
+	return createElement(
+		'html',
+		{ lang: 'en' },
+		createElement('head', null, createElement('title', null, 'injection')),
+		createElement('body', null, createElement(FragmentApp, { promise: props.promise })),
+	);
+}

--- a/packages/octane/tests/streaming-ssr-injection.test.ts
+++ b/packages/octane/tests/streaming-ssr-injection.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as ServerRuntime from 'octane/server';
+import { loadServerFixture } from './_server-fixture.js';
+import {
+	collectPipeableStream,
+	collectReadableStream,
+	createPipeableCollector,
+	deferred,
+	resetStreamRuntimeGlobals,
+} from './_server-stream.js';
+
+// Streaming SSR — external HTML injection (`StreamOptions.injection`). A
+// framework (e.g. TanStack Start) produces `<script>` chunks over time as its
+// loaders settle; the renderer merges them into the response stream natively:
+// verbatim, in push order, each as its own transport chunk strictly between
+// renderer chunks, never before the shell, and — for document renders — before
+// the held `</body></html>` tail. The stream stays open until the source's
+// `done` promise settles, so late data scripts are never dropped. Without the
+// option, streamed output is byte-identical to before.
+
+const FIXTURE = 'packages/octane/tests/_fixtures/ssr-injection.tsrx';
+const server = loadServerFixture(FIXTURE);
+
+afterEach(resetStreamRuntimeGlobals);
+
+interface TestInjection {
+	source: ServerRuntime.StreamInjectionSource;
+	push(html: string): void;
+	finish(): void;
+	fail(reason: unknown): void;
+	readonly subscribed: boolean;
+	readonly unsubscribed: boolean;
+}
+
+function createTestInjection(): TestInjection {
+	const queue: string[] = [];
+	let notify: (() => void) | null = null;
+	let subscribed = false;
+	let unsubscribed = false;
+	const done = deferred<void>();
+	// The renderer must observe `done` rejections itself; a consumer-side guard
+	// here keeps a failed test from dying on an unrelated unhandled rejection.
+	done.promise.catch(() => {});
+	return {
+		source: {
+			take: () => queue.splice(0).join(''),
+			subscribe(callback) {
+				subscribed = true;
+				notify = callback;
+				return () => {
+					unsubscribed = true;
+					notify = null;
+				};
+			},
+			done: done.promise,
+		},
+		push(html) {
+			queue.push(html);
+			notify?.();
+		},
+		finish: () => done.resolve(),
+		fail: (reason) => done.reject(reason),
+		get subscribed() {
+			return subscribed;
+		},
+		get unsubscribed() {
+			return unsubscribed;
+		},
+	};
+}
+
+const flushMicrotasks = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+// A document's closing tail: `</body>` followed by nothing but comment markers
+// (hydration block markers interleave with the closing tags) and `</html>`.
+const DOCUMENT_TAIL = /^<\/body>(?:\s|<!--[^]*?-->)*<\/html>(?:\s|<!--[^]*?-->)*$/;
+function tailOf(html: string): string {
+	const index = html.lastIndexOf('</body>');
+	expect(index).toBeGreaterThan(-1);
+	return html.slice(index);
+}
+
+describe('streaming injection — fragment renders', () => {
+	it('delivers pushed HTML verbatim, in order, as its own chunks between renderer chunks', async () => {
+		const value = deferred<string>();
+		const injection = createTestInjection();
+		const scriptA = '<script data-inject="a">window.__a=1</script>';
+		const scriptB = '<script data-inject="b">window.__b=1</script>';
+
+		const result = collectPipeableStream(
+			server.FragmentApp,
+			{ promise: value.promise },
+			{
+				injection: injection.source,
+			},
+		);
+		// Data available while the boundary is still pending.
+		await flushMicrotasks();
+		injection.push(scriptA);
+		await flushMicrotasks();
+		value.resolve('streamed');
+		await flushMicrotasks();
+		injection.push(scriptB);
+		injection.finish();
+
+		const { html, chunks } = await result;
+		// Verbatim + ordered: A before B, both after the shell chunk.
+		expect(html).toContain(scriptA);
+		expect(html).toContain(scriptB);
+		expect(html.indexOf(scriptA)).toBeLessThan(html.indexOf(scriptB));
+		expect(html.indexOf('shell')).toBeLessThan(html.indexOf(scriptA));
+		// Each injected payload is its own transport chunk — never spliced into
+		// the middle of a renderer chunk.
+		expect(chunks).toContain(scriptA);
+		expect(chunks).toContain(scriptB);
+		// The revealed boundary content still streamed normally.
+		expect(html).toContain('streamed');
+	});
+
+	it('holds the stream open until `done` settles and drains idle pushes promptly', async () => {
+		const value = deferred<string>();
+		const injection = createTestInjection();
+		const collector = createPipeableCollector();
+		let allReady = false;
+		let ended = false;
+		void collector.ended.then(() => {
+			ended = true;
+		});
+
+		ServerRuntime.renderToPipeableStream(
+			server.FragmentApp,
+			{ promise: value.promise },
+			{
+				injection: injection.source,
+				onAllReady: () => {
+					allReady = true;
+				},
+			},
+		).pipe(collector.destination);
+
+		value.resolve('streamed');
+		await flushMicrotasks();
+		await flushMicrotasks();
+		// Rendering is complete, but the injection source is not done: the
+		// response must stay open.
+		expect(ended).toBe(false);
+
+		// A push while the renderer is idle still reaches the wire without any
+		// renderer output to piggyback on.
+		const late = '<script data-inject="late">window.__late=1</script>';
+		injection.push(late);
+		await flushMicrotasks();
+		expect(collector.chunks).toContain(late);
+		expect(ended).toBe(false);
+
+		injection.finish();
+		await collector.ended;
+		expect(allReady).toBe(true);
+		expect(injection.unsubscribed).toBe(true);
+		expect(collector.chunks.join('')).toContain('streamed');
+	});
+
+	it('never emits injected HTML before the shell', async () => {
+		const value = deferred<string>();
+		const injection = createTestInjection();
+		// Queued before the render even starts.
+		const early = '<script data-inject="early">window.__early=1</script>';
+		injection.push(early);
+		value.resolve('streamed');
+		injection.finish();
+
+		const { html, chunks } = await collectPipeableStream(
+			server.FragmentApp,
+			{ promise: value.promise },
+			{ injection: injection.source },
+		);
+		expect(html).toContain(early);
+		expect(chunks[0]).not.toContain(early);
+		expect(html.indexOf('shell')).toBeLessThan(html.indexOf(early));
+	});
+
+	it('merges through the web-stream API identically', async () => {
+		const value = deferred<string>();
+		const injection = createTestInjection();
+		const script = '<script data-inject="w">window.__w=1</script>';
+		value.resolve('streamed');
+
+		const result = collectReadableStream(
+			server.FragmentApp,
+			{ promise: value.promise },
+			{
+				injection: injection.source,
+			},
+		);
+		await flushMicrotasks();
+		injection.push(script);
+		injection.finish();
+
+		const { html } = await result;
+		expect(html).toContain(script);
+		expect(html).toContain('streamed');
+		expect(html.indexOf('shell')).toBeLessThan(html.indexOf(script));
+	});
+});
+
+describe('streaming injection — document renders', () => {
+	it('holds </body></html> until render and injection both finish', async () => {
+		const value = deferred<string>();
+		const injection = createTestInjection();
+		const dataScript = '<script data-inject="doc">window.__doc=1</script>';
+
+		const result = collectPipeableStream(
+			server.DocumentApp,
+			{ promise: value.promise },
+			{
+				injection: injection.source,
+			},
+		);
+		await flushMicrotasks();
+		value.resolve('streamed');
+		await flushMicrotasks();
+		injection.push(dataScript);
+		injection.finish();
+
+		const { html, chunks } = await result;
+		// The response is a well-formed document that ends with the tail…
+		expect(tailOf(html)).toMatch(DOCUMENT_TAIL);
+		// …the tail appears exactly once…
+		expect(html.match(/<\/body>/g)).toHaveLength(1);
+		expect(html.match(/<\/html>/g)).toHaveLength(1);
+		// …and the injected script AND the streamed boundary content precede it,
+		// i.e. they live inside <body>.
+		expect(html.indexOf(dataScript)).toBeLessThan(html.indexOf('</body>'));
+		expect(html.indexOf('streamed')).toBeLessThan(html.indexOf('</body>'));
+		// The shell chunk no longer carries the tail; the tail is the final chunk.
+		expect(chunks[0]).not.toContain('</body>');
+		expect(chunks[chunks.length - 1]).toMatch(DOCUMENT_TAIL);
+	});
+
+	it('keeps document output byte-identical when no injection source is supplied', async () => {
+		const value = deferred<string>();
+		value.resolve('streamed');
+		const { chunks } = await collectPipeableStream(server.DocumentApp, {
+			promise: value.promise,
+		});
+		// Without injection the shell still contains the closing tags — the
+		// pre-feature stream shape is preserved exactly.
+		expect(chunks[0]).toContain('</body>');
+		expect(chunks[0]).toContain('</html>');
+	});
+});
+
+describe('streaming injection — failure modes', () => {
+	it('a rejected `done` fails the stream after rendering', async () => {
+		const value = deferred<string>();
+		const injection = createTestInjection();
+		value.resolve('streamed');
+
+		const errors: unknown[] = [];
+		const boom = new Error('serialization failed');
+		const collector = createPipeableCollector();
+		let allReady = false;
+		ServerRuntime.renderToPipeableStream(
+			server.FragmentApp,
+			{ promise: value.promise },
+			{
+				injection: injection.source,
+				onError: (error) => {
+					errors.push(error);
+				},
+				onAllReady: () => {
+					allReady = true;
+				},
+			},
+		).pipe(collector.destination);
+
+		await flushMicrotasks();
+		await flushMicrotasks();
+		injection.fail(boom);
+		await collector.ended;
+		expect(errors).toContain(boom);
+		// Degraded terminal completion mirrors the abort path: the consumer's
+		// completion callback still fires so surrounding document work ends.
+		expect(allReady).toBe(true);
+		expect(injection.unsubscribed).toBe(true);
+	});
+
+	it('an abort while awaiting `done` still ends the response with the held document tail', async () => {
+		const value = deferred<string>();
+		const injection = createTestInjection();
+		value.resolve('streamed');
+
+		const errors: unknown[] = [];
+		const collector = createPipeableCollector();
+		const render = ServerRuntime.renderToPipeableStream(
+			server.DocumentApp,
+			{ promise: value.promise },
+			{
+				injection: injection.source,
+				onError: (error) => {
+					errors.push(error);
+				},
+			},
+		);
+		render.pipe(collector.destination);
+		await flushMicrotasks();
+		await flushMicrotasks();
+		render.abort(new Error('client disconnected'));
+		const html = await collector.ended;
+		expect(errors.length).toBeGreaterThan(0);
+		// Best-effort well-formedness: the held tail is flushed terminally so the
+		// aborted document still closes <body>/<html>.
+		expect(tailOf(html)).toMatch(DOCUMENT_TAIL);
+		expect(injection.unsubscribed).toBe(true);
+	});
+});


### PR DESCRIPTION
## Why

TanStack team feedback on the Start integration: Start merges its data stream (`<script>` tags materializing as loaders settle) into the framework's HTML stream by decoding the bytes and re-parsing every chunk for safe insertion points (`transformStreamWithRouter`: backwards closing-tag scans, leftover buffers, a held `</body>` tail, four size caps, full decode→re-encode). Octane's streaming engine already emits **tag-complete chunks** and knows the document tail at generation time — so the merge is now first-class instead.

Along the way this surfaced a real defect in the external approach: for octane document renders the upstream transform enters tail-holding on the **first** chunk (the shell contains the whole document), after which every Suspense segment is buffered into a 64 KiB-capped tail until both streams end — out-of-order streaming is effectively disabled and large segments would trip the cap. Adopting this API restores real streaming.

## What

`StreamOptions.injection` (`StreamInjectionSource { take(), subscribe(notify), done }`) on `octane/server`'s `renderToPipeableStream` / `renderToReadableStream`:

- Injected HTML is emitted **verbatim, in push order, each drain as its own transport chunk strictly between renderer chunks** — never before the shell. A single serialized write chain gives out-of-band notify-drains and wave-loop writes a total order under the existing backpressure gates.
- **Document renders hold the closing tail** (`</body>` + interleaved hydration block markers + `</html>`, detected once by suffix) and write it last; injected chunks and streamed segments land inside `<body>`. The stream closes only when rendering is complete **and** `done` settles — late data scripts are never dropped. `done` rejection and abort route through the existing degraded terminal path, still emitting the tail for best-effort well-formedness.
- **Zero cost when absent**: every hook no-ops without the option; the tail stays in the shell and the write path is unchanged (pinned by a test).

Octane extension tier (Fizz owns its data injection internally, so there is no React surface to mirror). Docs in `docs/ssr.md`; design + remaining phases (styles-in-head, auto-doctype, switching `@octanejs/tanstack-start`'s vendored stream path onto this API, upstreaming to TanStack) in `docs/ssr-stream-injection-plan.md`.

## Testing

- `packages/octane/tests/streaming-ssr-injection.test.ts` — 8 contract cases (ordering/chunk-boundaries, done-gated close + idle drains, shell-first, web-stream parity, document tail-holding, no-injection byte-shape control, `done` rejection, abort during the done-wait). All red before the implementation, green after, in **both** the `octane` and `octane-prod` projects.
- Full `octane` + `octane-prod` projects: 7814 passed. `pnpm typecheck`, `pnpm format:check`, `changeset:check` green.
- Perf: `benchmarks/streaming-ssr` (30 iters, production builds) baseline vs candidate with injection absent — shell 0.22→0.23 ms (staggered) / 0.13→0.12 ms (all-fast), totals within run-to-run noise. No regression; no improvement claimed.

## Residual risk / follow-ups

- A source that never settles `done` holds the response open — `signal` is the bound (documented); TanStack applies its own serialization timeout upstream.
- The bot (`prerender`) and buffered paths are out of scope by design; Start's buffered splice continues to work unchanged.
- End-to-end proof through the website arrives with the follow-up that switches the vendored Start stream path onto this API (after #168).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core streaming SSR completion, write ordering, and document tail semantics in `runStream`; mistakes could affect response shape, hang streams, or regress the no-injection path, though tests and the cold-path design aim to keep absent-option behavior identical.
> 
> **Overview**
> Adds **`StreamOptions.injection`** (`StreamInjectionSource` with `take`, `subscribe`, and `done`) on `renderToPipeableStream` / `renderToReadableStream`, exported from `octane/server`. Frameworks can push externally produced HTML (e.g. loader data `<script>` tags) into the response **between** renderer chunks instead of re-parsing the byte stream for safe insertion points.
> 
> When `injection` is set, `runStream` drains queued HTML via a serialized write chain (subscribe notifications interleave safely with Suspense wave writes), never emits injection before the shell, and for full documents **splits and holds** the `</body>…</html>` tail until render completion **and** `done` settle—so injected scripts and streamed segments land inside `<body>` before the closing tags. Failures from `done` rejection, `take`/`subscribe` throws, or abort use the existing fatal/degraded path and still flush the held tail when possible. **Without** `injection`, the write path and shell byte shape stay unchanged.
> 
> Docs cover the API in `docs/ssr.md` plus a design/plan note in `docs/ssr-stream-injection-plan.md`; contract tests live in `streaming-ssr-injection.test.ts` (fragment + document ordering, idle drains, failures).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b849e0e5b1d1ec905facb2f323b6d35f6ab3b226. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->