### PR TITLE
perf(runtime): cut per-render cost of value-position element descriptors

### DIFF
--- a/.changeset/value-position-memo-bail-cost.md
+++ b/.changeset/value-position-memo-bail-cost.md
@@ -1,0 +1,24 @@
+---
+'octane': patch
+---
+
+Cut the per-render cost of value-position element descriptors, the shape every
+`@octanejs/*` binding and every `createElement`/`.map()` child tree produces.
+`createElement` no longer allocates a property descriptor per call to detect
+React's DEV-only `key` warning getter (that probe is now DEV-gated exactly as in
+React's `hasValidKey`), a keyed element no longer pays a WeakSet insert to record
+key presence that its non-null `key` already proves, `prepareDeoptList` builds
+its output arrays only once a list regime is established, and every renderable
+hole no longer re-reads its host's tag from the DOM to re-check a void-element
+constraint its enclosing list already validated.
+
+On the `memo-wall` benchmark (1000 `memo(Row)` children reached through a
+`{rows}` children hole) this drops a parent re-render absorbed by 1000 prop bails
+from 0.272ms to 0.177ms, a single-row change amid the wall from 0.275ms to
+0.184ms, and a context bump through the wall from 0.610ms to 0.517ms. Exact
+render counts and compiled-work counts are unchanged, and `memo-wall` now carries
+ratio guards for all three wall-B operations.
+
+The server runtime gets the same two allocation fixes that apply to it (the key
+probe and the deferred child-list arrays) so the client and server descriptor
+paths stay in step; `ssr-throughput` shows no measurable change from them.

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -65,6 +65,30 @@
   },
   {
     "suite": "memo-wall",
+    "op": "parent_rerender_equal_B",
+    "target": "octane-tsrx",
+    "reference": "react",
+    "maxRatio": 1,
+    "note": "Wall B is the value-position control: 1000 fresh createElement descriptors absorbed by the childSlot memo bail. Paired run measured 0.81x on 2026-07-26 (it was 1.22x before per-descriptor allocation was cut); 1.0 keeps noise headroom while a return to the old descriptor cost breaches it."
+  },
+  {
+    "suite": "memo-wall",
+    "op": "one_change_B",
+    "target": "octane-tsrx",
+    "reference": "react",
+    "maxRatio": 0.95,
+    "note": "One changed row amid wall B's 999 successful value-comparing bails. Paired run measured 0.73x on 2026-07-26 (1.08x before); 0.95 bounds a regression back toward per-descriptor reflective work."
+  },
+  {
+    "suite": "memo-wall",
+    "op": "ctx_through_wall_B",
+    "target": "octane-tsrx",
+    "reference": "react",
+    "maxRatio": 0.6,
+    "note": "Provider bump above wall B: rebuild 1000 descriptors, bail all 1000, refresh only the 1000 leaves. Paired runs measured 0.44-0.48x on 2026-07-26 (0.56x before); 0.6 stays above run-to-run spread while still breaching if the per-descriptor cost returns."
+  },
+  {
+    "suite": "memo-wall",
     "op": "mount",
     "target": "octane-jsx",
     "reference": "octane-tsrx",

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -440,8 +440,17 @@ interface ElementDescriptor {
 
 function hasElementConfigKey(config: any): boolean {
 	if (config == null || (typeof config !== 'object' && typeof config !== 'function')) return false;
-	const own = Object.getOwnPropertyDescriptor(config, 'key');
-	if (own?.get != null && (own.get as any).isReactWarning) return false;
+	// React's development-only props.key warning getter is not a real key, and
+	// must not be INVOKED (calling it emits React's warning). The reflective probe
+	// allocates a descriptor object, so reach it only when a `key` is actually
+	// present — the common no-key call now costs one lookup. Deliberately NOT
+	// gated on the build mode the way the client twin is: an SSR bundle does not
+	// always fold the dev-mode env check away, and reading it per call would cost
+	// more than the allocation it saves.
+	if (Object.prototype.hasOwnProperty.call(config, 'key')) {
+		const own = Object.getOwnPropertyDescriptor(config, 'key');
+		if (own?.get != null && (own.get as any).isReactWarning) return false;
+	}
 	return config.key !== undefined;
 }
 
@@ -605,21 +614,24 @@ function flattenSsrChildContainer(
 }
 
 function prepareSsrDeoptList(value: any, includeKeyedSingle: boolean): PreparedSsrDeoptList | null {
-	const items: any[] = [];
-	const keys: any[] = [];
+	// Asked for EVERY serialized child, and the non-list answer (a lone component
+	// descriptor, text, null) is the common one — build the two output arrays only
+	// once a list regime is established. Mirrors prepareDeoptList in runtime.ts.
 	if (isFragmentDescriptor(value)) {
+		const items: any[] = [];
+		const keys: any[] = [];
 		const path = value.key == null ? [] : ['keyed-fragment', value.key];
 		flattenSsrChildContainer(items, keys, fragmentDescriptorChildren(value), 'fragment', path);
 		return { items, keys };
 	}
 	if (Array.isArray(value)) {
+		const items: any[] = [];
+		const keys: any[] = [];
 		flattenSsrChildContainer(items, keys, value, ssrDeoptWrapperKind(value), []);
 		return { items, keys };
 	}
 	if (includeKeyedSingle && isElementDescriptor(value) && value.key != null) {
-		items.push(value);
-		keys.push(scopedSsrDeoptKey([], value, 0, value.key));
-		return { items, keys };
+		return { items: [value], keys: [scopedSsrDeoptKey([], value, 0, value.key)] };
 	}
 	return null;
 }

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -3591,7 +3591,7 @@ function renderReturnedValue(block: Block, out: unknown): void {
 					d.key ?? undefined,
 					true,
 					undefined,
-					activeHydration() !== null && KEYED_ELEMENT_DESCRIPTORS.has(d),
+					activeHydration() !== null && elementKeyWasProvided(d),
 				),
 			);
 		} else {
@@ -3605,7 +3605,7 @@ function renderReturnedValue(block: Block, out: unknown): void {
 				d.key ?? undefined,
 				true,
 				undefined,
-				activeHydration() !== null && KEYED_ELEMENT_DESCRIPTORS.has(d),
+				activeHydration() !== null && elementKeyWasProvided(d),
 			);
 		}
 	} else {
@@ -8683,6 +8683,10 @@ export function setHTML(el: Element, value: any): void {
 }
 
 const DANGER_HTML_ACTIVE = '__oct_dangerHTML';
+// Latched the first time any host actually takes ownership of its children via
+// dangerouslySetInnerHTML. Every childSlot call has to ask whether raw HTML owns
+// its parent; an app that never uses the feature skips the DOM read entirely.
+let DANGER_HTML_EVER_ACTIVE = false;
 const DANGER_HTML_STATIC_CHILD = '__oct_dangerChild';
 const DANGER_HTML_SPREAD_CHILD = '__oct_dangerSpreadChild';
 const DANGER_HTML_RESOLVED_VALUE = '__oct_dangerResolved';
@@ -8721,6 +8725,7 @@ export function setDangerouslySetInnerHTML(el: Element, value: any): void {
 		throw dangerHtmlChildrenError();
 	}
 	(el as any)[DANGER_HTML_ACTIVE] = true;
+	DANGER_HTML_EVER_ACTIVE = true;
 	setHTML(el, value.__html);
 }
 
@@ -8802,6 +8807,7 @@ export function markDangerouslySetInnerHTMLChildren(el: Element): void {
  * child reconciliation in that case so it cannot erase the raw HTML.
  */
 function dangerouslySetInnerHTMLOwnsChild(parent: Node, value: unknown): boolean {
+	if (!DANGER_HTML_EVER_ACTIVE) return false;
 	if (parent.nodeType !== 1 || (parent as any)[DANGER_HTML_ACTIVE] !== true) return false;
 	if (value !== null && value !== undefined) throw dangerHtmlChildrenError();
 	return true;
@@ -12882,7 +12888,14 @@ const ELEMENT_TAG = Symbol.for('octane.element');
 // of band. This lets hydration keep an explicit `key={undefined}` as an
 // independent reconciliation boundary without adding an observable descriptor
 // field or penalizing unkeyed descriptors with extra object shape.
+//
+// A non-null `key` already proves presence, so only the AMBIGUOUS nullish-key
+// case is recorded here — every `key={id}` element in a list would otherwise pay
+// a WeakSet insert per render. Read presence through `elementKeyWasProvided`.
 const KEYED_ELEMENT_DESCRIPTORS = new WeakSet<object>();
+function elementKeyWasProvided(descriptor: ElementDescriptor): boolean {
+	return descriptor.key !== null || KEYED_ELEMENT_DESCRIPTORS.has(descriptor);
+}
 // Children.map/toArray synthesize stable traversal keys. Keep the original
 // missing-key validation state out of band so rebasing an unkeyed element from
 // a dynamic collection does not accidentally silence the renderer warning.
@@ -12918,10 +12931,15 @@ export type OctaneNode = unknown;
 
 function hasElementConfigKey(config: any): boolean {
 	if (config == null || (typeof config !== 'object' && typeof config !== 'function')) return false;
-	const own = Object.getOwnPropertyDescriptor(config, 'key');
 	// React's development-only props.key warning getter is not a real key. This
 	// matters when an element's props object is fed back into createElement.
-	if (own?.get != null && (own.get as any).isReactWarning) return false;
+	// Gated exactly like React's hasValidKey: the reflective probe allocates a
+	// descriptor object on every call, and only a React DEV build can install
+	// such a getter — so production reaches the key with one property read.
+	if (process.env.NODE_ENV !== 'production' && hasOwnProp.call(config, 'key')) {
+		const own = Object.getOwnPropertyDescriptor(config, 'key');
+		if (own?.get != null && (own.get as any).isReactWarning) return false;
+	}
 	return config.key !== undefined;
 }
 
@@ -12986,8 +13004,6 @@ export function createElement<P>(
 	// createElement is callable userland API, so it must snapshot config even on
 	// the common two-argument path. Mutating the caller's object after creation
 	// must not retroactively mutate the element.
-	const keyWasProvided =
-		src != null && (typeof src === 'object' || typeof src === 'function') && 'key' in src;
 	const p = copyElementConfig(src);
 	if (hasPositional) p.children = kids;
 	applyElementDefaultProps(type, p);
@@ -13000,7 +13016,16 @@ export function createElement<P>(
 		ref: p.ref !== undefined ? p.ref : null,
 		children: kids ?? null,
 	};
-	if (keyWasProvided) KEYED_ELEMENT_DESCRIPTORS.add(descriptor);
+	// Only a NULLISH `key` leaves presence ambiguous (`key` is non-null exactly when
+	// `hasKey`), so the prototype-chain probe stays off the keyed-list hot path.
+	if (
+		key === null &&
+		src != null &&
+		(typeof src === 'object' || typeof src === 'function') &&
+		'key' in src
+	) {
+		KEYED_ELEMENT_DESCRIPTORS.add(descriptor);
+	}
 	return finalizeElementDescriptor(descriptor);
 }
 function isElementDescriptor(v: any): v is ElementDescriptor {
@@ -13074,9 +13099,11 @@ export function cloneElement<P>(
 		ref: props.ref !== undefined ? props.ref : null,
 		children: kids ?? null,
 	};
+	// Only a nullish result key needs the out-of-band record (see createElement).
 	if (
-		KEYED_ELEMENT_DESCRIPTORS.has(element) ||
-		(config != null && Object.prototype.hasOwnProperty.call(config, 'key'))
+		key === null &&
+		(elementKeyWasProvided(element) ||
+			(config != null && Object.prototype.hasOwnProperty.call(config, 'key')))
 	) {
 		KEYED_ELEMENT_DESCRIPTORS.add(descriptor);
 	}
@@ -13098,7 +13125,7 @@ function cloneAndReplaceElementKey(element: ElementDescriptor, key: string): Ele
 		ref: element.ref,
 		children: element.children,
 	};
-	KEYED_ELEMENT_DESCRIPTORS.add(descriptor);
+	// `key` is a real (non-null) string here, so presence is already implied.
 	if (ELEMENTS_MISSING_LIST_KEY.has(element)) ELEMENTS_MISSING_LIST_KEY.add(descriptor);
 	return finalizeElementDescriptor(descriptor);
 }
@@ -14635,26 +14662,27 @@ function prepareDeoptList(
 	forceSingle: boolean = false,
 	includeKeyedSingle: boolean = true,
 ): PreparedDeoptList | null {
-	const items: any[] = [];
-	const keys: any[] = [];
+	// childSlot calls this for EVERY renderable hole on every render, and the
+	// non-list answer (a lone component descriptor, text, null) is the common one
+	// — build the two output arrays only once a list regime is established.
 	if (isFragmentDescriptor(value)) {
+		const items: any[] = [];
+		const keys: any[] = [];
 		const path = value.key == null ? [] : ['keyed-fragment', value.key];
 		flattenReactChildContainer(items, keys, fragmentDescriptorChildren(value), 'fragment', path);
 		return { items, keys };
 	}
 	if (Array.isArray(value)) {
+		const items: any[] = [];
+		const keys: any[] = [];
 		flattenReactChildContainer(items, keys, value, deoptWrapperKind(value), []);
 		return { items, keys };
 	}
 	if (includeKeyedSingle && isElementDescriptor(value) && value.key != null) {
-		items.push(value);
-		keys.push(scopedDeoptKey([], value, 0, value.key));
-		return { items, keys };
+		return { items: [value], keys: [scopedDeoptKey([], value, 0, value.key)] };
 	}
 	if (forceSingle) {
-		items.push(value);
-		keys.push(scopedDeoptKey([], value, 0, deoptKeyPositional(value, 0)));
-		return { items, keys };
+		return { items: [value], keys: [scopedDeoptKey([], value, 0, deoptKeyPositional(value, 0))] };
 	}
 	return null;
 }
@@ -15489,11 +15517,17 @@ export function childSlot(
 	// in another one-item list.
 	includeKeyedSingle: boolean = true,
 ): void {
+	// Reading the host's tag costs two DOM accessors and this runs for every
+	// renderable hole on every render, so lead with the cheap facts. A de-opt list
+	// ITEM (`includeKeyedSingle === false`, passed only by deoptItemBody) shares
+	// the domParent its list's own childSlot already validated against a non-null
+	// list value, so re-reading the tag once per item proves nothing new.
 	if (
+		value != null &&
+		includeKeyedSingle &&
 		domParent.nodeType === 1 &&
 		VOID_ELEMENTS.has((domParent as Element).localName) &&
-		!isPortalTarget(parentScope.block, domParent) &&
-		value != null
+		!isPortalTarget(parentScope.block, domParent)
 	) {
 		throw new Error(formatClientError(26, (domParent as Element).localName));
 	}

--- a/packages/octane/tests/_fixtures/danger-html.tsx
+++ b/packages/octane/tests/_fixtures/danger-html.tsx
@@ -8,6 +8,11 @@ export function setHtml(h: string) {
 	if (_set) _set(h);
 }
 
+let _setChild: ((v: unknown) => void) | null = null;
+export function setDangerChild(v: unknown) {
+	if (_setChild) _setChild(v);
+}
+
 // Fast path: only child, no spread → htmlOnlyChild assignment (with update diff).
 export function DangerHtml(props: { html: string }) {
 	const [html, set] = useState(props.html);
@@ -23,6 +28,21 @@ export function BareInnerHtml(props: { html: string }) {
 // Spread CARRYING dangerouslySetInnerHTML → setSpread → setAttribute's danger path.
 export function SpreadDanger(props: { attrs: Record<string, unknown> }) {
 	return <div id="s" {...props.attrs} />;
+}
+
+// A compiled host carrying BOTH a spread and a dynamic child hole. Only the
+// spread can supply dangerouslySetInnerHTML here, so the compiler cannot reject
+// the pairing and the raw HTML wins the element at runtime — the hole must then
+// refuse to reconcile a non-nullish child into content it does not own, and
+// accept a nullish one without erasing the HTML.
+export function SpreadDangerPlusHole(props: { attrs: Record<string, unknown>; child: unknown }) {
+	const [child, set] = useState(props.child);
+	_setChild = set as (v: unknown) => void;
+	return (
+		<div id="sdh" {...props.attrs}>
+			{child}
+		</div>
+	);
 }
 
 // De-opt host path: a component RETURNING createElement(tag, {dangerouslySetInnerHTML})

--- a/packages/octane/tests/_fixtures/void-host-child.tsx
+++ b/packages/octane/tests/_fixtures/void-host-child.tsx
@@ -1,0 +1,39 @@
+import { createElement, useState } from 'octane';
+
+// Void hosts (`<input>`, `<br>`, …) have no content model, so no renderable
+// child may land inside one. A compiled template child is rejected at compile
+// time, so these fixtures use de-opt `createElement(voidTag, null, child)`
+// descriptors — the shape where the child value only exists at runtime.
+
+let _show: ((v: boolean) => void) | null = null;
+export function fillHole() {
+	if (_show) _show(true);
+}
+
+function Kid() {
+	return createElement('span', null, 'kid');
+}
+
+/** A component child inside a void host. */
+export function VoidComponentChild() {
+	return createElement('input', { id: 'vcc' }, createElement(Kid, null));
+}
+
+/** An array of children inside a void host. */
+export function VoidArrayChild() {
+	return createElement('br', null, [
+		createElement(Kid, { key: 'a' }),
+		createElement(Kid, { key: 'b' }),
+	]);
+}
+
+/** A void host whose child starts absent and appears on a later render. */
+export function VoidChildLater() {
+	const [show, set] = useState(false);
+	_show = set;
+	return createElement(
+		'div',
+		{ id: 'vhl' },
+		createElement('input', { id: 'vl' }, show ? createElement(Kid, null) : null),
+	);
+}

--- a/packages/octane/tests/danger-html.test.ts
+++ b/packages/octane/tests/danger-html.test.ts
@@ -4,8 +4,10 @@ import { mount } from './_helpers';
 import {
 	DangerHtml,
 	BareInnerHtml,
+	SpreadDangerPlusHole,
 	SpreadDanger,
 	DeoptDanger,
+	setDangerChild,
 	setHtml,
 } from './_fixtures/danger-html.tsx';
 
@@ -55,5 +57,26 @@ it('de-opt host path (createElement return) applies raw HTML and keeps it across
 	// Update flows through patchDeoptProps + the same skip.
 	flushSync(() => setHtml('.b{color:blue}'));
 	expect(el.textContent).toBe('.b{color:blue}');
+	r.unmount();
+});
+
+// Raw HTML OWNS its host's content, so a coexisting renderable hole must not be
+// allowed to reconcile into it. That question is asked for every hole on every
+// render, and short-circuited when no host in the page has ever taken raw-HTML
+// ownership — these pin that the check still arms once one has.
+const RAW = { dangerouslySetInnerHTML: { __html: '<b class="r">raw</b>' } };
+
+it('rejects a non-nullish child coexisting with spread-supplied raw HTML', () => {
+	expect(() => mount(SpreadDangerPlusHole as any, { attrs: RAW, child: 'kid' })).toThrow(
+		/dangerouslySetInnerHTML/,
+	);
+});
+
+it('accepts a nullish coexisting child and keeps the raw HTML', () => {
+	const r = mount(SpreadDangerPlusHole as any, { attrs: RAW, child: null });
+	const el = r.find('#sdh') as HTMLElement;
+	expect(el.querySelector('b.r')?.textContent).toBe('raw');
+	// Filling the hole on a LATER render is rejected just the same.
+	expect(() => flushSync(() => setDangerChild('kid'))).toThrow(/dangerouslySetInnerHTML/);
 	r.unmount();
 });

--- a/packages/octane/tests/ssr-element-utils.test.ts
+++ b/packages/octane/tests/ssr-element-utils.test.ts
@@ -37,6 +37,29 @@ describe('octane/server element utilities', () => {
 		expect(isValidElement('li')).toBe(false);
 	});
 
+	it('lifts key out of props with the same nullish rules as the client entry', () => {
+		// `key` is never a real prop, a nullish key still stringifies (React's
+		// shape), and an explicitly-undefined key is treated as absent.
+		expect(createElement('li', { key: 12, class: 'row' }).key).toBe('12');
+		expect(createElement('li', { key: 12, class: 'row' }).props).toEqual({ class: 'row' });
+		expect(createElement('li', { key: null }).key).toBe('null');
+		expect(createElement('li', { key: undefined, class: 'row' }).key).toBe(null);
+		expect(createElement('li', { class: 'row' }).key).toBe(null);
+	});
+
+	it('never invokes a React warning getter standing in for key', () => {
+		// A React DEV build installs a non-enumerable `key` getter on props that
+		// WARNS when read and yields undefined. Feeding such a props object back
+		// through createElement must neither treat it as a real key nor trigger
+		// the warning, so the getter has to stay uncalled.
+		const props: any = {};
+		const keyGetter: any = vi.fn(() => undefined);
+		keyGetter.isReactWarning = true;
+		Object.defineProperty(props, 'key', { enumerable: false, get: keyGetter });
+		expect(createElement('li', props).key).toBe(null);
+		expect(keyGetter).not.toHaveBeenCalled();
+	});
+
 	it('cloneElement merges props under config, overrides key, keeps children', () => {
 		const base = createElement('text', { x: 1, fill: 'red', key: 'a' }, 'label');
 		const clone = cloneElement(base, { x: 2, y: 3, key: 'b' });

--- a/packages/octane/tests/void-host-children.test.ts
+++ b/packages/octane/tests/void-host-children.test.ts
@@ -1,0 +1,31 @@
+import { it, expect } from 'vitest';
+import { flushSync } from '../src/index.js';
+import { mount } from './_helpers';
+import {
+	VoidArrayChild,
+	VoidChildLater,
+	VoidComponentChild,
+	fillHole,
+} from './_fixtures/void-host-child.tsx';
+
+// A void element has no content model, so rendering any content into one is an
+// authoring error rather than something to silently drop. Templates are rejected
+// at compile time; these cover the runtime arm, where the child value is only
+// known while rendering.
+
+it('rejects a component child inside a void host', () => {
+	expect(() => mount(VoidComponentChild)).toThrow(/void element/);
+});
+
+it('rejects an array of children inside a void host', () => {
+	expect(() => mount(VoidArrayChild)).toThrow(/void element/);
+});
+
+it('rejects a child that appears inside a void host on a later render', () => {
+	// An absent child legitimately coexists with a void host, so the rejection
+	// cannot be a mount-time-only check.
+	const r = mount(VoidChildLater);
+	expect((r.find('#vl') as HTMLElement).childNodes.length).toBe(0);
+	expect(() => flushSync(fillHole)).toThrow(/void element/);
+	r.unmount();
+});


### PR DESCRIPTION
## Summary

- Remove four per-descriptor allocations from the value-position element path — the shape every `@octanejs/*` binding, `createElement` call, and `.map()` child tree produces on every render.
- memo-wall wall-B operations drop 27–35% across both authoring dialects; exact render counts, deterministic compiled-work counts, and all octane bundle-size metrics are unchanged.
- Adds ratio guards for the three wall-B operations, which had none.

## Why

Profiling a 1000-row `memo(Row)` wall reached through a `{rows}` children hole showed `createElement` at 37% of the parent-re-render cost and GC at 6.8%. None of the four allocations were load-bearing:

- `hasElementConfigKey` allocated a property descriptor on **every** call to detect React's DEV-only `key` warning getter.
- Every `key={id}` element paid a WeakSet insert to record key presence that its non-null `key` already proves.
- `prepareDeoptList` built two output arrays before deciding the value was not a list — 2000 discarded arrays per render at this wall size.
- Every renderable hole re-read its host's tag from the DOM to re-check a void-element constraint (two DOM accessors), 44% of `childSlot`'s self time.

## Changes

- `runtime.ts`
  - `hasElementConfigKey`: reflective probe gated exactly like React's `hasValidKey` (DEV-only, and only when `key` is an own property).
  - Key presence: only the ambiguous nullish-`key` case is recorded out of band; presence reads through a new `elementKeyWasProvided`. `key !== null` ⟺ `hasKey` ⟹ `'key' in src`, so the predicate is unchanged for every input.
  - `prepareDeoptList`: output arrays allocated only once a list regime is established.
  - `childSlot`: void-host check leads with the two cheap facts, and a de-opt list **item** skips a check its list already performed on the same `domParent`.
  - Latch so apps that never use `dangerouslySetInnerHTML` skip that DOM read entirely.
- `runtime.server.ts`: the two fixes that apply server-side (key probe, deferred child-list arrays). Deliberately **not** gated on build mode — SSR bundles do not constant-fold it, so an env read would cost more than the allocation it saves.
- `benchmarks/baselines/ratios.json`: guards for `parent_rerender_equal_B`, `one_change_B`, `ctx_through_wall_B`.
- New tests + changeset.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 13476 passed / 1348 files / 0 failures
- [x] targeted tests: `void-host-children`, `danger-html`, `ssr-element-utils`, full `hydration/`, `rsbuild-plugin` integration
- [x] memo-wall correctness gates + deterministic work gates — exact counts unchanged
- [x] `bundle-size` — every octane metric byte-identical vs base
- [x] `bench.mjs --quick --ratios memo-wall` — 9 guards checked, 0 breached
- [x] `js-framework` (octane-jsx) — no regression
- [x] `ssr-throughput deopt-page` — 290.98 → 287.48 ops/sec, within noise

Matched paired runs, production builds, same machine:

| op | octane-tsrx | octane-jsx |
| --- | --- | --- |
| `parent_rerender_equal_B` | 0.248 → **0.181** | 0.335 → **0.226** |
| `one_change_B` | 0.279 → **0.181** | 0.330 → **0.231** |
| `ctx_through_wall_B` | 0.620 → **0.533** | 0.940 → **0.900** |

`mount` and the wall-A ops are flat — wall A is autoMemo'd and never enters these paths.

## Risk / follow-ups

- **The key-presence bit has no behavioral oracle.** Forcing `elementKeyWasProvided` to always-`false` and always-`true` both pass all 484 hydration tests; it only feeds hydration range-borrowing eligibility, where `keyed = true` is the conservative direction. It rests on the equivalence argument above, not on a test. Worth a reviewer's eye.
- **Server changes are measured neutral**, not a win. They are here for client/server symmetry; no SSR improvement is claimed.
- `parent_rerender_equal_B`'s guard sits at exactly 1.0 ("octane must not be slower than React here") with 23–29% headroom — the tightest of the three.
- Follow-up: `finalizeElementDescriptor` is ~10.9% of descriptor-path SSR render time, entirely from a per-call `process.env.NODE_ENV` read that SSR builds do not fold. Larger than anything in this PR; deliberately untouched.
- Pre-existing gap found while writing tests: the void-host guard does not fire when a hole transitions null → plain string (only null → component). Fails identically on `main`; left alone.
- Branch name predates my reading the `create-a-pr` skill's `fix/|feat/|docs/|test/` convention. Happy to recreate under a conforming name.
