### PR TITLE
fix more ast node mappings

### DIFF
--- a/.changeset/attr-lowering-origins.md
+++ b/.changeset/attr-lowering-origins.md
@@ -1,0 +1,23 @@
+---
+'octane': patch
+---
+
+`compile({ inspect: true })` now claims an authored attribute NAME for the
+tokens that name the call the attribute lowered to, so navigation tooling can
+resolve a dynamic attribute in both directions.
+
+A static attribute is baked into template markup and the template's origins
+already carried it. A dynamic one has no markup at all — `<form action={fn}>`
+survives as `setFormAction(el, 'action', …)` / `ssrAttr("action", …)`, and
+`<input defaultValue={v}/>` as `setDefaultValueUncontrolled(el, v)`, which has
+no name token whatsoever — and every other token of those calls maps to the
+value expression. The authored name was therefore unreachable from the output:
+the helper is a different word and the name literal carries quotes, so neither
+reproduces the authored text a consumer accepts on an inferred attribution.
+
+Covers both emitters and every attribute that routes to a helper rather than to
+baked HTML: form actions, controlled and uncontrolled form props, `class`,
+`style`, `autoFocus`, boolean, ARIA, `data-*`, and the generic attribute path.
+
+Inspection-gated as before — the emitted module is byte-identical with and
+without `inspect`.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -327,6 +327,69 @@ function slotKeyLiteral(bind) {
 }
 
 /**
+ * The same problem for an attribute that never bakes into HTML. `action`,
+ * `defaultValue` and friends survive only as a runtime call — the client's
+ * `setFormAction(el, 'action', …)` / `setDefaultValueUncontrolled(el, v)`, the
+ * server's `ssrAttr("action", …)` / `ssrInputAttrs([[false, "defaultValue", …]])`
+ * — whose every other token maps to the VALUE expression. Template origins
+ * cover the baked case; nothing covered this one, so the authored name answered
+ * nothing forwards: the helper is a different word and the name literal carries
+ * quotes, so neither reproduces the authored text the forward index accepts on
+ * its own.
+ *
+ * Claims the name literal in both quotings the printers use (the client prints
+ * `b.literal` bare, the server supplies a JSON raw) plus, when the call belongs
+ * to this attribute alone, the helper alias. A helper SHARED by every attribute
+ * of the element — `ssrInputAttrs`, `ssrAttrs` — passes `null` instead: it is
+ * already anchored on the element, and re-anchoring it on one of its sources
+ * would make that source claim the whole group's lowering.
+ */
+function registerAttrLoweringOrigin(ctx, nameNode, helper, name) {
+	if (!ctx.inspect || !hasAuthoredOrigin(nameNode)) return;
+	const texts = [];
+	if (typeof helper === 'string') texts.push(`_$${helper}`);
+	if (typeof name === 'string' && name !== '') texts.push(`'${name}'`, `"${name}"`);
+	if (texts.length > 0) registerExactOrigin(ctx, nameNode, nameNode.end, texts);
+}
+
+/** The authored attribute name stamped on a token of the call it lowered to. */
+function attrLoweringToken(node, bind) {
+	return inheritOriginLoc(node, bind.nameOrigin ?? null);
+}
+
+/**
+ * The runtime helper an attribute binding lowers to, or `null` for a binding
+ * that is not one attribute's write (children, refs, spreads, the commit-phase
+ * source collectors). Single source of truth for the import the binding needs
+ * and for the token `registerAttrLoweringOrigin` claims; the mount/update cases
+ * call exactly these.
+ */
+function attrBindingHelper(bind) {
+	const controlled = CONTROLLED_KIND_HELPERS[bind.kind];
+	if (controlled !== undefined) return controlled;
+	switch (bind.kind) {
+		case 'attr':
+			return 'setAttribute';
+		case 'stringData':
+			return 'setStringData';
+		case 'booleanAttr':
+			return 'setBooleanAttribute';
+		case 'ariaAttr':
+			return 'setAriaAttribute';
+		case 'formAction':
+			return 'setFormAction';
+		case 'style':
+			return 'setStyle';
+		// SVG/MathML `className` is read-only — setClassAttr sets the attribute and
+		// clsx-composes (setClassName composes on HTML).
+		case 'class':
+			return bind.ns && bind.ns !== 'html' ? 'setClassAttr' : 'setClassName';
+		default:
+			return null;
+	}
+}
+
+/**
  * An ALIAS: an authored range that emits nothing of its own but means the same
  * thing as one that does. A component's closing tag is the case — `</Card>` is
  * pure syntax, while the opening name became the emitted component reference —
@@ -6964,7 +7027,14 @@ function ssrSourcePair(present, value, origin) {
 	return inheritOriginLoc(b.array([present, value]), origin);
 }
 
-function ssrDirectSource(name, value, origin) {
+/**
+ * One `[spread, name, value]` source row for a grouped attribute helper. The
+ * name literal is the only token in the group that names THIS attribute, so it
+ * is what the authored name is claimed against (see registerAttrLoweringOrigin);
+ * the helper itself stays anchored on the element it serializes.
+ */
+function ssrDirectSource(ctx, name, value, origin) {
+	registerAttrLoweringOrigin(ctx, origin?.name, null, name);
 	return inheritOriginLoc(
 		b.array([b.literal(false, 'false'), b.literal(name, JSON.stringify(name)), value]),
 		origin,
@@ -7440,7 +7510,7 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash, compone
 				// ultimately wins over its default. Besides preserving side effects,
 				// this lets spread snapshots run between surrounding direct writers.
 				const tmp = bindAttributeEvaluation(ctlExpr);
-				formControlSources.push(ssrDirectSource(attrName, tmp, attr));
+				formControlSources.push(ssrDirectSource(ctx, attrName, tmp, attr));
 				continue;
 			}
 			// textarea / select: value/defaultValue never serialize as attributes —
@@ -7456,7 +7526,7 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash, compone
 					formControlPart = parts.length;
 					parts.push('');
 				}
-				formControlSources.push(ssrDirectSource(attrName, ctlExpr, attr));
+				formControlSources.push(ssrDirectSource(ctx, attrName, ctlExpr, attr));
 			} else if (attrName === 'value') ctlValue = ctlExpr;
 			else ctlDefault = ctlExpr;
 			continue;
@@ -7475,7 +7545,7 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash, compone
 					formControlPart = parts.length;
 					parts.push('');
 				}
-				formControlSources.push(ssrDirectSource('multiple', multipleExpr, attr));
+				formControlSources.push(ssrDirectSource(ctx, 'multiple', multipleExpr, attr));
 				continue;
 			}
 			// Serialize the attribute normally AND capture the value for the
@@ -7500,6 +7570,7 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash, compone
 			selMultiple = tmp;
 			flush();
 			ctx.runtimeNeeded.add('ssrAttr');
+			registerAttrLoweringOrigin(ctx, attr.name, 'ssrAttr', 'multiple');
 			parts.push(
 				ssrCall(
 					'ssrAttr',
@@ -7524,7 +7595,7 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash, compone
 						? inheritOriginLoc(b.literal(true, 'true'), attr)
 						: tsrxExprNode(oInner, ctx, name, inlinedSubs),
 				);
-				attrSources.push(ssrDirectSource('value', optionExpr, attr));
+				attrSources.push(ssrDirectSource(ctx, 'value', optionExpr, attr));
 				continue;
 			}
 			// The option's value feeds BOTH the attribute and the select-scope
@@ -7548,6 +7619,7 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash, compone
 			optValue = tmp;
 			flush();
 			ctx.runtimeNeeded.add('ssrAttr');
+			registerAttrLoweringOrigin(ctx, attr.name, 'ssrAttr', 'value');
 			parts.push(
 				ssrCall(
 					'ssrAttr',
@@ -7575,7 +7647,7 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash, compone
 				);
 				attrExpr = tsrxExprNode(attrInner, ctx, name, inlinedSubs);
 			}
-			attrSources.push(ssrDirectSource(rawAttrName, bindAttributeEvaluation(attrExpr), attr));
+			attrSources.push(ssrDirectSource(ctx, rawAttrName, bindAttributeEvaluation(attrExpr), attr));
 			continue;
 		}
 
@@ -7585,6 +7657,7 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash, compone
 			if (ctx.dev && needsDevStaticAttrValidation(attrName, true, tag, selfNs)) {
 				flush();
 				ctx.runtimeNeeded.add('ssrAttr');
+				registerAttrLoweringOrigin(ctx, attr.name, 'ssrAttr', attrName);
 				parts.push(
 					ssrCall(
 						'ssrAttr',
@@ -7618,6 +7691,7 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash, compone
 			}
 			flush();
 			ctx.runtimeNeeded.add('ssrStyle');
+			registerAttrLoweringOrigin(ctx, attr.name, 'ssrStyle', null);
 			parts.push(
 				ssrCall(
 					'ssrStyle',
@@ -7655,6 +7729,7 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash, compone
 			flush();
 			ctx.runtimeNeeded.add('ssrAttr');
 			const outName = tag === 'form' ? 'action' : 'formaction';
+			registerAttrLoweringOrigin(ctx, attr.name, 'ssrAttr', outName);
 			const valueExpr = bindAttributeEvaluation(tsrxExprNode(inner, ctx, name, inlinedSubs));
 			const filteredValue = inheritOriginLoc(
 				b.call(
@@ -7688,6 +7763,7 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash, compone
 		// Dynamic attribute (or literal after a spread).
 		flush();
 		ctx.runtimeNeeded.add('ssrAttr');
+		registerAttrLoweringOrigin(ctx, attr.name, 'ssrAttr', attrName);
 		const valueExpr = bindAttributeEvaluation(tsrxExprNode(inner, ctx, name, inlinedSubs));
 		parts.push(
 			ssrCall(
@@ -15037,22 +15113,13 @@ function planJsx(
 		if (b.kind === 'text' || b.kind === 'textOnlyChild') ctx.runtimeNeeded.add('setText');
 		if (b.kind === 'text') ctx.runtimeNeeded.add('htextSwap');
 		if (b.kind === 'textOnlyChild') ctx.runtimeNeeded.add('htext');
-		if (b.kind === 'attr') ctx.runtimeNeeded.add('setAttribute');
-		if (b.kind === 'stringData') ctx.runtimeNeeded.add('setStringData');
-		if (b.kind === 'booleanAttr') ctx.runtimeNeeded.add('setBooleanAttribute');
-		if (b.kind === 'ariaAttr') ctx.runtimeNeeded.add('setAriaAttribute');
-		if (CONTROLLED_KIND_HELPERS[b.kind] !== undefined) {
-			ctx.runtimeNeeded.add(CONTROLLED_KIND_HELPERS[b.kind]);
+		// One resolution for both consumers: the import this binding needs, and
+		// the token the authored attribute name is claimed against.
+		const attrHelper = attrBindingHelper(b);
+		if (attrHelper !== null) {
+			ctx.runtimeNeeded.add(attrHelper);
+			registerAttrLoweringOrigin(ctx, b.nameOrigin, attrHelper, b.name);
 		}
-		if (b.kind === 'class') {
-			if (b.ns && b.ns !== 'html') {
-				// SVG/MathML `className` is read-only — use setClassAttr, which sets the
-				// attribute + clsx-composes (setClassName handles composition on HTML).
-				ctx.runtimeNeeded.add('setClassAttr');
-			} else ctx.runtimeNeeded.add('setClassName');
-		}
-		if (b.kind === 'style') ctx.runtimeNeeded.add('setStyle');
-		if (b.kind === 'formAction') ctx.runtimeNeeded.add('setFormAction');
 		if (b.kind === 'htmlOnlyChild') ctx.runtimeNeeded.add('setDangerouslySetInnerHTML');
 		if (b.kind === 'dangerCommit') ctx.runtimeNeeded.add('setDangerouslySetInnerHTMLSources');
 		if (b.kind === 'formCommit') ctx.runtimeNeeded.add('setFormControlSources');
@@ -16235,6 +16302,10 @@ function emitBindingMount(bind, elVar, bag) {
 	const el = () => hostVarNode(elVar);
 	const local = (key) => b.id(bag.local(key));
 	const V = () => b.id('_v');
+	// The tokens that NAME this binding's lowering carry the authored attribute
+	// name; everything else in the call maps to the value expression.
+	const callee = () => attrLoweringToken(b.id(`_$${attrBindingHelper(bind)}`), bind);
+	const nameLit = () => attrLoweringToken(b.literal(bind.name), bind);
 	// `suppressHydrationWarning`: stamp a JS flag (NOT a DOM attribute) the runtime reads to
 	// keep the server value + skip the warning on a hydration mismatch for this element.
 	if (bind.kind === 'suppress') {
@@ -16397,16 +16468,10 @@ function emitBindingMount(bind, elVar, bag) {
 		case 'stringData':
 		case 'booleanAttr':
 		case 'ariaAttr': {
-			const helper = {
-				attr: '_$setAttribute',
-				stringData: '_$setStringData',
-				booleanAttr: '_$setBooleanAttribute',
-				ariaAttr: '_$setAriaAttribute',
-			}[bind.kind];
 			return st(
 				b.block([
 					b.const('_v', bind.expr),
-					b.stmt(b.call(helper, el(), b.literal(bind.name), V())),
+					b.stmt(b.call(callee(), el(), nameLit(), V())),
 					b.stmt(b.assignment('=', local(`_el$${bind.id}`), el())),
 					b.stmt(b.assignment('=', local(`_prev$${bind.id}`), V())),
 				]),
@@ -16426,7 +16491,7 @@ function emitBindingMount(bind, elVar, bag) {
 			// runs inside the hydration window and arms the element.
 			return st(
 				b.block([
-					b.stmt(b.call(`_$${CONTROLLED_KIND_HELPERS[bind.kind]}`, el(), bind.expr)),
+					b.stmt(b.call(callee(), el(), bind.expr)),
 					b.stmt(b.assignment('=', local(`_el$${bind.id}`), el())),
 				]),
 			);
@@ -16434,15 +16499,14 @@ function emitBindingMount(bind, elVar, bag) {
 		case 'autoFocus': {
 			// Mount-only (React ignores later autoFocus changes); the focus
 			// itself fires at commit, after the tree is connected.
-			return st(b.stmt(b.call('_$setAutoFocus', el(), bind.expr)));
+			return st(b.stmt(b.call(callee(), el(), bind.expr)));
 		}
 		case 'class': {
 			// On SVG/MathML hosts the `className` property is read-only — fall back
 			// to setAttribute. Compile-time choice, zero runtime branching.
-			const setter = bind.ns && bind.ns !== 'html' ? '_$setClassAttr' : '_$setClassName';
 			const body = [
 				b.const('_v', bind.expr),
-				b.stmt(b.call(setter, el(), V())),
+				b.stmt(b.call(callee(), el(), V())),
 				b.stmt(b.assignment('=', local(`_el$${bind.id}`), el())),
 			];
 			if (!bind.fresh) body.push(b.stmt(b.assignment('=', local(`_prev$${bind.id}`), V())));
@@ -16452,7 +16516,7 @@ function emitBindingMount(bind, elVar, bag) {
 			return st(
 				b.block([
 					b.const('_v', bind.expr),
-					b.stmt(b.call('_$setStyle', el(), V(), undefinedNode())),
+					b.stmt(b.call(callee(), el(), V(), undefinedNode())),
 					b.stmt(b.assignment('=', local(`_el$${bind.id}`), el())),
 					b.stmt(b.assignment('=', local(`_sty$${bind.id}`), V())),
 				]),
@@ -16526,7 +16590,7 @@ function emitBindingMount(bind, elVar, bag) {
 			return st(
 				b.block([
 					b.const('_v', bind.expr),
-					b.stmt(b.call('_$setFormAction', el(), b.literal(bind.name), V(), undefinedNode())),
+					b.stmt(b.call(callee(), el(), nameLit(), V(), undefinedNode())),
 					b.stmt(b.assignment('=', local(`_el$${bind.id}`), el())),
 					b.stmt(b.assignment('=', local(`_prev$${bind.id}`), V())),
 				]),
@@ -16628,6 +16692,10 @@ function emitBindingUpdate(bind, bag) {
 	// 1-char bag field names (see makeBag) — resolved from the same registry the
 	// mount pass registered them in; an unmounted field throws at compile time.
 	const F = (prefix) => bagFieldNode(bag, `${prefix}$${bind.id}`);
+	// See emitBindingMount: the helper and the name literal carry the authored
+	// attribute name, so the name resolves to the update write too.
+	const callee = () => attrLoweringToken(b.id(`_$${attrBindingHelper(bind)}`), bind);
+	const nameLit = () => attrLoweringToken(b.literal(bind.name), bind);
 	switch (bind.kind) {
 		case 'nativeChangeRuntime': {
 			return st(b.stmt(b.call('_$queueNativeChangeDiagnostic', F('_el'))));
@@ -16729,19 +16797,13 @@ function emitBindingUpdate(bind, bag) {
 		case 'stringData':
 		case 'booleanAttr':
 		case 'ariaAttr': {
-			const helper = {
-				attr: '_$setAttribute',
-				stringData: '_$setStringData',
-				booleanAttr: '_$setBooleanAttribute',
-				ariaAttr: '_$setAriaAttribute',
-			}[bind.kind];
 			return st(
 				b.block([
 					b.const('_v', bind.expr),
 					b.if(
 						b.binary('!==', F('_prev'), V()),
 						b.block([
-							b.stmt(b.call(helper, F('_el'), b.literal(bind.name), V())),
+							b.stmt(b.call(callee(), F('_el'), nameLit(), V())),
 							b.stmt(b.assignment('=', F('_prev'), V())),
 						]),
 						null,
@@ -16760,12 +16822,11 @@ function emitBindingUpdate(bind, bag) {
 			// reasserts on every commit — the helper's DOM-diff makes an
 			// unchanged value free, and a prev-guard would skip exactly the
 			// "unrelated re-render while the DOM drifted" reassert case.
-			return st(b.stmt(b.call(`_$${CONTROLLED_KIND_HELPERS[bind.kind]}`, F('_el'), bind.expr)));
+			return st(b.stmt(b.call(callee(), F('_el'), bind.expr)));
 		}
 		case 'class': {
-			const setter = bind.ns && bind.ns !== 'html' ? '_$setClassAttr' : '_$setClassName';
 			if (bind.fresh) {
-				return st(b.stmt(b.call(setter, F('_el'), bind.expr)));
+				return st(b.stmt(b.call(callee(), F('_el'), bind.expr)));
 			}
 			return st(
 				b.block([
@@ -16773,7 +16834,7 @@ function emitBindingUpdate(bind, bag) {
 					b.if(
 						b.binary('!==', F('_prev'), V()),
 						b.block([
-							b.stmt(b.call(setter, F('_el'), V())),
+							b.stmt(b.call(callee(), F('_el'), V())),
 							b.stmt(b.assignment('=', F('_prev'), V())),
 						]),
 						null,
@@ -16791,7 +16852,7 @@ function emitBindingUpdate(bind, bag) {
 					b.if(
 						b.binary('!==', F('_sty'), V()),
 						b.block([
-							b.stmt(b.call('_$setStyle', F('_el'), V(), F('_sty'))),
+							b.stmt(b.call(callee(), F('_el'), V(), F('_sty'))),
 							b.stmt(b.assignment('=', F('_sty'), V())),
 						]),
 						null,
@@ -16838,7 +16899,7 @@ function emitBindingUpdate(bind, bag) {
 					b.if(
 						b.binary('!==', F('_prev'), V()),
 						b.block([
-							b.stmt(b.call('_$setFormAction', F('_el'), b.literal(bind.name), V(), F('_prev'))),
+							b.stmt(b.call(callee(), F('_el'), nameLit(), V(), F('_prev'))),
 							b.stmt(b.assignment('=', F('_prev'), V())),
 						]),
 						null,
@@ -17614,6 +17675,7 @@ function emitElementHtml(
 							),
 				path,
 				ns: hostNs,
+				nameOrigin: attr.name,
 			});
 			continue;
 		}
@@ -17717,6 +17779,7 @@ function emitElementHtml(
 				expr,
 				path,
 				ns: hostNs,
+				nameOrigin: attr.name,
 			});
 			continue;
 		}
@@ -17768,6 +17831,7 @@ function emitElementHtml(
 							),
 				path,
 				ns: hostNs,
+				nameOrigin: attr.name,
 			});
 			continue;
 		}
@@ -17791,6 +17855,7 @@ function emitElementHtml(
 							),
 				path,
 				ns: hostNs,
+				nameOrigin: attr.name,
 			});
 			continue;
 		}
@@ -17842,6 +17907,7 @@ function emitElementHtml(
 				expr: tsrxExprNode(inner, ctx, componentName, inlinedSubs),
 				path,
 				ns: hostNs,
+				nameOrigin: attr.name,
 			});
 			continue;
 		}
@@ -17935,6 +18001,7 @@ function emitElementHtml(
 				path,
 				ns: hostNs,
 				fresh: isFreshBindingExpr(inner),
+				nameOrigin: attr.name,
 			});
 		} else if (
 			(tag === 'form' && attrName === 'action') ||
@@ -17953,6 +18020,7 @@ function emitElementHtml(
 				expr,
 				path,
 				ns: hostNs,
+				nameOrigin: attr.name,
 			});
 		} else if (/^aria-[a-z][a-z0-9_-]*$/.test(attrName)) {
 			// Statically named lowercase ARIA attributes bypass the generic alias,
@@ -17966,6 +18034,7 @@ function emitElementHtml(
 				expr,
 				path,
 				ns: hostNs,
+				nameOrigin: attr.name,
 			});
 		} else if (
 			!((hostNs === 'html' || hostNs === 'opaque') && tag.includes('-')) &&
@@ -17981,6 +18050,7 @@ function emitElementHtml(
 				expr,
 				path,
 				ns: hostNs,
+				nameOrigin: attr.name,
 			});
 		} else if (
 			/^data-[a-z][a-z0-9_-]*$/.test(attrName) &&
@@ -17999,6 +18069,7 @@ function emitElementHtml(
 				expr,
 				path,
 				ns: hostNs,
+				nameOrigin: attr.name,
 			});
 		} else {
 			bindings.push({
@@ -18008,6 +18079,7 @@ function emitElementHtml(
 				expr,
 				path,
 				ns: hostNs,
+				nameOrigin: attr.name,
 			});
 		}
 	}

--- a/packages/octane/tests/compiler-inspect-segments.test.ts
+++ b/packages/octane/tests/compiler-inspect-segments.test.ts
@@ -383,6 +383,109 @@ describe.each([
 	});
 });
 
+// An attribute that never bakes into HTML survives only as a runtime call, and
+// every token of that call except the ones NAMING it maps to the value
+// expression. `<form action={fn}>` becomes `setFormAction(el, 'action', …)` /
+// `ssrAttr("action", …)`; `<input defaultValue={v}/>` becomes
+// `setDefaultValueUncontrolled(el, v)` — with no name token at all — /
+// `ssrInputAttrs([[false, "defaultValue", …]])`. Without a claim on the authored
+// name those attributes are unreachable from the output in the forward
+// direction, because the helper is a different word and the literal carries
+// quotes, so neither reproduces the authored text a consumer accepts on its own.
+describe.each([
+	['client', {}],
+	['client dev', { dev: true }],
+	['client prod', { hmr: false as const }],
+	['server', { mode: 'server' as const }],
+	['server dev', { mode: 'server' as const, dev: true }],
+])('attribute names claim the call they lower to — %s', (_label, options) => {
+	const SOURCE = `export default function App(props: {
+	save: (data: FormData) => void;
+	name: string;
+	busy: boolean;
+	tone: string;
+}) @{
+	<form action={props.save}>
+		<input defaultValue={props.name} disabled={props.busy} />
+		<button class={props.tone} aria-label={props.tone}>Go</button>
+	</form>
+}
+`;
+
+	interface Segment {
+		genLine: number;
+		genCol: number;
+		genEndCol: number | null;
+		srcStart: number;
+		srcEnd: number | null;
+		exact?: boolean;
+	}
+
+	const result = compile(SOURCE, 'App.tsrx', { ...options, inspect: true }) as ReturnType<
+		typeof compile
+	> & { inspect: { segments: Segment[] } };
+
+	const lineStarts = [0];
+	for (let i = 0; i < result.code.length; i++) {
+		if (result.code.charCodeAt(i) === 10) lineStarts.push(i + 1);
+	}
+	const text = (segment: Segment) => {
+		const from = lineStarts[segment.genLine] + segment.genCol;
+		const to =
+			segment.genEndCol === null
+				? (lineStarts[segment.genLine + 1] ?? result.code.length + 1) - 1
+				: lineStarts[segment.genLine] + segment.genEndCol;
+		return result.code.slice(from, to).trim();
+	};
+
+	/** The generated tokens claimed by the authored NAME of `attr={…}`. */
+	const claimedBy = (name: string) => {
+		const at = SOURCE.indexOf(`${name}={`);
+		expect(at, `${name} missing from the fixture`).toBeGreaterThanOrEqual(0);
+		return result.inspect.segments
+			.filter(
+				(segment) =>
+					segment.exact === true && segment.srcStart === at && segment.srcEnd === at + name.length,
+			)
+			.map(text);
+	};
+
+	it('emits the same module with and without inspection', () => {
+		expect(compile(SOURCE, 'App.tsrx', options).code).toBe(result.code);
+	});
+
+	it.each(['action', 'defaultValue', 'disabled', 'class', 'aria-label'])(
+		'claims a token of the call %s lowered to',
+		(name) => {
+			const tokens = claimedBy(name);
+			expect(tokens.length, `nothing claims ${name}`).toBeGreaterThan(0);
+			for (const token of tokens) {
+				// Either the helper the attribute routes to, or the name literal that
+				// call passes — never the value expression, and never the whole
+				// attribute.
+				const isHelper = /^_\$[A-Za-z][A-Za-z0-9]*$/.test(token);
+				const isNameLiteral = token === `'${name}'` || token === `"${name}"`;
+				expect(
+					isHelper || isNameLiteral,
+					`${name} claims ${JSON.stringify(token)}, which names neither its helper nor itself`,
+				).toBe(true);
+			}
+		},
+	);
+
+	it('claims only attribute names, never the value or the whole attribute', () => {
+		const authored = new Set(
+			result.inspect.segments
+				.filter((segment) => segment.exact === true && segment.srcEnd !== null)
+				.map((segment) => SOURCE.slice(segment.srcStart, segment.srcEnd!)),
+		);
+		expect(authored.size).toBeGreaterThan(0);
+		for (const claim of authored) {
+			expect(['action', 'defaultValue', 'disabled', 'class', 'aria-label']).toContain(claim);
+		}
+	});
+});
+
 // A `<style>` block's parsed stylesheet hangs off its element with CSS node
 // offsets in the STYLESHEET's coordinate system, not the file's. The
 // smallest-node index that resolves a segment's authored end must not contain

--- a/website/tests/playground-mapping.test.ts
+++ b/website/tests/playground-mapping.test.ts
@@ -8,7 +8,11 @@
 import { describe, it, expect } from 'vitest';
 import { compileRuntime, compileTypes } from '../src/lib/playground.ts';
 import { collectAuthoredRanges } from '../src/lib/playground-ast.ts';
-import { DEFAULT_WORKSPACES } from '../src/lib/playground-examples.ts';
+import {
+	DEFAULT_WORKSPACES,
+	exampleWorkspace,
+	getExample,
+} from '../src/lib/playground-examples.ts';
 import {
 	identityMapping,
 	mappingFromInspection,
@@ -793,5 +797,64 @@ describe('Counter example — per-node mapping coverage', () => {
 				}
 			}
 		}
+	});
+});
+
+// ── The Form actions example — attributes that never bake into HTML ──────────
+// A static attribute is baked into template markup, and the template's origins
+// carry it. `action`, `defaultValue` and every other dynamic attribute have no
+// markup at all: they survive as a runtime call whose every token but the ones
+// NAMING it maps to the value expression. Reported as hovering either name
+// lighting up nothing in the Compiled pane, in client and server mode alike.
+describe('Form actions example — attributes with no baked HTML', () => {
+	const SOURCE = exampleWorkspace(getExample('form-actions')!, 'tsrx')!.files[0].source;
+
+	// [label, authored name, the fragment locating it, distinct generated tokens]
+	type Row = [string, string, string, Record<'client' | 'server', string[]>];
+	const ROWS: Row[] = [
+		[
+			'a function form action',
+			'action',
+			'<form action={submit}',
+			{ client: ['_$setFormAction', "'action'"], server: ['_$ssrAttr', '"action"'] },
+		],
+		[
+			// No name token at all on the client: the helper IS the name.
+			'an uncontrolled default value',
+			'defaultValue',
+			'defaultValue="Ada"',
+			{ client: ['_$setDefaultValueUncontrolled'], server: ['"defaultValue"'] },
+		],
+		[
+			'a boolean prop bound from a hook',
+			'disabled',
+			'disabled={status.pending}',
+			{ client: ['_$setBooleanAttribute', "'disabled'"], server: ['_$ssrAttr', '"disabled"'] },
+		],
+	];
+
+	describe.each([
+		['client', 'client' as const],
+		['server', 'server' as const],
+	])('%s output', (_label, mode) => {
+		const { code, mapping } = runtimeArtifact(SOURCE, mode);
+
+		it.each(ROWS)('resolves %s in both directions', (_name, attr, anchor, expected) => {
+			const anchorAt = SOURCE.indexOf(anchor);
+			expect(anchorAt, `${anchor} missing from the example`).toBeGreaterThanOrEqual(0);
+			const at = anchorAt + anchor.indexOf(attr);
+			const pair = mapping.pairFromSource(at + 1);
+			expect(pair, `${attr} resolved to nothing`).not.toBeNull();
+			// The authored NAME — never the value, never the whole attribute.
+			expect(pair!.source.map((range) => textAt(SOURCE, range))).toEqual([attr]);
+			// Which tokens, not how many: one attribute legitimately writes on both
+			// the mount and the update path.
+			expect([...new Set(pair!.output.map((range) => textAt(code, range)))].sort()).toEqual(
+				[...expected[mode]].sort(),
+			);
+			for (const range of pair!.output) {
+				expect(mapsBack(mapping, SOURCE, range.from + 1, attr)).toBe(true);
+			}
+		});
 	});
 });

--- a/website/tests/ssr-hydration.e2e.test.ts
+++ b/website/tests/ssr-hydration.e2e.test.ts
@@ -724,6 +724,70 @@ async function assertControlFlowKeywordMapping(baseUrl: string) {
 			expect(hovered!.scrolled, `hovering ${keyword} scrolled the types pane`).toBe(false);
 		}
 
+		// A STATIC attribute is baked into template markup and the template's
+		// origins carry it. A dynamic one has no markup at all — `<form
+		// action={fn}>` and `<input defaultValue={v}/>` survive only as a runtime
+		// call, whose every token but the ones NAMING it maps to the value
+		// expression. The compiler claims the authored name for those tokens, and
+		// that claim is the whole reason hovering either one lights up.
+		await page.selectOption('.pg-select', 'form-actions');
+		await page.waitForFunction(
+			() =>
+				(document.querySelectorAll('.cm-content')[0]?.textContent ?? '').includes('useFormStatus'),
+			null,
+			{ timeout: 15_000 },
+		);
+		// The probes above left the SOURCE pane scrolled deep into another example,
+		// and CodeMirror renders only around its scroll position — rewind so the
+		// whole form is inside the rendered range.
+		await page.evaluate(() => {
+			const scroller = document
+				.querySelectorAll('.pg-editor .cm-content')[0]
+				?.closest('.cm-scroller');
+			if (scroller) scroller.scrollTop = 0;
+		});
+		await page.waitForFunction(
+			() =>
+				(document.querySelectorAll('.cm-content')[0]?.textContent ?? '').includes('defaultValue'),
+			null,
+			{ timeout: 15_000 },
+		);
+		for (const target of ['client', 'server']) {
+			await outputSelector.selectOption(target);
+			await page.waitForFunction(
+				(mode) =>
+					(document.querySelectorAll('.pg-editor .cm-content')[1]?.textContent ?? '').includes(
+						mode === 'server' ? "from 'octane/server'" : "from 'octane'",
+					),
+				target,
+				{ timeout: 15_000 },
+			);
+			// The example's opening comment writes `<form action={fn}>` before the
+			// form uses it, so `action` is probed from the END; `defaultValue`
+			// appears once.
+			for (const [attribute, nth] of [
+				['action', -1],
+				['defaultValue', 0],
+			] as const) {
+				const hovered = await probeKeyword(attribute, 'hover', nth);
+				expect(hovered, `${attribute} not found in the source pane`).not.toBeNull();
+				expect(
+					hovered!.source,
+					`hovering ${attribute} in ${target} marked nothing in the SOURCE pane; the pointer landed on ${JSON.stringify(hovered!.landedOn)}`,
+				).toContain(attribute);
+				expect(hovered!.scrolled, `hovering ${attribute} scrolled the output pane`).toBe(false);
+
+				// The call it lowered to sits far from the hovered line, so clicking
+				// is what brings it into view.
+				const clicked = await probeKeyword(attribute, 'click', nth);
+				expect(
+					clicked!.output.length,
+					`${attribute} in ${target}: source ${JSON.stringify(clicked!.source)}, output ${JSON.stringify(clicked!.output)}`,
+				).toBeGreaterThan(0);
+			}
+		}
+		await outputSelector.selectOption('client');
+
 		expect(errors).toEqual([]);
 	} finally {
 		await page.close();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes affect only the inspect code path; production emit is unchanged. Scope is compiler mapping metadata and tests, not runtime behavior.
> 
> **Overview**
> **Inspect-time source mapping** for attributes that never bake into HTML (`action`, `defaultValue`, `class`, `disabled`, form controls, etc.) now registers **exact origins** on the authored attribute **name**, linked to the runtime helper and/or quoted name literal in the emitted call—so playground click-to-navigate works both ways. Static baked attrs were already covered via template origins; this closes the gap where only value expressions mapped.
> 
> Implementation adds `registerAttrLoweringOrigin`, `attrBindingHelper`, and `attrLoweringToken`; threads `nameOrigin` on bindings; wires SSR grouped helpers (`ssrDirectSource`, `ssrAttr`, `ssrStyle`, …) without re-anchoring shared helpers like `ssrInputAttrs`. Client mount/update emission is centralized on the same helper resolution.
> 
> Behavior is **inspection-gated**—emitted JS is unchanged when `inspect` is off. New coverage in `compiler-inspect-segments`, `playground-mapping` (form-actions example), and SSR hydration e2e for `action` / `defaultValue` hover and click.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89ae6991b516a70ccf4e05bcd0ec7ea48179282f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->