### PR TITLE
fix(octane): preserve externally streamed DOM in mixed-ownership hosts

### DIFF
--- a/.changeset/preserve-mixed-ownership-streams.md
+++ b/.changeset/preserve-mixed-ownership-streams.md
@@ -1,0 +1,11 @@
+---
+'octane': patch
+---
+
+Preserve independently managed streamed DOM when it is interleaved with
+renderer-owned host children.
+
+The de-optimized host reconciler now adopts unstamped nodes only during
+hydration. Normal client updates retain external stream boundaries, list nodes,
+interactive controls, and their listeners while continuing to update, reorder,
+and remove children created by Octane itself.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -14975,12 +14975,16 @@ function reconcileDeoptChildren(el: Element, children: any, ownerBlock: Block): 
 	if (next.length === 0 && activeHydration() === null && !hasDeoptOwnedChild(el)) {
 		return;
 	}
-	// Collect the children we OWN, skipping foreign `<!--portal-->…<!--/portal-->`
-	// ranges: a portal rendered elsewhere may target this element, and its nodes are
-	// not ours to reuse, remove, or reorder (React parity — portal content coexists
-	// with the container's rendered children). Range starts carry $$portalEnd.
+	// Collect only children this reconciler owns. Portal ranges and unstamped
+	// imperatively streamed nodes may coexist with our children; neither belongs
+	// to the descriptor and neither may be removed or positionally adopted.
+	// Hydration is the sole exception: its unstamped server nodes are ours to
+	// adopt. Check hydration lazily so already-stamped updates pay no extra cost.
 	const owned: Node[] = [];
 	let hasForeign = false;
+	let hydrationOwnsUnstamped: boolean | undefined;
+	let byKey: Map<any, Node> | null = null;
+	const unstamped: Node[] = [];
 	let scan: Node | null = getFirstChild(el);
 	while (scan !== null) {
 		const rangeEnd = (scan as any).$$portalEnd as Node | undefined;
@@ -14989,26 +14993,29 @@ function reconcileDeoptChildren(el: Element, children: any, ownerBlock: Block): 
 			scan = nodeAfterPortalRange(scan, rangeEnd);
 			continue;
 		}
+		const stampedKey = (scan as any).$$deoptKey;
+		const descriptor = stampedKey === undefined ? getDeoptDesc(scan) : undefined;
+		if (
+			stampedKey === undefined &&
+			descriptor === undefined &&
+			!(hydrationOwnsUnstamped ??= activeHydration() !== null)
+		) {
+			hasForeign = true;
+			scan = getNextSibling(scan);
+			continue;
+		}
 		owned.push(scan);
-		scan = getNextSibling(scan);
-	}
-	// Partition current children by their stamped SLOT KEY (position-scoped —
-	// see flattenDeoptChildrenKeyed; explicit keys ride the same scheme). Nodes
-	// without a stamp (server-adopted on the first post-hydration reconcile)
-	// fall back to document-order reuse, and get stamped below for next time.
-	let byKey: Map<any, Node> | null = null;
-	const unstamped: Node[] = [];
-	for (let i = 0; i < owned.length; i++) {
-		const n = owned[i];
-		const k = (n as any).$$deoptKey ?? getDeoptDesc(n)?.key;
-		if (k != null) {
+		const key = stampedKey ?? descriptor?.key;
+		if (key != null) {
 			if (byKey === null) byKey = new Map();
-			if (!byKey.has(k)) {
-				byKey.set(k, n);
+			if (!byKey.has(key)) {
+				byKey.set(key, scan);
+				scan = getNextSibling(scan);
 				continue;
 			}
 		}
-		unstamped.push(n);
+		unstamped.push(scan);
+		scan = getNextSibling(scan);
 	}
 	let up = 0;
 	const result: Node[] = [];
@@ -15041,7 +15048,9 @@ function reconcileDeoptChildren(el: Element, children: any, ownerBlock: Block): 
 	// like a React portal whose container children reorder around it).
 	for (let i = 0; i < result.length; i++) {
 		const want = result[i];
-		const at = hasForeign ? liveOwnedChildAt(el, i) : (existing[i] ?? null);
+		const at = hasForeign
+			? liveOwnedChildAt(el, i, hydrationOwnsUnstamped === true)
+			: (existing[i] ?? null);
 		if (at !== want) el.insertBefore(want, at);
 	}
 }
@@ -15059,13 +15068,21 @@ function nodeAfterPortalRange(start: Node, end: Node): Node | null {
 // The i-th child of `el` that the de-opt reconciler OWNS, skipping foreign
 // `<!--portal-->…<!--/portal-->` ranges (see reconcileDeoptChildren). Live walk —
 // called per reorder step, only when a foreign range exists.
-function liveOwnedChildAt(el: Element, index: number): Node | null {
+function liveOwnedChildAt(el: Element, index: number, adoptHydrationChildren = false): Node | null {
 	let i = 0;
 	let scan: Node | null = getFirstChild(el);
 	while (scan !== null) {
 		const rangeEnd = (scan as any).$$portalEnd as Node | undefined;
 		if (rangeEnd != null) {
 			scan = nodeAfterPortalRange(scan, rangeEnd);
+			continue;
+		}
+		if (
+			!adoptHydrationChildren &&
+			(scan as any).$$deoptKey === undefined &&
+			getDeoptDesc(scan) === undefined
+		) {
+			scan = getNextSibling(scan);
 			continue;
 		}
 		if (i === index) return scan;

--- a/packages/octane/tests/imperative-stream-ownership.test.ts
+++ b/packages/octane/tests/imperative-stream-ownership.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createElement, createRoot, flushSync, hydrateRoot, type Root } from '../src/index.js';
+
+const roots: Root[] = [];
+
+function createMixedElement(version: number, showChildren = true) {
+	return createElement(
+		'div',
+		{ class: 'mixed', 'data-version': String(version) },
+		showChildren ? createElement('h3', { class: 'owned-heading' }, 'Heading ' + version) : null,
+		showChildren
+			? createElement('p', { class: 'owned-description' }, 'Description ' + version)
+			: null,
+	);
+}
+
+function mountMixedHost({ hydrate = false }: { hydrate?: boolean } = {}) {
+	const container = document.createElement('div');
+	document.body.append(container);
+	if (hydrate) {
+		container.innerHTML =
+			'<div class="mixed" data-version="0">' +
+			'<h3 class="owned-heading">Heading 0</h3>' +
+			'<p class="owned-description">Description 0</p>' +
+			'</div>';
+	}
+	const root = hydrate ? hydrateRoot(container, createMixedElement(0)) : createRoot(container);
+	roots.push(root);
+
+	const render = (version: number, showChildren = true) => {
+		flushSync(() => {
+			root.render(createMixedElement(version, showChildren));
+		});
+	};
+
+	if (!hydrate) render(0);
+	const host = container.querySelector('.mixed');
+	if (!(host instanceof HTMLElement)) throw new Error('Expected the mixed host to mount.');
+
+	return { container, host, render };
+}
+
+function insertExternalStream(host: HTMLElement) {
+	const start = document.createProcessingInstruction('start', 'name="external-stream"');
+	const end = document.createProcessingInstruction('end', '');
+	const list = document.createElement('ol');
+	list.className = 'external-stream';
+	const item = document.createElement('li');
+	const source = document.createElement('button');
+	source.className = 'external-source';
+	source.dataset.sourcePayload = 'initial';
+	source.textContent = 'Original source';
+	let clicks = 0;
+	source.addEventListener('click', () => {
+		clicks++;
+	});
+	item.append(source);
+	list.append(item);
+	const description = host.querySelector('.owned-description');
+	if (!(description instanceof HTMLElement)) throw new Error('Expected the owned description.');
+	description.before(start, list, end);
+
+	return { clicks: () => clicks, end, list, source, start };
+}
+
+afterEach(() => {
+	for (const root of roots.splice(0)) root.unmount();
+	document.body.replaceChildren();
+});
+
+describe('independently streamed children inside a renderer-managed host', () => {
+	it('preserves streamed node identity, boundaries, and source interactions on sibling updates', () => {
+		const { host, render } = mountMixedHost();
+		const stream = insertExternalStream(host);
+
+		render(1);
+
+		expect(host.querySelector('.owned-heading')?.textContent).toBe('Heading 1');
+		expect(host.querySelector('.owned-description')?.textContent).toBe('Description 1');
+		expect(host.querySelector('.external-stream')).toBe(stream.list);
+		expect(host.querySelector('.external-source')).toBe(stream.source);
+		expect(stream.start.isConnected).toBe(true);
+		expect(stream.end.isConnected).toBe(true);
+
+		stream.source.dataset.sourcePayload = 'updated';
+		stream.source.click();
+		expect(stream.source.dataset.sourcePayload).toBe('updated');
+		expect(stream.clicks()).toBe(1);
+	});
+
+	it('removes renderer-owned children without removing an independent stream', () => {
+		const { host, render } = mountMixedHost();
+		const stream = insertExternalStream(host);
+
+		render(1, false);
+
+		expect(host.querySelector('.owned-heading')).toBeNull();
+		expect(host.querySelector('.owned-description')).toBeNull();
+		expect(host.querySelector('.external-stream')).toBe(stream.list);
+		expect(host.querySelector('.external-source')).toBe(stream.source);
+		expect(stream.start.isConnected).toBe(true);
+		expect(stream.end.isConnected).toBe(true);
+		stream.source.click();
+		expect(stream.clicks()).toBe(1);
+	});
+
+	it('adopts server-rendered children before preserving subsequently streamed nodes', () => {
+		const { host, render } = mountMixedHost({ hydrate: true });
+		const heading = host.querySelector('.owned-heading');
+		const stream = insertExternalStream(host);
+
+		render(1);
+
+		expect(host.querySelector('.owned-heading')).toBe(heading);
+		expect(heading?.textContent).toBe('Heading 1');
+		expect(host.querySelector('.owned-description')?.textContent).toBe('Description 1');
+		expect(host.querySelector('.external-stream')).toBe(stream.list);
+		expect(host.querySelector('.external-source')).toBe(stream.source);
+		expect(stream.start.isConnected).toBe(true);
+		expect(stream.end.isConnected).toBe(true);
+		stream.source.click();
+		expect(stream.clicks()).toBe(1);
+	});
+});

--- a/packages/rspack-plugin-octane/tests/rspack.test.ts
+++ b/packages/rspack-plugin-octane/tests/rspack.test.ts
@@ -7,6 +7,7 @@ import {
 	symlinkSync,
 	writeFileSync,
 } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -181,12 +182,12 @@ export function App() @{
 		);
 	});
 
-	afterEach(() => {
+	afterEach(async () => {
 		Reflect.deleteProperty(globalThis, profilerGlobal);
 		Reflect.deleteProperty(globalThis, runGlobal);
 		Reflect.deleteProperty(globalThis, productionErrorGlobal);
 		Reflect.deleteProperty(globalThis, transpileGlobal);
-		rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+		await rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
 	});
 
 	function installRealProfileFixture(includeRawBinding: boolean) {


### PR DESCRIPTION
## Summary

- Preserve externally managed streamed DOM when it is interleaved with children created by Octane's de-optimized host reconciler.
- Keep original streamed elements, processing-instruction boundaries, button identity, payloads, and event listeners connected across ordinary sibling updates.
- Continue to remove Octane-owned children correctly, and preserve normal server-rendered hydration.
- Include a patch changeset for the `octane` package.

## Why

The existing foreign-DOM safeguard correctly handles a host containing only externally inserted children. However, once the same host also contains an Octane-created child, the reconciliation scan considers every non-portal sibling owned. As a result, a normal update removes externally streamed nodes and their boundaries, disconnecting already interactive controls even though the newly rendered sibling is otherwise correct.

## Changes

- Classify existing host children using their established de-optimized ownership stamp or descriptor.
- Adopt unstamped nodes only while hydration is active; otherwise retain them as independently managed siblings.
- Keep foreign-node detection and hydration checks on the existing cold paths and combine ownership classification with keyed partitioning.
- Add three public-API behavioral regressions for sibling updates, removal of owned children, and hydration.

## Validation

- Confirmed both non-hydration regressions fail on the latest upstream `main` before the fix.
- Confirmed all three focused runtime regressions pass in development mode.
- Confirmed all three focused runtime regressions pass with `NODE_ENV=production`.
- Confirmed an existing server-rendered heading is adopted, remains the same DOM node, and updates after hydration.
- Confirmed externally inserted source buttons retain their identity and original event listener.
- Checked the changed source and regression test with the repository's formatting settings.
- Ran the patch-track changeset validation.
- The complete workspace test, type-check, and repository-wide formatting gates are left to upstream CI because the local package registry cannot install the latest upstream lockfile under its package-age policy.

## Risk / follow-ups

This change concerns the generic framework ownership contract. Integrations that separately replace whole server-streamed documents may still need their own independent fix; this PR does not claim to repair an application's document transport.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core DOM child-ownership rules in the de-opt reconciler, but behavior is narrowly scoped with a hydration exception and new regression tests.
> 
> **Overview**
> Fixes a regression where **de-optimized host reconciliation** treated every non-portal sibling as renderer-owned once Octane had created at least one child, so **externally streamed DOM** (processing-instruction boundaries, lists, buttons, listeners) was removed on ordinary updates.
> 
> The reconciler now treats nodes without a `$$deoptKey` or de-opt descriptor as **foreign** during client updates—same idea as portal ranges—while **hydration** still adopts unstamped server children. Reordering with mixed foreign content uses the same skip rules in `liveOwnedChildAt`. New runtime tests cover sibling updates, clearing owned children only, and post-hydration adoption alongside later streams. Includes an **octane** patch changeset; rspack integration tests use async `fs/promises.rm` with more retries for temp cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d703eeddc85e33f80ae73cddd4cd564346b68aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->