### PR TITLE
docs: make React differences example-first

### DIFF
--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -4,38 +4,82 @@ Octane implements React's programming model — the same hooks, `memo`, context,
 portals, Suspense, transitions, actions, and SSR/streaming APIs. Its core suite
 contains 3,900+ distinct behavioral tests; production-compiler executions rerun
 the normal cases and are not additional unique coverage. That is a local suite
-count, not a count of tests ported from React. The exact pinned snapshot and
-source-attributed React scenarios, classifications, and coverage are tracked in the generated
-[React parity coverage report](./react-parity-coverage.md).
+count, not a count of tests ported from React. The exact pinned snapshot,
+source-attributed React scenarios, classifications, and coverage are tracked in
+the generated [React parity coverage report](./react-parity-coverage.md).
 
 The differences below are **deliberate**; parity outside them is the goal.
+Examples omit routine imports and types unless they affect the behavior being
+shown.
 
 ## No rules of hooks (except plain JS loops)
 
-Hooks are tracked by compiler-assigned call-site slot, not call order. A hook
-may sit behind a condition or after an early return. The one exception is a
-plain JS loop: a slot-keyed hook inside `for`/`while` is a **compile error**,
-because every iteration would share the one call-site slot and its
-state/memo/effect entries would silently collide. Loop with the keyed `@for`
-template directive or extract a child component instead — each item then
-renders in its own scope. `use()` and `useContext` are exempt (they are
-call-order / context-identity keyed, not slot-keyed), so they may sit in plain
-loops.
+Hooks may sit behind a condition or after an early return:
+
+```tsx
+// React: hook order cannot change after a conditional return.
+// Octane: every hook call site owns its own stable slot.
+function Editor({ editable, initialValue }) {
+  if (!editable) return <ReadOnly />;
+
+  const [draft, setDraft] = useState(initialValue);
+  return (
+    <input
+      value={draft}
+      onInput={(event) => setDraft(event.currentTarget.value)}
+    />
+  );
+}
+```
+
+This is valid in Octane because the compiler assigns each hook call site a
+stable slot; hooks are not identified by call order.
+
+A plain JavaScript loop is the exception:
+
+```tsx
+for (const item of items) {
+  useState(false); // Compile error: every iteration would share one slot.
+}
+
+@for (const item of items; key item.id) {
+  const [open, setOpen] = useState(false); // Separate state for each key.
+  <Row item={item} open={open} onToggle={() => setOpen(!open)} />
+}
+```
+
+Use a keyed `@for` template directive or extract a child component so every item
+has its own render scope. `use()` and `useContext` are exempt from the loop
+restriction because they are keyed by call order and context identity,
+respectively.
 
 ## Compiler-inferred hook dependencies
 
 Dependency arrays are optional for `useEffect`, `useLayoutEffect`,
-`useInsertionEffect`, `useMemo`, `useCallback`, and `useImperativeHandle`.
-Omitting the list asks the compiler to derive it from the callback's lexical
-captures. The analysis tracks one-level member paths and omits values whose
-identity Octane can prove stable, including state setters, reducer dispatchers,
-refs, and state getters. It also omits `useEffectEvent` results because Effect
-Events are non-reactive captures, despite their intentionally fresh wrapper
-identity.
+`useInsertionEffect`, `useMemo`, `useCallback`, and `useImperativeHandle`:
 
-This inference applies to a supported built-in hook wherever Octane processes
-its call, including inside a custom hook authored in `.tsrx`, `.tsx`, or a plain
-`.ts`/`.js` module. For example, a custom hook in plain TypeScript can omit both
+```tsx
+import { save } from './api';
+
+useEffect(() => save(order.id)); // Inferred: [order.id]
+useEffect(() => save(order.id), [order]); // Exactly [order]
+useEffect(() => save(order.id), []); // Exactly []; never rewritten
+useEffect(() => save(order.id), null); // Run after every render
+
+useEffect(makeEffect()); // Compile error: pass an array or null
+```
+
+Omitting the argument asks the compiler to derive it from the callback's lexical
+captures. An explicit array is authoritative and keeps React's exact behavior;
+`null` opts out of tracking. Opaque callback creation such as
+`useEffect(makeEffect())` needs an explicit array or `null`, because evaluating
+it again to discover dependencies would change program behavior.
+
+### Direct built-in hook calls
+
+Inference applies wherever Octane processes a supported built-in hook call,
+including inside a custom hook authored in `.tsrx`, `.tsx`, or plain
+`.ts`/`.js`. For example, a custom hook in plain TypeScript can omit both
 dependency arrays:
 
 ```ts
@@ -52,74 +96,77 @@ export function useLoggedValue(value: string, log: (value: string) => void) {
 }
 ```
 
-The memo captures `value`, and the effect captures `formatted` and `log`.
-Changing `value` recomputes the memo; if the resulting `formatted` value changes,
-the effect reruns with the updated result. Changing `log` also reruns the
-effect. The custom hook's caller does not need to supply a dependency array.
+The memo tracks `value`; the effect tracks `formatted` and `log`. The custom
+hook's caller supplies no dependency array.
 
-A dependency array tracks what can change *between renders*, so a binding that
-is evaluated once for the program's lifetime is not a dependency. Alongside
-imports, the compiler omits module-scope `const` declarations and module-scope
-`function` and `class` declarations that nothing reassigns — the same values
-React's `exhaustive-deps` rule never asks you to list, because they are outside
-the component. This applies to a member read through one of them
-(`CONFIG.mode`), exactly as it already did for a namespace import, so a
-module-level object mutated in place is not witnessed by a dependency array;
-hold such state in a store or in state, not a module singleton. Module-scope
-`let` and `var` stay tracked: any later statement may rebind them. A local
-`const` that only names one of these values, or that binds a literal, is
-likewise omitted — naming a fixed value does not make it reactive.
+The analysis tracks one-level member paths and distinguishes values that can
+change between renders:
 
-Inferring an omitted dependency argument at a **call to a custom wrapper** is a
-separate, narrower operation. The full `.tsrx`/`.tsx` compiler can infer that
-argument only when a locally declared custom hook transparently forwards its
-callback and final dependency parameter to a supported built-in hook. Nested
-transparent wrappers can also be followed within the same module.
+| Capture | Inferred behavior |
+| --- | --- |
+| Other component-local values and module-scope `let`/`var` | Tracked |
+| State setters, reducer dispatchers, refs, and state getters | Omitted as stable |
+| `useEffectEvent` results | Omitted because Effect Events are non-reactive |
+| Imports and unreassigned module-scope `const`/`function`/`class` | Omitted as program-lifetime identities |
+| A local `const` naming one of those stable values, or a literal | Omitted |
 
-The surgical pass for plain `.ts`/`.js` modules still infers direct built-in
-hook calls, including those inside custom hooks, but it does not infer or append
-dependency arguments at calls to custom wrappers. Imported wrappers,
-method-style wrappers, and wrappers that transform or inspect their callback or
-dependency parameter also require an explicit dependency argument. The compiler
-does not guess a wrapper's contract from its `use*` name.
+A member read through a stable module binding, such as `CONFIG.mode`, is also
+omitted. Mutating such an object in place is therefore not witnessed by a
+dependency array; state that should drive rendering belongs in state, context,
+or a store rather than a module singleton.
 
-An explicit array, including `[]`, is authoritative and retains React's exact
-behavior. Pass `null` to opt out of tracking and run an effect—or recompute a
-memo—after every render. Opaque callback creation such as
-`useEffect(makeEffect())` requires an explicit array or `null`, because
-evaluating it again to construct a dependency would change program behavior.
+### Calls to custom wrappers
+
+Inferring a missing dependency argument at a **call to a custom wrapper** is a
+separate, narrower operation:
+
+```tsx
+function useTrackedEffect(effect, dependencies) {
+  useEffect(effect, dependencies);
+}
+
+useTrackedEffect(() => save(order.id)); // Local transparent wrapper: inferred.
+importedTrackedEffect(() => save(order.id), [order.id]); // Explicit array.
+```
+
+| Wrapper call | Dependency argument |
+| --- | --- |
+| Local transparent wrapper in `.tsrx`/`.tsx` | Inferred |
+| Nested transparent wrappers in the same module | Inferred |
+| Wrapper call in plain `.ts`/`.js` | Required explicitly |
+| Imported or method-style wrapper | Required explicitly |
+| Wrapper that inspects or transforms its callback/dependencies | Required explicitly |
+
+A transparent wrapper forwards its callback and final dependency parameter to a
+supported built-in hook. The compiler does not infer that contract from a
+`use*` name alone. Plain `.ts`/`.js` compilation still infers direct built-in
+hook calls inside a custom hook; it only declines to modify calls to wrappers.
 
 ## Automatic memoization and calls in templates
 
-Production builds memoize component regions automatically, on the same
-pure-render, immutable-snapshot contract React Compiler assumes. Rendering a
-value through a function call keeps the surrounding region memoizable when the
-callee is a **module-scope immutable identity**:
+Production builds automatically memoize component regions under the same
+pure-render, immutable-snapshot contract assumed by React Compiler:
 
-- an imported binding — `{formatPrice(cents)}`, `{t('total')}`,
-  `{segText(seg, done)}`;
-- a same-module `function` declaration that is never reassigned, and whose own
-  body is itself a value projection.
+```tsx
+{formatPrice(cents)} // May memoize: formatPrice is imported.
+{formatLabel(row)} // May memoize: same-module immutable projection.
 
-Anything else keeps the region unmemoized, and the region simply re-runs — the
-same result React gives an unmemoized component:
+{row.getValue()} // Re-runs: member call.
+{format(row.get())} // Re-runs: an argument contains a member call.
+{localFormat(row)} // Re-runs: component-local callee.
+{use(resource)} // Re-runs: hook and suspension point.
+```
 
-- **A method on your data.** `{header.getIsSorted()}` can return a new answer
-  while `header` stays the same object, so neither the value nor any dependency
-  witnesses the change. Library bindings that expose table/grid/store instances
-  with live accessor methods keep working unchanged, and so does a module helper
-  that merely wraps one (`function sortIcon(h) { return h.getIsSorted(); }` is
-  the same hazard one call frame away, and is rejected for the same reason).
-- **A component-local callee.** `const read = (h) => h.getIsSorted()` is an
-  identifier, but nothing pins it to an immutable module identity, so it cannot
-  stand in for a projection even when something hands it a stable reference.
-- **Hooks.** `use()` is a suspension point, and `use*` calls (including React's
-  `unstable_use*` staging prefix) own hook cells, context subscriptions, and
-  effect lifecycles, so a region containing one is always re-entered.
-- **`new Foo()` and tagged templates.** Construction is not a value projection.
+A call keeps its surrounding region memoizable only when the callee is an
+imported binding or an unreassigned same-module function whose body is itself a
+value projection. Arguments must satisfy the same rule.
 
-Arguments carry the same contract as the call itself: `{format(row.get())}` is
-rejected even though `format` qualifies.
+Member calls fail closed because the receiver may be a live object:
+`header.getIsSorted()` can return a new answer while `header` retains the same
+identity. A module helper that merely wraps that method has the same hazard and
+does not qualify. Component-local callees, hooks (including `unstable_use*`),
+`new Foo()`, and tagged templates also keep their region unmemoized. This
+changes only the optimization—the region safely re-runs.
 
 A region *is* allowed to memoize past a mutable module-level variable, whether
 read directly or returned by an imported helper; module state that must drive
@@ -130,32 +177,22 @@ assumption.
 
 ## Derived values are cached at their declaration
 
-A `const` whose initializer performs a call during render is cached on the
-component locals it reads — provided every one of those calls is a value
-projection by the rule above:
-
 ```tsx
-const labels = formatRows(rows); // formatRows is imported → cached on [rows]
+const labels = formatRows(rows); // Cached on [rows]: imported projection.
+const items = virtualizer.getVirtualItems(); // Not cached: member call.
+const visible = todos.filter((todo) => !todo.completed); // Not cached.
+let freshLabels = formatRows(rows); // Not cached: `let` is an escape hatch.
 ```
 
-`labels` keeps the same array identity until `rows` changes. This is what makes
-the region memoization above worth having: a region keys on the identity of what
-it renders, so a derived value rebuilt on every render defeats its cache
-unconditionally.
+An eligible `const` keeps the same identity until its tracked component-local
+inputs change. This lets a region key on the identity of a derived value instead
+of seeing a new array or object on every render.
 
-The callee rule is the same one regions use, and for the same reason. A member
-call is not cached even when its result is named:
-
-```tsx
-const items = virtualizer.getVirtualItems(); // NOT cached
-const visible = todos.filter((t) => !t.completed); // NOT cached
-```
-
-The first is the receiver hazard exactly: the window moves with scroll while the
-virtualizer instance stays put, so a cache keyed on it would freeze a
-virtualized list mid-scroll. The second is a genuine miss — `todos` really is an
-immutable snapshot — but this analysis cannot yet tell the two apart, so it fails
-closed on both. Wrap it in `useMemo` yourself when the identity matters.
+The same callee rule governs declaration caching. The virtualizer call must stay
+live because its window can move while the virtualizer object keeps the same
+identity. The `filter` call is a genuine optimization miss—the compiler cannot
+yet distinguish it from the live-object case—so both fail closed. Use an
+explicit `useMemo` when the identity matters.
 
 Also never cached:
 
@@ -163,8 +200,6 @@ Also never cached:
   keep their hook cells and subscriptions. Hooks are recognised by naming
   convention — the same signal React and React Compiler use — so a hook named
   outside that convention is the one shape this cannot protect.
-- **`let` declarations.** Reassignment would be dropped, so `let` is left alone.
-  It doubles as the escape hatch when you want a value recomputed every render.
 - **Values the render tree never reads.** A calculation used only by an event
   handler pays nothing.
 
@@ -175,10 +210,25 @@ witnesses keeps its old value. Pass such state through
 
 ## `useState` / `useReducer` current-state getters
 
-Both state hooks have an Octane-only third tuple member: a stable zero-argument
-function that reads the hook's latest state (`const [state, update, getState] =
-useState(initial)`). This replaces the common React pattern of synchronizing a
-ref solely so delayed or async callbacks can avoid a stale render closure.
+Both state hooks have an Octane-only third tuple member:
+
+```tsx
+const [draft, setDraft, getDraft] = useState('');
+const [total, dispatch, getTotal] = useReducer(reducer, 0);
+
+async function saveLater() {
+  await readyToSave();
+  save(getDraft()); // Latest scheduled state, not this render's stale value.
+}
+
+function add(amount) {
+  dispatch(amount);
+  console.log(getTotal()); // Latest scheduled reducer state.
+}
+```
+
+The stable zero-argument getter replaces the common React pattern of
+synchronizing a ref solely for delayed or async callbacks.
 
 The getter reads the latest scheduled hook-cell value and does not subscribe or
 render. During pending work it can therefore be newer than the currently
@@ -195,6 +245,14 @@ and native non-bubbling families (`toggle`, dialog `close`/`cancel`, media,
 `load`/`error`) all reach the same logical ancestors React does.
 
 What differs is the event API and synthesis layer:
+
+```tsx
+<button
+  onClick={(event) => {
+    console.log(event instanceof MouseEvent); // true
+  }}
+/>
+```
 
 - Handlers receive the browser's real `Event` object, not a React
   `SyntheticEvent` wrapper. There is no event pooling, and
@@ -229,18 +287,17 @@ of React-style text editing is a rename:
 <input value={text} onInput={(e) => setText(e.target.value)} /> // Octane
 ```
 
-The compiler warning `OCTANE_NATIVE_TEXT_ONCHANGE` points to `onChange` or
-`onChangeCapture` on statically known text-entry hosts when no usable input handler
-is present. It covers `<textarea>` and `<input>` with a missing/invalid type or the
-`text`, `search`, `url`, `tel`, `password`, `email`, or `number` types. A development
-runtime fallback checks final props for unresolved spreads, dynamic host/type values,
-and de-optimized `createElement` paths. It is nonfatal and never changes which event
-runs. `select`, checkbox/radio/file and other non-text input types, custom elements,
-and component callbacks named `onChange` are not warned. Bubble and capture phases
-are treated symmetrically (`onChangeCapture` suggests `onInputCapture`).
+`OCTANE_NATIVE_TEXT_ONCHANGE` warns when a statically known text-entry host has
+`onChange`/`onChangeCapture` but no usable input handler. It covers `<textarea>`
+and `<input>` with a missing or invalid type, or a `text`, `search`, `url`, `tel`,
+`password`, `email`, or `number` type. A development fallback handles unresolved
+spreads, dynamic host/type values, and de-optimized `createElement` calls. It is
+nonfatal and never changes which event runs. Selects, checkboxes, radios, file
+inputs, custom elements, and component callbacks named `onChange` are not
+warned. Capture handlers receive the corresponding `onInputCapture` guidance.
 
-Native commit behavior is sometimes exactly the intent. Use an uncontrolled value
-and the explicit JS-only suppression in that case:
+Native commit behavior is sometimes exactly the intent. Use an uncontrolled
+value and the explicit JS-only suppression in that case:
 
 ```jsx
 <input
@@ -250,17 +307,23 @@ and the explicit JS-only suppression in that case:
 />
 ```
 
-`suppressNativeChangeWarning` only suppresses this diagnostic. It does not serialize
-to HTML, rename an event, add a listener, or alter controlled-state restoration. Do
-not add a noop `onInput` merely to silence the warning.
+`suppressNativeChangeWarning` only suppresses this diagnostic. It does not
+serialize to HTML, rename an event, add a listener, or alter controlled-state
+restoration. Do not add a noop `onInput` merely to silence the warning.
 
-Checkbox/radio activation follows the platform's `click` → `input` → non-cancelable
-`change` sequence. `preventDefault()` in native `onChange` therefore cannot roll the
-toggle back; cancel in `onClick` when rollback is intended. React's synthetic
-checkable `onChange` is click-backed and can cancel activation at that callback, an
-intentional event-layer divergence. Octane still lets native input/change handlers
-observe the prospective checked state before restoring rejected controlled state
-and radio cousins.
+Checkbox/radio activation follows the platform's `click` → `input` →
+non-cancelable `change` sequence. `preventDefault()` in native `onChange`
+therefore cannot roll the toggle back:
+
+```jsx
+<input type="checkbox" onClick={(event) => event.preventDefault()} />
+```
+
+Cancel in `onClick` when rollback is intended. React's synthetic checkable
+`onChange` is click-backed and can cancel activation at that callback, an
+intentional event-layer divergence. Octane still lets native input/change
+handlers observe the prospective checked state before restoring rejected
+controlled state and radio cousins.
 
 Form **actions**
 (`<form action={fn}>`, `useActionState`, `useFormStatus`, `useOptimistic`,
@@ -269,31 +332,43 @@ cancel queued dispatches (octane keeps threading).
 
 ## Attributes: native names, React's value rules
 
-Attribute **values** follow React (matched 2026-07-08): boolean attributes
-(`disabled`, `hidden`, `inert`, `readOnly`, …) normalize — any truthy value
-renders the canonical `attr=""`, falsy removes (`hidden={0}` → absent); a
-boolean on a non-boolean attribute is removed + dev-warns (`title={true}` does
-not render `title=""`); `download`/`capture` keep React's overloaded-boolean
-semantics; `muted`/`multiple`/`selected` dynamic writes set the DOM
-**property** (mustUseProperty); `autoFocus` writes no attribute — the element
-is focused in the commit phase of its mount. Also matched: `aria-*` and
-`spellcheck`/`contenteditable`/`draggable` stringify booleans; empty
-`src`/`href` are stripped (except `<a>`); function/symbol values are
-removed; `dangerouslySetInnerHTML` shape and children-exclusivity throw; the
-canonical camelCase aliases (`strokeWidth` → `stroke-width`, `xlinkHref`,
-`className`/`htmlFor`) write the native attribute.
+Attribute **values** follow React (matched 2026-07-08):
+
+```tsx
+<div hidden={1} /> // hidden=""
+<div hidden={0} /> // attribute omitted
+<div title={true} /> // omitted with a development warning
+<div spellcheck={false} /> // spellcheck="false"
+```
+
+This includes boolean and overloaded-boolean normalization, property writes for
+`muted`/`multiple`/`selected`, commit-phase `autoFocus`, `aria-*` stringification,
+empty `src`/`href` removal (except `<a>`), function/symbol removal,
+`dangerouslySetInnerHTML` validation, and canonical camelCase aliases such as
+`strokeWidth`, `xlinkHref`, `className`, and `htmlFor`.
 
 What still differs: attribute **names** pass through natively — native
-spellings (`accept-charset`, `arabic-form`) are the idiom and simply work.
-Diagnostic coverage is expanding progressively from the latest upstream behavior
-without shipping React's complete `possibleStandardNames` table as runtime data.
-Today, a curated slice of genuinely-broken casings warns in dev (`autofocus` → `autoFocus`,
-`defaultvalue` → `defaultValue`, `defaultchecked` → `defaultChecked`,
-lowercase `on*` function props → camelCase). Odd objects coerce leniently via
-`toString()` (with a dev `[object Object]` warning) instead of throwing. Octane
-also retains `<area href="">` as a current-document hyperlink, while React
-strips it; a statically authored lowercase SVG `textlength` is canonicalized by
-the browser parser instead of following React's imperative warning path.
+spellings are the idiom and simply work:
+
+```tsx
+<form accept-charset="utf-8" />
+```
+
+Diagnostic coverage is expanding progressively from the latest upstream
+behavior without shipping React's complete `possibleStandardNames` table as
+runtime data. Today, a curated slice of genuinely-broken casings warns in
+development (`autofocus` → `autoFocus`, `defaultvalue` → `defaultValue`,
+`defaultchecked` → `defaultChecked`, lowercase `on*` function props →
+camelCase).
+
+Other current differences:
+
+- Odd objects coerce leniently via `toString()` (with a development
+  `[object Object]` warning) instead of throwing.
+- Octane retains `<area href="">` as a current-document hyperlink; React strips
+  it.
+- The browser parser canonicalizes a statically authored lowercase SVG
+  `textlength` instead of following React's imperative warning path.
 
 ## Development diagnostics and production errors
 
@@ -318,10 +393,18 @@ errors.
 
 ## `class`/`className` compose clsx-style
 
-Strings, numbers, arrays, objects, and nesting compose into a class string at
-every apply site, client and SSR (byte-identical). React coerces
-`className={['a','b']}` to `"a,b"`; octane yields `"a b"`. Nullish/false
-removes the attribute; an empty string writes `class=""`.
+```tsx
+<div class={['button', { active: selected }, ['compact']]} />
+// selected=true → class="button active compact"
+
+<div className={['a', 'b']} />
+// React: class="a,b"
+// Octane: class="a b"
+```
+
+Strings, numbers, arrays, objects, and nesting compose at every client and SSR
+apply site with byte-identical results. A nullish or `false` result removes the
+attribute; an empty string writes `class=""`.
 
 ## Reconciler: LIS moves, identical results
 
@@ -333,15 +416,33 @@ physically-moved nodes can differ.
 ## Scheduler: synchronous, two priorities
 
 Renders are microtask-batched and run to completion — no lanes, yields,
-time-slicing, expiration, or selective hydration. Consequences:
+time-slicing, expiration, or selective hydration. Priority changes Suspense
+behavior, not whether ordinary work is time-sliced:
 
-- `flushSync` drains the whole queue (transition work included) and never runs
-  passive effects synchronously — passives are always post-paint.
-- Priority (`urgent` vs `transition`) governs **suspense hold semantics** —
-  transition renders keep prior content on suspend, and fallback-visible boundaries
-  whose retries fully stage reveal together through refs/layout effects — not general
-  commit deferral. Same-identity synchronous rendering remains per-swap rather than a
-  global React-style WIP tree (see `SUSPENSE_DIVERGENCE.md` #4).
+```tsx
+setPage(next); // If it suspends, show the pending fallback.
+startTransition(() => setPage(next)); // Keep the previous content while pending.
+```
+
+`flushSync` drains both priorities but leaves passive effects asynchronous:
+
+```tsx
+flushSync(() => {
+  setQuery('octane');
+  startTransition(() => setResults(nextResults));
+});
+// Both updates committed; passive effects still run later.
+```
+
+Other consequences:
+
+- Priority (`urgent` vs `transition`) governs Suspense hold semantics, not
+  general commit deferral.
+- Fallback-visible boundaries whose retries fully stage reveal together,
+  including refs and layout effects.
+- Same-identity synchronous rendering remains per-swap rather than using a
+  global React-style work-in-progress tree. See
+  [Suspense divergence #4](../packages/octane/audit/SUSPENSE_DIVERGENCE.md).
 - Multiple unhandled root errors in one flush throw an `AggregateError`; an
   unhandled error unmounts its root's whole tree (both match React).
 - `useSyncExternalStore` skips React's commit-time getSnapshot re-read for
@@ -350,18 +451,25 @@ time-slicing, expiration, or selective hydration. Consequences:
 
 ## Parallel `use()`: no suspense waterfalls
 
-The compiler always applies its parallel-`use()` transform
-(docs/suspense-parallel-use-plan.md). When it can prove requests independent,
-idiomatic sequential `use()` code avoids the waterfall that React incurs for
-the same code:
+The compiler always applies its
+[parallel-`use()` transform](./suspense-parallel-use-plan.md). When it can prove
+requests independent, idiomatic sequential `use()` code avoids the waterfall
+React incurs for the same source:
+
+```tsx
+// These fetch functions are imported module bindings.
+const profile = use(fetchProfile(id)); // Starts now.
+const posts = use(fetchPosts(id)); // Starts with profile.
+const avatar = use(fetchAvatar(profile.avatarId)); // Waits for profile.
+```
+
+The first two creations form one independent stratum: they start together and
+the boundary suspends once for the batch. The third has a true data dependency
+and remains sequential.
 
 - **Creations are memoized per call site**: `use(fetchA(id))` compiles to a
   slot-keyed memo with member-path deps (`[fetchA, id]`), so replays never mint
   fresh promises and refetch happens exactly when inputs change.
-- **Independent creations start together**: provably-independent `use()`
-  arguments in one body are hoisted above the first unwrap and the boundary
-  suspends ONCE on the whole stratum (one replay per settled batch, not one per
-  promise). True data dependencies (`use(f(a))`) stay sequential.
 - **Fetch trees warm across components**: a suspended body prefetches
   descendants whose reachability and props are provably independent of the
   suspended data (compiled `__warm` plans, depth-capped recursion), so a nested
@@ -373,28 +481,43 @@ the same code:
   creates a fresh promise for a slot that already holds one reuses the stored
   thenable ("uncached promise" dev warning), and a replay that discovers a new
   pending `use()` behind a data dependency gets a dev waterfall diagnostic.
-- **Known gaps (regression-pinned in `benchmarks/async-composition`):** the
-  independence analysis stops at module boundaries, so two independent `use()`
-  reads inside an imported custom hook still serialize; a parent with no
-  `use()` of its own never triggers its warm plan, so adjacent async siblings
-  are discovered serially; and a transition-wrapped update currently reveals
-  newly-resolved content progressively — monotonic, never rolling back, and a
-  dependent value never renders against stale input — where React holds the
-  previous screen until the whole boundary completes (a runtime gap independent
-  of this transform). The benchmark enforces one-way ceilings on all three so
-  they can only improve.
+
+Known gaps are regression-pinned in `benchmarks/async-composition`:
+
+| Shape | Current behavior |
+| --- | --- |
+| Independent `use()` calls inside an imported custom hook | Serialize because independence analysis stops at the module boundary |
+| Adjacent async children under a parent with no `use()` | Are discovered serially because the parent never triggers its warm plan |
+| A transition-wrapped update | Reveals resolved content progressively instead of holding the whole previous screen |
+
+The transition result is monotonic: it never rolls back, and a dependent value
+never renders against stale input. The benchmark sets one-way ceilings so all
+three gaps can only improve.
 
 ## Root component entry points and container ownership
 
-`root.render(<App />)` is React-compatible. Octane also retains its original
-compiled-component entry point, `root.render(App, props)`, which avoids creating
-an element descriptor at application bootstrap. A bare function passed to
-`root.render` is therefore intentional, not an invalid-child warning.
+Both entry forms are valid:
+
+```tsx
+// Choose either entry form:
+root.render(<App />); // React-compatible
+// or
+root.render(App, props); // Octane extension
+```
+
+The second form avoids creating an element descriptor at application bootstrap.
+A bare function passed to `root.render` is therefore intentional, not an
+invalid-child warning.
 
 The first `root.render()` mounts synchronously. React's concurrent root queues
 its initial mount, so a render followed by an unmount in the same surrounding
 batch exposes no intermediate DOM there; Octane may expose the mounted DOM
 before its synchronous unmount leaves the same empty final state.
+
+```tsx
+root.render(App, props);
+console.log(container.firstChild !== null); // true
+```
 
 After `root.unmount()`, the root is permanently closed. If outside code removes
 some of a root's managed DOM first, unmount still performs safe cleanup instead
@@ -406,7 +529,15 @@ detached node.
 Like React, `lazy(load)` accepts a thenable that resolves to a module object with
 a `default` component. Octane additionally accepts a bare component as the
 resolved value, making named dynamic imports usable without a default-export
-shim. Nested lazy wrappers are rejected.
+shim:
+
+```tsx
+const Chart = lazy(() =>
+  import('./Chart').then((module) => module.Chart),
+);
+```
+
+Nested lazy wrappers are rejected.
 
 React's Suspense and ViewTransition values are exotic element types and React
 rejects wrapping them in `lazy()`. Octane exposes those boundaries as ordinary
@@ -415,51 +546,106 @@ behavior.
 
 ## Errors: `@try` / `@catch`, not class boundaries
 
-`@catch (err, reset)` (and the JSX `<ErrorBoundary>`) replaces class
+```tsx
+@try {
+  <RiskyPanel />
+} @catch (error, reset) {
+  <button onClick={() => reset()}>Retry</button>
+}
+```
+
+`@catch (error, reset)` and the JSX `<ErrorBoundary>` replace class
 error-boundary lifecycles. Catch fallbacks mount fresh nodes (like React's
 `forceUnmountCurrentAndReconcile`); deletion-phase and ref-detach errors route
-to the enclosing boundary; uncaught-error surfacing is `console.error` rather
-than `onUncaughtError`.
+to the enclosing boundary. Uncaught errors surface through `console.error`
+rather than `onUncaughtError`.
+
+## Refs are props
+
+Components receive refs as ordinary props; there is no `forwardRef` wrapper:
+
+```tsx
+function Search({ ref }) @{
+  <input ref={ref} />
+}
+
+<Search ref={[inputRef, measure]} />
+```
+
+A ref may be a callback, a `{ current }` object, or an array of refs as shown
+above.
 
 ## SSR and streaming
 
-`renderToString`/`renderToStaticMarkup`/`prerender` return `{ html, css }` —
-the `css` field carries octane's scoped styles (React has no equivalent). Hoisted
-document metadata folds into `html` as React does; the opt-in
-`headChannel: 'separate'` option (with `RenderResult.head` and
-`StreamOptions.onHeadReady`) is an octane extension for hosts that render into a
-`<head>`-bearing template instead of rendering the document, where React's fold
-has no `</head>` to target.
-`renderToPipeableStream`/`renderToReadableStream` stream out-of-order Suspense
-like Fizz, with these scope differences: per-round re-passes (the prerender
-cost model) instead of per-boundary incremental renders; no selective
-hydration; head elements hoisted inside streamed boundaries re-create
-client-side on hydration. Hydration mismatch recovery patches attributes to the
-**client** value (React keeps the server's) and warns + rebuilds in place
-rather than throwing. Structural validation depth matches React's: production
-hydration checks an adopted root's nodeType + tag only (tag and text mismatches
-still recover), so branches sharing a tag and differing only in static
-attributes — e.g. `@switch` cases that are all `<span>` with different
-`class` — are not detected in production; development performs the full
-static-structure and attribute comparison and warns + rebuilds.
+### Rendering surface
 
-Octane core also leaves document and transport orchestration to the surrounding
-server: it has no Fizz bootstrap-script/module/import-map, doctype/preamble,
-`onHeaders`, or header-construction options. One `nonce` option covers every
-inline style and script Octane emits rather than exposing separate script/style
-nonce channels. A readable stream's `allReady` settles after all boundary bytes
-have been accepted under consumer backpressure, so consumers should read while
-awaiting it. Error callbacks report the original value but do not synthesize
+The buffered renderers return Octane's scoped CSS beside the HTML:
+
+```tsx
+const { html, css } = renderToString(App, props);
+```
+
+`renderToString`, `renderToStaticMarkup`, and `prerender` all return
+`{ html, css }`; React has no equivalent `css` field. Hoisted document metadata
+folds into `html` as React does. For a host that owns the surrounding
+`<head>`-bearing template, `headChannel: 'separate'` instead exposes
+`RenderResult.head` and `StreamOptions.onHeadReady`.
+
+### Streaming
+
+`renderToPipeableStream` and `renderToReadableStream` stream out-of-order
+Suspense like Fizz, with these differences:
+
+- Octane performs per-round re-passes (the prerender cost model), not
+  per-boundary incremental renders.
+- There is no selective hydration.
+- Head elements hoisted inside streamed boundaries are re-created on the client
+  during hydration.
+
+Octane leaves document and transport orchestration to the surrounding server.
+It has no Fizz bootstrap-script/module/import-map, doctype/preamble, `onHeaders`,
+or header-construction options. One `nonce` covers every inline style and script
+Octane emits rather than exposing separate script and style channels.
+
+A readable stream's `allReady` settles after all boundary bytes have been
+accepted under consumer backpressure, so consumers should read the stream while
+awaiting it. Error callbacks report the original value without synthesizing
 React digests or React's `errorInfo` shape.
+
+### Hydration
+
+Attribute mismatches recover to the **client** value; React keeps the server
+value. Octane warns and rebuilds a mismatched subtree in place rather than
+throwing.
+
+Production structural validation has the same depth as React: it checks an
+adopted root's node type and tag. Tag and text mismatches still recover, but
+different static branches that share a tag may not be detected:
+
+```html
+<!-- Server branch -->
+<span class="compact">...</span>
+
+<!-- Client branch -->
+<span class="expanded">...</span>
+```
+
+Development performs the full static-structure and attribute comparison, warns,
+and rebuilds.
 
 ## Not implemented (by design)
 
-Class components, legacy `ReactDOM.render` roots, Server Components/RSC, `StrictMode` double-invoke,
-`Profiler`, `SuspenseList`, `forwardRef`/`createRef` (refs are props),
-`useDebugValue` is a no-op, and `cache()`.
-Resource hints ARE supported
-(`preload`/`preinit`/`preconnect`/`prefetchDNS`). React-19 custom-element
-listener semantics ARE supported (a function-valued lowercase `on*` prop on a
-custom element attaches a real listener — adjudicated 2026-07-05); the
-property-vs-attribute heuristic is not (attributes only, per the pass-through
-policy).
+Octane does not implement:
+
+- class components or legacy `ReactDOM.render` roots;
+- Server Components/RSC;
+- `StrictMode` double-invoke;
+- `Profiler`, `SuspenseList`, `forwardRef`, `createRef`, or `cache()`.
+
+`useDebugValue` is accepted as a no-op. Resource hints are supported
+(`preload`, `preinit`, `preconnect`, and `prefetchDNS`).
+
+React 19 custom-element listener semantics are also supported: a
+function-valued lowercase `on*` prop on a custom element attaches a real
+listener (adjudicated 2026-07-05). The property-versus-attribute heuristic is
+not; custom-element values follow Octane's attribute-only pass-through policy.

--- a/website/src/content/docs/differences-from-react.mdx
+++ b/website/src/content/docs/differences-from-react.mdx
@@ -50,11 +50,21 @@ useEffect(() => {
 }); // inferred from syncRoom and room.id
 ```
 
-Locally declared custom hooks in full-compiled `.tsrx`/`.tsx` modules participate when
-they transparently forward their callback and final dependency parameter to one of
-those hooks. The compiler follows nested transparent wrappers, but it does not guess
-from a `use*` name alone. Plain `.ts`/`.js` modules, imported custom hooks, and wrappers
-that transform or inspect those parameters need an explicit list.
+Direct calls to built-in hooks infer their dependencies in every compiler-processed
+module, including custom hooks written in plain `.ts` or `.js`:
+
+```ts
+export function useLoggedValue(value: string, log: (value: string) => void) {
+	useEffect(() => log(value)); // inferred from log and value
+}
+```
+
+Inferring an omitted list at a call to a custom wrapper is a narrower operation.
+It works when a local wrapper in a fully compiled `.tsrx`/`.tsx` module transparently
+forwards its callback and final dependency parameter to a built-in hook. Nested local
+transparent wrappers also work. Wrapper calls in plain `.ts`/`.js` and imported,
+method-style, or non-transparent wrappers need an explicit list; their internal calls
+to built-in hooks can still infer dependencies.
 
 An explicit array keeps its exact React meaning. Pass `null` when you intentionally
 want the effect or computation to run after every render.


### PR DESCRIPTION
## Summary

- Make `docs/differences-from-react.md` genuinely example-first with 25 small, source-backed examples and compact decision tables.
- Preserve the dependency-inference distinction documented in issue #326 between direct built-in-hook dependency inference in compiler-processed `.ts`/`.js` custom hooks and the narrower inference of local, transparent custom-wrapper calls.
- Correct the same distinction in the authoritative public website React migration guide so the two user-facing sources do not contradict one another.
- Cover conditional slot-keyed hooks and loop exceptions; inferred, explicit, empty, and `null` dependencies; pure automatic and derived-value memoization; both state and reducer getters; native and controlled events; class composition; scheduling and concurrent `use()`; roots, lazy boundaries, refs, server rendering, streaming, and hydration.
- Preserve the existing reconciler, scheduler, Suspense, controlled-input, diagnostics, and hydration guarantees without making claims about the unresolved separate #353 behavior.

## Why

React users should be able to see Octane's real syntax, observable behavior, and compiler eligibility before having to reconstruct them from dense prose.

Closes #351.

## Attribution

Adapted from Alec Larson's [public example-first prototype](https://github.com/aleclarson/octane/commit/caf41c2592c544fb8938895ce0082e826dc661e9), whose guide baseline is identical to current upstream `main`. The final GitHub-verified commit retains his `Co-authored-by` attribution and preserves subsequently clarified custom-hook behavior.

## Validation

- [x] Exact locked `prettier@3.9.6` with the repository Markdown/MDX options: `node node_modules/.pnpm/prettier@3.9.6/node_modules/prettier/bin/prettier.cjs --no-config --use-tabs --tab-width 2 --single-quote --print-width 100 --check docs/differences-from-react.md website/src/content/docs/differences-from-react.mdx`.
- [x] `node scripts/react-parity/check.mjs`.
- [x] `node scripts/workspace-packages.mjs --check`.
- [x] `node scripts/generate-parity-gaps.mjs --check`.
- [x] `node scripts/generate-binding-parity-gaps.mjs --check`.
- [x] `node scripts/generate-bindings-status.mjs --check`.
- [x] `node scripts/redact-audit/generate.mjs --check`.
- [x] `node scripts/check-changesets.js`, `node scripts/check-test-markers.mjs`, `node scripts/check-tsrx-module-decls.mjs`, and `node scripts/check-context-budget.mjs`.
- [x] `node --test scripts/react-parity/inventory-lib.test.mjs scripts/scaffold-react-port.test.mjs scripts/redact-audit/ledger-lib.test.mjs` — 44 tests passed.
- [x] All relative documentation links, all 25 guide examples, required sections, even code-fence pairs, and `git diff --check`.
- [ ] Full local `pnpm format:check`, `pnpm typecheck`, and `pnpm test`: a normal `pnpm install --frozen-lockfile` is blocked by the existing protected-registry HTTP 403 for the exact locked `@tsrx/core@0.1.54` tarball. The lockfile, parser, registry credentials, and source packages are unchanged; this upstream PR requests the normal GitHub Actions checks instead.

## Risk

Documentation only: exactly two existing documentation files, no runtime/compiler changes, no generated-document rewrites, and no package changeset.