### PR TITLE
Trim compiled and runtime client output

### DIFF
--- a/.changeset/compact-client-abi.md
+++ b/.changeset/compact-client-abi.md
@@ -1,0 +1,6 @@
+---
+'octane': patch
+---
+
+Reduce production client output with a compact single-root compiler ABI and a
+shared post-paint scheduler callback.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -7073,8 +7073,8 @@ function applyCssScoping(componentNode, ctx) {
 // caller passes a freshly-created compiler function that cannot yet be observed;
 // bundlers may therefore discard the initializer together with an unused export.
 function singleRootInitializer(ctx, component) {
-	ctx.runtimeNeeded.add('markSingleRoot');
-	return `/* @__PURE__ */ _$markSingleRoot(${component})`;
+	ctx.runtimeNeeded.add('__s');
+	return `/* @__PURE__ */ _$__s(${component})`;
 }
 
 function compileComponent(node, ctx, options) {

--- a/packages/octane/src/index.ts
+++ b/packages/octane/src/index.ts
@@ -184,6 +184,8 @@ export {
 	componentSlotLite,
 	compilerCacheContext,
 	markSingleRoot,
+	// Compact compiler ABI; keep the descriptive export for older compiled output.
+	markSingleRoot as __s,
 	markChildrenBlock,
 	childSlot,
 	positionalChildren,

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -2999,27 +2999,23 @@ function drainPostPaint(): void {
 	_postPaintCbs = [];
 	for (let i = 0; i < cbs.length; i++) cbs[i]();
 }
-let _channel: MessageChannel | null | undefined;
-function initPostPaintChannel(): MessageChannel | null {
-	if (_channel === undefined) {
+let _postAfterPaint: (() => void) | undefined;
+function initPostAfterPaint(): () => void {
+	if (_postAfterPaint === undefined) {
 		if (typeof MessageChannel === 'undefined') {
-			_channel = null;
+			_postAfterPaint = () => setTimeout(drainPostPaint, 0);
 		} else {
-			_channel = new MessageChannel();
-			_channel.port1.onmessage = drainPostPaint;
+			const channel = new MessageChannel();
+			channel.port1.onmessage = drainPostPaint;
+			_postAfterPaint = () => channel.port2.postMessage(0);
 		}
 	}
-	return _channel;
+	return _postAfterPaint;
 }
 function schedulePostPaint(cb: () => void): void {
 	_postPaintCbs.push(cb);
-	const channel = initPostPaintChannel();
-	if (channel !== null) {
-		// rAF lands before paint; MessageChannel posts a macrotask after paint.
-		requestAnimationFrame(() => channel.port2.postMessage(0));
-	} else {
-		requestAnimationFrame(() => setTimeout(drainPostPaint, 0));
-	}
+	// rAF lands before paint; the shared callback posts a macrotask after paint.
+	requestAnimationFrame(initPostAfterPaint());
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #167.

## Summary

- emit a compact internal single-root compiler ABI while retaining `markSingleRoot` for older compiled output
- reuse the lazily initialized post-paint callback, preserving MessageChannel construction timing and rAF-to-macrotask ordering while avoiding repeated closure allocation
- add an Octane patch changeset

## Benchmarks

- codegen gzip: 24,636 -> 24,514 bytes; compiled/source ratio 1.0413 -> 1.0361 (limit 1.04)
- TodoMVC gzip: 19,775 -> 19,765 bytes; Octane/Svelte ratio 1.0700 -> 1.0695 (limit 1.07)
- generic Octane gzip: 18,754 -> 18,741 bytes
- all 21 applicable deterministic size guards pass without changing ceilings

## Validation

- `pnpm --filter octane build`
- focused runtime/compiler tests: 118/118 across dev and production compile modes
- `pnpm typecheck`
- `pnpm format:check`
- full suite: 11,290/11,291 passed while a concurrent benchmark caused one Lucide differential timeout; isolated rerun passed 2/2 in 3.4s
- `node benchmarks/bench.mjs --ratios codegen-size bundle-size`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Output-size and micro-refactor changes to compiler emission and passive-effect scheduling; public `markSingleRoot` is preserved for backward compatibility.
> 
> **Overview**
> Shrinks production client bundles by emitting **`_$__s`** instead of **`_$markSingleRoot`** for single-root component bodies, while **`markSingleRoot`** stays exported (aliased as **`__s`**) so older compiled modules keep working.
> 
> **`schedulePostPaint`** now lazily builds one reusable macrotask callback (MessageChannel or `setTimeout` fallback) and passes it to **`requestAnimationFrame`** on each schedule, instead of allocating a new rAF closure and re-resolving the channel every time—same paint-then-macrotask ordering, less codegen and runtime churn.
> 
> Patch changeset only; benchmark/size guards noted in the PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67c9ee61f303f2f8cea53d9f5bc7c35299c2c2d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->