### PR TITLE
Fix warmed SSR computed props and harden regressions

### DIFF
--- a/.changeset/warm-computed-props.md
+++ b/.changeset/warm-computed-props.md
@@ -1,0 +1,6 @@
+---
+'octane': patch
+---
+
+Reuse warmed SSR fetches when child components read statically named computed
+props such as `props['aria-label']`.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -8408,26 +8408,31 @@ function isFreshBindingExpr(node) {
 	);
 }
 
+function depPathMember(node) {
+	const expression = node?.type === 'ChainExpression' ? node.expression : node;
+	return expression?.type === 'MemberExpression' ? expression : null;
+}
+
 function staticDepMemberName(node) {
-	if (node?.type !== 'MemberExpression') return null;
-	if (!node.computed && node.property.type === 'Identifier') return node.property.name;
+	const member = depPathMember(node);
+	if (member === null) return null;
+	if (!member.computed && member.property.type === 'Identifier') return member.property.name;
 	if (
-		node.computed &&
-		node.property.type === 'Literal' &&
-		typeof node.property.value === 'string'
+		member.computed &&
+		member.property.type === 'Literal' &&
+		typeof member.property.value === 'string'
 	) {
-		return node.property.value;
+		return member.property.value;
 	}
 	return null;
 }
 
 function depPathKey(node) {
 	if (node.type === 'Identifier') return `identifier:${node.name}`;
+	const member = depPathMember(node);
 	const propertyName = staticDepMemberName(node);
-	return node.type === 'MemberExpression' &&
-		node.object.type === 'Identifier' &&
-		propertyName !== null
-		? `member:${node.object.name}:${JSON.stringify(propertyName)}`
+	return member !== null && member.object.type === 'Identifier' && propertyName !== null
+		? `member:${member.object.name}:${JSON.stringify(propertyName)}`
 		: null;
 }
 
@@ -8461,7 +8466,7 @@ function collectDepPaths(expr) {
 				const propertyName = staticDepMemberName(n);
 				if (n.object.type === 'Identifier' && propertyName !== null) {
 					if (!bound.has(n.object.name)) {
-						const dep = {
+						const member = {
 							type: 'MemberExpression',
 							object: { type: 'Identifier', name: n.object.name },
 							property: n.computed
@@ -8474,6 +8479,10 @@ function collectDepPaths(expr) {
 							computed: n.computed,
 							optional: n.optional === true,
 						};
+						// Optional MemberExpressions must remain inside a ChainExpression.
+						// Besides keeping the synthesized tree valid ESTree, the wrapper
+						// preserves optional-evaluation semantics through later AST passes.
+						const dep = member.optional ? { type: 'ChainExpression', expression: member } : member;
 						push(dep, depPathKey(dep));
 					}
 					return;
@@ -8728,9 +8737,10 @@ function makeCreationMemoCall(
 		const seen = new Set();
 		const coarsened = [];
 		for (const dep of deps) {
+			const member = depPathMember(dep);
 			const next =
-				dep.type === 'MemberExpression' && coarsenDepRoots.has(dep.object.name)
-					? { type: 'Identifier', name: dep.object.name }
+				member?.object.type === 'Identifier' && coarsenDepRoots.has(member.object.name)
+					? { type: 'Identifier', name: member.object.name }
 					: dep;
 			const key = depPathKey(next);
 			if (key !== null && seen.has(key)) continue;

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -8408,10 +8408,34 @@ function isFreshBindingExpr(node) {
 	);
 }
 
+function staticDepMemberName(node) {
+	if (node?.type !== 'MemberExpression') return null;
+	if (!node.computed && node.property.type === 'Identifier') return node.property.name;
+	if (
+		node.computed &&
+		node.property.type === 'Literal' &&
+		typeof node.property.value === 'string'
+	) {
+		return node.property.value;
+	}
+	return null;
+}
+
+function depPathKey(node) {
+	if (node.type === 'Identifier') return `identifier:${node.name}`;
+	const propertyName = staticDepMemberName(node);
+	return node.type === 'MemberExpression' &&
+		node.object.type === 'Identifier' &&
+		propertyName !== null
+		? `member:${node.object.name}:${JSON.stringify(propertyName)}`
+		: null;
+}
+
 // Dep extraction for a memoized creation: one-level member paths for free
-// identifiers used as `obj.prop` (→ `props.id`, so a fresh props OBJECT with
-// unchanged fields doesn't refetch), bare identifiers otherwise. Scope-aware:
-// identifiers bound inside nested functions don't become deps.
+// identifiers used as `obj.prop` or `obj['prop']` (→ `props.id`, so a fresh
+// props OBJECT with unchanged fields doesn't refetch), bare identifiers
+// otherwise. Scope-aware: identifiers bound inside nested functions don't
+// become deps.
 function collectDepPaths(expr) {
 	const deps = [];
 	const seen = new Set();
@@ -8433,26 +8457,31 @@ function collectDepPaths(expr) {
 			case 'Identifier':
 				if (!bound.has(n.name)) push({ type: 'Identifier', name: n.name }, n.name);
 				return;
-			case 'MemberExpression':
-				if (!n.computed && n.object.type === 'Identifier' && n.property.type === 'Identifier') {
+			case 'MemberExpression': {
+				const propertyName = staticDepMemberName(n);
+				if (n.object.type === 'Identifier' && propertyName !== null) {
 					if (!bound.has(n.object.name)) {
-						const key = n.object.name + '.' + n.property.name;
-						push(
-							{
-								type: 'MemberExpression',
-								object: { type: 'Identifier', name: n.object.name },
-								property: { type: 'Identifier', name: n.property.name },
-								computed: false,
-								optional: false,
-							},
-							key,
-						);
+						const dep = {
+							type: 'MemberExpression',
+							object: { type: 'Identifier', name: n.object.name },
+							property: n.computed
+								? {
+										type: 'Literal',
+										value: propertyName,
+										raw: JSON.stringify(propertyName),
+									}
+								: { type: 'Identifier', name: propertyName },
+							computed: n.computed,
+							optional: n.optional === true,
+						};
+						push(dep, depPathKey(dep));
 					}
 					return;
 				}
 				walk(n.object, bound);
 				if (n.computed) walk(n.property, bound);
 				return;
+			}
 			case 'FunctionExpression':
 			case 'ArrowFunctionExpression': {
 				const inner = new Set(bound);
@@ -8703,10 +8732,9 @@ function makeCreationMemoCall(
 				dep.type === 'MemberExpression' && coarsenDepRoots.has(dep.object.name)
 					? { type: 'Identifier', name: dep.object.name }
 					: dep;
-			const key =
-				next.type === 'Identifier' ? next.name : `${next.object.name}.${next.property.name}`;
-			if (seen.has(key)) continue;
-			seen.add(key);
+			const key = depPathKey(next);
+			if (key !== null && seen.has(key)) continue;
+			if (key !== null) seen.add(key);
 			coarsened.push(next);
 		}
 		deps = coarsened;

--- a/packages/octane/tests/_fixtures/control-fold.tsrx
+++ b/packages/octane/tests/_fixtures/control-fold.tsrx
@@ -4,6 +4,7 @@ import {
 	cloneElement,
 	createContext,
 	createElement,
+	type OctaneNode,
 	use,
 	useState,
 } from 'octane';
@@ -270,6 +271,52 @@ export function ReturnedChildCodeBlock(props) {
 			<button id="child-code-block-action" onClick={props.onAction}>{props.label as string}</button>
 		}
 	</>;
+}
+
+function ValueTemplatePropHost(props: { content: OctaneNode }) {
+	return <main id="setup-value-prop-host">{props.content}</main>;
+}
+
+// Passing a setup JSX value through a component prop must preserve the authored
+// descriptor and the compiler-owned directive region nested inside it.
+export function ValueTemplatePropSlot(props: {
+	showHeading: boolean;
+	heading: string;
+}) @{
+	const content = <section id="setup-value-prop-content">
+		<span id="setup-value-prop-before">Before</span>
+
+		@if (props.showHeading) {
+			<h1 id="setup-value-prop-heading">{props.heading}</h1>
+		}
+
+		<span id="setup-value-prop-after">After</span>
+	</section>;
+
+	<ValueTemplatePropHost content={content} />
+}
+
+// Directive arms retain their ordinary setup/output split when they are nested
+// in a stored descriptor: the callback expression executes but does not render,
+// while the explicit fragment is the rendered value.
+export function ValueTemplateExpressionSemantics(props: {
+	visible: boolean;
+	setupValue: string;
+	output: string;
+	observe: (value: string) => string;
+}) @{
+	const content = <section id="setup-value-expression-semantics">
+		@if (props.visible) {
+			props.observe(props.setupValue);
+		}
+		@if (props.visible) {
+			<>
+				{props.output}
+			</>
+		}
+	</section>;
+
+	<main>{content}</main>
 }
 
 // The object wrapper mirrors component-slot composition used by consumers. Its

--- a/packages/octane/tests/_fixtures/multiline-string-attr.tsrx
+++ b/packages/octane/tests/_fixtures/multiline-string-attr.tsrx
@@ -1,8 +1,27 @@
 // Fixture for multi-line JSX string attributes (see
 // multiline-string-attrs.test.ts). The spread forces the hostValue binding
-// path; the component prop exercises the createElement/prop-bag paths.
-function Chip(props: { title?: string }) {
-	return <span>{props.title as string}</span>;
+// path; the component props exercise the createElement/prop-bag and server
+// warm-child paths, including prop names that are not JavaScript identifiers.
+import { use } from 'octane';
+
+type WarmPropInput = {
+	'aria-label': string;
+	'data-testid': string;
+	title: string;
+};
+
+type WarmPropLoader = (ariaLabel: string, dataTestId: string, title: string) => Promise<string>;
+
+function Chip(props: {
+	'aria-label': string;
+	'data-testid': string;
+	title: string;
+}) {
+	return <span
+		aria-label={props['aria-label']}
+		data-testid={props['data-testid']}
+		data-title={props.title}
+	>{props.title as string}</span>;
 }
 
 export function SpreadHost(props: { rest?: Record<string, string> }) {
@@ -11,6 +30,44 @@ export function SpreadHost(props: { rest?: Record<string, string> }) {
 }
 
 export function PropChip() {
-	return <Chip title="one
-		two" />;
+	return <Chip aria-label="accessible
+				chip" data-testid="multiline-prop-chip" title="one
+				two" />;
+}
+
+function WarmPropChip(props: WarmPropInput & { load: WarmPropLoader }) {
+	const value = use(props.load(props['aria-label'], props['data-testid'], props.title));
+	return <span data-warm-result={value}>{props.title as string}</span>;
+}
+
+export function WarmPropPage(props: { load: WarmPropLoader }) @{
+	<main>
+		@try {
+			<WarmPropChip
+				aria-label="accessible
+					chip"
+				data-testid="warmed-multiline-prop-chip"
+				title="one
+					two"
+				load={props.load}
+			/>
+		} @pending {
+			<i>pending</i>
+		}
+	</main>
+}
+
+export function OptionalComputedPropPage(props: {
+	metadata: { 'aria-label': string } | null;
+	load: (label: string) => Promise<string>;
+}) @{
+	const metadata = props.metadata;
+	<main>
+		@try {
+			const value = use(props.load(metadata?.['aria-label'] ?? 'fallback'));
+			<span data-optional-computed-result={value}>{value as string}</span>
+		} @pending {
+			<i>pending</i>
+		}
+	</main>
 }

--- a/packages/octane/tests/_fixtures/permanent-static-browser.tsrx
+++ b/packages/octane/tests/_fixtures/permanent-static-browser.tsrx
@@ -1,0 +1,48 @@
+import { Hydrate, useId } from 'octane';
+import { never } from 'octane/hydration';
+
+function StaticHtml(props: { onRender?: () => void }) @{
+	const id = useId();
+	props.onRender?.();
+	<article id="static-browser-article" data-static-id={id}>
+		<div id="externally-owned-range">
+			<span id="server-owned-initial">Server-owned initial content</span>
+		</div>
+	</article>
+}
+
+function LiveAction(props: { label: string; onClick?: (id: string) => void }) @{
+	const id = useId();
+	<button
+		id="static-browser-live-action"
+		data-runtime-id={id}
+		onClick={() => props.onClick?.(id)}
+	>{props.label}</button>
+}
+
+export function PermanentStaticBrowser(props: {
+	label: string;
+	onStaticRender?: () => void;
+	onLiveClick?: (id: string) => void;
+}) @{
+	<main id="static-browser-layout">
+		<Hydrate split={false} when={never()}>
+			<StaticHtml onRender={props.onStaticRender} />
+		</Hydrate>
+		<svg id="static-browser-svg" viewBox="0 0 10 10">
+			<Hydrate split={false} when={never()}>
+				<g id="static-browser-svg-group">
+					<circle cx="5" cy="5" r="4" />
+				</g>
+			</Hydrate>
+		</svg>
+		<math id="static-browser-math">
+			<Hydrate split={false} when={never()}>
+				<mrow id="static-browser-math-row">
+					<mi>{'x'}</mi>
+				</mrow>
+			</Hydrate>
+		</math>
+		<LiveAction label={props.label} onClick={props.onLiveClick} />
+	</main>
+}

--- a/packages/octane/tests/_fixtures/script-innerhtml.tsrx
+++ b/packages/octane/tests/_fixtures/script-innerhtml.tsrx
@@ -14,6 +14,10 @@ export interface ScriptSpreadProps {
 	spread: { dangerouslySetInnerHTML?: { __html: string } | null };
 }
 
+export interface ConditionalSpreadScriptProps extends ScriptSpreadProps {
+	show: boolean;
+}
+
 export function ExecutableScript(props: ScriptSourceProps) @{
 	<script data-kind="executable" dangerouslySetInnerHTML={{ __html: props.source }} />
 }
@@ -32,6 +36,13 @@ export function SpeculationRules(props: ScriptValueProps) @{
 		data-kind="speculationrules"
 		dangerouslySetInnerHTML={{ __html: JSON.stringify(props.value) }}
 	/>
+}
+
+export function ConditionalSpreadScript(props: ConditionalSpreadScriptProps) @{
+	<section>
+		{props.show &&
+			<script type="application/json" data-kind="conditional-spread" {...props.spread} />}
+	</section>
 }
 
 export function StaticScript() @{

--- a/packages/octane/tests/_fixtures/use-chain-memo.tsrx
+++ b/packages/octane/tests/_fixtures/use-chain-memo.tsrx
@@ -109,6 +109,27 @@ export function SwitchingChainHost({
 	}
 }
 
+function OptionalDerivedChainReader(props: {
+	fetchUser: (id: string) => Promise<{ v: string }> | null;
+	id: string;
+}) @{
+	const base = props.fetchUser(props.id);
+	const derived = base?.then((value) => value.v);
+	if (derived === undefined) throw new Error('fetchUser returned no promise');
+	<p id="optional-derived-chain">{use(derived) as string}</p>
+}
+
+export function OptionalDerivedChainHost(props: {
+	fetchUser: (id: string) => Promise<{ v: string }> | null;
+	id: string;
+}) @{
+	@try {
+		<OptionalDerivedChainReader fetchUser={props.fetchUser} id={props.id} />
+	} @pending {
+		<p>loading</p>
+	}
+}
+
 // A chain const declared in an `else if` arm — the alternate is an
 // IfStatement, not a block, and must still be reached by the taint pass.
 function BranchReader({

--- a/packages/octane/tests/_fixtures/use-chain-memo.tsrx
+++ b/packages/octane/tests/_fixtures/use-chain-memo.tsrx
@@ -51,6 +51,27 @@ export function PropChainHost({
 	}
 }
 
+function ComputedPropChainReader(props: {
+	'data-a': string;
+	'data-b': string;
+	load: (a: string, b: string) => Promise<string>;
+}) @{
+	const request = props.load(props['data-a'], props['data-b']);
+	<p id="computed-prop-chain">{use(request) as string}</p>
+}
+
+export function ComputedPropChainHost(props: {
+	'data-a': string;
+	'data-b': string;
+	load: (a: string, b: string) => Promise<string>;
+}) @{
+	@try {
+		<ComputedPropChainReader data-a={props['data-a']} data-b={props['data-b']} load={props.load} />
+	} @pending {
+		<p>loading</p>
+	}
+}
+
 function SwitchingChainReader({
 	fetchA,
 	fetchB,

--- a/packages/octane/tests/browser/permanent-static/index.html
+++ b/packages/octane/tests/browser/permanent-static/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Octane permanent-static hydration</title>
+	</head>
+	<body>
+		<div id="root"><!--octane-ssr--></div>
+		<script type="module" src="/main.ts"></script>
+	</body>
+</html>

--- a/packages/octane/tests/browser/permanent-static/main.ts
+++ b/packages/octane/tests/browser/permanent-static/main.ts
@@ -1,0 +1,77 @@
+import { flushSync, hydrateRoot } from '../../../src/index.js';
+import { PermanentStaticBrowser } from '../../_fixtures/permanent-static-browser.tsrx';
+
+const container = document.querySelector('#root')!;
+const layout = container.querySelector('#static-browser-layout')!;
+const article = container.querySelector('#static-browser-article')!;
+const svgGroup = container.querySelector('#static-browser-svg-group')!;
+const mathRow = container.querySelector('#static-browser-math-row')!;
+const liveAction = container.querySelector('#static-browser-live-action') as HTMLButtonElement;
+const liveId = liveAction.dataset.runtimeId;
+
+const external = document.createElement('strong');
+external.id = 'external-before-hydration';
+external.textContent = 'Externally managed before hydration';
+container.querySelector('#externally-owned-range')!.replaceChildren(external);
+
+let staticRenderCount = 0;
+let clickedId: string | null = null;
+const props = {
+	label: 'Server live action',
+	onStaticRender: () => staticRenderCount++,
+	onLiveClick: (id: string) => (clickedId = id),
+};
+const root = hydrateRoot(container, PermanentStaticBrowser, props);
+flushSync(() => {});
+flushSync(() =>
+	root.render(PermanentStaticBrowser, {
+		...props,
+		label: 'Updated live action',
+	}),
+);
+
+function state() {
+	const currentLayout = container.querySelector('#static-browser-layout')!;
+	const currentArticle = container.querySelector('#static-browser-article');
+	const currentSvgGroup = container.querySelector('#static-browser-svg-group');
+	const currentMathRow = container.querySelector('#static-browser-math-row');
+	const currentLiveAction = container.querySelector(
+		'#static-browser-live-action',
+	) as HTMLButtonElement;
+	return {
+		childIds: Array.from(currentLayout.children, (child) => child.id),
+		externalPreserved:
+			container.querySelector('#external-before-hydration') === external &&
+			external.parentElement?.id === 'externally-owned-range',
+		identity: {
+			article: currentArticle === article,
+			layout: currentLayout === layout,
+			liveAction: currentLiveAction === liveAction,
+			mathRow: currentMathRow === mathRow,
+			svgGroup: currentSvgGroup === svgGroup,
+		},
+		live: {
+			clickedId,
+			id: currentLiveAction.dataset.runtimeId,
+			label: currentLiveAction.textContent,
+			serverId: liveId,
+		},
+		namespaces: {
+			math: currentMathRow?.namespaceURI,
+			svg: currentSvgGroup?.namespaceURI,
+		},
+		wrapperFree: {
+			math: container.querySelector('#static-browser-math')?.firstElementChild === currentMathRow,
+			svg: container.querySelector('#static-browser-svg')?.firstElementChild === currentSvgGroup,
+		},
+		staticRenderCount,
+	};
+}
+
+window.__permanentStaticBrowser = { state };
+
+declare global {
+	interface Window {
+		__permanentStaticBrowser: { state: typeof state };
+	}
+}

--- a/packages/octane/tests/browser/permanent-static/permanent-static.test.ts
+++ b/packages/octane/tests/browser/permanent-static/permanent-static.test.ts
@@ -1,0 +1,127 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { chromium, type Browser, type Page } from 'playwright';
+import { createServer, type Plugin, type ViteDevServer } from 'vite';
+import { renderToString } from 'octane/server';
+import { octane } from 'octane/compiler/vite';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadServerFixture } from '../../_server-fixture.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = 'packages/octane/tests/_fixtures/permanent-static-browser.tsrx';
+
+let browser: Browser;
+
+beforeAll(async () => {
+	try {
+		browser = await chromium.launch({ headless: true });
+	} catch (error) {
+		throw new Error(
+			`Chromium is required for permanent-static browser evidence (run \`pnpm --filter octane exec playwright install chromium\`): ${String(error)}`,
+		);
+	}
+});
+
+afterAll(async () => {
+	await browser?.close();
+});
+
+async function openHydratedPage(mode: 'dev' | 'prod'): Promise<{
+	failures: string[];
+	page: Page;
+	server: ViteDevServer;
+}> {
+	const serverModule = loadServerFixture(FIXTURE, {
+		id: `/permanent-static-browser-${mode}.tsrx`,
+		compileOptions: mode === 'prod' ? { hmr: false } : {},
+	});
+	const { html } = renderToString(serverModule.PermanentStaticBrowser, {
+		label: 'Server live action',
+		onStaticRender: () => {},
+	});
+	const shellPlugin: Plugin = {
+		name: 'permanent-static-browser-shell',
+		transformIndexHtml(source) {
+			return source.replace('<!--octane-ssr-->', () => html);
+		},
+	};
+	const server = await createServer({
+		configFile: false,
+		root: HERE,
+		logLevel: 'error',
+		plugins: [shellPlugin, octane(mode === 'prod' ? { hmr: false } : {})],
+		server: { host: '127.0.0.1', port: 0 },
+	});
+	const failures: string[] = [];
+	let page: Page | undefined;
+	try {
+		await server.listen();
+		const address = server.httpServer!.address();
+		if (!address || typeof address === 'string') {
+			throw new Error('Vite did not expose a TCP port');
+		}
+
+		page = await browser.newPage();
+		page.on('pageerror', (error) => failures.push(`pageerror: ${error.message}`));
+		page.on('console', (message) => {
+			if (message.type() === 'error' || message.type() === 'warning') {
+				failures.push(`${message.type()}: ${message.text()}`);
+			}
+		});
+		await page.goto(`http://127.0.0.1:${address.port}`);
+		await page.waitForFunction(() => Boolean(window.__permanentStaticBrowser));
+		return { failures, page, server };
+	} catch (error) {
+		await Promise.allSettled([page?.close(), server.close()]);
+		throw error;
+	}
+}
+
+describe.sequential('permanent-static real-browser hydration', () => {
+	for (const mode of ['dev', 'prod'] as const) {
+		it(`${mode} preserves wrapper-free foreign and externally managed DOM`, async () => {
+			const { failures, page, server } = await openHydratedPage(mode);
+			try {
+				const initial = await page.evaluate(() => window.__permanentStaticBrowser.state());
+				expect(initial).toMatchObject({
+					childIds: [
+						'static-browser-article',
+						'static-browser-svg',
+						'static-browser-math',
+						'static-browser-live-action',
+					],
+					externalPreserved: true,
+					identity: {
+						article: true,
+						layout: true,
+						liveAction: true,
+						mathRow: true,
+						svgGroup: true,
+					},
+					live: {
+						clickedId: null,
+						label: 'Updated live action',
+					},
+					namespaces: {
+						math: 'http://www.w3.org/1998/Math/MathML',
+						svg: 'http://www.w3.org/2000/svg',
+					},
+					wrapperFree: {
+						math: true,
+						svg: true,
+					},
+					staticRenderCount: 0,
+				});
+				expect(initial.live.id).toBe(initial.live.serverId);
+
+				await page.locator('#static-browser-live-action').click();
+				const afterClick = await page.evaluate(() => window.__permanentStaticBrowser.state());
+				expect(afterClick.live.clickedId).toBe(afterClick.live.id);
+				expect(afterClick.externalPreserved).toBe(true);
+				expect(failures).toEqual([]);
+			} finally {
+				await Promise.all([page.close(), server.close()]);
+			}
+		});
+	}
+});

--- a/packages/octane/tests/control-fold.test.ts
+++ b/packages/octane/tests/control-fold.test.ts
@@ -23,6 +23,8 @@ import {
 	DescriptorHostWithKeyedFragment,
 	DescriptorHostWithKeyedComponents,
 	ReturnedChildCodeBlock,
+	ValueTemplatePropSlot,
+	ValueTemplateExpressionSemantics,
 	ValueTemplateSlot,
 	ClonedValueTemplateSlot,
 	ValueTemplateSvg,
@@ -822,6 +824,124 @@ describe('template directives in JSX setup values', () => {
 		result.unmount();
 	});
 
+	it('passes a stored descriptor through a component prop and updates it in place', () => {
+		const result = mount(ValueTemplatePropSlot, {
+			showHeading: true,
+			heading: 'First prop heading',
+		});
+		const host = result.find('#setup-value-prop-host');
+		const content = result.find('#setup-value-prop-content');
+		const before = result.find('#setup-value-prop-before');
+		const heading = result.find('#setup-value-prop-heading');
+		const after = result.find('#setup-value-prop-after');
+
+		result.update(ValueTemplatePropSlot, {
+			showHeading: true,
+			heading: 'Updated prop heading',
+		});
+		expect(result.find('#setup-value-prop-host')).toBe(host);
+		expect(result.find('#setup-value-prop-content')).toBe(content);
+		expect(result.find('#setup-value-prop-before')).toBe(before);
+		expect(result.find('#setup-value-prop-heading')).toBe(heading);
+		expect(heading.textContent).toBe('Updated prop heading');
+		expect(result.find('#setup-value-prop-after')).toBe(after);
+
+		result.update(ValueTemplatePropSlot, {
+			showHeading: false,
+			heading: 'Hidden prop heading',
+		});
+		expect(result.findAll('#setup-value-prop-heading')).toHaveLength(0);
+		expect(result.find('#setup-value-prop-host')).toBe(host);
+		expect(result.find('#setup-value-prop-content')).toBe(content);
+		expect(result.find('#setup-value-prop-before')).toBe(before);
+		expect(result.find('#setup-value-prop-after')).toBe(after);
+
+		result.update(ValueTemplatePropSlot, {
+			showHeading: true,
+			heading: 'Restored prop heading',
+		});
+		expect(result.find('#setup-value-prop-heading').textContent).toBe('Restored prop heading');
+		expect(result.find('#setup-value-prop-host')).toBe(host);
+		expect(result.find('#setup-value-prop-content')).toBe(content);
+		result.unmount();
+	});
+
+	it('server-renders and hydrates a component-prop descriptor in place', async () => {
+		const server = serverModule();
+		const props = { showHeading: true, heading: 'Server prop heading' };
+		const { html } = await ServerRT.renderToString(server.ValueTemplatePropSlot, props);
+
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		container.innerHTML = html;
+		const host = container.querySelector('#setup-value-prop-host');
+		const content = container.querySelector('#setup-value-prop-content');
+		const before = container.querySelector('#setup-value-prop-before');
+		const heading = container.querySelector('#setup-value-prop-heading');
+		const after = container.querySelector('#setup-value-prop-after');
+		expect(host).not.toBeNull();
+		expect(content).not.toBeNull();
+		expect(before?.textContent).toBe('Before');
+		expect(heading?.textContent).toBe('Server prop heading');
+		expect(after?.textContent).toBe('After');
+		const root = hydrateRoot(container, ValueTemplatePropSlot, props);
+		flushSync(() => {});
+
+		expect(container.querySelector('#setup-value-prop-host')).toBe(host);
+		expect(container.querySelector('#setup-value-prop-content')).toBe(content);
+		expect(container.querySelector('#setup-value-prop-before')).toBe(before);
+		expect(container.querySelector('#setup-value-prop-heading')).toBe(heading);
+		expect(container.querySelector('#setup-value-prop-after')).toBe(after);
+
+		root.render(ValueTemplatePropSlot, {
+			showHeading: true,
+			heading: 'Hydrated prop heading',
+		});
+		flushSync(() => {});
+		expect(container.querySelector('#setup-value-prop-host')).toBe(host);
+		expect(container.querySelector('#setup-value-prop-content')).toBe(content);
+		expect(container.querySelector('#setup-value-prop-heading')).toBe(heading);
+		expect(heading?.textContent).toBe('Hydrated prop heading');
+		root.unmount();
+		container.remove();
+	});
+
+	it('keeps bare expressions setup-only and renders explicit fragments', () => {
+		const observed = new Set<string>();
+		const observe = (value: string) => {
+			observed.add(value);
+			return 'setup result: ' + value;
+		};
+		const result = mount(ValueTemplateExpressionSemantics, {
+			visible: true,
+			setupValue: 'first setup',
+			output: 'First output',
+			observe,
+		});
+
+		expect(observed.has('first setup')).toBe(true);
+		expect(result.find('#setup-value-expression-semantics').textContent).toBe('First output');
+
+		result.update(ValueTemplateExpressionSemantics, {
+			visible: false,
+			setupValue: 'hidden setup',
+			output: 'Hidden output',
+			observe,
+		});
+		expect(observed.has('hidden setup')).toBe(false);
+		expect(result.find('#setup-value-expression-semantics').textContent).toBe('');
+
+		result.update(ValueTemplateExpressionSemantics, {
+			visible: true,
+			setupValue: 'restored setup',
+			output: 'Restored output',
+			observe,
+		});
+		expect(observed.has('restored setup')).toBe(true);
+		expect(result.find('#setup-value-expression-semantics').textContent).toBe('Restored output');
+		result.unmount();
+	});
+
 	it('preserves the outer descriptor in return-JSX setup and cloneElement', async () => {
 		const hostRef = { current: null as HTMLElement | null };
 		const props = {
@@ -994,6 +1114,33 @@ describe('template directives in JSX setup values', () => {
 		expect(container.querySelector('#setup-value-mode')?.textContent).toBe('Secondary');
 		root.unmount();
 		container.remove();
+	});
+
+	it('switches a stored keyed list through @empty and back to nonempty', () => {
+		const items = [
+			{ id: 'a', label: 'A' },
+			{ id: 'b', label: 'B' },
+		];
+		const result = mount(ValueTemplateMatrix, { items, mode: 'primary' });
+		const matrix = result.find('#setup-value-matrix');
+		const firstA = result.find('[data-id="a"]');
+		result.click('[data-id="a"]');
+		expect(firstA.textContent).toBe('A:1');
+
+		result.update(ValueTemplateMatrix, { items: [], mode: 'primary' });
+		expect(result.find('#setup-value-matrix')).toBe(matrix);
+		expect(result.findAll('.setup-value-row')).toHaveLength(0);
+		expect(result.find('#setup-value-empty').textContent).toBe('empty');
+
+		result.update(ValueTemplateMatrix, { items, mode: 'primary' });
+		expect(result.find('#setup-value-matrix')).toBe(matrix);
+		expect(result.findAll('#setup-value-empty')).toHaveLength(0);
+		expect(result.findAll('.setup-value-row').map((row) => row.textContent)).toEqual([
+			'A:0',
+			'B:0',
+		]);
+		expect(result.find('[data-id="a"]')).not.toBe(firstA);
+		result.unmount();
 	});
 });
 

--- a/packages/octane/tests/multiline-string-attrs.test.ts
+++ b/packages/octane/tests/multiline-string-attrs.test.ts
@@ -1,10 +1,26 @@
-import { describe, expect, it } from 'vitest';
-import { compile } from 'octane/compiler';
+import { describe, expect, it, vi } from 'vitest';
+import { flushSync, hydrateRoot } from 'octane';
+import { renderToString } from 'octane/server';
+import { prerender } from 'octane/static';
 import { mount } from './_helpers.js';
-// Client compile of a fixture using every affected path: importing it at all
-// proves the emission is valid JS (an unescaped newline would be a module-load
-// SyntaxError).
-import { SpreadHost, PropChip } from './_fixtures/multiline-string-attr.tsrx';
+import { loadServerFixture } from './_server-fixture.js';
+import * as client from './_fixtures/multiline-string-attr.tsrx';
+
+const FIXTURE = 'packages/octane/tests/_fixtures/multiline-string-attr.tsrx';
+const server = loadServerFixture<typeof client>(FIXTURE);
+const MULTILINE_VALUE = 'one\n\t\t\t\ttwo';
+const MULTILINE_LABEL = 'accessible\n\t\t\t\tchip';
+const WARM_DATA_TESTID = 'warmed-multiline-prop-chip';
+const WARM_MULTILINE_VALUE = 'one\n\t\t\t\t\ttwo';
+const WARM_MULTILINE_LABEL = 'accessible\n\t\t\t\t\tchip';
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((fulfill) => {
+		resolve = fulfill;
+	});
+	return { promise, resolve };
+}
 
 // JSX string ATTRIBUTES may legally span lines (multi-line class strings are
 // common in Tailwind-heavy React code — tanstack.com's homepage has several).
@@ -13,25 +29,8 @@ import { SpreadHost, PropChip } from './_fixtures/multiline-string-attr.tsrx';
 // hostValue/spread binding path (printExpr), the createElement de-opt path,
 // and the SSR warm-child plan. Found porting tanstack.com (Phase 2c).
 describe('multi-line JSX string attributes', () => {
-	const MULTILINE =
-		'export function App(props: any) {\n\treturn (\n\t\t<div {...props.rest} class="one\n\t\ttwo" />\n\t);\n}\n';
-	const PROP =
-		'function Chip(props: any) { return <span>{props.title as string}</span>; }\nexport function App() {\n\treturn <Chip title="one\n\ttwo" />;\n}\n';
-
-	it('client + server compiles emit loadable JS for every affected path', () => {
-		for (const src of [MULTILINE, PROP]) {
-			for (const mode of [undefined, 'server'] as const) {
-				const { code } = compile(src, 'App.tsrx', mode ? { mode } : {});
-				// The literal must appear escaped, never as a raw line break
-				// inside a quoted string.
-				expect(code).not.toMatch(/"one\n/);
-				expect(code).not.toMatch(/'one\n/);
-			}
-		}
-	});
-
 	it('the multi-line value round-trips to the DOM intact', () => {
-		const mounted = mount(SpreadHost as any, { rest: { 'data-x': '1' } });
+		const mounted = mount(client.SpreadHost as any, { rest: { 'data-x': '1' } });
 		try {
 			expect(mounted.find('div').getAttribute('class')).toBe('one\n\t\ttwo');
 		} finally {
@@ -40,29 +39,106 @@ describe('multi-line JSX string attributes', () => {
 	});
 
 	it('component props carry the multi-line string intact', () => {
-		const mounted = mount(PropChip as any, {});
+		const mounted = mount(client.PropChip as any, {});
 		try {
-			expect(mounted.find('span').textContent).toBe('one\n\t\ttwo');
+			const chip = mounted.find('[data-testid="multiline-prop-chip"]');
+			expect(chip.getAttribute('aria-label')).toBe(MULTILINE_LABEL);
+			expect(chip.getAttribute('data-title')).toBe(MULTILINE_VALUE);
+			expect(chip.textContent).toBe(MULTILINE_VALUE);
 		} finally {
 			mounted.unmount();
 		}
 	});
-});
 
-// Sibling warm-plan emission bug found in the same integration pass: warm-child
-// prop KEYS printed as bare Identifiers, so aria-*/data-* props emitted
-// `aria-hidden:` (a parse error). Keys must quote when non-identifier.
-describe('warm-child plans quote non-identifier prop keys', () => {
-	it('server emit with aria-/data- props parses', () => {
-		const src = [
-			"import { Loader2 } from '@octanejs/lucide';",
-			'export function Spinner() {',
-			'\treturn <Loader2 aria-hidden="true" data-testid="spin" class="animate-spin" />;',
-			'}',
-			'',
-		].join('\n');
-		const { code } = compile(src, 'Spinner.tsrx', { mode: 'server' });
-		expect(code).not.toMatch(/[^"']aria-hidden:/);
-		expect(code).toMatch(/"aria-hidden"/);
+	it('server-renders and hydrates a spread-host value without replacing the node', () => {
+		const props = { rest: { 'data-x': 'server-and-client' } };
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		container.innerHTML = renderToString(server.SpreadHost, props).html;
+		const serverNode = container.querySelector('div')!;
+		expect(serverNode.getAttribute('class')).toBe('one\n\t\ttwo');
+		expect(serverNode.getAttribute('data-x')).toBe('server-and-client');
+
+		const diagnostic = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const root = hydrateRoot(container, client.SpreadHost, props);
+		try {
+			flushSync(() => {});
+			const hydratedNode = container.querySelector('div')!;
+			expect(hydratedNode).toBe(serverNode);
+			expect(hydratedNode.getAttribute('class')).toBe('one\n\t\ttwo');
+			expect(hydratedNode.getAttribute('data-x')).toBe('server-and-client');
+			expect(diagnostic).not.toHaveBeenCalled();
+		} finally {
+			root.unmount();
+			diagnostic.mockRestore();
+			container.remove();
+		}
+	});
+
+	it('server-renders and hydrates warm-child props exactly without replacing the node', () => {
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		container.innerHTML = renderToString(server.PropChip).html;
+		const serverNode = container.querySelector('[data-testid="multiline-prop-chip"]')!;
+		expect(serverNode.getAttribute('aria-label')).toBe(MULTILINE_LABEL);
+		expect(serverNode.getAttribute('data-testid')).toBe('multiline-prop-chip');
+		expect(serverNode.getAttribute('data-title')).toBe(MULTILINE_VALUE);
+		expect(serverNode.textContent).toBe(MULTILINE_VALUE);
+
+		const diagnostic = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const root = hydrateRoot(container, client.PropChip);
+		try {
+			flushSync(() => {});
+			const hydratedNode = container.querySelector('[data-testid="multiline-prop-chip"]')!;
+			expect(hydratedNode).toBe(serverNode);
+			expect(hydratedNode.getAttribute('aria-label')).toBe(MULTILINE_LABEL);
+			expect(hydratedNode.getAttribute('data-testid')).toBe('multiline-prop-chip');
+			expect(hydratedNode.getAttribute('data-title')).toBe(MULTILINE_VALUE);
+			expect(hydratedNode.textContent).toBe(MULTILINE_VALUE);
+			expect(diagnostic).not.toHaveBeenCalled();
+		} finally {
+			root.unmount();
+			diagnostic.mockRestore();
+			container.remove();
+		}
+	});
+
+	it('passes exact multi-line props into a warmed child fetch before it resolves', async () => {
+		const pending = deferred<string>();
+		const inputs: string[][] = [];
+		const done = prerender(server.WarmPropPage, {
+			load(...input) {
+				inputs.push(input);
+				return pending.promise;
+			},
+		});
+
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(inputs).toEqual([[WARM_MULTILINE_LABEL, WARM_DATA_TESTID, WARM_MULTILINE_VALUE]]);
+
+		pending.resolve('warmed');
+		const { html } = await done;
+		const container = document.createElement('div');
+		container.innerHTML = html;
+		const chip = container.querySelector('[data-warm-result="warmed"]')!;
+		expect(chip.textContent).toBe(WARM_MULTILINE_VALUE);
+		expect(inputs).toHaveLength(1);
+	});
+
+	it('keeps an optional static computed dependency null-safe', async () => {
+		const inputs: string[] = [];
+		const { html } = await prerender(server.OptionalComputedPropPage, {
+			metadata: null,
+			load(label) {
+				inputs.push(label);
+				return Promise.resolve(label.toUpperCase());
+			},
+		});
+		const container = document.createElement('div');
+		container.innerHTML = html;
+		expect(container.querySelector('[data-optional-computed-result]')?.textContent).toBe(
+			'FALLBACK',
+		);
+		expect(inputs).toEqual(['fallback']);
 	});
 });

--- a/packages/octane/tests/script-innerhtml.test.ts
+++ b/packages/octane/tests/script-innerhtml.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import * as ServerRuntime from 'octane/server';
 import { flushSync, hydrateRoot } from '../src/index.js';
 import { loadCompiledFixtureSource, loadServerFixture } from './_server-fixture.js';
+import { collectPipeableStream } from './_server-stream.js';
 import { mount } from './_helpers.js';
 import * as client from './_fixtures/script-innerhtml.tsrx';
 
@@ -22,6 +23,10 @@ const BREAKOUT_VALUE = {
 };
 
 const EXECUTABLE_SOURCE = `window.__octaneScriptValue = ${JSON.stringify(BREAKOUT_VALUE)};`;
+
+function scriptSpread(value: unknown) {
+	return { dangerouslySetInnerHTML: { __html: JSON.stringify(value) } };
+}
 
 const STATIC_JSON_VALUE = {
 	nested: { enabled: true },
@@ -135,6 +140,91 @@ describe('<script> content contract', () => {
 			expect(container.querySelectorAll('script')).toHaveLength(1);
 			expect(container.querySelector('[data-pwn]')).toBeNull();
 			expect(serverNode?.textContent).toBe(JSON.stringify(next));
+		} finally {
+			root.unmount();
+			warning.mockRestore();
+			container.remove();
+		}
+	});
+
+	it('mounts, updates, and conditionally removes dynamic script content passed through a spread', () => {
+		const mounted = mount(client.ConditionalSpreadScript, {
+			show: true,
+			spread: scriptSpread(BREAKOUT_VALUE),
+		});
+		try {
+			const script = mounted.find('script');
+			expect(mounted.findAll('script')).toHaveLength(1);
+			expect(mounted.container.querySelector('[data-pwn]')).toBeNull();
+			expect(JSON.parse(script.textContent ?? '')).toEqual(BREAKOUT_VALUE);
+
+			const next = { enabled: false, boundary: '</script><script data-pwn="next">bad</script>' };
+			mounted.update(client.ConditionalSpreadScript, {
+				show: true,
+				spread: scriptSpread(next),
+			});
+			expect(mounted.find('script')).toBe(script);
+			expect(mounted.container.querySelector('[data-pwn]')).toBeNull();
+			expect(JSON.parse(script.textContent ?? '')).toEqual(next);
+
+			mounted.update(client.ConditionalSpreadScript, {
+				show: false,
+				spread: scriptSpread(next),
+			});
+			expect(mounted.container.querySelector('script')).toBeNull();
+		} finally {
+			mounted.unmount();
+		}
+	});
+
+	it('serializes conditional dynamic script spread props in buffered and streaming SSR', async () => {
+		const props = { show: true, spread: scriptSpread(BREAKOUT_VALUE) };
+		const buffered = ServerRuntime.renderToString(server.ConditionalSpreadScript, props);
+		const streamed = await collectPipeableStream(server.ConditionalSpreadScript, props);
+		expect(streamed.errors).toEqual([]);
+		for (const html of [buffered.html, streamed.html]) {
+			const fragment = parseFragment(html);
+			const scripts = fragment.querySelectorAll('script');
+			expect(scripts).toHaveLength(1);
+			expect(fragment.querySelector('[data-pwn]')).toBeNull();
+			expect(JSON.parse(scripts[0].textContent ?? '')).toEqual(BREAKOUT_VALUE);
+		}
+
+		const hidden = await collectPipeableStream(server.ConditionalSpreadScript, {
+			show: false,
+			spread: scriptSpread(BREAKOUT_VALUE),
+		});
+		expect(parseFragment(hidden.html).querySelector('script')).toBeNull();
+		expect(hidden.errors).toEqual([]);
+	});
+
+	it('hydrates a conditional dynamic script spread by adoption and applies later updates', () => {
+		const props = { show: true, spread: scriptSpread(BREAKOUT_VALUE) };
+		const { html } = ServerRuntime.renderToString(server.ConditionalSpreadScript, props);
+		const container = document.createElement('div');
+		container.innerHTML = html;
+		document.body.appendChild(container);
+		const serverNode = container.querySelector('script');
+		const warning = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const root = hydrateRoot(container, client.ConditionalSpreadScript, props);
+		try {
+			flushSync(() => {});
+			expect(container.querySelector('script')).toBe(serverNode);
+			expect(JSON.parse(serverNode?.textContent ?? '')).toEqual(BREAKOUT_VALUE);
+			expect(warning).not.toHaveBeenCalled();
+
+			const next = { enabled: true, boundary: '</script><script data-pwn="updated">bad</script>' };
+			flushSync(() =>
+				root.render(client.ConditionalSpreadScript, {
+					show: true,
+					spread: scriptSpread(next),
+				}),
+			);
+			expect(container.querySelector('script')).toBe(serverNode);
+			expect(container.querySelectorAll('script')).toHaveLength(1);
+			expect(container.querySelector('[data-pwn]')).toBeNull();
+			expect(JSON.parse(serverNode?.textContent ?? '')).toEqual(next);
+			expect(warning).not.toHaveBeenCalled();
 		} finally {
 			root.unmount();
 			warning.mockRestore();

--- a/packages/octane/tests/use-chain-memo.test.ts
+++ b/packages/octane/tests/use-chain-memo.test.ts
@@ -6,6 +6,7 @@ import {
 	ChainHost,
 	ComputedPropChainHost,
 	NestedBranchChainHost,
+	OptionalDerivedChainHost,
 	PropChainHost,
 	SetupShadowHost,
 	ShadowedLoopHost,
@@ -146,6 +147,26 @@ describe('use()-fed const chain memoization', () => {
 		});
 		await act(() => {});
 		expect(r.html()).toContain('v=B');
+		r.unmount();
+	});
+
+	it('refreshes an optional derived chain when its upstream promise changes', async () => {
+		const calls: string[] = [];
+		const fetchUser = (id: string) => {
+			calls.push(id);
+			return Promise.resolve({ v: id.toUpperCase() });
+		};
+		const r = mount(OptionalDerivedChainHost, { fetchUser, id: 'a' });
+		await act(() => {});
+		expect(r.find('#optional-derived-chain').textContent).toBe('A');
+		expect(calls).toEqual(['a']);
+
+		await act(() => {
+			r.root.render(OptionalDerivedChainHost, { fetchUser, id: 'b' });
+		});
+		await act(() => {});
+		expect(r.find('#optional-derived-chain').textContent).toBe('B');
+		expect(calls).toEqual(['a', 'b']);
 		r.unmount();
 	});
 

--- a/packages/octane/tests/use-chain-memo.test.ts
+++ b/packages/octane/tests/use-chain-memo.test.ts
@@ -4,6 +4,7 @@ import {
 	BracelessVarChainHost,
 	BranchChainHost,
 	ChainHost,
+	ComputedPropChainHost,
 	NestedBranchChainHost,
 	PropChainHost,
 	SetupShadowHost,
@@ -87,6 +88,35 @@ describe('use()-fed const chain memoization', () => {
 		expect(r.html()).toContain('<img src="thumb-a"');
 		expect(userCalls).toEqual(['a']);
 		expect(thumbCalls).toEqual(['a']);
+		r.unmount();
+	});
+
+	it('tracks distinct static computed prop dependencies in a local creation chain', () => {
+		const calls: string[] = [];
+		const load = (a: string, b: string) => {
+			const value = a + ':' + b;
+			calls.push(value);
+			return {
+				status: 'fulfilled',
+				value,
+				then() {},
+			} as unknown as Promise<string>;
+		};
+		const r = mount(ComputedPropChainHost, {
+			'data-a': 'stable',
+			'data-b': 'first',
+			load,
+		});
+		expect(r.find('#computed-prop-chain').textContent).toBe('stable:first');
+		expect(calls).toEqual(['stable:first']);
+
+		r.update(ComputedPropChainHost, {
+			'data-a': 'stable',
+			'data-b': 'second',
+			load,
+		});
+		expect(r.find('#computed-prop-chain').textContent).toBe('stable:second');
+		expect(calls).toEqual(['stable:first', 'stable:second']);
 		r.unmount();
 	});
 

--- a/packages/vite-plugin-octane/tests/_fixtures/app/src/Page.tsrx
+++ b/packages/vite-plugin-octane/tests/_fixtures/app/src/Page.tsrx
@@ -5,7 +5,7 @@ import { Canvas } from '@fixture/object-canvas';
 import { Scene } from './Scene.object.tsrx';
 import { DeferredHydrationProof } from './deferred-hydration.tsrx';
 import { PrefetchedHydrationProof } from './prefetched-hydration.tsrx';
-import { GuardedConst } from './GuardedConst.tsrx';
+import { GuardedConst } from './GuardedConst';
 
 export const fixturePageModuleState = { rendered: false };
 

--- a/packages/vite-plugin-octane/tests/production.test.ts
+++ b/packages/vite-plugin-octane/tests/production.test.ts
@@ -223,6 +223,10 @@ describe('production SSR build', { timeout: 30_000 }, () => {
 			expect(prodHtml).toContain('fixture-nav');
 			expect(prodHtml).toContain(url === '/' ? 'Fixture page home' : 'Fixture page hello');
 			expect(prodHtml).toContain(`<p class="url">${url}</p>`);
+			// GuardedConst is imported extensionlessly from a .tsrx module. Reaching
+			// its rendered output proves both dev and production SSR resolved that edge.
+			expect(prodHtml).toContain('class="vite-guarded-const"');
+			expect(prodHtml).toContain('vite-guarded-const-proof');
 			expect(prodHtml).toContain(`<link rel="stylesheet" href="/${deferredCss}">`);
 			expect(prodHtml).not.toContain(`src="/${deferredJavaScript}"`);
 			expect(prodHtml).not.toContain(`<link rel="modulepreload" href="/${deferredJavaScript}">`);


### PR DESCRIPTION
## Summary

- fix SSR creation-memo dependencies for statically named computed props such as `props['aria-label']`
- preserve optional-member semantics and keep distinct computed keys through Pass A′ dependency coarsening
- harden the issue #239 regressions across stored JSX values, inline script raw text, permanent-static hydration, warmed SSR props, and extensionless `.tsrx` resolution
- add a patch changeset for the user-facing compiler fix

## Root cause

Creation dependency analysis specialized `props.name` but treated `props['name']` as the whole props object. Warmed and canonical SSR passes receive equivalent but distinct prop bags, so that coarse dependency missed the warmed promise and could duplicate a fetch. The coarsening pass also assumed every member key was an identifier, which could collapse distinct computed-string dependencies after adding bracket-member support.

The compiler now uses scalar dependency paths for static computed-string members, shares one collision-safe key scheme across both passes, and preserves optional chaining.

## Validation

- `pnpm test` — 1,288 files and 12,532 tests passed
- `pnpm typecheck`
- `pnpm format:check`
- focused dev/forced-production, real-browser hydration, and Vite production suites

Related to #239.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The behavioral change is localized to compiler memo dependency analysis but affects SSR fetch deduplication and `use()` chain invalidation; incorrect dep keys could cause stale data or extra requests.
> 
> **Overview**
> Fixes **SSR creation-memo dependency tracking** so statically named computed members like `props['aria-label']` are treated like `props.ariaLabel`, letting warmed and canonical SSR passes **reuse the same fetch** instead of duplicating work when prop bags differ only by identity.
> 
> The compiler adds shared helpers for **static bracket/dot member paths**, **collision-safe dep keys**, and **optional chaining** (`ChainExpression`) through dependency extraction and Pass A′ coarsening.
> 
> The rest of the PR **locks regressions** with expanded coverage: multi-line / non-identifier props through warm SSR and hydration, `use()` chain memo for computed props and optional chains, stored JSX passed via component props, conditional script spreads, permanent-static real-browser hydration (SVG/MathML), and extensionless `.tsrx` imports in the Vite production fixture. Includes an **octane patch** changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5759a0d70f23bd9bcea113f4cc30a6213221d00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->