### PR TITLE
Lock Octane consumer build contracts

### DIFF
--- a/.changeset/bright-export-paths.md
+++ b/.changeset/bright-export-paths.md
@@ -1,0 +1,6 @@
+---
+'octane': patch
+---
+
+Restore the published JSX type-runtime and TSRX type-helper subpaths, and verify
+the required named exports of every built public JavaScript entry point.

--- a/docs/redact-adversarial-audit.md
+++ b/docs/redact-adversarial-audit.md
@@ -58,9 +58,9 @@ This is the explicit artifact sample reviewed at the pinned snapshot; broad sour
 
 | Status | Entries |
 | --- | ---: |
-| planned | 8 |
+| planned | 6 |
 | in progress | 0 |
-| covered | 15 |
+| covered | 17 |
 | documented | 5 |
 | decision required | 1 |
 | blocked | 0 |
@@ -82,9 +82,7 @@ This is the explicit artifact sample reviewed at the pinned snapshot; broad sour
 | [`RDX-HYD-007`](#rdx-hyd-007) | high | head-hydration | Head ownership keys are unique across compiled modules and tags | planned | Octane compiler and runtime head hydration |
 | [`RDX-PORT-002`](#rdx-port-002) | high | portal-updates | A stateful portal descendant resolves its foreign host for owned updates | planned | Octane portal host resolution |
 | [`RDX-REC-002`](#rdx-rec-002) | high | reconciliation-placement | Topology transitions use the correct absolute anchor without stable reattachment | planned | Octane reconciler and portal placement |
-| [`RDX-CFG-001`](#rdx-cfg-001) | medium | build-configuration | Public options must change the emitted build at their observation boundary | planned | Octane compiler and Vite/Rspack/Rsbuild integrations |
 | [`RDX-HYD-005`](#rdx-hyd-005) | medium | hydration-errors | Hydration recovery reporting has an explicit public contract | decision required | Octane public root API |
-| [`RDX-PKG-001`](#rdx-pkg-001) | medium | public-exports | Advertised named exports are locked at the consumer boundary | planned | Octane package surface |
 
 ## Contract ledger
 
@@ -94,7 +92,7 @@ This is the explicit artifact sample reviewed at the pinned snapshot; broad sour
 
 #### RDX-CFG-001 — Public options must change the emitted build at their observation boundary
 
-**Disposition:** medium risk; adaptable; planned; owner: Octane compiler and Vite/Rspack/Rsbuild integrations.
+**Disposition:** medium risk; adaptable; covered; owner: Octane compiler and Vite/Rspack/Rsbuild/Rspeedy integrations.
 
 **Upstream evidence**
 
@@ -103,20 +101,46 @@ This is the explicit artifact sample reviewed at the pinned snapshot; broad sour
 
 **Consumer-visible symptom.** A documented false-valued feature flag silently left the full implementation in the bundle because an internal folder name was cast to an unrelated public option key.
 
-**Octane contract.** Every public compiler or bundler boolean must have a test proving the option changes emitted code, resolution, bundle contents, or runtime behavior in each environment where it is supported.
+**Octane contract.** Every public compiler or bundler boolean must be traced through each adapter's resolved host configuration and the owning compiler's emitted code, module resolution, bundle contents, or runtime behavior. Pass-through host build controls lock both values in resolved configuration; options with Octane-owned output also require an executable output or bundle proof.
 
-**Applicable modes:** `production-compile`, `vite-client`, `vite-ssr`, `rspack`, `rsbuild`. **Observables:** `markup`, `package-resolution`.
+**Applicable modes:** `production-compile`, `vite-client`, `vite-ssr`, `rspack`, `rsbuild`, `rspeedy`. **Observables:** `emitted-code`, `resolved-configuration`, `bundle-contents`, `package-resolution`.
 
 **Octane references**
 
-- [packages/octane/tests/hmr.test.ts](../packages/octane/tests/hmr.test.ts) — “hmr option off → no wrapping, no accept block” — Representative direct option-to-output coverage; not yet a complete public-option matrix.
-- [packages/rspack-plugin-octane/tests/rspack.test.ts](../packages/rspack-plugin-octane/tests/rspack.test.ts) — “erases profiling and full diagnostics from a real production bundle”
+- [packages/octane/tests/compiler-vite-options.test.ts](../packages/octane/tests/compiler-vite-options.test.ts) — “changes emitted hot-update support for both hmr values” — Direct Vite integration coverage for explicit HMR, SSR-mode, and ownership booleans.
+- [packages/rspack-plugin-octane/tests/rspack.test.ts](../packages/rspack-plugin-octane/tests/rspack.test.ts) — “erases profiling and full diagnostics from a real production bundle” — Real bundle proof for the disabled profiling path; the adjacent profiled-runtime test covers the enabled path.
+- [packages/rsbuild-plugin-octane/tests/target.test.ts](../packages/rsbuild-plugin-octane/tests/target.test.ts) — “maps build.minify=false to webworker optimization” — Preserves both values of the shared app build boolean.
+- [packages/rspeedy-plugin-octane/tests/plugin.test.ts](../packages/rspeedy-plugin-octane/tests/plugin.test.ts) — “preserves an asymmetric public-boolean matrix in the installed Rspack integration” — Locks the newest public Rspack-backed adapter into an asymmetric option matrix that detects cross-wiring.
 
-**Next action (test).** Inventory public booleans and renderer mappings, then prove both enabled and disabled behavior at emitted-output or resolved-module boundaries without relying on unchecked name casts.
+**Executable evidence**
 
-Targets: `packages/octane/tests`, `packages/vite-plugin-octane/tests`, `packages/rspack-plugin-octane/tests`, `packages/rsbuild-plugin-octane/tests`.
+- [changes emitted hot-update support for both hmr values](../packages/octane/tests/compiler-vite-options.test.ts) — modes: `vite-client`; observables: `emitted-code`
+- [forces server output despite a client transform signal](../packages/octane/tests/compiler-vite-options.test.ts) — modes: `production-compile`, `vite-client`, `vite-ssr`; observables: `emitted-code`
+- [forces client output despite a server transform signal](../packages/octane/tests/compiler-vite-options.test.ts) — modes: `production-compile`, `vite-client`, `vite-ssr`; observables: `emitted-code`
+- [changes ownership of an unmarked project TSX module for both directive values](../packages/octane/tests/compiler-vite-options.test.ts) — modes: `vite-client`, `vite-ssr`; observables: `emitted-code`
+- [preserves both hmr values at the compiler output boundary](../packages/vite-plugin-octane/tests/plugin.test.ts) — modes: `vite-client`; observables: `emitted-code`
+- [preserves both requireDirective values at the compiler ownership boundary](../packages/vite-plugin-octane/tests/plugin.test.ts) — modes: `vite-client`; observables: `emitted-code`
+- [preserves build.minify=true and build.target=false in resolved Vite config](../packages/vite-plugin-octane/tests/plugin.test.ts) — modes: `production-compile`, `vite-client`; observables: `resolved-configuration`
+- [preserves build.minify=false and build.target=false in resolved Vite config](../packages/vite-plugin-octane/tests/plugin.test.ts) — modes: `production-compile`, `vite-client`; observables: `resolved-configuration`
+- [erases profiling from normal builds and installs it in profile builds](../packages/vite-plugin-octane/tests/profile-bundle.test.ts) — modes: `production-compile`, `vite-client`; observables: `bundle-contents`
+- [removes hot-update output when hmr is explicitly false in a hot compilation](../packages/rspack-plugin-octane/tests/loader.integration.test.ts) — modes: `rspack`; observables: `emitted-code`
+- [changes development metadata for both explicit dev values](../packages/rspack-plugin-octane/tests/loader.integration.test.ts) — modes: `rspack`; observables: `emitted-code`
+- [gates ownership behind requireDirective and reports forgotten pragmas](../packages/rspack-plugin-octane/tests/loader.integration.test.ts) — modes: `rspack`; observables: `emitted-code`
+- [honors explicit client mode and serializable loader options](../packages/rspack-plugin-octane/tests/plugin.test.ts) — modes: `rspack`; observables: `resolved-configuration`
+- [transpiles TypeScript only when plugin transpilation is enabled](../packages/rspack-plugin-octane/tests/rspack.test.ts) — modes: `rspack`; observables: `bundle-contents`
+- [splits client-only renderer dependencies from the raw server graph with stable module identity](../packages/rspack-plugin-octane/tests/rspack.test.ts) — modes: `rspack`; observables: `bundle-contents`, `package-resolution`
+- [erases profiling and full diagnostics from a real production bundle](../packages/rspack-plugin-octane/tests/rspack.test.ts) — modes: `rspack`, `production-compile`; observables: `bundle-contents`
+- [executes the profiled runtime](../packages/rspack-plugin-octane/tests/rspack.test.ts) — modes: `rspack`, `production-compile`; observables: `bundle-contents`
+- [preserves asymmetric public compiler booleans through custom client/server environments](../packages/rsbuild-plugin-octane/tests/renderer-config.test.ts) — modes: `rsbuild`; observables: `resolved-configuration`
+- [maps build.minify=true to webworker optimization](../packages/rsbuild-plugin-octane/tests/target.test.ts) — modes: `rsbuild`, `production-compile`; observables: `resolved-configuration`
+- [maps build.minify=false to webworker optimization](../packages/rsbuild-plugin-octane/tests/target.test.ts) — modes: `rsbuild`, `production-compile`; observables: `resolved-configuration`
+- [maps build.target=false without dropping the false-valued configuration](../packages/rsbuild-plugin-octane/tests/target.test.ts) — modes: `rsbuild`, `production-compile`; observables: `resolved-configuration`
+- [emits profiling only in the client production bundle](../packages/rsbuild-plugin-octane/tests/target.test.ts) — modes: `rsbuild`, `production-compile`; observables: `bundle-contents`
+- [preserves an asymmetric public-boolean matrix in the installed Rspack integration](../packages/rspeedy-plugin-octane/tests/plugin.test.ts) — modes: `rspeedy`; observables: `resolved-configuration`
+- [removes hot-update entries when hmr is explicitly false in development](../packages/rspeedy-plugin-octane/tests/plugin.test.ts) — modes: `rspeedy`; observables: `resolved-configuration`
+- [assembles a normal Octane application and generated receiver into a native bundle](../packages/rspeedy-plugin-octane/tests/build.test.ts) — modes: `rspeedy`; observables: `bundle-contents`, `package-resolution`
 
-**Rationale.** Redact's forwardRef and class-component flags are out of scope; the transferable lesson is to test configuration where consumers observe it.
+**Rationale.** Redact's forwardRef and class-component flags are out of scope. Octane's inventory composes adapter-level resolved-configuration checks with executable owning-compiler proofs, including real Vite/Rspack/Rsbuild/Rspeedy bundles, renderer routing, shared minification, Rspack transpilation, and the false-valued target sentinel. Diagnostic-only compiler escape hatches and unrelated runtime/server config are excluded.
 
 
 ### document-serialization
@@ -663,7 +687,7 @@ Targets: `packages/octane/tests/portal.test.ts`.
 
 #### RDX-PKG-001 — Advertised named exports are locked at the consumer boundary
 
-**Disposition:** medium risk; portable; planned; owner: Octane package surface.
+**Disposition:** medium risk; portable; covered; owner: Octane package surface.
 
 **Upstream evidence**
 
@@ -678,12 +702,16 @@ Targets: `packages/octane/tests/portal.test.ts`.
 
 **Octane references**
 
-- [packages/octane/scripts/verify-dist.mjs](../packages/octane/scripts/verify-dist.mjs) — `smokeDist` — Proves every JS entry imports, but not that a specific named export remains present.
-- [scripts/check-package-packs.mjs](../scripts/check-package-packs.mjs) — Builds isolated consumers from packed workspace artifacts.
+- [packages/octane/scripts/verify-dist.mjs](../packages/octane/scripts/verify-dist.mjs) — `REQUIRED_PUBLIC_VALUE_EXPORTS` — Defines a required subset for every published JavaScript namespace; additions remain compatible while removals fail the prepack build.
+- [scripts/check-package-packs.mjs](../scripts/check-package-packs.mjs) — Builds an isolated packed consumer that imports the JSX type-runtime and TSRX helper subpaths.
 
-**Next action (test).** Derive or explicitly declare intended named-export sets for public core subpaths and validate them from the built or packed artifact without making harmless additive exports unnecessarily brittle.
+**Executable evidence**
 
-Targets: `packages/octane/scripts/verify-dist.mjs`, `scripts/check-package-packs.mjs`.
+- [requires committed names while permitting additive exports](../packages/octane/tests/public-exports.test.ts) — modes: `production-compile`; observables: `package-resolution`
+- [publishes every subpath advertised to source consumers](../packages/octane/tests/public-exports.test.ts) — modes: `production-compile`, `packaged-consumer`; observables: `package-resolution`
+- command: `pnpm packages:pack:check` — modes: `packaged-consumer`, `production-compile`; observables: `package-resolution`
+
+**Rationale.** The audit found four source-advertised subpaths missing from the packed manifest. The package now publishes them, typechecks all four from an outside-workspace tarball consumer, executes the two value-bearing TSRX helpers there, and locks every JavaScript subpath to an additive-friendly required export subset.
 
 
 ### raw-text-hydration
@@ -1036,15 +1064,15 @@ Targets: `packages/octane/tests/portal.test.ts`, `packages/octane/tests/browser`
 
 **Octane contract.** Sibling client roots are independently namespaced, server IDs hydrate byte-for-byte, and explicit identifier prefixes compose with root-local allocation.
 
-**Applicable modes:** `client`, `server-string`, `server-stream`, `hydrate-match`, `production-compile`. **Observables:** `markup`.
+**Applicable modes:** `client`, `server-string`, `server-stream`, `hydrate-match`, `production-compile`. **Observables:** `markup`, `node-identity`.
 
 **Octane references**
 
 - [packages/octane/tests/conformance/useid-determinism.test.ts](../packages/octane/tests/conformance/useid-determinism.test.ts) — “automatically namespaces sibling createRoot roots”
-- [packages/octane/tests/conformance/useid-determinism.test.ts](../packages/octane/tests/conformance/useid-determinism.test.ts) — “server useId is preserved byte-for-byte after hydrateRoot()”
+- [packages/octane/tests/conformance/useid-determinism.test.ts](../packages/octane/tests/conformance/useid-determinism.test.ts) — “starts hydrated useId sequences from each server-rendered root”
 
 **Executable evidence**
 
 - [automatically namespaces sibling createRoot roots](../packages/octane/tests/conformance/useid-determinism.test.ts) — modes: `client`, `production-compile`; observables: `markup`
-- [server useId is preserved byte-for-byte after hydrateRoot()](../packages/octane/tests/conformance/useid-determinism.test.ts) — modes: `server-string`, `hydrate-match`, `production-compile`; observables: `markup`
-- [hydrates completed boundary useId values in its opaque stream namespace](../packages/octane/tests/streaming-ssr.test.ts) — modes: `server-stream`, `hydrate-match`, `production-compile`; observables: `markup`
+- [starts hydrated useId sequences from each server-rendered root](../packages/octane/tests/conformance/useid-determinism.test.ts) — modes: `server-string`, `hydrate-match`, `production-compile`; observables: `markup`, `node-identity`
+- [hydrates completed boundary useId values in its opaque stream namespace](../packages/octane/tests/streaming-ssr.test.ts) — modes: `server-stream`, `hydrate-match`, `production-compile`; observables: `markup`, `node-identity`

--- a/packages/octane/audit/react-conformance-ledger.json
+++ b/packages/octane/audit/react-conformance-ledger.json
@@ -61106,11 +61106,11 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “server useId is preserved byte-for-byte after hydrateRoot()” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in “starts hydrated useId sequences from each server-rendered root” covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/useid-determinism.test.ts",
-          "testName": "server useId is preserved byte-for-byte after hydrateRoot()",
+          "testName": "starts hydrated useId sequences from each server-rendered root",
           "modes": ["server-string", "hydrate-match", "production-compile"]
         }
       ]

--- a/packages/octane/audit/redact-adversarial-ledger.json
+++ b/packages/octane/audit/redact-adversarial-ledger.json
@@ -186,37 +186,204 @@
         }
       ],
       "symptom": "A documented false-valued feature flag silently left the full implementation in the bundle because an internal folder name was cast to an unrelated public option key.",
-      "octaneContract": "Every public compiler or bundler boolean must have a test proving the option changes emitted code, resolution, bundle contents, or runtime behavior in each environment where it is supported.",
+      "octaneContract": "Every public compiler or bundler boolean must be traced through each adapter's resolved host configuration and the owning compiler's emitted code, module resolution, bundle contents, or runtime behavior. Pass-through host build controls lock both values in resolved configuration; options with Octane-owned output also require an executable output or bundle proof.",
       "classification": "adaptable",
-      "status": "planned",
+      "status": "covered",
       "risk": "medium",
-      "owner": "Octane compiler and Vite/Rspack/Rsbuild integrations",
-      "applicableModes": ["production-compile", "vite-client", "vite-ssr", "rspack", "rsbuild"],
-      "observables": ["markup", "package-resolution"],
+      "owner": "Octane compiler and Vite/Rspack/Rsbuild/Rspeedy integrations",
+      "applicableModes": [
+        "production-compile",
+        "vite-client",
+        "vite-ssr",
+        "rspack",
+        "rsbuild",
+        "rspeedy"
+      ],
+      "observables": [
+        "emitted-code",
+        "resolved-configuration",
+        "bundle-contents",
+        "package-resolution"
+      ],
       "octaneReferences": [
         {
           "kind": "test",
-          "file": "packages/octane/tests/hmr.test.ts",
-          "testName": "hmr option off → no wrapping, no accept block",
-          "note": "Representative direct option-to-output coverage; not yet a complete public-option matrix."
+          "file": "packages/octane/tests/compiler-vite-options.test.ts",
+          "testName": "changes emitted hot-update support for both hmr values",
+          "note": "Direct Vite integration coverage for explicit HMR, SSR-mode, and ownership booleans."
         },
         {
           "kind": "test",
           "file": "packages/rspack-plugin-octane/tests/rspack.test.ts",
-          "testName": "erases profiling and full diagnostics from a real production bundle"
+          "testName": "erases profiling and full diagnostics from a real production bundle",
+          "note": "Real bundle proof for the disabled profiling path; the adjacent profiled-runtime test covers the enabled path."
+        },
+        {
+          "kind": "test",
+          "file": "packages/rsbuild-plugin-octane/tests/target.test.ts",
+          "testName": "maps build.minify=false to webworker optimization",
+          "note": "Preserves both values of the shared app build boolean."
+        },
+        {
+          "kind": "test",
+          "file": "packages/rspeedy-plugin-octane/tests/plugin.test.ts",
+          "testName": "preserves an asymmetric public-boolean matrix in the installed Rspack integration",
+          "note": "Locks the newest public Rspack-backed adapter into an asymmetric option matrix that detects cross-wiring."
         }
       ],
-      "nextAction": {
-        "kind": "test",
-        "targets": [
-          "packages/octane/tests",
-          "packages/vite-plugin-octane/tests",
-          "packages/rspack-plugin-octane/tests",
-          "packages/rsbuild-plugin-octane/tests"
-        ],
-        "acceptance": "Inventory public booleans and renderer mappings, then prove both enabled and disabled behavior at emitted-output or resolved-module boundaries without relying on unchecked name casts."
-      },
-      "rationale": "Redact's forwardRef and class-component flags are out of scope; the transferable lesson is to test configuration where consumers observe it."
+      "evidence": [
+        {
+          "file": "packages/octane/tests/compiler-vite-options.test.ts",
+          "testName": "changes emitted hot-update support for both hmr values",
+          "modes": ["vite-client"],
+          "observables": ["emitted-code"]
+        },
+        {
+          "file": "packages/octane/tests/compiler-vite-options.test.ts",
+          "testName": "forces server output despite a client transform signal",
+          "modes": ["production-compile", "vite-client", "vite-ssr"],
+          "observables": ["emitted-code"]
+        },
+        {
+          "file": "packages/octane/tests/compiler-vite-options.test.ts",
+          "testName": "forces client output despite a server transform signal",
+          "modes": ["production-compile", "vite-client", "vite-ssr"],
+          "observables": ["emitted-code"]
+        },
+        {
+          "file": "packages/octane/tests/compiler-vite-options.test.ts",
+          "testName": "changes ownership of an unmarked project TSX module for both directive values",
+          "modes": ["vite-client", "vite-ssr"],
+          "observables": ["emitted-code"]
+        },
+        {
+          "file": "packages/vite-plugin-octane/tests/plugin.test.ts",
+          "testName": "preserves both hmr values at the compiler output boundary",
+          "modes": ["vite-client"],
+          "observables": ["emitted-code"]
+        },
+        {
+          "file": "packages/vite-plugin-octane/tests/plugin.test.ts",
+          "testName": "preserves both requireDirective values at the compiler ownership boundary",
+          "modes": ["vite-client"],
+          "observables": ["emitted-code"]
+        },
+        {
+          "file": "packages/vite-plugin-octane/tests/plugin.test.ts",
+          "testName": "preserves build.minify=true and build.target=false in resolved Vite config",
+          "modes": ["production-compile", "vite-client"],
+          "observables": ["resolved-configuration"]
+        },
+        {
+          "file": "packages/vite-plugin-octane/tests/plugin.test.ts",
+          "testName": "preserves build.minify=false and build.target=false in resolved Vite config",
+          "modes": ["production-compile", "vite-client"],
+          "observables": ["resolved-configuration"]
+        },
+        {
+          "file": "packages/vite-plugin-octane/tests/profile-bundle.test.ts",
+          "testName": "erases profiling from normal builds and installs it in profile builds",
+          "modes": ["production-compile", "vite-client"],
+          "observables": ["bundle-contents"]
+        },
+        {
+          "file": "packages/rspack-plugin-octane/tests/loader.integration.test.ts",
+          "testName": "removes hot-update output when hmr is explicitly false in a hot compilation",
+          "modes": ["rspack"],
+          "observables": ["emitted-code"]
+        },
+        {
+          "file": "packages/rspack-plugin-octane/tests/loader.integration.test.ts",
+          "testName": "changes development metadata for both explicit dev values",
+          "modes": ["rspack"],
+          "observables": ["emitted-code"]
+        },
+        {
+          "file": "packages/rspack-plugin-octane/tests/loader.integration.test.ts",
+          "testName": "gates ownership behind requireDirective and reports forgotten pragmas",
+          "modes": ["rspack"],
+          "observables": ["emitted-code"]
+        },
+        {
+          "file": "packages/rspack-plugin-octane/tests/plugin.test.ts",
+          "testName": "honors explicit client mode and serializable loader options",
+          "modes": ["rspack"],
+          "observables": ["resolved-configuration"]
+        },
+        {
+          "file": "packages/rspack-plugin-octane/tests/rspack.test.ts",
+          "testName": "transpiles TypeScript only when plugin transpilation is enabled",
+          "modes": ["rspack"],
+          "observables": ["bundle-contents"]
+        },
+        {
+          "file": "packages/rspack-plugin-octane/tests/rspack.test.ts",
+          "testName": "splits client-only renderer dependencies from the raw server graph with stable module identity",
+          "modes": ["rspack"],
+          "observables": ["bundle-contents", "package-resolution"]
+        },
+        {
+          "file": "packages/rspack-plugin-octane/tests/rspack.test.ts",
+          "testName": "erases profiling and full diagnostics from a real production bundle",
+          "modes": ["rspack", "production-compile"],
+          "observables": ["bundle-contents"]
+        },
+        {
+          "file": "packages/rspack-plugin-octane/tests/rspack.test.ts",
+          "testName": "executes the profiled runtime",
+          "modes": ["rspack", "production-compile"],
+          "observables": ["bundle-contents"]
+        },
+        {
+          "file": "packages/rsbuild-plugin-octane/tests/renderer-config.test.ts",
+          "testName": "preserves asymmetric public compiler booleans through custom client/server environments",
+          "modes": ["rsbuild"],
+          "observables": ["resolved-configuration"]
+        },
+        {
+          "file": "packages/rsbuild-plugin-octane/tests/target.test.ts",
+          "testName": "maps build.minify=true to webworker optimization",
+          "modes": ["rsbuild", "production-compile"],
+          "observables": ["resolved-configuration"]
+        },
+        {
+          "file": "packages/rsbuild-plugin-octane/tests/target.test.ts",
+          "testName": "maps build.minify=false to webworker optimization",
+          "modes": ["rsbuild", "production-compile"],
+          "observables": ["resolved-configuration"]
+        },
+        {
+          "file": "packages/rsbuild-plugin-octane/tests/target.test.ts",
+          "testName": "maps build.target=false without dropping the false-valued configuration",
+          "modes": ["rsbuild", "production-compile"],
+          "observables": ["resolved-configuration"]
+        },
+        {
+          "file": "packages/rsbuild-plugin-octane/tests/target.test.ts",
+          "testName": "emits profiling only in the client production bundle",
+          "modes": ["rsbuild", "production-compile"],
+          "observables": ["bundle-contents"]
+        },
+        {
+          "file": "packages/rspeedy-plugin-octane/tests/plugin.test.ts",
+          "testName": "preserves an asymmetric public-boolean matrix in the installed Rspack integration",
+          "modes": ["rspeedy"],
+          "observables": ["resolved-configuration"]
+        },
+        {
+          "file": "packages/rspeedy-plugin-octane/tests/plugin.test.ts",
+          "testName": "removes hot-update entries when hmr is explicitly false in development",
+          "modes": ["rspeedy"],
+          "observables": ["resolved-configuration"]
+        },
+        {
+          "file": "packages/rspeedy-plugin-octane/tests/build.test.ts",
+          "testName": "assembles a normal Octane application and generated receiver into a native bundle",
+          "modes": ["rspeedy"],
+          "observables": ["bundle-contents", "package-resolution"]
+        }
+      ],
+      "rationale": "Redact's forwardRef and class-component flags are out of scope. Octane's inventory composes adapter-level resolved-configuration checks with executable owning-compiler proofs, including real Vite/Rspack/Rsbuild/Rspeedy bundles, renderer routing, shared minification, Rspack transpilation, and the false-valued target sentinel. Diagnostic-only compiler escape hatches and unrelated runtime/server config are excluded."
     },
     {
       "id": "RDX-DOC-001",
@@ -813,7 +980,7 @@
         "hydrate-match",
         "production-compile"
       ],
-      "observables": ["markup"],
+      "observables": ["markup", "node-identity"],
       "octaneReferences": [
         {
           "kind": "test",
@@ -823,7 +990,7 @@
         {
           "kind": "test",
           "file": "packages/octane/tests/conformance/useid-determinism.test.ts",
-          "testName": "server useId is preserved byte-for-byte after hydrateRoot()"
+          "testName": "starts hydrated useId sequences from each server-rendered root"
         }
       ],
       "evidence": [
@@ -835,15 +1002,15 @@
         },
         {
           "file": "packages/octane/tests/conformance/useid-determinism.test.ts",
-          "testName": "server useId is preserved byte-for-byte after hydrateRoot()",
+          "testName": "starts hydrated useId sequences from each server-rendered root",
           "modes": ["server-string", "hydrate-match", "production-compile"],
-          "observables": ["markup"]
+          "observables": ["markup", "node-identity"]
         },
         {
           "file": "packages/octane/tests/streaming-ssr.test.ts",
           "testName": "hydrates completed boundary useId values in its opaque stream namespace",
           "modes": ["server-stream", "hydrate-match", "production-compile"],
-          "observables": ["markup"]
+          "observables": ["markup", "node-identity"]
         }
       ]
     },
@@ -1059,7 +1226,7 @@
       "symptom": "A hook existed in source but was omitted from the package entrypoint, producing a link-time failure only in a downstream consumer.",
       "octaneContract": "Every intended value export for each public Octane subpath is checked from the built or packed artifact, so removing a re-export is an explicit review event rather than a downstream surprise.",
       "classification": "portable",
-      "status": "planned",
+      "status": "covered",
       "risk": "medium",
       "owner": "Octane package surface",
       "applicableModes": ["packaged-consumer", "production-compile"],
@@ -1068,20 +1235,36 @@
         {
           "kind": "source",
           "file": "packages/octane/scripts/verify-dist.mjs",
-          "symbol": "smokeDist",
-          "note": "Proves every JS entry imports, but not that a specific named export remains present."
+          "symbol": "REQUIRED_PUBLIC_VALUE_EXPORTS",
+          "note": "Defines a required subset for every published JavaScript namespace; additions remain compatible while removals fail the prepack build."
         },
         {
           "kind": "integration",
           "file": "scripts/check-package-packs.mjs",
-          "note": "Builds isolated consumers from packed workspace artifacts."
+          "note": "Builds an isolated packed consumer that imports the JSX type-runtime and TSRX helper subpaths."
         }
       ],
-      "nextAction": {
-        "kind": "test",
-        "targets": ["packages/octane/scripts/verify-dist.mjs", "scripts/check-package-packs.mjs"],
-        "acceptance": "Derive or explicitly declare intended named-export sets for public core subpaths and validate them from the built or packed artifact without making harmless additive exports unnecessarily brittle."
-      }
+      "evidence": [
+        {
+          "file": "packages/octane/tests/public-exports.test.ts",
+          "testName": "requires committed names while permitting additive exports",
+          "modes": ["production-compile"],
+          "observables": ["package-resolution"]
+        },
+        {
+          "file": "packages/octane/tests/public-exports.test.ts",
+          "testName": "publishes every subpath advertised to source consumers",
+          "modes": ["production-compile", "packaged-consumer"],
+          "observables": ["package-resolution"]
+        },
+        {
+          "kind": "command",
+          "script": "packages:pack:check",
+          "modes": ["packaged-consumer", "production-compile"],
+          "observables": ["package-resolution"]
+        }
+      ],
+      "rationale": "The audit found four source-advertised subpaths missing from the packed manifest. The package now publishes them, typechecks all four from an outside-workspace tarball consumer, executes the two value-bearing TSRX helpers there, and locks every JavaScript subpath to an additive-friendly required export subset."
     },
     {
       "id": "RDX-PKG-002",

--- a/packages/octane/audit/redact-adversarial-ledger.schema.json
+++ b/packages/octane/audit/redact-adversarial-ledger.schema.json
@@ -329,6 +329,7 @@
         "vite-ssr",
         "rspack",
         "rsbuild",
+        "rspeedy",
         "benchmark"
       ]
     },
@@ -346,7 +347,10 @@
         "events",
         "errors",
         "streaming",
+        "emitted-code",
         "package-resolution",
+        "resolved-configuration",
+        "bundle-contents",
         "performance"
       ]
     },

--- a/packages/octane/package.json
+++ b/packages/octane/package.json
@@ -58,6 +58,20 @@
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
       },
+      "./jsx-runtime": {
+        "types": "./dist/jsx-runtime.d.ts"
+      },
+      "./jsx-dev-runtime": {
+        "types": "./dist/jsx-runtime.d.ts"
+      },
+      "./tsrx-iterable": {
+        "types": "./dist/tsrx-iterable.d.ts",
+        "default": "./dist/tsrx-iterable.js"
+      },
+      "./tsrx-spread": {
+        "types": "./dist/tsrx-spread.d.ts",
+        "default": "./dist/tsrx-spread.js"
+      },
       "./react": {
         "types": "./dist/react/index.d.ts",
         "default": "./dist/react/index.js"

--- a/packages/octane/scripts/build.mjs
+++ b/packages/octane/scripts/build.mjs
@@ -53,8 +53,10 @@ await build({
 
 cpSync(join(src, 'compiler'), join(dist, 'compiler'), { recursive: true });
 // Hand-written declarations for the plain-JS dom-tables module (tsc only emits
-// declarations for the .ts sources).
+// declarations for the .ts sources). The JSX runtime is likewise a type-only
+// input declaration: compiled Octane JSX never imports a runtime module.
 cpSync(join(src, 'dom-tables.d.ts'), join(dist, 'dom-tables.d.ts'));
+cpSync(join(src, 'jsx-runtime.d.ts'), join(dist, 'jsx-runtime.d.ts'));
 
 execFileSync(join(root, 'node_modules/.bin/tsc'), ['-p', join(pkgDir, 'tsconfig.build.json')], {
 	stdio: 'inherit',

--- a/packages/octane/scripts/verify-dist.mjs
+++ b/packages/octane/scripts/verify-dist.mjs
@@ -12,23 +12,588 @@ import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-function publishedExportTargets(pkgDir) {
-	const pkg = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8'));
-	const targets = new Set();
-	for (const value of Object.values(pkg.publishConfig.exports)) {
-		if (typeof value === 'string') targets.add(value);
-		else for (const path of Object.values(value)) targets.add(path);
+// Required-subset contract for the package's public JavaScript namespaces.
+// Additive exports are intentionally harmless; removing one of these names is
+// a consumer-visible compatibility event and must update this list explicitly.
+export const REQUIRED_PUBLIC_VALUE_EXPORTS = {
+	'.': [
+		'Activity',
+		'Children',
+		'EXTERNAL_HYDRATION_PROMISE',
+		'ErrorBoundary',
+		'Fragment',
+		'FragmentInstance',
+		'HMR',
+		'HYDRATION_RANGE_BOUNDARY',
+		'Hydrate',
+		'Suspense',
+		'TsrxErrorBoundary',
+		'ViewTransition',
+		'ViewTransitionPseudoElement',
+		'__createVoidRoot',
+		'__s',
+		'__serverRpc',
+		'__useReducerWithGetter',
+		'__useStateWithGetter',
+		'__vtSeen',
+		'act',
+		'activityBlock',
+		'addTransitionType',
+		'attachRef',
+		'bag0',
+		'bag1',
+		'bag10',
+		'bag11',
+		'bag12',
+		'bag13',
+		'bag14',
+		'bag15',
+		'bag16',
+		'bag2',
+		'bag3',
+		'bag4',
+		'bag5',
+		'bag6',
+		'bag7',
+		'bag8',
+		'bag9',
+		'bagOf',
+		'bindRendererRegionOwner',
+		'child',
+		'childSlot',
+		'childTextHole',
+		'clone',
+		'cloneElement',
+		'compilerCacheContext',
+		'componentSlot',
+		'componentSlotLite',
+		'componentSlotVoid',
+		'createContext',
+		'createElement',
+		'createHostContextRequest',
+		'createPortal',
+		'createRoot',
+		'delegateCaptureEvents',
+		'delegateEvents',
+		'devEventListener',
+		'drainFrag',
+		'drainPassiveEffects',
+		'evt0',
+		'evt0u',
+		'evt1',
+		'evt1u',
+		'evt2',
+		'evt2u',
+		'evtN',
+		'evtNu',
+		'flushSync',
+		'forBlock',
+		'getTransitionFallbackTimeout',
+		'hasPendingWork',
+		'headBlock',
+		'hmr',
+		'hookSlots',
+		'hostComponent',
+		'htext',
+		'htextSwap',
+		'hydrateRoot',
+		'ifBlock',
+		'initializeHydrationEventCapture',
+		'injectStyle',
+		'isChildrenBlock',
+		'isValidElement',
+		'lazy',
+		'markChildrenBlock',
+		'markDangerouslySetInnerHTMLChildren',
+		'markNativeChangeDiagnosticStatic',
+		'markSingleRoot',
+		'memo',
+		'mountFragmentRef',
+		'namespaceHead',
+		'namespaceHeadElement',
+		'normalizeClass',
+		'portal',
+		'positionalChildren',
+		'preconnect',
+		'prefetchDNS',
+		'preinit',
+		'preload',
+		'provideContext',
+		'puMiss',
+		'puPub',
+		'puTake0',
+		'puTake1',
+		'puTake2',
+		'puTake3',
+		'puTake4',
+		'queueNativeChangeDiagnostic',
+		'queueRefAttach',
+		'queueRefDetach',
+		'renderBlock',
+		'requestFormReset',
+		'setAriaAttribute',
+		'setAttribute',
+		'setAutoFocus',
+		'setBooleanAttribute',
+		'setChecked',
+		'setCheckedCheckable',
+		'setClassAttr',
+		'setClassName',
+		'setDangerouslySetInnerHTML',
+		'setDangerouslySetInnerHTMLSources',
+		'setDefaultChecked',
+		'setDefaultValue',
+		'setDefaultValueUncontrolled',
+		'setFormAction',
+		'setFormControlSources',
+		'setHTML',
+		'setHostPropSources',
+		'setIsOctaneActEnvironment',
+		'setScriptText',
+		'setSelectValue',
+		'setSpread',
+		'setStringData',
+		'setStyle',
+		'setText',
+		'setTransitionFallbackTimeout',
+		'setValue',
+		'sibling',
+		'snapshotSpread',
+		'startTransition',
+		'switchBlock',
+		'template',
+		'textHole',
+		'textSlot',
+		'tryBlock',
+		'unstable_ViewTransition',
+		'unstable_addTransitionType',
+		'use',
+		'useActionState',
+		'useBatch',
+		'useCallback',
+		'useContext',
+		'useDebugValue',
+		'useDeferredValue',
+		'useEffect',
+		'useEffectEvent',
+		'useFormStatus',
+		'useId',
+		'useImperativeHandle',
+		'useInsertionEffect',
+		'useLayoutEffect',
+		'useMemo',
+		'useOptimistic',
+		'useReducer',
+		'useRef',
+		'useState',
+		'useSyncExternalStore',
+		'useTransition',
+		'version',
+		'warmChild',
+		'warmMemo',
+		'withSlot',
+	],
+	'./react': ['OctaneCompat', '__hostContextFiberWalks'],
+	'./hydration': [
+		'condition',
+		'idle',
+		'initializeHydrationEventCapture',
+		'interaction',
+		'load',
+		'media',
+		'never',
+		'visible',
+	],
+	'./react/server': ['OctaneCompat'],
+	'./server': [
+		'Activity',
+		'Children',
+		'EXTERNAL_HYDRATION_PROMISE',
+		'ErrorBoundary',
+		'Fragment',
+		'HYDRATION_RANGE_BOUNDARY',
+		'Hydrate',
+		'Suspense',
+		'ViewTransition',
+		'__useReducerWithGetter',
+		'__useStateWithGetter',
+		'addTransitionType',
+		'cloneElement',
+		'createContext',
+		'createElement',
+		'createPortal',
+		'escapeAttr',
+		'escapeHtml',
+		'executeServerFunction',
+		'flushSync',
+		'getSsrSuspenseTimeout',
+		'hookSlots',
+		'injectStyle',
+		'isChildrenBlock',
+		'isValidElement',
+		'lazy',
+		'markChildrenBlock',
+		'memo',
+		'namespaceHead',
+		'namespaceHeadElement',
+		'normalizeClass',
+		'positionalChildren',
+		'preconnect',
+		'prefetchDNS',
+		'preinit',
+		'preload',
+		'puBatch',
+		'puMemo',
+		'renderToPipeableStream',
+		'renderToReadableStream',
+		'renderToStaticMarkup',
+		'renderToString',
+		'requestFormReset',
+		'setSsrSuspenseTimeout',
+		'ssrActivity',
+		'ssrArm',
+		'ssrAttr',
+		'ssrAttrs',
+		'ssrBlock',
+		'ssrCheckedAttr',
+		'ssrChild',
+		'ssrChildText',
+		'ssrChildrenSources',
+		'ssrClass',
+		'ssrComponent',
+		'ssrComponentNS',
+		'ssrControl',
+		'ssrElement',
+		'ssrForBlock',
+		'ssrHeadEl',
+		'ssrInNamespace',
+		'ssrInnerHtml',
+		'ssrInputAttrs',
+		'ssrIsSuspense',
+		'ssrOption',
+		'ssrOptionValueSources',
+		'ssrPortal',
+		'ssrScriptInnerHtml',
+		'ssrSelectAttrs',
+		'ssrSelectScope',
+		'ssrSelectScopeSources',
+		'ssrSnapshotSpread',
+		'ssrSpread',
+		'ssrStyle',
+		'ssrText',
+		'ssrTextPre',
+		'ssrTextareaValue',
+		'ssrTextareaValueSources',
+		'ssrTry',
+		'ssrValueAttr',
+		'ssrVoidContent',
+		'startTransition',
+		'unstable_ViewTransition',
+		'unstable_addTransitionType',
+		'use',
+		'useActionState',
+		'useCallback',
+		'useContext',
+		'useDebugValue',
+		'useDeferredValue',
+		'useEffect',
+		'useEffectEvent',
+		'useFormStatus',
+		'useId',
+		'useImperativeHandle',
+		'useInsertionEffect',
+		'useLayoutEffect',
+		'useMemo',
+		'useOptimistic',
+		'useReducer',
+		'useRef',
+		'useState',
+		'useSyncExternalStore',
+		'useTransition',
+		'warmChild',
+		'warmMemo',
+		'withSlot',
+	],
+	'./static': ['prerender'],
+	'./constants': [
+		'ATTRIBUTE_ALIASES',
+		'BLOCK_CLOSE',
+		'BLOCK_OPEN',
+		'BOOLEAN_ATTR_PROPS',
+		'EMPTY_COMMENT',
+		'EXTERNAL_HYDRATION_PROMISE',
+		'FOR_BLOCK_OPEN_EMPTY',
+		'FOR_BLOCK_OPEN_ITEMS',
+		'HYDRATE_ID_ATTR',
+		'HYDRATE_ID_COUNT_ATTR',
+		'HYDRATE_SEED_ATTR',
+		'HYDRATE_STATIC_END',
+		'HYDRATE_STATIC_ID_COUNT_PREFIX',
+		'HYDRATE_STREAM_TOKEN_ATTR',
+		'HYDRATE_WHEN_ATTR',
+		'HYDRATION_END',
+		'HYDRATION_FOR_EMPTY',
+		'HYDRATION_FOR_ITEMS',
+		'HYDRATION_RANGE_BOUNDARY',
+		'HYDRATION_START',
+		'HYDRATION_TEXT_SEP',
+		'MUST_USE_PROPERTY_PROPS',
+		'POSITIVE_NUMERIC_ATTR_PROPS',
+		'REJECTION_SENTINEL_KEY',
+		'STREAM_BOUNDARY_ATTR',
+		'STREAM_SCRIPT_ATTR',
+		'STREAM_SEED_ATTR',
+		'STREAM_SEED_COMMENT',
+		'STREAM_SEGMENT_ATTR',
+		'SUSPENSE_SCRIPT_ATTR',
+		'SUSPENSE_SEED_WIRE_PREFIX',
+		'SVG_ONLY_TAGS',
+		'UNDEFINED_SENTINEL_KEY',
+		'VALID_ATTR_NAME',
+		'VOID_ELEMENTS',
+		'cssStyleValue',
+		'isEnumeratedBooleanAttr',
+		'isUnitlessStyleProp',
+	],
+	'./profiling': [
+		'__profileBail',
+		'__profileBeginRender',
+		'__profileComponent',
+		'__profileComponentSource',
+		'__profileEndRender',
+		'__profileHasComponentMetadata',
+		'__profileHook',
+		'__profileResolveHook',
+		'__profileSchedule',
+		'__profileTrackComponent',
+		'profiler',
+	],
+	'./universal': [
+		'Activity',
+		'UNIVERSAL_HMR',
+		'UNIVERSAL_TRANSPORT_PROTOCOL_VERSION',
+		'__useReducerWithGetter',
+		'__useStateWithGetter',
+		'createContext',
+		'createObjectContainer',
+		'createObjectDriver',
+		'createPortal',
+		'createUniversalHostBoundary',
+		'createUniversalRoot',
+		'defineUniversalComponent',
+		'flushUniversalAct',
+		'flushUniversalSync',
+		'hmrUniversalComponent',
+		'hookSlots',
+		'isRendererRegion',
+		'lazy',
+		'memo',
+		'rendererRegion',
+		'requestFormReset',
+		'startTransition',
+		'universalActivity',
+		'universalChildren',
+		'universalComponent',
+		'universalContext',
+		'universalFor',
+		'universalIf',
+		'universalKey',
+		'universalList',
+		'universalPlan',
+		'universalProps',
+		'universalSwitch',
+		'universalTry',
+		'universalValue',
+		'use',
+		'useActionState',
+		'useBatch',
+		'useCallback',
+		'useContext',
+		'useDebugValue',
+		'useDeferredValue',
+		'useEffect',
+		'useEffectEvent',
+		'useFormStatus',
+		'useId',
+		'useImperativeHandle',
+		'useInsertionEffect',
+		'useLayoutEffect',
+		'useMemo',
+		'useOptimistic',
+		'useReducer',
+		'useRef',
+		'useState',
+		'useSyncExternalStore',
+		'useTransition',
+		'warmChild',
+		'warmMemo',
+		'withSlot',
+	],
+	'./universal/native': [
+		'Activity',
+		'UNIVERSAL_HMR',
+		'UNIVERSAL_TRANSPORT_PROTOCOL_VERSION',
+		'__useReducerWithGetter',
+		'__useStateWithGetter',
+		'createContext',
+		'createObjectContainer',
+		'createObjectDriver',
+		'createPortal',
+		'createUniversalRoot',
+		'defineUniversalComponent',
+		'flushUniversalAct',
+		'flushUniversalSync',
+		'hmrUniversalComponent',
+		'hookSlots',
+		'isRendererRegion',
+		'lazy',
+		'memo',
+		'rendererRegion',
+		'requestFormReset',
+		'startTransition',
+		'universalActivity',
+		'universalChildren',
+		'universalComponent',
+		'universalContext',
+		'universalFor',
+		'universalIf',
+		'universalKey',
+		'universalList',
+		'universalPlan',
+		'universalProps',
+		'universalSwitch',
+		'universalTry',
+		'universalValue',
+		'use',
+		'useActionState',
+		'useBatch',
+		'useCallback',
+		'useContext',
+		'useDebugValue',
+		'useDeferredValue',
+		'useEffect',
+		'useEffectEvent',
+		'useFormStatus',
+		'useId',
+		'useImperativeHandle',
+		'useInsertionEffect',
+		'useLayoutEffect',
+		'useMemo',
+		'useOptimistic',
+		'useReducer',
+		'useRef',
+		'useState',
+		'useSyncExternalStore',
+		'useTransition',
+		'warmChild',
+		'warmMemo',
+		'withSlot',
+	],
+	'./compiler': ['__analyzeNativeChangeDiagnostics', 'compile', 'compileToVolarMappings', 'octane'],
+	'./compiler/bundler': [
+		'CLIENT_REFERENCE_MANIFEST_FILENAME',
+		'CLIENT_REFERENCE_MANIFEST_VERSION',
+		'DOM_RENDERER_ID',
+		'DOM_RENDERER_MODULE',
+		'HYDRATE_QUERY_PARAM',
+		'OCTANE_RUNTIME_REQUESTS',
+		'RENDERER_CONFIG_VERSION',
+		'canonicalModuleId',
+		'cleanModuleId',
+		'createClientReferenceManifest',
+		'createOctaneCompiler',
+		'discoverOctaneSourceDependencies',
+		'findVoidComponentExports',
+		'findVoidComponentImports',
+		'findVoidRootImports',
+		'normalizeRendererConfig',
+		'resolveOctaneRuntimeRequest',
+		'resolveRendererForFile',
+	],
+	'./compiler/renderers': [
+		'DOM_RENDERER_ID',
+		'DOM_RENDERER_MODULE',
+		'RENDERER_CONFIG_VERSION',
+		'normalizeRendererConfig',
+		'resolveRendererForFile',
+	],
+	'./compiler/vite': ['discoverOctaneSourceDependencies', 'octane'],
+	'./compiler/volar': ['compileToVolarMappings'],
+	'./tsrx-iterable': ['map_iterable'],
+	'./tsrx-spread': ['normalize_spread_props', 'normalize_spread_props_for_ref_attr'],
+};
+
+function readPackage(pkgDir) {
+	return JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8'));
+}
+
+function collectExportTargets(value, targets) {
+	if (typeof value === 'string') {
+		targets.add(value);
+		return;
 	}
+	if (Array.isArray(value)) {
+		for (const item of value) collectExportTargets(item, targets);
+		return;
+	}
+	if (value && typeof value === 'object') {
+		for (const item of Object.values(value)) collectExportTargets(item, targets);
+	}
+}
+
+function publishedExportTargets(pkg) {
+	const targets = new Set();
+	for (const value of Object.values(pkg.publishConfig.exports))
+		collectExportTargets(value, targets);
 	return [...targets];
 }
 
+export function publishedRuntimeEntries(publishedExports) {
+	return Object.entries(publishedExports).flatMap(([subpath, value]) => {
+		const targets = new Set();
+		collectExportTargets(value, targets);
+		return [...targets]
+			.filter((target) => /\.(?:c|m)?js$/.test(target))
+			.map((target) => [subpath, target]);
+	});
+}
+
+export function missingRequiredPublicValueExports(subpath, actualNames) {
+	const actual = new Set(actualNames);
+	return (REQUIRED_PUBLIC_VALUE_EXPORTS[subpath] ?? []).filter((name) => !actual.has(name));
+}
+
+export function assertRequiredPublicValueExports(subpath, actualNames) {
+	const missing = missingRequiredPublicValueExports(subpath, actualNames);
+	if (missing.length > 0) {
+		throw new Error(`${subpath} omitted required named exports: ${missing.join(', ')}`);
+	}
+}
+
+export function missingPublishedPublicSubpaths(advertisedExports, publishedExports) {
+	const publishedSubpaths = new Set(Object.keys(publishedExports));
+	return Object.keys(advertisedExports).filter((subpath) => !publishedSubpaths.has(subpath));
+}
+
 export async function verifyDist(pkgDir) {
+	const pkg = readPackage(pkgDir);
 	const dist = join(pkgDir, 'dist');
+
+	// Development consumes the source export map, while pnpm replaces it with
+	// publishConfig.exports in the tarball. Every advertised source subpath must
+	// therefore survive that replacement.
+	const missingSubpaths = missingPublishedPublicSubpaths(pkg.exports, pkg.publishConfig.exports);
+	if (missingSubpaths.length > 0) {
+		throw new Error(
+			`octane dist verify: source exports omitted from publishConfig.exports:\n` +
+				missingSubpaths.map((subpath) => `  ${subpath}`).join('\n'),
+		);
+	}
 
 	// Every publishConfig export target must exist. A missing entry module is a
 	// root that nothing else imports, so the import walk below cannot see it —
 	// this is exactly how the missing static/index.ts shipped unnoticed.
-	const missing = publishedExportTargets(pkgDir).filter((p) => !existsSync(join(pkgDir, p)));
+	const missing = publishedExportTargets(pkg).filter((p) => !existsSync(join(pkgDir, p)));
 	if (missing.length > 0) {
 		throw new Error(
 			`octane dist verify: publishConfig.exports targets missing from the build:\n` +
@@ -69,19 +634,52 @@ export async function verifyDist(pkgDir) {
 // resolution a consumer gets, catching anything static analysis can't (a module
 // that throws at init, a bad package.json attribute import, …).
 export function smokeDist(pkgDir) {
-	const entries = publishedExportTargets(pkgDir).filter((p) => p.endsWith('.js'));
-	for (const entry of entries) {
+	const pkg = readPackage(pkgDir);
+	const entries = publishedRuntimeEntries(pkg.publishConfig.exports);
+	const runtimeSubpaths = new Set(entries.map(([subpath]) => subpath));
+	const missingContracts = [...runtimeSubpaths].filter(
+		(subpath) => REQUIRED_PUBLIC_VALUE_EXPORTS[subpath] === undefined,
+	);
+	const unpublishedContracts = Object.keys(REQUIRED_PUBLIC_VALUE_EXPORTS).filter(
+		(subpath) => !runtimeSubpaths.has(subpath),
+	);
+	if (missingContracts.length > 0 || unpublishedContracts.length > 0) {
+		throw new Error(
+			`octane dist verify: public value-export contract is out of sync:\n` +
+				[
+					...missingContracts.map((subpath) => `  missing contract for ${subpath}`),
+					...unpublishedContracts.map(
+						(subpath) => `  contract has no published JS entry ${subpath}`,
+					),
+				].join('\n'),
+		);
+	}
+
+	for (const [subpath, entry] of entries) {
 		const url = pathToFileURL(join(pkgDir, entry)).href;
 		// Let Node exit naturally. This is also the published-runtime regression
 		// guard: importing an entry must not allocate a channel, timer, listener, or
 		// other host resource that keeps an otherwise-idle consumer alive.
-		execFileSync(
-			process.execPath,
-			['--input-type=module', '-e', `await import(${JSON.stringify(url)});`],
-			{ stdio: ['ignore', 'ignore', 'inherit'], cwd: pkgDir, timeout: 10_000 },
+		const exportedNames = JSON.parse(
+			execFileSync(
+				process.execPath,
+				[
+					'--input-type=module',
+					'-e',
+					`const namespace = await import(${JSON.stringify(url)});
+process.stdout.write(JSON.stringify(Object.keys(namespace)));`,
+				],
+				{
+					encoding: 'utf8',
+					stdio: ['ignore', 'pipe', 'inherit'],
+					cwd: pkgDir,
+					timeout: 10_000,
+				},
+			),
 		);
+		assertRequiredPublicValueExports(subpath, exportedNames);
 	}
-	return entries;
+	return entries.map(([, entry]) => entry);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/packages/octane/tests/_fixtures/useid-determinism.tsrx
+++ b/packages/octane/tests/_fixtures/useid-determinism.tsrx
@@ -26,6 +26,7 @@ export function Triple(props) @{
 	const a = useId();
 	const b = useId();
 	const c = useId();
+	props?.onIds?.([a, b, c]);
 	const [n, setN] = useState(0);
 	<div>
 		<span id="a" data-testid={a}>{a as string}</span>

--- a/packages/octane/tests/compiler-vite-options.test.ts
+++ b/packages/octane/tests/compiler-vite-options.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment node
+
+import { describe, expect, it } from 'vitest';
+import type { Plugin } from 'vite';
+import { octane } from 'octane/compiler/vite';
+
+const ROOT = '/project';
+const SOURCE = "export function App() @{ <main>{'configured'}</main> }\n";
+const STATEFUL_SOURCE =
+	"import { useState } from 'octane';\n" +
+	'export function App() @{\n' +
+	'\tconst [count] = useState(0);\n' +
+	'\t<main>{count as string}</main>\n' +
+	'}\n';
+
+function configure(plugin: Plugin, command: 'serve' | 'build', build: { ssr?: boolean } = {}) {
+	(plugin.config as (config: { root: string }) => unknown)({ root: ROOT });
+	(plugin.configResolved as (config: unknown) => void)({
+		root: ROOT,
+		command,
+		build,
+		define: {},
+	});
+}
+
+async function transform(
+	plugin: Plugin,
+	source = SOURCE,
+	id = `${ROOT}/src/App.tsrx`,
+	options?: { ssr?: boolean },
+) {
+	return (
+		plugin.transform as (source: string, id: string, options?: { ssr?: boolean }) => unknown
+	).call({}, source, id, options) as Promise<{ code: string } | null> | { code: string } | null;
+}
+
+describe('octane/compiler/vite public options', () => {
+	it('changes emitted hot-update support for both hmr values', async () => {
+		const enabled = octane({ hmr: true });
+		const disabled = octane({ hmr: false });
+		configure(enabled, 'serve');
+		configure(disabled, 'serve');
+
+		const enabledOutput = await transform(enabled);
+		const disabledOutput = await transform(disabled);
+
+		expect(enabledOutput?.code).toContain('import.meta.hot');
+		expect(disabledOutput?.code).not.toContain('import.meta.hot');
+	});
+
+	it('forces server output despite a client transform signal', async () => {
+		const plugin = octane({ hmr: false, ssr: true });
+		configure(plugin, 'build', { ssr: false });
+
+		const output = await transform(plugin, STATEFUL_SOURCE, `${ROOT}/src/App.tsrx`, {
+			ssr: false,
+		});
+
+		expect(output?.code).toMatch(/from ["']octane\/server["']/);
+	});
+
+	it('forces client output despite a server transform signal', async () => {
+		const plugin = octane({ hmr: false, ssr: false });
+		configure(plugin, 'build', { ssr: true });
+
+		const output = await transform(plugin, STATEFUL_SOURCE, `${ROOT}/src/App.tsrx`, {
+			ssr: true,
+		});
+
+		expect(output?.code).not.toMatch(/from ["']octane\/server["']/);
+	});
+
+	it('changes ownership of an unmarked project TSX module for both directive values', async () => {
+		const source = "export function App() @{ <main>{'owned'}</main> }\n";
+		for (const ssr of [false, true]) {
+			for (const options of [{}, { requireDirective: false }] as const) {
+				const plugin = octane({ hmr: false, ...options });
+				configure(plugin, 'build', { ssr });
+				expect(await transform(plugin, source, `${ROOT}/src/App.tsx`, { ssr })).not.toBeNull();
+			}
+
+			const gated = octane({ hmr: false, requireDirective: true });
+			configure(gated, 'build', { ssr });
+			expect(await transform(gated, source, `${ROOT}/src/App.tsx`, { ssr })).toBeNull();
+		}
+	});
+});

--- a/packages/octane/tests/conformance/useid-determinism.test.ts
+++ b/packages/octane/tests/conformance/useid-determinism.test.ts
@@ -132,40 +132,70 @@ describe('useId determinism', () => {
 		rootB.unmount();
 	});
 
-	// Per ReactDOMUseId-test.js:127/140-146 — the WHOLE point of useId is that the
-	// id produced on the server matches the id produced on the client so the two
-	// trees hydrateRoot without mismatch. We server-render Single, place its HTML in a
-	// container, then hydrateRoot the SAME component and capture the id the CLIENT
-	// actually computed during the hydration render (via the fixture's onId
-	// callback — reading the adopted attribute alone would just echo the server's
-	// id and prove nothing). The two must be byte-for-byte equal.
-	//
-	it('server useId is preserved byte-for-byte after hydrateRoot()', async () => {
-		// Warm a separate root first: root-local hydration state must be unaffected.
-		const warm = mount(Triple);
-		warm.unmount();
-
-		const out = await RT.renderToString(serverMod.Single, undefined, {
-			identifierPrefix: 'profile-',
-		});
-		const serverId = out.html.match(/data-testid="([^"]+)"/)?.[1];
-
+	// Per ReactDOMUseId-test.js:127/140-146 — each server-rendered root starts an
+	// independent useId sequence, and hydration must compute the same id without
+	// replacing the server DOM. Keep the first hydrated root alive while hydrating
+	// the second so allocations from one root cannot leak into the next.
+	it('starts hydrated useId sequences from each server-rendered root', async () => {
+		const options = { identifierPrefix: 'profile-' };
+		const warmContainer = document.createElement('div');
 		const container = document.createElement('div');
-		container.innerHTML = out.html;
-		document.body.appendChild(container);
+		let warmRoot: ReturnType<typeof hydrateRoot> | undefined;
+		let root: ReturnType<typeof hydrateRoot> | undefined;
+		try {
+			const warmOut = await RT.renderToString(serverMod.Triple, undefined, options);
+			const warmServerIds = [...warmOut.html.matchAll(/data-testid="([^"]+)"/g)].map(
+				(match) => match[1],
+			);
+			warmContainer.innerHTML = warmOut.html;
+			document.body.appendChild(warmContainer);
+			const warmOriginalSpans = [...warmContainer.querySelectorAll('span')];
 
-		let clientId: string | undefined;
-		const h = hydrateRoot(
-			container,
-			Single,
-			{ onId: (id: string) => (clientId = id) },
-			{ identifierPrefix: 'profile-' },
-		);
-		h.unmount();
-		container.remove();
+			let warmClientIds: string[] | undefined;
+			warmRoot = hydrateRoot(
+				warmContainer,
+				Triple,
+				{ onIds: (ids: string[]) => (warmClientIds = ids) },
+				options,
+			);
 
-		expect(serverId).toBeTruthy();
-		expect(serverId).toBe(':profile-in-0:');
-		expect(clientId).toBe(serverId);
+			const out = await RT.renderToString(serverMod.Triple, undefined, options);
+			const serverIds = [...out.html.matchAll(/data-testid="([^"]+)"/g)].map((match) => match[1]);
+			container.innerHTML = out.html;
+			document.body.appendChild(container);
+			const originalSpans = [...container.querySelectorAll('span')];
+			const originalButton = container.querySelector('button');
+
+			let clientIds: string[] | undefined;
+			root = hydrateRoot(
+				container,
+				Triple,
+				{ onIds: (ids: string[]) => (clientIds = ids) },
+				options,
+			);
+
+			const expectedIds = [':profile-in-0:', ':profile-in-1:', ':profile-in-2:'];
+			expect(warmServerIds).toEqual(expectedIds);
+			expect(warmClientIds).toEqual(expectedIds);
+			const warmCurrentSpans = [...warmContainer.querySelectorAll('span')];
+			expect(warmCurrentSpans).toHaveLength(warmOriginalSpans.length);
+			for (let i = 0; i < warmCurrentSpans.length; i++) {
+				expect(warmCurrentSpans[i]).toBe(warmOriginalSpans[i]);
+			}
+			expect(serverIds).toEqual(expectedIds);
+			expect(clientIds).toEqual(expectedIds);
+			const currentSpans = [...container.querySelectorAll('span')];
+			expect(currentSpans).toHaveLength(originalSpans.length);
+			for (let i = 0; i < currentSpans.length; i++) {
+				expect(currentSpans[i]).toBe(originalSpans[i]);
+			}
+			expect(originalButton).not.toBeNull();
+			expect(container.querySelector('button')).toBe(originalButton);
+		} finally {
+			root?.unmount();
+			warmRoot?.unmount();
+			container.remove();
+			warmContainer.remove();
+		}
 	});
 });

--- a/packages/octane/tests/public-exports.test.ts
+++ b/packages/octane/tests/public-exports.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+	assertRequiredPublicValueExports,
+	missingPublishedPublicSubpaths,
+	publishedRuntimeEntries,
+	REQUIRED_PUBLIC_VALUE_EXPORTS,
+} from '../scripts/verify-dist.mjs';
+
+describe('published package export contract', () => {
+	it('requires committed names while permitting additive exports', () => {
+		const required = REQUIRED_PUBLIC_VALUE_EXPORTS['./static'];
+
+		expect(() =>
+			assertRequiredPublicValueExports('./static', [...required, 'futureExport']),
+		).not.toThrow();
+		expect(() => assertRequiredPublicValueExports('./static', ['futureExport'])).toThrow(
+			'./static omitted required named exports: prerender',
+		);
+	});
+
+	it('checks every JavaScript branch of conditional exports', () => {
+		const entries = publishedRuntimeEntries({
+			'./feature': {
+				types: './dist/feature.d.ts',
+				import: {
+					node: './dist/feature-node.mjs',
+					default: './dist/feature.js',
+				},
+				require: ['./dist/feature.cjs', null],
+			},
+		});
+
+		expect(entries).toHaveLength(3);
+		expect(entries).toEqual(
+			expect.arrayContaining([
+				['./feature', './dist/feature-node.mjs'],
+				['./feature', './dist/feature.js'],
+				['./feature', './dist/feature.cjs'],
+			]),
+		);
+	});
+
+	it('publishes every subpath advertised to source consumers', () => {
+		expect(
+			missingPublishedPublicSubpaths(
+				{ '.': './src/index.ts', './helper': './src/helper.ts' },
+				{ '.': './dist/index.js' },
+			),
+		).toEqual(['./helper']);
+
+		const manifest = JSON.parse(
+			readFileSync(join(import.meta.dirname, '..', 'package.json'), 'utf8'),
+		) as {
+			exports: Record<string, unknown>;
+			publishConfig: { exports: Record<string, unknown> };
+		};
+
+		expect(
+			missingPublishedPublicSubpaths(manifest.exports, manifest.publishConfig.exports),
+		).toEqual([]);
+	});
+});

--- a/packages/rsbuild-plugin-octane/tests/renderer-config.test.ts
+++ b/packages/rsbuild-plugin-octane/tests/renderer-config.test.ts
@@ -70,6 +70,51 @@ describe('Rsbuild renderer configuration', () => {
 		rmSync(root, { recursive: true, force: true });
 	});
 
+	it('preserves asymmetric public compiler booleans through custom client/server environments', async () => {
+		writeProject(root, true);
+		for (const compilerOptions of [
+			{ hmr: true, profile: false, requireDirective: false },
+			{ hmr: false, profile: true, requireDirective: false },
+			{ hmr: false, profile: false, requireDirective: true },
+		]) {
+			const instance = await createRsbuild({
+				cwd: root,
+				rsbuildConfig: {
+					plugins: [
+						pluginOctane({
+							clientEnvironment: 'browser',
+							serverEnvironment: 'ssr',
+							...compilerOptions,
+						}),
+					],
+				},
+			});
+			const configs = await instance.initConfigs({ action: 'build' });
+			const pluginsByConfig = new Map(
+				configs.map((config) => [
+					config.name,
+					(config.plugins ?? []).find(
+						(plugin): plugin is OctaneRspackPlugin => plugin instanceof OctaneRspackPlugin,
+					),
+				]),
+			);
+
+			expect([...pluginsByConfig.keys()]).toEqual(expect.arrayContaining(['browser', 'ssr']));
+			expect(pluginsByConfig.get('browser')?.options).toMatchObject({
+				environment: 'client',
+				...compilerOptions,
+				transpile: false,
+			});
+			expect(pluginsByConfig.get('ssr')?.options).toMatchObject({
+				environment: 'server',
+				hmr: compilerOptions.hmr,
+				profile: false,
+				requireDirective: compilerOptions.requireDirective,
+				transpile: false,
+			});
+		}
+	});
+
 	it.each([
 		['compiler-only', false],
 		['routed app', true],

--- a/packages/rsbuild-plugin-octane/tests/rsbuild.integration.test.ts
+++ b/packages/rsbuild-plugin-octane/tests/rsbuild.integration.test.ts
@@ -422,6 +422,8 @@ export function App() @{
 		const serverRoot = join(root, 'build/server');
 		const clientCode = readJavaScript(clientRoot);
 		const serverCode = readJavaScript(serverRoot);
+		expect(clientCode).not.toContain('/src/Page.tsrx#Page');
+		expect(serverCode).not.toContain('/src/Page.tsrx#Page');
 		expect(existsSync(join(clientRoot, 'index.html'))).toBe(false);
 		expect(existsSync(join(serverRoot, 'entry.js'))).toBe(true);
 		expect(existsSync(join(serverRoot, 'index.html'))).toBe(true);

--- a/packages/rsbuild-plugin-octane/tests/target.test.ts
+++ b/packages/rsbuild-plugin-octane/tests/target.test.ts
@@ -146,6 +146,22 @@ describe('Rsbuild build.target mapping', () => {
 		);
 	});
 
+	it('maps build.target=false without dropping the false-valued configuration', async () => {
+		writeApp(root, 'false');
+		const instance = await createRsbuild({
+			cwd: root,
+			rsbuildConfig: { plugins: [pluginOctane({ hmr: false })] },
+		});
+		const configs = await instance.initConfigs({ action: 'build' });
+
+		expect(configs.map((config) => config.target)).toEqual(
+			expect.arrayContaining([
+				['web', 'es2024'],
+				['node', 'es2024'],
+			]),
+		);
+	});
+
 	it('emits an importable Cloudflare Worker entry only in production', async () => {
 		writeApp(root, JSON.stringify('es2022'), 'cloudflare');
 		const production = await createRsbuild({
@@ -192,7 +208,7 @@ describe('Rsbuild build.target mapping', () => {
 		).toBe(true);
 	}, 120_000);
 
-	it.each([true, false])('honors build.minify=%s for webworker output', async (minify) => {
+	it.each([true, false])('maps build.minify=%s to webworker optimization', async (minify) => {
 		writeApp(root, JSON.stringify('es2022'), 'webworker', minify);
 		const instance = await createRsbuild({
 			cwd: root,

--- a/packages/rspack-plugin-octane/tests/loader.integration.test.ts
+++ b/packages/rspack-plugin-octane/tests/loader.integration.test.ts
@@ -98,6 +98,43 @@ describe('loader with the neutral compiler', () => {
 		});
 	});
 
+	it('removes hot-update output when hmr is explicitly false in a hot compilation', () => {
+		const source = `export function App() @{ <button>ready</button> }\n`;
+		const resourcePath = write(root, 'src/HmrDisabled.tsrx', source);
+		const result = transform({
+			root,
+			resourcePath,
+			source,
+			hot: true,
+			options: { hmr: false },
+		});
+
+		expect(String(result.content)).not.toContain('import.meta.webpackHot');
+		expect(getOctaneRspackBuildInfo(result.module)?.transformKind).toBe('compile');
+	});
+
+	it('changes development metadata for both explicit dev values', () => {
+		const source = `export function App(props) @{
+	<main>@if (props.ready) { <span>ready</span> }</main>
+}\n`;
+		const resourcePath = write(root, 'src/DevMetadata.tsrx', source);
+		const enabled = transform({
+			root,
+			resourcePath,
+			source,
+			options: { dev: true, hmr: false },
+		});
+		const disabled = transform({
+			root,
+			resourcePath,
+			source,
+			options: { dev: false, hmr: false },
+		});
+
+		expect(String(enabled.content)).toContain('DevMetadata.tsrx');
+		expect(String(disabled.content)).not.toContain('DevMetadata.tsrx');
+	});
+
 	it('selects server codegen from a node target', async () => {
 		const resourcePath = write(root, 'src/App.tsrx', `export function App() @{ <p>server</p> }\n`);
 		const result = transform({
@@ -171,6 +208,25 @@ describe('loader with the neutral compiler', () => {
 			"/** @jsxImportSource octane */\nexport function Badge() @{ <p>{'badge'}</p> }";
 		const hookSource =
 			"import { useState } from 'octane';\nexport function useCount() { return useState(0); }\n";
+		const unmarkedOctaneSource = "export function Owned() @{ <p>{'owned'}</p> }\n";
+
+		// The same unmarked project source is compiled when the gate is disabled
+		// and left to the host toolchain when it is enabled.
+		const ungated = transform({
+			root,
+			resourcePath: write(root, 'src/Ungated.tsx', unmarkedOctaneSource),
+			source: unmarkedOctaneSource,
+			options: { requireDirective: false },
+		});
+		expect(getOctaneRspackBuildInfo(ungated.module)?.transformKind).toBe('compile');
+		const gated = transform({
+			root,
+			resourcePath: write(root, 'src/Gated.tsx', unmarkedOctaneSource),
+			source: unmarkedOctaneSource,
+			options,
+		});
+		expect(gated.content).toBe(unmarkedOctaneSource);
+		expect(getOctaneRspackBuildInfo(gated.module)).toBeNull();
 
 		// An unmarked project .tsx belongs to the host toolchain: untouched,
 		// no Octane build metadata.

--- a/packages/rspack-plugin-octane/tests/rspack.test.ts
+++ b/packages/rspack-plugin-octane/tests/rspack.test.ts
@@ -18,6 +18,7 @@ const repositoryRoot = resolve(fileURLToPath(new URL('../../..', import.meta.url
 const profilerGlobal = '__OCTANE_PROFILER__';
 const runGlobal = '__octane_rspack_profile_bundle_runs__';
 const productionErrorGlobal = '__octane_rspack_production_error__';
+const transpileGlobal = '__octane_rspack_transpiled_value__';
 
 function write(root: string, relativePath: string, content: string) {
 	const file = join(root, relativePath);
@@ -184,6 +185,7 @@ export function App() @{
 		Reflect.deleteProperty(globalThis, profilerGlobal);
 		Reflect.deleteProperty(globalThis, runGlobal);
 		Reflect.deleteProperty(globalThis, productionErrorGlobal);
+		Reflect.deleteProperty(globalThis, transpileGlobal);
 		rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 	});
 
@@ -273,6 +275,33 @@ ${includeRawBinding ? "export { Raw } from '@fixture/raw';" : ''}
 				true,
 			);
 		}
+	}, 30_000);
+
+	it('transpiles TypeScript only when plugin transpilation is enabled', async () => {
+		write(
+			root,
+			'src/typed-entry.ts',
+			`const value: number = 42;\nglobalThis.${transpileGlobal} = value;\n`,
+		);
+		const build = async (transpile: boolean) => {
+			const outputPath = join(root, `dist-transpile-${transpile}`);
+			await compile({
+				context: root,
+				mode: 'development',
+				target: 'node',
+				entry: './src/typed-entry.ts',
+				optimization: { minimize: false },
+				output: { path: outputPath, filename: 'bundle.cjs' },
+				plugins: [new OctaneRspackPlugin({ transpile })],
+			});
+			return join(outputPath, 'bundle.cjs');
+		};
+
+		const enabled = await build(true);
+		await import(`${pathToFileURL(enabled).href}?enabled`);
+		expect((globalThis as any)[transpileGlobal]).toBe(42);
+
+		await expect(build(false)).rejects.toThrow();
 	}, 30_000);
 
 	it('builds one source with layer-specific compiler and runtime identities', async () => {

--- a/packages/rspeedy-plugin-octane/tests/plugin.test.ts
+++ b/packages/rspeedy-plugin-octane/tests/plugin.test.ts
@@ -195,6 +195,10 @@ interface CompilerRendererOptions {
 
 function compilerOptions(state: ReturnType<typeof createChain>) {
 	return state.plugins.get('@octanejs/rspeedy-plugin:compiler')?.options[0] as {
+		dev?: boolean;
+		hmr?: boolean;
+		profile?: boolean;
+		requireDirective?: boolean;
 		runtime: string;
 		universalRuntime: unknown;
 		layerSpecializations?: Record<
@@ -243,6 +247,22 @@ afterEach(() => {
 });
 
 describe('@octanejs/rspeedy-plugin', () => {
+	it('preserves an asymmetric public-boolean matrix in the installed Rspack integration', () => {
+		for (const optionSignature of [
+			{ dev: true, hmr: false, profile: false, requireDirective: false },
+			{ dev: false, hmr: true, profile: false, requireDirective: false },
+			{ dev: false, hmr: false, profile: true, requireDirective: false },
+			{ dev: false, hmr: false, profile: false, requireDirective: true },
+		]) {
+			const state = applyPlugin({
+				thread: 'background',
+				...optionSignature,
+			});
+
+			expect(compilerOptions(state)).toMatchObject(optionSignature);
+		}
+	});
+
 	it('enforces application output invariants without discarding user configuration', () => {
 		const root = createToolchainRoot();
 		const callbacks: EnvironmentConfigCallback[] = [];
@@ -394,6 +414,25 @@ describe('@octanejs/rspeedy-plugin', () => {
 		expect(JSON.stringify([...state.entries.values()])).not.toMatch(
 			/@lynx-js\/react|react-refresh/i,
 		);
+	});
+
+	it('removes hot-update entries when hmr is explicitly false in development', () => {
+		const state = applyPlugin(
+			{ hmr: false },
+			'lynx',
+			{
+				environment: { config: { dev: { hmr: true, liveReload: true } } },
+				isDev: true,
+				isProd: false,
+			},
+			{ app: ['./src/setup.js', './src/App.lynx.tsrx'] },
+		);
+
+		const entryImports = JSON.stringify([...state.entries.values()]);
+		expect(entryImports).toContain('@lynx-js/webpack-dev-transport/client');
+		expect(entryImports).not.toContain('@rspack/core/hot/dev-server');
+		expect(entryImports).not.toContain('hotModuleReplacement.lepus.cjs');
+		expect(compilerOptions(state).hmr).toBe(false);
 	});
 
 	it('replaces only main-layer imports of the exact Lynx package root', () => {

--- a/packages/vite-plugin-octane/tests/plugin.test.ts
+++ b/packages/vite-plugin-octane/tests/plugin.test.ts
@@ -166,6 +166,92 @@ describe('octane() plugin factory', () => {
 		expect(transform.call({}, code, '/repo/src/useThing.ts')).not.toBeNull();
 	});
 
+	it('preserves both hmr values at the compiler output boundary', async () => {
+		const source = "export function App() @{ <main>{'configured'}</main> }\n";
+		for (const [hmr, expectsHotOutput] of [
+			[true, true],
+			[false, false],
+		] as const) {
+			const [compiler] = octane({ hmr });
+			await (compiler.config as (config: { root: string }) => unknown)({ root: '/repo' });
+			(compiler.configResolved as (config: unknown) => void)({
+				root: '/repo',
+				command: 'serve',
+				build: {},
+				define: {},
+			});
+			const output = await (
+				compiler.transform as (source: string, id: string) => Promise<{ code: string }>
+			).call({}, source, '/repo/src/App.tsrx');
+
+			expect(output.code.includes('import.meta.hot')).toBe(expectsHotOutput);
+		}
+	});
+
+	it('preserves both requireDirective values at the compiler ownership boundary', async () => {
+		const source = "export function App() @{ <main>{'configured'}</main> }\n";
+		for (const [requireDirective, expectsCompilation] of [
+			[false, true],
+			[true, false],
+		] as const) {
+			const [compiler] = octane({ hmr: false, requireDirective });
+			await (compiler.config as (config: { root: string }) => unknown)({ root: '/repo' });
+			const output = await (
+				compiler.transform as (
+					source: string,
+					id: string,
+				) => Promise<{ code: string } | null> | { code: string } | null
+			).call({}, source, '/repo/src/App.tsx');
+
+			expect(output !== null).toBe(expectsCompilation);
+		}
+	});
+
+	it.each([true, false])(
+		'preserves build.minify=%s and build.target=false in resolved Vite config',
+		async (minify) => {
+			const root = await mkdtemp(join(tmpdir(), 'octane-vite-build-booleans-'));
+			try {
+				await writeFile(
+					join(root, 'package.json'),
+					JSON.stringify({ private: true, type: 'module' }) + '\n',
+				);
+				await mkdir(join(root, 'src'), { recursive: true });
+				await writeFile(
+					join(root, 'index.html'),
+					'<head><!--ssr-head--></head><body><div id="root"><!--ssr-body--></div></body>\n',
+				);
+				await writeFile(
+					join(root, 'src/Page.tsrx'),
+					"export function Page() @{ <main>{'ready'}</main> }\n",
+				);
+				await mkdir(join(root, 'node_modules/@octanejs'), { recursive: true });
+				await symlink(PKG_ROOT, join(root, 'node_modules/@octanejs/vite-plugin'), 'dir');
+				await writeFile(
+					join(root, 'octane.config.ts'),
+					`import { RenderRoute } from '@octanejs/vite-plugin';
+export default {
+	build: { minify: ${minify}, target: false },
+	router: { routes: [new RenderRoute({ path: '/', entry: '/src/Page.tsrx' })] },
+};
+`,
+				);
+
+				const [, meta] = octane();
+				const resolved = await (
+					meta.config as (
+						config: UserConfig,
+						env: { command: 'build'; mode: string },
+					) => Promise<UserConfig>
+				)({ root }, { command: 'build', mode: 'production' });
+
+				expect(resolved.build).toMatchObject({ minify, target: false });
+			} finally {
+				await rm(root, { recursive: true, force: true });
+			}
+		},
+	);
+
 	it('forwards inline renderer rules to the bundled compiler', () => {
 		const [compiler] = octane({
 			hmr: false,

--- a/scripts/check-package-packs.mjs
+++ b/scripts/check-package-packs.mjs
@@ -26,6 +26,10 @@ import {
 	renderPackedExampleWorkspace,
 } from './package-pack-canaries.mjs';
 import { LYNX_TOOLCHAIN_LANES } from '../packages/rspeedy-plugin-octane/src/toolchain-lanes.js';
+import {
+	assertRequiredPublicValueExports,
+	REQUIRED_PUBLIC_VALUE_EXPORTS,
+} from '../packages/octane/scripts/verify-dist.mjs';
 
 const privatePackScaffolds = new Set(['@octanejs/lynx', '@octanejs/rspeedy-plugin']);
 const packages = getWorkspacePackages().filter(
@@ -125,6 +129,14 @@ function validatePackedPackage(pkg, manifest, files) {
 	}
 
 	if (!manifest.exports) errors.push('package.json has no exports field');
+	if (pkg.name === 'octane' && manifest.exports) {
+		const packedSubpaths = new Set(Object.keys(manifest.exports));
+		for (const subpath of Object.keys(pkg.manifest.exports)) {
+			if (!packedSubpaths.has(subpath)) {
+				errors.push(`packed exports omit advertised source subpath ${JSON.stringify(subpath)}`);
+			}
+		}
+	}
 	if (manifest.engines?.node !== '>=22') {
 		errors.push(
 			`packed engines.node is ${JSON.stringify(manifest.engines?.node)}, expected ">=22"`,
@@ -415,27 +427,43 @@ import * as coreApi from '@octanejs/three/core';
 import * as rendererApi from '@octanejs/three/renderer';
 import config, { threeRenderers } from '@octanejs/three/config';
 import testing, { create, fireEvent } from '@octanejs/three/testing';
+import { map_iterable } from 'octane/tsrx-iterable';
+import {
+	normalize_spread_props,
+	normalize_spread_props_for_ref_attr,
+} from 'octane/tsrx-spread';
+import type { JSX as OctaneRuntimeJSX } from 'octane/jsx-runtime';
+import type { JSX as OctaneDevRuntimeJSX } from 'octane/jsx-dev-runtime';
 import type { JSX as IntrinsicJSX } from '@octanejs/three/intrinsics';
 import type { JSX as RuntimeJSX } from '@octanejs/three/intrinsics/jsx-runtime';
 import type { ReconcilerRoot, ThreeElements } from '@octanejs/three';
 
+type OctaneRuntimeDiv = OctaneRuntimeJSX.IntrinsicElements['div'];
+type OctaneDevRuntimeDiv = OctaneDevRuntimeJSX.IntrinsicElements['div'];
 type IntrinsicMesh = IntrinsicJSX.IntrinsicElements['mesh'];
 type RuntimeMesh = RuntimeJSX.IntrinsicElements['mesh'];
 type RootMesh = ThreeElements['mesh'];
 
+const octaneRuntimeDiv: OctaneRuntimeDiv = {};
+const octaneDevRuntimeDiv: OctaneDevRuntimeDiv = octaneRuntimeDiv;
 const intrinsicMesh: IntrinsicMesh = { position: [1, 2, 3] };
 const runtimeMesh: RuntimeMesh = intrinsicMesh;
 const rootMesh: RootMesh = runtimeMesh;
 const reconcilerRoot: ReconcilerRoot<HTMLCanvasElement> | undefined = undefined;
 
 export function packageSurfaceProbe() {
+	void octaneDevRuntimeDiv;
 	void rootMesh;
 	void reconcilerRoot;
 	return {
 		config: config === threeRenderers,
 		core: typeof coreApi.createRoot === 'function',
+		iterable: typeof map_iterable === 'function',
 		publicApi: typeof publicApi.Canvas === 'function',
 		renderer: typeof rendererApi.createUniversalRoot === 'function',
+		spread:
+			typeof normalize_spread_props === 'function' &&
+			typeof normalize_spread_props_for_ref_attr === 'function',
 		testing: testing.create === create && typeof fireEvent === 'function',
 	};
 }
@@ -523,6 +551,36 @@ export function renderProbe() {
 
 	const consumerRequire = createRequire(path.join(consumerDirectory, 'package.json'));
 	const directRuntime = realpathSync(consumerRequire.resolve('octane'));
+	// Resolve through real ESM package specifiers from the installed consumer,
+	// not a CommonJS-resolved file URL, so conditional `import` branches remain
+	// part of the packed contract. React-hosted entries require their intentionally
+	// optional React peer and remain covered by the package build's fresh imports.
+	const packedRuntimeSpecifiers = Object.keys(REQUIRED_PUBLIC_VALUE_EXPORTS)
+		.filter((subpath) => subpath !== './react' && subpath !== './react/server')
+		.map((subpath) => [subpath, subpath === '.' ? 'octane' : `octane/${subpath.slice(2)}`]);
+	const packedRuntimeExports = JSON.parse(
+		execFileSync(
+			process.execPath,
+			[
+				'--input-type=module',
+				'-e',
+				`const result = Object.create(null);
+for (const specifier of ${JSON.stringify(packedRuntimeSpecifiers.map(([, specifier]) => specifier))}) {
+	result[specifier] = Object.keys(await import(specifier));
+}
+process.stdout.write(JSON.stringify(result));`,
+			],
+			{
+				cwd: consumerDirectory,
+				encoding: 'utf8',
+				stdio: ['ignore', 'pipe', 'inherit'],
+				timeout: 30_000,
+			},
+		),
+	);
+	for (const [subpath, specifier] of packedRuntimeSpecifiers) {
+		assertRequiredPublicValueExports(subpath, packedRuntimeExports[specifier]);
+	}
 	const bindingEntry = consumerRequire.resolve('@octanejs/hook-form');
 	const peerRuntime = realpathSync(createRequire(bindingEntry).resolve('octane'));
 	if (peerRuntime !== directRuntime) {

--- a/scripts/redact-audit/ledger-lib.mjs
+++ b/scripts/redact-audit/ledger-lib.mjs
@@ -29,6 +29,7 @@ export const MODES = [
 	'vite-ssr',
 	'rspack',
 	'rsbuild',
+	'rspeedy',
 	'benchmark',
 ];
 export const OBSERVABLES = [
@@ -44,7 +45,10 @@ export const OBSERVABLES = [
 	'events',
 	'errors',
 	'streaming',
+	'emitted-code',
 	'package-resolution',
+	'resolved-configuration',
+	'bundle-contents',
 	'performance',
 ];
 


### PR DESCRIPTION
## Summary

- restore the published `octane/jsx-runtime`, `octane/jsx-dev-runtime`, `octane/tsrx-iterable`, and `octane/tsrx-spread` subpaths, then lock every public JavaScript entry to an additive-friendly required-export contract across conditional branches and packed ESM consumption
- exercise public compiler/bundler booleans through Vite, Rspack, Rsbuild, and Rspeedy with asymmetric adapter matrices plus emitted-code, real bundle, and runtime evidence
- strengthen sequential SSR/hydration `useId` coverage with exact prefixed sequences and strict server-node adoption checks
- mark the corresponding Redact adversity contracts covered and add a patch changeset for `octane`

## Validation

- `pnpm test` — 1,308 files / 12,790 tests passed
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm packages:pack:check` — 49 tarballs plus external package consumers passed
- `pnpm redact-audit:check`
- `pnpm --dir packages/octane build`
- focused Octane dev/prod, Rspack, Rsbuild, Rspeedy, and Vite suites

## Performance

This changes package metadata/build verification and test/audit coverage only; it does not change a shipped runtime/compiler hot path, so no runtime benchmark delta is expected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are packaging, build verification, tests, and audit docs—no runtime or compiler hot-path behavior changes; risk is mainly release-surface and CI contract maintenance.
> 
> **Overview**
> **Locks Octane’s published package surface and bundler/compiler contracts** so downstream consumers and adapters cannot silently regress.
> 
> The `octane` package again publishes **`jsx-runtime`**, **`jsx-dev-runtime`**, **`tsrx-iterable`**, and **`tsrx-spread`** in `publishConfig.exports`, copies JSX type declarations into `dist`, and extends **`verify-dist.mjs`** with **`REQUIRED_PUBLIC_VALUE_EXPORTS`**: every published JS entry is smoke-imported and checked for a committed required named-export subset (additive exports stay allowed). **`packages:pack:check`** and **`public-exports.test.ts`** assert source vs packed subpath parity and packed ESM resolution.
> 
> **Public compiler/bundler booleans** get asymmetric matrix tests across **Vite**, **Rspack**, **Rsbuild**, and **Rspeedy** (HMR, `requireDirective`, SSR mode, `dev`, profiling, transpilation, `build.minify`/`target`), with observables on emitted code, resolved config, and real bundle contents. Redact ledger entries **RDX-CFG-001** and **RDX-PKG-001** move to **covered**; audit schema gains **`rspeedy`** and observables like **`emitted-code`**, **`resolved-configuration`**, **`bundle-contents`**.
> 
> **`useId` hydration** coverage is tightened: sequential multi-root SSR/hydration asserts prefixed ID sequences, client IDs match server, and **original server DOM nodes** are adopted (not replaced). A patch **changeset** records the `octane` release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aaccc99274bbbef5cf320ee20cdc0ffb9a995e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->