### PR TITLE
fix(compiler): bind indexes in explicit list key selectors

### DIFF
--- a/.changeset/fix-indexed-loop-key-selectors.md
+++ b/.changeset/fix-indexed-loop-key-selectors.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Correctly bind loop indexes in explicit TSRX and TSX list keys so indexed rendering and hydration do not throw.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -20238,14 +20238,16 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 	//   2. `for (const x of y; key x.id) { ... }` — TSRX for-of header.
 	//   3. `for (const x, i of y) { ... }` — second loop param treated as the key.
 	//   4. Fallback: `x.id ?? x` (object identity).
-	// Builds `(item) => keyExpr` — when the for-of head is destructured we use
-	// the same destructure pattern as the arg so the user's `key id` (where
-	// `id` is a destructured field) actually resolves.
+	// Builds `(item, index) => keyExpr` when the for-of declares an index.
+	// For a destructured head, the item param uses the same pattern so both its
+	// fields and the declared index remain in scope for the authored key.
 	function mkKeyFn(keyExpr) {
-		// The synthesized key arrow maps to the authored key expression; its item
-		// param maps to the for-of binding it mirrors.
+		// The synthesized arrow and its params map to the authored expression and
+		// bindings without mutating their parsed AST nodes.
 		const param = isDestructured ? leftDeclId : b.id(itemName, leftDeclId);
-		return inheritOriginLoc(b.arrow([param], keyExpr), keyExpr);
+		const params = [param];
+		if (node.index) params.push(b.id(node.index.name, node.index));
+		return inheritOriginLoc(b.arrow(params, keyExpr), keyExpr);
 	}
 
 	let keyFn = null;

--- a/packages/octane/tests/_fixtures/index-keyed-map.tsx
+++ b/packages/octane/tests/_fixtures/index-keyed-map.tsx
@@ -1,0 +1,49 @@
+/** @jsxImportSource octane */
+import { Fragment } from 'octane';
+
+type IndexedItem = {
+	id: number;
+	label: string;
+};
+
+type IndexedMapProps = {
+	items: IndexedItem[];
+};
+
+export function IndexKeyedHostMap(props: IndexedMapProps) {
+	return (
+		<ul>
+			{props.items.map((item, index) => (
+				<li key={index} data-id={item.id} data-index={index}>
+					{index + ':' + item.label}
+				</li>
+			))}
+		</ul>
+	);
+}
+
+export function IndexKeyedFragmentMap(props: IndexedMapProps) {
+	return (
+		<ul>
+			{props.items.map((item, index) => (
+				<Fragment key={index}>
+					<li data-id={item.id} data-index={index}>
+						{index + ':' + item.label}
+					</li>
+				</Fragment>
+			))}
+		</ul>
+	);
+}
+
+export function CompositeKeyedDestructuredMap(props: IndexedMapProps) {
+	return (
+		<ul>
+			{props.items.map(({ id, label }, index) => (
+				<li key={id + ':' + index} data-id={id} data-index={index}>
+					{index + ':' + label}
+				</li>
+			))}
+		</ul>
+	);
+}

--- a/packages/octane/tests/_fixtures/tsrx-features.tsrx
+++ b/packages/octane/tests/_fixtures/tsrx-features.tsrx
@@ -74,6 +74,38 @@ export function ForOfIndexAndKey(props) @{
 	</ul>
 }
 
+export function ForOfIndexAsKey(props) @{
+	<ul>
+		@for (const item of props.items; index i; key i) {
+			<li data-index={i}>{i + ':' + item as string}</li>
+		}
+	</ul>
+}
+
+export function ForOfIndexedHostKey(props) @{
+	<ul>
+		@for (const item of props.items; index i) {
+			<li key={i} data-index={i}>{i + ':' + item as string}</li>
+		}
+	</ul>
+}
+
+export function ForOfCompositeIndexKey(props) @{
+	<ul>
+		@for (const item of props.items; index i; key item.id + ':' + i) {
+			<li data-id={item.id} data-index={i}>{i + ':' + item.label as string}</li>
+		}
+	</ul>
+}
+
+export function ForOfDestructuredIndexKey(props) @{
+	<ul>
+		@for (const &{ id, label } of props.items; index i; key id + ':' + i) {
+			<li data-id={id} data-index={i}>{i + ':' + label as string}</li>
+		}
+	</ul>
+}
+
 // ---------------------------------------------------------------------------
 // Ternary with FRAGMENT branches — the only ternary-JSX form TSRX accepts.
 // Our compiler lowers it to ifBlock so each branch mounts real DOM.

--- a/packages/octane/tests/hydration/_fixtures/forlist.tsrx
+++ b/packages/octane/tests/hydration/_fixtures/forlist.tsrx
@@ -13,3 +13,13 @@ export function List(props) @{
 		}
 	</ul>
 }
+
+export function IndexedList(props) @{
+	<ul id="indexed-list">
+		@for (const item of props.items; index i; key i) {
+			<li class="indexed-row" data-index={i}>
+				<span class="name">{item.name as string}</span>
+			</li>
+		}
+	</ul>
+}

--- a/packages/octane/tests/hydration/_fixtures/map-list.tsx
+++ b/packages/octane/tests/hydration/_fixtures/map-list.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'octane';
+/** @jsxImportSource octane */
+import { Fragment, useState } from 'octane';
 
 // React-style `.tsx` `{items.map(x => <li key/>)}` keyed list. It lowers to the
 // SAME forBlock fast path as `@for` on the client AND the equivalent ssrBlock
@@ -25,6 +26,22 @@ export function MapList() {
 				<li className="row" data-id={x.id as number} key={x.id as number}>
 					{x.label as string}
 				</li>
+			))}
+		</ul>
+	);
+}
+
+export function IndexKeyedFragmentHydrationMap(props: {
+	items: Array<{ id: number; label: string }>;
+}) {
+	return (
+		<ul className="indexed-list">
+			{props.items.map((item, index) => (
+				<Fragment key={index}>
+					<li className="indexed-row" data-id={item.id} data-index={index}>
+						{item.label}
+					</li>
+				</Fragment>
 			))}
 		</ul>
 	);

--- a/packages/octane/tests/hydration/for-hydrate.test.ts
+++ b/packages/octane/tests/hydration/for-hydrate.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { compile } from 'octane/compiler';
 import { hydrateRoot, flushSync } from '../../src/index.js';
 import * as ServerRT from 'octane/server';
-import { List } from './_fixtures/forlist.tsrx';
+import { IndexedList, List } from './_fixtures/forlist.tsrx';
 
 // SSR Phase 6 (M2) — a keyed @for list hydrates: the server wraps the @for in
 // one block range and lets each proven direct-host item self-delimit. The client
@@ -32,6 +32,30 @@ beforeEach(() => {
 afterEach(() => container.remove());
 
 describe('hydrateRoot — @for list (SSR Phase 6 / M2)', () => {
+	it('adopts explicit index-keyed rows and preserves their positional identity', () => {
+		const items = [
+			{ id: 1, name: 'Alpha' },
+			{ id: 2, name: 'Beta' },
+			{ id: 3, name: 'Gamma' },
+		];
+		const { html } = ServerRT.renderToString(server.IndexedList, { items });
+		container.innerHTML = html;
+		const rows = [...container.querySelectorAll('li.indexed-row')];
+
+		const root = hydrateRoot(container, IndexedList, { items });
+		flushSync(() => {});
+		expect([...container.querySelectorAll('li.indexed-row')]).toEqual(rows);
+
+		flushSync(() => root.render(IndexedList, { items: [items[2], items[1], items[0]] }));
+		expect([...container.querySelectorAll('li.indexed-row')]).toEqual(rows);
+		expect(rows.map((row) => row.querySelector('.name')?.textContent)).toEqual([
+			'Gamma',
+			'Beta',
+			'Alpha',
+		]);
+		root.unmount();
+	});
+
 	it('adopts the server-rendered items (no rebuild) and per-item handlers work', async () => {
 		const items = [
 			{ id: 1, name: 'Alpha' },

--- a/packages/octane/tests/hydration/map-hydrate.test.ts
+++ b/packages/octane/tests/hydration/map-hydrate.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { compile } from 'octane/compiler';
 import { hydrateRoot, flushSync } from '../../src/index.js';
 import * as ServerRT from 'octane/server';
-import { MapList, reorder } from './_fixtures/map-list.tsx';
+import { IndexKeyedFragmentHydrationMap, MapList, reorder } from './_fixtures/map-list.tsx';
 
 // A React-style `.tsx` `{items.map(x => <li key/>)}` keyed list lowers to the
 // forBlock fast path on the client and the matching ssrBlock path on the server
@@ -40,6 +40,30 @@ describe('hydrateRoot — `.tsx` `.map()` keyed list (forBlock parity)', () => {
 		expect(code).toContain('ssrBlock');
 		// No per-row createElement descriptor reconciled by ssrChild.
 		expect(code).not.toMatch(/ssrChild\([^)]*createElement\(\s*['"]li['"]/);
+	});
+
+	it('adopts index-keyed fragment rows and preserves their positional identity', () => {
+		const items = [
+			{ id: 1, label: 'a' },
+			{ id: 2, label: 'b' },
+			{ id: 3, label: 'c' },
+		];
+		const { html } = ServerRT.renderToString(server.IndexKeyedFragmentHydrationMap, { items });
+		container.innerHTML = html;
+		const rows = [...container.querySelectorAll('li.indexed-row')];
+
+		const root = hydrateRoot(container, IndexKeyedFragmentHydrationMap, { items });
+		flushSync(() => {});
+		expect([...container.querySelectorAll('li.indexed-row')]).toEqual(rows);
+
+		flushSync(() =>
+			root.render(IndexKeyedFragmentHydrationMap, {
+				items: [items[2], items[1], items[0]],
+			}),
+		);
+		expect([...container.querySelectorAll('li.indexed-row')]).toEqual(rows);
+		expect(rows.map((row) => row.textContent)).toEqual(['c', 'b', 'a']);
+		root.unmount();
 	});
 
 	it('adopts the server-rendered list items (same nodes) and a keyed reorder reuses them', async () => {

--- a/packages/octane/tests/tsrx-features.test.ts
+++ b/packages/octane/tests/tsrx-features.test.ts
@@ -20,6 +20,10 @@ import {
 	NamespacedAttr,
 	ForOfIndexOnly,
 	ForOfIndexAndKey,
+	ForOfIndexAsKey,
+	ForOfIndexedHostKey,
+	ForOfCompositeIndexKey,
+	ForOfDestructuredIndexKey,
 	TernaryFragmentChild,
 	HtmlOnlyChild,
 	KeyedFragmentItems,
@@ -29,6 +33,11 @@ import {
 	LazyForOfHead,
 	ShorthandComponentProp,
 } from './_fixtures/tsrx-features.tsrx';
+import {
+	CompositeKeyedDestructuredMap,
+	IndexKeyedFragmentMap,
+	IndexKeyedHostMap,
+} from './_fixtures/index-keyed-map.tsx';
 
 // ---------------------------------------------------------------------------
 // P1: spread attributes — `{...obj}` on DOM elements and components
@@ -243,6 +252,113 @@ describe('TSRX features — for-of with `index` AND `key`', () => {
 
 		r.update(ForOfIndexAndKey, { items: [c, b, a] }); // same refs, reversed
 		expect(r.findAll('li').map((li) => li.textContent)).toEqual(['0:c', '1:b', '2:a']);
+		r.unmount();
+	});
+});
+
+describe('indexed keys across TSRX and TSX', () => {
+	it('uses the declared TSRX index as an explicit header key', () => {
+		const r = mount(ForOfIndexAsKey, { items: ['a', 'b', 'c'] });
+		const before = r.findAll('li');
+
+		expect(before.map((row) => row.textContent)).toEqual(['0:a', '1:b', '2:c']);
+		expect(before.map((row) => row.getAttribute('data-index'))).toEqual(['0', '1', '2']);
+
+		r.update(ForOfIndexAsKey, { items: ['c', 'b', 'a'] });
+		expect(r.findAll('li')).toEqual(before);
+		expect(r.findAll('li').map((row) => row.textContent)).toEqual(['0:c', '1:b', '2:a']);
+
+		r.update(ForOfIndexAsKey, { items: ['c'] });
+		expect(r.findAll('li')).toEqual([before[0]]);
+		expect(before[1].isConnected).toBe(false);
+		expect(before[2].isConnected).toBe(false);
+		r.unmount();
+	});
+
+	it('binds the declared index in an explicit TSRX host key', () => {
+		const r = mount(ForOfIndexedHostKey, { items: ['a', 'b'] });
+		const before = r.findAll('li');
+
+		expect(before.map((row) => row.textContent)).toEqual(['0:a', '1:b']);
+
+		r.update(ForOfIndexedHostKey, { items: ['b', 'a'] });
+		expect(r.findAll('li')).toEqual(before);
+		expect(r.findAll('li').map((row) => row.textContent)).toEqual(['0:b', '1:a']);
+		r.unmount();
+	});
+
+	it('evaluates composite TSRX keys using both the item and its declared index', () => {
+		const a = { id: 1, label: 'a' };
+		const b = { id: 2, label: 'b' };
+		const c = { id: 3, label: 'c' };
+		const r = mount(ForOfCompositeIndexKey, { items: [a, b, c] });
+		const before = r.findAll('li');
+
+		r.update(ForOfCompositeIndexKey, { items: [c, b, a] });
+		const after = r.findAll('li');
+
+		expect(after.map((row) => row.textContent)).toEqual(['0:c', '1:b', '2:a']);
+		expect(after[1]).toBe(before[1]);
+		expect(after[0]).not.toBe(before[2]);
+		expect(after[2]).not.toBe(before[0]);
+		r.unmount();
+	});
+
+	it('binds destructured TSRX items and the index in the same key selector', () => {
+		const r = mount(ForOfDestructuredIndexKey, {
+			items: [
+				{ id: 1, label: 'a' },
+				{ id: 2, label: 'b' },
+			],
+		});
+
+		expect(r.findAll('li').map((row) => row.textContent)).toEqual(['0:a', '1:b']);
+		expect(r.findAll('li').map((row) => row.getAttribute('data-id'))).toEqual(['1', '2']);
+		r.unmount();
+	});
+
+	it('uses the TSX map index as an explicit host key', () => {
+		const a = { id: 1, label: 'a' };
+		const b = { id: 2, label: 'b' };
+		const r = mount(IndexKeyedHostMap as any, { items: [a, b] });
+		const before = r.findAll('li');
+
+		expect(before.map((row) => row.textContent)).toEqual(['0:a', '1:b']);
+
+		r.update(IndexKeyedHostMap as any, { items: [b, a] });
+		expect(r.findAll('li')).toEqual(before);
+		expect(r.findAll('li').map((row) => row.textContent)).toEqual(['0:b', '1:a']);
+		r.unmount();
+	});
+
+	it('uses the TSX map index as an explicit Fragment key', () => {
+		const a = { id: 1, label: 'a' };
+		const b = { id: 2, label: 'b' };
+		const r = mount(IndexKeyedFragmentMap as any, { items: [a, b] });
+		const before = r.findAll('li');
+
+		expect(before.map((row) => row.textContent)).toEqual(['0:a', '1:b']);
+
+		r.update(IndexKeyedFragmentMap as any, { items: [b, a] });
+		expect(r.findAll('li')).toEqual(before);
+		expect(r.findAll('li').map((row) => row.textContent)).toEqual(['0:b', '1:a']);
+		r.unmount();
+	});
+
+	it('binds destructured TSX map items and indexes in composite keys', () => {
+		const a = { id: 1, label: 'a' };
+		const b = { id: 2, label: 'b' };
+		const c = { id: 3, label: 'c' };
+		const r = mount(CompositeKeyedDestructuredMap as any, { items: [a, b, c] });
+		const before = r.findAll('li');
+
+		r.update(CompositeKeyedDestructuredMap as any, { items: [c, b, a] });
+		const after = r.findAll('li');
+
+		expect(after.map((row) => row.textContent)).toEqual(['0:c', '1:b', '2:a']);
+		expect(after[1]).toBe(before[1]);
+		expect(after[0]).not.toBe(before[2]);
+		expect(after[2]).not.toBe(before[0]);
 		r.unmount();
 	});
 });


### PR DESCRIPTION
## Summary
- Fix the shared TSRX and TSX compiler path for explicit keys that reference a declared loop index.
- Cover header keys, host keys, Fragment keys, composite keys, destructured items, development and production rendering, server rendering, and hydration.
- Preserve the existing keyed reconciler, server fast path, and single-argument selectors for loops without an index.

## Regression proof
The first signed commit deliberately contains only reproductions. GitHub Actions can first demonstrate the existing ReferenceError before the compiler fix is pushed. Local dependency installation is blocked by a 403 for the protected @tsrx/core package, so the upstream CI is the source of truth for the full test, formatting, and typecheck matrix.

Closes #333

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared list-key codegen for client rendering and hydration; behavior change is narrow (index in scope for keys) but affects core reconciliation paths.
> 
> **Overview**
> Fixes a compiler bug where **explicit list keys that reference a declared loop index** (`key i`, `key={index}`, composite keys, etc.) could throw at runtime because the synthesized key function only accepted the item, not the index.
> 
> The client `@for` / `.map()` lowering now builds **`(item, index) => keyExpr`** in `mkKeyFn` when the loop declares an index (`node.index`), aligned with the existing SSR key-fn path. Destructured loop heads still mirror the item binding so fields and index stay in scope in the key expression. Loops without an index keep the single-argument key selector.
> 
> Coverage adds TSRX and TSX fixtures (header keys, host `key`, `Fragment` keys, composite/destructured keys) plus hydration tests that index-keyed lists adopt server DOM and preserve positional identity on reorder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf36c5a9e6bd87a58a19eeb2b917a841695943be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->