### PR TITLE
Sync the vendored stream file with the prepared TanStack upstream patch

### DIFF
--- a/packages/tanstack-start/README.md
+++ b/packages/tanstack-start/README.md
@@ -50,9 +50,11 @@ with ONE deliberate exception:
 octane's native `StreamOptions.injection` API (replacing the
 `transformStreamWithRouter` byte-level merge and its doctype/style wrapper
 transforms). That file is kept **byte-identical** to the patch prepared for
-the upstream PR (TanStack/router#7847,
-`~/Projects/tanstack-octane-native-injection.patch`) so vendor-vs-upstream
-diffs stay clean; once upstream applies it, the file is verbatim again.
+the upstream PR (TanStack/router#7847), committed here as
+[`tanstack-octane-native-injection.patch`](./tanstack-octane-native-injection.patch)
+so vendor-vs-upstream diffs stay clean and the claim is verifiable
+(`git apply --check` on a checkout of the PR branch); once upstream applies
+it, the file is verbatim again.
 To update, re-vendor from a newer upstream build and re-apply those rewrites.
 Once the upstream PR lands and `@tanstack/octane-*` publish to npm, `vendor/`
 can be deleted and this facade repointed at registry dependencies.

--- a/packages/tanstack-start/README.md
+++ b/packages/tanstack-start/README.md
@@ -44,7 +44,15 @@ both resolve to the vendored workspace packages.
 ## Maintenance
 
 Do not hand-edit `vendor/` beyond the package.json dependency rewrites
-(URL → `workspace:*` / exact registry versions, `octane` peer → `workspace:*`).
+(URL → `workspace:*` / exact registry versions, `octane` peer → `workspace:*`),
+with ONE deliberate exception:
+`vendor/octane-router/src/ssr/renderRouterToStream.ts` was rewritten onto
+octane's native `StreamOptions.injection` API (replacing the
+`transformStreamWithRouter` byte-level merge and its doctype/style wrapper
+transforms). That file is kept **byte-identical** to the patch prepared for
+the upstream PR (TanStack/router#7847,
+`~/Projects/tanstack-octane-native-injection.patch`) so vendor-vs-upstream
+diffs stay clean; once upstream applies it, the file is verbatim again.
 To update, re-vendor from a newer upstream build and re-apply those rewrites.
 Once the upstream PR lands and `@tanstack/octane-*` publish to npm, `vendor/`
 can be deleted and this facade repointed at registry dependencies.

--- a/packages/tanstack-start/tanstack-octane-native-injection.patch
+++ b/packages/tanstack-start/tanstack-octane-native-injection.patch
@@ -1,0 +1,612 @@
+From 1ac59fa2c54412bf1194394f9acee507c5c535e5 Mon Sep 17 00:00:00 2001
+From: Dominic Gannaway <trueadm@users.noreply.github.com>
+Date: Sun, 19 Jul 2026 01:26:05 +0100
+Subject: [PATCH] octane-router: merge the data stream via octane's native
+ StreamOptions.injection
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Replaces the transformStreamWithRouter byte-level merge (and the
+prependDoctype / relocateLeadingOctaneStylesToHead wrappers) with octane's
+native injection API (octane >= 0.1.11): serverSsr wires
+take/subscribe/done/renderComplete, the script barrier lifts at octane's
+post-shell subscribe, and the serialization timeout arms on renderComplete
+exactly as before.
+
+Because the transform entered tail-holding on octane's FIRST chunk (the
+shell contains the whole document), every post-shell suspense segment was
+buffered into its 64 KiB-capped tail until both streams ended — so this
+also restores out-of-order streaming for document renders and removes the
+segment-volume cap. Octane's document mode now owns the doctype and
+styles-into-head placement natively; the retained end-to-end SSR stream
+test (doctype at offset 0, scoped styles inside <head> with the CSP nonce)
+pins the same consumer-visible contract, while the two helper unit tests
+for the deleted transform go with it.
+---
+ packages/octane-router/package.json           |   2 +-
+ .../src/ssr/renderRouterToStream.ts           | 340 +++++-------------
+ .../tests/conformance/ssr.test.ts             |  84 -----
+ packages/octane-start-client/package.json     |   2 +-
+ packages/octane-start-server/package.json     |   2 +-
+ packages/octane-start/package.json            |   2 +-
+ pnpm-workspace.yaml                           |   2 +-
+ 7 files changed, 94 insertions(+), 340 deletions(-)
+
+diff --git a/packages/octane-router/package.json b/packages/octane-router/package.json
+index 562a16d..c92e914 100644
+--- a/packages/octane-router/package.json
++++ b/packages/octane-router/package.json
+@@ -80,6 +80,6 @@
+     "vite": "*"
+   },
+   "peerDependencies": {
+-    "octane": ">=0.1.8"
++    "octane": ">=0.1.11"
+   }
+ }
+diff --git a/packages/octane-router/src/ssr/renderRouterToStream.ts b/packages/octane-router/src/ssr/renderRouterToStream.ts
+index 261d3c3..17609cb 100644
+--- a/packages/octane-router/src/ssr/renderRouterToStream.ts
++++ b/packages/octane-router/src/ssr/renderRouterToStream.ts
+@@ -1,17 +1,38 @@
+ import { renderToReadableStream } from 'octane/server'
+ import { prerender } from 'octane/static'
+ import { isbot } from 'isbot'
+-import {
+-  createSsrStreamResponse,
+-  transformReadableStreamWithRouter,
+-} from '@tanstack/router-core/ssr/server'
++import { createSsrStreamResponse } from '@tanstack/router-core/ssr/server'
+ import { finalizeBufferedHtml } from './renderRouterToString'
+ import type { ComponentBody } from 'octane'
++import type { StreamInjectionSource } from 'octane/server'
+ import type { AnyRouter } from '@tanstack/router-core'
+ 
+ type RouterApp = ComponentBody<{ router: AnyRouter }>
+ type ServerComponent = Parameters<typeof renderToReadableStream>[0]
+ 
++// The router's data stream is merged through octane's native
++// `StreamOptions.injection` (octane >= 0.1.11) instead of router-core's
++// `transformStreamWithRouter` text transform. Octane emits tag-complete
++// chunks and owns the document tail, so the byte-level re-parse
++// (closing-tag scans, leftover buffers, the held-`</body>` tail that also
++// buffered every post-shell suspense segment until stream end) is
++// unnecessary — boundary segments stream out of order for document renders,
++// and the transform's 64 KiB tail cap on segment volume disappears.
++// Octane's document mode also emits `<!DOCTYPE html>` and folds the leading
++// renderer-owned styles into `<head>`, replacing the `prependDoctype` and
++// `relocateLeadingOctaneStylesToHead` transforms this file previously piped
++// the stream through.
++//
++// The serialization timeout is preserved: it arms when octane reports the
++// render finished (`renderComplete`) and fails the stream if serialization
++// never completes. The script barrier lifts when octane subscribes — octane
++// only subscribes after the shell (which carries the barrier anchor) is on
++// the wire, matching the transform's lift-after-marker-flush.
++// (`setRenderFinished` lifts it as a backstop regardless, exactly as
++// before.)
++
++const SERIALIZATION_TIMEOUT_MS = 60_000
++
+ export async function renderRouterToStream({
+   request,
+   router,
+@@ -27,17 +48,66 @@ export async function renderRouterToStream({
+     return renderRouterForBot({ request, router, responseHeaders, App })
+   }
+ 
++  const serverSsr = router.serverSsr
++  if (!serverSsr) {
++    throw new Error('Invariant failed: router.serverSsr is required')
++  }
++
+   const renderController = new AbortController()
+   const onRequestAbort = () => renderController.abort(request.signal.reason)
+   if (request.signal.aborted) {
+     onRequestAbort()
+   } else {
+     request.signal.addEventListener('abort', onRequestAbort, { once: true })
+-    router.serverSsr?.onCleanup(() => {
++    serverSsr.onCleanup(() => {
+       request.signal.removeEventListener('abort', onRequestAbort)
+     })
+   }
+ 
++  let serializationTimeout: ReturnType<typeof setTimeout> | undefined
++  let stopSerializationListener: (() => void) | undefined
++  let settleDone!: () => void
++  let failDone!: (reason: unknown) => void
++  const done = new Promise<void>((resolve, reject) => {
++    settleDone = resolve
++    failDone = reject
++  })
++  if (serverSsr.isSerializationFinished()) {
++    settleDone()
++  } else {
++    stopSerializationListener = serverSsr.onSerializationFinished(() =>
++      settleDone(),
++    )
++  }
++  const releaseInjection = () => {
++    if (serializationTimeout !== undefined) {
++      clearTimeout(serializationTimeout)
++      serializationTimeout = undefined
++    }
++    stopSerializationListener?.()
++    stopSerializationListener = undefined
++  }
++
++  const injection: StreamInjectionSource = {
++    take: () => serverSsr.takeBufferedHtml() ?? '',
++    subscribe(notify) {
++      serverSsr.liftScriptBarrier()
++      return serverSsr.onInjectedHtml(notify)
++    },
++    done,
++    renderComplete() {
++      serverSsr.setRenderFinished()
++      if (
++        !serverSsr.isSerializationFinished() &&
++        serializationTimeout === undefined
++      ) {
++        serializationTimeout = setTimeout(() => {
++          failDone(new Error('Serialization timeout after app render finished'))
++        }, SERIALIZATION_TIMEOUT_MS)
++      }
++    },
++  }
++
+   try {
+     const stream = await renderToReadableStream(
+       App as unknown as ServerComponent,
+@@ -45,6 +115,7 @@ export async function renderRouterToStream({
+       {
+         signal: renderController.signal,
+         nonce: router.options.ssr?.nonce,
++        injection,
+         onError(error) {
+           if (!isAbortError(request, error)) {
+             console.error('Error in renderToReadableStream:', error)
+@@ -53,218 +124,35 @@ export async function renderRouterToStream({
+       },
+     )
+ 
+-    const appStream = prependDoctype(relocateLeadingOctaneStylesToHead(stream))
+-    const responseStream = transformReadableStreamWithRouter(
+-      router,
+-      appStream as unknown as Parameters<
+-        typeof transformReadableStreamWithRouter
+-      >[1],
+-      {
+-        onAbort: (reason) => renderController.abort(reason),
++    // The renderer's stream is the response body verbatim. `allReady` settles
++    // in every terminal state (close, abort, fatal, consumer cancel) — the
++    // single place to release the injection wiring and the router's SSR state.
++    stream.allReady.then(
++      () => {
++        releaseInjection()
++        serverSsr.cleanup()
++      },
++      () => {
++        releaseInjection()
++        serverSsr.cleanup()
+       },
+     )
+ 
+     return createSsrStreamResponse(
+       router,
+-      new Response(responseStream as unknown as BodyInit, {
++      new Response(stream as unknown as BodyInit, {
+         status: router.stores.statusCode.get(),
+         headers: responseHeaders,
+       }),
+     )
+   } catch (error) {
+     renderController.abort(error)
++    releaseInjection()
+     router.serverSsr?.cleanup()
+     throw error
+   }
+ }
+ 
+-const MAX_DOCUMENT_PREFIX_CHARS = 64 * 1024
+-
+-/**
+- * Octane streams the scoped styles needed by the shell before the rendered
+- * markup. That is useful for fragment roots, but a full document would put the
+- * styles before `<html>`. Hold only those leading renderer-owned styles and the
+- * document prefix, then release them immediately after the opening `<head>`.
+- * All later chunks (including suspense styles and boundary instructions) keep
+- * flowing through this transform under the source stream's backpressure.
+- */
+-export function relocateLeadingOctaneStylesToHead(
+-  stream: globalThis.ReadableStream<Uint8Array>,
+-): globalThis.ReadableStream<Uint8Array> {
+-  const decoder = new TextDecoder()
+-  const encoder = new TextEncoder()
+-  let state: 'leading' | 'document-prefix' | 'passthrough' = 'leading'
+-  let buffer = ''
+-  let leadingStyles = ''
+-
+-  const transform = new TransformStream<Uint8Array, Uint8Array>({
+-    transform(chunk, controller) {
+-      buffer += decoder.decode(chunk, { stream: true })
+-      processBuffer(controller, false)
+-    },
+-    flush(controller) {
+-      buffer += decoder.decode()
+-      processBuffer(controller, true)
+-    },
+-  })
+-
+-  return stream.pipeThrough(transform)
+-
+-  function processBuffer(
+-    controller: TransformStreamDefaultController<Uint8Array>,
+-    isFinalChunk: boolean,
+-  ) {
+-    while (state === 'leading') {
+-      const style = readLeadingOctaneStyle(buffer, isFinalChunk)
+-      if (style === undefined) {
+-        return
+-      }
+-      if (style === null) {
+-        if (!leadingStyles) {
+-          state = 'passthrough'
+-          enqueueBuffer(controller)
+-          return
+-        }
+-        state = 'document-prefix'
+-        break
+-      }
+-      leadingStyles += buffer.slice(0, style)
+-      buffer = buffer.slice(style)
+-    }
+-
+-    if (state === 'document-prefix') {
+-      const headEnd = findOpeningTagEnd(buffer, 'head')
+-      if (headEnd !== -1) {
+-        enqueue(
+-          controller,
+-          `${buffer.slice(0, headEnd)}${leadingStyles}${buffer.slice(headEnd)}`,
+-        )
+-        leadingStyles = ''
+-        buffer = ''
+-        state = 'passthrough'
+-        return
+-      }
+-
+-      // A route-owned document is expected to render a head. Keep malformed or
+-      // fragment output streaming too: after a bounded prefix, preserve Octane's
+-      // original ordering instead of retaining the rest of the response.
+-      if (!isFinalChunk && buffer.length <= MAX_DOCUMENT_PREFIX_CHARS) {
+-        return
+-      }
+-
+-      enqueue(controller, `${leadingStyles}${buffer}`)
+-      leadingStyles = ''
+-      buffer = ''
+-      state = 'passthrough'
+-      return
+-    }
+-
+-    enqueueBuffer(controller)
+-  }
+-
+-  function enqueueBuffer(
+-    controller: TransformStreamDefaultController<Uint8Array>,
+-  ) {
+-    enqueue(controller, buffer)
+-    buffer = ''
+-  }
+-
+-  function enqueue(
+-    controller: TransformStreamDefaultController<Uint8Array>,
+-    value: string,
+-  ) {
+-    if (value) {
+-      controller.enqueue(encoder.encode(value))
+-    }
+-  }
+-}
+-
+-// Returns the end offset of a complete leading Octane style, null when the
+-// prefix is not one, or undefined while a split tag still needs more bytes.
+-function readLeadingOctaneStyle(
+-  html: string,
+-  isFinalChunk: boolean,
+-): number | null | undefined {
+-  const stylePrefix = '<style'
+-  const comparablePrefix = html
+-    .slice(0, Math.min(html.length, stylePrefix.length))
+-    .toLowerCase()
+-
+-  if (!stylePrefix.startsWith(comparablePrefix)) {
+-    return null
+-  }
+-  if (html.length < stylePrefix.length) {
+-    return isFinalChunk ? null : undefined
+-  }
+-
+-  const next = html.charAt(stylePrefix.length)
+-  if (!next) {
+-    return isFinalChunk ? null : undefined
+-  }
+-  if (next !== '>' && !isHtmlWhitespace(next)) {
+-    return null
+-  }
+-
+-  const openingTagEnd = findTagEnd(html, 0)
+-  if (openingTagEnd === -1) {
+-    return isFinalChunk ? null : undefined
+-  }
+-
+-  const openingTag = html.slice(0, openingTagEnd)
+-  if (!/\sdata-octane(?:\s|=|>)/i.test(openingTag)) {
+-    return null
+-  }
+-
+-  const closingTag = '</style>'
+-  const closingTagStart = html.toLowerCase().indexOf(closingTag, openingTagEnd)
+-  if (closingTagStart === -1) {
+-    return isFinalChunk ? null : undefined
+-  }
+-  return closingTagStart + closingTag.length
+-}
+-
+-function findOpeningTagEnd(html: string, tagName: string): number {
+-  const lowerHtml = html.toLowerCase()
+-  const prefix = `<${tagName}`
+-  let searchFrom = 0
+-
+-  while (searchFrom < html.length) {
+-    const start = lowerHtml.indexOf(prefix, searchFrom)
+-    if (start === -1) {
+-      return -1
+-    }
+-
+-    const next = html.charAt(start + prefix.length)
+-    if (next === '>' || isHtmlWhitespace(next)) {
+-      return findTagEnd(html, start)
+-    }
+-    searchFrom = start + prefix.length
+-  }
+-
+-  return -1
+-}
+-
+-function findTagEnd(html: string, start: number): number {
+-  let quote: '"' | "'" | undefined
+-  for (let index = start + 1; index < html.length; index++) {
+-    const char = html.charAt(index)
+-    if (quote) {
+-      if (char === quote) {
+-        quote = undefined
+-      }
+-    } else if (char === '"' || char === "'") {
+-      quote = char
+-    } else if (char === '>') {
+-      return index + 1
+-    }
+-  }
+-  return -1
+-}
+-
+-function isHtmlWhitespace(char: string) {
+-  return char === ' ' || char === '\n' || char === '\r' || char === '\t'
+-}
+-
+ async function renderRouterForBot({
+   request,
+   router,
+@@ -308,56 +196,6 @@ async function renderRouterForBot({
+   }
+ }
+ 
+-function prependDoctype(
+-  stream: globalThis.ReadableStream<Uint8Array>,
+-): ReadableStream<Uint8Array> {
+-  const encoder = new TextEncoder()
+-  let reader: ReadableStreamDefaultReader<Uint8Array> | undefined
+-  let sentDoctype = false
+-
+-  return new ReadableStream({
+-    start() {
+-      reader = stream.getReader()
+-    },
+-    async pull(controller) {
+-      if (!sentDoctype) {
+-        sentDoctype = true
+-        controller.enqueue(encoder.encode('<!DOCTYPE html>'))
+-        return
+-      }
+-
+-      try {
+-        const { done, value } = await reader!.read()
+-        if (done) {
+-          controller.close()
+-          releaseReader()
+-        } else {
+-          controller.enqueue(value)
+-        }
+-      } catch (error) {
+-        controller.error(error)
+-        releaseReader()
+-      }
+-    },
+-    async cancel(reason) {
+-      try {
+-        await reader?.cancel(reason)
+-      } finally {
+-        releaseReader()
+-      }
+-    },
+-  })
+-
+-  function releaseReader() {
+-    try {
+-      reader?.releaseLock()
+-    } catch {
+-      // The stream may already have released its reader during cancellation.
+-    }
+-    reader = undefined
+-  }
+-}
+-
+ function isAbortError(request: Request, error: unknown) {
+   return (
+     (request.signal.aborted && error === request.signal.reason) ||
+diff --git a/packages/octane-router/tests/conformance/ssr.test.ts b/packages/octane-router/tests/conformance/ssr.test.ts
+index 23560d7..7450194 100644
+--- a/packages/octane-router/tests/conformance/ssr.test.ts
++++ b/packages/octane-router/tests/conformance/ssr.test.ts
+@@ -8,7 +8,6 @@ import {
+   renderRouterToStream,
+   renderRouterToString,
+ } from '../../src/ssr/server'
+-import { relocateLeadingOctaneStylesToHead } from '../../src/ssr/renderRouterToStream'
+ import { makeSsrRouter } from '../_fixtures/ssr.tsrx'
+ 
+ describe('@tanstack/octane-router SSR', () => {
+@@ -115,87 +114,4 @@ describe('@tanstack/octane-router SSR', () => {
+     expect(html.slice(style, headClose)).toContain('nonce="octane-csp"')
+     expect(html.slice(style, headClose)).toContain('rgb(12, 34, 56)')
+   })
+-
+-  it('releases the normalized shell before later stream chunks', async () => {
+-    const encoder = new TextEncoder()
+-    const decoder = new TextDecoder()
+-    let releaseTail!: () => void
+-    const tailReady = new Promise<void>((resolve) => {
+-      releaseTail = resolve
+-    })
+-    const chunks = [
+-      '<sty',
+-      'le data-octane="tsrx-shell" nonce="test-nonce">.shell{color:red}</sty',
+-      'le><!--[--><html lang="en"><he',
+-      'ad data-label=">"><title>Stream</title></head><body>shell',
+-    ]
+-    let index = 0
+-    const source = new ReadableStream<Uint8Array>({
+-      async pull(controller) {
+-        if (index < chunks.length) {
+-          controller.enqueue(encoder.encode(chunks[index++]))
+-          return
+-        }
+-        await tailReady
+-        controller.enqueue(
+-          encoder.encode(
+-            '<style data-octane="tsrx-late" nonce="test-nonce">.late{color:blue}</style><aside>late</aside></body></html>',
+-          ),
+-        )
+-        controller.close()
+-      },
+-    })
+-
+-    const reader = relocateLeadingOctaneStylesToHead(source).getReader()
+-    const shellResult = await reader.read()
+-    const shell = decoder.decode(shellResult.value)
+-
+-    expect(shell).toContain(
+-      '<head data-label=">"><style data-octane="tsrx-shell" nonce="test-nonce">',
+-    )
+-    expect(shell.indexOf('<html')).toBeLessThan(shell.indexOf('<head'))
+-    expect(shell.indexOf('<head')).toBeLessThan(
+-      shell.indexOf('<style data-octane='),
+-    )
+-
+-    let tailReleased = false
+-    const tailResult = reader.read().then((result) => {
+-      tailReleased = true
+-      return result
+-    })
+-    await Promise.resolve()
+-    expect(tailReleased).toBe(false)
+-
+-    releaseTail()
+-    expect(decoder.decode((await tailResult).value)).toBe(
+-      '<style data-octane="tsrx-late" nonce="test-nonce">.late{color:blue}</style><aside>late</aside></body></html>',
+-    )
+-  })
+-
+-  it('propagates cancellation through document normalization', async () => {
+-    const encoder = new TextEncoder()
+-    const reason = new Error('client disconnected')
+-    let markCancelled!: (reason: unknown) => void
+-    const cancelled = new Promise<unknown>((resolve) => {
+-      markCancelled = resolve
+-    })
+-    const source = new ReadableStream<Uint8Array>({
+-      start(controller) {
+-        controller.enqueue(
+-          encoder.encode(
+-            '<style data-octane="tsrx-shell">.shell{}</style><html><head></head><body>',
+-          ),
+-        )
+-      },
+-      cancel(cancelReason) {
+-        markCancelled(cancelReason)
+-      },
+-    })
+-    const reader = relocateLeadingOctaneStylesToHead(source).getReader()
+-
+-    await reader.read()
+-    await reader.cancel(reason)
+-
+-    expect(await cancelled).toBe(reason)
+-  })
+ })
+diff --git a/packages/octane-start-client/package.json b/packages/octane-start-client/package.json
+index 81a9903..7591b23 100644
+--- a/packages/octane-start-client/package.json
++++ b/packages/octane-start-client/package.json
+@@ -69,6 +69,6 @@
+     "vite": "*"
+   },
+   "peerDependencies": {
+-    "octane": ">=0.1.8"
++    "octane": ">=0.1.11"
+   }
+ }
+diff --git a/packages/octane-start-server/package.json b/packages/octane-start-server/package.json
+index bc8cda2..272436c 100644
+--- a/packages/octane-start-server/package.json
++++ b/packages/octane-start-server/package.json
+@@ -61,6 +61,6 @@
+     "vite": "*"
+   },
+   "peerDependencies": {
+-    "octane": ">=0.1.8"
++    "octane": ">=0.1.11"
+   }
+ }
+diff --git a/packages/octane-start/package.json b/packages/octane-start/package.json
+index 7efe2b1..5394c11 100644
+--- a/packages/octane-start/package.json
++++ b/packages/octane-start/package.json
+@@ -121,7 +121,7 @@
+     "vite": "*"
+   },
+   "peerDependencies": {
+-    "octane": ">=0.1.8",
++    "octane": ">=0.1.11",
+     "vite": ">=7.0.0"
+   },
+   "peerDependenciesMeta": {
+diff --git a/pnpm-workspace.yaml b/pnpm-workspace.yaml
+index 5a8b6ee..dd908ab 100644
+--- a/pnpm-workspace.yaml
++++ b/pnpm-workspace.yaml
+@@ -47,7 +47,7 @@ catalog:
+   '@tanstack/react-query': ^5.99.0
+   '@tanstack/solid-query': ^5.99.0
+   '@tanstack/vue-query': ^5.99.0
+-  octane: ^0.1.8
++  octane: ^0.1.11
+ 
+ overrides:
+   '@types/babel__traverse': '^7.28.0'
+-- 
+2.50.1 (Apple Git-155)
+

--- a/packages/tanstack-start/vendor/octane-router/src/ssr/renderRouterToStream.ts
+++ b/packages/tanstack-start/vendor/octane-router/src/ssr/renderRouterToStream.ts
@@ -10,24 +10,26 @@ import type { AnyRouter } from '@tanstack/router-core'
 type RouterApp = ComponentBody<{ router: AnyRouter }>
 type ServerComponent = Parameters<typeof renderToReadableStream>[0]
 
-// OCTANE PATCH (diverges from the upstream PR-branch file): the router's data
-// stream is merged through octane's native `StreamOptions.injection` instead
-// of router-core's `transformStreamWithRouter` text transform. Octane emits
-// tag-complete chunks and owns the document tail, so the byte-level re-parse
+// The router's data stream is merged through octane's native
+// `StreamOptions.injection` (octane >= 0.1.11) instead of router-core's
+// `transformStreamWithRouter` text transform. Octane emits tag-complete
+// chunks and owns the document tail, so the byte-level re-parse
 // (closing-tag scans, leftover buffers, the held-`</body>` tail that also
-// buffered every post-shell suspense segment until stream end) is unnecessary
-// — boundary segments now stream out of order again for document renders.
+// buffered every post-shell suspense segment until stream end) is
+// unnecessary — boundary segments stream out of order for document renders,
+// and the transform's 64 KiB tail cap on segment volume disappears.
 // Octane's document mode also emits `<!DOCTYPE html>` and folds the leading
 // renderer-owned styles into `<head>`, replacing the `prependDoctype` and
 // `relocateLeadingOctaneStylesToHead` transforms this file previously piped
 // the stream through.
 //
-// Upstream's serialization timeout is preserved: it arms when octane reports
-// the render finished and fails the stream if serialization never completes.
-// The script barrier lifts when octane subscribes — octane only subscribes
-// after the shell (which carries the barrier anchor) is on the wire, matching
-// the transform's lift-after-marker-flush. (`setRenderFinished` lifts it as a
-// backstop regardless, exactly as upstream.)
+// The serialization timeout is preserved: it arms when octane reports the
+// render finished (`renderComplete`) and fails the stream if serialization
+// never completes. The script barrier lifts when octane subscribes — octane
+// only subscribes after the shell (which carries the barrier anchor) is on
+// the wire, matching the transform's lift-after-marker-flush.
+// (`setRenderFinished` lifts it as a backstop regardless, exactly as
+// before.)
 
 const SERIALIZATION_TIMEOUT_MS = 60_000
 


### PR DESCRIPTION
Follow-up to #168/#174. The native-injection `renderRouterToStream` was prepared as a ready-to-apply patch for TanStack/router#7847 (`taren/framework-adapter` @ `753f919e` — the exact commit the vendor tree came from). This keeps the vendored copy **byte-identical** to that patch (the delta was comment-only; the code already matched), so vendor-vs-upstream diffs stay clean and the file becomes verbatim again the moment upstream applies it.

Also documents the one deliberate vendor divergence in the package README, which still claimed the entire tree was verbatim.

Verified: injection contract tests 18/18, website ssr-hydration e2e 32/32 (cold vite cache), format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and comment alignment only; no new SSR logic in this diff beyond matching the already-applied upstream patch text.
> 
> **Overview**
> Adds **`tanstack-octane-native-injection.patch`** as the canonical copy of the TanStack/router#7847 change and updates **`@octanejs/tanstack-start` README** so maintenance docs no longer imply all of `vendor/` is verbatim.
> 
> The vendored **`renderRouterToStream.ts`** is brought **byte-identical** to that patch (comment-only delta vs the prior “OCTANE PATCH” wording); runtime behavior was already on octane’s native **`StreamOptions.injection`** path. Reviewers can verify with **`git apply --check`** on the upstream PR branch until upstream lands the same file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25a2bbdffe4428275bbf6cb0293481b414ba1583. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->