### PR TITLE
Fix dev SSR error page stringifying the raw route entry tuple

### DIFF
--- a/.changeset/render-route-entry-tuple-error-page.md
+++ b/.changeset/render-route-entry-tuple-error-page.md
@@ -1,0 +1,9 @@
+---
+'@octanejs/vite-plugin': patch
+---
+
+Fix the dev SSR error page printing the raw route `entry` tuple. A route
+configured with the `[exportName, modulePath]` tuple form rendered as the
+comma-joined array (`Post,/src/Post.tsrx`) on the 500 error overlay; it now
+resolves the module path through `get_route_entry_path`, "matching how the
+renderer resolves the entry path everywhere else.

--- a/packages/vite-plugin-octane/src/server/render-route.js
+++ b/packages/vite-plugin-octane/src/server/render-route.js
@@ -266,7 +266,7 @@ pre { background: #2d2d2d; padding: 1rem; border-radius: 4px; overflow-x: auto; 
 </head>
 <body>
 <h1>SSR Render Error</h1>
-<p class="route">Route: ${route.path} → ${route.entry}</p>
+<p class="route">Route: ${route.path} → ${get_route_entry_path(route.entry)}</p>
 <pre>${escapeHtml(message)}</pre>
 ${stack ? `<pre>${escapeHtml(stack)}</pre>` : ''}
 </body>

--- a/packages/vite-plugin-octane/tests/render-route.test.ts
+++ b/packages/vite-plugin-octane/tests/render-route.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { handleRenderRoute } from '../src/server/render-route.js';
+import { RenderRoute } from '../src/routes.js';
+
+describe('dev SSR error page', () => {
+	it('shows the module path, not the raw tuple, for a tuple-configured route', async () => {
+		// A route using the [exportName, modulePath] tuple entry form.
+		const route = new RenderRoute({ path: '/posts/:id', entry: ['Post', '/src/Post.tsrx'] });
+
+		// Make the render throw so we get the 500 error page. ssrLoadModule is the
+		// first thing handleRenderRoute awaits, so throwing here is enough.
+		const vite = {
+			ssrLoadModule: () => {
+				throw new Error('boom');
+			},
+		};
+
+		const response = await handleRenderRoute(route, {} as any, vite as any);
+		expect(response.status).toBe(500);
+
+		const html = await response.text();
+		// Should show the module path, not the whole tuple joined as "Post,/src/Post.tsrx".
+		expect(html).toContain('Route: /posts/:id → /src/Post.tsrx');
+		expect(html).not.toContain('Post,/src/Post.tsrx');
+	});
+});


### PR DESCRIPTION
Before:

<img width="438" height="251" alt="Screenshot 2026-07-19 at 6 44 09 PM" src="https://github.com/user-attachments/assets/4a7d70e0-2c32-403b-88ad-cde2b69c2df9" />

After:

<img width="488" height="252" alt="Screenshot 2026-07-19 at 6 49 46 PM" src="https://github.com/user-attachments/assets/b7191178-9f58-4d75-97fc-178b6a59aa48" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only error overlay formatting with a small helper already used on the render path; no production SSR behavior change.
> 
> **Overview**
> Fixes the **dev SSR 500 overlay** when a route uses the `[exportName, modulePath]` **tuple** `entry` form: it no longer prints the raw tuple (e.g. `Post,/src/Post.tsrx`) and instead shows the module path via `get_route_entry_path`, consistent with normal SSR loading.
> 
> Adds a **Vitest** case that forces a render failure and asserts the error HTML shows `/src/Post.tsrx`, plus a **patch** changeset for `@octanejs/vite-plugin`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ba03d3ed26ce6c6c3ccb68ade5544ac37247b7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->