### PR TITLE
perf(octane): cache derived values at their declaration

### DIFF
--- a/.changeset/auto-calculation-memo.md
+++ b/.changeset/auto-calculation-memo.md
@@ -1,0 +1,45 @@
+---
+'octane': patch
+---
+
+Derived values are now cached at their declaration. A `const` whose initializer
+performs a call during render — `const visible = todos.filter((t) => !t.completed)`
+— is lowered to a compiler-owned memo keyed on the component locals it reads, so
+its identity is stable until those inputs change.
+
+This is what makes region memoization worth having. A region keys on the
+identity of what it renders, so a derived list rebuilt on every render defeated
+its cache unconditionally: TodoMVC's list region was emitted with seven
+dependencies, six of them already stable, and never hit because the seventh was
+a fresh array every render.
+
+Never cached: hook calls (recognised by naming convention, including React's
+`unstable_use*` staging prefix — a cache around a hook freezes its state cell
+and any subscription it owns), `let` declarations, which stay the escape hatch
+for a value that must recompute every render, and calculations the render tree
+never reads. Server compiles are untouched, since a server render evaluates each
+body once.
+
+The cached value follows the same pure-render contract as the surrounding
+regions: a calculation reading state no dependency witnesses keeps its old
+value. Note that `{header.getIsSorted()}` inline in a template is still not
+memoized while `const s = header.getIsSorted()` is, so hoisting that expression
+into a local changes its reactivity — see "Derived values are cached at their
+declaration" in `docs/differences-from-react.md`.
+
+Paired benchmarks, same machine (js-framework is the control: byte-identical
+codegen with and without the pass, and it still moved ±8%, which calibrates the
+run's noise floor):
+
+  chat-stream  switchConv      3.92ms → 1.80ms  (−54%)
+  chat-stream  streamCoarse    0.56ms → 0.30ms  (−46%)
+  chat-stream  streamFine      0.94ms → 0.66ms  (−30%)
+  chat-stream  type160         1.22ms → 1.02ms  (−16%)
+  memo-wall    parent_equal_B  0.226ms → 0.109ms (−52%)
+  memo-wall    ctx_wall_B      0.569ms → 0.453ms (−20%)
+  todomvc      toggleAllOff    0.24ms → 0.12ms  (−50%)
+  todomvc      toggleAllOn     0.24ms → 0.14ms  (−42%)
+  todomvc      filterCycle     0.80ms → 0.46ms  (−42%)
+
+No operation regresses by the repository's compare rule. Compiled output grows
+0.25% gzip on the `codegen-size` corpus.

--- a/.changeset/auto-calculation-memo.md
+++ b/.changeset/auto-calculation-memo.md
@@ -3,43 +3,45 @@
 ---
 
 Derived values are now cached at their declaration. A `const` whose initializer
-performs a call during render — `const visible = todos.filter((t) => !t.completed)`
-— is lowered to a compiler-owned memo keyed on the component locals it reads, so
-its identity is stable until those inputs change.
+performs a call during render — where every such call is a value projection by
+the rule automatic memoization already uses — is lowered to a compiler-owned
+memo keyed on the component locals it reads, so its identity is stable until
+those inputs change.
 
 This is what makes region memoization worth having. A region keys on the
-identity of what it renders, so a derived list rebuilt on every render defeated
-its cache unconditionally: TodoMVC's list region was emitted with seven
-dependencies, six of them already stable, and never hit because the seventh was
-a fresh array every render.
+identity of what it renders, so a derived value rebuilt on every render defeats
+its cache unconditionally: memo-wall's value-position wall rebuilt 1,000
+descriptors through `buildValueRows(items)` on every parent re-render, and that
+call alone was 35% of the operation's CPU profile.
 
-Never cached: hook calls (recognised by naming convention, including React's
-`unstable_use*` staging prefix — a cache around a hook freezes its state cell
-and any subscription it owns), `let` declarations, which stay the escape hatch
-for a value that must recompute every render, and calculations the render tree
-never reads. Server compiles are untouched, since a server render evaluates each
-body once.
+A calculation is admitted on exactly the callee rule that governs regions, so
+the two agree. A member call is not cached even when its result is named:
+`virtualizer.getVirtualItems()` moves with scroll while the virtualizer instance
+stays put, and caching it froze a virtualized list mid-scroll. That also means
+`const visible = todos.filter(...)` stays uncached — a genuine miss, since
+`todos` really is an immutable snapshot, but this analysis cannot yet tell an
+immutable receiver from a live one. Wrap it in `useMemo` yourself when the
+identity matters; recovering it automatically needs receiver provenance and is
+left as follow-up.
 
-The cached value follows the same pure-render contract as the surrounding
-regions: a calculation reading state no dependency witnesses keeps its old
-value. Note that `{header.getIsSorted()}` inline in a template is still not
-memoized while `const s = header.getIsSorted()` is, so hoisting that expression
-into a local changes its reactivity — see "Derived values are cached at their
-declaration" in `docs/differences-from-react.md`.
+Also never cached: hook calls (recognised by naming convention, including
+React's `unstable_use*` staging prefix — a cache around a hook freezes its state
+cell and any subscription it owns), `let` declarations, which stay the escape
+hatch for a value that must recompute every render, and calculations the render
+tree never reads. Server compiles are untouched, since a server render evaluates
+each body once.
 
-Paired benchmarks, same machine (js-framework is the control: byte-identical
-codegen with and without the pass, and it still moved ±8%, which calibrates the
-run's noise floor):
+Measured on `benchmarks/memo-wall`, paired runs against a baseline recorded
+before any edit:
 
-  chat-stream  switchConv      3.92ms → 1.80ms  (−54%)
-  chat-stream  streamCoarse    0.56ms → 0.30ms  (−46%)
-  chat-stream  streamFine      0.94ms → 0.66ms  (−30%)
-  chat-stream  type160         1.22ms → 1.02ms  (−16%)
-  memo-wall    parent_equal_B  0.226ms → 0.109ms (−52%)
-  memo-wall    ctx_wall_B      0.569ms → 0.453ms (−20%)
-  todomvc      toggleAllOff    0.24ms → 0.12ms  (−50%)
-  todomvc      toggleAllOn     0.24ms → 0.14ms  (−42%)
-  todomvc      filterCycle     0.80ms → 0.46ms  (−42%)
+  parent_rerender_equal_B  0.226ms → 0.091ms  (−60%)
+  one_change_B             0.235ms → 0.156ms  (−34%)
+  ctx_through_wall_B       0.569ms → 0.413ms  (−27%)
 
-No operation regresses by the repository's compare rule. Compiled output grows
-0.25% gzip on the `codegen-size` corpus.
+That is the `createElement`-descriptors-through-a-children-hole shape every
+`@octanejs/*` binding produces. `todomvc`, `chat-stream` and `js-framework`
+compile byte-identically with and without this change and are reported as
+controls only — their run-to-run movement (up to ±100% on sub-millisecond
+operations) is the noise floor, not a result.
+
+Compiled output grows 0.07% gzip on the `codegen-size` corpus.

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -70,22 +70,68 @@ same result React gives an unmemoized component:
 - **A component-local callee.** `const read = (h) => h.getIsSorted()` is an
   identifier, but nothing pins it to an immutable module identity, so it cannot
   stand in for a projection even when something hands it a stable reference.
-- **Hooks.** `use()` is a suspension point, and `use*` calls own hook cells,
-  context subscriptions, and effect lifecycles, so a region containing one is
-  always re-entered.
+- **Hooks.** `use()` is a suspension point, and `use*` calls (including React's
+  `unstable_use*` staging prefix) own hook cells, context subscriptions, and
+  effect lifecycles, so a region containing one is always re-entered.
 - **`new Foo()` and tagged templates.** Construction is not a value projection.
 
 Arguments carry the same contract as the call itself: `{format(row.get())}` is
 rejected even though `format` qualifies.
 
-If you want a method-backed value memoized, read it into a local first
-(`const sorted = header.getIsSorted();`) and let the surrounding state own it —
-the same advice React Compiler gives. Conversely, a region *is* allowed to
-memoize past a mutable module-level variable, whether read directly or returned
-by an imported helper; module state that must drive rendering belongs in state
-or context. Octane cannot read across a module boundary, so an imported helper
-is taken at its word — that is the one place this analysis trusts rather than
-proves, and it matches React Compiler's own assumption.
+A region *is* allowed to memoize past a mutable module-level variable, whether
+read directly or returned by an imported helper; module state that must drive
+rendering belongs in state or context. Octane cannot read across a module
+boundary, so an imported helper is taken at its word — that is the one place
+this analysis trusts rather than proves, and it matches React Compiler's own
+assumption.
+
+## Derived values are cached at their declaration
+
+A `const` whose initializer performs a call during render is cached on the
+component-local values it reads:
+
+```tsx
+const visible = todos.filter((t) => !t.completed); // cached on [todos]
+```
+
+`visible` keeps the same array identity until `todos` changes. This is what
+makes the region memoization above worth having: a region keys on the identity
+of what it renders, so a derived list rebuilt on every render would defeat its
+cache unconditionally.
+
+**The contract is pure render.** The cached value is reused while its tracked
+inputs are unchanged, so a calculation that reads something no input witnesses —
+a live accessor, a mutable module variable — keeps its old value. Pass such
+state through `useState`/`useReducer`/context and it is witnessed normally.
+
+Never cached:
+
+- **Hook calls.** `const s = useThing()` and `const s = unstable_useThing()`
+  keep their hook cells and subscriptions. Hooks are recognised by naming
+  convention — the same signal React and React Compiler use — so a hook named
+  outside that convention is the one shape this cannot protect.
+- **`let` declarations.** Reassignment would be dropped, so `let` is left alone.
+  It doubles as the escape hatch when you want a value recomputed every render.
+- **Values the render tree never reads.** A calculation used only by an event
+  handler pays nothing.
+
+### Why a hoisted local and an inline expression can differ
+
+`{header.getIsSorted()}` inline in a template is **not** memoized (a method call
+carries the receiver hazard described above), but
+
+```tsx
+const sorted = header.getIsSorted(); // cached on [header]
+```
+
+**is** — so hoisting that expression into a local changes its reactivity.
+
+This asymmetry is deliberate. The inline form is what library bindings put in
+their consumers' templates, where the author may not know a live accessor is
+involved; the `const` form is a value the author chose to name in their own
+component body, which is exactly where React Compiler assumes the pure-render
+contract. Keep such a read inline, or assign it to a `let`, when you want it
+re-evaluated on every render.
 
 ## `useState` / `useReducer` current-state getters
 

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -88,23 +88,33 @@ assumption.
 ## Derived values are cached at their declaration
 
 A `const` whose initializer performs a call during render is cached on the
-component-local values it reads:
+component locals it reads — provided every one of those calls is a value
+projection by the rule above:
 
 ```tsx
-const visible = todos.filter((t) => !t.completed); // cached on [todos]
+const labels = formatRows(rows); // formatRows is imported → cached on [rows]
 ```
 
-`visible` keeps the same array identity until `todos` changes. This is what
-makes the region memoization above worth having: a region keys on the identity
-of what it renders, so a derived list rebuilt on every render would defeat its
-cache unconditionally.
+`labels` keeps the same array identity until `rows` changes. This is what makes
+the region memoization above worth having: a region keys on the identity of what
+it renders, so a derived value rebuilt on every render defeats its cache
+unconditionally.
 
-**The contract is pure render.** The cached value is reused while its tracked
-inputs are unchanged, so a calculation that reads something no input witnesses —
-a live accessor, a mutable module variable — keeps its old value. Pass such
-state through `useState`/`useReducer`/context and it is witnessed normally.
+The callee rule is the same one regions use, and for the same reason. A member
+call is not cached even when its result is named:
 
-Never cached:
+```tsx
+const items = virtualizer.getVirtualItems(); // NOT cached
+const visible = todos.filter((t) => !t.completed); // NOT cached
+```
+
+The first is the receiver hazard exactly: the window moves with scroll while the
+virtualizer instance stays put, so a cache keyed on it would freeze a
+virtualized list mid-scroll. The second is a genuine miss — `todos` really is an
+immutable snapshot — but this analysis cannot yet tell the two apart, so it fails
+closed on both. Wrap it in `useMemo` yourself when the identity matters.
+
+Also never cached:
 
 - **Hook calls.** `const s = useThing()` and `const s = unstable_useThing()`
   keep their hook cells and subscriptions. Hooks are recognised by naming
@@ -115,23 +125,10 @@ Never cached:
 - **Values the render tree never reads.** A calculation used only by an event
   handler pays nothing.
 
-### Why a hoisted local and an inline expression can differ
-
-`{header.getIsSorted()}` inline in a template is **not** memoized (a method call
-carries the receiver hazard described above), but
-
-```tsx
-const sorted = header.getIsSorted(); // cached on [header]
-```
-
-**is** — so hoisting that expression into a local changes its reactivity.
-
-This asymmetry is deliberate. The inline form is what library bindings put in
-their consumers' templates, where the author may not know a live accessor is
-involved; the `const` form is a value the author chose to name in their own
-component body, which is exactly where React Compiler assumes the pure-render
-contract. Keep such a read inline, or assign it to a `let`, when you want it
-re-evaluated on every render.
+Within those bounds the contract is pure render: the cached value is reused while
+its tracked inputs are unchanged, so a projection that reads state no input
+witnesses keeps its old value. Pass such state through
+`useState`/`useReducer`/context and it is witnessed normally.
 
 ## `useState` / `useReducer` current-state getters
 

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -2174,6 +2174,84 @@ function rewriteAutoCallback(stmt, stable, componentLocals, ctx) {
 	return modified ? { ...stmt, declarations: newDecls } : stmt;
 }
 
+// Auto-calculation: lower a derived `const X = <expr containing a render-time
+// call>` to `useMemo(() => <expr>, [deps])` so its identity is stable while its
+// inputs are. Without this, an idiomatic `const visible = todos.filter(...)`
+// allocates a fresh array every render, and every downstream consumer keyed on
+// its identity — an autoMemo region's dependency tuple, a memo() child's prop —
+// misses unconditionally. The region cache is only as good as the stability of
+// what it keys on.
+//
+// This is the calculation half of the same pure-render, immutable-snapshot
+// contract autoMemo's regions assume, and it is deliberately NOT gated on the
+// callee-shape rule that governs regions: a calculation is a value the author
+// hoisted into a local, and React Compiler memoizes those unconditionally.
+// docs/differences-from-react.md documents the resulting staleness contract.
+//
+// Scope: single-declarator `const` with an Identifier id whose init reaches a
+// render-time call (isPropCreationExpr — no JSX, no hook-shaped calls), whose
+// value the render tree actually reads (memoizing a value nothing renders only
+// adds cells), and whose dependencies are all component locals. Bodies that
+// already went through Pass A′ arrive with hook-shaped inits and are skipped.
+function rewriteAutoCalculation(stmt, componentLocals, renderReadNames, ctx) {
+	if (stmt.type !== 'VariableDeclaration' || stmt.kind !== 'const') return stmt;
+	if (stmt.declarations?.length !== 1) return stmt;
+	const decl = stmt.declarations[0];
+	if (!decl || decl.id?.type !== 'Identifier' || !decl.init) return stmt;
+	if (!renderReadNames.has(decl.id.name)) return stmt;
+	const init = unwrapTsExpr(decl.init);
+	// An arrow/function init is auto-callback's job, not ours.
+	if (FN_TYPES.has(init?.type)) return stmt;
+	if (!isPropCreationExpr(init, ctx)) return stmt;
+	const deps = [];
+	const seen = new Set();
+	for (const name of collectFreeIdentifiers(init, [])) {
+		if (name === decl.id.name) return stmt; // self-referential; leave alone
+		if (!componentLocals.has(name)) continue;
+		if (seen.has(name)) continue;
+		seen.add(name);
+		deps.push(name);
+	}
+	// Every free name must be a witnessed component local. An unwitnessed
+	// module/global read would make the cache freeze on something no dependency
+	// can observe, which is a different bargain from the one above.
+	for (const name of collectFreeIdentifiers(init, [])) {
+		if (
+			!componentLocals.has(name) &&
+			!ctx.moduleFunctionDeclarations?.has(name) &&
+			!ctx.importedNames?.has(name)
+		) {
+			return stmt;
+		}
+	}
+	return {
+		...stmt,
+		declarations: [
+			{
+				...decl,
+				init: inheritOriginLoc(
+					b.call(
+						{ ...b.id('useMemo'), _octaneGenerated: true },
+						b.arrow([], init),
+						b.array(deps.map((n) => b.id(n))),
+					),
+					init,
+				),
+			},
+		],
+	};
+}
+
+// Names the render tree actually reads, resolved against the scopes the
+// statement walker cannot see (nested functions, loops, `@for` item bindings,
+// directive-arm blocks) so a shadowing inner binding never nominates an
+// unrelated body const.
+function collectRenderReadNames(jsxNodes, ctx) {
+	const into = new Set();
+	collectUseArgumentRoots(jsxNodes, ctx, into, true, true);
+	return into;
+}
+
 function allocAutoMemoCell(ctx, dependencyCount) {
 	const base = ctx.currentAutoMemoOffset || 0;
 	const init = base + dependencyCount;
@@ -2858,6 +2936,12 @@ function containsRenderCall(stmts, memoCtx = null) {
 	return found;
 }
 
+// A hook call is identified by naming convention — the same signal React and
+// React Compiler key on. Prefixed forms (`unstable_useRouterState`) count: a
+// binding that mirrors React Router's `unstable_` naming is still a hook, and
+// wrapping one in a cache would freeze its subscription rather than merely
+// stale a value.
+const HOOK_NAME_CONVENTION_RE = /(?:^|_)use(?:$|[A-Z])/;
 const HOOK_CALLEE_NAME_RE = /^use[A-Z]/;
 
 function isHookCalleeName(name) {
@@ -9386,6 +9470,19 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 			creations,
 			puParamNames,
 		);
+		// Auto-calculation runs AFTER Pass A′ so use()-fed chains keep their
+		// Symbol-slot treatment (their rewritten inits are hook-shaped and are
+		// skipped here), and BEFORE Pass A/B so the numeric-slot useMemo it mints is
+		// lowered by the authored inline tier rather than re-wrapped. Client only:
+		// a server render evaluates each body once, so a cache is pure overhead.
+		if (ctx.currentComponentLocals && ctx.mode !== 'server') {
+			const renderReadNames = collectRenderReadNames(jsxNodes, ctx);
+			if (renderReadNames.size > 0) {
+				workingStatements = workingStatements.map((statement) =>
+					rewriteAutoCalculation(statement, ctx.currentComponentLocals, renderReadNames, ctx),
+				);
+			}
+		}
 		workingStatements = parallelUseMemoizePass(workingStatements, ctx, name, creations, [], null);
 		jsxNodes = parallelUseWalkJsx(jsxNodes, ctx, name, creations, warmChildren, [], new Set());
 		const warm = buildWarmArtifacts(node, ctx, name, creations, warmChildren);
@@ -10210,14 +10307,17 @@ function isPropCreationExpr(expr, ctx) {
 	function isHookishCallee(callee) {
 		if (callee.type === 'Identifier') {
 			return (
-				/^use($|[A-Z])/.test(callee.name) || ctx?._parallelUseAliases?.has(callee.name) === true
+				HOOK_NAME_CONVENTION_RE.test(callee.name) ||
+				ctx?._parallelUseAliases?.has(callee.name) === true
 			);
 		}
 		if (
 			(callee.type === 'MemberExpression' || callee.type === 'OptionalMemberExpression') &&
 			!callee.computed
 		) {
-			return callee.property.type === 'Identifier' && /^use($|[A-Z])/.test(callee.property.name);
+			return (
+				callee.property.type === 'Identifier' && HOOK_NAME_CONVENTION_RE.test(callee.property.name)
+			);
 		}
 		return false;
 	}
@@ -10632,7 +10732,13 @@ function memoizeUseFedCreations(stmts, jsxNodes, ctx, componentName, creations, 
 // Deep scan (nested functions and render-tree nodes included — a consumer
 // anywhere makes stability load-bearing) for `use(<arg>)` arguments' free
 // identifier roots.
-function collectUseArgumentRoots(root, ctx, into, startInRenderTree = false) {
+function collectUseArgumentRoots(
+	root,
+	ctx,
+	into,
+	startInRenderTree = false,
+	seedRenderReads = false,
+) {
 	walk(root, EMPTY_BOUND_SET, startInRenderTree);
 
 	// `bound` carries every name introduced by a scope the candidate collector
@@ -10701,6 +10807,9 @@ function collectUseArgumentRoots(root, ctx, into, startInRenderTree = false) {
 			walk(n.body, inner, true);
 			walk(n.empty, bound, true);
 			return;
+		}
+		if (seedRenderReads && inRenderTree && n.type === 'Identifier' && !bound.has(n.name)) {
+			into.add(n.name);
 		}
 		if (inRenderTree && n.type === 'BlockStatement') {
 			const inner = new Set(bound);

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -2182,17 +2182,26 @@ function rewriteAutoCallback(stmt, stable, componentLocals, ctx) {
 // misses unconditionally. The region cache is only as good as the stability of
 // what it keys on.
 //
-// This is the calculation half of the same pure-render, immutable-snapshot
-// contract autoMemo's regions assume, and it is deliberately NOT gated on the
-// callee-shape rule that governs regions: a calculation is a value the author
-// hoisted into a local, and React Compiler memoizes those unconditionally.
-// docs/differences-from-react.md documents the resulting staleness contract.
+// A calculation is admitted on exactly the callee rule that governs regions
+// (plainCalleeIsMemoizable): the receiver of a member call can return a new
+// answer while its own identity holds, and that hazard does not become safe
+// because the author named the result. `virtualizer.getVirtualItems()` in
+// examples/pulseboard is the same shape as `header.column.getIsSorted()` — its
+// window moves with scroll while the virtualizer instance stays put — so
+// caching it froze a virtualized list mid-scroll. One rule, both paths.
+//
+// The cost of that is real and accepted: `const visible = todos.filter(...)`
+// stays uncached, because `todos.filter` is a member call and this analysis
+// cannot yet prove the receiver is an immutable snapshot rather than a live
+// object. Recovering it needs receiver provenance (does the root trace to a
+// state binding?), which is a separate change with its own evidence.
 //
 // Scope: single-declarator `const` with an Identifier id whose init reaches a
 // render-time call (isPropCreationExpr — no JSX, no hook-shaped calls), whose
-// value the render tree actually reads (memoizing a value nothing renders only
-// adds cells), and whose dependencies are all component locals. Bodies that
-// already went through Pass A′ arrive with hook-shaped inits and are skipped.
+// every call is an admitted projection, whose value the render tree actually
+// reads (memoizing a value nothing renders only adds cells), and whose
+// dependencies are all component locals. Bodies that already went through Pass
+// A′ arrive with hook-shaped inits and are skipped.
 function rewriteAutoCalculation(stmt, componentLocals, renderReadNames, ctx) {
 	if (stmt.type !== 'VariableDeclaration' || stmt.kind !== 'const') return stmt;
 	if (stmt.declarations?.length !== 1) return stmt;
@@ -2203,6 +2212,9 @@ function rewriteAutoCalculation(stmt, componentLocals, renderReadNames, ctx) {
 	// An arrow/function init is auto-callback's job, not ours.
 	if (FN_TYPES.has(init?.type)) return stmt;
 	if (!isPropCreationExpr(init, ctx)) return stmt;
+	// Every call reached during render must be a proven value projection — the
+	// same admission the region cache uses. A member call fails closed.
+	if (containsRenderCall([init], ctx)) return stmt;
 	const deps = [];
 	const seen = new Set();
 	for (const name of collectFreeIdentifiers(init, [])) {
@@ -10742,7 +10754,7 @@ function collectUseArgumentRoots(
 	startInRenderTree = false,
 	seedRenderReads = false,
 ) {
-	walk(root, EMPTY_BOUND_SET, startInRenderTree);
+	walk(root, EMPTY_BOUND_SET, startInRenderTree, false);
 
 	// `bound` carries every name introduced by a scope the candidate collector
 	// cannot reach: nested-function params + internal declarations, loop
@@ -10754,10 +10766,10 @@ function collectUseArgumentRoots(
 	// into memoization (which would wrongly stop it recreating per render).
 	// Over-binding is the safe direction: a dropped seed just leaves that
 	// chain unmemoized — today's behavior.
-	function walk(n, bound, inRenderTree) {
+	function walk(n, bound, inRenderTree, deferred) {
 		if (n == null || typeof n !== 'object') return;
 		if (Array.isArray(n)) {
-			for (const child of n) walk(child, bound, inRenderTree);
+			for (const child of n) walk(child, bound, inRenderTree, deferred);
 			return;
 		}
 		if (
@@ -10774,7 +10786,10 @@ function collectUseArgumentRoots(
 			const inner = new Set(bound);
 			for (const param of n.params || []) collectPatternNames(param, inner);
 			collectScopeDeclaredNames(n.body, inner);
-			walk(n.body, inner, inRenderTree);
+			// A function VALUE runs at invoke time, not while the template renders,
+			// so names it reads are not render reads. use()-argument seeding still
+			// descends (a use() inside a render prop is a real suspension point).
+			walk(n.body, inner, inRenderTree, true);
 			return;
 		}
 		if (LOOP_TYPES.has(n.type)) {
@@ -10783,7 +10798,7 @@ function collectUseArgumentRoots(
 			for (const key in n) {
 				if (key === 'loc' || key === 'start' || key === 'end' || key.startsWith('_octane'))
 					continue;
-				walk(n[key], inner, inRenderTree);
+				walk(n[key], inner, inRenderTree, deferred);
 			}
 			return;
 		}
@@ -10791,7 +10806,7 @@ function collectUseArgumentRoots(
 			const inner = new Set(bound);
 			if (n.param) collectPatternNames(n.param, inner);
 			collectScopeDeclaredNames(n.body, inner);
-			walk(n.body, inner, inRenderTree);
+			walk(n.body, inner, inRenderTree, deferred);
 			return;
 		}
 		if (n.type === 'JSXForExpression') {
@@ -10805,19 +10820,32 @@ function collectUseArgumentRoots(
 				collectPatternNames(n.left, inner);
 			}
 			if (n.index) collectPatternNames(n.index, inner);
-			walk(n.right, bound, true);
-			walk(n.key, inner, true);
-			walk(n.body, inner, true);
-			walk(n.empty, bound, true);
+			walk(n.right, bound, true, deferred);
+			walk(n.key, inner, true, deferred);
+			walk(n.body, inner, true, deferred);
+			walk(n.empty, bound, true, deferred);
 			return;
 		}
-		if (seedRenderReads && inRenderTree && n.type === 'Identifier' && !bound.has(n.name)) {
+		if (
+			seedRenderReads &&
+			inRenderTree &&
+			!deferred &&
+			n.type === 'Identifier' &&
+			!bound.has(n.name)
+		) {
 			into.add(n.name);
+		}
+		if ((n.type === 'MemberExpression' || n.type === 'OptionalMemberExpression') && !n.computed) {
+			// `row.length` reads `row`, not a binding called `length`. Skipping the
+			// property also cannot hide a use() call: a non-computed property is an
+			// Identifier by construction.
+			walk(n.object, bound, inRenderTree, deferred);
+			return;
 		}
 		if (inRenderTree && n.type === 'BlockStatement') {
 			const inner = new Set(bound);
 			collectScopeDeclaredNames(n, inner);
-			for (const child of n.body || []) walk(child, inner, true);
+			for (const child of n.body || []) walk(child, inner, true, deferred);
 			return;
 		}
 		// JSX reached at a setup VALUE position (`const el = <div>{use(x)}</div>`)
@@ -10828,7 +10856,7 @@ function collectUseArgumentRoots(
 				(n.type.startsWith('JSX') || n.type === 'Element' || n.type === 'Tsrx'));
 		for (const key in n) {
 			if (key === 'loc' || key === 'start' || key === 'end' || key.startsWith('_octane')) continue;
-			walk(n[key], bound, nextInRenderTree);
+			walk(n[key], bound, nextInRenderTree, deferred);
 		}
 	}
 }

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -2937,15 +2937,18 @@ function containsRenderCall(stmts, memoCtx = null) {
 }
 
 // A hook call is identified by naming convention — the same signal React and
-// React Compiler key on. Prefixed forms (`unstable_useRouterState`) count: a
-// binding that mirrors React Router's `unstable_` naming is still a hook, and
-// wrapping one in a cache would freeze its subscription rather than merely
-// stale a value.
-const HOOK_NAME_CONVENTION_RE = /(?:^|_)use(?:$|[A-Z])/;
-const HOOK_CALLEE_NAME_RE = /^use[A-Z]/;
+// React Compiler key on — plus React's own `unstable_` staging prefix, which
+// bindings mirror (`unstable_useRouterState` in @octanejs/remix-router). The
+// prefix is enumerated rather than matched as "any `_use`" so an ordinary
+// helper cannot be mistaken for a hook by spelling alone.
+//
+// Getting this wrong in the permissive direction is not a staleness bug: a
+// cache wrapped around a hook call freezes its subscription and its state cell
+// for the life of the component.
+const HOOK_NAME_CONVENTION_RE = /^(?:unstable_)?use(?:$|[A-Z])/;
 
 function isHookCalleeName(name) {
-	return name === 'use' || HOOK_CALLEE_NAME_RE.test(name);
+	return HOOK_NAME_CONVENTION_RE.test(name);
 }
 
 /**

--- a/packages/octane/tests/_fixtures/auto-calculation-helpers.ts
+++ b/packages/octane/tests/_fixtures/auto-calculation-helpers.ts
@@ -1,0 +1,11 @@
+// Cross-module helpers for the auto-calculation fixture. An imported callee is
+// opaque to the importing module's compilation, so these exist to exercise the
+// admitted-projection path rather than to hide behavior.
+
+export function projectRows(rows: ReadonlyArray<{ id: number; n: number }>): string[] {
+	return rows.map((r) => `r${r.id}:${r.n}`);
+}
+
+export function tagged(value: string): string {
+	return `[${value}]`;
+}

--- a/packages/octane/tests/_fixtures/auto-calculation.tsrx
+++ b/packages/octane/tests/_fixtures/auto-calculation.tsrx
@@ -26,15 +26,15 @@ export function resetIdentities() {
 
 export function DerivedIdentity() @{
 	const [items, setItems] = useState([
-		{ id: 1, on: false },
+		{ id: 1, n: 1 },
 	]);
 	const [tick, setTick] = useState(0);
-	const visible = items.filter((it) => !it.on);
+	const visible = projectRows(items);
 	<div>
 		<button id="di-tick" onClick={() => setTick(tick + 1)}>{'tick'}</button>
 		<button
 			id="di-add"
-			onClick={() => setItems([...items, { id: items.length + 1, on: false }])}
+			onClick={() => setItems([...items, { id: items.length + 1, n: items.length + 1 }])}
 		>{'add'}</button>
 		<span id="di-identity">{identityOf(visible)}</span>
 		<span id="di-count">{'' + visible.length}</span>
@@ -127,5 +127,34 @@ export function HandlerOnlyCalculation() @{
 			onClick={() => setRows([...rows, { id: rows.length + 1, n: rows.length + 1 }])}
 		>{'bump'}</button>
 		<span id="ho-seen">{seen}</span>
+	</div>
+}
+
+// --- a member call on a live receiver is never cached -----------------------
+//
+// The receiver hazard: a stable object whose method returns a different answer
+// each time it is asked. `virtualizer.getVirtualItems()` in examples/pulseboard
+// is this shape — the window moves with scroll while the virtualizer instance
+// stays put — and caching it froze a virtualized list mid-scroll.
+function createSource() {
+	let n = 0;
+	return {
+		read() {
+			n += 1;
+			return 'n' + n;
+		},
+	};
+}
+
+export function LiveReceiverCalculation() @{
+	// Held in state so its identity is stable across renders — exactly the
+	// condition that makes a cache keyed on it freeze.
+	const [source] = useState(createSource);
+	const [tick, setTick] = useState(0);
+	const reading = source.read();
+	<div>
+		<button id="lr-tick" onClick={() => setTick(tick + 1)}>{'tick'}</button>
+		<span id="lr-reading">{reading}</span>
+		<span id="lr-tickval">{'' + tick}</span>
 	</div>
 }

--- a/packages/octane/tests/_fixtures/auto-calculation.tsrx
+++ b/packages/octane/tests/_fixtures/auto-calculation.tsrx
@@ -1,0 +1,131 @@
+import { useState } from 'octane';
+import { projectRows, tagged } from './auto-calculation-helpers.ts';
+
+// Fixtures for auto-calculation memoization: a derived `const` whose init
+// reaches a render-time call is cached on its component-local inputs, so its
+// identity is stable while those inputs are.
+
+// --- identity stability ----------------------------------------------------
+
+// `derived` is rebuilt only when `items` changes. The probe renders the
+// identity itself so a test can observe stability without asserting on
+// internals: a fresh array means a fresh label.
+let identityCounter = 0;
+const identities = new WeakMap<object, number>();
+function identityOf(value: object): string {
+	let id = identities.get(value);
+	if (id === undefined) {
+		id = ++identityCounter;
+		identities.set(value, id);
+	}
+	return 'id' + id;
+}
+export function resetIdentities() {
+	identityCounter = 0;
+}
+
+export function DerivedIdentity() @{
+	const [items, setItems] = useState([
+		{ id: 1, on: false },
+	]);
+	const [tick, setTick] = useState(0);
+	const visible = items.filter((it) => !it.on);
+	<div>
+		<button id="di-tick" onClick={() => setTick(tick + 1)}>{'tick'}</button>
+		<button
+			id="di-add"
+			onClick={() => setItems([...items, { id: items.length + 1, on: false }])}
+		>{'add'}</button>
+		<span id="di-identity">{identityOf(visible)}</span>
+		<span id="di-count">{'' + visible.length}</span>
+		<span id="di-tickval">{'' + tick}</span>
+	</div>
+}
+
+// --- correctness of the cached value ---------------------------------------
+
+export function DerivedValue() @{
+	const [rows, setRows] = useState([
+		{ id: 1, n: 1 },
+		{ id: 2, n: 2 },
+	]);
+	const [tick, setTick] = useState(0);
+	const total = rows.reduce((sum, r) => sum + r.n, 0);
+	const labels = projectRows(rows);
+	<div>
+		<button id="dv-tick" onClick={() => setTick(tick + 1)}>{'tick'}</button>
+		<button
+			id="dv-bump"
+			onClick={() => setRows(rows.map((r) => (r.id === 1 ? { ...r, n: r.n + 10 } : r)))}
+		>{'bump'}</button>
+		<span id="dv-total">{'' + total}</span>
+		<span id="dv-labels">{labels.join(',')}</span>
+		<span id="dv-tickval">{'' + tick}</span>
+	</div>
+}
+
+// --- hook calls are never wrapped ------------------------------------------
+//
+// A cache around a hook call freezes its state cell and any subscription it
+// owns. These two shapes both LOOK like ordinary creations to a purely
+// syntactic creation check: the callee is a plain identifier and the call is
+// reached during render. Only the naming convention distinguishes them.
+
+function useCounterState(): { value: number; bump: () => void } {
+	const [value, setValue] = useState(0);
+	return { value, bump: () => setValue(value + 1) };
+}
+
+// React's staging prefix, mirrored by bindings (@octanejs/remix-router ships
+// `unstable_useRouterState`). Still a hook.
+function unstable_useLabelState(): { label: string; set: () => void } {
+	const [label, setLabel] = useState('a');
+	return { label, set: () => setLabel('b') };
+}
+
+export function HookCallDeclarations() @{
+	const counter = useCounterState();
+	const labelled = unstable_useLabelState();
+	const [tick, setTick] = useState(0);
+	<div>
+		<button id="hc-tick" onClick={() => setTick(tick + 1)}>{'tick'}</button>
+		<button id="hc-bump" onClick={counter.bump}>{'bump'}</button>
+		<button id="hc-label" onClick={labelled.set}>{'label'}</button>
+		<span id="hc-count">{'' + counter.value}</span>
+		<span id="hc-label-value">{labelled.label}</span>
+		<span id="hc-tickval">{'' + tick}</span>
+	</div>
+}
+
+// --- shapes that must keep recomputing -------------------------------------
+
+// A `let` can be reassigned, so caching its initializer would drop the
+// reassignment. It must keep evaluating every render.
+export function ReassignedLocal() @{
+	const [tick, setTick] = useState(0);
+	let label = tagged('base');
+	if (tick > 0) label = tagged('changed');
+	<div>
+		<button id="rl-tick" onClick={() => setTick(tick + 1)}>{'tick'}</button>
+		<span id="rl-label">{label}</span>
+	</div>
+}
+
+// A calculation reached only by an event handler — never read by the render
+// tree — should not acquire a cache it cannot pay for. Behaviorally it must
+// simply keep working.
+export function HandlerOnlyCalculation() @{
+	const [rows, setRows] = useState([
+		{ id: 1, n: 1 },
+	]);
+	const [seen, setSeen] = useState('none');
+	const summary = projectRows(rows).join('|');
+	<div>
+		<button id="ho-read" onClick={() => setSeen(summary)}>{'read'}</button>
+		<button
+			id="ho-bump"
+			onClick={() => setRows([...rows, { id: rows.length + 1, n: rows.length + 1 }])}
+		>{'bump'}</button>
+		<span id="ho-seen">{seen}</span>
+	</div>
+}

--- a/packages/octane/tests/auto-calculation.test.ts
+++ b/packages/octane/tests/auto-calculation.test.ts
@@ -6,6 +6,7 @@ import {
 	HookCallDeclarations,
 	ReassignedLocal,
 	HandlerOnlyCalculation,
+	LiveReceiverCalculation,
 	resetIdentities,
 } from './_fixtures/auto-calculation.tsrx';
 
@@ -136,6 +137,26 @@ describe('auto-calculation — shapes that must keep recomputing', () => {
 		r.click('#ho-bump');
 		r.click('#ho-read');
 		expect(r.find('#ho-seen').textContent).toBe('r1:1|r2:2');
+		r.unmount();
+	});
+});
+
+describe('auto-calculation — a member call on a live receiver is never cached', () => {
+	it('re-reads a stable receiver whose method answer changes', () => {
+		// A cache keyed on the receiver's identity would freeze this reading, which
+		// is how caching `virtualizer.getVirtualItems()` froze a virtualized list
+		// mid-scroll. The receiver carries the hazard, so the author naming the
+		// result does not make it safe.
+		const r = mount(LiveReceiverCalculation);
+		const first = r.find('#lr-reading').textContent;
+
+		r.click('#lr-tick');
+		expect(r.find('#lr-tickval').textContent).toBe('1');
+		expect(r.find('#lr-reading').textContent).not.toBe(first);
+
+		const second = r.find('#lr-reading').textContent;
+		r.click('#lr-tick');
+		expect(r.find('#lr-reading').textContent).not.toBe(second);
 		r.unmount();
 	});
 });

--- a/packages/octane/tests/auto-calculation.test.ts
+++ b/packages/octane/tests/auto-calculation.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mount } from './_helpers';
+import {
+	DerivedIdentity,
+	DerivedValue,
+	HookCallDeclarations,
+	ReassignedLocal,
+	HandlerOnlyCalculation,
+	resetIdentities,
+} from './_fixtures/auto-calculation.tsrx';
+
+// A derived `const` whose initializer reaches a render-time call is cached on
+// its component-local inputs. The observable contract is identity stability —
+// downstream consumers keyed on that identity (an autoMemo region's dependency
+// tuple, a memo() child's prop) can only bail if it holds — and, of course,
+// that the cached value is still correct.
+//
+// The cache is a production-compile lowering, so `octane-prod` exercises the
+// inline flat-cache branch while `octane` exercises the runtime hook form.
+// Identical expectations across both projects is the semantic-equivalence
+// proof, which is why these are behavioral assertions rather than codegen ones.
+
+beforeEach(() => {
+	resetIdentities();
+});
+
+describe('auto-calculation — identity is stable while inputs are', () => {
+	it('reuses a derived array across an unrelated re-render', () => {
+		const r = mount(DerivedIdentity);
+		const first = r.find('#di-identity').textContent;
+		expect(r.find('#di-count').textContent).toBe('1');
+
+		// Unrelated state moves; `items` does not.
+		r.click('#di-tick');
+		expect(r.find('#di-tickval').textContent).toBe('1');
+		expect(r.find('#di-identity').textContent).toBe(first);
+
+		r.click('#di-tick');
+		expect(r.find('#di-tickval').textContent).toBe('2');
+		expect(r.find('#di-identity').textContent).toBe(first);
+		r.unmount();
+	});
+
+	it('rebuilds the derived array when its input changes', () => {
+		const r = mount(DerivedIdentity);
+		const first = r.find('#di-identity').textContent;
+
+		r.click('#di-add');
+		const second = r.find('#di-identity').textContent;
+		expect(second).not.toBe(first);
+		expect(r.find('#di-count').textContent).toBe('2');
+
+		// …and holds the new identity across the next unrelated render.
+		r.click('#di-tick');
+		expect(r.find('#di-identity').textContent).toBe(second);
+		expect(r.find('#di-count').textContent).toBe('2');
+		r.unmount();
+	});
+});
+
+describe('auto-calculation — cached values stay correct', () => {
+	it('recomputes a reduction and an imported projection when rows change', () => {
+		const r = mount(DerivedValue);
+		expect(r.find('#dv-total').textContent).toBe('3');
+		expect(r.find('#dv-labels').textContent).toBe('r1:1,r2:2');
+
+		// Unrelated re-render: values unchanged.
+		r.click('#dv-tick');
+		expect(r.find('#dv-tickval').textContent).toBe('1');
+		expect(r.find('#dv-total').textContent).toBe('3');
+		expect(r.find('#dv-labels').textContent).toBe('r1:1,r2:2');
+
+		// Real input change reaches both derived values, repeatedly.
+		r.click('#dv-bump');
+		expect(r.find('#dv-total').textContent).toBe('13');
+		expect(r.find('#dv-labels').textContent).toBe('r1:11,r2:2');
+		r.click('#dv-bump');
+		expect(r.find('#dv-total').textContent).toBe('23');
+		expect(r.find('#dv-labels').textContent).toBe('r1:21,r2:2');
+		r.unmount();
+	});
+});
+
+describe('auto-calculation — hook calls are never cached', () => {
+	// A cache around a hook call freezes its state cell and any subscription it
+	// owns — a far worse failure than a stale value. Both declarations below are
+	// syntactically indistinguishable from an ordinary creation; only the naming
+	// convention marks them as hooks.
+	it('keeps a custom hook declaration live', () => {
+		const r = mount(HookCallDeclarations);
+		expect(r.find('#hc-count').textContent).toBe('0');
+
+		r.click('#hc-bump');
+		expect(r.find('#hc-count').textContent).toBe('1');
+
+		// An unrelated re-render must not resurrect a stale cell either.
+		r.click('#hc-tick');
+		expect(r.find('#hc-count').textContent).toBe('1');
+		r.click('#hc-bump');
+		expect(r.find('#hc-count').textContent).toBe('2');
+		r.unmount();
+	});
+
+	it('keeps an `unstable_`-prefixed hook declaration live', () => {
+		// React's staging prefix, mirrored by bindings — @octanejs/remix-router
+		// ships `unstable_useRouterState`, and caching it froze the router's
+		// pending navigation state at "(idle)".
+		const r = mount(HookCallDeclarations);
+		expect(r.find('#hc-label-value').textContent).toBe('a');
+
+		r.click('#hc-label');
+		expect(r.find('#hc-label-value').textContent).toBe('b');
+
+		r.click('#hc-tick');
+		expect(r.find('#hc-label-value').textContent).toBe('b');
+		r.unmount();
+	});
+});
+
+describe('auto-calculation — shapes that must keep recomputing', () => {
+	it('leaves a reassigned local alone', () => {
+		// Caching a `let`'s initializer would drop the reassignment below it.
+		const r = mount(ReassignedLocal);
+		expect(r.find('#rl-label').textContent).toBe('[base]');
+
+		r.click('#rl-tick');
+		expect(r.find('#rl-label').textContent).toBe('[changed]');
+		r.unmount();
+	});
+
+	it('keeps a handler-only calculation correct as its inputs grow', () => {
+		const r = mount(HandlerOnlyCalculation);
+		r.click('#ho-read');
+		expect(r.find('#ho-seen').textContent).toBe('r1:1');
+
+		r.click('#ho-bump');
+		r.click('#ho-read');
+		expect(r.find('#ho-seen').textContent).toBe('r1:1|r2:2');
+		r.unmount();
+	});
+});


### PR DESCRIPTION
Follow-on to #262. That change let autoMemo *see through* a call in a template; this one makes the values those regions key on actually stable.

> **Updated after CI + review.** The first revision of this PR credited the change with chat-stream and TodoMVC wins. Both compile **byte-identically** with and without the pass, so those numbers were run-to-run variance, not results — corrected below. It also broke a virtualized list in `examples/pulseboard`, which forced the callee rule to be aligned with #262's. Details in the reviewer notes.

## The problem

A region cache is only as good as the stability of what it keys on. memo-wall's value-position wall rebuilt 1,000 descriptors through `buildValueRows(items)` on every parent re-render — that call alone was **35% of the operation's CPU profile** — so the region keyed on `rows` could never hit.

## The change

A `const` whose initializer performs a call during render is lowered to `useMemo(() => <init>, [deps])` over the component locals it reads, and the existing authored inline-hook-memo tier lowers that to a numeric `_k$N` flat cache. Nothing new was built: it reuses `isPropCreationExpr` for eligibility, Pass A′'s taint/shadowing and dependency-coarsening rules, and Tier A's cell layout. Dev and server keep the runtime hook form.

Placement is deliberate: **after Pass A′** so `use()`-fed chains keep their Symbol-slot/warm treatment; **before Pass A/B** so the minted `useMemo` is lowered by the authored tier rather than re-wrapped; **client only**, since a server render evaluates each body once.

**A calculation is admitted on exactly the callee rule that governs regions**, so the two agree. A member call is not cached even when its result is named. Also never cached: hook calls (including React's `unstable_use*` prefix), `let` declarations (the escape hatch), and calculations the render tree never reads.

## Measurements

Paired runs, one machine, baseline recorded before any edit. **memo-wall is the only suite that gains anything** — it is the sole fixture here whose codegen changes:

| suite | op | base | cand | Δ |
| --- | --- | --- | --- | --- |
| memo-wall | `parent_rerender_equal_B` | 0.226ms | **0.091ms** | −60% |
| memo-wall | `one_change_B` | 0.235ms | **0.156ms** | −34% |
| memo-wall | `ctx_through_wall_B` | 0.569ms | **0.413ms** | −27% |

That is the `createElement`-descriptors-through-a-children-hole shape every `@octanejs/*` binding produces.

`todomvc`, `chat-stream` and `js-framework` compile **byte-identically** with and without this change — I diffed the output to confirm — so they are reported as controls only. Their run-to-run movement, up to **±100% on sub-millisecond operations**, is this machine's noise floor. Treat any small number in this area with suspicion; that is exactly how the first revision's claims went wrong.

Size: **+0.07% gzip** on the `codegen-size` corpus (was +0.25% before the rule narrowed).

## Reviewer notes

**CI caught a real bug: a virtualized list froze mid-scroll.** `examples/pulseboard` does `const virtualItems = virtualizer.getVirtualItems()`. The virtualizer's identity is stable while its window moves with scroll, so caching on `[virtualizer]` froze it — `header.column.getIsSorted()` in another costume. Aligning the calculation rule with #262's fixed it (7/7 pulseboard e2e pass locally; CI had 1 failing) and removed the asymmetry the first revision documented. There is now one contract for both paths.

**What that costs.** `const visible = todos.filter(...)` is no longer cached. `todos` genuinely *is* an immutable snapshot, but the analysis cannot yet distinguish that from a live receiver, so it fails closed on both — which is why TodoMVC, the case that originally motivated this work, now gains nothing. Recovering it needs receiver provenance (does the root trace to a state binding?) and deserves its own change with its own evidence.

**Bugbot (medium), render-read scan over-nominated names** — fixed. It treated every unbound identifier in the JSX walk as a render consumer, including non-computed member *properties* (`row.length` nominated a local named `length`) and names read inside nested function bodies (handler-only locals). Both contradicted the documented "values the render tree never reads pay nothing". The walk now stops seeding inside function values and reads only the object side of a non-computed member expression; `use()`-argument seeding is unaffected.

**Residual risk.** Hooks are identified by naming convention — the same signal React and React Compiler use — so a hook named outside that convention would be cached and frozen. Documented.

**Known, pre-existing, not fixed here.** The `codegen-size` gzip ratio guard already breaches on this branch's base (1.07x against a 1.04x ceiling), confirmed both with the pass disabled and against the base commit. Its recorded numbers no longer match the corpus, so it reads as stale; re-recording a CI gate deserves its own change. That guard runs on manual dispatch and a weekly cron, so it does not gate this PR.

## Tests

`packages/octane/tests/auto-calculation.test.ts` — behavioral, run under both vitest projects so the runtime hook form and the inline flat-cache lowering must agree. Covers identity stability across an unrelated re-render, rebuild on a real input change, cached-value correctness, both hook-declaration shapes staying live, `let` keeping its reassignment, a handler-only calculation, and the live-receiver regression.

Validated against deliberately broken implementations:

| broken implementation | result |
| --- | --- |
| re-admit member calls (the pulseboard bug) | live-receiver test fails |
| drop the `unstable_` prefix | hook test fails |
| remove hook detection entirely | 2 fail |
| disable the pass | identity tests fail, both projects |
| restored implementation | all pass |

## Verification

- Full suite on current `main`: **1376 files / 13717 tests pass**
- `examples/pulseboard` e2e: 7/7
- `pnpm format:check`, `tsgo --noEmit -p packages/octane/tsconfig.json`, changeset check — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
