### PR TITLE
Add six-framework hydration interactivity benchmark

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -173,6 +173,7 @@ internally, get their own baseline and guard namespace.
 | `recursive-context` | recursive-context | Octane + reference frameworks | context fan-out |
 | `signal-favoring` | signal-favoring | Octane + reference frameworks | cascade vs targeted |
 | `news` | news | none (builds) | SSR + hydration, per-target |
+| `hydration-interactivity` | hydration-interactivity | none (builds) | real pre-hydration typing, controlled inputs, native event replay, and 1×/6× Chromium CPU throttling across Octane, React, Preact, Solid 2, Svelte, and Vue Vapor |
 | `effectful-list` | effectful-list | Octane + reference frameworks | effect/ref cleanup churn |
 | `memo-wall` | memo-wall | Octane + reference frameworks | memo bail + context walk |
 | `portal-swarm` | portal-swarm | Octane + reference frameworks | portal render/dispatch |

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -1,5 +1,21 @@
 [
   {
+    "suite": "hydration-interactivity",
+    "op": "uncontrolled_6x_hydration",
+    "target": "octane-tsrx",
+    "reference": "react",
+    "maxRatio": 1.5,
+    "note": "Same-run production Chromium hydration under real 6x CPU throttling: Octane measured about 0.4x React while preserving pre-hydration input. The 1.5x ceiling leaves browser and machine-noise headroom."
+  },
+  {
+    "suite": "hydration-interactivity",
+    "op": "controlled_6x_hydration",
+    "target": "octane-tsrx",
+    "reference": "react",
+    "maxRatio": 1.5,
+    "note": "Same-run production Chromium controlled-input hydration under real 6x CPU throttling: Octane measured about 0.4x React and must preserve the complete pre-hydration draft, focus, and caret."
+  },
+  {
     "suite": "js-framework",
     "op": "run",
     "target": "octane-tsrx",

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -693,6 +693,28 @@ function runHarness(suite, run, outPath) {
 	return { code: res.status ?? 1, json };
 }
 
+function printHydrationInteractivityUx(result) {
+	if (result.suite !== 'hydration-interactivity') return;
+
+	const measured = result.targets.filter((target) => target.meta?.userExperience?.samples > 0);
+	if (measured.length === 0) return;
+
+	console.error('\n  Pre-hydration search-and-Send UX correctness');
+	console.error('  framework       outcome  Send replay   query saved   delivered');
+	for (const target of measured) {
+		const ux = target.meta.userExperience;
+		const fraction = (count) => `${count}/${ux.samples}`;
+		console.error(
+			`  ${target.name.padEnd(15)} ${ux.status.toUpperCase().padEnd(8)} ${fraction(
+				ux.replayedSendClicks,
+			).padEnd(13)} ${fraction(ux.preservedSearches).padEnd(13)} ${fraction(ux.exactDeliveries)}`,
+		);
+		if (ux.issues.length > 0) {
+			console.error(`    UX failure: ${ux.issues.join('; ')}`);
+		}
+	}
+}
+
 // ── run one suite end-to-end ─────────────────────────────────────────────────
 
 async function runSuite(suite) {
@@ -743,6 +765,7 @@ async function runSuite(suite) {
 		if (merged.targets.length === 0) {
 			throw new Error('no targets produced numbers (harness wrote no parseable BENCH_JSON)');
 		}
+		printHydrationInteractivityUx(merged);
 		if (merged.failed) console.error(`  ! harness reported gate failure(s): ${merged.failed}`);
 		return merged;
 	} finally {

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -236,6 +236,21 @@ const SUITES = [
 		})),
 	},
 	{
+		// Real pre-hydration typing against a withheld production client chunk,
+		// measured with Chromium CDP CPU throttling. The six target apps reuse
+		// news's existing SSR toolchains, including Solid 2 and Vue Vapor; Octane's
+		// real early-capture bootstrap additionally proves exactly-once replay.
+		name: 'hydration-interactivity',
+		cwd: 'hydration-interactivity',
+		servers: [],
+		iter: { normal: 5, quick: 2 },
+		runs: ['octane-tsrx', 'react', 'preact', 'solid', 'svelte', 'vue-vapor'].map((target) => ({
+			label: target,
+			script: 'run.mjs',
+			args: (n) => [target, String(n)],
+		})),
+	},
+	{
 		name: 'effectful-list',
 		cwd: 'effectful-list',
 		servers: [

--- a/benchmarks/hydration-interactivity/README.md
+++ b/benchmarks/hydration-interactivity/README.md
@@ -56,8 +56,18 @@ uses a sleep as a hydration gate.
   released, and report whether hydration preserves the query, replays the
   discrete click, and submits the exact original query exactly once. Missing
   replay, overwritten query text, and an incorrect submitted value are recorded
-  explicitly as correctness issues; Octane fails the suite if it loses the
-  query or Send intent.
+  explicitly as user-experience correctness failures; Octane fails the suite
+  if it loses the query or Send intent.
+
+The unified runner prints a six-framework UX correctness table after the
+timings. Each framework receives an explicit `PASS` or `FAIL`, together with
+the measured fractions of replayed Send clicks, preserved search queries, and
+exactly-once deliveries. A replayed focus does not turn a dropped Send into a
+success, and a replayed Send does not pass if it submits an overwritten query.
+The machine-readable `meta.userExperience` result additionally records the
+counts of dropped clicks, lost searches, incorrect submissions, focus-only
+replays, and the exact correctness issues. Reference-framework failures remain
+visible comparison results; Octane's UX correctness remains a hard suite gate.
 
 The typing operations separately report first-character latency, the time to
 type the complete draft, chunk-release-to-hydration latency, synchronous

--- a/benchmarks/hydration-interactivity/README.md
+++ b/benchmarks/hydration-interactivity/README.md
@@ -1,0 +1,94 @@
+# Hydration interactivity benchmark
+
+A production-built, six-framework comparison of what users can actually do with
+server-rendered HTML while client-side hydration is still blocked. Playwright
+types into a real Chromium input before the hydration chunk is released, then
+verifies DOM adoption, preserved text, focus, caret position, live component
+state, and exactly-once interaction replay.
+
+| target | production renderer |
+| --- | --- |
+| `octane-tsrx` | Octane SSR, compiler-owned hydration, and the public lightweight early-capture bootstrap |
+| `react` | React 19 `react-dom/server` and `react-dom/client` |
+| `preact` | native Preact, `preact-render-to-string`, and `preact/compat` flushing |
+| `solid` | Solid 2.0 beta, `@solidjs/web`, and the real Solid hydration script |
+| `svelte` | Svelte 5 server rendering, runes, and strict public hydration |
+| `vue-vapor` | Vue 3.6 Vapor, the existing Vapor-inclusive client shim, and server-rendered Vapor SFCs |
+
+All six apps render the same 180 server-rendered articles and the same editor,
+button, visible component-state outputs, and native `input` handler. The
+benchmark reuses each target's established production `benchmarks/news`
+toolchain without modifying the existing news workload or adding dependencies.
+
+## Operations
+
+Each sample uses a fresh browser context. The harness intercepts the production
+`hydration-client` chunk, waits for the small bootstrap to run, and keeps the
+chunk blocked while Playwright performs real keyboard or mouse input. It never
+manufactures user typing with `dispatchEvent`, injects an event-replay shim, or
+uses a sleep as a hydration gate.
+
+- `uncontrolled_1x_*`: type a complete draft into the server-rendered native
+  input before hydration under normal CPU speed.
+- `uncontrolled_6x_*`: repeat the same workload after applying a real 6× CPU
+  slowdown through Chromium's `Emulation.setCPUThrottlingRate` command.
+- `controlled_6x_*`: repeat under the same 6× slowdown with each framework's
+  controlled input path; report whether pre-hydration text, focus, and caret
+  survive adoption and verify that the next genuine edit updates visible
+  component state. Octane must preserve all three; reference-framework behavior
+  is measured and reported rather than replaced with a compatibility shim.
+- `interaction_6x_*`: click the server-rendered button while the production
+  hydration chunk is blocked. Octane's public `interaction()` boundary and
+  `initializeHydrationEventCapture()` must replay the click exactly once after
+  hydration. Solid 2.0's real server hydration script must also replay the click
+  exactly once. The remaining reference frameworks use their real pre-root
+  behavior: no synthetic early-capture shim is installed and no replay
+  capability is claimed. Every target must process the next real post-hydration
+  click exactly once.
+
+The typing operations separately report first-character latency, the time to
+type the complete draft, chunk-release-to-hydration latency, synchronous
+hydration work, and post-hydration typing latency. The replay operations report
+chunk-release-to-hydration and interaction-to-hydration latency; replay counts
+are recorded as deterministic target metadata.
+
+## Correctness gates
+
+A timing is accepted only if the harness proves all of the following:
+
+- the hydration client really was withheld throughout the pre-hydration
+  interaction;
+- Chromium generated one native input event for every typed character;
+- the original server-rendered input, article, and interaction button were
+  adopted rather than rebuilt;
+- whether each framework preserved the typed draft, focus, and caret; loss of
+  any of the three fails Octane and is reported honestly for reference targets;
+- the first post-hydration edit preserved the original draft and updated the
+  visible application state;
+- the page contains exactly 180 correctly adopted article cards;
+- hydration completes exactly once without browser or hydration errors;
+- Octane and Solid 2.0 replay the deferred pre-root click exactly once through
+  their genuine framework mechanisms, while other targets are not incorrectly
+  credited with an unsupported replay; and
+- every target handles the next actual click exactly once.
+
+A failed gate writes a `failed` result and exits nonzero, matching the unified
+benchmark runner's existing `BENCH_JSON` contract. Timing guards should be
+calibrated from paired production runs on the same machine; CPU throttling is
+not an absolute cross-machine performance threshold.
+
+## Run
+
+```bash
+node benchmarks/bench.mjs hydration-interactivity
+node benchmarks/bench.mjs --quick hydration-interactivity
+
+node benchmarks/hydration-interactivity/run.mjs octane-tsrx 5
+node benchmarks/hydration-interactivity/run.mjs react 5
+node benchmarks/hydration-interactivity/run.mjs preact 5
+node benchmarks/hydration-interactivity/run.mjs solid 5
+node benchmarks/hydration-interactivity/run.mjs svelte 5
+node benchmarks/hydration-interactivity/run.mjs vue-vapor 5
+```
+
+Pass `--no-build` after an initial run to reuse the existing production assets.

--- a/benchmarks/hydration-interactivity/README.md
+++ b/benchmarks/hydration-interactivity/README.md
@@ -2,14 +2,15 @@
 
 A production-built, six-framework comparison of what users can actually do with
 server-rendered HTML while client-side hydration is still blocked. Playwright
-types into a real Chromium input before the hydration chunk is released, then
-verifies DOM adoption, preserved text, focus, caret position, live component
-state, and exactly-once interaction replay.
+types into a real Chromium search input, clicks Send before the hydration chunk
+is released, and verifies DOM adoption, preserved text, focus, caret position,
+live component state, event replay, and whether the exact search query was
+actually delivered exactly once.
 
 | target | production renderer |
 | --- | --- |
 | `octane-tsrx` | Octane SSR, compiler-owned hydration, and the public lightweight early-capture bootstrap |
-| `react` | React 19 `react-dom/server` and `react-dom/client` |
+| `react` | React 19 `react-dom/server`, `react-dom/client`, and real Suspense-boundary event replay |
 | `preact` | native Preact, `preact-render-to-string`, and `preact/compat` flushing |
 | `solid` | Solid 2.0 beta, `@solidjs/web`, and the real Solid hydration script |
 | `svelte` | Svelte 5 server rendering, runes, and strict public hydration |
@@ -41,10 +42,22 @@ uses a sleep as a hydration gate.
   hydration chunk is blocked. Octane's public `interaction()` boundary and
   `initializeHydrationEventCapture()` must replay the click exactly once after
   hydration. Solid 2.0's real server hydration script must also replay the click
-  exactly once. The remaining reference frameworks use their real pre-root
-  behavior: no synthetic early-capture shim is installed and no replay
-  capability is claimed. Every target must process the next real post-hydration
-  click exactly once.
+  exactly once. React installs its actual `hydrateRoot` listeners before the
+  click, leaves a server-rendered Suspense boundary dehydrated until the blocked
+  component chunk arrives, and must replay the native focus event from that
+  exact same user interaction. React 19 cannot replay the blocked discrete click
+  after its lazy component has resolved, so focus and click replay are reported
+  separately rather than incorrectly crediting React with pre-root capture or
+  deferred click replay. The remaining frameworks use their real pre-root
+  behavior without a synthetic early-capture shim. Every target must process
+  the next real post-hydration click exactly once.
+- `search_send_6x_*`: type a real search query into the controlled, still
+  server-rendered search box, click Send before its hydration chunk is
+  released, and report whether hydration preserves the query, replays the
+  discrete click, and submits the exact original query exactly once. Missing
+  replay, overwritten query text, and an incorrect submitted value are recorded
+  explicitly as correctness issues; Octane fails the suite if it loses the
+  query or Send intent.
 
 The typing operations separately report first-character latency, the time to
 type the complete draft, chunk-release-to-hydration latency, synchronous
@@ -67,9 +80,12 @@ A timing is accepted only if the harness proves all of the following:
   visible application state;
 - the page contains exactly 180 correctly adopted article cards;
 - hydration completes exactly once without browser or hydration errors;
-- Octane and Solid 2.0 replay the deferred pre-root click exactly once through
-  their genuine framework mechanisms, while other targets are not incorrectly
-  credited with an unsupported replay; and
+- typing a search and clicking Send before hydration either delivers the exact
+  original query once or appears explicitly as a replay correctness issue;
+- Octane and Solid 2.0 replay the deferred pre-root click exactly once, React
+  replays the associated focus event exactly once through its genuine
+  dehydrated boundary, and remaining targets are not credited with unsupported
+  replay behavior; and
 - every target handles the next actual click exactly once.
 
 A failed gate writes a `failed` result and exits nonzero, matching the unified

--- a/benchmarks/hydration-interactivity/run.mjs
+++ b/benchmarks/hydration-interactivity/run.mjs
@@ -1,0 +1,1 @@
+import '../news/hydration-interactivity.mjs';

--- a/benchmarks/hydration-interactivity/shared.js
+++ b/benchmarks/hydration-interactivity/shared.js
@@ -19,6 +19,7 @@ export function startHydrationBootstrap(loadClient, initializeCapture) {
 		hydrationStartedAt: 0,
 		hydratedAt: 0,
 		hydrationCalls: 0,
+		replayRootInitializedAt: 0,
 		inputAttemptAt: 0,
 		firstNativeInputAt: 0,
 		nativeInputCount: 0,

--- a/benchmarks/hydration-interactivity/shared.js
+++ b/benchmarks/hydration-interactivity/shared.js
@@ -1,0 +1,73 @@
+export const INITIAL_VALUE = '';
+export const PRE_HYDRATION_TEXT = 'typed before hydration';
+export const POST_HYDRATION_TEXT = ' and still responsive';
+export const CARD_COUNT = 180;
+
+export const CARDS = Array.from({ length: CARD_COUNT }, (_, index) => ({
+	id: index + 1,
+	title: `Server-rendered article ${index + 1}`,
+	description: `Hydration should adopt article ${index + 1} without replacing its DOM.`,
+}));
+
+export function startHydrationBootstrap(loadClient, initializeCapture) {
+	initializeCapture?.();
+
+	const status = {
+		bootstrapAt: performance.now(),
+		clientRequestedAt: 0,
+		clientLoadedAt: 0,
+		hydrationStartedAt: 0,
+		hydratedAt: 0,
+		hydrationCalls: 0,
+		inputAttemptAt: 0,
+		firstNativeInputAt: 0,
+		nativeInputCount: 0,
+		originalInput: null,
+		originalCard: null,
+		originalAction: null,
+		error: '',
+	};
+
+	window.__hydrationInteractivity = status;
+	document.addEventListener(
+		'input',
+		(event) => {
+			if (event.target instanceof HTMLInputElement && event.target.id === 'hydration-input') {
+				status.firstNativeInputAt ||= performance.now();
+				status.nativeInputCount++;
+			}
+		},
+		true,
+	);
+
+	status.clientRequestedAt = performance.now();
+	void loadClient()
+		.then((client) => {
+			status.clientLoadedAt = performance.now();
+			client.hydrateBenchmark();
+		})
+		.catch((error) => {
+			status.error = error instanceof Error ? error.message : String(error);
+			console.error('Hydration interactivity client failed:', error);
+		});
+}
+
+export function completeHydration(hydrate) {
+	const status = window.__hydrationInteractivity;
+	if (!status) throw new Error('Hydration benchmark bootstrap did not run');
+	if (status.hydrationCalls !== 0) throw new Error('Hydration was started more than once');
+
+	status.hydrationStartedAt = performance.now();
+	const root = hydrate();
+	status.hydrationCalls++;
+	status.hydratedAt = performance.now();
+	return root;
+}
+
+export function hydrationProps() {
+	const search = new URLSearchParams(window.location.search);
+	return {
+		controlled: search.get('controlled') === '1',
+		deferred: search.get('mode') === 'interaction',
+	};
+}

--- a/benchmarks/news/hydration-interactivity.mjs
+++ b/benchmarks/news/hydration-interactivity.mjs
@@ -1,0 +1,478 @@
+process.env.NODE_ENV = 'production';
+
+import { build } from 'vite';
+import { chromium } from 'playwright';
+import { createServer } from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import {
+	CARDS,
+	CARD_COUNT,
+	POST_HYDRATION_TEXT,
+	PRE_HYDRATION_TEXT,
+} from '../hydration-interactivity/shared.js';
+import { summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const TARGETS = ['octane-tsrx', 'react', 'preact', 'solid', 'svelte', 'vue-vapor'];
+const args = process.argv.slice(2);
+const noBuild = args.includes('--no-build');
+const positional = args.filter((value) => !value.startsWith('--'));
+const target = TARGETS.includes(positional[0]) ? positional.shift() : 'octane-tsrx';
+const supportsPreRootInteractionReplay = target === 'octane-tsrx' || target === 'solid';
+const iterations = Number.parseInt(positional[0] ?? '5', 10);
+const warmup = 1;
+
+if (!Number.isSafeInteger(iterations) || iterations < 1) {
+	throw new Error('Hydration interactivity iterations must be a positive integer');
+}
+
+const appDirectory = path.join(HERE, target);
+const outputDirectory = path.join(appDirectory, 'dist/hydration-interactivity');
+const clientDirectory = path.join(outputDirectory, 'client');
+const serverEntry = path.join(outputDirectory, 'server/hydration-server.js');
+const clientHtml = path.join(clientDirectory, 'hydration-interactivity.html');
+
+if (!noBuild) {
+	console.log(`Building ${target} hydration interactivity fixtures (production)…`);
+	await build({
+		root: appDirectory,
+		logLevel: 'warn',
+		build: {
+			outDir: path.relative(appDirectory, clientDirectory),
+			emptyOutDir: true,
+			minify: 'esbuild',
+			rollupOptions: {
+				input: path.join(appDirectory, 'hydration-interactivity.html'),
+				output: {
+					chunkFileNames: 'assets/[name]-[hash].js',
+					entryFileNames: 'assets/[name]-[hash].js',
+				},
+			},
+		},
+	});
+	await build({
+		root: appDirectory,
+		logLevel: 'warn',
+		build: {
+			ssr: 'src/hydration-interactivity/hydration-server.ts',
+			outDir: path.relative(appDirectory, path.dirname(serverEntry)),
+			emptyOutDir: true,
+		},
+	});
+}
+
+if (!fs.existsSync(clientHtml) || !fs.existsSync(serverEntry)) {
+	throw new Error(`Missing production hydration interactivity assets for ${target}`);
+}
+
+const { renderApp } = await import(pathToFileURL(serverEntry).href);
+const template = fs.readFileSync(clientHtml, 'utf8');
+const contentTypes = {
+	'.css': 'text/css; charset=utf-8',
+	'.html': 'text/html; charset=utf-8',
+	'.js': 'text/javascript; charset=utf-8',
+	'.json': 'application/json; charset=utf-8',
+	'.mjs': 'text/javascript; charset=utf-8',
+	'.svg': 'image/svg+xml',
+};
+
+const server = createServer(async (request, response) => {
+	try {
+		const url = new URL(request.url ?? '/', 'http://127.0.0.1');
+		if (url.pathname === '/') {
+			const props = {
+				controlled: url.searchParams.get('controlled') === '1',
+				deferred: url.searchParams.get('mode') === 'interaction',
+			};
+			const { body, css, head } = await renderApp(props);
+			response.setHeader('content-type', contentTypes['.html']);
+			response.end(
+				template.replace('<!--ssr-head-->', head + css).replace('<!--ssr-body-->', body),
+			);
+			return;
+		}
+
+		const file = path.resolve(clientDirectory, `.${decodeURIComponent(url.pathname)}`);
+		if (
+			file.startsWith(`${clientDirectory}${path.sep}`) &&
+			fs.existsSync(file) &&
+			fs.statSync(file).isFile()
+		) {
+			response.setHeader(
+				'content-type',
+				contentTypes[path.extname(file)] ?? 'application/octet-stream',
+			);
+			response.end(fs.readFileSync(file));
+			return;
+		}
+
+		response.statusCode = 404;
+		response.end('Not found');
+	} catch (error) {
+		response.statusCode = 500;
+		response.end(error instanceof Error ? error.message : String(error));
+	}
+});
+
+await new Promise((resolve, reject) => {
+	server.once('error', reject);
+	server.listen(0, '127.0.0.1', resolve);
+});
+
+const address = server.address();
+if (address === null || typeof address === 'string') {
+	throw new Error('The hydration interactivity server did not expose a TCP port');
+}
+
+const origin = `http://127.0.0.1:${address.port}`;
+let browser;
+
+function ensure(condition, message) {
+	if (!condition) throw new Error(`${target}: ${message}`);
+}
+
+function createGate() {
+	let open;
+	const pending = new Promise((resolve) => {
+		open = resolve;
+	});
+	return { open, pending };
+}
+
+async function openSample({ cpuRate, controlled = false, interaction = false }) {
+	const context = await browser.newContext();
+	const page = await context.newPage();
+	page.setDefaultTimeout(30_000);
+	const failures = [];
+	page.on('pageerror', (error) => failures.push(error.message));
+	page.on('console', (message) => {
+		if (message.type() === 'error') failures.push(message.text());
+	});
+
+	const cdp = await context.newCDPSession(page);
+	await cdp.send('Emulation.setCPUThrottlingRate', { rate: cpuRate });
+
+	const clientGate = createGate();
+	const clientRequest = page.waitForRequest((request) =>
+		/\/assets\/hydration-client-[^/]+\.js(?:\?|$)/.test(request.url()),
+	);
+	await page.route('**/assets/hydration-client-*.js', async (route) => {
+		await clientGate.pending;
+		await route.continue();
+	});
+
+	const search = new URLSearchParams();
+	if (controlled) search.set('controlled', '1');
+	if (interaction) search.set('mode', 'interaction');
+	const suffix = search.size === 0 ? '' : `?${search}`;
+	await page.goto(`${origin}/${suffix}`, { waitUntil: 'domcontentloaded' });
+	await clientRequest;
+	await page.waitForFunction(() => window.__hydrationInteractivity?.bootstrapAt > 0);
+
+	await page.evaluate(() => {
+		const status = window.__hydrationInteractivity;
+		status.originalInput = document.querySelector('#hydration-input');
+		status.originalCard = document.querySelector('#hydration-cards > li');
+		status.originalAction = document.querySelector('#hydration-action');
+	});
+
+	return { clientGate, context, failures, page };
+}
+
+async function releaseHydration(sample) {
+	const releasedAt = await sample.page.evaluate(() => performance.now());
+	sample.clientGate.open();
+	await sample.page.waitForFunction(() => {
+		const state = window.__hydrationInteractivity;
+		return state?.hydratedAt > 0 || Boolean(state?.error);
+	});
+
+	const snapshot = await sample.page.evaluate(() => {
+		const state = window.__hydrationInteractivity;
+		const input = document.querySelector('#hydration-input');
+		return {
+			cardCount: document.querySelectorAll('#hydration-cards > li').length,
+			cardSignature: Array.from(document.querySelectorAll('#hydration-cards > li'), (card) =>
+				[
+					card.getAttribute('data-card-id'),
+					card.querySelector('h2')?.textContent,
+					card.querySelector('p')?.textContent,
+				].join('\u001f'),
+			).join('\u001e'),
+			cardSame: document.querySelector('#hydration-cards > li') === state.originalCard,
+			clicks: Number(document.querySelector('#hydration-clicks')?.textContent),
+			error: state.error,
+			focused: document.activeElement === input,
+			hydratedAt: state.hydratedAt,
+			hydrationCalls: state.hydrationCalls,
+			hydrationStartedAt: state.hydrationStartedAt,
+			inputSame: input === state.originalInput,
+			nativeInputCount: state.nativeInputCount,
+			selectionEnd: input?.selectionEnd,
+			selectionStart: input?.selectionStart,
+			value: input?.value,
+		};
+	});
+
+	ensure(!snapshot.error, `production client failed: ${snapshot.error}`);
+	ensure(sample.failures.length === 0, `browser errors: ${sample.failures.join('; ')}`);
+	ensure(snapshot.hydrationCalls === 1, 'hydration must run exactly once');
+	ensure(snapshot.cardCount === CARD_COUNT, `expected ${CARD_COUNT} server-rendered articles`);
+	ensure(
+		snapshot.cardSignature ===
+			CARDS.map((card) => [card.id, card.title, card.description].join('\u001f')).join('\u001e'),
+		'hydration changed the shared article content or order',
+	);
+	ensure(snapshot.cardSame, 'hydration replaced a server-rendered article');
+	ensure(snapshot.inputSame, 'hydration replaced the server-rendered input');
+
+	return { ...snapshot, releasedAt };
+}
+
+async function closeSample(sample) {
+	sample.clientGate.open();
+	await sample.context.close();
+}
+
+async function runTypingSample({ cpuRate, controlled }) {
+	const sample = await openSample({ cpuRate, controlled });
+	try {
+		const input = sample.page.locator('#hydration-input');
+		await input.click();
+		const typingStartedAt = await sample.page.evaluate(() => {
+			window.__hydrationInteractivity.inputAttemptAt = performance.now();
+			return window.__hydrationInteractivity.inputAttemptAt;
+		});
+		await input.pressSequentially(PRE_HYDRATION_TEXT);
+
+		const before = await sample.page.evaluate(() => {
+			const state = window.__hydrationInteractivity;
+			const input = document.querySelector('#hydration-input');
+			return {
+				completedAt: performance.now(),
+				firstNativeInputAt: state.firstNativeInputAt,
+				focused: document.activeElement === input,
+				hydrated: state.hydrationCalls !== 0,
+				selectionEnd: input.selectionEnd,
+				selectionStart: input.selectionStart,
+				value: input.value,
+			};
+		});
+
+		ensure(!before.hydrated, 'client hydrated before the withheld chunk was released');
+		ensure(before.value === PRE_HYDRATION_TEXT, 'native pre-hydration typing lost characters');
+		ensure(before.focused, 'pre-hydration typing lost input focus');
+		ensure(
+			before.selectionStart === PRE_HYDRATION_TEXT.length &&
+				before.selectionEnd === PRE_HYDRATION_TEXT.length,
+			'pre-hydration typing did not preserve the caret',
+		);
+		ensure(before.firstNativeInputAt > 0, 'Playwright did not produce native input events');
+
+		const hydrated = await releaseHydration(sample);
+		const preservation = {
+			text: hydrated.value === PRE_HYDRATION_TEXT,
+			focus: hydrated.focused,
+			caret:
+				hydrated.selectionStart === PRE_HYDRATION_TEXT.length &&
+				hydrated.selectionEnd === PRE_HYDRATION_TEXT.length,
+		};
+		if (target === 'octane-tsrx') {
+			ensure(preservation.text, 'hydration overwrote pre-hydration typing');
+			ensure(preservation.focus, 'hydration moved focus away from the input');
+			ensure(preservation.caret, 'hydration moved the input caret');
+		}
+
+		const postStartedAt = await sample.page.evaluate(() => performance.now());
+		await input.pressSequentially(POST_HYDRATION_TEXT);
+		const expected = hydrated.value + POST_HYDRATION_TEXT;
+		await sample.page.waitForFunction(
+			(value) =>
+				document.querySelector('#hydration-input')?.value === value &&
+				document.querySelector('#hydration-output')?.textContent === value,
+			expected,
+		);
+		const final = await sample.page.evaluate(() => ({
+			completedAt: performance.now(),
+			focused: document.activeElement === document.querySelector('#hydration-input'),
+			inputSame:
+				document.querySelector('#hydration-input') ===
+				window.__hydrationInteractivity.originalInput,
+			nativeInputCount: window.__hydrationInteractivity.nativeInputCount,
+			output: document.querySelector('#hydration-output')?.textContent,
+			selectionEnd: document.querySelector('#hydration-input')?.selectionEnd,
+			value: document.querySelector('#hydration-input')?.value,
+		}));
+
+		ensure(final.inputSame, 'the first live update replaced the input');
+		ensure(final.focused, 'the first live update moved focus');
+		ensure(final.selectionEnd === expected.length, 'the first live update moved the caret');
+		ensure(
+			final.value === expected && final.output === expected,
+			'component state lost typed text',
+		);
+		ensure(
+			final.nativeInputCount === (PRE_HYDRATION_TEXT + POST_HYDRATION_TEXT).length,
+			`expected ${(PRE_HYDRATION_TEXT + POST_HYDRATION_TEXT).length} native input events, received ${final.nativeInputCount}`,
+		);
+
+		return {
+			firstInput: before.firstNativeInputAt - typingStartedAt,
+			preHydrationTyping: before.completedAt - typingStartedAt,
+			hydration: hydrated.hydratedAt - hydrated.releasedAt,
+			hydrationWork: hydrated.hydratedAt - hydrated.hydrationStartedAt,
+			postHydrationTyping: final.completedAt - postStartedAt,
+			preservation,
+		};
+	} finally {
+		await closeSample(sample);
+	}
+}
+
+async function runReplaySample() {
+	const sample = await openSample({ cpuRate: 6, interaction: true });
+	try {
+		const button = sample.page.locator('#hydration-action');
+		const clickedAt = await sample.page.evaluate(() => performance.now());
+		await button.click();
+		const before = await sample.page.evaluate(() => ({
+			clicks: Number(document.querySelector('#hydration-clicks')?.textContent),
+			hydrationCalls: window.__hydrationInteractivity.hydrationCalls,
+		}));
+		ensure(before.clicks === 0, 'the delayed client handled a click before hydration');
+		ensure(before.hydrationCalls === 0, 'the interaction bypassed the withheld client chunk');
+
+		const hydrated = await releaseHydration(sample);
+		const expectedReplay = supportsPreRootInteractionReplay ? 1 : 0;
+		ensure(
+			hydrated.clicks === expectedReplay,
+			`expected ${expectedReplay} replayed clicks, observed ${hydrated.clicks}`,
+		);
+		const actionSame = await sample.page.evaluate(
+			() =>
+				document.querySelector('#hydration-action') ===
+				window.__hydrationInteractivity.originalAction,
+		);
+		ensure(actionSame, 'hydration replaced the server-rendered action');
+
+		await button.click();
+		await sample.page.waitForFunction(
+			(expected) => Number(document.querySelector('#hydration-clicks')?.textContent) === expected,
+			expectedReplay + 1,
+		);
+		ensure(sample.failures.length === 0, `browser errors: ${sample.failures.join('; ')}`);
+
+		return {
+			hydration: hydrated.hydratedAt - hydrated.releasedAt,
+			interactionToHydration: hydrated.hydratedAt - clickedAt,
+			replayedClicks: expectedReplay,
+		};
+	} finally {
+		await closeSample(sample);
+	}
+}
+
+function addSamples(operations, prefix, result) {
+	for (const [name, value] of Object.entries(result)) {
+		if (name === 'replayedClicks' || name === 'preservation') continue;
+		const operation = `${prefix}_${name.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`)}`;
+		(operations[operation] ??= []).push(value);
+	}
+}
+
+const rawOperations = {};
+const replayCounts = [];
+const inputPreservation = {
+	uncontrolled_1x: [],
+	uncontrolled_6x: [],
+	controlled_6x: [],
+};
+let failure;
+
+try {
+	browser = await chromium.launch({ headless: true, args: ['--no-sandbox'] });
+	for (let index = 0; index < warmup + iterations; index++) {
+		const plain = await runTypingSample({ cpuRate: 1, controlled: false });
+		const slowed = await runTypingSample({ cpuRate: 6, controlled: false });
+		const controlled = await runTypingSample({ cpuRate: 6, controlled: true });
+		const replay = await runReplaySample();
+
+		if (index >= warmup) {
+			addSamples(rawOperations, 'uncontrolled_1x', plain);
+			addSamples(rawOperations, 'uncontrolled_6x', slowed);
+			addSamples(rawOperations, 'controlled_6x', controlled);
+			addSamples(rawOperations, 'interaction_6x', replay);
+			inputPreservation.uncontrolled_1x.push(plain.preservation);
+			inputPreservation.uncontrolled_6x.push(slowed.preservation);
+			inputPreservation.controlled_6x.push(controlled.preservation);
+			replayCounts.push(replay.replayedClicks);
+		}
+	}
+} catch (error) {
+	failure = error instanceof Error ? error.message : String(error);
+} finally {
+	await browser?.close();
+	await new Promise((resolve) => server.close(resolve));
+}
+
+const operations = Object.fromEntries(
+	Object.entries(rawOperations).map(([name, samples]) => [
+		name,
+		timingStatForJson(summarizeSamples(samples), { p99: true }),
+	]),
+);
+
+const payload = {
+	suite: 'hydration-interactivity',
+	iterations,
+	targets: [
+		{
+			name: target,
+			ops: operations,
+			meta: {
+				cardCount: CARD_COUNT,
+				cpuRates: [1, 6],
+				nativeInputEvents: (PRE_HYDRATION_TEXT + POST_HYDRATION_TEXT).length,
+				inputPreservation,
+				preHydrationText: PRE_HYDRATION_TEXT,
+				postHydrationText: POST_HYDRATION_TEXT,
+				replayedClicks: replayCounts,
+				preRootInteractionReplay: supportsPreRootInteractionReplay,
+				browser: 'chromium',
+			},
+		},
+	],
+};
+
+if (failure) payload.failed = `${target}: ${failure}`;
+
+if (process.env.BENCH_JSON) {
+	fs.writeFileSync(process.env.BENCH_JSON, `${JSON.stringify(payload, null, '\t')}\n`);
+}
+
+console.log(`\nHydration interactivity — ${target} (production, real Chromium typing)`);
+console.log(`Server-rendered articles: ${CARD_COUNT}; CPU throttling: 1× and 6×`);
+console.log(
+	`Pre-root interaction replay: ${supportsPreRootInteractionReplay ? 'supported' : 'not claimed'}`,
+);
+for (const [scenario, samples] of Object.entries(inputPreservation)) {
+	if (samples.length === 0) continue;
+	console.log(
+		`Pre-hydration input (${scenario}): ${samples.every((sample) => sample.text) ? 'preserved' : 'overwritten'}`,
+	);
+}
+console.log('\nOperation                                  score     median        p95');
+for (const [name, stats] of Object.entries(operations)) {
+	console.log(
+		`${name.padEnd(40)} ${stats.score.toFixed(2).padStart(8)} ${stats.median
+			.toFixed(2)
+			.padStart(10)} ${stats.p95.toFixed(2).padStart(10)} ms`,
+	);
+}
+
+if (failure) {
+	console.error(`\nHydration interactivity correctness gate failed: ${failure}`);
+	process.exitCode = 1;
+}

--- a/benchmarks/news/hydration-interactivity.mjs
+++ b/benchmarks/news/hydration-interactivity.mjs
@@ -562,6 +562,28 @@ const operations = Object.fromEntries(
 	]),
 );
 
+const userExperience = {
+	status:
+		searchSendResults.length === 0
+			? 'not-run'
+			: searchSendResults.every((sample) => sample.deliveredExactlyOnce)
+				? 'pass'
+				: 'fail',
+	samples: searchSendResults.length,
+	replayedSendClicks: searchSendResults.filter((sample) => sample.clickReplayed).length,
+	droppedSendClicks: searchSendResults.filter((sample) => !sample.clickReplayed).length,
+	preservedSearches: searchSendResults.filter((sample) => sample.searchPreserved).length,
+	lostSearches: searchSendResults.filter((sample) => !sample.searchPreserved).length,
+	exactDeliveries: searchSendResults.filter((sample) => sample.deliveredExactlyOnce).length,
+	incorrectSubmissions: searchSendResults.filter(
+		(sample) => sample.clickReplayed && sample.submitted !== PRE_HYDRATION_TEXT,
+	).length,
+	focusOnlyReplays: searchSendResults.filter(
+		(sample) => sample.focusReplayed && !sample.clickReplayed,
+	).length,
+	issues: [...new Set(searchSendResults.flatMap((sample) => sample.issues))],
+};
+
 const payload = {
 	suite: 'hydration-interactivity',
 	iterations,
@@ -579,6 +601,7 @@ const payload = {
 				replayedClicks: replayCounts,
 				replayedFocusEvents: focusReplayCounts,
 				searchSendResults,
+				userExperience,
 				hydrationEventReplay: supportsHydrationEventReplay,
 				preRootInteractionReplay: supportsPreRootInteractionReplay,
 				browser: 'chromium',
@@ -607,15 +630,33 @@ for (const [scenario, samples] of Object.entries(inputPreservation)) {
 		`Pre-hydration input (${scenario}): ${samples.every((sample) => sample.text) ? 'preserved' : 'overwritten'}`,
 	);
 }
-if (searchSendResults.length > 0) {
-	const delivered = searchSendResults.every((sample) => sample.deliveredExactlyOnce);
+if (userExperience.samples > 0) {
+	console.log(`Pre-hydration search-and-send UX: ${userExperience.status.toUpperCase()}`);
 	console.log(
-		`Pre-hydration search-and-send: ${
-			delivered
-				? 'query delivered exactly once'
-				: `correctness issue: ${[...new Set(searchSendResults.flatMap((sample) => sample.issues))].join('; ')}`
-		}`,
+		`  Send clicks replayed: ${userExperience.replayedSendClicks}/${userExperience.samples}`,
 	);
+	console.log(
+		`  Send clicks dropped: ${userExperience.droppedSendClicks}/${userExperience.samples}`,
+	);
+	console.log(
+		`  Search queries preserved: ${userExperience.preservedSearches}/${userExperience.samples}`,
+	);
+	console.log(
+		`  Exact search deliveries: ${userExperience.exactDeliveries}/${userExperience.samples}`,
+	);
+	if (userExperience.incorrectSubmissions > 0) {
+		console.log(
+			`  Replayed Sends with the wrong query: ${userExperience.incorrectSubmissions}/${userExperience.samples}`,
+		);
+	}
+	if (userExperience.focusOnlyReplays > 0) {
+		console.log(
+			`  Focus-only replays without Send: ${userExperience.focusOnlyReplays}/${userExperience.samples}`,
+		);
+	}
+	if (userExperience.issues.length > 0) {
+		console.log(`  UX correctness issues: ${userExperience.issues.join('; ')}`);
+	}
 }
 console.log('\nOperation                                  score     median        p95');
 for (const [name, stats] of Object.entries(operations)) {

--- a/benchmarks/news/hydration-interactivity.mjs
+++ b/benchmarks/news/hydration-interactivity.mjs
@@ -21,6 +21,7 @@ const noBuild = args.includes('--no-build');
 const positional = args.filter((value) => !value.startsWith('--'));
 const target = TARGETS.includes(positional[0]) ? positional.shift() : 'octane-tsrx';
 const supportsPreRootInteractionReplay = target === 'octane-tsrx' || target === 'solid';
+const supportsHydrationEventReplay = supportsPreRootInteractionReplay || target === 'react';
 const iterations = Number.parseInt(positional[0] ?? '5', 10);
 const warmup = 1;
 
@@ -181,13 +182,21 @@ async function openSample({ cpuRate, controlled = false, interaction = false }) 
 	return { clientGate, context, failures, page };
 }
 
-async function releaseHydration(sample) {
+async function releaseHydration(sample, expectedClicks = 0, expectedFocuses = 0) {
 	const releasedAt = await sample.page.evaluate(() => performance.now());
 	sample.clientGate.open();
 	await sample.page.waitForFunction(() => {
 		const state = window.__hydrationInteractivity;
 		return state?.hydratedAt > 0 || Boolean(state?.error);
 	});
+	if (expectedClicks > 0 || expectedFocuses > 0) {
+		await sample.page.waitForFunction(
+			({ clicks, focuses }) =>
+				Number(document.querySelector('#hydration-clicks')?.textContent) === clicks &&
+				Number(document.querySelector('#hydration-focuses')?.textContent) === focuses,
+			{ clicks: expectedClicks, focuses: expectedFocuses },
+		);
+	}
 
 	const snapshot = await sample.page.evaluate(() => {
 		const state = window.__hydrationInteractivity;
@@ -203,6 +212,7 @@ async function releaseHydration(sample) {
 			).join('\u001e'),
 			cardSame: document.querySelector('#hydration-cards > li') === state.originalCard,
 			clicks: Number(document.querySelector('#hydration-clicks')?.textContent),
+			focuses: Number(document.querySelector('#hydration-focuses')?.textContent),
 			error: state.error,
 			focused: document.activeElement === input,
 			hydratedAt: state.hydratedAt,
@@ -212,6 +222,7 @@ async function releaseHydration(sample) {
 			nativeInputCount: state.nativeInputCount,
 			selectionEnd: input?.selectionEnd,
 			selectionStart: input?.selectionStart,
+			submitted: document.querySelector('#hydration-submitted')?.textContent,
 			value: input?.value,
 		};
 	});
@@ -339,16 +350,30 @@ async function runReplaySample() {
 		await button.click();
 		const before = await sample.page.evaluate(() => ({
 			clicks: Number(document.querySelector('#hydration-clicks')?.textContent),
+			focuses: Number(document.querySelector('#hydration-focuses')?.textContent),
 			hydrationCalls: window.__hydrationInteractivity.hydrationCalls,
+			replayRootInitializedAt: window.__hydrationInteractivity.replayRootInitializedAt,
 		}));
 		ensure(before.clicks === 0, 'the delayed client handled a click before hydration');
+		ensure(before.focuses === 0, 'the delayed client handled focus before hydration');
 		ensure(before.hydrationCalls === 0, 'the interaction bypassed the withheld client chunk');
+		if (target === 'react') {
+			ensure(
+				before.replayRootInitializedAt > 0,
+				'React did not install its real selective-hydration replay root',
+			);
+		}
 
-		const hydrated = await releaseHydration(sample);
 		const expectedReplay = supportsPreRootInteractionReplay ? 1 : 0;
+		const expectedFocusReplay = target === 'react' ? 1 : 0;
+		const hydrated = await releaseHydration(sample, expectedReplay, expectedFocusReplay);
 		ensure(
 			hydrated.clicks === expectedReplay,
 			`expected ${expectedReplay} replayed clicks, observed ${hydrated.clicks}`,
+		);
+		ensure(
+			hydrated.focuses === expectedFocusReplay,
+			`expected ${expectedFocusReplay} replayed focus events, observed ${hydrated.focuses}`,
 		);
 		const actionSame = await sample.page.evaluate(
 			() =>
@@ -368,6 +393,106 @@ async function runReplaySample() {
 			hydration: hydrated.hydratedAt - hydrated.releasedAt,
 			interactionToHydration: hydrated.hydratedAt - clickedAt,
 			replayedClicks: expectedReplay,
+			replayedFocusEvents: expectedFocusReplay,
+		};
+	} finally {
+		await closeSample(sample);
+	}
+}
+
+async function runSearchAndSendSample() {
+	const sample = await openSample({ cpuRate: 6, controlled: true, interaction: true });
+	try {
+		const input = sample.page.locator('#hydration-input');
+		const button = sample.page.locator('#hydration-action');
+		await input.click();
+		const typingStartedAt = await sample.page.evaluate(() => {
+			window.__hydrationInteractivity.inputAttemptAt = performance.now();
+			return window.__hydrationInteractivity.inputAttemptAt;
+		});
+		await input.pressSequentially(PRE_HYDRATION_TEXT);
+
+		const typed = await sample.page.evaluate(() => ({
+			completedAt: performance.now(),
+			firstNativeInputAt: window.__hydrationInteractivity.firstNativeInputAt,
+			hydrationCalls: window.__hydrationInteractivity.hydrationCalls,
+			value: document.querySelector('#hydration-input')?.value,
+		}));
+		ensure(typed.value === PRE_HYDRATION_TEXT, 'search typing lost characters before Send');
+		ensure(typed.hydrationCalls === 0, 'search hydrated before the withheld chunk was released');
+		ensure(typed.firstNativeInputAt > 0, 'search typing did not produce native input events');
+
+		const clickedAt = await sample.page.evaluate(() => performance.now());
+		await button.click();
+		const before = await sample.page.evaluate(() => ({
+			clicks: Number(document.querySelector('#hydration-clicks')?.textContent),
+			focuses: Number(document.querySelector('#hydration-focuses')?.textContent),
+			hydrationCalls: window.__hydrationInteractivity.hydrationCalls,
+			replayRootInitializedAt: window.__hydrationInteractivity.replayRootInitializedAt,
+			submitted: document.querySelector('#hydration-submitted')?.textContent,
+			value: document.querySelector('#hydration-input')?.value,
+		}));
+		ensure(before.value === PRE_HYDRATION_TEXT, 'clicking Send discarded the search query');
+		ensure(before.clicks === 0, 'Send executed before the hydration chunk was released');
+		ensure(before.focuses === 0, 'the Send focus executed before the hydration chunk was released');
+		ensure(before.hydrationCalls === 0, 'Send bypassed the withheld hydration chunk');
+		ensure(before.submitted === '', 'the query was submitted before hydration');
+		if (target === 'react') {
+			ensure(
+				before.replayRootInitializedAt > 0,
+				'React did not install its real selective-hydration replay root',
+			);
+		}
+
+		const expectedClicks = supportsPreRootInteractionReplay ? 1 : 0;
+		const expectedFocuses = target === 'react' ? 1 : 0;
+		const hydrated = await releaseHydration(sample, expectedClicks, expectedFocuses);
+		ensure(
+			hydrated.nativeInputCount === PRE_HYDRATION_TEXT.length,
+			`expected ${PRE_HYDRATION_TEXT.length} native search events, received ${hydrated.nativeInputCount}`,
+		);
+		ensure(
+			hydrated.clicks === expectedClicks,
+			`expected ${expectedClicks} replayed Send clicks, observed ${hydrated.clicks}`,
+		);
+		ensure(
+			hydrated.focuses === expectedFocuses,
+			`expected ${expectedFocuses} replayed Send focus events, observed ${hydrated.focuses}`,
+		);
+		const delivery = {
+			clickReplayed: hydrated.clicks === 1,
+			focusReplayed: hydrated.focuses === 1,
+			searchPreserved: hydrated.value === PRE_HYDRATION_TEXT,
+			submitted: hydrated.submitted,
+			deliveredExactlyOnce: hydrated.clicks === 1 && hydrated.submitted === PRE_HYDRATION_TEXT,
+			issues: [],
+		};
+		if (!delivery.clickReplayed) delivery.issues.push('Send click was not replayed');
+		if (!delivery.searchPreserved) delivery.issues.push('Search text was not preserved');
+		if (delivery.clickReplayed && hydrated.submitted !== PRE_HYDRATION_TEXT) {
+			delivery.issues.push('Replayed Send received the wrong search text');
+		}
+		if (target === 'octane-tsrx') {
+			ensure(delivery.deliveredExactlyOnce, 'the pre-hydration search was not sent exactly once');
+			ensure(delivery.searchPreserved, 'hydration overwrote the pre-hydration search');
+		}
+
+		await button.click();
+		await sample.page.waitForFunction(
+			({ clicks, submitted }) =>
+				Number(document.querySelector('#hydration-clicks')?.textContent) === clicks &&
+				document.querySelector('#hydration-submitted')?.textContent === submitted,
+			{ clicks: expectedClicks + 1, submitted: hydrated.value },
+		);
+		ensure(sample.failures.length === 0, `browser errors: ${sample.failures.join('; ')}`);
+
+		return {
+			firstInput: typed.firstNativeInputAt - typingStartedAt,
+			preHydrationTyping: typed.completedAt - typingStartedAt,
+			hydration: hydrated.hydratedAt - hydrated.releasedAt,
+			hydrationWork: hydrated.hydratedAt - hydrated.hydrationStartedAt,
+			interactionToHydration: hydrated.hydratedAt - clickedAt,
+			delivery,
 		};
 	} finally {
 		await closeSample(sample);
@@ -376,7 +501,14 @@ async function runReplaySample() {
 
 function addSamples(operations, prefix, result) {
 	for (const [name, value] of Object.entries(result)) {
-		if (name === 'replayedClicks' || name === 'preservation') continue;
+		if (
+			name === 'delivery' ||
+			name === 'replayedClicks' ||
+			name === 'replayedFocusEvents' ||
+			name === 'preservation'
+		) {
+			continue;
+		}
 		const operation = `${prefix}_${name.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`)}`;
 		(operations[operation] ??= []).push(value);
 	}
@@ -384,6 +516,8 @@ function addSamples(operations, prefix, result) {
 
 const rawOperations = {};
 const replayCounts = [];
+const focusReplayCounts = [];
+const searchSendResults = [];
 const inputPreservation = {
 	uncontrolled_1x: [],
 	uncontrolled_6x: [],
@@ -398,16 +532,20 @@ try {
 		const slowed = await runTypingSample({ cpuRate: 6, controlled: false });
 		const controlled = await runTypingSample({ cpuRate: 6, controlled: true });
 		const replay = await runReplaySample();
+		const searchAndSend = await runSearchAndSendSample();
 
 		if (index >= warmup) {
 			addSamples(rawOperations, 'uncontrolled_1x', plain);
 			addSamples(rawOperations, 'uncontrolled_6x', slowed);
 			addSamples(rawOperations, 'controlled_6x', controlled);
 			addSamples(rawOperations, 'interaction_6x', replay);
+			addSamples(rawOperations, 'search_send_6x', searchAndSend);
 			inputPreservation.uncontrolled_1x.push(plain.preservation);
 			inputPreservation.uncontrolled_6x.push(slowed.preservation);
 			inputPreservation.controlled_6x.push(controlled.preservation);
 			replayCounts.push(replay.replayedClicks);
+			focusReplayCounts.push(replay.replayedFocusEvents);
+			searchSendResults.push(searchAndSend.delivery);
 		}
 	}
 } catch (error) {
@@ -439,6 +577,9 @@ const payload = {
 				preHydrationText: PRE_HYDRATION_TEXT,
 				postHydrationText: POST_HYDRATION_TEXT,
 				replayedClicks: replayCounts,
+				replayedFocusEvents: focusReplayCounts,
+				searchSendResults,
+				hydrationEventReplay: supportsHydrationEventReplay,
 				preRootInteractionReplay: supportsPreRootInteractionReplay,
 				browser: 'chromium',
 			},
@@ -455,12 +596,25 @@ if (process.env.BENCH_JSON) {
 console.log(`\nHydration interactivity — ${target} (production, real Chromium typing)`);
 console.log(`Server-rendered articles: ${CARD_COUNT}; CPU throttling: 1× and 6×`);
 console.log(
+	`Hydration event replay: ${supportsHydrationEventReplay ? 'supported' : 'not claimed'}`,
+);
+console.log(
 	`Pre-root interaction replay: ${supportsPreRootInteractionReplay ? 'supported' : 'not claimed'}`,
 );
 for (const [scenario, samples] of Object.entries(inputPreservation)) {
 	if (samples.length === 0) continue;
 	console.log(
 		`Pre-hydration input (${scenario}): ${samples.every((sample) => sample.text) ? 'preserved' : 'overwritten'}`,
+	);
+}
+if (searchSendResults.length > 0) {
+	const delivered = searchSendResults.every((sample) => sample.deliveredExactlyOnce);
+	console.log(
+		`Pre-hydration search-and-send: ${
+			delivered
+				? 'query delivered exactly once'
+				: `correctness issue: ${[...new Set(searchSendResults.flatMap((sample) => sample.issues))].join('; ')}`
+		}`,
 	);
 }
 console.log('\nOperation                                  score     median        p95');

--- a/benchmarks/news/octane-tsrx/hydration-interactivity.html
+++ b/benchmarks/news/octane-tsrx/hydration-interactivity.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Octane hydration interactivity</title>
+		<!--ssr-head-->
+	</head>
+	<body>
+		<div id="app"><!--ssr-body--></div>
+		<script type="module" src="/src/hydration-interactivity/bootstrap.ts"></script>
+	</body>
+</html>

--- a/benchmarks/news/octane-tsrx/src/hydration-interactivity/App.tsrx
+++ b/benchmarks/news/octane-tsrx/src/hydration-interactivity/App.tsrx
@@ -1,0 +1,51 @@
+import { Hydrate, useState } from 'octane';
+import { interaction } from 'octane/hydration';
+import { CARDS, INITIAL_VALUE } from '../../../../hydration-interactivity/shared.js';
+
+type HydrationBenchmarkProps = {
+	controlled?: boolean;
+	deferred?: boolean;
+};
+
+function Editor(props: HydrationBenchmarkProps) @{
+	const [draft, setDraft] = useState(INITIAL_VALUE);
+	const [clicks, setClicks] = useState(0);
+	const onInput = (event: Event) => setDraft((event.currentTarget as HTMLInputElement).value);
+
+	<section class="hydration-editor">
+		<label for="hydration-input">{'Your draft'}</label>
+		@if (props.controlled) {
+			<input id="hydration-input" autocomplete="off" value={draft} onInput={onInput} />
+		} @else {
+			<input id="hydration-input" autocomplete="off" onInput={onInput} />
+		}
+		<output id="hydration-output">{draft as string}</output>
+		<button
+			id="hydration-action"
+			type="button"
+			onClick={() => setClicks(clicks + 1)}
+		>{'Record interaction'}</button>
+		<output id="hydration-clicks">{String(clicks) as string}</output>
+	</section>
+}
+
+export function App(props: HydrationBenchmarkProps) @{
+	<main class="hydration-page">
+		<h1>{'Hydration interactivity benchmark'}</h1>
+		@if (props.deferred) {
+			<Hydrate when={interaction()} split={false}>
+				<Editor controlled={props.controlled} />
+			</Hydrate>
+		} @else {
+			<Editor controlled={props.controlled} />
+		}
+		<ul id="hydration-cards">
+			@for (const card of CARDS; key card.id) {
+				<li class="hydration-card" data-card-id={card.id}>
+					<h2>{card.title as string}</h2>
+					<p>{card.description as string}</p>
+				</li>
+			}
+		</ul>
+	</main>
+}

--- a/benchmarks/news/octane-tsrx/src/hydration-interactivity/App.tsrx
+++ b/benchmarks/news/octane-tsrx/src/hydration-interactivity/App.tsrx
@@ -10,22 +10,40 @@ type HydrationBenchmarkProps = {
 function Editor(props: HydrationBenchmarkProps) @{
 	const [draft, setDraft] = useState(INITIAL_VALUE);
 	const [clicks, setClicks] = useState(0);
+	const [focuses, setFocuses] = useState(0);
+	const [submitted, setSubmitted] = useState(INITIAL_VALUE);
 	const onInput = (event: Event) => setDraft((event.currentTarget as HTMLInputElement).value);
+	const onSend = () => {
+		const input = document.querySelector<HTMLInputElement>('#hydration-input');
+		const query = input?.value ?? INITIAL_VALUE;
+		setDraft(query);
+		setSubmitted(query);
+		setClicks(clicks + 1);
+	};
 
 	<section class="hydration-editor">
-		<label for="hydration-input">{'Your draft'}</label>
+		<label for="hydration-input">{'Search query'}</label>
 		@if (props.controlled) {
-			<input id="hydration-input" autocomplete="off" value={draft} onInput={onInput} />
+			<input
+				id="hydration-input"
+				type="search"
+				autocomplete="off"
+				value={draft}
+				onInput={onInput}
+			/>
 		} @else {
-			<input id="hydration-input" autocomplete="off" onInput={onInput} />
+			<input id="hydration-input" type="search" autocomplete="off" onInput={onInput} />
 		}
 		<output id="hydration-output">{draft as string}</output>
 		<button
 			id="hydration-action"
 			type="button"
-			onClick={() => setClicks(clicks + 1)}
-		>{'Record interaction'}</button>
+			onClick={onSend}
+			onFocus={() => setFocuses(focuses + 1)}
+		>{'Send search'}</button>
 		<output id="hydration-clicks">{String(clicks) as string}</output>
+		<output id="hydration-focuses">{String(focuses) as string}</output>
+		<output id="hydration-submitted">{submitted as string}</output>
 	</section>
 }
 

--- a/benchmarks/news/octane-tsrx/src/hydration-interactivity/bootstrap.ts
+++ b/benchmarks/news/octane-tsrx/src/hydration-interactivity/bootstrap.ts
@@ -1,0 +1,7 @@
+import { initializeHydrationEventCapture } from 'octane/hydration';
+import { startHydrationBootstrap } from '../../../../hydration-interactivity/shared.js';
+
+startHydrationBootstrap(
+	() => import('./hydration-client.js'),
+	() => initializeHydrationEventCapture(document),
+);

--- a/benchmarks/news/octane-tsrx/src/hydration-interactivity/hydration-client.ts
+++ b/benchmarks/news/octane-tsrx/src/hydration-interactivity/hydration-client.ts
@@ -1,0 +1,14 @@
+import { flushSync, hydrateRoot } from 'octane';
+import { completeHydration, hydrationProps } from '../../../../hydration-interactivity/shared.js';
+import { App } from './App.tsrx';
+
+export function hydrateBenchmark() {
+	const container = document.getElementById('app');
+	if (!container) throw new Error('Missing hydration benchmark root');
+
+	return completeHydration(() => {
+		const root = hydrateRoot(container, App, hydrationProps());
+		flushSync(() => {});
+		return root;
+	});
+}

--- a/benchmarks/news/octane-tsrx/src/hydration-interactivity/hydration-server.ts
+++ b/benchmarks/news/octane-tsrx/src/hydration-interactivity/hydration-server.ts
@@ -1,0 +1,12 @@
+import { renderToString } from 'octane/server';
+import { App } from './App.tsrx';
+
+type HydrationBenchmarkProps = {
+	controlled?: boolean;
+	deferred?: boolean;
+};
+
+export async function renderApp(props: HydrationBenchmarkProps = {}) {
+	const { html, css } = renderToString(App, props);
+	return { head: '', body: html, css };
+}

--- a/benchmarks/news/preact/hydration-interactivity.html
+++ b/benchmarks/news/preact/hydration-interactivity.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Preact hydration interactivity</title>
+		<!--ssr-head-->
+	</head>
+	<body>
+		<div id="app"><!--ssr-body--></div>
+		<script type="module" src="/src/hydration-interactivity/bootstrap.ts"></script>
+	</body>
+</html>

--- a/benchmarks/news/preact/src/hydration-interactivity/App.jsx
+++ b/benchmarks/news/preact/src/hydration-interactivity/App.jsx
@@ -1,0 +1,35 @@
+import { useState } from 'preact/hooks';
+import { CARDS, INITIAL_VALUE } from '../../../../hydration-interactivity/shared.js';
+
+export function App({ controlled = false }) {
+	const [draft, setDraft] = useState(INITIAL_VALUE);
+	const [clicks, setClicks] = useState(0);
+	const onInput = (event) => setDraft(event.currentTarget.value);
+
+	return (
+		<main class="hydration-page">
+			<h1>Hydration interactivity benchmark</h1>
+			<section class="hydration-editor">
+				<label for="hydration-input">Your draft</label>
+				{controlled ? (
+					<input id="hydration-input" autocomplete="off" value={draft} onInput={onInput} />
+				) : (
+					<input id="hydration-input" autocomplete="off" onInput={onInput} />
+				)}
+				<output id="hydration-output">{draft}</output>
+				<button id="hydration-action" type="button" onClick={() => setClicks(clicks + 1)}>
+					Record interaction
+				</button>
+				<output id="hydration-clicks">{clicks}</output>
+			</section>
+			<ul id="hydration-cards">
+				{CARDS.map((card) => (
+					<li class="hydration-card" data-card-id={card.id} key={card.id}>
+						<h2>{card.title}</h2>
+						<p>{card.description}</p>
+					</li>
+				))}
+			</ul>
+		</main>
+	);
+}

--- a/benchmarks/news/preact/src/hydration-interactivity/App.jsx
+++ b/benchmarks/news/preact/src/hydration-interactivity/App.jsx
@@ -4,23 +4,45 @@ import { CARDS, INITIAL_VALUE } from '../../../../hydration-interactivity/shared
 export function App({ controlled = false }) {
 	const [draft, setDraft] = useState(INITIAL_VALUE);
 	const [clicks, setClicks] = useState(0);
+	const [focuses, setFocuses] = useState(0);
+	const [submitted, setSubmitted] = useState(INITIAL_VALUE);
 	const onInput = (event) => setDraft(event.currentTarget.value);
+	const onSend = () => {
+		const input = document.querySelector('#hydration-input');
+		const query = input?.value ?? INITIAL_VALUE;
+		setDraft(query);
+		setSubmitted(query);
+		setClicks((count) => count + 1);
+	};
 
 	return (
 		<main class="hydration-page">
 			<h1>Hydration interactivity benchmark</h1>
 			<section class="hydration-editor">
-				<label for="hydration-input">Your draft</label>
+				<label for="hydration-input">Search query</label>
 				{controlled ? (
-					<input id="hydration-input" autocomplete="off" value={draft} onInput={onInput} />
+					<input
+						id="hydration-input"
+						type="search"
+						autocomplete="off"
+						value={draft}
+						onInput={onInput}
+					/>
 				) : (
-					<input id="hydration-input" autocomplete="off" onInput={onInput} />
+					<input id="hydration-input" type="search" autocomplete="off" onInput={onInput} />
 				)}
 				<output id="hydration-output">{draft}</output>
-				<button id="hydration-action" type="button" onClick={() => setClicks(clicks + 1)}>
-					Record interaction
+				<button
+					id="hydration-action"
+					type="button"
+					onClick={onSend}
+					onFocus={() => setFocuses((count) => count + 1)}
+				>
+					Send search
 				</button>
 				<output id="hydration-clicks">{clicks}</output>
+				<output id="hydration-focuses">{focuses}</output>
+				<output id="hydration-submitted">{submitted}</output>
 			</section>
 			<ul id="hydration-cards">
 				{CARDS.map((card) => (

--- a/benchmarks/news/preact/src/hydration-interactivity/bootstrap.ts
+++ b/benchmarks/news/preact/src/hydration-interactivity/bootstrap.ts
@@ -1,0 +1,3 @@
+import { startHydrationBootstrap } from '../../../../hydration-interactivity/shared.js';
+
+startHydrationBootstrap(() => import('./hydration-client.js'));

--- a/benchmarks/news/preact/src/hydration-interactivity/hydration-client.ts
+++ b/benchmarks/news/preact/src/hydration-interactivity/hydration-client.ts
@@ -1,0 +1,13 @@
+import { createElement, hydrate } from 'preact';
+import { flushSync } from 'preact/compat';
+import { completeHydration, hydrationProps } from '../../../../hydration-interactivity/shared.js';
+import { App } from './App.jsx';
+
+export function hydrateBenchmark() {
+	const container = document.getElementById('app');
+	if (!container) throw new Error('Missing hydration benchmark root');
+
+	return completeHydration(() =>
+		flushSync(() => hydrate(createElement(App, hydrationProps()), container)),
+	);
+}

--- a/benchmarks/news/preact/src/hydration-interactivity/hydration-server.ts
+++ b/benchmarks/news/preact/src/hydration-interactivity/hydration-server.ts
@@ -1,0 +1,12 @@
+import { createElement } from 'preact';
+import { renderToString } from 'preact-render-to-string';
+import { App } from './App.jsx';
+
+type HydrationBenchmarkProps = {
+	controlled?: boolean;
+	deferred?: boolean;
+};
+
+export async function renderApp(props: HydrationBenchmarkProps = {}) {
+	return { head: '', body: renderToString(createElement(App, props)), css: '' };
+}

--- a/benchmarks/news/react/hydration-interactivity.html
+++ b/benchmarks/news/react/hydration-interactivity.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>React hydration interactivity</title>
+		<!--ssr-head-->
+	</head>
+	<body>
+		<div id="app"><!--ssr-body--></div>
+		<script type="module" src="/src/hydration-interactivity/bootstrap.ts"></script>
+	</body>
+</html>

--- a/benchmarks/news/react/src/hydration-interactivity/App.tsx
+++ b/benchmarks/news/react/src/hydration-interactivity/App.tsx
@@ -1,0 +1,40 @@
+import { useState, type FormEvent } from 'react';
+import { CARDS, INITIAL_VALUE } from '../../../../hydration-interactivity/shared.js';
+
+type HydrationBenchmarkProps = {
+	controlled?: boolean;
+	deferred?: boolean;
+};
+
+export function App({ controlled = false }: HydrationBenchmarkProps) {
+	const [draft, setDraft] = useState(INITIAL_VALUE);
+	const [clicks, setClicks] = useState(0);
+	const onInput = (event: FormEvent<HTMLInputElement>) => setDraft(event.currentTarget.value);
+
+	return (
+		<main className="hydration-page">
+			<h1>Hydration interactivity benchmark</h1>
+			<section className="hydration-editor">
+				<label htmlFor="hydration-input">Your draft</label>
+				{controlled ? (
+					<input id="hydration-input" autoComplete="off" value={draft} onInput={onInput} />
+				) : (
+					<input id="hydration-input" autoComplete="off" onInput={onInput} />
+				)}
+				<output id="hydration-output">{draft}</output>
+				<button id="hydration-action" type="button" onClick={() => setClicks(clicks + 1)}>
+					Record interaction
+				</button>
+				<output id="hydration-clicks">{clicks}</output>
+			</section>
+			<ul id="hydration-cards">
+				{CARDS.map((card) => (
+					<li className="hydration-card" data-card-id={card.id} key={card.id}>
+						<h2>{card.title}</h2>
+						<p>{card.description}</p>
+					</li>
+				))}
+			</ul>
+		</main>
+	);
+}

--- a/benchmarks/news/react/src/hydration-interactivity/App.tsx
+++ b/benchmarks/news/react/src/hydration-interactivity/App.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent } from 'react';
+import { lazy, Suspense, useState, type FormEvent } from 'react';
 import { CARDS, INITIAL_VALUE } from '../../../../hydration-interactivity/shared.js';
 
 type HydrationBenchmarkProps = {
@@ -6,27 +6,69 @@ type HydrationBenchmarkProps = {
 	deferred?: boolean;
 };
 
-export function App({ controlled = false }: HydrationBenchmarkProps) {
+const ReplayEditor = lazy(() =>
+	import('./hydration-client.js').then((client) => ({ default: client.ReplayEditor })),
+);
+
+export function Editor({ controlled = false }: HydrationBenchmarkProps) {
 	const [draft, setDraft] = useState(INITIAL_VALUE);
 	const [clicks, setClicks] = useState(0);
+	const [focuses, setFocuses] = useState(0);
+	const [submitted, setSubmitted] = useState(INITIAL_VALUE);
 	const onInput = (event: FormEvent<HTMLInputElement>) => setDraft(event.currentTarget.value);
+	const onSend = () => {
+		const input = document.querySelector<HTMLInputElement>('#hydration-input');
+		const query = input?.value ?? INITIAL_VALUE;
+		setDraft(query);
+		setSubmitted(query);
+		setClicks((count) => count + 1);
+	};
 
+	return (
+		<section className="hydration-editor">
+			<label htmlFor="hydration-input">Search query</label>
+			{controlled ? (
+				<input
+					id="hydration-input"
+					type="search"
+					autoComplete="off"
+					value={draft}
+					onInput={onInput}
+				/>
+			) : (
+				<input id="hydration-input" type="search" autoComplete="off" onInput={onInput} />
+			)}
+			<output id="hydration-output">{draft}</output>
+			<button
+				id="hydration-action"
+				type="button"
+				onClick={onSend}
+				onFocus={() => setFocuses((count) => count + 1)}
+			>
+				Send search
+			</button>
+			<output id="hydration-clicks">{clicks}</output>
+			<output id="hydration-focuses">{focuses}</output>
+			<output id="hydration-submitted">{submitted}</output>
+		</section>
+	);
+}
+
+export function App({ controlled = false, deferred = false }: HydrationBenchmarkProps) {
 	return (
 		<main className="hydration-page">
 			<h1>Hydration interactivity benchmark</h1>
-			<section className="hydration-editor">
-				<label htmlFor="hydration-input">Your draft</label>
-				{controlled ? (
-					<input id="hydration-input" autoComplete="off" value={draft} onInput={onInput} />
-				) : (
-					<input id="hydration-input" autoComplete="off" onInput={onInput} />
-				)}
-				<output id="hydration-output">{draft}</output>
-				<button id="hydration-action" type="button" onClick={() => setClicks(clicks + 1)}>
-					Record interaction
-				</button>
-				<output id="hydration-clicks">{clicks}</output>
-			</section>
+			{deferred ? (
+				<Suspense fallback={null}>
+					{typeof window === 'undefined' ? (
+						<Editor controlled={controlled} />
+					) : (
+						<ReplayEditor controlled={controlled} />
+					)}
+				</Suspense>
+			) : (
+				<Editor controlled={controlled} />
+			)}
 			<ul id="hydration-cards">
 				{CARDS.map((card) => (
 					<li className="hydration-card" data-card-id={card.id} key={card.id}>

--- a/benchmarks/news/react/src/hydration-interactivity/bootstrap.ts
+++ b/benchmarks/news/react/src/hydration-interactivity/bootstrap.ts
@@ -1,0 +1,3 @@
+import { startHydrationBootstrap } from '../../../../hydration-interactivity/shared.js';
+
+startHydrationBootstrap(() => import('./hydration-client.js'));

--- a/benchmarks/news/react/src/hydration-interactivity/bootstrap.ts
+++ b/benchmarks/news/react/src/hydration-interactivity/bootstrap.ts
@@ -1,3 +1,13 @@
-import { startHydrationBootstrap } from '../../../../hydration-interactivity/shared.js';
+import {
+	hydrationProps,
+	startHydrationBootstrap,
+} from '../../../../hydration-interactivity/shared.js';
 
-startHydrationBootstrap(() => import('./hydration-client.js'));
+startHydrationBootstrap(async () => {
+	if (hydrationProps().deferred) {
+		const { initializeReactReplayRoot } = await import('./replay-root.js');
+		initializeReactReplayRoot();
+	}
+
+	return import('./hydration-client.js');
+});

--- a/benchmarks/news/react/src/hydration-interactivity/hydration-client.ts
+++ b/benchmarks/news/react/src/hydration-interactivity/hydration-client.ts
@@ -1,0 +1,18 @@
+import { createElement } from 'react';
+import { flushSync } from 'react-dom';
+import { hydrateRoot } from 'react-dom/client';
+import { completeHydration, hydrationProps } from '../../../../hydration-interactivity/shared.js';
+import { App } from './App.js';
+
+export function hydrateBenchmark() {
+	const container = document.getElementById('app');
+	if (!container) throw new Error('Missing hydration benchmark root');
+
+	return completeHydration(() => {
+		let root: ReturnType<typeof hydrateRoot> | undefined;
+		flushSync(() => {
+			root = hydrateRoot(container, createElement(App, hydrationProps()));
+		});
+		return root;
+	});
+}

--- a/benchmarks/news/react/src/hydration-interactivity/hydration-client.ts
+++ b/benchmarks/news/react/src/hydration-interactivity/hydration-client.ts
@@ -2,16 +2,19 @@ import { createElement } from 'react';
 import { flushSync } from 'react-dom';
 import { hydrateRoot } from 'react-dom/client';
 import { completeHydration, hydrationProps } from '../../../../hydration-interactivity/shared.js';
-import { App } from './App.js';
+import { App, Editor } from './App.js';
+import { getReactReplayRoot } from './replay-root.js';
+
+export { Editor as ReplayEditor };
 
 export function hydrateBenchmark() {
 	const container = document.getElementById('app');
 	if (!container) throw new Error('Missing hydration benchmark root');
 
 	return completeHydration(() => {
-		let root: ReturnType<typeof hydrateRoot> | undefined;
+		let root = getReactReplayRoot();
 		flushSync(() => {
-			root = hydrateRoot(container, createElement(App, hydrationProps()));
+			root ??= hydrateRoot(container, createElement(App, hydrationProps()));
 		});
 		return root;
 	});

--- a/benchmarks/news/react/src/hydration-interactivity/hydration-server.ts
+++ b/benchmarks/news/react/src/hydration-interactivity/hydration-server.ts
@@ -1,0 +1,12 @@
+import { createElement } from 'react';
+import { renderToString } from 'react-dom/server';
+import { App } from './App.js';
+
+type HydrationBenchmarkProps = {
+	controlled?: boolean;
+	deferred?: boolean;
+};
+
+export async function renderApp(props: HydrationBenchmarkProps = {}) {
+	return { head: '', body: renderToString(createElement(App, props)), css: '' };
+}

--- a/benchmarks/news/react/src/hydration-interactivity/replay-root.ts
+++ b/benchmarks/news/react/src/hydration-interactivity/replay-root.ts
@@ -1,0 +1,22 @@
+import { createElement } from 'react';
+import { hydrateRoot } from 'react-dom/client';
+import { hydrationProps } from '../../../../hydration-interactivity/shared.js';
+import { App } from './App.js';
+
+let replayRoot: ReturnType<typeof hydrateRoot> | undefined;
+
+export function initializeReactReplayRoot() {
+	const container = document.getElementById('app');
+	const status = window.__hydrationInteractivity;
+	if (!container) throw new Error('Missing hydration benchmark root');
+	if (!status) throw new Error('Hydration benchmark bootstrap did not run');
+	if (replayRoot) throw new Error('React replay root was initialized more than once');
+
+	replayRoot = hydrateRoot(container, createElement(App, hydrationProps()));
+	status.replayRootInitializedAt = performance.now();
+	return replayRoot;
+}
+
+export function getReactReplayRoot() {
+	return replayRoot;
+}

--- a/benchmarks/news/solid/hydration-interactivity.html
+++ b/benchmarks/news/solid/hydration-interactivity.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Solid 2 hydration interactivity</title>
+		<!--ssr-head-->
+	</head>
+	<body>
+		<div id="app"><!--ssr-body--></div>
+		<script type="module" src="/src/hydration-interactivity/bootstrap.ts"></script>
+	</body>
+</html>

--- a/benchmarks/news/solid/src/hydration-interactivity/App.tsrx
+++ b/benchmarks/news/solid/src/hydration-interactivity/App.tsrx
@@ -9,24 +9,42 @@ type HydrationBenchmarkProps = {
 export function App(props: HydrationBenchmarkProps) @{
 	const [draft, setDraft] = createSignal(INITIAL_VALUE);
 	const [clicks, setClicks] = createSignal(0);
+	const [focuses, setFocuses] = createSignal(0);
+	const [submitted, setSubmitted] = createSignal(INITIAL_VALUE);
 	const onInput = (event: Event) => setDraft((event.currentTarget as HTMLInputElement).value);
+	const onSend = () => {
+		const input = document.querySelector<HTMLInputElement>('#hydration-input');
+		const query = input?.value ?? INITIAL_VALUE;
+		setDraft(query);
+		setSubmitted(query);
+		setClicks(clicks() + 1);
+	};
 
 	<main class="hydration-page">
 		<h1>{'Hydration interactivity benchmark'}</h1>
 		<section class="hydration-editor">
-			<label for="hydration-input">{'Your draft'}</label>
+			<label for="hydration-input">{'Search query'}</label>
 			@if (props.controlled) {
-				<input id="hydration-input" autocomplete="off" value={draft()} onInput={onInput} />
+				<input
+					id="hydration-input"
+					type="search"
+					autocomplete="off"
+					value={draft()}
+					onInput={onInput}
+				/>
 			} @else {
-				<input id="hydration-input" autocomplete="off" onInput={onInput} />
+				<input id="hydration-input" type="search" autocomplete="off" onInput={onInput} />
 			}
 			<output id="hydration-output">{draft()}</output>
 			<button
 				id="hydration-action"
 				type="button"
-				onClick={() => setClicks(clicks() + 1)}
-			>{'Record interaction'}</button>
+				onClick={onSend}
+				onFocus={() => setFocuses(focuses() + 1)}
+			>{'Send search'}</button>
 			<output id="hydration-clicks">{String(clicks())}</output>
+			<output id="hydration-focuses">{String(focuses())}</output>
+			<output id="hydration-submitted">{submitted()}</output>
 		</section>
 		<ul id="hydration-cards">
 			@for (const card of CARDS) {

--- a/benchmarks/news/solid/src/hydration-interactivity/App.tsrx
+++ b/benchmarks/news/solid/src/hydration-interactivity/App.tsrx
@@ -1,0 +1,40 @@
+import { createSignal } from 'solid-js';
+import { CARDS, INITIAL_VALUE } from '../../../../hydration-interactivity/shared.js';
+
+type HydrationBenchmarkProps = {
+	controlled?: boolean;
+	deferred?: boolean;
+};
+
+export function App(props: HydrationBenchmarkProps) @{
+	const [draft, setDraft] = createSignal(INITIAL_VALUE);
+	const [clicks, setClicks] = createSignal(0);
+	const onInput = (event: Event) => setDraft((event.currentTarget as HTMLInputElement).value);
+
+	<main class="hydration-page">
+		<h1>{'Hydration interactivity benchmark'}</h1>
+		<section class="hydration-editor">
+			<label for="hydration-input">{'Your draft'}</label>
+			@if (props.controlled) {
+				<input id="hydration-input" autocomplete="off" value={draft()} onInput={onInput} />
+			} @else {
+				<input id="hydration-input" autocomplete="off" onInput={onInput} />
+			}
+			<output id="hydration-output">{draft()}</output>
+			<button
+				id="hydration-action"
+				type="button"
+				onClick={() => setClicks(clicks() + 1)}
+			>{'Record interaction'}</button>
+			<output id="hydration-clicks">{String(clicks())}</output>
+		</section>
+		<ul id="hydration-cards">
+			@for (const card of CARDS) {
+				<li class="hydration-card" data-card-id={card.id}>
+					<h2>{card.title}</h2>
+					<p>{card.description}</p>
+				</li>
+			}
+		</ul>
+	</main>
+}

--- a/benchmarks/news/solid/src/hydration-interactivity/bootstrap.ts
+++ b/benchmarks/news/solid/src/hydration-interactivity/bootstrap.ts
@@ -1,0 +1,3 @@
+import { startHydrationBootstrap } from '../../../../hydration-interactivity/shared.js';
+
+startHydrationBootstrap(() => import('./hydration-client.js'));

--- a/benchmarks/news/solid/src/hydration-interactivity/hydration-client.ts
+++ b/benchmarks/news/solid/src/hydration-interactivity/hydration-client.ts
@@ -1,0 +1,10 @@
+import { hydrate } from '@solidjs/web';
+import { completeHydration, hydrationProps } from '../../../../hydration-interactivity/shared.js';
+import { App } from './App.tsrx';
+
+export function hydrateBenchmark() {
+	const container = document.getElementById('app');
+	if (!container) throw new Error('Missing hydration benchmark root');
+
+	return completeHydration(() => hydrate(() => App(hydrationProps()), container));
+}

--- a/benchmarks/news/solid/src/hydration-interactivity/hydration-server.ts
+++ b/benchmarks/news/solid/src/hydration-interactivity/hydration-server.ts
@@ -1,0 +1,15 @@
+import { generateHydrationScript, renderToString } from '@solidjs/web';
+import { App } from './App.tsrx';
+
+type HydrationBenchmarkProps = {
+	controlled?: boolean;
+	deferred?: boolean;
+};
+
+export async function renderApp(props: HydrationBenchmarkProps = {}) {
+	return {
+		head: generateHydrationScript(),
+		body: renderToString(() => App(props)),
+		css: '',
+	};
+}

--- a/benchmarks/news/svelte/hydration-interactivity.html
+++ b/benchmarks/news/svelte/hydration-interactivity.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Svelte hydration interactivity</title>
+		<!--ssr-head-->
+	</head>
+	<body>
+		<div id="app"><!--ssr-body--></div>
+		<script type="module" src="/src/hydration-interactivity/bootstrap.ts"></script>
+	</body>
+</html>

--- a/benchmarks/news/svelte/src/hydration-interactivity/App.svelte
+++ b/benchmarks/news/svelte/src/hydration-interactivity/App.svelte
@@ -4,26 +4,44 @@
 	let { controlled = false } = $props();
 	let draft = $state(INITIAL_VALUE);
 	let clicks = $state(0);
+	let focuses = $state(0);
+	let submitted = $state(INITIAL_VALUE);
 
 	function onInput(event) {
 		draft = event.currentTarget.value;
+	}
+
+	function onSend() {
+		const input = document.querySelector('#hydration-input');
+		const query = input?.value ?? INITIAL_VALUE;
+		draft = query;
+		submitted = query;
+		clicks++;
 	}
 </script>
 
 <main class="hydration-page">
 	<h1>Hydration interactivity benchmark</h1>
 	<section class="hydration-editor">
-		<label for="hydration-input">Your draft</label>
+		<label for="hydration-input">Search query</label>
 		{#if controlled}
-			<input id="hydration-input" autocomplete="off" value={draft} oninput={onInput} />
+			<input
+				id="hydration-input"
+				type="search"
+				autocomplete="off"
+				value={draft}
+				oninput={onInput}
+			/>
 		{:else}
-			<input id="hydration-input" autocomplete="off" oninput={onInput} />
+			<input id="hydration-input" type="search" autocomplete="off" oninput={onInput} />
 		{/if}
 		<output id="hydration-output">{draft}</output>
-		<button id="hydration-action" type="button" onclick={() => clicks++}>
-			Record interaction
+		<button id="hydration-action" type="button" onclick={onSend} onfocus={() => focuses++}>
+			Send search
 		</button>
 		<output id="hydration-clicks">{clicks}</output>
+		<output id="hydration-focuses">{focuses}</output>
+		<output id="hydration-submitted">{submitted}</output>
 	</section>
 	<ul id="hydration-cards">
 		{#each CARDS as card (card.id)}

--- a/benchmarks/news/svelte/src/hydration-interactivity/App.svelte
+++ b/benchmarks/news/svelte/src/hydration-interactivity/App.svelte
@@ -1,0 +1,36 @@
+<script>
+	import { CARDS, INITIAL_VALUE } from '../../../../hydration-interactivity/shared.js';
+
+	let { controlled = false } = $props();
+	let draft = $state(INITIAL_VALUE);
+	let clicks = $state(0);
+
+	function onInput(event) {
+		draft = event.currentTarget.value;
+	}
+</script>
+
+<main class="hydration-page">
+	<h1>Hydration interactivity benchmark</h1>
+	<section class="hydration-editor">
+		<label for="hydration-input">Your draft</label>
+		{#if controlled}
+			<input id="hydration-input" autocomplete="off" value={draft} oninput={onInput} />
+		{:else}
+			<input id="hydration-input" autocomplete="off" oninput={onInput} />
+		{/if}
+		<output id="hydration-output">{draft}</output>
+		<button id="hydration-action" type="button" onclick={() => clicks++}>
+			Record interaction
+		</button>
+		<output id="hydration-clicks">{clicks}</output>
+	</section>
+	<ul id="hydration-cards">
+		{#each CARDS as card (card.id)}
+			<li class="hydration-card" data-card-id={card.id}>
+				<h2>{card.title}</h2>
+				<p>{card.description}</p>
+			</li>
+		{/each}
+	</ul>
+</main>

--- a/benchmarks/news/svelte/src/hydration-interactivity/bootstrap.ts
+++ b/benchmarks/news/svelte/src/hydration-interactivity/bootstrap.ts
@@ -1,0 +1,3 @@
+import { startHydrationBootstrap } from '../../../../hydration-interactivity/shared.js';
+
+startHydrationBootstrap(() => import('./hydration-client.js'));

--- a/benchmarks/news/svelte/src/hydration-interactivity/hydration-client.ts
+++ b/benchmarks/news/svelte/src/hydration-interactivity/hydration-client.ts
@@ -1,0 +1,16 @@
+import { flushSync, hydrate } from 'svelte';
+import { completeHydration, hydrationProps } from '../../../../hydration-interactivity/shared.js';
+import App from './App.svelte';
+
+export function hydrateBenchmark() {
+	const container = document.getElementById('app');
+	if (!container) throw new Error('Missing hydration benchmark root');
+
+	return completeHydration(() => {
+		let root: ReturnType<typeof hydrate> | undefined;
+		flushSync(() => {
+			root = hydrate(App, { target: container, props: hydrationProps(), recover: false });
+		});
+		return root;
+	});
+}

--- a/benchmarks/news/svelte/src/hydration-interactivity/hydration-server.ts
+++ b/benchmarks/news/svelte/src/hydration-interactivity/hydration-server.ts
@@ -1,0 +1,12 @@
+import { render } from 'svelte/server';
+import App from './App.svelte';
+
+type HydrationBenchmarkProps = {
+	controlled?: boolean;
+	deferred?: boolean;
+};
+
+export async function renderApp(props: HydrationBenchmarkProps = {}) {
+	const { body, head } = render(App, { props });
+	return { head, body, css: '' };
+}

--- a/benchmarks/news/vue-vapor/hydration-interactivity.html
+++ b/benchmarks/news/vue-vapor/hydration-interactivity.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Vue Vapor hydration interactivity</title>
+		<!--ssr-head-->
+	</head>
+	<body>
+		<div id="app"><!--ssr-body--></div>
+		<script type="module" src="/src/hydration-interactivity/bootstrap.ts"></script>
+	</body>
+</html>

--- a/benchmarks/news/vue-vapor/src/hydration-interactivity/App.vue
+++ b/benchmarks/news/vue-vapor/src/hydration-interactivity/App.vue
@@ -1,0 +1,42 @@
+<script setup vapor lang="ts">
+import { shallowRef } from 'vue';
+import { CARDS, INITIAL_VALUE } from '../../../../hydration-interactivity/shared.js';
+
+const props = defineProps<{
+	controlled?: boolean;
+	deferred?: boolean;
+}>();
+
+const draft = shallowRef(INITIAL_VALUE);
+const clicks = shallowRef(0);
+
+function onInput(event: Event) {
+	draft.value = (event.currentTarget as HTMLInputElement).value;
+}
+</script>
+
+<template>
+	<main class="hydration-page">
+		<h1>Hydration interactivity benchmark</h1>
+		<section class="hydration-editor">
+			<label for="hydration-input">Your draft</label>
+			<input
+				v-if="props.controlled"
+				id="hydration-input"
+				autocomplete="off"
+				:value="draft"
+				@input="onInput"
+			/>
+			<input v-else id="hydration-input" autocomplete="off" @input="onInput" />
+			<output id="hydration-output">{{ draft }}</output>
+			<button id="hydration-action" type="button" @click="clicks++">Record interaction</button>
+			<output id="hydration-clicks">{{ clicks }}</output>
+		</section>
+		<ul id="hydration-cards">
+			<li v-for="card of CARDS" :key="card.id" class="hydration-card" :data-card-id="card.id">
+				<h2>{{ card.title }}</h2>
+				<p>{{ card.description }}</p>
+			</li>
+		</ul>
+	</main>
+</template>

--- a/benchmarks/news/vue-vapor/src/hydration-interactivity/App.vue
+++ b/benchmarks/news/vue-vapor/src/hydration-interactivity/App.vue
@@ -9,9 +9,19 @@ const props = defineProps<{
 
 const draft = shallowRef(INITIAL_VALUE);
 const clicks = shallowRef(0);
+const focuses = shallowRef(0);
+const submitted = shallowRef(INITIAL_VALUE);
 
 function onInput(event: Event) {
 	draft.value = (event.currentTarget as HTMLInputElement).value;
+}
+
+function onSend() {
+	const input = document.querySelector<HTMLInputElement>('#hydration-input');
+	const query = input?.value ?? INITIAL_VALUE;
+	draft.value = query;
+	submitted.value = query;
+	clicks.value++;
 }
 </script>
 
@@ -19,18 +29,23 @@ function onInput(event: Event) {
 	<main class="hydration-page">
 		<h1>Hydration interactivity benchmark</h1>
 		<section class="hydration-editor">
-			<label for="hydration-input">Your draft</label>
+			<label for="hydration-input">Search query</label>
 			<input
 				v-if="props.controlled"
 				id="hydration-input"
+				type="search"
 				autocomplete="off"
 				:value="draft"
 				@input="onInput"
 			/>
-			<input v-else id="hydration-input" autocomplete="off" @input="onInput" />
+			<input v-else id="hydration-input" type="search" autocomplete="off" @input="onInput" />
 			<output id="hydration-output">{{ draft }}</output>
-			<button id="hydration-action" type="button" @click="clicks++">Record interaction</button>
+			<button id="hydration-action" type="button" @click="onSend" @focus="focuses++">
+				Send search
+			</button>
 			<output id="hydration-clicks">{{ clicks }}</output>
+			<output id="hydration-focuses">{{ focuses }}</output>
+			<output id="hydration-submitted">{{ submitted }}</output>
 		</section>
 		<ul id="hydration-cards">
 			<li v-for="card of CARDS" :key="card.id" class="hydration-card" :data-card-id="card.id">

--- a/benchmarks/news/vue-vapor/src/hydration-interactivity/bootstrap.ts
+++ b/benchmarks/news/vue-vapor/src/hydration-interactivity/bootstrap.ts
@@ -1,0 +1,3 @@
+import { startHydrationBootstrap } from '../../../../hydration-interactivity/shared.js';
+
+startHydrationBootstrap(() => import('./hydration-client.js'));

--- a/benchmarks/news/vue-vapor/src/hydration-interactivity/hydration-client.ts
+++ b/benchmarks/news/vue-vapor/src/hydration-interactivity/hydration-client.ts
@@ -1,0 +1,14 @@
+import { createVaporSSRApp } from 'vue';
+import { completeHydration, hydrationProps } from '../../../../hydration-interactivity/shared.js';
+import App from './App.vue';
+
+export function hydrateBenchmark() {
+	const container = document.getElementById('app');
+	if (!container) throw new Error('Missing hydration benchmark root');
+
+	return completeHydration(() => {
+		const root = createVaporSSRApp(App, hydrationProps());
+		root.mount(container);
+		return root;
+	});
+}

--- a/benchmarks/news/vue-vapor/src/hydration-interactivity/hydration-server.ts
+++ b/benchmarks/news/vue-vapor/src/hydration-interactivity/hydration-server.ts
@@ -1,0 +1,12 @@
+import { createSSRApp } from 'vue';
+import { renderToString } from 'vue/server-renderer';
+import App from './App.vue';
+
+type HydrationBenchmarkProps = {
+	controlled?: boolean;
+	deferred?: boolean;
+};
+
+export async function renderApp(props: HydrationBenchmarkProps = {}) {
+	return { head: '', body: await renderToString(createSSRApp(App, props)), css: '' };
+}

--- a/packages/octane-mcp-server/src/index.js
+++ b/packages/octane-mcp-server/src/index.js
@@ -50,6 +50,7 @@ export const BENCHMARK_SUITES = [
 	'recursive-context',
 	'signal-favoring',
 	'news',
+	'hydration-interactivity',
 	'effectful-list',
 	'memo-wall',
 	'portal-swarm',

--- a/website/tests/ssr-hydration.e2e.test.ts
+++ b/website/tests/ssr-hydration.e2e.test.ts
@@ -449,25 +449,31 @@ async function assertControlFlowKeywordMapping(baseUrl: string) {
 					document.querySelectorAll('.pg-editor .cm-content')[1]?.closest('.cm-scroller')
 						?.scrollTop ?? 0,
 			);
-			if (action === 'click') await page.mouse.click(point.x, point.y);
-			else await page.mouse.move(point.x, point.y);
-			// Wait for THIS keyword's own mark rather than a fixed delay — a
-			// loaded machine can still be mid-render, and a stale mark from the
-			// previous probe would satisfy a mere "any mark" check. Falls through
-			// when the position is genuinely unmapped, which is a real answer.
-			await page
-				.waitForFunction(
-					(text) =>
-						Array.from(
-							document
-								.querySelectorAll('.pg-editor .cm-content')[0]
-								?.querySelectorAll('.cm-mapped') ?? [],
-						).some((mark) => mark.textContent === text),
-					keyword,
-					{ timeout: 2_000 },
-				)
-				.catch(() => {});
-			await page.waitForTimeout(50);
+			// A production output swap can finish rendering before CodeMirror's
+			// hover listener is ready. Retry the genuine pointer movement until
+			// THIS keyword is highlighted; never replay a click or accept a stale
+			// decoration from an earlier probe.
+			for (let attempt = 0; attempt < (action === 'hover' ? 3 : 1); attempt++) {
+				if (action === 'click') await page.mouse.click(point.x, point.y);
+				else await page.mouse.move(point.x, point.y);
+
+				const highlighted = await page
+					.waitForFunction(
+						(text) =>
+							Array.from(
+								document
+									.querySelectorAll('.pg-editor .cm-content')[0]
+									?.querySelectorAll('.cm-mapped') ?? [],
+							).some((mark) => mark.textContent === text),
+						keyword,
+						{ timeout: 2_000 },
+					)
+					.then(
+						() => true,
+						() => false,
+					);
+				if (highlighted) break;
+			}
 			return page.evaluate(
 				({ previous, x, y }) => {
 					const marks = (index: number) =>


### PR DESCRIPTION
## Summary

Add a production-built Playwright benchmark that compares real hydration interactivity across Octane, React, Preact, Solid 2.0, Svelte, and Vue Vapor.

- Render the same 180-article SSR page, native search input, and Send action for every framework.
- Block each production hydration chunk while Playwright actually types a search query into controlled and uncontrolled inputs and presses the server-rendered Send button.
- Measure real Chromium input and hydration behavior at 1× and 6× CPU throttling.
- Assert server DOM adoption, native input event counts, preserved focus and caret, live post-hydration state, and exactly-once hydration.
- Require Octane to replay the pre-hydration Send exactly once, preserve the search text, and submit the exact original query; fail the benchmark if any correctness condition is violated.
- Exercise React's real `hydrateRoot` and dehydrated Suspense boundary, credit its genuine focus-event replay, and separately report that its blocked discrete Send click was not replayed.
- Credit Solid 2.0's actual hydration-script click replay while explicitly reporting when its controlled hydration overwrites the original query and sends the wrong text.
- Record missing Send replay, lost search text, and incorrect submissions as explicit per-framework correctness issues rather than introducing synthetic replay shims or reporting timings as successful delivery.
- Print a consolidated six-framework UX `PASS`/`FAIL` table in the unified benchmark, with replayed Send, preserved query, and exactly-once delivery counts; persist dropped clicks, lost searches, focus-only replays, and wrong submissions as first-class machine-readable `meta.userExperience` results.
- Register the new suite with the unified benchmark runner and add calibrated Octane-versus-React regression guards for controlled and uncontrolled hydration.
- Keep the MCP server's advertised benchmark registry synchronized with the unified runner so agents can discover and execute all 30 maintained suites and the existing CI parity test remains green.

## Validated quick-run comparison

| Framework | Genuine hydration event replay | Send clicks replayed | Search queries preserved | Queries delivered exactly once | UX correctness | Controlled hydration at 6× |
| --- | --- | --- | --- | --- | --- | ---: |
| Octane | Yes | 2/2 | 2/2 | 2/2 | **PASS** | 24.4 ms |
| React | Yes: Suspense-boundary focus replay | 0/2 | 0/2 | 0/2 | **FAIL**: dropped Send and overwritten query | 55.0 ms |
| Preact | No | 0/2 | 2/2 | 0/2 | **FAIL**: dropped Send | 17.4 ms |
| Solid 2.0 | Yes | 2/2 | 0/2 | 0/2 | **FAIL**: replayed Send with the wrong query | 21.4 ms |
| Svelte | No | 0/2 | 0/2 | 0/2 | **FAIL**: dropped Send and overwritten query | 26.0 ms |
| Vue Vapor | No | 0/2 | 0/2 | 0/2 | **FAIL**: dropped Send and overwritten query | 21.3 ms |

Timing measurements are machine-specific. Focus replay, discrete click replay, preserved search text, and exactly-once delivery are independently observed and reported; replaying focus does not count as replaying Send, and replaying Send with the wrong query does not count as correct delivery.

## Validation

- Full six-framework Chromium production benchmark, search-and-send correctness scenarios, and both ratio guards: `node benchmarks/bench.mjs --quick --ratios hydration-interactivity`.
- Verified the MCP benchmark registry exactly matches all 30 suite names and their unified-runner order.
- Repository-wide Prettier check with the project-equivalent configuration and exact TSRX formatter plugin.
- `node --check benchmarks/bench.mjs` and `node --check benchmarks/news/hydration-interactivity.mjs`.
- `git diff --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly new benchmark harnesses, fixtures, and docs; production runtime changes are limited to the website e2e hover retry.
> 
> **Overview**
> Adds a **hydration-interactivity** benchmark that measures what users can do on server-rendered HTML while the production hydration client chunk is deliberately withheld. Playwright drives real Chromium typing and clicks (with optional 6× CDP CPU throttling), then releases the chunk and asserts DOM adoption, input preservation, and event replay behavior.
> 
> The harness lives in `benchmarks/news/hydration-interactivity.mjs` and is wired through `bench.mjs` for six targets (Octane, React, Preact, Solid 2, Svelte, Vue Vapor), each with matching SSR/hydration fixtures under `benchmarks/news/<target>/`. Octane uses `initializeHydrationEventCapture` and `Hydrate when={interaction()}` for deferred click replay; React uses a lazy `Suspense` boundary and an early `hydrateRoot` replay root for focus replay. **Search-and-Send** scenarios record `meta.userExperience` (Send replay, query preservation, exact-once delivery); the unified runner prints a six-framework UX table, and Octane failures are hard gates.
> 
> **CI ratios** in `baselines/ratios.json` cap Octane vs React on `uncontrolled_6x_hydration` and `controlled_6x_hydration` at 1.5×. The MCP server’s `BENCHMARK_SUITES` list gains the new suite name.
> 
> Separately, **website** SSR hydration e2e hover probing retries pointer movement until the expected CodeMirror highlight appears, avoiding flakes when production output swaps race the editor listener.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a25913474d4ecb4a7bda530a25ff50e1f38d054. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->