### PR TITLE
Implement Lynx Milestone 6 first-screen adoption

### DIFF
--- a/.changeset/layered-universal-rspack.md
+++ b/.changeset/layered-universal-rspack.md
@@ -1,0 +1,13 @@
+---
+'@octanejs/rspack-plugin': patch
+'octane': patch
+---
+
+Add Rspack layer specializations for renderer configuration, universal runtime
+identity, and exact runtime aliases. Include every specialized renderer graph
+in dependency discovery and persistent-cache identity.
+
+Allow universal renderers to declare first-screen event prop patterns and opt
+into main-thread render-only compilation that erases background-owned effect
+and ref callbacks and replaces event closures with lightweight listener
+sentinels.

--- a/docs/lynx-native-renderer-plan.md
+++ b/docs/lynx-native-renderer-plan.md
@@ -1,6 +1,6 @@
 # Lynx native renderer and ReactLynx migration plan
 
-Status: **Milestone 0 blocked; Milestones 1–2 implemented; Milestones 3–5 have private source/test/build implementations but their formal exits remain blocked**
+Status: **Milestone 0 blocked; Milestones 1–2 implemented; Milestones 3–6 have private source/test/build implementations but their formal exits remain blocked**
 
 Upstream audit date: **2026-07-18**
 
@@ -13,6 +13,8 @@ Milestone 3 source/test evidence date: **2026-07-19**
 Milestone 4 source/test evidence date: **2026-07-19**
 
 Milestone 5 source/build evidence date: **2026-07-20**
+
+Milestone 6 source/build evidence date: **2026-07-21**
 
 This plan defines how Octane should become a first-class framework for the
 [Lynx](https://lynxjs.org/) native engine and how applications currently written
@@ -147,8 +149,8 @@ The Lynx package owns:
 - background-to-main transport, main-to-background event delivery, page
   lifecycle, init data, global props, native query/ref handles, and UI methods;
   and
-- main-thread first rendering, adoption, main-thread worklets, and cross-thread
-  function calls once those milestones land.
+- main-thread first rendering and adoption; main-thread worklets and
+  cross-thread function calls remain a later milestone.
 
 Rspeedy and Lynx's lower-level framework-neutral packages own bundle assembly,
 CSS serialization, native template encoding, and engine loading. The Octane
@@ -310,7 +312,9 @@ packages/lynx/
     config.ts
     intrinsics.ts
     renderer.ts
+    main-renderer.ts
     root.ts
+    first-screen.ts
     main-thread.ts
     platform.ts
     testing.ts
@@ -357,6 +361,8 @@ Required `@octanejs/lynx` exports:
 @octanejs/lynx
 @octanejs/lynx/config
 @octanejs/lynx/renderer
+@octanejs/lynx/main-renderer
+@octanejs/lynx/first-screen
 @octanejs/lynx/intrinsics
 @octanejs/lynx/intrinsics/jsx-runtime
 @octanejs/lynx/main-thread
@@ -489,8 +495,10 @@ seed from public `__presetData` and consume the framework-maintained current
 render-to-layout subscription race. The native update receiver that maintains
 that current snapshot is still uninstalled and remains part of the formal
 device gate. The source also does not install a framework reload or page-destroy
-receiver. `markFirstScreenSyncReady()` remains deferred until Milestone 6's
-dual-thread adoption protocol exists.
+receiver. Milestone 6 now supplies `markFirstScreenSyncReady()` as the explicit
+main-entry initialization gate before a first-tree snapshot is offered to the
+background runtime. This source contract has not been exercised by a native
+lifecycle receiver.
 
 Native Modules stay background-thread-only. The compiler diagnoses statically
 visible Native Module access and `@octanejs/lynx/platform` imports from
@@ -773,11 +781,11 @@ leaves no native nodes, listeners, callbacks, or resource handles.
 > public `@octanejs/lynx/testing` subpath is now a thin facade over the pinned
 > JavaScript testing environment, and production smoke evidence builds and
 > decodes the bundle without a React, Preact, or ReactLynx runtime. This does not
-> render the application on the main thread and does not implement first-paint
-> adoption (Milestone 6). No Lynx Web, Android, or iOS execution; device error
-> capture; authored-source-map resolution in an engine; or state-preserving HMR
-> evidence has landed. The packages therefore remain private and are not a
-> technical preview.
+> itself establish main-thread rendering or first-paint adoption; those now
+> have separate Milestone 6 source/build evidence. No Lynx Web, Android, or iOS
+> execution; device error capture; authored-source-map resolution in an engine;
+> or state-preserving HMR evidence has landed. The packages therefore remain
+> private and are not a technical preview.
 
 Both packages already appear in the generated private-package inventory. The
 public bindings-status generator intentionally excludes private packages, so
@@ -804,6 +812,26 @@ global props, errors, reload, and teardown work; source maps resolve to authored
 React/Preact. Publish only as a **background-rendered technical preview**.
 
 ### Milestone 6 — main-thread first paint and background adoption (4–7 engineer-weeks)
+
+> **Progress (2026-07-21): private source/build implementation complete; formal
+> exit blocked.** Rspeedy application mode now builds the same authored entry
+> in two Rspack layers. The generated main graph installs the receiver, resolves
+> the exact `@octanejs/lynx` package root to a synchronous first-screen facade,
+> runs authored imports through a PrimJS-safe one-shot renderer, and releases an
+> explicit manual synchronization gate after synchronous initialization. The
+> main renderer emits deterministic initial host IDs and event markers without
+> publishing effects, refs, state ownership, or later updates; the background
+> graph retains the full Octane runtime. A clone-safe snapshot and opaque local
+> journal support compatible transfer without host allocation or structural
+> mutation, FIFO ordinary-event replay after background listener ownership,
+> typed deterministic mismatch repair, and teardown. Source, compiler, graph,
+> and official-JavaScript-host tests cover these contracts. Native list hosts,
+> list materializations, and background-root-scoped native-resource props
+> remain excluded from first-tree capture, and boolean `defer` keeps only its
+> Milestone 4 metadata behavior. There is no Lynx Web,
+> Explorer, Android, or iOS proof of first paint, native node identity, or
+> handoff, and no native performance evidence. The formal exit and IFR claim
+> therefore remain blocked.
 
 - Add a PrimJS-safe, render-only main-thread specialization and automatic DCE
   for effects, ordinary handlers, background-only functions, and unused imports.

--- a/packages/lynx/README.md
+++ b/packages/lynx/README.md
@@ -1,18 +1,20 @@
 # Octane Lynx
 
-This directory now contains three deliberately separate pieces of the
+This directory now contains four deliberately separate pieces of the
 ReactLynx-to-Octane migration:
 
 - the immutable Milestone 0 audit and React-free framework probe;
 - the private Milestone 1 compiler/package scaffold plus the source-level
   Milestones 2–4 background renderer, host boundary, native list, and platform
-  API boundary; and
+  API boundary;
 - the private Milestone 5 production source/build path and packaged JavaScript
-  testing facade.
+  testing facade; and
+- the private Milestone 6 render-only main runtime, first-tree adoption
+  protocol, and dual-graph application build.
 
 The package is `0.0.0`, marked `private`, and is not a native renderer release.
 
-## Milestones 3–5 private surface
+## Milestones 3–6 private surface
 
 The package now contains:
 
@@ -43,7 +45,9 @@ The package now contains:
   background refs follow recycled native presence without exposing the list
   protocol to other renderers;
 - root-scoped serializable handles from `createLynxNativeResource()` for
-  application-owned custom-element resources;
+  application-owned custom-element resources in the background renderer; the
+  synchronous first-screen renderer rejects these props because it cannot
+  allocate background-root-scoped handles;
 - augmentable init-data, global-props, and Native Module types plus background
   hooks for data/global-event updates, typed global access, public reload
   requests, and error reporting;
@@ -51,6 +55,20 @@ The package now contains:
   statically visible `NativeModules` and `@octanejs/lynx/platform` use in the
   main-thread specialization; `createLynxRoot()` separately verifies the public
   background-only `lynx.getJSModule()` surface at runtime;
+- a PrimJS-safe, one-shot `@octanejs/lynx/main-renderer` specialization which
+  evaluates initial hooks and control flow, emits the first host batch, replaces
+  ordinary first-screen handlers with event markers, and does not publish
+  effects, refs, state ownership, or later updates; host props must be statically
+  named in this graph, so JSX host spreads are rejected rather than retaining
+  callback/ref values that cannot be erased soundly;
+- a synchronous `@octanejs/lynx/first-screen` root facade with an explicit
+  `markFirstScreenSyncReady()` gate for entry initialization; its
+  `createLynxRoot()` export maps to the same one-shot main root while the
+  background graph retains independent root creation;
+- clone-safe first-tree snapshots, compatible background transfer without
+  duplicate host allocation or restructuring, FIFO event replay only after the
+  background listener table owns the adopted nodes, typed deterministic
+  mismatch repair, and terminal cleanup;
 - renderer-local declarations for `page`, `view`, `text`, `raw-text`, `image`,
   `scroll-view`, `input`, `textarea`, `list`, and `list-item`;
 - explicit custom-native-element augmentation through
@@ -58,21 +76,26 @@ The package now contains:
 - a stable `@octanejs/lynx/testing` facade over the exact
   `@lynx-js/testing-environment@0.3.0` JavaScript host emulator.
 
-The private `@octanejs/rspeedy-plugin` Milestone 5 application mode now owns
-production bundle assembly. `pluginOctane()` splits every authored application
-entry into a background graph and a generated main-thread receiver, installs
-Octane's receiver in that generated graph, and configures Lynx's
-framework-neutral template, CSS extraction, runtime-wrapper, and native
-encoding packages. Production build tests construct and decode `.lynx.bundle`
-artifacts while checking CSS/assets, source/debug information, and the absence
-of React, Preact, and ReactLynx runtimes. Development builds wire the pinned Lynx
-transport, but no runtime HMR or live-reload claim is made.
+The private `@octanejs/rspeedy-plugin` Milestone 6 application mode owns the
+dual-graph production build. `pluginOctane()` compiles the same authored entry
+for both runtimes. Its generated main graph installs the receiver, resolves the
+exact `@octanejs/lynx` package root to the synchronous first-screen facade,
+evaluates authored imports under the render-only specialization, and opens the
+manual synchronization gate only after synchronous initialization returns. The
+background graph retains the complete Octane runtime and takes ownership by
+adopting a compatible snapshot or repairing a mismatch. The plugin also
+configures Lynx's framework-neutral template, CSS extraction, runtime wrapper,
+and native encoding packages.
 
-The generated main receiver does not render the application. Main-thread
-component rendering, first paint, and background adoption remain Milestone 6.
-Passing an explicit `thread: 'background'` or `thread: 'main-thread'` to the
-Rspeedy plugin retains the earlier isolated compiler-graph diagnostic mode; it
-is not the production application path.
+Production build tests construct and decode `.lynx.bundle` artifacts while
+checking graph ownership, CSS/assets, source/debug information, and the absence
+of React, Preact, and ReactLynx runtimes. Source and JavaScript-host tests cover
+synchronous first-tree creation, adoption, repair, event handoff, and cleanup.
+They do not prove native first paint or IFR behavior. Passing an explicit
+`thread: 'background'` or `thread: 'main-thread'` to the Rspeedy plugin retains
+the earlier isolated compiler-graph diagnostic mode; it is not the production
+application path. Development builds wire the pinned Lynx transport, but no
+runtime HMR or live-reload claim is made.
 
 The official `@lynx-js/testing-environment` lane mounts compiled `.lynx.tsrx`,
 updates state/context/conditionals, preserves keyed host identity while
@@ -123,7 +146,7 @@ request; it is not the missing framework reload receiver. No public
 page-destroy receiver has been installed. The packaged testing facade and
 production Rspeedy assembly do not remove those native execution gates.
 
-## Milestones 4–5 exclusions and examples
+## Milestones 4–6 exclusions and examples
 
 The initial Milestone 4 surface rejects nested `<list>` hosts and does not claim
 Lynx host proof for portals, Suspense, lazy bundles, gestures, or animations.
@@ -132,6 +155,11 @@ callback-demanded regardless of that prop, so this is not full ReactLynx
 `defer` semantics. ReactLynx's `defer={{ unmountRecycled: true }}` lifecycle
 behavior is also not implemented: recycling clears physical refs without
 unmounting the logical Octane subtree.
+
+Native list hosts and materializations are excluded from first-tree capture, so
+initial trees containing a native list have no Milestone 6 adoption claim.
+Boolean `defer` still has only the Milestone 4 metadata behavior; no eager-main
+versus deferred-background semantics are claimed without native evidence.
 
 `reuse-identifier` accepts strings. Omitting it or passing an empty string uses
 the default native reuse pool; logical identity still comes from the mandatory
@@ -151,6 +179,8 @@ The supported package subpaths are:
 @octanejs/lynx
 @octanejs/lynx/config
 @octanejs/lynx/renderer
+@octanejs/lynx/main-renderer
+@octanejs/lynx/first-screen
 @octanejs/lynx/intrinsics
 @octanejs/lynx/intrinsics/jsx-runtime
 @octanejs/lynx/main-thread
@@ -158,11 +188,11 @@ The supported package subpaths are:
 @octanejs/lynx/testing
 ```
 
-The production source/build path generates and installs the main-thread
-receiver. Application authors supply only the background entry:
+The production source/build path generates both specializations from one
+authored entry:
 
 ```ts
-// src/index.ts — background runtime
+// src/index.ts — evaluated by both specialized runtimes
 import { root } from '@octanejs/lynx';
 import { App } from './App.lynx.tsrx';
 
@@ -184,7 +214,7 @@ export default defineConfig({
 explicit one-thread compiler diagnostic mode. It is not a second application
 entry in normal application mode.
 
-Milestone 5 remains pinned to Lynx SDK `3.9.0` with target SDK `3.9`, Rspeedy
+Milestone 6 remains pinned to Lynx SDK `3.9.0` with target SDK `3.9`, Rspeedy
 `0.16.0`, Rsbuild `2.1.4`, Rspack `2.1.3`, template plugin `0.13.0`, CSS extract
 plugin `0.9.0`, runtime wrapper `0.2.2`, dev transport `0.3.0`, tasm `0.0.39`,
 testing environment `0.3.0`, Lynx types `4.0.0`, and the blocked Web control
@@ -210,13 +240,15 @@ The production Web control and transport bundles currently fail before
 rendering under `@lynx-js/web-core@0.22.2` with a `MutationObserver` target type
 error; the transported path additionally reports that Web `postMessage` is not
 implemented. Explorer, Android, and iOS execution were unavailable on the
-capture host. These remain explicit gates. The private Milestone 5 bundle path
-does not waive them and must not be described as a preview or production
+capture host. These remain explicit gates. The private Milestone 6 source/build
+path does not waive them and must not be described as a preview or production
 renderer.
 
-Milestones 3–5 have host/build-side private source and official-JavaScript
-evidence, but their formal exits remain unmet. The unresolved Milestone 0
-native event/lifecycle/reload hooks, Web failure, Android/iOS evidence, real
+Milestones 3–6 have host/build-side private source and official-JavaScript
+evidence, but their formal exits remain unmet. Milestone 6 specifically lacks
+native proof that the synchronous tree paints before background readiness or
+that adoption retains platform node identity. The unresolved Milestone 0 native
+event/lifecycle/reload hooks, Web failure, Android/iOS evidence, real
 selector-query/layout/list allocation behavior, app-native module/element
 execution, source-map resolution in an engine, runtime HMR cleanup, and pinned
 ReactLynx differential remain gates.
@@ -230,9 +262,13 @@ ReactLynx differential remain gates.
 - Complete batches are validated before PAPI mutation, and accepted batches
   cross one explicit flush boundary before acknowledgement.
 - Production native and Web bundles contain no ReactLynx or Preact runtime.
-- The Milestone 3–5 receiver uses named public `ContextProxy` events rather than
+- The Milestone 3–6 receiver uses named public `ContextProxy` events rather than
   the probe's `postMessage` fallback and keeps live Element PAPI objects wholly
   on the main thread.
+- Source/build and JavaScript-host tests show that the same authored entry has
+  separate render-only main and full background graphs, and that a compatible
+  first tree transfers without a second host allocation or structural mutation.
+  This is not native paint, identity, or performance evidence.
 
 The `imperative` entry is a small direct-PAPI control. The `main` entry runs the
 same visible tree through the Phase 0 background commit protocol.
@@ -248,7 +284,7 @@ See:
 - [`audit/phase-0-evidence.json`](./audit/phase-0-evidence.json) for captured
   results and blocked device/runtime gates.
 - [`audit/runtime-compatibility.json`](./audit/runtime-compatibility.json) for
-  checked Milestone 1–4 syntax, built-in, and runtime-graph assumptions and
+  checked Milestone 1–6 syntax, built-in, and runtime-graph assumptions and
   their qualifications.
 - [`UPSTREAM.md`](./UPSTREAM.md) for provenance and reuse policy.
 

--- a/packages/lynx/audit/runtime-compatibility.json
+++ b/packages/lynx/audit/runtime-compatibility.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": 1,
-  "recordedAt": "2026-07-19",
+  "recordedAt": "2026-07-21",
   "selectedSdk": "3.9.0",
   "selectedRspeedy": "0.16.0",
-  "purpose": "Milestones 1–4 source-level production-entry and runtime-ownership evidence for Octane's DOM-free Lynx graphs. This is JavaScript build/source evidence, not a .lynx.bundle or native device execution.",
+  "purpose": "Milestones 1–6 source/build runtime-ownership evidence for Octane's DOM-free Lynx graphs, including the dual-layer first-screen specialization. This is JavaScript graph, decoded-bundle, and host-emulator evidence, not Lynx Web or native device execution.",
   "sources": [
     {
       "url": "https://lynxjs.org/guide/scripting-runtime/",
@@ -28,16 +28,16 @@
       "engine": "PrimJS",
       "documentedSyntaxCeiling": "ES2019",
       "compileGraph": "packages/rspeedy-plugin-octane/tests/build.test.ts",
-      "entry": "packages/rspeedy-plugin-octane/tests/_fixtures/background/src/main-thread.ts",
-      "graphContract": "Consumes @octanejs/lynx/main-thread and contains the receiver, Element PAPI adapter, Lynx-specific list host, host-prop/event/NodesRef boundary modules, and shared attachment protocol without the universal core.",
+      "entry": "packages/rspeedy-plugin-octane/tests/_fixtures/application/src/background.ts (preceded and followed by generated receiver/sync modules)",
+      "graphContract": "Evaluates the same authored entry as the background layer after installing @octanejs/lynx/main-thread. The exact @octanejs/lynx package-root import resolves to @octanejs/lynx/first-screen, compiled components use @octanejs/lynx/main-renderer, and the graph contains the receiver, Element PAPI adapter, first-tree journal, Lynx-specific list host, and host prop/event boundary without the universal core, background client driver, or background root.",
       "nativeExecution": "blocked by the Phase 0 Explorer/Android/iOS gates"
     },
     "background": {
       "engines": ["PrimJS (Android default)", "JavaScriptCore (iOS default)"],
       "documentedSyntaxCeiling": "ES2015",
       "compileGraph": "packages/rspeedy-plugin-octane/tests/build.test.ts",
-      "entry": "packages/rspeedy-plugin-octane/tests/_fixtures/background/src/background.ts",
-      "graphContract": "Consumes the public Lynx root and a compiled TSRX component and contains the client driver, transport, shared host-attachment protocol, host-prop/event/NodesRef client modules, and Octane universal native core without main-thread host or list PAPI code.",
+      "entry": "packages/rspeedy-plugin-octane/tests/_fixtures/application/src/background.ts",
+      "graphContract": "Evaluates the same authored entry as the main layer through the public Lynx root and contains the client driver, transport, shared host-attachment protocol, host-prop/event/NodesRef client modules, and Octane universal native core without the main-thread host, first-screen renderer, or list PAPI code.",
       "platformSubpathContract": "@octanejs/lynx/platform is a separate background-only entry. Source tests cover init/global snapshot hooks, public GlobalEventEmitter subscriptions, typed Native Modules, reload request forwarding, and error reporting; compiler tests reject its import in main-thread specialization. It is not exercised by this default-root production graph fixture.",
       "nativeExecution": "blocked by the Phase 0 Explorer/Android/iOS gates"
     }
@@ -45,6 +45,15 @@
   "emittedSyntax": {
     "rspeedyTarget": "ES2017",
     "checkedForBothLayers": ["optional chaining is lowered", "nullish coalescing is lowered"]
+  },
+  "mainThreadRenderOnlyContract": {
+    "runtime": "@octanejs/lynx/main-renderer",
+    "facade": "@octanejs/lynx/first-screen",
+    "sync": "The generated receiver opens background readiness only after the authored entry's synchronous initialization returns.",
+    "ownership": "The main renderer emits one initial host batch and event markers. Effects, refs, state ownership, listener closures, scheduling, and later updates remain background-owned.",
+    "handoff": "A clone-safe snapshot is paired with a main-local host journal. Compatible background batches transfer the existing host tree without allocation or structural mutation; ordinary events replay in FIFO order after background listener ownership; typed mismatches repair from the background tree.",
+    "excluded": "Native list hosts and materializations are not captured for adoption. Boolean list defer has no eager-main versus deferred-background claim.",
+    "evidence": "Compiler, source-graph, decoded-bundle, and official JavaScript host-emulator tests only; no native first-paint, identity, device, or performance evidence."
   },
   "universalCoreBuiltins": {
     "documentedOrBaseline": [
@@ -76,5 +85,5 @@
       "WeakRef"
     ]
   },
-  "qualification": "The exact pinned Rspeedy toolchain builds isolated Milestone 4 background and main-thread JavaScript entries in production mode. The background entry consumes the public root plus compiled App and includes the universal native core and asynchronous query/event/attachment client boundary; the main entry consumes the public main-thread receiver and PAPI prop/event/list host boundary and excludes the universal core. Both graphs exclude DOM and React modules. This is a JavaScript graph/build smoke only: the separate platform entry, .lynx.bundle assembly, main-thread bytecode encoding, native event and lifecycle receiver wiring, native list allocation/scrolling, and all native runtime/device execution remain blocked gates."
+  "qualification": "The exact pinned Rspeedy toolchain specializes one authored Milestone 6 application entry into production background and main-thread graphs and emits a decoded .lynx.bundle. The background graph contains the full universal runtime and asynchronous client boundary; the main graph contains the one-shot first-screen renderer, receiver, and PAPI host while excluding the universal core. Both graphs exclude DOM, React, Preact, and ReactLynx runtime modules. Source and JavaScript-host tests cover snapshot adoption, event handoff, mismatch repair, and cleanup. This does not prove main-thread bytecode execution, native first paint, native identity retention, event/lifecycle receiver wiring, list allocation/scrolling, Lynx Web, Android, iOS, or performance; every corresponding formal gate remains blocked."
 }

--- a/packages/lynx/package.json
+++ b/packages/lynx/package.json
@@ -8,7 +8,7 @@
   "engines": {
     "node": ">=22"
   },
-  "description": "Private Milestone 5 source/build implementation of Octane's Lynx native renderer.",
+  "description": "Private Milestone 6 source/build implementation of Octane's Lynx native renderer.",
   "author": {
     "name": "Dominic Gannaway",
     "email": "dg@domgan.com"
@@ -39,6 +39,8 @@
       "default": "./src/config.runtime.js"
     },
     "./renderer": "./src/renderer.ts",
+    "./main-renderer": "./src/main-renderer.ts",
+    "./first-screen": "./src/first-screen.ts",
     "./intrinsics": "./src/intrinsics.ts",
     "./intrinsics/jsx-runtime": "./src/intrinsics.ts",
     "./main-thread": "./src/main-thread.ts",

--- a/packages/lynx/src/config.runtime.js
+++ b/packages/lynx/src/config.runtime.js
@@ -219,12 +219,13 @@ export const lynxBackgroundRenderer = {
 
 /** Main-thread renderer that rejects APIs owned by the background runtime. */
 export const lynxMainThreadRenderer = {
-	module: '@octanejs/lynx/renderer',
+	module: '@octanejs/lynx/main-renderer',
 	target: 'universal',
 	server: 'unsupported',
 	intrinsics: '@octanejs/lynx/intrinsics',
 	text: 'host',
-	capabilities: ['class-name-alias', 'visibility'],
+	capabilities: ['class-name-alias', 'visibility', 'main-thread-render-only'],
+	firstScreenEvents: ['bind*', 'catch*', 'capture-bind*', 'capture-catch*', 'global-bind*'],
 	validation: LYNX_MAIN_THREAD_VALIDATION,
 };
 

--- a/packages/lynx/src/config.ts
+++ b/packages/lynx/src/config.ts
@@ -219,12 +219,13 @@ export const lynxBackgroundRenderer = {
 
 /** Main-thread renderer that rejects APIs owned by the background runtime. */
 export const lynxMainThreadRenderer = {
-	module: '@octanejs/lynx/renderer',
+	module: '@octanejs/lynx/main-renderer',
 	target: 'universal',
 	server: 'unsupported',
 	intrinsics: '@octanejs/lynx/intrinsics',
 	text: 'host',
-	capabilities: ['class-name-alias', 'visibility'],
+	capabilities: ['class-name-alias', 'visibility', 'main-thread-render-only'],
+	firstScreenEvents: ['bind*', 'catch*', 'capture-bind*', 'capture-catch*', 'global-bind*'],
 	validation: LYNX_MAIN_THREAD_VALIDATION,
 } as const;
 

--- a/packages/lynx/src/core/first-screen.ts
+++ b/packages/lynx/src/core/first-screen.ts
@@ -1,0 +1,115 @@
+import type { UniversalEventPriority, UniversalSerializableValue } from 'octane/universal/native';
+import type { LynxElementRef } from './papi.js';
+
+/** Clone-safe event identity retained while ordinary events wait for adoption. */
+export interface LynxFirstTreeEventSnapshot {
+	readonly host: number;
+	readonly generation: number;
+	readonly type: string;
+	readonly listener: number;
+	readonly priority: UniversalEventPriority;
+}
+
+/** Clone-safe description of one physical node painted by the main runtime. */
+export interface LynxFirstTreeNodeSnapshot {
+	readonly id: number;
+	readonly nativeId: number;
+	readonly type: string;
+	readonly generation: number;
+	readonly parent: number | null;
+	readonly children: readonly number[];
+	readonly props: Readonly<Record<string, UniversalSerializableValue>>;
+	readonly visible: boolean;
+	readonly events: readonly LynxFirstTreeEventSnapshot[];
+}
+
+/**
+ * Serializable first-paint contract. PAPI node references deliberately remain
+ * in the opaque journal carried by {@link LynxFirstTree}.
+ */
+export interface LynxFirstTreeSnapshot {
+	readonly format: 1;
+	readonly renderer: 'lynx';
+	readonly root: number;
+	readonly version: number;
+	readonly plan: string | null;
+	readonly roots: readonly number[];
+	readonly nodes: readonly LynxFirstTreeNodeSnapshot[];
+}
+
+export interface CaptureLynxFirstTreeOptions {
+	/** Deterministic compiler plan identity used only to enrich mismatch reports. */
+	readonly plan?: string;
+}
+
+export interface LynxResolvedFirstTreeEvent {
+	readonly host: number;
+	readonly generation: number;
+	readonly type: string;
+	readonly listener: number;
+	readonly priority: UniversalEventPriority;
+}
+
+export const LYNX_FIRST_TREE_MISMATCH = 'OCTANE_LYNX_FIRST_SCREEN_MISMATCH' as const;
+
+/** Stable mismatch category; the host repairs from the background tree. */
+export class LynxFirstTreeMismatchError extends Error {
+	readonly code = LYNX_FIRST_TREE_MISMATCH;
+	readonly path: string;
+	readonly plan: string | null;
+
+	constructor(path: string, message: string, plan: string | null = null) {
+		super(`Octane Lynx first-screen mismatch at ${path}: ${message}`);
+		this.name = 'LynxFirstTreeMismatchError';
+		this.path = path;
+		this.plan = plan;
+	}
+}
+
+export const LYNX_FIRST_TREE_STATE: unique symbol = Symbol('octane.lynx.first-tree-state');
+
+export interface LynxFirstTreeState<Node extends LynxElementRef> {
+	owner: unknown;
+	status: 'available' | 'transferred' | 'disposed' | 'released';
+	readonly eventsByToken: Map<string, LynxResolvedFirstTreeEvent>;
+}
+
+/** Opaque main-local ownership journal paired with its clone-safe snapshot. */
+export interface LynxFirstTree<Node extends LynxElementRef = LynxElementRef> {
+	readonly snapshot: LynxFirstTreeSnapshot;
+	readonly [LYNX_FIRST_TREE_STATE]: LynxFirstTreeState<Node>;
+}
+
+export function createLynxFirstTree<Node extends LynxElementRef>(
+	snapshot: LynxFirstTreeSnapshot,
+	owner: unknown,
+	eventsByToken: Map<string, LynxResolvedFirstTreeEvent>,
+): LynxFirstTree<Node> {
+	const state: LynxFirstTreeState<Node> = {
+		owner,
+		status: 'available',
+		eventsByToken,
+	};
+	return Object.freeze({ snapshot, [LYNX_FIRST_TREE_STATE]: state });
+}
+
+/** Release clone-unsafe journal state after adoption replay has drained. */
+export function releaseLynxFirstTree(firstTree: LynxFirstTree): void {
+	const state = firstTree[LYNX_FIRST_TREE_STATE];
+	if (state.status === 'released') return;
+	if (state.status === 'available') {
+		throw new Error('Octane Lynx first tree must be adopted or disposed before release.');
+	}
+	state.owner = null;
+	state.eventsByToken.clear();
+	state.status = 'released';
+}
+
+/** Resolve a painted placeholder token without consulting adopted listeners. */
+export function resolveLynxFirstTreeEvent(
+	firstTree: LynxFirstTree,
+	token: unknown,
+): LynxResolvedFirstTreeEvent | null {
+	if (typeof token !== 'string') return null;
+	return firstTree[LYNX_FIRST_TREE_STATE].eventsByToken.get(token) ?? null;
+}

--- a/packages/lynx/src/core/host-driver.ts
+++ b/packages/lynx/src/core/host-driver.ts
@@ -4,6 +4,7 @@ import type {
 	UniversalHostCommitContext,
 	UniversalHostDriver,
 	UniversalPreparedHostBatch,
+	UniversalSerializableValue,
 } from 'octane/universal/native';
 import { LYNX_RENDERER_ID } from '../config.js';
 import {
@@ -13,6 +14,17 @@ import {
 	type LynxNativeEventBinding,
 	type LynxNativeEventToken,
 } from './native-events.js';
+import {
+	createLynxFirstTree,
+	LYNX_FIRST_TREE_STATE,
+	LynxFirstTreeMismatchError,
+	type CaptureLynxFirstTreeOptions,
+	type LynxFirstTree,
+	type LynxFirstTreeEventSnapshot,
+	type LynxFirstTreeNodeSnapshot,
+	type LynxFirstTreeSnapshot,
+	type LynxResolvedFirstTreeEvent,
+} from './first-screen.js';
 import {
 	LYNX_CSS_SCOPE_PROP,
 	planLynxHostPropPatch,
@@ -143,6 +155,7 @@ interface LynxHostState<Node extends LynxElementRef> {
 	faulted: boolean;
 	applying: boolean;
 	cleanupNeedsFlush: boolean;
+	firstTree: LynxFirstTree<Node> | null;
 }
 
 interface LynxNativeEventRegistration {
@@ -177,6 +190,13 @@ export interface LynxPreparedHostBatch extends UniversalPreparedHostBatch {
 	readonly mutationStarted: boolean;
 	/** Clone-safe public-handle changes that must be published before acknowledgement. */
 	readonly handleDelta: readonly LynxHostHandleDelta[];
+	/** First-screen path selected during clone-safe preparation. */
+	readonly firstTreeAction: 'none' | 'adopt' | 'repair';
+}
+
+export interface PrepareLynxHostBatchOptions<Node extends LynxElementRef> {
+	readonly firstTree?: LynxFirstTree<Node>;
+	readonly onMismatch?: (error: LynxFirstTreeMismatchError) => void;
 }
 
 export interface LynxHostDriver<
@@ -1248,6 +1268,7 @@ export function createLynxHostContainer<Node extends LynxElementRef>(
 		faulted: false,
 		applying: false,
 		cleanupNeedsFlush: false,
+		firstTree: null,
 	};
 	return Object.freeze({
 		renderer: LYNX_RENDERER_ID,
@@ -1267,13 +1288,448 @@ export function createLynxHostContainer<Node extends LynxElementRef>(
 	});
 }
 
+function sameSnapshotValue(first: unknown, second: unknown): boolean {
+	if (Object.is(first, second)) return true;
+	if (Array.isArray(first)) {
+		if (!Array.isArray(second) || first.length !== second.length) return false;
+		for (let index = 0; index < first.length; index++) {
+			if (!sameSnapshotValue(first[index], second[index])) return false;
+		}
+		return true;
+	}
+	if (
+		first === null ||
+		second === null ||
+		typeof first !== 'object' ||
+		typeof second !== 'object' ||
+		Array.isArray(second)
+	) {
+		return false;
+	}
+	const firstKeys = Object.keys(first).sort();
+	const secondKeys = Object.keys(second).sort();
+	if (firstKeys.length !== secondKeys.length) return false;
+	for (let index = 0; index < firstKeys.length; index++) {
+		const key = firstKeys[index]!;
+		if (
+			key !== secondKeys[index] ||
+			!sameSnapshotValue(
+				(first as Record<string, unknown>)[key],
+				(second as Record<string, unknown>)[key],
+			)
+		) {
+			return false;
+		}
+	}
+	return true;
+}
+
+function sameIds(first: readonly number[], second: readonly number[]): boolean {
+	if (first.length !== second.length) return false;
+	for (let index = 0; index < first.length; index++) {
+		if (first[index] !== second[index]) return false;
+	}
+	return true;
+}
+
+function snapshotFirstTreeValue(
+	value: UniversalSerializableValue,
+	seen: Set<object>,
+): UniversalSerializableValue {
+	if (value === null || typeof value !== 'object') return value;
+	if (seen.has(value)) throw hostError('first-tree props cannot contain cycles.');
+	seen.add(value);
+	try {
+		if (Array.isArray(value)) {
+			return Object.freeze(value.map((entry) => snapshotFirstTreeValue(entry, seen)));
+		}
+		const output: Record<string, UniversalSerializableValue> = {};
+		for (const key of Object.keys(value)) {
+			const entry = snapshotFirstTreeValue(
+				(value as Readonly<Record<string, UniversalSerializableValue>>)[key]!,
+				seen,
+			);
+			if (key === '__proto__') {
+				Object.defineProperty(output, key, {
+					configurable: false,
+					enumerable: true,
+					value: entry,
+					writable: false,
+				});
+			} else {
+				output[key] = entry;
+			}
+		}
+		return Object.freeze(output);
+	} finally {
+		seen.delete(value);
+	}
+}
+
+function snapshotFirstTreeProps(
+	props: Readonly<Record<string, unknown>>,
+): Readonly<Record<string, UniversalSerializableValue>> {
+	return snapshotFirstTreeValue(
+		props as Readonly<Record<string, UniversalSerializableValue>>,
+		new Set(),
+	) as Readonly<Record<string, UniversalSerializableValue>>;
+}
+
+function mismatch(
+	firstTree: LynxFirstTree,
+	path: string,
+	message: string,
+): LynxFirstTreeMismatchError {
+	return new LynxFirstTreeMismatchError(path, message, firstTree.snapshot.plan);
+}
+
+function firstTreeOwner<Node extends LynxElementRef>(
+	firstTree: LynxFirstTree<Node>,
+): LynxHostContainer<Node> {
+	if (firstTree === null || typeof firstTree !== 'object') {
+		throw hostError('firstTree must be a captured Lynx first tree.');
+	}
+	const journal = firstTree[LYNX_FIRST_TREE_STATE];
+	if (journal === undefined || journal.status !== 'available') {
+		throw hostError('firstTree is no longer available for adoption.');
+	}
+	const owner = journal.owner;
+	if (
+		owner === null ||
+		typeof owner !== 'object' ||
+		!(LYNX_HOST_STATE in owner) ||
+		(owner as LynxHostContainer<Node>).renderer !== LYNX_RENDERER_ID
+	) {
+		throw hostError('firstTree has no valid Lynx host owner.');
+	}
+	const source = owner as LynxHostContainer<Node>;
+	if (source[LYNX_HOST_STATE].firstTree !== firstTree) {
+		throw hostError('firstTree is not the current journal for its Lynx host owner.');
+	}
+	return source;
+}
+
+/**
+ * Freeze the accepted main-runtime tree into a clone-safe description while
+ * retaining PAPI references in a single-consumer, main-local journal.
+ */
+export function captureLynxFirstTree<Node extends LynxElementRef>(
+	container: LynxHostContainer<Node>,
+	options: CaptureLynxFirstTreeOptions = {},
+): LynxFirstTree<Node> {
+	const state = container[LYNX_HOST_STATE];
+	if (state.disposed || state.disposing || state.faulted || state.applying) {
+		throw hostError('first tree can only be captured from a stable accepted root.');
+	}
+	if (state.firstTree !== null) throw hostError('the root already owns a first-tree journal.');
+	if (state.acceptedVersion === 0)
+		throw hostError('cannot capture a first tree before a batch is accepted.');
+	if (
+		options.plan !== undefined &&
+		(typeof options.plan !== 'string' || options.plan.length === 0)
+	) {
+		throw hostError('first-tree plan must be a non-empty string when provided.');
+	}
+	if (state.lists.size !== 0) {
+		throw hostError('native list materializations cannot be captured as a first tree.');
+	}
+	const eventsByToken = new Map<string, LynxResolvedFirstTreeEvent>();
+	const nodes: LynxFirstTreeNodeSnapshot[] = [];
+	const ids = [...state.records.keys()].sort((first, second) => first - second);
+	for (const id of ids) {
+		const record = state.records.get(id)!;
+		if (record.node === null || record.parent === undefined) {
+			throw hostError(`first-tree host ${id} must own an attached physical node.`);
+		}
+		if (record.type === 'list') {
+			throw hostError('native list hosts cannot be captured as a first tree.');
+		}
+		if (!state.ownedNodes.has(record.node)) {
+			throw hostError(`first-tree host ${id} is missing from the physical ownership journal.`);
+		}
+		const nativeId = state.papi.getUniqueId(record.node);
+		assertSafeId(nativeId, `first-tree host ${id} native ID`);
+		const events: LynxFirstTreeEventSnapshot[] = [];
+		const eventEntries = [...record.events].sort(([first], [second]) =>
+			first < second ? -1 : first > second ? 1 : 0,
+		);
+		for (const [type, descriptor] of eventEntries) {
+			const event = Object.freeze({
+				host: id,
+				generation: record.handle.generation,
+				type,
+				listener: descriptor.id,
+				priority: descriptor.priority,
+			});
+			events.push(event);
+			const registration = state.nativeEvents.get(record.node)?.get(type);
+			if (record.visible) {
+				if (registration === undefined) {
+					throw hostError(`first-tree host ${id} is missing native event ${JSON.stringify(type)}.`);
+				}
+				eventsByToken.set(registration.token, event);
+			} else if (registration !== undefined) {
+				throw hostError(
+					`hidden first-tree host ${id} retains native event ${JSON.stringify(type)}.`,
+				);
+			}
+		}
+		nodes.push(
+			Object.freeze({
+				id,
+				nativeId,
+				type: record.type,
+				generation: record.handle.generation,
+				parent: record.parent,
+				children: Object.freeze([...record.children]),
+				props: snapshotFirstTreeProps(record.props),
+				visible: record.visible,
+				events: Object.freeze(events),
+			}),
+		);
+	}
+	if (state.ownedNodes.size !== state.records.size) {
+		throw hostError('first-tree physical ownership contains untracked nodes.');
+	}
+	if (state.ownedPageRoots.size !== state.rootChildren.length) {
+		throw hostError('first-tree page-root ownership does not match logical roots.');
+	}
+	for (const id of state.rootChildren) {
+		const node = state.records.get(id)?.node;
+		if (node === null || node === undefined || !state.ownedPageRoots.has(node)) {
+			throw hostError(`first-tree root ${id} is missing from page-root ownership.`);
+		}
+	}
+	const snapshot: LynxFirstTreeSnapshot = Object.freeze({
+		format: 1,
+		renderer: LYNX_RENDERER_ID,
+		root: container.root,
+		version: state.acceptedVersion,
+		plan: options.plan ?? null,
+		roots: Object.freeze([...state.rootChildren]),
+		nodes: Object.freeze(nodes),
+	});
+	const firstTree = createLynxFirstTree<Node>(snapshot, container, eventsByToken);
+	state.firstTree = firstTree;
+	return firstTree;
+}
+
+function compareFirstTree<Node extends LynxElementRef>(
+	target: LynxHostContainer<Node>,
+	batch: UniversalHostBatch,
+	firstTree: LynxFirstTree<Node>,
+	source: LynxHostContainer<Node>,
+	finalIds: ReadonlySet<number>,
+	finalRoots: readonly number[],
+	getRecord: (id: number) => LynxHostRecord<Node> | undefined,
+	operations: readonly LynxApplyOperation<Node>[],
+	listUpdates: readonly LynxPreparedListUpdate[],
+): LynxFirstTreeMismatchError | null {
+	const snapshot = firstTree.snapshot;
+	const sourceState = source[LYNX_HOST_STATE];
+	if (snapshot.format !== 1 || snapshot.renderer !== LYNX_RENDERER_ID) {
+		return mismatch(
+			firstTree,
+			'snapshot.format',
+			'the snapshot format or renderer is unsupported.',
+		);
+	}
+	if (snapshot.root !== target.root || source.root !== target.root) {
+		return mismatch(firstTree, 'snapshot.root', 'the captured and background root IDs differ.');
+	}
+	if (source.page !== target.page) {
+		return mismatch(
+			firstTree,
+			'snapshot.page',
+			'the captured and background page references differ.',
+		);
+	}
+	if (snapshot.version !== batch.version || sourceState.acceptedVersion !== snapshot.version) {
+		return mismatch(
+			firstTree,
+			'snapshot.version',
+			'the captured and background batch versions differ.',
+		);
+	}
+	if (
+		sourceState.disposed ||
+		sourceState.disposing ||
+		sourceState.faulted ||
+		sourceState.applying
+	) {
+		return mismatch(firstTree, 'snapshot.owner', 'the captured host owner is not stable.');
+	}
+	if (sourceState.lists.size !== 0 || listUpdates.length !== 0) {
+		return mismatch(firstTree, 'snapshot.nodes', 'native list materializations require repair.');
+	}
+	for (let index = 0; index < operations.length; index++) {
+		const operation = operations[index]!;
+		if (
+			operation.op !== 'create' &&
+			operation.op !== 'insert' &&
+			operation.op !== 'event' &&
+			operation.op !== 'visibility'
+		) {
+			return mismatch(
+				firstTree,
+				`batch.operations[${index}]`,
+				`initial adoption cannot replay a ${operation.op} operation.`,
+			);
+		}
+	}
+	if (snapshot.nodes.length !== finalIds.size || sourceState.records.size !== finalIds.size) {
+		return mismatch(firstTree, 'snapshot.nodes', 'the host counts differ.');
+	}
+	if (!sameIds(snapshot.roots, finalRoots)) {
+		return mismatch(firstTree, 'snapshot.roots', 'the root child order differs.');
+	}
+	const snapshotsById = new Map(snapshot.nodes.map((node) => [node.id, node]));
+	for (const id of [...finalIds].sort((first, second) => first - second)) {
+		const captured = snapshotsById.get(id);
+		const next = getRecord(id);
+		const sourceRecord = sourceState.records.get(id);
+		if (captured === undefined || next === undefined || sourceRecord === undefined) {
+			return mismatch(firstTree, `snapshot.nodes[${id}]`, 'the logical host identity differs.');
+		}
+		if (captured.type !== next.type || sourceRecord.type !== captured.type) {
+			return mismatch(firstTree, `snapshot.nodes[${id}].type`, 'the host type differs.');
+		}
+		if (
+			captured.generation !== next.handle.generation ||
+			sourceRecord.handle.generation !== captured.generation
+		) {
+			return mismatch(
+				firstTree,
+				`snapshot.nodes[${id}].generation`,
+				'the host generation differs.',
+			);
+		}
+		if (captured.parent !== next.parent || sourceRecord.parent !== captured.parent) {
+			return mismatch(firstTree, `snapshot.nodes[${id}].parent`, 'the host parent differs.');
+		}
+		if (
+			!sameIds(captured.children, next.children) ||
+			!sameIds(captured.children, sourceRecord.children)
+		) {
+			return mismatch(firstTree, `snapshot.nodes[${id}].children`, 'the child order differs.');
+		}
+		if (captured.visible !== next.visible || sourceRecord.visible !== captured.visible) {
+			return mismatch(firstTree, `snapshot.nodes[${id}].visible`, 'the visibility state differs.');
+		}
+		if (
+			!sameSnapshotValue(captured.props, next.props) ||
+			!sameSnapshotValue(captured.props, sourceRecord.props)
+		) {
+			return mismatch(firstTree, `snapshot.nodes[${id}].props`, 'the host props differ.');
+		}
+		if (
+			sourceRecord.node === null ||
+			sourceState.papi.getUniqueId(sourceRecord.node) !== captured.nativeId
+		) {
+			return mismatch(
+				firstTree,
+				`snapshot.nodes[${id}].nativeId`,
+				'the physical node identity changed.',
+			);
+		}
+		const physicalParent =
+			captured.parent === null ? source.page : sourceState.records.get(captured.parent)?.node;
+		if (physicalParent == null || !sourceState.papi.isChild(physicalParent, sourceRecord.node)) {
+			return mismatch(firstTree, `snapshot.nodes[${id}].parent`, 'the physical parent changed.');
+		}
+		const nextEvents = [...next.events].sort(([first], [second]) =>
+			first < second ? -1 : first > second ? 1 : 0,
+		);
+		const sourceEvents = [...sourceRecord.events].sort(([first], [second]) =>
+			first < second ? -1 : first > second ? 1 : 0,
+		);
+		if (
+			captured.events.length !== nextEvents.length ||
+			captured.events.length !== sourceEvents.length
+		) {
+			return mismatch(
+				firstTree,
+				`snapshot.nodes[${id}].events`,
+				'the event binding count differs.',
+			);
+		}
+		for (let index = 0; index < captured.events.length; index++) {
+			const event = captured.events[index]!;
+			const nextEntry = nextEvents[index]!;
+			const sourceEntry = sourceEvents[index]!;
+			if (
+				event.host !== id ||
+				event.generation !== captured.generation ||
+				event.type !== nextEntry[0] ||
+				event.type !== sourceEntry[0] ||
+				event.priority !== nextEntry[1].priority ||
+				event.listener !== sourceEntry[1].id ||
+				event.priority !== sourceEntry[1].priority
+			) {
+				return mismatch(
+					firstTree,
+					`snapshot.nodes[${id}].events[${index}]`,
+					'the event binding differs.',
+				);
+			}
+		}
+	}
+	return null;
+}
+
+function transferFirstTree<Node extends LynxElementRef>(
+	target: LynxHostContainer<Node>,
+	firstTree: LynxFirstTree<Node>,
+	source: LynxHostContainer<Node>,
+	activeNodes: Map<number, Node>,
+): void {
+	const targetState = target[LYNX_HOST_STATE];
+	const sourceState = source[LYNX_HOST_STATE];
+	for (const [id, targetRecord] of targetState.records) {
+		const sourceRecord = sourceState.records.get(id);
+		if (sourceRecord?.node === null || sourceRecord?.node === undefined) {
+			throw hostError(`captured first-tree host ${id} lost its physical node.`);
+		}
+		const node = sourceRecord.node;
+		targetRecord.node = node;
+		activeNodes.set(id, node);
+		targetState.ownedNodes.add(node);
+		if (targetRecord.parent === null) targetState.ownedPageRoots.add(node);
+		const nativeEvents = sourceState.nativeEvents.get(node);
+		if (nativeEvents !== undefined) targetState.nativeEvents.set(node, nativeEvents);
+	}
+
+	// From this point the background journal is the only disposal authority.
+	// Carry every native placeholder registration into that journal before the
+	// background tokens below replace them. If selector/event installation faults
+	// partway through adoption, terminal cleanup must still clear registrations on
+	// nodes the replacement loop did not reach.
+	sourceState.ownedNodes.clear();
+	sourceState.ownedPageRoots.clear();
+	sourceState.nativeEvents.clear();
+	sourceState.records.clear();
+	sourceState.rootChildren.length = 0;
+	sourceState.generations.clear();
+	sourceState.firstTree = null;
+	sourceState.cleanupNeedsFlush = false;
+	sourceState.disposing = false;
+	sourceState.disposed = true;
+	const journal = firstTree[LYNX_FIRST_TREE_STATE];
+	journal.owner = null;
+	journal.status = 'transferred';
+}
+
 export function prepareLynxHostBatch<Node extends LynxElementRef>(
 	container: LynxHostContainer<Node>,
 	batch: UniversalHostBatch,
+	options?: PrepareLynxHostBatchOptions<Node>,
 ): LynxPreparedHostBatch {
 	const state = container[LYNX_HOST_STATE];
 	if (state.disposed) throw hostError('cannot prepare a batch for a disposed root.');
 	if (state.disposing) throw hostError('cannot prepare a batch while root cleanup is pending.');
+	if (state.firstTree !== null) {
+		throw hostError('a captured first-tree root cannot accept another batch.');
+	}
 	if (container.renderer !== LYNX_RENDERER_ID || batch.renderer !== LYNX_RENDERER_ID) {
 		throw hostError(
 			`renderer mismatch: expected ${JSON.stringify(LYNX_RENDERER_ID)}, received ${JSON.stringify(batch.renderer)}.`,
@@ -1286,6 +1742,28 @@ export function prepareLynxHostBatch<Node extends LynxElementRef>(
 		);
 	}
 	if (!Array.isArray(batch.commands)) throw hostError('batch.commands must be an array.');
+	if (options?.onMismatch !== undefined && typeof options.onMismatch !== 'function') {
+		throw hostError('onMismatch must be a function when provided.');
+	}
+	const firstTree = options?.firstTree;
+	let firstTreeSource: LynxHostContainer<Node> | null = null;
+	if (firstTree !== undefined) {
+		if (
+			state.acceptedVersion !== 0 ||
+			state.records.size !== 0 ||
+			state.generations.size !== 0 ||
+			state.ownedNodes.size !== 0 ||
+			state.ownedPageRoots.size !== 0 ||
+			state.nativeEvents.size !== 0 ||
+			state.lists.size !== 0
+		) {
+			throw hostError('firstTree may only be prepared against an empty background root.');
+		}
+		firstTreeSource = firstTreeOwner(firstTree);
+		if (firstTreeSource === container) {
+			throw hostError('firstTree must be adopted by a different Lynx host container.');
+		}
+	}
 	const logicalTeardown = state.faulted;
 	if (
 		logicalTeardown &&
@@ -1684,6 +2162,23 @@ export function prepareLynxHostBatch<Node extends LynxElementRef>(
 		}
 	}
 	Object.freeze(handleDelta);
+	let firstTreeAction: LynxPreparedHostBatch['firstTreeAction'] = 'none';
+	let firstTreeMismatch: LynxFirstTreeMismatchError | null = null;
+	if (firstTree !== undefined && firstTreeSource !== null) {
+		firstTreeMismatch = compareFirstTree(
+			container,
+			batch,
+			firstTree,
+			firstTreeSource,
+			finalIds,
+			childrenForRead(null),
+			getRecord,
+			operations,
+			listUpdates,
+		);
+		firstTreeAction = firstTreeMismatch === null ? 'adopt' : 'repair';
+		if (firstTreeMismatch !== null) options?.onMismatch?.(firstTreeMismatch);
+	}
 	let status: 'prepared' | 'applying' | 'applied' | 'aborted' | 'faulted' = 'prepared';
 	let mutationStarted = false;
 	let fault: unknown;
@@ -1693,6 +2188,7 @@ export function prepareLynxHostBatch<Node extends LynxElementRef>(
 			return mutationStarted;
 		},
 		handleDelta,
+		firstTreeAction,
 		apply() {
 			if (status === 'aborted' || status === 'applied') return;
 			if (status === 'faulted') throw fault;
@@ -1700,15 +2196,35 @@ export function prepareLynxHostBatch<Node extends LynxElementRef>(
 			if (state.disposed || state.disposing) {
 				throw hostError('cannot apply a batch while root cleanup is pending.');
 			}
+			if (state.firstTree !== null) {
+				throw hostError('a captured first-tree root cannot apply a prepared batch.');
+			}
 			if (state.acceptedVersion !== baseVersion) {
 				throw hostError(
 					`prepared batch ${batch.version} was superseded by version ${state.acceptedVersion}.`,
 				);
 			}
+			if (
+				firstTree !== undefined &&
+				(firstTreeSource === null || firstTreeOwner(firstTree) !== firstTreeSource)
+			) {
+				throw hostError('firstTree ownership changed after preparation.');
+			}
 			status = 'applying';
 			state.applying = true;
 			try {
 				mutationStarted = true;
+				if (firstTreeAction === 'repair') {
+					const cleanup = disposeLynxFirstTree(firstTree!);
+					if (!cleanup.complete) {
+						const error =
+							cleanup.errors[0] ?? hostError('first-tree repair cleanup did not complete.');
+						state.faulted = true;
+						status = 'faulted';
+						fault = error;
+						throw error;
+					}
+				}
 				const retiredPhysicalIds = new Set<number>();
 				let preApplicationFailed = false;
 				let preApplicationError: unknown;
@@ -1764,7 +2280,25 @@ export function prepareLynxHostBatch<Node extends LynxElementRef>(
 					let applicationError: unknown = preApplicationError;
 					try {
 						if (applicationFailed) throw applicationError;
-						for (const operation of operations) {
+						if (firstTreeAction === 'adopt') {
+							transferFirstTree(container, firstTree!, firstTreeSource!, activeNodes);
+							for (const [id, record] of state.records) {
+								const node = nodeFor(activeNodes, id, 'first-tree adoption');
+								installNodesRefSelector(state.papi, node, record.handle);
+								if (record.visible) {
+									installNativeEvents(
+										state,
+										node,
+										container.root,
+										id,
+										record.handle.generation,
+										record.events,
+									);
+								}
+							}
+						}
+						const applicationOperations = firstTreeAction === 'adopt' ? [] : operations;
+						for (const operation of applicationOperations) {
 							if (retiredPhysicalIds.has(operation.id)) continue;
 							if (operation.op === 'create') {
 								const membership = directListItem((id) => state.records.get(id), operation.id);
@@ -2100,6 +2634,66 @@ function normalizeCleanupError(error: unknown): Error {
 	return error instanceof Error ? error : new Error(String(error));
 }
 
+function indexPhysicalNodes<Node extends LynxElementRef>(
+	papi: LynxElementPAPI<Node>,
+	nodes: ReadonlySet<Node>,
+): ReadonlyMap<number, Node> {
+	const byNativeId = new Map<number, Node>();
+	for (const node of nodes) {
+		const nativeId = papi.getUniqueId(node);
+		if (!Number.isSafeInteger(nativeId)) {
+			throw hostError('cleanup native ID must be a safe integer.');
+		}
+		const previous = byNativeId.get(nativeId);
+		if (previous !== undefined && previous !== node && !papi.isEqual(previous, node)) {
+			throw hostError(`cleanup native ID ${nativeId} is not unique.`);
+		}
+		if (previous === undefined) byNativeId.set(nativeId, node);
+	}
+	return byNativeId;
+}
+
+function containsPhysicalNode<Node extends LynxElementRef>(
+	papi: LynxElementPAPI<Node>,
+	byNativeId: ReadonlyMap<number, Node>,
+	candidate: Node,
+): boolean {
+	const nativeId = papi.getUniqueId(candidate);
+	if (!Number.isSafeInteger(nativeId)) {
+		throw hostError('cleanup parent native ID must be a safe integer.');
+	}
+	const owned = byNativeId.get(nativeId);
+	if (owned === undefined) return false;
+	// Native parent lookup may return a different opaque wrapper for the same
+	// element. The unique native-ID index keeps this equality fallback O(1)
+	// instead of rescanning the complete owned tree.
+	return owned === candidate || papi.isEqual(owned, candidate);
+}
+
+function completedFirstTreeCleanup(): LynxHostCleanupResult {
+	return Object.freeze({
+		complete: true,
+		removedRoots: 0,
+		remainingRoots: 0,
+		flushed: false,
+		errors: Object.freeze([]),
+	});
+}
+
+/** Dispose a captured tree unless its physical nodes were already transferred. */
+export function disposeLynxFirstTree<Node extends LynxElementRef>(
+	firstTree: LynxFirstTree<Node>,
+): LynxHostCleanupResult {
+	if (firstTree === null || typeof firstTree !== 'object') {
+		throw hostError('firstTree must be a captured Lynx first tree.');
+	}
+	const journal = firstTree[LYNX_FIRST_TREE_STATE];
+	if (journal === undefined) throw hostError('firstTree has no Lynx ownership journal.');
+	if (journal.status !== 'available') return completedFirstTreeCleanup();
+	const owner = firstTreeOwner(firstTree);
+	return disposeLynxHostContainer(owner);
+}
+
 /**
  * Retry-safe terminal cleanup for success and post-accept fault paths.
  * Incomplete attempts retain their ownership journal and logical records so a
@@ -2119,8 +2713,18 @@ export function disposeLynxHostContainer<Node extends LynxElementRef>(
 		});
 	}
 	state.disposing = true;
-	const roots = [...state.ownedPageRoots];
 	const errors: Error[] = [];
+	// Snapshot every physical reference before list teardown releases its ordinary
+	// journals. Failed external-edge removal re-adds that node to ownedNodes so a
+	// later dispose attempt can retry it.
+	const cleanupNodes = new Set(state.ownedNodes);
+	for (const node of state.ownedPageRoots) cleanupNodes.add(node);
+	let cleanupNodeIndex: ReadonlyMap<number, Node> | null = null;
+	try {
+		cleanupNodeIndex = indexPhysicalNodes(state.papi, cleanupNodes);
+	} catch (error) {
+		errors.push(normalizeCleanupError(error));
+	}
 	for (const listId of [...state.lists.keys()]) {
 		try {
 			disposeNativeListState(state, listId);
@@ -2140,35 +2744,76 @@ export function disposeLynxHostContainer<Node extends LynxElementRef>(
 		}
 	}
 	let removedRoots = 0;
-	for (const node of roots) {
-		let attached: boolean;
-		try {
-			attached = state.papi.isChild(container.page, node);
-		} catch (error) {
-			errors.push(normalizeCleanupError(error));
-			continue;
-		}
-		if (attached) {
-			try {
-				state.papi.remove(container.page, node);
-			} catch (error) {
-				try {
-					// Native removal may detach and then throw. Forget ownership only
-					// when public parent inspection proves the mutation completed.
-					if (state.papi.isChild(container.page, node)) {
-						errors.push(normalizeCleanupError(error));
-						continue;
-					}
-				} catch (inspectionError) {
-					errors.push(normalizeCleanupError(error));
-					errors.push(normalizeCleanupError(inspectionError));
-					continue;
-				}
-			}
-		}
-		state.ownedPageRoots.delete(node);
+	let unresolvedExternalRoots = 0;
+	const releaseRootOwnership = (node: Node): void => {
+		if (!state.ownedPageRoots.delete(node)) return;
 		state.cleanupNeedsFlush = true;
 		removedRoots += 1;
+	};
+	const retainUnresolvedOwnership = (node: Node): void => {
+		state.ownedNodes.add(node);
+		// Logical page roots already remain counted in ownedPageRoots. A child
+		// reparented beneath a non-owned native node is itself another physical
+		// cleanup root until that external edge can be removed.
+		if (!state.ownedPageRoots.has(node)) unresolvedExternalRoots += 1;
+	};
+	for (const node of cleanupNodes) {
+		let parent: Node | null;
+		try {
+			parent = state.papi.getParent(node);
+		} catch (error) {
+			errors.push(normalizeCleanupError(error));
+			retainUnresolvedOwnership(node);
+			continue;
+		}
+		if (parent === null) {
+			releaseRootOwnership(node);
+			continue;
+		}
+		if (cleanupNodeIndex === null) {
+			retainUnresolvedOwnership(node);
+			continue;
+		}
+		let parentIsOwned: boolean;
+		try {
+			parentIsOwned = containsPhysicalNode(state.papi, cleanupNodeIndex, parent);
+		} catch (error) {
+			errors.push(normalizeCleanupError(error));
+			retainUnresolvedOwnership(node);
+			continue;
+		}
+		if (parentIsOwned) {
+			// Nested ownership is released by removing the one external edge above
+			// this subtree. Do not turn normal cleanup into one native removal per host.
+			releaseRootOwnership(node);
+			continue;
+		}
+
+		let externalEdgeRemoved = false;
+		try {
+			state.papi.remove(parent, node);
+			externalEdgeRemoved = true;
+		} catch (error) {
+			try {
+				// Native removal may detach and then throw. It is also safe if the node
+				// ended up beneath another owned node: the remaining owned boundary edge
+				// will release that complete subtree.
+				const currentParent = state.papi.getParent(node);
+				externalEdgeRemoved =
+					currentParent === null ||
+					containsPhysicalNode(state.papi, cleanupNodeIndex, currentParent);
+				if (!externalEdgeRemoved) errors.push(normalizeCleanupError(error));
+			} catch (inspectionError) {
+				errors.push(normalizeCleanupError(error));
+				errors.push(normalizeCleanupError(inspectionError));
+			}
+		}
+		if (!externalEdgeRemoved) {
+			retainUnresolvedOwnership(node);
+			continue;
+		}
+		state.cleanupNeedsFlush = true;
+		releaseRootOwnership(node);
 	}
 	let flushed = false;
 	if (state.cleanupNeedsFlush) {
@@ -2180,25 +2825,33 @@ export function disposeLynxHostContainer<Node extends LynxElementRef>(
 			errors.push(normalizeCleanupError(error));
 		}
 	}
+	const remainingRoots = state.ownedPageRoots.size + unresolvedExternalRoots;
 	const complete =
-		state.ownedPageRoots.size === 0 &&
+		remainingRoots === 0 &&
 		state.nativeEvents.size === 0 &&
 		state.lists.size === 0 &&
 		!state.cleanupNeedsFlush;
 	if (complete) {
+		const firstTree = state.firstTree;
 		state.ownedNodes.clear();
 		state.nativeEvents.clear();
 		state.lists.clear();
 		state.records.clear();
 		state.rootChildren.length = 0;
 		state.generations.clear();
+		state.firstTree = null;
 		state.disposing = false;
 		state.disposed = true;
+		if (firstTree !== null) {
+			const journal = firstTree[LYNX_FIRST_TREE_STATE];
+			journal.owner = null;
+			journal.status = 'disposed';
+		}
 	}
 	return Object.freeze({
 		complete,
 		removedRoots,
-		remainingRoots: state.ownedPageRoots.size,
+		remainingRoots,
 		flushed,
 		errors: Object.freeze(errors),
 	});

--- a/packages/lynx/src/core/papi.ts
+++ b/packages/lynx/src/core/papi.ts
@@ -98,6 +98,8 @@ export interface LynxElementPAPI<Node extends LynxElementRef = LynxElementRef> {
 	/** Present when the runtime publishes the native list callback API. */
 	readonly list?: LynxListPAPI<Node>;
 	getUniqueId(node: Node): number;
+	getParent(node: Node): Node | null;
+	isEqual(first: Node, second: Node): boolean;
 	isChild(parent: Node, child: Node): boolean;
 	insertBefore(parent: Node, child: Node, before: Node | null): void;
 	remove(parent: Node, child: Node): void;
@@ -210,6 +212,17 @@ export function createLynxElementPAPI<Node extends LynxElementRef = LynxElementR
 			'Octane Lynx requires the public Element PAPI function __GetParent for retry-safe cleanup.',
 		);
 	}
+	const normalizedParent = (node: Node): Node | null => {
+		if (getParent !== undefined) return getParent(node) ?? null;
+		if (node !== null && typeof node === 'object' && 'parentNode' in node) {
+			const parent = (node as { parentNode: unknown }).parentNode;
+			if (parent === null || parent === undefined) return null;
+			if (typeof parent === 'object') return parent as Node;
+		}
+		throw new Error('Octane Lynx could not inspect an Element PAPI parent.');
+	};
+	const elementsAreEqual = (first: Node, second: Node): boolean =>
+		elementIsEqual === undefined ? first === second : elementIsEqual(first, second);
 	const insertBefore = requireFunction<Node, '__InsertElementBefore'>(
 		target,
 		'__InsertElementBefore',
@@ -250,22 +263,15 @@ export function createLynxElementPAPI<Node extends LynxElementRef = LynxElementR
 		getUniqueId(node) {
 			return getUniqueId(node);
 		},
+		getParent(node) {
+			return normalizedParent(node);
+		},
+		isEqual(first, second) {
+			return elementsAreEqual(first, second);
+		},
 		isChild(parent, child) {
-			if (getParent !== undefined) {
-				const actualParent = getParent(child);
-				return actualParent != null && elementIsEqual!(actualParent, parent);
-			}
-			// @lynx-js/testing-environment@0.3.0 models ElementRefs as DOM nodes,
-			// but does not expose the public parent-inspection primitives.
-			if (
-				hasTestingParentFallback &&
-				child !== null &&
-				typeof child === 'object' &&
-				'parentNode' in child
-			) {
-				return (child as { parentNode: unknown }).parentNode === parent;
-			}
-			return false;
+			const actualParent = normalizedParent(child);
+			return actualParent !== null && elementsAreEqual(actualParent, parent);
 		},
 		insertBefore(parent, child, before) {
 			insertBefore(parent, child, before ?? undefined);

--- a/packages/lynx/src/core/protocol.ts
+++ b/packages/lynx/src/core/protocol.ts
@@ -13,6 +13,7 @@ import type {
 	UniversalTransportIdentity,
 	UniversalTransportRejectMessage,
 } from 'octane/universal/native';
+import type { LynxFirstTreeSnapshot } from './first-screen.js';
 
 /**
  * Kept as a local literal so the main-thread protocol graph does not evaluate
@@ -52,6 +53,7 @@ export interface LynxMainReadyReply {
 	readonly renderer: typeof LYNX_TRANSPORT_RENDERER;
 	readonly type: 'main-ready';
 	readonly request: number;
+	readonly firstTree?: LynxFirstTreeSnapshot;
 }
 
 export interface LynxPublicHandleUpsert {
@@ -73,6 +75,12 @@ export type LynxPublicHandleDelta = LynxPublicHandleUpsert | LynxPublicHandleRem
 
 export interface LynxTransportAcknowledgement extends UniversalTransportAcknowledgement {
 	readonly handles: readonly LynxPublicHandleDelta[];
+	readonly adoption?: 'adopted' | 'repaired';
+}
+
+/** Background listener ownership is live; buffered first-screen events may replay. */
+export interface LynxAdoptionReadyMessage extends UniversalTransportIdentity {
+	readonly type: 'adoption-ready';
 }
 
 export interface LynxHostAttachmentChange {
@@ -113,6 +121,7 @@ export interface LynxDisposeRetryMessage extends UniversalTransportIdentity {
 
 export type LynxBackgroundOutboundMessage =
 	| LynxMainReadyRequest
+	| LynxAdoptionReadyMessage
 	| UniversalTransportCommitMessage
 	| UniversalTransportAbortMessage
 	| LynxDisposeMessage
@@ -387,10 +396,69 @@ function assertHandleDelta(
 	fail(`${label}.op`, `uses unsupported operation ${JSON.stringify(delta.op)}.`);
 }
 
+function assertFirstTreeSnapshot(value: unknown, label: string): void {
+	const snapshot = record(value, label);
+	exactKeys(snapshot, ['format', 'renderer', 'root', 'version', 'plan', 'roots', 'nodes'], label);
+	if (snapshot.format !== 1) fail(`${label}.format`, 'must be 1.');
+	if (snapshot.renderer !== LYNX_TRANSPORT_RENDERER) {
+		fail(`${label}.renderer`, `must be ${JSON.stringify(LYNX_TRANSPORT_RENDERER)}.`);
+	}
+	positiveInteger(snapshot.root, `${label}.root`);
+	positiveInteger(snapshot.version, `${label}.version`);
+	if (snapshot.plan !== null && (typeof snapshot.plan !== 'string' || snapshot.plan.length === 0)) {
+		fail(`${label}.plan`, 'must be null or a non-empty string.');
+	}
+	if (!Array.isArray(snapshot.roots)) fail(`${label}.roots`, 'must be an array.');
+	for (let index = 0; index < snapshot.roots.length; index++) {
+		positiveInteger(snapshot.roots[index], `${label}.roots[${index}]`);
+	}
+	if (!Array.isArray(snapshot.nodes)) fail(`${label}.nodes`, 'must be an array.');
+	for (let index = 0; index < snapshot.nodes.length; index++) {
+		const nodeLabel = `${label}.nodes[${index}]`;
+		const node = record(snapshot.nodes[index], nodeLabel);
+		exactKeys(
+			node,
+			['id', 'nativeId', 'type', 'generation', 'parent', 'children', 'props', 'visible', 'events'],
+			nodeLabel,
+		);
+		positiveInteger(node.id, `${nodeLabel}.id`);
+		positiveInteger(node.nativeId, `${nodeLabel}.nativeId`);
+		nonEmptyString(node.type, `${nodeLabel}.type`);
+		positiveInteger(node.generation, `${nodeLabel}.generation`);
+		nullableHostId(node.parent, `${nodeLabel}.parent`);
+		if (!Array.isArray(node.children)) fail(`${nodeLabel}.children`, 'must be an array.');
+		for (let child = 0; child < node.children.length; child++) {
+			positiveInteger(node.children[child], `${nodeLabel}.children[${child}]`);
+		}
+		assertProps(node.props, `${nodeLabel}.props`);
+		if (typeof node.visible !== 'boolean') fail(`${nodeLabel}.visible`, 'must be a boolean.');
+		if (!Array.isArray(node.events)) fail(`${nodeLabel}.events`, 'must be an array.');
+		for (let eventIndex = 0; eventIndex < node.events.length; eventIndex++) {
+			const eventLabel = `${nodeLabel}.events[${eventIndex}]`;
+			const event = record(node.events[eventIndex], eventLabel);
+			exactKeys(event, ['host', 'generation', 'type', 'listener', 'priority'], eventLabel);
+			positiveInteger(event.host, `${eventLabel}.host`);
+			positiveInteger(event.generation, `${eventLabel}.generation`);
+			nonEmptyString(event.type, `${eventLabel}.type`);
+			positiveInteger(event.listener, `${eventLabel}.listener`);
+			if (!['continuous', 'default', 'discrete'].includes(event.priority as string)) {
+				fail(`${eventLabel}.priority`, 'must be discrete, continuous, or default.');
+			}
+		}
+	}
+}
+
 function assertReady(value: unknown, reply: boolean): LynxMainReadyRequest | LynxMainReadyReply {
 	const label = reply ? 'main-ready reply' : 'main-ready request';
 	const message = record(value, label);
-	exactKeys(message, ['protocol', 'renderer', 'type', 'request'], label);
+	const hasFirstTree = reply && Object.prototype.hasOwnProperty.call(message, 'firstTree');
+	exactKeys(
+		message,
+		hasFirstTree
+			? ['protocol', 'renderer', 'type', 'request', 'firstTree']
+			: ['protocol', 'renderer', 'type', 'request'],
+		label,
+	);
 	if (message.protocol !== LYNX_TRANSPORT_PROTOCOL_VERSION) {
 		fail(label, `protocol must be ${LYNX_TRANSPORT_PROTOCOL_VERSION}.`);
 	}
@@ -405,6 +473,7 @@ function assertReady(value: unknown, reply: boolean): LynxMainReadyRequest | Lyn
 	}
 	if (reply) nonNegativeInteger(message.request, `${label}.request`);
 	else positiveInteger(message.request, `${label}.request`);
+	if (hasFirstTree) assertFirstTreeSnapshot(message.firstTree, `${label}.firstTree`);
 	return message as unknown as LynxMainReadyRequest | LynxMainReadyReply;
 }
 
@@ -415,6 +484,10 @@ export function validateLynxBackgroundOutboundMessage(
 	if (message.type === 'main-ready-request')
 		return assertReady(message, false) as LynxMainReadyRequest;
 	assertIdentity(message, 'outbound message');
+	if (message.type === 'adoption-ready') {
+		exactKeys(message, ['protocol', 'renderer', 'root', 'version', 'type'], 'adoption-ready');
+		return message as unknown as LynxAdoptionReadyMessage;
+	}
 	if (message.type === 'commit') {
 		exactKeys(message, ['protocol', 'renderer', 'root', 'version', 'type', 'batch'], 'commit');
 		assertBatch(message.batch, message);
@@ -440,7 +513,17 @@ export function validateLynxBackgroundInboundMessage(value: unknown): LynxBackgr
 	if (message.type === 'main-ready') return assertReady(message, true) as LynxMainReadyReply;
 	assertIdentity(message, 'inbound message');
 	if (message.type === 'ack') {
-		exactKeys(message, ['protocol', 'renderer', 'root', 'version', 'type', 'handles'], 'ack');
+		const hasAdoption = Object.prototype.hasOwnProperty.call(message, 'adoption');
+		exactKeys(
+			message,
+			hasAdoption
+				? ['protocol', 'renderer', 'root', 'version', 'type', 'handles', 'adoption']
+				: ['protocol', 'renderer', 'root', 'version', 'type', 'handles'],
+			'ack',
+		);
+		if (hasAdoption && message.adoption !== 'adopted' && message.adoption !== 'repaired') {
+			fail('ack.adoption', 'must be adopted or repaired.');
+		}
 		if (!Array.isArray(message.handles)) fail('ack.handles', 'must be an array.');
 		for (let index = 0; index < message.handles.length; index++) {
 			assertHandleDelta(message.handles[index], index, message);

--- a/packages/lynx/src/core/transport.ts
+++ b/packages/lynx/src/core/transport.ts
@@ -373,6 +373,16 @@ export function createLynxBackgroundTransport(
 			terminalCloseAfterHostAcceptance(message, terminalError);
 			return;
 		}
+		if (message.adoption === 'adopted') {
+			try {
+				dispatch({ ...frozenIdentity(message), type: 'adoption-ready' });
+			} catch (error) {
+				terminalCloseAfterHostAcceptance(
+					message,
+					report(error, `Octane Lynx could not confirm adoption ${message.version}.`),
+				);
+			}
+		}
 	};
 
 	const settleCommitResponse = (entry: PendingCommit, message: CommitSettlement): void => {

--- a/packages/lynx/src/first-screen.ts
+++ b/packages/lynx/src/first-screen.ts
@@ -1,0 +1,95 @@
+import type { UniversalComponent } from 'octane/universal/native';
+import type { LynxFirstScreenRenderResult } from './main-renderer.js';
+
+/** Main-thread root contract installed by the generated receiver entry. */
+export interface LynxFirstScreenHost {
+	render<Props>(component: UniversalComponent<Props>, props: Props): LynxFirstScreenRenderResult;
+	markSyncReady(): void;
+	unmount(): void;
+}
+
+let installedHost: LynxFirstScreenHost | null = null;
+
+/** @internal Connect the application facade to its entry-owned PAPI receiver. */
+export function installLynxFirstScreenHost(host: LynxFirstScreenHost): () => void {
+	if (installedHost !== null) {
+		throw new Error('A Lynx first-screen host is already installed for this entry.');
+	}
+	installedHost = host;
+	let active = true;
+	return () => {
+		if (!active) return;
+		active = false;
+		if (installedHost === host) installedHost = null;
+	};
+}
+
+function requireHost(): LynxFirstScreenHost {
+	if (installedHost === null) {
+		throw new Error(
+			'Lynx first-screen root rendered before the generated main-thread receiver was installed.',
+		);
+	}
+	return installedHost;
+}
+
+export interface LynxFirstScreenRoot {
+	readonly renderer: 'lynx';
+	readonly ready: Promise<void>;
+	render<Props>(component: UniversalComponent<Props>, props?: Props): LynxFirstScreenRenderResult;
+	flushTransport(): Promise<void>;
+	unmount(): Promise<void>;
+}
+
+const ready = Promise.resolve();
+
+/** Synchronous main-thread facade selected only for the generated first-screen graph. */
+export const root: LynxFirstScreenRoot = Object.freeze({
+	renderer: 'lynx' as const,
+	ready,
+	render<Props>(component: UniversalComponent<Props>, props?: Props) {
+		if (typeof component !== 'function') {
+			throw new TypeError('Lynx first-screen root.render() requires a component function.');
+		}
+		return requireHost().render(component, props === undefined ? ({} as Props) : props);
+	},
+	flushTransport() {
+		return ready;
+	},
+	unmount() {
+		if (installedHost !== null) installedHost.unmount();
+		return ready;
+	},
+});
+
+/** Main specialization for the background root factory's first, one-shot root. */
+export function createLynxRoot(): LynxFirstScreenRoot {
+	return root;
+}
+
+/** Release a receiver configured for manual first-screen synchronization. */
+export function markFirstScreenSyncReady(): void {
+	requireHost().markSyncReady();
+}
+
+export const lynxRootAvailability = {
+	available: true,
+	implementedMilestone: 6,
+	status: 'private-milestone-0-native-gates-blocked',
+} as const;
+
+// Rspeedy's main graph aliases the exact package root to this facade, so keep
+// root-level authoring helpers addressable even when their values are accepted
+// only by the background renderer.
+export { createLynxNativeResource } from './resource.js';
+export type { LynxNativeResource } from './resource.js';
+export { LynxNodesRefError } from './core/nodes-ref.js';
+
+export type {
+	LynxCustomIntrinsicElements,
+	LynxElements,
+	LynxIntrinsicElements,
+	LynxRef,
+	LynxRefCallback,
+	LynxRefObject,
+} from './intrinsics.js';

--- a/packages/lynx/src/main-renderer.ts
+++ b/packages/lynx/src/main-renderer.ts
@@ -1,0 +1,1103 @@
+/**
+ * PrimJS-safe, one-shot renderer ABI for Lynx's synchronous first screen.
+ *
+ * This intentionally mirrors only the compiler-facing descriptor surface from
+ * `octane/universal/native`. It does not import the universal scheduler,
+ * reconciler, effects, refs, event handlers, or background transport.
+ */
+import type {
+	UniversalComponent,
+	UniversalContext,
+	UniversalEventPriority,
+	UniversalHostBatch,
+	UniversalHostCommand,
+	UniversalKey,
+	UniversalPlan,
+	UniversalPlanNode,
+	UniversalPropEntry,
+	UniversalRenderable,
+	UniversalRenderContext,
+} from 'octane/universal/native';
+import { isLynxNativeResource } from './resource.js';
+
+const UNIVERSAL_PLAN = Symbol.for('octane.universal.plan');
+const UNIVERSAL_VALUE = Symbol.for('octane.universal.value');
+const UNIVERSAL_LIST = Symbol.for('octane.universal.list');
+const UNIVERSAL_COMPONENT = Symbol.for('octane.universal.component');
+const UNIVERSAL_COMPONENT_VALUE = Symbol.for('octane.universal.component-value');
+const UNIVERSAL_PROPS = Symbol.for('octane.universal.props');
+const UNIVERSAL_CHILDREN = Symbol.for('octane.universal.children');
+const UNIVERSAL_IF = Symbol.for('octane.universal.if');
+const UNIVERSAL_SWITCH = Symbol.for('octane.universal.switch');
+const UNIVERSAL_FOR = Symbol.for('octane.universal.for');
+const UNIVERSAL_TRY = Symbol.for('octane.universal.try');
+const UNIVERSAL_CONTEXT = Symbol.for('octane.universal.context');
+const UNIVERSAL_ACTIVITY = Symbol.for('octane.universal.activity');
+const UNIVERSAL_KEYED = Symbol.for('octane.universal.keyed');
+const UNIVERSAL_PORTAL = Symbol.for('octane.universal.portal');
+const CONTEXT_TAG = Symbol.for('octane.context');
+const FIRST_SCREEN_EVENT = Symbol.for('octane.lynx.first-screen-event');
+const NO_CHILDREN = Symbol('octane.lynx.first-screen.no-children');
+const NO_KEY = Symbol('octane.lynx.first-screen.no-key');
+
+export const UNIVERSAL_HMR: unique symbol = Symbol.for('octane.universal.hmr') as never;
+
+interface PlanValue {
+	readonly $$kind: symbol;
+	readonly plan: UniversalPlan;
+	readonly values: readonly unknown[];
+	readonly key: UniversalKey | null;
+}
+
+interface PropsValue {
+	readonly $$kind: symbol;
+	readonly props: Readonly<Record<string, unknown>>;
+	readonly key: unknown;
+	readonly hasKey: boolean;
+	readonly hasChildren: boolean;
+}
+
+interface ComponentValue {
+	readonly $$kind: symbol;
+	readonly renderer: string;
+	readonly component: UniversalComponent<any>;
+	readonly props: PropsValue;
+	readonly key: unknown;
+	readonly hasKey: boolean;
+}
+
+interface FirstScreenOwner {
+	readonly parent: FirstScreenOwner | null;
+	readonly contexts: Map<UniversalContext<any>, unknown> | null;
+	readonly visibility: 'visible' | 'hidden';
+}
+
+interface FirstScreenHost {
+	kind: 'host';
+	key: UniversalKey | null;
+	id: number;
+	readonly type: string;
+	readonly props: Readonly<Record<string, unknown>>;
+	readonly events: ReadonlyMap<string, UniversalEventPriority>;
+	readonly visibility: 'visible' | 'hidden';
+	readonly children: FirstScreenNode[];
+}
+
+interface FirstScreenRange {
+	kind: 'range';
+	key: UniversalKey | null;
+	id: number;
+	readonly children: FirstScreenNode[];
+}
+
+type FirstScreenNode = FirstScreenHost | FirstScreenRange;
+
+interface FirstScreenAttempt {
+	owner: FirstScreenOwner;
+	nextId: number;
+	nextListener: number;
+	nextUniversalId: number;
+}
+
+interface TrackedThenable<T = unknown> extends PromiseLike<T> {
+	status?: 'pending' | 'fulfilled' | 'rejected';
+	value?: T;
+	reason?: unknown;
+}
+
+class FirstScreenSuspense {
+	constructor(readonly thenable: PromiseLike<unknown>) {}
+}
+
+let CURRENT_ATTEMPT: FirstScreenAttempt | null = null;
+let NEXT_HOOK_SLOT = 0;
+const SLOT_STACK: unknown[] = [];
+
+function currentAttempt(): FirstScreenAttempt {
+	if (CURRENT_ATTEMPT === null) {
+		throw new Error('Lynx first-screen hooks may only run while a component is rendering.');
+	}
+	return CURRENT_ATTEMPT;
+}
+
+function currentOwner(): FirstScreenOwner {
+	return currentAttempt().owner;
+}
+
+function withOwner<T>(owner: FirstScreenOwner, render: () => T): T {
+	const attempt = currentAttempt();
+	const previous = attempt.owner;
+	attempt.owner = owner;
+	try {
+		return render();
+	} finally {
+		attempt.owner = previous;
+	}
+}
+
+function childOwner(
+	parent: FirstScreenOwner,
+	contexts: Map<UniversalContext<any>, unknown> | null = null,
+	visibility: 'visible' | 'hidden' = parent.visibility,
+): FirstScreenOwner {
+	return { parent, contexts, visibility };
+}
+
+function assertRenderer(renderer: string): void {
+	if (renderer !== 'lynx') {
+		throw new Error(
+			`Lynx first-screen renderer cannot evaluate renderer ${JSON.stringify(renderer)}.`,
+		);
+	}
+}
+
+function freezePlanNode(node: UniversalPlanNode): UniversalPlanNode {
+	if (node.kind === 'host') {
+		return Object.freeze({
+			kind: 'host',
+			type: node.type,
+			...(node.props === undefined ? null : { props: Object.freeze({ ...node.props }) }),
+			...(node.bindings === undefined
+				? null
+				: {
+						bindings: Object.freeze(
+							node.bindings.map(([name, slot]) => Object.freeze([name, slot] as const)),
+						),
+					}),
+			...(node.propsSlot === undefined ? null : { propsSlot: node.propsSlot }),
+			children: Object.freeze((node.children || []).map(freezePlanNode)),
+		});
+	}
+	if (node.kind === 'range') {
+		return Object.freeze({
+			kind: 'range',
+			children: Object.freeze(node.children.map(freezePlanNode)),
+		});
+	}
+	if (node.kind === 'slot') return Object.freeze({ kind: 'slot', slot: node.slot });
+	if (node.kind === 'component') {
+		return Object.freeze({
+			kind: 'component',
+			renderer: node.renderer,
+			...(node.component === undefined ? null : { component: node.component }),
+			...(node.componentSlot === undefined ? null : { componentSlot: node.componentSlot }),
+			...(node.propsSlot === undefined ? null : { propsSlot: node.propsSlot }),
+			...(node.keySlot === undefined ? null : { keySlot: node.keySlot }),
+			children: Object.freeze((node.children || []).map(freezePlanNode)),
+		});
+	}
+	if (node.kind === 'if') {
+		return Object.freeze({
+			kind: 'if',
+			conditionSlot: node.conditionSlot,
+			then: freezePlanNode(node.then),
+			...(node.else === undefined ? null : { else: freezePlanNode(node.else) }),
+		});
+	}
+	if (node.kind === 'switch') {
+		return Object.freeze({
+			kind: 'switch',
+			valueSlot: node.valueSlot,
+			cases: Object.freeze(
+				node.cases.map(([value, child]) => Object.freeze([value, freezePlanNode(child)] as const)),
+			),
+			...(node.default === undefined ? null : { default: freezePlanNode(node.default) }),
+		});
+	}
+	return Object.freeze({
+		kind: 'text',
+		...(node.value === undefined ? null : { value: node.value }),
+		...(node.slot === undefined ? null : { slot: node.slot }),
+	});
+}
+
+export function universalPlan(renderer: string, root: UniversalPlanNode): UniversalPlan {
+	assertRenderer(renderer);
+	return Object.freeze({
+		$$kind: UNIVERSAL_PLAN,
+		renderer,
+		root: freezePlanNode(root),
+	}) as unknown as UniversalPlan;
+}
+
+export function universalValue(
+	plan: UniversalPlan,
+	values: readonly unknown[] = [],
+	key: UniversalKey | null = null,
+): UniversalRenderable {
+	if ((plan as { $$kind?: unknown }).$$kind !== UNIVERSAL_PLAN) {
+		throw new TypeError('universalValue expected a universal plan.');
+	}
+	return { $$kind: UNIVERSAL_VALUE, plan, values, key } as unknown as UniversalRenderable;
+}
+
+export function universalKey(key: UniversalKey, value: UniversalRenderable): UniversalRenderable {
+	if ((value as { $$kind?: unknown }).$$kind === UNIVERSAL_VALUE) {
+		return { ...(value as PlanValue), key } as UniversalRenderable;
+	}
+	return { $$kind: UNIVERSAL_KEYED, key, value } as unknown as UniversalRenderable;
+}
+
+export function universalList<T>(
+	items: Iterable<T>,
+	render: (item: T, index: number) => UniversalRenderable,
+	empty?: UniversalRenderable,
+): UniversalRenderable {
+	const values: UniversalRenderable[] = [];
+	let index = 0;
+	for (const item of items) values.push(render(item, index++));
+	return { $$kind: UNIVERSAL_LIST, values, ...(values.length === 0 ? { empty } : null) } as never;
+}
+
+function defineProtoProp(props: Record<PropertyKey, unknown>, value: unknown): void {
+	Object.defineProperty(props, '__proto__', {
+		configurable: true,
+		enumerable: true,
+		value,
+		writable: true,
+	});
+}
+
+function assignSpread(
+	props: Record<PropertyKey, unknown>,
+	value: unknown,
+	canonicalizeHostClass: boolean,
+): void {
+	if (value == null) return;
+	const source = Object(value) as Record<PropertyKey, unknown>;
+	for (const key of Reflect.ownKeys(source)) {
+		if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue;
+		if (key === '__proto__') defineProtoProp(props, source[key]);
+		else if (canonicalizeHostClass && key === 'className') props.class = source[key];
+		else props[key] = source[key];
+	}
+}
+
+export function universalProps(
+	entries: readonly UniversalPropEntry[],
+	children: unknown = NO_CHILDREN,
+	canonicalizeHostClass = false,
+): PropsValue {
+	const props: Record<string, unknown> = {};
+	for (const entry of entries) {
+		if (entry[0] === 'spread') {
+			assignSpread(props, entry[1], canonicalizeHostClass);
+			continue;
+		}
+		const name = canonicalizeHostClass && entry[1] === 'className' ? 'class' : entry[1];
+		if (name === '__proto__') defineProtoProp(props, entry[2]);
+		else props[name] = entry[2];
+	}
+	if (children !== NO_CHILDREN) props.children = children;
+	const hasKey = Object.prototype.hasOwnProperty.call(props, 'key');
+	const key = hasKey ? props.key : null;
+	if (hasKey) delete props.key;
+	return {
+		$$kind: UNIVERSAL_PROPS,
+		props: Object.freeze(props),
+		key,
+		hasKey,
+		hasChildren: Object.prototype.hasOwnProperty.call(props, 'children'),
+	};
+}
+
+function normalizeProps(value: unknown): PropsValue {
+	if ((value as { $$kind?: unknown })?.$$kind === UNIVERSAL_PROPS) return value as PropsValue;
+	return universalProps(value == null ? [] : [['spread', value]]);
+}
+
+export function universalComponent(
+	renderer: string,
+	component: UniversalComponent<any>,
+	props: PropsValue | Readonly<Record<string, unknown>> | null = null,
+	key: unknown = NO_KEY,
+): UniversalRenderable {
+	assertRenderer(renderer);
+	const normalized = normalizeProps(props);
+	return {
+		$$kind: UNIVERSAL_COMPONENT_VALUE,
+		renderer,
+		component,
+		props: normalized,
+		key: key === NO_KEY ? normalized.key : key,
+		hasKey: key !== NO_KEY || normalized.hasKey,
+	} as never;
+}
+
+export function universalChildren(
+	renderer: string,
+	render: () => UniversalRenderable,
+): UniversalRenderable {
+	assertRenderer(renderer);
+	return { $$kind: UNIVERSAL_CHILDREN, renderer, render } as never;
+}
+
+export function universalIf(
+	condition: unknown,
+	then: () => UniversalRenderable,
+	otherwise: (() => UniversalRenderable) | null = null,
+): UniversalRenderable {
+	return { $$kind: UNIVERSAL_IF, condition: !!condition, then, else: otherwise } as never;
+}
+
+export function universalSwitch(
+	value: unknown,
+	cases: readonly (readonly [unknown, () => UniversalRenderable])[],
+	defaultValue: (() => UniversalRenderable) | null = null,
+): UniversalRenderable {
+	return { $$kind: UNIVERSAL_SWITCH, value, cases, default: defaultValue } as never;
+}
+
+export function universalFor<T>(
+	items: Iterable<T>,
+	key: (item: T, index: number) => UniversalKey,
+	render: (item: T, index: number) => UniversalRenderable,
+	empty: (() => UniversalRenderable) | null = null,
+	ownerless = false,
+	compact = false,
+): UniversalRenderable {
+	return { $$kind: UNIVERSAL_FOR, items, key, render, empty, ownerless, compact } as never;
+}
+
+export function universalTry(
+	body: () => UniversalRenderable,
+	pending: (() => UniversalRenderable) | null = null,
+	catchBody: ((error: unknown, reset: () => void) => UniversalRenderable) | null = null,
+): UniversalRenderable {
+	return { $$kind: UNIVERSAL_TRY, body, pending, catch: catchBody } as never;
+}
+
+export function universalContext<T>(
+	context: UniversalContext<T>,
+	value: T,
+	children: UniversalRenderable | (() => UniversalRenderable),
+): UniversalRenderable {
+	return { $$kind: UNIVERSAL_CONTEXT, context, value, children } as never;
+}
+
+export function universalActivity(
+	mode: 'visible' | 'hidden' | string,
+	body: () => UniversalRenderable,
+): UniversalRenderable {
+	if (mode !== 'visible' && mode !== 'hidden') {
+		throw new TypeError(`Universal Activity mode must be "visible" or "hidden".`);
+	}
+	return { $$kind: UNIVERSAL_ACTIVITY, mode, body } as never;
+}
+
+export function defineUniversalComponent<P>(
+	renderer: string,
+	render: (props: P, context: UniversalRenderContext) => UniversalRenderable,
+	metadata?: { module?: string },
+): UniversalComponent<P> {
+	assertRenderer(renderer);
+	Object.defineProperty(render, UNIVERSAL_COMPONENT, {
+		configurable: false,
+		enumerable: false,
+		value: Object.freeze({ id: renderer, module: metadata?.module, target: 'universal' }),
+	});
+	return render as UniversalComponent<P>;
+}
+
+/** Compiler sentinel replacing an ordinary background event expression. */
+export const firstScreenEvent = FIRST_SCREEN_EVENT;
+
+export function hmrUniversalComponent<P>(
+	_renderer: string,
+	component: UniversalComponent<P>,
+): UniversalComponent<P> {
+	return component;
+}
+
+export function rendererRegion(): never {
+	throw new Error('Lynx first-screen rendering does not support cross-renderer regions.');
+}
+
+function componentContext(): UniversalRenderContext {
+	return {
+		renderer: 'lynx',
+		readContext: useContext,
+		insertionEffect() {},
+		layoutEffect() {},
+		effect() {},
+	};
+}
+
+function normalizeKey(value: unknown): UniversalKey | null {
+	return typeof value === 'string' ||
+		typeof value === 'number' ||
+		typeof value === 'symbol' ||
+		typeof value === 'bigint'
+		? value
+		: null;
+}
+
+const DISCRETE_EVENTS: ReadonlySet<string> = new Set([
+	'blur',
+	'change',
+	'focus',
+	'input',
+	'longpress',
+	'longtap',
+	'tap',
+	'touchend',
+	'touchstart',
+]);
+const CONTINUOUS_EVENTS: ReadonlySet<string> = new Set([
+	'layoutchange',
+	'scroll',
+	'touchmove',
+	'wheel',
+]);
+const EVENT_PROP = /^(?:capture-bind|capture-catch|global-bind|bind|catch)([A-Za-z]+)$/;
+
+function eventPriority(name: string): UniversalEventPriority | null {
+	const match = EVENT_PROP.exec(name);
+	if (match === null) return null;
+	const event = match[1];
+	return DISCRETE_EVENTS.has(event)
+		? 'discrete'
+		: CONTINUOUS_EVENTS.has(event)
+			? 'continuous'
+			: 'default';
+}
+
+function hostNode(
+	type: string,
+	rawProps: Readonly<Record<string, unknown>>,
+	children: FirstScreenNode[],
+): FirstScreenHost {
+	const props: Record<string, unknown> = { ...rawProps };
+	const key = normalizeKey(props.key);
+	delete props.key;
+	delete props.ref;
+	delete props.children;
+	const events = new Map<string, UniversalEventPriority>();
+	for (const name of Object.keys(props)) {
+		if (isLynxNativeResource(props[name])) {
+			throw new TypeError(
+				`Lynx first-screen rendering does not support native resource prop ${JSON.stringify(name)} on <${type}>; native resources are background-only.`,
+			);
+		}
+		const priority = eventPriority(name);
+		if (priority === null) continue;
+		const value = props[name];
+		delete props[name];
+		if (value === FIRST_SCREEN_EVENT || typeof value === 'function') events.set(name, priority);
+	}
+	return {
+		kind: 'host',
+		key,
+		id: 0,
+		type,
+		props: Object.freeze(props),
+		events,
+		visibility: currentOwner().visibility,
+		children,
+	};
+}
+
+function range(children: FirstScreenNode[], key: UniversalKey | null = null): FirstScreenRange {
+	return { kind: 'range', key, id: 0, children };
+}
+
+function renderComponent(
+	component: UniversalComponent<any>,
+	props: Readonly<Record<string, unknown>>,
+): FirstScreenNode[] {
+	const metadata = (component as unknown as Record<PropertyKey, unknown>)[UNIVERSAL_COMPONENT] as
+		| { id?: unknown }
+		| undefined;
+	if (metadata?.id !== 'lynx') {
+		throw new Error('Lynx first-screen rendering requires a compiled Lynx component.');
+	}
+	const owner = childOwner(currentOwner());
+	return withOwner(owner, () => materialize(component(props, componentContext()), null));
+}
+
+function renderPlanNode(node: UniversalPlanNode, values: readonly unknown[]): FirstScreenNode[] {
+	if (node.kind === 'slot') return materialize(values[node.slot], null);
+	if (node.kind === 'text') {
+		return materialize(node.slot === undefined ? (node.value ?? '') : values[node.slot], null);
+	}
+	if (node.kind === 'range') {
+		const children: FirstScreenNode[] = [];
+		for (const child of node.children) children.push(...renderPlanNode(child, values));
+		return [range(children)];
+	}
+	if (node.kind === 'component') {
+		const component = node.component ?? (values[node.componentSlot!] as UniversalComponent<any>);
+		let props =
+			node.propsSlot === undefined ? universalProps([]) : normalizeProps(values[node.propsSlot]);
+		if ((node.children || []).length !== 0) {
+			const childPlan = universalPlan('lynx', { kind: 'range', children: node.children! });
+			props = universalProps(
+				[['spread', props.props]],
+				universalChildren('lynx', () => universalValue(childPlan, values)),
+			);
+		}
+		const rendered = renderComponent(component, props.props);
+		return [
+			range(rendered, normalizeKey(node.keySlot === undefined ? props.key : values[node.keySlot])),
+		];
+	}
+	if (node.kind === 'if') {
+		const selected = values[node.conditionSlot] ? node.then : node.else;
+		return selected === undefined ? [] : [range(renderPlanNode(selected, values))];
+	}
+	if (node.kind === 'switch') {
+		let selected = node.default;
+		for (const entry of node.cases) {
+			if (entry[0] === values[node.valueSlot]) {
+				selected = entry[1];
+				break;
+			}
+		}
+		return selected === undefined ? [] : [range(renderPlanNode(selected, values))];
+	}
+	const props: Record<string, unknown> = { ...(node.props || {}) };
+	for (const binding of node.bindings || []) props[binding[0]] = values[binding[1]];
+	if (node.propsSlot !== undefined)
+		Object.assign(props, normalizeProps(values[node.propsSlot]).props);
+	const dynamicChildren = props.children;
+	const children: FirstScreenNode[] = [];
+	if ((node.children || []).length !== 0) {
+		for (const child of node.children!) children.push(...renderPlanNode(child, values));
+	} else if (dynamicChildren !== undefined) {
+		children.push(...materialize(dynamicChildren, null));
+	}
+	return [hostNode(node.type, props, children)];
+}
+
+function renderTry(value: Record<string, unknown>): FirstScreenNode[] {
+	const attempt = currentAttempt();
+	const universalIdCheckpoint = attempt.nextUniversalId;
+	const owner = childOwner(currentOwner());
+	return withOwner(owner, () => {
+		try {
+			const body = value.body as () => UniversalRenderable;
+			return [range([range(materialize(body(), null))])];
+		} catch (error) {
+			// The body is abandoned before pending/catch commits. Match the
+			// background transaction by making its speculative useId allocations
+			// available to whichever fallback becomes the first tree.
+			attempt.nextUniversalId = universalIdCheckpoint;
+			if (error instanceof FirstScreenSuspense) {
+				const pending = value.pending as (() => UniversalRenderable) | null;
+				if (pending === null) throw error;
+				return [range([range(materialize(pending(), null))])];
+			}
+			const catchBody = value.catch as
+				| ((error: unknown, reset: () => void) => UniversalRenderable)
+				| null;
+			if (catchBody === null) throw error;
+			return [
+				range([
+					range(
+						materialize(
+							catchBody(error, () => {}),
+							null,
+						),
+					),
+				]),
+			];
+		}
+	});
+}
+
+function renderableKey(value: unknown): UniversalKey | null {
+	const record = value as Record<string, unknown>;
+	if (record?.$$kind === UNIVERSAL_VALUE) return (record as unknown as PlanValue).key;
+	if (record?.$$kind === UNIVERSAL_KEYED) return normalizeKey(record.key);
+	if (record?.$$kind === UNIVERSAL_COMPONENT_VALUE) {
+		const component = record as unknown as ComponentValue;
+		return component.hasKey ? normalizeKey(component.key) : null;
+	}
+	return null;
+}
+
+function materialize(value: unknown, key: UniversalKey | null): FirstScreenNode[] {
+	if (value == null || value === false || value === true) return [];
+	const record = value as Record<string, unknown>;
+	if (record?.$$kind === UNIVERSAL_KEYED) {
+		const rendered = materialize(record.value, normalizeKey(record.key));
+		if (rendered.length === 1) rendered[0].key = normalizeKey(record.key);
+		else return [range(rendered, normalizeKey(record.key))];
+		return rendered;
+	}
+	if (record?.$$kind === UNIVERSAL_LIST) {
+		const values = record.values as readonly unknown[];
+		if (values.length === 0 && Object.prototype.hasOwnProperty.call(record, 'empty')) {
+			return materialize(record.empty, null);
+		}
+		const output: FirstScreenNode[] = [];
+		for (const child of values) output.push(...materialize(child, renderableKey(child)));
+		return output;
+	}
+	if (record?.$$kind === UNIVERSAL_VALUE) {
+		const planValue = value as PlanValue;
+		assertRenderer(planValue.plan.renderer);
+		const rendered = renderPlanNode(planValue.plan.root, planValue.values);
+		const resolvedKey = key ?? planValue.key;
+		if (resolvedKey !== null && rendered.length === 1) rendered[0].key = resolvedKey;
+		else if (resolvedKey !== null) return [range(rendered, resolvedKey)];
+		return rendered;
+	}
+	if (record?.$$kind === UNIVERSAL_COMPONENT_VALUE) {
+		const component = value as ComponentValue;
+		assertRenderer(component.renderer);
+		return [
+			range(
+				renderComponent(component.component, component.props.props),
+				component.hasKey ? normalizeKey(component.key) : key,
+			),
+		];
+	}
+	if (record?.$$kind === UNIVERSAL_CHILDREN) {
+		assertRenderer(record.renderer as string);
+		return materialize((record.render as () => UniversalRenderable)(), key);
+	}
+	if (record?.$$kind === UNIVERSAL_IF) {
+		const body = record.condition ? record.then : record.else;
+		return typeof body === 'function' ? [range(materialize(body(), null))] : [];
+	}
+	if (record?.$$kind === UNIVERSAL_SWITCH) {
+		let selected = record.default as (() => UniversalRenderable) | null;
+		for (const entry of record.cases as readonly (readonly [
+			unknown,
+			() => UniversalRenderable,
+		])[]) {
+			if (entry[0] === record.value) {
+				selected = entry[1];
+				break;
+			}
+		}
+		return selected === null ? [] : [range(materialize(selected(), null))];
+	}
+	if (record?.$$kind === UNIVERSAL_FOR) {
+		const output: FirstScreenNode[] = [];
+		const keys = new Set<UniversalKey>();
+		let index = 0;
+		for (const item of record.items as Iterable<unknown>) {
+			const itemKey = (record.key as (item: unknown, index: number) => UniversalKey)(item, index);
+			if (keys.has(itemKey)) throw new Error(`Duplicate universal child key ${String(itemKey)}.`);
+			keys.add(itemKey);
+			const rendered = materialize(
+				(record.render as (item: unknown, index: number) => UniversalRenderable)(item, index++),
+				null,
+			);
+			// `ownerless`/`compact` are compiler hints, not unconditional descriptor
+			// semantics. The background Lynx client driver does not advertise the
+			// compilerLeafProps capability, so universal-core deliberately falls back
+			// to one logical owner range per item. The first-screen program must retain
+			// those ranges too or every following host ID diverges during adoption.
+			output.push(range(rendered, itemKey));
+		}
+		if (index === 0 && typeof record.empty === 'function') {
+			return [range(materialize((record.empty as () => UniversalRenderable)(), null))];
+		}
+		return output;
+	}
+	if (record?.$$kind === UNIVERSAL_CONTEXT) {
+		const context = record.context as UniversalContext<unknown>;
+		const owner = childOwner(currentOwner(), new Map([[context, record.value]]));
+		return [
+			range(
+				withOwner(owner, () => {
+					const children = record.children;
+					return materialize(
+						typeof children === 'function' ? (children as () => UniversalRenderable)() : children,
+						null,
+					);
+				}),
+			),
+		];
+	}
+	if (record?.$$kind === UNIVERSAL_TRY) return renderTry(record);
+	if (record?.$$kind === UNIVERSAL_ACTIVITY) {
+		const visibility =
+			currentOwner().visibility === 'hidden' || record.mode === 'hidden' ? 'hidden' : 'visible';
+		const owner = childOwner(currentOwner(), null, visibility);
+		return [
+			range(
+				withOwner(owner, () => materialize((record.body as () => UniversalRenderable)(), null)),
+			),
+		];
+	}
+	if (record?.$$kind === UNIVERSAL_PORTAL) {
+		throw new Error('Lynx first-screen rendering does not support portals.');
+	}
+	if (Array.isArray(value)) {
+		const output: FirstScreenNode[] = [];
+		for (const child of value) output.push(...materialize(child, renderableKey(child)));
+		return output;
+	}
+	if (typeof value === 'string' || typeof value === 'number' || typeof value === 'bigint') {
+		return [hostNode('#text', { value: String(value) }, [])];
+	}
+	throw new TypeError(
+		`Unsupported Lynx first-screen child ${Object.prototype.toString.call(value)}.`,
+	);
+}
+
+function assignIds(nodes: readonly FirstScreenNode[], attempt: FirstScreenAttempt): void {
+	for (const node of nodes) {
+		node.id = attempt.nextId++;
+		assignIds(node.children, attempt);
+	}
+}
+
+function visitHosts(
+	nodes: readonly FirstScreenNode[],
+	visit: (host: FirstScreenHost) => void,
+): void {
+	for (const node of nodes) {
+		if (node.kind === 'host') visit(node);
+		visitHosts(node.children, visit);
+	}
+}
+
+function physicalChildren(
+	nodes: readonly FirstScreenNode[],
+	output: FirstScreenHost[] = [],
+): FirstScreenHost[] {
+	for (const node of nodes) {
+		if (node.kind === 'host') output.push(node);
+		else physicalChildren(node.children, output);
+	}
+	return output;
+}
+
+function stagePlacements(
+	nodes: readonly FirstScreenNode[],
+	commands: UniversalHostCommand[],
+): void {
+	for (const node of nodes) {
+		stagePlacements(node.children, commands);
+		if (node.kind !== 'host') continue;
+		for (const child of physicalChildren(node.children)) {
+			commands.push({ op: 'insert', parent: node.id, id: child.id, before: null });
+		}
+	}
+}
+
+function freezeBatch(commands: UniversalHostCommand[]): UniversalHostBatch {
+	for (const command of commands) Object.freeze(command);
+	return Object.freeze({ renderer: 'lynx', version: 1, commands: Object.freeze(commands) });
+}
+
+export interface LynxFirstScreenRenderResult {
+	readonly batch: UniversalHostBatch;
+	readonly hostCount: number;
+	readonly logicalCount: number;
+}
+
+/** Evaluate one compiled root and produce the background-compatible initial host batch. */
+export function renderLynxFirstScreen<Props>(
+	component: UniversalComponent<Props>,
+	props: Props,
+): LynxFirstScreenRenderResult {
+	if (CURRENT_ATTEMPT !== null)
+		throw new Error('Lynx first-screen roots cannot render reentrantly.');
+	const rootOwner: FirstScreenOwner = { parent: null, contexts: null, visibility: 'visible' };
+	const attempt: FirstScreenAttempt = {
+		owner: rootOwner,
+		nextId: 1,
+		// Universal roots reserve one million listener IDs per root. The main and
+		// background programs have isolated module globals, so their first roots
+		// both begin at the same deterministic listener seed.
+		nextListener: 1_000_000,
+		nextUniversalId: 1,
+	};
+	CURRENT_ATTEMPT = attempt;
+	let nodes: FirstScreenNode[];
+	try {
+		const metadata = (component as unknown as Record<PropertyKey, unknown>)[UNIVERSAL_COMPONENT] as
+			| { id?: unknown }
+			| undefined;
+		if (metadata?.id !== 'lynx') {
+			throw new Error('Lynx first-screen root.render() requires a compiled Lynx component.');
+		}
+		nodes = materialize(component(props, componentContext()), null);
+		assignIds(nodes, attempt);
+	} finally {
+		CURRENT_ATTEMPT = null;
+	}
+
+	const commands: UniversalHostCommand[] = [];
+	let hostCount = 0;
+	visitHosts(nodes, (host) => {
+		hostCount++;
+		commands.push({ op: 'create', id: host.id, type: host.type, props: host.props });
+	});
+	visitHosts(nodes, (host) => {
+		for (const [type, priority] of host.events) {
+			commands.push({
+				op: 'event',
+				id: host.id,
+				type,
+				listener: { id: attempt.nextListener++, priority },
+			});
+		}
+	});
+	stagePlacements(nodes, commands);
+	for (const host of physicalChildren(nodes)) {
+		commands.push({ op: 'insert', parent: null, id: host.id, before: null });
+	}
+	const hidden: FirstScreenHost[] = [];
+	const collectHiddenPostOrder = (children: readonly FirstScreenNode[]): void => {
+		for (const child of children) {
+			collectHiddenPostOrder(child.children);
+			if (child.kind === 'host' && child.visibility === 'hidden') hidden.push(child);
+		}
+	};
+	collectHiddenPostOrder(nodes);
+	for (const host of hidden) commands.push({ op: 'visibility', id: host.id, state: 'hidden' });
+	return Object.freeze({
+		batch: freezeBatch(commands),
+		hostCount,
+		logicalCount: attempt.nextId - 1,
+	});
+}
+
+export function hookSlots(count: number): number {
+	const base = NEXT_HOOK_SLOT;
+	NEXT_HOOK_SLOT += count;
+	return base;
+}
+
+export function withSlot<T>(slot: unknown, fn: (...args: any[]) => T, ...args: any[]): T {
+	SLOT_STACK.push(slot);
+	try {
+		return fn(...args);
+	} finally {
+		SLOT_STACK.pop();
+	}
+}
+
+const NOOP_UPDATE = () => {};
+
+export function useState<T>(
+	initial: T | (() => T),
+	_slot?: unknown,
+): [T, (value: T | ((previous: T) => T)) => void, () => T] {
+	currentOwner();
+	const value = typeof initial === 'function' ? (initial as () => T)() : initial;
+	return [value, NOOP_UPDATE, () => value];
+}
+
+export const __useStateWithGetter = useState;
+
+export function useReducer<S, A, I = S>(
+	_reducer: (state: S, action: A) => S,
+	initialArg: I,
+	initOrSlot?: ((value: I) => S) | unknown,
+	_maybeSlot?: unknown,
+): [S, (action: A) => void, () => S] {
+	currentOwner();
+	const value =
+		typeof initOrSlot === 'function'
+			? (initOrSlot as (value: I) => S)(initialArg)
+			: (initialArg as unknown as S);
+	return [value, NOOP_UPDATE, () => value];
+}
+
+export const __useReducerWithGetter = useReducer;
+
+export function useInsertionEffect(): void {
+	currentOwner();
+}
+export function useLayoutEffect(): void {
+	currentOwner();
+}
+export function useEffect(): void {
+	currentOwner();
+}
+
+export function useMemo<T>(
+	compute: () => T,
+	_deps?: readonly unknown[] | null,
+	_slot?: unknown,
+): T {
+	currentOwner();
+	return compute();
+}
+
+export function useCallback<T extends (...args: any[]) => any>(
+	callback: T,
+	_deps?: readonly unknown[] | null,
+	_slot?: unknown,
+): T {
+	currentOwner();
+	return callback;
+}
+
+export function useRef<T>(initial: T, _slot?: unknown): { current: T } {
+	currentOwner();
+	return { current: initial };
+}
+
+export function useId(_slot?: unknown): string {
+	const attempt = currentAttempt();
+	const index = attempt.nextUniversalId++;
+	const sum = 1 + index;
+	const paired = (sum * (sum + 1)) / 2 + index;
+	return `:octane-u${paired.toString(36)}:`;
+}
+
+export function useSyncExternalStore<T>(
+	_subscribe: (onStoreChange: () => void) => () => void,
+	getSnapshot: () => T,
+): T {
+	currentOwner();
+	return getSnapshot();
+}
+
+export function useDeferredValue<T>(value: T): T {
+	currentOwner();
+	return value;
+}
+
+export function startTransition(_fn: () => void | Promise<unknown>): void {}
+
+export function useTransition(_slot?: unknown): [boolean, typeof startTransition] {
+	currentOwner();
+	return [false, startTransition];
+}
+
+export function useActionState<State, Payload>(
+	_action: (previousState: State, payload: Payload) => State | Promise<State>,
+	initialState: State,
+): [State, (payload: Payload) => void, boolean] {
+	currentOwner();
+	return [initialState, NOOP_UPDATE, false];
+}
+
+export interface FormStatus {
+	pending: boolean;
+	data: unknown;
+	method: string | null;
+	action: string | ((formData: unknown) => void | Promise<void>) | null;
+}
+
+const FORM_STATUS: FormStatus = Object.freeze({
+	pending: false,
+	data: null,
+	method: null,
+	action: null,
+});
+
+export function useFormStatus(): FormStatus {
+	currentOwner();
+	return FORM_STATUS;
+}
+
+export function useOptimistic<State, Action = State>(
+	passthrough: State,
+	_reducer?: (state: State, action: Action) => State,
+): [State, (action: Action) => void] {
+	currentOwner();
+	return [passthrough, NOOP_UPDATE];
+}
+
+export function useContext<T>(context: UniversalContext<T>): T {
+	for (let owner: FirstScreenOwner | null = currentOwner(); owner !== null; owner = owner.parent) {
+		if (owner.contexts?.has(context)) return owner.contexts.get(context) as T;
+	}
+	return context.defaultValue;
+}
+
+function trackThenable<T>(thenable: TrackedThenable<T>): void {
+	if (
+		thenable.status === 'pending' ||
+		thenable.status === 'fulfilled' ||
+		thenable.status === 'rejected'
+	) {
+		return;
+	}
+	thenable.status = 'pending';
+	thenable.then(
+		(value) => {
+			thenable.status = 'fulfilled';
+			thenable.value = value;
+		},
+		(error) => {
+			thenable.status = 'rejected';
+			thenable.reason = error;
+		},
+	);
+}
+
+export function use<T>(usable: UniversalContext<T> | PromiseLike<T>): T {
+	if ((usable as UniversalContext<T>).$$kind === CONTEXT_TAG)
+		return useContext(usable as UniversalContext<T>);
+	const thenable = usable as TrackedThenable<T>;
+	if (thenable.status === 'fulfilled') return thenable.value as T;
+	if (thenable.status === 'rejected') throw thenable.reason;
+	trackThenable(thenable);
+	throw new FirstScreenSuspense(thenable);
+}
+
+export function useBatch(items: any[]): void {
+	let pending: TrackedThenable[] | null = null;
+	for (const item of items) {
+		if (item == null || typeof item.then !== 'function') continue;
+		const thenable = item as TrackedThenable;
+		trackThenable(thenable);
+		if (thenable.status === 'rejected') break;
+		if (thenable.status === 'pending') (pending ??= []).push(thenable);
+	}
+	if (pending === null) return;
+	if (pending.length === 1) throw new FirstScreenSuspense(pending[0]);
+	throw new FirstScreenSuspense(Promise.all(pending));
+}
+
+export function warmMemo(): void {}
+export function warmChild(): void {}
+
+export function useImperativeHandle(): void {
+	currentOwner();
+}
+
+export function useEffectEvent<T extends (...args: any[]) => any>(_fn: T, _slot?: unknown): T {
+	currentOwner();
+	return NOOP_UPDATE as T;
+}
+
+export function useDebugValue(): void {
+	currentOwner();
+}
+
+export function requestFormReset(): void {}
+
+export function memo<P>(component: UniversalComponent<P>): UniversalComponent<P> {
+	return component;
+}
+
+export function createPortal(children: UniversalRenderable, target: unknown): UniversalRenderable {
+	return { $$kind: UNIVERSAL_PORTAL, children, target } as never;
+}
+
+export const Activity: unique symbol = Symbol.for('octane.Activity') as never;
+
+export interface NativeUniversalContext<T> extends UniversalContext<T> {
+	(props: {
+		value: T;
+		children?: UniversalRenderable | (() => UniversalRenderable);
+	}): UniversalRenderable;
+	readonly Provider: NativeUniversalContext<T>;
+}
+
+export function createContext<T>(defaultValue: T): NativeUniversalContext<T> {
+	const context = ((props: {
+		value: T;
+		children?: UniversalRenderable | (() => UniversalRenderable);
+	}) => universalContext(context, props.value, props.children)) as NativeUniversalContext<T>;
+	Object.defineProperties(context, {
+		$$kind: { value: CONTEXT_TAG, enumerable: true },
+		defaultValue: { value: defaultValue, enumerable: true },
+		Provider: { value: context, enumerable: true },
+		$$version: { value: 0, enumerable: true, writable: true },
+	});
+	return context;
+}

--- a/packages/lynx/src/main-thread.ts
+++ b/packages/lynx/src/main-thread.ts
@@ -803,7 +803,10 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 		}
 
 		let prepared: LynxPreparedHostBatch;
-		const candidateFirstTree = firstTree;
+		// The opaque journal remains live after transfer only so first-screen event
+		// tokens can be resolved until background confirms listener ownership. It
+		// must never be offered to an already-populated background container again.
+		const candidateFirstTree = provisional ? firstTree : null;
 		try {
 			prepared = prepareLynxHostBatch(
 				record.container,
@@ -950,7 +953,7 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 			message.root !== awaitingAdoption.root ||
 			message.version !== awaitingAdoption.version ||
 			message.root !== active.root ||
-			message.version !== active.acceptedVersion
+			message.version > active.acceptedVersion
 		) {
 			report(new Error('Octane Lynx received a stale or foreign adoption-ready message.'));
 			return;

--- a/packages/lynx/src/main-thread.ts
+++ b/packages/lynx/src/main-thread.ts
@@ -1,4 +1,5 @@
 import type {
+	UniversalComponent,
 	UniversalHostBatch,
 	UniversalEventPriority,
 	UniversalSerializableValue,
@@ -6,9 +7,12 @@ import type {
 	UniversalTransportIdentity,
 } from 'octane/universal/native';
 import {
+	captureLynxFirstTree,
 	createLynxHostContainer,
 	createLynxHostDriver,
+	disposeLynxFirstTree,
 	disposeLynxHostContainer,
+	getLynxHostEventListener,
 	isLynxHostAttached,
 	prepareLynxHostBatch,
 	resolveLynxHostNativeEvent,
@@ -18,6 +22,13 @@ import {
 	type LynxHostHandle,
 	type LynxPreparedHostBatch,
 } from './core/host-driver.js';
+import {
+	releaseLynxFirstTree,
+	resolveLynxFirstTreeEvent,
+	type LynxFirstTree,
+	type LynxFirstTreeEventSnapshot,
+	type LynxFirstTreeSnapshot,
+} from './core/first-screen.js';
 import {
 	snapshotLynxNativeEventPayload,
 	type LynxNativeEventPayloadSnapshot,
@@ -32,6 +43,7 @@ import {
 	validateLynxBackgroundInboundMessage,
 	validateLynxBackgroundOutboundMessage,
 	type LynxBackgroundInboundMessage,
+	type LynxAdoptionReadyMessage,
 	type LynxContextProxy,
 	type LynxContextProxyEvent,
 	type LynxDisposeAcknowledgement,
@@ -45,6 +57,8 @@ import {
 	type LynxTerminalDisposeMessage,
 } from './core/protocol.js';
 import { createLynxElementPAPI, type LynxElementPAPI, type LynxElementRef } from './core/papi.js';
+import { installLynxFirstScreenHost } from './first-screen.js';
+import { renderLynxFirstScreen, type LynxFirstScreenRenderResult } from './main-renderer.js';
 
 interface LynxMainThreadGlobals {
 	readonly lynx?: {
@@ -58,6 +72,13 @@ export interface InstallLynxMainThreadOptions {
 	readonly context?: LynxContextProxy;
 	readonly componentId?: string;
 	readonly cssId?: number;
+	/** Enable the synchronous, one-shot main-thread first-screen renderer. */
+	readonly firstScreen?: boolean;
+	/**
+	 * `manual` waits for `markFirstScreenSyncReady()` after authored synchronous
+	 * initialization. `automatic` releases background work after `root.render()`.
+	 */
+	readonly firstScreenSync?: 'automatic' | 'manual';
 	readonly onDiagnostic?: (error: Error) => void;
 }
 
@@ -68,6 +89,10 @@ export interface LynxMainThreadController {
 	dispatchNativeEvent(token: LynxNativeEventToken | string, payload: unknown): void;
 	/** Preserve one native propagation path as a single Octane event scope. */
 	dispatchNativeEventBatch(deliveries: readonly LynxNativeEventDelivery[]): void;
+	/** Clone-safe snapshot retained while background adoption is pending. */
+	firstScreenSnapshot(): LynxFirstTreeSnapshot | null;
+	/** Release a receiver configured with manual first-screen synchronization. */
+	markFirstScreenSyncReady(): void;
 	close(): void;
 }
 
@@ -79,6 +104,7 @@ export interface LynxNativeEventDelivery {
 interface LynxQueuedNativeEventDelivery {
 	readonly token: LynxNativeEventToken | string;
 	readonly payload: LynxNativeEventPayloadSnapshot;
+	readonly firstTreeTarget?: Omit<LynxFirstTreeEventSnapshot, 'listener'>;
 }
 
 interface ActiveLynxMainRoot<Node extends LynxElementRef> {
@@ -95,6 +121,8 @@ type LynxCommitMessage = Extract<
 const MAX_ABORT_TOMBSTONES = 128;
 const MAX_DISPOSED_ROOT_TOMBSTONES = 128;
 const MAX_CLOSE_CLEANUP_ATTEMPTS = 3;
+const MAX_FIRST_SCREEN_EVENT_DELIVERIES = 128;
+const FIRST_SCREEN_ROOT_ID = 1;
 
 function normalizedError(value: unknown, fallback: string): Error {
 	if (value instanceof Error) return value;
@@ -200,6 +228,21 @@ function acknowledgementHandles<Node extends LynxElementRef>(
 export function installLynxMainThread<Node extends LynxElementRef = LynxElementRef>(
 	options: InstallLynxMainThreadOptions = {},
 ): LynxMainThreadController {
+	if (options.firstScreen !== undefined && typeof options.firstScreen !== 'boolean') {
+		throw new TypeError('Octane Lynx firstScreen must be a boolean when provided.');
+	}
+	if (
+		options.firstScreenSync !== undefined &&
+		options.firstScreenSync !== 'automatic' &&
+		options.firstScreenSync !== 'manual'
+	) {
+		throw new TypeError('Octane Lynx firstScreenSync must be automatic or manual.');
+	}
+	if (options.firstScreen !== true && options.firstScreenSync !== undefined) {
+		throw new TypeError('Octane Lynx firstScreenSync requires firstScreen: true.');
+	}
+	const firstScreenEnabled = options.firstScreen === true;
+	const firstScreenSync = options.firstScreenSync ?? 'automatic';
 	const rawTarget = options.target ?? globalThis;
 	if (rawTarget === null || typeof rawTarget !== 'object') {
 		throw new TypeError('Octane Lynx main-thread target must be a global object.');
@@ -236,8 +279,18 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 	let active: ActiveLynxMainRoot<Node> | null = null;
 	let closed = false;
 	let commitInProgress = false;
+	let firstScreenState: 'open' | 'painted' | 'skipped' | 'failed' | 'cleanup-pending' =
+		firstScreenEnabled ? 'open' : 'skipped';
+	let firstScreenSyncReady = !firstScreenEnabled;
+	let firstTree: LynxFirstTree<Node> | null = null;
+	let failedFirstScreenSource: LynxHostContainer<Node> | null = null;
+	let awaitingAdoption: UniversalTransportIdentity | null = null;
+	let readyAnnouncementSent = false;
+	let firstTreeSnapshotSent = false;
+	let uninstallFirstScreenHost: (() => void) | null = null;
 	const queuedCommits: LynxCommitMessage[] = [];
 	const queuedNativeEvents: Array<readonly LynxQueuedNativeEventDelivery[]> = [];
+	const queuedReadyRequests = new Set<number>();
 	const queuedHostAttachments: Array<{
 		readonly version: number;
 		readonly deltas: readonly LynxHostAttachmentDelta[];
@@ -261,6 +314,89 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 		context.dispatchEvent({ type: LYNX_MAIN_TO_BACKGROUND_EVENT, data: validated });
 	};
 
+	const canAnnounceReady = () =>
+		!firstScreenEnabled ||
+		(firstScreenState !== 'open' && firstScreenState !== 'cleanup-pending' && firstScreenSyncReady);
+
+	const dispatchReady = (request: number): void => {
+		// Request 0 is an unsolicited availability hint and can be emitted before a
+		// background listener exists. Put the clone-safe tree on the first correlated
+		// reply so the O(tree) clone happens once and always has a receiver.
+		const snapshot =
+			request === LYNX_READY_ANNOUNCEMENT_REQUEST || firstTreeSnapshotSent || firstTree === null
+				? null
+				: firstTree.snapshot;
+		const reply: LynxMainReadyReply = {
+			protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
+			renderer: LYNX_TRANSPORT_RENDERER,
+			type: 'main-ready',
+			request,
+			...(snapshot == null ? null : { firstTree: snapshot }),
+		};
+		dispatch(reply);
+		if (snapshot !== null) firstTreeSnapshotSent = true;
+	};
+
+	const announceReady = (): void => {
+		if (!canAnnounceReady()) return;
+		try {
+			if (!readyAnnouncementSent && queuedReadyRequests.size === 0) {
+				// A queued request already proves the background listener is present, so
+				// answer it directly instead of cloning the first-tree snapshot into both
+				// an unsolicited announcement and the correlated reply.
+				dispatchReady(LYNX_READY_ANNOUNCEMENT_REQUEST);
+				readyAnnouncementSent = true;
+			}
+			for (const request of [...queuedReadyRequests]) {
+				dispatchReady(request);
+				queuedReadyRequests.delete(request);
+				readyAnnouncementSent = true;
+			}
+		} catch (error) {
+			throw report(error, 'Octane Lynx could not dispatch the main-ready reply.');
+		}
+	};
+
+	const releaseFirstTree = (): void => {
+		if (firstTree === null) return;
+		try {
+			releaseLynxFirstTree(firstTree);
+		} catch (error) {
+			report(error, 'Octane Lynx could not release its first-screen journal.');
+			return;
+		}
+		firstTree = null;
+	};
+
+	const disposeAvailableFirstTree = (): boolean => {
+		if (firstTree === null) return true;
+		const cleanup = disposeLynxFirstTree(firstTree);
+		for (const error of cleanup.errors) {
+			report(error, 'Octane Lynx first-screen cleanup failed.');
+		}
+		if (cleanup.complete) releaseFirstTree();
+		return cleanup.complete && firstTree === null;
+	};
+
+	const disposeFailedFirstScreenSource = (): boolean => {
+		if (failedFirstScreenSource === null) return true;
+		const cleanup = disposeLynxHostContainer(failedFirstScreenSource);
+		for (const error of cleanup.errors) {
+			report(error, 'Octane Lynx failed first-screen cleanup retry.');
+		}
+		if (cleanup.complete) failedFirstScreenSource = null;
+		return cleanup.complete;
+	};
+
+	const retryFirstScreenCleanup = (): boolean => {
+		for (let attempt = 0; attempt < MAX_CLOSE_CLEANUP_ATTEMPTS; attempt++) {
+			const treeComplete = disposeAvailableFirstTree();
+			const sourceComplete = disposeFailedFirstScreenSource();
+			if (treeComplete && sourceComplete) return true;
+		}
+		return false;
+	};
+
 	const snapshotNativeEventBatch = (
 		deliveries: readonly LynxNativeEventDelivery[],
 	): readonly LynxQueuedNativeEventDelivery[] => {
@@ -275,9 +411,21 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 				if (typeof delivery.token !== 'string') {
 					throw new TypeError(`Octane Lynx native event delivery ${index} token must be a string.`);
 				}
+				const resolved =
+					firstTree === null ? null : resolveLynxFirstTreeEvent(firstTree, delivery.token);
 				return Object.freeze({
 					token: delivery.token,
 					payload: snapshotLynxNativeEventPayload(delivery.payload),
+					...(resolved === null
+						? null
+						: {
+								firstTreeTarget: Object.freeze({
+									host: resolved.host,
+									generation: resolved.generation,
+									type: resolved.type,
+									priority: resolved.priority,
+								}),
+							}),
 				});
 			}),
 		);
@@ -290,7 +438,27 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 		}
 		let priority: UniversalEventPriority | null = null;
 		const transported = deliveries.map((delivery) => {
-			const resolved = resolveLynxHostNativeEvent(active!.container, delivery.token);
+			const firstTarget = delivery.firstTreeTarget;
+			const resolved =
+				firstTarget === undefined
+					? resolveLynxHostNativeEvent(active!.container, delivery.token)
+					: (() => {
+							const handle = driver.getPublicInstance(active!.container, firstTarget.host);
+							if (
+								handle === null ||
+								handle.generation !== firstTarget.generation ||
+								!isLynxHostAttached(active!.container, firstTarget.host)
+							) {
+								return null;
+							}
+							const listener = getLynxHostEventListener(
+								active!.container,
+								firstTarget.host,
+								firstTarget.type,
+							);
+							if (listener === null || listener.priority !== firstTarget.priority) return null;
+							return Object.freeze({ listener: listener.id, priority: listener.priority });
+						})();
 			if (resolved === null) {
 				throw new Error('Octane Lynx received a stale, hidden, removed, or foreign native event.');
 			}
@@ -324,6 +492,31 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 			return;
 		}
 		if (commitInProgress) {
+			const queuedCount = queuedNativeEvents.reduce((count, queued) => count + queued.length, 0);
+			if (
+				(firstTree !== null || awaitingAdoption !== null) &&
+				queuedCount + snapshot.length > MAX_FIRST_SCREEN_EVENT_DELIVERIES
+			) {
+				report(
+					new Error(
+						`Octane Lynx dropped a first-screen event batch after ${MAX_FIRST_SCREEN_EVENT_DELIVERIES} buffered deliveries.`,
+					),
+				);
+				return;
+			}
+			queuedNativeEvents.push(snapshot);
+			return;
+		}
+		if (firstTree !== null || awaitingAdoption !== null) {
+			const queuedCount = queuedNativeEvents.reduce((count, queued) => count + queued.length, 0);
+			if (queuedCount + snapshot.length > MAX_FIRST_SCREEN_EVENT_DELIVERIES) {
+				report(
+					new Error(
+						`Octane Lynx dropped a first-screen event batch after ${MAX_FIRST_SCREEN_EVENT_DELIVERIES} buffered deliveries.`,
+					),
+				);
+				return;
+			}
 			queuedNativeEvents.push(snapshot);
 			return;
 		}
@@ -476,17 +669,72 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 	const abortKey = (identity: UniversalTransportIdentity) => `${identity.root}:${identity.version}`;
 
 	const handleReady = (message: LynxMainReadyRequest): void => {
-		const reply: LynxMainReadyReply = {
-			protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
-			renderer: LYNX_TRANSPORT_RENDERER,
-			type: 'main-ready',
-			request: message.request,
-		};
-		try {
-			dispatch(reply);
-		} catch (error) {
-			throw report(error, 'Octane Lynx could not dispatch the main-ready reply.');
+		queuedReadyRequests.add(message.request);
+		if (firstScreenState === 'cleanup-pending' && retryFirstScreenCleanup()) {
+			firstScreenState = 'failed';
 		}
+		if (canAnnounceReady()) announceReady();
+	};
+
+	const renderFirstScreen = <Props>(
+		component: UniversalComponent<Props>,
+		props: Props,
+	): LynxFirstScreenRenderResult => {
+		if (closed) throw new Error('Octane Lynx first-screen root rendered after receiver close.');
+		if (firstScreenState !== 'open') {
+			throw new Error(
+				'Octane Lynx first-screen root is one-shot and its render window has closed.',
+			);
+		}
+		let source: LynxHostContainer<Node> | null = null;
+		try {
+			const result = renderLynxFirstScreen(component, props);
+			source = createLynxHostContainer(papi, {
+				root: FIRST_SCREEN_ROOT_ID,
+				page,
+			});
+			const prepared = prepareLynxHostBatch(source, result.batch);
+			prepared.apply();
+			if (!prepared.mutationStarted) {
+				throw new Error('Octane Lynx first-screen host batch did not cross its apply boundary.');
+			}
+			firstTree = captureLynxFirstTree(source);
+			firstScreenState = 'painted';
+			if (firstScreenSync === 'automatic') firstScreenSyncReady = true;
+			announceReady();
+			return result;
+		} catch (error) {
+			firstScreenState = 'cleanup-pending';
+			firstScreenSyncReady = true;
+			if (firstTree === null && source !== null) {
+				// Retain the only native ownership journal before cleanup. A throwing
+				// remove/flush must remain retryable rather than leaking an unreachable
+				// first tree and allowing the background root to duplicate it.
+				failedFirstScreenSource = source;
+			}
+			if (retryFirstScreenCleanup()) {
+				firstScreenState = 'failed';
+			} else {
+				report(
+					new Error(
+						'Octane Lynx withheld background readiness because failed first-screen cleanup remains incomplete.',
+					),
+				);
+			}
+			announceReady();
+			throw report(error, 'Octane Lynx could not render its synchronous first screen.');
+		}
+	};
+
+	const markFirstScreenSyncReady = (): void => {
+		if (!firstScreenEnabled) {
+			throw new Error('Octane Lynx first-screen synchronization is not enabled.');
+		}
+		if (closed) throw new Error('Octane Lynx first-screen synchronization ran after close.');
+		if (firstScreenSyncReady) return;
+		firstScreenSyncReady = true;
+		if (firstScreenState === 'open') firstScreenState = 'skipped';
+		announceReady();
 	};
 
 	const handleAbort = (identity: UniversalTransportIdentity): void => {
@@ -555,8 +803,20 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 		}
 
 		let prepared: LynxPreparedHostBatch;
+		const candidateFirstTree = firstTree;
 		try {
-			prepared = prepareLynxHostBatch(record.container, message.batch);
+			prepared = prepareLynxHostBatch(
+				record.container,
+				message.batch,
+				candidateFirstTree === null
+					? undefined
+					: {
+							firstTree: candidateFirstTree,
+							onMismatch(error) {
+								report(error, 'Octane Lynx repaired a first-screen mismatch.');
+							},
+						},
+			);
 		} catch (error) {
 			if (provisional) disposeRecord(record);
 			reject(identity, error);
@@ -583,16 +843,30 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 		}
 
 		record.acceptedVersion = message.version;
+		if (!applyFailed && prepared.firstTreeAction === 'adopt') {
+			awaitingAdoption = Object.freeze({ ...identity });
+		} else if (candidateFirstTree !== null) {
+			queuedNativeEvents.length = 0;
+			if (prepared.firstTreeAction === 'repair' || applyFailed) {
+				disposeAvailableFirstTree();
+			}
+		}
 		const handles = acknowledgementHandles(driver, record.container, prepared, message.batch);
 		const acknowledgement: LynxTransportAcknowledgement = {
 			...identity,
 			type: 'ack',
 			handles,
+			...(prepared.firstTreeAction === 'none'
+				? null
+				: {
+						adoption: prepared.firstTreeAction === 'adopt' ? 'adopted' : 'repaired',
+					}),
 		};
 		try {
 			dispatch(acknowledgement);
 		} catch (error) {
 			queuedNativeEvents.length = 0;
+			awaitingAdoption = null;
 			const cleanup = disposeRecord(record);
 			if (!cleanup.complete) {
 				report(
@@ -604,15 +878,18 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 				rememberDisposed(record.root, record.acceptedVersion);
 				active = null;
 			}
+			if (firstTree !== null) {
+				disposeAvailableFirstTree();
+			}
 			throw report(error, 'Octane Lynx could not dispatch an accepted batch acknowledgement.');
 		}
 
 		if (!applyFailed) {
 			if (!drainHostAttachments()) return;
-			drainNativeEvents();
+			if (awaitingAdoption === null) drainNativeEvents();
 			try {
 				dispatch({ ...identity, type: 'complete' });
-				drainNativeEvents();
+				if (awaitingAdoption === null) drainNativeEvents();
 			} catch (error) {
 				throw report(error, 'Octane Lynx could not dispatch accepted batch completion.');
 			}
@@ -621,6 +898,8 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 
 		queuedNativeEvents.length = 0;
 		queuedHostAttachments.length = 0;
+		awaitingAdoption = null;
+		if (firstTree !== null) disposeAvailableFirstTree();
 		try {
 			dispatch({
 				...identity,
@@ -664,9 +943,30 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 		}
 	};
 
+	const handleAdoptionReady = (message: LynxAdoptionReadyMessage): void => {
+		if (
+			awaitingAdoption === null ||
+			active === null ||
+			message.root !== awaitingAdoption.root ||
+			message.version !== awaitingAdoption.version ||
+			message.root !== active.root ||
+			message.version !== active.acceptedVersion
+		) {
+			report(new Error('Octane Lynx received a stale or foreign adoption-ready message.'));
+			return;
+		}
+		try {
+			drainNativeEvents();
+		} finally {
+			awaitingAdoption = null;
+			releaseFirstTree();
+		}
+	};
+
 	const handleDispose = (message: LynxDisposeMessage | LynxTerminalDisposeMessage): void => {
 		queuedNativeEvents.length = 0;
 		queuedHostAttachments.length = 0;
+		awaitingAdoption = null;
 		const terminal = message.type === 'terminal-dispose';
 		const acknowledge = () => {
 			const acknowledgement: LynxDisposeAcknowledgement = {
@@ -679,11 +979,32 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 				throw report(error, 'Octane Lynx could not dispatch dispose acknowledgement.');
 			}
 		};
+		const requestRetry = (error: Error) => {
+			try {
+				dispatch({
+					...message,
+					type: 'dispose-retry',
+					error: wireError(error, 'Octane Lynx native cleanup is incomplete.'),
+				});
+			} catch (dispatchError) {
+				throw report(dispatchError, 'Octane Lynx could not dispatch a dispose retry request.');
+			}
+		};
 		if (disposedRoots.get(message.root) === message.version) {
 			acknowledge();
 			return;
 		}
 		if (terminal && active === null) {
+			if (!retryFirstScreenCleanup()) {
+				requestRetry(
+					report(
+						new Error(
+							`Octane Lynx withheld dispose acknowledgement for root ${message.root}; first-screen cleanup remains incomplete.`,
+						),
+					),
+				);
+				return;
+			}
 			rememberDisposed(message.root, message.version);
 			acknowledge();
 			return;
@@ -706,18 +1027,17 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 					`Octane Lynx withheld dispose acknowledgement for root ${record.root}; ${cleanup.remainingRoots} native root(s) remain attached.`,
 				),
 			);
-			try {
-				dispatch({
-					...message,
-					type: 'dispose-retry',
-					error: wireError(
-						cleanup.errors[0] ?? unresolvedError,
-						'Octane Lynx native cleanup is incomplete.',
+			requestRetry(cleanup.errors[0] ?? unresolvedError);
+			return;
+		}
+		if (!retryFirstScreenCleanup()) {
+			requestRetry(
+				report(
+					new Error(
+						`Octane Lynx withheld dispose acknowledgement for root ${record.root}; first-screen cleanup remains incomplete.`,
 					),
-				});
-			} catch (error) {
-				throw report(error, 'Octane Lynx could not dispatch a dispose retry request.');
-			}
+				),
+			);
 			return;
 		}
 		rememberDisposed(record.root, terminal ? message.version : record.acceptedVersion);
@@ -745,6 +1065,8 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 		}
 		if (message.type === 'main-ready-request') {
 			handleReady(message);
+		} else if (message.type === 'adoption-ready') {
+			handleAdoptionReady(message);
 		} else if (message.type === 'abort') {
 			handleAbort(message);
 		} else if (message.type === 'dispose' || message.type === 'terminal-dispose') {
@@ -756,19 +1078,47 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 
 	context.addEventListener(LYNX_BACKGROUND_TO_MAIN_EVENT, receive);
 	try {
-		dispatch({
-			protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
-			renderer: LYNX_TRANSPORT_RENDERER,
-			type: 'main-ready',
-			request: LYNX_READY_ANNOUNCEMENT_REQUEST,
-		});
+		if (firstScreenEnabled) {
+			uninstallFirstScreenHost = installLynxFirstScreenHost({
+				render: renderFirstScreen,
+				markSyncReady: markFirstScreenSyncReady,
+				unmount() {
+					queuedNativeEvents.length = 0;
+					awaitingAdoption = null;
+					// Unmount closes the authored synchronous window immediately. Cleanup
+					// can still gate readiness until a retry succeeds.
+					firstScreenSyncReady = true;
+					if (!retryFirstScreenCleanup()) {
+						firstScreenState = 'cleanup-pending';
+						report(
+							new Error(
+								'Octane Lynx withheld background readiness because first-screen unmount cleanup remains incomplete.',
+							),
+						);
+						return;
+					}
+					if (
+						firstScreenState === 'open' ||
+						firstScreenState === 'painted' ||
+						firstScreenState === 'cleanup-pending'
+					) {
+						firstScreenState = 'skipped';
+					}
+					announceReady();
+				},
+			});
+		}
+		announceReady();
 	} catch (error) {
 		closed = true;
 		context.removeEventListener(LYNX_BACKGROUND_TO_MAIN_EVENT, receive);
+		uninstallFirstScreenHost?.();
+		uninstallFirstScreenHost = null;
 		if (active !== null) {
 			disposeRecord(active);
 			active = null;
 		}
+		if (firstTree !== null) disposeAvailableFirstTree();
 		throw report(error, 'Octane Lynx could not announce main-thread readiness.');
 	}
 
@@ -791,9 +1141,17 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 		dispatchNativeEventBatch(deliveries) {
 			submitNativeEventBatch(deliveries);
 		},
+		firstScreenSnapshot() {
+			return firstTree?.snapshot ?? null;
+		},
+		markFirstScreenSyncReady,
 		close() {
 			queuedNativeEvents.length = 0;
 			queuedHostAttachments.length = 0;
+			queuedReadyRequests.clear();
+			awaitingAdoption = null;
+			uninstallFirstScreenHost?.();
+			uninstallFirstScreenHost = null;
 			if (!closed) {
 				closed = true;
 				try {
@@ -815,6 +1173,13 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 					rememberDisposed(record.root, record.acceptedVersion);
 					active = null;
 				}
+			}
+			if (!retryFirstScreenCleanup()) {
+				report(
+					new Error(
+						'Octane Lynx retained incomplete first-screen cleanup for a later close retry.',
+					),
+				);
 			}
 		},
 	};

--- a/packages/lynx/status.json
+++ b/packages/lynx/status.json
@@ -3,18 +3,18 @@
     "package": "@lynx-js/react",
     "version": "0.123.0 (b6b809cd)"
   },
-  "surface": "Private Milestones 3–5 source/test/build implementation: the native element/prop/event/ref slice; callback-demanded list cells; serializable native-resource handles; background platform hooks; separate thread compiler presets; a production Rspeedy application mode that pairs each authored background graph with a generated main receiver and emits a .lynx.bundle verified by decoding; and a facade over the official JavaScript testing environment. No Lynx Web, native allocation, scrolling, lifecycle, Native Module, custom-element, Android, or iOS execution claim is made.",
+  "surface": "Private Milestones 3–6 source/test/build implementation: the native element/prop/event/ref slice; callback-demanded list cells; serializable native-resource handles; background platform hooks; a one-shot render-only main runtime; clone-safe first-tree snapshots, adoption, event handoff, mismatch repair, and cleanup; a production Rspeedy application mode that specializes the same authored entry into main and background graphs and emits a .lynx.bundle verified by decoding; and a facade over the official JavaScript testing environment. No Lynx Web, native first-paint, native identity, allocation, scrolling, lifecycle, Native Module, custom-element, Android, iOS, or performance claim is made.",
   "divergences": [
     "The package adapts an audited @lynx-js/types@4.0.0 props/events slice into renderer-owned module declarations because the upstream events entry transitively loads global Element/JSX augmentation.",
     "Background refs receive cloned acknowledgement-gated asynchronous handles, never live main-thread Element PAPI objects or synchronous layout.",
     "A recycled list item remains a logical Octane subtree while its physical native cell is absent. Refs detach and reattach through the optional universal host-attachment capability; viewport recycling alone does not run component or effect cleanup.",
     "Background event handlers receive detached data-only payloads without live event methods or native instances.",
-    "Rspeedy application mode generates and installs a main-thread receiver, but that receiver only applies transported background commits. It does not render the application, provide main-thread first paint, or adopt a first tree; those remain Milestone 6.",
+    "Rspeedy application mode compiles the same authored entry twice: the main layer resolves the package root to the synchronous first-screen facade and uses a PrimJS-safe one-shot renderer, while the background layer owns effects, refs, state, listeners, scheduling, and later updates.",
     "Platform APIs are background-only; the main-thread compiler preset rejects @octanejs/lynx/platform imports and statically visible NativeModules access. createLynxRoot() separately verifies the public background-only lynx.getJSModule() surface at runtime. The reload export only requests lynx.reload(); it is not a framework reload receiver.",
-    "Nested lists, portals, Lynx Suspense proof, lazy bundles, gestures, animations, full boolean-defer parity, and defer.unmountRecycled semantics are excluded from the initial Milestone 4 surface."
+    "Native list hosts, list materializations, and background-root-scoped native-resource props are excluded from first-tree capture and have no Milestone 6 adoption claim. Nested lists, portals, native Lynx Suspense proof, lazy bundles, gestures, animations, eager-main versus deferred-background boolean-defer semantics, and defer.unmountRecycled semantics remain excluded."
   ],
   "ssr": "Unsupported. Lynx first-screen adoption is a native runtime protocol, not HTML SSR or Octane hydration.",
-  "verified": "2026-07-20",
+  "verified": "2026-07-21",
   "notes": [
     "Milestone 0 remains blocked on public lifecycle/event hooks, reload/background teardown, Web execution, and the Android/iOS engine matrix; this private implementation is not a technical preview.",
     "Native __AddEvent token registration is public, but the production background callback receiver remains the private lynxCoreInject.tt.publishEvent hook; dispatchNativeEvent* is a source/test bridge only.",
@@ -28,11 +28,12 @@
     "The app-owned Android/iOS Native Module and custom-element files under examples/native-capabilities are illustrative, excluded from package files, and not compiled or device-verified.",
     "Boolean list-item defer metadata is accepted and forwarded, but all initial Octane list cells are callback-demanded regardless of that prop; this is not full ReactLynx defer behavior. ReactLynx's defer={{ unmountRecycled: true }} lifecycle behavior is not implemented.",
     "Nested <list> hosts are rejected during batch preparation in the initial contract rather than entering a partially supported recycling path.",
-    "Milestones 3–5 formal exits remain unmet until equivalent pinned ReactLynx fixtures and native capability samples are compared through public observations on Lynx Web, Explorer, Android, and iOS.",
-    "Omitting the Rspeedy plugin's thread option is the production application source/build path. Explicit background and main-thread options remain isolated compiler-graph diagnostics.",
+    "Milestone 6 source and JavaScript-host tests cover synchronous one-shot rendering, an explicit entry-initialization synchronization gate, a clone-safe snapshot, compatible adoption without host allocation or restructuring, FIFO ordinary-event replay after background listener ownership, typed mismatch repair, and cleanup. This is not native first-frame, identity, or performance evidence.",
+    "Milestones 3–6 formal exits remain unmet until equivalent pinned ReactLynx fixtures and native capability samples are compared through public observations on Lynx Web, Explorer, Android, and iOS.",
+    "Omitting the Rspeedy plugin's thread option is the production application source/build path. The generated main graph installs the receiver, evaluates the same authored imports under the first-screen specialization, and releases its manual sync gate after synchronous initialization; the background graph evaluates those authored imports with the full renderer. Explicit background and main-thread options remain isolated compiler-graph diagnostics.",
     "@octanejs/lynx/testing re-exports the pinned JavaScript testing environment's public classes and install/tree/event helpers. Its availability explicitly excludes native and device execution.",
     "The exact private compatibility set is Lynx SDK 3.9.0 (target 3.9), Rspeedy 0.16.0, Rsbuild 2.1.4, Rspack 2.1.3, template plugin 0.13.0, CSS extract plugin 0.9.0, runtime wrapper 0.2.2, dev transport 0.3.0, runtime globals 0.0.7, tasm 0.0.39, testing environment 0.3.0, Lynx types 4.0.0, and the blocked Web control @lynx-js/web-core@0.22.2.",
-    "The source/build milestone does not establish Lynx Web or device startup, runtime event delivery, reload/teardown, device error capture, source-map resolution in an engine, or stale-free HMR. The private packages are not a technical preview."
+    "The source/build milestone does not establish Lynx Web or device startup, native first paint or adoption, runtime event delivery through the private native callback, reload/teardown receivers, device error capture, source-map resolution in an engine, or stale-free HMR. The private packages are not a technical preview."
   ],
   "docs": [
     "docs/lynx-native-renderer-plan.md",

--- a/packages/lynx/tests/first-screen.test.ts
+++ b/packages/lynx/tests/first-screen.test.ts
@@ -1,0 +1,450 @@
+import { installLynxTestingEnv, uninstallLynxTestingEnv } from '@lynx-js/testing-environment';
+import { JSDOM } from 'jsdom';
+import {
+	defineUniversalComponent,
+	universalFor,
+	universalPlan,
+	universalProps,
+	universalValue,
+	useLayoutEffect,
+	type UniversalComponent,
+} from 'octane/universal/native';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createLynxRoot, type LynxRoot } from '../src/index.js';
+import { root as firstScreenRoot } from '../src/first-screen.js';
+import { installLynxMainThread, type LynxMainThreadController } from '../src/main-thread.js';
+import {
+	defineUniversalComponent as defineFirstScreenComponent,
+	firstScreenEvent,
+	renderLynxFirstScreen,
+	universalFor as firstScreenFor,
+	universalPlan as firstScreenPlan,
+	universalProps as firstScreenProps,
+	universalValue as firstScreenValue,
+	useLayoutEffect as useFirstScreenLayoutEffect,
+} from '../src/main-renderer.js';
+import {
+	LYNX_BACKGROUND_TO_MAIN_EVENT,
+	LYNX_MAIN_TO_BACKGROUND_EVENT,
+	LYNX_TRANSPORT_PROTOCOL_VERSION,
+	LYNX_TRANSPORT_RENDERER,
+	type LynxBackgroundInboundMessage,
+	type LynxContextProxy,
+} from '../src/core/protocol.js';
+
+interface SceneProps {
+	readonly id: string;
+	readonly items: readonly string[];
+	readonly onTap: (payload: unknown) => void;
+	readonly onEffect: (owner: 'main' | 'background') => void;
+}
+
+interface EventRegistration {
+	readonly listener: string | undefined;
+}
+
+interface InstalledEnvironment {
+	readonly dom: JSDOM;
+	readonly main: LynxMainThreadController;
+	readonly registrations: EventRegistration[];
+}
+
+const mainPlan = firstScreenPlan('lynx', {
+	kind: 'host',
+	type: 'view',
+	propsSlot: 0,
+});
+
+const MainScene = defineFirstScreenComponent('lynx', (props: SceneProps) => {
+	useFirstScreenLayoutEffect(() => {
+		props.onEffect('main');
+	});
+	return [
+		firstScreenValue(mainPlan, [
+			firstScreenProps([
+				['set', 'id', props.id],
+				['set', 'bindtap', firstScreenEvent],
+			]),
+		]),
+		firstScreenFor(
+			props.items,
+			(item) => item,
+			(item) => firstScreenValue(mainPlan, [firstScreenProps([['set', 'id', item]])]),
+			null,
+			true,
+			true,
+		),
+	];
+});
+
+const MainSingleHost = defineFirstScreenComponent('lynx', (props: { readonly id: string }) =>
+	firstScreenValue(mainPlan, [firstScreenProps([['set', 'id', props.id]])]),
+);
+
+const backgroundPlan = universalPlan('lynx', {
+	kind: 'host',
+	type: 'view',
+	propsSlot: 0,
+});
+
+const BackgroundScene = defineUniversalComponent('lynx', (props: SceneProps) => {
+	useLayoutEffect(() => {
+		props.onEffect('background');
+	}, []);
+	return [
+		universalValue(backgroundPlan, [
+			universalProps([
+				['set', 'id', props.id],
+				['set', 'bindtap', props.onTap],
+			]),
+		]),
+		universalFor(
+			props.items,
+			(item) => item,
+			(item) => universalValue(backgroundPlan, [universalProps([['set', 'id', item]])]),
+			null,
+			true,
+			true,
+		),
+	];
+});
+
+let installed: InstalledEnvironment | null = null;
+let backgroundRoot: LynxRoot | null = null;
+
+function mainContext(): LynxContextProxy {
+	return (
+		globalThis as typeof globalThis & {
+			lynx: { getJSContext(): LynxContextProxy };
+		}
+	).lynx.getJSContext();
+}
+
+function backgroundContext(): LynxContextProxy {
+	return (
+		globalThis as typeof globalThis & {
+			lynx: { getCoreContext(): LynxContextProxy };
+		}
+	).lynx.getCoreContext();
+}
+
+function installEnvironment(
+	configurePAPI?: (target: Record<string, unknown>) => void,
+): InstalledEnvironment {
+	const dom = new JSDOM('<!doctype html><html><body></body></html>');
+	installLynxTestingEnv(globalThis, {
+		window: dom.window as unknown as Window & typeof globalThis,
+	});
+	globalThis.lynxTestingEnv.switchToMainThread();
+	const target = globalThis as unknown as Record<string, unknown>;
+	configurePAPI?.(target);
+	const registrations: EventRegistration[] = [];
+	const addEvent = target.__AddEvent as (
+		node: object,
+		kind: string,
+		name: string,
+		listener: string | undefined,
+	) => void;
+	target.__AddEvent = (node, kind, name, listener) => {
+		registrations.push(Object.freeze({ listener }));
+		addEvent(node, kind, name, listener);
+	};
+	const main = installLynxMainThread({ firstScreen: true, firstScreenSync: 'manual' });
+	return (installed = { dom, main, registrations });
+}
+
+afterEach(async () => {
+	if (backgroundRoot !== null) {
+		try {
+			await backgroundRoot.unmount();
+		} catch {
+			// A manual protocol test can leave no live background root.
+		}
+	}
+	backgroundRoot = null;
+	if (installed !== null) {
+		installed.main.close();
+		globalThis.lynxTestingEnv.clearGlobal();
+		uninstallLynxTestingEnv(globalThis);
+		installed.dom.window.close();
+	}
+	installed = null;
+});
+
+describe.sequential('Lynx synchronous first-screen adoption', () => {
+	it('paints synchronously, gates background startup, adopts node identity, and replays events', async () => {
+		const { dom, main, registrations } = installEnvironment();
+		const inbound: LynxBackgroundInboundMessage[] = [];
+		mainContext().addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
+			inbound.push(event.data as LynxBackgroundInboundMessage);
+		});
+		const effects: string[] = [];
+		const events: unknown[] = [];
+		let placeholderToken: string | undefined;
+		const props: SceneProps = {
+			id: 'first-screen',
+			items: ['a', 'b'],
+			onTap(payload) {
+				events.push(payload);
+				if (
+					(payload as { detail?: { phase?: unknown } }).detail?.phase === 'first' &&
+					placeholderToken !== undefined
+				) {
+					main.dispatchNativeEvent(placeholderToken, {
+						type: 'tap',
+						detail: { phase: 'reentrant' },
+					});
+				}
+			},
+			onEffect(owner) {
+				effects.push(owner);
+			},
+		};
+
+		const painted = firstScreenRoot.render(MainScene as UniversalComponent<SceneProps>, props);
+		const firstNode = dom.window.document.querySelector('#first-screen');
+		const firstA = dom.window.document.querySelector('#a');
+		const firstB = dom.window.document.querySelector('#b');
+		expect(painted).toMatchObject({ hostCount: 3, logicalCount: 5 });
+		expect(firstNode).not.toBeNull();
+		expect(firstA).not.toBeNull();
+		expect(firstB).not.toBeNull();
+		expect(effects).toEqual([]);
+		expect(main.firstScreenSnapshot()).toMatchObject({ root: 1, version: 1 });
+
+		placeholderToken = registrations.find((entry) => entry.listener !== undefined)?.listener;
+		expect(placeholderToken).toBeTypeOf('string');
+		main.dispatchNativeEvent(placeholderToken!, { type: 'tap', detail: { phase: 'first' } });
+
+		globalThis.lynxTestingEnv.switchToBackgroundThread();
+		backgroundRoot = createLynxRoot();
+		const rendering = backgroundRoot.render(BackgroundScene, props);
+		let settled = false;
+		void rendering.finally(() => {
+			settled = true;
+		});
+		await Promise.resolve();
+		expect(settled).toBe(false);
+		expect(events).toEqual([]);
+
+		globalThis.lynxTestingEnv.switchToMainThread();
+		main.markFirstScreenSyncReady();
+		globalThis.lynxTestingEnv.switchToBackgroundThread();
+		await rendering;
+
+		expect(dom.window.document.querySelector('#first-screen')).toBe(firstNode);
+		expect(dom.window.document.querySelector('#a')).toBe(firstA);
+		expect(dom.window.document.querySelector('#b')).toBe(firstB);
+		expect(effects).toEqual(['background']);
+		expect(main.diagnostics()).toEqual([]);
+		expect(events).toEqual([
+			{ type: 'tap', detail: { phase: 'first' } },
+			{ type: 'tap', detail: { phase: 'reentrant' } },
+		]);
+		expect(main.firstScreenSnapshot()).toBeNull();
+		expect(main.activeIdentity()).toMatchObject({ root: 1, version: 1 });
+		const ready = inbound.filter((message) => message.type === 'main-ready');
+		expect(ready).toHaveLength(1);
+		expect(ready[0]).toMatchObject({
+			type: 'main-ready',
+			firstTree: { root: 1, version: 1 },
+		});
+		expect((ready[0] as { request: number }).request).toBeGreaterThan(0);
+	});
+
+	it('repairs a nondeterministic first tree and reports the typed mismatch', () => {
+		const { dom, main } = installEnvironment();
+		const props: SceneProps = {
+			id: 'main-value',
+			items: ['a', 'b'],
+			onTap() {},
+			onEffect() {},
+		};
+		firstScreenRoot.render(MainScene as UniversalComponent<SceneProps>, props);
+		const firstNode = dom.window.document.querySelector('#main-value');
+		const inbound: LynxBackgroundInboundMessage[] = [];
+		mainContext().addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
+			inbound.push(event.data as LynxBackgroundInboundMessage);
+		});
+		main.markFirstScreenSyncReady();
+
+		const replacement = renderLynxFirstScreen(MainScene, {
+			...props,
+			id: 'background-value',
+		});
+		backgroundContext().dispatchEvent({
+			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
+			data: {
+				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
+				renderer: LYNX_TRANSPORT_RENDERER,
+				root: 1,
+				version: 1,
+				type: 'commit',
+				batch: replacement.batch,
+			},
+		});
+
+		expect(inbound.find((message) => message.type === 'ack')).toMatchObject({
+			type: 'ack',
+			adoption: 'repaired',
+		});
+		expect(dom.window.document.querySelector('#background-value')).not.toBe(firstNode);
+		expect(main.diagnostics()).toEqual([
+			expect.objectContaining({
+				code: 'OCTANE_LYNX_FIRST_SCREEN_MISMATCH',
+				path: 'snapshot.nodes[1].props',
+			}),
+		]);
+	});
+
+	it('can seal an entry with no first-screen render and unblock background readiness', () => {
+		const { main } = installEnvironment();
+		const inbound: LynxBackgroundInboundMessage[] = [];
+		mainContext().addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
+			inbound.push(event.data as LynxBackgroundInboundMessage);
+		});
+
+		main.markFirstScreenSyncReady();
+
+		expect(inbound).toEqual([
+			{
+				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
+				renderer: LYNX_TRANSPORT_RENDERER,
+				type: 'main-ready',
+				request: 0,
+			},
+		]);
+		expect(() =>
+			firstScreenRoot.render(MainScene as UniversalComponent<SceneProps>, {
+				id: 'late',
+				items: ['a', 'b'],
+				onTap() {},
+				onEffect() {},
+			}),
+		).toThrow(/render window has closed/);
+	});
+
+	it('retains a captured first tree until facade unmount cleanup can be retried', async () => {
+		let removalFailures = 0;
+		const { dom, main } = installEnvironment((target) => {
+			const remove = target.__RemoveElement as (parent: object, child: object) => unknown;
+			target.__RemoveElement = (parent: object, child: object) => {
+				if (removalFailures++ < 3) throw new Error('transient first-tree remove failure');
+				return remove(parent, child);
+			};
+		});
+		const inbound: LynxBackgroundInboundMessage[] = [];
+		mainContext().addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
+			inbound.push(event.data as LynxBackgroundInboundMessage);
+		});
+		firstScreenRoot.render(MainSingleHost, { id: 'cleanup-retry' });
+
+		await firstScreenRoot.unmount();
+		expect(dom.window.document.querySelector('#cleanup-retry')).not.toBeNull();
+		expect(main.firstScreenSnapshot()).not.toBeNull();
+		expect(inbound).toEqual([]);
+
+		backgroundContext().dispatchEvent({
+			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
+			data: {
+				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
+				renderer: LYNX_TRANSPORT_RENDERER,
+				type: 'main-ready-request',
+				request: 43,
+			},
+		});
+		expect(dom.window.document.querySelector('#cleanup-retry')).toBeNull();
+		expect(main.firstScreenSnapshot()).toBeNull();
+		expect(inbound).toEqual([expect.objectContaining({ type: 'main-ready', request: 43 })]);
+	});
+
+	it('retains a failed pre-capture source and retries cleanup for background readiness', () => {
+		const captureFailure = new Error('capture unique ID failed');
+		let uniqueIdCalls = 0;
+		let removalFailures = 0;
+		const { dom, main } = installEnvironment((target) => {
+			const getUniqueId = target.__GetElementUniqueID as (node: object) => number;
+			target.__GetElementUniqueID = (node: object) => {
+				if (++uniqueIdCalls === 2) throw captureFailure;
+				return getUniqueId(node);
+			};
+			const remove = target.__RemoveElement as (parent: object, child: object) => unknown;
+			target.__RemoveElement = (parent: object, child: object) => {
+				if (removalFailures++ < 6) throw new Error('transient failed-source remove failure');
+				return remove(parent, child);
+			};
+		});
+		const inbound: LynxBackgroundInboundMessage[] = [];
+		mainContext().addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
+			inbound.push(event.data as LynxBackgroundInboundMessage);
+		});
+
+		expect(() => firstScreenRoot.render(MainSingleHost, { id: 'failed-capture' })).toThrow(
+			captureFailure,
+		);
+		expect(dom.window.document.querySelector('#failed-capture')).not.toBeNull();
+		expect(main.firstScreenSnapshot()).toBeNull();
+		expect(inbound).toEqual([]);
+
+		backgroundContext().dispatchEvent({
+			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
+			data: {
+				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
+				renderer: LYNX_TRANSPORT_RENDERER,
+				type: 'main-ready-request',
+				request: 41,
+			},
+		});
+		expect(dom.window.document.querySelector('#failed-capture')).not.toBeNull();
+		expect(inbound).toEqual([]);
+
+		backgroundContext().dispatchEvent({
+			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
+			data: {
+				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
+				renderer: LYNX_TRANSPORT_RENDERER,
+				type: 'main-ready-request',
+				request: 42,
+			},
+		});
+
+		expect(dom.window.document.querySelector('#failed-capture')).toBeNull();
+		expect(inbound).toEqual([
+			expect.objectContaining({ type: 'main-ready', request: 41 }),
+			expect.objectContaining({ type: 'main-ready', request: 42 }),
+		]);
+	});
+
+	it('withholds terminal dispose acknowledgement until first-tree cleanup succeeds', () => {
+		let removalFailures = 0;
+		const { dom, main } = installEnvironment((target) => {
+			const remove = target.__RemoveElement as (parent: object, child: object) => unknown;
+			target.__RemoveElement = (parent: object, child: object) => {
+				if (removalFailures++ < 3) throw new Error('transient terminal remove failure');
+				return remove(parent, child);
+			};
+		});
+		const inbound: LynxBackgroundInboundMessage[] = [];
+		mainContext().addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
+			inbound.push(event.data as LynxBackgroundInboundMessage);
+		});
+		firstScreenRoot.render(MainSingleHost, { id: 'terminal-retry' });
+		const dispose = {
+			protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
+			renderer: LYNX_TRANSPORT_RENDERER,
+			root: 1,
+			version: 1,
+			type: 'terminal-dispose' as const,
+		};
+
+		backgroundContext().dispatchEvent({ type: LYNX_BACKGROUND_TO_MAIN_EVENT, data: dispose });
+		expect(inbound.at(-1)).toMatchObject({ type: 'dispose-retry', root: 1, version: 1 });
+		expect(dom.window.document.querySelector('#terminal-retry')).not.toBeNull();
+		expect(main.firstScreenSnapshot()).not.toBeNull();
+
+		backgroundContext().dispatchEvent({ type: LYNX_BACKGROUND_TO_MAIN_EVENT, data: dispose });
+		expect(inbound.at(-1)).toMatchObject({ type: 'dispose-ack', root: 1, version: 1 });
+		expect(dom.window.document.querySelector('#terminal-retry')).toBeNull();
+		expect(main.firstScreenSnapshot()).toBeNull();
+	});
+});

--- a/packages/lynx/tests/first-screen.test.ts
+++ b/packages/lynx/tests/first-screen.test.ts
@@ -297,6 +297,72 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 		]);
 	});
 
+	it('accepts a later commit before adoption ownership is confirmed', () => {
+		const { dom, main } = installEnvironment();
+		firstScreenRoot.render(MainSingleHost, { id: 'first-screen' });
+		const inbound: LynxBackgroundInboundMessage[] = [];
+		let queuedSecondCommit = false;
+		mainContext().addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
+			const message = event.data as LynxBackgroundInboundMessage;
+			inbound.push(message);
+			if (message.type !== 'ack' || message.version !== 1 || queuedSecondCommit) return;
+			queuedSecondCommit = true;
+			backgroundContext().dispatchEvent({
+				type: LYNX_BACKGROUND_TO_MAIN_EVENT,
+				data: {
+					protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
+					renderer: LYNX_TRANSPORT_RENDERER,
+					root: 1,
+					version: 2,
+					type: 'commit',
+					batch: {
+						renderer: 'lynx',
+						version: 2,
+						commands: [{ op: 'update', id: 1, props: { id: 'after-adoption' } }],
+					},
+				},
+			});
+		});
+		main.markFirstScreenSyncReady();
+
+		const initial = renderLynxFirstScreen(MainSingleHost, { id: 'first-screen' });
+		backgroundContext().dispatchEvent({
+			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
+			data: {
+				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
+				renderer: LYNX_TRANSPORT_RENDERER,
+				root: 1,
+				version: 1,
+				type: 'commit',
+				batch: initial.batch,
+			},
+		});
+
+		expect(inbound.filter((message) => message.type === 'ack')).toEqual([
+			expect.objectContaining({ type: 'ack', version: 1, adoption: 'adopted' }),
+			expect.objectContaining({ type: 'ack', version: 2 }),
+		]);
+		expect(inbound.some((message) => message.type === 'reject')).toBe(false);
+		expect(dom.window.document.querySelector('#after-adoption')).not.toBeNull();
+		expect(main.activeIdentity()).toMatchObject({ root: 1, version: 2 });
+		expect(main.firstScreenSnapshot()).not.toBeNull();
+
+		backgroundContext().dispatchEvent({
+			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
+			data: {
+				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
+				renderer: LYNX_TRANSPORT_RENDERER,
+				root: 1,
+				version: 1,
+				type: 'adoption-ready',
+			},
+		});
+
+		expect(main.firstScreenSnapshot()).toBeNull();
+		expect(main.activeIdentity()).toMatchObject({ root: 1, version: 2 });
+		expect(main.diagnostics()).toEqual([]);
+	});
+
 	it('can seal an entry with no first-screen render and unblock background readiness', () => {
 		const { main } = installEnvironment();
 		const inbound: LynxBackgroundInboundMessage[] = [];

--- a/packages/lynx/tests/host-driver.test.ts
+++ b/packages/lynx/tests/host-driver.test.ts
@@ -3,13 +3,20 @@ import { installLynxTestingEnv, uninstallLynxTestingEnv } from '@lynx-js/testing
 import { JSDOM } from 'jsdom';
 import { describe, expect, it } from 'vitest';
 import {
+	captureLynxFirstTree,
 	createLynxHostContainer,
 	createLynxHostDriver,
 	disposeLynxHostContainer,
+	disposeLynxFirstTree,
 	getLynxHostEventListener,
 	prepareLynxHostBatch,
 	resolveLynxHostNativeEvent,
 } from '../src/core/host-driver.js';
+import {
+	LYNX_FIRST_TREE_MISMATCH,
+	releaseLynxFirstTree,
+	resolveLynxFirstTreeEvent,
+} from '../src/core/first-screen.js';
 import { LYNX_CSS_SCOPE_PROP } from '../src/core/host-props.js';
 import { createLynxElementPAPI, type LynxElementPAPI } from '../src/core/papi.js';
 
@@ -29,7 +36,15 @@ interface FakeNode {
 	text: string;
 }
 
-type FaultMethod = 'flush' | 'insertBefore' | 'remove' | 'replace' | 'setAttribute';
+type FaultMethod =
+	| 'flush'
+	| 'getParent'
+	| 'insertBefore'
+	| 'remove'
+	| 'replace'
+	| 'setAttribute'
+	| 'setEvent'
+	| 'setRefSelector';
 
 interface FakePAPI extends LynxElementPAPI<FakeNode> {
 	readonly calls: string[];
@@ -58,19 +73,20 @@ function createFakePAPI(): FakePAPI {
 		id: null,
 		text,
 	});
-	const run = (method: FaultMethod, mutation: () => void): void => {
+	const run = <Result>(method: FaultMethod, mutation: () => Result): Result => {
 		calls.push(method);
 		if (fault?.method === method && fault.timing === 'before') {
 			const error = fault.error;
 			fault = null;
 			throw error;
 		}
-		mutation();
+		const result = mutation();
 		if (fault?.method === method && fault.timing === 'after') {
 			const error = fault.error;
 			fault = null;
 			throw error;
 		}
+		return result;
 	};
 	const detach = (node: FakeNode): void => {
 		if (node.parent === null) return;
@@ -95,6 +111,12 @@ function createFakePAPI(): FakePAPI {
 		getUniqueId(node) {
 			calls.push('getUniqueId');
 			return node.uid;
+		},
+		getParent(node) {
+			return run('getParent', () => node.parent);
+		},
+		isEqual(first, second) {
+			return first === second;
 		},
 		isChild(parent, child) {
 			calls.push('isChild');
@@ -160,14 +182,16 @@ function createFakePAPI(): FakePAPI {
 			Object.assign(node.dataset, value);
 		},
 		setEvent(node, kind, name, listener) {
-			calls.push('setEvent');
-			const key = `${kind}:${name}`;
-			if (listener === undefined) node.events.delete(key);
-			else node.events.set(key, listener);
+			run('setEvent', () => {
+				const key = `${kind}:${name}`;
+				if (listener === undefined) node.events.delete(key);
+				else node.events.set(key, listener);
+			});
 		},
 		setRefSelector(node, value) {
-			calls.push('setRefSelector');
-			node.selector = value;
+			run('setRefSelector', () => {
+				node.selector = value;
+			});
 		},
 		setId(node, id) {
 			calls.push('setId');
@@ -259,6 +283,369 @@ describe('Lynx Element PAPI host driver', () => {
 		expect(papi.calls).toEqual(['getUniqueId']);
 	});
 
+	it('transfers a compatible first tree without allocating or restructuring native nodes', () => {
+		const papi = createFakePAPI();
+		const page = papi.createPage('entry', 0);
+		const source = createLynxHostContainer(papi, { root: 7, page });
+		prepareLynxHostBatch(
+			source,
+			batch(1, [
+				{ op: 'create', id: 1, type: 'view', props: { id: 'button' } },
+				{ op: 'create', id: 2, type: 'text', props: { class: ['label', 'active'] } },
+				{ op: 'event', id: 1, type: 'bindtap', listener: { id: 101, priority: 'discrete' } },
+				{ op: 'insert', parent: null, id: 1, before: null },
+				{ op: 'insert', parent: 1, id: 2, before: null },
+			]),
+		).apply();
+		const sourceRoot = page.children[0]!;
+		const sourceChild = sourceRoot.children[0]!;
+		const placeholderToken = sourceRoot.events.get('bindEvent:tap')!;
+		const preparedBeforeCapture = prepareLynxHostBatch(
+			source,
+			batch(2, [{ op: 'update', id: 1, props: { id: 'too-late' } }]),
+		);
+		const firstTree = captureLynxFirstTree(source, { plan: 'scene:compatible' });
+
+		expect(JSON.parse(JSON.stringify(firstTree.snapshot))).toEqual(firstTree.snapshot);
+		expect(firstTree.snapshot).toMatchObject({
+			format: 1,
+			renderer: 'lynx',
+			root: 7,
+			version: 1,
+			plan: 'scene:compatible',
+			roots: [1],
+		});
+		const capturedClass = firstTree.snapshot.nodes.find((node) => node.id === 2)?.props.class;
+		expect(capturedClass).toEqual(['label', 'active']);
+		expect(Object.isFrozen(capturedClass)).toBe(true);
+		expect(() => (capturedClass as string[]).push('mutated')).toThrow();
+		expect(resolveLynxFirstTreeEvent(firstTree, placeholderToken)).toEqual({
+			host: 1,
+			generation: 1,
+			type: 'bindtap',
+			listener: 101,
+			priority: 'discrete',
+		});
+		expect(() => prepareLynxHostBatch(source, batch(2, []))).toThrow(/captured first-tree root/);
+		expect(() => preparedBeforeCapture.apply()).toThrow(/captured first-tree root/);
+		preparedBeforeCapture.abort();
+
+		const target = createLynxHostContainer(papi, { root: 7, page });
+		const driver = createLynxHostDriver<FakeNode>();
+		papi.resetCalls();
+		const prepared = prepareLynxHostBatch(
+			target,
+			batch(1, [
+				{ op: 'create', id: 1, type: 'view', props: { id: 'button' } },
+				{ op: 'create', id: 2, type: 'text', props: { class: ['label', 'active'] } },
+				{ op: 'event', id: 1, type: 'bindtap', listener: { id: 202, priority: 'discrete' } },
+				{ op: 'insert', parent: null, id: 1, before: null },
+				{ op: 'insert', parent: 1, id: 2, before: null },
+			]),
+			{ firstTree },
+		);
+
+		expect(prepared.firstTreeAction).toBe('adopt');
+		expect(prepared.handleDelta.map((entry) => entry.op)).toEqual(['create', 'create']);
+		prepared.apply();
+
+		expect(page.children).toEqual([sourceRoot]);
+		expect(sourceRoot.children).toEqual([sourceChild]);
+		expect(source.disposed).toBe(true);
+		expect(target.instanceCount).toBe(2);
+		expect(driver.getPublicInstance(target, 1)).toMatchObject({
+			root: 7,
+			id: 1,
+			generation: 1,
+		});
+		expect(papi.calls.some((call) => call.startsWith('create:'))).toBe(false);
+		expect(papi.calls).not.toContain('insertBefore');
+		expect(papi.calls).not.toContain('remove');
+		const adoptedToken = sourceRoot.events.get('bindEvent:tap')!;
+		expect(adoptedToken).not.toBe(placeholderToken);
+		expect(resolveLynxHostNativeEvent(target, adoptedToken)).toEqual({
+			listener: 202,
+			priority: 'discrete',
+		});
+		expect(disposeLynxFirstTree(firstTree).complete).toBe(true);
+		expect(target.disposed).toBe(false);
+		releaseLynxFirstTree(firstTree);
+		expect(resolveLynxFirstTreeEvent(firstTree, placeholderToken)).toBeNull();
+	});
+
+	it.each([
+		['setRefSelector', 'before'],
+		['setRefSelector', 'after'],
+		['setEvent', 'before'],
+		['setEvent', 'after'],
+	] as const)(
+		'cleans every transferred placeholder event when adoption %s fails %s mutation',
+		(method, timing) => {
+			const papi = createFakePAPI();
+			const page = papi.createPage('entry', 0);
+			const source = createLynxHostContainer(papi, { root: 7, page });
+			const sourceBatch = batch(1, [
+				{ op: 'create', id: 1, type: 'view', props: { id: 'parent' } },
+				{ op: 'create', id: 2, type: 'view', props: { id: 'child' } },
+				{ op: 'event', id: 1, type: 'bindtap', listener: { id: 101, priority: 'discrete' } },
+				{ op: 'event', id: 2, type: 'bindtap', listener: { id: 102, priority: 'discrete' } },
+				{ op: 'insert', parent: null, id: 1, before: null },
+				{ op: 'insert', parent: 1, id: 2, before: null },
+			]);
+			prepareLynxHostBatch(source, sourceBatch).apply();
+			const sourceRoot = page.children[0]!;
+			const sourceChild = sourceRoot.children[0]!;
+			const firstTree = captureLynxFirstTree(source);
+			const target = createLynxHostContainer(papi, { root: 7, page });
+			const targetBatch = batch(1, [
+				{ op: 'create', id: 1, type: 'view', props: { id: 'parent' } },
+				{ op: 'create', id: 2, type: 'view', props: { id: 'child' } },
+				{ op: 'event', id: 1, type: 'bindtap', listener: { id: 201, priority: 'discrete' } },
+				{ op: 'event', id: 2, type: 'bindtap', listener: { id: 202, priority: 'discrete' } },
+				{ op: 'insert', parent: null, id: 1, before: null },
+				{ op: 'insert', parent: 1, id: 2, before: null },
+			]);
+			const prepared = prepareLynxHostBatch(target, targetBatch, { firstTree });
+			const failure = new Error(`${method} failed ${timing} mutation`);
+			papi.failNext(method, timing, failure);
+
+			expect(() => prepared.apply()).toThrow(failure);
+			expect(prepared.mutationStarted).toBe(true);
+			expect(source.disposed).toBe(true);
+			expect(disposeLynxFirstTree(firstTree).complete).toBe(true);
+
+			const cleanup = disposeLynxHostContainer(target);
+			expect(cleanup.complete).toBe(true);
+			expect(cleanup.errors).toEqual([]);
+			expect(page.children).toEqual([]);
+			expect(sourceRoot.events.size).toBe(0);
+			expect(sourceChild.events.size).toBe(0);
+			expect(target.disposed).toBe(true);
+			releaseLynxFirstTree(firstTree);
+		},
+	);
+
+	it('repairs a captured first tree whose page root was physically detached', () => {
+		const papi = createFakePAPI();
+		const page = papi.createPage('entry', 0);
+		const source = createLynxHostContainer(papi, { root: 5, page });
+		const commands = batch(1, [
+			{ op: 'create', id: 1, type: 'view', props: { id: 'root' } },
+			{ op: 'insert', parent: null, id: 1, before: null },
+		]);
+		prepareLynxHostBatch(source, commands).apply();
+		const painted = page.children[0]!;
+		const firstTree = captureLynxFirstTree(source);
+		papi.remove(page, painted);
+		const target = createLynxHostContainer(papi, { root: 5, page });
+		const mismatches: Error[] = [];
+
+		const prepared = prepareLynxHostBatch(target, commands, {
+			firstTree,
+			onMismatch(error) {
+				mismatches.push(error);
+			},
+		});
+
+		expect(prepared.firstTreeAction).toBe('repair');
+		expect(mismatches).toEqual([
+			expect.objectContaining({
+				code: LYNX_FIRST_TREE_MISMATCH,
+				path: 'snapshot.nodes[1].parent',
+			}),
+		]);
+		prepared.apply();
+		expect(source.disposed).toBe(true);
+		expect(page.children).toHaveLength(1);
+		expect(page.children[0]).not.toBe(painted);
+		expect(page.children[0]!.id).toBe('root');
+	});
+
+	it('repairs a captured first tree whose page root was reparented under an external host', () => {
+		const papi = createFakePAPI();
+		const page = papi.createPage('entry', 0);
+		const source = createLynxHostContainer(papi, { root: 5, page });
+		const commands = batch(1, [
+			{ op: 'create', id: 1, type: 'view', props: { id: 'root' } },
+			{ op: 'event', id: 1, type: 'bindtap', listener: { id: 101, priority: 'discrete' } },
+			{ op: 'insert', parent: null, id: 1, before: null },
+		]);
+		prepareLynxHostBatch(source, commands).apply();
+		const painted = page.children[0]!;
+		const firstTree = captureLynxFirstTree(source);
+		const external = papi.createElement('view', page.uid, '');
+		papi.insertBefore(page, external, null);
+		papi.insertBefore(external, painted, null);
+		const target = createLynxHostContainer(papi, { root: 5, page });
+		const mismatches: Error[] = [];
+
+		const prepared = prepareLynxHostBatch(target, commands, {
+			firstTree,
+			onMismatch(error) {
+				mismatches.push(error);
+			},
+		});
+
+		expect(prepared.firstTreeAction).toBe('repair');
+		expect(mismatches).toEqual([
+			expect.objectContaining({
+				code: LYNX_FIRST_TREE_MISMATCH,
+				path: 'snapshot.nodes[1].parent',
+			}),
+		]);
+		prepared.apply();
+		expect(source.disposed).toBe(true);
+		expect(external.children).toEqual([]);
+		expect(painted.parent).toBeNull();
+		expect(painted.events.size).toBe(0);
+		expect(page.children).toHaveLength(2);
+		expect(page.children[0]).toBe(external);
+		expect(page.children[1]).not.toBe(painted);
+		expect(page.children[1]!.id).toBe('root');
+	});
+
+	it('repairs a captured first tree whose child was physically reparented', () => {
+		const papi = createFakePAPI();
+		const page = papi.createPage('entry', 0);
+		const source = createLynxHostContainer(papi, { root: 5, page });
+		const commands = batch(1, [
+			{ op: 'create', id: 1, type: 'view', props: { id: 'root' } },
+			{ op: 'create', id: 2, type: 'view', props: { id: 'first' } },
+			{ op: 'create', id: 3, type: 'view', props: { id: 'second' } },
+			{ op: 'insert', parent: null, id: 1, before: null },
+			{ op: 'insert', parent: 1, id: 2, before: null },
+			{ op: 'insert', parent: 1, id: 3, before: null },
+		]);
+		prepareLynxHostBatch(source, commands).apply();
+		const painted = page.children[0]!;
+		const firstChild = painted.children[0]!;
+		const secondChild = painted.children[1]!;
+		const firstTree = captureLynxFirstTree(source);
+		papi.insertBefore(secondChild, firstChild, null);
+		const target = createLynxHostContainer(papi, { root: 5, page });
+		const mismatches: Error[] = [];
+
+		const prepared = prepareLynxHostBatch(target, commands, {
+			firstTree,
+			onMismatch(error) {
+				mismatches.push(error);
+			},
+		});
+
+		expect(prepared.firstTreeAction).toBe('repair');
+		expect(mismatches).toEqual([
+			expect.objectContaining({
+				code: LYNX_FIRST_TREE_MISMATCH,
+				path: 'snapshot.nodes[2].parent',
+			}),
+		]);
+		prepared.apply();
+		expect(source.disposed).toBe(true);
+		expect(page.children).toHaveLength(1);
+		expect(page.children[0]).not.toBe(painted);
+		expect(page.children[0]!.children.map((node) => node.id)).toEqual(['first', 'second']);
+	});
+
+	it('repairs a captured first tree whose child was reparented under an external host', () => {
+		const papi = createFakePAPI();
+		const page = papi.createPage('entry', 0);
+		const source = createLynxHostContainer(papi, { root: 5, page });
+		const commands = batch(1, [
+			{ op: 'create', id: 1, type: 'view', props: { id: 'root' } },
+			{ op: 'create', id: 2, type: 'view', props: { id: 'child' } },
+			{ op: 'event', id: 2, type: 'bindtap', listener: { id: 102, priority: 'discrete' } },
+			{ op: 'insert', parent: null, id: 1, before: null },
+			{ op: 'insert', parent: 1, id: 2, before: null },
+		]);
+		prepareLynxHostBatch(source, commands).apply();
+		const painted = page.children[0]!;
+		const paintedChild = painted.children[0]!;
+		const firstTree = captureLynxFirstTree(source);
+		const external = papi.createElement('view', page.uid, '');
+		papi.insertBefore(page, external, null);
+		papi.insertBefore(external, paintedChild, null);
+		const target = createLynxHostContainer(papi, { root: 5, page });
+		const mismatches: Error[] = [];
+
+		const prepared = prepareLynxHostBatch(target, commands, {
+			firstTree,
+			onMismatch(error) {
+				mismatches.push(error);
+			},
+		});
+
+		expect(prepared.firstTreeAction).toBe('repair');
+		expect(mismatches).toEqual([
+			expect.objectContaining({
+				code: LYNX_FIRST_TREE_MISMATCH,
+				path: 'snapshot.nodes[2].parent',
+			}),
+		]);
+		prepared.apply();
+		expect(source.disposed).toBe(true);
+		expect(external.children).toEqual([]);
+		expect(painted.parent).toBeNull();
+		expect(paintedChild.parent).toBeNull();
+		expect(paintedChild.events.size).toBe(0);
+		expect(page.children).toHaveLength(2);
+		expect(page.children[0]).toBe(external);
+		expect(page.children[1]).not.toBe(painted);
+		expect(page.children[1]!.children.map((node) => node.id)).toEqual(['child']);
+	});
+
+	it('reports a deterministic mismatch and repairs only when the batch is applied', () => {
+		const papi = createFakePAPI();
+		const page = papi.createPage('entry', 0);
+		const source = createLynxHostContainer(papi, { root: 3, page });
+		prepareLynxHostBatch(
+			source,
+			batch(1, [
+				{ op: 'create', id: 1, type: 'view', props: { id: 'main-value' } },
+				{ op: 'insert', parent: null, id: 1, before: null },
+			]),
+		).apply();
+		const painted = page.children[0]!;
+		const firstTree = captureLynxFirstTree(source, { plan: 'scene:mismatch' });
+		const target = createLynxHostContainer(papi, { root: 3, page });
+		const mismatches: Error[] = [];
+		const commands = batch(1, [
+			{ op: 'create', id: 1, type: 'view', props: { id: 'background-value' } },
+			{ op: 'insert', parent: null, id: 1, before: null },
+		]);
+		const aborted = prepareLynxHostBatch(target, commands, {
+			firstTree,
+			onMismatch(error) {
+				mismatches.push(error);
+			},
+		});
+
+		expect(aborted.firstTreeAction).toBe('repair');
+		expect(mismatches[0]).toMatchObject({
+			code: LYNX_FIRST_TREE_MISMATCH,
+			path: 'snapshot.nodes[1].props',
+			plan: 'scene:mismatch',
+		});
+		papi.resetCalls();
+		aborted.abort();
+		expect(papi.calls).toEqual([]);
+		expect(page.children).toEqual([painted]);
+		expect(source.disposed).toBe(false);
+
+		const repaired = prepareLynxHostBatch(target, commands, { firstTree });
+		papi.resetCalls();
+		repaired.apply();
+
+		expect(repaired.firstTreeAction).toBe('repair');
+		expect(source.disposed).toBe(true);
+		expect(painted.parent).toBeNull();
+		expect(page.children).toHaveLength(1);
+		expect(page.children[0]).not.toBe(painted);
+		expect(page.children[0]!.id).toBe('background-value');
+		expect(papi.calls.indexOf('remove')).toBeLessThan(papi.calls.indexOf('create:view'));
+		expect(papi.calls.filter((call) => call === 'flush')).toHaveLength(2);
+		expect(disposeLynxFirstTree(firstTree).complete).toBe(true);
+	});
+
 	it('applies every structural command with complete props and one flush per batch', () => {
 		const { container, driver, page, papi } = createHost();
 		const mount = prepareLynxHostBatch(
@@ -276,6 +663,7 @@ describe('Lynx Element PAPI host driver', () => {
 		);
 
 		expect(mount.mutationStarted).toBe(false);
+		expect(mount.firstTreeAction).toBe('none');
 		expect(mount.handleDelta.map((entry) => entry.op)).toEqual(['create', 'create', 'create']);
 		mount.apply();
 
@@ -841,6 +1229,91 @@ describe('Lynx Element PAPI host driver', () => {
 		expect(container.instanceCount).toBe(0);
 		expect(container.disposed).toBe(true);
 	});
+
+	it.each([
+		['root', 'before', false],
+		['root', 'after', true],
+		['child', 'before', false],
+		['child', 'after', true],
+	] as const)(
+		'handles external %s removal faults %s mutation without losing retry ownership',
+		(scope, timing, completesImmediately) => {
+			const { container, page, papi } = createHost();
+			prepareLynxHostBatch(
+				container,
+				batch(1, [
+					{ op: 'create', id: 1, type: 'view', props: { id: 'root' } },
+					{ op: 'create', id: 2, type: 'view', props: { id: 'child' } },
+					{ op: 'insert', parent: null, id: 1, before: null },
+					{ op: 'insert', parent: 1, id: 2, before: null },
+				]),
+			).apply();
+			const root = page.children[0]!;
+			const child = root.children[0]!;
+			const external = papi.createElement('view', page.uid, '');
+			papi.insertBefore(page, external, null);
+			if (scope === 'root') {
+				papi.insertBefore(external, root, null);
+			} else {
+				papi.insertBefore(external, child, null);
+				papi.remove(page, root);
+			}
+			const failure = new Error(`external ${scope} removal failed ${timing} mutation`);
+			papi.failNext('remove', timing, failure);
+
+			const first = disposeLynxHostContainer(container);
+			expect(first.complete).toBe(completesImmediately);
+			expect(first.remainingRoots).toBe(completesImmediately ? 0 : 1);
+			expect(first.errors).toEqual(completesImmediately ? [] : [failure]);
+			expect(container.disposed).toBe(completesImmediately);
+			expect(external.children).toHaveLength(completesImmediately ? 0 : 1);
+
+			if (!completesImmediately) {
+				const retry = disposeLynxHostContainer(container);
+				expect(retry.complete).toBe(true);
+				expect(retry.remainingRoots).toBe(0);
+				expect(retry.errors).toEqual([]);
+				expect(container.disposed).toBe(true);
+				expect(external.children).toEqual([]);
+			}
+		},
+	);
+
+	it.each(['before', 'after'] as const)(
+		'retains ownership when native parentage cannot be resolved %s inspection',
+		(timing) => {
+			const { container, page, papi } = createHost();
+			prepareLynxHostBatch(
+				container,
+				batch(1, [
+					{ op: 'create', id: 1, type: 'view', props: { id: 'retry-parent' } },
+					{ op: 'insert', parent: null, id: 1, before: null },
+				]),
+			).apply();
+			const failure = new Error('parent inspection failed');
+			papi.failNext('getParent', timing, failure);
+
+			expect(disposeLynxHostContainer(container)).toEqual({
+				complete: false,
+				removedRoots: 0,
+				remainingRoots: 1,
+				flushed: false,
+				errors: [failure],
+			});
+			expect(page.children).toHaveLength(1);
+			expect(container.disposed).toBe(false);
+
+			expect(disposeLynxHostContainer(container)).toEqual({
+				complete: true,
+				removedRoots: 1,
+				remainingRoots: 0,
+				flushed: true,
+				errors: [],
+			});
+			expect(page.children).toHaveLength(0);
+			expect(container.disposed).toBe(true);
+		},
+	);
 
 	it('completes cleanup when parent inspection proves a throwing removal detached the root', () => {
 		const { container, page, papi } = createHost();

--- a/packages/lynx/tests/main-renderer.test.ts
+++ b/packages/lynx/tests/main-renderer.test.ts
@@ -1,0 +1,408 @@
+import type { UniversalHostBatch, UniversalHostDriver } from 'octane/universal/native';
+import {
+	createUniversalRoot,
+	use as useBackground,
+	useId as useBackgroundId,
+	type UniversalComponent,
+	type UniversalHostCommitContext,
+} from 'octane/universal/native';
+import { describe, expect, it, vi } from 'vitest';
+import { createLynxNativeResource } from '../src/first-screen.js';
+import {
+	createContext,
+	defineUniversalComponent,
+	firstScreenEvent,
+	renderLynxFirstScreen,
+	universalComponent,
+	universalContext,
+	universalActivity,
+	universalFor,
+	universalIf,
+	universalPlan,
+	universalProps,
+	universalSwitch,
+	universalTry,
+	universalValue,
+	useContext,
+	useEffect,
+	useId,
+	useLayoutEffect,
+	useRef,
+	useState,
+	use,
+	useBatch,
+} from '../src/main-renderer.js';
+
+interface CapturedContainer {
+	batch: UniversalHostBatch | null;
+}
+
+function captureBackgroundBatch<Props>(
+	component: UniversalComponent<Props>,
+	props: Props,
+): UniversalHostBatch {
+	const container: CapturedContainer = { batch: null };
+	const driver: UniversalHostDriver<CapturedContainer> = {
+		id: 'lynx',
+		capabilities: { text: 'host', visibility: true },
+		events: {
+			classify(name) {
+				const match = /^(?:capture-bind|capture-catch|global-bind|bind|catch)([A-Za-z]+)$/.exec(
+					name,
+				);
+				if (match === null) return null;
+				return {
+					type: name,
+					priority: match[1] === 'tap' ? 'discrete' : 'default',
+				};
+			},
+		},
+		prepareBatch(
+			target: CapturedContainer,
+			batch: UniversalHostBatch,
+			_context: UniversalHostCommitContext,
+		) {
+			return {
+				apply() {
+					target.batch = batch;
+				},
+				abort() {},
+			};
+		},
+		getPublicInstance() {
+			return null;
+		},
+	};
+	createUniversalRoot(container, driver, { scheduleMicrotask: (callback) => callback() }).render(
+		component,
+		props,
+	);
+	if (container.batch === null) throw new Error('Background root did not commit.');
+	return container.batch;
+}
+
+function normalizeRootScopedUseId(batch: UniversalHostBatch, id: string): unknown {
+	return {
+		...batch,
+		commands: batch.commands.map((command) =>
+			command.op === 'create' && command.props.id === id
+				? { ...command, props: { ...command.props, id: '<committed-use-id>' } }
+				: command,
+		),
+	};
+}
+
+const leafPlan = universalPlan('lynx', {
+	kind: 'host',
+	type: 'text',
+	propsSlot: 0,
+	children: [{ kind: 'text', slot: 1 }],
+});
+
+const rowPlan = universalPlan('lynx', {
+	kind: 'host',
+	type: 'view',
+	propsSlot: 0,
+});
+
+const Child = defineUniversalComponent('lynx', (props: { readonly value: string }) =>
+	universalValue(leafPlan, [universalProps([['set', 'id', 'label']]), props.value]),
+);
+
+const Scene = defineUniversalComponent(
+	'lynx',
+	(props: {
+		readonly handler: () => void;
+		readonly items: readonly string[];
+		readonly title: string;
+	}) => [
+		universalComponent('lynx', Child, universalProps([['set', 'value', props.title]])),
+		universalFor(
+			props.items,
+			(item) => item,
+			(item) =>
+				universalValue(rowPlan, [
+					universalProps([
+						['set', 'id', item],
+						['set', 'bindtap', props.handler],
+					]),
+				]),
+		),
+	],
+);
+
+describe('Lynx main-thread first-screen renderer', () => {
+	it('emits the same initial host IDs, topology, props, and listener metadata as background', () => {
+		const props = {
+			handler: () => {},
+			items: ['a', 'b'],
+			title: 'Hello',
+		};
+		const main = renderLynxFirstScreen(Scene, props);
+		const background = captureBackgroundBatch(Scene, props);
+
+		expect(main.batch).toEqual(background);
+		expect(main.hostCount).toBe(4);
+		expect(main.logicalCount).toBeGreaterThan(main.hostCount);
+		expect(main.batch.commands.some((command) => 'props' in command && command.props.bindtap)).toBe(
+			false,
+		);
+	});
+
+	it('matches background range IDs for production-compiled ownerless leaf loops', () => {
+		const ProductionLeafLoop = defineUniversalComponent(
+			'lynx',
+			(props: { readonly items: readonly string[] }) =>
+				universalFor(
+					props.items,
+					(item) => item,
+					(item) => universalValue(rowPlan, [universalProps([['set', 'id', item]])]),
+					null,
+					true,
+					true,
+				),
+		);
+		const props = { items: ['a', 'b'] };
+		const main = renderLynxFirstScreen(ProductionLeafLoop, props);
+		const background = captureBackgroundBatch(ProductionLeafLoop, props);
+
+		// A production compile emits the two trailing `true` hints for this leaf
+		// shape. Lynx does not advertise compilerLeafProps, so both runtimes must
+		// preserve the per-item ranges and therefore allocate host IDs 2 and 4.
+		expect(main.batch).toEqual(background);
+		expect(
+			main.batch.commands.filter((command) => command.op === 'create').map((command) => command.id),
+		).toEqual([2, 4]);
+		expect(main.logicalCount).toBe(4);
+	});
+
+	it('recognizes the compiler sentinel without retaining an authored callback', () => {
+		const EventOnly = defineUniversalComponent('lynx', () =>
+			universalValue(rowPlan, [universalProps([['set', 'bindtap', firstScreenEvent]])]),
+		);
+		const result = renderLynxFirstScreen(EventOnly, {});
+
+		expect(result.batch.commands).toEqual([
+			{ op: 'create', id: 1, type: 'view', props: {} },
+			{
+				op: 'event',
+				id: 1,
+				type: 'bindtap',
+				listener: { id: 1_000_000, priority: 'discrete' },
+			},
+			{ op: 'insert', parent: null, id: 1, before: null },
+		]);
+	});
+
+	it('uses initial hook values and never publishes effects, refs, or updates', () => {
+		const effect = vi.fn();
+		const layout = vi.fn();
+		const ref = vi.fn();
+		const Hooks = defineUniversalComponent('lynx', () => {
+			const [count, setCount] = useState(2);
+			const localRef = useRef('private');
+			useEffect(effect);
+			useLayoutEffect(layout);
+			setCount(9);
+			return universalValue(leafPlan, [
+				universalProps([
+					['set', 'id', useId()],
+					['set', 'ref', ref],
+				]),
+				`${localRef.current}:${count}`,
+			]);
+		});
+
+		const result = renderLynxFirstScreen(Hooks, {});
+		expect(result.batch.commands).toContainEqual({
+			op: 'create',
+			id: 1,
+			type: 'text',
+			props: { id: ':octane-u4:' },
+		});
+		expect(result.batch.commands).toContainEqual({
+			op: 'create',
+			id: 2,
+			type: '#text',
+			props: { value: 'private:2' },
+		});
+		expect(effect).not.toHaveBeenCalled();
+		expect(layout).not.toHaveBeenCalled();
+		expect(ref).not.toHaveBeenCalled();
+	});
+
+	it('reclaims useId allocations from discarded try arms before committing a fallback', () => {
+		const never = new Promise<never>(() => {});
+		for (const discard of ['error', 'suspend'] as const) {
+			let discardedMainId = '';
+			const MainBoundary = defineUniversalComponent('lynx', () =>
+				universalTry(
+					() => {
+						discardedMainId = useId();
+						if (discard === 'error') throw new Error('discard main try arm');
+						use(never);
+					},
+					() => universalValue(rowPlan, [universalProps([['set', 'id', useId()]])]),
+					() => universalValue(rowPlan, [universalProps([['set', 'id', useId()]])]),
+				),
+			);
+			let discardedBackgroundId = '';
+			const BackgroundBoundary = defineUniversalComponent('lynx', () =>
+				universalTry(
+					() => {
+						discardedBackgroundId = useBackgroundId('discarded-arm-id');
+						if (discard === 'error') throw new Error('discard background try arm');
+						useBackground(never);
+					},
+					() =>
+						universalValue(rowPlan, [
+							universalProps([['set', 'id', useBackgroundId('committed-pending-id')]]),
+						]),
+					() =>
+						universalValue(rowPlan, [
+							universalProps([['set', 'id', useBackgroundId('committed-catch-id')]]),
+						]),
+				),
+			);
+
+			const main = renderLynxFirstScreen(MainBoundary, {}).batch;
+			const background = captureBackgroundBatch(BackgroundBoundary, {});
+			const mainCreate = main.commands.find((command) => command.op === 'create');
+			const backgroundCreate = background.commands.find((command) => command.op === 'create');
+			if (mainCreate?.op !== 'create' || backgroundCreate?.op !== 'create') {
+				throw new Error('Expected both try fallbacks to create a host.');
+			}
+			expect(mainCreate.props.id).toBe(discardedMainId);
+			expect(backgroundCreate.props.id).toBe(discardedBackgroundId);
+			expect(normalizeRootScopedUseId(main, discardedMainId)).toEqual(
+				normalizeRootScopedUseId(background, discardedBackgroundId),
+			);
+		}
+	});
+
+	it('rejects background-scoped native resource props before emitting a first-screen batch', () => {
+		const NativeResource = defineUniversalComponent('lynx', () =>
+			universalValue(rowPlan, [
+				universalProps([['set', 'texture', createLynxNativeResource('hero')]]),
+			]),
+		);
+
+		expect(() => renderLynxFirstScreen(NativeResource, {})).toThrow(
+			/native resource prop "texture".*background-only/,
+		);
+	});
+
+	it('renders context, keyed control flow, caught errors, and pending fallbacks deterministically', () => {
+		const Context = createContext('default');
+		const Read = defineUniversalComponent('lynx', () =>
+			universalValue(leafPlan, [universalProps([]), useContext(Context)]),
+		);
+		const pending = new Promise<void>(() => {});
+		const Boundary = defineUniversalComponent('lynx', () =>
+			universalContext(Context, 'provided', [
+				universalTry(
+					() => {
+						use(pending);
+						return null;
+					},
+					() => universalComponent('lynx', Read),
+				),
+				universalTry(
+					() => {
+						throw new Error('expected');
+					},
+					null,
+					() => universalValue(leafPlan, [universalProps([]), 'caught']),
+				),
+			]),
+		);
+
+		const result = renderLynxFirstScreen(Boundary, {});
+		const creates = result.batch.commands.filter((command) => command.op === 'create');
+		expect(
+			creates.filter((command) => command.type === '#text').map((command) => command.props),
+		).toEqual([{ value: 'provided' }, { value: 'caught' }]);
+	});
+
+	it('starts every pending member in a compiler-batched suspension stratum', () => {
+		const first = new Promise<void>(() => {}) as Promise<void> & { status?: string };
+		const second = new Promise<void>(() => {}) as Promise<void> & { status?: string };
+		const Batched = defineUniversalComponent('lynx', () =>
+			universalTry(
+				() => {
+					useBatch([first, second]);
+					use(first);
+					return null;
+				},
+				() => universalValue(leafPlan, [universalProps([]), 'pending']),
+			),
+		);
+
+		const result = renderLynxFirstScreen(Batched, {});
+		expect(first.status).toBe('pending');
+		expect(second.status).toBe('pending');
+		expect(result.batch.commands).toContainEqual({
+			op: 'create',
+			id: 4,
+			type: '#text',
+			props: { value: 'pending' },
+		});
+	});
+
+	it('matches background IDs and topology through early and directive control flow', () => {
+		const ControlFlow = defineUniversalComponent(
+			'lynx',
+			(props: { show: boolean; branch: string; fail: boolean }) => {
+				if (!props.show) return null;
+				return [
+					universalIf(true, () => universalValue(rowPlan, [universalProps([['set', 'id', 'if']])])),
+					universalSwitch(
+						props.branch,
+						[['a', () => universalValue(rowPlan, [universalProps([['set', 'id', 'case']])])]],
+						() => universalValue(rowPlan, [universalProps([['set', 'id', 'default']])]),
+					),
+					universalTry(
+						() => {
+							if (props.fail) throw new Error('expected');
+							return universalValue(rowPlan, [universalProps([['set', 'id', 'body']])]);
+						},
+						null,
+						() => universalValue(rowPlan, [universalProps([['set', 'id', 'catch']])]),
+					),
+					universalActivity('hidden', () =>
+						universalValue(rowPlan, [universalProps([['set', 'id', 'hidden']])]),
+					),
+				];
+			},
+		);
+
+		for (const props of [
+			{ show: false, branch: 'a', fail: false },
+			{ show: true, branch: 'a', fail: false },
+			{ show: true, branch: 'other', fail: true },
+		]) {
+			expect(renderLynxFirstScreen(ControlFlow, props).batch).toEqual(
+				captureBackgroundBatch(ControlFlow, props),
+			);
+		}
+	});
+
+	it('accepts conditional initial hooks without retaining an update path', () => {
+		const ConditionalHooks = defineUniversalComponent('lynx', (props: { enabled: boolean }) => {
+			if (!props.enabled) return null;
+			const [value, update] = useState('initial');
+			update('ignored');
+			return universalValue(leafPlan, [universalProps([]), value]);
+		});
+
+		expect(renderLynxFirstScreen(ConditionalHooks, { enabled: false }).batch.commands).toEqual([]);
+		expect(
+			renderLynxFirstScreen(ConditionalHooks, { enabled: true }).batch.commands,
+		).toContainEqual({
+			op: 'create',
+			id: 2,
+			type: '#text',
+			props: { value: 'initial' },
+		});
+	});
+});

--- a/packages/lynx/tests/public-api.test.ts
+++ b/packages/lynx/tests/public-api.test.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
+import * as firstScreenApi from '../src/first-screen.js';
 import * as rootApi from '../src/index.js';
+import * as mainRendererApi from '../src/main-renderer.js';
 import * as mainThreadApi from '../src/main-thread.js';
 import * as platformApi from '../src/platform.js';
 import * as testingApi from '../src/testing.js';
@@ -13,7 +15,7 @@ const packageJson = JSON.parse(
 	exports: Record<string, string>;
 };
 
-describe('@octanejs/lynx Milestone 5 public surface', () => {
+describe('@octanejs/lynx Milestone 6 private surface', () => {
 	it('keeps every required package subpath private and addressable', () => {
 		expect(packageJson.private).toBe(true);
 		expect(packageJson.version).toBe('0.0.0');
@@ -21,6 +23,8 @@ describe('@octanejs/lynx Milestone 5 public surface', () => {
 			'.',
 			'./config',
 			'./renderer',
+			'./main-renderer',
+			'./first-screen',
 			'./intrinsics',
 			'./intrinsics/jsx-runtime',
 			'./main-thread',
@@ -49,6 +53,17 @@ describe('@octanejs/lynx Milestone 5 public surface', () => {
 			deviceExecution: false,
 		});
 		expect(rootApi.root.renderer).toBe('lynx');
+		expect(firstScreenApi.lynxRootAvailability).toMatchObject({
+			available: true,
+			implementedMilestone: 6,
+		});
+		expect(firstScreenApi.root.renderer).toBe('lynx');
+		expect(firstScreenApi.createLynxRoot()).toBe(firstScreenApi.root);
+		expect(firstScreenApi.markFirstScreenSyncReady).toBeTypeOf('function');
+		expect(firstScreenApi.createLynxNativeResource).toBe(rootApi.createLynxNativeResource);
+		expect(firstScreenApi.LynxNodesRefError).toBe(rootApi.LynxNodesRefError);
+		expect(mainRendererApi.renderLynxFirstScreen).toBeTypeOf('function');
+		expect(mainRendererApi.firstScreenEvent).toBeTypeOf('symbol');
 		expect(rootApi.createLynxRoot).toBeTypeOf('function');
 		expect(rootApi.createLynxNativeResource).toBeTypeOf('function');
 		expect(mainThreadApi.installLynxMainThread).toBeTypeOf('function');

--- a/packages/lynx/tests/resource.test.ts
+++ b/packages/lynx/tests/resource.test.ts
@@ -9,7 +9,7 @@ import {
 } from 'octane/universal/native';
 import { describe, expect, it } from 'vitest';
 import { createLynxClientContainer, createLynxClientDriver } from '../src/core/client-driver.js';
-import { createLynxNativeResource } from '../src/resource.js';
+import { createLynxNativeResource } from '../src/index.js';
 
 const resourcePlan = universalPlan('lynx', {
 	kind: 'host',

--- a/packages/lynx/tests/runtime-compatibility.test.ts
+++ b/packages/lynx/tests/runtime-compatibility.test.ts
@@ -110,6 +110,7 @@ describe('Lynx runtime compatibility evidence', () => {
 		expect(runtimeSourceGraph(resolve(LYNX_ROOT, 'src/main-thread.ts'))).toEqual({
 			files: [
 				'src/config.ts',
+				'src/core/first-screen.ts',
 				'src/core/host-driver.ts',
 				'src/core/host-props.ts',
 				'src/core/list.ts',
@@ -117,7 +118,10 @@ describe('Lynx runtime compatibility evidence', () => {
 				'src/core/nodes-ref.ts',
 				'src/core/papi.ts',
 				'src/core/protocol.ts',
+				'src/first-screen.ts',
+				'src/main-renderer.ts',
 				'src/main-thread.ts',
+				'src/resource.ts',
 			],
 			packages: [],
 		});

--- a/packages/octane/src/compiler/compile-universal.js
+++ b/packages/octane/src/compiler/compile-universal.js
@@ -41,6 +41,84 @@ const UNIVERSAL_RUNTIME_IMPORTS = new Set([
 	'useTransition',
 ]);
 
+// A renderer must opt in explicitly before main-thread metadata changes emitted
+// code. This keeps universalRuntime useful as cache/diagnostic identity for
+// ordinary renderers while allowing native first-screen programs to erase
+// background-owned callbacks from their render-only specialization.
+const MAIN_THREAD_RENDER_ONLY_CAPABILITY = 'main-thread-render-only';
+const MAIN_THREAD_BACKGROUND_EFFECTS = new Set([
+	'useEffect',
+	'useEffectEvent',
+	'useImperativeHandle',
+	'useInsertionEffect',
+	'useLayoutEffect',
+]);
+
+function isMainThreadRenderOnly(state) {
+	return (
+		state.universalRuntime?.thread === 'main-thread' &&
+		rendererHasCapability(state, MAIN_THREAD_RENDER_ONLY_CAPABILITY)
+	);
+}
+
+function isFirstScreenEvent(name, state) {
+	return (state.renderer.firstScreenEvents ?? []).some((pattern) => hostPropMatches(name, pattern));
+}
+
+function unwrapFirstScreenExpression(node) {
+	while (
+		node &&
+		(node.type === 'ParenthesizedExpression' ||
+			node.type === 'ChainExpression' ||
+			node.type === 'TSAsExpression' ||
+			node.type === 'TSNonNullExpression' ||
+			node.type === 'TSSatisfiesExpression' ||
+			node.type === 'TSTypeAssertion')
+	) {
+		node = node.expression;
+	}
+	return node;
+}
+
+function firstScreenEventHelper(state) {
+	return (state.helpers.firstScreenEvent ??= allocName(state, '__octaneFirstScreenEvent'));
+}
+
+function firstScreenEventValue(expression, state) {
+	const value = unwrapFirstScreenExpression(expression);
+	if (value?.type === 'ArrowFunctionExpression' || value?.type === 'FunctionExpression') {
+		return firstScreenEventHelper(state);
+	}
+	if (value?.type === 'Literal' && value.value === null) {
+		return printDynamicExpression(expression, state);
+	}
+	if (value?.type === 'Identifier' && value.name === 'undefined') {
+		return printDynamicExpression(expression, state);
+	}
+	if (value?.type === 'UnaryExpression' && value.operator === 'void') {
+		return printDynamicExpression(expression, state);
+	}
+	if (value?.type === 'ConditionalExpression') {
+		return `(${printDynamicExpression(value.test, state)} ? ${firstScreenEventValue(
+			value.consequent,
+			state,
+		)} : ${firstScreenEventValue(value.alternate, state)})`;
+	}
+	// A callback read through props or another runtime expression may be
+	// optional. Evaluate that read exactly once, preserve its nullish absence,
+	// and replace only a present value with the marker. Inline callback bodies
+	// take the static branch above and never enter the main-thread graph.
+	return `((${printDynamicExpression(expression, state)}) == null ? undefined : ${firstScreenEventHelper(state)})`;
+}
+
+function mainThreadHostValue(name, expression, state) {
+	if (!isMainThreadRenderOnly(state)) return printDynamicExpression(expression, state);
+	if (name === 'ref') return 'undefined';
+	return isFirstScreenEvent(name, state)
+		? firstScreenEventValue(expression, state)
+		: printDynamicExpression(expression, state);
+}
+
 function universalError(filename, node, message) {
 	const start = node?.loc?.start;
 	const at = start ? ` at ${filename}:${start.line}:${start.column}` : '';
@@ -242,6 +320,48 @@ function validateRuntimeImports(ast, state) {
 			}
 		}
 	}
+}
+
+/**
+ * Keep effect hook calls (and therefore compiler-assigned call-site slots) in
+ * the first-screen program, but erase every authored argument before the
+ * shared hook pass sees it. The main renderer supplies inert implementations;
+ * preserving the call shape keeps later state/useId slots deterministic while
+ * removing callback closures, captured imports, refs, and dependency reads.
+ */
+function prepareMainThreadRenderOnlyReplacements(ast, state) {
+	if (!isMainThreadRenderOnly(state)) return;
+	state.sourceNodeReplacements ??= new WeakMap();
+	const { nodeScopes, resolveBinding, rootScope } = createLexicalAnalysis(ast);
+	const seen = new WeakSet();
+	const visit = (node) => {
+		if (!node || typeof node !== 'object') return;
+		if (Array.isArray(node)) {
+			for (const child of node) visit(child);
+			return;
+		}
+		if (seen.has(node)) return;
+		seen.add(node);
+		if (
+			node.type === 'CallExpression' &&
+			node.callee?.type === 'Identifier' &&
+			resolveBinding(nodeScopes.get(node.callee) ?? rootScope, node.callee.name)?.importSource
+				?.value === 'octane' &&
+			MAIN_THREAD_BACKGROUND_EFFECTS.has(state.runtimeImports.get(node.callee.name))
+		) {
+			for (const argument of node.arguments ?? []) {
+				if (argument && typeof argument === 'object') {
+					state.sourceNodeReplacements.set(argument, 'undefined');
+				}
+			}
+			return;
+		}
+		for (const [key, child] of Object.entries(node)) {
+			if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata') continue;
+			visit(child);
+		}
+	};
+	visit(ast);
 }
 
 const NON_RUNTIME_AST_KEYS = new Set([
@@ -1381,7 +1501,7 @@ function compileProps(attributes, childrenExpression, state, canonicalizeHostCla
 		if (value.type === 'JSXExpressionContainer') {
 			if (!value.expression || value.expression.type === 'JSXEmptyExpression') continue;
 			entries.push(
-				`['set', ${JSON.stringify(name)}, (${printDynamicExpression(value.expression, state)})]`,
+				`['set', ${JSON.stringify(name)}, (${mainThreadHostValue(name, value.expression, state)})]`,
 			);
 			continue;
 		}
@@ -1436,7 +1556,7 @@ function compileAttribute(attribute, context, state, canonicalizeHostClass) {
 	if (value.type === 'JSXExpressionContainer') {
 		if (!value.expression || value.expression.type === 'JSXEmptyExpression') return null;
 		const slot = context.values.length;
-		context.values.push(printDynamicExpression(value.expression, state));
+		context.values.push(mainThreadHostValue(name, value.expression, state));
 		return { name, slot };
 	}
 	throw universalError(state.filename, attribute, `unsupported value for host attribute ${name}.`);
@@ -1458,6 +1578,19 @@ function compileHostElement(node, context, state) {
 	if (!/^[a-z]/.test(type)) return compileComponentElement(node, context, state);
 	recordMapping(state, JSON.stringify(type), node.openingElement?.name ?? node.name ?? node);
 	const attributes = node.openingElement?.attributes ?? node.attributes ?? [];
+	if (isMainThreadRenderOnly(state)) {
+		const spread = attributes.find(
+			(attribute) =>
+				attribute.type === 'JSXSpreadAttribute' || attribute.type === 'SpreadAttribute',
+		);
+		if (spread !== undefined) {
+			throw universalError(
+				state.filename,
+				spread,
+				'main-thread render-only host spreads are unsupported because first-screen event and ref props must be statically named for callback erasure; expand the spread into explicit host props.',
+			);
+		}
+	}
 	const canonicalizeHostClass = rendererHasCapability(state, 'class-name-alias');
 	const needsOrderedProps =
 		attributes.some(
@@ -2637,6 +2770,7 @@ export function lowerUniversalRendererRegion(
 		source: wrapper,
 		filename,
 		renderer,
+		universalRuntime,
 		names: new Set(),
 		plans: [],
 		components: [],
@@ -2702,6 +2836,7 @@ export function lowerUniversalRendererRegion(
 		validateLoweredRendererSource(ast, state, synthetic.origins, options.authoredSource);
 	}
 	validateRuntimeImports(ast, state);
+	prepareMainThreadRenderOnlyReplacements(ast, state);
 	const regionHelper = allocName(state, `${prefix}Descriptor`);
 	const componentName = allocName(state, `${prefix}Body`);
 	const emittedComponents = [];
@@ -2768,6 +2903,9 @@ export function lowerUniversalRendererRegion(
 		`universalSwitch as ${state.helpers.switch}, universalFor as ${state.helpers.for}, ` +
 		`universalTry as ${state.helpers.try}, universalChildren as ${state.helpers.children}, ` +
 		`universalContext as ${state.helpers.context}, universalActivity as ${state.helpers.activity}, ` +
+		(state.helpers.firstScreenEvent === undefined
+			? ''
+			: `firstScreenEvent as ${state.helpers.firstScreenEvent}, `) +
 		`rendererRegion as ${regionHelper}` +
 		(state.hmr
 			? `, hmrUniversalComponent as ${state.helpers.hmr}, UNIVERSAL_HMR as ${state.helpers.hmrSymbol}`
@@ -2890,7 +3028,7 @@ export function lowerUniversalRendererRegion(
 /**
  * @param {string} source
  * @param {string} filename
- * @param {{ id: string, module: string, target: 'universal', text?: 'host'|'ignore'|'reject', capabilities?: readonly string[] }} renderer
+ * @param {{ id: string, module: string, target: 'universal', text?: 'host'|'ignore'|'reject', capabilities?: readonly string[], firstScreenEvents?: readonly string[] }} renderer
  * @param {(source: string, metadata: any) => { code: string, map: any }} compileClient
  * @param {Record<string, any>} [options]
  */
@@ -2910,6 +3048,7 @@ export function compileUniversal(source, filename, renderer, compileClient, opti
 		source,
 		filename,
 		renderer,
+		universalRuntime,
 		names: new Set(),
 		plans: [],
 		components: [],
@@ -2951,6 +3090,7 @@ export function compileUniversal(source, filename, renderer, compileClient, opti
 		}
 	}
 	validateRuntimeImports(ast, state);
+	prepareMainThreadRenderOnlyReplacements(ast, state);
 
 	const emitted = [];
 	for (const node of ast.body ?? []) {
@@ -2974,6 +3114,9 @@ export function compileUniversal(source, filename, renderer, compileClient, opti
 		`universalSwitch as ${state.helpers.switch}, universalFor as ${state.helpers.for}, ` +
 		`universalTry as ${state.helpers.try}, universalChildren as ${state.helpers.children}, ` +
 		`universalContext as ${state.helpers.context}, universalActivity as ${state.helpers.activity}` +
+		(state.helpers.firstScreenEvent === undefined
+			? ''
+			: `, firstScreenEvent as ${state.helpers.firstScreenEvent}`) +
 		(state.hmr
 			? `, hmrUniversalComponent as ${state.helpers.hmr}, UNIVERSAL_HMR as ${state.helpers.hmrSymbol}`
 			: '') +

--- a/packages/octane/src/compiler/renderers.js
+++ b/packages/octane/src/compiler/renderers.js
@@ -17,6 +17,7 @@ const CONFIG_KEYS = new Set(['boundaries', 'default', 'registry', 'rules', 'sign
 const RULE_KEYS = new Set(['exclude', 'include', 'renderer']);
 const REGISTRY_ENTRY_KEYS = new Set([
 	'capabilities',
+	'firstScreenEvents',
 	'intrinsics',
 	'module',
 	'server',
@@ -187,6 +188,7 @@ function normalizeRegistryEntry(id, value, path) {
 	let intrinsics;
 	let text;
 	let capabilities;
+	let firstScreenEvents;
 	let validation;
 	if (typeof value === 'string') {
 		moduleId = validateModuleId(value, path);
@@ -229,6 +231,13 @@ function normalizeRegistryEntry(id, value, path) {
 			throw configError(`${path}.text must be "reject", "ignore", or "host".`);
 		}
 		capabilities = normalizeCapabilities(value.capabilities, `${path}.capabilities`);
+		if (value.firstScreenEvents !== undefined) {
+			firstScreenEvents = normalizeValidationList(
+				value.firstScreenEvents,
+				`${path}.firstScreenEvents`,
+				validateHostPropPattern,
+			);
+		}
 		validation = normalizeValidation(value.validation, `${path}.validation`);
 	}
 
@@ -240,6 +249,7 @@ function normalizeRegistryEntry(id, value, path) {
 			intrinsics !== undefined ||
 			text !== 'host' ||
 			capabilities.length !== 0 ||
+			firstScreenEvents !== undefined ||
 			validation !== undefined
 		) {
 			throw configError(
@@ -257,6 +267,7 @@ function normalizeRegistryEntry(id, value, path) {
 		...(intrinsics === undefined ? {} : { intrinsics }),
 		text,
 		capabilities,
+		...(firstScreenEvents === undefined ? {} : { firstScreenEvents }),
 		...(validation === undefined ? {} : { validation }),
 	});
 }
@@ -597,7 +608,10 @@ export function normalizeRendererConfig(input = {}) {
 	const signature = stableSignature({
 		default: defaultRenderer,
 		registry: entries.map(
-			([id, { module, target, server, intrinsics, text, capabilities, validation }]) => [
+			([
+				id,
+				{ module, target, server, intrinsics, text, capabilities, firstScreenEvents, validation },
+			]) => [
 				id,
 				module,
 				target,
@@ -605,6 +619,7 @@ export function normalizeRendererConfig(input = {}) {
 				intrinsics ?? null,
 				text,
 				capabilities,
+				firstScreenEvents ?? null,
 				validation ?? null,
 			],
 		),

--- a/packages/octane/src/compiler/vite.d.ts
+++ b/packages/octane/src/compiler/vite.d.ts
@@ -32,6 +32,8 @@ export type OctaneRendererRegistryEntry =
 			intrinsics?: string;
 			text?: 'reject' | 'ignore' | 'host';
 			capabilities?: readonly string[];
+			/** Host event prop names/prefixes replaced by first-screen listener sentinels. */
+			firstScreenEvents?: readonly string[];
 			validation?: OctaneRendererValidationOptions;
 	  };
 

--- a/packages/octane/tests/renderer-config.test.ts
+++ b/packages/octane/tests/renderer-config.test.ts
@@ -135,6 +135,42 @@ describe('renderer configuration', () => {
 		expect(normalizeRendererConfig(config).signature).toBe(config.signature);
 	});
 
+	it('normalizes first-screen event patterns as frozen renderer metadata', () => {
+		const config = normalizeRendererConfig({
+			registry: {
+				native: {
+					module: '@octanejs/native/renderer',
+					capabilities: ['main-thread-render-only'],
+					firstScreenEvents: ['onUpdate', 'bind*', 'onUpdate', 'catch*'],
+				},
+			},
+		});
+
+		expect(config.registry.native.firstScreenEvents).toEqual(['bind*', 'catch*', 'onUpdate']);
+		expect(Object.isFrozen(config.registry.native.firstScreenEvents)).toBe(true);
+		const reordered = normalizeRendererConfig({
+			registry: {
+				native: {
+					module: '@octanejs/native/renderer',
+					firstScreenEvents: ['catch*', 'onUpdate', 'bind*'],
+					capabilities: ['main-thread-render-only'],
+				},
+			},
+		});
+		expect(reordered.signature).toBe(config.signature);
+		expect(normalizeRendererConfig(config).signature).toBe(config.signature);
+		const differentPatterns = normalizeRendererConfig({
+			registry: {
+				native: {
+					module: '@octanejs/native/renderer',
+					capabilities: ['main-thread-render-only'],
+					firstScreenEvents: ['bind*', 'onUpdate'],
+				},
+			},
+		});
+		expect(differentPatterns.signature).not.toBe(config.signature);
+	});
+
 	it('normalizes renderer-owned child regions by stable module and export identity', () => {
 		const config = normalizeRendererConfig({
 			registry: { three: '@octanejs/three/renderer' },
@@ -410,6 +446,16 @@ describe('renderer configuration', () => {
 				},
 			}),
 		).toThrow(/hostProps\["view"\]\[0\].*prefix ending in "\*"/);
+		expect(() =>
+			normalizeRendererConfig({
+				registry: {
+					three: {
+						module: '@octanejs/three/renderer',
+						firstScreenEvents: ['bind*suffix'],
+					},
+				},
+			}),
+		).toThrow(/firstScreenEvents\[0\].*prefix ending in "\*"/);
 		expect(() =>
 			normalizeRendererConfig({
 				registry: { three: '@octanejs/three/renderer' },

--- a/packages/octane/tests/universal-renderer.test.ts
+++ b/packages/octane/tests/universal-renderer.test.ts
@@ -93,6 +93,75 @@ function objectRoot(compilerLeafProps = false) {
 	return { container, root };
 }
 
+function walkCompiledAst(root: unknown, visit: (node: any) => void): void {
+	const seen = new WeakSet<object>();
+	const walk = (node: any): void => {
+		if (node === null || typeof node !== 'object') return;
+		if (Array.isArray(node)) {
+			for (const child of node) walk(child);
+			return;
+		}
+		if (seen.has(node)) return;
+		seen.add(node);
+		visit(node);
+		for (const [key, child] of Object.entries(node)) {
+			if (key === 'loc' || key === 'metadata' || key === 'parent') continue;
+			walk(child);
+		}
+	};
+	walk(root);
+}
+
+function callsByImportedName(code: string, request: string): Map<string, any[]> {
+	const ast = parseModule(code, '/dist/compiled.js');
+	const imports = new Map<string, string>();
+	for (const statement of ast.body as any[]) {
+		if (statement.type !== 'ImportDeclaration' || statement.source?.value !== request) continue;
+		for (const specifier of statement.specifiers ?? []) {
+			if (specifier.type !== 'ImportSpecifier') continue;
+			imports.set(specifier.local.name, specifier.imported.name ?? specifier.imported.value);
+		}
+	}
+	const calls = new Map<string, any[]>();
+	walkCompiledAst(ast, (node) => {
+		if (node.type !== 'CallExpression' || node.callee?.type !== 'Identifier') return;
+		const imported = imports.get(node.callee.name);
+		if (imported === undefined) return;
+		const entries = calls.get(imported);
+		if (entries === undefined) calls.set(imported, [node]);
+		else entries.push(node);
+	});
+	return calls;
+}
+
+function importedLocalName(
+	code: string,
+	request: string,
+	importedName: string,
+): string | undefined {
+	const ast = parseModule(code, '/dist/compiled.js');
+	for (const statement of ast.body as any[]) {
+		if (statement.type !== 'ImportDeclaration' || statement.source?.value !== request) continue;
+		for (const specifier of statement.specifiers ?? []) {
+			if (specifier.type !== 'ImportSpecifier') continue;
+			if ((specifier.imported.name ?? specifier.imported.value) === importedName) {
+				return specifier.local.name;
+			}
+		}
+	}
+	return undefined;
+}
+
+function comparableCompiledAst(node: any): unknown {
+	if (Array.isArray(node)) return node.map(comparableCompiledAst);
+	if (node === null || typeof node !== 'object') return node;
+	return Object.fromEntries(
+		Object.entries(node)
+			.filter(([key]) => !['start', 'end', 'loc', 'metadata', 'parent'].includes(key))
+			.map(([key, value]) => [key, comparableCompiledAst(value)]),
+	);
+}
+
 describe('universal compiler target', () => {
 	it('leaves the DOM compiler byte-identical when renderer selection stays DOM', () => {
 		const source =
@@ -117,7 +186,7 @@ describe('universal compiler target', () => {
 		expect(optionalValidation).toEqual(baseline);
 	});
 
-	it('carries frozen runtime/thread metadata without changing emitted code', () => {
+	it('carries frozen runtime/thread metadata without changing emitted code by default', () => {
 		const source = 'export function Scene() @{ <view id="root" /> }';
 		const baseline = compile(source, '/src/Scene.object.tsrx', { hmr: false, renderer });
 		const background = compile(source, '/src/Scene.object.tsrx', {
@@ -156,6 +225,223 @@ describe('universal compiler target', () => {
 				universalRuntime: { runtime: 'object', thread: 'background' },
 			}),
 		).toThrow(/universalRuntime is available only in client mode/);
+	});
+
+	it('erases background callbacks from opted-in main-thread first-screen output', () => {
+		const source = `
+import {
+  useEffect as usePassive,
+  useEffectEvent,
+  useImperativeHandle,
+  useInsertionEffect,
+  useLayoutEffect,
+  useState,
+} from 'octane';
+
+function preserveLocalUseEffect(useEffect) {
+  useEffect(() => console.log('non-runtime-use-effect-callback'));
+}
+
+export function Scene({ id, ref }) @{
+  const [count] = useState(0);
+  usePassive(() => console.log('passive-main-thread-capture', id), [id]);
+  useLayoutEffect(() => console.log('layout-main-thread-capture', id));
+  useInsertionEffect(() => console.log('insertion-main-thread-capture', id), null);
+  const update = useEffectEvent(() => console.log('effect-event-main-thread-capture', id));
+  useImperativeHandle(ref, () => ({ id }), [id]);
+
+  <>
+    <view id={id} bindtap={() => console.log('event-main-thread-capture', count)} ref={ref} onUpdate={update} catchtap={null} />
+    <view key="ordered" bindlongpress={() => console.log('ordered-main-thread-capture', count)} ref={ref} />
+  </>
+}`;
+		const firstScreenRenderer = {
+			...renderer,
+			capabilities: ['main-thread-render-only'],
+			firstScreenEvents: ['bind*', 'catch*', 'onUpdate'],
+		} as const;
+		const baseline = compile(source, '/src/FirstScreen.object.tsrx', {
+			hmr: false,
+			renderer: firstScreenRenderer,
+		});
+		const background = compile(source, '/src/FirstScreen.object.tsrx', {
+			hmr: false,
+			renderer: firstScreenRenderer,
+			universalRuntime: { runtime: 'object', thread: 'background' },
+		});
+		const mainThread = compile(source, '/src/FirstScreen.object.tsrx', {
+			hmr: false,
+			renderer: firstScreenRenderer,
+			universalRuntime: { runtime: 'object', thread: 'main-thread' },
+		});
+
+		// The capability is inert outside the main-thread specialization.
+		expect(background.code).toBe(baseline.code);
+		expect(() => parseModule(mainThread.code, '/dist/FirstScreen.js')).not.toThrow();
+		expect(mainThread.code).toContain('non-runtime-use-effect-callback');
+		for (const marker of [
+			'passive-main-thread-capture',
+			'layout-main-thread-capture',
+			'insertion-main-thread-capture',
+			'effect-event-main-thread-capture',
+			'event-main-thread-capture',
+			'ordered-main-thread-capture',
+		]) {
+			expect(baseline.code).toContain(marker);
+			expect(mainThread.code).not.toContain(marker);
+		}
+
+		const baselineCalls = callsByImportedName(baseline.code, 'octane/universal');
+		const mainCalls = callsByImportedName(mainThread.code, 'octane/universal');
+		const baselinePlan = baselineCalls.get('universalPlan')?.[0];
+		const mainPlan = mainCalls.get('universalPlan')?.[0];
+		expect(comparableCompiledAst(mainPlan?.arguments[1])).toEqual(
+			comparableCompiledAst(baselinePlan?.arguments[1]),
+		);
+		expect(mainCalls.get('hookSlots')?.[0]?.arguments[0]?.value).toBe(
+			baselineCalls.get('hookSlots')?.[0]?.arguments[0]?.value,
+		);
+
+		for (const hook of [
+			'useEffect',
+			'useEffectEvent',
+			'useImperativeHandle',
+			'useInsertionEffect',
+			'useLayoutEffect',
+		]) {
+			const call = mainCalls.get(hook)?.[0];
+			expect(call, `expected ${hook} to retain its compiler-owned slot`).toBeDefined();
+			expect(call.arguments.at(-1)?.type).toBe('Identifier');
+			expect(call.arguments.slice(0, -1)).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ type: 'Identifier', name: 'undefined' }),
+				]),
+			);
+		}
+
+		const mainValues = mainCalls.get('universalValue') ?? [];
+		const baselineValues = baselineCalls.get('universalValue') ?? [];
+		const firstScreenEvent = importedLocalName(
+			mainThread.code,
+			'octane/universal',
+			'firstScreenEvent',
+		);
+		expect(firstScreenEvent).toBeDefined();
+		expect(
+			importedLocalName(baseline.code, 'octane/universal', 'firstScreenEvent'),
+		).toBeUndefined();
+		expect(mainValues).toHaveLength(baselineValues.length);
+		expect(mainValues[0].arguments[1].elements.map((element: any) => element.type)).toEqual([
+			'Identifier',
+			'Identifier',
+			'Identifier',
+			'ConditionalExpression',
+			'Literal',
+			'CallExpression',
+		]);
+		expect(mainValues[0].arguments[1].elements[1].name).toBe(firstScreenEvent);
+		expect(mainValues[0].arguments[1].elements[2].name).toBe('undefined');
+		expect(mainValues[0].arguments[1].elements[3]).toMatchObject({
+			type: 'ConditionalExpression',
+			consequent: { type: 'Identifier', name: 'undefined' },
+			alternate: { type: 'Identifier', name: firstScreenEvent },
+		});
+		expect(mainValues[0].arguments[1].elements[4].value).toBeNull();
+		const orderedEntries = mainCalls.get('universalProps')?.[0]?.arguments[0]?.elements;
+		expect(orderedEntries.at(-2).elements[2]).toMatchObject({
+			type: 'Identifier',
+			name: firstScreenEvent,
+		});
+		expect(orderedEntries.at(-1).elements[2]).toMatchObject({
+			type: 'Identifier',
+			name: 'undefined',
+		});
+	});
+
+	it('preserves nullish optional event reads while erasing inline callback bodies', () => {
+		const source = `
+import { runBackgroundOnly } from './background-only.js';
+
+export function Scene({ onTap, handlers }) @{
+  <view
+    bindtap={onTap}
+    catchtap={handlers.catchtap}
+    bindlongpress={() => runBackgroundOnly('optional-event-inline-capture')}
+  />
+}`;
+		const firstScreenRenderer = {
+			...renderer,
+			capabilities: ['main-thread-render-only'],
+			firstScreenEvents: ['bind*', 'catch*'],
+		} as const;
+		const mainThread = compile(source, '/src/OptionalEvents.object.tsrx', {
+			hmr: false,
+			renderer: firstScreenRenderer,
+			universalRuntime: { runtime: 'object', thread: 'main-thread' },
+		});
+
+		expect(() => parseModule(mainThread.code, '/dist/OptionalEvents.js')).not.toThrow();
+		expect(mainThread.code).not.toContain('optional-event-inline-capture');
+		const calls = callsByImportedName(mainThread.code, 'octane/universal');
+		const values = calls.get('universalValue')?.[0]?.arguments[1]?.elements;
+		const firstScreenEvent = importedLocalName(
+			mainThread.code,
+			'octane/universal',
+			'firstScreenEvent',
+		);
+		expect(firstScreenEvent).toBeDefined();
+		expect(values).toHaveLength(3);
+		for (const optional of values.slice(0, 2)) {
+			expect(optional).toMatchObject({
+				type: 'ConditionalExpression',
+				test: {
+					type: 'BinaryExpression',
+					operator: '==',
+					right: { type: 'Literal', value: null },
+				},
+				consequent: { type: 'Identifier', name: 'undefined' },
+				alternate: { type: 'Identifier', name: firstScreenEvent },
+			});
+		}
+		expect(values[0].test.left).toMatchObject({ type: 'Identifier', name: 'onTap' });
+		expect(values[1].test.left).toMatchObject({
+			type: 'MemberExpression',
+			property: { type: 'Identifier', name: 'catchtap' },
+		});
+		expect(values[2]).toMatchObject({ type: 'Identifier', name: firstScreenEvent });
+	});
+
+	it('rejects host spreads only in the main-thread render-only specialization', () => {
+		const source = `
+export function Scene({ hostProps }) @{
+  <view {...hostProps} />
+}`;
+		const firstScreenRenderer = {
+			...renderer,
+			capabilities: ['main-thread-render-only'],
+			firstScreenEvents: ['bind*', 'catch*'],
+		} as const;
+
+		expect(() =>
+			compile(source, '/src/SpreadEvents.object.tsrx', {
+				hmr: false,
+				renderer: firstScreenRenderer,
+			}),
+		).not.toThrow();
+		expect(() =>
+			compile(source, '/src/SpreadEvents.object.tsrx', {
+				hmr: false,
+				renderer: firstScreenRenderer,
+				universalRuntime: { runtime: 'object', thread: 'background' },
+			}),
+		).not.toThrow();
+		expect(() =>
+			compile(source, '/src/SpreadEvents.object.tsrx', {
+				hmr: false,
+				renderer: firstScreenRenderer,
+				universalRuntime: { runtime: 'object', thread: 'main-thread' },
+			}),
+		).toThrow(/main-thread render-only host spreads.*statically named.*expand the spread/);
 	});
 
 	it('accepts allowed hosts and props while respecting lexical bindings and property keys', () => {

--- a/packages/octane/typetests/vite-plugin.test-d.ts
+++ b/packages/octane/typetests/vite-plugin.test-d.ts
@@ -16,6 +16,8 @@ export const options = {
 			object: {
 				module: '/src/object-renderer.js',
 				server: 'client-only',
+				capabilities: ['main-thread-render-only'],
+				firstScreenEvents: ['bind*', 'catch*'],
 				validation: {
 					textParents: ['text'],
 					forbiddenGlobals: ['document'],

--- a/packages/rspack-plugin-octane/README.md
+++ b/packages/rspack-plugin-octane/README.md
@@ -67,6 +67,34 @@ new OctaneRspackPlugin({
 Options remain serializable data—there are no renderer callbacks—so the same
 configuration is safe to reuse across compiler environments and caches.
 
+Rspack layers can compile the same authored module against distinct universal
+renderer graphs. Configure the background graph at the top level, then key
+`layerSpecializations` by the exact value of `module.layer`:
+
+```js
+new OctaneRspackPlugin({
+	runtime: '@fixture/native-background-runtime',
+	renderers: backgroundRenderers,
+	universalRuntime: { runtime: 'native', thread: 'background' },
+	layerSpecializations: {
+		'native:main': {
+			runtime: '@fixture/native-main-runtime',
+			renderers: mainThreadRenderers,
+			universalRuntime: { runtime: 'native', thread: 'main-thread' },
+		},
+	},
+});
+```
+
+The compiler selects `renderers` and `universalRuntime` from each transformed
+module's layer. The plugin also installs `runtime` as an exact `octane` alias
+for requests whose issuer belongs to that layer. Unconfigured and unknown
+layers keep the top-level options. All renderer configurations participate in
+source-dependency discovery and watching, and their normalized signatures and
+runtime identities salt Rspack's persistent cache. The standalone loader
+supports layer-specific compiler options but cannot install runtime aliases,
+so `runtime` specializations require `OctaneRspackPlugin`.
+
 Rspack's dev server enables the loader's hot context. If you run a custom dev
 server, add Rspack's `HotModuleReplacementPlugin` as usual.
 

--- a/packages/rspack-plugin-octane/src/loader.js
+++ b/packages/rspack-plugin-octane/src/loader.js
@@ -2,7 +2,11 @@ import { realpathSync } from 'node:fs';
 import { dirname, isAbsolute, resolve } from 'node:path';
 import remapping from '@jridgewell/remapping';
 import { canonicalModuleId, cleanModuleId, createOctaneCompiler } from 'octane/compiler/bundler';
-import { inferRspackEnvironment, normalizeLoaderOptions } from './shared.js';
+import {
+	inferRspackEnvironment,
+	normalizeLoaderOptions,
+	selectLayerCompilerOptions,
+} from './shared.js';
 
 function realRoot(path) {
 	try {
@@ -99,14 +103,20 @@ export default function octaneLoader(source, inputSourceMap) {
 			environment === 'client' &&
 			(options.dev ?? (this.mode === undefined || this.mode !== 'production'));
 		const profile = environment === 'client' && options.profile === true;
+		const compilerOptions =
+			options.layerSpecializations === undefined
+				? options
+				: selectLayerCompilerOptions(options, this._module);
 		const compiler = createOctaneCompiler({
 			root,
 			profile,
 			...(options.exclude === undefined ? null : { exclude: options.exclude }),
-			...(options.renderers === undefined ? null : { renderers: options.renderers }),
-			...(options.universalRuntime === undefined
+			...(compilerOptions.renderers === undefined
 				? null
-				: { universalRuntime: options.universalRuntime }),
+				: { renderers: compilerOptions.renderers }),
+			...(compilerOptions.universalRuntime === undefined
+				? null
+				: { universalRuntime: compilerOptions.universalRuntime }),
 			...(options.requireDirective === undefined
 				? null
 				: { requireDirective: options.requireDirective }),

--- a/packages/rspack-plugin-octane/src/plugin.js
+++ b/packages/rspack-plugin-octane/src/plugin.js
@@ -78,6 +78,54 @@ function addProjectRendererAliases(resolveOptions, renderers, root) {
 	resolveOptions.alias = { ...aliases, ...additions };
 }
 
+function layerSpecializationCacheIdentity(layerSpecializations) {
+	if (layerSpecializations === undefined) return undefined;
+	return Object.fromEntries(
+		Object.entries(layerSpecializations).map(([layer, specialization]) => [
+			layer,
+			{
+				...(specialization.runtime === undefined ? null : { runtime: specialization.runtime }),
+				...(specialization.renderers === undefined
+					? null
+					: { renderers: specialization.renderers.signature }),
+				...(specialization.universalRuntime === undefined
+					? null
+					: { universalRuntime: specialization.universalRuntime }),
+			},
+		]),
+	);
+}
+
+function createDiscoveryCompiler(options, root, profile, specialization) {
+	const renderers = specialization?.renderers ?? options.renderers;
+	const universalRuntime = specialization?.universalRuntime ?? options.universalRuntime;
+	return createOctaneCompiler({
+		root,
+		profile,
+		...(options.exclude === undefined ? null : { exclude: options.exclude }),
+		...(renderers === undefined ? null : { renderers }),
+		...(universalRuntime === undefined ? null : { universalRuntime }),
+	});
+}
+
+function discoverAll(compilers) {
+	if (compilers.length === 1) return compilers[0].discoverSourceDependencies();
+	const packages = new Set();
+	const dependencies = new Set();
+	const missingDependencies = new Set();
+	for (const compiler of compilers) {
+		const discovery = compiler.discoverSourceDependencies();
+		for (const value of discovery.packages ?? []) packages.add(value);
+		for (const value of discovery.dependencies ?? []) dependencies.add(value);
+		for (const value of discovery.missingDependencies ?? []) missingDependencies.add(value);
+	}
+	return {
+		packages: [...packages].sort(),
+		dependencies: [...dependencies].sort(),
+		missingDependencies: [...missingDependencies].sort(),
+	};
+}
+
 function addDependencies(collection, values) {
 	if (!collection?.add) return;
 	for (const value of values ?? []) collection.add(value);
@@ -239,21 +287,18 @@ export class OctaneRspackPlugin {
 			renderers: this.options.renderers?.signature,
 			runtime: this.options.runtime,
 			universalRuntime: this.options.universalRuntime,
+			layerSpecializations: layerSpecializationCacheIdentity(this.options.layerSpecializations),
 			// Ownership flips which modules compile vs pass through — cached
 			// transform results must not survive a requireDirective toggle.
 			requireDirective: this.options.requireDirective === true,
 			transpile: this.options.transpile !== false,
 		});
 		installProfilingDefine(compiler, profile);
-		const neutralCompiler = createOctaneCompiler({
-			root,
-			profile,
-			...(this.options.exclude === undefined ? null : { exclude: this.options.exclude }),
-			...(this.options.renderers === undefined ? null : { renderers: this.options.renderers }),
-			...(this.options.universalRuntime === undefined
-				? null
-				: { universalRuntime: this.options.universalRuntime }),
-		});
+		const neutralCompiler = createDiscoveryCompiler(this.options, root, profile);
+		const discoveryCompilers = [neutralCompiler];
+		for (const specialization of Object.values(this.options.layerSpecializations ?? {})) {
+			discoveryCompilers.push(createDiscoveryCompiler(this.options, root, profile, specialization));
+		}
 		const runtimeRequest =
 			this.options.runtime ?? neutralCompiler.resolveRuntimeRequest('octane', environment);
 
@@ -261,6 +306,9 @@ export class OctaneRspackPlugin {
 		addUniqueExtensions(compiler.options.resolve);
 		addRuntimeAlias(compiler.options.resolve, runtimeRequest, root);
 		addProjectRendererAliases(compiler.options.resolve, this.options.renderers, root);
+		for (const specialization of Object.values(this.options.layerSpecializations ?? {})) {
+			addProjectRendererAliases(compiler.options.resolve, specialization.renderers, root);
+		}
 
 		compiler.options.module ??= {};
 		compiler.options.module.rules ??= [];
@@ -275,6 +323,9 @@ export class OctaneRspackPlugin {
 			...(this.options.universalRuntime === undefined
 				? null
 				: { universalRuntime: this.options.universalRuntime }),
+			...(this.options.layerSpecializations === undefined
+				? null
+				: { layerSpecializations: this.options.layerSpecializations }),
 			...(this.options.requireDirective === undefined
 				? null
 				: { requireDirective: this.options.requireDirective }),
@@ -292,21 +343,32 @@ export class OctaneRspackPlugin {
 				use: [{ loader: 'builtin:swc-loader', options: { detectSyntax: 'auto' } }],
 			});
 		}
+		for (const [layer, specialization] of Object.entries(this.options.layerSpecializations ?? {})) {
+			if (specialization.runtime === undefined) continue;
+			compiler.options.module.rules.push({
+				issuerLayer: layer,
+				resolve: {
+					alias: {
+						octane$: resolveRuntimeModule(specialization.runtime, root),
+					},
+				},
+			});
+		}
 
 		let discovery;
 		const discover = () => {
 			if (discovery === undefined) {
-				discovery = neutralCompiler.discoverSourceDependencies();
+				discovery = discoverAll(discoveryCompilers);
 				this.sourceDependencies = Object.freeze([...(discovery.packages ?? [])]);
 			}
 			return discovery;
 		};
 		compiler.hooks.invalid?.tap(PLUGIN_NAME, (filename) => {
-			neutralCompiler.invalidate(filename);
+			for (const current of discoveryCompilers) current.invalidate(filename);
 			discovery = undefined;
 		});
 		compiler.hooks.watchRun?.tap(PLUGIN_NAME, () => {
-			neutralCompiler.invalidate();
+			for (const current of discoveryCompilers) current.invalidate();
 			discovery = undefined;
 		});
 		compiler.hooks.thisCompilation?.tap(PLUGIN_NAME, (compilation) => {

--- a/packages/rspack-plugin-octane/src/shared.js
+++ b/packages/rspack-plugin-octane/src/shared.js
@@ -44,8 +44,19 @@ const LOADER_OPTION_KEYS = new Set([
 	'renderers',
 	'requireDirective',
 	'universalRuntime',
+	'layerSpecializations',
 ]);
 const PLUGIN_OPTION_KEYS = new Set([...LOADER_OPTION_KEYS, 'runtime', 'transpile']);
+const LAYER_SPECIALIZATION_KEYS = new Set(['runtime', 'renderers', 'universalRuntime']);
+
+function normalizeRuntimeRequest(value, label = 'runtime') {
+	if (value !== undefined && (typeof value !== 'string' || value.trim() !== value || !value)) {
+		throw new TypeError(
+			`@octanejs/rspack-plugin: \`${label}\` must be a non-empty module request string.`,
+		);
+	}
+	return value;
+}
 
 function normalizeUniversalRuntime(value) {
 	if (value === undefined) return undefined;
@@ -73,6 +84,68 @@ function normalizeUniversalRuntime(value) {
 	return Object.freeze({ runtime: value.runtime, thread: value.thread });
 }
 
+function normalizeLayerSpecializations(value) {
+	if (value === undefined) return undefined;
+	if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+		throw new TypeError('@octanejs/rspack-plugin: `layerSpecializations` must be an object map.');
+	}
+	const entries = Object.entries(value).sort(([left], [right]) =>
+		left < right ? -1 : left > right ? 1 : 0,
+	);
+	const normalized = [];
+	for (const [layer, specialization] of entries) {
+		if (!layer || layer.trim() !== layer) {
+			throw new TypeError(
+				'@octanejs/rspack-plugin: `layerSpecializations` keys must be non-empty layer names without surrounding whitespace.',
+			);
+		}
+		if (
+			specialization === null ||
+			typeof specialization !== 'object' ||
+			Array.isArray(specialization)
+		) {
+			throw new TypeError(
+				`@octanejs/rspack-plugin: \`layerSpecializations.${layer}\` must be an object.`,
+			);
+		}
+		for (const key of Object.keys(specialization)) {
+			if (!LAYER_SPECIALIZATION_KEYS.has(key)) {
+				throw new TypeError(
+					`@octanejs/rspack-plugin: unknown \`layerSpecializations.${layer}.${key}\` option.`,
+				);
+			}
+		}
+		const runtime = normalizeRuntimeRequest(
+			specialization.runtime,
+			`layerSpecializations.${layer}.runtime`,
+		);
+		const renderers =
+			specialization.renderers === undefined
+				? undefined
+				: normalizeRendererConfig(specialization.renderers);
+		const universalRuntime = normalizeUniversalRuntime(specialization.universalRuntime);
+		normalized.push([
+			layer,
+			Object.freeze({
+				...(runtime === undefined ? null : { runtime }),
+				...(renderers === undefined ? null : { renderers }),
+				...(universalRuntime === undefined ? null : { universalRuntime }),
+			}),
+		]);
+	}
+	return Object.freeze(Object.fromEntries(normalized));
+}
+
+/** Select the compiler-facing options for a module's Rspack layer. */
+export function selectLayerCompilerOptions(options, module) {
+	const layer = typeof module?.layer === 'string' ? module.layer : undefined;
+	const specialization = layer === undefined ? undefined : options.layerSpecializations?.[layer];
+	return {
+		renderers: specialization?.renderers ?? options.renderers,
+		universalRuntime: specialization?.universalRuntime ?? options.universalRuntime,
+	};
+}
+
 function assertBooleanOption(options, key) {
 	if (options[key] !== undefined && typeof options[key] !== 'boolean') {
 		throw new TypeError(`@octanejs/rspack-plugin: \`${key}\` must be a boolean.`);
@@ -93,17 +166,7 @@ function normalizeOptions(value, plugin) {
 	if (options.root !== undefined && typeof options.root !== 'string') {
 		throw new TypeError('@octanejs/rspack-plugin: `root` must be a path string.');
 	}
-	if (
-		plugin &&
-		options.runtime !== undefined &&
-		(typeof options.runtime !== 'string' ||
-			options.runtime.trim() !== options.runtime ||
-			!options.runtime)
-	) {
-		throw new TypeError(
-			'@octanejs/rspack-plugin: `runtime` must be a non-empty module request string.',
-		);
-	}
+	if (plugin) normalizeRuntimeRequest(options.runtime);
 	if (
 		options.environment !== undefined &&
 		options.environment !== 'client' &&
@@ -125,6 +188,7 @@ function normalizeOptions(value, plugin) {
 	const renderers =
 		options.renderers === undefined ? undefined : normalizeRendererConfig(options.renderers);
 	const universalRuntime = normalizeUniversalRuntime(options.universalRuntime);
+	const layerSpecializations = normalizeLayerSpecializations(options.layerSpecializations);
 
 	const normalized = {
 		...(options.root === undefined ? null : { root: options.root }),
@@ -135,6 +199,7 @@ function normalizeOptions(value, plugin) {
 		...(options.exclude === undefined ? null : { exclude: [...options.exclude] }),
 		...(renderers === undefined ? null : { renderers }),
 		...(universalRuntime === undefined ? null : { universalRuntime }),
+		...(layerSpecializations === undefined ? null : { layerSpecializations }),
 		...(options.requireDirective === undefined
 			? null
 			: { requireDirective: options.requireDirective }),

--- a/packages/rspack-plugin-octane/tests/loader.test.ts
+++ b/packages/rspack-plugin-octane/tests/loader.test.ts
@@ -30,7 +30,7 @@ function runLoader({
 	resource = '/project/src/App.tsrx?cache=1',
 	source = 'export function App() @{ <div /> }',
 	inputSourceMap,
-	module = { buildInfo: {} as Record<string, unknown> },
+	module = { buildInfo: {} as Record<string, unknown>, layer: undefined as string | undefined },
 }: {
 	options?: Record<string, unknown>;
 	target?: unknown;
@@ -40,7 +40,7 @@ function runLoader({
 	resource?: string;
 	source?: string | Buffer;
 	inputSourceMap?: unknown;
-	module?: { buildInfo: Record<string, unknown> };
+	module?: { buildInfo: Record<string, unknown>; layer?: string };
 } = {}) {
 	const dependencies: string[] = [];
 	const missingDependencies: string[] = [];
@@ -148,6 +148,60 @@ describe('octane Rspack loader', () => {
 			serverRpc: true,
 			universalRuntime: { runtime: 'lynx', thread: 'background' },
 		});
+	});
+
+	it('selects compiler configuration from the current Rspack layer', () => {
+		mocks.transform.mockReturnValue(null);
+		const options = {
+			renderers: {
+				registry: { native: '/src/background-renderer.js' },
+				default: 'native',
+			},
+			universalRuntime: { runtime: 'native', thread: 'background' },
+			layerSpecializations: {
+				'octane:main-thread': {
+					runtime: '@fixture/main-runtime',
+					renderers: {
+						registry: { native: '/src/main-renderer.js' },
+						default: 'native',
+					},
+					universalRuntime: { runtime: 'native', thread: 'main-thread' },
+				},
+			},
+		};
+
+		runLoader({
+			options,
+			module: { buildInfo: {}, layer: 'octane:main-thread' },
+		});
+		expect(mocks.createOctaneCompiler).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				renderers: expect.objectContaining({
+					registry: {
+						dom: expect.any(Object),
+						native: expect.objectContaining({ module: '/src/main-renderer.js' }),
+					},
+					default: 'native',
+				}),
+				universalRuntime: { runtime: 'native', thread: 'main-thread' },
+			}),
+		);
+
+		runLoader({
+			options,
+			module: { buildInfo: {}, layer: 'other' },
+		});
+		expect(mocks.createOctaneCompiler).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				renderers: expect.objectContaining({
+					registry: expect.objectContaining({
+						native: expect.objectContaining({ module: '/src/background-renderer.js' }),
+					}),
+					default: 'native',
+				}),
+				universalRuntime: { runtime: 'native', thread: 'background' },
+			}),
+		);
 	});
 
 	it('composes a prior loader map with the Octane compiler map', () => {

--- a/packages/rspack-plugin-octane/tests/plugin.test.ts
+++ b/packages/rspack-plugin-octane/tests/plugin.test.ts
@@ -188,6 +188,121 @@ describe('OctaneRspackPlugin', () => {
 		);
 	});
 
+	it('specializes compiler and runtime resolution by Rspack layer', () => {
+		const compiler = createCompiler('web');
+		const plugin = new OctaneRspackPlugin({
+			runtime: '@fixture/background-runtime',
+			renderers: {
+				registry: { native: '/src/background-renderer.js' },
+				default: 'native',
+			},
+			universalRuntime: { runtime: 'native', thread: 'background' },
+			layerSpecializations: {
+				'octane:main-thread': {
+					runtime: '@fixture/main-runtime',
+					renderers: {
+						registry: { native: '/src/main-renderer.js' },
+						default: 'native',
+					},
+					universalRuntime: { runtime: 'native', thread: 'main-thread' },
+				},
+			},
+			transpile: false,
+		});
+		plugin.apply(compiler as any);
+
+		expect(mocks.createOctaneCompiler).toHaveBeenCalledTimes(2);
+		expect(mocks.createOctaneCompiler).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({
+				renderers: expect.objectContaining({
+					default: 'native',
+					registry: expect.objectContaining({
+						native: expect.objectContaining({ module: '/src/background-renderer.js' }),
+					}),
+				}),
+				universalRuntime: { runtime: 'native', thread: 'background' },
+			}),
+		);
+		expect(mocks.createOctaneCompiler).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({
+				renderers: expect.objectContaining({
+					default: 'native',
+					registry: expect.objectContaining({
+						native: expect.objectContaining({ module: '/src/main-renderer.js' }),
+					}),
+				}),
+				universalRuntime: { runtime: 'native', thread: 'main-thread' },
+			}),
+		);
+
+		const aliases = compiler.options.resolve.alias as Record<string, string>;
+		expect(aliases['octane$']).toBe('@fixture/background-runtime');
+		expect(aliases['/src/background-renderer.js$']).toBe('/project/src/background-renderer.js');
+		expect(aliases['/src/main-renderer.js$']).toBe('/project/src/main-renderer.js');
+		expect(compiler.options.module.rules).toHaveLength(2);
+		expect(compiler.options.module.rules[0].use[0].options).toMatchObject({
+			universalRuntime: { runtime: 'native', thread: 'background' },
+			layerSpecializations: {
+				'octane:main-thread': expect.objectContaining({
+					runtime: '@fixture/main-runtime',
+					universalRuntime: { runtime: 'native', thread: 'main-thread' },
+				}),
+			},
+		});
+		expect(compiler.options.module.rules[1]).toEqual({
+			issuerLayer: 'octane:main-thread',
+			resolve: { alias: { octane$: '@fixture/main-runtime' } },
+		});
+	});
+
+	it('watches the union of base and layer-specialized source dependencies', () => {
+		const invalidations = new Map<string, ReturnType<typeof vi.fn>>();
+		mocks.createOctaneCompiler.mockImplementation((options) => {
+			const thread = options.universalRuntime?.thread ?? 'base';
+			const invalidate = vi.fn();
+			invalidations.set(thread, invalidate);
+			return {
+				discoverSourceDependencies: () => ({
+					packages: [`@fixture/${thread}`, '@fixture/shared'],
+					dependencies: [`/project/${thread}.json`, '/project/shared.json'],
+					missingDependencies: [`/project/${thread}.missing`],
+				}),
+				invalidate,
+				resolveRuntimeRequest: mocks.resolveRuntimeRequest,
+			};
+		});
+		const compiler = createCompiler('node');
+		const plugin = new OctaneRspackPlugin({
+			universalRuntime: { runtime: 'native', thread: 'background' },
+			layerSpecializations: {
+				'octane:main-thread': {
+					universalRuntime: { runtime: 'native', thread: 'main-thread' },
+				},
+			},
+		});
+		plugin.apply(compiler as any);
+
+		const compilation = { fileDependencies: new Set(), missingDependencies: new Set() };
+		compiler.hooks.thisCompilation.call(compilation);
+		expect(compilation.fileDependencies).toEqual(
+			new Set(['/project/background.json', '/project/main-thread.json', '/project/shared.json']),
+		);
+		expect(compilation.missingDependencies).toEqual(
+			new Set(['/project/background.missing', '/project/main-thread.missing']),
+		);
+		expect(plugin.sourceDependencies).toEqual([
+			'@fixture/background',
+			'@fixture/main-thread',
+			'@fixture/shared',
+		]);
+
+		compiler.hooks.invalid.call('/project/package.json');
+		expect(invalidations.get('background')).toHaveBeenCalledWith('/project/package.json');
+		expect(invalidations.get('main-thread')).toHaveBeenCalledWith('/project/package.json');
+	});
+
 	it('salts persistent caches with the normalized renderer configuration', () => {
 		const createCachedCompiler = () => {
 			const compiler = createCompiler('web');
@@ -199,6 +314,8 @@ describe('OctaneRspackPlugin', () => {
 		const boundedObject = createCachedCompiler();
 		const nativeBackground = createCachedCompiler();
 		const nativeMain = createCachedCompiler();
+		const layeredBackground = createCachedCompiler();
+		const layeredMain = createCachedCompiler();
 
 		new OctaneRspackPlugin().apply(dom as any);
 		new OctaneRspackPlugin({
@@ -230,6 +347,16 @@ describe('OctaneRspackPlugin', () => {
 			runtime: '@octanejs/lynx/renderer',
 			universalRuntime: { runtime: 'lynx', thread: 'main-thread' },
 		}).apply(nativeMain as any);
+		new OctaneRspackPlugin({
+			layerSpecializations: {
+				main: { universalRuntime: { runtime: 'lynx', thread: 'background' } },
+			},
+		}).apply(layeredBackground as any);
+		new OctaneRspackPlugin({
+			layerSpecializations: {
+				main: { universalRuntime: { runtime: 'lynx', thread: 'main-thread' } },
+			},
+		}).apply(layeredMain as any);
 
 		expect((dom.options as any).cache.version).toMatch(/^user-cache\|octane-rspack@/);
 		expect((object.options as any).cache.version).toMatch(/^user-cache\|octane-rspack@/);
@@ -240,6 +367,9 @@ describe('OctaneRspackPlugin', () => {
 		);
 		expect((nativeBackground.options as any).cache.version).not.toBe(
 			(nativeMain.options as any).cache.version,
+		);
+		expect((layeredBackground.options as any).cache.version).not.toBe(
+			(layeredMain.options as any).cache.version,
 		);
 
 		// requireDirective flips which modules compile vs pass through, so a

--- a/packages/rspack-plugin-octane/tests/rspack.test.ts
+++ b/packages/rspack-plugin-octane/tests/rspack.test.ts
@@ -275,6 +275,103 @@ ${includeRawBinding ? "export { Raw } from '@fixture/raw';" : ''}
 		}
 	}, 30_000);
 
+	it('builds one source with layer-specific compiler and runtime identities', async () => {
+		for (const [name, marker] of [
+			['background', 'background-runtime-marker'],
+			['main', 'main-runtime-marker'],
+		] as const) {
+			write(
+				root,
+				`node_modules/@fixture/${name}-runtime/package.json`,
+				JSON.stringify({
+					name: `@fixture/${name}-runtime`,
+					type: 'module',
+					exports: './index.js',
+				}) + '\n',
+			);
+			write(
+				root,
+				`node_modules/@fixture/${name}-runtime/index.js`,
+				`export const runtimeMarker = '${marker}';\n`,
+			);
+			write(
+				root,
+				`src/${name}-renderer.js`,
+				readFileSync(join(root, 'node_modules/@fixture/object-renderer/index.js'), 'utf8').replace(
+					'client-object-renderer',
+					`${name}-renderer-marker`,
+				),
+			);
+		}
+		write(root, 'src/Layered.tsrx', `export function Layered() @{ <item /> }\n`);
+		write(root, 'src/runtime-marker.js', `export { runtimeMarker } from 'octane';\n`);
+		for (const name of ['background', 'main']) {
+			write(
+				root,
+				`src/${name}.js`,
+				`export { Layered } from './Layered.tsrx';\nexport { runtimeMarker } from './runtime-marker.js';\n`,
+			);
+		}
+
+		const outputPath = join(root, 'dist-layers');
+		const stats = await compile({
+			context: root,
+			mode: 'development',
+			target: 'web',
+			experiments: { layers: true },
+			entry: {
+				background: { import: './src/background.js', layer: 'octane:background' },
+				main: { import: './src/main.js', layer: 'octane:main-thread' },
+			},
+			optimization: { minimize: false },
+			output: { path: outputPath, filename: '[name].js' },
+			plugins: [
+				new OctaneRspackPlugin({
+					runtime: '@fixture/background-runtime',
+					renderers: {
+						registry: { object: '/src/background-renderer.js' },
+						default: 'object',
+					},
+					universalRuntime: { runtime: 'object', thread: 'background' },
+					layerSpecializations: {
+						'octane:main-thread': {
+							runtime: '@fixture/main-runtime',
+							renderers: {
+								registry: { object: '/src/main-renderer.js' },
+								default: 'object',
+							},
+							universalRuntime: { runtime: 'object', thread: 'main-thread' },
+						},
+					},
+				}),
+			],
+		});
+
+		const background = readFileSync(join(outputPath, 'background.js'), 'utf8');
+		const main = readFileSync(join(outputPath, 'main.js'), 'utf8');
+		expect(background).toContain('background-runtime-marker');
+		expect(background).toContain('background-renderer-marker');
+		expect(background).not.toContain('main-runtime-marker');
+		expect(background).not.toContain('main-renderer-marker');
+		expect(main).toContain('main-runtime-marker');
+		expect(main).toContain('main-renderer-marker');
+		expect(main).not.toContain('background-runtime-marker');
+		expect(main).not.toContain('background-renderer-marker');
+
+		const layeredModules = [...stats.compilation.modules]
+			.map((module: any) => ({
+				identifier: module.identifier?.(),
+				info: getOctaneRspackBuildInfo(module),
+			}))
+			.filter((module) => module.identifier?.includes('src/Layered.tsrx'));
+		expect(layeredModules.map((module) => module.info?.universalRuntime)).toEqual(
+			expect.arrayContaining([
+				{ runtime: 'object', thread: 'background' },
+				{ runtime: 'object', thread: 'main-thread' },
+			]),
+		);
+	}, 30_000);
+
 	it('splits client-only renderer dependencies from the raw server graph with stable module identity', async () => {
 		write(
 			root,

--- a/packages/rspack-plugin-octane/tests/shared.test.ts
+++ b/packages/rspack-plugin-octane/tests/shared.test.ts
@@ -94,6 +94,52 @@ describe('declarative options', () => {
 		expect(() => normalizeLoaderOptions({ runtime: 'other' })).toThrow(/unknown option `runtime`/);
 	});
 
+	it('copies, orders, and deeply freezes layer compiler specializations', () => {
+		const layerSpecializations = {
+			'worker:main': {
+				runtime: '@fixture/main-runtime',
+				renderers: {
+					registry: { native: '/src/main-renderer.js' },
+					default: 'native',
+				},
+				universalRuntime: { runtime: 'native', thread: 'main-thread' as const },
+			},
+			'worker:background': {
+				universalRuntime: { runtime: 'native', thread: 'background' as const },
+			},
+		};
+		const options = normalizePluginOptions({ layerSpecializations });
+
+		layerSpecializations['worker:main'].runtime = '@fixture/later-runtime';
+		layerSpecializations['worker:main'].renderers.registry.native = '/src/later-renderer.js';
+		(layerSpecializations['worker:main'].universalRuntime as { thread: string }).thread =
+			'background';
+
+		expect(Object.keys(options.layerSpecializations!)).toEqual([
+			'worker:background',
+			'worker:main',
+		]);
+		expect(options.layerSpecializations!['worker:main']).toMatchObject({
+			runtime: '@fixture/main-runtime',
+			renderers: {
+				registry: {
+					native: { module: '/src/main-renderer.js', target: 'universal' },
+				},
+				default: 'native',
+			},
+			universalRuntime: { runtime: 'native', thread: 'main-thread' },
+		});
+		expect(Object.isFrozen(options.layerSpecializations)).toBe(true);
+		expect(Object.isFrozen(options.layerSpecializations!['worker:main'])).toBe(true);
+		expect(Object.isFrozen(options.layerSpecializations!['worker:main'].renderers)).toBe(true);
+		expect(Object.isFrozen(options.layerSpecializations!['worker:main'].universalRuntime)).toBe(
+			true,
+		);
+		expect(normalizeLoaderOptions({ layerSpecializations })).toHaveProperty(
+			'layerSpecializations.worker:main',
+		);
+	});
+
 	it.each([
 		[{ environment: 'worker' }, /environment/],
 		[{ hmr: 'webpack' }, /hmr/],
@@ -101,6 +147,15 @@ describe('declarative options', () => {
 		[{ renderers: { default: 'missing' } }, /default references unknown renderer/],
 		[{ universalRuntime: { runtime: 'lynx', thread: 'worker' } }, /thread/],
 		[{ universalRuntime: { runtime: 'Lynx', thread: 'background' } }, /runtime/],
+		[{ layerSpecializations: [] }, /layerSpecializations/],
+		[{ layerSpecializations: { '': {} } }, /layer names/],
+		[{ layerSpecializations: { main: null } }, /layerSpecializations\.main/],
+		[{ layerSpecializations: { main: { environment: 'client' } } }, /unknown/],
+		[{ layerSpecializations: { main: { runtime: ' later ' } } }, /runtime/],
+		[
+			{ layerSpecializations: { main: { universalRuntime: { runtime: 'native', thread: 'ui' } } } },
+			/thread/,
+		],
 		[{ runtime: '' }, /runtime/],
 		[{ transform: () => {} }, /unknown option/],
 	] as const)('rejects invalid options %#', (value, message) => {

--- a/packages/rspack-plugin-octane/types/index.d.ts
+++ b/packages/rspack-plugin-octane/types/index.d.ts
@@ -32,6 +32,8 @@ export type OctaneRendererRegistryEntry =
 			intrinsics?: string;
 			text?: 'reject' | 'ignore' | 'host';
 			capabilities?: readonly string[];
+			/** Host event prop names or prefix patterns retained as first-screen listener sentinels. */
+			firstScreenEvents?: readonly string[];
 			validation?: OctaneRendererValidationOptions;
 	  };
 
@@ -64,6 +66,7 @@ export interface OctaneResolvedRendererConfig {
 				readonly intrinsics?: string;
 				readonly text: 'reject' | 'ignore' | 'host';
 				readonly capabilities: readonly string[];
+				readonly firstScreenEvents?: readonly string[];
 				readonly validation?: Readonly<OctaneRendererValidationOptions>;
 			}
 		>
@@ -78,6 +81,24 @@ export interface OctaneResolvedRendererConfig {
 		readonly renderer: string;
 	}[];
 	readonly signature: string;
+}
+
+/** Compile-only host identity attached to a universal renderer graph. */
+export interface OctaneUniversalRuntimeOptions {
+	readonly runtime: string;
+	readonly thread: 'background' | 'main-thread';
+}
+
+/** Compiler options selected for modules issued from one Rspack layer. */
+export interface OctaneRspackLoaderLayerSpecializationOptions {
+	renderers?: OctaneRendererConfigOptions | OctaneResolvedRendererConfig;
+	universalRuntime?: OctaneUniversalRuntimeOptions;
+}
+
+/** Plugin-owned compiler and runtime options selected for one Rspack layer. */
+export interface OctaneRspackLayerSpecializationOptions extends OctaneRspackLoaderLayerSpecializationOptions {
+	/** Override exact `octane` imports for modules issued from this layer. */
+	runtime?: string;
 }
 
 export interface OctaneRspackLoaderOptions {
@@ -101,10 +122,13 @@ export interface OctaneRspackLoaderOptions {
 	/** @experimental Renderer registry and ordered per-file selection rules. */
 	renderers?: OctaneRendererConfigOptions | OctaneResolvedRendererConfig;
 	/** Compile-only host runtime/thread identity for a universal renderer graph. */
-	universalRuntime?: {
-		readonly runtime: string;
-		readonly thread: 'background' | 'main-thread';
-	};
+	universalRuntime?: OctaneUniversalRuntimeOptions;
+	/**
+	 * Compiler options selected by the current module's Rspack layer. Unknown
+	 * layers retain the top-level compiler options. Runtime aliases remain a
+	 * class-plugin concern and cannot be configured by the standalone loader.
+	 */
+	layerSpecializations?: Readonly<Record<string, OctaneRspackLoaderLayerSpecializationOptions>>;
 	/**
 	 * Mixed-toolchain ownership gate: when `true`, a project `.tsrx` is
 	 * Octane's by extension, and a project `.tsx` (full compile) or plain
@@ -119,6 +143,11 @@ export interface OctaneRspackLoaderOptions {
 }
 
 export interface OctaneRspackPluginOptions extends OctaneRspackLoaderOptions {
+	/**
+	 * Compiler and exact-runtime overrides selected by the current module's
+	 * Rspack layer. Unknown layers retain the top-level plugin options.
+	 */
+	layerSpecializations?: Readonly<Record<string, OctaneRspackLayerSpecializationOptions>>;
 	/**
 	 * Override the exact module used for plain `octane` imports in this graph.
 	 * Universal host integrations use this to share one hook/context runtime
@@ -138,10 +167,7 @@ export interface OctaneRspackBuildInfo {
 	transformKind: 'compile' | 'slots' | 'client-only-stub';
 	serverRpc: boolean;
 	/** Universal host runtime/thread identity, when this module was specialized. */
-	universalRuntime?: {
-		readonly runtime: string;
-		readonly thread: 'background' | 'main-thread';
-	};
+	universalRuntime?: OctaneUniversalRuntimeOptions;
 	/** Stable identity shared by the client compile and its inert server stub. */
 	clientReference?: {
 		readonly id: string;

--- a/packages/rspack-plugin-octane/types/options.test-d.ts
+++ b/packages/rspack-plugin-octane/types/options.test-d.ts
@@ -1,0 +1,41 @@
+import type { OctaneRspackLoaderOptions, OctaneRspackPluginOptions } from './index.js';
+
+const loaderOptions: OctaneRspackLoaderOptions = {
+	layerSpecializations: {
+		'native:main': {
+			renderers: {
+				registry: {
+					native: {
+						module: '@fixture/native-main-renderer',
+						capabilities: ['main-thread-render-only'],
+						firstScreenEvents: ['bind*', 'catch*'],
+					},
+				},
+				default: 'native',
+			},
+			universalRuntime: { runtime: 'native', thread: 'main-thread' },
+		},
+	},
+};
+
+const pluginOptions: OctaneRspackPluginOptions = {
+	layerSpecializations: {
+		'native:main': {
+			runtime: '@fixture/native-main-runtime',
+			universalRuntime: { runtime: 'native', thread: 'main-thread' },
+		},
+	},
+};
+
+const unsupportedLoaderRuntime: OctaneRspackLoaderOptions = {
+	layerSpecializations: {
+		'native:main': {
+			// @ts-expect-error The standalone loader cannot install an issuer-layer runtime alias.
+			runtime: '@fixture/native-main-runtime',
+		},
+	},
+};
+
+void loaderOptions;
+void pluginOptions;
+void unsupportedLoaderRuntime;

--- a/packages/rspeedy-plugin-octane/README.md
+++ b/packages/rspeedy-plugin-octane/README.md
@@ -1,12 +1,13 @@
-# `@octanejs/rspeedy-plugin` (private Milestone 5 source/build path)
+# `@octanejs/rspeedy-plugin` (private Milestone 6 source/build path)
 
 This private package turns an Octane Lynx application entry into the two
 programs required by a Lynx template:
 
-- the authored application runs in the background runtime with Octane's Lynx
-  universal renderer; and
-- a generated main-thread receiver installs `installLynxMainThread()` before
-  the first transported background commit arrives.
+- the generated main-thread graph installs `installLynxMainThread()` and then
+  evaluates the authored entry with Octane's render-only first-screen runtime;
+  and
+- the same authored entry runs in the background runtime with Octane's full
+  Lynx renderer, which adopts or deterministically repairs the first tree.
 
 The plugin configures the framework-neutral Lynx template, CSS extraction,
 runtime-wrapper, and native encoding packages and emits one `.lynx.bundle` per
@@ -15,9 +16,9 @@ debug metadata remain in Rspeedy's normal build graph. Development builds wire
 the pinned Lynx dev transport when Rspeedy enables HMR or live reload.
 
 This is a **private source/build milestone**, not a published technical preview.
-The repository proves bundle construction and decoding; it does not yet prove
-the bundle in Lynx Web, Android Explorer, or iOS Explorer, nor does it prove
-state-preserving HMR or native reload/teardown behavior.
+The repository proves graph specialization, bundle construction, and decoding;
+it does not yet prove first paint or adoption on Lynx Web, Android Explorer, or
+iOS Explorer, nor does it prove state-preserving HMR on those targets.
 
 ## Application mode
 
@@ -34,17 +35,26 @@ export default defineConfig({
 ```
 
 ```ts
-// src/index.ts — background runtime
+// src/index.ts — evaluated by both specialized thread graphs
 import { root } from '@octanejs/lynx';
 import { App } from './App.lynx.tsrx';
 
 void root.render(App);
 ```
 
-Each authored entry is split into an Octane background graph and an internal,
-generated main-thread receiver graph. The main graph does not render `App` and
-does not implement main-thread first paint or background adoption; those remain
-Milestone 6 work.
+Each authored entry is split into an Octane background graph and an internal
+main-thread graph. The main graph always installs the receiver in manual
+first-screen synchronization mode, resolves the exact `@octanejs/lynx` package
+root to the first-screen facade, and then evaluates the authored imports in
+their original order. A generated tail module marks the first screen ready only
+after synchronous authored initialization returns. Subpath imports are not
+rewritten. The compiler selects the render-only main renderer and main-thread
+runtime metadata by Rspack layer; unconfigured layers retain the background
+configuration.
+
+Compatible Rspack entry metadata is copied to both generated graphs so they see
+the same entry initialization inputs. Development-only CSS HMR setup runs after
+the receiver install and before the authored imports.
 
 Explicit `thread: 'background'` and `thread: 'main-thread'` are retained as
 isolated compiler-graph diagnostic modes. They stamp and compile the supplied
@@ -56,7 +66,7 @@ pluginOctane({ thread: 'main-thread' });
 
 ## Exact compatibility set
 
-Milestone 5 supports one exact set while the packages remain private:
+Milestone 6 supports one exact set while the packages remain private:
 
 | Component | Version |
 | --- | ---: |

--- a/packages/rspeedy-plugin-octane/package.json
+++ b/packages/rspeedy-plugin-octane/package.json
@@ -8,7 +8,7 @@
   "engines": {
     "node": ">=22"
   },
-  "description": "Private Milestone 5 Rspeedy production bundle integration for Octane Lynx.",
+  "description": "Private Milestone 6 dual-thread Rspeedy bundle integration for Octane Lynx.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/octanejs/octane.git",

--- a/packages/rspeedy-plugin-octane/src/application.js
+++ b/packages/rspeedy-plugin-octane/src/application.js
@@ -30,6 +30,7 @@ const ENTRY_METADATA_KEYS = new Set([
 ]);
 const pluginRequire = createRequire(import.meta.url);
 const mainThreadEntry = fileURLToPath(new URL('./main-thread-entry.js', import.meta.url));
+const mainThreadReady = fileURLToPath(new URL('./main-thread-ready.js', import.meta.url));
 const mainThreadCSSHMR = pluginRequire.resolve(
 	'@lynx-js/css-extract-webpack-plugin/runtime/hotModuleReplacement.lepus.cjs',
 );
@@ -230,7 +231,7 @@ function prefixFilename(prefix, filename) {
 		: posix.join(prefix, filename);
 }
 
-/** Split authored entries into a background application and generated receiver. */
+/** Split authored entries into specialized main-thread and background graphs. */
 export function applyLynxApplication(chain, context, rspeedyConfig, options) {
 	const kind = environmentKind(context.environment.name);
 	if (kind === null) return false;
@@ -262,18 +263,22 @@ export function applyLynxApplication(chain, context, rspeedyConfig, options) {
 			resolveBackgroundFilename(entryName, context.environment.config, isProd),
 		);
 
-		const receiver = chain.entry(generatedName);
-		receiver.add({
+		const mainThread = chain.entry(generatedName);
+		mainThread.add({
+			...configuredEntry.metadata,
 			filename: mainFilename,
-			import: [mainThreadEntry],
+			// The receiver owns the first side effect. The authored imports then
+			// evaluate with the same entry metadata and initialization inputs as the
+			// background graph under the main-thread compiler specialization. The
+			// final module releases manual synchronization only after setup returns.
+			import: [
+				mainThreadEntry,
+				...(hmr ? [mainThreadCSSHMR] : []),
+				...configuredEntry.imports,
+				mainThreadReady,
+			],
 			layer: LYNX_MAIN_THREAD_LAYER,
 		});
-		if (hmr) {
-			prepend(receiver, {
-				import: [mainThreadCSSHMR],
-				layer: LYNX_MAIN_THREAD_LAYER,
-			});
-		}
 
 		const background = chain.entry(entryName);
 		background.add({

--- a/packages/rspeedy-plugin-octane/src/css.js
+++ b/packages/rspeedy-plugin-octane/src/css.js
@@ -1,7 +1,6 @@
 import { CssExtractRspackPlugin } from '@lynx-js/css-extract-webpack-plugin';
 
 import { LYNX_TARGET_SDK_VERSION } from './application.js';
-import { LYNX_BACKGROUND_LAYER } from './layers.js';
 
 const PLUGIN_NAME = '@octanejs/rspeedy-plugin';
 
@@ -41,10 +40,7 @@ export function configureLynxCSS(api, environments) {
 			const mainRuleName = ruleName === CHAIN_ID.RULE.CSS ? CHAIN_ID.ONE_OF.CSS_MAIN : ruleName;
 			const mainRule = rule.oneOf(mainRuleName);
 			removeLightningCSS(mainRule, CHAIN_ID.USE.LIGHTNINGCSS);
-			mainRule
-				.issuerLayer(LYNX_BACKGROUND_LAYER)
-				.use(CHAIN_ID.USE.MINI_CSS_EXTRACT)
-				.loader(CssExtractRspackPlugin.loader);
+			mainRule.use(CHAIN_ID.USE.MINI_CSS_EXTRACT).loader(CssExtractRspackPlugin.loader);
 
 			const inlineRuleName =
 				ruleName === CHAIN_ID.RULE.CSS ? CHAIN_ID.ONE_OF.CSS_INLINE : `${ruleName}-inline`;

--- a/packages/rspeedy-plugin-octane/src/main-thread-entry.js
+++ b/packages/rspeedy-plugin-octane/src/main-thread-entry.js
@@ -1,3 +1,3 @@
 import { installLynxMainThread } from '@octanejs/lynx/main-thread';
 
-installLynxMainThread();
+installLynxMainThread({ firstScreen: true, firstScreenSync: 'manual' });

--- a/packages/rspeedy-plugin-octane/src/main-thread-ready.js
+++ b/packages/rspeedy-plugin-octane/src/main-thread-ready.js
@@ -1,0 +1,3 @@
+import { markFirstScreenSyncReady } from '@octanejs/lynx/first-screen';
+
+markFirstScreenSyncReady();

--- a/packages/rspeedy-plugin-octane/src/plugin.js
+++ b/packages/rspeedy-plugin-octane/src/plugin.js
@@ -8,10 +8,40 @@ import { OctaneRspackPlugin } from '@octanejs/rspack-plugin';
 
 import { applyLynxApplication, exposeLynxTemplatePlugin } from './application.js';
 import { configureLynxCSS } from './css.js';
-import { applyLynxEntryLayer, resolveLynxLayer } from './layers.js';
+import {
+	applyLynxEntryLayer,
+	LYNX_MAIN_THREAD_LAYER,
+	LYNX_MAIN_THREAD_RUNTIME,
+	resolveLynxLayer,
+} from './layers.js';
 import { assertLynxToolchain } from './toolchain.js';
 
 const PLUGIN_NAME = '@octanejs/rspeedy-plugin';
+const MAIN_THREAD_FACADE_PLUGIN = `${PLUGIN_NAME}:main-thread-facade`;
+const LYNX_PACKAGE_ROOT = /^@octanejs\/lynx$/;
+const APPLICATION_LAYER_SPECIALIZATIONS = Object.freeze({
+	[LYNX_MAIN_THREAD_LAYER]: Object.freeze({
+		renderers: lynxRspeedyMainThreadRenderers,
+		runtime: '@octanejs/lynx/main-renderer',
+		universalRuntime: LYNX_MAIN_THREAD_RUNTIME,
+	}),
+});
+
+class LynxMainThreadFacadePlugin {
+	apply(compiler) {
+		const NormalModuleReplacementPlugin = compiler.webpack?.NormalModuleReplacementPlugin;
+		if (typeof NormalModuleReplacementPlugin !== 'function') {
+			throw new TypeError(
+				`${PLUGIN_NAME}: this Rspack compiler does not expose webpack.NormalModuleReplacementPlugin.`,
+			);
+		}
+		new NormalModuleReplacementPlugin(LYNX_PACKAGE_ROOT, (resource) => {
+			if (resource.contextInfo?.issuerLayer === LYNX_MAIN_THREAD_LAYER) {
+				resource.request = '@octanejs/lynx/first-screen';
+			}
+		}).apply(compiler);
+	}
+}
 
 function normalizeStringArray(value, name) {
 	if (value === undefined) return undefined;
@@ -52,6 +82,7 @@ function normalizeOptions(value) {
 		thread,
 		renderers:
 			thread === 'main-thread' ? lynxRspeedyMainThreadRenderers : lynxRspeedyBackgroundRenderers,
+		...(application ? { layerSpecializations: APPLICATION_LAYER_SPECIALIZATIONS } : null),
 		...(options.dev === undefined ? null : { dev: options.dev }),
 		...(options.hmr === undefined ? null : { hmr: options.hmr }),
 		...(options.profile === undefined ? null : { profile: options.profile }),
@@ -107,6 +138,9 @@ export function pluginOctane(value) {
 						renderers: options.renderers,
 						runtime: '@octanejs/lynx/renderer',
 						universalRuntime: options.universalRuntime,
+						...(options.layerSpecializations === undefined
+							? null
+							: { layerSpecializations: options.layerSpecializations }),
 						...(options.dev === undefined ? null : { dev: options.dev }),
 						...(options.hmr === undefined ? null : { hmr: options.hmr }),
 						...(options.profile === undefined ? null : { profile: options.profile }),
@@ -116,6 +150,9 @@ export function pluginOctane(value) {
 							: { requireDirective: options.requireDirective }),
 					},
 				]);
+				if (options.application) {
+					chain.plugin(MAIN_THREAD_FACADE_PLUGIN).use(LynxMainThreadFacadePlugin, []);
+				}
 			});
 			api.modifyBundlerChain({
 				order: 'post',

--- a/packages/rspeedy-plugin-octane/tests/_fixtures/application/src/App.tsrx
+++ b/packages/rspeedy-plugin-octane/tests/_fixtures/application/src/App.tsrx
@@ -1,9 +1,20 @@
+import { useEffect } from 'octane';
+
 import badge from './badge.svg';
+import { runBackgroundOnlyCallback } from './background-only.js';
 import styles from './card.module.css';
 import './global.css';
 
 export function App({ label }: { label: string }) @{
-	<view id="milestone-five" class={[styles.card, 'application-shell']}>
+	useEffect(() => {
+		runBackgroundOnlyCallback();
+	}, []);
+
+	<view
+		id="milestone-five"
+		class={[styles.card, 'application-shell']}
+		bindtap={() => runBackgroundOnlyCallback()}
+	>
 		<image src={badge} />
 		<text>
 			{label as string}

--- a/packages/rspeedy-plugin-octane/tests/_fixtures/application/src/background-only.ts
+++ b/packages/rspeedy-plugin-octane/tests/_fixtures/application/src/background-only.ts
@@ -1,0 +1,5 @@
+export const BACKGROUND_ONLY_MARKER = 'octane-milestone-six-background-only-callback';
+
+export function runBackgroundOnlyCallback(): void {
+	console.info(BACKGROUND_ONLY_MARKER);
+}

--- a/packages/rspeedy-plugin-octane/tests/build.test.ts
+++ b/packages/rspeedy-plugin-octane/tests/build.test.ts
@@ -15,6 +15,7 @@ import { pluginOctane } from '../src/index.js';
 
 const FIXTURE = resolve(import.meta.dirname, '_fixtures/background');
 const APPLICATION_FIXTURE = resolve(import.meta.dirname, '_fixtures/application');
+const BACKGROUND_ONLY_MARKER = 'octane-milestone-six-background-only-callback';
 const FORBIDDEN_MODULE =
 	/(?:^|[\\/])(?:runtime(?:\.server)?|universal-dom-boundary|dom-tables)\.[cm]?[jt]sx?$|(?:^|[\\/])hydration(?:[\\/]|\.[cm]?[jt]sx?$)|(?:^|[\\/])(?:react|react-dom|preact)(?:[\\/]|$)|@lynx-js[\\/]react/i;
 
@@ -102,10 +103,17 @@ function containsEncodedText(content: Buffer, value: string): boolean {
 	return content.includes(Buffer.from(value)) || content.includes(Buffer.from(value, 'utf16le'));
 }
 
+function withoutKnownDiagnosticText(content: string): string {
+	// The native decoder includes receiver string tables. This describes a
+	// first-screen render phase; it is not a reference to the browser global.
+	return content.replaceAll('render window has closed', 'render phase has closed');
+}
+
 class MetadataProbePlugin {
 	constructor(
 		private readonly observed: unknown[],
 		private readonly moduleIdentifiers: string[],
+		private readonly layeredModules: { identifier: string; layer?: string | null }[],
 	) {}
 
 	apply(compiler: any): void {
@@ -114,8 +122,16 @@ class MetadataProbePlugin {
 				for (const module of modules) {
 					const record = module as {
 						identifier?: () => string;
+						layer?: string | null;
 						nameForCondition?: () => string | null;
 					};
+					const moduleIdentifier = record.identifier?.();
+					if (typeof moduleIdentifier === 'string') {
+						this.layeredModules.push({
+							identifier: moduleIdentifier,
+							...(record.layer === undefined ? null : { layer: record.layer }),
+						});
+					}
 					for (const identifier of [record.identifier?.(), record.nameForCondition?.()]) {
 						if (typeof identifier === 'string') this.moduleIdentifiers.push(identifier);
 					}
@@ -127,14 +143,18 @@ class MetadataProbePlugin {
 	}
 }
 
-function metadataProbe(observed: unknown[], moduleIdentifiers: string[]) {
+function metadataProbe(
+	observed: unknown[],
+	moduleIdentifiers: string[],
+	layeredModules: { identifier: string; layer?: string | null }[] = [],
+) {
 	return {
 		name: 'octane:lynx-runtime-graph-probe',
 		setup(api: any) {
 			api.modifyBundlerChain((chain: any) => {
 				chain
 					.plugin('octane:lynx-runtime-graph-probe')
-					.use(MetadataProbePlugin, [observed, moduleIdentifiers]);
+					.use(MetadataProbePlugin, [observed, moduleIdentifiers, layeredModules]);
 			});
 		},
 	};
@@ -250,7 +270,9 @@ describe('@octanejs/rspeedy-plugin native production entries', () => {
 				const output = readJavaScript(outputRoot);
 				if (thread === 'background') expect(output).toContain('octane-phase1-es2017');
 				expect(output).not.toMatch(/\?\.|\?\?/);
-				expect(output).not.toMatch(/\b(?:document|window|HTMLElement|MutationObserver)\b/);
+				expect(withoutKnownDiagnosticText(output)).not.toMatch(
+					/\b(?:document|window|HTMLElement|MutationObserver)\b/,
+				);
 			} finally {
 				await result?.close();
 				rmSync(temporaryRoot, { recursive: true, force: true });
@@ -264,6 +286,7 @@ describe('@octanejs/rspeedy-plugin native production entries', () => {
 		const outputRoot = join(temporaryRoot, 'dist');
 		const observed: unknown[] = [];
 		const moduleIdentifiers: string[] = [];
+		const layeredModules: { identifier: string; layer?: string | null }[] = [];
 		const styleSheets: string[] = [];
 		const debugMetadata: string[] = [];
 		const rspeedy = await createRspeedy({
@@ -285,7 +308,7 @@ describe('@octanejs/rspeedy-plugin native production entries', () => {
 				splitChunks: false,
 				plugins: [
 					pluginOctane({ hmr: false, dev: false }),
-					metadataProbe(observed, moduleIdentifiers),
+					metadataProbe(observed, moduleIdentifiers, layeredModules),
 					nativeArtifactProbe(styleSheets, debugMetadata),
 				],
 			},
@@ -305,11 +328,15 @@ describe('@octanejs/rspeedy-plugin native production entries', () => {
 			expect(mainThread).not.toMatch(/getCoreContext/);
 			expect(background).toMatch(/getCoreContext/);
 			expect(background).not.toMatch(/getJSContext/);
+			expect(mainThread).toContain('milestone-five');
+			expect(mainThread).toContain('Native bundle');
+			expect(mainThread).not.toContain(BACKGROUND_ONLY_MARKER);
 			expect(background).toContain('milestone-five');
+			expect(background).toContain(BACKGROUND_ONLY_MARKER);
 			expect(completeBundleText).not.toMatch(
 				/@lynx-js[\\/]react|ReactLynx|\b(?:react-dom|preact)\b/i,
 			);
-			expect(completeBundleText).not.toMatch(
+			expect(withoutKnownDiagnosticText(completeBundleText)).not.toMatch(
 				/\b(?:document|window|HTMLElement|MutationObserver)\b/,
 			);
 
@@ -336,8 +363,64 @@ describe('@octanejs/rspeedy-plugin native production entries', () => {
 						transformKind: 'compile',
 						universalRuntime: { runtime: 'lynx', thread: 'background' },
 					}),
+					expect.objectContaining({
+						transformKind: 'compile',
+						universalRuntime: { runtime: 'lynx', thread: 'main-thread' },
+					}),
 				]),
 			);
+			const modulesForLayer = (layer: string) =>
+				new Set(
+					layeredModules
+						.filter((module) => module.layer === layer)
+						.map((module) =>
+							module.identifier
+								.slice(module.identifier.lastIndexOf('!') + 1)
+								.replace(/\|octane:(?:background|main-thread)$/, '')
+								.split('?', 1)[0]
+								.replaceAll('\\', '/'),
+						),
+				);
+			const hasSuffix = (modules: Set<string>, suffix: string) =>
+				[...modules].some((identifier) => identifier.endsWith(suffix));
+			const backgroundModules = modulesForLayer('octane:background');
+			const mainModules = modulesForLayer('octane:main-thread');
+			for (const suffix of [
+				'/packages/rspeedy-plugin-octane/tests/_fixtures/application/src/background.ts',
+				'/packages/rspeedy-plugin-octane/tests/_fixtures/application/src/App.tsrx',
+				'/packages/lynx/src/root.ts',
+			]) {
+				expect(hasSuffix(backgroundModules, suffix), `missing ${suffix} from background`).toBe(
+					true,
+				);
+			}
+			for (const suffix of [
+				'/packages/rspeedy-plugin-octane/tests/_fixtures/application/src/background.ts',
+				'/packages/rspeedy-plugin-octane/tests/_fixtures/application/src/App.tsrx',
+				'/packages/rspeedy-plugin-octane/src/main-thread-entry.js',
+				'/packages/rspeedy-plugin-octane/src/main-thread-ready.js',
+				'/packages/lynx/src/first-screen.ts',
+				'/packages/lynx/src/main-renderer.ts',
+			]) {
+				expect(hasSuffix(mainModules, suffix), `missing ${suffix} from main thread`).toBe(true);
+			}
+			for (const suffix of [
+				'/packages/rspeedy-plugin-octane/src/main-thread-entry.js',
+				'/packages/rspeedy-plugin-octane/src/main-thread-ready.js',
+				'/packages/lynx/src/first-screen.ts',
+				'/packages/lynx/src/main-renderer.ts',
+			]) {
+				expect(hasSuffix(backgroundModules, suffix), `unexpected ${suffix} in background`).toBe(
+					false,
+				);
+			}
+			for (const suffix of [
+				'/packages/lynx/src/root.ts',
+				'/packages/lynx/src/core/client-driver.ts',
+				'/packages/octane/src/universal-core.ts',
+			]) {
+				expect(hasSuffix(mainModules, suffix), `unexpected ${suffix} in main thread`).toBe(false);
+			}
 
 			const extractedCSS = styleSheets.join('\n');
 			expect(extractedCSS).toContain('#123456');
@@ -350,6 +433,7 @@ describe('@octanejs/rspeedy-plugin native production entries', () => {
 			expect(moduleClass).toBeDefined();
 			expect(moduleClass).not.toBe('card');
 			expect(background).toContain(moduleClass!);
+			expect(mainThread).toContain(moduleClass!);
 			expect(bundle.includes(Buffer.from('#123456'))).toBe(true);
 			expect(bundle.includes(Buffer.from('application-shell'))).toBe(true);
 
@@ -357,6 +441,7 @@ describe('@octanejs/rspeedy-plugin native production entries', () => {
 			expect(emittedAsset).toBeDefined();
 			expect(readFileSync(emittedAsset!, 'utf8')).toContain('data-octane-asset="milestone-five"');
 			expect(bundle.includes(Buffer.from(emittedAsset!.split(/[\\/]/).at(-1)!))).toBe(true);
+			expect(mainThread).toContain(emittedAsset!.split(/[\\/]/).at(-1)!);
 
 			expect(debugMetadata).toHaveLength(1);
 			const metadata = JSON.parse(debugMetadata[0]);
@@ -420,21 +505,25 @@ describe('@octanejs/rspeedy-plugin native production entries', () => {
 		let result: Awaited<ReturnType<typeof rspeedy.build>> | undefined;
 		try {
 			result = await rspeedy.build();
-			const main = nativeScriptText(
-				(await decodeNativeBundle(readFileSync(join(outputRoot, 'main.lynx.bundle'))))[
-					'background-thread-script'
-				],
+			const mainBundle = await decodeNativeBundle(
+				readFileSync(join(outputRoot, 'main.lynx.bundle')),
 			);
-			const secondary = nativeScriptText(
-				(await decodeNativeBundle(readFileSync(join(outputRoot, 'secondary.lynx.bundle'))))[
-					'background-thread-script'
-				],
+			const secondaryBundle = await decodeNativeBundle(
+				readFileSync(join(outputRoot, 'secondary.lynx.bundle')),
 			);
+			const main = nativeScriptText(mainBundle['background-thread-script']);
+			const mainFirstScreen = nativeScriptText(mainBundle['main-thread-script']);
+			const secondary = nativeScriptText(secondaryBundle['background-thread-script']);
+			const secondaryFirstScreen = nativeScriptText(secondaryBundle['main-thread-script']);
 
 			expect(main).toContain('Native bundle');
 			expect(main).not.toContain('Secondary bundle');
+			expect(mainFirstScreen).toContain('Native bundle');
+			expect(mainFirstScreen).not.toContain('Secondary bundle');
 			expect(secondary).toContain('Secondary bundle');
 			expect(secondary).not.toContain('Native bundle');
+			expect(secondaryFirstScreen).toContain('Secondary bundle');
+			expect(secondaryFirstScreen).not.toContain('Native bundle');
 		} finally {
 			await result?.close();
 			rmSync(temporaryRoot, { recursive: true, force: true });

--- a/packages/rspeedy-plugin-octane/tests/packed-consumer.test.ts
+++ b/packages/rspeedy-plugin-octane/tests/packed-consumer.test.ts
@@ -200,6 +200,7 @@ try {
 			const background = nativeScriptText(decoded['background-thread-script']);
 			expect(decoded['engine-version']).toBe('3.9');
 			expect(mainThread).toMatch(/getJSContext/);
+			expect(mainThread).toContain('milestone-five');
 			expect(background).toMatch(/getCoreContext/);
 			expect(background).toContain('milestone-five');
 			expect(readdirSync(join(outputRoot, 'static/svg'))).toContain('badge.svg');
@@ -213,9 +214,11 @@ try {
 			const developmentBundlePath = join(developmentOutputRoot, 'main.lynx.bundle');
 			expect(existsSync(developmentBundlePath)).toBe(true);
 			const developmentDecoded = await decodeNativeBundle(readFileSync(developmentBundlePath));
+			const developmentMainThread = nativeScriptText(developmentDecoded['main-thread-script']);
 			const developmentBackground = nativeScriptText(
 				developmentDecoded['background-thread-script'],
 			);
+			expect(developmentMainThread).toContain('milestone-five');
 			expect(developmentBackground).toMatch(/pathname=(?:\/|%2F)rsbuild-hmr/);
 			expect(developmentBackground).toContain('hot=true');
 			expect(developmentBackground).toContain('live-reload=true');

--- a/packages/rspeedy-plugin-octane/tests/plugin.test.ts
+++ b/packages/rspeedy-plugin-octane/tests/plugin.test.ts
@@ -122,20 +122,32 @@ function createChain(
 	};
 }
 
-function compilerOptions(state: ReturnType<typeof createChain>) {
-	return state.plugins.get('@octanejs/rspeedy-plugin:compiler')?.options[0] as {
-		universalRuntime: unknown;
-		renderers: {
-			default: string;
-			registry: {
-				lynx: {
-					validation: {
-						forbiddenGlobals: readonly string[];
-						forbiddenImports: readonly string[];
-					};
-				};
+interface CompilerRendererOptions {
+	default: string;
+	registry: {
+		lynx: {
+			module: string;
+			validation: {
+				forbiddenGlobals: readonly string[];
+				forbiddenImports: readonly string[];
 			};
 		};
+	};
+}
+
+function compilerOptions(state: ReturnType<typeof createChain>) {
+	return state.plugins.get('@octanejs/rspeedy-plugin:compiler')?.options[0] as {
+		runtime: string;
+		universalRuntime: unknown;
+		layerSpecializations?: Record<
+			string,
+			{
+				runtime: string;
+				universalRuntime: unknown;
+				renderers: CompilerRendererOptions;
+			}
+		>;
+		renderers: CompilerRendererOptions;
 	};
 }
 
@@ -231,6 +243,8 @@ describe('@octanejs/rspeedy-plugin', () => {
 				renderers: expect.objectContaining({ default: 'lynx' }),
 			}),
 		]);
+		expect(compilerOptions(state).layerSpecializations).toBeUndefined();
+		expect(state.plugins.has('@octanejs/rspeedy-plugin:main-thread-facade')).toBe(false);
 		expect(
 			compilerOptions(state).renderers.registry.lynx.validation.forbiddenGlobals,
 		).not.toContain('NativeModules');
@@ -253,6 +267,8 @@ describe('@octanejs/rspeedy-plugin', () => {
 		]);
 		const compiler = compilerOptions(state);
 		expect(compiler.universalRuntime).toBe(LYNX_MAIN_THREAD_RUNTIME);
+		expect(compiler.layerSpecializations).toBeUndefined();
+		expect(state.plugins.has('@octanejs/rspeedy-plugin:main-thread-facade')).toBe(false);
 		expect(compiler.renderers.registry.lynx.validation.forbiddenGlobals).toContain('NativeModules');
 		expect(compiler.renderers.registry.lynx.validation.forbiddenImports).toContain(
 			'@octanejs/lynx/platform',
@@ -281,20 +297,38 @@ describe('@octanejs/rspeedy-plugin', () => {
 			},
 		]);
 		const receiver = state.entries.get('app__octane_main_thread');
-		expect(receiver).toHaveLength(2);
+		expect(receiver).toHaveLength(1);
 		expect(receiver?.[0]).toEqual(
 			expect.objectContaining({
-				import: [expect.stringMatching(/hotModuleReplacement\.lepus\.cjs$/)],
-				layer: LYNX_MAIN_THREAD_LAYER,
-			}),
-		);
-		expect(receiver?.[1]).toEqual(
-			expect.objectContaining({
 				filename: '.rspeedy/app/main-thread.js',
-				import: [expect.stringMatching(/main-thread-entry\.js$/)],
+				import: [
+					expect.stringMatching(/main-thread-entry\.js$/),
+					expect.stringMatching(/hotModuleReplacement\.lepus\.cjs$/),
+					'./src/setup.js',
+					'./src/App.lynx.tsrx',
+					expect.stringMatching(/main-thread-ready\.js$/),
+				],
 				layer: LYNX_MAIN_THREAD_LAYER,
 			}),
 		);
+		const applicationCompiler = compilerOptions(state);
+		expect(applicationCompiler).toMatchObject({
+			runtime: '@octanejs/lynx/renderer',
+			universalRuntime: LYNX_BACKGROUND_RUNTIME,
+			renderers: { default: 'lynx' },
+		});
+		expect(applicationCompiler.renderers.registry.lynx.module).toBe('@octanejs/lynx/renderer');
+		const mainSpecialization = applicationCompiler.layerSpecializations?.[LYNX_MAIN_THREAD_LAYER];
+		expect(mainSpecialization).toMatchObject({
+			runtime: '@octanejs/lynx/main-renderer',
+			universalRuntime: LYNX_MAIN_THREAD_RUNTIME,
+			renderers: { default: 'lynx' },
+		});
+		expect(mainSpecialization?.renderers.registry.lynx.module).toBe('@octanejs/lynx/main-renderer');
+		expect(mainSpecialization?.renderers.registry.lynx.validation.forbiddenGlobals).toContain(
+			'NativeModules',
+		);
+		expect(state.plugins.has('@octanejs/rspeedy-plugin:main-thread-facade')).toBe(true);
 		const appRequire = createRequire(join(state.root, 'package.json'));
 		expect(realpathSync(appRequire.resolve('@lynx-js/webpack-dev-transport/client'))).toBe(
 			realpathSync(testRequire.resolve('@lynx-js/webpack-dev-transport/client')),
@@ -302,6 +336,44 @@ describe('@octanejs/rspeedy-plugin', () => {
 		expect(JSON.stringify([...state.entries.values()])).not.toMatch(
 			/@lynx-js\/react|react-refresh/i,
 		);
+	});
+
+	it('replaces only main-layer imports of the exact Lynx package root', () => {
+		const state = applyPlugin(undefined, 'lynx', {}, { app: ['./src/App.tsrx'] });
+		const installed = state.plugins.get('@octanejs/rspeedy-plugin:main-thread-facade');
+		const FacadePlugin = installed?.implementation as new () => {
+			apply(compiler: unknown): void;
+		};
+		let requestPattern: RegExp | undefined;
+		let replace:
+			| ((resource: { request: string; contextInfo?: { issuerLayer?: string } }) => void)
+			| undefined;
+		class NormalModuleReplacementPlugin {
+			constructor(
+				pattern: RegExp,
+				callback: (resource: { request: string; contextInfo?: { issuerLayer?: string } }) => void,
+			) {
+				requestPattern = pattern;
+				replace = callback;
+			}
+			apply() {}
+		}
+		new FacadePlugin().apply({ webpack: { NormalModuleReplacementPlugin } });
+
+		expect(requestPattern?.test('@octanejs/lynx')).toBe(true);
+		expect(requestPattern?.test('@octanejs/lynx/main-thread')).toBe(false);
+		const background = {
+			request: '@octanejs/lynx',
+			contextInfo: { issuerLayer: LYNX_BACKGROUND_LAYER },
+		};
+		const main = {
+			request: '@octanejs/lynx',
+			contextInfo: { issuerLayer: LYNX_MAIN_THREAD_LAYER },
+		};
+		replace?.(background);
+		replace?.(main);
+		expect(background.request).toBe('@octanejs/lynx');
+		expect(main.request).toBe('@octanejs/lynx/first-screen');
 	});
 
 	it('preserves public entry loading metadata on the background graph', () => {
@@ -335,6 +407,24 @@ describe('@octanejs/rspeedy-plugin', () => {
 				filename: '.rspeedy/app/background.js',
 				import: ['./src/App.tsrx'],
 				layer: LYNX_BACKGROUND_LAYER,
+				library,
+				publicPath: '/assets/',
+				runtime: false,
+				wasmLoading: false,
+			},
+		]);
+		expect(state.entries.get('app__octane_main_thread')).toEqual([
+			{
+				asyncChunks: false,
+				baseUri: 'lynx://octane/',
+				chunkLoading: false,
+				filename: '.rspeedy/app/main-thread.js',
+				import: [
+					expect.stringMatching(/main-thread-entry\.js$/),
+					'./src/App.tsrx',
+					expect.stringMatching(/main-thread-ready\.js$/),
+				],
+				layer: LYNX_MAIN_THREAD_LAYER,
 				library,
 				publicPath: '/assets/',
 				runtime: false,

--- a/packages/rspeedy-plugin-octane/types/index.d.ts
+++ b/packages/rspeedy-plugin-octane/types/index.d.ts
@@ -10,7 +10,8 @@ export interface OctaneLynxUniversalRuntime {
 export interface OctaneRspeedyPluginOptions {
 	/**
 	 * Select one isolated compiler graph for diagnostics and source tests.
-	 * Omit this option to build a complete background-rendered Lynx application.
+	 * Omit this option to build the dual-thread application graph: a synchronous
+	 * main-thread first screen followed by background runtime adoption.
 	 */
 	thread?: OctaneLynxThread;
 	/** Restrict the plugin to named Rspeedy environments. */

--- a/scripts/check-package-packs.mjs
+++ b/scripts/check-package-packs.mjs
@@ -653,7 +653,7 @@ process.stdout.write(output, () => process.exit(0));
 }
 
 /**
- * Exercise the private Milestone 5 Lynx packages exactly as an external
+ * Exercise the private Milestone 6 Lynx packages exactly as an external
  * application consumes them. This builds and decodes the native artifact but
  * remains a source/build check, not a device-runtime claim.
  */
@@ -701,12 +701,11 @@ function validatePackedLynxConsumer(tempRoot, archives) {
 	writeFileSync(
 		path.join(sourceDirectory, 'App.tsrx'),
 		`import { createLynxNativeResource } from '@octanejs/lynx';
-import { lynxPlatformAvailability } from '@octanejs/lynx/platform';
 import { useState } from 'octane';
 
 const resource = createLynxNativeResource('packed-resource');
-if (resource.id !== 'packed-resource' || lynxPlatformAvailability.implementedMilestone !== 4) {
-	throw new Error('packed Lynx Milestone 4 public subpaths are incomplete');
+if (resource.id !== 'packed-resource') {
+	throw new Error('packed Lynx package root is incomplete');
 }
 
 export function App() @{
@@ -739,6 +738,7 @@ import path from 'node:path';
 const root = ${JSON.stringify(consumerDirectory)};
 const outputRoot = ${JSON.stringify(outputDirectory)};
 const request = createRequire(import.meta.url);
+const platformFacade = realpathSync(request.resolve('@octanejs/lynx/platform'));
 const testingFacade = realpathSync(request.resolve('@octanejs/lynx/testing'));
 const testingEnvironment = realpathSync(request.resolve('@lynx-js/testing-environment'));
 const canonicalRoot = realpathSync(root);
@@ -746,8 +746,8 @@ const isInstalledHere = (target) => {
 	const relative = path.relative(canonicalRoot, target);
 	return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
 };
-if (!isInstalledHere(testingFacade) || !isInstalledHere(testingEnvironment)) {
-	throw new Error('packed Lynx testing facade or its explicit optional peer resolved outside the consumer');
+if (!isInstalledHere(platformFacade) || !isInstalledHere(testingFacade) || !isInstalledHere(testingEnvironment)) {
+	throw new Error('packed Lynx platform/testing facade or its explicit optional peer resolved outside the consumer');
 }
 const directRuntime = realpathSync(request.resolve('octane'));
 const directLynx = realpathSync(request.resolve('@octanejs/lynx'));
@@ -895,6 +895,12 @@ try {
 	const mainThread = scriptText(decoded['main-thread-script']);
 	const background = scriptText(decoded['background-thread-script']);
 	const completeBundle = scriptText(decoded);
+	// The native decoder includes receiver string tables. This describes a
+	// first-screen render phase; it is not a reference to the browser global.
+	const executableBundle = completeBundle.replaceAll(
+		'render window has closed',
+		'render phase has closed',
+	);
 	if (decoded['engine-version'] !== '3.9') {
 		throw new Error('packed native bundle targets engine ' + decoded['engine-version'] + ', expected 3.9');
 	}
@@ -904,7 +910,7 @@ try {
 	if (!background.includes('octane-packed-lynx-compiled')) {
 		throw new Error('packed native bundle background section omitted the authored application');
 	}
-	if (/\\b(?:document|window|HTMLElement|MutationObserver)\\b/.test(completeBundle)) {
+	if (/\\b(?:document|window|HTMLElement|MutationObserver)\\b/.test(executableBundle)) {
 		throw new Error('packed native bundle contains a DOM runtime global');
 	}
 	if (/(?:^|[^$\\w])(?:react|react-dom|preact|ReactLynx)(?:[^$\\w]|$)/i.test(completeBundle)) {
@@ -939,7 +945,7 @@ try {
 	});
 
 	console.log(
-		'built and decoded one packed Lynx Milestone 5 native bundle outside the workspace; exact toolchain, singleton Octane/native core, and DOM/React exclusions passed',
+		'built and decoded one packed Lynx Milestone 6 native bundle outside the workspace; exact toolchain, singleton Octane/native core, public subpaths, and DOM/React exclusions passed',
 	);
 }
 

--- a/website/tests/ssr-hydration.e2e.test.ts
+++ b/website/tests/ssr-hydration.e2e.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 // Dev-SSR → real-browser hydration smoke — the seam every historical website
 // breakage lived in (router-parity SSR regression, the 2026-07-08 bare-Symbol()
 // slot regression) and the one the jsdom suites can't see: those client-render
@@ -13,15 +15,26 @@
 // a required prerequisite; CI installs it (see ci.yml), and local runs fail
 // with the exact setup command when it is missing.
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { build } from 'esbuild';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { createServer } from 'node:net';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 import { encodePlaygroundHash } from '../src/lib/playground-hash.ts';
+import { PLAYGROUND_REACT_VERSION } from '../src/lib/playground-sandbox.ts';
 
 const WEBSITE = join(process.cwd(), 'website');
 const PLAYWRIGHT_ACTION_TIMEOUT = 10_000;
 const PLAYWRIGHT_NAVIGATION_TIMEOUT = 15_000;
+const REACT_CDN_ENTRY_PREFIX = 'octane-e2e-react-cdn:';
+const REACT_CDN_ENTRIES = {
+	[`react@${PLAYGROUND_REACT_VERSION}`]: 'react',
+	[`react@${PLAYGROUND_REACT_VERSION}/jsx-runtime`]: 'react/jsx-runtime',
+	[`react@${PLAYGROUND_REACT_VERSION}/jsx-dev-runtime`]: 'react/jsx-dev-runtime',
+	[`react-dom@${PLAYGROUND_REACT_VERSION}`]: 'react-dom',
+	[`react-dom@${PLAYGROUND_REACT_VERSION}/client`]: 'react-dom/client',
+};
 const ROUTES = [
 	'/',
 	'/docs',
@@ -36,6 +49,99 @@ const ROUTES = [
 	'/benchmarks',
 	'/playground',
 ];
+
+let reactCdnMirror: Promise<Map<string, Buffer>> | undefined;
+
+// The playground deliberately points its opaque-origin iframe at esm.sh. Keep
+// that production security boundary intact while making this behavioral test
+// deterministic: Chromium still performs the real cross-origin module loads,
+// but Playwright fulfills the React family from the workspace packages.
+function getReactCdnMirror(): Promise<Map<string, Buffer>> {
+	return (reactCdnMirror ??= buildReactCdnMirror());
+}
+
+async function buildReactCdnMirror(): Promise<Map<string, Buffer>> {
+	const octaneRequire = createRequire(join(process.cwd(), 'packages/octane/package.json'));
+	const outdir = join(process.cwd(), '.octane-e2e-react-cdn');
+	const result = await build({
+		absWorkingDir: process.cwd(),
+		entryPoints: Object.fromEntries(
+			Object.entries(REACT_CDN_ENTRIES).map(([cdnPath, packageSpecifier]) => [
+				cdnPath,
+				REACT_CDN_ENTRY_PREFIX + packageSpecifier,
+			]),
+		),
+		bundle: true,
+		chunkNames: 'chunks/[name]-[hash]',
+		define: { 'process.env.NODE_ENV': '"production"' },
+		entryNames: '[dir]/[name]',
+		format: 'esm',
+		outdir,
+		platform: 'browser',
+		plugins: [
+			{
+				name: 'workspace-react-cdn-entries',
+				setup(esbuild) {
+					esbuild.onResolve({ filter: /^octane-e2e-react-cdn:/ }, (args) => ({
+						namespace: 'workspace-react-cdn-entry',
+						path: args.path.slice(REACT_CDN_ENTRY_PREFIX.length),
+					}));
+					esbuild.onLoad({ filter: /.*/, namespace: 'workspace-react-cdn-entry' }, (args) => {
+						const entryPath = octaneRequire.resolve(args.path);
+						const exportNames = Object.keys(
+							octaneRequire(args.path) as Record<string, unknown>,
+						).filter((name) => /^[$A-Z_a-z][$\w]*$/.test(name) && name !== 'default');
+						return {
+							contents: [
+								`import workspaceModule from ${JSON.stringify(entryPath)};`,
+								'export default workspaceModule;',
+								`export const { ${exportNames.join(', ')} } = workspaceModule;`,
+							].join('\n'),
+							loader: 'js',
+							resolveDir: '/',
+						};
+					});
+				},
+			},
+		],
+		splitting: true,
+		write: false,
+	});
+
+	const modules = new Map<string, Buffer>();
+	for (const output of result.outputFiles) {
+		const outputPath = relative(outdir, output.path).replaceAll('\\', '/');
+		const requestPath = outputPath.startsWith('chunks/')
+			? '/' + outputPath
+			: '/' + outputPath.replace(/\.js$/, '');
+		modules.set(requestPath, Buffer.from(output.contents));
+	}
+	return modules;
+}
+
+async function installReactCdnMirror(
+	page: import('playwright').Page,
+	errors: string[],
+): Promise<void> {
+	const modules = await getReactCdnMirror();
+	await page.route('https://esm.sh/**', async (route) => {
+		const url = new URL(route.request().url());
+		const body = url.search === '' ? modules.get(url.pathname) : undefined;
+		if (!body) {
+			errors.push(`unexpected esm.sh request: ${url.pathname}${url.search}`);
+			await route.abort('blockedbyclient');
+			return;
+		}
+		await route.fulfill({
+			body,
+			headers: {
+				'access-control-allow-origin': '*',
+				'content-type': 'application/javascript; charset=utf-8',
+			},
+			status: 200,
+		});
+	});
+}
 
 // A fresh ephemeral port per run — NEVER a fixed one. With a fixed port, a
 // leftover server from an earlier run (or another checkout) already listening
@@ -156,7 +262,10 @@ async function stop(child: ChildProcess | undefined): Promise<void> {
 async function loadRoute(
 	base: string,
 	path: string,
-	options: { waitForNetworkIdle?: boolean } = {},
+	options: {
+		beforeNavigation?: (page: import('playwright').Page, errors: string[]) => Promise<void>;
+		waitForNetworkIdle?: boolean;
+	} = {},
 ) {
 	const page = await browser!.newPage();
 	page.setDefaultTimeout(PLAYWRIGHT_ACTION_TIMEOUT);
@@ -167,6 +276,7 @@ async function loadRoute(
 	});
 	page.on('pageerror', (e) => errors.push('pageerror: ' + String(e)));
 	try {
+		await options.beforeNavigation?.(page, errors);
 		await page.goto(base + path, { waitUntil: 'load' });
 		if (options.waitForNetworkIdle) await page.waitForLoadState('networkidle');
 		await page.waitForFunction(
@@ -1046,19 +1156,15 @@ describe.sequential('website production build → hydration (Nitro Vercel previe
 	}, 45_000);
 
 	it('playground runs the OctaneCompat React-host example end to end', async () => {
-		// This example loads the real react/react-dom from esm.sh inside the
-		// sandbox — like the rest of this browser suite, it requires a working
-		// network. A probe up front turns an unreachable CDN into an immediate,
-		// clearly-attributed failure instead of a slow in-iframe timeout.
-		const probe = await fetch('https://esm.sh/react@19.2.0', { method: 'HEAD' });
-		expect(probe.ok, 'esm.sh must be reachable to exercise the OctaneCompat example').toBe(true);
-		const { page, errors } = await loadRoute(`http://localhost:${PREVIEW_PORT}`, '/playground');
+		const { page, errors } = await loadRoute(`http://localhost:${PREVIEW_PORT}`, '/playground', {
+			beforeNavigation: installReactCdnMirror,
+		});
 		try {
 			await page.waitForSelector('.pg-grid.ready', { timeout: 20_000 });
 			await page.selectOption('.pg-select', 'octane-compat');
 			await page.locator('.pg-tab', { hasText: 'Island.tsrx' }).waitFor({ timeout: 10_000 });
 			const preview = page.frameLocator('iframe[title="Playground preview"]');
-			// react-dom (esm.sh) mounts the host; the compiled Octane island renders
+			// Real react-dom mounts the host; the compiled Octane island renders
 			// inside it and resolves its own @try/@pending fetch.
 			await preview.locator('h3', { hasText: 'Octane island' }).waitFor({ timeout: 30_000 });
 			await preview.locator('body').getByText('island data #1').waitFor({ timeout: 20_000 });


### PR DESCRIPTION
## Summary

- add a PrimJS-safe, render-only Lynx main-thread runtime that produces a deterministic synchronous first host tree while keeping effects, refs, state ownership, listener closures, scheduling, and later updates background-owned
- add clone-safe first-tree snapshots, compatible native-node adoption, FIFO event handoff, deterministic mismatch repair, and retry-safe teardown including externally reparented native nodes
- teach the Octane compiler and Rspack plugin about layer-specific renderer/runtime specialization, first-screen event markers, and main-thread callback/ref erasure
- update the Rspeedy application pipeline to compile the same authored entry into main and background layers, install the receiver before authored initialization, and release background readiness afterward
- document Milestone 6 evidence, exclusions, compatibility bounds, and the remaining formal IFR gates

## Why

Milestone 5 could build and run Octane's Lynx renderer only as a background-owned graph. Lynx first paint requires a deliberately smaller synchronous main-thread graph plus a safe transfer of ownership to the complete background runtime. This change establishes that source/build and JavaScript-host contract without forking ReactLynx or claiming unverified native behavior.

## User and developer impact

Normal Rspeedy application mode now emits specialized main/background graphs from one authored entry. Compatible initial trees retain native node identity during adoption; mismatches repair deterministically. Native lists, native-resource props, boolean-defer parity, lifecycle/reload receivers, and native-device IFR proof remain explicitly outside this milestone.

## Validation

- Octane dev + production projects: 706 files, 8,118 tests
- Lynx project: 17 files, 148 tests
- Rspack plugin: 5 files, 65 tests
- Rspeedy plugin: 4 files, 26 tests, including decoded production bundles and packed-consumer coverage
- Lynx source, testing, and typetest TypeScript configurations
- Octane source/typetests plus Rspack and Rspeedy typechecks
- repository-wide Prettier check, binding-status check, package-inventory check, changeset status, and `git diff --check`

## Remaining evidence gates

This PR does not claim Lynx IFR yet. The formal exit still requires Lynx Web/Explorer, Android, and iOS evidence for first-frame timing, native node identity/allocation, public event/lifecycle/reload delivery, and native performance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large cross-cutting change to Lynx main/background lifecycle, host adoption, and transport ordering; mistakes could cause duplicate trees, lost events, or native leaks, though scope is private Milestone 6 with heavy test coverage and no public preview claim.
> 
> **Overview**
> Adds **Lynx Milestone 6**: a PrimJS-safe, one-shot **main-thread** path that paints a synchronous first host tree while the **background** graph keeps the full Octane runtime (effects, refs, updates).
> 
> New package surfaces `@octanejs/lynx/main-renderer` and `@octanejs/lynx/first-screen` (with `markFirstScreenSyncReady()`), and the main-thread preset now points at `main-renderer` with `main-thread-render-only` and first-screen event patterns. The render-only runtime emits an initial host batch and **event markers** instead of real listener closures; native-resource props are rejected on first screen.
> 
> The host driver gains **clone-safe first-tree snapshots**, **compatible adoption** (transfer physical nodes without reallocating), **typed mismatch repair**, and stronger dispose/cleanup (including externally reparented nodes). PAPI adds `getParent` / `isEqual` for that cleanup.
> 
> `installLynxMainThread` can run **first-screen mode** (manual or automatic sync), capture a journal, attach snapshots to `main-ready`, and gate **FIFO event replay** until `adoption-ready` after an `ack` with `adopted`/`repaired`. Transport/protocol and docs/status move the milestone from “receiver only” to **dual-graph** application builds; formal native IFR/device gates stay explicitly blocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb591d7c129e2488a86f542d916bc3499555082a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->