### PR TITLE
Remove whitespace text mount benchmark

### DIFF
--- a/benchmarks/baselines/local/recursive-context.json
+++ b/benchmarks/baselines/local/recursive-context.json
@@ -102,11 +102,6 @@
           "min": 0,
           "samples": 1
         },
-        "whitespace_text_mounted": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
         "nodes_partial_unmounted": {
           "median": 2984,
           "min": 2984,
@@ -288,11 +283,6 @@
           "samples": 1
         },
         "empty_text_mounted": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "whitespace_text_mounted": {
           "median": 0,
           "min": 0,
           "samples": 1
@@ -483,11 +473,6 @@
           "min": 0,
           "samples": 1
         },
-        "whitespace_text_mounted": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
         "nodes_partial_unmounted": {
           "median": 4961,
           "min": 4961,
@@ -668,11 +653,6 @@
           "min": 0,
           "samples": 1
         },
-        "whitespace_text_mounted": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
         "nodes_partial_unmounted": {
           "median": 2976,
           "min": 2976,
@@ -842,11 +822,6 @@
         "empty_text_mounted": {
           "median": 1,
           "min": 1,
-          "samples": 1
-        },
-        "whitespace_text_mounted": {
-          "median": 0,
-          "min": 0,
           "samples": 1
         },
         "nodes_partial_unmounted": {
@@ -1020,11 +995,6 @@
           "min": 4094,
           "samples": 1
         },
-        "whitespace_text_mounted": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
         "nodes_partial_unmounted": {
           "median": 6946,
           "min": 6946,
@@ -1192,11 +1162,6 @@
           "samples": 1
         },
         "empty_text_mounted": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "whitespace_text_mounted": {
           "median": 0,
           "min": 0,
           "samples": 1
@@ -1370,11 +1335,6 @@
         "empty_text_mounted": {
           "median": 3072,
           "min": 3072,
-          "samples": 1
-        },
-        "whitespace_text_mounted": {
-          "median": 1023,
-          "min": 1023,
           "samples": 1
         },
         "nodes_partial_unmounted": {

--- a/benchmarks/baselines/local/signal-favoring.json
+++ b/benchmarks/baselines/local/signal-favoring.json
@@ -125,11 +125,6 @@
           "median": 0,
           "min": 0,
           "samples": 1
-        },
-        "whitespace_text_mounted": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
         }
       },
       "meta": {
@@ -277,11 +272,6 @@
           "samples": 1
         },
         "empty_text_mounted": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "whitespace_text_mounted": {
           "median": 0,
           "min": 0,
           "samples": 1
@@ -435,11 +425,6 @@
           "median": 0,
           "min": 0,
           "samples": 1
-        },
-        "whitespace_text_mounted": {
-          "median": 10,
-          "min": 10,
-          "samples": 1
         }
       },
       "meta": {
@@ -590,11 +575,6 @@
           "median": 0,
           "min": 0,
           "samples": 1
-        },
-        "whitespace_text_mounted": {
-          "median": 10,
-          "min": 10,
-          "samples": 1
         }
       },
       "meta": {
@@ -740,11 +720,6 @@
         "empty_text_mounted": {
           "median": 1,
           "min": 1,
-          "samples": 1
-        },
-        "whitespace_text_mounted": {
-          "median": 0,
-          "min": 0,
           "samples": 1
         }
       },
@@ -896,11 +871,6 @@
           "median": 0,
           "min": 0,
           "samples": 1
-        },
-        "whitespace_text_mounted": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
         }
       },
       "meta": {
@@ -1047,11 +1017,6 @@
           "median": 0,
           "min": 0,
           "samples": 1
-        },
-        "whitespace_text_mounted": {
-          "median": 10,
-          "min": 10,
-          "samples": 1
         }
       },
       "meta": {
@@ -1197,11 +1162,6 @@
         "empty_text_mounted": {
           "median": 1,
           "min": 1,
-          "samples": 1
-        },
-        "whitespace_text_mounted": {
-          "median": 0,
-          "min": 0,
           "samples": 1
         }
       },

--- a/benchmarks/recursive-context/run.mjs
+++ b/benchmarks/recursive-context/run.mjs
@@ -365,7 +365,6 @@ const DOM_OPS = [
 	['text_mounted', 'mounted', 'text'],
 	['comments_mounted', 'mounted', 'comments'],
 	['empty_text_mounted', 'mounted', 'emptyText'],
-	['whitespace_text_mounted', 'mounted', 'whitespaceText'],
 	['nodes_partial_unmounted', 'partialUnmounted', 'total'],
 	['elements_partial_unmounted', 'partialUnmounted', 'elements'],
 	['text_partial_unmounted', 'partialUnmounted', 'text'],

--- a/benchmarks/signal-favoring/run.mjs
+++ b/benchmarks/signal-favoring/run.mjs
@@ -405,7 +405,6 @@ const DOM_OPS = [
 	['text_mounted', 'text'],
 	['comments_mounted', 'comments'],
 	['empty_text_mounted', 'emptyText'],
-	['whitespace_text_mounted', 'whitespaceText'],
 ];
 
 const DIALECT_PAIR_NAMES = ['octane-tsrx', 'octane-jsx'];


### PR DESCRIPTION
## Summary

- remove the `whitespace_text_mounted` result from the recursive-context and signal-favoring benchmark harnesses
- remove the corresponding historical entries from both local baseline files
- keep the underlying DOM snapshots and other whitespace metrics unchanged

## Why

The mount metric conflates formatting-created whitespace nodes with meaningful mounted work, making cross-framework comparisons misleading rather than actionable.

## Impact

The two suites no longer publish or compare `whitespace_text_mounted`. Their timing, node, element, text, comment, empty-text, partial-unmount, and raw DOM snapshot data are unchanged.

## Checks

- `node --check benchmarks/recursive-context/run.mjs`
- `node --check benchmarks/signal-favoring/run.mjs`
- parsed both edited baseline JSON files with Node
- verified no remaining `whitespace_text_mounted` references under `benchmarks/`
- Prettier check for all four changed files
- `node benchmarks/bench.mjs --list`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark reporting and baseline JSON only; no runtime product or security impact.
> 
> **Overview**
> Stops reporting **`whitespace_text_mounted`** from the **recursive-context** and **signal-favoring** harnesses so mount DOM ops no longer include formatting-driven whitespace text nodes in published results and baseline comparisons.
> 
> Each suite drops the corresponding **`DOM_OPS`** mapping in **`run.mjs`**, and local baseline JSON under **`benchmarks/baselines/local/`** is trimmed to match. Timing ops, other mount counters (nodes, elements, text, comments, empty text), partial-unmount whitespace metrics in recursive-context, and raw **`meta.dom`** snapshots (including **`whitespaceText`**) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eabc4caf215e561710333bf4e8d7d5d94f44a73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->