### PR TITLE
fix(base-ui): preserve popover payload type

### DIFF
--- a/.changeset/tidy-popovers-typecheck.md
+++ b/.changeset/tidy-popovers-typecheck.md
@@ -1,0 +1,5 @@
+---
+'@octanejs/base-ui': patch
+---
+
+Preserve the Popover payload type through the root wrapper so strict source consumers do not report an unused generic parameter.

--- a/packages/base-ui/src/popover.ts
+++ b/packages/base-ui/src/popover.ts
@@ -532,7 +532,12 @@ function PopoverRootComponent<Payload>(props: any): any {
 	});
 }
 
-function PopoverRoot<Payload = unknown>(props: any): any {
+interface PopoverRootProps<Payload> {
+	handle?: PopoverHandle<Payload>;
+	[key: string]: unknown;
+}
+
+function PopoverRoot<Payload = unknown>(props: PopoverRootProps<Payload>): any {
 	const slot = S('PopoverRootWrapper');
 	// Top-level popovers establish a FloatingTree; nested ones reuse the parent's.
 	if (usePopoverRootContext(true)) {


### PR DESCRIPTION
## Summary

- type `Popover.Root` through its real `handle?: PopoverHandle<Payload>` input
- preserve payload inference while avoiding an unused generic diagnostic in strict source consumers
- add a Base UI patch changeset

## Root cause

`@octanejs/base-ui` publishes raw TypeScript source. `PopoverRoot<Payload>` accepted `props: any`, so consumer projects with `noUnusedParameters` enabled reported `TS6133: Payload is declared but its value is never read` as soon as they imported the Popover subpath. The payload type now flows through the existing handle API instead of being a decorative generic.

## Validation

- reproduced in a TS 5.9 TSRX consumer before the change
- the same consumer passes strict typecheck after the change
- `pnpm exec vitest run --project base-ui` — 14 files / 142 tests passed
- `pnpm exec tsgo --noEmit -p packages/base-ui/tsconfig.json` — passed
- Prettier check and changeset check — passed

This intentionally avoids TypeScript instantiation-expression syntax at the call site, which the current TSRX source transform does not parse reliably.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Typing-only change on the popover root wrapper; no runtime or behavioral changes.
> 
> **Overview**
> **`Popover.Root`** no longer types its props as `any`. It now accepts **`PopoverRootProps<Payload>`**, with an optional **`handle?: PopoverHandle<Payload>`** plus an index signature for the rest of the root API.
> 
> That wires the **`Payload`** generic to the existing handle API so strict consumers of published **`@octanejs/base-ui`** source stop hitting **TS6133** (“`Payload` is declared but its value is never read”) under **`noUnusedParameters`**, without changing runtime behavior.
> 
> A **patch** changeset documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27e705433d433a7b3930bb02a5410739186843b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->