### PR TITLE
WIP: fix(ast): playground ast preview

### DIFF
--- a/.changeset/client-template-tag-maps.md
+++ b/.changeset/client-template-tag-maps.md
@@ -2,5 +2,6 @@
 'octane': patch
 ---
 
-Map host JSX tag names baked into client template strings back to their exact
-authored positions in compiler source maps.
+Allow inspection tooling to opt into exact source-map anchors for host JSX tag
+names baked into client template strings. Normal compiles keep the existing
+path without tag-location allocations or scans.

--- a/.changeset/client-template-tag-maps.md
+++ b/.changeset/client-template-tag-maps.md
@@ -1,0 +1,6 @@
+---
+'octane': patch
+---
+
+Map host JSX tag names baked into client template strings back to their exact
+authored positions in compiler source maps.

--- a/.changeset/trace-playground-asts.md
+++ b/.changeset/trace-playground-asts.md
@@ -1,0 +1,7 @@
+---
+'octane': patch
+---
+
+Expose opt-in type-transform and generated-output AST tracing through the
+Volar compiler path. Keep scoped-style virtual TSX parseable with correctly
+shifted source mappings so tooling can correlate its final output reliably.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -3648,16 +3648,42 @@ function countNewlines(str) {
 	return n;
 }
 
+function sourceLineStarts(source) {
+	const starts = [0];
+	for (let index = 0; index < source.length; index++) {
+		if (source.charCodeAt(index) === 10) starts.push(index + 1);
+	}
+	return starts;
+}
+
+function closingTagSourceLoc(ctx, node, tag) {
+	const end = node.loc?.end;
+	const starts = ctx.hostTagMap?.lineStarts;
+	if (!end || !starts) return null;
+	const endOffset = starts[end.line - 1] + end.column;
+	const nameOffset = ctx.mapSource.lastIndexOf(`</${tag}`, endOffset) + 2;
+	if (nameOffset < 2) return null;
+	let low = 0;
+	let high = starts.length;
+	while (low < high) {
+		const middle = (low + high) >> 1;
+		if (starts[middle] <= nameOffset) low = middle + 1;
+		else high = middle;
+	}
+	const lineIndex = low - 1;
+	return { line: lineIndex + 1, column: nameOffset - starts[lineIndex] };
+}
+
 /**
  * Build a v3 source map from a flat list of mapping segments. The segments come
  * from esrap itself — we print each user statement/expression via esrap with
  * `sourceMapEncodeMappings: false` (the same machinery the mainline TSRX
  * compilers use) and merge each node's real per-token mappings into module
  * coordinates. Generated runtime plumbing (mount/update DOM ops) is left
- * unmapped — never mapped to a wrong position. Baked template tag names are the
- * exception: the emitter records their exact authored and generated positions
- * so devtools can trace the static DOM shape too. `sourcesContent` is inlined so
- * the original `.tsrx` is visible in devtools.
+ * unmapped — never mapped to a wrong position. Opt-in inspection compiles also
+ * record exact authored and generated positions for baked client template tag
+ * names. `sourcesContent` is inlined so the original `.tsrx` is visible in
+ * devtools.
  *
  * @param {string} source original .tsrx text
  * @param {string} sourceName basename used as the map's single source entry
@@ -4182,7 +4208,7 @@ function instrumentProfileComponents(ast, ctx) {
  * Compile a .tsrx source string into JS targeting `octane`.
  * @param {string} source
  * @param {string} filename
- * @param {{ hmr?: boolean | 'vite' | 'webpack', mode?: 'client' | 'server', dev?: boolean, profile?: boolean, profileFilename?: string, autoMemo?: boolean, inlineHookMemo?: boolean, renderer?: { id: string, module: string, target: 'dom' | 'universal', server?: string }, rendererBoundaries?: Readonly<Record<string, Readonly<Record<string, { ownerRenderer: string, childRenderer: string, prop: string, server?: string }>>>>, rendererRegistry?: Readonly<Record<string, { module: string, target: 'dom' | 'universal', server?: string }>>, clientOnlyImports?: readonly unknown[], __hydratePrepared?: boolean, __hydrateBoundaryModule?: boolean, __nativeChangeDiagnostics?: readonly unknown[], __nativeChangeAnalysis?: { diagnostics: readonly unknown[], classifications: Map<number, string> } }} [options] —
+ * @param {{ hmr?: boolean | 'vite' | 'webpack', mode?: 'client' | 'server', dev?: boolean, profile?: boolean, profileFilename?: string, autoMemo?: boolean, inlineHookMemo?: boolean, sourceMapHostTags?: boolean, renderer?: { id: string, module: string, target: 'dom' | 'universal', server?: string }, rendererBoundaries?: Readonly<Record<string, Readonly<Record<string, { ownerRenderer: string, childRenderer: string, prop: string, server?: string }>>>>, rendererRegistry?: Readonly<Record<string, { module: string, target: 'dom' | 'universal', server?: string }>>, clientOnlyImports?: readonly unknown[], __hydratePrepared?: boolean, __hydrateBoundaryModule?: boolean, __nativeChangeDiagnostics?: readonly unknown[], __nativeChangeAnalysis?: { diagnostics: readonly unknown[], classifications: Map<number, string> } }} [options] —
  *   `dev: true` emits client hydration source-location metadata (per-component
  *   `__s.locs`/`__s.locFile`) and, in server mode, source-located native-element
  *   scopes for invalid HTML nesting diagnostics. Both are strictly gated so
@@ -4197,6 +4223,9 @@ function instrumentProfileComponents(ast, ctx) {
  *   template-clone DOM runtime; `'server'` emits HTML-string SSR output (static
  *   chunks interleaved with `ssr*` helpers) carrying the hydration markers the
  *   client `hydrateRoot` adopts.
+ *   `sourceMapHostTags: true` adds exact source-map anchors for host tag
+ *   names baked into client template strings. It is opt-in for inspection
+ *   tooling; normal compiles skip all tag-location collection and scanning.
  *   `rendererBoundaries` and `rendererRegistry` are the normalized static
  *   boundary table and renderer registry. Pass them together when a client
  *   module may contain an explicitly renderer-owned component prop.
@@ -4632,6 +4661,7 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 	// inline-cache-vs-elsewhere in one line.
 	const inlineHookMemoEnabled =
 		options?.inlineHookMemo !== false && !hmrEnabled && !devEnabled && !profileEnabled;
+	const sourceMapHostTags = mode === 'client' && options?.sourceMapHostTags === true;
 	const ctx = {
 		filename,
 		usedCompilerNames: collectIdentifierNames(ast),
@@ -4654,8 +4684,7 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 		userRuntimeNamespaces: new Set(), // `import * as ns from 'octane'`
 		userRuntimeDefaults: new Set(), // preserved verbatim; package resolution owns validity
 		consumedRuntimeLocals,
-		hoistedTemplates: [], // { name, html, tagMappings }
-		_templateTagSources: null, // current plan's emitted host-tag source positions
+		hoistedTemplates: [], // { name, html, tagMappings? }
 		hoistedHelpers: [], // raw JS strings (sub-components, hook Symbols, key fns)
 		delegatedEvents: new Set(), // bubble event names seen in JSX — auto-emits delegateEvents(...)
 		capturedEvents: new Set(), // capture-phase event names (onXxxCapture) — auto-emits delegateCaptureEvents(...)
@@ -4701,6 +4730,11 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 		// the top-level (autoCallback) pass and drained per component below.
 		_setupMaps: null,
 	};
+	if (sourceMapHostTags) {
+		// Inspection-only state stays completely absent from the normal compiler
+		// context shape. `current` is swapped per nested JSX plan.
+		ctx.hostTagMap = { current: null, lineStarts: sourceLineStarts(source) };
+	}
 	{
 		const imports = collectOctaneImportBindings(ast.body);
 		ctx.octaneImportLocals = imports.locals;
@@ -5305,36 +5339,45 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 		.map((i) => `_$injectStyle(${JSON.stringify(i.hash)}, ${JSON.stringify(i.css)});`)
 		.join('\n');
 	const styleBlock = styleInjections ? styleInjections + '\n\n' : '';
-	const templateSegments = [];
-	const templates = ctx.hoistedTemplates
-		.map((t, templateLine) => {
-			const prefix = `const ${t.name} = /* @__PURE__ */ _$template(`;
-			const args = [JSON.stringify(t.html)];
-			let previousHtmlOffset = 0;
-			let encodedHtmlOffset = 0;
+	const templateSegments = sourceMapHostTags ? [] : null;
+	const templateLines = [];
+	for (let templateLine = 0; templateLine < ctx.hoistedTemplates.length; templateLine++) {
+		const t = ctx.hoistedTemplates[templateLine];
+		const prefix = `const ${t.name} = /* @__PURE__ */ _$template(`;
+		const encodedHtml = JSON.stringify(t.html);
+		if (templateSegments !== null) {
+			let htmlOffset = 0;
+			let encodedOffset = 1; // Skip the serialized string's opening quote.
 			for (const mapping of t.tagMappings) {
-				// JSON string escaping can expand quotes/control characters before a
-				// tag. Encode each disjoint chunk once so mapping all tags stays O(n).
-				encodedHtmlOffset +=
-					JSON.stringify(t.html.slice(previousHtmlOffset, mapping.htmlOffset)).length - 2;
-				previousHtmlOffset = mapping.htmlOffset;
+				// Walk the already-serialized string monotonically. An escape sequence
+				// occupies 2 or 6 generated columns but represents one UTF-16 code unit.
+				while (htmlOffset < mapping.htmlOffset) {
+					if (encodedHtml.charCodeAt(encodedOffset) === 92) {
+						encodedOffset += encodedHtml.charCodeAt(encodedOffset + 1) === 117 ? 6 : 2;
+					} else {
+						encodedOffset++;
+					}
+					htmlOffset++;
+				}
 				templateSegments.push({
 					genLine: templateLine,
-					genCol: prefix.length + 1 + encodedHtmlOffset,
+					genCol: prefix.length + encodedOffset,
 					srcLine0: mapping.srcLine0,
 					srcCol0: mapping.srcCol0,
 				});
 				templateSegments.push({
 					genLine: templateLine,
-					genCol: prefix.length + 1 + encodedHtmlOffset + mapping.length,
+					genCol: prefix.length + encodedOffset + mapping.length,
 					unmapped: true,
 				});
 			}
-			if (t.ns || t.frag) args.push(String(t.ns | 0));
-			if (t.frag) args.push(String(t.frag | 0));
-			return prefix + args.join(', ') + ');';
-		})
-		.join('\n');
+		}
+		let args = encodedHtml;
+		if (t.ns || t.frag) args += `, ${t.ns | 0}`;
+		if (t.frag) args += `, ${t.frag | 0}`;
+		templateLines.push(prefix + args + ');');
+	}
+	const templates = templateLines.join('\n');
 	const templatesBlock = templates ? templates + '\n\n' : '';
 	// No tail slots exist on the client today (prop memos are server-only), but
 	// flush before assembly so a future client-side tail site cannot trip the
@@ -5464,21 +5507,18 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 	const prelude = beforeTemplates + templatesBlock + helpersBlock;
 	const preludeLines = countNewlines(prelude);
 	const templateLineOffset = countNewlines(beforeTemplates);
-	const segments = [
-		...templateSegments.map((s) => ({
-			genLine: s.genLine + templateLineOffset,
-			genCol: s.genCol,
-			srcLine0: s.srcLine0,
-			srcCol0: s.srcCol0,
-			unmapped: s.unmapped,
-		})),
-		...bodySegments.map((s) => ({
+	const segments = templateSegments ?? [];
+	if (templateSegments !== null) {
+		for (const segment of templateSegments) segment.genLine += templateLineOffset;
+	}
+	for (const s of bodySegments) {
+		segments.push({
 			genLine: s.genLine + preludeLines,
 			genCol: s.genCol,
 			srcLine0: s.srcLine0,
 			srcCol0: s.srcCol0,
-		})),
-	];
+		});
+	}
 
 	const result = {
 		code: prelude + body + stampBlock + hmrBlock + profileBlock,
@@ -12443,7 +12483,6 @@ function normalizeChildren(nodes, inSvg = false) {
 				id: n.openingElement.name,
 				attributes: n.openingElement.attributes || [],
 				openingElement: n.openingElement,
-				closingTagLoc: n.closingElement?.name?.loc?.start,
 				children: n.children || [],
 				selfClosing: n.openingElement.selfClosing,
 				loc: n.loc, // preserve element position for dev hydration LOC (component slots)
@@ -12903,8 +12942,9 @@ function planJsx(
 	// Source positions for host tags emitted into THIS plan's template. Nested
 	// plans temporarily replace this list and restore it before the outer walk
 	// continues, matching the other plan-local compiler state below.
-	const _prevTemplateTagSources = ctx._templateTagSources;
-	ctx._templateTagSources = [];
+	const hostTagMap = ctx.hostTagMap;
+	const previousHostTagSources = hostTagMap?.current ?? null;
+	if (hostTagMap) hostTagMap.current = [];
 
 	// Emit ONE template containing all top-level JSX (wrapping multiple roots in
 	// a synthetic <octane-frag>).
@@ -13129,7 +13169,7 @@ function planJsx(
 		const fragArg = !single && (flag !== 0 || resolvedFrag) ? 1 : 0;
 		const tplHtml =
 			single || flag !== 0 || resolvedFrag ? html : `<octane-frag>${html}</octane-frag>`;
-		const tpl = allocTemplate(ctx, tplHtml, flag, fragArg, ctx._templateTagSources);
+		const tpl = allocTemplate(ctx, tplHtml, flag, fragArg, hostTagMap?.current ?? null);
 		// DEV: pass the root element's source location so a STRUCTURAL hydration mismatch
 		// (swapped @if/@switch branch, changed tag) warns with `file:line:col`. Single-root
 		// only (a multi-root <octane-frag> wrapper has no source position); prod omits it.
@@ -13923,7 +13963,7 @@ function planJsx(
 	ctx._fragRefStack = _prevFragRefStack;
 	// Restore the outer plan's per-element LOC map — pairs with the save at planJsx top.
 	ctx._elemLocs = _prevElemLocs;
-	ctx._templateTagSources = _prevTemplateTagSources;
+	if (hostTagMap) hostTagMap.current = previousHostTagSources;
 
 	const updateJoined = updateLines.join('\n');
 	const everyRenderJoined = everyRenderLines.join('\n');
@@ -14710,14 +14750,18 @@ function emitElementHtml(
 
 	const tag = node.id?.name || node.openingElement?.name?.name;
 	if (!tag) throw new Error('Element without tag');
-	const openingTagLoc = (node.openingElement?.name ?? node.id)?.loc?.start;
-	if (ctx._templateTagSources && openingTagLoc) {
-		ctx._templateTagSources.push({
-			kind: 'open',
-			tag,
-			srcLine0: openingTagLoc.line - 1,
-			srcCol0: openingTagLoc.column | 0,
-		});
+	const hostTagSources = ctx.hostTagMap?.current;
+	let openingTagLoc = null;
+	if (hostTagSources) {
+		openingTagLoc = (node.openingElement?.name ?? node.id)?.loc?.start;
+		if (openingTagLoc) {
+			hostTagSources.push({
+				kind: 'open',
+				tag,
+				srcLine0: openingTagLoc.line - 1,
+				srcCol0: openingTagLoc.column | 0,
+			});
+		}
 	}
 	const authoredStaticScriptContent = staticScriptContent(node, tag);
 	const hasAuthoredStaticScriptBody =
@@ -15705,17 +15749,18 @@ function emitElementHtml(
 
 	if (!isVoid) {
 		html += `</${tag}>`;
-		const closingTagLoc =
-			node.closingTagLoc ??
-			node.closingElement?.name?.loc?.start ??
-			(node.selfClosing ? openingTagLoc : null);
-		if (ctx._templateTagSources && closingTagLoc) {
-			ctx._templateTagSources.push({
-				kind: 'close',
-				tag,
-				srcLine0: closingTagLoc.line - 1,
-				srcCol0: closingTagLoc.column | 0,
-			});
+		if (hostTagSources) {
+			const closingTagLoc =
+				node.closingElement?.name?.loc?.start ??
+				(node.selfClosing ? openingTagLoc : closingTagSourceLoc(ctx, node, tag));
+			if (closingTagLoc) {
+				hostTagSources.push({
+					kind: 'close',
+					tag,
+					srcLine0: closingTagLoc.line - 1,
+					srcCol0: closingTagLoc.column | 0,
+				});
+			}
 		}
 	}
 	return html;
@@ -17203,10 +17248,11 @@ function walkExprH(rootVar, path) {
 	return expr;
 }
 
-function templateTagTokens(html) {
-	const tokens = [];
+function mapTemplateTags(html, sources) {
+	if (!sources || sources.length === 0) return sources || [];
+	let sourceIndex = 0;
 	let index = 0;
-	while (index < html.length) {
+	while (index < html.length && sourceIndex < sources.length) {
 		const opening = html.indexOf('<', index);
 		if (opening === -1) break;
 		if (html.startsWith('<!--', opening)) {
@@ -17227,8 +17273,16 @@ function templateTagTokens(html) {
 			if (character <= 32 || character === 47 || character === 62) break;
 			nameEnd++;
 		}
-		if (nameEnd > nameStart) {
-			tokens.push({ kind, tag: html.slice(nameStart, nameEnd), nameStart });
+
+		const source = sources[sourceIndex];
+		if (
+			kind === source.kind &&
+			nameEnd - nameStart === source.tag.length &&
+			html.startsWith(source.tag, nameStart)
+		) {
+			source.htmlOffset = nameStart;
+			source.length = source.tag.length;
+			sourceIndex++;
 		}
 
 		// Advance past the complete tag so a `<tag` substring inside a quoted
@@ -17248,43 +17302,18 @@ function templateTagTokens(html) {
 		}
 		index = cursor > opening ? cursor : opening + 1;
 	}
-	return tokens;
-}
-
-function mapTemplateTags(html, sources) {
-	if (!sources || sources.length === 0) return [];
-	const tokens = templateTagTokens(html);
-	const mappings = [];
-	let tokenIndex = 0;
-	for (const source of sources) {
-		while (
-			tokenIndex < tokens.length &&
-			(tokens[tokenIndex].kind !== source.kind || tokens[tokenIndex].tag !== source.tag)
-		) {
-			tokenIndex++;
-		}
-		if (tokenIndex === tokens.length) break;
-		mappings.push({
-			htmlOffset: tokens[tokenIndex].nameStart,
-			length: source.tag.length,
-			srcLine0: source.srcLine0,
-			srcCol0: source.srcCol0,
-		});
-		tokenIndex++;
-	}
-	return mappings;
+	// The matched prefix already contains the mapping objects. Truncate any
+	// unmatched tail instead of allocating a second per-template array.
+	sources.length = sourceIndex;
+	return sources;
 }
 
 function allocTemplate(ctx, html, ns = 0, frag = 0, tagSources = null) {
 	const id = ctx.nextTemplateId++;
 	const name = `_t$${id}`;
-	ctx.hoistedTemplates.push({
-		name,
-		html,
-		ns,
-		frag,
-		tagMappings: mapTemplateTags(html, tagSources),
-	});
+	const template = { name, html, ns, frag };
+	if (tagSources !== null) template.tagMappings = mapTemplateTags(html, tagSources);
+	ctx.hoistedTemplates.push(template);
 	return name;
 }
 

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -3653,13 +3653,15 @@ function countNewlines(str) {
  * from esrap itself — we print each user statement/expression via esrap with
  * `sourceMapEncodeMappings: false` (the same machinery the mainline TSRX
  * compilers use) and merge each node's real per-token mappings into module
- * coordinates. Generated runtime plumbing (templates, mount/update DOM ops) is
- * left unmapped — never mapped to a wrong position. `sourcesContent` is inlined
- * so the original `.tsrx` is visible in devtools.
+ * coordinates. Generated runtime plumbing (mount/update DOM ops) is left
+ * unmapped — never mapped to a wrong position. Baked template tag names are the
+ * exception: the emitter records their exact authored and generated positions
+ * so devtools can trace the static DOM shape too. `sourcesContent` is inlined so
+ * the original `.tsrx` is visible in devtools.
  *
  * @param {string} source original .tsrx text
  * @param {string} sourceName basename used as the map's single source entry
- * @param {Array<{ genLine: number, genCol: number, srcLine0: number, srcCol0: number }>} segments
+ * @param {Array<{ genLine: number, genCol: number, srcLine0?: number, srcCol0?: number, unmapped?: boolean }>} segments
  *   genLine/genCol are 0-based ABSOLUTE generated coords; src* are 0-based source coords.
  */
 function buildSourceMap(source, sourceName, segments) {
@@ -3689,6 +3691,11 @@ function buildSourceMap(source, sourceName, segments) {
 		for (const s of arr) {
 			if (s.genCol === lastGenCol) continue;
 			lastGenCol = s.genCol;
+			if (s.unmapped) {
+				group += (group ? ',' : '') + encodeVlq([s.genCol - prevGenCol]);
+				prevGenCol = s.genCol;
+				continue;
+			}
 			// Fields: [genColumn, sourceIndex, sourceLine, sourceColumn] as deltas.
 			// genColumn resets per line; sourceIndex is always 0 (single source).
 			group +=
@@ -4647,7 +4654,8 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 		userRuntimeNamespaces: new Set(), // `import * as ns from 'octane'`
 		userRuntimeDefaults: new Set(), // preserved verbatim; package resolution owns validity
 		consumedRuntimeLocals,
-		hoistedTemplates: [], // { name, html }
+		hoistedTemplates: [], // { name, html, tagMappings }
+		_templateTagSources: null, // current plan's emitted host-tag source positions
 		hoistedHelpers: [], // raw JS strings (sub-components, hook Symbols, key fns)
 		delegatedEvents: new Set(), // bubble event names seen in JSX — auto-emits delegateEvents(...)
 		capturedEvents: new Set(), // capture-phase event names (onXxxCapture) — auto-emits delegateCaptureEvents(...)
@@ -5297,12 +5305,34 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 		.map((i) => `_$injectStyle(${JSON.stringify(i.hash)}, ${JSON.stringify(i.css)});`)
 		.join('\n');
 	const styleBlock = styleInjections ? styleInjections + '\n\n' : '';
+	const templateSegments = [];
 	const templates = ctx.hoistedTemplates
-		.map((t) => {
+		.map((t, templateLine) => {
+			const prefix = `const ${t.name} = /* @__PURE__ */ _$template(`;
 			const args = [JSON.stringify(t.html)];
+			let previousHtmlOffset = 0;
+			let encodedHtmlOffset = 0;
+			for (const mapping of t.tagMappings) {
+				// JSON string escaping can expand quotes/control characters before a
+				// tag. Encode each disjoint chunk once so mapping all tags stays O(n).
+				encodedHtmlOffset +=
+					JSON.stringify(t.html.slice(previousHtmlOffset, mapping.htmlOffset)).length - 2;
+				previousHtmlOffset = mapping.htmlOffset;
+				templateSegments.push({
+					genLine: templateLine,
+					genCol: prefix.length + 1 + encodedHtmlOffset,
+					srcLine0: mapping.srcLine0,
+					srcCol0: mapping.srcCol0,
+				});
+				templateSegments.push({
+					genLine: templateLine,
+					genCol: prefix.length + 1 + encodedHtmlOffset + mapping.length,
+					unmapped: true,
+				});
+			}
 			if (t.ns || t.frag) args.push(String(t.ns | 0));
 			if (t.frag) args.push(String(t.frag | 0));
-			return `const ${t.name} = /* @__PURE__ */ _$template(${args.join(', ')});`;
+			return prefix + args.join(', ') + ');';
 		})
 		.join('\n');
 	const templatesBlock = templates ? templates + '\n\n' : '';
@@ -5429,21 +5459,26 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 
 	// Everything before `body` in the output — shifts every body segment's
 	// generated line down by the prelude's line count.
-	const prelude =
-		finalRuntimeImport +
-		finalProfileRuntimeImport +
-		vtHintBlock +
-		delegateCall +
-		styleBlock +
-		templatesBlock +
-		helpersBlock;
+	const beforeTemplates =
+		finalRuntimeImport + finalProfileRuntimeImport + vtHintBlock + delegateCall + styleBlock;
+	const prelude = beforeTemplates + templatesBlock + helpersBlock;
 	const preludeLines = countNewlines(prelude);
-	const segments = bodySegments.map((s) => ({
-		genLine: s.genLine + preludeLines,
-		genCol: s.genCol,
-		srcLine0: s.srcLine0,
-		srcCol0: s.srcCol0,
-	}));
+	const templateLineOffset = countNewlines(beforeTemplates);
+	const segments = [
+		...templateSegments.map((s) => ({
+			genLine: s.genLine + templateLineOffset,
+			genCol: s.genCol,
+			srcLine0: s.srcLine0,
+			srcCol0: s.srcCol0,
+			unmapped: s.unmapped,
+		})),
+		...bodySegments.map((s) => ({
+			genLine: s.genLine + preludeLines,
+			genCol: s.genCol,
+			srcLine0: s.srcLine0,
+			srcCol0: s.srcCol0,
+		})),
+	];
 
 	const result = {
 		code: prelude + body + stampBlock + hmrBlock + profileBlock,
@@ -12408,6 +12443,7 @@ function normalizeChildren(nodes, inSvg = false) {
 				id: n.openingElement.name,
 				attributes: n.openingElement.attributes || [],
 				openingElement: n.openingElement,
+				closingTagLoc: n.closingElement?.name?.loc?.start,
 				children: n.children || [],
 				selfClosing: n.openingElement.selfClosing,
 				loc: n.loc, // preserve element position for dev hydration LOC (component slots)
@@ -12864,6 +12900,11 @@ function planJsx(
 		ctx._elemLocs = _prevElemLocs;
 		return { mount: '', update: '', after: '', head: emitHeadClient(headNodes, ctx, 0) };
 	}
+	// Source positions for host tags emitted into THIS plan's template. Nested
+	// plans temporarily replace this list and restore it before the outer walk
+	// continues, matching the other plan-local compiler state below.
+	const _prevTemplateTagSources = ctx._templateTagSources;
+	ctx._templateTagSources = [];
 
 	// Emit ONE template containing all top-level JSX (wrapping multiple roots in
 	// a synthetic <octane-frag>).
@@ -13088,7 +13129,7 @@ function planJsx(
 		const fragArg = !single && (flag !== 0 || resolvedFrag) ? 1 : 0;
 		const tplHtml =
 			single || flag !== 0 || resolvedFrag ? html : `<octane-frag>${html}</octane-frag>`;
-		const tpl = allocTemplate(ctx, tplHtml, flag, fragArg);
+		const tpl = allocTemplate(ctx, tplHtml, flag, fragArg, ctx._templateTagSources);
 		// DEV: pass the root element's source location so a STRUCTURAL hydration mismatch
 		// (swapped @if/@switch branch, changed tag) warns with `file:line:col`. Single-root
 		// only (a multi-root <octane-frag> wrapper has no source position); prod omits it.
@@ -13882,6 +13923,7 @@ function planJsx(
 	ctx._fragRefStack = _prevFragRefStack;
 	// Restore the outer plan's per-element LOC map — pairs with the save at planJsx top.
 	ctx._elemLocs = _prevElemLocs;
+	ctx._templateTagSources = _prevTemplateTagSources;
 
 	const updateJoined = updateLines.join('\n');
 	const everyRenderJoined = everyRenderLines.join('\n');
@@ -14668,6 +14710,15 @@ function emitElementHtml(
 
 	const tag = node.id?.name || node.openingElement?.name?.name;
 	if (!tag) throw new Error('Element without tag');
+	const openingTagLoc = (node.openingElement?.name ?? node.id)?.loc?.start;
+	if (ctx._templateTagSources && openingTagLoc) {
+		ctx._templateTagSources.push({
+			kind: 'open',
+			tag,
+			srcLine0: openingTagLoc.line - 1,
+			srcCol0: openingTagLoc.column | 0,
+		});
+	}
 	const authoredStaticScriptContent = staticScriptContent(node, tag);
 	const hasAuthoredStaticScriptBody =
 		authoredStaticScriptContent !== undefined && authoredStaticScriptContent.length > 0;
@@ -15652,7 +15703,21 @@ function emitElementHtml(
 		});
 	}
 
-	if (!isVoid) html += `</${tag}>`;
+	if (!isVoid) {
+		html += `</${tag}>`;
+		const closingTagLoc =
+			node.closingTagLoc ??
+			node.closingElement?.name?.loc?.start ??
+			(node.selfClosing ? openingTagLoc : null);
+		if (ctx._templateTagSources && closingTagLoc) {
+			ctx._templateTagSources.push({
+				kind: 'close',
+				tag,
+				srcLine0: closingTagLoc.line - 1,
+				srcCol0: closingTagLoc.column | 0,
+			});
+		}
+	}
 	return html;
 }
 
@@ -17138,10 +17203,88 @@ function walkExprH(rootVar, path) {
 	return expr;
 }
 
-function allocTemplate(ctx, html, ns = 0, frag = 0) {
+function templateTagTokens(html) {
+	const tokens = [];
+	let index = 0;
+	while (index < html.length) {
+		const opening = html.indexOf('<', index);
+		if (opening === -1) break;
+		if (html.startsWith('<!--', opening)) {
+			const end = html.indexOf('-->', opening + 4);
+			index = end === -1 ? html.length : end + 3;
+			continue;
+		}
+
+		let nameStart = opening + 1;
+		let kind = 'open';
+		if (html.charCodeAt(nameStart) === 47) {
+			kind = 'close';
+			nameStart++;
+		}
+		let nameEnd = nameStart;
+		while (nameEnd < html.length) {
+			const character = html.charCodeAt(nameEnd);
+			if (character <= 32 || character === 47 || character === 62) break;
+			nameEnd++;
+		}
+		if (nameEnd > nameStart) {
+			tokens.push({ kind, tag: html.slice(nameStart, nameEnd), nameStart });
+		}
+
+		// Advance past the complete tag so a `<tag` substring inside a quoted
+		// attribute value can never be mistaken for a nested element.
+		let quote = 0;
+		let cursor = nameEnd;
+		for (; cursor < html.length; cursor++) {
+			const character = html.charCodeAt(cursor);
+			if (quote !== 0) {
+				if (character === quote) quote = 0;
+			} else if (character === 34 || character === 39) {
+				quote = character;
+			} else if (character === 62) {
+				cursor++;
+				break;
+			}
+		}
+		index = cursor > opening ? cursor : opening + 1;
+	}
+	return tokens;
+}
+
+function mapTemplateTags(html, sources) {
+	if (!sources || sources.length === 0) return [];
+	const tokens = templateTagTokens(html);
+	const mappings = [];
+	let tokenIndex = 0;
+	for (const source of sources) {
+		while (
+			tokenIndex < tokens.length &&
+			(tokens[tokenIndex].kind !== source.kind || tokens[tokenIndex].tag !== source.tag)
+		) {
+			tokenIndex++;
+		}
+		if (tokenIndex === tokens.length) break;
+		mappings.push({
+			htmlOffset: tokens[tokenIndex].nameStart,
+			length: source.tag.length,
+			srcLine0: source.srcLine0,
+			srcCol0: source.srcCol0,
+		});
+		tokenIndex++;
+	}
+	return mappings;
+}
+
+function allocTemplate(ctx, html, ns = 0, frag = 0, tagSources = null) {
 	const id = ctx.nextTemplateId++;
 	const name = `_t$${id}`;
-	ctx.hoistedTemplates.push({ name, html, ns, frag });
+	ctx.hoistedTemplates.push({
+		name,
+		html,
+		ns,
+		frag,
+		tagMappings: mapTemplateTags(html, tagSources),
+	});
 	return name;
 }
 

--- a/packages/octane/src/compiler/volar.js
+++ b/packages/octane/src/compiler/volar.js
@@ -25,10 +25,12 @@
 
 import {
 	analyzeTsrx,
+	acorn,
 	createJsxTransform,
 	createVolarMappingsResult,
 	dedupeMappings,
 	parseModule,
+	tsPlugin,
 } from '@tsrx/core';
 import { analyzeNativeChangeDiagnostics } from './native-change-diagnostics.js';
 import { jsxImportSourcePragmaModule } from './pragma.js';
@@ -96,6 +98,7 @@ const OCTANE_PLATFORM = {
 };
 
 const octaneTransform = createJsxTransform(OCTANE_PLATFORM);
+const GeneratedOutputParser = acorn.Parser.extend(tsPlugin({ jsx: true }));
 
 /**
  * Does the parsed file carry an authored `@jsxImportSource` pragma in its
@@ -140,6 +143,82 @@ function shiftGeneratedOffsets(mappings, offset) {
 		...mapping,
 		generatedOffsets: mapping.generatedOffsets.map((generatedOffset) => generatedOffset + offset),
 	}));
+}
+
+// The shared type-only printer keeps a scoped-style placeholder as a bare JSX
+// expression statement. Without separators, a preceding JSX statement and a
+// following `return` are parsed as one malformed expression. Insert explicit
+// statement terminators and return their original-code offsets so Volar
+// mappings can be shifted with the output.
+function terminateStylePlaceholderStatements(code) {
+	const marker = '<style></style>';
+	const insertions = new Set();
+	let from = 0;
+	while (true) {
+		const start = code.indexOf(marker, from);
+		if (start < 0) break;
+		const lineStart = code.lastIndexOf('\n', start - 1) + 1;
+		const nextLine = code.indexOf('\n', start + marker.length);
+		const lineEnd = nextLine < 0 ? code.length : nextLine;
+		if (code.slice(lineStart, lineEnd).trim() !== marker) {
+			from = start + marker.length;
+			continue;
+		}
+		let before = start - 1;
+		while (before >= 0 && /\s/.test(code[before])) before--;
+		if (code[before] === '>') insertions.add(before + 1);
+		const end = start + marker.length;
+		if (code[end] !== ';') insertions.add(end);
+		from = end;
+	}
+	const positions = [...insertions].sort((a, b) => a - b);
+	let output = '';
+	let cursor = 0;
+	for (const position of positions) {
+		output += code.slice(cursor, position) + ';';
+		cursor = position;
+	}
+	return { code: output + code.slice(cursor), insertions: positions };
+}
+
+function shiftGeneratedInsertions(mappings, insertions) {
+	if (insertions.length === 0) return mappings;
+	return mappings.map((mapping) => {
+		const generatedLengths = mapping.generatedLengths ?? mapping.lengths;
+		return {
+			...mapping,
+			generatedOffsets: mapping.generatedOffsets.map(
+				(offset) => offset + insertions.filter((position) => position <= offset).length,
+			),
+			generatedLengths: generatedLengths.map((length, index) => {
+				const start =
+					mapping.generatedOffsets[Math.min(index, mapping.generatedOffsets.length - 1)];
+				return (
+					length +
+					insertions.filter((position) => start < position && position < start + length).length
+				);
+			}),
+		};
+	});
+}
+
+/**
+ * Parse emitted compiler code for diagnostics tooling. Runtime client/server
+ * emitters do not retain one complete transformed tree, so consumers that
+ * need an output-coordinate AST must parse the final artifact instead.
+ *
+ * @param {string} code
+ * @returns {unknown}
+ * @internal
+ */
+export function __parseGeneratedModuleAst(code) {
+	return GeneratedOutputParser.parse(code, {
+		sourceType: 'module',
+		ecmaVersion: 'latest',
+		allowReturnOutsideFunction: true,
+		locations: true,
+		preserveParens: true,
+	});
 }
 
 /**
@@ -191,8 +270,16 @@ function markNativeTemplateBodies(root) {
  * `intrinsics`; when present, the virtual TSX gets a file-local pragma so host
  * element types cannot leak into files owned by another renderer.
  *
- * @param {{ loose?: boolean, renderers?: unknown }} [options]
- * @returns {import('@tsrx/core/types').VolarMappingsResult & { diagnostics: readonly unknown[] }}
+ * `astTrace` is an opt-in diagnostics hook used by tooling such as the
+ * playground. It exposes the copy-on-write transform tree and an AST parsed
+ * from the final virtual TSX. The normal language-service path does not pay
+ * for that second parse.
+ *
+ * @param {{ loose?: boolean, renderers?: unknown, astTrace?: boolean | 'transform' | 'generated' }} [options]
+ * @returns {import('@tsrx/core/types').VolarMappingsResult & {
+ *   diagnostics: readonly unknown[],
+ *   astTrace?: { transformedAst: unknown, generatedAst?: unknown }
+ * }}
  */
 export function compileToVolarMappings(source, filename, options) {
 	/** @type {import('@tsrx/core/types').CompileError[]} */
@@ -249,11 +336,25 @@ export function compileToVolarMappings(source, filename, options) {
 		source_map: transformed.map,
 		errors,
 	});
-	const mappings = dedupeMappings(result.mappings);
+	const mappings = shiftGeneratedOffsets(dedupeMappings(result.mappings), prelude.length);
+	const terminated = terminateStylePlaceholderStatements(prelude + result.code);
+	const code = terminated.code;
 	return {
 		...result,
-		code: prelude + result.code,
-		mappings: shiftGeneratedOffsets(mappings, prelude.length),
+		code,
+		mappings: shiftGeneratedInsertions(mappings, terminated.insertions),
 		diagnostics,
+		...(options?.astTrace
+			? {
+					astTrace: {
+						transformedAst: transformed.ast,
+						...(options.astTrace === 'transform'
+							? null
+							: {
+									generatedAst: __parseGeneratedModuleAst(code),
+								}),
+					},
+				}
+			: null),
 	};
 }

--- a/packages/octane/src/compiler/volar.js
+++ b/packages/octane/src/compiler/volar.js
@@ -150,6 +150,11 @@ function shiftGeneratedOffsets(mappings, offset) {
 // following `return` are parsed as one malformed expression. Insert explicit
 // statement terminators and return their original-code offsets so Volar
 // mappings can be shifted with the output.
+//
+// IMPORTANT: this applies only to statement-level native templates. Scoped
+// styles in return-style components stay as fragment children, where inserting
+// semicolons would produce invalid TSX like `<section/>;<style></style>;`
+// inside a `<>...</>`. Detect JSX context by scanning for an unclosed fragment.
 function terminateStylePlaceholderStatements(code) {
 	const marker = '<style></style>';
 	const insertions = new Set();
@@ -161,6 +166,35 @@ function terminateStylePlaceholderStatements(code) {
 		const nextLine = code.indexOf('\n', start + marker.length);
 		const lineEnd = nextLine < 0 ? code.length : nextLine;
 		if (code.slice(lineStart, lineEnd).trim() !== marker) {
+			from = start + marker.length;
+			continue;
+		}
+		// Check if we're inside a JSX fragment by scanning backwards for an
+		// unclosed `<>`. Find the enclosing block start first.
+		let braceDepth = 0;
+		let blockStart = start - 1;
+		while (blockStart >= 0) {
+			const ch = code[blockStart];
+			if (ch === '}') braceDepth++;
+			else if (ch === '{') {
+				if (braceDepth === 0) break;
+				braceDepth--;
+			}
+			blockStart--;
+		}
+		// Scan from block start to the style, tracking fragment depth.
+		let fragmentDepth = 0;
+		for (let i = Math.max(0, blockStart); i < start; i++) {
+			if (code[i] === '<' && code[i + 1] === '>') {
+				fragmentDepth++;
+				i++;
+			} else if (code[i] === '<' && code[i + 1] === '/' && code[i + 2] === '>') {
+				fragmentDepth--;
+				i += 2;
+			}
+		}
+		if (fragmentDepth > 0) {
+			// Inside an unclosed JSX fragment — skip terminators.
 			from = start + marker.length;
 			continue;
 		}

--- a/packages/octane/tests/compiler-source-map.test.ts
+++ b/packages/octane/tests/compiler-source-map.test.ts
@@ -34,7 +34,12 @@ describe('client compiler source maps', () => {
 		<span><div /></span>
 	</div>
 }`;
-		const output = compile(source, 'App.tsrx', { mode: 'client' });
+		const defaultOutput = compile(source, 'App.tsrx', { mode: 'client' });
+		const output = compile(source, 'App.tsrx', {
+			mode: 'client',
+			sourceMapHostTags: true,
+		});
+		expect(output.code).toBe(defaultOutput.code);
 
 		const generatedAttributeText = nthIndexOf(output.code, '<span', 0) + 1;
 		const generatedSpanOpen = nthIndexOf(output.code, '<span', 1) + 1;
@@ -42,6 +47,7 @@ describe('client compiler source maps', () => {
 		const sourceSpanOpen = nthIndexOf(source, '<span', 1) + 1;
 		const sourceSpanClose = source.indexOf('</span>') + 2;
 
+		expect(originalPosition(defaultOutput.code, defaultOutput.map, generatedSpanOpen)).toBeNull();
 		expect(originalPosition(output.code, output.map, generatedAttributeText)).toBeNull();
 		expect(originalPosition(output.code, output.map, generatedSpanOpen)).toEqual(
 			offsetPosition(source, sourceSpanOpen),

--- a/packages/octane/tests/compiler-source-map.test.ts
+++ b/packages/octane/tests/compiler-source-map.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { compile } from '../src/compiler/compile.js';
+import { decodeMappings } from '../src/compiler/compile-universal.js';
+
+function offsetPosition(text: string, offset: number) {
+	const lines = text.slice(0, offset).split('\n');
+	return { line: lines.length - 1, column: lines.at(-1)!.length };
+}
+
+function originalPosition(code: string, map: { mappings: string }, offset: number) {
+	const generated = offsetPosition(code, offset);
+	let traced: number[] | null = null;
+	for (const segment of decodeMappings(map.mappings)[generated.line] ?? []) {
+		if (segment[0] > generated.column) break;
+		traced = segment;
+	}
+	return traced && traced.length >= 4 ? { line: traced[2], column: traced[3] } : null;
+}
+
+function nthIndexOf(text: string, needle: string, occurrence: number) {
+	let offset = -1;
+	for (let index = 0; index <= occurrence; index++) offset = text.indexOf(needle, offset + 1);
+	expect(
+		offset,
+		`expected occurrence ${occurrence} of ${JSON.stringify(needle)}`,
+	).toBeGreaterThanOrEqual(0);
+	return offset;
+}
+
+describe('client compiler source maps', () => {
+	it('maps nested template tag names without treating attribute text as an element', () => {
+		const source = `export function App() @{
+	<div data-label="<span">
+		<span><div /></span>
+	</div>
+}`;
+		const output = compile(source, 'App.tsrx', { mode: 'client' });
+
+		const generatedAttributeText = nthIndexOf(output.code, '<span', 0) + 1;
+		const generatedSpanOpen = nthIndexOf(output.code, '<span', 1) + 1;
+		const generatedSpanClose = output.code.indexOf('</span>') + 2;
+		const sourceSpanOpen = nthIndexOf(source, '<span', 1) + 1;
+		const sourceSpanClose = source.indexOf('</span>') + 2;
+
+		expect(originalPosition(output.code, output.map, generatedAttributeText)).toBeNull();
+		expect(originalPosition(output.code, output.map, generatedSpanOpen)).toEqual(
+			offsetPosition(source, sourceSpanOpen),
+		);
+		expect(originalPosition(output.code, output.map, generatedSpanClose)).toEqual(
+			offsetPosition(source, sourceSpanClose),
+		);
+
+		// A non-void self-closing host becomes an opening+closing HTML pair. Both
+		// generated names trace to the one authored JSX name.
+		const generatedSelfClosing = output.code.indexOf('<div></div>');
+		const sourceSelfClosing = source.indexOf('<div />') + 1;
+		expect(originalPosition(output.code, output.map, generatedSelfClosing + 1)).toEqual(
+			offsetPosition(source, sourceSelfClosing),
+		);
+		expect(originalPosition(output.code, output.map, generatedSelfClosing + 7)).toEqual(
+			offsetPosition(source, sourceSelfClosing),
+		);
+	});
+});

--- a/packages/octane/tests/volar.test.ts
+++ b/packages/octane/tests/volar.test.ts
@@ -63,6 +63,54 @@ describe('compileToVolarMappings', () => {
 		expect(result.sourceAst.type).toBe('Program');
 	});
 
+	it('builds transform and generated ASTs only when tracing is requested', () => {
+		const source = "export function App() @{ <button>{'Trace'}</button> }\n";
+		const normal = compileToVolarMappings(source, 'App.tsrx') as any;
+		const transformed = compileToVolarMappings(source, 'App.tsrx', {
+			astTrace: 'transform',
+		}) as any;
+		const generated = compileToVolarMappings(source, 'App.tsrx', {
+			astTrace: 'generated',
+		}) as any;
+
+		expect(normal.astTrace).toBeUndefined();
+		expect(transformed.astTrace.transformedAst.type).toBe('Program');
+		expect(transformed.astTrace.transformedAst.end).toBe(source.length);
+		expect(transformed.astTrace.generatedAst).toBeUndefined();
+		expect(generated.astTrace.generatedAst.type).toBe('Program');
+		expect(generated.astTrace.generatedAst.end).toBe(generated.code.length);
+	});
+
+	it('keeps scoped-style virtual TSX parseable without shifting mappings', () => {
+		const source = `export function App() @{
+	<button>Styled</button>
+	<style>
+		button { color: red; }
+	</style>
+}`;
+		const result = compileToVolarMappings(source, 'App.tsrx', {
+			astTrace: 'generated',
+		}) as any;
+
+		expect(result.code).toContain('<style></style>;');
+		expect(result.code).toContain('</button>;');
+		expect(result.astTrace.generatedAst.end).toBe(result.code.length);
+		for (const mapping of result.mappings) {
+			for (const offset of mapping.generatedOffsets) {
+				expect(offset).toBeLessThanOrEqual(result.code.length);
+			}
+		}
+	});
+
+	it('does not rewrite style-placeholder text inside authored strings', () => {
+		const source = `export const marker = '<style></style>';
+export function App() @{ <div>{marker}</div> }`;
+		const result = compileToVolarMappings(source, 'App.tsrx');
+
+		expect(result.code).toContain("marker = '<style></style>'");
+		expect(result.code).not.toContain("'<style></style>;'");
+	});
+
 	it('preserves user identifiers in the generated TSX', () => {
 		const src =
 			"import { useState } from 'octane';\n" +

--- a/website/env.d.ts
+++ b/website/env.d.ts
@@ -45,13 +45,20 @@ declare module 'octane/compiler/volar' {
 	export function compileToVolarMappings(
 		source: string,
 		filename?: string,
-		options?: { loose?: boolean; renderers?: unknown },
+		options?: {
+			loose?: boolean;
+			renderers?: unknown;
+			astTrace?: boolean | 'transform' | 'generated';
+		},
 	): {
 		code: string;
 		mappings: VolarMapping[];
 		errors: readonly unknown[];
 		diagnostics: readonly unknown[];
+		sourceAst: unknown;
+		astTrace?: { transformedAst: unknown; generatedAst?: unknown };
 	};
+	export function __parseGeneratedModuleAst(code: string): unknown;
 }
 
 // `.mdx` documents compile (via @octanejs/mdx) to octane component modules with

--- a/website/env.d.ts
+++ b/website/env.d.ts
@@ -29,6 +29,8 @@ declare module 'octane/compiler' {
 			mode?: 'client' | 'server';
 			hmr?: boolean;
 			dev?: boolean;
+			/** Inspection-only anchors for host tags baked into client templates. */
+			sourceMapHostTags?: boolean;
 		},
 	): { code: string; map: unknown; diagnostics: CompileDiagnostic[] };
 }

--- a/website/src/lib/playground-ast.ts
+++ b/website/src/lib/playground-ast.ts
@@ -157,7 +157,7 @@ export function findDeepestAstNode(
 }
 
 export interface AstPreviewController {
-	setAst(ast: unknown, filename: string): void;
+	setAst(ast: unknown, filename: string, options?: { label?: string; notice?: string }): void;
 	setUnavailable(message: string, filename: string): void;
 	reveal(offset: number, scroll: boolean): void;
 	clear(): void;
@@ -180,6 +180,7 @@ export function createAstPreview(
 	const doc = host.ownerDocument;
 	let prepared: PreparedPlaygroundAst | null = null;
 	let filename = '';
+	let label = 'AST';
 	let unavailable = '';
 	let destroyed = false;
 	let activeNodes: PlaygroundAstNode[] = [];
@@ -195,7 +196,7 @@ export function createAstPreview(
 	scrollHost.className = 'pg-ast-scroll';
 	const notice = doc.createElement('div');
 	notice.className = 'pg-ast-notice';
-	notice.textContent = 'Compiler-internal AST; its shape may change.';
+	notice.textContent = 'Compiler AST; its internal shape may change.';
 	shell.append(status, scrollHost, notice);
 	host.replaceChildren(shell);
 
@@ -209,7 +210,7 @@ export function createAstPreview(
 		}
 		activeNodes = [];
 		if (!node) {
-			status.textContent = `AST · ${filename}`;
+			status.textContent = `${label} · ${filename}`;
 			return;
 		}
 
@@ -239,7 +240,7 @@ export function createAstPreview(
 		}
 		activeNodes = path;
 		const range = node.range;
-		status.textContent = `${node.type ?? node.path} · [${range?.from ?? '–'}, ${range?.to ?? '–'})`;
+		status.textContent = `${label} · ${node.type ?? node.path} · [${range?.from ?? '–'}, ${range?.to ?? '–'})`;
 	};
 
 	const renderNode = (node: PlaygroundAstNode): HTMLLIElement => {
@@ -329,7 +330,7 @@ export function createAstPreview(
 		elements.clear();
 		renderedBranches = new WeakSet<PlaygroundAstNode>();
 		activeNodes = [];
-		status.textContent = `AST · ${filename}`;
+		status.textContent = `${label} · ${filename}`;
 		if (unavailable) {
 			scrollHost.textContent = unavailable;
 			return;
@@ -346,8 +347,10 @@ export function createAstPreview(
 
 	renderAst();
 	return {
-		setAst(ast, nextFilename) {
+		setAst(ast, nextFilename, nextOptions) {
 			filename = nextFilename;
+			label = nextOptions?.label ?? 'AST';
+			notice.textContent = nextOptions?.notice ?? 'Compiler AST; its internal shape may change.';
 			unavailable = '';
 			prepared = preparePlaygroundAst(ast);
 			renderAst();

--- a/website/src/lib/playground-ast.ts
+++ b/website/src/lib/playground-ast.ts
@@ -355,6 +355,8 @@ export function createAstPreview(
 		setUnavailable(message, nextFilename) {
 			filename = nextFilename;
 			unavailable = message;
+			prepared = null;
+			options.onNodeRange(null, false);
 			renderAst();
 		},
 		reveal(offset, scroll) {

--- a/website/src/lib/playground-ast.ts
+++ b/website/src/lib/playground-ast.ts
@@ -1,0 +1,373 @@
+export interface AstRange {
+	from: number;
+	to: number;
+}
+
+type AstValueKind = 'object' | 'array' | 'primitive' | 'reference';
+
+export interface PlaygroundAstNode {
+	key: string | null;
+	kind: AstValueKind;
+	type: string | null;
+	value: string | null;
+	path: string;
+	range: AstRange | null;
+	depth: number;
+	parent: PlaygroundAstNode | null;
+	children: PlaygroundAstNode[];
+}
+
+export interface PreparedPlaygroundAst {
+	root: PlaygroundAstNode;
+	rangeNodes: PlaygroundAstNode[];
+}
+
+const primitiveText = (value: unknown): string => {
+	if (value === undefined) return 'undefined';
+	if (typeof value === 'bigint') return `${value}n`;
+	if (typeof value === 'symbol' || typeof value === 'function') return String(value);
+	return JSON.stringify(value) ?? String(value);
+};
+
+const childPath = (path: string, key: string, array: boolean): string =>
+	array ? `${path}[${key}]` : `${path}.${key}`;
+
+/**
+ * Convert the parser's object graph into a cycle-safe tree for display. Every
+ * enumerable field remains visible; shared/cyclic values become an explicit
+ * reference to their first path instead of being silently dropped. Range
+ * nodes are indexed once so cursor tracking never traverses non-AST metadata.
+ */
+export function preparePlaygroundAst(value: unknown): PreparedPlaygroundAst {
+	// Parser metadata contains back-references into the syntax tree. Discover
+	// canonical paths without descending into metadata first, so a node's real
+	// structural field always owns its expanded representation even when an
+	// earlier sibling's metadata.path points to it.
+	const canonicalPaths = new WeakMap<object, string>();
+	const discoverCanonicalPaths = (current: unknown, path: string) => {
+		if (!current || typeof current !== 'object' || canonicalPaths.has(current)) return;
+		canonicalPaths.set(current, path);
+		for (const [key, child] of Object.entries(current)) {
+			if (key === 'metadata') continue;
+			discoverCanonicalPaths(child, childPath(path, key, Array.isArray(current)));
+		}
+	};
+	discoverCanonicalPaths(value, '$');
+
+	const seen = new WeakMap<object, string>();
+	const rangeNodes: PlaygroundAstNode[] = [];
+
+	const visit = (
+		current: unknown,
+		key: string | null,
+		path: string,
+		parent: PlaygroundAstNode | null,
+		depth: number,
+	): PlaygroundAstNode => {
+		if (current === null || typeof current !== 'object') {
+			return {
+				key,
+				kind: 'primitive',
+				type: current === null ? 'null' : typeof current,
+				value: primitiveText(current),
+				path,
+				range: null,
+				depth,
+				parent,
+				children: [],
+			};
+		}
+
+		const canonicalPath = canonicalPaths.get(current);
+		const firstPath = canonicalPath !== path ? (canonicalPath ?? seen.get(current)) : undefined;
+		if (firstPath !== undefined) {
+			return {
+				key,
+				kind: 'reference',
+				type: null,
+				value: `Reference → ${firstPath}`,
+				path,
+				range: null,
+				depth,
+				parent,
+				children: [],
+			};
+		}
+		seen.set(current, path);
+
+		const record = current as Record<string, unknown>;
+		const from = record.start;
+		const to = record.end;
+		const range =
+			typeof from === 'number' &&
+			Number.isFinite(from) &&
+			typeof to === 'number' &&
+			Number.isFinite(to) &&
+			from <= to
+				? { from, to }
+				: null;
+		const node: PlaygroundAstNode = {
+			key,
+			kind: Array.isArray(current) ? 'array' : 'object',
+			type: typeof record.type === 'string' ? record.type : null,
+			value: null,
+			path,
+			range,
+			depth,
+			parent,
+			children: [],
+		};
+		if (range) rangeNodes.push(node);
+		for (const [childKey, child] of Object.entries(current)) {
+			node.children.push(
+				visit(
+					child,
+					Array.isArray(current) ? null : childKey,
+					childPath(path, childKey, Array.isArray(current)),
+					node,
+					depth + 1,
+				),
+			);
+		}
+		return node;
+	};
+
+	return { root: visit(value, null, '$', null, 0), rangeNodes };
+}
+
+/** Select the narrowest AST node whose half-open range contains `offset`. */
+export function findDeepestAstNode(
+	prepared: PreparedPlaygroundAst,
+	offset: number,
+): PlaygroundAstNode | null {
+	let best: PlaygroundAstNode | null = null;
+	let bestWidth = Number.POSITIVE_INFINITY;
+	for (const node of prepared.rangeNodes) {
+		const range = node.range!;
+		const contains =
+			range.from === range.to ? offset === range.from : range.from <= offset && offset < range.to;
+		if (!contains) continue;
+		const width = range.to - range.from;
+		if (width < bestWidth || (width === bestWidth && node.depth > (best?.depth ?? -1))) {
+			best = node;
+			bestWidth = width;
+		}
+	}
+	return best;
+}
+
+export interface AstPreviewController {
+	setAst(ast: unknown, filename: string): void;
+	setUnavailable(message: string, filename: string): void;
+	reveal(offset: number, scroll: boolean): void;
+	clear(): void;
+	destroy(): void;
+}
+
+interface AstPreviewOptions {
+	onNodeRange(range: AstRange | null, scroll: boolean): void;
+}
+
+/**
+ * Mount the interactive AST tree. Branches render lazily when opened, while
+ * the prepared object graph keeps enough ancestry to reveal a cursor-selected
+ * node without rebuilding the tree.
+ */
+export function createAstPreview(
+	host: HTMLElement,
+	options: AstPreviewOptions,
+): AstPreviewController {
+	const doc = host.ownerDocument;
+	let prepared: PreparedPlaygroundAst | null = null;
+	let filename = '';
+	let unavailable = '';
+	let destroyed = false;
+	let activeNodes: PlaygroundAstNode[] = [];
+	const elements = new Map<PlaygroundAstNode, HTMLLIElement>();
+	let renderedBranches = new WeakSet<PlaygroundAstNode>();
+
+	const shell = doc.createElement('div');
+	shell.className = 'pg-ast-shell';
+	const status = doc.createElement('div');
+	status.className = 'pg-ast-status';
+	status.setAttribute('aria-live', 'polite');
+	const scrollHost = doc.createElement('div');
+	scrollHost.className = 'pg-ast-scroll';
+	const notice = doc.createElement('div');
+	notice.className = 'pg-ast-notice';
+	notice.textContent = 'Compiler-internal AST; its shape may change.';
+	shell.append(status, scrollHost, notice);
+	host.replaceChildren(shell);
+
+	const setActiveNodes = (node: PlaygroundAstNode | null, scroll: boolean) => {
+		for (const active of activeNodes) {
+			const element = elements.get(active);
+			if (element) {
+				delete element.dataset.astPath;
+				delete element.dataset.astLeaf;
+			}
+		}
+		activeNodes = [];
+		if (!node) {
+			status.textContent = `AST · ${filename}`;
+			return;
+		}
+
+		const path: PlaygroundAstNode[] = [];
+		for (let current: PlaygroundAstNode | null = node; current; current = current.parent) {
+			path.push(current);
+		}
+		path.reverse();
+		if (scroll) {
+			for (const current of path.slice(0, -1)) {
+				const li = elements.get(current);
+				const details = li?.firstElementChild;
+				if (details instanceof doc.defaultView!.HTMLDetailsElement) {
+					details.open = true;
+					details.dispatchEvent(new doc.defaultView!.Event('ast-open'));
+				}
+			}
+		}
+		for (const current of path) {
+			const element = elements.get(current);
+			if (element) element.dataset.astPath = 'true';
+		}
+		const leaf = elements.get(node);
+		if (leaf) {
+			leaf.dataset.astLeaf = 'true';
+			if (scroll) leaf.scrollIntoView({ block: 'center' });
+		}
+		activeNodes = path;
+		const range = node.range;
+		status.textContent = `${node.type ?? node.path} · [${range?.from ?? '–'}, ${range?.to ?? '–'})`;
+	};
+
+	const renderNode = (node: PlaygroundAstNode): HTMLLIElement => {
+		const li = doc.createElement('li');
+		li.className = 'pg-ast-node';
+		li.dataset.astPathName = node.path;
+		elements.set(node, li);
+
+		if (node.kind === 'primitive' || node.kind === 'reference') {
+			const value = doc.createElement('span');
+			value.className = `pg-ast-value pg-ast-${node.kind === 'reference' ? 'reference' : node.type}`;
+			if (node.key) {
+				const key = doc.createElement('span');
+				key.className = 'pg-ast-key';
+				key.textContent = `${node.key}: `;
+				value.append(key);
+			}
+			value.append(node.value ?? '');
+			li.append(value);
+			return li;
+		}
+
+		const details = doc.createElement('details');
+		const summary = doc.createElement('summary');
+		if (node.key) {
+			const key = doc.createElement('span');
+			key.className = 'pg-ast-key';
+			key.textContent = `${node.key}: `;
+			summary.append(key);
+		}
+		const label = doc.createElement('span');
+		label.className = node.type ? 'pg-ast-type' : 'pg-ast-delimiter';
+		summary.append(label);
+		const updateLabel = () => {
+			label.textContent =
+				node.kind === 'array'
+					? details.open
+						? '['
+						: `[…] (${node.children.length})`
+					: `${node.type ? `${node.type} ` : ''}{${details.open ? '' : '…'}}`;
+		};
+		updateLabel();
+		const range = node.range;
+		if (range) {
+			const coordinates = doc.createElement('span');
+			coordinates.className = 'pg-ast-range';
+			coordinates.textContent = ` [${range.from}, ${range.to})`;
+			summary.append(coordinates);
+			const activate = (scroll: boolean) => {
+				setActiveNodes(node, false);
+				options.onNodeRange(range, scroll);
+			};
+			summary.addEventListener('mouseenter', () => activate(false));
+			summary.addEventListener('focus', () => activate(false));
+			summary.addEventListener('click', () => activate(true));
+			summary.addEventListener('mouseleave', () => options.onNodeRange(null, false));
+			summary.addEventListener('blur', () => options.onNodeRange(null, false));
+		}
+		details.append(summary);
+
+		const renderChildren = () => {
+			if (renderedBranches.has(node)) return;
+			renderedBranches.add(node);
+			const list = doc.createElement('ul');
+			for (const child of node.children) list.append(renderNode(child));
+			const closing = doc.createElement('span');
+			closing.className = 'pg-ast-closing';
+			closing.textContent = node.kind === 'array' ? ']' : '}';
+			details.append(list, closing);
+		};
+		details.addEventListener('toggle', () => {
+			updateLabel();
+			if (details.open) renderChildren();
+		});
+		details.addEventListener('ast-open', renderChildren);
+		if (node.depth === 0) {
+			details.open = true;
+			updateLabel();
+			renderChildren();
+		}
+		li.append(details);
+		return li;
+	};
+
+	const renderAst = () => {
+		if (destroyed) return;
+		elements.clear();
+		renderedBranches = new WeakSet<PlaygroundAstNode>();
+		activeNodes = [];
+		status.textContent = `AST · ${filename}`;
+		if (unavailable) {
+			scrollHost.textContent = unavailable;
+			return;
+		}
+		if (!prepared) {
+			scrollHost.textContent = 'AST appears after a successful compile.';
+			return;
+		}
+		const list = doc.createElement('ul');
+		list.className = 'pg-ast-tree';
+		list.append(renderNode(prepared.root));
+		scrollHost.replaceChildren(list);
+	};
+
+	renderAst();
+	return {
+		setAst(ast, nextFilename) {
+			filename = nextFilename;
+			unavailable = '';
+			prepared = preparePlaygroundAst(ast);
+			renderAst();
+		},
+		setUnavailable(message, nextFilename) {
+			filename = nextFilename;
+			unavailable = message;
+			renderAst();
+		},
+		reveal(offset, scroll) {
+			const node = prepared ? findDeepestAstNode(prepared, offset) : null;
+			setActiveNodes(node, scroll);
+			options.onNodeRange(node?.range ?? null, false);
+		},
+		clear() {
+			setActiveNodes(null, false);
+		},
+		destroy() {
+			destroyed = true;
+			host.replaceChildren();
+		},
+	};
+}

--- a/website/src/lib/playground-mapping.ts
+++ b/website/src/lib/playground-mapping.ts
@@ -18,7 +18,16 @@ export interface MappedRange {
 	to: number;
 }
 
+export interface MappedPair {
+	source: MappedRange[];
+	output: MappedRange[];
+}
+
 export interface CodeMapping {
+	/** Source and output ranges selected by one source-side lookup. */
+	pairFromSource(offset: number): MappedPair | null;
+	/** Source and output ranges selected by one generated-side lookup. */
+	pairFromGenerated(offset: number): MappedPair | null;
 	/** Ranges in the generated output mapped from a source offset (document order). */
 	toGenerated(offset: number): MappedRange[] | null;
 	/** Ranges in the source mapped from a generated-output offset (document order). */
@@ -194,8 +203,20 @@ function createMapping(segments: Segment[]): CodeMapping | null {
 		result.sort((a, b) => a.from - b.from || a.to - b.to);
 		return result.length > 0 ? result : null;
 	};
+	const pair = (matched: Segment[] | null): MappedPair | null => {
+		if (!matched) return null;
+		const source = ranges(matched, 'src');
+		const output = ranges(matched, 'gen');
+		return source && output ? { source, output } : null;
+	};
 
 	return {
+		pairFromSource(offset) {
+			return pair(containing(bySrc, srcPrefixEnds, 'src', offset));
+		},
+		pairFromGenerated(offset) {
+			return pair(containing(byGen, genPrefixEnds, 'gen', offset));
+		},
 		toGenerated(offset) {
 			const matched = containing(bySrc, srcPrefixEnds, 'src', offset);
 			return matched ? ranges(matched, 'gen') : null;

--- a/website/src/lib/playground-mapping.ts
+++ b/website/src/lib/playground-mapping.ts
@@ -1,8 +1,7 @@
-// Source ↔ output position mapping for the playground's TYPES pane —
-// clicking in the editor reveals the corresponding output, and vice versa.
-// `octane/compiler/volar` emits per-token
-// offset mappings (sourceOffsets/generatedOffsets/lengths) for the language
-// service; those lengths are exact, so ranges are used verbatim.
+// Source ↔ generated position mapping for playground compiler artifacts.
+// Type-only output uses exact per-token Volar mappings. Client output uses
+// the compiler's V3 source-map anchors; those anchors are deliberately kept
+// sparse, so unmapped generated plumbing stays unmapped.
 //
 // Queries select the narrowest range containing the hovered/cursor offset.
 // This matters for Volar's nested mappings: a JSX expression maps as one
@@ -24,6 +23,8 @@ export interface CodeMapping {
 	toGenerated(offset: number): MappedRange[] | null;
 	/** Ranges in the source mapped from a generated-output offset (document order). */
 	toSource(offset: number): MappedRange[] | null;
+	/** First mapped source ranges intersecting a generated AST node range. */
+	toSourceRange(from: number, to: number): MappedRange[] | null;
 }
 
 /** The Volar mapping entries `compileToVolarMappings` returns. */
@@ -39,6 +40,72 @@ interface Segment {
 	gen: number;
 	srcLen: number;
 	genLen: number;
+}
+
+const B64 = new Int8Array(128).fill(-1);
+for (let index = 0; index < 64; index++) {
+	B64['ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'.charCodeAt(index)] = index;
+}
+
+function decodeVlqLines(encoded: string): number[][][] | null {
+	const lines: number[][][] = [];
+	let line: number[][] = [];
+	let segment: number[] = [];
+	let value = 0;
+	let shift = 0;
+	for (let index = 0; index < encoded.length; index++) {
+		const character = encoded.charCodeAt(index);
+		if (character === 59 || character === 44) {
+			if (shift !== 0) return null;
+			if (segment.length > 0) line.push(segment);
+			segment = [];
+			if (character === 59) {
+				lines.push(line);
+				line = [];
+			}
+			continue;
+		}
+		const digit = character < 128 ? B64[character] : -1;
+		if (digit < 0) return null;
+		value += (digit & 31) << shift;
+		if (digit & 32) shift += 5;
+		else {
+			segment.push(value & 1 ? -(value >>> 1) : value >>> 1);
+			value = 0;
+			shift = 0;
+		}
+	}
+	if (shift !== 0) return null;
+	if (segment.length > 0) line.push(segment);
+	lines.push(line);
+	return lines;
+}
+
+function lineStartOffsets(text: string): number[] {
+	const starts = [0];
+	for (let index = 0; index < text.length; index++) {
+		if (text.charCodeAt(index) === 10) starts.push(index + 1);
+	}
+	return starts;
+}
+
+const WORD_CHARACTER = /[A-Za-z0-9_$]/;
+
+function wordRange(text: string, offset: number): MappedRange | null {
+	if (offset < 0 || offset >= text.length) return null;
+	if (
+		!WORD_CHARACTER.test(text[offset]) &&
+		offset + 1 < text.length &&
+		WORD_CHARACTER.test(text[offset + 1])
+	)
+		offset++;
+	let from = offset;
+	let to = offset + 1;
+	if (WORD_CHARACTER.test(text[offset])) {
+		while (from > 0 && WORD_CHARACTER.test(text[from - 1])) from--;
+		while (to < text.length && WORD_CHARACTER.test(text[to])) to++;
+	}
+	return { from, to };
 }
 
 function createMapping(segments: Segment[]): CodeMapping | null {
@@ -137,6 +204,25 @@ function createMapping(segments: Segment[]): CodeMapping | null {
 			const matched = containing(byGen, genPrefixEnds, 'gen', offset);
 			return matched ? ranges(matched, 'src') : null;
 		},
+		toSourceRange(from, to) {
+			let low = 0;
+			let high = byGen.length;
+			while (low < high) {
+				const middle = (low + high) >> 1;
+				if (byGen[middle].gen < from) low = middle + 1;
+				else high = middle;
+			}
+			if (low < byGen.length && byGen[low].gen === from) {
+				let last = low + 1;
+				while (last < byGen.length && byGen[last].gen === from) last++;
+				return ranges(byGen.slice(low, last), 'src');
+			}
+			const atStart = containing(byGen, genPrefixEnds, 'gen', from)?.filter(
+				(segment) => segment.gen + segment.genLen > from,
+			);
+			if (atStart?.length) return ranges(atStart, 'src');
+			return low < byGen.length && byGen[low].gen < to ? ranges([byGen[low]], 'src') : null;
+		},
 	};
 }
 
@@ -161,6 +247,60 @@ export function mappingFromVolar(
 			const genLen = generatedLengths[Math.min(i, generatedLengths.length - 1)] ?? 0;
 			if (srcLen <= 0 || genLen <= 0) continue;
 			segments.push({ src: sourceOffsets[i], gen: generatedOffsets[i], srcLen, genLen });
+		}
+	}
+	return createMapping(segments);
+}
+
+/**
+ * Build the partial mapping carried by a runtime compiler source map. Each
+ * source-map position expands only to its adjacent token; no interpolation is
+ * performed across generated code that has no origin information.
+ */
+export function mappingFromSourceMap(
+	map: unknown,
+	sourceText: string,
+	generatedText: string,
+): CodeMapping | null {
+	const encoded = (map as { mappings?: unknown } | null | undefined)?.mappings;
+	if (typeof encoded !== 'string' || encoded.length === 0) return null;
+	const lines = decodeVlqLines(encoded);
+	if (!lines) return null;
+	const sourceLines = lineStartOffsets(sourceText);
+	const generatedLines = lineStartOffsets(generatedText);
+	const segments: Segment[] = [];
+	let sourceIndex = 0;
+	let sourceLine = 0;
+	let sourceColumn = 0;
+	for (
+		let generatedLine = 0;
+		generatedLine < lines.length && generatedLine < generatedLines.length;
+		generatedLine++
+	) {
+		let generatedColumn = 0;
+		for (const encodedSegment of lines[generatedLine]) {
+			generatedColumn += encodedSegment[0];
+			if (encodedSegment.length < 4) continue;
+			sourceIndex += encodedSegment[1];
+			sourceLine += encodedSegment[2];
+			sourceColumn += encodedSegment[3];
+			if (
+				sourceIndex !== 0 ||
+				sourceLine < 0 ||
+				sourceLine >= sourceLines.length ||
+				sourceColumn < 0 ||
+				generatedColumn < 0
+			)
+				continue;
+			const source = wordRange(sourceText, sourceLines[sourceLine] + sourceColumn);
+			const generated = wordRange(generatedText, generatedLines[generatedLine] + generatedColumn);
+			if (!source || !generated) continue;
+			segments.push({
+				src: source.from,
+				gen: generated.from,
+				srcLen: source.to - source.from,
+				genLen: generated.to - generated.from,
+			});
 		}
 	}
 	return createMapping(segments);

--- a/website/src/lib/playground-mapping.ts
+++ b/website/src/lib/playground-mapping.ts
@@ -307,7 +307,9 @@ export function mappingFromSourceMap(
 		generatedLine++
 	) {
 		let generatedColumn = 0;
-		for (const encodedSegment of lines[generatedLine]) {
+		const encodedLine = lines[generatedLine];
+		for (let segmentIndex = 0; segmentIndex < encodedLine.length; segmentIndex++) {
+			const encodedSegment = encodedLine[segmentIndex];
 			generatedColumn += encodedSegment[0];
 			if (encodedSegment.length < 4) continue;
 			sourceIndex += encodedSegment[1];
@@ -321,8 +323,29 @@ export function mappingFromSourceMap(
 				generatedColumn < 0
 			)
 				continue;
-			const source = wordRange(sourceText, sourceLines[sourceLine] + sourceColumn);
-			const generated = wordRange(generatedText, generatedLines[generatedLine] + generatedColumn);
+			const sourceOffset = sourceLines[sourceLine] + sourceColumn;
+			const generatedOffset = generatedLines[generatedLine] + generatedColumn;
+			const next = encodedLine[segmentIndex + 1];
+			const explicitLength = next?.length === 1 && next[0] > 0 ? next[0] : 0;
+			const explicitToken =
+				explicitLength > 0
+					? generatedText.slice(generatedOffset, generatedOffset + explicitLength)
+					: '';
+			// The client compiler emits a single-field (unmapped) segment directly
+			// after a host-tag anchor to mark its exact generated endpoint. Preserve
+			// that boundary when the same token exists at the authored coordinate;
+			// wordRange intentionally remains the fallback for ordinary sparse maps.
+			const exactBoundary =
+				explicitToken.length === explicitLength &&
+				/[-:]/.test(explicitToken) &&
+				!/[\s"'<>/=]/.test(explicitToken) &&
+				sourceText.startsWith(explicitToken, sourceOffset);
+			const source = exactBoundary
+				? { from: sourceOffset, to: sourceOffset + explicitLength }
+				: wordRange(sourceText, sourceOffset);
+			const generated = exactBoundary
+				? { from: generatedOffset, to: generatedOffset + explicitLength }
+				: wordRange(generatedText, generatedOffset);
 			if (!source || !generated) continue;
 			segments.push({
 				src: source.from,

--- a/website/src/lib/playground-mapping.ts
+++ b/website/src/lib/playground-mapping.ts
@@ -1,27 +1,15 @@
-// Source ↔ output position mapping for the playground's compiled panes —
+// Source ↔ output position mapping for the playground's TYPES pane —
 // clicking in the editor reveals the corresponding output, and vice versa
-// (the Svelte-playground interaction). Two constructors, one query shape:
+// (the Svelte-playground interaction). `octane/compiler/volar` emits per-token
+// offset mappings (sourceOffsets/generatedOffsets/lengths) for the language
+// service; those lengths are exact, so ranges are used verbatim.
 //
-//   mappingFromSourceMap — the PROD pane. `octane/compiler`'s `compile()`
-//     returns a standard V3 source map (esrap-printed, composed across the
-//     compiler's internal rewrites); its VLQ segments are decoded into
-//     absolute-offset pairs. Segments carry positions but no lengths, so
-//     highlight ranges are expanded to the identifier/word at the position.
-//
-//   mappingFromVolar — the TYPES pane. `octane/compiler/volar` emits
-//     per-token offset mappings (sourceOffsets/generatedOffsets/lengths)
-//     for the language service; those lengths are exact, so ranges are used
-//     verbatim.
-//
-// Queries match the nearest preceding anchor, BOUNDED to that anchor's token
-// span — the exact token for Volar segments, the identifier/word at the
-// anchor for source-map segments. An offset past the span (whitespace, a
-// keyword, compiler-generated plumbing with no anchor of its own) is
-// unmapped and returns null so the highlight clears instead of lighting an
-// unrelated node. A match returns EVERY range mapped from the anchor — one
-// source expression can lower to several places in the compiled output
-// (e.g. a value read in both the create and update paths), and all of them
-// should light up.
+// Queries select the narrowest range containing the hovered/cursor offset.
+// This matters for Volar's nested mappings: a JSX expression maps as one
+// range while its identifiers map as smaller ranges. Positions between those
+// identifiers must fall back to the containing expression instead of becoming
+// spuriously unmapped. A match returns EVERY range mapped from the selected
+// source range because one expression can appear in several output locations.
 //
 // Pure string/offset math — no CodeMirror or DOM imports, so tests can run
 // it directly and the editor wiring stays in the page component.
@@ -49,98 +37,39 @@ export interface VolarTokenMapping {
 interface Segment {
 	src: number;
 	gen: number;
-	/** Exact lengths when known (Volar); -1 means expand to the word at the offset. */
 	srcLen: number;
 	genLen: number;
 }
 
-const B64 = new Int8Array(128).fill(-1);
-for (let i = 0; i < 64; i++) {
-	B64['ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'.charCodeAt(i)] = i;
-}
-
-/** Decode a V3 `mappings` string into per-generated-line delta segments. */
-function decodeVlqLines(encoded: string): number[][][] | null {
-	const lines: number[][][] = [];
-	let line: number[][] = [];
-	let segment: number[] = [];
-	let value = 0;
-	let shift = 0;
-	for (let i = 0; i < encoded.length; i++) {
-		const ch = encoded.charCodeAt(i);
-		if (ch === 59 /* ; */ || ch === 44 /* , */) {
-			if (shift !== 0) return null; // truncated VLQ group
-			if (segment.length > 0) line.push(segment);
-			segment = [];
-			if (ch === 59) {
-				lines.push(line);
-				line = [];
-			}
-			continue;
-		}
-		const digit = ch < 128 ? B64[ch] : -1;
-		if (digit < 0) return null;
-		value += (digit & 31) << shift;
-		if (digit & 32) {
-			shift += 5;
-		} else {
-			segment.push(value & 1 ? -(value >>> 1) : value >>> 1);
-			value = 0;
-			shift = 0;
-		}
-	}
-	if (shift !== 0) return null;
-	if (segment.length > 0) line.push(segment);
-	lines.push(line);
-	return lines;
-}
-
-function lineStartOffsets(text: string): number[] {
-	const starts = [0];
-	for (let i = 0; i < text.length; i++) {
-		if (text.charCodeAt(i) === 10) starts.push(i + 1);
-	}
-	return starts;
-}
-
-const WORD_CHAR = /[A-Za-z0-9_$]/;
-
-/**
- * The identifier/word span at `offset`, or the single character there. Map
- * segments frequently anchor on the punctuation JUST BEFORE an identifier
- * (e.g. the `(` in `(setCount)`), so a non-word position steps forward to an
- * adjacent word before expanding — highlighting the identifier, not the paren.
- */
-function expandWord(text: string, offset: number): MappedRange {
-	if (text.length === 0) return { from: 0, to: 0 };
-	if (offset >= text.length) offset = text.length - 1;
-	if (
-		!WORD_CHAR.test(text[offset]) &&
-		offset + 1 < text.length &&
-		WORD_CHAR.test(text[offset + 1])
-	) {
-		offset += 1;
-	}
-	let from = offset;
-	let to = offset + 1;
-	if (WORD_CHAR.test(text[offset])) {
-		while (from > 0 && WORD_CHAR.test(text[from - 1])) from--;
-		while (to < text.length && WORD_CHAR.test(text[to])) to++;
-	}
-	return { from, to };
-}
-
-function createMapping(
-	segments: Segment[],
-	sourceText: string,
-	generatedText: string,
-): CodeMapping | null {
+function createMapping(segments: Segment[]): CodeMapping | null {
 	if (segments.length === 0) return null;
 	const bySrc = [...segments].sort((a, b) => a.src - b.src || a.gen - b.gen);
 	const byGen = [...segments].sort((a, b) => a.gen - b.gen || a.src - b.src);
 
-	// Greatest anchor ≤ offset, plus every segment sharing that anchor.
-	const group = (list: Segment[], key: 'src' | 'gen', offset: number): Segment[] | null => {
+	const prefixEnds = (list: Segment[], key: 'src' | 'gen'): number[] => {
+		const result: number[] = [];
+		let maximum = -1;
+		for (const segment of list) {
+			const length = key === 'src' ? segment.srcLen : segment.genLen;
+			maximum = Math.max(maximum, segment[key] + length);
+			result.push(maximum);
+		}
+		return result;
+	};
+	const srcPrefixEnds = prefixEnds(bySrc, 'src');
+	const genPrefixEnds = prefixEnds(byGen, 'gen');
+
+	// Find every range containing the offset, then select the narrowest one.
+	// Prefix maxima stop the backwards scan when no earlier range can overlap.
+	// At a shared boundary prefer a range STARTING at the cursor; otherwise a
+	// cursor parked just after a token still belongs to that token.
+	const containing = (
+		list: Segment[],
+		ends: number[],
+		key: 'src' | 'gen',
+		offset: number,
+	): Segment[] | null => {
+		if (!Number.isSafeInteger(offset) || offset < 0) return null;
 		let lo = 0;
 		let hi = list.length - 1;
 		let found = -1;
@@ -154,39 +83,43 @@ function createMapping(
 			}
 		}
 		if (found < 0) return null;
-		const anchor = list[found][key];
-		let first = found;
-		while (first > 0 && list[first - 1][key] === anchor) first--;
-		return list.slice(first, found + 1);
-	};
 
-	// A query hits only within the matched anchor's own token span — the exact
-	// token for Volar segments, the word at the anchor for source-map segments
-	// (group() guarantees anchor ≤ offset, so only the upper edge needs
-	// checking; the end is inclusive so a cursor parked right after a word
-	// still counts). Past the span the offset belongs to unmapped text and the
-	// highlight must clear rather than borrow a farther anchor.
-	const withinAnchor = (matched: Segment[], side: 'src' | 'gen', offset: number): boolean => {
-		const text = side === 'gen' ? generatedText : sourceText;
-		for (const segment of matched) {
-			const start = side === 'gen' ? segment.gen : segment.src;
-			const length = side === 'gen' ? segment.genLen : segment.srcLen;
-			if (offset <= (length >= 0 ? start + length : expandWord(text, start).to)) return true;
+		const candidates: Segment[] = [];
+		for (let i = found; i >= 0 && ends[i] >= offset; i--) {
+			const segment = list[i];
+			const length = key === 'src' ? segment.srcLen : segment.genLen;
+			if (offset <= segment[key] + length) candidates.push(segment);
 		}
-		return false;
+		if (candidates.length === 0) return null;
+
+		const startsHere = candidates.some((segment) => segment[key] === offset);
+		let selected: Segment | null = null;
+		let selectedLength = Infinity;
+		for (const segment of candidates) {
+			if (startsHere && segment[key] !== offset) continue;
+			const length = key === 'src' ? segment.srcLen : segment.genLen;
+			if (length < selectedLength) {
+				selected = segment;
+				selectedLength = length;
+			}
+		}
+		if (!selected) return null;
+		const selectedStart = selected[key];
+		return candidates.filter((segment) => {
+			const length = key === 'src' ? segment.srcLen : segment.genLen;
+			return segment[key] === selectedStart && length === selectedLength;
+		});
 	};
 
 	const ranges = (matched: Segment[], side: 'src' | 'gen'): MappedRange[] | null => {
-		const text = side === 'gen' ? generatedText : sourceText;
-		const seen = new Set<number>();
+		const seen = new Set<string>();
 		const result: MappedRange[] = [];
 		for (const segment of matched) {
 			const start = side === 'gen' ? segment.gen : segment.src;
 			const length = side === 'gen' ? segment.genLen : segment.srcLen;
-			const range = length >= 0 ? { from: start, to: start + length } : expandWord(text, start);
+			const range = { from: start, to: start + length };
 			if (range.to <= range.from) continue;
-			// Ranges are small; a from<<20|to key would overflow long docs — use both.
-			const key = range.from * 0x100000000 + range.to;
+			const key = range.from + ':' + range.to;
 			if (seen.has(key)) continue;
 			seen.add(key);
 			result.push(range);
@@ -197,55 +130,14 @@ function createMapping(
 
 	return {
 		toGenerated(offset) {
-			const matched = group(bySrc, 'src', offset);
-			return matched && withinAnchor(matched, 'src', offset) ? ranges(matched, 'gen') : null;
+			const matched = containing(bySrc, srcPrefixEnds, 'src', offset);
+			return matched ? ranges(matched, 'gen') : null;
 		},
 		toSource(offset) {
-			const matched = group(byGen, 'gen', offset);
-			return matched && withinAnchor(matched, 'gen', offset) ? ranges(matched, 'src') : null;
+			const matched = containing(byGen, genPrefixEnds, 'gen', offset);
+			return matched ? ranges(matched, 'src') : null;
 		},
 	};
-}
-
-/**
- * Build a mapping from a compiler source map (the `map` field `compile()`
- * returns) plus the exact source/generated text the map describes. Returns
- * null when the map is missing, malformed, or empty — navigation simply
- * stays off.
- */
-export function mappingFromSourceMap(
-	map: unknown,
-	sourceText: string,
-	generatedText: string,
-): CodeMapping | null {
-	const mappings = (map as { mappings?: unknown } | null | undefined)?.mappings;
-	if (typeof mappings !== 'string' || mappings.length === 0) return null;
-	const lines = decodeVlqLines(mappings);
-	if (!lines) return null;
-	const srcStarts = lineStartOffsets(sourceText);
-	const genStarts = lineStartOffsets(generatedText);
-	const segments: Segment[] = [];
-	let srcIndex = 0;
-	let srcLine = 0;
-	let srcCol = 0;
-	for (let genLine = 0; genLine < lines.length && genLine < genStarts.length; genLine++) {
-		let genCol = 0;
-		for (const segment of lines[genLine]) {
-			genCol += segment[0];
-			if (segment.length < 4) continue;
-			srcIndex += segment[1];
-			srcLine += segment[2];
-			srcCol += segment[3];
-			// The playground compiles one virtual file per map; skip anything else.
-			if (srcIndex !== 0) continue;
-			if (srcLine < 0 || srcLine >= srcStarts.length || srcCol < 0 || genCol < 0) continue;
-			const src = srcStarts[srcLine] + srcCol;
-			const gen = genStarts[genLine] + genCol;
-			if (src >= sourceText.length || gen >= generatedText.length) continue;
-			segments.push({ src, gen, srcLen: -1, genLen: -1 });
-		}
-	}
-	return createMapping(segments, sourceText, generatedText);
 }
 
 /**
@@ -271,5 +163,5 @@ export function mappingFromVolar(
 			segments.push({ src: sourceOffsets[i], gen: generatedOffsets[i], srcLen, genLen });
 		}
 	}
-	return createMapping(segments, '', '');
+	return createMapping(segments);
 }

--- a/website/src/lib/playground-mapping.ts
+++ b/website/src/lib/playground-mapping.ts
@@ -1,6 +1,6 @@
 // Source ↔ output position mapping for the playground's TYPES pane —
-// clicking in the editor reveals the corresponding output, and vice versa
-// (the Svelte-playground interaction). `octane/compiler/volar` emits per-token
+// clicking in the editor reveals the corresponding output, and vice versa.
+// `octane/compiler/volar` emits per-token
 // offset mappings (sourceOffsets/generatedOffsets/lengths) for the language
 // service; those lengths are exact, so ranges are used verbatim.
 //

--- a/website/src/lib/playground-mapping.ts
+++ b/website/src/lib/playground-mapping.ts
@@ -205,6 +205,19 @@ function createMapping(segments: Segment[]): CodeMapping | null {
 			return matched ? ranges(matched, 'src') : null;
 		},
 		toSourceRange(from, to) {
+			if (!Number.isSafeInteger(from) || !Number.isSafeInteger(to) || from < 0 || to <= from)
+				return null;
+
+			// An AST range is half-open. Prefer the narrowest mapping that
+			// contains its first character; Volar can emit a parent expression
+			// and a nested token at the same generated boundary.
+			const atStart = containing(byGen, genPrefixEnds, 'gen', from)?.filter(
+				(segment) => segment.gen < to && segment.gen + segment.genLen > from,
+			);
+			if (atStart?.length) return ranges(atStart, 'src');
+
+			// If the node starts in unmapped compiler plumbing, use the first
+			// mapped token inside the node, again narrowing shared boundaries.
 			let low = 0;
 			let high = byGen.length;
 			while (low < high) {
@@ -212,16 +225,11 @@ function createMapping(segments: Segment[]): CodeMapping | null {
 				if (byGen[middle].gen < from) low = middle + 1;
 				else high = middle;
 			}
-			if (low < byGen.length && byGen[low].gen === from) {
-				let last = low + 1;
-				while (last < byGen.length && byGen[last].gen === from) last++;
-				return ranges(byGen.slice(low, last), 'src');
-			}
-			const atStart = containing(byGen, genPrefixEnds, 'gen', from)?.filter(
-				(segment) => segment.gen + segment.genLen > from,
+			if (low >= byGen.length || byGen[low].gen >= to) return null;
+			const firstMapped = containing(byGen, genPrefixEnds, 'gen', byGen[low].gen)?.filter(
+				(segment) => segment.gen < to && segment.gen + segment.genLen > from,
 			);
-			if (atStart?.length) return ranges(atStart, 'src');
-			return low < byGen.length && byGen[low].gen < to ? ranges([byGen[low]], 'src') : null;
+			return firstMapped?.length ? ranges(firstMapped, 'src') : null;
 		},
 	};
 }

--- a/website/src/lib/playground.ts
+++ b/website/src/lib/playground.ts
@@ -110,7 +110,10 @@ export function compileAst(
 	try {
 		if (stage === 'client-output' || stage === 'server-output') {
 			const mode = stage === 'client-output' ? 'client' : 'server';
-			const result = compile(source, filename, { mode });
+			const result = compile(source, filename, {
+				mode,
+				sourceMapHostTags: mode === 'client',
+			});
 			return {
 				ok: true,
 				ast: parseGeneratedAst(result.code),

--- a/website/src/lib/playground.ts
+++ b/website/src/lib/playground.ts
@@ -65,6 +65,28 @@ export interface TypesSuccess {
 	mappings: VolarTokenMapping[];
 }
 
+export interface AstSuccess {
+	ok: true;
+	/** Parser AST for the authored TSRX/TSX, including Octane/TSRX metadata. */
+	ast: unknown;
+}
+
+/**
+ * Build the AST shown by the playground. The Volar entry point returns the
+ * source tree from the same parser used by Octane's compiler, with TSRX
+ * metadata attached by the type-only transform. Never throws.
+ */
+export function compileAst(source: string, filename: string): AstSuccess | CompileFailure {
+	try {
+		const result = compileToVolarMappings(source, filename, { loose: true }) as unknown as {
+			sourceAst: unknown;
+		};
+		return { ok: true, ast: result.sourceAst };
+	} catch (error) {
+		return { ok: false, error: error instanceof Error ? error.message : String(error) };
+	}
+}
+
 /**
  * Generate the TYPES view of a playground file: the same typed virtual TSX
  * the IDE language service sees (`octane/compiler/volar`), not the runtime

--- a/website/src/lib/playground.ts
+++ b/website/src/lib/playground.ts
@@ -14,7 +14,7 @@
 //
 // Client-only: load via dynamic import from an effect (never during SSR).
 import { compile, type CompileDiagnostic } from 'octane/compiler';
-import { compileToVolarMappings } from 'octane/compiler/volar';
+import { __parseGeneratedModuleAst, compileToVolarMappings } from 'octane/compiler/volar';
 import {
 	sandboxSrcdoc,
 	RUNTIME_MANIFEST_PATH,
@@ -67,21 +67,99 @@ export interface TypesSuccess {
 
 export interface AstSuccess {
 	ok: true;
-	/** Parser AST for the authored TSRX/TSX, including Octane/TSRX metadata. */
+	/** AST for the selected compiler stage. */
 	ast: unknown;
+	/** Coordinate space used by the AST node start/end offsets. */
+	space: 'source' | 'generated';
+	/** Human-readable stage name shown above the tree. */
+	label: string;
+	/** Explains which tree is displayed and how its positions map. */
+	notice: string;
+	/** Generated artifact corresponding to output AST stages. */
+	code?: string;
+	/** Exact type-only source mappings, when available. */
+	mappings?: VolarTokenMapping[];
+	/** Compiler source map for client/server output, when available. */
+	map?: unknown;
 }
 
+export type PlaygroundAstStage =
+	'source' | 'type-transform' | 'type-output' | 'client-output' | 'server-output';
+
+const parseGeneratedAst = (code: string): unknown => __parseGeneratedModuleAst(code);
+
 /**
- * Build the AST shown by the playground. The Volar entry point returns the
- * source tree from the same parser used by Octane's compiler, with TSRX
- * metadata attached by the type-only transform. Never throws.
+ * Build one stage of the AST trace shown by the playground. Source and
+ * type-only transform trees come directly from the compiler. Client/server
+ * output trees are parsed from the exact emitted code because those emitters
+ * do not maintain one complete transformed AST. Never throws.
  */
-export function compileAst(source: string, filename: string): AstSuccess | CompileFailure {
+export function compileAst(
+	source: string,
+	filename: string,
+	stage: PlaygroundAstStage = 'source',
+): AstSuccess | CompileFailure {
 	try {
-		const result = compileToVolarMappings(source, filename, { loose: true }) as unknown as {
-			sourceAst: unknown;
+		if (stage === 'client-output' || stage === 'server-output') {
+			const mode = stage === 'client-output' ? 'client' : 'server';
+			const result = compile(source, filename, { mode });
+			return {
+				ok: true,
+				ast: parseGeneratedAst(result.code),
+				space: 'generated',
+				label: mode === 'client' ? 'Client output AST' : 'Server output AST',
+				notice:
+					mode === 'client'
+						? 'Parsed from the exact client output. Source navigation is limited to compiler source-map anchors.'
+						: 'Parsed from the exact server output. The server emitter currently provides no source positions.',
+				code: result.code,
+				map: result.map,
+			};
+		}
+
+		if (stage === 'source') {
+			const result = compileToVolarMappings(source, filename, { loose: true });
+			return {
+				ok: true,
+				ast: result.sourceAst,
+				space: 'source',
+				label: 'Parsed source AST',
+				notice:
+					'The parser tree for the authored source. Node positions refer directly to the source editor.',
+			};
+		}
+
+		const result = compileToVolarMappings(source, filename, {
+			loose: true,
+			astTrace: stage === 'type-transform' ? 'transform' : 'generated',
+		}) as ReturnType<typeof compileToVolarMappings> & {
+			astTrace: { transformedAst: unknown; generatedAst?: unknown };
 		};
-		return { ok: true, ast: result.sourceAst };
+		if (stage === 'type-transform') {
+			return {
+				ok: true,
+				ast: result.astTrace.transformedAst,
+				space: 'source',
+				label: 'Type transform AST',
+				notice:
+					'The type-only transformer tree. Authored nodes retain source ranges; synthetic nodes intentionally have no range.',
+				code: result.code,
+				mappings: result.mappings as VolarTokenMapping[],
+			};
+		}
+		if (stage === 'type-output') {
+			return {
+				ok: true,
+				ast: result.astTrace.generatedAst!,
+				space: 'generated',
+				label: 'Types output AST',
+				notice:
+					'Parsed from the exact typed TSX output. Positions map bidirectionally through the compiler type mappings.',
+				code: result.code,
+				mappings: result.mappings as VolarTokenMapping[],
+			};
+		}
+		throw new Error(`Unknown AST stage: ${stage}`);
 	} catch (error) {
 		return { ok: false, error: error instanceof Error ? error.message : String(error) };
 	}

--- a/website/src/lib/playground.ts
+++ b/website/src/lib/playground.ts
@@ -40,6 +40,14 @@ export interface CompileFailure {
 	error: string;
 }
 
+/** Preserve an inspection failure unless module-graph compilation has a more direct error. */
+export function resolvePlaygroundError(
+	graphError: string | null,
+	inspectionError: string | null,
+): string {
+	return graphError ?? inspectionError ?? '';
+}
+
 /**
  * Compile one playground file for the client runtime. Never throws. The
  * filename is the virtual file's real name (e.g. `Island.tsrx`) so diagnostics

--- a/website/src/lib/playground.ts
+++ b/website/src/lib/playground.ts
@@ -87,20 +87,19 @@ export interface AstSuccess {
 	code?: string;
 	/** Exact type-only source mappings, when available. */
 	mappings?: VolarTokenMapping[];
-	/** Compiler source map for client/server output, when available. */
+	/** Compiler source map for client output, when available. */
 	map?: unknown;
 }
 
-export type PlaygroundAstStage =
-	'source' | 'type-transform' | 'type-output' | 'client-output' | 'server-output';
+export type PlaygroundAstStage = 'source' | 'type-transform' | 'type-output' | 'client-output';
 
 const parseGeneratedAst = (code: string): unknown => __parseGeneratedModuleAst(code);
 
 /**
  * Build one stage of the AST trace shown by the playground. Source and
- * type-only transform trees come directly from the compiler. Client/server
- * output trees are parsed from the exact emitted code because those emitters
- * do not maintain one complete transformed AST. Never throws.
+ * type-only transform trees come directly from the compiler. The client output
+ * tree is parsed from the exact emitted code because that emitter does not
+ * maintain one complete transformed AST. Never throws.
  */
 export function compileAst(
 	source: string,
@@ -108,21 +107,18 @@ export function compileAst(
 	stage: PlaygroundAstStage = 'source',
 ): AstSuccess | CompileFailure {
 	try {
-		if (stage === 'client-output' || stage === 'server-output') {
-			const mode = stage === 'client-output' ? 'client' : 'server';
+		if (stage === 'client-output') {
 			const result = compile(source, filename, {
-				mode,
-				sourceMapHostTags: mode === 'client',
+				mode: 'client',
+				sourceMapHostTags: true,
 			});
 			return {
 				ok: true,
 				ast: parseGeneratedAst(result.code),
 				space: 'generated',
-				label: mode === 'client' ? 'Client output AST' : 'Server output AST',
+				label: 'Client output AST',
 				notice:
-					mode === 'client'
-						? 'Parsed from the exact client output. Source navigation is limited to compiler source-map anchors.'
-						: 'Parsed from the exact server output. The server emitter currently provides no source positions.',
+					'Parsed from the exact client output. Source navigation is limited to compiler source-map anchors.',
 				code: result.code,
 				map: result.map,
 			};

--- a/website/src/pages/playground/Playground.tsrx
+++ b/website/src/pages/playground/Playground.tsrx
@@ -1060,7 +1060,7 @@ export function Playground() @{
 						<div class="pg-compiled-controls">
 							@if (compiledMode === 'ast') {
 								<select
-									class="pg-ast-stage-select"
+									class="pg-select pg-ast-stage-select"
 									aria-label="AST compiler stage"
 									value={astStage}
 									onChange={(event) => selectAstStage(event.currentTarget.value as typeof astStage)}
@@ -1231,12 +1231,8 @@ export function Playground() @{
 			}
 			.pg-ast-stage-select {
 				max-width: 9.5rem;
-				padding: 0.18rem 0.35rem;
-				border: 1px solid var(--border);
-				border-radius: 5px;
-				background: var(--code-bg);
-				color: var(--text-secondary);
-				font: inherit;
+				padding: 0.18rem 1.7rem 0.18rem 0.55rem;
+				background-position: right 0.55rem center;
 				font-size: 0.68rem;
 				letter-spacing: 0;
 				text-transform: none;

--- a/website/src/pages/playground/Playground.tsrx
+++ b/website/src/pages/playground/Playground.tsrx
@@ -1,11 +1,11 @@
 // /playground — write TSRX (or TSX) on the left, and on the right either the
 // LIVE rendered app or the compiled output, switchable with a tab. The
-// compiled pane has two modes: PROD (the client-runtime emit of `compile()`)
-// and TYPES (the typed virtual TSX the IDE language service sees, via
-// `octane/compiler/volar`). Both modes support position mapping — placing the
-// cursor in the source highlights and scrolls the corresponding output ranges
-// into view, and vice versa (prod uses the compiler's real source map, types
-// uses the Volar token mappings; see src/lib/playground-mapping.ts). The
+// compiled pane has two modes: AST (the compiler's parser tree for the
+// authored file) and TYPES (the typed virtual TSX the IDE language service
+// sees via `octane/compiler/volar`). Like Svelte's AST output, hovering or
+// selecting source reveals the deepest containing AST node and hovering a
+// tree node highlights its source range. Types uses the Volar token mappings
+// bidirectionally (see src/lib/playground-mapping.ts). The
 // whole pipeline runs in the browser: `octane/compiler` (and sucrase for
 // React-host `.react.tsx` files) compiles the virtual files on a debounce, the
 // module graph executes inside a SANDBOXED IFRAME with an opaque origin (see
@@ -63,9 +63,8 @@ export function Playground() @{
 	useTitle('Octane — Playground');
 	const [lang, setLang] = useState<PlaygroundLang>('tsrx');
 	const [view, setView] = useState<'preview' | 'compiled'>('preview');
-	// Which artifact the compiled pane shows: the prod client-runtime emit or
-	// the typed virtual TSX (a dev-emit option can join later).
-	const [compiledMode, setCompiledMode] = useState<'prod' | 'types'>('prod');
+	// Which compiler artifact the right pane shows.
+	const [compiledMode, setCompiledMode] = useState<'ast' | 'types'>('ast');
 	// Mobile only: which panel is visible (desktop always shows both).
 	const [pane, setPane] = useState<'editor' | 'result'>('editor');
 	const [error, setError] = useState('');
@@ -85,13 +84,17 @@ export function Playground() @{
 
 	const sourceHostRef = useRef<HTMLDivElement | null>(null);
 	const outputHostRef = useRef<HTMLDivElement | null>(null);
+	const astHostRef = useRef<HTMLDivElement | null>(null);
 	const previewHostRef = useRef<HTMLDivElement | null>(null);
 	// The boot closure runs once, so it can't read the view/mode STATE — this
 	// ref mirrors it (updated by the same handlers that set state) for the
 	// closure's output-refresh and position-mapping paths.
-	const resultModeRef = useRef<{ view: 'preview' | 'compiled'; compiledMode: 'prod' | 'types' }>({
+	const resultModeRef = useRef<{
+		view: 'preview' | 'compiled';
+		compiledMode: 'ast' | 'types';
+	}>({
 		view: 'preview',
-		compiledMode: 'prod',
+		compiledMode: 'ast',
 	});
 	// Imperative bridge into the boot closure below — populated once the editor
 	// stack has loaded; the toolbar buttons (and the consent overlay's Run
@@ -110,7 +113,7 @@ export function Playground() @{
 		resultModeRef.current.view = next;
 		controllerRef.current.syncOutput?.();
 	};
-	const selectCompiledMode = (next: 'prod' | 'types') => {
+	const selectCompiledMode = (next: 'ast' | 'types') => {
 		setCompiledMode(next);
 		resultModeRef.current.compiledMode = next;
 		controllerRef.current.syncOutput?.();
@@ -119,12 +122,14 @@ export function Playground() @{
 	useEffect(() => {
 		const sourceHost = sourceHostRef.current;
 		const outputHost = outputHostRef.current;
+		const astHost = astHostRef.current;
 		const previewHost = previewHostRef.current;
-		if (!sourceHost || !outputHost || !previewHost) return;
+		if (!sourceHost || !outputHost || !astHost || !previewHost) return;
 
 		let disposed = false;
 		let sourceView: any;
 		let outputView: any;
+		let astPreview: any;
 		let preview: any = null;
 		let compileDebounceId = 0;
 		let hashDebounceId = 0;
@@ -138,9 +143,9 @@ export function Playground() @{
 
 		(async () => {
 			let stateMod: any, commandsMod: any, viewMod: any, shikiMod: any, pg: any, pgModules: any;
-			let pgExamples: any, pgMapping: any;
+			let pgExamples: any, pgMapping: any, pgAst: any;
 			try {
-				[stateMod, commandsMod, viewMod, shikiMod, pg, pgModules, pgExamples, pgMapping] =
+				[stateMod, commandsMod, viewMod, shikiMod, pg, pgModules, pgExamples, pgMapping, pgAst] =
 					await Promise.all([
 						import('@codemirror/state'),
 						import('@codemirror/commands'),
@@ -150,6 +155,7 @@ export function Playground() @{
 						import('../../lib/playground-modules.ts'),
 						import('../../lib/playground-examples.ts'),
 						import('../../lib/playground-mapping.ts'),
+						import('../../lib/playground-ast.ts'),
 					]);
 			} catch (bootError) {
 				// A load failure after unmount (e.g. a test env torn down mid-import)
@@ -285,22 +291,18 @@ export function Playground() @{
 				view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: doc } });
 			};
 
-			// The compiled-output pane tracks the ACTIVE file and the selected
-			// mode (prod emit vs typed virtual TSX); the last good graph is kept
-			// so tab/mode switches don't need a recompile. `mapping` is derived
-			// lazily per artifact on first navigation and cached on it under an
-			// undefined/null sentinel (undefined = not built yet, null = built
-			// and absent); compiled-module identity is stable across rebuilds
-			// while a file's source is unchanged, so the cache survives them.
+			// The last good graph still drives preview execution. AST and Types
+			// are generated lazily for only the active file when their tab opens.
 			let lastCompiled: Map<string, any> | null = null;
 			// name → { source, code, volarMappings, mapping } — the types view is
 			// generated on demand for the active file only, keyed by the exact
 			// source. Raw volar mappings are kept so the CodeMapping is built
-			// lazily, exactly like the prod pane's source-map path.
+			// lazily on first Types navigation.
 			const typesCache = new Map<
 				string,
 				{ source: string; code: string; volarMappings: any; mapping: any }
 			>();
+			const astCache = new Map<string, { source: string; ast: unknown }>();
 
 			const typesEntry = (name: string) => {
 				const source = fileSource(name);
@@ -329,23 +331,51 @@ export function Playground() @{
 				typesCache.set(name, entry);
 				return entry;
 			};
+			const astEntry = (name: string) => {
+				if (pgModules.isReactHostFile(name)) return null;
+				const source = fileSource(name);
+				const cached = astCache.get(name);
+				if (cached && cached.source === source) return cached;
+				const result = pg.compileAst(source, name);
+				if (!result.ok) {
+					setError(`AST generation failed: ${result.error}`);
+					return null;
+				}
+				const entry = { source, ast: result.ast };
+				astCache.set(name, entry);
+				return entry;
+			};
 
 			// The exact string the output editor currently displays. The output
 			// view is read-only and written ONLY here, so this makes both the
 			// refresh no-op check and activeMapping's staleness check a string
 			// reference compare instead of an O(doc) toString per call.
-			const OUTPUT_PLACEHOLDER = '// Compiled output appears here.';
+			const OUTPUT_PLACEHOLDER = '// Types output appears here.';
 			let lastShownOutput = OUTPUT_PLACEHOLDER;
+			let lastShownAst: object | null = null;
 			const showOutput = () => {
 				// The compiled pane is not visible: skip entirely — no types
 				// generation, no doc replacement, and (the dominant cost) no Shiki
 				// re-tokenize of the output document. syncOutput re-runs this when
 				// the pane is revealed, so it refreshes exactly once, on demand.
 				if (resultModeRef.current.view !== 'compiled') return;
-				const code =
-					resultModeRef.current.compiledMode === 'types'
-						? typesEntry(currentFile).code
-						: lastCompiled?.get(currentFile)?.code;
+				if (resultModeRef.current.compiledMode === 'ast') {
+					const entry = astEntry(currentFile);
+					if (entry && entry !== lastShownAst) {
+						astPreview.setAst(entry.ast, currentFile);
+						lastShownAst = entry;
+					} else if (!entry && pgModules.isReactHostFile(currentFile)) {
+						astPreview.setUnavailable(
+							'AST trace covers Octane-owned .tsrx and .tsx files. React-host files use the separate Sucrase pipeline.',
+							currentFile,
+						);
+						lastShownAst = null;
+					}
+					clearMappedPair();
+					astPreview.clear();
+					return;
+				}
+				const code = typesEntry(currentFile).code;
 				if (typeof code !== 'string' || code === lastShownOutput) return;
 				replaceDoc(outputView, code);
 				lastShownOutput = code;
@@ -395,23 +425,24 @@ export function Playground() @{
 			// Only the first navigation against a fresh artifact builds the
 			// CodeMapping (undefined = not built, null = built, none available).
 			const activeMapping = () => {
-				if (resultModeRef.current.view !== 'compiled') return null;
-				const types = resultModeRef.current.compiledMode === 'types';
-				const entry =
-					types ? typesCache.get(currentFile) : lastCompiled?.get(currentFile);
+				if (
+					resultModeRef.current.view !== 'compiled' ||
+						resultModeRef.current.compiledMode !== 'types'
+				) return null;
+				const entry = typesCache.get(currentFile);
 				if (!entry || entry.source !== fileSource(currentFile)) return null;
 				if (entry.code !== lastShownOutput) return null;
 				if (entry.mapping === undefined) {
-					entry.mapping = types
-						? pgMapping.mappingFromVolar(entry.volarMappings)
-						: entry.map
-							? pgMapping.mappingFromSourceMap(entry.map, entry.source, entry.code)
-							: null;
+					entry.mapping = pgMapping.mappingFromVolar(entry.volarMappings);
 				}
 				return entry.mapping;
 			};
 
-			const revealRanges = (targetView: any, ranges: { from: number; to: number }[]) => {
+			const revealRanges = (
+				targetView: any,
+				ranges: { from: number; to: number }[],
+				scroll: boolean,
+			) => {
 				const limit = targetView.state.doc.length;
 				const clamped = ranges.filter((range: { from: number }) => range.from < limit).map(
 					(range: { from: number; to: number }) => ({
@@ -424,19 +455,57 @@ export function Playground() @{
 					clearMappedIn(targetView);
 					return;
 				}
-				targetView.dispatch({
-					effects: [
-						setMapped.of(
-							Decoration.set(
-								clamped.map(
-									(range: { from: number; to: number }) => mappedMark.range(range.from, range.to),
-								),
+				const effects = [
+					setMapped.of(
+						Decoration.set(
+							clamped.map(
+								(range: { from: number; to: number }) => mappedMark.range(range.from, range.to),
 							),
 						),
-						EditorView.scrollIntoView(clamped[0].from, { y: 'center' }),
-					],
-				});
+					),
+				];
+				if (scroll) effects.push(EditorView.scrollIntoView(clamped[0].from, { y: 'center' }));
+				targetView.dispatch({ effects });
 			};
+
+			const mappedPair = (side: 'source' | 'output', offset: number) => {
+				const mapping = activeMapping();
+				if (!mapping) return null;
+				if (side === 'source') {
+					const output = mapping.toGenerated(offset);
+					const source =
+						output ? mapping.toSource(output[0].from) : null;
+					return source && output ? { source, output } : null;
+				}
+				const source = mapping.toSource(offset);
+				const output =
+					source ? mapping.toGenerated(source[0].from) : null;
+				return source && output ? { source, output } : null;
+			};
+			const clearMappedPair = () => {
+				clearMappedIn(sourceView);
+				clearMappedIn(outputView);
+			};
+			const revealPair = (
+				pair: { source: { from: number; to: number }[]; output: { from: number; to: number }[] },
+				scrollSide: 'source' | 'output' | null,
+			) => {
+				revealRanges(sourceView, pair.source, scrollSide === 'source');
+				revealRanges(outputView, pair.output, scrollSide === 'output');
+			};
+			const revealAstRange = (range: { from: number; to: number } | null, scroll: boolean) => {
+				if (resultModeRef.current.compiledMode !== 'ast') return;
+				if (!range) {
+					clearMappedPair();
+					return;
+				}
+				clearMappedIn(outputView);
+				revealRanges(sourceView, [range], scroll);
+			};
+
+			astPreview = pgAst.createAstPreview(astHost, {
+				onNodeRange: revealAstRange,
+			});
 
 			const crossNavigate = (side: 'source' | 'output') => EditorView.updateListener.of((
 				update: any,
@@ -446,19 +515,38 @@ export function Playground() @{
 				// (doc replacement, highlight effects) must not feed back.
 				if (!update.transactions.some((tr: any) => tr.isUserEvent('select'))) return;
 				if (resultModeRef.current.view !== 'compiled') return;
-				const target =
-					side === 'source' ? outputView : sourceView;
-				const mapping = activeMapping();
 				const offset = update.state.selection.main.head;
-				const ranges =
-					mapping
-						? side === 'source'
-							? mapping.toGenerated(offset)
-							: mapping.toSource(offset)
-						: null;
+				if (resultModeRef.current.compiledMode === 'ast' && side === 'source') {
+					astPreview.reveal(offset, true);
+					return;
+				}
+				const pair = mappedPair(side, offset);
 				// Marks reflect the CURRENT selection — an unmapped one clears.
-				if (ranges) revealRanges(target, ranges);
-				else clearMappedIn(target);
+				if (pair) revealPair(pair, side === 'source' ? 'output' : 'source');
+				else clearMappedPair();
+			});
+
+			// Match Svelte's playground interaction: hovering either document
+			// highlights the corresponding ranges without moving its scroll
+			// position; clicking/cursor movement above additionally reveals them.
+			const crossHover = (side: 'source' | 'output') => EditorView.domEventObservers({
+				mousemove(event: MouseEvent, view: any) {
+					if (resultModeRef.current.view !== 'compiled') return;
+					const offset = view.posAtCoords({ x: event.clientX, y: event.clientY });
+					if (resultModeRef.current.compiledMode === 'ast' && side === 'source') {
+						if (offset == null) clearMappedPair();
+						else astPreview.reveal(offset, false);
+						return;
+					}
+					const pair =
+						offset == null ? null : mappedPair(side, offset);
+					if (pair) revealPair(pair, null);
+					else clearMappedPair();
+				},
+				mouseleave() {
+					clearMappedPair();
+					astPreview.clear();
+				},
 			});
 
 			let compileSeq = 0;
@@ -575,6 +663,7 @@ export function Playground() @{
 					shikiHighlight(grammarFor(name)),
 					sharedTheme,
 					mappedField,
+					crossHover('source'),
 					crossNavigate('source'),
 					EditorView.updateListener.of((update: any) => {
 						if (!update.docChanged) return;
@@ -582,6 +671,10 @@ export function Playground() @{
 						// shown in the output (this field self-clears; a failed
 						// recompile would otherwise leave the output's marks forever).
 						clearMappedIn(outputView);
+						if (resultModeRef.current.compiledMode === 'ast') {
+							astPreview.setUnavailable('Waiting for the next successful compile…', currentFile);
+							lastShownAst = null;
+						}
 						const next = update.state.doc.toString();
 						const file = workspace().files.find(
 							(candidate: { name: string }) => candidate.name === currentFile,
@@ -628,6 +721,7 @@ export function Playground() @{
 						shikiHighlight('tsx'),
 						sharedTheme,
 						mappedField,
+						crossHover('output'),
 						crossNavigate('output'),
 					],
 				}),
@@ -677,6 +771,7 @@ export function Playground() @{
 				currentFile = workspace().entry;
 				editorStates.clear();
 				typesCache.clear();
+				astCache.clear();
 				sourceView.setState(makeEditorState(currentFile, fileSource(currentFile)));
 				clearMappedIn(outputView);
 				// Picking an example is the visitor's own action — never gated.
@@ -753,6 +848,7 @@ export function Playground() @{
 			window.clearTimeout(hashDebounceId);
 			sourceView?.destroy();
 			outputView?.destroy();
+			astPreview?.destroy();
 			preview?.destroy();
 		};
 	}, []);
@@ -881,17 +977,17 @@ export function Playground() @{
 					<span>
 						{view === 'preview'
 							? 'Live preview'
-							: (compiledMode === 'types' ? 'Types output · ' : 'Compiled output · ') +
+							: (compiledMode === 'types' ? 'Types output · ' : 'AST output · ') +
 								(activeFile || '…')}
 					</span>
 					@if (view === 'compiled') {
 						<div class="pg-seg pg-seg-sm" role="group" aria-label="Compiled output mode">
 							<button
 								type="button"
-								class={['pg-seg-btn', compiledMode === 'prod' && 'active']}
-								onClick={() => selectCompiledMode('prod')}
+								class={['pg-seg-btn', compiledMode === 'ast' && 'active']}
+								onClick={() => selectCompiledMode('ast')}
 							>
-								Prod
+								AST
 							</button>
 							<button
 								type="button"
@@ -925,7 +1021,12 @@ export function Playground() @{
 						</div>
 					}
 				</div>
-				<div class={['pg-editor', view !== 'compiled' && 'hidden']} ref={outputHostRef} />
+				<div class={['pg-compiled', view !== 'compiled' && 'hidden']}>
+					<div class={['pg-ast-host', compiledMode !== 'ast' && 'hidden']} ref={astHostRef} />
+					<div class={['pg-output', compiledMode !== 'types' && 'hidden']}>
+						<div class="pg-editor" ref={outputHostRef} />
+					</div>
+				</div>
 			</section>
 		</div>
 
@@ -1022,7 +1123,7 @@ export function Playground() @{
 				border: 1px solid var(--border);
 				background: var(--surface-subtle);
 			}
-			/* Compact variant for the panel-head Prod/Types switch. */
+			/* Compact variant for the panel-head AST/Types switch. */
 			.pg-seg-sm {
 				padding: 2px;
 			}
@@ -1159,8 +1260,115 @@ export function Playground() @{
 				min-height: 0;
 			}
 			.pg-editor.hidden,
+			.pg-compiled.hidden,
 			.pg-result.hidden {
 				display: none;
+			}
+			.pg-compiled {
+				display: flex;
+				flex: 1;
+				min-height: 0;
+				flex-direction: column;
+			}
+			.pg-output {
+				display: flex;
+				flex: 1;
+				min-height: 0;
+				flex-direction: column;
+			}
+			.pg-output.hidden {
+				display: none;
+			}
+			.pg-ast-host {
+				flex: 1;
+				min-height: 0;
+				overflow: hidden;
+			}
+			.pg-ast-host.hidden {
+				display: none;
+			}
+			.pg-ast-host :global(.pg-ast-shell) {
+				display: flex;
+				height: 100%;
+				min-height: 0;
+				flex-direction: column;
+				background: var(--code-bg);
+				color: var(--text);
+				font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+				font-size: 0.75rem;
+			}
+			.pg-ast-host :global(.pg-ast-status),
+			.pg-ast-host :global(.pg-ast-notice) {
+				padding: 0.18rem 0.45rem;
+				border-bottom: 1px solid var(--border);
+				color: var(--text-secondary);
+				font-family: var(--font-sans, system-ui, sans-serif);
+				font-size: 0.65rem;
+			}
+			.pg-ast-host :global(.pg-ast-status) {
+				color: var(--text);
+				font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+			}
+			.pg-ast-host :global(.pg-ast-notice) {
+				border-top: 1px solid var(--border);
+				border-bottom: 0;
+			}
+			.pg-ast-host :global(.pg-ast-scroll) {
+				flex: 1;
+				min-height: 0;
+				overflow: auto;
+				padding: 0.35rem 0.45rem 0.65rem;
+			}
+			.pg-ast-host :global(.pg-ast-tree),
+			.pg-ast-host :global(.pg-ast-node ul) {
+				margin: 0;
+				padding: 0;
+				list-style: none;
+			}
+			.pg-ast-host :global(.pg-ast-node ul) {
+				padding-left: 1rem;
+			}
+			.pg-ast-host :global(.pg-ast-node summary),
+			.pg-ast-host :global(.pg-ast-value),
+			.pg-ast-host :global(.pg-ast-closing) {
+				display: block;
+				width: max-content;
+				padding: 0 0.1rem;
+				border-radius: 2px;
+				white-space: pre;
+			}
+			.pg-ast-host :global(.pg-ast-node summary) {
+				cursor: pointer;
+			}
+			.pg-ast-host :global(.pg-ast-node[data-ast-path='true'] > details:not([open]) > summary),
+			.pg-ast-host :global(.pg-ast-node[data-ast-leaf='true'] > details > summary) {
+				background: rgba(255, 234, 0, 0.2);
+				box-shadow: inset 0 0 0 1px rgba(214, 185, 0, 0.2);
+			}
+			.pg-ast-host :global(.pg-ast-node[data-ast-leaf='true'] > details > summary) {
+				background: rgba(255, 234, 0, 0.34);
+			}
+			.pg-ast-host :global(.pg-ast-key) {
+				color: var(--text);
+				text-decoration: underline;
+				text-decoration-color: var(--border-strong);
+			}
+			.pg-ast-host :global(.pg-ast-type) {
+				color: var(--accent-text);
+			}
+			.pg-ast-host :global(.pg-ast-range),
+			.pg-ast-host :global(.pg-ast-reference),
+			.pg-ast-host :global(.pg-ast-undefined),
+			.pg-ast-host :global(.pg-ast-null) {
+				color: var(--text-secondary);
+			}
+			.pg-ast-host :global(.pg-ast-string) {
+				color: var(--syntax-string, #a56a12);
+			}
+			.pg-ast-host :global(.pg-ast-number),
+			.pg-ast-host :global(.pg-ast-boolean),
+			.pg-ast-host :global(.pg-ast-bigint) {
+				color: var(--syntax-number, #2f8f46);
 			}
 			.pg-grid:not(.ready) :global(.cm-editor) {
 				opacity: 0;
@@ -1170,7 +1378,8 @@ export function Playground() @{
 			}
 			/* Ranges revealed by source↔output position mapping. */
 			.pg-editor :global(.cm-mapped) {
-				background: rgba(255, 221, 0, 0.55);
+				background: rgba(255, 234, 0, 0.42);
+				box-shadow: inset 0 0 0 1px rgba(214, 185, 0, 0.28);
 				border-radius: 2px;
 			}
 			.pg-result {

--- a/website/src/pages/playground/Playground.tsrx
+++ b/website/src/pages/playground/Playground.tsrx
@@ -350,16 +350,16 @@ export function Playground() @{
 				typesCache.set(name, entry);
 				return entry;
 			};
-			const astEntry = (name: string) => {
-				if (pgModules.isReactHostFile(name)) return null;
+			type AstEntryResult = { entry: AstEntry | null; error: string | null };
+			const astEntry = (name: string): AstEntryResult => {
+				if (pgModules.isReactHostFile(name)) return { entry: null, error: null };
 				const source = fileSource(name);
 				const key = astCacheKey(name);
 				const cached = astCache.get(key);
-				if (cached && cached.source === source) return cached;
+				if (cached && cached.source === source) return { entry: cached, error: null };
 				const result = pg.compileAst(source, name, resultModeRef.current.astStage);
 				if (!result.ok) {
-					setError(`AST generation failed: ${result.error}`);
-					return null;
+					return { entry: null, error: `AST generation failed: ${result.error}` };
 				}
 				const entry: AstEntry = {
 					source,
@@ -373,7 +373,7 @@ export function Playground() @{
 					mapping: undefined,
 				};
 				astCache.set(key, entry);
-				return entry;
+				return { entry, error: null };
 			};
 
 			// The exact string the output editor currently displays. The output
@@ -383,14 +383,14 @@ export function Playground() @{
 			const OUTPUT_PLACEHOLDER = '// Types output appears here.';
 			let lastShownOutput = OUTPUT_PLACEHOLDER;
 			let lastShownAst: object | null = null;
-			const showOutput = () => {
+			const showOutput = (): string | null => {
 				// The compiled pane is not visible: skip entirely — no types
 				// generation, no doc replacement, and (the dominant cost) no Shiki
 				// re-tokenize of the output document. syncOutput re-runs this when
 				// the pane is revealed, so it refreshes exactly once, on demand.
-				if (resultModeRef.current.view !== 'compiled') return;
+				if (resultModeRef.current.view !== 'compiled') return null;
 				if (resultModeRef.current.compiledMode === 'ast') {
-					const entry = astEntry(currentFile);
+					const { entry, error } = astEntry(currentFile);
 					if (entry && entry !== lastShownAst) {
 						astPreview.setAst(entry.ast, currentFile, {
 							label: entry.label,
@@ -406,20 +406,22 @@ export function Playground() @{
 					}
 					clearMappedPair();
 					astPreview.clear();
-					return;
+					if (error) setError(error);
+					return error;
 				}
 				const code = typesEntry(currentFile).code;
 				// AST and Types highlights describe different artifacts. Clear the
 				// pair even when the cached Types document needs no replacement.
 				clearMappedPair();
 				astPreview.clear();
-				if (typeof code !== 'string' || code === lastShownOutput) return;
+				if (typeof code !== 'string' || code === lastShownOutput) return null;
 				replaceDoc(outputView, code);
 				lastShownOutput = code;
 				// The output half of the pair changed — source marks were computed
 				// against the previous artifact (the output field self-cleared via
 				// its own doc change just now).
 				clearMappedIn(sourceView);
+				return null;
 			};
 
 			// ── Source ↔ output position mapping ─────────────────────────────
@@ -524,16 +526,9 @@ export function Playground() @{
 			const mappedPair = (side: 'source' | 'output', offset: number) => {
 				const mapping = activeMapping();
 				if (!mapping) return null;
-				if (side === 'source') {
-					const output = mapping.toGenerated(offset);
-					const source =
-						output ? mapping.toSource(output[0].from) : null;
-					return source && output ? { source, output } : null;
-				}
-				const source = mapping.toSource(offset);
-				const output =
-					source ? mapping.toGenerated(source[0].from) : null;
-				return source && output ? { source, output } : null;
+				return side === 'source'
+					? mapping.pairFromSource(offset)
+					: mapping.pairFromGenerated(offset);
 			};
 			const clearMappedPair = () => {
 				clearMappedIn(sourceView);
@@ -645,16 +640,16 @@ export function Playground() @{
 				// AST and Types describe the active source file, independently of
 				// whether another workspace file prevents the runnable module graph
 				// from compiling. Refresh inspection before handling graph failure.
-				showOutput();
+				const inspectionError = showOutput();
 				if (!graph.ok) {
 					setWarnings([]);
-					setError(graph.error);
+					setError(pg.resolvePlaygroundError(graph.error, inspectionError));
 					return;
 				}
 				setWarnings(
 					graph.warnings.map((warning: { diagnostic: CompileDiagnostic }) => warning.diagnostic),
 				);
-				setError('');
+				setError(pg.resolvePlaygroundError(null, inspectionError));
 				// While a shared payload is gated, everything except EXECUTION
 				// happens — the visitor can inspect source and compiled output.
 				if (executionGated) return;

--- a/website/src/pages/playground/Playground.tsrx
+++ b/website/src/pages/playground/Playground.tsrx
@@ -2,8 +2,8 @@
 // LIVE rendered app or the compiled output, switchable with a tab. The
 // compiled pane has two modes: AST (the compiler's parser tree for the
 // authored file) and TYPES (the typed virtual TSX the IDE language service
-// sees via `octane/compiler/volar`). Like Svelte's AST output, hovering or
-// selecting source reveals the deepest containing AST node and hovering a
+// sees via `octane/compiler/volar`). Hovering or selecting source reveals the
+// deepest containing AST node and hovering a
 // tree node highlights its source range. Types uses the Volar token mappings
 // bidirectionally (see src/lib/playground-mapping.ts). The
 // whole pipeline runs in the browser: `octane/compiler` (and sucrase for
@@ -526,8 +526,7 @@ export function Playground() @{
 				else clearMappedPair();
 			});
 
-			// Match Svelte's playground interaction: hovering either document
-			// highlights the corresponding ranges without moving its scroll
+			// Hovering either document highlights the corresponding ranges without moving its scroll
 			// position; clicking/cursor movement above additionally reveals them.
 			const crossHover = (side: 'source' | 'output') => EditorView.domEventObservers({
 				mousemove(event: MouseEvent, view: any) {

--- a/website/src/pages/playground/Playground.tsrx
+++ b/website/src/pages/playground/Playground.tsrx
@@ -1,7 +1,7 @@
 // /playground — write TSRX (or TSX) on the left, and on the right either the
 // LIVE rendered app or the compiled output, switchable with a tab. The
 // compiled pane has two modes: AST (parsed source, type transform, and exact
-// emitted client/server/type-output trees) and TYPES (the typed virtual TSX
+// emitted client/type-output trees) and TYPES (the typed virtual TSX
 // the IDE language service sees via `octane/compiler/volar`). Hovering or
 // selecting source reveals the corresponding AST node where the compiler has
 // a mapping; hovering a tree node highlights its source origin. Types uses
@@ -30,7 +30,7 @@
 // the default sources auto-run as before.
 import { useState, useRef, useEffect } from 'octane';
 import type { CompileDiagnostic } from 'octane/compiler';
-import type { PlaygroundLang } from '../../lib/playground.ts';
+import type { PlaygroundAstStage, PlaygroundLang } from '../../lib/playground.ts';
 import {
 	decodePlaygroundHash,
 	encodePlaygroundHash,
@@ -65,9 +65,7 @@ export function Playground() @{
 	const [view, setView] = useState<'preview' | 'compiled'>('preview');
 	// Which compiler artifact the right pane shows.
 	const [compiledMode, setCompiledMode] = useState<'ast' | 'types'>('ast');
-	const [astStage, setAstStage] = useState<
-		'source' | 'type-transform' | 'type-output' | 'client-output' | 'server-output'
-	>('source');
+	const [astStage, setAstStage] = useState<PlaygroundAstStage>('source');
 	// Mobile only: which panel is visible (desktop always shows both).
 	const [pane, setPane] = useState<'editor' | 'result'>('editor');
 	const [error, setError] = useState('');
@@ -95,7 +93,7 @@ export function Playground() @{
 	const resultModeRef = useRef<{
 		view: 'preview' | 'compiled';
 		compiledMode: 'ast' | 'types';
-		astStage: 'source' | 'type-transform' | 'type-output' | 'client-output' | 'server-output';
+		astStage: PlaygroundAstStage;
 	}>({
 		view: 'preview',
 		compiledMode: 'ast',
@@ -1069,7 +1067,6 @@ export function Playground() @{
 									<option value="type-transform">Type transform</option>
 									<option value="type-output">Types output</option>
 									<option value="client-output">Client output</option>
-									<option value="server-output">Server output</option>
 								</select>
 							}
 							<div class="pg-seg pg-seg-sm" role="group" aria-label="Compiled output mode">

--- a/website/src/pages/playground/Playground.tsrx
+++ b/website/src/pages/playground/Playground.tsrx
@@ -559,6 +559,20 @@ export function Playground() @{
 				if (sourceRanges) revealRanges(sourceView, sourceRanges, scroll);
 				else clearMappedIn(sourceView);
 			};
+			const revealMappedAstFromSource = (offset: number, scroll: boolean) => {
+				const pair = activeMapping()?.pairFromSource(offset);
+				if (!pair) {
+					astPreview.clear();
+					clearMappedPair();
+					return;
+				}
+				astPreview.reveal(pair.output[0].from, scroll);
+				// Client templates are parsed as one string Literal. Revealing that
+				// AST node reports its whole range back through onNodeRange, whose
+				// first source anchor may be a different tag. Restore the exact
+				// source-side range that initiated navigation after the reveal.
+				revealRanges(sourceView, pair.source, false);
+			};
 
 			astPreview = pgAst.createAstPreview(astHost, {
 				onNodeRange: revealAstRange,
@@ -576,14 +590,7 @@ export function Playground() @{
 				if (resultModeRef.current.compiledMode === 'ast' && side === 'source') {
 					const entry = activeAstEntry();
 					if (entry?.space === 'source') astPreview.reveal(offset, true);
-					else {
-						const generated = activeMapping()?.toGenerated(offset);
-						if (generated) astPreview.reveal(generated[0].from, true);
-						else {
-							astPreview.clear();
-							clearMappedPair();
-						}
-					}
+					else revealMappedAstFromSource(offset, true);
 					return;
 				}
 				const pair = mappedPair(side, offset);
@@ -602,14 +609,7 @@ export function Playground() @{
 						const entry = activeAstEntry();
 						if (offset == null || !entry) clearMappedPair();
 						else if (entry.space === 'source') astPreview.reveal(offset, false);
-						else {
-							const generated = activeMapping()?.toGenerated(offset);
-							if (generated) astPreview.reveal(generated[0].from, false);
-							else {
-								astPreview.clear();
-								clearMappedPair();
-							}
-						}
+						else revealMappedAstFromSource(offset, false);
 						return;
 					}
 					const pair =

--- a/website/src/pages/playground/Playground.tsrx
+++ b/website/src/pages/playground/Playground.tsrx
@@ -1,11 +1,11 @@
 // /playground — write TSRX (or TSX) on the left, and on the right either the
 // LIVE rendered app or the compiled output, switchable with a tab. The
-// compiled pane has two modes: AST (the compiler's parser tree for the
-// authored file) and TYPES (the typed virtual TSX the IDE language service
-// sees via `octane/compiler/volar`). Hovering or selecting source reveals the
-// deepest containing AST node and hovering a
-// tree node highlights its source range. Types uses the Volar token mappings
-// bidirectionally (see src/lib/playground-mapping.ts). The
+// compiled pane has two modes: AST (parsed source, type transform, and exact
+// emitted client/server/type-output trees) and TYPES (the typed virtual TSX
+// the IDE language service sees via `octane/compiler/volar`). Hovering or
+// selecting source reveals the corresponding AST node where the compiler has
+// a mapping; hovering a tree node highlights its source origin. Types uses
+// the Volar token mappings bidirectionally (see playground-mapping.ts). The
 // whole pipeline runs in the browser: `octane/compiler` (and sucrase for
 // React-host `.react.tsx` files) compiles the virtual files on a debounce, the
 // module graph executes inside a SANDBOXED IFRAME with an opaque origin (see
@@ -65,6 +65,9 @@ export function Playground() @{
 	const [view, setView] = useState<'preview' | 'compiled'>('preview');
 	// Which compiler artifact the right pane shows.
 	const [compiledMode, setCompiledMode] = useState<'ast' | 'types'>('ast');
+	const [astStage, setAstStage] = useState<
+		'source' | 'type-transform' | 'type-output' | 'client-output' | 'server-output'
+	>('source');
 	// Mobile only: which panel is visible (desktop always shows both).
 	const [pane, setPane] = useState<'editor' | 'result'>('editor');
 	const [error, setError] = useState('');
@@ -92,9 +95,11 @@ export function Playground() @{
 	const resultModeRef = useRef<{
 		view: 'preview' | 'compiled';
 		compiledMode: 'ast' | 'types';
+		astStage: 'source' | 'type-transform' | 'type-output' | 'client-output' | 'server-output';
 	}>({
 		view: 'preview',
 		compiledMode: 'ast',
+		astStage: 'source',
 	});
 	// Imperative bridge into the boot closure below — populated once the editor
 	// stack has loaded; the toolbar buttons (and the consent overlay's Run
@@ -116,6 +121,11 @@ export function Playground() @{
 	const selectCompiledMode = (next: 'ast' | 'types') => {
 		setCompiledMode(next);
 		resultModeRef.current.compiledMode = next;
+		controllerRef.current.syncOutput?.();
+	};
+	const selectAstStage = (next: typeof astStage) => {
+		setAstStage(next);
+		resultModeRef.current.astStage = next;
 		controllerRef.current.syncOutput?.();
 	};
 
@@ -299,7 +309,19 @@ export function Playground() @{
 				string,
 				{ source: string; code: string; volarMappings: any; mapping: any }
 			>();
-			const astCache = new Map<string, { source: string; ast: unknown }>();
+			type AstEntry = {
+				source: string;
+				ast: unknown;
+				space: 'source' | 'generated';
+				label: string;
+				notice: string;
+				code?: string;
+				volarMappings?: any;
+				map?: unknown;
+				mapping?: any;
+			};
+			const astCache = new Map<string, AstEntry>();
+			const astCacheKey = (name: string) => name + '::' + resultModeRef.current.astStage;
 
 			const typesEntry = (name: string) => {
 				const source = fileSource(name);
@@ -331,15 +353,26 @@ export function Playground() @{
 			const astEntry = (name: string) => {
 				if (pgModules.isReactHostFile(name)) return null;
 				const source = fileSource(name);
-				const cached = astCache.get(name);
+				const key = astCacheKey(name);
+				const cached = astCache.get(key);
 				if (cached && cached.source === source) return cached;
-				const result = pg.compileAst(source, name);
+				const result = pg.compileAst(source, name, resultModeRef.current.astStage);
 				if (!result.ok) {
 					setError(`AST generation failed: ${result.error}`);
 					return null;
 				}
-				const entry = { source, ast: result.ast };
-				astCache.set(name, entry);
+				const entry: AstEntry = {
+					source,
+					ast: result.ast,
+					space: result.space,
+					label: result.label,
+					notice: result.notice,
+					code: result.code,
+					volarMappings: result.mappings,
+					map: result.map,
+					mapping: undefined,
+				};
+				astCache.set(key, entry);
 				return entry;
 			};
 
@@ -359,7 +392,10 @@ export function Playground() @{
 				if (resultModeRef.current.compiledMode === 'ast') {
 					const entry = astEntry(currentFile);
 					if (entry && entry !== lastShownAst) {
-						astPreview.setAst(entry.ast, currentFile);
+						astPreview.setAst(entry.ast, currentFile, {
+							label: entry.label,
+							notice: entry.notice,
+						});
 						lastShownAst = entry;
 					} else if (!entry) {
 						const message = pgModules.isReactHostFile(currentFile)
@@ -425,16 +461,32 @@ export function Playground() @{
 			// source tracks every edit, and lastShownOutput mirrors the pane.
 			// Only the first navigation against a fresh artifact builds the
 			// CodeMapping (undefined = not built, null = built, none available).
-			const activeMapping = () => {
+			const activeAstEntry = (): AstEntry | null => {
 				if (
-					resultModeRef.current.view !== 'compiled' ||
-						resultModeRef.current.compiledMode !== 'types'
+					resultModeRef.current.view !== 'compiled' || resultModeRef.current.compiledMode !== 'ast'
 				) return null;
-				const entry = typesCache.get(currentFile);
-				if (!entry || entry.source !== fileSource(currentFile)) return null;
-				if (entry.code !== lastShownOutput) return null;
+				const entry = astCache.get(astCacheKey(currentFile));
+				return entry && entry.source === fileSource(currentFile) && entry === lastShownAst
+					? entry
+					: null;
+			};
+			const activeMapping = () => {
+				if (resultModeRef.current.view !== 'compiled') return null;
+				if (resultModeRef.current.compiledMode === 'types') {
+					const entry = typesCache.get(currentFile);
+					if (!entry || entry.source !== fileSource(currentFile)) return null;
+					if (entry.code !== lastShownOutput) return null;
+					if (entry.mapping === undefined) {
+						entry.mapping = pgMapping.mappingFromVolar(entry.volarMappings);
+					}
+					return entry.mapping;
+				}
+				const entry = activeAstEntry();
+				if (!entry || entry.space !== 'generated') return null;
 				if (entry.mapping === undefined) {
-					entry.mapping = pgMapping.mappingFromVolar(entry.volarMappings);
+					entry.mapping = entry.volarMappings
+						? pgMapping.mappingFromVolar(entry.volarMappings)
+						: pgMapping.mappingFromSourceMap(entry.map, entry.source, entry.code ?? '');
 				}
 				return entry.mapping;
 			};
@@ -496,12 +548,19 @@ export function Playground() @{
 			};
 			const revealAstRange = (range: { from: number; to: number } | null, scroll: boolean) => {
 				if (resultModeRef.current.compiledMode !== 'ast') return;
-				if (!range) {
+				const entry = activeAstEntry();
+				if (!range || !entry) {
 					clearMappedPair();
 					return;
 				}
 				clearMappedIn(outputView);
-				revealRanges(sourceView, [range], scroll);
+				if (entry.space === 'source') {
+					revealRanges(sourceView, [range], scroll);
+					return;
+				}
+				const sourceRanges = activeMapping()?.toSourceRange(range.from, range.to) ?? null;
+				if (sourceRanges) revealRanges(sourceView, sourceRanges, scroll);
+				else clearMappedIn(sourceView);
 			};
 
 			astPreview = pgAst.createAstPreview(astHost, {
@@ -518,7 +577,16 @@ export function Playground() @{
 				if (resultModeRef.current.view !== 'compiled') return;
 				const offset = update.state.selection.main.head;
 				if (resultModeRef.current.compiledMode === 'ast' && side === 'source') {
-					astPreview.reveal(offset, true);
+					const entry = activeAstEntry();
+					if (entry?.space === 'source') astPreview.reveal(offset, true);
+					else {
+						const generated = activeMapping()?.toGenerated(offset);
+						if (generated) astPreview.reveal(generated[0].from, true);
+						else {
+							astPreview.clear();
+							clearMappedPair();
+						}
+					}
 					return;
 				}
 				const pair = mappedPair(side, offset);
@@ -534,8 +602,17 @@ export function Playground() @{
 					if (resultModeRef.current.view !== 'compiled') return;
 					const offset = view.posAtCoords({ x: event.clientX, y: event.clientY });
 					if (resultModeRef.current.compiledMode === 'ast' && side === 'source') {
-						if (offset == null) clearMappedPair();
-						else astPreview.reveal(offset, false);
+						const entry = activeAstEntry();
+						if (offset == null || !entry) clearMappedPair();
+						else if (entry.space === 'source') astPreview.reveal(offset, false);
+						else {
+							const generated = activeMapping()?.toGenerated(offset);
+							if (generated) astPreview.reveal(generated[0].from, false);
+							else {
+								astPreview.clear();
+								clearMappedPair();
+							}
+						}
 						return;
 					}
 					const pair =
@@ -980,21 +1057,37 @@ export function Playground() @{
 								(activeFile || '…')}
 					</span>
 					@if (view === 'compiled') {
-						<div class="pg-seg pg-seg-sm" role="group" aria-label="Compiled output mode">
-							<button
-								type="button"
-								class={['pg-seg-btn', compiledMode === 'ast' && 'active']}
-								onClick={() => selectCompiledMode('ast')}
-							>
-								AST
-							</button>
-							<button
-								type="button"
-								class={['pg-seg-btn', compiledMode === 'types' && 'active']}
-								onClick={() => selectCompiledMode('types')}
-							>
-								Types
-							</button>
+						<div class="pg-compiled-controls">
+							@if (compiledMode === 'ast') {
+								<select
+									class="pg-ast-stage-select"
+									aria-label="AST compiler stage"
+									value={astStage}
+									onChange={(event) => selectAstStage(event.currentTarget.value as typeof astStage)}
+								>
+									<option value="source">Parsed source</option>
+									<option value="type-transform">Type transform</option>
+									<option value="type-output">Types output</option>
+									<option value="client-output">Client output</option>
+									<option value="server-output">Server output</option>
+								</select>
+							}
+							<div class="pg-seg pg-seg-sm" role="group" aria-label="Compiled output mode">
+								<button
+									type="button"
+									class={['pg-seg-btn', compiledMode === 'ast' && 'active']}
+									onClick={() => selectCompiledMode('ast')}
+								>
+									AST
+								</button>
+								<button
+									type="button"
+									class={['pg-seg-btn', compiledMode === 'types' && 'active']}
+									onClick={() => selectCompiledMode('types')}
+								>
+									Types
+								</button>
+							</div>
 						</div>
 					}
 				</div>
@@ -1130,6 +1223,23 @@ export function Playground() @{
 				font-size: 0.68rem;
 				padding: 0.12rem 0.6rem;
 				letter-spacing: 0.06em;
+			}
+			.pg-compiled-controls {
+				display: flex;
+				align-items: center;
+				gap: 0.45rem;
+			}
+			.pg-ast-stage-select {
+				max-width: 9.5rem;
+				padding: 0.18rem 0.35rem;
+				border: 1px solid var(--border);
+				border-radius: 5px;
+				background: var(--code-bg);
+				color: var(--text-secondary);
+				font: inherit;
+				font-size: 0.68rem;
+				letter-spacing: 0;
+				text-transform: none;
 			}
 			.pg-seg-btn {
 				border: none;

--- a/website/src/pages/playground/Playground.tsrx
+++ b/website/src/pages/playground/Playground.tsrx
@@ -406,7 +406,7 @@ export function Playground() @{
 					}
 					clearMappedPair();
 					astPreview.clear();
-					if (error) setError(error);
+					setError(error || '');
 					return error;
 				}
 				const code = typesEntry(currentFile).code;
@@ -414,6 +414,8 @@ export function Playground() @{
 				// pair even when the cached Types document needs no replacement.
 				clearMappedPair();
 				astPreview.clear();
+				// Clear any stale error from a previous stage/mode.
+				setError('');
 				if (typeof code !== 'string' || code === lastShownOutput) return null;
 				replaceDoc(outputView, code);
 				lastShownOutput = code;

--- a/website/src/pages/playground/Playground.tsrx
+++ b/website/src/pages/playground/Playground.tsrx
@@ -291,9 +291,6 @@ export function Playground() @{
 				view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: doc } });
 			};
 
-			// The last good graph still drives preview execution. AST and Types
-			// are generated lazily for only the active file when their tab opens.
-			let lastCompiled: Map<string, any> | null = null;
 			// name → { source, code, volarMappings, mapping } — the types view is
 			// generated on demand for the active file only, keyed by the exact
 			// source. Raw volar mappings are kept so the CodeMapping is built
@@ -364,11 +361,11 @@ export function Playground() @{
 					if (entry && entry !== lastShownAst) {
 						astPreview.setAst(entry.ast, currentFile);
 						lastShownAst = entry;
-					} else if (!entry && pgModules.isReactHostFile(currentFile)) {
-						astPreview.setUnavailable(
-							'AST trace covers Octane-owned .tsrx and .tsx files. React-host files use the separate Sucrase pipeline.',
-							currentFile,
-						);
+					} else if (!entry) {
+						const message = pgModules.isReactHostFile(currentFile)
+							? 'AST trace covers Octane-owned .tsrx and .tsx files. React-host files use the separate Sucrase pipeline.'
+							: 'AST generation failed. Fix the source to generate a new tree.';
+						astPreview.setUnavailable(message, currentFile);
 						lastShownAst = null;
 					}
 					clearMappedPair();
@@ -376,6 +373,10 @@ export function Playground() @{
 					return;
 				}
 				const code = typesEntry(currentFile).code;
+				// AST and Types highlights describe different artifacts. Clear the
+				// pair even when the cached Types document needs no replacement.
+				clearMappedPair();
+				astPreview.clear();
 				if (typeof code !== 'string' || code === lastShownOutput) return;
 				replaceDoc(outputView, code);
 				lastShownOutput = code;
@@ -573,7 +574,6 @@ export function Playground() @{
 					graph.warnings.map((warning: { diagnostic: CompileDiagnostic }) => warning.diagnostic),
 				);
 				setError('');
-				lastCompiled = graph.compiled;
 				showOutput();
 				// While a shared payload is gated, everything except EXECUTION
 				// happens — the visitor can inspect source and compiled output.

--- a/website/src/pages/playground/Playground.tsrx
+++ b/website/src/pages/playground/Playground.tsrx
@@ -642,6 +642,10 @@ export function Playground() @{
 				}
 				const graph = await pgModules.buildModuleGraph(wsFiles, entry);
 				if (disposed || seq !== compileSeq) return;
+				// AST and Types describe the active source file, independently of
+				// whether another workspace file prevents the runnable module graph
+				// from compiling. Refresh inspection before handling graph failure.
+				showOutput();
 				if (!graph.ok) {
 					setWarnings([]);
 					setError(graph.error);
@@ -651,7 +655,6 @@ export function Playground() @{
 					graph.warnings.map((warning: { diagnostic: CompileDiagnostic }) => warning.diagnostic),
 				);
 				setError('');
-				showOutput();
 				// While a shared payload is gated, everything except EXECUTION
 				// happens — the visitor can inspect source and compiled output.
 				if (executionGated) return;

--- a/website/tests/playground-ast.test.ts
+++ b/website/tests/playground-ast.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import {
+	findDeepestAstNode,
+	preparePlaygroundAst,
+	type PlaygroundAstNode,
+} from '../src/lib/playground-ast.ts';
+import { compileAst } from '../src/lib/playground.ts';
+
+const nodeTypes = (root: PlaygroundAstNode): Set<string> => {
+	const types = new Set<string>();
+	const visit = (node: PlaygroundAstNode) => {
+		if (node.type) types.add(node.type);
+		for (const child of node.children) visit(child);
+	};
+	visit(root);
+	return types;
+};
+
+describe('playground AST preparation', () => {
+	it('keeps every enumerable field and renders graph cycles as explicit references', () => {
+		const ast: Record<string, unknown> = {
+			type: 'Program',
+			start: 0,
+			end: 10,
+			body: [],
+			metadata: { transformed: true },
+		};
+		ast.self = ast;
+
+		const prepared = preparePlaygroundAst(ast);
+		expect(prepared.root.children.map((child) => child.key)).toEqual([
+			'type',
+			'start',
+			'end',
+			'body',
+			'metadata',
+			'self',
+		]);
+		const self = prepared.root.children.at(-1)!;
+		expect(self.kind).toBe('reference');
+		expect(self.value).toBe('Reference → $');
+	});
+
+	it('keeps structural nodes canonical when an earlier metadata path references them', () => {
+		const shared = { type: 'Identifier', start: 4, end: 5, name: 'x' };
+		const prepared = preparePlaygroundAst({
+			type: 'Program',
+			start: 0,
+			end: 5,
+			first: { type: 'Marker', start: 0, end: 1, metadata: { path: [shared] } },
+			actual: shared,
+		});
+		const first = prepared.root.children.find((child) => child.key === 'first')!;
+		const metadataReference = first.children
+			.find((child) => child.key === 'metadata')!
+			.children.find((child) => child.key === 'path')!.children[0];
+		const actual = prepared.root.children.find((child) => child.key === 'actual')!;
+
+		expect(metadataReference.kind).toBe('reference');
+		expect(metadataReference.value).toBe('Reference → $.actual');
+		expect(actual.kind).toBe('object');
+		expect(actual.type).toBe('Identifier');
+	});
+
+	it('finds the narrowest containing node with half-open AST ranges', () => {
+		const prepared = preparePlaygroundAst({
+			type: 'Program',
+			start: 0,
+			end: 10,
+			body: [
+				{
+					type: 'ExpressionStatement',
+					start: 2,
+					end: 8,
+					expression: { type: 'Identifier', start: 4, end: 6, name: 'x' },
+				},
+			],
+		});
+
+		expect(findDeepestAstNode(prepared, 5)?.type).toBe('Identifier');
+		expect(findDeepestAstNode(prepared, 6)?.type).toBe('ExpressionStatement');
+		expect(findDeepestAstNode(prepared, 10)).toBeNull();
+	});
+});
+
+describe.each([
+	{
+		filename: 'App.tsrx',
+		source: `export function App() @{
+	const label = 'TSRX';
+	<button>{label}</button>
+}`,
+		sourceNode: 'JSXCodeBlock',
+	},
+	{
+		filename: 'App.tsx',
+		source: `/** @jsxImportSource octane */
+export function App() {
+	const label = 'TSX';
+	return <button>{label}</button>;
+}`,
+		sourceNode: 'JSXElement',
+	},
+])('playground $filename AST pipeline', ({ filename, source, sourceNode }) => {
+	it('exposes the compiler parser AST for the authored file', () => {
+		const ast = compileAst(source, filename);
+		if (!ast.ok) throw new Error(ast.error);
+
+		const tree = preparePlaygroundAst(ast.ast);
+		expect(nodeTypes(tree.root)).toContain(sourceNode);
+		expect(tree.root.range).toEqual({ from: 0, to: source.length });
+	});
+});

--- a/website/tests/playground-ast.test.ts
+++ b/website/tests/playground-ast.test.ts
@@ -141,4 +141,41 @@ export function App() {
 		expect(nodeTypes(tree.root)).toContain(sourceNode);
 		expect(tree.root.range).toEqual({ from: 0, to: source.length });
 	});
+
+	it('distinguishes transformer and emitted-output coordinate spaces', () => {
+		const transform = compileAst(source, filename, 'type-transform');
+		const typeOutput = compileAst(source, filename, 'type-output');
+		const clientOutput = compileAst(source, filename, 'client-output');
+		const serverOutput = compileAst(source, filename, 'server-output');
+		for (const result of [transform, typeOutput, clientOutput, serverOutput]) {
+			if (!result.ok) throw new Error(result.error);
+		}
+		if (!transform.ok || !typeOutput.ok || !clientOutput.ok || !serverOutput.ok) return;
+
+		expect(transform.space).toBe('source');
+		expect((transform.ast as { end: number }).end).toBe(source.length);
+		for (const output of [typeOutput, clientOutput, serverOutput]) {
+			expect(output.space).toBe('generated');
+			expect((output.ast as { type: string }).type).toBe('Program');
+			expect((output.ast as { end: number }).end).toBe(output.code!.length);
+		}
+		expect(clientOutput.map).toBeDefined();
+		expect(serverOutput.notice).toContain('no source positions');
+	});
+});
+
+it('parses typed output as TSX when the source contains a scoped style block', () => {
+	const source = `export function App() @{
+	<button>Styled</button>
+	<style>
+		button { color: red; }
+	</style>
+}`;
+	const parsed = compileAst(source, 'App.tsrx', 'source');
+	const output = compileAst(source, 'App.tsrx', 'type-output');
+	if (!parsed.ok) throw new Error(parsed.error);
+	if (!output.ok) throw new Error(output.error);
+
+	expect((parsed.ast as { end: number }).end).toBe(source.length);
+	expect((output.ast as { end: number }).end).toBe(output.code!.length);
 });

--- a/website/tests/playground-ast.test.ts
+++ b/website/tests/playground-ast.test.ts
@@ -146,21 +146,19 @@ export function App() {
 		const transform = compileAst(source, filename, 'type-transform');
 		const typeOutput = compileAst(source, filename, 'type-output');
 		const clientOutput = compileAst(source, filename, 'client-output');
-		const serverOutput = compileAst(source, filename, 'server-output');
-		for (const result of [transform, typeOutput, clientOutput, serverOutput]) {
+		for (const result of [transform, typeOutput, clientOutput]) {
 			if (!result.ok) throw new Error(result.error);
 		}
-		if (!transform.ok || !typeOutput.ok || !clientOutput.ok || !serverOutput.ok) return;
+		if (!transform.ok || !typeOutput.ok || !clientOutput.ok) return;
 
 		expect(transform.space).toBe('source');
 		expect((transform.ast as { end: number }).end).toBe(source.length);
-		for (const output of [typeOutput, clientOutput, serverOutput]) {
+		for (const output of [typeOutput, clientOutput]) {
 			expect(output.space).toBe('generated');
 			expect((output.ast as { type: string }).type).toBe('Program');
 			expect((output.ast as { end: number }).end).toBe(output.code!.length);
 		}
 		expect(clientOutput.map).toBeDefined();
-		expect(serverOutput.notice).toContain('no source positions');
 	});
 });
 

--- a/website/tests/playground-ast.test.ts
+++ b/website/tests/playground-ast.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+	createAstPreview,
 	findDeepestAstNode,
 	preparePlaygroundAst,
 	type PlaygroundAstNode,
@@ -80,6 +81,36 @@ describe('playground AST preparation', () => {
 		expect(findDeepestAstNode(prepared, 5)?.type).toBe('Identifier');
 		expect(findDeepestAstNode(prepared, 6)?.type).toBe('ExpressionStatement');
 		expect(findDeepestAstNode(prepared, 10)).toBeNull();
+	});
+
+	it('drops source ranges when the current AST becomes unavailable', () => {
+		const host = document.createElement('div');
+		const ranges: Array<{ from: number; to: number } | null> = [];
+		const preview = createAstPreview(host, {
+			onNodeRange(range) {
+				ranges.push(range);
+			},
+		});
+		preview.setAst(
+			{
+				type: 'Program',
+				start: 0,
+				end: 10,
+				body: [{ type: 'Identifier', start: 4, end: 6, name: 'x' }],
+			},
+			'App.tsrx',
+		);
+		preview.reveal(5, false);
+		expect(ranges.at(-1)).toEqual({ from: 4, to: 6 });
+
+		preview.setUnavailable('Waiting for a successful compile…', 'App.tsrx');
+		expect(ranges.at(-1)).toBeNull();
+		expect(host.querySelector('.pg-ast-tree')).toBeNull();
+		expect(host.textContent).toContain('Waiting for a successful compile…');
+
+		preview.reveal(5, false);
+		expect(ranges.at(-1)).toBeNull();
+		preview.destroy();
 	});
 });
 

--- a/website/tests/playground-mapping.test.ts
+++ b/website/tests/playground-mapping.test.ts
@@ -1,14 +1,11 @@
 // Source ↔ output position mapping (src/lib/playground-mapping.ts) — the
 // contract behind the playground's click-to-navigate: an offset in the source
 // resolves to the range(s) in the compiled output that came from it, and an
-// offset in the output resolves back to its source range. Both constructors
-// are exercised against REAL compiler artifacts (the prod source map and the
-// Volar token mappings), not synthetic fixtures, so offset math breaking —
-// VLQ decode, line-start conversion, anchor search — lands on wrong text and
-// fails these assertions.
+// offset in the output resolves back to its source range. It is exercised
+// against real Volar token mappings, not synthetic fixtures.
 import { describe, it, expect } from 'vitest';
-import { compilePlayground, compileTypes } from '../src/lib/playground.ts';
-import { mappingFromSourceMap, mappingFromVolar } from '../src/lib/playground-mapping.ts';
+import { compileTypes } from '../src/lib/playground.ts';
+import { mappingFromVolar } from '../src/lib/playground-mapping.ts';
 
 const SOURCE = `import { useState } from 'octane';
 
@@ -24,69 +21,6 @@ export default function App() @{
 
 const textAt = (text: string, range: { from: number; to: number }) =>
 	text.slice(range.from, range.to);
-
-describe('prod mapping (compiler source map)', () => {
-	const compiled = compilePlayground(SOURCE, 'App.tsrx');
-	if (!compiled.ok) throw new Error(compiled.error);
-	const mapping = mappingFromSourceMap(compiled.map, SOURCE, compiled.code);
-
-	it('builds a mapping from the real compile artifact', () => {
-		expect(mapping).not.toBeNull();
-	});
-
-	it('maps a source identifier to output ranges holding that code', () => {
-		const offset = SOURCE.indexOf('useState(0)') + 2; // inside `useState`
-		const ranges = mapping!.toGenerated(offset);
-		expect(ranges).not.toBeNull();
-		expect(ranges!.length).toBeGreaterThan(0);
-		expect(ranges!.some((range) => textAt(compiled.code, range).includes('useState'))).toBe(true);
-	});
-
-	it('maps an output identifier back to its source range', () => {
-		const offset = compiled.code.indexOf('useState(0') + 2;
-		const ranges = mapping!.toSource(offset);
-		expect(ranges).not.toBeNull();
-		expect(ranges!.some((range) => textAt(SOURCE, range).includes('useState'))).toBe(true);
-	});
-
-	it('clears on unmapped positions instead of borrowing a distant anchor', () => {
-		// The blank line between the hook statement and the JSX carries no
-		// mapping segment. Unbounded nearest-anchor matching used to resolve it
-		// to the previous anchor and light an unrelated range in the output.
-		const offset = SOURCE.indexOf('\n\n\t<div>') + 1;
-		expect(mapping!.toGenerated(offset)).toBeNull();
-	});
-
-	it('maps no source from generated plumbing past the last anchored token', () => {
-		const offset = compiled.code.lastIndexOf('\n\n') + 1;
-		expect(mapping!.toSource(offset)).toBeNull();
-	});
-
-	it('still matches with the cursor parked at the trailing edge of a word', () => {
-		const offset = SOURCE.indexOf('const [') + 'const'.length;
-		const ranges = mapping!.toGenerated(offset);
-		expect(ranges).not.toBeNull();
-		expect(ranges!.some((range) => textAt(compiled.code, range).includes('const'))).toBe(true);
-	});
-
-	it('answers every offset without throwing (bounded-anchor semantics)', () => {
-		for (const offset of [0, SOURCE.length - 1, SOURCE.length]) {
-			const ranges = mapping!.toGenerated(offset);
-			if (ranges) {
-				for (const range of ranges) {
-					expect(range.from).toBeLessThan(range.to);
-					expect(range.to).toBeLessThanOrEqual(compiled.code.length);
-				}
-			}
-		}
-	});
-
-	it('returns null for a missing or malformed map instead of throwing', () => {
-		expect(mappingFromSourceMap(null, SOURCE, compiled.code)).toBeNull();
-		expect(mappingFromSourceMap({}, SOURCE, compiled.code)).toBeNull();
-		expect(mappingFromSourceMap({ mappings: '!!not-vlq!!' }, SOURCE, compiled.code)).toBeNull();
-	});
-});
 
 describe('types mapping (Volar token mappings)', () => {
 	const types = compileTypes(SOURCE, 'App.tsrx');
@@ -109,6 +43,15 @@ describe('types mapping (Volar token mappings)', () => {
 		const ranges = mapping!.toSource(offset);
 		expect(ranges).not.toBeNull();
 		expect(ranges!.some((range) => textAt(SOURCE, range) === 'useState')).toBe(true);
+	});
+
+	it('falls back to a containing expression between nested token mappings', () => {
+		// Volar maps the whole renderable expression as well as the string and
+		// identifier inside it. The operator is covered only by the outer range.
+		const offset = SOURCE.indexOf("'Count: ' + count") + "'Count: ' ".length;
+		const ranges = mapping!.toGenerated(offset);
+		expect(ranges).not.toBeNull();
+		expect(ranges!.some((range) => textAt(types.code, range) === "{'Count: ' + count}")).toBe(true);
 	});
 
 	it('clears on positions past the mapped token instead of reusing it', () => {

--- a/website/tests/playground-mapping.test.ts
+++ b/website/tests/playground-mapping.test.ts
@@ -146,6 +146,29 @@ describe('client output mapping (compiler source map)', () => {
 		});
 	});
 
+	it('uses explicit source-map endpoints for custom element tag names', () => {
+		const source = `export function App() @{
+	<my-el></my-el>
+}`;
+		const compiled = compileAst(source, 'App.tsrx', 'client-output');
+		if (!compiled.ok) throw new Error(compiled.error);
+		const customMapping = mappingFromSourceMap(compiled.map, source, compiled.code!);
+		const sourceTag = source.indexOf('<my-el>') + 1;
+		const generatedTag = compiled.code!.indexOf('<my-el>') + 1;
+
+		expect(customMapping?.pairFromSource(sourceTag)).toEqual({
+			source: [{ from: sourceTag, to: sourceTag + 'my-el'.length }],
+			output: [{ from: generatedTag, to: generatedTag + 'my-el'.length }],
+		});
+
+		const sourceClosingTag = source.indexOf('</my-el>') + 2;
+		const generatedClosingTag = compiled.code!.indexOf('</my-el>') + 2;
+		expect(customMapping?.pairFromGenerated(generatedClosingTag)).toEqual({
+			source: [{ from: sourceClosingTag, to: sourceClosingTag + 'my-el'.length }],
+			output: [{ from: generatedClosingTag, to: generatedClosingTag + 'my-el'.length }],
+		});
+	});
+
 	it('keeps nested and self-closing tags exact when attribute text looks like markup', () => {
 		const source = `export function App() @{
 	<div data-label="<span">

--- a/website/tests/playground-mapping.test.ts
+++ b/website/tests/playground-mapping.test.ts
@@ -122,6 +122,55 @@ describe('client output mapping (compiler source map)', () => {
 		expect(mapping?.toSourceRange(0, output.code.length)).not.toBeNull();
 	});
 
+	it('maps authored JSX tags to the tags baked into the client template', () => {
+		const sourceTag = SOURCE.indexOf('<div>') + 1;
+		const generatedTag = output.code.indexOf('<div>') + 1;
+		expect(mapping?.pairFromSource(sourceTag)).toEqual({
+			source: [{ from: sourceTag, to: sourceTag + 3 }],
+			output: [{ from: generatedTag, to: generatedTag + 3 }],
+		});
+		expect(mapping?.pairFromGenerated(generatedTag)).toEqual({
+			source: [{ from: sourceTag, to: sourceTag + 3 }],
+			output: [{ from: generatedTag, to: generatedTag + 3 }],
+		});
+
+		const sourceClosingTag = SOURCE.indexOf('</div>') + 2;
+		const generatedClosingTag = output.code.indexOf('</div>') + 2;
+		expect(mapping?.pairFromGenerated(generatedClosingTag)).toEqual({
+			source: [{ from: sourceClosingTag, to: sourceClosingTag + 3 }],
+			output: [{ from: generatedClosingTag, to: generatedClosingTag + 3 }],
+		});
+	});
+
+	it('keeps nested and self-closing tags exact when attribute text looks like markup', () => {
+		const source = `export function App() @{
+	<div data-label="<span">
+		<span><div /></span>
+	</div>
+}`;
+		const compiled = compilePlayground(source, 'App.tsrx');
+		if (!compiled.ok) throw new Error(compiled.error);
+		const nested = mappingFromSourceMap(compiled.map, source, compiled.code);
+		const fakeGeneratedTag = compiled.code.indexOf('<span') + 1;
+		const realGeneratedTag = compiled.code.indexOf('<span', fakeGeneratedTag) + 1;
+		const sourceTag = source.indexOf('<span', source.indexOf('<span') + 1) + 1;
+
+		expect(nested?.pairFromGenerated(fakeGeneratedTag)).toBeNull();
+		expect(nested?.pairFromGenerated(realGeneratedTag)?.source).toEqual([
+			{ from: sourceTag, to: sourceTag + 4 },
+		]);
+
+		const sourceSelfClosing = source.indexOf('<div />') + 1;
+		const generatedSelfClosing = compiled.code.indexOf('<div></div>');
+		expect(nested?.pairFromSource(sourceSelfClosing)).toEqual({
+			source: [{ from: sourceSelfClosing, to: sourceSelfClosing + 3 }],
+			output: [
+				{ from: generatedSelfClosing + 1, to: generatedSelfClosing + 4 },
+				{ from: generatedSelfClosing + 7, to: generatedSelfClosing + 10 },
+			],
+		});
+	});
+
 	it('does not interpolate across source text without an anchor', () => {
 		const blankLine = SOURCE.indexOf('\n\n\t<div>') + 1;
 		expect(mapping?.toGenerated(blankLine)).toBeNull();

--- a/website/tests/playground-mapping.test.ts
+++ b/website/tests/playground-mapping.test.ts
@@ -82,6 +82,26 @@ describe('types mapping (Volar token mappings)', () => {
 		expect(nested?.toSourceRange(8, 13)).toEqual([{ from: 5, to: 8 }]);
 	});
 
+	it('keeps both highlights on the same mapping at shared boundaries', () => {
+		const sharedOutputBoundary = mappingFromVolar([
+			{ sourceOffsets: [0], generatedOffsets: [10], lengths: [20] },
+			{ sourceOffsets: [5], generatedOffsets: [10], lengths: [3] },
+		]);
+		expect(sharedOutputBoundary?.pairFromSource(15)).toEqual({
+			source: [{ from: 0, to: 20 }],
+			output: [{ from: 10, to: 30 }],
+		});
+
+		const sharedSourceBoundary = mappingFromVolar([
+			{ sourceOffsets: [0], generatedOffsets: [10], lengths: [20] },
+			{ sourceOffsets: [0], generatedOffsets: [15], lengths: [3] },
+		]);
+		expect(sharedSourceBoundary?.pairFromGenerated(25)).toEqual({
+			source: [{ from: 0, to: 20 }],
+			output: [{ from: 10, to: 30 }],
+		});
+	});
+
 	it('returns null for empty or absent mappings instead of throwing', () => {
 		expect(mappingFromVolar([])).toBeNull();
 		expect(mappingFromVolar(null)).toBeNull();

--- a/website/tests/playground-mapping.test.ts
+++ b/website/tests/playground-mapping.test.ts
@@ -5,7 +5,7 @@
 // against real compiler artifacts; a focused nested-range fixture protects
 // Volar's shared generated-boundary behavior.
 import { describe, it, expect } from 'vitest';
-import { compilePlayground, compileTypes } from '../src/lib/playground.ts';
+import { compileAst, compilePlayground, compileTypes } from '../src/lib/playground.ts';
 import { mappingFromSourceMap, mappingFromVolar } from '../src/lib/playground-mapping.ts';
 
 const SOURCE = `import { useState } from 'octane';
@@ -113,6 +113,9 @@ describe('client output mapping (compiler source map)', () => {
 	const output = compilePlayground(SOURCE, 'App.tsrx');
 	if (!output.ok) throw new Error(output.error);
 	const mapping = mappingFromSourceMap(output.map, SOURCE, output.code);
+	const clientOutput = compileAst(SOURCE, 'App.tsrx', 'client-output');
+	if (!clientOutput.ok) throw new Error(clientOutput.error);
+	const clientMapping = mappingFromSourceMap(clientOutput.map, SOURCE, clientOutput.code!);
 
 	it('maps only tokens backed by compiler source-map anchors', () => {
 		const count = SOURCE.indexOf('count, setCount');
@@ -124,19 +127,20 @@ describe('client output mapping (compiler source map)', () => {
 
 	it('maps authored JSX tags to the tags baked into the client template', () => {
 		const sourceTag = SOURCE.indexOf('<div>') + 1;
-		const generatedTag = output.code.indexOf('<div>') + 1;
-		expect(mapping?.pairFromSource(sourceTag)).toEqual({
+		const generatedTag = clientOutput.code!.indexOf('<div>') + 1;
+		expect(mapping?.pairFromSource(sourceTag)).toBeNull();
+		expect(clientMapping?.pairFromSource(sourceTag)).toEqual({
 			source: [{ from: sourceTag, to: sourceTag + 3 }],
 			output: [{ from: generatedTag, to: generatedTag + 3 }],
 		});
-		expect(mapping?.pairFromGenerated(generatedTag)).toEqual({
+		expect(clientMapping?.pairFromGenerated(generatedTag)).toEqual({
 			source: [{ from: sourceTag, to: sourceTag + 3 }],
 			output: [{ from: generatedTag, to: generatedTag + 3 }],
 		});
 
 		const sourceClosingTag = SOURCE.indexOf('</div>') + 2;
-		const generatedClosingTag = output.code.indexOf('</div>') + 2;
-		expect(mapping?.pairFromGenerated(generatedClosingTag)).toEqual({
+		const generatedClosingTag = clientOutput.code!.indexOf('</div>') + 2;
+		expect(clientMapping?.pairFromGenerated(generatedClosingTag)).toEqual({
 			source: [{ from: sourceClosingTag, to: sourceClosingTag + 3 }],
 			output: [{ from: generatedClosingTag, to: generatedClosingTag + 3 }],
 		});
@@ -148,11 +152,11 @@ describe('client output mapping (compiler source map)', () => {
 		<span><div /></span>
 	</div>
 }`;
-		const compiled = compilePlayground(source, 'App.tsrx');
+		const compiled = compileAst(source, 'App.tsrx', 'client-output');
 		if (!compiled.ok) throw new Error(compiled.error);
-		const nested = mappingFromSourceMap(compiled.map, source, compiled.code);
-		const fakeGeneratedTag = compiled.code.indexOf('<span') + 1;
-		const realGeneratedTag = compiled.code.indexOf('<span', fakeGeneratedTag) + 1;
+		const nested = mappingFromSourceMap(compiled.map, source, compiled.code!);
+		const fakeGeneratedTag = compiled.code!.indexOf('<span') + 1;
+		const realGeneratedTag = compiled.code!.indexOf('<span', fakeGeneratedTag) + 1;
 		const sourceTag = source.indexOf('<span', source.indexOf('<span') + 1) + 1;
 
 		expect(nested?.pairFromGenerated(fakeGeneratedTag)).toBeNull();
@@ -161,7 +165,7 @@ describe('client output mapping (compiler source map)', () => {
 		]);
 
 		const sourceSelfClosing = source.indexOf('<div />') + 1;
-		const generatedSelfClosing = compiled.code.indexOf('<div></div>');
+		const generatedSelfClosing = compiled.code!.indexOf('<div></div>');
 		expect(nested?.pairFromSource(sourceSelfClosing)).toEqual({
 			source: [{ from: sourceSelfClosing, to: sourceSelfClosing + 3 }],
 			output: [

--- a/website/tests/playground-mapping.test.ts
+++ b/website/tests/playground-mapping.test.ts
@@ -2,7 +2,8 @@
 // contract behind the playground's click-to-navigate: an offset in the source
 // resolves to the range(s) in the compiled output that came from it, and an
 // offset in the output resolves back to its source range. It is exercised
-// against real Volar token mappings, not synthetic fixtures.
+// against real compiler artifacts; a focused nested-range fixture protects
+// Volar's shared generated-boundary behavior.
 import { describe, it, expect } from 'vitest';
 import { compilePlayground, compileTypes } from '../src/lib/playground.ts';
 import { mappingFromSourceMap, mappingFromVolar } from '../src/lib/playground-mapping.ts';
@@ -67,6 +68,18 @@ describe('types mapping (Volar token mappings)', () => {
 		const ranges = mapping!.toGenerated(offset);
 		expect(ranges).not.toBeNull();
 		expect(ranges!.some((range) => textAt(types.code, range) === 'setCount')).toBe(true);
+	});
+
+	it('maps a generated AST range to the narrowest token at a shared boundary', () => {
+		const nested = mappingFromVolar([
+			{ sourceOffsets: [0], generatedOffsets: [10], lengths: [20] },
+			{ sourceOffsets: [5], generatedOffsets: [10], lengths: [3] },
+		]);
+
+		expect(nested?.toSourceRange(10, 13)).toEqual([{ from: 5, to: 8 }]);
+		// The AST node may begin in unmapped generated plumbing. Its first
+		// mapped boundary must make the same narrow choice.
+		expect(nested?.toSourceRange(8, 13)).toEqual([{ from: 5, to: 8 }]);
 	});
 
 	it('returns null for empty or absent mappings instead of throwing', () => {

--- a/website/tests/playground-mapping.test.ts
+++ b/website/tests/playground-mapping.test.ts
@@ -4,8 +4,8 @@
 // offset in the output resolves back to its source range. It is exercised
 // against real Volar token mappings, not synthetic fixtures.
 import { describe, it, expect } from 'vitest';
-import { compileTypes } from '../src/lib/playground.ts';
-import { mappingFromVolar } from '../src/lib/playground-mapping.ts';
+import { compilePlayground, compileTypes } from '../src/lib/playground.ts';
+import { mappingFromSourceMap, mappingFromVolar } from '../src/lib/playground-mapping.ts';
 
 const SOURCE = `import { useState } from 'octane';
 
@@ -55,8 +55,8 @@ describe('types mapping (Volar token mappings)', () => {
 	});
 
 	it('clears on positions past the mapped token instead of reusing it', () => {
-		// Same contract as the prod pane: an offset beyond the anchored token's
-		// exact span (here the blank line before the JSX) is unmapped and must
+		// An offset beyond the anchored token's exact span (here the blank line
+		// before the JSX) is unmapped and must
 		// clear the highlight, not resolve to the preceding token's image.
 		const offset = SOURCE.indexOf('\n\n\t<div>') + 1;
 		expect(mapping!.toGenerated(offset)).toBeNull();
@@ -73,5 +73,51 @@ describe('types mapping (Volar token mappings)', () => {
 		expect(mappingFromVolar([])).toBeNull();
 		expect(mappingFromVolar(null)).toBeNull();
 		expect(mappingFromVolar(undefined)).toBeNull();
+	});
+});
+
+describe('client output mapping (compiler source map)', () => {
+	const output = compilePlayground(SOURCE, 'App.tsrx');
+	if (!output.ok) throw new Error(output.error);
+	const mapping = mappingFromSourceMap(output.map, SOURCE, output.code);
+
+	it('maps only tokens backed by compiler source-map anchors', () => {
+		const count = SOURCE.indexOf('count, setCount');
+		const generated = mapping?.toGenerated(count);
+		expect(generated).not.toBeNull();
+		expect(generated!.some((range) => textAt(output.code, range) === 'count')).toBe(true);
+		expect(mapping?.toSourceRange(0, output.code.length)).not.toBeNull();
+	});
+
+	it('does not interpolate across source text without an anchor', () => {
+		const blankLine = SOURCE.indexOf('\n\n\t<div>') + 1;
+		expect(mapping?.toGenerated(blankLine)).toBeNull();
+	});
+
+	it('returns null for the server-style empty map', () => {
+		expect(mappingFromSourceMap({ mappings: '' }, SOURCE, '')).toBeNull();
+	});
+});
+
+it('keeps type mappings after a scoped-style statement terminator', () => {
+	const source = `export function App() @{
+	<button>Styled</button>
+	<style>button { color: red; }</style>
+}
+export const afterStyle = 1;`;
+	const output = compileTypes(source, 'App.tsrx');
+	if (!output.ok) throw new Error(output.error);
+	const mapping = mappingFromVolar(output.mappings);
+	const sourceOffset = source.indexOf('afterStyle');
+	const generatedOffset = output.code.indexOf('afterStyle');
+
+	expect(output.code).toContain('<style></style>;');
+	expect(mapping?.toGenerated(sourceOffset)).toContainEqual({
+		from: generatedOffset,
+		to: generatedOffset + 'afterStyle'.length,
+	});
+	expect(mapping?.toSource(generatedOffset)).toContainEqual({
+		from: sourceOffset,
+		to: sourceOffset + 'afterStyle'.length,
 	});
 });

--- a/website/tests/playground.test.ts
+++ b/website/tests/playground.test.ts
@@ -13,6 +13,7 @@ import { getRouter } from '../src/router.ts';
 import {
 	compilePlayground,
 	compileTypes,
+	resolvePlaygroundError,
 	createPreview,
 	PREVIEW_READY_TIMEOUT_MS,
 	PREVIEW_RUN_TIMEOUT_MS,
@@ -41,6 +42,15 @@ async function renderRoute(url: string) {
 }
 
 describe('playground compile pipeline', () => {
+	it('keeps an AST inspection error when the runnable graph succeeds', () => {
+		expect(resolvePlaygroundError(null, 'AST generation failed: invalid output')).toBe(
+			'AST generation failed: invalid output',
+		);
+		expect(resolvePlaygroundError('Module graph failed', 'AST generation failed')).toBe(
+			'Module graph failed',
+		);
+	});
+
 	it('compiles the default TSRX workspace to client runtime code', () => {
 		const result = compilePlayground(DEFAULT_WORKSPACES.tsrx.files[0].source, 'App.tsrx');
 		expect(result.ok).toBe(true);

--- a/website/tests/ssr-hydration.e2e.test.ts
+++ b/website/tests/ssr-hydration.e2e.test.ts
@@ -1041,7 +1041,7 @@ describe.sequential('website production build → hydration (Nitro Vercel previe
 		}
 	}, 30_000);
 
-	it('playground compiled pane offers Svelte-style AST and types mapping', async () => {
+	it('playground compiled pane offers AST and types mapping', async () => {
 		const { page, errors } = await loadRoute(`http://localhost:${PREVIEW_PORT}`, '/playground');
 		try {
 			await page.waitForSelector('.pg-grid.ready', { timeout: 20_000 });
@@ -1119,8 +1119,8 @@ describe.sequential('website production build → hydration (Nitro Vercel previe
 					[paneIndex, token] as const,
 					{ timeout: 10_000 },
 				);
-			// AST is the default compiler artifact. Like Svelte's playground it
-			// shows one source AST and reveals the deepest containing node.
+			// AST is the default compiler artifact. It shows one source AST and
+			// reveals the deepest containing node.
 			await page.locator('[aria-label="Result view"] button', { hasText: 'Compiled' }).click();
 			await page.locator('.pg-ast-tree').waitFor();
 			expect(

--- a/website/tests/ssr-hydration.e2e.test.ts
+++ b/website/tests/ssr-hydration.e2e.test.ts
@@ -1158,6 +1158,21 @@ describe.sequential('website production build → hydration (Nitro Vercel previe
 			// Clicking keeps that bidirectional mapping and scrolls it into view.
 			await clickToken(1, 'setCount', 1);
 			await mappedIn(0, 'setCount');
+			// A cached Types document must not retain the source highlight from
+			// AST when the user switches back to it.
+			await page.locator('[aria-label="Compiled output mode"] button', { hasText: 'AST' }).click();
+			await clickToken(0, 'useState', 2);
+			await page.waitForFunction(
+				() => !!document.querySelector('.pg-ast-node[data-ast-leaf="true"]'),
+				null,
+				{ timeout: 10_000 },
+			);
+			await page
+				.locator('[aria-label="Compiled output mode"] button', { hasText: 'Types' })
+				.click();
+			await page.waitForFunction(() => !document.querySelector('.pg-editor .cm-mapped'), null, {
+				timeout: 5_000,
+			});
 			// Switching to Preview clears every mark; Compiled returns clean.
 			await page.locator('[aria-label="Result view"] button', { hasText: 'Preview' }).click();
 			await page.waitForFunction(() => !document.querySelector('.pg-editor .cm-mapped'), null, {
@@ -1186,6 +1201,17 @@ describe.sequential('website production build → hydration (Nitro Vercel previe
 				null,
 				{ timeout: 10_000 },
 			);
+			// A failed AST generation replaces the prior tree and cannot map
+			// source hover through its stale ranges.
+			await page.locator('[aria-label="Compiled output mode"] button', { hasText: 'AST' }).click();
+			await page
+				.getByText('AST generation failed. Fix the source to generate a new tree.')
+				.waitFor();
+			expect(await page.locator('.pg-ast-tree').count()).toBe(0);
+			await hoverToken(0, 'import', 1);
+			await page.waitForFunction(() => !document.querySelector('.pg-editor .cm-mapped'), null, {
+				timeout: 5_000,
+			});
 			expect(errors).toEqual([]);
 		} finally {
 			await page.close();

--- a/website/tests/ssr-hydration.e2e.test.ts
+++ b/website/tests/ssr-hydration.e2e.test.ts
@@ -1218,6 +1218,54 @@ describe.sequential('website production build → hydration (Nitro Vercel previe
 		}
 	}, 45_000);
 
+	it('playground refreshes the active AST when another workspace file fails', async () => {
+		const appSource =
+			"import { value } from './Value';\nexport default function App() @{ <p>{'Value: ' + value}</p> }";
+		const selectAll = process.platform === 'darwin' ? 'Meta+A' : 'Control+A';
+		const hash = encodePlaygroundHash({
+			lang: 'tsrx',
+			entry: 'App.tsrx',
+			files: [
+				{
+					name: 'App.tsrx',
+					source: appSource,
+				},
+				{ name: 'Value.tsrx', source: 'export const value = 1;' },
+			],
+		});
+		const { page, errors } = await loadRoute(
+			`http://localhost:${PREVIEW_PORT}`,
+			`/playground#${hash}`,
+		);
+		try {
+			await page.waitForSelector('.pg-grid.ready', { timeout: 20_000 });
+			await page.locator('[aria-label="Result view"] button', { hasText: 'Compiled' }).click();
+			await page.locator('.pg-ast-tree').waitFor();
+
+			// Break an inactive dependency so the runnable module graph fails.
+			await page.locator('.pg-tab', { hasText: 'Value.tsrx' }).click();
+			await page.locator('.pg-editor .cm-content').first().click();
+			await page.keyboard.press(selectAll);
+			await page.keyboard.type('export const value = ;');
+			await page.locator('.pg-error').waitFor({ timeout: 10_000 });
+
+			// The active App source still has a valid compiler AST. Editing it
+			// briefly invalidates the tree, then must restore it even though the
+			// dependency keeps the module graph in its failed state.
+			await page.locator('.pg-tab', { hasText: 'App.tsrx' }).click();
+			await page.locator('.pg-ast-tree').waitFor();
+			await page.locator('.pg-editor .cm-content').first().click();
+			await page.keyboard.press(selectAll);
+			await page.keyboard.type(appSource + '\n');
+			await page.getByText('Waiting for the next successful compile…').waitFor({ timeout: 5_000 });
+			await page.locator('.pg-ast-tree').waitFor({ timeout: 10_000 });
+			expect(await page.locator('.pg-error').count()).toBe(1);
+			expect(errors).toEqual([]);
+		} finally {
+			await page.close();
+		}
+	}, 30_000);
+
 	it('playground shows compiler warnings without treating runnable code as an error', async () => {
 		const source = `export function App() @{ <input onChange={() => {}} /> }`;
 		const hash = encodePlaygroundHash({

--- a/website/tests/ssr-hydration.e2e.test.ts
+++ b/website/tests/ssr-hydration.e2e.test.ts
@@ -1041,7 +1041,7 @@ describe.sequential('website production build → hydration (Nitro Vercel previe
 		}
 	}, 30_000);
 
-	it('playground compiled pane offers prod and types output with click-through position mapping', async () => {
+	it('playground compiled pane offers Svelte-style AST and types mapping', async () => {
 		const { page, errors } = await loadRoute(`http://localhost:${PREVIEW_PORT}`, '/playground');
 		try {
 			await page.waitForSelector('.pg-grid.ready', { timeout: 20_000 });
@@ -1061,7 +1061,7 @@ describe.sequential('website production build → hydration (Nitro Vercel previe
 			// captured before that flush lands on whatever scrolled into the
 			// stale coordinates (a CI-speed flake). A token outside the
 			// scroller's visible box resolves null instead of clicking through.
-			const clickToken = async (paneIndex: number, token: string, occurrence: number) => {
+			const tokenPoint = async (paneIndex: number, token: string, occurrence: number) => {
 				const point = await page.evaluate(
 					([index, needle, wanted]) =>
 						new Promise<{ x: number; y: number } | null>((resolve) =>
@@ -1100,7 +1100,15 @@ describe.sequential('website production build → hydration (Nitro Vercel previe
 					point,
 					`${token} (occurrence ${occurrence}) not visible in pane ${paneIndex}`,
 				).not.toBeNull();
-				await page.mouse.click(point!.x, point!.y);
+				return point!;
+			};
+			const clickToken = async (paneIndex: number, token: string, occurrence: number) => {
+				const point = await tokenPoint(paneIndex, token, occurrence);
+				await page.mouse.click(point.x, point.y);
+			};
+			const hoverToken = async (paneIndex: number, token: string, occurrence: number) => {
+				const point = await tokenPoint(paneIndex, token, occurrence);
+				await page.mouse.move(point.x, point.y);
 			};
 			const mappedIn = (paneIndex: number, token: string) =>
 				page.waitForFunction(
@@ -1111,20 +1119,29 @@ describe.sequential('website production build → hydration (Nitro Vercel previe
 					[paneIndex, token] as const,
 					{ timeout: 10_000 },
 				);
-			// Prod is the default compiled mode: the real client-runtime emit.
+			// AST is the default compiler artifact. Like Svelte's playground it
+			// shows one source AST and reveals the deepest containing node.
 			await page.locator('[aria-label="Result view"] button', { hasText: 'Compiled' }).click();
-			await outputIncludes("from 'octane'");
-			// Prod navigation places marks; a cursor move to an unmapped position
-			// (the import line sits before the prod map's first anchor) clears
-			// them — marks must always reflect the current selection.
+			await page.locator('.pg-ast-tree').waitFor();
+			expect(
+				await page
+					.locator('[aria-label="Compiled output mode"] button', { hasText: 'Prod' })
+					.count(),
+			).toBe(0);
 			await clickToken(0, 'useState', 2);
-			await mappedIn(1, 'useState');
-			await clickToken(0, 'import', 1);
 			await page.waitForFunction(
-				() => !document.querySelectorAll('.pg-editor .cm-content')[1]?.querySelector('.cm-mapped'),
+				() => !!document.querySelector('.pg-ast-node[data-ast-leaf="true"]'),
 				null,
 				{ timeout: 10_000 },
 			);
+			expect(await page.locator('.pg-ast-status').textContent()).toMatch(/\[(\d+), (\d+)\)/);
+			expect(await page.locator('.cm-mapped').count()).toBe(1);
+			expect(
+				await page
+					.locator('.pg-editor .cm-mapped')
+					.first()
+					.evaluate((element) => getComputedStyle(element).backgroundColor),
+			).toBe('rgba(255, 234, 0, 0.42)');
 			// Types swaps the pane to the typed virtual TSX (the language-service
 			// view), without recompiling the preview.
 			await page
@@ -1134,7 +1151,11 @@ describe.sequential('website production build → hydration (Nitro Vercel previe
 			// Clicking a source token reveals the mapped token in the output…
 			await clickToken(0, 'useState', 2); // the useState(0) call, not the import
 			await mappedIn(1, 'useState');
-			// …and clicking the output maps back into the source.
+			// …and hovering the output maps back into the source too.
+			await hoverToken(1, 'setCount', 1);
+			await mappedIn(0, 'setCount');
+			await mappedIn(1, 'setCount');
+			// Clicking keeps that bidirectional mapping and scrolls it into view.
 			await clickToken(1, 'setCount', 1);
 			await mappedIn(0, 'setCount');
 			// Switching to Preview clears every mark; Compiled returns clean.

--- a/website/tests/ssr-hydration.e2e.test.ts
+++ b/website/tests/ssr-hydration.e2e.test.ts
@@ -1128,6 +1128,11 @@ describe.sequential('website production build → hydration (Nitro Vercel previe
 					.locator('[aria-label="Compiled output mode"] button', { hasText: 'Prod' })
 					.count(),
 			).toBe(0);
+			expect(
+				await page
+					.locator('[aria-label="AST compiler stage"] option', { hasText: 'Server output' })
+					.count(),
+			).toBe(0);
 			await clickToken(0, 'useState', 2);
 			await page.waitForFunction(
 				() => !!document.querySelector('.pg-ast-node[data-ast-leaf="true"]'),

--- a/website/tests/ssr-hydration.e2e.test.ts
+++ b/website/tests/ssr-hydration.e2e.test.ts
@@ -1142,6 +1142,14 @@ describe.sequential('website production build → hydration (Nitro Vercel previe
 					.first()
 					.evaluate((element) => getComputedStyle(element).backgroundColor),
 			).toBe('rgba(255, 234, 0, 0.42)');
+			// Client output bakes static JSX into one template Literal. Its AST
+			// reveal must preserve the exact tag that initiated navigation instead
+			// of falling back to the template's first source-map anchor.
+			await page.locator('[aria-label="AST compiler stage"]').selectOption('client-output');
+			await hoverToken(0, 'button', 2);
+			await mappedIn(0, 'button');
+			expect(await page.locator('.pg-ast-status').textContent()).toContain('Literal');
+			await page.locator('[aria-label="AST compiler stage"]').selectOption('source');
 			// Types swaps the pane to the typed virtual TSX (the language-service
 			// view), without recompiling the preview.
 			await page


### PR DESCRIPTION
## What changed

- Replaced the playground's Production output with a source AST preview.
- Kept the Types view backed by the compiler's Volar mappings.
- Added bidirectional source-to-AST and source-to-types highlighting.
- Added a compact, lazy-rendered, cycle-safe AST tree.
- Invalidated stale AST trees and highlights when parsing becomes unavailable.
- Cleared AST highlights when returning to a cached Types document.
- Added unit and browser-level regression coverage.

## Why

The previous Production view exposed generated code without making the compiler transformation easy to inspect. The AST preview now shows the parser tree used by Octane and lets users trace nodes back to exact source ranges.

## User impact

Playground users can inspect how TSRX and TSX source is parsed, follow nested AST nodes, and compare source ranges with the typed virtual TSX output. Failed parsing no longer leaves a stale tree or stale source highlight visible. The live preview behavior is unchanged.

## Validation

- `pnpm exec vitest run website/tests/playground-ast.test.ts website/tests/playground-mapping.test.ts --reporter=dot`
- `pnpm --filter website typecheck`
- `pnpm --filter website build`
- `pnpm format:check`
- Manual playground verification for AST/Types cache transitions and failed AST generation

The standalone hydration E2E suite could not launch its bundled Chromium in this environment; the affected flow was verified against the running website in the available browser.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Volar mapping output (scoped styles) and large playground/compiler surface area, but runtime client emit and default source maps stay unchanged unless opt-in flags are set.
> 
> **Overview**
> Replaces the playground **Production** compiled pane with an **AST** inspector (parsed source, type transform, types output, and client output stages) plus bidirectional hover/selection linking to source. **Types** still shows virtual TSX with improved Volar mapping (narrowest containing range, nested-expression fallback).
> 
> **Compiler:** `compileToVolarMappings` gains opt-in `astTrace` and fixes scoped-`<style>` virtual TSX via statement terminators with shifted mappings; `__parseGeneratedModuleAst` parses final emit for tooling. Client compile adds opt-in `sourceMapHostTags` so inspection can anchor host JSX tag names inside hoisted template strings without changing default emit or maps.
> 
> Playground clears stale AST/highlight state on failed parses and mode switches; module-graph failures no longer block refreshing AST for the active file when inspection still succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f80670b03f7efb29e4f5c99952d3d97b056ddf23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->