### PR TITLE
Streamed document roots always lead with <!DOCTYPE html> (React Fizz parity)

### DIFF
--- a/.changeset/ssr-streaming-doctype.md
+++ b/.changeset/ssr-streaming-doctype.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Streaming SSR: a shell whose root renders `<html>` now always leads the response with `<!DOCTYPE html>` — React Fizz parity, no longer gated on the `injection` document mode. The buffered renderers (`renderToString`, `renderToStaticMarkup`, `prerender`) stay doctype-free, also matching React.

--- a/docs/ssr-stream-injection-plan.md
+++ b/docs/ssr-stream-injection-plan.md
@@ -16,9 +16,13 @@ production preview), streaming-ssr benchmark flat for the no-injection path;
 user docs in `docs/ssr.md`. Open questions resolved: the tail is held (and
 document mode engages) ONLY when `injection` is present; `onAllReady`/close
 both gate on `done`; the script-barrier lift maps to octane's post-shell
-subscribe. Remaining follow-up: auto-doctype for document renders WITHOUT
-injection is a candidate React-parity change, measured separately; upstream
-the native-path `renderRouterToStream` to TanStack.
+subscribe. DOCTYPE PARITY landed 2026-07-19 as its own phase: STREAMED
+document roots always lead with `<!DOCTYPE html>` (no longer injection-gated
+— React Fizz emits it whenever the root renders `<html>`; its harness treats
+a doctype-less `<html>` as "almost certainly a bug in React",
+ReactDOMFizzServer-test.js:237 at canary b740af2), while the buffered
+renderers stay doctype-free, verified against react-dom 19.2.7. Remaining
+follow-up: upstream the native-path `renderRouterToStream` to TanStack.
 Requested by: TanStack team feedback via the `@tanstack/octane-start` integration
 (2026-07-18).
 

--- a/docs/ssr.md
+++ b/docs/ssr.md
@@ -76,7 +76,10 @@ argument convention). Returns `{ pipe, abort }`; chunks buffer until
 `pipe(destination)` is called. The **shell** — the full page with `@pending`
 fallbacks for anything still suspended — flushes immediately; each Suspense
 boundary then streams **out of order** as a hidden segment plus an inline
-`$OCTRC` swap script when its data settles. Scoped styles flush with the shell
+`$OCTRC` swap script when its data settles. A shell whose root renders
+`<html>` leads the response with `<!DOCTYPE html>` (React Fizz parity —
+streaming only; the buffered renderers stay doctype-free, also matching
+React). Scoped styles flush with the shell
 (before the body markup) and per-wave with their segment; hoisted head elements
 render with the shell only. `hydrateRoot` on the client adopts the swapped-in
 DOM byte-for-byte, including per-boundary `use()` value or rejection seeds (a
@@ -119,17 +122,18 @@ path before degraded terminal output — so a source can finalize asynchronous
 serialization and then settle `done`.
 
 When the shell is a document (`… </body></html>`), **document mode** engages:
-the response leads with `<!DOCTYPE html>`; renderer-owned leading scoped
-styles and the hoisted-head buffer fold inside the authored `<head>` instead
-of preceding `<html>`; and the closing tail is split out and written **last**
-— injected chunks and streamed Suspense segments land inside `<body>`, and
-the stream (tail included) closes only once rendering is complete **and**
-`done` has settled, so late data scripts are never dropped. `subscribe`
+renderer-owned leading scoped styles and the hoisted-head buffer fold inside
+the authored `<head>` instead of preceding `<html>`, and the closing tail is
+split out and written **last** — injected chunks and streamed Suspense
+segments land inside `<body>`, and the stream (tail included) closes only
+once rendering is complete **and** `done` has settled, so late data scripts
+are never dropped. (The `<!DOCTYPE html>` preamble is not injection-gated:
+every streamed document render leads with it, see above.) `subscribe`
 notifications drain promptly even while the render is idle awaiting `done`;
 bound the wait with `signal` (a source that never settles `done` holds the
 response open). A `done` rejection fails the stream through the same degraded
-terminal path as `abort`. Without `injection`, streamed output is
-byte-identical to previous releases (measured flat on the streaming-ssr
+terminal path as `abort`. Without `injection`, streamed output is unchanged
+apart from that doctype preamble (measured flat on the streaming-ssr
 benchmark).
 
 ### `renderToReadableStream(component, props?, options?)` — `octane/server`

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -5910,6 +5910,22 @@ function documentTailStart(body: string): number {
 	return DOCUMENT_TAIL_RE.test(body.slice(index)) ? index : -1;
 }
 
+// A document render's markup is the root `<html>` element wrapped only by
+// hydration block markers — a prefix scan bounded by wrapper depth, so the
+// common fragment path pays a few byte compares, not a body scan. Streaming
+// renders of a document lead with `<!DOCTYPE html>` (React parity: Fizz emits
+// the doctype whenever the root renders `<html>`, and its test harness treats
+// a doctype-less `<html>` as "almost certainly a bug in React" — per
+// ReactDOMFizzServer-test.js:237, React canary b740af2). Buffered
+// renderToString/renderToStaticMarkup stay doctype-free, also per React.
+function isDocumentRoot(body: string): boolean {
+	let i = 0;
+	while (body.startsWith('<!--[-->', i)) i += 8;
+	if (!body.startsWith('<html', i)) return false;
+	const next = body.charCodeAt(i + 5);
+	return next === 62 /* > */ || next === 32 || next === 9 || next === 10 || next === 13;
+}
+
 // Locate the insertion point just inside a document's opening <head> tag —
 // where renderer-owned leading styles and hoisted head elements belong in
 // document mode. Quote-aware so an attribute value containing '>' cannot
@@ -6212,36 +6228,37 @@ async function runStream(
 			escapeEntireInlineStyleContent(sheet) +
 			'</style>';
 	}
-	// DOCUMENT MODE (external injection + the shell renders a document): the
-	// closing tail is split out of the shell and written LAST — injected chunks
-	// and streamed segments then land inside <body> before it (streamed
-	// segments otherwise trail `</html>`, which browsers reparent but external
-	// merge layers must not re-parse around); `<!DOCTYPE html>` leads the
-	// response; and renderer-owned leading styles + hoisted head elements move
-	// inside the authored <head> instead of preceding `<html>`. The tail
-	// carries only closing tags + block markers, so it needs no vt stripping.
-	// Without injection the shell shape is unchanged.
-	let shell = '';
+	// Streaming DOCUMENT renders always lead with `<!DOCTYPE html>` — React
+	// Fizz parity, injection or not (buffered renderers stay doctype-free,
+	// also per React; see isDocumentRoot).
+	//
+	// DOCUMENT MODE (external injection + the shell renders a document)
+	// additionally restructures the shell: the closing tail is split out and
+	// written LAST — injected chunks and streamed segments then land inside
+	// <body> before it (streamed segments otherwise trail `</html>`, which
+	// browsers reparent but external merge layers must not re-parse around) —
+	// and renderer-owned leading styles + hoisted head elements move inside
+	// the authored <head> instead of preceding `<html>`. The tail carries only
+	// closing tags + block markers, so it needs no vt stripping. Without
+	// injection the shell shape is otherwise unchanged.
+	const documentRoot = isDocumentRoot(pass.body);
+	let shell = documentRoot ? '<!DOCTYPE html>' : '';
 	let heldDocumentTail = '';
-	if (injection !== undefined) {
+	if (injection !== undefined && documentRoot) {
 		const tailStart = documentTailStart(pass.body);
 		if (tailStart !== -1) {
 			heldDocumentTail = pass.body.slice(tailStart);
 			const bodyHtml = pass.body.slice(0, tailStart);
 			const headInsert = documentHeadInsertionPoint(bodyHtml);
-			shell =
+			shell +=
 				headInsert !== -1
-					? '<!DOCTYPE html>' +
-						bodyHtml.slice(0, headInsert) +
-						leadingStyles +
-						pass.head +
-						bodyHtml.slice(headInsert)
-					: '<!DOCTYPE html>' + leadingStyles + pass.head + bodyHtml;
+					? bodyHtml.slice(0, headInsert) + leadingStyles + pass.head + bodyHtml.slice(headInsert)
+					: leadingStyles + pass.head + bodyHtml;
 		} else {
-			shell = leadingStyles + pass.head + pass.body;
+			shell += leadingStyles + pass.head + pass.body;
 		}
 	} else {
-		shell = leadingStyles + pass.head + pass.body;
+		shell += leadingStyles + pass.head + pass.body;
 	}
 	if (pass.serial.length > 0) shell += serializeSuspenseSeeds(pass.serial, nonceAttr);
 	const anyPending = stream.boundaries.size > 0;

--- a/packages/octane/tests/streaming-ssr-injection.test.ts
+++ b/packages/octane/tests/streaming-ssr-injection.test.ts
@@ -250,17 +250,19 @@ describe('streaming injection — document renders', () => {
 		expect(chunks[chunks.length - 1]).toMatch(DOCUMENT_TAIL);
 	});
 
-	it('keeps document output byte-identical when no injection source is supplied', async () => {
+	it('keeps the tail inside the shell when no injection source is supplied', async () => {
 		const value = deferred<string>();
 		value.resolve('streamed');
 		const { chunks } = await collectPipeableStream(server.DocumentApp, {
 			promise: value.promise,
 		});
-		// Without injection the shell still contains the closing tags and no
-		// document-mode additions — the pre-feature stream shape is preserved.
+		// Without injection there is no tail-holding or head restructuring —
+		// the shell still carries the closing tags. (The doctype itself is NOT
+		// injection-gated: streamed documents always lead with it, see the
+		// doctype parity suite below.)
 		expect(chunks[0]).toContain('</body>');
 		expect(chunks[0]).toContain('</html>');
-		expect(chunks[0]).not.toContain('<!DOCTYPE html>');
+		expect(chunks[0].startsWith('<!DOCTYPE html>')).toBe(true);
 	});
 
 	it('leads the document with <!DOCTYPE html> under injection', async () => {
@@ -463,5 +465,57 @@ describe('streaming injection — failure modes', () => {
 		await collector.ended;
 		expect(injection.renderCompleteCalls).toBe(1);
 		expect(injection.unsubscribed).toBe(true);
+	});
+});
+
+// Doctype parity — independent of injection. React Fizz emits
+// `<!DOCTYPE html>` whenever the STREAMED root renders `<html>`; its test
+// harness treats a doctype-less `<html>` as "almost certainly a bug in React"
+// (per ReactDOMFizzServer-test.js:237, React canary b740af2). The buffered
+// renderers do NOT emit a doctype — verified against react-dom 19.2.7
+// renderToString/renderToStaticMarkup of an `<html>` root.
+describe('streaming document renders — doctype parity', () => {
+	it('streamed documents lead with <!DOCTYPE html> without any injection source', async () => {
+		const value = deferred<string>();
+		value.resolve('streamed');
+		const { html, chunks } = await collectPipeableStream(server.DocumentApp, {
+			promise: value.promise,
+		});
+		expect(chunks[0].startsWith('<!DOCTYPE html>')).toBe(true);
+		expect(html.match(/<!DOCTYPE html>/g)).toHaveLength(1);
+	});
+
+	it('streamed documents lead with <!DOCTYPE html> through the web-stream API', async () => {
+		const value = deferred<string>();
+		value.resolve('streamed');
+		const { chunks } = await collectReadableStream(server.DocumentApp, {
+			promise: value.promise,
+		});
+		expect(chunks[0].startsWith('<!DOCTYPE html>')).toBe(true);
+	});
+
+	it('streamed fragments never receive a doctype', async () => {
+		const value = deferred<string>();
+		value.resolve('streamed');
+		const { html } = await collectPipeableStream(server.FragmentApp, {
+			promise: value.promise,
+		});
+		expect(html).not.toContain('<!DOCTYPE');
+	});
+
+	it('buffered renderers stay doctype-free for document roots, matching React', async () => {
+		const value = deferred<string>();
+		value.resolve('streamed');
+		// renderToString / renderToStaticMarkup of an <html> root produce no
+		// doctype in react-dom 19.2.7; octane matches. (Framework bot paths that
+		// want one — e.g. the Start prerender handler — prepend it themselves.)
+		const buffered = ServerRuntime.renderToString(server.DocumentApp, {
+			promise: value.promise,
+		});
+		expect(buffered.html).not.toContain('<!DOCTYPE');
+		const statics = ServerRuntime.renderToStaticMarkup(server.DocumentApp, {
+			promise: value.promise,
+		});
+		expect(statics.html).not.toContain('<!DOCTYPE');
 	});
 });


### PR DESCRIPTION
## Why

The remaining octane follow-up from `docs/ssr-stream-injection-plan.md` (after #169 and #168): the `<!DOCTYPE html>` preamble was gated on the `injection` document mode, but it is actually a **React parity** behavior — verified empirically against react-dom 19.2.7:

- **Streaming** (`renderToPipeableStream` / `renderToReadableStream`): Fizz emits `<!DOCTYPE html>` whenever the root renders `<html>`; its own test harness asserts a doctype-less `<html>` is *"almost certainly a bug in React"* (`ReactDOMFizzServer-test.js:237`, canary `b740af2`).
- **Buffered** (`renderToString` / `renderToStaticMarkup`): **no doctype** — React leaves it to the caller.

## What

- The streaming shell prepends `<!DOCTYPE html>` for document roots **unconditionally** — detected by an O(wrapper-depth) prefix scan (hydration block markers + `<html`), so fragment streams pay a few byte compares, not a body scan. The injection document mode keeps its tail-holding/head-folding behavior but no longer owns the doctype.
- Buffered renderers stay doctype-free, matching React. The vendored Start bot path (`finalizeBufferedHtml`) already prepends its own onto the buffered output — no doubling.
- Incidental: the injection branch's tail scan is now gated on the same document-root check, sparing injected *fragment* renders the full-body suffix scan.
- Docs (`docs/ssr.md`), changeset, and the plan doc updated.

## Testing

- New doctype parity suite in `streaming-ssr-injection.test.ts` (× both compile modes): streamed pipeable + web documents lead with exactly one doctype, fragments never receive one, buffered document renders stay bare. The three streaming pins were red-checked against the pre-change runtime (exactly those fail, everything else passes).
- Full suite **11311 passed, zero failures** (clean run); octane + octane-prod projects 7846 passed; website ssr-hydration e2e **32/32 on a cold vite cache** — the native Start path already emitted the doctype via document mode, so website output is byte-identical.
- streaming-ssr bench flat (staggered shell 0.13ms / all-fast 0.11ms — at or below prior baselines); typecheck, format, changeset checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted streaming shell assembly change with explicit parity tests; buffered APIs and fragment streams are unchanged aside from documented doctype behavior.
> 
> **Overview**
> **Streaming SSR** now prepends `<!DOCTYPE html>` whenever the shell root is a document (`<html>`), matching React Fizz — not only when `injection` document mode is active. Detection uses a cheap prefix scan (`isDocumentRoot`); fragments are unchanged.
> 
> **Injection document mode** still holds the closing tail and folds styles/head into `<head>`, but that path is gated on `documentRoot` so injected fragment renders skip the full-body tail scan. Buffered `renderToString` / `renderToStaticMarkup` stay doctype-free (React parity).
> 
> Docs, changeset, and contract tests were updated; the no-injection streaming case now expects the doctype on the first chunk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 308fdf7dcac8615eace25297291a2ce23e80d8fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->