### PR TITLE
Port the Base UI list-navigation and typeahead infrastructure (Phase 3e)

### DIFF
--- a/.changeset/base-ui-list-index-disabled.md
+++ b/.changeset/base-ui-list-index-disabled.md
@@ -1,0 +1,9 @@
+---
+'@octanejs/base-ui': patch
+---
+
+Composite roving focus now skips list items that are not visible, and an explicit `disabledIndices`
+no longer suppresses that check. This brings the vendored list-navigation helpers in line with Base
+UI 1.6.0's `isListIndexDisabled`, where an explicit `disabledIndices` hit wins, an invisible element
+is always disabled, and the `disabled`/`aria-disabled` attribute fallback applies only when no
+`disabledIndices` was passed at all.

--- a/packages/base-ui/src/utils/RequestQueue.ts
+++ b/packages/base-ui/src/utils/RequestQueue.ts
@@ -1,0 +1,132 @@
+// Ported from .base-ui/packages/react/src/internals/RequestQueue.ts (v1.6.0). Manages concurrent
+// fetching with a queue: tracks each key's lifecycle through queued → pending and caps the number
+// of in-flight requests so the server is not overwhelmed. Subclasses override `pickEntries` to
+// change the ordering (the default is FIFO).
+//
+// Pure — no renderer API is involved, so this is a straight transcription.
+export type RequestStatus = 'queued' | 'pending' | 'unknown';
+
+export interface RequestQueueOptions<TKey> {
+	/**
+	 * The function to call when a queued key is ready to be fetched.
+	 */
+	fetchFn: (key: TKey) => Promise<void>;
+	/**
+	 * The maximum number of concurrent requests.
+	 * @default Infinity
+	 */
+	maxConcurrentRequests?: number | undefined;
+	/**
+	 * Serialize a key to a string for use as a map key.
+	 * Required for complex key types (e.g., objects).
+	 * @default String(key)
+	 */
+	getKeyId?: ((key: TKey) => string) | undefined;
+}
+
+/**
+ * Manages concurrent fetching with a queue system.
+ * Tracks request lifecycle through queued → pending states
+ * and limits concurrency to prevent overwhelming the server.
+ */
+export class RequestQueue<TKey> {
+	protected pendingRequests = new Map<string, TKey>();
+
+	protected queuedRequests = new Map<string, TKey>();
+
+	protected fetchFn: (key: TKey) => Promise<void>;
+
+	protected maxConcurrentRequests: number;
+
+	protected getKeyId: (key: TKey) => string;
+
+	constructor(options: RequestQueueOptions<TKey>) {
+		this.fetchFn = options.fetchFn;
+		this.maxConcurrentRequests = options.maxConcurrentRequests ?? Infinity;
+		this.getKeyId = options.getKeyId ?? String;
+	}
+
+	/**
+	 * Returns the next `count` entries to process from the queue.
+	 * Default is FIFO (oldest first). Subclasses can override for different ordering.
+	 */
+	protected pickEntries(count: number): [string, TKey][] {
+		const result: [string, TKey][] = [];
+		const iterator = this.queuedRequests.entries();
+		for (let i = 0; i < count; i += 1) {
+			const { value } = iterator.next() as IteratorYieldResult<[string, TKey]>;
+			result.push(value);
+		}
+		return result;
+	}
+
+	protected processQueue = async () => {
+		if (this.queuedRequests.size === 0 || this.pendingRequests.size >= this.maxConcurrentRequests) {
+			return;
+		}
+
+		const loopLength = Math.min(
+			this.maxConcurrentRequests - this.pendingRequests.size,
+			this.queuedRequests.size,
+		);
+		if (loopLength === 0) {
+			return;
+		}
+
+		const fetchPromises: Promise<void>[] = [];
+
+		for (const [keyId, key] of this.pickEntries(loopLength)) {
+			this.queuedRequests.delete(keyId);
+			this.pendingRequests.set(keyId, key);
+
+			fetchPromises.push(
+				this.fetchFn(key).catch(() => {
+					this.pendingRequests.delete(keyId);
+				}),
+			);
+		}
+
+		await Promise.all(fetchPromises);
+		if (this.queuedRequests.size > 0) {
+			await this.processQueue();
+		}
+	};
+
+	public queue = async (keys: TKey[]) => {
+		for (const key of keys) {
+			const keyId = this.getKeyId(key);
+			if (!this.pendingRequests.has(keyId)) {
+				this.queuedRequests.set(keyId, key);
+			}
+		}
+		await this.processQueue();
+	};
+
+	public setRequestSettled = async (key: TKey) => {
+		const keyId = this.getKeyId(key);
+		this.pendingRequests.delete(keyId);
+		await this.processQueue();
+	};
+
+	public clear = () => {
+		this.queuedRequests.clear();
+		this.pendingRequests.clear();
+	};
+
+	public clearPendingRequest = async (key: TKey) => {
+		const keyId = this.getKeyId(key);
+		this.pendingRequests.delete(keyId);
+		await this.processQueue();
+	};
+
+	public getRequestStatus = (key: TKey): RequestStatus => {
+		const keyId = this.getKeyId(key);
+		if (this.pendingRequests.has(keyId)) {
+			return 'pending';
+		}
+		if (this.queuedRequests.has(keyId)) {
+			return 'queued';
+		}
+		return 'unknown';
+	};
+}

--- a/packages/base-ui/src/utils/TimeoutManager.ts
+++ b/packages/base-ui/src/utils/TimeoutManager.ts
@@ -1,0 +1,32 @@
+// Ported from .base-ui/packages/react/src/internals/TimeoutManager.ts (v1.6.0). Several keyed
+// timeouts behind one handle, so a caller can start/replace/cancel each independently and drop them
+// all on teardown. Distinct from `utils/useTimeout`'s `Timeout`, which owns exactly one.
+//
+// Pure — no renderer API is involved, so this is a straight transcription.
+export class TimeoutManager {
+	private ids: Map<string, number> = new Map();
+
+	/** Starts `fn` after `delay`, replacing any timeout already running under `key`. */
+	start = (key: string, delay: number, fn: () => void): void => {
+		this.clear(key);
+		const id = setTimeout(() => {
+			this.ids.delete(key);
+			fn();
+		}, delay) as unknown as number;
+
+		this.ids.set(key, id);
+	};
+
+	clear = (key: string): void => {
+		const id = this.ids.get(key);
+		if (id != null) {
+			clearTimeout(id);
+			this.ids.delete(key);
+		}
+	};
+
+	clearAll = (): void => {
+		this.ids.forEach(clearTimeout);
+		this.ids.clear();
+	};
+}

--- a/packages/base-ui/src/utils/composite/grid-utils.ts
+++ b/packages/base-ui/src/utils/composite/grid-utils.ts
@@ -1,0 +1,437 @@
+// The two-dimensional half of `.base-ui/packages/react/src/floating-ui-react/utils/composite.ts`
+// (v1.6.0): the grid navigation algorithm and the cell-map helpers that let a spanning or densely
+// packed item occupy more than one cell. Both `gridNavigation` entry points
+// (`../floating/gridNavigation`, `./gridNavigation`) build on these, and nothing else does — a
+// composite that never passes `grid` leaves this module out of its bundle entirely, which is the
+// point of the injection.
+//
+// Upstream keeps this in the same module as the one-dimensional list algebra; this binding already
+// vendors that into `./list-utils`, so the grid half sits beside it rather than folding back in.
+// That also keeps `list-utils` free of a cycle: it imports `isElementVisible` from
+// `../floating/composite`, and nothing imports this file back.
+//
+// octane adaptations: `React.KeyboardEvent` is the NATIVE `KeyboardEvent`.
+// `createGridCellMap`'s invalid-width check is dev-only upstream; it throws unconditionally here,
+// because this binding carries no `process.env.NODE_ENV` branches and the production fallthrough
+// upstream accepts is an infinite placement loop, not a degraded layout.
+import { floor, type Dimensions } from '@floating-ui/utils';
+
+import { ARROW_DOWN, ARROW_LEFT, ARROW_RIGHT, ARROW_UP } from './keys';
+import {
+	findNonDisabledListIndex,
+	isDifferentGridRow,
+	isIndexOutOfListBounds,
+	isListIndexDisabled,
+	stopEvent,
+	type DisabledIndices,
+} from './list-utils';
+
+export function getGridNavigatedIndex(
+	list: Array<HTMLElement | null>,
+	{
+		event,
+		orientation,
+		loopFocus,
+		onLoop,
+		rtl,
+		cols,
+		disabledIndices,
+		minIndex,
+		maxIndex,
+		prevIndex,
+		stopEvent: stop = false,
+	}: {
+		event: KeyboardEvent;
+		orientation: 'horizontal' | 'vertical' | 'both';
+		loopFocus: boolean;
+		onLoop?: ((event: KeyboardEvent, prevIndex: number, nextIndex: number) => number) | undefined;
+		rtl: boolean;
+		cols: number;
+		disabledIndices: DisabledIndices | undefined;
+		minIndex: number;
+		maxIndex: number;
+		prevIndex: number;
+		stopEvent?: boolean | undefined;
+	},
+): number {
+	let nextIndex = prevIndex;
+
+	let verticalDirection: 'up' | 'down' | undefined;
+	if (event.key === ARROW_UP) {
+		verticalDirection = 'up';
+	} else if (event.key === ARROW_DOWN) {
+		verticalDirection = 'down';
+	}
+
+	if (verticalDirection) {
+		// -------------------------------------------------------------------------
+		// Detect row structure only when handling vertical navigation. This keeps
+		// the non-vertical key paths free from row inference work.
+		// -------------------------------------------------------------------------
+		const rows: number[][] = [];
+		const rowIndexMap: number[] = [];
+		let hasRoleRow = false;
+		let visibleItemCount = 0;
+		{
+			let currentRowEl: Element | null = null;
+			let currentRowIndex = -1;
+
+			list.forEach((el, idx) => {
+				if (el == null) {
+					return;
+				}
+
+				visibleItemCount += 1;
+
+				const rowEl = el.closest('[role="row"]');
+				if (rowEl) {
+					hasRoleRow = true;
+				}
+
+				if (rowEl !== currentRowEl || currentRowIndex === -1) {
+					currentRowEl = rowEl;
+					currentRowIndex += 1;
+					rows[currentRowIndex] = [];
+				}
+				rows[currentRowIndex].push(idx);
+				rowIndexMap[idx] = currentRowIndex;
+			});
+		}
+
+		let hasDomRows = false;
+		let inferredDomCols = 0;
+
+		if (hasRoleRow) {
+			for (const row of rows) {
+				const rowLength = row.length;
+
+				if (rowLength > inferredDomCols) {
+					inferredDomCols = rowLength;
+				}
+
+				if (rowLength !== cols) {
+					hasDomRows = true;
+				}
+			}
+		}
+
+		const hasVirtualizedGaps = hasDomRows && visibleItemCount < list.length;
+		const verticalCols = inferredDomCols || cols;
+
+		const navigateVertically = (direction: 'up' | 'down') => {
+			if (!hasDomRows || prevIndex === -1) {
+				return undefined;
+			}
+
+			const currentRow = rowIndexMap[prevIndex];
+			if (currentRow == null) {
+				return undefined;
+			}
+
+			const colInRow = rows[currentRow].indexOf(prevIndex);
+			const step = direction === 'up' ? -1 : 1;
+
+			for (let nextRow = currentRow + step, i = 0; i < rows.length; i += 1, nextRow += step) {
+				if (nextRow < 0 || nextRow >= rows.length) {
+					if (!loopFocus || hasVirtualizedGaps) {
+						return undefined;
+					}
+					nextRow = nextRow < 0 ? rows.length - 1 : 0;
+					if (onLoop) {
+						const clampedCol = Math.min(colInRow, rows[nextRow].length - 1);
+						const targetItemIndex = rows[nextRow][clampedCol] ?? rows[nextRow][0];
+						const returnedItemIndex = onLoop(event, prevIndex, targetItemIndex);
+						nextRow = rowIndexMap[returnedItemIndex] ?? nextRow;
+					}
+				}
+
+				const targetRow = rows[nextRow];
+				for (let col = Math.min(colInRow, targetRow.length - 1); col >= 0; col -= 1) {
+					const candidate = targetRow[col];
+					if (!isListIndexDisabled(list, candidate, disabledIndices)) {
+						return candidate;
+					}
+				}
+			}
+
+			return undefined;
+		};
+
+		const navigateVerticallyWithInferredRows = (direction: 'up' | 'down') => {
+			if (!hasVirtualizedGaps || prevIndex === -1) {
+				return undefined;
+			}
+
+			const colInRow = prevIndex % verticalCols;
+			const rowStep = direction === 'up' ? -verticalCols : verticalCols;
+			const lastRowStart = maxIndex - (maxIndex % verticalCols);
+			const rowCount = floor(maxIndex / verticalCols) + 1;
+
+			for (
+				let rowStart = prevIndex - colInRow + rowStep, i = 0;
+				i < rowCount;
+				i += 1, rowStart += rowStep
+			) {
+				if (rowStart < 0 || rowStart > maxIndex) {
+					if (!loopFocus) {
+						return undefined;
+					}
+					rowStart = rowStart < 0 ? lastRowStart : 0;
+				}
+
+				const rowEnd = Math.min(rowStart + verticalCols - 1, maxIndex);
+				for (
+					let candidate = Math.min(rowStart + colInRow, rowEnd);
+					candidate >= rowStart;
+					candidate -= 1
+				) {
+					if (!isListIndexDisabled(list, candidate, disabledIndices)) {
+						return candidate;
+					}
+				}
+			}
+
+			return undefined;
+		};
+
+		if (stop) {
+			stopEvent(event);
+		}
+
+		const verticalCandidate =
+			navigateVertically(verticalDirection) ??
+			navigateVerticallyWithInferredRows(verticalDirection);
+
+		if (verticalCandidate !== undefined) {
+			nextIndex = verticalCandidate;
+		} else if (prevIndex === -1) {
+			nextIndex = verticalDirection === 'up' ? maxIndex : minIndex;
+		} else {
+			nextIndex = findNonDisabledListIndex(list, {
+				startingIndex: prevIndex,
+				amount: verticalCols,
+				decrement: verticalDirection === 'up',
+				disabledIndices,
+			});
+
+			if (loopFocus) {
+				if (verticalDirection === 'up' && (prevIndex - verticalCols < minIndex || nextIndex < 0)) {
+					const col = prevIndex % verticalCols;
+					const maxCol = maxIndex % verticalCols;
+					const offset = maxIndex - (maxCol - col);
+
+					if (maxCol === col) {
+						nextIndex = maxIndex;
+					} else {
+						nextIndex = maxCol > col ? offset : offset - verticalCols;
+					}
+					if (onLoop) {
+						nextIndex = onLoop(event, prevIndex, nextIndex);
+					}
+				}
+
+				if (verticalDirection === 'down' && prevIndex + verticalCols > maxIndex) {
+					nextIndex = findNonDisabledListIndex(list, {
+						startingIndex: (prevIndex % verticalCols) - verticalCols,
+						amount: verticalCols,
+						disabledIndices,
+					});
+					if (onLoop) {
+						nextIndex = onLoop(event, prevIndex, nextIndex);
+					}
+				}
+			}
+		}
+
+		if (isIndexOutOfListBounds(list, nextIndex)) {
+			nextIndex = prevIndex;
+		}
+	}
+
+	// Remains on the same row/column.
+	if (orientation === 'both') {
+		const prevRow = floor(prevIndex / cols);
+
+		if (event.key === (rtl ? ARROW_LEFT : ARROW_RIGHT)) {
+			if (stop) {
+				stopEvent(event);
+			}
+
+			if (prevIndex % cols !== cols - 1) {
+				nextIndex = findNonDisabledListIndex(list, {
+					startingIndex: prevIndex,
+					disabledIndices,
+				});
+
+				if (loopFocus && isDifferentGridRow(nextIndex, cols, prevRow)) {
+					nextIndex = findNonDisabledListIndex(list, {
+						startingIndex: prevIndex - (prevIndex % cols) - 1,
+						disabledIndices,
+					});
+					if (onLoop) {
+						nextIndex = onLoop(event, prevIndex, nextIndex);
+					}
+				}
+			} else if (loopFocus) {
+				nextIndex = findNonDisabledListIndex(list, {
+					startingIndex: prevIndex - (prevIndex % cols) - 1,
+					disabledIndices,
+				});
+				if (onLoop) {
+					nextIndex = onLoop(event, prevIndex, nextIndex);
+				}
+			}
+
+			if (isDifferentGridRow(nextIndex, cols, prevRow)) {
+				nextIndex = prevIndex;
+			}
+		}
+
+		if (event.key === (rtl ? ARROW_RIGHT : ARROW_LEFT)) {
+			if (stop) {
+				stopEvent(event);
+			}
+
+			if (prevIndex % cols !== 0) {
+				nextIndex = findNonDisabledListIndex(list, {
+					startingIndex: prevIndex,
+					decrement: true,
+					disabledIndices,
+				});
+
+				if (loopFocus && isDifferentGridRow(nextIndex, cols, prevRow)) {
+					nextIndex = findNonDisabledListIndex(list, {
+						startingIndex: prevIndex + (cols - (prevIndex % cols)),
+						decrement: true,
+						disabledIndices,
+					});
+					if (onLoop) {
+						nextIndex = onLoop(event, prevIndex, nextIndex);
+					}
+				}
+			} else if (loopFocus) {
+				nextIndex = findNonDisabledListIndex(list, {
+					startingIndex: prevIndex + (cols - (prevIndex % cols)),
+					decrement: true,
+					disabledIndices,
+				});
+				if (onLoop) {
+					nextIndex = onLoop(event, prevIndex, nextIndex);
+				}
+			}
+
+			if (isDifferentGridRow(nextIndex, cols, prevRow)) {
+				nextIndex = prevIndex;
+			}
+		}
+
+		const lastRow = floor(maxIndex / cols) === prevRow;
+
+		if (isIndexOutOfListBounds(list, nextIndex)) {
+			if (loopFocus && lastRow) {
+				nextIndex =
+					event.key === (rtl ? ARROW_RIGHT : ARROW_LEFT)
+						? maxIndex
+						: findNonDisabledListIndex(list, {
+								startingIndex: prevIndex - (prevIndex % cols) - 1,
+								disabledIndices,
+							});
+				if (onLoop) {
+					nextIndex = onLoop(event, prevIndex, nextIndex);
+				}
+			} else {
+				nextIndex = prevIndex;
+			}
+		}
+	}
+
+	return nextIndex;
+}
+
+/** For each cell index, gets the item index that occupies that cell */
+export function createGridCellMap(
+	sizes: Dimensions[],
+	cols: number,
+	dense: boolean,
+): Array<number | undefined> {
+	const cellMap: (number | undefined)[] = [];
+	let startIndex = 0;
+	sizes.forEach(({ width, height }, index) => {
+		if (width > cols) {
+			// octane: dev-only upstream. Left unguarded because the alternative is the placement loop
+			// below spinning forever.
+			throw new Error(
+				`[Floating UI]: Invalid grid - item width at index ${index} is greater than grid columns`,
+			);
+		}
+		let itemPlaced = false;
+		if (dense) {
+			startIndex = 0;
+		}
+		while (!itemPlaced) {
+			const targetCells: number[] = [];
+			for (let i = 0; i < width; i += 1) {
+				for (let j = 0; j < height; j += 1) {
+					targetCells.push(startIndex + i + j * cols);
+				}
+			}
+			if (
+				(startIndex % cols) + width <= cols &&
+				targetCells.every((cell) => cellMap[cell] == null)
+			) {
+				targetCells.forEach((cell) => {
+					cellMap[cell] = index;
+				});
+				itemPlaced = true;
+			} else {
+				startIndex += 1;
+			}
+		}
+	});
+
+	// convert into a non-sparse array
+	return [...cellMap];
+}
+
+/** Gets cell index of an item's corner or -1 when index is -1. */
+export function getGridCellIndexOfCorner(
+	index: number,
+	sizes: Dimensions[],
+	cellMap: (number | undefined)[],
+	cols: number,
+	corner: 'tl' | 'tr' | 'bl' | 'br',
+): number {
+	if (index === -1) {
+		return -1;
+	}
+
+	const firstCellIndex = cellMap.indexOf(index);
+	const sizeItem = sizes[index];
+
+	switch (corner) {
+		case 'tl':
+			return firstCellIndex;
+		case 'tr':
+			if (!sizeItem) {
+				return firstCellIndex;
+			}
+			return firstCellIndex + sizeItem.width - 1;
+		case 'bl':
+			if (!sizeItem) {
+				return firstCellIndex;
+			}
+			return firstCellIndex + (sizeItem.height - 1) * cols;
+		case 'br':
+			return cellMap.lastIndexOf(index);
+		default:
+			return -1;
+	}
+}
+
+/** Gets all cell indices that correspond to the specified indices */
+export function getGridCellIndices(
+	indices: (number | undefined)[],
+	cellMap: (number | undefined)[],
+): number[] {
+	return cellMap.flatMap((index, cellIndex) => (indices.includes(index) ? [cellIndex] : []));
+}

--- a/packages/base-ui/src/utils/composite/gridNavigation.ts
+++ b/packages/base-ui/src/utils/composite/gridNavigation.ts
@@ -1,0 +1,127 @@
+// Ported from .base-ui/packages/react/src/internals/composite/root/gridNavigation.ts (v1.6.0).
+// The navigator a composite passes to `useCompositeRoot`'s `grid` option — distinct from
+// `../floating/gridNavigation`, which is the 1x1 navigator `useListNavigation` injects for itself.
+//
+// octane adaptations: the event is the NATIVE `KeyboardEvent`, and `React.RefObject<T>` is a plain
+// `{ current: T }`. Not a hook, so no slot.
+import {
+	createGridCellMap,
+	getGridCellIndexOfCorner,
+	getGridCellIndices,
+	getGridNavigatedIndex,
+} from './grid-utils';
+import { isListIndexDisabled } from './list-utils';
+import { ARROW_DOWN, ARROW_LEFT, ARROW_RIGHT } from './keys';
+
+type CompositeGridElementsRef = { current: Array<HTMLElement | null> };
+type CompositeGridOnLoop = (event: KeyboardEvent, prevIndex: number, nextIndex: number) => number;
+
+export interface CompositeGridItemSize {
+	width: number;
+	height: number;
+}
+
+export interface CompositeGridConfig {
+	cols: number;
+	dense?: boolean | undefined;
+	itemSizes?: CompositeGridItemSize[] | undefined;
+}
+
+export interface CompositeGridNavigationState {
+	event: KeyboardEvent;
+	elementsRef: CompositeGridElementsRef;
+	highlightedIndex: number;
+	minIndex: number;
+	maxIndex: number;
+	orientation: 'horizontal' | 'vertical' | 'both';
+	loopFocus: boolean;
+	onLoop?: CompositeGridOnLoop | undefined;
+	disabledIndices?: number[] | undefined;
+	rtl: boolean;
+}
+
+export type CompositeGridNavigator = (state: CompositeGridNavigationState) => number;
+
+/**
+ * Builds the grid navigation handler passed to `CompositeRoot`/`useCompositeRoot`
+ * via the `grid` prop. Importing and calling this is the opt-in for grid
+ * navigation: composites that don't pass `grid` never reference the algorithm,
+ * so bundlers tree-shake the grid helpers out.
+ */
+export function gridNavigation(config: CompositeGridConfig): CompositeGridNavigator {
+	const { cols, dense = false, itemSizes } = config;
+
+	return (state) => {
+		const {
+			disabledIndices,
+			elementsRef,
+			event,
+			highlightedIndex,
+			loopFocus,
+			maxIndex,
+			minIndex,
+			onLoop,
+			orientation,
+			rtl,
+		} = state;
+
+		const sizes =
+			itemSizes ||
+			Array.from({ length: elementsRef.current.length }, () => ({
+				width: 1,
+				height: 1,
+			}));
+		// Work in hypothetical 1x1 cell indices, then convert back to item indices.
+		const cellMap = createGridCellMap(sizes, cols, dense);
+		const minGridIndex = cellMap.findIndex(
+			(index) => index != null && !isListIndexDisabled(elementsRef.current, index, disabledIndices),
+		);
+		const maxGridIndex = cellMap.reduce(
+			(foundIndex: number, index, cellIndex) =>
+				index != null && !isListIndexDisabled(elementsRef.current, index, disabledIndices)
+					? cellIndex
+					: foundIndex,
+			-1,
+		);
+		const cellIndex = getGridNavigatedIndex(
+			cellMap.map((itemIndex) => (itemIndex != null ? elementsRef.current[itemIndex] : null)),
+			{
+				event,
+				orientation,
+				loopFocus,
+				onLoop,
+				cols,
+				// Treat undefined gaps as disabled so navigation cannot land in them.
+				disabledIndices: getGridCellIndices(
+					[
+						...(disabledIndices ||
+							elementsRef.current.map((_, index) =>
+								isListIndexDisabled(elementsRef.current, index) ? index : undefined,
+							)),
+						undefined,
+					],
+					cellMap,
+				),
+				minIndex: minGridIndex,
+				maxIndex: maxGridIndex,
+				prevIndex: getGridCellIndexOfCorner(
+					highlightedIndex > maxIndex ? minIndex : highlightedIndex,
+					sizes,
+					cellMap,
+					cols,
+					// Choose the corner closest to the movement direction so spanning items
+					// do not immediately resolve back to themselves.
+					event.key === ARROW_DOWN
+						? 'bl'
+						: event.key === (rtl ? ARROW_LEFT : ARROW_RIGHT)
+							? 'tr'
+							: 'tl',
+				),
+				rtl,
+			},
+		);
+
+		// Navigated cell will never be nullish.
+		return cellMap[cellIndex] as number;
+	};
+}

--- a/packages/base-ui/src/utils/composite/list-utils.ts
+++ b/packages/base-ui/src/utils/composite/list-utils.ts
@@ -1,7 +1,18 @@
 // Vendored list-navigation helpers — Base UI itself vendors these from `floating-ui-react`
-// (`.base-ui/packages/react/src/floating-ui-react/utils.ts`); octane's `@octanejs/floating-ui`
-// implements the identical functions but does not export them publicly, so we keep a small
-// self-contained copy here (matching the octane port's implementations verbatim).
+// (`.base-ui/packages/react/src/floating-ui-react/utils/composite.ts`, re-exported through
+// `internals/composite/composite.ts`); octane's `@octanejs/floating-ui` implements the identical
+// functions but does not export them publicly, so we keep a small self-contained copy here.
+//
+// Signatures follow Base UI 1.6.0 exactly: the index helpers take the item ARRAY, while
+// `getMinListIndex`/`getMaxListIndex` take the REF (they need `listRef.current.length` at call
+// time). `isListIndexDisabled` is likewise the 1.6.0 body: an explicit `disabledIndices` hit wins,
+// an invisible element is always disabled, and the `disabled`/`aria-disabled` attribute fallback
+// applies only when the consumer passed no `disabledIndices` at all. `useListNavigation` depends on
+// that last clause — it deliberately omits `disabledIndices` when picking the item to focus on open
+// so attribute-disabled items are still skipped for consumers passing an empty array.
+import { isElementVisible } from '../floating/composite';
+
+export type DisabledIndices = ReadonlyArray<number> | ((index: number) => boolean);
 
 export function getTarget(event: any): EventTarget | null {
 	if ('composedPath' in event) {
@@ -15,36 +26,53 @@ export function stopEvent(event: any): void {
 	event.stopPropagation();
 }
 
-export function isIndexOutOfListBounds(listRef: { current: any[] }, index: number): boolean {
-	return index < 0 || index >= listRef.current.length;
+export function isDifferentGridRow(index: number, cols: number, prevRow: number): boolean {
+	return Math.floor(index / cols) !== prevRow;
+}
+
+export function isIndexOutOfListBounds(
+	list: ReadonlyArray<HTMLElement | null>,
+	index: number,
+): boolean {
+	return index < 0 || index >= list.length;
 }
 
 export function isListIndexDisabled(
-	listRef: { current: any[] },
+	list: ReadonlyArray<HTMLElement | null>,
 	index: number,
-	disabledIndices?: number[] | ((index: number) => boolean),
+	disabledIndices?: DisabledIndices | undefined,
 ): boolean {
-	if (typeof disabledIndices === 'function') {
-		return disabledIndices(index);
+	const isExplicitlyDisabled =
+		typeof disabledIndices === 'function'
+			? disabledIndices(index)
+			: (disabledIndices?.includes(index) ?? false);
+
+	if (isExplicitlyDisabled) {
+		return true;
 	}
-	if (disabledIndices) {
-		return disabledIndices.includes(index);
+
+	const element = list[index];
+	if (!element) {
+		return false;
 	}
-	const element = listRef.current[index];
+
+	if (!isElementVisible(element)) {
+		return true;
+	}
+
 	return (
-		element == null ||
-		element.hasAttribute('disabled') ||
-		element.getAttribute('aria-disabled') === 'true'
+		!disabledIndices &&
+		(element.hasAttribute('disabled') || element.getAttribute('aria-disabled') === 'true')
 	);
 }
 
 export function findNonDisabledListIndex(
-	listRef: { current: any[] },
+	list: ReadonlyArray<HTMLElement | null>,
 	options: {
-		startingIndex?: number;
-		decrement?: boolean;
-		disabledIndices?: number[] | ((index: number) => boolean);
-		amount?: number;
+		startingIndex?: number | undefined;
+		decrement?: boolean | undefined;
+		disabledIndices?: DisabledIndices | undefined;
+		amount?: number | undefined;
 	} = {},
 ): number {
 	const { startingIndex = -1, decrement = false, disabledIndices, amount = 1 } = options;
@@ -53,24 +81,24 @@ export function findNonDisabledListIndex(
 		index += decrement ? -amount : amount;
 	} while (
 		index >= 0 &&
-		index <= listRef.current.length - 1 &&
-		isListIndexDisabled(listRef, index, disabledIndices)
+		index <= list.length - 1 &&
+		isListIndexDisabled(list, index, disabledIndices)
 	);
 	return index;
 }
 
 export function getMinListIndex(
-	listRef: { current: any[] },
-	disabledIndices: number[] | ((index: number) => boolean) | undefined,
+	listRef: { current: ReadonlyArray<HTMLElement | null> },
+	disabledIndices?: DisabledIndices | undefined,
 ): number {
-	return findNonDisabledListIndex(listRef, { disabledIndices });
+	return findNonDisabledListIndex(listRef.current, { disabledIndices });
 }
 
 export function getMaxListIndex(
-	listRef: { current: any[] },
-	disabledIndices: number[] | ((index: number) => boolean) | undefined,
+	listRef: { current: ReadonlyArray<HTMLElement | null> },
+	disabledIndices?: DisabledIndices | undefined,
 ): number {
-	return findNonDisabledListIndex(listRef, {
+	return findNonDisabledListIndex(listRef.current, {
 		decrement: true,
 		startingIndex: listRef.current.length,
 		disabledIndices,

--- a/packages/base-ui/src/utils/composite/useCompositeRoot.ts
+++ b/packages/base-ui/src/utils/composite/useCompositeRoot.ts
@@ -141,14 +141,9 @@ export function useCompositeRoot(...args: any[]): {
 
 			if (activeIndex !== -1) {
 				onHighlightedIndexChange(activeIndex);
-			} else if (
-				isListIndexDisabled({ current: sortedElements }, highlightedIndex, disabledIndices)
-			) {
-				const firstEnabledIndex = findNonDisabledListIndex(
-					{ current: sortedElements },
-					{ disabledIndices },
-				);
-				if (!isIndexOutOfListBounds({ current: sortedElements }, firstEnabledIndex)) {
+			} else if (isListIndexDisabled(sortedElements, highlightedIndex, disabledIndices)) {
+				const firstEnabledIndex = findNonDisabledListIndex(sortedElements, { disabledIndices });
+				if (!isIndexOutOfListBounds(sortedElements, firstEnabledIndex)) {
 					onHighlightedIndexChange(firstEnabledIndex);
 				}
 			}
@@ -168,9 +163,9 @@ export function useCompositeRoot(...args: any[]): {
 				return;
 			}
 			const elements = elementsRef.current;
-			if (isListIndexDisabled(elementsRef, highlightedIndex, disabledIndices)) {
-				const firstEnabledIndex = findNonDisabledListIndex(elementsRef, { disabledIndices });
-				if (!isIndexOutOfListBounds({ current: elements }, firstEnabledIndex)) {
+			if (isListIndexDisabled(elements, highlightedIndex, disabledIndices)) {
+				const firstEnabledIndex = findNonDisabledListIndex(elements, { disabledIndices });
+				if (!isIndexOutOfListBounds(elements, firstEnabledIndex)) {
 					onHighlightedIndexChange(firstEnabledIndex);
 				}
 			}
@@ -294,7 +289,7 @@ export function useCompositeRoot(...args: any[]): {
 						nextIndex = onLoop(event, highlightedIndex, nextIndex, elementsRef);
 					}
 				} else {
-					nextIndex = findNonDisabledListIndex(elementsRef, {
+					nextIndex = findNonDisabledListIndex(elementsRef.current, {
 						startingIndex: nextIndex,
 						decrement: backwardKeys.includes(event.key),
 						disabledIndices,
@@ -302,7 +297,10 @@ export function useCompositeRoot(...args: any[]): {
 				}
 			}
 
-			if (nextIndex !== highlightedIndex && !isIndexOutOfListBounds(elementsRef, nextIndex)) {
+			if (
+				nextIndex !== highlightedIndex &&
+				!isIndexOutOfListBounds(elementsRef.current, nextIndex)
+			) {
 				if (stopEventPropagation) {
 					event.stopPropagation();
 				}

--- a/packages/base-ui/src/utils/createChangeEventDetails.ts
+++ b/packages/base-ui/src/utils/createChangeEventDetails.ts
@@ -28,6 +28,7 @@ export const REASONS = {
 	outsidePress: 'outside-press',
 	closePress: 'close-press',
 	focusOut: 'focus-out',
+	listNavigation: 'list-navigation',
 	escapeKey: 'escape-key',
 	imperativeAction: 'imperative-action',
 } as const;

--- a/packages/base-ui/src/utils/floating/gridNavigation.ts
+++ b/packages/base-ui/src/utils/floating/gridNavigation.ts
@@ -1,0 +1,54 @@
+// Ported from .base-ui/packages/react/src/floating-ui-react/hooks/gridNavigation.ts (v1.6.0). The
+// grid navigator `useListNavigation` injects for its own `grid` option — distinct from
+// `../composite/gridNavigation`, which builds the navigator `useCompositeRoot` takes.
+//
+// octane adaptations: the event is the NATIVE `KeyboardEvent`, and `React.RefObject<T>` is a plain
+// `{ current: T }`. Not a hook, so no slot. Upstream's `utils/composite` module is split in this
+// binding: the list algebra lives in `../composite/list-utils`, the grid algorithm in
+// `../composite/grid-utils`.
+import { getGridNavigatedIndex } from '../composite/grid-utils';
+import { isIndexOutOfListBounds, type DisabledIndices } from '../composite/list-utils';
+
+/**
+ * Positional arguments are deliberate: property names of an options object
+ * don't minify, and the signature is locked to the caller via `typeof` on the
+ * `grid` option of `useListNavigation`.
+ *
+ * The injected grid navigator only ever operates on a uniform 1x1 grid (sizes are
+ * always `1x1` and packing is never dense), so the cell-map machinery that supports
+ * multi-cell items collapses to an identity transform over the item list. Calling
+ * `getGridNavigatedIndex` directly keeps the cell-map helpers
+ * (`createGridCellMap`/`getGridCellIndexOfCorner`/`getGridCellIndices`) out of
+ * grid-combobox bundles.
+ */
+export function gridNavigation(
+	event: KeyboardEvent,
+	prevIndex: number,
+	listRef: { current: Array<HTMLElement | null> },
+	orientation: 'horizontal' | 'vertical' | 'both',
+	loopFocus: boolean,
+	rtl: boolean,
+	disabledIndices: DisabledIndices | undefined,
+	minIndex: number,
+	maxIndex: number,
+	cols = 2,
+): number | undefined {
+	const nextIndex = getGridNavigatedIndex(listRef.current, {
+		event,
+		orientation,
+		loopFocus,
+		rtl,
+		cols,
+		disabledIndices,
+		minIndex,
+		maxIndex,
+		// An out-of-range previous index falls back to the first enabled item.
+		prevIndex: prevIndex > maxIndex ? minIndex : prevIndex,
+		stopEvent: true,
+	});
+
+	// `getGridNavigatedIndex` can return an out-of-bounds sentinel (e.g. `-1` when there is no
+	// previous item to move from); surface that as `undefined` so the caller treats it as
+	// "no navigation" rather than highlighting index `-1`.
+	return isIndexOutOfListBounds(listRef.current, nextIndex) ? undefined : nextIndex;
+}

--- a/packages/base-ui/src/utils/floating/useListNavigation.ts
+++ b/packages/base-ui/src/utils/floating/useListNavigation.ts
@@ -1,0 +1,1018 @@
+// Ported from .base-ui/packages/react/src/floating-ui-react/hooks/useListNavigation.ts (v1.6.0),
+// octane-adapted: reads the FloatingRootStore (`store.useState`/`select`/`setOpen`/`context`);
+// native events (no `.nativeEvent`); `useIsoLayoutEffect` → octane's `useLayoutEffect` (a plain-`.ts`
+// hook is not compiled, so an `undefined` dep array runs the effect every render — the same
+// semantics as upstream's dep-less `useIsoLayoutEffect`); every hook threads an explicit slot.
+// Returns `{ reference, floating, item, trigger }` prop bags.
+//
+// Adds arrow-key navigation of a list of items using either real DOM focus or virtual focus
+// (`aria-activedescendant`). The two dev-only `console.warn` guards upstream emits for
+// `allowEscape`/grid misconfiguration are dropped: this package carries no `process.env.NODE_ENV`
+// branches (same call as `useStableCallback`'s dropped called-during-render guard).
+import { useMemo, useRef, useLayoutEffect } from 'octane';
+
+import { subSlot } from '../../internal';
+import { isHTMLElement } from '../dom';
+import { ownerDocument } from '../owner';
+import { useAnimationFrame } from '../useAnimationFrame';
+import { useStableCallback } from '../useStableCallback';
+import { useValueAsRef } from '../useValueAsRef';
+import { createChangeEventDetails, REASONS } from '../createChangeEventDetails';
+import { ARROW_DOWN, ARROW_LEFT, ARROW_RIGHT, ARROW_UP } from '../composite/keys';
+import {
+	findNonDisabledListIndex,
+	getMaxListIndex,
+	getMinListIndex,
+	isIndexOutOfListBounds,
+	stopEvent,
+	type DisabledIndices,
+} from '../composite/list-utils';
+import { useFloatingParentNodeId, useFloatingTree } from './FloatingTree';
+import type { FloatingTreeStore } from './FloatingTreeStore';
+import type { ElementProps, FloatingContext, FloatingRootContext } from './types';
+import {
+	activeElement,
+	contains,
+	getFloatingFocusElement,
+	getTarget,
+	isTypeableCombobox,
+} from './element';
+import { enqueueFocus } from './enqueueFocus';
+import { isVirtualClick, isVirtualPointerEvent } from './event';
+
+export const ESCAPE = 'Escape';
+
+export type ListOrientation = 'vertical' | 'horizontal' | 'both';
+
+/**
+ * The two-dimensional navigator injected through the `grid` prop. Upstream types this as
+ * `typeof gridNavigation` (`.base-ui/…/floating-ui-react/hooks/gridNavigation.ts`) and notes that
+ * the positional arguments are deliberate — property names of an options object don't minify, and
+ * the signature is locked to the caller. The grid navigator itself lands with the grid-capable
+ * consumers (Combobox); non-grid consumers (Menu, Select) pass nothing so the grid helpers stay out
+ * of their bundles, which is the whole point of injecting it. A `gridNavigation` port satisfies this
+ * type structurally.
+ */
+export type GridNavigator = (
+	event: KeyboardEvent,
+	prevIndex: number,
+	listRef: { current: Array<HTMLElement | null> },
+	orientation: ListOrientation,
+	loopFocus: boolean,
+	rtl: boolean,
+	disabledIndices: DisabledIndices | undefined,
+	minIndex: number,
+	maxIndex: number,
+	cols?: number,
+) => number | undefined;
+
+function doSwitch(
+	orientation: ListOrientation | undefined,
+	vertical: boolean,
+	horizontal: boolean,
+) {
+	switch (orientation) {
+		case 'vertical':
+			return vertical;
+		case 'horizontal':
+			return horizontal;
+		default:
+			return vertical || horizontal;
+	}
+}
+
+function isMainOrientationKey(key: string, orientation: ListOrientation | undefined) {
+	const vertical = key === ARROW_UP || key === ARROW_DOWN;
+	const horizontal = key === ARROW_LEFT || key === ARROW_RIGHT;
+	return doSwitch(orientation, vertical, horizontal);
+}
+
+function isMainOrientationToEndKey(
+	key: string,
+	orientation: ListOrientation | undefined,
+	rtl: boolean,
+) {
+	const vertical = key === ARROW_DOWN;
+	const horizontal = rtl ? key === ARROW_LEFT : key === ARROW_RIGHT;
+	return (
+		doSwitch(orientation, vertical, horizontal) || key === 'Enter' || key === ' ' || key === ''
+	);
+}
+
+function isCrossOrientationOpenKey(
+	key: string,
+	orientation: ListOrientation | undefined,
+	rtl: boolean,
+) {
+	const vertical = rtl ? key === ARROW_LEFT : key === ARROW_RIGHT;
+	const horizontal = key === ARROW_DOWN;
+	return doSwitch(orientation, vertical, horizontal);
+}
+
+function isCrossOrientationCloseKey(
+	key: string,
+	orientation: ListOrientation | undefined,
+	rtl: boolean,
+	grid: boolean,
+) {
+	const vertical = rtl ? key === ARROW_RIGHT : key === ARROW_LEFT;
+	const horizontal = key === ARROW_UP;
+	if (orientation === 'both' || (orientation === 'horizontal' && grid)) {
+		return key === ESCAPE;
+	}
+	return doSwitch(orientation, vertical, horizontal);
+}
+
+export interface UseListNavigationProps {
+	/**
+	 * A ref that holds an array of list items.
+	 * @default empty list
+	 */
+	listRef: { current: Array<HTMLElement | null> };
+	/**
+	 * The index of the currently active (focused or highlighted) item, which may
+	 * or may not be selected.
+	 * @default null
+	 */
+	activeIndex: number | null;
+	/**
+	 * A callback that is called when the user navigates to a new active item,
+	 * passed in a new `activeIndex`.
+	 */
+	onNavigate?: ((activeIndex: number | null, event: Event | undefined) => void) | undefined;
+	/**
+	 * Whether the Hook is enabled, including all internal Effects and event
+	 * handlers.
+	 * @default true
+	 */
+	enabled?: boolean | undefined;
+	/**
+	 * The currently selected item index, which may or may not be active.
+	 * @default null
+	 */
+	selectedIndex?: number | null | undefined;
+	/**
+	 * Whether to focus the item upon opening the floating element. 'auto' infers
+	 * what to do based on the input type (keyboard vs. pointer), while a boolean
+	 * value will force the value.
+	 * @default 'auto'
+	 */
+	focusItemOnOpen?: boolean | 'auto' | undefined;
+	/**
+	 * Whether hovering an item synchronizes the focus.
+	 * @default true
+	 */
+	focusItemOnHover?: boolean | undefined;
+	/**
+	 * Whether pressing an arrow key on the navigation's main axis opens the
+	 * floating element.
+	 * @default true
+	 */
+	openOnArrowKeyDown?: boolean | undefined;
+	/**
+	 * By default elements with either a `disabled` or `aria-disabled` attribute
+	 * are skipped in the list navigation — however, this requires the items to
+	 * be rendered.
+	 * This prop allows you to manually specify indices which should be disabled,
+	 * overriding the default logic.
+	 * For Windows-style select popups, where the menu does not open when
+	 * navigating via arrow keys, specify an empty array.
+	 * @default undefined
+	 */
+	disabledIndices?: DisabledIndices | undefined;
+	/**
+	 * Determines whether focus can escape the list, such that nothing is selected
+	 * after navigating beyond the boundary of the list. In some
+	 * autocomplete/combobox components, this may be desired, as screen
+	 * readers will return to the input.
+	 * `loopFocus` must be `true`.
+	 * @default false
+	 */
+	allowEscape?: boolean | undefined;
+	/**
+	 * Determines whether focus should loop around when navigating past the first
+	 * or last item.
+	 * @default false
+	 */
+	loopFocus?: boolean | undefined;
+	/**
+	 * If the list is nested within another one (e.g. a nested submenu), the
+	 * navigation semantics change.
+	 * @default false
+	 */
+	nested?: boolean | undefined;
+	/**
+	 * Allows to specify the orientation of the parent list, which is used to
+	 * determine the direction of the navigation.
+	 * This is useful when list navigation is used within a Composite,
+	 * as the hook can't determine the orientation of the parent list automatically.
+	 */
+	parentOrientation?: ListOrientation | undefined;
+	/**
+	 * Whether the direction of the floating element's navigation is in RTL
+	 * layout.
+	 * @default false
+	 */
+	rtl?: boolean | undefined;
+	/**
+	 * Whether the focus is virtual (using `aria-activedescendant`).
+	 * Use this if you need focus to remain on the reference element
+	 * (such as an input), but allow arrow keys to navigate list items.
+	 * This is common in autocomplete listbox components.
+	 * Your virtually-focused list items must have a unique `id` set on them.
+	 * @default false
+	 */
+	virtual?: boolean | undefined;
+	/**
+	 * The orientation in which navigation occurs.
+	 * @default 'vertical'
+	 */
+	orientation?: ListOrientation | undefined;
+	/**
+	 * The id of the root component.
+	 */
+	id?: string | undefined;
+	/**
+	 * Whether to clear the active index when the pointer leaves an item.
+	 * @default true
+	 */
+	resetOnPointerLeave?: boolean | undefined;
+	/**
+	 * External FloatingTree to use when the one provided by context can't be used.
+	 */
+	externalTree?: FloatingTreeStore | undefined;
+	/**
+	 * Computes two-dimensional list navigation for grid-capable consumers.
+	 */
+	grid?: GridNavigator | null | undefined;
+}
+
+/**
+ * Adds arrow key-based navigation of a list of items, either using real DOM
+ * focus or virtual focus.
+ * @see https://floating-ui.com/docs/useListNavigation
+ */
+export function useListNavigation(
+	context: FloatingRootContext | FloatingContext,
+	props: UseListNavigationProps,
+	slot: symbol | undefined,
+): ElementProps {
+	const {
+		listRef,
+		activeIndex,
+		onNavigate: onNavigateProp,
+		enabled = true,
+		selectedIndex = null,
+		allowEscape = false,
+		loopFocus = false,
+		nested = false,
+		rtl = false,
+		virtual = false,
+		focusItemOnOpen = 'auto',
+		focusItemOnHover = true,
+		openOnArrowKeyDown = true,
+		disabledIndices = undefined,
+		orientation = 'vertical',
+		parentOrientation,
+		id,
+		resetOnPointerLeave = true,
+		externalTree,
+		grid: navigateGrid,
+	} = props;
+	const isGrid = navigateGrid != null;
+
+	const store = (context && 'rootStore' in context ? context.rootStore : context) as any;
+
+	const open = store.useState('open', subSlot(slot, 'open'));
+	const floatingElement = store.useState('floatingElement', subSlot(slot, 'fel'));
+	const domReferenceElement = store.useState('domReferenceElement', subSlot(slot, 'drel'));
+
+	const dataRef = store.context.dataRef;
+
+	const floatingFocusElement = getFloatingFocusElement(floatingElement);
+	const typeableComboboxReference = isTypeableCombobox(domReferenceElement);
+	const floatingFocusElementRef = useValueAsRef<HTMLElement | null>(
+		floatingFocusElement,
+		subSlot(slot, 'ffe'),
+	);
+
+	const parentId = useFloatingParentNodeId();
+	const tree = useFloatingTree(externalTree);
+
+	const focusItemOnOpenRef = useRef(focusItemOnOpen, subSlot(slot, 'fioo'));
+	const indexRef = useRef(selectedIndex ?? -1, subSlot(slot, 'index'));
+	const keyRef = useRef<null | string>(null, subSlot(slot, 'key'));
+	const isPointerModalityRef = useRef(true, subSlot(slot, 'ipm'));
+
+	const onNavigate = useStableCallback(
+		(event?: Event) => {
+			onNavigateProp?.(indexRef.current === -1 ? null : indexRef.current, event);
+		},
+		subSlot(slot, 'on'),
+	);
+
+	const previousMountedRef = useRef(!!floatingElement, subSlot(slot, 'pm'));
+	const previousOpenRef = useRef(open, subSlot(slot, 'po'));
+	const forceSyncFocusRef = useRef(false, subSlot(slot, 'fsf'));
+	const forceScrollIntoViewRef = useRef(false, subSlot(slot, 'fsiv'));
+	const cancelQueuedFocusRef = useRef<(() => void) | null>(null, subSlot(slot, 'cqf'));
+
+	const disabledIndicesRef = useValueAsRef<DisabledIndices | undefined>(
+		disabledIndices,
+		subSlot(slot, 'dir'),
+	);
+	const latestOpenRef = useValueAsRef<boolean>(open, subSlot(slot, 'lo'));
+	const selectedIndexRef = useValueAsRef<number | null>(selectedIndex, subSlot(slot, 'si'));
+	const resetOnPointerLeaveRef = useValueAsRef<boolean>(resetOnPointerLeave, subSlot(slot, 'ropl'));
+
+	const focusFrame = useAnimationFrame(subSlot(slot, 'ff'));
+	const waitForListPopulatedFrame = useAnimationFrame(subSlot(slot, 'wflp'));
+
+	const focusItem = useStableCallback(
+		() => {
+			function runFocus(itemElement: HTMLElement) {
+				if (virtual) {
+					tree?.events.emit('virtualfocus', itemElement);
+				} else {
+					cancelQueuedFocusRef.current = enqueueFocus(itemElement, {
+						sync: forceSyncFocusRef.current,
+						preventScroll: true,
+					});
+				}
+			}
+
+			const initialItem = listRef.current[indexRef.current];
+			const forceScrollIntoView = forceScrollIntoViewRef.current;
+
+			if (initialItem) {
+				runFocus(initialItem);
+			}
+
+			const scheduler = forceSyncFocusRef.current
+				? (callback: () => void) => callback()
+				: (callback: () => void) => focusFrame.request(callback);
+
+			scheduler(() => {
+				const waitedItem = listRef.current[indexRef.current] || initialItem;
+
+				if (!waitedItem) {
+					return;
+				}
+
+				if (!initialItem) {
+					runFocus(waitedItem);
+				}
+
+				// `item` is the prop bag declared further down; by the time this runs (from a layout
+				// effect or an event handler) it is always initialized, so this is upstream's
+				// truthiness guard verbatim.
+				const shouldScrollIntoView =
+					// eslint-disable-next-line @typescript-eslint/no-use-before-define
+					item && (forceScrollIntoView || !isPointerModalityRef.current);
+
+				if (shouldScrollIntoView) {
+					// JSDOM doesn't support `.scrollIntoView()` but it's widely supported
+					// by all browsers.
+					waitedItem.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
+				}
+			});
+		},
+		subSlot(slot, 'fi'),
+	);
+
+	useLayoutEffect(
+		() => {
+			dataRef.current.orientation = orientation;
+		},
+		[dataRef, orientation],
+		subSlot(slot, 'e:orientation'),
+	);
+
+	// Sync `selectedIndex` to be the `activeIndex` upon opening the floating
+	// element. Also, reset `activeIndex` upon closing the floating element.
+	useLayoutEffect(
+		() => {
+			if (!enabled) {
+				return;
+			}
+
+			if (open && floatingElement) {
+				indexRef.current = selectedIndex ?? -1;
+				if (focusItemOnOpenRef.current && selectedIndex != null) {
+					// Regardless of the pointer modality, we want to ensure the selected
+					// item comes into view when the floating element is opened.
+					forceScrollIntoViewRef.current = true;
+					onNavigate();
+				}
+			} else if (previousMountedRef.current) {
+				// Reset the active index when the list is no longer open and mounted (closing or
+				// unmounting). `onNavigate` is a stable callback that always forwards to the latest
+				// `onNavigate` prop.
+				indexRef.current = -1;
+				onNavigate();
+			}
+		},
+		[enabled, open, floatingElement, selectedIndex, onNavigate],
+		subSlot(slot, 'e:syncSelected'),
+	);
+
+	// Sync `activeIndex` to be the focused item while the floating element is
+	// open.
+	useLayoutEffect(
+		() => {
+			if (!enabled) {
+				return;
+			}
+			if (!open) {
+				forceSyncFocusRef.current = false;
+				return;
+			}
+			if (!floatingElement) {
+				return;
+			}
+
+			if (activeIndex == null) {
+				forceSyncFocusRef.current = false;
+
+				if (selectedIndexRef.current != null) {
+					return;
+				}
+
+				// Reset while the floating element was open (e.g. the list changed).
+				if (previousMountedRef.current) {
+					indexRef.current = -1;
+					focusItem();
+				}
+
+				// Initial sync.
+				if (
+					(!previousOpenRef.current || !previousMountedRef.current) &&
+					focusItemOnOpenRef.current &&
+					(keyRef.current != null ||
+						(focusItemOnOpenRef.current === true && keyRef.current == null))
+				) {
+					let runs = 0;
+					const waitForListPopulated = () => {
+						if (listRef.current[0] == null) {
+							// Avoid letting the browser paint if possible on the first try,
+							// otherwise use rAF. Don't try more than twice, since something
+							// is wrong otherwise.
+							if (runs < 2) {
+								const scheduler = runs
+									? (callback: () => void) => waitForListPopulatedFrame.request(callback)
+									: queueMicrotask;
+								scheduler(waitForListPopulated);
+							}
+							runs += 1;
+						} else {
+							// Initially focus the first non-disabled item. `disabledIndices` is deliberately
+							// omitted here so attribute-disabled items (`disabled`/`aria-disabled`) are skipped
+							// on open even when the consumer passes an empty `disabledIndices` array. Passing it
+							// would regress that behavior (see mui/base-ui#2604).
+							indexRef.current =
+								keyRef.current == null ||
+								isMainOrientationToEndKey(keyRef.current, orientation, rtl) ||
+								nested
+									? getMinListIndex(listRef)
+									: getMaxListIndex(listRef);
+							keyRef.current = null;
+							onNavigate();
+						}
+					};
+
+					waitForListPopulated();
+				}
+			} else if (!isIndexOutOfListBounds(listRef.current, activeIndex)) {
+				indexRef.current = activeIndex;
+				focusItem();
+				forceScrollIntoViewRef.current = false;
+			}
+		},
+		[
+			enabled,
+			open,
+			floatingElement,
+			activeIndex,
+			selectedIndexRef,
+			nested,
+			listRef,
+			orientation,
+			rtl,
+			onNavigate,
+			focusItem,
+			waitForListPopulatedFrame,
+		],
+		subSlot(slot, 'e:syncActive'),
+	);
+
+	// Ensure the parent floating element has focus when a nested child closes
+	// to allow arrow key navigation to work after the pointer leaves the child.
+	useLayoutEffect(
+		() => {
+			if (!enabled || floatingElement || !tree || virtual || !previousMountedRef.current) {
+				return;
+			}
+
+			const nodes = tree.nodesRef.current;
+			const parent = nodes.find((node) => node.id === parentId)?.context?.elements.floating;
+			// `floatingElement` is null here (see the guard above), so resolve the owner document from an
+			// in-DOM element for realm-safety (shadow DOM/iframes): the reference element, falling back to
+			// the parent floating element when the reference is virtual (`domReferenceElement` is null).
+			const activeEl = activeElement(ownerDocument(domReferenceElement ?? parent ?? null));
+			const treeContainsActiveEl = nodes.some(
+				(node) => node.context && contains(node.context.elements.floating, activeEl),
+			);
+
+			if (parent && !treeContainsActiveEl && isPointerModalityRef.current) {
+				parent.focus({ preventScroll: true });
+			}
+		},
+		[enabled, floatingElement, domReferenceElement, tree, parentId, virtual],
+		subSlot(slot, 'e:parentFocus'),
+	);
+
+	useLayoutEffect(
+		() => {
+			previousOpenRef.current = open;
+			previousMountedRef.current = !!floatingElement;
+		},
+		undefined,
+		subSlot(slot, 'e:previous'),
+	);
+
+	useLayoutEffect(
+		() => {
+			if (!open) {
+				keyRef.current = null;
+				focusItemOnOpenRef.current = focusItemOnOpen;
+			}
+		},
+		[open, focusItemOnOpen],
+		subSlot(slot, 'e:resetKey'),
+	);
+
+	const hasActiveIndex = activeIndex != null;
+
+	const syncCurrentTarget = useStableCallback(
+		(event: any) => {
+			if (!latestOpenRef.current) {
+				return;
+			}
+
+			const index = listRef.current.indexOf(event.currentTarget);
+			if (index !== -1 && (indexRef.current !== index || activeIndex !== index)) {
+				indexRef.current = index;
+				onNavigate(event);
+			}
+		},
+		subSlot(slot, 'sct'),
+	);
+
+	const getParentOrientation = useStableCallback(
+		(): ListOrientation | undefined => {
+			return (
+				parentOrientation ??
+				(tree?.nodesRef.current.find((node) => node.id === parentId)?.context?.dataRef?.current
+					.orientation as ListOrientation | undefined)
+			);
+		},
+		subSlot(slot, 'gpo'),
+	);
+
+	const getMinEnabledIndex = useStableCallback(
+		() => {
+			return getMinListIndex(listRef, disabledIndicesRef.current);
+		},
+		subSlot(slot, 'gmei'),
+	);
+
+	const commonOnKeyDown = useStableCallback(
+		(event: any) => {
+			isPointerModalityRef.current = false;
+			forceSyncFocusRef.current = true;
+
+			// When composing a character, Chrome fires ArrowDown twice. Firefox/Safari
+			// don't appear to suffer from this. `event.isComposing` is avoided due to
+			// Safari not supporting it properly (although it's not needed in the first
+			// place for Safari, just avoiding any possible issues).
+			if (event.which === 229) {
+				return;
+			}
+
+			// If the floating element is animating out, ignore navigation. Otherwise,
+			// the `activeIndex` gets set to 0 despite not being open so the next time
+			// the user ArrowDowns, the first item won't be focused.
+			if (!latestOpenRef.current && event.currentTarget === floatingFocusElementRef.current) {
+				return;
+			}
+
+			if (nested && isCrossOrientationCloseKey(event.key, orientation, rtl, isGrid)) {
+				// If the nested list's close key is also the parent navigation key,
+				// let the parent navigate. Otherwise, stop propagating the event.
+				if (!isMainOrientationKey(event.key, getParentOrientation())) {
+					stopEvent(event);
+				}
+
+				store.setOpen(false, createChangeEventDetails(REASONS.listNavigation, event));
+
+				if (isHTMLElement(domReferenceElement)) {
+					if (virtual) {
+						tree?.events.emit('virtualfocus', domReferenceElement);
+					} else {
+						domReferenceElement.focus();
+					}
+				}
+
+				return;
+			}
+
+			const currentIndex = indexRef.current;
+			const minIndex = getMinListIndex(listRef, disabledIndices);
+			const maxIndex = getMaxListIndex(listRef, disabledIndices);
+
+			if (!typeableComboboxReference) {
+				if (event.key === 'Home') {
+					stopEvent(event);
+					indexRef.current = minIndex;
+					onNavigate(event);
+				}
+
+				if (event.key === 'End') {
+					stopEvent(event);
+					indexRef.current = maxIndex;
+					onNavigate(event);
+				}
+			}
+
+			// Grid navigation is injected by grid-capable consumers so non-grid
+			// consumers (menu, select) tree-shake the grid helpers out.
+			if (navigateGrid != null) {
+				const index = navigateGrid(
+					event,
+					indexRef.current,
+					listRef,
+					orientation,
+					loopFocus,
+					rtl,
+					disabledIndices,
+					minIndex,
+					maxIndex,
+				);
+
+				if (index != null) {
+					indexRef.current = index;
+					onNavigate(event);
+				}
+
+				if (orientation === 'both') {
+					return;
+				}
+			}
+
+			if (isMainOrientationKey(event.key, orientation)) {
+				stopEvent(event);
+
+				// Reset the index if no item is focused.
+				if (
+					open &&
+					!virtual &&
+					activeElement(event.currentTarget.ownerDocument) === event.currentTarget
+				) {
+					indexRef.current = isMainOrientationToEndKey(event.key, orientation, rtl)
+						? minIndex
+						: maxIndex;
+					onNavigate(event);
+					return;
+				}
+
+				if (isMainOrientationToEndKey(event.key, orientation, rtl)) {
+					if (loopFocus) {
+						if (currentIndex >= maxIndex) {
+							if (allowEscape && currentIndex !== listRef.current.length) {
+								indexRef.current = -1;
+							} else {
+								// Give time for virtualizers to update the listRef.
+								forceSyncFocusRef.current = false;
+								indexRef.current = minIndex;
+							}
+						} else {
+							indexRef.current = findNonDisabledListIndex(listRef.current, {
+								startingIndex: currentIndex,
+								disabledIndices,
+							});
+						}
+					} else {
+						indexRef.current = Math.min(
+							maxIndex,
+							findNonDisabledListIndex(listRef.current, {
+								startingIndex: currentIndex,
+								disabledIndices,
+							}),
+						);
+					}
+				} else if (loopFocus) {
+					if (currentIndex <= minIndex) {
+						if (allowEscape && currentIndex !== -1) {
+							indexRef.current = listRef.current.length;
+						} else {
+							// Give time for virtualizers to update the listRef.
+							forceSyncFocusRef.current = false;
+							indexRef.current = maxIndex;
+						}
+					} else {
+						indexRef.current = findNonDisabledListIndex(listRef.current, {
+							startingIndex: currentIndex,
+							decrement: true,
+							disabledIndices,
+						});
+					}
+				} else {
+					indexRef.current = Math.max(
+						minIndex,
+						findNonDisabledListIndex(listRef.current, {
+							startingIndex: currentIndex,
+							decrement: true,
+							disabledIndices,
+						}),
+					);
+				}
+
+				if (isIndexOutOfListBounds(listRef.current, indexRef.current)) {
+					indexRef.current = -1;
+				}
+
+				onNavigate(event);
+			}
+		},
+		subSlot(slot, 'cokd'),
+	);
+
+	const item = useMemo(
+		() => {
+			const itemProps: ElementProps['item'] = {
+				onFocus(event: any) {
+					forceSyncFocusRef.current = true;
+					syncCurrentTarget(event);
+				},
+				onClick: ({ currentTarget }: any) => currentTarget.focus({ preventScroll: true }), // Safari
+				onMouseMove(event: any) {
+					forceSyncFocusRef.current = true;
+					forceScrollIntoViewRef.current = false;
+					if (focusItemOnHover) {
+						syncCurrentTarget(event);
+					}
+				},
+				onPointerLeave(event: any) {
+					if (
+						!latestOpenRef.current ||
+						!isPointerModalityRef.current ||
+						event.pointerType === 'touch'
+					) {
+						return;
+					}
+
+					forceSyncFocusRef.current = true;
+
+					const relatedTarget = event.relatedTarget as HTMLElement | null;
+
+					if (!focusItemOnHover || listRef.current.includes(relatedTarget)) {
+						return;
+					}
+
+					if (!resetOnPointerLeaveRef.current) {
+						return;
+					}
+
+					cancelQueuedFocusRef.current?.();
+					cancelQueuedFocusRef.current = null;
+
+					indexRef.current = -1;
+					onNavigate(event);
+
+					if (!virtual) {
+						const floatingFocusEl = floatingFocusElementRef.current;
+						const activeEl = activeElement(ownerDocument(floatingFocusEl));
+						if (floatingFocusEl && contains(floatingFocusEl, activeEl)) {
+							floatingFocusEl.focus({ preventScroll: true });
+						}
+					}
+				},
+			};
+
+			return itemProps;
+		},
+		[
+			syncCurrentTarget,
+			latestOpenRef,
+			floatingFocusElementRef,
+			focusItemOnHover,
+			listRef,
+			onNavigate,
+			resetOnPointerLeaveRef,
+			virtual,
+		],
+		subSlot(slot, 'item'),
+	);
+
+	const ariaActiveDescendantProp = useMemo(
+		() => {
+			return (
+				virtual &&
+				open &&
+				hasActiveIndex && {
+					'aria-activedescendant': `${id}-${activeIndex}`,
+				}
+			);
+		},
+		[virtual, open, hasActiveIndex, id, activeIndex],
+		subSlot(slot, 'aad'),
+	);
+
+	const floating: ElementProps['floating'] = useMemo(
+		() => {
+			return {
+				'aria-orientation': orientation === 'both' ? undefined : orientation,
+				...(!typeableComboboxReference ? ariaActiveDescendantProp : {}),
+				onKeyDown(event: any) {
+					// Close submenu on Shift+Tab
+					if (event.key === 'Tab' && event.shiftKey && open && !virtual) {
+						// If the event originated from within a nested element (e.g., a Dialog opened from
+						// within the menu), don't close the menu. The nested element has its own focus
+						// management and should handle the Tab key.
+						const target = getTarget(event) as Element | null;
+						if (target && !contains(floatingFocusElementRef.current, target)) {
+							return;
+						}
+
+						stopEvent(event);
+						store.setOpen(false, createChangeEventDetails(REASONS.focusOut, event));
+
+						if (isHTMLElement(domReferenceElement)) {
+							domReferenceElement.focus();
+						}
+
+						return;
+					}
+
+					commonOnKeyDown(event);
+				},
+				onPointerMove() {
+					isPointerModalityRef.current = true;
+				},
+			};
+		},
+		[
+			ariaActiveDescendantProp,
+			commonOnKeyDown,
+			floatingFocusElementRef,
+			orientation,
+			typeableComboboxReference,
+			store,
+			open,
+			virtual,
+			domReferenceElement,
+		],
+		subSlot(slot, 'floating'),
+	);
+
+	const trigger: ElementProps['trigger'] = useMemo(
+		() => {
+			function openOnNavigationKeyDown(event: any) {
+				store.setOpen(
+					true,
+					createChangeEventDetails(
+						REASONS.listNavigation,
+						event,
+						event.currentTarget as HTMLElement,
+					),
+				);
+			}
+
+			function checkVirtualMouse(event: any) {
+				if (focusItemOnOpen === 'auto' && isVirtualClick(event)) {
+					focusItemOnOpenRef.current = !virtual;
+				}
+			}
+
+			function checkVirtualPointer(event: any) {
+				// `pointerdown` fires first, reset the state then perform the checks.
+				focusItemOnOpenRef.current = focusItemOnOpen;
+				if (focusItemOnOpen === 'auto' && isVirtualPointerEvent(event)) {
+					focusItemOnOpenRef.current = true;
+				}
+			}
+
+			return {
+				onKeyDown(event: any) {
+					// non-reactive open state (to prevent re-creation of the handler)
+					const currentOpen = store.select('open');
+					isPointerModalityRef.current = false;
+
+					const isArrowKey = event.key.startsWith('Arrow');
+					const isParentCrossOpenKey = isCrossOrientationOpenKey(
+						event.key,
+						getParentOrientation(),
+						rtl,
+					);
+					const isMainKey = isMainOrientationKey(event.key, orientation);
+					const isNavigationKey =
+						(nested ? isParentCrossOpenKey : isMainKey) ||
+						event.key === 'Enter' ||
+						event.key.trim() === '';
+
+					if (virtual && currentOpen) {
+						return commonOnKeyDown(event);
+					}
+
+					// If a floating element should not open on arrow key down, avoid
+					// setting `activeIndex` while it's closed.
+					if (!currentOpen && !openOnArrowKeyDown && isArrowKey) {
+						return undefined;
+					}
+
+					if (isNavigationKey) {
+						const isParentMainKey = isMainOrientationKey(event.key, getParentOrientation());
+						keyRef.current = nested && isParentMainKey ? null : event.key;
+					}
+
+					if (nested) {
+						if (isParentCrossOpenKey) {
+							stopEvent(event);
+
+							if (currentOpen) {
+								indexRef.current = getMinEnabledIndex();
+								onNavigate(event);
+							} else {
+								openOnNavigationKeyDown(event);
+							}
+						}
+
+						return undefined;
+					}
+
+					if (isMainKey) {
+						if (selectedIndexRef.current != null) {
+							indexRef.current = selectedIndexRef.current;
+						}
+
+						stopEvent(event);
+
+						if (!currentOpen && openOnArrowKeyDown) {
+							openOnNavigationKeyDown(event);
+						} else {
+							commonOnKeyDown(event);
+						}
+
+						if (currentOpen) {
+							onNavigate(event);
+						}
+					}
+
+					return undefined;
+				},
+				onFocus(event: any) {
+					if (store.select('open') && !virtual) {
+						indexRef.current = -1;
+						onNavigate(event);
+					}
+				},
+				onPointerDown: checkVirtualPointer,
+				onPointerEnter: checkVirtualPointer,
+				onMouseDown: checkVirtualMouse,
+				onClick: checkVirtualMouse,
+			};
+		},
+		[
+			commonOnKeyDown,
+			focusItemOnOpen,
+			getMinEnabledIndex,
+			nested,
+			onNavigate,
+			store,
+			openOnArrowKeyDown,
+			orientation,
+			getParentOrientation,
+			rtl,
+			selectedIndexRef,
+			virtual,
+		],
+		subSlot(slot, 'trigger'),
+	);
+
+	const reference: ElementProps['reference'] = useMemo(
+		() => {
+			return {
+				...ariaActiveDescendantProp,
+				...trigger,
+			};
+		},
+		[ariaActiveDescendantProp, trigger],
+		subSlot(slot, 'ref'),
+	);
+
+	return useMemo(
+		() => (enabled ? { reference, floating, item, trigger } : {}),
+		[enabled, reference, floating, trigger, item],
+		subSlot(slot, 'out'),
+	);
+}

--- a/packages/base-ui/src/utils/floating/useTypeahead.ts
+++ b/packages/base-ui/src/utils/floating/useTypeahead.ts
@@ -1,0 +1,287 @@
+// Ported from .base-ui/packages/react/src/floating-ui-react/hooks/useTypeahead.ts (v1.6.0). Matches
+// list items as the user types, the way a native `<select>` does — usually paired with
+// `useListNavigation`. Returns an `ElementProps` bag whose `onKeyDown`/`onBlur` the reference and
+// the floating element both merge.
+//
+// octane adaptations: handlers receive the NATIVE event, so `event.nativeEvent` collapses to
+// `event`; `useIsoLayoutEffect` is octane's `useLayoutEffect`; every composed hook threads an
+// explicit slot.
+//
+// SLOT: plain-`.ts` hook; the trailing arg is the caller's slot.
+import { useLayoutEffect, useMemo, useRef } from 'octane';
+
+import { S, splitSlot, subSlot } from '../../internal';
+import { EMPTY_ARRAY } from '../empty';
+import { useStableCallback } from '../useStableCallback';
+import { useTimeout } from '../useTimeout';
+import { isListIndexDisabled, stopEvent, type DisabledIndices } from '../composite/list-utils';
+import { isElementVisible } from './composite';
+import { contains } from './element';
+import type { ElementProps, FloatingContext, FloatingRootContext } from './types';
+
+export interface UseTypeaheadProps {
+	/**
+	 * A ref which contains an array of strings whose indices match the HTML
+	 * elements of the list.
+	 * @default empty list
+	 */
+	listRef: { current: Array<string | null> };
+	/**
+	 * The index of the active (focused or highlighted) item in the list.
+	 * @default null
+	 */
+	activeIndex: number | null;
+	/**
+	 * Callback invoked with the matching index if found as the user types.
+	 */
+	onMatch?: ((index: number) => void) | undefined;
+	/**
+	 * Optional list of item elements that correspond to `listRef` indices.
+	 * When an element exists for an index, typeahead skips it if it is hidden by
+	 * `display: none`, `visibility: hidden|collapse`, or other
+	 * browser-reported visibility checks.
+	 */
+	elementsRef?: { current: Array<HTMLElement | null> } | undefined;
+	/**
+	 * Indices that are disabled, either as an array or a predicate (the same shape as
+	 * `useListNavigation`'s `disabledIndices`). Disabled items are skipped while matching,
+	 * so a single keypress advances to the next selectable item (matching native `<select>`
+	 * and arrow-key navigation). The disabled check doesn't read `elementsRef`, so consumers
+	 * whose items stay mounted-but-hidden while closed can still skip disabled items without
+	 * passing `elementsRef`.
+	 */
+	disabledIndices?: DisabledIndices | undefined;
+	/**
+	 * Callback invoked with the current typing activity as the user types.
+	 */
+	onTyping?: ((isTyping: boolean) => void) | undefined;
+	/**
+	 * Whether the hook is enabled, including all internal effects and event
+	 * handlers.
+	 * @default true
+	 */
+	enabled?: boolean | undefined;
+	/**
+	 * The number of milliseconds to wait before resetting the typed string.
+	 * @default 750
+	 */
+	resetMs?: number | undefined;
+	/**
+	 * The index of the selected item in the list, if available.
+	 * @default null
+	 */
+	selectedIndex?: number | null | undefined;
+}
+
+/**
+ * Provides a matching callback that can be used to focus an item as the user
+ * types, often used in tandem with `useListNavigation()`.
+ * @see https://floating-ui.com/docs/useTypeahead
+ */
+export function useTypeahead(...args: any[]): ElementProps {
+	const [user, slotArg] = splitSlot(args);
+	const slot = slotArg ?? S('useTypeahead');
+	const context = user[0] as FloatingRootContext | FloatingContext;
+	const props = user[1] as UseTypeaheadProps;
+
+	const {
+		listRef,
+		elementsRef,
+		activeIndex,
+		onMatch: onMatchProp,
+		disabledIndices,
+		onTyping,
+		enabled = true,
+		resetMs = 750,
+		selectedIndex = null,
+	} = props;
+
+	const store = (context && 'rootStore' in context ? context.rootStore : context) as any;
+
+	const open = store.useState('open', subSlot(slot, 'open'));
+
+	const timeout = useTimeout(subSlot(slot, 'to'));
+	const stringRef = useRef('', subSlot(slot, 'str'));
+	const prevIndexRef = useRef<number | null>(
+		selectedIndex ?? activeIndex ?? -1,
+		subSlot(slot, 'prev'),
+	);
+	const matchIndexRef = useRef<number | null>(null, subSlot(slot, 'match'));
+
+	const onKeyDown = useStableCallback(
+		(event: KeyboardEvent) => {
+			function isVisible(index: number) {
+				const element = elementsRef?.current[index];
+				return !element || isElementVisible(element);
+			}
+
+			function isItemAvailable(index: number) {
+				if (!isVisible(index)) {
+					return false;
+				}
+				// Visibility is handled above; pass an empty element list so `isListIndexDisabled`
+				// resolves only the explicit `disabledIndices` (array/predicate) and skips its own
+				// visibility/attribute fallbacks. Consumers that don't opt in keep matching every
+				// visible item.
+				return disabledIndices == null || !isListIndexDisabled(EMPTY_ARRAY, index, disabledIndices);
+			}
+
+			function getMatchingIndex(list: Array<string | null>, string: string, startIndex = 0) {
+				if (list.length === 0) {
+					return -1;
+				}
+
+				const normalizedStartIndex = ((startIndex % list.length) + list.length) % list.length;
+				const lowerString = string.toLowerCase();
+
+				for (let offset = 0; offset < list.length; offset += 1) {
+					const index = (normalizedStartIndex + offset) % list.length;
+					const text = list[index];
+					if (!text?.toLowerCase().startsWith(lowerString) || !isItemAvailable(index)) {
+						continue;
+					}
+					return index;
+				}
+				return -1;
+			}
+
+			const listContent = listRef.current;
+
+			if (stringRef.current.length > 0 && event.key === ' ') {
+				// Space should continue the in-progress typeahead session.
+				stopEvent(event);
+				onTyping?.(true);
+			}
+
+			if (stringRef.current.length > 0 && stringRef.current[0] !== ' ') {
+				if (getMatchingIndex(listContent, stringRef.current) === -1 && event.key !== ' ') {
+					onTyping?.(false);
+				}
+			}
+
+			if (
+				listContent == null ||
+				// Character key.
+				event.key.length !== 1 ||
+				// Modifier key.
+				event.ctrlKey ||
+				event.metaKey ||
+				event.altKey
+			) {
+				return;
+			}
+
+			if (open && event.key !== ' ') {
+				stopEvent(event);
+				onTyping?.(true);
+			}
+
+			// Capture whether this is a new typing session before mutating the string.
+			const isNewSession = stringRef.current === '';
+			if (isNewSession) {
+				prevIndexRef.current = selectedIndex ?? activeIndex ?? -1;
+			}
+
+			// Bail out if the list contains a word like "llama" or "aaron". TODO:
+			// allow it in this case, too. Unavailable items are skipped while matching, so
+			// they must be ignored here as well — otherwise a hidden or disabled double-letter
+			// label would block rapid cycling through the available items.
+			const allowRapidSuccessionOfFirstLetter = listContent.every((text, index) =>
+				text && isItemAvailable(index) ? text[0]?.toLowerCase() !== text[1]?.toLowerCase() : true,
+			);
+
+			// Allows the user to cycle through items that start with the same letter
+			// in rapid succession.
+			if (allowRapidSuccessionOfFirstLetter && stringRef.current === event.key) {
+				stringRef.current = '';
+				prevIndexRef.current = matchIndexRef.current;
+			}
+
+			stringRef.current += event.key;
+			timeout.start(resetMs, () => {
+				stringRef.current = '';
+				prevIndexRef.current = matchIndexRef.current;
+				onTyping?.(false);
+			});
+
+			// Compute the starting index for this search.
+			// If this is a new typing session (string is empty), base it on the current
+			// selection/active item; otherwise continue from the last matched index.
+			const prevIndex = isNewSession ? (selectedIndex ?? activeIndex ?? -1) : prevIndexRef.current;
+			const startIndex = (prevIndex ?? 0) + 1;
+
+			const index = getMatchingIndex(listContent, stringRef.current, startIndex);
+
+			if (index !== -1) {
+				onMatchProp?.(index);
+				matchIndexRef.current = index;
+			} else if (event.key !== ' ') {
+				stringRef.current = '';
+				onTyping?.(false);
+			}
+		},
+		subSlot(slot, 'okd'),
+	);
+
+	const onBlur = useStableCallback(
+		(event: FocusEvent) => {
+			const next = event.relatedTarget as Element | null;
+			const currentDomReferenceElement = store.select('domReferenceElement');
+			const currentFloatingElement = store.select('floatingElement');
+			const withinComposite =
+				contains(currentDomReferenceElement, next) || contains(currentFloatingElement, next);
+
+			// Keep the session if focus moves within the composite (reference <-> floating).
+			if (withinComposite) {
+				return;
+			}
+
+			// End the current typing session when focus leaves the composite entirely.
+			timeout.clear();
+			stringRef.current = '';
+			prevIndexRef.current = matchIndexRef.current;
+			onTyping?.(false);
+		},
+		subSlot(slot, 'ob'),
+	);
+
+	useLayoutEffect(
+		() => {
+			if (!open && selectedIndex !== null) {
+				return;
+			}
+
+			timeout.clear();
+			matchIndexRef.current = null;
+
+			if (stringRef.current !== '') {
+				stringRef.current = '';
+			}
+		},
+		[open, selectedIndex, timeout],
+		subSlot(slot, 'e:reset'),
+	);
+
+	useLayoutEffect(
+		() => {
+			// Sync arrow key navigation but not typeahead navigation.
+			if (open && stringRef.current === '') {
+				prevIndexRef.current = selectedIndex ?? activeIndex ?? -1;
+			}
+		},
+		[open, selectedIndex, activeIndex],
+		subSlot(slot, 'e:sync'),
+	);
+
+	const sharedProps = useMemo(
+		() => ({ onKeyDown, onBlur }),
+		[onKeyDown, onBlur],
+		subSlot(slot, 'shared'),
+	);
+
+	return useMemo(
+		() => (enabled ? { reference: sharedProps, floating: sharedProps } : {}),
+		[enabled, sharedProps],
+		subSlot(slot, 'out'),
+	);
+}

--- a/packages/base-ui/src/utils/getPseudoElementBounds.ts
+++ b/packages/base-ui/src/utils/getPseudoElementBounds.ts
@@ -1,0 +1,54 @@
+// Ported from .base-ui/packages/react/src/utils/getPseudoElementBounds.ts (v1.6.0). Returns an
+// element's bounding box widened to cover its `::before`/`::after` pseudo-elements, so hit-testing
+// (safe-polygon / mouse-tracking) accounts for decorations drawn outside the box.
+//
+// Pure — no renderer API is involved, so this is a straight transcription.
+import { ownerWindow } from './owner';
+import { platform } from './platform';
+
+interface ElementBounds {
+	left: number;
+	right: number;
+	top: number;
+	bottom: number;
+}
+
+export function getPseudoElementBounds(element: HTMLElement): ElementBounds {
+	const elementRect = element.getBoundingClientRect();
+	const win = ownerWindow(element);
+
+	// Avoid "Not implemented: window.getComputedStyle(elt, pseudoElt)" in jsdom.
+	if (platform.env.jsdom) {
+		return elementRect;
+	}
+
+	const beforeStyles = win.getComputedStyle(element, '::before');
+	const afterStyles = win.getComputedStyle(element, '::after');
+
+	const hasPseudoElements = beforeStyles.content !== 'none' || afterStyles.content !== 'none';
+
+	if (!hasPseudoElements) {
+		return elementRect;
+	}
+
+	// Get dimensions of pseudo-elements
+	const beforeWidth = parseFloat(beforeStyles.width) || 0;
+	const beforeHeight = parseFloat(beforeStyles.height) || 0;
+	const afterWidth = parseFloat(afterStyles.width) || 0;
+	const afterHeight = parseFloat(afterStyles.height) || 0;
+
+	// Calculate max dimensions including pseudo-elements
+	const totalWidth = Math.max(elementRect.width, beforeWidth, afterWidth);
+	const totalHeight = Math.max(elementRect.height, beforeHeight, afterHeight);
+
+	// Calculate the differences to extend the bounds
+	const widthDiff = totalWidth - elementRect.width;
+	const heightDiff = totalHeight - elementRect.height;
+
+	return {
+		left: elementRect.left - widthDiff / 2,
+		right: elementRect.right + widthDiff / 2,
+		top: elementRect.top - heightDiff / 2,
+		bottom: elementRect.bottom + heightDiff / 2,
+	};
+}

--- a/packages/base-ui/src/utils/useMixedToggleClickHandler.ts
+++ b/packages/base-ui/src/utils/useMixedToggleClickHandler.ts
@@ -1,0 +1,77 @@
+// Ported from .base-ui/packages/react/src/utils/useMixedToggleClickHandler.ts (v1.6.0),
+// octane-adapted (slot-threaded; native events). Returns `click`/`mousedown` handlers for a trigger
+// whose popup is toggled by two different events — opened on mousedown, closed on click — so the
+// click that follows the opening mousedown does not immediately close the popup again.
+//
+// octane adaptations: events are NATIVE (not synthetic), so the handlers take the native event
+// and `preventBaseUIHandler` is the shim `mergeProps`/`makeEventPreventable` attaches to it.
+// Upstream's empty `UseMixedToggleClickHandlerState` interface is a docs-pipeline artifact with no
+// members, so it is dropped.
+//
+// SLOT: plain-`.ts` hook; the trailing arg is the caller's slot.
+import { useMemo, useRef } from 'octane';
+
+import { S, splitSlot, subSlot } from '../internal';
+import { EMPTY_OBJECT } from './empty';
+import { ownerDocument } from './owner';
+
+export interface UseMixedToggleClickHandlerParameters {
+	/**
+	 * Whether the mixed toggle click handler is enabled.
+	 * @default true
+	 */
+	enabled?: boolean | undefined;
+	/**
+	 * Determines what action is performed on mousedown.
+	 */
+	mouseDownAction: 'open' | 'close';
+	/**
+	 * The current open state of the popup.
+	 */
+	open: boolean;
+}
+
+export interface UseMixedToggleClickHandlerReturnValue {
+	onMouseDown?: (event: any) => void;
+	onClick?: (event: any) => void;
+}
+
+export function useMixedToggleClickHandler(...args: any[]): UseMixedToggleClickHandlerReturnValue {
+	const [user, slotArg] = splitSlot(args);
+	const slot = slotArg ?? S('useMixedToggleClickHandler');
+	const { enabled = true, mouseDownAction, open } = user[0] as UseMixedToggleClickHandlerParameters;
+
+	const ignoreClickRef = useRef(false, subSlot(slot, 'ignore'));
+
+	return useMemo(
+		() => {
+			if (!enabled) {
+				return EMPTY_OBJECT;
+			}
+
+			return {
+				onMouseDown: (event: any) => {
+					if ((mouseDownAction === 'open' && !open) || (mouseDownAction === 'close' && open)) {
+						ignoreClickRef.current = true;
+
+						ownerDocument(event.currentTarget as Element).addEventListener(
+							'click',
+							() => {
+								ignoreClickRef.current = false;
+							},
+							{ once: true },
+						);
+					}
+				},
+				onClick: (event: any) => {
+					if (ignoreClickRef.current) {
+						ignoreClickRef.current = false;
+						event.preventBaseUIHandler();
+					}
+				},
+			};
+		},
+		[enabled, mouseDownAction, open],
+		subSlot(slot, 'm'),
+	);
+}


### PR DESCRIPTION
## Summary

- Ports the whole of Base UI Phase 3e — the list-navigation and typeahead infrastructure — into `@octanejs/base-ui`, transcribed from Base UI 1.6.0.
- **Not for merge on its own.** Per the one-deliverable decision, this branch merges once the Menu family lands on top of it; Menu is the first real consumer and is what proves the infrastructure. Opened now so the infrastructure half is reviewable while Menu is ported onto the same branch.

## Why

3e is pure infrastructure with no consumer until Menu/Select/Combobox exist. Landing it alone would leave the differential rig nothing to render and no behavior test exercising it — the same shape as the `openOnHover` stub that sat inert and unflagged for months. Hence: review now, merge with Menu.

## Changes

**`useListNavigation`** (930 loc upstream) — arrow-key navigation over a list using either real DOM focus or virtual focus (`aria-activedescendant`), returning the `{ reference, floating, item, trigger }` bags Menu, Select and Combobox merge onto their parts. octane adaptations: reads the `FloatingRootStore` (`store.useState`/`select`/`setOpen`/`context`); events are native, so `event.nativeEvent` collapses to `event`; `useIsoLayoutEffect` is octane's `useLayoutEffect`, and because a plain-`.ts` hook is not compiled, an `undefined` dep array runs the effect every render, matching upstream's dep-less form; every composed hook threads an explicit sub-slot. The two dev-only `console.warn` misconfiguration guards are dropped — this package carries no `process.env.NODE_ENV` branches.

**Grid navigation** — `utils/composite/grid-utils.ts` holds the two-dimensional algorithm and the cell-map helpers, with the two `gridNavigation` entry points beside their consumers: `utils/floating/gridNavigation.ts` (the uniform 1x1 navigator `useListNavigation` injects into its own `grid` option) and `utils/composite/gridNavigation.ts` (the navigator a composite passes to `useCompositeRoot`). `grid` stays *injected* rather than imported, so a consumer that never passes it leaves the grid helpers out of its bundle entirely — that is the point of the injection. `useListNavigation` types the option as `GridNavigator`, which `gridNavigation` satisfies structurally.

**`useTypeahead`** — matches list items as the user types, the way a native `<select>` does; pairs with `useListNavigation`.

**Supporting utilities** — `TimeoutManager` (several keyed timeouts behind one handle, distinct from `useTimeout`'s single-timeout `Timeout`), `RequestQueue`, `getPseudoElementBounds`, `useMixedToggleClickHandler`.

**Upstream-drift fix (behavioral).** Porting `useListNavigation` exposed that the vendored list-navigation helpers in `utils/composite/list-utils.ts` had drifted from Base UI 1.6.0: `isListIndexDisabled` neither skipped invisible items nor kept the `disabled`/`aria-disabled` attribute fallback separate from an explicit `disabledIndices`. `useListNavigation` depends on that separation — it deliberately omits `disabledIndices` when choosing the item to focus on open so attribute-disabled items are still skipped for consumers passing an empty array (mui/base-ui#2604). `list-utils` now matches upstream's body and signatures (item array for the index helpers, ref for `getMinListIndex`/`getMaxListIndex`), and `useCompositeRoot` drops the `{ current }` wrappers it needed for the old shape. This changes the already-shipped composite roving focus — hidden items are now skipped — so it carries a patch changeset. `REASONS.listNavigation` was added alongside.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 13,937 tests / 1,399 files, all passing

## Risk / follow-ups

- **No tests for the new hooks yet, on purpose rather than by omission**: a differential test needs a rendered component, and the first one arrives with Menu. That is the reason this branch does not merge alone.
- The one behavioral change to already-shipped code is the `isListIndexDisabled` fidelity fix above; it is covered by the existing composite suite and carries a changeset.
- Follow-ons after Menu: Menubar (217 loc) and ContextMenu (433 loc, `useClientPoint` already ported) are cheap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large, accessibility-critical keyboard/focus surface with a behavioral change to existing composite navigation; risk is moderated because it tracks upstream 1.6.0 and has no Menu/Select consumer wired in this PR alone.
> 
> **Overview**
> **Phase 3e** brings Base UI’s floating list infrastructure into `@octanejs/base-ui`: **`useListNavigation`** (arrow keys, real or virtual focus via `aria-activedescendant`, `{ reference, floating, item, trigger }` prop bags) and **`useTypeahead`** (type-to-match, meant to pair with list navigation). Grid support is **opt-in via injection**—`grid-utils` plus separate `gridNavigation` factories for **`useCompositeRoot`** (multi-cell grids) and **`useListNavigation`** (uniform 1×1 grids)—so Menu/Select-style consumers can tree-shake the heavy grid code.
> 
> Also adds small upstream utilities: **`RequestQueue`**, **`TimeoutManager`**, **`getPseudoElementBounds`**, **`useMixedToggleClickHandler`**, and **`REASONS.listNavigation`** for open/close details.
> 
> **Shipped behavior change:** vendored **`list-utils`** now matches Base UI 1.6.0’s **`isListIndexDisabled`** (explicit `disabledIndices` wins; invisible items always skipped; `disabled`/`aria-disabled` only when no `disabledIndices` was passed). **`useCompositeRoot`** call sites were updated for array-based helpers—composite roving focus now skips non-visible items (patch changeset).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90b44ae58f0e3b35d9734feaa7c8c71351fb7bb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->