### PR TITLE
fix: regenerated data

### DIFF
--- a/packages/cli/src/data/octane-data.json
+++ b/packages/cli/src/data/octane-data.json
@@ -34,16 +34,16 @@
       "version": "0.1.15",
       "category": "UI and interaction",
       "upstream": { "package": "@base-ui/react", "version": "1.6.0" },
-      "surface": "Alpha, in progress: 28 of 43 upstream subpaths. The foundation, overlay infrastructure, hover/focus interaction layer and popup viewport have landed, along with Dialog, AlertDialog, Popover, Tooltip, PreviewCard, the full form-control set, and the standalone Button/DirectionProvider/CSPProvider/useMediaQuery utilities — ported at full fidelity and differential-verified against the real `@base-ui/react`.",
+      "surface": "Alpha, in progress: 29 of 43 upstream subpaths. The foundation, overlay infrastructure, hover/focus interaction layer, list-navigation/typeahead layer and popup viewport have landed, along with Dialog, AlertDialog, Popover, Tooltip, PreviewCard, the full form-control set, and the standalone Button/DirectionProvider/CSPProvider/useMediaQuery utilities — ported at full fidelity and differential-verified against the real `@base-ui/react`. Menu is PARTIAL: `Root`/`Trigger`/`Portal`/`Positioner`/`Popup` (the open/close + roving-focus path) are in place; items, submenus, `Viewport`/`Arrow`/`Backdrop`/`Separator`, Menubar and ContextMenu are not yet ported.",
       "divergences": [
-        "Handlers receive native DOM events (no synthetic layer): visible text controls use per-edit `input`, while the NumberField form-facing number input intentionally observes native `change` commits.",
+        "Handlers receive native DOM events (no synthetic layer): visible text controls use per-edit `input`, while the NumberField form-facing number input intentionally observes native `change` commits. React's synthetic-only `event.isPropagationStopped()` (used by Menu's popup keyboard relay) becomes a native `event.cancelBubble` read.",
         "`forwardRef` becomes ref-as-prop; `className` composes via octane's `normalizeClass` (the render-prop string merge matches Base UI exactly).",
         "The vendored `floating-ui-react` surface is internal rather than republished, so its standalone `useHover` combiner is not ported — no Base UI component uses it.",
         "Tooltips outside a `Tooltip.Provider` still share the delay-group context's module-level default refs, so opening one closes another. Transcribed from Base UI rather than chosen; pinned by `tests/tooltip-delay-group.test.ts`.",
         "`NumberField.ScrubArea` and hold-to-repeat stepping remain unported; the steppers respond to single presses only."
       ],
       "ssr": "Dedicated Node-mode tests cover server snapshots, accessible separators, edge-aligned slider visibility, and closed dialogs; hydration adopts Vite-compiled Octane server markup, transitions to the client snapshot, and preserves interaction. Open overlays and remaining components are not yet covered.",
-      "verified": "2026-07-26"
+      "verified": "2026-07-27"
     },
     {
       "name": "@octanejs/cmdk",


### PR DESCRIPTION
Regenerated CLI data (json)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only regeneration of CLI catalog JSON; no runtime or application logic changes.
> 
> **Overview**
> Refreshes the CLI’s snapshotted **`octane-data.json`** so **`@octanejs/base-ui`** matches the current port status.
> 
> **`surface`** now reports **29 of 43** upstream subpaths (was 28), including the **list-navigation/typeahead** layer, and documents **Menu as PARTIAL** (`Root`/`Trigger`/`Portal`/`Positioner`/`Popup` in place; items, submenus, chrome, Menubar, and ContextMenu still out).
> 
> **`divergences`** adds that Menu’s popup keyboard relay maps React’s **`event.isPropagationStopped()`** to native **`event.cancelBubble`**.
> 
> **`verified`** is bumped to **2026-07-27**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77f45733c2d8f2f89976103430c8b453ff04b6c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->