### PR TITLE
Remove portal swarm DOM count operations

### DIFF
--- a/benchmarks/baselines/local/portal-swarm.json
+++ b/benchmarks/baselines/local/portal-swarm.json
@@ -100,66 +100,6 @@
           "scoreRme": 13.45121547072046,
           "warmupRatio": 1,
           "samples": 20
-        },
-        "nodes_closed_main": {
-          "median": 2622,
-          "min": 2622,
-          "samples": 1
-        },
-        "elements_closed_main": {
-          "median": 1411,
-          "min": 1411,
-          "samples": 1
-        },
-        "text_closed_main": {
-          "median": 603,
-          "min": 603,
-          "samples": 1
-        },
-        "comments_closed_main": {
-          "median": 608,
-          "min": 608,
-          "samples": 1
-        },
-        "nodes_open_main": {
-          "median": 2822,
-          "min": 2822,
-          "samples": 1
-        },
-        "comments_open_main": {
-          "median": 608,
-          "min": 608,
-          "samples": 1
-        },
-        "nodes_open_body": {
-          "median": 7025,
-          "min": 7025,
-          "samples": 1
-        },
-        "elements_open_body": {
-          "median": 3412,
-          "min": 3412,
-          "samples": 1
-        },
-        "text_open_body": {
-          "median": 1805,
-          "min": 1805,
-          "samples": 1
-        },
-        "comments_open_body": {
-          "median": 1808,
-          "min": 1808,
-          "samples": 1
-        },
-        "empty_text_open_body": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "whitespace_text_open_body": {
-          "median": 2,
-          "min": 2,
-          "samples": 1
         }
       },
       "meta": {
@@ -348,66 +288,6 @@
           "scoreRme": 5.996325080602008,
           "warmupRatio": 0.927710854448243,
           "samples": 20
-        },
-        "nodes_closed_main": {
-          "median": 2014,
-          "min": 2014,
-          "samples": 1
-        },
-        "elements_closed_main": {
-          "median": 1411,
-          "min": 1411,
-          "samples": 1
-        },
-        "text_closed_main": {
-          "median": 603,
-          "min": 603,
-          "samples": 1
-        },
-        "comments_closed_main": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "nodes_open_main": {
-          "median": 2214,
-          "min": 2214,
-          "samples": 1
-        },
-        "comments_open_main": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "nodes_open_body": {
-          "median": 5217,
-          "min": 5217,
-          "samples": 1
-        },
-        "elements_open_body": {
-          "median": 3412,
-          "min": 3412,
-          "samples": 1
-        },
-        "text_open_body": {
-          "median": 1805,
-          "min": 1805,
-          "samples": 1
-        },
-        "comments_open_body": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "empty_text_open_body": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "whitespace_text_open_body": {
-          "median": 2,
-          "min": 2,
-          "samples": 1
         }
       },
       "meta": {
@@ -569,66 +449,6 @@
           "scoreRme": 28.579502464807156,
           "warmupRatio": 1.0000001589457446,
           "samples": 20
-        },
-        "nodes_closed_main": {
-          "median": 2618,
-          "min": 2618,
-          "samples": 1
-        },
-        "elements_closed_main": {
-          "median": 1411,
-          "min": 1411,
-          "samples": 1
-        },
-        "text_closed_main": {
-          "median": 1203,
-          "min": 1203,
-          "samples": 1
-        },
-        "comments_closed_main": {
-          "median": 4,
-          "min": 4,
-          "samples": 1
-        },
-        "nodes_open_main": {
-          "median": 2618,
-          "min": 2618,
-          "samples": 1
-        },
-        "comments_open_main": {
-          "median": 4,
-          "min": 4,
-          "samples": 1
-        },
-        "nodes_open_body": {
-          "median": 5621,
-          "min": 5621,
-          "samples": 1
-        },
-        "elements_open_body": {
-          "median": 3212,
-          "min": 3212,
-          "samples": 1
-        },
-        "text_open_body": {
-          "median": 2405,
-          "min": 2405,
-          "samples": 1
-        },
-        "comments_open_body": {
-          "median": 4,
-          "min": 4,
-          "samples": 1
-        },
-        "empty_text_open_body": {
-          "median": 600,
-          "min": 600,
-          "samples": 1
-        },
-        "whitespace_text_open_body": {
-          "median": 2,
-          "min": 2,
-          "samples": 1
         }
       },
       "meta": {
@@ -802,66 +622,6 @@
           "scoreRme": 17.14773238427606,
           "warmupRatio": 0.9600000343322789,
           "samples": 20
-        },
-        "nodes_closed_main": {
-          "median": 2619,
-          "min": 2619,
-          "samples": 1
-        },
-        "elements_closed_main": {
-          "median": 1411,
-          "min": 1411,
-          "samples": 1
-        },
-        "text_closed_main": {
-          "median": 608,
-          "min": 608,
-          "samples": 1
-        },
-        "comments_closed_main": {
-          "median": 600,
-          "min": 600,
-          "samples": 1
-        },
-        "nodes_open_main": {
-          "median": 2619,
-          "min": 2619,
-          "samples": 1
-        },
-        "comments_open_main": {
-          "median": 600,
-          "min": 600,
-          "samples": 1
-        },
-        "nodes_open_body": {
-          "median": 6222,
-          "min": 6222,
-          "samples": 1
-        },
-        "elements_open_body": {
-          "median": 3212,
-          "min": 3212,
-          "samples": 1
-        },
-        "text_open_body": {
-          "median": 2410,
-          "min": 2410,
-          "samples": 1
-        },
-        "comments_open_body": {
-          "median": 600,
-          "min": 600,
-          "samples": 1
-        },
-        "empty_text_open_body": {
-          "median": 605,
-          "min": 605,
-          "samples": 1
-        },
-        "whitespace_text_open_body": {
-          "median": 2,
-          "min": 2,
-          "samples": 1
         }
       },
       "meta": {
@@ -1035,66 +795,6 @@
           "scoreRme": 22.8052592660955,
           "warmupRatio": 0.96153841216184,
           "samples": 20
-        },
-        "nodes_closed_main": {
-          "median": 2618,
-          "min": 2618,
-          "samples": 1
-        },
-        "elements_closed_main": {
-          "median": 1411,
-          "min": 1411,
-          "samples": 1
-        },
-        "text_closed_main": {
-          "median": 1207,
-          "min": 1207,
-          "samples": 1
-        },
-        "comments_closed_main": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "nodes_open_main": {
-          "median": 3818,
-          "min": 3818,
-          "samples": 1
-        },
-        "comments_open_main": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "nodes_open_body": {
-          "median": 8021,
-          "min": 8021,
-          "samples": 1
-        },
-        "elements_open_body": {
-          "median": 3212,
-          "min": 3212,
-          "samples": 1
-        },
-        "text_open_body": {
-          "median": 4809,
-          "min": 4809,
-          "samples": 1
-        },
-        "comments_open_body": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "empty_text_open_body": {
-          "median": 3004,
-          "min": 3004,
-          "samples": 1
-        },
-        "whitespace_text_open_body": {
-          "median": 2,
-          "min": 2,
-          "samples": 1
         }
       },
       "meta": {
@@ -1256,66 +956,6 @@
           "scoreRme": 25.217201496475067,
           "warmupRatio": 1.0588234551637872,
           "samples": 20
-        },
-        "nodes_closed_main": {
-          "median": 2014,
-          "min": 2014,
-          "samples": 1
-        },
-        "elements_closed_main": {
-          "median": 1411,
-          "min": 1411,
-          "samples": 1
-        },
-        "text_closed_main": {
-          "median": 603,
-          "min": 603,
-          "samples": 1
-        },
-        "comments_closed_main": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "nodes_open_main": {
-          "median": 2214,
-          "min": 2214,
-          "samples": 1
-        },
-        "comments_open_main": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "nodes_open_body": {
-          "median": 5217,
-          "min": 5217,
-          "samples": 1
-        },
-        "elements_open_body": {
-          "median": 3412,
-          "min": 3412,
-          "samples": 1
-        },
-        "text_open_body": {
-          "median": 1805,
-          "min": 1805,
-          "samples": 1
-        },
-        "comments_open_body": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "empty_text_open_body": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "whitespace_text_open_body": {
-          "median": 2,
-          "min": 2,
-          "samples": 1
         }
       },
       "meta": {
@@ -1477,66 +1117,6 @@
           "scoreRme": 12.769795345904148,
           "warmupRatio": 0.9642856625878072,
           "samples": 20
-        },
-        "nodes_closed_main": {
-          "median": 3228,
-          "min": 3228,
-          "samples": 1
-        },
-        "elements_closed_main": {
-          "median": 1411,
-          "min": 1411,
-          "samples": 1
-        },
-        "text_closed_main": {
-          "median": 1214,
-          "min": 1214,
-          "samples": 1
-        },
-        "comments_closed_main": {
-          "median": 603,
-          "min": 603,
-          "samples": 1
-        },
-        "nodes_open_main": {
-          "median": 4828,
-          "min": 4828,
-          "samples": 1
-        },
-        "comments_open_main": {
-          "median": 1403,
-          "min": 1403,
-          "samples": 1
-        },
-        "nodes_open_body": {
-          "median": 8431,
-          "min": 8431,
-          "samples": 1
-        },
-        "elements_open_body": {
-          "median": 3412,
-          "min": 3412,
-          "samples": 1
-        },
-        "text_open_body": {
-          "median": 3616,
-          "min": 3616,
-          "samples": 1
-        },
-        "comments_open_body": {
-          "median": 1403,
-          "min": 1403,
-          "samples": 1
-        },
-        "empty_text_open_body": {
-          "median": 605,
-          "min": 605,
-          "samples": 1
-        },
-        "whitespace_text_open_body": {
-          "median": 1208,
-          "min": 1208,
-          "samples": 1
         }
       },
       "meta": {

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -628,58 +628,6 @@
     "note": "Semantic control: equivalent chat states render exactly 25 text nodes."
   },
   {
-    "suite": "portal-swarm",
-    "op": "nodes_closed_main",
-    "target": "octane-tsrx",
-    "reference": "react",
-    "maxRatio": 1.33,
-    "note": "Closed portal swarm #main census: Octane 2622 vs React 2014 nodes after component-item and dormant-if elision (1.302x, 2026-07-13)."
-  },
-  {
-    "suite": "portal-swarm",
-    "op": "elements_closed_main",
-    "target": "octane-tsrx",
-    "reference": "react",
-    "minRatio": 1.0,
-    "maxRatio": 1.0,
-    "note": "Semantic control: closed portal fixtures render exactly 1411 elements under #main."
-  },
-  {
-    "suite": "portal-swarm",
-    "op": "text_closed_main",
-    "target": "octane-tsrx",
-    "reference": "react",
-    "minRatio": 1.0,
-    "maxRatio": 1.0,
-    "note": "Semantic control: closed portal fixtures render exactly 603 text nodes under #main."
-  },
-  {
-    "suite": "portal-swarm",
-    "op": "nodes_open_body",
-    "target": "octane-tsrx",
-    "reference": "react",
-    "maxRatio": 1.38,
-    "note": "Open portal swarm whole-body census retains load-bearing foreign target pairs: Octane 7025 vs React 5217 nodes (1.347x, 2026-07-13)."
-  },
-  {
-    "suite": "portal-swarm",
-    "op": "elements_open_body",
-    "target": "octane-tsrx",
-    "reference": "react",
-    "minRatio": 1.0,
-    "maxRatio": 1.0,
-    "note": "Semantic control: open portal fixtures render exactly 3412 elements across main and foreign targets."
-  },
-  {
-    "suite": "portal-swarm",
-    "op": "text_open_body",
-    "target": "octane-tsrx",
-    "reference": "react",
-    "minRatio": 1.0,
-    "maxRatio": 1.0,
-    "note": "Semantic control: open portal fixtures render exactly 1805 text nodes across main and foreign targets."
-  },
-  {
     "suite": "three-renderer",
     "op": "mount_1k",
     "target": "octane",

--- a/benchmarks/portal-swarm/run.mjs
+++ b/benchmarks/portal-swarm/run.mjs
@@ -53,7 +53,7 @@
 
 import { chromium } from 'playwright';
 import fs from 'node:fs';
-import { censusDomNodes, deterministicCount } from '../lib/dom-nodes.mjs';
+import { censusDomNodes } from '../lib/dom-nodes.mjs';
 import { scoreOf, summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
 
 const ITER = parseInt(process.argv[2] || '20', 10);
@@ -94,20 +94,6 @@ const OPS = [
 	'open_close_cycle',
 	'open_close_distinct',
 	'dispatch_through_portal',
-];
-const DOM_OPS = [
-	'nodes_closed_main',
-	'elements_closed_main',
-	'text_closed_main',
-	'comments_closed_main',
-	'nodes_open_main',
-	'comments_open_main',
-	'nodes_open_body',
-	'elements_open_body',
-	'text_open_body',
-	'comments_open_body',
-	'empty_text_open_body',
-	'whitespace_text_open_body',
 ];
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
@@ -472,18 +458,6 @@ async function runTarget(t) {
 			open_close_cycle,
 			open_close_distinct,
 			dispatch_through_portal,
-			nodes_closed_main: deterministicCount(dom.closedMain.total),
-			elements_closed_main: deterministicCount(dom.closedMain.elements),
-			text_closed_main: deterministicCount(dom.closedMain.text),
-			comments_closed_main: deterministicCount(dom.closedMain.comments),
-			nodes_open_main: deterministicCount(dom.openMain.total),
-			comments_open_main: deterministicCount(dom.openMain.comments),
-			nodes_open_body: deterministicCount(dom.openBody.total),
-			elements_open_body: deterministicCount(dom.openBody.elements),
-			text_open_body: deterministicCount(dom.openBody.text),
-			comments_open_body: deterministicCount(dom.openBody.comments),
-			empty_text_open_body: deterministicCount(dom.openBody.emptyText),
-			whitespace_text_open_body: deterministicCount(dom.openBody.whitespaceText),
 		},
 		meta: {
 			gates: 'pass',
@@ -503,19 +477,7 @@ function writeBenchJson(all, failed) {
 		iterations: ITER,
 		targets: TARGETS.filter((t) => all[t.name]).map((t) => ({
 			name: t.name,
-			ops: Object.fromEntries(
-				[...OPS, ...DOM_OPS]
-					.filter((op) => all[t.name].results[op])
-					.map((op) => {
-						const r = all[t.name].results[op];
-						return [
-							op,
-							r.score == null
-								? { median: r.median, min: r.min, samples: r.samples.length }
-								: timingStatForJson(r),
-						];
-					}),
-			),
+			ops: Object.fromEntries(OPS.map((op) => [op, timingStatForJson(all[t.name].results[op])])),
 			meta: all[t.name].meta,
 		})),
 	};
@@ -548,11 +510,6 @@ for (const op of OPS) {
 		const r = all[c].results[op];
 		row.push(`${fmt(r.median)} (min ${fmt(r.min)}, sd ${fmt(r.stddev)})`.padEnd(W));
 	}
-	console.log(row.join('| '));
-}
-for (const op of DOM_OPS) {
-	const row = [op.padEnd(23)];
-	for (const c of cols) row.push(String(all[c].results[op].median).padEnd(W));
 	console.log(row.join('| '));
 }
 

--- a/website/src/content/home-benchmark.ts
+++ b/website/src/content/home-benchmark.ts
@@ -115,12 +115,12 @@ export const HOME_SUMMARY: BenchCard = {
 		{
 			op: 'portal-swarm',
 			'octane-tsrx': 1,
-			react: 2.6345384087565744,
-			preact: 2.9212365593032366,
-			solid: 0.4512400392440764,
-			svelte: 2.544428225389751,
-			ripple: 1.5436200245548042,
-			'vue-vapor': 1.271864317288355,
+			react: 7.674610301092914,
+			preact: 9.435843248855534,
+			solid: 1.0544782471163001,
+			svelte: 2.873552787834435,
+			ripple: 3.213255345880366,
+			'vue-vapor': 1.2497161384375328,
 		},
 		{
 			op: 'async-waterfall',


### PR DESCRIPTION
## Summary

- remove all 12 portal-swarm DOM census operations from benchmark results and console output
- remove their 84 local baseline records across seven framework targets
- remove all six portal-swarm DOM-count ratio guards
- remove the now-unused deterministic-count mapping and import
- preserve the full DOM census under target metadata for correctness verification

## Why

Portal-swarm is intended to compare mount, portal update, cycle, and event-dispatch time. Publishing node, element, text, comment, empty-text, and whitespace counts as benchmark operations mixes structural implementation details into the performance results and makes comparisons misleading.

## Impact

Every portal-swarm target now exposes only its eight timing operations. Correctness gates and `meta.dom` remain unchanged, so placement, portal shape, teardown, and dispatch semantics are still verified.

## Checks

- executed `benchmarks/portal-swarm/run.mjs` with an empty target set and `BENCH_JSON` enabled to cover summary and JSON post-processing
- parsed and validated the generated `BENCH_JSON` payload
- verified all seven local baseline targets contain only timing operations
- verified no portal-swarm ratio guards or promoted DOM operation names remain
- `node --check benchmarks/portal-swarm/run.mjs`
- Prettier check for all three changed files
- `node benchmarks/bench.mjs --list`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and documentation surface changes only; correctness gates and `meta.dom` verification are preserved, with no runtime product code affected.
> 
> **Overview**
> Portal-swarm benchmark output is narrowed to **eight timing operations** (mount, open, rerender, cycles, dispatch). The twelve DOM census metrics (`nodes_closed_main`, `elements_open_body`, etc.) are no longer emitted as `ops`, printed in the console table, or written to `BENCH_JSON`.
> 
> **Harness:** `DOM_OPS`, `deterministicCount`, and the extra console rows are removed; JSON export maps only `OPS` through `timingStatForJson`. **`meta.dom`** from `measureDomShape` / `censusDomNodes` is unchanged for correctness checks.
> 
> **Baselines & guards:** `portal-swarm.json` drops the DOM op records per target; **`ratios.json`** removes all six portal-swarm DOM-count ratio entries.
> 
> **Website:** `home-benchmark.ts` **portal-swarm** summary ratios are rebased to reflect timing-only suite aggregation (e.g. React ~7.67× vs ~2.63× previously).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e36f800cf8c20adea77911fef9518668953e4f81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->