### PR TITLE
fix(octane): repair two capture-analysis defects in inferred hook deps

### DIFF
--- a/.changeset/hook-deps-stability.md
+++ b/.changeset/hook-deps-stability.md
@@ -27,3 +27,9 @@ Module-scope `let` and `var` remain tracked, since any later statement may
 rebind them. A member read through a module-scope `const` (`CONFIG.mode`) is
 now omitted, matching the answer a namespace import already gave: a module-level
 object mutated in place is not witnessed by a dependency array either way.
+
+A regex literal is not treated as an invariant initializer. ESTree spells
+`/foo/g` as a `Literal`, but it allocates a fresh RegExp on every evaluation and
+carries mutable `lastIndex` state, so a local `const pattern = /foo/g` stays
+reactive. The predicate is now shared with the one `compile.js` already used for
+the same question.

--- a/.changeset/hook-deps-stability.md
+++ b/.changeset/hook-deps-stability.md
@@ -1,0 +1,29 @@
+---
+'octane': patch
+---
+
+Compiler-inferred hook dependency arrays now resolve two capture-analysis
+defects.
+
+A computed key in a binding pattern (`const { [key]: picked } = source`) is a
+read of the surrounding scope, but the scope walk never visited it, so the
+identifier resolved to no binding at all — indistinguishable from a global —
+and was dropped. Any effect keyed on that value kept a stale capture and never
+re-ran when it changed. The fix covers every position a pattern can appear in:
+declarations, function parameters, catch clauses, for-of heads, and patterns
+nested in any of them.
+
+Module-scope `const` declarations, and module-scope `function` and `class`
+declarations that nothing reassigns, are no longer emitted as dependencies. A
+dependency array tracks what can change between renders, and these are
+evaluated once for the program's lifetime — the conclusion imports already got
+here, that `exhaustive-deps` reaches for any outer-scope value, and that
+autoMemo already reached for same-module function declarations. Previously
+`import { fmt } from './fmt'` and a byte-identical local helper produced
+different arrays. A local `const` that only names such a value, or that binds a
+literal, is omitted for the same reason.
+
+Module-scope `let` and `var` remain tracked, since any later statement may
+rebind them. A member read through a module-scope `const` (`CONFIG.mode`) is
+now omitted, matching the answer a namespace import already gave: a module-level
+object mutated in place is not witnessed by a dependency array either way.

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -33,6 +33,19 @@ refs, and state getters. It also omits `useEffectEvent` results because Effect
 Events are non-reactive captures, despite their intentionally fresh wrapper
 identity.
 
+A dependency array tracks what can change *between renders*, so a binding that
+is evaluated once for the program's lifetime is not a dependency. Alongside
+imports, the compiler omits module-scope `const` declarations and module-scope
+`function` and `class` declarations that nothing reassigns — the same values
+React's `exhaustive-deps` rule never asks you to list, because they are outside
+the component. This applies to a member read through one of them
+(`CONFIG.mode`), exactly as it already did for a namespace import, so a
+module-level object mutated in place is not witnessed by a dependency array;
+hold such state in a store or in state, not a module singleton. Module-scope
+`let` and `var` stay tracked: any later statement may rebind them. A local
+`const` that only names one of these values, or that binds a literal, is
+likewise omitted — naming a fixed value does not make it reactive.
+
 The full `.tsrx`/`.tsx` compiler also recognizes locally declared custom hooks
 that transparently forward a callback parameter and their final dependency
 parameter to one of those hooks. Nested transparent wrappers are followed

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -41,7 +41,7 @@ import {
 import { print as esrapPrint } from 'esrap';
 import esrapTsx from 'esrap/languages/tsx';
 import { buildFatSegments } from './fat-segments.js';
-import { applyHookDependencies } from './hook-deps.js';
+import { applyHookDependencies, isInvariantLiteral } from './hook-deps.js';
 import { compileUniversal, UNIVERSAL_COMPILER_RUNTIME_IMPORTS } from './compile-universal.js';
 import {
 	expandDomRendererRegionsAst,
@@ -10267,13 +10267,6 @@ function unwrapTsExpr(n) {
 // ESTree represents RegExp syntax as a Literal too, but evaluating `/x/`
 // creates a new object every render. Only primitive literal values are safe to
 // use in a component-lifetime identity proof.
-function isInvariantLiteral(node) {
-	if (!node || node.type !== 'Literal' || node.regex != null) return false;
-	return (
-		node.value === null || (typeof node.value !== 'object' && typeof node.value !== 'function')
-	);
-}
-
 // A value that can safely be installed once at mount: only identifiers proven
 // to have component-lifetime identity. Literals are normally baked into the
 // template before this point, but accepting them makes event-bundle argument

--- a/packages/octane/src/compiler/hook-deps.js
+++ b/packages/octane/src/compiler/hook-deps.js
@@ -50,6 +50,7 @@ function declareName(scope, name, details = null) {
 			scope,
 			imported: false,
 			dependencyInvariant: false,
+			moduleImmutable: false,
 			reassigned: false,
 			octaneImport: null,
 			octaneNamespace: false,
@@ -59,6 +60,7 @@ function declareName(scope, name, details = null) {
 		scope.bindings.set(name, binding);
 	}
 	if (details?.imported) binding.imported = true;
+	if (details?.moduleImmutable) binding.moduleImmutable = true;
 	if (details?.octaneImport) binding.octaneImport = details.octaneImport;
 	if (details?.octaneNamespace) binding.octaneNamespace = true;
 	if (details?.hookRuntimeImport) binding.hookRuntimeImport = details.hookRuntimeImport;
@@ -134,14 +136,21 @@ function predeclareDirect(statements, scope, hookRuntimeModules) {
 		}
 		const node = unwrapExport(original);
 		if (!node) continue;
+		// A module-scope `const`/`function`/`class` is evaluated once for the
+		// program's lifetime, so its identity is fixed exactly like an import's.
+		// `var` and `let` are excluded: any later statement may rebind them.
+		// Function and class bindings are writable, so their claim is provisional
+		// here and withdrawn by `reassigned` at marking time.
+		const atModuleScope = scope.kind === 'module';
 		if (node.type === 'VariableDeclaration') {
 			const target = node.kind === 'var' ? nearestFunctionScope(scope) : scope;
-			for (const decl of node.declarations || []) declarePattern(decl.id, target);
+			const details = atModuleScope && node.kind === 'const' ? { moduleImmutable: true } : null;
+			for (const decl of node.declarations || []) declarePattern(decl.id, target, details);
 		} else if (
 			(node.type === 'FunctionDeclaration' || node.type === 'ClassDeclaration') &&
 			node.id
 		) {
-			declareName(scope, node.id.name);
+			declareName(scope, node.id.name, atModuleScope ? { moduleImmutable: true } : null);
 		}
 	}
 }
@@ -494,6 +503,7 @@ function buildScopes(ast, onlyImported, hookRuntimeModules) {
 		record.stableDefinition = kind === 'const';
 	}
 	const analysis = {
+		moduleScope,
 		nodeScopes,
 		functionScopes,
 		declarators,
@@ -688,7 +698,27 @@ function discoverCustomDependencyHooks(analysis) {
 	return configs;
 }
 
+// Is this initializer the same value on every evaluation of its declaration?
+// Deliberately narrow: a literal has no identity to change. An object or array
+// literal is excluded — it allocates a fresh identity each time.
+function isInvariantLiteral(node) {
+	if (node?.type === 'Literal') return true;
+	return node?.type === 'TemplateLiteral' && (node.expressions?.length ?? 0) === 0;
+}
+
 function markDependencyInvariantBindings(analysis) {
+	// Seed the lattice with the bindings whose identity is fixed for the
+	// program's lifetime, so the `const alias = original` propagation below
+	// carries them into component scope for free.
+	//
+	// An imported binding was already filtered at every use site; marking it
+	// here changes nothing about its own treatment and exists so an alias of it
+	// inherits the same answer.
+	for (const binding of analysis.moduleScope.bindings.values()) {
+		if (binding.imported || (binding.moduleImmutable && !binding.reassigned)) {
+			binding.dependencyInvariant = true;
+		}
+	}
 	let changed = true;
 	while (changed) {
 		changed = false;
@@ -705,6 +735,7 @@ function markDependencyInvariantBindings(analysis) {
 				if (!dependencyInvariant && init?.type === 'Identifier') {
 					dependencyInvariant = resolveBinding(scope, init.name)?.dependencyInvariant === true;
 				}
+				if (!dependencyInvariant) dependencyInvariant = isInvariantLiteral(init);
 				if (dependencyInvariant && bindings[0] && !bindings[0].binding.dependencyInvariant) {
 					bindings[0].binding.dependencyInvariant = true;
 					changed = true;

--- a/packages/octane/src/compiler/hook-deps.js
+++ b/packages/octane/src/compiler/hook-deps.js
@@ -698,12 +698,29 @@ function discoverCustomDependencyHooks(analysis) {
 	return configs;
 }
 
-// Is this initializer the same value on every evaluation of its declaration?
-// Deliberately narrow: a literal has no identity to change. An object or array
-// literal is excluded — it allocates a fresh identity each time.
-function isInvariantLiteral(node) {
-	if (node?.type === 'Literal') return true;
-	return node?.type === 'TemplateLiteral' && (node.expressions?.length ?? 0) === 0;
+/**
+ * Is this expression the same value on every evaluation? Only a PRIMITIVE
+ * literal qualifies: it has no identity to change.
+ *
+ * A regex literal is excluded even though ESTree calls it a `Literal` —
+ * `/foo/g` allocates a fresh RegExp on every evaluation, and carries mutable
+ * `lastIndex` state besides. The object/function check is the same guard one
+ * step more general, for any parser that materializes a literal value.
+ */
+export function isInvariantLiteral(node) {
+	if (!node || node.type !== 'Literal' || node.regex != null) return false;
+	return (
+		node.value === null || (typeof node.value !== 'object' && typeof node.value !== 'function')
+	);
+}
+
+// The same question for a hook initializer, which additionally accepts a
+// template literal with no substitutions — that is a plain string constant.
+// Kept separate so the shared predicate above stays byte-identical to what
+// compile.js's other call sites have always meant by it.
+function isInvariantInitializer(node) {
+	if (node?.type === 'TemplateLiteral') return (node.expressions?.length ?? 0) === 0;
+	return isInvariantLiteral(node);
 }
 
 function markDependencyInvariantBindings(analysis) {
@@ -735,7 +752,7 @@ function markDependencyInvariantBindings(analysis) {
 				if (!dependencyInvariant && init?.type === 'Identifier') {
 					dependencyInvariant = resolveBinding(scope, init.name)?.dependencyInvariant === true;
 				}
-				if (!dependencyInvariant) dependencyInvariant = isInvariantLiteral(init);
+				if (!dependencyInvariant) dependencyInvariant = isInvariantInitializer(init);
 				if (dependencyInvariant && bindings[0] && !bindings[0].binding.dependencyInvariant) {
 					bindings[0].binding.dependencyInvariant = true;
 					changed = true;

--- a/packages/octane/src/compiler/hook-deps.js
+++ b/packages/octane/src/compiler/hook-deps.js
@@ -467,6 +467,13 @@ function buildScopes(ast, onlyImported, hookRuntimeModules) {
 				return;
 			case 'ObjectPattern':
 				for (const prop of pattern.properties || []) {
+					// A computed key is a READ of the surrounding scope, not a binding
+					// (`const { [key]: picked } = source`). It must be walked so the
+					// identifier gets a `nodeScopes` entry: `collectDependencies`
+					// resolves every capture through that map, and an unmapped node
+					// resolves to no binding, which it cannot distinguish from a
+					// genuine global — so the capture would be dropped silently.
+					if (prop.computed) walk(prop.key, scope);
 					walkPatternDefaults(prop.type === 'RestElement' ? prop.argument : prop.value, scope);
 				}
 				return;

--- a/packages/octane/tests/_fixtures/auto-hook-deps-behavior.tsrx
+++ b/packages/octane/tests/_fixtures/auto-hook-deps-behavior.tsrx
@@ -82,6 +82,20 @@ export function EffectFromDestructuring(props) @{
 	<span>{props.noise as string}</span>
 }
 
+const MODULE_SCALE = 10;
+const MODULE_CONFIG = { prefix: 'cfg' };
+
+function moduleFormat(value) {
+	return `fmt:${value}`;
+}
+
+export function EffectFromModuleScopeHelpers(props) @{
+	useEffect(() => {
+		props.log(`${MODULE_CONFIG.prefix}:${moduleFormat(props.value * MODULE_SCALE)}`);
+	});
+	<span>{props.noise as string}</span>
+}
+
 export function EffectWithConvergingUpdate(props) @{
 	const [value, setValue] = useState(0);
 	useEffect(() => {

--- a/packages/octane/tests/auto-hook-deps-behavior.test.ts
+++ b/packages/octane/tests/auto-hook-deps-behavior.test.ts
@@ -8,6 +8,7 @@ import {
 	EffectFromCleanupOnly,
 	EffectFromDeferredWork,
 	EffectFromDestructuring,
+	EffectFromModuleScopeHelpers,
 	EffectFromProps,
 	EffectFromReferencedCallback,
 	EffectFromState,
@@ -306,6 +307,58 @@ describe('inferred useEffect dependencies — behavior', () => {
 		});
 		flushEffects();
 		expect(log).toHaveBeenLastCalledWith('fallback');
+		expect(log).toHaveBeenCalledTimes(2);
+		r.unmount();
+		flushEffects();
+	});
+
+	it('reruns when only the computed destructuring key changes', () => {
+		const log = vi.fn();
+		// One record and one fallback for the whole test, so the computed key is
+		// the ONLY thing that can drive a rerun. The neighbouring case varies the
+		// key and the fallback together, which a dropped key would survive.
+		const record = { primary: 'first', secondary: 'second' };
+		const r = mount(EffectFromDestructuring, {
+			field: 'primary',
+			fallback: 'missing',
+			record,
+			noise: 0,
+			log,
+		});
+		flushEffects();
+		expect(log).toHaveBeenLastCalledWith('first');
+
+		r.update(EffectFromDestructuring, {
+			field: 'secondary',
+			fallback: 'missing',
+			record,
+			noise: 0,
+			log,
+		});
+		flushEffects();
+		expect(log).toHaveBeenLastCalledWith('second');
+		expect(log).toHaveBeenCalledTimes(2);
+		r.unmount();
+		flushEffects();
+	});
+
+	it('reads module-scope helpers correctly without treating them as reactive', () => {
+		const log = vi.fn();
+		const r = mount(EffectFromModuleScopeHelpers, { value: 1, noise: 0, log });
+		flushEffects();
+		// The omitted captures still resolve — dropping them from the array must
+		// not change what the callback computes.
+		expect(log).toHaveBeenLastCalledWith('cfg:fmt:10');
+
+		// An unrelated prop change must not rerun an effect whose only other
+		// captures are module-scope constants.
+		r.update(EffectFromModuleScopeHelpers, { value: 1, noise: 1, log });
+		flushEffects();
+		expect(log).toHaveBeenCalledTimes(1);
+
+		r.update(EffectFromModuleScopeHelpers, { value: 2, noise: 1, log });
+		flushEffects();
+		expect(log).toHaveBeenLastCalledWith('cfg:fmt:20');
 		expect(log).toHaveBeenCalledTimes(2);
 		r.unmount();
 		flushEffects();

--- a/packages/octane/tests/auto-hook-deps-stability.test.ts
+++ b/packages/octane/tests/auto-hook-deps-stability.test.ts
@@ -2,27 +2,27 @@ import { describe, expect, it } from 'vitest';
 import { compile } from 'octane/compiler';
 import { slotHooks } from '../src/compiler/slot-hooks.js';
 
-// Known GAPS in compiler-inferred hook dependencies, written as executable
-// assertions of the intended behaviour.
+// Which captures a compiler-inferred dependency array may omit, and which it
+// must keep.
 //
-// Every `it.fails` below states what the compiler SHOULD emit and currently
-// does not. They stay green while the gap is open and flip red the moment it
-// closes — at which point drop the `.fails` rather than deleting the case.
-// The plain `it` blocks are the guards those fixes must not break.
+// The governing rule is that a dependency array tracks values whose identity
+// can change BETWEEN RENDERS. A binding evaluated once for the program's
+// lifetime cannot, so it is not a dependency — the same conclusion React's
+// exhaustive-deps rule reaches for any outer-scope value, and the one two
+// neighbouring parts of this compiler already reached:
 //
-// The contract being asserted is the same one two neighbouring passes already
-// hold, and which `hook-deps.js` alone does not:
+//   - an IMPORTED binding is omitted from an inferred array;
+//   - autoMemo's `plainCalleeIsMemoizable` treats a same-module `function`
+//     declaration that is never reassigned as a "module-scope immutable
+//     identity", explicitly indistinguishable from an import.
 //
-//   - an IMPORTED binding is already omitted from an inferred array, because a
-//     module binding's identity is fixed for the program lifetime;
-//   - autoMemo's `plainCalleeIsMemoizable` already treats a same-module
-//     `function` declaration that is never reassigned as a "module-scope
-//     immutable identity", indistinguishable from an import.
+// A same-module `const`/`function`/`class` is that same identity. Treating it
+// as reactive put a dead comparison slot in every array that touched one, and
+// made `import { fmt } from './fmt'` disagree with the byte-identical helper
+// declared locally.
 //
-// A same-module `const`/`function`/`class` is that same identity, so making it
-// a reactive dependency is a dead comparison slot in every emitted array and a
-// behavioural difference between `import { fmt } from './fmt'` and the byte
-// identical helper declared locally.
+// The final describe block holds the boundary: `let`, shadowing, and derived
+// values stay reactive, because for those the premise does not hold.
 const c = (source: string): string =>
 	compile(source, 'auto-deps-stability.tsrx', { inlineHookMemo: false }).code;
 
@@ -32,7 +32,7 @@ const depsOf = (code: string): string[] =>
 	);
 
 describe('dependency stability — module-scope immutable identities', () => {
-	it.fails('omits a module-scope const binding', () => {
+	it('omits a module-scope const binding', () => {
 		const code = c(`
       import { useEffect } from 'octane';
       const SCALE = 2;
@@ -42,11 +42,10 @@ describe('dependency stability — module-scope immutable identities', () => {
       }
     `);
 
-		// Emits [props.log, props.value, SCALE].
 		expect(depsOf(code)).toEqual(['props.log, props.value']);
 	});
 
-	it.fails('omits a module-scope function declaration', () => {
+	it('omits a module-scope function declaration', () => {
 		const code = c(`
       import { useEffect } from 'octane';
       function fmt(n) { return String(n); }
@@ -56,12 +55,12 @@ describe('dependency stability — module-scope immutable identities', () => {
       }
     `);
 
-		// Emits [props.log, fmt, props.value]. An `import { fmt } from './fmt'`
-		// with the identical call site already emits [props.log, props.value].
+		// `import { fmt } from './fmt'` with the identical call site must produce
+		// the identical array: where the helper is declared cannot change it.
 		expect(depsOf(code)).toEqual(['props.log, props.value']);
 	});
 
-	it.fails('omits a module-scope const arrow function', () => {
+	it('omits a module-scope const arrow function', () => {
 		const code = c(`
       import { useEffect } from 'octane';
       const fmt = (n) => String(n);
@@ -74,7 +73,7 @@ describe('dependency stability — module-scope immutable identities', () => {
 		expect(depsOf(code)).toEqual(['props.log, props.value']);
 	});
 
-	it.fails('omits a module-scope class binding', () => {
+	it('omits a module-scope class binding', () => {
 		const code = c(`
       import { useEffect } from 'octane';
       class Thing {}
@@ -87,7 +86,7 @@ describe('dependency stability — module-scope immutable identities', () => {
 		expect(depsOf(code)).toEqual(['props.log']);
 	});
 
-	it.fails('omits a member read of a module-scope const object', () => {
+	it('omits a member read of a module-scope const object', () => {
 		const code = c(`
       import { useEffect } from 'octane';
       const CONFIG = { mode: 'fast' };
@@ -97,12 +96,13 @@ describe('dependency stability — module-scope immutable identities', () => {
       }
     `);
 
-		// Emits [props.log, CONFIG.mode]. `import * as CONFIG` + `CONFIG.mode` is
-		// already omitted, so the two spellings disagree on the same read.
+		// The receiver is what a dependency would witness, and it is fixed. This
+		// matches the answer `import * as CONFIG` + `CONFIG.mode` already gives:
+		// a module-level object mutated in place is unwitnessed either way.
 		expect(depsOf(code)).toEqual(['props.log']);
 	});
 
-	it.fails('omits a module-scope component referenced as a JSX tag', () => {
+	it('omits a module-scope component referenced as a JSX tag', () => {
 		const code = c(`
       import { useMemo } from 'octane';
       function Row(props) @{ <li>{props.text as string}</li> }
@@ -112,11 +112,11 @@ describe('dependency stability — module-scope immutable identities', () => {
       }
     `);
 
-		// Emits [props.items, Row].
+		// A component referenced as a tag is an ordinary capture of its binding.
 		expect(depsOf(code)).toEqual(['props.items']);
 	});
 
-	it.fails('omits a module-scope const declared after the component', () => {
+	it('omits a module-scope const declared after the component', () => {
 		const code = c(`
       import { useEffect } from 'octane';
       export function App(props) @{
@@ -131,7 +131,7 @@ describe('dependency stability — module-scope immutable identities', () => {
 		expect(depsOf(code)).toEqual(['props.log']);
 	});
 
-	it.fails('holds the same contract in the plain-TS surgical pass', () => {
+	it('holds the same contract in the plain-TS surgical pass', () => {
 		const source = `
 import { useEffect } from 'octane';
 import { imported } from './config';
@@ -143,14 +143,13 @@ export function useThing(value: number) {
 `;
 		const code = slotHooks(source, 'use-thing.ts')!.code;
 
-		// Emits [helper, value, SCALE]. Both entry points share hook-deps.js, so
-		// the gap and its fix are one and the same.
+		// The `.tsrx` compiler and this pass must agree on the same source.
 		expect(code).toMatch(/useEffect\([^;]*?, \[value\], _h\$\d+\)/);
 	});
 });
 
 describe('dependency stability — component-local invariants', () => {
-	it.fails('omits a component-local const bound to a literal', () => {
+	it('omits a component-local const bound to a literal', () => {
 		const code = c(`
       import { useEffect } from 'octane';
       export function App(props) @{
@@ -160,11 +159,11 @@ describe('dependency stability — component-local invariants', () => {
       }
     `);
 
-		// Emits [props.log, limit]. `limit` is 10 on every render by construction.
+		// `limit` is 10 on every render by construction, so nothing can witness it.
 		expect(depsOf(code)).toEqual(['props.log']);
 	});
 
-	it.fails('omits a component-local const aliasing an import', () => {
+	it('omits a component-local const aliasing an import', () => {
 		const code = c(`
       import { useEffect } from 'octane';
       import { fmt } from './fmt';
@@ -175,27 +174,20 @@ describe('dependency stability — component-local invariants', () => {
       }
     `);
 
-		// Emits [props.log, f, props.value]. markDependencyInvariantBindings
-		// propagates `const a = b` through an already-invariant `b`, but an
-		// IMPORTED binding is never marked invariant — it is only filtered at the
-		// use site — so the alias does not inherit it.
+		// Naming an invariant value does not make it reactive, so an alias must
+		// reach the same answer as the binding it aliases.
 		expect(depsOf(code)).toEqual(['props.log, props.value']);
 	});
 });
 
 describe('dependency inference — computed destructuring keys', () => {
-	// These were missed dependencies, not dead slots: the effect kept a stale
-	// `key` and never re-ran when it changed.
+	// A computed key is a READ of the surrounding scope, so it is a capture like
+	// any other — the object-literal case below is the same read in a position
+	// that was never in doubt. Dropping it is a missed dependency: the effect
+	// keeps a stale `key` and never re-runs when it changes.
 	//
-	// `buildScopes`'s `walkPatternDefaults` did not visit a computed ObjectPattern
-	// key, so those Identifier nodes got no `nodeScopes` entry.
-	// `collectDependencies`'s `walkPatternExpression` DOES visit them
-	// (`if (prop.computed) walk(prop.key)`) — the intent was never in doubt — but
-	// `addIdentifier` resolves through `nodeScopes`, and an unmapped node is
-	// indistinguishable from a genuine global, so the capture was skipped.
-	//
-	// Every binding position that admits a pattern routes through
-	// `walkPatternDefaults`, so each of these shapes is a separate entry into it.
+	// Patterns appear in several binding positions, and each reaches the walk
+	// differently, so every position gets a case.
 
 	it('tracks a computed key in a declaration inside the callback', () => {
 		const code = c(`
@@ -332,6 +324,79 @@ describe('dependency stability — guards the fixes must not break', () => {
     `);
 
 		expect(depsOf(code)).toEqual(['props.log, hits']);
+	});
+
+	it('keeps a module-scope function that some statement reassigns', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      function fmt(n) { return String(n); }
+      export function install(next) { fmt = next; }
+      export function App(props) @{
+        useEffect(() => { props.log(fmt(props.value)); });
+        <div />
+      }
+    `);
+
+		// A function binding is writable, unlike a const. Reassigned anywhere in
+		// the module — including from inside another function — it is reactive.
+		expect(depsOf(code)).toEqual(['props.log, fmt, props.value']);
+	});
+
+	it('keeps a module-scope class that some statement reassigns', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      class Thing {}
+      export function swap(next) { Thing = next; }
+      export function App(props) @{
+        useEffect(() => { props.log(new Thing()); });
+        <div />
+      }
+    `);
+
+		expect(depsOf(code)).toEqual(['props.log, Thing']);
+	});
+
+	it('keeps a module-scope var, which is neither const nor block scoped', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      var moduleVar = 0;
+      export function App(props) @{
+        useEffect(() => { props.log(moduleVar); });
+        <div />
+      }
+    `);
+
+		expect(depsOf(code)).toEqual(['props.log, moduleVar']);
+	});
+
+	it('omits an exported module-scope const and function alike', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      export const SCALE = 2;
+      export function fmt(n) { return String(n); }
+      export function App(props) @{
+        useEffect(() => { props.log(fmt(props.value * SCALE)); });
+        <div />
+      }
+    `);
+
+		// Exporting a binding does not let anything rebind it from outside.
+		expect(depsOf(code)).toEqual(['props.log, props.value']);
+	});
+
+	it('omits a name bound by a module-scope const destructuring pattern', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      const { mode, sizes: [first] } = { mode: 'fast', sizes: [1] };
+      export function App(props) @{
+        useEffect(() => { props.log(mode, first); });
+        <div />
+      }
+    `);
+
+		// The pattern runs once at module evaluation, so every name it binds is
+		// as fixed as a plain `const`.
+		expect(depsOf(code)).toEqual(['props.log']);
 	});
 
 	it('keeps a component-local const that shadows a module-scope const', () => {

--- a/packages/octane/tests/auto-hook-deps-stability.test.ts
+++ b/packages/octane/tests/auto-hook-deps-stability.test.ts
@@ -23,11 +23,17 @@ import { slotHooks } from '../src/compiler/slot-hooks.js';
 //
 // The final describe block holds the boundary: `let`, shadowing, and derived
 // values stay reactive, because for those the premise does not hold.
-const c = (source: string): string =>
-	compile(source, 'auto-deps-stability.tsrx', { inlineHookMemo: false }).code;
+const c = (source: string, options?: { mode?: 'client' | 'server'; filename?: string }): string =>
+	compile(source, options?.filename ?? 'auto-deps-stability.tsrx', {
+		inlineHookMemo: false,
+		...options,
+	}).code;
 
+// The inferred array, read back from the emitted hook call. The trailing slot
+// argument is a numeric index in `.tsrx` output and a Symbol alias in `.tsx`
+// output; both forms anchor the match without being asserted themselves.
 const depsOf = (code: string): string[] =>
-	[...code.matchAll(/\[([^[\]]*)\],\s*\d+\s*\)/g)].map((match) =>
+	[...code.matchAll(/\[([^[\]]*)\],\s*(?:\d+|_h\$\d+)\s*\)/g)].map((match) =>
 		match[1].replace(/\s+/g, ' ').trim(),
 	);
 
@@ -131,6 +137,41 @@ describe('dependency stability — module-scope immutable identities', () => {
 		expect(depsOf(code)).toEqual(['props.log']);
 	});
 
+	it('holds the same contract in a server compile', () => {
+		const code = c(
+			`
+      import { useEffect, useMemo } from 'octane';
+      const SCALE = 2;
+      function fmt(n) { return String(n); }
+      export function App(props) @{
+        const label = useMemo(() => fmt(props.value * SCALE));
+        useEffect(() => { props.log(label); });
+        <div>{label as string}</div>
+      }
+    `,
+			{ mode: 'server' },
+		);
+
+		expect(depsOf(code)).toEqual(['props.value', 'props.log, label']);
+	});
+
+	it('holds the same contract for a .tsx source', () => {
+		const code = c(
+			`
+      import { useEffect } from 'octane';
+      const SCALE = 2;
+      function fmt(n) { return String(n); }
+      export function App(props) {
+        useEffect(() => { props.log(fmt(props.value * SCALE)); });
+        return <div />;
+      }
+    `,
+			{ filename: 'auto-deps-stability.tsx' },
+		);
+
+		expect(depsOf(code)).toEqual(['props.log, props.value']);
+	});
+
 	it('holds the same contract in the plain-TS surgical pass', () => {
 		const source = `
 import { useEffect } from 'octane';
@@ -161,6 +202,62 @@ describe('dependency stability — component-local invariants', () => {
 
 		// `limit` is 10 on every render by construction, so nothing can witness it.
 		expect(depsOf(code)).toEqual(['props.log']);
+	});
+
+	it('keeps a component-local const bound to a regex literal', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      export function App(props) @{
+        const pattern = /foo/g;
+        useEffect(() => { props.log(pattern); });
+        <div />
+      }
+    `);
+
+		// ESTree spells a regex as a `Literal`, but `/foo/g` allocates a fresh
+		// RegExp on every render and carries mutable `lastIndex` state, so it is
+		// reactive exactly like an object literal would be.
+		expect(depsOf(code)).toEqual(['props.log, pattern']);
+	});
+
+	it('keeps a component-local const bound to an object or array literal', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      export function App(props) @{
+        const options = { deep: true };
+        const items = [1, 2];
+        useEffect(() => { props.log(options, items); });
+        <div />
+      }
+    `);
+
+		expect(depsOf(code)).toEqual(['props.log, options, items']);
+	});
+
+	it('omits a component-local const bound to a substitution-free template', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      export function App(props) @{
+        const label = \`total\`;
+        useEffect(() => { props.log(label); });
+        <div />
+      }
+    `);
+
+		expect(depsOf(code)).toEqual(['props.log']);
+	});
+
+	it('keeps a component-local const bound to an interpolated template', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      export function App(props) @{
+        const label = \`total: \${props.total}\`;
+        useEffect(() => { props.log(label); });
+        <div />
+      }
+    `);
+
+		expect(depsOf(code)).toEqual(['props.log, label']);
 	});
 
 	it('omits a component-local const aliasing an import', () => {

--- a/packages/octane/tests/auto-hook-deps-stability.test.ts
+++ b/packages/octane/tests/auto-hook-deps-stability.test.ts
@@ -1,0 +1,364 @@
+import { describe, expect, it } from 'vitest';
+import { compile } from 'octane/compiler';
+import { slotHooks } from '../src/compiler/slot-hooks.js';
+
+// Known GAPS in compiler-inferred hook dependencies, written as executable
+// assertions of the intended behaviour.
+//
+// Every `it.fails` below states what the compiler SHOULD emit and currently
+// does not. They stay green while the gap is open and flip red the moment it
+// closes — at which point drop the `.fails` rather than deleting the case.
+// The plain `it` blocks are the guards those fixes must not break.
+//
+// The contract being asserted is the same one two neighbouring passes already
+// hold, and which `hook-deps.js` alone does not:
+//
+//   - an IMPORTED binding is already omitted from an inferred array, because a
+//     module binding's identity is fixed for the program lifetime;
+//   - autoMemo's `plainCalleeIsMemoizable` already treats a same-module
+//     `function` declaration that is never reassigned as a "module-scope
+//     immutable identity", indistinguishable from an import.
+//
+// A same-module `const`/`function`/`class` is that same identity, so making it
+// a reactive dependency is a dead comparison slot in every emitted array and a
+// behavioural difference between `import { fmt } from './fmt'` and the byte
+// identical helper declared locally.
+const c = (source: string): string =>
+	compile(source, 'auto-deps-stability.tsrx', { inlineHookMemo: false }).code;
+
+const depsOf = (code: string): string[] =>
+	[...code.matchAll(/\[([^[\]]*)\],\s*\d+\s*\)/g)].map((match) =>
+		match[1].replace(/\s+/g, ' ').trim(),
+	);
+
+describe('dependency stability — module-scope immutable identities', () => {
+	it.fails('omits a module-scope const binding', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      const SCALE = 2;
+      export function App(props) @{
+        useEffect(() => { props.log(props.value * SCALE); });
+        <div />
+      }
+    `);
+
+		// Emits [props.log, props.value, SCALE].
+		expect(depsOf(code)).toEqual(['props.log, props.value']);
+	});
+
+	it.fails('omits a module-scope function declaration', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      function fmt(n) { return String(n); }
+      export function App(props) @{
+        useEffect(() => { props.log(fmt(props.value)); });
+        <div />
+      }
+    `);
+
+		// Emits [props.log, fmt, props.value]. An `import { fmt } from './fmt'`
+		// with the identical call site already emits [props.log, props.value].
+		expect(depsOf(code)).toEqual(['props.log, props.value']);
+	});
+
+	it.fails('omits a module-scope const arrow function', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      const fmt = (n) => String(n);
+      export function App(props) @{
+        useEffect(() => { props.log(fmt(props.value)); });
+        <div />
+      }
+    `);
+
+		expect(depsOf(code)).toEqual(['props.log, props.value']);
+	});
+
+	it.fails('omits a module-scope class binding', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      class Thing {}
+      export function App(props) @{
+        useEffect(() => { props.log(new Thing()); });
+        <div />
+      }
+    `);
+
+		expect(depsOf(code)).toEqual(['props.log']);
+	});
+
+	it.fails('omits a member read of a module-scope const object', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      const CONFIG = { mode: 'fast' };
+      export function App(props) @{
+        useEffect(() => { props.log(CONFIG.mode); });
+        <div />
+      }
+    `);
+
+		// Emits [props.log, CONFIG.mode]. `import * as CONFIG` + `CONFIG.mode` is
+		// already omitted, so the two spellings disagree on the same read.
+		expect(depsOf(code)).toEqual(['props.log']);
+	});
+
+	it.fails('omits a module-scope component referenced as a JSX tag', () => {
+		const code = c(`
+      import { useMemo } from 'octane';
+      function Row(props) @{ <li>{props.text as string}</li> }
+      export function App(props) @{
+        const rows = useMemo(() => props.items.map((t) => <Row text={t} />));
+        <ul>{rows}</ul>
+      }
+    `);
+
+		// Emits [props.items, Row].
+		expect(depsOf(code)).toEqual(['props.items']);
+	});
+
+	it.fails('omits a module-scope const declared after the component', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      export function App(props) @{
+        useEffect(() => { props.log(LATER); });
+        <div />
+      }
+      const LATER = 5;
+    `);
+
+		// Declaration ORDER must not change the answer: the binding is immutable
+		// either way, and the scope walk already predeclares the whole module body.
+		expect(depsOf(code)).toEqual(['props.log']);
+	});
+
+	it.fails('holds the same contract in the plain-TS surgical pass', () => {
+		const source = `
+import { useEffect } from 'octane';
+import { imported } from './config';
+const SCALE = 2;
+function helper(n: number) { return n * SCALE; }
+export function useThing(value: number) {
+  useEffect(() => console.log(imported, helper(value), SCALE));
+}
+`;
+		const code = slotHooks(source, 'use-thing.ts')!.code;
+
+		// Emits [helper, value, SCALE]. Both entry points share hook-deps.js, so
+		// the gap and its fix are one and the same.
+		expect(code).toMatch(/useEffect\([^;]*?, \[value\], _h\$\d+\)/);
+	});
+});
+
+describe('dependency stability — component-local invariants', () => {
+	it.fails('omits a component-local const bound to a literal', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      export function App(props) @{
+        const limit = 10;
+        useEffect(() => { props.log(limit); });
+        <div />
+      }
+    `);
+
+		// Emits [props.log, limit]. `limit` is 10 on every render by construction.
+		expect(depsOf(code)).toEqual(['props.log']);
+	});
+
+	it.fails('omits a component-local const aliasing an import', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      import { fmt } from './fmt';
+      export function App(props) @{
+        const f = fmt;
+        useEffect(() => { props.log(f(props.value)); });
+        <div />
+      }
+    `);
+
+		// Emits [props.log, f, props.value]. markDependencyInvariantBindings
+		// propagates `const a = b` through an already-invariant `b`, but an
+		// IMPORTED binding is never marked invariant — it is only filtered at the
+		// use site — so the alias does not inherit it.
+		expect(depsOf(code)).toEqual(['props.log, props.value']);
+	});
+});
+
+describe('dependency inference — computed destructuring keys', () => {
+	// These were missed dependencies, not dead slots: the effect kept a stale
+	// `key` and never re-ran when it changed.
+	//
+	// `buildScopes`'s `walkPatternDefaults` did not visit a computed ObjectPattern
+	// key, so those Identifier nodes got no `nodeScopes` entry.
+	// `collectDependencies`'s `walkPatternExpression` DOES visit them
+	// (`if (prop.computed) walk(prop.key)`) — the intent was never in doubt — but
+	// `addIdentifier` resolves through `nodeScopes`, and an unmapped node is
+	// indistinguishable from a genuine global, so the capture was skipped.
+	//
+	// Every binding position that admits a pattern routes through
+	// `walkPatternDefaults`, so each of these shapes is a separate entry into it.
+
+	it('tracks a computed key in a declaration inside the callback', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      export function App(props) @{
+        const key = props.key;
+        useEffect(() => { const { [key]: picked } = props.map; props.log(picked); });
+        <div />
+      }
+    `);
+
+		expect(depsOf(code)).toEqual(['key, props.map, props.log']);
+	});
+
+	it('tracks a computed key in a nested function parameter pattern', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      export function App(props) @{
+        const key = props.key;
+        useEffect(() => { const f = ({ [key]: v }) => v; props.log(f(props.map)); });
+        <div />
+      }
+    `);
+
+		expect(depsOf(code)).toEqual(['key, props.log, props.map']);
+	});
+
+	it('tracks a computed key nested inside another pattern', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      export function App(props) @{
+        const key = props.key;
+        useEffect(() => { const { outer: { [key]: v } } = props.map; props.log(v); });
+        <div />
+      }
+    `);
+
+		expect(depsOf(code)).toEqual(['key, props.map, props.log']);
+	});
+
+	it('tracks a computed key inside an array pattern element', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      export function App(props) @{
+        const key = props.key;
+        useEffect(() => { const [{ [key]: v }] = props.rows; props.log(v); });
+        <div />
+      }
+    `);
+
+		expect(depsOf(code)).toEqual(['key, props.rows, props.log']);
+	});
+
+	it('tracks a computed key in a catch clause parameter', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      export function App(props) @{
+        const key = props.key;
+        useEffect(() => {
+          try { props.run(); } catch ({ [key]: v }) { props.log(v); }
+        });
+        <div />
+      }
+    `);
+
+		expect(depsOf(code)).toEqual(['props.run, key, props.log']);
+	});
+
+	it('tracks a computed key in a for-of declaration', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      export function App(props) @{
+        const key = props.key;
+        useEffect(() => { for (const { [key]: v } of props.rows) props.log(v); });
+        <div />
+      }
+    `);
+
+		expect(depsOf(code)).toEqual(['key, props.rows, props.log']);
+	});
+
+	it('tracks a computed key alongside a default value in the same pattern', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      export function App(props) @{
+        const key = props.key;
+        const fallback = props.fallback;
+        useEffect(() => { const { [key]: v = fallback } = props.map; props.log(v); });
+        <div />
+      }
+    `);
+
+		expect(depsOf(code)).toEqual(['key, fallback, props.map, props.log']);
+	});
+
+	it('already tracked a computed key in an object LITERAL, for contrast', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      export function App(props) @{
+        const key = props.key;
+        useEffect(() => { props.log({ [key]: 1 }); });
+        <div />
+      }
+    `);
+
+		expect(depsOf(code)).toEqual(['props.log, key']);
+	});
+
+	it('still binds the pattern names themselves, which are not captures', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      export function App(props) @{
+        const key = props.key;
+        useEffect(() => { const { [key]: picked, rest } = props.map; props.log(picked, rest); });
+        <div />
+      }
+    `);
+
+		// `picked`/`rest` are declared inside the callback, so they must NOT appear.
+		expect(depsOf(code)).toEqual(['key, props.map, props.log']);
+	});
+});
+
+describe('dependency stability — guards the fixes must not break', () => {
+	it('keeps a module-scope let, which any module statement may rebind', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      let hits = 0;
+      export function bump() { hits++; }
+      export function App(props) @{
+        useEffect(() => { props.log(hits); });
+        <div />
+      }
+    `);
+
+		expect(depsOf(code)).toEqual(['props.log, hits']);
+	});
+
+	it('keeps a component-local const that shadows a module-scope const', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      const SCALE = 2;
+      export function App(props) @{
+        const SCALE = props.scale;
+        useEffect(() => { props.log(SCALE); });
+        <div />
+      }
+    `);
+
+		expect(depsOf(code)).toEqual(['props.log, SCALE']);
+	});
+
+	it('keeps a component-local const bound to a reactive expression', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      const SCALE = 2;
+      export function App(props) @{
+        const scaled = props.value * SCALE;
+        useEffect(() => { props.log(scaled); });
+        <div />
+      }
+    `);
+
+		expect(depsOf(code)).toEqual(['props.log, scaled']);
+	});
+});

--- a/packages/octane/tests/auto-hook-deps.test.ts
+++ b/packages/octane/tests/auto-hook-deps.test.ts
@@ -137,7 +137,7 @@ describe('automatic hook dependencies — full compiler', () => {
 		expect(code).not.toMatch(/\[\s*ref\.current/);
 	});
 
-	it('tracks mutable module bindings while omitting imports', () => {
+	it('tracks mutable module bindings while omitting immutable ones', () => {
 		const code = c(`
       import { useEffect } from 'octane';
       import { importedValue } from './config';
@@ -151,9 +151,11 @@ describe('automatic hook dependencies — full compiler', () => {
       }
     `);
 
-		expect(code).toMatch(
-			/useEffect\([\s\S]*?,\s*\[props\.log, moduleValue, moduleObject\.value\],\s*\d+\s*\)/,
-		);
+		// `let` is the only one of the three a later statement can rebind, so it is
+		// the only one a dependency array can witness. An import and a module-scope
+		// `const` are both fixed for the program's lifetime — see
+		// auto-hook-deps-stability.test.ts for that contract in full.
+		expect(code).toMatch(/useEffect\([\s\S]*?,\s*\[props\.log, moduleValue\],\s*\d+\s*\)/);
 	});
 
 	it('emits valid chain expressions for deep optional reads', () => {


### PR DESCRIPTION
## Summary

Three defects in compiler-inferred hook dependency capture analysis, as three reviewable commits.

1. **A computed key in a binding pattern was dropped from the inferred array** — a missed dependency, so a stale closure.
2. **Module-scope immutable bindings were emitted as dependencies** — dead comparison slots, and an inconsistency with imports.
3. **Regex literals were wrongly treated as invariant** — caught in review on this branch, before it left the PR.

## Why

### Computed destructuring keys (`9d1911af`)

`const { [key]: picked } = source` reads `key` from the surrounding scope, but the scope walk never visited computed keys, so the identifier got no scope mapping. The collection side resolves every capture through that map and cannot distinguish an unmapped node from a genuine global, so `key` was silently skipped:

```js
const key = props.key;
useEffect(() => { const { [key]: picked } = props.map; props.log(picked); });
// before: [props.map, props.log]      ← key missing, effect never re-runs
// after:  [key, props.map, props.log]
```

The collection side already walked computed keys, so the two walkers simply disagreed — the intent was never in doubt. The same read in an object *literal* (`{ [key]: 1 }`) was always tracked correctly.

### Module-scope immutable bindings (`83492d6e`)

A dependency array tracks what can change **between renders**. A binding evaluated once for the program's lifetime cannot. Three neighbouring places already agree:

- an **imported** binding is omitted from an inferred array;
- React's `exhaustive-deps` never asks you to list an outer-scope value;
- autoMemo's `plainCalleeIsMemoizable` calls a same-module never-reassigned `function` declaration *"a module-scope immutable identity"*, explicitly indistinguishable from an import.

Only `hook-deps.js` disagreed, so `import { fmt } from './fmt'` and a byte-identical local helper produced different arrays.

Real case — `website/src/components/BenchBars.tsrx`, where `barView`/`shortLabel` are module functions and `OVERALL_OP` a module const:

```
before: [compare, card.series, card.rows, barView, op, OVERALL_OP, shortLabel]
after:  [compare, card.series, card.rows, op]
```

Across the repo's 1,429 `.tsrx` sources, inferred deps fall from 174 to 162, and deps rooted at a module-scope `const`/`function`/`class` from 13 to 0.

## Changes

- `hook-deps.js`: walk computed `ObjectPattern` keys in `walkPatternDefaults`, so every pattern position — declarations, parameters, catch clauses, for-of heads, and nesting — maps its reads.
- `hook-deps.js`: track `moduleImmutable` on module-scope `const`/`function`/`class` bindings and seed the invariance lattice with them (plus imports) before its fixpoint, so the existing `const alias = original` propagation carries them into component scope for free. A local `const` binding a literal is omitted on the same grounds.
- `hook-deps.js`: exclude regex from the invariant-initializer predicate, and take ownership of it so `compile.js` imports one copy instead of keeping a second that had drifted.
- `auto-hook-deps-stability.test.ts`: new, 33 cases × 2 projects, spanning `.tsrx`, `.tsx`, server compile, and the plain-TS surgical pass.
- `auto-hook-deps-behavior.test.ts` + fixture: two runtime cases — see below.
- `auto-hook-deps.test.ts`: one existing case updated — it pinned `const moduleObject` as a dependency, which its own name (*"tracks mutable module bindings"*) already argued against. Retitled and sharpened.
- `docs/differences-from-react.md`: the contract, including the one behavioural change below.
- Changeset (`patch`).

### What stays reactive

`let` and `var` at module scope; a `function`/`class` binding that anything reassigns; a component-local name shadowing a module one; anything derived from a reactive value. Each has a guard test, and I mutation-tested both gates — dropping the reassignment gate fails exactly the two reassignment cases, and widening the declaration kind fails exactly the `var` case plus the two pre-existing module-`let` tests.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 14,186 passed, 1,407 files, 0 failed
- [x] targeted: every computed-key case verified red before the fix (8 of 9 — the object-literal control stays green); both module-scope gates verified by deliberate mutation

## Risk / follow-ups

**One behavioural change:** a member read through a module-scope `const` (`CONFIG.mode`) is now omitted. A module-level object mutated in place stops being witnessed by a dependency array — but it already was not witnessed when reached through a namespace import, so this makes the two spellings agree rather than newly breaking anything. Documented, with the guidance to hold such state in a store or in state.

**Deliberately not done:** a never-reassigned module-scope `let` is technically stable, but binding kind is a local, obviously-correct rule where "never reassigned anywhere in the module" is a whole-module analysis for marginal gain.

**An existing test was overclaiming.** `auto-hook-deps-behavior.test.ts`'s *"tracks computed destructuring keys, defaults, records, and observers"* varied the computed key **and** the fallback together. The fallback was in the array, so it drove the rerun — the test passed for the entire time the key was being dropped. Added a case that varies only the key, verified red without the fix in both the dev and production-tier projects, plus a fixture proving omitted module-scope captures still resolve and still don't rerun. Behavioral coverage runs under `octane-prod` too, so the inline hook-memo tier is exercised rather than only the `inlineHookMemo: false` diagnostic form the source assertions use.

**Follow-up:** cross-module stability is still invisible — the compiler cannot see that `useDispatch()` or `useSetAtom()` return lifetime-stable values. The natural shape is a declarative `stableHooks` registry mirroring the existing `hookRuntimeModules` option, each binding package shipping its own map. Worth sizing only now that module scope is handled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
