### PR TITLE
Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -26,13 +26,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
           cache: "pnpm"
@@ -51,7 +51,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bench-results
           path: benchmarks/results/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       # Any missing or unexpected data falls back to the full test matrix.
       - name: Identify a generated Changesets release merge
         id: classify
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             core.setOutput("is_release", "false");
@@ -210,13 +210,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"
@@ -264,17 +264,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           # The production-error catalog is append-only. Its check compares the
           # current tree with the PR base or previous main commit.
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
           cache: "pnpm"
@@ -370,13 +370,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
           cache: "pnpm"
@@ -404,13 +404,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
           cache: "pnpm"
@@ -460,13 +460,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
           cache: "pnpm"
@@ -516,13 +516,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
           cache: "pnpm"
@@ -550,13 +550,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
           cache: "pnpm"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
       # the privileged job can only execute a release commit that passed CI.
       - name: Resolve validated SHA
         id: release
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const runId = Number(process.env.CI_RUN_ID);
@@ -151,16 +151,16 @@ jobs:
             core.info(`Publishing validated SHA ${run.head_sha} from CI run ${runId}`);
 
       - name: Checkout validated SHA
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ steps.release.outputs.sha }}
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24.x
           # Do not enable dependency caching in this privileged workflow.
@@ -173,7 +173,7 @@ jobs:
 
       - name: Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
         with:
           publish: pnpm changeset:publish
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,15 +25,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24.x
           cache: pnpm
@@ -70,7 +70,7 @@ jobs:
       - name: Create or update release pull request
         id: release_pr_first
         continue-on-error: true
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
         with:
           branch: main
           github-token: ${{ github.token }}
@@ -102,7 +102,7 @@ jobs:
         id: release_pr_retry
         if: steps.release_pr_first.outcome == 'failure'
         continue-on-error: true
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
         with:
           branch: main
           github-token: ${{ github.token }}
@@ -122,7 +122,7 @@ jobs:
         if: >-
           steps.release_pr_first.outcome == 'failure' &&
           steps.release_pr_retry.outcome == 'failure'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const { owner, repo } = context.repo;

--- a/website/tests/ssr-hydration.e2e.test.ts
+++ b/website/tests/ssr-hydration.e2e.test.ts
@@ -1066,15 +1066,14 @@ describe.sequential('website production build → hydration (Nitro Vercel previe
 		try {
 			await page.setViewportSize({ width: 390, height: 667 });
 			await page.waitForSelector('.pg-grid.ready', { timeout: 20_000 });
-			await page
-				.locator('.pg-panel[aria-label="Source editor"] .cm-content')
-				.click({ position: { x: 150, y: 70 } });
+			const source = page.locator('.pg-panel[aria-label="Source editor"] .cm-content');
+			// Mobile reflow can move fixed coordinates onto whitespace. Select
+			// the visible useState call so Inspect always has a real AST range.
+			await source.getByText('useState', { exact: true }).nth(1).click();
 			await page.locator('.pg-mobile-toggle button', { hasText: 'Inspect' }).click();
 			// Browsers may deliver the source editor's mouseleave after its mobile
 			// panel is hidden. It must not clear the AST node we just revealed.
-			await page
-				.locator('.pg-panel[aria-label="Source editor"] .cm-content')
-				.dispatchEvent('mouseleave');
+			await source.dispatchEvent('mouseleave');
 
 			const leaf = page.locator('.pg-ast-node[data-ast-leaf="true"]');
 			await leaf.waitFor({ timeout: 10_000 });


### PR DESCRIPTION
## Summary

- Pin all external GitHub Actions in CI, publishing, release, and benchmark workflows to verified full-length commit SHAs.
- Preserve the exact current action versions and add the corresponding major-version comments beside each SHA.
- Make the canonical workflows compatible with fork organizations that enforce `sha_pinning_required`, without weakening the security policy or introducing fork-only workflow changes.

## Root cause

The synchronized `openai-oss-forks/octane` fork enforces full-length GitHub Actions commit SHA pinning, while the upstream workflows reference action major-version tags. Consequently every fork CI job is rejected before its steps can execute even though the same workflows pass upstream.

## Verified action versions

- `actions/checkout@v6`
- `pnpm/action-setup@v6`
- `actions/setup-node@v6`
- `actions/github-script@v8`
- `actions/upload-artifact@v4`
- `changesets/action@v1`

GitHub MCP independently verified that each version tag and its pinned commit expose the same upstream `action.yml`.

## Validation

- All four workflows parse as valid YAML.
- All 37 external action references use full 40-character commit SHAs.
- Every action step preserves its existing version, order, and readable major-version comment.
- No action steps are added, removed, upgraded, or downgraded.
- `git diff --check` passes.
- The change satisfies the fork's full-SHA-pinning policy without changing its policy.
- Local `pnpm format:check` cannot run because the configured Corepack registry returns HTTP 403 for `pnpm@11.15.1`; the canonical upstream CI formatting check must verify it.

After merging, fast-forward `openai-oss-forks/octane:main` from `octanejs/octane:main` so both repositories contain the same policy-compatible workflows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow pins are behavior-preserving supply-chain hardening; the e2e change only affects test interaction, not production code.
> 
> **Overview**
> Pins every third-party GitHub Action in **bench**, **CI**, **publish**, and **release** workflows from floating major-version tags to **full 40-character commit SHAs**, with the same version kept in trailing comments (e.g. `# v6`). Covered actions include `actions/checkout`, `pnpm/action-setup`, `actions/setup-node`, `actions/github-script`, `actions/upload-artifact`, and `changesets/action`—no version bumps or step reordering.
> 
> Separately, the **playground mobile Inspect** SSR-hydration e2e no longer clicks fixed coordinates in the source editor (which could hit whitespace after mobile reflow). It clicks the visible **`useState`** token and reuses the same `source` locator for the `mouseleave` dispatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa6ff0f800edb8079491de2df17b9f441018060a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->