### PR TITLE
Fix permanent-static and streamed deferred hydration

### DIFF
--- a/.changeset/static-hydrate-stream-races.md
+++ b/.changeset/static-hydrate-stream-races.md
@@ -1,0 +1,8 @@
+---
+'octane': patch
+---
+
+Emit exact `split={false}` / `never()` hydration boundaries as wrapper-free
+server-only ranges, prune private module-scope descendants used exclusively by
+those ranges, and defer boundary activation until nested renderer-owned Suspense
+reveals settle.

--- a/docs/deferred-hydration.md
+++ b/docs/deferred-hydration.md
@@ -245,6 +245,32 @@ JavaScript behavior; keep their fallback values safe to evaluate on the server.
 `onHydrated` runs once after the child successfully commits on the client,
 whether the boundary adopts preserved server DOM or mounts client-only.
 
+The exact direct-import form `<Hydrate split={false} when={never()}>` is a
+server-only static range. The compiler removes its descendants from the client
+render and prunes private module-scope declarations and imports reachable
+exclusively from that range. SSR emits the children without a host wrapper, and
+hydration reserves their ID positions without evaluating or reconciling them. A
+client-only mount has no server range to preserve, so this exact form renders no
+children. The tag must have exactly those two attributes; additional attributes,
+spreads, indirect `Hydrate`/`never` values, and every other strategy retain the
+ordinary runtime boundary semantics. Shared, exported, and coupled declarations
+remain in the client module so the optimization cannot change unrelated module
+behavior.
+
+When a descendant module is reachable only through a pruned static declaration
+chain, it is absent from the client manifest; a CSS file imported only by that
+module is absent too. Import ordinary stylesheets from an eager route/layout
+module. Scoped `<style>` remains safe: the client compiler retains a directly
+authored style long enough to preserve the surrounding component's scope hash,
+while SSR collects styles owned by removed descendant components and emits them
+with the rendered static content.
+
+For streamed static content, a synchronous unhandled server error still reaches
+the nearest authored server catch (or the stream's fatal path). If a pending
+fallback has already flushed, a later rejection or abort terminalizes that
+server-owned range and retains the fallback; it cannot request client recovery
+because its client graph does not exist.
+
 ## Correctness and nesting
 
 Deferred hydration is a performance hint. An update outside a dormant boundary
@@ -264,6 +290,13 @@ target boundary. A `never()` ancestor keeps every deferred descendant inert.
 Native event payload details such as pointer coordinates are not guaranteed to
 survive replay.
 
-`Hydrate` always renders a persistent HTML `<div>`. Account for that wrapper in
-layout and HTML nesting. Direct placement inside SVG or MathML is unsupported,
-because an HTML parser moves a `<div>` out of foreign content before hydration.
+If activation races a pending renderer-owned streamed Suspense reveal, the
+boundary waits for that reveal or its client-render degradation before adopting
+the range. Pending reveals inside an independently dormant nested `Hydrate`
+boundary remain owned by that nested boundary and do not delay its ancestor.
+
+Ordinary `Hydrate` boundaries render a persistent HTML `<div>`. Account for that
+wrapper in layout and HTML nesting; direct placement inside SVG or MathML is
+unsupported because an HTML parser moves a `<div>` out of foreign content before
+hydration. The exact permanent-static form described above is wrapper-free and
+inherits its HTML, SVG, or MathML parser namespace.

--- a/packages/octane/src/compiler/hydrate-boundaries.js
+++ b/packages/octane/src/compiler/hydrate-boundaries.js
@@ -85,6 +85,20 @@ function applyMappedReplacements(source, start, end, replacements) {
 	return concatMapped(parts);
 }
 
+/** Keep a containing deletion/rewrite instead of edits wholly nested inside it. */
+function outermostReplacements(replacements) {
+	const outermost = [];
+	let coveredUntil = -1;
+	for (const replacement of [...replacements].sort(
+		(left, right) => left.start - right.start || right.end - left.end,
+	)) {
+		if (replacement.start < coveredUntil) continue;
+		outermost.push(replacement);
+		coveredUntil = replacement.end;
+	}
+	return outermost;
+}
+
 function nameOf(node) {
 	if (node?.type === 'Identifier' || node?.type === 'JSXIdentifier') return node.name;
 	if (node?.type === 'Literal' && typeof node.value === 'string') return node.value;
@@ -93,6 +107,10 @@ function nameOf(node) {
 
 function collectBindingNames(pattern, output) {
 	if (!pattern) return;
+	if (pattern.type === 'TSParameterProperty') {
+		collectBindingNames(pattern.parameter, output);
+		return;
+	}
 	if (pattern.type === 'Identifier' || pattern.type === 'JSXIdentifier') {
 		output.add(pattern.name);
 		return;
@@ -177,7 +195,11 @@ function functionVarBindings(body) {
 			!root &&
 			(node.type === 'FunctionDeclaration' ||
 				node.type === 'FunctionExpression' ||
-				node.type === 'ArrowFunctionExpression')
+				node.type === 'ArrowFunctionExpression' ||
+				node.type === 'ClassDeclaration' ||
+				node.type === 'ClassExpression' ||
+				node.type === 'StaticBlock' ||
+				node.type === 'TSModuleDeclaration')
 		) {
 			return;
 		}
@@ -196,6 +218,7 @@ function functionVarBindings(body) {
 function collectImports(ast) {
 	const hydrateNames = new Set();
 	const hookNames = new Set();
+	const neverNames = new Set();
 	const importBindings = new Set();
 	const declarations = [];
 	for (const statement of ast.body ?? []) {
@@ -223,9 +246,19 @@ function collectImports(ast) {
 			) {
 				hookNames.add(specifier.local.name);
 			}
+			if (
+				statement.source?.value === 'octane/hydration' &&
+				statement.importKind !== 'type' &&
+				specifier.type === 'ImportSpecifier' &&
+				specifier.importKind !== 'type' &&
+				nameOf(specifier.imported) === 'never' &&
+				specifier.local?.name
+			) {
+				neverNames.add(specifier.local.name);
+			}
 		}
 	}
-	return { declarations, hookNames, hydrateNames, importBindings };
+	return { declarations, hookNames, hydrateNames, neverNames, importBindings };
 }
 
 function rewrittenImport(input, declaration, keptSpecifiers) {
@@ -348,12 +381,114 @@ function literalSplitDisabled(node) {
 	return value?.type === 'Literal' && value.value === false;
 }
 
+/**
+ * Recognize only the exact server-only form whose client subtree may be erased.
+ * Spreads and indirect strategies stay on the ordinary persistent-wrapper path:
+ * either could change the final `split`, `when`, or `children` value at runtime.
+ */
+function isPermanentStaticBoundary(node, neverNames, shadowedImports) {
+	let split = null;
+	let when = null;
+	const attributes = node.openingElement?.attributes ?? [];
+	if (attributes.length !== 2) return false;
+	for (const attribute of attributes) {
+		if (attribute.type === 'JSXSpreadAttribute' || attribute.type === 'SpreadAttribute') {
+			return false;
+		}
+		const name = jsxAttributeName(attribute);
+		if (name === 'children') return false;
+		if (name === 'split') split = attribute;
+		else if (name === 'when') when = attribute;
+	}
+	if (split === null || when === null || !literalSplitDisabled(node)) return false;
+	const raw = when.value?.type === 'JSXExpressionContainer' ? when.value.expression : when.value;
+	const expression = unwrapExpression(raw);
+	if (expression?.type !== 'CallExpression' || (expression.arguments?.length ?? 0) !== 0) {
+		return false;
+	}
+	const callee = unwrapExpression(expression.callee);
+	return (
+		callee?.type === 'Identifier' &&
+		neverNames.has(callee.name) &&
+		!shadowedImports.has(callee.name)
+	);
+}
+
 function openingInsertOffset(source, opening) {
 	const text = source.slice(opening.start, opening.end);
 	if (!text.endsWith('>')) {
 		throw new Error('Octane Hydrate compiler found an invalid JSX opening tag.');
 	}
 	return opening.end - (text.endsWith('/>') ? 2 : 1);
+}
+
+/**
+ * Keep compile-time scoped styles owned by the component that contains an
+ * erased static range. CSS scoping annotates every host in that component, not
+ * just hosts lexically beside the `<style>`, so dropping these nodes before the
+ * style pass would give the client and server different scope hashes/classes.
+ * Styles inside nested function bodies belong to those functions and leave with
+ * the server-only descendant graph instead.
+ */
+function permanentStaticStyleChildren(source, boundary) {
+	const styles = [];
+	const seen = new WeakSet();
+	const visit = (node) => {
+		if (!node || typeof node !== 'object') return;
+		if (Array.isArray(node)) {
+			for (const child of node) visit(child);
+			return;
+		}
+		if (seen.has(node)) return;
+		seen.add(node);
+		if (
+			node.type === 'FunctionDeclaration' ||
+			node.type === 'FunctionExpression' ||
+			node.type === 'ArrowFunctionExpression'
+		) {
+			return;
+		}
+		if (node.type === 'JSXStyleElement') {
+			styles.push(node);
+			return;
+		}
+		for (const [key, value] of Object.entries(node)) {
+			if (SKIP_KEYS.has(key)) continue;
+			visit(value);
+		}
+	};
+	visit(boundary.node.children);
+	styles.sort((left, right) => left.start - right.start);
+	return concatMapped(
+		styles.flatMap((style, index) => [
+			...(index === 0 ? [] : [generatedText('\n')]),
+			authoredText(source, style.start, style.end),
+		]),
+	);
+}
+
+const PERMANENT_STATIC_HYDRATE_MEMBER = '__octanePermanentStatic';
+
+/** Route compiler-proven exact forms through the runtime's hidden component. */
+function permanentStaticTagReplacements(boundary) {
+	const replacements = [];
+	const openingName = boundary.node.openingElement?.name;
+	if (openingName?.end != null) {
+		replacements.push({
+			start: openingName.end,
+			end: openingName.end,
+			value: generatedText('.' + PERMANENT_STATIC_HYDRATE_MEMBER),
+		});
+	}
+	const closingName = boundary.node.closingElement?.name;
+	if (closingName?.end != null) {
+		replacements.push({
+			start: closingName.end,
+			end: closingName.end,
+			value: generatedText('.' + PERMANENT_STATIC_HYDRATE_MEMBER),
+		});
+	}
+	return replacements;
 }
 
 function formatLocation(filename, node) {
@@ -561,6 +696,7 @@ export function analyzeHydrateBoundaries(source, filename = 'unknown.tsrx') {
 				boundary = {
 					children: [],
 					disabled: literalSplitDisabled(node),
+					permanentStatic: isPermanentStaticBoundary(node, imports.neverNames, shadowed),
 					node,
 					parent: parentBoundary,
 					path,
@@ -759,11 +895,20 @@ function collectCaptures(nodes, importBindings, shadowedImports = new Set()) {
 			node.type === 'FunctionExpression' ||
 			node.type === 'ArrowFunctionExpression'
 		) {
-			const bindings = functionVarBindings(node.body);
-			collectBindingNames(node.id, bindings);
-			for (const parameter of node.params ?? []) collectBindingNames(parameter, bindings);
-			scopes.push(bindings);
+			const parameterBindings = new Set();
+			collectBindingNames(node.id, parameterBindings);
+			for (const parameter of node.params ?? []) {
+				collectBindingNames(parameter, parameterBindings);
+			}
+			// A non-simple parameter list executes outside the function body's `var`
+			// environment. Defaults and computed parameter keys can therefore still
+			// reference a module binding with the same name as a body-local `var`.
+			scopes.push(parameterBindings);
 			for (const parameter of node.params ?? []) visitPatternDefaults(parameter);
+			scopes.pop();
+			const bodyBindings = new Set(parameterBindings);
+			for (const binding of functionVarBindings(node.body)) bodyBindings.add(binding);
+			scopes.push(bodyBindings);
 			visit(node.body);
 			scopes.pop();
 			return;
@@ -847,9 +992,117 @@ function declarationBindingSet(node) {
 	return bindings;
 }
 
+// `collectCaptures` deliberately ignores erased TypeScript syntax, but these
+// nodes either emit JavaScript or contain runtime initializers. The permanent-
+// static declaration pruner must not prove exclusivity with an analysis that
+// cannot see those references. Keep the direct subtree erasure/import pruning,
+// but leave module declarations intact whenever one of these forms is present.
+const PRIVATE_DECLARATION_PRUNING_UNSAFE_TS_NODES = new Set([
+	'TSEnumDeclaration',
+	'TSExportAssignment',
+	'TSImportEqualsDeclaration',
+	'TSModuleDeclaration',
+	'TSParameterProperty',
+]);
+
+function canPrunePrivateModuleDeclarations(ast) {
+	let safe = true;
+	const seen = new WeakSet();
+	const visit = (node) => {
+		if (!safe || !node || typeof node !== 'object') return;
+		if (Array.isArray(node)) {
+			for (const child of node) visit(child);
+			return;
+		}
+		if (seen.has(node)) return;
+		seen.add(node);
+		// Direct eval can observe module/function lexical bindings that do not
+		// appear as identifier nodes in the parsed AST. Treat even a shadowed
+		// syntactic `eval(...)` conservatively rather than deleting a declaration
+		// whose name may be read from the string payload.
+		if (
+			node.type === 'CallExpression' &&
+			node.callee?.type === 'Identifier' &&
+			node.callee.name === 'eval'
+		) {
+			safe = false;
+			return;
+		}
+		if (PRIVATE_DECLARATION_PRUNING_UNSAFE_TS_NODES.has(node.type)) {
+			safe = false;
+			return;
+		}
+		for (const [key, value] of Object.entries(node)) {
+			if (SKIP_KEYS.has(key)) continue;
+			visit(value);
+		}
+	};
+	visit(ast);
+	return safe;
+}
+
+function localExportBindings(ast) {
+	const bindings = new Set();
+	for (const statement of ast.body ?? []) {
+		if (statement.type === 'ExportNamedDeclaration' && statement.source == null) {
+			for (const specifier of statement.specifiers ?? []) {
+				if (specifier.local?.name) bindings.add(specifier.local.name);
+			}
+		} else if (
+			statement.type === 'ExportDefaultDeclaration' &&
+			statement.declaration?.type === 'Identifier'
+		) {
+			bindings.add(statement.declaration.name);
+		}
+	}
+	return bindings;
+}
+
+/** Private module declarations that can disappear with a proven server-only graph. */
+function privateModuleDeclarationGraph(ast, importBindings) {
+	const records = [];
+	const exportedBindings = localExportBindings(ast);
+	for (const node of ast.body ?? []) {
+		if (
+			node.type !== 'VariableDeclaration' &&
+			node.type !== 'FunctionDeclaration' &&
+			node.type !== 'ClassDeclaration'
+		) {
+			continue;
+		}
+		if (node.declare === true || (node.type === 'FunctionDeclaration' && node.body == null)) {
+			continue;
+		}
+		const bindings = declarationBindingSet(node);
+		if (bindings.size === 0) continue;
+		records.push({
+			bindings,
+			dependencies: new Set(),
+			// Removing one declarator must not discard an unrelated initializer in
+			// the same authored statement. Keep multi-declarator declarations whole.
+			removable:
+				![...bindings].some((binding) => exportedBindings.has(binding)) &&
+				(node.type !== 'VariableDeclaration' ||
+					((node.declarations?.length ?? 0) === 1 && bindings.size === 1)),
+			node,
+		});
+	}
+	const byBinding = new Map();
+	for (const record of records) {
+		for (const binding of record.bindings) byBinding.set(binding, record);
+	}
+	for (const record of records) {
+		for (const dependency of collectCaptures([record.node], importBindings)) {
+			if (byBinding.has(dependency)) record.dependencies.add(dependency);
+		}
+	}
+	return { byBinding, records };
+}
+
 function movableModuleDeclarations(analysis) {
 	const records = [];
 	const moduleBindings = topLevelBindingNames(analysis.ast);
+	const exportedBindings = localExportBindings(analysis.ast);
 	for (const node of analysis.ast.body ?? []) {
 		if (
 			node.type !== 'VariableDeclaration' &&
@@ -873,6 +1126,7 @@ function movableModuleDeclarations(analysis) {
 		}
 		const bindings = declarationBindingSet(node);
 		if (bindings.size === 0) continue;
+		if ([...bindings].some((binding) => exportedBindings.has(binding))) continue;
 		records.push({
 			bindings,
 			dependencies: new Set(),
@@ -968,11 +1222,13 @@ function createModuleMovePlan(source, filename, analysis, request) {
 
 	const allBindingsByPath = new Map();
 	for (const boundary of analysis.boundaries) {
-		if (!boundary.disabled) allBindingsByPath.set(boundary.path, allBindings);
+		if (!boundary.disabled && !hasPermanentStaticAncestor(boundary)) {
+			allBindingsByPath.set(boundary.path, allBindings);
+		}
 	}
 	const referencesByPath = new Map();
 	for (const boundary of analysis.boundaries) {
-		if (boundary.disabled) continue;
+		if (boundary.disabled || hasPermanentStaticAncestor(boundary)) continue;
 		const provisionalChild = extractedModule(
 			source,
 			filename,
@@ -1030,7 +1286,7 @@ function createModuleMovePlan(source, filename, analysis, request) {
 	const declarationsByPath = new Map();
 	const movedRecords = new Set();
 	for (const boundary of analysis.boundaries) {
-		if (boundary.disabled) continue;
+		if (boundary.disabled || hasPermanentStaticAncestor(boundary)) continue;
 		const records = recordsForReferences(referencesByPath.get(boundary.path) ?? []);
 		if (records.size === 0) continue;
 		const ordered = candidates.records.filter((record) => records.has(record));
@@ -1044,6 +1300,133 @@ function createModuleMovePlan(source, filename, analysis, request) {
 		declarationsByPath,
 		movedRecords: candidates.records.filter((record) => movedRecords.has(record)),
 	};
+}
+
+/**
+ * Delete private declaration chains used only by permanent-static descendants.
+ *
+ * The ordinary import-pruner sees references inside a now-unreachable local
+ * wrapper and conservatively keeps its imports. Build two declaration graphs:
+ * the authored graph identifies the transitive server-only closure, while the
+ * prepared client graph omits references erased by static boundaries. Anything
+ * still referenced by retained client code is protected; the remaining closure
+ * can be removed before import pruning, including side-effectful module edges.
+ */
+function createPermanentStaticRemovalPlan(source, filename, analysis, request, moduleMovePlan) {
+	const staticBoundaries = analysis.boundaries.filter(
+		(boundary) => boundary.permanentStatic && !hasPermanentStaticAncestor(boundary),
+	);
+	if (staticBoundaries.length === 0) return [];
+	if (!canPrunePrivateModuleDeclarations(analysis.ast)) return [];
+
+	const authored = privateModuleDeclarationGraph(analysis.ast, analysis.imports.importBindings);
+	if (authored.records.length === 0) return [];
+	const staticRecords = new Set();
+	const staticQueue = [];
+	const enqueueStatic = (record) => {
+		if (record === undefined || staticRecords.has(record)) return;
+		staticRecords.add(record);
+		staticQueue.push(record);
+	};
+	for (const boundary of staticBoundaries) {
+		for (const reference of collectCaptures(
+			boundary.node.children,
+			analysis.imports.importBindings,
+			boundary.shadowedImports,
+		)) {
+			enqueueStatic(authored.byBinding.get(reference));
+		}
+	}
+	for (let index = 0; index < staticQueue.length; index++) {
+		for (const dependency of staticQueue[index].dependencies) {
+			enqueueStatic(authored.byBinding.get(dependency));
+		}
+	}
+	if (staticRecords.size === 0) return [];
+
+	const preparedReplacements = extractionFrontier(analysis.roots).flatMap((boundary) =>
+		boundaryReplacements(
+			source,
+			boundary,
+			request,
+			analysis.imports.importBindings,
+			moduleMovePlan.bindingsByPath.get(boundary.path),
+		),
+	);
+	for (const record of moduleMovePlan.movedRecords) {
+		preparedReplacements.push({
+			start: record.node.start,
+			end: record.node.end,
+			value: generatedText(''),
+		});
+	}
+	const preparedSource = applyMappedReplacements(
+		source,
+		0,
+		source.length,
+		preparedReplacements,
+	).code;
+	const preparedAst = parseModule(preparedSource, filename);
+	const preparedImports = collectImports(preparedAst);
+	const client = privateModuleDeclarationGraph(preparedAst, preparedImports.importBindings);
+
+	const withoutPrivateDeclarations = applyMappedReplacements(
+		preparedSource,
+		0,
+		preparedSource.length,
+		client.records
+			.filter((record) => record.removable)
+			.map((record) => ({
+				start: record.node.start,
+				end: record.node.end,
+				value: generatedText(''),
+			})),
+	).code;
+	const eagerAst = parseModule(withoutPrivateDeclarations, filename);
+	const eagerReferences = collectCaptures(
+		(eagerAst.body ?? []).filter((node) => node.type !== 'ImportDeclaration'),
+		preparedImports.importBindings,
+	);
+
+	const protectedRecords = new Set();
+	const protectedQueue = [];
+	const enqueueProtected = (record) => {
+		if (record === undefined || protectedRecords.has(record)) return;
+		protectedRecords.add(record);
+		protectedQueue.push(record);
+	};
+	// Declarations outside the static closure remain authored client code even if
+	// a bundler may later prove them dead. Preserve every dependency they still
+	// reference after the boundary rewrite so this pass never leaves a dangling
+	// identifier or changes unrelated module-initialization semantics.
+	for (const record of authored.records) {
+		if (!staticRecords.has(record) || !record.removable) enqueueProtected(record);
+	}
+	for (const reference of eagerReferences) enqueueProtected(authored.byBinding.get(reference));
+	const movedBindings = new Set(
+		moduleMovePlan.movedRecords.flatMap((record) => [...record.bindings]),
+	);
+	for (const binding of movedBindings) enqueueProtected(authored.byBinding.get(binding));
+	for (let index = 0; index < protectedQueue.length; index++) {
+		const authoredRecord = protectedQueue[index];
+		let clientRecord;
+		for (const binding of authoredRecord.bindings) {
+			clientRecord = client.byBinding.get(binding);
+			if (clientRecord !== undefined) break;
+		}
+		if (clientRecord === undefined) continue;
+		for (const dependency of clientRecord.dependencies) {
+			enqueueProtected(authored.byBinding.get(dependency));
+		}
+	}
+
+	return authored.records.filter(
+		(record) =>
+			record.removable &&
+			staticRecords.has(record) &&
+			!protectedRecords.has(record) &&
+			![...record.bindings].some((binding) => movedBindings.has(binding)),
+	);
 }
 
 function sameSourceRequest(filename) {
@@ -1097,6 +1480,25 @@ function boundaryReplacements(
 	importBindings,
 	additionalModuleBindings = new Set(),
 ) {
+	if (boundary.permanentStatic) {
+		const insert = openingInsertOffset(source, boundary.node.openingElement);
+		const replacements = [
+			...permanentStaticTagReplacements(boundary),
+			{
+				start: insert,
+				end: insert,
+				value: generatedText(' children={null}'),
+			},
+		];
+		if (boundary.node.closingElement != null) {
+			replacements.push({
+				start: boundary.node.openingElement.end,
+				end: boundary.node.closingElement.start,
+				value: permanentStaticStyleChildren(source, boundary),
+			});
+		}
+		return replacements;
+	}
 	if (boundary.disabled) return [];
 	assertDirectChildren(boundary, boundary.filename);
 	validateBoundary(boundary, boundary.filename, boundary.hookNames);
@@ -1128,7 +1530,9 @@ function boundaryReplacements(
 function extractionFrontier(boundaries) {
 	const output = [];
 	const visit = (boundary) => {
-		if (boundary.disabled) {
+		if (boundary.permanentStatic) {
+			output.push(boundary);
+		} else if (boundary.disabled) {
 			for (const child of boundary.children) visit(child);
 		} else {
 			output.push(boundary);
@@ -1136,6 +1540,13 @@ function extractionFrontier(boundaries) {
 	};
 	for (const boundary of boundaries) visit(boundary);
 	return output;
+}
+
+function hasPermanentStaticAncestor(boundary) {
+	for (let parent = boundary.parent; parent !== null; parent = parent.parent) {
+		if (parent.permanentStatic) return true;
+	}
+	return false;
 }
 
 function uniqueGeneratedName(source, preferred) {
@@ -1262,6 +1673,10 @@ export function prepareHydrateBoundaries(source, filename, boundaryPath = null) 
 	}
 	const request = sameSourceRequest(filename);
 	const moduleMovePlan = createModuleMovePlan(source, filename, analysis, request);
+	const permanentStaticRemoved =
+		boundaryPath === null
+			? createPermanentStaticRemovalPlan(source, filename, analysis, request, moduleMovePlan)
+			: [];
 	let transformed;
 	if (boundaryPath === null) {
 		const replacements = extractionFrontier(analysis.roots).flatMap((boundary) =>
@@ -1280,8 +1695,20 @@ export function prepareHydrateBoundaries(source, filename, boundaryPath = null) 
 				value: generatedText(''),
 			});
 		}
+		for (const record of permanentStaticRemoved) {
+			replacements.push({
+				start: record.node.start,
+				end: record.node.end,
+				value: generatedText(''),
+			});
+		}
 		if (replacements.length === 0) return null;
-		transformed = applyMappedReplacements(source, 0, source.length, replacements);
+		transformed = applyMappedReplacements(
+			source,
+			0,
+			source.length,
+			permanentStaticRemoved.length === 0 ? replacements : outermostReplacements(replacements),
+		);
 		transformed = pruneUnusedImports(transformed, filename, true);
 	} else {
 		const boundary = analysis.boundaries.find((candidate) => candidate.path === boundaryPath);
@@ -1310,7 +1737,7 @@ export function prepareHydrateBoundaries(source, filename, boundaryPath = null) 
 		mappingNeedles:
 			boundaryPath === null
 				? extractionFrontier(analysis.roots).flatMap((boundary) =>
-						boundaryMappingNeedles(source, boundary),
+						boundary.permanentStatic ? [] : boundaryMappingNeedles(source, boundary),
 					)
 				: boundaryMappingNeedles(
 						source,
@@ -1450,6 +1877,9 @@ export function prepareServerHydrateBoundaries(source, filename) {
 	const constObjects = collectSingleUseConstObjects(analysis.ast);
 	const replacements = [];
 	for (const boundary of analysis.boundaries) {
+		if (boundary.permanentStatic) {
+			replacements.push(...permanentStaticTagReplacements(boundary));
+		}
 		for (const attribute of boundary.node.openingElement?.attributes ?? []) {
 			if (jsxAttributeName(attribute) === 'fallback') {
 				replacements.push({
@@ -1483,16 +1913,12 @@ export function prepareServerHydrateBoundaries(source, filename) {
 	// Removing an outer fallback also removes any Hydrate authored inside that
 	// fallback. Keep only outermost ranges so nested client-only fallbacks cannot
 	// produce overlapping textual edits.
-	const outermost = [];
-	let coveredUntil = -1;
-	for (const replacement of replacements.sort(
-		(left, right) => left.start - right.start || right.end - left.end,
-	)) {
-		if (replacement.start < coveredUntil) continue;
-		outermost.push(replacement);
-		coveredUntil = replacement.end;
-	}
-	const transformed = applyMappedReplacements(source, 0, source.length, outermost);
+	const transformed = applyMappedReplacements(
+		source,
+		0,
+		source.length,
+		outermostReplacements(replacements),
+	);
 	return {
 		boundaryPath: null,
 		map: sourceMapFromOrigins(transformed.code, transformed.origins, source, filename),

--- a/packages/octane/src/constants.ts
+++ b/packages/octane/src/constants.ts
@@ -96,19 +96,26 @@ export const HYDRATION_RANGE_BOUNDARY: unique symbol = Symbol.for(
 );
 
 // ── Deferred hydration boundary protocol (`<Hydrate>`) ──────────────────────────────
-// The boundary is a persistent real `<div>`: visibility/interaction strategies
-// and procedural prefetching need an Element to observe. During the initial
-// root hydration the client adopts that wrapper but leaves its child block
-// dormant. The attributes below carry the stable boundary id, strategy kind,
-// and number of useId slots reserved by the dormant child. Resolved `use()`
-// values are removed from the root seed stream and stored in a direct-child
-// JSON script so the later subtree hydration owns precisely its own seeds.
+// An ordinary boundary is a persistent real `<div>`: visibility/interaction
+// strategies and procedural prefetching need an Element to observe. During the
+// initial root hydration the client adopts that wrapper but leaves its child
+// block dormant. The attributes below carry the stable boundary id, strategy
+// kind, and number of useId slots reserved by the dormant child. Resolved `use()`
+// values are removed from the root seed stream and stored in a direct-child JSON
+// script so the later subtree hydration owns precisely its own seeds. The exact
+// compiler-proven permanent-static form instead uses the comment protocol below.
+/** Comment prefix carrying skipped `useId()` slots for a wrapper-free permanent-static range. */
+export const HYDRATE_STATIC_ID_COUNT_PREFIX = 'octane-static-hydrate:';
+/** Closing comment for a wrapper-free permanent-static range. */
+export const HYDRATE_STATIC_END = '/octane-static-hydrate';
 /** Stable id of a server-rendered deferred hydration boundary. */
 export const HYDRATE_ID_ATTR = 'data-octane-hydrate-id';
 /** Serialized strategy kind (`visible`, `idle`, `dynamic`, …). */
 export const HYDRATE_WHEN_ATTR = 'data-octane-hydrate-when';
 /** Number of `useId()` slots consumed while rendering the deferred child. */
 export const HYDRATE_ID_COUNT_ATTR = 'data-octane-hydrate-id-count';
+/** Opaque renderer stream token authenticating pending descendants owned by this boundary. */
+export { HYDRATE_STREAM_TOKEN_ATTR } from './stream-protocol.js';
 /** Direct-child JSON script carrying this boundary's `use()` seed slice. */
 export const HYDRATE_SEED_ATTR = 'data-octane-hydrate-seed';
 
@@ -122,7 +129,7 @@ export const HYDRATE_SEED_ATTR = 'data-octane-hydrate-seed';
 // replaces the template with a `<!--oct-seed:N-->` comment the client's
 // hydration uses to scope that boundary's seeds.
 /** Sentinel <template> attribute marking a pending streamed boundary. */
-export const STREAM_BOUNDARY_ATTR = 'data-oct-b';
+export { STREAM_BOUNDARY_ATTR } from './stream-protocol.js';
 /** Hidden segment container attribute carrying a completed boundary's content. */
 export const STREAM_SEGMENT_ATTR = 'data-oct-s';
 /** Per-boundary seed-JSON script attribute (inside the segment). */

--- a/packages/octane/src/hydration/event-capture.ts
+++ b/packages/octane/src/hydration/event-capture.ts
@@ -2,6 +2,7 @@ import {
 	HYDRATE_DEFAULT_INTERACTION_EVENTS,
 	HYDRATE_INTERACTION_EVENTS_ATTR,
 } from './interaction-config.js';
+import { HYDRATE_STREAM_TOKEN_ATTR, isRendererStreamBoundaryTemplate } from '../stream-protocol.js';
 
 const HYDRATE_MARKER_SELECTOR = '[data-octane-hydrate-id]';
 const HYDRATE_WHEN_ATTR = 'data-octane-hydrate-when';
@@ -53,19 +54,28 @@ const HYDRATE_DELEGATED_DYNAMIC_MARKERS = /* @__PURE__ */ new WeakSet<Element>()
 const HYDRATE_HANDLED_INTENT_EVENTS = /* @__PURE__ */ new WeakSet<Event>();
 const HYDRATE_INTENT_DOCUMENTS = /* @__PURE__ */ new WeakSet<Document>();
 
-/** @internal Resolve an event target to an element-only path beneath a marker. */
+/**
+ * @internal Resolve an event target to an element-only path beneath a marker.
+ * Renderer stream sentinels are omitted so the address survives their reveal.
+ */
 export function hydrationEventPathWithin(
 	root: Element,
 	target: EventTarget | null,
 ): number[] | null {
 	if (!isHydrationNode(target)) return null;
+	const streamToken = root.getAttribute(HYDRATE_STREAM_TOKEN_ATTR);
 	const path: number[] = [];
 	let node: Element | null = isHydrationElement(target) ? target : target.parentElement;
 	while (node !== root) {
 		const parent: Element | null = node?.parentElement ?? null;
 		if (parent === null) return null;
-		const index = Array.prototype.indexOf.call(parent.children, node) as number;
-		if (index < 0) return null;
+		let index = 0;
+		let sibling = parent.firstElementChild;
+		while (sibling !== null && sibling !== node) {
+			if (!isRendererStreamBoundaryTemplate(sibling, streamToken)) index++;
+			sibling = sibling.nextElementSibling;
+		}
+		if (sibling === null) return null;
 		path.push(index);
 		node = parent;
 	}

--- a/packages/octane/src/hydration/types.ts
+++ b/packages/octane/src/hydration/types.ts
@@ -113,5 +113,5 @@ export type HydrateOptions =
 	  });
 
 export type HydrateProps = HydrateOptions & {
-	children: unknown;
+	children?: unknown;
 };

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -35,9 +35,12 @@ import {
 	REJECTION_SENTINEL_KEY,
 	EXTERNAL_HYDRATION_PROMISE,
 	HYDRATION_RANGE_BOUNDARY,
+	HYDRATE_STATIC_ID_COUNT_PREFIX,
+	HYDRATE_STATIC_END,
 	HYDRATE_ID_ATTR,
 	HYDRATE_WHEN_ATTR,
 	HYDRATE_ID_COUNT_ATTR,
+	HYDRATE_STREAM_TOKEN_ATTR,
 	HYDRATE_SEED_ATTR,
 	STREAM_BOUNDARY_ATTR,
 	STREAM_SEGMENT_ATTR,
@@ -126,6 +129,11 @@ let NONCE_ATTR = '';
 // non-hydratable HTML (emails / static pages). It is part of the ambient pass
 // snapshot so a nested hydratable render cannot inherit a static outer pass.
 let MARKERS = true;
+// Exact wrapper-free permanent-static Hydrate children are server-owned. Any
+// ordinary Hydrate reached beneath them keeps its layout wrapper and SSR try
+// shape, but publishes a never marker so pre-root interaction capture cannot
+// enqueue work whose client component graph was erased.
+let PERMANENT_STATIC_HYDRATE_DEPTH = 0;
 // Accumulates hoisted `<head>` content (`<title>`/`<meta>`/`<link>`) during the
 // active render pass (a mutable container, mirroring CSS's mutable Map, so a
 // per-pass local capture keeps accumulating via `HEAD.html +=` even though
@@ -2915,17 +2923,32 @@ function ssrChildrenHtml(children: unknown, scope: SSRScope): string {
 	return ssrChild(children, scope);
 }
 
+function streamTokenForPendingHtml(html: string): string | null {
+	const stream = STREAM;
+	return stream !== null && html.includes(STREAM_BOUNDARY_ATTR + '="' + stream.token + '-')
+		? stream.token
+		: null;
+}
+
 /** Serialize runtime-owned and strategy-supplied attributes for `<Hydrate>`. */
 function ssrHydrateAttrs(
 	id: string,
 	when: HydrationStrategy | (() => HydrationStrategy),
 	idCount: number,
+	permanentStaticAncestor: boolean = false,
+	streamToken: string | null = null,
 ): string {
 	const direct = typeof when !== 'function' && when !== null ? when : null;
 	let attrs =
 		ssrAttr(HYDRATE_ID_ATTR, id, 'div') +
-		ssrAttr(HYDRATE_WHEN_ATTR, direct?._t ?? 'dynamic', 'div') +
+		ssrAttr(
+			HYDRATE_WHEN_ATTR,
+			permanentStaticAncestor ? 'never' : (direct?._t ?? 'dynamic'),
+			'div',
+		) +
 		ssrAttr(HYDRATE_ID_COUNT_ATTR, idCount, 'div');
+	if (streamToken !== null) attrs += ssrAttr(HYDRATE_STREAM_TOKEN_ATTR, streamToken, 'div');
+	if (permanentStaticAncestor) return attrs;
 	const strategyAttrs = direct?._a?.();
 	if (strategyAttrs === undefined) return attrs;
 
@@ -2936,6 +2959,7 @@ function ssrHydrateAttrs(
 			name === HYDRATE_ID_ATTR ||
 			name === HYDRATE_WHEN_ATTR ||
 			name === HYDRATE_ID_COUNT_ATTR ||
+			name === HYDRATE_STREAM_TOKEN_ATTR ||
 			name === HYDRATE_SEED_ATTR ||
 			!VALID_ATTR_NAME.test(name)
 		)
@@ -2957,10 +2981,50 @@ function ssrHydrateAttrs(
  * read browser state, so only a direct strategy descriptor contributes `_a()`
  * attributes and its concrete strategy kind.
  */
-export const Hydrate = /* @__PURE__ */ markComponentFlags(
+const PermanentStaticHydrate = /* @__PURE__ */ markComponentFlags(
+	function PermanentStaticHydrate(props: HydrateProps, scope: SSRScope): string {
+		// Match ordinary Hydrate's own useId. Child IDs are counted separately and
+		// reserved by the client-side paired private range marker.
+		useId();
+		const inheritedPermanentStatic = PERMANENT_STATIC_HYDRATE_DEPTH !== 0;
+		PERMANENT_STATIC_HYDRATE_DEPTH++;
+		try {
+			// The outer static range already erases this client subtree and reserves
+			// all descendant IDs. Collapse nested exact boundaries to their authored
+			// children instead of leaving orphaned private sidecars.
+			if (inheritedPermanentStatic || !MARKERS) return ssrChildrenHtml(props.children, scope);
+			const childIdStart = ID_COUNTER;
+			const serialStart = SERIAL?.length ?? 0;
+			const children = ssrBlock(
+				ssrTry(
+					scope,
+					'jsx-static-hydrate',
+					(_arg, childScope) => ssrChildrenHtml(props.children, childScope),
+					null,
+					null,
+				),
+			);
+			const idCount = ID_COUNTER - childIdStart;
+			if (SERIAL !== null) SERIAL.splice(serialStart);
+			const streamToken = streamTokenForPendingHtml(children);
+			const markerToken = streamToken === null ? '' : streamToken + ':';
+			const endToken = streamToken === null ? '' : ':' + streamToken;
+			return (
+				`<!--${HYDRATE_STATIC_ID_COUNT_PREFIX}${markerToken}${idCount}-->` +
+				children +
+				`<!--${HYDRATE_STATIC_END}${endToken}-->`
+			);
+		} finally {
+			PERMANENT_STATIC_HYDRATE_DEPTH--;
+		}
+	},
+	COMPONENT_FLAG_BOUNDARY,
+	'PermanentStaticHydrate',
+);
+
+const hydrate = /* @__PURE__ */ markComponentFlags(
 	function Hydrate(props: HydrateProps, scope: SSRScope): string {
 		const id = useId();
-
 		// The client always creates an HTMLDivElement. Force the same namespace for
 		// SSR children and attribute semantics instead of inheriting SVG/MathML from
 		// the call site. Direct placement in foreign content remains unsupported: an
@@ -2992,9 +3056,16 @@ export const Hydrate = /* @__PURE__ */ markComponentFlags(
 					);
 					const idCount = ID_COUNTER - childIdStart;
 					const childSeeds = SERIAL === null ? [] : SERIAL.splice(serialStart);
-					const attrs = ssrHydrateAttrs(id, props.when, idCount);
+					const permanentStaticAncestor = PERMANENT_STATIC_HYDRATE_DEPTH !== 0;
+					const attrs = ssrHydrateAttrs(
+						id,
+						props.when,
+						idCount,
+						permanentStaticAncestor,
+						streamTokenForPendingHtml(children),
+					);
 					const seedSidecar =
-						childSeeds.length === 0
+						permanentStaticAncestor || childSeeds.length === 0
 							? ''
 							: '<script type="application/json" ' +
 								HYDRATE_SEED_ATTR +
@@ -3011,6 +3082,9 @@ export const Hydrate = /* @__PURE__ */ markComponentFlags(
 	COMPONENT_FLAG_BOUNDARY,
 	'Hydrate',
 );
+
+Object.defineProperty(hydrate, '__octanePermanentStatic', { value: PermanentStaticHydrate });
+export const Hydrate: ServerComponent = hydrate;
 
 /**
  * `<Suspense fallback={…}>…</Suspense>` — the JSX built-in mirror of the
@@ -4764,6 +4838,7 @@ interface Ambient {
 	css: Map<string, string> | null;
 	nonceAttr: string;
 	markers: boolean;
+	permanentStaticHydrateDepth: number;
 	head: HeadBuffer | null;
 	susp: SuspendedList | null;
 	res: ResolvedMap | null;
@@ -4790,6 +4865,7 @@ function saveAmbient(): Ambient {
 		css: CSS,
 		nonceAttr: NONCE_ATTR,
 		markers: MARKERS,
+		permanentStaticHydrateDepth: PERMANENT_STATIC_HYDRATE_DEPTH,
 		head: HEAD,
 		susp: SUSPENDED,
 		res: RESOLVED,
@@ -4817,6 +4893,7 @@ function restoreAmbient(a: Ambient): void {
 	CSS = a.css;
 	NONCE_ATTR = a.nonceAttr;
 	MARKERS = a.markers;
+	PERMANENT_STATIC_HYDRATE_DEPTH = a.permanentStaticHydrateDepth;
 	HEAD = a.head;
 	SUSPENDED = a.susp;
 	RESOLVED = a.res;
@@ -4863,6 +4940,7 @@ function runFullFramedPass(
 	NONCE_ATTR = nonceAttr;
 	ASYNC_SCOPE = '';
 	MARKERS = markers;
+	PERMANENT_STATIC_HYDRATE_DEPTH = 0;
 	VT_SSR_TRY_SEQ = 0;
 	VT_SSR_HAS_CANDIDATES = false;
 	VT_SSR_STACK.length = 0;
@@ -4954,6 +5032,7 @@ function runDiscoveryRound(
 	NONCE_ATTR = '';
 	ASYNC_SCOPE = '';
 	MARKERS = true;
+	PERMANENT_STATIC_HYDRATE_DEPTH = 0;
 	VT_SSR_TRY_SEQ = 0;
 	VT_SSR_HAS_CANDIDATES = false;
 	VT_SSR_STACK.length = 0;
@@ -5599,6 +5678,8 @@ interface StreamBoundary {
 	errorReported?: boolean;
 	/** Whether its client-render recovery instruction was accepted by the transport. */
 	errorFlushed?: boolean;
+	/** The client graph is erased, so failure retains the authored server fallback. */
+	serverOwnedStatic: boolean;
 	/** Inner branch-range html (`<!--[-->…<!--]-->`) from the resolving pass. */
 	html: string;
 	/** This boundary's `use()` seed slice from the resolving pass. */
@@ -5914,7 +5995,7 @@ export function ssrTry(
 								])
 							: inner;
 					if (SERIAL !== null) {
-						entry.seeds = SERIAL.slice(serialStart);
+						if (!entry.serverOwnedStatic) entry.seeds = SERIAL.slice(serialStart);
 						SERIAL.length = serialStart;
 					}
 					pruneUnrepresentedStreamDescendants(stream!, key, entry.html);
@@ -5941,6 +6022,7 @@ export function ssrTry(
 							id: stream.token + '-' + order.toString(36),
 							order,
 							state: 'pending',
+							serverOwnedStatic: PERMANENT_STATIC_HYDRATE_DEPTH !== 0,
 							html: '',
 							seeds: [],
 							pendingIdOffset,
@@ -5961,13 +6043,18 @@ export function ssrTry(
 				// record. The client replays that exact seed order, throws at the same
 				// use(), then hydrates the already-streamed catch arm (whose own use() calls
 				// consume any seeds appended while rendering it below).
-				const caughtSeeds = entry !== undefined && SERIAL !== null ? SERIAL.slice(serialStart) : [];
+				const caughtSeeds =
+					entry !== undefined && !entry.serverOwnedStatic && SERIAL !== null
+						? SERIAL.slice(serialStart)
+						: [];
 				if (entry !== undefined && SERIAL !== null) SERIAL.length = serialStart;
 				const inner = ssrBlock(withCatchArm(() => catchFn(e, scope, NOOP)));
 				if (entry !== undefined) {
 					if (entry.state !== 'done') {
 						if (SERIAL !== null) {
-							caughtSeeds.push(...SERIAL.slice(serialStart));
+							if (!entry.serverOwnedStatic) {
+								caughtSeeds.push(...SERIAL.slice(serialStart));
+							}
 							SERIAL.length = serialStart;
 						}
 						entry.state = 'done';
@@ -5988,6 +6075,7 @@ export function ssrTry(
 				// client render. Buffered renderers still rethrow below because they have
 				// no progressive recovery channel.
 				if (SERIAL !== null) SERIAL.length = serialStart;
+				if (entry === undefined && PERMANENT_STATIC_HYDRATE_DEPTH !== 0) throw e;
 				if (entry === undefined) {
 					const pendingIdOffset = Math.max(0, ID_COUNTER - outerIdCounter);
 					restoreOuterIds();
@@ -5996,6 +6084,7 @@ export function ssrTry(
 						id: stream.token + '-' + order.toString(36),
 						order,
 						state: 'errored',
+						serverOwnedStatic: false,
 						error: e,
 						html: '',
 						seeds: [],
@@ -6034,7 +6123,9 @@ export function ssrTry(
 // `<!--oct-seed:id-->` scoping comment. `id` is the full render-scoped opaque
 // key, so both document queries and the seed stash remain disjoint when output
 // from multiple streams is composed into one page. $OCTRX(id) marks the
-// boundary errored (hydration client-renders it via mismatch recovery).
+// boundary errored (hydration client-renders it via mismatch recovery). A
+// truthy second argument removes only a server-owned permanent-static sentinel,
+// retaining its already-flushed fallback because no client graph can recover it.
 const STREAM_RUNTIME_JS =
 	'(function(){var d=document;var S=window.$OCTS=window.$OCTS||{};' +
 	// Legacy `[` / `]` means one physical range; `[N` / `]N` is canonical only
@@ -6066,11 +6157,11 @@ const STREAM_RUNTIME_JS =
 	STREAM_SEED_COMMENT +
 	'"+id),t);' +
 	's.parentNode.removeChild(s);};' +
-	'window.$OCTRX=function(id){' +
+	'window.$OCTRX=function(id,so){' +
 	"var t=d.querySelector('template[" +
 	STREAM_BOUNDARY_ATTR +
 	"=\"'+id+'\"]');" +
-	'if(t)t.setAttribute("data-oct-err","");};' +
+	'if(t){if(so)t.remove();else t.setAttribute("data-oct-err","");}};' +
 	'})();';
 
 interface StreamSink {
@@ -6247,12 +6338,14 @@ function segmentChunk(b: StreamBoundary, nonceAttr: string): string {
 }
 
 function boundaryErrorChunk(b: StreamBoundary, nonceAttr: string): string {
+	const serverOwnedStatic = b.serverOwnedStatic ? ',1' : '';
 	return (
 		'<script ' +
 		STREAM_SCRIPT_ATTR +
 		nonceAttr +
 		'>$OCTRX(' +
 		JSON.stringify(b.id).replace(/</g, '\\u003c') +
+		serverOwnedStatic +
 		')</script>'
 	);
 }

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -15,6 +15,8 @@
 
 import {
 	SUSPENSE_SCRIPT_ATTR,
+	HYDRATE_STATIC_ID_COUNT_PREFIX,
+	HYDRATE_STATIC_END,
 	HYDRATE_ID_ATTR,
 	HYDRATE_WHEN_ATTR,
 	HYDRATE_ID_COUNT_ATTR,
@@ -86,6 +88,12 @@ import {
 	markComponentFlags,
 } from './component-flags.js';
 import { formatClientError } from './error-codes.client.generated.js';
+import {
+	HYDRATE_STREAM_TOKEN_ATTR,
+	isRendererStreamBoundaryTemplate,
+	isRendererStreamToken,
+	rendererRangeClose,
+} from './stream-protocol.js';
 
 export { EXTERNAL_HYDRATION_PROMISE, HYDRATION_RANGE_BOUNDARY };
 
@@ -4965,6 +4973,9 @@ const HYDRATE_STRATEGY_TYPES = /* @__PURE__ */ new Set<HydrationWhen>([
 // Boundary-local interaction capture uses the same marker protocol as the
 // lightweight pre-root event-capture module.
 const HYDRATE_MARKER_SELECTOR = '[data-octane-hydrate-id]';
+const HYDRATE_STREAM_ERROR_ATTR = 'data-oct-err';
+const HYDRATE_STREAM_BOUNDARY_SELECTOR = `template[${STREAM_BOUNDARY_ATTR}]`;
+const HYDRATE_STREAM_SCAN_MASK = 1 /* SHOW_ELEMENT */ | 128; /* SHOW_COMMENT */
 
 type HydrateLoadResult = ComponentBody | { default: ComponentBody };
 
@@ -5019,8 +5030,84 @@ interface HydrateSlot {
 	replays: HydrationReplayIntent[];
 }
 
+// Created only for the rare activation that races a renderer stream. Keep the
+// ordinary Hydrate state shape unchanged and retain no completed boundaries.
+let hydrateStreamWaitCleanups: WeakMap<HydrateSlot, () => void> | null = null;
+
 function hydrateStrategyType(when: InternalHydrateProps['when']): HydrationWhen {
 	return typeof when === 'function' ? 'dynamic' : (when?._t ?? 'dynamic');
+}
+
+function reserveHydrationIds(ids: RootIdState, count: number): void {
+	let owner = ids;
+	while (count > 0) {
+		while (owner.limit !== undefined && owner.next >= owner.limit && owner.overflow !== undefined) {
+			owner = owner.overflow;
+		}
+		if (owner.limit === undefined || owner.overflow === undefined) {
+			owner.next += count;
+			return;
+		}
+		const available = owner.limit - owner.next;
+		const reserved = Math.min(count, available);
+		owner.next += reserved;
+		count -= reserved;
+	}
+}
+
+interface PermanentStaticHydrationMarker {
+	idCount: number;
+	streamToken: string | null;
+}
+
+function parsePermanentStaticHydrationMarker(data: string): PermanentStaticHydrationMarker | null {
+	if (!data.startsWith(HYDRATE_STATIC_ID_COUNT_PREFIX)) return null;
+	const payload = data.slice(HYDRATE_STATIC_ID_COUNT_PREFIX.length);
+	let rawCount = payload;
+	let streamToken: string | null = null;
+	const separator = payload.lastIndexOf(':');
+	if (separator !== -1) {
+		streamToken = payload.slice(0, separator);
+		rawCount = payload.slice(separator + 1);
+		if (!isRendererStreamToken(streamToken)) return null;
+	}
+	if (!/^(?:0|[1-9]\d*)$/.test(rawCount)) return null;
+	const idCount = Number(rawCount);
+	return Number.isSafeInteger(idCount) ? { idCount, streamToken } : null;
+}
+
+function permanentStaticHydrationRangeEnd(
+	marker: Comment,
+	expectedStreamToken?: string,
+): { end: Comment; idCount: number } | null {
+	const parsed = parsePermanentStaticHydrationMarker(marker.data);
+	if (
+		parsed === null ||
+		(expectedStreamToken !== undefined && parsed.streamToken !== expectedStreamToken)
+	)
+		return null;
+	const childClose = rendererRangeClose(marker.nextSibling);
+	const end = childClose?.nextSibling;
+	const expectedEnd =
+		parsed.streamToken === null
+			? HYDRATE_STATIC_END
+			: HYDRATE_STATIC_END + ':' + parsed.streamToken;
+	return end?.nodeType === 8 && (end as Comment).data === expectedEnd
+		? { end: end as Comment, idCount: parsed.idCount }
+		: null;
+}
+
+function preservePermanentStaticHydrationRange(scope: Scope): void {
+	const hydration = activeHydration();
+	if (hydration === null) return;
+	const marker = hydration.node;
+	if (marker?.nodeType !== 8) return;
+	const range = permanentStaticHydrationRangeEnd(marker as Comment);
+	if (range === null) return;
+	reserveHydrationIds(scope.block.idState, range.idCount);
+	hydration.node = marker.nextSibling;
+	(marker as ChildNode).remove();
+	range.end.remove();
 }
 
 function resolveHydrateStrategy(state: HydrateSlot): HydrationStrategy {
@@ -5116,6 +5203,7 @@ function hydrateBoundaryBody(state: HydrateSlot): ComponentBody {
 
 function failHydrateBoundary(state: HydrateSlot, error: unknown): void {
 	if (state.hasError || state.block.disposed) return;
+	cleanupHydrateStreamWait(state);
 	state.hasError = true;
 	state.error = error;
 	scheduleRender(state.parentBlock);
@@ -5223,6 +5311,7 @@ function cleanupHydrateInstallers(state: HydrateSlot): void {
 }
 
 function invalidateHydrateActivation(state: HydrateSlot): void {
+	cleanupHydrateStreamWait(state);
 	state.activationGeneration++;
 	state.activationRequested = false;
 	state.activationReady = false;
@@ -5242,16 +5331,26 @@ function invalidateHydrateActivation(state: HydrateSlot): void {
 
 function teardownHydrateBoundary(state: HydrateSlot): void {
 	cleanupHydrateInstallers(state);
+	cleanupHydrateStreamWait(state);
 	state.prefetchAbort?.abort();
 	resolveHydrateWaiters(state, 'abort');
 	unregisterHydrationIntentBoundary(state.wrapper, state.intentBoundary);
 }
 
 function resolveEventPath(root: Element, path: number[]): Element | null {
+	const streamToken = root.getAttribute(HYDRATE_STREAM_TOKEN_ATTR);
 	let node: Element = root;
 	for (let i = 0; i < path.length; i++) {
-		const next = node.children[path[i]];
-		if (next === undefined) return null;
+		let index = path[i];
+		let next = node.firstElementChild;
+		while (next !== null) {
+			if (!isRendererStreamBoundaryTemplate(next, streamToken)) {
+				if (index === 0) break;
+				index--;
+			}
+			next = next.nextElementSibling;
+		}
+		if (next === null) return null;
 		node = next;
 	}
 	return node;
@@ -5358,6 +5457,112 @@ function installHydrateInteraction(state: HydrateSlot, strategy: HydrationStrate
 	};
 }
 
+function isCanonicalHydrateIdCount(value: string | null): boolean {
+	if (value === null || !/^(?:0|[1-9]\d*)$/.test(value)) return false;
+	return Number.isSafeInteger(Number(value));
+}
+
+function isDormantServerHydrateOwner(element: Element, streamToken: string): boolean {
+	return (
+		element.localName === 'div' &&
+		element.getAttribute(HYDRATE_STREAM_TOKEN_ATTR) === streamToken &&
+		element.hasAttribute(HYDRATE_ID_ATTR) &&
+		element.hasAttribute(HYDRATE_WHEN_ATTR) &&
+		isCanonicalHydrateIdCount(element.getAttribute(HYDRATE_ID_COUNT_ATTR)) &&
+		rendererRangeClose(element.firstChild) !== null
+	);
+}
+
+function hydrateStreamBoundaryOwnedByState(
+	boundary: Element,
+	state: HydrateSlot,
+	streamToken: string,
+): boolean {
+	let owner = boundary.parentElement;
+	while (owner !== null && owner !== state.wrapper) {
+		// Only a complete token-bound server shape creates an ownership barrier.
+		// Authored lookalike data attributes remain ordinary descendants.
+		if (isDormantServerHydrateOwner(owner, streamToken)) return false;
+		owner = owner.parentElement;
+	}
+	return owner === state.wrapper;
+}
+
+function hasPendingHydrateStreamReveal(state: HydrateSlot): boolean {
+	const streamToken = state.wrapper.getAttribute(HYDRATE_STREAM_TOKEN_ATTR);
+	if (!isRendererStreamToken(streamToken)) return false;
+	// querySelector is the fast native rejection path for the overwhelmingly
+	// common non-streamed boundary. Only pay the ownership/range-aware JS walk
+	// after proving at least one renderer stream sentinel remains below it.
+	if (state.wrapper.querySelector(HYDRATE_STREAM_BOUNDARY_SELECTOR) === null) return false;
+	const walker = state.wrapper.ownerDocument.createTreeWalker(
+		state.wrapper,
+		HYDRATE_STREAM_SCAN_MASK,
+	);
+	let node: Node | null;
+	while ((node = walker.nextNode()) !== null) {
+		if (node.nodeType === 8) {
+			const range = permanentStaticHydrationRangeEnd(node as Comment, streamToken);
+			// The compiler-proven static range has no client owner. Skip its exact
+			// balanced server range so a descendant reveal cannot block this boundary.
+			if (range !== null) walker.currentNode = range.end;
+			continue;
+		}
+		const boundary = node as Element;
+		if (
+			isRendererStreamBoundaryTemplate(boundary, streamToken) &&
+			!boundary.hasAttribute(HYDRATE_STREAM_ERROR_ATTR) &&
+			hydrateStreamBoundaryOwnedByState(boundary, state, streamToken)
+		)
+			return true;
+	}
+	return false;
+}
+
+function cleanupHydrateStreamWait(state: HydrateSlot): void {
+	const cleanup = hydrateStreamWaitCleanups?.get(state);
+	hydrateStreamWaitCleanups?.delete(state);
+	cleanup?.();
+}
+
+/**
+ * A dormant Hydrate boundary still leaves its server DOM under the streaming
+ * renderer's ownership. If interaction opens it while a nested Suspense reveal
+ * is pending, wait for the renderer to either swap that range or mark it for
+ * client recovery. Pending ranges below another dormant Hydrate boundary belong
+ * to that boundary instead and must not block this one.
+ */
+function beginHydrateStreamWait(state: HydrateSlot): Promise<void> | null {
+	if (!state.serverPreserved || !hasPendingHydrateStreamReveal(state)) return null;
+
+	return new Promise<void>((resolve) => {
+		let settled = false;
+		let observer!: MutationObserver;
+		const finish = () => {
+			if (settled) return;
+			settled = true;
+			observer.disconnect();
+			if (hydrateStreamWaitCleanups?.get(state) === finish) hydrateStreamWaitCleanups.delete(state);
+			resolve();
+		};
+		const MutationObserverImpl =
+			state.wrapper.ownerDocument.defaultView?.MutationObserver ?? MutationObserver;
+		observer = new MutationObserverImpl(() => {
+			if (!hasPendingHydrateStreamReveal(state)) finish();
+		});
+
+		(hydrateStreamWaitCleanups ??= new WeakMap()).set(state, finish);
+		observer.observe(state.wrapper, {
+			attributes: true,
+			attributeFilter: [HYDRATE_STREAM_ERROR_ATTR],
+			childList: true,
+			subtree: true,
+		});
+		// The reveal may have landed after the initial scan but before observation.
+		if (!hasPendingHydrateStreamReveal(state)) finish();
+	});
+}
+
 function requestHydrateBoundary(state: HydrateSlot): void {
 	if (state.hydrated || state.activationRequested || state.block.disposed) return;
 	// A direct strategy prop can become never() after an earlier installer was
@@ -5370,6 +5575,8 @@ function requestHydrateBoundary(state: HydrateSlot): void {
 	resolveHydrateWaiters(state, 'hydrate');
 
 	const waits: Promise<void>[] = [];
+	const streamReveal = beginHydrateStreamWait(state);
+	if (streamReveal !== null) waits.push(streamReveal);
 	const prefetch = beginProceduralHydratePrefetch(state);
 	if (prefetch !== null) waits.push(prefetch);
 	const preload = beginHydratePreload(state);
@@ -5637,7 +5844,17 @@ function notifyHydrateBoundary(state: HydrateSlot): void {
 	state.replays = [];
 	for (let i = 0; i < replays.length; i++) {
 		const replay = replays[i];
-		const target = resolveEventPath(state.wrapper, replay.path);
+		const originalTarget = replay.event.target;
+		// A streamed reveal can change the number of elements before an unrelated
+		// live sibling. Preserve exact intent whenever its original element survived;
+		// the filtered logical path remains the fallback for replaced server arms.
+		const target =
+			originalTarget !== null &&
+			typeof (originalTarget as Node).nodeType === 'number' &&
+			(originalTarget as Node).nodeType === 1 &&
+			state.wrapper.contains(originalTarget as Node)
+				? (originalTarget as Element)
+				: resolveEventPath(state.wrapper, replay.path);
 		if (target !== null) {
 			const event = replay.event;
 			// `click` is the platform exception among untrusted events: dispatching
@@ -5657,11 +5874,16 @@ function notifyHydrateBoundary(state: HydrateSlot): void {
 
 /**
  * Defer the initial hydration of server-rendered children until `when` resolves.
- * A boundary first mounted on the client renders immediately; only existing SSR
- * HTML can be left dormant.
+ * An ordinary boundary first mounted on the client renders immediately; only
+ * existing SSR HTML can be left dormant. The compiler-proven permanent-static
+ * form is the server-only exception and intentionally renders no client child.
  */
-function initializeHydrateComponent(): ComponentBody<HydrateProps> {
-	return markComponentFlags<ComponentBody<HydrateProps>>(
+type InternalHydrateComponent = ComponentBody<HydrateProps> & {
+	readonly __octanePermanentStatic: ComponentBody<HydrateProps>;
+};
+
+function initializeHydrateComponent(): InternalHydrateComponent {
+	const hydrate = markComponentFlags<ComponentBody<HydrateProps>>(
 		function Hydrate(rawProps, scope) {
 			const props = rawProps as InternalHydrateProps;
 			const boundaryId = useId(HYDRATE_ID_SLOT);
@@ -5717,6 +5939,19 @@ function initializeHydrateComponent(): ComponentBody<HydrateProps> {
 		COMPONENT_FLAG_BOUNDARY,
 		'Hydrate',
 	);
+	const permanentStatic = markComponentFlags<ComponentBody<HydrateProps>>(
+		function PermanentStaticHydrate(_props, scope) {
+			// Match Hydrate's own server useId while leaving all child IDs to the
+			// paired private sidecar. The componentSlot's adopted outer range owns
+			// the untouched server DOM across parent updates and unmount.
+			useId(HYDRATE_ID_SLOT);
+			preservePermanentStaticHydrationRange(scope);
+		},
+		COMPONENT_FLAG_BOUNDARY,
+		'PermanentStaticHydrate',
+	);
+	Object.defineProperty(hydrate, '__octanePermanentStatic', { value: permanentStatic });
+	return hydrate as InternalHydrateComponent;
 }
 
 export const Hydrate: ComponentBody<HydrateProps> = /* @__PURE__ */ initializeHydrateComponent();
@@ -16687,8 +16922,7 @@ function mountTry(state: TrySlot): void {
 		hydration !== null &&
 		adoptCursor !== null &&
 		adoptCursor.nodeType === 1 &&
-		(adoptCursor as Element).localName === 'template' &&
-		(adoptCursor as Element).hasAttribute(STREAM_BOUNDARY_ATTR)
+		isRendererStreamBoundaryTemplate(adoptCursor as Element)
 	) {
 		hasScopedBoundary = true;
 		streamedBoundaryId = (adoptCursor as Element).getAttribute(STREAM_BOUNDARY_ATTR);
@@ -16720,6 +16954,10 @@ function mountTry(state: TrySlot): void {
 		bEnd = document.createComment('/try-b');
 		state.domParent.insertBefore(bStart, state.end);
 		state.domParent.insertBefore(bEnd, state.end);
+		if (hydration !== null) {
+			hydration.markFresh(bStart);
+			hydration.markFresh(bEnd);
+		}
 	}
 	const b = createBlock(
 		'control-flow',

--- a/packages/octane/src/stream-protocol.ts
+++ b/packages/octane/src/stream-protocol.ts
@@ -1,0 +1,89 @@
+/**
+ * Tiny client/server streaming protocol subset shared with the lightweight
+ * pre-root hydration event capture. Keep this module dependency-free: loading
+ * interaction capture before the main runtime must not initialize DOM tables.
+ */
+
+/** Sentinel <template> attribute marking a pending streamed boundary. */
+export const STREAM_BOUNDARY_ATTR = 'data-oct-b';
+
+/** Render-unique token stamped on deferred-hydration owners in a streamed shell. */
+export const HYDRATE_STREAM_TOKEN_ATTR = 'data-octane-stream-token';
+
+function hydrationMarkerMultiplicity(data: string, open: boolean): number {
+	const marker = open ? '[' : ']';
+	if (data === marker) return 1;
+	if (open && (data === '[f0' || data === '[f1')) return 1;
+	if (data.length < 2 || data.charCodeAt(0) !== marker.charCodeAt(0)) return 0;
+	const first = data.charCodeAt(1);
+	if (first < 49 || first > 57) return 0;
+	let value = first - 48;
+	for (let i = 2; i < data.length; i++) {
+		const digit = data.charCodeAt(i) - 48;
+		if (digit < 0 || digit > 9) return 0;
+		value = value * 10 + digit;
+		if (!Number.isSafeInteger(value)) return 0;
+	}
+	return value >= 2 ? value : 0;
+}
+
+function isHydrationOpen(node: Node | null): node is Comment {
+	return (
+		node !== null &&
+		node.nodeType === 8 &&
+		hydrationMarkerMultiplicity((node as Comment).data, true) !== 0
+	);
+}
+
+/** Find a physical hydration range's close without trusting malformed comment input. */
+export function rendererRangeClose(open: Node | null): Comment | null {
+	if (!isHydrationOpen(open)) return null;
+	let depth = 0;
+	let node = open.nextSibling;
+	while (node !== null) {
+		if (node.nodeType === 8) {
+			const data = (node as Comment).data;
+			if (hydrationMarkerMultiplicity(data, true) !== 0) {
+				depth++;
+			} else if (hydrationMarkerMultiplicity(data, false) !== 0) {
+				if (depth === 0) return node as Comment;
+				depth--;
+			}
+		}
+		node = node.nextSibling;
+	}
+	return null;
+}
+
+/** True for the opaque per-render token minted by the server streamer. */
+export function isRendererStreamToken(token: string | null): token is string {
+	return token !== null && /^os[a-zA-Z0-9_-]+-[0-9a-z]+$/.test(token);
+}
+
+/** Extract the render token from a canonical streamed-boundary id. */
+export function streamTokenFromBoundaryId(id: string | null): string | null {
+	if (id === null) return null;
+	const separator = id.lastIndexOf('-');
+	if (separator <= 2 || separator === id.length - 1) return null;
+	const token = id.slice(0, separator);
+	const order = id.slice(separator + 1);
+	if (!isRendererStreamToken(token)) return null;
+	if (!/^(?:0|[1-9a-z][0-9a-z]*)$/.test(order)) return null;
+	return token;
+}
+
+/**
+ * Recognize a renderer sentinel only when its opaque id belongs to the expected
+ * stream and it occupies the exact leading position of a balanced SSR range.
+ */
+export function isRendererStreamBoundaryTemplate(
+	node: Element,
+	expectedToken?: string | null,
+): boolean {
+	if (node.localName !== 'template') return false;
+	const id = node.getAttribute(STREAM_BOUNDARY_ATTR);
+	const token = streamTokenFromBoundaryId(id);
+	if (token === null || (expectedToken !== undefined && token !== expectedToken)) return false;
+	const open = node.previousSibling;
+	return isHydrationOpen(open) && open.nextSibling === node && rendererRangeClose(open) !== null;
+}

--- a/packages/octane/tests/_fixtures/ssr-permanent-static-stream.tsrx
+++ b/packages/octane/tests/_fixtures/ssr-permanent-static-stream.tsrx
@@ -1,0 +1,67 @@
+import { Hydrate, Suspense, use } from 'octane';
+import { never } from 'octane/hydration';
+
+function PermanentStaticStreamedValue(props) @{
+	const value = use(props.promise);
+	<span id="permanent-static-stream-value">{value as string}</span>
+}
+
+export function DeferredWithPermanentStaticStream(props) @{
+	<Hydrate when={props.when} split={false} onHydrated={props.onHydrated}>
+		<section id="deferred-permanent-static-shell">
+			<Hydrate when={never()} split={false}>
+				<Suspense
+					fallback={<span id="permanent-static-stream-value">{'Loading static stream'}</span>}
+				>
+					<PermanentStaticStreamedValue promise={props.promise} />
+				</Suspense>
+			</Hydrate>
+			<button
+				id="deferred-permanent-static-action"
+				onClick={props.onClick}
+			>{'Activate outer'}</button>
+		</section>
+	</Hydrate>
+}
+
+function ThrowingPermanentStaticValue(props) @{
+	throw props.error;
+	<span id="permanent-static-unreachable">{'unreachable'}</span>
+}
+
+export function PermanentStaticSyncCaught(props) @{
+	<main id="permanent-static-sync-shell">
+		@try {
+			<Hydrate when={never()} split={false}>
+				<ThrowingPermanentStaticValue error={props.error} />
+			</Hydrate>
+		} @catch (error) {
+			<p id="permanent-static-sync-catch">{error.message as string}</p>
+		}
+	</main>
+}
+
+export function PermanentStaticRejectedStream(props) @{
+	<main id="permanent-static-rejected-shell">
+		<Hydrate when={never()} split={false}>
+			<Suspense fallback={<span id="permanent-static-rejected-fallback">{'Static fallback'}</span>}>
+				<PermanentStaticStreamedValue promise={props.promise} />
+			</Suspense>
+		</Hydrate>
+	</main>
+}
+
+export function PermanentStaticCaughtStream(props) @{
+	<main id="permanent-static-caught-shell">
+		<Hydrate when={never()} split={false}>
+			@try {
+				const value = use(props.promise);
+				<span id="permanent-static-caught-value">{value as string}</span>
+			} @pending {
+				<span id="permanent-static-caught-fallback">{'Caught fallback'}</span>
+			} @catch (error) {
+				<span id="permanent-static-caught-error">{error.message as string}</span>
+			}
+		</Hydrate>
+	</main>
+}

--- a/packages/octane/tests/_fixtures/ssr-suspense.tsrx
+++ b/packages/octane/tests/_fixtures/ssr-suspense.tsrx
@@ -35,6 +35,51 @@ export function DeferredStreamedSuspense(props) @{
 	</Hydrate>
 }
 
+function NestedDeferredStreamedButton(props) @{
+	const value = use(props.promise);
+	<button
+		id="nested-deferred-stream-action"
+		onClick={() => props.onClick?.(value)}
+	>{value as string}</button>
+}
+
+export function NestedDeferredStreamedHydrates(props) @{
+	<Hydrate when={props.outerWhen} split={false} onHydrated={props.onOuterHydrated}>
+		<section id="outer-deferred-stream-shell">
+			<button
+				id="outer-deferred-stream-action"
+				onClick={props.onOuterClick}
+			>{'Activate outer'}</button>
+			<Hydrate when={props.innerWhen} split={false} onHydrated={props.onInnerHydrated}>
+				<Suspense
+					fallback={<button id="nested-deferred-stream-action">{'Loading nested stream'}</button>}
+				>
+					<NestedDeferredStreamedButton promise={props.promise} onClick={props.onInnerClick} />
+				</Suspense>
+			</Hydrate>
+		</section>
+	</Hydrate>
+}
+
+function TwoNodeStreamedValue(props) @{
+	const value = use(props.promise);
+	<>
+		<span id="streamed-first-value">{value as string}</span>
+		<span id="streamed-second-value">{'Second streamed node'}</span>
+	</>
+}
+
+export function DeferredStreamWithLiveSibling(props) @{
+	<Hydrate when={props.when} split={false} onHydrated={props.onHydrated}>
+		<section id="deferred-stream-live-shell">
+			<Suspense fallback={<span id="streamed-first-value">{'Loading one node'}</span>}>
+				<TwoNodeStreamedValue promise={props.promise} />
+			</Suspense>
+			<button id="stream-live-sibling" onClick={props.onClick}>{'Live sibling'}</button>
+		</section>
+	</Hydrate>
+}
+
 // A use() that resolves to `undefined`. The resolved value must round-trip
 // through the SSR seed as `undefined`, NOT `null` (JSON has no undefined). The
 // rendered marker discriminates undefined / null / other so the hydration test

--- a/packages/octane/tests/_fixtures/ssr-suspense.tsrx
+++ b/packages/octane/tests/_fixtures/ssr-suspense.tsrx
@@ -1,4 +1,4 @@
-import { Hydrate, use, useId, useState } from 'octane';
+import { Hydrate, Suspense, use, useId, useState } from 'octane';
 
 // SSR Phase 4 — Suspense + data serialization. The server render() awaits
 // use(promise) and renders the resolved value (not the @pending fallback); the
@@ -16,6 +16,22 @@ export function AsyncLeaf(props) @{
 export function DeferredAsyncLeaf(props) @{
 	<Hydrate when={props.when} split={false}>
 		<AsyncLeaf promise={props.promise} />
+	</Hydrate>
+}
+
+function DeferredStreamedButton(props) @{
+	const value = use(props.promise);
+	<button
+		id="deferred-stream-action"
+		onClick={() => props.onClick?.(value)}
+	>{value as string}</button>
+}
+
+export function DeferredStreamedSuspense(props) @{
+	<Hydrate when={props.when} split={false} onHydrated={props.onHydrated}>
+		<Suspense fallback={<button id="deferred-stream-action">{'Loading streamed content'}</button>}>
+			<DeferredStreamedButton promise={props.promise} onClick={props.onClick} />
+		</Suspense>
 	</Hydrate>
 }
 

--- a/packages/octane/tests/_fixtures/stream-ownership-collisions.tsrx
+++ b/packages/octane/tests/_fixtures/stream-ownership-collisions.tsrx
@@ -1,0 +1,35 @@
+import { Hydrate, Suspense, use } from 'octane';
+
+function StreamedCollisionButton(props) @{
+	const value = use(props.promise);
+	<button
+		id="stream-collision-action"
+		onClick={() => props.onClick?.(value)}
+	>{value as string}</button>
+}
+
+export function AuthoredStreamAttribute(props) @{
+	<Hydrate when={props.when} split={false} onHydrated={props.onHydrated}>
+		<template data-oct-b="authored-template"></template>
+		<button id="authored-stream-attribute-action" onClick={props.onClick}>{'Activate'}</button>
+	</Hydrate>
+}
+
+export function ForgedNestedHydrateAttribute(props) @{
+	<Hydrate when={props.when} split={false} onHydrated={props.onHydrated}>
+		<section data-octane-hydrate-id="authored-lookalike">
+			<Suspense fallback={<button id="stream-collision-action">{'Loading forged owner'}</button>}>
+				<StreamedCollisionButton promise={props.promise} onClick={props.onClick} />
+			</Suspense>
+		</section>
+	</Hydrate>
+}
+
+export function MalformedStaticComment(props) @{
+	<Hydrate when={props.when} split={false} onHydrated={props.onHydrated}>
+		<div dangerouslySetInnerHTML={{ __html: props.authoredHtml }} />
+		<Suspense fallback={<button id="stream-collision-action">{'Loading malformed marker'}</button>}>
+			<StreamedCollisionButton promise={props.promise} onClick={props.onClick} />
+		</Suspense>
+	</Hydrate>
+}

--- a/packages/octane/tests/_server-fixture.ts
+++ b/packages/octane/tests/_server-fixture.ts
@@ -10,6 +10,7 @@ import { readFileSync } from 'node:fs';
 import { isAbsolute, relative, resolve, sep } from 'node:path';
 import { compile } from 'octane/compiler';
 import * as ServerRuntime from 'octane/server';
+import * as HydrationRuntime from 'octane/hydration';
 import * as ClientRuntime from '../src/index.js';
 
 export type CompiledFixtureModule = Record<string, any>;
@@ -44,6 +45,11 @@ export function loadCompiledFixtureSource<T extends CompiledFixtureModule = Comp
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane(?:\/server)?['"];?/g,
 		(_match: string, names: string) => `const {${names.replace(/\s+as\s+/g, ': ')}} = __runtime;`,
 	);
+	code = code.replace(
+		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/hydration['"];?/g,
+		(_match: string, names: string) =>
+			`const {${names.replace(/\s+as\s+/g, ': ')}} = __hydrationRuntime;`,
+	);
 
 	code = code.replace(
 		/export\s+(async\s+)?function\s+(\w+)/g,
@@ -64,10 +70,11 @@ export function loadCompiledFixtureSource<T extends CompiledFixtureModule = Comp
 
 	const evaluate = new Function(
 		'__runtime',
+		'__hydrationRuntime',
 		'__exports',
 		`'use strict';\n${code}\n//# sourceURL=${id}?${mode}-fixture\nreturn __exports;`,
 	);
-	return evaluate(runtime, {}) as T;
+	return evaluate(runtime, HydrationRuntime, {}) as T;
 }
 
 export function loadServerFixture<T extends CompiledFixtureModule = CompiledFixtureModule>(

--- a/packages/octane/tests/hydrate-compiler.test.ts
+++ b/packages/octane/tests/hydrate-compiler.test.ts
@@ -391,6 +391,187 @@ export function App(enabled) @{
 		expect(dynamicImports(defaulted.code)).toEqual(new Set(['./App.tsrx?octane-hydrate=0']));
 	});
 
+	it('erases only the exact permanent-static descendant graph from the client', () => {
+		const exact = `
+import { Hydrate, Hydrate as StaticRange } from 'octane';
+import { never as permanently } from 'octane/hydration';
+import { StaticNavigation } from './StaticNavigation.tsrx';
+export function App() @{
+  <StaticRange split={false} when={permanently()}>
+    <Hydrate when={gate}><StaticNavigation data-server-only="yes" /></Hydrate>
+  </StaticRange>
+}
+`;
+		const client = compiler().transform(exact, FILE, { environment: 'client' })!;
+		expect(hasStaticImport(client.code, './StaticNavigation.tsrx')).toBe(false);
+		expect(dynamicImports(client.code)).toEqual(new Set());
+		expect(client.code).not.toContain('data-server-only');
+		expect(client.code).toContain('__octanePermanentStatic');
+
+		const server = compiler().transform(exact, FILE, { environment: 'server' })!;
+		expect(hasStaticImport(server.code, './StaticNavigation.tsrx')).toBe(true);
+		expect(server.code).toContain('data-server-only');
+		expect(server.code).toContain('__octanePermanentStatic');
+
+		const configured = `
+import { Hydrate } from 'octane';
+import { never } from 'octane/hydration';
+import { StaticNavigation } from './StaticNavigation.tsrx';
+export function App() @{
+  <Hydrate split={false} when={never()} onHydrated={done}>
+    <StaticNavigation data-server-only="yes" />
+  </Hydrate>
+}
+`;
+		const ordinary = compiler().transform(configured, FILE, { environment: 'client' })!;
+		expect(hasStaticImport(ordinary.code, './StaticNavigation.tsrx')).toBe(true);
+		expect(ordinary.code).toContain('data-server-only');
+		expect(ordinary.code).not.toContain('__octanePermanentStatic');
+
+		const empty = compiler().transform(
+			`import { Hydrate } from 'octane'; import { never } from 'octane/hydration'; export function App() @{ <Hydrate split={false} when={never()} /> }`,
+			FILE,
+			{ environment: 'client' },
+		)!;
+		expect(dynamicImports(empty.code)).toEqual(new Set());
+		expect(empty.code).toContain('__octanePermanentStatic');
+
+		for (const inexact of [
+			`import { Hydrate } from 'octane'; import { never } from 'octane/hydration'; import { StaticNavigation } from './StaticNavigation.tsrx'; export function App(options) @{ <Hydrate split={false} when={never()} {...options}><StaticNavigation data-server-only="yes" /></Hydrate> }`,
+			`import { Hydrate } from 'octane'; import { never as importedNever } from 'octane/hydration'; import { StaticNavigation } from './StaticNavigation.tsrx'; export function App(importedNever) @{ <Hydrate split={false} when={importedNever()}><StaticNavigation data-server-only="yes" /></Hydrate> }`,
+			`import { Hydrate } from 'octane'; import { never } from 'octane/hydration'; import { StaticNavigation } from './StaticNavigation.tsrx'; export function App() @{ <Hydrate split={false} when={never()} __static={true}><StaticNavigation data-server-only="yes" /></Hydrate> }`,
+		]) {
+			const retained = compiler().transform(inexact, FILE, { environment: 'client' })!;
+			expect(hasStaticImport(retained.code, './StaticNavigation.tsrx')).toBe(true);
+			expect(retained.code).toContain('data-server-only');
+			expect(retained.code).not.toContain('__octanePermanentStatic');
+		}
+	});
+
+	it('removes private declaration chains reachable only from a permanent-static range', () => {
+		const source = `
+import { Hydrate } from 'octane';
+import { never } from 'octane/hydration';
+import { StaticNavigation } from './StaticNavigation.tsrx';
+function StaticLeaf() @{ <StaticNavigation data-server-only="leaf" /> }
+function StaticShell() @{ <StaticLeaf /> }
+function RetainedHelper() @{ <span data-client-retained="yes" /> }
+export function App() @{
+  <main>
+    <Hydrate split={false} when={never()}><StaticShell /></Hydrate>
+    <RetainedHelper />
+  </main>
+}
+`;
+		const client = compiler().transform(source, FILE, { environment: 'client' })!;
+		expect(hasStaticImport(client.code, './StaticNavigation.tsrx')).toBe(false);
+		expect(client.code).not.toContain('StaticLeaf');
+		expect(client.code).not.toContain('StaticShell');
+		expect(client.code).toContain('data-client-retained');
+
+		const server = compiler().transform(source, FILE, { environment: 'server' })!;
+		expect(hasStaticImport(server.code, './StaticNavigation.tsrx')).toBe(true);
+		expect(server.code).toContain('data-server-only');
+
+		const shared = source.replace('<RetainedHelper />', '<><StaticShell /><RetainedHelper /></>');
+		const retained = compiler().transform(shared, FILE, { environment: 'client' })!;
+		expect(hasStaticImport(retained.code, './StaticNavigation.tsrx')).toBe(true);
+		expect(retained.code).toContain('data-server-only');
+
+		const coupledInitializer = source.replace(
+			'function StaticShell() @{ <StaticLeaf /> }',
+			`const StaticShell = function StaticShell() @{ <StaticLeaf /> }, unrelated = observeClientModule();`,
+		);
+		const conservative = compiler().transform(coupledInitializer, FILE, {
+			environment: 'client',
+		})!;
+		expect(conservative.code).toContain('observeClientModule');
+		expect(hasStaticImport(conservative.code, './StaticNavigation.tsrx')).toBe(true);
+	});
+
+	it('preserves a permanent-static declaration graph exported by a later specifier', () => {
+		const source = `
+import { Hydrate } from 'octane';
+import { never } from 'octane/hydration';
+import { StaticNavigation } from './StaticNavigation.tsrx';
+function StaticLeaf() @{ <StaticNavigation data-server-only="leaf" /> }
+function StaticShell() @{ <StaticLeaf /> }
+export { StaticShell as PublicStaticShell };
+export function App() @{
+  <Hydrate split={false} when={never()}><StaticShell /></Hydrate>
+}
+`;
+		const client = compiler().transform(source, FILE, { environment: 'client' })!;
+		expect(hasStaticImport(client.code, './StaticNavigation.tsrx')).toBe(true);
+		expect(client.code).toContain('function StaticLeaf');
+		expect(client.code).toContain('function StaticShell');
+		expect(client.code).toContain('export { StaticShell as PublicStaticShell }');
+	});
+
+	it.each([
+		['a TypeScript export assignment', 'export = StaticShell;'],
+		['a runtime enum initializer', 'export enum RuntimeValue { value = StaticShell() }'],
+		[
+			'a runtime namespace initializer',
+			'export namespace RuntimeValue { export const value = StaticShell }',
+		],
+		['a runtime export-import alias', 'export import RuntimeAlias = StaticShell.Member;'],
+		[
+			'a TypeScript parameter-property default',
+			'export class Retained { constructor(public shell = StaticShell) {} }',
+		],
+		[
+			'a parameter default before a body var',
+			'export function Retained(value = StaticShell) { var StaticShell; return value }',
+		],
+		[
+			'a use outside a nested class static-block var',
+			'export function Retained() { class Local { static { var StaticShell } } return StaticShell }',
+		],
+		[
+			'a declaration name observed through direct eval',
+			"export function Retained() { return eval('StaticShell') }",
+		],
+	])('does not erase a declaration referenced by %s', (_name, retainedSource) => {
+		const source = `
+import { Hydrate } from 'octane';
+import { never } from 'octane/hydration';
+function StaticShell() { return <b /> }
+${retainedSource}
+function App() {
+  return <Hydrate split={false} when={never()}><StaticShell /></Hydrate>;
+}
+`;
+		const client = compiler().transform(source, FILE, { environment: 'client' })!;
+		expect(client.code).toContain('function StaticShell');
+		expect(client.code).toContain('__octanePermanentStatic');
+	});
+
+	it('erases an inner permanent-static graph from an ordinary split child', () => {
+		const source = `
+import { Hydrate } from 'octane';
+import { never } from 'octane/hydration';
+import { StaticNavigation } from './StaticNavigation.tsrx';
+export function App() @{
+  <Hydrate when={gate}>
+    <section>
+      <Hydrate split={false} when={never()}>
+        <StaticNavigation data-server-only="yes" />
+      </Hydrate>
+    </section>
+  </Hydrate>
+}
+`;
+		const root = compiler().transform(source, FILE, { environment: 'client' })!;
+		expect(dynamicImports(root.code)).toEqual(new Set(['./App.tsrx?octane-hydrate=0']));
+		const child = compiler().transform(source, `${FILE}?octane-hydrate=0`, {
+			environment: 'client',
+		})!;
+		expect(hasStaticImport(child.code, './StaticNavigation.tsrx')).toBe(false);
+		expect(dynamicImports(child.code)).toEqual(new Set());
+		expect(child.code).not.toContain('data-server-only');
+	});
+
 	it('derives stable nested paths from the original source', () => {
 		const source = `
 import { Hydrate as Deferred } from 'octane';
@@ -575,6 +756,34 @@ export function App() @{
 		const server = hashes(instance.transform(source, FILE, { environment: 'server' })!.code);
 		expect(client.size).toBeGreaterThan(0);
 		expect(client).toEqual(server);
+	});
+
+	it('keeps owning scoped styles while erasing permanent-static runtime children', () => {
+		const source = `
+import { Hydrate } from 'octane';
+import { never } from 'octane/hydration';
+import { StaticNavigation } from './StaticNavigation.tsrx';
+export function App() @{
+  <main class="host">
+    <Hydrate split={false} when={never()}>
+      <section class="static"><StaticNavigation /></section>
+      <style>
+        .host, .static { color: red; }
+      </style>
+    </Hydrate>
+    <p class="live">Live sibling</p>
+  </main>
+}
+`;
+		const hashes = (code: string) => new Set(code.match(/tsrx-[0-9a-z]+/g) ?? []);
+		const clientCode = compile(source, FILE, { hmr: false }).code;
+		const serverCode = compile(source, FILE, { hmr: false, mode: 'server' }).code;
+		expect(hasStaticImport(clientCode, './StaticNavigation.tsrx')).toBe(false);
+		expect(clientCode).not.toContain('StaticNavigation');
+		expect(clientCode).toContain('.host.tsrx-');
+		expect(clientCode).toContain('live tsrx-');
+		expect(hashes(clientCode).size).toBeGreaterThan(0);
+		expect(hashes(clientCode)).toEqual(hashes(serverCode));
 	});
 
 	it.each([

--- a/packages/octane/tests/hydration/_fixtures/deferred-hydration-static.tsrx
+++ b/packages/octane/tests/hydration/_fixtures/deferred-hydration-static.tsrx
@@ -1,0 +1,82 @@
+import { Hydrate, useId } from 'octane';
+import { never } from 'octane/hydration';
+
+function StaticLeaf(props) @{
+	const id = useId();
+	props.onRender?.();
+	<nav id="static-navigation" data-runtime-id={id}>
+		<a href="/">{'Home'}</a>
+		<a href="/about">{'About'}</a>
+	</nav>
+}
+
+function LiveSibling(props) @{
+	const id = useId();
+	<button
+		id="live-sibling"
+		data-runtime-id={id}
+		onClick={() => props.onClick?.(id)}
+	>{props.label as string}</button>
+}
+
+export function PermanentStaticHtml(props) @{
+	<main id="static-layout">
+		<Hydrate split={false} when={never()}>
+			<aside id="static-sidebar">
+				<StaticLeaf onRender={props.onStaticRender} />
+			</aside>
+			<span id="static-tail">{'Static tail'}</span>
+		</Hydrate>
+		<LiveSibling label={props.label} onClick={props.onLiveClick} />
+	</main>
+}
+
+export function NestedPermanentStatic() @{
+	<main id="nested-static-layout">
+		<Hydrate split={false} when={never()}>
+			<section id="outer-static-content">
+				<Hydrate split={false} when={never()}>
+					<span id="inner-static-content">{'Nested static content'}</span>
+				</Hydrate>
+			</section>
+		</Hydrate>
+	</main>
+}
+
+export function PermanentStaticForeign() @{
+	<>
+		<svg id="static-svg" viewBox="0 0 20 20">
+			<Hydrate split={false} when={never()}>
+				<g id="static-svg-group">
+					<path d="M0 0h20v20H0z" />
+				</g>
+			</Hydrate>
+		</svg>
+		<math id="static-math">
+			<Hydrate split={false} when={never()}>
+				<mrow id="static-math-row">
+					<mi>{'x'}</mi>
+				</mrow>
+			</Hydrate>
+		</math>
+	</>
+}
+
+function ServerOwnedRange(props) @{
+	props.onRender?.();
+	<div
+		id="server-owned-range"
+		dangerouslySetInnerHTML={{
+			__html: props.html,
+		}}
+	/>
+}
+
+export function PermanentServerOwned(props) @{
+	<section id="server-owned-layout">
+		<Hydrate split={false} when={never()}>
+			<ServerOwnedRange html={props.html} onRender={props.onStaticRender} />
+		</Hydrate>
+		<span id="server-owned-live-label">{props.label as string}</span>
+	</section>
+}

--- a/packages/octane/tests/hydration/_fixtures/deferred-hydration-static.tsrx
+++ b/packages/octane/tests/hydration/_fixtures/deferred-hydration-static.tsrx
@@ -31,6 +31,13 @@ export function PermanentStaticHtml(props) @{
 	</main>
 }
 
+export function EmptyPermanentStatic(props) @{
+	<main id="empty-static-layout">
+		<Hydrate split={false} when={never()} />
+		<LiveSibling label="Live after empty range" onClick={props.onLiveClick} />
+	</main>
+}
+
 export function NestedPermanentStatic() @{
 	<main id="nested-static-layout">
 		<Hydrate split={false} when={never()}>
@@ -39,6 +46,20 @@ export function NestedPermanentStatic() @{
 					<span id="inner-static-content">{'Nested static content'}</span>
 				</Hydrate>
 			</section>
+		</Hydrate>
+	</main>
+}
+
+export function NestedInteractiveHydrate(props) @{
+	<Hydrate split={false} when={props.when}>
+		<button id="static-nested-native-action">{'Native static action'}</button>
+	</Hydrate>
+}
+
+export function PermanentStaticWithNestedHydrate(props) @{
+	<main id="static-nested-hydrate-layout">
+		<Hydrate split={false} when={never()}>
+			<props.Child when={props.when} />
 		</Hydrate>
 	</main>
 }
@@ -62,7 +83,21 @@ export function PermanentStaticForeign() @{
 	</>
 }
 
-function ServerOwnedRange(props) @{
+export function PermanentStaticInsideDeferred(props) @{
+	<main id="nested-deferred-static-layout">
+		<Hydrate split={false} when={props.when}>
+			<section id="nested-deferred-content">
+				<Hydrate split={false} when={never()}>
+					<StaticLeaf onRender={props.onStaticRender} />
+				</Hydrate>
+				<LiveSibling label="Inner live sibling" onClick={props.onInnerLiveClick} />
+			</section>
+		</Hydrate>
+		<LiveSibling label="Outer live sibling" onClick={props.onOuterLiveClick} />
+	</main>
+}
+
+function ExternallyPatchedRange(props) @{
 	props.onRender?.();
 	<div
 		id="server-owned-range"
@@ -72,10 +107,10 @@ function ServerOwnedRange(props) @{
 	/>
 }
 
-export function PermanentServerOwned(props) @{
+export function PermanentExternallyPatched(props) @{
 	<section id="server-owned-layout">
 		<Hydrate split={false} when={never()}>
-			<ServerOwnedRange html={props.html} onRender={props.onStaticRender} />
+			<ExternallyPatchedRange html={props.html} onRender={props.onStaticRender} />
 		</Hydrate>
 		<span id="server-owned-live-label">{props.label as string}</span>
 	</section>

--- a/packages/octane/tests/hydration/deferred-hydration-static.test.ts
+++ b/packages/octane/tests/hydration/deferred-hydration-static.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, hydrateRoot } from 'octane';
+import { renderToString } from 'octane/server';
+import { flushEffects } from '../_helpers.js';
+import { loadServerFixture } from '../_server-fixture.js';
+import * as client from './_fixtures/deferred-hydration-static.tsrx';
+
+const FIXTURE = 'packages/octane/tests/hydration/_fixtures/deferred-hydration-static.tsrx';
+const server = loadServerFixture<typeof client>(FIXTURE);
+
+describe('permanently static hydration ranges', () => {
+	let container: HTMLElement;
+	let root: ReturnType<typeof hydrateRoot> | undefined;
+
+	beforeEach(() => {
+		container = document.createElement('div');
+		document.body.appendChild(container);
+	});
+
+	afterEach(() => {
+		root?.unmount();
+		root = undefined;
+		container.remove();
+	});
+
+	it('preserves direct-child DOM shape in server HTML', () => {
+		container.innerHTML = renderToString(server.PermanentStaticHtml, {
+			label: 'Live sibling',
+		}).html;
+		const layout = container.querySelector('#static-layout')!;
+		const sidebar = container.querySelector('#static-sidebar')!;
+		const tail = container.querySelector('#static-tail')!;
+		const liveSibling = container.querySelector('#live-sibling') as HTMLButtonElement;
+
+		expect(Array.from(layout.children)).toEqual([sidebar, tail, liveSibling]);
+	});
+
+	it('skips client evaluation and reserves IDs for a live sibling', () => {
+		const onStaticRender = vi.fn();
+		const onLiveClick = vi.fn();
+		container.innerHTML = renderToString(server.PermanentStaticHtml, {
+			label: 'Live sibling',
+		}).html;
+		const sidebar = container.querySelector('#static-sidebar')!;
+		const tail = container.querySelector('#static-tail')!;
+		const liveSibling = container.querySelector('#live-sibling') as HTMLButtonElement;
+		const liveId = liveSibling.dataset.runtimeId;
+
+		root = hydrateRoot(container, client.PermanentStaticHtml, {
+			label: 'Live sibling',
+			onStaticRender,
+			onLiveClick,
+		});
+		flushSync(() => {});
+		flushEffects();
+
+		expect(container.querySelector('#static-sidebar')).toBe(sidebar);
+		expect(container.querySelector('#static-tail')).toBe(tail);
+		expect(container.querySelector('#live-sibling')).toBe(liveSibling);
+		expect(onStaticRender).not.toHaveBeenCalled();
+
+		flushSync(() => liveSibling.click());
+		expect(onLiveClick).toHaveBeenCalledOnce();
+		expect(onLiveClick).toHaveBeenCalledWith(liveId);
+	});
+
+	it('collapses nested permanent-static boundaries', () => {
+		container.innerHTML = renderToString(server.NestedPermanentStatic).html;
+		const layout = container.querySelector('#nested-static-layout')!;
+		const outer = container.querySelector('#outer-static-content')!;
+		const inner = container.querySelector('#inner-static-content')!;
+
+		expect(layout.firstElementChild).toBe(outer);
+		expect(outer.firstElementChild).toBe(inner);
+	});
+
+	it('preserves SVG and MathML parser namespaces', () => {
+		container.innerHTML = renderToString(server.PermanentStaticForeign).html;
+		const svg = container.querySelector('#static-svg')!;
+		const group = container.querySelector('#static-svg-group')!;
+		const math = container.querySelector('#static-math')!;
+		const row = container.querySelector('#static-math-row')!;
+
+		expect(svg.firstElementChild).toBe(group);
+		expect(group.namespaceURI).toBe('http://www.w3.org/2000/svg');
+		expect(math.firstElementChild).toBe(row);
+		expect(row.namespaceURI).toBe('http://www.w3.org/1998/Math/MathML');
+	});
+
+	it('leaves externally patched descendants untouched across hydration and updates', () => {
+		const onStaticRender = vi.fn();
+		container.innerHTML = renderToString(server.PermanentServerOwned, {
+			html: '<p id="server-owned-initial">Initial server content</p>',
+			label: 'Initial label',
+		}).html;
+		const range = container.querySelector('#server-owned-range')!;
+		const externalBefore = document.createElement('article');
+		externalBefore.id = 'external-before-hydration';
+		externalBefore.textContent = 'Patched before hydration';
+		range.replaceChildren(externalBefore);
+
+		root = hydrateRoot(container, client.PermanentServerOwned, {
+			html: '<p>Client content must not reconcile this range</p>',
+			label: 'Initial label',
+			onStaticRender,
+		});
+		flushSync(() => {});
+		flushEffects();
+
+		expect(container.querySelector('#server-owned-range')).toBe(range);
+		expect(container.querySelector('#external-before-hydration')).toBe(externalBefore);
+		expect(onStaticRender).not.toHaveBeenCalled();
+
+		const externalAfter = document.createElement('span');
+		externalAfter.id = 'external-after-hydration';
+		externalAfter.textContent = 'Patched after hydration';
+		range.appendChild(externalAfter);
+		flushSync(() =>
+			root!.render(client.PermanentServerOwned, {
+				html: '<p>Updated client content must still not reconcile this range</p>',
+				label: 'Updated label',
+				onStaticRender,
+			}),
+		);
+		flushEffects();
+
+		expect(container.querySelector('#server-owned-range')).toBe(range);
+		expect(container.querySelector('#external-before-hydration')).toBe(externalBefore);
+		expect(container.querySelector('#external-after-hydration')).toBe(externalAfter);
+		expect(container.querySelector('#server-owned-live-label')?.textContent).toBe('Updated label');
+		expect(onStaticRender).not.toHaveBeenCalled();
+	});
+});

--- a/packages/octane/tests/hydration/deferred-hydration-static.test.ts
+++ b/packages/octane/tests/hydration/deferred-hydration-static.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { flushSync, hydrateRoot } from 'octane';
+import { createRoot, flushSync, hydrateRoot } from 'octane';
+import { initializeHydrationEventCapture, interaction, load } from 'octane/hydration';
 import { renderToString } from 'octane/server';
 import { flushEffects } from '../_helpers.js';
 import { loadServerFixture } from '../_server-fixture.js';
@@ -54,11 +55,57 @@ describe('permanently static hydration ranges', () => {
 		flushSync(() => {});
 		flushEffects();
 
+		expect(Array.from(container.querySelector('#static-layout')!.children)).toEqual([
+			sidebar,
+			tail,
+			liveSibling,
+		]);
 		expect(container.querySelector('#static-sidebar')).toBe(sidebar);
 		expect(container.querySelector('#static-tail')).toBe(tail);
 		expect(container.querySelector('#live-sibling')).toBe(liveSibling);
 		expect(onStaticRender).not.toHaveBeenCalled();
 
+		flushSync(() => liveSibling.click());
+		expect(onLiveClick).toHaveBeenCalledOnce();
+		expect(onLiveClick).toHaveBeenCalledWith(liveId);
+	});
+
+	it('renders no permanent-static descendants on a client-only mount', () => {
+		const onStaticRender = vi.fn();
+		const onLiveClick = vi.fn();
+		root = createRoot(container);
+		flushSync(() =>
+			root!.render(client.PermanentStaticHtml, {
+				label: 'Client-only live sibling',
+				onStaticRender,
+				onLiveClick,
+			}),
+		);
+		flushEffects();
+
+		const layout = container.querySelector('#static-layout')!;
+		const liveSibling = container.querySelector('#live-sibling') as HTMLButtonElement;
+		expect(Array.from(layout.children)).toEqual([liveSibling]);
+		expect(container.querySelector('#static-sidebar')).toBeNull();
+		expect(onStaticRender).not.toHaveBeenCalled();
+		flushSync(() => liveSibling.click());
+		expect(onLiveClick).toHaveBeenCalledOnce();
+	});
+
+	it('hydrates an empty permanent-static range without shifting its live sibling', () => {
+		const onLiveClick = vi.fn();
+		container.innerHTML = renderToString(server.EmptyPermanentStatic).html;
+		const layout = container.querySelector('#empty-static-layout')!;
+		const liveSibling = container.querySelector('#live-sibling') as HTMLButtonElement;
+		const liveId = liveSibling.dataset.runtimeId;
+		expect(Array.from(layout.children)).toEqual([liveSibling]);
+
+		root = hydrateRoot(container, client.EmptyPermanentStatic, { onLiveClick });
+		flushSync(() => {});
+		flushEffects();
+
+		expect(Array.from(layout.children)).toEqual([liveSibling]);
+		expect(container.querySelector('#live-sibling')).toBe(liveSibling);
 		flushSync(() => liveSibling.click());
 		expect(onLiveClick).toHaveBeenCalledOnce();
 		expect(onLiveClick).toHaveBeenCalledWith(liveId);
@@ -70,8 +117,39 @@ describe('permanently static hydration ranges', () => {
 		const outer = container.querySelector('#outer-static-content')!;
 		const inner = container.querySelector('#inner-static-content')!;
 
+		root = hydrateRoot(container, client.NestedPermanentStatic);
+		flushSync(() => {});
+		flushEffects();
+
 		expect(layout.firstElementChild).toBe(outer);
+		expect(container.querySelector('#outer-static-content')).toBe(outer);
 		expect(outer.firstElementChild).toBe(inner);
+		expect(container.querySelector('#inner-static-content')).toBe(inner);
+	});
+
+	it('keeps a cross-component nested Hydrate inert under permanent-static ownership', () => {
+		const when = interaction({ events: 'click' });
+		container.innerHTML = renderToString(server.PermanentStaticWithNestedHydrate, {
+			Child: server.NestedInteractiveHydrate,
+			when,
+		}).html;
+		const action = container.querySelector('#static-nested-native-action') as HTMLButtonElement;
+		const nativeClick = vi.fn();
+		action.addEventListener('click', nativeClick);
+
+		initializeHydrationEventCapture(document);
+		const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+		action.dispatchEvent(event);
+		expect(event.defaultPrevented).toBe(false);
+		expect(nativeClick).toHaveBeenCalledOnce();
+
+		root = hydrateRoot(container, client.PermanentStaticWithNestedHydrate, {
+			Child: client.NestedInteractiveHydrate,
+			when,
+		});
+		flushSync(() => {});
+		flushEffects();
+		expect(container.querySelector('#static-nested-native-action')).toBe(action);
 	});
 
 	it('preserves SVG and MathML parser namespaces', () => {
@@ -81,15 +159,60 @@ describe('permanently static hydration ranges', () => {
 		const math = container.querySelector('#static-math')!;
 		const row = container.querySelector('#static-math-row')!;
 
+		root = hydrateRoot(container, client.PermanentStaticForeign);
+		flushSync(() => {});
+		flushEffects();
+
 		expect(svg.firstElementChild).toBe(group);
+		expect(container.querySelector('#static-svg-group')).toBe(group);
 		expect(group.namespaceURI).toBe('http://www.w3.org/2000/svg');
 		expect(math.firstElementChild).toBe(row);
+		expect(container.querySelector('#static-math-row')).toBe(row);
 		expect(row.namespaceURI).toBe('http://www.w3.org/1998/Math/MathML');
 	});
 
+	it('reserves IDs inside an activating deferred boundary', () => {
+		const when = load();
+		const onStaticRender = vi.fn();
+		const onInnerLiveClick = vi.fn();
+		const onOuterLiveClick = vi.fn();
+		container.innerHTML = renderToString(server.PermanentStaticInsideDeferred, { when }).html;
+		const staticNavigation = container.querySelector('#static-navigation')!;
+		const deferredContent = container.querySelector('#nested-deferred-content')!;
+		const innerLive = deferredContent.querySelector('#live-sibling') as HTMLButtonElement;
+		const outerLive = container.querySelector('#nested-deferred-static-layout')!
+			.lastElementChild as HTMLButtonElement;
+		const innerId = innerLive.dataset.runtimeId;
+		const outerId = outerLive.dataset.runtimeId;
+
+		root = hydrateRoot(container, client.PermanentStaticInsideDeferred, {
+			when,
+			onStaticRender,
+			onInnerLiveClick,
+			onOuterLiveClick,
+		});
+		flushSync(() => {});
+		flushEffects();
+
+		expect(container.querySelector('#static-navigation')).toBe(staticNavigation);
+		expect(deferredContent.querySelector('#live-sibling')).toBe(innerLive);
+		expect(container.querySelector('#nested-deferred-static-layout')!.lastElementChild).toBe(
+			outerLive,
+		);
+		expect(onStaticRender).not.toHaveBeenCalled();
+		flushSync(() => {
+			innerLive.click();
+			outerLive.click();
+		});
+		expect(onInnerLiveClick).toHaveBeenCalledWith(innerId);
+		expect(onOuterLiveClick).toHaveBeenCalledWith(outerId);
+	});
+
+	// This protects the permanent-static range invariant; it does not establish a
+	// behavior-adoption, conflict-resolution, or disposal API for external owners.
 	it('leaves externally patched descendants untouched across hydration and updates', () => {
 		const onStaticRender = vi.fn();
-		container.innerHTML = renderToString(server.PermanentServerOwned, {
+		container.innerHTML = renderToString(server.PermanentExternallyPatched, {
 			html: '<p id="server-owned-initial">Initial server content</p>',
 			label: 'Initial label',
 		}).html;
@@ -99,7 +222,7 @@ describe('permanently static hydration ranges', () => {
 		externalBefore.textContent = 'Patched before hydration';
 		range.replaceChildren(externalBefore);
 
-		root = hydrateRoot(container, client.PermanentServerOwned, {
+		root = hydrateRoot(container, client.PermanentExternallyPatched, {
 			html: '<p>Client content must not reconcile this range</p>',
 			label: 'Initial label',
 			onStaticRender,
@@ -116,7 +239,7 @@ describe('permanently static hydration ranges', () => {
 		externalAfter.textContent = 'Patched after hydration';
 		range.appendChild(externalAfter);
 		flushSync(() =>
-			root!.render(client.PermanentServerOwned, {
+			root!.render(client.PermanentExternallyPatched, {
 				html: '<p>Updated client content must still not reconcile this range</p>',
 				label: 'Updated label',
 				onStaticRender,

--- a/packages/octane/tests/production-bundle.test.ts
+++ b/packages/octane/tests/production-bundle.test.ts
@@ -102,4 +102,69 @@ export function Retained() @{
 		expect(code).not.toContain('unused-warm-template');
 		expect(code).not.toContain('unused-event-template');
 	});
+
+	it('omits modules used only by a permanent-static boundary from the client bundle', async () => {
+		const page = compile(
+			`
+import { Hydrate } from 'octane';
+import { never } from 'octane/hydration';
+import { StaticNavigation } from 'fixture:static-navigation';
+
+export function App() @{
+	<main data-bundle-probe="live-page">
+		<Hydrate split={false} when={never()}>
+			<StaticNavigation />
+		</Hydrate>
+	</main>
+}
+`,
+			'Page.tsrx',
+			{ hmr: false },
+		).code;
+		const staticNavigation = compile(
+			`
+globalThis.__octanePermanentStaticModuleLoaded = true;
+
+export function StaticNavigation() @{
+	<nav data-bundle-probe="permanent-static-navigation" />
+}
+`,
+			'StaticNavigation.tsrx',
+			{ hmr: false },
+		).code;
+
+		const result = await build({
+			stdin: {
+				contents: `export { App } from 'fixture:page';`,
+				loader: 'js',
+				sourcefile: 'entry.js',
+			},
+			bundle: true,
+			format: 'esm',
+			minify: true,
+			treeShaking: true,
+			write: false,
+			external: ['octane', 'octane/hydration'],
+			plugins: [
+				{
+					name: 'permanent-static-fixtures',
+					setup(build) {
+						build.onResolve({ filter: /^fixture:/ }, (args) => ({
+							path: args.path,
+							namespace: 'fixture',
+						}));
+						build.onLoad({ filter: /.*/, namespace: 'fixture' }, (args) => ({
+							contents: args.path === 'fixture:page' ? page : staticNavigation,
+							loader: 'js',
+						}));
+					},
+				},
+			],
+		});
+		const code = result.outputFiles[0].text;
+
+		expect(code).toContain('live-page');
+		expect(code).not.toContain('__octanePermanentStaticModuleLoaded');
+		expect(code).not.toContain('permanent-static-navigation');
+	});
 });

--- a/packages/octane/tests/production-bundle.test.ts
+++ b/packages/octane/tests/production-bundle.test.ts
@@ -6,6 +6,27 @@ import { describe, expect, it } from 'vitest';
 import { compile } from '../src/compiler/index.js';
 
 describe('production component bundles', () => {
+	it('keeps pre-root hydration capture independent of the DOM tables', async () => {
+		const result = await build({
+			stdin: {
+				contents: `export { initializeHydrationEventCapture } from './src/hydration/index.ts';`,
+				loader: 'js',
+				resolveDir: resolve(import.meta.dirname, '..'),
+				sourcefile: 'hydration-capture-entry.js',
+			},
+			bundle: true,
+			format: 'esm',
+			logLevel: 'silent',
+			metafile: true,
+			treeShaking: false,
+			write: false,
+		});
+		const inputs = Object.keys(result.metafile.inputs).map((input) => input.split(sep).join('/'));
+
+		expect(inputs.some((input) => input.endsWith('/src/constants.ts'))).toBe(false);
+		expect(inputs.some((input) => input.endsWith('/src/dom-tables.js'))).toBe(false);
+	});
+
 	it('drops a bare package-root import when no exports are used', async () => {
 		const result = await build({
 			stdin: {
@@ -103,17 +124,25 @@ export function Retained() @{
 		expect(code).not.toContain('unused-event-template');
 	});
 
-	it('omits modules used only by a permanent-static boundary from the client bundle', async () => {
+	it('omits modules reached only through permanent-static local wrappers', async () => {
 		const page = compile(
 			`
 import { Hydrate } from 'octane';
 import { never } from 'octane/hydration';
 import { StaticNavigation } from 'fixture:static-navigation';
 
+function StaticLeaf() @{
+	<StaticNavigation />
+}
+
+function StaticShell() @{
+	<StaticLeaf />
+}
+
 export function App() @{
 	<main data-bundle-probe="live-page">
 		<Hydrate split={false} when={never()}>
-			<StaticNavigation />
+			<StaticShell />
 		</Hydrate>
 	</main>
 }

--- a/packages/octane/tests/stream-ownership-collisions.test.ts
+++ b/packages/octane/tests/stream-ownership-collisions.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, hydrateRoot } from 'octane';
+import { interaction } from 'octane/hydration';
+import { renderToPipeableStream, renderToString } from 'octane/server';
+import { loadServerFixture } from './_server-fixture.js';
+import * as client from './_fixtures/stream-ownership-collisions.tsrx';
+
+const server = loadServerFixture<typeof client>(
+	'packages/octane/tests/_fixtures/stream-ownership-collisions.tsrx',
+);
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((res) => (resolve = res));
+	return { promise, resolve };
+}
+
+function collector() {
+	const chunks: string[] = [];
+	let end!: () => void;
+	const ended = new Promise<void>((resolve) => (end = resolve));
+	return {
+		chunks,
+		ended,
+		dest: { write: (chunk: string) => chunks.push(chunk), end },
+	};
+}
+
+function activate(container: HTMLElement): void {
+	for (const script of Array.from(container.querySelectorAll('script'))) {
+		if (script.type === 'application/json') continue;
+		// eslint-disable-next-line no-eval
+		(0, eval)(script.textContent || '');
+		script.remove();
+	}
+}
+
+describe('stream ownership collision resistance', () => {
+	let container: HTMLDivElement;
+
+	beforeEach(() => {
+		container = document.createElement('div');
+		document.body.appendChild(container);
+	});
+
+	afterEach(() => {
+		container.remove();
+		delete (window as any).$OCTS;
+		delete (window as any).$OCTRC;
+		delete (window as any).$OCTRX;
+	});
+
+	it('treats an authored data-oct-b template as ordinary Hydrate content', async () => {
+		const onClick = vi.fn();
+		const onHydrated = vi.fn();
+		const when = interaction({ events: 'click' });
+		container.innerHTML = renderToString(server.AuthoredStreamAttribute, { when }).html;
+		const root = hydrateRoot(container, client.AuthoredStreamAttribute, {
+			when,
+			onClick,
+			onHydrated,
+		});
+		try {
+			(container.querySelector('#authored-stream-attribute-action') as HTMLButtonElement).click();
+			await vi.waitFor(async () => {
+				await act(() => {});
+				expect(onHydrated).toHaveBeenCalledOnce();
+			});
+			expect(onClick).toHaveBeenCalledOnce();
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it.each([
+		[
+			'a forged nested Hydrate attribute',
+			client.ForgedNestedHydrateAttribute,
+			server.ForgedNestedHydrateAttribute,
+			undefined,
+		],
+		[
+			'a malformed static comment',
+			client.MalformedStaticComment,
+			server.MalformedStaticComment,
+			'<!--octane-static-hydrate:not-a-count-->',
+		],
+		[
+			'an unmatched legacy static comment',
+			client.MalformedStaticComment,
+			server.MalformedStaticComment,
+			'<!--octane-static-hydrate:0-->',
+		],
+	])(
+		'waits for the genuine stream past %s',
+		async (_label, Component, ServerComponent, authoredHtml) => {
+			const serverValue = deferred<string>();
+			const onClick = vi.fn();
+			const onHydrated = vi.fn();
+			const when = interaction({ events: 'click' });
+			const c = collector();
+			renderToPipeableStream(ServerComponent as any, {
+				promise: serverValue.promise,
+				when,
+				authoredHtml,
+			}).pipe(c.dest);
+			container.innerHTML = c.chunks.join('');
+			activate(container);
+			const shellChunkCount = c.chunks.length;
+			const fallback = container.querySelector('#stream-collision-action') as HTMLButtonElement;
+			const root = hydrateRoot(container, Component as any, {
+				promise: new Promise<string>(() => {}),
+				when,
+				authoredHtml,
+				onClick,
+				onHydrated,
+			});
+			try {
+				fallback.click();
+				await act(() => {});
+				expect(onHydrated).not.toHaveBeenCalled();
+				expect(onClick).not.toHaveBeenCalled();
+
+				serverValue.resolve('Authenticated reveal');
+				await c.ended;
+				container.insertAdjacentHTML('beforeend', c.chunks.slice(shellChunkCount).join(''));
+				activate(container);
+				const revealed = container.querySelector('#stream-collision-action') as HTMLButtonElement;
+				expect(revealed.textContent).toBe('Authenticated reveal');
+				await vi.waitFor(async () => {
+					await act(() => {});
+					expect(onHydrated).toHaveBeenCalledOnce();
+				});
+				expect(container.querySelector('#stream-collision-action')).toBe(revealed);
+				expect(onClick).toHaveBeenCalledOnce();
+				expect(onClick).toHaveBeenCalledWith('Authenticated reveal');
+			} finally {
+				root.unmount();
+			}
+		},
+	);
+});

--- a/packages/octane/tests/streaming-ssr.test.ts
+++ b/packages/octane/tests/streaming-ssr.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { EventEmitter } from 'node:events';
 import { compile } from 'octane/compiler';
-import { hydrateRoot, flushSync } from '../src/index.js';
+import { act, hydrateRoot, flushSync } from '../src/index.js';
 import * as ServerRT from 'octane/server';
 import { prerender } from 'octane/static';
 import { interaction } from 'octane/hydration';
@@ -11,6 +11,7 @@ import { interaction } from 'octane/hydration';
 import {
 	Boundary,
 	DeferredAsyncLeaf,
+	DeferredStreamedSuspense,
 	IdBoundary,
 	LateStyledBoundary,
 	NestedStreamSeedScopes,
@@ -135,6 +136,60 @@ describe('renderToPipeableStream — chunk protocol', () => {
 		expect(clientValue.value).toBe('streamed deferred value');
 		expect(container.querySelector('#leaf')).toBe(serverLeaf);
 		root.unmount();
+	});
+
+	it('waits for a pending streamed reveal before activating deferred hydration', async () => {
+		const serverValue = deferred<string>();
+		const clientValue: any = new Promise<string>(() => {});
+		const onClick = vi.fn();
+		const onHydrated = vi.fn();
+		const when = interaction({ events: 'click' });
+		const c = collector();
+		ServerRT.renderToPipeableStream(server.DeferredStreamedSuspense, {
+			promise: serverValue.promise,
+			when,
+		}).pipe(c.dest);
+
+		container.innerHTML = c.chunks.join('');
+		activate(container);
+		const shellChunkCount = c.chunks.length;
+		const fallback = container.querySelector('#deferred-stream-action') as HTMLButtonElement;
+		expect(fallback.textContent).toBe('Loading streamed content');
+
+		const root = hydrateRoot(container, DeferredStreamedSuspense as any, {
+			promise: clientValue,
+			when,
+			onClick,
+			onHydrated,
+		});
+		try {
+			expect(() => fallback.click()).not.toThrow();
+			await act(() => {});
+
+			// Activation must stay dormant while the server still owns the pending
+			// reveal. Claiming the fallback now strands the later server result.
+			expect(container.querySelector('#deferred-stream-action')).toBe(fallback);
+			expect(onHydrated).not.toHaveBeenCalled();
+
+			serverValue.resolve('Streamed content');
+			await c.ended;
+			container.insertAdjacentHTML('beforeend', c.chunks.slice(shellChunkCount).join(''));
+			activate(container);
+			const revealed = container.querySelector('#deferred-stream-action') as HTMLButtonElement;
+			expect(revealed.textContent).toBe('Streamed content');
+
+			await vi.waitFor(async () => {
+				await act(() => {});
+				expect(onHydrated).toHaveBeenCalledOnce();
+			});
+			expect(container.querySelector('#deferred-stream-action')).toBe(revealed);
+			expect(clientValue.status).toBe('fulfilled');
+			expect(clientValue.value).toBe('Streamed content');
+			expect(onClick).toHaveBeenCalledOnce();
+			expect(onClick).toHaveBeenCalledWith('Streamed content');
+		} finally {
+			root.unmount();
+		}
 	});
 
 	it('flushes the shell with the fallback + template sentinel, then the segment', async () => {

--- a/packages/octane/tests/streaming-ssr.test.ts
+++ b/packages/octane/tests/streaming-ssr.test.ts
@@ -5,20 +5,25 @@ import { EventEmitter } from 'node:events';
 import { compile } from 'octane/compiler';
 import { act, hydrateRoot, flushSync } from '../src/index.js';
 import * as ServerRT from 'octane/server';
+import * as HydrationRT from 'octane/hydration';
 import { prerender } from 'octane/static';
-import { interaction } from 'octane/hydration';
+import { initializeHydrationEventCapture, interaction } from 'octane/hydration';
+import { loadServerFixture } from './_server-fixture.js';
 // CLIENT-compiled fixture (registers click delegation at import).
 import {
 	Boundary,
 	DeferredAsyncLeaf,
+	DeferredStreamWithLiveSibling,
 	DeferredStreamedSuspense,
 	IdBoundary,
 	LateStyledBoundary,
+	NestedDeferredStreamedHydrates,
 	NestedStreamSeedScopes,
 	ReasonBoundary,
 	Siblings,
 	StyledBoundary,
 } from './_fixtures/ssr-suspense.tsrx';
+import { DeferredWithPermanentStaticStream } from './_fixtures/ssr-permanent-static-stream.tsrx';
 
 // Streaming SSR — renderToPipeableStream / renderToReadableStream: shell with
 // fallbacks + <template data-oct-b> sentinels, out-of-order hidden segments
@@ -36,11 +41,22 @@ function serverModule(): Record<string, any> {
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
 		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
 	);
+	code = code.replace(
+		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/hydration['"];?/g,
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __hydration;`,
+	);
 	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
 	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');
-	return new Function('__rt', '__exports', code + '\nreturn __exports;')(ServerRT, {});
+	return new Function('__rt', '__hydration', '__exports', code + '\nreturn __exports;')(
+		ServerRT,
+		HydrationRT,
+		{},
+	);
 }
 const server = serverModule();
+const permanentStaticServer = loadServerFixture<{
+	DeferredWithPermanentStaticStream: typeof DeferredWithPermanentStaticStream;
+}>('packages/octane/tests/_fixtures/ssr-permanent-static-stream.tsrx');
 
 function deferred<T>() {
 	let resolve!: (v: T) => void;
@@ -77,6 +93,10 @@ function swapCall(id: string): string {
 
 function errorCall(id: string): string {
 	return '$OCTRX(' + JSON.stringify(id) + ')';
+}
+
+function staticErrorCall(id: string): string {
+	return '$OCTRX(' + JSON.stringify(id) + ',1)';
 }
 
 /** Execute the stream's inline scripts the way a browser would (in order). */
@@ -170,6 +190,7 @@ describe('renderToPipeableStream — chunk protocol', () => {
 			// reveal. Claiming the fallback now strands the later server result.
 			expect(container.querySelector('#deferred-stream-action')).toBe(fallback);
 			expect(onHydrated).not.toHaveBeenCalled();
+			expect(onClick).not.toHaveBeenCalled();
 
 			serverValue.resolve('Streamed content');
 			await c.ended;
@@ -183,10 +204,393 @@ describe('renderToPipeableStream — chunk protocol', () => {
 				expect(onHydrated).toHaveBeenCalledOnce();
 			});
 			expect(container.querySelector('#deferred-stream-action')).toBe(revealed);
-			expect(clientValue.status).toBe('fulfilled');
-			expect(clientValue.value).toBe('Streamed content');
 			expect(onClick).toHaveBeenCalledOnce();
 			expect(onClick).toHaveBeenCalledWith('Streamed content');
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('replays pre-root interaction after the pending stream reveals', async () => {
+		const serverValue = deferred<string>();
+		const clientValue: any = new Promise<string>(() => {});
+		const onClick = vi.fn();
+		const onHydrated = vi.fn();
+		const when = interaction({ events: 'click' });
+		const c = collector();
+		ServerRT.renderToPipeableStream(server.DeferredStreamedSuspense, {
+			promise: serverValue.promise,
+			when,
+		}).pipe(c.dest);
+
+		container.innerHTML = c.chunks.join('');
+		activate(container);
+		const shellChunkCount = c.chunks.length;
+		const fallback = container.querySelector('#deferred-stream-action') as HTMLButtonElement;
+		initializeHydrationEventCapture(document);
+		fallback.click();
+		expect(onClick).not.toHaveBeenCalled();
+
+		// The stream can replace the event target before hydrateRoot consumes the
+		// queued intent. Replay must address the corresponding revealed element.
+		serverValue.resolve('Pre-root streamed content');
+		await c.ended;
+		container.insertAdjacentHTML('beforeend', c.chunks.slice(shellChunkCount).join(''));
+		activate(container);
+		const revealed = container.querySelector('#deferred-stream-action') as HTMLButtonElement;
+		expect(revealed.textContent).toBe('Pre-root streamed content');
+
+		const root = hydrateRoot(container, DeferredStreamedSuspense as any, {
+			promise: clientValue,
+			when,
+			onClick,
+			onHydrated,
+		});
+		try {
+			await vi.waitFor(async () => {
+				await act(() => {});
+				expect(onHydrated).toHaveBeenCalledOnce();
+			});
+			expect(container.querySelector('#deferred-stream-action')).toBe(revealed);
+			expect(onClick).toHaveBeenCalledOnce();
+			expect(onClick).toHaveBeenCalledWith('Pre-root streamed content');
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('replays to a surviving sibling when a preceding stream changes element count', async () => {
+		const serverValue = deferred<string>();
+		const clientValue: any = new Promise<string>(() => {});
+		const onClick = vi.fn();
+		const onHydrated = vi.fn();
+		const when = interaction({ events: 'click' });
+		const c = collector();
+		ServerRT.renderToPipeableStream(server.DeferredStreamWithLiveSibling, {
+			promise: serverValue.promise,
+			when,
+		}).pipe(c.dest);
+
+		container.innerHTML = c.chunks.join('');
+		activate(container);
+		const shellChunkCount = c.chunks.length;
+		const sibling = container.querySelector('#stream-live-sibling') as HTMLButtonElement;
+		const root = hydrateRoot(container, DeferredStreamWithLiveSibling as any, {
+			promise: clientValue,
+			when,
+			onClick,
+			onHydrated,
+		});
+		try {
+			sibling.click();
+			await act(() => {});
+			expect(onClick).not.toHaveBeenCalled();
+			expect(onHydrated).not.toHaveBeenCalled();
+
+			serverValue.resolve('First streamed node');
+			await c.ended;
+			container.insertAdjacentHTML('beforeend', c.chunks.slice(shellChunkCount).join(''));
+			activate(container);
+			expect(container.querySelector('#streamed-first-value')?.textContent).toBe(
+				'First streamed node',
+			);
+			expect(container.querySelector('#streamed-second-value')?.textContent).toBe(
+				'Second streamed node',
+			);
+
+			await vi.waitFor(async () => {
+				await act(() => {});
+				expect(onHydrated).toHaveBeenCalledOnce();
+			});
+			expect(container.querySelector('#stream-live-sibling')).toBe(sibling);
+			expect(onClick).toHaveBeenCalledOnce();
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('does not make an outer Hydrate wait for a nested Hydrate stream reveal', async () => {
+		const serverValue = deferred<string>();
+		const clientValue: any = new Promise<string>(() => {});
+		const onOuterClick = vi.fn();
+		const onInnerClick = vi.fn();
+		const onOuterHydrated = vi.fn();
+		const onInnerHydrated = vi.fn();
+		const outerWhen = interaction({ events: 'click' });
+		const innerWhen = interaction({ events: 'click' });
+		const c = collector();
+		ServerRT.renderToPipeableStream(server.NestedDeferredStreamedHydrates, {
+			promise: serverValue.promise,
+			outerWhen,
+			innerWhen,
+		}).pipe(c.dest);
+
+		container.innerHTML = c.chunks.join('');
+		activate(container);
+		const shellChunkCount = c.chunks.length;
+		const outer = container.querySelector('#outer-deferred-stream-action') as HTMLButtonElement;
+		const nestedFallback = container.querySelector(
+			'#nested-deferred-stream-action',
+		) as HTMLButtonElement;
+		expect(nestedFallback.textContent).toBe('Loading nested stream');
+
+		const root = hydrateRoot(container, NestedDeferredStreamedHydrates as any, {
+			promise: clientValue,
+			outerWhen,
+			innerWhen,
+			onOuterClick,
+			onInnerClick,
+			onOuterHydrated,
+			onInnerHydrated,
+		});
+		try {
+			outer.click();
+			await vi.waitFor(async () => {
+				await act(() => {});
+				expect(onOuterHydrated).toHaveBeenCalledOnce();
+			});
+
+			// The pending record belongs to the independently dormant inner marker.
+			// It must survive outer adoption and must not delay the outer replay.
+			expect(container.querySelector('#outer-deferred-stream-action')).toBe(outer);
+			expect(container.querySelector('#nested-deferred-stream-action')).toBe(nestedFallback);
+			expect(onOuterClick).toHaveBeenCalledOnce();
+			expect(onInnerHydrated).not.toHaveBeenCalled();
+			expect(onInnerClick).not.toHaveBeenCalled();
+
+			serverValue.resolve('Nested streamed content');
+			await c.ended;
+			container.insertAdjacentHTML('beforeend', c.chunks.slice(shellChunkCount).join(''));
+			activate(container);
+			const revealed = container.querySelector(
+				'#nested-deferred-stream-action',
+			) as HTMLButtonElement;
+			expect(revealed.textContent).toBe('Nested streamed content');
+			expect(onInnerHydrated).not.toHaveBeenCalled();
+
+			revealed.click();
+			await vi.waitFor(async () => {
+				await act(() => {});
+				expect(onInnerHydrated).toHaveBeenCalledOnce();
+			});
+			expect(container.querySelector('#nested-deferred-stream-action')).toBe(revealed);
+			expect(onInnerClick).toHaveBeenCalledOnce();
+			expect(onInnerClick).toHaveBeenCalledWith('Nested streamed content');
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('does not make an outer Hydrate wait for a permanent-static stream reveal', async () => {
+		const serverValue = deferred<string>();
+		const onClick = vi.fn();
+		const onHydrated = vi.fn();
+		const when = interaction({ events: 'click' });
+		const c = collector();
+		ServerRT.renderToPipeableStream(permanentStaticServer.DeferredWithPermanentStaticStream, {
+			promise: serverValue.promise,
+			when,
+		}).pipe(c.dest);
+
+		container.innerHTML = c.chunks.join('');
+		activate(container);
+		const [staticBoundaryId] = protocolIds(c.chunks.join(''));
+		const shellChunkCount = c.chunks.length;
+		const staticFallback = container.querySelector(
+			'#permanent-static-stream-value',
+		) as HTMLSpanElement;
+		const action = container.querySelector(
+			'#deferred-permanent-static-action',
+		) as HTMLButtonElement;
+		const root = hydrateRoot(container, DeferredWithPermanentStaticStream as any, {
+			promise: new Promise<string>(() => {}),
+			when,
+			onClick,
+			onHydrated,
+		});
+		try {
+			action.click();
+			await vi.waitFor(async () => {
+				await act(() => {});
+				expect(onHydrated).toHaveBeenCalledOnce();
+			});
+
+			// The static subtree stays under the server stream's ownership while the
+			// live sibling hydrates and replays independently.
+			expect(container.querySelector('#deferred-permanent-static-action')).toBe(action);
+			expect(container.querySelector('#permanent-static-stream-value')).toBe(staticFallback);
+			expect(onClick).toHaveBeenCalledOnce();
+
+			serverValue.resolve('Permanent static streamed content');
+			await c.ended;
+			const tail = c.chunks.slice(shellChunkCount).join('');
+			expect(tail).not.toContain('data-oct-seed');
+			container.insertAdjacentHTML('beforeend', tail);
+			activate(container);
+			expect((window as any).$OCTS?.[staticBoundaryId]).toBeUndefined();
+			expect(container.querySelector('#permanent-static-stream-value')?.textContent).toBe(
+				'Permanent static streamed content',
+			);
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('routes a synchronous permanent-static error to an enclosing server catch', async () => {
+		const c = collector();
+		const onError = vi.fn();
+		ServerRT.renderToPipeableStream(
+			permanentStaticServer.PermanentStaticSyncCaught,
+			{ error: new Error('static shell boom') },
+			{ onError },
+		).pipe(c.dest);
+
+		await c.ended;
+		const html = c.chunks.join('');
+		expect(html).toContain('id="permanent-static-sync-catch"');
+		expect(html).toContain('static shell boom');
+		expect(html).not.toContain('data-oct-b');
+		expect(html).not.toContain('$OCTRX(');
+		expect(onError).not.toHaveBeenCalled();
+	});
+
+	it('retains a permanent-static fallback when its pending stream rejects', async () => {
+		const value = deferred<string>();
+		const c = collector();
+		const onError = vi.fn();
+		const onAllReady = vi.fn();
+		ServerRT.renderToPipeableStream(
+			permanentStaticServer.PermanentStaticRejectedStream,
+			{ promise: value.promise },
+			{ onError, onAllReady },
+		).pipe(c.dest);
+
+		container.innerHTML = c.chunks.join('');
+		activate(container);
+		const shellChunkCount = c.chunks.length;
+		const [id] = protocolIds(c.chunks.join(''));
+		const fallback = container.querySelector('#permanent-static-rejected-fallback');
+		value.reject(new Error('static stream boom'));
+		await c.ended;
+		const tail = c.chunks.slice(shellChunkCount).join('');
+		expect(tail).toContain(staticErrorCall(id));
+		expect(tail).not.toContain(errorCall(id));
+		container.insertAdjacentHTML('beforeend', tail);
+		activate(container);
+
+		expect(container.querySelector('template[data-oct-b]')).toBeNull();
+		expect(container.querySelector('#permanent-static-rejected-fallback')).toBe(fallback);
+		expect(onError).toHaveBeenCalledWith(
+			expect.objectContaining({ message: 'static stream boom' }),
+		);
+		expect(onAllReady).toHaveBeenCalledOnce();
+	});
+
+	it('streams an authored catch inside a permanent-static range', async () => {
+		const value = deferred<string>();
+		const c = collector();
+		const onError = vi.fn();
+		ServerRT.renderToPipeableStream(
+			permanentStaticServer.PermanentStaticCaughtStream,
+			{ promise: value.promise },
+			{ onError },
+		).pipe(c.dest);
+
+		container.innerHTML = c.chunks.join('');
+		activate(container);
+		const shellChunkCount = c.chunks.length;
+		value.reject(new Error('caught static stream boom'));
+		await c.ended;
+		const tail = c.chunks.slice(shellChunkCount).join('');
+		expect(tail).not.toContain('data-oct-seed');
+		container.insertAdjacentHTML('beforeend', tail);
+		activate(container);
+
+		expect(container.querySelector('#permanent-static-caught-error')?.textContent).toBe(
+			'caught static stream boom',
+		);
+		expect(onError).not.toHaveBeenCalled();
+	});
+
+	it('retains a permanent-static fallback when the stream aborts', async () => {
+		const value = deferred<string>();
+		const c = collector();
+		const onError = vi.fn();
+		const onAllReady = vi.fn();
+		const render = ServerRT.renderToPipeableStream(
+			permanentStaticServer.PermanentStaticRejectedStream,
+			{ promise: value.promise },
+			{ onError, onAllReady },
+		);
+		render.pipe(c.dest);
+
+		container.innerHTML = c.chunks.join('');
+		activate(container);
+		const shellChunkCount = c.chunks.length;
+		const [id] = protocolIds(c.chunks.join(''));
+		const fallback = container.querySelector('#permanent-static-rejected-fallback');
+		render.abort(new Error('static stream aborted'));
+		await c.ended;
+		const tail = c.chunks.slice(shellChunkCount).join('');
+		expect(tail).toContain(staticErrorCall(id));
+		container.insertAdjacentHTML('beforeend', tail);
+		activate(container);
+
+		expect(container.querySelector('template[data-oct-b]')).toBeNull();
+		expect(container.querySelector('#permanent-static-rejected-fallback')).toBe(fallback);
+		expect(onError).toHaveBeenCalledWith(
+			expect.objectContaining({ message: 'static stream aborted' }),
+		);
+		expect(onAllReady).toHaveBeenCalledOnce();
+	});
+
+	it('releases deferred activation when a pending stream degrades to client rendering', async () => {
+		const serverValue = deferred<string>();
+		const clientValue = deferred<string>();
+		const onClick = vi.fn();
+		const onHydrated = vi.fn();
+		const onError = vi.fn();
+		const when = interaction({ events: 'click' });
+		const c = collector();
+		const render = ServerRT.renderToPipeableStream(
+			server.DeferredStreamedSuspense,
+			{ promise: serverValue.promise, when },
+			{ onError },
+		);
+		render.pipe(c.dest);
+
+		container.innerHTML = c.chunks.join('');
+		activate(container);
+		const shellChunkCount = c.chunks.length;
+		const fallback = container.querySelector('#deferred-stream-action') as HTMLButtonElement;
+		const root = hydrateRoot(container, DeferredStreamedSuspense as any, {
+			promise: clientValue.promise,
+			when,
+			onClick,
+			onHydrated,
+		});
+		try {
+			fallback.click();
+			await act(() => {});
+			expect(onHydrated).not.toHaveBeenCalled();
+
+			render.abort(new Error('defer to client'));
+			await c.ended;
+			container.insertAdjacentHTML('beforeend', c.chunks.slice(shellChunkCount).join(''));
+			activate(container);
+			expect(container.querySelector('#deferred-stream-action')).toBe(fallback);
+			expect(onError).toHaveBeenCalled();
+
+			clientValue.resolve('Client recovery');
+			await vi.waitFor(async () => {
+				await act(() => {});
+				expect(onHydrated).toHaveBeenCalledOnce();
+			});
+			expect(container.querySelector('#deferred-stream-action')?.textContent).toBe(
+				'Client recovery',
+			);
+			expect(onClick).toHaveBeenCalledOnce();
+			expect(onClick).toHaveBeenCalledWith('Client recovery');
 		} finally {
 			root.unmount();
 		}

--- a/packages/octane/typetests/hydration-jsx.test-d.tsx
+++ b/packages/octane/typetests/hydration-jsx.test-d.tsx
@@ -1,0 +1,7 @@
+/** @jsxImportSource octane */
+import { Hydrate } from 'octane';
+import { never } from 'octane/hydration';
+
+// The permanent-static contract includes an empty range. `children` is
+// therefore optional even though useful deferred boundaries normally provide it.
+export const emptyPermanentStaticBoundary = <Hydrate split={false} when={never()} />;


### PR DESCRIPTION
## Summary

- compile the exact direct-import `<Hydrate split={false} when={never()}>` form into a wrapper-free server-owned range, reserve IDs without client evaluation, and prune only private module-scope descendants proven exclusive to it
- make deferred activation wait for authenticated renderer-owned streamed Suspense reveals, preserving replay targets across swaps while respecting nested Hydrate/static ownership
- retain static fallbacks on late stream rejection or abort, omit unconsumable static seeds, and reject forged protocol lookalikes
- document the contract and add a patch changeset plus dev/prod compiler, SSR, hydration, bundle, type, collision, and failure regressions

Addresses #228.

## Scope note

Existing externally patched descendants remain preserved across hydration and surrounding updates while Octane's private ownership markers remain intact. This PR does not invent a public behavior-adoption, conflict, or disposal API; that remains separate API design work.

## Validation

- `pnpm test` — 1,280 files / 12,348 tests passed
- `pnpm typecheck`
- `pnpm format:check`
- focused dev/prod deferred-hydration matrix — 20 files / 312 tests passed

## Performance and conservatism

The common activation path uses a native selector rejection before ownership-aware scanning, and stream tokens are emitted only for Hydrate ranges containing pending renderer work. Static declaration pruning deliberately retains exported, shared, coupled, unsupported runtime-TypeScript, and direct-eval shapes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches hydration compiler graph pruning, SSR streaming error paths, and client activation/replay—areas where subtle ordering bugs affect DOM adoption and interactivity.
> 
> **Overview**
> Adds the **permanent-static** contract for the exact `<Hydrate split={false} when={never()}>` form: the client compiler erases that subtree, prunes private module-scope declarations/imports used only there, and rewrites the tag to `Hydrate.__octanePermanentStatic` with `children={null}` while retaining owning scoped `<style>` for hash parity. SSR renders **wrapper-free** content bounded by `<!--octane-static-hydrate:…-->` markers (with optional stream tokens); the client reserves `useId` slots without evaluating or reconciling those nodes, and client-only mounts render no static children.
> 
> **Streaming SSR** marks boundaries under permanent-static depth as `serverOwnedStatic` (no per-boundary client seeds, sync errors reach authored catches). Pending stream failures use `$OCTRX(id,1)` to drop the sentinel and **keep the flushed fallback** instead of client recovery.
> 
> **Deferred activation** no longer races renderer-owned Suspense: dormant boundaries with a stream token wait via `MutationObserver` until owned `template[data-oct-b]` reveals complete or degrade; nested dormant `Hydrate` and permanent-static ranges do not block ancestors. Event paths and interaction replay skip stream sentinels and prefer the original event target when it still lives in the tree.
> 
> Introduces dependency-free `stream-protocol.ts` for shared stream/Hydrate token helpers (including pre-root capture), documents the new behavior, and expands compiler, hydration, streaming, bundle, and collision tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba0fa9941ab0064a43815b5612a761a0fb1a0890. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->