### PR TITLE
fix(octane): scope JSX values and prevent deep SSR stack overflows

### DIFF
--- a/.changeset/scoped-jsx-render-bodies.md
+++ b/.changeset/scoped-jsx-render-bodies.md
@@ -1,0 +1,9 @@
+---
+'octane': patch
+---
+
+Keep JSX values in the render scope represented by their element tree, including
+implicit getter, Proxy, coercion, iterator, and computed-key evaluation. Preserve
+context, Suspense, error-boundary, SSR, hydration, and element-descriptor
+compatibility when JSX moves into a variable, prop, array, or another value
+position.

--- a/.changeset/scoped-jsx-render-bodies.md
+++ b/.changeset/scoped-jsx-render-bodies.md
@@ -6,4 +6,5 @@ Keep JSX values in the render scope represented by their element tree, including
 implicit getter, Proxy, coercion, iterator, and computed-key evaluation. Preserve
 context, Suspense, error-boundary, SSR, hydration, and element-descriptor
 compatibility when JSX moves into a variable, prop, array, or another value
-position.
+position. Render deeply nested server component trees without exhausting the
+JavaScript call stack across buffered and streaming server-rendering APIs.

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -239,6 +239,47 @@ can be observed, preserving the existing runtime path and allocation profile for
 ordinary two-item destructuring. Escaped or ambiguous tuples conservatively
 receive the complete three-item shape.
 
+## JSX values follow the represented render scope
+
+Moving compiler-authored JSX into a variable, prop, array, or other value
+position does not move its represented context provider, Suspense boundary, or
+error boundary:
+
+```tsx
+const Theme = createContext('outer');
+const theme = {
+  get current() {
+    return use(Theme);
+  },
+};
+
+function Page() {
+  const content = (
+    <Theme.Provider value="inner">
+      <span>{theme.current}</span>
+    </Theme.Provider>
+  );
+
+  return <main>{content}</main>; // "inner", just like direct JSX output.
+}
+```
+
+When Octane renders that stored subtree, descendant expressions run after their
+represented provider or boundary has entered its scope. This includes implicit
+user code in getters, Proxy traps, coercion hooks, iterators, and computed keys,
+not only explicit function calls. React evaluates JSX child expressions while
+constructing the caller's element, before that element's represented provider or
+boundary renders; Octane intentionally follows the visible rendered tree
+instead.
+
+JSX values remain inspectable element descriptors: `isValidElement`,
+`Children.only`, `cloneElement`, and ordinary `type`/`props`/`children`
+inspection keep their existing contracts. Reading an element's children as data
+can evaluate them in the inspecting caller's current scope; it does not enter a
+provider or boundary that has not rendered. The root element's tag and props,
+explicit `createElement(...)` calls, and event or render-prop callbacks retain
+ordinary JavaScript evaluation semantics.
+
 ## Native event objects, no synthetic event layer
 
 Event propagation itself matches React and is **not a divergence**. Ordinary

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -256,29 +256,30 @@ const theme = {
 function Page() {
   const content = (
     <Theme.Provider value="inner">
-      <span>{theme.current}</span>
+      <span data-theme={theme.current}>{theme.current}</span>
     </Theme.Provider>
   );
 
-  return <main>{content}</main>; // "inner", just like direct JSX output.
+  return <main>{content}</main>; // data-theme="inner" and text "inner".
 }
 ```
 
-When Octane renders that stored subtree, descendant expressions run after their
-represented provider or boundary has entered its scope. This includes implicit
-user code in getters, Proxy traps, coercion hooks, iterators, and computed keys,
-not only explicit function calls. React evaluates JSX child expressions while
-constructing the caller's element, before that element's represented provider or
-boundary renders; Octane intentionally follows the visible rendered tree
-instead.
+When Octane renders that stored subtree, the entire compiler-authored element
+record, including a dynamic root type, its props, and descendant expressions,
+resolves after its represented provider or boundary has entered its scope. This
+includes implicit user code in getters, Proxy traps, coercion hooks, iterators,
+and computed keys, not only explicit function calls. React evaluates JSX
+expressions while constructing the caller's element, before that element's
+represented provider or boundary renders; Octane intentionally follows the
+visible rendered tree instead.
 
 JSX values remain inspectable element descriptors: `isValidElement`,
 `Children.only`, `cloneElement`, and ordinary `type`/`props`/`children`
-inspection keep their existing contracts. Reading an element's children as data
-can evaluate them in the inspecting caller's current scope; it does not enter a
-provider or boundary that has not rendered. The root element's tag and props,
-explicit `createElement(...)` calls, and event or render-prop callbacks retain
-ordinary JavaScript evaluation semantics.
+inspection keep their existing contracts. Inspecting a deferred element record
+as data resolves it in the inspecting caller's current scope; it does not enter
+a provider or boundary that has not rendered. Static JSX, explicit
+`createElement(...)` calls, and event or render-prop callbacks retain ordinary
+JavaScript evaluation semantics.
 
 ## Native event objects, no synthetic event layer
 

--- a/packages/docusaurus/tests/mdx.test.ts
+++ b/packages/docusaurus/tests/mdx.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
+import * as ServerRuntime from 'octane/server';
+import * as ServerMdx from '@octanejs/mdx/server';
+import { evalModuleCode, stripMarkers } from '../../mdx/tests/_helpers.js';
 import { compileDocusaurusMdxSync, remarkDocusaurusPageData } from '../src/mdx.js';
 import { docusaurusMdx } from '../src/vite.js';
 
@@ -19,7 +22,7 @@ title: Guide
 
 describe('Docusaurus-aware MDX', () => {
 	it('emits the Docusaurus document export surface through Octane compilation', () => {
-		const result = compileDocusaurusMdxSync(SOURCE, '/site/docs/guide.mdx', {
+		const options = {
 			metadata: {
 				id: 'guide',
 				frontMatter: { image: './social.png' },
@@ -27,12 +30,22 @@ describe('Docusaurus-aware MDX', () => {
 			resolveMarkdownLink: ({ linkPathname }) => linkPathname.replace('./', '/guide/'),
 			resolveMarkdownImage: ({ url }) => url.replace('./', '/assets/'),
 			createAssets: ({ frontMatter }) => ({ image: frontMatter.image }),
-		});
+		};
+		const result = compileDocusaurusMdxSync(SOURCE, '/site/docs/guide.mdx', options);
 
 		expect(result.diagnostics).toEqual([]);
 		expect(result.code).toContain('export const frontMatter = frontmatter');
 		expect(result.code).toContain('export const contentTitle = "Guide"');
-		expect(result.code).toContain('_$createElement(_components.header');
+		const serverResult = compileDocusaurusMdxSync(SOURCE, '/site/docs/guide.mdx', {
+			...options,
+			mode: 'server',
+		});
+		const compiledModule = evalModuleCode(serverResult.code, {
+			'octane/server': ServerRuntime,
+			'@octanejs/mdx/server': ServerMdx,
+		});
+		const { html } = ServerRuntime.renderToString(compiledModule.default, {});
+		expect(stripMarkers(html)).toContain('<header><h1 id="guide">Guide</h1></header>');
 		expect(result.code).toContain('id: "install"');
 		expect(result.code).toContain('id: "install-1"');
 		expect(result.code).toContain('"/guide/next.md"');

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -14193,7 +14193,7 @@ function lowerJsxChild(child, ctx) {
 		// server export is the identity (`ssrChild` just renders the array).
 		ctx.runtimeNeeded.add('positionalChildren');
 		const children = inheritOriginLoc(b.call(rtAlias('positionalChildren'), b.array(els)), child);
-		if (!jsxValueChildrenNeedRenderScope(child)) return children;
+		if (!jsxValueChildrenNeedRenderScope(child, true)) return children;
 
 		// A bare expression in a fragment has no parent element descriptor to
 		// defer it, so the fragment itself must own the represented render scope.
@@ -14247,7 +14247,7 @@ function isStaticJsxValueExpression(expression) {
 // syntax is effectful. Nested component/tag resolution and dynamic attributes
 // belong to their represented parent, so they make that parent's children lazy
 // even when the nested element has no expression children of its own.
-function jsxValueChildrenNeedRenderScope(node) {
+function jsxValueChildrenNeedRenderScope(node, descendantElementsOwnChildren = false) {
 	for (const child of node.children || []) {
 		if (child == null || child.type === 'JSXText' || child.type === 'Text') continue;
 		if (child.type === 'JSXExpressionContainer') {
@@ -14261,7 +14261,7 @@ function jsxValueChildrenNeedRenderScope(node) {
 			continue;
 		}
 		if (child.type === 'Fragment' || child.type === 'JSXFragment') {
-			if (jsxValueChildrenNeedRenderScope(child)) return true;
+			if (jsxValueChildrenNeedRenderScope(child, descendantElementsOwnChildren)) return true;
 			continue;
 		}
 		if (child.type !== 'Element' && child.type !== 'JSXElement') return true;
@@ -14272,7 +14272,9 @@ function jsxValueChildrenNeedRenderScope(node) {
 			if (attr.value?.type !== 'JSXExpressionContainer') continue;
 			if (!isStaticJsxValueExpression(attr.value.expression)) return true;
 		}
-		if (jsxValueChildrenNeedRenderScope(child)) return true;
+		// A fragment can retain its inspectable positional array when only a nested
+		// element's descendants are dynamic: that element already owns their scope.
+		if (!descendantElementsOwnChildren && jsxValueChildrenNeedRenderScope(child)) return true;
 	}
 	return false;
 }

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -14243,6 +14243,26 @@ function isStaticJsxValueExpression(expression) {
 	);
 }
 
+// A root member tag, spread, or dynamic prop can invoke user code before its
+// descriptor exists. Defer the complete record rather than just its children.
+function jsxValueRootNeedsRenderScope(node) {
+	const name = node.openingElement?.name || node.id;
+	if (
+		name?.type === 'MemberExpression' ||
+		name?.type === 'JSXMemberExpression' ||
+		name?.type === 'JSXExpressionContainer'
+	) {
+		return true;
+	}
+	for (const attr of node.attributes || node.openingElement?.attributes || []) {
+		if (attr.type === 'SpreadAttribute' || attr.type === 'JSXSpreadAttribute') return true;
+		if (attr.type !== 'Attribute' && attr.type !== 'JSXAttribute') continue;
+		if (attr.value?.type !== 'JSXExpressionContainer') continue;
+		if (!isStaticJsxValueExpression(attr.value.expression)) return true;
+	}
+	return false;
+}
+
 // Prove a whole descendant tree static instead of guessing which JavaScript
 // syntax is effectful. Nested component/tag resolution and dynamic attributes
 // belong to their represented parent, so they make that parent's children lazy
@@ -14381,6 +14401,7 @@ function jsxElementToCreateElement(node, ctx) {
 			if (lowered !== null) loweredChildren.push(lowered);
 		}
 	}
+	let descriptor;
 	if (childrenNeedRenderScope && loweredChildren.length > 0) {
 		let childrenValue = loweredChildren[0];
 		if (loweredChildren.length > 1) {
@@ -14392,15 +14413,25 @@ function jsxElementToCreateElement(node, ctx) {
 		}
 		ctx.runtimeNeeded.add('createScopedElement');
 		const readChildren = inheritOriginLoc(b.arrow([], childrenValue), node);
-		return inheritOriginLoc(
+		descriptor = inheritOriginLoc(
 			b.call('_$createScopedElement', compNode, propsNode, readChildren),
 			node,
 		);
+	} else {
+		ctx.runtimeNeeded.add('createElement');
+		// Remaining scaffolding (callee, props object, spread/diagnostic wrappers,
+		// static-content literals) maps to the authored JSX element.
+		descriptor = inheritOriginLoc(
+			b.call('_$createElement', compNode, propsNode, ...loweredChildren),
+			node,
+		);
 	}
-	ctx.runtimeNeeded.add('createElement');
-	// Remaining scaffolding (callee, props object, spread/diagnostic wrappers,
-	// static-content literals) maps to the authored JSX element.
-	return inheritOriginLoc(b.call('_$createElement', compNode, propsNode, ...loweredChildren), node);
+	if (!jsxValueRootNeedsRenderScope(node)) return descriptor;
+	ctx.runtimeNeeded.add('createScopedValue');
+	return inheritOriginLoc(
+		b.call(rtAlias('createScopedValue'), inheritOriginLoc(b.arrow([], descriptor), node)),
+		node,
+	);
 }
 
 // Short, unique, path-free slot description for non-HMR output: a djb2 hash of

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -13215,6 +13215,18 @@ function lowerReturnJsx(node, ctx, compInlinedSubs, cssHash = null) {
 	// the existing returned-JSX head contract; titles crossing a nested component
 	// boundary are rewritten by rewriteOpaqueTitles itself.
 	const rewritten = rewriteOpaqueTitles(node, ctx, 'html');
+	if (VALUE_DIRECTIVE_ARM_TYPES.has(rewritten.type)) {
+		// A lowered built-in ErrorBoundary can be the returned root itself. Fragment
+		// extraction folds directive CHILDREN into owning-body helpers; handing it a
+		// bare directive instead strands captured props/locals in a module helper.
+		return lowerHostFragment(
+			setupDirectiveFragment(rewritten),
+			ctx,
+			compInlinedSubs,
+			'opaque',
+			cssHash,
+		);
+	}
 	if (
 		(rewritten.type === 'Element' || rewritten.type === 'JSXElement') &&
 		!isComponentTag(rewritten)
@@ -14203,10 +14215,57 @@ function jsxNameToExpr(name) {
 	return b.id(String(name.name || name));
 }
 
+// JSX text and primitive literals cannot execute user code. Every other child
+// expression must stay in its represented render scope: even an identifier can
+// hit the TDZ, while a member, coercion, spread, or computed key can invoke
+// user code without containing a call. Function expressions are values here;
+// their bodies still run only when an event/render-prop consumer invokes them.
+function isStaticJsxValueExpression(expression) {
+	const value = unwrapTsExpr(expression);
+	return (
+		isInvariantLiteral(value) ||
+		value?.type === 'ArrowFunctionExpression' ||
+		value?.type === 'FunctionExpression'
+	);
+}
+
+// Prove a whole descendant tree static instead of guessing which JavaScript
+// syntax is effectful. Nested component/tag resolution and dynamic attributes
+// belong to their represented parent, so they make that parent's children lazy
+// even when the nested element has no expression children of its own.
+function jsxValueChildrenNeedRenderScope(node) {
+	for (const child of node.children || []) {
+		if (child == null || child.type === 'JSXText' || child.type === 'Text') continue;
+		if (child.type === 'JSXExpressionContainer') {
+			if (
+				child.expression &&
+				child.expression.type !== 'JSXEmptyExpression' &&
+				!isStaticJsxValueExpression(child.expression)
+			) {
+				return true;
+			}
+			continue;
+		}
+		if (child.type === 'Fragment' || child.type === 'JSXFragment') {
+			if (jsxValueChildrenNeedRenderScope(child)) return true;
+			continue;
+		}
+		if (child.type !== 'Element' && child.type !== 'JSXElement') return true;
+		if (isComponentTag(child)) return true;
+		for (const attr of child.attributes || child.openingElement?.attributes || []) {
+			if (attr.type === 'SpreadAttribute' || attr.type === 'JSXSpreadAttribute') return true;
+			if (attr.type !== 'Attribute' && attr.type !== 'JSXAttribute') return true;
+			if (attr.value?.type !== 'JSXExpressionContainer') continue;
+			if (!isStaticJsxValueExpression(attr.value.expression)) return true;
+		}
+		if (jsxValueChildrenNeedRenderScope(child)) return true;
+	}
+	return false;
+}
+
 // Build a `createElement(Comp, { ...props })` CallExpression AST node from a
 // component Element node. Recurses into prop values so nested JSX values lower too.
 function jsxElementToCreateElement(node, ctx) {
-	ctx.runtimeNeeded.add('createElement');
 	const nameNode = node.openingElement?.name || node.id;
 	const componentTag = isComponentTag(node);
 	// Host (lowercase) tag → string literal (`'li'`) for the de-opt renderer;
@@ -14280,7 +14339,9 @@ function jsxElementToCreateElement(node, ctx) {
 			);
 		}
 	}
-	const args = [compNode, b.object(properties)];
+	const propsNode = inheritOriginLoc(b.object(properties), node);
+	const childrenNeedRenderScope = jsxValueChildrenNeedRenderScope(node);
+	const loweredChildren = [];
 	// Children → trailing `createElement(type, props, ...children)` args, each
 	// lowered recursively (host child → createElement, `{expr}` → expr, text →
 	// string). The runtime collects these into `descriptor.children`.
@@ -14293,7 +14354,7 @@ function jsxElementToCreateElement(node, ctx) {
 		// the same whole-script neutralization.
 		const content = normalizeStaticScriptDescriptorContent(authoredStaticScriptContent);
 		if (content !== '') {
-			args.push(b.literal(content));
+			loweredChildren.push(inheritOriginLoc(b.literal(content), node));
 		}
 	} else {
 		for (const child of node.children || []) {
@@ -14301,12 +14362,29 @@ function jsxElementToCreateElement(node, ctx) {
 				componentTag ? rewriteOpaqueTitles(child, ctx, 'opaque') : child,
 				ctx,
 			);
-			if (lowered !== null) args.push(lowered);
+			if (lowered !== null) loweredChildren.push(lowered);
 		}
 	}
+	if (childrenNeedRenderScope && loweredChildren.length > 0) {
+		let childrenValue = loweredChildren[0];
+		if (loweredChildren.length > 1) {
+			ctx.runtimeNeeded.add('positionalChildren');
+			childrenValue = inheritOriginLoc(
+				b.call(rtAlias('positionalChildren'), inheritOriginLoc(b.array(loweredChildren), node)),
+				node,
+			);
+		}
+		ctx.runtimeNeeded.add('createScopedElement');
+		const readChildren = inheritOriginLoc(b.arrow([], childrenValue), node);
+		return inheritOriginLoc(
+			b.call('_$createScopedElement', compNode, propsNode, readChildren),
+			node,
+		);
+	}
+	ctx.runtimeNeeded.add('createElement');
 	// Remaining scaffolding (callee, props object, spread/diagnostic wrappers,
 	// static-content literals) maps to the authored JSX element.
-	return inheritOriginLoc(b.call('_$createElement', ...args), node);
+	return inheritOriginLoc(b.call('_$createElement', compNode, propsNode, ...loweredChildren), node);
 }
 
 // Short, unique, path-free slot description for non-HMR output: a djb2 hash of

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -14146,9 +14146,8 @@ function rewriteJsxValues(node, ctx) {
 			return jsxElementToCreateElement(n, ctx);
 		}
 		if (t === 'Fragment' || t === 'JSXFragment') {
-			// `<>…</>` at a value position → an array of its lowered children (the
-			// de-opt childSlot flattens nested arrays, matching React's fragment).
-			// lowerJsxChild owns the single implementation of fragment lowering.
+			// lowerJsxChild keeps static fragments as positional arrays and defers
+			// dynamic fragment children until their represented render scope.
 			return lowerJsxChild(n, ctx);
 		}
 		// The fold above already replaced every directive this body owns, so one still
@@ -14166,7 +14165,7 @@ function rewriteJsxValues(node, ctx) {
 // Lower one JSX child node to a `createElement` argument expression (or null to
 // drop it). Text → string literal (whitespace-only-with-newline indentation is
 // dropped, JSX rule); `{expr}` → the lowered inner expression; nested element →
-// recurse; fragment → array of children.
+// recurse; fragment → positional children or a scope-preserving descriptor.
 function lowerJsxChild(child, ctx) {
 	const t = child && child.type;
 	if (t === 'JSXText' || t === 'Text') {
@@ -14193,7 +14192,22 @@ function lowerJsxChild(child, ctx) {
 		// runtime-built arrays (`.map()` results). Emitted in BOTH modes — the
 		// server export is the identity (`ssrChild` just renders the array).
 		ctx.runtimeNeeded.add('positionalChildren');
-		return inheritOriginLoc(b.call(rtAlias('positionalChildren'), b.array(els)), child);
+		const children = inheritOriginLoc(b.call(rtAlias('positionalChildren'), b.array(els)), child);
+		if (!jsxValueChildrenNeedRenderScope(child)) return children;
+
+		// A bare expression in a fragment has no parent element descriptor to
+		// defer it, so the fragment itself must own the represented render scope.
+		ctx.runtimeNeeded.add('Fragment');
+		ctx.runtimeNeeded.add('createScopedElement');
+		return inheritOriginLoc(
+			b.call(
+				rtAlias('createScopedElement'),
+				inheritOriginLoc(b.id(rtAlias('Fragment')), child),
+				inheritOriginLoc(b.object([]), child),
+				inheritOriginLoc(b.arrow([], children), child),
+			),
+			child,
+		);
 	}
 	return null; // Comment / unknown — drop.
 }

--- a/packages/octane/src/index.ts
+++ b/packages/octane/src/index.ts
@@ -191,6 +191,7 @@ export {
 	// Compact compiler ABI; keep the descriptive export for older compiled output.
 	markSingleRoot as __s,
 	markChildrenBlock,
+	createScopedElement,
 	childSlot,
 	positionalChildren,
 	textSlot,

--- a/packages/octane/src/index.ts
+++ b/packages/octane/src/index.ts
@@ -191,6 +191,7 @@ export {
 	// Compact compiler ABI; keep the descriptive export for older compiled output.
 	markSingleRoot as __s,
 	markChildrenBlock,
+	createScopedValue,
 	createScopedElement,
 	childSlot,
 	positionalChildren,

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -486,6 +486,43 @@ function finalizeElementDescriptor(descriptor: ElementDescriptor): ElementDescri
 	return descriptor;
 }
 
+/** Server twin of the compiler-only complete JSX-record deferral helper. */
+export function createScopedValue(readElement: () => ElementDescriptor): ElementDescriptor {
+	let resolved: ElementDescriptor | undefined;
+	let resolvedScope: SSRScope | null = null;
+
+	const resolve = (): ElementDescriptor => {
+		const scope = CURRENT_SCOPE;
+		if (resolved === undefined || resolvedScope !== scope) {
+			const next = readElement();
+			resolvedScope = scope;
+			resolved = next;
+		}
+		return resolved;
+	};
+
+	const descriptor: ElementDescriptor = {
+		$$kind: ELEMENT_TAG,
+		get type() {
+			return resolve().type;
+		},
+		get props() {
+			return resolve().props;
+		},
+		get key() {
+			return resolve().key;
+		},
+		get ref() {
+			return resolve().ref;
+		},
+		get children() {
+			return resolve().children;
+		},
+	};
+	if (process.env.NODE_ENV !== 'production') Object.freeze(descriptor);
+	return descriptor;
+}
+
 /** Server twin of the compiler-only scope-preserving JSX descriptor factory. */
 export function createScopedElement(
 	type: ServerComponent | string | typeof Fragment,

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -438,6 +438,11 @@ interface ElementDescriptor {
 	children: any;
 }
 
+// Scoped descriptors keep their ordinary public shape while deferring child
+// evaluation. The component serializer must pass these props through intact:
+// spreading them would invoke the child accessor before entering the component.
+const SCOPED_ELEMENT_PROPS = new WeakSet<object>();
+
 function hasElementConfigKey(config: any): boolean {
 	if (config == null || (typeof config !== 'object' && typeof config !== 'function')) return false;
 	// React's development-only props.key warning getter is not a real key, and
@@ -479,6 +484,45 @@ function finalizeElementDescriptor(descriptor: ElementDescriptor): ElementDescri
 		Object.freeze(descriptor);
 	}
 	return descriptor;
+}
+
+/** Server twin of the compiler-only scope-preserving JSX descriptor factory. */
+export function createScopedElement(
+	type: ServerComponent | string | typeof Fragment,
+	props: any,
+	readChildren: () => unknown,
+): ElementDescriptor {
+	const src = (props ?? null) as any;
+	const key = hasElementConfigKey(src) ? '' + src.key : null;
+	const copiedProps = copyElementConfig(src);
+	applyElementDefaultProps(type, copiedProps);
+
+	let resolved = false;
+	let resolvedScope: SSRScope | null = null;
+	let resolvedChildren: unknown;
+	const children = (): unknown => {
+		const scope = CURRENT_SCOPE;
+		if (!resolved || resolvedScope !== scope) {
+			const nextChildren = readChildren();
+			resolvedScope = scope;
+			resolvedChildren = nextChildren;
+			resolved = true;
+		}
+		return resolvedChildren;
+	};
+	const childProperty = { configurable: true, enumerable: true, get: children };
+	Object.defineProperty(copiedProps, 'children', childProperty);
+	SCOPED_ELEMENT_PROPS.add(copiedProps);
+	const descriptor: ElementDescriptor = {
+		$$kind: ELEMENT_TAG,
+		type,
+		props: copiedProps,
+		key,
+		ref: copiedProps.ref !== undefined ? copiedProps.ref : null,
+		children: null,
+	};
+	Object.defineProperty(descriptor, 'children', childProperty);
+	return finalizeElementDescriptor(descriptor);
 }
 
 // Server `createElement(type, props, ...children)` — produces the SAME descriptor
@@ -999,6 +1043,9 @@ export function ssrTextPre(v: unknown): string {
 // its descriptors the spread is a no-op copy — it stays as a defensive guard for
 // hand-rolled descriptors whose props/children were never reconciled.
 function ssrComponentDescriptor(d: ElementDescriptor, scope: SSRScope): string {
+	if (SCOPED_ELEMENT_PROPS.has(d.props)) {
+		return ssrComponent(scope, d.type as ServerComponent, d.props);
+	}
 	return ssrComponent(scope, d.type as ServerComponent, {
 		...d.props,
 		children: d.children ?? d.props?.children,

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -708,46 +708,82 @@ export function cloneElement(
 	if (!isElementDescriptor(element)) {
 		throw new Error(formatServerError(4));
 	}
-	const props = copyElementConfig(element.props);
+	// Preserve deferred children until their represented component owns the read.
+	let scopedChildren: (() => unknown) | undefined;
+	let props: any;
+	if (SCOPED_ELEMENT_PROPS.has(element.props)) {
+		scopedChildren = Object.getOwnPropertyDescriptor(element, 'children')!.get;
+		props = {};
+		for (const name in element.props) {
+			if (
+				name !== 'key' &&
+				name !== 'children' &&
+				Object.prototype.hasOwnProperty.call(element.props, name)
+			) {
+				props[name] = element.props[name];
+			}
+		}
+	} else {
+		props = copyElementConfig(element.props);
+	}
 	let key = element.key;
+	let replacedChildren = false;
 	if (config != null) {
 		if (hasElementConfigKey(config)) key = '' + config.key;
 		for (const name in config) {
 			if (name === 'key') continue;
 			if (name === 'ref' && config.ref === undefined) continue;
-			if (Object.prototype.hasOwnProperty.call(config, name)) props[name] = config[name];
+			if (Object.prototype.hasOwnProperty.call(config, name)) {
+				props[name] = config[name];
+				if (name === 'children') replacedChildren = true;
+			}
 		}
 	}
 	const n = children.length;
 	let kids: any;
+	let childProperty: PropertyDescriptor | undefined;
 	if (n === 1) {
 		kids = children[0];
 	} else if (n > 1) {
 		kids = children;
+	} else if (scopedChildren !== undefined && !replacedChildren) {
+		childProperty = { configurable: true, enumerable: true, get: scopedChildren };
+		Object.defineProperty(props, 'children', childProperty);
+		SCOPED_ELEMENT_PROPS.add(props);
+		kids = null;
 	} else {
 		// No new children: reuse `config.children` (now merged into props) or the original.
 		kids = 'children' in props ? props.children : element.children;
 	}
 	if (n > 0) props.children = kids;
-	return finalizeElementDescriptor({
+	const descriptor: ElementDescriptor = {
 		$$kind: ELEMENT_TAG,
 		type: element.type,
 		props,
 		key,
 		ref: props.ref !== undefined ? props.ref : null,
 		children: kids ?? null,
-	});
+	};
+	if (childProperty !== undefined) Object.defineProperty(descriptor, 'children', childProperty);
+	return finalizeElementDescriptor(descriptor);
 }
 
 function cloneAndReplaceElementKey(element: ElementDescriptor, key: string): ElementDescriptor {
-	return finalizeElementDescriptor({
+	// Traversal changes only the key, never the scope that resolves its children.
+	const scopedChildren = SCOPED_ELEMENT_PROPS.has(element.props);
+	const descriptor: ElementDescriptor = {
 		$$kind: ELEMENT_TAG,
 		type: element.type,
 		props: element.props,
 		key,
 		ref: element.ref,
-		children: element.children,
-	});
+		children: scopedChildren ? null : element.children,
+	};
+	if (scopedChildren) {
+		const get = Object.getOwnPropertyDescriptor(element, 'children')!.get;
+		Object.defineProperty(descriptor, 'children', { configurable: true, enumerable: true, get });
+	}
+	return finalizeElementDescriptor(descriptor);
 }
 
 function escapeElementKey(key: string): string {

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -2761,6 +2761,30 @@ function rewindComponentReplayState(
 // byte-identical to a single pass rendered directly with the settled state. A
 // suspension or real error propagates as before (the discarded updates die with
 // the pass; the suspense retry re-runs the initializers, exactly like Fizz).
+function replayUpdatedComponentBody(
+	comp: ServerComponent,
+	props: any,
+	scope: SSRScope,
+	frame: Frame | null,
+	hp: HookPass,
+	snapshot: ReturnType<typeof captureComponentReplayState>,
+	warmPlanCheckpoint: number,
+): unknown {
+	let passes = 1;
+	let out: unknown;
+	do {
+		if (++passes > MAX_RENDER_PHASE_PASSES) {
+			throw new Error(formatServerError(9));
+		}
+		hp.update = false;
+		hp.occ = new Map();
+		rewindComponentReplayState(snapshot, scope, frame);
+		ACTIVE_PU_WARM_PLANS.length = warmPlanCheckpoint;
+		out = comp(props ?? {}, scope, undefined);
+	} while (hp.update);
+	return out;
+}
+
 function invokeComponentBody(
 	comp: ServerComponent,
 	props: any,
@@ -2774,17 +2798,9 @@ function invokeComponentBody(
 	HOOK_PASS = hp;
 	try {
 		ACTIVE_PU_WARM_PLANS.length = warmPlanCheckpoint;
-		let out = comp(props ?? {}, scope, undefined);
-		let passes = 1;
-		while (hp.update) {
-			if (++passes > MAX_RENDER_PHASE_PASSES) {
-				throw new Error(formatServerError(9));
-			}
-			hp.update = false;
-			hp.occ = new Map();
-			rewindComponentReplayState(snapshot, scope, frame);
-			ACTIVE_PU_WARM_PLANS.length = warmPlanCheckpoint;
-			out = comp(props ?? {}, scope, undefined);
+		let out: unknown = comp(props ?? {}, scope, undefined);
+		if (hp.update) {
+			out = replayUpdatedComponentBody(comp, props, scope, frame, hp, snapshot, warmPlanCheckpoint);
 		}
 		return out;
 	} finally {
@@ -2830,10 +2846,36 @@ function renderComponentFramed(
 		// instead, mirroring the client where such a return flows through the block's
 		// childSlot. Normalize it the same way (ssrChild = the server childSlot), or it
 		// would stringify to `[object Object]`.
-		// Every component gets an independent replay boundary. A body with no
-		// syntactic calls can still execute user code through a getter, Proxy, or
-		// coercion; that code may call hooks or schedule render-phase updates.
-		const out = invokeComponentBody(comp, props, scope, frame);
+		// Every component gets an independent replay boundary. Invoke its first
+		// pass directly in this frame: otherwise each recursive component retains
+		// an extra invokeComponentBody frame and a legitimate 1,000-level Fizz tree
+		// exceeds the cold JavaScript stack. Render-phase retries are uncommon, so
+		// their shared loop lives behind a cold branch without charging that extra
+		// frame to normal component nesting.
+		const previousHookPass = HOOK_PASS;
+		const hookPass: HookPass = { hooks: new Map(), occ: new Map(), update: false };
+		const replaySnapshot = captureComponentReplayState(scope, frame);
+		const warmPlanCheckpoint = ACTIVE_PU_WARM_PLANS.length;
+		let out: unknown;
+		HOOK_PASS = hookPass;
+		try {
+			ACTIVE_PU_WARM_PLANS.length = warmPlanCheckpoint;
+			out = comp(props ?? {}, scope, undefined);
+			if (hookPass.update) {
+				out = replayUpdatedComponentBody(
+					comp,
+					props,
+					scope,
+					frame,
+					hookPass,
+					replaySnapshot,
+					warmPlanCheckpoint,
+				);
+			}
+		} finally {
+			ACTIVE_PU_WARM_PLANS.length = warmPlanCheckpoint;
+			HOOK_PASS = previousHookPass;
+		}
 		const inner = typeof out === 'string' ? out : out == null ? '' : ssrChild(out, scope);
 		// Wrap the child's output in a hydration block range so the client's
 		// componentSlot can ADOPT it during hydration (its `<!--[-->`/`<!--]-->`

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -5229,6 +5229,15 @@ function childrenAsBody(children: unknown): ComponentBody {
 	};
 }
 
+// Descriptor children remain inspectable values, but a scoped JSX descriptor
+// resolves them only after its represented boundary enters its try body. Reading
+// the accessor while constructing that body would move throws and suspension
+// outside the boundary, recreating the eager-JSX ownership bug.
+function scopedChildrenAsBody(props: { children: unknown }): ComponentBody {
+	if (!SCOPED_ELEMENT_PROPS.has(props)) return childrenAsBody(props.children);
+	return (_props, scope, extra) => childrenAsBody(props.children)(undefined, scope, extra);
+}
+
 /**
  * Records which children dialect (1 = compiled body, 2 = descriptor) a scope last rendered, so a
  * flip can be detected. Lives in the hook map, whose Symbol keys are disjoint from the numeric
@@ -6348,7 +6357,7 @@ export const Suspense: ComponentBody<{ fallback?: unknown; children: unknown }> 
 				scope,
 				0,
 				block.parentNode,
-				childrenAsBody(props.children),
+				scopedChildrenAsBody(props),
 				null,
 				pendingBody,
 				block.endMarker,
@@ -6415,7 +6424,7 @@ export const ErrorBoundary: ComponentBody<{
 			scope,
 			0,
 			block.parentNode,
-			childrenAsBody(props.children),
+			scopedChildrenAsBody(props),
 			catchBody,
 			null,
 			block.endMarker,
@@ -13140,6 +13149,10 @@ function elementKeyWasProvided(descriptor: ElementDescriptor): boolean {
 // missing-key validation state out of band so rebasing an unkeyed element from
 // a dynamic collection does not accidentally silence the renderer warning.
 const ELEMENTS_MISSING_LIST_KEY = new WeakSet<object>();
+// Only compiler-authored descriptors with a deferred child body enter this
+// collection. Ordinary createElement calls retain their exact public shape and
+// allocation path.
+const SCOPED_ELEMENT_PROPS = new WeakSet<object>();
 export interface ElementDescriptor<P = any> {
 	$$kind: typeof ELEMENT_TAG;
 	// A compiled ComponentBody (the fast/common case, e.g. `root.render(<App/>)`)
@@ -13207,6 +13220,68 @@ function finalizeElementDescriptor<P>(descriptor: ElementDescriptor<P>): Element
 	}
 	return descriptor;
 }
+
+/**
+ * Compiler-only JSX descriptor whose child tree resolves in its rendered scope.
+ *
+ * Matching accessors preserve the ordinary descriptor type, props, key, ref, and
+ * synchronously inspectable children without introducing component boundaries or
+ * hydration markers. Scope/context-aware memoization prevents one module-level
+ * element from retaining another provider's children or stale context values.
+ *
+ * @internal
+ */
+export function createScopedElement<P>(
+	type: ComponentBody<P> | string | typeof Fragment,
+	props: P | undefined,
+	readChildren: () => unknown,
+): ElementDescriptor<P> {
+	const src = (props ?? null) as any;
+	const hasKey = hasElementConfigKey(src);
+	const key = hasKey ? '' + src.key : null;
+	const copiedProps = copyElementConfig(src);
+	applyElementDefaultProps(type, copiedProps);
+
+	let resolved = false;
+	let resolvedScope: Scope | null = null;
+	let resolvedEpoch = 0;
+	let resolvedChildren: unknown;
+	const children = (): unknown => {
+		const scope = CURRENT_SCOPE;
+		const epoch = COMPILER_CACHE_CONTEXT_EPOCH;
+		if (!resolved || resolvedScope !== scope || resolvedEpoch !== epoch) {
+			const nextChildren = readChildren();
+			resolvedScope = scope;
+			resolvedEpoch = epoch;
+			resolvedChildren = nextChildren;
+			resolved = true;
+		}
+		return resolvedChildren;
+	};
+	const childProperty = { configurable: true, enumerable: true, get: children };
+	Object.defineProperty(copiedProps, 'children', childProperty);
+	SCOPED_ELEMENT_PROPS.add(copiedProps);
+
+	const descriptor: ElementDescriptor<P> = {
+		$$kind: ELEMENT_TAG,
+		type,
+		props: copiedProps as P,
+		key,
+		ref: copiedProps.ref !== undefined ? copiedProps.ref : null,
+		children: null,
+	};
+	Object.defineProperty(descriptor, 'children', childProperty);
+	if (
+		key === null &&
+		src != null &&
+		(typeof src === 'object' || typeof src === 'function') &&
+		'key' in src
+	) {
+		KEYED_ELEMENT_DESCRIPTORS.add(descriptor);
+	}
+	return finalizeElementDescriptor(descriptor);
+}
+
 // React-shape `createElement(type, props, ...children)`. Two-arg calls
 // (`createElement(Comp, props)`) stay the component-value form the compiler emits
 // for `{<Comp/>}`. With a string `type` and/or explicit children it produces a

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -13380,9 +13380,23 @@ export function cloneElement<P>(
 	if (!isElementDescriptor(element)) {
 		throw new Error(formatClientError(4));
 	}
-	const props = copyElementConfig(element.props);
+	let scopedChildren: (() => unknown) | undefined;
+	let props: any;
+	if (SCOPED_ELEMENT_PROPS.has(element.props as object)) {
+		// Copy a scoped descriptor's child accessor without evaluating it in the caller's scope.
+		scopedChildren = Object.getOwnPropertyDescriptor(element, 'children')!.get;
+		props = {};
+		for (const name in element.props) {
+			if (name !== 'key' && name !== 'children' && hasOwnProp.call(element.props, name)) {
+				props[name] = (element.props as any)[name];
+			}
+		}
+	} else {
+		props = copyElementConfig(element.props);
+	}
 	let key = element.key;
 	let hasKeyOverride = false;
+	let replacedChildren = false;
 	if (config != null) {
 		hasKeyOverride = hasElementConfigKey(config);
 		if (hasKeyOverride) key = '' + config.key;
@@ -13391,16 +13405,25 @@ export function cloneElement<P>(
 			// React 19 keeps refs as props, but cloneElement treats an explicitly
 			// undefined ref as absent for backwards compatibility.
 			if (name === 'ref' && config.ref === undefined) continue;
-			if (hasOwnProp.call(config, name)) props[name] = config[name];
+			if (hasOwnProp.call(config, name)) {
+				props[name] = config[name];
+				if (name === 'children') replacedChildren = true;
+			}
 		}
 	}
 	const n = children.length;
 	let kids: any;
+	let childProperty: PropertyDescriptor | undefined;
 	if (n === 1) {
 		kids = children[0];
 	} else if (n > 1) {
 		POSITIONAL_CHILDREN.add(children);
 		kids = children;
+	} else if (scopedChildren !== undefined && !replacedChildren) {
+		childProperty = { configurable: true, enumerable: true, get: scopedChildren };
+		Object.defineProperty(props, 'children', childProperty);
+		SCOPED_ELEMENT_PROPS.add(props);
+		kids = null;
 	} else {
 		// No new children: reuse `config.children` (now merged into props) or the original.
 		kids = 'children' in props ? props.children : element.children;
@@ -13414,6 +13437,7 @@ export function cloneElement<P>(
 		ref: props.ref !== undefined ? props.ref : null,
 		children: kids ?? null,
 	};
+	if (childProperty !== undefined) Object.defineProperty(descriptor, 'children', childProperty);
 	// Only a nullish result key needs the out-of-band record (see createElement).
 	if (
 		key === null &&
@@ -13432,14 +13456,22 @@ export function cloneElement<P>(
 }
 
 function cloneAndReplaceElementKey(element: ElementDescriptor, key: string): ElementDescriptor {
+	const scoped = SCOPED_ELEMENT_PROPS.has(element.props);
 	const descriptor: ElementDescriptor = {
 		$$kind: ELEMENT_TAG,
 		type: element.type,
 		props: element.props,
 		key,
 		ref: element.ref,
-		children: element.children,
+		children: scoped ? null : element.children,
 	};
+	if (scoped) {
+		Object.defineProperty(descriptor, 'children', {
+			configurable: true,
+			enumerable: true,
+			get: Object.getOwnPropertyDescriptor(element, 'children')!.get!,
+		});
+	}
 	// `key` is a real (non-null) string here, so presence is already implied.
 	if (ELEMENTS_MISSING_LIST_KEY.has(element)) ELEMENTS_MISSING_LIST_KEY.add(descriptor);
 	return finalizeElementDescriptor(descriptor);

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -13221,6 +13221,67 @@ function finalizeElementDescriptor<P>(descriptor: ElementDescriptor<P>): Element
 	return descriptor;
 }
 
+const SCOPED_VALUE_RECORD: unique symbol = Symbol('octane.scopedValue');
+
+type ScopedValueDescriptor<P> = ElementDescriptor<P> & {
+	readonly [SCOPED_VALUE_RECORD]?: () => ElementDescriptor<P>;
+};
+
+/**
+ * Preserve an inspectable JSX descriptor while deferring its complete record.
+ *
+ * The marker stays eagerly available to public element checks, while inspecting
+ * any actual field resolves type, props, key, ref, and children together in the
+ * current render scope. A shared value is rebuilt when its provider scope or
+ * context epoch changes, just like a scoped element's deferred children.
+ *
+ * @internal
+ */
+export function createScopedValue<P>(
+	readElement: () => ElementDescriptor<P>,
+): ElementDescriptor<P> {
+	let resolved: ElementDescriptor<P> | undefined;
+	let resolvedScope: Scope | null = null;
+	let resolvedEpoch = 0;
+
+	const resolve = (): ElementDescriptor<P> => {
+		const scope = CURRENT_SCOPE;
+		const epoch = COMPILER_CACHE_CONTEXT_EPOCH;
+		if (resolved === undefined || resolvedScope !== scope || resolvedEpoch !== epoch) {
+			const next = readElement();
+			if (next.key === null && KEYED_ELEMENT_DESCRIPTORS.has(next)) {
+				KEYED_ELEMENT_DESCRIPTORS.add(descriptor);
+			}
+			resolvedScope = scope;
+			resolvedEpoch = epoch;
+			resolved = next;
+		}
+		return resolved;
+	};
+
+	const descriptor: ElementDescriptor<P> = {
+		$$kind: ELEMENT_TAG,
+		get type() {
+			return resolve().type;
+		},
+		get props() {
+			return resolve().props;
+		},
+		get key() {
+			return resolve().key;
+		},
+		get ref() {
+			return resolve().ref;
+		},
+		get children() {
+			return resolve().children;
+		},
+	};
+	Object.defineProperty(descriptor, SCOPED_VALUE_RECORD, { value: resolve });
+	if (process.env.NODE_ENV !== 'production') Object.freeze(descriptor);
+	return descriptor;
+}
+
 /**
  * Compiler-only JSX descriptor whose child tree resolves in its rendered scope.
  *
@@ -14943,7 +15004,13 @@ function getDeoptDesc(n: Node): ElementDescriptor | undefined {
 	return (n as Node & DeoptStamped)[DEOPT_DESC];
 }
 function setDeoptDesc(el: Element, d: ElementDescriptor): void {
-	(el as Element & DeoptStamped)[DEOPT_DESC] = d;
+	// Preserve the record committed to this DOM node. A deferred JSX shell can
+	// resolve differently after a Provider update; stamping the shell itself
+	// would make both sides of the next prop diff observe the new record and
+	// would run user code outside render while Suspense detaches subtree refs.
+	const resolveScopedRecord = (d as ScopedValueDescriptor<any>)[SCOPED_VALUE_RECORD];
+	(el as Element & DeoptStamped)[DEOPT_DESC] =
+		resolveScopedRecord === undefined ? d : resolveScopedRecord();
 }
 
 type DeoptWrapperKind = 'array' | 'fragment';

--- a/packages/octane/src/server/index.ts
+++ b/packages/octane/src/server/index.ts
@@ -103,6 +103,7 @@ export {
 	// Compiler-emitted codegen helpers (private ABI — see module doc)
 	markChildrenBlock,
 	createElement,
+	createScopedValue,
 	createScopedElement,
 	positionalChildren,
 	escapeHtml,

--- a/packages/octane/src/server/index.ts
+++ b/packages/octane/src/server/index.ts
@@ -103,6 +103,7 @@ export {
 	// Compiler-emitted codegen helpers (private ABI — see module doc)
 	markChildrenBlock,
 	createElement,
+	createScopedElement,
 	positionalChildren,
 	escapeHtml,
 	escapeAttr,

--- a/packages/octane/tests/_fixtures/scoped-jsx-values.tsx
+++ b/packages/octane/tests/_fixtures/scoped-jsx-values.tsx
@@ -126,6 +126,55 @@ export function GetterContext() {
 	return <section>{content}</section>;
 }
 
+export function FragmentContext() {
+	const content = <>{use(ValueContext)}</>;
+	return (
+		<ValueContext.Provider value="inner">
+			<span data-context="fragment">{content}</span>
+		</ValueContext.Provider>
+	);
+}
+
+export function FragmentGetterContext() {
+	const content = <>{getterValue.current}</>;
+	return (
+		<ValueContext.Provider value="inner">
+			<span data-context="fragment-getter">{content}</span>
+		</ValueContext.Provider>
+	);
+}
+
+export function NestedFragmentContext() {
+	const content = (
+		<>
+			<>{getterValue.current}</>
+		</>
+	);
+	return (
+		<ValueContext.Provider value="inner">
+			<span data-context="fragment-nested">{content}</span>
+		</ValueContext.Provider>
+	);
+}
+
+export function FragmentPropContext() {
+	const content = <Slot content={<>{getterValue.current}</>} />;
+	return (
+		<ValueContext.Provider value="inner">
+			<section data-context="fragment-prop">{content}</section>
+		</ValueContext.Provider>
+	);
+}
+
+export function FragmentArrayContext() {
+	const content = [<>{getterValue.current}</>];
+	return (
+		<ValueContext.Provider value="inner">
+			<span data-context="fragment-array">{content[0]}</span>
+		</ValueContext.Provider>
+	);
+}
+
 export function ProxyContext() {
 	const content = (
 		<ValueContext.Provider value="inner">
@@ -265,6 +314,13 @@ export function WrappedGetterErrorValue() {
 	);
 }
 
+export function FragmentErrorValue() {
+	const content = <>{throwingGetter.current}</>;
+	return (
+		<ErrorBoundary fallback={<strong data-fallback="inner">inner</strong>}>{content}</ErrorBoundary>
+	);
+}
+
 export function MappedErrorValue() {
 	const content = <span>{throwingGetter.current}</span>;
 	const mapped = Children.map(content, (child) => child);
@@ -329,6 +385,15 @@ export function GetterSuspenseValue(props: { promise: Promise<string> }) {
 		</WrappedSuspense>
 	);
 	return <section data-outlet="suspense">{content}</section>;
+}
+
+export function FragmentSuspense(props: { promise: Promise<string> }) {
+	const content = <>{use(props.promise)}</>;
+	return (
+		<Suspense fallback={<i data-fallback="pending">pending</i>}>
+			<span data-resolved="fragment">{content}</span>
+		</Suspense>
+	);
 }
 
 export function MappedSuspense(props: { promise: Promise<string> }) {

--- a/packages/octane/tests/_fixtures/scoped-jsx-values.tsx
+++ b/packages/octane/tests/_fixtures/scoped-jsx-values.tsx
@@ -21,6 +21,12 @@ const getterValue = {
 	},
 };
 
+const contextualAttributes = {
+	get 'data-value'() {
+		return use(ValueContext);
+	},
+};
+
 const proxyValue = new Proxy(
 	{ current: 'outer' },
 	{
@@ -53,6 +59,28 @@ const sharedContextChild = <span data-context="shared">{getterValue.current}</sp
 
 function Slot(props: { content: OctaneNode }) {
 	return <section data-outlet="slot">{props.content}</section>;
+}
+
+function ContextAttributeComponent(props: { value: string }) {
+	return (
+		<strong data-context="root-component-attribute" data-value={props.value}>
+			attribute
+		</strong>
+	);
+}
+
+function InspectContextAttribute(props: { child: OctaneNode }) {
+	const child = Children.only(props.child) as ElementDescriptor;
+	const cloned = cloneElement(child, { 'data-inspected': 'yes' });
+	return (
+		<section
+			data-root-valid={String(isValidElement(child))}
+			data-root-type={String(child.type)}
+			data-observed-value={String(child.props['data-value'])}
+		>
+			{cloned}
+		</section>
+	);
 }
 
 function InnerFragmentComponent() {
@@ -95,6 +123,75 @@ export function DirectContext() {
 	return (
 		<ValueContext.Provider value="inner">
 			<span data-context="direct">{use(ValueContext)}</span>
+		</ValueContext.Provider>
+	);
+}
+
+export function DirectGetterAttributeContext() {
+	return (
+		<ValueContext.Provider value="inner">
+			<span data-context="direct-attribute" data-value={getterValue.current}>
+				attribute
+			</span>
+		</ValueContext.Provider>
+	);
+}
+
+export function DirectSpreadAttributeContext() {
+	return (
+		<ValueContext.Provider value="inner">
+			<span data-context="direct-spread-attribute" {...contextualAttributes}>
+				attribute
+			</span>
+		</ValueContext.Provider>
+	);
+}
+
+export function DirectDynamicComponentContext() {
+	return (
+		<ValueContext.Provider value="inner">
+			<contextualFragmentComponent.current />
+		</ValueContext.Provider>
+	);
+}
+
+export function RootHostAttributeContext() {
+	const content = (
+		<span data-context="root-host-attribute" data-value={getterValue.current}>
+			attribute
+		</span>
+	);
+	return <ValueContext.Provider value="inner">{content}</ValueContext.Provider>;
+}
+
+export function RootSpreadAttributeContext() {
+	const content = (
+		<span data-context="root-spread-attribute" {...contextualAttributes}>
+			attribute
+		</span>
+	);
+	return <ValueContext.Provider value="inner">{content}</ValueContext.Provider>;
+}
+
+export function RootComponentAttributeContext() {
+	const content = <ContextAttributeComponent value={getterValue.current} />;
+	return <ValueContext.Provider value="inner">{content}</ValueContext.Provider>;
+}
+
+export function RootDynamicComponentContext() {
+	const content = <contextualFragmentComponent.current />;
+	return <ValueContext.Provider value="inner">{content}</ValueContext.Provider>;
+}
+
+export function RootInspectedAttributeContext() {
+	const content = (
+		<span data-context="root-inspected-attribute" data-value={getterValue.current}>
+			attribute
+		</span>
+	);
+	return (
+		<ValueContext.Provider value="inner">
+			<InspectContextAttribute child={content} />
 		</ValueContext.Provider>
 	);
 }
@@ -324,6 +421,20 @@ export function SharedDescriptorProviders(props: { first: string; second: string
 	);
 }
 
+export function SharedRootAttributeProviders(props: { first: string; second: string }) {
+	const content = (
+		<span data-context="shared-root" data-value={getterValue.current}>
+			{getterValue.current}
+		</span>
+	);
+	return (
+		<section data-outlet="shared-root">
+			<ValueContext.Provider value={props.first}>{content}</ValueContext.Provider>
+			<ValueContext.Provider value={props.second}>{content}</ValueContext.Provider>
+		</section>
+	);
+}
+
 export function BuiltInErrorValue() {
 	const content = (
 		<ErrorBoundary fallback={<strong data-fallback="inner">inner</strong>}>
@@ -359,6 +470,13 @@ export function WrappedGetterErrorValue() {
 
 export function FragmentErrorValue() {
 	const content = <>{throwingGetter.current}</>;
+	return (
+		<ErrorBoundary fallback={<strong data-fallback="inner">inner</strong>}>{content}</ErrorBoundary>
+	);
+}
+
+export function RootGetterErrorValue() {
+	const content = <span data-root-error={throwingGetter.current}>unreachable</span>;
 	return (
 		<ErrorBoundary fallback={<strong data-fallback="inner">inner</strong>}>{content}</ErrorBoundary>
 	);
@@ -437,6 +555,20 @@ export function FragmentSuspense(props: { promise: Promise<string> }) {
 			<span data-resolved="fragment">{content}</span>
 		</Suspense>
 	);
+}
+
+export function RootGetterSuspense(props: { promise: Promise<string> }) {
+	const suspendedValue = {
+		get current() {
+			return use(props.promise);
+		},
+	};
+	const content = (
+		<span data-resolved="root-attribute" data-value={suspendedValue.current}>
+			{'resolved'}
+		</span>
+	);
+	return <Suspense fallback={<i data-fallback="pending">pending</i>}>{content}</Suspense>;
 }
 
 export function MappedSuspense(props: { promise: Promise<string> }) {

--- a/packages/octane/tests/_fixtures/scoped-jsx-values.tsx
+++ b/packages/octane/tests/_fixtures/scoped-jsx-values.tsx
@@ -1,0 +1,289 @@
+/** @jsxImportSource octane */
+
+import {
+	Children,
+	ErrorBoundary,
+	Suspense,
+	cloneElement,
+	createContext,
+	createElement,
+	isValidElement,
+	use,
+	type ElementDescriptor,
+	type OctaneNode,
+} from 'octane';
+
+const ValueContext = createContext('outer');
+
+const getterValue = {
+	get current() {
+		return use(ValueContext);
+	},
+};
+
+const proxyValue = new Proxy(
+	{ current: 'outer' },
+	{
+		get(target, key, receiver) {
+			return key === 'current' ? use(ValueContext) : Reflect.get(target, key, receiver);
+		},
+	},
+);
+
+const coercibleValue = {
+	[Symbol.toPrimitive]() {
+		return use(ValueContext);
+	},
+};
+
+const iterableValue = {
+	*[Symbol.iterator]() {
+		yield use(ValueContext);
+	},
+};
+
+const computedKey = {
+	[Symbol.toPrimitive]() {
+		return use(ValueContext);
+	},
+};
+
+const valuesByContext: Record<string, string> = { inner: 'inner', outer: 'outer' };
+const sharedContextChild = <span data-context="shared">{getterValue.current}</span>;
+
+function Slot(props: { content: OctaneNode }) {
+	return <section data-outlet="slot">{props.content}</section>;
+}
+
+function WrappedErrorBoundary(props: { children: OctaneNode }) {
+	return (
+		<ErrorBoundary fallback={<strong data-fallback="inner">inner</strong>}>
+			{props.children}
+		</ErrorBoundary>
+	);
+}
+
+function WrappedSuspense(props: { children: OctaneNode }) {
+	return <Suspense fallback={<i data-fallback="pending">pending</i>}>{props.children}</Suspense>;
+}
+
+function readFailure(): string {
+	throw new Error('scoped failure');
+}
+
+const throwingGetter = {
+	get current(): string {
+		throw new Error('scoped getter failure');
+	},
+};
+
+export function DirectContext() {
+	return (
+		<ValueContext.Provider value="inner">
+			<span data-context="direct">{use(ValueContext)}</span>
+		</ValueContext.Provider>
+	);
+}
+
+export function VariableContext() {
+	const content = (
+		<ValueContext.Provider value="inner">
+			<span data-context="variable">{use(ValueContext)}</span>
+		</ValueContext.Provider>
+	);
+	return <section data-outlet="variable">{content}</section>;
+}
+
+export function PropContext() {
+	return (
+		<Slot
+			content={
+				<ValueContext.Provider value="inner">
+					<span data-context="prop">{use(ValueContext)}</span>
+				</ValueContext.Provider>
+			}
+		/>
+	);
+}
+
+export function NestedContext() {
+	const nested = {
+		items: [
+			<ValueContext.Provider value="inner">
+				<span data-context="nested">{use(ValueContext)}</span>
+			</ValueContext.Provider>,
+		],
+	};
+	return <section data-outlet="nested">{nested.items[0]}</section>;
+}
+
+export function GetterContext() {
+	const content = (
+		<ValueContext.Provider value="inner">
+			<span data-context="getter">{getterValue.current}</span>
+		</ValueContext.Provider>
+	);
+	return <section>{content}</section>;
+}
+
+export function ProxyContext() {
+	const content = (
+		<ValueContext.Provider value="inner">
+			<span data-context="proxy">{proxyValue.current}</span>
+		</ValueContext.Provider>
+	);
+	return <section>{content}</section>;
+}
+
+export function CoercionContext() {
+	const content = (
+		<ValueContext.Provider value="inner">
+			<span data-context="coercion">{'' + coercibleValue}</span>
+		</ValueContext.Provider>
+	);
+	return <section>{content}</section>;
+}
+
+export function IterableContext() {
+	const content = (
+		<ValueContext.Provider value="inner">
+			<span data-context="iterable">{[...iterableValue]}</span>
+		</ValueContext.Provider>
+	);
+	return <section>{content}</section>;
+}
+
+export function OptionalComputedKeyContext() {
+	const content = (
+		<ValueContext.Provider value="inner">
+			<span data-context="optional-key">{valuesByContext?.[computedKey as unknown as string]}</span>
+		</ValueContext.Provider>
+	);
+	return <section>{content}</section>;
+}
+
+export function GetterAttributeContext() {
+	const content = (
+		<ValueContext.Provider value="inner">
+			<span data-context="attribute" data-value={getterValue.current}>
+				attribute
+			</span>
+		</ValueContext.Provider>
+	);
+	return <section>{content}</section>;
+}
+
+export function SharedDescriptorProviders(props: { first: string; second: string }) {
+	return (
+		<section data-outlet="shared">
+			<ValueContext.Provider value={props.first}>{sharedContextChild}</ValueContext.Provider>
+			<ValueContext.Provider value={props.second}>{sharedContextChild}</ValueContext.Provider>
+		</section>
+	);
+}
+
+export function BuiltInErrorValue() {
+	const content = (
+		<ErrorBoundary fallback={<strong data-fallback="inner">inner</strong>}>
+			<span>{readFailure()}</span>
+		</ErrorBoundary>
+	);
+	return (
+		<ErrorBoundary fallback={<strong data-fallback="outer">outer</strong>}>{content}</ErrorBoundary>
+	);
+}
+
+export function WrappedErrorValue() {
+	const content = (
+		<WrappedErrorBoundary>
+			<span>{readFailure()}</span>
+		</WrappedErrorBoundary>
+	);
+	return (
+		<ErrorBoundary fallback={<strong data-fallback="outer">outer</strong>}>{content}</ErrorBoundary>
+	);
+}
+
+export function WrappedGetterErrorValue() {
+	const content = (
+		<WrappedErrorBoundary>
+			<span>{throwingGetter.current}</span>
+		</WrappedErrorBoundary>
+	);
+	return (
+		<ErrorBoundary fallback={<strong data-fallback="outer">outer</strong>}>{content}</ErrorBoundary>
+	);
+}
+
+export function DirectSuspense(props: { promise: Promise<string> }) {
+	return (
+		<Suspense fallback={<i data-fallback="pending">pending</i>}>
+			<span data-resolved="direct">{use(props.promise)}</span>
+		</Suspense>
+	);
+}
+
+export function VariableSuspense(props: { promise: Promise<string> }) {
+	const content = (
+		<Suspense fallback={<i data-fallback="pending">pending</i>}>
+			<span data-resolved="variable">{use(props.promise)}</span>
+		</Suspense>
+	);
+	return <section data-outlet="suspense">{content}</section>;
+}
+
+export function WrappedSuspenseValue(props: { promise: Promise<string> }) {
+	const content = (
+		<WrappedSuspense>
+			<span data-resolved="wrapped">{use(props.promise)}</span>
+		</WrappedSuspense>
+	);
+	return <section data-outlet="suspense">{content}</section>;
+}
+
+export function GetterSuspenseValue(props: { promise: Promise<string> }) {
+	const suspendedValue = {
+		get current() {
+			return use(props.promise);
+		},
+	};
+	const content = (
+		<WrappedSuspense>
+			<span data-resolved="getter">{suspendedValue.current}</span>
+		</WrappedSuspense>
+	);
+	return <section data-outlet="suspense">{content}</section>;
+}
+
+function InspectChild(props: { child: OctaneNode }) {
+	const child = Children.only(props.child) as ElementDescriptor;
+	const cloned = cloneElement(child, { 'data-inspected': 'yes' });
+	return (
+		<section
+			data-valid={String(isValidElement(child))}
+			data-element-type={String(child.type)}
+			data-child-type={typeof child.props.children}
+		>
+			{cloned}
+		</section>
+	);
+}
+
+function collectionLabel() {
+	return 'inspected';
+}
+
+export function OrdinaryElementValue() {
+	const content = <span data-ordinary="yes">ordinary</span>;
+	return <InspectChild child={content} />;
+}
+
+export function InspectableExpressionValue() {
+	const content = <span data-ordinary="expression">{collectionLabel()}</span>;
+	return <InspectChild child={content} />;
+}
+
+export function DirectCreateElementValue() {
+	const content = createElement('span', { 'data-ordinary': 'create-element' }, 'direct');
+	return <InspectChild child={content} />;
+}

--- a/packages/octane/tests/_fixtures/scoped-jsx-values.tsx
+++ b/packages/octane/tests/_fixtures/scoped-jsx-values.tsx
@@ -173,6 +173,56 @@ export function GetterAttributeContext() {
 	return <section>{content}</section>;
 }
 
+export function MappedContext() {
+	const content = <span data-context="mapped">{getterValue.current}</span>;
+	const mapped = Children.map(content, (child) => child);
+	return <ValueContext.Provider value="inner">{mapped}</ValueContext.Provider>;
+}
+
+export function FlattenedContext() {
+	const content = <span data-context="flattened">{getterValue.current}</span>;
+	const flattened = Children.toArray(content);
+	return <ValueContext.Provider value="inner">{flattened}</ValueContext.Provider>;
+}
+
+export function ClonedContext() {
+	const content = <span data-context="cloned">{getterValue.current}</span>;
+	const cloned = cloneElement(content as ElementDescriptor, { 'data-cloned': 'yes' });
+	return <ValueContext.Provider value="inner">{cloned}</ValueContext.Provider>;
+}
+
+export function MappedClonedContext() {
+	const content = <span data-context="mapped-cloned">{getterValue.current}</span>;
+	const mapped = Children.map(content, (child) =>
+		cloneElement(child as ElementDescriptor, { 'data-cloned': 'yes' }),
+	);
+	return <ValueContext.Provider value="inner">{mapped}</ValueContext.Provider>;
+}
+
+export function ConfigReplacedScopedChild() {
+	const content = <span data-replacement="config">{throwingGetter.current}</span>;
+	const replaced = cloneElement(content as ElementDescriptor, { children: 'configured' });
+	return <section>{replaced}</section>;
+}
+
+export function ConfigUndefinedReplacedScopedChild() {
+	const content = <span data-replacement="config-undefined">{throwingGetter.current}</span>;
+	const replaced = cloneElement(content as ElementDescriptor, { children: undefined });
+	return <section>{replaced}</section>;
+}
+
+export function PositionalReplacedScopedChild() {
+	const content = <span data-replacement="positional">{throwingGetter.current}</span>;
+	const replaced = cloneElement(content as ElementDescriptor, {}, 'first-', 'second');
+	return <section>{replaced}</section>;
+}
+
+export function UndefinedReplacedScopedChild() {
+	const content = <span data-replacement="undefined">{throwingGetter.current}</span>;
+	const replaced = cloneElement(content as ElementDescriptor, {}, undefined);
+	return <section>{replaced}</section>;
+}
+
 export function SharedDescriptorProviders(props: { first: string; second: string }) {
 	return (
 		<section data-outlet="shared">
@@ -215,6 +265,32 @@ export function WrappedGetterErrorValue() {
 	);
 }
 
+export function MappedErrorValue() {
+	const content = <span>{throwingGetter.current}</span>;
+	const mapped = Children.map(content, (child) => child);
+	return (
+		<ErrorBoundary fallback={<strong data-fallback="inner">inner</strong>}>{mapped}</ErrorBoundary>
+	);
+}
+
+export function FlattenedErrorValue() {
+	const content = <span>{throwingGetter.current}</span>;
+	const flattened = Children.toArray(content);
+	return (
+		<ErrorBoundary fallback={<strong data-fallback="inner">inner</strong>}>
+			{flattened}
+		</ErrorBoundary>
+	);
+}
+
+export function ClonedErrorValue() {
+	const content = <span>{throwingGetter.current}</span>;
+	const cloned = cloneElement(content as ElementDescriptor, {});
+	return (
+		<ErrorBoundary fallback={<strong data-fallback="inner">inner</strong>}>{cloned}</ErrorBoundary>
+	);
+}
+
 export function DirectSuspense(props: { promise: Promise<string> }) {
 	return (
 		<Suspense fallback={<i data-fallback="pending">pending</i>}>
@@ -253,6 +329,24 @@ export function GetterSuspenseValue(props: { promise: Promise<string> }) {
 		</WrappedSuspense>
 	);
 	return <section data-outlet="suspense">{content}</section>;
+}
+
+export function MappedSuspense(props: { promise: Promise<string> }) {
+	const content = <span data-resolved="mapped">{use(props.promise)}</span>;
+	const mapped = Children.map(content, (child) => child);
+	return <Suspense fallback={<i data-fallback="pending">pending</i>}>{mapped}</Suspense>;
+}
+
+export function FlattenedSuspense(props: { promise: Promise<string> }) {
+	const content = <span data-resolved="flattened">{use(props.promise)}</span>;
+	const flattened = Children.toArray(content);
+	return <Suspense fallback={<i data-fallback="pending">pending</i>}>{flattened}</Suspense>;
+}
+
+export function ClonedSuspense(props: { promise: Promise<string> }) {
+	const content = <span data-resolved="cloned">{use(props.promise)}</span>;
+	const cloned = cloneElement(content as ElementDescriptor, {});
+	return <Suspense fallback={<i data-fallback="pending">pending</i>}>{cloned}</Suspense>;
 }
 
 function InspectChild(props: { child: OctaneNode }) {

--- a/packages/octane/tests/_fixtures/scoped-jsx-values.tsx
+++ b/packages/octane/tests/_fixtures/scoped-jsx-values.tsx
@@ -55,6 +55,20 @@ function Slot(props: { content: OctaneNode }) {
 	return <section data-outlet="slot">{props.content}</section>;
 }
 
+function InnerFragmentComponent() {
+	return <strong data-context="fragment-component-tag">inner</strong>;
+}
+
+function OuterFragmentComponent() {
+	return <strong data-context="fragment-component-tag">outer</strong>;
+}
+
+const contextualFragmentComponent = {
+	get current() {
+		return use(ValueContext) === 'inner' ? InnerFragmentComponent : OuterFragmentComponent;
+	},
+};
+
 function WrappedErrorBoundary(props: { children: OctaneNode }) {
 	return (
 		<ErrorBoundary fallback={<strong data-fallback="inner">inner</strong>}>
@@ -173,6 +187,35 @@ export function FragmentArrayContext() {
 			<span data-context="fragment-array">{content[0]}</span>
 		</ValueContext.Provider>
 	);
+}
+
+export function FragmentNestedExpressionContext() {
+	const content = (
+		<>
+			<strong data-context="fragment-nested-expression">{getterValue.current}</strong>
+		</>
+	);
+	return <ValueContext.Provider value="inner">{content}</ValueContext.Provider>;
+}
+
+export function FragmentNestedAttributeContext() {
+	const content = (
+		<>
+			<strong data-context="fragment-nested-attribute" data-value={getterValue.current}>
+				attribute
+			</strong>
+		</>
+	);
+	return <ValueContext.Provider value="inner">{content}</ValueContext.Provider>;
+}
+
+export function FragmentDynamicComponentContext() {
+	const content = (
+		<>
+			<contextualFragmentComponent.current />
+		</>
+	);
+	return <ValueContext.Provider value="inner">{content}</ValueContext.Provider>;
 }
 
 export function ProxyContext() {
@@ -428,8 +471,33 @@ function InspectChild(props: { child: OctaneNode }) {
 	);
 }
 
+function InspectIndexedChildren(props: { children: OctaneNode }) {
+	const children = Children.toArray(props.children);
+	const indexed = children[1];
+	return (
+		<section
+			data-fragment-count={String(children.length)}
+			data-fragment-type={isValidElement(indexed) ? String(indexed.type) : 'missing'}
+		>
+			{indexed}
+		</section>
+	);
+}
+
 function collectionLabel() {
 	return 'inspected';
+}
+
+export function IndexedFragmentChildren(props: { name: string }) {
+	return (
+		<InspectIndexedChildren
+			children={
+				<>
+					Hello <strong data-indexed="yes">{props.name}</strong>
+				</>
+			}
+		/>
+	);
 }
 
 export function OrdinaryElementValue() {

--- a/packages/octane/tests/conformance/fizz-streaming.test.ts
+++ b/packages/octane/tests/conformance/fizz-streaming.test.ts
@@ -687,6 +687,52 @@ describe('conformance: Fizz public streaming behavior', () => {
 		expect(result.html).toContain('<span id="deep-leaf">done</span>');
 	});
 
+	// Per ReactDOMFizzServer-test.js:8734.
+	it('renders a component tree one thousand levels deep through a readable stream', async () => {
+		const result = await collectReadableStream(server.DeepTree, { depth: 1_000 });
+		expect(result.errors).toEqual([]);
+		expect(result.html).toContain('<span id="deep-leaf">done</span>');
+	});
+
+	// Per ReactDOMFizzServer-test.js:8734.
+	it('renders a component tree one thousand levels deep through buffered SSR', () => {
+		const result = ServerRuntime.renderToString(server.DeepTree, { depth: 1_000 });
+		expect(result.html).toContain('<span id="deep-leaf">done</span>');
+	});
+
+	// Per ReactDOMFizzServer-test.js:8734 and ReactDOMFizzServerNode-test.js:453.
+	it('preserves Provider values around a component tree one thousand levels deep', async () => {
+		const ContextValue = ({ id }: { id: string }) =>
+			ServerRuntime.createElement('span', { id }, ServerRuntime.use(server.StreamContext));
+		const ProvidedDeepTree = () =>
+			ServerRuntime.createElement(
+				'section',
+				{ id: 'deep-context-root' },
+				ServerRuntime.createElement(
+					server.StreamContext.Provider,
+					{ value: 'deeply provided' },
+					ServerRuntime.createElement(server.DeepTree, { depth: 1_000 }),
+					ServerRuntime.createElement(ContextValue, { id: 'inside-deep-provider' }),
+				),
+				ServerRuntime.createElement(ContextValue, { id: 'outside-deep-provider' }),
+			);
+
+		const pipeable = await collectPipeableStream(ProvidedDeepTree);
+		const readable = await collectReadableStream(ProvidedDeepTree);
+		expect(pipeable.errors).toEqual([]);
+		expect(readable.errors).toEqual([]);
+
+		for (const result of [pipeable, readable, ServerRuntime.renderToString(ProvidedDeepTree)]) {
+			const template = document.createElement('template');
+			template.innerHTML = result.html;
+			expect(template.content.querySelector('#deep-leaf')?.textContent).toBe('done');
+			expect(template.content.querySelector('#inside-deep-provider')?.textContent).toBe(
+				'deeply provided',
+			);
+			expect(template.content.querySelector('#outside-deep-provider')?.textContent).toBe('default');
+		}
+	});
+
 	// Per ReactDOMServerIntegrationHooks-test.js:122, a state updater invoked
 	// outside its owning component's current render is inert on the server.
 	it('keeps a parent render-phase dispatcher isolated from a call-free child getter', async () => {

--- a/packages/octane/tests/render-prop.test.ts
+++ b/packages/octane/tests/render-prop.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
+import { type ComponentBody } from '../src/index.js';
 import { mount } from './_helpers';
-import { compile } from 'octane/compiler';
+import { loadCompiledFixtureSource } from './_server-fixture.js';
 import { App, AppFrag } from './_fixtures/render-prop.tsrx';
 
 // React-style render-prop children: `<Comp>{(data) => <jsx/>}</Comp>`. The arrow
@@ -26,15 +27,21 @@ describe('render-prop children (bare-JSX arrow)', () => {
 		r.unmount();
 	});
 
-	it('lowers a parenthesised arrow body to createElement (kept callable)', () => {
-		// The prettier plugin canonicalises `(v) => (<span/>)`, so assert the
-		// parenthesised source compiles via a string literal the formatter can't
-		// rewrite. The arrow is preserved; only its body is lowered.
+	it('keeps a parenthesised JSX render prop callable and renders its returned element', () => {
+		// Keep the authored parentheses in source bytes because formatting a fixture
+		// canonicalizes them away. Executing the output proves the render prop stays
+		// callable and its JSX result remains renderable without pinning a factory.
 		const src =
 			'function Provide(props) @{ <div>{props.children("hi")}</div> }\n' +
 			'export function App() @{ <Provide>{(v) => (<span class="rendered">{v as string}</span>)}</Provide> }';
-		const { code } = compile(src, 'rp-paren.tsrx', { mode: 'client' });
-		expect(code).not.toMatch(/<span/); // no raw (unlowered) JSX leaked
-		expect(code).toContain('(v) => _$createElement');
+		const fixture = loadCompiledFixtureSource<{ App: ComponentBody }>(src, {
+			id: 'rp-paren.tsrx',
+			mode: 'client',
+		});
+		const result = mount(fixture.App);
+		const rendered = result.find('.rendered');
+		expect(rendered.tagName).toBe('SPAN');
+		expect(rendered.textContent).toBe('hi');
+		result.unmount();
 	});
 });

--- a/packages/octane/tests/scoped-jsx-values.test.ts
+++ b/packages/octane/tests/scoped-jsx-values.test.ts
@@ -155,6 +155,56 @@ export function GetterAttributeContext() @{
 	<section>{content}</section>
 }
 
+export function MappedContext() @{
+	const content = <span data-context="mapped">{getterValue.current as string}</span>;
+	const mapped = Children.map(content, (child) => child);
+	<ValueContext.Provider value="inner">{mapped}</ValueContext.Provider>
+}
+
+export function FlattenedContext() @{
+	const content = <span data-context="flattened">{getterValue.current as string}</span>;
+	const flattened = Children.toArray(content);
+	<ValueContext.Provider value="inner">{flattened}</ValueContext.Provider>
+}
+
+export function ClonedContext() @{
+	const content = <span data-context="cloned">{getterValue.current as string}</span>;
+	const cloned = cloneElement(content as ElementDescriptor, { 'data-cloned': 'yes' });
+	<ValueContext.Provider value="inner">{cloned}</ValueContext.Provider>
+}
+
+export function MappedClonedContext() @{
+	const content = <span data-context="mapped-cloned">{getterValue.current as string}</span>;
+	const mapped = Children.map(content, (child) =>
+		cloneElement(child as ElementDescriptor, { 'data-cloned': 'yes' }),
+	);
+	<ValueContext.Provider value="inner">{mapped}</ValueContext.Provider>
+}
+
+export function ConfigReplacedScopedChild() @{
+	const content = <span data-replacement="config">{throwingGetter.current as string}</span>;
+	const replaced = cloneElement(content as ElementDescriptor, { children: 'configured' });
+	<section>{replaced}</section>
+}
+
+export function ConfigUndefinedReplacedScopedChild() @{
+	const content = <span data-replacement="config-undefined">{throwingGetter.current as string}</span>;
+	const replaced = cloneElement(content as ElementDescriptor, { children: undefined });
+	<section>{replaced}</section>
+}
+
+export function PositionalReplacedScopedChild() @{
+	const content = <span data-replacement="positional">{throwingGetter.current as string}</span>;
+	const replaced = cloneElement(content as ElementDescriptor, {}, 'first-', 'second');
+	<section>{replaced}</section>
+}
+
+export function UndefinedReplacedScopedChild() @{
+	const content = <span data-replacement="undefined">{throwingGetter.current as string}</span>;
+	const replaced = cloneElement(content as ElementDescriptor, {}, undefined);
+	<section>{replaced}</section>
+}
+
 export function SharedDescriptorProviders(props: { first: string; second: string }) @{
 	<section data-outlet="shared">
 		<ValueContext.Provider value={props.first}>{sharedContextChild}</ValueContext.Provider>
@@ -196,6 +246,24 @@ export function WrappedGetterErrorValue() @{
 	<ErrorBoundary fallback={<strong data-fallback="outer">outer</strong>}>{content}</ErrorBoundary>
 }
 
+export function MappedErrorValue() @{
+	const content = <span>{throwingGetter.current as string}</span>;
+	const mapped = Children.map(content, (child) => child);
+	<ErrorBoundary fallback={<strong data-fallback="inner">inner</strong>}>{mapped}</ErrorBoundary>
+}
+
+export function FlattenedErrorValue() @{
+	const content = <span>{throwingGetter.current as string}</span>;
+	const flattened = Children.toArray(content);
+	<ErrorBoundary fallback={<strong data-fallback="inner">inner</strong>}>{flattened}</ErrorBoundary>
+}
+
+export function ClonedErrorValue() @{
+	const content = <span>{throwingGetter.current as string}</span>;
+	const cloned = cloneElement(content as ElementDescriptor, {});
+	<ErrorBoundary fallback={<strong data-fallback="inner">inner</strong>}>{cloned}</ErrorBoundary>
+}
+
 export function DirectSuspense(props: { promise: Promise<string> }) @{
 	<Suspense fallback={<i data-fallback="pending">pending</i>}>
 		<span data-resolved="direct">{use(props.promise) as string}</span>
@@ -226,6 +294,24 @@ export function GetterSuspenseValue(props: { promise: Promise<string> }) @{
 		<span data-resolved="getter">{suspendedValue.current as string}</span>
 	</WrappedSuspense>;
 	<section data-outlet="suspense">{content}</section>
+}
+
+export function MappedSuspense(props: { promise: Promise<string> }) @{
+	const content = <span data-resolved="mapped">{use(props.promise) as string}</span>;
+	const mapped = Children.map(content, (child) => child);
+	<Suspense fallback={<i data-fallback="pending">pending</i>}>{mapped}</Suspense>
+}
+
+export function FlattenedSuspense(props: { promise: Promise<string> }) @{
+	const content = <span data-resolved="flattened">{use(props.promise) as string}</span>;
+	const flattened = Children.toArray(content);
+	<Suspense fallback={<i data-fallback="pending">pending</i>}>{flattened}</Suspense>
+}
+
+export function ClonedSuspense(props: { promise: Promise<string> }) @{
+	const content = <span data-resolved="cloned">{use(props.promise) as string}</span>;
+	const cloned = cloneElement(content as ElementDescriptor, {});
+	<Suspense fallback={<i data-fallback="pending">pending</i>}>{cloned}</Suspense>
 }
 
 function InspectChild(props: { child: OctaneNode }) @{
@@ -310,6 +396,10 @@ const contextScenarios = [
 	['CoercionContext', '[data-context="coercion"]'],
 	['IterableContext', '[data-context="iterable"]'],
 	['OptionalComputedKeyContext', '[data-context="optional-key"]'],
+	['MappedContext', '[data-context="mapped"]'],
+	['FlattenedContext', '[data-context="flattened"]'],
+	['ClonedContext', '[data-context="cloned"]'],
+	['MappedClonedContext', '[data-context="mapped-cloned"]'],
 ] as const;
 
 for (const fixture of fixtures) {
@@ -422,10 +512,51 @@ for (const fixture of fixtures) {
 			container.remove();
 		});
 
+		for (const [exportName, kind, expected] of [
+			['ConfigReplacedScopedChild', 'config', 'configured'],
+			['ConfigUndefinedReplacedScopedChild', 'config-undefined', ''],
+			['PositionalReplacedScopedChild', 'positional', 'first-second'],
+			['UndefinedReplacedScopedChild', 'undefined', ''],
+		] as const) {
+			const selector = `[data-replacement="${kind}"]`;
+
+			it(`${exportName} replaces children without evaluating the original subtree`, () => {
+				const result = mount(fixture.client[exportName]);
+				expect(result.find(selector).textContent).toBe(expected);
+				result.unmount();
+			});
+
+			it(`${exportName} server-renders only its explicitly replaced children`, () => {
+				const { html } = ServerRuntime.renderToString(fixture.server[exportName]);
+				const markup = document.createElement('div');
+				markup.innerHTML = html;
+				expect(markup.querySelector(selector)?.textContent).toBe(expected);
+			});
+
+			it(`${exportName} hydrates its explicitly replaced children`, () => {
+				const { html } = ServerRuntime.renderToString(fixture.server[exportName]);
+				const container = document.createElement('div');
+				container.innerHTML = html;
+				document.body.appendChild(container);
+				const existing = container.querySelector(selector);
+				expect(existing?.textContent).toBe(expected);
+
+				const root = hydrateRoot(container, fixture.client[exportName]);
+				flushSync(() => {});
+				expect(container.querySelector(selector)).toBe(existing);
+				expect(existing?.textContent).toBe(expected);
+				root.unmount();
+				container.remove();
+			});
+		}
+
 		for (const exportName of [
 			'BuiltInErrorValue',
 			'WrappedErrorValue',
 			'WrappedGetterErrorValue',
+			'MappedErrorValue',
+			'FlattenedErrorValue',
+			'ClonedErrorValue',
 		] as const) {
 			it(`${exportName} assigns a synchronous error to its nearest boundary`, () => {
 				const result = mount(fixture.client[exportName]);
@@ -446,6 +577,9 @@ for (const fixture of fixtures) {
 			['VariableSuspense', 'variable'],
 			['WrappedSuspenseValue', 'wrapped'],
 			['GetterSuspenseValue', 'getter'],
+			['MappedSuspense', 'mapped'],
+			['FlattenedSuspense', 'flattened'],
+			['ClonedSuspense', 'cloned'],
 		] as const) {
 			it(`${exportName} suspends and resolves inside its represented boundary`, async () => {
 				const pending = deferred();

--- a/packages/octane/tests/scoped-jsx-values.test.ts
+++ b/packages/octane/tests/scoped-jsx-values.test.ts
@@ -118,6 +118,41 @@ export function GetterContext() @{
 	<section>{content}</section>
 }
 
+export function FragmentContext() @{
+	const content = <>{use(ValueContext) as string}</>;
+	<ValueContext.Provider value="inner">
+		<span data-context="fragment">{content}</span>
+	</ValueContext.Provider>
+}
+
+export function FragmentGetterContext() @{
+	const content = <>{getterValue.current as string}</>;
+	<ValueContext.Provider value="inner">
+		<span data-context="fragment-getter">{content}</span>
+	</ValueContext.Provider>
+}
+
+export function NestedFragmentContext() @{
+	const content = <><>{getterValue.current as string}</></>;
+	<ValueContext.Provider value="inner">
+		<span data-context="fragment-nested">{content}</span>
+	</ValueContext.Provider>
+}
+
+export function FragmentPropContext() @{
+	const content = <Slot content={<>{getterValue.current as string}</>} />;
+	<ValueContext.Provider value="inner">
+		<section data-context="fragment-prop">{content}</section>
+	</ValueContext.Provider>
+}
+
+export function FragmentArrayContext() @{
+	const content = [<>{getterValue.current as string}</>];
+	<ValueContext.Provider value="inner">
+		<span data-context="fragment-array">{content[0]}</span>
+	</ValueContext.Provider>
+}
+
 export function ProxyContext() @{
 	const content = <ValueContext.Provider value="inner">
 		<span data-context="proxy">{proxyValue.current as string}</span>
@@ -246,6 +281,11 @@ export function WrappedGetterErrorValue() @{
 	<ErrorBoundary fallback={<strong data-fallback="outer">outer</strong>}>{content}</ErrorBoundary>
 }
 
+export function FragmentErrorValue() @{
+	const content = <>{throwingGetter.current as string}</>;
+	<ErrorBoundary fallback={<strong data-fallback="inner">inner</strong>}>{content}</ErrorBoundary>
+}
+
 export function MappedErrorValue() @{
 	const content = <span>{throwingGetter.current as string}</span>;
 	const mapped = Children.map(content, (child) => child);
@@ -294,6 +334,13 @@ export function GetterSuspenseValue(props: { promise: Promise<string> }) @{
 		<span data-resolved="getter">{suspendedValue.current as string}</span>
 	</WrappedSuspense>;
 	<section data-outlet="suspense">{content}</section>
+}
+
+export function FragmentSuspense(props: { promise: Promise<string> }) @{
+	const content = <>{use(props.promise) as string}</>;
+	<Suspense fallback={<i data-fallback="pending">pending</i>}>
+		<span data-resolved="fragment">{content}</span>
+	</Suspense>
 }
 
 export function MappedSuspense(props: { promise: Promise<string> }) @{
@@ -392,6 +439,11 @@ const contextScenarios = [
 	['PropContext', '[data-context="prop"]'],
 	['NestedContext', '[data-context="nested"]'],
 	['GetterContext', '[data-context="getter"]'],
+	['FragmentContext', '[data-context="fragment"]'],
+	['FragmentGetterContext', '[data-context="fragment-getter"]'],
+	['NestedFragmentContext', '[data-context="fragment-nested"]'],
+	['FragmentPropContext', '[data-context="fragment-prop"]'],
+	['FragmentArrayContext', '[data-context="fragment-array"]'],
 	['ProxyContext', '[data-context="proxy"]'],
 	['CoercionContext', '[data-context="coercion"]'],
 	['IterableContext', '[data-context="iterable"]'],
@@ -554,6 +606,7 @@ for (const fixture of fixtures) {
 			'BuiltInErrorValue',
 			'WrappedErrorValue',
 			'WrappedGetterErrorValue',
+			'FragmentErrorValue',
 			'MappedErrorValue',
 			'FlattenedErrorValue',
 			'ClonedErrorValue',
@@ -577,6 +630,7 @@ for (const fixture of fixtures) {
 			['VariableSuspense', 'variable'],
 			['WrappedSuspenseValue', 'wrapped'],
 			['GetterSuspenseValue', 'getter'],
+			['FragmentSuspense', 'fragment'],
 			['MappedSuspense', 'mapped'],
 			['FlattenedSuspense', 'flattened'],
 			['ClonedSuspense', 'cloned'],

--- a/packages/octane/tests/scoped-jsx-values.test.ts
+++ b/packages/octane/tests/scoped-jsx-values.test.ts
@@ -28,6 +28,12 @@ const getterValue = {
 	},
 };
 
+const contextualAttributes = {
+	get 'data-value'() {
+		return use(ValueContext);
+	},
+};
+
 const proxyValue = new Proxy({ current: 'outer' }, {
 	get(target, key, receiver) {
 		return key === 'current' ? use(ValueContext) : Reflect.get(target, key, receiver);
@@ -57,6 +63,24 @@ const sharedContextChild = <span data-context="shared">{getterValue.current as s
 
 function Slot(props: { content: OctaneNode }) @{
 	<section data-outlet="slot">{props.content}</section>
+}
+
+function ContextAttributeComponent(props: { value: string }) @{
+	<strong data-context="root-component-attribute" data-value={props.value}>
+		attribute
+	</strong>
+}
+
+function InspectContextAttribute(props: { child: OctaneNode }) @{
+	const child = Children.only(props.child) as ElementDescriptor;
+	const cloned = cloneElement(child, { 'data-inspected': 'yes' });
+	<section
+		data-root-valid={String(isValidElement(child))}
+		data-root-type={String(child.type)}
+		data-observed-value={String(child.props['data-value'])}
+	>
+		{cloned}
+	</section>
 }
 
 function InnerFragmentComponent() @{
@@ -94,6 +118,61 @@ const throwingGetter = {
 export function DirectContext() @{
 	<ValueContext.Provider value="inner">
 		<span data-context="direct">{use(ValueContext) as string}</span>
+	</ValueContext.Provider>
+}
+
+export function DirectGetterAttributeContext() @{
+	<ValueContext.Provider value="inner">
+		<span data-context="direct-attribute" data-value={getterValue.current}>
+			attribute
+		</span>
+	</ValueContext.Provider>
+}
+
+export function DirectSpreadAttributeContext() @{
+	<ValueContext.Provider value="inner">
+		<span data-context="direct-spread-attribute" {...contextualAttributes}>
+			attribute
+		</span>
+	</ValueContext.Provider>
+}
+
+export function DirectDynamicComponentContext() @{
+	<ValueContext.Provider value="inner">
+		<contextualFragmentComponent.current />
+	</ValueContext.Provider>
+}
+
+export function RootHostAttributeContext() @{
+	const content = <span data-context="root-host-attribute" data-value={getterValue.current}>
+		attribute
+	</span>;
+	<ValueContext.Provider value="inner">{content}</ValueContext.Provider>
+}
+
+export function RootSpreadAttributeContext() @{
+	const content = <span data-context="root-spread-attribute" {...contextualAttributes}>
+		attribute
+	</span>;
+	<ValueContext.Provider value="inner">{content}</ValueContext.Provider>
+}
+
+export function RootComponentAttributeContext() @{
+	const content = <ContextAttributeComponent value={getterValue.current} />;
+	<ValueContext.Provider value="inner">{content}</ValueContext.Provider>
+}
+
+export function RootDynamicComponentContext() @{
+	const content = <contextualFragmentComponent.current />;
+	<ValueContext.Provider value="inner">{content}</ValueContext.Provider>
+}
+
+export function RootInspectedAttributeContext() @{
+	const content = <span data-context="root-inspected-attribute" data-value={getterValue.current}>
+		attribute
+	</span>;
+	<ValueContext.Provider value="inner">
+		<InspectContextAttribute child={content} />
 	</ValueContext.Provider>
 }
 
@@ -282,6 +361,16 @@ export function SharedDescriptorProviders(props: { first: string; second: string
 	</section>
 }
 
+export function SharedRootAttributeProviders(props: { first: string; second: string }) @{
+	const content = <span data-context="shared-root" data-value={getterValue.current}>
+		{getterValue.current as string}
+	</span>;
+	<section data-outlet="shared-root">
+		<ValueContext.Provider value={props.first}>{content}</ValueContext.Provider>
+		<ValueContext.Provider value={props.second}>{content}</ValueContext.Provider>
+	</section>
+}
+
 export function DirectiveContext(props: { visible: boolean }) @{
 	const content = <ValueContext.Provider value="inner">
 		<div data-outlet="directive">
@@ -318,6 +407,11 @@ export function WrappedGetterErrorValue() @{
 
 export function FragmentErrorValue() @{
 	const content = <>{throwingGetter.current as string}</>;
+	<ErrorBoundary fallback={<strong data-fallback="inner">inner</strong>}>{content}</ErrorBoundary>
+}
+
+export function RootGetterErrorValue() @{
+	const content = <span data-root-error={throwingGetter.current}>unreachable</span>;
 	<ErrorBoundary fallback={<strong data-fallback="inner">inner</strong>}>{content}</ErrorBoundary>
 }
 
@@ -376,6 +470,18 @@ export function FragmentSuspense(props: { promise: Promise<string> }) @{
 	<Suspense fallback={<i data-fallback="pending">pending</i>}>
 		<span data-resolved="fragment">{content}</span>
 	</Suspense>
+}
+
+export function RootGetterSuspense(props: { promise: Promise<string> }) @{
+	const suspendedValue = {
+		get current() {
+			return use(props.promise);
+		},
+	};
+	const content = <span data-resolved="root-attribute" data-value={suspendedValue.current}>
+		{'resolved' as string}
+	</span>;
+	<Suspense fallback={<i data-fallback="pending">pending</i>}>{content}</Suspense>
 }
 
 export function MappedSuspense(props: { promise: Promise<string> }) @{
@@ -487,8 +593,22 @@ function deferred() {
 	return { promise, resolve };
 }
 
+function expectSharedValues(
+	elements: Iterable<Element>,
+	expected: string[],
+	inspectAttributes: boolean,
+) {
+	const values = Array.from(elements);
+	expect(values.map((element) => element.textContent)).toEqual(expected);
+	if (inspectAttributes) {
+		expect(values.map((element) => element.getAttribute('data-value'))).toEqual(expected);
+	}
+}
+
 const contextScenarios = [
 	['DirectContext', '[data-context="direct"]'],
+	['DirectDynamicComponentContext', '[data-context="fragment-component-tag"]'],
+	['RootDynamicComponentContext', '[data-context="fragment-component-tag"]'],
 	['VariableContext', '[data-context="variable"]'],
 	['PropContext', '[data-context="prop"]'],
 	['NestedContext', '[data-context="nested"]'],
@@ -554,6 +674,87 @@ for (const fixture of fixtures) {
 			expect(html).not.toContain('data-value="outer"');
 		});
 
+		for (const [exportName, selector] of [
+			['DirectGetterAttributeContext', '[data-context="direct-attribute"]'],
+			['DirectSpreadAttributeContext', '[data-context="direct-spread-attribute"]'],
+			['RootHostAttributeContext', '[data-context="root-host-attribute"]'],
+			['RootSpreadAttributeContext', '[data-context="root-spread-attribute"]'],
+			['RootComponentAttributeContext', '[data-context="root-component-attribute"]'],
+		] as const) {
+			it(`${exportName} evaluates host attributes inside its provider`, () => {
+				const result = mount(fixture.client[exportName]);
+				expect(result.find(selector).getAttribute('data-value')).toBe('inner');
+				result.unmount();
+			});
+
+			it(`${exportName} server-renders host attributes inside its provider`, () => {
+				const { html } = ServerRuntime.renderToString(fixture.server[exportName]);
+				expect(html).toContain('data-value="inner"');
+				expect(html).not.toContain('data-value="outer"');
+			});
+
+			it(`${exportName} hydrates host attributes inside its provider`, () => {
+				const { html } = ServerRuntime.renderToString(fixture.server[exportName]);
+				const container = document.createElement('div');
+				container.innerHTML = html;
+				document.body.appendChild(container);
+				const existing = container.querySelector(selector);
+				expect(existing?.getAttribute('data-value')).toBe('inner');
+
+				const root = hydrateRoot(container, fixture.client[exportName]);
+				flushSync(() => {});
+				expect(container.querySelector(selector)).toBe(existing);
+				expect(existing?.getAttribute('data-value')).toBe('inner');
+				root.unmount();
+				container.remove();
+			});
+		}
+
+		it('RootInspectedAttributeContext preserves inspectable descriptors under its provider', () => {
+			const result = mount(fixture.client.RootInspectedAttributeContext);
+			const parent = result.find('[data-root-valid]');
+			const child = result.find('[data-context="root-inspected-attribute"]');
+			expect(parent.getAttribute('data-root-valid')).toBe('true');
+			expect(parent.getAttribute('data-root-type')).toBe('span');
+			expect(parent.getAttribute('data-observed-value')).toBe('inner');
+			expect(child.getAttribute('data-value')).toBe('inner');
+			expect(child.getAttribute('data-inspected')).toBe('yes');
+			result.unmount();
+		});
+
+		it('RootInspectedAttributeContext server-renders inspected descriptors under its provider', () => {
+			const { html } = ServerRuntime.renderToString(fixture.server.RootInspectedAttributeContext);
+			const markup = document.createElement('div');
+			markup.innerHTML = html;
+			const parent = markup.querySelector('[data-root-valid]');
+			const child = markup.querySelector('[data-context="root-inspected-attribute"]');
+			expect(parent?.getAttribute('data-root-valid')).toBe('true');
+			expect(parent?.getAttribute('data-root-type')).toBe('span');
+			expect(parent?.getAttribute('data-observed-value')).toBe('inner');
+			expect(child?.getAttribute('data-value')).toBe('inner');
+			expect(child?.getAttribute('data-inspected')).toBe('yes');
+		});
+
+		it('RootInspectedAttributeContext hydrates inspected descriptors under its provider', () => {
+			const { html } = ServerRuntime.renderToString(fixture.server.RootInspectedAttributeContext);
+			const container = document.createElement('div');
+			container.innerHTML = html;
+			document.body.appendChild(container);
+			const existing = container.querySelector('[data-context="root-inspected-attribute"]');
+			expect(existing?.getAttribute('data-value')).toBe('inner');
+
+			const root = hydrateRoot(container, fixture.client.RootInspectedAttributeContext);
+			flushSync(() => {});
+			expect(container.querySelector('[data-context="root-inspected-attribute"]')).toBe(existing);
+			expect(
+				container.querySelector('[data-root-valid]')?.getAttribute('data-observed-value'),
+			).toBe('inner');
+			expect(existing?.getAttribute('data-value')).toBe('inner');
+			expect(existing?.getAttribute('data-inspected')).toBe('yes');
+			root.unmount();
+			container.remove();
+		});
+
 		it('evaluates fragment-nested host attributes inside their represented provider', () => {
 			const result = mount(fixture.client.FragmentNestedAttributeContext);
 			expect(
@@ -584,71 +785,73 @@ for (const fixture of fixtures) {
 			container.remove();
 		});
 
-		it('keeps a shared JSX descriptor isolated across providers and updates', () => {
-			const result = mount(fixture.client.SharedDescriptorProviders, {
-				first: 'first',
-				second: 'second',
-			});
-			const values = () =>
-				result.findAll('[data-context="shared"]').map((element) => element.textContent);
-			expect(values()).toEqual(['first', 'second']);
+		for (const [exportName, selector, inspectAttributes] of [
+			['SharedDescriptorProviders', '[data-context="shared"]', false],
+			['SharedRootAttributeProviders', '[data-context="shared-root"]', true],
+		] as const) {
+			it(`${exportName} isolates one descriptor across providers and updates`, () => {
+				const result = mount(fixture.client[exportName], {
+					first: 'first',
+					second: 'second',
+				});
+				expectSharedValues(result.findAll(selector), ['first', 'second'], inspectAttributes);
 
-			result.update(fixture.client.SharedDescriptorProviders, {
-				first: 'updated-first',
-				second: 'updated-second',
-			});
-			expect(values()).toEqual(['updated-first', 'updated-second']);
-			result.unmount();
-		});
-
-		it('isolates a shared JSX descriptor across providers and server requests', () => {
-			const first = ServerRuntime.renderToString(fixture.server.SharedDescriptorProviders, {
-				first: 'first',
-				second: 'second',
-			});
-			const next = ServerRuntime.renderToString(fixture.server.SharedDescriptorProviders, {
-				first: 'next-first',
-				second: 'next-second',
+				result.update(fixture.client[exportName], {
+					first: 'updated-first',
+					second: 'updated-second',
+				});
+				expectSharedValues(
+					result.findAll(selector),
+					['updated-first', 'updated-second'],
+					inspectAttributes,
+				);
+				result.unmount();
 			});
 
-			const firstMarkup = document.createElement('div');
-			firstMarkup.innerHTML = first.html;
-			const nextMarkup = document.createElement('div');
-			nextMarkup.innerHTML = next.html;
-			expect(
-				Array.from(
-					firstMarkup.querySelectorAll('[data-context="shared"]'),
-					(element) => element.textContent,
-				),
-			).toEqual(['first', 'second']);
-			expect(
-				Array.from(
-					nextMarkup.querySelectorAll('[data-context="shared"]'),
-					(element) => element.textContent,
-				),
-			).toEqual(['next-first', 'next-second']);
-		});
+			it(`${exportName} isolates one descriptor across providers and server requests`, () => {
+				const first = ServerRuntime.renderToString(fixture.server[exportName], {
+					first: 'first',
+					second: 'second',
+				});
+				const next = ServerRuntime.renderToString(fixture.server[exportName], {
+					first: 'next-first',
+					second: 'next-second',
+				});
 
-		it('hydrates a shared JSX descriptor without leaking provider values', () => {
-			const props = { first: 'first', second: 'second' };
-			const { html } = ServerRuntime.renderToString(
-				fixture.server.SharedDescriptorProviders,
-				props,
-			);
-			const container = document.createElement('div');
-			container.innerHTML = html;
-			document.body.appendChild(container);
-			const existing = Array.from(container.querySelectorAll('[data-context="shared"]'));
-			expect(existing.map((element) => element.textContent)).toEqual(['first', 'second']);
+				const firstMarkup = document.createElement('div');
+				firstMarkup.innerHTML = first.html;
+				const nextMarkup = document.createElement('div');
+				nextMarkup.innerHTML = next.html;
+				expectSharedValues(
+					firstMarkup.querySelectorAll(selector),
+					['first', 'second'],
+					inspectAttributes,
+				);
+				expectSharedValues(
+					nextMarkup.querySelectorAll(selector),
+					['next-first', 'next-second'],
+					inspectAttributes,
+				);
+			});
 
-			const root = hydrateRoot(container, fixture.client.SharedDescriptorProviders, props);
-			flushSync(() => {});
-			const adopted = Array.from(container.querySelectorAll('[data-context="shared"]'));
-			expect(adopted).toEqual(existing);
-			expect(adopted.map((element) => element.textContent)).toEqual(['first', 'second']);
-			root.unmount();
-			container.remove();
-		});
+			it(`${exportName} hydrates one descriptor without leaking provider values`, () => {
+				const props = { first: 'first', second: 'second' };
+				const { html } = ServerRuntime.renderToString(fixture.server[exportName], props);
+				const container = document.createElement('div');
+				container.innerHTML = html;
+				document.body.appendChild(container);
+				const existing = Array.from(container.querySelectorAll(selector));
+				expectSharedValues(existing, ['first', 'second'], inspectAttributes);
+
+				const root = hydrateRoot(container, fixture.client[exportName], props);
+				flushSync(() => {});
+				const adopted = Array.from(container.querySelectorAll(selector));
+				expect(adopted).toEqual(existing);
+				expectSharedValues(adopted, ['first', 'second'], inspectAttributes);
+				root.unmount();
+				container.remove();
+			});
+		}
 
 		for (const [exportName, kind, expected] of [
 			['ConfigReplacedScopedChild', 'config', 'configured'],
@@ -693,6 +896,7 @@ for (const fixture of fixtures) {
 			'WrappedErrorValue',
 			'WrappedGetterErrorValue',
 			'FragmentErrorValue',
+			'RootGetterErrorValue',
 			'MappedErrorValue',
 			'FlattenedErrorValue',
 			'ClonedErrorValue',
@@ -717,6 +921,7 @@ for (const fixture of fixtures) {
 			['WrappedSuspenseValue', 'wrapped'],
 			['GetterSuspenseValue', 'getter'],
 			['FragmentSuspense', 'fragment'],
+			['RootGetterSuspense', 'root-attribute'],
 			['MappedSuspense', 'mapped'],
 			['FlattenedSuspense', 'flattened'],
 			['ClonedSuspense', 'cloned'],
@@ -730,7 +935,11 @@ for (const fixture of fixtures) {
 					pending.resolve('resolved');
 				});
 
-				expect(result.find(`[data-resolved="${resolved}"]`).textContent).toBe('resolved');
+				const resolvedElement = result.find(`[data-resolved="${resolved}"]`);
+				expect(resolvedElement.textContent).toBe('resolved');
+				if (exportName === 'RootGetterSuspense') {
+					expect(resolvedElement.getAttribute('data-value')).toBe('resolved');
+				}
 				expect(result.findAll('[data-fallback="pending"]')).toHaveLength(0);
 				result.unmount();
 			});

--- a/packages/octane/tests/scoped-jsx-values.test.ts
+++ b/packages/octane/tests/scoped-jsx-values.test.ts
@@ -59,6 +59,20 @@ function Slot(props: { content: OctaneNode }) @{
 	<section data-outlet="slot">{props.content}</section>
 }
 
+function InnerFragmentComponent() @{
+	<strong data-context="fragment-component-tag">inner</strong>
+}
+
+function OuterFragmentComponent() @{
+	<strong data-context="fragment-component-tag">outer</strong>
+}
+
+const contextualFragmentComponent = {
+	get current() {
+		return use(ValueContext) === 'inner' ? InnerFragmentComponent : OuterFragmentComponent;
+	},
+};
+
 function WrappedErrorBoundary({ children }: { children: OctaneNode }) @{
 	<ErrorBoundary fallback={<strong data-fallback="inner">inner</strong>}>{children}</ErrorBoundary>
 }
@@ -151,6 +165,27 @@ export function FragmentArrayContext() @{
 	<ValueContext.Provider value="inner">
 		<span data-context="fragment-array">{content[0]}</span>
 	</ValueContext.Provider>
+}
+
+export function FragmentNestedExpressionContext() @{
+	const content = <>
+		<strong data-context="fragment-nested-expression">{getterValue.current as string}</strong>
+	</>;
+	<ValueContext.Provider value="inner">{content}</ValueContext.Provider>
+}
+
+export function FragmentNestedAttributeContext() @{
+	const content = <>
+		<strong data-context="fragment-nested-attribute" data-value={getterValue.current}>
+			attribute
+		</strong>
+	</>;
+	<ValueContext.Provider value="inner">{content}</ValueContext.Provider>
+}
+
+export function FragmentDynamicComponentContext() @{
+	const content = <><contextualFragmentComponent.current /></>;
+	<ValueContext.Provider value="inner">{content}</ValueContext.Provider>
 }
 
 export function ProxyContext() @{
@@ -373,8 +408,27 @@ function InspectChild(props: { child: OctaneNode }) @{
 	</section>
 }
 
+function InspectIndexedChildren(props: { children: OctaneNode }) @{
+	const children = Children.toArray(props.children);
+	const indexed = children[1];
+	<section
+		data-fragment-count={String(children.length)}
+		data-fragment-type={isValidElement(indexed) ? String(indexed.type) : 'missing'}
+	>
+		{indexed}
+	</section>
+}
+
 function collectionLabel() {
 	return 'inspected';
+}
+
+export function IndexedFragmentChildren(props: { name: string }) @{
+	<InspectIndexedChildren
+		children={<>
+			Hello <strong data-indexed="yes">{props.name as string}</strong>
+		</>}
+	/>
 }
 
 export function OrdinaryElementValue() @{
@@ -444,6 +498,8 @@ const contextScenarios = [
 	['NestedFragmentContext', '[data-context="fragment-nested"]'],
 	['FragmentPropContext', '[data-context="fragment-prop"]'],
 	['FragmentArrayContext', '[data-context="fragment-array"]'],
+	['FragmentNestedExpressionContext', '[data-context="fragment-nested-expression"]'],
+	['FragmentDynamicComponentContext', '[data-context="fragment-component-tag"]'],
 	['ProxyContext', '[data-context="proxy"]'],
 	['CoercionContext', '[data-context="coercion"]'],
 	['IterableContext', '[data-context="iterable"]'],
@@ -496,6 +552,36 @@ for (const fixture of fixtures) {
 			const { html } = ServerRuntime.renderToString(fixture.server.GetterAttributeContext);
 			expect(html).toContain('data-value="inner"');
 			expect(html).not.toContain('data-value="outer"');
+		});
+
+		it('evaluates fragment-nested host attributes inside their represented provider', () => {
+			const result = mount(fixture.client.FragmentNestedAttributeContext);
+			expect(
+				result.find('[data-context="fragment-nested-attribute"]').getAttribute('data-value'),
+			).toBe('inner');
+			result.unmount();
+		});
+
+		it('server-renders fragment-nested host attributes inside their represented provider', () => {
+			const { html } = ServerRuntime.renderToString(fixture.server.FragmentNestedAttributeContext);
+			expect(html).toContain('data-value="inner"');
+			expect(html).not.toContain('data-value="outer"');
+		});
+
+		it('hydrates fragment-nested host attributes inside their represented provider', () => {
+			const { html } = ServerRuntime.renderToString(fixture.server.FragmentNestedAttributeContext);
+			const container = document.createElement('div');
+			container.innerHTML = html;
+			document.body.appendChild(container);
+			const existing = container.querySelector('[data-context="fragment-nested-attribute"]');
+			expect(existing?.getAttribute('data-value')).toBe('inner');
+
+			const root = hydrateRoot(container, fixture.client.FragmentNestedAttributeContext);
+			flushSync(() => {});
+			expect(container.querySelector('[data-context="fragment-nested-attribute"]')).toBe(existing);
+			expect(existing?.getAttribute('data-value')).toBe('inner');
+			root.unmount();
+			container.remove();
 		});
 
 		it('keeps a shared JSX descriptor isolated across providers and updates', () => {
@@ -684,6 +770,47 @@ for (const fixture of fixtures) {
 				expect(html).toContain(expected);
 			});
 		}
+
+		it('preserves positional fragment siblings when nested child expressions are dynamic', () => {
+			const result = mount(fixture.client.IndexedFragmentChildren, { name: 'Ada' });
+			const parent = result.find('[data-fragment-count]');
+			expect(parent.getAttribute('data-fragment-count')).toBe('2');
+			expect(parent.getAttribute('data-fragment-type')).toBe('strong');
+			expect(result.find('[data-indexed="yes"]').textContent).toBe('Ada');
+			result.unmount();
+		});
+
+		it('server-renders inspectable positional fragment siblings', () => {
+			const { html } = ServerRuntime.renderToString(fixture.server.IndexedFragmentChildren, {
+				name: 'Ada',
+			});
+			const markup = document.createElement('div');
+			markup.innerHTML = html;
+			const parent = markup.querySelector('[data-fragment-count]');
+			expect(parent?.getAttribute('data-fragment-count')).toBe('2');
+			expect(parent?.getAttribute('data-fragment-type')).toBe('strong');
+			expect(parent?.querySelector('[data-indexed="yes"]')?.textContent).toBe('Ada');
+		});
+
+		it('hydrates inspectable positional fragment siblings', () => {
+			const props = { name: 'Ada' };
+			const { html } = ServerRuntime.renderToString(fixture.server.IndexedFragmentChildren, props);
+			const container = document.createElement('div');
+			container.innerHTML = html;
+			document.body.appendChild(container);
+			const parent = container.querySelector('[data-fragment-count]');
+			const existing = parent?.querySelector('[data-indexed="yes"]');
+			expect(parent?.getAttribute('data-fragment-count')).toBe('2');
+			expect(parent?.getAttribute('data-fragment-type')).toBe('strong');
+			expect(existing?.textContent).toBe('Ada');
+
+			const root = hydrateRoot(container, fixture.client.IndexedFragmentChildren, props);
+			flushSync(() => {});
+			expect(container.querySelector('[data-indexed="yes"]')).toBe(existing);
+			expect(existing?.textContent).toBe('Ada');
+			root.unmount();
+			container.remove();
+		});
 	});
 }
 

--- a/packages/octane/tests/scoped-jsx-values.test.ts
+++ b/packages/octane/tests/scoped-jsx-values.test.ts
@@ -1,0 +1,520 @@
+import { describe, expect, it } from 'vitest';
+import * as ServerRuntime from 'octane/server';
+
+import { flushSync, hydrateRoot, type ComponentBody } from '../src/index.js';
+import { act, mount } from './_helpers.js';
+import { loadCompiledFixtureSource, loadServerFixture } from './_server-fixture.js';
+import * as tsx from './_fixtures/scoped-jsx-values.tsx';
+
+const tsrxSource = String.raw`
+import {
+	Children,
+	ErrorBoundary,
+	Suspense,
+	cloneElement,
+	createContext,
+	createElement,
+	isValidElement,
+	use,
+	type ElementDescriptor,
+	type OctaneNode,
+} from 'octane';
+
+const ValueContext = createContext('outer');
+
+const getterValue = {
+	get current() {
+		return use(ValueContext);
+	},
+};
+
+const proxyValue = new Proxy({ current: 'outer' }, {
+	get(target, key, receiver) {
+		return key === 'current' ? use(ValueContext) : Reflect.get(target, key, receiver);
+	},
+});
+
+const coercibleValue = {
+	[Symbol.toPrimitive]() {
+		return use(ValueContext);
+	},
+};
+
+const iterableValue = {
+	*[Symbol.iterator]() {
+		yield use(ValueContext);
+	},
+};
+
+const computedKey = {
+	[Symbol.toPrimitive]() {
+		return use(ValueContext);
+	},
+};
+
+const valuesByContext: Record<string, string> = { inner: 'inner', outer: 'outer' };
+const sharedContextChild = <span data-context="shared">{getterValue.current as string}</span>;
+
+function Slot(props: { content: OctaneNode }) @{
+	<section data-outlet="slot">{props.content}</section>
+}
+
+function WrappedErrorBoundary({ children }: { children: OctaneNode }) @{
+	<ErrorBoundary fallback={<strong data-fallback="inner">inner</strong>}>{children}</ErrorBoundary>
+}
+
+function WrappedSuspense(props: { children: OctaneNode }) @{
+	<Suspense fallback={<i data-fallback="pending">pending</i>}>{props.children}</Suspense>
+}
+
+function readFailure(): string {
+	throw new Error('scoped failure');
+}
+
+const throwingGetter = {
+	get current(): string {
+		throw new Error('scoped getter failure');
+	},
+};
+
+export function DirectContext() @{
+	<ValueContext.Provider value="inner">
+		<span data-context="direct">{use(ValueContext) as string}</span>
+	</ValueContext.Provider>
+}
+
+export function VariableContext() @{
+	const content = <ValueContext.Provider value="inner">
+		<span data-context="variable">{use(ValueContext) as string}</span>
+	</ValueContext.Provider>;
+	<section data-outlet="variable">{content}</section>
+}
+
+export function PropContext() @{
+	<Slot
+		content={
+			<ValueContext.Provider value="inner">
+				<span data-context="prop">{use(ValueContext) as string}</span>
+			</ValueContext.Provider>
+		}
+	/>
+}
+
+export function NestedContext() @{
+	const nested = {
+		items: [
+			<ValueContext.Provider value="inner">
+				<span data-context="nested">{use(ValueContext) as string}</span>
+			</ValueContext.Provider>,
+		],
+	};
+	<section data-outlet="nested">{nested.items[0]}</section>
+}
+
+export function GetterContext() @{
+	const content = <ValueContext.Provider value="inner">
+		<span data-context="getter">{getterValue.current as string}</span>
+	</ValueContext.Provider>;
+	<section>{content}</section>
+}
+
+export function ProxyContext() @{
+	const content = <ValueContext.Provider value="inner">
+		<span data-context="proxy">{proxyValue.current as string}</span>
+	</ValueContext.Provider>;
+	<section>{content}</section>
+}
+
+export function CoercionContext() @{
+	const content = <ValueContext.Provider value="inner">
+		<span data-context="coercion">{('' + coercibleValue) as string}</span>
+	</ValueContext.Provider>;
+	<section>{content}</section>
+}
+
+export function IterableContext() @{
+	const content = <ValueContext.Provider value="inner">
+		<span data-context="iterable">{[...iterableValue]}</span>
+	</ValueContext.Provider>;
+	<section>{content}</section>
+}
+
+export function OptionalComputedKeyContext() @{
+	const content = <ValueContext.Provider value="inner">
+		<span data-context="optional-key">
+			{valuesByContext?.[computedKey as unknown as string] as string}
+		</span>
+	</ValueContext.Provider>;
+	<section>{content}</section>
+}
+
+export function GetterAttributeContext() @{
+	const content = <ValueContext.Provider value="inner">
+		<span data-context="attribute" data-value={getterValue.current}>attribute</span>
+	</ValueContext.Provider>;
+	<section>{content}</section>
+}
+
+export function SharedDescriptorProviders(props: { first: string; second: string }) @{
+	<section data-outlet="shared">
+		<ValueContext.Provider value={props.first}>{sharedContextChild}</ValueContext.Provider>
+		<ValueContext.Provider value={props.second}>{sharedContextChild}</ValueContext.Provider>
+	</section>
+}
+
+export function DirectiveContext(props: { visible: boolean }) @{
+	const content = <ValueContext.Provider value="inner">
+		<div data-outlet="directive">
+			@if (props.visible) {
+				<span data-context="directive">{use(ValueContext) as string}</span>
+			} @else {
+				<span data-context="directive">hidden</span>
+			}
+		</div>
+	</ValueContext.Provider>;
+	<section>{content}</section>
+}
+
+export function BuiltInErrorValue() @{
+	const content = <ErrorBoundary fallback={<strong data-fallback="inner">inner</strong>}>
+		<span>{readFailure() as string}</span>
+	</ErrorBoundary>;
+	<ErrorBoundary fallback={<strong data-fallback="outer">outer</strong>}>{content}</ErrorBoundary>
+}
+
+export function WrappedErrorValue() @{
+	const content = <WrappedErrorBoundary>
+		<span>{readFailure() as string}</span>
+	</WrappedErrorBoundary>;
+	<ErrorBoundary fallback={<strong data-fallback="outer">outer</strong>}>{content}</ErrorBoundary>
+}
+
+export function WrappedGetterErrorValue() @{
+	const content = <WrappedErrorBoundary>
+		<span>{throwingGetter.current as string}</span>
+	</WrappedErrorBoundary>;
+	<ErrorBoundary fallback={<strong data-fallback="outer">outer</strong>}>{content}</ErrorBoundary>
+}
+
+export function DirectSuspense(props: { promise: Promise<string> }) @{
+	<Suspense fallback={<i data-fallback="pending">pending</i>}>
+		<span data-resolved="direct">{use(props.promise) as string}</span>
+	</Suspense>
+}
+
+export function VariableSuspense(props: { promise: Promise<string> }) @{
+	const content = <Suspense fallback={<i data-fallback="pending">pending</i>}>
+		<span data-resolved="variable">{use(props.promise) as string}</span>
+	</Suspense>;
+	<section data-outlet="suspense">{content}</section>
+}
+
+export function WrappedSuspenseValue(props: { promise: Promise<string> }) @{
+	const content = <WrappedSuspense>
+		<span data-resolved="wrapped">{use(props.promise) as string}</span>
+	</WrappedSuspense>;
+	<section data-outlet="suspense">{content}</section>
+}
+
+export function GetterSuspenseValue(props: { promise: Promise<string> }) @{
+	const suspendedValue = {
+		get current() {
+			return use(props.promise);
+		},
+	};
+	const content = <WrappedSuspense>
+		<span data-resolved="getter">{suspendedValue.current as string}</span>
+	</WrappedSuspense>;
+	<section data-outlet="suspense">{content}</section>
+}
+
+function InspectChild(props: { child: OctaneNode }) @{
+	const child = Children.only(props.child) as ElementDescriptor;
+	const cloned = cloneElement(child, { 'data-inspected': 'yes' });
+	<section
+		data-valid={String(isValidElement(child))}
+		data-element-type={String(child.type)}
+		data-child-type={typeof child.props.children}
+	>
+		{cloned}
+	</section>
+}
+
+function collectionLabel() {
+	return 'inspected';
+}
+
+export function OrdinaryElementValue() @{
+	const content = <span data-ordinary="yes">ordinary</span>;
+	<InspectChild child={content} />
+}
+
+export function InspectableExpressionValue() @{
+	const content = <span data-ordinary="expression">{collectionLabel() as string}</span>;
+	<InspectChild child={content} />
+}
+
+export function DirectCreateElementValue() @{
+	const content = createElement('span', { 'data-ordinary': 'create-element' }, 'direct');
+	<InspectChild child={content} />
+}
+`;
+
+type ScopedTsRxFixture = typeof tsx & {
+	DirectiveContext: ComponentBody<{ visible: boolean }>;
+};
+
+const tsrxFixtureId = '/packages/octane/tests/_fixtures/scoped-jsx-values.tsrx';
+const compileOptions = {
+	dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod',
+	hmr: false,
+};
+const tsrx = loadCompiledFixtureSource<ScopedTsRxFixture>(tsrxSource, {
+	id: tsrxFixtureId,
+	mode: 'client',
+	compileOptions,
+});
+
+const fixtures = [
+	{
+		name: 'TSRX',
+		client: tsrx,
+		server: loadCompiledFixtureSource<ScopedTsRxFixture>(tsrxSource, {
+			id: tsrxFixtureId,
+			mode: 'server',
+			compileOptions,
+		}),
+	},
+	{
+		name: 'TSX',
+		client: tsx,
+		server: loadServerFixture<typeof tsx>('packages/octane/tests/_fixtures/scoped-jsx-values.tsx'),
+	},
+];
+
+function deferred() {
+	let resolve!: (value: string) => void;
+	const promise = new Promise<string>((complete) => {
+		resolve = complete;
+	});
+	return { promise, resolve };
+}
+
+const contextScenarios = [
+	['DirectContext', '[data-context="direct"]'],
+	['VariableContext', '[data-context="variable"]'],
+	['PropContext', '[data-context="prop"]'],
+	['NestedContext', '[data-context="nested"]'],
+	['GetterContext', '[data-context="getter"]'],
+	['ProxyContext', '[data-context="proxy"]'],
+	['CoercionContext', '[data-context="coercion"]'],
+	['IterableContext', '[data-context="iterable"]'],
+	['OptionalComputedKeyContext', '[data-context="optional-key"]'],
+] as const;
+
+for (const fixture of fixtures) {
+	describe(`${fixture.name} JSX values follow the represented render scope`, () => {
+		for (const [exportName, selector] of contextScenarios) {
+			it(`${exportName} reads its nearest represented provider`, () => {
+				const result = mount(fixture.client[exportName]);
+				expect(result.find(selector).textContent).toBe('inner');
+				result.unmount();
+			});
+
+			it(`${exportName} server-renders its nearest represented provider`, () => {
+				const { html } = ServerRuntime.renderToString(fixture.server[exportName]);
+				expect(html).toContain('inner');
+				expect(html).not.toContain('outer');
+			});
+
+			it(`${exportName} hydrates its existing provider and child`, () => {
+				const { html } = ServerRuntime.renderToString(fixture.server[exportName]);
+				const container = document.createElement('div');
+				container.innerHTML = html;
+				document.body.appendChild(container);
+				const existing = container.querySelector(selector);
+				expect(existing?.textContent).toBe('inner');
+
+				const root = hydrateRoot(container, fixture.client[exportName]);
+				flushSync(() => {});
+				expect(container.querySelector(selector)).toBe(existing);
+				expect(existing?.textContent).toBe('inner');
+				root.unmount();
+				container.remove();
+			});
+		}
+
+		it('evaluates nested host attributes inside their represented provider', () => {
+			const result = mount(fixture.client.GetterAttributeContext);
+			expect(result.find('[data-context="attribute"]').getAttribute('data-value')).toBe('inner');
+			result.unmount();
+		});
+
+		it('server-renders nested host attributes inside their represented provider', () => {
+			const { html } = ServerRuntime.renderToString(fixture.server.GetterAttributeContext);
+			expect(html).toContain('data-value="inner"');
+			expect(html).not.toContain('data-value="outer"');
+		});
+
+		it('keeps a shared JSX descriptor isolated across providers and updates', () => {
+			const result = mount(fixture.client.SharedDescriptorProviders, {
+				first: 'first',
+				second: 'second',
+			});
+			const values = () =>
+				result.findAll('[data-context="shared"]').map((element) => element.textContent);
+			expect(values()).toEqual(['first', 'second']);
+
+			result.update(fixture.client.SharedDescriptorProviders, {
+				first: 'updated-first',
+				second: 'updated-second',
+			});
+			expect(values()).toEqual(['updated-first', 'updated-second']);
+			result.unmount();
+		});
+
+		it('isolates a shared JSX descriptor across providers and server requests', () => {
+			const first = ServerRuntime.renderToString(fixture.server.SharedDescriptorProviders, {
+				first: 'first',
+				second: 'second',
+			});
+			const next = ServerRuntime.renderToString(fixture.server.SharedDescriptorProviders, {
+				first: 'next-first',
+				second: 'next-second',
+			});
+
+			const firstMarkup = document.createElement('div');
+			firstMarkup.innerHTML = first.html;
+			const nextMarkup = document.createElement('div');
+			nextMarkup.innerHTML = next.html;
+			expect(
+				Array.from(
+					firstMarkup.querySelectorAll('[data-context="shared"]'),
+					(element) => element.textContent,
+				),
+			).toEqual(['first', 'second']);
+			expect(
+				Array.from(
+					nextMarkup.querySelectorAll('[data-context="shared"]'),
+					(element) => element.textContent,
+				),
+			).toEqual(['next-first', 'next-second']);
+		});
+
+		it('hydrates a shared JSX descriptor without leaking provider values', () => {
+			const props = { first: 'first', second: 'second' };
+			const { html } = ServerRuntime.renderToString(
+				fixture.server.SharedDescriptorProviders,
+				props,
+			);
+			const container = document.createElement('div');
+			container.innerHTML = html;
+			document.body.appendChild(container);
+			const existing = Array.from(container.querySelectorAll('[data-context="shared"]'));
+			expect(existing.map((element) => element.textContent)).toEqual(['first', 'second']);
+
+			const root = hydrateRoot(container, fixture.client.SharedDescriptorProviders, props);
+			flushSync(() => {});
+			const adopted = Array.from(container.querySelectorAll('[data-context="shared"]'));
+			expect(adopted).toEqual(existing);
+			expect(adopted.map((element) => element.textContent)).toEqual(['first', 'second']);
+			root.unmount();
+			container.remove();
+		});
+
+		for (const exportName of [
+			'BuiltInErrorValue',
+			'WrappedErrorValue',
+			'WrappedGetterErrorValue',
+		] as const) {
+			it(`${exportName} assigns a synchronous error to its nearest boundary`, () => {
+				const result = mount(fixture.client[exportName]);
+				expect(result.find('[data-fallback="inner"]').textContent).toBe('inner');
+				expect(result.findAll('[data-fallback="outer"]')).toHaveLength(0);
+				result.unmount();
+			});
+
+			it(`${exportName} server-renders its nearest error fallback`, () => {
+				const { html } = ServerRuntime.renderToString(fixture.server[exportName]);
+				expect(html).toContain('data-fallback="inner"');
+				expect(html).not.toContain('data-fallback="outer"');
+			});
+		}
+
+		for (const [exportName, resolved] of [
+			['DirectSuspense', 'direct'],
+			['VariableSuspense', 'variable'],
+			['WrappedSuspenseValue', 'wrapped'],
+			['GetterSuspenseValue', 'getter'],
+		] as const) {
+			it(`${exportName} suspends and resolves inside its represented boundary`, async () => {
+				const pending = deferred();
+				const result = mount(fixture.client[exportName], { promise: pending.promise });
+				expect(result.find('[data-fallback="pending"]').textContent).toBe('pending');
+
+				await act(() => {
+					pending.resolve('resolved');
+				});
+
+				expect(result.find(`[data-resolved="${resolved}"]`).textContent).toBe('resolved');
+				expect(result.findAll('[data-fallback="pending"]')).toHaveLength(0);
+				result.unmount();
+			});
+
+			it(`${exportName} server-renders its own pending fallback`, () => {
+				const pending = deferred();
+				const { html } = ServerRuntime.renderToString(fixture.server[exportName], {
+					promise: pending.promise,
+				});
+				expect(html).toContain('data-fallback="pending"');
+			});
+		}
+
+		for (const [exportName, value, expected] of [
+			['OrdinaryElementValue', 'yes', 'ordinary'],
+			['InspectableExpressionValue', 'expression', 'inspected'],
+			['DirectCreateElementValue', 'create-element', 'direct'],
+		] as const) {
+			it(`${exportName} preserves inspectable, cloneable element descriptors`, () => {
+				const result = mount(fixture.client[exportName]);
+				const parent = result.find('[data-valid="true"]');
+				const child = result.find(`[data-ordinary="${value}"]`);
+				expect(parent.getAttribute('data-element-type')).toBe('span');
+				expect(parent.getAttribute('data-child-type')).toBe('string');
+				expect(child.textContent).toBe(expected);
+				expect(child.getAttribute('data-inspected')).toBe('yes');
+				result.unmount();
+			});
+
+			it(`${exportName} preserves descriptor inspection during server rendering`, () => {
+				const { html } = ServerRuntime.renderToString(fixture.server[exportName]);
+				expect(html).toContain('data-valid="true"');
+				expect(html).toContain('data-element-type="span"');
+				expect(html).toContain('data-child-type="string"');
+				expect(html).toContain(`data-ordinary="${value}"`);
+				expect(html).toContain('data-inspected="yes"');
+				expect(html).toContain(expected);
+			});
+		}
+	});
+}
+
+describe('TSRX directives nested in JSX values', () => {
+	it('retains the provider inside an active directive arm', () => {
+		const result = mount(tsrx.DirectiveContext, { visible: true });
+		expect(result.find('[data-context="directive"]').textContent).toBe('inner');
+		result.update(tsrx.DirectiveContext, { visible: false });
+		expect(result.find('[data-context="directive"]').textContent).toBe('hidden');
+		result.unmount();
+	});
+
+	it('server-renders a nested directive under its represented provider', () => {
+		const server = fixtures[0].server as ScopedTsRxFixture;
+		const { html } = ServerRuntime.renderToString(server.DirectiveContext, {
+			visible: true,
+		});
+		expect(html).toContain('data-context="directive"');
+		expect(html).toContain('inner');
+		expect(html).not.toContain('outer');
+	});
+});

--- a/packages/octane/tests/ssr-tsx-children.test.ts
+++ b/packages/octane/tests/ssr-tsx-children.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect } from 'vitest';
 import { compile } from 'octane/compiler';
 
 // A React-style `.tsx` `return <jsx>` body is VALUE position: the client lowers it
-// to `createElement(...)` descriptors, so a component's children are a DESCRIPTOR
+// to element descriptors, so a component's children are a DESCRIPTOR
 // (one hydration block). A `@{}` body is TEMPLATE position: the client uses a
 // `__children` render-fn (an extra block). The SERVER must match per form, or the
 // server tree is one block deeper than the client and the hydration cursor desyncs
@@ -15,6 +15,52 @@ function clientCode(src: string): string {
 }
 function serverCode(src: string): string {
 	return compile(src, 'f.tsx', { mode: 'server' }).code;
+}
+
+function runtimeImports(code: string, names: readonly string[]): Set<string> {
+	const factories = new Set<string>();
+	const program = parseModule(code, 'compiled.js');
+	for (const statement of program.body) {
+		if (statement.type !== 'ImportDeclaration') continue;
+		if (statement.source?.value !== 'octane' && statement.source?.value !== 'octane/server') {
+			continue;
+		}
+		for (const specifier of statement.specifiers) {
+			if (specifier.type !== 'ImportSpecifier') continue;
+			if (names.includes(specifier.imported?.name)) {
+				factories.add(specifier.local.name);
+			}
+		}
+	}
+	return factories;
+}
+
+function descriptorFactories(code: string): Set<string> {
+	return runtimeImports(code, ['createElement', 'createScopedElement']);
+}
+
+function elementDescriptorCalls(code: string, component: string): any[] {
+	const factories = descriptorFactories(code);
+	const calls: any[] = [];
+	const seen = new WeakSet<object>();
+	const visit = (node: any) => {
+		if (node === null || typeof node !== 'object' || seen.has(node)) return;
+		seen.add(node);
+		if (
+			node.type === 'CallExpression' &&
+			factories.has(node.callee?.name) &&
+			node.arguments[0]?.name === component
+		) {
+			calls.push(node);
+		}
+		for (const [key, value] of Object.entries(node)) {
+			if (key === 'loc' || key === 'metadata') continue;
+			if (Array.isArray(value)) value.forEach(visit);
+			else visit(value);
+		}
+	};
+	visit(parseModule(code, 'compiled.js'));
+	return calls;
 }
 
 function childrenValues(code: string): any[] {
@@ -50,30 +96,26 @@ describe('.tsx return-form component children — server matches client (descrip
 			);
 		}`;
 
-	it('client lowers return-form children to a createElement descriptor', () => {
+	it('client lowers return-form components and children to element descriptors', () => {
 		const code = clientCode(RETURN_FORM);
-		expect(code).toMatch(/createElement\(\s*Provider/);
-		// The child is a nested createElement (descriptor), not a render-fn.
-		expect(code).toMatch(/createElement\(\s*Inner/);
+		expect(elementDescriptorCalls(code, 'Provider').length).toBeGreaterThan(0);
+		expect(elementDescriptorCalls(code, 'Inner').length).toBeGreaterThan(0);
 	});
 
-	it('server passes return-form children as a createElement DESCRIPTOR (not __schildren)', () => {
+	it('server passes return-form children as an element descriptor, not a render block', () => {
 		const code = serverCode(RETURN_FORM);
-		// children must be a createElement(Inner, …) descriptor — matching the client —
-		// so `{props.children}` → ssrChild(descriptor) is ONE block, like childSlot.
+		const factories = descriptorFactories(code);
+		// The child remains an inspectable descriptor rather than a template-only
+		// children block, whichever descriptor factory preserves its render scope.
 		const values = childrenValues(code);
 		expect(
 			values.some(
 				(value) =>
 					value.type === 'CallExpression' &&
-					value.callee?.name === '_$createElement' &&
+					factories.has(value.callee?.name) &&
 					value.arguments[0]?.name === 'Inner',
 			),
 		).toBe(true);
-		// It must NOT wrap children in a __schildren render-fn (that adds a block).
-		expect(
-			values.some((value) => value.type === 'Identifier' && value.name.startsWith('__schildren')),
-		).toBe(false);
 	});
 
 	it('`@{}` (template-form) children stay a __schildren render-fn on the server', () => {
@@ -86,16 +128,14 @@ describe('.tsx return-form component children — server matches client (descrip
 				</Provider>
 			}`;
 		const code = serverCode(TEMPLATE_FORM);
-		// Tagged with markChildrenBlock (like the client) so render-prop checks
-		// (`typeof children === 'function' && !isChildrenBlock(children)`) agree
-		// on both runtimes.
+		const childrenBlockFactories = runtimeImports(code, ['markChildrenBlock']);
+		// Tagged as a children block so render-prop checks agree on both runtimes.
 		expect(
 			childrenValues(code).some(
 				(value) =>
 					value.type === 'CallExpression' &&
-					value.callee?.name === '_$markChildrenBlock' &&
-					value.arguments[0]?.type === 'Identifier' &&
-					value.arguments[0].name.startsWith('__schildren'),
+					childrenBlockFactories.has(value.callee?.name) &&
+					value.arguments[0]?.type === 'Identifier',
 			),
 		).toBe(true);
 	});

--- a/packages/octane/tests/ssr-tsx-children.test.ts
+++ b/packages/octane/tests/ssr-tsx-children.test.ts
@@ -39,7 +39,7 @@ function descriptorFactories(code: string): Set<string> {
 	return runtimeImports(code, ['createElement', 'createScopedElement']);
 }
 
-function elementDescriptorCalls(code: string, component: string): any[] {
+function elementDescriptorCalls(code: string, component: string, root?: any): any[] {
 	const factories = descriptorFactories(code);
 	const calls: any[] = [];
 	const seen = new WeakSet<object>();
@@ -59,7 +59,7 @@ function elementDescriptorCalls(code: string, component: string): any[] {
 			else visit(value);
 		}
 	};
-	visit(parseModule(code, 'compiled.js'));
+	visit(root ?? parseModule(code, 'compiled.js'));
 	return calls;
 }
 
@@ -104,16 +104,15 @@ describe('.tsx return-form component children — server matches client (descrip
 
 	it('server passes return-form children as an element descriptor, not a render block', () => {
 		const code = serverCode(RETURN_FORM);
-		const factories = descriptorFactories(code);
+		const childrenBlockFactories = runtimeImports(code, ['markChildrenBlock']);
 		// The child remains an inspectable descriptor rather than a template-only
-		// children block, whichever descriptor factory preserves its render scope.
+		// children block, even when its complete record is deferred until inspection.
 		const values = childrenValues(code);
 		expect(
 			values.some(
 				(value) =>
-					value.type === 'CallExpression' &&
-					factories.has(value.callee?.name) &&
-					value.arguments[0]?.name === 'Inner',
+					!(value.type === 'CallExpression' && childrenBlockFactories.has(value.callee?.name)) &&
+					elementDescriptorCalls(code, 'Inner', value).length > 0,
 			),
 		).toBe(true);
 	});

--- a/packages/rspeedy-plugin-octane/tests/demo.test.ts
+++ b/packages/rspeedy-plugin-octane/tests/demo.test.ts
@@ -200,7 +200,9 @@ it('fails instead of moving the demo when its requested port is occupied', async
 
 		expect(result.error).toBeUndefined();
 		expect(result.status).not.toBe(0);
-		expect(`${result.stdout}\n${result.stderr}`).toMatch(/port.*(?:in use|occupied|unavailable)/iu);
+		expect(`${result.stdout}\n${result.stderr}`).toMatch(
+			/port.*(?:in use|occupied|unavailable)|(?:failed|unable) to find an available port/iu,
+		);
 	} finally {
 		await new Promise<void>((resolveClose, reject) => {
 			server.close((error) => {


### PR DESCRIPTION
## Summary

- Defer the **complete compiler-authored JSX element record**—dynamic root type, props, key/ref, and descendants—until its represented render scope is active, addressing the latest human review and the direct-return server-rendering mismatch.
- Keep JSX values as ordinary inspectable element descriptors: `isValidElement`, `Children.only`, `cloneElement`, and direct `type`/`props`/`children` inspection resolve the record in the inspecting caller's current scope.
- Preserve static JSX, explicit `createElement`, fragment/indexed-child compatibility, native event/render-prop semantics, hydration identity, and existing client/server descriptor topology.
- Preserve the existing fix for cold 1,000-level buffered and streaming server component trees without changing the separate JSX/TSRX performance work.
- Repair the failing package-build integration check by accepting current Rsbuild occupied-port diagnostics while still requiring strict-port startup to fail.

## Why

Deferring only descendants left root member tags, getter-backed attributes, component props, and spreads evaluating before their represented Provider, Suspense boundary, or ErrorBoundary. The server's direct `.tsx` return path also exposed this mismatch as incorrect SSR markup and hydration disagreement. A lazy but normally inspectable complete descriptor resolves all of those cases uniformly without introducing additional component boundaries or hydration markers.

## Changes

- Introduce matching client/server compiler-ABI `createScopedValue` helpers for dynamic root records, retaining `createScopedElement` child deferral and leaving statically provable JSX on its existing fast path.
- Cache deferred records by active scope and client context epoch; stamp the concrete committed descriptor on deoptimized host nodes so Provider updates correctly diff previous attributes and Suspense cleanup never evaluates user getters outside render.
- Cover direct-return SSR, root getter attributes, spreads, component props, dynamic component tags, descriptor inspection/cloning, shared descriptors, Provider updates, independent server requests, hydration adoption, nearest ErrorBoundary ownership, and Suspense resolution/cleanup across TSX and TSRX.
- Update the compiler-artifact compatibility assertion to verify the underlying inspectable descriptor without depending on a particular lazy-wrapper shape.
- Document complete-record render-scope semantics and update the strict-port integration matcher for modern Rsbuild diagnostics.

## Validation

- [x] Complete Octane development and production core suites: **780 files / 10,346 tests passed**, with zero failures or unhandled errors.
- [x] Expanded TSX/TSRX scoped-JSX review matrix: **604/604 passed** across client rendering, SSR, hydration, descriptor inspection, Provider updates, ErrorBoundary, and Suspense.
- [x] Frozen-AST/source-map/compiler compatibility coverage: **464/464 passed**; universal/custom renderer coverage: **234/234 passed**.
- [x] Representative app-core, i18next client/server, Visx SSR, and Lynx ecosystem integrations: **364/364 passed**.
- [x] Complete repository Prettier check; Octane runtime/public type tests; app-core typecheck; changeset, generated-error-code, test-marker, published-TSRX-declaration, and package-inventory gates.
- [x] Octane production package build and generated client/server declaration/import smoke tests, including both `createScopedValue` exports.
- [x] Deterministic 16-file production-codegen corpus remains **byte-for-byte unchanged** from the previous PR head: **146,802 raw / 72,459 minified / 26,150 gzip bytes**.
- [x] Paired ordinary-element runtime microbenchmark is unchanged within noise; the new helper increases compressed runtime size by approximately **141 client bytes / 96 server bytes** and applies only to dynamic value-position root records.
- [x] Reproduced the real strict occupied-port Rsbuild failure and verified the previous matcher rejects its current message while the replacement matcher accepts it; full package-build/browser jobs remain covered by GitHub Actions because optional local dependencies/Chromium are absent.
- [x] Confirmed this branch and the independent runtime-performance PR #363 **merge automatically without conflicts**, despite five independently edited core files; its branch and worktree were left untouched.

## Risk / follow-ups

- Dynamic value-position roots now intentionally evaluate their full record at inspection/render time rather than when the lexical JSX expression is created; static JSX, explicit `createElement`, and ordinary callbacks retain JavaScript evaluation timing.
- A newly introduced lazy shell adds approximately 600 ns to first construction/resolution only for the affected uncommon dynamic-root path; steady-state ordinary element creation and the representative production-codegen corpus are unchanged.
- Server rendering remains synchronous and subject to the engine's ultimate stack ceiling; the existing 1,000-level buffered/streaming regression coverage remains in the complete core run.
- Optional Three, package-build, and real-browser integrations require dependencies/browser binaries not present in this isolated local worktree and will be rechecked by the PR's GitHub Actions matrix.

Follow-up to #353 and #355; addresses https://github.com/octanejs/octane/issues/353#issuecomment-5109217418 and the latest review on #361.
