### PR TITLE
fix(runtime): preserve Suspense boundaries when editor branches switch

### DIFF
--- a/.changeset/fix-suspense-detached-branch-marker.md
+++ b/.changeset/fix-suspense-detached-branch-marker.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Keep enclosing DOM boundaries attached when a ref-owning conditional branch switches to a lazy Suspense component.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -19746,6 +19746,7 @@ function renderBranchSlot(
 		const oldBoundaryShared = sharesBlockBoundary(parentBlock, oldBlockStart, oldBlockEnd);
 		if (state.block) {
 			unmountBlock(state.block);
+			if (parentBlock.disposed) return;
 			state.block = null;
 		}
 		state.branch = next;

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -19749,6 +19749,19 @@ function renderBranchSlot(
 			state.block = null;
 		}
 		state.branch = next;
+		if (state.start === null && body !== null && oldBoundaryShared) {
+			// A sole-root ancestor can borrow the outgoing branch's host as its
+			// own boundary. Publish a durable replacement before rendering the
+			// incoming arm: a nested Suspense may otherwise observe that removed
+			// host and pass a detached insertion anchor to its try block.
+			const s = document.createComment(marker);
+			const e = document.createComment('/' + marker);
+			domParent.insertBefore(s, after);
+			domParent.insertBefore(e, after);
+			state.start = s;
+			state.end = e;
+			replaceSharedBlockBoundary(parentBlock, oldBlockStart, oldBlockEnd, s, e);
+		}
 		if (state.start !== null) {
 			// MARKER path — hydration-adopted, or already markered (multi-node / post-
 			// swap). The branch borrows the slot's start/end (exclusiveMarkers teardown

--- a/packages/octane/tests/_fixtures/value-jsx-suspense.tsx
+++ b/packages/octane/tests/_fixtures/value-jsx-suspense.tsx
@@ -1,4 +1,4 @@
-import { Suspense, ErrorBoundary } from 'octane';
+import { Suspense, ErrorBoundary, useRef, type ComponentBody } from 'octane';
 import { Row } from './value-jsx-row.tsrx';
 
 // Keyed .map of <Suspense>-wrapped component descriptors — the Hacker News
@@ -30,5 +30,49 @@ export function BoundaryChildren() {
 		<ErrorBoundary fallback={<span class="err">boom</span>}>
 			<Row label="y" />
 		</ErrorBoundary>
+	);
+}
+
+type EditorHostRef = { current: HTMLDivElement | null };
+
+function RefOwningEditor(props: { hostRef: EditorHostRef }) {
+	const localRef = useRef<HTMLDivElement | null>(null);
+
+	return (
+		<div data-editor="rich" ref={[localRef, props.hostRef]}>
+			rich editor
+		</div>
+	);
+}
+
+export function SourceEditor() {
+	return <div data-editor="source">source editor</div>;
+}
+
+export function ConditionalSuspenseEditor(props: {
+	source: boolean;
+	hostRef: EditorHostRef;
+	sourceEditor: ComponentBody;
+}) {
+	const Source = props.sourceEditor;
+
+	return (
+		<div data-editor-boundary="suspense">
+			{props.source ? (
+				<Suspense fallback={null}>
+					<Source />
+				</Suspense>
+			) : (
+				<RefOwningEditor hostRef={props.hostRef} />
+			)}
+		</div>
+	);
+}
+
+export function ConditionalSynchronousEditor(props: { source: boolean; hostRef: EditorHostRef }) {
+	return (
+		<div data-editor-boundary="synchronous">
+			{props.source ? <SourceEditor /> : <RefOwningEditor hostRef={props.hostRef} />}
+		</div>
 	);
 }

--- a/packages/octane/tests/provider-children-dialect.test.ts
+++ b/packages/octane/tests/provider-children-dialect.test.ts
@@ -89,11 +89,11 @@ describe('context Provider — children dialect changes', () => {
 		try {
 			m.click('.toggle');
 
-			// The control: an `@if` swap deleting the identical component. It reaches the boundary
-			// too, so the Provider flip is not inventing its own routing. This arm asserts only
-			// that the boundary engages — `@if` currently surfaces a follow-on DOM error rather
-			// than the cleanup's own, a separate pre-existing gap that is not this PR's to close.
-			expect(m.container.querySelector('.caught')).not.toBe(null);
+			// The control: an `@if` swap deleting the identical component. The
+			// cleanup disposes the old branch through its enclosing boundary, so
+			// the swap must stop before mounting into that disposed catch range.
+			expect(m.container.querySelector('.caught')?.textContent).toBe('cleanup-boom');
+			expect(m.container.querySelector('.other')).toBe(null);
 			expect(error.mock.calls.filter((c) => String(c[0]).includes('cleanup-boom'))).toHaveLength(0);
 		} finally {
 			error.mockRestore();

--- a/packages/octane/tests/value-jsx-suspense.test.ts
+++ b/packages/octane/tests/value-jsx-suspense.test.ts
@@ -1,6 +1,14 @@
-import { it, expect } from 'vitest';
-import { mount } from './_helpers';
-import { MapSuspense, DirectSuspense, BoundaryChildren } from './_fixtures/value-jsx-suspense.tsx';
+import { describe, expect, it } from 'vitest';
+import { lazy } from '../src/index.js';
+import { act, mount } from './_helpers';
+import {
+	BoundaryChildren,
+	ConditionalSuspenseEditor,
+	ConditionalSynchronousEditor,
+	DirectSuspense,
+	MapSuspense,
+	SourceEditor,
+} from './_fixtures/value-jsx-suspense.tsx';
 
 // Regression: <Suspense>/<ErrorBoundary> render their children as the try BODY
 // (renderBlock calls it as a function). The .tsrx `{props.children}` lowering
@@ -21,4 +29,85 @@ it('a .tsx <ErrorBoundary> with element children renders them', () => {
 	const r = mount(BoundaryChildren as any);
 	expect(r.find('.inner').textContent).toBe('y');
 	r.unmount();
+});
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((complete) => {
+		resolve = complete;
+	});
+
+	return { promise, resolve };
+}
+
+describe('TSX editor branch ownership', () => {
+	it('switches a ref-owning editor into pending null-fallback Suspense', async () => {
+		const hostRef: { current: HTMLDivElement | null } = { current: null };
+		const sourceModule = deferred<{ default: any }>();
+		const sourceEditor = lazy(() => sourceModule.promise);
+		const result = mount(ConditionalSuspenseEditor as any, {
+			source: false,
+			hostRef,
+			sourceEditor,
+		});
+		const richEditor = result.find('[data-editor="rich"]');
+
+		expect(hostRef.current).toBe(richEditor);
+
+		result.update(ConditionalSuspenseEditor as any, {
+			source: true,
+			hostRef,
+			sourceEditor,
+		});
+
+		expect(hostRef.current).toBeNull();
+		expect(result.findAll('[data-editor]')).toHaveLength(0);
+
+		await act(() => {
+			sourceModule.resolve({ default: SourceEditor });
+		});
+
+		expect(result.find('[data-editor="source"]').textContent).toBe('source editor');
+		expect(hostRef.current).toBeNull();
+		result.unmount();
+	});
+
+	it('keeps editor refs and DOM valid across repeated lazy branch switches', async () => {
+		const hostRef: { current: HTMLDivElement | null } = { current: null };
+		const sourceModule = deferred<{ default: any }>();
+		const sourceEditor = lazy(() => sourceModule.promise);
+		const props = { hostRef, sourceEditor };
+		const result = mount(ConditionalSuspenseEditor as any, { ...props, source: false });
+
+		result.update(ConditionalSuspenseEditor as any, { ...props, source: true });
+		await act(() => {
+			sourceModule.resolve({ default: SourceEditor });
+		});
+		expect(result.find('[data-editor="source"]').textContent).toBe('source editor');
+
+		result.update(ConditionalSuspenseEditor as any, { ...props, source: false });
+		expect(hostRef.current).toBe(result.find('[data-editor="rich"]'));
+		expect(hostRef.current?.isConnected).toBe(true);
+
+		result.update(ConditionalSuspenseEditor as any, { ...props, source: true });
+		expect(result.find('[data-editor="source"]').textContent).toBe('source editor');
+		expect(hostRef.current).toBeNull();
+		result.unmount();
+	});
+
+	it('switches a synchronous single-ref editor in both directions', () => {
+		const hostRef: { current: HTMLDivElement | null } = { current: null };
+		const result = mount(ConditionalSynchronousEditor as any, { source: false, hostRef });
+
+		expect(hostRef.current).toBe(result.find('[data-editor="rich"]'));
+
+		result.update(ConditionalSynchronousEditor as any, { source: true, hostRef });
+		expect(result.find('[data-editor="source"]').textContent).toBe('source editor');
+		expect(hostRef.current).toBeNull();
+
+		result.update(ConditionalSynchronousEditor as any, { source: false, hostRef });
+		expect(hostRef.current).toBe(result.find('[data-editor="rich"]'));
+		expect(hostRef.current?.isConnected).toBe(true);
+		result.unmount();
+	});
 });

--- a/packages/tiptap/tests/browser/editor.browser.test.ts
+++ b/packages/tiptap/tests/browser/editor.browser.test.ts
@@ -126,6 +126,31 @@ async function readMenuGeometry(kind: 'bubble' | 'floating') {
 }
 
 describe('@octanejs/tiptap real-browser behavior', () => {
+	it('switches EditorContent and a lazy Suspense source editor without detached anchors', async () => {
+		const modeSwitch = page.locator('[data-editor-switch="true"]');
+		const toggle = modeSwitch.getByRole('button', { name: 'Toggle source editor' });
+		const richEditor = modeSwitch.locator('[data-branch-rich-editor="true"] .ProseMirror');
+		const sourceEditor = modeSwitch.locator('[data-branch-source-editor="true"]');
+
+		await richEditor.waitFor();
+		expect(await richEditor.textContent()).toBe('Switchable editor');
+
+		await toggle.click();
+		await sourceEditor.waitFor();
+		expect(await sourceEditor.textContent()).toBe('source editor');
+		expect(await richEditor.count()).toBe(0);
+
+		await toggle.click();
+		await richEditor.waitFor();
+		expect(await richEditor.textContent()).toBe('Switchable editor');
+		expect(await sourceEditor.count()).toBe(0);
+
+		await toggle.click();
+		await sourceEditor.waitFor();
+		expect(await richEditor.count()).toBe(0);
+		expect(pageErrors).toEqual([]);
+	});
+
 	it('keeps a live caret while typing updates editor content', async () => {
 		const paragraph = page.locator('.ProseMirror > p').first();
 		await paragraph.click();

--- a/packages/tiptap/tests/browser/editor.browser.test.ts
+++ b/packages/tiptap/tests/browser/editor.browser.test.ts
@@ -127,6 +127,8 @@ async function readMenuGeometry(kind: 'bubble' | 'floating') {
 
 describe('@octanejs/tiptap real-browser behavior', () => {
 	it('switches EditorContent and a lazy Suspense source editor without detached anchors', async () => {
+		await page.goto(`${origin}/?editor-switch=1`, { waitUntil: 'networkidle' });
+
 		const modeSwitch = page.locator('[data-editor-switch="true"]');
 		const toggle = modeSwitch.getByRole('button', { name: 'Toggle source editor' });
 		const richEditor = modeSwitch.locator('[data-branch-rich-editor="true"] .ProseMirror');

--- a/packages/tiptap/tests/browser/editor.browser.test.ts
+++ b/packages/tiptap/tests/browser/editor.browser.test.ts
@@ -127,7 +127,7 @@ async function readMenuGeometry(kind: 'bubble' | 'floating') {
 
 describe('@octanejs/tiptap real-browser behavior', () => {
 	it('switches EditorContent and a lazy Suspense source editor without detached anchors', async () => {
-		await page.goto(`${origin}/?editor-switch=1`, { waitUntil: 'networkidle' });
+		await page.goto(`${origin}/editor-switch.html`, { waitUntil: 'networkidle' });
 
 		const modeSwitch = page.locator('[data-editor-switch="true"]');
 		const toggle = modeSwitch.getByRole('button', { name: 'Toggle source editor' });

--- a/packages/tiptap/tests/browser/harness/editor-mode-switch.tsx
+++ b/packages/tiptap/tests/browser/harness/editor-mode-switch.tsx
@@ -1,0 +1,30 @@
+/** @jsxImportSource octane */
+import { EditorContent, type Editor } from '@octanejs/tiptap';
+import { Suspense, lazy, useState } from 'octane';
+
+const SourceEditor = lazy(() => import('./source-editor.tsx'));
+
+export function EditorModeSwitch(props: { editor: Editor }) {
+	const [source, setSource] = useState(false);
+
+	return (
+		<section data-editor-switch="true" data-editor-mode={source ? 'source' : 'rich'}>
+			<button
+				type="button"
+				aria-label="Toggle source editor"
+				onClick={() => setSource((previous) => !previous)}
+			>
+				{source ? 'Show rich editor' : 'Show source editor'}
+			</button>
+			<div data-editor-mode-content="true">
+				{source ? (
+					<Suspense fallback={null}>
+						<SourceEditor />
+					</Suspense>
+				) : (
+					<EditorContent editor={props.editor} data-branch-rich-editor="true" />
+				)}
+			</div>
+		</section>
+	);
+}

--- a/packages/tiptap/tests/browser/harness/editor-switch.html
+++ b/packages/tiptap/tests/browser/harness/editor-switch.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>@octanejs/tiptap Suspense editor regression</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/editor-switch.tsx"></script>
+	</body>
+</html>

--- a/packages/tiptap/tests/browser/harness/editor-switch.tsx
+++ b/packages/tiptap/tests/browser/harness/editor-switch.tsx
@@ -1,0 +1,24 @@
+/** @jsxImportSource octane */
+import StarterKit from '@tiptap/starter-kit';
+import { useEditor } from '@octanejs/tiptap';
+import { createRoot, delegateEvents } from 'octane';
+import { EditorModeSwitch } from './editor-mode-switch.tsx';
+
+delegateEvents(['click']);
+
+function EditorSwitchHarness() {
+	const editor = useEditor({
+		extensions: [StarterKit],
+		content: '<p>Switchable editor</p>',
+		immediatelyRender: true,
+	});
+
+	return editor ? <EditorModeSwitch editor={editor} /> : null;
+}
+
+const rootElement = document.getElementById('root');
+if (!rootElement) {
+	throw new Error('Missing #root');
+}
+
+createRoot(rootElement).render(EditorSwitchHarness);

--- a/packages/tiptap/tests/browser/harness/main.tsrx
+++ b/packages/tiptap/tests/browser/harness/main.tsrx
@@ -9,9 +9,8 @@ import {
 } from '@octanejs/tiptap';
 import { BubbleMenu, FloatingMenu } from '@octanejs/tiptap/menus';
 import { createRoot, delegateEvents, useState } from 'octane';
-import { EditorModeSwitch } from './editor-mode-switch.tsx';
 
-delegateEvents(['click', 'dragstart', 'dragover', 'drop']);
+delegateEvents(['dragstart', 'dragover', 'drop']);
 
 function DraggableCardView(props) @{
 	<NodeViewWrapper as="article" class="draggable-card" data-card-label={props.node.attrs.label}>
@@ -98,13 +97,6 @@ function BrowserHarness() @{
 		content: initialContent,
 		immediatelyRender: true,
 	});
-	const modeEditor = new URLSearchParams(window.location.search).has('editor-switch')
-		? useEditor({
-				extensions: [StarterKit],
-				content: '<p>Switchable editor</p>',
-				immediatelyRender: true,
-			})
-		: null;
 
 	<main>
 		@if (editor) {
@@ -131,9 +123,6 @@ function BrowserHarness() @{
 					</FloatingMenu>
 				</Tiptap>
 			</section>
-		}
-		@if (modeEditor) {
-			<EditorModeSwitch editor={modeEditor} />
 		}
 
 		<section

--- a/packages/tiptap/tests/browser/harness/main.tsrx
+++ b/packages/tiptap/tests/browser/harness/main.tsrx
@@ -98,11 +98,13 @@ function BrowserHarness() @{
 		content: initialContent,
 		immediatelyRender: true,
 	});
-	const modeEditor = useEditor({
-		extensions: [StarterKit],
-		content: '<p>Switchable editor</p>',
-		immediatelyRender: true,
-	});
+	const modeEditor = new URLSearchParams(window.location.search).has('editor-switch')
+		? useEditor({
+				extensions: [StarterKit],
+				content: '<p>Switchable editor</p>',
+				immediatelyRender: true,
+			})
+		: null;
 
 	<main>
 		@if (editor) {

--- a/packages/tiptap/tests/browser/harness/main.tsrx
+++ b/packages/tiptap/tests/browser/harness/main.tsrx
@@ -9,8 +9,9 @@ import {
 } from '@octanejs/tiptap';
 import { BubbleMenu, FloatingMenu } from '@octanejs/tiptap/menus';
 import { createRoot, delegateEvents, useState } from 'octane';
+import { EditorModeSwitch } from './editor-mode-switch.tsx';
 
-delegateEvents(['dragstart', 'dragover', 'drop']);
+delegateEvents(['click', 'dragstart', 'dragover', 'drop']);
 
 function DraggableCardView(props) @{
 	<NodeViewWrapper as="article" class="draggable-card" data-card-label={props.node.attrs.label}>
@@ -97,6 +98,11 @@ function BrowserHarness() @{
 		content: initialContent,
 		immediatelyRender: true,
 	});
+	const modeEditor = useEditor({
+		extensions: [StarterKit],
+		content: '<p>Switchable editor</p>',
+		immediatelyRender: true,
+	});
 
 	<main>
 		@if (editor) {
@@ -123,6 +129,9 @@ function BrowserHarness() @{
 					</FloatingMenu>
 				</Tiptap>
 			</section>
+		}
+		@if (modeEditor) {
+			<EditorModeSwitch editor={modeEditor} />
 		}
 
 		<section

--- a/packages/tiptap/tests/browser/harness/source-editor.tsx
+++ b/packages/tiptap/tests/browser/harness/source-editor.tsx
@@ -1,0 +1,5 @@
+/** @jsxImportSource octane */
+
+export default function SourceEditor() {
+	return <pre data-branch-source-editor="true">source editor</pre>;
+}


### PR DESCRIPTION
## Summary

- Reproduce issue #335 with a ref-owning TSX editor switching to pending lazy Suspense with a null fallback, resolution, repeated toggles, and the synchronous variant.
- Reproduce the original Tiptap EditorContent transition in real Chromium, asserting source and rich content, editor reattachment, and no browser page errors.
- Fix the owning Octane runtime by promoting a borrowed sole-root branch boundary before rendering its replacement; preserve the ordinary markerless hot path.
- Add an octane patch changeset.

## Validation

- [x] Regression tests committed separately so CI can establish the pre-fix behavior.
- [x] Changed TypeScript/TSX files pass the repository Prettier settings.
- [x] Patch-only changeset policy.
- [x] Test-marker policy.
- [x] Published TSXR declaration policy.
- [x] git diff --check.
- [ ] Development and production Octane regression tests (upstream CI).
- [ ] Real-Chromium Tiptap browser regression (upstream CI).
- [ ] Repository format, typecheck, and full test matrix (upstream CI).

Local full-suite execution is blocked because the configured package registry returns HTTP 403 for the locked @tsrx/core@0.1.54 dependency; upstream CI is the authoritative validation.

Closes #335

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core control-flow branch-swap and block-boundary logic in the runtime, which can affect conditional rendering and Suspense across the framework.
> 
> **Overview**
> Fixes **detached DOM anchors** when a conditional swaps from a ref-owning branch (e.g. rich editor) to **lazy `<Suspense>`** with a null fallback (#335).
> 
> The Octane runtime now **bails out** if unmounting the old branch disposes the parent block, and when a sole-root slot **borrowed** the outgoing branch’s host as its boundary, it **inserts durable comment markers** and updates shared block boundaries **before** mounting the incoming arm so nested Suspense never receives a removed insertion anchor.
> 
> Adds **unit** coverage for ref lifecycle across Suspense toggles and lazy resolution, a **Chromium** harness toggling `EditorContent` vs lazy source editor, and tightens the `@if` cleanup-throw control test to expect boundary-caught errors without follow-on DOM mounts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b06303b77ae55a76582de7918485bed23c83d75f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->