### PR TITLE
Add Redact-derived adversarial contract audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,6 +322,14 @@ jobs:
           pnpm react-parity:test
           pnpm react-parity:check
 
+      # Redact's issues, pull requests, and tests are mined at a pinned commit
+      # into an authored contract ledger. This network-free gate validates its
+      # dispositions/local evidence and keeps the generated report current.
+      - name: Check Redact-derived adversarial contract ledger
+        env:
+          OCTANE_REDACT_AUDIT_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: pnpm redact-audit:check
+
       # Production error URLs are a public compatibility surface. Keep the
       # append-only catalog, generated client/server formatters, and literal
       # runtime call sites synchronized before a package can be built.

--- a/docs/project-analysis-concerns.md
+++ b/docs/project-analysis-concerns.md
@@ -147,6 +147,11 @@ suite per shard.
 When adding a feature, choose the suite by observable rather than assuming a
 final-HTML differential test is sufficient.
 
+The generated [Redact-derived adversarial contract audit](redact-adversarial-audit.md)
+tracks external production failures and test patterns against these same observation
+boundaries. Its authored ledger distinguishes open Octane probes from covered
+contracts, intentional divergences, and Redact-specific non-goals.
+
 ## 5. Compiler/runtime contracts and hook slotting
 
 Status: **duplicated tables resolved; emitted ABI remains a compatibility

--- a/docs/redact-adversarial-audit.md
+++ b/docs/redact-adversarial-audit.md
@@ -1,0 +1,961 @@
+# Redact-derived adversarial contract audit (generated)
+
+<!-- GENERATED FILE — do not edit. Regenerate with `pnpm redact-audit:generate`. -->
+
+This is a source-backed extraction ledger for consumer-observable failure modes found in [TanStack Redact](https://github.com/TanStack/redact). Redact is an adversity source, not an implementation target or a blanket compatibility promise. Classifications describe whether each contract transfers to Octane; statuses describe the current Octane evidence or follow-up.
+
+The authored source is [`packages/octane/audit/redact-adversarial-ledger.json`](../packages/octane/audit/redact-adversarial-ledger.json). Permanent IDs must not be renamed or reused.
+
+## Upstream snapshot
+
+- Repository: [`https://github.com/TanStack/redact`](https://github.com/TanStack/redact)
+- Commit: [`e1620a13aab8935c806238f117ba58559b7cd002`](https://github.com/TanStack/redact/commit/e1620a13aab8935c806238f117ba58559b7cd002)
+- Captured: 2026-07-22
+- Issues reviewed: #17
+- Pull requests reviewed: #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16
+- Repository paths reviewed: `packages/redact/src/core`, `packages/redact/src/dom`, `packages/redact/src/react`, `packages/redact/src/scheduler`, `packages/redact/src/server`, `packages/redact/src/vite`, `scripts`, `tests`
+
+### Audited artifact dispositions
+
+This is the explicit artifact sample reviewed at the pinned snapshot; broad source paths above do not imply that every file was mined. `mapped` artifacts have an exact upstream test source, while `folded` artifacts were inspected and assigned to an existing contract without duplicating every case.
+
+| Artifact | Disposition | Ledger IDs | Note |
+| --- | --- | --- | --- |
+| `tests/callback-ref-commit-phase.test.tsx` | mapped | [`RDX-REF-001`](#rdx-ref-001) | Exact source mapping. |
+| `tests/child-reorder.test.tsx` | mapped | [`RDX-REC-001`](#rdx-rec-001) | Exact source mapping. |
+| `tests/controlled-input.test.tsx` | folded | [`RDX-EVT-001`](#rdx-evt-001) | The native-event observation boundary transfers; Redact's synthetic onChange mapping is an explicit Octane divergence. |
+| `tests/create-root-clear-container.test.tsx` | mapped | [`RDX-ROOT-001`](#rdx-root-001) | Exact source mapping. |
+| `tests/document-hydration.test.tsx` | mapped | [`RDX-HYD-001`](#rdx-hyd-001), [`RDX-HYD-002`](#rdx-hyd-002), [`RDX-HYD-003`](#rdx-hyd-003), [`RDX-HYD-004`](#rdx-hyd-004) | Exact source mapping. |
+| `tests/event-replay.test.ts` | mapped | [`RDX-EVT-002`](#rdx-evt-002) | Exact source mapping. |
+| `tests/external-store-unmount.test.tsx` | mapped | [`RDX-STORE-001`](#rdx-store-001) | Exact source mapping. |
+| `tests/floating-ui-pattern.test.tsx` | mapped | [`RDX-PORT-002`](#rdx-port-002) | Exact source mapping. |
+| `tests/hydration-mismatch-recovery.test.tsx` | mapped | [`RDX-HYD-006`](#rdx-hyd-006) | Exact source mapping. |
+| `tests/hydration.test.tsx` | mapped | [`RDX-ID-001`](#rdx-id-001) | Exact source mapping. |
+| `tests/memo-state-rerender.test.tsx` | mapped | [`RDX-MEM-001`](#rdx-mem-001) | Exact source mapping. |
+| `tests/place-children-anchor.test.tsx` | mapped | [`RDX-REC-002`](#rdx-rec-002) | Exact source mapping. |
+| `tests/portal-doctype.test.tsx` | mapped | [`RDX-PORT-001`](#rdx-port-001), [`RDX-SSR-002`](#rdx-ssr-002) | Exact source mapping. |
+| `tests/public-exports.test.ts` | mapped | [`RDX-PKG-001`](#rdx-pkg-001) | Exact source mapping. |
+| `tests/react-integration/reconnecting.test.tsx` | folded | [`RDX-HYD-006`](#rdx-hyd-006), [`RDX-NON-001`](#rdx-non-001) | Host reconnecting outcomes transfer; class-component cases are explicit non-goals. |
+| `tests/security.test.tsx` | mapped | [`RDX-SEC-001`](#rdx-sec-001) | Exact source mapping. |
+| `tests/ssr-context.test.tsx` | mapped | [`RDX-SSR-001`](#rdx-ssr-001) | Exact source mapping. |
+| `tests/ssr.test.tsx` | mapped | [`RDX-SSR-001`](#rdx-ssr-001) | Exact source mapping. |
+| `tests/streaming-hydration.test.tsx` | folded | [`RDX-HYD-001`](#rdx-hyd-001), [`RDX-SSR-001`](#rdx-ssr-001) | The cases reinforce streamed-boundary recovery and transactional streaming entries. |
+| `tests/suspense-preserves-dom.test.tsx` | mapped | [`RDX-SUS-001`](#rdx-sus-001) | Exact source mapping. |
+| `tests/use-effect-coalesced-renders.test.tsx` | mapped | [`RDX-LIF-001`](#rdx-lif-001) | Exact source mapping. |
+| `tests/vite-plugin.test.ts` | folded | [`RDX-CFG-001`](#rdx-cfg-001), [`RDX-PKG-002`](#rdx-pkg-002) | Redact-specific React aliases are excluded; option-to-output and environment-routing lessons transfer. |
+
+## Entry contract
+
+- Keep one consumer-observable owning contract per permanent ID; split an upstream issue or pull request when it exposes independent contracts.
+- The append-only `idRegistry` retains retired IDs as tombstones. Never rename, remove, or reuse a registered ID; retire it with rationale and mint a new ID when the owning contract changes.
+- A `covered` entry cites an exact executable Octane test. A `planned` entry carries a bounded next action. A `decision required` entry records the decision owner and acceptance boundary.
+- A `documented` entry is terminal only for an explained divergence/non-goal or a portable process policy backed exclusively by documentation/benchmark references.
+- Keep resolved, divergent, and non-goal entries in the ledger so future audits do not rediscover them or silently import Redact-specific behavior.
+- Choose tests by observable. Final markup alone cannot prove identity, focus, selection, scroll, live properties, lifecycle ordering, or global error behavior.
+- Update the authored JSON, then run `pnpm redact-audit:generate`; never hand-edit this report.
+
+## Summary
+
+| Status | Entries |
+| --- | ---: |
+| planned | 13 |
+| in progress | 0 |
+| covered | 9 |
+| documented | 5 |
+| decision required | 1 |
+| blocked | 0 |
+
+| Classification | Entries |
+| --- | ---: |
+| portable | 13 |
+| adaptable | 11 |
+| divergence | 2 |
+| non goal | 2 |
+
+## Open priority queue
+
+| ID | Risk | Area | Contract | Status | Owner |
+| --- | --- | --- | --- | --- | --- |
+| [`RDX-HYD-001`](#rdx-hyd-001) | critical | hydration | Suspending hydration recovery must not leak an uncaught mismatch | planned | Octane runtime hydration and browser tests |
+| [`RDX-HYD-002`](#rdx-hyd-002) | critical | head-hydration | Hoisted head markers must only claim the intended element | planned | Octane compiler and runtime head hydration |
+| [`RDX-SUS-001`](#rdx-sus-001) | critical | suspense-preservation | Re-suspension preserves browser-owned state in committed UI | planned | Octane Suspense runtime and browser tests |
+| [`RDX-EVT-002`](#rdx-evt-002) | high | event-replay | Hydration event replay preserves platform event shape and queue semantics | planned | Octane deferred hydration and DOM events |
+| [`RDX-HYD-003`](#rdx-hyd-003) | high | raw-text-hydration | Raw script and style hydration must use their parsing contexts | planned | Octane DOM hydration and SSR serialization |
+| [`RDX-HYD-006`](#rdx-hyd-006) | high | hydration-recovery | Mismatch recovery is bounded to the failed ownership scope | planned | Octane hydration cursor and ownership ranges |
+| [`RDX-LIF-001`](#rdx-lif-001) | high | effects | Coalesced dependency changes leave one live passive side effect | planned | Octane scheduler and effect hooks |
+| [`RDX-MEM-001`](#rdx-mem-001) | high | memo-scheduling | Memo prop bailouts do not swallow owned updates or revive removed work | planned | Octane memo and scheduler |
+| [`RDX-PORT-002`](#rdx-port-002) | high | portal-updates | A stateful portal descendant resolves its foreign host for owned updates | planned | Octane portal host resolution |
+| [`RDX-REC-002`](#rdx-rec-002) | high | reconciliation-placement | Topology transitions use the correct absolute anchor without stable reattachment | planned | Octane reconciler and portal placement |
+| [`RDX-STORE-001`](#rdx-store-001) | high | external-store | External-store subscription races cannot create zombie DOM | planned | Octane useSyncExternalStore and scheduler |
+| [`RDX-CFG-001`](#rdx-cfg-001) | medium | build-configuration | Public options must change the emitted build at their observation boundary | planned | Octane compiler and Vite/Rspack/Rsbuild integrations |
+| [`RDX-HYD-005`](#rdx-hyd-005) | medium | hydration-errors | Hydration recovery reporting has an explicit public contract | decision required | Octane public root API |
+| [`RDX-PKG-001`](#rdx-pkg-001) | medium | public-exports | Advertised named exports are locked at the consumer boundary | planned | Octane package surface |
+
+## Contract ledger
+
+### build-configuration
+
+<a id="rdx-cfg-001"></a>
+
+#### RDX-CFG-001 — Public options must change the emitted build at their observation boundary
+
+**Disposition:** medium risk; adaptable; planned; owner: Octane compiler and Vite/Rspack/Rsbuild integrations.
+
+**Upstream evidence**
+
+- [pull request #15](https://github.com/TanStack/redact/pull/15) — fix(redact/vite): respect 'forwardRef' and 'classComponents' feature flags
+- [commit 04f39662123a](https://github.com/TanStack/redact/commit/04f39662123a2ca9c896dca0a35429b0554a4847)
+
+**Consumer-visible symptom.** A documented false-valued feature flag silently left the full implementation in the bundle because an internal folder name was cast to an unrelated public option key.
+
+**Octane contract.** Every public compiler or bundler boolean must have a test proving the option changes emitted code, resolution, bundle contents, or runtime behavior in each environment where it is supported.
+
+**Applicable modes:** `production-compile`, `vite-client`, `vite-ssr`, `rspack`, `rsbuild`. **Observables:** `markup`, `package-resolution`.
+
+**Octane references**
+
+- [packages/octane/tests/hmr.test.ts](../packages/octane/tests/hmr.test.ts) — “hmr option off → no wrapping, no accept block” — Representative direct option-to-output coverage; not yet a complete public-option matrix.
+- [packages/rspack-plugin-octane/tests/rspack.test.ts](../packages/rspack-plugin-octane/tests/rspack.test.ts) — “erases profiling and full diagnostics from a real production bundle”
+
+**Next action (test).** Inventory public booleans and renderer mappings, then prove both enabled and disabled behavior at emitted-output or resolved-module boundaries without relying on unchecked name casts.
+
+Targets: `packages/octane/tests`, `packages/vite-plugin-octane/tests`, `packages/rspack-plugin-octane/tests`, `packages/rsbuild-plugin-octane/tests`.
+
+**Rationale.** Redact's forwardRef and class-component flags are out of scope; the transferable lesson is to test configuration where consumers observe it.
+
+
+### document-serialization
+
+<a id="rdx-ssr-002"></a>
+
+#### RDX-SSR-002 — Doctype ownership is explicit for each server rendering API
+
+**Disposition:** high risk; divergence; covered; owner: Octane server render APIs.
+
+**Upstream evidence**
+
+- [test: prepends a DOCTYPE when the root element is &lt;html&gt;](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/portal-doctype.test.tsx#L115-L135) (`tests/portal-doctype.test.tsx`)
+- [test: does not prepend a DOCTYPE for non-html roots](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/portal-doctype.test.tsx#L137-L150) (`tests/portal-doctype.test.tsx`)
+
+**Consumer-visible symptom.** A document response omitted or misplaced its doctype and entered quirks mode, or a fragment unexpectedly received a document preamble.
+
+**Octane contract.** Pipeable &lt;html&gt; document streams contain exactly one &lt;!DOCTYPE html&gt;, and readable &lt;html&gt; streams begin with that doctype; the shared serializer emits none for non-document roots, directly exercised through the pipeable API; renderToString and renderToStaticMarkup remain doctype-free so the embedding framework owns buffered preambles.
+
+**Applicable modes:** `server-string`, `server-static`, `server-stream`. **Observables:** `markup`, `streaming`.
+
+**Octane references**
+
+- [docs/ssr.md](../docs/ssr.md) — Documents streaming-only doctype ownership and buffered framework composition.
+- [packages/octane/tests/streaming-ssr-injection.test.ts](../packages/octane/tests/streaming-ssr-injection.test.ts) — Covers injected/non-injected document streams, fragments, web streams, and buffered APIs.
+
+**Executable evidence**
+
+- [streamed documents lead with &lt;!DOCTYPE html&gt; without any injection source](../packages/octane/tests/streaming-ssr-injection.test.ts) — modes: `server-stream`; observables: `markup`, `streaming`
+- [streamed documents lead with &lt;!DOCTYPE html&gt; through the web-stream API](../packages/octane/tests/streaming-ssr-injection.test.ts) — modes: `server-stream`; observables: `markup`, `streaming`
+- [streamed fragments never receive a doctype](../packages/octane/tests/streaming-ssr-injection.test.ts) — modes: `server-stream`; observables: `markup`, `streaming`
+- [buffered renderers stay doctype-free for document roots, matching React](../packages/octane/tests/streaming-ssr-injection.test.ts) — modes: `server-string`, `server-static`; observables: `markup`
+
+**Rationale.** Redact's buffered renderer prepends a doctype for an &lt;html&gt; root. Octane intentionally matches React's API split: streaming owns the document preamble, while buffered output remains composable. The transferable contract is explicit API ownership, not identical bytes across unlike APIs.
+
+
+### documentation
+
+<a id="rdx-doc-001"></a>
+
+#### RDX-DOC-001 — Surface, protocol, and size documentation must follow executable evidence
+
+**Disposition:** medium risk; portable; documented; owner: Octane documentation and release tooling.
+
+**Upstream evidence**
+
+- [pull request #3](https://github.com/TanStack/redact/pull/3) — docs: update SURFACE.md and SAVINGS_ANALYSIS.md for @tanstack/redact
+- [pull request #13](https://github.com/TanStack/redact/pull/13) — docs(redact/server): correct fallback wire-format comment — fallback '&lt;div&gt;' is visible, not hidden
+
+**Consumer-visible symptom.** Published size numbers, package layout, or streaming wire-format commentary drifted away from the scripts and bytes that users actually received.
+
+**Octane contract.** Measured claims and protocol descriptions must cite the live generator, benchmark, emitted fixture, or focused test that makes them reviewable.
+
+**Applicable modes:** `server-stream`, `benchmark`. **Observables:** `streaming`, `performance`.
+
+**Octane references**
+
+- [docs/project-analysis-concerns.md](../docs/project-analysis-concerns.md) — Distinguishes current source-backed claims from historical plans.
+- [benchmarks/README.md](../benchmarks/README.md) — Defines comparable baselines and the repository benchmark contract.
+
+**Rationale.** This is a maintenance rule rather than an independent runtime workstream.
+
+
+### effects
+
+<a id="rdx-lif-001"></a>
+
+#### RDX-LIF-001 — Coalesced dependency changes leave one live passive side effect
+
+**Disposition:** high risk; portable; planned; owner: Octane scheduler and effect hooks.
+
+**Upstream evidence**
+
+- [test: does not leak side-effects when two deps-changing renders coalesce before passive drain](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/use-effect-coalesced-renders.test.tsx#L13-L57) (`tests/use-effect-coalesced-renders.test.tsx`)
+
+**Consumer-visible symptom.** Two renders before the passive queue drained installed multiple imperative artifacts because cleanup ownership was cleared before the intermediate body ran.
+
+**Octane contract.** After any coalesced dependency-changing render sequence, at most one passive side effect is live; each installed effect is cleaned exactly once, including final unmount.
+
+**Applicable modes:** `client`, `production-compile`. **Observables:** `markup`, `effects`.
+
+**Octane references**
+
+- [packages/octane/tests/effect-timing.test.ts](../packages/octane/tests/effect-timing.test.ts) — “phase order on re-render: cleanups fire before bodies of same phase” — Strong ordering coverage, but not the exact two-renders-before-passive-drain race.
+
+**Next action (test).** Drive a→b→c before passive drain, assert one live imperative artifact, exact cleanup order through c, and one final cleanup on unmount in development and production compile modes.
+
+Targets: `packages/octane/tests/effect-timing.test.ts`.
+
+
+### event-replay
+
+<a id="rdx-evt-002"></a>
+
+#### RDX-EVT-002 — Hydration event replay preserves platform event shape and queue semantics
+
+**Disposition:** high risk; adaptable; planned; owner: Octane deferred hydration and DOM events.
+
+**Upstream evidence**
+
+- [test: replays buffered events with browser-compatible event subclasses](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/event-replay.test.ts#L12-L68) (`tests/event-replay.test.ts`)
+
+**Consumer-visible symptom.** A replay queue delivered the right event names but degraded keyboard and input events to generic Event objects, lost target/default semantics, changed order, or replayed an item twice.
+
+**Octane contract.** For every event Octane buffers, replay must preserve the documented platform subclass and supported metadata, original target, FIFO order, bubbling/cancelability/default behavior, and exactly-once delivery.
+
+**Applicable modes:** `deferred-hydration`, `real-browser`. **Observables:** `events`.
+
+**Octane references**
+
+- [packages/octane/src/runtime.ts](../packages/octane/src/runtime.ts) — `notifyHydrateBoundary` — Mouse and focus families retain subclasses; other buffered families currently fall back to Event.
+- [packages/octane/tests/streaming-ssr.test.ts](../packages/octane/tests/streaming-ssr.test.ts) — “replays pre-root interaction after the pending stream reveals” — Covers click delivery and target survival, not the cross-family event-shape matrix.
+
+**Next action (test).** Exercise every public HydrationInteractionEvent family in a real browser: click/auxclick/contextmenu/dblclick, focusin, keydown/keyup, mouse, and pointer events. Assert subclass, supported metadata, target, FIFO ordering, preventDefault visibility, queue drain, and no duplicate replay; keep input/change/submit excluded unless a separate API decision expands the public union.
+
+Targets: `packages/octane/tests/hydration/deferred-hydration-contract.test.ts`, `packages/octane/tests/browser`.
+
+**Rationale.** Octane replays interaction intent rather than cloning every native event field, so the transferable contract must explicitly define which event shape it promises instead of silently copying Redact's implementation.
+
+
+### events
+
+<a id="rdx-evt-001"></a>
+
+#### RDX-EVT-001 — Native form events must be exercised, without importing synthetic onChange
+
+**Disposition:** high risk; divergence; documented; owner: Octane DOM events and forms.
+
+**Upstream evidence**
+
+- [pull request #1](https://github.com/TanStack/redact/pull/1) — fix(react-dom): fire onChange on every keystroke for text inputs
+- [commit 1da7232dbe16](https://github.com/TanStack/redact/commit/1da7232dbe1658971219b6a83f2f44a4f1b5ff16)
+
+**Consumer-visible symptom.** Initial form markup looked correct while real editing was dead because the tests never dispatched the platform event that drives the control.
+
+**Octane contract.** Controlled-property tests must dispatch real native input/change events and assert handler delivery, live-property reassertion, and dynamic input-type behavior.
+
+**Applicable modes:** `client`, `hydrate-match`, `production-compile`, `real-browser`. **Observables:** `events`, `live-properties`, `markup`.
+
+**Octane references**
+
+- [docs/differences-from-react.md](../docs/differences-from-react.md) — Octane deliberately uses onInput per edit and native change on commit.
+- [packages/octane/tests/browser/native-change/native-change.test.ts](../packages/octane/tests/browser/native-change/native-change.test.ts) — “fires Octane change on focus commit while React derives it from each input” — Real-browser native change contract.
+
+**Rationale.** Adopt Redact's event-level observation boundary, but reject its synthetic onChange-to-input mapping because that conflicts with Octane's documented native-event model.
+
+
+### external-store
+
+<a id="rdx-store-001"></a>
+
+#### RDX-STORE-001 — External-store subscription races cannot create zombie DOM
+
+**Disposition:** high risk; portable; planned; owner: Octane useSyncExternalStore and scheduler.
+
+**Upstream evidence**
+
+- [test: subscribes after render when the store synchronously notifies](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/external-store-unmount.test.tsx#L47-L81) (`tests/external-store-unmount.test.tsx`)
+- [test: store notifications after unmount do not resurrect DOM](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/external-store-unmount.test.tsx#L116-L156) (`tests/external-store-unmount.test.tsx`)
+
+**Consumer-visible symptom.** Subscription ran during render or a stale listener scheduled an unmounted component, causing removed UI to reappear in its former host.
+
+**Octane contract.** useSyncExternalStore subscribes after render, converges when subscribe synchronously notifies, unsubscribes on conditional/root removal, and ignores every post-unmount notification.
+
+**Applicable modes:** `client`, `production-compile`. **Observables:** `markup`, `effects`.
+
+**Octane references**
+
+- [packages/octane/tests/sync-external-store.test.ts](../packages/octane/tests/sync-external-store.test.ts) — “post-unmount store mutations do NOT trigger any work” — Covers root unmount but not synchronous subscribe notification or conditional stale-listener delivery.
+- [packages/octane/src/runtime.ts](../packages/octane/src/runtime.ts) — `useSyncExternalStore`
+
+**Next action (test).** Prove subscription occurs outside render, a synchronous notifier converges without looping, conditional removal unsubscribes, and a retained stale callback cannot resurrect DOM.
+
+Targets: `packages/octane/tests/sync-external-store.test.ts`.
+
+
+### head-hydration
+
+<a id="rdx-hyd-002"></a>
+
+#### RDX-HYD-002 — Hoisted head markers must only claim the intended element
+
+**Disposition:** critical risk; adaptable; planned; owner: Octane compiler and runtime head hydration.
+
+**Upstream evidence**
+
+- [issue #17](https://github.com/TanStack/redact/issues/17) — Hydration bugs: async-resume mismatch escapes uncaught; head-script claiming; innerHTML probe escaping; foreign-node strictness
+- [test: claims typeless and typed head scripts in document order](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/document-hydration.test.tsx#L171-L206) (`tests/document-hydration.test.tsx`)
+
+**Consumer-visible symptom.** Weak head-node identity allowed one logical head entry to adopt a different server node and validate or update the wrong content.
+
+**Octane contract.** A compiled head marker may adopt only an element with the expected tag and ownership; missing, duplicated, reordered, or corrupted markers must create or recover the expected node without mutating unrelated head content.
+
+**Applicable modes:** `hydrate-match`, `hydrate-mismatch`, `production-compile`, `real-browser`. **Observables:** `markup`, `node-identity`, `errors`.
+
+**Octane references**
+
+- [packages/octane/src/runtime.ts](../packages/octane/src/runtime.ts) — `adoptServerHeadEl` — The current helper returns the first element after a matching marker without validating the expected tag.
+- [packages/octane/tests/hydration/head-hydrate.test.ts](../packages/octane/tests/hydration/head-hydrate.test.ts) — “adopts the server head (one &lt;title&gt;/&lt;meta&gt;, markers removed) + single-root body, removed on unmount” — Happy-path adoption only.
+
+**Next action (test).** Cover a foreign wrong-tag node between marker and target, missing target, duplicate marker, reordered metadata, and preservation of unrelated head nodes before deciding whether runtime validation is needed.
+
+Targets: `packages/octane/tests/hydration/head-hydrate.test.ts`.
+
+**Rationale.** Redact matches scripts by attributes while Octane uses compiler markers; the portable contract is ownership-safe claiming, not Redact's matching algorithm.
+
+
+### host-serialization-security
+
+<a id="rdx-sec-001"></a>
+
+#### RDX-SEC-001 — Untrusted host values remain inside their parser and execution boundaries
+
+**Disposition:** critical risk; adaptable; covered; owner: Octane DOM application and server serialization.
+
+**Upstream evidence**
+
+- [test: escapes &lt;, &gt;, &amp; in text children](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/security.test.tsx#L15-L19) (`tests/security.test.tsx`)
+- [test: escapes quotes in attribute values](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/security.test.tsx#L34-L40) (`tests/security.test.tsx`)
+- [test: breaks an attempted &lt;/script&gt; inside script body](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/security.test.tsx#L52-L64) (`tests/security.test.tsx`)
+- [test: breaks an attempted &lt;/style&gt; inside style body](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/security.test.tsx#L66-L78) (`tests/security.test.tsx`)
+- [test: does not allow CSS injection via style values containing quotes](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/security.test.tsx#L123-L132) (`tests/security.test.tsx`)
+- [test: only attaches function event handlers — string handlers are silently ignored](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/security.test.tsx#L134-L157) (`tests/security.test.tsx`)
+- [test: only honors the `__html` key — extra keys are ignored](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/security.test.tsx#L159-L174) (`tests/security.test.tsx`)
+
+**Consumer-visible symptom.** Untrusted text, attributes, styles, raw-text bodies, event props, or malformed raw-HTML objects crossed into executable markup or a neighboring parser context.
+
+**Octane contract.** Untrusted values remain within their owning text, attribute, style, or raw-text parser context at each tested serialization boundary; streamed raw script and style bodies remain confined as chunks are emitted. Raw HTML requires the __html shape, and non-function delegated event values never execute as handlers.
+
+**Applicable modes:** `client`, `server-string`, `server-static`, `server-stream`, `production-compile`. **Observables:** `markup`, `events`, `errors`.
+
+**Octane references**
+
+- [packages/octane/tests/conformance/dom-component-ssr.test.ts](../packages/octane/tests/conformance/dom-component-ssr.test.ts) — “escapes text content and attribute values (round-trip)”
+- [packages/octane/tests/conformance/fizz-main-wave4c.test.ts](../packages/octane/tests/conformance/fizz-main-wave4c.test.ts) — “keeps valid inline script characters while preventing closing-tag injection”
+- [packages/octane/tests/conformance/invalid-listeners.test.ts](../packages/octane/tests/conformance/invalid-listeners.test.ts) — “a $label listener warns at render and reports an Error at dispatch”
+
+**Executable evidence**
+
+- [escapes text content and attribute values (round-trip)](../packages/octane/tests/conformance/dom-component-ssr.test.ts) — modes: `server-static`, `production-compile`; observables: `markup`
+- [keeps valid inline script characters while preventing closing-tag injection](../packages/octane/tests/conformance/fizz-main-wave4c.test.ts) — modes: `server-string`, `server-stream`, `production-compile`; observables: `markup`
+- [keeps raw style text in one element when it contains closing-tag-like tokens](../packages/octane/tests/conformance/fizz-main-wave4c.test.ts) — modes: `server-string`, `server-stream`, `production-compile`; observables: `markup`
+- [a $label listener warns at render and reports an Error at dispatch](../packages/octane/tests/conformance/invalid-listeners.test.ts) — modes: `client`, `production-compile`; observables: `events`, `errors`
+- [throws for a malformed dangerouslySetInnerHTML value](../packages/octane/tests/conformance/dom-component-children.test.ts) — modes: `client`, `production-compile`; observables: `errors`
+
+**Rationale.** Octane follows React's whole-inline-script escape rather than Redact's exact comment/token spelling, reports invalid listeners instead of silently ignoring them, and rejects malformed raw HTML instead of ignoring extra shapes. The parser/execution containment is covered; byte-level Redact parity is intentionally not claimed.
+
+
+### hydration
+
+<a id="rdx-hyd-001"></a>
+
+#### RDX-HYD-001 — Suspending hydration recovery must not leak an uncaught mismatch
+
+**Disposition:** critical risk; adaptable; planned; owner: Octane runtime hydration and browser tests.
+
+**Upstream evidence**
+
+- [issue #17](https://github.com/TanStack/redact/issues/17) — Hydration bugs: async-resume mismatch escapes uncaught; head-script claiming; innerHTML probe escaping; foreign-node strictness
+- [test: recovers a mismatch when lazy hydration resumes inside Suspense](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/document-hydration.test.tsx#L120-L169) (`tests/document-hydration.test.tsx`)
+
+**Consumer-visible symptom.** A mismatch reached after a lazy hydration suspension reported as recoverable and then escaped through the global error channel, abandoning interaction setup.
+
+**Octane contract.** A client suspension encountered during hydration must converge to exactly one live client arm, report through Octane's chosen hydration channel only, preserve unaffected siblings, and never emit an uncaught error or rejection.
+
+**Applicable modes:** `hydrate-mismatch`, `deferred-hydration`, `production-compile`, `real-browser`. **Observables:** `markup`, `node-identity`, `events`, `errors`.
+
+**Octane references**
+
+- [packages/octane/tests/conformance/fizz-readiness-hydration.test.ts](../packages/octane/tests/conformance/fizz-readiness-hydration.test.ts) — “reports eager pending-arm recovery instead of deferring a streamed-boundary mismatch” — Already proves one final client arm and one expected diagnostic in development and production compile modes.
+- [packages/octane/src/runtime.ts](../packages/octane/src/runtime.ts) — `hideTryContentAndMountPending`
+
+**Next action (test).** Retain the existing one-final-arm oracle, add global error/unhandled-rejection capture, and prove an outside sibling keeps identity and remains interactive after resolution.
+
+Targets: `packages/octane/tests/conformance/fizz-readiness-hydration.test.ts`, `packages/octane/tests/browser`.
+
+**Rationale.** Issue #17 remained open when captured, but Redact main commit e1620a13aab8935c806238f117ba58559b7cd002 contains the matching fix and regression, so the resolution is inferred rather than administratively confirmed. Octane eagerly leaves synchronous hydration for a fresh client arm, so Redact's resumed-cursor implementation bug does not transfer directly; only the missing global-error and outside-sibling observations remain.
+
+
+### hydration-errors
+
+<a id="rdx-hyd-005"></a>
+
+#### RDX-HYD-005 — Hydration recovery reporting has an explicit public contract
+
+**Disposition:** medium risk; adaptable; decision required; owner: Octane public root API.
+
+**Upstream evidence**
+
+- [issue #17](https://github.com/TanStack/redact/issues/17) — Hydration bugs: async-resume mismatch escapes uncaught; head-script claiming; innerHTML probe escaping; foreign-node strictness
+- [commit e1620a13aab8](https://github.com/TanStack/redact/commit/e1620a13aab8935c806238f117ba58559b7cd002) — fix(redact): harden document hydration recovery
+
+**Consumer-visible symptom.** The same hydration failure appeared on both a recoverable callback and the global error channel, making recovery behavior ambiguous to framework integrations.
+
+**Octane contract.** Octane must document whether hydration diagnostics are console-only or root-callback-addressable and ensure every initial, deferred, and streamed recovery path follows that decision exactly once.
+
+**Applicable modes:** `hydrate-match`, `hydrate-mismatch`, `deferred-hydration`, `production-compile`. **Observables:** `errors`.
+
+**Octane references**
+
+- [packages/octane/tests/conformance/hydration-mismatch.test.ts](../packages/octane/tests/conformance/hydration-mismatch.test.ts) — Documents that onRecoverableError is not currently an Octane root option.
+
+**Next action (decision).** Choose and document console-only diagnostics versus recoverable/caught/uncaught root callbacks, including exact deduplication and production behavior, before adding an API.
+
+Targets: `packages/octane/src/runtime.ts`, `docs/ssr.md`.
+
+**Rationale.** Redact's callback surface should not be copied implicitly; frameworks need a deliberate Octane contract if error callbacks become public.
+
+
+### hydration-recovery
+
+<a id="rdx-hyd-006"></a>
+
+#### RDX-HYD-006 — Mismatch recovery is bounded to the failed ownership scope
+
+**Disposition:** high risk; adaptable; planned; owner: Octane hydration cursor and ownership ranges.
+
+**Upstream evidence**
+
+- [test: root fallback produces one clean client tree for wrong element type](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/hydration-mismatch-recovery.test.tsx#L53-L64) (`tests/hydration-mismatch-recovery.test.tsx`)
+- [test: Suspense-scoped extra server node recovery preserves siblings outside the boundary](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/hydration-mismatch-recovery.test.tsx#L183-L208) (`tests/hydration-mismatch-recovery.test.tsx`)
+- [test: Suspense-scoped missing server node recovery preserves siblings outside the boundary](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/hydration-mismatch-recovery.test.tsx#L209-L233) (`tests/hydration-mismatch-recovery.test.tsx`)
+- [test: Suspense-scoped recovery attaches events to the client-rendered subtree](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/hydration-mismatch-recovery.test.tsx#L234-L260) (`tests/hydration-mismatch-recovery.test.tsx`)
+- [test: nearest host recovery preserves siblings outside the failed host subtree](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/hydration-mismatch-recovery.test.tsx#L262-L297) (`tests/hydration-mismatch-recovery.test.tsx`)
+
+**Consumer-visible symptom.** Recovering one mismatched host or Suspense subtree could remount unaffected siblings, abandon the hydration cursor, or leave the regenerated subtree without live handlers.
+
+**Octane contract.** A structural hydration mismatch rebuilds only its owning failed range, preserves the object identity of unaffected siblings outside that range, and installs events on regenerated content.
+
+**Applicable modes:** `hydrate-mismatch`, `production-compile`, `real-browser`. **Observables:** `markup`, `node-identity`, `events`.
+
+**Octane references**
+
+- [packages/octane/tests/conformance/hydration-mismatch.test.ts](../packages/octane/tests/conformance/hydration-mismatch.test.ts) — “hydration continues past a mismatch: the next sibling adopts + is interactive” — Proves final content and sibling interactivity, but does not retain and compare the sibling object across the recovery.
+- [packages/octane/tests/hydration/mismatch-structural.test.ts](../packages/octane/tests/hydration/mismatch-structural.test.ts) — “PROD build: @if branch swap rebuilds SILENTLY (recovery is not gated on the dev loc)” — Proves production recovery but not a nearest-host/Suspense containment matrix.
+
+**Next action (test).** For root, nearest-host, and Suspense-scoped structural mismatches, capture outside siblings before hydration and assert the same objects and handlers survive while the failed subtree is regenerated and its handlers become live in development and production.
+
+Targets: `packages/octane/tests/conformance/hydration-mismatch.test.ts`, `packages/octane/tests/browser`.
+
+**Rationale.** Octane recovers ranges in place instead of following Redact's checkpoint stack, so the transferable requirement is the observable containment boundary rather than checkpoint implementation parity.
+
+
+### memo-scheduling
+
+<a id="rdx-mem-001"></a>
+
+#### RDX-MEM-001 — Memo prop bailouts do not swallow owned updates or revive removed work
+
+**Disposition:** high risk; portable; planned; owner: Octane memo and scheduler.
+
+**Upstream evidence**
+
+- [test: re-renders a memo component when its useSyncExternalStore fires, even with unchanged props](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/memo-state-rerender.test.tsx#L51-L74) (`tests/memo-state-rerender.test.tsx`)
+- [test: does not mount DOM when a pending fiber was unmounted between scheduling and flush](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/memo-state-rerender.test.tsx#L131-L180) (`tests/memo-state-rerender.test.tsx`)
+
+**Consumer-visible symptom.** A stable-prop memo gate swallowed the component's own store update, while stale queued work could render after an ancestor removed it.
+
+**Octane contract.** A memoized component processes its own state/store updates without disabling descendant memo bailouts, and pending work beneath a removed ancestor cannot mount new DOM.
+
+**Applicable modes:** `client`, `production-compile`. **Observables:** `markup`, `effects`.
+
+**Octane references**
+
+- [packages/octane/tests/conformance/update-reconciliation.test.ts](../packages/octane/tests/conformance/update-reconciliation.test.ts) — “should update children even if parent blocks updates”
+- [packages/octane/tests/conformance/update-reconciliation.test.ts](../packages/octane/tests/conformance/update-reconciliation.test.ts) — “does not call render after a component as been deleted”
+
+**Next action (test).** Combine memo with useSyncExternalStore, prove the owner updates while a stable memo grandchild bails, then queue/remove work and prove no zombie DOM or effects appear.
+
+Targets: `packages/octane/tests/conformance/memo-bailout.test.ts`, `packages/octane/tests/conformance/update-reconciliation.test.ts`.
+
+
+### package-resolution
+
+<a id="rdx-pkg-002"></a>
+
+#### RDX-PKG-002 — Packed Vite consumers and supported integration graphs resolve one runtime
+
+**Disposition:** high risk; adaptable; covered; owner: Octane packaging and bundler integrations.
+
+**Upstream evidence**
+
+- [pull request #2](https://github.com/TanStack/redact/pull/2) — refactor!: rename to @tanstack/redact and consolidate into single package
+- [pull request #4](https://github.com/TanStack/redact/pull/4) — fix(redact): switch exports to `default` so RSC + other conditions resolve
+- [pull request #5](https://github.com/TanStack/redact/pull/5) — fix(redact): scope resolve.alias to client+ssr envs so RSC stays on real React
+- [pull request #8](https://github.com/TanStack/redact/pull/8) — Add React DOM edge server aliases
+- [pull request #14](https://github.com/TanStack/redact/pull/14) — feat(redact): vinext SSR/hydration compatibility — 0.0.9
+
+**Consumer-visible symptom.** Source-level tests passed while published export conditions or top-level aliases failed in a real framework environment or selected the wrong runtime graph.
+
+**Octane contract.** Outside-workspace consumers built from packed Octane artifacts resolve one runtime through Vite client and SSR graphs; supported Rspack and Rsbuild environment routing is exercised by their integration builds. This does not claim an external packed-consumer lane for every plugin.
+
+**Applicable modes:** `packaged-consumer`, `vite-client`, `vite-ssr`, `rspack`, `rsbuild`, `production-compile`. **Observables:** `package-resolution`, `markup`.
+
+**Octane references**
+
+- [packages/octane/package.json](../packages/octane/package.json) — Published subpaths provide default conditions.
+- [scripts/check-package-packs.mjs](../scripts/check-package-packs.mjs) — Packs, installs, resolves, builds, and executes consumers outside the workspace.
+
+**Executable evidence**
+
+- [discovers a parent package and routes raw dependency imports to the SSR runtime](../packages/octane/tests/vite-integration.test.ts) — modes: `vite-ssr`, `production-compile`; observables: `package-resolution`, `markup`
+- [builds client and server graphs with maps, raw dependencies, and one target runtime](../packages/rspack-plugin-octane/tests/rspack.test.ts) — modes: `rspack`; observables: `package-resolution`
+- [builds routed client/server environments and serves the production SSR handler](../packages/rsbuild-plugin-octane/tests/rsbuild.integration.test.ts) — modes: `rsbuild`, `production-compile`; observables: `package-resolution`, `markup`
+- command: `pnpm packages:pack:check` — modes: `packaged-consumer`, `vite-client`, `vite-ssr`, `production-compile`; observables: `package-resolution`, `markup`
+
+**Rationale.** The exact React/RSC aliases are Redact-only. Octane's packed canary proves the external Vite boundary, while Rspack and Rsbuild remain honestly labeled workspace integration evidence rather than external packed coverage.
+
+
+### performance
+
+<a id="rdx-perf-001"></a>
+
+#### RDX-PERF-001 — Performance claims use real browsers and multiple controlled workloads
+
+**Disposition:** high risk; portable; documented; owner: Octane core engineering.
+
+**Upstream evidence**
+
+- [pull request #6](https://github.com/TanStack/redact/pull/6) — perf(redact): close ~85% of the render-bench gap to React
+- [pull request #7](https://github.com/TanStack/redact/pull/7) — perf(redact): four more render-bench wins — now ~18% faster than React
+
+**Consumer-visible symptom.** JSDOM suggested the opposite performance result from real Chrome, and a single workload hid regressions in keyed reorder, mount/unmount, deep trees, or state churn.
+
+**Octane contract.** Framework performance changes require same-machine comparable baselines, semantic controls, real-browser measurement for DOM work, representative workload coverage, and bundle/codegen accounting.
+
+**Applicable modes:** `benchmark`, `real-browser`, `production-compile`. **Observables:** `performance`, `markup`, `node-identity`.
+
+**Octane references**
+
+- [.agents/memories/core-engineering.md](../.agents/memories/core-engineering.md) — Requires relevant baselines and forbids unsupported performance claims.
+- [benchmarks/README.md](../benchmarks/README.md) — Defines browser/Node runners, correctness gates, ratios, and workload inventory.
+
+**Rationale.** Octane already follows this discipline. Add or run only the benchmark relevant to a future hot-path change; do not port Redact's optimizations.
+
+
+### portal-updates
+
+<a id="rdx-port-002"></a>
+
+#### RDX-PORT-002 — A stateful portal descendant resolves its foreign host for owned updates
+
+**Disposition:** high risk; adaptable; planned; owner: Octane portal host resolution.
+
+**Upstream evidence**
+
+- [test: re-renders a Portal descendant when its own state updates (getHostParent on Portal)](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/floating-ui-pattern.test.tsx#L133-L163) (`tests/floating-ui-pattern.test.tsx`)
+
+**Consumer-visible symptom.** A component inside a portal scheduled its own state update, resolved the logical parent as its host, and inserted or replaced DOM outside the portal target.
+
+**Octane contract.** A descendant component rendered inside a portal may own and schedule updates while all of its host mutations remain anchored in the supplied portal target and preserve surrounding target siblings.
+
+**Applicable modes:** `client`, `production-compile`. **Observables:** `markup`, `node-identity`.
+
+**Octane references**
+
+- [packages/octane/tests/portal.test.ts](../packages/octane/tests/portal.test.ts) — “compiles and renders an inline host-element body into the target, updating reactively” — Updates state owned outside the portal, so it does not exercise descendant-owned host resolution.
+
+**Next action (test).** Render a child component with its own useState inside a portal, schedule its update from that child, and assert the same target and unaffected target siblings retain identity while only the child's host content changes in development and production compile modes.
+
+Targets: `packages/octane/tests/portal.test.ts`.
+
+
+### portals
+
+<a id="rdx-port-001"></a>
+
+#### RDX-PORT-001 — Portal content mounts in its target and cleans up with its owner
+
+**Disposition:** high risk; portable; covered; owner: Octane portals and UI bindings.
+
+**Upstream evidence**
+
+- [test: mounts portal children into the supplied container](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/portal-doctype.test.tsx#L32-L59) (`tests/portal-doctype.test.tsx`)
+- [test: unmounts portal children when the parent stops rendering them](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/portal-doctype.test.tsx#L61-L81) (`tests/portal-doctype.test.tsx`)
+- [test: renders portal alongside sibling elements correctly](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/portal-doctype.test.tsx#L83-L113) (`tests/portal-doctype.test.tsx`)
+
+**Consumer-visible symptom.** Portal content mounted outside its supplied target or remained there after the logical owner stopped rendering it.
+
+**Octane contract.** Portal content mounts in the supplied foreign target, and closing or unmounting its logical owner removes that content.
+
+**Applicable modes:** `client`, `production-compile`. **Observables:** `markup`.
+
+**Octane references**
+
+- [packages/octane/tests/portal.test.ts](../packages/octane/tests/portal.test.ts) — “compiles and renders an inline host-element body into the target, updating reactively”
+
+**Executable evidence**
+
+- [compiles and renders an inline host-element body into the target, updating reactively](../packages/octane/tests/portal.test.ts) — modes: `client`, `production-compile`; observables: `markup`
+- [unmounts portal content when the if-branch closes](../packages/octane/tests/portal.test.ts) — modes: `client`, `production-compile`; observables: `markup`
+
+
+### public-exports
+
+<a id="rdx-pkg-001"></a>
+
+#### RDX-PKG-001 — Advertised named exports are locked at the consumer boundary
+
+**Disposition:** medium risk; portable; planned; owner: Octane package surface.
+
+**Upstream evidence**
+
+- [pull request #2](https://github.com/TanStack/redact/pull/2) — refactor!: rename to @tanstack/redact and consolidate into single package
+- [test: exposes hooks needed by use-sync-external-store/shim/* aliases](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/public-exports.test.ts#L170-L180) (`tests/public-exports.test.ts`)
+
+**Consumer-visible symptom.** A hook existed in source but was omitted from the package entrypoint, producing a link-time failure only in a downstream consumer.
+
+**Octane contract.** Every intended value export for each public Octane subpath is checked from the built or packed artifact, so removing a re-export is an explicit review event rather than a downstream surprise.
+
+**Applicable modes:** `packaged-consumer`, `production-compile`. **Observables:** `package-resolution`.
+
+**Octane references**
+
+- [packages/octane/scripts/verify-dist.mjs](../packages/octane/scripts/verify-dist.mjs) — `smokeDist` — Proves every JS entry imports, but not that a specific named export remains present.
+- [scripts/check-package-packs.mjs](../scripts/check-package-packs.mjs) — Builds isolated consumers from packed workspace artifacts.
+
+**Next action (test).** Derive or explicitly declare intended named-export sets for public core subpaths and validate them from the built or packed artifact without making harmless additive exports unnecessarily brittle.
+
+Targets: `packages/octane/scripts/verify-dist.mjs`, `scripts/check-package-packs.mjs`.
+
+
+### raw-text-hydration
+
+<a id="rdx-hyd-003"></a>
+
+#### RDX-HYD-003 — Raw script and style hydration must use their parsing contexts
+
+**Disposition:** high risk; portable; planned; owner: Octane DOM hydration and SSR serialization.
+
+**Upstream evidence**
+
+- [issue #17](https://github.com/TanStack/redact/issues/17) — Hydration bugs: async-resume mismatch escapes uncaught; head-script claiming; innerHTML probe escaping; foreign-node strictness
+- [test: hydrates matching raw script content without HTML normalization](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/document-hydration.test.tsx#L208-L223) (`tests/document-hydration.test.tsx`)
+
+**Consumer-visible symptom.** Byte-equivalent script or style text containing ampersands or less-than signs was parsed through a generic div and falsely reported as mismatched.
+
+**Octane contract.** Hydration comparison must respect script-data and style raw-text parsing, preserve node identity for equivalent server bytes, avoid false diagnostics, and remain safe against closing-tag injection.
+
+**Applicable modes:** `server-string`, `server-stream`, `hydrate-match`, `production-compile`, `real-browser`. **Observables:** `markup`, `node-identity`, `errors`.
+
+**Octane references**
+
+- [packages/octane/src/runtime.ts](../packages/octane/src/runtime.ts) — `setHTML` — Script uses textContent; other hosts use a same-tag contextual probe.
+- [packages/octane/tests/script-innerhtml.test.ts](../packages/octane/tests/script-innerhtml.test.ts) — “hydrates the server-safe script spelling by adoption and applies later updates” — Script coverage is already strong.
+- [packages/octane/tests/conformance/fizz-main-wave4c.test.ts](../packages/octane/tests/conformance/fizz-main-wave4c.test.ts) — “keeps raw style text in one element when it contains closing-tag-like tokens” — Current style evidence is server-only.
+
+**Next action (test).** Add server-render, parse, hydrate, and update coverage for raw style text containing &amp;&amp;, &lt;, entity-like text, and closing-tag-like tokens; assert adoption and no warning in the unit lane, then use Chromium/CSSOM to prove intact stylesheet semantics.
+
+Targets: `packages/octane/tests/script-innerhtml.test.ts`, `packages/octane/tests/browser`.
+
+**Rationale.** The Redact script failure is already prevented; the remaining gap is direct hydration evidence for style's distinct raw-text and SSR-escape behavior.
+
+
+### reconciliation
+
+<a id="rdx-rec-001"></a>
+
+#### RDX-REC-001 — Keyed reorders preserve survivor identity and final order
+
+**Disposition:** high risk; adaptable; covered; owner: Octane reconciler.
+
+**Upstream evidence**
+
+- [test: reorders keyed list items preserving DOM identity](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/child-reorder.test.tsx#L95-L128) (`tests/child-reorder.test.tsx`)
+
+**Consumer-visible symptom.** A keyed reorder produced the right text but recreated survivor DOM nodes or left them in the wrong final order.
+
+**Octane contract.** Keyed survivors retain object identity and reach the requested final order; Octane's LIS-selected physical move set need not match React or Redact.
+
+**Applicable modes:** `client`, `production-compile`. **Observables:** `markup`, `node-identity`.
+
+**Octane references**
+
+- [packages/octane/tests/conformance/multichild-identity.test.ts](../packages/octane/tests/conformance/multichild-identity.test.ts) — “reverse preserves all instances (pure moves)”
+- [packages/octane/tests/conformance/fuzz-keyed-list.test.ts](../packages/octane/tests/conformance/fuzz-keyed-list.test.ts) — Exercises prefix, tail, small-displacement, and LIS paths across deterministic mutation streams.
+
+**Executable evidence**
+
+- [reverse preserves all instances (pure moves)](../packages/octane/tests/conformance/multichild-identity.test.ts) — modes: `client`, `production-compile`; observables: `markup`, `node-identity`
+- [inserting in the middle preserves existing instances](../packages/octane/tests/conformance/multichild-identity.test.ts) — modes: `client`, `production-compile`; observables: `markup`, `node-identity`
+
+**Rationale.** Physical move-sequence parity is intentionally excluded because Octane's LIS reconciler promises final order and survivor identity with fewer moves.
+
+
+### reconciliation-placement
+
+<a id="rdx-rec-002"></a>
+
+#### RDX-REC-002 — Topology transitions use the correct absolute anchor without stable reattachment
+
+**Disposition:** high risk; adaptable; planned; owner: Octane reconciler and portal placement.
+
+**Upstream evidence**
+
+- [test: Sidebar Portal→div via Provider cascade: new div lands BEFORE chat](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/place-children-anchor.test.tsx#L31-L99) (`tests/place-children-anchor.test.tsx`)
+- [test: first child swaps Portal→div with multiple later siblings](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/place-children-anchor.test.tsx#L101-L158) (`tests/place-children-anchor.test.tsx`)
+- [test: first child goes null→div via Provider cascade: new div at index 0](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/place-children-anchor.test.tsx#L160-L202) (`tests/place-children-anchor.test.tsx`)
+- [test: stable re-render does not reorder stable DOM](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/place-children-anchor.test.tsx#L204-L242) (`tests/place-children-anchor.test.tsx`)
+
+**Consumer-visible symptom.** A Portal-to-element or null-to-element transition inserted new output after the wrong sibling, while a no-op rerender could detach and reinsert otherwise stable DOM.
+
+**Octane contract.** When a child changes topology, each newly materialized range lands at its absolute logical anchor around portal and ordinary siblings; a stable rerender emits no child-list mutations and preserves every existing host object.
+
+**Applicable modes:** `client`, `production-compile`, `real-browser`. **Observables:** `markup`, `node-identity`, `dom-mutations`.
+
+**Octane references**
+
+- [packages/octane/tests/differential/anchor-order.test.ts](../packages/octane/tests/differential/anchor-order.test.ts) — Covers final source order across control-flow transitions, but differential HTML cannot see host reattachment and has no portal topology case.
+- [packages/octane/tests/portal.test.ts](../packages/octane/tests/portal.test.ts) — “unmounts portal content when the if-branch closes” — Covers removal/recreation, not Portal→ordinary replacement around stable siblings.
+
+**Next action (test).** Port Portal→element and null→element first-child transitions with multiple stable later siblings; retain every survivor object, assert exact final order, and use MutationObserver in Chromium to prove a stable rerender produces no child-list records.
+
+Targets: `packages/octane/tests/portal.test.ts`, `packages/octane/tests/browser`.
+
+**Rationale.** The existing keyed identity suite proves a different reconciler contract. Redact's topology cases require portal-aware absolute placement plus a mutation-level oracle, so they remain an explicit gap instead of being hidden under RDX-REC-001.
+
+
+### redact-specific-surfaces
+
+<a id="rdx-non-001"></a>
+
+#### RDX-NON-001 — React package shims, RSC internals, and private debug names are not Octane targets
+
+**Disposition:** low risk; non goal; documented; owner: Octane architecture.
+
+**Upstream evidence**
+
+- [pull request #5](https://github.com/TanStack/redact/pull/5) — fix(redact): scope resolve.alias to client+ssr envs so RSC stays on real React
+- [pull request #8](https://github.com/TanStack/redact/pull/8) — Add React DOM edge server aliases
+- [pull request #11](https://github.com/TanStack/redact/pull/11) — Expose ReactDOM Flight hint internals
+- [pull request #12](https://github.com/TanStack/redact/pull/12) — chore(redact/hydration): rename internal '__tdom*' scroll-guard globals to '__redact*'
+- [pull request #14](https://github.com/TanStack/redact/pull/14) — feat(redact): vinext SSR/hydration compatibility — 0.0.9
+
+**Consumer-visible symptom.** Redact needed compatibility with React package names, Flight private internals, RSC environment routing, and legacy internal global names.
+
+**Octane contract.** Octane remains responsible for its public runtime, compiler, SSR, hydration, and documented bundler integrations, not for impersonating React private package or Flight surfaces.
+
+**Applicable modes:** `vite-client`, `vite-ssr`, `packaged-consumer`. **Observables:** `package-resolution`.
+
+**Octane references**
+
+- [docs/differences-from-react.md](../docs/differences-from-react.md) — Records unsupported React-only surfaces.
+
+**Rationale.** Class components, forwardRef, Server Components/Flight, React package aliases, Redact's renderer registry, and private debug globals are architecture-specific exclusions. Portable packaging or SSR lessons are tracked separately.
+
+
+### refs
+
+<a id="rdx-ref-001"></a>
+
+#### RDX-REF-001 — Callback refs run in commit order and clean up exactly once
+
+**Disposition:** high risk; portable; covered; owner: Octane refs and commit phase.
+
+**Upstream evidence**
+
+- [test: does not invoke a callback ref during render](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/callback-ref-commit-phase.test.tsx#L33-L65) (`tests/callback-ref-commit-phase.test.tsx`)
+- [test: runs the cleanup ref(null) on unmount](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/callback-ref-commit-phase.test.tsx#L67-L85) (`tests/callback-ref-commit-phase.test.tsx`)
+- [test: runs the user-provided cleanup function returned from a callback ref](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/callback-ref-commit-phase.test.tsx#L87-L113) (`tests/callback-ref-commit-phase.test.tsx`)
+
+**Consumer-visible symptom.** A callback ref fired during render or received both its returned cleanup and a redundant null detach call.
+
+**Octane contract.** Refs attach only after connected DOM exists, precede layout-effect bodies, detach in the documented commit order, and use either cleanup-return or legacy null notification exactly once.
+
+**Applicable modes:** `client`, `production-compile`. **Observables:** `refs`, `effects`.
+
+**Octane references**
+
+- [packages/octane/tests/ref-timing.test.ts](../packages/octane/tests/ref-timing.test.ts) — “ref attaches before the layout effect body (mount), layout cleanup before ref detach (unmount)”
+- [packages/octane/tests/conformance/refs.test.ts](../packages/octane/tests/conformance/refs.test.ts) — “handles detaching refs with either cleanup function or null argument”
+
+**Executable evidence**
+
+- [a callback ref fires with a node already connected to the document](../packages/octane/tests/ref-timing.test.ts) — modes: `client`, `production-compile`; observables: `refs`
+- [ref attaches before the layout effect body (mount), layout cleanup before ref detach (unmount)](../packages/octane/tests/ref-timing.test.ts) — modes: `client`, `production-compile`; observables: `refs`, `effects`
+- [handles detaching refs with either cleanup function or null argument](../packages/octane/tests/conformance/refs.test.ts) — modes: `client`, `production-compile`; observables: `refs`
+
+
+### root-ownership
+
+<a id="rdx-hyd-004"></a>
+
+#### RDX-HYD-004 — Foreign document nodes do not weaken ordinary element-root ownership
+
+**Disposition:** medium risk; non goal; documented; owner: Octane root API and metaframework integrations.
+
+**Upstream evidence**
+
+- [issue #17](https://github.com/TanStack/redact/issues/17) — Hydration bugs: async-resume mismatch escapes uncaught; head-script claiming; innerHTML probe escaping; foreign-node strictness
+- [pull request #10](https://github.com/TanStack/redact/pull/10) — Project document head elements
+- [test: preserves foreign nodes after expected document body children](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/document-hydration.test.tsx#L87-L118) (`tests/document-hydration.test.tsx`)
+
+**Consumer-visible symptom.** A hidden iframe injected at the open document boundary caused whole-document hydration to fail, even though it was not application-owned content.
+
+**Octane contract.** The element passed to hydrateRoot remains strictly owned: ordinary unclaimed content inside it is diagnosed and removed, while ordinary nodes outside it are untouched. Explicit portal targets and compiler-owned head hoists follow their own ownership contracts. Document/body tolerance requires a separate explicit API and ownership decision.
+
+**Applicable modes:** `hydrate-mismatch`, `real-browser`. **Observables:** `markup`, `node-identity`, `errors`.
+
+**Octane references**
+
+- [packages/octane/src/runtime.ts](../packages/octane/src/runtime.ts) — `finishRoot` — Intentionally diagnoses and removes unclaimed root siblings.
+- [packages/octane/tests/conformance/hydration-mismatch.test.ts](../packages/octane/tests/conformance/hydration-mismatch.test.ts) — “server renders an extra element the client omits (Per :834)”
+
+**Rationale.** Octane hydrates a supplied Element rather than Document. Redact's body-level tolerance must not become blanket permissiveness inside an application-owned container. Revisit only if Octane introduces document/body hydration.
+
+<a id="rdx-root-001"></a>
+
+#### RDX-ROOT-001 — The first root render clears foreign children exactly once
+
+**Disposition:** high risk; portable; covered; owner: Octane root lifecycle.
+
+**Upstream evidence**
+
+- [test: clears pre-existing children on the first render](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/create-root-clear-container.test.tsx#L27-L37) (`tests/create-root-clear-container.test.tsx`)
+- [test: does not re-clear on subsequent renders (preserves reconciled DOM)](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/create-root-clear-container.test.tsx#L39-L55) (`tests/create-root-clear-container.test.tsx`)
+
+**Consumer-visible symptom.** A root either left stale foreign children in its managed container or cleared the entire container again on an update, destroying reconciled host identity.
+
+**Octane contract.** The first createRoot render removes pre-existing unowned children before mounting the client tree; later renders reconcile that managed tree without clearing the container and preserve stable host objects.
+
+**Applicable modes:** `client`, `production-compile`. **Observables:** `markup`, `node-identity`.
+
+**Octane references**
+
+- [packages/octane/tests/conformance/root-semantics.test.ts](../packages/octane/tests/conformance/root-semantics.test.ts) — “clears existing children”
+- [packages/octane/tests/conformance/root-semantics.test.ts](../packages/octane/tests/conformance/root-semantics.test.ts) — “should reuse markup if rendering to the same target twice”
+
+**Executable evidence**
+
+- [clears existing children](../packages/octane/tests/conformance/root-semantics.test.ts) — modes: `client`, `production-compile`; observables: `markup`
+- [should reuse markup if rendering to the same target twice](../packages/octane/tests/conformance/root-semantics.test.ts) — modes: `client`, `production-compile`; observables: `markup`, `node-identity`
+
+
+### ssr-streaming
+
+<a id="rdx-ssr-001"></a>
+
+#### RDX-SSR-001 — SSR retries and render replays are transactional and request-scoped
+
+**Disposition:** critical risk; portable; covered; owner: Octane server renderer and streaming transports.
+
+**Upstream evidence**
+
+- [pull request #9](https://github.com/TanStack/redact/pull/9) — Support vinext SSR stream bootstrap
+- [pull request #14](https://github.com/TanStack/redact/pull/14) — feat(redact): vinext SSR/hydration compatibility — 0.0.9
+- [test: restores nested providers](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/ssr-context.test.tsx#L52-L83) (`tests/ssr-context.test.tsx`)
+- [test: retries when the root render suspends before any boundary](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/ssr.test.tsx#L160-L174) (`tests/ssr.test.tsx`)
+- [test: hydrates a resolved boundary against the streamed real content](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/streaming-hydration.test.tsx#L43-L90) (`tests/streaming-hydration.test.tsx`)
+- [test: re-hydrates a pending boundary when the server reveal fires](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/streaming-hydration.test.tsx#L92-L157) (`tests/streaming-hydration.test.tsx`)
+
+**Consumer-visible symptom.** A root-level suspension or boundary replay could leak partial chunks, IDs, boundary records, or provider values into the retry or another request.
+
+**Octane contract.** Buffered render replays and streamed retries isolate render state, retire discarded boundary records, preserve provider stacks and stable IDs, hydrate revealed ranges in place, and report terminal root failure once.
+
+**Applicable modes:** `server-string`, `server-static`, `server-stream`, `hydrate-match`. **Observables:** `markup`, `node-identity`, `streaming`, `errors`.
+
+**Octane references**
+
+- [packages/octane/tests/ssr-stream-state-regressions.test.ts](../packages/octane/tests/ssr-stream-state-regressions.test.ts) — Covers discarded passes, stable IDs, retired boundaries, and late errors.
+- [packages/octane/tests/streaming-ssr.test.ts](../packages/octane/tests/streaming-ssr.test.ts) — Covers stream/hydration interleavings, reveal replacement, failure reporting, and seed scopes.
+- [docs/ssr.md](../docs/ssr.md) — Bootstrap modules/import maps remain a metaframework concern rather than a core renderer option.
+
+**Executable evidence**
+
+- [settled output is byte-identical to a single-pass render of the final state (useId, markers, sibling order)](../packages/octane/tests/ssr-render-phase-state.test.ts) — modes: `server-string`; observables: `markup`
+- [rewinds the suspense seed stream — one use() seeds exactly once across the passes](../packages/octane/tests/ssr-render-phase-state.test.ts) — modes: `server-static`; observables: `markup`
+- [restores each Provider value across suspended concurrent streams](../packages/octane/tests/conformance/fizz-streaming.test.ts) — modes: `server-stream`; observables: `markup`, `streaming`
+- [delivers a boundary that resolves while a bare Promise delays the shell](../packages/octane/tests/conformance/fizz-streaming.test.ts) — modes: `server-stream`; observables: `markup`, `streaming`
+- [does not retain a boundary registered by a discarded render-phase pass](../packages/octane/tests/ssr-stream-state-regressions.test.ts) — modes: `server-stream`; observables: `streaming`
+- [swaps the segment into place, scopes its seeds, and hydrates byte-for-byte](../packages/octane/tests/streaming-ssr.test.ts) — modes: `server-stream`, `hydrate-match`; observables: `markup`, `node-identity`, `streaming`
+- [reports a root failure through the shell callbacks and rejects a readable stream](../packages/octane/tests/conformance/fizz-streaming.test.ts) — modes: `server-stream`; observables: `errors`, `streaming`
+
+**Rationale.** Redact's inline bootstrap API belongs at Octane's plugin/adapter boundary; the portable transactional retry and request-isolation contracts are already strongly covered.
+
+
+### suspense-preservation
+
+<a id="rdx-sus-001"></a>
+
+#### RDX-SUS-001 — Re-suspension preserves browser-owned state in committed UI
+
+**Disposition:** critical risk; portable; planned; owner: Octane Suspense runtime and browser tests.
+
+**Upstream evidence**
+
+- [pull request #16](https://github.com/TanStack/redact/pull/16) — fix(redact): preserve committed DOM across Suspense re-suspension
+- [test: preserves focus on an input across a sibling suspension](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/suspense-preserves-dom.test.tsx#L170-L220) (`tests/suspense-preserves-dom.test.tsx`)
+
+**Consumer-visible symptom.** Navigating through a suspension destroyed a committed sidebar, resetting scroll and focus even though the logical UI survived.
+
+**Octane contract.** An already committed Suspense primary tree preserves node identity, component state, scroll, focus, selection, uncontrolled values, and other browser-owned state through urgent and transitioned re-suspension, while refs/effects follow Octane's documented lifecycle.
+
+**Applicable modes:** `client`, `production-compile`, `real-browser`. **Observables:** `node-identity`, `focus`, `selection`, `scroll`, `live-properties`, `effects`, `refs`.
+
+**Octane references**
+
+- [packages/octane/src/runtime.ts](../packages/octane/src/runtime.ts) — `softDetachTryBlock` — Ordinary Suspense currently parks committed DOM in savedDom before reinsertion.
+- [packages/octane/tests/conformance/suspense-refs.test.ts](../packages/octane/tests/conformance/suspense-refs.test.ts) — “detaches host refs on suspend and re-attaches on reveal” — Proves reuse of the same node, not browser focus/scroll preservation.
+- [packages/octane/tests/conformance/suspense-effects-semantics.test.ts](../packages/octane/tests/conformance/suspense-effects-semantics.test.ts) — “destroys the committed layout effect on re-suspend, recreates on reveal”
+
+**Next action (test).** In real Chromium, cover same-tree and route-swap re-suspension with identity, scrollTop, activeElement, selection, uncontrolled value, state, refs, and effect logs for urgent and transitioned paths before changing the hiding mechanism.
+
+Targets: `packages/octane/tests/browser`, `packages/octane/tests/suspense.test.ts`.
+
+**Rationale.** The observable preservation contract transfers; Redact's display:none and detached-fallback fiber implementation does not. JSDOM is insufficient for the browser-owned state assertions.
+
+
+### use-id
+
+<a id="rdx-id-001"></a>
+
+#### RDX-ID-001 — Each root owns a deterministic useId sequence
+
+**Disposition:** high risk; portable; covered; owner: Octane root and SSR identity.
+
+**Upstream evidence**
+
+- [commit e1620a13aab8](https://github.com/TanStack/redact/commit/e1620a13aab8935c806238f117ba58559b7cd002) — fix(redact): harden document hydration recovery
+- [test: starts hydrated useId sequences from each server-rendered root](https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/hydration.test.tsx#L232-L266) (`tests/hydration.test.tsx`)
+
+**Consumer-visible symptom.** A prior root's allocations shifted the next root's hydrated IDs away from the server sequence.
+
+**Octane contract.** Sibling client roots are independently namespaced, server IDs hydrate byte-for-byte, and explicit identifier prefixes compose with root-local allocation.
+
+**Applicable modes:** `client`, `server-string`, `server-stream`, `hydrate-match`, `production-compile`. **Observables:** `markup`.
+
+**Octane references**
+
+- [packages/octane/tests/conformance/useid-determinism.test.ts](../packages/octane/tests/conformance/useid-determinism.test.ts) — “automatically namespaces sibling createRoot roots”
+- [packages/octane/tests/conformance/useid-determinism.test.ts](../packages/octane/tests/conformance/useid-determinism.test.ts) — “server useId is preserved byte-for-byte after hydrateRoot()”
+
+**Executable evidence**
+
+- [automatically namespaces sibling createRoot roots](../packages/octane/tests/conformance/useid-determinism.test.ts) — modes: `client`, `production-compile`; observables: `markup`
+- [server useId is preserved byte-for-byte after hydrateRoot()](../packages/octane/tests/conformance/useid-determinism.test.ts) — modes: `server-string`, `hydrate-match`, `production-compile`; observables: `markup`
+- [hydrates completed boundary useId values in its opaque stream namespace](../packages/octane/tests/streaming-ssr.test.ts) — modes: `server-stream`, `hydrate-match`, `production-compile`; observables: `markup`

--- a/docs/ssr.md
+++ b/docs/ssr.md
@@ -332,8 +332,8 @@ These are the known gaps between Octane SSR and a full streaming SSR stack:
   React-style error digests. Recoverable Suspense errors retain their fallback
   and mark that boundary for client rendering; a fatal post-shell error ends the
   stream with every still-pending boundary marked for client rendering.
-- **React Fizz document orchestration options**: core rendering deliberately
-  does not own doctype/preamble insertion, bootstrap script/module lists,
-  import-map construction, response headers, or `onHeaders`. Compose the
-  returned stream into the surrounding document and set headers in the Vite
-  plugin, adapter, or application server instead.
+- **Document orchestration beyond the streaming doctype**: a streamed `<html>`
+  root gets the core-owned doctype described above, but core does not own
+  arbitrary preamble insertion, bootstrap script/module lists, import-map
+  construction, response headers, or `onHeaders`. Compose those concerns around
+  the returned stream in the Vite plugin, adapter, or application server.

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "react-parity:check": "node scripts/react-parity/check.mjs",
     "react-parity:candidates": "node scripts/react-parity/citation-candidates.mjs",
     "react-parity:test": "node --test scripts/react-parity/*.test.mjs scripts/scaffold-react-port.test.mjs",
+    "redact-audit:generate": "node scripts/redact-audit/generate.mjs",
+    "redact-audit:check": "node scripts/redact-audit/generate.mjs --check && node --test scripts/redact-audit/*.test.mjs",
     "error-codes:generate": "node scripts/error-codes/generate.mjs",
     "error-codes:check": "node scripts/error-codes/generate.mjs --check && node --test scripts/error-codes/*.test.mjs",
     "binding-parity:gaps": "node scripts/generate-binding-parity-gaps.mjs",

--- a/packages/octane/audit/redact-adversarial-ledger.json
+++ b/packages/octane/audit/redact-adversarial-ledger.json
@@ -1,0 +1,1802 @@
+{
+  "$schema": "./redact-adversarial-ledger.schema.json",
+  "schemaVersion": 1,
+  "upstream": {
+    "repository": "https://github.com/TanStack/redact",
+    "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+    "capturedOn": "2026-07-22",
+    "scope": {
+      "issueNumbers": [17],
+      "pullRequestNumbers": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+      "paths": [
+        "packages/redact/src/core",
+        "packages/redact/src/dom",
+        "packages/redact/src/react",
+        "packages/redact/src/scheduler",
+        "packages/redact/src/server",
+        "packages/redact/src/vite",
+        "scripts",
+        "tests"
+      ],
+      "artifacts": [
+        {
+          "path": "tests/callback-ref-commit-phase.test.tsx",
+          "disposition": "mapped",
+          "entryIds": ["RDX-REF-001"]
+        },
+        {
+          "path": "tests/child-reorder.test.tsx",
+          "disposition": "mapped",
+          "entryIds": ["RDX-REC-001"]
+        },
+        {
+          "path": "tests/controlled-input.test.tsx",
+          "disposition": "folded",
+          "entryIds": ["RDX-EVT-001"],
+          "note": "The native-event observation boundary transfers; Redact's synthetic onChange mapping is an explicit Octane divergence."
+        },
+        {
+          "path": "tests/create-root-clear-container.test.tsx",
+          "disposition": "mapped",
+          "entryIds": ["RDX-ROOT-001"]
+        },
+        {
+          "path": "tests/document-hydration.test.tsx",
+          "disposition": "mapped",
+          "entryIds": ["RDX-HYD-001", "RDX-HYD-002", "RDX-HYD-003", "RDX-HYD-004"]
+        },
+        {
+          "path": "tests/event-replay.test.ts",
+          "disposition": "mapped",
+          "entryIds": ["RDX-EVT-002"]
+        },
+        {
+          "path": "tests/external-store-unmount.test.tsx",
+          "disposition": "mapped",
+          "entryIds": ["RDX-STORE-001"]
+        },
+        {
+          "path": "tests/floating-ui-pattern.test.tsx",
+          "disposition": "mapped",
+          "entryIds": ["RDX-PORT-002"]
+        },
+        {
+          "path": "tests/hydration-mismatch-recovery.test.tsx",
+          "disposition": "mapped",
+          "entryIds": ["RDX-HYD-006"]
+        },
+        {
+          "path": "tests/hydration.test.tsx",
+          "disposition": "mapped",
+          "entryIds": ["RDX-ID-001"]
+        },
+        {
+          "path": "tests/memo-state-rerender.test.tsx",
+          "disposition": "mapped",
+          "entryIds": ["RDX-MEM-001"]
+        },
+        {
+          "path": "tests/place-children-anchor.test.tsx",
+          "disposition": "mapped",
+          "entryIds": ["RDX-REC-002"]
+        },
+        {
+          "path": "tests/portal-doctype.test.tsx",
+          "disposition": "mapped",
+          "entryIds": ["RDX-PORT-001", "RDX-SSR-002"]
+        },
+        {
+          "path": "tests/public-exports.test.ts",
+          "disposition": "mapped",
+          "entryIds": ["RDX-PKG-001"]
+        },
+        {
+          "path": "tests/react-integration/reconnecting.test.tsx",
+          "disposition": "folded",
+          "entryIds": ["RDX-HYD-006", "RDX-NON-001"],
+          "note": "Host reconnecting outcomes transfer; class-component cases are explicit non-goals."
+        },
+        {
+          "path": "tests/security.test.tsx",
+          "disposition": "mapped",
+          "entryIds": ["RDX-SEC-001"]
+        },
+        {
+          "path": "tests/ssr-context.test.tsx",
+          "disposition": "mapped",
+          "entryIds": ["RDX-SSR-001"]
+        },
+        {
+          "path": "tests/ssr.test.tsx",
+          "disposition": "mapped",
+          "entryIds": ["RDX-SSR-001"]
+        },
+        {
+          "path": "tests/streaming-hydration.test.tsx",
+          "disposition": "folded",
+          "entryIds": ["RDX-HYD-001", "RDX-SSR-001"],
+          "note": "The cases reinforce streamed-boundary recovery and transactional streaming entries."
+        },
+        {
+          "path": "tests/suspense-preserves-dom.test.tsx",
+          "disposition": "mapped",
+          "entryIds": ["RDX-SUS-001"]
+        },
+        {
+          "path": "tests/use-effect-coalesced-renders.test.tsx",
+          "disposition": "mapped",
+          "entryIds": ["RDX-LIF-001"]
+        },
+        {
+          "path": "tests/vite-plugin.test.ts",
+          "disposition": "folded",
+          "entryIds": ["RDX-CFG-001", "RDX-PKG-002"],
+          "note": "Redact-specific React aliases are excluded; option-to-output and environment-routing lessons transfer."
+        }
+      ]
+    }
+  },
+  "idRegistry": [
+    { "id": "RDX-CFG-001", "status": "active", "introducedOn": "2026-07-22" },
+    { "id": "RDX-DOC-001", "status": "active", "introducedOn": "2026-07-22" },
+    { "id": "RDX-EVT-001", "status": "active", "introducedOn": "2026-07-22" },
+    { "id": "RDX-EVT-002", "status": "active", "introducedOn": "2026-07-22" },
+    { "id": "RDX-HYD-001", "status": "active", "introducedOn": "2026-07-22" },
+    { "id": "RDX-HYD-002", "status": "active", "introducedOn": "2026-07-22" },
+    { "id": "RDX-HYD-003", "status": "active", "introducedOn": "2026-07-22" },
+    { "id": "RDX-HYD-004", "status": "active", "introducedOn": "2026-07-22" },
+    { "id": "RDX-HYD-005", "status": "active", "introducedOn": "2026-07-22" },
+    { "id": "RDX-HYD-006", "status": "active", "introducedOn": "2026-07-22" },
+    { "id": "RDX-ID-001", "status": "active", "introducedOn": "2026-07-22" },
+    { "id": "RDX-LIF-001", "status": "active", "introducedOn": "2026-07-22" },
+    { "id": "RDX-MEM-001", "status": "active", "introducedOn": "2026-07-22" },
+    { "id": "RDX-NON-001", "status": "active", "introducedOn": "2026-07-22" },
+    { "id": "RDX-PERF-001", "status": "active", "introducedOn": "2026-07-22" },
+    { "id": "RDX-PKG-001", "status": "active", "introducedOn": "2026-07-22" },
+    { "id": "RDX-PKG-002", "status": "active", "introducedOn": "2026-07-22" },
+    { "id": "RDX-PORT-001", "status": "active", "introducedOn": "2026-07-22" },
+    { "id": "RDX-PORT-002", "status": "active", "introducedOn": "2026-07-22" },
+    { "id": "RDX-REC-001", "status": "active", "introducedOn": "2026-07-22" },
+    { "id": "RDX-REC-002", "status": "active", "introducedOn": "2026-07-22" },
+    { "id": "RDX-REF-001", "status": "active", "introducedOn": "2026-07-22" },
+    { "id": "RDX-ROOT-001", "status": "active", "introducedOn": "2026-07-22" },
+    { "id": "RDX-SEC-001", "status": "active", "introducedOn": "2026-07-22" },
+    { "id": "RDX-SSR-001", "status": "active", "introducedOn": "2026-07-22" },
+    { "id": "RDX-SSR-002", "status": "active", "introducedOn": "2026-07-22" },
+    { "id": "RDX-STORE-001", "status": "active", "introducedOn": "2026-07-22" },
+    { "id": "RDX-SUS-001", "status": "active", "introducedOn": "2026-07-22" }
+  ],
+  "entries": [
+    {
+      "id": "RDX-CFG-001",
+      "area": "build-configuration",
+      "title": "Public options must change the emitted build at their observation boundary",
+      "sources": [
+        {
+          "kind": "pull_request",
+          "number": 15,
+          "url": "https://github.com/TanStack/redact/pull/15",
+          "title": "fix(redact/vite): respect 'forwardRef' and 'classComponents' feature flags"
+        },
+        {
+          "kind": "commit",
+          "commit": "04f39662123a2ca9c896dca0a35429b0554a4847",
+          "url": "https://github.com/TanStack/redact/commit/04f39662123a2ca9c896dca0a35429b0554a4847"
+        }
+      ],
+      "symptom": "A documented false-valued feature flag silently left the full implementation in the bundle because an internal folder name was cast to an unrelated public option key.",
+      "octaneContract": "Every public compiler or bundler boolean must have a test proving the option changes emitted code, resolution, bundle contents, or runtime behavior in each environment where it is supported.",
+      "classification": "adaptable",
+      "status": "planned",
+      "risk": "medium",
+      "owner": "Octane compiler and Vite/Rspack/Rsbuild integrations",
+      "applicableModes": ["production-compile", "vite-client", "vite-ssr", "rspack", "rsbuild"],
+      "observables": ["markup", "package-resolution"],
+      "octaneReferences": [
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/hmr.test.ts",
+          "testName": "hmr option off → no wrapping, no accept block",
+          "note": "Representative direct option-to-output coverage; not yet a complete public-option matrix."
+        },
+        {
+          "kind": "test",
+          "file": "packages/rspack-plugin-octane/tests/rspack.test.ts",
+          "testName": "erases profiling and full diagnostics from a real production bundle"
+        }
+      ],
+      "nextAction": {
+        "kind": "test",
+        "targets": [
+          "packages/octane/tests",
+          "packages/vite-plugin-octane/tests",
+          "packages/rspack-plugin-octane/tests",
+          "packages/rsbuild-plugin-octane/tests"
+        ],
+        "acceptance": "Inventory public booleans and renderer mappings, then prove both enabled and disabled behavior at emitted-output or resolved-module boundaries without relying on unchecked name casts."
+      },
+      "rationale": "Redact's forwardRef and class-component flags are out of scope; the transferable lesson is to test configuration where consumers observe it."
+    },
+    {
+      "id": "RDX-DOC-001",
+      "area": "documentation",
+      "title": "Surface, protocol, and size documentation must follow executable evidence",
+      "sources": [
+        {
+          "kind": "pull_request",
+          "number": 3,
+          "url": "https://github.com/TanStack/redact/pull/3",
+          "title": "docs: update SURFACE.md and SAVINGS_ANALYSIS.md for @tanstack/redact"
+        },
+        {
+          "kind": "pull_request",
+          "number": 13,
+          "url": "https://github.com/TanStack/redact/pull/13",
+          "title": "docs(redact/server): correct fallback wire-format comment — fallback '<div>' is visible, not hidden"
+        }
+      ],
+      "symptom": "Published size numbers, package layout, or streaming wire-format commentary drifted away from the scripts and bytes that users actually received.",
+      "octaneContract": "Measured claims and protocol descriptions must cite the live generator, benchmark, emitted fixture, or focused test that makes them reviewable.",
+      "classification": "portable",
+      "status": "documented",
+      "risk": "medium",
+      "owner": "Octane documentation and release tooling",
+      "applicableModes": ["server-stream", "benchmark"],
+      "observables": ["streaming", "performance"],
+      "octaneReferences": [
+        {
+          "kind": "documentation",
+          "file": "docs/project-analysis-concerns.md",
+          "note": "Distinguishes current source-backed claims from historical plans."
+        },
+        {
+          "kind": "documentation",
+          "file": "benchmarks/README.md",
+          "note": "Defines comparable baselines and the repository benchmark contract."
+        }
+      ],
+      "rationale": "This is a maintenance rule rather than an independent runtime workstream."
+    },
+    {
+      "id": "RDX-EVT-001",
+      "area": "events",
+      "title": "Native form events must be exercised, without importing synthetic onChange",
+      "sources": [
+        {
+          "kind": "pull_request",
+          "number": 1,
+          "url": "https://github.com/TanStack/redact/pull/1",
+          "title": "fix(react-dom): fire onChange on every keystroke for text inputs"
+        },
+        {
+          "kind": "commit",
+          "commit": "1da7232dbe1658971219b6a83f2f44a4f1b5ff16",
+          "url": "https://github.com/TanStack/redact/commit/1da7232dbe1658971219b6a83f2f44a4f1b5ff16"
+        }
+      ],
+      "symptom": "Initial form markup looked correct while real editing was dead because the tests never dispatched the platform event that drives the control.",
+      "octaneContract": "Controlled-property tests must dispatch real native input/change events and assert handler delivery, live-property reassertion, and dynamic input-type behavior.",
+      "classification": "divergence",
+      "status": "documented",
+      "risk": "high",
+      "owner": "Octane DOM events and forms",
+      "applicableModes": ["client", "hydrate-match", "production-compile", "real-browser"],
+      "observables": ["events", "live-properties", "markup"],
+      "octaneReferences": [
+        {
+          "kind": "documentation",
+          "file": "docs/differences-from-react.md",
+          "note": "Octane deliberately uses onInput per edit and native change on commit."
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/browser/native-change/native-change.test.ts",
+          "testName": "fires Octane change on focus commit while React derives it from each input",
+          "note": "Real-browser native change contract."
+        }
+      ],
+      "rationale": "Adopt Redact's event-level observation boundary, but reject its synthetic onChange-to-input mapping because that conflicts with Octane's documented native-event model."
+    },
+    {
+      "id": "RDX-EVT-002",
+      "area": "event-replay",
+      "title": "Hydration event replay preserves platform event shape and queue semantics",
+      "sources": [
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/event-replay.test.ts",
+          "testName": "replays buffered events with browser-compatible event subclasses",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/event-replay.test.ts#L12-L68"
+        }
+      ],
+      "symptom": "A replay queue delivered the right event names but degraded keyboard and input events to generic Event objects, lost target/default semantics, changed order, or replayed an item twice.",
+      "octaneContract": "For every event Octane buffers, replay must preserve the documented platform subclass and supported metadata, original target, FIFO order, bubbling/cancelability/default behavior, and exactly-once delivery.",
+      "classification": "adaptable",
+      "status": "planned",
+      "risk": "high",
+      "owner": "Octane deferred hydration and DOM events",
+      "applicableModes": ["deferred-hydration", "real-browser"],
+      "observables": ["events"],
+      "octaneReferences": [
+        {
+          "kind": "source",
+          "file": "packages/octane/src/runtime.ts",
+          "symbol": "notifyHydrateBoundary",
+          "note": "Mouse and focus families retain subclasses; other buffered families currently fall back to Event."
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/streaming-ssr.test.ts",
+          "testName": "replays pre-root interaction after the pending stream reveals",
+          "note": "Covers click delivery and target survival, not the cross-family event-shape matrix."
+        }
+      ],
+      "nextAction": {
+        "kind": "test",
+        "targets": [
+          "packages/octane/tests/hydration/deferred-hydration-contract.test.ts",
+          "packages/octane/tests/browser"
+        ],
+        "acceptance": "Exercise every public HydrationInteractionEvent family in a real browser: click/auxclick/contextmenu/dblclick, focusin, keydown/keyup, mouse, and pointer events. Assert subclass, supported metadata, target, FIFO ordering, preventDefault visibility, queue drain, and no duplicate replay; keep input/change/submit excluded unless a separate API decision expands the public union."
+      },
+      "rationale": "Octane replays interaction intent rather than cloning every native event field, so the transferable contract must explicitly define which event shape it promises instead of silently copying Redact's implementation."
+    },
+    {
+      "id": "RDX-HYD-001",
+      "area": "hydration",
+      "title": "Suspending hydration recovery must not leak an uncaught mismatch",
+      "sources": [
+        {
+          "kind": "issue",
+          "number": 17,
+          "url": "https://github.com/TanStack/redact/issues/17",
+          "title": "Hydration bugs: async-resume mismatch escapes uncaught; head-script claiming; innerHTML probe escaping; foreign-node strictness"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/document-hydration.test.tsx",
+          "testName": "recovers a mismatch when lazy hydration resumes inside Suspense",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/document-hydration.test.tsx#L120-L169"
+        }
+      ],
+      "symptom": "A mismatch reached after a lazy hydration suspension reported as recoverable and then escaped through the global error channel, abandoning interaction setup.",
+      "octaneContract": "A client suspension encountered during hydration must converge to exactly one live client arm, report through Octane's chosen hydration channel only, preserve unaffected siblings, and never emit an uncaught error or rejection.",
+      "classification": "adaptable",
+      "status": "planned",
+      "risk": "critical",
+      "owner": "Octane runtime hydration and browser tests",
+      "applicableModes": [
+        "hydrate-mismatch",
+        "deferred-hydration",
+        "production-compile",
+        "real-browser"
+      ],
+      "observables": ["markup", "node-identity", "events", "errors"],
+      "octaneReferences": [
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/conformance/fizz-readiness-hydration.test.ts",
+          "testName": "reports eager pending-arm recovery instead of deferring a streamed-boundary mismatch",
+          "note": "Already proves one final client arm and one expected diagnostic in development and production compile modes."
+        },
+        {
+          "kind": "source",
+          "file": "packages/octane/src/runtime.ts",
+          "symbol": "hideTryContentAndMountPending"
+        }
+      ],
+      "nextAction": {
+        "kind": "test",
+        "targets": [
+          "packages/octane/tests/conformance/fizz-readiness-hydration.test.ts",
+          "packages/octane/tests/browser"
+        ],
+        "acceptance": "Retain the existing one-final-arm oracle, add global error/unhandled-rejection capture, and prove an outside sibling keeps identity and remains interactive after resolution."
+      },
+      "rationale": "Issue #17 remained open when captured, but Redact main commit e1620a13aab8935c806238f117ba58559b7cd002 contains the matching fix and regression, so the resolution is inferred rather than administratively confirmed. Octane eagerly leaves synchronous hydration for a fresh client arm, so Redact's resumed-cursor implementation bug does not transfer directly; only the missing global-error and outside-sibling observations remain."
+    },
+    {
+      "id": "RDX-HYD-002",
+      "area": "head-hydration",
+      "title": "Hoisted head markers must only claim the intended element",
+      "sources": [
+        {
+          "kind": "issue",
+          "number": 17,
+          "url": "https://github.com/TanStack/redact/issues/17",
+          "title": "Hydration bugs: async-resume mismatch escapes uncaught; head-script claiming; innerHTML probe escaping; foreign-node strictness"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/document-hydration.test.tsx",
+          "testName": "claims typeless and typed head scripts in document order",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/document-hydration.test.tsx#L171-L206"
+        }
+      ],
+      "symptom": "Weak head-node identity allowed one logical head entry to adopt a different server node and validate or update the wrong content.",
+      "octaneContract": "A compiled head marker may adopt only an element with the expected tag and ownership; missing, duplicated, reordered, or corrupted markers must create or recover the expected node without mutating unrelated head content.",
+      "classification": "adaptable",
+      "status": "planned",
+      "risk": "critical",
+      "owner": "Octane compiler and runtime head hydration",
+      "applicableModes": [
+        "hydrate-match",
+        "hydrate-mismatch",
+        "production-compile",
+        "real-browser"
+      ],
+      "observables": ["markup", "node-identity", "errors"],
+      "octaneReferences": [
+        {
+          "kind": "source",
+          "file": "packages/octane/src/runtime.ts",
+          "symbol": "adoptServerHeadEl",
+          "note": "The current helper returns the first element after a matching marker without validating the expected tag."
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/hydration/head-hydrate.test.ts",
+          "testName": "adopts the server head (one <title>/<meta>, markers removed) + single-root body, removed on unmount",
+          "note": "Happy-path adoption only."
+        }
+      ],
+      "nextAction": {
+        "kind": "test",
+        "targets": ["packages/octane/tests/hydration/head-hydrate.test.ts"],
+        "acceptance": "Cover a foreign wrong-tag node between marker and target, missing target, duplicate marker, reordered metadata, and preservation of unrelated head nodes before deciding whether runtime validation is needed."
+      },
+      "rationale": "Redact matches scripts by attributes while Octane uses compiler markers; the portable contract is ownership-safe claiming, not Redact's matching algorithm."
+    },
+    {
+      "id": "RDX-HYD-003",
+      "area": "raw-text-hydration",
+      "title": "Raw script and style hydration must use their parsing contexts",
+      "sources": [
+        {
+          "kind": "issue",
+          "number": 17,
+          "url": "https://github.com/TanStack/redact/issues/17",
+          "title": "Hydration bugs: async-resume mismatch escapes uncaught; head-script claiming; innerHTML probe escaping; foreign-node strictness"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/document-hydration.test.tsx",
+          "testName": "hydrates matching raw script content without HTML normalization",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/document-hydration.test.tsx#L208-L223"
+        }
+      ],
+      "symptom": "Byte-equivalent script or style text containing ampersands or less-than signs was parsed through a generic div and falsely reported as mismatched.",
+      "octaneContract": "Hydration comparison must respect script-data and style raw-text parsing, preserve node identity for equivalent server bytes, avoid false diagnostics, and remain safe against closing-tag injection.",
+      "classification": "portable",
+      "status": "planned",
+      "risk": "high",
+      "owner": "Octane DOM hydration and SSR serialization",
+      "applicableModes": [
+        "server-string",
+        "server-stream",
+        "hydrate-match",
+        "production-compile",
+        "real-browser"
+      ],
+      "observables": ["markup", "node-identity", "errors"],
+      "octaneReferences": [
+        {
+          "kind": "source",
+          "file": "packages/octane/src/runtime.ts",
+          "symbol": "setHTML",
+          "note": "Script uses textContent; other hosts use a same-tag contextual probe."
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/script-innerhtml.test.ts",
+          "testName": "hydrates the server-safe script spelling by adoption and applies later updates",
+          "note": "Script coverage is already strong."
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/conformance/fizz-main-wave4c.test.ts",
+          "testName": "keeps raw style text in one element when it contains closing-tag-like tokens",
+          "note": "Current style evidence is server-only."
+        }
+      ],
+      "nextAction": {
+        "kind": "test",
+        "targets": [
+          "packages/octane/tests/script-innerhtml.test.ts",
+          "packages/octane/tests/browser"
+        ],
+        "acceptance": "Add server-render, parse, hydrate, and update coverage for raw style text containing &&, <, entity-like text, and closing-tag-like tokens; assert adoption and no warning in the unit lane, then use Chromium/CSSOM to prove intact stylesheet semantics."
+      },
+      "rationale": "The Redact script failure is already prevented; the remaining gap is direct hydration evidence for style's distinct raw-text and SSR-escape behavior."
+    },
+    {
+      "id": "RDX-HYD-004",
+      "area": "root-ownership",
+      "title": "Foreign document nodes do not weaken ordinary element-root ownership",
+      "sources": [
+        {
+          "kind": "issue",
+          "number": 17,
+          "url": "https://github.com/TanStack/redact/issues/17",
+          "title": "Hydration bugs: async-resume mismatch escapes uncaught; head-script claiming; innerHTML probe escaping; foreign-node strictness"
+        },
+        {
+          "kind": "pull_request",
+          "number": 10,
+          "url": "https://github.com/TanStack/redact/pull/10",
+          "title": "Project document head elements"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/document-hydration.test.tsx",
+          "testName": "preserves foreign nodes after expected document body children",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/document-hydration.test.tsx#L87-L118"
+        }
+      ],
+      "symptom": "A hidden iframe injected at the open document boundary caused whole-document hydration to fail, even though it was not application-owned content.",
+      "octaneContract": "The element passed to hydrateRoot remains strictly owned: ordinary unclaimed content inside it is diagnosed and removed, while ordinary nodes outside it are untouched. Explicit portal targets and compiler-owned head hoists follow their own ownership contracts. Document/body tolerance requires a separate explicit API and ownership decision.",
+      "classification": "non_goal",
+      "status": "documented",
+      "risk": "medium",
+      "owner": "Octane root API and metaframework integrations",
+      "applicableModes": ["hydrate-mismatch", "real-browser"],
+      "observables": ["markup", "node-identity", "errors"],
+      "octaneReferences": [
+        {
+          "kind": "source",
+          "file": "packages/octane/src/runtime.ts",
+          "symbol": "finishRoot",
+          "note": "Intentionally diagnoses and removes unclaimed root siblings."
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/conformance/hydration-mismatch.test.ts",
+          "testName": "server renders an extra element the client omits (Per :834)"
+        }
+      ],
+      "rationale": "Octane hydrates a supplied Element rather than Document. Redact's body-level tolerance must not become blanket permissiveness inside an application-owned container. Revisit only if Octane introduces document/body hydration."
+    },
+    {
+      "id": "RDX-HYD-005",
+      "area": "hydration-errors",
+      "title": "Hydration recovery reporting has an explicit public contract",
+      "sources": [
+        {
+          "kind": "issue",
+          "number": 17,
+          "url": "https://github.com/TanStack/redact/issues/17",
+          "title": "Hydration bugs: async-resume mismatch escapes uncaught; head-script claiming; innerHTML probe escaping; foreign-node strictness"
+        },
+        {
+          "kind": "commit",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "url": "https://github.com/TanStack/redact/commit/e1620a13aab8935c806238f117ba58559b7cd002",
+          "title": "fix(redact): harden document hydration recovery"
+        }
+      ],
+      "symptom": "The same hydration failure appeared on both a recoverable callback and the global error channel, making recovery behavior ambiguous to framework integrations.",
+      "octaneContract": "Octane must document whether hydration diagnostics are console-only or root-callback-addressable and ensure every initial, deferred, and streamed recovery path follows that decision exactly once.",
+      "classification": "adaptable",
+      "status": "decision_required",
+      "risk": "medium",
+      "owner": "Octane public root API",
+      "applicableModes": [
+        "hydrate-match",
+        "hydrate-mismatch",
+        "deferred-hydration",
+        "production-compile"
+      ],
+      "observables": ["errors"],
+      "octaneReferences": [
+        {
+          "kind": "documentation",
+          "file": "packages/octane/tests/conformance/hydration-mismatch.test.ts",
+          "note": "Documents that onRecoverableError is not currently an Octane root option."
+        }
+      ],
+      "nextAction": {
+        "kind": "decision",
+        "targets": ["packages/octane/src/runtime.ts", "docs/ssr.md"],
+        "acceptance": "Choose and document console-only diagnostics versus recoverable/caught/uncaught root callbacks, including exact deduplication and production behavior, before adding an API."
+      },
+      "rationale": "Redact's callback surface should not be copied implicitly; frameworks need a deliberate Octane contract if error callbacks become public."
+    },
+    {
+      "id": "RDX-HYD-006",
+      "area": "hydration-recovery",
+      "title": "Mismatch recovery is bounded to the failed ownership scope",
+      "sources": [
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/hydration-mismatch-recovery.test.tsx",
+          "testName": "root fallback produces one clean client tree for wrong element type",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/hydration-mismatch-recovery.test.tsx#L53-L64"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/hydration-mismatch-recovery.test.tsx",
+          "testName": "Suspense-scoped extra server node recovery preserves siblings outside the boundary",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/hydration-mismatch-recovery.test.tsx#L183-L208"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/hydration-mismatch-recovery.test.tsx",
+          "testName": "Suspense-scoped missing server node recovery preserves siblings outside the boundary",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/hydration-mismatch-recovery.test.tsx#L209-L233"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/hydration-mismatch-recovery.test.tsx",
+          "testName": "Suspense-scoped recovery attaches events to the client-rendered subtree",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/hydration-mismatch-recovery.test.tsx#L234-L260"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/hydration-mismatch-recovery.test.tsx",
+          "testName": "nearest host recovery preserves siblings outside the failed host subtree",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/hydration-mismatch-recovery.test.tsx#L262-L297"
+        }
+      ],
+      "symptom": "Recovering one mismatched host or Suspense subtree could remount unaffected siblings, abandon the hydration cursor, or leave the regenerated subtree without live handlers.",
+      "octaneContract": "A structural hydration mismatch rebuilds only its owning failed range, preserves the object identity of unaffected siblings outside that range, and installs events on regenerated content.",
+      "classification": "adaptable",
+      "status": "planned",
+      "risk": "high",
+      "owner": "Octane hydration cursor and ownership ranges",
+      "applicableModes": ["hydrate-mismatch", "production-compile", "real-browser"],
+      "observables": ["markup", "node-identity", "events"],
+      "octaneReferences": [
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/conformance/hydration-mismatch.test.ts",
+          "testName": "hydration continues past a mismatch: the next sibling adopts + is interactive",
+          "note": "Proves final content and sibling interactivity, but does not retain and compare the sibling object across the recovery."
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/hydration/mismatch-structural.test.ts",
+          "testName": "PROD build: @if branch swap rebuilds SILENTLY (recovery is not gated on the dev loc)",
+          "note": "Proves production recovery but not a nearest-host/Suspense containment matrix."
+        }
+      ],
+      "nextAction": {
+        "kind": "test",
+        "targets": [
+          "packages/octane/tests/conformance/hydration-mismatch.test.ts",
+          "packages/octane/tests/browser"
+        ],
+        "acceptance": "For root, nearest-host, and Suspense-scoped structural mismatches, capture outside siblings before hydration and assert the same objects and handlers survive while the failed subtree is regenerated and its handlers become live in development and production."
+      },
+      "rationale": "Octane recovers ranges in place instead of following Redact's checkpoint stack, so the transferable requirement is the observable containment boundary rather than checkpoint implementation parity."
+    },
+    {
+      "id": "RDX-ID-001",
+      "area": "use-id",
+      "title": "Each root owns a deterministic useId sequence",
+      "sources": [
+        {
+          "kind": "commit",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "url": "https://github.com/TanStack/redact/commit/e1620a13aab8935c806238f117ba58559b7cd002",
+          "title": "fix(redact): harden document hydration recovery"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/hydration.test.tsx",
+          "testName": "starts hydrated useId sequences from each server-rendered root",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/hydration.test.tsx#L232-L266"
+        }
+      ],
+      "symptom": "A prior root's allocations shifted the next root's hydrated IDs away from the server sequence.",
+      "octaneContract": "Sibling client roots are independently namespaced, server IDs hydrate byte-for-byte, and explicit identifier prefixes compose with root-local allocation.",
+      "classification": "portable",
+      "status": "covered",
+      "risk": "high",
+      "owner": "Octane root and SSR identity",
+      "applicableModes": [
+        "client",
+        "server-string",
+        "server-stream",
+        "hydrate-match",
+        "production-compile"
+      ],
+      "observables": ["markup"],
+      "octaneReferences": [
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/conformance/useid-determinism.test.ts",
+          "testName": "automatically namespaces sibling createRoot roots"
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/conformance/useid-determinism.test.ts",
+          "testName": "server useId is preserved byte-for-byte after hydrateRoot()"
+        }
+      ],
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/useid-determinism.test.ts",
+          "testName": "automatically namespaces sibling createRoot roots",
+          "modes": ["client", "production-compile"],
+          "observables": ["markup"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/useid-determinism.test.ts",
+          "testName": "server useId is preserved byte-for-byte after hydrateRoot()",
+          "modes": ["server-string", "hydrate-match", "production-compile"],
+          "observables": ["markup"]
+        },
+        {
+          "file": "packages/octane/tests/streaming-ssr.test.ts",
+          "testName": "hydrates completed boundary useId values in its opaque stream namespace",
+          "modes": ["server-stream", "hydrate-match", "production-compile"],
+          "observables": ["markup"]
+        }
+      ]
+    },
+    {
+      "id": "RDX-LIF-001",
+      "area": "effects",
+      "title": "Coalesced dependency changes leave one live passive side effect",
+      "sources": [
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/use-effect-coalesced-renders.test.tsx",
+          "testName": "does not leak side-effects when two deps-changing renders coalesce before passive drain",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/use-effect-coalesced-renders.test.tsx#L13-L57"
+        }
+      ],
+      "symptom": "Two renders before the passive queue drained installed multiple imperative artifacts because cleanup ownership was cleared before the intermediate body ran.",
+      "octaneContract": "After any coalesced dependency-changing render sequence, at most one passive side effect is live; each installed effect is cleaned exactly once, including final unmount.",
+      "classification": "portable",
+      "status": "planned",
+      "risk": "high",
+      "owner": "Octane scheduler and effect hooks",
+      "applicableModes": ["client", "production-compile"],
+      "observables": ["markup", "effects"],
+      "octaneReferences": [
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/effect-timing.test.ts",
+          "testName": "phase order on re-render: cleanups fire before bodies of same phase",
+          "note": "Strong ordering coverage, but not the exact two-renders-before-passive-drain race."
+        }
+      ],
+      "nextAction": {
+        "kind": "test",
+        "targets": ["packages/octane/tests/effect-timing.test.ts"],
+        "acceptance": "Drive a→b→c before passive drain, assert one live imperative artifact, exact cleanup order through c, and one final cleanup on unmount in development and production compile modes."
+      }
+    },
+    {
+      "id": "RDX-MEM-001",
+      "area": "memo-scheduling",
+      "title": "Memo prop bailouts do not swallow owned updates or revive removed work",
+      "sources": [
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/memo-state-rerender.test.tsx",
+          "testName": "re-renders a memo component when its useSyncExternalStore fires, even with unchanged props",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/memo-state-rerender.test.tsx#L51-L74"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/memo-state-rerender.test.tsx",
+          "testName": "does not mount DOM when a pending fiber was unmounted between scheduling and flush",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/memo-state-rerender.test.tsx#L131-L180"
+        }
+      ],
+      "symptom": "A stable-prop memo gate swallowed the component's own store update, while stale queued work could render after an ancestor removed it.",
+      "octaneContract": "A memoized component processes its own state/store updates without disabling descendant memo bailouts, and pending work beneath a removed ancestor cannot mount new DOM.",
+      "classification": "portable",
+      "status": "planned",
+      "risk": "high",
+      "owner": "Octane memo and scheduler",
+      "applicableModes": ["client", "production-compile"],
+      "observables": ["markup", "effects"],
+      "octaneReferences": [
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "should update children even if parent blocks updates"
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "does not call render after a component as been deleted"
+        }
+      ],
+      "nextAction": {
+        "kind": "test",
+        "targets": [
+          "packages/octane/tests/conformance/memo-bailout.test.ts",
+          "packages/octane/tests/conformance/update-reconciliation.test.ts"
+        ],
+        "acceptance": "Combine memo with useSyncExternalStore, prove the owner updates while a stable memo grandchild bails, then queue/remove work and prove no zombie DOM or effects appear."
+      }
+    },
+    {
+      "id": "RDX-NON-001",
+      "area": "redact-specific-surfaces",
+      "title": "React package shims, RSC internals, and private debug names are not Octane targets",
+      "sources": [
+        {
+          "kind": "pull_request",
+          "number": 5,
+          "url": "https://github.com/TanStack/redact/pull/5",
+          "title": "fix(redact): scope resolve.alias to client+ssr envs so RSC stays on real React"
+        },
+        {
+          "kind": "pull_request",
+          "number": 8,
+          "url": "https://github.com/TanStack/redact/pull/8",
+          "title": "Add React DOM edge server aliases"
+        },
+        {
+          "kind": "pull_request",
+          "number": 11,
+          "url": "https://github.com/TanStack/redact/pull/11",
+          "title": "Expose ReactDOM Flight hint internals"
+        },
+        {
+          "kind": "pull_request",
+          "number": 12,
+          "url": "https://github.com/TanStack/redact/pull/12",
+          "title": "chore(redact/hydration): rename internal '__tdom*' scroll-guard globals to '__redact*'"
+        },
+        {
+          "kind": "pull_request",
+          "number": 14,
+          "url": "https://github.com/TanStack/redact/pull/14",
+          "title": "feat(redact): vinext SSR/hydration compatibility — 0.0.9"
+        }
+      ],
+      "symptom": "Redact needed compatibility with React package names, Flight private internals, RSC environment routing, and legacy internal global names.",
+      "octaneContract": "Octane remains responsible for its public runtime, compiler, SSR, hydration, and documented bundler integrations, not for impersonating React private package or Flight surfaces.",
+      "classification": "non_goal",
+      "status": "documented",
+      "risk": "low",
+      "owner": "Octane architecture",
+      "applicableModes": ["vite-client", "vite-ssr", "packaged-consumer"],
+      "observables": ["package-resolution"],
+      "octaneReferences": [
+        {
+          "kind": "documentation",
+          "file": "docs/differences-from-react.md",
+          "note": "Records unsupported React-only surfaces."
+        }
+      ],
+      "rationale": "Class components, forwardRef, Server Components/Flight, React package aliases, Redact's renderer registry, and private debug globals are architecture-specific exclusions. Portable packaging or SSR lessons are tracked separately."
+    },
+    {
+      "id": "RDX-PERF-001",
+      "area": "performance",
+      "title": "Performance claims use real browsers and multiple controlled workloads",
+      "sources": [
+        {
+          "kind": "pull_request",
+          "number": 6,
+          "url": "https://github.com/TanStack/redact/pull/6",
+          "title": "perf(redact): close ~85% of the render-bench gap to React"
+        },
+        {
+          "kind": "pull_request",
+          "number": 7,
+          "url": "https://github.com/TanStack/redact/pull/7",
+          "title": "perf(redact): four more render-bench wins — now ~18% faster than React"
+        }
+      ],
+      "symptom": "JSDOM suggested the opposite performance result from real Chrome, and a single workload hid regressions in keyed reorder, mount/unmount, deep trees, or state churn.",
+      "octaneContract": "Framework performance changes require same-machine comparable baselines, semantic controls, real-browser measurement for DOM work, representative workload coverage, and bundle/codegen accounting.",
+      "classification": "portable",
+      "status": "documented",
+      "risk": "high",
+      "owner": "Octane core engineering",
+      "applicableModes": ["benchmark", "real-browser", "production-compile"],
+      "observables": ["performance", "markup", "node-identity"],
+      "octaneReferences": [
+        {
+          "kind": "documentation",
+          "file": ".agents/memories/core-engineering.md",
+          "note": "Requires relevant baselines and forbids unsupported performance claims."
+        },
+        {
+          "kind": "benchmark",
+          "file": "benchmarks/README.md",
+          "note": "Defines browser/Node runners, correctness gates, ratios, and workload inventory."
+        }
+      ],
+      "rationale": "Octane already follows this discipline. Add or run only the benchmark relevant to a future hot-path change; do not port Redact's optimizations."
+    },
+    {
+      "id": "RDX-PKG-001",
+      "area": "public-exports",
+      "title": "Advertised named exports are locked at the consumer boundary",
+      "sources": [
+        {
+          "kind": "pull_request",
+          "number": 2,
+          "url": "https://github.com/TanStack/redact/pull/2",
+          "title": "refactor!: rename to @tanstack/redact and consolidate into single package"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/public-exports.test.ts",
+          "testName": "exposes hooks needed by use-sync-external-store/shim/* aliases",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/public-exports.test.ts#L170-L180"
+        }
+      ],
+      "symptom": "A hook existed in source but was omitted from the package entrypoint, producing a link-time failure only in a downstream consumer.",
+      "octaneContract": "Every intended value export for each public Octane subpath is checked from the built or packed artifact, so removing a re-export is an explicit review event rather than a downstream surprise.",
+      "classification": "portable",
+      "status": "planned",
+      "risk": "medium",
+      "owner": "Octane package surface",
+      "applicableModes": ["packaged-consumer", "production-compile"],
+      "observables": ["package-resolution"],
+      "octaneReferences": [
+        {
+          "kind": "source",
+          "file": "packages/octane/scripts/verify-dist.mjs",
+          "symbol": "smokeDist",
+          "note": "Proves every JS entry imports, but not that a specific named export remains present."
+        },
+        {
+          "kind": "integration",
+          "file": "scripts/check-package-packs.mjs",
+          "note": "Builds isolated consumers from packed workspace artifacts."
+        }
+      ],
+      "nextAction": {
+        "kind": "test",
+        "targets": ["packages/octane/scripts/verify-dist.mjs", "scripts/check-package-packs.mjs"],
+        "acceptance": "Derive or explicitly declare intended named-export sets for public core subpaths and validate them from the built or packed artifact without making harmless additive exports unnecessarily brittle."
+      }
+    },
+    {
+      "id": "RDX-PKG-002",
+      "area": "package-resolution",
+      "title": "Packed Vite consumers and supported integration graphs resolve one runtime",
+      "sources": [
+        {
+          "kind": "pull_request",
+          "number": 2,
+          "url": "https://github.com/TanStack/redact/pull/2",
+          "title": "refactor!: rename to @tanstack/redact and consolidate into single package"
+        },
+        {
+          "kind": "pull_request",
+          "number": 4,
+          "url": "https://github.com/TanStack/redact/pull/4",
+          "title": "fix(redact): switch exports to `default` so RSC + other conditions resolve"
+        },
+        {
+          "kind": "pull_request",
+          "number": 5,
+          "url": "https://github.com/TanStack/redact/pull/5",
+          "title": "fix(redact): scope resolve.alias to client+ssr envs so RSC stays on real React"
+        },
+        {
+          "kind": "pull_request",
+          "number": 8,
+          "url": "https://github.com/TanStack/redact/pull/8",
+          "title": "Add React DOM edge server aliases"
+        },
+        {
+          "kind": "pull_request",
+          "number": 14,
+          "url": "https://github.com/TanStack/redact/pull/14",
+          "title": "feat(redact): vinext SSR/hydration compatibility — 0.0.9"
+        }
+      ],
+      "symptom": "Source-level tests passed while published export conditions or top-level aliases failed in a real framework environment or selected the wrong runtime graph.",
+      "octaneContract": "Outside-workspace consumers built from packed Octane artifacts resolve one runtime through Vite client and SSR graphs; supported Rspack and Rsbuild environment routing is exercised by their integration builds. This does not claim an external packed-consumer lane for every plugin.",
+      "classification": "adaptable",
+      "status": "covered",
+      "risk": "high",
+      "owner": "Octane packaging and bundler integrations",
+      "applicableModes": [
+        "packaged-consumer",
+        "vite-client",
+        "vite-ssr",
+        "rspack",
+        "rsbuild",
+        "production-compile"
+      ],
+      "observables": ["package-resolution", "markup"],
+      "octaneReferences": [
+        {
+          "kind": "source",
+          "file": "packages/octane/package.json",
+          "note": "Published subpaths provide default conditions."
+        },
+        {
+          "kind": "integration",
+          "file": "scripts/check-package-packs.mjs",
+          "note": "Packs, installs, resolves, builds, and executes consumers outside the workspace."
+        }
+      ],
+      "evidence": [
+        {
+          "file": "packages/octane/tests/vite-integration.test.ts",
+          "testName": "discovers a parent package and routes raw dependency imports to the SSR runtime",
+          "modes": ["vite-ssr", "production-compile"],
+          "observables": ["package-resolution", "markup"]
+        },
+        {
+          "file": "packages/rspack-plugin-octane/tests/rspack.test.ts",
+          "testName": "builds client and server graphs with maps, raw dependencies, and one target runtime",
+          "modes": ["rspack"],
+          "observables": ["package-resolution"]
+        },
+        {
+          "file": "packages/rsbuild-plugin-octane/tests/rsbuild.integration.test.ts",
+          "testName": "builds routed client/server environments and serves the production SSR handler",
+          "modes": ["rsbuild", "production-compile"],
+          "observables": ["package-resolution", "markup"]
+        },
+        {
+          "kind": "command",
+          "script": "packages:pack:check",
+          "modes": ["packaged-consumer", "vite-client", "vite-ssr", "production-compile"],
+          "observables": ["package-resolution", "markup"]
+        }
+      ],
+      "rationale": "The exact React/RSC aliases are Redact-only. Octane's packed canary proves the external Vite boundary, while Rspack and Rsbuild remain honestly labeled workspace integration evidence rather than external packed coverage."
+    },
+    {
+      "id": "RDX-PORT-001",
+      "area": "portals",
+      "title": "Portal content mounts in its target and cleans up with its owner",
+      "sources": [
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/portal-doctype.test.tsx",
+          "testName": "mounts portal children into the supplied container",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/portal-doctype.test.tsx#L32-L59"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/portal-doctype.test.tsx",
+          "testName": "unmounts portal children when the parent stops rendering them",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/portal-doctype.test.tsx#L61-L81"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/portal-doctype.test.tsx",
+          "testName": "renders portal alongside sibling elements correctly",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/portal-doctype.test.tsx#L83-L113"
+        }
+      ],
+      "symptom": "Portal content mounted outside its supplied target or remained there after the logical owner stopped rendering it.",
+      "octaneContract": "Portal content mounts in the supplied foreign target, and closing or unmounting its logical owner removes that content.",
+      "classification": "portable",
+      "status": "covered",
+      "risk": "high",
+      "owner": "Octane portals and UI bindings",
+      "applicableModes": ["client", "production-compile"],
+      "observables": ["markup"],
+      "octaneReferences": [
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/portal.test.ts",
+          "testName": "compiles and renders an inline host-element body into the target, updating reactively"
+        }
+      ],
+      "evidence": [
+        {
+          "file": "packages/octane/tests/portal.test.ts",
+          "testName": "compiles and renders an inline host-element body into the target, updating reactively",
+          "modes": ["client", "production-compile"],
+          "observables": ["markup"]
+        },
+        {
+          "file": "packages/octane/tests/portal.test.ts",
+          "testName": "unmounts portal content when the if-branch closes",
+          "modes": ["client", "production-compile"],
+          "observables": ["markup"]
+        }
+      ]
+    },
+    {
+      "id": "RDX-PORT-002",
+      "area": "portal-updates",
+      "title": "A stateful portal descendant resolves its foreign host for owned updates",
+      "sources": [
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/floating-ui-pattern.test.tsx",
+          "testName": "re-renders a Portal descendant when its own state updates (getHostParent on Portal)",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/floating-ui-pattern.test.tsx#L133-L163"
+        }
+      ],
+      "symptom": "A component inside a portal scheduled its own state update, resolved the logical parent as its host, and inserted or replaced DOM outside the portal target.",
+      "octaneContract": "A descendant component rendered inside a portal may own and schedule updates while all of its host mutations remain anchored in the supplied portal target and preserve surrounding target siblings.",
+      "classification": "adaptable",
+      "status": "planned",
+      "risk": "high",
+      "owner": "Octane portal host resolution",
+      "applicableModes": ["client", "production-compile"],
+      "observables": ["markup", "node-identity"],
+      "octaneReferences": [
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/portal.test.ts",
+          "testName": "compiles and renders an inline host-element body into the target, updating reactively",
+          "note": "Updates state owned outside the portal, so it does not exercise descendant-owned host resolution."
+        }
+      ],
+      "nextAction": {
+        "kind": "test",
+        "targets": ["packages/octane/tests/portal.test.ts"],
+        "acceptance": "Render a child component with its own useState inside a portal, schedule its update from that child, and assert the same target and unaffected target siblings retain identity while only the child's host content changes in development and production compile modes."
+      }
+    },
+    {
+      "id": "RDX-REC-001",
+      "area": "reconciliation",
+      "title": "Keyed reorders preserve survivor identity and final order",
+      "sources": [
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/child-reorder.test.tsx",
+          "testName": "reorders keyed list items preserving DOM identity",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/child-reorder.test.tsx#L95-L128"
+        }
+      ],
+      "symptom": "A keyed reorder produced the right text but recreated survivor DOM nodes or left them in the wrong final order.",
+      "octaneContract": "Keyed survivors retain object identity and reach the requested final order; Octane's LIS-selected physical move set need not match React or Redact.",
+      "classification": "adaptable",
+      "status": "covered",
+      "risk": "high",
+      "owner": "Octane reconciler",
+      "applicableModes": ["client", "production-compile"],
+      "observables": ["markup", "node-identity"],
+      "octaneReferences": [
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/conformance/multichild-identity.test.ts",
+          "testName": "reverse preserves all instances (pure moves)"
+        },
+        {
+          "kind": "integration",
+          "file": "packages/octane/tests/conformance/fuzz-keyed-list.test.ts",
+          "note": "Exercises prefix, tail, small-displacement, and LIS paths across deterministic mutation streams."
+        }
+      ],
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/multichild-identity.test.ts",
+          "testName": "reverse preserves all instances (pure moves)",
+          "modes": ["client", "production-compile"],
+          "observables": ["markup", "node-identity"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/multichild-identity.test.ts",
+          "testName": "inserting in the middle preserves existing instances",
+          "modes": ["client", "production-compile"],
+          "observables": ["markup", "node-identity"]
+        }
+      ],
+      "rationale": "Physical move-sequence parity is intentionally excluded because Octane's LIS reconciler promises final order and survivor identity with fewer moves."
+    },
+    {
+      "id": "RDX-REC-002",
+      "area": "reconciliation-placement",
+      "title": "Topology transitions use the correct absolute anchor without stable reattachment",
+      "sources": [
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/place-children-anchor.test.tsx",
+          "testName": "Sidebar Portal→div via Provider cascade: new div lands BEFORE chat",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/place-children-anchor.test.tsx#L31-L99"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/place-children-anchor.test.tsx",
+          "testName": "first child swaps Portal→div with multiple later siblings",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/place-children-anchor.test.tsx#L101-L158"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/place-children-anchor.test.tsx",
+          "testName": "first child goes null→div via Provider cascade: new div at index 0",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/place-children-anchor.test.tsx#L160-L202"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/place-children-anchor.test.tsx",
+          "testName": "stable re-render does not reorder stable DOM",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/place-children-anchor.test.tsx#L204-L242"
+        }
+      ],
+      "symptom": "A Portal-to-element or null-to-element transition inserted new output after the wrong sibling, while a no-op rerender could detach and reinsert otherwise stable DOM.",
+      "octaneContract": "When a child changes topology, each newly materialized range lands at its absolute logical anchor around portal and ordinary siblings; a stable rerender emits no child-list mutations and preserves every existing host object.",
+      "classification": "adaptable",
+      "status": "planned",
+      "risk": "high",
+      "owner": "Octane reconciler and portal placement",
+      "applicableModes": ["client", "production-compile", "real-browser"],
+      "observables": ["markup", "node-identity", "dom-mutations"],
+      "octaneReferences": [
+        {
+          "kind": "integration",
+          "file": "packages/octane/tests/differential/anchor-order.test.ts",
+          "note": "Covers final source order across control-flow transitions, but differential HTML cannot see host reattachment and has no portal topology case."
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/portal.test.ts",
+          "testName": "unmounts portal content when the if-branch closes",
+          "note": "Covers removal/recreation, not Portal→ordinary replacement around stable siblings."
+        }
+      ],
+      "nextAction": {
+        "kind": "test",
+        "targets": ["packages/octane/tests/portal.test.ts", "packages/octane/tests/browser"],
+        "acceptance": "Port Portal→element and null→element first-child transitions with multiple stable later siblings; retain every survivor object, assert exact final order, and use MutationObserver in Chromium to prove a stable rerender produces no child-list records."
+      },
+      "rationale": "The existing keyed identity suite proves a different reconciler contract. Redact's topology cases require portal-aware absolute placement plus a mutation-level oracle, so they remain an explicit gap instead of being hidden under RDX-REC-001."
+    },
+    {
+      "id": "RDX-REF-001",
+      "area": "refs",
+      "title": "Callback refs run in commit order and clean up exactly once",
+      "sources": [
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/callback-ref-commit-phase.test.tsx",
+          "testName": "does not invoke a callback ref during render",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/callback-ref-commit-phase.test.tsx#L33-L65"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/callback-ref-commit-phase.test.tsx",
+          "testName": "runs the cleanup ref(null) on unmount",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/callback-ref-commit-phase.test.tsx#L67-L85"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/callback-ref-commit-phase.test.tsx",
+          "testName": "runs the user-provided cleanup function returned from a callback ref",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/callback-ref-commit-phase.test.tsx#L87-L113"
+        }
+      ],
+      "symptom": "A callback ref fired during render or received both its returned cleanup and a redundant null detach call.",
+      "octaneContract": "Refs attach only after connected DOM exists, precede layout-effect bodies, detach in the documented commit order, and use either cleanup-return or legacy null notification exactly once.",
+      "classification": "portable",
+      "status": "covered",
+      "risk": "high",
+      "owner": "Octane refs and commit phase",
+      "applicableModes": ["client", "production-compile"],
+      "observables": ["refs", "effects"],
+      "octaneReferences": [
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/ref-timing.test.ts",
+          "testName": "ref attaches before the layout effect body (mount), layout cleanup before ref detach (unmount)"
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/conformance/refs.test.ts",
+          "testName": "handles detaching refs with either cleanup function or null argument"
+        }
+      ],
+      "evidence": [
+        {
+          "file": "packages/octane/tests/ref-timing.test.ts",
+          "testName": "a callback ref fires with a node already connected to the document",
+          "modes": ["client", "production-compile"],
+          "observables": ["refs"]
+        },
+        {
+          "file": "packages/octane/tests/ref-timing.test.ts",
+          "testName": "ref attaches before the layout effect body (mount), layout cleanup before ref detach (unmount)",
+          "modes": ["client", "production-compile"],
+          "observables": ["refs", "effects"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/refs.test.ts",
+          "testName": "handles detaching refs with either cleanup function or null argument",
+          "modes": ["client", "production-compile"],
+          "observables": ["refs"]
+        }
+      ]
+    },
+    {
+      "id": "RDX-ROOT-001",
+      "area": "root-ownership",
+      "title": "The first root render clears foreign children exactly once",
+      "sources": [
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/create-root-clear-container.test.tsx",
+          "testName": "clears pre-existing children on the first render",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/create-root-clear-container.test.tsx#L27-L37"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/create-root-clear-container.test.tsx",
+          "testName": "does not re-clear on subsequent renders (preserves reconciled DOM)",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/create-root-clear-container.test.tsx#L39-L55"
+        }
+      ],
+      "symptom": "A root either left stale foreign children in its managed container or cleared the entire container again on an update, destroying reconciled host identity.",
+      "octaneContract": "The first createRoot render removes pre-existing unowned children before mounting the client tree; later renders reconcile that managed tree without clearing the container and preserve stable host objects.",
+      "classification": "portable",
+      "status": "covered",
+      "risk": "high",
+      "owner": "Octane root lifecycle",
+      "applicableModes": ["client", "production-compile"],
+      "observables": ["markup", "node-identity"],
+      "octaneReferences": [
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "clears existing children"
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "should reuse markup if rendering to the same target twice"
+        }
+      ],
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "clears existing children",
+          "modes": ["client", "production-compile"],
+          "observables": ["markup"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/root-semantics.test.ts",
+          "testName": "should reuse markup if rendering to the same target twice",
+          "modes": ["client", "production-compile"],
+          "observables": ["markup", "node-identity"]
+        }
+      ]
+    },
+    {
+      "id": "RDX-SEC-001",
+      "area": "host-serialization-security",
+      "title": "Untrusted host values remain inside their parser and execution boundaries",
+      "sources": [
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/security.test.tsx",
+          "testName": "escapes <, >, & in text children",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/security.test.tsx#L15-L19"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/security.test.tsx",
+          "testName": "escapes quotes in attribute values",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/security.test.tsx#L34-L40"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/security.test.tsx",
+          "testName": "breaks an attempted </script> inside script body",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/security.test.tsx#L52-L64"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/security.test.tsx",
+          "testName": "breaks an attempted </style> inside style body",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/security.test.tsx#L66-L78"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/security.test.tsx",
+          "testName": "does not allow CSS injection via style values containing quotes",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/security.test.tsx#L123-L132"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/security.test.tsx",
+          "testName": "only attaches function event handlers — string handlers are silently ignored",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/security.test.tsx#L134-L157"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/security.test.tsx",
+          "testName": "only honors the `__html` key — extra keys are ignored",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/security.test.tsx#L159-L174"
+        }
+      ],
+      "symptom": "Untrusted text, attributes, styles, raw-text bodies, event props, or malformed raw-HTML objects crossed into executable markup or a neighboring parser context.",
+      "octaneContract": "Untrusted values remain within their owning text, attribute, style, or raw-text parser context at each tested serialization boundary; streamed raw script and style bodies remain confined as chunks are emitted. Raw HTML requires the __html shape, and non-function delegated event values never execute as handlers.",
+      "classification": "adaptable",
+      "status": "covered",
+      "risk": "critical",
+      "owner": "Octane DOM application and server serialization",
+      "applicableModes": [
+        "client",
+        "server-string",
+        "server-static",
+        "server-stream",
+        "production-compile"
+      ],
+      "observables": ["markup", "events", "errors"],
+      "octaneReferences": [
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/conformance/dom-component-ssr.test.ts",
+          "testName": "escapes text content and attribute values (round-trip)"
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/conformance/fizz-main-wave4c.test.ts",
+          "testName": "keeps valid inline script characters while preventing closing-tag injection"
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/conformance/invalid-listeners.test.ts",
+          "testName": "a $label listener warns at render and reports an Error at dispatch"
+        }
+      ],
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/dom-component-ssr.test.ts",
+          "testName": "escapes text content and attribute values (round-trip)",
+          "modes": ["server-static", "production-compile"],
+          "observables": ["markup"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/fizz-main-wave4c.test.ts",
+          "testName": "keeps valid inline script characters while preventing closing-tag injection",
+          "modes": ["server-string", "server-stream", "production-compile"],
+          "observables": ["markup"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/fizz-main-wave4c.test.ts",
+          "testName": "keeps raw style text in one element when it contains closing-tag-like tokens",
+          "modes": ["server-string", "server-stream", "production-compile"],
+          "observables": ["markup"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/invalid-listeners.test.ts",
+          "testName": "a $label listener warns at render and reports an Error at dispatch",
+          "modes": ["client", "production-compile"],
+          "observables": ["events", "errors"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/dom-component-children.test.ts",
+          "testName": "throws for a malformed dangerouslySetInnerHTML value",
+          "modes": ["client", "production-compile"],
+          "observables": ["errors"]
+        }
+      ],
+      "rationale": "Octane follows React's whole-inline-script escape rather than Redact's exact comment/token spelling, reports invalid listeners instead of silently ignoring them, and rejects malformed raw HTML instead of ignoring extra shapes. The parser/execution containment is covered; byte-level Redact parity is intentionally not claimed."
+    },
+    {
+      "id": "RDX-SSR-001",
+      "area": "ssr-streaming",
+      "title": "SSR retries and render replays are transactional and request-scoped",
+      "sources": [
+        {
+          "kind": "pull_request",
+          "number": 9,
+          "url": "https://github.com/TanStack/redact/pull/9",
+          "title": "Support vinext SSR stream bootstrap"
+        },
+        {
+          "kind": "pull_request",
+          "number": 14,
+          "url": "https://github.com/TanStack/redact/pull/14",
+          "title": "feat(redact): vinext SSR/hydration compatibility — 0.0.9"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/ssr-context.test.tsx",
+          "testName": "restores nested providers",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/ssr-context.test.tsx#L52-L83"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/ssr.test.tsx",
+          "testName": "retries when the root render suspends before any boundary",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/ssr.test.tsx#L160-L174"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/streaming-hydration.test.tsx",
+          "testName": "hydrates a resolved boundary against the streamed real content",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/streaming-hydration.test.tsx#L43-L90"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/streaming-hydration.test.tsx",
+          "testName": "re-hydrates a pending boundary when the server reveal fires",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/streaming-hydration.test.tsx#L92-L157"
+        }
+      ],
+      "symptom": "A root-level suspension or boundary replay could leak partial chunks, IDs, boundary records, or provider values into the retry or another request.",
+      "octaneContract": "Buffered render replays and streamed retries isolate render state, retire discarded boundary records, preserve provider stacks and stable IDs, hydrate revealed ranges in place, and report terminal root failure once.",
+      "classification": "portable",
+      "status": "covered",
+      "risk": "critical",
+      "owner": "Octane server renderer and streaming transports",
+      "applicableModes": ["server-string", "server-static", "server-stream", "hydrate-match"],
+      "observables": ["markup", "node-identity", "streaming", "errors"],
+      "octaneReferences": [
+        {
+          "kind": "integration",
+          "file": "packages/octane/tests/ssr-stream-state-regressions.test.ts",
+          "note": "Covers discarded passes, stable IDs, retired boundaries, and late errors."
+        },
+        {
+          "kind": "integration",
+          "file": "packages/octane/tests/streaming-ssr.test.ts",
+          "note": "Covers stream/hydration interleavings, reveal replacement, failure reporting, and seed scopes."
+        },
+        {
+          "kind": "documentation",
+          "file": "docs/ssr.md",
+          "note": "Bootstrap modules/import maps remain a metaframework concern rather than a core renderer option."
+        }
+      ],
+      "evidence": [
+        {
+          "file": "packages/octane/tests/ssr-render-phase-state.test.ts",
+          "testName": "settled output is byte-identical to a single-pass render of the final state (useId, markers, sibling order)",
+          "modes": ["server-string"],
+          "observables": ["markup"]
+        },
+        {
+          "file": "packages/octane/tests/ssr-render-phase-state.test.ts",
+          "testName": "rewinds the suspense seed stream — one use() seeds exactly once across the passes",
+          "modes": ["server-static"],
+          "observables": ["markup"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/fizz-streaming.test.ts",
+          "testName": "restores each Provider value across suspended concurrent streams",
+          "modes": ["server-stream"],
+          "observables": ["markup", "streaming"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/fizz-streaming.test.ts",
+          "testName": "delivers a boundary that resolves while a bare Promise delays the shell",
+          "modes": ["server-stream"],
+          "observables": ["markup", "streaming"]
+        },
+        {
+          "file": "packages/octane/tests/ssr-stream-state-regressions.test.ts",
+          "testName": "does not retain a boundary registered by a discarded render-phase pass",
+          "modes": ["server-stream"],
+          "observables": ["streaming"]
+        },
+        {
+          "file": "packages/octane/tests/streaming-ssr.test.ts",
+          "testName": "swaps the segment into place, scopes its seeds, and hydrates byte-for-byte",
+          "modes": ["server-stream", "hydrate-match"],
+          "observables": ["markup", "node-identity", "streaming"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/fizz-streaming.test.ts",
+          "testName": "reports a root failure through the shell callbacks and rejects a readable stream",
+          "modes": ["server-stream"],
+          "observables": ["errors", "streaming"]
+        }
+      ],
+      "rationale": "Redact's inline bootstrap API belongs at Octane's plugin/adapter boundary; the portable transactional retry and request-isolation contracts are already strongly covered."
+    },
+    {
+      "id": "RDX-SSR-002",
+      "area": "document-serialization",
+      "title": "Doctype ownership is explicit for each server rendering API",
+      "sources": [
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/portal-doctype.test.tsx",
+          "testName": "prepends a DOCTYPE when the root element is <html>",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/portal-doctype.test.tsx#L115-L135"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/portal-doctype.test.tsx",
+          "testName": "does not prepend a DOCTYPE for non-html roots",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/portal-doctype.test.tsx#L137-L150"
+        }
+      ],
+      "symptom": "A document response omitted or misplaced its doctype and entered quirks mode, or a fragment unexpectedly received a document preamble.",
+      "octaneContract": "Pipeable <html> document streams contain exactly one <!DOCTYPE html>, and readable <html> streams begin with that doctype; the shared serializer emits none for non-document roots, directly exercised through the pipeable API; renderToString and renderToStaticMarkup remain doctype-free so the embedding framework owns buffered preambles.",
+      "classification": "divergence",
+      "status": "covered",
+      "risk": "high",
+      "owner": "Octane server render APIs",
+      "applicableModes": ["server-string", "server-static", "server-stream"],
+      "observables": ["markup", "streaming"],
+      "octaneReferences": [
+        {
+          "kind": "documentation",
+          "file": "docs/ssr.md",
+          "note": "Documents streaming-only doctype ownership and buffered framework composition."
+        },
+        {
+          "kind": "integration",
+          "file": "packages/octane/tests/streaming-ssr-injection.test.ts",
+          "note": "Covers injected/non-injected document streams, fragments, web streams, and buffered APIs."
+        }
+      ],
+      "evidence": [
+        {
+          "file": "packages/octane/tests/streaming-ssr-injection.test.ts",
+          "testName": "streamed documents lead with <!DOCTYPE html> without any injection source",
+          "modes": ["server-stream"],
+          "observables": ["markup", "streaming"]
+        },
+        {
+          "file": "packages/octane/tests/streaming-ssr-injection.test.ts",
+          "testName": "streamed documents lead with <!DOCTYPE html> through the web-stream API",
+          "modes": ["server-stream"],
+          "observables": ["markup", "streaming"]
+        },
+        {
+          "file": "packages/octane/tests/streaming-ssr-injection.test.ts",
+          "testName": "streamed fragments never receive a doctype",
+          "modes": ["server-stream"],
+          "observables": ["markup", "streaming"]
+        },
+        {
+          "file": "packages/octane/tests/streaming-ssr-injection.test.ts",
+          "testName": "buffered renderers stay doctype-free for document roots, matching React",
+          "modes": ["server-string", "server-static"],
+          "observables": ["markup"]
+        }
+      ],
+      "rationale": "Redact's buffered renderer prepends a doctype for an <html> root. Octane intentionally matches React's API split: streaming owns the document preamble, while buffered output remains composable. The transferable contract is explicit API ownership, not identical bytes across unlike APIs."
+    },
+    {
+      "id": "RDX-STORE-001",
+      "area": "external-store",
+      "title": "External-store subscription races cannot create zombie DOM",
+      "sources": [
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/external-store-unmount.test.tsx",
+          "testName": "subscribes after render when the store synchronously notifies",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/external-store-unmount.test.tsx#L47-L81"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/external-store-unmount.test.tsx",
+          "testName": "store notifications after unmount do not resurrect DOM",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/external-store-unmount.test.tsx#L116-L156"
+        }
+      ],
+      "symptom": "Subscription ran during render or a stale listener scheduled an unmounted component, causing removed UI to reappear in its former host.",
+      "octaneContract": "useSyncExternalStore subscribes after render, converges when subscribe synchronously notifies, unsubscribes on conditional/root removal, and ignores every post-unmount notification.",
+      "classification": "portable",
+      "status": "planned",
+      "risk": "high",
+      "owner": "Octane useSyncExternalStore and scheduler",
+      "applicableModes": ["client", "production-compile"],
+      "observables": ["markup", "effects"],
+      "octaneReferences": [
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/sync-external-store.test.ts",
+          "testName": "post-unmount store mutations do NOT trigger any work",
+          "note": "Covers root unmount but not synchronous subscribe notification or conditional stale-listener delivery."
+        },
+        {
+          "kind": "source",
+          "file": "packages/octane/src/runtime.ts",
+          "symbol": "useSyncExternalStore"
+        }
+      ],
+      "nextAction": {
+        "kind": "test",
+        "targets": ["packages/octane/tests/sync-external-store.test.ts"],
+        "acceptance": "Prove subscription occurs outside render, a synchronous notifier converges without looping, conditional removal unsubscribes, and a retained stale callback cannot resurrect DOM."
+      }
+    },
+    {
+      "id": "RDX-SUS-001",
+      "area": "suspense-preservation",
+      "title": "Re-suspension preserves browser-owned state in committed UI",
+      "sources": [
+        {
+          "kind": "pull_request",
+          "number": 16,
+          "url": "https://github.com/TanStack/redact/pull/16",
+          "title": "fix(redact): preserve committed DOM across Suspense re-suspension"
+        },
+        {
+          "kind": "test",
+          "commit": "e1620a13aab8935c806238f117ba58559b7cd002",
+          "path": "tests/suspense-preserves-dom.test.tsx",
+          "testName": "preserves focus on an input across a sibling suspension",
+          "url": "https://github.com/TanStack/redact/blob/e1620a13aab8935c806238f117ba58559b7cd002/tests/suspense-preserves-dom.test.tsx#L170-L220"
+        }
+      ],
+      "symptom": "Navigating through a suspension destroyed a committed sidebar, resetting scroll and focus even though the logical UI survived.",
+      "octaneContract": "An already committed Suspense primary tree preserves node identity, component state, scroll, focus, selection, uncontrolled values, and other browser-owned state through urgent and transitioned re-suspension, while refs/effects follow Octane's documented lifecycle.",
+      "classification": "portable",
+      "status": "planned",
+      "risk": "critical",
+      "owner": "Octane Suspense runtime and browser tests",
+      "applicableModes": ["client", "production-compile", "real-browser"],
+      "observables": [
+        "node-identity",
+        "focus",
+        "selection",
+        "scroll",
+        "live-properties",
+        "effects",
+        "refs"
+      ],
+      "octaneReferences": [
+        {
+          "kind": "source",
+          "file": "packages/octane/src/runtime.ts",
+          "symbol": "softDetachTryBlock",
+          "note": "Ordinary Suspense currently parks committed DOM in savedDom before reinsertion."
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/conformance/suspense-refs.test.ts",
+          "testName": "detaches host refs on suspend and re-attaches on reveal",
+          "note": "Proves reuse of the same node, not browser focus/scroll preservation."
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/conformance/suspense-effects-semantics.test.ts",
+          "testName": "destroys the committed layout effect on re-suspend, recreates on reveal"
+        }
+      ],
+      "nextAction": {
+        "kind": "test",
+        "targets": ["packages/octane/tests/browser", "packages/octane/tests/suspense.test.ts"],
+        "acceptance": "In real Chromium, cover same-tree and route-swap re-suspension with identity, scrollTop, activeElement, selection, uncontrolled value, state, refs, and effect logs for urgent and transitioned paths before changing the hiding mechanism."
+      },
+      "rationale": "The observable preservation contract transfers; Redact's display:none and detached-fallback fiber implementation does not. JSDOM is insufficient for the browser-owned state assertions."
+    }
+  ]
+}

--- a/packages/octane/audit/redact-adversarial-ledger.schema.json
+++ b/packages/octane/audit/redact-adversarial-ledger.schema.json
@@ -1,0 +1,405 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://octanejs.dev/schemas/redact-adversarial-ledger.schema.json",
+  "title": "Octane Redact-derived adversarial contract ledger",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["$schema", "schemaVersion", "upstream", "idRegistry", "entries"],
+  "properties": {
+    "$schema": { "const": "./redact-adversarial-ledger.schema.json" },
+    "schemaVersion": { "const": 1 },
+    "upstream": { "$ref": "#/$defs/upstream" },
+    "idRegistry": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/idRegistryEntry" }
+    },
+    "entries": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/entry" }
+    }
+  },
+  "$defs": {
+    "upstream": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "commit", "capturedOn", "scope"],
+      "properties": {
+        "repository": { "const": "https://github.com/TanStack/redact" },
+        "commit": { "$ref": "#/$defs/commit" },
+        "capturedOn": { "type": "string", "format": "date" },
+        "scope": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["issueNumbers", "pullRequestNumbers", "paths", "artifacts"],
+          "properties": {
+            "issueNumbers": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": { "type": "integer", "minimum": 1 }
+            },
+            "pullRequestNumbers": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": { "type": "integer", "minimum": 1 }
+            },
+            "paths": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": { "$ref": "#/$defs/repositoryPath" }
+            },
+            "artifacts": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/auditedArtifact" }
+            }
+          }
+        }
+      }
+    },
+    "entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "area",
+        "title",
+        "sources",
+        "symptom",
+        "octaneContract",
+        "classification",
+        "status",
+        "risk",
+        "owner",
+        "applicableModes",
+        "observables"
+      ],
+      "properties": {
+        "id": { "type": "string", "pattern": "^RDX-[A-Z]+-[0-9]{3}$" },
+        "area": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
+        "title": { "type": "string", "minLength": 1 },
+        "sources": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/source" }
+        },
+        "symptom": { "type": "string", "minLength": 1 },
+        "octaneContract": { "type": "string", "minLength": 1 },
+        "classification": { "$ref": "#/$defs/classification" },
+        "status": { "$ref": "#/$defs/status" },
+        "risk": { "$ref": "#/$defs/risk" },
+        "owner": { "type": "string", "minLength": 1 },
+        "applicableModes": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/mode" }
+        },
+        "observables": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/observable" }
+        },
+        "octaneReferences": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/octaneReference" }
+        },
+        "evidence": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/evidence" }
+        },
+        "nextAction": { "$ref": "#/$defs/nextAction" },
+        "rationale": { "type": "string", "minLength": 1 }
+      },
+      "allOf": [
+        {
+          "if": {
+            "required": ["status"],
+            "properties": { "status": { "const": "covered" } }
+          },
+          "then": { "required": ["evidence"] }
+        },
+        {
+          "if": {
+            "required": ["status"],
+            "properties": { "status": { "enum": ["planned", "in_progress"] } }
+          },
+          "then": { "required": ["nextAction"] }
+        },
+        {
+          "if": {
+            "required": ["status"],
+            "properties": { "status": { "const": "decision_required" } }
+          },
+          "then": {
+            "required": ["nextAction", "rationale"],
+            "properties": {
+              "nextAction": {
+                "properties": { "kind": { "const": "decision" } }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["classification"],
+            "properties": { "classification": { "enum": ["divergence", "non_goal"] } }
+          },
+          "then": { "required": ["rationale"] }
+        },
+        {
+          "if": {
+            "required": ["status"],
+            "properties": { "status": { "const": "blocked" } }
+          },
+          "then": { "required": ["rationale"] }
+        },
+        {
+          "if": {
+            "required": ["status"],
+            "properties": { "status": { "const": "documented" } }
+          },
+          "then": { "required": ["rationale"] }
+        },
+        {
+          "if": {
+            "required": ["status", "classification"],
+            "properties": {
+              "status": { "const": "documented" },
+              "classification": { "enum": ["portable", "adaptable"] }
+            }
+          },
+          "then": {
+            "required": ["octaneReferences"],
+            "properties": {
+              "octaneReferences": {
+                "minItems": 1,
+                "items": {
+                  "properties": {
+                    "kind": { "enum": ["documentation", "benchmark"] }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "url"],
+      "properties": {
+        "kind": { "enum": ["issue", "pull_request", "commit", "test"] },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^https://github\\.com/TanStack/redact/"
+        },
+        "title": { "type": "string", "minLength": 1 },
+        "number": { "type": "integer", "minimum": 1 },
+        "commit": { "$ref": "#/$defs/commit" },
+        "path": { "$ref": "#/$defs/repositoryPath" },
+        "testName": { "type": "string", "minLength": 1 }
+      },
+      "allOf": [
+        {
+          "if": {
+            "required": ["kind"],
+            "properties": { "kind": { "enum": ["issue", "pull_request"] } }
+          },
+          "then": { "required": ["number", "title"] }
+        },
+        {
+          "if": {
+            "required": ["kind"],
+            "properties": { "kind": { "const": "commit" } }
+          },
+          "then": { "required": ["commit"] }
+        },
+        {
+          "if": {
+            "required": ["kind"],
+            "properties": { "kind": { "const": "test" } }
+          },
+          "then": { "required": ["commit", "path", "testName"] }
+        }
+      ]
+    },
+    "octaneReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "file"],
+      "properties": {
+        "kind": { "enum": ["source", "test", "documentation", "benchmark", "integration"] },
+        "file": { "$ref": "#/$defs/repositoryPath" },
+        "symbol": { "type": "string", "minLength": 1 },
+        "testName": { "type": "string", "minLength": 1 },
+        "note": { "type": "string", "minLength": 1 }
+      },
+      "allOf": [
+        {
+          "if": {
+            "required": ["kind"],
+            "properties": { "kind": { "const": "test" } }
+          },
+          "then": { "required": ["testName"] }
+        }
+      ]
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["modes", "observables"],
+      "properties": {
+        "kind": { "enum": ["test", "command"] },
+        "file": { "$ref": "#/$defs/repositoryPath" },
+        "testName": { "type": "string", "minLength": 1 },
+        "script": { "type": "string", "minLength": 1 },
+        "modes": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/mode" }
+        },
+        "observables": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/observable" }
+        }
+      },
+      "oneOf": [
+        {
+          "required": ["file", "testName"],
+          "properties": { "kind": { "const": "test" } },
+          "not": { "required": ["script"] }
+        },
+        {
+          "required": ["kind", "script"],
+          "properties": { "kind": { "const": "command" } },
+          "not": { "anyOf": [{ "required": ["file"] }, { "required": ["testName"] }] }
+        }
+      ]
+    },
+    "nextAction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "targets", "acceptance"],
+      "properties": {
+        "kind": {
+          "enum": ["test", "implementation", "decision", "documentation", "benchmark"]
+        },
+        "targets": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "acceptance": { "type": "string", "minLength": 1 }
+      }
+    },
+    "classification": {
+      "enum": ["portable", "adaptable", "divergence", "non_goal"]
+    },
+    "status": {
+      "enum": ["planned", "in_progress", "covered", "documented", "decision_required", "blocked"]
+    },
+    "risk": { "enum": ["critical", "high", "medium", "low"] },
+    "mode": {
+      "enum": [
+        "client",
+        "server-string",
+        "server-static",
+        "server-stream",
+        "hydrate-match",
+        "hydrate-mismatch",
+        "deferred-hydration",
+        "production-compile",
+        "real-browser",
+        "packaged-consumer",
+        "vite-client",
+        "vite-ssr",
+        "rspack",
+        "rsbuild",
+        "benchmark"
+      ]
+    },
+    "observable": {
+      "enum": [
+        "markup",
+        "node-identity",
+        "dom-mutations",
+        "focus",
+        "selection",
+        "scroll",
+        "live-properties",
+        "effects",
+        "refs",
+        "events",
+        "errors",
+        "streaming",
+        "package-resolution",
+        "performance"
+      ]
+    },
+    "commit": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "repositoryPath": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$)).+"
+    },
+    "idRegistryEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "status", "introducedOn"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^RDX-[A-Z]+-[0-9]{3}$" },
+        "status": { "enum": ["active", "retired"] },
+        "introducedOn": { "type": "string", "format": "date" },
+        "rationale": { "type": "string", "minLength": 1 }
+      },
+      "allOf": [
+        {
+          "if": {
+            "required": ["status"],
+            "properties": { "status": { "const": "retired" } }
+          },
+          "then": { "required": ["rationale"] }
+        }
+      ]
+    },
+    "auditedArtifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "disposition", "entryIds"],
+      "properties": {
+        "path": { "$ref": "#/$defs/repositoryPath" },
+        "disposition": { "enum": ["mapped", "folded", "non_goal"] },
+        "entryIds": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^RDX-[A-Z]+-[0-9]{3}$" }
+        },
+        "note": { "type": "string", "minLength": 1 }
+      },
+      "allOf": [
+        {
+          "if": {
+            "required": ["disposition"],
+            "properties": { "disposition": { "enum": ["folded", "non_goal"] } }
+          },
+          "then": { "required": ["note"] }
+        }
+      ]
+    }
+  }
+}

--- a/scripts/redact-audit/generate.mjs
+++ b/scripts/redact-audit/generate.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { renderReport, validateIdRegistryCompatibility, validateLedger } from './ledger-lib.mjs';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const LEDGER_PATH = path.join(REPO_ROOT, 'packages/octane/audit/redact-adversarial-ledger.json');
+const REPORT_PATH = path.join(REPO_ROOT, 'docs/redact-adversarial-audit.md');
+const CHECK = process.argv.includes('--check');
+const unknownArguments = process.argv.slice(2).filter((argument) => argument !== '--check');
+
+if (unknownArguments.length > 0) {
+	console.error(`Unknown argument(s): ${unknownArguments.join(', ')}`);
+	process.exit(1);
+}
+
+if (!existsSync(LEDGER_PATH)) {
+	console.error(
+		'Redact adversarial ledger is missing: packages/octane/audit/redact-adversarial-ledger.json.',
+	);
+	process.exit(1);
+}
+
+let ledger;
+try {
+	ledger = JSON.parse(readFileSync(LEDGER_PATH, 'utf8'));
+} catch (error) {
+	console.error(`Redact adversarial ledger is invalid JSON: ${error.message}`);
+	process.exit(1);
+}
+
+const errors = validateLedger(ledger, REPO_ROOT);
+if (errors.length > 0) {
+	console.error(`Redact adversarial ledger is invalid:\n  - ${errors.join('\n  - ')}`);
+	process.exit(1);
+}
+
+const compatibilityBase = process.env.OCTANE_REDACT_AUDIT_BASE;
+if (compatibilityBase !== undefined) {
+	try {
+		execFileSync('git', ['cat-file', '-e', `${compatibilityBase}^{commit}`], {
+			cwd: REPO_ROOT,
+			stdio: 'ignore',
+		});
+	} catch {
+		console.error(`Cannot resolve Redact audit compatibility base ${compatibilityBase}.`);
+		process.exit(1);
+	}
+	let previousSource;
+	try {
+		previousSource = execFileSync(
+			'git',
+			['show', `${compatibilityBase}:packages/octane/audit/redact-adversarial-ledger.json`],
+			{ cwd: REPO_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+		);
+	} catch {
+		// The first release of the ledger has no prior file to compare. Every
+		// later PR/push is checked against its base commit by CI.
+		previousSource = undefined;
+	}
+	if (previousSource !== undefined) {
+		let previousLedger;
+		try {
+			previousLedger = JSON.parse(previousSource);
+		} catch (error) {
+			console.error(`Base Redact adversarial ledger is invalid JSON: ${error.message}`);
+			process.exit(1);
+		}
+		const compatibilityErrors = validateIdRegistryCompatibility(previousLedger, ledger);
+		if (compatibilityErrors.length > 0) {
+			console.error(
+				`Redact adversarial ledger breaks permanent-ID compatibility:\n  - ${compatibilityErrors.join('\n  - ')}`,
+			);
+			process.exit(1);
+		}
+	}
+}
+
+const report = renderReport(ledger);
+if (CHECK) {
+	if (!existsSync(REPORT_PATH) || readFileSync(REPORT_PATH, 'utf8') !== report) {
+		console.error(
+			'docs/redact-adversarial-audit.md is stale — run `pnpm redact-audit:generate` and commit the result.',
+		);
+		process.exit(1);
+	}
+	console.log(`Redact adversarial audit is current (${ledger.entries.length} entries).`);
+} else {
+	writeFileSync(REPORT_PATH, report);
+	console.log(`wrote docs/redact-adversarial-audit.md (${ledger.entries.length} entries).`);
+}

--- a/scripts/redact-audit/ledger-lib.mjs
+++ b/scripts/redact-audit/ledger-lib.mjs
@@ -1,0 +1,1069 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { extractTestCases } from '../react-parity/inventory-lib.mjs';
+
+export const REDACT_REPOSITORY = 'https://github.com/TanStack/redact';
+export const LEDGER_SCHEMA = './redact-adversarial-ledger.schema.json';
+export const CLASSIFICATIONS = ['portable', 'adaptable', 'divergence', 'non_goal'];
+export const STATUSES = [
+	'planned',
+	'in_progress',
+	'covered',
+	'documented',
+	'decision_required',
+	'blocked',
+];
+export const RISKS = ['critical', 'high', 'medium', 'low'];
+export const MODES = [
+	'client',
+	'server-string',
+	'server-static',
+	'server-stream',
+	'hydrate-match',
+	'hydrate-mismatch',
+	'deferred-hydration',
+	'production-compile',
+	'real-browser',
+	'packaged-consumer',
+	'vite-client',
+	'vite-ssr',
+	'rspack',
+	'rsbuild',
+	'benchmark',
+];
+export const OBSERVABLES = [
+	'markup',
+	'node-identity',
+	'dom-mutations',
+	'focus',
+	'selection',
+	'scroll',
+	'live-properties',
+	'effects',
+	'refs',
+	'events',
+	'errors',
+	'streaming',
+	'package-resolution',
+	'performance',
+];
+
+const SOURCE_KINDS = ['issue', 'pull_request', 'commit', 'test'];
+const REFERENCE_KINDS = ['source', 'test', 'documentation', 'benchmark', 'integration'];
+const ACTION_KINDS = ['test', 'implementation', 'decision', 'documentation', 'benchmark'];
+const EVIDENCE_KINDS = ['test', 'command'];
+const OPEN_STATUSES = new Set(['planned', 'in_progress', 'decision_required', 'blocked']);
+const COMMIT_PATTERN = /^[0-9a-f]{40}$/;
+const ID_PATTERN = /^RDX-[A-Z]+-[0-9]{3}$/;
+const AREA_PATTERN = /^[a-z][a-z0-9-]*$/;
+
+function isRecord(value) {
+	return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function expectRecord(value, label, errors) {
+	if (isRecord(value)) return value;
+	errors.push(`${label} must be an object.`);
+	return null;
+}
+
+function checkKeys(record, allowed, label, errors) {
+	for (const key of Object.keys(record)) {
+		if (!allowed.includes(key)) errors.push(`${label} has unknown field ${JSON.stringify(key)}.`);
+	}
+}
+
+function requireKeys(record, required, label, errors) {
+	for (const key of required) {
+		if (!Object.hasOwn(record, key)) errors.push(`${label} is missing ${JSON.stringify(key)}.`);
+	}
+}
+
+function expectString(value, label, errors, pattern = null) {
+	if (typeof value !== 'string' || value.trim() === '') {
+		errors.push(`${label} must be a non-empty string.`);
+		return false;
+	}
+	if (pattern && !pattern.test(value)) {
+		errors.push(`${label} has invalid value ${JSON.stringify(value)}.`);
+		return false;
+	}
+	return true;
+}
+
+function expectEnum(value, allowed, label, errors) {
+	if (!allowed.includes(value)) {
+		errors.push(
+			`${label} must be one of ${allowed.map((item) => JSON.stringify(item)).join(', ')}.`,
+		);
+		return false;
+	}
+	return true;
+}
+
+function expectUniqueArray(value, label, errors, { minItems = 1 } = {}) {
+	if (!Array.isArray(value)) {
+		errors.push(`${label} must be an array.`);
+		return null;
+	}
+	if (value.length < minItems) errors.push(`${label} must contain at least ${minItems} item(s).`);
+	const seen = new Set();
+	for (const item of value) {
+		const key = JSON.stringify(item);
+		if (seen.has(key)) errors.push(`${label} contains duplicate ${key}.`);
+		seen.add(key);
+	}
+	return value;
+}
+
+function expectEnumArray(value, allowed, label, errors) {
+	const items = expectUniqueArray(value, label, errors);
+	if (!items) return;
+	for (const [index, item] of items.entries()) {
+		expectEnum(item, allowed, `${label}[${index}]`, errors);
+	}
+}
+
+function expectPositiveIntegerArray(value, label, errors) {
+	const items = expectUniqueArray(value, label, errors);
+	if (!items) return [];
+	for (const [index, item] of items.entries()) {
+		if (!Number.isInteger(item) || item < 1)
+			errors.push(`${label}[${index}] must be a positive integer.`);
+	}
+	const sorted = [...items].sort((a, b) => a - b);
+	if (items.some((item, index) => item !== sorted[index]))
+		errors.push(`${label} must be sorted numerically.`);
+	return items;
+}
+
+function isRepositoryPath(value) {
+	if (typeof value !== 'string' || value === '' || value.includes('\\') || value.includes('\0'))
+		return false;
+	if (path.posix.isAbsolute(value) || value.startsWith('./')) return false;
+	const normalized = path.posix.normalize(value);
+	return normalized === value && normalized !== '..' && !normalized.startsWith('../');
+}
+
+function expectRepositoryPath(value, label, errors) {
+	if (isRepositoryPath(value)) return true;
+	errors.push(`${label} must be a normalized repository-relative path.`);
+	return false;
+}
+
+function resolveRepositoryFile(repoRoot, file, label, errors) {
+	if (!expectRepositoryPath(file, label, errors)) return null;
+	const absolute = path.resolve(repoRoot, file);
+	const relative = path.relative(repoRoot, absolute);
+	if (relative.startsWith('..') || path.isAbsolute(relative)) {
+		errors.push(`${label} resolves outside the repository.`);
+		return null;
+	}
+	if (!existsSync(absolute) || !statSync(absolute).isFile()) {
+		errors.push(`${label} does not name an existing file: ${file}.`);
+		return null;
+	}
+	return absolute;
+}
+
+function checkSourceUrl(source, label, errors) {
+	if (!expectString(source.url, `${label}.url`, errors)) return;
+	let expected;
+	switch (source.kind) {
+		case 'issue':
+			expected = `${REDACT_REPOSITORY}/issues/${source.number}`;
+			break;
+		case 'pull_request':
+			expected = `${REDACT_REPOSITORY}/pull/${source.number}`;
+			break;
+		case 'commit':
+			expected = `${REDACT_REPOSITORY}/commit/${source.commit}`;
+			break;
+		case 'test':
+			expected = `${REDACT_REPOSITORY}/blob/${source.commit}/${source.path}`;
+			break;
+		default:
+			return;
+	}
+	if (
+		source.url !== expected &&
+		!(source.kind === 'test' && source.url.startsWith(`${expected}#`))
+	) {
+		errors.push(`${label}.url must be the pinned canonical URL ${JSON.stringify(expected)}.`);
+	}
+}
+
+function validateSource(sourceValue, label, errors, observedSources, snapshotCommit) {
+	const source = expectRecord(sourceValue, label, errors);
+	if (!source) return null;
+	checkKeys(
+		source,
+		['kind', 'url', 'title', 'number', 'commit', 'path', 'testName'],
+		label,
+		errors,
+	);
+	requireKeys(source, ['kind', 'url'], label, errors);
+	if (!expectEnum(source.kind, SOURCE_KINDS, `${label}.kind`, errors)) return null;
+	if (source.title !== undefined) expectString(source.title, `${label}.title`, errors);
+
+	if (source.kind === 'issue' || source.kind === 'pull_request') {
+		if (source.title === undefined)
+			errors.push(`${label}.title is required for issue and pull-request attribution.`);
+		if (!Number.isInteger(source.number) || source.number < 1)
+			errors.push(`${label}.number must be a positive integer.`);
+		for (const key of ['commit', 'path', 'testName']) {
+			if (source[key] !== undefined)
+				errors.push(`${label}.${key} is not valid for a ${source.kind} source.`);
+		}
+		const sourceKey = `${source.kind}:${source.number}`;
+		const priorTitle = observedSources.titles.get(sourceKey);
+		if (priorTitle !== undefined && priorTitle !== source.title)
+			errors.push(
+				`${label}.title disagrees with the other ${source.kind} #${source.number} attribution.`,
+			);
+		else if (typeof source.title === 'string') observedSources.titles.set(sourceKey, source.title);
+		if (source.kind === 'issue') observedSources.issues.add(source.number);
+		else observedSources.pullRequests.add(source.number);
+	} else {
+		if (!expectString(source.commit, `${label}.commit`, errors, COMMIT_PATTERN)) return null;
+		if (source.number !== undefined)
+			errors.push(`${label}.number is not valid for a ${source.kind} source.`);
+		if (source.kind === 'test') {
+			expectRepositoryPath(source.path, `${label}.path`, errors);
+			expectString(source.testName, `${label}.testName`, errors);
+			if (typeof source.path === 'string') observedSources.tests.add(source.path);
+			if (source.commit !== snapshotCommit)
+				errors.push(`${label}.commit must match the audited upstream snapshot ${snapshotCommit}.`);
+		} else {
+			for (const key of ['path', 'testName']) {
+				if (source[key] !== undefined)
+					errors.push(`${label}.${key} is not valid for a commit source.`);
+			}
+		}
+	}
+
+	checkSourceUrl(source, label, errors);
+	return source;
+}
+
+const configuredTestPatternsByRoot = new Map();
+
+function globPatternToRegExp(pattern) {
+	let source = '^';
+	for (let index = 0; index < pattern.length; index++) {
+		if (pattern.startsWith('**/', index)) {
+			source += '(?:.*/)?';
+			index += 2;
+		} else if (pattern.startsWith('**', index)) {
+			source += '.*';
+			index += 1;
+		} else if (pattern[index] === '*') {
+			source += '[^/]*';
+		} else {
+			source += pattern[index].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+		}
+	}
+	return new RegExp(`${source}$`);
+}
+
+function configuredTestPatterns(repoRoot) {
+	if (configuredTestPatternsByRoot.has(repoRoot)) return configuredTestPatternsByRoot.get(repoRoot);
+	const configPath = path.join(repoRoot, 'vitest.config.js');
+	if (!existsSync(configPath)) {
+		configuredTestPatternsByRoot.set(repoRoot, []);
+		return [];
+	}
+	const config = readFileSync(configPath, 'utf8');
+	const patterns = [
+		...config.matchAll(/['"]((?:packages|website)[^'"]*\*[^'"]*(?:\.test|\.spec)\.[^'"]+)['"]/g),
+	].map((match) => globPatternToRegExp(match[1]));
+	configuredTestPatternsByRoot.set(repoRoot, patterns);
+	return patterns;
+}
+
+function hasExecutableTest(contents, file, testName, repoRoot) {
+	if (!configuredTestPatterns(repoRoot).some((pattern) => pattern.test(file))) return false;
+	if (/\b(?:describe|suite)\s*\.\s*(?:skip|todo)\s*\(/.test(contents)) return false;
+	return extractTestCases(contents, { file }).some(
+		(testCase) =>
+			testCase.title === testName &&
+			testCase.kind !== 'xit' &&
+			!testCase.modifiers.some((modifier) =>
+				['skip', 'todo', 'fails', 'failing'].includes(modifier),
+			) &&
+			testCase.gate === null &&
+			Number.isInteger(testCase.estimatedRegistrations) &&
+			testCase.estimatedRegistrations > 0,
+	);
+}
+
+function validateOctaneReference(referenceValue, label, errors, repoRoot) {
+	const reference = expectRecord(referenceValue, label, errors);
+	if (!reference) return;
+	checkKeys(reference, ['kind', 'file', 'symbol', 'testName', 'note'], label, errors);
+	requireKeys(reference, ['kind', 'file'], label, errors);
+	expectEnum(reference.kind, REFERENCE_KINDS, `${label}.kind`, errors);
+	if (reference.symbol !== undefined) expectString(reference.symbol, `${label}.symbol`, errors);
+	if (reference.testName !== undefined)
+		expectString(reference.testName, `${label}.testName`, errors);
+	if (reference.note !== undefined) expectString(reference.note, `${label}.note`, errors);
+	if (reference.kind === 'test' && reference.testName === undefined)
+		errors.push(`${label}.testName is required for a test reference.`);
+
+	const absolute = resolveRepositoryFile(repoRoot, reference.file, `${label}.file`, errors);
+	if (!absolute) return;
+	const contents = readFileSync(absolute, 'utf8');
+	if (reference.symbol && !contents.includes(reference.symbol))
+		errors.push(`${label}.symbol was not found in ${reference.file}: ${reference.symbol}.`);
+	if (
+		reference.testName &&
+		!hasExecutableTest(contents, reference.file, reference.testName, repoRoot)
+	)
+		errors.push(
+			`${label}.testName is not an executable registered test in ${reference.file}: ${reference.testName}.`,
+		);
+}
+
+function validateEvidence(evidenceValue, label, errors, repoRoot) {
+	const evidence = expectRecord(evidenceValue, label, errors);
+	if (!evidence) return;
+	checkKeys(
+		evidence,
+		['kind', 'file', 'testName', 'script', 'modes', 'observables'],
+		label,
+		errors,
+	);
+	requireKeys(evidence, ['modes', 'observables'], label, errors);
+	const kind = evidence.kind ?? 'test';
+	expectEnum(kind, EVIDENCE_KINDS, `${label}.kind`, errors);
+	expectEnumArray(evidence.modes, MODES, `${label}.modes`, errors);
+	expectEnumArray(evidence.observables, OBSERVABLES, `${label}.observables`, errors);
+
+	if (kind === 'command') {
+		requireKeys(evidence, ['kind', 'script'], label, errors);
+		expectString(evidence.script, `${label}.script`, errors);
+		for (const key of ['file', 'testName']) {
+			if (evidence[key] !== undefined)
+				errors.push(`${label}.${key} is not valid for command evidence.`);
+		}
+		if (typeof evidence.script === 'string') {
+			const manifest = JSON.parse(readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+			const command = manifest.scripts?.[evidence.script];
+			if (typeof command !== 'string') {
+				errors.push(`${label}.script is not registered in package.json: ${evidence.script}.`);
+			} else {
+				for (const match of command.matchAll(/(?:^|&&|\|\||;)\s*node\s+(['"]?)([^\s'";&|]+)\1/g)) {
+					if (!existsSync(path.join(repoRoot, match[2])))
+						errors.push(`${label}.script references a missing Node entry point: ${match[2]}.`);
+				}
+				const workflowsDirectory = path.join(repoRoot, '.github/workflows');
+				const workflowSources = existsSync(workflowsDirectory)
+					? readdirSync(workflowsDirectory)
+							.filter((file) => file.endsWith('.yml') || file.endsWith('.yaml'))
+							.map((file) => readFileSync(path.join(workflowsDirectory, file), 'utf8'))
+					: [];
+				const invocation = new RegExp(
+					`\\bpnpm\\s+${evidence.script.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:\\s|$)`,
+				);
+				if (!workflowSources.some((source) => invocation.test(source)))
+					errors.push(
+						`${label}.script is not invoked by a checked-in workflow: ${evidence.script}.`,
+					);
+			}
+		}
+		return;
+	}
+
+	requireKeys(evidence, ['file', 'testName'], label, errors);
+	if (evidence.script !== undefined) errors.push(`${label}.script is not valid for test evidence.`);
+	expectString(evidence.testName, `${label}.testName`, errors);
+	const absolute = resolveRepositoryFile(repoRoot, evidence.file, `${label}.file`, errors);
+	if (!absolute || typeof evidence.testName !== 'string') return;
+	if (
+		!hasExecutableTest(readFileSync(absolute, 'utf8'), evidence.file, evidence.testName, repoRoot)
+	)
+		errors.push(
+			`${label}.testName is not an executable registered test in ${evidence.file}: ${evidence.testName}.`,
+		);
+}
+
+function validateNextAction(actionValue, label, errors) {
+	const action = expectRecord(actionValue, label, errors);
+	if (!action) return;
+	checkKeys(action, ['kind', 'targets', 'acceptance'], label, errors);
+	requireKeys(action, ['kind', 'targets', 'acceptance'], label, errors);
+	expectEnum(action.kind, ACTION_KINDS, `${label}.kind`, errors);
+	const targets = expectUniqueArray(action.targets, `${label}.targets`, errors);
+	if (targets) {
+		for (const [index, target] of targets.entries())
+			expectString(target, `${label}.targets[${index}]`, errors);
+	}
+	expectString(action.acceptance, `${label}.acceptance`, errors);
+}
+
+function validateEntry(entryValue, index, errors, repoRoot, observedSources, snapshotCommit) {
+	const label = `entries[${index}]`;
+	const entry = expectRecord(entryValue, label, errors);
+	if (!entry) return null;
+	const allowed = [
+		'id',
+		'area',
+		'title',
+		'sources',
+		'symptom',
+		'octaneContract',
+		'classification',
+		'status',
+		'risk',
+		'owner',
+		'applicableModes',
+		'observables',
+		'octaneReferences',
+		'evidence',
+		'nextAction',
+		'rationale',
+	];
+	const required = [
+		'id',
+		'area',
+		'title',
+		'sources',
+		'symptom',
+		'octaneContract',
+		'classification',
+		'status',
+		'risk',
+		'owner',
+		'applicableModes',
+		'observables',
+	];
+	checkKeys(entry, allowed, label, errors);
+	requireKeys(entry, required, label, errors);
+	expectString(entry.id, `${label}.id`, errors, ID_PATTERN);
+	expectString(entry.area, `${label}.area`, errors, AREA_PATTERN);
+	for (const key of ['title', 'symptom', 'octaneContract', 'owner'])
+		expectString(entry[key], `${label}.${key}`, errors);
+	expectEnum(entry.classification, CLASSIFICATIONS, `${label}.classification`, errors);
+	expectEnum(entry.status, STATUSES, `${label}.status`, errors);
+	expectEnum(entry.risk, RISKS, `${label}.risk`, errors);
+	expectEnumArray(entry.applicableModes, MODES, `${label}.applicableModes`, errors);
+	expectEnumArray(entry.observables, OBSERVABLES, `${label}.observables`, errors);
+	if (entry.rationale !== undefined) expectString(entry.rationale, `${label}.rationale`, errors);
+
+	const sources = expectUniqueArray(entry.sources, `${label}.sources`, errors);
+	if (sources) {
+		const identities = new Set();
+		for (const [sourceIndex, sourceValue] of sources.entries()) {
+			const source = validateSource(
+				sourceValue,
+				`${label}.sources[${sourceIndex}]`,
+				errors,
+				observedSources,
+				snapshotCommit,
+			);
+			if (!source) continue;
+			const identity = `${source.kind}:${source.url}`;
+			if (identities.has(identity)) errors.push(`${label}.sources repeats ${identity}.`);
+			identities.add(identity);
+		}
+	}
+
+	if (entry.octaneReferences !== undefined) {
+		if (!Array.isArray(entry.octaneReferences))
+			errors.push(`${label}.octaneReferences must be an array.`);
+		else
+			for (const [referenceIndex, reference] of entry.octaneReferences.entries())
+				validateOctaneReference(
+					reference,
+					`${label}.octaneReferences[${referenceIndex}]`,
+					errors,
+					repoRoot,
+				);
+	}
+
+	if (entry.evidence !== undefined) {
+		const evidence = expectUniqueArray(entry.evidence, `${label}.evidence`, errors);
+		if (evidence) {
+			const declaredModes = new Set(
+				Array.isArray(entry.applicableModes) ? entry.applicableModes : [],
+			);
+			const declaredObservables = new Set(
+				Array.isArray(entry.observables) ? entry.observables : [],
+			);
+			for (const [evidenceIndex, item] of evidence.entries()) {
+				validateEvidence(item, `${label}.evidence[${evidenceIndex}]`, errors, repoRoot);
+				for (const mode of Array.isArray(item?.modes) ? item.modes : []) {
+					if (!declaredModes.has(mode))
+						errors.push(
+							`${label}.evidence[${evidenceIndex}] claims mode ${mode} outside the entry contract.`,
+						);
+				}
+				for (const observable of Array.isArray(item?.observables) ? item.observables : []) {
+					if (!declaredObservables.has(observable))
+						errors.push(
+							`${label}.evidence[${evidenceIndex}] claims observable ${observable} outside the entry contract.`,
+						);
+				}
+			}
+		}
+	}
+	if (entry.nextAction !== undefined)
+		validateNextAction(entry.nextAction, `${label}.nextAction`, errors);
+
+	if (entry.status === 'covered' && (!Array.isArray(entry.evidence) || entry.evidence.length === 0))
+		errors.push(`${label} is covered but has no executable evidence.`);
+	if (entry.status === 'covered' && Array.isArray(entry.evidence)) {
+		const evidenceModes = new Set(
+			entry.evidence.flatMap((item) => (Array.isArray(item?.modes) ? item.modes : [])),
+		);
+		const evidenceObservables = new Set(
+			entry.evidence.flatMap((item) => (Array.isArray(item?.observables) ? item.observables : [])),
+		);
+		for (const mode of Array.isArray(entry.applicableModes) ? entry.applicableModes : []) {
+			if (!evidenceModes.has(mode))
+				errors.push(`${label} is covered but has no executable evidence for mode ${mode}.`);
+		}
+		for (const observable of Array.isArray(entry.observables) ? entry.observables : []) {
+			if (!evidenceObservables.has(observable))
+				errors.push(
+					`${label} is covered but has no executable evidence for observable ${observable}.`,
+				);
+		}
+	}
+	if ((entry.status === 'planned' || entry.status === 'in_progress') && !isRecord(entry.nextAction))
+		errors.push(`${label} has status ${entry.status} but no nextAction.`);
+	if (entry.status === 'decision_required') {
+		if (!isRecord(entry.nextAction) || entry.nextAction.kind !== 'decision')
+			errors.push(`${label} requires a nextAction with kind "decision".`);
+		if (typeof entry.rationale !== 'string' || entry.rationale.trim() === '')
+			errors.push(`${label} requires rationale for the pending decision.`);
+	}
+	if (entry.status === 'documented') {
+		if (typeof entry.rationale !== 'string' || entry.rationale.trim() === '')
+			errors.push(`${label} is documented but has no rationale.`);
+		if (entry.nextAction !== undefined)
+			errors.push(`${label} is documented but still has a nextAction.`);
+		if (entry.classification !== 'divergence' && entry.classification !== 'non_goal') {
+			if (!Array.isArray(entry.octaneReferences) || entry.octaneReferences.length === 0) {
+				errors.push(`${label} is a documented portable policy but has no references.`);
+			} else if (
+				entry.octaneReferences.some(
+					(reference) => reference?.kind !== 'documentation' && reference?.kind !== 'benchmark',
+				)
+			) {
+				errors.push(
+					`${label} may use documented for a portable policy only when every reference is documentation or a benchmark.`,
+				);
+			}
+		}
+	}
+	if (
+		(entry.classification === 'divergence' || entry.classification === 'non_goal') &&
+		(typeof entry.rationale !== 'string' || entry.rationale.trim() === '')
+	)
+		errors.push(`${label} requires rationale for classification ${entry.classification}.`);
+	if (
+		entry.status === 'blocked' &&
+		(typeof entry.rationale !== 'string' || entry.rationale.trim() === '')
+	)
+		errors.push(`${label} is blocked but has no rationale.`);
+	return entry;
+}
+
+function validateScope(scopeValue, errors) {
+	const scope = expectRecord(scopeValue, 'upstream.scope', errors);
+	if (!scope) return { issueNumbers: [], pullRequestNumbers: [], paths: [], artifacts: [] };
+	checkKeys(
+		scope,
+		['issueNumbers', 'pullRequestNumbers', 'paths', 'artifacts'],
+		'upstream.scope',
+		errors,
+	);
+	requireKeys(
+		scope,
+		['issueNumbers', 'pullRequestNumbers', 'paths', 'artifacts'],
+		'upstream.scope',
+		errors,
+	);
+	const issueNumbers = expectPositiveIntegerArray(
+		scope.issueNumbers,
+		'upstream.scope.issueNumbers',
+		errors,
+	);
+	const pullRequestNumbers = expectPositiveIntegerArray(
+		scope.pullRequestNumbers,
+		'upstream.scope.pullRequestNumbers',
+		errors,
+	);
+	const paths = expectUniqueArray(scope.paths, 'upstream.scope.paths', errors) ?? [];
+	const validPathOrder = [];
+	for (const [index, value] of paths.entries()) {
+		if (expectRepositoryPath(value, `upstream.scope.paths[${index}]`, errors))
+			validPathOrder.push(value);
+	}
+	const sortedPaths = [...validPathOrder].sort((a, b) => a.localeCompare(b));
+	if (validPathOrder.some((value, index) => value !== sortedPaths[index]))
+		errors.push('upstream.scope.paths must be sorted.');
+	const artifacts = expectUniqueArray(scope.artifacts, 'upstream.scope.artifacts', errors) ?? [];
+	const artifactPaths = new Set();
+	const artifactPathOrder = [];
+	for (const [index, value] of artifacts.entries()) {
+		const label = `upstream.scope.artifacts[${index}]`;
+		const artifact = expectRecord(value, label, errors);
+		if (!artifact) continue;
+		checkKeys(artifact, ['path', 'disposition', 'entryIds', 'note'], label, errors);
+		requireKeys(artifact, ['path', 'disposition', 'entryIds'], label, errors);
+		if (expectRepositoryPath(artifact.path, `${label}.path`, errors)) {
+			if (artifactPaths.has(artifact.path))
+				errors.push(`upstream.scope.artifacts repeats ${artifact.path}.`);
+			artifactPaths.add(artifact.path);
+			artifactPathOrder.push(artifact.path);
+		}
+		expectEnum(
+			artifact.disposition,
+			['mapped', 'folded', 'non_goal'],
+			`${label}.disposition`,
+			errors,
+		);
+		const entryIds = expectUniqueArray(artifact.entryIds, `${label}.entryIds`, errors);
+		const validEntryIdOrder = [];
+		if (entryIds)
+			for (const [entryIndex, id] of entryIds.entries()) {
+				if (expectString(id, `${label}.entryIds[${entryIndex}]`, errors, ID_PATTERN))
+					validEntryIdOrder.push(id);
+			}
+		if (entryIds) {
+			const sortedEntryIds = [...validEntryIdOrder].sort((a, b) => a.localeCompare(b));
+			if (validEntryIdOrder.some((id, entryIndex) => id !== sortedEntryIds[entryIndex]))
+				errors.push(`${label}.entryIds must be sorted by permanent ID.`);
+		}
+		if (artifact.note !== undefined) expectString(artifact.note, `${label}.note`, errors);
+		if (
+			(artifact.disposition === 'folded' || artifact.disposition === 'non_goal') &&
+			(typeof artifact.note !== 'string' || !artifact.note.trim())
+		)
+			errors.push(`${label} requires a note for disposition ${artifact.disposition}.`);
+	}
+	const sortedArtifactPaths = [...artifactPathOrder].sort((a, b) => a.localeCompare(b));
+	if (artifactPathOrder.some((value, index) => value !== sortedArtifactPaths[index]))
+		errors.push('upstream.scope.artifacts must be sorted by path.');
+	return { issueNumbers, pullRequestNumbers, paths, artifacts };
+}
+
+function validateUpstream(upstreamValue, errors) {
+	const upstream = expectRecord(upstreamValue, 'upstream', errors);
+	if (!upstream)
+		return { scope: { issueNumbers: [], pullRequestNumbers: [], paths: [], artifacts: [] } };
+	checkKeys(upstream, ['repository', 'commit', 'capturedOn', 'scope'], 'upstream', errors);
+	requireKeys(upstream, ['repository', 'commit', 'capturedOn', 'scope'], 'upstream', errors);
+	if (upstream.repository !== REDACT_REPOSITORY)
+		errors.push(`upstream.repository must be ${JSON.stringify(REDACT_REPOSITORY)}.`);
+	expectString(upstream.commit, 'upstream.commit', errors, COMMIT_PATTERN);
+	if (expectString(upstream.capturedOn, 'upstream.capturedOn', errors, /^\d{4}-\d{2}-\d{2}$/)) {
+		const captured = new Date(`${upstream.capturedOn}T00:00:00.000Z`);
+		if (
+			Number.isNaN(captured.getTime()) ||
+			captured.toISOString().slice(0, 10) !== upstream.capturedOn
+		)
+			errors.push('upstream.capturedOn must be a valid YYYY-MM-DD date.');
+	}
+	return { ...upstream, scope: validateScope(upstream.scope, errors) };
+}
+
+function compareArtifacts(scope, observedSources, entries, errors) {
+	const entryById = new Map(entries.map((entry) => [entry.id, entry]));
+	const sourceEntryIdsByPath = new Map();
+	for (const entry of entries) {
+		for (const source of Array.isArray(entry.sources) ? entry.sources : []) {
+			if (source?.kind !== 'test' || typeof source.path !== 'string') continue;
+			const ids = sourceEntryIdsByPath.get(source.path) ?? new Set();
+			ids.add(entry.id);
+			sourceEntryIdsByPath.set(source.path, ids);
+		}
+	}
+	const artifactsByPath = new Map(
+		scope.artifacts
+			.filter((artifact) => isRecord(artifact) && typeof artifact.path === 'string')
+			.map((artifact) => [artifact.path, artifact]),
+	);
+	for (const sourcePath of observedSources.tests) {
+		if (!artifactsByPath.has(sourcePath))
+			errors.push(`Referenced upstream test ${sourcePath} has no audited artifact disposition.`);
+	}
+	for (const [index, artifact] of scope.artifacts.entries()) {
+		if (!isRecord(artifact)) continue;
+		const artifactEntryIds = Array.isArray(artifact.entryIds) ? artifact.entryIds : [];
+		for (const id of artifactEntryIds) {
+			const entry = entryById.get(id);
+			if (!entry) {
+				errors.push(`upstream.scope.artifacts[${index}] references unknown ledger ID ${id}.`);
+			} else if (
+				artifact.disposition === 'mapped' &&
+				!entry.sources?.some((source) => source.kind === 'test' && source.path === artifact.path)
+			) {
+				errors.push(
+					`Mapped upstream artifact ${artifact.path} assigns ${id}, but that entry has no exact test source for the artifact.`,
+				);
+			}
+		}
+		if (artifact.disposition === 'mapped' && !observedSources.tests.has(artifact.path)) {
+			errors.push(
+				`Mapped upstream artifact ${artifact.path} has no exact test source in the ledger; use folded or add a source.`,
+			);
+		}
+		if (artifact.disposition === 'mapped') {
+			const assignedIds = new Set(artifactEntryIds);
+			for (const id of sourceEntryIdsByPath.get(artifact.path) ?? []) {
+				if (!assignedIds.has(id))
+					errors.push(`Mapped upstream artifact ${artifact.path} omits source entry ${id}.`);
+			}
+		}
+		if (artifact.disposition === 'non_goal') {
+			for (const id of artifactEntryIds) {
+				const classification = entryById.get(id)?.classification;
+				if (classification !== 'non_goal' && classification !== 'divergence')
+					errors.push(
+						`Non-goal artifact ${artifact.path} points to ${id}, which is not a divergence or non-goal.`,
+					);
+			}
+		}
+	}
+}
+
+function compareScope(scope, observedSources, errors) {
+	const expectedIssues = new Set(scope.issueNumbers);
+	const expectedPullRequests = new Set(scope.pullRequestNumbers);
+	for (const number of expectedIssues) {
+		if (!observedSources.issues.has(number))
+			errors.push(`Audited issue #${number} has no source reference in the ledger.`);
+	}
+	for (const number of observedSources.issues) {
+		if (!expectedIssues.has(number))
+			errors.push(`Ledger references issue #${number}, which is absent from upstream.scope.`);
+	}
+	for (const number of expectedPullRequests) {
+		if (!observedSources.pullRequests.has(number))
+			errors.push(`Audited pull request #${number} has no source reference in the ledger.`);
+	}
+	for (const number of observedSources.pullRequests) {
+		if (!expectedPullRequests.has(number))
+			errors.push(
+				`Ledger references pull request #${number}, which is absent from upstream.scope.`,
+			);
+	}
+}
+
+export function validateLedger(ledgerValue, repoRoot) {
+	const errors = [];
+	const ledger = expectRecord(ledgerValue, 'ledger', errors);
+	if (!ledger) return errors;
+	checkKeys(
+		ledger,
+		['$schema', 'schemaVersion', 'upstream', 'idRegistry', 'entries'],
+		'ledger',
+		errors,
+	);
+	requireKeys(
+		ledger,
+		['$schema', 'schemaVersion', 'upstream', 'idRegistry', 'entries'],
+		'ledger',
+		errors,
+	);
+	if (ledger.$schema !== LEDGER_SCHEMA)
+		errors.push(`ledger.$schema must be ${JSON.stringify(LEDGER_SCHEMA)}.`);
+	if (ledger.schemaVersion !== 1) errors.push('ledger.schemaVersion must be 1.');
+	const upstream = validateUpstream(ledger.upstream, errors);
+
+	if (!Array.isArray(ledger.entries) || ledger.entries.length === 0) {
+		errors.push('ledger.entries must be a non-empty array.');
+		return errors;
+	}
+	const observedSources = {
+		issues: new Set(),
+		pullRequests: new Set(),
+		tests: new Set(),
+		titles: new Map(),
+	};
+	const ids = new Set();
+	const validIds = [];
+	const entries = [];
+	for (const [index, value] of ledger.entries.entries()) {
+		const entry = validateEntry(value, index, errors, repoRoot, observedSources, upstream.commit);
+		if (!entry) continue;
+		entries.push(entry);
+		if (typeof entry.id === 'string') {
+			if (ids.has(entry.id)) errors.push(`Duplicate ledger ID ${entry.id}.`);
+			ids.add(entry.id);
+			validIds.push(entry.id);
+		}
+	}
+	const sortedIds = [...validIds].sort((a, b) => a.localeCompare(b));
+	if (validIds.some((id, index) => id !== sortedIds[index]))
+		errors.push('ledger.entries must be sorted by permanent ID.');
+	const registry = expectUniqueArray(ledger.idRegistry, 'ledger.idRegistry', errors);
+	if (registry) {
+		const registryIds = [];
+		const seenRegistryIds = new Set();
+		const activeIds = new Set();
+		for (const [index, value] of registry.entries()) {
+			const label = `ledger.idRegistry[${index}]`;
+			const record = expectRecord(value, label, errors);
+			if (!record) continue;
+			checkKeys(record, ['id', 'status', 'introducedOn', 'rationale'], label, errors);
+			requireKeys(record, ['id', 'status', 'introducedOn'], label, errors);
+			expectString(record.id, `${label}.id`, errors, ID_PATTERN);
+			expectEnum(record.status, ['active', 'retired'], `${label}.status`, errors);
+			if (
+				expectString(record.introducedOn, `${label}.introducedOn`, errors, /^\d{4}-\d{2}-\d{2}$/)
+			) {
+				const introduced = new Date(`${record.introducedOn}T00:00:00.000Z`);
+				if (
+					Number.isNaN(introduced.getTime()) ||
+					introduced.toISOString().slice(0, 10) !== record.introducedOn
+				)
+					errors.push(`${label}.introducedOn must be a valid YYYY-MM-DD date.`);
+			}
+			if (record.rationale !== undefined)
+				expectString(record.rationale, `${label}.rationale`, errors);
+			if (
+				record.status === 'retired' &&
+				(typeof record.rationale !== 'string' || !record.rationale.trim())
+			)
+				errors.push(`${label} is retired but has no rationale.`);
+			if (typeof record.id === 'string') {
+				if (seenRegistryIds.has(record.id))
+					errors.push(`ledger.idRegistry repeats permanent ID ${record.id}.`);
+				seenRegistryIds.add(record.id);
+				registryIds.push(record.id);
+				if (record.status === 'active') activeIds.add(record.id);
+				else if (ids.has(record.id)) errors.push(`${label} is retired but still has an entry.`);
+			}
+		}
+		const sortedRegistryIds = [...registryIds].sort((a, b) => a.localeCompare(b));
+		if (registryIds.some((id, index) => id !== sortedRegistryIds[index]))
+			errors.push('ledger.idRegistry must be sorted by permanent ID.');
+		for (const id of ids) {
+			if (!activeIds.has(id))
+				errors.push(`Ledger entry ${id} is absent from the active ID registry.`);
+		}
+		for (const id of activeIds) {
+			if (!ids.has(id)) errors.push(`Active ID registry entry ${id} has no ledger entry.`);
+		}
+	}
+	compareScope(upstream.scope, observedSources, errors);
+	compareArtifacts(upstream.scope, observedSources, entries, errors);
+	return errors;
+}
+
+export function validateIdRegistryCompatibility(previousLedger, currentLedger) {
+	const errors = [];
+	const previousRecords = Array.isArray(previousLedger?.idRegistry)
+		? previousLedger.idRegistry
+		: [];
+	const currentRecords = Array.isArray(currentLedger?.idRegistry) ? currentLedger.idRegistry : [];
+	const previousRegistry = new Map(
+		previousRecords
+			.filter((record) => isRecord(record) && typeof record.id === 'string')
+			.map((record) => [record.id, record]),
+	);
+	const currentRegistry = new Map(
+		currentRecords
+			.filter((record) => isRecord(record) && typeof record.id === 'string')
+			.map((record) => [record.id, record]),
+	);
+	for (const [id, previous] of previousRegistry) {
+		const current = currentRegistry.get(id);
+		if (!current) {
+			errors.push(`Previously registered permanent ID ${id} was removed.`);
+			continue;
+		}
+		if (current.introducedOn !== previous.introducedOn) {
+			errors.push(`Permanent ID ${id} changed its introducedOn date.`);
+		}
+		if (previous.status === 'retired' && current.status !== 'retired') {
+			errors.push(`Retired permanent ID ${id} was reactivated.`);
+		}
+	}
+	return errors;
+}
+
+function normalizedProse(value) {
+	return value.trim().replace(/\s+/g, ' ');
+}
+
+function prose(value) {
+	return normalizedProse(value)
+		.replaceAll('&', '&amp;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;');
+}
+
+function label(value) {
+	return prose(value).replaceAll('[', '\\[').replaceAll(']', '\\]');
+}
+
+function cell(value) {
+	return prose(value).replaceAll('|', '\\|');
+}
+
+function displayEnum(value) {
+	return value.replaceAll('_', ' ').replaceAll('-', ' ');
+}
+
+function inlineCode(value) {
+	const contents = normalizedProse(value);
+	const longestRun = Math.max(0, ...(contents.match(/`+/g) ?? []).map((run) => run.length));
+	const fence = '`'.repeat(longestRun + 1);
+	const padding = longestRun > 0 ? ' ' : '';
+	return `${fence}${padding}${contents}${padding}${fence}`;
+}
+
+function sourceMarkdown(source) {
+	let sourceLabel;
+	if (source.kind === 'issue') sourceLabel = `issue #${source.number}`;
+	else if (source.kind === 'pull_request') sourceLabel = `pull request #${source.number}`;
+	else if (source.kind === 'commit') sourceLabel = `commit ${source.commit.slice(0, 12)}`;
+	else sourceLabel = `test: ${source.testName}`;
+	const suffix = source.title ? ` — ${prose(source.title)}` : '';
+	const pathSuffix = source.kind === 'test' ? ` (\`${source.path}\`)` : '';
+	return `[${label(sourceLabel)}](${source.url})${pathSuffix}${suffix}`;
+}
+
+function localFileMarkdown(file, text = file) {
+	return `[${label(text)}](../${encodeURI(file)})`;
+}
+
+function referenceMarkdown(reference) {
+	let suffix = '';
+	if (reference.symbol) suffix += ` — ${inlineCode(reference.symbol)}`;
+	if (reference.testName) suffix += ` — “${prose(reference.testName)}”`;
+	if (reference.note) suffix += ` — ${prose(reference.note)}`;
+	return `${localFileMarkdown(reference.file)}${suffix}`;
+}
+
+function evidenceMarkdown(evidence) {
+	const executable =
+		evidence.kind === 'command'
+			? `command: \`pnpm ${evidence.script}\``
+			: localFileMarkdown(evidence.file, evidence.testName);
+	return `${executable} — modes: ${evidence.modes
+		.map((mode) => `\`${mode}\``)
+		.join(', ')}; observables: ${evidence.observables
+		.map((observable) => `\`${observable}\``)
+		.join(', ')}`;
+}
+
+function countBy(entries, key, values) {
+	return values.map((value) => ({
+		value,
+		count: entries.filter((entry) => entry[key] === value).length,
+	}));
+}
+
+function renderSummary(entries) {
+	let result = `## Summary\n\n`;
+	result += `| Status | Entries |\n| --- | ---: |\n`;
+	for (const { value, count } of countBy(entries, 'status', STATUSES))
+		result += `| ${displayEnum(value)} | ${count} |\n`;
+	result += `\n| Classification | Entries |\n| --- | ---: |\n`;
+	for (const { value, count } of countBy(entries, 'classification', CLASSIFICATIONS))
+		result += `| ${displayEnum(value)} | ${count} |\n`;
+	return result;
+}
+
+function renderPriorityQueue(entries) {
+	const riskOrder = new Map(RISKS.map((risk, index) => [risk, index]));
+	const open = entries
+		.filter((entry) => OPEN_STATUSES.has(entry.status))
+		.sort((a, b) => riskOrder.get(a.risk) - riskOrder.get(b.risk) || a.id.localeCompare(b.id));
+	let result = `## Open priority queue\n\n`;
+	if (open.length === 0) return `${result}_No open entries._\n`;
+	result += `| ID | Risk | Area | Contract | Status | Owner |\n`;
+	result += `| --- | --- | --- | --- | --- | --- |\n`;
+	for (const entry of open) {
+		result += `| [\`${entry.id}\`](#${entry.id.toLowerCase()}) | ${entry.risk} | ${cell(
+			entry.area,
+		)} | ${cell(entry.title)} | ${displayEnum(entry.status)} | ${cell(entry.owner)} |\n`;
+	}
+	return result;
+}
+
+function renderEntry(entry) {
+	let result = `<a id="${entry.id.toLowerCase()}"></a>\n\n#### ${entry.id} — ${entry.title}\n\n`;
+	result += `**Disposition:** ${entry.risk} risk; ${displayEnum(entry.classification)}; ${displayEnum(
+		entry.status,
+	)}; owner: ${entry.owner}.\n\n`;
+	result += `**Upstream evidence**\n\n`;
+	for (const source of entry.sources) result += `- ${sourceMarkdown(source)}\n`;
+	result += `\n**Consumer-visible symptom.** ${prose(entry.symptom)}\n\n`;
+	result += `**Octane contract.** ${prose(entry.octaneContract)}\n\n`;
+	result += `**Applicable modes:** ${entry.applicableModes
+		.map((mode) => `\`${mode}\``)
+		.join(', ')}. **Observables:** ${entry.observables
+		.map((observable) => `\`${observable}\``)
+		.join(', ')}.\n`;
+	if (entry.octaneReferences?.length) {
+		result += `\n**Octane references**\n\n`;
+		for (const reference of entry.octaneReferences) result += `- ${referenceMarkdown(reference)}\n`;
+	}
+	if (entry.evidence?.length) {
+		result += `\n**Executable evidence**\n\n`;
+		for (const evidence of entry.evidence) result += `- ${evidenceMarkdown(evidence)}\n`;
+	}
+	if (entry.nextAction) {
+		result += `\n**Next action (${displayEnum(entry.nextAction.kind)}).** ${prose(
+			entry.nextAction.acceptance,
+		)}\n\n`;
+		result += `Targets: ${entry.nextAction.targets.map((target) => `\`${target}\``).join(', ')}.\n`;
+	}
+	if (entry.rationale) result += `\n**Rationale.** ${prose(entry.rationale)}\n`;
+	return result;
+}
+
+export function renderReport(ledger) {
+	const entries = [...ledger.entries].sort((a, b) => a.id.localeCompare(b.id));
+	const { upstream } = ledger;
+	let report = `# Redact-derived adversarial contract audit (generated)\n\n`;
+	report += `<!-- GENERATED FILE — do not edit. Regenerate with \`pnpm redact-audit:generate\`. -->\n\n`;
+	report += `This is a source-backed extraction ledger for consumer-observable failure modes found in [TanStack Redact](${upstream.repository}). Redact is an adversity source, not an implementation target or a blanket compatibility promise. Classifications describe whether each contract transfers to Octane; statuses describe the current Octane evidence or follow-up.\n\n`;
+	report += `The authored source is [\`packages/octane/audit/redact-adversarial-ledger.json\`](../packages/octane/audit/redact-adversarial-ledger.json). Permanent IDs must not be renamed or reused.\n\n`;
+	report += `## Upstream snapshot\n\n`;
+	report += `- Repository: [\`${upstream.repository}\`](${upstream.repository})\n`;
+	report += `- Commit: [\`${upstream.commit}\`](${upstream.repository}/commit/${upstream.commit})\n`;
+	report += `- Captured: ${upstream.capturedOn}\n`;
+	report += `- Issues reviewed: ${upstream.scope.issueNumbers.map((number) => `#${number}`).join(', ')}\n`;
+	report += `- Pull requests reviewed: ${upstream.scope.pullRequestNumbers
+		.map((number) => `#${number}`)
+		.join(', ')}\n`;
+	report += `- Repository paths reviewed: ${upstream.scope.paths
+		.map((item) => `\`${item}\``)
+		.join(', ')}\n\n`;
+	report += `### Audited artifact dispositions\n\n`;
+	report += `This is the explicit artifact sample reviewed at the pinned snapshot; broad source paths above do not imply that every file was mined. \`mapped\` artifacts have an exact upstream test source, while \`folded\` artifacts were inspected and assigned to an existing contract without duplicating every case.\n\n`;
+	report += `| Artifact | Disposition | Ledger IDs | Note |\n`;
+	report += `| --- | --- | --- | --- |\n`;
+	for (const artifact of upstream.scope.artifacts) {
+		report += `| \`${cell(artifact.path)}\` | ${displayEnum(artifact.disposition)} | ${artifact.entryIds
+			.map((id) => `[\`${id}\`](#${id.toLowerCase()})`)
+			.join(', ')} | ${cell(artifact.note ?? 'Exact source mapping.')} |\n`;
+	}
+	report += `\n`;
+	report += `## Entry contract\n\n`;
+	report += `- Keep one consumer-observable owning contract per permanent ID; split an upstream issue or pull request when it exposes independent contracts.\n`;
+	report += `- The append-only \`idRegistry\` retains retired IDs as tombstones. Never rename, remove, or reuse a registered ID; retire it with rationale and mint a new ID when the owning contract changes.\n`;
+	report += `- A \`covered\` entry cites an exact executable Octane test. A \`planned\` entry carries a bounded next action. A \`decision required\` entry records the decision owner and acceptance boundary.\n`;
+	report += `- A \`documented\` entry is terminal only for an explained divergence/non-goal or a portable process policy backed exclusively by documentation/benchmark references.\n`;
+	report += `- Keep resolved, divergent, and non-goal entries in the ledger so future audits do not rediscover them or silently import Redact-specific behavior.\n`;
+	report += `- Choose tests by observable. Final markup alone cannot prove identity, focus, selection, scroll, live properties, lifecycle ordering, or global error behavior.\n`;
+	report += `- Update the authored JSON, then run \`pnpm redact-audit:generate\`; never hand-edit this report.\n\n`;
+	report += `${renderSummary(entries)}\n`;
+	report += `${renderPriorityQueue(entries)}\n`;
+	report += `## Contract ledger\n`;
+	const areas = [...new Set(entries.map((entry) => entry.area))].sort((a, b) => a.localeCompare(b));
+	for (const area of areas) {
+		report += `\n### ${area}\n\n`;
+		for (const entry of entries.filter((item) => item.area === area))
+			report += `${renderEntry(entry)}\n`;
+	}
+	return `${report.trimEnd()}\n`;
+}

--- a/scripts/redact-audit/ledger-lib.test.mjs
+++ b/scripts/redact-audit/ledger-lib.test.mjs
@@ -1,0 +1,437 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+import {
+	CLASSIFICATIONS,
+	MODES,
+	OBSERVABLES,
+	RISKS,
+	STATUSES,
+	renderReport,
+	validateIdRegistryCompatibility,
+	validateLedger,
+} from './ledger-lib.mjs';
+
+const COMMIT = 'a'.repeat(40);
+
+function createRepository(t) {
+	const root = mkdtempSync(path.join(tmpdir(), 'octane-redact-ledger-'));
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+	const testFile = 'packages/octane/tests/hydration-contract.test.ts';
+	mkdirSync(path.join(root, path.dirname(testFile)), { recursive: true });
+	writeFileSync(
+		path.join(root, testFile),
+		`it('recovers a deferred mismatch without escaping', () => {});\n`,
+	);
+	writeFileSync(
+		path.join(root, 'vitest.config.js'),
+		`export default { test: { include: ['packages/octane/tests/**/*.test.ts'] } };\n`,
+	);
+	return { root, testFile };
+}
+
+function fixture(testFile) {
+	return {
+		$schema: './redact-adversarial-ledger.schema.json',
+		schemaVersion: 1,
+		upstream: {
+			repository: 'https://github.com/TanStack/redact',
+			commit: COMMIT,
+			capturedOn: '2026-07-22',
+			scope: {
+				issueNumbers: [17],
+				pullRequestNumbers: [16],
+				paths: ['packages/redact/src', 'tests'],
+				artifacts: [
+					{
+						path: 'tests/document-hydration.test.tsx',
+						disposition: 'mapped',
+						entryIds: ['RDX-HYDRATION-001'],
+					},
+				],
+			},
+		},
+		idRegistry: [
+			{ id: 'RDX-HYDRATION-001', status: 'active', introducedOn: '2026-07-22' },
+			{ id: 'RDX-SUSPENSE-001', status: 'active', introducedOn: '2026-07-22' },
+		],
+		entries: [
+			{
+				id: 'RDX-HYDRATION-001',
+				area: 'hydration',
+				title: 'Deferred mismatch recovery',
+				sources: [
+					{
+						kind: 'issue',
+						number: 17,
+						url: 'https://github.com/TanStack/redact/issues/17',
+						title: 'Hydration recovery failure',
+					},
+					{
+						kind: 'test',
+						commit: COMMIT,
+						path: 'tests/document-hydration.test.tsx',
+						testName: 'recovers after lazy hydration resumes',
+						url: `https://github.com/TanStack/redact/blob/${COMMIT}/tests/document-hydration.test.tsx#L1`,
+					},
+				],
+				symptom: 'A resumed mismatch escapes through the scheduler.',
+				octaneContract: 'Recovery stays inside the nearest hydration boundary.',
+				classification: 'adaptable',
+				status: 'covered',
+				risk: 'critical',
+				owner: 'runtime + hydration',
+				applicableModes: ['hydrate-mismatch', 'deferred-hydration', 'production-compile'],
+				observables: ['node-identity', 'events', 'errors'],
+				octaneReferences: [
+					{
+						kind: 'test',
+						file: testFile,
+						testName: 'recovers a deferred mismatch without escaping',
+					},
+				],
+				evidence: [
+					{
+						file: testFile,
+						testName: 'recovers a deferred mismatch without escaping',
+						modes: ['hydrate-mismatch', 'deferred-hydration', 'production-compile'],
+						observables: ['node-identity', 'events', 'errors'],
+					},
+				],
+			},
+			{
+				id: 'RDX-SUSPENSE-001',
+				area: 'suspense',
+				title: 'Preserve committed DOM while resuspended',
+				sources: [
+					{
+						kind: 'pull_request',
+						number: 16,
+						url: 'https://github.com/TanStack/redact/pull/16',
+						title: 'Preserve committed DOM',
+					},
+				],
+				symptom: 'A route suspension loses scroll and focus.',
+				octaneContract: 'Committed UI state survives a temporary suspension.',
+				classification: 'portable',
+				status: 'planned',
+				risk: 'high',
+				owner: 'runtime',
+				applicableModes: ['client', 'real-browser'],
+				observables: ['node-identity', 'focus', 'scroll'],
+				nextAction: {
+					kind: 'test',
+					targets: ['website/tests/suspense-preservation.e2e.test.ts'],
+					acceptance: 'The same node retains focus and scroll through suspension.',
+				},
+			},
+		],
+	};
+}
+
+test('accepts a complete ledger and renders a deterministic report', (t) => {
+	const { root, testFile } = createRepository(t);
+	const ledger = fixture(testFile);
+	assert.deepEqual(validateLedger(ledger, root), []);
+	const report = renderReport(ledger);
+	assert.match(report, /GENERATED FILE — do not edit/);
+	assert.match(report, /## Entry contract/);
+	assert.match(report, /RDX-HYDRATION-001 — Deferred mismatch recovery/);
+	assert.match(report, /\[`RDX-SUSPENSE-001`\]\(#rdx-suspense-001\)/);
+	assert.doesNotMatch(report, /No open entries\./);
+});
+
+test('requires exact executable evidence for covered entries', (t) => {
+	const { root, testFile } = createRepository(t);
+	const ledger = fixture(testFile);
+	ledger.entries[0].evidence[0].testName = 'a test title that does not exist';
+	const errors = validateLedger(ledger, root);
+	assert.ok(
+		errors.some((error) => error.includes('not an executable registered test')),
+		`expected a missing-title error, received:\n${errors.join('\n')}`,
+	);
+	writeFileSync(
+		path.join(root, testFile),
+		`// it('a test title that does not exist', () => {});\nconst label = 'a test title that does not exist';\n`,
+	);
+	assert.ok(
+		validateLedger(ledger, root).some((error) =>
+			error.includes('not an executable registered test'),
+		),
+	);
+	delete ledger.entries[0].evidence;
+	assert.ok(validateLedger(ledger, root).some((error) => error.includes('no executable evidence')));
+});
+
+test('rejects skipped-suite and out-of-lane test evidence', (t) => {
+	const { root, testFile } = createRepository(t);
+	const ledger = fixture(testFile);
+	writeFileSync(
+		path.join(root, testFile),
+		`describe.skip('disabled suite', () => { it('recovers a deferred mismatch without escaping', () => {}); });\n`,
+	);
+	assert.ok(
+		validateLedger(ledger, root).some((error) =>
+			error.includes('not an executable registered test'),
+		),
+	);
+	writeFileSync(
+		path.join(root, testFile),
+		`it('recovers a deferred mismatch without escaping', () => {});\n`,
+	);
+	const outsideFile = 'packages/octane/specs/outside.test.ts';
+	mkdirSync(path.join(root, path.dirname(outsideFile)), { recursive: true });
+	writeFileSync(
+		path.join(root, outsideFile),
+		`it('recovers a deferred mismatch without escaping', () => {});\n`,
+	);
+	ledger.entries[0].evidence[0].file = outsideFile;
+	assert.ok(
+		validateLedger(ledger, root).some((error) =>
+			error.includes('not an executable registered test'),
+		),
+	);
+});
+
+test('covered entries prove every declared mode and observable', (t) => {
+	const { root, testFile } = createRepository(t);
+	const ledger = fixture(testFile);
+	ledger.entries[0].applicableModes.push('real-browser');
+	ledger.entries[0].observables.push('focus');
+	const errors = validateLedger(ledger, root);
+	assert.ok(errors.some((error) => error.includes('evidence for mode real-browser')));
+	assert.ok(errors.some((error) => error.includes('evidence for observable focus')));
+});
+
+test('evidence cannot claim modes or observables outside its owning contract', (t) => {
+	const { root, testFile } = createRepository(t);
+	const ledger = fixture(testFile);
+	ledger.entries[0].evidence[0].modes.push('real-browser');
+	ledger.entries[0].evidence[0].observables.push('focus');
+	const errors = validateLedger(ledger, root);
+	assert.ok(errors.some((error) => error.includes('mode real-browser outside the entry contract')));
+	assert.ok(errors.some((error) => error.includes('observable focus outside the entry contract')));
+});
+
+test('accepts registered package scripts as command evidence', (t) => {
+	const { root, testFile } = createRepository(t);
+	writeFileSync(
+		path.join(root, 'package.json'),
+		JSON.stringify({ scripts: { 'pack:check': 'node scripts/pack-check.mjs' } }),
+	);
+	mkdirSync(path.join(root, '.github/workflows'), { recursive: true });
+	writeFileSync(path.join(root, '.github/workflows/ci.yml'), 'run: pnpm pack:check\n');
+	const ledger = fixture(testFile);
+	ledger.entries[0].applicableModes.push('packaged-consumer');
+	ledger.entries[0].evidence.push({
+		kind: 'command',
+		script: 'pack:check',
+		modes: ['packaged-consumer'],
+		observables: ['node-identity'],
+	});
+	assert.ok(
+		validateLedger(ledger, root).some((error) => error.includes('missing Node entry point')),
+	);
+	mkdirSync(path.join(root, 'scripts'), { recursive: true });
+	writeFileSync(path.join(root, 'scripts/pack-check.mjs'), 'export {};\n');
+	assert.deepEqual(validateLedger(ledger, root), []);
+	ledger.entries[0].evidence[1].script = 'missing';
+	assert.ok(validateLedger(ledger, root).some((error) => error.includes('not registered')));
+});
+
+test('documented status cannot hide an unsupported portable runtime contract', (t) => {
+	const { root, testFile } = createRepository(t);
+	const ledger = fixture(testFile);
+	const entry = ledger.entries[1];
+	entry.status = 'documented';
+	entry.rationale = 'Already described.';
+	delete entry.nextAction;
+	entry.octaneReferences = [
+		{ kind: 'test', file: testFile, testName: 'recovers a deferred mismatch without escaping' },
+	];
+	assert.ok(
+		validateLedger(ledger, root).some((error) =>
+			error.includes('only when every reference is documentation or a benchmark'),
+		),
+	);
+});
+
+test('permanent IDs remain registered and retired IDs remain tombstones', (t) => {
+	const { root, testFile } = createRepository(t);
+	const ledger = fixture(testFile);
+	ledger.entries[0].id = 'RDX-HYDRATION-002';
+	const errors = validateLedger(ledger, root);
+	assert.ok(errors.some((error) => error.includes('absent from the active ID registry')));
+	assert.ok(errors.some((error) => error.includes('has no ledger entry')));
+});
+
+test('permanent IDs are append-only across the compatibility base', (t) => {
+	const { testFile } = createRepository(t);
+	const previous = fixture(testFile);
+	const renamed = structuredClone(previous);
+	renamed.entries[0].id = 'RDX-HYDRATION-002';
+	renamed.idRegistry[0].id = 'RDX-HYDRATION-002';
+	renamed.upstream.scope.artifacts[0].entryIds = ['RDX-HYDRATION-002'];
+	assert.ok(
+		validateIdRegistryCompatibility(previous, renamed).some((error) =>
+			error.includes('RDX-HYDRATION-001 was removed'),
+		),
+	);
+	const removed = structuredClone(previous);
+	removed.idRegistry.pop();
+	assert.ok(
+		validateIdRegistryCompatibility(previous, removed).some((error) =>
+			error.includes('RDX-SUSPENSE-001 was removed'),
+		),
+	);
+	const retired = structuredClone(previous);
+	retired.idRegistry[1].status = 'retired';
+	retired.idRegistry[1].rationale = 'The owning contract was superseded.';
+	assert.deepEqual(validateIdRegistryCompatibility(previous, retired), []);
+	assert.ok(
+		validateIdRegistryCompatibility(retired, previous).some((error) =>
+			error.includes('RDX-SUSPENSE-001 was reactivated'),
+		),
+	);
+});
+
+test('accounts for each sourced upstream test in the artifact sample', (t) => {
+	const { root, testFile } = createRepository(t);
+	const ledger = fixture(testFile);
+	ledger.upstream.scope.artifacts[0].path = 'tests/another.test.tsx';
+	const errors = validateLedger(ledger, root);
+	assert.ok(errors.some((error) => error.includes('has no audited artifact disposition')));
+	assert.ok(errors.some((error) => error.includes('has no exact test source')));
+	ledger.upstream.scope.artifacts[0].entryIds = ['RDX-MISSING-001'];
+	assert.ok(validateLedger(ledger, root).some((error) => error.includes('unknown ledger ID')));
+	ledger.upstream.scope.artifacts[0].path = 'tests/document-hydration.test.tsx';
+	ledger.upstream.scope.artifacts[0].entryIds = ['RDX-SUSPENSE-001'];
+	const mismatchedErrors = validateLedger(ledger, root);
+	assert.ok(
+		mismatchedErrors.some((error) =>
+			error.includes('RDX-SUSPENSE-001, but that entry has no exact test source'),
+		),
+	);
+	assert.ok(
+		mismatchedErrors.some((error) => error.includes('omits source entry RDX-HYDRATION-001')),
+	);
+	ledger.upstream.scope.artifacts[0] = null;
+	assert.doesNotThrow(() => validateLedger(ledger, root));
+	assert.ok(
+		validateLedger(ledger, root).some((error) =>
+			error.includes('upstream.scope.artifacts[0] must be an object'),
+		),
+	);
+	ledger.upstream.scope.paths[0] = null;
+	assert.doesNotThrow(() => validateLedger(ledger, root));
+	assert.ok(
+		validateLedger(ledger, root).some((error) =>
+			error.includes('upstream.scope.paths[0] must be a normalized repository-relative path'),
+		),
+	);
+	const malformedEntryIds = fixture(testFile);
+	malformedEntryIds.upstream.scope.artifacts[0].entryIds = [null];
+	assert.doesNotThrow(() => validateLedger(malformedEntryIds, root));
+	assert.ok(
+		validateLedger(malformedEntryIds, root).some((error) =>
+			error.includes('upstream.scope.artifacts[0].entryIds[0] must be a non-empty string'),
+		),
+	);
+	const malformedNote = fixture(testFile);
+	malformedNote.upstream.scope.artifacts[0].disposition = 'folded';
+	malformedNote.upstream.scope.artifacts[0].note = 1;
+	assert.doesNotThrow(() => validateLedger(malformedNote, root));
+	assert.ok(
+		validateLedger(malformedNote, root).some((error) =>
+			error.includes('upstream.scope.artifacts[0].note must be a non-empty string'),
+		),
+	);
+	const malformedRationale = fixture(testFile);
+	malformedRationale.idRegistry[1].status = 'retired';
+	malformedRationale.idRegistry[1].rationale = {};
+	assert.doesNotThrow(() => validateLedger(malformedRationale, root));
+	assert.ok(
+		validateLedger(malformedRationale, root).some((error) =>
+			error.includes('ledger.idRegistry[1].rationale must be a non-empty string'),
+		),
+	);
+});
+
+test('escapes test titles and symbols in generated Markdown', (t) => {
+	const { testFile } = createRepository(t);
+	const ledger = fixture(testFile);
+	ledger.entries[0].octaneReferences[0].testName = 'adopts one <title>/<meta> pair';
+	ledger.entries[0].octaneReferences[0].symbol = 'render`Document<title>';
+	const report = renderReport(ledger);
+	assert.match(report, /adopts one &lt;title&gt;\/&lt;meta&gt; pair/);
+	assert.ok(report.includes('— `` render`Document<title> ``'));
+	assert.doesNotMatch(report, /adopts one <title>\/<meta> pair/);
+});
+
+test('enforces decision actions, permanent ordering, canonical sources, and scope coverage', (t) => {
+	const { root, testFile } = createRepository(t);
+	const ledger = fixture(testFile);
+	const decision = ledger.entries[1];
+	decision.status = 'decision_required';
+	decision.rationale = 'Octane must define whether the supplied element owns foreign children.';
+	assert.ok(
+		validateLedger(ledger, root).some((error) =>
+			error.includes('requires a nextAction with kind "decision"'),
+		),
+	);
+	decision.nextAction.kind = 'decision';
+	decision.sources[0].url = 'https://github.com/TanStack/redact/pull/15';
+	ledger.entries.reverse();
+	ledger.upstream.scope.issueNumbers.push(18);
+	const errors = validateLedger(ledger, root);
+	assert.ok(errors.some((error) => error.includes('pinned canonical URL')));
+	assert.ok(errors.some((error) => error.includes('sorted by permanent ID')));
+	assert.ok(errors.some((error) => error.includes('issue #18 has no source reference')));
+});
+
+test('rejects an impossible capture date without throwing', (t) => {
+	const { root, testFile } = createRepository(t);
+	const ledger = fixture(testFile);
+	ledger.upstream.capturedOn = '2026-02-31';
+	assert.ok(validateLedger(ledger, root).some((error) => error.includes('valid YYYY-MM-DD')));
+});
+
+test('reports malformed evidence matrices without throwing', (t) => {
+	const { root, testFile } = createRepository(t);
+	const malformedEntry = fixture(testFile);
+	malformedEntry.entries[0].applicableModes = {};
+	malformedEntry.entries[0].observables = 1;
+	assert.doesNotThrow(() => validateLedger(malformedEntry, root));
+	const entryErrors = validateLedger(malformedEntry, root);
+	assert.ok(
+		entryErrors.some((error) => error.includes('entries[0].applicableModes must be an array')),
+	);
+	assert.ok(entryErrors.some((error) => error.includes('entries[0].observables must be an array')));
+
+	const malformedEvidence = fixture(testFile);
+	malformedEvidence.entries[0].evidence[0].modes = {};
+	malformedEvidence.entries[0].evidence[0].observables = 1;
+	assert.doesNotThrow(() => validateLedger(malformedEvidence, root));
+	const evidenceErrors = validateLedger(malformedEvidence, root);
+	assert.ok(evidenceErrors.some((error) => error.includes('evidence[0].modes must be an array')));
+	assert.ok(
+		evidenceErrors.some((error) => error.includes('evidence[0].observables must be an array')),
+	);
+});
+
+test('keeps validator enums synchronized with the JSON schema', () => {
+	const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+	const schemaPath = path.resolve(
+		scriptDirectory,
+		'../../packages/octane/audit/redact-adversarial-ledger.schema.json',
+	);
+	const schema = JSON.parse(readFileSync(schemaPath, 'utf8'));
+	assert.deepEqual(schema.$defs.classification.enum, CLASSIFICATIONS);
+	assert.deepEqual(schema.$defs.status.enum, STATUSES);
+	assert.deepEqual(schema.$defs.risk.enum, RISKS);
+	assert.deepEqual(schema.$defs.mode.enum, MODES);
+	assert.deepEqual(schema.$defs.observable.enum, OBSERVABLES);
+});


### PR DESCRIPTION
## Summary

- add a source-backed ledger of 28 consumer-observable contracts extracted from TanStack Redact issues, pull requests, and regression tests
- generate a readable audit report with explicit covered, planned, divergent, and non-goal dispositions
- add schema validation, executable-evidence checks, permanent-ID compatibility, and network-free CI enforcement
- clarify Octane's streaming doctype ownership in the SSR documentation

## Why

Redact is pursuing adjacent runtime, hydration, scheduling, and integration goals. Capturing its production failures as durable Octane contracts gives us a prioritized adversity corpus without implying blanket implementation parity.

The first queue highlights async hydration mismatch containment, head-marker claiming, browser-state preservation through Suspense, event replay shape, and portal descendant-owned updates.

## Impact

This is documentation and internal audit tooling only. It does not change Octane runtime behavior, dependencies, or the lockfile.

## Validation

- `pnpm redact-audit:check` (15/15 tests)
- `pnpm format:check`
- `git diff --check`
- permanent-ID compatibility check against the Git base

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and internal audit tooling only; no runtime, dependency, or lockfile changes. Risk is mainly keeping the large generated ledger/report in sync via CI.
> 
> **Overview**
> Introduces a **Redact-derived adversarial contract audit** pipeline: an authored ledger of consumer-observable contracts mined from TanStack Redact (pinned upstream commit), a JSON schema, generators/validators, and a generated `docs/redact-adversarial-audit.md` report. Entries are classified as portable, adaptable, divergence, or non-goal, with statuses such as covered, planned, and decision required, and they link upstream evidence to Octane tests or explicit follow-ups.
> 
> Adds **`pnpm redact-audit:generate`** / **`redact-audit:check`** (ledger validation, local evidence checks, permanent-ID compatibility against `OCTANE_REDACT_AUDIT_BASE`, report freshness, and unit tests) and wires **`redact-audit:check`** into CI lint alongside the existing React parity gate. **`docs/project-analysis-concerns.md`** points reviewers at the audit; **`docs/ssr.md`** wording is tightened so streaming doctype ownership is explicit vs other document orchestration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d71354b8d4b3aa4593df742cb4110a115a5c81bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->