### PR TITLE
feat(compiler): expose granular client AST inspection

### DIFF
--- a/.changeset/client-template-tag-maps.md
+++ b/.changeset/client-template-tag-maps.md
@@ -2,6 +2,8 @@
 'octane': patch
 ---
 
-Allow inspection tooling to opt into exact source-map anchors for host JSX tag
-names baked into client template strings. Normal compiles keep the existing
-path without tag-location allocations or scans.
+Expose an inspection-only client output AST that expands hoisted template
+literals into exact element, attribute, text, comment, and marker nodes. The
+same linear scan supplies source-map anchors for authored host tags and static
+attributes; normal compiles keep the existing path without cloning, collection,
+template scans, or an output parse.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -17378,15 +17378,21 @@ function walkExprH(rootVar, path) {
 	return expr;
 }
 
-// Octane template nodes are inspection metadata, not executable ESTree. Keep
-// their construction behind one local builder; standard generated-JS nodes
-// below use @tsrx/core builders and setLocation instead.
-function inspectionNode(type, fields = null) {
-	return fields === null ? { type } : { type, ...fields };
+// Octane template nodes are compiler-owned inspection metadata, not executable
+// ESTree. Their initial ranges are relative to the decoded template and are
+// relocated in place after output parsing; standard generated-JS nodes below
+// still use @tsrx/core builders and never mutate the parsed output tree.
+function inspectionNode(type, fields = null, start = null, end = null) {
+	const node = fields === null ? { type } : { type, ...fields };
+	if (start !== null) {
+		node.start = start;
+		node.end = end;
+	}
+	return node;
 }
 
-function inspectionName(type, name) {
-	return inspectionNode(type, { name });
+function inspectionName(type, name, start, end) {
+	return inspectionNode(type, { name }, start, end);
 }
 
 function rawTextClosingTag(html, from, tag) {
@@ -17407,16 +17413,17 @@ function rawTextClosingTag(html, from, tag) {
 }
 
 function inspectTemplateHtml(html, sources) {
-	const root = inspectionNode('OctaneTemplate', { children: [] });
-	const ranges = [{ node: root, start: 0, end: html.length }];
-	const stack = [{ tag: null, node: root, range: ranges[0] }];
+	const offsets = [0, html.length];
+	const root = inspectionNode('OctaneTemplate', { children: [] }, 0, html.length);
+	const stack = [{ tag: null, node: root }];
 	let sourceIndex = 0;
 	let index = 0;
 	const append = (node, start, end) => {
+		node.start = start;
+		node.end = end;
+		offsets.push(start, end);
 		stack[stack.length - 1].node.children.push(node);
-		const range = { node, start, end };
-		ranges.push(range);
-		return range;
+		return node;
 	};
 	const match = (kind, from, to) => {
 		const source = sources[sourceIndex];
@@ -17489,12 +17496,14 @@ function inspectTemplateHtml(html, sources) {
 			const close = html.indexOf('>', nameEnd);
 			const end = close === -1 ? html.length : close + 1;
 			match('close', nameStart, nameEnd);
-			const name = inspectionName('OctaneTemplateIdentifier', html.slice(nameStart, nameEnd));
-			const closingElement = inspectionNode('OctaneTemplateClosingElement', { name });
-			ranges.push(
-				{ node: closingElement, start: index, end },
-				{ node: name, start: nameStart, end: nameEnd },
+			const name = inspectionName(
+				'OctaneTemplateIdentifier',
+				html.slice(nameStart, nameEnd),
+				nameStart,
+				nameEnd,
 			);
+			const closingElement = inspectionNode('OctaneTemplateClosingElement', { name }, index, end);
+			offsets.push(nameStart, nameEnd, index, end);
 			let matchIndex = stack.length - 1;
 			while (matchIndex > 0 && stack[matchIndex].tag.toLowerCase() !== name.name.toLowerCase()) {
 				matchIndex--;
@@ -17502,7 +17511,8 @@ function inspectTemplateHtml(html, sources) {
 			if (matchIndex > 0) {
 				const entry = stack[matchIndex];
 				entry.node.closingElement = closingElement;
-				entry.range.end = end;
+				entry.node.end = end;
+				offsets.push(end);
 				stack.length = matchIndex;
 			} else {
 				append(closingElement, index, end);
@@ -17528,7 +17538,8 @@ function inspectTemplateHtml(html, sources) {
 		}
 		match('open', nameStart, nameEnd);
 		const tag = html.slice(nameStart, nameEnd);
-		const name = inspectionName('OctaneTemplateIdentifier', tag);
+		const name = inspectionName('OctaneTemplateIdentifier', tag, nameStart, nameEnd);
+		offsets.push(nameStart, nameEnd);
 		const attributes = [];
 		let cursor = nameEnd;
 		let selfClosing = false;
@@ -17559,7 +17570,10 @@ function inspectTemplateHtml(html, sources) {
 			const attrName = inspectionName(
 				'OctaneTemplateAttributeName',
 				html.slice(attrNameStart, attrNameEnd),
+				attrNameStart,
+				attrNameEnd,
 			);
+			offsets.push(attrNameStart, attrNameEnd);
 			let value = null;
 			while (cursor < html.length && html.charCodeAt(cursor) <= 32) cursor++;
 			if (html.charCodeAt(cursor) === 61) {
@@ -17571,11 +17585,16 @@ function inspectTemplateHtml(html, sources) {
 					while (cursor < html.length && html.charCodeAt(cursor) !== quote) cursor++;
 					const valueEnd = cursor;
 					match('attr-value', valueStart, valueEnd);
-					value = inspectionNode('OctaneTemplateAttributeValue', {
-						value: html.slice(valueStart, valueEnd),
-						raw: html.slice(valueStart - 1, cursor < html.length ? cursor + 1 : cursor),
-					});
-					ranges.push({ node: value, start: valueStart, end: valueEnd });
+					value = inspectionNode(
+						'OctaneTemplateAttributeValue',
+						{
+							value: html.slice(valueStart, valueEnd),
+							raw: html.slice(valueStart - 1, cursor < html.length ? cursor + 1 : cursor),
+						},
+						valueStart,
+						valueEnd,
+					);
+					offsets.push(valueStart, valueEnd);
 					if (cursor < html.length) cursor++;
 				} else {
 					const valueStart = cursor;
@@ -17585,43 +17604,52 @@ function inspectTemplateHtml(html, sources) {
 						cursor++;
 					}
 					match('attr-value', valueStart, cursor);
-					value = inspectionNode('OctaneTemplateAttributeValue', {
-						value: html.slice(valueStart, cursor),
-						raw: html.slice(valueStart, cursor),
-					});
-					ranges.push({ node: value, start: valueStart, end: cursor });
+					value = inspectionNode(
+						'OctaneTemplateAttributeValue',
+						{
+							value: html.slice(valueStart, cursor),
+							raw: html.slice(valueStart, cursor),
+						},
+						valueStart,
+						cursor,
+					);
+					offsets.push(valueStart, cursor);
 				}
 			}
-			const attribute = inspectionNode('OctaneTemplateAttribute', { name: attrName, value });
-			attributes.push(attribute);
-			ranges.push(
-				{ node: attribute, start: attrStart, end: cursor },
-				{ node: attrName, start: attrNameStart, end: attrNameEnd },
+			const attribute = inspectionNode(
+				'OctaneTemplateAttribute',
+				{ name: attrName, value },
+				attrStart,
+				cursor,
 			);
+			offsets.push(attrStart, cursor);
+			attributes.push(attribute);
 		}
-		const openingElement = inspectionNode('OctaneTemplateOpeningElement', {
-			name,
-			attributes,
-			selfClosing,
-		});
+		const openingElement = inspectionNode(
+			'OctaneTemplateOpeningElement',
+			{
+				name,
+				attributes,
+				selfClosing,
+			},
+			index,
+			cursor,
+		);
+		offsets.push(index, cursor);
 		const element = inspectionNode('OctaneTemplateElement', {
 			openingElement,
 			closingElement: null,
 			children: [],
 		});
-		const elementRange = append(element, index, cursor);
-		ranges.push(
-			{ node: openingElement, start: index, end: cursor },
-			{ node: name, start: nameStart, end: nameEnd },
-		);
+		append(element, index, cursor);
 		if (!selfClosing && !VOID_ELEMENTS.has(tag.toLowerCase())) {
-			stack.push({ tag, node: element, range: elementRange });
+			stack.push({ tag, node: element });
 		}
 		index = cursor;
 	}
 
 	sources.length = sourceIndex;
-	return { mappings: sources, ast: root, ranges };
+	return { mappings: sources, ast: root, offsets };
 }
 
 function allocTemplate(ctx, html, ns = 0, frag = 0, tagSources = null) {
@@ -17632,7 +17660,7 @@ function allocTemplate(ctx, html, ns = 0, frag = 0, tagSources = null) {
 		const inspection = inspectTemplateHtml(html, tagSources);
 		template.tagMappings = inspection.mappings;
 		template.inspectionAst = inspection.ast;
-		template.inspectionRanges = inspection.ranges;
+		template.inspectionOffsets = inspection.offsets;
 	}
 	ctx.hoistedTemplates.push(template);
 	return name;
@@ -17653,9 +17681,7 @@ function parseGeneratedOutputAst(code) {
 	});
 }
 
-function encodedTemplateBoundaries(raw, ranges) {
-	const boundaries = [];
-	for (const range of ranges) boundaries.push(range.start, range.end);
+function encodedTemplateBoundaries(raw, boundaries) {
 	boundaries.sort((a, b) => a - b);
 	const offsets = new Map();
 	let htmlOffset = 0;
@@ -17702,24 +17728,23 @@ function generatedLocation(lineStarts, offset) {
 }
 
 function materializeTemplateAst(template, literal, lineStarts) {
-	const rangeByNode = new Map();
-	for (const range of template.inspectionRanges) rangeByNode.set(range.node, range);
-	const offsets = encodedTemplateBoundaries(literal.raw, template.inspectionRanges);
+	const offsets = encodedTemplateBoundaries(literal.raw, template.inspectionOffsets);
 	const visit = (value) => {
-		if (Array.isArray(value)) return value.map(visit);
-		if (!value || typeof value !== 'object') return value;
-		const node = inspectionNode(value.type);
-		for (const key of Object.keys(value)) {
-			if (key !== 'type') node[key] = visit(value[key]);
+		if (Array.isArray(value)) {
+			for (const child of value) visit(child);
+			return value;
 		}
-		const range = rangeByNode.get(value);
-		if (range) {
-			const relativeStart = offsets.get(range.start);
-			const relativeEnd = offsets.get(range.end);
-			const start = literal.start + relativeStart;
-			const end = literal.start + relativeEnd;
+		if (!value || typeof value !== 'object') return value;
+		const relativeStart = value.start;
+		const relativeEnd = value.end;
+		for (const key of Object.keys(value)) {
+			if (key !== 'start' && key !== 'end' && key !== 'loc') visit(value[key]);
+		}
+		if (Number.isInteger(relativeStart)) {
+			const start = literal.start + offsets.get(relativeStart);
+			const end = literal.start + offsets.get(relativeEnd);
 			return setLocation(
-				node,
+				value,
 				{
 					start,
 					end,
@@ -17731,7 +17756,7 @@ function materializeTemplateAst(template, literal, lineStarts) {
 				true,
 			);
 		}
-		return node;
+		return value;
 	};
 	return visit(template.inspectionAst);
 }

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -35,7 +35,12 @@ import {
 	renderStylesheets,
 	annotateWithHash,
 	createStyleClassMapFromStylesheet,
+	builders as b,
+	clone_ast_node as cloneAstNode,
+	acorn,
+	setLocation,
 	strongHash,
+	tsPlugin,
 } from '@tsrx/core';
 import { print as esrapPrint } from 'esrap';
 import esrapTsx from 'esrap/languages/tsx';
@@ -3674,6 +3679,103 @@ function closingTagSourceLoc(ctx, node, tag) {
 	return { line: lineIndex + 1, column: nameOffset - starts[lineIndex] };
 }
 
+function staticAttributeOrigin(ctx, attr) {
+	const origins = ctx.hostTagMap?.attributeOrigins;
+	if (!origins) return null;
+	if (origins.has(attr)) return origins.get(attr);
+	const nameLoc = attr.name?.loc?.start;
+	if (!nameLoc) {
+		origins.set(attr, null);
+		return null;
+	}
+	const origin = { nameLoc, valueLoc: null, valueToken: null };
+	const valueNode =
+		attr.value?.type === 'JSXExpressionContainer' ? attr.value.expression : attr.value;
+	const valueLoc = valueNode?.loc?.start;
+	const starts = ctx.hostTagMap.lineStarts;
+	if (valueLoc && starts) {
+		const sourceOffset = starts[valueLoc.line - 1] + valueLoc.column;
+		const quote = ctx.mapSource.charCodeAt(sourceOffset);
+		if (quote === 34 || quote === 39) {
+			const sourceEnd = Number.isInteger(valueNode.end) ? valueNode.end : sourceOffset;
+			const sourceLiteral = ctx.mapSource.slice(
+				sourceOffset + 1,
+				Math.max(sourceOffset + 1, sourceEnd - 1),
+			);
+			// JS- or HTML-escaped literals need a character-level source-to-HTML table.
+			// Keep them unmapped rather than attaching an approximate span.
+			const escapedLiteral = escapeAttr(sourceLiteral);
+			if (sourceLiteral && !sourceLiteral.includes('\\') && escapedLiteral === sourceLiteral) {
+				origin.valueLoc = { line: valueLoc.line, column: (valueLoc.column | 0) + 1 };
+				origin.valueToken = sourceLiteral;
+			}
+		}
+	}
+	origins.set(attr, origin);
+	return origin;
+}
+
+function captureStaticAttributeOrigins(ctx, root) {
+	if (!ctx.hostTagMap?.attributeOrigins) return;
+	const seen = new WeakSet();
+	const visit = (node) => {
+		if (!node || typeof node !== 'object' || seen.has(node)) return;
+		seen.add(node);
+		if (
+			(node.type === 'FunctionDeclaration' ||
+				node.type === 'FunctionExpression' ||
+				node.type === 'ArrowFunctionExpression') &&
+			node.metadata?.tsrx_dynamic_wrapper !== true
+		)
+			return;
+		for (const attr of node.openingElement?.attributes || []) staticAttributeOrigin(ctx, attr);
+		for (const key of Object.keys(node)) {
+			if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata' || key === 'css')
+				continue;
+			const value = node[key];
+			if (Array.isArray(value)) {
+				for (const child of value) visit(child);
+			} else {
+				visit(value);
+			}
+		}
+	};
+	visit(root);
+}
+
+function recordStaticAttributeSource(ctx, attr, emitted) {
+	const sources = ctx.hostTagMap?.current;
+	const origin = staticAttributeOrigin(ctx, attr);
+	if (!sources || !origin || !emitted) return;
+
+	let nameStart = 0;
+	while (nameStart < emitted.length && emitted.charCodeAt(nameStart) <= 32) nameStart++;
+	let nameEnd = nameStart;
+	while (nameEnd < emitted.length) {
+		const character = emitted.charCodeAt(nameEnd);
+		if (character <= 32 || character === 61 || character === 47 || character === 62) break;
+		nameEnd++;
+	}
+	if (nameEnd === nameStart) return;
+	sources.push({
+		kind: 'attr-name',
+		tag: emitted.slice(nameStart, nameEnd),
+		srcLine0: origin.nameLoc.line - 1,
+		srcCol0: origin.nameLoc.column | 0,
+	});
+
+	if (!origin.valueLoc || !origin.valueToken) return;
+	const emittedValueStart = emitted.indexOf('=', nameEnd);
+	if (emittedValueStart === -1) return;
+	if (emitted.indexOf(origin.valueToken, emittedValueStart + 1) === -1) return;
+	sources.push({
+		kind: 'attr-value',
+		tag: origin.valueToken,
+		srcLine0: origin.valueLoc.line - 1,
+		srcCol0: origin.valueLoc.column,
+	});
+}
+
 /**
  * Build a v3 source map from a flat list of mapping segments. The segments come
  * from esrap itself — we print each user statement/expression via esrap with
@@ -3682,8 +3784,8 @@ function closingTagSourceLoc(ctx, node, tag) {
  * coordinates. Generated runtime plumbing (mount/update DOM ops) is left
  * unmapped — never mapped to a wrong position. Opt-in inspection compiles also
  * record exact authored and generated positions for baked client template tag
- * names. `sourcesContent` is inlined so the original `.tsrx` is visible in
- * devtools.
+ * names and static attributes. `sourcesContent` is inlined so the original
+ * `.tsrx` is visible in devtools.
  *
  * @param {string} source original .tsrx text
  * @param {string} sourceName basename used as the map's single source entry
@@ -4208,7 +4310,7 @@ function instrumentProfileComponents(ast, ctx) {
  * Compile a .tsrx source string into JS targeting `octane`.
  * @param {string} source
  * @param {string} filename
- * @param {{ hmr?: boolean | 'vite' | 'webpack', mode?: 'client' | 'server', dev?: boolean, profile?: boolean, profileFilename?: string, autoMemo?: boolean, inlineHookMemo?: boolean, sourceMapHostTags?: boolean, renderer?: { id: string, module: string, target: 'dom' | 'universal', server?: string }, rendererBoundaries?: Readonly<Record<string, Readonly<Record<string, { ownerRenderer: string, childRenderer: string, prop: string, server?: string }>>>>, rendererRegistry?: Readonly<Record<string, { module: string, target: 'dom' | 'universal', server?: string }>>, clientOnlyImports?: readonly unknown[], __hydratePrepared?: boolean, __hydrateBoundaryModule?: boolean, __nativeChangeDiagnostics?: readonly unknown[], __nativeChangeAnalysis?: { diagnostics: readonly unknown[], classifications: Map<number, string> } }} [options] —
+ * @param {{ hmr?: boolean | 'vite' | 'webpack', mode?: 'client' | 'server', dev?: boolean, profile?: boolean, profileFilename?: string, autoMemo?: boolean, inlineHookMemo?: boolean, astTrace?: boolean, renderer?: { id: string, module: string, target: 'dom' | 'universal', server?: string }, rendererBoundaries?: Readonly<Record<string, Readonly<Record<string, { ownerRenderer: string, childRenderer: string, prop: string, server?: string }>>>>, rendererRegistry?: Readonly<Record<string, { module: string, target: 'dom' | 'universal', server?: string }>>, clientOnlyImports?: readonly unknown[], __hydratePrepared?: boolean, __hydrateBoundaryModule?: boolean, __nativeChangeDiagnostics?: readonly unknown[], __nativeChangeAnalysis?: { diagnostics: readonly unknown[], classifications: Map<number, string> } }} [options] —
  *   `dev: true` emits client hydration source-location metadata (per-component
  *   `__s.locs`/`__s.locFile`) and, in server mode, source-located native-element
  *   scopes for invalid HTML nesting diagnostics. Both are strictly gated so
@@ -4223,13 +4325,14 @@ function instrumentProfileComponents(ast, ctx) {
  *   template-clone DOM runtime; `'server'` emits HTML-string SSR output (static
  *   chunks interleaved with `ssr*` helpers) carrying the hydration markers the
  *   client `hydrateRoot` adopts.
- *   `sourceMapHostTags: true` adds exact source-map anchors for host tag
- *   names baked into client template strings. It is opt-in for inspection
- *   tooling; normal compiles skip all tag-location collection and scanning.
+ *   `astTrace: true` returns an immutable AST parsed from the exact client
+ *   artifact and enriches template literals with granular element, attribute,
+ *   text, and marker nodes. It also adds their exact source-map anchors. Normal
+ *   compiles skip the clone, collection, template scan, and output parse.
  *   `rendererBoundaries` and `rendererRegistry` are the normalized static
  *   boundary table and renderer registry. Pass them together when a client
  *   module may contain an explicitly renderer-owned component prop.
- * @returns {{ code: string, map: any, diagnostics: readonly unknown[] }}
+ * @returns {{ code: string, map: any, diagnostics: readonly unknown[], astTrace?: { generatedAst: unknown } }}
  */
 // --- Authored scoped-style hashes across source rewrites -------------------
 //
@@ -4355,6 +4458,7 @@ function compileAuthored(source, filename, options, bundlerMetadata) {
 
 function compileInternal(source, filename, options, analyzedAst, mode, bundlerMetadata) {
 	const authoredSource = source;
+	const astTraceRequested = mode === 'client' && options?.astTrace === true;
 	const universalRuntime = normalizeUniversalRuntime(options?.universalRuntime);
 	if (!options?.__rendererBoundariesLowered) {
 		assertUniversalRuntimeTarget(universalRuntime, mode, options?.renderer);
@@ -4589,10 +4693,14 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 			diagnostics: rendererAuthoredDiagnostics ?? [],
 		};
 	}
-	const ast =
+	const parsedAst =
 		rendererBoundaryPreparation === null && analyzedAst !== null
 			? analyzedAst
 			: parseModule(source, filename);
+	// The normal compiler keeps its allocation-free in-place transform. Inspection
+	// transforms an official TSRX clone, so the parser tree is never modified and
+	// every subsequent mutation remains confined to compiler-owned nodes.
+	const ast = astTraceRequested ? cloneAstNode(parsedAst) : parsedAst;
 	const nativeChangeAnalysis =
 		options?.__nativeChangeAnalysis ??
 		analyzeNativeChangeDiagnostics(ast, source, filename, {
@@ -4661,7 +4769,7 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 	// inline-cache-vs-elsewhere in one line.
 	const inlineHookMemoEnabled =
 		options?.inlineHookMemo !== false && !hmrEnabled && !devEnabled && !profileEnabled;
-	const sourceMapHostTags = mode === 'client' && options?.sourceMapHostTags === true;
+	const astTraceEnabled = astTraceRequested;
 	const ctx = {
 		filename,
 		usedCompilerNames: collectIdentifierNames(ast),
@@ -4730,10 +4838,14 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 		// the top-level (autoCallback) pass and drained per component below.
 		_setupMaps: null,
 	};
-	if (sourceMapHostTags) {
+	if (astTraceEnabled) {
 		// Inspection-only state stays completely absent from the normal compiler
 		// context shape. `current` is swapped per nested JSX plan.
-		ctx.hostTagMap = { current: null, lineStarts: sourceLineStarts(source) };
+		ctx.hostTagMap = {
+			current: null,
+			lineStarts: sourceLineStarts(source),
+			attributeOrigins: new WeakMap(),
+		};
 	}
 	{
 		const imports = collectOctaneImportBindings(ast.body);
@@ -5339,7 +5451,7 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 		.map((i) => `_$injectStyle(${JSON.stringify(i.hash)}, ${JSON.stringify(i.css)});`)
 		.join('\n');
 	const styleBlock = styleInjections ? styleInjections + '\n\n' : '';
-	const templateSegments = sourceMapHostTags ? [] : null;
+	const templateSegments = astTraceEnabled ? [] : null;
 	const templateLines = [];
 	for (let templateLine = 0; templateLine < ctx.hoistedTemplates.length; templateLine++) {
 		const t = ctx.hoistedTemplates[templateLine];
@@ -5540,6 +5652,9 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 			authoredSource,
 			rendererBoundaryPreparation.mappingNeedles,
 		);
+	}
+	if (astTraceEnabled) {
+		result.astTrace = { generatedAst: createClientOutputAst(result.code, ctx.hoistedTemplates) };
 	}
 	return result;
 }
@@ -7498,6 +7613,11 @@ function applyCssScoping(componentNode, ctx) {
 	// Mutate every owned render root: add the canonical hash class to native
 	// elements and strip JSXStyleElement nodes from DOM output.
 	for (const root of roots) {
+		if (ctx.hostTagMap) {
+			// Preserve authored attribute origins before scoped hashes rewrite class
+			// literals on the inspection clone. Synthetic suffixes remain unmapped.
+			captureStaticAttributeOrigins(ctx, root.node);
+		}
 		// Normalize dynamic class exprs BEFORE the hash is appended (see helper), so
 		// clsx array/object values compose correctly alongside the scope hash.
 		wrapScopedClassExprs(root.node, ctx);
@@ -12939,9 +13059,9 @@ function planJsx(
 		ctx._elemLocs = _prevElemLocs;
 		return { mount: '', update: '', after: '', head: emitHeadClient(headNodes, ctx, 0) };
 	}
-	// Source positions for host tags emitted into THIS plan's template. Nested
-	// plans temporarily replace this list and restore it before the outer walk
-	// continues, matching the other plan-local compiler state below.
+	// Source positions for host tags and static attributes emitted into THIS
+	// plan's template. Nested plans temporarily replace this list and restore it
+	// before the outer walk continues, matching the other plan-local state below.
 	const hostTagMap = ctx.hostTagMap;
 	const previousHostTagSources = hostTagMap?.current ?? null;
 	if (hostTagMap) hostTagMap.current = [];
@@ -15148,7 +15268,9 @@ function emitElementHtml(
 			) {
 				inner = { type: 'Literal', value: true, raw: 'true' };
 			} else {
-				attrHtml += bakeStaticAttr(attrName, true, tag, hostNs);
+				const emitted = bakeStaticAttr(attrName, true, tag, hostNs);
+				if (hostTagSources) recordStaticAttributeSource(ctx, attr, emitted);
+				attrHtml += emitted;
 				continue;
 			}
 		} else {
@@ -15163,12 +15285,18 @@ function emitElementHtml(
 		// values become a setStyle binding.
 		if (attrName === 'style') {
 			if (!isAfterSpread && inner.type === 'Literal' && typeof inner.value === 'string') {
-				attrHtml += ` style="${escapeAttr(inner.value)}"`;
+				const emitted = ` style="${escapeAttr(inner.value)}"`;
+				if (hostTagSources) recordStaticAttributeSource(ctx, attr, emitted);
+				attrHtml += emitted;
 				continue;
 			}
 			if (!isAfterSpread && inner.type === 'ObjectExpression' && objectExprIsStaticLiteral(inner)) {
 				const css = staticObjectToCssString(inner);
-				if (css) attrHtml += ` style="${escapeAttr(css)}"`;
+				if (css) {
+					const emitted = ` style="${escapeAttr(css)}"`;
+					if (hostTagSources) recordStaticAttributeSource(ctx, attr, emitted);
+					attrHtml += emitted;
+				}
 				continue;
 			}
 			const expr = printExprWithTsrx(inner, ctx, componentName, inlinedSubs);
@@ -15188,7 +15316,9 @@ function emitElementHtml(
 			!classBeforeSpread &&
 			!(ctx.dev && needsDevStaticAttrValidation(attrName, inner.value, tag, hostNs))
 		) {
-			attrHtml += bakeStaticAttr(attrName, inner.value, tag, hostNs);
+			const emitted = bakeStaticAttr(attrName, inner.value, tag, hostNs);
+			if (hostTagSources) recordStaticAttributeSource(ctx, attr, emitted);
+			attrHtml += emitted;
 			continue;
 		}
 
@@ -17248,73 +17378,407 @@ function walkExprH(rootVar, path) {
 	return expr;
 }
 
-function mapTemplateTags(html, sources) {
-	if (!sources || sources.length === 0) return sources || [];
+// Octane template nodes are inspection metadata, not executable ESTree. Keep
+// their construction behind one local builder; standard generated-JS nodes
+// below use @tsrx/core builders and setLocation instead.
+function inspectionNode(type, fields = null) {
+	return fields === null ? { type } : { type, ...fields };
+}
+
+function inspectionName(type, name) {
+	return inspectionNode(type, { name });
+}
+
+function rawTextClosingTag(html, from, tag) {
+	const expected = tag.toLowerCase();
+	let candidate = from;
+	while ((candidate = html.indexOf('</', candidate)) !== -1) {
+		const nameEnd = candidate + 2 + expected.length;
+		const boundary = html.charCodeAt(nameEnd);
+		if (
+			html.slice(candidate + 2, nameEnd).toLowerCase() === expected &&
+			(boundary <= 32 || boundary === 62)
+		) {
+			return candidate;
+		}
+		candidate += 2;
+	}
+	return -1;
+}
+
+function inspectTemplateHtml(html, sources) {
+	const root = inspectionNode('OctaneTemplate', { children: [] });
+	const ranges = [{ node: root, start: 0, end: html.length }];
+	const stack = [{ tag: null, node: root, range: ranges[0] }];
 	let sourceIndex = 0;
 	let index = 0;
-	while (index < html.length && sourceIndex < sources.length) {
-		const opening = html.indexOf('<', index);
-		if (opening === -1) break;
-		if (html.startsWith('<!--', opening)) {
-			const end = html.indexOf('-->', opening + 4);
-			index = end === -1 ? html.length : end + 3;
+	const append = (node, start, end) => {
+		stack[stack.length - 1].node.children.push(node);
+		const range = { node, start, end };
+		ranges.push(range);
+		return range;
+	};
+	const match = (kind, from, to) => {
+		const source = sources[sourceIndex];
+		if (!source || source.kind !== kind) return;
+		let tokenStart = from;
+		if (kind === 'attr-value') {
+			tokenStart = html.indexOf(source.tag, from);
+			if (tokenStart === -1 || tokenStart + source.tag.length > to) return;
+		} else if (to - from !== source.tag.length || !html.startsWith(source.tag, from)) {
+			return;
+		}
+		source.htmlOffset = tokenStart;
+		source.length = source.tag.length;
+		sourceIndex++;
+	};
+	while (index < html.length) {
+		const active = stack[stack.length - 1];
+		if (active.tag?.toLowerCase() === 'script') {
+			const closing = rawTextClosingTag(html, index, active.tag);
+			if (closing !== index) {
+				const end = closing === -1 ? html.length : closing;
+				if (end > index) {
+					append(
+						inspectionNode('OctaneTemplateText', { value: html.slice(index, end) }),
+						index,
+						end,
+					);
+				}
+				index = end;
+				continue;
+			}
+		}
+
+		if (html.charCodeAt(index) !== 60) {
+			const next = html.indexOf('<', index);
+			const end = next === -1 ? html.length : next;
+			append(inspectionNode('OctaneTemplateText', { value: html.slice(index, end) }), index, end);
+			index = end;
 			continue;
 		}
 
-		let nameStart = opening + 1;
-		let kind = 'open';
-		if (html.charCodeAt(nameStart) === 47) {
-			kind = 'close';
-			nameStart++;
+		if (html.startsWith('<!--', index)) {
+			const commentEnd = html.indexOf('-->', index + 4);
+			const end = commentEnd === -1 ? html.length : commentEnd + 3;
+			append(
+				inspectionNode('OctaneTemplateComment', {
+					value: html.slice(index + 4, commentEnd === -1 ? html.length : commentEnd),
+				}),
+				index,
+				end,
+			);
+			index = end;
+			continue;
 		}
+
+		if (html.startsWith('<!>', index)) {
+			append(inspectionNode('OctaneTemplateMarker', { value: '<!>' }), index, index + 3);
+			index += 3;
+			continue;
+		}
+
+		if (html.startsWith('</', index)) {
+			const nameStart = index + 2;
+			let nameEnd = nameStart;
+			while (nameEnd < html.length) {
+				const character = html.charCodeAt(nameEnd);
+				if (character <= 32 || character === 62) break;
+				nameEnd++;
+			}
+			const close = html.indexOf('>', nameEnd);
+			const end = close === -1 ? html.length : close + 1;
+			match('close', nameStart, nameEnd);
+			const name = inspectionName('OctaneTemplateIdentifier', html.slice(nameStart, nameEnd));
+			const closingElement = inspectionNode('OctaneTemplateClosingElement', { name });
+			ranges.push(
+				{ node: closingElement, start: index, end },
+				{ node: name, start: nameStart, end: nameEnd },
+			);
+			let matchIndex = stack.length - 1;
+			while (matchIndex > 0 && stack[matchIndex].tag.toLowerCase() !== name.name.toLowerCase()) {
+				matchIndex--;
+			}
+			if (matchIndex > 0) {
+				const entry = stack[matchIndex];
+				entry.node.closingElement = closingElement;
+				entry.range.end = end;
+				stack.length = matchIndex;
+			} else {
+				append(closingElement, index, end);
+			}
+			index = end;
+			continue;
+		}
+
+		if (html.startsWith('<!', index)) {
+			const markerEnd = html.indexOf('>', index + 2);
+			const end = markerEnd === -1 ? html.length : markerEnd + 1;
+			append(inspectionNode('OctaneTemplateMarker', { value: html.slice(index, end) }), index, end);
+			index = end;
+			continue;
+		}
+
+		const nameStart = index + 1;
 		let nameEnd = nameStart;
 		while (nameEnd < html.length) {
 			const character = html.charCodeAt(nameEnd);
 			if (character <= 32 || character === 47 || character === 62) break;
 			nameEnd++;
 		}
-
-		const source = sources[sourceIndex];
-		if (
-			kind === source.kind &&
-			nameEnd - nameStart === source.tag.length &&
-			html.startsWith(source.tag, nameStart)
-		) {
-			source.htmlOffset = nameStart;
-			source.length = source.tag.length;
-			sourceIndex++;
-		}
-
-		// Advance past the complete tag so a `<tag` substring inside a quoted
-		// attribute value can never be mistaken for a nested element.
-		let quote = 0;
+		match('open', nameStart, nameEnd);
+		const tag = html.slice(nameStart, nameEnd);
+		const name = inspectionName('OctaneTemplateIdentifier', tag);
+		const attributes = [];
 		let cursor = nameEnd;
-		for (; cursor < html.length; cursor++) {
-			const character = html.charCodeAt(cursor);
-			if (quote !== 0) {
-				if (character === quote) quote = 0;
-			} else if (character === 34 || character === 39) {
-				quote = character;
-			} else if (character === 62) {
+		let selfClosing = false;
+		while (cursor < html.length) {
+			while (cursor < html.length && html.charCodeAt(cursor) <= 32) cursor++;
+			if (html.charCodeAt(cursor) === 47) {
+				selfClosing = true;
+				cursor++;
+				continue;
+			}
+			if (html.charCodeAt(cursor) === 62) {
 				cursor++;
 				break;
 			}
+			const attrStart = cursor;
+			const attrNameStart = cursor;
+			while (cursor < html.length) {
+				const character = html.charCodeAt(cursor);
+				if (character <= 32 || character === 61 || character === 47 || character === 62) break;
+				cursor++;
+			}
+			const attrNameEnd = cursor;
+			if (attrNameEnd === attrNameStart) {
+				cursor++;
+				continue;
+			}
+			match('attr-name', attrNameStart, attrNameEnd);
+			const attrName = inspectionName(
+				'OctaneTemplateAttributeName',
+				html.slice(attrNameStart, attrNameEnd),
+			);
+			let value = null;
+			while (cursor < html.length && html.charCodeAt(cursor) <= 32) cursor++;
+			if (html.charCodeAt(cursor) === 61) {
+				cursor++;
+				while (cursor < html.length && html.charCodeAt(cursor) <= 32) cursor++;
+				const quote = html.charCodeAt(cursor);
+				if (quote === 34 || quote === 39) {
+					const valueStart = ++cursor;
+					while (cursor < html.length && html.charCodeAt(cursor) !== quote) cursor++;
+					const valueEnd = cursor;
+					match('attr-value', valueStart, valueEnd);
+					value = inspectionNode('OctaneTemplateAttributeValue', {
+						value: html.slice(valueStart, valueEnd),
+						raw: html.slice(valueStart - 1, cursor < html.length ? cursor + 1 : cursor),
+					});
+					ranges.push({ node: value, start: valueStart, end: valueEnd });
+					if (cursor < html.length) cursor++;
+				} else {
+					const valueStart = cursor;
+					while (cursor < html.length) {
+						const character = html.charCodeAt(cursor);
+						if (character <= 32 || character === 47 || character === 62) break;
+						cursor++;
+					}
+					match('attr-value', valueStart, cursor);
+					value = inspectionNode('OctaneTemplateAttributeValue', {
+						value: html.slice(valueStart, cursor),
+						raw: html.slice(valueStart, cursor),
+					});
+					ranges.push({ node: value, start: valueStart, end: cursor });
+				}
+			}
+			const attribute = inspectionNode('OctaneTemplateAttribute', { name: attrName, value });
+			attributes.push(attribute);
+			ranges.push(
+				{ node: attribute, start: attrStart, end: cursor },
+				{ node: attrName, start: attrNameStart, end: attrNameEnd },
+			);
 		}
-		index = cursor > opening ? cursor : opening + 1;
+		const openingElement = inspectionNode('OctaneTemplateOpeningElement', {
+			name,
+			attributes,
+			selfClosing,
+		});
+		const element = inspectionNode('OctaneTemplateElement', {
+			openingElement,
+			closingElement: null,
+			children: [],
+		});
+		const elementRange = append(element, index, cursor);
+		ranges.push(
+			{ node: openingElement, start: index, end: cursor },
+			{ node: name, start: nameStart, end: nameEnd },
+		);
+		if (!selfClosing && !VOID_ELEMENTS.has(tag.toLowerCase())) {
+			stack.push({ tag, node: element, range: elementRange });
+		}
+		index = cursor;
 	}
-	// The matched prefix already contains the mapping objects. Truncate any
-	// unmatched tail instead of allocating a second per-template array.
+
 	sources.length = sourceIndex;
-	return sources;
+	return { mappings: sources, ast: root, ranges };
 }
 
 function allocTemplate(ctx, html, ns = 0, frag = 0, tagSources = null) {
 	const id = ctx.nextTemplateId++;
 	const name = `_t$${id}`;
 	const template = { name, html, ns, frag };
-	if (tagSources !== null) template.tagMappings = mapTemplateTags(html, tagSources);
+	if (tagSources !== null) {
+		const inspection = inspectTemplateHtml(html, tagSources);
+		template.tagMappings = inspection.mappings;
+		template.inspectionAst = inspection.ast;
+		template.inspectionRanges = inspection.ranges;
+	}
 	ctx.hoistedTemplates.push(template);
 	return name;
+}
+
+let generatedOutputParser = null;
+
+function parseGeneratedOutputAst(code) {
+	if (generatedOutputParser === null) {
+		generatedOutputParser = acorn.Parser.extend(tsPlugin({ jsx: true }));
+	}
+	return generatedOutputParser.parse(code, {
+		sourceType: 'module',
+		ecmaVersion: 'latest',
+		allowReturnOutsideFunction: true,
+		locations: true,
+		preserveParens: true,
+	});
+}
+
+function encodedTemplateBoundaries(raw, ranges) {
+	const boundaries = [];
+	for (const range of ranges) boundaries.push(range.start, range.end);
+	boundaries.sort((a, b) => a - b);
+	const offsets = new Map();
+	let htmlOffset = 0;
+	let encodedOffset = 1;
+	for (const boundary of boundaries) {
+		if (offsets.has(boundary)) continue;
+		while (htmlOffset < boundary) {
+			if (raw.charCodeAt(encodedOffset) === 92) {
+				encodedOffset += raw.charCodeAt(encodedOffset + 1) === 117 ? 6 : 2;
+			} else {
+				encodedOffset++;
+			}
+			htmlOffset++;
+		}
+		offsets.set(boundary, encodedOffset);
+	}
+	return offsets;
+}
+
+function generatedLineStarts(code) {
+	const starts = [0];
+	for (let index = 0; index < code.length; index++) {
+		const character = code.charCodeAt(index);
+		if (character === 13) {
+			if (code.charCodeAt(index + 1) === 10) index++;
+			starts.push(index + 1);
+		} else if (character === 10 || character === 0x2028 || character === 0x2029) {
+			starts.push(index + 1);
+		}
+	}
+	return starts;
+}
+
+function generatedLocation(lineStarts, offset) {
+	let low = 0;
+	let high = lineStarts.length;
+	while (low < high) {
+		const middle = (low + high) >> 1;
+		if (lineStarts[middle] <= offset) low = middle + 1;
+		else high = middle;
+	}
+	const lineIndex = low - 1;
+	return { line: lineIndex + 1, column: offset - lineStarts[lineIndex] };
+}
+
+function materializeTemplateAst(template, literal, lineStarts) {
+	const rangeByNode = new Map();
+	for (const range of template.inspectionRanges) rangeByNode.set(range.node, range);
+	const offsets = encodedTemplateBoundaries(literal.raw, template.inspectionRanges);
+	const visit = (value) => {
+		if (Array.isArray(value)) return value.map(visit);
+		if (!value || typeof value !== 'object') return value;
+		const node = inspectionNode(value.type);
+		for (const key of Object.keys(value)) {
+			if (key !== 'type') node[key] = visit(value[key]);
+		}
+		const range = rangeByNode.get(value);
+		if (range) {
+			const relativeStart = offsets.get(range.start);
+			const relativeEnd = offsets.get(range.end);
+			const start = literal.start + relativeStart;
+			const end = literal.start + relativeEnd;
+			return setLocation(
+				node,
+				{
+					start,
+					end,
+					loc: {
+						start: generatedLocation(lineStarts, start),
+						end: generatedLocation(lineStarts, end),
+					},
+				},
+				true,
+			);
+		}
+		return node;
+	};
+	return visit(template.inspectionAst);
+}
+
+function createClientOutputAst(code, templates) {
+	const parsed = parseGeneratedOutputAst(code);
+	const byName = new Map(templates.map((template) => [template.name, template]));
+	const lineStarts = generatedLineStarts(code);
+	let changed = false;
+	// Rebuild only declaration paths that contain a hoisted template. The parsed
+	// output tree is never mutated, and all unrelated branches retain identity.
+	const body = parsed.body.map((statement) => {
+		if (statement.type !== 'VariableDeclaration') return statement;
+		let declarationChanged = false;
+		const declarations = statement.declarations.map((declaration) => {
+			const template = byName.get(declaration.id?.name);
+			const init = declaration.init;
+			const literal = init?.type === 'CallExpression' ? init.arguments?.[0] : null;
+			if (
+				!template?.inspectionAst ||
+				literal?.type !== 'Literal' ||
+				typeof literal.value !== 'string'
+			) {
+				return declaration;
+			}
+			declarationChanged = true;
+			changed = true;
+			const nextLiteral = {
+				...setLocation(b.literal(literal.value, literal.raw), literal, true),
+				template: materializeTemplateAst(template, literal, lineStarts),
+			};
+			const nextInit = setLocation(
+				b.call(
+					cloneAstNode(init.callee),
+					nextLiteral,
+					...init.arguments.slice(1).map((argument) => cloneAstNode(argument)),
+				),
+				init,
+				true,
+			);
+			return setLocation(b.declarator(cloneAstNode(declaration.id), nextInit), declaration, true);
+		});
+		return declarationChanged
+			? setLocation(b.declaration(statement.kind, declarations), statement, true)
+			: statement;
+	});
+	return changed ? { ...parsed, body } : parsed;
 }
 
 function escapeHtml(s) {

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -5460,10 +5460,8 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 		if (templateSegments !== null) {
 			let htmlOffset = 0;
 			let encodedOffset = 1; // Skip the serialized string's opening quote.
-			for (const mapping of t.tagMappings) {
-				// Walk the already-serialized string monotonically. An escape sequence
-				// occupies 2 or 6 generated columns but represents one UTF-16 code unit.
-				while (htmlOffset < mapping.htmlOffset) {
+			const advanceTo = (target) => {
+				while (htmlOffset < target) {
 					if (encodedHtml.charCodeAt(encodedOffset) === 92) {
 						encodedOffset += encodedHtml.charCodeAt(encodedOffset + 1) === 117 ? 6 : 2;
 					} else {
@@ -5471,15 +5469,22 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 					}
 					htmlOffset++;
 				}
+			};
+			for (const mapping of t.tagMappings) {
+				// Walk the already-serialized string monotonically. An escape sequence
+				// occupies 2 or 6 generated columns but represents one UTF-16 code unit.
+				advanceTo(mapping.htmlOffset);
+				const encodedStart = encodedOffset;
+				advanceTo(mapping.htmlOffset + mapping.length);
 				templateSegments.push({
 					genLine: templateLine,
-					genCol: prefix.length + encodedOffset,
+					genCol: prefix.length + encodedStart,
 					srcLine0: mapping.srcLine0,
 					srcCol0: mapping.srcCol0,
 				});
 				templateSegments.push({
 					genLine: templateLine,
-					genCol: prefix.length + encodedOffset + mapping.length,
+					genCol: prefix.length + encodedOffset,
 					unmapped: true,
 				});
 			}
@@ -17412,10 +17417,22 @@ function rawTextClosingTag(html, from, tag) {
 	return -1;
 }
 
-function inspectTemplateHtml(html, sources) {
+const TEMPLATE_TEXT_ONLY_ELEMENTS = new Set(['script', 'textarea', 'title']);
+
+function inspectTemplateHtml(html, sources, namespaceFlag = 0) {
 	const offsets = [0, html.length];
 	const root = inspectionNode('OctaneTemplate', { children: [] }, 0, html.length);
-	const stack = [{ tag: null, node: root }];
+	const rootNamespace =
+		namespaceFlag === 1
+			? 'svg'
+			: namespaceFlag === 2
+				? 'mathml'
+				: namespaceFlag === 3
+					? 'opaque'
+					: 'html';
+	const stack = [
+		{ tag: null, node: root, namespace: rootNamespace, childNamespace: rootNamespace },
+	];
 	let sourceIndex = 0;
 	let index = 0;
 	const append = (node, start, end) => {
@@ -17439,9 +17456,21 @@ function inspectTemplateHtml(html, sources) {
 		source.length = source.tag.length;
 		sourceIndex++;
 	};
+	const skipTextOnlySources = (tag) => {
+		const expected = tag.toLowerCase();
+		while (sourceIndex < sources.length) {
+			const source = sources[sourceIndex];
+			if (source.kind === 'close' && source.tag.toLowerCase() === expected) return;
+			sourceIndex++;
+		}
+	};
 	while (index < html.length) {
 		const active = stack[stack.length - 1];
-		if (active.tag?.toLowerCase() === 'script') {
+		if (
+			active.namespace === 'html' &&
+			active.tag &&
+			TEMPLATE_TEXT_ONLY_ELEMENTS.has(active.tag.toLowerCase())
+		) {
 			const closing = rawTextClosingTag(html, index, active.tag);
 			if (closing !== index) {
 				const end = closing === -1 ? html.length : closing;
@@ -17455,6 +17484,7 @@ function inspectTemplateHtml(html, sources) {
 				index = end;
 				continue;
 			}
+			skipTextOnlySources(active.tag);
 		}
 
 		if (html.charCodeAt(index) !== 60) {
@@ -17538,6 +17568,9 @@ function inspectTemplateHtml(html, sources) {
 		}
 		match('open', nameStart, nameEnd);
 		const tag = html.slice(nameStart, nameEnd);
+		const parentNamespace = active.childNamespace;
+		const namespace = nsForSelf(tag, parentNamespace);
+		const childNamespace = nsForChildren(tag, parentNamespace);
 		const name = inspectionName('OctaneTemplateIdentifier', tag, nameStart, nameEnd);
 		offsets.push(nameStart, nameEnd);
 		const attributes = [];
@@ -17642,8 +17675,8 @@ function inspectTemplateHtml(html, sources) {
 			children: [],
 		});
 		append(element, index, cursor);
-		if (!selfClosing && !VOID_ELEMENTS.has(tag.toLowerCase())) {
-			stack.push({ tag, node: element });
+		if (!selfClosing && (namespace !== 'html' || !VOID_ELEMENTS.has(tag.toLowerCase()))) {
+			stack.push({ tag, node: element, namespace, childNamespace });
 		}
 		index = cursor;
 	}
@@ -17657,7 +17690,7 @@ function allocTemplate(ctx, html, ns = 0, frag = 0, tagSources = null) {
 	const name = `_t$${id}`;
 	const template = { name, html, ns, frag };
 	if (tagSources !== null) {
-		const inspection = inspectTemplateHtml(html, tagSources);
+		const inspection = inspectTemplateHtml(html, tagSources, ns);
 		template.tagMappings = inspection.mappings;
 		template.inspectionAst = inspection.ast;
 		template.inspectionOffsets = inspection.offsets;

--- a/packages/octane/tests/compiler-source-map.test.ts
+++ b/packages/octane/tests/compiler-source-map.test.ts
@@ -28,7 +28,7 @@ function nthIndexOf(text: string, needle: string, occurrence: number) {
 }
 
 describe('client compiler source maps', () => {
-	it('maps nested template tag names without treating attribute text as an element', () => {
+	it('maps nested tags and attribute values without confusing their coordinates', () => {
 		const source = `export function App() @{
 	<div data-label="<span">
 		<span><div /></span>
@@ -37,18 +37,23 @@ describe('client compiler source maps', () => {
 		const defaultOutput = compile(source, 'App.tsrx', { mode: 'client' });
 		const output = compile(source, 'App.tsrx', {
 			mode: 'client',
-			sourceMapHostTags: true,
+			astTrace: true,
 		});
 		expect(output.code).toBe(defaultOutput.code);
+		expect(defaultOutput).not.toHaveProperty('astTrace');
+		expect(output.astTrace?.generatedAst).toMatchObject({ type: 'Program' });
 
 		const generatedAttributeText = nthIndexOf(output.code, '<span', 0) + 1;
 		const generatedSpanOpen = nthIndexOf(output.code, '<span', 1) + 1;
 		const generatedSpanClose = output.code.indexOf('</span>') + 2;
+		const sourceAttributeText = source.indexOf('<span');
 		const sourceSpanOpen = nthIndexOf(source, '<span', 1) + 1;
 		const sourceSpanClose = source.indexOf('</span>') + 2;
 
 		expect(originalPosition(defaultOutput.code, defaultOutput.map, generatedSpanOpen)).toBeNull();
-		expect(originalPosition(output.code, output.map, generatedAttributeText)).toBeNull();
+		expect(originalPosition(output.code, output.map, generatedAttributeText)).toEqual(
+			offsetPosition(source, sourceAttributeText),
+		);
 		expect(originalPosition(output.code, output.map, generatedSpanOpen)).toEqual(
 			offsetPosition(source, sourceSpanOpen),
 		);
@@ -66,5 +71,37 @@ describe('client compiler source maps', () => {
 		expect(originalPosition(output.code, output.map, generatedSelfClosing + 7)).toEqual(
 			offsetPosition(source, sourceSelfClosing),
 		);
+	});
+
+	it('maps authored static attributes without claiming compiler-injected class text', () => {
+		const source = `export function App() @{
+	<div class="demo">
+		<h2 title="a&b">Title</h2>
+		<style>div { color: red; }</style>
+	</div>
+}`;
+		const defaultOutput = compile(source, 'App.tsrx', { mode: 'client' });
+		const output = compile(source, 'App.tsrx', {
+			mode: 'client',
+			astTrace: true,
+		});
+		expect(output.code).toBe(defaultOutput.code);
+
+		const generatedClass = output.code.indexOf('class=');
+		const generatedDemo = output.code.indexOf('demo', generatedClass);
+		const generatedScope = output.code.indexOf('tsrx-', generatedDemo);
+		const generatedEscapedValue = output.code.indexOf('a&amp;b');
+		const sourceClass = source.indexOf('class=');
+		const sourceDemo = source.indexOf('demo', sourceClass);
+
+		expect(originalPosition(defaultOutput.code, defaultOutput.map, generatedClass)).toBeNull();
+		expect(originalPosition(output.code, output.map, generatedClass)).toEqual(
+			offsetPosition(source, sourceClass),
+		);
+		expect(originalPosition(output.code, output.map, generatedDemo)).toEqual(
+			offsetPosition(source, sourceDemo),
+		);
+		expect(originalPosition(output.code, output.map, generatedScope)).toBeNull();
+		expect(originalPosition(output.code, output.map, generatedEscapedValue)).toBeNull();
 	});
 });

--- a/packages/octane/tests/compiler-source-map.test.ts
+++ b/packages/octane/tests/compiler-source-map.test.ts
@@ -104,4 +104,28 @@ describe('client compiler source maps', () => {
 		expect(originalPosition(output.code, output.map, generatedScope)).toBeNull();
 		expect(originalPosition(output.code, output.map, generatedEscapedValue)).toBeNull();
 	});
+
+	it('bounds encoded template mappings after JSON string escapes', () => {
+		const decodedValue = 'line\nnext\tvalue';
+		const source = `export function App() @{
+	<div data-label="${decodedValue}">Label</div>
+}`;
+		const output = compile(source, 'App.tsrx', {
+			mode: 'client',
+			astTrace: true,
+		});
+		const encodedValue = JSON.stringify(decodedValue).slice(1, -1);
+		const generatedOffset = output.code.indexOf(encodedValue);
+		const generated = offsetPosition(output.code, generatedOffset);
+		const segments = decodeMappings(output.map.mappings)[generated.line] ?? [];
+		const mappedIndex = segments.findIndex(
+			(segment) => segment.length >= 4 && segment[0] === generated.column,
+		);
+
+		expect(mappedIndex).toBeGreaterThanOrEqual(0);
+		expect(segments[mappedIndex + 1]).toEqual([generated.column + encodedValue.length]);
+		expect(originalPosition(output.code, output.map, generatedOffset)).toEqual(
+			offsetPosition(source, source.indexOf(decodedValue)),
+		);
+	});
 });

--- a/website/env.d.ts
+++ b/website/env.d.ts
@@ -29,10 +29,15 @@ declare module 'octane/compiler' {
 			mode?: 'client' | 'server';
 			hmr?: boolean;
 			dev?: boolean;
-			/** Inspection-only anchors for host tags baked into client templates. */
-			sourceMapHostTags?: boolean;
+			/** Inspection-only generated AST and template source-map anchors. */
+			astTrace?: boolean;
 		},
-	): { code: string; map: unknown; diagnostics: CompileDiagnostic[] };
+	): {
+		code: string;
+		map: unknown;
+		diagnostics: CompileDiagnostic[];
+		astTrace?: { generatedAst: unknown };
+	};
 }
 
 // The Volar (language-service) pipeline — the playground's TYPES output pane.

--- a/website/src/lib/playground.ts
+++ b/website/src/lib/playground.ts
@@ -14,7 +14,7 @@
 //
 // Client-only: load via dynamic import from an effect (never during SSR).
 import { compile, type CompileDiagnostic } from 'octane/compiler';
-import { __parseGeneratedModuleAst, compileToVolarMappings } from 'octane/compiler/volar';
+import { compileToVolarMappings } from 'octane/compiler/volar';
 import {
 	sandboxSrcdoc,
 	RUNTIME_MANIFEST_PATH,
@@ -93,13 +93,12 @@ export interface AstSuccess {
 
 export type PlaygroundAstStage = 'source' | 'type-transform' | 'type-output' | 'client-output';
 
-const parseGeneratedAst = (code: string): unknown => __parseGeneratedModuleAst(code);
-
 /**
- * Build one stage of the AST trace shown by the playground. Source and
- * type-only transform trees come directly from the compiler. The client output
- * tree is parsed from the exact emitted code because that emitter does not
- * maintain one complete transformed AST. Never throws.
+ * Build one stage of the AST trace shown by the playground. Every tree comes
+ * directly from its owning compiler pipeline. Client output parses the exact
+ * artifact and enriches its hoisted literals under the compiler's inspection
+ * gate because runtime codegen deliberately does not retain a full tree.
+ * Never throws.
  */
 export function compileAst(
 	source: string,
@@ -110,15 +109,15 @@ export function compileAst(
 		if (stage === 'client-output') {
 			const result = compile(source, filename, {
 				mode: 'client',
-				sourceMapHostTags: true,
-			});
+				astTrace: true,
+			}) as ReturnType<typeof compile> & { astTrace: { generatedAst: unknown } };
 			return {
 				ok: true,
-				ast: parseGeneratedAst(result.code),
+				ast: result.astTrace.generatedAst,
 				space: 'generated',
 				label: 'Client output AST',
 				notice:
-					'Parsed from the exact client output. Source navigation is limited to compiler source-map anchors.',
+					'Parsed from the exact client output. Hoisted template literals include inspection-only element, attribute, text, and marker nodes with exact output ranges.',
 				code: result.code,
 				map: result.map,
 			};

--- a/website/src/pages/playground/Playground.tsrx
+++ b/website/src/pages/playground/Playground.tsrx
@@ -336,6 +336,7 @@ export function Playground() @{
 					};
 				} else {
 					const result = pg.compileTypes(source, name);
+					if (!result.ok && cached) return cached;
 					entry = result.ok
 						? { source, code: result.code, volarMappings: result.mappings, mapping: undefined }
 						: {
@@ -565,10 +566,6 @@ export function Playground() @{
 					return;
 				}
 				astPreview.reveal(pair.output[0].from, scroll);
-				// Client templates are parsed as one string Literal. Revealing that
-				// AST node reports its whole range back through onNodeRange, whose
-				// first source anchor may be a different tag. Restore the exact
-				// source-side range that initiated navigation after the reveal.
 				revealRanges(sourceView, pair.source, false);
 			};
 

--- a/website/tests/playground-ast.test.ts
+++ b/website/tests/playground-ast.test.ts
@@ -112,6 +112,39 @@ describe('playground AST preparation', () => {
 		expect(ranges.at(-1)).toBeNull();
 		preview.destroy();
 	});
+
+	it('exposes granular client template nodes at exact generated ranges', () => {
+		const source = `export function App() @{
+	<div class="demo"><h2>Title</h2></div>
+}`;
+		const output = compileAst(source, 'App.tsrx', 'client-output');
+		if (!output.ok) throw new Error(output.error);
+		const prepared = preparePlaygroundAst(output.ast);
+		const h2 = output.code!.indexOf('<h2>') + 1;
+		const className = output.code!.indexOf('class=');
+		const classValue = output.code!.indexOf('demo', className);
+
+		expect(findDeepestAstNode(prepared, h2)?.type).toBe('OctaneTemplateIdentifier');
+		expect(findDeepestAstNode(prepared, className)?.type).toBe('OctaneTemplateAttributeName');
+		expect(findDeepestAstNode(prepared, classValue)?.type).toBe('OctaneTemplateAttributeValue');
+	});
+
+	it('keeps escaped attributes, raw script text, and dynamic markers distinct', () => {
+		const source = `export function App() @{
+	const value = 'ready';
+	<div title="a&b"><script>if (a < b) x()</script>{value}</div>
+}`;
+		const output = compileAst(source, 'App.tsrx', 'client-output');
+		if (!output.ok) throw new Error(output.error);
+		const prepared = preparePlaygroundAst(output.ast);
+		const escapedValue = output.code!.indexOf('a&amp;b');
+		const scriptComparison = output.code!.indexOf('a < b');
+		const marker = output.code!.indexOf('<!>');
+
+		expect(findDeepestAstNode(prepared, escapedValue)?.type).toBe('OctaneTemplateAttributeValue');
+		expect(findDeepestAstNode(prepared, scriptComparison + 2)?.type).toBe('OctaneTemplateText');
+		expect(findDeepestAstNode(prepared, marker)?.type).toBe('OctaneTemplateMarker');
+	});
 });
 
 describe.each([

--- a/website/tests/playground-ast.test.ts
+++ b/website/tests/playground-ast.test.ts
@@ -145,6 +145,37 @@ describe('playground AST preparation', () => {
 		expect(findDeepestAstNode(prepared, scriptComparison + 2)?.type).toBe('OctaneTemplateText');
 		expect(findDeepestAstNode(prepared, marker)?.type).toBe('OctaneTemplateMarker');
 	});
+
+	it('keeps textarea content text-only without desynchronizing later nodes', () => {
+		const source = `export function App() @{
+	<div>
+		<textarea><fake data-x="bad"></fake></textarea>
+		<span data-after="ok">after</span>
+	</div>
+}`;
+		const output = compileAst(source, 'App.tsrx', 'client-output');
+		if (!output.ok) throw new Error(output.error);
+		const prepared = preparePlaygroundAst(output.ast);
+		const textareaText = output.code!.indexOf('<fake');
+		const laterAttribute = output.code!.indexOf('data-after');
+
+		expect(findDeepestAstNode(prepared, textareaText + 1)?.type).toBe('OctaneTemplateText');
+		expect(findDeepestAstNode(prepared, laterAttribute)?.type).toBe('OctaneTemplateAttributeName');
+	});
+
+	it('keeps title content structural in the SVG namespace', () => {
+		const source = `export function App() @{
+	<svg><title><fake></fake></title><path /></svg>
+}`;
+		const output = compileAst(source, 'App.tsrx', 'client-output');
+		if (!output.ok) throw new Error(output.error);
+		const prepared = preparePlaygroundAst(output.ast);
+		const nestedTag = output.code!.indexOf('<fake');
+		const laterTag = output.code!.indexOf('<path');
+
+		expect(findDeepestAstNode(prepared, nestedTag + 1)?.type).toBe('OctaneTemplateIdentifier');
+		expect(findDeepestAstNode(prepared, laterTag + 1)?.type).toBe('OctaneTemplateIdentifier');
+	});
 });
 
 describe.each([

--- a/website/tests/playground-mapping.test.ts
+++ b/website/tests/playground-mapping.test.ts
@@ -169,7 +169,7 @@ describe('client output mapping (compiler source map)', () => {
 		});
 	});
 
-	it('keeps nested and self-closing tags exact when attribute text looks like markup', () => {
+	it('keeps nested tags, attribute text, and self-closing tags in distinct ranges', () => {
 		const source = `export function App() @{
 	<div data-label="<span">
 		<span><div /></span>
@@ -180,9 +180,12 @@ describe('client output mapping (compiler source map)', () => {
 		const nested = mappingFromSourceMap(compiled.map, source, compiled.code!);
 		const fakeGeneratedTag = compiled.code!.indexOf('<span') + 1;
 		const realGeneratedTag = compiled.code!.indexOf('<span', fakeGeneratedTag) + 1;
+		const sourceAttributeText = source.indexOf('<span') + 1;
 		const sourceTag = source.indexOf('<span', source.indexOf('<span') + 1) + 1;
 
-		expect(nested?.pairFromGenerated(fakeGeneratedTag)).toBeNull();
+		expect(nested?.pairFromGenerated(fakeGeneratedTag)?.source).toEqual([
+			{ from: sourceAttributeText, to: sourceAttributeText + 4 },
+		]);
 		expect(nested?.pairFromGenerated(realGeneratedTag)?.source).toEqual([
 			{ from: sourceTag, to: sourceTag + 4 },
 		]);
@@ -196,6 +199,33 @@ describe('client output mapping (compiler source map)', () => {
 				{ from: generatedSelfClosing + 7, to: generatedSelfClosing + 10 },
 			],
 		});
+	});
+
+	it('maps authored static attribute names and values but not scoped class additions', () => {
+		const source = `export function App() @{
+	<div class="demo">
+		<h2>Title</h2>
+		<style>div { color: red; }</style>
+	</div>
+}`;
+		const compiled = compileAst(source, 'App.tsrx', 'client-output');
+		if (!compiled.ok) throw new Error(compiled.error);
+		const scoped = mappingFromSourceMap(compiled.map, source, compiled.code!);
+		const sourceClass = source.indexOf('class=');
+		const sourceDemo = source.indexOf('demo', sourceClass);
+		const generatedClass = compiled.code!.indexOf('class=');
+		const generatedDemo = compiled.code!.indexOf('demo', generatedClass);
+		const generatedScope = compiled.code!.indexOf('tsrx-', generatedDemo);
+
+		expect(scoped?.pairFromSource(sourceClass)).toEqual({
+			source: [{ from: sourceClass, to: sourceClass + 'class'.length }],
+			output: [{ from: generatedClass, to: generatedClass + 'class'.length }],
+		});
+		expect(scoped?.pairFromSource(sourceDemo)).toEqual({
+			source: [{ from: sourceDemo, to: sourceDemo + 'demo'.length }],
+			output: [{ from: generatedDemo, to: generatedDemo + 'demo'.length }],
+		});
+		expect(scoped?.pairFromGenerated(generatedScope)).toBeNull();
 	});
 
 	it('does not interpolate across source text without an anchor', () => {

--- a/website/tests/playground-mapping.test.ts
+++ b/website/tests/playground-mapping.test.ts
@@ -228,6 +228,25 @@ describe('client output mapping (compiler source map)', () => {
 		expect(scoped?.pairFromGenerated(generatedScope)).toBeNull();
 	});
 
+	it('keeps anchors after textarea pseudo-markup synchronized', () => {
+		const source = `export function App() @{
+	<div>
+		<textarea><fake data-x="bad"></fake></textarea>
+		<span data-after="ok">after</span>
+	</div>
+}`;
+		const compiled = compileAst(source, 'App.tsrx', 'client-output');
+		if (!compiled.ok) throw new Error(compiled.error);
+		const textareaMapping = mappingFromSourceMap(compiled.map, source, compiled.code!);
+		const sourceAttribute = source.indexOf('data-after');
+		const generatedAttribute = compiled.code!.indexOf('data-after');
+
+		expect(textareaMapping?.pairFromSource(sourceAttribute)).toEqual({
+			source: [{ from: sourceAttribute, to: sourceAttribute + 'data-after'.length }],
+			output: [{ from: generatedAttribute, to: generatedAttribute + 'data-after'.length }],
+		});
+	});
+
 	it('does not interpolate across source text without an anchor', () => {
 		const blankLine = SOURCE.indexOf('\n\n\t<div>') + 1;
 		expect(mapping?.toGenerated(blankLine)).toBeNull();

--- a/website/tests/ssr-hydration.e2e.test.ts
+++ b/website/tests/ssr-hydration.e2e.test.ts
@@ -1147,13 +1147,14 @@ describe.sequential('website production build → hydration (Nitro Vercel previe
 					.first()
 					.evaluate((element) => getComputedStyle(element).backgroundColor),
 			).toBe('rgba(255, 234, 0, 0.42)');
-			// Client output bakes static JSX into one template Literal. Its AST
-			// reveal must preserve the exact tag that initiated navigation instead
-			// of falling back to the template's first source-map anchor.
+			// Client output keeps the exact Literal but enriches it with granular
+			// template nodes, so the initiating tag resolves to its own identifier.
 			await page.locator('[aria-label="AST compiler stage"]').selectOption('client-output');
 			await hoverToken(0, 'button', 2);
 			await mappedIn(0, 'button');
-			expect(await page.locator('.pg-ast-status').textContent()).toContain('Literal');
+			expect(await page.locator('.pg-ast-status').textContent()).toContain(
+				'OctaneTemplateIdentifier',
+			);
 			await page.locator('[aria-label="AST compiler stage"]').selectOption('source');
 			// Types swaps the pane to the typed virtual TSX (the language-service
 			// view), without recompiling the preview.


### PR DESCRIPTION
## What changed

- adds an inspection-only `astTrace` client output with granular template nodes
- builds the inspected AST with the TSRX 0.1.47 builders and cloning helpers
- maps host tags and static attributes between source, generated output, and AST
- updates the playground to consume the compiler-provided AST directly
- preserves the last valid Types document when an inspection compile fails

## Why

Hoisted templates are optimized into one string literal. The previous preview could therefore select only an entire subtree, making individual JSX tags and attributes impossible to trace precisely.

## Performance

Normal and inspection compiles generate byte-identical application code. On a stress fixture with 4,003 elements and 4,002 attributes, the compiler median was 547.7 ms normally and 597.4 ms with inspection enabled (+9.1%, inspection gate only). Normal runtime and build output have no AST inspection overhead.

## Validation

- focused compiler/playground suites: 31/31 passed
- Octane package build passed
- repository typecheck passed
- production Chromium playground E2E passed
- repository-wide format check passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new inspection path in the core client compiler, but it is strictly opt-in and does not change default emit; mapping edge cases could affect playground navigation only when `astTrace` is enabled.
> 
> **Overview**
> Replaces the inspection-only **`sourceMapHostTags`** flag with **`astTrace`**, which still emits **byte-identical** client code but additionally returns a **`generatedAst`** parsed from the real output and enriched with **`OctaneTemplate*`** nodes (elements, attributes, text, comments, markers) under hoisted template literals.
> 
> Inspection compiles **clone** the parser AST, walk baked template HTML (including textarea/script/title and SVG quirks), record **source-map anchors** for host tag names plus **authored static** attribute names/values (not scoped `tsrx-*` class injection or HTML-escaped values), then **materialize** template subtrees onto the parsed output with correct generated ranges. The playground **client-output** stage consumes this AST directly instead of re-parsing via Volar, and keeps the **last valid Types** document when a types compile fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a11f311a12e22f2edeca3ba548dbca99b3f4f884. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->