### PR TITLE
Cache native DOM accessors and pre-seed node expandos on prototypes

### DIFF
--- a/.changeset/violet-moons-tickle.md
+++ b/.changeset/violet-moons-tickle.md
@@ -1,0 +1,13 @@
+---
+'octane': patch
+---
+
+Adopt Svelte's DOM operations technique in the client runtime: the shared
+traversal helpers (`child`/`sibling`, hydration cursor walks, range clears,
+de-opt child scans) now call cached native `firstChild`/`nextSibling`
+accessors so those megamorphic call sites stay monomorphic, and the expando
+keys the runtime polls on nodes that mostly don't carry them (`$$<event>`
+handler slots, `$$portalParent`/`$$portalEnd`, `$$deoptKey`, `$$ctrl`,
+hydration markers) are pre-seeded as `undefined` on the `Element`/
+`CharacterData` prototypes, turning negative lookups into fast prototype
+hits. Drift-corrected js-framework list/mount operations improve ~5–20%.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -3799,15 +3799,16 @@ function unmountBlockInner(block: Block, detachDom: boolean): void {
 			let n: Node | null = excl ? block.startMarker.nextSibling : block.startMarker;
 			const stop = excl ? block.endMarker : block.endMarker.nextSibling;
 			while (n && n !== stop) {
-				const next: Node | null = n.nextSibling;
+				const next: Node | null = getNextSibling(n);
 				parent.removeChild(n);
 				n = next;
 			}
 		}
 	} else if (block.kind === 'root') {
 		// Root block — clear the whole container.
-		while (block.parentNode.firstChild) {
-			block.parentNode.removeChild(block.parentNode.firstChild);
+		let c: Node | null;
+		while ((c = getFirstChild(block.parentNode)) !== null) {
+			block.parentNode.removeChild(c);
 		}
 	}
 	// else: a non-root block with no markers produced no DOM (e.g. a singleRoot
@@ -6996,6 +6997,90 @@ export function useId(slot?: HookSlot): string {
 }
 
 // ---------------------------------------------------------------------------
+// DOM operations bootstrap (Svelte's operations.js technique, measured for
+// octane on the js-framework / dbmon / news suites).
+//
+// Two independent tricks, both initialized lazily so importing the runtime in
+// a DOM-less process (compiler tooling, node-only tests) stays safe:
+//
+// 1. `firstChild` / `nextSibling` reads on the runtime's SHARED helpers
+//    (`child`, `sibling`, the hydration cursor walks, range clears) see every
+//    DOM hidden class — element tags, Text, Comment — at ONE call site, so the
+//    property access goes megamorphic. Calling the native accessor through a
+//    cached function reference keeps those sites monomorphic: the C++ accessor
+//    doesn't dispatch on the receiver's map. (Compiled template walks —
+//    `_root.firstChild.nextSibling…` — stay raw property access on purpose:
+//    each generated mount has its own per-template call sites, which V8 keeps
+//    mono/polymorphic already.)
+//
+// 2. The runtime polls expando slots on nodes that mostly DON'T carry them —
+//    `$$<type>` handler bundles + `$$portalParent` on every ancestor of every
+//    delegated event, `$$portalEnd`/`$$deoptKey` in the de-opt child scans,
+//    `$$ctrl`/`__oct_suppress` on form/hydration paths. A read of a property
+//    the object does NOT have walks the whole prototype chain and cannot be
+//    negatively cached as well as a hit. Pre-seeding the key as `undefined` on
+//    the prototype turns every such miss into a fast constant proto hit.
+//    Handler-slot keys are seeded per delegated event type at registration
+//    (delegateEvents / delegateCaptureEvents), the fixed set here.
+// ---------------------------------------------------------------------------
+
+let firstChildGetter: ((this: Node) => Node | null) | undefined;
+let nextSiblingGetter: ((this: Node) => Node | null) | undefined;
+
+function getFirstChild(node: Node): Node | null {
+	// Fallback keeps DOM-less/uninitialized callers correct; the branch is a
+	// single well-predicted check once initDomOperations has run.
+	return firstChildGetter === undefined ? node.firstChild : firstChildGetter.call(node);
+}
+
+function getNextSibling(node: Node): Node | null {
+	return nextSiblingGetter === undefined ? node.nextSibling : nextSiblingGetter.call(node);
+}
+
+/** Pre-seed one expando key on a prototype (see bootstrap comment, trick 2). */
+function seedExpando(proto: object, key: string): void {
+	if (!(key in proto)) (proto as any)[key] = undefined;
+}
+
+let domOperationsReady = false;
+
+/**
+ * One-time client bootstrap. Called from every cold entry that precedes DOM
+ * work — parseTemplate (first template mount), root creation/hydration, and
+ * delegation-target registration — and a no-op everywhere without a DOM.
+ */
+function initDomOperations(): void {
+	if (domOperationsReady || typeof Element === 'undefined') return;
+	domOperationsReady = true;
+	const nodeProto = Node.prototype;
+	firstChildGetter = Object.getOwnPropertyDescriptor(nodeProto, 'firstChild')?.get;
+	nextSiblingGetter = Object.getOwnPropertyDescriptor(nodeProto, 'nextSibling')?.get;
+	const elementProto = Element.prototype;
+	if (Object.isExtensible(elementProto)) {
+		// Polled on every delegated event's ancestor walk.
+		seedExpando(elementProto, '$$portalParent');
+		// De-opt child scans poll these on every owned child.
+		seedExpando(elementProto, '$$portalEnd');
+		seedExpando(elementProto, '$$deoptKey');
+		// Controlled-form and hydration-suppression checks.
+		seedExpando(elementProto, '$$ctrl');
+		seedExpando(elementProto, '__oct_suppress');
+		// clone()/drainFrag() fragment-wrapper discriminants.
+		seedExpando(elementProto, '__oct_frag');
+		seedExpando(elementProto, '__oct_vfrag');
+		if (process.env.NODE_ENV !== 'production') {
+			seedExpando(elementProto, '__oct_loc');
+		}
+	}
+	// The de-opt/portal scans also poll Text and Comment children (both inherit
+	// from CharacterData).
+	if (typeof CharacterData !== 'undefined' && Object.isExtensible(CharacterData.prototype)) {
+		seedExpando(CharacterData.prototype, '$$portalEnd');
+		seedExpando(CharacterData.prototype, '$$deoptKey');
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Templates: inert module token → parse on first mount → clone per instance
 // ---------------------------------------------------------------------------
 
@@ -7022,6 +7107,7 @@ interface LazyTemplateRecord {
 const LAZY_TEMPLATE = Symbol('octane.lazy-template');
 
 function parseTemplate(html: string, ns: 0 | 1 | 2, frag: number): Element {
+	initDomOperations();
 	const t = document.createElement('template');
 	if (ns === 0) {
 		// Fixed HTML multi-root templates arrive pre-wrapped by the compiler. Opaque
@@ -7564,7 +7650,7 @@ class HydrationCapability {
 	}
 
 	htext(el: Node, text: string, loc?: string): Text {
-		const first = el.firstChild;
+		const first = getFirstChild(el);
 		if (first !== null && first.nodeType === 3) {
 			const server = (first as Text).nodeValue;
 			if (
@@ -7623,12 +7709,12 @@ class HydrationCapability {
 			if (cursor === null) return null;
 			if (isBlockOpen(cursor)) cursor = this.close(cursor);
 			if (isTextSeparator(cursor)) {
-				cursor = cursor.nextSibling;
+				cursor = getNextSibling(cursor!);
 				continue;
 			}
-			cursor = cursor.nextSibling;
+			cursor = getNextSibling(cursor!);
 			if (isTextSeparator(cursor)) {
-				const after: Node | null = cursor.nextSibling;
+				const after: Node | null = getNextSibling(cursor!);
 				if (after !== null && (after.nodeType === 3 || isTextSeparator(after))) cursor = after;
 			}
 		}
@@ -7833,7 +7919,8 @@ export function clone<T extends Node>(node: T, loc?: string): T {
  */
 export function drainFrag(root: Node, parent: Node, anchor: Node | null): void {
 	if (activeHydration() !== null && (root as any).__oct_vfrag === true) return;
-	while (root.firstChild) parent.insertBefore(root.firstChild, anchor);
+	let c: Node | null;
+	while ((c = getFirstChild(root)) !== null) parent.insertBefore(c, anchor);
 }
 
 /**
@@ -8045,7 +8132,7 @@ function isTextSeparator(node: Node | null): node is Comment {
 /** From a block-open `<!--[-->`, the matching `<!--]-->` (depth-tracked). */
 function findMatchingClose(open: Node): Comment {
 	let depth = 0;
-	let node: Node = open.nextSibling as Node;
+	let node: Node = getNextSibling(open) as Node;
 	for (;;) {
 		if (node.nodeType === 8) {
 			const data = (node as Comment).data;
@@ -8068,7 +8155,7 @@ function findMatchingClose(open: Node): Comment {
 				depth += 1;
 			}
 		}
-		node = node.nextSibling as Node;
+		node = getNextSibling(node) as Node;
 	}
 }
 
@@ -8081,7 +8168,12 @@ function ssrForMarkerState(node: Node): -1 | 0 | 1 {
 
 /** Logical index-0 child: `node.firstChild` for both client and hydration. */
 export function child<T extends Node>(node: T): Node | null {
-	return node.firstChild;
+	// While hydrating, a multi-root clone() can hand back the virtual-fragment
+	// stand-in — a plain object whose `firstChild` is a snapshot property (see
+	// adopt()) — and the native accessor throws on a non-Node receiver. Keep the
+	// plain read on the hydration branch; client mounts always hold a real Node.
+	if (currentHydration !== null) return node.firstChild;
+	return getFirstChild(node);
 }
 
 /**
@@ -8096,7 +8188,7 @@ export function sibling(node: Node, n: number = 1): Node | null {
 	for (let i = 0; i < n; i++) {
 		// Over-walk (cursor already past the last node) → return null, don't throw.
 		if (c === null) return null;
-		c = c.nextSibling;
+		c = getNextSibling(c);
 	}
 	return c;
 }
@@ -10341,10 +10433,16 @@ const TARGET_ONLY_DELEGATED = /* @__PURE__ */ new Set([
 ]);
 
 export function delegateEvents(eventNames: string[]): void {
+	// Seedable prototype may not exist at compiled-module load in exotic hosts.
+	const canSeed = typeof Element !== 'undefined' && Object.isExtensible(Element.prototype);
 	for (let i = 0; i < eventNames.length; i++) {
 		const name = eventNames[i];
 		if (_delegated.has(name)) continue;
 		_delegated.add(name);
+		// Pre-seed the handler-slot key: the dispatch walk polls `$$<type>` on
+		// EVERY logical ancestor of every delegated event, and most of them carry
+		// no handler (see initDomOperations, trick 2).
+		if (canSeed) seedExpando(Element.prototype, '$$' + name);
 		// A new event type was registered after some roots/portals already mounted —
 		// back-attach the listener to every active target so handlers stamped on
 		// their DOM via `el.$$click = …` still receive events.
@@ -10360,10 +10458,14 @@ export function delegateEvents(eventNames: string[]): void {
 // modules call this at load for the capture handlers they contain; the spread path
 // lazy-registers dynamically-supplied ones.
 export function delegateCaptureEvents(eventNames: string[]): void {
+	const canSeed = typeof Element !== 'undefined' && Object.isExtensible(Element.prototype);
 	for (let i = 0; i < eventNames.length; i++) {
 		const name = eventNames[i];
 		if (_delegatedCapture.has(name)) continue;
 		_delegatedCapture.add(name);
+		// Same seeding rationale as delegateEvents (the capture walk polls
+		// `$$capture:<type>` along the built path).
+		if (canSeed) seedExpando(Element.prototype, CAPTURE_PREFIX + name);
 		for (const target of _delegationTargets.keys()) {
 			target.addEventListener(name, dispatchDelegatedCapture, true);
 		}
@@ -10377,6 +10479,7 @@ export function delegateCaptureEvents(eventNames: string[]): void {
  * just bump the refcount.
  */
 function registerDelegationTarget(target: Node): void {
+	initDomOperations();
 	const prev = _delegationTargets.get(target) || 0;
 	_delegationTargets.set(target, prev + 1);
 	if (prev === 0) {
@@ -14242,7 +14345,7 @@ function reconcileDeoptChildren(el: Element, children: any, ownerBlock: Block): 
 	// with the container's rendered children). Range starts carry $$portalEnd.
 	const owned: Node[] = [];
 	let hasForeign = false;
-	let scan: Node | null = el.firstChild;
+	let scan: Node | null = getFirstChild(el);
 	while (scan !== null) {
 		const rangeEnd = (scan as any).$$portalEnd as Node | undefined;
 		if (rangeEnd != null) {
@@ -14251,7 +14354,7 @@ function reconcileDeoptChildren(el: Element, children: any, ownerBlock: Block): 
 			continue;
 		}
 		owned.push(scan);
-		scan = scan.nextSibling;
+		scan = getNextSibling(scan);
 	}
 	// Partition current children by their stamped SLOT KEY (position-scoped —
 	// see flattenDeoptChildrenKeyed; explicit keys ride the same scheme). Nodes
@@ -14313,8 +14416,8 @@ function reconcileDeoptChildren(el: Element, children: any, ownerBlock: Block): 
 // Shared by reconcileDeoptChildren's owned-children scan and liveOwnedChildAt.
 function nodeAfterPortalRange(start: Node, end: Node): Node | null {
 	let m: Node | null = start;
-	while (m !== null && m !== end) m = m.nextSibling;
-	return (m ?? start).nextSibling;
+	while (m !== null && m !== end) m = getNextSibling(m);
+	return getNextSibling(m ?? start);
 }
 
 // The i-th child of `el` that the de-opt reconciler OWNS, skipping foreign
@@ -14322,7 +14425,7 @@ function nodeAfterPortalRange(start: Node, end: Node): Node | null {
 // called per reorder step, only when a foreign range exists.
 function liveOwnedChildAt(el: Element, index: number): Node | null {
 	let i = 0;
-	let scan: Node | null = el.firstChild;
+	let scan: Node | null = getFirstChild(el);
 	while (scan !== null) {
 		const rangeEnd = (scan as any).$$portalEnd as Node | undefined;
 		if (rangeEnd != null) {
@@ -14331,7 +14434,7 @@ function liveOwnedChildAt(el: Element, index: number): Node | null {
 		}
 		if (i === index) return scan;
 		i++;
-		scan = scan.nextSibling;
+		scan = getNextSibling(scan);
 	}
 	return null;
 }


### PR DESCRIPTION
## Summary

Adopts Svelte's [`operations.js`](https://github.com/sveltejs/svelte/blob/main/packages/svelte/src/internal/client/dom/operations.js) techniques in the client runtime, both behind a lazy one-time `initDomOperations()` bootstrap (wired through `parseTemplate` and `registerDelegationTarget`, so DOM-less imports stay safe):

1. **Cached native accessors.** The shared traversal helpers — `child`/`sibling`, the hydration cursor walks (`HydrationCapability.sibling`/`findMatchingClose`/`htext`), `drainFrag`, block teardown range clears, and the de-opt child scans — now call cached `Node.prototype` `firstChild`/`nextSibling` getters via `.call(node)`. Those single shared call sites see every DOM hidden class (element tags, Text, Comment) and go megamorphic as plain property access; the cached accessor call doesn't dispatch on the receiver's map. Compiled per-template walks (`_root.firstChild.nextSibling…`) intentionally keep raw access — each generated mount owns its call sites, which V8 keeps mono/polymorphic already.
2. **Prototype expando pre-seeding.** The expando keys the runtime polls on nodes that mostly don't carry them are pre-seeded as `undefined` on `Element.prototype` (and `CharacterData.prototype` for the scans that visit Text/Comment children): `$$portalParent` (polled on every ancestor of every delegated event), `$$portalEnd`/`$$deoptKey` (de-opt child scans), `$$ctrl`, `__oct_suppress`, `__oct_frag`/`__oct_vfrag`, dev-only `__oct_loc`. Handler-slot keys (`$$<type>` / `$$capture:<type>`) seed per event type at `delegateEvents`/`delegateCaptureEvents` registration. A read of an absent property walks the whole prototype chain and caches poorly; seeding turns each miss into a fast constant proto hit.

Svelte's third trick — `createElement` vs `createElementNS` Blink fast-path branching — was already present in octane.

One hydration edge handled: multi-root `clone()` returns the virtual-fragment **plain object** (`{__oct_vfrag, firstChild}`) while hydrating, and the native accessor throws on a non-Node receiver, so `child()` keeps the plain read on the `currentHydration !== null` branch (caught by `mixed-frag-hydrate` before the fix).

## Measurements

Protocol: `bench.mjs --record js-framework dbmon news` before the change, `--compare` after, twice; deltas drift-corrected against the unchanged reference frameworks measured in the same run (run 2 had +30% machine-wide drift, which the correction cancels).

- **js-framework** (traversal-heavy): ms-scale ops improved in **both** post-change runs — octane-tsrx −5…−27% (run/replace/add/runlots/clear; e.g. runlots −21%/−26% corrected), octane-jsx −3…−15% in run 2. Sub-ms ops excluded per the suite's noise rule.
- **dbmon**: flat (±3%) — its cost is in text/class bindings, not traversal. Expected.
- **news**: hydrate within noise; SSR untouched (`runtime.server.ts` is a separate path).
- **Bundle**: js-framework fixture framework gz 16,134 vs 16,346 recorded local baseline (~+300 B gz added, inside headroom).

Timing magnitudes are drift-corrected rather than from a quiet machine, so treat them as directional; the direction is consistent across 2/2 runs and every ms-scale op.

## Validation

- `pnpm test`: 12,153/12,154 — the single failure was the website smoke test pinning the tracked `benchmarks/baselines/local/*.json` this investigation temporarily re-recorded; restored, file passes.
- `pnpm typecheck`, `pnpm format:check`: clean.
- Hydration directory (dev + the octane-prod compile project ran as part of the full suite): green.
- Changeset included (patch).

## Follow-up candidates (not in this PR)

- Sweep the remaining warm `.nextSibling` sites (portal reconcile scans, childSlot marker walks).
- Consider caching `parentNode` for the delegated-event ancestor walk (Svelte doesn't; kept out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hot-path DOM traversal and mutates `Element`/`CharacterData` prototypes globally at runtime; behavior is intended to be equivalent with hydration guarded, but any host that forbids prototype extension or shares the page with other code could be affected.
> 
> **Overview**
> Adds a lazy **`initDomOperations()`** bootstrap in the client runtime (Svelte-style) so shared DOM walks stay fast without breaking DOM-less imports.
> 
> **Cached `firstChild` / `nextSibling`:** Shared helpers (`child`/`sibling`, hydration cursor walks, `drainFrag`, block teardown clears, de-opt child scans) now use native getters via **`getFirstChild` / `getNextSibling`** instead of megamorphic property reads. Per-template compiled walks are unchanged. **`child()`** still uses plain **`firstChild` while hydrating** so multi-root virtual-fragment stand-ins (non-`Node` receivers) do not throw.
> 
> **Prototype expando seeding:** Frequently polled but usually absent keys (`$$portalParent`, `$$portalEnd`, `$$deoptKey`, `$$ctrl`, `__oct_suppress`, fragment markers, etc.) are pre-seeded as **`undefined`** on **`Element`** / **`CharacterData`** prototypes; delegated handler slots (`$$<event>`, capture variants) seed when events register. Bootstrap runs from **`parseTemplate`** and **`registerDelegationTarget`**.
> 
> Patch changeset notes ~5–20% improvement on drift-corrected js-framework list/mount benchmarks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ef8ec1b3eac49a34d50a0755e34410c245af002. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->