### PR TITLE
bench(tanstack-com): fix octane flavor's empty SSR bodies (missing compile-time defines)

### DIFF
--- a/benchmarks/tanstack-com/octane/vite.config.ts
+++ b/benchmarks/tanstack-com/octane/vite.config.ts
@@ -11,6 +11,14 @@ import tailwindcss from '@tailwindcss/vite';
 import path from 'node:path';
 
 export default defineConfig({
+	// Same compile-time globals as the react flavor's bench config — utils
+	// reference them and SSR dies with a ReferenceError otherwise (this was
+	// the whole-page-body-missing bug: the root error boundary swallowed it).
+	define: {
+		__TANSTACK_ENABLE_SERVER_BUILDER_GENERATION__: JSON.stringify(false),
+		__TANSTACK_ENABLE_IMAGE_TRANSFORMATIONS__: JSON.stringify(false),
+		__TANSTACK_SITE_URL__: JSON.stringify('https://tanstack.com'),
+	},
 	server: { port: Number(process.env.PORT) || 3000 },
 	resolve: {
 		alias: [{ find: '~', replacement: path.resolve(__dirname, './src') }],

--- a/packages/octane/tests/_fixtures/createelement-passthrough-children.tsrx
+++ b/packages/octane/tests/_fixtures/createelement-passthrough-children.tsrx
@@ -1,0 +1,23 @@
+// Mirrors @octanejs/tanstack-router's server-side Body: a component that
+// re-parents its compiled CHILDREN BLOCK through createElement positional
+// children into a bare-children-return passthrough component.
+import { createElement, HYDRATION_RANGE_BOUNDARY } from 'octane';
+
+const Owner = (props: any) => props.children;
+(Owner as any)[HYDRATION_RANGE_BOUNDARY] = 'owner';
+
+const Body = (props: any) => {
+	const { children, ...attrs } = props;
+	return createElement(
+		'body',
+		attrs,
+		createElement('div', { id: '__app' }, createElement(Owner, {}, children)),
+	);
+};
+
+export function App() {
+	return <Body class="overflow-x-hidden">
+		<div data-probe="static">static child</div>
+		<p>{'text' as string}</p>
+	</Body>;
+}

--- a/packages/octane/tests/createelement-passthrough-children.test.ts
+++ b/packages/octane/tests/createelement-passthrough-children.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import * as ServerRuntime from 'octane/server';
+import { mount } from './_helpers.js';
+import { loadServerFixture } from './_server-fixture.js';
+import { App } from './_fixtures/createelement-passthrough-children.tsrx';
+
+const FIXTURE = 'packages/octane/tests/_fixtures/createelement-passthrough-children.tsrx';
+
+// tanstack.com Phase 2c: the octane flavor SSR'd an ENTIRELY EMPTY <body> —
+// @octanejs/tanstack-router's Body re-parents the compiled children block via
+// createElement positional children into a passthrough component
+// ((props) => props.children). The children must render through that chain in
+// BOTH compile modes.
+describe('createElement passthrough of compiled children blocks', () => {
+	it('client: children render through the createElement re-parent chain', () => {
+		const mounted = mount(App as any, {});
+		try {
+			expect(mounted.find('[data-probe="static"]').textContent).toBe('static child');
+		} finally {
+			mounted.unmount();
+		}
+	});
+
+	it('server: children render into the SSR html', () => {
+		const server = loadServerFixture(FIXTURE);
+		const { html } = ServerRuntime.renderToString(server.App, {});
+		expect(html).toContain('static child');
+		expect(html).toContain('text');
+		expect(html).toContain('id="__app"');
+	});
+});


### PR DESCRIPTION
## What

Closes the Phase 2c known issue: every octane-flavor route streamed an **empty document body** (homepage 29KB vs react's 309KB).

## Root cause

Not an octane bug: the scaffolded octane vite config never declared the `__TANSTACK_*` compile-time globals the react flavor's bench config defines. Utils reference them; the SSR ReferenceError was swallowed whole by the root error boundary, so responses were head content + closed hydration markers with a 200 status. Found by live-bisecting the dev stream down to the last real content before the marker tail: `__TANSTACK_ENABLE_IMAGE_TRANSFORMATIONS__ is not defined` rendered inside the error-boundary UI.

## After

All six benchmark routes stream full content, octane sizes exceeding react's as expected (hydration markers + serialized payload):

| Route | octane | react |
| --- | --- | --- |
| `/` | 390KB | 309KB |
| `/blog` | 270KB | 197KB |
| `/libraries` | 254KB | 192KB |
| `/router/latest` | 354KB | 263KB |
| docs overview | 338KB | 238KB |
| `/ethos` | 197KB | 134KB |

Homepage headings: **12/12, matching order** (only the known JSX-whitespace preservation differs — normalized by the compare gate).

## Also

Pins the `@octanejs/tanstack-router` `Body` children path (compiled children block → createElement positional children → hydration-range passthrough) with an octane test in both compile modes — written while bisecting; the chain proved innocent but is worth keeping pinned.

Unblocks Phase 2d (3-way compare gate + perf suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark Vite config and test-only coverage; no production auth, data, or core runtime behavior changes beyond fixing missing compile-time constants for the octane bench.
> 
> **Overview**
> Fixes the octane **tanstack-com** benchmark streaming **empty document bodies** on SSR by adding the same Vite **`define`** compile-time globals the react flavor already sets (`__TANSTACK_ENABLE_SERVER_BUILDER_GENERATION__`, `__TANSTACK_ENABLE_IMAGE_TRANSFORMATIONS__`, `__TANSTACK_SITE_URL__`). Shared utils read those identifiers; without defines, SSR hit a **`ReferenceError`** that the root error boundary swallowed, so responses looked like head + hydration markers with no page content.
> 
> Adds an octane regression test (client mount + server `renderToString`) that mirrors **`@octanejs/tanstack-router`**’s `Body` pattern: compiled children passed through **`createElement`** into a hydration-range passthrough component, asserting static and text children still appear in the HTML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3859d5254abe61538e7dc265ab1acabef42b2f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->