### PR TITLE
fix(runtime): don't report a deleted subtree's cleanup as a render-phase update

### DIFF
--- a/.changeset/deletion-cleanup-cross-render-warning.md
+++ b/.changeset/deletion-cleanup-cross-render-warning.md
@@ -1,0 +1,22 @@
+---
+'octane': patch
+---
+
+Stop reporting a deleted subtree's cleanup as a render-phase cross-component update.
+
+Octane discovers a deletion while reconciling the deleting parent's output, so
+`CURRENT_BLOCK` still names that parent while the removed subtree's destroys and
+cleanups run. A cleanup that calls `setState` on a surviving component was
+therefore treated as a render-phase update: it logged `Cannot update a component
+(X) while rendering a different component (Y)` and flagged the target for the
+render-phase branch of the update-depth error.
+
+Those callbacks are mutation-phase work (React runs them in
+`commitDeletionEffects`), and updating another component from them is the normal
+registry pattern, so they no longer take that branch. `@octanejs/radix`'s Select
+hit this on every open and close: `SelectItemText`'s layout cleanup calls
+`onNativeOptionRemove` on the Select provider as the content swaps between its
+detached fragment and the open popper.
+
+Genuine render-body updates are unaffected: those run with no cleanup on the
+stack and still warn and still terminate the loop.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -1839,8 +1839,17 @@ function scheduleRender(block: Block): void {
 	// transition priority (and useDeferredValue in the replay doesn't defer) —
 	// per ReactDeferredValue-test.js:232.
 	const renderPhaseSelf = CURRENT_BLOCK === block;
+	// A deletion is discovered while reconciling the deleting parent's output, so
+	// CURRENT_BLOCK still names that parent while the removed subtree's destroys and
+	// cleanups run (the same reason Effect Events are permitted from them). Those
+	// are mutation-phase callbacks — React runs them in commitDeletionEffects — so
+	// an update they schedule for a surviving component is legal, not a render-phase
+	// cross-component update.
 	const renderPhaseOther =
-		CURRENT_BLOCK !== null && !renderPhaseSelf && TRANSITION_LISTENER_PUBLISH_DEPTH === 0;
+		CURRENT_BLOCK !== null &&
+		!renderPhaseSelf &&
+		TRANSITION_LISTENER_PUBLISH_DEPTH === 0 &&
+		EFFECT_EVENT_LIFECYCLE_DEPTH === 0;
 	if (renderPhaseOther) {
 		block.crossRenderUpdate = true;
 		warnCrossComponentRenderUpdate(block, CURRENT_BLOCK!);

--- a/packages/octane/tests/conformance/_fixtures/update-reconciliation.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/update-reconciliation.tsrx
@@ -27,6 +27,7 @@ let _setFunctionSwitchMode: any = null;
 let _bumpFunctionSwitch: any = null;
 let _setFunctionSwitchContext: any = null;
 let _bumpExternalUnmountTarget: any = null;
+let _setDeletionRegistrySwitch: any = null;
 
 export function setFirst(value: any) {
 	_setFirst(value);
@@ -54,6 +55,9 @@ export function setDeleteChild(value: any) {
 }
 export function setDeleteStoreParent(value: boolean) {
 	_setDeleteStoreParent!(value);
+}
+export function setDeletionRegistrySwitch(value: boolean) {
+	_setDeletionRegistrySwitch(value);
 }
 export function setMemoChild(value: any) {
 	_setMemoChild(value);
@@ -447,6 +451,38 @@ export function NestedEffectUpdates(props) @{
 		if (step < props.limit) setStep((value: number) => value + 1);
 	}, null);
 	<span id="nested-effect-step">{step as number}</span>
+}
+
+// A registry owner whose members register/unregister from a layout effect, with a
+// plain-return switcher in between: flipping the switch DELETES the mounted member
+// while the switcher's own body is still on the render stack, so the member's layout
+// destroy is discovered mid-render even though it is commit-phase work.
+function DeletionRegistryMember(props) @{
+	useLayoutEffect(() => {
+		props.register();
+		return () => props.unregister();
+	}, []);
+	<span id="deletion-registry-member">{'member'}</span>
+}
+
+function DeletionRegistrySwitcher(props) {
+	return props.showMember
+		? <DeletionRegistryMember register={props.register} unregister={props.unregister} />
+		: null;
+}
+
+export function DeletionCleanupRegistry() @{
+	const [showMember, setShowMember] = useState(true);
+	const [registered, setRegistered] = useState(0);
+	_setDeletionRegistrySwitch = setShowMember;
+	<div>
+		<DeletionRegistrySwitcher
+			showMember={showMember}
+			register={() => setRegistered((count: number) => count + 1)}
+			unregister={() => setRegistered((count: number) => count - 1)}
+		/>
+		<span id="deletion-registry-count">{registered as number}</span>
+	</div>
 }
 
 export function ExternalUnmountCleanupSource(props) @{

--- a/packages/octane/tests/conformance/update-reconciliation.test.ts
+++ b/packages/octane/tests/conformance/update-reconciliation.test.ts
@@ -525,6 +525,33 @@ describe('ReactUpdates update reconciliation', () => {
 		removeRoot(root, container);
 	});
 
+	// A deletion's layout destroy is commit-phase work (React's
+	// commitDeletionEffects), even though Octane discovers the deletion while the
+	// deleting parent's body is still on the render stack. An update it schedules
+	// for a surviving component is legal and must not be reported as a render-phase
+	// cross-component update.
+	it("does not warn when a deleted subtree's cleanup updates a surviving component", async () => {
+		const container = ownedContainer();
+		const root = createRoot(container);
+		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			await act(() => root.render(Fixture.DeletionCleanupRegistry));
+			expect(container.querySelector('#deletion-registry-count')!.textContent).toBe('1');
+
+			await act(() => Fixture.setDeletionRegistrySwitch(false));
+			expect(container.querySelector('#deletion-registry-member')).toBeNull();
+			expect(container.querySelector('#deletion-registry-count')!.textContent).toBe('0');
+			expect(
+				error.mock.calls.filter((call) =>
+					String(call[0]).includes('while rendering a different component'),
+				),
+			).toEqual([]);
+		} finally {
+			error.mockRestore();
+			removeRoot(root, container);
+		}
+	});
+
 	// Per ReactUpdates-test.js:1912. An external root unmount is a fresh update
 	// boundary: its cleanup may advance a different root after that root completed
 	// an exactly-at-the-limit chain without inheriting the old budget.


### PR DESCRIPTION
## Summary

- A deleted subtree's effect cleanup no longer counts as a render-phase cross-component update.

## Why

`@octanejs/radix`'s Select logs this on every open and close:

```
Cannot update a component (`Provider`) while rendering a different component (`Presence`).
```

Nothing in Select is doing that. Octane discovers a deletion while reconciling the deleting
parent's returned output, so `CURRENT_BLOCK` still names that parent (here `Presence`) while
the removed subtree's destroys run. `SelectItemText`'s layout cleanup calls
`onNativeOptionRemove` on the Select provider as the content swaps between its detached
fragment and the open popper, and `scheduleRender` read that as an update issued from
`Presence`'s body.

Those callbacks are mutation-phase work (React runs them in `commitDeletionEffects`), and
updating a surviving component from them is the normal registry pattern. Besides the false
console error, the target was flagged `crossRenderUpdate`, which picks the render-phase
branch of the update-depth error.

## Changes

- `scheduleRender` skips the cross-component render-phase branch while
  `EFFECT_EVENT_LIFECYCLE_DEPTH` is non-zero — the signal the runtime already uses to permit
  Effect Events from deletion destroys. Genuine render-body updates run with no cleanup on
  the stack, so they still warn and still terminate the loop.
- Conformance regression test + fixture: a registry owner, a plain-return switcher, and a
  member that registers/unregisters from a layout effect. Flipping the switch deletes the
  member mid-render; the cleanup's update must land without the warning.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` — full run in progress locally; a first pass had 20 failures concentrated in
      the heavy differential/integration projects where the React side rendered empty
      (`@tsrx/react:` blank). Those files pass in isolation, so it reads as the known
      under-load flakiness, not this change. CI is the gate.
- [x] targeted: `packages/octane/tests/conformance/update-reconciliation.test.ts` (70 tests,
      octane + octane-prod). The new test fails before the fix with exactly the reported
      message. `packages/shadcn/tests/differential/parity.test.ts`,
      `packages/radix/tests/select.test.ts`.
- [x] manual: instrumented the radix `Select` fixture — the warning fires on every open/close
      before the fix and never after.

## Risk / follow-ups

- Narrow diagnostic gap: a runaway loop driven by a scope cleanup that does *not* go through
  `runEffectCleanupCallback` (ref detach, listener teardown) now reports "Too many
  re-renders" instead of "Maximum update depth exceeded". Layout and insertion destroys are
  unaffected — they already ride the nested-update chain. Both still terminate the loop.
- Separate, still open: on a swap (delete + mount in one commit) the deleted subtree's destroy
  update drains in the render pass while the new subtree's layout-setup update lands in the
  next one, so a shared parent renders once more than React does. Measured on a matched
  fixture: React 2 renders per swap, Octane 3. In Select that also exposes an intermediate
  render where `nativeOptions` is momentarily empty. Fixing it means deferring deletion
  teardown into the mutation phase — an architectural change, not this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to dev-only diagnostics in scheduleRender; genuine render-body cross updates still warn. Minor follow-up: some non-effect cleanups may get a different loop error message.
> 
> **Overview**
> **Fixes false “Cannot update a component while rendering a different component” warnings** when a removed subtree’s layout/effect cleanup updates a surviving component (e.g. Radix Select’s registry `unregister` on close).
> 
> `scheduleRender` no longer treats those updates as render-phase cross-component work: the `renderPhaseOther` guard now also requires `EFFECT_EVENT_LIFECYCLE_DEPTH === 0`, reusing the depth already set during deletion destroys (same signal that allows Effect Events from that path). Real updates from a component’s render body are unchanged.
> 
> Adds a conformance fixture (`DeletionCleanupRegistry`) and test that toggles a member off mid-render and asserts the registry count updates with no console warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2a43c9f13ab03b04f33d07a3a917bb02903fdc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->