### PR TITLE
Tear down omitted conditional effects

### DIFF
--- a/.changeset/conditional-effect-teardown.md
+++ b/.changeset/conditional-effect-teardown.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Tear down an effect when its conditional hook call site is not reached during a successful component render.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -656,6 +656,14 @@ export interface Block extends Scope {
 interface EffectSlot {
 	deps: any[] | undefined;
 	cleanup: Cleanup | undefined;
+	/** Render token of the latest completed attempt that reached this call site. */
+	renderVersion: number;
+	/** Invalidates queued work superseded by a later render of this call site. */
+	revision: number;
+	/** True while the current revision has commit work queued but not yet drained. */
+	pending: boolean;
+	/** Stable first-enqueue order within the owning scope. */
+	order: number;
 	/** Hook key retained so a bailed Suspense descendant can reconnect at commit. */
 	slot: HookSlot;
 	/** Last effect body and args that actually reached commit. */
@@ -675,12 +683,23 @@ interface EffectSlot {
 	phase: Phase;
 }
 
-type EffectDepsSnapshot = Map<EffectSlot, any[] | undefined>;
+interface EffectStateSnapshot {
+	deps: any[] | undefined;
+	revision: number;
+	pending: boolean;
+}
+
+type EffectDepsSnapshot = Map<EffectSlot, EffectStateSnapshot>;
 
 interface PendingEffect {
 	scope: Scope;
 	slot: HookSlot;
-	fn: EffectFn;
+	/** Null for a conditional call site that disappeared and only needs teardown. */
+	fn: EffectFn | null;
+	/** Stable first-enqueue order of the owning slot within its scope. */
+	order: number;
+	/** Slot revision this entry belongs to; stale entries are ignored at drain. */
+	revision: number;
 	/**
 	 * The effect's deps array, spread as positional arguments to the body when it
 	 * runs (`fn.apply(null, args)`). This is a deliberate superset of React: a
@@ -718,6 +737,13 @@ interface PendingEffect {
 
 let CURRENT_SCOPE: Scope | null = null;
 let CURRENT_BLOCK: Block | null = null;
+// Conditional effects need to distinguish "deps unchanged" from "the call site
+// was not reached". Effect-less components keep this at zero and pay no counter
+// increment; a render of an existing effect-owning scope allocates its token up
+// front, while the first effect call lazily allocates one below.
+let CURRENT_EFFECT_RENDER_VERSION = 0;
+let CURRENT_EFFECT_REACHED = 0;
+let NEXT_EFFECT_RENDER_VERSION = 1;
 interface ActiveWarmPlan {
 	block: Block;
 	fn: () => void;
@@ -2852,14 +2878,26 @@ function comparePostOrder(
 	return aSeq - bSeq;
 }
 function compareEffectPostOrder(a: PendingEffect, b: PendingEffect): number {
+	if (a.scope === b.scope) return a.order - b.order || a.seq - b.seq;
 	return comparePostOrder(a.scope.block, a.seq, b.scope.block, b.seq);
 }
 
 /** Fire (and clear) the CURRENT cleanup of the slot behind a queued effect. */
 function fireEffectCleanup(e: PendingEffect): void {
 	const slot = e.scope.hooks?.get(e.slot) as EffectSlot | undefined;
-	if (slot && slot.cleanup) {
-		const cleanup = slot.cleanup;
+	if (slot === undefined || slot.revision !== e.revision) return;
+	const disconnect = e.fn === null;
+	const cleanup = slot.cleanup;
+	if (disconnect) {
+		// Publish the absence before user cleanup runs. A cleanup may schedule a
+		// render; that render must see this call site as disconnected and must not
+		// queue a duplicate teardown while the current one is still unwinding.
+		slot.pending = false;
+		slot.connectedFn = null;
+		slot.connectedArgs = undefined;
+		slot.disconnected = false;
+	}
+	if (cleanup) {
 		slot.cleanup = undefined;
 		try {
 			runEffectCleanupCallback(cleanup);
@@ -2874,13 +2912,14 @@ function fireEffectCleanup(e: PendingEffect): void {
 
 /** Run a queued effect's body and stash its returned cleanup on the slot. */
 function runEffectBody(e: PendingEffect): void {
+	if (e.fn === null) return;
 	let cleanup: void | Cleanup;
 	const slot = e.scope.hooks?.get(e.slot) as EffectSlot | undefined;
-	if (slot) {
-		slot.connectedFn = e.fn;
-		slot.connectedArgs = e.args;
-		slot.disconnected = false;
-	}
+	if (slot === undefined || slot.revision !== e.revision) return;
+	slot.pending = false;
+	slot.connectedFn = e.fn;
+	slot.connectedArgs = e.args;
+	slot.disconnected = false;
 	try {
 		EFFECT_BODY_DEPTH++;
 		try {
@@ -2903,7 +2942,7 @@ function runEffectBody(e: PendingEffect): void {
 		// The slot owns its LATEST cleanup: unmountScope's effect-slot walk (and
 		// deactivateScope's hide walk) read + clear it, so a dep-changed effect's
 		// stale cleanup can never replay at teardown.
-		if (slot) slot.cleanup = cleanup;
+		slot.cleanup = cleanup;
 	}
 }
 
@@ -2970,7 +3009,11 @@ function drainMutationEffects(): PendingEffect[] | null {
 		}
 		for (let k = i; k < end; k++) {
 			const e = q[k];
-			if (e.phase === LAYOUT && !e.scope.block.disposed && !inInactiveSubtree(e.scope.block))
+			if (
+				e.phase === LAYOUT &&
+				!e.scope.block.disposed &&
+				(e.fn === null || !inInactiveSubtree(e.scope.block))
+			)
 				fireEffectCleanup(e);
 		}
 		i = end;
@@ -3008,7 +3051,7 @@ function drainPassivePhase(): void {
 	q.sort(compareEffectPostOrder);
 	for (let i = 0; i < q.length; i++) {
 		const e = q[i];
-		if (e.scope.block.disposed || inInactiveSubtree(e.scope.block)) continue;
+		if (e.scope.block.disposed || (e.fn !== null && inInactiveSubtree(e.scope.block))) continue;
 		fireEffectCleanup(e);
 	}
 	for (let i = 0; i < q.length; i++) {
@@ -3374,6 +3417,8 @@ function enqueueEffectEventCommitAction(action: () => void): void {
 function renderBlockInner(block: Block): void {
 	const prevScope = CURRENT_SCOPE;
 	const prevBlock = CURRENT_BLOCK;
+	const prevEffectRenderVersion = CURRENT_EFFECT_RENDER_VERSION;
+	const prevEffectReached = CURRENT_EFFECT_REACHED;
 	const prevWarmEpisode = CURRENT_WARM_EPISODE;
 	const warmPlanCheckpoint = ACTIVE_WARM_PLANS.length;
 	const prevEffectEventTarget = EFFECT_EVENT_RENDER_TARGET;
@@ -3384,6 +3429,8 @@ function renderBlockInner(block: Block): void {
 	const effectEventActionCheckpoint = effectEventActionTarget.length;
 	CURRENT_SCOPE = block;
 	CURRENT_BLOCK = block;
+	CURRENT_EFFECT_RENDER_VERSION = block.effectSlots === null ? 0 : NEXT_EFFECT_RENDER_VERSION++;
+	CURRENT_EFFECT_REACHED = 0;
 	const continuesParentTree = prevBlock !== null && blockIsAncestor(prevBlock, block);
 	if (!continuesParentTree) {
 		// A true Suspense retry enters from no ambient block and resumes its saved
@@ -3468,6 +3515,7 @@ function renderBlockInner(block: Block): void {
 			block.extra,
 		);
 		if (out !== undefined && block.outputHandler !== null) block.outputHandler(block, out);
+		finishEffectRender(block);
 		if (!block.mounted) block.mounted = true;
 		if (block.effectEventRenderVersion !== 0) {
 			block.effectEventCompletedVersion = block.effectEventRenderVersion;
@@ -3495,6 +3543,8 @@ function renderBlockInner(block: Block): void {
 		EFFECT_EVENT_ACTION_TARGET = prevEffectEventActionTarget;
 		ACTIVE_WARM_PLANS.length = warmPlanCheckpoint;
 		CURRENT_WARM_EPISODE = prevWarmEpisode;
+		CURRENT_EFFECT_RENDER_VERSION = prevEffectRenderVersion;
+		CURRENT_EFFECT_REACHED = prevEffectReached;
 		CURRENT_SCOPE = prevScope;
 		CURRENT_BLOCK = prevBlock;
 	}
@@ -4466,23 +4516,81 @@ function inInactiveSubtree(block: Block | null): boolean {
 	return false;
 }
 
+function ensureEffectRenderVersion(): number {
+	if (CURRENT_EFFECT_RENDER_VERSION === 0) {
+		CURRENT_EFFECT_RENDER_VERSION = NEXT_EFFECT_RENDER_VERSION++;
+	}
+	return CURRENT_EFFECT_RENDER_VERSION;
+}
+
+/**
+ * A completed render disconnects any previously-live effect call site it did
+ * not reach. The teardown rides the ordinary phase queue, so insertion/layout
+ * stay synchronous and passive stays post-paint. Suspended/thrown renders never
+ * call this function; captured renders redirect the entries into WIP_CAPTURE.
+ */
+function finishEffectRender(scope: Scope): void {
+	const effects = scope.effectSlots;
+	if (effects === null || CURRENT_EFFECT_RENDER_VERSION === 0) return;
+	// Compiler-owned effect call sites cannot repeat in a plain loop, so reaching
+	// the registered slot count proves there is no conditional omission. This is
+	// the overwhelmingly common path and avoids scanning the slot list.
+	if (CURRENT_EFFECT_REACHED === effects.length) return;
+	for (let i = 0; i < effects.length; i++) {
+		const effect = effects[i];
+		if (effect.renderVersion === CURRENT_EFFECT_RENDER_VERSION) continue;
+		// Reaching this call site again must recreate even when its authored deps
+		// are unchanged.
+		effect.deps = undefined;
+		// A disconnected Activity/Suspense slot still retains connectedFn solely
+		// so reveal can reconnect a bailed subtree. Queueing it here clears that
+		// retained body at commit, preventing an omitted call site from returning.
+		if (!effect.pending && effect.connectedFn === null && effect.cleanup === undefined) {
+			continue;
+		}
+		const revision = ++effect.revision;
+		effect.pending = true;
+		const target =
+			WIP_CAPTURE !== null ? WIP_CAPTURE.effects[effect.phase] : effectQueues[effect.phase];
+		target.push({
+			scope,
+			slot: effect.slot,
+			fn: null,
+			order: effect.order,
+			revision,
+			args: undefined,
+			phase: effect.phase,
+			seq: commitSeq++,
+		});
+	}
+}
+
 function enqueueEffect(slot: HookSlot, fn: EffectFn, deps: any[] | undefined, phase: Phase): void {
 	const scope = CURRENT_SCOPE!;
-	// Hidden <Activity> subtree: render (state + DOM) but DON'T run effects. Skip
-	// BEFORE touching the slot so the effect is treated as fresh and re-fires when
-	// the Activity becomes visible (deactivateScope also clears prior deps). Walk
-	// ancestors so a visible inner block inside a hidden outer Activity is skipped
-	// too. Effects are rare on the hot path, so this extra walk is cheap.
+	const prev = scope.hooks?.get(slot) as EffectSlot | undefined;
+	const renderVersion = ensureEffectRenderVersion();
+	CURRENT_EFFECT_REACHED++;
+	if (prev) prev.renderVersion = renderVersion;
+	// Hidden <Activity> subtree: render (state + DOM) but DON'T run effects. Record
+	// that this call site was reached, then skip lifecycle state so the effect is
+	// treated as fresh and re-fires when the Activity becomes visible
+	// (deactivateScope also clears prior deps). Walk ancestors so a visible inner
+	// block inside a hidden outer Activity is skipped too. Effects are rare on the
+	// hot path, so this extra walk is cheap.
 	// INSERTION effects are exempt (React: they stay connected while hidden and an
 	// update in a hidden-but-rendered subtree still fires them — Activity-test.js:1428).
 	if (phase !== INSERTION && inInactiveSubtree(scope.block)) return;
-	const prev = scope.hooks?.get(slot) as EffectSlot | undefined;
 	if (prev && !depsChanged(prev.deps, deps)) return;
 	let effect: EffectSlot;
 	if (!prev) {
+		const order = scope.effectSlots === null ? 0 : scope.effectSlots.length;
 		const slotObj: EffectSlot = {
 			deps,
 			cleanup: undefined,
+			renderVersion,
+			revision: 0,
+			pending: false,
+			order,
 			effect: true,
 			phase,
 			slot,
@@ -4500,9 +4608,20 @@ function enqueueEffect(slot: HookSlot, fn: EffectFn, deps: any[] | undefined, ph
 		prev.deps = deps;
 		effect = prev;
 	}
+	const revision = ++effect.revision;
+	effect.pending = true;
 	// Tag with the enqueue sequence (DFS pre-order). The commit drains turn this +
 	// the parentBlock chain into React's post-order commit order — see PendingEffect.seq.
-	const entry = { scope, slot, fn, args: deps, phase, seq: commitSeq++ };
+	const entry = {
+		scope,
+		slot,
+		fn,
+		order: effect.order,
+		revision,
+		args: deps,
+		phase,
+		seq: commitSeq++,
+	};
 	const target = WIP_CAPTURE !== null ? WIP_CAPTURE.effects[phase] : effectQueues[phase];
 	target.push(entry);
 	markEffectReconnectQueued(effect, phase, target);
@@ -18071,7 +18190,11 @@ function snapshotSubtreeEffectDeps(scope: Scope): EffectDepsSnapshot {
 			for (const slot of hooks.values()) {
 				const effect = slot as EffectSlot | undefined;
 				if (effect?.effect === true) {
-					snapshot.set(effect, effect.deps);
+					snapshot.set(effect, {
+						deps: effect.deps,
+						revision: effect.revision,
+						pending: effect.pending,
+					});
 				}
 			}
 		}
@@ -18089,7 +18212,18 @@ function restoreSubtreeEffectDeps(scope: Scope, snapshot: EffectDepsSnapshot): v
 			for (const slot of hooks.values()) {
 				const effect = slot as EffectSlot | undefined;
 				if (effect?.effect !== true) continue;
-				effect.deps = snapshot.has(effect) ? snapshot.get(effect) : undefined;
+				const previous = snapshot.get(effect);
+				if (previous === undefined) {
+					// A slot created only by the discarded attempt remains reusable,
+					// but none of that attempt's commit work is still pending.
+					effect.deps = undefined;
+					effect.revision = 0;
+					effect.pending = false;
+				} else {
+					effect.deps = previous.deps;
+					effect.revision = previous.revision;
+					effect.pending = previous.pending;
+				}
 			}
 		}
 		forEachSubtreeChild(current, visit);
@@ -18152,10 +18286,14 @@ function reconnectBailedEffects(block: Block): void {
 	// key and reconnect earlier-declared effects after later ones.
 	for (let i = 0; i < disconnected.length; i++) {
 		const { scope, effect } = disconnected[i];
+		const revision = ++effect.revision;
+		effect.pending = true;
 		context.queues[effect.phase].push({
 			scope,
 			slot: effect.slot,
 			fn: effect.connectedFn!,
+			order: effect.order,
+			revision,
 			args: effect.connectedArgs,
 			phase: effect.phase,
 			seq: commitSeq++,

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -658,10 +658,10 @@ interface EffectSlot {
 	cleanup: Cleanup | undefined;
 	/** Render token of the latest completed attempt that reached this call site. */
 	renderVersion: number;
-	/** Invalidates queued work superseded by a later render of this call site. */
+	/** Invalidates queued work superseded by a later render or presence transition. */
 	revision: number;
-	/** True while the current revision has commit work queued but not yet drained. */
-	pending: boolean;
+	/** Whether the latest completed render reached this registered call site. */
+	active: boolean;
 	/** Stable first-enqueue order within the owning scope. */
 	order: number;
 	/** Hook key retained so a bailed Suspense descendant can reconnect at commit. */
@@ -686,7 +686,7 @@ interface EffectSlot {
 interface EffectStateSnapshot {
 	deps: any[] | undefined;
 	revision: number;
-	pending: boolean;
+	active: boolean;
 }
 
 type EffectDepsSnapshot = Map<EffectSlot, EffectStateSnapshot>;
@@ -2892,7 +2892,6 @@ function fireEffectCleanup(e: PendingEffect): void {
 		// Publish the absence before user cleanup runs. A cleanup may schedule a
 		// render; that render must see this call site as disconnected and must not
 		// queue a duplicate teardown while the current one is still unwinding.
-		slot.pending = false;
 		slot.connectedFn = null;
 		slot.connectedArgs = undefined;
 		slot.disconnected = false;
@@ -2916,7 +2915,6 @@ function runEffectBody(e: PendingEffect): void {
 	let cleanup: void | Cleanup;
 	const slot = e.scope.hooks?.get(e.slot) as EffectSlot | undefined;
 	if (slot === undefined || slot.revision !== e.revision) return;
-	slot.pending = false;
 	slot.connectedFn = e.fn;
 	slot.connectedArgs = e.args;
 	slot.disconnected = false;
@@ -4532,24 +4530,20 @@ function ensureEffectRenderVersion(): number {
 function finishEffectRender(scope: Scope): void {
 	const effects = scope.effectSlots;
 	if (effects === null || CURRENT_EFFECT_RENDER_VERSION === 0) return;
-	// Compiler-owned effect call sites cannot repeat in a plain loop, so reaching
-	// the registered slot count proves there is no conditional omission. This is
-	// the overwhelmingly common path and avoids scanning the slot list.
+	// enqueueEffect counts each registered slot at most once per render. Reaching
+	// the registered slot count therefore proves there is no conditional
+	// omission, even when custom-hook composition invokes one effective slot more
+	// than once. This common path avoids scanning the slot list.
 	if (CURRENT_EFFECT_REACHED === effects.length) return;
 	for (let i = 0; i < effects.length; i++) {
 		const effect = effects[i];
 		if (effect.renderVersion === CURRENT_EFFECT_RENDER_VERSION) continue;
+		if (!effect.active) continue;
 		// Reaching this call site again must recreate even when its authored deps
 		// are unchanged.
 		effect.deps = undefined;
-		// A disconnected Activity/Suspense slot still retains connectedFn solely
-		// so reveal can reconnect a bailed subtree. Queueing it here clears that
-		// retained body at commit, preventing an omitted call site from returning.
-		if (!effect.pending && effect.connectedFn === null && effect.cleanup === undefined) {
-			continue;
-		}
+		effect.active = false;
 		const revision = ++effect.revision;
-		effect.pending = true;
 		const target =
 			WIP_CAPTURE !== null ? WIP_CAPTURE.effects[effect.phase] : effectQueues[effect.phase];
 		target.push({
@@ -4569,8 +4563,11 @@ function enqueueEffect(slot: HookSlot, fn: EffectFn, deps: any[] | undefined, ph
 	const scope = CURRENT_SCOPE!;
 	const prev = scope.hooks?.get(slot) as EffectSlot | undefined;
 	const renderVersion = ensureEffectRenderVersion();
-	CURRENT_EFFECT_REACHED++;
-	if (prev) prev.renderVersion = renderVersion;
+	const firstReach = prev !== undefined && prev.renderVersion !== renderVersion;
+	if (firstReach) {
+		CURRENT_EFFECT_REACHED++;
+		prev!.renderVersion = renderVersion;
+	}
 	// Hidden <Activity> subtree: render (state + DOM) but DON'T run effects. Record
 	// that this call site was reached, then skip lifecycle state so the effect is
 	// treated as fresh and re-fires when the Activity becomes visible
@@ -4579,17 +4576,39 @@ function enqueueEffect(slot: HookSlot, fn: EffectFn, deps: any[] | undefined, ph
 	// hot path, so this extra walk is cheap.
 	// INSERTION effects are exempt (React: they stay connected while hidden and an
 	// update in a hidden-but-rendered subtree still fires them — Activity-test.js:1428).
-	if (phase !== INSERTION && inInactiveSubtree(scope.block)) return;
-	if (prev && !depsChanged(prev.deps, deps)) return;
+	if (phase !== INSERTION && inInactiveSubtree(scope.block)) {
+		if (prev && !prev.active) {
+			// A hidden re-reach supersedes teardown from an earlier completed
+			// hidden render. Advance the presence revision so its fn:null entry
+			// cannot clear the retained body needed by a bailed reveal.
+			prev.active = true;
+			prev.revision++;
+		}
+		return;
+	}
+	if (prev) {
+		let reactivated = false;
+		if (!prev.active) {
+			prev.active = true;
+			prev.revision++;
+			reactivated = true;
+		}
+		if (!depsChanged(prev.deps, deps)) return;
+		// Multiple calls may legitimately compose onto one effective slot through
+		// plain-TypeScript custom-hook paths. Advance once for a later render, not
+		// once per enqueue, so every call from this render remains observable.
+		if (firstReach && !reactivated) prev.revision++;
+	}
 	let effect: EffectSlot;
 	if (!prev) {
+		CURRENT_EFFECT_REACHED++;
 		const order = scope.effectSlots === null ? 0 : scope.effectSlots.length;
 		const slotObj: EffectSlot = {
 			deps,
 			cleanup: undefined,
 			renderVersion,
 			revision: 0,
-			pending: false,
+			active: true,
 			order,
 			effect: true,
 			phase,
@@ -4608,8 +4627,6 @@ function enqueueEffect(slot: HookSlot, fn: EffectFn, deps: any[] | undefined, ph
 		prev.deps = deps;
 		effect = prev;
 	}
-	const revision = ++effect.revision;
-	effect.pending = true;
 	// Tag with the enqueue sequence (DFS pre-order). The commit drains turn this +
 	// the parentBlock chain into React's post-order commit order — see PendingEffect.seq.
 	const entry = {
@@ -4617,7 +4634,7 @@ function enqueueEffect(slot: HookSlot, fn: EffectFn, deps: any[] | undefined, ph
 		slot,
 		fn,
 		order: effect.order,
-		revision,
+		revision: effect.revision,
 		args: deps,
 		phase,
 		seq: commitSeq++,
@@ -18209,7 +18226,7 @@ function snapshotSubtreeEffectDeps(scope: Scope): EffectDepsSnapshot {
 					snapshot.set(effect, {
 						deps: effect.deps,
 						revision: effect.revision,
-						pending: effect.pending,
+						active: effect.active,
 					});
 				}
 			}
@@ -18234,11 +18251,11 @@ function restoreSubtreeEffectDeps(scope: Scope, snapshot: EffectDepsSnapshot): v
 					// but none of that attempt's commit work is still pending.
 					effect.deps = undefined;
 					effect.revision = 0;
-					effect.pending = false;
+					effect.active = false;
 				} else {
 					effect.deps = previous.deps;
 					effect.revision = previous.revision;
-					effect.pending = previous.pending;
+					effect.active = previous.active;
 				}
 			}
 		}
@@ -18285,6 +18302,7 @@ function reconnectBailedEffects(block: Block): void {
 			for (let i = 0; i < effects.length; i++) {
 				const effect = effects[i];
 				if (
+					effect.active &&
 					effect.disconnected &&
 					effect.connectedFn !== null &&
 					!context.queuedSlots.has(effect)
@@ -18302,14 +18320,12 @@ function reconnectBailedEffects(block: Block): void {
 	// key and reconnect earlier-declared effects after later ones.
 	for (let i = 0; i < disconnected.length; i++) {
 		const { scope, effect } = disconnected[i];
-		const revision = ++effect.revision;
-		effect.pending = true;
 		context.queues[effect.phase].push({
 			scope,
 			slot: effect.slot,
 			fn: effect.connectedFn!,
 			order: effect.order,
-			revision,
+			revision: effect.revision,
 			args: effect.connectedArgs,
 			phase: effect.phase,
 			seq: commitSeq++,

--- a/packages/octane/tests/_fixtures/conditional-effect-helpers.ts
+++ b/packages/octane/tests/_fixtures/conditional-effect-helpers.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'octane';
+
+function useSharedEffect(label: string, log: string[]): void {
+	useEffect(() => {
+		log.push('shared:create:' + label);
+		return () => log.push('shared:cleanup:' + label);
+	}, [label, log]);
+}
+
+// The surgical plain-TypeScript transform slots the base hook, but does not
+// wrap nested custom-hook calls. Both invocations therefore enqueue through the
+// same effective runtime slot and must remain independently observable.
+export function useRepeatedSharedEffects(log: string[]): void {
+	useSharedEffect('first', log);
+	useSharedEffect('second', log);
+}

--- a/packages/octane/tests/_fixtures/conditional-hooks.tsrx
+++ b/packages/octane/tests/_fixtures/conditional-hooks.tsrx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'octane';
+import { Activity, memo, use, useState, useEffect } from 'octane';
 
 // React-style guarded component: `if (cond) return;` early-exit followed by
 // hooks. octane supports runtime-conditional hooks (each call site has
@@ -29,4 +29,72 @@ export function PartialGuard(props) @{
 		<button id="bumpN" onClick={() => setN(n + 1)}>{'n=' + n as string}</button>
 		<button id="bumpM" onClick={() => setM(m + 1)}>{'m=' + m as string}</button>
 	</>
+}
+
+// A plain JavaScript conditional does not create an @if-owned child scope.
+// The effect still disconnects when its call site is not reached by a completed
+// render, while the component's stable output keeps updating in place.
+export function ConditionalTsrxEffect(props: {
+	enabled: boolean;
+	label: string;
+	log: string[];
+}) @{
+	if (props.enabled) {
+		useEffect(() => {
+			props.log.push('create:' + props.label);
+			return () => props.log.push('cleanup:' + props.label);
+		}, [props.label, props.log]);
+	}
+	<div class="conditional-tsrx">{props.label}</div>
+}
+
+function ConditionalSuspendingEffect(props: {
+	enabled: boolean;
+	log: string[];
+	promise: PromiseLike<string>;
+}) @{
+	if (props.enabled) {
+		useEffect(() => {
+			props.log.push('suspense:create');
+			return () => props.log.push('suspense:cleanup');
+		}, [props.log]);
+	}
+	const value = use(props.promise);
+	<span class="conditional-suspense-value">{value}</span>
+}
+
+export function ConditionalSuspenseEffect(props: {
+	enabled: boolean;
+	log: string[];
+	promise: PromiseLike<string>;
+}) @{
+	@try {
+		<ConditionalSuspendingEffect enabled={props.enabled} log={props.log} promise={props.promise} />
+	} @pending {
+		<span class="conditional-suspense-pending">{'pending'}</span>
+	}
+}
+
+function ConditionalActivityChildImpl(props: { enabled: boolean; log: string[] }) @{
+	if (props.enabled) {
+		useEffect(() => {
+			props.log.push('activity:create');
+			return () => props.log.push('activity:cleanup');
+		}, [props.log]);
+	}
+	<span class="conditional-activity">
+		{props.enabled ? 'enabled' : 'disabled'}
+	</span>
+}
+
+const ConditionalActivityChild = memo(ConditionalActivityChildImpl);
+
+export function ConditionalActivityEffect(props: {
+	enabled: boolean;
+	log: string[];
+	mode: 'visible' | 'hidden';
+}) @{
+	<Activity mode={props.mode}>
+		<ConditionalActivityChild enabled={props.enabled} log={props.log} />
+	</Activity>
 }

--- a/packages/octane/tests/_fixtures/conditional-hooks.tsrx
+++ b/packages/octane/tests/_fixtures/conditional-hooks.tsrx
@@ -1,4 +1,5 @@
 import { Activity, memo, use, useState, useEffect } from 'octane';
+import { useRepeatedSharedEffects } from './conditional-effect-helpers';
 
 // React-style guarded component: `if (cond) return;` early-exit followed by
 // hooks. octane supports runtime-conditional hooks (each call site has
@@ -46,6 +47,15 @@ export function ConditionalTsrxEffect(props: {
 		}, [props.label, props.log]);
 	}
 	<div class="conditional-tsrx">{props.label}</div>
+}
+
+export function ConditionalRepeatedEffects(props: { enabled: boolean; log: string[] }) @{
+	if (props.enabled) {
+		useRepeatedSharedEffects(props.log);
+	}
+	<div class="conditional-repeated">
+		{props.enabled ? 'enabled' : 'disabled'}
+	</div>
 }
 
 function ConditionalSuspendingEffect(props: {
@@ -96,5 +106,39 @@ export function ConditionalActivityEffect(props: {
 }) @{
 	<Activity mode={props.mode}>
 		<ConditionalActivityChild enabled={props.enabled} log={props.log} />
+	</Activity>
+}
+
+function ConditionalActivityReentryChildImpl(props: {
+	expose: (setEnabled: (enabled: boolean) => void) => void;
+	log: string[];
+}) @{
+	const [enabled, setEnabled] = useState(true);
+	props.expose(setEnabled);
+	if (enabled) {
+		useEffect(() => {
+			props.log.push('reentry:create');
+			return () => props.log.push('reentry:cleanup');
+		}, [props.log]);
+	} else {
+		// This slot is first reached while Activity is hidden, so no EffectSlot is
+		// registered. It must not count as evidence that the earlier slot above
+		// was reached by this render.
+		useEffect(() => {}, [props.log]);
+	}
+	<span class="conditional-activity-reentry">
+		{enabled ? 'enabled' : 'disabled'}
+	</span>
+}
+
+const ConditionalActivityReentryChild = memo(ConditionalActivityReentryChildImpl);
+
+export function ConditionalActivityReentryEffect(props: {
+	expose: (setEnabled: (enabled: boolean) => void) => void;
+	log: string[];
+	mode: 'visible' | 'hidden';
+}) @{
+	<Activity mode={props.mode}>
+		<ConditionalActivityReentryChild expose={props.expose} log={props.log} />
 	</Activity>
 }

--- a/packages/octane/tests/_fixtures/conditional-hooks.tsx
+++ b/packages/octane/tests/_fixtures/conditional-hooks.tsx
@@ -1,0 +1,44 @@
+/** @jsxImportSource octane */
+import { useEffect, useInsertionEffect, useLayoutEffect } from 'octane';
+
+export function ConditionalTsxEffect(props: { enabled: boolean; label: string; log: string[] }) {
+	if (props.enabled) {
+		useEffect(() => {
+			props.log.push('create:' + props.label);
+			return () => props.log.push('cleanup:' + props.label);
+		}, [props.label, props.log]);
+	}
+	return <div className="conditional-tsx">{props.label}</div>;
+}
+
+export function ConditionalEffectPhases(props: { enabled: boolean; log: string[] }) {
+	if (props.enabled) {
+		useEffect(() => {
+			props.log.push('passive:create');
+			return () => props.log.push('passive:cleanup');
+		}, [props.log]);
+		useLayoutEffect(() => {
+			props.log.push('layout:create');
+			return () => props.log.push('layout:cleanup');
+		}, [props.log]);
+		useInsertionEffect(() => {
+			props.log.push('insertion:create');
+			return () => props.log.push('insertion:cleanup');
+		}, [props.log]);
+	}
+	return <div className="conditional-phases">stable</div>;
+}
+
+export function ConditionalEffectOrder(props: { first: boolean; tick: number; log: string[] }) {
+	if (props.first) {
+		useEffect(() => {
+			props.log.push('first:create');
+			return () => props.log.push('first:cleanup');
+		}, [props.log]);
+	}
+	useEffect(() => {
+		props.log.push('second:create:' + props.tick);
+		return () => props.log.push('second:cleanup:' + props.tick);
+	}, [props.log, props.tick]);
+	return <div className="conditional-order">stable</div>;
+}

--- a/packages/octane/tests/conditional-hooks.test.ts
+++ b/packages/octane/tests/conditional-hooks.test.ts
@@ -1,6 +1,29 @@
 import { describe, it, expect } from 'vitest';
-import { mount, nextPaint } from './_helpers';
-import { Guarded, PartialGuard } from './_fixtures/conditional-hooks.tsrx';
+import { act, mount, nextPaint } from './_helpers';
+import {
+	ConditionalActivityEffect,
+	ConditionalSuspenseEffect,
+	ConditionalTsrxEffect,
+	Guarded,
+	PartialGuard,
+} from './_fixtures/conditional-hooks.tsrx';
+import {
+	ConditionalEffectOrder,
+	ConditionalEffectPhases,
+	ConditionalTsxEffect,
+} from './_fixtures/conditional-hooks.tsx';
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((res) => {
+		resolve = res;
+	});
+	return { promise, resolve };
+}
+
+function fulfilled<T>(value: T): PromiseLike<T> {
+	return { then() {}, status: 'fulfilled', value } as any;
+}
 
 // octane supports runtime-conditional hooks: each hook call site gets a
 // stable Symbol.for(stableId) slot from the compiler, so `if (cond) return;`
@@ -64,5 +87,144 @@ describe('conditional hooks — guard before useEffect', () => {
 		await nextPaint();
 		expect(log).toEqual(['mount:7', 'cleanup:7', 'mount:7']);
 		r.unmount();
+	});
+
+	it.each([
+		['TSX', ConditionalTsxEffect, '.conditional-tsx'],
+		['TSRX', ConditionalTsrxEffect, '.conditional-tsrx'],
+	] as const)(
+		'tears down and recreates an effect skipped by a plain %s conditional',
+		async (_dialect, Component, selector) => {
+			const log: string[] = [];
+			const r = mount(Component, { enabled: true, label: 'A', log });
+			await nextPaint();
+			expect(log).toEqual(['create:A']);
+
+			r.update(Component, { enabled: false, label: 'B', log });
+			await nextPaint();
+			expect(r.find(selector).textContent).toBe('B');
+			expect(log).toEqual(['create:A', 'cleanup:A']);
+
+			r.update(Component, { enabled: false, label: 'C', log });
+			await nextPaint();
+			expect(r.find(selector).textContent).toBe('C');
+			expect(log).toEqual(['create:A', 'cleanup:A']);
+
+			// Reaching the call site again must recreate it even though its last
+			// reached render used the same dependency values.
+			r.update(Component, { enabled: true, label: 'A', log });
+			await nextPaint();
+			expect(log).toEqual(['create:A', 'cleanup:A', 'create:A']);
+
+			r.unmount();
+			await nextPaint();
+			expect(log).toEqual(['create:A', 'cleanup:A', 'create:A', 'cleanup:A']);
+		},
+	);
+
+	it('tears down skipped effects in their lifecycle phases', async () => {
+		const log: string[] = [];
+		const r = mount(ConditionalEffectPhases, { enabled: true, log });
+		expect(log).toEqual(['insertion:create', 'layout:create']);
+		await nextPaint();
+		expect(log).toEqual(['insertion:create', 'layout:create', 'passive:create']);
+
+		r.update(ConditionalEffectPhases, { enabled: false, log });
+		expect(log).toEqual([
+			'insertion:create',
+			'layout:create',
+			'passive:create',
+			'insertion:cleanup',
+			'layout:cleanup',
+		]);
+		await nextPaint();
+		expect(log).toEqual([
+			'insertion:create',
+			'layout:create',
+			'passive:create',
+			'insertion:cleanup',
+			'layout:cleanup',
+			'passive:cleanup',
+		]);
+
+		r.update(ConditionalEffectPhases, { enabled: true, log });
+		expect(log.slice(-2)).toEqual(['insertion:create', 'layout:create']);
+		await nextPaint();
+		expect(log.slice(-3)).toEqual(['insertion:create', 'layout:create', 'passive:create']);
+		r.unmount();
+	});
+
+	it('runs all skipped cleanups before later effect recreation in declaration order', async () => {
+		const log: string[] = [];
+		const r = mount(ConditionalEffectOrder, { first: true, tick: 0, log });
+		await nextPaint();
+		expect(log).toEqual(['first:create', 'second:create:0']);
+
+		r.update(ConditionalEffectOrder, { first: false, tick: 1, log });
+		await nextPaint();
+		expect(log).toEqual([
+			'first:create',
+			'second:create:0',
+			'first:cleanup',
+			'second:cleanup:0',
+			'second:create:1',
+		]);
+		r.unmount();
+	});
+
+	it('does not tear down for a render that suspends before committing', async () => {
+		const log: string[] = [];
+		const pending = deferred<string>();
+		const r = mount(ConditionalSuspenseEffect, {
+			enabled: true,
+			log,
+			promise: fulfilled('A'),
+		});
+		await nextPaint();
+		expect(log).toEqual(['suspense:create']);
+
+		r.update(ConditionalSuspenseEffect, {
+			enabled: false,
+			log,
+			promise: pending.promise,
+		});
+		expect(r.find('.conditional-suspense-pending').textContent).toBe('pending');
+		await nextPaint();
+		expect(log).toEqual(['suspense:create']);
+
+		await act(() => pending.resolve('B'));
+		expect(r.find('.conditional-suspense-value').textContent).toBe('B');
+		expect(log).toEqual(['suspense:create', 'suspense:cleanup']);
+		r.unmount();
+	});
+
+	it('does not reconnect an effect omitted by a completed hidden Activity render', async () => {
+		const log: string[] = [];
+		const r = mount(ConditionalActivityEffect, { enabled: true, log, mode: 'visible' });
+		await nextPaint();
+		expect(log).toEqual(['activity:create']);
+
+		r.update(ConditionalActivityEffect, { enabled: false, log, mode: 'hidden' });
+		await nextPaint();
+		expect(log).toEqual(['activity:create', 'activity:cleanup']);
+
+		// The memoized child bails during reveal. Its old effect body must have
+		// been forgotten when the hidden render omitted that call site.
+		r.update(ConditionalActivityEffect, { enabled: false, log, mode: 'visible' });
+		await nextPaint();
+		expect(r.find('.conditional-activity').textContent).toBe('disabled');
+		expect(log).toEqual(['activity:create', 'activity:cleanup']);
+
+		r.update(ConditionalActivityEffect, { enabled: true, log, mode: 'visible' });
+		await nextPaint();
+		expect(log).toEqual(['activity:create', 'activity:cleanup', 'activity:create']);
+		r.unmount();
+		await nextPaint();
+		expect(log).toEqual([
+			'activity:create',
+			'activity:cleanup',
+			'activity:create',
+			'activity:cleanup',
+		]);
 	});
 });

--- a/packages/octane/tests/conditional-hooks.test.ts
+++ b/packages/octane/tests/conditional-hooks.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { act, mount, nextPaint } from './_helpers';
 import {
 	ConditionalActivityEffect,
+	ConditionalActivityReentryEffect,
+	ConditionalRepeatedEffects,
 	ConditionalSuspenseEffect,
 	ConditionalTsrxEffect,
 	Guarded,
@@ -226,5 +228,70 @@ describe('conditional hooks — guard before useEffect', () => {
 			'activity:create',
 			'activity:cleanup',
 		]);
+	});
+
+	it('preserves repeated enqueues through one effective custom-hook slot', async () => {
+		const log: string[] = [];
+		const r = mount(ConditionalRepeatedEffects, { enabled: true, log });
+		await nextPaint();
+		expect(log).toEqual(['shared:create:first', 'shared:create:second']);
+
+		r.update(ConditionalRepeatedEffects, { enabled: false, log });
+		await nextPaint();
+		expect(log).toEqual(['shared:create:first', 'shared:create:second', 'shared:cleanup:second']);
+
+		r.update(ConditionalRepeatedEffects, { enabled: true, log });
+		await nextPaint();
+		expect(log.slice(-2)).toEqual(['shared:create:first', 'shared:create:second']);
+		r.unmount();
+	});
+
+	it('invalidates hidden teardown when the effect call site is reached again', async () => {
+		const log: string[] = [];
+		let setEnabled!: (enabled: boolean) => void;
+		const expose = (set: (enabled: boolean) => void) => {
+			setEnabled = set;
+		};
+		const r = mount(ConditionalActivityReentryEffect, {
+			expose,
+			log,
+			mode: 'visible',
+		});
+		await nextPaint();
+		expect(log).toEqual(['reentry:create']);
+
+		r.update(ConditionalActivityReentryEffect, { expose, log, mode: 'hidden' });
+		expect(log).toEqual(['reentry:create', 'reentry:cleanup']);
+
+		setEnabled(false);
+		setEnabled(true);
+		r.update(ConditionalActivityReentryEffect, { expose, log, mode: 'visible' });
+		await nextPaint();
+		expect(r.find('.conditional-activity-reentry').textContent).toBe('enabled');
+		expect(log).toEqual(['reentry:create', 'reentry:cleanup', 'reentry:create']);
+		r.unmount();
+	});
+
+	it('does not let an unregistered hidden call site mask an omitted effect', async () => {
+		const log: string[] = [];
+		let setEnabled!: (enabled: boolean) => void;
+		const expose = (set: (enabled: boolean) => void) => {
+			setEnabled = set;
+		};
+		const r = mount(ConditionalActivityReentryEffect, {
+			expose,
+			log,
+			mode: 'visible',
+		});
+		await nextPaint();
+
+		r.update(ConditionalActivityReentryEffect, { expose, log, mode: 'hidden' });
+		setEnabled(false);
+		r.update(ConditionalActivityReentryEffect, { expose, log, mode: 'visible' });
+		await nextPaint();
+
+		expect(r.find('.conditional-activity-reentry').textContent).toBe('disabled');
+		expect(log).toEqual(['reentry:create', 'reentry:cleanup']);
+		r.unmount();
 	});
 });


### PR DESCRIPTION
## Summary

- track which registered effect slots are reached during each successful block re-render
- queue phase-correct teardown for previously live effects whose call sites are omitted
- preserve committed effects across suspended or thrown render attempts
- prevent hidden Activity renders from reconnecting effects they omitted
- add TSX and TSRX regressions covering passive, layout, insertion, Suspense, Activity, ordering, and same-dependency recreation

## Root cause

Effect slots are keyed by compiler-assigned call sites, so Octane supports hooks behind ordinary JavaScript conditionals. The runtime previously updated a slot only when its hook function was called. When a later re-render skipped that call site, no runtime operation represented its absence, leaving the previous effect connected.

## Implementation

Each effect-owning block now assigns a render token and records effect slots captured during the successful render. Once the block finishes, previously registered slots that were not captured receive teardown-only entries through the existing phase queues. Slot revisions invalidate superseded queued work, while Suspense snapshot/restore retains the committed state for aborted attempts. The common case where every slot is captured returns without scanning the slot list.

## Validation

- `vitest run packages/octane/tests/conditional-hooks.test.ts packages/octane/tests/activity.test.ts packages/octane/tests/conformance/suspense-effects-semantics.test.ts packages/octane/tests/suspense-preserves-dom.test.ts` — 90/90 passed across development and production projects
- `tsgo --noEmit -p packages/octane/tsconfig.json`
- `pnpm format:check`
- full Octane run — 9,575 tests passed; one unrelated browser fixture hit Vite's transient `504 Outdated Optimize Dep`, and its isolated rerun passed 12/12
- deterministic 1,000-row effect benchmark — all correctness gates passed with no material hot-path regression

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large changes to core effect commit, enqueue, and snapshot/restore in `runtime.ts` affect all components using effects, including Suspense and Activity semantics.
> 
> **Overview**
> Fixes **stale effects staying connected** when a successful render skips a hook call site behind a plain `if` (or early return), while Octane still allows runtime-conditional hooks via stable per-call-site slots.
> 
> The runtime now **tracks which registered effect slots were reached** on each completed block render (`renderVersion`, `active`, `revision`, stable `order`). After the body finishes, **`finishEffectRender`** queues **teardown-only** commit work (`fn: null`) through the existing insertion/layout/passive queues for any previously live slot that was not reached; commit drains run cleanups with correct phase ordering and ignore superseded entries via **revision**. **Suspended or thrown renders** never run this pass; **Suspense snapshot/restore** rolls back `deps` / `active` / `revision` for discarded attempts. **Hidden Activity** paths avoid reconnecting omitted effects and can invalidate pending teardown when a call site is reached again.
> 
> Adds TSX/TSRX fixtures and broad **conditional-hooks** tests (phases, declaration order, Suspense, Activity, custom-hook slot sharing, same-deps recreation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d670fa41a1b8da13e959d7fa73eb11f5630dd537. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->