### PR TITLE
fix(motion): render TSX wrapper children

### DIFF
--- a/.changeset/motion-tsx-transparent-children.md
+++ b/.changeset/motion-tsx-transparent-children.md
@@ -1,0 +1,6 @@
+---
+'@octanejs/motion': patch
+---
+
+Render TSX-authored descriptor children through `AnimatePresence` and
+`MotionConfig`, including conditional updates that insert or remove the child.

--- a/packages/motion/src/index.ts
+++ b/packages/motion/src/index.ts
@@ -7,7 +7,7 @@
 // drives animation/gesture/layout/drag from layout effects — exactly the refs +
 // effects + rendering path this is meant to exercise.
 import { animate, hover, press, inView } from 'motion';
-import { hostComponent, useLayoutEffect, useState, provideContext } from 'octane';
+import { childSlot, hostComponent, useLayoutEffect, useState, provideContext } from 'octane';
 import {
 	MotionConfigContext,
 	VariantContext,
@@ -494,7 +494,7 @@ export const motion: any = new Proxy(
 // self-animates its own removal (see the exit cleanup above), so this is a thin
 // passthrough that exists for drop-in compatibility with Framer Motion's API.
 export function AnimatePresence(props: any, scope: any): void {
-	if (typeof props.children === 'function') props.children(undefined, scope);
+	renderTransparentChildren(props.children, scope);
 }
 
 // MotionConfig — provides global defaults (transition, reduced motion) to every
@@ -505,7 +505,15 @@ export function MotionConfig(props: any, scope: any): void {
 		transition: props.transition,
 		reducedMotion: props.reducedMotion,
 	});
-	if (typeof props.children === 'function') props.children(undefined, scope);
+	renderTransparentChildren(props.children, scope);
+}
+
+function renderTransparentChildren(children: unknown, scope: any): void {
+	if (typeof children === 'function') {
+		children(undefined, scope);
+		return;
+	}
+	childSlot(scope, 0, scope.block.parentNode, children, scope.block.endMarker);
 }
 
 export { useAnimate } from './useAnimate';

--- a/packages/motion/src/index.ts
+++ b/packages/motion/src/index.ts
@@ -509,10 +509,6 @@ export function MotionConfig(props: any, scope: any): void {
 }
 
 function renderTransparentChildren(children: unknown, scope: any): void {
-	if (typeof children === 'function') {
-		children(undefined, scope);
-		return;
-	}
 	childSlot(scope, 0, scope.block.parentNode, children, scope.block.endMarker);
 }
 

--- a/packages/motion/tests/_fixtures/transparent-children-dialect.tsrx
+++ b/packages/motion/tests/_fixtures/transparent-children-dialect.tsrx
@@ -1,0 +1,37 @@
+import { createElement, useState, type ComponentBody, type OctaneNode } from 'octane';
+import { AnimatePresence } from '@octanejs/motion';
+
+interface PassthroughProps {
+	children?: OctaneNode | ComponentBody;
+}
+
+function Passthrough(props: PassthroughProps) {
+	return props.children ?? null;
+}
+
+interface DialectRootProps extends PassthroughProps {
+	wrapped: boolean;
+}
+
+function DialectRoot(props: DialectRootProps) {
+	return createElement(AnimatePresence, {
+		children: props.wrapped
+			? createElement(Passthrough, { children: props.children })
+			: props.children,
+	});
+}
+
+function Counter() @{
+	const [count, setCount, getCount] = useState(0);
+	<button class="count" onClick={() => setCount(getCount() + 1)}>{'count:' + count}</button>
+}
+
+export function AnimatePresenceChildrenDialectFlip() @{
+	const [wrapped, setWrapped, getWrapped] = useState(false);
+	<div>
+		<button class="toggle" onClick={() => setWrapped(!getWrapped())}>toggle wrapper</button>
+		<DialectRoot wrapped={wrapped}>
+			<Counter />
+		</DialectRoot>
+	</div>
+}

--- a/packages/motion/tests/_fixtures/transparent-children.tsx
+++ b/packages/motion/tests/_fixtures/transparent-children.tsx
@@ -1,0 +1,16 @@
+/** @jsxImportSource octane */
+import { AnimatePresence, MotionConfig } from '@octanejs/motion';
+
+export function TsxPresence(props: { show: boolean }) {
+	return (
+		<AnimatePresence>{props.show ? <div id="presence-child">visible</div> : null}</AnimatePresence>
+	);
+}
+
+export function TsxMotionConfig() {
+	return (
+		<MotionConfig reducedMotion="always">
+			<span id="config-child">configured</span>
+		</MotionConfig>
+	);
+}

--- a/packages/motion/tests/conformance/transparent-children.test.ts
+++ b/packages/motion/tests/conformance/transparent-children.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { mount } from '../_helpers';
+import { AnimatePresenceChildrenDialectFlip } from '../_fixtures/transparent-children-dialect.tsrx';
 import { TsxMotionConfig, TsxPresence } from '../_fixtures/transparent-children';
 
 describe('transparent Motion components', () => {
@@ -18,6 +19,21 @@ describe('transparent Motion components', () => {
 	it('renders MotionConfig descriptor children authored in TSX', () => {
 		const rendered = mount(TsxMotionConfig, {});
 		expect(rendered.container.querySelector('#config-child')?.textContent).toBe('configured');
+		rendered.unmount();
+	});
+
+	it('remounts children when their authoring dialect changes', () => {
+		const rendered = mount(AnimatePresenceChildrenDialectFlip, {});
+		expect(rendered.container.querySelector('.count')?.textContent).toBe('count:0');
+
+		rendered.click('.count');
+		expect(rendered.container.querySelector('.count')?.textContent).toBe('count:1');
+
+		rendered.click('.toggle');
+		expect(rendered.container.querySelector('.count')?.textContent).toBe('count:0');
+
+		rendered.click('.toggle');
+		expect(rendered.container.querySelector('.count')?.textContent).toBe('count:0');
 		rendered.unmount();
 	});
 });

--- a/packages/motion/tests/conformance/transparent-children.test.ts
+++ b/packages/motion/tests/conformance/transparent-children.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '../_helpers';
+import { TsxMotionConfig, TsxPresence } from '../_fixtures/transparent-children';
+
+describe('transparent Motion components', () => {
+	it('renders and updates descriptor children authored in TSX', () => {
+		const rendered = mount(TsxPresence, { show: false });
+		expect(rendered.container.querySelector('#presence-child')).toBeNull();
+
+		rendered.update(TsxPresence, { show: true });
+		expect(rendered.container.querySelector('#presence-child')?.textContent).toBe('visible');
+
+		rendered.update(TsxPresence, { show: false });
+		expect(rendered.container.querySelector('#presence-child')).toBeNull();
+		rendered.unmount();
+	});
+
+	it('renders MotionConfig descriptor children authored in TSX', () => {
+		const rendered = mount(TsxMotionConfig, {});
+		expect(rendered.container.querySelector('#config-child')?.textContent).toBe('configured');
+		rendered.unmount();
+	});
+});


### PR DESCRIPTION
## Summary
- render TSX descriptor children through `AnimatePresence`
- render TSX descriptor children through `MotionConfig`
- cover initial render plus conditional insert/remove updates

## Why
- both transparent components only invoked function-shaped TSRX children
- TSX callers pass descriptors, arrays, text, or null, so their children were silently omitted
- Markd exposed the update failure when an expanded tree placed a conditional Motion child under `AnimatePresence`

## Changes
- normalize function children and descriptor children through one transparent render helper
- add a TSX consumer fixture and two conformance regressions
- add a patch changeset for `@octanejs/motion`

## Validation
- [x] pre-fix regression: both new tests failed
- [x] `pnpm exec vitest run --project motion --reporter=verbose` — 19 files, 34 tests
- [x] `pnpm typecheck`
- [x] targeted Prettier check

## Risk / follow-ups
- this fixes transparent wrappers only
- TSX descriptors passed directly to `motion.*` host components are covered separately by #328

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to transparent wrapper rendering in @octanejs/motion with regression tests; no auth, data, or core renderer API changes beyond using the existing childSlot primitive.
> 
> **Overview**
> **`AnimatePresence` and `MotionConfig` no longer drop TSX-authored children.** Both wrappers used to render children only when `children` was a function (the TSRX path), so descriptor children from TSX were never mounted.
> 
> They now share **`renderTransparentChildren`**, which routes all child shapes through octane’s **`childSlot`** (descriptors, arrays, text, `null`, and function bodies). **`MotionConfig`** still provides context first, then renders children the same way.
> 
> Conformance coverage adds TSX fixtures for conditional presence insert/remove, **`MotionConfig`** children, and a dialect-flip case where wrapping under **`AnimatePresence`** toggles between TSRX and TSX child shapes without losing state incorrectly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f37037900726a0f478f83c1909dcfc80543be0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->