### PR TITLE
Separate typecheck and example CI gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,8 +364,8 @@ jobs:
       - name: Build octane package and verify dist
         run: pnpm build
 
-  typecheck_run:
-    name: typecheck packages, website, and examples
+  typecheck:
+    name: typecheck
     runs-on: ubuntu-latest
 
     steps:
@@ -390,7 +390,7 @@ jobs:
       - name: Validate example catalog and orchestration
         run: pnpm examples:static:check
 
-  examples:
+  example_shard:
     name: example apps (${{ matrix.shard }})
     runs-on: ubuntu-latest
 
@@ -424,22 +424,20 @@ jobs:
       - name: Run example browser journeys
         run: pnpm examples:e2e -- --shard=${{ matrix.shard }}
 
-  # Keep the existing protected `typecheck` context stable while the actual
-  # typecheck and browser-heavy example gate run in parallel. `always()` turns
-  # either failed dependency into a failed required check instead of a skip.
-  typecheck:
-    needs: [typecheck_run, examples]
+  # Keep browser journeys behind their own stable aggregate check so the
+  # protected `typecheck` context can finish as soon as typechecking does.
+  # `always()` makes a failed shard produce a failed example check, not a skip.
+  examples:
+    name: examples
+    needs: example_shard
     if: ${{ always() }}
     runs-on: ubuntu-latest
 
     steps:
-      - name: Verify typecheck and example apps passed
+      - name: Verify all example shards passed
         env:
-          TYPECHECK_RESULT: ${{ needs.typecheck_run.result }}
-          EXAMPLES_RESULT: ${{ needs.examples.result }}
-        run: |
-          test "$TYPECHECK_RESULT" = success
-          test "$EXAMPLES_RESULT" = success
+          EXAMPLE_SHARD_RESULT: ${{ needs.example_shard.result }}
+        run: test "$EXAMPLE_SHARD_RESULT" = success
 
   three_compat:
     name: Three compatibility (${{ matrix.lane }})

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,6 +96,7 @@ jobs:
               { owner, repo, run_id: runId, per_page: 100 },
             );
             const requiredJobs = new Set([
+              "examples",
               "lint",
               "Lynx compatibility (current)",
               "Lynx compatibility (minimum)",


### PR DESCRIPTION
## Summary

- Make the existing required `typecheck` job run directly, so its result is available without waiting for browser-example tests.
- Keep all three browser-example shards behind a separate, stable `examples` aggregate check.
- Require both independent checks in release publishing while preserving existing Node and compatibility gates.

## Root cause

The required `typecheck` status was an aggregate that depended on both `typecheck_run` and the browser-example matrix. TypeScript itself ran in parallel, but GitHub did not report the protected typecheck as complete until the example browser journeys finished.

## Validation

- Rebased onto the latest canonical `octanejs/octane` main.
- Verified that only the intended CI and publish workflows differ from upstream.
- Parsed both workflows as YAML.
- Verified `typecheck` has no job dependencies and directly runs `pnpm typecheck`.
- Verified all three browser-example shards remain enabled and their `always()` aggregate fails if any shard fails.
- Verified release publishing requires `examples`, `typecheck`, `test (22)`, and `test (24)`.
- `git diff FETCH_HEAD...HEAD --check` passed.
- Local `pnpm format:check` is blocked because this environment's configured Corepack registry returns HTTP 403 for `pnpm@11.15.1`; upstream CI will run the repository formatting gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes to job naming and dependencies; no application or security logic is modified.
> 
> **Overview**
> **Splits CI so the protected `typecheck` check finishes without waiting on Playwright example runs.**
> 
> The required `typecheck` job now runs `pnpm typecheck` (and `examples:static:check`) directly instead of being an aggregate that waited on both a former `typecheck_run` job and the example matrix. Browser example work moves to `example_shard` (unchanged 3-shard matrix) with a new **`examples`** aggregate that uses `always()` and only verifies shard success.
> 
> **Publish workflow** now treats **`examples`** as an independent required successful job alongside **`typecheck`**, so releases still need both gates even though they report separately on PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d06b258357b36cfd47642452cc136182e9bc14f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->