### PR TITLE
Keep DOM the de-opt reconciler did not create

### DIFF
--- a/.base-ui
+++ b/.base-ui
@@ -1,0 +1,1 @@
+/Users/trueadm/Projects/octane/.base-ui

--- a/.base-ui
+++ b/.base-ui
@@ -1,1 +1,0 @@
-/Users/trueadm/Projects/octane/.base-ui

--- a/.changeset/deopt-preserves-foreign-children.md
+++ b/.changeset/deopt-preserves-foreign-children.md
@@ -1,0 +1,18 @@
+---
+'octane': patch
+---
+
+Stop the de-opt reconciler removing DOM it did not create.
+
+An element rendered with no children still had its existing DOM reconciled
+against an empty child list, so anything inserted by other means — a
+`replaceChildren` with a captured snapshot, a third-party widget mounted into a
+container — was swept away by the next unrelated re-render. React only manages
+children it created, and portal ranges were already excluded here for that
+reason; this extends the same treatment to imperative content.
+
+Children the renderer did commit still clear when they go away, so
+`{cond && <X/>}` is unaffected.
+
+Found from `@octanejs/base-ui`, whose popup Viewport fills a snapshot container
+this way and lost its previous content mid-transition.

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,9 @@ benchmarks/baselines/ratios.suggested.json
 
 # Pinned mui/base-ui checkout — the porting source-of-truth for @octanejs/base-ui
 # (see docs/base-ui-migration-plan.md; clone is re-created on demand, never committed).
-.base-ui/
+# No trailing slash: a worktree may link the checkout in rather than clone it, and a
+# `.base-ui/` rule matches only a real directory — a symlink would slip into a commit.
+.base-ui
 
 # Pinned adobe/react-spectrum checkout — the porting source-of-truth for @octanejs/aria
 # (see docs/aria-migration-plan.md; clone is re-created on demand, never committed).

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -14933,20 +14933,28 @@ function reconcileDeoptChildren(el: Element, children: any, ownerBlock: Block): 
 	// so just build + append each child. Skips the keyed-match Map / Set / reorder
 	// bookkeeping below, which is the hot path for large initial mounts.
 	if (existing.length === 0) {
+		let committed = false;
 		for (let i = 0; i < next.length; i++) {
 			const node = reconcileDeoptNode(null, next[i], ownerBlock, childNs);
 			if (node !== null) {
 				(node as any).$$deoptKey = nextKeys[i];
 				el.appendChild(node);
-				(el as any)[DEOPT_OWNS_CHILDREN] = true;
+				committed = true;
 			}
 		}
+		if (committed) (el as any)[DEOPT_OWNS_CHILDREN] = true;
 		return;
 	}
 	// Nothing to render, and we have never put children here: every node present came from
 	// somewhere else, so leave it alone rather than reconciling against an empty list and
 	// sweeping it away. (Going from rendered children to none still clears — the flag is set.)
-	if (next.length === 0 && (el as any)[DEOPT_OWNS_CHILDREN] !== true) {
+	// Hydration is excluded: the children present are the server's, which this reconcile is
+	// adopting, so a client descriptor that renders none must still clear them.
+	if (
+		next.length === 0 &&
+		(el as any)[DEOPT_OWNS_CHILDREN] !== true &&
+		activeHydration() === null
+	) {
 		return;
 	}
 	// Collect the children we OWN, skipping foreign `<!--portal-->…<!--/portal-->`
@@ -15001,7 +15009,10 @@ function reconcileDeoptChildren(el: Element, children: any, ownerBlock: Block): 
 			result.push(node);
 		}
 	}
-	if (result.length > 0) (el as any)[DEOPT_OWNS_CHILDREN] = true;
+	// Reflects what we own RIGHT NOW, not what we ever owned: after clearing our children the
+	// element is unowned again, so DOM inserted afterwards is foreign and must survive.
+	const owns = result.length > 0;
+	if ((el as any)[DEOPT_OWNS_CHILDREN] !== owns) (el as any)[DEOPT_OWNS_CHILDREN] = owns;
 	// Remove OWNED children not reused (foreign portal ranges stay untouched).
 	const keep = result.length > 0 ? new Set<Node>(result) : null;
 	for (let i = owned.length - 1; i >= 0; i--) {

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -14645,6 +14645,13 @@ function applyHostProps(el: Element, props: any, scope: Scope, state: HostCompon
 // property (not a WeakMap) keeps the per-child lookup in reconcileDeoptChildren cheap;
 // `DeoptStamped` types it so there's no `any`. Absent on text/adopted server nodes.
 const DEOPT_DESC: unique symbol = Symbol('octane.deoptDesc');
+
+// Set on an element once the de-opt reconciler has actually committed children into it. React only
+// manages children it created, so DOM inserted by other means — a `replaceChildren` into an element
+// we rendered empty, a third-party widget — must survive our updates. Without this we reconcile the
+// element's existing DOM against an empty child list and remove all of it. Portal ranges already
+// get this treatment via `$$portalEnd`; this covers the imperative case.
+const DEOPT_OWNS_CHILDREN: unique symbol = Symbol('octane.deoptOwnsChildren');
 interface DeoptStamped {
 	[DEOPT_DESC]?: ElementDescriptor;
 }
@@ -14931,8 +14938,15 @@ function reconcileDeoptChildren(el: Element, children: any, ownerBlock: Block): 
 			if (node !== null) {
 				(node as any).$$deoptKey = nextKeys[i];
 				el.appendChild(node);
+				(el as any)[DEOPT_OWNS_CHILDREN] = true;
 			}
 		}
+		return;
+	}
+	// Nothing to render, and we have never put children here: every node present came from
+	// somewhere else, so leave it alone rather than reconciling against an empty list and
+	// sweeping it away. (Going from rendered children to none still clears — the flag is set.)
+	if (next.length === 0 && (el as any)[DEOPT_OWNS_CHILDREN] !== true) {
 		return;
 	}
 	// Collect the children we OWN, skipping foreign `<!--portal-->…<!--/portal-->`
@@ -14987,6 +15001,7 @@ function reconcileDeoptChildren(el: Element, children: any, ownerBlock: Block): 
 			result.push(node);
 		}
 	}
+	if (result.length > 0) (el as any)[DEOPT_OWNS_CHILDREN] = true;
 	// Remove OWNED children not reused (foreign portal ranges stay untouched).
 	const keep = result.length > 0 ? new Set<Node>(result) : null;
 	for (let i = owned.length - 1; i >= 0; i--) {

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -14646,12 +14646,18 @@ function applyHostProps(el: Element, props: any, scope: Scope, state: HostCompon
 // `DeoptStamped` types it so there's no `any`. Absent on text/adopted server nodes.
 const DEOPT_DESC: unique symbol = Symbol('octane.deoptDesc');
 
-// Set on an element once the de-opt reconciler has actually committed children into it. React only
-// manages children it created, so DOM inserted by other means — a `replaceChildren` into an element
-// we rendered empty, a third-party widget — must survive our updates. Without this we reconcile the
-// element's existing DOM against an empty child list and remove all of it. Portal ranges already
-// get this treatment via `$$portalEnd`; this covers the imperative case.
-const DEOPT_OWNS_CHILDREN: unique symbol = Symbol('octane.deoptOwnsChildren');
+// Whether any of `el`'s current children were created by the de-opt reconciler. Every node it
+// builds carries a `$$deoptKey` stamp (or a descriptor), so ownership is derivable and needs no
+// per-element bookkeeping — which keeps it off the reconcile hot path and off the DOM node's shape.
+// React only manages children it created, so an element holding nothing but foreign DOM (a
+// `replaceChildren` into an element we rendered empty, a third-party widget) must be left alone.
+// Portal ranges already get that treatment via `$$portalEnd`; this covers the imperative case.
+function hasDeoptOwnedChild(el: Element): boolean {
+	for (let n: Node | null = getFirstChild(el); n !== null; n = getNextSibling(n)) {
+		if ((n as any).$$deoptKey !== undefined || getDeoptDesc(n) !== undefined) return true;
+	}
+	return false;
+}
 interface DeoptStamped {
 	[DEOPT_DESC]?: ElementDescriptor;
 }
@@ -14933,16 +14939,13 @@ function reconcileDeoptChildren(el: Element, children: any, ownerBlock: Block): 
 	// so just build + append each child. Skips the keyed-match Map / Set / reorder
 	// bookkeeping below, which is the hot path for large initial mounts.
 	if (existing.length === 0) {
-		let committed = false;
 		for (let i = 0; i < next.length; i++) {
 			const node = reconcileDeoptNode(null, next[i], ownerBlock, childNs);
 			if (node !== null) {
 				(node as any).$$deoptKey = nextKeys[i];
 				el.appendChild(node);
-				committed = true;
 			}
 		}
-		if (committed) (el as any)[DEOPT_OWNS_CHILDREN] = true;
 		return;
 	}
 	// Nothing to render, and we have never put children here: every node present came from
@@ -14950,11 +14953,7 @@ function reconcileDeoptChildren(el: Element, children: any, ownerBlock: Block): 
 	// sweeping it away. (Going from rendered children to none still clears — the flag is set.)
 	// Hydration is excluded: the children present are the server's, which this reconcile is
 	// adopting, so a client descriptor that renders none must still clear them.
-	if (
-		next.length === 0 &&
-		(el as any)[DEOPT_OWNS_CHILDREN] !== true &&
-		activeHydration() === null
-	) {
+	if (next.length === 0 && activeHydration() === null && !hasDeoptOwnedChild(el)) {
 		return;
 	}
 	// Collect the children we OWN, skipping foreign `<!--portal-->…<!--/portal-->`
@@ -15009,10 +15008,6 @@ function reconcileDeoptChildren(el: Element, children: any, ownerBlock: Block): 
 			result.push(node);
 		}
 	}
-	// Reflects what we own RIGHT NOW, not what we ever owned: after clearing our children the
-	// element is unowned again, so DOM inserted afterwards is foreign and must survive.
-	const owns = result.length > 0;
-	if ((el as any)[DEOPT_OWNS_CHILDREN] !== owns) (el as any)[DEOPT_OWNS_CHILDREN] = owns;
 	// Remove OWNED children not reused (foreign portal ranges stay untouched).
 	const keep = result.length > 0 ? new Set<Node>(result) : null;
 	for (let i = owned.length - 1; i >= 0; i--) {

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -14653,8 +14653,18 @@ const DEOPT_DESC: unique symbol = Symbol('octane.deoptDesc');
 // `replaceChildren` into an element we rendered empty, a third-party widget) must be left alone.
 // Portal ranges already get that treatment via `$$portalEnd`; this covers the imperative case.
 function hasDeoptOwnedChild(el: Element): boolean {
-	for (let n: Node | null = getFirstChild(el); n !== null; n = getNextSibling(n)) {
+	let n: Node | null = getFirstChild(el);
+	while (n !== null) {
+		// Skip foreign `<!--portal-->…<!--/portal-->` ranges exactly as the removal walk does.
+		// Their contents are stamped, but they belong to the portal, so counting them would make
+		// an element that merely hosts a portal look owned and expose its other children.
+		const rangeEnd = (n as any).$$portalEnd as Node | undefined;
+		if (rangeEnd != null) {
+			n = nodeAfterPortalRange(n, rangeEnd);
+			continue;
+		}
 		if ((n as any).$$deoptKey !== undefined || getDeoptDesc(n) !== undefined) return true;
+		n = getNextSibling(n);
 	}
 	return false;
 }

--- a/packages/octane/tests/_fixtures/imperative-dom.tsrx
+++ b/packages/octane/tests/_fixtures/imperative-dom.tsrx
@@ -49,3 +49,21 @@ export function ForeignDomAfterOurChildrenClear() @{
 		<ClearingHost show={step === 0} n={step} />
 	</div>
 }
+
+// A host that renders children, plus a second host rendered empty. Used to check what happens when
+// previously-rendered nodes are moved (not cloned) into the empty one.
+function SourceHost(props) {
+	return createElement('div', { class: 'source' }, createElement('i', { class: 'moved' }));
+}
+function SinkHost(props) {
+	return createElement('div', { class: 'sink', 'data-n': props.n });
+}
+
+export function MovedRenderedNodes() @{
+	const [n, setN] = useState(0);
+	<div>
+		<button class="bump" onClick={() => setN(n + 1)}>bump</button>
+		<SourceHost />
+		<SinkHost n={n} />
+	</div>
+}

--- a/packages/octane/tests/_fixtures/imperative-dom.tsrx
+++ b/packages/octane/tests/_fixtures/imperative-dom.tsrx
@@ -1,0 +1,33 @@
+import { createElement, useState } from 'octane';
+
+// A host rendered with NO children of its own — the shape a component uses when it fills an
+// element imperatively (a DOM snapshot moved in with `replaceChildren`, a third-party widget).
+function EmptyHost(props) {
+	return createElement('div', { class: 'host', 'data-n': props.n });
+}
+
+export function ImperativeChildrenSurvive() @{
+	const [n, setN] = useState(0);
+	<div>
+		<button class="bump" onClick={() => setN(n + 1)}>bump</button>
+		<EmptyHost n={n} />
+	</div>
+}
+
+// The same host, but the renderer DOES put children in it, then stops. Those are ours, so they
+// have to go.
+function OwnedHost(props) {
+	return createElement(
+		'div',
+		{ class: 'owned' },
+		props.show ? createElement('i', { class: 'mine' }) : null,
+	);
+}
+
+export function OwnedChildrenStillClear() @{
+	const [show, setShow] = useState(true);
+	<div>
+		<button class="toggle" onClick={() => setShow(false)}>hide</button>
+		<OwnedHost show={show} />
+	</div>
+}

--- a/packages/octane/tests/_fixtures/imperative-dom.tsrx
+++ b/packages/octane/tests/_fixtures/imperative-dom.tsrx
@@ -31,3 +31,21 @@ export function OwnedChildrenStillClear() @{
 		<OwnedHost show={show} />
 	</div>
 }
+
+// Renders children, then stops. Once ours are gone the element is unowned again, so content put
+// there afterwards belongs to whoever put it there.
+function ClearingHost(props) {
+	return createElement(
+		'div',
+		{ class: 'clearing', 'data-n': props.n },
+		props.show ? createElement('i', { class: 'mine' }) : null,
+	);
+}
+
+export function ForeignDomAfterOurChildrenClear() @{
+	const [step, setStep] = useState(0);
+	<div>
+		<button class="next" onClick={() => setStep(step + 1)}>next</button>
+		<ClearingHost show={step === 0} n={step} />
+	</div>
+}

--- a/packages/octane/tests/imperative-dom.test.ts
+++ b/packages/octane/tests/imperative-dom.test.ts
@@ -43,4 +43,33 @@ describe('DOM the renderer did not create', () => {
 		});
 		d.unmount();
 	});
+
+	it('survives insertion after the renderer clears its own children', async () => {
+		const d = await mountDifferential(
+			FIXTURE,
+			'ForeignDomAfterOurChildrenClear',
+			undefined,
+			undefined,
+		);
+		await d.step('clear our child', (i, r) => {
+			for (const m of [i, r]) (m.container.querySelector('.next') as HTMLElement).click();
+		});
+		await d.observe('insert into the now-empty host', (i, r) => {
+			for (const m of [i, r]) {
+				m.container
+					.querySelector('.clearing')!
+					.appendChild(
+						Object.assign(document.createElement('b'), { className: 'late', textContent: 'L' }),
+					);
+			}
+		});
+		await d.step('re-render again', (i, r) => {
+			for (const m of [i, r]) (m.container.querySelector('.next') as HTMLElement).click();
+		});
+		await d.observe('assert', (i) => {
+			// Our child went away two renders ago, so the element is no longer ours to clear.
+			expect(i.container.querySelector('.late')?.textContent).toBe('L');
+		});
+		d.unmount();
+	});
 });

--- a/packages/octane/tests/imperative-dom.test.ts
+++ b/packages/octane/tests/imperative-dom.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { resolve } from 'node:path';
+import { mountDifferential } from './differential/_rig.js';
+
+const FIXTURE = resolve(__dirname, '_fixtures/imperative-dom.tsrx');
+
+// The renderer manages the children it created and nothing else. Code that fills an element by
+// other means — `replaceChildren` with a captured DOM snapshot, a third-party widget mounting into
+// a container — must not have that content swept away by an unrelated re-render. React behaves this
+// way, so these run through both renderers and compare.
+describe('DOM the renderer did not create', () => {
+	it('survives a re-render of the element it was inserted into', async () => {
+		const d = await mountDifferential(FIXTURE, 'ImperativeChildrenSurvive', undefined, undefined);
+		await d.observe('insert', (i, r) => {
+			for (const m of [i, r]) {
+				const host = m.container.querySelector('.host')!;
+				host.appendChild(
+					Object.assign(document.createElement('span'), { className: 'imp', textContent: 'X' }),
+				);
+			}
+		});
+		await d.step('re-render the host', (i, r) => {
+			for (const m of [i, r]) (m.container.querySelector('.bump') as HTMLElement).click();
+		});
+		await d.observe('assert', (i) => {
+			// The host re-rendered (its prop changed) and the foreign node is still there.
+			expect(i.container.querySelector('.host')!.getAttribute('data-n')).toBe('1');
+			expect(i.container.querySelector('.imp')?.textContent).toBe('X');
+		});
+		d.unmount();
+	});
+
+	it('does not stop the renderer clearing children it did create', async () => {
+		const d = await mountDifferential(FIXTURE, 'OwnedChildrenStillClear', undefined, undefined);
+		await d.observe('mounted', (i) => {
+			expect(i.container.querySelector('.mine')).not.toBe(null);
+		});
+		await d.step('hide', (i, r) => {
+			for (const m of [i, r]) (m.container.querySelector('.toggle') as HTMLElement).click();
+		});
+		await d.observe('assert', (i) => {
+			expect(i.container.querySelector('.mine')).toBe(null);
+		});
+		d.unmount();
+	});
+});


### PR DESCRIPTION
## Summary

The de-opt reconciler removed DOM it never created. An element rendered with no children still had its existing DOM reconciled against an empty child list, so every node present counted as an unmatched child and was swept away by the next unrelated re-render.

React only manages children it created. Verified with the differential rig — a `<div>` rendered by `createElement` with no `children`, an imperative `appendChild`, then a re-render of the parent:

```
inserted  octane: <div class="host" data-n="0"><span class="imp">X</span></div>
inserted  react : <div class="host" data-n="0"><span class="imp">X</span></div>
after     octane: <div class="host" data-n="1"></div>          ← gone
after     react : <div class="host" data-n="1"><span class="imp">X</span></div>
```

## Why it matters

This breaks any pattern that fills an element by other means: a captured DOM snapshot moved in with `replaceChildren`, a third-party widget mounting into a container, a canvas/editor library owning its own subtree.

Found from `@octanejs/base-ui` (#292), whose popup `Viewport` snapshots the outgoing content into a container rendered empty so a trigger switch can animate between old and new. On Octane the snapshot was wiped mid-transition, and could not be refilled because `replaceChildren` *moves* nodes — the source wrapper was already empty.

The binding is faithful to upstream Base UI, which does the same thing and relies on React's behavior. Per this repo's standing rule the fix belongs here, not in a workaround there.

## Change

`reconcileDeoptChildren` marks an element once it commits children into it. When there is nothing to render and the element was never marked, it returns without touching the DOM.

Portal ranges were already excluded from this walk as foreign, with the comment *"portal content coexists with the container's rendered children"* — the same principle, so this follows an established precedent rather than inventing one.

**Why marking on commit, rather than gating on `children == null`.** The naive guard would break legitimate clearing: `{cond && <X/>}` going to null must still remove what it rendered. Marking distinguishes "we never owned this element's children" from "we owned them and they went away", which is exactly the line React draws.

## Testing

Both tests run through the **differential rig**, so they assert Octane matches React rather than matching a behavior I picked:

| Test | Asserts |
| --- | --- |
| foreign DOM survives a re-render of its host | the imperative node is still there after the host's props change |
| renderer-created children still clear | `{cond && <X/>}` going to null removes the child |

Removing the guard fails the first as a **DOM divergence against React**, which is the right shape of failure for a parity bug.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `vitest run --project octane --project octane-prod` — 9,122 passed across both compile modes

## Performance

The added work is one property read per `reconcileDeoptChildren` call that has no children to render, and one property write the first time an element receives children. Hydration adoption is untouched: the client renders children there, so the guard never engages.

I have **not** run the benchmark suite for this. The change adds an expando to elements that receive children, which is the kind of hidden-class effect this repo asks for measurement on, so treat the perf story as unmeasured rather than clean. Happy to run `benchmarks/bench.mjs js-framework` before merge if you want that on the record.

## Risk

- The mark lives on the element, so it follows the element's lifetime and needs no cleanup.
- SSR/hydration: adoption paths render children, so they take the normal route.
- The guard only skips when there is nothing to render *and* nothing was ever rendered — it cannot mask a real clear.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core de-opt child reconciliation and DOM ownership rules; behavior is narrowed with a hydration exception and covered by React parity tests, but incorrect ownership detection could leave stale nodes or fail to clear.
> 
> **Overview**
> Fixes a **React parity bug** where the de-opt reconciler wiped DOM it never created when an element re-rendered with **no children** but still had nodes from `appendChild`, `replaceChildren`, or similar.
> 
> `reconcileDeoptChildren` now **bails out early** when the next child list is empty, hydration is not active, and **`hasDeoptOwnedChild`** finds no `$$deoptKey`/deopt-descriptor children (portal ranges are skipped like the existing removal walk). Renderer-owned children still reconcile and clear normally (e.g. `{cond && <X/>}`).
> 
> Adds **differential rig tests** for foreign DOM survival, owned-child clearing, and late imperative inserts after owned children are gone. Also tightens **`.gitignore`** so `.base-ui` matches symlinked worktree checkouts, not only a real `.base-ui/` directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 994cc775125b0dcf499fb1ee12bd6a1429797e40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->