### PR TITLE
Allocate scope cleanups and children lazily

### DIFF
--- a/.changeset/lazy-scope-collections.md
+++ b/.changeset/lazy-scope-collections.md
@@ -1,0 +1,19 @@
+---
+'octane': patch
+---
+
+Allocate a Scope's `cleanups` and `children` arrays lazily.
+
+Both were created eagerly for every Scope even though most scopes never register
+a cleanup or a child scope, while the neighbouring `hooks`, `effectSlots` and
+`_slots` fields were already lazy. They now follow the same pattern: `null` until
+something registers, allocated at the registration site.
+
+On a 500-row × 3-cell tree (2,501 scopes) this removes 4,002 of the 7,503 array
+allocations those three collections were making — every `cleanups` array and 60%
+of the `children` arrays. Compiled output grows 17 bytes gzipped across the
+16-file codegen corpus, from the `??=` at the three cleanup-registration sites.
+
+`slots` deliberately stays eager: every scope in that same measurement used it,
+so making it lazy would add a null check to the framework's hottest path and to
+every emitted `__s.slots[N]` access while saving nothing.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -16057,9 +16057,11 @@ function propertyIsEnumerableCall(objNode, name) {
 	);
 }
 
-// `__s.cleanups.push(<fn>)`.
+// `(__s.cleanups ??= []).push(<fn>)` — the scope's cleanup array is lazily allocated (most
+// scopes never register one), so the registration site owns creating it.
 function cleanupsPush(fnNode) {
-	return b.stmt(b.call(b.member(b.member(b.id('__s'), 'cleanups'), 'push'), fnNode));
+	const lazyArray = b.assignment('??=', b.member(b.id('__s'), 'cleanups'), b.array([]));
+	return b.stmt(b.call(b.member(lazyArray, 'push'), fnNode));
 }
 
 // Mount for a DEFERRED property-write binding: store the element ref + seed the

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -201,7 +201,12 @@ export interface Scope {
 	 * `undefined` when null, identical to a Map.get miss.
 	 */
 	hooks: Map<HookSlot, any> | null;
-	cleanups: Cleanup[];
+	/**
+	 * Teardown callbacks (ref detaches, listener removal, slot cleanup). Lazily allocated by
+	 * `pushCleanup` — most scopes never register one, so the array is only paid for on demand,
+	 * matching `hooks` / `effectSlots` / `_slots`.
+	 */
+	cleanups: Cleanup[] | null;
 	/**
 	 * This scope's effect slots in hook DECLARATION order (first-enqueue order —
 	 * the order the hooks ran in the scope's first render). unmountScope walks it
@@ -218,8 +223,10 @@ export interface Scope {
 	 * (NOT a Map): iteration is a plain indexed for-loop, and lookups are linear
 	 * scans — faster than `Map.get` for the typical N ≤ 8 case (most components
 	 * have a handful of static sub-component calls at most).
+	 *
+	 * Lazily allocated when the first child scope registers: a leaf component has none.
 	 */
-	children: ChildScope[];
+	children: ChildScope[] | null;
 	mounted: boolean;
 	/**
 	 * Slot objects owned by this scope (ifBlockSlot, forBlockSlot, etc.).
@@ -3147,9 +3154,9 @@ class BlockImpl {
 	inactive: boolean;
 	// Hooks + cleanups (per-block state).
 	hooks: Map<HookSlot, any> | null;
-	cleanups: Cleanup[];
+	cleanups: Cleanup[] | null;
 	effectSlots: EffectSlot[] | null;
-	children: ChildScope[];
+	children: ChildScope[] | null;
 	_slots: any[] | null;
 	refFields: string[] | null;
 	$$ctxValues: Map<Context<any>, any> | null;
@@ -3237,9 +3244,9 @@ class BlockImpl {
 		this.currentRenderDeferred = false;
 		this.inactive = false;
 		this.hooks = null;
-		this.cleanups = [];
+		this.cleanups = null;
 		this.effectSlots = null;
-		this.children = [];
+		this.children = null;
 		this._slots = null;
 		this.refFields = null;
 		this.$$ctxValues = null;
@@ -3284,9 +3291,9 @@ class ScopeImpl {
 	block: Block;
 	parent: Scope | null;
 	hooks: Map<HookSlot, any> | null;
-	cleanups: Cleanup[];
+	cleanups: Cleanup[] | null;
 	effectSlots: EffectSlot[] | null;
-	children: ChildScope[];
+	children: ChildScope[] | null;
 	_slots: any[] | null;
 	refFields: string[] | null;
 	$$ctxValues: Map<Context<any>, any> | null;
@@ -3301,9 +3308,9 @@ class ScopeImpl {
 		this.block = block;
 		this.parent = parent;
 		this.hooks = null;
-		this.cleanups = [];
+		this.cleanups = null;
 		this.effectSlots = null;
-		this.children = [];
+		this.children = null;
 		this._slots = null;
 		this.refFields = null;
 		this.slots = [];
@@ -3794,7 +3801,7 @@ export function componentSlotLite<P>(
 		}
 		parentScope.slots[slotKey] = scope;
 		// Register on parent.children so unmountScope(parent) walks into us.
-		parentScope.children.push({ key: slotKey, scope });
+		(parentScope.children ??= []).push({ key: slotKey, scope });
 	} else {
 		// Re-render: the parent's host/anchor are stable across renders so no
 		// need to rebuild the LiteBlockImpl. Skip the allocation on warm path.
@@ -4003,20 +4010,22 @@ function unmountScope(scope: Scope, detachDom: boolean = true): void {
 // so its recursive cleanup must not manufacture a matching detach.
 function unmountScopeChildrenAndSlots(scope: Scope, detachDom: boolean): void {
 	const c = scope.cleanups;
-	for (let i = c.length - 1; i >= 0; i--) {
-		try {
-			runEffectLifecycleCallback(c[i]);
-		} catch (err) {
-			// Route to the boundary enclosing the DELETION (collected + dispatched
-			// after the walk — see reportTeardownError); React parity: an error in a
-			// deletion-phase cleanup reaches the nearest still-mounted boundary
-			// instead of being swallowed (ReactErrorBoundaries:1927).
-			reportTeardownError(err);
+	if (c !== null)
+		for (let i = c.length - 1; i >= 0; i--) {
+			try {
+				runEffectLifecycleCallback(c[i]);
+			} catch (err) {
+				// Route to the boundary enclosing the DELETION (collected + dispatched
+				// after the walk — see reportTeardownError); React parity: an error in a
+				// deletion-phase cleanup reaches the nearest still-mounted boundary
+				// instead of being swallowed (ReactErrorBoundaries:1927).
+				reportTeardownError(err);
+			}
 		}
-	}
 	// Then recurse into child scopes (parent → child order).
 	const children = scope.children;
-	for (let i = 0, n = children.length; i < n; i++) unmountScope(children[i].scope, detachDom);
+	if (children !== null)
+		for (let i = 0, n = children.length; i < n; i++) unmountScope(children[i].scope, detachDom);
 	// Walk slot-stashed child Blocks (ifBlock / forBlock / componentSlot / portal).
 	const slots = scope._slots;
 	if (slots !== null) {
@@ -4883,7 +4892,7 @@ export function useEffectEvent<F extends (...args: any[]) => any>(fn: F, slot?: 
 		s = { impl: fn, active: true };
 		ensureHooks(scope).set(slot, s);
 		const cell = s;
-		scope.cleanups.push(() => {
+		(scope.cleanups ??= []).push(() => {
 			cell.active = false;
 		});
 	} else {
@@ -5095,14 +5104,14 @@ function resetScopeChildren(scope: Scope): void {
 	const start = block.startMarker;
 	removeRange(start !== null ? start.nextSibling : block.parentNode.firstChild, block.endMarker);
 
-	// Truncate the eagerly-allocated arrays in place rather than replacing them: same empty
-	// result, no garbage, and the Scope keeps the backing store it already sized.
-	scope.children.length = 0;
-	scope.cleanups.length = 0;
-	scope.slots.length = 0;
+	// Drop the collections rather than emptying them: the lazily-allocated ones go back to null,
+	// and `slots` gets a fresh array (compiled bodies index it directly, so it stays non-null).
+	scope.children = null;
+	scope.cleanups = null;
 	scope._slots = null;
 	scope.effectSlots = null;
 	scope.hooks = null;
+	scope.slots = [];
 }
 
 // ---------------------------------------------------------------------------
@@ -6442,7 +6451,7 @@ export function bindRendererRegionOwner(props: unknown): void {
 	RENDERER_REGION_DOM_OWNERS.set(root, bridge);
 	root.$$ctxCache?.clear();
 	if (previous === undefined) {
-		root.cleanups.push(() => {
+		(root.cleanups ??= []).push(() => {
 			const current = RENDERER_REGION_DOM_BINDINGS.get(root);
 			if (current === undefined) return;
 			current.release();
@@ -9424,7 +9433,7 @@ export function mountFragmentRef(
 	// `ref`) so a ref the compiler re-points via the update path is honored, and
 	// so the detach cleanup always releases whatever ref is current on unmount.
 	queueRefAttach(scope, () => attachRef(fi._currentRef, fi));
-	scope.cleanups.push(() => {
+	(scope.cleanups ??= []).push(() => {
 		// Detach at commit, not inline (queueRefDetach) — unmount cleanups run
 		// mid-render, and a state-setter ref firing null synchronously can render
 		// before a replacement's attach. The instance is destroyed now; the queued
@@ -10565,7 +10574,7 @@ export function headBlock(
 		scope.slots[slot] = state;
 		// Removed once, on the owning scope's unmount (NOT between re-renders) —
 		// scope.cleanups fire only on teardown, mirroring the spread-ref cleanup.
-		scope.cleanups.push(() => {
+		(scope.cleanups ??= []).push(() => {
 			state!.el.remove();
 			scope.slots[slot] = undefined;
 		});
@@ -14506,9 +14515,9 @@ export function hostComponent(
 		// unmountScope walks into it), keeping the children's slot off `scope` itself.
 		const childScope = new ScopeImpl(scope, block);
 		state.childScope = childScope;
-		scope.children.push({ key: slot, scope: childScope });
+		(scope.children ??= []).push({ key: slot, scope: childScope });
 		block.parentNode.insertBefore(el, anchor ?? block.endMarker);
-		scope.cleanups.push(() => queueRefDetach(state!.ref, state!.el));
+		(scope.cleanups ??= []).push(() => queueRefDetach(state!.ref, state!.el));
 	}
 	const el = state.el;
 	applyHostProps(el, props, scope, state);
@@ -18517,7 +18526,7 @@ export function useTransition(
 			}
 		};
 		TRANSITION_LISTENERS.add(listener);
-		scope.cleanups.push(() => TRANSITION_LISTENERS.delete(listener));
+		(scope.cleanups ??= []).push(() => TRANSITION_LISTENERS.delete(listener));
 	}
 	return [s.isPending, s.start];
 }
@@ -18687,7 +18696,7 @@ export function useFormStatus(slot?: HookSlot): FormStatus {
 		s = { form: null, listener: null };
 		const slotRef = s;
 		ensureHooks(scope).set(slot, slotRef);
-		scope.cleanups.push(() => {
+		(scope.cleanups ??= []).push(() => {
 			if (slotRef.form && slotRef.listener)
 				FORM_STATUS_LISTENERS.get(slotRef.form)?.delete(slotRef.listener);
 		});
@@ -18809,7 +18818,7 @@ export function useOptimistic<S, V = S>(
 			if (TRANSITION_PENDING_COUNT === 0 && slotRef.armed) clear();
 		};
 		TRANSITION_LISTENERS.add(listener);
-		scope.cleanups.push(() => TRANSITION_LISTENERS.delete(listener));
+		(scope.cleanups ??= []).push(() => TRANSITION_LISTENERS.delete(listener));
 	}
 	s.updateFn = updateFn;
 	let optimistic = passthrough;
@@ -19896,7 +19905,7 @@ function forEachSubtreeChild(
 	includeHiddenTry: boolean = true,
 ): void {
 	const children = scope.children;
-	for (let i = 0, n = children.length; i < n; i++) visit(children[i].scope);
+	if (children !== null) for (let i = 0, n = children.length; i < n; i++) visit(children[i].scope);
 	const slots = scope._slots;
 	if (slots !== null) {
 		for (let i = 0, n = slots.length; i < n; i++) {
@@ -21136,7 +21145,7 @@ function batchClearItems(state: ForSlot, oldItems: Map<any, Block>): void {
 	// head/tail only AFTER this returns, so the chain still covers exactly the
 	// old items here.
 	for (let b: Block | null = state.head; b !== null; b = b.nextSibling) {
-		if (b.cleanups.length > 0 || b.children.length > 0 || b._slots !== null) {
+		if (b.cleanups !== null || b.children !== null || b._slots !== null) {
 			unmountBlock(b, false);
 		} else {
 			// Pure-host de-opt item (deoptItemBody with no component descendants):
@@ -21658,7 +21667,7 @@ function coalesceHydratedRanges(
 		if (
 			registered !== null &&
 			registered.length === 1 &&
-			scope.children.length === 0 &&
+			scope.children === null &&
 			registered[0].__kind === 'childSlot' &&
 			(registered[0] as ChildSlot).compactable &&
 			mayBorrowCandidate(registered[0])
@@ -21749,7 +21758,8 @@ function coalesceHydratedRanges(
 
 	function visitScopeContents(scope: Scope): void {
 		const children = scope.children;
-		for (let i = 0; i < children.length; i++) visitNestedScope(children[i].scope);
+		if (children !== null)
+			for (let i = 0; i < children.length; i++) visitNestedScope(children[i].scope);
 		const registered = scope._slots;
 		if (registered === null) return;
 		for (let i = 0; i < registered.length; i++) visitSlot(registered[i]);

--- a/packages/octane/tests/_fixtures/scope-lazy-collections.tsrx
+++ b/packages/octane/tests/_fixtures/scope-lazy-collections.tsrx
@@ -1,0 +1,39 @@
+import { useState } from 'octane';
+
+// A leaf that registers a ref (so its scope lazily allocates `cleanups` for the detach) and no
+// child scopes.
+function Leaf(props) @{
+	<span class="leaf" ref={props.collect} />
+}
+
+// A middle layer with no ref of its own: its scope only ever allocates `children`.
+function Branch(props) @{
+	<div class="branch">
+		<Leaf collect={props.collect} />
+		<Leaf collect={props.collect} />
+	</div>
+}
+
+// Unmounting the root has to walk the lazily-allocated `children` of every level to reach the
+// leaves' lazily-allocated `cleanups`.
+export function NestedRefs(props) @{
+	const [shown, setShown, getShown] = useState(true);
+	<div>
+		<button class="toggle" onClick={() => setShown(!getShown())}>t</button>
+		@if (shown) {
+			<Branch collect={props.collect} />
+		}
+	</div>
+}
+
+// A keyed list of pure host rows carrying refs — the de-opt clear path checks whether an item
+// scope holds any teardown state before unmounting it.
+export function RefRows(props) @{
+	const [items, setItems, getItems] = useState(() => [{ id: 1 }, { id: 2 }, { id: 3 }]);
+	<div>
+		<button class="clear" onClick={() => setItems([])}>clear</button>
+		@for (const it of items; key it.id) {
+			<span class="row" ref={props.collect} />
+		}
+	</div>
+}

--- a/packages/octane/tests/scope-lazy-collections.test.ts
+++ b/packages/octane/tests/scope-lazy-collections.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { mount, flushEffects } from './_helpers';
+import { NestedRefs, RefRows } from './_fixtures/scope-lazy-collections.tsrx';
+
+// A Scope allocates its `cleanups` and `children` arrays only when something actually registers
+// one. These pin the teardown behavior that laziness must not change: a scope that registered a
+// cleanup still runs it, a scope that registered none still tears down, and the de-opt list clear
+// still detaches refs on rows whose scopes hold no teardown state of their own.
+describe('scope collections are lazily allocated', () => {
+	it('detaches refs through nested scopes when a subtree unmounts', () => {
+		const detached: number[] = [];
+		let attached = 0;
+		const collect = (el: Element | null) => {
+			if (el) attached += 1;
+			else detached.push(attached);
+		};
+
+		const m = mount(NestedRefs, { collect });
+		flushEffects();
+		expect(attached).toBe(2);
+
+		m.click('.toggle');
+		flushEffects();
+
+		// Reaching both leaves means the teardown walked each level's lazily-allocated child
+		// scopes and then each leaf's lazily-allocated cleanup array.
+		expect(m.container.querySelectorAll('.leaf')).toHaveLength(0);
+		expect(detached).toHaveLength(2);
+
+		m.unmount();
+	});
+
+	it('detaches refs on keyed rows when the list is cleared', () => {
+		const attached: Element[] = [];
+		const detached: Element[] = [];
+		const collect = (el: Element | null) => {
+			if (el) attached.push(el);
+			else detached.push(el as any);
+		};
+
+		const m = mount(RefRows, { collect });
+		flushEffects();
+		expect(attached).toHaveLength(3);
+
+		m.click('.clear');
+		flushEffects();
+
+		expect(m.container.querySelectorAll('.row')).toHaveLength(0);
+		expect(detached).toHaveLength(3);
+
+		m.unmount();
+	});
+});


### PR DESCRIPTION
> Stacked on #294 — it touches the same reset helper. Review that one first.

## Summary

- `Scope.cleanups` and `Scope.children` are now allocated lazily, like the `hooks`, `effectSlots` and `_slots` fields beside them.
- Removes **4,002 of the 7,503** array allocations those collections were making on a 2,501-scope tree.
- `slots` deliberately stays eager. The measurement says making it lazy would cost more than it saves.

## Why

Every Scope eagerly created three arrays:

```js
this.cleanups = [];
this.children = [];
this.slots = [];
```

Most scopes never register a cleanup or a child scope, so two of those three were pure waste — and the fields right next to them (`hooks`, `effectSlots`, `_slots`) were already `T | null`, lazily built. This just makes the rest of the object consistent with that.

## Measurement

Instrumented run over a 500-row × 3-cell keyed table — 2,501 scopes:

| Collection | Allocated before | Allocated after | Saved |
| --- | ---: | ---: | ---: |
| `cleanups` | 2,501 | **0** | 100% |
| `children` | 2,501 | 1,000 | 60% |
| `slots` | 2,501 | 2,501 | — |
| **Total** | **7,503** | **3,501** | **53%** |

Cost side, `benchmarks/bench.mjs codegen-size` over the 16-file corpus:

| | baseline | this PR | delta |
| --- | ---: | ---: | ---: |
| compiled gz(min) | 25,183 | 25,200 | **+17 B** (+0.07%) |

That is the `??=` at the three cleanup-registration sites in codegen.

These are deterministic counters rather than wall-clock timings, which is the right instrument for an allocation change — the repo's own guidance prefers stable operation counters over timing when the signal would otherwise sit in the noise.

### Why `slots` stays eager

Intuition says make all three lazy. The measurement disagrees: **all 2,501 scopes used `slots`** — zero had an empty one at teardown. Making it lazy would therefore save nothing on this workload, while adding a null check to the hottest path in the framework and to every emitted `__s.slots[N]` access, since codegen indexes it directly. So it keeps its eager array, and the `Scope` shape stays monomorphic where it matters most.

## Changes

- `cleanups: Cleanup[] | null` and `children: ChildScope[] | null`, both `null` at construction.
- Registration sites allocate on demand (`(scope.cleanups ??= []).push(…)`); teardown, subtree, and de-opt walks null-check.
- The compiler emits `(__s.cleanups ??= []).push(fn)` instead of `__s.cleanups.push(fn)` — one emission site, three call sites.
- The Provider dialect reset from #294 now drops these collections instead of emptying them, so it no longer sets `length = 0` on arrays it is about to discard.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `vitest run --project octane --project octane-prod` — 9,082 passed across both compile modes
- [x] `benchmarks/bench.mjs codegen-size` — baseline vs candidate, above

### Test evidence

`packages/octane/tests/scope-lazy-collections.test.ts` pins the teardown behavior laziness must preserve, and each test was checked against the half of the change it guards:

| Test | Fails when |
| --- | --- |
| refs detach through nested scopes on unmount | the `children` walk is skipped, **or** the `cleanups` walk is |
| the de-opt keyed-list clear detaches row refs | the `cleanups` walk is skipped, or the de-opt fast-path check is |

An earlier draft of the first test used `useEffect` teardown and passed with the walk disabled — effect destroys run through `effectSlots`, not `cleanups`. It was rewritten around ref detachment, which does go through `cleanups`.

## Risk / follow-ups

- The de-opt list fast path changed from `b.cleanups.length > 0` to `b.cleanups !== null`. These are equivalent because entries are only ever appended, never spliced, so a non-null array always has at least one entry.
- The codegen change is an ABI change between compiler and runtime. They ship together, so no mixed-version window — but it does mean output compiled by an older compiler must not run on this runtime.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core unmount/teardown and compiler–runtime ABI for cleanup registration; behavior is guarded by tests but mistakes in null checks could skip cleanups or child walks.
> 
> **Overview**
> **Scope `cleanups` and `children` are now lazily allocated** (`null` until first registration), matching `hooks`, `effectSlots`, and `_slots`. Construction no longer eagerly creates empty arrays; registration uses `(scope.cleanups ??= []).push(…)` and `(parentScope.children ??= []).push(…)`, and unmount/subtree walks skip when the field is `null`.
> 
> The compiler’s `cleanupsPush` helper emits `(__s.cleanups ??= []).push(fn)` instead of assuming an existing array. On scope reset after unmount, those collections are set back to `null` rather than truncated in place; `slots` stays a fresh eager array because compiled code indexes it directly.
> 
> The keyed-list de-opt teardown fast path now gates on `cleanups !== null` (and the same for `children`) instead of `.length > 0`. New tests cover nested ref detach and clearing keyed ref rows so teardown behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d74118c6d2af71332287fa1fb307fb756c3db64d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->