### PR TITLE
fix(compiler): recognise a hook callback through a type assertion

### DIFF
--- a/.changeset/typed-callback-dep-keying.md
+++ b/.changeset/typed-callback-dep-keying.md
@@ -1,0 +1,14 @@
+---
+'octane': patch
+---
+
+A hook callback written through a type assertion — `((s) => s.total) as Sel` —
+is now recognised as a callback. It previously matched neither the module-scope
+lift nor dep-keying, because both tested the argument's node type directly and a
+`TSAsExpression` is not an arrow, so a typed selector silently kept its
+per-render identity churn.
+
+Both passes now peel the assertion, and both move the UNWRAPPED function. The
+assertion is erased from the emitted module either way, and dropping it means a
+type alias declared inside the component cannot be dragged out to module scope
+by the lift.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -3055,9 +3055,14 @@ function hoistCaptureFreeHookCallbacks(ast, options = {}) {
 			const args = n.arguments.map((arg) => {
 				const walked = mapAst(arg, visit);
 				if (ownsIdentity || arg?.type === 'SpreadElement') return walked;
-				if (!isHoistableHookCallback(walked, componentBound)) return walked;
+				// A callback written `((s) => …) as Sel` is still a function; the
+				// assertion is erased from the emitted module either way. The
+				// UNWRAPPED node is what moves, so a component-local type alias
+				// cannot be dragged out of the scope that declares it.
+				const fn = unwrapTsExpr(walked);
+				if (!isHoistableHookCallback(fn, componentBound)) return walked;
 				const name = `_fn$${nextId++}`;
-				hoisted.push(inheritOriginLoc(b.const(name, walked), arg));
+				hoisted.push(inheritOriginLoc(b.const(name, fn), arg));
 				return inheritOriginLoc(b.id(name), arg);
 			});
 			return { ...n, arguments: args };
@@ -3222,7 +3227,10 @@ function wrapCapturingHookCallbacks(ast, options = {}) {
 			const args = n.arguments.map((arg, index) => {
 				const walked = mapAst(arg, visit);
 				if (ownsIdentity || arg?.type === 'SpreadElement') return walked;
-				if (!isMovableHookCallback(walked)) return walked;
+				// Same as the lift: peel the assertion so a typed callback is still
+				// recognised as one, and key the unwrapped function.
+				const fn = unwrapTsExpr(walked);
+				if (!isMovableHookCallback(fn)) return walked;
 				// An argument that looks like a dependency list immediately after the
 				// callback means the hook already owns when that callback is
 				// considered fresh. An explicit `null` is the author's "re-run every
@@ -3242,9 +3250,9 @@ function wrapCapturingHookCallbacks(ast, options = {}) {
 				}
 				// A callback that captures nothing is the LIFT's job — a module-scope
 				// identity is strictly better than a per-instance memo cell.
-				if (!capturesComponentBindings(walked, componentBound)) return walked;
+				if (!capturesComponentBindings(fn, componentBound)) return walked;
 				wrapped = true;
-				return inheritOriginLoc(b.call(b.id(AUTO_CALLBACK_ALIAS), walked), arg);
+				return inheritOriginLoc(b.call(b.id(AUTO_CALLBACK_ALIAS), fn), arg);
 			});
 			return { ...n, arguments: args };
 		};

--- a/packages/octane/tests/data-callback-hooks.test.ts
+++ b/packages/octane/tests/data-callback-hooks.test.ts
@@ -189,4 +189,46 @@ describe('data-callback hooks', () => {
 			expect(wraps(code), `deps written as \`${deps}\``).toBe(0);
 		}
 	});
+
+	it('recognises a callback through a type assertion', () => {
+		// `((s) => …) as Sel` is still a function. Missing that skipped BOTH the
+		// module-scope lift and dep-keying, so a typed selector silently kept its
+		// per-render identity churn.
+		const code = compile(
+			`
+        import { useSelector } from '@octanejs/tanstack-store';
+        type Sel = (s: any) => any;
+        export function App(props) @{
+          const free = useSelector(props.store, ((s) => s.total) as Sel);
+          const captured = useSelector(props.store, ((s) => s.items[props.id]) as Sel);
+          <p>{free + '/' + captured}</p>
+        }
+      `,
+			'typed-callback.tsrx',
+			{ ...PROD, dataCallbackHooks: DECLARED },
+		).code;
+		// Same routing as the unasserted forms: capture-free lifts, capturing keys.
+		expect(lifts(code)).toBe(1);
+		expect(wraps(code)).toBe(1);
+		expect(code).toMatch(/\[props\.id\]/);
+	});
+
+	it('keeps a locally declared type out of module scope when lifting', () => {
+		// The lift moves the UNWRAPPED function, so a type alias declared inside
+		// the component cannot be dragged along to module scope.
+		const code = compile(
+			`
+        import { useSelector } from '@octanejs/tanstack-store';
+        export function App(props) @{
+          type LocalSel = (s: any) => any;
+          const free = useSelector(props.store, ((s) => s.total) as LocalSel);
+          <p>{free as string}</p>
+        }
+      `,
+			'local-type.tsrx',
+			{ ...PROD, dataCallbackHooks: DECLARED },
+		).code;
+		expect(lifts(code)).toBe(1);
+		expect(code).not.toMatch(/_fn\$\d+ = [^\n]*LocalSel/);
+	});
 });


### PR DESCRIPTION
## Summary

Follow-up to #347, which merged before this finding was reported. A hook callback written through a type assertion is now recognised as a callback.

## Why

Both the module-scope lift and dep-keying tested the argument's node type directly, and a `TSAsExpression` is not an `ArrowFunctionExpression`. So a typed selector matched neither, and silently kept its per-render identity churn:

| callback | before | after |
| --- | --- | --- |
| `(s) => s.total` | lifted | lifted |
| `((s) => s.total)` | lifted | lifted |
| `((s) => s.total) as Sel` | **neither** | lifted |
| `(s) => s.items[props.id]` | dep-keyed | dep-keyed |
| `((s) => s.items[props.id]) as Sel` | **neither** | dep-keyed |

Both passes now peel with the existing module-level `unwrapTsExpr`, so typed callbacks route identically to their unasserted equivalents.

## One deliberate choice beyond the reported fix

Both passes move the **unwrapped** function, not the asserted expression. The assertion is erased from the emitted module either way, so this is semantically identical — but it also means the lift cannot drag a component-local type alias out to module scope:

```tsx
export function App(props) @{
  type LocalSel = (s: any) => any;
  const v = useSelector(props.store, ((s) => s.total) as LocalSel);
}
```

Hoisting that expression verbatim would reference `LocalSel` from module scope. Covered by a test asserting the lifted binding carries no reference to the local type.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` — **1441 files, 14,763 tests, 0 failures**

Two tests added, verified failing against the unpeeled checks.

## Note on the pattern

This is the fourth finding in this family: a syntactic check missing the ways its target can be written. The previous three all failed *toward* wrapping — the silent stale-closure direction. This one fails the other way, toward not optimizing, which is why it surfaced as a missed win rather than a bug.

The enumeration is now complete as far as I can probe it, and every peel site uses the one shared `unwrapTsExpr`. If a fifth appears I would stop enumerating and make the gate conservative by construction instead, as noted on the #347 thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compiler-only optimization fix with targeted tests; behavior change is enabling existing transforms for a previously missed syntax form, not altering runtime semantics of emitted code beyond fixing missed memoization/lifting.
> 
> **Overview**
> **Typed hook callbacks** like `((s) => s.total) as Sel` were skipped by both the **module-scope lift** and **dep-keyed memoization** passes because those paths checked the argument AST node directly and a `TSAsExpression` is not an arrow. Those callbacks kept **per-render identity churn** with no optimization.
> 
> Both passes now call the shared **`unwrapTsExpr`** before `isHoistableHookCallback` / `isMovableHookCallback`, and they **hoist or wrap the unwrapped function** (not the asserted expression). That matches unasserted callbacks and avoids lifting a reference to a **component-local type alias** into module scope.
> 
> Tests cover typed selectors (one lift, one `_$autoCb` wrap with `[props.id]`) and that lifted bindings do not mention `LocalSel`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab1f84bc599ee144dce3644a5ea0e7962ea8a238. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->