### PR TITLE
perf(compiler): stop re-walking primitives in the per-body __block scan

### DIFF
--- a/.changeset/block-scan-single-pass.md
+++ b/.changeset/block-scan-single-pass.md
@@ -1,0 +1,9 @@
+---
+'octane': patch
+---
+
+The compiler's `__block` reference scan no longer recurses into non-object node
+properties and stops as soon as it finds a match. Compiler output is
+byte-identical. The walk itself does 44% fewer recursive calls, though it is a
+small share of total compile time, so expect a marginal build-time effect rather
+than a visible one.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -938,28 +938,30 @@ function collectNestedBindingNames(root) {
 }
 
 function hasIdentifierReference(root, name) {
-	let found = false;
+	// The visited guard is load-bearing: passes share subtrees, so without it
+	// this walk goes exponential on shared shapes.
 	const seen = new WeakSet();
 	const walk = (value) => {
-		if (found || !value || typeof value !== 'object') return;
 		if (Array.isArray(value)) {
-			for (const child of value) walk(child);
-			return;
+			for (const child of value) {
+				if (child !== null && typeof child === 'object' && walk(child)) return true;
+			}
+			return false;
 		}
-		if (seen.has(value)) return;
+		if (seen.has(value)) return false;
 		seen.add(value);
-		if (value.type === 'ImportDeclaration') return;
-		if ((value.type === 'Identifier' || value.type === 'JSXIdentifier') && value.name === name) {
-			found = true;
-			return;
-		}
+		if (value.type === 'ImportDeclaration') return false;
+		if ((value.type === 'Identifier' || value.type === 'JSXIdentifier') && value.name === name)
+			return true;
 		for (const key in value) {
+			const child = value[key];
+			if (child === null || typeof child !== 'object') continue;
 			if (AST_WALK_SKIP_KEYS.has(key)) continue;
-			walk(value[key]);
+			if (walk(child)) return true;
 		}
+		return false;
 	};
-	walk(root);
-	return found;
+	return root !== null && typeof root === 'object' ? walk(root) : false;
 }
 
 function errorBoundaryFallback(node, fallbackAttribute) {

--- a/packages/octane/tests/_fixtures/block-header.tsrx
+++ b/packages/octane/tests/_fixtures/block-header.tsrx
@@ -1,0 +1,124 @@
+import { createContext, createPortal, ErrorBoundary, Suspense } from 'octane';
+
+// Components whose OUTPUT is a range rather than a single cloned element need
+// the compiler-emitted block handle. If the scan that decides to emit it ever
+// under-reports, these throw ReferenceError on first render.
+
+export function IfRoot(props) @{
+	@if (props.on) {
+		<b class="out">{'on'}</b>
+	} @else {
+		<i class="out">{'off'}</i>
+	}
+}
+
+export function ForRoot(props) @{
+	@for (const item of props.items; key item.id) {
+		<li class="out">{item.label}</li>
+	} @empty {
+		<li class="out">{'empty'}</li>
+	}
+}
+
+export function SwitchRoot(props) @{
+	@switch (props.kind) {
+		@case 'a': {
+			<b class="out">{'A'}</b>
+		}
+		@default: {
+			<i class="out">{'D'}</i>
+		}
+	}
+}
+
+export function TryRoot(props) @{
+	@try {
+		<b class="out">{props.value as string}</b>
+	} @catch (error) {
+		<i class="out">{'caught'}</i>
+	}
+}
+
+export function FragmentRoot() @{
+	<>
+		<b class="out">{'one'}</b>
+		<i class="out">{'two'}</i>
+	</>
+}
+
+export function DynamicTagRoot(props) @{
+	<props.tag class="out">{'dyn'}</props.tag>
+}
+
+function Leaf(props) @{
+	<b class="out">{props.text as string}</b>
+}
+
+export function ComponentRoot(props) @{
+	<Leaf text={props.text} />
+}
+
+export function SuspenseRoot(props) @{
+	<Suspense fallback={<i class="out">{'pending'}</i>}>
+		<b class="out">{props.value as string}</b>
+	</Suspense>
+}
+
+const Theme = createContext('light');
+
+export function ProviderRoot(props) @{
+	<Theme.Provider value={props.value}>
+		<b class="out">{props.value as string}</b>
+	</Theme.Provider>
+}
+
+// Nesting the range constructs inside each other exercises the walk over a
+// deep, repeated body rather than a flat one.
+export function DeeplyNested(props) @{
+	@if (props.on) {
+		@for (const item of props.items; key item.id) {
+			@try {
+				<>
+					<b class="out">{item.label}</b>
+					@if (item.extra) {
+						<i class="out">{item.extra as string}</i>
+					}
+				</>
+			} @catch (error) {
+				<i class="out">{'caught'}</i>
+			};
+		}
+	}
+}
+
+function Thrower(props) @{
+	if (props.explode) throw new Error('boom');
+	<b class="out">{'ok'}</b>
+}
+
+// The same reference scan decides whether an <ErrorBoundary> import is still
+// live once the element has been lowered away. It must not count the import
+// declaration itself as a use, or the lowering never completes cleanly.
+export function BoundaryRoot(props) @{
+	<ErrorBoundary fallback={<i class="out">{'caught'}</i>}>
+		<Thrower explode={props.explode} />
+	</ErrorBoundary>
+}
+
+// Controls: these do NOT need the block handle. They are here so the same
+// suite proves the surrounding compile path still works either way.
+export function PlainElement(props) @{
+	<div class="out">{props.text as string}</div>
+}
+
+export function NestedIf(props) @{
+	<div>
+		@if (props.on) {
+			<b class="out">{'nested'}</b>
+		}
+	</div>
+}
+
+export function PortalHost(props) @{
+	<div>{createPortal(<b class="out">{'portal'}</b>, props.target)}</div>
+}

--- a/packages/octane/tests/block-header.test.ts
+++ b/packages/octane/tests/block-header.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from './_helpers';
+import {
+	BoundaryRoot,
+	ComponentRoot,
+	DeeplyNested,
+	DynamicTagRoot,
+	ForRoot,
+	FragmentRoot,
+	IfRoot,
+	NestedIf,
+	PlainElement,
+	PortalHost,
+	ProviderRoot,
+	SuspenseRoot,
+	SwitchRoot,
+	TryRoot,
+} from './_fixtures/block-header.tsrx';
+
+const texts = (r: { container: HTMLElement }): string[] =>
+	[...r.container.querySelectorAll('.out')].map((n) => n.textContent ?? '');
+
+describe('components whose output is a range', () => {
+	// Each of these renders through the compiler-emitted block handle. If the
+	// scan that decides to emit that handle under-reports, the component throws
+	// ReferenceError on first render rather than producing wrong markup.
+	it('renders a root-level @if in both arms', () => {
+		const on = mount(IfRoot, { on: true });
+		expect(texts(on)).toEqual(['on']);
+		on.unmount();
+
+		const off = mount(IfRoot, { on: false });
+		expect(texts(off)).toEqual(['off']);
+		off.unmount();
+	});
+
+	it('renders a root-level @for including its empty arm', () => {
+		const filled = mount(ForRoot, {
+			items: [
+				{ id: 1, label: 'a' },
+				{ id: 2, label: 'b' },
+			],
+		});
+		expect(texts(filled)).toEqual(['a', 'b']);
+		filled.unmount();
+
+		const empty = mount(ForRoot, { items: [] });
+		expect(texts(empty)).toEqual(['empty']);
+		empty.unmount();
+	});
+
+	it('renders a root-level @switch in a matched and a default case', () => {
+		const matched = mount(SwitchRoot, { kind: 'a' });
+		expect(texts(matched)).toEqual(['A']);
+		matched.unmount();
+
+		const fallback = mount(SwitchRoot, { kind: 'zzz' });
+		expect(texts(fallback)).toEqual(['D']);
+		fallback.unmount();
+	});
+
+	it('renders a root-level @try', () => {
+		const r = mount(TryRoot, { value: 'body' });
+		expect(texts(r)).toEqual(['body']);
+		r.unmount();
+	});
+
+	it('renders a multi-root fragment', () => {
+		const r = mount(FragmentRoot);
+		expect(texts(r)).toEqual(['one', 'two']);
+		r.unmount();
+	});
+
+	it('renders a dynamic root tag', () => {
+		const r = mount(DynamicTagRoot, { tag: 'span' });
+		expect(texts(r)).toEqual(['dyn']);
+		expect(r.container.querySelector('.out')?.tagName).toBe('SPAN');
+		r.unmount();
+	});
+
+	it('renders a component as the sole root', () => {
+		const r = mount(ComponentRoot, { text: 'leaf' });
+		expect(texts(r)).toEqual(['leaf']);
+		r.unmount();
+	});
+
+	it('renders a Suspense root that never suspends', () => {
+		const r = mount(SuspenseRoot, { value: 'ready' });
+		expect(texts(r)).toEqual(['ready']);
+		r.unmount();
+	});
+
+	it('renders a context provider root', () => {
+		const r = mount(ProviderRoot, { value: 'dark' });
+		expect(texts(r)).toEqual(['dark']);
+		r.unmount();
+	});
+
+	it('renders range constructs nested inside each other', () => {
+		const r = mount(DeeplyNested, {
+			on: true,
+			items: [
+				{ id: 1, label: 'a', extra: 'x' },
+				{ id: 2, label: 'b', extra: null },
+			],
+		});
+		expect(texts(r)).toEqual(['a', 'x', 'b']);
+		r.unmount();
+	});
+
+	it('recovers through an ErrorBoundary root after its element is lowered', () => {
+		// Exercises the reference scan's other caller: deciding whether the
+		// <ErrorBoundary> binding is still live once the element is lowered away.
+		const ok = mount(BoundaryRoot, { explode: false });
+		expect(texts(ok)).toEqual(['ok']);
+		ok.unmount();
+
+		const caught = mount(BoundaryRoot, { explode: true });
+		expect(texts(caught)).toEqual(['caught']);
+		caught.unmount();
+	});
+});
+
+describe('components whose output is a single element', () => {
+	it('renders a plain element root', () => {
+		const r = mount(PlainElement, { text: 'flat' });
+		expect(texts(r)).toEqual(['flat']);
+		r.unmount();
+	});
+
+	it('renders an @if nested inside an element root', () => {
+		const r = mount(NestedIf, { on: true });
+		expect(texts(r)).toEqual(['nested']);
+		r.unmount();
+	});
+
+	it('renders a portal from an element root', () => {
+		const target = document.createElement('section');
+		document.body.appendChild(target);
+		const r = mount(PortalHost, { target });
+		expect(target.querySelector('.out')?.textContent).toBe('portal');
+		r.unmount();
+		expect(target.querySelector('.out')).toBe(null);
+		target.remove();
+	});
+});


### PR DESCRIPTION
## Summary

- stop the per-body `__block` scan recursing into non-object properties, so it no longer calls itself once per string, number and null it walks past
- move the skip-key `Set` lookup behind the type check, so rejecting a property costs a `typeof` instead of a hash lookup
- return the answer from the recursion instead of setting a closure flag, so a match unwinds at once rather than through every pending frame
- add regression coverage for the decision this scan drives, which had none

## Why

`hasIdentifierReference` runs once per compiled function body and decides whether the block handle is declared. It descended first and asked questions later: every property, `start` and `end` and `raw` included, became a recursive call that immediately returned. Nearly half of its calls did no work.

## Impact

| metric, 166 fixtures, client + server | before | after | change |
| --- | ---: | ---: | ---: |
| recursive calls | 377,277 | 210,775 | -44.1% |
| of those, no-ops on primitives | 165,107 | 0 | -100% |
| skip-key `Set` lookups | 999,993 | 337,572 | -66.2% |
| emitted bytes | unchanged | unchanged | byte-identical |
| compiler source | | | +15 / -13 |

This walk is roughly 1% of compile time on an application corpus, so the build-time effect is marginal. It lands because the removed work was pure overhead, not because builds get faster.

The visited `WeakSet` is kept on purpose. Compiler passes share subtrees, so without it the walk is exponential: 43 calls against 2,097,153 at depth 20 on a shared-subtree DAG. The suite passes without the guard, so tests do not protect it.

## Validation

- `vitest run --project=octane --project=octane-prod` over `block-header`, `basic`, `components`, `boundary`, `differential/`, `hydration/`: 798 passed
- compiled all 166 fixtures in both modes before and after, compared SHA-256 of every emitted module: identical
- new tests checked against two broken implementations (scan always reports false; array children skipped): 11 of 14 fail in each case, and the 3 that survive are exactly the controls that need no block handle