### PR TITLE
docs: clarify custom hook dependency inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ Octane is the day-to-day feel:
   effect events. It is the no-bookkeeping dependency DX associated with signal
   frameworks, while keeping the hooks model you already know. Explicit arrays
   remain authoritative; pass `null` when you intentionally want every render.
-  Locally declared custom hooks in a full-compiled `.tsrx`/`.tsx` module get
-  the same inference when they transparently forward a callback and final
-  dependency parameter to one of these hooks.
+  Built-in hook calls retain this inference inside custom hooks, including
+  compiler-processed plain `.ts`/`.js` modules. A separate, narrower rule also
+  infers omitted dependency arguments at calls to locally declared custom
+  wrappers in fully compiled `.tsrx`/`.tsx` modules when they transparently
+  forward a callback and final dependency parameter to one of these hooks.
 - **No rules of hooks.** Hooks are tracked by call site, not call order, so a
   hook can live inside an `if` or after an early return — the usual React
   footguns simply aren't there. The one rule that remains is enforced for you:
@@ -408,6 +410,27 @@ setters, reducer dispatchers, refs, and state getters. It also omits
 `useEffectEvent` results because Effect Events are non-reactive captures, even
 though React-compatible wrappers have a fresh identity on each render.
 
+This applies to built-in hook calls inside compiler-processed custom hooks,
+including custom hooks written in plain `.ts` or `.js` modules:
+
+```ts
+import { useEffect, useMemo } from 'octane';
+
+export function useLoggedValue(value: string, log: (value: string) => void) {
+  const formatted = useMemo(() => value.toUpperCase());
+
+  useEffect(() => {
+    log(formatted);
+  });
+
+  return formatted;
+}
+```
+
+The memo's inferred dependency is `value`; the effect's inferred dependencies
+are `formatted` and `log`. Changes propagate through the custom hook without
+requiring its caller to pass a dependency array.
+
 Explicit arrays keep their React meaning and are never rewritten. Pass `null`
 for the uncommon every-render form:
 
@@ -418,9 +441,10 @@ useEffect(() => sync(room.id), [room.id]); // explicit dependencies
 useEffect(() => measure(), null); // explicitly after every commit
 ```
 
-The same inference applies to a locally declared custom hook in a full-compiled
-`.tsrx`/`.tsx` module when its implementation transparently forwards a callback
-and final dependency parameter:
+Inferring a missing dependency argument at a **call to a custom wrapper** is a
+separate case. In a fully compiled `.tsrx`/`.tsx` module, a locally declared
+wrapper qualifies when it transparently forwards a callback and its final
+dependency parameter:
 
 ```jsx
 function useTrackedEffect(callback, dependencies) {
@@ -430,9 +454,11 @@ function useTrackedEffect(callback, dependencies) {
 useTrackedEffect(() => sync(room.id)); // inferred from the closure
 ```
 
-This proof is deliberately local and conservative. Plain `.ts`/`.js` modules,
-imported custom hooks, and wrappers that transform or otherwise inspect those
-parameters still require an explicit dependency argument.
+This proof is deliberately local and conservative. The surgical pass for plain
+`.ts`/`.js` modules still infers direct built-in hook calls, but it does not
+infer dependency arguments at calls to custom wrappers. Imported or method-style
+wrappers and wrappers that transform or inspect their callback or dependency
+parameter also require an explicit dependency argument.
 
 `useState` and `useReducer` also expose an optional third tuple member: a stable getter for
 the hook's latest state. It is useful in async callbacks and other long-lived

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -33,6 +33,30 @@ refs, and state getters. It also omits `useEffectEvent` results because Effect
 Events are non-reactive captures, despite their intentionally fresh wrapper
 identity.
 
+This inference applies to a supported built-in hook wherever Octane processes
+its call, including inside a custom hook authored in `.tsrx`, `.tsx`, or a plain
+`.ts`/`.js` module. For example, a custom hook in plain TypeScript can omit both
+dependency arrays:
+
+```ts
+import { useEffect, useMemo } from 'octane';
+
+export function useLoggedValue(value: string, log: (value: string) => void) {
+  const formatted = useMemo(() => value.toUpperCase());
+
+  useEffect(() => {
+    log(formatted);
+  });
+
+  return formatted;
+}
+```
+
+The memo captures `value`, and the effect captures `formatted` and `log`.
+Changing `value` recomputes the memo; if the resulting `formatted` value changes,
+the effect reruns with the updated result. Changing `log` also reruns the
+effect. The custom hook's caller does not need to supply a dependency array.
+
 A dependency array tracks what can change *between renders*, so a binding that
 is evaluated once for the program's lifetime is not a dependency. Alongside
 imports, the compiler omits module-scope `const` declarations and module-scope
@@ -46,18 +70,24 @@ hold such state in a store or in state, not a module singleton. Module-scope
 `const` that only names one of these values, or that binds a literal, is
 likewise omitted — naming a fixed value does not make it reactive.
 
-The full `.tsrx`/`.tsx` compiler also recognizes locally declared custom hooks
-that transparently forward a callback parameter and their final dependency
-parameter to one of those hooks. Nested transparent wrappers are followed
-within the module. This does not guess from a `use*` name alone: plain
-`.ts`/`.js` modules, imported custom hooks, method hooks, and wrappers that
-transform or inspect those parameters require an explicit dependency argument.
+Inferring an omitted dependency argument at a **call to a custom wrapper** is a
+separate, narrower operation. The full `.tsrx`/`.tsx` compiler can infer that
+argument only when a locally declared custom hook transparently forwards its
+callback and final dependency parameter to a supported built-in hook. Nested
+transparent wrappers can also be followed within the same module.
 
-An explicit array is authoritative and retains React's exact behavior. Pass
-`null` to opt out of tracking and run an effect—or recompute a memo—after every
-render. Opaque callback creation such as `useEffect(makeEffect())` requires an
-explicit array or `null`, because evaluating it again to construct a dependency
-would change program behavior.
+The surgical pass for plain `.ts`/`.js` modules still infers direct built-in
+hook calls, including those inside custom hooks, but it does not infer or append
+dependency arguments at calls to custom wrappers. Imported wrappers,
+method-style wrappers, and wrappers that transform or inspect their callback or
+dependency parameter also require an explicit dependency argument. The compiler
+does not guess a wrapper's contract from its `use*` name.
+
+An explicit array, including `[]`, is authoritative and retains React's exact
+behavior. Pass `null` to opt out of tracking and run an effect—or recompute a
+memo—after every render. Opaque callback creation such as
+`useEffect(makeEffect())` requires an explicit array or `null`, because
+evaluating it again to construct a dependency would change program behavior.
 
 ## Automatic memoization and calls in templates
 

--- a/packages/octane/README.md
+++ b/packages/octane/README.md
@@ -9,11 +9,13 @@ Octane is a fast, JavaScript UI framework, and the successor to
 already know, a compiler that keeps the runtime small and fast, no rules of
 hooks, and no hand-maintained dependency arrays in the common case. Omit a hook's
 dependency list and the compiler derives it from the closure; explicit arrays
-retain React semantics, while `null` means every render. Locally declared custom
-hooks in full-compiled `.tsrx`/`.tsx` modules also qualify when they transparently
-forward their callback and final dependency parameter to a supported hook. This
-package ships both the runtime and compiler, with the compiler exposed at
-`octane/compiler`.
+retain React semantics, while `null` means every render. Built-in hook calls
+retain this inference inside compiler-processed custom hooks, including those in
+plain `.ts`/`.js` modules. Inferring a dependency argument at a call to a custom
+wrapper is narrower: the wrapper must be locally declared in a fully compiled
+`.tsrx`/`.tsx` module and transparently forward its callback and final dependency
+parameter to a supported hook. This package ships both the runtime and compiler,
+with the compiler exposed at `octane/compiler`.
 
 For the full story, see the
 [main README](https://github.com/octanejs/octane#readme).


### PR DESCRIPTION
## Summary

- Clarify that supported built-in hooks infer omitted dependency arrays inside custom hooks, including compiler-processed plain `.ts` and `.js` modules.
- Distinguish that behavior from inference at calls to custom dependency-forwarding wrappers, which is deliberately limited to locally declared transparent wrappers in fully compiled `.tsrx` and `.tsx` modules.
- Keep the React-differences guide, repository README, and published `octane` package README consistent.

## Why

Fixes #326.

The existing documentation could be read as forbidding `useEffect` or `useMemo` without a dependency array inside a plain-TypeScript custom hook. The current compiler and its existing behavioral regression already support that exact pattern. The restriction instead applies when the compiler would need to infer and append an argument at a call to a custom wrapper.

## Changes

- Add a plain-TypeScript example demonstrating how a memo captures its input and how an effect captures the derived value and logging callback.
- Explain how changes propagate through the custom hook without requiring the caller to supply a dependency array.
- Document the boundaries for plain-module wrapper calls, imported wrappers, method-style wrappers, and wrappers that transform or inspect forwarded arguments.
- Reaffirm that an omitted built-in dependency array requests inference, an explicit array including `[]` is authoritative, and `null` requests every-render effect execution or memo recomputation.
- Preserve the existing consumer-observable plain-TypeScript effect and memo regression; no compiler, runtime, fixture, generated file, or changeset is changed.

## Validation

- [x] `node node_modules/.pnpm/prettier@3.9.6/node_modules/prettier/bin/prettier.cjs --check '**/*.md'`
- [x] `node scripts/workspace-packages.mjs --check`
- [x] `node scripts/check-changesets.js`
- [x] `node scripts/check-test-markers.mjs`
- [x] `node scripts/check-tsrx-module-decls.mjs`
- [x] `node scripts/check-context-budget.mjs`
- [x] `node scripts/generate-parity-gaps.mjs --check`
- [x] `node scripts/react-parity/check.mjs`
- [x] `node scripts/redact-audit/generate.mjs --check`
- [x] `node scripts/generate-binding-parity-gaps.mjs --check`
- [x] `node scripts/generate-bindings-status.mjs --check`
- [x] `node --test scripts/react-parity/*.test.mjs scripts/scaffold-react-port.test.mjs` (29 tests)
- [x] `node --test scripts/redact-audit/*.test.mjs` (15 tests)
- [x] `git show --check --oneline HEAD`
- [x] `git verify-commit HEAD`
- [x] `pnpm format:check` in the [successful upstream CI run](https://github.com/octanejs/octane/actions/runs/30366173462).
- [x] `pnpm typecheck` in the upstream CI run.
- [x] `pnpm test` across all eight Node 22 and Node 24 test shards, including the existing `auto-hook-deps` compiler, capture-stability, and plain-TypeScript behavioral regressions.
- [x] Upstream website, browser, package-build, example, Three, and Lynx integration jobs.

Local frozen installation is blocked by the protected registry returning HTTP 403 for the exact locked `@tsrx/core@0.1.54`; the complete checks above passed on the upstream runner without changing credentials, dependency versions, the parser, or the lockfile.

## Risk / follow-ups

Low: documentation only. The existing compiler implementation, runtime behavior, generated artifacts, and React-divergence contract are preserved.
