### PR TITLE
Define a safe inline script content contract

### DIFF
--- a/.changeset/safe-script-content.md
+++ b/.changeset/safe-script-content.md
@@ -1,0 +1,8 @@
+---
+'octane': patch
+---
+
+Define the inline-script content contract around static raw bodies and dynamic
+`dangerouslySetInnerHTML` values. Preserve authored static script characters,
+keep dynamic client and server output inside one script element, and hydrate the
+server-safe script spelling without a false mismatch.

--- a/README.md
+++ b/README.md
@@ -505,6 +505,41 @@ export function Greeting(props) @{
 }
 ```
 
+### Inline scripts
+
+An authored `<script>` body is static, raw script text. Braces are literal source,
+so blocks and object literals work normally; Octane does not treat `{...}` inside
+the body as a TSRX interpolation:
+
+```jsx
+export function Bootstrap() @{
+  <script>
+    window.appConfig = { locale: 'en-GB' };
+  </script>
+}
+```
+
+For a dynamic whole-script value, use the standard raw-content prop. Serialize
+structured values explicitly:
+
+```jsx
+export function Rules(props) @{
+  <script
+    type="speculationrules"
+    dangerouslySetInnerHTML={{ __html: JSON.stringify(props.rules) }}
+  />
+}
+```
+
+`<script>{JSON.stringify(props.rules) as string}</script>` is static script source,
+not an interpolation; the cast does not change the raw-text grammar.
+`dangerouslySetInnerHTML` supplies the complete body and cannot be combined with
+child content. Client mounts and updates write it through `textContent`; server
+rendering neutralizes case-insensitive opening and closing `script` tokens without
+HTML-escaping ordinary JavaScript or JSON characters. This prevents the value from
+creating sibling markup, but it does not validate or sanitize executable
+JavaScript—only inject executable source you trust.
+
 ### Class composition
 
 `class` (and its alias `className`) accepts more than a string. Octane composes the

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -476,6 +476,19 @@ function escapeInlineScriptContent(value) {
 	);
 }
 
+// Value-position host JSX lowers through a descriptor and installs its child via
+// textContent instead of parsing a static template. Match the HTML script-data
+// input normalization up front so fresh client DOM and parsed SSR DOM have the
+// same spelling; character references deliberately remain literal.
+const SCRIPT_DATA_INPUT_NORMALIZATION = /\r\n?|\u0000/g;
+
+function normalizeStaticScriptDescriptorContent(value) {
+	const normalized = value.replace(SCRIPT_DATA_INPUT_NORMALIZATION, (match) =>
+		match === '\u0000' ? '\uFFFD' : '\n',
+	);
+	return escapeInlineScriptContent(normalized);
+}
+
 function hasDefinitelyNonNullishJsxChild(children, knownStringLocals) {
 	for (const child of children || []) {
 		if (!child) continue;
@@ -11421,11 +11434,12 @@ function jsxElementToCreateElement(node, ctx) {
 		? undefined
 		: staticScriptContent(node, compNode.value);
 	if (authoredStaticScriptContent !== undefined) {
-		// Raw script-data is one authored body, not ordinary JSX text. Preserve
-		// whitespace verbatim and let the client/server descriptor renderers own
-		// their respective whole-script safety paths.
-		if (authoredStaticScriptContent !== '') {
-			args.push({ type: 'Literal', value: authoredStaticScriptContent });
+		// Raw script-data is one authored body, not ordinary JSX text. Carry it as
+		// one unit while matching the parsed template/SSR DOM spelling and applying
+		// the same whole-script neutralization.
+		const content = normalizeStaticScriptDescriptorContent(authoredStaticScriptContent);
+		if (content !== '') {
+			args.push({ type: 'Literal', value: content });
 		}
 	} else {
 		for (const child of node.children || []) {

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -448,6 +448,34 @@ function hasSemanticJsxChildren(children) {
 	return semanticJsxChildCount(children) > 0;
 }
 
+// @tsrx/core keeps an authored <script> body as verbatim raw text on
+// `element.content`. Braces inside that string are JavaScript/JSON source, not
+// JSX expression containers. An empty explicitly closed body is semantically
+// absent, while whitespace is real script content and therefore owns the child
+// position over an earlier `children=` attribute or spread.
+function staticScriptContent(node, tag) {
+	return tag === 'script' && typeof node.content === 'string' ? node.content : undefined;
+}
+
+function hasStaticScriptBody(node, tag) {
+	const content = staticScriptContent(node, tag);
+	return content !== undefined && content.length > 0;
+}
+
+// Static script source must not pass through generic HTML text escaping: entity
+// references are not decoded in the HTML script-data state. Neutralize only a
+// case-insensitive opening/closing script token so the surrounding template or
+// SSR document cannot be terminated early; the JavaScript/JSON escape preserves
+// the value's meaning.
+const INLINE_SCRIPT_TOKEN = /(<\/|<)(s)(cript)/gi;
+
+function escapeInlineScriptContent(value) {
+	return value.replace(
+		INLINE_SCRIPT_TOKEN,
+		(_match, prefix, s, suffix) => `${prefix}${s === 's' ? '\\u0073' : '\\u0053'}${suffix}`,
+	);
+}
+
 function hasDefinitelyNonNullishJsxChild(children, knownStringLocals) {
 	for (const child of children || []) {
 		if (!child) continue;
@@ -485,11 +513,13 @@ function hasDefinitelyNonNullishJsxChild(children, knownStringLocals) {
 	return false;
 }
 
-function rejectDangerouslySetInnerHTMLChildren(_tag, node, ctx) {
+function rejectDangerouslySetInnerHTMLChildren(tag, node, ctx) {
 	if (!hasDefinitelyPresentDirectDangerouslySetInnerHTML(node)) return;
-	const hasNestedChildren = hasSemanticJsxChildren(node.children || []);
+	const hasRawScriptBody = hasStaticScriptBody(node, tag);
+	const hasNestedChildren = hasRawScriptBody || hasSemanticJsxChildren(node.children || []);
 	if (
 		(hasNestedChildren || !hasDefinitelyPresentDirectChildrenProp(node)) &&
+		!hasRawScriptBody &&
 		!hasDefinitelyNonNullishJsxChild(node.children || [], ctx.knownStringLocals)
 	)
 		return;
@@ -5884,6 +5914,9 @@ function ssrEmitNode(
 
 function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash, componentNs) {
 	const tag = elementTagName(node);
+	const authoredStaticScriptContent = staticScriptContent(node, tag);
+	const hasAuthoredStaticScriptBody =
+		authoredStaticScriptContent !== undefined && authoredStaticScriptContent.length > 0;
 	rejectVoidElementContent(tag, node, ctx);
 	rejectTextareaValueChildren(tag, node, ctx);
 	rejectDangerouslySetInnerHTMLChildren(tag, node, ctx);
@@ -6367,13 +6400,15 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash, compone
 	}
 
 	if (tag !== 'option') lit += '>'; // option: ssrOption assembles the tag (attrs-only here)
-	const normChildren = normalizeChildren(node.children || [], childNs === 'svg');
-	const hasNestedChildren = normChildren.length > 0;
+	const normChildren =
+		authoredStaticScriptContent === undefined
+			? normalizeChildren(node.children || [], childNs === 'svg')
+			: [];
+	const hasNestedChildren = hasAuthoredStaticScriptBody || normChildren.length > 0;
 	const effectiveChildrenPropSources = hasNestedChildren ? [] : childrenPropSources;
-	const definitelyHasDangerChild = hasDefinitelyNonNullishJsxChild(
-		node.children || [],
-		ctx.knownStringLocals,
-	);
+	const definitelyHasDangerChild =
+		hasDefinitelyNonNullishJsxChild(node.children || [], ctx.knownStringLocals) ||
+		hasAuthoredStaticScriptBody;
 	// Only-child renderable `{expr}` → markerless `ssrChildText` (mirrors the client's
 	// markerless `childTextHole` mount: a primitive is the host's bare text, an object
 	// still gets a `<!--[-->…<!--]-->` block). Must match the client's only-child
@@ -6383,7 +6418,10 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash, compone
 	const onlyChild0 =
 		normChildren.length === 1 && normChildren[0].type === 'Text' ? normChildren[0] : null;
 	let childrenExpr;
-	if (
+	if (authoredStaticScriptContent !== undefined) {
+		const content = escapeInlineScriptContent(authoredStaticScriptContent);
+		childrenExpr = content === '' ? "''" : JSON.stringify(content);
+	} else if (
 		htmlSources.length === 0 &&
 		onlyChild0 !== null &&
 		staticTextLiteral(onlyChild0.expression) === null &&
@@ -11313,12 +11351,13 @@ function jsxNameToExpr(name) {
 function jsxElementToCreateElement(node, ctx) {
 	ctx.runtimeNeeded.add('createElement');
 	const nameNode = node.openingElement?.name || node.id;
+	const componentTag = isComponentTag(node);
 	// Host (lowercase) tag → string literal (`'li'`) for the de-opt renderer;
 	// component (capitalized / member / dynamic) → the identifier/member ref.
-	const compNode = isComponentTag(node)
+	const compNode = componentTag
 		? jsxNameToExpr(nameNode)
 		: { type: 'Literal', value: nameNode.name != null ? nameNode.name : String(nameNode) };
-	if (!isComponentTag(node)) {
+	if (!componentTag) {
 		rejectVoidElementContent(compNode.value, node, ctx);
 		rejectDangerouslySetInnerHTMLChildren(compNode.value, node, ctx);
 	}
@@ -11355,7 +11394,7 @@ function jsxElementToCreateElement(node, ctx) {
 			computed: false,
 		});
 	}
-	if (ctx.dev && !isComponentTag(node)) {
+	if (ctx.dev && !componentTag) {
 		const classification = ctx.nativeChangeClassifications?.get(
 			node.start ?? node.openingElement?.start,
 		);
@@ -11378,13 +11417,24 @@ function jsxElementToCreateElement(node, ctx) {
 	// Children → trailing `createElement(type, props, ...children)` args, each
 	// lowered recursively (host child → createElement, `{expr}` → expr, text →
 	// string). The runtime collects these into `descriptor.children`.
-	const opaqueChildren = isComponentTag(node);
-	for (const child of node.children || []) {
-		const lowered = lowerJsxChild(
-			opaqueChildren ? rewriteOpaqueTitles(child, ctx, 'opaque') : child,
-			ctx,
-		);
-		if (lowered !== null) args.push(lowered);
+	const authoredStaticScriptContent = componentTag
+		? undefined
+		: staticScriptContent(node, compNode.value);
+	if (authoredStaticScriptContent !== undefined) {
+		// Raw script-data is one authored body, not ordinary JSX text. Preserve
+		// whitespace verbatim and let the client/server descriptor renderers own
+		// their respective whole-script safety paths.
+		if (authoredStaticScriptContent !== '') {
+			args.push({ type: 'Literal', value: authoredStaticScriptContent });
+		}
+	} else {
+		for (const child of node.children || []) {
+			const lowered = lowerJsxChild(
+				componentTag ? rewriteOpaqueTitles(child, ctx, 'opaque') : child,
+				ctx,
+			);
+			if (lowered !== null) args.push(lowered);
+		}
 	}
 	return {
 		type: 'CallExpression',
@@ -12016,7 +12066,7 @@ function normalizeChildren(nodes, inSvg = false) {
 				out.push({ type: 'HeadHoist', element: n });
 				continue;
 			}
-			out.push({
+			const element = {
 				type: 'Element',
 				id: n.openingElement.name,
 				attributes: n.openingElement.attributes || [],
@@ -12024,7 +12074,13 @@ function normalizeChildren(nodes, inSvg = false) {
 				children: n.children || [],
 				selfClosing: n.openingElement.selfClosing,
 				loc: n.loc, // preserve element position for dev hydration LOC (component slots)
-			});
+			};
+			// Preserve @tsrx/core's raw-text script discriminator without changing
+			// the normalized object shape of every ordinary element.
+			if (elementTagName(element) === 'script' && typeof n.content === 'string') {
+				element.content = n.content;
+			}
+			out.push(element);
 		} else if (n.type === 'Tsx' || n.type === 'Tsrx' || n.type === 'JSXFragment') {
 			out.push(...normalizeChildren(n.children || [], inSvg));
 		} else if (n.type === 'JSXStyleElement') {
@@ -14234,6 +14290,9 @@ function emitElementHtml(
 
 	const tag = node.id?.name || node.openingElement?.name?.name;
 	if (!tag) throw new Error('Element without tag');
+	const authoredStaticScriptContent = staticScriptContent(node, tag);
+	const hasAuthoredStaticScriptBody =
+		authoredStaticScriptContent !== undefined && authoredStaticScriptContent.length > 0;
 	rejectVoidElementContent(tag, node, ctx);
 	rejectTextareaValueChildren(tag, node, ctx);
 	rejectDangerouslySetInnerHTMLChildren(tag, node, ctx);
@@ -14251,9 +14310,11 @@ function emitElementHtml(
 	// preceding binding just adopted/applied.
 	const potentialDangerouslySetInnerHTML = hasPotentialDangerouslySetInnerHTML(node);
 	const sourceChildren =
-		potentialDangerouslySetInnerHTML && hasOnlyDefinitelyNullishJsxChildren(node.children || [])
+		authoredStaticScriptContent !== undefined
 			? []
-			: node.children || [];
+			: potentialDangerouslySetInnerHTML && hasOnlyDefinitelyNullishJsxChildren(node.children || [])
+				? []
+				: node.children || [];
 	// React convention: later attributes win on collision. If ANY spread is
 	// present, attributes that come AFTER the first spread can't be inlined
 	// into the template HTML (the spread would clobber them at runtime) —
@@ -14290,7 +14351,8 @@ function emitElementHtml(
 	const hostClientSources = [];
 	let directChildrenClientBinding = null;
 	let hostCommitClientBinding = null;
-	const hasNestedJsxChildren = normalizeChildren(node.children || [], childNs === 'svg').length > 0;
+	const hasNestedJsxChildren =
+		hasAuthoredStaticScriptBody || normalizeChildren(sourceChildren, childNs === 'svg').length > 0;
 	const resolveDangerouslySetInnerHTMLAcrossSpreads = firstSpreadIdx !== -1;
 	const dangerHtmlClientSources = [];
 	const resolveFormControlsAcrossSpreads =
@@ -14850,6 +14912,9 @@ function emitElementHtml(
 
 	const isVoid = VOID_ELEMENTS.has(tag);
 	let html = isVoid ? `<${tag}${attrHtml}/>` : `<${tag}${attrHtml}>`;
+	if (authoredStaticScriptContent !== undefined) {
+		html += escapeInlineScriptContent(authoredStaticScriptContent);
+	}
 
 	const children = normalizeChildren(sourceChildren, childNs === 'svg');
 	// Special case: a single Text child (only-child text fast path).
@@ -15197,7 +15262,8 @@ function emitElementHtml(
 	}
 	if (
 		potentialDangerouslySetInnerHTML &&
-		hasDefinitelyNonNullishJsxChild(node.children || [], ctx.knownStringLocals)
+		(hasAuthoredStaticScriptBody ||
+			hasDefinitelyNonNullishJsxChild(node.children || [], ctx.knownStringLocals))
 	) {
 		bindings.push({
 			id: bindings.length,

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -1203,26 +1203,35 @@ function ssrHostElement(
 		} else if (rawInner !== undefined) {
 			inner = rawInner;
 		} else if (hasChildren) {
-			// A de-opt host whose children contain COMPONENTS renders those children on the
-			// client through `hostElementBody` → `childSlot` (a Block path that ADOPTS markers
-			// on hydration), so they must carry the full childSlot/block marker structure —
-			// emit them via `ssrChild` (the server analogue of childSlot). Pure host/text
-			// children are rebuilt by the client de-opt reconciler, so they stay as plain
-			// marker-less markup via `ssrDescriptorContent`.
-			const build = () =>
-				ssrInNamespace(childrenNamespace, () =>
-					iterableChildren || serverDescNeedsBlocks(children)
-						? ssrDeoptBlockChildren(children, scope)
-						: ssrDescriptorContent(children, scope),
-				);
-			// A controlled <select> projects `selected` onto the options serialized
-			// inside its children (compiled options included — the scope is global).
-			inner =
-				semanticTag === 'select' &&
-				props != null &&
-				(props.value != null || props.defaultValue != null)
-					? ssrSelectScope(props.value, props.defaultValue, !!props.multiple, build)
-					: build();
+			// Script-data does not decode HTML entities. A compiler-generated host
+			// descriptor therefore needs the same whole-body serializer as the direct
+			// template path. Join primitive arrays before escaping so a breakout token
+			// split across adjacent children cannot evade the boundary guard.
+			const scriptText = semanticTag === 'script' ? scriptDescriptorText(children) : null;
+			if (scriptText !== null) {
+				inner = escapeEntireInlineScriptContent(scriptText);
+			} else {
+				// A de-opt host whose children contain COMPONENTS renders those children on the
+				// client through `hostElementBody` → `childSlot` (a Block path that ADOPTS markers
+				// on hydration), so they must carry the full childSlot/block marker structure —
+				// emit them via `ssrChild` (the server analogue of childSlot). Pure host/text
+				// children are rebuilt by the client de-opt reconciler, so they stay as plain
+				// marker-less markup via `ssrDescriptorContent`.
+				const build = () =>
+					ssrInNamespace(childrenNamespace, () =>
+						iterableChildren || serverDescNeedsBlocks(children)
+							? ssrDeoptBlockChildren(children, scope)
+							: ssrDescriptorContent(children, scope),
+					);
+				// A controlled <select> projects `selected` onto the options serialized
+				// inside its children (compiled options included — the scope is global).
+				inner =
+					semanticTag === 'select' &&
+					props != null &&
+					(props.value != null || props.defaultValue != null)
+						? ssrSelectScope(props.value, props.defaultValue, !!props.multiple, build)
+						: build();
+			}
 		}
 		// <option> assembles via ssrOption so an active select scope can mark it
 		// ` selected` (its value prop already serialized as a plain attribute).
@@ -1298,6 +1307,25 @@ function serverDescNeedsBlocks(v: unknown): boolean {
 		return typeof d.type === 'function' || serverDescNeedsBlocks(d.children);
 	}
 	return false;
+}
+
+// Return one complete script-data string when a host descriptor contains only
+// primitive text children. `null` means the descriptor needs the ordinary
+// renderable-child path. This mirrors ssrDescriptorContent's primitive coercion
+// and empty handling without serializing HTML entities into script data.
+function scriptDescriptorText(v: unknown): string | null {
+	if (v == null || v === false || v === true || v === '') return '';
+	if (Array.isArray(v)) {
+		let out = '';
+		for (let i = 0; i < v.length; i++) {
+			const part = scriptDescriptorText(v[i]);
+			if (part === null) return null;
+			out += part;
+		}
+		return out;
+	}
+	if (typeof v === 'object' || typeof v === 'function') return null;
+	return String(v);
 }
 
 // Serialize the CONTENT inside a host descriptor (a `createElement(...)` child

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -8021,9 +8021,9 @@ export function setScriptText(el: Element, value: any): void {
 }
 
 // SSR replaces only the `s` in case-insensitive opening/closing script tokens.
-// Hydration compares against that serialized spelling after the same HTML parser
-// normalization as the server markup; later client updates use textContent
-// directly and therefore need no escape.
+// Hydration compares against that serialized spelling after the script-data
+// input normalization applied to server markup; later client updates use
+// textContent directly and therefore need no escape.
 const INLINE_SCRIPT_TOKEN = /(<\/|<)(s)(cript)/gi;
 
 function escapeInlineScriptContentForHydration(value: string): string {
@@ -8031,6 +8031,17 @@ function escapeInlineScriptContentForHydration(value: string): string {
 		INLINE_SCRIPT_TOKEN,
 		(_match, prefix: string, s: string, suffix: string) =>
 			`${prefix}${s === 's' ? '\\u0073' : '\\u0053'}${suffix}`,
+	);
+}
+
+// Unlike ordinary HTML data, script-data preserves character references such as
+// `&amp;` verbatim. Normalize only the input-stream transformations that affect a
+// parsed script Text node: CRLF/CR become LF and NUL becomes U+FFFD.
+const SCRIPT_DATA_NORMALIZATION = /\r\n?|\u0000/g;
+
+function normalizeScriptTextForHydration(value: string): string {
+	return value.replace(SCRIPT_DATA_NORMALIZATION, (match) =>
+		match === '\u0000' ? '\uFFFD' : '\n',
 	);
 }
 
@@ -8056,7 +8067,7 @@ export function setHTML(el: Element, value: any): void {
 		const server = el.localName === 'script' ? (el.textContent ?? '') : el.innerHTML;
 		const expected =
 			el.localName === 'script'
-				? normalizeHTMLForHydration(el, escapeInlineScriptContentForHydration(next))
+				? normalizeScriptTextForHydration(escapeInlineScriptContentForHydration(next))
 				: normalizeHTMLForHydration(el, next);
 		if (server === expected || isHydrationSuppressed(el)) return;
 		warnHydrationKeptServerValue(

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -8020,6 +8020,20 @@ export function setScriptText(el: Element, value: any): void {
 	el.textContent = value == null ? '' : String(value);
 }
 
+// SSR replaces only the `s` in case-insensitive opening/closing script tokens.
+// Hydration compares against that serialized spelling after the same HTML parser
+// normalization as the server markup; later client updates use textContent
+// directly and therefore need no escape.
+const INLINE_SCRIPT_TOKEN = /(<\/|<)(s)(cript)/gi;
+
+function escapeInlineScriptContentForHydration(value: string): string {
+	return value.replace(
+		INLINE_SCRIPT_TOKEN,
+		(_match, prefix: string, s: string, suffix: string) =>
+			`${prefix}${s === 's' ? '\\u0073' : '\\u0053'}${suffix}`,
+	);
+}
+
 /** Parse raw HTML in its authored host context for hydration comparison. */
 function normalizeHTMLForHydration(parent: Element, html: string): string {
 	// Match React's comparison boundary: the browser canonicalizes equivalent
@@ -8040,7 +8054,10 @@ export function setHTML(el: Element, value: any): void {
 	const hydration = activeHydration();
 	if (hydration !== null && !hydration.isFresh(el)) {
 		const server = el.localName === 'script' ? (el.textContent ?? '') : el.innerHTML;
-		const expected = el.localName === 'script' ? next : normalizeHTMLForHydration(el, next);
+		const expected =
+			el.localName === 'script'
+				? normalizeHTMLForHydration(el, escapeInlineScriptContentForHydration(next))
+				: normalizeHTMLForHydration(el, next);
 		if (server === expected || isHydrationSuppressed(el)) return;
 		warnHydrationKeptServerValue(
 			(el as any).__oct_loc,

--- a/packages/octane/tests/_fixtures/script-innerhtml.tsrx
+++ b/packages/octane/tests/_fixtures/script-innerhtml.tsrx
@@ -1,0 +1,79 @@
+export interface ScriptSourceProps {
+	source: string;
+}
+
+export interface ScriptValueProps {
+	value: unknown;
+}
+
+export interface ScriptDangerProps {
+	danger: { __html: string } | null;
+}
+
+export interface ScriptSpreadProps {
+	spread: { dangerouslySetInnerHTML?: { __html: string } | null };
+}
+
+export function ExecutableScript(props: ScriptSourceProps) @{
+	<script data-kind="executable" dangerouslySetInnerHTML={{ __html: props.source }} />
+}
+
+export function JsonScript(props: ScriptValueProps) @{
+	<script
+		type="application/json"
+		data-kind="application-json"
+		dangerouslySetInnerHTML={{ __html: JSON.stringify(props.value) }}
+	/>
+}
+
+export function SpeculationRules(props: ScriptValueProps) @{
+	<script
+		type="speculationrules"
+		data-kind="speculationrules"
+		dangerouslySetInnerHTML={{ __html: JSON.stringify(props.value) }}
+	/>
+}
+
+export function StaticScript() @{
+	<script type="text/plain" data-kind="static">
+		function compare(left, right) {
+			if (left < right) {
+				return { result: { less: true }, chars: '&"\'' };
+			}
+		}
+	</script>
+}
+
+export function StaticJsonScript() @{
+	// prettier-ignore
+	<script type="application/json" data-kind="static-json">{"nested":{"enabled":true},"chars":"<&\"'","boundary":"</ScRiPt><ScRiPt data-pwn=\"static\">bad</ScRiPt>"}</script>
+}
+
+export function ConditionalStaticJsonScript(props: { show: boolean }) @{
+	// prettier-ignore
+	<section>{props.show && <script type="application/json" data-kind="conditional-static-json">{"nested":{"enabled":true},"chars":"<&\"'","boundary":"</ScRiPt><ScRiPt data-pwn=\"static\">bad</ScRiPt>"}</script>}</section>
+}
+
+export function AuthoredExpressionScript(props: ScriptValueProps) @{
+	// prettier-ignore
+	<script type="speculationrules" data-kind="authored-expression">
+		{JSON.stringify(props.value) as string}
+	</script>
+}
+
+export function WhitespaceDirectScript(props: ScriptDangerProps) @{
+	// prettier-ignore
+	<script data-kind="whitespace-direct" dangerouslySetInnerHTML={props.danger}> </script>
+}
+
+export function WhitespaceSpreadScript(props: ScriptSpreadProps) @{
+	// prettier-ignore
+	<script data-kind="whitespace-spread" {...props.spread}> </script>
+}
+
+export function ConditionalWhitespaceScript(props: { show: boolean }) @{
+	// prettier-ignore
+	<section>{props.show && <script data-kind="conditional-whitespace">
+
+	</script>}</section>
+}

--- a/packages/octane/tests/_server-fixture.ts
+++ b/packages/octane/tests/_server-fixture.ts
@@ -1,16 +1,18 @@
 /**
- * Shared loader for executing a real fixture through Octane's server compiler.
+ * Shared loader for executing Octane compiler output in tests.
  *
- * Client fixtures should be imported normally through Vitest. This helper owns
- * the one unavoidable server-module evaluation boundary so SSR, streaming, and
- * hydration tests do not duplicate generated-import/export rewriting.
+ * Real client fixtures should normally be imported through Vitest. Tests that
+ * require source bytes which cannot live in a formatted fixture may use the
+ * source loader below. This module owns the generated import/export rewriting
+ * and the one unavoidable `new Function` boundary.
  */
 import { readFileSync } from 'node:fs';
 import { isAbsolute, relative, resolve, sep } from 'node:path';
 import { compile } from 'octane/compiler';
 import * as ServerRuntime from 'octane/server';
+import * as ClientRuntime from '../src/index.js';
 
-export type ServerFixtureModule = Record<string, any>;
+export type CompiledFixtureModule = Record<string, any>;
 
 export interface ServerFixtureOptions {
 	/** Compiler module id. Defaults to the root-relative fixture path. */
@@ -19,27 +21,30 @@ export interface ServerFixtureOptions {
 	compileOptions?: Record<string, unknown>;
 }
 
-export function loadServerFixture<T extends ServerFixtureModule = ServerFixtureModule>(
-	fixture: string,
-	options: ServerFixtureOptions = {},
+export interface CompiledFixtureSourceOptions {
+	/** Compiler module id used for diagnostics and source locations. */
+	id: string;
+	mode: 'client' | 'server';
+	/** Additional public compiler options; `mode` is always enforced. */
+	compileOptions?: Record<string, unknown>;
+}
+
+export function loadCompiledFixtureSource<T extends CompiledFixtureModule = CompiledFixtureModule>(
+	source: string,
+	options: CompiledFixtureSourceOptions,
 ): T {
-	const absolute = isAbsolute(fixture) ? fixture : resolve(process.cwd(), fixture);
-	const defaultId = '/' + relative(process.cwd(), absolute).split(sep).join('/');
-	let { code } = compile(readFileSync(absolute, 'utf8'), options.id ?? defaultId, {
+	const { id, mode } = options;
+	let { code } = compile(source, id, {
 		...options.compileOptions,
-		mode: 'server',
+		mode,
 	});
 
-	// Server compilation retargets Octane API imports to `octane/server`.
-	// Bind that generated import to the real public runtime supplied below.
+	const runtime = mode === 'server' ? ServerRuntime : ClientRuntime;
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane(?:\/server)?['"];?/g,
-		(_match: string, names: string) =>
-			`const {${names.replace(/\s+as\s+/g, ': ')}} = __serverRuntime;`,
+		(_match: string, names: string) => `const {${names.replace(/\s+as\s+/g, ': ')}} = __runtime;`,
 	);
 
-	// Fixtures are authored as normal ESM. Publish named declarations onto a
-	// result object while keeping the compiler output otherwise executable.
 	code = code.replace(
 		/export\s+(async\s+)?function\s+(\w+)/g,
 		(_match: string, asyncKeyword: string | undefined, name: string) =>
@@ -53,16 +58,27 @@ export function loadServerFixture<T extends ServerFixtureModule = ServerFixtureM
 
 	if (/^\s*import\s/m.test(code) || /^\s*export\s/m.test(code)) {
 		throw new Error(
-			`Server fixture ${fixture} contains an import/export shape the shared loader cannot evaluate.`,
+			`Compiled fixture ${id} contains an import/export shape the shared loader cannot evaluate.`,
 		);
 	}
 
 	const evaluate = new Function(
-		'__serverRuntime',
+		'__runtime',
 		'__exports',
-		`'use strict';\n` +
-			code +
-			`\n//# sourceURL=${options.id ?? defaultId}?server-fixture\nreturn __exports;`,
+		`'use strict';\n${code}\n//# sourceURL=${id}?${mode}-fixture\nreturn __exports;`,
 	);
-	return evaluate(ServerRuntime, {}) as T;
+	return evaluate(runtime, {}) as T;
+}
+
+export function loadServerFixture<T extends CompiledFixtureModule = CompiledFixtureModule>(
+	fixture: string,
+	options: ServerFixtureOptions = {},
+): T {
+	const absolute = isAbsolute(fixture) ? fixture : resolve(process.cwd(), fixture);
+	const defaultId = '/' + relative(process.cwd(), absolute).split(sep).join('/');
+	return loadCompiledFixtureSource<T>(readFileSync(absolute, 'utf8'), {
+		id: options.id ?? defaultId,
+		mode: 'server',
+		compileOptions: options.compileOptions,
+	});
 }

--- a/packages/octane/tests/script-innerhtml.test.ts
+++ b/packages/octane/tests/script-innerhtml.test.ts
@@ -1,0 +1,297 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import * as ServerRuntime from 'octane/server';
+import { flushSync, hydrateRoot } from '../src/index.js';
+import { loadServerFixture } from './_server-fixture.js';
+import { mount } from './_helpers.js';
+import * as client from './_fixtures/script-innerhtml.tsrx';
+
+const FIXTURE = 'packages/octane/tests/_fixtures/script-innerhtml.tsrx';
+const FIXTURE_SOURCE = readFileSync(resolve(process.cwd(), FIXTURE), 'utf8');
+const server = loadServerFixture(FIXTURE);
+const DANGER_CONFLICT = /Can only set one of `children` or `props\.dangerouslySetInnerHTML`/;
+
+const BREAKOUT_VALUE = {
+	lessThan: '<',
+	ampersand: '&',
+	quotes: `"'`,
+	separators: '\u2028\u2029',
+	lowercase: '</script><script data-pwn="lower">bad</script>',
+	mixedCase: '</ScRiPt><ScRiPt data-pwn="mixed">bad</ScRiPt>',
+};
+
+const EXECUTABLE_SOURCE = `window.__octaneScriptValue = ${JSON.stringify(BREAKOUT_VALUE)};`;
+
+const STATIC_JSON_VALUE = {
+	nested: { enabled: true },
+	chars: `<&"'`,
+	boundary: '</ScRiPt><ScRiPt data-pwn="static">bad</ScRiPt>',
+};
+
+const SPLIT_DESCRIPTOR_VALUE = {
+	boundary: '</script><script data-pwn="split">bad</script>',
+};
+
+const SPLIT_DESCRIPTOR_CHILDREN = [
+	'{"boundary":"</scr',
+	'ipt><scr',
+	'ipt data-pwn=\\"split\\">bad</scr',
+	'ipt>"}',
+];
+
+function parseFragment(html: string): DocumentFragment {
+	const template = document.createElement('template');
+	template.innerHTML = html;
+	return template.content;
+}
+
+function authoredScriptBody(kind: string): string {
+	const markerStart = FIXTURE_SOURCE.indexOf(`data-kind="${kind}"`);
+	const bodyStart = FIXTURE_SOURCE.indexOf('>', markerStart) + 1;
+	const bodyEnd = FIXTURE_SOURCE.indexOf('</script>', bodyStart);
+	return FIXTURE_SOURCE.slice(bodyStart, bodyEnd);
+}
+
+describe('<script> content contract', () => {
+	it('mounts and updates executable, application/json, and speculationrules content without parsing it as markup', () => {
+		const executable = mount(client.ExecutableScript, { source: EXECUTABLE_SOURCE });
+		const json = mount(client.JsonScript, { value: BREAKOUT_VALUE });
+		const speculation = mount(client.SpeculationRules, {
+			value: { prefetch: [{ source: 'list' }] },
+		});
+		try {
+			const executableNode = executable.find('script');
+			expect(executable.findAll('script')).toHaveLength(1);
+			expect(executable.container.querySelector('[data-pwn]')).toBeNull();
+			expect(executableNode.textContent).toBe(EXECUTABLE_SOURCE);
+
+			const jsonNode = json.find('script');
+			expect(jsonNode.getAttribute('type')).toBe('application/json');
+			expect(json.container.querySelector('[data-pwn]')).toBeNull();
+			expect(JSON.parse(jsonNode.textContent ?? '')).toEqual(BREAKOUT_VALUE);
+
+			const speculationNode = speculation.find('script');
+			expect(speculationNode.getAttribute('type')).toBe('speculationrules');
+			expect(JSON.parse(speculationNode.textContent ?? '')).toEqual({
+				prefetch: [{ source: 'list' }],
+			});
+
+			const next = { prefetch: [{ source: 'document', where: { href_matches: '/next/*' } }] };
+			speculation.update(client.SpeculationRules, { value: next });
+			expect(speculation.find('script')).toBe(speculationNode);
+			expect(JSON.parse(speculationNode.textContent ?? '')).toEqual(next);
+		} finally {
+			executable.unmount();
+			json.unmount();
+			speculation.unmount();
+		}
+	});
+
+	it('serializes dynamic script content as one safe, semantically intact script body', () => {
+		for (const [component, props] of [
+			[server.ExecutableScript, { source: EXECUTABLE_SOURCE }],
+			[server.JsonScript, { value: BREAKOUT_VALUE }],
+			[server.SpeculationRules, { value: BREAKOUT_VALUE }],
+		] as const) {
+			const { html } = ServerRuntime.renderToString(component, props);
+			const fragment = parseFragment(html);
+			const scripts = fragment.querySelectorAll('script');
+			expect(scripts).toHaveLength(1);
+			expect(fragment.querySelector('[data-pwn]')).toBeNull();
+			expect(scripts[0].textContent).toContain('<');
+			expect(scripts[0].textContent).toContain('&');
+			expect(scripts[0].textContent).toContain(`"'`);
+			expect(scripts[0].textContent).toContain('\u2028\u2029');
+			if (scripts[0].getAttribute('type') === null) {
+				const isolatedWindow: { __octaneScriptValue?: unknown } = {};
+				new Function('window', scripts[0].textContent ?? '')(isolatedWindow);
+				expect(isolatedWindow.__octaneScriptValue).toEqual(BREAKOUT_VALUE);
+			} else {
+				expect(JSON.parse(scripts[0].textContent ?? '')).toEqual(BREAKOUT_VALUE);
+			}
+		}
+	});
+
+	it('hydrates the server-safe script spelling by adoption and applies later updates', () => {
+		const { html } = ServerRuntime.renderToString(server.SpeculationRules, {
+			value: BREAKOUT_VALUE,
+		});
+		const container = document.createElement('div');
+		container.innerHTML = html;
+		document.body.appendChild(container);
+		const serverNode = container.querySelector('script');
+		const warning = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const root = hydrateRoot(container, client.SpeculationRules, { value: BREAKOUT_VALUE });
+		try {
+			flushSync(() => {});
+			expect(container.querySelector('script')).toBe(serverNode);
+			expect(JSON.parse(serverNode?.textContent ?? '')).toEqual(BREAKOUT_VALUE);
+			expect(warning).not.toHaveBeenCalled();
+
+			const next = { value: '</script><script data-pwn="updated">bad</script>' };
+			flushSync(() => root.render(client.SpeculationRules, { value: next }));
+			expect(container.querySelector('script')).toBe(serverNode);
+			expect(container.querySelectorAll('script')).toHaveLength(1);
+			expect(container.querySelector('[data-pwn]')).toBeNull();
+			expect(serverNode?.textContent).toBe(JSON.stringify(next));
+		} finally {
+			root.unmount();
+			warning.mockRestore();
+			container.remove();
+		}
+	});
+
+	it('hydrates executable source after HTML parser line-ending normalization', () => {
+		const source = 'window.__first = 1;\r\nwindow.__boundary = "</ScRiPt>";\rwindow.__last = 2;';
+		const { html } = ServerRuntime.renderToString(server.ExecutableScript, { source });
+		const container = document.createElement('div');
+		container.innerHTML = html;
+		document.body.appendChild(container);
+		const serverNode = container.querySelector('script');
+		const warning = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const root = hydrateRoot(container, client.ExecutableScript, { source });
+		try {
+			flushSync(() => {});
+			expect(container.querySelector('script')).toBe(serverNode);
+			expect(serverNode?.textContent).not.toContain('\r');
+			expect(warning).not.toHaveBeenCalled();
+			const isolatedWindow: Record<string, unknown> = {};
+			new Function('window', serverNode?.textContent ?? '')(isolatedWindow);
+			expect(isolatedWindow).toMatchObject({
+				__first: 1,
+				__boundary: '</ScRiPt>',
+				__last: 2,
+			});
+		} finally {
+			root.unmount();
+			warning.mockRestore();
+			container.remove();
+		}
+	});
+
+	it('preserves an authored static script body as raw source', () => {
+		const expected = authoredScriptBody('static');
+		const mounted = mount(client.StaticScript);
+		try {
+			expect(mounted.find('script').textContent).toBe(expected);
+		} finally {
+			mounted.unmount();
+		}
+
+		const { html } = ServerRuntime.renderToString(server.StaticScript);
+		expect(parseFragment(html).querySelector('script')?.textContent).toBe(expected);
+	});
+
+	it('treats interpolation-looking braces as literal static script source', () => {
+		const expected = authoredScriptBody('authored-expression');
+		expect(expected).toContain('{JSON.stringify(props.value) as string}');
+		const mounted = mount(client.AuthoredExpressionScript, { value: { first: true } });
+		try {
+			const script = mounted.find('script');
+			expect(script.textContent).toBe(expected);
+			mounted.update(client.AuthoredExpressionScript, { value: { second: true } });
+			expect(mounted.find('script')).toBe(script);
+			expect(script.textContent).toBe(expected);
+		} finally {
+			mounted.unmount();
+		}
+
+		for (const value of [{ first: true }, { second: true }]) {
+			const { html } = ServerRuntime.renderToString(server.AuthoredExpressionScript, { value });
+			expect(parseFragment(html).querySelector('script')?.textContent).toBe(expected);
+		}
+	});
+
+	it('treats whitespace in a static script body as content when validating raw HTML', () => {
+		const danger = { __html: 'dynamic' };
+		expect(() => mount(client.WhitespaceDirectScript, { danger })).toThrow(DANGER_CONFLICT);
+		const spread = mount(client.WhitespaceSpreadScript, { spread: {} });
+		try {
+			expect(() =>
+				spread.update(client.WhitespaceSpreadScript, {
+					spread: { dangerouslySetInnerHTML: danger },
+				}),
+			).toThrow(DANGER_CONFLICT);
+		} finally {
+			spread.unmount();
+		}
+		expect(() => ServerRuntime.renderToString(server.WhitespaceDirectScript, { danger })).toThrow(
+			DANGER_CONFLICT,
+		);
+		expect(() =>
+			ServerRuntime.renderToString(server.WhitespaceSpreadScript, {
+				spread: { dangerouslySetInnerHTML: danger },
+			}),
+		).toThrow(DANGER_CONFLICT);
+	});
+
+	it('keeps static JSON boundary tokens inside the authored script element', () => {
+		const mounted = mount(client.StaticJsonScript);
+		try {
+			expect(mounted.findAll('script')).toHaveLength(1);
+			expect(mounted.container.querySelector('[data-pwn]')).toBeNull();
+			expect(JSON.parse(mounted.find('script').textContent ?? '')).toEqual(STATIC_JSON_VALUE);
+		} finally {
+			mounted.unmount();
+		}
+
+		const { html } = ServerRuntime.renderToString(server.StaticJsonScript);
+		const fragment = parseFragment(html);
+		expect(fragment.querySelectorAll('script')).toHaveLength(1);
+		expect(fragment.querySelector('[data-pwn]')).toBeNull();
+		expect(JSON.parse(fragment.querySelector('script')?.textContent ?? '')).toEqual(
+			STATIC_JSON_VALUE,
+		);
+	});
+
+	it('preserves static script text when JSX lowers through a value-position descriptor', () => {
+		const mounted = mount(client.ConditionalStaticJsonScript, { show: true });
+		try {
+			expect(mounted.findAll('script')).toHaveLength(1);
+			expect(mounted.container.querySelector('[data-pwn]')).toBeNull();
+			expect(JSON.parse(mounted.find('script').textContent ?? '')).toEqual(STATIC_JSON_VALUE);
+		} finally {
+			mounted.unmount();
+		}
+
+		const { html } = ServerRuntime.renderToString(server.ConditionalStaticJsonScript, {
+			show: true,
+		});
+		const fragment = parseFragment(html);
+		expect(fragment.querySelectorAll('script')).toHaveLength(1);
+		expect(fragment.querySelector('[data-pwn]')).toBeNull();
+		expect(JSON.parse(fragment.querySelector('script')?.textContent ?? '')).toEqual(
+			STATIC_JSON_VALUE,
+		);
+
+		const whitespaceExpected = authoredScriptBody('conditional-whitespace');
+		expect(whitespaceExpected).toContain('\n');
+		expect(whitespaceExpected.trim()).toBe('');
+		const whitespace = mount(client.ConditionalWhitespaceScript, { show: true });
+		try {
+			expect(whitespace.find('script').textContent).toBe(whitespaceExpected);
+		} finally {
+			whitespace.unmount();
+		}
+		const whitespaceHtml = ServerRuntime.renderToString(server.ConditionalWhitespaceScript, {
+			show: true,
+		}).html;
+		expect(parseFragment(whitespaceHtml).querySelector('script')?.textContent).toBe(
+			whitespaceExpected,
+		);
+
+		const SplitDescriptorScript = () =>
+			ServerRuntime.createElement(
+				'script',
+				{ type: 'application/json' },
+				...SPLIT_DESCRIPTOR_CHILDREN,
+			);
+		const split = parseFragment(ServerRuntime.renderToString(SplitDescriptorScript).html);
+		expect(split.querySelectorAll('script')).toHaveLength(1);
+		expect(split.querySelector('[data-pwn]')).toBeNull();
+		expect(JSON.parse(split.querySelector('script')?.textContent ?? '')).toEqual(
+			SPLIT_DESCRIPTOR_VALUE,
+		);
+	});
+});

--- a/packages/octane/tests/script-innerhtml.test.ts
+++ b/packages/octane/tests/script-innerhtml.test.ts
@@ -142,8 +142,10 @@ describe('<script> content contract', () => {
 		}
 	});
 
-	it('hydrates executable source after HTML parser line-ending normalization', () => {
-		const source = 'window.__first = 1;\r\nwindow.__boundary = "</ScRiPt>";\rwindow.__last = 2;';
+	it('hydrates executable source after HTML script-data normalization', () => {
+		const source =
+			'/* nul:\u0000 */window.__first = 1;\r\nwindow.__boundary = "</ScRiPt>";\r' +
+			'window.__entities = "&amp;&lt;&quot;&#39;";\nwindow.__last = 2;';
 		const { html } = ServerRuntime.renderToString(server.ExecutableScript, { source });
 		const container = document.createElement('div');
 		container.innerHTML = html;
@@ -155,12 +157,15 @@ describe('<script> content contract', () => {
 			flushSync(() => {});
 			expect(container.querySelector('script')).toBe(serverNode);
 			expect(serverNode?.textContent).not.toContain('\r');
+			expect(serverNode?.textContent).not.toContain('\u0000');
+			expect(serverNode?.textContent).toContain('\uFFFD');
 			expect(warning).not.toHaveBeenCalled();
 			const isolatedWindow: Record<string, unknown> = {};
 			new Function('window', serverNode?.textContent ?? '')(isolatedWindow);
 			expect(isolatedWindow).toMatchObject({
 				__first: 1,
 				__boundary: '</ScRiPt>',
+				__entities: '&amp;&lt;&quot;&#39;',
 				__last: 2,
 			});
 		} finally {

--- a/packages/octane/tests/script-innerhtml.test.ts
+++ b/packages/octane/tests/script-innerhtml.test.ts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import * as ServerRuntime from 'octane/server';
 import { flushSync, hydrateRoot } from '../src/index.js';
-import { loadServerFixture } from './_server-fixture.js';
+import { loadCompiledFixtureSource, loadServerFixture } from './_server-fixture.js';
 import { mount } from './_helpers.js';
 import * as client from './_fixtures/script-innerhtml.tsrx';
 
@@ -248,6 +248,80 @@ describe('<script> content contract', () => {
 		expect(JSON.parse(fragment.querySelector('script')?.textContent ?? '')).toEqual(
 			STATIC_JSON_VALUE,
 		);
+	});
+
+	it('hydrates a value-position static script without rewriting its server-safe text', () => {
+		const { html } = ServerRuntime.renderToString(server.ConditionalStaticJsonScript, {
+			show: true,
+		});
+		const container = document.createElement('div');
+		container.innerHTML = html;
+		document.body.appendChild(container);
+		const serverNode = container.querySelector('script');
+		const serverText = serverNode?.textContent ?? '';
+		expect(JSON.parse(serverText)).toEqual(STATIC_JSON_VALUE);
+		const warning = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const root = hydrateRoot(container, client.ConditionalStaticJsonScript, { show: true });
+		try {
+			flushSync(() => {});
+			expect(container.querySelector('script')).toBe(serverNode);
+			expect(serverNode?.textContent).toBe(serverText);
+			expect(warning).not.toHaveBeenCalled();
+		} finally {
+			root.unmount();
+			warning.mockRestore();
+			container.remove();
+		}
+	});
+
+	it('normalizes static descriptor script text to the parsed HTML spelling', () => {
+		const source =
+			'export function NormalizedStaticScript(props: { show: boolean }) @{\n' +
+			'\t<section>{props.show && <script type="text/plain">first\r\nsecond\rthird\u0000fourth</script>}</section>\n' +
+			'}\n';
+		const compileOptions = {
+			dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod',
+			hmr: false,
+		};
+		const compiledClient = loadCompiledFixtureSource(source, {
+			id: '/inline-script-normalization.tsrx',
+			mode: 'client',
+			compileOptions,
+		});
+		const compiledServer = loadCompiledFixtureSource(source, {
+			id: '/inline-script-normalization.tsrx',
+			mode: 'server',
+			compileOptions,
+		});
+		const expected = 'first\nsecond\nthird\uFFFDfourth';
+
+		const mounted = mount(compiledClient.NormalizedStaticScript, { show: true });
+		try {
+			expect(mounted.find('script').textContent).toBe(expected);
+		} finally {
+			mounted.unmount();
+		}
+
+		const { html } = ServerRuntime.renderToString(compiledServer.NormalizedStaticScript, {
+			show: true,
+		});
+		const container = document.createElement('div');
+		container.innerHTML = html;
+		document.body.appendChild(container);
+		const serverNode = container.querySelector('script');
+		expect(serverNode?.textContent).toBe(expected);
+		const warning = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const root = hydrateRoot(container, compiledClient.NormalizedStaticScript, { show: true });
+		try {
+			flushSync(() => {});
+			expect(container.querySelector('script')).toBe(serverNode);
+			expect(serverNode?.textContent).toBe(expected);
+			expect(warning).not.toHaveBeenCalled();
+		} finally {
+			root.unmount();
+			warning.mockRestore();
+			container.remove();
+		}
 	});
 
 	it('preserves static script text when JSX lowers through a value-position descriptor', () => {


### PR DESCRIPTION
## Summary

- define raw `<script>...</script>` bodies as static script data, with braces kept as literal JavaScript/JSON source
- document `dangerouslySetInnerHTML={{ __html: ... }}` as the supported dynamic whole-script path
- preserve authored static script characters in direct templates and value-position descriptors
- keep client updates, buffered/streaming SSR, and hydration aligned while neutralizing case-insensitive opening/closing script tokens
- add a patch changeset and public-boundary regressions for executable scripts, `application/json`, and speculation rules

Addresses JS-01 from #211 only.

## Root cause

The current `@tsrx/core` parser exposes a complete script body as verbatim raw text rather than expression AST nodes. Octane therefore cannot safely recover an authored JSX expression from braces, which are also valid JavaScript syntax. In addition, static script data was passing through generic HTML text escaping even though HTML entities are not decoded in the script-data state.

This change makes that parser boundary an explicit language contract instead of attempting ambiguous regex recovery. Dynamic values use the existing attribute expression AST retained by `dangerouslySetInnerHTML`; client writes use `textContent`, while server output applies whole-script token neutralization. Hydration compares against the browser-normalized server spelling, including CRLF/CR normalization.

## Validation

- focused regression matrix: 12 files, 420 assertions across client dev/prod and server paths
- `./node_modules/.bin/tsgo --noEmit -p packages/octane/tsconfig.json`
- `pnpm --config.minimum-release-age=0 format:check`
- `pnpm --config.minimum-release-age=0 changeset:check`
- `git diff --check`

No dependency or lockfile changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches compiler SSR/client emission and hydration comparison for script elements—security-sensitive HTML boundary behavior—but changes are narrowly scoped with extensive regression tests and fail-closed validation.
> 
> **Overview**
> Defines how **`<script>`** bodies work in Octane: authored content is **verbatim script data** (braces stay literal JS/JSON, not TSRX interpolation), with **`dangerouslySetInnerHTML`** as the supported path for dynamic whole-script values. README documents static vs dynamic usage and the security boundary (token neutralization, not JS sanitization).
> 
> The **compiler** threads `@tsrx/core`’s `element.content` through normalization, SSR/client templates, and de-opt `createElement` paths: static bodies skip generic HTML escaping, only neutralize case-insensitive `</script` / `<script` tokens, and apply script-data line/NUL normalization so client and SSR spellings match. **`dangerouslySetInnerHTML` vs children** validation treats non-empty static script bodies (including whitespace-only) as real content.
> 
> **Server** joins primitive-only descriptor children before escaping so breakout tokens cannot straddle fragments. **Client hydration** for script `dangerouslySetInnerHTML` compares against the same escaped + normalized spelling the browser parsed from SSR, avoiding false mismatches while updates still use `textContent`.
> 
> Adds a patch changeset, **`loadCompiledFixtureSource`** for client/server compile tests, fixtures, and a broad regression suite (executable, JSON, speculation rules, static boundaries, hydration).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26107805d5b58da7f5fa044b339881b90f51c8c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->