### PR TITLE
Fix Provider children dialect flips, and allocate scope collections lazily

### DIFF
--- a/.changeset/lazy-scope-collections.md
+++ b/.changeset/lazy-scope-collections.md
@@ -1,0 +1,19 @@
+---
+'octane': patch
+---
+
+Allocate a Scope's `cleanups` and `children` arrays lazily.
+
+Both were created eagerly for every Scope even though most scopes never register
+a cleanup or a child scope, while the neighbouring `hooks`, `effectSlots` and
+`_slots` fields were already lazy. They now follow the same pattern: `null` until
+something registers, allocated at the registration site.
+
+On a 500-row × 3-cell tree (2,501 scopes) this removes 4,002 of the 7,503 array
+allocations those three collections were making — every `cleanups` array and 60%
+of the `children` arrays. Compiled output grows 17 bytes gzipped across the
+16-file codegen corpus, from the `??=` at the three cleanup-registration sites.
+
+`slots` deliberately stays eager: every scope in that same measurement used it,
+so making it lazy would add a null check to the framework's hottest path and to
+every emitted `__s.slots[N]` access while saving nothing.

--- a/.changeset/provider-children-dialect-flip.md
+++ b/.changeset/provider-children-dialect-flip.md
@@ -1,0 +1,16 @@
+---
+'octane': patch
+---
+
+Fix a context Provider corrupting the tree when its children switch dialect.
+
+A Provider accepts its children either as the compiled children-block function a
+`.tsrx` parent passes, or as an element descriptor from a `createElement` parent.
+Both claimed `scope.slots[0]` — a compiled body stores its binding bag there,
+while the descriptor path stores a `childSlot` record — so a parent that wraps
+its children conditionally, and therefore alternates between the two shapes
+across renders, had the incoming dialect read the outgoing one's record as its
+own. The result was a `TypeError` and a detached subtree.
+
+The children now remount across such a flip, which is the same contract React
+gives an element-type change.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -16057,9 +16057,11 @@ function propertyIsEnumerableCall(objNode, name) {
 	);
 }
 
-// `__s.cleanups.push(<fn>)`.
+// `(__s.cleanups ??= []).push(<fn>)` — the scope's cleanup array is lazily allocated (most
+// scopes never register one), so the registration site owns creating it.
 function cleanupsPush(fnNode) {
-	return b.stmt(b.call(b.member(b.member(b.id('__s'), 'cleanups'), 'push'), fnNode));
+	const lazyArray = b.assignment('??=', b.member(b.id('__s'), 'cleanups'), b.array([]));
+	return b.stmt(b.call(b.member(lazyArray, 'push'), fnNode));
 }
 
 // Mount for a DEFERRED property-write binding: store the element ref + seed the

--- a/packages/octane/src/devtools-hook.ts
+++ b/packages/octane/src/devtools-hook.ts
@@ -14,7 +14,8 @@ export interface DevtoolsScopeLike {
 	body?: unknown; // Block.body (the component function); used by the name resolver
 	hooks: Map<symbol | number, any> | null;
 	effectSlots: any[] | null;
-	children: Array<{ key: symbol | string | number; scope: DevtoolsScopeLike }>;
+	// Lazily allocated by the runtime — null on a scope that never registered a child.
+	children: Array<{ key: symbol | string | number; scope: DevtoolsScopeLike }> | null;
 	$$ctxValues?: Map<any, any> | null;
 }
 
@@ -145,7 +146,7 @@ function buildNode(
 		id,
 		name: nameOf(scope, key),
 		kind: scope.kind ?? 'component',
-		children: scope.children.map((c) => buildNode(c.scope, c.key)),
+		children: scope.children === null ? [] : scope.children.map((c) => buildNode(c.scope, c.key)),
 	};
 }
 

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -5124,6 +5124,11 @@ function resetScopeChildren(scope: Scope): void {
 		scope.effectSlots = null;
 		scope.hooks = null;
 		scope.slots = [];
+		// The compiled ref manifest describes the OUTGOING body's binding bag. A compiled body
+		// re-stamps its own on mount, but the descriptor dialect never does — it would leave the
+		// old manifest pointed at a `childSlot` record, which `detachSubtreeRefs` would then read
+		// as a bag.
+		scope.refFields = null;
 	} finally {
 		if (--TEARDOWN_DEPTH === 0) dispatchTeardownErrors();
 	}

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -5094,24 +5094,39 @@ const CHILDREN_DIALECT_SLOT = Symbol('octane.childrenDialect') as HookSlot;
  * no hooks of its own, so every hook in the map belongs to the children being replaced.
  */
 function resetScopeChildren(scope: Scope): void {
-	unmountScopeChildrenAndSlots(scope, true);
-
-	// Child scopes and slots detach their own DOM above, but a compiled body also creates host
-	// nodes directly in the Block's range. Clear whatever is left of it. `removeRange` stops
-	// BEFORE the end marker, so borrowed markers survive for their owning slot; a null start or
-	// end means the Block runs to that edge of its parent (marker elision).
+	// This deletion runs mid-render rather than through `unmountBlock`, so it has to install the
+	// same teardown bracket that path does — otherwise a cleanup that throws would find no handler
+	// and be logged instead of reaching the boundary enclosing the deletion.
 	const block = scope.block;
-	const start = block.startMarker;
-	removeRange(start !== null ? start.nextSibling : block.parentNode.firstChild, block.endMarker);
+	if (TEARDOWN_DEPTH === 0) {
+		TEARDOWN_HANDLER = findTryHandler(block.parentBlock) ?? rendererRegionTryHandler(block);
+	}
+	TEARDOWN_DEPTH++;
+	// The bracket spans the WHOLE reset, not just the teardown call: a queued error is dispatched
+	// when the depth returns to zero, and its handler re-renders the enclosing boundary. Running
+	// that while the scope is half torn down would have the handler walk a scope whose DOM range
+	// and slot arrays disagree, so the scope is left consistent first.
+	try {
+		unmountScopeChildrenAndSlots(scope, true);
 
-	// Drop the collections rather than emptying them: the lazily-allocated ones go back to null,
-	// and `slots` gets a fresh array (compiled bodies index it directly, so it stays non-null).
-	scope.children = null;
-	scope.cleanups = null;
-	scope._slots = null;
-	scope.effectSlots = null;
-	scope.hooks = null;
-	scope.slots = [];
+		// Child scopes and slots detach their own DOM above, but a compiled body also creates host
+		// nodes directly in the Block's range. Clear whatever is left of it. `removeRange` stops
+		// BEFORE the end marker, so borrowed markers survive for their owning slot; a null start or
+		// end means the Block runs to that edge of its parent (marker elision).
+		const start = block.startMarker;
+		removeRange(start !== null ? start.nextSibling : block.parentNode.firstChild, block.endMarker);
+
+		// Drop the collections rather than emptying them: the lazily-allocated ones go back to null,
+		// and `slots` gets a fresh array (compiled bodies index it directly, so it stays non-null).
+		scope.children = null;
+		scope.cleanups = null;
+		scope._slots = null;
+		scope.effectSlots = null;
+		scope.hooks = null;
+		scope.slots = [];
+	} finally {
+		if (--TEARDOWN_DEPTH === 0) dispatchTeardownErrors();
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -12436,6 +12436,12 @@ function formDiagnosticOutcome(el: Element): FormDiagnosticOutcome | null {
 		el.hasAttribute('disabled')
 	)
 		return null;
+	// An aria-hidden control is a form-interop MIRROR (AT-hidden and, by the
+	// pattern's contract, focus-excluded — e.g. the hidden "bubble inputs"
+	// radix-style libraries render behind a custom control): users cannot reach
+	// it, so handler-less controlled props are the intended wiring, not the
+	// authoring mistake this diagnostic exists to catch.
+	if (el.getAttribute('aria-hidden') === 'true') return null;
 
 	const hasInput =
 		isUsableEventSlot(host.$$input as EventSlot) ||

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -4987,7 +4987,14 @@ export function createContext<T>(defaultValue: T): Context<T> {
 			const dialect = typeof props.children === 'function' ? 1 : 2;
 			const previous = scope.hooks?.get(CHILDREN_DIALECT_SLOT);
 			if (previous !== dialect) {
-				if (previous !== undefined) resetScopeChildren(scope);
+				if (previous !== undefined) {
+					resetScopeChildren(scope);
+					// The reset runs user cleanups, so it can throw into the enclosing boundary and
+					// switch it to its catch arm — which disposes this block. Rendering children
+					// into a disposed block writes into the catch range, so bail out here, as every
+					// other mid-render teardown site does after `unmountBlock`.
+					if (scope.block.disposed) return;
+				}
 				ensureHooks(scope).set(CHILDREN_DIALECT_SLOT, dialect);
 			}
 			childrenAsBody(props.children)(undefined, scope, undefined);

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -4964,7 +4964,23 @@ export function createContext<T>(defaultValue: T): Context<T> {
 		//     into `props.children` (a descriptor, an array, or text — never a function).
 		// `childrenAsBody` normalizes either shape to a callable body, so both dialects
 		// render their children inside the Provider's scope (and thus under its context).
+		//
+		// The two dialects both claim `scope.slots[0]` — a compiled body stores its binding
+		// bag there, while the descriptor path's `childSlot(scope, 0, …)` stores a childSlot
+		// record. A parent that wraps its children conditionally (common in ported React
+		// bindings) flips between them across renders, so the incoming dialect would read the
+		// outgoing one's record as its own and corrupt the tree. Remount the children on a
+		// flip instead: the two sides are structurally different code, which is the same
+		// contract React gives an element-type change.
 		if (props.children != null) {
+			// Steady state is one map read and an integer compare — the write happens only on the
+			// first render and on an actual flip.
+			const dialect = typeof props.children === 'function' ? 1 : 2;
+			const previous = scope.hooks?.get(CHILDREN_DIALECT_SLOT);
+			if (previous !== dialect) {
+				if (previous !== undefined) resetScopeChildren(scope);
+				ensureHooks(scope).set(CHILDREN_DIALECT_SLOT, dialect);
+			}
 			childrenAsBody(props.children)(undefined, scope, undefined);
 		}
 	} as Context<T>;
@@ -5050,6 +5066,43 @@ function childrenAsBody(children: unknown): ComponentBody {
 	return (_p, s) => {
 		childSlot(s, 0, s.block.parentNode, children, s.block.endMarker);
 	};
+}
+
+/**
+ * Records which children dialect (1 = compiled body, 2 = descriptor) a scope last rendered, so a
+ * flip can be detected. Lives in the hook map, whose Symbol keys are disjoint from the numeric
+ * `slots` indices the two dialects contend over.
+ */
+const CHILDREN_DIALECT_SLOT = Symbol('octane.childrenDialect') as HookSlot;
+
+/**
+ * Tear down everything a scope rendered and hand it back empty, so a caller can re-render it from
+ * scratch in the same Block. Used when a scope's children switch dialect: the outgoing dialect's
+ * `slots`/`_slots`/child-scope state is meaningless to the incoming one, and leaving it in place
+ * would have the incoming dialect adopt records of the wrong kind.
+ *
+ * The scope's own hook state goes with it. That is correct for the one caller — a Provider keeps
+ * no hooks of its own, so every hook in the map belongs to the children being replaced.
+ */
+function resetScopeChildren(scope: Scope): void {
+	unmountScopeChildrenAndSlots(scope, true);
+
+	// Child scopes and slots detach their own DOM above, but a compiled body also creates host
+	// nodes directly in the Block's range. Clear whatever is left of it. `removeRange` stops
+	// BEFORE the end marker, so borrowed markers survive for their owning slot; a null start or
+	// end means the Block runs to that edge of its parent (marker elision).
+	const block = scope.block;
+	const start = block.startMarker;
+	removeRange(start !== null ? start.nextSibling : block.parentNode.firstChild, block.endMarker);
+
+	// Truncate the eagerly-allocated arrays in place rather than replacing them: same empty
+	// result, no garbage, and the Scope keeps the backing store it already sized.
+	scope.children.length = 0;
+	scope.cleanups.length = 0;
+	scope.slots.length = 0;
+	scope._slots = null;
+	scope.effectSlots = null;
+	scope.hooks = null;
 }
 
 // ---------------------------------------------------------------------------
@@ -12374,12 +12427,6 @@ function formDiagnosticOutcome(el: Element): FormDiagnosticOutcome | null {
 		el.hasAttribute('disabled')
 	)
 		return null;
-	// An aria-hidden control is a form-interop MIRROR (AT-hidden and, by the
-	// pattern's contract, focus-excluded — e.g. the hidden "bubble inputs"
-	// radix-style libraries render behind a custom control): users cannot reach
-	// it, so handler-less controlled props are the intended wiring, not the
-	// authoring mistake this diagnostic exists to catch.
-	if (el.getAttribute('aria-hidden') === 'true') return null;
 
 	const hasInput =
 		isUsableEventSlot(host.$$input as EventSlot) ||

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -201,7 +201,12 @@ export interface Scope {
 	 * `undefined` when null, identical to a Map.get miss.
 	 */
 	hooks: Map<HookSlot, any> | null;
-	cleanups: Cleanup[];
+	/**
+	 * Teardown callbacks (ref detaches, listener removal, slot cleanup). Lazily allocated by
+	 * `pushCleanup` — most scopes never register one, so the array is only paid for on demand,
+	 * matching `hooks` / `effectSlots` / `_slots`.
+	 */
+	cleanups: Cleanup[] | null;
 	/**
 	 * This scope's effect slots in hook DECLARATION order (first-enqueue order —
 	 * the order the hooks ran in the scope's first render). unmountScope walks it
@@ -218,8 +223,10 @@ export interface Scope {
 	 * (NOT a Map): iteration is a plain indexed for-loop, and lookups are linear
 	 * scans — faster than `Map.get` for the typical N ≤ 8 case (most components
 	 * have a handful of static sub-component calls at most).
+	 *
+	 * Lazily allocated when the first child scope registers: a leaf component has none.
 	 */
-	children: ChildScope[];
+	children: ChildScope[] | null;
 	mounted: boolean;
 	/**
 	 * Slot objects owned by this scope (ifBlockSlot, forBlockSlot, etc.).
@@ -3147,9 +3154,9 @@ class BlockImpl {
 	inactive: boolean;
 	// Hooks + cleanups (per-block state).
 	hooks: Map<HookSlot, any> | null;
-	cleanups: Cleanup[];
+	cleanups: Cleanup[] | null;
 	effectSlots: EffectSlot[] | null;
-	children: ChildScope[];
+	children: ChildScope[] | null;
 	_slots: any[] | null;
 	refFields: string[] | null;
 	$$ctxValues: Map<Context<any>, any> | null;
@@ -3237,9 +3244,9 @@ class BlockImpl {
 		this.currentRenderDeferred = false;
 		this.inactive = false;
 		this.hooks = null;
-		this.cleanups = [];
+		this.cleanups = null;
 		this.effectSlots = null;
-		this.children = [];
+		this.children = null;
 		this._slots = null;
 		this.refFields = null;
 		this.$$ctxValues = null;
@@ -3284,9 +3291,9 @@ class ScopeImpl {
 	block: Block;
 	parent: Scope | null;
 	hooks: Map<HookSlot, any> | null;
-	cleanups: Cleanup[];
+	cleanups: Cleanup[] | null;
 	effectSlots: EffectSlot[] | null;
-	children: ChildScope[];
+	children: ChildScope[] | null;
 	_slots: any[] | null;
 	refFields: string[] | null;
 	$$ctxValues: Map<Context<any>, any> | null;
@@ -3301,9 +3308,9 @@ class ScopeImpl {
 		this.block = block;
 		this.parent = parent;
 		this.hooks = null;
-		this.cleanups = [];
+		this.cleanups = null;
 		this.effectSlots = null;
-		this.children = [];
+		this.children = null;
 		this._slots = null;
 		this.refFields = null;
 		this.slots = [];
@@ -3794,7 +3801,7 @@ export function componentSlotLite<P>(
 		}
 		parentScope.slots[slotKey] = scope;
 		// Register on parent.children so unmountScope(parent) walks into us.
-		parentScope.children.push({ key: slotKey, scope });
+		(parentScope.children ??= []).push({ key: slotKey, scope });
 	} else {
 		// Re-render: the parent's host/anchor are stable across renders so no
 		// need to rebuild the LiteBlockImpl. Skip the allocation on warm path.
@@ -4003,20 +4010,22 @@ function unmountScope(scope: Scope, detachDom: boolean = true): void {
 // so its recursive cleanup must not manufacture a matching detach.
 function unmountScopeChildrenAndSlots(scope: Scope, detachDom: boolean): void {
 	const c = scope.cleanups;
-	for (let i = c.length - 1; i >= 0; i--) {
-		try {
-			runEffectLifecycleCallback(c[i]);
-		} catch (err) {
-			// Route to the boundary enclosing the DELETION (collected + dispatched
-			// after the walk — see reportTeardownError); React parity: an error in a
-			// deletion-phase cleanup reaches the nearest still-mounted boundary
-			// instead of being swallowed (ReactErrorBoundaries:1927).
-			reportTeardownError(err);
+	if (c !== null)
+		for (let i = c.length - 1; i >= 0; i--) {
+			try {
+				runEffectLifecycleCallback(c[i]);
+			} catch (err) {
+				// Route to the boundary enclosing the DELETION (collected + dispatched
+				// after the walk — see reportTeardownError); React parity: an error in a
+				// deletion-phase cleanup reaches the nearest still-mounted boundary
+				// instead of being swallowed (ReactErrorBoundaries:1927).
+				reportTeardownError(err);
+			}
 		}
-	}
 	// Then recurse into child scopes (parent → child order).
 	const children = scope.children;
-	for (let i = 0, n = children.length; i < n; i++) unmountScope(children[i].scope, detachDom);
+	if (children !== null)
+		for (let i = 0, n = children.length; i < n; i++) unmountScope(children[i].scope, detachDom);
 	// Walk slot-stashed child Blocks (ifBlock / forBlock / componentSlot / portal).
 	const slots = scope._slots;
 	if (slots !== null) {
@@ -4883,7 +4892,7 @@ export function useEffectEvent<F extends (...args: any[]) => any>(fn: F, slot?: 
 		s = { impl: fn, active: true };
 		ensureHooks(scope).set(slot, s);
 		const cell = s;
-		scope.cleanups.push(() => {
+		(scope.cleanups ??= []).push(() => {
 			cell.active = false;
 		});
 	} else {
@@ -5095,14 +5104,14 @@ function resetScopeChildren(scope: Scope): void {
 	const start = block.startMarker;
 	removeRange(start !== null ? start.nextSibling : block.parentNode.firstChild, block.endMarker);
 
-	// Truncate the eagerly-allocated arrays in place rather than replacing them: same empty
-	// result, no garbage, and the Scope keeps the backing store it already sized.
-	scope.children.length = 0;
-	scope.cleanups.length = 0;
-	scope.slots.length = 0;
+	// Drop the collections rather than emptying them: the lazily-allocated ones go back to null,
+	// and `slots` gets a fresh array (compiled bodies index it directly, so it stays non-null).
+	scope.children = null;
+	scope.cleanups = null;
 	scope._slots = null;
 	scope.effectSlots = null;
 	scope.hooks = null;
+	scope.slots = [];
 }
 
 // ---------------------------------------------------------------------------
@@ -6442,7 +6451,7 @@ export function bindRendererRegionOwner(props: unknown): void {
 	RENDERER_REGION_DOM_OWNERS.set(root, bridge);
 	root.$$ctxCache?.clear();
 	if (previous === undefined) {
-		root.cleanups.push(() => {
+		(root.cleanups ??= []).push(() => {
 			const current = RENDERER_REGION_DOM_BINDINGS.get(root);
 			if (current === undefined) return;
 			current.release();
@@ -9424,7 +9433,7 @@ export function mountFragmentRef(
 	// `ref`) so a ref the compiler re-points via the update path is honored, and
 	// so the detach cleanup always releases whatever ref is current on unmount.
 	queueRefAttach(scope, () => attachRef(fi._currentRef, fi));
-	scope.cleanups.push(() => {
+	(scope.cleanups ??= []).push(() => {
 		// Detach at commit, not inline (queueRefDetach) — unmount cleanups run
 		// mid-render, and a state-setter ref firing null synchronously can render
 		// before a replacement's attach. The instance is destroyed now; the queued
@@ -10565,7 +10574,7 @@ export function headBlock(
 		scope.slots[slot] = state;
 		// Removed once, on the owning scope's unmount (NOT between re-renders) —
 		// scope.cleanups fire only on teardown, mirroring the spread-ref cleanup.
-		scope.cleanups.push(() => {
+		(scope.cleanups ??= []).push(() => {
 			state!.el.remove();
 			scope.slots[slot] = undefined;
 		});
@@ -14506,9 +14515,9 @@ export function hostComponent(
 		// unmountScope walks into it), keeping the children's slot off `scope` itself.
 		const childScope = new ScopeImpl(scope, block);
 		state.childScope = childScope;
-		scope.children.push({ key: slot, scope: childScope });
+		(scope.children ??= []).push({ key: slot, scope: childScope });
 		block.parentNode.insertBefore(el, anchor ?? block.endMarker);
-		scope.cleanups.push(() => queueRefDetach(state!.ref, state!.el));
+		(scope.cleanups ??= []).push(() => queueRefDetach(state!.ref, state!.el));
 	}
 	const el = state.el;
 	applyHostProps(el, props, scope, state);
@@ -18517,7 +18526,7 @@ export function useTransition(
 			}
 		};
 		TRANSITION_LISTENERS.add(listener);
-		scope.cleanups.push(() => TRANSITION_LISTENERS.delete(listener));
+		(scope.cleanups ??= []).push(() => TRANSITION_LISTENERS.delete(listener));
 	}
 	return [s.isPending, s.start];
 }
@@ -18687,7 +18696,7 @@ export function useFormStatus(slot?: HookSlot): FormStatus {
 		s = { form: null, listener: null };
 		const slotRef = s;
 		ensureHooks(scope).set(slot, slotRef);
-		scope.cleanups.push(() => {
+		(scope.cleanups ??= []).push(() => {
 			if (slotRef.form && slotRef.listener)
 				FORM_STATUS_LISTENERS.get(slotRef.form)?.delete(slotRef.listener);
 		});
@@ -18809,7 +18818,7 @@ export function useOptimistic<S, V = S>(
 			if (TRANSITION_PENDING_COUNT === 0 && slotRef.armed) clear();
 		};
 		TRANSITION_LISTENERS.add(listener);
-		scope.cleanups.push(() => TRANSITION_LISTENERS.delete(listener));
+		(scope.cleanups ??= []).push(() => TRANSITION_LISTENERS.delete(listener));
 	}
 	s.updateFn = updateFn;
 	let optimistic = passthrough;
@@ -19896,7 +19905,7 @@ function forEachSubtreeChild(
 	includeHiddenTry: boolean = true,
 ): void {
 	const children = scope.children;
-	for (let i = 0, n = children.length; i < n; i++) visit(children[i].scope);
+	if (children !== null) for (let i = 0, n = children.length; i < n; i++) visit(children[i].scope);
 	const slots = scope._slots;
 	if (slots !== null) {
 		for (let i = 0, n = slots.length; i < n; i++) {
@@ -21136,7 +21145,7 @@ function batchClearItems(state: ForSlot, oldItems: Map<any, Block>): void {
 	// head/tail only AFTER this returns, so the chain still covers exactly the
 	// old items here.
 	for (let b: Block | null = state.head; b !== null; b = b.nextSibling) {
-		if (b.cleanups.length > 0 || b.children.length > 0 || b._slots !== null) {
+		if (b.cleanups !== null || b.children !== null || b._slots !== null) {
 			unmountBlock(b, false);
 		} else {
 			// Pure-host de-opt item (deoptItemBody with no component descendants):
@@ -21658,7 +21667,7 @@ function coalesceHydratedRanges(
 		if (
 			registered !== null &&
 			registered.length === 1 &&
-			scope.children.length === 0 &&
+			scope.children === null &&
 			registered[0].__kind === 'childSlot' &&
 			(registered[0] as ChildSlot).compactable &&
 			mayBorrowCandidate(registered[0])
@@ -21749,7 +21758,8 @@ function coalesceHydratedRanges(
 
 	function visitScopeContents(scope: Scope): void {
 		const children = scope.children;
-		for (let i = 0; i < children.length; i++) visitNestedScope(children[i].scope);
+		if (children !== null)
+			for (let i = 0; i < children.length; i++) visitNestedScope(children[i].scope);
 		const registered = scope._slots;
 		if (registered === null) return;
 		for (let i = 0; i < registered.length; i++) visitSlot(registered[i]);

--- a/packages/octane/tests/_fixtures/provider-children-dialect.tsrx
+++ b/packages/octane/tests/_fixtures/provider-children-dialect.tsrx
@@ -1,4 +1,4 @@
-import { createContext, createElement, useContext, useState } from 'octane';
+import { createContext, createElement, useContext, useLayoutEffect, useState } from 'octane';
 
 const Ctx = createContext('none');
 
@@ -60,5 +60,49 @@ export function ProviderChildrenDialectFlipWithSiblings() @{
 			<Reader />
 		</DialectRoot>
 		<span class="after">after</span>
+	</div>
+}
+
+// A cleanup that throws while the Provider swaps dialects. The deletion happens mid-render rather
+// than through the normal unmount path, so this checks the teardown error still reaches the
+// enclosing boundary instead of being logged and swallowed.
+function ThrowingCleanup() @{
+	useLayoutEffect(() => {
+		return () => {
+			throw new Error('cleanup-boom');
+		};
+	}, []);
+	<span class="throwing" />
+}
+
+export function ProviderDialectFlipCleanupThrows() @{
+	const [wrapped, setWrapped, getWrapped] = useState(false);
+	<div>
+		<button class="toggle" onClick={() => setWrapped(!getWrapped())}>toggle</button>
+		@try {
+			<DialectRoot wrapped={wrapped} value="ctx">
+				<ThrowingCleanup />
+			</DialectRoot>
+		} @catch (err) {
+			<span class="caught">{(err.message ?? String(err)) as string}</span>
+		}
+	</div>
+}
+
+// Control: the SAME throwing cleanup torn down by an ordinary mid-render branch swap. Whatever
+// the runtime does here is the established contract for a deletion that happens during render.
+export function IfBranchSwapCleanupThrows() @{
+	const [shown, setShown, getShown] = useState(true);
+	<div>
+		<button class="toggle" onClick={() => setShown(!getShown())}>toggle</button>
+		@try {
+			@if (shown) {
+				<ThrowingCleanup />
+			} @else {
+				<span class="other" />
+			}
+		} @catch (err) {
+			<span class="caught">{(err.message ?? String(err)) as string}</span>
+		}
 	</div>
 }

--- a/packages/octane/tests/_fixtures/provider-children-dialect.tsrx
+++ b/packages/octane/tests/_fixtures/provider-children-dialect.tsrx
@@ -1,4 +1,4 @@
-import { createContext, createElement, useContext, useLayoutEffect, useState } from 'octane';
+import { createContext, createElement, use, useContext, useLayoutEffect, useState } from 'octane';
 
 const Ctx = createContext('none');
 
@@ -103,6 +103,24 @@ export function IfBranchSwapCleanupThrows() @{
 			}
 		} @catch (err) {
 			<span class="caught">{(err.message ?? String(err)) as string}</span>
+		}
+	</div>
+}
+
+// A ref-carrying compiled children body inside a Provider, under a Suspense boundary. The compiled
+// body stamps a ref manifest on the Provider's scope; after a flip to the descriptor dialect the
+// suspense-hide walk reads that manifest against whatever now sits in the scope's first slot.
+export function ProviderRefFlipUnderSuspense(props) @{
+	const [wrapped, setWrapped, getWrapped] = useState(false);
+	<div>
+		<button class="toggle" onClick={() => setWrapped(!getWrapped())}>toggle</button>
+		@try {
+			const value = use(props.promise);
+			<DialectRoot wrapped={wrapped} value="ctx">
+				<span class="reffed" ref={props.cbRef}>{value as string}</span>
+			</DialectRoot>
+		} @pending {
+			<span class="pending-arm" />
 		}
 	</div>
 }

--- a/packages/octane/tests/_fixtures/provider-children-dialect.tsrx
+++ b/packages/octane/tests/_fixtures/provider-children-dialect.tsrx
@@ -1,0 +1,64 @@
+import { createContext, createElement, useContext, useState } from 'octane';
+
+const Ctx = createContext('none');
+
+export function Reader() @{
+	<span class="val">{useContext(Ctx) as string}</span>
+}
+
+function Passthrough(props) {
+	return props.children ?? null;
+}
+
+// A plain-`.ts` component that forwards its children into a Provider, wrapping them in another
+// component only in one of the two states. The Provider's `children` prop therefore alternates
+// between the compiled children-block FUNCTION its `.tsrx` consumer passed and an element
+// DESCRIPTOR — the two dialects a Provider must accept.
+function DialectRoot(props) {
+	return createElement(Ctx.Provider, {
+		value: props.value,
+		children: props.wrapped
+			? createElement(Passthrough, { children: props.children })
+			: props.children,
+	});
+}
+
+export function ProviderChildrenDialectFlip() @{
+	const [wrapped, setWrapped, getWrapped] = useState(false);
+	<div>
+		<button class="toggle" onClick={() => setWrapped(!getWrapped())}>toggle</button>
+		<DialectRoot wrapped={wrapped} value="ctx">
+			<Reader />
+		</DialectRoot>
+	</div>
+}
+
+// The same flip with live state inside the children, so a remount is observable as a reset.
+function Counter() @{
+	const [n, setN, getN] = useState(0);
+	<button class="count" onClick={() => setN(getN() + 1)}>{'n' + n as string}</button>
+}
+
+export function ProviderChildrenDialectFlipWithState() @{
+	const [wrapped, setWrapped, getWrapped] = useState(false);
+	<div>
+		<button class="toggle" onClick={() => setWrapped(!getWrapped())}>toggle</button>
+		<DialectRoot wrapped={wrapped} value="ctx">
+			<Counter />
+		</DialectRoot>
+	</div>
+}
+
+// The flip happening next to siblings in the same parent element: tearing the Provider's range
+// down must not disturb anything outside it.
+export function ProviderChildrenDialectFlipWithSiblings() @{
+	const [wrapped, setWrapped, getWrapped] = useState(false);
+	<div>
+		<span class="before">before</span>
+		<button class="toggle" onClick={() => setWrapped(!getWrapped())}>toggle</button>
+		<DialectRoot wrapped={wrapped} value="ctx">
+			<Reader />
+		</DialectRoot>
+		<span class="after">after</span>
+	</div>
+}

--- a/packages/octane/tests/_fixtures/scope-lazy-collections.tsrx
+++ b/packages/octane/tests/_fixtures/scope-lazy-collections.tsrx
@@ -1,0 +1,39 @@
+import { useState } from 'octane';
+
+// A leaf that registers a ref (so its scope lazily allocates `cleanups` for the detach) and no
+// child scopes.
+function Leaf(props) @{
+	<span class="leaf" ref={props.collect} />
+}
+
+// A middle layer with no ref of its own: its scope only ever allocates `children`.
+function Branch(props) @{
+	<div class="branch">
+		<Leaf collect={props.collect} />
+		<Leaf collect={props.collect} />
+	</div>
+}
+
+// Unmounting the root has to walk the lazily-allocated `children` of every level to reach the
+// leaves' lazily-allocated `cleanups`.
+export function NestedRefs(props) @{
+	const [shown, setShown, getShown] = useState(true);
+	<div>
+		<button class="toggle" onClick={() => setShown(!getShown())}>t</button>
+		@if (shown) {
+			<Branch collect={props.collect} />
+		}
+	</div>
+}
+
+// A keyed list of pure host rows carrying refs — the de-opt clear path checks whether an item
+// scope holds any teardown state before unmounting it.
+export function RefRows(props) @{
+	const [items, setItems, getItems] = useState(() => [{ id: 1 }, { id: 2 }, { id: 3 }]);
+	<div>
+		<button class="clear" onClick={() => setItems([])}>clear</button>
+		@for (const it of items; key it.id) {
+			<span class="row" ref={props.collect} />
+		}
+	</div>
+}

--- a/packages/octane/tests/devtools-hook.test.ts
+++ b/packages/octane/tests/devtools-hook.test.ts
@@ -22,7 +22,9 @@ function scope(partial: Partial<DevtoolsScopeLike>): DevtoolsScopeLike {
 		body: undefined,
 		hooks: null,
 		effectSlots: null,
-		children: [],
+		// The runtime allocates `children` lazily, so a scope with no child scopes has null
+		// here — not an empty array. The fake mirrors that so the walk is exercised as shipped.
+		children: null,
 		$$ctxValues: null,
 		...partial,
 	} as DevtoolsScopeLike;

--- a/packages/octane/tests/native-change-runtime-diagnostic.test.ts
+++ b/packages/octane/tests/native-change-runtime-diagnostic.test.ts
@@ -115,6 +115,23 @@ describe('native text change development diagnostic', () => {
 		}
 	});
 
+	it('skips a mirror input that is aria-hidden from its first render', () => {
+		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const checkableCalls = () =>
+			error.mock.calls.filter((call) => String(call[0]).includes('`checked` prop'));
+		// Mounting straight into the mirror shape is what a form-interop bubble input actually
+		// does. The sibling case above reaches this state via an update, which the diagnostic
+		// does not re-evaluate, so only this one exercises the aria-hidden skip on its own.
+		const result = mount(SpreadText, {
+			hostProps: { type: 'checkbox', checked: true, 'aria-hidden': true },
+		});
+		try {
+			expect(checkableCalls()).toHaveLength(0);
+		} finally {
+			result.unmount();
+		}
+	});
+
 	it('classifies the live input type and skips read-only, disabled, and non-text hosts', () => {
 		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
 		const result = mount(SpreadText, {

--- a/packages/octane/tests/provider-children-dialect.test.ts
+++ b/packages/octane/tests/provider-children-dialect.test.ts
@@ -1,9 +1,11 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { mount } from './_helpers';
 import {
 	ProviderChildrenDialectFlip,
 	ProviderChildrenDialectFlipWithState,
 	ProviderChildrenDialectFlipWithSiblings,
+	ProviderDialectFlipCleanupThrows,
+	IfBranchSwapCleanupThrows,
 } from './_fixtures/provider-children-dialect.tsrx';
 
 // A Provider accepts its children in either dialect: the compiled children-block function a
@@ -59,5 +61,40 @@ describe('context Provider — children dialect changes', () => {
 		expect(m.container.querySelector('.val')?.textContent).toBe('ctx');
 
 		m.unmount();
+	});
+
+	it('routes a cleanup that throws during the flip to the enclosing boundary', () => {
+		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const m = mount(ProviderDialectFlipCleanupThrows);
+		try {
+			expect(m.container.querySelector('.throwing')).not.toBe(null);
+
+			m.click('.toggle');
+
+			// The remount tears the old children down mid-render. A deletion-phase throw has to
+			// reach the boundary rather than be logged and swallowed — the same contract an
+			// ordinary mid-render deletion gets, pinned by the `@if` control below.
+			expect(m.container.querySelector('.caught')).not.toBe(null);
+			expect(error.mock.calls.filter((c) => String(c[0]).includes('cleanup-boom'))).toHaveLength(0);
+		} finally {
+			error.mockRestore();
+			m.unmount();
+		}
+	});
+
+	it('handles that cleanup throw the same way an ordinary branch swap does', () => {
+		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const m = mount(IfBranchSwapCleanupThrows);
+		try {
+			m.click('.toggle');
+
+			// The control: an `@if` swap deleting the identical component. The Provider flip is a
+			// deletion like any other, so it must not invent its own error-routing behavior.
+			expect(m.container.querySelector('.caught')).not.toBe(null);
+			expect(error.mock.calls.filter((c) => String(c[0]).includes('cleanup-boom'))).toHaveLength(0);
+		} finally {
+			error.mockRestore();
+			m.unmount();
+		}
 	});
 });

--- a/packages/octane/tests/provider-children-dialect.test.ts
+++ b/packages/octane/tests/provider-children-dialect.test.ts
@@ -6,6 +6,7 @@ import {
 	ProviderChildrenDialectFlipWithSiblings,
 	ProviderDialectFlipCleanupThrows,
 	IfBranchSwapCleanupThrows,
+	ProviderRefFlipUnderSuspense,
 } from './_fixtures/provider-children-dialect.tsrx';
 
 // A Provider accepts its children in either dialect: the compiled children-block function a
@@ -94,6 +95,31 @@ describe('context Provider — children dialect changes', () => {
 			expect(error.mock.calls.filter((c) => String(c[0]).includes('cleanup-boom'))).toHaveLength(0);
 		} finally {
 			error.mockRestore();
+			m.unmount();
+		}
+	});
+
+	it('keeps a ref inside the children attached across the flip and detached on hide', () => {
+		const calls: string[] = [];
+		const cbRef = (el: Element | null) => calls.push(el === null ? 'detach' : 'attach');
+		const fulfilled = Object.assign(Promise.resolve('a'), { status: 'fulfilled', value: 'a' });
+		const m = mount(ProviderRefFlipUnderSuspense as any, { promise: fulfilled, cbRef });
+		try {
+			expect(calls).toEqual(['attach']);
+
+			// The flip remounts the children, so the ref detaches from the old element and
+			// attaches to the new one — no dangling attach, no missed detach.
+			m.click('.toggle');
+			expect(calls).toEqual(['attach', 'detach', 'attach']);
+
+			// Hiding the boundary detaches it once. The scope was rebuilt by the flip, so this
+			// exercises the hide walk against the post-flip scope rather than the original.
+			m.update(ProviderRefFlipUnderSuspense as any, {
+				promise: Object.assign(new Promise(() => {}), { status: 'pending' }),
+				cbRef,
+			});
+			expect(calls).toEqual(['attach', 'detach', 'attach', 'detach']);
+		} finally {
 			m.unmount();
 		}
 	});

--- a/packages/octane/tests/provider-children-dialect.test.ts
+++ b/packages/octane/tests/provider-children-dialect.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from './_helpers';
+import {
+	ProviderChildrenDialectFlip,
+	ProviderChildrenDialectFlipWithState,
+	ProviderChildrenDialectFlipWithSiblings,
+} from './_fixtures/provider-children-dialect.tsrx';
+
+// A Provider accepts its children in either dialect: the compiled children-block function a
+// `.tsrx` parent passes, or an element descriptor from a `createElement` parent. Bindings that
+// wrap children conditionally flip between the two across renders, and the Provider must keep
+// rendering them — and keep providing context — rather than corrupting the tree.
+describe('context Provider — children dialect changes', () => {
+	it('keeps rendering children when they flip from a children-block to a descriptor', () => {
+		const m = mount(ProviderChildrenDialectFlip);
+		expect(m.container.querySelector('.val')?.textContent).toBe('ctx');
+
+		m.click('.toggle');
+		expect(m.container.querySelector('.toggle')).not.toBe(null);
+		expect(m.container.querySelector('.val')?.textContent).toBe('ctx');
+
+		m.click('.toggle');
+		expect(m.container.querySelector('.val')?.textContent).toBe('ctx');
+
+		m.unmount();
+	});
+
+	it('remounts the children across the flip, so their state resets', () => {
+		const m = mount(ProviderChildrenDialectFlipWithState);
+		expect(m.container.querySelector('.count')?.textContent).toBe('n0');
+
+		m.click('.count');
+		m.click('.count');
+		expect(m.container.querySelector('.count')?.textContent).toBe('n2');
+
+		// The children are structurally different code either side of the flip, so they remount
+		// and their state starts over — the same contract React gives an element-type change.
+		m.click('.toggle');
+		expect(m.container.querySelector('.count')?.textContent).toBe('n0');
+
+		m.click('.count');
+		expect(m.container.querySelector('.count')?.textContent).toBe('n1');
+
+		m.unmount();
+	});
+
+	it('leaves sibling content outside the Provider untouched across the flip', () => {
+		const m = mount(ProviderChildrenDialectFlipWithSiblings);
+		const before = m.container.querySelector('.before');
+		const after = m.container.querySelector('.after');
+		expect(before?.textContent).toBe('before');
+		expect(after?.textContent).toBe('after');
+
+		m.click('.toggle');
+
+		// Same nodes, still in place: only the Provider's own range was rebuilt.
+		expect(m.container.querySelector('.before')).toBe(before);
+		expect(m.container.querySelector('.after')).toBe(after);
+		expect(m.container.querySelector('.val')?.textContent).toBe('ctx');
+
+		m.unmount();
+	});
+});

--- a/packages/octane/tests/provider-children-dialect.test.ts
+++ b/packages/octane/tests/provider-children-dialect.test.ts
@@ -72,10 +72,10 @@ describe('context Provider — children dialect changes', () => {
 
 			m.click('.toggle');
 
-			// The remount tears the old children down mid-render. A deletion-phase throw has to
-			// reach the boundary rather than be logged and swallowed — the same contract an
-			// ordinary mid-render deletion gets, pinned by the `@if` control below.
-			expect(m.container.querySelector('.caught')).not.toBe(null);
+			// The remount tears the old children down mid-render. The boundary has to receive the
+			// cleanup's own error — which also means the Provider stopped rendering once the
+			// teardown disposed its block, instead of writing children into the catch range.
+			expect(m.container.querySelector('.caught')?.textContent).toBe('cleanup-boom');
 			expect(error.mock.calls.filter((c) => String(c[0]).includes('cleanup-boom'))).toHaveLength(0);
 		} finally {
 			error.mockRestore();
@@ -89,8 +89,10 @@ describe('context Provider — children dialect changes', () => {
 		try {
 			m.click('.toggle');
 
-			// The control: an `@if` swap deleting the identical component. The Provider flip is a
-			// deletion like any other, so it must not invent its own error-routing behavior.
+			// The control: an `@if` swap deleting the identical component. It reaches the boundary
+			// too, so the Provider flip is not inventing its own routing. This arm asserts only
+			// that the boundary engages — `@if` currently surfaces a follow-on DOM error rather
+			// than the cleanup's own, a separate pre-existing gap that is not this PR's to close.
 			expect(m.container.querySelector('.caught')).not.toBe(null);
 			expect(error.mock.calls.filter((c) => String(c[0]).includes('cleanup-boom'))).toHaveLength(0);
 		} finally {

--- a/packages/octane/tests/scope-lazy-collections.test.ts
+++ b/packages/octane/tests/scope-lazy-collections.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { mount, flushEffects } from './_helpers';
+import { NestedRefs, RefRows } from './_fixtures/scope-lazy-collections.tsrx';
+
+// A Scope allocates its `cleanups` and `children` arrays only when something actually registers
+// one. These pin the teardown behavior that laziness must not change: a scope that registered a
+// cleanup still runs it, a scope that registered none still tears down, and the de-opt list clear
+// still detaches refs on rows whose scopes hold no teardown state of their own.
+describe('scope collections are lazily allocated', () => {
+	it('detaches refs through nested scopes when a subtree unmounts', () => {
+		const detached: number[] = [];
+		let attached = 0;
+		const collect = (el: Element | null) => {
+			if (el) attached += 1;
+			else detached.push(attached);
+		};
+
+		const m = mount(NestedRefs, { collect });
+		flushEffects();
+		expect(attached).toBe(2);
+
+		m.click('.toggle');
+		flushEffects();
+
+		// Reaching both leaves means the teardown walked each level's lazily-allocated child
+		// scopes and then each leaf's lazily-allocated cleanup array.
+		expect(m.container.querySelectorAll('.leaf')).toHaveLength(0);
+		expect(detached).toHaveLength(2);
+
+		m.unmount();
+	});
+
+	it('detaches refs on keyed rows when the list is cleared', () => {
+		const attached: Element[] = [];
+		const detached: Element[] = [];
+		const collect = (el: Element | null) => {
+			if (el) attached.push(el);
+			else detached.push(el as any);
+		};
+
+		const m = mount(RefRows, { collect });
+		flushEffects();
+		expect(attached).toHaveLength(3);
+
+		m.click('.clear');
+		flushEffects();
+
+		expect(m.container.querySelectorAll('.row')).toHaveLength(0);
+		expect(detached).toHaveLength(3);
+
+		m.unmount();
+	});
+});


### PR DESCRIPTION
Two related Scope changes: a correctness fix, and the allocation cleanup it made obvious. #295 was merged in here, so both land together.

---

# 1. Remount Provider children when their dialect changes

## Why

A Provider's children arrive in one of two shapes:

- the compiled children-block **function** a `.tsrx` parent passes, or
- an element **descriptor**, from a `createElement` parent (`<Ctx.Provider>…</Ctx.Provider>` in a React-shaped `.tsx`).

`childrenAsBody` normalizes both, but they store their state in the same place. A compiled body keeps its binding bag in `scope.slots[0]`; the descriptor path's `childSlot(scope, 0, …)` keeps a childSlot record there. Nothing checked the record's kind, so a parent that alternates between the shapes had the incoming dialect adopt the outgoing one's record and walk it as its own — `TypeError: Cannot read properties of undefined (reading 'items')`, and the subtree detached.

That alternation is not exotic. It is the ordinary React idiom of wrapping children conditionally:

```jsx
<Ctx.Provider value={v}>
  {enabled ? <Wrapper>{children}</Wrapper> : children}
</Ctx.Provider>
```

Found from a real consumer: `@octanejs/base-ui` hit it porting Base UI's overlays and had been carrying a workaround to avoid it.

## Change

`ProviderBody` records which dialect it last rendered and remounts the children when that changes — the same contract React gives an element-type change.

- The marker lives in the **hook map**, whose Symbol keys are disjoint from the numeric `slots` indices the two dialects contend over.
- Steady state is one map read and an integer compare; the write happens only on the first render and on an actual flip.
- `resetScopeChildren` tears the scope down with the existing `unmountScopeChildrenAndSlots` and clears the block's DOM range with a single `removeRange`.

Deliberately scoped to the Provider. `childrenAsBody` is also used by the Suspense/ErrorBoundary try-block and by `Hydrate`, which share the contention in principle, but the reset drops the scope's hook state — safe only because a Provider keeps none of its own. That reasoning does not carry to a boundary that does, so a flip reported there needs its own fix rather than this one widened.

---

# 2. Allocate scope `cleanups` and `children` lazily

## Why

Every Scope eagerly created three arrays, though most scopes never register a cleanup or a child scope — and the fields right beside them (`hooks`, `effectSlots`, `_slots`) were already `T | null`, lazily built.

## Measurement

Instrumented run over a 500-row × 3-cell keyed table — 2,501 scopes:

| Collection | Allocated before | Allocated after | Saved |
| --- | ---: | ---: | ---: |
| `cleanups` | 2,501 | **0** | 100% |
| `children` | 2,501 | 1,000 | 60% |
| `slots` | 2,501 | 2,501 | — |
| **Total** | **7,503** | **3,501** | **53%** |

Cost side, `benchmarks/bench.mjs codegen-size` over the 16-file corpus:

| | baseline | this PR | delta |
| --- | ---: | ---: | ---: |
| compiled gz(min) | 25,183 | 25,200 | **+17 B** (+0.07%) |

Deterministic counters rather than wall-clock, which is the right instrument for an allocation change.

### Why `slots` stays eager

Intuition says make all three lazy. The measurement disagrees: **all 2,501 scopes used `slots`** — none had an empty one at teardown. Making it lazy would save nothing here while adding a null check to the hottest path in the framework and to every emitted `__s.slots[N]` access, since codegen indexes it directly.

## Change

- `cleanups: Cleanup[] | null` and `children: ChildScope[] | null`, both `null` at construction; registration sites allocate on demand, and teardown/subtree/de-opt walks null-check.
- The compiler emits `(__s.cleanups ??= []).push(fn)` instead of `__s.cleanups.push(fn)` — one emission site, three call sites.
- The dialect reset from part 1 drops these collections rather than emptying them, so no `length = 0` on arrays about to be discarded.

---

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `vitest run --project octane --project octane-prod` — 9,082 passed across both compile modes
- [x] `pnpm test` — full suite
- [x] `benchmarks/bench.mjs codegen-size` — baseline vs candidate, above

### Test evidence

Five regression tests, each checked against the specific piece of the change it guards:

| Test | Fails when |
| --- | --- |
| children keep rendering across a dialect flip | the reset is removed → the original `TypeError` |
| children remount, so their state resets | the reset is removed |
| sibling content outside the Provider survives | the range clear is widened to ignore the start marker |
| refs detach through nested scopes on unmount | the `children` walk is skipped, **or** the `cleanups` walk is |
| the de-opt keyed-list clear detaches row refs | the `cleanups` walk is skipped, or the de-opt fast-path check is |

An earlier draft of the fourth test used `useEffect` teardown and passed with the walk disabled — effect destroys run through `effectSlots`, not `cleanups`. It was rewritten around ref detachment, which does go through `cleanups`.

## Risk / follow-ups

- The reset clears the Provider block's DOM range, assuming a marker-less block owns its whole parent — what marker elision guarantees today. The sibling test pins that boundary.
- Hydration is unaffected: a flip needs at least two renders, and the first takes the no-previous-dialect path.
- The de-opt fast path changed from `b.cleanups.length > 0` to `b.cleanups !== null`. Equivalent, because entries are only ever appended, never spliced.
- The codegen change is a compiler/runtime ABI change. They ship together, so there is no mixed-version window, but output compiled by an older compiler must not run on this runtime.
- #292 (the Base UI port that surfaced the bug) is independent and does not depend on this PR: its 89 tests pass against `origin/main`'s runtime.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core runtime teardown, Provider rendering, and compiler/runtime ABI for cleanup registration; behavior changes on dialect flip (intentional remount) require matching compiler output.
> 
> **Overview**
> Fixes **context Providers** when `children` alternates between a compiled `.tsrx` body function and a `createElement` descriptor (e.g. conditional wrapper). Both dialects reused `scope.slots[0]` with incompatible shapes, which could throw and detach the subtree. The Provider now tracks the last dialect in the hook map and **remounts** via `resetScopeChildren` on a flip (React-style element-type change), including proper mid-render teardown and DOM range clearing.
> 
> **Scopes** now allocate **`cleanups` and `children` lazily** (`null` until first registration), with null checks in unmount/subtree walks and compiler-emitted `(__s.cleanups ??= []).push(...)`. `slots` stays eager. Devtools and de-opt fast paths are updated accordingly.
> 
> Adds regression tests for dialect flips, lazy-collection teardown, aria-hidden mirror inputs on first mount, and a small native-change diagnostic case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5da0d3a870658e166871df81d83b8e89653321cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->