### PR TITLE
Add JSX/TSRX performance guardrails

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -135,6 +135,20 @@ the whole body so target-side portal ranges stay visible. Keep visible
 elements/text as independent guards—a lower total obtained by dropping
 user-visible content is a correctness failure, not an optimization.
 
+Compiler-sensitive work counts use a separate production `work.mjs` invocation
+with jitless Chromium precise call coverage. This avoids source probes changing
+purity or memoization. Such invocations emit unique `*-work` target names, omit
+`iterations` so they cannot overwrite the timing run's sample count, and fail on
+missing production-asset coverage, exact semantic-write mismatches, or increases
+above exhaustive scaffolding ceilings. Specialized component-slot variants use
+aggregate ceilings so a cheaper lowering may replace a generic slot without
+turning an optimization into a gate failure.
+
+When a dialect timing ratio is important, suites may emit
+`octane-{tsrx,jsx}-dialect-pair` aliases. Those aliases combine fully-warmed raw
+samples from a TSRX→TSX→TSX→TSRX sequence with an independent-run mean; the
+original one-pass rows remain unchanged for cross-framework comparisons.
+
 The runner keys everything (result files, baselines, ratio guards) by the
 **manifest suite name**, not the JSON's internal `suite` field — so the deopt
 variants (`dbmon-deopt`, `js-framework-deopt`), which reuse a base harness via a

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -24,6 +24,22 @@
     "note": "swap rows: LIS keyed reconcile vs React (known <1x)."
   },
   {
+    "suite": "js-framework",
+    "op": "runlots",
+    "target": "octane-jsx",
+    "reference": "octane-tsrx",
+    "maxRatio": 1.25,
+    "note": "TSX/TSRX flat-list control: create-10k stayed within 1.03-1.13x across seeded normal and reversed target orders through 2026-07-19. The 1.25 ceiling protects the shared keyed forBlock lowering without relying on sub-millisecond ops."
+  },
+  {
+    "suite": "js-framework",
+    "op": "clear",
+    "target": "octane-jsx",
+    "reference": "octane-tsrx",
+    "maxRatio": 1.3,
+    "note": "TSX/TSRX flat-list control: seeded quick clear-10k runs measured up to 1.14x through 2026-07-19 with high three-sample teardown variance. The 1.3 ceiling keeps useful headroom while catching a dialect-specific cliff."
+  },
+  {
     "suite": "js-framework-reorder",
     "op": "rotateb",
     "target": "octane-tsrx",
@@ -46,6 +62,78 @@
     "reference": "react",
     "maxRatio": 0.6,
     "note": "Production autoMemo skips the unchanged RowsA region before the keyed wall; if dependency-scoped reuse breaks this rises toward the vanilla React memo-wall cost."
+  },
+  {
+    "suite": "memo-wall",
+    "op": "mount",
+    "target": "octane-jsx",
+    "reference": "octane-tsrx",
+    "maxRatio": 1.6,
+    "note": "TSX/TSRX component-heavy mount control. Adaptive paired runs stayed at 1.22-1.32x through 2026-07-19; 1.6 leaves browser/JIT headroom while keeping the dialect gap bounded."
+  },
+  {
+    "suite": "memo-wall",
+    "op": "parent_rerender_equal_A",
+    "target": "octane-jsx",
+    "reference": "octane-tsrx",
+    "maxRatio": 600,
+    "note": "Known return-JSX autoMemo gap: the calibrated 8ms batches measured 469-491x through 2026-07-19. This intentionally loose ceiling catches added work until descriptor-output reuse closes the gap; deterministic work gates remain the primary oracle."
+  },
+  {
+    "suite": "memo-wall",
+    "op": "one_change_A",
+    "target": "octane-jsx",
+    "reference": "octane-tsrx",
+    "maxRatio": 32,
+    "note": "Known return-JSX one-change gap measured 21.2-25.9x through 2026-07-19. The 32x ceiling allows normal paired variation while preventing more row/list work from landing."
+  },
+  {
+    "suite": "memo-wall",
+    "op": "ctx_through_wall_A",
+    "target": "octane-jsx",
+    "reference": "octane-tsrx",
+    "maxRatio": 3,
+    "note": "Context-through-wall TSX/TSRX ratio remained 2.24-2.37x through 2026-07-19. The ceiling protects leaf-only refresh behavior while the return-JSX wrapper work is optimized."
+  },
+  {
+    "suite": "recursive-context",
+    "op": "mount",
+    "target": "octane-jsx-dialect-pair",
+    "reference": "octane-tsrx-dialect-pair",
+    "maxRatio": 2.25,
+    "note": "Order-balanced A-B-B-A TSX/TSRX mount guard. Current and historical production ratios are 1.55-1.79x; 2.25 leaves cold-page noise headroom while catching more component-boundary scaffolding."
+  },
+  {
+    "suite": "recursive-context",
+    "op": "update_root",
+    "target": "octane-jsx-dialect-pair",
+    "reference": "octane-tsrx-dialect-pair",
+    "maxRatio": 3.75,
+    "note": "Order-balanced A-B-B-A full context fan-out guard. Current and historical production ratios are 2.28-2.94x; deterministic work gates separately pin blocks, descriptors, keyed survivors and 1024 text writes."
+  },
+  {
+    "suite": "recursive-context",
+    "op": "unmount",
+    "target": "octane-jsx-dialect-pair",
+    "reference": "octane-tsrx-dialect-pair",
+    "maxRatio": 6.75,
+    "note": "Order-balanced A-B-B-A full teardown guard. Current and historical production ratios are 4.05-5.25x; the ceiling catches growth while deterministic work gates bound block/scope teardown."
+  },
+  {
+    "suite": "signal-favoring",
+    "op": "mount",
+    "target": "octane-jsx-dialect-pair",
+    "reference": "octane-tsrx-dialect-pair",
+    "maxRatio": 1.8,
+    "note": "Order-balanced A-B-B-A 100-component chain mount guard. Current and historical production ratios are 1.19-1.41x; 1.8 leaves cold-page noise headroom."
+  },
+  {
+    "suite": "signal-favoring",
+    "op": "bump_shallow",
+    "target": "octane-jsx-dialect-pair",
+    "reference": "octane-tsrx-dialect-pair",
+    "maxRatio": 5.5,
+    "note": "Order-balanced A-B-B-A shallow cascade guard. Current and historical production ratios are 3.0-4.13x; precise work gates separately require one text write and cap every extra block/descriptor path."
   },
   {
     "suite": "dbmon",
@@ -71,6 +159,30 @@
     "minRatio": 1.2,
     "maxRatio": 4.0,
     "note": "intra-octane de-opt cliff: plain-.ts createElement vs compiled .tsrx SSR (known ~2.1x). Bounds the cliff so a broken fast path (ratio\u21921) or a runaway deopt (ratio>4) both surface."
+  },
+  {
+    "suite": "bundle-size",
+    "op": "js_gzip",
+    "target": "octane-jsx",
+    "reference": "octane-tsrx",
+    "maxRatio": 1.82,
+    "note": "Deterministic TSX/TSRX total-gzip gap. Two clean production runs on 2026-07-19 were byte-identical at 33765 / 18754 = 1.8004x; 1.82 catches retained runtime graph growth while allowing improvements."
+  },
+  {
+    "suite": "bundle-size",
+    "op": "fw_gzip",
+    "target": "octane-jsx",
+    "reference": "octane-tsrx",
+    "maxRatio": 1.9,
+    "note": "Deterministic TSX/TSRX framework-gzip gap: 30974 / 16407 = 1.8879x on 2026-07-19. This isolates the generic descriptor/runtime graph from application code."
+  },
+  {
+    "suite": "bundle-size",
+    "op": "app_gzip",
+    "target": "octane-jsx",
+    "reference": "octane-tsrx",
+    "maxRatio": 1.2,
+    "note": "Deterministic TSX/TSRX application-code gzip: 2791 / 2347 = 1.1892x on 2026-07-19. Keeping this separate prevents a framework-size win from hiding generated app-code growth."
   },
   {
     "suite": "bundle-size",
@@ -330,6 +442,108 @@
     "reference": "react",
     "maxRatio": 1.0,
     "note": "Cross-framework transition topology guard: Octane reaches the honest 2-wave dependency floor vs React's 3 waves in the 2026-07-17 record. The 1.5x ratio headroom allows reference improvements; the suite separately enforces Octane's exact seven-resource independent first wave and eight-call ceiling."
+  },
+  {
+    "suite": "recursive-context",
+    "op": "nodes_mounted",
+    "target": "octane-jsx",
+    "reference": "octane-tsrx",
+    "maxRatio": 3.66,
+    "note": "Deterministic mounted-tree scaffolding ceiling: TSX 11263 / TSRX 3081 nodes on 2026-07-19. Visible element/text controls below prevent dropped output from looking like an improvement."
+  },
+  {
+    "suite": "recursive-context",
+    "op": "comments_mounted",
+    "target": "octane-jsx",
+    "reference": "octane-tsrx",
+    "maxRatio": 820,
+    "note": "Return-JSX boundary-marker tripwire: TSX 8192 / TSRX 10 comments at mount. This is a max-only gap ceiling so direct-return lowering can reduce it without rebaselining."
+  },
+  {
+    "suite": "recursive-context",
+    "op": "elements_mounted",
+    "target": "octane-jsx",
+    "reference": "octane-tsrx",
+    "minRatio": 1,
+    "maxRatio": 1,
+    "note": "Semantic control for the recursive mounted census: both dialects render exactly 2047 visible elements."
+  },
+  {
+    "suite": "recursive-context",
+    "op": "text_mounted",
+    "target": "octane-jsx",
+    "reference": "octane-tsrx",
+    "minRatio": 1,
+    "maxRatio": 1,
+    "note": "Semantic control for the recursive mounted census: both dialects render exactly 1024 text nodes."
+  },
+  {
+    "suite": "recursive-context",
+    "op": "nodes_partial_unmounted",
+    "target": "octane-jsx",
+    "reference": "octane-tsrx",
+    "maxRatio": 3.66,
+    "note": "Deterministic partial-teardown scaffolding ceiling: TSX 10920 / TSRX 2984 nodes after removing the 32-leaf subtree."
+  },
+  {
+    "suite": "recursive-context",
+    "op": "comments_partial_unmounted",
+    "target": "octane-jsx",
+    "reference": "octane-tsrx",
+    "maxRatio": 993,
+    "note": "Partial-teardown marker tripwire: TSX 7944 / TSRX 8 comments. Max-only so intended marker removal passes."
+  },
+  {
+    "suite": "recursive-context",
+    "op": "elements_partial_unmounted",
+    "target": "octane-jsx",
+    "reference": "octane-tsrx",
+    "minRatio": 1,
+    "maxRatio": 1,
+    "note": "Semantic control after partial teardown: both dialects retain exactly 1984 visible elements."
+  },
+  {
+    "suite": "recursive-context",
+    "op": "text_partial_unmounted",
+    "target": "octane-jsx",
+    "reference": "octane-tsrx",
+    "minRatio": 1,
+    "maxRatio": 1,
+    "note": "Semantic control after partial teardown: both dialects retain exactly 992 text nodes."
+  },
+  {
+    "suite": "signal-favoring",
+    "op": "nodes_mounted",
+    "target": "octane-jsx",
+    "reference": "octane-tsrx",
+    "maxRatio": 1.32,
+    "note": "Deterministic 100-component-chain scaffolding ceiling: TSX 418 / TSRX 319 mounted nodes on 2026-07-19."
+  },
+  {
+    "suite": "signal-favoring",
+    "op": "comments_mounted",
+    "target": "octane-jsx",
+    "reference": "octane-tsrx",
+    "maxRatio": 1.91,
+    "note": "Return-JSX chain marker tripwire: TSX 208 / TSRX 109 comments. Max-only so direct component lowering can reduce it."
+  },
+  {
+    "suite": "signal-favoring",
+    "op": "elements_mounted",
+    "target": "octane-jsx",
+    "reference": "octane-tsrx",
+    "minRatio": 1,
+    "maxRatio": 1,
+    "note": "Semantic control for the signal-chain census: both dialects render exactly 100 visible elements."
+  },
+  {
+    "suite": "signal-favoring",
+    "op": "text_mounted",
+    "target": "octane-jsx",
+    "reference": "octane-tsrx",
+    "minRatio": 1,
+    "maxRatio": 1,
+    "note": "Semantic control for the signal-chain census: both dialects render exactly 110 text nodes."
   },
   {
     "suite": "js-framework",

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -188,7 +188,10 @@ const SUITES = [
 			{ filter: 'svelte-recursive-bench', port: 5275 },
 		],
 		iter: { normal: 20, quick: 3 },
-		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
+		runs: [
+			{ script: 'run.mjs', args: (n) => [String(n)] },
+			{ label: 'work', script: 'work.mjs', args: () => [] },
+		],
 	},
 	{
 		name: 'signal-favoring',
@@ -204,7 +207,10 @@ const SUITES = [
 			{ filter: 'svelte-signal-bench', port: 5276 },
 		],
 		iter: { normal: 20, quick: 3 },
-		runs: [{ script: 'run.mjs', args: (n) => [String(n)] }],
+		runs: [
+			{ script: 'run.mjs', args: (n) => [String(n)] },
+			{ label: 'work', script: 'work.mjs', args: () => [] },
+		],
 	},
 	{
 		// News is build-based (no preview servers): its harness vite-builds each

--- a/benchmarks/js-framework/README.md
+++ b/benchmarks/js-framework/README.md
@@ -101,7 +101,9 @@ Output is a table of median + min millis per operation: `run`, `replace`,
 `add`, `update`, `select`, `swap`, `remove`, `runlots`, `clear`. The harness
 uses `page.evaluate(el.click)` to fire clicks synchronously inside the page —
 avoids per-click CDP IPC overhead (~10ms each on Chromium) so the numbers
-reflect the renderer's wall time, not Playwright transport.
+reflect the renderer's wall time, not Playwright transport. Before warmup, each
+target receives the same seeded `Math.random` stream so generated label lengths
+and allocation patterns cannot drift between dialects.
 
 ## Keyed-reorder matrix (`run-reorder.mjs`)
 

--- a/benchmarks/js-framework/run.mjs
+++ b/benchmarks/js-framework/run.mjs
@@ -69,6 +69,20 @@ const OPS = [
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+// Use the same data stream for every target. Label generation is inside the
+// measured create operations, so uncontrolled randomness would add dialect
+// noise through different string lengths and allocation patterns.
+const seedRandom = (page) =>
+	page.evaluate(() => {
+		let state = 0x5eed5eed >>> 0;
+		Math.random = () => {
+			state = (state + 0x6d2b79f5) | 0;
+			let value = Math.imul(state ^ (state >>> 15), 1 | state);
+			value = (value + Math.imul(value ^ (value >>> 7), 61 | value)) ^ value;
+			return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+		};
+	});
+
 async function ensureState(page, pre) {
 	if (pre === 'empty') {
 		await page.evaluate(() => {
@@ -136,6 +150,7 @@ async function runTarget(t) {
 	const page = await context.newPage();
 	await page.goto(t.url, { waitUntil: 'load' });
 	await page.waitForSelector(t.ready, { timeout: 10000 });
+	await seedRandom(page);
 
 	// Warmup — let JIT settle.
 	for (let i = 0; i < 3; i++) {

--- a/benchmarks/lib/dom-nodes.d.mts
+++ b/benchmarks/lib/dom-nodes.d.mts
@@ -25,3 +25,11 @@ export interface DeterministicCount {
 }
 
 export function deterministicCount(value: number): DeterministicCount;
+
+export interface DeterministicJsonStat {
+	median: number;
+	min: number;
+	samples: number;
+}
+
+export function deterministicStatForJson(stat: DeterministicCount): DeterministicJsonStat;

--- a/benchmarks/lib/dom-nodes.mjs
+++ b/benchmarks/lib/dom-nodes.mjs
@@ -112,3 +112,11 @@ export function censusDomNodes(rootSelector = '#main') {
 export function deterministicCount(value) {
 	return { median: value, min: value, samples: [value] };
 }
+
+export function deterministicStatForJson(stat) {
+	return {
+		median: stat.median,
+		min: stat.min,
+		samples: Array.isArray(stat.samples) ? stat.samples.length : stat.samples,
+	};
+}

--- a/benchmarks/lib/precise-work.mjs
+++ b/benchmarks/lib/precise-work.mjs
@@ -1,0 +1,70 @@
+// Deterministic production-work instrumentation shared by browser benchmarks.
+//
+// Source probes can change the program a compiler sees (and, in particular,
+// disqualify purity/memoization proofs). Chromium precise call coverage observes
+// the emitted production bundle instead. Callers should launch Chromium with
+// `--jitless` so optimized/inlined functions cannot disappear from coverage.
+
+async function invokeHook(page, hook) {
+	await page.evaluate(async (name) => {
+		const fn = window[name];
+		if (typeof fn !== 'function') throw new Error(`missing ${name}`);
+		const result = fn();
+		if (result && typeof result.then === 'function') await result;
+	}, hook);
+}
+
+function countNamedFunctions(coverage, metrics) {
+	const counts = Object.fromEntries(metrics.map((name) => [name, 0]));
+	let productionCalls = 0;
+	for (const script of coverage.result) {
+		if (!script.url.includes('/assets/')) continue;
+		for (const fn of script.functions) {
+			productionCalls += fn.ranges[0]?.count ?? 0;
+			if (Object.prototype.hasOwnProperty.call(counts, fn.functionName)) {
+				counts[fn.functionName] += fn.ranges[0]?.count ?? 0;
+			}
+		}
+	}
+	if (productionCalls === 0) {
+		throw new Error('operation produced no production asset call coverage');
+	}
+	return counts;
+}
+
+/**
+ * Count named production-bundle calls for one operation after a fresh page.
+ * `before` establishes committed state outside the observed coverage window.
+ */
+export async function collectPreciseCalls(browser, { url, before = [], operation, metrics }) {
+	const context = await browser.newContext();
+	const page = await context.newPage();
+	const cdp = await context.newCDPSession(page);
+	let profiling = false;
+	try {
+		await cdp.send('Profiler.enable');
+		await cdp.send('Profiler.startPreciseCoverage', {
+			callCount: true,
+			detailed: true,
+			allowTriggeredUpdates: false,
+		});
+		profiling = true;
+		await page.goto(url, { waitUntil: 'load' });
+		await page.waitForFunction(() => window.__ready === true, null, { timeout: 10_000 });
+
+		// Module initialization and state setup are controls, not part of the row.
+		await cdp.send('Profiler.takePreciseCoverage');
+		for (const hook of before) await invokeHook(page, hook);
+		await cdp.send('Profiler.takePreciseCoverage');
+
+		await invokeHook(page, operation);
+		const coverage = await cdp.send('Profiler.takePreciseCoverage');
+		return countNamedFunctions(coverage, metrics);
+	} finally {
+		if (profiling) {
+			await cdp.send('Profiler.stopPreciseCoverage').catch(() => {});
+			await cdp.send('Profiler.disable').catch(() => {});
+		}
+		await context.close();
+	}
+}

--- a/benchmarks/recursive-context/README.md
+++ b/benchmarks/recursive-context/README.md
@@ -21,6 +21,7 @@ benchmarks/recursive-context/
 ├── preact/           # Vite app, dev :5264 — native Preact context + hooks
 ├── svelte/           # Vite app, dev :5275 — Svelte 5 createContext + runes
 ├── run.mjs            # Playwright harness — drives all adapters
+├── work.mjs           # untimed Chromium precise-call-coverage gates for Octane
 ├── package.json       # umbrella: `pnpm bench`
 └── README.md
 ```
@@ -93,6 +94,10 @@ node benchmarks/bench.mjs --quick recursive-context
 node benchmarks/bench.mjs recursive-context
 ```
 
+The unified runner also executes `work.mjs` against the already-built Octane
+previews. Run it directly with `pnpm --dir benchmarks/recursive-context
+bench:work` when those two previews are already running.
+
 Output is a side-by-side table of median / min / p95 millis per op, followed by a
 pairwise ratio block, e.g.:
 
@@ -136,5 +141,21 @@ The harness:
 - **UNMOUNT**: one page; per iteration `__mount()` (untimed), time `__unmount()`,
   then `__reset()` + small sleep before the next iteration.
 
-Default: 5 warmups + 20 iters. Pass an integer to `bench` to override iters
+After the semantic gate, the harness publishes zero-variance DOM censuses for
+the mounted tree and the partial-unmount state. Visible element/text counts are
+semantic controls; total/comment counts expose framework bookkeeping. The
+Octane dialect timing rows also have order-balanced aliases: the primary
+TSRX→TSX pass is repeated TSX→TSRX, and the two fully-warmed sample sets are
+combined for TSX/TSRX ratio guards.
+
+`work.mjs` observes the emitted production bundles rather than adding source
+probes that could change compiler purity. A jitless Chromium precise-coverage
+pass caps blocks, generic slots, descriptors, keyed survivor work, and teardown
+scopes at their current levels while permitting reductions. Full/all-slot
+aggregates allow a generic slot to become a cheaper specialized slot without
+allowing duplicate dispatch. Every row requires live production-bundle coverage,
+and the root and partial updates must still execute exactly 1024 and 32 `setText`
+calls.
+
+Default: 10 warmups + 20 iters. Pass an integer to `bench` to override iters
 (`bench:long` runs 40).

--- a/benchmarks/recursive-context/package.json
+++ b/benchmarks/recursive-context/package.json
@@ -6,6 +6,7 @@
   "description": "Recursive component and context fan-out benchmark across Octane and reference frameworks.",
   "scripts": {
     "bench": "node run.mjs",
+    "bench:work": "node work.mjs",
     "bench:long": "node run.mjs 40"
   },
   "dependencies": {

--- a/benchmarks/recursive-context/run.mjs
+++ b/benchmarks/recursive-context/run.mjs
@@ -26,6 +26,7 @@
 
 import { chromium } from 'playwright';
 import fs from 'node:fs';
+import { censusDomNodes, deterministicCount, deterministicStatForJson } from '../lib/dom-nodes.mjs';
 import { scoreOf, summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
 
 const ITER = parseInt(process.argv[2] || '20', 10);
@@ -47,8 +48,8 @@ const TARGETS = process.env.TARGETS
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-function summarize(samples) {
-	return summarizeSamples(samples);
+function summarize(samples, options) {
+	return { ...summarizeSamples(samples, options), __samples: samples };
 }
 
 async function freshPage(browser, url) {
@@ -149,6 +150,25 @@ async function semanticGate(browser, url) {
 			expect(document.getElementById('main')?.childNodes.length === 0, 'reset left root DOM');
 			return errors;
 		});
+	} finally {
+		await ctx.close();
+	}
+}
+
+async function measureDom(browser, url) {
+	const { ctx, page } = await freshPage(browser, url);
+	const call = async (name) => {
+		await page.evaluate(async (hook) => {
+			const result = window[hook]();
+			if (result && typeof result.then === 'function') await result;
+		}, name);
+	};
+	try {
+		await call('__mount');
+		const mounted = await page.evaluate(censusDomNodes, '#main');
+		await call('__partialUnmount');
+		const partialUnmounted = await page.evaluate(censusDomNodes, '#main');
+		return { mounted, partialUnmounted };
 	} finally {
 		await ctx.close();
 	}
@@ -274,16 +294,18 @@ async function measurePartialUnmountRemount(browser, url) {
 	return { partial_unmount: summarize(u), partial_remount: summarize(r) };
 }
 
-async function runTarget(t) {
+async function runTarget(t, { verify = true } = {}) {
 	const browser = await chromium.launch({
 		headless: true,
 		args: ['--disable-extensions', '--no-sandbox', '--js-flags=--expose-gc'],
 	});
 
 	try {
-		console.error(`  → semantic gate`);
-		const gateErrors = await semanticGate(browser, t.url);
-		if (gateErrors.length > 0) return { gateErrors, results: null };
+		if (verify) {
+			console.error(`  → semantic gate`);
+			const gateErrors = await semanticGate(browser, t.url);
+			if (gateErrors.length > 0) return { gateErrors, results: null };
+		}
 
 		const { ctx, page } = await freshPage(browser, t.url);
 		const hasGc = await page.evaluate(() => typeof window.gc === 'function');
@@ -293,6 +315,7 @@ async function runTarget(t) {
 				'  ! window.gc unavailable (need --js-flags=--expose-gc) — results will be noisier',
 			);
 		}
+		const dom = verify ? await measureDom(browser, t.url) : null;
 
 		console.error(`  → mount`);
 		const mount = await measureMount(browser, t.url);
@@ -304,16 +327,23 @@ async function runTarget(t) {
 		const { partial_unmount, partial_remount } = await measurePartialUnmountRemount(browser, t.url);
 		console.error(`  → unmount`);
 		const unmount = await measureUnmount(browser, t.url);
+		const results = {
+			mount,
+			update_root,
+			update_partial,
+			partial_unmount,
+			partial_remount,
+			unmount,
+		};
+		if (dom !== null) {
+			for (const [op, state, field] of DOM_OPS) {
+				results[op] = deterministicCount(dom[state][field]);
+			}
+			results.__dom = dom;
+		}
 		return {
 			gateErrors: [],
-			results: {
-				mount,
-				update_root,
-				update_partial,
-				partial_unmount,
-				partial_remount,
-				unmount,
-			},
+			results,
 		};
 	} finally {
 		await browser.close();
@@ -329,11 +359,33 @@ const OPS = [
 	'unmount',
 ];
 
+const DOM_OPS = [
+	['nodes_mounted', 'mounted', 'total'],
+	['elements_mounted', 'mounted', 'elements'],
+	['text_mounted', 'mounted', 'text'],
+	['comments_mounted', 'mounted', 'comments'],
+	['empty_text_mounted', 'mounted', 'emptyText'],
+	['whitespace_text_mounted', 'mounted', 'whitespaceText'],
+	['nodes_partial_unmounted', 'partialUnmounted', 'total'],
+	['elements_partial_unmounted', 'partialUnmounted', 'elements'],
+	['text_partial_unmounted', 'partialUnmounted', 'text'],
+	['comments_partial_unmounted', 'partialUnmounted', 'comments'],
+	['empty_text_partial_unmounted', 'partialUnmounted', 'emptyText'],
+	['whitespace_text_partial_unmounted', 'partialUnmounted', 'whitespaceText'],
+];
+
+const DIALECT_PAIR_NAMES = ['octane-tsrx', 'octane-jsx'];
+
 (async () => {
 	const all = {};
+	const dialectPairs = {};
 	const failures = [];
 	const failedTargets = new Set();
-	for (const t of TARGETS) {
+	const dialectTargets = DIALECT_PAIR_NAMES.map((name) =>
+		TARGETS.find((target) => target.name === name),
+	).filter(Boolean);
+	const remainingTargets = TARGETS.filter((target) => !DIALECT_PAIR_NAMES.includes(target.name));
+	const runVerifiedTarget = async (t) => {
 		console.error(`Running ${t.name} (${t.url}) × ${ITER} (+${WARMUP} warmup)…`);
 		try {
 			const { gateErrors, results } = await runTarget(t);
@@ -344,7 +396,7 @@ const OPS = [
 					failures.push(message);
 					console.error(`  ✗ ${message}`);
 				}
-				continue;
+				return;
 			}
 			all[t.name] = results;
 		} catch (error) {
@@ -353,7 +405,43 @@ const OPS = [
 			failures.push(message);
 			console.error(`  ✗ ${message}`);
 		}
+	};
+	for (const t of dialectTargets) await runVerifiedTarget(t);
+
+	// Order-balanced dialect aliases: the primary pass is TSRX₁ → TSX₁; repeat
+	// only those two in reverse, then combine their fully-warmed raw samples as
+	// independent runs. Existing target rows remain untouched for cross-framework
+	// comparisons, while TSX/TSRX guards use these A-B-B-A aliases.
+	if (dialectTargets.length === 2 && dialectTargets.every((target) => all[target.name])) {
+		const repeat = {};
+		for (const t of [...dialectTargets].reverse()) {
+			console.error(`Repeating ${t.name} for order-balanced dialect pair…`);
+			try {
+				const { results } = await runTarget(t, { verify: false });
+				repeat[t.name] = results;
+			} catch (error) {
+				const alias = `${t.name}-dialect-pair`;
+				failedTargets.add(alias);
+				const message = `${alias}: ${error instanceof Error ? error.message : String(error)}`;
+				failures.push(message);
+				console.error(`  ✗ ${message}`);
+			}
+		}
+		if (dialectTargets.every((target) => repeat[target.name])) {
+			for (const t of dialectTargets) {
+				const alias = `${t.name}-dialect-pair`;
+				dialectPairs[alias] = Object.fromEntries(
+					OPS.map((op) => [
+						op,
+						summarize([...all[t.name][op].__samples, ...repeat[t.name][op].__samples], {
+							scoreMode: 'mean',
+						}),
+					]),
+				);
+			}
+		}
 	}
+	for (const t of remainingTargets) await runVerifiedTarget(t);
 
 	const successfulTargets = TARGETS.filter((t) => all[t.name]);
 	const cols = successfulTargets.map((t) => t.name);
@@ -370,6 +458,22 @@ const OPS = [
 			);
 		}
 		console.log(row.join('| '));
+	}
+	for (const [op] of DOM_OPS) {
+		const row = [op.padEnd(16)];
+		for (const c of cols) row.push(String(all[c][op].median).padEnd(W));
+		console.log(row.join('| '));
+	}
+
+	const tsrxPair = dialectPairs['octane-tsrx-dialect-pair'];
+	const jsxPair = dialectPairs['octane-jsx-dialect-pair'];
+	if (tsrxPair && jsxPair) {
+		console.log('\norder-balanced octane-jsx / octane-tsrx dialect ratio:');
+		for (const op of OPS) {
+			console.log(
+				`  ${op.padEnd(16)} ${(scoreOf(jsxPair[op]) / scoreOf(tsrxPair[op])).toFixed(2)}x`,
+			);
+		}
 	}
 
 	if (successfulTargets.length > 1) {
@@ -407,18 +511,28 @@ const OPS = [
 		const payload = {
 			suite: 'recursive-context',
 			iterations: ITER,
-			targets: TARGETS.map((t) => ({
-				name: t.name,
-				ops: all[t.name]
-					? Object.fromEntries(
-							OPS.map((op) => {
-								const r = all[t.name][op];
-								return [op, timingStatForJson(r)];
-							}),
-						)
-					: {},
-				meta: { gates: failedTargets.has(t.name) ? 'fail' : 'pass' },
-			})),
+			targets: [
+				...TARGETS.map((t) => ({
+					name: t.name,
+					ops: all[t.name]
+						? {
+								...Object.fromEntries(OPS.map((op) => [op, timingStatForJson(all[t.name][op])])),
+								...Object.fromEntries(
+									DOM_OPS.map(([op]) => [op, deterministicStatForJson(all[t.name][op])]),
+								),
+							}
+						: {},
+					meta: {
+						gates: failedTargets.has(t.name) ? 'fail' : 'pass',
+						...(all[t.name]?.__dom ? { dom: all[t.name].__dom } : null),
+					},
+				})),
+				...Object.entries(dialectPairs).map(([name, results]) => ({
+					name,
+					ops: Object.fromEntries(OPS.map((op) => [op, timingStatForJson(results[op])])),
+					meta: { gates: failedTargets.has(name) ? 'fail' : 'pass', order: 'ABBA' },
+				})),
+			],
 		};
 		if (failures.length > 0) payload.failed = failures.join('; ');
 		fs.writeFileSync(process.env.BENCH_JSON, JSON.stringify(payload, null, '\t') + '\n');

--- a/benchmarks/recursive-context/work.mjs
+++ b/benchmarks/recursive-context/work.mjs
@@ -1,0 +1,343 @@
+// Deterministic, untimed production-work gate for Octane's TSRX/TSX twins.
+// Source counters would change the compiler's purity analysis, so this observes
+// the unminified production bundles through Chromium precise call coverage.
+
+import fs from 'node:fs';
+import { chromium } from 'playwright';
+import { deterministicCount, deterministicStatForJson } from '../lib/dom-nodes.mjs';
+import { collectPreciseCalls } from '../lib/precise-work.mjs';
+
+const TARGETS = [
+	{ name: 'octane-tsrx', url: 'http://localhost:5185/' },
+	{ name: 'octane-jsx', url: 'http://localhost:5188/' },
+];
+
+const METRICS = [
+	'renderBlock',
+	'componentSlot',
+	'componentSlotVoid',
+	'componentSlotLite',
+	'childSlot',
+	'createElement',
+	'hostElementBody',
+	'deoptItemBody',
+	'reconcileKeyed',
+	'updateSurvivor',
+	'setText',
+	'unmountBlock',
+	'unmountScope',
+];
+
+const OPS = [
+	{ name: 'mount', before: [], operation: '__mount' },
+	{ name: 'update_root', before: ['__mount'], operation: '__updateRoot' },
+	{ name: 'update_partial', before: ['__mount'], operation: '__updatePartial' },
+	{ name: 'partial_unmount', before: ['__mount'], operation: '__partialUnmount' },
+	{
+		name: 'partial_remount',
+		before: ['__mount', '__partialUnmount'],
+		operation: '__partialRemount',
+	},
+	{ name: 'unmount', before: ['__mount'], operation: '__unmount' },
+];
+
+// Scaffolding is bounded above so later direct-return lowering can reduce it
+// without rebaselining this gate. The visible update cardinality is exact.
+const GATES = {
+	'octane-tsrx': {
+		mount: {
+			maxFullSlotCalls: 1027,
+			maxSlotCalls: 3074,
+			max: {
+				renderBlock: 4099,
+				componentSlot: 2,
+				childSlot: 0,
+				createElement: 0,
+				hostElementBody: 0,
+				deoptItemBody: 0,
+				reconcileKeyed: 0,
+				updateSurvivor: 0,
+			},
+		},
+		update_root: {
+			maxFullSlotCalls: 1027,
+			maxSlotCalls: 3074,
+			max: {
+				renderBlock: 4099,
+				componentSlot: 2,
+				childSlot: 0,
+				createElement: 0,
+				hostElementBody: 0,
+				deoptItemBody: 0,
+				reconcileKeyed: 0,
+				updateSurvivor: 0,
+			},
+			exact: { setText: 1024 },
+		},
+		update_partial: {
+			maxFullSlotCalls: 33,
+			maxSlotCalls: 95,
+			max: {
+				renderBlock: 127,
+				componentSlot: 1,
+				childSlot: 0,
+				createElement: 0,
+				hostElementBody: 0,
+				deoptItemBody: 0,
+				reconcileKeyed: 0,
+				updateSurvivor: 0,
+			},
+			exact: { setText: 32 },
+		},
+		partial_unmount: {
+			maxFullSlotCalls: 0,
+			maxSlotCalls: 0,
+			max: {
+				renderBlock: 1,
+				componentSlot: 0,
+				childSlot: 0,
+				createElement: 0,
+				hostElementBody: 0,
+				deoptItemBody: 0,
+				reconcileKeyed: 0,
+				updateSurvivor: 0,
+				unmountBlock: 126,
+				unmountScope: 188,
+			},
+		},
+		partial_remount: {
+			maxFullSlotCalls: 33,
+			maxSlotCalls: 95,
+			max: {
+				renderBlock: 127,
+				componentSlot: 1,
+				childSlot: 0,
+				createElement: 0,
+				hostElementBody: 0,
+				deoptItemBody: 0,
+				reconcileKeyed: 0,
+				updateSurvivor: 0,
+			},
+		},
+		unmount: {
+			maxFullSlotCalls: 0,
+			maxSlotCalls: 0,
+			max: { unmountBlock: 4099, unmountScope: 6146 },
+		},
+	},
+	'octane-jsx': {
+		mount: {
+			maxFullSlotCalls: 2048,
+			maxSlotCalls: 3074,
+			max: {
+				renderBlock: 7168,
+				componentSlot: 2048,
+				childSlot: 4096,
+				createElement: 5121,
+				hostElementBody: 1023,
+				deoptItemBody: 2046,
+				reconcileKeyed: 1023,
+				updateSurvivor: 0,
+			},
+		},
+		update_root: {
+			maxFullSlotCalls: 2048,
+			maxSlotCalls: 3074,
+			max: {
+				renderBlock: 7168,
+				componentSlot: 2048,
+				childSlot: 4096,
+				createElement: 5121,
+				hostElementBody: 1023,
+				deoptItemBody: 2046,
+				reconcileKeyed: 1023,
+				updateSurvivor: 2046,
+			},
+			exact: { setText: 1024 },
+		},
+		update_partial: {
+			maxFullSlotCalls: 64,
+			maxSlotCalls: 95,
+			max: {
+				renderBlock: 221,
+				componentSlot: 64,
+				childSlot: 125,
+				createElement: 158,
+				hostElementBody: 31,
+				deoptItemBody: 62,
+				reconcileKeyed: 31,
+				updateSurvivor: 62,
+			},
+			exact: { setText: 32 },
+		},
+		partial_unmount: {
+			maxFullSlotCalls: 0,
+			maxSlotCalls: 0,
+			max: {
+				renderBlock: 1,
+				componentSlot: 0,
+				childSlot: 1,
+				createElement: 0,
+				hostElementBody: 0,
+				deoptItemBody: 0,
+				reconcileKeyed: 0,
+				updateSurvivor: 0,
+				unmountBlock: 220,
+				unmountScope: 220,
+			},
+		},
+		partial_remount: {
+			maxFullSlotCalls: 64,
+			maxSlotCalls: 95,
+			max: {
+				renderBlock: 221,
+				componentSlot: 64,
+				childSlot: 125,
+				createElement: 158,
+				hostElementBody: 31,
+				deoptItemBody: 62,
+				reconcileKeyed: 31,
+				updateSurvivor: 0,
+			},
+		},
+		unmount: {
+			maxFullSlotCalls: 0,
+			maxSlotCalls: 0,
+			max: { unmountBlock: 7168, unmountScope: 7168 },
+		},
+	},
+};
+
+const hasOwn = (object, key) => Object.prototype.hasOwnProperty.call(object, key);
+const METRIC_NAMES = new Set(METRICS);
+const AGGREGATED_SLOT_METRICS = new Set(['componentSlotVoid', 'componentSlotLite']);
+
+function validate(target, op, counts, failures) {
+	const gate = GATES[target][op];
+	for (const [kind, configured] of [
+		['max', gate.max ?? {}],
+		['exact', gate.exact ?? {}],
+	]) {
+		for (const [metric, value] of Object.entries(configured)) {
+			if (
+				!METRIC_NAMES.has(metric) ||
+				AGGREGATED_SLOT_METRICS.has(metric) ||
+				!Number.isFinite(value)
+			) {
+				failures.push(`${target}.${op}.${kind}: invalid ${metric}=${String(value)}`);
+			}
+		}
+	}
+	for (const metric of Object.keys(gate.exact ?? {})) {
+		if (hasOwn(gate.max ?? {}, metric)) {
+			failures.push(`${target}.${op}.${metric}: configured as both max and exact`);
+		}
+	}
+	if (!Number.isFinite(gate.maxFullSlotCalls) || !Number.isFinite(gate.maxSlotCalls)) {
+		failures.push(`${target}.${op}: missing finite aggregate slot ceilings`);
+	}
+	for (const metric of ['componentSlot', ...AGGREGATED_SLOT_METRICS]) {
+		if (!hasOwn(counts, metric) || !Number.isFinite(counts[metric])) {
+			failures.push(`${target}.${op}.${metric}: missing finite coverage count`);
+			return;
+		}
+	}
+	const fullSlotCalls = counts.componentSlot + counts.componentSlotVoid;
+	const slotCalls = fullSlotCalls + counts.componentSlotLite;
+	if (fullSlotCalls > gate.maxFullSlotCalls) {
+		failures.push(
+			`${target}.${op}.fullSlotCalls: ${fullSlotCalls} exceeds ceiling ${gate.maxFullSlotCalls}`,
+		);
+	}
+	if (slotCalls > gate.maxSlotCalls) {
+		failures.push(`${target}.${op}.slotCalls: ${slotCalls} exceeds ceiling ${gate.maxSlotCalls}`);
+	}
+	for (const metric of METRICS) {
+		if (AGGREGATED_SLOT_METRICS.has(metric)) continue;
+		if (!hasOwn(counts, metric) || !Number.isFinite(counts[metric])) {
+			failures.push(`${target}.${op}.${metric}: missing finite coverage count`);
+			continue;
+		}
+		if (hasOwn(gate.exact ?? {}, metric)) {
+			const expected = gate.exact[metric];
+			if (counts[metric] !== expected) {
+				failures.push(`${target}.${op}.${metric}: ${counts[metric]} !== expected ${expected}`);
+			}
+			continue;
+		}
+		const ceiling = hasOwn(gate.max ?? {}, metric) ? gate.max[metric] : 0;
+		if (counts[metric] > ceiling) {
+			failures.push(`${target}.${op}.${metric}: ${counts[metric]} exceeds ceiling ${ceiling}`);
+		}
+	}
+}
+
+const browser = await chromium.launch({
+	headless: true,
+	args: ['--no-sandbox', '--js-flags=--jitless'],
+});
+const results = {};
+const failures = [];
+try {
+	for (const target of TARGETS) {
+		results[target.name] = {};
+		for (const op of OPS) {
+			const counts = await collectPreciseCalls(browser, {
+				url: target.url,
+				before: op.before,
+				operation: op.operation,
+				metrics: METRICS,
+			});
+			results[target.name][op.name] = counts;
+			validate(target.name, op.name, counts, failures);
+		}
+	}
+} finally {
+	await browser.close();
+}
+
+console.log(
+	'Operation                 | render | full | void | lite | child | descriptors | host/deopt/keyed/survivors | text | unmount block/scope',
+);
+console.log(
+	'--------------------------+--------+------+------+------+-------+-------------+----------------------------+------+--------------------',
+);
+for (const target of TARGETS) {
+	for (const op of OPS) {
+		const c = results[target.name][op.name];
+		console.log(
+			`${`${target.name}.${op.name}`.padEnd(25)} | ${String(c.renderBlock).padStart(6)} | ${String(c.componentSlot).padStart(4)} | ${String(c.componentSlotVoid).padStart(4)} | ${String(c.componentSlotLite).padStart(4)} | ${String(c.childSlot).padStart(5)} | ${String(c.createElement).padStart(11)} | ${c.hostElementBody}/${c.deoptItemBody}/${c.reconcileKeyed}/${c.updateSurvivor} | ${String(c.setText).padStart(4)} | ${c.unmountBlock}/${c.unmountScope}`,
+		);
+	}
+}
+
+const outputPath = process.env.BENCH_JSON || process.env.WORK_JSON;
+if (outputPath) {
+	const payload = {
+		suite: 'recursive-context-work',
+		targets: TARGETS.map((target) => ({
+			name: `${target.name}-work`,
+			ops: Object.fromEntries(
+				OPS.flatMap((op) =>
+					METRICS.map((metric) => [
+						`${op.name}_${metric}`,
+						deterministicStatForJson(deterministicCount(results[target.name][op.name][metric])),
+					]),
+				),
+			),
+			meta: {
+				gates: failures.some((failure) => failure.startsWith(`${target.name}.`)) ? 'fail' : 'pass',
+			},
+		})),
+	};
+	if (failures.length > 0) payload.failed = failures.join('; ');
+	fs.writeFileSync(outputPath, JSON.stringify(payload, null, '\t') + '\n');
+}
+
+if (failures.length > 0) {
+	console.error(`\n${failures.length} deterministic work gate failure(s):`);
+	for (const failure of failures) console.error(`  - ${failure}`);
+	process.exit(1);
+}
+
+console.log('\nAll deterministic work gates passed.');

--- a/benchmarks/signal-favoring/README.md
+++ b/benchmarks/signal-favoring/README.md
@@ -30,6 +30,7 @@ benchmarks/signal-favoring/
 ├── svelte/           # Vite app, dev :5276 — Svelte 5 runes, 100 generated SFCs
 ├── gen.mjs            # Source generator for the App fixtures (scaffold; see note below)
 ├── run.mjs            # Playwright harness — drives all adapters
+├── work.mjs           # untimed Chromium precise-call-coverage gates for Octane
 ├── package.json       # umbrella: `pnpm bench`
 └── README.md
 ```
@@ -128,6 +129,10 @@ node benchmarks/bench.mjs --quick signal-favoring
 node benchmarks/bench.mjs signal-favoring
 ```
 
+The unified runner also executes `work.mjs` against the already-built Octane
+previews. Run it directly with `pnpm --dir benchmarks/signal-favoring
+bench:work` when those two previews are already running.
+
 ## Measurement contract
 
 Each adapter installs these globals on `window`:
@@ -151,5 +156,18 @@ The harness:
   before the rAF gate.
 - **UNMOUNT**: one page; per iteration `__mount()` (untimed), time `__unmount()`,
   then `__reset()`.
+
+After the semantic gate, the harness publishes a zero-variance mounted DOM
+census. Visible element/text counts control for equivalent output; total/comment
+counts expose framework bookkeeping. The Octane timing rows also have
+order-balanced aliases: the primary TSRX→TSX pass is repeated TSX→TSRX, and the
+two fully-warmed sample sets are combined for TSX/TSRX ratio guards.
+
+`work.mjs` uses jitless Chromium precise call coverage rather than source
+counters, which would change the program presented to the compiler. It caps
+blocks, aggregate component-slot dispatch, child slots, descriptors, and
+teardown work at the current production levels while allowing every count to
+fall. Every row requires live production-bundle coverage. C1/C51/C91 must still
+perform exactly one text write, and the ancestor-first batch exactly ten.
 
 Default: 5 warmups + 20 iters. Pass an integer to `bench` to override iters.

--- a/benchmarks/signal-favoring/package.json
+++ b/benchmarks/signal-favoring/package.json
@@ -6,6 +6,7 @@
   "description": "100-component chain comparing hook cascades with fine-grained updates across Octane and reference frameworks.",
   "scripts": {
     "bench": "node run.mjs",
+    "bench:work": "node work.mjs",
     "bench:long": "node run.mjs 40"
   },
   "dependencies": {

--- a/benchmarks/signal-favoring/run.mjs
+++ b/benchmarks/signal-favoring/run.mjs
@@ -33,6 +33,7 @@
 
 import { chromium } from 'playwright';
 import fs from 'node:fs';
+import { censusDomNodes, deterministicCount, deterministicStatForJson } from '../lib/dom-nodes.mjs';
 import { scoreOf, summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
 
 const ITER = parseInt(process.argv[2] || '20', 10);
@@ -171,8 +172,21 @@ async function semanticGate(browser, url) {
 	}
 }
 
-function summarize(samples) {
-	return summarizeSamples(samples);
+async function measureDom(browser, url) {
+	const { ctx, page } = await freshPage(browser, url);
+	try {
+		await page.evaluate(async () => {
+			const result = window.__mount();
+			if (result && typeof result.then === 'function') await result;
+		});
+		return await page.evaluate(censusDomNodes, '#main');
+	} finally {
+		await ctx.close();
+	}
+}
+
+function summarize(samples, options) {
+	return { ...summarizeSamples(samples, options), __samples: samples };
 }
 
 // MOUNT — fresh page per sample; time the synchronous __mount() on a clean heap.
@@ -322,15 +336,18 @@ async function measureUnmount(browser, url) {
 	return summarize(samples);
 }
 
-async function runTarget(t) {
+async function runTarget(t, { verify = true } = {}) {
 	const browser = await chromium.launch({
 		headless: true,
 		args: ['--disable-extensions', '--no-sandbox', '--js-flags=--expose-gc'],
 	});
 	try {
-		console.error(`  → semantic gate`);
-		const gateErrors = await semanticGate(browser, t.url);
-		if (gateErrors.length > 0) return { gateErrors, results: null };
+		if (verify) {
+			console.error(`  → semantic gate`);
+			const gateErrors = await semanticGate(browser, t.url);
+			if (gateErrors.length > 0) return { gateErrors, results: null };
+		}
+		const dom = verify ? await measureDom(browser, t.url) : null;
 
 		console.error(`  → mount`);
 		const mount = await measureMount(browser, t.url);
@@ -348,18 +365,23 @@ async function runTarget(t) {
 		const bump_sweep_reverse = await measureSweep(browser, t.url, '__sweepBatchedReverse');
 		console.error(`  → unmount`);
 		const unmount = await measureUnmount(browser, t.url);
+		const results = {
+			mount,
+			bump_shallow,
+			bump_middle,
+			bump_deep,
+			bump_sweep,
+			bump_sweep_batched,
+			bump_sweep_reverse,
+			unmount,
+		};
+		if (dom !== null) {
+			for (const [op, field] of DOM_OPS) results[op] = deterministicCount(dom[field]);
+			results.__dom = dom;
+		}
 		return {
 			gateErrors: [],
-			results: {
-				mount,
-				bump_shallow,
-				bump_middle,
-				bump_deep,
-				bump_sweep,
-				bump_sweep_batched,
-				bump_sweep_reverse,
-				unmount,
-			},
+			results,
 		};
 	} finally {
 		await browser.close();
@@ -377,11 +399,27 @@ const OPS = [
 	'unmount',
 ];
 
+const DOM_OPS = [
+	['nodes_mounted', 'total'],
+	['elements_mounted', 'elements'],
+	['text_mounted', 'text'],
+	['comments_mounted', 'comments'],
+	['empty_text_mounted', 'emptyText'],
+	['whitespace_text_mounted', 'whitespaceText'],
+];
+
+const DIALECT_PAIR_NAMES = ['octane-tsrx', 'octane-jsx'];
+
 (async () => {
 	const all = {};
+	const dialectPairs = {};
 	const failures = [];
 	const failedTargets = new Set();
-	for (const t of TARGETS) {
+	const dialectTargets = DIALECT_PAIR_NAMES.map((name) =>
+		TARGETS.find((target) => target.name === name),
+	).filter(Boolean);
+	const remainingTargets = TARGETS.filter((target) => !DIALECT_PAIR_NAMES.includes(target.name));
+	const runVerifiedTarget = async (t) => {
 		console.error(`Running ${t.name} (${t.url}) × ${ITER} (+${WARMUP} warmup)…`);
 		try {
 			const { gateErrors, results } = await runTarget(t);
@@ -392,7 +430,7 @@ const OPS = [
 					failures.push(message);
 					console.error(`  ✗ ${message}`);
 				}
-				continue;
+				return;
 			}
 			all[t.name] = results;
 		} catch (error) {
@@ -401,7 +439,42 @@ const OPS = [
 			failures.push(message);
 			console.error(`  ✗ ${message}`);
 		}
+	};
+	for (const t of dialectTargets) await runVerifiedTarget(t);
+
+	// Repeat only the Octane twins in reverse and combine the two independent,
+	// fully-warmed sample sets. Ratio guards use these A-B-B-A aliases so a fixed
+	// target order cannot masquerade as a dialect cost.
+	if (dialectTargets.length === 2 && dialectTargets.every((target) => all[target.name])) {
+		const repeat = {};
+		for (const t of [...dialectTargets].reverse()) {
+			console.error(`Repeating ${t.name} for order-balanced dialect pair…`);
+			try {
+				const { results } = await runTarget(t, { verify: false });
+				repeat[t.name] = results;
+			} catch (error) {
+				const alias = `${t.name}-dialect-pair`;
+				failedTargets.add(alias);
+				const message = `${alias}: ${error instanceof Error ? error.message : String(error)}`;
+				failures.push(message);
+				console.error(`  ✗ ${message}`);
+			}
+		}
+		if (dialectTargets.every((target) => repeat[target.name])) {
+			for (const t of dialectTargets) {
+				const alias = `${t.name}-dialect-pair`;
+				dialectPairs[alias] = Object.fromEntries(
+					OPS.map((op) => [
+						op,
+						summarize([...all[t.name][op].__samples, ...repeat[t.name][op].__samples], {
+							scoreMode: 'mean',
+						}),
+					]),
+				);
+			}
+		}
 	}
+	for (const t of remainingTargets) await runVerifiedTarget(t);
 
 	const successfulTargets = TARGETS.filter((t) => all[t.name]);
 	const cols = successfulTargets.map((t) => t.name);
@@ -419,6 +492,22 @@ const OPS = [
 			row.push(`${fmt(r.median)} (min ${fmt(r.min)}, sd ${fmt(r.stddev)})`.padEnd(W));
 		}
 		console.log(row.join('| '));
+	}
+	for (const [op] of DOM_OPS) {
+		const row = [op.padEnd(14)];
+		for (const c of cols) row.push(String(all[c][op].median).padEnd(W));
+		console.log(row.join('| '));
+	}
+
+	const tsrxPair = dialectPairs['octane-tsrx-dialect-pair'];
+	const jsxPair = dialectPairs['octane-jsx-dialect-pair'];
+	if (tsrxPair && jsxPair) {
+		console.log('\norder-balanced octane-jsx / octane-tsrx dialect ratio:');
+		for (const op of OPS) {
+			console.log(
+				`  ${op.padEnd(14)} ${(scoreOf(jsxPair[op]) / scoreOf(tsrxPair[op])).toFixed(2)}x`,
+			);
+		}
 	}
 
 	if (successfulTargets.length > 1) {
@@ -492,18 +581,28 @@ const OPS = [
 		const payload = {
 			suite: 'signal-favoring',
 			iterations: ITER,
-			targets: TARGETS.map((t) => ({
-				name: t.name,
-				ops: all[t.name]
-					? Object.fromEntries(
-							OPS.map((op) => {
-								const r = all[t.name][op];
-								return [op, timingStatForJson(r)];
-							}),
-						)
-					: {},
-				meta: { gates: failedTargets.has(t.name) ? 'fail' : 'pass' },
-			})),
+			targets: [
+				...TARGETS.map((t) => ({
+					name: t.name,
+					ops: all[t.name]
+						? {
+								...Object.fromEntries(OPS.map((op) => [op, timingStatForJson(all[t.name][op])])),
+								...Object.fromEntries(
+									DOM_OPS.map(([op]) => [op, deterministicStatForJson(all[t.name][op])]),
+								),
+							}
+						: {},
+					meta: {
+						gates: failedTargets.has(t.name) ? 'fail' : 'pass',
+						...(all[t.name]?.__dom ? { dom: all[t.name].__dom } : null),
+					},
+				})),
+				...Object.entries(dialectPairs).map(([name, results]) => ({
+					name,
+					ops: Object.fromEntries(OPS.map((op) => [op, timingStatForJson(results[op])])),
+					meta: { gates: failedTargets.has(name) ? 'fail' : 'pass', order: 'ABBA' },
+				})),
+			],
 		};
 		if (failures.length > 0) payload.failed = failures.join('; ');
 		fs.writeFileSync(process.env.BENCH_JSON, JSON.stringify(payload, null, '\t') + '\n');

--- a/benchmarks/signal-favoring/work.mjs
+++ b/benchmarks/signal-favoring/work.mjs
@@ -1,0 +1,246 @@
+// Deterministic, untimed production-work gate for Octane's TSRX/TSX twins.
+// Run against the production previews; the normal Vite configs are already
+// unminified, and --jitless keeps precise-call-coverage attribution stable.
+
+import fs from 'node:fs';
+import { chromium } from 'playwright';
+import { deterministicCount, deterministicStatForJson } from '../lib/dom-nodes.mjs';
+import { collectPreciseCalls } from '../lib/precise-work.mjs';
+
+const TARGETS = [
+	{ name: 'octane-tsrx', url: 'http://localhost:5190/' },
+	{ name: 'octane-jsx', url: 'http://localhost:5194/' },
+];
+
+const METRICS = [
+	'renderBlock',
+	'componentSlot',
+	'componentSlotVoid',
+	'componentSlotLite',
+	'childSlot',
+	'createElement',
+	'setText',
+	'unmountBlock',
+	'unmountScope',
+];
+
+const OPS = [
+	{ name: 'mount', before: [], operation: '__mount' },
+	{ name: 'bump_shallow', before: ['__mount'], operation: '__bumpAt1' },
+	{ name: 'bump_middle', before: ['__mount'], operation: '__bumpAt51' },
+	{ name: 'bump_deep', before: ['__mount'], operation: '__bumpAt91' },
+	{ name: 'bump_batched', before: ['__mount'], operation: '__sweepBatched' },
+	{ name: 'unmount', before: ['__mount'], operation: '__unmount' },
+];
+
+// These are ceilings on scaffolding, not exact implementation pins: every
+// planned TSX optimization should make them smaller. Text writes remain exact
+// because every update changes a known number of visible counters.
+const GATES = {
+	'octane-tsrx': {
+		mount: {
+			maxFullSlotCalls: 18,
+			maxSlotCalls: 100,
+			max: { renderBlock: 19, componentSlot: 0, childSlot: 10, createElement: 0 },
+		},
+		bump_shallow: {
+			maxFullSlotCalls: 9,
+			maxSlotCalls: 91,
+			max: { renderBlock: 10, componentSlot: 0, childSlot: 0, createElement: 0 },
+			exact: { setText: 1 },
+		},
+		bump_middle: {
+			maxFullSlotCalls: 4,
+			maxSlotCalls: 41,
+			max: { renderBlock: 5, componentSlot: 0, childSlot: 0, createElement: 0 },
+			exact: { setText: 1 },
+		},
+		bump_deep: {
+			maxFullSlotCalls: 0,
+			maxSlotCalls: 1,
+			max: { renderBlock: 1, componentSlot: 0, childSlot: 0, createElement: 0 },
+			exact: { setText: 1 },
+		},
+		bump_batched: {
+			maxFullSlotCalls: 9,
+			maxSlotCalls: 91,
+			max: { renderBlock: 10, componentSlot: 0, childSlot: 0, createElement: 0 },
+			exact: { setText: 10 },
+		},
+		unmount: {
+			maxFullSlotCalls: 0,
+			maxSlotCalls: 0,
+			max: { unmountBlock: 19, unmountScope: 101 },
+		},
+	},
+	'octane-jsx': {
+		mount: {
+			maxFullSlotCalls: 101,
+			maxSlotCalls: 101,
+			max: { renderBlock: 201, componentSlot: 101, childSlot: 109, createElement: 200 },
+		},
+		bump_shallow: {
+			maxFullSlotCalls: 100,
+			maxSlotCalls: 100,
+			max: { renderBlock: 200, componentSlot: 100, childSlot: 99, createElement: 199 },
+			exact: { setText: 1 },
+		},
+		bump_middle: {
+			maxFullSlotCalls: 50,
+			maxSlotCalls: 50,
+			max: { renderBlock: 100, componentSlot: 50, childSlot: 49, createElement: 99 },
+			exact: { setText: 1 },
+		},
+		bump_deep: {
+			maxFullSlotCalls: 10,
+			maxSlotCalls: 10,
+			max: { renderBlock: 20, componentSlot: 10, childSlot: 9, createElement: 19 },
+			exact: { setText: 1 },
+		},
+		bump_batched: {
+			maxFullSlotCalls: 100,
+			maxSlotCalls: 100,
+			max: { renderBlock: 200, componentSlot: 100, childSlot: 99, createElement: 199 },
+			exact: { setText: 10 },
+		},
+		unmount: {
+			maxFullSlotCalls: 0,
+			maxSlotCalls: 0,
+			max: { unmountBlock: 201, unmountScope: 201 },
+		},
+	},
+};
+
+const hasOwn = (object, key) => Object.prototype.hasOwnProperty.call(object, key);
+const METRIC_NAMES = new Set(METRICS);
+const AGGREGATED_SLOT_METRICS = new Set(['componentSlotVoid', 'componentSlotLite']);
+
+function validate(target, op, counts, failures) {
+	const gate = GATES[target][op];
+	for (const [kind, configured] of [
+		['max', gate.max ?? {}],
+		['exact', gate.exact ?? {}],
+	]) {
+		for (const [metric, value] of Object.entries(configured)) {
+			if (
+				!METRIC_NAMES.has(metric) ||
+				AGGREGATED_SLOT_METRICS.has(metric) ||
+				!Number.isFinite(value)
+			) {
+				failures.push(`${target}.${op}.${kind}: invalid ${metric}=${String(value)}`);
+			}
+		}
+	}
+	for (const metric of Object.keys(gate.exact ?? {})) {
+		if (hasOwn(gate.max ?? {}, metric)) {
+			failures.push(`${target}.${op}.${metric}: configured as both max and exact`);
+		}
+	}
+	if (!Number.isFinite(gate.maxFullSlotCalls) || !Number.isFinite(gate.maxSlotCalls)) {
+		failures.push(`${target}.${op}: missing finite aggregate slot ceilings`);
+	}
+	for (const metric of ['componentSlot', ...AGGREGATED_SLOT_METRICS]) {
+		if (!hasOwn(counts, metric) || !Number.isFinite(counts[metric])) {
+			failures.push(`${target}.${op}.${metric}: missing finite coverage count`);
+			return;
+		}
+	}
+	const fullSlotCalls = counts.componentSlot + counts.componentSlotVoid;
+	const slotCalls = fullSlotCalls + counts.componentSlotLite;
+	if (fullSlotCalls > gate.maxFullSlotCalls) {
+		failures.push(
+			`${target}.${op}.fullSlotCalls: ${fullSlotCalls} exceeds ceiling ${gate.maxFullSlotCalls}`,
+		);
+	}
+	if (slotCalls > gate.maxSlotCalls) {
+		failures.push(`${target}.${op}.slotCalls: ${slotCalls} exceeds ceiling ${gate.maxSlotCalls}`);
+	}
+	for (const metric of METRICS) {
+		if (AGGREGATED_SLOT_METRICS.has(metric)) continue;
+		if (!hasOwn(counts, metric) || !Number.isFinite(counts[metric])) {
+			failures.push(`${target}.${op}.${metric}: missing finite coverage count`);
+			continue;
+		}
+		if (hasOwn(gate.exact ?? {}, metric)) {
+			const expected = gate.exact[metric];
+			if (counts[metric] !== expected) {
+				failures.push(`${target}.${op}.${metric}: ${counts[metric]} !== expected ${expected}`);
+			}
+			continue;
+		}
+		const ceiling = hasOwn(gate.max ?? {}, metric) ? gate.max[metric] : 0;
+		if (counts[metric] > ceiling) {
+			failures.push(`${target}.${op}.${metric}: ${counts[metric]} exceeds ceiling ${ceiling}`);
+		}
+	}
+}
+
+const browser = await chromium.launch({
+	headless: true,
+	args: ['--no-sandbox', '--js-flags=--jitless'],
+});
+const results = {};
+const failures = [];
+try {
+	for (const target of TARGETS) {
+		results[target.name] = {};
+		for (const op of OPS) {
+			const counts = await collectPreciseCalls(browser, {
+				url: target.url,
+				before: op.before,
+				operation: op.operation,
+				metrics: METRICS,
+			});
+			results[target.name][op.name] = counts;
+			validate(target.name, op.name, counts, failures);
+		}
+	}
+} finally {
+	await browser.close();
+}
+
+console.log(
+	'Operation              | render | full | void | lite | child | descriptors | text | unmount block/scope',
+);
+console.log(
+	'-----------------------+--------+------+------+------+-------+-------------+------+--------------------',
+);
+for (const target of TARGETS) {
+	for (const op of OPS) {
+		const c = results[target.name][op.name];
+		console.log(
+			`${`${target.name}.${op.name}`.padEnd(22)} | ${String(c.renderBlock).padStart(6)} | ${String(c.componentSlot).padStart(4)} | ${String(c.componentSlotVoid).padStart(4)} | ${String(c.componentSlotLite).padStart(4)} | ${String(c.childSlot).padStart(5)} | ${String(c.createElement).padStart(11)} | ${String(c.setText).padStart(4)} | ${c.unmountBlock}/${c.unmountScope}`,
+		);
+	}
+}
+
+const outputPath = process.env.BENCH_JSON || process.env.WORK_JSON;
+if (outputPath) {
+	const payload = {
+		suite: 'signal-favoring-work',
+		targets: TARGETS.map((target) => ({
+			name: `${target.name}-work`,
+			ops: Object.fromEntries(
+				OPS.flatMap((op) =>
+					METRICS.map((metric) => [
+						`${op.name}_${metric}`,
+						deterministicStatForJson(deterministicCount(results[target.name][op.name][metric])),
+					]),
+				),
+			),
+			meta: {
+				gates: failures.some((failure) => failure.startsWith(`${target.name}.`)) ? 'fail' : 'pass',
+			},
+		})),
+	};
+	if (failures.length > 0) payload.failed = failures.join('; ');
+	fs.writeFileSync(outputPath, JSON.stringify(payload, null, '\t') + '\n');
+}
+
+if (failures.length > 0) {
+	console.error(`\n${failures.length} deterministic work gate failure(s):`);
+	for (const failure of failures) console.error(`  - ${failure}`);
+	process.exit(1);
+}
+
+console.log('\nAll deterministic work gates passed.');


### PR DESCRIPTION
## Summary

- add contiguous TSRX → TSX → TSX → TSRX order-balanced timing aliases for the recursive-context and signal-favoring suites
- add deterministic production work gates using jitless Chromium precise call coverage, exhaustive ceilings, coverage-liveness checks, and exact visible-write controls
- add DOM-shape censuses and 26 JSX/TSRX ratio guards across recursive, signal-chain, flat-list, memo-wall, and bundle-size workloads
- seed js-framework label generation and document the new benchmark contracts

## Why

Octane's JSX/TSX path is substantially behind TSRX in component-heavy workloads, while the existing timing-only measurements were vulnerable to target order, sub-millisecond noise, and structurally incorrect "wins." This Phase 1 change establishes stable, comparable baselines and regression guardrails before compiler/runtime optimization work begins.

The latest order-balanced quick runs reproduce the gap: recursive TSX is about 1.62× on mount, 2.41× on root context fan-out, and 4.69× on teardown; the signal-chain shallow update is about 2.87×.

This is benchmark/tooling-only and does not change compiler or runtime behavior.

## Validation

- `node benchmarks/bench.mjs --quick --ratios recursive-context signal-favoring` — passes semantic gates, deterministic work gates, DOM controls, and all applicable ratio guards
- new js-framework, memo-wall, and JSX/TSRX bundle-size guards pass in the combined quick run
- `corepack pnpm format:check`
- syntax, ratio-schema, duplicate-guard, JSON-shape, and `git diff --check` checks

A pre-existing TodoMVC/Svelte gzip ratio is fractionally above its old 1.07 ceiling in the broader bundle-size run; this PR leaves that unrelated threshold unchanged.

No changeset: benchmark and internal tooling only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and CI ratio-guard tooling only; no production compiler, runtime, or application code paths change.
> 
> **Overview**
> **Phase 1 benchmark guardrails** for the Octane JSX vs TSRX gap: no compiler or runtime changes.
> 
> **Order-balanced dialect timing** — `recursive-context` and `signal-favoring` now run TSRX→TSX, then repeat TSX→TSRX, and emit `octane-*-dialect-pair` targets whose samples are merged (mean score) for ratio checks while one-pass rows stay for cross-framework compares.
> 
> **Deterministic production-work gates** — shared `precise-work.mjs` uses jitless Chromium CDP precise call coverage on production bundles (avoids source probes that affect purity). New `work.mjs` in both suites caps scaffolding with max ceilings, pins exact `setText` counts, and writes `*-work` BENCH_JSON targets; `bench.mjs` runs them after `run.mjs`.
> 
> **DOM shape + ratios** — harnesses publish zero-variance censuses (`nodes_*`, `comments_*`, exact element/text controls). `ratios.json` gains TSX/TSRX guards for flat-list ops, memo-wall, recursive/signal dialect-pair timings, DOM scaffolding, and bundle gzip splits. **js-framework** seeds `Math.random` before warmup so label allocation noise does not skew dialect timings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9125faf50163944e9cf2834e6eb20116991dee4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->