### PR TITLE
fix(pack): finish strict published TSRX consumer validation

### DIFF
--- a/packages/tiptap/src/Context.tsrx
+++ b/packages/tiptap/src/Context.tsrx
@@ -11,18 +11,20 @@ export interface EditorConsumerProps {
 	children: (value: EditorContextValue) => OctaneNode;
 }
 
-export type EditorContainerProps = Omit<EditorContentProps, 'editor' | 'innerRef' | 'ref'> & {
-	editor?: never;
-	innerRef?: never;
-	ref?: never;
-};
+export type EditorContainerProps =
+	Omit<EditorContentProps, 'editor' | 'innerRef' | 'ref'> & {
+		editor?: never;
+		innerRef?: never;
+		ref?: never;
+	};
 
-export type EditorProviderProps = UseEditorOptions & {
-	children?: OctaneNode;
-	slotBefore?: OctaneNode;
-	slotAfter?: OctaneNode;
-	editorContainerProps?: EditorContainerProps;
-};
+export type EditorProviderProps =
+	UseEditorOptions & {
+		children?: OctaneNode;
+		slotBefore?: OctaneNode;
+		slotAfter?: OctaneNode;
+		editorContainerProps?: EditorContainerProps;
+	};
 
 export function EditorConsumer(props: EditorConsumerProps): OctaneNode {
 	const value = useCurrentEditor();

--- a/packages/tiptap/src/EditorContent.tsrx
+++ b/packages/tiptap/src/EditorContent.tsrx
@@ -19,9 +19,7 @@ import type {
 } from './Editor';
 
 export type EditorContentRef<T> =
-	| { current: T | null }
-	| ((value: T | null) => void | (() => void))
-	| null;
+	{ current: T | null } | ((value: T | null) => void | (() => void)) | null;
 
 export interface EditorContentProps {
 	editor: Editor | null;

--- a/packages/tiptap/src/Tiptap.tsrx
+++ b/packages/tiptap/src/Tiptap.tsrx
@@ -49,21 +49,22 @@ export function useTiptap(): TiptapContextType {
 	return useContext(TiptapContext);
 }
 
-type TiptapStateSelector<TSelectorResult> =
-	(options: UseEditorStateOptions<TSelectorResult, Editor>, slot: symbol) => TSelectorResult;
-
 /** Select a reactive slice of editor state from the context editor. */
 export function useTiptapState<TSelectorResult>(
 	selector: (context: EditorStateSnapshot<Editor>) => TSelectorResult,
 	...args: [equalityFn?: (left: TSelectorResult, right: TSelectorResult | null) => boolean]
 ): TSelectorResult {
 	const [userArgs, slot] = splitSlot(args);
-	const equalityFn = userArgs[0] as UseEditorStateOptions<TSelectorResult, Editor>['equalityFn'];
+	const equalityFn = userArgs[0] as ((left: TSelectorResult, right: | TSelectorResult
+	| null) => boolean) | undefined;
 	const { editor } = useTiptap();
 
 	// Call through a non-hook-named alias because this source is itself compiled:
 	// the public call site's slot is already being forwarded explicitly here.
-	const selectEditorState = useEditorState as TiptapStateSelector<TSelectorResult>;
+	const selectEditorState = useEditorState as (options: UseEditorStateOptions<
+		TSelectorResult,
+		Editor
+	>, slot: symbol) => TSelectorResult;
 	return selectEditorState(
 		{
 			editor,

--- a/packages/tiptap/src/Tiptap.tsrx
+++ b/packages/tiptap/src/Tiptap.tsrx
@@ -25,14 +25,16 @@ export type TiptapWrapperEditorInstanceProps =
 			instance: Editor;
 	  };
 
-export type TiptapWrapperProps = TiptapWrapperEditorInstanceProps & {
-	children: OctaneNode;
-};
+export type TiptapWrapperProps =
+	TiptapWrapperEditorInstanceProps & {
+		children: OctaneNode;
+	};
 
-export type TiptapContentProps = Omit<EditorContentProps, 'editor' | 'ref'> & {
-	editor?: never;
-	ref?: never;
-};
+export type TiptapContentProps =
+	Omit<EditorContentProps, 'editor' | 'ref'> & {
+		editor?: never;
+		ref?: never;
+	};
 
 export const TiptapContext: Context<TiptapContextType> & { displayName?: string } = createContext({
 	get editor(): Editor {
@@ -47,23 +49,21 @@ export function useTiptap(): TiptapContextType {
 	return useContext(TiptapContext);
 }
 
+type TiptapStateSelector<TSelectorResult> =
+	(options: UseEditorStateOptions<TSelectorResult, Editor>, slot: symbol) => TSelectorResult;
+
 /** Select a reactive slice of editor state from the context editor. */
 export function useTiptapState<TSelectorResult>(
 	selector: (context: EditorStateSnapshot<Editor>) => TSelectorResult,
 	...args: [equalityFn?: (left: TSelectorResult, right: TSelectorResult | null) => boolean]
 ): TSelectorResult {
 	const [userArgs, slot] = splitSlot(args);
-	const equalityFn = userArgs[0] as
-		| ((left: TSelectorResult, right: TSelectorResult | null) => boolean)
-		| undefined;
+	const equalityFn = userArgs[0] as UseEditorStateOptions<TSelectorResult, Editor>['equalityFn'];
 	const { editor } = useTiptap();
 
 	// Call through a non-hook-named alias because this source is itself compiled:
 	// the public call site's slot is already being forwarded explicitly here.
-	const selectEditorState = useEditorState as (
-		options: UseEditorStateOptions<TSelectorResult, Editor>,
-		slot: symbol,
-	) => TSelectorResult;
+	const selectEditorState = useEditorState as TiptapStateSelector<TSelectorResult>;
 	return selectEditorState(
 		{
 			editor,
@@ -105,4 +105,4 @@ export const Tiptap = Object.assign(TiptapWrapper, {
 	Content: TiptapContent,
 });
 
-export default Tiptap;
+export default Tiptap

--- a/scripts/package-pack-canaries.mjs
+++ b/scripts/package-pack-canaries.mjs
@@ -108,6 +108,9 @@ export function createPackedTsrxConsumerConfig() {
 			target: 'esnext',
 			types: ['node'],
 		},
+		tsrx: {
+			compiler: 'octane/compiler/volar',
+		},
 		include: ['src/**/*.ts', 'src/**/*.tsrx'],
 	};
 }

--- a/scripts/package-pack-canaries.test.mjs
+++ b/scripts/package-pack-canaries.test.mjs
@@ -145,6 +145,7 @@ describe('packed TSRX source consumers', () => {
 		assert.equal(config.compilerOptions.jsx, 'react-jsx');
 		assert.equal(config.compilerOptions.jsxImportSource, 'octane');
 		assert.deepEqual(config.compilerOptions.plugins, [{ name: '@tsrx/typescript-plugin' }]);
+		assert.deepEqual(config.tsrx, { compiler: 'octane/compiler/volar' });
 		assert.deepEqual(config.include, ['src/**/*.ts', 'src/**/*.tsrx']);
 		assert.equal(config.compilerOptions.paths, undefined);
 	});


### PR DESCRIPTION
## Summary

Follow-up to #345 and #332. The original issue PR was merged before its final CI completed; this repairs the two actionable failures without changing the lockfile or weakening the consumer boundary.

- Select the published `octane/compiler/volar` compiler in the external strict `tsrx-tsc` consumer and regression-test the exact setting.
- Format the three Tiptap TSRX source files with the exact pinned upstream `@tsrx/prettier-plugin@0.3.116` and `@tsrx/core@0.1.54`.
- Preserve strongly typed editor-state slot forwarding using the authoritative `UseEditorStateOptions` equality type and a named typed selector; add no ambient TSRX declarations.
- Retain the patch changeset for Cmdk, Sonner, and Tiptap already merged by #345.

## Validation

- Exact pinned TSRX formatter: all three changed `.tsrx` files pass.
- `node --test scripts/package-pack-canaries.test.mjs scripts/npm-release-preflight.test.mjs`: 17 passed.
- `node scripts/check-tsrx-module-decls.mjs`.
- `node scripts/check-changesets.js`.
- `node scripts/check-test-markers.mjs`.
- `node scripts/workspace-packages.mjs --check`.
- `git diff --check`.
- The original PR upstream `typecheck` job passed, including the strict Cmdk, Sonner, and Tiptap `tsrx-tsc` checks. Full external packed-consumer validation will run in this upstream PR because the normal local frozen installation of `@tsrx/core@0.1.54` encounters the protected-registry HTTP 403.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to pack-canary TypeScript config, tests, and TSRX formatting with no auth, data, or core runtime logic touched.
> 
> **Overview**
> Completes **strict external `tsrx-tsc` validation** for packed published bindings by wiring the consumer `tsconfig` to **`octane/compiler/volar`** and locking that in **`package-pack-canaries` tests**.
> 
> The **Tiptap** `.tsrx` sources (`Context`, `EditorContent`, `Tiptap`) are **reformatted** to match the pinned TSRX Prettier rules (mostly type-alias layout and `useTiptapState` equality-fn typing); there is no intended runtime or API behavior change beyond what the formatter enforces (e.g. `export default Tiptap` without a trailing semicolon).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff0cf5b77f07349f80c3a27653e988033332baea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->