### PR TITLE
Fix SSR livelock for promises created in an ancestor and passed down via props

### DIFF
--- a/.changeset/plenty-pandas-punch.md
+++ b/.changeset/plenty-pandas-punch.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Fix the streaming/buffered SSR livelock for promises created in an ancestor render and passed down through props to descendant `use()` sites (the React "uncached promise" shape). The server compiler now caches inline creations in component-prop position across suspense passes (`<Kid p={make(x)}/>`), warm plans share that same creation instead of racing a second one, and a runtime livelock guard detects non-analyzable recreation shapes and degrades to per-site replay instead of burning 50 render passes and serving only `@pending` fallbacks. The max-pass SSR errors now hint at the recreated-promise cause.

--- a/docs/suspense-parallel-use-plan.md
+++ b/docs/suspense-parallel-use-plan.md
@@ -135,6 +135,39 @@ What shipped, and where it deviates from the phases as written:
   true-dependency strata or siblings from refetching prior work. Client, SSR,
   production, and universal-renderer regressions pin distinct and repeated
   same-dependency siblings plus exactly-once creation.
+- **Prop-flow creations + uncached-recreation guard LANDED 2026-07-20.** The
+  React-trained "uncached promise" shape — per-request promises created in an
+  ancestor's render and passed down through props to descendant `use()` sites —
+  livelocked streaming SSR: every wave re-pass re-ran the ancestor, the fresh
+  instances could never resolve by identity (`resolvedT`), and `puBatch` threw
+  before the unwraps could record their stable string keys, so the render
+  burned MAX_SUSPENSE_PASSES and served only @pending fallbacks (on CPU-metered
+  hosts this presented as ~50 full render passes of billed CPU per request).
+  Two-layer fix:
+  - Server Pass A now also memoizes INLINE creations in component-prop
+    position (`<Kid p={make(x)}/>` → `p: _$puMemo(() => make(x), deps, slot)`),
+    deps-keyed like a use()-site memo. Inline-only by design: the value has no
+    other binding, so cross-pass caching cannot observe an escape or a
+    mutation. Warm plans print the SAME slot through the now value-returning
+    `warmMemo`, so the warm walk claims the render's creation (and vice versa)
+    instead of racing a second one — creation runs exactly once per request.
+    Hook-shaped calls and JSX-bearing expressions are excluded; @for/@switch
+    arms remain excluded (v1 rule).
+  - Shapes the compiler cannot see (locals flowing into props, spreads,
+    foreign bodies) hit a runtime livelock guard (`observeSuspenseWave`, wired
+    into the streaming wave, pre-shell root, and buffered loops — all off the
+    hot path): two consecutive no-progress cycles whose settled wave was
+    entirely batch-registered and whose next pass registers only fresh
+    identities — while `pu.created` didn't grow and no plain string key
+    recorded — cannot be a legitimate waterfall level, so batching is disabled
+    for the rest of the request. `puBatch` then keeps its status probes but
+    stops registering/suspending; the first unresolved `use()` suspends under
+    its stable frame-scoped string key and key replay completes the render
+    (degraded but correct — matching what un-batched `use()` always did for
+    per-pass creations). A dev-only console.error names the pattern; the
+    MAX-pass errors (retired 33/37 → 47/48) now hint at the cause. Pinned in
+    `tests/ssr-prop-flow-promises.test.ts` (streaming + prerender + bare-root,
+    exactly-once creation for the memoized shape).
 - **Decision points resolved:** (1) unconditional, with no serial-timing mode;
   (2) loops excluded — mandatory (Phase 0); (3) member-path deps; (4)
   AbortSignal not shipped; (5)

--- a/packages/octane/error-codes/codes.json
+++ b/packages/octane/error-codes/codes.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "nextCode": 47,
+  "nextCode": 49,
   "codes": {
     "1": {
       "message": "Maximum update depth exceeded. Octane limits the number of nested updates to prevent infinite loops.",
@@ -198,7 +198,7 @@
       "message": "octane SSR: exceeded %s suspense passes — a use(thenable) never resolved.",
       "argumentCount": 1,
       "runtime": ["server"],
-      "status": "active"
+      "status": "retired"
     },
     "34": {
       "message": "octane SSR: a root suspension no longer has resumable work.",
@@ -222,7 +222,7 @@
       "message": "octane SSR: %s consecutive streaming passes completed no boundary — a use(thenable) never resolved.",
       "argumentCount": 1,
       "runtime": ["server"],
-      "status": "active"
+      "status": "retired"
     },
     "38": {
       "message": "The stream destination closed.",
@@ -276,6 +276,18 @@
       "message": "Expected %s listener to be a function, instead got a value of `%s` type.",
       "argumentCount": 2,
       "runtime": ["client"],
+      "status": "active"
+    },
+    "47": {
+      "message": "octane SSR: exceeded %s suspense passes — a use(thenable) never resolved. If promises are re-created on every render pass (e.g. created in an ancestor render and passed down through props), create them at their use() site or hoist them out of render.",
+      "argumentCount": 1,
+      "runtime": ["server"],
+      "status": "active"
+    },
+    "48": {
+      "message": "octane SSR: %s consecutive streaming passes completed no boundary — a use(thenable) never resolved. If promises are re-created on every render pass (e.g. created in an ancestor render and passed down through props), create them at their use() site or hoist them out of render.",
+      "argumentCount": 1,
+      "runtime": ["server"],
       "status": "active"
     }
   }

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -8153,6 +8153,58 @@ function isTrivialUseArg(n) {
 	return false;
 }
 
+// Server prop-flow eligibility: an inline component-prop expression whose
+// evaluation CREATES values per pass — a call or `new` reached during render
+// (nested function bodies don't run at render time and are skipped). Two
+// blockers: JSX (lowered later; wrapping the raw node would smuggle it past
+// the lowering passes) and hook-shaped calls (`use` / `use[A-Z]…` / a tracked
+// `use` import alias — their slot/occurrence bookkeeping must execute on the
+// body proper every pass, so they can never sit behind a cache hit).
+function isPropCreationExpr(expr, ctx) {
+	let found = false;
+	let blocked = false;
+	walk(expr);
+	return found && !blocked;
+
+	function isHookishCallee(callee) {
+		if (callee.type === 'Identifier') {
+			return (
+				/^use($|[A-Z])/.test(callee.name) || ctx?._parallelUseAliases?.has(callee.name) === true
+			);
+		}
+		if (callee.type === 'MemberExpression' && !callee.computed) {
+			return callee.property.type === 'Identifier' && /^use($|[A-Z])/.test(callee.property.name);
+		}
+		return false;
+	}
+
+	function walk(n) {
+		if (blocked || !n || typeof n !== 'object') return;
+		if (Array.isArray(n)) {
+			for (const x of n) walk(x);
+			return;
+		}
+		if (typeof n.type === 'string') {
+			if (n.type.startsWith('JSX')) {
+				blocked = true;
+				return;
+			}
+			if (FN_TYPES.has(n.type)) return; // does not run during render
+			if (n.type === 'CallExpression' || n.type === 'NewExpression') {
+				if (n.type === 'CallExpression' && isHookishCallee(n.callee)) {
+					blocked = true;
+					return;
+				}
+				found = true;
+			}
+		}
+		for (const k in n) {
+			if (k === 'loc' || k === 'start' || k === 'end' || k === 'metadata') continue;
+			walk(n[k]);
+		}
+	}
+}
+
 const LOOP_TYPES = new Set([
 	'ForStatement',
 	'ForOfStatement',
@@ -8284,6 +8336,13 @@ function parallelUseWalkJsx(nodes, ctx, componentName, creations, warmChildren, 
 				const isComponent =
 					nameNode && nameNode.type === 'JSXIdentifier' && /^[A-Z]/.test(nameNode.name);
 				if (isComponent) {
+					// Server: creations flowing INTO child props (`<Kid p={make(x)}/>`)
+					// need the same cross-pass identity as use()-site creations — every
+					// streaming wave re-runs this body, and a recreated per-request
+					// promise can never resolve at the descendant's unwrap (identity-
+					// keyed via puBatch). Inline attribute position only: the value has
+					// no other binding, so caching it cannot observe an escape.
+					if (ctx.mode === 'server') node = memoizePropCreations(node);
 					collectWarmChild(node, nameNode.name);
 					return node; // component children render inside the child — don't descend
 				}
@@ -8376,6 +8435,68 @@ function parallelUseWalkJsx(nodes, ctx, componentName, creations, warmChildren, 
 		return { ...arm, body };
 	}
 
+	// Server Pass A over component ATTRIBUTES: wrap each inline creation
+	// expression in the cross-pass creation cache (`_$puMemo`) so the value —
+	// and any per-request thenables inside it — keeps its identity between
+	// streaming/buffered passes. Deps-keyed exactly like a use()-site memo; a
+	// dependency drift is a clean recreation. The original expression is kept
+	// on the attribute for the warm printer (collectWarmChild below), which
+	// prints the SAME slot through warmMemo so the warm walk and the render
+	// path share one creation instead of racing two.
+	function memoizePropCreations(node) {
+		const attrs = node.openingElement.attributes || [];
+		let changed = false;
+		const nextAttrs = attrs.map((a) => {
+			if (a.type !== 'JSXAttribute' || a.name.type !== 'JSXIdentifier') return a;
+			const key = a.name.name;
+			if (key === 'ref' || key === 'key') return a; // instance-wired — never cached
+			if (!a.value || a.value.type !== 'JSXExpressionContainer') return a;
+			const expr = unwrapTsExpr(a.value.expression);
+			if (!isPropCreationExpr(expr, ctx)) return a;
+			const symVar = allocHookSymbol(
+				ctx,
+				`${componentName}.prop.memo#${ctx.nextHookSymId}`,
+				{
+					componentName,
+					name: 'prop memo',
+					kind: 'useMemo',
+					node: expr,
+				},
+				// Same reservation rule as use() memos: warm caches span component
+				// scopes, so every warmable creation site gets a composable Symbol.
+				true,
+			);
+			const deps = collectDepPaths(expr);
+			const memoAlias = requireRuntimeForContext(ctx, 'puMemo');
+			changed = true;
+			return {
+				...a,
+				value: {
+					type: 'JSXExpressionContainer',
+					expression: {
+						type: 'CallExpression',
+						callee: { type: 'Identifier', name: memoAlias },
+						arguments: [
+							{
+								type: 'ArrowFunctionExpression',
+								params: [],
+								expression: true,
+								async: false,
+								body: expr,
+							},
+							{ type: 'ArrayExpression', elements: deps },
+							{ type: 'Identifier', name: symVar },
+						],
+						optional: false,
+					},
+				},
+				_octanePropMemo: { expr, deps, symVar },
+			};
+		});
+		if (!changed) return node;
+		return { ...node, openingElement: { ...node.openingElement, attributes: nextAttrs } };
+	}
+
 	function collectWarmChild(node, compName) {
 		const attrs = node.openingElement.attributes || [];
 		if ((node.children || []).length > 0) return; // children render inside the child — skip
@@ -8388,7 +8509,7 @@ function parallelUseWalkJsx(nodes, ctx, componentName, creations, warmChildren, 
 			if (a.value == null) value = { type: 'Literal', value: true, raw: 'true' };
 			else if (a.value.type === 'JSXExpressionContainer') value = a.value.expression;
 			else value = a.value; // Literal
-			props.push({ key, value });
+			props.push({ key, value, memo: a._octanePropMemo });
 		}
 		warmChildren.push({ compName, props, guards: [...guards], locals });
 	}
@@ -8655,7 +8776,11 @@ function buildWarmArtifacts(node, ctx, componentName, creations, warmChildren) {
 			!paramNames.has(w.compName) &&
 			!(locals && locals.has(w.compName)) &&
 			!(w.locals && w.locals.has(w.compName)) &&
-			w.props.every((p) => isWarmSafeExpr(p.value, paramNames, locals, w.locals)),
+			// A memoized prop is judged by its ORIGINAL creation expression — the
+			// puMemo wrapper only adds compiler-owned module-scope names.
+			w.props.every((p) =>
+				isWarmSafeExpr(p.memo ? p.memo.expr : p.value, paramNames, locals, w.locals),
+			),
 	);
 	if (warmKids.length === 0 && warmMemos.length === 0) return { thunk: null, warmSrc: null };
 	// A component whose only warm edge is recursion back to itself and which has
@@ -8688,6 +8813,29 @@ function buildWarmArtifacts(node, ctx, componentName, creations, warmChildren) {
 		],
 		optional: false,
 	});
+	// A memoized prop prints through the value-returning warmMemo form: at warm
+	// time it CLAIMS the render pass's creation for the same slot (or creates
+	// once, adoptable by the render's puMemo) instead of re-evaluating the raw
+	// expression — the warm walk and the render path share one creation.
+	const warmPropValue = (p) =>
+		p.memo
+			? {
+					type: 'CallExpression',
+					callee: { type: 'Identifier', name: warmMemoAlias },
+					arguments: [
+						{
+							type: 'ArrowFunctionExpression',
+							params: [],
+							expression: true,
+							async: false,
+							body: p.memo.expr,
+						},
+						{ type: 'ArrayExpression', elements: p.memo.deps },
+						{ type: 'Identifier', name: p.memo.symVar },
+					],
+					optional: false,
+				}
+			: p.value;
 	const childCall = (w) => ({
 		type: 'CallExpression',
 		callee: { type: 'Identifier', name: warmChildAlias },
@@ -8698,7 +8846,7 @@ function buildWarmArtifacts(node, ctx, componentName, creations, warmChildren) {
 				properties: w.props.map((p) => ({
 					type: 'Property',
 					key: { type: 'Identifier', name: p.key },
-					value: p.value,
+					value: warmPropValue(p),
 					kind: 'init',
 					method: false,
 					shorthand: false,
@@ -8709,7 +8857,8 @@ function buildWarmArtifacts(node, ctx, componentName, creations, warmChildren) {
 		optional: false,
 	});
 
-	if (warmMemos.length > 0) requireRuntimeForContext(ctx, 'warmMemo');
+	if (warmMemos.length > 0 || warmKids.some((w) => w.props.some((p) => p.memo)))
+		requireRuntimeForContext(ctx, 'warmMemo');
 	if (warmKids.length > 0) requireRuntimeForContext(ctx, 'warmChild');
 
 	// In-body warm thunk: children only — the body's own creations already ran

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -8453,19 +8453,17 @@ function parallelUseWalkJsx(nodes, ctx, componentName, creations, warmChildren, 
 			if (!a.value || a.value.type !== 'JSXExpressionContainer') return a;
 			const expr = unwrapTsExpr(a.value.expression);
 			if (!isPropCreationExpr(expr, ctx)) return a;
-			const symVar = allocHookSymbol(
-				ctx,
-				`${componentName}.prop.memo#${ctx.nextHookSymId}`,
-				{
-					componentName,
-					name: 'prop memo',
-					kind: 'useMemo',
-					node: expr,
-				},
-				// Same reservation rule as use() memos: warm caches span component
-				// scopes, so every warmable creation site gets a composable Symbol.
-				true,
-			);
+			// Tail-allocated (see allocTailHookSymbol): this slot exists only in
+			// the server compile, and taking an inline id here would shift every
+			// later shared site's id relative to the client compile. Composable
+			// Symbol for the same reason as use() memos: warm caches span
+			// component scopes.
+			const symVar = allocTailHookSymbol(ctx, `${componentName}.prop.memo`, {
+				componentName,
+				name: 'prop memo',
+				kind: 'useMemo',
+				node: expr,
+			});
 			const deps = collectDepPaths(expr);
 			const memoAlias = requireRuntimeForContext(ctx, 'puMemo');
 			changed = true;
@@ -10436,6 +10434,7 @@ function ensureHookSlotBase(ctx) {
 }
 
 function joinHoistedHelpers(ctx) {
+	flushTailHookSymbols(ctx);
 	return ctx.hoistedHelpers
 		.map((helper) => {
 			if (helper === HOOK_SLOT_BASE_HELPER) {
@@ -10449,9 +10448,35 @@ function joinHoistedHelpers(ctx) {
 		.join('\n');
 }
 
-function allocHookSymbol(ctx, debugName, profile = null, forceSymbol = false) {
+// Server-only slots (prop memos) must not perturb the shared hook-symbol
+// sequence: the client compile never allocates them, and the two compiles of
+// one module should agree on every shared site's id. Nothing crosses the
+// SSR/client boundary by slot id (hydration seeds are consumed by positional
+// cursor), so this is a symmetry invariant, not a wire contract — but it keeps
+// numeric hook slots, HMR stable keys, and profile indices identical across
+// modes for every site that exists in both. The NAME is allocated eagerly (the
+// rewritten AST needs it); the id is assigned at module finalize
+// (joinHoistedHelpers), after every shared site has claimed its id, so
+// server-only slots take the tail of the module's range.
+function allocTailHookSymbol(ctx, debugName, profile = null) {
+	const pending = (ctx._pendingTailHookSlots ??= []);
+	const name = allocCompilerName(ctx, `_pm$${pending.length}`);
+	pending.push({ name, debugName, profile });
+	return name;
+}
+
+function flushTailHookSymbols(ctx) {
+	const pending = ctx._pendingTailHookSlots;
+	if (pending === undefined) return;
+	ctx._pendingTailHookSlots = undefined;
+	for (const p of pending) {
+		allocHookSymbol(ctx, `${p.debugName}#${ctx.nextHookSymId}`, p.profile, true, p.name);
+	}
+}
+
+function allocHookSymbol(ctx, debugName, profile = null, forceSymbol = false, presetName = null) {
 	const id = ctx.nextHookSymId++;
-	const name = allocCompilerName(ctx, `_h$${id}`);
+	const name = presetName ?? allocCompilerName(ctx, `_h$${id}`);
 	let symbolExpr;
 	if (ctx.hmr) {
 		// HMR (dev serve): Symbol.for(stableKey) so re-imports produce the SAME

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -5126,6 +5126,11 @@ export function compile(source, filename, options) {
 		})
 		.join('\n');
 	const templatesBlock = templates ? templates + '\n\n' : '';
+	// No tail slots exist on the client today (prop memos are server-only), but
+	// flush before assembly so a future client-side tail site cannot trip the
+	// joinHoistedHelpers assertion — imports are built after this join, so the
+	// timing is safe here.
+	flushTailHookSymbols(ctx);
 	const helpers = joinHoistedHelpers(ctx);
 	const helpersBlock = helpers ? helpers + '\n\n' : '';
 
@@ -5424,6 +5429,9 @@ function compileServer(source, filename, options, styleRemap = null) {
 		}
 	}
 
+	// Assign deferred (server-only) slot ids BEFORE the import list is built:
+	// the flush may register `hookSlots` as a needed runtime import.
+	flushTailHookSymbols(ctx);
 	const runtimeImport = buildRuntimeImport(ctx, 'octane/server');
 	const joinedHelpers = joinHoistedHelpers(ctx);
 	const helpers = joinedHelpers ? joinedHelpers + '\n\n' : '';
@@ -10434,7 +10442,15 @@ function ensureHookSlotBase(ctx) {
 }
 
 function joinHoistedHelpers(ctx) {
-	flushTailHookSymbols(ctx);
+	if (ctx._pendingTailHookSlots !== undefined) {
+		// Flushing here would be too late for the server pipeline: its runtime
+		// import list is built BEFORE the helpers join, and a flush-time
+		// ensureHookSlotBase would register `hookSlots` after the imports were
+		// printed — the emitted module then references _$hookSlots without
+		// importing it (broke every prod module whose only slot sites were prop
+		// memos). Each pipeline flushes explicitly before assembling imports.
+		throw new Error('octane compiler: tail hook slots were not flushed before module assembly.');
+	}
 	return ctx.hoistedHelpers
 		.map((helper) => {
 			if (helper === HOOK_SLOT_BASE_HELPER) {

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -8180,7 +8180,10 @@ function isPropCreationExpr(expr, ctx) {
 				/^use($|[A-Z])/.test(callee.name) || ctx?._parallelUseAliases?.has(callee.name) === true
 			);
 		}
-		if (callee.type === 'MemberExpression' && !callee.computed) {
+		if (
+			(callee.type === 'MemberExpression' || callee.type === 'OptionalMemberExpression') &&
+			!callee.computed
+		) {
 			return callee.property.type === 'Identifier' && /^use($|[A-Z])/.test(callee.property.name);
 		}
 		return false;
@@ -8198,8 +8201,20 @@ function isPropCreationExpr(expr, ctx) {
 				return;
 			}
 			if (FN_TYPES.has(n.type)) return; // does not run during render
-			if (n.type === 'CallExpression' || n.type === 'NewExpression') {
-				if (n.type === 'CallExpression' && isHookishCallee(n.callee)) {
+			// Same render-time-call inventory as containsRenderCall: plain and
+			// optional calls, constructions, tagged templates, and dynamic
+			// import() (ESTree flavor; the Babel flavor is a CallExpression).
+			if (
+				n.type === 'CallExpression' ||
+				n.type === 'OptionalCallExpression' ||
+				n.type === 'NewExpression' ||
+				n.type === 'TaggedTemplateExpression' ||
+				n.type === 'ImportExpression'
+			) {
+				if (
+					(n.type === 'CallExpression' || n.type === 'OptionalCallExpression') &&
+					isHookishCallee(n.callee)
+				) {
 					blocked = true;
 					return;
 				}

--- a/packages/octane/src/error-codes.server.generated.ts
+++ b/packages/octane/src/error-codes.server.generated.ts
@@ -21,11 +21,9 @@ type ServerErrorArguments = {
 	30: [unknown];
 	31: [];
 	32: [unknown];
-	33: [unknown];
 	34: [];
 	35: [unknown];
 	36: [];
-	37: [unknown];
 	38: [];
 	39: [];
 	40: [];
@@ -34,6 +32,8 @@ type ServerErrorArguments = {
 	43: [];
 	44: [];
 	45: [];
+	47: [unknown];
+	48: [unknown];
 };
 
 export function formatServerError<Code extends keyof ServerErrorArguments>(
@@ -108,11 +108,6 @@ export function formatServerError<Code extends keyof ServerErrorArguments>(
 					'octane SSR: a use(thenable) did not settle within %sms.',
 					args,
 				);
-			case 33:
-				return formatDevErrorMessage(
-					'octane SSR: exceeded %s suspense passes — a use(thenable) never resolved.',
-					args,
-				);
 			case 34:
 				return formatDevErrorMessage(
 					'octane SSR: a root suspension no longer has resumable work.',
@@ -126,11 +121,6 @@ export function formatServerError<Code extends keyof ServerErrorArguments>(
 			case 36:
 				return formatDevErrorMessage(
 					'octane SSR: a pending streamed boundary no longer has resumable work; its error escaped to an ancestor that was already flushed.',
-					args,
-				);
-			case 37:
-				return formatDevErrorMessage(
-					'octane SSR: %s consecutive streaming passes completed no boundary — a use(thenable) never resolved.',
 					args,
 				);
 			case 38:
@@ -152,6 +142,16 @@ export function formatServerError<Code extends keyof ServerErrorArguments>(
 				return formatDevErrorMessage('The readable stream is closed.', args);
 			case 45:
 				return formatDevErrorMessage('Server-rendered use() rejected (function)', args);
+			case 47:
+				return formatDevErrorMessage(
+					'octane SSR: exceeded %s suspense passes — a use(thenable) never resolved. If promises are re-created on every render pass (e.g. created in an ancestor render and passed down through props), create them at their use() site or hoist them out of render.',
+					args,
+				);
+			case 48:
+				return formatDevErrorMessage(
+					'octane SSR: %s consecutive streaming passes completed no boundary — a use(thenable) never resolved. If promises are re-created on every render pass (e.g. created in an ancestor render and passed down through props), create them at their use() site or hoist them out of render.',
+					args,
+				);
 			default:
 				return formatUnknownDevErrorMessage(code);
 		}

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -3577,6 +3577,8 @@ export function use<T>(
 	if (RESOLVED !== null) {
 		const entryT = RESOLVED.pu.resolvedT.get(usable as PromiseLike<unknown>);
 		if (entryT !== undefined) {
+			// Livelock-guard consumption mark (armed only after a first strike).
+			RESOLVED.pu.touched?.add(usable as PromiseLike<unknown>);
 			if ('reason' in entryT) {
 				recordHydrationRejection(serial, entryT.reason);
 				throw entryT.reason;
@@ -3776,11 +3778,20 @@ export function puBatch(thenables: unknown[], warm?: () => void): void {
 	}
 	const res = RESOLVED as ResolvedMap | null;
 	const pu = res !== null ? res.pu : null;
+	// Livelock guard tripped (observeSuspenseWave): keep the status probes below
+	// (they feed resolvedT for settled instances) but register nothing and never
+	// suspend — the first unresolved use() after this call suspends under its
+	// stable string key instead, and key replay completes the render.
+	const disabled = pu !== null && pu.batchDisabled === true;
 	let pending = false;
 	for (let i = 0; i < thenables.length; i++) {
 		const t = thenables[i] as PromiseLike<unknown> | null | undefined;
 		if (t == null || typeof (t as any).then !== 'function') continue;
-		if (pu !== null && pu.resolvedT.has(t)) continue;
+		if (pu !== null && pu.resolvedT.has(t)) {
+			// Livelock-guard consumption mark (armed only after a first strike).
+			pu.touched?.add(t);
+			continue;
+		}
 		// `puBatch` runs before the corresponding use() calls, so it must perform
 		// the same status probe for already-instrumented thenables. Otherwise the
 		// batch suspends before use() can trigger a Flight-style lazy subscription.
@@ -3832,9 +3843,9 @@ export function puBatch(thenables: unknown[], warm?: () => void): void {
 		// pending entry would strand its boundary. Duplicate registrations are
 		// harmless — synthetic keys are unique, and awaiting a promise twice
 		// just records the same outcome twice.
-		if (SUSPENDED !== null) SUSPENDED.push({ promise: t, key: '|pu#' + PU_ID++ });
+		if (!disabled && SUSPENDED !== null) SUSPENDED.push({ promise: t, key: '|pu#' + PU_ID++ });
 	}
-	if (!pending) return;
+	if (!pending || disabled) return;
 	// About to suspend — run the warm walk first (the compiler passes the thunk
 	// on the active component stack): descendant components' independent creations
 	// start AND register with this round via warmMemo, so their data resolves
@@ -3896,11 +3907,14 @@ const WARM_DEPTH_CAP = 64;
  * the render loop so the current round awaits it — that is the whole point: the
  * descendant's data settles before its body runs, and its unwraps then resolve
  * by identity (resolvedT). Speculative: a throwing creation is simply not
- * warmed.
+ * warmed. Returns the claimed/created value so a memoized child PROP printed
+ * into a warmChild plan hands the real value to the descent instead of
+ * re-evaluating its creation (undefined when nothing could be claimed or
+ * created — the descent then just prefetches less).
  */
-export function warmMemo(compute: () => unknown, deps: unknown[], slot: ServerHookSlot): void {
+export function warmMemo(compute: () => unknown, deps: unknown[], slot: ServerHookSlot): unknown {
 	const res = RESOLVED;
-	if (res === null) return;
+	if (res === null) return undefined;
 	const warm = res.pu.warm;
 	let list = warm.get(slot);
 	if (list !== undefined) {
@@ -3908,7 +3922,7 @@ export function warmMemo(compute: () => unknown, deps: unknown[], slot: ServerHo
 			const entry = list[i];
 			if (!puDepsEqual(entry.deps, deps) || CURRENT_PU_WARM_CLAIMS?.has(entry)) continue;
 			CURRENT_PU_WARM_CLAIMS?.add(entry);
-			return; // this concrete occurrence already ran or warmed
+			return entry.value; // this concrete occurrence already ran or warmed
 		}
 	}
 	// A parent plan recurses through the currently-rendering source component as
@@ -3933,16 +3947,19 @@ export function warmMemo(compute: () => unknown, deps: unknown[], slot: ServerHo
 			list = [];
 			warm.set(slot, list);
 		}
-		const entry = { deps, value: undefined, available: false };
+		// available:false — the render pass owns this creation under its own
+		// frame key; the tombstone only blocks a later speculative refetch. The
+		// value still rides along so warm-plan PROP claims can hand it onward.
+		const entry = { deps, value: activeCreation.value, available: false };
 		list.push(entry);
 		CURRENT_PU_WARM_CLAIMS?.add(entry);
-		return;
+		return activeCreation.value;
 	}
 	let value: unknown;
 	try {
 		value = compute();
 	} catch {
-		return;
+		return undefined;
 	}
 	if (list === undefined) {
 		list = [];
@@ -3959,6 +3976,7 @@ export function warmMemo(compute: () => unknown, deps: unknown[], slot: ServerHo
 		if (SUSPENDED !== null)
 			SUSPENDED.push({ promise: value as PromiseLike<unknown>, key: '|pu#' + PU_ID++ });
 	}
+	return value;
 }
 
 /**
@@ -4663,6 +4681,20 @@ type ResolvedMap = Map<string, SuspenseOutcome> & {
 		// a value is adoptable once, while its retained tombstone prevents a later
 		// dependency stratum from speculatively recreating the same request.
 		warm: Map<ServerHookSlot, { deps: unknown[]; value: unknown; available: boolean }[]>;
+		/** Livelock guard tripped (see observeSuspenseWave): puBatch stops
+		 *  registering/suspending for the rest of this render so plain use()
+		 *  string-key replay drives progress instead. */
+		batchDisabled?: boolean;
+		/** observeSuspenseWave state — consecutive recreation strikes + the
+		 *  puMemo creation-cache size at the previous observation. */
+		recreate?: { strikes: number; prevCreated: number };
+		/** Armed by observeSuspenseWave after a first strike: identity-resolved
+		 *  thenables (use() / puBatch resolvedT hits) are recorded here during
+		 *  the next pass so the guard can tell a legitimate waterfall stratum
+		 *  (it CONSUMES the previous wave's outcomes) from ancestor recreation
+		 *  (the settled instances are never referenced again). Undefined —
+		 *  the common case — costs one undefined-check per identity hit. */
+		touched?: Set<PromiseLike<unknown>>;
 	};
 };
 function newResolvedMap(): ResolvedMap {
@@ -5084,6 +5116,101 @@ async function settleFirstOfWave(
 	signal?.throwIfAborted();
 }
 
+// ---------------------------------------------------------------------------
+// Uncached-creation livelock guard.
+//
+// Batch-registered thenables resolve by IDENTITY (resolvedT). A per-request
+// promise CREATED in an ancestor's render and passed down through props is
+// recreated by every full re-pass unless the compiler could cache the
+// creation (puMemo) — each wave then settles instances the next pass never
+// asks about, no boundary ever completes, and the render burns
+// MAX_SUSPENSE_PASSES before erroring. This is the React-trained "uncached
+// promise" shape (React's Fizz renders each boundary once, so there it only
+// duplicates work instead of livelocking). The compiler memoizes inline
+// creations at use() sites and in component-prop position, but shapes it
+// cannot see (locals flowing into props, spreads, foreign-toolchain bodies)
+// still reach the runtime — this guard keeps them terminating.
+//
+// Watched signature, once per settle→re-render cycle: no boundary completed,
+// no new puMemo creation site was reached, no plain use() string key was
+// recorded, and the new pass registers ONLY batch thenables whose identities
+// are disjoint from the previous wave's (a still-pending batch thenable
+// re-registers on every pass by design, so a legitimate slow wave always
+// overlaps). One such cycle can still be a legitimate waterfall level whose
+// unwraps are trivial (un-memoized) references, so the first strike only ARMS
+// consumption tracking: a real dependency stratum CONSUMES the settled wave's
+// outcomes on the very next pass (identity hits in use()/puBatch), while a
+// recreating ancestor never references the settled instances again. A second
+// consecutive strike with zero consumption switches batching off for the rest
+// of the request: puBatch stops registering/suspending, the first unresolved
+// use() below it suspends under its stable frame-scoped STRING key instead,
+// and key replay drives the render to completion — degraded (one newly
+// recorded unwrap key per pass) but correct, matching what un-batched use()
+// has always done for per-pass creations.
+function observeSuspenseWave(
+	resolved: ResolvedMap,
+	settled: SuspendedList,
+	next: SuspendedList,
+	boundaryProgress: boolean,
+): void {
+	const pu = resolved.pu;
+	if (pu.batchDisabled === true) {
+		pu.touched = undefined;
+		return;
+	}
+	let state = pu.recreate;
+	if (state === undefined) state = pu.recreate = { strikes: 0, prevCreated: -1 };
+	const createdGrew = pu.created.size !== state.prevCreated;
+	state.prevCreated = pu.created.size;
+	const touched = pu.touched;
+	pu.touched = undefined;
+	const reset = (): void => {
+		state.strikes = 0;
+	};
+	if (boundaryProgress || createdGrew) return reset();
+	let prevPu: Set<PromiseLike<unknown>> | null = null;
+	for (const { promise, key } of settled) {
+		if (key.charCodeAt(0) === 124 /* '|' */ && key.startsWith('|pu#')) {
+			(prevPu ??= new Set()).add(promise);
+		} else if (resolved.has(key)) {
+			// A plain use() key settled — that site advances next pass.
+			return reset();
+		}
+	}
+	if (prevPu === null) return reset();
+	let sawFresh = false;
+	for (const { promise, key } of next) {
+		if (key.charCodeAt(0) !== 124 || !key.startsWith('|pu#')) continue;
+		// A carried-over (still pending) or already-settled identity is normal
+		// batching at work, not recreation.
+		if (prevPu.has(promise) || pu.resolvedT.has(promise)) return reset();
+		sawFresh = true;
+	}
+	if (!sawFresh) return reset();
+	if (touched !== undefined) {
+		// Tracking was armed by the previous strike: any identity hit against
+		// the settled wave means its outcomes were consumed — a real stratum.
+		for (const promise of prevPu) {
+			if (touched.has(promise)) return reset();
+		}
+	}
+	if (++state.strikes < 2) {
+		pu.touched = new Set(); // arm consumption tracking for the next pass
+		return;
+	}
+	pu.batchDisabled = true;
+	if (process.env.NODE_ENV !== 'production') {
+		console.error(
+			'octane SSR: use() thenables appear to be re-created on every render pass — ' +
+				'promises created during an ancestor render and passed down (e.g. via props) ' +
+				'get a fresh identity each pass, so their boundaries can never resolve by ' +
+				'identity. Create the promise at its use() site, or hoist the creation out ' +
+				'of render (the compiler caches analyzable inline creations automatically). ' +
+				'Falling back to per-site replay for the rest of this render.',
+		);
+	}
+}
+
 // The await-everything render core. Runs full canonical passes interleaved with
 // cheap discovery rounds until nothing suspends, then returns the final pass —
 // so every `use(thenable)` is resolved and the @try success arms are rendered.
@@ -5101,6 +5228,7 @@ async function runBuffered(
 	// (never a module global) so concurrent renders can't share it.
 	const resolved: ResolvedMap = newResolvedMap();
 	let attempt = 0;
+	let lastSettled: SuspendedList | null = null;
 	for (;;) {
 		// Bail before doing pass work if the request already died.
 		signal?.throwIfAborted();
@@ -5116,6 +5244,7 @@ async function runBuffered(
 			throw err;
 		}
 		if (pass.suspended.length === 0) return pass;
+		if (lastSettled !== null) observeSuspenseWave(resolved, lastSettled, pass.suspended, false);
 		// Between full passes, greedily discover deeper waterfall levels with cheap
 		// SUBTREE re-runs (skipping the static bulk) so the NEXT full pass jumps
 		// straight to canonical. A root-level boundary (job.frame.parent === null)
@@ -5126,17 +5255,23 @@ async function runBuffered(
 			// MAX bounds the TOTAL awaits (full-pass- and round-driven) so a
 			// never-resolving or nondeterministic use() can't wedge the loop.
 			if (++attempt > MAX_SUSPENSE_PASSES) {
-				const err = new Error(formatServerError(33, MAX_SUSPENSE_PASSES));
+				const err = new Error(formatServerError(47, MAX_SUSPENSE_PASSES));
 				options?.onError?.(err);
 				throw err;
 			}
 			await settleSuspended(pending, resolved, timeoutMs, signal);
+			lastSettled = pending;
 			if (jobs.length === 0 || !jobs.every((j) => j.frame.parent !== null)) break;
 			const round = withStream(null, () => runDiscoveryRound(jobs, resolved, identifierPrefix));
 			if (round.suspended.length === 0) break; // fully discovered → next full pass is canonical
 			pending = round.suspended;
 			jobs = round.deferred;
 		}
+		// Discovery rounds replay suspended subtrees with their CAPTURED props,
+		// so their identity hits are stale-prop consumption, not canonical
+		// progress — discard them so the livelock guard only credits identity
+		// hits made by the next full pass.
+		if (resolved.pu.touched !== undefined) resolved.pu.touched = new Set();
 		// Loop → another full canonical pass with the now-populated cache. If it
 		// still suspends (a nondeterministic render whose keys shift), it simply
 		// makes progress via more full passes, bounded by MAX_SUSPENSE_PASSES.
@@ -6274,9 +6409,11 @@ async function runStream(
 			if (++rootAttempts > MAX_SUSPENSE_PASSES) {
 				throw new Error(formatServerError(35, MAX_SUSPENSE_PASSES));
 			}
-			await settleFirstOfWave(pass.suspended, resolved, timeoutMs, signal);
+			const settledWave = pass.suspended;
+			await settleFirstOfWave(settledWave, resolved, timeoutMs, signal);
 			({ pass, boundaryKeys: shellBoundaryKeys } = renderFullPass());
 			preShellSuspended = pass.suspended;
+			observeSuspenseWave(resolved, settledWave, pass.suspended, false);
 			signal?.throwIfAborted();
 		}
 		pruneStreamBoundariesAbsentFromShell(stream, shellBoundaryKeys);
@@ -6391,9 +6528,10 @@ async function runStream(
 				throw new Error(formatServerError(36));
 			}
 			if (++attempt > MAX_SUSPENSE_PASSES) {
-				throw new Error(formatServerError(37, MAX_SUSPENSE_PASSES));
+				throw new Error(formatServerError(48, MAX_SUSPENSE_PASSES));
 			}
-			await settleFirstOfWave(suspended, resolved, timeoutMs, signal);
+			const settledWave = suspended;
+			await settleFirstOfWave(settledWave, resolved, timeoutMs, signal);
 			pass = renderFullPass().pass;
 			suspended = pass.suspended;
 			reportRecoverableBoundaryErrors();
@@ -6418,6 +6556,7 @@ async function runStream(
 				}
 			}
 			if (madeProgress) attempt = 0; // a boundary completed — this wave was legitimate
+			observeSuspenseWave(resolved, settledWave, suspended, madeProgress);
 
 			// A nested boundary's template may live inside an enclosing boundary's
 			// not-yet-flushed segment. Build a topological emission order: roots and

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -5133,20 +5133,27 @@ async function settleFirstOfWave(
 //
 // Watched signature, once per settle→re-render cycle: no boundary completed,
 // no new puMemo creation site was reached, no plain use() string key was
-// recorded, and the new pass registers ONLY batch thenables whose identities
-// are disjoint from the previous wave's (a still-pending batch thenable
-// re-registers on every pass by design, so a legitimate slow wave always
-// overlaps). One such cycle can still be a legitimate waterfall level whose
-// unwraps are trivial (un-memoized) references, so the first strike only ARMS
-// consumption tracking: a real dependency stratum CONSUMES the settled wave's
-// outcomes on the very next pass (identity hits in use()/puBatch), while a
-// recreating ancestor never references the settled instances again. A second
-// consecutive strike with zero consumption switches batching off for the rest
-// of the request: puBatch stops registering/suspending, the first unresolved
-// use() below it suspends under its stable frame-scoped STRING key instead,
-// and key replay drives the render to completion — degraded (one newly
-// recorded unwrap key per pass) but correct, matching what un-batched use()
-// has always done for per-pass creations.
+// recorded, and the new pass registers FRESH batch thenables (identities
+// disjoint from the previous wave's). Carried-over registrations — a
+// still-pending batch thenable re-registers on every pass by design — are
+// normal batching at work, but they must only be EXCLUDED from the fresh set,
+// never treated as a wave-wide veto: a slow stable fetch pending beside
+// recreated sites would otherwise clear the evidence every pass while the
+// recreated sites manufacture fast no-boundary waves straight into the
+// MAX_SUSPENSE_PASSES error. One qualifying cycle can still be a legitimate
+// waterfall level whose unwraps are trivial (un-memoized) references, so the
+// first strike only ARMS consumption tracking: a real dependency stratum
+// CONSUMES the settled wave's outcomes on the very next pass (identity hits
+// in use()/puBatch), while a recreating ancestor never references the settled
+// instances again. A second consecutive strike with zero consumption switches
+// batching off for the rest of the request: puBatch stops
+// registering/suspending, the first unresolved use() below it suspends under
+// its stable frame-scoped STRING key instead, and key replay drives the
+// render to completion — degraded (one newly recorded unwrap key per pass)
+// but correct, matching what un-batched use() has always done for per-pass
+// creations. (Still-pending stable work is unaffected by the switch: its
+// use() suspends with the SAME thenable under a string key and resolves on
+// settle exactly as un-batched code always has.)
 function observeSuspenseWave(
 	resolved: ResolvedMap,
 	settled: SuspendedList,
@@ -5181,10 +5188,12 @@ function observeSuspenseWave(
 	let sawFresh = false;
 	for (const { promise, key } of next) {
 		if (key.charCodeAt(0) !== 124 || !key.startsWith('|pu#')) continue;
-		// A carried-over (still pending) or already-settled identity is normal
-		// batching at work, not recreation.
-		if (prevPu.has(promise) || pu.resolvedT.has(promise)) return reset();
+		// Carried-over (still pending) and already-settled identities are not
+		// recreation — but they are also not progress, so they merely don't
+		// count as fresh (see the mixed-recreation note above).
+		if (prevPu.has(promise) || pu.resolvedT.has(promise)) continue;
 		sawFresh = true;
+		break;
 	}
 	if (!sawFresh) return reset();
 	if (touched !== undefined) {

--- a/packages/octane/tests/_fixtures/ssr-prop-flow-hydrate.tsrx
+++ b/packages/octane/tests/_fixtures/ssr-prop-flow-hydrate.tsrx
@@ -1,11 +1,12 @@
 import { use, useState } from 'octane';
 
 // Prop-flow hydration shape: SeedPage inline-creates a promise in child-prop
-// position (server compile caches it via a server-only prop-memo slot, which
-// advances the module's hook-symbol counter ahead of SeedCard's client slots)
-// AND both components carry state hooks plus a seeded use(). Hydration must be
-// insensitive to that server/client slot-id divergence: seeds are consumed by
-// the positional cursor in use()-call order, never by slot identity.
+// position (the server compile caches it via a prop-memo slot the client
+// compile never allocates) AND both components carry state hooks plus a
+// seeded use(). Hydration must be insensitive to server-only slots: seeds are
+// consumed by the positional cursor in use()-call order, never by slot
+// identity, and the shared sites' ids stay aligned across the two compiles
+// (server-only slots take the tail of the module's range).
 export function SeedPage(p) @{
 	const [label] = useState('L');
 	<main>

--- a/packages/octane/tests/_fixtures/ssr-prop-flow-hydrate.tsrx
+++ b/packages/octane/tests/_fixtures/ssr-prop-flow-hydrate.tsrx
@@ -1,0 +1,26 @@
+import { use, useState } from 'octane';
+
+// Prop-flow hydration shape: SeedPage inline-creates a promise in child-prop
+// position (server compile caches it via a server-only prop-memo slot, which
+// advances the module's hook-symbol counter ahead of SeedCard's client slots)
+// AND both components carry state hooks plus a seeded use(). Hydration must be
+// insensitive to that server/client slot-id divergence: seeds are consumed by
+// the positional cursor in use()-call order, never by slot identity.
+export function SeedPage(p) @{
+	const [label] = useState('L');
+	<main>
+		<SeedCard promise={p.load('x')} tag={label} />
+	</main>
+}
+
+export function SeedCard(props) @{
+	const [n, setN] = useState(0);
+	<div>
+		@try {
+			const v = use(props.promise);
+			<button id="card" onClick={() => setN(n + 1)}>{v + ':' + props.tag + ':' + n}</button>
+		} @pending {
+			<i>p</i>
+		}
+	</div>
+}

--- a/packages/octane/tests/ssr-prop-flow-promises.test.ts
+++ b/packages/octane/tests/ssr-prop-flow-promises.test.ts
@@ -288,6 +288,54 @@ describe('streaming SSR — promises created in an ancestor, unwrapped via props
 		}
 	});
 
+	it('caches optional-call prop creations cross-pass like plain calls', async () => {
+		// `p.makeCards?.()` parses as an OptionalCallExpression — it creates per
+		// evaluation exactly like a plain call and must take the identity-cache
+		// path (exactly-once creation, no recreation warning), not the degraded
+		// livelock-guard fallback.
+		const OPTIONAL_FLOW =
+			CARD_AND_LIST +
+			`
+			export function Page(p) @{
+				<main><List cards={p.makeCards?.()} /></main>
+			}
+		`;
+		const mod = evalServer(OPTIONAL_FLOW, 'prop-flow-optional.tsrx');
+		const { state, makeCards } = timedCardsFactory();
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			const { ended, errors } = collect(mod.Page, { makeCards });
+			const html = await ended;
+			expect(errors).toEqual([]);
+			expect(html).toContain('card-0');
+			expect(html).toContain('card-1');
+			expect(html).toContain('card-2');
+			expect(state.creations).toBe(1);
+			expect(errorSpy).not.toHaveBeenCalled();
+		} finally {
+			errorSpy.mockRestore();
+		}
+	});
+
+	it('never caches hook-shaped calls in prop position — plain or optional', () => {
+		// A hook call's slot/occurrence bookkeeping must run on the body proper
+		// every pass, so it can never sit behind a cross-pass cache hit. This is
+		// an authoring-pattern contract the render output cannot distinguish, so
+		// assert the narrowest compile-level property: no creation cache is
+		// emitted for these attributes.
+		const HOOKISH = `
+			export function Kid(props) @{ <i>{props.v as string}</i> }
+			export function Page(p) @{
+				<main>
+					<Kid v={useThing(p)} />
+					<Kid v={p.store?.useSelector()} />
+				</main>
+			}
+		`;
+		const { code } = compile(HOOKISH, 'prop-hookish.tsrx', { mode: 'server' });
+		expect(code).not.toContain('puMemo');
+	});
+
 	it('compiles and renders a module whose ONLY slot sites are prop memos', async () => {
 		// The website/example-app CI break: routes are split across modules, so
 		// a module can pass call-valued props while its consumers (use(), hooks)

--- a/packages/octane/tests/ssr-prop-flow-promises.test.ts
+++ b/packages/octane/tests/ssr-prop-flow-promises.test.ts
@@ -288,6 +288,27 @@ describe('streaming SSR — promises created in an ancestor, unwrapped via props
 		}
 	});
 
+	it('compiles and renders a module whose ONLY slot sites are prop memos', async () => {
+		// The website/example-app CI break: routes are split across modules, so
+		// a module can pass call-valued props while its consumers (use(), hooks)
+		// live elsewhere. Its prop memos are then the module's only slot sites —
+		// the emitted module must still import everything it references (the
+		// tail-slot flush once ran after the import list was built, emitting
+		// _$hookSlots without importing it; module init then threw and SSR
+		// served only the error fallback).
+		const ONLY_PROP_MEMO = `
+			export function Kid(props) @{
+				<i>{props.data as string}</i>
+			}
+			export function Page(p) @{
+				<main><Kid data={p.load('x')} /></main>
+			}
+		`;
+		const mod = evalServer(ONLY_PROP_MEMO, 'prop-memo-only.tsrx');
+		const out = await prerender(mod.Page, { load: (id: string) => 'v-' + id });
+		expect(out.html).toContain('<i>v-x</i>');
+	});
+
 	it('prerender completes the recreated-promise shape', async () => {
 		const mod = evalServer(LOCAL_PROP_FLOW, 'prop-flow-local.tsrx');
 		const { makeCards } = timedCardsFactory();

--- a/packages/octane/tests/ssr-prop-flow-promises.test.ts
+++ b/packages/octane/tests/ssr-prop-flow-promises.test.ts
@@ -66,7 +66,7 @@ function collect(component: any, props?: any) {
 		},
 		end,
 	});
-	return { ended, errors };
+	return { ended, errors, chunks };
 }
 
 // Card/List are shared by every Page shape below: the grandchild unwraps a
@@ -312,6 +312,71 @@ describe('streaming SSR — promises created in an ancestor, unwrapped via props
 			expect(html).toContain('card-2');
 			expect(state.creations).toBe(1);
 			expect(errorSpy).not.toHaveBeenCalled();
+		} finally {
+			errorSpy.mockRestore();
+		}
+	});
+
+	it('degrades recreated sites even while a slow stable fetch is still pending', async () => {
+		// Mixed tree: a stable (use-site memoized) fetch that stays in flight
+		// beside prop-flowed promises recreated every pass. The recreated sites
+		// manufacture fast no-boundary waves the whole time the stable fetch
+		// pends; its carried-over registration must not clear the recreation
+		// evidence each pass, or the render burns MAX_SUSPENSE_PASSES before
+		// the stable work ever lands. The slow fetch is only resolved AFTER the
+		// recreated cards' content reaches the wire — impossible unless the
+		// guard tripped while the fetch was still pending.
+		const MIXED =
+			CARD_AND_LIST +
+			`
+			export function Slow(props) @{
+				<div>
+					@try {
+						const v = use(props.fetchSlow());
+						<b class="slow">{v as string}</b>
+					} @pending {
+						<i>s</i>
+					}
+				</div>
+			}
+			export function Page(p) @{
+				const cards = p.makeCards();
+				<main>
+					<Slow fetchSlow={p.fetchSlow} />
+					<List cards={cards} />
+				</main>
+			}
+		`;
+		const mod = evalServer(MIXED, 'prop-flow-mixed.tsrx');
+		const { makeCards } = timedCardsFactory();
+		let resolveSlow!: (v: string) => void;
+		const slow = new Promise<string>((resolve) => {
+			resolveSlow = resolve;
+		});
+		let fetches = 0;
+		const fetchSlow = () => {
+			fetches++;
+			return slow;
+		};
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			const { ended, errors, chunks } = collect(mod.Page, { makeCards, fetchSlow });
+			// Release the stable fetch only once every recreated card is on the
+			// wire — the guard must have degraded those sites by then.
+			const deadline = Date.now() + 5000;
+			while (!chunks.join('').includes('card-2')) {
+				if (Date.now() > deadline) throw new Error('recreated cards never flushed');
+				await new Promise((resolve) => setTimeout(resolve, 5));
+			}
+			resolveSlow('slow-data');
+			const html = await ended;
+			expect(errors).toEqual([]);
+			expect(html).toContain('card-0');
+			expect(html).toContain('card-1');
+			expect(html).toContain('card-2');
+			expect(html).toContain('slow-data');
+			// The stable creation stayed memoized throughout the degradation.
+			expect(fetches).toBe(1);
 		} finally {
 			errorSpy.mockRestore();
 		}

--- a/packages/octane/tests/ssr-prop-flow-promises.test.ts
+++ b/packages/octane/tests/ssr-prop-flow-promises.test.ts
@@ -248,8 +248,7 @@ describe('streaming SSR — promises created in an ancestor, unwrapped via props
 
 	it('hydrates the memoized prop-flow shape — seeds adopt positionally despite server-only prop-memo slots', async () => {
 		// The server compile allocates a prop-memo slot the client compile never
-		// sees, shifting later server slot ids relative to the client's. That
-		// divergence must be invisible across the boundary: seeds serialize in
+		// sees. That must be invisible across the boundary: seeds serialize in
 		// use()-call order and the client consumes them by positional cursor,
 		// never by slot identity. Server-render the fixture, hydrate the
 		// CLIENT-compiled module over it, and require full adoption — no

--- a/packages/octane/tests/ssr-prop-flow-promises.test.ts
+++ b/packages/octane/tests/ssr-prop-flow-promises.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { compile } from 'octane/compiler';
 import * as RT from 'octane/server';
 import { prerender } from 'octane/static';
+import { hydrateRoot, flushSync } from '../src/index.js';
+// CLIENT-compiled side of the hydration fixture (normal .tsrx import path).
+import { SeedPage } from './_fixtures/ssr-prop-flow-hydrate.tsrx';
 
 // Per-request promises CREATED in an ancestor's render and passed down through
 // child JSX props to descendant use() sites (the React-trained "uncached
@@ -15,13 +20,27 @@ function evalModule(code: string, file: string): Record<string, any> {
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane(?:\/server)?['"];?/g,
 		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
+	// Keep declarations as declarations (a function-expression rewrite would
+	// unbind the name for sibling components that reference it) and attach the
+	// exports at the end.
+	const exported: string[] = [];
 	code = code.replace(
 		/export\s+(async\s+)?function\s+(\w+)/g,
-		(_m: string, asyncKeyword: string | undefined, name: string) =>
-			`__exports.${name} = ${asyncKeyword ?? ''}function ${name}`,
+		(_m: string, asyncKeyword: string | undefined, name: string) => {
+			exported.push(name);
+			return `${asyncKeyword ?? ''}function ${name}`;
+		},
 	);
-	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
-	const fn = new Function('__rt', '__exports', code + `\nreturn __exports;\n//# sourceURL=${file}`);
+	code = code.replace(/export const (\w+) =/g, (_m: string, name: string) => {
+		exported.push(name);
+		return `const ${name} =`;
+	});
+	const footer = exported.map((name) => `__exports.${name} = ${name};`).join('\n');
+	const fn = new Function(
+		'__rt',
+		'__exports',
+		code + `\n${footer}\nreturn __exports;\n//# sourceURL=${file}`,
+	);
 	return fn(RT, {});
 }
 
@@ -224,6 +243,49 @@ describe('streaming SSR — promises created in an ancestor, unwrapped via props
 			expect(warned).toBe(false);
 		} finally {
 			errorSpy.mockRestore();
+		}
+	});
+
+	it('hydrates the memoized prop-flow shape — seeds adopt positionally despite server-only prop-memo slots', async () => {
+		// The server compile allocates a prop-memo slot the client compile never
+		// sees, shifting later server slot ids relative to the client's. That
+		// divergence must be invisible across the boundary: seeds serialize in
+		// use()-call order and the client consumes them by positional cursor,
+		// never by slot identity. Server-render the fixture, hydrate the
+		// CLIENT-compiled module over it, and require full adoption — no
+		// re-suspend, no rebuild, no mismatch warning — plus live state after.
+		const fixture = join(
+			process.cwd(),
+			'packages/octane/tests/_fixtures/ssr-prop-flow-hydrate.tsrx',
+		);
+		const server = evalServer(readFileSync(fixture, 'utf8'), 'ssr-prop-flow-hydrate.tsrx');
+		const load = (id: string) => Promise.resolve('v-' + id);
+		const { html } = await prerender(server.SeedPage, { load });
+		expect(html).toContain('v-x:L:0');
+
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			container.innerHTML = html;
+			const button = container.querySelector('#card') as HTMLElement;
+			const textNode = button.firstChild;
+			const root = hydrateRoot(container, SeedPage as any, { load });
+			flushSync(() => {});
+			// Adopted, not rebuilt: same element and text node, seed consumed.
+			expect(container.querySelector('#card')).toBe(button);
+			expect(button.firstChild).toBe(textNode);
+			expect(button.textContent).toBe('v-x:L:0');
+			expect(container.querySelector('script[data-octane-suspense]')).toBeNull();
+			expect(errorSpy).not.toHaveBeenCalled();
+			// Hooks are live post-hydration (state cells resolved on client slots).
+			button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+			flushSync(() => {});
+			expect(button.textContent).toBe('v-x:L:1');
+			root.unmount();
+		} finally {
+			errorSpy.mockRestore();
+			container.remove();
 		}
 	});
 

--- a/packages/octane/tests/ssr-prop-flow-promises.test.ts
+++ b/packages/octane/tests/ssr-prop-flow-promises.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi } from 'vitest';
+import { compile } from 'octane/compiler';
+import * as RT from 'octane/server';
+import { prerender } from 'octane/static';
+
+// Per-request promises CREATED in an ancestor's render and passed down through
+// child JSX props to descendant use() sites (the React-trained "uncached
+// promise" shape). Streaming SSR re-runs the ancestor on every wave pass; the
+// creations must be cached cross-pass (or the runtime must fall back to
+// string-key replay) or every pass recreates the promises, no boundary ever
+// completes, and the render burns MAX_SUSPENSE_PASSES before erroring.
+
+function evalModule(code: string, file: string): Record<string, any> {
+	code = code.replace(
+		/import\s*\{([^}]*)\}\s*from\s*['"]octane(?:\/server)?['"];?/g,
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
+	);
+	code = code.replace(
+		/export\s+(async\s+)?function\s+(\w+)/g,
+		(_m: string, asyncKeyword: string | undefined, name: string) =>
+			`__exports.${name} = ${asyncKeyword ?? ''}function ${name}`,
+	);
+	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
+	const fn = new Function('__rt', '__exports', code + `\nreturn __exports;\n//# sourceURL=${file}`);
+	return fn(RT, {});
+}
+
+function evalServer(source: string, file: string): Record<string, any> {
+	return evalModule(compile(source, file, { mode: 'server' }).code, file);
+}
+
+function collect(component: any, props?: any) {
+	const chunks: string[] = [];
+	const errors: unknown[] = [];
+	let end!: () => void;
+	const ended = new Promise<string>((resolve) => {
+		end = () => resolve(chunks.join(''));
+	});
+	RT.renderToPipeableStream(component, props, {
+		onError(error: unknown) {
+			errors.push(error);
+		},
+	}).pipe({
+		write(chunk: string | Uint8Array) {
+			chunks.push(typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk));
+			return true;
+		},
+		end,
+	});
+	return { ended, errors };
+}
+
+// Card/List are shared by every Page shape below: the grandchild unwraps a
+// promise it never created (`use(props.promise)`).
+const CARD_AND_LIST = `
+	export function Card(props) @{
+		<div class="card">
+			@try {
+				const v = use(props.promise);
+				<span class="ok">{v as string}</span>
+			} @pending {
+				<i>loading</i>
+			}
+		</div>
+	}
+	export function List(props) @{
+		<section>
+			@for (const c of props.cards; key c.id) {
+				<Card promise={c.promise} />
+			}
+		</section>
+	}
+`;
+
+// Creation INLINE in child-prop position — the compiler caches it cross-pass
+// (server Pass A prop extension), so the promises keep their identity and the
+// upstream work runs exactly once per request.
+const INLINE_PROP_FLOW =
+	CARD_AND_LIST +
+	`
+	export function Page(p) @{
+		<main><List cards={p.makeCards()} /></main>
+	}
+`;
+
+// Creation assigned to a LOCAL first — outside the compiler's inline-only
+// analysis, so the promises really are recreated every pass. The runtime's
+// livelock guard must still complete the render via string-key replay.
+const LOCAL_PROP_FLOW =
+	CARD_AND_LIST +
+	`
+	export function Page(p) @{
+		const cards = p.makeCards();
+		<main><List cards={cards} /></main>
+	}
+`;
+
+function timedCardsFactory() {
+	const state = { creations: 0 };
+	const makeCards = () => {
+		state.creations++;
+		return [0, 1, 2].map((i) => ({
+			id: i,
+			promise: new Promise<string>((resolve) => setTimeout(() => resolve('card-' + i), 2)),
+		}));
+	};
+	return { state, makeCards };
+}
+
+describe('streaming SSR — promises created in an ancestor, unwrapped via props', () => {
+	it('resolves inline prop-flowed promises without recreating them each pass', async () => {
+		const mod = evalServer(INLINE_PROP_FLOW, 'prop-flow-inline.tsrx');
+		const { state, makeCards } = timedCardsFactory();
+		const { ended, errors } = collect(mod.Page, { makeCards });
+		const html = await ended;
+		expect(errors).toEqual([]);
+		expect(html).toContain('card-0');
+		expect(html).toContain('card-1');
+		expect(html).toContain('card-2');
+		expect(state.creations).toBe(1);
+	});
+
+	it('prerender resolves inline prop-flowed promises with one creation', async () => {
+		const mod = evalServer(INLINE_PROP_FLOW, 'prop-flow-inline.tsrx');
+		const { state, makeCards } = timedCardsFactory();
+		const out = await prerender(mod.Page, { makeCards });
+		expect(out.html).toContain('card-0');
+		expect(out.html).toContain('card-1');
+		expect(out.html).toContain('card-2');
+		expect(out.html).not.toContain('<i>loading</i>');
+		expect(state.creations).toBe(1);
+	});
+
+	it('completes when the creation escapes analysis and IS recreated each pass', async () => {
+		const mod = evalServer(LOCAL_PROP_FLOW, 'prop-flow-local.tsrx');
+		const { makeCards } = timedCardsFactory();
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			const { ended, errors } = collect(mod.Page, { makeCards });
+			const html = await ended;
+			// The guard degrades to per-site replay instead of burning
+			// MAX_SUSPENSE_PASSES and serving only @pending fallbacks.
+			expect(errors).toEqual([]);
+			expect(html).toContain('card-0');
+			expect(html).toContain('card-1');
+			expect(html).toContain('card-2');
+			const warned = errorSpy.mock.calls.some((args) =>
+				String(args[0]).includes('re-created on every render pass'),
+			);
+			expect(warned).toBe(true);
+		} finally {
+			errorSpy.mockRestore();
+		}
+	});
+
+	it('completes a recreated-promise shape with no @try — shell blocked on the root loop', async () => {
+		// No boundary anywhere: the suspension escapes to the root, so the
+		// pre-shell retry loop (not the boundary wave loop) must detect the
+		// recreation and still produce a complete shell.
+		const BARE = `
+			export function BareCard(props) @{
+				const v = use(props.promise);
+				<div class="ok">{v as string}</div>
+			}
+			export function Page(p) @{
+				const cards = p.makeCards();
+				<main>
+					@for (const c of cards; key c.id) {
+						<BareCard promise={c.promise} />
+					}
+				</main>
+			}
+		`;
+		const mod = evalServer(BARE, 'prop-flow-bare.tsrx');
+		const { makeCards } = timedCardsFactory();
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			const { ended, errors } = collect(mod.Page, { makeCards });
+			const html = await ended;
+			expect(errors).toEqual([]);
+			expect(html).toContain('card-0');
+			expect(html).toContain('card-1');
+			expect(html).toContain('card-2');
+		} finally {
+			errorSpy.mockRestore();
+		}
+	});
+
+	it('does not flag a legitimate stable-identity waterfall of trivial use() references', async () => {
+		// A pre-created linked chain unwrapped stratum by stratum: every
+		// argument is a trivial reference (never memoized, so the creation
+		// cache never grows) and every stratum registers fresh identities —
+		// but each pass CONSUMES the previous wave's outcomes, which is what
+		// separates a real waterfall from ancestor recreation. Batching must
+		// stay on and the recreation warning must not fire.
+		const CHAIN = `
+			export function Chain(p) @{
+				<main>
+					@try {
+						const a = use(p.head);
+						const b = use(a.next);
+						const c = use(b.next);
+						const d = use(c.next);
+						<div class="ok">{d.label as string}</div>
+					} @pending {
+						<i>w</i>
+					}
+				</main>
+			}
+		`;
+		const mod = evalServer(CHAIN, 'prop-flow-chain.tsrx');
+		const link = <T>(value: T): Promise<T> =>
+			new Promise((resolve) => setTimeout(() => resolve(value), 2));
+		const head = link({ next: link({ next: link({ next: link({ label: 'deep' }) }) }) });
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			const { ended, errors } = collect(mod.Chain, { head });
+			const html = await ended;
+			expect(errors).toEqual([]);
+			expect(html).toContain('deep');
+			const warned = errorSpy.mock.calls.some((args) =>
+				String(args[0]).includes('re-created on every render pass'),
+			);
+			expect(warned).toBe(false);
+		} finally {
+			errorSpy.mockRestore();
+		}
+	});
+
+	it('prerender completes the recreated-promise shape', async () => {
+		const mod = evalServer(LOCAL_PROP_FLOW, 'prop-flow-local.tsrx');
+		const { makeCards } = timedCardsFactory();
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			const out = await prerender(mod.Page, { makeCards });
+			expect(out.html).toContain('card-0');
+			expect(out.html).toContain('card-1');
+			expect(out.html).toContain('card-2');
+			expect(out.html).not.toContain('<i>loading</i>');
+		} finally {
+			errorSpy.mockRestore();
+		}
+	});
+});


### PR DESCRIPTION
## Problem

Streaming SSR livelocked (error #37, ~50 full render passes of billed CPU on Cloudflare Workers, page served with only `@pending` fallbacks) when per-request promises were **created in an ancestor component's render and passed down through props** to descendant `use()` sites — the React-trained "uncached promise" shape. React's Fizz merely duplicates work there; Octane livelocked.

Root cause: `puBatch` resolves registered thenables by **identity only** (`resolvedT`) and throws before the `use()` unwraps can record their stable string keys. Every wave re-pass re-ran the ancestor, recreated the promises, identity never matched, and no boundary ever completed. (Plain un-batched `use()` never livelocks on this shape — string-key replay serializes it.)

## Fix

**Layer 1 — compiler (root cause).** Server Pass A now `puMemo`-caches inline creations in component-prop position (`<Kid p={make(x)}/>`), deps-keyed like use()-site memos. Inline-only by design: the value has no other binding, so cross-pass caching cannot observe an escape or mutation. Warm plans print the same slot through the now value-returning `warmMemo`, so the prefetch walk claims the render's creation instead of racing a second one — the upstream factory runs **exactly once per request**. Hook-shaped calls and JSX-bearing expressions are excluded; `@for`/`@switch` arms keep the v1 exclusion; client compilation untouched.

**Layer 2 — runtime guard.** Shapes the compiler can't analyze (locals flowing into props, spreads, foreign toolchains) hit `observeSuspenseWave`, wired into the streaming wave, pre-shell root, and buffered loops (all off the hot path): two consecutive no-progress cycles registering only fresh batch identities disable batching for the request; `puBatch` keeps its status probes but stops registering/suspending, and string-key replay completes the render — degraded but correct. A first strike only **arms consumption tracking**: legitimate trivial-reference waterfalls (`use(a.next)` chains) consume the previous wave's outcomes on the next pass and never trip the guard (regression-pinned). Buffered discovery rounds replay with captured props, so their identity hits are excluded from consumption. A dev-only warning names the pattern.

**Diagnostics.** The max-pass errors now hint at the cause; published messages are immutable, so codes 33/37 are retired → 47/48 with the appended guidance.

## Tests

`packages/octane/tests/ssr-prop-flow-promises.test.ts`, run under both the dev and prod compile projects:
- inline prop-flow: streaming + prerender, content correct, `creations === 1`
- local-escape (non-analyzable): streaming + prerender complete via the guard, dev warning asserted
- bare-root (no `@try`): pre-shell root loop path
- stable-identity trivial chain: guard must NOT flag (fails if consumption tracking is removed)

Pre-fix failure verified: the inline shape reproduced error #37 verbatim.

## Validation

- Full suite: 11,942 passed / 0 related failures (one unrelated 180s `beforeAll` build timeout in the three bundlers browser suite under full-suite load; passes in isolation)
- Benchmarks (octane-only, identical commands both sides via `git stash`): `streaming-ssr` + `ssr-throughput` flat — parallel-k4/k8 and nested-d4/d8 p50 ~5.11ms both sides, waterfalls byte-identical, x32 overhead 1.00→1.01x; bytes/markers/chunks identical as semantic controls
- `pnpm format:check`, `pnpm typecheck`, `pnpm error-codes:check` clean; changeset included (patch)

Note: full benchmark runs currently fail building the **ripple** comparison targets — `node_modules` ripple's server exports changed underneath the repo mid-session (external to this change); octane-only filters were used for the comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core SSR suspense loops (`puBatch`, warm walk, streaming/buffered passes) and server compilation; incorrect guard or memo rules could change suspense timing or hydration, though behavior is heavily regression-tested.
> 
> **Overview**
> Fixes **streaming/buffered SSR livelock** when per-request promises are created in an ancestor render and passed to descendant `use()` through props (`puBatch` identity resolution never matched across re-passes).
> 
> **Compiler:** On the server, inline creation expressions in JSX props (e.g. `<Kid p={make(x)}/>`) are wrapped in deps-keyed `_$puMemo`, with **tail hook slots** so client/server slot IDs stay aligned. Warm child plans route memoized props through **value-returning `warmMemo`** so prefetch and render share one creation. Hook-shaped calls and JSX in prop expressions are excluded; **`flushTailHookSymbols`** runs before import assembly so prop-memo-only modules still import `hookSlots`.
> 
> **Runtime:** **`observeSuspenseWave`** detects two consecutive no-progress waves with only fresh batch identities and disables `puBatch` registration for the request, falling back to string-key `use()` replay (dev warning). **`warmMemo`** returns the claimed value for prop warm paths. Max-pass SSR errors **33/37 → 47/48** with guidance on re-created promises.
> 
> **Tests:** `ssr-prop-flow-promises.test.ts` covers inline memo (once per request), local-escape guard, bare root, legitimate chains, hydration with server-only slots, and mixed slow+recreated trees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 163b73dd0fa384af8315951ffb9b85cbe94fe436. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->