### PR TITLE
Remove empty and whitespace DOM benchmarks

### DIFF
--- a/benchmarks/baselines/local/recursive-context.json
+++ b/benchmarks/baselines/local/recursive-context.json
@@ -97,11 +97,6 @@
           "min": 10,
           "samples": 1
         },
-        "empty_text_mounted": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
         "nodes_partial_unmounted": {
           "median": 2984,
           "min": 2984,
@@ -120,16 +115,6 @@
         "comments_partial_unmounted": {
           "median": 8,
           "min": 8,
-          "samples": 1
-        },
-        "empty_text_partial_unmounted": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "whitespace_text_partial_unmounted": {
-          "median": 0,
-          "min": 0,
           "samples": 1
         }
       },
@@ -282,11 +267,6 @@
           "min": 8192,
           "samples": 1
         },
-        "empty_text_mounted": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
         "nodes_partial_unmounted": {
           "median": 10920,
           "min": 10920,
@@ -305,16 +285,6 @@
         "comments_partial_unmounted": {
           "median": 7944,
           "min": 7944,
-          "samples": 1
-        },
-        "empty_text_partial_unmounted": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "whitespace_text_partial_unmounted": {
-          "median": 0,
-          "min": 0,
           "samples": 1
         }
       },
@@ -468,11 +438,6 @@
           "min": 2046,
           "samples": 1
         },
-        "empty_text_mounted": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
         "nodes_partial_unmounted": {
           "median": 4961,
           "min": 4961,
@@ -491,16 +456,6 @@
         "comments_partial_unmounted": {
           "median": 1984,
           "min": 1984,
-          "samples": 1
-        },
-        "empty_text_partial_unmounted": {
-          "median": 1,
-          "min": 1,
-          "samples": 1
-        },
-        "whitespace_text_partial_unmounted": {
-          "median": 0,
-          "min": 0,
           "samples": 1
         }
       },
@@ -648,11 +603,6 @@
           "min": 0,
           "samples": 1
         },
-        "empty_text_mounted": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
         "nodes_partial_unmounted": {
           "median": 2976,
           "min": 2976,
@@ -669,16 +619,6 @@
           "samples": 1
         },
         "comments_partial_unmounted": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "empty_text_partial_unmounted": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "whitespace_text_partial_unmounted": {
           "median": 0,
           "min": 0,
           "samples": 1
@@ -819,11 +759,6 @@
           "min": 0,
           "samples": 1
         },
-        "empty_text_mounted": {
-          "median": 1,
-          "min": 1,
-          "samples": 1
-        },
         "nodes_partial_unmounted": {
           "median": 2977,
           "min": 2977,
@@ -840,16 +775,6 @@
           "samples": 1
         },
         "comments_partial_unmounted": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "empty_text_partial_unmounted": {
-          "median": 1,
-          "min": 1,
-          "samples": 1
-        },
-        "whitespace_text_partial_unmounted": {
           "median": 0,
           "min": 0,
           "samples": 1
@@ -990,11 +915,6 @@
           "min": 0,
           "samples": 1
         },
-        "empty_text_mounted": {
-          "median": 4094,
-          "min": 4094,
-          "samples": 1
-        },
         "nodes_partial_unmounted": {
           "median": 6946,
           "min": 6946,
@@ -1011,16 +931,6 @@
           "samples": 1
         },
         "comments_partial_unmounted": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "empty_text_partial_unmounted": {
-          "median": 3970,
-          "min": 3970,
-          "samples": 1
-        },
-        "whitespace_text_partial_unmounted": {
           "median": 0,
           "min": 0,
           "samples": 1
@@ -1161,11 +1071,6 @@
           "min": 0,
           "samples": 1
         },
-        "empty_text_mounted": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
         "nodes_partial_unmounted": {
           "median": 2976,
           "min": 2976,
@@ -1182,16 +1087,6 @@
           "samples": 1
         },
         "comments_partial_unmounted": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "empty_text_partial_unmounted": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "whitespace_text_partial_unmounted": {
           "median": 0,
           "min": 0,
           "samples": 1
@@ -1332,11 +1227,6 @@
           "min": 5117,
           "samples": 1
         },
-        "empty_text_mounted": {
-          "median": 3072,
-          "min": 3072,
-          "samples": 1
-        },
         "nodes_partial_unmounted": {
           "median": 11911,
           "min": 11911,
@@ -1355,16 +1245,6 @@
         "comments_partial_unmounted": {
           "median": 4963,
           "min": 4963,
-          "samples": 1
-        },
-        "empty_text_partial_unmounted": {
-          "median": 2980,
-          "min": 2980,
-          "samples": 1
-        },
-        "whitespace_text_partial_unmounted": {
-          "median": 992,
-          "min": 992,
           "samples": 1
         }
       },

--- a/benchmarks/baselines/local/signal-favoring.json
+++ b/benchmarks/baselines/local/signal-favoring.json
@@ -120,11 +120,6 @@
           "median": 109,
           "min": 109,
           "samples": 1
-        },
-        "empty_text_mounted": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
         }
       },
       "meta": {
@@ -269,11 +264,6 @@
         "comments_mounted": {
           "median": 208,
           "min": 208,
-          "samples": 1
-        },
-        "empty_text_mounted": {
-          "median": 0,
-          "min": 0,
           "samples": 1
         }
       },
@@ -420,11 +410,6 @@
           "median": 20,
           "min": 20,
           "samples": 1
-        },
-        "empty_text_mounted": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
         }
       },
       "meta": {
@@ -570,11 +555,6 @@
           "median": 0,
           "min": 0,
           "samples": 1
-        },
-        "empty_text_mounted": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
         }
       },
       "meta": {
@@ -715,11 +695,6 @@
         "comments_mounted": {
           "median": 99,
           "min": 99,
-          "samples": 1
-        },
-        "empty_text_mounted": {
-          "median": 1,
-          "min": 1,
           "samples": 1
         }
       },
@@ -866,11 +841,6 @@
           "median": 0,
           "min": 0,
           "samples": 1
-        },
-        "empty_text_mounted": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
         }
       },
       "meta": {
@@ -1009,11 +979,6 @@
           "samples": 1
         },
         "comments_mounted": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "empty_text_mounted": {
           "median": 0,
           "min": 0,
           "samples": 1
@@ -1157,11 +1122,6 @@
         "comments_mounted": {
           "median": 99,
           "min": 99,
-          "samples": 1
-        },
-        "empty_text_mounted": {
-          "median": 1,
-          "min": 1,
           "samples": 1
         }
       },

--- a/benchmarks/recursive-context/run.mjs
+++ b/benchmarks/recursive-context/run.mjs
@@ -364,13 +364,10 @@ const DOM_OPS = [
 	['elements_mounted', 'mounted', 'elements'],
 	['text_mounted', 'mounted', 'text'],
 	['comments_mounted', 'mounted', 'comments'],
-	['empty_text_mounted', 'mounted', 'emptyText'],
 	['nodes_partial_unmounted', 'partialUnmounted', 'total'],
 	['elements_partial_unmounted', 'partialUnmounted', 'elements'],
 	['text_partial_unmounted', 'partialUnmounted', 'text'],
 	['comments_partial_unmounted', 'partialUnmounted', 'comments'],
-	['empty_text_partial_unmounted', 'partialUnmounted', 'emptyText'],
-	['whitespace_text_partial_unmounted', 'partialUnmounted', 'whitespaceText'],
 ];
 
 const DIALECT_PAIR_NAMES = ['octane-tsrx', 'octane-jsx'];

--- a/benchmarks/signal-favoring/run.mjs
+++ b/benchmarks/signal-favoring/run.mjs
@@ -404,7 +404,6 @@ const DOM_OPS = [
 	['elements_mounted', 'elements'],
 	['text_mounted', 'text'],
 	['comments_mounted', 'comments'],
-	['empty_text_mounted', 'emptyText'],
 ];
 
 const DIALECT_PAIR_NAMES = ['octane-tsrx', 'octane-jsx'];


### PR DESCRIPTION
## Summary

- remove `empty_text_mounted` from the recursive-context and signal-favoring benchmark harnesses
- remove `empty_text_partial_unmounted` and `whitespace_text_partial_unmounted` from recursive-context
- remove all corresponding records from the local baselines
- keep the underlying DOM snapshots and meaningful aggregate node metrics unchanged

## Why

These operations expose formatting and framework-marker details rather than actionable application work. Their values are easy to misread as comparable mount or unmount costs across frameworks, so publishing them as standalone benchmark results is misleading.

## Impact

The affected suites no longer publish or compare these three operations. Timing, total-node, element, text, comment, and raw DOM snapshot data are unchanged.

## Checks

- `node --check benchmarks/recursive-context/run.mjs`
- `node --check benchmarks/signal-favoring/run.mjs`
- parsed both edited baseline JSON files with Node
- verified no remaining references to the three removed operation names under `benchmarks/`
- Prettier check for all four changed files
- `node benchmarks/bench.mjs --list`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark reporting-only change; no runtime or framework code paths affected.
> 
> **Overview**
> Stops publishing **empty** and **whitespace** text-node counts as first-class benchmark operations in the **recursive-context** and **signal-favoring** harnesses.
> 
> **recursive-context** no longer reports `empty_text_mounted`, `empty_text_partial_unmounted`, or `whitespace_text_partial_unmounted`; **signal-favoring** drops `empty_text_mounted`. The `DOM_OPS` tables in `run.mjs` for both suites are trimmed accordingly, and matching keys are removed from the local baseline JSON files.
> 
> Timing ops and aggregate DOM metrics (nodes, elements, text, comments) are unchanged. Full DOM snapshots under `meta.dom` still include `emptyText` and `whitespaceText` for inspection—they are just not surfaced as standalone comparable ops.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05c64da5801122a83d35c96d58c66ec19d596fc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->