### PR TITLE
fix: correct TSRX switch authoring grammar

### DIFF
--- a/.agents/memories/tsrx-authoring.md
+++ b/.agents/memories/tsrx-authoring.md
@@ -53,7 +53,7 @@ setup.
 ```tsx
 @if (c) { } @else { }
 @for (const x of xs; key x.id) { } @empty { }
-@switch (v) { @case (a) { } @default { } }
+@switch (v) { @case a: { } @default: { } }
 @try { } @pending { } @catch (e) { }
 ```
 

--- a/.changeset/tsrx-switch-authoring-grammar.md
+++ b/.changeset/tsrx-switch-authoring-grammar.md
@@ -1,0 +1,5 @@
+---
+'@octanejs/mcp-server': patch
+---
+
+Correct the React component migration guidance to use the supported TSRX switch case and default clause grammar.

--- a/.claude/rules/tsrx-authoring.md
+++ b/.claude/rules/tsrx-authoring.md
@@ -57,7 +57,7 @@ setup.
 ```tsx
 @if (c) { } @else { }
 @for (const x of xs; key x.id) { } @empty { }
-@switch (v) { @case (a) { } @default { } }
+@switch (v) { @case a: { } @default: { } }
 @try { } @pending { } @catch (e) { }
 ```
 

--- a/.cursor/rules/tsrx-authoring.mdc
+++ b/.cursor/rules/tsrx-authoring.mdc
@@ -58,7 +58,7 @@ setup.
 ```tsx
 @if (c) { } @else { }
 @for (const x of xs; key x.id) { } @empty { }
-@switch (v) { @case (a) { } @default { } }
+@switch (v) { @case a: { } @default: { } }
 @try { } @pending { } @catch (e) { }
 ```
 

--- a/.gemini/memories/tsrx-authoring.md
+++ b/.gemini/memories/tsrx-authoring.md
@@ -53,7 +53,7 @@ setup.
 ```tsx
 @if (c) { } @else { }
 @for (const x of xs; key x.id) { } @empty { }
-@switch (v) { @case (a) { } @default { } }
+@switch (v) { @case a: { } @default: { } }
 @try { } @pending { } @catch (e) { }
 ```
 

--- a/.github/instructions/tsrx-authoring.instructions.md
+++ b/.github/instructions/tsrx-authoring.instructions.md
@@ -59,7 +59,7 @@ setup.
 ```tsx
 @if (c) { } @else { }
 @for (const x of xs; key x.id) { } @empty { }
-@switch (v) { @case (a) { } @default { } }
+@switch (v) { @case a: { } @default: { } }
 @try { } @pending { } @catch (e) { }
 ```
 

--- a/.rulesync/rules/tsrx-authoring.md
+++ b/.rulesync/rules/tsrx-authoring.md
@@ -60,7 +60,7 @@ setup.
 ```tsx
 @if (c) { } @else { }
 @for (const x of xs; key x.id) { } @empty { }
-@switch (v) { @case (a) { } @default { } }
+@switch (v) { @case a: { } @default: { } }
 @try { } @pending { } @catch (e) { }
 ```
 

--- a/packages/octane-mcp-server/skills/migrate-react-component.md
+++ b/packages/octane-mcp-server/skills/migrate-react-component.md
@@ -38,7 +38,7 @@ locals, early returns) stays above it.
 | `items.map(x => <li key={x.id}>...` | `@for (const x of items; key x.id) { <li>... }` with optional `@empty { }` |
 | `cond ? <A/> : <B/>` in JSX | `@if (cond) { <A/> } @else { <B/> }` |
 | `{cond && <A/>}` | `@if (cond) { <A/> }` |
-| switch on a value | `@switch (v) { @case (a) { } @default { } }` |
+| switch on a value | `@switch (v) { @case a: { } @default: { } }` |
 | `<Suspense fallback={...}>` | `<Suspense>` or `@try { } @pending { }` |
 | Error boundary class | `<ErrorBoundary>` or `@try { } @catch (e) { }` |
 | `forwardRef((props, ref) => ...)` | plain function; `ref` arrives as a prop |

--- a/packages/octane/tests/switch.test.ts
+++ b/packages/octane/tests/switch.test.ts
@@ -1,8 +1,39 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { compile } from 'octane/compiler';
 import { mount } from './_helpers';
 import { PickKind, Cycle, NoDefault, HookInCase } from './_fixtures/switch.tsrx';
 
 describe('switchBlock', () => {
+	it('compiles the case and default grammar documented by authoring guidance', () => {
+		const guidancePaths = [
+			'.rulesync/rules/tsrx-authoring.md',
+			'packages/octane-mcp-server/skills/migrate-react-component.md',
+		];
+
+		for (const guidancePath of guidancePaths) {
+			const guidance = readFileSync(resolve(guidancePath), 'utf8');
+			const example = guidance.match(/@switch\s*\(v\)\s*\{[^\r\n]*\}/)?.[0];
+
+			expect(example, `${guidancePath} documents a switch example`).toBeDefined();
+			expect(example, `${guidancePath} documents a valid case clause`).toMatch(
+				/@case\s+a\s*:\s*\{/,
+			);
+			expect(example, `${guidancePath} documents a valid default clause`).toMatch(
+				/@default\s*:\s*\{/,
+			);
+
+			const source = `export function DocumentedSwitch(props) @{
+	const v = props.value;
+	const a = props.case;
+	<div>${example}</div>
+}`;
+
+			expect(() => compile(source, 'documented-switch.tsrx')).not.toThrow();
+		}
+	});
+
 	it('picks the first matching @case', () => {
 		const r = mount(PickKind, { kind: 'a' });
 		expect(r.findAll('.pick')).toHaveLength(1);


### PR DESCRIPTION
## Summary
- Correct the authoritative RuleSync TSRX example to the parser-supported `@case a:` and `@default:` grammar.
- Regenerate all five agent-facing authoring surfaces from the authoritative rule.
- Correct the independently published MCP React-component migration skill and include its patch changeset.
- Add a switch regression that extracts both real guidance examples, verifies case and default clauses, and compiles each example through Octane's actual compiler.

Closes #336.

## Validation
- [x] Reproduced the stale-guidance failure against the existing executable switch fixture before the fix.
- [x] Regenerated with the exact lockfile-pinned `rulesync@8.32.0`; `rulesync generate --check` passes.
- [x] Checked all nine changed files with exact lockfile-pinned `prettier@3.9.6` and the repository's equivalent formatting settings.
- [x] `pnpm --config.verify-deps-before-run=false changeset:check`.
- [x] `git diff --check` and a clean final worktree.
- [x] Confirmed GitHub marks the final commit signature **Verified**.
- [ ] Full switch/hydration regressions, repository-wide formatting, and typechecking: run by upstream GitHub Actions. Local `pnpm install --prod false --frozen-lockfile` is blocked by the configured protected registry returning `403` for the required `@tsrx/core@0.1.54`; no registry credentials, dependency versions, or parser were changed.

## Risk
Documentation, packaged agent guidance, generated instructions, and regression coverage only. The existing compiler, runtime, parser grammar, and hydration behavior are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, generated agent instructions, packaged migration skill, and test coverage only; compiler, runtime, and hydration behavior are unchanged.
> 
> **Overview**
> **Fixes incorrect `@switch` examples** in TSRX authoring and migration docs: `@case (a)` / `@default { }` is replaced with the compiler-supported **`@case a:`** and **`@default: { }`** form everywhere those examples appear (RuleSync source plus regenerated agent surfaces and the MCP migrate-react-component skill).
> 
> Adds a **patch changeset** for `@octanejs/mcp-server` and a **switch test** that pulls the documented `@switch` snippet from key guidance files, asserts the case/default syntax, and compiles it through Octane’s compiler so docs and parser stay aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 365c568c21f0b63bb42f53742ae120194ac2add6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->