### PR TITLE
fix(octane): harden hydration ownership and event replay

### DIFF
--- a/.changeset/fair-events-replay.md
+++ b/.changeset/fair-events-replay.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Preserve keyboard, pointer, focus, and mouse event subclasses and metadata when deferred hydration replays interaction intent, including roots owned by another document realm.

--- a/.changeset/steady-hydration-ownership.md
+++ b/.changeset/steady-hydration-ownership.md
@@ -1,0 +1,6 @@
+---
+'octane': patch
+---
+
+Make hoisted head ownership module-, tag-, and root-aware, and reject malformed
+marker intervals without claiming unrelated server metadata.

--- a/docs/redact-adversarial-audit.md
+++ b/docs/redact-adversarial-audit.md
@@ -249,9 +249,10 @@ This is the explicit artifact sample reviewed at the pinned snapshot; broad sour
 
 **Octane references**
 
-- [packages/octane/src/runtime.ts](../packages/octane/src/runtime.ts) — `cloneHydrationReplayEvent` — Clones every public event family with its realm-specific platform constructor; pointer detection precedes mouse detection.
+- [packages/octane/src/runtime.ts](../packages/octane/src/runtime.ts) — `cloneHydrationReplayEvent` — Clones every public event family with the target realm's platform constructor, falling back to the Web IDL brand when instanceof cannot cross realms; pointer detection precedes mouse detection.
 - [packages/octane/tests/hydration/deferred-hydration-contract.test.ts](../packages/octane/tests/hydration/deferred-hydration-contract.test.ts) — “replays every public interaction event once with its platform shape and queue semantics” — An exhaustive type-level-locked matrix covers all 15 public interaction events in development and production compilation.
 - [packages/octane/tests/hydration/deferred-hydration-contract.test.ts](../packages/octane/tests/hydration/deferred-hydration-contract.test.ts) — “classifies parent-realm events before replaying them in an iframe realm” — Parent-created focus, keyboard, mouse, and pointer events replay with the iframe target's constructors and retain their metadata.
+- [packages/octane/tests/hydration/deferred-hydration-contract.test.ts](../packages/octane/tests/hydration/deferred-hydration-contract.test.ts) — “classifies iframe-realm events before replaying them at a host-document target” — The opposite realm crossing: an embedded widget's own events replay with the host document's constructors, proving the clone follows the target rather than the incoming event.
 - [packages/octane/tests/browser/deferred-hydration-event-replay/deferred-hydration-event-replay.test.ts](../packages/octane/tests/browser/deferred-hydration-event-replay/deferred-hydration-event-replay.test.ts) — “preserves every public event family, metadata, order, target, and cancellation” — Real Chromium proves platform subclasses, metadata, FIFO delivery, original target, default cancellation, and one queue drain.
 
 **Executable evidence**

--- a/docs/redact-adversarial-audit.md
+++ b/docs/redact-adversarial-audit.md
@@ -58,9 +58,9 @@ This is the explicit artifact sample reviewed at the pinned snapshot; broad sour
 
 | Status | Entries |
 | --- | ---: |
-| planned | 6 |
+| planned | 2 |
 | in progress | 0 |
-| covered | 17 |
+| covered | 21 |
 | documented | 5 |
 | decision required | 1 |
 | blocked | 0 |
@@ -76,10 +76,6 @@ This is the explicit artifact sample reviewed at the pinned snapshot; broad sour
 
 | ID | Risk | Area | Contract | Status | Owner |
 | --- | --- | --- | --- | --- | --- |
-| [`RDX-EVT-002`](#rdx-evt-002) | high | event-replay | Hydration event replay preserves platform event shape and queue semantics | planned | Octane deferred hydration and DOM events |
-| [`RDX-HYD-003`](#rdx-hyd-003) | high | raw-text-hydration | Raw script and style hydration must use their parsing contexts | planned | Octane DOM hydration and SSR serialization |
-| [`RDX-HYD-006`](#rdx-hyd-006) | high | hydration-recovery | Mismatch recovery is bounded to the failed ownership scope | planned | Octane hydration cursor and ownership ranges |
-| [`RDX-HYD-007`](#rdx-hyd-007) | high | head-hydration | Head ownership keys are unique across compiled modules and tags | planned | Octane compiler and runtime head hydration |
 | [`RDX-PORT-002`](#rdx-port-002) | high | portal-updates | A stateful portal descendant resolves its foreign host for owned updates | planned | Octane portal host resolution |
 | [`RDX-REC-002`](#rdx-rec-002) | high | reconciliation-placement | Topology transitions use the correct absolute anchor without stable reattachment | planned | Octane reconciler and portal placement |
 | [`RDX-HYD-005`](#rdx-hyd-005) | medium | hydration-errors | Hydration recovery reporting has an explicit public contract | decision required | Octane public root API |
@@ -239,7 +235,7 @@ This is the explicit artifact sample reviewed at the pinned snapshot; broad sour
 
 #### RDX-EVT-002 — Hydration event replay preserves platform event shape and queue semantics
 
-**Disposition:** high risk; adaptable; planned; owner: Octane deferred hydration and DOM events.
+**Disposition:** high risk; adaptable; covered; owner: Octane deferred hydration and DOM events.
 
 **Upstream evidence**
 
@@ -253,14 +249,17 @@ This is the explicit artifact sample reviewed at the pinned snapshot; broad sour
 
 **Octane references**
 
-- [packages/octane/src/runtime.ts](../packages/octane/src/runtime.ts) — `notifyHydrateBoundary` — Mouse and focus families retain subclasses; other buffered families currently fall back to Event.
-- [packages/octane/tests/streaming-ssr.test.ts](../packages/octane/tests/streaming-ssr.test.ts) — “replays pre-root interaction after the pending stream reveals” — Covers click delivery and target survival, not the cross-family event-shape matrix.
+- [packages/octane/src/runtime.ts](../packages/octane/src/runtime.ts) — `cloneHydrationReplayEvent` — Clones every public event family with its realm-specific platform constructor; pointer detection precedes mouse detection.
+- [packages/octane/tests/hydration/deferred-hydration-contract.test.ts](../packages/octane/tests/hydration/deferred-hydration-contract.test.ts) — “replays every public interaction event once with its platform shape and queue semantics” — An exhaustive type-level-locked matrix covers all 15 public interaction events in development and production compilation.
+- [packages/octane/tests/hydration/deferred-hydration-contract.test.ts](../packages/octane/tests/hydration/deferred-hydration-contract.test.ts) — “classifies parent-realm events before replaying them in an iframe realm” — Parent-created focus, keyboard, mouse, and pointer events replay with the iframe target's constructors and retain their metadata.
+- [packages/octane/tests/browser/deferred-hydration-event-replay/deferred-hydration-event-replay.test.ts](../packages/octane/tests/browser/deferred-hydration-event-replay/deferred-hydration-event-replay.test.ts) — “preserves every public event family, metadata, order, target, and cancellation” — Real Chromium proves platform subclasses, metadata, FIFO delivery, original target, default cancellation, and one queue drain.
 
-**Next action (test).** Exercise every public HydrationInteractionEvent family in a real browser: click/auxclick/contextmenu/dblclick, focusin, keydown/keyup, mouse, and pointer events. Assert subclass, supported metadata, target, FIFO ordering, preventDefault visibility, queue drain, and no duplicate replay; keep input/change/submit excluded unless a separate API decision expands the public union.
+**Executable evidence**
 
-Targets: `packages/octane/tests/hydration/deferred-hydration-contract.test.ts`, `packages/octane/tests/browser`.
+- [replays every public interaction event once with its platform shape and queue semantics](../packages/octane/tests/hydration/deferred-hydration-contract.test.ts) — modes: `deferred-hydration`; observables: `events`
+- [preserves every public event family, metadata, order, target, and cancellation](../packages/octane/tests/browser/deferred-hydration-event-replay/deferred-hydration-event-replay.test.ts) — modes: `deferred-hydration`, `real-browser`; observables: `events`
 
-**Rationale.** Octane replays interaction intent rather than cloning every native event field, so the transferable contract must explicitly define which event shape it promises instead of silently copying Redact's implementation.
+**Rationale.** Octane continues to replay only its documented interaction-intent union. The clone is now realm-aware and constructor-specific, while exhaustive unit and Chromium evidence lock every public family to its supported platform metadata and exactly-once FIFO semantics.
 
 
 ### events
@@ -342,30 +341,30 @@ Targets: `packages/octane/tests/hydration/deferred-hydration-contract.test.ts`, 
 
 **Consumer-visible symptom.** Weak head-node identity allowed one logical head entry to adopt a different server node and validate or update the wrong content.
 
-**Octane contract.** Within a matching head-marker interval, hydration adopts only an element with the expected tag. It preserves interposed wrong-tag nodes and, when no expected-tag candidate exists before the next Octane marker, creates the expected node without claiming unrelated head content.
+**Octane contract.** Within a valid paired head-ownership interval, hydration adopts only an element with the expected tag. It preserves interposed wrong-tag nodes and, when no expected-tag candidate exists before the matching closing marker, creates the expected node without claiming unrelated head content.
 
 **Applicable modes:** `server-string`, `hydrate-match`, `hydrate-mismatch`, `production-compile`. **Observables:** `markup`, `node-identity`, `dom-mutations`.
 
 **Octane references**
 
-- [packages/octane/src/runtime.ts](../packages/octane/src/runtime.ts) — `adoptServerHeadEl` — Claims only a matching tag inside the ownership interval closed by the next Octane head marker.
-- [packages/octane/tests/hydration/head-hydrate.test.ts](../packages/octane/tests/hydration/head-hydrate.test.ts) — “adopts the server head (one &lt;title&gt;/&lt;meta&gt;, markers removed) + single-root body, removed on unmount” — Happy-path adoption and lifecycle ownership.
+- [packages/octane/src/runtime.ts](../packages/octane/src/runtime.ts) — `adoptServerHeadEl` — Claims only a matching tag inside a valid interval closed by that entry's paired ownership marker.
+- [packages/octane/tests/hydration/head-hydrate.test.ts](../packages/octane/tests/hydration/head-hydrate.test.ts) — “adopts the server head and single-root body, then removes owned nodes on unmount” — Happy-path adoption and lifecycle ownership.
 - [packages/octane/tests/hydration/head-hydrate.test.ts](../packages/octane/tests/hydration/head-hydrate.test.ts) — “skips an interposed foreign element and adopts the intended head element”
 - [packages/octane/tests/hydration/head-hydrate.test.ts](../packages/octane/tests/hydration/head-hydrate.test.ts) — “creates a missing expected head element without claiming a wrong-tag neighbor”
 
 **Executable evidence**
 
-- [adopts the server head (one &lt;title&gt;/&lt;meta&gt;, markers removed) + single-root body, removed on unmount](../packages/octane/tests/hydration/head-hydrate.test.ts) — modes: `server-string`, `hydrate-match`, `production-compile`; observables: `markup`, `node-identity`, `dom-mutations`
+- [adopts the server head and single-root body, then removes owned nodes on unmount](../packages/octane/tests/hydration/head-hydrate.test.ts) — modes: `server-string`, `hydrate-match`, `production-compile`; observables: `markup`, `node-identity`, `dom-mutations`
 - [skips an interposed foreign element and adopts the intended head element](../packages/octane/tests/hydration/head-hydrate.test.ts) — modes: `server-string`, `hydrate-mismatch`, `production-compile`; observables: `markup`, `node-identity`, `dom-mutations`
 - [creates a missing expected head element without claiming a wrong-tag neighbor](../packages/octane/tests/hydration/head-hydrate.test.ts) — modes: `server-string`, `hydrate-mismatch`, `production-compile`; observables: `markup`, `node-identity`, `dom-mutations`
 
-**Rationale.** Redact matches scripts by attributes while Octane uses compiler markers, so the transferable contract is ownership-safe claiming rather than Redact's matcher. This closes wrong-tag and missing-target corruption within one marker interval. Compiler key uniqueness and ambiguous same-tag collisions remain explicitly tracked by RDX-HYD-007.
+**Rationale.** Redact matches scripts by attributes while Octane uses compiler markers, so the transferable contract is ownership-safe claiming rather than Redact's matcher. This closes wrong-tag and missing-target corruption within one paired ownership interval. Compiler key uniqueness and ambiguous same-tag collisions remain explicitly tracked by RDX-HYD-007.
 
 <a id="rdx-hyd-007"></a>
 
 #### RDX-HYD-007 — Head ownership keys are unique across compiled modules and tags
 
-**Disposition:** high risk; adaptable; planned; owner: Octane compiler and runtime head hydration.
+**Disposition:** high risk; adaptable; covered; owner: Octane compiler and runtime head hydration.
 
 **Upstream evidence**
 
@@ -374,20 +373,29 @@ Targets: `packages/octane/tests/hydration/deferred-hydration-contract.test.ts`, 
 
 **Consumer-visible symptom.** A marker derived only from a source offset can collide across modules or tags, making same-tag ownership ambiguous even when runtime claiming validates the element tag.
 
-**Octane contract.** Compiler-emitted head ownership keys are stable between server and client builds and collision-resistant across modules, tags, and multiple roots; duplicate, reordered, or missing markers cannot make one logical entry claim another same-tag element.
+**Octane contract.** Compiler-emitted head ownership keys are stable between server and client builds and collision-resistant across modules and tags; the existing distinct identifierPrefix contract isolates sibling roots. Duplicate, reordered, or missing marker pairs cannot make one logical entry claim another same-tag element.
 
 **Applicable modes:** `server-string`, `server-stream`, `hydrate-match`, `hydrate-mismatch`, `production-compile`. **Observables:** `markup`, `node-identity`, `dom-mutations`.
 
 **Octane references**
 
-- [packages/octane/src/compiler/compile.js](../packages/octane/src/compiler/compile.js) — `headKey` — The current key hashes only the element source position, which is unique within one file but not across modules.
-- [packages/octane/src/runtime.ts](../packages/octane/src/runtime.ts) — `adoptServerHeadEl` — Tag validation closes wrong-tag claiming but cannot distinguish colliding same-tag owners.
+- [packages/octane/src/compiler/compile.js](../packages/octane/src/compiler/compile.js) — `headKey` — Hashes the canonical module ID, element tag, and source position into a fixed-size compiler key shared by client and server output.
+- [packages/octane/src/runtime.ts](../packages/octane/src/runtime.ts) — `adoptServerHeadEl` — Adopts exactly one expected-tag element only inside a structurally valid paired ownership interval.
+- [packages/octane/tests/hydration/head-hydrate.test.ts](../packages/octane/tests/hydration/head-hydrate.test.ts) — “uses the root namespace for a head entry emitted before a streamed boundary suspends” — A genuinely suspending readable stream proves boundary-local useId prefixes cannot desynchronize head ownership.
+- [packages/octane/tests/hydration/head-hydrate.test.ts](../packages/octane/tests/hydration/head-hydrate.test.ts) — “contains reordered ownership markers without cross-claiming same-tag server entries” — Malformed pairs create fresh client metadata while preserving both unclaimed server entries.
 
-**Next action (implementation).** Define a server/client-stable module-aware key, prove identical compilation modes emit the same key, and cover cross-module same-tag collisions plus duplicate, missing, and reordered markers without claiming or deleting unrelated head nodes.
+**Executable evidence**
 
-Targets: `packages/octane/src/compiler/compile.js`, `packages/octane/tests/compiler.test.ts`, `packages/octane/tests/hydration/head-hydrate.test.ts`.
+- [keeps streamed head ownership byte-compatible with client hydration](../packages/octane/tests/hydration/head-hydrate.test.ts) — modes: `server-stream`, `hydrate-match`, `production-compile`; observables: `markup`, `node-identity`, `dom-mutations`
+- [uses the root namespace for a head entry emitted before a streamed boundary suspends](../packages/octane/tests/hydration/head-hydrate.test.ts) — modes: `server-stream`, `hydrate-match`, `production-compile`; observables: `markup`, `node-identity`, `dom-mutations`
+- [keeps cross-module same-tag ownership stable when roots hydrate out of order](../packages/octane/tests/hydration/head-hydrate.test.ts) — modes: `server-string`, `hydrate-match`, `production-compile`; observables: `markup`, `node-identity`, `dom-mutations`
+- [uses existing identifierPrefix semantics to isolate same-module sibling roots](../packages/octane/tests/hydration/head-hydrate.test.ts) — modes: `server-string`, `hydrate-match`, `production-compile`; observables: `markup`, `node-identity`, `dom-mutations`
+- [does not claim or delete a server title when its opening ownership marker is missing](../packages/octane/tests/hydration/head-hydrate.test.ts) — modes: `server-string`, `hydrate-mismatch`, `production-compile`; observables: `markup`, `node-identity`, `dom-mutations`
+- [does not claim or delete a server title when its closing ownership marker is missing](../packages/octane/tests/hydration/head-hydrate.test.ts) — modes: `server-string`, `hydrate-mismatch`, `production-compile`; observables: `markup`, `node-identity`, `dom-mutations`
+- [treats a duplicate ownership marker as ambiguous instead of claiming a server title](../packages/octane/tests/hydration/head-hydrate.test.ts) — modes: `server-string`, `hydrate-mismatch`, `production-compile`; observables: `markup`, `node-identity`, `dom-mutations`
+- [contains reordered ownership markers without cross-claiming same-tag server entries](../packages/octane/tests/hydration/head-hydrate.test.ts) — modes: `server-string`, `hydrate-mismatch`, `production-compile`; observables: `markup`, `node-identity`, `dom-mutations`
 
-**Rationale.** RDX-HYD-002 deliberately closes the runtime's wrong-tag corruption without overstating marker identity. Redact's ownership failure exposed this distinct Octane compiler protocol risk, which needs a cross-module fixture rather than another adjacent-node unit case.
+**Rationale.** The compiler now separates modules and tags, the existing root identifierPrefix separates repeated roots, and paired delimiters make same-tag claiming fail closed under missing, duplicate, or reordered markers. Root-only namespacing also stays stable through streamed boundary-local useId subspaces.
 
 
 ### host-serialization-security
@@ -500,7 +508,7 @@ Targets: `packages/octane/src/runtime.ts`, `docs/ssr.md`.
 
 #### RDX-HYD-006 — Mismatch recovery is bounded to the failed ownership scope
 
-**Disposition:** high risk; adaptable; planned; owner: Octane hydration cursor and ownership ranges.
+**Disposition:** high risk; adaptable; covered; owner: Octane hydration cursor and ownership ranges.
 
 **Upstream evidence**
 
@@ -519,13 +527,18 @@ Targets: `packages/octane/src/runtime.ts`, `docs/ssr.md`.
 **Octane references**
 
 - [packages/octane/tests/conformance/hydration-mismatch.test.ts](../packages/octane/tests/conformance/hydration-mismatch.test.ts) — “hydration continues past a mismatch: the next sibling adopts + is interactive” — Proves final content and sibling interactivity, but does not retain and compare the sibling object across the recovery.
-- [packages/octane/tests/hydration/mismatch-structural.test.ts](../packages/octane/tests/hydration/mismatch-structural.test.ts) — “PROD build: @if branch swap rebuilds SILENTLY (recovery is not gated on the dev loc)” — Proves production recovery but not a nearest-host/Suspense containment matrix.
+- [packages/octane/tests/hydration/mismatch-structural.test.ts](../packages/octane/tests/hydration/mismatch-structural.test.ts) — “nearest-host recovery preserves outside objects and both outside and regenerated handlers” — Runs under explicit development and production compilation and retains every stable host object.
+- [packages/octane/tests/hydration/mismatch-structural.test.ts](../packages/octane/tests/hydration/mismatch-structural.test.ts) — “Suspense-scoped recovery preserves outside objects and installs the regenerated handler” — Pins boundary-external identity and both surviving and regenerated handler delivery.
+- [packages/octane/tests/browser/suspense-hydration/suspense-hydration.test.ts](../packages/octane/tests/browser/suspense-hydration/suspense-hydration.test.ts) — “contains async hydration recovery and preserves an interactive outside sibling” — Real Chromium drives the streamed mismatch, surviving sibling, and regenerated action.
 
-**Next action (test).** For root, nearest-host, and Suspense-scoped structural mismatches, capture outside siblings before hydration and assert the same objects and handlers survive while the failed subtree is regenerated and its handlers become live in development and production.
+**Executable evidence**
 
-Targets: `packages/octane/tests/conformance/hydration-mismatch.test.ts`, `packages/octane/tests/browser`.
+- [root recovery leaves one clean client tree with a live replacement handler](../packages/octane/tests/hydration/mismatch-structural.test.ts) — modes: `hydrate-mismatch`, `production-compile`; observables: `markup`, `node-identity`, `events`
+- [nearest-host recovery preserves outside objects and both outside and regenerated handlers](../packages/octane/tests/hydration/mismatch-structural.test.ts) — modes: `hydrate-mismatch`, `production-compile`; observables: `markup`, `node-identity`, `events`
+- [Suspense-scoped recovery preserves outside objects and installs the regenerated handler](../packages/octane/tests/hydration/mismatch-structural.test.ts) — modes: `hydrate-mismatch`, `production-compile`; observables: `markup`, `node-identity`, `events`
+- [contains async hydration recovery and preserves an interactive outside sibling](../packages/octane/tests/browser/suspense-hydration/suspense-hydration.test.ts) — modes: `hydrate-mismatch`, `real-browser`; observables: `markup`, `node-identity`, `events`
 
-**Rationale.** Octane recovers ranges in place instead of following Redact's checkpoint stack, so the transferable requirement is the observable containment boundary rather than checkpoint implementation parity.
+**Rationale.** Octane's compiler-owned ranges recover in place rather than unwinding Redact checkpoints. The completed root, nearest-host, Suspense, production-compile, and Chromium matrix now proves the equivalent observable containment boundary and live event wiring.
 
 
 ### memo-scheduling
@@ -720,7 +733,7 @@ Targets: `packages/octane/tests/portal.test.ts`.
 
 #### RDX-HYD-003 — Raw script and style hydration must use their parsing contexts
 
-**Disposition:** high risk; portable; planned; owner: Octane DOM hydration and SSR serialization.
+**Disposition:** high risk; portable; covered; owner: Octane DOM hydration and SSR serialization.
 
 **Upstream evidence**
 
@@ -737,13 +750,18 @@ Targets: `packages/octane/tests/portal.test.ts`.
 
 - [packages/octane/src/runtime.ts](../packages/octane/src/runtime.ts) — `setHTML` — Script uses textContent; other hosts use a same-tag contextual probe.
 - [packages/octane/tests/script-innerhtml.test.ts](../packages/octane/tests/script-innerhtml.test.ts) — “hydrates the server-safe script spelling by adoption and applies later updates” — Script coverage is already strong.
-- [packages/octane/tests/conformance/fizz-main-wave4c.test.ts](../packages/octane/tests/conformance/fizz-main-wave4c.test.ts) — “keeps raw style text in one element when it contains closing-tag-like tokens” — Current style evidence is server-only.
+- [packages/octane/tests/conformance/fizz-main-wave4c.test.ts](../packages/octane/tests/conformance/fizz-main-wave4c.test.ts) — “keeps raw style text in one element when it contains closing-tag-like tokens” — Pins the server serializer's closing-tag safety.
+- [packages/octane/tests/script-innerhtml.test.ts](../packages/octane/tests/script-innerhtml.test.ts) — “adopts server-parsed raw text without diagnostics and updates the same stylesheet” — Covers buffered and streamed parsing, strict adoption, diagnostics, and same-node updates.
+- [packages/octane/tests/browser/raw-style-hydration/raw-style-hydration.test.ts](../packages/octane/tests/browser/raw-style-hydration/raw-style-hydration.test.ts) — “prod adopts server CSS and preserves raw-text semantics through update” — Chromium verifies production hydration identity plus CSSOM and computed-style semantics.
 
-**Next action (test).** Add server-render, parse, hydrate, and update coverage for raw style text containing &amp;&amp;, &lt;, entity-like text, and closing-tag-like tokens; assert adoption and no warning in the unit lane, then use Chromium/CSSOM to prove intact stylesheet semantics.
+**Executable evidence**
 
-Targets: `packages/octane/tests/script-innerhtml.test.ts`, `packages/octane/tests/browser`.
+- [hydrates the server-safe script spelling by adoption and applies later updates](../packages/octane/tests/script-innerhtml.test.ts) — modes: `server-string`, `hydrate-match`, `production-compile`; observables: `markup`, `node-identity`, `errors`
+- [adopts server-parsed raw text without diagnostics and updates the same stylesheet](../packages/octane/tests/script-innerhtml.test.ts) — modes: `server-string`, `server-stream`, `hydrate-match`, `production-compile`; observables: `markup`, `node-identity`, `errors`
+- [dev adopts server CSS and preserves raw-text semantics through update](../packages/octane/tests/browser/raw-style-hydration/raw-style-hydration.test.ts) — modes: `server-string`, `hydrate-match`, `real-browser`; observables: `markup`, `node-identity`, `errors`
+- [prod adopts server CSS and preserves raw-text semantics through update](../packages/octane/tests/browser/raw-style-hydration/raw-style-hydration.test.ts) — modes: `server-string`, `hydrate-match`, `production-compile`, `real-browser`; observables: `markup`, `node-identity`, `errors`
 
-**Rationale.** The Redact script failure is already prevented; the remaining gap is direct hydration evidence for style's distinct raw-text and SSR-escape behavior.
+**Rationale.** Script already used script-data comparison; the completed style matrix now proves its distinct raw-text parser context through buffered and streamed SSR, strict dev/prod adoption, same-node updates, breakout-token safety, and real Chromium CSSOM semantics.
 
 
 ### reconciliation

--- a/packages/octane/audit/redact-adversarial-ledger.json
+++ b/packages/octane/audit/redact-adversarial-ledger.json
@@ -481,7 +481,7 @@
       "symptom": "A replay queue delivered the right event names but degraded keyboard and input events to generic Event objects, lost target/default semantics, changed order, or replayed an item twice.",
       "octaneContract": "For every event Octane buffers, replay must preserve the documented platform subclass and supported metadata, original target, FIFO order, bubbling/cancelability/default behavior, and exactly-once delivery.",
       "classification": "adaptable",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "owner": "Octane deferred hydration and DOM events",
       "applicableModes": ["deferred-hydration", "real-browser"],
@@ -490,25 +490,43 @@
         {
           "kind": "source",
           "file": "packages/octane/src/runtime.ts",
-          "symbol": "notifyHydrateBoundary",
-          "note": "Mouse and focus families retain subclasses; other buffered families currently fall back to Event."
+          "symbol": "cloneHydrationReplayEvent",
+          "note": "Clones every public event family with its realm-specific platform constructor; pointer detection precedes mouse detection."
         },
         {
           "kind": "test",
-          "file": "packages/octane/tests/streaming-ssr.test.ts",
-          "testName": "replays pre-root interaction after the pending stream reveals",
-          "note": "Covers click delivery and target survival, not the cross-family event-shape matrix."
+          "file": "packages/octane/tests/hydration/deferred-hydration-contract.test.ts",
+          "testName": "replays every public interaction event once with its platform shape and queue semantics",
+          "note": "An exhaustive type-level-locked matrix covers all 15 public interaction events in development and production compilation."
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/hydration/deferred-hydration-contract.test.ts",
+          "testName": "classifies parent-realm events before replaying them in an iframe realm",
+          "note": "Parent-created focus, keyboard, mouse, and pointer events replay with the iframe target's constructors and retain their metadata."
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/browser/deferred-hydration-event-replay/deferred-hydration-event-replay.test.ts",
+          "testName": "preserves every public event family, metadata, order, target, and cancellation",
+          "note": "Real Chromium proves platform subclasses, metadata, FIFO delivery, original target, default cancellation, and one queue drain."
         }
       ],
-      "nextAction": {
-        "kind": "test",
-        "targets": [
-          "packages/octane/tests/hydration/deferred-hydration-contract.test.ts",
-          "packages/octane/tests/browser"
-        ],
-        "acceptance": "Exercise every public HydrationInteractionEvent family in a real browser: click/auxclick/contextmenu/dblclick, focusin, keydown/keyup, mouse, and pointer events. Assert subclass, supported metadata, target, FIFO ordering, preventDefault visibility, queue drain, and no duplicate replay; keep input/change/submit excluded unless a separate API decision expands the public union."
-      },
-      "rationale": "Octane replays interaction intent rather than cloning every native event field, so the transferable contract must explicitly define which event shape it promises instead of silently copying Redact's implementation."
+      "evidence": [
+        {
+          "file": "packages/octane/tests/hydration/deferred-hydration-contract.test.ts",
+          "testName": "replays every public interaction event once with its platform shape and queue semantics",
+          "modes": ["deferred-hydration"],
+          "observables": ["events"]
+        },
+        {
+          "file": "packages/octane/tests/browser/deferred-hydration-event-replay/deferred-hydration-event-replay.test.ts",
+          "testName": "preserves every public event family, metadata, order, target, and cancellation",
+          "modes": ["deferred-hydration", "real-browser"],
+          "observables": ["events"]
+        }
+      ],
+      "rationale": "Octane continues to replay only its documented interaction-intent union. The clone is now realm-aware and constructor-specific, while exhaustive unit and Chromium evidence lock every public family to its supported platform metadata and exactly-once FIFO semantics."
     },
     {
       "id": "RDX-HYD-001",
@@ -603,7 +621,7 @@
         }
       ],
       "symptom": "Weak head-node identity allowed one logical head entry to adopt a different server node and validate or update the wrong content.",
-      "octaneContract": "Within a matching head-marker interval, hydration adopts only an element with the expected tag. It preserves interposed wrong-tag nodes and, when no expected-tag candidate exists before the next Octane marker, creates the expected node without claiming unrelated head content.",
+      "octaneContract": "Within a valid paired head-ownership interval, hydration adopts only an element with the expected tag. It preserves interposed wrong-tag nodes and, when no expected-tag candidate exists before the matching closing marker, creates the expected node without claiming unrelated head content.",
       "classification": "adaptable",
       "status": "covered",
       "risk": "critical",
@@ -620,12 +638,12 @@
           "kind": "source",
           "file": "packages/octane/src/runtime.ts",
           "symbol": "adoptServerHeadEl",
-          "note": "Claims only a matching tag inside the ownership interval closed by the next Octane head marker."
+          "note": "Claims only a matching tag inside a valid interval closed by that entry's paired ownership marker."
         },
         {
           "kind": "test",
           "file": "packages/octane/tests/hydration/head-hydrate.test.ts",
-          "testName": "adopts the server head (one <title>/<meta>, markers removed) + single-root body, removed on unmount",
+          "testName": "adopts the server head and single-root body, then removes owned nodes on unmount",
           "note": "Happy-path adoption and lifecycle ownership."
         },
         {
@@ -642,7 +660,7 @@
       "evidence": [
         {
           "file": "packages/octane/tests/hydration/head-hydrate.test.ts",
-          "testName": "adopts the server head (one <title>/<meta>, markers removed) + single-root body, removed on unmount",
+          "testName": "adopts the server head and single-root body, then removes owned nodes on unmount",
           "modes": ["server-string", "hydrate-match", "production-compile"],
           "observables": ["markup", "node-identity", "dom-mutations"]
         },
@@ -659,7 +677,7 @@
           "observables": ["markup", "node-identity", "dom-mutations"]
         }
       ],
-      "rationale": "Redact matches scripts by attributes while Octane uses compiler markers, so the transferable contract is ownership-safe claiming rather than Redact's matcher. This closes wrong-tag and missing-target corruption within one marker interval. Compiler key uniqueness and ambiguous same-tag collisions remain explicitly tracked by RDX-HYD-007."
+      "rationale": "Redact matches scripts by attributes while Octane uses compiler markers, so the transferable contract is ownership-safe claiming rather than Redact's matcher. This closes wrong-tag and missing-target corruption within one paired ownership interval. Compiler key uniqueness and ambiguous same-tag collisions remain explicitly tracked by RDX-HYD-007."
     },
     {
       "id": "RDX-HYD-003",
@@ -683,7 +701,7 @@
       "symptom": "Byte-equivalent script or style text containing ampersands or less-than signs was parsed through a generic div and falsely reported as mismatched.",
       "octaneContract": "Hydration comparison must respect script-data and style raw-text parsing, preserve node identity for equivalent server bytes, avoid false diagnostics, and remain safe against closing-tag injection.",
       "classification": "portable",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "owner": "Octane DOM hydration and SSR serialization",
       "applicableModes": [
@@ -711,18 +729,48 @@
           "kind": "test",
           "file": "packages/octane/tests/conformance/fizz-main-wave4c.test.ts",
           "testName": "keeps raw style text in one element when it contains closing-tag-like tokens",
-          "note": "Current style evidence is server-only."
+          "note": "Pins the server serializer's closing-tag safety."
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/script-innerhtml.test.ts",
+          "testName": "adopts server-parsed raw text without diagnostics and updates the same stylesheet",
+          "note": "Covers buffered and streamed parsing, strict adoption, diagnostics, and same-node updates."
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/browser/raw-style-hydration/raw-style-hydration.test.ts",
+          "testName": "prod adopts server CSS and preserves raw-text semantics through update",
+          "note": "Chromium verifies production hydration identity plus CSSOM and computed-style semantics."
         }
       ],
-      "nextAction": {
-        "kind": "test",
-        "targets": [
-          "packages/octane/tests/script-innerhtml.test.ts",
-          "packages/octane/tests/browser"
-        ],
-        "acceptance": "Add server-render, parse, hydrate, and update coverage for raw style text containing &&, <, entity-like text, and closing-tag-like tokens; assert adoption and no warning in the unit lane, then use Chromium/CSSOM to prove intact stylesheet semantics."
-      },
-      "rationale": "The Redact script failure is already prevented; the remaining gap is direct hydration evidence for style's distinct raw-text and SSR-escape behavior."
+      "evidence": [
+        {
+          "file": "packages/octane/tests/script-innerhtml.test.ts",
+          "testName": "hydrates the server-safe script spelling by adoption and applies later updates",
+          "modes": ["server-string", "hydrate-match", "production-compile"],
+          "observables": ["markup", "node-identity", "errors"]
+        },
+        {
+          "file": "packages/octane/tests/script-innerhtml.test.ts",
+          "testName": "adopts server-parsed raw text without diagnostics and updates the same stylesheet",
+          "modes": ["server-string", "server-stream", "hydrate-match", "production-compile"],
+          "observables": ["markup", "node-identity", "errors"]
+        },
+        {
+          "file": "packages/octane/tests/browser/raw-style-hydration/raw-style-hydration.test.ts",
+          "testName": "dev adopts server CSS and preserves raw-text semantics through update",
+          "modes": ["server-string", "hydrate-match", "real-browser"],
+          "observables": ["markup", "node-identity", "errors"]
+        },
+        {
+          "file": "packages/octane/tests/browser/raw-style-hydration/raw-style-hydration.test.ts",
+          "testName": "prod adopts server CSS and preserves raw-text semantics through update",
+          "modes": ["server-string", "hydrate-match", "production-compile", "real-browser"],
+          "observables": ["markup", "node-identity", "errors"]
+        }
+      ],
+      "rationale": "Script already used script-data comparison; the completed style matrix now proves its distinct raw-text parser context through buffered and streamed SSR, strict dev/prod adoption, same-node updates, breakout-token safety, and real Chromium CSSOM semantics."
     },
     {
       "id": "RDX-HYD-004",
@@ -861,7 +909,7 @@
       "symptom": "Recovering one mismatched host or Suspense subtree could remount unaffected siblings, abandon the hydration cursor, or leave the regenerated subtree without live handlers.",
       "octaneContract": "A structural hydration mismatch rebuilds only its owning failed range, preserves the object identity of unaffected siblings outside that range, and installs events on regenerated content.",
       "classification": "adaptable",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "owner": "Octane hydration cursor and ownership ranges",
       "applicableModes": ["hydrate-mismatch", "production-compile", "real-browser"],
@@ -876,19 +924,49 @@
         {
           "kind": "test",
           "file": "packages/octane/tests/hydration/mismatch-structural.test.ts",
-          "testName": "PROD build: @if branch swap rebuilds SILENTLY (recovery is not gated on the dev loc)",
-          "note": "Proves production recovery but not a nearest-host/Suspense containment matrix."
+          "testName": "nearest-host recovery preserves outside objects and both outside and regenerated handlers",
+          "note": "Runs under explicit development and production compilation and retains every stable host object."
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/hydration/mismatch-structural.test.ts",
+          "testName": "Suspense-scoped recovery preserves outside objects and installs the regenerated handler",
+          "note": "Pins boundary-external identity and both surviving and regenerated handler delivery."
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/browser/suspense-hydration/suspense-hydration.test.ts",
+          "testName": "contains async hydration recovery and preserves an interactive outside sibling",
+          "note": "Real Chromium drives the streamed mismatch, surviving sibling, and regenerated action."
         }
       ],
-      "nextAction": {
-        "kind": "test",
-        "targets": [
-          "packages/octane/tests/conformance/hydration-mismatch.test.ts",
-          "packages/octane/tests/browser"
-        ],
-        "acceptance": "For root, nearest-host, and Suspense-scoped structural mismatches, capture outside siblings before hydration and assert the same objects and handlers survive while the failed subtree is regenerated and its handlers become live in development and production."
-      },
-      "rationale": "Octane recovers ranges in place instead of following Redact's checkpoint stack, so the transferable requirement is the observable containment boundary rather than checkpoint implementation parity."
+      "evidence": [
+        {
+          "file": "packages/octane/tests/hydration/mismatch-structural.test.ts",
+          "testName": "root recovery leaves one clean client tree with a live replacement handler",
+          "modes": ["hydrate-mismatch", "production-compile"],
+          "observables": ["markup", "node-identity", "events"]
+        },
+        {
+          "file": "packages/octane/tests/hydration/mismatch-structural.test.ts",
+          "testName": "nearest-host recovery preserves outside objects and both outside and regenerated handlers",
+          "modes": ["hydrate-mismatch", "production-compile"],
+          "observables": ["markup", "node-identity", "events"]
+        },
+        {
+          "file": "packages/octane/tests/hydration/mismatch-structural.test.ts",
+          "testName": "Suspense-scoped recovery preserves outside objects and installs the regenerated handler",
+          "modes": ["hydrate-mismatch", "production-compile"],
+          "observables": ["markup", "node-identity", "events"]
+        },
+        {
+          "file": "packages/octane/tests/browser/suspense-hydration/suspense-hydration.test.ts",
+          "testName": "contains async hydration recovery and preserves an interactive outside sibling",
+          "modes": ["hydrate-mismatch", "real-browser"],
+          "observables": ["markup", "node-identity", "events"]
+        }
+      ],
+      "rationale": "Octane's compiler-owned ranges recover in place rather than unwinding Redact checkpoints. The completed root, nearest-host, Suspense, production-compile, and Chromium matrix now proves the equivalent observable containment boundary and live event wiring."
     },
     {
       "id": "RDX-HYD-007",
@@ -910,9 +988,9 @@
         }
       ],
       "symptom": "A marker derived only from a source offset can collide across modules or tags, making same-tag ownership ambiguous even when runtime claiming validates the element tag.",
-      "octaneContract": "Compiler-emitted head ownership keys are stable between server and client builds and collision-resistant across modules, tags, and multiple roots; duplicate, reordered, or missing markers cannot make one logical entry claim another same-tag element.",
+      "octaneContract": "Compiler-emitted head ownership keys are stable between server and client builds and collision-resistant across modules and tags; the existing distinct identifierPrefix contract isolates sibling roots. Duplicate, reordered, or missing marker pairs cannot make one logical entry claim another same-tag element.",
       "classification": "adaptable",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "owner": "Octane compiler and runtime head hydration",
       "applicableModes": [
@@ -928,25 +1006,78 @@
           "kind": "source",
           "file": "packages/octane/src/compiler/compile.js",
           "symbol": "headKey",
-          "note": "The current key hashes only the element source position, which is unique within one file but not across modules."
+          "note": "Hashes the canonical module ID, element tag, and source position into a fixed-size compiler key shared by client and server output."
         },
         {
           "kind": "source",
           "file": "packages/octane/src/runtime.ts",
           "symbol": "adoptServerHeadEl",
-          "note": "Tag validation closes wrong-tag claiming but cannot distinguish colliding same-tag owners."
+          "note": "Adopts exactly one expected-tag element only inside a structurally valid paired ownership interval."
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/hydration/head-hydrate.test.ts",
+          "testName": "uses the root namespace for a head entry emitted before a streamed boundary suspends",
+          "note": "A genuinely suspending readable stream proves boundary-local useId prefixes cannot desynchronize head ownership."
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/hydration/head-hydrate.test.ts",
+          "testName": "contains reordered ownership markers without cross-claiming same-tag server entries",
+          "note": "Malformed pairs create fresh client metadata while preserving both unclaimed server entries."
         }
       ],
-      "nextAction": {
-        "kind": "implementation",
-        "targets": [
-          "packages/octane/src/compiler/compile.js",
-          "packages/octane/tests/compiler.test.ts",
-          "packages/octane/tests/hydration/head-hydrate.test.ts"
-        ],
-        "acceptance": "Define a server/client-stable module-aware key, prove identical compilation modes emit the same key, and cover cross-module same-tag collisions plus duplicate, missing, and reordered markers without claiming or deleting unrelated head nodes."
-      },
-      "rationale": "RDX-HYD-002 deliberately closes the runtime's wrong-tag corruption without overstating marker identity. Redact's ownership failure exposed this distinct Octane compiler protocol risk, which needs a cross-module fixture rather than another adjacent-node unit case."
+      "evidence": [
+        {
+          "file": "packages/octane/tests/hydration/head-hydrate.test.ts",
+          "testName": "keeps streamed head ownership byte-compatible with client hydration",
+          "modes": ["server-stream", "hydrate-match", "production-compile"],
+          "observables": ["markup", "node-identity", "dom-mutations"]
+        },
+        {
+          "file": "packages/octane/tests/hydration/head-hydrate.test.ts",
+          "testName": "uses the root namespace for a head entry emitted before a streamed boundary suspends",
+          "modes": ["server-stream", "hydrate-match", "production-compile"],
+          "observables": ["markup", "node-identity", "dom-mutations"]
+        },
+        {
+          "file": "packages/octane/tests/hydration/head-hydrate.test.ts",
+          "testName": "keeps cross-module same-tag ownership stable when roots hydrate out of order",
+          "modes": ["server-string", "hydrate-match", "production-compile"],
+          "observables": ["markup", "node-identity", "dom-mutations"]
+        },
+        {
+          "file": "packages/octane/tests/hydration/head-hydrate.test.ts",
+          "testName": "uses existing identifierPrefix semantics to isolate same-module sibling roots",
+          "modes": ["server-string", "hydrate-match", "production-compile"],
+          "observables": ["markup", "node-identity", "dom-mutations"]
+        },
+        {
+          "file": "packages/octane/tests/hydration/head-hydrate.test.ts",
+          "testName": "does not claim or delete a server title when its opening ownership marker is missing",
+          "modes": ["server-string", "hydrate-mismatch", "production-compile"],
+          "observables": ["markup", "node-identity", "dom-mutations"]
+        },
+        {
+          "file": "packages/octane/tests/hydration/head-hydrate.test.ts",
+          "testName": "does not claim or delete a server title when its closing ownership marker is missing",
+          "modes": ["server-string", "hydrate-mismatch", "production-compile"],
+          "observables": ["markup", "node-identity", "dom-mutations"]
+        },
+        {
+          "file": "packages/octane/tests/hydration/head-hydrate.test.ts",
+          "testName": "treats a duplicate ownership marker as ambiguous instead of claiming a server title",
+          "modes": ["server-string", "hydrate-mismatch", "production-compile"],
+          "observables": ["markup", "node-identity", "dom-mutations"]
+        },
+        {
+          "file": "packages/octane/tests/hydration/head-hydrate.test.ts",
+          "testName": "contains reordered ownership markers without cross-claiming same-tag server entries",
+          "modes": ["server-string", "hydrate-mismatch", "production-compile"],
+          "observables": ["markup", "node-identity", "dom-mutations"]
+        }
+      ],
+      "rationale": "The compiler now separates modules and tags, the existing root identifierPrefix separates repeated roots, and paired delimiters make same-tag claiming fail closed under missing, duplicate, or reordered markers. Root-only namespacing also stays stable through streamed boundary-local useId subspaces."
     },
     {
       "id": "RDX-ID-001",

--- a/packages/octane/audit/redact-adversarial-ledger.json
+++ b/packages/octane/audit/redact-adversarial-ledger.json
@@ -491,7 +491,7 @@
           "kind": "source",
           "file": "packages/octane/src/runtime.ts",
           "symbol": "cloneHydrationReplayEvent",
-          "note": "Clones every public event family with its realm-specific platform constructor; pointer detection precedes mouse detection."
+          "note": "Clones every public event family with the target realm's platform constructor, falling back to the Web IDL brand when instanceof cannot cross realms; pointer detection precedes mouse detection."
         },
         {
           "kind": "test",
@@ -504,6 +504,12 @@
           "file": "packages/octane/tests/hydration/deferred-hydration-contract.test.ts",
           "testName": "classifies parent-realm events before replaying them in an iframe realm",
           "note": "Parent-created focus, keyboard, mouse, and pointer events replay with the iframe target's constructors and retain their metadata."
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/hydration/deferred-hydration-contract.test.ts",
+          "testName": "classifies iframe-realm events before replaying them at a host-document target",
+          "note": "The opposite realm crossing: an embedded widget's own events replay with the host document's constructors, proving the clone follows the target rather than the incoming event."
         },
         {
           "kind": "test",

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -12879,20 +12879,19 @@ function isHoistableHeadElementNode(n) {
 }
 
 // Deterministic per-element key bridging the client `headBlock` (its scope-state
-// key + SSR-marker adoption) and the server `ssrHeadEl` marker. Must be
-// byte-identical across the client and server compiles of the SAME source, so it
-// is keyed ONLY on the element's SOURCE POSITION (same AST → same offset in both
-// modes), NOT the filename. Unique per head element WITHIN a file.
-/** @param {any} node @param {number} index @returns {string} */
-function headKey(node, index) {
+// key + SSR-marker adoption) and the server `ssrHeadEl` marker. Bundlers pass a
+// canonical root-relative module id; direct compiler callers already need to
+// use the same filename for client/server parity. Hashing the cleaned id keeps
+// output path-free while separating identical source offsets across modules.
+/** @param {any} node @param {number} index @param {any} ctx @returns {string} */
+function headKey(node, index, ctx) {
 	const pos =
 		node && node.openingElement && node.openingElement.start != null
 			? node.openingElement.start
 			: index;
-	const src = `head:${pos}`;
-	let h = 5381;
-	for (let i = 0; i < src.length; i++) h = (Math.imul(h, 33) + src.charCodeAt(i)) | 0;
-	return 'rnh-' + (h >>> 0).toString(36);
+	const tag = jsxTagName(node) ?? '';
+	const filename = cleanCompileFilename(ctx.filename || '<anon>');
+	return 'rnh-' + strongHash(`${filename}\0${tag}\0${pos}`);
 }
 
 // Shared title-text expression for ordinary head hoists and namespace-deferred
@@ -12974,7 +12973,7 @@ function deferredTitleElement(el, ctx) {
 		}
 	}
 	const args = [
-		b.literal(headKey(el, 0)),
+		b.literal(headKey(el, 0, ctx)),
 		b.literal('title'),
 		deferredHeadAttrs(el),
 		headTextExpression(el),
@@ -13105,8 +13104,8 @@ function rewriteOpaqueTitles(node, ctx, namespace = 'html') {
 // object-literal expression (dynamic values stay live expressions, so the
 // metadata is reactive); a `<title>`'s text becomes a string-concat expression;
 // void tags (`<meta>`/`<link>`) pass `null` for text.
-/** @param {any} node @param {number} index @returns {string} */
-function headElementArgNodes(node, index) {
+/** @param {any} node @param {number} index @param {any} ctx @returns {string} */
+function headElementArgNodes(node, index, ctx) {
 	const el = node.element;
 	const tag = jsxTagName(el);
 	const attrProps = [];
@@ -13144,7 +13143,7 @@ function headElementArgNodes(node, index) {
 	const attrsExpr = attrProps.length ? b.object(attrProps) : b.literal(null);
 	const textExpr = VOID_ELEMENTS.has(tag) ? b.literal(null) : headTextExpression(el);
 	return [
-		b.literal(headKey(el, index), undefined, el),
+		b.literal(headKey(el, index, ctx), undefined, el),
 		b.literal(tag, undefined, el),
 		inheritOriginLoc(attrsExpr, el),
 		inheritOriginLoc(textExpr, el),
@@ -13162,7 +13161,12 @@ function emitHeadClient(headNodes, ctx, slotBase) {
 	return headNodes.map((h, i) =>
 		inheritOriginLoc(
 			b.stmt(
-				b.call('_$headBlock', b.id('__s'), b.literal(slotBase + i), ...headElementArgNodes(h, i)),
+				b.call(
+					'_$headBlock',
+					b.id('__s'),
+					b.literal(slotBase + i),
+					...headElementArgNodes(h, i, ctx),
+				),
 			),
 			h.element ?? h,
 		),
@@ -13177,7 +13181,7 @@ function emitHeadServer(headNodes, ctx) {
 	ctx.runtimeNeeded.add('ssrHeadEl');
 	return headNodes.map((head, index) =>
 		inheritOriginLoc(
-			b.stmt(b.call('_$ssrHeadEl', ...headElementArgNodes(head, index))),
+			b.stmt(b.call('_$ssrHeadEl', ...headElementArgNodes(head, index, ctx))),
 			head.element ?? head,
 		),
 	);

--- a/packages/octane/src/head-ownership.ts
+++ b/packages/octane/src/head-ownership.ts
@@ -1,0 +1,42 @@
+/**
+ * Compose the compiler's module-local head key with the existing root ID
+ * namespace. Sibling hydrating roots already require distinct
+ * `identifierPrefix` values; carrying that namespace into head ownership lets
+ * them hydrate in any order without claiming another root's metadata.
+ *
+ * The optional hexadecimal root suffix is fixed-width and comment-safe. This
+ * runs only for authored head entries (server serialization and the client's
+ * one-time adoption), never on the ordinary component/host update path.
+ */
+export function headOwnershipSuffix(identifierPrefix: string): string {
+	if (identifierPrefix === '') return '';
+	let left = 0x811c9dc5;
+	let right = 0x9e3779b9;
+	for (let i = 0; i < identifierPrefix.length; i++) {
+		const code = identifierPrefix.charCodeAt(i);
+		left = Math.imul(left ^ code, 0x01000193);
+		right = Math.imul(right ^ code, 0x85ebca6b);
+		right = (right << 13) | (right >>> 19);
+	}
+	left ^= left >>> 16;
+	left = Math.imul(left, 0x85ebca6b);
+	left ^= left >>> 13;
+	left = Math.imul(left, 0xc2b2ae35);
+	left ^= left >>> 16;
+	right ^= identifierPrefix.length;
+	right ^= right >>> 16;
+	right = Math.imul(right, 0x85ebca6b);
+	right ^= right >>> 13;
+	right = Math.imul(right, 0xc2b2ae35);
+	right ^= right >>> 16;
+	return (
+		'-' + (left >>> 0).toString(16).padStart(8, '0') + (right >>> 0).toString(16).padStart(8, '0')
+	);
+}
+
+export function headOwnershipKey(key: string, identifierPrefix: string): string {
+	// Default-root metadata is already isolated by the module-aware compiler key.
+	// Keep that overwhelmingly common path allocation-free.
+	const suffix = headOwnershipSuffix(identifierPrefix);
+	return suffix === '' ? key : key + suffix;
+}

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -59,6 +59,7 @@ import {
 	// static-markup emission of `ssrEmitElement`.
 	VOID_ELEMENTS,
 } from './constants.js';
+import { headOwnershipSuffix } from './head-ownership.js';
 import type { HydrateProps, HydrationStrategy } from './hydration/types.js';
 
 // Shared client/SSR CSS helpers (single source in css.ts so class strings and
@@ -143,6 +144,8 @@ interface HeadBuffer {
 	html: string;
 	/** Resource-hint dedupe keys emitted into `html` during this pass. */
 	hints: Set<string>;
+	/** Precomputed caller root namespace, unaffected by streamed useId subspaces. */
+	rootSuffix: string;
 }
 let HEAD: HeadBuffer | null = null;
 
@@ -4533,10 +4536,11 @@ export function injectStyle(id: string, css: string): void {
 }
 
 // Compiler-emitted for each hoisted `<title>`/`<meta>`/`<link>` (rendered
-// anywhere in a component). Serializes the element — prefixed with a `<!--key-->`
-// marker the client's headBlock adopts — into the active render pass's head
-// buffer (null-guarded like injectStyle, so it only collects during a
-// synchronous pass). Returned as RenderResult.head and injected at <!--ssr-head-->.
+// anywhere in a component). Serializes the element inside a paired ownership
+// marker interval that the client's headBlock adopts and appends it to the active
+// render-pass head buffer (null-guarded like injectStyle, so it only collects
+// during a synchronous pass). Returned as RenderResult.head and injected at
+// <!--ssr-head-->.
 const HEAD_VOID_ELEMENTS = new Set(['meta', 'link', 'base']);
 
 export function ssrHeadEl(
@@ -4546,9 +4550,11 @@ export function ssrHeadEl(
 	text: unknown,
 ): void {
 	if (HEAD === null) return;
-	// The `<!--key-->` prefix is the client headBlock's adoption marker; static
-	// markup is non-hydratable, so it's omitted there.
-	let s = (MARKERS ? '<!--' + key + '-->' : '') + '<' + tag;
+	// Paired ownership comments bound the exact adoption interval; static markup
+	// is non-hydratable, so both are omitted there.
+	const rootSuffix = HEAD.rootSuffix;
+	const ownershipKey = MARKERS ? (rootSuffix === '' ? key : key + rootSuffix) : '';
+	let s = (MARKERS ? '<!--' + ownershipKey + '-->' : '') + '<' + tag;
 	if (attrs !== null) {
 		for (const k in attrs) {
 			// Hoisted metadata must share ordinary-host value filtering and DEV
@@ -4562,6 +4568,7 @@ export function ssrHeadEl(
 	} else {
 		s += '>' + (text == null ? '' : escapeHtml(text)) + '</' + tag + '>';
 	}
+	if (MARKERS) s += '<!--/' + ownershipKey + '-->';
 	HEAD.html += s;
 }
 
@@ -4945,7 +4952,11 @@ function runFullFramedPass(
 	VT_SSR_HAS_CANDIDATES = false;
 	VT_SSR_STACK.length = 0;
 	const cssMap = (CSS = new Map<string, string>());
-	const headBuf = (HEAD = { html: '', hints: new Set() });
+	const headBuf = (HEAD = {
+		html: '',
+		hints: new Set(),
+		rootSuffix: markers ? headOwnershipSuffix(identifierPrefix) : '',
+	});
 	const suspended = (SUSPENDED = [] as SuspendedList);
 	const serial = (SERIAL = [] as unknown[]);
 	const deferred = (DEFERRED = [] as Job[]);
@@ -5037,7 +5048,7 @@ function runDiscoveryRound(
 	VT_SSR_HAS_CANDIDATES = false;
 	VT_SSR_STACK.length = 0;
 	CSS = new Map();
-	HEAD = { html: '', hints: new Set() };
+	HEAD = { html: '', hints: new Set(), rootSuffix: headOwnershipSuffix(identifierPrefix) };
 	const suspended = (SUSPENDED = [] as SuspendedList);
 	SERIAL = [] as unknown[];
 	const deferred = (DEFERRED = [] as Job[]);

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -43,6 +43,7 @@ import {
 	// Read only on setAttribute's cold dangerouslySetInnerHTML arm.
 	VOID_ELEMENTS,
 } from './constants.js';
+import { headOwnershipKey } from './head-ownership.js';
 import {
 	__profileBail,
 	__profileBeginRender,
@@ -5908,6 +5909,84 @@ function activateHydrateBoundary(state: HydrateSlot): void {
 	if (completed && hydration.hasAdjacentRangePair) hydration.coalesce();
 }
 
+function cloneHydrationReplayEvent(event: Event, target: Element): Event {
+	// Event constructors are realm-specific. Hydrating an iframe-owned root from
+	// its parent realm must still replay an event created by the iframe's Window.
+	const ownerWindow = target.ownerDocument.defaultView;
+	if (ownerWindow !== null) {
+		// PointerEvent extends MouseEvent, so it must be selected first or pointer-
+		// specific metadata (pressure, pointerId, tilt, etc.) is discarded.
+		if (
+			typeof ownerWindow.PointerEvent !== 'undefined' &&
+			event instanceof ownerWindow.PointerEvent
+		) {
+			return new ownerWindow.PointerEvent(event.type, event);
+		}
+		if (
+			typeof ownerWindow.KeyboardEvent !== 'undefined' &&
+			event instanceof ownerWindow.KeyboardEvent
+		) {
+			return new ownerWindow.KeyboardEvent(event.type, event);
+		}
+		if (typeof ownerWindow.MouseEvent !== 'undefined' && event instanceof ownerWindow.MouseEvent) {
+			return new ownerWindow.MouseEvent(event.type, event);
+		}
+		if (typeof ownerWindow.FocusEvent !== 'undefined' && event instanceof ownerWindow.FocusEvent) {
+			return new ownerWindow.FocusEvent(event.type, event);
+		}
+		// Programmatic dispatch may cross realms: the original event can come from
+		// a parent Window while its target belongs to this iframe Window. Web IDL's
+		// toStringTag preserves the platform family across that identity boundary;
+		// always construct the replay with the target realm's constructor.
+		const eventBrand = Object.prototype.toString.call(event);
+		if (eventBrand === '[object PointerEvent]' && typeof ownerWindow.PointerEvent !== 'undefined') {
+			return new ownerWindow.PointerEvent(event.type, event);
+		}
+		if (
+			eventBrand === '[object KeyboardEvent]' &&
+			typeof ownerWindow.KeyboardEvent !== 'undefined'
+		) {
+			return new ownerWindow.KeyboardEvent(event.type, event);
+		}
+		if (eventBrand === '[object MouseEvent]' && typeof ownerWindow.MouseEvent !== 'undefined') {
+			return new ownerWindow.MouseEvent(event.type, event);
+		}
+		if (eventBrand === '[object FocusEvent]' && typeof ownerWindow.FocusEvent !== 'undefined') {
+			return new ownerWindow.FocusEvent(event.type, event);
+		}
+		return new ownerWindow.Event(event.type, event);
+	}
+
+	// A detached synthetic Document can have no defaultView. Preserve the
+	// previous ambient-realm fallback for that uncommon host shape.
+	if (typeof PointerEvent !== 'undefined' && event instanceof PointerEvent) {
+		return new PointerEvent(event.type, event);
+	}
+	if (typeof KeyboardEvent !== 'undefined' && event instanceof KeyboardEvent) {
+		return new KeyboardEvent(event.type, event);
+	}
+	if (typeof MouseEvent !== 'undefined' && event instanceof MouseEvent) {
+		return new MouseEvent(event.type, event);
+	}
+	if (typeof FocusEvent !== 'undefined' && event instanceof FocusEvent) {
+		return new FocusEvent(event.type, event);
+	}
+	const eventBrand = Object.prototype.toString.call(event);
+	if (eventBrand === '[object PointerEvent]' && typeof PointerEvent !== 'undefined') {
+		return new PointerEvent(event.type, event);
+	}
+	if (eventBrand === '[object KeyboardEvent]' && typeof KeyboardEvent !== 'undefined') {
+		return new KeyboardEvent(event.type, event);
+	}
+	if (eventBrand === '[object MouseEvent]' && typeof MouseEvent !== 'undefined') {
+		return new MouseEvent(event.type, event);
+	}
+	if (eventBrand === '[object FocusEvent]' && typeof FocusEvent !== 'undefined') {
+		return new FocusEvent(event.type, event);
+	}
+	return new Event(event.type, event);
+}
+
 function notifyHydrateBoundary(state: HydrateSlot): void {
 	if (state.didNotify || !state.hydrated) return;
 	state.didNotify = true;
@@ -5939,14 +6018,8 @@ function notifyHydrateBoundary(state: HydrateSlot): void {
 			// `click` is the platform exception among untrusted events: dispatching
 			// the clone still runs its native activation behavior, so links navigate
 			// and submit controls submit unless a hydrated handler prevents default.
-			// Keep dispatchEvent here to preserve the original mouse-event metadata.
-			target.dispatchEvent(
-				typeof MouseEvent !== 'undefined' && event instanceof MouseEvent
-					? new MouseEvent(event.type, event)
-					: typeof FocusEvent !== 'undefined' && event instanceof FocusEvent
-						? new FocusEvent(event.type, event)
-						: new Event(event.type, event),
-			);
+			// Keep dispatchEvent here to preserve native activation and cancellation.
+			target.dispatchEvent(cloneHydrationReplayEvent(event, target));
 		}
 	}
 }
@@ -10370,7 +10443,7 @@ const _injectedStyles = new Set<string>();
 // and text are re-applied each render (so `<title>{state}</title>` is reactive),
 // and it is removed from <head> when the owning scope unmounts (so a route swap
 // replaces the page's metadata). On a hydrated page the server wrote
-// `<!--key-->` + the element into <head> (ssrHeadEl → RenderResult.head →
+// paired key markers + the element into <head> (ssrHeadEl → RenderResult.head →
 // <!--ssr-head-->); headBlock ADOPTS that element rather than appending a copy.
 // ---------------------------------------------------------------------------
 
@@ -10380,30 +10453,59 @@ interface HeadSlot {
 	handlers?: Map<string, EventListener>;
 }
 
-// Find the server-rendered `tag` inside `key`'s marker interval in <head>, remove
-// the marker so a later mount can't re-match it, and return the element. A foreign
+// Find the server-rendered `tag` inside `key`'s paired marker interval in <head>,
+// remove the pair so a later mount can't re-match it, and return the element. A foreign
 // node can be injected between the marker and the server element (extensions,
 // analytics, or document transforms); never claim or mutate it merely because it
-// is adjacent. The next Octane head marker closes this ownership interval.
+// is adjacent. Nested, missing, or reordered delimiters make the interval
+// unprovable, so recovery creates fresh metadata without claiming a same-tag node.
 // Returns null on a fresh client render or when the expected element is missing.
 function adoptServerHeadEl(key: string, tag: string): Element | null {
+	const closeKey = '/' + key;
 	for (let n: Node | null = document.head.firstChild; n !== null; n = n.nextSibling) {
 		if (n.nodeType === 8 && (n as Comment).data === key) {
 			let candidate: Node | null = n.nextSibling;
-			(n as Comment).remove();
+			let match: Element | null = null;
+			let end: Comment | null = null;
+			let malformed = false;
+			let ambiguous = false;
 			while (candidate !== null) {
-				if (candidate.nodeType === 8 && (candidate as Comment).data.startsWith('rnh-')) {
-					break;
+				if (candidate.nodeType === 8) {
+					const marker = (candidate as Comment).data;
+					if (marker === closeKey) {
+						end = candidate as Comment;
+						break;
+					}
+					// A nested/reordered ownership marker means this interval cannot
+					// prove which same-tag node belongs to the requested entry.
+					if (marker.startsWith('rnh-') || marker.startsWith('/rnh-')) {
+						malformed = true;
+						break;
+					}
 				}
 				if (candidate.nodeType === 1 && (candidate as Element).localName === tag) {
-					return candidate as Element;
+					if (match !== null) {
+						ambiguous = true;
+					} else {
+						match = candidate as Element;
+					}
 				}
 				candidate = candidate.nextSibling;
+			}
+			(n as Comment).remove();
+			if (!malformed && end !== null) {
+				end.remove();
+				return ambiguous ? null : match;
 			}
 			return null;
 		}
 	}
 	return null;
+}
+
+function rootIdentifierPrefix(block: Block): string {
+	while (block.parentBlock !== null) block = block.parentBlock;
+	return block.idState.prefix;
 }
 
 export function headBlock(
@@ -10416,11 +10518,11 @@ export function headBlock(
 ): void {
 	if (typeof document === 'undefined') return;
 	// State lives in the dense `slots` array (like every other slot) so the scope
-	// shape stays monomorphic; `key` is only the content hash used to adopt the
+	// shape stays monomorphic; `key` is only the ownership hash used to adopt the
 	// matching server-rendered head element on hydration.
 	let state = scope.slots[slot] as HeadSlot | undefined;
 	if (state === undefined) {
-		let el = adoptServerHeadEl(key, tag);
+		let el = adoptServerHeadEl(headOwnershipKey(key, rootIdentifierPrefix(scope.block)), tag);
 		if (el === null) {
 			el = document.createElement(tag);
 			document.head.appendChild(el);

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -5910,81 +5910,45 @@ function activateHydrateBoundary(state: HydrateSlot): void {
 }
 
 function cloneHydrationReplayEvent(event: Event, target: Element): Event {
-	// Event constructors are realm-specific. Hydrating an iframe-owned root from
-	// its parent realm must still replay an event created by the iframe's Window.
-	const ownerWindow = target.ownerDocument.defaultView;
-	if (ownerWindow !== null) {
-		// PointerEvent extends MouseEvent, so it must be selected first or pointer-
-		// specific metadata (pressure, pointerId, tilt, etc.) is discarded.
-		if (
-			typeof ownerWindow.PointerEvent !== 'undefined' &&
-			event instanceof ownerWindow.PointerEvent
-		) {
-			return new ownerWindow.PointerEvent(event.type, event);
-		}
-		if (
-			typeof ownerWindow.KeyboardEvent !== 'undefined' &&
-			event instanceof ownerWindow.KeyboardEvent
-		) {
-			return new ownerWindow.KeyboardEvent(event.type, event);
-		}
-		if (typeof ownerWindow.MouseEvent !== 'undefined' && event instanceof ownerWindow.MouseEvent) {
-			return new ownerWindow.MouseEvent(event.type, event);
-		}
-		if (typeof ownerWindow.FocusEvent !== 'undefined' && event instanceof ownerWindow.FocusEvent) {
-			return new ownerWindow.FocusEvent(event.type, event);
-		}
-		// Programmatic dispatch may cross realms: the original event can come from
-		// a parent Window while its target belongs to this iframe Window. Web IDL's
-		// toStringTag preserves the platform family across that identity boundary;
-		// always construct the replay with the target realm's constructor.
-		const eventBrand = Object.prototype.toString.call(event);
-		if (eventBrand === '[object PointerEvent]' && typeof ownerWindow.PointerEvent !== 'undefined') {
-			return new ownerWindow.PointerEvent(event.type, event);
-		}
-		if (
-			eventBrand === '[object KeyboardEvent]' &&
-			typeof ownerWindow.KeyboardEvent !== 'undefined'
-		) {
-			return new ownerWindow.KeyboardEvent(event.type, event);
-		}
-		if (eventBrand === '[object MouseEvent]' && typeof ownerWindow.MouseEvent !== 'undefined') {
-			return new ownerWindow.MouseEvent(event.type, event);
-		}
-		if (eventBrand === '[object FocusEvent]' && typeof ownerWindow.FocusEvent !== 'undefined') {
-			return new ownerWindow.FocusEvent(event.type, event);
-		}
-		return new ownerWindow.Event(event.type, event);
+	// Event constructors are realm-specific, so the clone is always built with the
+	// TARGET's constructors: hydrating an iframe-owned root from its parent realm
+	// must still replay an event the iframe's own code recognizes. A detached
+	// synthetic Document has no defaultView and falls back to the ambient realm.
+	const realm = target.ownerDocument.defaultView ?? globalThis;
+	// Same-realm replay is the overwhelmingly common case, so it stays a plain
+	// constructor walk: no brand string, no comparisons beyond `instanceof`.
+	// PointerEvent extends MouseEvent, so it must be tested first or pointer-
+	// specific metadata (pressure, pointerId, tilt, etc.) is discarded.
+	if (realm.PointerEvent !== undefined && event instanceof realm.PointerEvent) {
+		return new realm.PointerEvent(event.type, event);
 	}
-
-	// A detached synthetic Document can have no defaultView. Preserve the
-	// previous ambient-realm fallback for that uncommon host shape.
-	if (typeof PointerEvent !== 'undefined' && event instanceof PointerEvent) {
-		return new PointerEvent(event.type, event);
+	if (realm.KeyboardEvent !== undefined && event instanceof realm.KeyboardEvent) {
+		return new realm.KeyboardEvent(event.type, event);
 	}
-	if (typeof KeyboardEvent !== 'undefined' && event instanceof KeyboardEvent) {
-		return new KeyboardEvent(event.type, event);
+	if (realm.MouseEvent !== undefined && event instanceof realm.MouseEvent) {
+		return new realm.MouseEvent(event.type, event);
 	}
-	if (typeof MouseEvent !== 'undefined' && event instanceof MouseEvent) {
-		return new MouseEvent(event.type, event);
+	if (realm.FocusEvent !== undefined && event instanceof realm.FocusEvent) {
+		return new realm.FocusEvent(event.type, event);
 	}
-	if (typeof FocusEvent !== 'undefined' && event instanceof FocusEvent) {
-		return new FocusEvent(event.type, event);
+	// Cold: a programmatic dispatch may cross realms, where the original event
+	// came from a parent Window while its target belongs to an iframe Window (or
+	// the reverse). No local constructor claims it, but Web IDL's toStringTag
+	// still reports the platform family across that identity boundary.
+	const brand = Object.prototype.toString.call(event);
+	if (realm.PointerEvent !== undefined && brand === '[object PointerEvent]') {
+		return new realm.PointerEvent(event.type, event);
 	}
-	const eventBrand = Object.prototype.toString.call(event);
-	if (eventBrand === '[object PointerEvent]' && typeof PointerEvent !== 'undefined') {
-		return new PointerEvent(event.type, event);
+	if (realm.KeyboardEvent !== undefined && brand === '[object KeyboardEvent]') {
+		return new realm.KeyboardEvent(event.type, event);
 	}
-	if (eventBrand === '[object KeyboardEvent]' && typeof KeyboardEvent !== 'undefined') {
-		return new KeyboardEvent(event.type, event);
+	if (realm.MouseEvent !== undefined && brand === '[object MouseEvent]') {
+		return new realm.MouseEvent(event.type, event);
 	}
-	if (eventBrand === '[object MouseEvent]' && typeof MouseEvent !== 'undefined') {
-		return new MouseEvent(event.type, event);
+	if (realm.FocusEvent !== undefined && brand === '[object FocusEvent]') {
+		return new realm.FocusEvent(event.type, event);
 	}
-	if (eventBrand === '[object FocusEvent]' && typeof FocusEvent !== 'undefined') {
-		return new FocusEvent(event.type, event);
-	}
-	return new Event(event.type, event);
+	return new realm.Event(event.type, event);
 }
 
 function notifyHydrateBoundary(state: HydrateSlot): void {
@@ -10467,8 +10431,7 @@ function adoptServerHeadEl(key: string, tag: string): Element | null {
 			let candidate: Node | null = n.nextSibling;
 			let match: Element | null = null;
 			let end: Comment | null = null;
-			let malformed = false;
-			let ambiguous = false;
+			let matches = 0;
 			while (candidate !== null) {
 				if (candidate.nodeType === 8) {
 					const marker = (candidate as Comment).data;
@@ -10477,27 +10440,20 @@ function adoptServerHeadEl(key: string, tag: string): Element | null {
 						break;
 					}
 					// A nested/reordered ownership marker means this interval cannot
-					// prove which same-tag node belongs to the requested entry.
-					if (marker.startsWith('rnh-') || marker.startsWith('/rnh-')) {
-						malformed = true;
-						break;
-					}
+					// prove which same-tag node belongs to the requested entry. Leaving
+					// `end` unset below is what makes that case adopt nothing.
+					if (marker.startsWith('rnh-') || marker.startsWith('/rnh-')) break;
 				}
 				if (candidate.nodeType === 1 && (candidate as Element).localName === tag) {
-					if (match !== null) {
-						ambiguous = true;
-					} else {
-						match = candidate as Element;
-					}
+					if (matches++ === 0) match = candidate as Element;
 				}
 				candidate = candidate.nextSibling;
 			}
 			(n as Comment).remove();
-			if (!malformed && end !== null) {
-				end.remove();
-				return ambiguous ? null : match;
-			}
-			return null;
+			if (end === null) return null;
+			end.remove();
+			// Two same-tag candidates are as unprovable as none.
+			return matches === 1 ? match : null;
 		}
 	}
 	return null;

--- a/packages/octane/tests/_fixtures/raw-style-content.ts
+++ b/packages/octane/tests/_fixtures/raw-style-content.ts
@@ -1,0 +1,12 @@
+export const RAW_STYLE_MARKER = "amp=& less=< entity=&amp; close=</style><style data-pwn='server'>";
+
+export const RAW_STYLE_SOURCE =
+	'#raw-style-target { color: rgb(1, 2, 3); }\n' +
+	`#raw-style-target::before { content: "${RAW_STYLE_MARKER}"; }`;
+
+export const UPDATED_RAW_STYLE_MARKER =
+	"updated=& updated-less=< updated-entity=&lt; close=</style><style data-pwn='updated'>";
+
+export const UPDATED_RAW_STYLE_SOURCE =
+	'#raw-style-target { color: rgb(4, 5, 6); }\n' +
+	`#raw-style-target::before { content: "${UPDATED_RAW_STYLE_MARKER}"; }`;

--- a/packages/octane/tests/_fixtures/script-innerhtml.tsrx
+++ b/packages/octane/tests/_fixtures/script-innerhtml.tsrx
@@ -18,6 +18,11 @@ export interface ConditionalSpreadScriptProps extends ScriptSpreadProps {
 	show: boolean;
 }
 
+export interface RawStyleProps {
+	source: string;
+	tag: string;
+}
+
 export function ExecutableScript(props: ScriptSourceProps) @{
 	<script data-kind="executable" dangerouslySetInnerHTML={{ __html: props.source }} />
 }
@@ -87,4 +92,12 @@ export function ConditionalWhitespaceScript(props: { show: boolean }) @{
 	<section>{props.show && <script data-kind="conditional-whitespace">
 
 	</script>}</section>
+}
+
+export function RawStyle(props: RawStyleProps) @{
+	const Tag = props.tag;
+	<>
+		<Tag id="raw-style-sheet" dangerouslySetInnerHTML={{ __html: props.source }} />
+		<div id="raw-style-target">{'styled target'}</div>
+	</>
 }

--- a/packages/octane/tests/browser/deferred-hydration-event-replay/deferred-hydration-event-replay.test.ts
+++ b/packages/octane/tests/browser/deferred-hydration-event-replay/deferred-hydration-event-replay.test.ts
@@ -1,0 +1,155 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { chromium, type Browser, type Page } from 'playwright';
+import { createServer, type Plugin, type ViteDevServer } from 'vite';
+import { renderToString } from 'octane/server';
+import { octane } from 'octane/compiler/vite';
+import { interaction } from 'octane/hydration';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadServerFixture } from '../../_server-fixture.js';
+import {
+	expectedHydrationReplayMetadata,
+	HYDRATION_INTERACTION_EVENT_CASES,
+	HYDRATION_INTERACTION_EVENT_TYPES,
+} from '../../hydration/_hydration-interaction-event-matrix.js';
+import type { HydrationReplayRecord } from '../../hydration/_hydration-interaction-event-matrix.js';
+import * as client from '../../hydration/_fixtures/deferred-hydration-event-replay.tsrx';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = 'packages/octane/tests/hydration/_fixtures/deferred-hydration-event-replay.tsrx';
+const serverFixture = loadServerFixture<typeof client>(FIXTURE);
+
+let server: ViteDevServer;
+let browser: Browser;
+let baseUrl: string;
+let page: Page | undefined;
+let pageFailures: string[] = [];
+
+beforeAll(async () => {
+	const when = interaction({ events: HYDRATION_INTERACTION_EVENT_TYPES });
+	const { html } = renderToString(serverFixture.DeferredHydrationEventReplay, { when });
+	const shellPlugin: Plugin = {
+		name: 'deferred-hydration-event-replay-shell',
+		transformIndexHtml(source) {
+			return source.replace('<!--octane-ssr-->', () => html);
+		},
+	};
+	server = await createServer({
+		configFile: false,
+		root: HERE,
+		logLevel: 'error',
+		cacheDir: resolve(HERE, '../../../../../node_modules/.vite/octane-hydration-event-replay'),
+		plugins: [shellPlugin, octane()],
+		server: { host: '127.0.0.1', port: 0 },
+	});
+	await server.listen();
+	const address = server.httpServer!.address();
+	if (!address || typeof address === 'string') throw new Error('Vite did not expose a TCP port');
+	baseUrl = `http://127.0.0.1:${address.port}`;
+	try {
+		browser = await chromium.launch({ headless: true });
+	} catch (error) {
+		throw new Error(
+			`Chromium is required for deferred hydration event replay evidence (run \`pnpm --filter octane exec playwright install chromium\`): ${String(error)}`,
+		);
+	}
+});
+
+afterEach(async () => {
+	const failures = pageFailures.slice();
+	try {
+		await page?.evaluate(() => window.__deferredHydrationEventReplay?.unmount());
+		await page?.close();
+	} finally {
+		page = undefined;
+		pageFailures = [];
+	}
+	expect(failures).toEqual([]);
+});
+
+afterAll(async () => {
+	await browser?.close();
+	await server?.close();
+});
+
+async function openPage(): Promise<Page> {
+	page = await browser.newPage();
+	pageFailures = [];
+	page.on('pageerror', (error) => pageFailures.push(`pageerror: ${error.message}`));
+	page.on('console', (message) => {
+		if (message.type() === 'error' || message.type() === 'warning') {
+			pageFailures.push(`${message.type()}: ${message.text()}`);
+		}
+	});
+	await page.goto(baseUrl);
+	await page.waitForFunction(
+		() => window.__deferredHydrationEventReplay?.state().onHydratedCount === 1,
+	);
+	if (pageFailures.length) throw new Error(pageFailures.join('\n'));
+	return page;
+}
+
+describe.sequential('deferred hydration event replay in a real browser', () => {
+	it('preserves every public event family, metadata, order, target, and cancellation', async () => {
+		const page = await openPage();
+		const state = await page.evaluate(() => window.__deferredHydrationEventReplay.state());
+
+		expect(state.targetSame).toBe(true);
+		expect(state.onHydratedCount).toBe(1);
+		expect(state.originalOutcomes).toEqual(
+			HYDRATION_INTERACTION_EVENT_CASES.map((testCase) => ({
+				type: testCase.type,
+				dispatched: !(testCase.bubbles && testCase.cancelable),
+				defaultPrevented: testCase.bubbles && testCase.cancelable,
+			})),
+		);
+
+		const targetRecords = state.records.filter(
+			(record: HydrationReplayRecord) => record.phase === 'target',
+		);
+		const parentRecords = state.records.filter(
+			(record: HydrationReplayRecord) => record.phase === 'parent',
+		);
+		expect(targetRecords.map((record: HydrationReplayRecord) => record.type)).toEqual(
+			HYDRATION_INTERACTION_EVENT_TYPES,
+		);
+		const bubblingCases = HYDRATION_INTERACTION_EVENT_CASES.filter((testCase) => testCase.bubbles);
+		expect(parentRecords.map((record: HydrationReplayRecord) => record.type)).toEqual(
+			bubblingCases.map((testCase) => testCase.type),
+		);
+
+		for (let i = 0; i < HYDRATION_INTERACTION_EVENT_CASES.length; i++) {
+			const testCase = HYDRATION_INTERACTION_EVENT_CASES[i];
+			expect(targetRecords[i]).toMatchObject({
+				phase: 'target',
+				type: testCase.type,
+				targetId: 'hydration-replay-target',
+				currentTargetId: 'hydration-replay-target',
+				targetIsOriginal: true,
+				bubbles: testCase.bubbles,
+				cancelable: testCase.cancelable,
+				composed: testCase.composed,
+				defaultPreventedBefore: false,
+				defaultPreventedAfter: testCase.type === 'click',
+				...expectedHydrationReplayMetadata(testCase),
+			});
+		}
+		for (let i = 0; i < parentRecords.length; i++) {
+			const testCase = bubblingCases[i];
+			expect(parentRecords[i]).toMatchObject({
+				phase: 'parent',
+				type: testCase.type,
+				targetId: 'hydration-replay-target',
+				currentTargetId: 'hydration-replay-parent',
+				targetIsOriginal: true,
+				bubbles: true,
+				cancelable: testCase.cancelable,
+				composed: testCase.composed,
+				defaultPreventedBefore: testCase.type === 'click',
+				defaultPreventedAfter: testCase.type === 'click',
+				...expectedHydrationReplayMetadata(testCase),
+			});
+		}
+		expect(state.hash).toBe('');
+	});
+});

--- a/packages/octane/tests/browser/deferred-hydration-event-replay/index.html
+++ b/packages/octane/tests/browser/deferred-hydration-event-replay/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Octane deferred hydration event replay</title>
+	</head>
+	<body>
+		<div id="root"><!--octane-ssr--></div>
+		<script type="module" src="/main.ts"></script>
+	</body>
+</html>

--- a/packages/octane/tests/browser/deferred-hydration-event-replay/main.ts
+++ b/packages/octane/tests/browser/deferred-hydration-event-replay/main.ts
@@ -1,0 +1,78 @@
+import { flushSync, hydrateRoot } from '../../../src/index.js';
+import { initializeHydrationEventCapture, interaction } from '../../../src/hydration/index.js';
+import {
+	createHydrationInteractionEvent,
+	HYDRATION_INTERACTION_EVENT_CASES,
+	HYDRATION_INTERACTION_EVENT_TYPES,
+	observeHydrationReplays,
+	type HydrationReplayRecord,
+} from '../../hydration/_hydration-interaction-event-matrix.js';
+import { DeferredHydrationEventReplay } from '../../hydration/_fixtures/deferred-hydration-event-replay.tsrx';
+
+type OriginalEventOutcome = {
+	type: string;
+	dispatched: boolean;
+	defaultPrevented: boolean;
+};
+
+type BrowserReplayState = {
+	hash: string;
+	onHydratedCount: number;
+	originalOutcomes: OriginalEventOutcome[];
+	records: HydrationReplayRecord[];
+	targetSame: boolean;
+};
+
+const container = document.querySelector('#root')!;
+const parent = container.querySelector('#hydration-replay-parent')!;
+const target = container.querySelector('#hydration-replay-target')!;
+const relatedTarget = container.querySelector('#hydration-replay-related')!;
+const originalOutcomes: OriginalEventOutcome[] = [];
+
+initializeHydrationEventCapture(document);
+for (const testCase of HYDRATION_INTERACTION_EVENT_CASES) {
+	const event = createHydrationInteractionEvent(window, relatedTarget, testCase);
+	originalOutcomes.push({
+		type: testCase.type,
+		dispatched: target.dispatchEvent(event),
+		defaultPrevented: event.defaultPrevented,
+	});
+}
+
+let onHydratedCount = 0;
+let observation: ReturnType<typeof observeHydrationReplays> | undefined;
+const root = hydrateRoot(container, DeferredHydrationEventReplay, {
+	when: interaction({ events: HYDRATION_INTERACTION_EVENT_TYPES }),
+	onHydrated() {
+		onHydratedCount++;
+		observation = observeHydrationReplays(parent, target);
+	},
+});
+flushSync(() => {});
+
+function state(): BrowserReplayState {
+	return {
+		hash: location.hash,
+		onHydratedCount,
+		originalOutcomes: originalOutcomes.map((outcome) => ({ ...outcome })),
+		records: observation?.records.map((record) => ({ ...record })) ?? [],
+		targetSame: container.querySelector('#hydration-replay-target') === target,
+	};
+}
+
+window.__deferredHydrationEventReplay = {
+	state,
+	unmount() {
+		observation?.cleanup();
+		root.unmount();
+	},
+};
+
+declare global {
+	interface Window {
+		__deferredHydrationEventReplay: {
+			state(): BrowserReplayState;
+			unmount(): void;
+		};
+	}
+}

--- a/packages/octane/tests/browser/raw-style-hydration/index.html
+++ b/packages/octane/tests/browser/raw-style-hydration/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Octane raw style hydration</title>
+	</head>
+	<body>
+		<div id="root"><!--octane-ssr--></div>
+		<script type="module" src="/main.ts"></script>
+	</body>
+</html>

--- a/packages/octane/tests/browser/raw-style-hydration/main.ts
+++ b/packages/octane/tests/browser/raw-style-hydration/main.ts
@@ -1,0 +1,52 @@
+import { flushSync, hydrateRoot } from '../../../src/index.js';
+import { RawStyle } from '../../_fixtures/script-innerhtml.tsrx';
+import { RAW_STYLE_SOURCE, UPDATED_RAW_STYLE_SOURCE } from '../../_fixtures/raw-style-content.js';
+
+const container = document.querySelector('#root') as HTMLElement;
+const serverStyle = container.querySelector('#raw-style-sheet') as HTMLStyleElement;
+const serverTarget = container.querySelector('#raw-style-target') as HTMLElement;
+const props = { tag: 'style', source: RAW_STYLE_SOURCE };
+const root = hydrateRoot(container, RawStyle, props);
+flushSync(() => {});
+
+function snapshot() {
+	const style = container.querySelector('#raw-style-sheet') as HTMLStyleElement;
+	const target = container.querySelector('#raw-style-target') as HTMLElement;
+	return {
+		color: getComputedStyle(target).color,
+		content: getComputedStyle(target, '::before').content,
+		cssRuleCount: style.sheet?.cssRules.length ?? -1,
+		styleCount: container.querySelectorAll('style').length,
+		styleSame: style === serverStyle,
+		styleText: style.textContent ?? '',
+		targetSame: target === serverTarget,
+		unexpectedElementCount: container.querySelectorAll('[data-pwn]').length,
+	};
+}
+
+const initial = snapshot();
+flushSync(() =>
+	root.render(RawStyle, {
+		tag: 'style',
+		source: UPDATED_RAW_STYLE_SOURCE,
+	}),
+);
+const updated = snapshot();
+
+window.__rawStyleHydration = {
+	initial,
+	updated,
+	unmount() {
+		root.unmount();
+	},
+};
+
+declare global {
+	interface Window {
+		__rawStyleHydration: {
+			initial: ReturnType<typeof snapshot>;
+			updated: ReturnType<typeof snapshot>;
+			unmount(): void;
+		};
+	}
+}

--- a/packages/octane/tests/browser/raw-style-hydration/raw-style-hydration.test.ts
+++ b/packages/octane/tests/browser/raw-style-hydration/raw-style-hydration.test.ts
@@ -1,0 +1,125 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { chromium, type Browser, type Page } from 'playwright';
+import { createServer, type Plugin, type ViteDevServer } from 'vite';
+import { octane } from 'octane/compiler/vite';
+import { renderToString } from 'octane/server';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadServerFixture } from '../../_server-fixture.js';
+import {
+	RAW_STYLE_MARKER,
+	RAW_STYLE_SOURCE,
+	UPDATED_RAW_STYLE_MARKER,
+} from '../../_fixtures/raw-style-content.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = 'packages/octane/tests/_fixtures/script-innerhtml.tsrx';
+
+let browser: Browser;
+
+beforeAll(async () => {
+	try {
+		browser = await chromium.launch({ headless: true });
+	} catch (error) {
+		throw new Error(
+			`Chromium is required for raw-style hydration evidence (run \`pnpm --filter octane exec playwright install chromium\`): ${String(error)}`,
+		);
+	}
+});
+
+afterAll(async () => {
+	await browser?.close();
+});
+
+async function openHydratedPage(mode: 'dev' | 'prod'): Promise<{
+	failures: string[];
+	page: Page;
+	server: ViteDevServer;
+}> {
+	const serverModule = loadServerFixture(FIXTURE, {
+		id: `/raw-style-hydration-${mode}.tsrx`,
+		compileOptions: mode === 'prod' ? { hmr: false } : {},
+	});
+	const { html } = renderToString(serverModule.RawStyle, {
+		tag: 'style',
+		source: RAW_STYLE_SOURCE,
+	});
+	const shellPlugin: Plugin = {
+		name: 'raw-style-hydration-shell',
+		transformIndexHtml(source) {
+			return source.replace('<!--octane-ssr-->', () => html);
+		},
+	};
+	const server = await createServer({
+		cacheDir: resolve(HERE, `../../../../../node_modules/.vite/octane-raw-style-hydration-${mode}`),
+		configFile: false,
+		root: HERE,
+		logLevel: 'error',
+		plugins: [shellPlugin, octane(mode === 'prod' ? { hmr: false } : {})],
+		server: { host: '127.0.0.1', port: 0 },
+	});
+	const failures: string[] = [];
+	let page: Page | undefined;
+	try {
+		await server.listen();
+		const address = server.httpServer!.address();
+		if (!address || typeof address === 'string') {
+			throw new Error('Vite did not expose a TCP port');
+		}
+
+		page = await browser.newPage();
+		page.on('pageerror', (error) => failures.push(`pageerror: ${error.message}`));
+		page.on('console', (message) => {
+			if (message.type() === 'error' || message.type() === 'warning') {
+				failures.push(`${message.type()}: ${message.text()}`);
+			}
+		});
+		await page.goto(`http://127.0.0.1:${address.port}`);
+		await page.waitForFunction(() => Boolean(window.__rawStyleHydration));
+		return { failures, page, server };
+	} catch (error) {
+		await Promise.allSettled([page?.close(), server.close()]);
+		throw error;
+	}
+}
+
+describe.sequential('raw <style> real-browser hydration', () => {
+	it.each(['dev', 'prod'])(
+		'%s adopts server CSS and preserves raw-text semantics through update',
+		async (mode) => {
+			const { failures, page, server } = await openHydratedPage(mode as 'dev' | 'prod');
+			try {
+				const state = await page.evaluate(() => window.__rawStyleHydration);
+				expect(state.initial).toMatchObject({
+					color: 'rgb(1, 2, 3)',
+					cssRuleCount: 2,
+					styleCount: 1,
+					styleSame: true,
+					targetSame: true,
+					unexpectedElementCount: 0,
+				});
+				expect(state.initial.content).toContain(RAW_STYLE_MARKER);
+				expect(state.initial.styleText).toContain('amp=&');
+				expect(state.initial.styleText).toContain('less=<');
+				expect(state.initial.styleText).toContain('entity=&amp;');
+
+				expect(state.updated).toMatchObject({
+					color: 'rgb(4, 5, 6)',
+					cssRuleCount: 2,
+					styleCount: 1,
+					styleSame: true,
+					targetSame: true,
+					unexpectedElementCount: 0,
+				});
+				expect(state.updated.content).toContain(UPDATED_RAW_STYLE_MARKER);
+				expect(failures).toEqual([]);
+			} finally {
+				try {
+					await page.evaluate(() => window.__rawStyleHydration.unmount());
+				} finally {
+					await Promise.allSettled([page.close(), server.close()]);
+				}
+			}
+		},
+	);
+});

--- a/packages/octane/tests/browser/suspense-hydration/main.ts
+++ b/packages/octane/tests/browser/suspense-hydration/main.ts
@@ -85,6 +85,8 @@ function mountHydrationCase(): void {
 					container.querySelectorAll('#hydration-text'),
 					(node) => node.textContent,
 				),
+				recoveredActionText:
+					container.querySelector('#hydration-recovered-action')?.textContent?.trim() ?? '',
 				globalFailures: globalFailures.slice(),
 			};
 		},

--- a/packages/octane/tests/browser/suspense-hydration/suspense-hydration.test.ts
+++ b/packages/octane/tests/browser/suspense-hydration/suspense-hydration.test.ts
@@ -193,8 +193,11 @@ describe.sequential('real-browser Suspense and async hydration evidence', () => 
 		expect(state.outsideSame).toBe(true);
 		expect(state.fallbackCount).toBe(0);
 		expect(state.headings).toEqual(['replaced']);
+		expect(state.recoveredActionText).toBe('recovered:0');
 		expect(state.globalFailures).toEqual([]);
 		expect(hydrationDiagnostics).toHaveLength(1);
+		await page.locator('#hydration-recovered-action').click();
+		expect((await snapshot()).recoveredActionText).toBe('recovered:1');
 		await page.locator('#hydration-outside').click();
 		expect((await snapshot()).outsideText).toBe('outside:2');
 	});

--- a/packages/octane/tests/bundler-compiler.test.ts
+++ b/packages/octane/tests/bundler-compiler.test.ts
@@ -32,6 +32,10 @@ function profileFiles(code: string | undefined): Set<string> {
 	return new Set(uniqueMetadata([...output.components, ...output.hooks]).map(({ file }) => file));
 }
 
+function emittedHeadKey(code: string | undefined): string | undefined {
+	return code?.match(/["'](rnh-[0-9a-f]{8})["']/)?.[1];
+}
+
 describe('bundler-neutral compiler integration', () => {
 	it('normalizes the canonical cross-adapter client-reference manifest', () => {
 		const first = {
@@ -90,6 +94,23 @@ describe('bundler-neutral compiler integration', () => {
 			'C:/external/App.tsrx',
 		);
 		expect(canonicalModuleId('#nitro/virtual/polyfills', root)).toBe('#nitro/virtual/polyfills');
+	});
+
+	it('uses the shared canonical module id for client/server head ownership', () => {
+		const compiler = createOctaneCompiler({ root: '/project' });
+		const source = 'export function Page() @{ <title>module title</title> }';
+		const client = compiler.transform(source, '/project/src/Page.tsrx?client=1', {
+			environment: 'client',
+		});
+		const server = compiler.transform(source, '/project/src/Page.tsrx?server=1', {
+			environment: 'server',
+		});
+		const otherModule = compiler.transform(source, '/project/src/OtherPage.tsrx', {
+			environment: 'client',
+		});
+
+		expect(emittedHeadKey(client?.code)).toBe(emittedHeadKey(server?.code));
+		expect(emittedHeadKey(otherModule?.code)).not.toBe(emittedHeadKey(client?.code));
 	});
 
 	it('compiles the same source for client and server with maps', () => {

--- a/packages/octane/tests/conformance/_fixtures/fizz-readiness-hydration.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/fizz-readiness-hydration.tsrx
@@ -56,9 +56,13 @@ export function ContentAndNestedFallbackSuspend(props) @{
 }
 
 export function HydrationLeaf(props) @{
+	const [count, setCount] = useState(0);
 	<>
 		<p id="hydration-leaf">{'A'}</p>
 		<h2 id="hydration-text">{props.text as string}</h2>
+		<button id="hydration-recovered-action" onClick={() => setCount(count + 1)}>
+			{'recovered:' + count}
+		</button>
 	</>
 }
 

--- a/packages/octane/tests/conformance/fizz-readiness-hydration.test.ts
+++ b/packages/octane/tests/conformance/fizz-readiness-hydration.test.ts
@@ -218,6 +218,11 @@ describe('conformance: Fizz readiness and hydration behavior', () => {
 			expect(
 				Array.from(container.querySelectorAll('#hydration-text'), (node) => node.textContent),
 			).toEqual(['replaced']);
+			const recoveredAction = container.querySelector<HTMLButtonElement>(
+				'#hydration-recovered-action',
+			)!;
+			flushSync(() => recoveredAction.click());
+			expect(recoveredAction.textContent?.trim()).toBe('recovered:1');
 			expect(container.querySelector('#hydration-outside')).toBe(outside);
 			flushSync(() => outside.click());
 			expect(outside.textContent?.trim()).toBe('outside:2');

--- a/packages/octane/tests/control-fold.test.ts
+++ b/packages/octane/tests/control-fold.test.ts
@@ -612,11 +612,15 @@ describe('template directives in a returned fragment', () => {
 		expect(link?.getAttribute('href')).toBe('/hydrated');
 		expect(body?.textContent).toBe('Hydrated body');
 		for (const headElement of [title!, meta!, link!]) {
-			const adjacentServerNode = headElement.previousSibling;
-			if (adjacentServerNode?.nodeType === Node.COMMENT_NODE) {
-				document.head.append(adjacentServerNode);
+			const precedingServerNode = headElement.previousSibling;
+			const followingServerNode = headElement.nextSibling;
+			if (precedingServerNode?.nodeType === Node.COMMENT_NODE) {
+				document.head.append(precedingServerNode);
 			}
 			document.head.append(headElement);
+			if (followingServerNode?.nodeType === Node.COMMENT_NODE) {
+				document.head.append(followingServerNode);
+			}
 		}
 		const container = document.createElement('div');
 		document.body.appendChild(container);

--- a/packages/octane/tests/hydration/_fixtures/deferred-hydration-event-replay.tsrx
+++ b/packages/octane/tests/hydration/_fixtures/deferred-hydration-event-replay.tsrx
@@ -1,0 +1,10 @@
+import { Hydrate } from 'octane';
+
+export function DeferredHydrationEventReplay(props) @{
+	<Hydrate when={props.when} split={false} onHydrated={props.onHydrated}>
+		<section id="hydration-replay-parent">
+			<a id="hydration-replay-target" href="#hydration-replay-default">{'Replay interaction'}</a>
+			<span id="hydration-replay-related">{'Related target'}</span>
+		</section>
+	</Hydrate>
+}

--- a/packages/octane/tests/hydration/_fixtures/structural.tsrx
+++ b/packages/octane/tests/hydration/_fixtures/structural.tsrx
@@ -1,5 +1,6 @@
 // P3 structural-mismatch fixtures: branches whose ROOT TAG differs, so a server/client
 // branch swap is a true structural divergence the hydration recovery detects + rebuilds.
+import { Suspense, useState } from 'octane';
 
 export function Pick(props) @{
 	<div id="pick">
@@ -15,4 +16,67 @@ export function Pick(props) @{
 			}
 		}
 	</div>
+}
+
+function RecoveryButton(props: { id: string; label: string }) @{
+	const [count, setCount] = useState(0);
+	<button id={props.id} onClick={() => setCount(count + 1)}>{props.label + ':' + count}</button>
+}
+
+// RDX-HYD-006: a mismatch at the root has no narrower ownership scope. Recovery
+// must leave one clean client tree and install handlers on the replacement.
+export function RootScopedRecovery(props: { isClient: boolean }) @{
+	@if (props.isClient) {
+		<article id="root-client">
+			<RecoveryButton id="root-recovered-action" label="root" />
+		</article>
+	} @else {
+		<section id="root-server">
+			<span id="root-stale">{'server root'}</span>
+		</section>
+	}
+}
+
+// RDX-HYD-006: the divergent range is nested beneath a stable host. The host and
+// its outside siblings must stay adopted while only the failed range is rebuilt.
+export function HostScopedRecovery(props: { isClient: boolean }) @{
+	<main id="host-recovery-root">
+		<header id="host-stable-header">{'header'}</header>
+		<section id="host-recovery-scope">
+			@if (props.isClient) {
+				<article id="host-client-range">
+					<RecoveryButton id="host-recovered-action" label="inside" />
+				</article>
+			} @else {
+				<aside id="host-server-range">
+					<span id="host-stale">{'server range'}</span>
+				</aside>
+			}
+		</section>
+		<footer id="host-stable-footer">
+			<RecoveryButton id="host-outside-action" label="outside" />
+		</footer>
+	</main>
+}
+
+// RDX-HYD-006: the failed range is owned inside Suspense. Recovery must not
+// remount siblings outside the boundary, and the regenerated handler must work.
+export function SuspenseScopedRecovery(props: { isClient: boolean }) @{
+	<main id="suspense-recovery-root">
+		<header id="suspense-stable-header">
+			<RecoveryButton id="suspense-outside-action" label="outside" />
+		</header>
+		<Suspense fallback={<p id="suspense-recovery-fallback">{'loading'}</p>}>
+			@if (props.isClient) {
+				<section id="suspense-client-range">
+					<RecoveryButton id="suspense-recovered-action" label="inside" />
+				</section>
+			} @else {
+				<article id="suspense-server-range">
+					<span id="suspense-stale">{'server boundary'}</span>
+				</article>
+			}
+		</Suspense>
+		<footer id="suspense-stable-footer">{'footer'}</footer>
+	</main>
 }

--- a/packages/octane/tests/hydration/_hydration-interaction-event-matrix.ts
+++ b/packages/octane/tests/hydration/_hydration-interaction-event-matrix.ts
@@ -1,0 +1,450 @@
+import type { HydrationInteractionEvent } from 'octane/hydration';
+
+export type HydrationInteractionEventFamily = 'focus' | 'keyboard' | 'mouse' | 'pointer';
+
+export type HydrationInteractionEventCase = {
+	type: HydrationInteractionEvent;
+	family: HydrationInteractionEventFamily;
+	bubbles: boolean;
+	cancelable: boolean;
+	composed: boolean;
+	sequence: number;
+};
+
+export const HYDRATION_INTERACTION_EVENT_CASES = [
+	{
+		type: 'auxclick',
+		family: 'mouse',
+		bubbles: true,
+		cancelable: true,
+		composed: true,
+		sequence: 1,
+	},
+	{
+		type: 'click',
+		family: 'mouse',
+		bubbles: true,
+		cancelable: true,
+		composed: true,
+		sequence: 2,
+	},
+	{
+		type: 'contextmenu',
+		family: 'mouse',
+		bubbles: true,
+		cancelable: true,
+		composed: true,
+		sequence: 3,
+	},
+	{
+		type: 'dblclick',
+		family: 'mouse',
+		bubbles: true,
+		cancelable: true,
+		composed: true,
+		sequence: 4,
+	},
+	{
+		type: 'focusin',
+		family: 'focus',
+		bubbles: true,
+		cancelable: false,
+		composed: true,
+		sequence: 5,
+	},
+	{
+		type: 'keydown',
+		family: 'keyboard',
+		bubbles: true,
+		cancelable: true,
+		composed: true,
+		sequence: 6,
+	},
+	{
+		type: 'keyup',
+		family: 'keyboard',
+		bubbles: true,
+		cancelable: true,
+		composed: true,
+		sequence: 7,
+	},
+	{
+		type: 'mousedown',
+		family: 'mouse',
+		bubbles: true,
+		cancelable: true,
+		composed: true,
+		sequence: 8,
+	},
+	{
+		type: 'mouseenter',
+		family: 'mouse',
+		bubbles: false,
+		cancelable: false,
+		composed: false,
+		sequence: 9,
+	},
+	{
+		type: 'mouseover',
+		family: 'mouse',
+		bubbles: true,
+		cancelable: true,
+		composed: true,
+		sequence: 10,
+	},
+	{
+		type: 'mouseup',
+		family: 'mouse',
+		bubbles: true,
+		cancelable: true,
+		composed: true,
+		sequence: 11,
+	},
+	{
+		type: 'pointerdown',
+		family: 'pointer',
+		bubbles: true,
+		cancelable: true,
+		composed: true,
+		sequence: 12,
+	},
+	{
+		type: 'pointerenter',
+		family: 'pointer',
+		bubbles: false,
+		cancelable: false,
+		composed: false,
+		sequence: 13,
+	},
+	{
+		type: 'pointerover',
+		family: 'pointer',
+		bubbles: true,
+		cancelable: true,
+		composed: true,
+		sequence: 14,
+	},
+	{
+		type: 'pointerup',
+		family: 'pointer',
+		bubbles: true,
+		cancelable: true,
+		composed: true,
+		sequence: 15,
+	},
+] as const satisfies ReadonlyArray<HydrationInteractionEventCase>;
+
+type AssertNever<T extends never> = T;
+
+// Adding a public interaction event must add public replay evidence in the same
+// change. The reverse direction is checked by `satisfies` above.
+export type AllHydrationInteractionEventsCovered = AssertNever<
+	Exclude<HydrationInteractionEvent, (typeof HYDRATION_INTERACTION_EVENT_CASES)[number]['type']>
+>;
+
+export const HYDRATION_INTERACTION_EVENT_TYPES = HYDRATION_INTERACTION_EVENT_CASES.map(
+	(testCase) => testCase.type,
+);
+
+export const HYDRATION_INTERACTION_CROSS_REALM_CASES = HYDRATION_INTERACTION_EVENT_CASES.filter(
+	(testCase) =>
+		testCase.type === 'focusin' ||
+		testCase.type === 'keydown' ||
+		testCase.type === 'mousedown' ||
+		testCase.type === 'pointerdown',
+);
+
+type EventWindow = Window & typeof globalThis;
+
+function mouseEventInit(
+	relatedTarget: EventTarget,
+	testCase: HydrationInteractionEventCase,
+): MouseEventInit {
+	const sequence = testCase.sequence;
+	const button = testCase.type === 'auxclick' ? 1 : testCase.type === 'contextmenu' ? 2 : 0;
+	return {
+		bubbles: testCase.bubbles,
+		cancelable: testCase.cancelable,
+		composed: testCase.composed,
+		detail: sequence,
+		screenX: 100 + sequence,
+		screenY: 200 + sequence,
+		clientX: 300 + sequence,
+		clientY: 400 + sequence,
+		ctrlKey: sequence % 2 === 0,
+		shiftKey: sequence % 3 === 0,
+		altKey: sequence % 4 === 0,
+		metaKey: sequence % 5 === 0,
+		button,
+		buttons: 1 << button,
+		relatedTarget,
+	};
+}
+
+export function createHydrationInteractionEvent(
+	ownerWindow: EventWindow,
+	relatedTarget: EventTarget,
+	testCase: HydrationInteractionEventCase,
+): Event {
+	const base = {
+		bubbles: testCase.bubbles,
+		cancelable: testCase.cancelable,
+		composed: testCase.composed,
+	};
+	const sequence = testCase.sequence;
+	switch (testCase.family) {
+		case 'focus':
+			return new ownerWindow.FocusEvent(testCase.type, {
+				...base,
+				detail: sequence,
+				relatedTarget,
+			});
+		case 'keyboard':
+			return new ownerWindow.KeyboardEvent(testCase.type, {
+				...base,
+				detail: sequence,
+				key: `key-${sequence}`,
+				code: `Code${sequence}`,
+				location: sequence % 4,
+				repeat: sequence % 2 === 0,
+				isComposing: sequence % 3 === 0,
+				ctrlKey: sequence % 2 === 0,
+				shiftKey: sequence % 3 === 0,
+				altKey: sequence % 4 === 0,
+				metaKey: sequence % 5 === 0,
+			});
+		case 'mouse':
+			return new ownerWindow.MouseEvent(testCase.type, mouseEventInit(relatedTarget, testCase));
+		case 'pointer':
+			return new ownerWindow.PointerEvent(testCase.type, {
+				...mouseEventInit(relatedTarget, testCase),
+				pointerId: 500 + sequence,
+				width: 20 + sequence,
+				height: 30 + sequence,
+				pressure: 0.5,
+				tangentialPressure: 0.25,
+				tiltX: sequence,
+				tiltY: -sequence,
+				twist: 40 + sequence,
+				pointerType: 'pen',
+				isPrimary: sequence % 2 === 0,
+			});
+	}
+}
+
+export type HydrationReplayRecord = {
+	phase: 'parent' | 'target';
+	type: string;
+	constructorName: string;
+	targetId: string | null;
+	currentTargetId: string | null;
+	targetIsOriginal: boolean;
+	bubbles: boolean;
+	cancelable: boolean;
+	composed: boolean;
+	defaultPreventedBefore: boolean;
+	defaultPreventedAfter: boolean;
+	detail: number | null;
+	relatedTargetId: string | null;
+	screenX: number | null;
+	screenY: number | null;
+	clientX: number | null;
+	clientY: number | null;
+	ctrlKey: boolean | null;
+	shiftKey: boolean | null;
+	altKey: boolean | null;
+	metaKey: boolean | null;
+	button: number | null;
+	buttons: number | null;
+	key: string | null;
+	code: string | null;
+	location: number | null;
+	repeat: boolean | null;
+	isComposing: boolean | null;
+	pointerId: number | null;
+	width: number | null;
+	height: number | null;
+	pressure: number | null;
+	tangentialPressure: number | null;
+	tiltX: number | null;
+	tiltY: number | null;
+	twist: number | null;
+	pointerType: string | null;
+	isPrimary: boolean | null;
+};
+
+function numberProperty(event: Event, name: string): number | null {
+	const value = (event as unknown as Record<string, unknown>)[name];
+	return typeof value === 'number' ? value : null;
+}
+
+function booleanProperty(event: Event, name: string): boolean | null {
+	const value = (event as unknown as Record<string, unknown>)[name];
+	return typeof value === 'boolean' ? value : null;
+}
+
+function stringProperty(event: Event, name: string): string | null {
+	const value = (event as unknown as Record<string, unknown>)[name];
+	return typeof value === 'string' ? value : null;
+}
+
+function elementId(value: unknown): string | null {
+	return value !== null &&
+		typeof value === 'object' &&
+		'nodeType' in value &&
+		(value as Node).nodeType === 1
+		? (value as Element).id
+		: null;
+}
+
+function hydrationReplayRecord(
+	phase: 'parent' | 'target',
+	originalTarget: Element,
+	event: Event,
+): HydrationReplayRecord {
+	const defaultPreventedBefore = event.defaultPrevented;
+	if (phase === 'target' && event.type === 'click') event.preventDefault();
+	return {
+		phase,
+		type: event.type,
+		constructorName: event.constructor.name,
+		targetId: elementId(event.target),
+		currentTargetId: elementId(event.currentTarget),
+		targetIsOriginal: event.target === originalTarget,
+		bubbles: event.bubbles,
+		cancelable: event.cancelable,
+		composed: event.composed,
+		defaultPreventedBefore,
+		defaultPreventedAfter: event.defaultPrevented,
+		detail: numberProperty(event, 'detail'),
+		relatedTargetId: elementId((event as unknown as Record<string, unknown>).relatedTarget ?? null),
+		screenX: numberProperty(event, 'screenX'),
+		screenY: numberProperty(event, 'screenY'),
+		clientX: numberProperty(event, 'clientX'),
+		clientY: numberProperty(event, 'clientY'),
+		ctrlKey: booleanProperty(event, 'ctrlKey'),
+		shiftKey: booleanProperty(event, 'shiftKey'),
+		altKey: booleanProperty(event, 'altKey'),
+		metaKey: booleanProperty(event, 'metaKey'),
+		button: numberProperty(event, 'button'),
+		buttons: numberProperty(event, 'buttons'),
+		key: stringProperty(event, 'key'),
+		code: stringProperty(event, 'code'),
+		location: numberProperty(event, 'location'),
+		repeat: booleanProperty(event, 'repeat'),
+		isComposing: booleanProperty(event, 'isComposing'),
+		pointerId: numberProperty(event, 'pointerId'),
+		width: numberProperty(event, 'width'),
+		height: numberProperty(event, 'height'),
+		pressure: numberProperty(event, 'pressure'),
+		tangentialPressure: numberProperty(event, 'tangentialPressure'),
+		tiltX: numberProperty(event, 'tiltX'),
+		tiltY: numberProperty(event, 'tiltY'),
+		twist: numberProperty(event, 'twist'),
+		pointerType: stringProperty(event, 'pointerType'),
+		isPrimary: booleanProperty(event, 'isPrimary'),
+	};
+}
+
+export function observeHydrationReplays(
+	parent: Element,
+	target: Element,
+): { records: HydrationReplayRecord[]; cleanup: () => void } {
+	const records: HydrationReplayRecord[] = [];
+	const listeners: Array<{
+		element: Element;
+		type: HydrationInteractionEvent;
+		listener: EventListener;
+	}> = [];
+	const listen = (
+		element: Element,
+		phase: 'parent' | 'target',
+		type: HydrationInteractionEvent,
+	) => {
+		const listener: EventListener = (event) => {
+			records.push(hydrationReplayRecord(phase, target, event));
+		};
+		element.addEventListener(type, listener);
+		listeners.push({ element, type, listener });
+	};
+	for (const testCase of HYDRATION_INTERACTION_EVENT_CASES) {
+		listen(target, 'target', testCase.type);
+		listen(parent, 'parent', testCase.type);
+	}
+	return {
+		records,
+		cleanup() {
+			for (const { element, type, listener } of listeners) {
+				element.removeEventListener(type, listener);
+			}
+		},
+	};
+}
+
+export function expectedHydrationReplayMetadata(
+	testCase: HydrationInteractionEventCase,
+): Partial<HydrationReplayRecord> {
+	const sequence = testCase.sequence;
+	const button = testCase.type === 'auxclick' ? 1 : testCase.type === 'contextmenu' ? 2 : 0;
+	const modifiers = {
+		ctrlKey: sequence % 2 === 0,
+		shiftKey: sequence % 3 === 0,
+		altKey: sequence % 4 === 0,
+		metaKey: sequence % 5 === 0,
+	};
+	switch (testCase.family) {
+		case 'focus':
+			return {
+				constructorName: 'FocusEvent',
+				detail: sequence,
+				relatedTargetId: 'hydration-replay-related',
+			};
+		case 'keyboard':
+			return {
+				constructorName: 'KeyboardEvent',
+				detail: sequence,
+				key: `key-${sequence}`,
+				code: `Code${sequence}`,
+				location: sequence % 4,
+				repeat: sequence % 2 === 0,
+				isComposing: sequence % 3 === 0,
+				...modifiers,
+			};
+		case 'mouse':
+			return {
+				constructorName: 'MouseEvent',
+				detail: sequence,
+				screenX: 100 + sequence,
+				screenY: 200 + sequence,
+				clientX: 300 + sequence,
+				clientY: 400 + sequence,
+				button,
+				buttons: 1 << button,
+				relatedTargetId: 'hydration-replay-related',
+				...modifiers,
+			};
+		case 'pointer':
+			return {
+				constructorName: 'PointerEvent',
+				detail: sequence,
+				screenX: 100 + sequence,
+				screenY: 200 + sequence,
+				clientX: 300 + sequence,
+				clientY: 400 + sequence,
+				button,
+				buttons: 1 << button,
+				relatedTargetId: 'hydration-replay-related',
+				pointerId: 500 + sequence,
+				width: 20 + sequence,
+				height: 30 + sequence,
+				pressure: 0.5,
+				tangentialPressure: 0.25,
+				tiltX: sequence,
+				tiltY: -sequence,
+				twist: 40 + sequence,
+				pointerType: 'pen',
+				isPrimary: sequence % 2 === 0,
+				...modifiers,
+			};
+	}
+}

--- a/packages/octane/tests/hydration/deferred-hydration-contract.test.ts
+++ b/packages/octane/tests/hydration/deferred-hydration-contract.test.ts
@@ -354,6 +354,87 @@ describe('deferred hydration contract edges', () => {
 		}
 	});
 
+	// The replay clone is built from the TARGET's constructors, never the incoming
+	// event's, so the same realm crossing must hold in the opposite direction: an
+	// embedded widget can dispatch an event of its own realm into its host document.
+	it('classifies iframe-realm events before replaying them at a host-document target', () => {
+		const iframe = document.createElement('iframe');
+		document.body.appendChild(iframe);
+		let observation: ReturnType<typeof observeHydrationReplays> | undefined;
+		try {
+			const foreignWindow = iframe.contentWindow!;
+			expect(foreignWindow.MouseEvent).not.toBe(MouseEvent);
+			const replayCases = HYDRATION_INTERACTION_CROSS_REALM_CASES;
+			const when = interaction({ events: replayCases.map((testCase) => testCase.type) });
+			container.innerHTML = renderToString(eventReplayServer.DeferredHydrationEventReplay, {
+				when,
+			}).html;
+			const parent = container.querySelector('#hydration-replay-parent')!;
+			const target = container.querySelector('#hydration-replay-target')!;
+			const relatedTarget = container.querySelector('#hydration-replay-related')!;
+
+			initializeHydrationEventCapture(document);
+			for (const testCase of replayCases) {
+				target.dispatchEvent(
+					createHydrationInteractionEvent(foreignWindow, relatedTarget, testCase),
+				);
+			}
+
+			const targetRealmMatches: boolean[] = [];
+			root = hydrateRoot(container, eventReplayClient.DeferredHydrationEventReplay, {
+				when,
+				onHydrated() {
+					for (const testCase of replayCases) {
+						target.addEventListener(
+							testCase.type,
+							(event) => {
+								switch (testCase.family) {
+									case 'focus':
+										targetRealmMatches.push(event instanceof FocusEvent);
+										break;
+									case 'keyboard':
+										targetRealmMatches.push(event instanceof KeyboardEvent);
+										break;
+									case 'mouse':
+										targetRealmMatches.push(event instanceof MouseEvent);
+										break;
+									case 'pointer':
+										targetRealmMatches.push(event instanceof PointerEvent);
+										break;
+								}
+							},
+							{ once: true },
+						);
+					}
+					observation = observeHydrationReplays(parent, target);
+				},
+			});
+			flushSync(() => {});
+			flushEffects();
+
+			const records = observation!.records.filter((record) => record.phase === 'target');
+			expect(records.map((record) => record.type)).toEqual([
+				'focusin',
+				'keydown',
+				'mousedown',
+				'pointerdown',
+			]);
+			expect(targetRealmMatches).toEqual([true, true, true, true]);
+			for (let i = 0; i < replayCases.length; i++) {
+				expect(records[i]).toMatchObject({
+					type: replayCases[i].type,
+					targetIsOriginal: true,
+					...expectedHydrationReplayMetadata(replayCases[i]),
+				});
+			}
+		} finally {
+			observation?.cleanup();
+			root?.unmount();
+			root = undefined;
+			iframe.remove();
+		}
+	});
+
 	it('keeps function-form visibility dormant after hydrateRoot interaction setup', async () => {
 		let intersect!: IntersectionObserverCallback;
 		const observe = vi.fn();

--- a/packages/octane/tests/hydration/deferred-hydration-contract.test.ts
+++ b/packages/octane/tests/hydration/deferred-hydration-contract.test.ts
@@ -14,10 +14,22 @@ import {
 import { renderToString } from 'octane/server';
 import { flushEffects } from '../_helpers.js';
 import { loadServerFixture } from '../_server-fixture.js';
+import {
+	createHydrationInteractionEvent,
+	expectedHydrationReplayMetadata,
+	HYDRATION_INTERACTION_CROSS_REALM_CASES,
+	HYDRATION_INTERACTION_EVENT_CASES,
+	HYDRATION_INTERACTION_EVENT_TYPES,
+	observeHydrationReplays,
+} from './_hydration-interaction-event-matrix.js';
 import * as client from './_fixtures/deferred-hydration-contract.tsrx';
+import * as eventReplayClient from './_fixtures/deferred-hydration-event-replay.tsrx';
 
 const FIXTURE = 'packages/octane/tests/hydration/_fixtures/deferred-hydration-contract.tsrx';
 const server = loadServerFixture<typeof client>(FIXTURE);
+const EVENT_REPLAY_FIXTURE =
+	'packages/octane/tests/hydration/_fixtures/deferred-hydration-event-replay.tsrx';
+const eventReplayServer = loadServerFixture<typeof eventReplayClient>(EVENT_REPLAY_FIXTURE);
 
 function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
 	let resolve!: (value: T) => void;
@@ -116,6 +128,231 @@ describe('deferred hydration contract edges', () => {
 			expect(onClick).toHaveBeenCalledOnce();
 		});
 	}
+
+	it('replays every public interaction event once with its platform shape and queue semantics', () => {
+		const when = interaction({ events: HYDRATION_INTERACTION_EVENT_TYPES });
+		container.innerHTML = renderToString(eventReplayServer.DeferredHydrationEventReplay, {
+			when,
+		}).html;
+		const parent = container.querySelector('#hydration-replay-parent')!;
+		const target = container.querySelector('#hydration-replay-target')!;
+		const relatedTarget = container.querySelector('#hydration-replay-related')!;
+		const initialHash = location.hash;
+		const originalOutcomes: Array<{
+			type: string;
+			dispatched: boolean;
+			defaultPrevented: boolean;
+		}> = [];
+
+		initializeHydrationEventCapture(document);
+		for (const testCase of HYDRATION_INTERACTION_EVENT_CASES) {
+			const event = createHydrationInteractionEvent(document.defaultView!, relatedTarget, testCase);
+			originalOutcomes.push({
+				type: testCase.type,
+				dispatched: target.dispatchEvent(event),
+				defaultPrevented: event.defaultPrevented,
+			});
+		}
+
+		let observation: ReturnType<typeof observeHydrationReplays> | undefined;
+		const onHydrated = vi.fn(() => {
+			observation = observeHydrationReplays(parent, target);
+		});
+		root = hydrateRoot(container, eventReplayClient.DeferredHydrationEventReplay, {
+			when,
+			onHydrated,
+		});
+		flushSync(() => {});
+		flushEffects();
+
+		expect(container.querySelector('#hydration-replay-target')).toBe(target);
+		expect(onHydrated).toHaveBeenCalledOnce();
+		expect(originalOutcomes).toEqual(
+			HYDRATION_INTERACTION_EVENT_CASES.map((testCase) => ({
+				type: testCase.type,
+				dispatched: !(testCase.bubbles && testCase.cancelable),
+				defaultPrevented: testCase.bubbles && testCase.cancelable,
+			})),
+		);
+
+		const records = observation!.records;
+		const targetRecords = records.filter((record) => record.phase === 'target');
+		const parentRecords = records.filter((record) => record.phase === 'parent');
+		const bubblingCases = HYDRATION_INTERACTION_EVENT_CASES.filter((testCase) => testCase.bubbles);
+		expect(targetRecords.map((record) => record.type)).toEqual(HYDRATION_INTERACTION_EVENT_TYPES);
+		expect(parentRecords.map((record) => record.type)).toEqual(
+			bubblingCases.map((testCase) => testCase.type),
+		);
+
+		for (let i = 0; i < HYDRATION_INTERACTION_EVENT_CASES.length; i++) {
+			const testCase = HYDRATION_INTERACTION_EVENT_CASES[i];
+			expect(targetRecords[i]).toMatchObject({
+				phase: 'target',
+				type: testCase.type,
+				targetId: 'hydration-replay-target',
+				currentTargetId: 'hydration-replay-target',
+				targetIsOriginal: true,
+				bubbles: testCase.bubbles,
+				cancelable: testCase.cancelable,
+				composed: testCase.composed,
+				defaultPreventedBefore: false,
+				defaultPreventedAfter: testCase.type === 'click',
+				...expectedHydrationReplayMetadata(testCase),
+			});
+		}
+
+		for (let i = 0; i < parentRecords.length; i++) {
+			const testCase = bubblingCases[i];
+			expect(parentRecords[i]).toMatchObject({
+				phase: 'parent',
+				type: testCase.type,
+				targetId: 'hydration-replay-target',
+				currentTargetId: 'hydration-replay-parent',
+				targetIsOriginal: true,
+				bubbles: true,
+				cancelable: testCase.cancelable,
+				composed: testCase.composed,
+				defaultPreventedBefore: testCase.type === 'click',
+				defaultPreventedAfter: testCase.type === 'click',
+				...expectedHydrationReplayMetadata(testCase),
+			});
+		}
+		expect(location.hash).toBe(initialHash);
+		observation!.cleanup();
+	});
+
+	it('preserves replay event subclasses from another document realm', () => {
+		const iframe = document.createElement('iframe');
+		document.body.appendChild(iframe);
+		let observation: ReturnType<typeof observeHydrationReplays> | undefined;
+		try {
+			const foreignDocument = iframe.contentDocument!;
+			const foreignWindow = iframe.contentWindow!;
+			const foreignContainer = foreignDocument.createElement('div');
+			foreignDocument.body.appendChild(foreignContainer);
+			const replayCases = HYDRATION_INTERACTION_EVENT_CASES.filter(
+				(testCase) => testCase.type === 'keydown' || testCase.type === 'pointerdown',
+			);
+			const when = interaction({ events: replayCases.map((testCase) => testCase.type) });
+			foreignContainer.innerHTML = renderToString(eventReplayServer.DeferredHydrationEventReplay, {
+				when,
+			}).html;
+			const parent = foreignContainer.querySelector('#hydration-replay-parent')!;
+			const target = foreignContainer.querySelector('#hydration-replay-target')!;
+			const relatedTarget = foreignContainer.querySelector('#hydration-replay-related')!;
+
+			initializeHydrationEventCapture(foreignDocument);
+			for (const testCase of replayCases) {
+				target.dispatchEvent(
+					createHydrationInteractionEvent(foreignWindow, relatedTarget, testCase),
+				);
+			}
+
+			root = hydrateRoot(foreignContainer, eventReplayClient.DeferredHydrationEventReplay, {
+				when,
+				onHydrated() {
+					observation = observeHydrationReplays(parent, target);
+				},
+			});
+			flushSync(() => {});
+			flushEffects();
+
+			const records = observation!.records.filter((record) => record.phase === 'target');
+			expect(records.map((record) => record.type)).toEqual(['keydown', 'pointerdown']);
+			for (let i = 0; i < replayCases.length; i++) {
+				expect(records[i]).toMatchObject({
+					type: replayCases[i].type,
+					targetIsOriginal: true,
+					...expectedHydrationReplayMetadata(replayCases[i]),
+				});
+			}
+		} finally {
+			observation?.cleanup();
+			root?.unmount();
+			root = undefined;
+			iframe.remove();
+		}
+	});
+
+	it('classifies parent-realm events before replaying them in an iframe realm', () => {
+		const iframe = document.createElement('iframe');
+		document.body.appendChild(iframe);
+		let observation: ReturnType<typeof observeHydrationReplays> | undefined;
+		try {
+			const foreignDocument = iframe.contentDocument!;
+			const foreignWindow = iframe.contentWindow!;
+			const foreignContainer = foreignDocument.createElement('div');
+			foreignDocument.body.appendChild(foreignContainer);
+			const replayCases = HYDRATION_INTERACTION_CROSS_REALM_CASES;
+			const when = interaction({ events: replayCases.map((testCase) => testCase.type) });
+			foreignContainer.innerHTML = renderToString(eventReplayServer.DeferredHydrationEventReplay, {
+				when,
+			}).html;
+			const parent = foreignContainer.querySelector('#hydration-replay-parent')!;
+			const target = foreignContainer.querySelector('#hydration-replay-target')!;
+			const relatedTarget = foreignContainer.querySelector('#hydration-replay-related')!;
+
+			initializeHydrationEventCapture(foreignDocument);
+			for (const testCase of replayCases) {
+				target.dispatchEvent(
+					createHydrationInteractionEvent(document.defaultView!, relatedTarget, testCase),
+				);
+			}
+
+			const targetRealmMatches: boolean[] = [];
+			root = hydrateRoot(foreignContainer, eventReplayClient.DeferredHydrationEventReplay, {
+				when,
+				onHydrated() {
+					for (const testCase of replayCases) {
+						target.addEventListener(
+							testCase.type,
+							(event) => {
+								switch (testCase.family) {
+									case 'focus':
+										targetRealmMatches.push(event instanceof foreignWindow.FocusEvent);
+										break;
+									case 'keyboard':
+										targetRealmMatches.push(event instanceof foreignWindow.KeyboardEvent);
+										break;
+									case 'mouse':
+										targetRealmMatches.push(event instanceof foreignWindow.MouseEvent);
+										break;
+									case 'pointer':
+										targetRealmMatches.push(event instanceof foreignWindow.PointerEvent);
+										break;
+								}
+							},
+							{ once: true },
+						);
+					}
+					observation = observeHydrationReplays(parent, target);
+				},
+			});
+			flushSync(() => {});
+			flushEffects();
+
+			const records = observation!.records.filter((record) => record.phase === 'target');
+			expect(records.map((record) => record.type)).toEqual([
+				'focusin',
+				'keydown',
+				'mousedown',
+				'pointerdown',
+			]);
+			expect(targetRealmMatches).toEqual([true, true, true, true]);
+			for (let i = 0; i < replayCases.length; i++) {
+				expect(records[i]).toMatchObject({
+					type: replayCases[i].type,
+					targetIsOriginal: true,
+					...expectedHydrationReplayMetadata(replayCases[i]),
+				});
+			}
+		} finally {
+			observation?.cleanup();
+			root?.unmount();
+			root = undefined;
+			iframe.remove();
+		}
+	});
 
 	it('keeps function-form visibility dormant after hydrateRoot interaction setup', async () => {
 		let intersect!: IntersectionObserverCallback;

--- a/packages/octane/tests/hydration/head-hydrate.test.ts
+++ b/packages/octane/tests/hydration/head-hydrate.test.ts
@@ -4,6 +4,12 @@ import { join, relative, sep } from 'node:path';
 import { compile } from 'octane/compiler';
 import { hydrateRoot, flushSync, delegateEvents } from '../../src/index.js';
 import * as ServerRT from 'octane/server';
+import {
+	loadCompiledFixtureSource,
+	loadServerFixture,
+	type CompiledFixtureModule,
+} from '../_server-fixture.js';
+import { activateStreamedMarkup, deferred, resetStreamRuntimeGlobals } from '../_server-stream.js';
 import { Page } from './_fixtures/head.tsrx';
 
 // Hoisted document metadata (React-19 model): inline `<title>`/`<meta>` are
@@ -20,32 +26,111 @@ const FIXTURE = join(process.cwd(), 'packages/octane/tests/hydration/_fixtures/h
 // ids so client/server builds (and installed symlink layouts) hash the same
 // logical module path. Mirror that id for this manually evaluated server copy.
 const VITE_FILENAME = '/' + relative(process.cwd(), FIXTURE).split(sep).join('/');
-function serverModule(): Record<string, any> {
-	// Compile with the SAME root-relative module id the client gets from the Vite plugin, so the
-	// CSS scope hash (which includes the filename) matches both sides — exactly as in a real
-	// app where client + server compile the same path. (A short name here desynced the hash,
-	// which the structural-mismatch static-attribute check would then flag + rebuild.)
-	let { code } = compile(readFileSync(FIXTURE, 'utf8'), VITE_FILENAME, { mode: 'server' });
-	code = code.replace(
-		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
-		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
-	);
-	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
-	return new Function('__rt', '__exports', code + '\nreturn __exports;')(ServerRT, {});
+// Compile with the SAME root-relative module id the client gets from the Vite
+// plugin, so CSS and head ownership hashes match both sides.
+const server = loadServerFixture(FIXTURE, { id: VITE_FILENAME });
+
+interface OwnershipModule extends CompiledFixtureModule {
+	Page: (props: { label: string }) => unknown;
 }
-const server = serverModule();
+
+interface StreamedHeadModule extends CompiledFixtureModule {
+	Page: (props: { value: Promise<string> }) => unknown;
+}
+
+const OWNERSHIP_SOURCE = `
+export function Page(props: { label: string }) @{
+	<>
+		<title>{props.label as string}</title>
+		<main data-label={props.label}>{props.label as string}</main>
+	</>
+}
+`;
+
+const STREAMED_BOUNDARY_HEAD_SOURCE = `
+import { use } from 'octane';
+
+export function Page(props: { value: Promise<string> }) @{
+	<section id="streamed-boundary-head">
+		@try {
+			<BoundaryContent value={props.value} />
+		} @pending {
+			<main data-state="pending">pending</main>
+		}
+	</section>
+}
+
+function BoundaryContent(props: { value: Promise<string> }) @{
+	<>
+		<title>streamed boundary title</title>
+		<main data-state="ready">{use(props.value) as string}</main>
+	</>
+}
+`;
+
+function ownershipModule(id: string, mode: 'client' | 'server'): OwnershipModule {
+	return loadCompiledFixtureSource<OwnershipModule>(OWNERSHIP_SOURCE, { id, mode });
+}
+
+function compilerHeadKey(source: string, id: string, mode: 'client' | 'server'): string {
+	const { code } = compile(source, id, { mode });
+	const match = code.match(/["'](rnh-[a-z0-9-]+)["']/);
+	if (match === null) throw new Error(`No compiler-emitted head key in ${id} (${mode})`);
+	return match[1];
+}
 
 let container: HTMLElement;
+let extraContainers: HTMLElement[];
 beforeEach(() => {
 	container = document.createElement('div');
 	document.body.appendChild(container);
+	extraContainers = [];
 });
 afterEach(() => {
 	container.remove();
+	for (const extra of extraContainers) extra.remove();
 	// Reset the document head between tests (title + any adopted/mounted nodes).
 	document.head.innerHTML = '';
-	document.title = '';
+	resetStreamRuntimeGlobals();
 });
+
+function appendRoot(
+	serverPage: OwnershipModule['Page'],
+	label: string,
+	options?: ServerRT.RenderOptions,
+): { container: HTMLElement; title: HTMLTitleElement } {
+	const { html } = ServerRT.renderToString(serverPage, { label }, options);
+	return appendRenderedRoot(html);
+}
+
+function appendRenderedRoot(html: string): {
+	container: HTMLElement;
+	title: HTMLTitleElement;
+} {
+	const target = document.createElement('div');
+	document.body.appendChild(target);
+	extraContainers.push(target);
+	const bodyStart = html.indexOf('<main');
+	if (bodyStart === -1) throw new Error('Expected ownership fixture body markup');
+	document.head.insertAdjacentHTML('beforeend', html.slice(0, bodyStart));
+	target.innerHTML = html.slice(bodyStart);
+	const title = document.head.lastElementChild;
+	if (!(title instanceof HTMLTitleElement))
+		throw new Error('Expected server title in document.head');
+	return { container: target, title };
+}
+
+function openingMarkerFor(title: HTMLTitleElement): Comment {
+	const marker = title.previousSibling;
+	if (!(marker instanceof Comment)) throw new Error('Expected title ownership opening marker');
+	return marker;
+}
+
+function closingMarkerFor(title: HTMLTitleElement): Comment {
+	const marker = title.nextSibling;
+	if (!(marker instanceof Comment)) throw new Error('Expected title ownership closing marker');
+	return marker;
+}
 
 describe('hoisted document metadata — compile', () => {
 	it('client: single-root body template (no <octane-frag>) + headBlock', () => {
@@ -70,17 +155,37 @@ describe('hoisted document metadata — compile', () => {
 			serverCode.includes(`ssrHeadEl("${key}"`) || serverCode.includes(`ssrHeadEl('${key}'`),
 		).toBe(true);
 	});
+
+	it('emits fixed-size module/tag-aware keys with query-insensitive client/server parity', () => {
+		const titleSource = `export function Page() @{ <title>same position</title> }`;
+		const metaSource = `export function Page() @{ <meta content="same position" /> }`;
+		const titleA = compilerHeadKey(titleSource, '/workspace/src/a.tsrx', 'client');
+		const titleAServer = compilerHeadKey(titleSource, '/workspace/src/a.tsrx', 'server');
+		const titleAQuery = compilerHeadKey(
+			titleSource,
+			'/workspace/src/a.tsrx?client=1#fragment',
+			'client',
+		);
+		const titleB = compilerHeadKey(titleSource, '/workspace/src/b.tsrx', 'client');
+		const metaA = compilerHeadKey(metaSource, '/workspace/src/a.tsrx', 'client');
+
+		expect(titleA).toMatch(/^rnh-[0-9a-f]{8}$/);
+		expect(titleAServer).toBe(titleA);
+		expect(titleAQuery).toBe(titleA);
+		expect(titleB).not.toBe(titleA);
+		expect(metaA).not.toBe(titleA);
+		expect(titleA).not.toContain('workspace');
+	});
 });
 
 describe('hoisted document metadata — SSR', () => {
-	it('html carries the title + meta (each marker-prefixed) folded to the front; body is single-root', () => {
+	it('folds the title and meta before a single-root body', () => {
 		const { html, css } = ServerRT.renderToString(server.Page, { params: {} });
 		expect(html).toContain('<title>TSRX Page</title>');
 		expect(html).toContain('name="description"');
 		expect(html).toContain('content="A test page"');
-		// Head metadata folds to the FRONT of html (a body-only render has no
-		// <head> to splice into), each still prefixed by its adoption marker.
-		expect(html).toMatch(/^<!--rnh-/);
+		// A body-only render has no <head> to splice into, so metadata folds to
+		// the front while preserving the authored body as a single root.
 		expect(html.indexOf('<title')).toBeLessThan(html.indexOf('<section'));
 		// Body is the single <section>, NOT a <octane-frag> multi-root.
 		expect(html).toContain('<section id="body"');
@@ -88,10 +193,78 @@ describe('hoisted document metadata — SSR', () => {
 		// The <style> still routes to CSS.
 		expect(css).toContain('rebeccapurple');
 	});
+
+	it('keeps streamed head ownership byte-compatible with client hydration', async () => {
+		const client = ownershipModule('/src/streamed-head.tsrx', 'client');
+		const serverModule = ownershipModule('/src/streamed-head.tsrx', 'server');
+		const stream = await ServerRT.renderToReadableStream(
+			serverModule.Page,
+			{ label: 'streamed' },
+			{ identifierPrefix: 'stream-' },
+		);
+		const page = appendRenderedRoot(await new Response(stream).text());
+		const root = hydrateRoot(
+			page.container,
+			client.Page,
+			{ label: 'streamed' },
+			{ identifierPrefix: 'stream-' },
+		);
+		flushSync(() => {});
+
+		expect(document.head.querySelector('title')).toBe(page.title);
+		expect(page.title.textContent).toBe('streamed');
+		root.unmount();
+		expect(page.title.isConnected).toBe(false);
+	});
+
+	it('uses the root namespace for a head entry emitted before a streamed boundary suspends', async () => {
+		const client = loadCompiledFixtureSource<StreamedHeadModule>(STREAMED_BOUNDARY_HEAD_SOURCE, {
+			id: '/src/streamed-boundary-head.tsrx',
+			mode: 'client',
+		});
+		const serverModule = loadCompiledFixtureSource<StreamedHeadModule>(
+			STREAMED_BOUNDARY_HEAD_SOURCE,
+			{
+				id: '/src/streamed-boundary-head.tsrx',
+				mode: 'server',
+			},
+		);
+		const value = deferred<string>();
+		const stream = await ServerRT.renderToReadableStream(
+			serverModule.Page,
+			{ value: value.promise },
+			{ identifierPrefix: 'stream-root-' },
+		);
+		const htmlPromise = new Response(stream).text();
+		value.resolve('ready');
+		const html = await htmlPromise;
+		const bodyStart = html.indexOf('<section id="streamed-boundary-head"');
+		if (bodyStart === -1) throw new Error('Expected authored streamed-boundary root');
+		document.head.innerHTML = html.slice(0, bodyStart);
+		container.innerHTML = html.slice(bodyStart);
+		activateStreamedMarkup(container);
+		const title = document.head.querySelector('title')!;
+		const ready = container.querySelector('[data-state="ready"]');
+		expect(ready?.textContent).toBe('ready');
+
+		const root = hydrateRoot(
+			container,
+			client.Page,
+			{ value: new Promise<string>(() => {}) },
+			{ identifierPrefix: 'stream-root-' },
+		);
+		flushSync(() => {});
+
+		expect(document.head.querySelector('title')).toBe(title);
+		expect(document.head.querySelectorAll('title')).toHaveLength(1);
+		expect(container.querySelector('[data-state="ready"]')).toBe(ready);
+		root.unmount();
+		expect(title.isConnected).toBe(false);
+	});
 });
 
 describe('hoisted document metadata — hydration', () => {
-	it('adopts the server head (one <title>/<meta>, markers removed) + single-root body, removed on unmount', () => {
+	it('adopts the server head and single-root body, then removes owned nodes on unmount', () => {
 		const { html } = ServerRT.renderToString(server.Page, { params: {} });
 		// html folds head metadata to the front + body after. A document places the
 		// head part in <head> and the body part in the app container — split there.
@@ -109,14 +282,10 @@ describe('hoisted document metadata — hydration', () => {
 		const root = hydrateRoot(container, Page, { params: {} });
 		flushSync(() => {});
 
-		// Head: title + meta ADOPTED (no duplication), adoption markers removed.
+		// Head: title + meta ADOPTED without duplication.
 		expect(document.title).toBe('TSRX Page');
 		expect(document.head.querySelectorAll('title').length).toBe(1);
 		expect(document.head.querySelectorAll('meta[name="description"]').length).toBe(1);
-		const markerComments = Array.from(document.head.childNodes).filter(
-			(n) => n.nodeType === 8 && (n as Comment).data.startsWith('rnh-'),
-		);
-		expect(markerComments.length).toBe(0);
 
 		// Body: single-root <section> ADOPTED (same node), no <octane-frag>, interactive.
 		expect(container.querySelector('#body')).toBe(section);
@@ -190,5 +359,143 @@ describe('hoisted document metadata — hydration', () => {
 		expect(createdTitle.isConnected).toBe(false);
 		expect(meta.isConnected).toBe(false);
 		expect(foreign.isConnected).toBe(true);
+	});
+
+	it('keeps cross-module same-tag ownership stable when roots hydrate out of order', () => {
+		const clientA = ownershipModule('/src/head-a.tsrx', 'client');
+		const serverA = ownershipModule('/src/head-a.tsrx', 'server');
+		const clientB = ownershipModule('/src/head-b.tsrx', 'client');
+		const serverB = ownershipModule('/src/head-b.tsrx', 'server');
+		const a = appendRoot(serverA.Page, 'module-a');
+		const b = appendRoot(serverB.Page, 'module-b');
+
+		const rootB = hydrateRoot(b.container, clientB.Page, { label: 'module-b' });
+		const rootA = hydrateRoot(a.container, clientA.Page, { label: 'module-a' });
+		flushSync(() => {});
+
+		expect(a.title.textContent).toBe('module-a');
+		expect(b.title.textContent).toBe('module-b');
+		expect(a.title.isConnected).toBe(true);
+		expect(b.title.isConnected).toBe(true);
+
+		rootB.unmount();
+		expect(a.title.isConnected).toBe(true);
+		expect(b.title.isConnected).toBe(false);
+		rootA.unmount();
+		expect(a.title.isConnected).toBe(false);
+	});
+
+	it('uses existing identifierPrefix semantics to isolate same-module sibling roots', () => {
+		const client = ownershipModule('/src/repeated-head.tsrx', 'client');
+		const serverModule = ownershipModule('/src/repeated-head.tsrx', 'server');
+		// These distinct prefixes collide under the former single-lane djb2 hash.
+		const a = appendRoot(serverModule.Page, 'root-a', { identifierPrefix: 'ar' });
+		const b = appendRoot(serverModule.Page, 'root-b', { identifierPrefix: 'c0' });
+
+		const rootB = hydrateRoot(
+			b.container,
+			client.Page,
+			{ label: 'root-b' },
+			{ identifierPrefix: 'c0' },
+		);
+		const rootA = hydrateRoot(
+			a.container,
+			client.Page,
+			{ label: 'root-a' },
+			{ identifierPrefix: 'ar' },
+		);
+		flushSync(() => {});
+
+		expect(a.title.textContent).toBe('root-a');
+		expect(b.title.textContent).toBe('root-b');
+		rootB.unmount();
+		expect(a.title.isConnected).toBe(true);
+		expect(b.title.isConnected).toBe(false);
+		rootA.unmount();
+	});
+
+	it.each(['opening', 'closing'])(
+		'does not claim or delete a server title when its %s ownership marker is missing',
+		(missing) => {
+			const client = ownershipModule('/src/missing-marker.tsrx', 'client');
+			const serverModule = ownershipModule('/src/missing-marker.tsrx', 'server');
+			const page = appendRoot(serverModule.Page, 'server-title');
+			(missing === 'opening'
+				? openingMarkerFor(page.title)
+				: closingMarkerFor(page.title)
+			).remove();
+
+			const root = hydrateRoot(page.container, client.Page, { label: 'client-title' });
+			flushSync(() => {});
+
+			const createdTitle = Array.from(document.head.querySelectorAll('title')).find(
+				(title) => title !== page.title,
+			);
+			expect(createdTitle?.textContent).toBe('client-title');
+			expect(page.title.textContent).toBe('server-title');
+			expect(page.title.isConnected).toBe(true);
+
+			root.unmount();
+			expect(createdTitle?.isConnected).toBe(false);
+			expect(page.title.isConnected).toBe(true);
+		},
+	);
+
+	it('treats a duplicate ownership marker as ambiguous instead of claiming a server title', () => {
+		const client = ownershipModule('/src/duplicate-marker.tsrx', 'client');
+		const serverModule = ownershipModule('/src/duplicate-marker.tsrx', 'server');
+		const page = appendRoot(serverModule.Page, 'server-title');
+		const marker = openingMarkerFor(page.title);
+		document.head.insertBefore(marker.cloneNode(), marker);
+
+		const root = hydrateRoot(page.container, client.Page, { label: 'client-title' });
+		flushSync(() => {});
+
+		const createdTitle = Array.from(document.head.querySelectorAll('title')).find(
+			(title) => title !== page.title,
+		);
+		expect(createdTitle?.textContent).toBe('client-title');
+		expect(page.title.textContent).toBe('server-title');
+		expect(page.title.isConnected).toBe(true);
+
+		root.unmount();
+		expect(createdTitle?.isConnected).toBe(false);
+		expect(page.title.isConnected).toBe(true);
+	});
+
+	it('contains reordered ownership markers without cross-claiming same-tag server entries', () => {
+		const clientA = ownershipModule('/src/reordered-a.tsrx', 'client');
+		const serverA = ownershipModule('/src/reordered-a.tsrx', 'server');
+		const clientB = ownershipModule('/src/reordered-b.tsrx', 'client');
+		const serverB = ownershipModule('/src/reordered-b.tsrx', 'server');
+		const a = appendRoot(serverA.Page, 'server-a');
+		const b = appendRoot(serverB.Page, 'server-b');
+		const markerA = openingMarkerFor(a.title);
+		const markerB = openingMarkerFor(b.title);
+		const markerAData = markerA.data;
+		markerA.data = markerB.data;
+		markerB.data = markerAData;
+
+		const rootB = hydrateRoot(b.container, clientB.Page, { label: 'client-b' });
+		const rootA = hydrateRoot(a.container, clientA.Page, { label: 'client-a' });
+		flushSync(() => {});
+
+		const createdTitles = Array.from(document.head.querySelectorAll('title')).filter(
+			(title) => title !== a.title && title !== b.title,
+		);
+		expect(createdTitles.map((title) => title.textContent).sort()).toEqual([
+			'client-a',
+			'client-b',
+		]);
+		expect(a.title.textContent).toBe('server-a');
+		expect(b.title.textContent).toBe('server-b');
+		expect(a.title.isConnected).toBe(true);
+		expect(b.title.isConnected).toBe(true);
+
+		rootB.unmount();
+		rootA.unmount();
+		expect(createdTitles.every((title) => !title.isConnected)).toBe(true);
+		expect(a.title.isConnected).toBe(true);
+		expect(b.title.isConnected).toBe(true);
 	});
 });

--- a/packages/octane/tests/hydration/mismatch-structural.test.ts
+++ b/packages/octane/tests/hydration/mismatch-structural.test.ts
@@ -450,3 +450,141 @@ describe('hydrateRoot — PROD runtime validation (root nodeType+tag only, parse
 		expect(warns()).toEqual([]);
 	});
 });
+
+// RDX-HYD-006 — adapted from TanStack/redact's
+// hydration-mismatch-recovery.test.tsx. Octane recovers its compiler-owned DOM
+// ranges in place rather than unwinding Redact checkpoints, so the observable
+// contract is identity outside the failed range plus live replacement content.
+describe.each([
+	{
+		name: 'development compile',
+		client: devClientModule(STRUCTURAL, 'structural.tsrx'),
+		warns: true,
+	},
+	{
+		name: 'production compile',
+		client: prodClientModule(STRUCTURAL, 'structural.tsrx'),
+		warns: false,
+	},
+])('hydrateRoot — mismatch containment ($name)', ({ client, warns: shouldWarn }) => {
+	const server = serverModule(STRUCTURAL, 'structural.tsrx');
+	let container: HTMLElement;
+	let errSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		container.remove();
+		errSpy.mockRestore();
+	});
+
+	function expectDiagnostics(): void {
+		const messages = errSpy.mock.calls
+			.map((call) => String(call[0]))
+			.filter((message) => message.includes('hydration mismatch'));
+		if (shouldWarn) expect(messages.length).toBeGreaterThanOrEqual(1);
+		else expect(messages).toEqual([]);
+	}
+
+	// Per Redact hydration-mismatch-recovery.test.tsx:53-64.
+	it('root recovery leaves one clean client tree with a live replacement handler', async () => {
+		const { html } = await ServerRT.renderToString(server.RootScopedRecovery, {
+			isClient: false,
+		});
+		container.innerHTML = html;
+		const staleRoot = container.querySelector('#root-server')!;
+		const staleLeaf = container.querySelector('#root-stale')!;
+		const root = hydrateRoot(container, client.RootScopedRecovery, { isClient: true });
+		flushSync(() => {});
+
+		try {
+			expect(staleRoot.isConnected).toBe(false);
+			expect(staleLeaf.isConnected).toBe(false);
+			expect(container.querySelectorAll('#root-client')).toHaveLength(1);
+			expect(container.querySelector('#root-server')).toBeNull();
+
+			const action = container.querySelector<HTMLButtonElement>('#root-recovered-action')!;
+			expect(action.textContent?.trim()).toBe('root:0');
+			flushSync(() => action.click());
+			expect(action.textContent?.trim()).toBe('root:1');
+			expectDiagnostics();
+		} finally {
+			root.unmount();
+		}
+	});
+
+	// Per Redact hydration-mismatch-recovery.test.tsx:262-297.
+	it('nearest-host recovery preserves outside objects and both outside and regenerated handlers', async () => {
+		const { html } = await ServerRT.renderToString(server.HostScopedRecovery, {
+			isClient: false,
+		});
+		container.innerHTML = html;
+		const stableRoot = container.querySelector('#host-recovery-root')!;
+		const stableHeader = container.querySelector('#host-stable-header')!;
+		const stableScope = container.querySelector('#host-recovery-scope')!;
+		const stableFooter = container.querySelector('#host-stable-footer')!;
+		const outsideAction = container.querySelector<HTMLButtonElement>('#host-outside-action')!;
+		const staleRange = container.querySelector('#host-server-range')!;
+		const root = hydrateRoot(container, client.HostScopedRecovery, { isClient: true });
+		flushSync(() => {});
+
+		try {
+			expect(container.querySelector('#host-recovery-root')).toBe(stableRoot);
+			expect(container.querySelector('#host-stable-header')).toBe(stableHeader);
+			expect(container.querySelector('#host-recovery-scope')).toBe(stableScope);
+			expect(container.querySelector('#host-stable-footer')).toBe(stableFooter);
+			expect(container.querySelector('#host-outside-action')).toBe(outsideAction);
+			expect(staleRange.isConnected).toBe(false);
+			expect(container.querySelectorAll('#host-client-range')).toHaveLength(1);
+
+			const recoveredAction = container.querySelector<HTMLButtonElement>('#host-recovered-action')!;
+			flushSync(() => recoveredAction.click());
+			expect(recoveredAction.textContent?.trim()).toBe('inside:1');
+			flushSync(() => outsideAction.click());
+			expect(outsideAction.textContent?.trim()).toBe('outside:1');
+			expectDiagnostics();
+		} finally {
+			root.unmount();
+		}
+	});
+
+	// Per Redact hydration-mismatch-recovery.test.tsx:183-260.
+	it('Suspense-scoped recovery preserves outside objects and installs the regenerated handler', async () => {
+		const { html } = await ServerRT.renderToString(server.SuspenseScopedRecovery, {
+			isClient: false,
+		});
+		container.innerHTML = html;
+		const stableRoot = container.querySelector('#suspense-recovery-root')!;
+		const stableHeader = container.querySelector('#suspense-stable-header')!;
+		const outsideAction = container.querySelector<HTMLButtonElement>('#suspense-outside-action')!;
+		const stableFooter = container.querySelector('#suspense-stable-footer')!;
+		const staleRange = container.querySelector('#suspense-server-range')!;
+		const root = hydrateRoot(container, client.SuspenseScopedRecovery, { isClient: true });
+		flushSync(() => {});
+
+		try {
+			expect(container.querySelector('#suspense-recovery-root')).toBe(stableRoot);
+			expect(container.querySelector('#suspense-stable-header')).toBe(stableHeader);
+			expect(container.querySelector('#suspense-outside-action')).toBe(outsideAction);
+			expect(container.querySelector('#suspense-stable-footer')).toBe(stableFooter);
+			expect(staleRange.isConnected).toBe(false);
+			expect(container.querySelectorAll('#suspense-client-range')).toHaveLength(1);
+			expect(container.querySelector('#suspense-recovery-fallback')).toBeNull();
+
+			const recoveredAction = container.querySelector<HTMLButtonElement>(
+				'#suspense-recovered-action',
+			)!;
+			flushSync(() => recoveredAction.click());
+			expect(recoveredAction.textContent?.trim()).toBe('inside:1');
+			flushSync(() => outsideAction.click());
+			expect(outsideAction.textContent?.trim()).toBe('outside:1');
+			expectDiagnostics();
+		} finally {
+			root.unmount();
+		}
+	});
+});

--- a/packages/octane/tests/script-innerhtml.test.ts
+++ b/packages/octane/tests/script-innerhtml.test.ts
@@ -7,6 +7,7 @@ import { loadCompiledFixtureSource, loadServerFixture } from './_server-fixture.
 import { collectPipeableStream } from './_server-stream.js';
 import { mount } from './_helpers.js';
 import * as client from './_fixtures/script-innerhtml.tsrx';
+import { RAW_STYLE_SOURCE, UPDATED_RAW_STYLE_SOURCE } from './_fixtures/raw-style-content.js';
 
 const FIXTURE = 'packages/octane/tests/_fixtures/script-innerhtml.tsrx';
 const FIXTURE_SOURCE = readFileSync(resolve(process.cwd(), FIXTURE), 'utf8');
@@ -462,5 +463,55 @@ describe('<script> content contract', () => {
 		expect(JSON.parse(split.querySelector('script')?.textContent ?? '')).toEqual(
 			SPLIT_DESCRIPTOR_VALUE,
 		);
+	});
+});
+
+describe('<style> raw-text hydration', () => {
+	it('adopts server-parsed raw text without diagnostics and updates the same stylesheet', async () => {
+		const props = { tag: 'style', source: RAW_STYLE_SOURCE };
+		const buffered = ServerRuntime.renderToString(server.RawStyle, props);
+		const streamed = await collectPipeableStream(server.RawStyle, props);
+		expect(streamed.errors).toEqual([]);
+
+		for (const html of [buffered.html, streamed.html]) {
+			const fragment = parseFragment(html);
+			const style = fragment.querySelector('#raw-style-sheet');
+			expect(fragment.querySelectorAll('style')).toHaveLength(1);
+			expect(fragment.querySelector('[data-pwn]')).toBeNull();
+			expect(style?.textContent).toContain('amp=&');
+			expect(style?.textContent).toContain('less=<');
+			expect(style?.textContent).toContain('entity=&amp;');
+		}
+
+		const container = document.createElement('div');
+		container.innerHTML = buffered.html;
+		document.body.appendChild(container);
+		const serverStyle = container.querySelector('#raw-style-sheet');
+		const serverTarget = container.querySelector('#raw-style-target');
+		const warning = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const root = hydrateRoot(container, client.RawStyle, props);
+		try {
+			flushSync(() => {});
+			expect(container.querySelector('#raw-style-sheet')).toBe(serverStyle);
+			expect(container.querySelector('#raw-style-target')).toBe(serverTarget);
+			expect(warning).not.toHaveBeenCalled();
+
+			flushSync(() =>
+				root.render(client.RawStyle, {
+					tag: 'style',
+					source: UPDATED_RAW_STYLE_SOURCE,
+				}),
+			);
+			expect(container.querySelector('#raw-style-sheet')).toBe(serverStyle);
+			expect(container.querySelector('#raw-style-target')).toBe(serverTarget);
+			expect(container.querySelectorAll('style')).toHaveLength(1);
+			expect(container.querySelector('[data-pwn]')).toBeNull();
+			expect(serverStyle?.textContent).toBe(UPDATED_RAW_STYLE_SOURCE);
+			expect(warning).not.toHaveBeenCalled();
+		} finally {
+			root.unmount();
+			warning.mockRestore();
+			container.remove();
+		}
 	});
 });

--- a/packages/octane/tests/svg-title-hoist.test.ts
+++ b/packages/octane/tests/svg-title-hoist.test.ts
@@ -15,6 +15,18 @@ import {
 const FIXTURE = 'packages/octane/tests/_fixtures/svg-title-hoist.tsrx';
 const server = loadServerFixture(FIXTURE);
 
+function moveServerHeadElement(element: Element): void {
+	const precedingServerNode = element.previousSibling;
+	const followingServerNode = element.nextSibling;
+	if (precedingServerNode?.nodeType === Node.COMMENT_NODE) {
+		document.head.append(precedingServerNode);
+	}
+	document.head.append(element);
+	if (followingServerNode?.nodeType === Node.COMMENT_NODE) {
+		document.head.append(followingServerNode);
+	}
+}
+
 afterEach(() => {
 	for (const node of document.head.querySelectorAll(
 		'[data-opaque-boundary-document-title], [data-lexical-document-title], [data-opaque-boundary-html-title], [data-directive-document-title]',
@@ -289,11 +301,7 @@ describe('title placement across HTML and SVG namespaces', () => {
 		const documentTitle = serverMarkup.content.querySelector(
 			'[data-opaque-boundary-document-title]',
 		) as HTMLTitleElement;
-		const adjacentServerNode = documentTitle.previousSibling;
-		if (adjacentServerNode?.nodeType === Node.COMMENT_NODE) {
-			document.head.append(adjacentServerNode);
-		}
-		document.head.append(documentTitle);
+		moveServerHeadElement(documentTitle);
 
 		const container = document.createElement('div');
 		document.body.appendChild(container);
@@ -336,11 +344,7 @@ describe('title placement across HTML and SVG namespaces', () => {
 		const documentTitle = serverMarkup.content.querySelector(
 			'[data-opaque-boundary-html-title]',
 		) as HTMLTitleElement;
-		const adjacentServerNode = documentTitle.previousSibling;
-		if (adjacentServerNode?.nodeType === Node.COMMENT_NODE) {
-			document.head.append(adjacentServerNode);
-		}
-		document.head.append(documentTitle);
+		moveServerHeadElement(documentTitle);
 
 		const container = document.createElement('div');
 		document.body.appendChild(container);
@@ -377,11 +381,7 @@ describe('title placement across HTML and SVG namespaces', () => {
 		const documentTitle = serverMarkup.content.querySelector(
 			'[data-directive-document-title]',
 		) as HTMLTitleElement;
-		const adjacentServerNode = documentTitle.previousSibling;
-		if (adjacentServerNode?.nodeType === Node.COMMENT_NODE) {
-			document.head.append(adjacentServerNode);
-		}
-		document.head.append(documentTitle);
+		moveServerHeadElement(documentTitle);
 
 		const container = document.createElement('div');
 		document.body.appendChild(container);


### PR DESCRIPTION
## Summary

- preserve deferred-hydration replay event subclasses, metadata, FIFO order, cancellation, targets, and exactly-once delivery, including cross-realm targets
- make hoisted head ownership module-, tag-, and root-aware, with paired bounds that fail closed for missing, duplicate, nested, or reordered ownership data
- add raw `<style>` parse/hydrate/update and Chromium CSSOM coverage, plus root/nearest-host/Suspense mismatch-containment identity and live-handler coverage
- close RDX-EVT-002, RDX-HYD-003, RDX-HYD-006, and RDX-HYD-007 in the generated Redact adversarial audit

## Runtime and shapes

- no `Block`, `Scope`, `HydrateSlot`, or `HeadSlot` fields were added
- `HeadBuffer` has one consistently initialized suffix field, so its shape remains monomorphic
- the root suffix is hashed once per server render; the empty-prefix path returns the compiler key directly
- client root lookup and marker validation run only on first head-slot adoption
- event family branding runs only after target-realm constructor checks miss during deferred replay; ordinary event dispatch is unchanged

Paired production SSR microbenchmark (11 alternating samples; 100k renders/sample without head entries and 20k renders/sample for 32 head entries):

| Scenario | `main` median | This PR median | Paired delta |
| --- | ---: | ---: | ---: |
| No head entries, default prefix | 322.4 ns | 320.0 ns | -0.04% |
| 32 head entries, default prefix | 17.41 µs | 18.00 µs | +3.13% |
| 32 head entries, nonempty prefix | 17.37 µs | 18.29 µs | +5.30% |

Hoisting the root hash from once per entry to once per render reduced the nonempty-prefix delta from +12.94% to +5.30%. The no-head result is effectively neutral; the measured overhead is isolated to authored SSR head output and its new paired ownership delimiters.

## Validation

- `pnpm test` — 1,310/1,310 files and 12,831/12,831 tests
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm changeset:check`
- `pnpm redact-audit:check` — 29 entries current, 15/15 validator tests
- `pnpm --filter octane build`
- `git diff --check`

Rebased onto the latest `origin/main`; no merge conflicts remain.

## Residual constraints

- reverse-order hydration of same-module sibling roots continues to require distinct `identifierPrefix` values
- head metadata first encountered only after a streamed boundary suspends remains a broader pre-existing streaming limitation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core hydration paths (head claiming, deferred replay, mismatch recovery) where bugs would corrupt DOM metadata or user intent, but behavior is fail-closed and backed by broad unit and Chromium tests.
> 
> **Overview**
> Strengthens **deferred hydration** and **hoisted head** behavior, with audit ledger entries moved to **covered** for event replay, raw style hydration, mismatch containment, and head key uniqueness.
> 
> **Deferred hydration replay** now clones buffered interaction events with the **target realm’s** `PointerEvent` / `KeyboardEvent` / `MouseEvent` / `FocusEvent` constructors (pointer before mouse), with Web IDL branding when `instanceof` crosses iframe boundaries—replacing the prior mouse/focus-only or generic `Event` fallback. Unit matrix, cross-realm fixtures, and Chromium tests lock FIFO order, metadata, targets, and cancellation.
> 
> **Hoisted `<head>` ownership** uses compiler keys hashed from **module id, tag, and source position**, plus an optional **`identifierPrefix` suffix** on SSR and client adoption. Server output wraps each head node in **paired ownership comments**; runtime adoption only claims a matching tag inside a valid open/close interval and **fails closed** on missing, duplicate, nested, or reordered markers. New tests cover cross-module collisions, sibling roots, streaming, and malformed markers.
> 
> **Raw `<style>` hydration** gains streamed/buffered adoption, same-node updates, and Chromium CSSOM checks. **Structural mismatch recovery** adds root, nearest-host, and Suspense-scoped fixtures asserting outside **node identity** and live handlers, including browser Suspense coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a388f695a2508579cde135cc39af19a0e994977. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->