### PR TITLE
benchmarks: add selector-based external-store fan-out suite

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -180,6 +180,7 @@ internally, get their own baseline and guard namespace.
 | `controlled-form` | controlled-form | none (builds) | 512 controlled fields, real typing, DOM identity, focus and caret, validation cancellation, complete submit/reset, and native select/checkbox/radio correctness |
 | `external-store-fanout` | external-store-fanout | none (builds) | 512 subscribers, narrow and broad writes, rapid-write tearing checks, snapshots, notifications, renders, and exact subscription cleanup |
 | `external-store-integrations` | external-store-integrations | none (builds) | real Zustand stores, Jotai atoms, and TanStack Query caches with selector fan-out, query invalidation, and six-framework cleanup gates |
+| `store-selector-fanout` | store-selector-fanout | none (builds) | 512 subscribers reading one store through a `with-selector`-shaped selector, 20 unrelated parent re-renders with the store untouched, and deterministic selector-invocation counts beside render and snapshot counts |
 | `scheduler-responsiveness` | scheduler-responsiveness | none (builds) | real controlled typing during eight 512-subscriber store updates at 6× CPU throttling, with focus, caret, frame, and notification gates |
 | `suspense-recovery` | suspense-recovery | none (builds) | six-framework visible async pending, rejection, retry, cancellation, and stale-response correctness |
 | `event-delegation` | event-delegation | none (builds) | 128 real native input events, 512 event-bearing hosts, capture/bubble accounting, and every controlled output |

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -24,6 +24,14 @@
     "note": "Same-run 512-subscriber useSyncExternalStore fan-out, gated on complete visible updates, rapid-write consistency, and exact listener teardown. A verified quick run measured about 1.01x; 2x leaves real-browser scheduling headroom."
   },
   {
+    "suite": "store-selector-fanout",
+    "op": "parent_rerenders",
+    "target": "octane-tsrx",
+    "reference": "react",
+    "maxRatio": 0.95,
+    "note": "Twenty unrelated parent re-renders across 512 selector-based subscribers with the store untouched, gated on every subscriber still showing the correct total and the new generation. Octane keeps one identity for a capture-free selector, so the selection is reused: verified full and quick runs measured 0.59x (0.586-0.597 across three quick runs), against 1.20x when that identity churns per render. 0.95x leaves roughly 60% headroom over the observed ratio while still failing if the selection is recomputed per render. The deterministic companion signal is meta.selectorCallsDuringRerenders, which is 0 rather than 10,240 while meta.subscriberRendersDuringRerenders stays at 10,240."
+  },
+  {
     "suite": "hydration-interactivity",
     "op": "uncontrolled_6x_hydration",
     "target": "octane-tsrx",

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -283,6 +283,21 @@ const SUITES = [
 		})),
 	})),
 	{
+		// Selector-based fan-out: 512 subscribers read one store through a
+		// selector, then the parent re-renders 20 times with the store untouched.
+		// Reuses the news per-target toolchains with its own page, so the shared
+		// runtime-stress fixture's 512 form fields stay out of the measurement.
+		name: 'store-selector-fanout',
+		cwd: 'store-selector-fanout',
+		servers: [],
+		iter: { normal: 8, quick: 2 },
+		runs: ['octane-tsrx', 'react', 'preact', 'solid', 'svelte', 'vue-vapor'].map((target) => ({
+			label: target,
+			script: 'run.mjs',
+			args: (n) => [target, String(n)],
+		})),
+	},
+	{
 		name: 'effectful-list',
 		cwd: 'effectful-list',
 		servers: [

--- a/benchmarks/news/octane-tsrx/src/store-selector-fanout/App.tsrx
+++ b/benchmarks/news/octane-tsrx/src/store-selector-fanout/App.tsrx
@@ -1,0 +1,76 @@
+import { useMemo, useState, useSyncExternalStore } from 'octane';
+import {
+	SELECTOR_SUBSCRIBERS,
+	getStoreSelectorStress,
+	markSubscriberRender,
+	selectTotal,
+} from '../../../../store-selector-fanout/shared.js';
+
+type StoreSnapshot = { values: number[]; version: number };
+type Selector = (snapshot: StoreSnapshot) => number;
+
+// React's `use-sync-external-store/with-selector` shape: the cached read is
+// keyed on the selector's identity, so a selector argument that is reallocated
+// every render throws the cache away and re-runs the selection.
+function useStoreSelector(selector: Selector) {
+	const store = getStoreSelectorStress().store;
+	const read = useMemo(() => {
+		let cachedSnapshot: StoreSnapshot | null = null;
+		let cachedSelection = 0;
+		return () => {
+			const snapshot = store.getSnapshot() as StoreSnapshot;
+			if (snapshot === cachedSnapshot) return cachedSelection;
+			cachedSnapshot = snapshot;
+			cachedSelection = selector(snapshot);
+			return cachedSelection;
+		};
+	}, [store, selector]);
+
+	return useSyncExternalStore(store.subscribe, read, read);
+}
+
+function StoreSubscriber(props: { generation: number; index: number }) @{
+	const total = useStoreSelector((snapshot) => selectTotal(snapshot.values));
+	markSubscriberRender();
+
+	<output
+		data-subscriber-index={String(props.index)}
+		data-generation={String(props.generation)}
+	>{String(total) as string}</output>
+}
+
+export function App() @{
+	const [visible, setVisible] = useState(false);
+	const [generation, setGeneration] = useState(0);
+	const stress = getStoreSelectorStress();
+	const store = stress.store;
+	// The harness drives discrete parent renders through this, so a re-render
+	// costs no Playwright round trip and no timer floor.
+	stress.bump = () => setGeneration((value: number) => value + 1);
+
+	<main>
+		<button
+			id="selector-toggle"
+			type="button"
+			onClick={() => setVisible((value: boolean) => !value)}
+		>{'Toggle subscribers'}</button>
+		<button
+			id="selector-write"
+			type="button"
+			onClick={() => store.writeAll(7)}
+		>{'Write every store value'}</button>
+		<button
+			id="selector-rewrite"
+			type="button"
+			onClick={() => store.writeAll(9)}
+		>{'Rewrite every store value'}</button>
+		<output id="selector-generation">{String(generation) as string}</output>
+		@if (visible) {
+			<div id="selector-subscribers">
+				@for (const index of SELECTOR_SUBSCRIBERS; key index) {
+					<StoreSubscriber index={index} generation={generation} />
+				}
+			</div>
+		}
+	</main>
+}

--- a/benchmarks/news/octane-tsrx/src/store-selector-fanout/entry.ts
+++ b/benchmarks/news/octane-tsrx/src/store-selector-fanout/entry.ts
@@ -1,0 +1,13 @@
+import { createRoot, flushSync } from 'octane';
+import { installStoreSelectorStress } from '../../../../store-selector-fanout/shared.js';
+import { App } from './App.tsrx';
+
+const container = document.getElementById('app');
+if (!container) throw new Error('Missing store selector benchmark root');
+
+const stress = installStoreSelectorStress();
+stress.flush = (run: () => void) => flushSync(run);
+const root = createRoot(container);
+root.render(App, {});
+flushSync(() => {});
+stress.ready = true;

--- a/benchmarks/news/octane-tsrx/store-selector-fanout.html
+++ b/benchmarks/news/octane-tsrx/store-selector-fanout.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Octane store selector fan-out</title>
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="module" src="/src/store-selector-fanout/entry.ts"></script>
+	</body>
+</html>

--- a/benchmarks/news/preact/src/store-selector-fanout/App.jsx
+++ b/benchmarks/news/preact/src/store-selector-fanout/App.jsx
@@ -1,0 +1,70 @@
+import { memo, useSyncExternalStore } from 'preact/compat';
+import { useMemo, useState } from 'preact/hooks';
+import {
+	SELECTOR_SUBSCRIBERS,
+	getStoreSelectorStress,
+	markSubscriberRender,
+	selectTotal,
+} from '../../../../store-selector-fanout/shared.js';
+
+// React's `use-sync-external-store/with-selector` shape: the cached read is
+// keyed on the selector's identity, so a selector argument that is reallocated
+// every render throws the cache away and re-runs the selection.
+function useStoreSelector(selector) {
+	const store = getStoreSelectorStress().store;
+	const read = useMemo(() => {
+		let cachedSnapshot = null;
+		let cachedSelection = 0;
+		return () => {
+			const snapshot = store.getSnapshot();
+			if (snapshot === cachedSnapshot) return cachedSelection;
+			cachedSnapshot = snapshot;
+			cachedSelection = selector(snapshot);
+			return cachedSelection;
+		};
+	}, [store, selector]);
+
+	return useSyncExternalStore(store.subscribe, read, read);
+}
+
+const StoreSubscriber = memo(function StoreSubscriber({ generation, index }) {
+	const total = useStoreSelector((snapshot) => selectTotal(snapshot.values));
+	markSubscriberRender();
+	return (
+		<output data-subscriber-index={index} data-generation={generation}>
+			{total}
+		</output>
+	);
+});
+
+export function App() {
+	const [visible, setVisible] = useState(false);
+	const [generation, setGeneration] = useState(0);
+	const stress = getStoreSelectorStress();
+	const store = stress.store;
+	// The harness drives discrete parent renders through this, so a re-render
+	// costs no Playwright round trip and no timer floor.
+	stress.bump = () => setGeneration((value) => value + 1);
+
+	return (
+		<main>
+			<button id="selector-toggle" type="button" onClick={() => setVisible((value) => !value)}>
+				Toggle subscribers
+			</button>
+			<button id="selector-write" type="button" onClick={() => store.writeAll(7)}>
+				Write every store value
+			</button>
+			<button id="selector-rewrite" type="button" onClick={() => store.writeAll(9)}>
+				Rewrite every store value
+			</button>
+			<output id="selector-generation">{generation}</output>
+			{visible && (
+				<div id="selector-subscribers">
+					{SELECTOR_SUBSCRIBERS.map((index) => (
+						<StoreSubscriber generation={generation} index={index} key={index} />
+					))}
+				</div>
+			)}
+		</main>
+	);
+}

--- a/benchmarks/news/preact/src/store-selector-fanout/entry.jsx
+++ b/benchmarks/news/preact/src/store-selector-fanout/entry.jsx
@@ -1,0 +1,12 @@
+import { createElement, render } from 'preact';
+import { flushSync } from 'preact/compat';
+import { installStoreSelectorStress } from '../../../../store-selector-fanout/shared.js';
+import { App } from './App.jsx';
+
+const container = document.getElementById('app');
+if (!container) throw new Error('Missing store selector benchmark root');
+
+const stress = installStoreSelectorStress();
+stress.flush = (run) => flushSync(run);
+flushSync(() => render(createElement(App), container));
+stress.ready = true;

--- a/benchmarks/news/preact/store-selector-fanout.html
+++ b/benchmarks/news/preact/store-selector-fanout.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Preact store selector fan-out</title>
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="module" src="/src/store-selector-fanout/entry.jsx"></script>
+	</body>
+</html>

--- a/benchmarks/news/react/src/store-selector-fanout/App.tsx
+++ b/benchmarks/news/react/src/store-selector-fanout/App.tsx
@@ -1,0 +1,78 @@
+import { memo, useMemo, useState, useSyncExternalStore } from 'react';
+import {
+	SELECTOR_SUBSCRIBERS,
+	getStoreSelectorStress,
+	markSubscriberRender,
+	selectTotal,
+} from '../../../../store-selector-fanout/shared.js';
+
+type StoreSnapshot = { values: number[]; version: number };
+type Selector = (snapshot: StoreSnapshot) => number;
+
+// React's `use-sync-external-store/with-selector` shape: the cached read is
+// keyed on the selector's identity, so a selector argument that is reallocated
+// every render throws the cache away and re-runs the selection.
+function useStoreSelector(selector: Selector) {
+	const store = getStoreSelectorStress().store;
+	const read = useMemo(() => {
+		let cachedSnapshot: StoreSnapshot | null = null;
+		let cachedSelection = 0;
+		return () => {
+			const snapshot = store.getSnapshot() as StoreSnapshot;
+			if (snapshot === cachedSnapshot) return cachedSelection;
+			cachedSnapshot = snapshot;
+			cachedSelection = selector(snapshot);
+			return cachedSelection;
+		};
+	}, [store, selector]);
+
+	return useSyncExternalStore(store.subscribe, read, read);
+}
+
+const StoreSubscriber = memo(function StoreSubscriber({
+	generation,
+	index,
+}: {
+	generation: number;
+	index: number;
+}) {
+	const total = useStoreSelector((snapshot) => selectTotal(snapshot.values));
+	markSubscriberRender();
+	return (
+		<output data-subscriber-index={index} data-generation={generation}>
+			{total}
+		</output>
+	);
+});
+
+export function App() {
+	const [visible, setVisible] = useState(false);
+	const [generation, setGeneration] = useState(0);
+	const stress = getStoreSelectorStress();
+	const store = stress.store;
+	// The harness drives discrete parent renders through this, so a re-render
+	// costs no Playwright round trip and no timer floor.
+	stress.bump = () => setGeneration((value: number) => value + 1);
+
+	return (
+		<main>
+			<button id="selector-toggle" type="button" onClick={() => setVisible((value) => !value)}>
+				Toggle subscribers
+			</button>
+			<button id="selector-write" type="button" onClick={() => store.writeAll(7)}>
+				Write every store value
+			</button>
+			<button id="selector-rewrite" type="button" onClick={() => store.writeAll(9)}>
+				Rewrite every store value
+			</button>
+			<output id="selector-generation">{generation}</output>
+			{visible && (
+				<div id="selector-subscribers">
+					{SELECTOR_SUBSCRIBERS.map((index: number) => (
+						<StoreSubscriber generation={generation} index={index} key={index} />
+					))}
+				</div>
+			)}
+		</main>
+	);
+}

--- a/benchmarks/news/react/src/store-selector-fanout/entry.tsx
+++ b/benchmarks/news/react/src/store-selector-fanout/entry.tsx
@@ -1,0 +1,14 @@
+import { createElement } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import { installStoreSelectorStress } from '../../../../store-selector-fanout/shared.js';
+import { App } from './App';
+
+const container = document.getElementById('app');
+if (!container) throw new Error('Missing store selector benchmark root');
+
+const stress = installStoreSelectorStress();
+stress.flush = (run: () => void) => flushSync(run);
+const root = createRoot(container);
+flushSync(() => root.render(createElement(App)));
+stress.ready = true;

--- a/benchmarks/news/react/store-selector-fanout.html
+++ b/benchmarks/news/react/store-selector-fanout.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>React store selector fan-out</title>
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="module" src="/src/store-selector-fanout/entry.tsx"></script>
+	</body>
+</html>

--- a/benchmarks/news/solid/src/store-selector-fanout/App.jsx
+++ b/benchmarks/news/solid/src/store-selector-fanout/App.jsx
@@ -1,0 +1,57 @@
+import { For, Show, createMemo, createSignal, onCleanup } from 'solid-js';
+import {
+	SELECTOR_SUBSCRIBERS,
+	getStoreSelectorStress,
+	markSubscriberRender,
+	selectTotal,
+} from '../../../../store-selector-fanout/shared.js';
+
+// Solid has no render pass to re-run, so the selection is a `createMemo` over
+// the snapshot signal: it recomputes when the store publishes a new snapshot
+// and never because a parent rendered.
+function StoreSubscriber(props) {
+	const store = getStoreSelectorStress().store;
+	const [snapshot, setSnapshot] = createSignal(store.getSnapshot());
+	const unsubscribe = store.subscribe(() => setSnapshot(store.getSnapshot()));
+	onCleanup(unsubscribe);
+	const total = createMemo(() => selectTotal(snapshot().values));
+	markSubscriberRender();
+
+	return (
+		<output data-subscriber-index={props.index} data-generation={props.generation}>
+			{total()}
+		</output>
+	);
+}
+
+export function App() {
+	const [visible, setVisible] = createSignal(false);
+	const [generation, setGeneration] = createSignal(0);
+	const stress = getStoreSelectorStress();
+	const store = stress.store;
+	// The harness drives discrete parent renders through this, so a re-render
+	// costs no Playwright round trip and no timer floor.
+	stress.bump = () => setGeneration((value) => value + 1);
+
+	return (
+		<main>
+			<button id="selector-toggle" type="button" onClick={() => setVisible((value) => !value)}>
+				Toggle subscribers
+			</button>
+			<button id="selector-write" type="button" onClick={() => store.writeAll(7)}>
+				Write every store value
+			</button>
+			<button id="selector-rewrite" type="button" onClick={() => store.writeAll(9)}>
+				Rewrite every store value
+			</button>
+			<output id="selector-generation">{generation()}</output>
+			<Show when={visible()}>
+				<div id="selector-subscribers">
+					<For each={SELECTOR_SUBSCRIBERS}>
+						{(index) => <StoreSubscriber generation={generation()} index={index} />}
+					</For>
+				</div>
+			</Show>
+		</main>
+	);
+}

--- a/benchmarks/news/solid/src/store-selector-fanout/entry.jsx
+++ b/benchmarks/news/solid/src/store-selector-fanout/entry.jsx
@@ -1,0 +1,16 @@
+import { render } from '@solidjs/web';
+import { flush } from 'solid-js';
+import { installStoreSelectorStress } from '../../../../store-selector-fanout/shared.js';
+import { App } from './App.jsx';
+
+const container = document.getElementById('app');
+if (!container) throw new Error('Missing store selector benchmark root');
+
+const stress = installStoreSelectorStress();
+stress.flush = (run) => {
+	run();
+	flush();
+};
+render(() => <App />, container);
+flush();
+stress.ready = true;

--- a/benchmarks/news/solid/store-selector-fanout.html
+++ b/benchmarks/news/solid/store-selector-fanout.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Solid store selector fan-out</title>
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="module" src="/src/store-selector-fanout/entry.jsx"></script>
+	</body>
+</html>

--- a/benchmarks/news/store-selector-fanout.mjs
+++ b/benchmarks/news/store-selector-fanout.mjs
@@ -1,0 +1,348 @@
+process.env.NODE_ENV = 'production';
+
+import { createServer } from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+import { build } from 'vite';
+import {
+	PARENT_RERENDER_COUNT,
+	SELECTOR_INPUT_SIZE,
+	SELECTOR_SUBSCRIBER_COUNT,
+} from '../store-selector-fanout/shared.js';
+import { summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const TARGETS = ['octane-tsrx', 'react', 'preact', 'solid', 'svelte', 'vue-vapor'];
+const WRITE_VALUE = 7;
+const REWRITE_VALUE = 9;
+const WRITE_TOTAL = String(WRITE_VALUE * SELECTOR_INPUT_SIZE);
+const REWRITE_TOTAL = String(REWRITE_VALUE * SELECTOR_INPUT_SIZE);
+
+const args = process.argv.slice(2);
+const positional = args.filter((value) => !value.startsWith('--'));
+const target = TARGETS.includes(positional[0]) ? positional.shift() : 'octane-tsrx';
+const iterations = Number.parseInt(positional[0] ?? '5', 10);
+
+if (!Number.isSafeInteger(iterations) || iterations < 1) {
+	throw new Error('Store selector fan-out iterations must be a positive integer');
+}
+
+const appDirectory = path.join(HERE, target);
+const clientDirectory = path.join(appDirectory, 'dist/store-selector-fanout');
+const clientHtml = path.join(clientDirectory, 'store-selector-fanout.html');
+
+if (!args.includes('--no-build')) {
+	console.log(`Building ${target} store selector fixture (production)…`);
+	await build({
+		root: appDirectory,
+		logLevel: 'warn',
+		build: {
+			outDir: path.relative(appDirectory, clientDirectory),
+			emptyOutDir: true,
+			minify: 'esbuild',
+			rollupOptions: {
+				input: path.join(appDirectory, 'store-selector-fanout.html'),
+				output: {
+					chunkFileNames: 'assets/[name]-[hash].js',
+					entryFileNames: 'assets/[name]-[hash].js',
+				},
+			},
+		},
+	});
+}
+
+if (!fs.existsSync(clientHtml)) {
+	throw new Error(`Missing production store selector assets for ${target}`);
+}
+
+const contentTypes = {
+	'.css': 'text/css; charset=utf-8',
+	'.html': 'text/html; charset=utf-8',
+	'.js': 'text/javascript; charset=utf-8',
+	'.json': 'application/json; charset=utf-8',
+	'.mjs': 'text/javascript; charset=utf-8',
+	'.svg': 'image/svg+xml',
+};
+
+const server = createServer((request, response) => {
+	try {
+		const url = new URL(request.url ?? '/', 'http://127.0.0.1');
+		const file =
+			url.pathname === '/'
+				? clientHtml
+				: path.resolve(clientDirectory, `.${decodeURIComponent(url.pathname)}`);
+		if (
+			(file === clientHtml || file.startsWith(`${clientDirectory}${path.sep}`)) &&
+			fs.existsSync(file) &&
+			fs.statSync(file).isFile()
+		) {
+			response.setHeader(
+				'content-type',
+				contentTypes[path.extname(file)] ?? 'application/octet-stream',
+			);
+			response.end(fs.readFileSync(file));
+			return;
+		}
+		response.statusCode = 404;
+		response.end('Not found');
+	} catch (error) {
+		response.statusCode = 500;
+		response.end(error instanceof Error ? error.message : String(error));
+	}
+});
+
+await new Promise((resolve, reject) => {
+	server.once('error', reject);
+	server.listen(0, '127.0.0.1', resolve);
+});
+
+const address = server.address();
+if (address === null || typeof address === 'string') {
+	throw new Error('The store selector server did not expose a TCP port');
+}
+
+const origin = `http://127.0.0.1:${address.port}`;
+let browser;
+
+function ensure(condition, message) {
+	if (!condition) throw new Error(`${target}: ${message}`);
+}
+
+async function openSample() {
+	const context = await browser.newContext();
+	const page = await context.newPage();
+	const failures = [];
+	page.setDefaultTimeout(30_000);
+	page.on('pageerror', (error) => failures.push(error.message));
+	page.on('console', (message) => {
+		if (message.type() === 'error') failures.push(message.text());
+	});
+	await page.goto(origin, { waitUntil: 'domcontentloaded' });
+	try {
+		await page.waitForFunction(() => window.__storeSelectorStress?.ready === true, null, {
+			timeout: 10_000,
+		});
+	} catch (error) {
+		const details = failures.length > 0 ? failures.join('; ') : 'bootstrap never became ready';
+		await context.close();
+		throw new Error(`${target}: production store selector fixture failed to start: ${details}`, {
+			cause: error,
+		});
+	}
+	ensure(failures.length === 0, `production browser errors: ${failures.join('; ')}`);
+	return { context, failures, page };
+}
+
+/** Every mounted subscriber shows `total`, and its parent-driven prop is `generation`. */
+function subscribersSettled({ count, generation, total }) {
+	const nodes = Array.from(document.querySelectorAll('[data-subscriber-index]'));
+	return (
+		nodes.length === count &&
+		nodes.every(
+			(node) =>
+				node.textContent === total &&
+				(generation === null || node.getAttribute('data-generation') === generation),
+		)
+	);
+}
+
+async function runSample() {
+	const sample = await openSample();
+	const { page } = sample;
+	try {
+		const mountStarted = await page.evaluate(() => performance.now());
+		await page.locator('#selector-toggle').click();
+		await page.waitForFunction(
+			(count) =>
+				document.querySelectorAll('[data-subscriber-index]').length === count &&
+				window.__storeSelectorStress.store.size === count,
+			SELECTOR_SUBSCRIBER_COUNT,
+		);
+		const mountedAt = await page.evaluate(() => performance.now());
+
+		// A real store write: the selection genuinely changes, so every subscriber
+		// must recompute and repaint. This is the control that proves a cheap
+		// re-render number was not bought by dropping the subscription.
+		const writeStarted = await page.evaluate(() => performance.now());
+		await page.locator('#selector-write').click();
+		await page.waitForFunction(subscribersSettled, {
+			count: SELECTOR_SUBSCRIBER_COUNT,
+			generation: '0',
+			total: WRITE_TOTAL,
+		});
+		const writtenAt = await page.evaluate(() => performance.now());
+
+		// The measured op: unrelated parent re-renders with the store untouched.
+		// Driven and timed inside the page so neither a Playwright round trip nor
+		// a timer floor sits between renders.
+		const rerendered = await page.evaluate(async (count) => {
+			const stress = window.__storeSelectorStress;
+			const selectorCallsBefore = stress.stats.selectorCalls;
+			const snapshotCallsBefore = stress.stats.snapshotCalls;
+			const subscriberRendersBefore = stress.stats.subscriberRenders;
+			const startedAt = performance.now();
+			for (let index = 0; index < count; index++) await stress.flush(() => stress.bump());
+			const completedAt = performance.now();
+			return {
+				completedAt,
+				selectorCalls: stress.stats.selectorCalls - selectorCallsBefore,
+				snapshotCalls: stress.stats.snapshotCalls - snapshotCallsBefore,
+				startedAt,
+				subscriberRenders: stress.stats.subscriberRenders - subscriberRendersBefore,
+			};
+		}, PARENT_RERENDER_COUNT);
+		await page.waitForFunction(subscribersSettled, {
+			count: SELECTOR_SUBSCRIBER_COUNT,
+			generation: String(PARENT_RERENDER_COUNT),
+			total: WRITE_TOTAL,
+		});
+		const generationText = await page.evaluate(
+			() => document.querySelector('#selector-generation')?.textContent,
+		);
+		ensure(
+			generationText === String(PARENT_RERENDER_COUNT),
+			'the parent did not complete every unrelated re-render',
+		);
+
+		// A second real write after the re-render burst: subscriptions established
+		// before the burst must still deliver.
+		const rewriteStarted = await page.evaluate(() => performance.now());
+		await page.locator('#selector-rewrite').click();
+		await page.waitForFunction(subscribersSettled, {
+			count: SELECTOR_SUBSCRIBER_COUNT,
+			generation: String(PARENT_RERENDER_COUNT),
+			total: REWRITE_TOTAL,
+		});
+		const rewrittenAt = await page.evaluate(() => performance.now());
+
+		const unmountStarted = await page.evaluate(() => performance.now());
+		await page.locator('#selector-toggle').click();
+		await page.waitForFunction(
+			() =>
+				document.querySelectorAll('[data-subscriber-index]').length === 0 &&
+				window.__storeSelectorStress.store.size === 0,
+		);
+		const state = await page.evaluate(() => ({
+			completedAt: performance.now(),
+			...window.__storeSelectorStress.stats,
+			retainedSubscribers: window.__storeSelectorStress.store.size,
+		}));
+
+		ensure(state.subscribeCalls >= SELECTOR_SUBSCRIBER_COUNT, 'subscribers never connected');
+		ensure(
+			state.subscribeCalls === state.unsubscribeCalls,
+			'a store subscription was not cleaned up exactly once',
+		);
+		ensure(state.retainedSubscribers === 0, 'the store retained an unmounted subscriber');
+		ensure(
+			state.notifications >= SELECTOR_SUBSCRIBER_COUNT * 2,
+			'a store write did not reach every subscriber',
+		);
+		ensure(
+			state.selectorCalls >= SELECTOR_SUBSCRIBER_COUNT * 2,
+			'the two store writes did not run the selection for every subscriber',
+		);
+		ensure(sample.failures.length === 0, sample.failures.join('; '));
+
+		return {
+			ops: {
+				mount: mountedAt - mountStarted,
+				store_write: writtenAt - writeStarted,
+				parent_rerenders: rerendered.completedAt - rerendered.startedAt,
+				store_write_after_rerenders: rewrittenAt - rewriteStarted,
+				unmount: state.completedAt - unmountStarted,
+			},
+			meta: {
+				inputSize: SELECTOR_INPUT_SIZE,
+				notifications: state.notifications,
+				parentRerenders: PARENT_RERENDER_COUNT,
+				retainedSubscribers: state.retainedSubscribers,
+				// The signal that is purely attributable to selector identity: the
+				// store never moves during the burst, so every one of these is work
+				// a stable selector would not have done.
+				selectorCallsDuringRerenders: rerendered.selectorCalls,
+				selectorCallsTotal: state.selectorCalls,
+				snapshotCallsDuringRerenders: rerendered.snapshotCalls,
+				snapshotCallsTotal: state.snapshotCalls,
+				subscribeCalls: state.subscribeCalls,
+				subscriberCount: SELECTOR_SUBSCRIBER_COUNT,
+				// Read alongside `selectorCallsDuringRerenders`: on a render-pass
+				// framework this stays at 512 per re-render, so zero selector calls
+				// means the selection was reused, not that the renders were skipped.
+				subscriberRendersDuringRerenders: rerendered.subscriberRenders,
+				subscriberRendersTotal: state.subscriberRenders,
+				unsubscribeCalls: state.unsubscribeCalls,
+			},
+		};
+	} finally {
+		await sample.context.close();
+	}
+}
+
+const rawOperations = {};
+const samples = [];
+let failure;
+
+try {
+	browser = await chromium.launch({ headless: true, args: ['--no-sandbox'] });
+	for (let index = 0; index < iterations + 1; index++) {
+		const result = await runSample();
+		if (index === 0) continue;
+		for (const [name, value] of Object.entries(result.ops)) {
+			(rawOperations[name] ??= []).push(value);
+		}
+		samples.push(result.meta);
+	}
+} catch (error) {
+	failure = error instanceof Error ? (error.stack ?? error.message) : String(error);
+} finally {
+	await browser?.close();
+	await new Promise((resolve) => server.close(resolve));
+}
+
+const payload = {
+	suite: 'store-selector-fanout',
+	iterations,
+	targets: [
+		{
+			name: target,
+			ops: Object.fromEntries(
+				Object.entries(rawOperations).map(([name, values]) => [
+					name,
+					timingStatForJson(summarizeSamples(values), { p99: true }),
+				]),
+			),
+			meta: {
+				browser: 'chromium',
+				correctness: failure ? 'fail' : 'pass',
+				samples,
+			},
+		},
+	],
+	...(failure ? { failed: failure } : {}),
+};
+
+if (process.env.BENCH_JSON) {
+	fs.writeFileSync(process.env.BENCH_JSON, `${JSON.stringify(payload, null, '\t')}\n`);
+}
+
+if (failure) {
+	console.error(`FAIL store-selector-fanout/${target}: ${failure}`);
+	process.exitCode = 1;
+} else {
+	console.log(
+		`PASS store-selector-fanout/${target}: ${iterations} correctness-gated Chromium samples ` +
+			`(${samples[0].selectorCallsDuringRerenders} selector calls across ` +
+			`${PARENT_RERENDER_COUNT} unrelated parent re-renders)`,
+	);
+	console.table(
+		Object.fromEntries(
+			Object.entries(payload.targets[0].ops).map(([name, stats]) => [
+				name,
+				{ 'score (ms)': stats.score, 'p95 (ms)': stats.p95, samples: stats.samples },
+			]),
+		),
+	);
+}

--- a/benchmarks/news/svelte/src/store-selector-fanout/App.svelte
+++ b/benchmarks/news/svelte/src/store-selector-fanout/App.svelte
@@ -1,0 +1,35 @@
+<script>
+	import {
+		SELECTOR_SUBSCRIBERS,
+		getStoreSelectorStress,
+	} from '../../../../store-selector-fanout/shared.js';
+	import StoreSubscriber from './StoreSubscriber.svelte';
+
+	let visible = $state(false);
+	let generation = $state(0);
+	const stress = getStoreSelectorStress();
+	const store = stress.store;
+	// The harness drives discrete parent renders through this, so a re-render
+	// costs no Playwright round trip and no timer floor.
+	stress.bump = () => generation++;
+</script>
+
+<main>
+	<button id="selector-toggle" type="button" onclick={() => (visible = !visible)}>
+		Toggle subscribers
+	</button>
+	<button id="selector-write" type="button" onclick={() => store.writeAll(7)}>
+		Write every store value
+	</button>
+	<button id="selector-rewrite" type="button" onclick={() => store.writeAll(9)}>
+		Rewrite every store value
+	</button>
+	<output id="selector-generation">{generation}</output>
+	{#if visible}
+		<div id="selector-subscribers">
+			{#each SELECTOR_SUBSCRIBERS as index (index)}
+				<StoreSubscriber {generation} {index} />
+			{/each}
+		</div>
+	{/if}
+</main>

--- a/benchmarks/news/svelte/src/store-selector-fanout/StoreSubscriber.svelte
+++ b/benchmarks/news/svelte/src/store-selector-fanout/StoreSubscriber.svelte
@@ -1,0 +1,27 @@
+<script>
+	import {
+		getStoreSelectorStress,
+		markSubscriberRender,
+		selectTotal,
+	} from '../../../../store-selector-fanout/shared.js';
+
+	let { generation, index } = $props();
+	const store = getStoreSelectorStress().store;
+	// `$state.raw` keeps the 2,000-element snapshot out of the deep proxy, so the
+	// measured work stays the selection itself rather than reactivity plumbing.
+	let snapshot = $state.raw(store.getSnapshot());
+
+	$effect(() =>
+		store.subscribe(() => {
+			snapshot = store.getSnapshot();
+		}),
+	);
+
+	// Svelte has no render pass to re-run: the derived recomputes when the store
+	// publishes a new snapshot and never because a parent rendered.
+	const total = $derived(selectTotal(snapshot.values));
+
+	markSubscriberRender();
+</script>
+
+<output data-subscriber-index={index} data-generation={generation}>{total}</output>

--- a/benchmarks/news/svelte/src/store-selector-fanout/entry.js
+++ b/benchmarks/news/svelte/src/store-selector-fanout/entry.js
@@ -1,0 +1,11 @@
+import { flushSync, mount } from 'svelte';
+import { installStoreSelectorStress } from '../../../../store-selector-fanout/shared.js';
+import App from './App.svelte';
+
+const container = document.getElementById('app');
+if (!container) throw new Error('Missing store selector benchmark root');
+
+const stress = installStoreSelectorStress();
+stress.flush = (run) => flushSync(run);
+flushSync(() => mount(App, { target: container }));
+stress.ready = true;

--- a/benchmarks/news/svelte/store-selector-fanout.html
+++ b/benchmarks/news/svelte/store-selector-fanout.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Svelte store selector fan-out</title>
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="module" src="/src/store-selector-fanout/entry.js"></script>
+	</body>
+</html>

--- a/benchmarks/news/vue-vapor/src/store-selector-fanout/App.vue
+++ b/benchmarks/news/vue-vapor/src/store-selector-fanout/App.vue
@@ -1,0 +1,41 @@
+<script setup vapor lang="ts">
+import { shallowRef } from 'vue';
+import {
+	SELECTOR_SUBSCRIBERS,
+	getStoreSelectorStress,
+} from '../../../../store-selector-fanout/shared.js';
+import StoreSubscriber from './StoreSubscriber.vue';
+
+const visible = shallowRef(false);
+const generation = shallowRef(0);
+const stress = getStoreSelectorStress();
+const store = stress.store;
+// The harness drives discrete parent renders through this, so a re-render costs
+// no Playwright round trip and no timer floor.
+stress.bump = () => {
+	generation.value++;
+};
+</script>
+
+<template>
+	<main>
+		<button id="selector-toggle" type="button" @click="visible = !visible">
+			Toggle subscribers
+		</button>
+		<button id="selector-write" type="button" @click="store.writeAll(7)">
+			Write every store value
+		</button>
+		<button id="selector-rewrite" type="button" @click="store.writeAll(9)">
+			Rewrite every store value
+		</button>
+		<output id="selector-generation">{{ generation }}</output>
+		<div v-if="visible" id="selector-subscribers">
+			<StoreSubscriber
+				v-for="index of SELECTOR_SUBSCRIBERS"
+				:key="index"
+				:generation="generation"
+				:index="index"
+			/>
+		</div>
+	</main>
+</template>

--- a/benchmarks/news/vue-vapor/src/store-selector-fanout/StoreSubscriber.vue
+++ b/benchmarks/news/vue-vapor/src/store-selector-fanout/StoreSubscriber.vue
@@ -1,0 +1,37 @@
+<script setup vapor lang="ts">
+import { computed, onMounted, onUnmounted, shallowRef } from 'vue';
+import {
+	getStoreSelectorStress,
+	markSubscriberRender,
+	selectTotal,
+} from '../../../../store-selector-fanout/shared.js';
+
+const props = defineProps<{ generation: number; index: number }>();
+const store = getStoreSelectorStress().store;
+// `shallowRef` keeps the 2,000-element snapshot out of the deep proxy, so the
+// measured work stays the selection itself rather than reactivity plumbing.
+const snapshot = shallowRef(store.getSnapshot());
+let unsubscribe: (() => void) | undefined;
+
+onMounted(() => {
+	unsubscribe = store.subscribe(() => {
+		snapshot.value = store.getSnapshot();
+	});
+});
+
+onUnmounted(() => {
+	unsubscribe?.();
+});
+
+// Vue has no render pass to re-run for the selection: the computed recomputes
+// when the store publishes a new snapshot and never because a parent rendered.
+const total = computed(() => selectTotal(snapshot.value.values));
+
+markSubscriberRender();
+</script>
+
+<template>
+	<output :data-subscriber-index="props.index" :data-generation="props.generation">{{
+		total
+	}}</output>
+</template>

--- a/benchmarks/news/vue-vapor/src/store-selector-fanout/entry.ts
+++ b/benchmarks/news/vue-vapor/src/store-selector-fanout/entry.ts
@@ -1,0 +1,16 @@
+import { createVaporApp, nextTick } from 'vue';
+import { installStoreSelectorStress } from '../../../../store-selector-fanout/shared.js';
+import App from './App.vue';
+
+const container = document.getElementById('app');
+if (!container) throw new Error('Missing store selector benchmark root');
+
+const stress = installStoreSelectorStress();
+stress.flush = async (run: () => void) => {
+	run();
+	await nextTick();
+};
+createVaporApp(App).mount(container);
+void nextTick().then(() => {
+	stress.ready = true;
+});

--- a/benchmarks/news/vue-vapor/src/vue-shim.js
+++ b/benchmarks/news/vue-vapor/src/vue-shim.js
@@ -8,6 +8,7 @@
 // any overlapping names in the star export, per ES module semantics.
 export * from '@vue/runtime-vapor';
 export {
+	computed,
 	ref,
 	shallowRef,
 	unref,

--- a/benchmarks/news/vue-vapor/store-selector-fanout.html
+++ b/benchmarks/news/vue-vapor/store-selector-fanout.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Vue Vapor store selector fan-out</title>
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="module" src="/src/store-selector-fanout/entry.ts"></script>
+	</body>
+</html>

--- a/benchmarks/store-selector-fanout/README.md
+++ b/benchmarks/store-selector-fanout/README.md
@@ -1,0 +1,54 @@
+# Store selector fan-out
+
+512 independently rendered subscribers read one external store **through a
+selector**, in production-built Octane, React, Preact, Solid 2, Svelte, and Vue
+Vapor applications. The measured operation is the one a selector layer is
+supposed to make free: **unrelated parent re-renders while the store is
+untouched**.
+
+`external-store-fanout` is the sibling suite for a raw `useSyncExternalStore`
+fan-out with an inline snapshot getter and no selector layer at all;
+`external-store-integrations` measures real Zustand/Jotai/TanStack Query
+backends. Neither isolates the cost of the selector itself, which is what this
+suite exists for.
+
+## Why the shape is what it is
+
+Octane, React, and Preact use the `use-sync-external-store/with-selector` shape:
+a cached read, memoized on the **selector's identity**, wrapped in
+`useSyncExternalStore`. That is the shape a selector argument's identity
+actually matters in — a selector reallocated on every render throws the cache
+away, so each subscriber redoes a selection whose inputs never moved. Solid,
+Svelte, and Vue have no render pass to redo, so their subscribers express the
+same thing as a `createMemo` / `$derived` / `computed` over a snapshot signal.
+
+The store publishes an **immutable snapshot** whose identity changes only on a
+write, which is what lets a selection be reused across renders at all. The
+selection reduces a 2,000-element array, large enough that eliminating it is
+visible above real-browser noise; every framework's selector calls the same
+shared reduction, so the work per invocation is identical and only the
+invocation **count** can differ.
+
+Each subscriber also takes a parent-owned `generation` prop and renders it as
+`data-generation`, so a parent re-render genuinely reaches all 512 subscribers
+instead of being absorbed by a memo boundary.
+
+## Diagnostics
+
+`selectorCallsDuringRerenders` is the deterministic signal: the store does not
+move during the burst, so every one of those calls is work a stable selector
+would not have done. Read it next to `subscriberRendersDuringRerenders` and
+`snapshotCallsDuringRerenders` — on a render-pass framework those stay at
+512 × 20, so a zero selector count means the selection was **reused**, not that
+the renders were skipped. `subscribeCalls`/`unsubscribeCalls`, `notifications`,
+and `retainedSubscribers` gate teardown.
+
+Real Chromium also gates the semantics directly: every subscriber must show the
+correct total after each broad write, and must still show it — with the new
+generation — after the re-render burst. A second write after the burst proves
+subscriptions established before it still deliver.
+
+```bash
+node benchmarks/bench.mjs --quick store-selector-fanout
+node benchmarks/bench.mjs store-selector-fanout
+```

--- a/benchmarks/store-selector-fanout/run.mjs
+++ b/benchmarks/store-selector-fanout/run.mjs
@@ -1,0 +1,1 @@
+await import('../news/store-selector-fanout.mjs');

--- a/benchmarks/store-selector-fanout/shared.js
+++ b/benchmarks/store-selector-fanout/shared.js
@@ -1,0 +1,104 @@
+// Shared fixture state for the selector-based external-store fan-out suite.
+//
+// The workload this suite exists to observe is an UNRELATED PARENT RE-RENDER
+// while the store is untouched. Every subscriber reads the same store through a
+// selector, so a parent render that changes nothing the store owns must not
+// re-run the selection 512 times. `selectorCalls` is the deterministic signal:
+// it is attributable entirely to selector identity, with no timing noise in it.
+//
+// The store publishes an immutable snapshot whose identity changes only on a
+// write, which is what lets a selector layer cache a selection across renders.
+
+export const SELECTOR_SUBSCRIBER_COUNT = 512;
+export const SELECTOR_INPUT_SIZE = 2000;
+export const PARENT_RERENDER_COUNT = 20;
+
+export const SELECTOR_SUBSCRIBERS = Array.from(
+	{ length: SELECTOR_SUBSCRIBER_COUNT },
+	(_, index) => index,
+);
+
+function createSnapshot(version, value) {
+	return {
+		values: Array.from({ length: SELECTOR_INPUT_SIZE }, () => value),
+		version,
+	};
+}
+
+function createStore(stats) {
+	const listeners = new Set();
+	let snapshot = createSnapshot(0, 0);
+
+	return {
+		getSnapshot() {
+			stats.snapshotCalls++;
+			return snapshot;
+		},
+		subscribe(listener) {
+			stats.subscribeCalls++;
+			listeners.add(listener);
+			let active = true;
+			return () => {
+				if (!active) return;
+				active = false;
+				listeners.delete(listener);
+				stats.unsubscribeCalls++;
+			};
+		},
+		writeAll(value) {
+			snapshot = createSnapshot(snapshot.version + 1, value);
+			for (const listener of [...listeners]) {
+				stats.notifications++;
+				listener();
+			}
+		},
+		get size() {
+			return listeners.size;
+		},
+	};
+}
+
+export function installStoreSelectorStress() {
+	const stats = {
+		notifications: 0,
+		selectorCalls: 0,
+		snapshotCalls: 0,
+		subscribeCalls: 0,
+		subscriberRenders: 0,
+		unsubscribeCalls: 0,
+	};
+	const state = {
+		// Per-target synchronous flush, installed by each fixture entry so the
+		// harness can drive N discrete parent renders without a Playwright round
+		// trip or a timer floor per render.
+		flush: (run) => run(),
+		ready: false,
+		stats,
+		store: createStore(stats),
+	};
+	globalThis.__storeSelectorStress = state;
+	return state;
+}
+
+export function getStoreSelectorStress() {
+	const state = globalThis.__storeSelectorStress;
+	if (!state) throw new Error('The store selector benchmark has not been initialized');
+	return state;
+}
+
+/**
+ * The expensive half of the selection. Every framework's selector calls this
+ * with the same array, so the work per invocation is identical across targets
+ * and the invocation COUNT is the only thing a selector layer can change.
+ */
+export function selectTotal(values) {
+	const stats = getStoreSelectorStress().stats;
+	stats.selectorCalls++;
+	let total = 0;
+	for (let index = 0; index < values.length; index++) total += values[index];
+	return total;
+}
+
+export function markSubscriberRender() {
+	getStoreSelectorStress().stats.subscriberRenders++;
+}

--- a/packages/octane-mcp-server/src/index.js
+++ b/packages/octane-mcp-server/src/index.js
@@ -61,6 +61,7 @@ export const BENCHMARK_SUITES = [
 	'event-delegation',
 	'application-composition',
 	'scaling-curves',
+	'store-selector-fanout',
 	'effectful-list',
 	'list-clear',
 	'memo-wall',


### PR DESCRIPTION
## Summary
- New `store-selector-fanout` benchmark suite: 512 subscribers read one external store **through a selector**, then the parent re-renders 20 times with the store untouched.
- Ratio guard `parent_rerenders` octane-tsrx vs react at `maxRatio 0.95`.
- **Stacked on #337** — the guard is calibrated to the capture-free hook-callback lift and only holds with it.

## Why
No existing suite could see a regression in selector identity. `external-store-fanout` uses a raw `useSyncExternalStore` with an inline snapshot getter and has **no selector layer at all**; `external-store-integrations` goes through selector paths but measures Zustand / Jotai / TanStack Query backends rather than isolating selector cost.

The motivating shape is `useSelector(store, (s) => s.total)`: the selection is memoized on the selector's identity, so an inline arrow reallocated per render throws the cache away and an unrelated parent re-render re-runs the selection for every subscriber.

## Changes
- `benchmarks/store-selector-fanout/{shared.js,run.mjs,README.md}` — snapshot store whose identity changes only on a write, a shared 2,000-element reduction, and the stats counters.
- `benchmarks/news/store-selector-fanout.mjs` — Playwright/vite harness (BENCH_JSON contract, correctness-gated).
- `benchmarks/news/<target>/store-selector-fanout.html` + `src/store-selector-fanout/` for octane-tsrx, react, preact, solid, svelte, vue-vapor.
- `bench.mjs` manifest entry, `benchmarks/README.md` suite row, `baselines/ratios.json` guard, `@octanejs/mcp-server` suite list.
- `benchmarks/news/vue-vapor/src/vue-shim.js` gains a `computed` re-export — vapor's default entry does not expose it, and the shim already re-exports `ref`/`watch`/etc. the same way.

### Design notes
Its own page inside the news target apps (the `hydration-interactivity` pattern), **not** a new suite name on the runtime-stress harness: that harness's shared App always renders 512 controlled form fields, which would have swamped the selection cost and perturbed nine existing suites' baselines.

Each subscriber takes a parent-owned `generation` prop and renders it as `data-generation`, so a parent re-render genuinely reaches all 512 subscribers instead of being absorbed by a memo boundary. Renders are driven and timed **inside the page** through a per-target synchronous flush, so neither a Playwright round trip nor a timer floor sits between them.

Solid, Svelte and Vue have no render pass to redo, so their subscribers express the same thing as a `createMemo` / `$derived` / `computed` over a snapshot signal.

## Measurements
Full 8-iteration runs, `parent_rerenders`:

| target | score (ms) | selector calls during 20 re-renders | subscriber renders |
| --- | --- | --- | --- |
| octane-tsrx | 10.08 | **0** | 10,240 |
| react | 16.98 | 10,240 | 10,240 |
| preact | 24.30 | 10,240 | 10,240 |
| solid | 3.88 | 0 | 0 |
| svelte | 4.52 | 0 | 0 |
| vue-vapor | 5.56 | 0 | 0 |

**Does it discriminate?** Recompiling the fixture with the lift disabled, same machine, same run:

| | octane | react | ratio | guard |
| --- | --- | --- | --- | --- |
| lift on | 10.08 | 16.98 | **0.59x** | PASS |
| lift off | 18.12 | 15.16 | **1.20x** | `BREACH … 1.12x outside maxRatio 0.95` (quick mode) |

Selector invocations go 0 → 10,240 with the lift removed, while `subscriberRendersDuringRerenders` stays at 10,240 either way — the win is a reused selection, not skipped renders.

**Guard headroom.** CI runs `--quick`, and that is the stable case: 0.586 / 0.597 / 0.593 across three independent quick runs, 0.594 on the full run. `0.95` leaves roughly 60% headroom over the observed ratio while still failing on the 1.12–1.20x un-lifted ratio. Observed values are recorded in the guard's `note`.

Production compile confirmed directly: `hmr: false` emits `const _fn$0 = (snapshot) => selectTotal(snapshot.values);` at module scope; `hmr: true` keeps it inline at the call site.

## Validation
- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 1428 files, 14,575 tests passed
- [x] `node benchmarks/bench.mjs --quick store-selector-fanout` — 6/6 targets pass
- [x] `node benchmarks/bench.mjs store-selector-fanout` — full run, 6/6 pass
- [x] `node benchmarks/bench.mjs --quick --ratios store-selector-fanout` — guard checked, PASS (and BREACH with the lift disabled)
- [x] `node benchmarks/external-store-fanout/run.mjs vue-vapor 1` — regression check on the `vue-shim.js` edit

## Risk / follow-ups
- **Merge order**: the `0.95` guard assumes #337. Merging this to `main` ahead of #337 would break the weekly bench cron; that is why it is stacked. Re-target to `main` only after #337 lands.
- No changeset: benchmark-only, matching #296 and #299, which touched the same MCP suite list without one.
- Incidental observation, not addressed here: `unmount` is octane 33ms vs react 20ms on this fixture. Pre-existing and unrelated to the selector path — no guard added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0feb65e55aeb66a0f6388345b12957a388390fbb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->