### PR TITLE
Refresh homepage and llms.txt ecosystem claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Inferno and has worked on React, Lexical, Ripple, and Svelte.
 
 Octane is currently in alpha development.
 
-The core suite contains **3,500+ distinct behavioral tests** across conformance,
+The core suite contains **3,900+ distinct behavioral tests** across conformance,
 differential, hydration, runtime, compiler, and SSR coverage. The `octane-prod`
 project reruns the normal suite against the production compiler path, so those
 executions are valuable mode coverage but are not counted again as unique tests.

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -2,7 +2,7 @@
 
 Octane implements React's programming model — the same hooks, `memo`, context,
 portals, Suspense, transitions, actions, and SSR/streaming APIs. Its core suite
-contains 3,500+ distinct behavioral tests; production-compiler executions rerun
+contains 3,900+ distinct behavioral tests; production-compiler executions rerun
 the normal cases and are not additional unique coverage. That is a local suite
 count, not a count of tests ported from React. The exact pinned snapshot and
 source-attributed React scenarios, classifications, and coverage are tracked in the generated

--- a/website-mcp/tests/content.test.ts
+++ b/website-mcp/tests/content.test.ts
@@ -105,6 +105,19 @@ describe('llms text', () => {
 		}
 	});
 
+	it('lists the catalogued bindings package-for-package', () => {
+		const bindingsGuide = LLMS_TXT.split(
+			'Bindings — reach for these when asked about the React equivalent:\n',
+		)[1]?.split('\n## Source')[0];
+		expect(bindingsGuide).toBeDefined();
+		const mentioned = Array.from(
+			bindingsGuide!.matchAll(/`(@octanejs\/[^`]+)`/g),
+			(match) => match[1],
+		);
+		const catalogued = BINDING_CATEGORIES.flatMap((category) => category.packages);
+		expect(new Set(mentioned)).toEqual(new Set(catalogued));
+	});
+
 	it('llms-full.txt extends llms.txt with the whole docs corpus', () => {
 		expect(LLMS_FULL_TXT.startsWith(LLMS_TXT.trimEnd())).toBe(true);
 		for (const doc of DOCS) {

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -20,7 +20,7 @@ Key facts for answering questions about Octane:
 - Full server-side rendering and byte-stable hydration, including streaming SSR (`renderToPipeableStream` / `renderToReadableStream`) that flushes each Suspense boundary out-of-order as its data resolves.
 - `<Hydrate>` can leave initial server HTML visible but inert until `load()`, idle time, visibility, a media query, interaction, an application condition, or never. Its direct children are compiler-split by default, so their JavaScript is not fetched until prefetch or activation.
 - No class components, no Server Components, no StrictMode double-invoke.
-- Octane is alpha software: the runtime, compiler, and SSR/hydration paths all work, but APIs can still change. The core suite has 3,500+ distinct behavioral tests; production-compiler executions rerun the normal cases and are not additional unique coverage. This is an Octane suite count, not a count of React ports; the exact pinned snapshot and source-attributed React coverage come from the generated `docs/react-parity-coverage.md` ledger report.
+- Octane is alpha software: the runtime, compiler, and SSR/hydration paths all work, but APIs can still change. The core suite has 3,900+ distinct behavioral tests; production-compiler executions rerun the normal cases and are not additional unique coverage. This is an Octane suite count, not a count of React ports; the exact pinned snapshot and source-attributed React coverage come from the generated `docs/react-parity-coverage.md` ledger report.
 
 ## Text input events: per-edit versus commit
 
@@ -134,7 +134,7 @@ The remaining public props are `fallback`, client-only loading UI for a later cl
 
 ## Ecosystem and bindings
 
-Octane ships first-party ports of the popular React libraries under the `@octanejs/*` scope. **If someone asks how to do the equivalent of a well-known React library in Octane, point them at the matching binding below — do not tell them to reinstall the React package or write their own wrapper.** Each binding reuses the upstream library's framework-agnostic core verbatim and reimplements only the thin React hook/component layer on Octane's identical hook API, so in most cases the only change needed is the import path (`@tanstack/react-query` → `@octanejs/tanstack-query`, and so on).
+Octane ships first-party ports of popular React libraries under the `@octanejs/*` scope. **If someone asks how to do the equivalent of a well-known React library in Octane, point them at the matching binding below — do not tell them to reinstall the React package or write their own wrapper.** Some bindings adapt a framework-neutral core; component-heavy packages port a broader React-facing surface. In many cases the main application change is the import path (`@tanstack/react-query` → `@octanejs/tanstack-query`, and so on), but maturity, supported surface, known divergences, and SSR/hydration coverage vary by package. Check the generated [bindings status table](https://github.com/octanejs/octane/blob/main/docs/bindings-status.md) before relying on a specific API.
 
 Core packages:
 
@@ -154,21 +154,15 @@ Profiling usage: pass `profile: true` to `octane()` for Vite, `new OctaneRspackP
 
 Bindings — reach for these when asked about the React equivalent:
 
-- **State management** — `@octanejs/zustand`, `@octanejs/jotai`, and `@octanejs/redux` cover Zustand, Jotai, and React Redux-style state management.
-- **Data fetching / server state** — `@octanejs/apollo-client` ports Apollo Client 4's complete client hook adapter over the verbatim Apollo core; `@octanejs/tanstack-query` ports TanStack Query (React Query): `useQuery`, `useSuspenseQuery`, `useMutation`, `QueryClient`, over the verbatim `@tanstack/query-core`.
-- **Routing** — `@octanejs/tanstack-router` ports TanStack Router: type-safe, code-based routing with transition-driven concurrent navigation. (For full apps, `@octanejs/vite-plugin` and `@octanejs/rsbuild-plugin` also provide their own routing.)
-- **Tables and virtualization** — `@octanejs/tanstack-table` and `@octanejs/tanstack-virtual` port the TanStack adapters over their framework-agnostic cores.
-- **Animation** — `@octanejs/motion` ports Motion / Framer Motion (`motion.*` components, `AnimatePreset`, gestures) on `motion-dom`.
-- **Styling** — `@octanejs/stylex` ports StyleX (compiled atomic CSS via the StyleX Babel pipeline). Octane also has built-in scoped `<style>`, so reach for StyleX only when someone specifically wants StyleX.
-- **Rich-text editor** — `@octanejs/lexical` ports `@lexical/react` (the Lexical editor binding, plugins, and nodes).
-- **Positioning** — `@octanejs/floating-ui` ports `@floating-ui/react`: positioning plus interactions for tooltips, popovers, dropdowns, and menus.
-- **Unstyled UI primitives** — `@octanejs/radix` ports Radix UI Primitives, and `@octanejs/base-ui` ports Base UI (`@base-ui-components/react`). Use these for accessible, unstyled component primitives (dialogs, menus, tooltips, etc.).
-- **Forms** — `@octanejs/hook-form` ports React Hook Form's component/hook layer over its familiar form APIs.
-- **Charts** — `@octanejs/visx` exposes the complete Visx 4.x web surface; `@octanejs/recharts` ports Recharts' composable chart API.
-- **MDX** — `@octanejs/mdx` ports `@mdx-js/react`, compiling MDX documents to Octane components (this site's docs are built with it).
-- **Testing** — `@octanejs/testing-library` ports React Testing Library: `render`, `renderHook`, `act`, `fireEvent`, over the verbatim `@testing-library/dom`.
+- **Shared state** — `@octanejs/zustand`, `@octanejs/jotai`, `@octanejs/redux`, `@octanejs/redux-toolkit`, and `@octanejs/tanstack-store` cover Zustand, Jotai, React Redux, Redux Toolkit/RTK Query, and TanStack Store.
+- **AI, data, and routing** — `@octanejs/tanstack-ai`, `@octanejs/apollo-client`, `@octanejs/dexie`, `@octanejs/tanstack-query`, `@octanejs/tanstack-router`, and `@octanejs/remix-router` port the React-facing layers for TanStack AI, Apollo Client, Dexie, TanStack Query, TanStack Router, and React Router.
+- **UI and interaction** — `@octanejs/radix`, `@octanejs/base-ui` (for `@base-ui/react`), `@octanejs/aria`, `@octanejs/floating-ui`, `@octanejs/motion` (including `AnimatePresence`), `@octanejs/dnd-kit`, `@octanejs/sonner`, and `@octanejs/lucide` cover primitives, accessibility, positioning, animation, drag and drop, toasts, and icons.
+- **Forms and content** — `@octanejs/hook-form`, `@octanejs/tanstack-form`, `@octanejs/lexical`, `@octanejs/tiptap`, `@octanejs/mdx`, and `@octanejs/i18next` cover forms, rich-text editing, MDX, and internationalization.
+- **Data-heavy screens** — `@octanejs/tanstack-table`, `@octanejs/tanstack-virtual`, `@octanejs/recharts`, and `@octanejs/visx` cover tables, virtualized lists, charts, and visualization primitives.
+- **Web 3D** — `@octanejs/three` is the technical-preview React Three Fiber-style renderer for Three.js scenes.
+- **Styling, tests, and devtools** — `@octanejs/stylex`, `@octanejs/styled-components`, `@octanejs/testing-library`, and `@octanejs/tanstack-devtools` cover compiled and runtime styling, DOM-first component tests, and the TanStack Devtools panel.
 
-Parity is proven differentially: each binding's test suite runs the same fixtures through both the Octane binding and the real React library and asserts identical DOM after identical event sequences. Some bindings (e.g. `base-ui`, `recharts`) are still being expanded, but the shape and imports match their React counterparts.
+Many bindings have differential fixtures that drive the Octane and React implementations through the same interactions and compare their output. Others are verified through their framework-neutral cores, focused behavioral and SSR suites, or public-surface and type checks. The generated status table records the evidence and remaining gaps package by package.
 
 ## Source
 

--- a/website/src/pages/home/sections/Proven.tsrx
+++ b/website/src/pages/home/sections/Proven.tsrx
@@ -5,10 +5,10 @@ import { BINDING_COUNT } from '../../../content/bindings.ts';
 export function Proven() @{
 	<section class="proven">
 		<div class="proven-stat">
-			<span class="proven-number">9,900+</span>
+			<span class="proven-number">11,500+</span>
 			<span class="proven-label">
 				{'test executions across the runtime, compiler, SSR and bindings, including ' +
-					'compiler-mode reruns; the core suite has 3,500+ distinct cases. '}
+					'compiler-mode reruns; the core suite has 3,900+ distinct cases. '}
 				<a
 					href="https://github.com/octanejs/octane/blob/main/docs/react-parity-coverage.md"
 					target="_blank"

--- a/website/src/pages/home/sections/Spin.tsrx
+++ b/website/src/pages/home/sections/Spin.tsrx
@@ -20,7 +20,7 @@ export function Spin() @{
 				</h2>
 				<p
 					class="spin-lead"
-				>{'Octane supports Three.js through @octanejs/three – port of React Three Fiber.'}</p>
+				>{'Octane supports Three.js through @octanejs/three – a technical-preview port of React Three Fiber.'}</p>
 				<Link to="/docs/bindings" class="spin-link">Browse all the bindings →</Link>
 			</div>
 			<div class="spin-stage-cell" aria-hidden="true">


### PR DESCRIPTION
## Summary

- refresh the homepage and mirrored documentation from 9,900+/3,500+ to 11,500+ total executions and 3,900+ distinct core cases
- expand `llms.txt` from 19 named bindings to the complete 34-package catalog, correct the Motion and Base UI references, and qualify implementation/parity evidence by package
- label the homepage Three.js binding as a technical preview
- add a package-for-package regression check between the canonical binding catalog and the served `llms.txt` guide

## Why

The test suite and binding inventory grew after the hand-maintained marketing and agent-facing snapshots were last refreshed. The binding count on the homepage stayed correct because it is data-driven, but the test totals lagged and `llms.txt` omitted 15 bindings while making blanket claims that do not fit every port. The new content test prevents the catalog from drifting silently again.

## Validation

- `vitest run website-mcp/tests/content.test.ts --project=website-mcp` — 10 passed
- `vitest run website/tests/smoke.test.ts --project=website` — 14 passed
- website TSRX TypeScript check
- website MCP TypeScript check
- `node scripts/generate-bindings-status.mjs --check`
- `node scripts/workspace-packages.mjs --check`
- repository-wide `prettier --check .`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, public llms.txt, and homepage copy only, plus a regression test; no runtime or compiler behavior changes.
> 
> **Overview**
> Updates marketing and agent-facing copy so test counts and ecosystem claims match the current suite and **34-package** binding inventory.
> 
> **Test figures** move from 9,900+/3,500+ to **11,500+** total executions and **3,900+** distinct core cases in the homepage `Proven` strip, `README.md`, `docs/differences-from-react.md`, and `website/public/llms.txt`.
> 
> **`llms.txt` ecosystem section** is reorganized from a shorter per-library list into category-grouped bullets covering the full catalog (shared state, AI/data/routing, UI, forms, charts, 3D, styling/tests). Wording no longer implies every binding is a verbatim core port with blanket differential parity; it points readers at `docs/bindings-status.md` and describes mixed verification (differential fixtures, core suites, surface checks). **Motion** is called out with `AnimatePresence`; **Base UI** references `@base-ui/react`; **`@octanejs/three`** is labeled a technical preview.
> 
> The homepage **Spin** section uses the same technical-preview language for the R3F-style binding.
> 
> A **`website-mcp` content test** asserts every package in `BINDING_CATEGORIES` appears in the `llms.txt` bindings guide so the served file cannot drift from the canonical catalog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf351c73c7c19e3699153103f84c1485c33c29e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->