### PR TITLE
docs: keep state getters searchable

### DIFF
--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -210,7 +210,8 @@ witnesses keeps its old value. Pass such state through
 
 ## `useState` / `useReducer` current-state getters
 
-Both state hooks have an Octane-only third tuple member:
+Both state hooks have an Octane-only third tuple member: a stable `getState`
+function that reads the latest scheduled state.
 
 ```tsx
 const [draft, setDraft, getDraft] = useState('');


### PR DESCRIPTION
## Summary

- Restore the canonical `getState` API name in the example-first state-getter section merged by #354.
- Preserve both concrete `useState`/`useReducer` getter examples and make the existing website MCP query `useState getState` discoverable again.
- Keep the fix at the actual documentation owner: one existing Markdown file, two added lines, one removed line, no runtime or test changes.

## Why

The maintainer merged #354 before its full Node 24 matrix completed. The existing `website-mcp/tests/search.test.ts` regression subsequently exposed that the rewritten guide used only example-specific `getDraft`/`getTotal` names, so the public `getState` search query no longer matched a section.

This change restores the documented public API term instead of weakening the search test or changing the search implementation.

Failed check: https://github.com/octanejs/octane/actions/runs/30386781017/job/90369157298

## Validation

- [x] Reproduced the pre-fix failure using the real shared `recordsFor`/`searchDocs` implementation: `useState getState` produces no reference result.
- [x] Verified the fixed canonical Markdown with the same real search implementation: `useState getState` returns `differences-from-react-reference`.
- [x] Exact locked `prettier@3.9.6` with repository Markdown options on both React-differences documentation surfaces.
- [x] `node scripts/react-parity/check.mjs`.
- [x] `node scripts/check-changesets.js`.
- [x] `node --test scripts/react-parity/inventory-lib.test.mjs scripts/scaffold-react-port.test.mjs scripts/redact-audit/ledger-lib.test.mjs` — 44 tests passed.
- [x] `git diff --check`.
- [x] GitHub-verified commit directly on the latest merged upstream `main`; comparison confirms exactly one changed file and a two-line fix.

## Risk

Documentation only. The original issue #351 is already closed by merged PR #354; this follow-up only repairs the existing search regression discovered by that PR's full CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Markdown wording change with no runtime, API, or test logic changes beyond fixing search discoverability.
> 
> **Overview**
> Repairs a **docs-only** regression from the rewritten state-getter section: the prose again names the public **`getState`** API on the third `useState`/`useReducer` tuple member, so site search for `useState getState` can index `differences-from-react-reference`.
> 
> The **`getDraft` / `getTotal` examples are unchanged**; only the introductory sentence is adjusted (split across two lines with the canonical term).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4be46fcc09bba6cfedc7101e4fabbdc8867db96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->