### PR TITLE
fix(compiler): reject template directives at a JSX attribute value

### DIFF
--- a/.changeset/reject-directive-in-attribute.md
+++ b/.changeset/reject-directive-in-attribute.md
@@ -1,0 +1,9 @@
+---
+'octane': patch
+---
+
+A template directive written directly as a JSX attribute value now fails with a
+compiler diagnostic naming the source position and the working form, instead of
+crashing inside the printer with `Not implemented: JSXIfExpression`. The same
+applies to `<ErrorBoundary>` in that position, which lowers to a directive node.
+Assign the directive to a local and pass that local as the prop.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -4786,6 +4786,50 @@ export function compileForBundler(source, filename, options) {
 	return { result, hydrateAst: metadata.hydrateAst };
 }
 
+// Template directives are lowered where they appear as output or as a setup
+// value. Inside a JSX attribute they reach neither pass, so without this they
+// survive to the printer and surface as an internal "Not implemented" error.
+function assertNoDirectiveInAttributeValue(ast, filename) {
+	const seen = new WeakSet();
+	walk(ast, false);
+
+	function walk(node, inAttributeValue) {
+		if (node === null || typeof node !== 'object') return;
+		if (Array.isArray(node)) {
+			for (const child of node) walk(child, inAttributeValue);
+			return;
+		}
+		if (seen.has(node)) return;
+		seen.add(node);
+		const type = node.type;
+		if (inAttributeValue && SETUP_VALUE_DIRECTIVE_TYPES.has(type) && type !== 'JSXCodeBlock') {
+			const start = node.loc && node.loc.start;
+			const at = start ? ` (${filename}:${start.line}:${start.column})` : '';
+			throw new Error(
+				`A template directive cannot be used directly as a JSX attribute value.${at} ` +
+					`Assign it to a local first and pass that: ` +
+					`\`const body = @if (…) { … }\` then \`<Comp body={body} />\`.`,
+			);
+		}
+		const attributeValue =
+			inAttributeValue ||
+			type === 'JSXAttribute' ||
+			type === 'Attribute' ||
+			type === 'JSXSpreadAttribute' ||
+			type === 'SpreadAttribute';
+		for (const key in node) {
+			if (AST_WALK_SKIP_KEYS.has(key)) continue;
+			// An element nested in an attribute value opens a fresh child position,
+			// where directives are ordinary output again.
+			const nested =
+				attributeValue && key === 'children' && (type === 'JSXElement' || type === 'Element')
+					? false
+					: attributeValue;
+			walk(node[key], nested);
+		}
+	}
+}
+
 function compileAuthored(source, filename, options, bundlerMetadata) {
 	const mode = (options && options.mode) || 'client';
 	if (mode !== 'client' && mode !== 'server') {
@@ -4794,6 +4838,7 @@ function compileAuthored(source, filename, options, bundlerMetadata) {
 	const cleanFilename = cleanCompileFilename(filename);
 	const analyzedAst = parseModule(source, cleanFilename);
 	analyzeTsrx(analyzedAst, cleanFilename);
+	assertNoDirectiveInAttributeValue(analyzedAst, cleanFilename);
 	adoptParserAst(analyzedAst);
 	if (bundlerMetadata !== null) bundlerMetadata.hydrateAst = analyzedAst;
 	return compileInternal(source, filename, options, analyzedAst, mode, bundlerMetadata);
@@ -5017,6 +5062,9 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 	ast = annotatePureLazyCalls(ast);
 	const errorBoundaryLowering = lowerImportedErrorBoundaries(ast);
 	ast = errorBoundaryLowering.ast;
+	// <ErrorBoundary> only becomes a directive node here, so it needs the same
+	// attribute-position check the authored directives already got.
+	assertNoDirectiveInAttributeValue(ast, cleanCompileFilename(filename));
 	const consumedRuntimeLocals = errorBoundaryLowering.consumed;
 	// A null-only shorthand guard is template control flow, not an arbitrary
 	// JavaScript return value. Lower it in every compiler mode so SSR, hydration,
@@ -6052,6 +6100,9 @@ function compileServer(source, filename, options, analyzedAst = null) {
 	ast = annotatePureLazyCalls(ast);
 	const errorBoundaryLowering = lowerImportedErrorBoundaries(ast);
 	ast = errorBoundaryLowering.ast;
+	// <ErrorBoundary> only becomes a directive node here, so it needs the same
+	// attribute-position check the authored directives already got.
+	assertNoDirectiveInAttributeValue(ast, cleanCompileFilename(filename));
 	const consumedRuntimeLocals = errorBoundaryLowering.consumed;
 	// Mirror the client transform so SSR emits the same control-flow ranges
 	// hydration expects in both development and production.

--- a/packages/octane/tests/compile-errors.test.ts
+++ b/packages/octane/tests/compile-errors.test.ts
@@ -7,6 +7,107 @@ import { compile } from 'octane/compiler';
 // the user-facing contract, not the throw itself.
 
 describe('compile errors — rejected authoring patterns', () => {
+	describe('template directives at a JSX attribute value', () => {
+		// Directives are lowered where they appear as output or as a setup value.
+		// Inside an attribute they reach neither pass, so they used to survive to
+		// the printer and surface as an internal "Not implemented" error.
+		const PRELUDE = `
+			function Leaf() @{ <b>{'leaf'}</b> }
+			function Slot(props) @{ <section>{props.body}</section> }
+		`;
+		const REJECTED = /template directive cannot be used directly as a JSX attribute value/;
+		const modes = ['client', 'server'] as const;
+
+		const positions: Array<[string, string]> = [
+			['a component prop', `<Slot body={DIRECTIVE} />`],
+			['a host attribute', `<span title={DIRECTIVE} />`],
+			['a spread attribute object', `<Slot {...{ body: DIRECTIVE }} />`],
+			['an array literal', `<Slot body={[DIRECTIVE]} />`],
+			['a member read of an array', `<Slot body={[DIRECTIVE].length} />`],
+			['a ternary arm', `<Slot body={props.on ? DIRECTIVE : null} />`],
+			['an arrow body', `<Slot body={() => DIRECTIVE} />`],
+			['the second of two attributes', `<Slot k={1} body={DIRECTIVE} />`],
+			['an attribute of a nested element', `<Slot body={<span title={DIRECTIVE} />} />`],
+		];
+		const directives: Array<[string, string]> = [
+			['@if', `@if (props.on) { <Leaf /> } @else { <i>{'n'}</i> }`],
+			['@for', `@for (const x of props.xs; key x.id) { <Leaf /> }`],
+			['@switch', `@switch (props.k) { @case 'a': { <Leaf /> } @default: { <i>{'d'}</i> } }`],
+			['@try', `@try { <Leaf /> } @catch (error) { <i>{'c'}</i> }`],
+		];
+
+		for (const [where, shape] of positions) {
+			it(`rejects a directive in ${where}`, () => {
+				for (const [name, directive] of directives) {
+					const src = `${PRELUDE}export function App(props) @{ <div>${shape.replace('DIRECTIVE', directive)}</div> }`;
+					for (const mode of modes) {
+						expect(
+							() => compile(src, 'directive-in-attr.tsrx', { mode }),
+							`${name} in ${where} (${mode})`,
+						).toThrow(REJECTED);
+					}
+				}
+			});
+		}
+
+		it('names the working form in the message', () => {
+			const src = `${PRELUDE}export function App(props) @{ <div><Slot body={@if (props.on) { <Leaf /> }} /></div> }`;
+			expect(() => compile(src, 'directive-in-attr.tsrx')).toThrow(/const body =/);
+			expect(() => compile(src, 'directive-in-attr.tsrx')).toThrow(
+				/directive-in-attr\.tsrx:\d+:\d+/,
+			);
+		});
+
+		it('rejects an <ErrorBoundary> used as an attribute value', () => {
+			// It only becomes a directive node once the boundary lowering runs, so it
+			// needs the same rejection after that pass rather than at parse time.
+			const src = `
+				import { ErrorBoundary } from 'octane';
+				${PRELUDE}
+				export function App() @{
+					<div><Slot body={<ErrorBoundary fallback={'c'}><Leaf /></ErrorBoundary>} /></div>
+				}
+			`;
+			for (const mode of modes) {
+				expect(() => compile(src, 'boundary-in-attr.tsrx', { mode })).toThrow(REJECTED);
+			}
+		});
+
+		const allowed: Array<[string, string]> = [
+			[
+				'assigned to a local first',
+				`const body = @if (props.on) { <Leaf /> } @else { <i>{'n'}</i> };
+				 <div><Slot body={body} /></div>`,
+			],
+			[
+				'an <ErrorBoundary> assigned to a local first',
+				`const body = <ErrorBoundary fallback={'c'}><Leaf /></ErrorBoundary>;
+				 <div><Slot body={body} /></div>`,
+			],
+			[
+				'a child of an element nested in an attribute',
+				`<div><Slot body={<span>@if (props.on) { <Leaf /> }</span>} /></div>`,
+			],
+			[
+				'a child of a fragment nested in an attribute',
+				`<div><Slot body={<span><>@if (props.on) { <Leaf /> }</></span>} /></div>`,
+			],
+			['ordinary output', `<div>@if (props.on) { <Leaf /> }</div>`],
+		];
+		for (const [what, body] of allowed) {
+			it(`allows a directive ${what}`, () => {
+				const src = `
+					import { ErrorBoundary } from 'octane';
+					${PRELUDE}
+					export function App(props) @{ ${body} }
+				`;
+				for (const mode of modes) {
+					expect(() => compile(src, 'directive-allowed.tsrx', { mode })).not.toThrow();
+				}
+			});
+		}
+	});
+
 	it('rejects multiple `ref={…}` attributes on a single element', () => {
 		const src = `
       import { useRef } from 'octane';


### PR DESCRIPTION
## Summary

- reject a template directive written directly as a JSX attribute value, with the source position and the form that works
- run the same check after the `<ErrorBoundary>` lowering, which produces a directive node
- keep directives compiling in every position where they are already lowered

## Why

```tsx
<Slot body={@if (cond) { <Leaf /> }} />
```

crashed with `Not implemented: JSXIfExpression (consider using 'esrap/languages/tsx')`, an internal printer error that says nothing about the authored code.

Directives are lowered in two places: as component output, and as a setup value through `lowerSetupValueDirectives`. An attribute value reaches neither, so the node survives every pass and arrives at esrap, which has no case for it.

## Impact

| | before | after |
| --- | --- | --- |
| directive in an attribute value | internal printer error | diagnostic with file:line:col and the fix |
| `<ErrorBoundary>` in an attribute value | internal printer error | same diagnostic |
| directive assigned to a local, passed as a prop | compiles | compiles |
| directive as a child of an element nested in an attribute | compiles | compiles |
| emitted output for every existing fixture | | byte-identical |

Affects all four directives across nine attribute positions in both compile modes: component prop, host attribute, spread attribute object, array literal, member read, ternary arm, arrow body, second of two attributes, and an attribute of a nested element.

Supporting directives inline is a larger change than a diagnostic. It would route them through `prepareSetupValueDirective` from inside `planJsx`, after template slot assignment has begun, so it needs a hook-slot ordering proof plus client, server and hydration agreement. This PR replaces a crash with guidance and leaves that open.

## Validation

- full suite: 8,788 passed across `octane` and `octane-prod`
- compiled all 166 fixtures in both modes before and after: `c09ef16a170eb1a9` on both sides
- each arm of the check is pinned: disabling it fails 11 tests, dropping only the spread-attribute arm fails exactly the spread test, dropping the nested-children carve-out fails exactly the two tests that assert legal forms still compile

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an early compile-time validation pass with no change to lowering or emitted output for valid code; behavior change is limited to previously crashing invalid authoring.
> 
> **Overview**
> Using a template directive (`@if`, `@for`, `@switch`, `@try`) **directly inside a JSX attribute expression** now fails at compile time with a clear diagnostic (file:line:column plus guidance to assign to a local and pass the variable), instead of an internal printer error (`Not implemented: JSXIfExpression`).
> 
> The compiler adds an AST walk that treats props, host attributes, spreads, and nested attribute shapes as “attribute value” contexts, while still allowing directives as normal element children (including inside JSX nested under an attribute). The same check runs **again after `<ErrorBoundary>` lowering**, because that JSX becomes a directive node only at that stage.
> 
> Compile-error tests lock in rejection across client/server modes and several attribute positions, plus cases that must keep compiling unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8dccdf1a9b03562f5256fee8c93f41167c15169. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->