### PR TITLE
fix(ci): cancel superseded CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  # A newer revision makes an older run for the same PR obsolete. Main pushes
+  # stay independent because release-merge CI can gate package publishing.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 env:
   # Named once: the sharded suite excludes these specs and website_e2e runs
   # them. Splitting the paths means a stale name could silently stop running

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,8 @@ on:
     branches: [main]
 
 concurrency:
-  # A newer revision makes an older run for the same PR obsolete. Main pushes
-  # stay independent because release-merge CI can gate package publishing.
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
+  # Only the newest state of a pull request or main can still ship.
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
## Summary
- cancel an older CI run when a newer revision of the same pull request starts
- cancel an older `main` CI run when a newer `main` commit lands

## Why
- superseded runs were consuming the full 20-job hosted-runner allowance and delaying current work
- PR #350 gates the normal CI fan-out behind the fast `classify changeset release` job, so capacity exhaustion can leave new runs showing only that queued prerequisite
- publishing reconciles from any successful validated `main` SHA, so the newest main run safely subsumes an older one

## Changes
- group CI runs by workflow and Git ref
- enable `cancel-in-progress: true`

## Validation
- [x] `actionlint` 1.7.12 `.github/workflows/ci.yml`
- [x] `pnpm exec prettier --check .github/workflows/ci.yml`
- [x] parsed `.github/workflows/ci.yml` with Ruby YAML
- [x] `git diff --check`
- [ ] `pnpm typecheck` (not run; workflow-only change)
- [ ] `pnpm test` (not run; workflow-only change)

## Risk / follow-ups
- rapid successive pushes can keep cancelling `main` CI until the branch is quiet long enough for the newest run to finish
- if a release merge loses the completed-parent proof because that parent run was cancelled, the classifier fails safe and runs the full suite
- distinct pull requests still run independently and can consume the shared runner pool.