### PR TITLE
test(octane): harden portal placement contracts

### DIFF
--- a/docs/redact-adversarial-audit.md
+++ b/docs/redact-adversarial-audit.md
@@ -58,9 +58,9 @@ This is the explicit artifact sample reviewed at the pinned snapshot; broad sour
 
 | Status | Entries |
 | --- | ---: |
-| planned | 2 |
+| planned | 0 |
 | in progress | 0 |
-| covered | 21 |
+| covered | 23 |
 | documented | 5 |
 | decision required | 1 |
 | blocked | 0 |
@@ -76,8 +76,6 @@ This is the explicit artifact sample reviewed at the pinned snapshot; broad sour
 
 | ID | Risk | Area | Contract | Status | Owner |
 | --- | --- | --- | --- | --- | --- |
-| [`RDX-PORT-002`](#rdx-port-002) | high | portal-updates | A stateful portal descendant resolves its foreign host for owned updates | planned | Octane portal host resolution |
-| [`RDX-REC-002`](#rdx-rec-002) | high | reconciliation-placement | Topology transitions use the correct absolute anchor without stable reattachment | planned | Octane reconciler and portal placement |
 | [`RDX-HYD-005`](#rdx-hyd-005) | medium | hydration-errors | Hydration recovery reporting has an explicit public contract | decision required | Octane public root API |
 
 ## Contract ledger
@@ -644,7 +642,7 @@ Targets: `packages/octane/src/runtime.ts`, `docs/ssr.md`.
 
 #### RDX-PORT-002 — A stateful portal descendant resolves its foreign host for owned updates
 
-**Disposition:** high risk; adaptable; planned; owner: Octane portal host resolution.
+**Disposition:** high risk; adaptable; covered; owner: Octane portal host resolution.
 
 **Upstream evidence**
 
@@ -658,11 +656,14 @@ Targets: `packages/octane/src/runtime.ts`, `docs/ssr.md`.
 
 **Octane references**
 
-- [packages/octane/tests/portal.test.ts](../packages/octane/tests/portal.test.ts) — “compiles and renders an inline host-element body into the target, updating reactively” — Updates state owned outside the portal, so it does not exercise descendant-owned host resolution.
+- [packages/octane/src/runtime.ts](../packages/octane/src/runtime.ts) — `renderPortalState` — The portal Block stores the foreign target directly as parentNode, so descendant-owned rerenders retain the correct host without an ancestor walk.
+- [packages/octane/tests/portal.test.ts](../packages/octane/tests/portal.test.ts) — “keeps a descendant-owned root replacement inside its portal target” — A portal child owns the update and replaces its host-root kind while the logical root and foreign target siblings retain identity.
 
-**Next action (test).** Render a child component with its own useState inside a portal, schedule its update from that child, and assert the same target and unaffected target siblings retain identity while only the child's host content changes in development and production compile modes.
+**Executable evidence**
 
-Targets: `packages/octane/tests/portal.test.ts`.
+- [keeps a descendant-owned root replacement inside its portal target](../packages/octane/tests/portal.test.ts) — modes: `client`, `production-compile`; observables: `markup`, `node-identity`
+
+**Rationale.** Octane does not need Redact's ancestor host resolver: the portal Block captures the supplied target, and each descendant Block captures its actual DOM parent when created. The regression replaces the descendant's host-root kind rather than only updating a text binding, proving that owned rerenders still use the retained foreign-host chain.
 
 
 ### portals
@@ -802,7 +803,7 @@ Targets: `packages/octane/tests/portal.test.ts`.
 
 #### RDX-REC-002 — Topology transitions use the correct absolute anchor without stable reattachment
 
-**Disposition:** high risk; adaptable; planned; owner: Octane reconciler and portal placement.
+**Disposition:** high risk; adaptable; covered; owner: Octane reconciler and portal placement.
 
 **Upstream evidence**
 
@@ -820,13 +821,18 @@ Targets: `packages/octane/tests/portal.test.ts`.
 **Octane references**
 
 - [packages/octane/tests/differential/anchor-order.test.ts](../packages/octane/tests/differential/anchor-order.test.ts) — Covers final source order across control-flow transitions, but differential HTML cannot see host reattachment and has no portal topology case.
-- [packages/octane/tests/portal.test.ts](../packages/octane/tests/portal.test.ts) — “unmounts portal content when the if-branch closes” — Covers removal/recreation, not Portal→ordinary replacement around stable siblings.
+- [packages/octane/tests/portal.test.ts](../packages/octane/tests/portal.test.ts) — “places a Portal-to-element first-child transition before stable later siblings” — Pins portal cleanup, exact absolute order, and identity of the parent plus both later siblings in development and production compilation.
+- [packages/octane/tests/portal.test.ts](../packages/octane/tests/portal.test.ts) — “places a null-to-element first-child transition before stable later siblings” — Pins materialization at index zero while both later siblings retain identity.
+- [packages/octane/tests/browser/portal-placement/portal-placement.test.ts](../packages/octane/tests/browser/portal-placement/portal-placement.test.ts) — “prod preserves absolute order without reattaching stable host nodes” — Real Chromium observes both the logical parent and foreign target and proves a child-topology-equivalent rerender emits zero child-list records.
 
-**Next action (test).** Port Portal→element and null→element first-child transitions with multiple stable later siblings; retain every survivor object, assert exact final order, and use MutationObserver in Chromium to prove a stable rerender produces no child-list records.
+**Executable evidence**
 
-Targets: `packages/octane/tests/portal.test.ts`, `packages/octane/tests/browser`.
+- [places a Portal-to-element first-child transition before stable later siblings](../packages/octane/tests/portal.test.ts) — modes: `client`, `production-compile`; observables: `markup`, `node-identity`
+- [places a null-to-element first-child transition before stable later siblings](../packages/octane/tests/portal.test.ts) — modes: `client`, `production-compile`; observables: `markup`, `node-identity`
+- [dev preserves absolute order without reattaching stable host nodes](../packages/octane/tests/browser/portal-placement/portal-placement.test.ts) — modes: `client`, `real-browser`; observables: `markup`, `node-identity`, `dom-mutations`
+- [prod preserves absolute order without reattaching stable host nodes](../packages/octane/tests/browser/portal-placement/portal-placement.test.ts) — modes: `production-compile`, `real-browser`; observables: `markup`, `node-identity`, `dom-mutations`
 
-**Rationale.** The existing keyed identity suite proves a different reconciler contract. Redact's topology cases require portal-aware absolute placement plus a mutation-level oracle, so they remain an explicit gap instead of being hidden under RDX-REC-001.
+**Rationale.** This is distinct from keyed-list identity: compiler-owned component anchors reserve the source position while portal or null output has no in-flow host. The regressions prove that later materialization stays inside that range and that the existing absolute-anchor path does not reattach stable hosts.
 
 
 ### redact-specific-surfaces

--- a/packages/octane/audit/redact-adversarial-ledger.json
+++ b/packages/octane/audit/redact-adversarial-ledger.json
@@ -1567,24 +1567,34 @@
       "symptom": "A component inside a portal scheduled its own state update, resolved the logical parent as its host, and inserted or replaced DOM outside the portal target.",
       "octaneContract": "A descendant component rendered inside a portal may own and schedule updates while all of its host mutations remain anchored in the supplied portal target and preserve surrounding target siblings.",
       "classification": "adaptable",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "owner": "Octane portal host resolution",
       "applicableModes": ["client", "production-compile"],
       "observables": ["markup", "node-identity"],
       "octaneReferences": [
         {
+          "kind": "source",
+          "file": "packages/octane/src/runtime.ts",
+          "symbol": "renderPortalState",
+          "note": "The portal Block stores the foreign target directly as parentNode, so descendant-owned rerenders retain the correct host without an ancestor walk."
+        },
+        {
           "kind": "test",
           "file": "packages/octane/tests/portal.test.ts",
-          "testName": "compiles and renders an inline host-element body into the target, updating reactively",
-          "note": "Updates state owned outside the portal, so it does not exercise descendant-owned host resolution."
+          "testName": "keeps a descendant-owned root replacement inside its portal target",
+          "note": "A portal child owns the update and replaces its host-root kind while the logical root and foreign target siblings retain identity."
         }
       ],
-      "nextAction": {
-        "kind": "test",
-        "targets": ["packages/octane/tests/portal.test.ts"],
-        "acceptance": "Render a child component with its own useState inside a portal, schedule its update from that child, and assert the same target and unaffected target siblings retain identity while only the child's host content changes in development and production compile modes."
-      }
+      "evidence": [
+        {
+          "file": "packages/octane/tests/portal.test.ts",
+          "testName": "keeps a descendant-owned root replacement inside its portal target",
+          "modes": ["client", "production-compile"],
+          "observables": ["markup", "node-identity"]
+        }
+      ],
+      "rationale": "Octane does not need Redact's ancestor host resolver: the portal Block captures the supplied target, and each descendant Block captures its actual DOM parent when created. The regression replaces the descendant's host-root kind rather than only updating a text binding, proving that owned rerenders still use the retained foreign-host chain."
     },
     {
       "id": "RDX-REC-001",
@@ -1672,7 +1682,7 @@
       "symptom": "A Portal-to-element or null-to-element transition inserted new output after the wrong sibling, while a no-op rerender could detach and reinsert otherwise stable DOM.",
       "octaneContract": "When a child changes topology, each newly materialized range lands at its absolute logical anchor around portal and ordinary siblings; a stable rerender emits no child-list mutations and preserves every existing host object.",
       "classification": "adaptable",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "owner": "Octane reconciler and portal placement",
       "applicableModes": ["client", "production-compile", "real-browser"],
@@ -1686,16 +1696,49 @@
         {
           "kind": "test",
           "file": "packages/octane/tests/portal.test.ts",
-          "testName": "unmounts portal content when the if-branch closes",
-          "note": "Covers removal/recreation, not Portal→ordinary replacement around stable siblings."
+          "testName": "places a Portal-to-element first-child transition before stable later siblings",
+          "note": "Pins portal cleanup, exact absolute order, and identity of the parent plus both later siblings in development and production compilation."
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/portal.test.ts",
+          "testName": "places a null-to-element first-child transition before stable later siblings",
+          "note": "Pins materialization at index zero while both later siblings retain identity."
+        },
+        {
+          "kind": "test",
+          "file": "packages/octane/tests/browser/portal-placement/portal-placement.test.ts",
+          "testName": "prod preserves absolute order without reattaching stable host nodes",
+          "note": "Real Chromium observes both the logical parent and foreign target and proves a child-topology-equivalent rerender emits zero child-list records."
         }
       ],
-      "nextAction": {
-        "kind": "test",
-        "targets": ["packages/octane/tests/portal.test.ts", "packages/octane/tests/browser"],
-        "acceptance": "Port Portal→element and null→element first-child transitions with multiple stable later siblings; retain every survivor object, assert exact final order, and use MutationObserver in Chromium to prove a stable rerender produces no child-list records."
-      },
-      "rationale": "The existing keyed identity suite proves a different reconciler contract. Redact's topology cases require portal-aware absolute placement plus a mutation-level oracle, so they remain an explicit gap instead of being hidden under RDX-REC-001."
+      "evidence": [
+        {
+          "file": "packages/octane/tests/portal.test.ts",
+          "testName": "places a Portal-to-element first-child transition before stable later siblings",
+          "modes": ["client", "production-compile"],
+          "observables": ["markup", "node-identity"]
+        },
+        {
+          "file": "packages/octane/tests/portal.test.ts",
+          "testName": "places a null-to-element first-child transition before stable later siblings",
+          "modes": ["client", "production-compile"],
+          "observables": ["markup", "node-identity"]
+        },
+        {
+          "file": "packages/octane/tests/browser/portal-placement/portal-placement.test.ts",
+          "testName": "dev preserves absolute order without reattaching stable host nodes",
+          "modes": ["client", "real-browser"],
+          "observables": ["markup", "node-identity", "dom-mutations"]
+        },
+        {
+          "file": "packages/octane/tests/browser/portal-placement/portal-placement.test.ts",
+          "testName": "prod preserves absolute order without reattaching stable host nodes",
+          "modes": ["production-compile", "real-browser"],
+          "observables": ["markup", "node-identity", "dom-mutations"]
+        }
+      ],
+      "rationale": "This is distinct from keyed-list identity: compiler-owned component anchors reserve the source position while portal or null output has no in-flow host. The regressions prove that later materialization stays inside that range and that the existing absolute-anchor path does not reattach stable hosts."
     },
     {
       "id": "RDX-REF-001",

--- a/packages/octane/tests/_fixtures/portal.tsrx
+++ b/packages/octane/tests/_fixtures/portal.tsrx
@@ -2,6 +2,24 @@ import { useState, createContext, use, createPortal } from 'octane';
 
 export const Theme = createContext('light');
 
+export type PortalPlacementMode = 'portal' | 'null' | 'inline';
+
+export interface PortalPlacementControls {
+	setMode(mode: PortalPlacementMode): void;
+	rerender(): void;
+}
+
+interface PortalTargetProps {
+	target: Element;
+}
+
+interface PortalPlacementProps extends PortalTargetProps {
+	initialMode: PortalPlacementMode;
+	bind(controls: PortalPlacementControls): void;
+}
+
+const PlacementMode = createContext<PortalPlacementMode>('portal');
+
 export function PortalledChild() @{
 	const theme = use(Theme);
 	<span class="child">{theme as string}</span>
@@ -48,4 +66,44 @@ export function InlineModal(props) @{
 		<button id="bump" onClick={() => setN(n + 1)}>{'bump'}</button>
 		{createPortal(<div class="inline-modal">{'count:' + n}</div>, props.target)}
 	</section>
+}
+
+function PortalOwnedStateChild() {
+	const [updated, setUpdated] = useState(false);
+	if (updated) {
+		return <section data-slot="portal-owned-child">{'updated'}</section>;
+	}
+	return <button
+		data-slot="portal-owned-child"
+		onClick={() => setUpdated(true)}
+	>{'initial'}</button>;
+}
+
+export function PortalOwnedStateApp(props: PortalTargetProps) @{
+	<div data-slot="portal-owner">{createPortal(<PortalOwnedStateChild />, props.target)}</div>
+}
+
+function PlacementFirstChild(props: PortalTargetProps) {
+	const mode = use(PlacementMode);
+	if (mode === 'portal') {
+		return createPortal(<div data-slot="portalled">{'PORTALLED'}</div>, props.target);
+	}
+	if (mode === 'null') return null;
+	return <div data-slot="first">{'FIRST'}</div>;
+}
+
+export function PortalPlacementApp(props: PortalPlacementProps) @{
+	const [mode, setMode] = useState<PortalPlacementMode>(props.initialMode);
+	const [tick, setTick] = useState(0);
+	props.bind({
+		setMode,
+		rerender: () => setTick(tick + 1),
+	});
+	<PlacementMode.Provider value={mode}>
+		<div data-slot="parent" data-tick={tick as string}>
+			<PlacementFirstChild target={props.target} />
+			<main data-slot="second">{'SECOND'}</main>
+			<aside data-slot="third">{'THIRD'}</aside>
+		</div>
+	</PlacementMode.Provider>
 }

--- a/packages/octane/tests/browser/portal-placement/index.html
+++ b/packages/octane/tests/browser/portal-placement/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Octane portal placement</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<section id="portal-target">
+			<i data-slot="foreign-before">before</i>
+		</section>
+		<script type="module" src="/main.ts"></script>
+	</body>
+</html>

--- a/packages/octane/tests/browser/portal-placement/main.ts
+++ b/packages/octane/tests/browser/portal-placement/main.ts
@@ -1,0 +1,102 @@
+import { createRoot, flushSync } from '../../../src/index.js';
+import {
+	PortalPlacementApp,
+	type PortalPlacementControls,
+	type PortalPlacementMode,
+} from '../../_fixtures/portal.tsrx';
+
+const container = document.querySelector('#root') as HTMLElement;
+const portalTarget = document.querySelector('#portal-target') as HTMLElement;
+const foreignBefore = portalTarget.querySelector('[data-slot="foreign-before"]')!;
+let controls!: PortalPlacementControls;
+
+const root = createRoot(container);
+root.render(PortalPlacementApp, {
+	target: portalTarget,
+	initialMode: 'portal',
+	bind(next) {
+		controls = next;
+	},
+});
+flushSync(() => {});
+
+const foreignAfter = document.createElement('i');
+foreignAfter.dataset.slot = 'foreign-after';
+foreignAfter.textContent = 'after';
+portalTarget.appendChild(foreignAfter);
+
+const initialParent = container.querySelector('[data-slot="parent"]')!;
+const initialSecond = container.querySelector('[data-slot="second"]')!;
+const initialThird = container.querySelector('[data-slot="third"]')!;
+
+function slots(parent: Element): Array<string | null> {
+	return Array.from(parent.children, (child) => child.getAttribute('data-slot'));
+}
+
+function snapshot() {
+	const parent = container.querySelector('[data-slot="parent"]')!;
+	return {
+		identity: {
+			foreignAfter: portalTarget.querySelector('[data-slot="foreign-after"]') === foreignAfter,
+			foreignBefore: portalTarget.querySelector('[data-slot="foreign-before"]') === foreignBefore,
+			parent: parent === initialParent,
+			second: container.querySelector('[data-slot="second"]') === initialSecond,
+			third: container.querySelector('[data-slot="third"]') === initialThird,
+		},
+		portalSlots: slots(portalTarget),
+		rootSlots: slots(parent),
+		tick: parent.getAttribute('data-tick'),
+	};
+}
+
+function setMode(mode: PortalPlacementMode) {
+	flushSync(() => controls.setMode(mode));
+	return snapshot();
+}
+
+async function stableRerender() {
+	const parent = container.querySelector('[data-slot="parent"]')!;
+	const first = parent.querySelector('[data-slot="first"]')!;
+	const second = parent.querySelector('[data-slot="second"]')!;
+	const third = parent.querySelector('[data-slot="third"]')!;
+	const records: MutationRecord[] = [];
+	const observer = new MutationObserver((next) => records.push(...next));
+	observer.observe(parent, { childList: true, subtree: true });
+	observer.observe(portalTarget, { childList: true, subtree: true });
+
+	flushSync(() => controls.rerender());
+	await Promise.resolve();
+	records.push(...observer.takeRecords());
+	observer.disconnect();
+
+	return {
+		...snapshot(),
+		addedNodeCount: records.reduce((count, record) => count + record.addedNodes.length, 0),
+		childListRecordCount: records.length,
+		settledIdentity: {
+			first: parent.querySelector('[data-slot="first"]') === first,
+			second: parent.querySelector('[data-slot="second"]') === second,
+			third: parent.querySelector('[data-slot="third"]') === third,
+		},
+	};
+}
+
+window.__portalPlacement = {
+	setMode,
+	snapshot,
+	stableRerender,
+	unmount() {
+		root.unmount();
+	},
+};
+
+declare global {
+	interface Window {
+		__portalPlacement: {
+			setMode: typeof setMode;
+			snapshot: typeof snapshot;
+			stableRerender: typeof stableRerender;
+			unmount(): void;
+		};
+	}
+}

--- a/packages/octane/tests/browser/portal-placement/portal-placement.test.ts
+++ b/packages/octane/tests/browser/portal-placement/portal-placement.test.ts
@@ -1,0 +1,134 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { chromium, type Browser, type Page } from 'playwright';
+import { createServer, type ViteDevServer } from 'vite';
+import { octane } from 'octane/compiler/vite';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+let browser: Browser;
+
+beforeAll(async () => {
+	try {
+		browser = await chromium.launch({ headless: true });
+	} catch (error) {
+		throw new Error(
+			`Chromium is required for portal-placement browser evidence (run \`pnpm --filter octane exec playwright install chromium\`): ${String(error)}`,
+		);
+	}
+});
+
+afterAll(async () => {
+	await browser?.close();
+});
+
+async function openPage(mode: 'dev' | 'prod'): Promise<{
+	failures: string[];
+	page: Page;
+	server: ViteDevServer;
+}> {
+	const server = await createServer({
+		cacheDir: resolve(HERE, `../../../../../node_modules/.vite/octane-portal-placement-${mode}`),
+		configFile: false,
+		root: HERE,
+		logLevel: 'error',
+		plugins: [octane(mode === 'prod' ? { hmr: false } : {})],
+		server: { host: '127.0.0.1', port: 0 },
+	});
+	const failures: string[] = [];
+	let page: Page | undefined;
+	try {
+		await server.listen();
+		const address = server.httpServer!.address();
+		if (!address || typeof address === 'string') {
+			throw new Error('Vite did not expose a TCP port');
+		}
+
+		page = await browser.newPage();
+		page.on('pageerror', (error) => failures.push(`pageerror: ${error.message}`));
+		page.on('console', (message) => {
+			if (message.type() === 'error' || message.type() === 'warning') {
+				failures.push(`${message.type()}: ${message.text()}`);
+			}
+		});
+		await page.goto(`http://127.0.0.1:${address.port}`);
+		await page.waitForFunction(() => Boolean(window.__portalPlacement));
+		return { failures, page, server };
+	} catch (error) {
+		await Promise.allSettled([page?.close(), server.close()]);
+		throw error;
+	}
+}
+
+describe.sequential('portal absolute placement in a real browser', () => {
+	it.each(['dev', 'prod'])(
+		'%s preserves absolute order without reattaching stable host nodes',
+		async (mode) => {
+			const { failures, page, server } = await openPage(mode as 'dev' | 'prod');
+			try {
+				const initial = await page.evaluate(() => window.__portalPlacement.snapshot());
+				expect(initial).toEqual({
+					identity: {
+						foreignAfter: true,
+						foreignBefore: true,
+						parent: true,
+						second: true,
+						third: true,
+					},
+					portalSlots: ['foreign-before', 'portalled', 'foreign-after'],
+					rootSlots: ['second', 'third'],
+					tick: '0',
+				});
+
+				const inline = await page.evaluate(() => window.__portalPlacement.setMode('inline'));
+				expect(inline).toMatchObject({
+					identity: {
+						foreignAfter: true,
+						foreignBefore: true,
+						parent: true,
+						second: true,
+						third: true,
+					},
+					portalSlots: ['foreign-before', 'foreign-after'],
+					rootSlots: ['first', 'second', 'third'],
+				});
+
+				const empty = await page.evaluate(() => window.__portalPlacement.setMode('null'));
+				expect(empty.rootSlots).toEqual(['second', 'third']);
+				const rematerialized = await page.evaluate(() =>
+					window.__portalPlacement.setMode('inline'),
+				);
+				expect(rematerialized.rootSlots).toEqual(['first', 'second', 'third']);
+
+				const stable = await page.evaluate(() => window.__portalPlacement.stableRerender());
+				expect(stable).toMatchObject({
+					addedNodeCount: 0,
+					childListRecordCount: 0,
+					identity: {
+						foreignAfter: true,
+						foreignBefore: true,
+						parent: true,
+						second: true,
+						third: true,
+					},
+					portalSlots: ['foreign-before', 'foreign-after'],
+					rootSlots: ['first', 'second', 'third'],
+					settledIdentity: {
+						first: true,
+						second: true,
+						third: true,
+					},
+					tick: '1',
+				});
+				expect(failures).toEqual([]);
+			} finally {
+				try {
+					await page.evaluate(() => window.__portalPlacement.unmount());
+				} finally {
+					await Promise.allSettled([page.close(), server.close()]);
+				}
+			}
+		},
+	);
+});

--- a/packages/octane/tests/portal.test.ts
+++ b/packages/octane/tests/portal.test.ts
@@ -1,6 +1,17 @@
 import { describe, it, expect } from 'vitest';
+import { flushSync } from '../src/index.js';
 import { mount } from './_helpers';
-import { App, InlineModal } from './_fixtures/portal.tsrx';
+import {
+	App,
+	InlineModal,
+	PortalOwnedStateApp,
+	PortalPlacementApp,
+	type PortalPlacementControls,
+} from './_fixtures/portal.tsrx';
+
+function elementSlots(parent: Element): Array<string | null> {
+	return Array.from(parent.children, (child) => child.getAttribute('data-slot'));
+}
 
 describe('portal', () => {
 	it('renders content into a foreign DOM target, with context flowing through', () => {
@@ -55,6 +66,100 @@ describe('portal — inline element body (React authoring shape)', () => {
 
 		r.unmount();
 		expect(portalTarget.querySelector('.inline-modal')).toBe(null);
+		portalTarget.remove();
+	});
+});
+
+describe('portal — descendant-owned updates', () => {
+	it('keeps a descendant-owned root replacement inside its portal target', () => {
+		const portalTarget = document.createElement('section');
+		const before = document.createElement('i');
+		before.dataset.slot = 'foreign-before';
+		portalTarget.appendChild(before);
+		document.body.appendChild(portalTarget);
+
+		const r = mount(PortalOwnedStateApp, { target: portalTarget });
+		const logicalRoot = r.find('[data-slot="portal-owner"]');
+		const initial = portalTarget.querySelector('[data-slot="portal-owned-child"]')!;
+		const after = document.createElement('i');
+		after.dataset.slot = 'foreign-after';
+		portalTarget.appendChild(after);
+
+		expect(Array.from(portalTarget.children)).toEqual([before, initial, after]);
+		expect(initial.tagName).toBe('BUTTON');
+
+		flushSync(() => (initial as HTMLButtonElement).click());
+
+		const replacement = portalTarget.querySelector('[data-slot="portal-owned-child"]')!;
+		expect(replacement.tagName).toBe('SECTION');
+		expect(replacement.textContent).toBe('updated');
+		expect(replacement.parentNode).toBe(portalTarget);
+		expect(r.find('[data-slot="portal-owner"]')).toBe(logicalRoot);
+		expect(r.findAll('[data-slot="portal-owned-child"]')).toHaveLength(0);
+		expect(Array.from(portalTarget.children)).toEqual([before, replacement, after]);
+		expect(initial.isConnected).toBe(false);
+
+		r.unmount();
+		expect(Array.from(portalTarget.children)).toEqual([before, after]);
+		portalTarget.remove();
+	});
+});
+
+describe('portal — absolute placement', () => {
+	it('places a Portal-to-element first-child transition before stable later siblings', () => {
+		const portalTarget = document.createElement('section');
+		document.body.appendChild(portalTarget);
+		let controls!: PortalPlacementControls;
+		const r = mount(PortalPlacementApp, {
+			target: portalTarget,
+			initialMode: 'portal',
+			bind(next) {
+				controls = next;
+			},
+		});
+		const parent = r.find('[data-slot="parent"]');
+		const second = r.find('[data-slot="second"]');
+		const third = r.find('[data-slot="third"]');
+
+		expect(elementSlots(parent)).toEqual(['second', 'third']);
+		expect(portalTarget.querySelector('[data-slot="portalled"]')).not.toBe(null);
+
+		flushSync(() => controls.setMode('inline'));
+
+		expect(r.find('[data-slot="parent"]')).toBe(parent);
+		expect(elementSlots(parent)).toEqual(['first', 'second', 'third']);
+		expect(parent.children[1]).toBe(second);
+		expect(parent.children[2]).toBe(third);
+		expect(portalTarget.querySelector('[data-slot="portalled"]')).toBe(null);
+
+		r.unmount();
+		portalTarget.remove();
+	});
+
+	it('places a null-to-element first-child transition before stable later siblings', () => {
+		const portalTarget = document.createElement('section');
+		document.body.appendChild(portalTarget);
+		let controls!: PortalPlacementControls;
+		const r = mount(PortalPlacementApp, {
+			target: portalTarget,
+			initialMode: 'null',
+			bind(next) {
+				controls = next;
+			},
+		});
+		const parent = r.find('[data-slot="parent"]');
+		const second = r.find('[data-slot="second"]');
+		const third = r.find('[data-slot="third"]');
+
+		expect(elementSlots(parent)).toEqual(['second', 'third']);
+		flushSync(() => controls.setMode('inline'));
+
+		expect(r.find('[data-slot="parent"]')).toBe(parent);
+		expect(elementSlots(parent)).toEqual(['first', 'second', 'third']);
+		expect(parent.children[1]).toBe(second);
+		expect(parent.children[2]).toBe(third);
+
+		r.unmount();
 		portalTarget.remove();
 	});
 });


### PR DESCRIPTION
## Summary

- add development and production regression coverage for descendant-owned updates that replace a portal child’s host root while preserving foreign-target siblings
- cover Portal-to-element and null-to-element first-child transitions at their absolute logical anchors without replacing stable later siblings
- add real-Chromium MutationObserver evidence proving a stable rerender emits no child-list mutations in either compile mode
- mark `RDX-PORT-002` and `RDX-REC-002` covered, leaving the Redact audit with 23 covered and 0 planned contracts

## Why

Redact exposed two portable failure modes around portal host resolution and absolute placement. Octane’s current retained host-parent and compiler-anchor architecture already satisfies these contracts, so this PR pins the behavior at the DOM identity and mutation boundaries where a regression would be observable.

## Impact

This PR changes tests and audit documentation only. It does not modify runtime or compiler code, so it adds no shipped runtime overhead, object-shape change, or benchmark impact.

## Validation

- `./node_modules/.bin/vitest run packages/octane/tests/portal.test.ts --project octane --project octane-prod --reporter=dot`
- `./node_modules/.bin/vitest run packages/octane/tests/browser/portal-placement/portal-placement.test.ts --project octane-events-browser --reporter=dot`
- `corepack pnpm@11.15.1 redact-audit:check`
- `PNPM_CONFIG_PM_ON_FAIL=ignore corepack pnpm@11.15.1 typecheck`
- `corepack pnpm@11.15.1 format:check`

A repository-wide Vitest run completed 12,836 of 12,839 tests successfully; the three load-related failures (eval subprocess timeout, deferred-hydration timing, and Lucide timeout) all passed when rerun independently.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and audit documentation only; no shipped runtime or compiler behavior changes.
> 
> **Overview**
> Adds **regression coverage** for two Redact-derived portal contracts and updates the adversarial audit so **`RDX-PORT-002`** and **`RDX-REC-002`** are **covered** (23 covered, 0 planned).
> 
> **Descendant-owned portal updates:** a portal child that replaces its host root (e.g. button → section) on its own state stays inside the foreign target and keeps surrounding target siblings stable (`portal.test.ts` + `portal.tsrx` fixtures).
> 
> **Absolute placement:** Portal→inline and null→inline first-child transitions insert at index 0 before stable later siblings without reattaching them; a new **Chromium** harness uses **MutationObserver** to assert a topology-equivalent stable rerender emits **zero** child-list mutations in dev and prod.
> 
> No runtime or compiler code changes—tests, fixtures, browser harness, ledger JSON, and generated audit report only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c6806d56c245af1893976c2675ee330a628261b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->