### PR TITLE
perf(octane): memoize through plain-callee projections; skip the de-opt key serializer

### DIFF
--- a/.changeset/automemo-plain-callee.md
+++ b/.changeset/automemo-plain-callee.md
@@ -8,12 +8,19 @@ and `{segText(seg, done)}` are ordinary value projections, but a single one of
 them previously disqualified the whole component — and, transitively, every
 component that rendered it — from region memoization.
 
-Calls through a **method on your data** (`{header.getIsSorted()}`) still
-disqualify the region: the receiver can return a new answer while the object
-identity that would witness the change stays the same, which is the shape
-table/grid/store bindings produce. Hook calls (`use()` and any `use*`) are never
-treated as value projections either, since they own suspension, hook cells,
-context subscriptions, and effect lifecycles.
+A call is admitted only when its callee is a module-scope immutable identity: an
+imported binding, or a same-module `function` declaration that is never
+reassigned and whose own body is itself a value projection. Everything else
+still fails closed, because each can hide state that no dependency witnesses:
+
+- a method on your data (`{header.getIsSorted()}`), including a helper that
+  merely wraps one — the same hazard one call frame away;
+- a component-local callee, which nothing pins to an immutable identity;
+- hook calls (`use()` and any `use*`), which own suspension, hook cells, context
+  subscriptions, and effect lifecycles rather than projecting a value;
+- `new Foo()` and tagged templates.
+
+Arguments carry the same contract, so `{format(row.get())}` stays disqualified.
 
 Same-module `function` helpers that are never reassigned are also now accepted
 as memo-region witnesses, on the same immutable-identity grounds already given

--- a/.changeset/automemo-plain-callee.md
+++ b/.changeset/automemo-plain-callee.md
@@ -1,0 +1,28 @@
+---
+'octane': patch
+---
+
+Automatic memoization no longer gives up on a component because its template
+renders a value through a function call. `{formatPrice(cents)}`, `{t('total')}`,
+and `{segText(seg, done)}` are ordinary value projections, but a single one of
+them previously disqualified the whole component — and, transitively, every
+component that rendered it — from region memoization.
+
+Calls through a **method on your data** (`{header.getIsSorted()}`) still
+disqualify the region: the receiver can return a new answer while the object
+identity that would witness the change stays the same, which is the shape
+table/grid/store bindings produce. Hook calls (`use()` and any `use*`) are never
+treated as value projections either, since they own suspension, hook cells,
+context subscriptions, and effect lifecycles.
+
+Same-module `function` helpers that are never reassigned are also now accepted
+as memo-region witnesses, on the same immutable-identity grounds already given
+to same-module components and `const X = memo(C)` walls.
+
+Measured on `benchmarks/chat-stream` (paired runs, same machine): 160 keystrokes
+through the controlled composer 2.22ms → 0.78ms, streaming a reply into a
+200-message history 1.56ms → 0.72ms, fine-grained token streaming 1.58ms →
+0.96ms.
+
+See "Automatic memoization and calls in templates" in
+`docs/differences-from-react.md`.

--- a/.changeset/deopt-child-key-fast-path.md
+++ b/.changeset/deopt-child-key-fast-path.md
@@ -1,0 +1,16 @@
+---
+'octane': patch
+---
+
+De-opt child reconciliation keys skip the JSON serializer at the unwrapped top
+level — the shape every `{items.map(...)}` list and every `@octanejs/*` binding's
+rendered output produces. That level re-keyed every child on every parent
+render, including renders where all children went on to bail, so a 1,000-row
+list allocated 1,000 serialized strings per update. Nested wrapper paths keep
+the serialized encoding, and the two aliasing properties it provides (an
+explicit `key="0"` stays distinct from an implicit index 0; a user key cannot
+resemble a wrapper path) are preserved.
+
+On the `benchmarks/memo-wall` value-position wall, a Chromium CPU profile of the
+all-bail parent re-render drops the flatten step from 13.4% to 6.0% of samples
+and total samples by 13.8%; the timed op moves from 1.48x to 1.39x React.

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -50,26 +50,42 @@ would change program behavior.
 
 Production builds memoize component regions automatically, on the same
 pure-render, immutable-snapshot contract React Compiler assumes. Rendering a
-value through a plain function call — `{formatPrice(cents)}`, `{t('total')}`,
-`{segText(seg, done)}` — keeps the surrounding region memoizable; the callee is
-a module or imported binding that the region already tracks.
+value through a function call keeps the surrounding region memoizable when the
+callee is a **module-scope immutable identity**:
 
-Calling a **method on your data** during render does not. `{header.getIsSorted()}`
-can return a new answer while `header` stays the same object, so neither the
-value nor any dependency witnesses the change. Octane keeps those regions
-unmemoized and re-runs them, matching what React does for an unmemoized
-component. Library bindings that expose table/grid/store instances with live
-accessor methods therefore keep working unchanged.
+- an imported binding — `{formatPrice(cents)}`, `{t('total')}`,
+  `{segText(seg, done)}`;
+- a same-module `function` declaration that is never reassigned, and whose own
+  body is itself a value projection.
 
-Hooks are never treated as value projections. `use()` is a suspension point, and
-`use*` calls own hook cells, context subscriptions, and effect lifecycles, so a
-region containing one is always re-entered.
+Anything else keeps the region unmemoized, and the region simply re-runs — the
+same result React gives an unmemoized component:
+
+- **A method on your data.** `{header.getIsSorted()}` can return a new answer
+  while `header` stays the same object, so neither the value nor any dependency
+  witnesses the change. Library bindings that expose table/grid/store instances
+  with live accessor methods keep working unchanged, and so does a module helper
+  that merely wraps one (`function sortIcon(h) { return h.getIsSorted(); }` is
+  the same hazard one call frame away, and is rejected for the same reason).
+- **A component-local callee.** `const read = (h) => h.getIsSorted()` is an
+  identifier, but nothing pins it to an immutable module identity, so it cannot
+  stand in for a projection even when something hands it a stable reference.
+- **Hooks.** `use()` is a suspension point, and `use*` calls own hook cells,
+  context subscriptions, and effect lifecycles, so a region containing one is
+  always re-entered.
+- **`new Foo()` and tagged templates.** Construction is not a value projection.
+
+Arguments carry the same contract as the call itself: `{format(row.get())}` is
+rejected even though `format` qualifies.
 
 If you want a method-backed value memoized, read it into a local first
 (`const sorted = header.getIsSorted();`) and let the surrounding state own it —
 the same advice React Compiler gives. Conversely, a region *is* allowed to
 memoize past a mutable module-level variable, whether read directly or returned
-by a helper; module state that must drive rendering belongs in state or context.
+by an imported helper; module state that must drive rendering belongs in state
+or context. Octane cannot read across a module boundary, so an imported helper
+is taken at its word — that is the one place this analysis trusts rather than
+proves, and it matches React Compiler's own assumption.
 
 ## `useState` / `useReducer` current-state getters
 

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -46,6 +46,31 @@ render. Opaque callback creation such as `useEffect(makeEffect())` requires an
 explicit array or `null`, because evaluating it again to construct a dependency
 would change program behavior.
 
+## Automatic memoization and calls in templates
+
+Production builds memoize component regions automatically, on the same
+pure-render, immutable-snapshot contract React Compiler assumes. Rendering a
+value through a plain function call — `{formatPrice(cents)}`, `{t('total')}`,
+`{segText(seg, done)}` — keeps the surrounding region memoizable; the callee is
+a module or imported binding that the region already tracks.
+
+Calling a **method on your data** during render does not. `{header.getIsSorted()}`
+can return a new answer while `header` stays the same object, so neither the
+value nor any dependency witnesses the change. Octane keeps those regions
+unmemoized and re-runs them, matching what React does for an unmemoized
+component. Library bindings that expose table/grid/store instances with live
+accessor methods therefore keep working unchanged.
+
+Hooks are never treated as value projections. `use()` is a suspension point, and
+`use*` calls own hook cells, context subscriptions, and effect lifecycles, so a
+region containing one is always re-entered.
+
+If you want a method-backed value memoized, read it into a local first
+(`const sorted = header.getIsSorted();`) and let the surrounding state own it —
+the same advice React Compiler gives. Conversely, a region *is* allowed to
+memoize past a mutable module-level variable, whether read directly or returned
+by a helper; module state that must drive rendering belongs in state or context.
+
 ## `useState` / `useReducer` current-state getters
 
 Both state hooks have an Octane-only third tuple member: a stable zero-argument

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -2618,20 +2618,21 @@ function containsAutoMemoContextRead(root, ctx) {
 }
 
 /**
- * True when the keyed-item body executes any call DURING render:
- * CallExpression / NewExpression / TaggedTemplateExpression in render-value
- * position (holes, attribute values, locals). Such a call can read mutable
- * state that neither the item reference nor the deps tuple changes with —
- * e.g. `header.column.getIsSorted()` on a memoized table-core header — so the
- * PURE/DEP-PURE survivor short-circuit (see the body analysis in makeForCall)
- * would freeze its output where React re-runs the body unconditionally.
+ * True when the body executes a call DURING render: CallExpression /
+ * NewExpression / TaggedTemplateExpression in render-value position (holes,
+ * attribute values, locals).
  *
  * Calls nested inside FUNCTION VALUES (event-handler arrows, function
  * expressions) are deferred to invoke time and close over the same ref-stable
  * item/deps a skipped survivor would have, so they can't go stale at render
  * time — the walk does not descend into function bodies or parameters.
+ *
+ * `allowPlainCallee` admits calls through a bare IDENTIFIER callee — see
+ * `plainCalleeIsMemoizable` for the contract and why the two callee shapes are
+ * classified differently. Callers that need "no call executes here" for a reason
+ * other than memo staleness (SSR item identity) must leave it off.
  */
-function containsRenderCall(stmts) {
+function containsRenderCall(stmts, allowPlainCallee = false) {
 	let found = false;
 	const seen = new WeakSet();
 	function walk(n) {
@@ -2658,6 +2659,12 @@ function containsRenderCall(stmts) {
 			t === 'NewExpression' ||
 			t === 'TaggedTemplateExpression'
 		) {
+			if (allowPlainCallee && plainCalleeIsMemoizable(n)) {
+				// The callee itself is a witnessed binding; its ARGUMENTS still carry
+				// the render-value contract, so `fmt(row.get())` stays disqualified.
+				walk(n.arguments);
+				return;
+			}
 			found = true;
 			return;
 		}
@@ -2668,6 +2675,91 @@ function containsRenderCall(stmts) {
 	}
 	for (const s of stmts) walk(s);
 	return found;
+}
+
+const HOOK_CALLEE_NAME_RE = /^use[A-Z]/;
+
+function isHookCalleeName(name) {
+	return name === 'use' || HOOK_CALLEE_NAME_RE.test(name);
+}
+
+/**
+ * Does this call go through a bare identifier callee — `segText(seg, done)`,
+ * `formatPrice(cents)`, `t('key')` — rather than a member expression?
+ *
+ * autoMemo models React Compiler's pure-render / immutable-snapshot contract,
+ * under which memoizing through a call is the NORMAL case. The blanket call veto
+ * exists for one shape that violates that contract in practice and is pervasive
+ * in library bindings: reading mutable state through an object reachable from
+ * the item or props, where neither the item ref nor any dep witnesses the change
+ * (`header.column.getIsSorted()` flips while `header` stays the memoized
+ * object). That hazard is carried by the RECEIVER, so it is the member-callee
+ * shape that must fail closed.
+ *
+ * A bare identifier callee resolves to a module-local declaration or an imported
+ * binding — both already carried in the region's dependency tuple. Such a call
+ * is exactly as exposed to mutable module state as the bare identifier read the
+ * same region is already allowed to memoize through (see the DEP-PURE contract
+ * in tests/_fixtures/for.tsrx), so vetoing one while permitting the other bought
+ * no guarantee and cost every formatting call in the codebase its memo region.
+ *
+ * `new Foo()` and tagged templates stay disqualified: construction is not a
+ * value projection, and a tag function receives the raw strings array.
+ *
+ * HOOK-shaped callees are also disqualified. `use(promise)` is a suspension
+ * point and `useState`/`useLayoutEffect`/a custom `useThing()` own hook cells,
+ * context subscriptions, and effect lifecycles — none of which are value
+ * projections, and all of which change observable commit/retry behavior when a
+ * region is skipped (a re-suspended boundary must re-run to destroy and
+ * recreate its layout effects). The naming convention is the same signal React
+ * and React Compiler key on, and it is what the blanket call veto was
+ * incidentally covering here.
+ */
+function plainCalleeIsMemoizable(node) {
+	if (node.type !== 'CallExpression' && node.type !== 'OptionalCallExpression') return false;
+	const callee = node.callee;
+	if (callee?.type !== 'Identifier') return false;
+	return !isHookCalleeName(callee.name);
+}
+
+/**
+ * Top-level `function foo() {}` names that are never reassigned anywhere in the
+ * module. A function declaration hoists to one immutable identity, so closing
+ * over it cannot make a memo region stale — unlike a module `let`, which the
+ * classifiers correctly refuse to witness. An assignment anywhere in the module
+ * (including inside a nested function that may run later) demotes the name.
+ */
+function collectImmutableModuleFunctionNames(body) {
+	const declared = new Set();
+	for (const statement of body) {
+		const declaration =
+			statement.type === 'ExportNamedDeclaration' ? statement.declaration : statement;
+		if (declaration?.type === 'FunctionDeclaration' && declaration.id?.type === 'Identifier') {
+			declared.add(declaration.id.name);
+		}
+	}
+	if (declared.size === 0) return declared;
+	const seen = new WeakSet();
+	function walk(n) {
+		if (!n || typeof n !== 'object') return;
+		if (Array.isArray(n)) {
+			for (const x of n) walk(x);
+			return;
+		}
+		if (seen.has(n)) return;
+		seen.add(n);
+		if (n.type === 'AssignmentExpression' && n.left?.type === 'Identifier') {
+			declared.delete(n.left.name);
+		} else if (n.type === 'UpdateExpression' && n.argument?.type === 'Identifier') {
+			declared.delete(n.argument.name);
+		}
+		for (const key in n) {
+			if (AST_WALK_SKIP_KEYS.has(key)) continue;
+			walk(n[key]);
+		}
+	}
+	walk(body);
+	return declared;
 }
 
 // Conservative semantic boundary for compiler-owned component-region memoization.
@@ -5122,6 +5214,13 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 			}
 		}
 	}
+	// Module-level `function foo() {}` helpers. The binding is an immutable
+	// identity for the module's lifetime, so a memo region that closes over one
+	// needs no dependency slot to witness it — the same standing the classifiers
+	// already give same-module components and `const X = memo(C)` walls. Names
+	// that are ever assigned (`foo = bar`) are excluded: their identity is then
+	// as mutable as a module `let`, which fails closed.
+	ctx.moduleFunctionBindings = collectImmutableModuleFunctionNames(ast.body);
 	// M3 inherit-range exclusion set (see inheritSoleCompRoot).
 	ctx._octaneBoundaryNames = collectOctaneBoundaryNames(ast.body);
 	// Client prelude `_$vtSeen()` module-load hint (view-transitions plan).
@@ -5207,7 +5306,7 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 			(compNode.params?.length !== 1 || compNode.params[0]?.type === 'Identifier');
 		let autoMemoSafe =
 			ordinaryPropsParam &&
-			!containsRenderCall(stmts) &&
+			!containsRenderCall(stmts, true) &&
 			!containsAutoMemoUnsafeStructure(stmts) &&
 			!containsImportedMemberRead(root, ctx.importedNames);
 		const autoMemoCaptures = [];
@@ -5231,7 +5330,10 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 					// Immutable const wrapper; its default memo contract is the wall.
 					continue;
 				} else if (ctx.componentInfo.has(name)) autoMemoComponentDeps.push(name);
-				else {
+				else if (ctx.moduleFunctionBindings?.has(name)) {
+					// Immutable same-module function identity; no dependency slot needed.
+					continue;
+				} else {
 					autoMemoSafe = false;
 					break;
 				}
@@ -18418,7 +18520,7 @@ function makeCompCall(
 					ctx.currentAutoMemoCallsitesSafe !== false &&
 					callSiteOk &&
 					calleeInfo.autoMemoSafe === true &&
-					!containsRenderCall([node]) &&
+					!containsRenderCall([node], true) &&
 					!containsAutoMemoUnsafeStructure([node]) &&
 					!containsImportedMemberRead(node, ctx.importedNames)
 				) {
@@ -18445,7 +18547,11 @@ function makeCompCall(
 							depsSafe = false;
 						} else if (ctx.currentComponentLocals.has(name) || ctx.importedNames.has(name)) {
 							if (!callsiteDeps.coveredRoots.has(name)) deps.add(name);
-						} else if (ctx.componentInfo.has(name) || ctx.defaultMemoBindings.has(name)) {
+						} else if (
+							ctx.componentInfo.has(name) ||
+							ctx.defaultMemoBindings.has(name) ||
+							ctx.moduleFunctionBindings?.has(name)
+						) {
 							// Same-module FunctionDeclaration identity is immutable.
 							continue;
 						} else {
@@ -18845,13 +18951,14 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 			}
 		}
 		const hasNestedComp = containsComponentCallOrControlFlow(subStmts);
-		// A render-time CALL disqualifies the survivor short-circuit entirely: the
-		// call can read state neither the item ref nor the deps tuple witnesses
-		// (`header.column.getIsSorted()` flips while `header` stays the memoized
-		// object), so a skipped body would render stale output — React re-runs
-		// bodies unconditionally. Property reads stay eligible (the measured
+		// A render-time call through a METHOD disqualifies the survivor
+		// short-circuit entirely: it can read state neither the item ref nor the
+		// deps tuple witnesses (`header.column.getIsSorted()` flips while `header`
+		// stays the memoized object), so a skipped body would render stale output —
+		// React re-runs bodies unconditionally. Property reads and plain-callee
+		// projections stay eligible (see plainCalleeIsMemoizable; the measured
 		// js-framework-benchmark/dbmon wins are read-only bodies).
-		const hasRenderCall = containsRenderCall(subStmts);
+		const hasRenderCall = containsRenderCall(subStmts, true);
 		itemMemo =
 			ctx.autoMemo === true &&
 			hasNestedComp &&
@@ -18903,7 +19010,11 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 					if (child.autoMemoMayReadContext) itemMemoContextAware = true;
 					continue;
 				}
-				// Ambient globals and module locals are not reactive witnesses. Imported
+				if (ctx.moduleFunctionBindings?.has(name)) {
+					// Immutable same-module function identity; no dependency slot needed.
+					continue;
+				}
+				// Ambient globals and module `let`s are not reactive witnesses. Imported
 				// live bindings are handled above; everything else fails closed.
 				itemMemo = false;
 				break;
@@ -18923,8 +19034,8 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 			ctx.autoMemo === true &&
 			isAutoMemoCalculationDependency(node.right) &&
 			!hasHook &&
-			!containsRenderCall(regionStmts) &&
-			!containsRenderCall(node.key ? [node.key] : []) &&
+			!containsRenderCall(regionStmts, true) &&
+			!containsRenderCall(node.key ? [node.key] : [], true) &&
 			!containsAutoMemoUnsafeStructure(regionStmts) &&
 			!containsAutoMemoUnsafeStructure(node.key ? [node.key] : []) &&
 			!containsImportedMemberRead(regionAst, ctx.importedNames);
@@ -18956,6 +19067,14 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 						witnesses.add(witness);
 					}
 					if (child.autoMemoMayReadContext) listMayReadContext = true;
+					continue;
+				}
+				// Checked LAST, and never for a component: a same-module component is
+				// also a FunctionDeclaration, but its eligibility is decided by the
+				// branch above — an ineligible one (a context consumer, say) must fail
+				// closed here rather than be rescued as a plain helper.
+				if (ctx.moduleFunctionBindings?.has(name) && !ctx.componentInfo.has(name)) {
+					// Immutable same-module function identity; no dependency slot needed.
 					continue;
 				}
 				listSafe = false;

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -2627,12 +2627,12 @@ function containsAutoMemoContextRead(root, ctx) {
  * item/deps a skipped survivor would have, so they can't go stale at render
  * time — the walk does not descend into function bodies or parameters.
  *
- * `allowPlainCallee` admits calls through a bare IDENTIFIER callee — see
- * `plainCalleeIsMemoizable` for the contract and why the two callee shapes are
+ * Passing `memoCtx` admits calls that are provable value projections — see
+ * `plainCalleeIsMemoizable` for the contract and why callee shapes are
  * classified differently. Callers that need "no call executes here" for a reason
- * other than memo staleness (SSR item identity) must leave it off.
+ * other than memo staleness (SSR item identity) omit it and keep every call.
  */
-function containsRenderCall(stmts, allowPlainCallee = false) {
+function containsRenderCall(stmts, memoCtx = null) {
 	let found = false;
 	const seen = new WeakSet();
 	function walk(n) {
@@ -2659,9 +2659,9 @@ function containsRenderCall(stmts, allowPlainCallee = false) {
 			t === 'NewExpression' ||
 			t === 'TaggedTemplateExpression'
 		) {
-			if (allowPlainCallee && plainCalleeIsMemoizable(n)) {
-				// The callee itself is a witnessed binding; its ARGUMENTS still carry
-				// the render-value contract, so `fmt(row.get())` stays disqualified.
+			if (memoCtx !== null && plainCalleeIsMemoizable(n, memoCtx)) {
+				// The callee is a proven projection; its ARGUMENTS still carry the
+				// render-value contract, so `fmt(row.get())` stays disqualified.
 				walk(n.arguments);
 				return;
 			}
@@ -2684,8 +2684,8 @@ function isHookCalleeName(name) {
 }
 
 /**
- * Does this call go through a bare identifier callee — `segText(seg, done)`,
- * `formatPrice(cents)`, `t('key')` — rather than a member expression?
+ * Is this call a memoizable value projection — `segText(seg, done)`,
+ * `formatPrice(cents)`, `t('key')`?
  *
  * autoMemo models React Compiler's pure-render / immutable-snapshot contract,
  * under which memoizing through a call is the NORMAL case. The blanket call veto
@@ -2693,15 +2693,27 @@ function isHookCalleeName(name) {
  * in library bindings: reading mutable state through an object reachable from
  * the item or props, where neither the item ref nor any dep witnesses the change
  * (`header.column.getIsSorted()` flips while `header` stays the memoized
- * object). That hazard is carried by the RECEIVER, so it is the member-callee
- * shape that must fail closed.
+ * object). That hazard is carried by the RECEIVER, so a member callee always
+ * fails closed.
  *
- * A bare identifier callee resolves to a module-local declaration or an imported
- * binding — both already carried in the region's dependency tuple. Such a call
- * is exactly as exposed to mutable module state as the bare identifier read the
- * same region is already allowed to memoize through (see the DEP-PURE contract
- * in tests/_fixtures/for.tsrx), so vetoing one while permitting the other bought
- * no guarantee and cost every formatting call in the codebase its memo region.
+ * A bare identifier callee is admitted ONLY when the binding it resolves to is
+ * a module-scope immutable identity:
+ *
+ *   - an IMPORTED binding. Its body is across a module boundary we cannot read,
+ *     so this is the same pure-projection assumption React Compiler makes for
+ *     any imported helper. Documented in docs/differences-from-react.md.
+ *   - a same-module `function` declaration that is never reassigned AND whose
+ *     own body is a pure projection (see moduleHelperIsPureProjection). Because
+ *     we CAN read that body, we check it: `function sortIcon(h) { return
+ *     h.getIsSorted(); }` is the receiver hazard moved one call frame away and
+ *     must fail closed exactly like the direct member call.
+ *
+ * Everything else fails closed — in particular a COMPONENT-LOCAL callee. A local
+ * `const read = () => item.read()` (or a local function declaration) wraps the
+ * member-callee hazard in an identifier, and the inline hook-memo tier can hand
+ * it a stable identity, so admitting it would let a skipped body freeze a live
+ * accessor result. Unbound globals fail closed for the same reason: nothing
+ * witnesses what they close over.
  *
  * `new Foo()` and tagged templates stay disqualified: construction is not a
  * value projection, and a tag function receives the raw strings array.
@@ -2715,27 +2727,103 @@ function isHookCalleeName(name) {
  * and React Compiler key on, and it is what the blanket call veto was
  * incidentally covering here.
  */
-function plainCalleeIsMemoizable(node) {
+function plainCalleeIsMemoizable(node, ctx) {
 	if (node.type !== 'CallExpression' && node.type !== 'OptionalCallExpression') return false;
 	const callee = node.callee;
 	if (callee?.type !== 'Identifier') return false;
-	return !isHookCalleeName(callee.name);
+	const name = callee.name;
+	if (isHookCalleeName(name)) return false;
+	// A namespace member (`ns.fn()`) is already a member callee; a namespace used
+	// bare is not callable as a projection.
+	if (ctx?.importNamespaceNames?.has(name)) return false;
+	if (ctx?.importedNames?.has(name)) return true;
+	return moduleHelperIsPureProjection(name, ctx);
 }
 
 /**
- * Top-level `function foo() {}` names that are never reassigned anywhere in the
- * module. A function declaration hoists to one immutable identity, so closing
+ * Can a same-module `function` helper stand in for the value projection its call
+ * site claims to be? True when its body performs no member-callee call, no
+ * construction, and no tagged template in render-value position, and every plain
+ * call it makes is itself an admitted projection.
+ *
+ * Cycles resolve to false: a recursive helper cannot be proven, and failing
+ * closed is the safe direction. Nested function VALUES inside the helper are not
+ * descended into for the same reason `containsRenderCall` skips them — they run
+ * when invoked, not while the helper projects a value — but a helper that
+ * *invokes* one through `.map(...)` trips the member-callee rule anyway.
+ */
+function moduleHelperIsPureProjection(name, ctx, seen) {
+	const decl = ctx?.moduleFunctionDeclarations?.get(name);
+	if (decl === undefined) return false;
+	const cache = ctx.__moduleHelperProjection ?? (ctx.__moduleHelperProjection = new Map());
+	const cached = cache.get(name);
+	if (cached !== undefined) return cached;
+	const active = seen ?? new Set();
+	if (active.has(name)) return false; // recursion — unprovable, fail closed
+	active.add(name);
+	let pure = true;
+	const nodes = new WeakSet();
+	function walk(n) {
+		if (!pure || !n || typeof n !== 'object') return;
+		if (Array.isArray(n)) {
+			for (const x of n) walk(x);
+			return;
+		}
+		if (nodes.has(n)) return;
+		nodes.add(n);
+		const t = n.type;
+		if (
+			t === 'ArrowFunctionExpression' ||
+			t === 'FunctionExpression' ||
+			t === 'FunctionDeclaration'
+		) {
+			if (n !== decl) return; // deferred value, not this helper's projection
+		}
+		if (t === 'NewExpression' || t === 'TaggedTemplateExpression') {
+			pure = false;
+			return;
+		}
+		if (t === 'CallExpression' || t === 'OptionalCallExpression') {
+			const callee = n.callee;
+			if (callee?.type !== 'Identifier' || isHookCalleeName(callee.name)) {
+				pure = false;
+				return;
+			}
+			if (
+				!ctx.importedNames?.has(callee.name) &&
+				!moduleHelperIsPureProjection(callee.name, ctx, active)
+			) {
+				pure = false;
+				return;
+			}
+			walk(n.arguments);
+			return;
+		}
+		for (const key in n) {
+			if (AST_WALK_SKIP_KEYS.has(key)) continue;
+			walk(n[key]);
+		}
+	}
+	walk(decl.body);
+	active.delete(name);
+	cache.set(name, pure);
+	return pure;
+}
+
+/**
+ * Top-level `function foo() {}` declarations that are never reassigned anywhere
+ * in the module, by name. A function declaration hoists to one immutable identity, so closing
  * over it cannot make a memo region stale — unlike a module `let`, which the
  * classifiers correctly refuse to witness. An assignment anywhere in the module
  * (including inside a nested function that may run later) demotes the name.
  */
-function collectImmutableModuleFunctionNames(body) {
-	const declared = new Set();
+function collectImmutableModuleFunctions(body) {
+	const declared = new Map();
 	for (const statement of body) {
 		const declaration =
 			statement.type === 'ExportNamedDeclaration' ? statement.declaration : statement;
 		if (declaration?.type === 'FunctionDeclaration' && declaration.id?.type === 'Identifier') {
-			declared.add(declaration.id.name);
+			declared.set(declaration.id.name, declaration);
 		}
 	}
 	if (declared.size === 0) return declared;
@@ -5220,7 +5308,7 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 	// already give same-module components and `const X = memo(C)` walls. Names
 	// that are ever assigned (`foo = bar`) are excluded: their identity is then
 	// as mutable as a module `let`, which fails closed.
-	ctx.moduleFunctionBindings = collectImmutableModuleFunctionNames(ast.body);
+	ctx.moduleFunctionDeclarations = collectImmutableModuleFunctions(ast.body);
 	// M3 inherit-range exclusion set (see inheritSoleCompRoot).
 	ctx._octaneBoundaryNames = collectOctaneBoundaryNames(ast.body);
 	// Client prelude `_$vtSeen()` module-load hint (view-transitions plan).
@@ -5291,7 +5379,8 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 				ctx.importNamespaceNames.has(name) ||
 				(!ctx.importedNames.has(name) &&
 					!ctx.defaultMemoBindings.has(name) &&
-					!ctx.componentInfo.has(name))
+					!ctx.componentInfo.has(name) &&
+					!ctx.moduleFunctionDeclarations.has(name))
 			) {
 				autoMemoCallsitesSafe = false;
 				break;
@@ -5306,7 +5395,7 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 			(compNode.params?.length !== 1 || compNode.params[0]?.type === 'Identifier');
 		let autoMemoSafe =
 			ordinaryPropsParam &&
-			!containsRenderCall(stmts, true) &&
+			!containsRenderCall(stmts, ctx) &&
 			!containsAutoMemoUnsafeStructure(stmts) &&
 			!containsImportedMemberRead(root, ctx.importedNames);
 		const autoMemoCaptures = [];
@@ -5330,7 +5419,7 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 					// Immutable const wrapper; its default memo contract is the wall.
 					continue;
 				} else if (ctx.componentInfo.has(name)) autoMemoComponentDeps.push(name);
-				else if (ctx.moduleFunctionBindings?.has(name)) {
+				else if (ctx.moduleFunctionDeclarations?.has(name)) {
 					// Immutable same-module function identity; no dependency slot needed.
 					continue;
 				} else {
@@ -18520,7 +18609,7 @@ function makeCompCall(
 					ctx.currentAutoMemoCallsitesSafe !== false &&
 					callSiteOk &&
 					calleeInfo.autoMemoSafe === true &&
-					!containsRenderCall([node], true) &&
+					!containsRenderCall([node], ctx) &&
 					!containsAutoMemoUnsafeStructure([node]) &&
 					!containsImportedMemberRead(node, ctx.importedNames)
 				) {
@@ -18550,7 +18639,7 @@ function makeCompCall(
 						} else if (
 							ctx.componentInfo.has(name) ||
 							ctx.defaultMemoBindings.has(name) ||
-							ctx.moduleFunctionBindings?.has(name)
+							ctx.moduleFunctionDeclarations?.has(name)
 						) {
 							// Same-module FunctionDeclaration identity is immutable.
 							continue;
@@ -18958,7 +19047,7 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 		// React re-runs bodies unconditionally. Property reads and plain-callee
 		// projections stay eligible (see plainCalleeIsMemoizable; the measured
 		// js-framework-benchmark/dbmon wins are read-only bodies).
-		const hasRenderCall = containsRenderCall(subStmts, true);
+		const hasRenderCall = containsRenderCall(subStmts, ctx);
 		itemMemo =
 			ctx.autoMemo === true &&
 			hasNestedComp &&
@@ -19010,7 +19099,7 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 					if (child.autoMemoMayReadContext) itemMemoContextAware = true;
 					continue;
 				}
-				if (ctx.moduleFunctionBindings?.has(name)) {
+				if (ctx.moduleFunctionDeclarations?.has(name)) {
 					// Immutable same-module function identity; no dependency slot needed.
 					continue;
 				}
@@ -19034,8 +19123,8 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 			ctx.autoMemo === true &&
 			isAutoMemoCalculationDependency(node.right) &&
 			!hasHook &&
-			!containsRenderCall(regionStmts, true) &&
-			!containsRenderCall(node.key ? [node.key] : [], true) &&
+			!containsRenderCall(regionStmts, ctx) &&
+			!containsRenderCall(node.key ? [node.key] : [], ctx) &&
 			!containsAutoMemoUnsafeStructure(regionStmts) &&
 			!containsAutoMemoUnsafeStructure(node.key ? [node.key] : []) &&
 			!containsImportedMemberRead(regionAst, ctx.importedNames);
@@ -19073,7 +19162,7 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 				// also a FunctionDeclaration, but its eligibility is decided by the
 				// branch above — an ineligible one (a context consumer, say) must fail
 				// closed here rather than be rescued as a plain helper.
-				if (ctx.moduleFunctionBindings?.has(name) && !ctx.componentInfo.has(name)) {
+				if (ctx.moduleFunctionDeclarations?.has(name) && !ctx.componentInfo.has(name)) {
 					// Immutable same-module function identity; no dependency slot needed.
 					continue;
 				}

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -14564,6 +14564,15 @@ function scopedDeoptKey(
 	// cannot alias a nested child. JSON quoting makes arbitrary user strings data,
 	// never structure, while remaining stable across renders without an intern map.
 	const explicit = isElementDescriptor(item) && item.key != null;
+	// The unwrapped top level — a plain children array or a single-layer Fragment,
+	// which is what every `{items.map(...)}` list and every binding's rendered
+	// output produces — is the hot path: it re-keys EVERY child on EVERY parent
+	// render, including renders where all children go on to bail. Skip the
+	// serializer there. A JSON encoding always begins with '[', so no 'k'/'i'
+	// prefixed key can collide with a nested wrapper path, and the differing
+	// prefixes keep an explicit key="0" distinct from an implicit index 0 — the
+	// same two aliasing properties the serialized form provides.
+	if (path.length === 0) return explicit ? 'k' + String(key) : 'i' + index;
 	return JSON.stringify([path, explicit ? 'key' : 'index', explicit ? String(key) : index]);
 }
 

--- a/packages/octane/tests/_fixtures/automemo-format-helpers.ts
+++ b/packages/octane/tests/_fixtures/automemo-format-helpers.ts
@@ -1,0 +1,15 @@
+// Cross-module helpers for the autoMemo render-call contract fixture.
+//
+// An IMPORTED callee is admitted as a value projection on the documented
+// module-boundary assumption (the compiler cannot read this file from the
+// importing module's compilation). `projectValue` honours that assumption —
+// it is a pure function of its argument — so a region memoized through it must
+// still re-render whenever the argument it was given actually changes.
+
+export function projectValue(row: { id: number; value: number }): string {
+	return `i${row.id}:${row.value}`;
+}
+
+export function projectCount(n: number): string {
+	return `n${n}`;
+}

--- a/packages/octane/tests/_fixtures/automemo-render-calls.tsrx
+++ b/packages/octane/tests/_fixtures/automemo-render-calls.tsrx
@@ -1,0 +1,312 @@
+import { createContext, use, useCallback, useState } from 'octane';
+import { projectValue, projectCount } from './automemo-format-helpers.ts';
+
+// Fixtures for the boundary autoMemo draws around calls in a template.
+//
+// Every LIVE_* component below renders a list whose ARRAY IDENTITY never
+// changes and whose item objects are never replaced — the only thing that moves
+// is state hidden behind an accessor (the TanStack Table shape:
+// `header.column.getIsSorted()` flips while `header` stays the memoized
+// object). A region that memoized on the stable list identity would freeze that
+// output, so each of these asserts the value still reaches the DOM after an
+// unrelated parent re-render.
+//
+// The PROJECTION_* components are the converse: they render through calls that
+// ARE admitted as value projections, and must stay reactive to their real
+// inputs.
+
+let LIVE = 'v0';
+export function setLive(value: string) {
+	LIVE = value;
+}
+export function resetLive() {
+	LIVE = 'v0';
+}
+
+// Stable identities: neither the array nor the row objects are ever replaced,
+// so nothing in a dependency tuple witnesses a LIVE change.
+const liveRows = [
+	{ id: 1, read: () => `r1:${LIVE}` },
+	{ id: 2, read: () => `r2:${LIVE}` },
+];
+
+// --- callee shapes that must NOT be memoized through -----------------------
+
+// A module helper that calls a method on its parameter: the receiver hazard
+// moved one call frame away from `{row.read()}`.
+function viaModuleHelper(row: { read: () => string }): string {
+	return row.read();
+}
+
+// The same hazard two frames away, through another module helper.
+function viaTransitiveHelper(row: { read: () => string }): string {
+	return viaModuleHelper(row);
+}
+
+// A module `function` that is REASSIGNED later in the module: its identity is
+// as mutable as a module `let`, so it is not an immutable witness.
+function reassignedHelper(row: { read: () => string }): string {
+	return `orig:${row.id}`;
+}
+// eslint-disable-next-line no-func-assign
+reassignedHelper = (row: { read: () => string }) => row.read();
+
+export function LiveViaModuleHelper() @{
+	const [n, setN] = useState(0);
+	<div>
+		<button id="lmh-go" onClick={() => setN(n + 1)}>{'go'}</button>
+		<ul>
+			@for (const row of liveRows; key row.id) {
+				<li class="lmh-row">{viaModuleHelper(row)}</li>
+			}
+		</ul>
+	</div>
+}
+
+export function LiveViaTransitiveHelper() @{
+	const [n, setN] = useState(0);
+	<div>
+		<button id="lth-go" onClick={() => setN(n + 1)}>{'go'}</button>
+		<ul>
+			@for (const row of liveRows; key row.id) {
+				<li class="lth-row">{viaTransitiveHelper(row)}</li>
+			}
+		</ul>
+	</div>
+}
+
+export function LiveViaLocalArrow() @{
+	const [n, setN] = useState(0);
+	const read = (row: { read: () => string }) => row.read();
+	<div>
+		<button id="lla-go" onClick={() => setN(n + 1)}>{'go'}</button>
+		<ul>
+			@for (const row of liveRows; key row.id) {
+				<li class="lla-row">{read(row)}</li>
+			}
+		</ul>
+	</div>
+}
+
+// A component-local callee handed a STABLE identity by useCallback — the shape
+// that makes "local callees are unstable anyway" an unsafe assumption.
+export function LiveViaStableLocal() @{
+	const [n, setN] = useState(0);
+	const read = useCallback((row: { read: () => string }) => row.read());
+	<div>
+		<button id="lsl-go" onClick={() => setN(n + 1)}>{'go'}</button>
+		<ul>
+			@for (const row of liveRows; key row.id) {
+				<li class="lsl-row">{read(row)}</li>
+			}
+		</ul>
+	</div>
+}
+
+export function LiveViaLocalFunction() @{
+	const [n, setN] = useState(0);
+	function read(row: { read: () => string }) {
+		return row.read();
+	}
+	<div>
+		<button id="llf-go" onClick={() => setN(n + 1)}>{'go'}</button>
+		<ul>
+			@for (const row of liveRows; key row.id) {
+				<li class="llf-row">{read(row)}</li>
+			}
+		</ul>
+	</div>
+}
+
+export function LiveViaReassignedHelper() @{
+	const [n, setN] = useState(0);
+	<div>
+		<button id="lrh-go" onClick={() => setN(n + 1)}>{'go'}</button>
+		<ul>
+			@for (const row of liveRows; key row.id) {
+				<li class="lrh-row">{reassignedHelper(row)}</li>
+			}
+		</ul>
+	</div>
+}
+
+// The callee is an admitted projection but an ARGUMENT executes the live
+// accessor — arguments carry the render-value contract too.
+export function LiveViaProjectedArgument() @{
+	const [n, setN] = useState(0);
+	<div>
+		<button id="lpa-go" onClick={() => setN(n + 1)}>{'go'}</button>
+		<ul>
+			@for (const row of liveRows; key row.id) {
+				<li class="lpa-row">{projectCount(row.read().length)}</li>
+			}
+		</ul>
+	</div>
+}
+
+// A direct member call — the original contract, unchanged by this work.
+export function LiveViaMemberCall() @{
+	const [n, setN] = useState(0);
+	<div>
+		<button id="lmc-go" onClick={() => setN(n + 1)}>{'go'}</button>
+		<ul>
+			@for (const row of liveRows; key row.id) {
+				<li class="lmc-row">{row.read()}</li>
+			}
+		</ul>
+	</div>
+}
+
+// --- callee shapes that ARE memoized through, and must stay reactive -------
+
+function projectRow(row: { id: number; value: number }): string {
+	return `m${row.id}:${row.value}`;
+}
+
+function projectRowTransitive(row: { id: number; value: number }): string {
+	return projectRow(row);
+}
+
+export function ProjectionModuleHelper() @{
+	const [rows, setRows] = useState([
+		{ id: 1, value: 0 },
+		{ id: 2, value: 0 },
+	]);
+	const [n, setN] = useState(0);
+	<div>
+		<button id="pmh-go" onClick={() => setN(n + 1)}>{'go'}</button>
+		<button
+			id="pmh-bump"
+			onClick={() => setRows(rows.map((r) => (r.id === 1 ? { ...r, value: r.value + 1 } : r)))}
+		>{'bump'}</button>
+		<ul>
+			@for (const row of rows; key row.id) {
+				<li class="pmh-row">{projectRow(row)}</li>
+			}
+		</ul>
+	</div>
+}
+
+export function ProjectionTransitive() @{
+	const [rows, setRows] = useState([
+		{ id: 1, value: 0 },
+		{ id: 2, value: 0 },
+	]);
+	const [n, setN] = useState(0);
+	<div>
+		<button id="pt-go" onClick={() => setN(n + 1)}>{'go'}</button>
+		<button
+			id="pt-bump"
+			onClick={() => setRows(rows.map((r) => (r.id === 1 ? { ...r, value: r.value + 1 } : r)))}
+		>{'bump'}</button>
+		<ul>
+			@for (const row of rows; key row.id) {
+				<li class="pt-row">{projectRowTransitive(row)}</li>
+			}
+		</ul>
+	</div>
+}
+
+export function ProjectionImported() @{
+	const [rows, setRows] = useState([
+		{ id: 1, value: 0 },
+		{ id: 2, value: 0 },
+	]);
+	const [n, setN] = useState(0);
+	<div>
+		<button id="pi-go" onClick={() => setN(n + 1)}>{'go'}</button>
+		<button
+			id="pi-bump"
+			onClick={() => setRows(rows.map((r) => (r.id === 1 ? { ...r, value: r.value + 1 } : r)))}
+		>{'bump'}</button>
+		<ul>
+			@for (const row of rows; key row.id) {
+				<li class="pi-row">{projectValue(row)}</li>
+			}
+		</ul>
+	</div>
+}
+
+// --- hook-shaped callees are never value projections ----------------------
+
+// A custom hook called inside the region. Each row owns its own hook cell, so
+// every row's setter is collected — bumping all of them proves the region did
+// not skip the hook call for any of them.
+const labelSetters: Array<(v: string) => void> = [];
+export function bumpLabels() {
+	for (const set of labelSetters) set('b');
+}
+export function resetLabelSetters() {
+	labelSetters.length = 0;
+}
+
+function useLabel(seed: number): string {
+	const [suffix, setSuffix] = useState('a');
+	if (!labelSetters.includes(setSuffix)) labelSetters.push(setSuffix);
+	return `${seed}${suffix}`;
+}
+
+export function HookInRegion() @{
+	const [rows] = useState([{ id: 1 }, { id: 2 }]);
+	const [n, setN] = useState(0);
+	<div>
+		<button id="hir-go" onClick={() => setN(n + 1)}>{'go'}</button>
+		<ul>
+			@for (const row of rows; key row.id) {
+				<li class="hir-row">{useLabel(row.id)}</li>
+			}
+		</ul>
+	</div>
+}
+
+// A context consumer reached through a memoizable region. The consumer is an
+// ordinary module `function` declaration — the shape that must be classified by
+// its own component eligibility, never rescued as a plain module helper.
+const LabelCtx = createContext('c0');
+
+function CtxLeaf() @{
+	const value = use(LabelCtx);
+	<span class="ctx-leaf">{value as string}</span>
+}
+
+export function CtxUnderRegion() @{
+	const [rows] = useState([{ id: 1 }, { id: 2 }]);
+	const [value, setValue] = useState('c0');
+	<div>
+		<button id="cur-bump" onClick={() => setValue('c1')}>{'bump'}</button>
+		<LabelCtx.Provider value={value}>
+			<ul>
+				@for (const row of rows; key row.id) {
+					<li class="cur-row">
+						<CtxLeaf />
+					</li>
+				}
+			</ul>
+		</LabelCtx.Provider>
+	</div>
+}
+
+// --- component call sites under a module-helper-using parent ---------------
+
+// Admitting module helpers as witnesses also unblocks the CALL-SITE memo for
+// child components rendered by a parent that formats through one. The child
+// must still re-render whenever the props it is given actually change, and must
+// not be re-rendered into staleness when they do not.
+function labelFor(n: number): string {
+	return `L${n}`;
+}
+
+function CallSiteChild(props) @{
+	<span class="csc-child">{props.label as string}</span>
+}
+
+export function CallSiteParent() @{
+	const [count, setCount] = useState(0);
+	const [tick, setTick] = useState(0);
+	<div>
+		<button id="csp-tick" onClick={() => setTick(tick + 1)}>{'tick'}</button>
+		<button id="csp-count" onClick={() => setCount(count + 1)}>{'count'}</button>
+		<span class="csc-heading">{labelFor(tick)}</span>
+		<CallSiteChild label={labelFor(count)} />
+	</div>
+}

--- a/packages/octane/tests/_fixtures/deopt-child-keys.tsrx
+++ b/packages/octane/tests/_fixtures/deopt-child-keys.tsrx
@@ -1,0 +1,8 @@
+// A compiled template whose sole child is a HOLE: descriptor arrays handed to
+// `{props.rows}` reach the de-opt keyed list, which is the path every
+// `@octanejs/*` binding's rendered output takes. Raw `createElement(host, null,
+// children)` reconciles through a different keying function, so a fixture with
+// a real hole is required to exercise this one.
+export function RowsHole(props) @{
+	<ul class="rows">{props.rows}</ul>
+}

--- a/packages/octane/tests/_fixtures/for.tsrx
+++ b/packages/octane/tests/_fixtures/for.tsrx
@@ -101,12 +101,13 @@ export function setExternal(v) {
 	EXTERNAL = v;
 }
 
-// A render-time CALL in the body defeats the survivor short-circuit entirely:
-// `item.read()` reads mutable state through a STABLE item ref (the TanStack
-// Table header pattern — `header.column.getIsSorted()` flips while the header
-// object stays memoized), so the body must re-run on every parent render,
+// A render-time call through a MEMBER callee defeats the survivor short-circuit
+// entirely: `item.read()` reads mutable state through a STABLE item ref (the
+// TanStack Table header pattern — `header.column.getIsSorted()` flips while the
+// header object stays memoized), so the body must re-run on every parent render,
 // React-parity. Contrast DepPureList below: a bare module-var READ stays
-// eligible (documented at-your-own-risk), a call does not.
+// eligible (documented at-your-own-risk), and so does a call through a plain
+// identifier callee (PlainCalleeList) — the receiver is what carries the hazard.
 const callItems = [
 	{ id: 1, read: () => 'r1:' + EXTERNAL },
 	{ id: 2, read: () => 'r2:' + EXTERNAL },
@@ -134,6 +135,36 @@ export function DepPureList() @{
 		<ul>
 			@for (const item of items; key item.id) {
 				<li class="dp-row" data-m={marker}>{'row' + item.id + ':' + EXTERNAL}</li>
+			}
+		</ul>
+	</div>
+}
+
+// A call through a PLAIN IDENTIFIER callee is an ordinary value projection —
+// the shape of every `{formatPrice(cents)}` / `{t('key')}` in real code. It does
+// NOT defeat memoization (contrast CallBodyList's member callee), so the region
+// tracks its real dependencies: a changed item value must still reach the DOM.
+function fmtRow(item: { id: number; value: number }) {
+	return 'p' + item.id + ':' + item.value;
+}
+
+export function PlainCalleeList() @{
+	const [items, setItems] = useState([
+		{ id: 1, value: 0 },
+		{ id: 2, value: 0 },
+	]);
+	const [, setN] = useState(0);
+	<div>
+		<button id="pc-rerender" onClick={() => setN((n) => n + 1)}>{'go'}</button>
+		<button
+			id="pc-bump"
+			onClick={() => setItems(
+				(prev) => prev.map((it) => (it.id === 1 ? { ...it, value: it.value + 1 } : it)),
+			)}
+		>{'bump'}</button>
+		<ul>
+			@for (const item of items; key item.id) {
+				<li class="pc-row">{fmtRow(item)}</li>
 			}
 		</ul>
 	</div>

--- a/packages/octane/tests/automemo-render-calls.test.ts
+++ b/packages/octane/tests/automemo-render-calls.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mount } from './_helpers';
+import {
+	LiveViaMemberCall,
+	LiveViaModuleHelper,
+	LiveViaTransitiveHelper,
+	LiveViaLocalArrow,
+	LiveViaStableLocal,
+	LiveViaLocalFunction,
+	LiveViaReassignedHelper,
+	LiveViaProjectedArgument,
+	ProjectionModuleHelper,
+	ProjectionTransitive,
+	ProjectionImported,
+	HookInRegion,
+	CtxUnderRegion,
+	CallSiteParent,
+	setLive,
+	resetLive,
+	bumpLabels,
+	resetLabelSetters,
+} from './_fixtures/automemo-render-calls.tsrx';
+
+// Automatic memoization is a production-compile transform, so the assertions
+// below only exercise a cached region under the `octane-prod` project. They are
+// written as ordinary behavioral tests because the contract they protect —
+// "what reaches the DOM after a re-render" — is identical in both modes.
+
+afterEach(() => {
+	resetLive();
+	resetLabelSetters();
+});
+
+// Each case renders a list whose array identity AND item objects are stable
+// across renders; only state behind an accessor moves. A region memoized on
+// that stable identity would freeze the output, so an unrelated parent
+// re-render surfacing the new value is the oracle.
+const liveCases: Array<[string, any, string, string, [string, string]]> = [
+	['a direct member call', LiveViaMemberCall, '#lmc-go', '.lmc-row', ['r1:', 'r2:']],
+	[
+		'a module helper calling a method on its parameter',
+		LiveViaModuleHelper,
+		'#lmh-go',
+		'.lmh-row',
+		['r1:', 'r2:'],
+	],
+	[
+		'a module helper two frames from the accessor',
+		LiveViaTransitiveHelper,
+		'#lth-go',
+		'.lth-row',
+		['r1:', 'r2:'],
+	],
+	['a component-local arrow callee', LiveViaLocalArrow, '#lla-go', '.lla-row', ['r1:', 'r2:']],
+	[
+		'a component-local callee with a stable identity',
+		LiveViaStableLocal,
+		'#lsl-go',
+		'.lsl-row',
+		['r1:', 'r2:'],
+	],
+	[
+		'a component-local function declaration',
+		LiveViaLocalFunction,
+		'#llf-go',
+		'.llf-row',
+		['r1:', 'r2:'],
+	],
+	['a reassigned module function', LiveViaReassignedHelper, '#lrh-go', '.lrh-row', ['r1:', 'r2:']],
+];
+
+describe('autoMemo — live accessor results are never frozen by a region cache', () => {
+	for (const [label, Component, button, row, [p1, p2]] of liveCases) {
+		it(`re-reads through ${label}`, () => {
+			const r = mount(Component);
+			expect(r.findAll(row).map((li) => li.textContent)).toEqual([`${p1}v0`, `${p2}v0`]);
+
+			// Mutate state that neither the list identity nor any item object
+			// witnesses, then force an unrelated parent re-render.
+			setLive('v1');
+			r.click(button);
+			expect(r.findAll(row).map((li) => li.textContent)).toEqual([`${p1}v1`, `${p2}v1`]);
+
+			setLive('v2');
+			r.click(button);
+			expect(r.findAll(row).map((li) => li.textContent)).toEqual([`${p1}v2`, `${p2}v2`]);
+			r.unmount();
+		});
+	}
+
+	it('re-reads when the live accessor runs in an argument to an admitted projection', () => {
+		// `projectCount(row.read().length)` — the callee is a value projection but
+		// the ARGUMENT executes the accessor, so the region must not be cached.
+		const r = mount(LiveViaProjectedArgument);
+		expect(r.findAll('.lpa-row').map((li) => li.textContent)).toEqual(['n5', 'n5']);
+
+		setLive('longer-value');
+		r.click('#lpa-go');
+		const after = r.findAll('.lpa-row').map((li) => li.textContent);
+		expect(after).toEqual(['n15', 'n15']);
+		r.unmount();
+	});
+});
+
+// The converse: regions that ARE memoized through a call must stay reactive to
+// the inputs they actually depend on.
+const projectionCases: Array<[string, any, string, string, string]> = [
+	['a same-module helper', ProjectionModuleHelper, '#pmh-go', '#pmh-bump', '.pmh-row'],
+	[
+		'a same-module helper reached through another helper',
+		ProjectionTransitive,
+		'#pt-go',
+		'#pt-bump',
+		'.pt-row',
+	],
+	['an imported helper', ProjectionImported, '#pi-go', '#pi-bump', '.pi-row'],
+];
+
+describe('autoMemo — memoized projections stay reactive to their real inputs', () => {
+	for (const [label, Component, go, bump, row] of projectionCases) {
+		it(`updates a changed item rendered through ${label}`, () => {
+			const r = mount(Component);
+			const initial = r.findAll(row).map((li) => li.textContent);
+			expect(initial).toHaveLength(2);
+			expect(initial[0]).toMatch(/1:0$/);
+			expect(initial[1]).toMatch(/2:0$/);
+
+			// An unrelated parent re-render must not change the rendered text.
+			r.click(go);
+			expect(r.findAll(row).map((li) => li.textContent)).toEqual(initial);
+
+			// A real item change must reach the DOM, twice in a row.
+			r.click(bump);
+			expect(r.findAll(row).map((li) => li.textContent)[0]).toMatch(/1:1$/);
+			r.click(bump);
+			const bumped = r.findAll(row).map((li) => li.textContent);
+			expect(bumped[0]).toMatch(/1:2$/);
+			// The untouched sibling keeps its original value.
+			expect(bumped[1]).toBe(initial[1]);
+			r.unmount();
+		});
+	}
+});
+
+describe('autoMemo — hook-shaped callees are not value projections', () => {
+	it('a custom hook called inside a region keeps driving the DOM', () => {
+		const r = mount(HookInRegion);
+		expect(r.findAll('.hir-row').map((li) => li.textContent)).toEqual(['1a', '2a']);
+
+		// Each row owns a hook cell; a region that skipped the call for any row
+		// would strand that row's state.
+		bumpLabels();
+		r.click('#hir-go');
+		expect(r.findAll('.hir-row').map((li) => li.textContent)).toEqual(['1b', '2b']);
+		r.unmount();
+	});
+
+	it('a context consumer under a memoizable region still sees Provider updates', () => {
+		// The consumer is an ordinary module `function` declaration. Classifying it
+		// as an immutable module helper instead of by its own component
+		// eligibility would let the region skip and strand every consumer.
+		const r = mount(CtxUnderRegion);
+		expect(r.findAll('.ctx-leaf').map((el) => el.textContent)).toEqual(['c0', 'c0']);
+
+		r.click('#cur-bump');
+		expect(r.findAll('.ctx-leaf').map((el) => el.textContent)).toEqual(['c1', 'c1']);
+		r.unmount();
+	});
+});
+
+describe('autoMemo — module helpers as call-site witnesses', () => {
+	it('a child rendered by a helper-formatting parent tracks its own props', () => {
+		// Accepting immutable module `function` helpers as witnesses unblocks the
+		// component call-site cache in this parent. The child must still see every
+		// real prop change, and must not change when only unrelated state moves.
+		const r = mount(CallSiteParent);
+		expect(r.find('.csc-child').textContent).toBe('L0');
+		expect(r.find('.csc-heading').textContent).toBe('L0');
+
+		// Unrelated state: the heading moves, the child's prop does not.
+		r.click('#csp-tick');
+		expect(r.find('.csc-heading').textContent).toBe('L1');
+		expect(r.find('.csc-child').textContent).toBe('L0');
+
+		// The child's own prop changes and must reach the DOM, repeatedly.
+		r.click('#csp-count');
+		expect(r.find('.csc-child').textContent).toBe('L1');
+		r.click('#csp-count');
+		expect(r.find('.csc-child').textContent).toBe('L2');
+		expect(r.find('.csc-heading').textContent).toBe('L1');
+		r.unmount();
+	});
+});

--- a/packages/octane/tests/deopt-child-key-aliasing.test.ts
+++ b/packages/octane/tests/deopt-child-key-aliasing.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect } from 'vitest';
+import { createElement, Fragment, positionalChildren, useState } from 'octane';
+import { mount } from './_helpers';
+import { RowsHole } from './_fixtures/deopt-child-keys.tsrx';
+
+// Descriptors handed to a template HOLE reach the de-opt keyed list, which
+// derives an internal reconciliation key per child from its wrapper path plus
+// either an explicit `key` or its index. Two properties of that derivation are
+// load-bearing:
+//
+//   1. An explicit `key` never aliases an implicit index — `key="0"` and the
+//      unkeyed child at index 0 are different slots, and both can appear in the
+//      SAME list.
+//   2. A user key can never resemble a nested wrapper path, so a keyed child in
+//      one wrapper never adopts a child from another.
+//
+// Assertions are about node identity and live DOM state, never the key
+// spelling — the encoding may change as long as these hold.
+
+const text = (nodes: Element[]) => nodes.map((n) => n.textContent);
+
+describe('de-opt child keys — an explicit key never aliases a positional index', () => {
+	it('keeps an unkeyed child and a child keyed "0" in separate slots', () => {
+		// Both children live in one list: the unkeyed <input> is at index 0 while
+		// its sibling carries key="0". If the two derivations collapsed to the same
+		// key, one child would adopt the other's node and its typed value with it.
+		function App() {
+			const [n, setN] = useState(0);
+			const rows = [
+				createElement('li', null, createElement('input', { 'data-testid': 'plain' })),
+				createElement('li', { key: '0' }, createElement('input', { 'data-testid': 'keyed' })),
+			];
+			return createElement(
+				'div',
+				null,
+				createElement('button', { 'data-testid': 'go', onClick: () => setN(n + 1) }, 'go'),
+				createElement(RowsHole, { rows }),
+			);
+		}
+
+		const r = mount(App);
+		const plain = r.find('[data-testid="plain"]') as HTMLInputElement;
+		const keyed = r.find('[data-testid="keyed"]') as HTMLInputElement;
+		expect(plain).not.toBe(keyed);
+		plain.value = 'p';
+		keyed.value = 'k';
+
+		r.click('[data-testid="go"]');
+		expect(r.find('[data-testid="plain"]')).toBe(plain);
+		expect(r.find('[data-testid="keyed"]')).toBe(keyed);
+		expect((r.find('[data-testid="plain"]') as HTMLInputElement).value).toBe('p');
+		expect((r.find('[data-testid="keyed"]') as HTMLInputElement).value).toBe('k');
+		r.unmount();
+	});
+
+	it('does not let a newly prepended unkeyed child steal the key="0" node', () => {
+		function App() {
+			const [grown, setGrown] = useState(false);
+			const keyedRow = createElement(
+				'li',
+				{ key: '0' },
+				createElement('input', { 'data-testid': 'keyed' }),
+			);
+			const rows = grown
+				? [createElement('li', null, createElement('input', { 'data-testid': 'plain' })), keyedRow]
+				: [keyedRow];
+			return createElement(
+				'div',
+				null,
+				createElement('button', { 'data-testid': 'go', onClick: () => setGrown(true) }, 'go'),
+				createElement(RowsHole, { rows }),
+			);
+		}
+
+		const r = mount(App);
+		const keyed = r.find('[data-testid="keyed"]') as HTMLInputElement;
+		keyed.value = 'survivor';
+
+		r.click('[data-testid="go"]');
+		expect(r.findAll('input')).toHaveLength(2);
+		// The keyed row is the survivor; the prepended unkeyed row is new.
+		expect(r.find('[data-testid="keyed"]')).toBe(keyed);
+		expect((r.find('[data-testid="keyed"]') as HTMLInputElement).value).toBe('survivor');
+		expect((r.find('[data-testid="plain"]') as HTMLInputElement).value).toBe('');
+		r.unmount();
+	});
+
+	it('moves the original nodes when explicitly keyed children reorder', () => {
+		function App() {
+			const [order, setOrder] = useState(['0', '1', '2']);
+			const rows = order.map((k) => createElement('li', { key: k, 'data-testid': `li-${k}` }, k));
+			return createElement(
+				'div',
+				null,
+				createElement(
+					'button',
+					{ 'data-testid': 'rev', onClick: () => setOrder((p) => [...p].reverse()) },
+					'rev',
+				),
+				createElement(RowsHole, { rows }),
+			);
+		}
+
+		const r = mount(App);
+		const before = ['0', '1', '2'].map((k) => r.find(`[data-testid="li-${k}"]`));
+		r.click('[data-testid="rev"]');
+		expect(text(r.findAll('li'))).toEqual(['2', '1', '0']);
+		const after = r.findAll('li');
+		expect(after[0]).toBe(before[2]);
+		expect(after[1]).toBe(before[1]);
+		expect(after[2]).toBe(before[0]);
+		r.unmount();
+	});
+});
+
+describe('de-opt child keys — user keys never collide with wrapper paths', () => {
+	it('keeps keys that resemble a serialized wrapper path distinct', () => {
+		// Deliberately adversarial keys: each resembles some internal encoding. If a
+		// user string could act as structure, two children would share a slot.
+		const keys = ['[]', '["wrapper",0]', '[[],"index",0]', '[[],"key","0"]', '0', 'k0', 'i0', 'i1'];
+
+		function App() {
+			const [rev, setRev] = useState(false);
+			const list = rev ? [...keys].reverse() : keys;
+			const rows = list.map((k) => createElement('li', { key: k }, k));
+			return createElement(
+				'div',
+				null,
+				createElement('button', { 'data-testid': 'rev', onClick: () => setRev((v) => !v) }, 'rev'),
+				createElement(RowsHole, { rows }),
+			);
+		}
+
+		const r = mount(App);
+		expect(text(r.findAll('li'))).toEqual(keys);
+		const before = r.findAll('li');
+
+		r.click('[data-testid="rev"]');
+		expect(text(r.findAll('li'))).toEqual([...keys].reverse());
+		const after = r.findAll('li');
+		// Every child survived with its own node — none collapsed into another.
+		expect(new Set(after).size).toBe(keys.length);
+		for (let i = 0; i < keys.length; i++) expect(after[i]).toBe(before[keys.length - 1 - i]);
+		r.unmount();
+	});
+
+	it('addresses equally keyed children under different wrappers separately', () => {
+		// Two sibling positions each hold an array containing a child keyed "a".
+		// The wrapper path is what keeps them apart.
+		function App() {
+			const [n, setN] = useState(0);
+			const rows = positionalChildren([
+				[createElement('li', { key: 'a' }, createElement('input', { 'data-testid': 'first' }))],
+				[createElement('li', { key: 'a' }, createElement('input', { 'data-testid': 'second' }))],
+			]);
+			return createElement(
+				'div',
+				null,
+				createElement('button', { 'data-testid': 'go', onClick: () => setN(n + 1) }, 'go'),
+				createElement(RowsHole, { rows }),
+			);
+		}
+
+		const r = mount(App);
+		const first = r.find('[data-testid="first"]') as HTMLInputElement;
+		const second = r.find('[data-testid="second"]') as HTMLInputElement;
+		expect(first).not.toBe(second);
+		first.value = 'one';
+		second.value = 'two';
+
+		r.click('[data-testid="go"]');
+		expect(r.find('[data-testid="first"]')).toBe(first);
+		expect(r.find('[data-testid="second"]')).toBe(second);
+		expect((r.find('[data-testid="first"]') as HTMLInputElement).value).toBe('one');
+		expect((r.find('[data-testid="second"]') as HTMLInputElement).value).toBe('two');
+		r.unmount();
+	});
+});
+
+describe('de-opt child keys — wrapper boundaries survive the top-level fast path', () => {
+	it('carries a keyed fragment’s children through a reorder', () => {
+		function App() {
+			const [rev, setRev] = useState(false);
+			const groups = rev ? ['g2', 'g1'] : ['g1', 'g2'];
+			const rows = groups.map((g) =>
+				createElement(
+					Fragment,
+					{ key: g },
+					createElement('li', { key: 'a', 'data-testid': `${g}-a` }, `${g}a`),
+					createElement('li', { key: 'b', 'data-testid': `${g}-b` }, `${g}b`),
+				),
+			);
+			return createElement(
+				'div',
+				null,
+				createElement('button', { 'data-testid': 'rev', onClick: () => setRev((v) => !v) }, 'rev'),
+				createElement(RowsHole, { rows }),
+			);
+		}
+
+		const r = mount(App);
+		expect(text(r.findAll('li'))).toEqual(['g1a', 'g1b', 'g2a', 'g2b']);
+		const g1a = r.find('[data-testid="g1-a"]');
+		const g2b = r.find('[data-testid="g2-b"]');
+
+		r.click('[data-testid="rev"]');
+		expect(text(r.findAll('li'))).toEqual(['g2a', 'g2b', 'g1a', 'g1b']);
+		expect(r.find('[data-testid="g1-a"]')).toBe(g1a);
+		expect(r.find('[data-testid="g2-b"]')).toBe(g2b);
+		r.unmount();
+	});
+
+	it('keeps an UNKEYED nested wrapper positional', () => {
+		// The converse contract, and the reason the wrapper path is part of the key
+		// at all: without a key on the wrapper, position addresses the group. This
+		// guards against a future key change silently promoting positional wrappers
+		// into keyed ones.
+		function App() {
+			const [rev, setRev] = useState(false);
+			const groups = rev ? ['g2', 'g1'] : ['g1', 'g2'];
+			const rows = groups.map((g) => [
+				createElement('li', { key: `${g}-a`, 'data-testid': `${g}-a` }, `${g}a`),
+				createElement('li', { key: `${g}-b`, 'data-testid': `${g}-b` }, `${g}b`),
+			]);
+			return createElement(
+				'div',
+				null,
+				createElement('button', { 'data-testid': 'rev', onClick: () => setRev((v) => !v) }, 'rev'),
+				createElement(RowsHole, { rows }),
+			);
+		}
+
+		const r = mount(App);
+		const g1a = r.find('[data-testid="g1-a"]');
+		r.click('[data-testid="rev"]');
+		expect(text(r.findAll('li'))).toEqual(['g2a', 'g2b', 'g1a', 'g1b']);
+		expect(r.find('[data-testid="g1-a"]')).not.toBe(g1a);
+		r.unmount();
+	});
+
+	it('preserves a mixed keyed/unkeyed list across an unrelated re-render', () => {
+		function App() {
+			const [n, setN] = useState(0);
+			const rows = positionalChildren([
+				createElement('li', { 'data-testid': 'plain' }, 'plain'),
+				createElement('li', { key: 'kept', 'data-testid': 'kept' }, 'kept'),
+				createElement('li', { 'data-testid': 'tail' }, 'tail'),
+			]);
+			return createElement(
+				'div',
+				null,
+				createElement('button', { 'data-testid': 'go', onClick: () => setN(n + 1) }, 'go'),
+				createElement(RowsHole, { rows }),
+			);
+		}
+
+		const r = mount(App);
+		const nodes = ['plain', 'kept', 'tail'].map((t) => r.find(`[data-testid="${t}"]`));
+		r.click('[data-testid="go"]');
+		expect(text(r.findAll('li'))).toEqual(['plain', 'kept', 'tail']);
+		const after = r.findAll('li');
+		for (let i = 0; i < nodes.length; i++) expect(after[i]).toBe(nodes[i]);
+		r.unmount();
+	});
+});

--- a/packages/octane/tests/for.test.ts
+++ b/packages/octane/tests/for.test.ts
@@ -7,6 +7,7 @@ import {
 	ToggleableEmpty,
 	DepPureList,
 	CallBodyList,
+	PlainCalleeList,
 	setExternal,
 } from './_fixtures/for.tsrx';
 
@@ -147,6 +148,28 @@ describe('forBlock — @empty branch', () => {
 		});
 		expect(r.findAll('.empty')).toHaveLength(0);
 		expect(r.findAll('.row').map((li) => li.textContent)).toEqual(['x', 'y']);
+		r.unmount();
+	});
+});
+
+describe('forBlock — a plain-callee projection stays reactive to its real inputs', () => {
+	it('a body calling a module helper still renders a changed item value', () => {
+		// `{fmtRow(item)}` is the shape of every `{formatPrice(cents)}` in real code.
+		// Unlike an item METHOD call, its receiver cannot hide mutable state behind a
+		// stable ref, so it does not disqualify the region from memoization. What must
+		// hold regardless is the ordinary contract: an unrelated parent re-render keeps
+		// the rendered text, and a real item change reaches the DOM.
+		const r = mount(PlainCalleeList);
+		expect(r.findAll('.pc-row').map((li) => li.textContent)).toEqual(['p1:0', 'p2:0']);
+
+		r.click('#pc-rerender');
+		expect(r.findAll('.pc-row').map((li) => li.textContent)).toEqual(['p1:0', 'p2:0']);
+
+		r.click('#pc-bump');
+		expect(r.findAll('.pc-row').map((li) => li.textContent)).toEqual(['p1:1', 'p2:0']);
+
+		r.click('#pc-bump');
+		expect(r.findAll('.pc-row').map((li) => li.textContent)).toEqual(['p1:2', 'p2:0']);
 		r.unmount();
 	});
 });


### PR DESCRIPTION
Two independent findings from a benchmark audit of the suites where Octane trailed the fine-grained frameworks (Solid / Ripple / Vue Vapor). Both are conservative-analysis gaps rather than missing machinery.

## 1. autoMemo gave up on a component because its template contained a call

`containsRenderCall` vetoed **every** `CallExpression` in render-value position. It gates three tiers — the component's `autoMemoSafe` flag (which propagates transitively to every ancestor that renders it), the per-item survivor short-circuit, and the whole-list region cache. So a single `{formatDate(d)}` removed region memoization from that component *and* everything above it.

The veto exists for one real hazard: `header.column.getIsSorted()` returns a new answer while `header` stays the memoized object, so nothing in the dependency tuple witnesses the change. That hazard is carried by the **receiver**, so only the member-callee shape needs to fail closed. A bare identifier callee resolves to a module-local or imported binding the region already tracks — exactly as exposed to mutable module state as the bare identifier *read* the same region is already permitted to memoize through (the documented DEP-PURE contract in `tests/_fixtures/for.tsrx`).

Kept disqualified:
- **Member callees** — `{header.getIsSorted()}`. The TanStack Table pattern; bindings that expose live accessor methods keep working unchanged.
- **Hook-shaped callees** — `use` and `use*`. These own suspension, hook cells, context subscriptions, and effect lifecycles, not value projections. The blanket veto was incidentally covering them.
- **`new Foo()` and tagged templates** — construction isn't a value projection.

The SSR item-identity call site (`itemNeedsIdentity`) is left strict: it needs "no call executes here" for a different reason than memo staleness, so it takes the unchanged default.

Also in this change: same-module `function` helpers that are never reassigned are accepted as memo-region witnesses, on the immutable-identity grounds already given to same-module components and `const X = memo(C)` walls. Reassigned names are excluded (their identity is as mutable as a module `let`).

## 2. De-opt child keys ran `JSON.stringify` per child per render

`scopedDeoptKey` built every child's reconciliation key with `JSON.stringify([path, kind, key])`, including at the unwrapped top level that every `{items.map(...)}` and every `@octanejs/*` binding's rendered output produces. A 1,000-row list allocated 1,000 serialized strings on every parent update, including updates where all 1,000 rows went on to bail.

The path-free level now returns `'k' + key` / `'i' + index`. A JSON encoding always begins with `[`, so no prefixed key can collide with a nested wrapper path, and the differing prefixes keep an explicit `key="0"` distinct from an implicit index 0 — the same two aliasing properties the serialized form provides. Nested wrapper paths keep the serializer.

## Measurements

Paired runs on one machine, baseline = this branch's merge-base, same command / warmup / iteration policy:

| suite | op | base | candidate | Δ |
| --- | --- | --- | --- | --- |
| chat-stream | `type160` | 2.22ms | **0.78ms** | −65% |
| chat-stream | `appendHistory` | 1.56ms | **0.72ms** | −54% |
| chat-stream | `streamCoarse` | 0.78ms | **0.46ms** | −41% |
| chat-stream | `streamFine` | 1.58ms | **0.96ms** | −39% |
| chat-stream | `switchConv` | 4.08ms | 3.56ms | −13% |

`type160` (160 keystrokes through the controlled composer) moves Octane from the slowest of the fast frameworks to ahead of Solid (0.96), Ripple (0.80) and Vue Vapor (0.80).

No regressions in `js-framework`, `effectful-list`, or `memo-wall`. The memo-wall value-position wall — the `createElement(Row, props)` → children-hole shape every binding produces — improves from 1.48x to 1.39x React. A Chromium CPU profile of that op drops the flatten step from 13.4% to 6.0% of samples and total samples by 13.8%; **the timed op moves far less than that profile implies**, and the changeset states both numbers rather than the flattering one.

## Reviewer notes

Three real prod-only failures surfaced during development and are fixed in this diff — worth knowing because they show the veto was load-bearing in ways its comment didn't state:

1. The module-function fallback initially rescued **components** whose own eligibility said no. A context consumer got memoized away and Provider updates stopped propagating. Fixed by checking that fallback last and never for a name in `componentInfo`.
2. Admitting identifier callees made `use(promise)` memoizable, so a re-suspended boundary stopped destroying and recreating its layout effects. Hooks are now explicitly excluded.
3. autoMemo is production-only, so all three were invisible to the dev-mode project and only appeared under `octane-prod`.

`docs/differences-from-react.md` gains an "Automatic memoization and calls in templates" section documenting the observable boundary for binding authors, including the escape hatch (read a method-backed value into a local and let state own it).

**Not included:** there are no `chat-stream` *timing* ratio guards today (only the node census), so nothing locks in this win. The benchmarks README is explicit that guards are hand-copied after review rather than auto-ratcheted, so I did not add them unilaterally — happy to run `--record --ratios chat-stream` and propose thresholds in a follow-up.

## Verification

- Full suite on current `main`: **1328 files / 12914 tests pass** (includes the new `octane-prod` coverage)
- `pnpm format:check` clean, `tsgo --noEmit -p packages/octane/tsconfig.json` clean, changeset check clean
- New behavioral test `PlainCalleeList` asserts the durable contract: an unrelated parent re-render keeps rendered text, and a real item change still reaches the DOM through a helper call. The existing `CallBodyList` member-callee test is unchanged and still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compiler memo eligibility and reconciliation key encoding; incorrect classification could freeze stale UI or collapse child identity, though analysis fails closed and tests target both hazards.
> 
> **Overview**
> Production **autoMemo** no longer disqualifies a whole region because the template contains *any* render-time call. `containsRenderCall` now takes an optional memo context and treats **plain identifier callees** as memoizable when they are imported bindings or never-reassigned same-module `function` helpers whose bodies pass a purity walk (`plainCalleeIsMemoizable` / `moduleHelperIsPureProjection`). **Member calls**, **hooks** (`use` / `use*`), **local/reassigned callees**, **`new`**, and **tagged templates** still block memoization; call **arguments** are still walked so live accessors inside args (e.g. `projectCount(row.read())`) keep regions uncached. Immutable module `function` declarations are also collected and treated like components/`memo` walls for dependency witnessing (without rescuing ineligible components).
> 
> On the runtime side, **`scopedDeoptKey`** at the unwrapped top level (`path.length === 0`) returns `'k' + key` / `'i' + index` instead of **`JSON.stringify`**, cutting per-child allocation on hot list/hole paths while nested wrapper paths keep the serialized encoding.
> 
> Docs add **“Automatic memoization and calls in templates”**; new prod behavioral tests cover projection vs live-accessor contracts and de-opt key aliasing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c542bb5ea767070a00d7ca18f8264db7798b8adb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->