### PR TITLE
followup to #309 from late cursor feedback

### DIFF
--- a/.changeset/grouped-prop-lowering-origins.md
+++ b/.changeset/grouped-prop-lowering-origins.md
@@ -1,0 +1,25 @@
+---
+'octane': patch
+---
+
+`compile({ inspect: true })` now also claims the authored attribute NAME for the
+two lowerings that resolve an element's props as a GROUP, rather than one call
+per attribute. Both dropped the name on the way out, leaving common controlled
+form props unreachable from the output in the forward direction.
+
+A host with a spread, a duplicate prop, or a `value`/`defaultValue` cascade
+routes every prop through one commit-phase collector —
+`setHostPropSources(el, [[false, 'defaultValue', …]])` — where the per-source
+name literal is the only token that names its attribute. It now carries the
+authored name instead of the element's location, the same split
+`ssrAttrs`/`ssrInputAttrs` rows already made on the server.
+
+Server-side `<textarea>`/`<select>` `value`/`defaultValue` never serialize as
+attributes at all: they become the content-position `ssrTextareaValue(…)` or
+option-projection `ssrSelectScope(…)` call, which takes its writers
+POSITIONALLY, so there is no name literal and the helper alias is the only token
+there is. It is now anchored on the authored name, and when both writers are
+present the second aliases onto the first — one call cannot carry two locations.
+
+The emitted module is byte-identical with and without `inspect`, and unchanged
+from before this fix.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -7011,8 +7011,16 @@ function ssrVoid(origin) {
 	return inheritOriginLoc(b.unary('void', b.literal(0)), origin);
 }
 
+/**
+ * `helper` is the runtime alias to call, or a prepared callee node when the
+ * caller already anchored it (see ctlContentCallee) — the alias would otherwise
+ * inherit the element's location like the rest of the call.
+ */
 function ssrCall(helper, args, origin) {
-	return inheritOriginLoc(b.call(`_$${helper}`, ...args), origin);
+	return inheritOriginLoc(
+		b.call(typeof helper === 'string' ? `_$${helper}` : helper, ...args),
+		origin,
+	);
 }
 
 function ssrThunk(expression, origin) {
@@ -7039,6 +7047,33 @@ function ssrDirectSource(ctx, name, value, origin) {
 		b.array([b.literal(false, 'false'), b.literal(name, JSON.stringify(name)), value]),
 		origin,
 	);
+}
+
+/**
+ * `<textarea value>` / `<select value>` put NOTHING in the attribute list: the
+ * whole lowering of `value`/`defaultValue` is the content-position
+ * `ssrTextareaValue(…)` / option-projection `ssrSelectScope(…)` call, which
+ * takes its writers POSITIONALLY. So unlike ssrDirectSource there is no name
+ * literal to claim, and the helper alias is the only token that names what
+ * these attributes became.
+ *
+ * One call serves BOTH writers, and a call carries one location, so `value`
+ * anchors the alias when present (`defaultValue` otherwise) and the other
+ * writer's name aliases onto it — the same split claimCssOrigins makes for
+ * `<style>` blocks sharing one injection, and for the same reason: an exact
+ * claim on an offset the print never emits at would refine nothing.
+ */
+function ctlContentCallee(ctx, helper, origins) {
+	const callee = b.id(`_$${helper}`);
+	const anchor = origins.find((origin) => hasAuthoredOrigin(origin?.name));
+	if (anchor === undefined) return callee;
+	registerAttrLoweringOrigin(ctx, anchor.name, helper, null);
+	for (const origin of origins) {
+		if (origin !== anchor && hasAuthoredOrigin(origin?.name)) {
+			registerOriginAlias(ctx, origin.name, anchor.name);
+		}
+	}
+	return inheritOriginLoc(callee, anchor.name);
 }
 
 function ssrAstCallsAny(root, prefixes) {
@@ -7276,6 +7311,10 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash, compone
 	// (never an attribute); <option> captures its `value` for the scope compare.
 	let ctlValue = null; // textarea/select captured `value` expr
 	let ctlDefault = null; // textarea/select captured `defaultValue` expr
+	// …and the attributes they came from: the capture discards the authored
+	// names, which the positional content/scope call has to claim (ctlContentCallee).
+	let ctlValueAttr = null;
+	let ctlDefaultAttr = null;
 	let selMultiple = inheritOriginLoc(b.literal(false, 'false'), node); // select `multiple`
 	let optValue = null; // option `value` expr (constant or temp); null = no value attr
 	// TSRX accepts repeated attributes. JSX prop construction is last-writer-wins,
@@ -7527,8 +7566,13 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash, compone
 					parts.push('');
 				}
 				formControlSources.push(ssrDirectSource(ctx, attrName, ctlExpr, attr));
-			} else if (attrName === 'value') ctlValue = ctlExpr;
-			else ctlDefault = ctlExpr;
+			} else if (attrName === 'value') {
+				ctlValue = ctlExpr;
+				ctlValueAttr = attr;
+			} else {
+				ctlDefault = ctlExpr;
+				ctlDefaultAttr = attr;
+			}
 			continue;
 		}
 		if (tag === 'select' && attrName === 'multiple') {
@@ -7950,7 +7994,11 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash, compone
 			b.conditional(
 				b.binary('==', src, b.literal(null)),
 				childrenExpr,
-				ssrCall('ssrTextareaValue', [src], node),
+				ssrCall(
+					ctlContentCallee(ctx, 'ssrTextareaValue', [ctlValueAttr, ctlDefaultAttr]),
+					[src],
+					node,
+				),
 			),
 			node,
 		);
@@ -7969,7 +8017,7 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash, compone
 	} else if (tag === 'select' && (ctlValue !== null || ctlDefault !== null)) {
 		ctx.runtimeNeeded.add('ssrSelectScope');
 		childrenExpr = ssrCall(
-			'ssrSelectScope',
+			ctlContentCallee(ctx, 'ssrSelectScope', [ctlValueAttr, ctlDefaultAttr]),
 			[
 				ctlValue ?? ssrVoid(node),
 				ctlDefault ?? ssrVoid(node),
@@ -15127,6 +15175,17 @@ function planJsx(
 			ctx.runtimeNeeded.add('setHostPropSources');
 			ctx.runtimeNeeded.add('queueRefDetach');
 		}
+		// A commit-phase collector takes the element's props as one grouped call,
+		// so each source's name literal — not the shared helper — is what claims
+		// that attribute's name (see commitSourceRows). Registered once here; the
+		// literal carries the same authored location on the update path.
+		if (b.kind === 'hostCommit' || b.kind === 'formCommit') {
+			for (const source of b.sources) {
+				if (source.spread !== true) {
+					registerAttrLoweringOrigin(ctx, source.nameOrigin, null, source.name);
+				}
+			}
+		}
 		if (b.kind === 'dangerChild') ctx.runtimeNeeded.add('markDangerouslySetInnerHTMLChildren');
 		if (b.kind === 'nativeChangeStatic') {
 			ctx.runtimeNeeded.add('markNativeChangeDiagnosticStatic');
@@ -16271,6 +16330,33 @@ function cleanupsPush(fnNode) {
 	return b.stmt(b.call(b.member(lazyArray, 'push'), fnNode));
 }
 
+/**
+ * The `[spread, name, value]` rows a commit-phase source collector
+ * (`setHostPropSources` / `setFormControlSources`) resolves in authored order.
+ * Shared by the mount and update emits, which differ only in how a source's
+ * value is read back — a bag local at mount, a bag field on update.
+ *
+ * Each name literal is the one token in the group that names ITS attribute, so
+ * it carries the authored name rather than the element's location (the same
+ * split ssrDirectSource makes on the server); the collector itself serializes
+ * every source of the element and stays anchored there. Nothing else in a row
+ * reproduces the authored name — the value is the prop's expression — so
+ * without this the whole group answered only for the element.
+ */
+function commitSourceRows(sources, valueOf) {
+	return b.array(
+		sources.map(({ spread, name, nameOrigin, binding }) =>
+			spread
+				? b.array([b.literal(true), valueOf(binding, true)])
+				: b.array([
+						b.literal(false),
+						inheritOriginLoc(b.literal(name), nameOrigin ?? null),
+						valueOf(binding, false),
+					]),
+		),
+	);
+}
+
 // Mount for a DEFERRED property-write binding: store the element ref + seed the
 // diff field to `undefined`. The every-render diff then performs the actual
 // write — including on the first render, since the `undefined` seed makes its
@@ -16377,13 +16463,8 @@ function emitBindingMount(bind, elVar, bag) {
 			);
 		}
 		case 'formCommit': {
-			const sources = b.array(
-				bind.sources.map(({ spread, name, binding }) => {
-					const value = b.id(bag.local(`${spread ? '_sp' : '_prev'}$${binding.id}`));
-					return spread
-						? b.array([b.literal(true), value])
-						: b.array([b.literal(false), b.literal(name), value]);
-				}),
+			const sources = commitSourceRows(bind.sources, (binding, spread) =>
+				b.id(bag.local(`${spread ? '_sp' : '_prev'}$${binding.id}`)),
 			);
 			return st(
 				b.block([
@@ -16395,13 +16476,8 @@ function emitBindingMount(bind, elVar, bag) {
 		case 'hostCommit': {
 			const elLocal = local(`_el$${bind.id}`);
 			const propsLocal = local(`_host$${bind.id}`);
-			const sources = b.array(
-				bind.sources.map(({ spread, name, binding }) => {
-					const value = b.id(bag.local(`${spread ? '_sp' : '_prev'}$${binding.id}`));
-					return spread
-						? b.array([b.literal(true), value])
-						: b.array([b.literal(false), b.literal(name), value]);
-				}),
+			const sources = commitSourceRows(bind.sources, (binding, spread) =>
+				b.id(bag.local(`${spread ? '_sp' : '_prev'}$${binding.id}`)),
 			);
 			// The cleanup closure reads the bag through the captured `_b` — the bag
 			// exists by the time any cleanup runs (committed at mount end), and the
@@ -16757,24 +16833,14 @@ function emitBindingUpdate(bind, bag) {
 			return st(b.stmt(b.call('_$setDangerouslySetInnerHTMLSources', F('_el'), sources)));
 		}
 		case 'formCommit': {
-			const sources = b.array(
-				bind.sources.map(({ spread, name, binding }) => {
-					const value = bagFieldNode(bag, `${spread ? '_sp' : '_prev'}$${binding.id}`);
-					return spread
-						? b.array([b.literal(true), value])
-						: b.array([b.literal(false), b.literal(name), value]);
-				}),
+			const sources = commitSourceRows(bind.sources, (binding, spread) =>
+				bagFieldNode(bag, `${spread ? '_sp' : '_prev'}$${binding.id}`),
 			);
 			return st(b.stmt(b.call('_$setFormControlSources', F('_el'), sources)));
 		}
 		case 'hostCommit': {
-			const sources = b.array(
-				bind.sources.map(({ spread, name, binding }) => {
-					const value = bagFieldNode(bag, `${spread ? '_sp' : '_prev'}$${binding.id}`);
-					return spread
-						? b.array([b.literal(true), value])
-						: b.array([b.literal(false), b.literal(name), value]);
-				}),
+			const sources = commitSourceRows(bind.sources, (binding, spread) =>
+				bagFieldNode(bag, `${spread ? '_sp' : '_prev'}$${binding.id}`),
 			);
 			return st(
 				b.stmt(
@@ -17627,7 +17693,12 @@ function emitElementHtml(
 				path,
 			};
 			bindings.push(binding);
-			hostClientSources.push({ spread: false, name: rawAttrName, binding });
+			hostClientSources.push({
+				spread: false,
+				name: rawAttrName,
+				nameOrigin: attr.name,
+				binding,
+			});
 			continue;
 		}
 		// `key` on a regular element:
@@ -17808,7 +17879,12 @@ function emitElementHtml(
 				path,
 			};
 			bindings.push(binding);
-			formControlClientSources.push({ spread: false, name: attrName, binding });
+			formControlClientSources.push({
+				spread: false,
+				name: attrName,
+				nameOrigin: attr.name,
+				binding,
+			});
 			continue;
 		}
 		if (ctlKind !== null) {

--- a/packages/octane/tests/compiler-inspect-segments.test.ts
+++ b/packages/octane/tests/compiler-inspect-segments.test.ts
@@ -486,6 +486,145 @@ describe.each([
 	});
 });
 
+// Two lowerings resolve an element's props as a GROUP rather than one call per
+// attribute, and both dropped the authored names on the floor.
+//
+// A host with a spread, a duplicate prop, or a value/defaultValue cascade
+// routes every prop through one commit-phase collector — `setHostPropSources(
+// el, [[false, 'defaultValue', …]])` — whose per-source name literal is the
+// only token naming each attribute. Server-side, `<textarea>`/`<select>`
+// value/defaultValue never serialize as attributes at all: they become the
+// content/projection call `ssrTextareaValue(…)` / `ssrSelectScope(…)`, which
+// takes its sources POSITIONALLY, so the helper is the only token there is.
+// Unclaimed, both leave common controlled-form names unreachable from the
+// output.
+describe.each([
+	['client', {}],
+	['client dev', { dev: true }],
+	['client prod', { hmr: false as const }],
+	['server', { mode: 'server' as const }],
+	['server dev', { mode: 'server' as const, dev: true }],
+])('grouped prop lowerings claim their attribute names — %s', (_label, options) => {
+	const SOURCE = `export default function App(props: {
+	rest: Record<string, unknown>;
+	name: string;
+	bio: string;
+	fallback: string;
+	tone: string;
+}) @{
+	<form>
+		<input {...props.rest} defaultValue={props.name} />
+		<textarea value={props.bio} defaultValue={props.fallback} />
+		<select value={props.tone}><option value="a">A</option></select>
+	</form>
+}
+`;
+
+	interface Segment {
+		genLine: number;
+		genCol: number;
+		genEndCol: number | null;
+		srcStart: number;
+		srcEnd: number | null;
+		exact?: boolean;
+	}
+
+	const result = compile(SOURCE, 'App.tsrx', { ...options, inspect: true }) as ReturnType<
+		typeof compile
+	> & {
+		inspect: {
+			segments: Segment[];
+			aliases: { srcStart: number; srcEnd: number; ofStart: number }[];
+		};
+	};
+
+	const lineStarts = [0];
+	for (let i = 0; i < result.code.length; i++) {
+		if (result.code.charCodeAt(i) === 10) lineStarts.push(i + 1);
+	}
+	const text = (segment: Segment) => {
+		const from = lineStarts[segment.genLine] + segment.genCol;
+		const to =
+			segment.genEndCol === null
+				? (lineStarts[segment.genLine + 1] ?? result.code.length + 1) - 1
+				: lineStarts[segment.genLine] + segment.genEndCol;
+		return result.code.slice(from, to).trim();
+	};
+
+	/** The authored offset of `name` in the writer located by `anchor`. */
+	const nameAt = (anchor: string, name: string) => {
+		const at = SOURCE.indexOf(anchor);
+		expect(at, `${anchor} missing from the fixture`).toBeGreaterThanOrEqual(0);
+		return at + anchor.indexOf(name);
+	};
+
+	/** The generated tokens claimed by that authored name. */
+	const claimedBy = (anchor: string, name: string) => {
+		const at = nameAt(anchor, name);
+		return result.inspect.segments
+			.filter(
+				(segment) =>
+					segment.exact === true && segment.srcStart === at && segment.srcEnd === at + name.length,
+			)
+			.map(text);
+	};
+
+	it('emits the same module with and without inspection', () => {
+		expect(compile(SOURCE, 'App.tsrx', options).code).toBe(result.code);
+	});
+
+	it.each([
+		['a spread-resolved input default', '{...props.rest} defaultValue={', 'defaultValue'],
+		['a cascading textarea value', '<textarea value={', 'value'],
+		['a select value', '<select value={', 'value'],
+	])('claims a token of the call %s lowered to', (_case, anchor, name) => {
+		const tokens = claimedBy(anchor, name);
+		expect(tokens.length, `nothing claims ${name} of \`${anchor}\``).toBeGreaterThan(0);
+		for (const token of tokens) {
+			// Either the helper the group routes through, or the name literal that
+			// call passes for this source — never the value expression.
+			const isHelper = /^_\$[A-Za-z][A-Za-z0-9]*$/.test(token);
+			const isNameLiteral = token === `'${name}'` || token === `"${name}"`;
+			expect(
+				isHelper || isNameLiteral,
+				`${name} claims ${JSON.stringify(token)}, which names neither its helper nor itself`,
+			).toBe(true);
+		}
+	});
+
+	// The second writer of a cascade is reachable too. Client-side it has its own
+	// source row; server-side both writers feed ONE positional call, so the name
+	// resolves through an alias onto the writer that anchors it.
+	it('reaches the second writer of a textarea cascade', () => {
+		const at = nameAt('{props.bio} defaultValue={', 'defaultValue');
+		const direct = claimedBy('{props.bio} defaultValue={', 'defaultValue');
+		const aliased = result.inspect.aliases.filter(
+			(alias) => alias.srcStart === at && alias.srcEnd === at + 'defaultValue'.length,
+		);
+		expect(
+			direct.length + aliased.length,
+			'the textarea `defaultValue` writer names nothing',
+		).toBeGreaterThan(0);
+		for (const alias of aliased) {
+			// An alias lends the target's ranges, so it must point at the sibling
+			// writer's NAME — the only offset that claims the shared call.
+			expect(alias.ofStart).toBe(nameAt('<textarea value={', 'value'));
+		}
+	});
+
+	it('claims only attribute names, never the value or the whole attribute', () => {
+		const authored = new Set(
+			result.inspect.segments
+				.filter((segment) => segment.exact === true && segment.srcEnd !== null)
+				.map((segment) => SOURCE.slice(segment.srcStart, segment.srcEnd!)),
+		);
+		expect(authored.size).toBeGreaterThan(0);
+		for (const claim of authored) {
+			expect(['value', 'defaultValue']).toContain(claim);
+		}
+	});
+});
+
 // A `<style>` block's parsed stylesheet hangs off its element with CSS node
 // offsets in the STYLESHEET's coordinate system, not the file's. The
 // smallest-node index that resolves a segment's authored end must not contain

--- a/website/tests/playground-mapping.test.ts
+++ b/website/tests/playground-mapping.test.ts
@@ -858,3 +858,87 @@ describe('Form actions example — attributes with no baked HTML', () => {
 		});
 	});
 });
+
+// ── Props resolved as a GROUP rather than one call per attribute ─────────────
+// Two lowerings drop the authored name on the way out. A host with a spread, a
+// duplicate prop, or a value/defaultValue cascade routes every prop through one
+// commit-phase collector, `setHostPropSources(el, [[false, 'defaultValue', …]])`
+// — the per-source name literal is all that names each attribute. Server-side,
+// `<textarea>`/`<select>` value/defaultValue never serialize as attributes at
+// all: they become the content/projection call, which takes its writers
+// POSITIONALLY, so the helper alias is the only token there is. Reported as
+// hovering common controlled-form names lighting up nothing in the Compiled
+// pane.
+describe('grouped prop lowerings — commit sources and content positions', () => {
+	const SOURCE = `export default function App(props: {
+	rest: Record<string, unknown>;
+	name: string;
+	bio: string;
+	fallback: string;
+	tone: string;
+}) @{
+	<form>
+		<input {...props.rest} defaultValue={props.name} />
+		<textarea value={props.bio} defaultValue={props.fallback} />
+		<select value={props.tone}><option value="a">A</option></select>
+	</form>
+}
+`;
+
+	// [label, authored name, the fragment locating it, distinct generated tokens]
+	type Row = [string, string, string, Record<'client' | 'server', string[]>];
+	const ROWS: Row[] = [
+		[
+			// The spread makes every prop of this input a commit source.
+			'a spread-resolved input default',
+			'defaultValue',
+			'{...props.rest} defaultValue={',
+			{ client: ["'defaultValue'"], server: ['"defaultValue"'] },
+		],
+		[
+			'the value writer of a textarea cascade',
+			'value',
+			'<textarea value={',
+			{ client: ["'value'"], server: ['_$ssrTextareaValue'] },
+		],
+		[
+			// Both writers feed ONE positional call on the server, so this name
+			// resolves through an alias onto the writer that anchors it.
+			'the default writer of a textarea cascade',
+			'defaultValue',
+			'{props.bio} defaultValue={',
+			{ client: ["'defaultValue'"], server: ['_$ssrTextareaValue'] },
+		],
+		[
+			'a select value driving option projection',
+			'value',
+			'<select value={',
+			{ client: ['_$setSelectValue'], server: ['_$ssrSelectScope'] },
+		],
+	];
+
+	describe.each([
+		['client', 'client' as const],
+		['server', 'server' as const],
+	])('%s output', (_label, mode) => {
+		const { code, mapping } = runtimeArtifact(SOURCE, mode);
+
+		it.each(ROWS)('resolves %s in both directions', (_name, attr, anchor, expected) => {
+			const anchorAt = SOURCE.indexOf(anchor);
+			expect(anchorAt, `${anchor} missing from the fixture`).toBeGreaterThanOrEqual(0);
+			const at = anchorAt + anchor.indexOf(attr);
+			const pair = mapping.pairFromSource(at + 1);
+			expect(pair, `${attr} resolved to nothing`).not.toBeNull();
+			// The authored NAME — never the value, never the whole attribute.
+			expect(pair!.source.map((range) => textAt(SOURCE, range))).toEqual([attr]);
+			// Which tokens, not how many: one attribute legitimately writes on both
+			// the mount and the update path.
+			expect([...new Set(pair!.output.map((range) => textAt(code, range)))].sort()).toEqual(
+				[...expected[mode]].sort(),
+			);
+			for (const range of pair!.output) {
+				expect(mapsBack(mapping, SOURCE, range.from + 1, attr)).toBe(true);
+			}
+		});
+	});
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are gated to inspect-time origin registration and AST location metadata; runtime emit is unchanged and tests assert code identity with and without inspection.
> 
> **Overview**
> Fixes **source↔output mapping** when props are lowered as a **group** instead of one runtime call per attribute — a follow-up to #309.
> 
> **Client:** Elements with spreads, duplicate props, or cascades route props through **`setHostPropSources`** / **`setFormControlSources`**. Inspect now registers each non-spread source’s **authored attribute name** on the per-row name literal (via **`commitSourceRows`** and **`nameOrigin`** on host/form sources), so names like `defaultValue` resolve to `'defaultValue'` in the output instead of only the shared helper/element.
> 
> **Server:** **`<textarea>`** / **`<select>`** `value`/`defaultValue` lower to positional **`ssrTextareaValue`** / **`ssrSelectScope`** calls with no attribute name token. **`ctlContentCallee`** anchors the helper identifier on the primary writer’s authored name and **aliases** the sibling writer when both are present (same pattern as shared `<style>` injection). **`ssrCall`** accepts a pre-anchored callee node.
> 
> Emitted modules stay **byte-identical** with or without `inspect`. Coverage added in **`compiler-inspect-segments.test.ts`** and **`playground-mapping.test.ts`**; octane **patch** changeset included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4fcb926306f231884ac95c57447b81bfe355c55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->