### PR TITLE
Recover stranded Changesets npm releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -699,6 +699,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # The privileged publish workflow uses this network-free contract to
+      # classify registry state before Changesets is allowed to publish.
+      - name: Test npm release reconciliation
+        run: pnpm release:preflight:test
+
       # Pack the live, discovered package set instead of a hand-maintained
       # allowlist. The validator checks the post-pnpm manifest and tar contents,
       # including exports/bin/types and workspace/catalog protocol replacement,

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -150,6 +150,14 @@ jobs:
         id: npm_release
         run: pnpm release:preflight
 
+      # changesets/action creates a version PR instead of running its publish
+      # command whenever any pending changeset document exists. release.yml
+      # already owns version PRs, so hide those documents in this ephemeral
+      # checkout and force this action to perform only npm reconciliation.
+      - name: Isolate pending changesets from npm reconciliation
+        if: steps.npm_release.outputs.needs_publish == 'true'
+        run: pnpm release:prepare-publish
+
       - name: Publish to npm
         id: changesets
         if: steps.npm_release.outputs.needs_publish == 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,13 +9,12 @@ on:
     types: [completed]
     branches: [main]
 
-  # Recovery path for a Version Packages CI run whose validation jobs passed
-  # but whose former inline publish job failed. The job below validates the run
-  # and derives its SHA; callers cannot supply an arbitrary commit to publish.
+  # Recovery path for any successful main CI run. The job below validates the
+  # run and derives its SHA; callers cannot supply an arbitrary commit.
   workflow_dispatch:
     inputs:
       ci_run_id:
-        description: CI run ID containing the validated Version Packages SHA
+        description: Successful CI push run ID for the main SHA to reconcile
         required: true
         type: string
 
@@ -31,8 +30,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (
         github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'push' &&
-        contains(github.event.workflow_run.head_commit.message, 'Version Packages')
+        github.event.workflow_run.event == 'push'
       )
     runs-on: ubuntu-latest
     permissions:
@@ -84,9 +82,6 @@ jobs:
               }
             }
 
-            if (!run.head_commit?.message.includes("Version Packages")) {
-              throw new Error(`CI run ${runId} is not a Version Packages run`);
-            }
             if (!/^[0-9a-f]{40}$/.test(run.head_sha)) {
               throw new Error(`CI run ${runId} returned an invalid head SHA`);
             }
@@ -120,36 +115,11 @@ jobs:
             }
 
             if (run.conclusion !== "success") {
-              const unexpected = jobs.filter(
-                (job) =>
-                  job.conclusion !== "success" &&
-                  !(
-                    job.name === "publish validated SHA" &&
-                    job.conclusion === "failure"
-                  ),
-              );
-              if (unexpected.length > 0) {
-                throw new Error(
-                  `CI run ${runId} has non-publish failures: ${unexpected
-                    .map((job) => `${job.name} (${job.conclusion})`)
-                    .join(", ")}`,
-                );
-              }
-
-              const failedLegacyPublish = jobs.some(
-                (job) =>
-                  job.name === "publish validated SHA" &&
-                  job.conclusion === "failure",
-              );
-              if (!failedLegacyPublish) {
-                throw new Error(
-                  `CI run ${runId} failed for a reason other than the legacy publisher`,
-                );
-              }
+              throw new Error(`CI run ${runId} concluded ${run.conclusion}, expected success`);
             }
 
             core.setOutput("sha", run.head_sha);
-            core.info(`Publishing validated SHA ${run.head_sha} from CI run ${runId}`);
+            core.info(`Reconciling validated SHA ${run.head_sha} from CI run ${runId}`);
 
       - name: Checkout validated SHA
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -172,8 +142,17 @@ jobs:
       - name: Disallow major and minor bumps in changesets
         run: pnpm changeset:check
 
+      # Check the complete workspace before Changesets starts. npm publishing is
+      # not atomic across packages, so discovering a new unbootstrapped package
+      # inside `changeset publish` would otherwise repeat the partial release
+      # that stranded the July 2026 versions.
+      - name: Preflight npm release state
+        id: npm_release
+        run: pnpm release:preflight
+
       - name: Publish to npm
         id: changesets
+        if: steps.npm_release.outputs.needs_publish == 'true'
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
         with:
           publish: pnpm changeset:publish

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,46 @@
+# Releases
+
+Changesets opens the `Version Packages` pull request. Publishing is a separate,
+privileged workflow: after any successful `main` CI run, `publish.yml` checks
+every publishable workspace version against npm and runs `changeset publish`
+only when at least one version is missing.
+
+This is deliberately a reconciliation loop rather than a one-shot tied to the
+Version Packages commit. If that commit's CI fails, a later fix on `main` can
+publish the stranded versions after it passes the same required checks.
+
+## New package bootstrap
+
+npm trusted publishing can only be configured after a package exists. Before a
+new public workspace package can join automated releases, a maintainer must
+publish its first version interactively and then authorize this repository's
+publish workflow:
+
+```bash
+pnpm --filter <package-name> publish --access public --no-git-checks
+npm trust github <package-name> \
+  --file publish.yml \
+  --repo octanejs/octane \
+  --allow-publish
+```
+
+Run this from a clean, validated `main` checkout with npm 11.15 or newer and an
+npm account that owns the package and has two-factor authentication enabled.
+The interactive publish is intentionally not automated with a long-lived token.
+
+`pnpm release:preflight` lists every package that needs this bootstrap and exits
+before any existing package is published. After bootstrapping, rerun the failed
+Publish workflow, or dispatch `publish.yml` with the ID of any successful CI
+push run on `main`.
+
+## Recovery
+
+The Publish workflow accepts only successful CI push runs from
+`octanejs/octane`, the `main` branch, and `.github/workflows/ci.yml`. It also
+requires every protected package, compatibility, typecheck, example, lint, and
+test job to have succeeded.
+
+Because npm package versions are immutable, the preflight is safe to repeat:
+already-published versions are skipped. It also refuses a stale checkout when a
+newer npm version exists, preventing an out-of-order workflow from moving the
+`latest` tag backwards.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -8,6 +8,9 @@ only when at least one version is missing.
 This is deliberately a reconciliation loop rather than a one-shot tied to the
 Version Packages commit. If that commit's CI fails, a later fix on `main` can
 publish the stranded versions after it passes the same required checks.
+Pending changeset documents are isolated only inside the ephemeral publish
+checkout so they cannot switch the publishing action back into version-PR mode;
+the Release PR workflow remains their sole owner.
 
 ## New package bootstrap
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "changeset:check": "node scripts/check-changesets.js",
     "changeset:version": "pnpm changeset:check && changeset version && pnpm bindings:status && pnpm packages:inventory && pnpm --filter @octanejs/evals corpus:generate",
     "changeset:publish": "pnpm changeset:check && changeset publish",
+    "release:preflight": "node scripts/npm-release-preflight.mjs",
+    "release:preflight:test": "node --test scripts/npm-release-preflight.test.mjs",
     "prepare": "rulesync generate || true",
     "rules:generate": "rulesync generate",
     "rules:check": "rulesync generate --check",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "changeset:publish": "pnpm changeset:check && changeset publish",
     "release:preflight": "node scripts/npm-release-preflight.mjs",
     "release:preflight:test": "node --test scripts/npm-release-preflight.test.mjs",
+    "release:prepare-publish": "node scripts/prepare-changesets-publish.mjs",
     "prepare": "rulesync generate || true",
     "rules:generate": "rulesync generate",
     "rules:check": "rulesync generate --check",

--- a/scripts/npm-release-preflight.mjs
+++ b/scripts/npm-release-preflight.mjs
@@ -1,0 +1,221 @@
+import { appendFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+import { getPublishablePackages } from './workspace-packages.mjs';
+
+const DEFAULT_REGISTRY = 'https://registry.npmjs.org/';
+const DEFAULT_CONCURRENCY = 8;
+const REQUEST_TIMEOUT_MS = 15_000;
+
+function parseSemver(version) {
+	const match =
+		/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.exec(
+			version,
+		);
+	if (!match) throw new Error(`invalid semantic version ${JSON.stringify(version)}`);
+	return {
+		major: Number(match[1]),
+		minor: Number(match[2]),
+		patch: Number(match[3]),
+		prerelease: match[4]?.split('.') ?? [],
+	};
+}
+
+function comparePrerelease(left, right) {
+	if (left.length === 0 || right.length === 0) {
+		if (left.length === right.length) return 0;
+		return left.length === 0 ? 1 : -1;
+	}
+	const length = Math.max(left.length, right.length);
+	for (let index = 0; index < length; index++) {
+		const leftPart = left[index];
+		const rightPart = right[index];
+		if (leftPart === undefined) return -1;
+		if (rightPart === undefined) return 1;
+		if (leftPart === rightPart) continue;
+
+		const leftNumeric = /^(?:0|[1-9]\d*)$/.test(leftPart);
+		const rightNumeric = /^(?:0|[1-9]\d*)$/.test(rightPart);
+		if (leftNumeric && rightNumeric) return Number(leftPart) < Number(rightPart) ? -1 : 1;
+		if (leftNumeric !== rightNumeric) return leftNumeric ? -1 : 1;
+		return leftPart < rightPart ? -1 : 1;
+	}
+	return 0;
+}
+
+export function compareSemver(leftVersion, rightVersion) {
+	const left = parseSemver(leftVersion);
+	const right = parseSemver(rightVersion);
+	for (const field of ['major', 'minor', 'patch']) {
+		if (left[field] !== right[field]) return left[field] < right[field] ? -1 : 1;
+	}
+	return comparePrerelease(left.prerelease, right.prerelease);
+}
+
+function registryPackageUrl(registry, packageName) {
+	return new URL(encodeURIComponent(packageName), registry).href;
+}
+
+async function inspectPackage(pkg, fetchImpl, registry) {
+	let response;
+	try {
+		response = await fetchImpl(registryPackageUrl(registry, pkg.name), {
+			headers: { accept: 'application/vnd.npm.install-v1+json' },
+			signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+		});
+	} catch (error) {
+		return {
+			...pkg,
+			state: 'unreachable',
+			reason: error instanceof Error ? error.message : String(error),
+		};
+	}
+
+	if (response.status === 404) return { ...pkg, state: 'unbootstrapped' };
+	if (!response.ok) {
+		return {
+			...pkg,
+			state: 'unreachable',
+			reason: `registry returned HTTP ${response.status}`,
+		};
+	}
+
+	let metadata;
+	try {
+		metadata = await response.json();
+	} catch (error) {
+		return {
+			...pkg,
+			state: 'unreachable',
+			reason: `registry returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+		};
+	}
+
+	if (Object.hasOwn(metadata.versions ?? {}, pkg.version)) {
+		return { ...pkg, state: 'published' };
+	}
+
+	const latest = metadata['dist-tags']?.latest;
+	if (typeof latest !== 'string') {
+		return { ...pkg, state: 'invalid', reason: 'registry metadata has no latest dist-tag' };
+	}
+
+	let comparison;
+	try {
+		comparison = compareSemver(pkg.version, latest);
+	} catch (error) {
+		return {
+			...pkg,
+			state: 'invalid',
+			reason: error instanceof Error ? error.message : String(error),
+		};
+	}
+	if (comparison <= 0) {
+		return {
+			...pkg,
+			state: 'invalid',
+			reason: `local version is absent while npm latest is ${latest}`,
+		};
+	}
+	return { ...pkg, state: 'pending', latest };
+}
+
+async function mapWithConcurrency(values, concurrency, callback) {
+	const results = new Array(values.length);
+	let nextIndex = 0;
+	async function worker() {
+		while (nextIndex < values.length) {
+			const index = nextIndex++;
+			results[index] = await callback(values[index]);
+		}
+	}
+	const workerCount = Math.min(concurrency, values.length);
+	await Promise.all(Array.from({ length: workerCount }, () => worker()));
+	return results;
+}
+
+export async function inspectNpmReleaseState(
+	packages,
+	{ concurrency = DEFAULT_CONCURRENCY, fetchImpl = fetch, registry = DEFAULT_REGISTRY } = {},
+) {
+	if (!Number.isSafeInteger(concurrency) || concurrency <= 0) {
+		throw new Error(`concurrency must be a positive integer, received ${concurrency}`);
+	}
+	const normalizedRegistry = registry.endsWith('/') ? registry : `${registry}/`;
+	const identities = packages
+		.map(({ name, version }) => ({ name, version }))
+		.sort((left, right) => left.name.localeCompare(right.name));
+	const results = await mapWithConcurrency(identities, concurrency, (pkg) =>
+		inspectPackage(pkg, fetchImpl, normalizedRegistry),
+	);
+
+	return {
+		published: results.filter((entry) => entry.state === 'published'),
+		pending: results.filter((entry) => entry.state === 'pending'),
+		unbootstrapped: results.filter((entry) => entry.state === 'unbootstrapped'),
+		invalid: results.filter((entry) => entry.state === 'invalid'),
+		unreachable: results.filter((entry) => entry.state === 'unreachable'),
+	};
+}
+
+function identity(pkg) {
+	return `${pkg.name}@${pkg.version}`;
+}
+
+export function releaseStateErrors(state) {
+	const errors = [];
+	if (state.unbootstrapped.length > 0) {
+		errors.push(
+			`npm packages require one-time bootstrap before trusted publishing:\n${state.unbootstrapped
+				.map((pkg) => `  - ${identity(pkg)}`)
+				.join('\n')}\nFollow docs/releases.md, then rerun this workflow.`,
+		);
+	}
+	for (const pkg of state.invalid) {
+		errors.push(`${identity(pkg)} cannot be published safely: ${pkg.reason}`);
+	}
+	for (const pkg of state.unreachable) {
+		errors.push(`${identity(pkg)} could not be checked: ${pkg.reason}`);
+	}
+	return errors;
+}
+
+export function renderReleaseSummary(state) {
+	const lines = [
+		'## npm release preflight',
+		'',
+		`- Already published: ${state.published.length}`,
+		`- Ready to publish: ${state.pending.length}`,
+		`- Require bootstrap: ${state.unbootstrapped.length}`,
+		`- Invalid release state: ${state.invalid.length}`,
+		`- Registry errors: ${state.unreachable.length}`,
+	];
+	for (const [label, packages] of [
+		['Ready to publish', state.pending],
+		['Require bootstrap', state.unbootstrapped],
+	]) {
+		if (packages.length === 0) continue;
+		lines.push('', `### ${label}`, '', ...packages.map((pkg) => `- \`${identity(pkg)}\``));
+	}
+	return `${lines.join('\n')}\n`;
+}
+
+async function runCli() {
+	const state = await inspectNpmReleaseState(getPublishablePackages());
+	const errors = releaseStateErrors(state);
+	const needsPublish = errors.length === 0 && state.pending.length > 0;
+	const summary = renderReleaseSummary(state);
+
+	process.stdout.write(summary);
+	if (process.env.GITHUB_OUTPUT) {
+		appendFileSync(process.env.GITHUB_OUTPUT, `needs_publish=${needsPublish}\n`);
+	}
+	if (process.env.GITHUB_STEP_SUMMARY) {
+		appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
+	}
+	if (errors.length > 0) {
+		for (const error of errors) console.error(`\n${error}`);
+		process.exitCode = 1;
+	}
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) await runCli();

--- a/scripts/npm-release-preflight.test.mjs
+++ b/scripts/npm-release-preflight.test.mjs
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+	compareSemver,
+	inspectNpmReleaseState,
+	releaseStateErrors,
+} from './npm-release-preflight.mjs';
+
+function registryFixture(packages) {
+	return async (url) => {
+		const name = decodeURIComponent(new URL(url).pathname.slice(1));
+		const metadata = packages[name];
+		if (metadata === undefined) {
+			return { ok: false, status: 404, json: async () => ({ error: 'Not found' }) };
+		}
+		if (metadata instanceof Error) throw metadata;
+		return { ok: true, status: 200, json: async () => metadata };
+	};
+}
+
+function metadata(latest, versions) {
+	return {
+		'dist-tags': { latest },
+		versions: Object.fromEntries(versions.map((version) => [version, {}])),
+	};
+}
+
+describe('npm release preflight', () => {
+	test('treats exact registry versions as already published', async () => {
+		const state = await inspectNpmReleaseState(
+			[
+				{ name: 'octane', version: '0.1.16' },
+				{ name: '@octanejs/app-core', version: '0.0.12' },
+			],
+			{
+				fetchImpl: registryFixture({
+					octane: metadata('0.1.16', ['0.1.15', '0.1.16']),
+					'@octanejs/app-core': metadata('0.0.13', ['0.0.12', '0.0.13']),
+				}),
+			},
+		);
+
+		assert.deepEqual(
+			state.published.map((pkg) => `${pkg.name}@${pkg.version}`),
+			['@octanejs/app-core@0.0.12', 'octane@0.1.16'],
+		);
+		assert.deepEqual(state.pending, []);
+		assert.deepEqual(releaseStateErrors(state), []);
+	});
+
+	test('reconciles unpublished versions after a later successful main build', async () => {
+		const state = await inspectNpmReleaseState(
+			[
+				{ name: 'octane', version: '0.1.16' },
+				{ name: '@octanejs/app-core', version: '0.0.12' },
+			],
+			{
+				fetchImpl: registryFixture({
+					octane: metadata('0.1.13', ['0.1.13']),
+					'@octanejs/app-core': metadata('0.0.9', ['0.0.9']),
+				}),
+			},
+		);
+
+		assert.deepEqual(
+			state.pending.map((pkg) => `${pkg.name}@${pkg.version}`),
+			['@octanejs/app-core@0.0.12', 'octane@0.1.16'],
+		);
+		assert.deepEqual(releaseStateErrors(state), []);
+	});
+
+	test('blocks the complete release before an unbootstrapped package can cause a partial publish', async () => {
+		const state = await inspectNpmReleaseState(
+			[
+				{ name: 'octane', version: '0.1.16' },
+				{ name: '@octanejs/tanstack-hotkeys', version: '0.0.5' },
+			],
+			{ fetchImpl: registryFixture({ octane: metadata('0.1.13', ['0.1.13']) }) },
+		);
+
+		assert.deepEqual(
+			state.unbootstrapped.map((pkg) => `${pkg.name}@${pkg.version}`),
+			['@octanejs/tanstack-hotkeys@0.0.5'],
+		);
+		assert.match(releaseStateErrors(state)[0], /one-time bootstrap/);
+	});
+
+	test('blocks a stale SHA from publishing a missing version behind npm latest', async () => {
+		const state = await inspectNpmReleaseState([{ name: 'octane', version: '0.1.15' }], {
+			fetchImpl: registryFixture({
+				octane: metadata('0.1.16', ['0.1.13', '0.1.16']),
+			}),
+		});
+
+		assert.deepEqual(state.pending, []);
+		assert.match(releaseStateErrors(state)[0], /npm latest is 0\.1\.16/);
+	});
+
+	test('fails closed when registry state cannot be read', async () => {
+		const state = await inspectNpmReleaseState([{ name: 'octane', version: '0.1.16' }], {
+			fetchImpl: registryFixture({ octane: new Error('registry unavailable') }),
+		});
+
+		assert.match(releaseStateErrors(state)[0], /registry unavailable/);
+	});
+});
+
+describe('compareSemver', () => {
+	test('orders stable and prerelease versions', () => {
+		assert.equal(compareSemver('0.1.16', '0.1.15'), 1);
+		assert.equal(compareSemver('0.1.16', '0.1.16'), 0);
+		assert.equal(compareSemver('0.1.16-beta.2', '0.1.16-beta.11'), -1);
+		assert.equal(compareSemver('0.1.16', '0.1.16-beta.11'), 1);
+	});
+});

--- a/scripts/npm-release-preflight.test.mjs
+++ b/scripts/npm-release-preflight.test.mjs
@@ -1,10 +1,14 @@
 import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import { describe, test } from 'node:test';
 import {
 	compareSemver,
 	inspectNpmReleaseState,
 	releaseStateErrors,
 } from './npm-release-preflight.mjs';
+import { isolatePendingChangesets } from './prepare-changesets-publish.mjs';
 
 function registryFixture(packages) {
 	return async (url) => {
@@ -111,5 +115,39 @@ describe('compareSemver', () => {
 		assert.equal(compareSemver('0.1.16', '0.1.16'), 0);
 		assert.equal(compareSemver('0.1.16-beta.2', '0.1.16-beta.11'), -1);
 		assert.equal(compareSemver('0.1.16', '0.1.16-beta.11'), 1);
+	});
+});
+
+describe('npm publish preparation', () => {
+	test('keeps pending release plans from switching the recovery action into version mode', async () => {
+		const root = await mkdtemp(path.join(os.tmpdir(), 'octane-publish-'));
+		const directory = path.join(root, '.changeset');
+		await mkdir(directory);
+		await Promise.all([
+			writeFile(path.join(directory, 'config.json'), '{}'),
+			writeFile(path.join(directory, 'README.md'), 'Changesets documentation'),
+			writeFile(path.join(directory, 'pending-release.md'), 'pending release'),
+			writeFile(path.join(directory, 'empty-release.md'), 'empty release'),
+		]);
+
+		try {
+			assert.deepEqual(await isolatePendingChangesets(directory), [
+				'empty-release.md',
+				'pending-release.md',
+			]);
+			assert.deepEqual((await readdir(directory)).sort(), [
+				'.empty-release.md.publish-pending',
+				'.pending-release.md.publish-pending',
+				'README.md',
+				'config.json',
+			]);
+			assert.equal(
+				await readFile(path.join(directory, '.pending-release.md.publish-pending'), 'utf8'),
+				'pending release',
+			);
+			assert.deepEqual(await isolatePendingChangesets(directory), []);
+		} finally {
+			await rm(root, { force: true, recursive: true });
+		}
 	});
 });

--- a/scripts/prepare-changesets-publish.mjs
+++ b/scripts/prepare-changesets-publish.mjs
@@ -1,0 +1,58 @@
+import { access, readdir, rename } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const CHANGESET_DIRECTORY = path.resolve('.changeset');
+const PUBLISH_SUFFIX = '.publish-pending';
+
+async function pathExists(filePath) {
+	try {
+		await access(filePath);
+		return true;
+	} catch (error) {
+		if (error?.code === 'ENOENT') return false;
+		throw error;
+	}
+}
+
+function isPendingChangeset(entry) {
+	return (
+		entry.isFile() &&
+		!entry.name.startsWith('.') &&
+		entry.name.endsWith('.md') &&
+		entry.name.toLowerCase() !== 'readme.md'
+	);
+}
+
+export async function isolatePendingChangesets(directory = CHANGESET_DIRECTORY) {
+	const entries = await readdir(directory, { withFileTypes: true });
+	const changesets = entries.filter(isPendingChangeset).sort((left, right) => {
+		return left.name.localeCompare(right.name);
+	});
+
+	for (const entry of changesets) {
+		const source = path.join(directory, entry.name);
+		const destination = path.join(directory, `.${entry.name}${PUBLISH_SUFFIX}`);
+		if (await pathExists(destination)) {
+			throw new Error(`refusing to overwrite isolated changeset ${destination}`);
+		}
+		await rename(source, destination);
+	}
+
+	return changesets.map((entry) => entry.name);
+}
+
+async function runCli() {
+	const isolated = await isolatePendingChangesets();
+	if (isolated.length === 0) {
+		console.log('No pending changesets need isolation.');
+		return;
+	}
+	console.log(
+		`Isolated ${isolated.length} pending changeset(s) from the npm publish action:\n${isolated
+			.map((file) => `  - ${file}`)
+			.join('\n')}`,
+	);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) await runCli();


### PR DESCRIPTION
## Summary

- reconcile npm publication after every successful main CI run, so a later fix commit can recover versions stranded by a failed Version Packages build
- preflight every publishable workspace package against npm before Changesets starts, failing closed for unbootstrapped packages, registry errors, and stale or out-of-order versions
- test the reconciliation contract in unprivileged CI and document trusted-publisher bootstrap and recovery procedures

## Root cause

Publishing only ran when the successful CI commit message contained Version Packages. PR #279 merged version bumps, but that commit failed CI; later successful main commits therefore could not retry its npm publication. Earlier releases also reached Changesets before discovering new packages that lacked their one-time npm bootstrap, allowing partial publication.

## Current recovery state

The live preflight reports all three formerly missing TanStack packages at 0.0.5 as published and trusted-publishing-ready. The other 45 workspace versions are pending with no invalid or unreachable registry entries. Once this lands, the next successful main CI run can publish that backlog.

## Validation

- release preflight unit tests
- live npm registry preflight: 3 published, 45 ready, 0 errors
- full repository typecheck
- repository-wide format check
- changeset policy check
- generated eval corpus check
- RuleSync generated-file check
- workflow YAML parse and staged diff check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the privileged npm publish workflow and gating logic for every package release; mistakes could block publishes or allow unsafe partial/out-of-order releases despite new safeguards.
> 
> **Overview**
> Replaces **one-shot publishing tied to Version Packages commits** with an **npm reconciliation loop** after every successful `main` CI push (or manual dispatch against a validated CI run).
> 
> **Privileged `publish.yml`** now runs `release:preflight` against all publishable workspace versions before Changesets: skip already-published versions, publish only when something is missing, **fail closed** on unbootstrapped packages, registry errors, or local versions behind npm `latest`. Pending `.changeset` markdown is **renamed in the ephemeral checkout** so `changesets/action` publishes instead of opening another version PR. Legacy “failed inline publish on Version Packages run” recovery is removed in favor of requiring full CI success.
> 
> **Unprivileged CI** runs `release:preflight:test` so the registry-classification contract stays covered without network access. **`docs/releases.md`** documents bootstrap for trusted publishing and recovery via workflow dispatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec2c41eb586e880674065da959feeec56ed6202f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->