### PR TITLE
Fix first post-hydration update remounting the passthrough-hydrated subtree

### DIFF
--- a/.changeset/sticky-return-slot-regime-after-passthrough-hydration.md
+++ b/.changeset/sticky-return-slot-regime-after-passthrough-hydration.md
@@ -1,0 +1,10 @@
+---
+'octane': patch
+---
+
+Keep a return slot mounted through the passthrough-hydration componentSlot
+route on that route while the returned component identity is unchanged. The
+first post-hydration re-render previously flipped the slot to the childSlot
+regime and disposed it, remounting the entire adopted subtree — visible in
+TanStack Start apps as the whole page tearing down (losing all component
+state) on the first router event after hydration.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -3427,9 +3427,21 @@ function renderReturnedValue(block: Block, out: unknown): void {
 		(out as any).$$kind === ELEMENT_TAG &&
 		(out as any).key == null &&
 		typeof (out as any).type === 'function';
+	const existingRet = block.slots[0] as any;
 	const useSingleRoot =
 		isComponentDescriptor &&
-		((out as any).type.$$singleRoot === true || activeHydration()?.passthroughRanges === true);
+		((out as any).type.$$singleRoot === true ||
+			activeHydration()?.passthroughRanges === true ||
+			// STICKY regime: a return slot mounted through the componentSlot route
+			// (most importantly by the passthrough-hydration branch above, whose
+			// condition is false again once hydration ends) keeps that route while
+			// the returned component identity is unchanged. Falling through to the
+			// childSlot route would dispose the slot for a mere kind flip — tearing
+			// down the very subtree hydration just adopted on its FIRST update. An
+			// identity change still disposes below (matching remount semantics).
+			(existingRet !== undefined &&
+				existingRet.__kind === 'componentSlotSlot' &&
+				existingRet.currentComp === (out as any).type));
 	// The private return slot holds EITHER a componentSlotSlot (singleRoot
 	// path) or a childSlot. A re-render can flip which applies: a body that
 	// returns `<SingleRootComp/>` one render and `null` / a portal / an array
@@ -3437,7 +3449,6 @@ function renderReturnedValue(block: Block, out: unknown): void {
 	// shapes are incompatible, so tear the old one down before the other path
 	// reads it as its own kind (else e.g. childSlot would touch a
 	// componentSlotSlot and crash).
-	const existingRet = block.slots[0] as any;
 	if (
 		existingRet !== undefined &&
 		existingRet.__kind !== (useSingleRoot ? 'componentSlotSlot' : 'childSlot')

--- a/packages/octane/tests/hydration/_fixtures/match-shape.tsrx
+++ b/packages/octane/tests/hydration/_fixtures/match-shape.tsrx
@@ -1,0 +1,222 @@
+// Mirrors the octane-router `Match` composition: a chain of DYNAMIC component
+// slots resolved in setup (Shell/Suspense/Catch/NotFound wrappers that are
+// either a real boundary or a SafeFragment passthrough), a context provider,
+// an `@try`-based catch boundary, and an `@if/@else` around the inner match
+// content — re-rendered by a `useSyncExternalStore` reset key. The hydrated
+// instance of this chain must survive its first post-hydration update without
+// remounting (state, effects, and DOM identity preserved).
+import {
+	HYDRATION_RANGE_BOUNDARY,
+	createContext,
+	createElement,
+	Suspense,
+	useLayoutEffect,
+	useState,
+	useSyncExternalStore,
+} from 'octane';
+import type { OctaneNode } from 'octane';
+
+export interface ResetStore {
+	subscribe: (cb: () => void) => () => void;
+	get: () => number;
+}
+
+const matchContext = createContext<string | undefined>(undefined);
+
+function SafeFragment(props: any) @{
+	<>
+		{props.children}
+	</>
+}
+
+function CatchBoundary(props: {
+	getResetKey: () => number;
+	children: OctaneNode;
+	onCatch?: (error: Error) => void;
+}) @{
+	@try {
+		<>
+			{props.children}
+		</>
+	} @catch (error: unknown) {
+		<div class="match-error">{String(error)}</div>
+	}
+}
+
+function CatchNotFound(props: {
+	fallback: (error: Error) => OctaneNode;
+	children: OctaneNode;
+}) @{
+	@try {
+		<>
+			{props.children}
+		</>
+	} @catch (error: unknown) {
+		<>
+			{props.fallback(error as Error)}
+		</>
+	}
+}
+
+function MatchInner(props: { log: string[] }) @{
+	const [count, setCount] = useState(0);
+	useLayoutEffect(() => {
+		props.log.push('mount:inner');
+		return () => props.log.push('unmount:inner');
+	}, []);
+	<button class="inner-button" onClick={() => setCount(count + 1)}>
+		{'inner:' + count}
+	</button>
+}
+
+export function MatchShape(props: {
+	store: ResetStore;
+	log: string[];
+	displayPending?: boolean;
+	withBoundaries?: boolean;
+}) @{
+	const resetKey = useSyncExternalStore(
+		(cb) => props.store.subscribe(cb),
+		() => props.store.get(),
+		() => props.store.get(),
+	);
+
+	// Boundary presence is decided in setup, exactly like Match resolves
+	// SuspenseWrap/CatchWrap/NotFoundWrap from route options.
+	const SuspenseWrap = props.withBoundaries ? Suspense : SafeFragment;
+	const CatchWrap = props.withBoundaries ? CatchBoundary : SafeFragment;
+	const NotFoundWrap = props.withBoundaries ? CatchNotFound : SafeFragment;
+	const ShellComponent = SafeFragment;
+
+	<ShellComponent>
+		<matchContext.Provider value="match-id">
+			<SuspenseWrap fallback={null}>
+				<CatchWrap getResetKey={() => resetKey} onCatch={() => undefined}>
+					<NotFoundWrap
+						fallback={(error: Error) => {
+							throw error;
+						}}
+					>
+						@if (props.displayPending) {
+							<p class="match-pending">pending</p>
+						} @else {
+							<MatchInner log={props.log} />
+						}
+					</NotFoundWrap>
+				</CatchWrap>
+			</SuspenseWrap>
+		</matchContext.Provider>
+	</ShellComponent>
+}
+
+// --- Start-shaped document shell -------------------------------------------
+// Mirrors @tanstack/octane-start hydration: the client tree above the document
+// body hydrates TRANSPARENTLY (the server shell markup lives outside the
+// hydration container), and the owner-stamped passthrough inside the body
+// adopts the first server range within `#__app`.
+
+function HydrationRangeOwner(props: { children?: unknown }) {
+	return props.children;
+}
+(HydrationRangeOwner as any)[HYDRATION_RANGE_BOUNDARY] = 'owner';
+
+function Html(props: { isServer?: boolean; children?: unknown }) {
+	const { children, isServer, ...attrs } = props as Record<string, unknown>;
+	if (isServer) return createElement('html', attrs, children);
+	return children;
+}
+
+function Body(props: { isServer?: boolean; children?: unknown }) {
+	const { children, isServer, ...attrs } = props as Record<string, unknown>;
+	if (isServer) {
+		return createElement(
+			'body',
+			attrs,
+			createElement('div', { id: '__app' }, createElement(HydrationRangeOwner, {}, children)),
+		);
+	}
+	return createElement(HydrationRangeOwner, {}, children);
+}
+
+function RootShell(props: { isServer?: boolean; children?: unknown }) @{
+	<Html isServer={props.isServer}>
+		<Body isServer={props.isServer}>{props.children}</Body>
+	</Html>
+}
+
+interface StartShapeProps {
+	store: ResetStore;
+	log: string[];
+	isServer?: boolean;
+	displayPending?: boolean;
+	withBoundaries?: boolean;
+}
+
+// The Match analog: shell + provider + boundary chain around the inner
+// content, re-rendered by the loadedAt-style reset key.
+function StartMatch(props: StartShapeProps) @{
+	const resetKey = useSyncExternalStore(
+		(cb) => props.store.subscribe(cb),
+		() => props.store.get(),
+		() => props.store.get(),
+	);
+
+	const SuspenseWrap = props.withBoundaries ? Suspense : SafeFragment;
+	const CatchWrap = props.withBoundaries ? CatchBoundary : SafeFragment;
+	const NotFoundWrap = CatchNotFound;
+	const ShellComponent = RootShell;
+
+	<ShellComponent isServer={props.isServer}>
+		<matchContext.Provider value="match-id">
+			<SuspenseWrap fallback={null}>
+				<CatchWrap getResetKey={() => resetKey} onCatch={() => undefined}>
+					<NotFoundWrap
+						fallback={(error: Error) => {
+							throw error;
+						}}
+					>
+						@if (props.displayPending) {
+							<p class="match-pending">pending</p>
+						} @else {
+							<MatchInner log={props.log} />
+						}
+					</NotFoundWrap>
+				</CatchWrap>
+			</SuspenseWrap>
+		</matchContext.Provider>
+	</ShellComponent>
+}
+
+// MatchesInner analog: subscribes to the same reset key, wraps the match in
+// the always-present global catch boundary.
+function StartMatchesInner(props: StartShapeProps) @{
+	const resetKey = useSyncExternalStore(
+		(cb) => props.store.subscribe(cb),
+		() => props.store.get(),
+		() => props.store.get(),
+	);
+	const CatchWrap = CatchBoundary;
+
+	<matchContext.Provider value="root-match-id">
+		<CatchWrap getResetKey={() => resetKey} onCatch={() => undefined}>
+			@if (true) {
+				<StartMatch {...props} />
+			}
+		</CatchWrap>
+	</matchContext.Provider>
+}
+
+// Matches analog: InnerWrap passthrough + the always-present root Suspense.
+function StartMatches(props: StartShapeProps) @{
+	const InnerWrap = SafeFragment;
+	<InnerWrap>
+		<Suspense fallback={null}>
+			<StartMatchesInner {...props} />
+		</Suspense>
+	</InnerWrap>
+}
+
+export function StartShape(props: StartShapeProps) @{
+	<StartMatches {...props} />
+}
+(StartShape as any)[HYDRATION_RANGE_BOUNDARY] = 'passthrough';

--- a/packages/octane/tests/hydration/post-hydration-update.test.ts
+++ b/packages/octane/tests/hydration/post-hydration-update.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { compile } from 'octane/compiler';
+import { hydrateRoot, flushSync } from '../../src/index.js';
+import * as ServerRT from 'octane/server';
+import { MatchShape, StartShape } from './_fixtures/match-shape.tsrx';
+import type { ResetStore } from './_fixtures/match-shape.tsrx';
+
+// A router-Match-shaped tree (dynamic wrapper slots chosen in setup, a context
+// provider, an @try catch boundary, and an @if/@else around the content) must
+// survive its FIRST post-hydration re-render without remounting the subtree:
+// no effect cleanup fires, component state survives, and the server-rendered
+// DOM nodes keep their identity.
+
+const FIXTURE = join(process.cwd(), 'packages/octane/tests/hydration/_fixtures/match-shape.tsrx');
+
+function serverModule(): Record<string, any> {
+	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'match-shape.tsrx', { mode: 'server' });
+	code = code.replace(
+		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
+	);
+	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
+	return new Function('__rt', '__exports', code + '\nreturn __exports;')(ServerRT, {});
+}
+const server = serverModule();
+
+function createResetStore(): ResetStore & { set: (v: number) => void } {
+	let value = 0;
+	const listeners = new Set<() => void>();
+	return {
+		subscribe(cb: () => void) {
+			listeners.add(cb);
+			return () => listeners.delete(cb);
+		},
+		get: () => value,
+		set(v: number) {
+			value = v;
+			for (const cb of [...listeners]) cb();
+		},
+	};
+}
+
+let container: HTMLElement;
+beforeEach(() => {
+	container = document.createElement('div');
+	document.body.appendChild(container);
+});
+afterEach(() => container.remove());
+
+describe('hydrateRoot — first update after hydration', () => {
+	for (const withBoundaries of [false, true]) {
+		const label = withBoundaries ? 'real boundaries' : 'SafeFragment passthroughs';
+		it(`does not remount the wrapper chain (${label})`, () => {
+			const store = createResetStore();
+			const log: string[] = [];
+			const props = { store, log, withBoundaries };
+			container.innerHTML = ServerRT.renderToString(server.MatchShape, {
+				...props,
+				log: [],
+			}).html;
+			const serverButton = container.querySelector('.inner-button') as HTMLButtonElement;
+			expect(serverButton).toBeTruthy();
+
+			const root = hydrateRoot(container, MatchShape, props);
+			flushSync(() => {});
+			expect(log).toEqual(['mount:inner']);
+			expect(container.querySelector('.inner-button')).toBe(serverButton);
+
+			// Interactive state proves the hydrated instance is live.
+			flushSync(() => serverButton.click());
+			expect(serverButton.textContent).toBe('inner:1');
+
+			// The first reset-key change re-renders the chain; nothing may remount.
+			flushSync(() => store.set(1));
+			expect(log).toEqual(['mount:inner']);
+			expect(container.querySelector('.inner-button')).toBe(serverButton);
+			expect(serverButton.textContent).toBe('inner:1');
+
+			// And again — later updates must stay stable too.
+			flushSync(() => store.set(2));
+			expect(log).toEqual(['mount:inner']);
+			expect(container.querySelector('.inner-button')).toBe(serverButton);
+			root.unmount();
+		});
+	}
+
+	for (const withBoundaries of [false, true]) {
+		const label = withBoundaries ? 'real boundaries' : 'SafeFragment passthroughs';
+		it(`does not remount the chain under a document-shell range owner (${label})`, () => {
+			const store = createResetStore();
+			const log: string[] = [];
+			const props = { store, log, withBoundaries };
+			// The server renders the whole document; the hydration container only
+			// holds what the shell put inside `#__app` (the owner's range).
+			const { html } = ServerRT.renderToString(server.StartShape, {
+				...props,
+				log: [],
+				isServer: true,
+			});
+			const open = html.indexOf('<div id="__app">');
+			const close = html.lastIndexOf('</div>');
+			expect(open).toBeGreaterThanOrEqual(0);
+			expect(close).toBeGreaterThan(open);
+			container.innerHTML = html.slice(open + '<div id="__app">'.length, close);
+			const serverButton = container.querySelector('.inner-button') as HTMLButtonElement;
+			expect(serverButton).toBeTruthy();
+
+			const root = hydrateRoot(container, StartShape, props);
+			flushSync(() => {});
+			expect(log).toEqual(['mount:inner']);
+			expect(container.querySelector('.inner-button')).toBe(serverButton);
+
+			flushSync(() => serverButton.click());
+			expect(serverButton.textContent).toBe('inner:1');
+
+			// First loadedAt-style change after hydration — nothing may remount.
+			flushSync(() => store.set(1));
+			expect(log).toEqual(['mount:inner']);
+			expect(container.querySelector('.inner-button')).toBe(serverButton);
+			expect(serverButton.textContent).toBe('inner:1');
+
+			flushSync(() => store.set(2));
+			expect(log).toEqual(['mount:inner']);
+			expect(container.querySelector('.inner-button')).toBe(serverButton);
+			root.unmount();
+		});
+	}
+});

--- a/website/tests/ssr-hydration.e2e.test.ts
+++ b/website/tests/ssr-hydration.e2e.test.ts
@@ -543,6 +543,46 @@ describe.sequential('website dev-SSR → hydration (real browser)', () => {
 		}
 	}, 30_000);
 
+	it('the first router event after hydration does not remount the app', async () => {
+		const { page, errors } = await loadRoute(`http://localhost:${DEV_PORT}`, '/', {
+			waitForNetworkIdle: true,
+		});
+		try {
+			// Let hydrateStart's post-networkidle tail (router match commit +
+			// hydrateRoot) finish before firing the event.
+			await page.waitForTimeout(500);
+			// A hash replaceState is the smallest router event: it reloads and bumps
+			// the router's loadedAt without changing matches. The hydrated tree must
+			// update in place — a remount would replace every DOM node (and lose all
+			// component state) on the first interaction after page load.
+			const survived = await page.evaluate(async () => {
+				const router = (window as any).__TSR_ROUTER__;
+				const before = router.stores.loadedAt.get() as number;
+				const header = document.querySelector('header');
+				const main = document.querySelector('main');
+				history.replaceState(history.state, '', '#post-hydration');
+				// Positive control: the router must actually process the event —
+				// without this the assertion could pass vacuously (event fired
+				// before the router subscribed to history).
+				const deadline = Date.now() + 5000;
+				while (router.stores.loadedAt.get() === before && Date.now() < deadline) {
+					await new Promise((resolve) => setTimeout(resolve, 25));
+				}
+				await new Promise((resolve) => setTimeout(resolve, 100));
+				return {
+					processed: router.stores.loadedAt.get() !== before,
+					header: document.querySelector('header') === header,
+					main: document.querySelector('main') === main,
+				};
+			});
+			expect(survived).toEqual({ processed: true, header: true, main: true });
+			const real = errors.filter((e) => !e.includes('Failed to load resource'));
+			expect(real).toEqual([]);
+		} finally {
+			await page.close();
+		}
+	}, 30_000);
+
 	// Editing a route and the router invalidates both the client and SSR module
 	// graphs. A full reload on that hot server must still hydrate through one
 	// current router graph. Keep this last: Vite's cache-busting timestamps stay


### PR DESCRIPTION
## Problem

The FIRST router event after SSR hydration (a hash `replaceState`, `router.navigate`, or `router.load()`) remounted the entire route tree in TanStack Start apps — every component under `#__app` unmounted and remounted, losing all state. Subsequent events behaved correctly.

## Root cause

`renderReturnedValue`'s slot-regime choice was unstable across hydration:

- During **passthrough hydration** (the Start document-shell model — `StartClient` stamped `HYDRATION_RANGE_BOUNDARY: 'passthrough'`, `Body`'s `HydrationRangeOwner` stamped `'owner'`), any component-descriptor return routes through the **componentSlot** regime, so `block.slots[0]` is a `componentSlotSlot`. That's how `Body`'s `createElement(HydrationRangeOwner, {}, children)` — the slot owning everything inside `#__app` — mounts.
- On the first post-hydration re-render of `Body`, `activeHydration()` is null and `HydrationRangeOwner` has no `$$singleRoot` stamp, so the same return now classifies as the **childSlot** regime. The kind mismatch hit `disposeReturnSlot`, tearing down the whole adopted subtree and rebuilding it. Every later render is childSlot→childSlot — hence first-event-only.

## Fix

The return-slot regime is **sticky** while the returned component identity is unchanged: a slot mounted through the componentSlot route stays on it instead of being disposed for a mere kind re-classification. Identity changes and genuine shape flips (different component, null, array, portal, text) still dispose, preserving remount semantics. One extra short-circuited comparison on a cold path; no new state.

## Tests

- `packages/octane/tests/hydration/post-hydration-update.test.ts` + `_fixtures/match-shape.tsrx`: a router-Match-shaped wrapper chain and a Start-shaped document-shell scenario (passthrough root → transparent layers → `Html`/`Body` shell → range owner → provider/boundary chain), driven by a `useSyncExternalStore` reset key. Pre-fix, the Start-shaped scenario failed with `['mount:inner', 'unmount:inner', 'mount:inner']` and lost DOM identity in both the dev and prod compile projects.
- `website/tests/ssr-hydration.e2e.test.ts`: new real-browser test — after hydration, fire `history.replaceState(history.state, '', '#…')`, require the router to actually process it (`loadedAt` bump via `window.__TSR_ROUTER__` as a positive control against a vacuous pass), and assert `header`/`main` DOM identity survives. Verified failing with the fix reverted.

## Validation

- `pnpm test`: 1212 files / 11623 tests green (clean run on the final tree)
- `pnpm typecheck`, `pnpm format:check`: clean
- Changeset: `octane` patch

Residual note: a pre-existing edge remains where a *transparent* return slot whose value flips shape post-hydration disposes without a whole-container sweep; this change narrows exposure (same-identity no longer disposes) but doesn't audit that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `renderReturnedValue` slot-regime logic on the hydration boundary; the fix is narrow (same-component identity only) and heavily tested, but incorrect stickiness could affect remount semantics for return-slot shape changes.
> 
> **Overview**
> Fixes a **first post-hydration update** bug where TanStack Start (and similar passthrough-hydration shells) **remounted the entire `#__app` subtree** on the first router-driven re-render, wiping component state and replacing DOM nodes.
> 
> In `renderReturnedValue`, passthrough hydration used the **componentSlot** path for descriptor returns; once hydration ended, the same return was reclassified as **childSlot**, triggering slot disposal and a full subtree teardown. The change adds a **sticky** rule: an existing `componentSlotSlot` whose `currentComp` still matches the returned component type keeps the componentSlot route instead of flipping regimes.
> 
> Adds **hydration unit tests** (Match-shaped wrapper chain + Start-shaped document shell) and a **website e2e** that fires `history.replaceState` after load and asserts `header`/`main` DOM identity plus router `loadedAt` processing. Ships an **octane** patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53c671bd8895bdc0a5eae2c9788ac7c8ef32df55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->