### PR TITLE
fix(octane): render descriptor host children

### DIFF
--- a/.changeset/brave-motions-render.md
+++ b/.changeset/brave-motions-render.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Allow runtime host components to render descriptor children produced by TSX and `createElement` call sites.

--- a/packages/motion/tests/_fixtures/tsx-descriptor-children.tsx
+++ b/packages/motion/tests/_fixtures/tsx-descriptor-children.tsx
@@ -10,3 +10,16 @@ export function TsxDescriptorChildren(props: { first: string; second: string }) 
 		</section>
 	);
 }
+
+// A TSX value position can evaluate to `null`, which the compiled TSRX children
+// body never could (it is emitted statically, present or absent for the whole
+// component). Clearing the host must run through the same reconcile.
+export function ToggleableTsxChildren(props: { show: boolean }) {
+	return (
+		<section>
+			<motion.div id="tsx-toggle">
+				{props.show ? <span id="tsx-toggle-kid">kid</span> : null}
+			</motion.div>
+		</section>
+	);
+}

--- a/packages/motion/tests/_fixtures/tsx-descriptor-children.tsx
+++ b/packages/motion/tests/_fixtures/tsx-descriptor-children.tsx
@@ -1,0 +1,12 @@
+import { motion } from '@octanejs/motion';
+
+export function TsxDescriptorChildren(props: { first: string; second: string }) {
+	return (
+		<section>
+			<motion.div id="tsx-motion">
+				<span id="tsx-first">{props.first}</span>
+				<span id="tsx-second">{props.second}</span>
+			</motion.div>
+		</section>
+	);
+}

--- a/packages/motion/tests/conformance/render.test.ts
+++ b/packages/motion/tests/conformance/render.test.ts
@@ -8,7 +8,7 @@
 import { describe, it, expect } from 'vitest';
 import { mount } from '../_helpers';
 import { Box, Span } from '../_fixtures/boxes.tsrx';
-import { TsxDescriptorChildren } from '../_fixtures/tsx-descriptor-children';
+import { TsxDescriptorChildren, ToggleableTsxChildren } from '../_fixtures/tsx-descriptor-children';
 
 describe('motion.<tag> rendering', () => {
 	it('renders a real <div> with className + children', () => {
@@ -42,6 +42,21 @@ describe('motion.<tag> rendering', () => {
 
 		r.update(TsxDescriptorChildren, { first: 'updated', second: 'children' });
 		expect(motionDiv.textContent).toBe('updatedchildren');
+		r.unmount();
+	});
+
+	it('clears descriptor children when the TSX value position goes null', () => {
+		const r = mount(ToggleableTsxChildren, { show: true });
+		const motionDiv = r.find('#tsx-toggle');
+		expect(motionDiv.textContent).toBe('kid');
+
+		r.update(ToggleableTsxChildren, { show: false });
+		expect(motionDiv.textContent).toBe('');
+		expect(r.container.querySelector('#tsx-toggle-kid')).toBe(null);
+
+		// …and comes back, so the cleared slot is still reconcilable.
+		r.update(ToggleableTsxChildren, { show: true });
+		expect(motionDiv.textContent).toBe('kid');
 		r.unmount();
 	});
 });

--- a/packages/motion/tests/conformance/render.test.ts
+++ b/packages/motion/tests/conformance/render.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect } from 'vitest';
 import { mount } from '../_helpers';
 import { Box, Span } from '../_fixtures/boxes.tsrx';
+import { TsxDescriptorChildren } from '../_fixtures/tsx-descriptor-children';
 
 describe('motion.<tag> rendering', () => {
 	it('renders a real <div> with className + children', () => {
@@ -29,6 +30,18 @@ describe('motion.<tag> rendering', () => {
 		expect(sp.tagName).toBe('SPAN');
 		expect(sp.className).toBe('lbl');
 		expect(sp.textContent).toBe('label');
+		r.unmount();
+	});
+
+	it('renders and updates descriptor children produced by a TSX value position', () => {
+		const r = mount(TsxDescriptorChildren, { first: 'first', second: 'second' });
+		const motionDiv = r.find('#tsx-motion');
+		expect(motionDiv.textContent).toBe('firstsecond');
+		expect(motionDiv.contains(r.find('#tsx-first'))).toBe(true);
+		expect(motionDiv.contains(r.find('#tsx-second'))).toBe(true);
+
+		r.update(TsxDescriptorChildren, { first: 'updated', second: 'children' });
+		expect(motionDiv.textContent).toBe('updatedchildren');
 		r.unmount();
 	});
 });

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -14542,7 +14542,7 @@ export function hostComponent(
 	slot: number,
 	tag: string,
 	props: Record<string, any> | null,
-	childrenBody?: ComponentBody | null,
+	childrenBody?: unknown,
 	anchor?: Node | null,
 ): Element {
 	const block = scope.block;
@@ -14563,17 +14563,21 @@ export function hostComponent(
 	}
 	const el = state.el;
 	applyHostProps(el, props, scope, state);
-	if (childrenBody != null) {
+	if (typeof childrenBody === 'function') {
 		// The compiled children render-body is a FRESH closure every parent render, but
 		// it is the SAME positional children slot. childSlot keys block-reuse on body
 		// identity, so handing it the raw closure would re-mount (and DOM-duplicate) the
 		// children — a `@for`/`@if` block especially — on every re-render. Pass a STABLE
 		// delegating body whose target we update each render, so childSlot reconciles.
-		state.latest = childrenBody;
+		state.latest = childrenBody as ComponentBody;
 		if (state.body === undefined) {
 			state.body = ((...args: any[]) => (state!.latest as any)(...args)) as ComponentBody;
 		}
 		childSlot(state.childScope!, 0, el, state.body, null, false, el);
+	} else if (childrenBody != null) {
+		// createElement/descriptor callers already supply a renderable value. Let
+		// childSlot reconcile it directly instead of assuming every child is callable.
+		childSlot(state.childScope!, 0, el, childrenBody, null, false, el);
 	}
 	return el;
 }

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -14542,7 +14542,10 @@ export function hostComponent(
 	slot: number,
 	tag: string,
 	props: Record<string, any> | null,
-	childrenBody?: unknown,
+	// A compiled TSRX call site passes its children render-body; a TSX/createElement
+	// value position passes a descriptor. `OctaneNode` is the alias for "whatever a
+	// hole may render", and covers both — see the branch below.
+	childrenBody?: ComponentBody | OctaneNode,
 	anchor?: Node | null,
 ): Element {
 	const block = scope.block;
@@ -14574,10 +14577,19 @@ export function hostComponent(
 			state.body = ((...args: any[]) => (state!.latest as any)(...args)) as ComponentBody;
 		}
 		childSlot(state.childScope!, 0, el, state.body, null, false, el);
-	} else if (childrenBody != null) {
+	} else if (childrenBody != null || state.childScope!.slots[0] !== undefined) {
 		// createElement/descriptor callers already supply a renderable value. Let
 		// childSlot reconcile it directly instead of assuming every child is callable.
-		childSlot(state.childScope!, 0, el, childrenBody, null, false, el);
+		//
+		// A TSX value position can go null between renders (`{cond ? <x/> : null}`),
+		// unlike the compiled TSRX body which is statically present or absent. Once
+		// the slot exists it must keep receiving the value — including null — or the
+		// previous Block and its DOM stay stranded inside the host (hostElementBody
+		// reconciles unconditionally for the same reason). A host that never had
+		// children stays out of childSlot: under hydration `ownsHost` is ignored, so
+		// an unconditional call would mint a stray end marker inside every childless
+		// host component.
+		childSlot(state.childScope!, 0, el, childrenBody ?? null, null, false, el);
 	}
 	return el;
 }


### PR DESCRIPTION
## Summary

- accept both compiled TSRX child bodies and TSX/createElement descriptors in `hostComponent`
- preserve the stable delegate path for function children
- reconcile descriptor children directly through `childSlot`
- add a Motion regression covering initial render and update

## Root cause

`@octanejs/motion` forwards `props.children` into `hostComponent`. Compiled TSRX call sites provide a render function, while a TSX value position provides an element descriptor. `hostComponent` treated both shapes as callable and crashed with `TypeError: state.latest is not a function`.

## Validation

- regression observed failing before the runtime change, then passing
- `pnpm exec vitest run --project motion` — 18 files / 33 tests passed
- `pnpm exec vitest run --project octane packages/octane/tests/host-component-props.test.ts` — passed
- `pnpm typecheck` — passed
- `pnpm format:check` — passed
- `pnpm changeset:check` — passed
- `pnpm --filter octane build` — passed
- full `pnpm test`: 14,408 passed; remaining failures require Playwright-downloaded Chromium (not installed in this environment), plus an unrelated Jotai `localStorage` environment failure. The only contention timeout (Lucide) passed when rerun alone.

## Performance

The existing TSRX function path retains its stable delegate and does not add a type check inside that hot delegate. Descriptor children take the new direct `childSlot` branch. There is no meaningful before/after timing for the descriptor path because the baseline throws before rendering.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Octane host rendering and child reconciliation used by Motion; behavior change is scoped but affects every `hostComponent` child path.
> 
> **Overview**
> Fixes **`hostComponent`** so Motion and other TSX callers can pass **`props.children`** as element descriptors instead of only compiled TSRX render bodies.
> 
> **`hostComponent`** now branches on child shape: **function** children still use the stable delegating body into **`childSlot`**; **descriptor** (and **`null`**) children reconcile directly through **`childSlot`**, including when a conditional TSX slot clears on update. Childless hosts skip **`childSlot`** unless a slot already exists, avoiding stray hydration markers.
> 
> Motion conformance tests cover TSX descriptor render/update and toggle-to-**`null`** cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8397d443c0bb52ebd79f164f0b0aaa30e2b1ebf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->