### PR TITLE
benchmarks: measure native Preact scheduling

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -12,9 +12,10 @@ result contract**.
 
 The comparative suites include native Preact and Svelte 5 fixtures alongside
 the existing React, Solid, Ripple, and Vue Vapor references. Preact fixtures use
-`preact`/`preact/hooks` directly (with `preact/compat` only for APIs such as
-portals, Suspense, and `flushSync`); Svelte fixtures use runes, keyed `#each`,
-modern event attributes, and the public imperative APIs. Framework-specific
+`preact`/`preact/hooks` directly, including native scheduler timing, with
+`preact/compat` only for React-shaped APIs that core does not expose, such as
+portals, Suspense, `memo`, and `useSyncExternalStore`; Svelte fixtures use runes,
+keyed `#each`, modern event attributes, and the public imperative APIs. Framework-specific
 capability gaps stay explicit: Svelte's public server renderer is buffered, so
 `streaming-ssr` reports no Svelte target rather than wrapping buffered HTML in a
 fake stream. `codegen-size`, `dbmon-deopt`, and `js-framework-deopt` remain

--- a/benchmarks/async-waterfall/preact/src/main.jsx
+++ b/benchmarks/async-waterfall/preact/src/main.jsx
@@ -1,6 +1,6 @@
 import { render } from 'preact';
 import { useState } from 'preact/hooks';
-import { flushSync, startTransition, Suspense } from 'preact/compat';
+import { startTransition, Suspense } from 'preact/compat';
 import { fetchData, LEVELS } from './data.js';
 
 const records = new WeakMap();
@@ -67,7 +67,7 @@ let version = 0;
 
 window.__init = () => {
 	const t0 = performance.now();
-	flushSync(() => render(<Main />, target));
+	render(<Main />, target);
 	return waitForDeep(`L${LEVELS - 1}:v0`, t0);
 };
 

--- a/benchmarks/chat-stream/README.md
+++ b/benchmarks/chat-stream/README.md
@@ -30,7 +30,8 @@ counter per pump; segment text derives via the shared `segText(seg, done)`
 (settled segments cache their joined text). Frameworks differ only in their
 idiomatic reactivity around that model. Ripple's deriveds are functions called
 in template expressions, Solid and Svelte update fine-grained bindings, and the
-React and Preact handlers use public `flushSync` to bound each timed commit.
+React handlers use public `flushSync`; Preact uses its native microtask scheduler
+and the harness awaits each queued commit inside the timed window.
 
 Known variance: solid's `switchConv` is bimodal PER BROWSER SESSION (~3.6ms
 or ~6ms median, stable within a session) — its recorded baseline is pinned at

--- a/benchmarks/chat-stream/preact/src/main.jsx
+++ b/benchmarks/chat-stream/preact/src/main.jsx
@@ -1,10 +1,10 @@
 import { render } from 'preact';
 import { useState } from 'preact/hooks';
-import { flushSync } from 'preact/compat';
 import { initialConversations, nextReply, segText, userMessage } from './data.js';
 
-// Native Preact streaming-chat fixture. compat is used only for the public
-// synchronous flush that keeps network-pump and input work inside the timer.
+// Preact queues hook updates in a microtask. The harness awaits this after each
+// event/network update so native scheduling and the DOM commit stay timed.
+window.__benchFlush = () => Promise.resolve();
 function ChatApp() {
 	const [conversations, setConversations] = useState(initialConversations);
 	const [active, setActive] = useState(0);
@@ -15,20 +15,18 @@ function ChatApp() {
 		const text = draft.trim();
 		if (text === '') return;
 		const reply = nextReply();
-		flushSync(() => {
-			setConversations((items) =>
-				items.map((conversation, index) =>
-					index === active
-						? {
-								...conversation,
-								messages: [...conversation.messages, userMessage(text), reply],
-							}
-						: conversation,
-				),
-			);
-			setStreamingId(reply.id);
-			setDraft('');
-		});
+		setConversations((items) =>
+			items.map((conversation, index) =>
+				index === active
+					? {
+							...conversation,
+							messages: [...conversation.messages, userMessage(text), reply],
+						}
+					: conversation,
+			),
+		);
+		setStreamingId(reply.id);
+		setDraft('');
 	};
 
 	window.__pump = (count) => {
@@ -36,30 +34,27 @@ function ChatApp() {
 		const message = conversations[active].messages.find((item) => item.id === streamingId);
 		if (message === undefined) return 0;
 		const done = Math.min(message.total, message.done + count);
-		flushSync(() => {
-			setConversations((items) =>
-				items.map((conversation, index) =>
-					index === active
-						? {
-								...conversation,
-								messages: conversation.messages.map((item) =>
-									item.id === streamingId ? { ...item, done } : item,
-								),
-							}
-						: conversation,
-				),
-			);
-			if (done === message.total) setStreamingId(null);
-		});
+		setConversations((items) =>
+			items.map((conversation, index) =>
+				index === active
+					? {
+							...conversation,
+							messages: conversation.messages.map((item) =>
+								item.id === streamingId ? { ...item, done } : item,
+							),
+						}
+					: conversation,
+			),
+		);
+		if (done === message.total) setStreamingId(null);
 		return message.total - done;
 	};
-	window.__reset = () =>
-		flushSync(() => {
-			setConversations(initialConversations());
-			setActive(0);
-			setDraft('');
-			setStreamingId(null);
-		});
+	window.__reset = () => {
+		setConversations(initialConversations());
+		setActive(0);
+		setDraft('');
+		setStreamingId(null);
+	};
 
 	const conversation = conversations[active];
 	return (
@@ -72,7 +67,7 @@ function ChatApp() {
 							key={item.id}
 							class={'conv-tab' + (item.id === active ? ' active' : '')}
 							data-conv={String(item.id)}
-							onClick={() => flushSync(() => setActive(item.id))}
+							onClick={() => setActive(item.id)}
 						>
 							{item.title}
 						</button>
@@ -106,7 +101,7 @@ function ChatApp() {
 					class="prompt"
 					placeholder="Message…"
 					value={draft}
-					onInput={(event) => flushSync(() => setDraft(event.currentTarget.value))}
+					onInput={(event) => setDraft(event.currentTarget.value)}
 					onKeyDown={(event) => {
 						if (event.key === 'Enter') send();
 					}}

--- a/benchmarks/chat-stream/run.mjs
+++ b/benchmarks/chat-stream/run.mjs
@@ -17,8 +17,8 @@
 // cost.
 //
 // Timing protocol matches ../todomvc/run.mjs: sync-commit frameworks flush
-// inside the call (octane/react/ripple flushSync, solid flush()); vue-vapor
-// exposes `__benchFlush` and the loop awaits it per interaction.
+// inside the call (octane/react/ripple flushSync, solid flush()); Preact and
+// vue-vapor expose `__benchFlush` and the loop awaits it per interaction.
 //
 // Usage:
 //   node benchmarks/chat-stream/run.mjs [iterations]      # default 8

--- a/benchmarks/dbmon/preact/src/main.jsx
+++ b/benchmarks/dbmon/preact/src/main.jsx
@@ -1,29 +1,32 @@
 import { createElement, render } from 'preact';
-import { flushSync } from 'preact/compat';
 import App from './App.jsx';
 import { remount, sortRows, tickFull, tickPartial } from './ops.js';
 
 const target = document.getElementById('main');
 if (!target) throw new Error('missing #main root');
 let mounted = false;
+const update = (run) => {
+	run();
+	return Promise.resolve();
+};
 
 window.__mount = () => {
-	flushSync(() => render(createElement(App), target));
+	render(createElement(App), target);
 	mounted = true;
 };
-window.__tick = () => flushSync(tickFull);
-window.__tickPartial = () => flushSync(tickPartial);
-window.__remount = () => flushSync(remount);
-window.__sort = () => flushSync(sortRows);
+window.__tick = () => update(tickFull);
+window.__tickPartial = () => update(tickPartial);
+window.__remount = () => update(remount);
+window.__sort = () => update(sortRows);
 window.__unmount = () => {
 	if (mounted) {
-		flushSync(() => render(null, target));
+		render(null, target);
 		mounted = false;
 	}
 };
 window.__reset = () => {
 	if (mounted) {
-		flushSync(() => render(null, target));
+		render(null, target);
 		mounted = false;
 	}
 	while (target.firstChild) target.removeChild(target.firstChild);

--- a/benchmarks/dbmon/run.mjs
+++ b/benchmarks/dbmon/run.mjs
@@ -7,8 +7,8 @@
 //
 // Methodology mirrors the sibling benches: every op mutates the DOM inside its
 // adapter call — synchronously where the framework allows it (octane/react via
-// flushSync, solid via flush()); an adapter with no public sync flush
-// (vue-vapor) returns a thenable and the timed window extends until it settles.
+// flushSync, solid via flush()); adapters using native async scheduling (Preact
+// and vue-vapor) return a thenable and the timed window extends until it settles.
 // Either way we time ONLY the framework's JS work, and force a GC right before
 // each timed sample so a stray collection can't inflate it. Medians are
 // framework cost, not paint.
@@ -172,7 +172,7 @@ async function semanticGate(browser, url) {
 
 // MOUNT — fresh page per sample (quiescent start); time __mount() with a
 // freshly-collected heap. An adapter whose commit is scheduler-deferred
-// returns a thenable (vue-vapor's update ops do; see its main.js) — the timed
+// returns a thenable (Preact and vue-vapor do) — the timed
 // window extends until it settles, so the scheduling cost stays inside the
 // measurement.
 async function measureMount(browser, url) {

--- a/benchmarks/effectful-list/preact/src/main.jsx
+++ b/benchmarks/effectful-list/preact/src/main.jsx
@@ -1,5 +1,4 @@
 import { createElement, render } from 'preact';
-import { flushSync } from 'preact/compat';
 import App from './App.jsx';
 import './fx.js';
 import { remove100, toEmpty, toFresh1k, updateDeps, updateNodeps } from './ops.js';
@@ -15,12 +14,12 @@ let mounted = false;
 // scheduling and cleanup work without reaching into scheduler internals.
 const run = (fn) => {
 	const settled = waitForPassiveEffects();
-	flushSync(fn);
+	fn();
 	return settled;
 };
 
 window.__mount = () => {
-	flushSync(() => render(createElement(App), target));
+	render(createElement(App), target);
 	mounted = true;
 };
 
@@ -36,7 +35,7 @@ window.__opRemove100 = () => run(remove100);
 
 window.__unmount = () => {
 	if (mounted) {
-		flushSync(() => render(null, target));
+		render(null, target);
 		mounted = false;
 	}
 };

--- a/benchmarks/effectful-list/run.mjs
+++ b/benchmarks/effectful-list/run.mjs
@@ -13,10 +13,9 @@
 // AND its effect dispatch inside the adapter call — synchronously where the
 // framework allows it (octane: flushSync + drainPassiveEffects; react:
 // flushSync — React 19 flushes passives synchronously at the tail of a
-// sync-lane commit; solid: flush(); ripple: flushSync); an adapter with no
-// public sync flush (vue-vapor) returns a thenable and the timed window
-// extends until it settles (nextTick resolves after Vue's flushJobs — DOM
-// mutated and post-flush watchers drained). Either way we time ONLY the
+// sync-lane commit; solid: flush(); ripple: flushSync). Native async adapters
+// (Preact and vue-vapor) return a thenable and the timed window extends until it
+// settles after the DOM mutation. Either way we time ONLY the
 // framework's JS work, with a forced GC before each timed sample.
 // Sub-millisecond ops (update_nodeps / update_deps on the fine-grained
 // targets) loop N times inside the timed window and divide, to beat timer
@@ -196,7 +195,7 @@ async function gateCheck(page, op) {
 // Timed loop, entirely in-page: (optional per-sample pre) → gc() → inner×op →
 // divide. Yields a macrotask between samples so the page stays responsive and
 // deferred work can't bleed into the next sample. An op that returns a
-// thenable (vue-vapor — no public sync flush; see the methodology note) is
+// thenable (Preact/vue-vapor; see the methodology note) is
 // awaited BETWEEN inner iterations, so each iteration commits — the inner
 // state changes would otherwise coalesce into one commit and the sample
 // would time a single net update instead of `inner` full ones.

--- a/benchmarks/js-framework/README.md
+++ b/benchmarks/js-framework/README.md
@@ -76,7 +76,8 @@ and expose the same button + table contract:
 ### Preact and Svelte 5 references
 
 - **`preact`** (`:5260`) is a native Preact hooks implementation using keyed
-  JSX rows and the public compat `flushSync`; it is not a React-alias build.
+  JSX rows. The harness awaits Preact's queued microtask commit inside each timed
+  click; it is not a React-alias build.
 - **`svelte`** (`:5271`) is a runes-mode Svelte 5 implementation using a raw
   row array, keyed `#each`, modern event attributes, and public `flushSync`.
 

--- a/benchmarks/js-framework/preact/src/main.jsx
+++ b/benchmarks/js-framework/preact/src/main.jsx
@@ -1,20 +1,15 @@
 import { render } from 'preact';
 import { useCallback, useReducer } from 'preact/hooks';
-import { flushSync, memo } from 'preact/compat';
+import { memo } from 'preact/compat';
 
 // Native Preact hooks implementation, modeled on the js-framework-benchmark
 // frameworks/keyed/react-hooks reference, for the same
 // create/replace/update/select/swap/remove/runlots/clear ops the octane apps are
 // driven through by run.mjs.
 //
-// One adaptation: dispatch is wrapped in `flushSync` so Preact commits the update
-// SYNCHRONOUSLY inside the discrete click, the way octane flushes on the event
-// (and ripple/solid use flushSync/flush). The run.mjs harness times only the
-// synchronous click handler; Preact's `createRoot` otherwise schedules the
-// commit AFTER the click returns, so the timer would capture ~0ms of scheduling
-// instead of the actual render. flushSync forces the same commit work to run in
-// the timed window — it doesn't change the work (each op is a single dispatch,
-// so there's nothing to batch).
+// Preact queues hook updates in a microtask. The harness awaits this after each
+// click so native scheduling and the DOM commit stay inside the timed window.
+window.__benchFlush = () => Promise.resolve();
 
 const random = (max) => Math.round(Math.random() * 1000) % max;
 
@@ -320,9 +315,9 @@ const Jumbotron = memo(
 
 const Main = () => {
 	const [{ data, selected }, rawDispatch] = useReducer(listReducer, initialState);
-	// Commit synchronously inside the click so the sync-timed harness captures the
-	// real render (see the note up top). Stable identity keeps the memo'd children.
-	const dispatch = useCallback((action) => flushSync(() => rawDispatch(action)), []);
+	// Stable identity keeps the memo'd children; the harness awaits the queued
+	// commit after each click (see the note up top).
+	const dispatch = useCallback((action) => rawDispatch(action), []);
 	return (
 		<div className="container">
 			<Jumbotron dispatch={dispatch} />

--- a/benchmarks/memo-wall/preact/src/main.jsx
+++ b/benchmarks/memo-wall/preact/src/main.jsx
@@ -1,7 +1,6 @@
 // Probes must exist before any component renders.
 import './probes.js';
 import { createElement, render } from 'preact';
-import { flushSync } from 'preact/compat';
 import App from './App.jsx';
 import {
 	ctxA,
@@ -16,17 +15,21 @@ import {
 const target = document.getElementById('main');
 if (!target) throw new Error('missing #main root');
 let mounted = false;
+const update = (run) => {
+	run();
+	return Promise.resolve();
+};
 
 window.__mount = () => {
-	flushSync(() => render(createElement(App), target));
+	render(createElement(App), target);
 	mounted = true;
 };
-window.__tickA = () => flushSync(parentRerenderA);
-window.__tickB = () => flushSync(parentRerenderB);
-window.__oneChangeA = () => flushSync(oneChangeA);
-window.__oneChangeB = () => flushSync(oneChangeB);
-window.__ctxA = () => flushSync(ctxA);
-window.__ctxB = () => flushSync(ctxB);
+window.__tickA = () => update(parentRerenderA);
+window.__tickB = () => update(parentRerenderB);
+window.__oneChangeA = () => update(oneChangeA);
+window.__oneChangeB = () => update(oneChangeB);
+window.__ctxA = () => update(ctxA);
+window.__ctxB = () => update(ctxB);
 window.__state = currentState;
 window.__unmount = () => {
 	if (mounted) {

--- a/benchmarks/memo-wall/run.mjs
+++ b/benchmarks/memo-wall/run.mjs
@@ -24,7 +24,7 @@
 //
 // Methodology mirrors the sibling benches: ops commit inside the timed hook —
 // synchronously where the framework allows it (react flushSync, solid flush());
-// vue-vapor's hooks return a nextTick() thenable the harness awaits inside the
+// Preact and vue-vapor hooks return a thenable the harness awaits inside the
 // timed window — gc() is forced before every timed sample, and sub-millisecond
 // ops loop enough invocations inside the timed window to keep newly auto-memoized
 // regions above performance.now()'s resolution before dividing by the rep count.
@@ -191,9 +191,8 @@ async function measureLoop(browser, url, op) {
 			const gc = window.gc || (() => {});
 			const runBatch = async (count) => {
 				const t0 = performance.now();
-				// Async-commit targets (vue-vapor — hooks return a nextTick()
-				// thenable; see its main.js) await the flush BETWEEN reps so the
-				// reps don't coalesce into one commit; sync targets are unchanged.
+				// Async-commit targets (Preact and vue-vapor) await the flush BETWEEN
+				// reps so they don't coalesce into one commit; sync targets are unchanged.
 				for (let k = 0; k < count; k++) {
 					const r = fn();
 					if (r && typeof r.then === 'function') await r;

--- a/benchmarks/news/preact/src/entry-client.jsx
+++ b/benchmarks/news/preact/src/entry-client.jsx
@@ -1,9 +1,8 @@
 import { hydrate } from 'preact';
-import { flushSync } from 'preact/compat';
 import { App } from './App.jsx';
 
 const container = document.getElementById('app');
 if (!container) throw new Error('Missing #app root in index.html');
 
-window.__hydrate = () => flushSync(() => hydrate(<App />, container));
+window.__hydrate = () => hydrate(<App />, container);
 window.__ready = true;

--- a/benchmarks/news/preact/src/hydration-interactivity/hydration-client.ts
+++ b/benchmarks/news/preact/src/hydration-interactivity/hydration-client.ts
@@ -1,5 +1,4 @@
 import { createElement, hydrate } from 'preact';
-import { flushSync } from 'preact/compat';
 import { completeHydration, hydrationProps } from '../../../../hydration-interactivity/shared.js';
 import { App } from './App.jsx';
 
@@ -7,7 +6,5 @@ export function hydrateBenchmark() {
 	const container = document.getElementById('app');
 	if (!container) throw new Error('Missing hydration benchmark root');
 
-	return completeHydration(() =>
-		flushSync(() => hydrate(createElement(App, hydrationProps()), container)),
-	);
+	return completeHydration(() => hydrate(createElement(App, hydrationProps()), container));
 }

--- a/benchmarks/news/preact/src/runtime-stress/entry.jsx
+++ b/benchmarks/news/preact/src/runtime-stress/entry.jsx
@@ -1,5 +1,4 @@
 import { createElement, render } from 'preact';
-import { flushSync } from 'preact/compat';
 import { installRuntimeStress } from '../../../../runtime-stress/shared.js';
 import { App } from './App.jsx';
 
@@ -7,5 +6,5 @@ const container = document.getElementById('app');
 if (!container) throw new Error('Missing runtime stress benchmark root');
 
 const stress = installRuntimeStress();
-flushSync(() => render(createElement(App), container));
+render(createElement(App), container);
 stress.ready = true;

--- a/benchmarks/news/preact/src/store-selector-fanout/entry.jsx
+++ b/benchmarks/news/preact/src/store-selector-fanout/entry.jsx
@@ -1,5 +1,4 @@
 import { createElement, render } from 'preact';
-import { flushSync } from 'preact/compat';
 import { installStoreSelectorStress } from '../../../../store-selector-fanout/shared.js';
 import { App } from './App.jsx';
 
@@ -7,6 +6,9 @@ const container = document.getElementById('app');
 if (!container) throw new Error('Missing store selector benchmark root');
 
 const stress = installStoreSelectorStress();
-stress.flush = (run) => flushSync(run);
-flushSync(() => render(createElement(App), container));
+stress.flush = (run) => {
+	run();
+	return Promise.resolve();
+};
+render(createElement(App), container);
 stress.ready = true;

--- a/benchmarks/portal-swarm/preact/src/main.jsx
+++ b/benchmarks/portal-swarm/preact/src/main.jsx
@@ -1,40 +1,42 @@
 import { createElement, render } from 'preact';
-import { flushSync } from 'preact/compat';
 import App from './App.jsx';
 import * as ops from './ops.js';
 
 const target = document.getElementById('main');
 if (!target) throw new Error('missing #main root');
 let mounted = false;
-
+const update = (run) => {
+	run();
+	return Promise.resolve();
+};
 window.__hits = 0;
 window.__mount = () => {
-	flushSync(() => render(createElement(App), target));
+	render(createElement(App), target);
 	mounted = true;
 };
 window.__unmount = () => {
 	if (mounted) {
-		flushSync(() => render(null, target));
+		render(null, target);
 		mounted = false;
 	}
 };
 window.__reset = () => {
 	if (mounted) {
-		flushSync(() => render(null, target));
+		render(null, target);
 		mounted = false;
 	}
 	while (target.firstChild) target.removeChild(target.firstChild);
 };
-window.__openA = () => flushSync(ops.openA);
-window.__closeA = () => flushSync(ops.closeA);
-window.__openB = () => flushSync(ops.openB);
-window.__closeB = () => flushSync(ops.closeB);
-window.__openBS = () => flushSync(ops.openBS);
-window.__closeBS = () => flushSync(ops.closeBS);
-window.__openAll = () => flushSync(ops.openAll);
-window.__closeAll = () => flushSync(ops.closeAll);
-window.__rerenderA = () => flushSync(ops.rerenderA);
-window.__rerenderB = () => flushSync(ops.rerenderB);
-window.__rerenderBS = () => flushSync(ops.rerenderBS);
-window.__setDistinct = (on) => flushSync(() => ops.setDistinct(on));
+window.__openA = () => update(ops.openA);
+window.__closeA = () => update(ops.closeA);
+window.__openB = () => update(ops.openB);
+window.__closeB = () => update(ops.closeB);
+window.__openBS = () => update(ops.openBS);
+window.__closeBS = () => update(ops.closeBS);
+window.__openAll = () => update(ops.openAll);
+window.__closeAll = () => update(ops.closeAll);
+window.__rerenderA = () => update(ops.rerenderA);
+window.__rerenderB = () => update(ops.rerenderB);
+window.__rerenderBS = () => update(ops.rerenderBS);
+window.__setDistinct = (on) => update(() => ops.setDistinct(on));
 window.__ready = true;

--- a/benchmarks/portal-swarm/run.mjs
+++ b/benchmarks/portal-swarm/run.mjs
@@ -219,8 +219,8 @@ async function verifyTarget(browser, url) {
 
 // MOUNT — fresh page per sample (quiescent start); time __mount() with a
 // freshly-collected heap. All portals closed. An adapter whose commit is
-// scheduler-deferred returns a thenable (vue-vapor's update ops do — see its
-// main.js); every timed window below extends until it settles, so the
+// scheduler-deferred returns a thenable (Preact and vue-vapor do); every timed
+// window below extends until it settles, so the
 // scheduling cost stays inside the measurement.
 async function measureMountClosed(browser, url) {
 	const samples = [];

--- a/benchmarks/recursive-context/preact/src/main.jsx
+++ b/benchmarks/recursive-context/preact/src/main.jsx
@@ -1,27 +1,30 @@
 import { createElement, render } from 'preact';
-import { flushSync } from 'preact/compat';
 import App, { bumpPartial, bumpRoot, hideMid, showMid } from './App.jsx';
 
 const target = document.getElementById('main');
 let mounted = false;
+const update = (run) => {
+	run();
+	return Promise.resolve();
+};
 
 window.__mount = () => {
-	flushSync(() => render(createElement(App, { depth: 10 }), target));
+	render(createElement(App, { depth: 10 }), target);
 	mounted = true;
 };
-window.__updateRoot = () => flushSync(bumpRoot);
-window.__updatePartial = () => flushSync(bumpPartial);
-window.__partialUnmount = () => flushSync(hideMid);
-window.__partialRemount = () => flushSync(showMid);
+window.__updateRoot = () => update(bumpRoot);
+window.__updatePartial = () => update(bumpPartial);
+window.__partialUnmount = () => update(hideMid);
+window.__partialRemount = () => update(showMid);
 window.__unmount = () => {
 	if (mounted) {
-		flushSync(() => render(null, target));
+		render(null, target);
 		mounted = false;
 	}
 };
 window.__reset = () => {
 	if (mounted) {
-		flushSync(() => render(null, target));
+		render(null, target);
 		mounted = false;
 	}
 	while (target.firstChild) target.removeChild(target.firstChild);

--- a/benchmarks/recursive-context/run.mjs
+++ b/benchmarks/recursive-context/run.mjs
@@ -4,8 +4,8 @@
 // Methodology: every op (mount, update_root, update_partial, partial_unmount /
 // remount, unmount) mutates the DOM inside its adapter call — synchronously
 // where the framework allows it (ripple / octane / react via `flushSync`,
-// solid via `flush()`); an adapter with no public sync flush (vue-vapor)
-// returns a thenable (nextTick(), settling after Vue's flushJobs) and the
+// solid via `flush()`); native async adapters (Preact and vue-vapor) return a
+// thenable settling after their queued update and the
 // timed window extends until it settles. Either way we time ONLY the op (the
 // framework's JS work) and force a GC right before each timed sample, so a
 // surprise mid-sample collection can't inflate it. This isolates framework

--- a/benchmarks/signal-favoring/preact/src/main.jsx
+++ b/benchmarks/signal-favoring/preact/src/main.jsx
@@ -1,5 +1,4 @@
 import { createElement, render } from 'preact';
-import { flushSync } from 'preact/compat';
 import App, {
 	bumpAt1,
 	bumpAt11,
@@ -15,20 +14,24 @@ import App, {
 
 const target = document.getElementById('main');
 let mounted = false;
+const update = (run) => {
+	run();
+	return Promise.resolve();
+};
 
 window.__mount = () => {
-	flushSync(() => render(createElement(App), target));
+	render(createElement(App), target);
 	mounted = true;
 };
 window.__unmount = () => {
 	if (mounted) {
-		flushSync(() => render(null, target));
+		render(null, target);
 		mounted = false;
 	}
 };
 window.__reset = () => {
 	if (mounted) {
-		flushSync(() => render(null, target));
+		render(null, target);
 		mounted = false;
 	}
 	while (target.firstChild) target.removeChild(target.firstChild);
@@ -58,14 +61,14 @@ for (const [index, bump] of [
 	[81, bumpAt81],
 	[91, bumpAt91],
 ]) {
-	window['__bumpAt' + index] = () => flushSync(bump);
+	window['__bumpAt' + index] = () => update(bump);
 }
 window.__sweepBatched = () =>
-	flushSync(() => {
+	update(() => {
 		for (const bump of bumps) bump();
 	});
 window.__sweepBatchedReverse = () =>
-	flushSync(() => {
+	update(() => {
 		for (let i = bumps.length - 1; i >= 0; i--) bumps[i]();
 	});
 window.__ready = true;

--- a/benchmarks/signal-favoring/run.mjs
+++ b/benchmarks/signal-favoring/run.mjs
@@ -58,8 +58,8 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 // All ops mutate the DOM inside the adapter call — synchronously where the
 // framework allows it (ripple / octane / react via flushSync, solid via
-// flush()); an adapter with no public sync flush (vue-vapor) returns a
-// thenable (nextTick(), settling after Vue's flushJobs) and the timed window
+// flush()); native async adapters (Preact and vue-vapor) return a thenable after
+// their queued DOM update, and the timed window
 // extends until it settles — awaited BETWEEN reps so bumps can't coalesce
 // into one commit. Either way we time ONLY the framework's work and force a
 // GC right before each timed sample. This isolates framework JS work from
@@ -286,7 +286,7 @@ async function measureSweep(browser, url, batchFn) {
 						for (const idx of indices) {
 							const fn = window['__bumpAt' + idx];
 							if (typeof fn !== 'function') throw new Error('missing __bumpAt' + idx);
-							// An async-commit bump (vue-vapor) is awaited per change —
+							// An async-commit bump (Preact/vue-vapor) is awaited per change —
 							// that IS the "flush on every change" mode for a microtask
 							// scheduler (each await lets flushJobs run before the next).
 							const r = fn();

--- a/benchmarks/store-selector-fanout/shared.js
+++ b/benchmarks/store-selector-fanout/shared.js
@@ -68,9 +68,9 @@ export function installStoreSelectorStress() {
 		unsubscribeCalls: 0,
 	};
 	const state = {
-		// Per-target synchronous flush, installed by each fixture entry so the
+		// Per-target commit boundary, installed by each fixture entry so the
 		// harness can drive N discrete parent renders without a Playwright round
-		// trip or a timer floor per render.
+		// trip or a timer floor per render. Async schedulers return a thenable.
 		flush: (run) => run(),
 		ready: false,
 		stats,

--- a/benchmarks/todomvc/README.md
+++ b/benchmarks/todomvc/README.md
@@ -20,7 +20,7 @@ comparison: the `bundle-size` suite builds these apps too (ops prefixed
 | `solid`       | 5242 | Solid 2.0-beta; `flush()` per handler; class STRINGS (beta `classList` is inert) |
 | `ripple`      | 5243 | deriveds are FUNCTIONS called in template expressions (fine-grained: the body runs once — a setup-time `const` freezes) |
 | `vue-vapor`   | 5244 | Vapor SFC; `window.__benchFlush = () => nextTick()` (no public sync flush) |
-| `preact`      | 5261 | Preact core/hooks; `flushSync` commits each handler inside the timed window |
+| `preact`      | 5261 | Preact core/hooks; native microtask commits are awaited inside the timed window |
 | `svelte`      | 5272 | Svelte 5 runes; `flushSync` commits each handler inside the timed window |
 
 ## DOM contract (shared by every app)

--- a/benchmarks/todomvc/preact/src/main.jsx
+++ b/benchmarks/todomvc/preact/src/main.jsx
@@ -1,10 +1,9 @@
 import { render } from 'preact';
 import { useCallback, useState } from 'preact/hooks';
-import { flushSync } from 'preact/compat';
 
-// Native Preact TodoMVC fixture. State and hooks come from Preact directly;
-// compat is used only for its public synchronous flush so the timed event
-// window includes the DOM commit, matching the sibling adapters.
+// Preact queues hook updates in a microtask. The harness awaits this after each
+// interaction so native scheduling and the DOM commit stay timed.
+window.__benchFlush = () => Promise.resolve();
 
 let nextId = 1;
 
@@ -18,44 +17,37 @@ function TodoApp() {
 		const input = e.currentTarget;
 		const title = input.value.trim();
 		if (title === '') return;
-		flushSync(() => setTodos((items) => [...items, { id: nextId++, title, completed: false }]));
+		setTodos((items) => [...items, { id: nextId++, title, completed: false }]);
 		input.value = '';
 	}, []);
 	const toggle = (id) =>
-		flushSync(() =>
-			setTodos((items) =>
-				items.map((item) => (item.id === id ? { ...item, completed: !item.completed } : item)),
-			),
+		setTodos((items) =>
+			items.map((item) => (item.id === id ? { ...item, completed: !item.completed } : item)),
 		);
-	const destroy = (id) =>
-		flushSync(() => setTodos((items) => items.filter((item) => item.id !== id)));
+	const destroy = (id) => setTodos((items) => items.filter((item) => item.id !== id));
 	const toggleAll = (e) => {
 		const completed = e.currentTarget.checked;
-		flushSync(() =>
-			setTodos((items) =>
-				items.map((item) => (item.completed === completed ? item : { ...item, completed })),
-			),
+		setTodos((items) =>
+			items.map((item) => (item.completed === completed ? item : { ...item, completed })),
 		);
 	};
 	const clearCompleted = useCallback(
-		() => flushSync(() => setTodos((items) => items.filter((item) => !item.completed))),
+		() => setTodos((items) => items.filter((item) => !item.completed)),
 		[],
 	);
-	const startEdit = (id) => flushSync(() => setEditing(id));
+	const startEdit = (id) => setEditing(id);
 	const commitEdit = (id, e) => {
 		const title = e.currentTarget.value.trim();
-		flushSync(() => {
-			setTodos((items) =>
-				title === ''
-					? items.filter((item) => item.id !== id)
-					: items.map((item) => (item.id === id ? { ...item, title } : item)),
-			);
-			setEditing(null);
-		});
+		setTodos((items) =>
+			title === ''
+				? items.filter((item) => item.id !== id)
+				: items.map((item) => (item.id === id ? { ...item, title } : item)),
+		);
+		setEditing(null);
 	};
 	const editKeyDown = (id, e) => {
 		if (e.key === 'Enter') commitEdit(id, e);
-		else if (e.key === 'Escape') flushSync(() => setEditing(null));
+		else if (e.key === 'Escape') setEditing(null);
 	};
 
 	const visible =
@@ -124,7 +116,7 @@ function TodoApp() {
 									<a
 										class={filter === name ? 'selected' : ''}
 										data-filter={name}
-										onClick={() => flushSync(() => setFilter(name))}
+										onClick={() => setFilter(name)}
 									>
 										{name[0].toUpperCase() + name.slice(1)}
 									</a>

--- a/benchmarks/todomvc/run.mjs
+++ b/benchmarks/todomvc/run.mjs
@@ -9,12 +9,11 @@
 // Timing protocol (shared with ../js-framework/run.mjs): interactions run
 // inside one page.evaluate, `performance.now()` around the batch. Frameworks
 // that commit synchronously on the dispatched event (octane native flush,
-// react/preact/ripple/Svelte flushSync in handlers, solid flush()) are fully
-// measured by the synchronous window; vue-vapor exposes
-// `window.__benchFlush = () => nextTick()`
-// and the loop awaits it after EACH interaction — one scheduler flush per
-// user action, matching how real input arrives (discrete tasks), with Vue's
-// own scheduling cost inside the measurement.
+// react/ripple/Svelte flushSync in handlers, solid flush()) are fully measured
+// by the synchronous window; Preact and vue-vapor expose
+// `window.__benchFlush` and the loop awaits it after EACH interaction — one
+// scheduler flush per user action, matching how real input arrives (discrete
+// tasks), with each framework's own scheduling cost inside the measurement.
 //
 // The `.new-todo` / `.edit` inputs are uncontrolled in every app: the driver
 // sets `input.value` directly and dispatches `keydown` (Enter/Escape) — the


### PR DESCRIPTION
## Summary

Make the Preact benchmark fixtures use Preact's native scheduler instead of importing `preact/compat` solely for `flushSync`.

Compat remains where the workload actually requires APIs that Preact core does not expose, including `memo`, `Suspense`, `startTransition`, `useSyncExternalStore`, and `createPortal`.

## Why

The Preact columns are intended to represent native Preact, but `flushSync` changes the runtime being measured. Its compat implementation temporarily replaces `options.debounceRendering` with an immediate callback. That forces synchronous rendering and can prevent updates that Preact normally schedules together from batching.

Importing compat also installs React-compatibility behavior globally and adds compat code to fixtures that otherwise use only `preact` and `preact/hooks`. This makes those columns larger and changes their runtime profile before the benchmark begins.

Preact's core `render()` and `hydrate()` already commit synchronously, so wrapping them in `flushSync` is unnecessary. Hook updates use Preact's resolved-Promise render queue. The benchmark harnesses already support asynchronous commit boundaries, so they can await a resolved promise after scheduling each update. This keeps Preact's scheduling hop and DOM commit inside the measured interval without forcing React-style scheduling.

The await remains per benchmark operation rather than once after a loop, preventing multiple intended commits from being accidentally coalesced.

## Changes

- Call native `render()` and `hydrate()` directly.
- Replace `flushSync`-wrapped state updates with native updates followed by an awaited Preact commit boundary.
- Preserve one commit per scripted interaction where the workload requires it.
- Retain compat imports only for APIs that are part of the benchmarked workload.
- Update benchmark documentation to describe the native Preact scheduling model.

## AI disclosure

This change, its source audit, and this pull request description were authored with AI assistance through Hermes Agent using OpenAI Codex, under Jovi De Croock's direction.
