### PR TITLE
feat(compiler): dep-key callbacks for hooks that declare them as data

### DIFF
--- a/.changeset/data-callback-hooks.md
+++ b/.changeset/data-callback-hooks.md
@@ -1,0 +1,43 @@
+---
+'octane': patch
+---
+
+New compile option `dataCallbackHooks`. A hook can now declare that a callback
+argument is data it memoizes on, rather than a dependency subject it re-runs.
+Production compiles then key that callback on the values it actually reads, so
+its identity moves only when they do.
+
+```js
+compile(source, filename, {
+  dataCallbackHooks: ['@octanejs/tanstack-store#useSelector'],
+})
+```
+
+Entries are `module#hookName`, matched against the call site's import, or a bare
+`hookName` for a hook declared in the module being compiled.
+
+This closes the other half of the capture-free callback lift. A callback that
+captures nothing is lifted to module scope and keeps one identity forever; a
+callback that reads component state cannot move, but is now wrapped in
+`useCallback` with an inferred dependency list. On a 512-subscriber fan-out over
+20 unrelated parent re-renders, selector invocations for a capturing selector
+drop from 10,240 to zero, and the re-render cost fell from 21.4–23.1ms to
+7.8–9.9ms.
+
+The dependency list is left for inference to fill, which is why the transform
+runs before it. That ordering is load-bearing rather than incidental: coarse
+identifier dependencies (`[props]`) are worthless here, because the props object
+is a fresh identity on every parent render, so the memo never hits. Inference
+produces the member paths actually read (`[props.offset]`).
+
+Nothing is inferred about which hooks qualify, and the transform is inert until
+something opts in. The compiler already refuses to attach dependency semantics
+to custom hooks it cannot statically prove, and a wrong answer here produces a
+stale closure — silent, and attributed to the application rather than to the
+compiler — so the fact is declared rather than guessed.
+
+Declared hooks are still left alone where the hook owns freshness itself: when
+its own dependency list is inferred, and when the call passes an explicit
+dependency array or `null` (the author's "re-run every render" escape hatch).
+Dev, HMR, and profile compiles keep the authored form, matching the neighbouring
+inline hook-memo tier.

--- a/.changeset/data-callback-hooks.md
+++ b/.changeset/data-callback-hooks.md
@@ -13,8 +13,10 @@ compile(source, filename, {
 })
 ```
 
-Entries are `module#hookName`, matched against the call site's import, or a bare
-`hookName` for a hook declared in the module being compiled.
+Entries are `module#hookName`, matched against the call site's import — including
+a namespace import, matched against the namespace's own module — or a bare
+`hookName` for a hook declared in the module being compiled. A default or
+namespace import from elsewhere never matches a bare entry.
 
 This closes the other half of the capture-free callback lift. A callback that
 captures nothing is lifted to module scope and keeps one identity forever; a

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -3126,22 +3126,36 @@ function buildDataCallbackHookIndex(entries) {
 	return { byModule, bareNames };
 }
 
-/** Local name -> `{ module, imported }` for every named import in the module. */
+/**
+ * How each imported local name entered the module. Bare declarations mean "a
+ * hook declared HERE", so every import form has to be recognised — otherwise a
+ * default or namespace import from another package falls through and silently
+ * matches a bare entry.
+ */
 function collectImportOrigins(ast) {
-	const origins = new Map();
+	/** local -> { module, imported } */
+	const named = new Map();
+	/** local -> module, for `import * as NS` */
+	const namespaces = new Map();
+	/** locals bound by a default import: opaque, never declarable */
+	const opaque = new Set();
 	for (const statement of ast.body || []) {
 		if (statement?.type !== 'ImportDeclaration') continue;
 		const moduleName = statement.source?.value;
 		if (typeof moduleName !== 'string') continue;
 		for (const spec of statement.specifiers || []) {
-			if (spec.type !== 'ImportSpecifier' || spec.local?.type !== 'Identifier') continue;
-			origins.set(spec.local.name, {
-				module: moduleName,
-				imported: spec.imported?.name ?? spec.local.name,
-			});
+			const local = spec.local?.name;
+			if (typeof local !== 'string') continue;
+			if (spec.type === 'ImportSpecifier') {
+				named.set(local, { module: moduleName, imported: spec.imported?.name ?? local });
+			} else if (spec.type === 'ImportNamespaceSpecifier') {
+				namespaces.set(local, moduleName);
+			} else {
+				opaque.add(local);
+			}
 		}
 	}
-	return origins;
+	return { named, namespaces, opaque };
 }
 
 function wrapCapturingHookCallbacks(ast, options = {}) {
@@ -3153,14 +3167,31 @@ function wrapCapturingHookCallbacks(ast, options = {}) {
 
 	/** Whether THIS call site's hook declared its callback is data. */
 	const hookDeclaresDataCallback = (call) => {
-		const name = hookShapedCalleeName(call);
-		if (name === null) return false;
-		const origin = importOrigins.get(name);
-		if (origin !== undefined) {
-			return declared.byModule.get(origin.module)?.has(origin.imported) === true;
+		const callee = call.callee;
+		if (callee?.type === 'Identifier') {
+			const origin = importOrigins.named.get(callee.name);
+			if (origin !== undefined) {
+				return declared.byModule.get(origin.module)?.has(origin.imported) === true;
+			}
+			// A namespace or default import is not a module-local declaration, and
+			// its origin module cannot be attributed to this name.
+			if (importOrigins.namespaces.has(callee.name) || importOrigins.opaque.has(callee.name)) {
+				return false;
+			}
+			return declared.bareNames.has(callee.name);
 		}
-		// Not an import: a hook declared in this module.
-		return declared.bareNames.has(name);
+		// `NS.useThing(...)` is declarable only against the namespace's module.
+		if (
+			callee?.type === 'MemberExpression' &&
+			!callee.computed &&
+			callee.object?.type === 'Identifier' &&
+			callee.property?.type === 'Identifier'
+		) {
+			const moduleName = importOrigins.namespaces.get(callee.object.name);
+			if (moduleName === undefined) return false;
+			return declared.byModule.get(moduleName)?.has(callee.property.name) === true;
+		}
+		return false;
 	};
 
 	// Calls whose OWN dependency list the compiler infers — `useMemo(fn)` and,
@@ -3202,10 +3233,7 @@ function wrapCapturingHookCallbacks(ast, options = {}) {
 					next &&
 					(next.type === 'ArrayExpression' ||
 						(next.type === 'Literal' && next.value === null) ||
-						next.type === 'NullLiteral' ||
-						// `undefined` parses as an Identifier, and passing it explicitly
-						// means the same as omitting the list.
-						(next.type === 'Identifier' && next.name === 'undefined'))
+						next.type === 'NullLiteral')
 				) {
 					return walked;
 				}

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -3228,7 +3228,10 @@ function wrapCapturingHookCallbacks(ast, options = {}) {
 				// considered fresh. An explicit `null` is the author's "re-run every
 				// render" escape hatch, so memoizing the callback beneath it could
 				// hand the hook a stale closure.
-				const next = n.arguments[index + 1];
+				// Peeled: `null as any` and `[dep] satisfies T` are the same escape
+				// hatch as the bare forms, and a type wrapper hiding one of them is
+				// exactly the stale-closure case this guard exists to prevent.
+				const next = unwrapTsExpr(n.arguments[index + 1]);
 				if (
 					next &&
 					(next.type === 'ArrayExpression' ||

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -41,7 +41,7 @@ import {
 import { print as esrapPrint } from 'esrap';
 import esrapTsx from 'esrap/languages/tsx';
 import { buildFatSegments } from './fat-segments.js';
-import { applyHookDependencies, isInvariantLiteral } from './hook-deps.js';
+import { analyzeHookDependencies, applyHookDependencies, isInvariantLiteral } from './hook-deps.js';
 import { compileUniversal, UNIVERSAL_COMPILER_RUNTIME_IMPORTS } from './compile-universal.js';
 import {
 	expandDomRendererRegionsAst,
@@ -2947,27 +2947,20 @@ function hookOwnsCallbackIdentity(call) {
 }
 
 /**
- * Whether `fn` can be lifted to module scope without changing what it computes.
- * `componentBound` is the over-approximated set of names the enclosing
- * module-level function declares.
+ * Whether `fn` can be relocated or memoized at all — independent of what it
+ * captures. A function whose meaning is tied to the call site it was written
+ * in (`this`, `arguments`, JSX, a nested hook) has to stay exactly where it is.
  */
-function isHoistableHookCallback(fn, componentBound) {
-	if (fn.type !== 'ArrowFunctionExpression' && fn.type !== 'FunctionExpression') return false;
+function isMovableHookCallback(fn) {
+	if (!fn || (fn.type !== 'ArrowFunctionExpression' && fn.type !== 'FunctionExpression'))
+		return false;
 	// A JSX code-block body is a subtemplate with its own compile pass.
 	if (fn.body?.type === 'JSXCodeBlock') return false;
 
 	let disqualified = false;
 	const seen = new WeakSet();
 	scan(fn);
-	if (disqualified) return false;
-
-	// Any reference to a name the component declares makes the closure
-	// instance-specific, so it must stay where it was authored.
-	const free = collectFreeIdentifiers(fn, new Set());
-	for (const name of free) {
-		if (componentBound.has(name)) return false;
-	}
-	return true;
+	return !disqualified;
 
 	function scan(n) {
 		if (disqualified || !n || typeof n !== 'object') return;
@@ -3013,6 +3006,23 @@ function isHoistableHookCallback(fn, componentBound) {
 	}
 }
 
+/** Whether `fn` reads anything the enclosing component declares. */
+function capturesComponentBindings(fn, componentBound) {
+	for (const name of collectFreeIdentifiers(fn, new Set())) {
+		if (componentBound.has(name)) return true;
+	}
+	return false;
+}
+
+/**
+ * Whether `fn` can be lifted to module scope without changing what it computes.
+ * `componentBound` is the over-approximated set of names the enclosing
+ * module-level function declares.
+ */
+function isHoistableHookCallback(fn, componentBound) {
+	return isMovableHookCallback(fn) && !capturesComponentBindings(fn, componentBound);
+}
+
 /**
  * Lift capture-free function arguments of hook calls to module scope, so the
  * hook sees one identity for the module's lifetime. Returns the AST unchanged
@@ -3054,6 +3064,169 @@ function hoistCaptureFreeHookCallbacks(ast, options = {}) {
 		};
 		return mapAst(statement, visit);
 	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Dep-keyed hook-callback memoization (production compiles).
+//
+// The companion to the capture-free lift. A callback that DOES read component
+// state cannot move to module scope, but its identity still only needs to
+// change when the values it reads change — so it is wrapped in `useCallback`
+// with its dependency list left for inference to fill.
+//
+// This runs BEFORE applyHookDependencies precisely so inference owns that list,
+// which matters more than it looks: coarse identifier deps (`[props]`) are
+// worthless here, because the props object is a fresh identity on every parent
+// render, so the memo never hits. Inference produces the member PATHS actually
+// read (`[props.offset]`), and that is what holds the identity across a
+// re-render which changed nothing relevant.
+//
+// The wrapper is emitted inline at the argument position rather than as a
+// preceding `const`, which keeps the rewrite local — no statement insertion, so
+// no chance of lifting a callback out of the block whose scope it depends on.
+//
+// `useCallback` is IMPORTED under a reserved alias rather than synthesized as a
+// bare identifier, because dependency inference resolves hooks through real
+// import bindings; an unresolvable callee would silently receive no
+// dependencies at all, which is the failure mode that still looks like it works.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const AUTO_CALLBACK_ALIAS = '_$autoCb';
+
+/**
+ * Which hooks have DECLARED that a callback argument is data they memoize on,
+ * rather than a dependency subject they re-run. Entries are `module#hookName`
+ * (matched against the call site's import) or a bare `hookName` for a hook
+ * declared in the module being compiled.
+ *
+ * This is an explicit declaration rather than an inference because the fact
+ * lives in the hook's own package, and a single-module compile cannot read it.
+ * Guessing is not an option here: the compiler already refuses to attach
+ * dependency semantics to unproven custom hooks, and getting this wrong yields
+ * a STALE CLOSURE — silent, intermittent, and attributed to the application
+ * rather than to the compiler.
+ */
+function buildDataCallbackHookIndex(entries) {
+	const byModule = new Map();
+	const bareNames = new Set();
+	for (const entry of entries || []) {
+		if (typeof entry !== 'string') continue;
+		const hash = entry.indexOf('#');
+		if (hash === -1) {
+			bareNames.add(entry);
+			continue;
+		}
+		const moduleName = entry.slice(0, hash);
+		const hookName = entry.slice(hash + 1);
+		if (!moduleName || !hookName) continue;
+		let names = byModule.get(moduleName);
+		if (names === undefined) byModule.set(moduleName, (names = new Set()));
+		names.add(hookName);
+	}
+	return { byModule, bareNames };
+}
+
+/** Local name -> `{ module, imported }` for every named import in the module. */
+function collectImportOrigins(ast) {
+	const origins = new Map();
+	for (const statement of ast.body || []) {
+		if (statement?.type !== 'ImportDeclaration') continue;
+		const moduleName = statement.source?.value;
+		if (typeof moduleName !== 'string') continue;
+		for (const spec of statement.specifiers || []) {
+			if (spec.type !== 'ImportSpecifier' || spec.local?.type !== 'Identifier') continue;
+			origins.set(spec.local.name, {
+				module: moduleName,
+				imported: spec.imported?.name ?? spec.local.name,
+			});
+		}
+	}
+	return origins;
+}
+
+function wrapCapturingHookCallbacks(ast, options = {}) {
+	if (options.enabled !== true) return ast;
+	if (!Array.isArray(ast?.body)) return ast;
+	const declared = buildDataCallbackHookIndex(options.dataCallbackHooks);
+	if (declared.byModule.size === 0 && declared.bareNames.size === 0) return ast;
+	const importOrigins = collectImportOrigins(ast);
+
+	/** Whether THIS call site's hook declared its callback is data. */
+	const hookDeclaresDataCallback = (call) => {
+		const name = hookShapedCalleeName(call);
+		if (name === null) return false;
+		const origin = importOrigins.get(name);
+		if (origin !== undefined) {
+			return declared.byModule.get(origin.module)?.has(origin.imported) === true;
+		}
+		// Not an import: a hook declared in this module.
+		return declared.bareNames.has(name);
+	};
+
+	// Calls whose OWN dependency list the compiler infers — `useMemo(fn)` and,
+	// more importantly, custom dependency hooks like `useComputed(fn)` that
+	// forward to one. Inference requires their callback to still be an inline
+	// function at that call site, so wrapping it would turn a working inference
+	// into a hard compile error. Keyed by call node, which is why this analysis
+	// runs on the very AST the walk below visits.
+	let inferenceOwned;
+	try {
+		inferenceOwned = analyzeHookDependencies(ast, {
+			filename: options.filename,
+			hookRuntimeModules: options.hookRuntimeModules,
+		});
+	} catch {
+		// Inference reports its own diagnostics through applyHookDependencies
+		// moments later; this pass must not be the one to surface them.
+		return ast;
+	}
+
+	let wrapped = false;
+	const body = ast.body.map((statement) => {
+		const componentBound = collectSubtreeBindings(statement, new Set());
+		const visit = (n) => {
+			if (n.type !== 'CallExpression' || !isHookShapedCall(n)) return null;
+			const ownsIdentity =
+				hookOwnsCallbackIdentity(n) || inferenceOwned.has(n) || !hookDeclaresDataCallback(n);
+			const args = n.arguments.map((arg, index) => {
+				const walked = mapAst(arg, visit);
+				if (ownsIdentity || arg?.type === 'SpreadElement') return walked;
+				if (!isMovableHookCallback(walked)) return walked;
+				// An argument that looks like a dependency list immediately after the
+				// callback means the hook already owns when that callback is
+				// considered fresh. An explicit `null` is the author's "re-run every
+				// render" escape hatch, so memoizing the callback beneath it could
+				// hand the hook a stale closure.
+				const next = n.arguments[index + 1];
+				if (
+					next &&
+					(next.type === 'ArrayExpression' ||
+						(next.type === 'Literal' && next.value === null) ||
+						next.type === 'NullLiteral' ||
+						// `undefined` parses as an Identifier, and passing it explicitly
+						// means the same as omitting the list.
+						(next.type === 'Identifier' && next.name === 'undefined'))
+				) {
+					return walked;
+				}
+				// A callback that captures nothing is the LIFT's job — a module-scope
+				// identity is strictly better than a per-instance memo cell.
+				if (!capturesComponentBindings(walked, componentBound)) return walked;
+				wrapped = true;
+				return inheritOriginLoc(b.call(b.id(AUTO_CALLBACK_ALIAS), walked), arg);
+			});
+			return { ...n, arguments: args };
+		};
+		return mapAst(statement, visit);
+	});
+	if (!wrapped) return ast;
+	return {
+		...ast,
+		body: [
+			inheritOriginLoc(b.imports([['useCallback', AUTO_CALLBACK_ALIAS]], 'octane'), ast.body[0]),
+			...body,
+		],
+	};
 }
 
 /**
@@ -5353,7 +5526,7 @@ function instrumentProfileComponents(ast, ctx) {
  * Compile a .tsrx source string into JS targeting `octane`.
  * @param {string} source
  * @param {string} filename
- * @param {{ hmr?: boolean | 'vite' | 'webpack', mode?: 'client' | 'server', dev?: boolean, profile?: boolean, profileFilename?: string, autoMemo?: boolean, inlineHookMemo?: boolean, renderer?: { id: string, module: string, target: 'dom' | 'universal', server?: string }, rendererBoundaries?: Readonly<Record<string, Readonly<Record<string, { ownerRenderer: string, childRenderer: string, prop: string, server?: string }>>>>, rendererRegistry?: Readonly<Record<string, { module: string, target: 'dom' | 'universal', server?: string }>>, clientOnlyImports?: readonly unknown[], __hydratePrepared?: boolean, __hydrateBoundaryModule?: boolean, __nativeChangeDiagnostics?: readonly unknown[], __nativeChangeAnalysis?: { diagnostics: readonly unknown[], classifications: Map<number, string> } }} [options] —
+ * @param {{ hmr?: boolean | 'vite' | 'webpack', mode?: 'client' | 'server', dev?: boolean, profile?: boolean, profileFilename?: string, autoMemo?: boolean, inlineHookMemo?: boolean, dataCallbackHooks?: readonly string[], renderer?: { id: string, module: string, target: 'dom' | 'universal', server?: string }, rendererBoundaries?: Readonly<Record<string, Readonly<Record<string, { ownerRenderer: string, childRenderer: string, prop: string, server?: string }>>>>, rendererRegistry?: Readonly<Record<string, { module: string, target: 'dom' | 'universal', server?: string }>>, clientOnlyImports?: readonly unknown[], __hydratePrepared?: boolean, __hydrateBoundaryModule?: boolean, __nativeChangeDiagnostics?: readonly unknown[], __nativeChangeAnalysis?: { diagnostics: readonly unknown[], classifications: Map<number, string> } }} [options] —
  *   `dev: true` emits client hydration source-location metadata (per-component
  *   `__s.locs`/`__s.locFile`) and, in server mode, source-located native-element
  *   scopes for invalid HTML nesting diagnostics. Both are strictly gated so
@@ -5637,6 +5810,22 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 	// before any component splitting/hoisting so every lexical binding is still
 	// visible to the shared TSRX/TSX analysis. Explicit arrays and `null` pass
 	// through untouched.
+	// Wrapping runs BEFORE inference so the synthesized `useCallback` receives a
+	// real inferred dependency list — member paths rather than the whole props
+	// object, which is the difference between a memo that holds and one that
+	// never hits. Gated exactly like the lift below.
+	ast = wrapCapturingHookCallbacks(ast, {
+		enabled:
+			(options?.hmr ?? false) === false &&
+			!(options && options.dev) &&
+			!(options && options.profile),
+		filename,
+		dataCallbackHooks: options?.dataCallbackHooks,
+		hookRuntimeModules: hookRuntimeModulesForCompile(
+			options,
+			rendererBoundaryPreparation?.universalUnits,
+		),
+	});
 	ast = applyHookDependencies(ast, {
 		filename,
 		hookRuntimeModules: hookRuntimeModulesForCompile(

--- a/packages/octane/tests/_fixtures/data-callback-hooks.tsrx
+++ b/packages/octane/tests/_fixtures/data-callback-hooks.tsrx
@@ -1,0 +1,47 @@
+import { useCallback, useMemo, useState, useSyncExternalStore } from 'octane';
+
+// A hook shaped like a store binding's selector read: the selection is memoized
+// on the SELECTOR's identity, which is what dep-keying the callback is for.
+export function useLocalSelector(source, selector, slot?: symbol) {
+	const memo = useMemo(() => {
+		let has = false;
+		let lastSnap;
+		let lastSel;
+		return (snap) => {
+			if (has && Object.is(lastSnap, snap)) return lastSel;
+			has = true;
+			lastSnap = snap;
+			lastSel = selector(snap);
+			return lastSel;
+		};
+	}, [selector]);
+	const snapshot = useSyncExternalStore(source.subscribe, source.get, undefined, slot);
+	return memo(snapshot);
+}
+
+// The selector reads `props.offset`, so its identity must move when the offset
+// moves and hold when only unrelated state changes.
+export function OffsetReader(props) @{
+	const [tick, setTick] = useState(0);
+	props.bind(setTick);
+	const total = useLocalSelector(props.store, (s) => s.base + props.offset);
+	<div>
+		<span id="total">{total as string}</span>
+		<span id="tick">{tick as string}</span>
+	</div>
+}
+
+// The shape the compiler emits for a declared hook, written by hand: the
+// selector wrapped in useCallback keyed on the member path it reads. Compiled
+// output is asserted separately; this pins that the SHAPE is semantically
+// correct, in both compile modes, independent of who produced it.
+export function OffsetReaderKeyed(props) @{
+	const [tick, setTick] = useState(0);
+	props.bind(setTick);
+	const selector = useCallback((s) => s.base + props.offset, [props.offset]);
+	const total = useLocalSelector(props.store, selector);
+	<div>
+		<span id="total">{total as string}</span>
+		<span id="tick">{tick as string}</span>
+	</div>
+}

--- a/packages/octane/tests/data-callback-hooks-behavior.test.ts
+++ b/packages/octane/tests/data-callback-hooks-behavior.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { act, mount } from './_helpers';
+import { OffsetReader, OffsetReaderKeyed } from './_fixtures/data-callback-hooks.tsrx';
+
+// Dep-keying a callback changes when its identity moves, never what it computes.
+// These run in BOTH vitest projects, so the dev compile (which never keys) and
+// the production compile must agree on every assertion.
+
+function makeStore(base: number) {
+	let value = { base };
+	const listeners = new Set<() => void>();
+	return {
+		get: () => value,
+		set: (b: number) => {
+			value = { base: b };
+			for (const l of listeners) l();
+		},
+		subscribe: (l: () => void) => {
+			listeners.add(l);
+			return () => listeners.delete(l);
+		},
+	};
+}
+
+describe.each([
+	['authored form', OffsetReader],
+	['dep-keyed form', OffsetReaderKeyed],
+])('dep-keyed callbacks preserve semantics (%s)', (_label, Component) => {
+	it('tracks the store, the captured prop, and unrelated state independently', async () => {
+		const store = makeStore(10);
+		let setTick!: (n: number) => void;
+		const r = mount(Component, { store, offset: 1, bind: (fn: any) => (setTick = fn) });
+		await act(() => {});
+		expect(r.find('#total').textContent).toBe('11');
+
+		// Unrelated local state moves; the selection must not go stale or change.
+		await act(() => setTick(1));
+		expect(r.find('#tick').textContent).toBe('1');
+		expect(r.find('#total').textContent).toBe('11');
+
+		// The store moves.
+		await act(() => store.set(20));
+		expect(r.find('#total').textContent).toBe('21');
+
+		// The CAPTURED prop moves — the whole point of keying on captures rather
+		// than on the callback's identity.
+		await act(() => r.update(Component, { store, offset: 5, bind: (fn: any) => (setTick = fn) }));
+		expect(r.find('#total').textContent).toBe('25');
+
+		// And the store still moves after the prop change.
+		await act(() => store.set(30));
+		expect(r.find('#total').textContent).toBe('35');
+		r.unmount();
+	});
+});

--- a/packages/octane/tests/data-callback-hooks.test.ts
+++ b/packages/octane/tests/data-callback-hooks.test.ts
@@ -169,4 +169,24 @@ describe('data-callback hooks', () => {
 		).code;
 		expect(wraps(code)).toBe(1);
 	});
+
+	it('sees the dependency escape hatch through a type wrapper', () => {
+		// `null as any` and `[dep] as const` are the same author intent as the bare
+		// forms. A type wrapper hiding one is exactly the stale-closure case the
+		// escape hatch exists to prevent.
+		for (const deps of ['null as any', '(null)', '[props.id] as const', '[props.id]!']) {
+			const code = compile(
+				`
+          import { useSelector } from '@octanejs/tanstack-store';
+          export function App(props) @{
+            const v = useSelector(props.store, (s) => s.items[props.id], ${deps});
+            <p>{v as string}</p>
+          }
+        `,
+				'ts-wrapped-deps.tsrx',
+				{ ...PROD, dataCallbackHooks: DECLARED },
+			).code;
+			expect(wraps(code), `deps written as \`${deps}\``).toBe(0);
+		}
+	});
 });

--- a/packages/octane/tests/data-callback-hooks.test.ts
+++ b/packages/octane/tests/data-callback-hooks.test.ts
@@ -105,4 +105,68 @@ describe('data-callback hooks', () => {
 			expect(wraps(code)).toBe(0);
 		}
 	});
+
+	it('does not treat an imported hook as module-local for a bare declaration', () => {
+		// A bare entry declares a hook written in THIS module. A default or
+		// namespace import from some other package must not fall through into it,
+		// or a hook that never opted in gets its callbacks dep-keyed.
+		const asDefault = compile(
+			`
+        import useSelector from 'some-other-package';
+        export function App(props) @{
+          const v = useSelector(props.store, (s) => s.items[props.id]);
+          <p>{v as string}</p>
+        }
+      `,
+			'default-import.tsrx',
+			{ ...PROD, dataCallbackHooks: ['useSelector'] },
+		).code;
+		expect(wraps(asDefault)).toBe(0);
+
+		const viaNamespace = compile(
+			`
+        import * as Store from 'some-other-package';
+        export function App(props) @{
+          const v = Store.useSelector(props.store, (s) => s.items[props.id]);
+          <p>{v as string}</p>
+        }
+      `,
+			'namespace-import.tsrx',
+			{ ...PROD, dataCallbackHooks: ['useSelector'] },
+		).code;
+		expect(wraps(viaNamespace)).toBe(0);
+	});
+
+	it('matches a namespace-imported hook against its own module', () => {
+		const code = compile(
+			`
+        import * as Store from '@octanejs/tanstack-store';
+        export function App(props) @{
+          const v = Store.useSelector(props.store, (s) => s.items[props.id]);
+          <p>{v as string}</p>
+        }
+      `,
+			'namespace-declared.tsrx',
+			{ ...PROD, dataCallbackHooks: DECLARED },
+		).code;
+		expect(wraps(code)).toBe(1);
+	});
+
+	it('keys a callback whose call passes an explicit undefined', () => {
+		// `undefined` is not a deliberate dependency list — it is what an omitted
+		// optional argument looks like, and omitted is exactly when a capturing
+		// callback should be keyed.
+		const code = compile(
+			`
+        import { useSelector } from '@octanejs/tanstack-store';
+        export function App(props) @{
+          const v = useSelector(props.store, (s) => s.items[props.id], undefined);
+          <p>{v as string}</p>
+        }
+      `,
+			'explicit-undefined.tsrx',
+			{ ...PROD, dataCallbackHooks: DECLARED },
+		).code;
+		expect(wraps(code)).toBe(1);
+	});
 });

--- a/packages/octane/tests/data-callback-hooks.test.ts
+++ b/packages/octane/tests/data-callback-hooks.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { compile } from 'octane/compiler';
+
+// A hook that memoizes on its callback's identity wants that identity to move
+// only when the values the callback reads move. The compiler can supply that —
+// it can see the captures at the call site — but it cannot see whether the HOOK
+// treats its callback as data or as a dependency subject, because that fact
+// lives in the hook's own package.
+//
+// So the hook declares it, via `dataCallbackHooks`. Getting this wrong yields a
+// stale closure rather than a loud error, which is why nothing is inferred here
+// and why the transform is inert until something opts in.
+
+const PROD = { hmr: false as const, dev: false };
+const DECLARED = ['@octanejs/tanstack-store#useSelector'];
+
+const SOURCE = `
+  import { useSelector } from '@octanejs/tanstack-store';
+  export function App(props) @{
+    const free = useSelector(props.store, (s) => s.total);
+    const captured = useSelector(props.store, (s) => s.items[props.id]);
+    <p>{free + '/' + captured}</p>
+  }
+`;
+
+const wraps = (code: string) => [...code.matchAll(/_\$autoCb\(/g)].length;
+const lifts = (code: string) => [...code.matchAll(/const _fn\$\d+ =/g)].length;
+
+describe('data-callback hooks', () => {
+	it('changes nothing until a hook declares its callback is data', () => {
+		const code = compile(SOURCE, 'inert.tsrx', PROD).code;
+		expect(wraps(code)).toBe(0);
+		// The capture-free selector is still lifted; that decision is unrelated.
+		expect(lifts(code)).toBe(1);
+	});
+
+	it('keys a capturing callback on its captures once declared', () => {
+		const code = compile(SOURCE, 'declared.tsrx', {
+			...PROD,
+			dataCallbackHooks: DECLARED,
+		}).code;
+		expect(wraps(code)).toBe(1);
+		// The dependency list is the member PATH actually read. A coarse `[props]`
+		// would be worthless — the props object is a fresh identity every render,
+		// so the memo would never hit.
+		expect(code).toMatch(/\[props\.id\]/);
+		// A callback that captures nothing still takes the module-scope lift,
+		// which is strictly better than a per-instance memo cell.
+		expect(lifts(code)).toBe(1);
+	});
+
+	it('matches the declaration against the module the hook came from', () => {
+		const code = compile(SOURCE, 'other-module.tsrx', {
+			...PROD,
+			dataCallbackHooks: ['some-other-package#useSelector'],
+		}).code;
+		expect(wraps(code)).toBe(0);
+	});
+
+	it('accepts a bare name for a hook declared in the module being compiled', () => {
+		const code = compile(
+			`
+        import { useSyncExternalStore } from 'octane';
+        export function useLocalSelector(source, selector, slot?: symbol) {
+          const snap = useSyncExternalStore(source.subscribe, source.get, undefined, slot);
+          return selector(snap);
+        }
+        export function App(props) @{
+          const v = useLocalSelector(props.store, (s) => s.items[props.id]);
+          <p>{v as string}</p>
+        }
+      `,
+			'local-hook.tsrx',
+			{ ...PROD, dataCallbackHooks: ['useLocalSelector'] },
+		).code;
+		expect(wraps(code)).toBe(1);
+	});
+
+	it('leaves a declared hook alone when it takes its own dependency list', () => {
+		// An explicit `null` is the author's "re-run every render" escape hatch,
+		// and an explicit array means the hook already owns freshness. Memoizing
+		// the callback beneath either could hand the hook a stale closure.
+		const code = compile(
+			`
+        import { useSelector } from '@octanejs/tanstack-store';
+        export function App(props) @{
+          const a = useSelector(props.store, (s) => s.items[props.id], null);
+          const b = useSelector(props.store, (s) => s.rows[props.id], [props.id]);
+          <p>{a + '/' + b}</p>
+        }
+      `,
+			'own-deps.tsrx',
+			{ ...PROD, dataCallbackHooks: DECLARED },
+		).code;
+		expect(wraps(code)).toBe(0);
+	});
+
+	it('stays out of dev, HMR and profile compiles', () => {
+		for (const mode of [
+			{ hmr: false as const, dev: true },
+			{ hmr: 'vite' as const, dev: true },
+			{ hmr: false as const, dev: false, profile: true },
+		]) {
+			const code = compile(SOURCE, 'modes.tsrx', { ...mode, dataCallbackHooks: DECLARED }).code;
+			expect(wraps(code)).toBe(0);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

New compile option `dataCallbackHooks`, letting a hook declare that a callback argument is **data it memoizes on** rather than a dependency subject it re-runs. Production compiles then key that callback on the values it actually reads.

This is option 1 from the earlier discussion, and it unparks the dep-keying work that was blocked on exactly this question.

## Why

The capture-free lift (#337) handles callbacks that capture nothing. A callback that reads component state cannot move to module scope — but its identity still only needs to change when the values it reads change.

Measured, 512 subscribers over 20 unrelated parent re-renders with a capturing selector:

| | selector invocations | prod re-render |
| --- | --- | --- |
| authored form | 10,240 | 21.4–23.1 ms |
| dep-keyed | **0** | 7.8–9.9 ms |

**The pass runs before dependency inference, and that ordering is the whole design.** Coarse identifier dependencies (`[props]`) are worthless here — I measured it, and the win vanishes completely (10,240 invocations, 24.2ms, identical to the authored form), because the props object is a fresh identity on every parent render so the memo never hits. Inference produces the member paths actually read (`[props.offset]`), which is what makes the identity hold.

## Why it is declared and not inferred

The fact lives in the hook's own package, and a single-module compile cannot read it. The cross-module facts spike (#321) that would have supplied it is closed.

More importantly, guessing is the wrong trade. The compiler already refuses to attach dependency semantics to custom hooks it cannot statically prove (`infers only statically proven local custom dependency hooks`), and a wrong answer here is a **stale closure** — silent, intermittent, and attributed to the application rather than to the compiler — where the lift's failure mode is a loud `ReferenceError`. So the transform is **inert until something opts in**.

```js
compile(source, filename, {
  dataCallbackHooks: ['@octanejs/tanstack-store#useSelector'],
})
```

Entries are `module#hookName`, matched against the call site's import, or a bare `hookName` for a hook declared in the module being compiled.

Declared hooks are still skipped wherever the hook owns freshness itself: when its own dependency list is inferred (wrapping there turns a working inference into a hard compile error — found by the suite), and when the call passes an explicit dependency array or `null`, the author's "re-run every render" escape hatch. Dev, HMR and profile compiles keep the authored form.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` — **1438 files, 14,641 tests, 0 failures**

Coverage is split deliberately, because the vitest projects cannot pass a per-file compile option:

- **Codegen** (12 assertions) — inert by default; wraps once declared; the dependency list is the member path `[props.id]`; module-scoped matching rejects a same-named hook from another package; bare names work for local hooks; explicit `null`/array deps are skipped; dev, HMR and profile are skipped.
- **Behavioral** (4, across both compile modes) — the *emitted shape* is exercised directly, hand-written to match what the compiler produces, against the authored form as a control. It asserts the selection tracks the store, the captured prop, and unrelated local state independently. This is what proves dep-keying does not go stale; the codegen tests prove the compiler emits that shape.

## Risk / follow-ups

- **Not yet exposed through the Vite/Rspack plugins.** The option is compile-level and tested there; plugin passthrough is the remaining step before an app can actually opt in, and I did not want to guess at that wiring. No binding declares itself yet, so nothing changes for anyone today.
- The lift's safety analysis is now property-tested (#342), which was the prerequisite for trusting this transform at all.
- Uses `useCallback` at the argument position rather than a preceding `const`, so the inline hook-memo tier does not consume it and it survives as a runtime call. Measured at parity with the declaration form (9.4 vs 9.9ms), and it keeps the rewrite local — no statement insertion, so no risk of lifting a callback out of the block whose scope it depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Production-only AST rewrite can introduce stale closures if `dataCallbackHooks` is mis-declared, but the transform is opt-in and skips explicit author dependency escape hatches and inference-owned hook calls.
> 
> **Overview**
> Adds an opt-in compile option **`dataCallbackHooks`** so production builds can stabilize callback identities for hooks that memoize on their callback argument (e.g. store selectors), complementing the existing capture-free module-scope lift.
> 
> For declared hooks only, capturing inline callbacks are wrapped inline as **`_$autoCb(...)`** (aliased `useCallback` from `octane`) **before** hook dependency inference runs, so inferred deps use member paths like **`[props.id]`** instead of useless coarse **`[props]`**. Capture-free callbacks still hoist to module scope; calls with explicit dependency arrays, `null`, or TypeScript-wrapped equivalents are left alone, as are hooks whose own deps are inference-owned.
> 
> Matching is explicit: **`module#hookName`**, namespace member calls against the namespace module, or a bare name for a hook defined in the compiling module—default/namespace imports from other packages never match a bare entry. The transform is disabled for dev, HMR, and profile compiles, matching the inline hook-memo tier.
> 
> Codegen and behavioral tests cover inert-by-default behavior, wrapping shape, import matching edge cases, and semantic parity between authored and dep-keyed selector usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4726686117284af35f6f75282cddf378e246af69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->