### PR TITLE
Trim keyed @for first-fill and no-work commits off the cold hydrate path

### DIFF
--- a/.changeset/hydrate-cold-path-trims.md
+++ b/.changeset/hydrate-cold-path-trims.md
@@ -1,0 +1,14 @@
+---
+'octane': patch
+---
+
+Trim two cold-path costs on hydration/first mount. A keyed `@for`'s first fill
+(hydration adoption of the server item ranges, or a fresh mount) now runs
+through a small dedicated linear pass (`mountItemsLinear`) instead of entering
+the full prefix/suffix/LIS reconciler, so a cold page never pays the big
+function's first-call cost just to append items in order; the survivor key map
+and sibling chain are still built as a byproduct of the same pass, so update
+behavior and the keyed reconciler's guarantees are unchanged. And
+`commitEffects` now takes a single no-work fast path when every commit queue is
+empty — the common case for a hydration adoption or an effect-free flush —
+instead of calling each drain helper to discover there is nothing to do.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -2508,6 +2508,32 @@ function blockSubtreeDisposed(block: Block | null): boolean {
 }
 
 function commitEffects(): void {
+	// No-work fast path: every commit queue the drains below consume is empty —
+	// the common case for a hydration adoption or an effect-free app's flush.
+	// One combined check (module-scope length reads, same emptiness conditions
+	// each drain tests individually) keeps the whole drain pipeline off this
+	// path; only the passive hand-off below can still apply. INVARIANT: a drain
+	// added to this function must also add its has-work condition here, or its
+	// work is silently skipped whenever the other queues are empty.
+	if (
+		effectEventQueue.length === 0 &&
+		effectEventCommitActions.length === 0 &&
+		effectQueues[INSERTION].length === 0 &&
+		effectQueues[LAYOUT].length === 0 &&
+		refDetachQueue.length === 0 &&
+		refAttachQueue.length === 0 &&
+		storeSyncQueue.length === 0 &&
+		activeFragments.size === 0 &&
+		!hasControlledSyncs()
+	) {
+		if (
+			(effectQueues[PASSIVE].length > 0 || pendingPassiveUnmounts.length > 0) &&
+			!passiveScheduled
+		) {
+			schedulePassiveFlush();
+		}
+		return;
+	}
 	// React publishes every Effect Event body before any insertion/layout effect
 	// can call an already-registered wrapper. Entries from failed or suspended
 	// renders are filtered by their block's completed render version.
@@ -15116,7 +15142,13 @@ export function childSlot(
 		// singleRoot=2 (marker-elision M4): pure single-element items self-mark —
 		// no `it` pair per item — resolved per item value in mountItem; shape
 		// flips promote to a minted pair in place (deoptItemBody).
-		reconcileKeyed(parentBlock, state.forSlot, items, getKey, deoptItemBody as any, false, 2);
+		// First fill dispatches to the linear pass directly (see mountItemsLinear)
+		// so a de-opt list's hydration adopt skips the full reconciler too.
+		if (state.forSlot.size === 0) {
+			mountItemsLinear(parentBlock, state.forSlot, items, getKey, deoptItemBody as any, 2, false);
+		} else {
+			reconcileKeyed(parentBlock, state.forSlot, items, getKey, deoptItemBody as any, false, 2);
+		}
 		// Upgrade adoption: nodes the empty→fill mount didn't consume (old
 		// children whose keys have no new item) are orphans inside the range —
 		// sweep them now.
@@ -19232,18 +19264,32 @@ export function forBlock<T>(
 		}
 		state.cachedDeps = deps;
 	}
-	reconcileKeyed(
-		parentBlock,
-		state,
-		items,
-		getKey,
-		itemBody as any,
-		pure,
-		(f & 2) !== 0,
-		lite,
-		(f & 8) !== 0,
-		(f & 16) !== 0,
-	);
+	if (state.size === 0) {
+		// First fill (hydration adopt / fresh mount / update-path 0 → N): the
+		// linear pass — the full reconciler has no old list to diff against.
+		mountItemsLinear(
+			parentBlock,
+			state,
+			items,
+			getKey,
+			itemBody as any,
+			(f & 2) !== 0,
+			(f & 16) !== 0,
+		);
+	} else {
+		reconcileKeyed(
+			parentBlock,
+			state,
+			items,
+			getKey,
+			itemBody as any,
+			pure,
+			(f & 2) !== 0,
+			lite,
+			(f & 8) !== 0,
+			(f & 16) !== 0,
+		);
+	}
 	// Advance the hydration cursor past the @for's `<!--]-->` so a later sibling's
 	// clone() starts after this block — covers the zero-item, no-@empty case where
 	// reconcileKeyed mounts nothing and the cursor would otherwise stay on the
@@ -19369,6 +19415,90 @@ function updateSurvivor<T>(
 	}
 }
 
+/**
+ * Linear first-fill of an EMPTY keyed list — the hydration-adopt / first-mount
+ * path: append (or adopt) each item in order and build the survivor machinery
+ * (key map + intrusive sibling chain) as a byproduct of the same pass. Kept as
+ * its own small function, OUTSIDE reconcileKeyed, so a first mount — every
+ * hydration adopt of a server-rendered @for, and every fresh list mount — never
+ * enters (and on a cold page, never lazily compiles) the full prefix/suffix/LIS
+ * reconciler. reconcileKeyed delegates here too, so its empty→fill contract is
+ * unchanged for update-path 0 → N transitions.
+ */
+function mountItemsLinear<T>(
+	parentBlock: Block,
+	state: ForSlot,
+	items: ArrayLike<T>,
+	getKey: (item: T, index: number) => any,
+	itemBody: (item: T, scope: Scope) => void,
+	singleRoot: boolean | 2,
+	ssrMarkerless: boolean,
+): void {
+	const newLen = items.length;
+	if (newLen === 0) return;
+	const oldItems = state.items;
+	const parentNode = state.end.parentNode!;
+	// Pure-host → blocks upgrade adoption (childSlot arms `state.adopt`): the
+	// element's existing raw children, keyed like the incoming items. An item
+	// whose key matches the queue FRONT adopts that node in place (mountItem
+	// wraps it in the item's markers and seeds block.deoptNode); other items
+	// mount fresh BEFORE the next unconsumed node so DOM order tracks list
+	// order. Non-front key matches (a reorder in the very same render) mount
+	// fresh — the unconsumed nodes are swept by the caller.
+	const adopt = state.adopt;
+	let prev: Block | null = null;
+	const mounted: Block[] = [];
+	try {
+		for (let i = 0; i < newLen; i++) {
+			const item = items[i];
+			const key = getKey(item, i);
+			let adoptNode: Node | null = null;
+			let anchor: Node = state.end;
+			if (adopt !== null && adopt.length !== 0) {
+				if (adopt[0].key === key) adoptNode = adopt.shift()!.node;
+				else anchor = adopt[0].node;
+			}
+			const block = mountItem(
+				parentBlock,
+				parentNode,
+				anchor,
+				item,
+				i,
+				itemBody,
+				state,
+				singleRoot,
+				ssrMarkerless,
+				adoptNode,
+			);
+			mounted.push(block);
+			oldItems.set(key, block);
+			block.key = key;
+			block.prevSibling = prev;
+			block.nextSibling = null;
+			if (prev) prev.nextSibling = block;
+			else state.head = block;
+			prev = block;
+		}
+		state.tail = prev;
+		state.size = newLen;
+	} catch (error) {
+		// A list item may suspend while mounting (most visibly a lazy
+		// component). None of this empty->fill pass has committed yet: discard
+		// every completed prefix item, while mountItem discards the throwing
+		// item itself. A retry then starts from a genuinely empty list instead
+		// of duplicating the completed prefix and overwriting its Map entry.
+		for (let i = mounted.length - 1; i >= 0; i--) {
+			const block = mounted[i];
+			oldItems.delete(block.key);
+			unmountBlock(block, true);
+		}
+		state.head = null;
+		state.tail = null;
+		state.size = 0;
+		throw error;
+	}
+}
+
 function reconcileKeyed<T>(
 	parentBlock: Block,
 	state: ForSlot,
@@ -19391,68 +19521,10 @@ function reconcileKeyed<T>(
 	const newLen = items.length;
 	const parentNode = state.end.parentNode!;
 
-	// Fast path: empty → fill. Append each new block to the tail of the (empty) list.
+	// Fast path: empty → fill — the linear first-fill pass (callers on the
+	// first-mount path dispatch to it directly and skip this function entirely).
 	if (oldSize === 0) {
-		if (newLen === 0) return;
-		// Pure-host → blocks upgrade adoption (childSlot arms `state.adopt`): the
-		// element's existing raw children, keyed like the incoming items. An item
-		// whose key matches the queue FRONT adopts that node in place (mountItem
-		// wraps it in the item's markers and seeds block.deoptNode); other items
-		// mount fresh BEFORE the next unconsumed node so DOM order tracks list
-		// order. Non-front key matches (a reorder in the very same render) mount
-		// fresh — the unconsumed nodes are swept by the caller.
-		const adopt = state.adopt;
-		let prev: Block | null = null;
-		const mounted: Block[] = [];
-		try {
-			for (let i = 0; i < newLen; i++) {
-				const item = items[i];
-				const key = getKey(item, i);
-				let adoptNode: Node | null = null;
-				let anchor: Node = state.end;
-				if (adopt !== null && adopt.length !== 0) {
-					if (adopt[0].key === key) adoptNode = adopt.shift()!.node;
-					else anchor = adopt[0].node;
-				}
-				const block = mountItem(
-					parentBlock,
-					parentNode,
-					anchor,
-					item,
-					i,
-					itemBody,
-					state,
-					singleRoot,
-					ssrMarkerless,
-					adoptNode,
-				);
-				mounted.push(block);
-				oldItems.set(key, block);
-				block.key = key;
-				block.prevSibling = prev;
-				block.nextSibling = null;
-				if (prev) prev.nextSibling = block;
-				else state.head = block;
-				prev = block;
-			}
-			state.tail = prev;
-			state.size = newLen;
-		} catch (error) {
-			// A list item may suspend while mounting (most visibly a lazy
-			// component). None of this empty->fill pass has committed yet: discard
-			// every completed prefix item, while mountItem discards the throwing
-			// item itself. A retry then starts from a genuinely empty list instead
-			// of duplicating the completed prefix and overwriting its Map entry.
-			for (let i = mounted.length - 1; i >= 0; i--) {
-				const block = mounted[i];
-				oldItems.delete(block.key);
-				unmountBlock(block, true);
-			}
-			state.head = null;
-			state.tail = null;
-			state.size = 0;
-			throw error;
-		}
+		mountItemsLinear(parentBlock, state, items, getKey, itemBody, singleRoot, ssrMarkerless);
 		return;
 	}
 	// Fast path: clear all.


### PR DESCRIPTION
News-bench hydrate campaign P2 (see the 2026-07-21 diagnosis; P0 landed as #217, P1 is #218). Two independent cold-path optimizations, measured and landed on their own merits.

## What

1. **Keyed `@for` first-fill linear pass.** `reconcileKeyed`'s empty→fill branch is extracted verbatim into a small top-level `mountItemsLinear`. `forBlock` and `childSlot`'s de-opt keyed-list regime dispatch to it directly when `size === 0`, and `reconcileKeyed` delegates to it for update-path 0→N transitions, so its contract is unchanged. The survivor key map and intrusive sibling chain are still built as a byproduct of the same pass — deferring them to first update was considered and rejected (µs-level mount gain against a real first-update tax).
2. **`commitEffects` no-work fast path.** One combined emptiness check over all nine commit queues — provably equivalent to the per-drain early-returns (each drain's condition is folded in, including `hasControlledSyncs()` covering the dev-only form-diagnostics queue) — returns before touching the drain pipeline. The passive hand-off is preserved verbatim, and an INVARIANT comment requires any future drain to add its condition.

## Why this works

Per-fresh-page CDP profiles of the news bench (40 pages, prod build) show cold-hydrate self-time is dominated by **V8 lazy compilation attributed to the caller's frame**: `forBlock` self-time fell 183→43 µs/page purely by no longer calling the ~500-line reconciler on first fill, and `commitEffects`' ~110 µs/page vanished once the drains stopped being called. On a first paint, function size on the call path matters more than executed ops.

## Numbers (interleaved A/B, 40 iters per run, same machine/session)

| | hydrate score | median | min |
|---|---|---|---|
| baseline (main @ f3257751) | 1.76 / 1.71 | 1.70–1.80 | 1.60 |
| this PR | **1.58 / 1.58** | 1.60 | 1.50 |
| svelte (reference, same session) | 1.57 | 1.50 | 1.30 |

Attribution: commit fast path alone ≈ 0.04 ms; @for linear pass ≈ +0.11 ms on top. SSR score unchanged. Caveat: concurrent sibling sessions shared the machine; the interleaved A/B and identical repeat candidate runs (1.58/1.58) are the mitigation.

## Update-path controls

`bench.mjs --record` on baseline → `--compare` on candidate for js-framework, dbmon, effectful-list, todomvc: **zero regressions on octane targets across 168 ops** (the few flags were on solid/preact/svelte — untouched frameworks, i.e. machine noise). The only update-path delta is one integer compare per `forBlock`/`childSlot` list render.

## Validation

- `pnpm test`: 1269 files / 12093 tests passed (octane + octane-prod projects)
- `pnpm typecheck`, `pnpm format:check`: pass
- `website/tests/ssr-hydration.e2e.test.ts`: 44/44 (real dev + preview servers, headless Chromium)
- fuzz-keyed-list, differential/, hydration/, PR #192 sticky return-slot, and keyed-@for stale-survivor tests all green
- news bench correctness gates: cards=50, no-rebuild=true, interactive=true
- Changeset added (patch)

Residual risk: the cold-compile win's exact magnitude is V8-version-dependent (the mechanism isn't). The svelte hydrate ratio guard + committed results refresh remain with P3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core commit flushing and keyed list mounting on hydration/first mount; logic is mostly moved verbatim but a missed queue in the new `commitEffects` guard would silently skip work.
> 
> **Overview**
> **Cold hydration / first-mount** gets two optimizations aimed at avoiding V8 lazy-compile and no-op drain overhead on the first paint.
> 
> **Keyed `@for` first fill** no longer enters `reconcileKeyed` when the list is empty (`size === 0`). The former empty→fill loop is extracted to **`mountItemsLinear`**, which `forBlock`, de-opt `childSlot`, and `reconcileKeyed` (for 0→N updates) call directly. Behavior is unchanged: items append/adopt in order, key map and sibling chain are still built in the same pass, and suspend errors still roll back the prefix.
> 
> **`commitEffects`** now returns early when all commit queues are empty (plus the same `hasControlledSyncs()` gate the drains use), skipping the full drain pipeline. Passive scheduling when only passive work is pending is preserved; a comment documents that new drains must extend this check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3408161ce7b75fe649d7b6f2c2041b2d1481247. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->