### PR TITLE
perf(compiler): resolve the imported-member-read proof once per component

### DIFF
--- a/.changeset/imported-member-read-single-walk.md
+++ b/.changeset/imported-member-read-single-walk.md
@@ -1,0 +1,9 @@
+---
+'octane': patch
+---
+
+The auto-memo purity analysis no longer walks each component body twice to ask
+whether it reads a member of an imported binding. Both proofs that needed the
+answer now share one lazily-resolved walk, and the predicate's unused
+`includeJsx` flag, whose two values could not produce different results, is
+gone. Compiler output is unchanged.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -2723,7 +2723,10 @@ function containsDeferredRefRead(root) {
 	return found;
 }
 
-function containsImportedMemberRead(root, importedNames, includeJsx = true) {
+// A JSX member chain bottoms out at a JSXIdentifier, so the base test below
+// never matches one. Do not reintroduce a JSX-awareness flag: it cannot change
+// the answer.
+function containsImportedMemberRead(root, importedNames) {
 	let found = false;
 	const seen = new WeakSet();
 	function walk(n) {
@@ -2734,7 +2737,7 @@ function containsImportedMemberRead(root, importedNames, includeJsx = true) {
 		}
 		if (typeof n !== 'object' || seen.has(n)) return;
 		seen.add(n);
-		if (n.type === 'MemberExpression' || (includeJsx && n.type === 'JSXMemberExpression')) {
+		if (n.type === 'MemberExpression' || n.type === 'JSXMemberExpression') {
 			let object = n;
 			while (object?.type === 'MemberExpression' || object?.type === 'JSXMemberExpression') {
 				object = object.object;
@@ -5184,8 +5187,12 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 		const root = b.block(stmts);
 		const free = collectFreeIdentifiers(root, locals);
 		const autoMemoImportedComponents = collectImportedComponentReferences(root, ctx.importedNames);
-		let autoMemoCallsitesSafe =
-			!containsDeferredRefRead(root) && !containsImportedMemberRead(root, ctx.importedNames, false);
+		// Both proofs below ask this of the same root. Kept lazy because the
+		// short-circuits ahead of each use skip it entirely for some components.
+		let importedMemberRead = null;
+		const readsImportedMember = () =>
+			(importedMemberRead ??= containsImportedMemberRead(root, ctx.importedNames));
+		let autoMemoCallsitesSafe = !containsDeferredRefRead(root) && !readsImportedMember();
 		for (const name of free) {
 			if (
 				ctx._octaneBoundaryNames.has(name) ||
@@ -5209,7 +5216,7 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 			ordinaryPropsParam &&
 			!containsRenderCall(stmts) &&
 			!containsAutoMemoUnsafeStructure(stmts) &&
-			!containsImportedMemberRead(root, ctx.importedNames);
+			!readsImportedMember();
 		const autoMemoCaptures = [];
 		const autoMemoComponentDeps = [];
 		if (autoMemoSafe) {

--- a/packages/octane/tests/auto-memo.test.ts
+++ b/packages/octane/tests/auto-memo.test.ts
@@ -196,6 +196,46 @@ describe('compiler-owned component-region memoization', () => {
 		expect(transitiveCapture.match(/const __memoDep[\w$]* = \(?live\)?;/g)).toHaveLength(2);
 	});
 
+	it('judges each component in a module on its own imported reads', () => {
+		// Every component is analysed against its own body. Both declaration
+		// orders are checked because a verdict leaking from one component to the
+		// next would only be visible in one direction.
+		const cases = [
+			[
+				'impure declared first',
+				`import { Menu } from './menu';
+				 function Dirty(props) @{ <b>{props.v}<Menu.Item /></b> }
+				 function Clean(props) @{ <i>{props.v}</i> }
+				 export function App(props) @{ <div><Dirty v={props.a} /><Clean v={props.b} /></div> }`,
+			],
+			[
+				'pure declared first',
+				`import { Menu } from './menu';
+				 function Clean(props) @{ <i>{props.v}</i> }
+				 function Dirty(props) @{ <b>{props.v}<Menu.Item /></b> }
+				 export function App(props) @{ <div><Clean v={props.b} /><Dirty v={props.a} /></div> }`,
+			],
+		];
+		for (const [order, source] of cases) {
+			const code = compile(source, 'auto-memo-per-component.tsrx', {
+				hmr: false,
+				autoMemo: true,
+			}).code;
+			expect(
+				/__memoCache[\w$]*\[\d+\] !== __memoDep[\w$]*\) \{\s*_\$componentSlot[A-Za-z]*\([^;]*, Clean,/.test(
+					code,
+				),
+				`${order}: the component reading no import should memoize`,
+			).toBe(true);
+			expect(
+				/__memoCache[\w$]*\[\d+\] !== __memoDep[\w$]*\) \{\s*_\$componentSlot[A-Za-z]*\([^;]*, Dirty,/.test(
+					code,
+				),
+				`${order}: the component reading an imported member should not memoize`,
+			).toBe(false);
+		}
+	});
+
 	it('falls back for impure calls, refs, and direct Suspense boundaries', () => {
 		const cases = [
 			`function Child(props) @{ <div>{props.read()}</div> }`,
@@ -211,6 +251,12 @@ describe('compiler-owned component-region memoization', () => {
 			`import { ViewTransition as VT } from 'octane'; function Child(props) @{ <VT>{props.value}</VT> }`,
 			`import { ErrorBoundary as Boundary } from 'octane'; function Child(props) @{ <Boundary fallback={null}>{props.value}</Boundary> }`,
 			`let ambient = 'a'; function Child() @{ <div>{ambient}</div> }`,
+			// A JSX member read of an import is caught by the free-identifier check,
+			// not by the member-read predicate: a JSX member chain bottoms out at a
+			// JSXIdentifier, which that predicate's base test does not match.
+			`import { Menu } from './menu'; function Child(props) @{ <div>{props.value}<Menu.Item /></div> }`,
+			`import { Menu } from './menu'; function Child(props) @{ <div>{props.value}<Menu.Item.Deep /></div> }`,
+			`import { Menu } from './menu'; function Child(props) @{ <div title={Menu.label}>{props.value}</div> }`,
 		];
 		for (const child of cases) {
 			const code = compile(


### PR DESCRIPTION
## Summary

- resolve the imported-member-read proof once per component instead of walking the same body twice
- drop the `includeJsx` parameter, whose two values cannot produce different answers
- keep the walk lazy, so components whose earlier checks already settle the proof still skip it
- pin the behaviour the removed parameter was aimed at, and the per-component isolation the shared walk introduces

## Why

`containsImportedMemberRead` was called twice on the identical component root, differing only in `includeJsx`. Each call fully re-descended the body and allocated its own visited set.

The parameter is inert. A JSX member chain bottoms out at a `JSXIdentifier`, never an `Identifier`, and the predicate's base test only matches `Identifier`, so the JSX arm can never fire. Both call sites were asking one question.

## Impact

| metric, 166 fixtures | before | after |
| --- | ---: | ---: |
| walks per component | 2 | 1 |
| visited sets allocated per component | 2 | 1 |
| components that reach the walk at all | 977 of 1,008 | unchanged |
| `JSXMemberExpression` nodes with an `Identifier` base | 0 of 82 | unchanged |
| emitted bytes | unchanged | byte-identical |
| compiler source | | +12 / -5 |

Removing the parameter loses no coverage: a component reading a member of an import through JSX is already rejected by the free-identifier check over the same body, verified across member chains, nested chains, namespace and named imports, attribute values, and reads inside nested functions.

## Validation

- `vitest run --project=octane --project=octane-prod` over `auto-memo`, `basic`, `components`, `component-hoisting`, `differential/`, `hydration/`: 784 passed
- compiled all 166 fixtures in both modes before and after: byte-identical
- the JSX-read tests fail when the free-identifier rejection is removed; the isolation test fails when the memo is hoisted out of the per-component loop