### PR TITLE
Cover Redact scheduler adversity contracts

### DIFF
--- a/docs/redact-adversarial-audit.md
+++ b/docs/redact-adversarial-audit.md
@@ -58,9 +58,9 @@ This is the explicit artifact sample reviewed at the pinned snapshot; broad sour
 
 | Status | Entries |
 | --- | ---: |
-| planned | 11 |
+| planned | 8 |
 | in progress | 0 |
-| covered | 12 |
+| covered | 15 |
 | documented | 5 |
 | decision required | 1 |
 | blocked | 0 |
@@ -80,11 +80,8 @@ This is the explicit artifact sample reviewed at the pinned snapshot; broad sour
 | [`RDX-HYD-003`](#rdx-hyd-003) | high | raw-text-hydration | Raw script and style hydration must use their parsing contexts | planned | Octane DOM hydration and SSR serialization |
 | [`RDX-HYD-006`](#rdx-hyd-006) | high | hydration-recovery | Mismatch recovery is bounded to the failed ownership scope | planned | Octane hydration cursor and ownership ranges |
 | [`RDX-HYD-007`](#rdx-hyd-007) | high | head-hydration | Head ownership keys are unique across compiled modules and tags | planned | Octane compiler and runtime head hydration |
-| [`RDX-LIF-001`](#rdx-lif-001) | high | effects | Coalesced dependency changes leave one live passive side effect | planned | Octane scheduler and effect hooks |
-| [`RDX-MEM-001`](#rdx-mem-001) | high | memo-scheduling | Memo prop bailouts do not swallow owned updates or revive removed work | planned | Octane memo and scheduler |
 | [`RDX-PORT-002`](#rdx-port-002) | high | portal-updates | A stateful portal descendant resolves its foreign host for owned updates | planned | Octane portal host resolution |
 | [`RDX-REC-002`](#rdx-rec-002) | high | reconciliation-placement | Topology transitions use the correct absolute anchor without stable reattachment | planned | Octane reconciler and portal placement |
-| [`RDX-STORE-001`](#rdx-store-001) | high | external-store | External-store subscription races cannot create zombie DOM | planned | Octane useSyncExternalStore and scheduler |
 | [`RDX-CFG-001`](#rdx-cfg-001) | medium | build-configuration | Public options must change the emitted build at their observation boundary | planned | Octane compiler and Vite/Rspack/Rsbuild integrations |
 | [`RDX-HYD-005`](#rdx-hyd-005) | medium | hydration-errors | Hydration recovery reporting has an explicit public contract | decision required | Octane public root API |
 | [`RDX-PKG-001`](#rdx-pkg-001) | medium | public-exports | Advertised named exports are locked at the consumer boundary | planned | Octane package surface |
@@ -189,7 +186,7 @@ Targets: `packages/octane/tests`, `packages/vite-plugin-octane/tests`, `packages
 
 #### RDX-LIF-001 — Coalesced dependency changes leave one live passive side effect
 
-**Disposition:** high risk; portable; planned; owner: Octane scheduler and effect hooks.
+**Disposition:** high risk; portable; covered; owner: Octane scheduler and effect hooks.
 
 **Upstream evidence**
 
@@ -203,11 +200,13 @@ Targets: `packages/octane/tests`, `packages/vite-plugin-octane/tests`, `packages
 
 **Octane references**
 
-- [packages/octane/tests/effect-timing.test.ts](../packages/octane/tests/effect-timing.test.ts) — “phase order on re-render: cleanups fire before bodies of same phase” — Strong ordering coverage, but not the exact two-renders-before-passive-drain race.
+- [packages/octane/tests/effect-timing.test.ts](../packages/octane/tests/effect-timing.test.ts) — “coalesced dependency changes leave one live passive side effect” — Commits b, requests c before the ordinary passive task drains, and proves Octane settles b's queued passive work before the c render while preserving one live artifact and exactly-once cleanup.
 
-**Next action (test).** Drive a→b→c before passive drain, assert one live imperative artifact, exact cleanup order through c, and one final cleanup on unmount in development and production compile modes.
+**Executable evidence**
 
-Targets: `packages/octane/tests/effect-timing.test.ts`.
+- [coalesced dependency changes leave one live passive side effect](../packages/octane/tests/effect-timing.test.ts) — modes: `client`, `production-compile`; observables: `markup`, `effects`
+
+**Rationale.** Same-batch root renders coalesce before an intermediate effect can enqueue. When an intermediate revision does commit, Octane drains its pending passive work before the next render begins. The portable single-live-artifact and exactly-once cleanup contract therefore holds without exposing Redact's two-entry queue shape.
 
 
 ### event-replay
@@ -273,7 +272,7 @@ Targets: `packages/octane/tests/hydration/deferred-hydration-contract.test.ts`, 
 
 #### RDX-STORE-001 — External-store subscription races cannot create zombie DOM
 
-**Disposition:** high risk; portable; planned; owner: Octane useSyncExternalStore and scheduler.
+**Disposition:** high risk; portable; covered; owner: Octane useSyncExternalStore and scheduler.
 
 **Upstream evidence**
 
@@ -284,16 +283,24 @@ Targets: `packages/octane/tests/hydration/deferred-hydration-contract.test.ts`, 
 
 **Octane contract.** useSyncExternalStore subscribes after render, converges when subscribe synchronously notifies, unsubscribes on conditional/root removal, and ignores every post-unmount notification.
 
-**Applicable modes:** `client`, `production-compile`. **Observables:** `markup`, `effects`.
+**Applicable modes:** `client`, `production-compile`. **Observables:** `markup`, `node-identity`, `effects`.
 
 **Octane references**
 
-- [packages/octane/tests/sync-external-store.test.ts](../packages/octane/tests/sync-external-store.test.ts) — “post-unmount store mutations do NOT trigger any work” — Covers root unmount but not synchronous subscribe notification or conditional stale-listener delivery.
+- [packages/octane/tests/sync-external-store.test.ts](../packages/octane/tests/sync-external-store.test.ts) — “subscribes outside render and converges when subscribe notifies synchronously” — Proves subscription timing at the public callback boundary and commits the synchronously published snapshot without resubscribing.
+- [packages/octane/tests/sync-external-store.test.ts](../packages/octane/tests/sync-external-store.test.ts) — “unsubscribes on unmount (store drops its listener)”
+- [packages/octane/tests/sync-external-store.test.ts](../packages/octane/tests/sync-external-store.test.ts) — “unsubscribes when its conditional owner removes it”
+- [packages/octane/tests/sync-external-store.test.ts](../packages/octane/tests/sync-external-store.test.ts) — “ignores a retained stale callback after conditional removal” — Invokes the exact callback retained by the store and proves the removed reader stays absent while unrelated host and sibling objects survive.
 - [packages/octane/src/runtime.ts](../packages/octane/src/runtime.ts) — `useSyncExternalStore`
 
-**Next action (test).** Prove subscription occurs outside render, a synchronous notifier converges without looping, conditional removal unsubscribes, and a retained stale callback cannot resurrect DOM.
+**Executable evidence**
 
-Targets: `packages/octane/tests/sync-external-store.test.ts`.
+- [subscribes outside render and converges when subscribe notifies synchronously](../packages/octane/tests/sync-external-store.test.ts) — modes: `client`, `production-compile`; observables: `markup`, `effects`
+- [unsubscribes on unmount (store drops its listener)](../packages/octane/tests/sync-external-store.test.ts) — modes: `client`, `production-compile`; observables: `effects`
+- [unsubscribes when its conditional owner removes it](../packages/octane/tests/sync-external-store.test.ts) — modes: `client`, `production-compile`; observables: `markup`, `effects`
+- [ignores a retained stale callback after conditional removal](../packages/octane/tests/sync-external-store.test.ts) — modes: `client`, `production-compile`; observables: `markup`, `node-identity`, `effects`
+
+**Rationale.** Octane subscribes through a passive effect, owns unsubscribe in that effect slot, and schedules notifications onto a block whose disposed guards make stale callbacks inert after removal.
 
 
 ### head-hydration
@@ -503,7 +510,7 @@ Targets: `packages/octane/tests/conformance/hydration-mismatch.test.ts`, `packag
 
 #### RDX-MEM-001 — Memo prop bailouts do not swallow owned updates or revive removed work
 
-**Disposition:** high risk; portable; planned; owner: Octane memo and scheduler.
+**Disposition:** high risk; portable; covered; owner: Octane memo and scheduler.
 
 **Upstream evidence**
 
@@ -514,16 +521,19 @@ Targets: `packages/octane/tests/conformance/hydration-mismatch.test.ts`, `packag
 
 **Octane contract.** A memoized component processes its own state/store updates without disabling descendant memo bailouts, and pending work beneath a removed ancestor cannot mount new DOM.
 
-**Applicable modes:** `client`, `production-compile`. **Observables:** `markup`, `effects`.
+**Applicable modes:** `client`, `production-compile`. **Observables:** `markup`, `node-identity`, `effects`.
 
 **Octane references**
 
-- [packages/octane/tests/conformance/update-reconciliation.test.ts](../packages/octane/tests/conformance/update-reconciliation.test.ts) — “should update children even if parent blocks updates”
-- [packages/octane/tests/conformance/update-reconciliation.test.ts](../packages/octane/tests/conformance/update-reconciliation.test.ts) — “does not call render after a component as been deleted”
+- [packages/octane/tests/conformance/memo-bailout.test.ts](../packages/octane/tests/conformance/memo-bailout.test.ts) — “processes an owned external-store update while stable descendants bail out” — The memo owner updates from its own subscription while an unchanged memo descendant retains both render and host identity.
+- [packages/octane/tests/conformance/update-reconciliation.test.ts](../packages/octane/tests/conformance/update-reconciliation.test.ts) — “does not commit a memoized store update after its ancestor removes it” — Queues the deeper store update before the ancestor deletion and proves no committed DOM or effect work can publish from the disposed subtree.
 
-**Next action (test).** Combine memo with useSyncExternalStore, prove the owner updates while a stable memo grandchild bails, then queue/remove work and prove no zombie DOM or effects appear.
+**Executable evidence**
 
-Targets: `packages/octane/tests/conformance/memo-bailout.test.ts`, `packages/octane/tests/conformance/update-reconciliation.test.ts`.
+- [processes an owned external-store update while stable descendants bail out](../packages/octane/tests/conformance/memo-bailout.test.ts) — modes: `client`, `production-compile`; observables: `markup`, `node-identity`
+- [does not commit a memoized store update after its ancestor removes it](../packages/octane/tests/conformance/update-reconciliation.test.ts) — modes: `client`, `production-compile`; observables: `markup`, `effects`
+
+**Rationale.** Octane schedules hook-owned work directly on the owning block rather than re-entering through its parent memo gate. Its shallow-first queue and disposed-block guards then discard deeper work after an ancestor removes that subtree.
 
 
 ### package-resolution

--- a/packages/octane/audit/redact-adversarial-ledger.json
+++ b/packages/octane/audit/redact-adversarial-ledger.json
@@ -863,7 +863,7 @@
       "symptom": "Two renders before the passive queue drained installed multiple imperative artifacts because cleanup ownership was cleared before the intermediate body ran.",
       "octaneContract": "After any coalesced dependency-changing render sequence, at most one passive side effect is live; each installed effect is cleaned exactly once, including final unmount.",
       "classification": "portable",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "owner": "Octane scheduler and effect hooks",
       "applicableModes": ["client", "production-compile"],
@@ -872,15 +872,19 @@
         {
           "kind": "test",
           "file": "packages/octane/tests/effect-timing.test.ts",
-          "testName": "phase order on re-render: cleanups fire before bodies of same phase",
-          "note": "Strong ordering coverage, but not the exact two-renders-before-passive-drain race."
+          "testName": "coalesced dependency changes leave one live passive side effect",
+          "note": "Commits b, requests c before the ordinary passive task drains, and proves Octane settles b's queued passive work before the c render while preserving one live artifact and exactly-once cleanup."
         }
       ],
-      "nextAction": {
-        "kind": "test",
-        "targets": ["packages/octane/tests/effect-timing.test.ts"],
-        "acceptance": "Drive a→b→c before passive drain, assert one live imperative artifact, exact cleanup order through c, and one final cleanup on unmount in development and production compile modes."
-      }
+      "evidence": [
+        {
+          "file": "packages/octane/tests/effect-timing.test.ts",
+          "testName": "coalesced dependency changes leave one live passive side effect",
+          "modes": ["client", "production-compile"],
+          "observables": ["markup", "effects"]
+        }
+      ],
+      "rationale": "Same-batch root renders coalesce before an intermediate effect can enqueue. When an intermediate revision does commit, Octane drains its pending passive work before the next render begins. The portable single-live-artifact and exactly-once cleanup contract therefore holds without exposing Redact's two-entry queue shape."
     },
     {
       "id": "RDX-MEM-001",
@@ -905,31 +909,40 @@
       "symptom": "A stable-prop memo gate swallowed the component's own store update, while stale queued work could render after an ancestor removed it.",
       "octaneContract": "A memoized component processes its own state/store updates without disabling descendant memo bailouts, and pending work beneath a removed ancestor cannot mount new DOM.",
       "classification": "portable",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "owner": "Octane memo and scheduler",
       "applicableModes": ["client", "production-compile"],
-      "observables": ["markup", "effects"],
+      "observables": ["markup", "node-identity", "effects"],
       "octaneReferences": [
         {
           "kind": "test",
-          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
-          "testName": "should update children even if parent blocks updates"
+          "file": "packages/octane/tests/conformance/memo-bailout.test.ts",
+          "testName": "processes an owned external-store update while stable descendants bail out",
+          "note": "The memo owner updates from its own subscription while an unchanged memo descendant retains both render and host identity."
         },
         {
           "kind": "test",
           "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
-          "testName": "does not call render after a component as been deleted"
+          "testName": "does not commit a memoized store update after its ancestor removes it",
+          "note": "Queues the deeper store update before the ancestor deletion and proves no committed DOM or effect work can publish from the disposed subtree."
         }
       ],
-      "nextAction": {
-        "kind": "test",
-        "targets": [
-          "packages/octane/tests/conformance/memo-bailout.test.ts",
-          "packages/octane/tests/conformance/update-reconciliation.test.ts"
-        ],
-        "acceptance": "Combine memo with useSyncExternalStore, prove the owner updates while a stable memo grandchild bails, then queue/remove work and prove no zombie DOM or effects appear."
-      }
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/memo-bailout.test.ts",
+          "testName": "processes an owned external-store update while stable descendants bail out",
+          "modes": ["client", "production-compile"],
+          "observables": ["markup", "node-identity"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/update-reconciliation.test.ts",
+          "testName": "does not commit a memoized store update after its ancestor removes it",
+          "modes": ["client", "production-compile"],
+          "observables": ["markup", "effects"]
+        }
+      ],
+      "rationale": "Octane schedules hook-owned work directly on the owning block rather than re-entering through its parent memo gate. Its shallow-first queue and disposed-block guards then discard deeper work after an ancestor removes that subtree."
     },
     {
       "id": "RDX-NON-001",
@@ -1815,17 +1828,33 @@
       "symptom": "Subscription ran during render or a stale listener scheduled an unmounted component, causing removed UI to reappear in its former host.",
       "octaneContract": "useSyncExternalStore subscribes after render, converges when subscribe synchronously notifies, unsubscribes on conditional/root removal, and ignores every post-unmount notification.",
       "classification": "portable",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "owner": "Octane useSyncExternalStore and scheduler",
       "applicableModes": ["client", "production-compile"],
-      "observables": ["markup", "effects"],
+      "observables": ["markup", "node-identity", "effects"],
       "octaneReferences": [
         {
           "kind": "test",
           "file": "packages/octane/tests/sync-external-store.test.ts",
-          "testName": "post-unmount store mutations do NOT trigger any work",
-          "note": "Covers root unmount but not synchronous subscribe notification or conditional stale-listener delivery."
+          "testName": "subscribes outside render and converges when subscribe notifies synchronously",
+          "note": "Proves subscription timing at the public callback boundary and commits the synchronously published snapshot without resubscribing."
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/sync-external-store.test.ts",
+          "testName": "unsubscribes on unmount (store drops its listener)"
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/sync-external-store.test.ts",
+          "testName": "unsubscribes when its conditional owner removes it"
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/sync-external-store.test.ts",
+          "testName": "ignores a retained stale callback after conditional removal",
+          "note": "Invokes the exact callback retained by the store and proves the removed reader stays absent while unrelated host and sibling objects survive."
         },
         {
           "kind": "source",
@@ -1833,11 +1862,33 @@
           "symbol": "useSyncExternalStore"
         }
       ],
-      "nextAction": {
-        "kind": "test",
-        "targets": ["packages/octane/tests/sync-external-store.test.ts"],
-        "acceptance": "Prove subscription occurs outside render, a synchronous notifier converges without looping, conditional removal unsubscribes, and a retained stale callback cannot resurrect DOM."
-      }
+      "evidence": [
+        {
+          "file": "packages/octane/tests/sync-external-store.test.ts",
+          "testName": "subscribes outside render and converges when subscribe notifies synchronously",
+          "modes": ["client", "production-compile"],
+          "observables": ["markup", "effects"]
+        },
+        {
+          "file": "packages/octane/tests/sync-external-store.test.ts",
+          "testName": "unsubscribes on unmount (store drops its listener)",
+          "modes": ["client", "production-compile"],
+          "observables": ["effects"]
+        },
+        {
+          "file": "packages/octane/tests/sync-external-store.test.ts",
+          "testName": "unsubscribes when its conditional owner removes it",
+          "modes": ["client", "production-compile"],
+          "observables": ["markup", "effects"]
+        },
+        {
+          "file": "packages/octane/tests/sync-external-store.test.ts",
+          "testName": "ignores a retained stale callback after conditional removal",
+          "modes": ["client", "production-compile"],
+          "observables": ["markup", "node-identity", "effects"]
+        }
+      ],
+      "rationale": "Octane subscribes through a passive effect, owns unsubscribe in that effect slot, and schedules notifications onto a block whose disposed guards make stale callbacks inert after removal."
     },
     {
       "id": "RDX-SUS-001",

--- a/packages/octane/tests/_fixtures/effect-timing.tsrx
+++ b/packages/octane/tests/_fixtures/effect-timing.tsrx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useInsertionEffect, useState } from 'octane';
+import { useEffect, useLayoutEffect, useInsertionEffect, useRef, useState } from 'octane';
 
 // Three-phase ordering: insertion fires sync-before-layout-before-paint;
 // passive fires after paint. Cleanups of each phase fire before that phase's
@@ -41,6 +41,25 @@ export function PassiveDeferred(props) @{
 		props.log.push('passive');
 	}, [props.tick, props.log]);
 	<span>{'z'}</span>
+}
+
+// Models an imperative integration (a chart/canvas library, for example) that
+// installs one artifact and removes exactly that artifact from its cleanup.
+// Back-to-back dependency changes must never leave both revisions installed.
+export function CoalescedPassiveArtifact(props: { label: string; log: string[] }) @{
+	const host = useRef<HTMLDivElement | null>(null);
+	props.log.push('render:' + props.label);
+	useEffect(() => {
+		const artifact = document.createElement('span');
+		artifact.dataset.label = props.label;
+		host.current!.appendChild(artifact);
+		props.log.push('body:' + props.label);
+		return () => {
+			props.log.push('cleanup:' + props.label);
+			artifact.remove();
+		};
+	}, [props.label, props.log]);
+	<div id="coalesced-passive-host" ref={host} />
 }
 
 // React parity: pending PASSIVE effects flush BEFORE the next render pass begins

--- a/packages/octane/tests/_fixtures/memo-bailout.tsrx
+++ b/packages/octane/tests/_fixtures/memo-bailout.tsrx
@@ -1,4 +1,4 @@
-import { useState, createContext, use, memo } from 'octane';
+import { useState, useSyncExternalStore, createContext, use, memo } from 'octane';
 
 // ---------------------------------------------------------------------------
 // memo() bailout heuristics — ports of ReactMemo-test.js cases :66, :101, :298.
@@ -70,5 +70,58 @@ export function CustomCompareHost(props) @{
 		<button id="ctick" onClick={() => setTick(tick + 1)}>{'tick'}</button>
 		<button id="ccount" onClick={() => setCount(count + 1)}>{'count'}</button>
 		<CustomCounter count={count} log={props.log} />
+	</div>
+}
+
+// --- Redact RDX-MEM-001 — an owned store update crosses a memo gate ----------
+type MemoStoreListener = () => void;
+type MemoStore = {
+	getSnapshot: () => number;
+	set: (next: number) => void;
+	subscribe: (listener: MemoStoreListener) => () => void;
+	listenerCount: () => number;
+};
+type MemoStoreLog = (message: string) => void;
+
+export function makeMemoStore(initial = 0): MemoStore {
+	let value = initial;
+	const listeners = new Set<MemoStoreListener>();
+	return {
+		getSnapshot: () => value,
+		set(next: number) {
+			value = next;
+			for (const listener of listeners) listener();
+		},
+		subscribe(listener: MemoStoreListener) {
+			listeners.add(listener);
+			return () => {
+				listeners.delete(listener);
+			};
+		},
+		listenerCount: () => listeners.size,
+	};
+}
+
+function StableStoreLeafImpl(props: { label: string; log: MemoStoreLog }) @{
+	props.log('leaf:' + props.label);
+	<span id="memo-store-leaf">{props.label as string}</span>
+}
+const StableStoreLeaf = memo(StableStoreLeafImpl);
+
+function MemoStoreOwnerImpl(props: { store: MemoStore; log: MemoStoreLog }) @{
+	const value = useSyncExternalStore(props.store.subscribe, props.store.getSnapshot);
+	props.log('owner:' + value);
+	<section id="memo-store-owner">
+		<output id="memo-store-value">{value as number}</output>
+		<StableStoreLeaf label="stable" log={props.log} />
+	</section>
+}
+const MemoStoreOwner = memo(MemoStoreOwnerImpl);
+
+export function MemoStoreHost(props: { store: MemoStore; log: MemoStoreLog }) @{
+	const [tick, setTick] = useState(0);
+	<div data-tick={tick as number}>
+		<button id="memo-store-parent-update" onClick={() => setTick(tick + 1)}>{'parent'}</button>
+		<MemoStoreOwner store={props.store} log={props.log} />
 	</div>
 }

--- a/packages/octane/tests/_fixtures/sync-external-store.tsrx
+++ b/packages/octane/tests/_fixtures/sync-external-store.tsrx
@@ -1,5 +1,11 @@
 import { useSyncExternalStore, useCallback } from 'octane';
 
+type StoreListener = () => void;
+type StoreLike = {
+	get: () => unknown;
+	subscribe: (notify: StoreListener) => () => void;
+};
+
 // Smallest practical store: a mutable counter with a Set of listeners.
 // Identical-by-reference subscribe / getSnapshot keep the useEffect deps
 // stable across renders — re-mounting / re-subscribing only when a fresh
@@ -32,6 +38,20 @@ export function Reader(props) @{
 	<p class="value">{value as string}</p>
 }
 
+// Marks only the component's render interval so tests can distinguish render
+// from the later subscription lifecycle without observing runtime internals.
+export function RenderObservedReader(props: {
+	store: StoreLike;
+	onRenderState: (rendering: boolean) => void;
+}) @{
+	props.onRenderState(true);
+	const subscribe = useCallback(props.store.subscribe, [props.store]);
+	const getSnapshot = useCallback(props.store.get, [props.store]);
+	const value = useSyncExternalStore(subscribe, getSnapshot);
+	props.onRenderState(false);
+	<p class="value">{value as string}</p>
+}
+
 // Same component bound to a different store identity — exercises the
 // re-subscribe-on-store-swap path.
 export function SwappableReader(props) @{
@@ -39,4 +59,44 @@ export function SwappableReader(props) @{
 	const getSnapshot = useCallback(props.store.get, [props.store]);
 	const value = useSyncExternalStore(subscribe, getSnapshot);
 	<p class="value" data-key={props.store === props.alt ? 'alt' : 'main'}>{value as string}</p>
+}
+
+// Removes the reader without unmounting its host so a stale store callback
+// cannot hide a resurrection behind wholesale root teardown.
+export function ConditionalReader(props: { store: StoreLike; show: boolean }) @{
+	<div id="conditional-host">
+		<span id="conditional-survivor">{'keep'}</span>
+		@if (props.show) {
+			<Reader store={props.store} />
+		}
+	</div>
+}
+
+// Deliberately retains the most recently subscribed callback after unsubscribe.
+// Real stores can retain stale listener snapshots while notifying; invoking it
+// lets the test prove an already-removed owner stays dead.
+export function makeRetainedCallbackStore(initial = 0): StoreLike & {
+	notifyRetained: (next: number) => boolean;
+	listenerCount: () => number;
+} {
+	let value = initial;
+	let retained: StoreListener | null = null;
+	const listeners = new Set<StoreListener>();
+	return {
+		get: () => value,
+		subscribe: (notify: StoreListener) => {
+			retained = notify;
+			listeners.add(notify);
+			return () => {
+				listeners.delete(notify);
+			};
+		},
+		notifyRetained: (next: number) => {
+			value = next;
+			if (retained === null) return false;
+			retained();
+			return true;
+		},
+		listenerCount: () => listeners.size,
+	};
 }

--- a/packages/octane/tests/conformance/_fixtures/update-reconciliation.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/update-reconciliation.tsrx
@@ -8,6 +8,7 @@ import {
 	useLayoutEffect,
 	useReducer,
 	useState,
+	useSyncExternalStore,
 } from 'octane';
 
 let _setFirst: any = null;
@@ -18,6 +19,7 @@ let _setCrossRootA: any = null;
 let _setCrossRootB: any = null;
 let _setDeleteParent: any = null;
 let _setDeleteChild: any = null;
+let _setDeleteStoreParent: ((value: boolean) => void) | null = null;
 let _setMemoChild: any = null;
 let _setNestedEffectStep: any = null;
 let _setFiniteLayoutStep: any = null;
@@ -49,6 +51,9 @@ export function setDeleteParent(value: any) {
 }
 export function setDeleteChild(value: any) {
 	_setDeleteChild(value);
+}
+export function setDeleteStoreParent(value: boolean) {
+	_setDeleteStoreParent!(value);
 }
 export function setMemoChild(value: any) {
 	_setMemoChild(value);
@@ -245,6 +250,54 @@ export function DeletePendingChild(props) @{
 	_setDeleteParent = setShow;
 	<div>
 		{show ? <DeleteChild log={props.log} /> : <span id="deleted">{'deleted'}</span>}
+	</div>
+}
+
+type DeleteStoreListener = () => void;
+type DeleteStore = {
+	getSnapshot: () => number;
+	set: (next: number) => void;
+	subscribe: (listener: DeleteStoreListener) => () => void;
+	listenerCount: () => number;
+};
+type DeleteStoreLog = (message: string) => void;
+
+export function makeDeleteStore(initial = 0): DeleteStore {
+	let value = initial;
+	const listeners = new Set<DeleteStoreListener>();
+	return {
+		getSnapshot: () => value,
+		set(next: number) {
+			value = next;
+			for (const listener of listeners) listener();
+		},
+		subscribe(listener: DeleteStoreListener) {
+			listeners.add(listener);
+			return () => {
+				listeners.delete(listener);
+			};
+		},
+		listenerCount: () => listeners.size,
+	};
+}
+
+function DeleteStoreChildBody(props: { store: DeleteStore; log: DeleteStoreLog }) @{
+	const value = useSyncExternalStore(props.store.subscribe, props.store.getSnapshot);
+	useEffect(() => {
+		props.log(`store-child-effect:${value}`);
+		return () => props.log(`store-child-cleanup:${value}`);
+	}, [value, props.log]);
+	<span id="delete-store-child">{value as number}</span>
+}
+const DeleteStoreChild = memo(DeleteStoreChildBody);
+
+export function DeletePendingStoreChild(props: { store: DeleteStore; log: DeleteStoreLog }) @{
+	const [show, setShow] = useState(true);
+	_setDeleteStoreParent = setShow;
+	<div>
+		{show
+			? <DeleteStoreChild store={props.store} log={props.log} />
+			: <span id="store-child-deleted">{'deleted'}</span>}
 	</div>
 }
 

--- a/packages/octane/tests/conformance/memo-bailout.test.ts
+++ b/packages/octane/tests/conformance/memo-bailout.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { mount, createLog } from '../_helpers';
-import { BailoutHost, ContextHost, CustomCompareHost } from '../_fixtures/memo-bailout.tsrx';
+import { flushSync } from '../../src/index.js';
+import { mount, createLog, flushEffects } from '../_helpers';
+import {
+	BailoutHost,
+	ContextHost,
+	CustomCompareHost,
+	makeMemoStore,
+	MemoStoreHost,
+} from '../_fixtures/memo-bailout.tsrx';
 
 // Ports of memo() bailout heuristics from
 // packages/react-reconciler/src/__tests__/ReactMemo-test.js
@@ -62,5 +69,38 @@ describe('memo bailout', () => {
 		expect(log.drain()).toEqual(['compare:0->1', 'render:1']);
 
 		r.unmount();
+	});
+
+	it('processes an owned external-store update while stable descendants bail out', () => {
+		// Redact-derived RDX-MEM-001: stable props may block a parent-driven
+		// re-render, but they must not swallow work scheduled by the memoized
+		// component itself.
+		const store = makeMemoStore(0);
+		const log = createLog();
+		const r = mount(MemoStoreHost, { store, log: log.push });
+		flushEffects();
+		expect(log.drain()).toEqual(['owner:0', 'leaf:stable']);
+		expect(store.listenerCount()).toBe(1);
+
+		const host = r.find('[data-tick]');
+		const owner = r.find('#memo-store-owner');
+		const leaf = r.find('#memo-store-leaf');
+
+		// Unchanged props take the ordinary memo bailout.
+		r.click('#memo-store-parent-update');
+		expect(host.getAttribute('data-tick')).toBe('1');
+		expect(log.drain()).toEqual([]);
+
+		// The owner's subscription schedules that owner directly. It must cross
+		// its memo gate, while the stable memoized leaf still bails out.
+		flushSync(() => store.set(1));
+		expect(r.find('#memo-store-value').textContent).toBe('1');
+		expect(r.find('#memo-store-owner')).toBe(owner);
+		expect(r.find('#memo-store-leaf')).toBe(leaf);
+		expect(log.drain()).toEqual(['owner:1']);
+
+		r.unmount();
+		flushEffects();
+		expect(store.listenerCount()).toBe(0);
 	});
 });

--- a/packages/octane/tests/conformance/update-reconciliation.test.ts
+++ b/packages/octane/tests/conformance/update-reconciliation.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, createRoot, flushSync, startTransition, type Root } from '../../src/index.js';
-import { createLog, mount } from '../_helpers';
+import { createLog, flushEffects, mount } from '../_helpers';
 import * as Fixture from './_fixtures/update-reconciliation.tsrx';
 
 function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
@@ -218,6 +218,34 @@ describe('ReactUpdates update reconciliation', () => {
 		expect(r.findAll('#delete-child')).toHaveLength(0);
 		expect(r.find('#deleted').textContent).toBe('deleted');
 		expect(log.drain()).toEqual([]);
+		r.unmount();
+	});
+
+	// Redact-derived RDX-MEM-001: pending work beneath an ancestor removed in
+	// the same batch cannot revive that memoized subtree.
+	it('does not commit a memoized store update after its ancestor removes it', () => {
+		const store = Fixture.makeDeleteStore(0);
+		const log = createLog();
+		const r = mount(Fixture.DeletePendingStoreChild, { store, log: log.push });
+		flushEffects();
+		expect(log.drain()).toEqual(['store-child-effect:0']);
+		expect(store.listenerCount()).toBe(1);
+
+		flushSync(() => {
+			// Queue the child first, then queue its ancestor's removal. The
+			// ancestor must win regardless of enqueue order.
+			store.set(1);
+			Fixture.setDeleteStoreParent(false);
+		});
+
+		expect(r.findAll('#delete-store-child')).toHaveLength(0);
+		expect(r.find('#store-child-deleted').textContent).toBe('deleted');
+		expect(log.drain()).toEqual([]);
+
+		flushEffects();
+		expect(log.drain()).toEqual(['store-child-cleanup:0']);
+		expect(store.listenerCount()).toBe(0);
+		expect(r.findAll('#delete-store-child')).toHaveLength(0);
 		r.unmount();
 	});
 

--- a/packages/octane/tests/effect-timing.test.ts
+++ b/packages/octane/tests/effect-timing.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
+import { flushSync } from '../src/index.js';
 import { mount, nextPaint } from './_helpers';
 import {
 	PhaseOrder,
 	LayoutReadsDom,
 	PassiveDeferred,
+	CoalescedPassiveArtifact,
 	ManyPassiveEffects,
 	PassiveBeforeCascadeRender,
 } from './_fixtures/effect-timing.tsrx';
@@ -77,6 +79,52 @@ describe('effect timing', () => {
 		await nextPaint();
 		expect(log).toEqual(['layout', 'passive']);
 		r.unmount();
+	});
+
+	it('coalesced dependency changes leave one live passive side effect', async () => {
+		const log: string[] = [];
+		const r = mount(CoalescedPassiveArtifact, { label: 'a', log });
+		await nextPaint();
+
+		const host = r.find('#coalesced-passive-host');
+		expect(Array.from(host.children, (child) => child.getAttribute('data-label'))).toEqual(['a']);
+		expect(log).toEqual(['render:a', 'body:a']);
+
+		// Commit b, but issue c before the ordinary asynchronous passive drain.
+		// Octane settles b's queued passive work before beginning the c render,
+		// so each committed revision owns exactly one artifact at the boundary.
+		flushSync(() => r.root.render(CoalescedPassiveArtifact, { label: 'b', log }));
+		expect(log).toEqual(['render:a', 'body:a', 'render:b']);
+
+		flushSync(() => r.root.render(CoalescedPassiveArtifact, { label: 'c', log }));
+		expect(Array.from(host.children, (child) => child.getAttribute('data-label'))).toEqual(['b']);
+		expect(log).toEqual(['render:a', 'body:a', 'render:b', 'cleanup:a', 'body:b', 'render:c']);
+
+		await nextPaint();
+		expect(Array.from(host.children, (child) => child.getAttribute('data-label'))).toEqual(['c']);
+		expect(log).toEqual([
+			'render:a',
+			'body:a',
+			'render:b',
+			'cleanup:a',
+			'body:b',
+			'render:c',
+			'cleanup:b',
+			'body:c',
+		]);
+		r.unmount();
+		await nextPaint();
+		expect(log).toEqual([
+			'render:a',
+			'body:a',
+			'render:b',
+			'cleanup:a',
+			'body:b',
+			'render:c',
+			'cleanup:b',
+			'body:c',
+			'cleanup:c',
+		]);
 	});
 
 	it('pending passive effects flush BEFORE a layout-cascade render mounts new children', async () => {

--- a/packages/octane/tests/sync-external-store.test.ts
+++ b/packages/octane/tests/sync-external-store.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import { mount, nextPaint } from './_helpers';
-import { makeStore, Reader, SwappableReader } from './_fixtures/sync-external-store.tsrx';
+import {
+	ConditionalReader,
+	makeRetainedCallbackStore,
+	makeStore,
+	Reader,
+	RenderObservedReader,
+	SwappableReader,
+} from './_fixtures/sync-external-store.tsrx';
 
 // React 18's useSyncExternalStore contract: subscribe on mount, unsubscribe
 // on unmount, re-render on every notify, fresh getSnapshot() every render.
@@ -32,6 +39,43 @@ describe('useSyncExternalStore', () => {
 		r.unmount();
 	});
 
+	it('subscribes outside render and converges when subscribe notifies synchronously', async () => {
+		let value = 0;
+		let rendering = false;
+		let subscribeCalls = 0;
+		let subscribedDuringRender = false;
+		const listeners = new Set<() => void>();
+		const store = {
+			get: () => value,
+			subscribe(notify: () => void) {
+				subscribeCalls++;
+				subscribedDuringRender ||= rendering;
+				listeners.add(notify);
+				value = 1;
+				notify();
+				return () => {
+					listeners.delete(notify);
+				};
+			},
+		};
+
+		const r = mount(RenderObservedReader, {
+			store,
+			onRenderState(next: boolean) {
+				rendering = next;
+			},
+		});
+		await nextPaint();
+
+		expect(subscribedDuringRender).toBe(false);
+		expect(subscribeCalls).toBe(1);
+		expect(listeners.size).toBe(1);
+		expect(r.find('.value').textContent).toBe('1');
+		r.unmount();
+		await nextPaint();
+		expect(listeners.size).toBe(0);
+	});
+
 	it('unsubscribes on unmount (store drops its listener)', async () => {
 		const store = makeStore(1);
 		const r = mount(Reader, { store });
@@ -51,6 +95,39 @@ describe('useSyncExternalStore', () => {
 		// No throw, no stray DOM mutation — the unsubscribe contract is honored.
 		expect(() => store.set(999)).not.toThrow();
 		expect(store.listenerCount()).toBe(0);
+	});
+
+	it('unsubscribes when its conditional owner removes it', async () => {
+		const store = makeStore(1);
+		const r = mount(ConditionalReader, { store, show: true });
+		await nextPaint();
+		expect(store.listenerCount()).toBe(1);
+
+		r.update(ConditionalReader, { store, show: false });
+		await nextPaint();
+		expect(store.listenerCount()).toBe(0);
+		expect(r.findAll('.value')).toHaveLength(0);
+		r.unmount();
+	});
+
+	it('ignores a retained stale callback after conditional removal', async () => {
+		const store = makeRetainedCallbackStore(0);
+		const r = mount(ConditionalReader, { store, show: true });
+		await nextPaint();
+		const host = r.find('#conditional-host');
+		const survivor = r.find('#conditional-survivor');
+
+		r.update(ConditionalReader, { store, show: false });
+		await nextPaint();
+		expect(store.listenerCount()).toBe(0);
+		expect(r.findAll('.value')).toHaveLength(0);
+
+		expect(store.notifyRetained(1)).toBe(true);
+		await nextPaint();
+		expect(r.find('#conditional-host')).toBe(host);
+		expect(r.find('#conditional-survivor')).toBe(survivor);
+		expect(r.findAll('.value')).toHaveLength(0);
+		r.unmount();
 	});
 
 	it('swapping the store unsubscribes from the old and subscribes to the new', async () => {


### PR DESCRIPTION
## Summary

- cover `RDX-LIF-001` with a public passive-effect lifecycle probe that preserves one live imperative artifact across back-to-back dependency changes
- cover `RDX-STORE-001` with synchronous-subscribe, conditional-unsubscribe, and retained stale-listener regressions
- cover `RDX-MEM-001` with memo-owned external-store scheduling and ancestor-removal race regressions
- update the generated Redact adversarial audit from 12 to 15 covered contracts

## Runtime and performance impact

This PR changes only tests, fixtures, and audit documentation. It does not modify the runtime, compiler, generated application code, or benchmark paths, so it introduces no shipped runtime overhead and does not require a changeset.

## Validation

- `pnpm test` — 1,292 files / 12,613 tests passed
- focused development + production-compile tests — 8 files / 110 tests passed
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm redact-audit:check` — 15/15 audit integrity tests passed
- adversarial mutation probes confirmed each new regression fails when its relevant cleanup, memo scheduling, disposed-work, or unsubscribe guard is removed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tests, fixtures, and generated audit docs only; no runtime, compiler, or public API changes.
> 
> **Overview**
> Adds Octane regression tests and fixtures for three Redact-derived scheduler contracts, then marks them **covered** in the adversarial audit (12 → 15 covered entries).
> 
> **RDX-LIF-001** — `effect-timing` gains a coalesced passive-effect probe (`CoalescedPassiveArtifact`) that asserts one live imperative artifact and exactly-once cleanup when dependency changes stack before the passive queue drains.
> 
> **RDX-STORE-001** — `sync-external-store` adds cases for subscribe-after-render with synchronous notify, conditional unmount unsubscribe, and a retained stale callback that must not resurrect removed UI.
> 
> **RDX-MEM-001** — `memo-bailout` and `update-reconciliation` cover memo-owned `useSyncExternalStore` updates through a memo gate (stable descendants still bail) and queued store work discarded when an ancestor removes the subtree.
> 
> The authored ledger JSON and generated `docs/redact-adversarial-audit.md` drop these IDs from the open queue and record executable evidence plus rationale; no runtime or compiler code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed6867d740b466f857a9b988c1e187914e4dfa86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->