### PR TITLE
perf(octane): bring JSX keyed-list rendering closer to TSRX

### DIFF
--- a/.changeset/jsx-keyed-list-memo-parity.md
+++ b/.changeset/jsx-keyed-list-memo-parity.md
@@ -1,0 +1,10 @@
+---
+'octane': patch
+---
+
+Enable the existing keyed-list purity and automatic memoization optimizations for
+components authored with ordinary TSX/JSX returns. JSX lists now reuse unchanged
+items like equivalent TSRX templates while preserving context updates, captured
+values, component boundaries, and JSX children semantics. Native dense Arrays
+retain the optimized path; custom or overridden map methods, sparse Arrays, and
+additional map arguments preserve normal JavaScript behavior.

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -148,24 +148,24 @@
     "op": "parent_rerender_equal_A",
     "target": "octane-jsx",
     "reference": "octane-tsrx",
-    "maxRatio": 600,
-    "note": "Known return-JSX autoMemo gap: the calibrated 8ms batches measured 469-491x through 2026-07-19. This intentionally loose ceiling catches added work until descriptor-output reuse closes the gap; deterministic work gates remain the primary oracle."
+    "maxRatio": 6,
+    "note": "Guarded native-array JSX lists reuse unchanged keyed work; the 20-sample production pairing measured 3.86x TSRX after preserving the ordinary return-descriptor boundary (previously 497x). Six leaves browser-noise headroom while preventing a return to 1000 survivor visits."
   },
   {
     "suite": "memo-wall",
     "op": "one_change_A",
     "target": "octane-jsx",
     "reference": "octane-tsrx",
-    "maxRatio": 32,
-    "note": "Known return-JSX one-change gap measured 21.2-25.9x through 2026-07-19. The 32x ceiling allows normal paired variation while preventing more row/list work from landing."
+    "maxRatio": 10,
+    "note": "Guarded returned-JSX keyed lists enter only the changed row helper. Conservatively checking each fresh array snapshot for observable indexed accessors measured 7.41x TSRX, improving the prior 26.62x gap while preserving ordinary Array.map getter semantics. Ten leaves browser-noise headroom without allowing the old descriptor-rebuild path."
   },
   {
     "suite": "memo-wall",
     "op": "ctx_through_wall_A",
     "target": "octane-jsx",
     "reference": "octane-tsrx",
-    "maxRatio": 3,
-    "note": "Context-through-wall TSX/TSRX ratio remained 2.24-2.37x through 2026-07-19. The ceiling protects leaf-only refresh behavior while the return-JSX wrapper work is optimized."
+    "maxRatio": 2.25,
+    "note": "Context-aware returned-JSX list caching keeps all 1000 leaf consumers reactive without revisiting keyed survivors; the 20-sample production pairing measured 1.94x TSRX. The ceiling allows browser variance while protecting the context invalidation path."
   },
   {
     "suite": "recursive-context",

--- a/benchmarks/memo-wall/README.md
+++ b/benchmarks/memo-wall/README.md
@@ -6,13 +6,12 @@ create/update throughput, **memo-wall isolates the memo bail**: 1000
 `memo(Row)` children under one parent, where a parent re-render traditionally
 gets absorbed by 1000 shallow-equal prop comparisons, a single prop change must
 re-render exactly one row, and a context bump above the wall must refresh only
-the leaf consumers without re-running any bailed body. Octane TSRX wall A also
-exercises the default production `autoMemo` transform: an equal `items`
-dependency reuses the whole `RowsA` region before the keyed wall. Wall B stays
-the untransformed control — autoMemo does not reach through an imported
-helper's returned descriptors (that calculation/output phase ships together
-with per-key descriptor reuse), so every wall-B parent update rebuilds all
-1000 descriptors and must be absorbed by the value-comparing memo bail.
+the leaf consumers without re-running any bailed body. Both Octane dialects
+exercise production `autoMemo` on wall A: TSRX can skip the entire pure `RowsA`
+region, while returned JSX preserves its descriptor boundary and skips the
+unchanged compiled keyed list inside `RowsA`. Wall B remains the descriptor
+control; its imported calculation may be reused when its inputs are unchanged,
+while changed inputs still exercise the value-comparing memo bail.
 
 This is the canonical home for octane's `shallowEqualProps` and
 `refreshContextConsumers` numbers — if a store-fanout suite lands later it must
@@ -77,20 +76,20 @@ how `<Row>` is put on screen:
   Provider children because the `.tsx` dialect only folds a keyed `.map` to
   the compiled forBlock under host-only ancestors; the Octane, React, and
   Preact fixtures keep the identical structure so those columns stay comparable.
-  The default production `autoMemo` transform also caches the call to pure
-  `RowsA` by its inferred `items` capture and skips this whole path on
-  equal/context-only parent updates. The return-JSX `.tsx` descriptor-cache path
-  is a later phase and currently remains a 1000-bail control.
+  The default production `autoMemo` transform caches the TSRX call to pure
+  `RowsA` by its inferred `items` capture. For returned JSX, `RowsA` still
+  enters through its normal descriptor boundary, but its dense native Array
+  `.map` uses the same whole-list and per-item guards. Custom or overridden map
+  methods, sparse arrays, and calls with additional arguments retain normal
+  JavaScript dispatch.
 - **wall B — value-position**: a plain-`.ts` helper (`src/wall-b.ts`) builds
   `createElement(Row, props)` descriptors that reach the DOM through a
   `{rows}` children hole → `childSlot`'s keyed de-opt list → the **childSlot
   arm** of `tryMemoBail`. This is the shape every `@octanejs/*` binding
   produces. A fresh descriptor + fresh props object is allocated every parent
-  render — the bail must succeed on prop VALUES, not object identity. autoMemo
-  deliberately leaves this path alone: caching an imported helper's returned
-  descriptors is the calculation/output phase, deferred until per-key
-  descriptor reuse makes its miss path at least as fast as the bail it
-  replaces.
+  render unless automatic calculation memoization reuses the imported helper's
+  result for unchanged inputs. When its input changes, the bail must succeed on
+  prop VALUES, not object identity.
 
 For React the A/B distinction collapses (JSX IS `createElement`); both walls
 are kept so the op list and DOM stay identical across targets. The vanilla
@@ -123,10 +122,10 @@ disable automatic memoization. `work.mjs` provides the stronger, untimed gate
 after compilation using Chromium precise call coverage. For TSRX equal/context
 A it requires zero list helpers, keyed survivor visits, descriptors, shallow
 memo comparisons, and row bodies (context A additionally requires exactly 1000
-Leaf refreshes). Wall B's gates pin the memo-bail control: every parent update
-runs the helper once, builds 1000 descriptors, visits 1000 survivors, and bails
-1000 comparisons with zero row bodies. Mount and one-change A/B also carry
-exact compiled-work gates.
+Leaf refreshes). JSX retains its normal `RowsA`/descriptor entry but likewise
+requires zero keyed survivor visits, item helpers, and memo comparisons on an
+unchanged list. Wall B verifies both reused unchanged calculations and changed
+descriptor lists. Mount and one-change A/B also carry exact compiled-work gates.
 
 The React Row/Inner/Leaf counters likewise make those component bodies impure,
 so React Compiler conservatively leaves them alone; the explicit `memo`
@@ -184,6 +183,10 @@ used for timings):
 MEMO_WALL_WORK=1 pnpm --filter octane-tsrx-memowall-bench build
 pnpm --filter octane-tsrx-memowall-bench preview
 pnpm --dir benchmarks/memo-wall bench:work
+
+MEMO_WALL_WORK=1 pnpm --filter octane-jsx-memowall-bench build
+pnpm --filter octane-jsx-memowall-bench preview
+WORK_DIALECT=jsx pnpm --dir benchmarks/memo-wall bench:work
 ```
 
 Set `TARGET_URL` to use a non-default preview URL and `WORK_JSON` to persist the
@@ -195,11 +198,11 @@ per-operation counts.
   PURE path enters only the changed item helper; wall B also performs the 999
   successful prop bails around the single miss. This is the intended "one
   change amid a wall" workload, not a pure single-row-render cost.
-- Vanilla React and Octane JSX `parent_rerender_equal` include recreating or
-  reconciling 1000 row descriptions. Auto-memoized Octane TSRX stops at wall
-  A's inferred region/list dependencies but deliberately rebuilds wall B's
-  descriptors (imported-helper output caching is a later phase), while React
-  Compiler caches both the `.map` and the imported helper call. The
+- Vanilla React `parent_rerender_equal` recreates or reconciles 1000 row
+  descriptions. Both Octane dialects skip wall A's unchanged keyed list; JSX
+  retains its descriptor-wrapper overhead. Unchanged wall-B helper output can
+  also be cached, while changed inputs exercise descriptor reconciliation.
+  React Compiler caches both the `.map` and imported helper call. The
   cross-framework ratio is the honest end-to-end cost of each production
   compiler, not an instruction-level apples-to-apples comparison.
 - `mount` covers BOTH walls (2000 rows + providers), not 1000.

--- a/benchmarks/memo-wall/work.mjs
+++ b/benchmarks/memo-wall/work.mjs
@@ -1,4 +1,5 @@
 // Deterministic, untimed work gate for Octane's production TSRX target.
+// Set WORK_DIALECT=jsx to check the equivalent return-JSX production target.
 //
 // This deliberately uses Chromium precise call coverage after compilation,
 // rather than source-level counters inside RowsA/@for. Observable mutations in
@@ -13,7 +14,11 @@
 import { chromium } from 'playwright';
 import fs from 'node:fs';
 
-const URL = process.env.TARGET_URL || 'http://localhost:5206/';
+const DIALECT = process.env.WORK_DIALECT || 'tsrx';
+if (DIALECT !== 'tsrx' && DIALECT !== 'jsx') {
+	throw new Error(`Unsupported WORK_DIALECT ${JSON.stringify(DIALECT)}; expected "tsrx" or "jsx".`);
+}
+const URL = process.env.TARGET_URL || `http://localhost:${DIALECT === 'jsx' ? 5207 : 5206}/`;
 const ROWS = 1000;
 const METRICS = [
 	'RowsA',
@@ -103,10 +108,9 @@ const OPS = [
 			Leaf: 1,
 		},
 	},
-	// Wall B renders through an imported helper's returned descriptors, which
-	// autoMemo deliberately does not cache (per-key descriptor reuse is a later
-	// phase). Every parent update therefore rebuilds all 1000 descriptors and
-	// must be absorbed by value-comparing memo bails — zero row bodies.
+	// Wall B's imported helper is cached against its `items` argument by
+	// production auto-calculation. Equal/context-only TSRX parent updates reuse
+	// that descriptor array; changed items still rebuild it in one_change_B.
 	{
 		name: 'context_B',
 		hook: '__ctxB',
@@ -114,8 +118,8 @@ const OPS = [
 			RowsA: 0,
 			updateSurvivor: ROWS,
 			itemBody: 0,
-			buildValueRows: 1,
-			createElement: ROWS,
+			buildValueRows: 0,
+			createElement: 0,
 			shallowEqualProps: ROWS,
 			RowImpl: 0,
 			InnerImpl: 0,
@@ -129,8 +133,8 @@ const OPS = [
 			RowsA: 0,
 			updateSurvivor: ROWS,
 			itemBody: 0,
-			buildValueRows: 1,
-			createElement: ROWS,
+			buildValueRows: 0,
+			createElement: 0,
 			shallowEqualProps: ROWS,
 			RowImpl: 0,
 			InnerImpl: 0,
@@ -138,6 +142,21 @@ const OPS = [
 		},
 	},
 ];
+
+// Return-JSX components keep their public descriptor ABI, so their wrapper
+// allocations differ from TSRX even when both dialects do the same keyed-list
+// work. Keep the consumer-visible bodies and the optimized list work exact:
+// an unchanged wall must visit no keyed survivors, while a changed item must
+// visit the survivors but run exactly one item/row/inner/leaf body.
+const JSX_EXPECTATIONS = {
+	mount: { createElement: 11007 },
+	equal_A: { RowsA: 1, createElement: 3 },
+	one_change_A: { createElement: 8 },
+	context_A: { RowsA: 1, createElement: ROWS + 3 },
+	one_change_B: { createElement: ROWS + 6 },
+	context_B: { buildValueRows: 1, createElement: ROWS * 2 + 1 },
+	equal_B_control: { buildValueRows: 1, createElement: ROWS + 1 },
+};
 
 function callCounts(coverage) {
 	const counts = Object.fromEntries(METRICS.map((name) => [name, 0]));
@@ -200,9 +219,10 @@ try {
 	for (const op of OPS) {
 		const counts = await measure(browser, op);
 		results[op.name] = counts;
+		const expected = DIALECT === 'jsx' ? { ...op.expect, ...JSX_EXPECTATIONS[op.name] } : op.expect;
 		for (const metric of METRICS) {
-			if (counts[metric] !== op.expect[metric]) {
-				failures.push(`${op.name}.${metric}: ${counts[metric]} !== expected ${op.expect[metric]}`);
+			if (counts[metric] !== expected[metric]) {
+				failures.push(`${op.name}.${metric}: ${counts[metric]} !== expected ${expected[metric]}`);
 			}
 		}
 	}

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -13420,10 +13420,13 @@ function lowerReturnJsx(node, ctx, compInlinedSubs, cssHash = null) {
 		(rewritten.type === 'Element' || rewritten.type === 'JSXElement') &&
 		!isComponentTag(rewritten)
 	) {
-		return lowerHostFragment(rewritten, ctx, compInlinedSubs, 'opaque', cssHash);
+		return lowerHostFragment(rewritten, ctx, compInlinedSubs, 'opaque', cssHash, true);
 	}
 	if (requiresTemplateNormalization(rewritten)) {
-		return lowerHostFragment(rewritten, ctx, compInlinedSubs, 'opaque', cssHash);
+		return lowerHostFragment(rewritten, ctx, compInlinedSubs, 'opaque', cssHash, true);
+	}
+	if (rewritten.type === 'Element' || rewritten.type === 'JSXElement') {
+		return jsxElementToCreateElement(rewritten, ctx, true);
 	}
 	return rewriteJsxValues(rewritten, ctx);
 }
@@ -13560,7 +13563,12 @@ function extractFragment(node, ctx, holeProps, parentNs = 'html') {
 				newChildren.push(extractFragmentComponent(child, ctx, holeProps, childNs));
 			} else if (isComponentTag(child)) {
 				const hn = `h${holeProps.length}`;
-				holeProps.push(objectProp(hn, jsxElementToCreateElement(child, ctx)));
+				holeProps.push(
+					objectProp(
+						hn,
+						jsxElementToCreateElement(child, ctx, ctx._foldCtx?.immediateRenderedOutput === true),
+					),
+				);
 				newChildren.push(b.jsx_expression_container(memberProps(hn, child)));
 			} else {
 				newChildren.push(extractFragment(child, ctx, holeProps, childNs));
@@ -13887,7 +13895,14 @@ function extractFragmentRoot(node, ctx, holeProps, parentNs = 'html') {
 // renderer + `createElement(_frag$N, {...})`.
 // `compInlinedSubs` is the COMPONENT's inlinedSubs: a folded directive's branch
 // helper functions are emitted there (closure preserved), not in the renderer.
-function lowerHostFragment(node, ctx, compInlinedSubs, parentNs = 'html', cssHash = null) {
+function lowerHostFragment(
+	node,
+	ctx,
+	compInlinedSubs,
+	parentNs = 'html',
+	cssHash = null,
+	immediateRenderedOutput = false,
+) {
 	const holeProps = [];
 	const directiveCalls = { ifCalls: [], forCalls: [], switchCalls: [], tryCalls: [] };
 	// extractFragment reads `ctx._foldCtx` for any directive child it folds (and to
@@ -13902,6 +13917,9 @@ function lowerHostFragment(node, ctx, compInlinedSubs, parentNs = 'html', cssHas
 					parentNs,
 					cssHash,
 					templateComponentChildren,
+					// Direct return holes run in their owning component's current render
+					// scope; setup/escaped values still need complete-record deferral.
+					immediateRenderedOutput,
 				}
 			: null;
 	const rendererEl = extractFragmentRoot(node, ctx, holeProps, parentNs);

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -9220,7 +9220,7 @@ function ssrEmitFor(node, ctx, name, inlinedSubs, parentNs, cssHash, componentNs
 			ssrCall(
 				'ssrChild',
 				[
-					b.call('_$mapSlot', receiver, method, rewriteJsxValues(mapCall.callback, ctx)),
+					b.call('_$mapSlot', receiver, method, rewriteMapCallbackJsxValues(mapCall.callback, ctx)),
 					b.id('__s'),
 				],
 				node,
@@ -13690,7 +13690,9 @@ function extractFragment(node, ctx, holeProps, parentNs = 'html') {
 				);
 				rec.mapMethodExpr = memberProps(methodHole, mapCall.callback);
 				const callbackHole = `h${holeProps.length}`;
-				holeProps.push(objectProp(callbackHole, rewriteJsxValues(mapCall.callback, ctx)));
+				holeProps.push(
+					objectProp(callbackHole, rewriteMapCallbackJsxValues(mapCall.callback, ctx)),
+				);
 				rec.mapCallbackExpr = memberProps(callbackHole, mapCall.callback);
 			}
 			if (rec.emptyHelper && rec.emptyHelper !== 'null') {
@@ -14289,6 +14291,12 @@ function rewriteModuleJsxValues(node, ctx) {
 	}
 }
 
+// A map callback must evaluate its returned JSX record during the callback; only
+// that record's descendants keep their independently represented render scopes.
+function rewriteMapCallbackJsxValues(callback, ctx) {
+	return rewriteJsxValues(callback, ctx, true, unwrapTsExpr(callback));
+}
+
 /**
  * Lower a JSX COMPONENT element used at VALUE position (not as a component body's
  * rendered output) into a `createElement(Comp, props)` call, so JSX-as-a-value
@@ -14302,7 +14310,7 @@ function rewriteModuleJsxValues(node, ctx) {
  * recursively. This never touches a component body's OUTPUT JSX — that is split
  * out as `jsxNodes` and handled by planJsx before this runs.
  */
-function rewriteJsxValues(node, ctx) {
+function rewriteJsxValues(node, ctx, eagerMapCallbackRoots = false, eagerMapCallbackOwner = null) {
 	// A compiler-owned directive can sit anywhere an expression is allowed — an
 	// attribute value, an expression-container child, a child of an element that is
 	// itself a value. esrap cannot print those TSRX-only nodes, so fold them first,
@@ -14314,6 +14322,42 @@ function rewriteJsxValues(node, ctx) {
 	if (lower != null) node = lowerSetupValueDirectives(node, lower);
 	return mapAst(node, (n) => {
 		const t = n && n.type;
+		if (t === 'CallExpression') {
+			const callee = n.callee;
+			const callback = unwrapTsExpr(n.arguments?.[0]);
+			const mapMethod =
+				callee?.type === 'MemberExpression' &&
+				(callee.computed
+					? callee.property?.type === 'Literal' && callee.property.value === 'map'
+					: callee.property?.name === 'map');
+			if (mapMethod && isFunctionNode(callback)) {
+				let out = n;
+				const mappedCallee = rewriteJsxValues(
+					callee,
+					ctx,
+					eagerMapCallbackRoots,
+					eagerMapCallbackOwner,
+				);
+				if (mappedCallee !== callee) out = { ...out, callee: mappedCallee };
+				const mappedArgs = n.arguments.map((argument, index) =>
+					index === 0
+						? rewriteMapCallbackJsxValues(argument, ctx)
+						: rewriteJsxValues(argument, ctx, eagerMapCallbackRoots, eagerMapCallbackOwner),
+				);
+				if (mappedArgs.some((argument, index) => argument !== n.arguments[index])) {
+					out = { ...out, arguments: mappedArgs };
+				}
+				return out;
+			}
+		}
+		if (
+			eagerMapCallbackRoots &&
+			lower == null &&
+			isFunctionNode(n) &&
+			n !== eagerMapCallbackOwner
+		) {
+			return rewriteJsxValues(n, ctx);
+		}
 		// A nested function is a separate LEXICAL owner, but a folded arm never needs
 		// lexical access to it: arms are hoisted to module scope and receive what they
 		// capture through the `__extra` env tuple, and that tuple is built at the
@@ -14358,7 +14402,12 @@ function rewriteJsxValues(node, ctx) {
 					if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata') continue;
 					const child = n[key];
 					if (child === null || typeof child !== 'object') continue;
-					const mapped = rewriteJsxValues(child, ctx);
+					const mapped = rewriteJsxValues(
+						child,
+						ctx,
+						eagerMapCallbackRoots && n === eagerMapCallbackOwner && key === 'body',
+						eagerMapCallbackOwner,
+					);
 					if (mapped !== child) {
 						if (out === n) out = { ...n };
 						out[key] = mapped;
@@ -14379,7 +14428,7 @@ function rewriteJsxValues(node, ctx) {
 		// `jsxNodes` and handled by planJsx, which gives keyed `@for` lists their
 		// fast path.) `jsxElementToCreateElement` recurses, so mapAst need not.
 		if (t === 'Element' || t === 'JSXElement') {
-			return jsxElementToCreateElement(n, ctx);
+			return jsxElementToCreateElement(n, ctx, eagerMapCallbackRoots);
 		}
 		if (t === 'Fragment' || t === 'JSXFragment') {
 			// lowerJsxChild keeps static fragments as positional arrays and defers
@@ -14537,7 +14586,7 @@ function jsxValueChildrenNeedRenderScope(node, descendantElementsOwnChildren = f
 
 // Build a `createElement(Comp, { ...props })` CallExpression AST node from a
 // component Element node. Recurses into prop values so nested JSX values lower too.
-function jsxElementToCreateElement(node, ctx) {
+function jsxElementToCreateElement(node, ctx, eagerRoot = false) {
 	const nameNode = node.openingElement?.name || node.id;
 	const componentTag = isComponentTag(node);
 	// Host (lowercase) tag → string literal (`'li'`) for the de-opt renderer;
@@ -14662,7 +14711,7 @@ function jsxElementToCreateElement(node, ctx) {
 			node,
 		);
 	}
-	if (!jsxValueRootNeedsRenderScope(node)) return descriptor;
+	if (eagerRoot || !jsxValueRootNeedsRenderScope(node)) return descriptor;
 	ctx.runtimeNeeded.add('createScopedValue');
 	return inheritOriginLoc(
 		b.call(rtAlias('createScopedValue'), inheritOriginLoc(b.arrow([], descriptor), node)),
@@ -21335,7 +21384,7 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 				? b.member(b.id(mapCall.receiverName), 'map')
 				: b.id(mapCall.methodName)
 			: null,
-		mapCallbackExpr: mapCall ? rewriteJsxValues(mapCall.callback, ctx) : null,
+		mapCallbackExpr: mapCall ? rewriteMapCallbackJsxValues(mapCall.callback, ctx) : null,
 		keyHelper,
 		inlineKey: inlineKey ? keyFn : null,
 		bodyHelper: itemHelperName,

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -4049,6 +4049,7 @@ function mapCallToForOf(expr, ctx) {
 		params.length > 2 ||
 		params[0].type === 'AssignmentPattern' ||
 		params[0].type === 'RestElement' ||
+		params.some(mapCallbackPatternCapturesLexicalReceiver) ||
 		mapCallbackCapturesLexicalReceiver(arrow.body)
 	) {
 		return null;
@@ -4104,6 +4105,33 @@ function mapCallToForOf(expr, ctx) {
 		},
 	);
 	return inheritOriginLoc(forNode, expr);
+}
+
+function mapCallbackPatternCapturesLexicalReceiver(pattern) {
+	if (!pattern || typeof pattern !== 'object') return false;
+	switch (pattern.type) {
+		case 'AssignmentPattern':
+			return (
+				mapCallbackPatternCapturesLexicalReceiver(pattern.left) ||
+				mapCallbackCapturesLexicalReceiver(pattern.right)
+			);
+		case 'ObjectPattern':
+			return (pattern.properties || []).some((property) => {
+				if (property.type === 'RestElement') {
+					return mapCallbackPatternCapturesLexicalReceiver(property.argument);
+				}
+				return (
+					(property.computed && mapCallbackCapturesLexicalReceiver(property.key)) ||
+					mapCallbackPatternCapturesLexicalReceiver(property.value || property.key)
+				);
+			});
+		case 'ArrayPattern':
+			return (pattern.elements || []).some(mapCallbackPatternCapturesLexicalReceiver);
+		case 'RestElement':
+			return mapCallbackPatternCapturesLexicalReceiver(pattern.argument);
+		default:
+			return false;
+	}
 }
 
 function mapCallbackCapturesLexicalReceiver(root) {

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -4018,24 +4018,41 @@ function isJsxReturningMapCall(node) {
 
 /**
  * Convert a `{xs.map((item[, index]) => <jsx key={K}>…)}` JSX child into a
- * synthetic `@for` (ForOfStatement) so it lowers to the SAME `forBlock` keyed
- * fast path as `@for` — a compiled per-item body + the raw items array — instead
- * of eagerly building a `createElement` descriptor per row on every render and
- * reconciling that array through `childSlot`/`reconcileKeyed`. The result flows
- * straight into the existing ForOfStatement fold path (makeForCall + items/body
- * holes), so the JSX `.map` and the directive `@for` produce identical output.
+ * guarded synthetic `@for` dispatched through the shared map slot so a genuine,
+ * dense native Array map lowers to the SAME keyed fast path as `@for`. Arbitrary `.map` methods are
+ * user code, not syntax: custom receivers, Array subclasses/overrides, sparse
+ * arrays, and additional call arguments must retain the original dispatch.
+ * Evaluate both receiver and method exactly once before choosing the branch.
  *
  * Returns null for shapes we don't lower — a named/ref callback, a block-body
  * arrow (`{ … return <jsx> }`), a fragment/non-element return, more than two
  * params, or a non-identifier index — so the caller keeps the childSlot path.
  */
-function mapCallToForOf(expr) {
+function mapCallToForOf(expr, ctx) {
 	if (!isJsxReturningMapCall(expr)) return null;
+	if (
+		!ctx?.currentMapTemps ||
+		expr.arguments.length !== 1 ||
+		expr.optional ||
+		expr.callee.optional ||
+		expr.callee.computed
+	) {
+		return null;
+	}
 	const arrow = expr.arguments[0];
 	const params = arrow.params || [];
 	// `(item)` and `(item, index)` map to a for-of header; the rarely-used
 	// `array`/thisArg params (or a destructured index) don't, so bail to childSlot.
-	if (params.length < 1 || params.length > 2) return null;
+	if (
+		arrow.async ||
+		params.length < 1 ||
+		params.length > 2 ||
+		params[0].type === 'AssignmentPattern' ||
+		params[0].type === 'RestElement' ||
+		mapCallbackCapturesLexicalReceiver(arrow.body)
+	) {
+		return null;
+	}
 	if (params[1] && params[1].type !== 'Identifier') return null;
 	// Only an EXPRESSION-body arrow returning a single JSX ELEMENT (host or
 	// component). Block bodies and fragment roots keep the childSlot path.
@@ -4059,11 +4076,54 @@ function mapCallToForOf(expr) {
 			? { ...body, openingElement: { ...body.openingElement, attributes: kept } }
 			: { ...body, attributes: kept };
 	}
-	return Object.assign(b.for_of(b.const(params[0], null), expr.callee.object, b.block([bodyEl])), {
-		key: keyExpr,
-		index: params[1] || null,
-		empty: null,
-	});
+	const directReceiver = expr.callee.object.type === 'Identifier';
+	const receiverName = directReceiver
+		? expr.callee.object.name
+		: allocCompilerName(ctx, '__mapItems');
+	const directFold = directReceiver && ctx._foldCtx != null;
+	const methodName = directFold ? null : allocCompilerName(ctx, '__mapMethod');
+	if (!directReceiver) ctx.currentMapTemps.push(receiverName);
+	if (methodName !== null) ctx.currentMapTemps.push(methodName);
+	// Synthetic branch helpers can move to module scope. Include their captures
+	// in the existing environment proof so the receiver/method remain available.
+	if (!directReceiver) ctx.currentComponentLocals?.add(receiverName);
+	if (methodName !== null) ctx.currentComponentLocals?.add(methodName);
+	const forNode = Object.assign(
+		b.for_of(b.const(params[0], null), b.id(receiverName), b.block([bodyEl])),
+		{
+			key: keyExpr,
+			index: params[1] || null,
+			empty: null,
+			nativeArrayMap: {
+				receiver: expr.callee.object,
+				receiverName,
+				methodName,
+				directReceiver,
+				callback: arrow,
+			},
+		},
+	);
+	return inheritOriginLoc(forNode, expr);
+}
+
+function mapCallbackCapturesLexicalReceiver(root) {
+	const seen = new WeakSet();
+	const walk = (node) => {
+		if (!node || typeof node !== 'object') return false;
+		if (Array.isArray(node)) return node.some(walk);
+		if (seen.has(node)) return false;
+		seen.add(node);
+		if (node.type === 'ThisExpression') return true;
+		if (node.type === 'Identifier' && node.name === 'arguments') return true;
+		if (node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression') return false;
+		if (node.type === 'MemberExpression' && !node.computed) return walk(node.object);
+		if (node.type === 'Property' && !node.computed) return walk(node.value);
+		for (const key in node) {
+			if (!AST_WALK_SKIP_KEYS.has(key) && walk(node[key])) return true;
+		}
+		return false;
+	};
+	return walk(root);
 }
 
 // Recognise `{style (expr)}` — TSRX parses it as a plain
@@ -5959,6 +6019,7 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 		capturedEvents: new Set(), // capture-phase event names (onXxxCapture) — auto-emits delegateCaptureEvents(...)
 		cssInjections: [], // { hash, css } — one entry per component with a <style> block
 		currentComponentLocals: null, // Set<string> while compiling a component body; null otherwise
+		currentMapTemps: null, // receiver/method temps owned by the current emitted function
 		currentAutoMemoOffset: 0, // flat compiler-cache cell offset for the body being emitted
 		currentAutoMemoCacheName: null, // collision-free local bound to the body's cache array
 		currentAutoMemoCommittedName: null, // committed cache snapshot (copy-on-write source)
@@ -6956,6 +7017,7 @@ function compileServer(source, filename, options, analyzedAst = null) {
 		cssInjections: [],
 		moduleCssInjections: [],
 		currentComponentLocals: null,
+		currentMapTemps: null,
 		knownStringLocals: null, // Set<string> of provably-string locals (text-hole inference)
 		nextHookSymId: 0,
 		nextFragId: 0,
@@ -7221,7 +7283,40 @@ function ssrCompileBody(
 	returnedFragmentTemplate = false,
 	returnedFragmentRoot = false,
 ) {
+	const prevMapTemps = ctx.currentMapTemps;
+	ctx.currentMapTemps = [];
+	try {
+		return ssrCompileBodyWithMapTemps(
+			node,
+			ctx,
+			name,
+			cssHash,
+			cssEntries,
+			parentNs,
+			localSetupSlots,
+			componentNs,
+			returnedFragmentTemplate,
+			returnedFragmentRoot,
+		);
+	} finally {
+		ctx.currentMapTemps = prevMapTemps;
+	}
+}
+
+function ssrCompileBodyWithMapTemps(
+	node,
+	ctx,
+	name,
+	cssHash,
+	cssEntries,
+	parentNs,
+	localSetupSlots,
+	componentNs,
+	returnedFragmentTemplate,
+	returnedFragmentRoot,
+) {
 	const returnedOutput = node.body?.type === 'JSXCodeBlock' && hasOwnValueReturn(node);
+	const mapTemps = ctx.currentMapTemps;
 
 	let statements;
 	let jsxNodes;
@@ -7318,7 +7413,7 @@ function ssrCompileBody(
 	// Partition hoisted `<title>`/`<meta>`/`<link>` out of the body (mirrors the
 	// client planJsx): they accumulate into render()'s `head` via `ssrHeadEl`, NOT
 	// the body HTML — so the body collapses to its single real root.
-	const normalized = normalizeChildren(jsxNodes, parentNs === 'svg');
+	const normalized = normalizeChildren(jsxNodes, parentNs === 'svg', ctx);
 	const headNodes = normalized.filter((n) => n.type === 'HeadHoist');
 	const bodyNodes = normalized.filter((n) => n.type !== 'HeadHoist');
 	// A `return <jsx>` body (a React-style `.tsx` component) is VALUE position: the
@@ -7386,6 +7481,9 @@ function ssrCompileBody(
 		}
 	}
 	// `ssrHeadEl(…)` side-effect statements (one per hoisted head element), like injectStyle.
+	if (mapTemps.length > 0) {
+		body.push(...mapTemps.map((temp) => inheritOriginLoc(b.let(temp), node)));
+	}
 	body.push(...emitHeadServer(headNodes, ctx), ...rewritten, ...inlinedSubs);
 	// PROPS-FIRST ABI (matches the client): `(…userParams, __s, __extra)`. A leading
 	// `__props` placeholder stands in when there are no user params, so a verbatim
@@ -8407,7 +8505,7 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash, compone
 	if (tag !== 'option') lit += '>'; // option: ssrOption assembles the tag (attrs-only here)
 	const normChildren =
 		authoredStaticScriptContent === undefined
-			? normalizeChildren(node.children || [], childNs === 'svg')
+			? normalizeChildren(node.children || [], childNs === 'svg', ctx)
 			: [];
 	const hasNestedChildren = hasAuthoredStaticScriptBody || normChildren.length > 0;
 	const effectiveChildrenPropSources = hasNestedChildren ? [] : childrenPropSources;
@@ -8937,6 +9035,7 @@ function ssrEmitActivity(node, ctx, name, inlinedSubs, parentNs, cssHash, compon
 function ssrEmitFor(node, ctx, name, inlinedSubs, parentNs, cssHash, componentNs) {
 	// rewriteHookCalls: key any `use(thenable)` in the @for iterable expression.
 	const itemsExpr = rewriteHookCalls(node.right, ctx, name);
+	const mapCall = node.nativeArrayMap || null;
 	const itemId = node.left.declarations[0].id; // Identifier or destructuring Pattern
 	const params = [itemId];
 	if (node.index) params.push(node.index);
@@ -9054,7 +9153,9 @@ function ssrEmitFor(node, ctx, name, inlinedSubs, parentNs, cssHash, componentNs
 		b.block([
 			b.const(
 				'__items',
-				b.call(b.member(b.id('Array'), 'from'), b.logical('??', itemsExpr, b.array([]))),
+				mapCall !== null
+					? itemsExpr
+					: b.call(b.member(b.id('Array'), 'from'), b.logical('??', itemsExpr, b.array([]))),
 			),
 			b.if(
 				b.binary('===', b.member(items, 'length'), b.literal(0)),
@@ -9071,7 +9172,34 @@ function ssrEmitFor(node, ctx, name, inlinedSubs, parentNs, cssHash, componentNs
 			b.return(ssrCall('ssrForBlock', [b.id('__html'), b.literal(true, 'true')], node)),
 		]),
 	);
-	return ssrCall('ssrControl', [b.literal(ssrControlKey('for', node)), render], node);
+	const fast = ssrCall('ssrControl', [b.literal(ssrControlKey('for', node)), render], node);
+	if (mapCall === null) return fast;
+	ctx.runtimeNeeded.add('mapSlot');
+	ctx.runtimeNeeded.add('ssrChild');
+	const receiver = b.id(mapCall.receiverName);
+	const method = b.id(mapCall.methodName);
+	const evaluated = b.sequence([
+		...(mapCall.directReceiver
+			? []
+			: [b.assignment('=', receiver, rewriteHookCalls(mapCall.receiver, ctx, name))]),
+		b.assignment('=', method, b.member(receiver, 'map')),
+		receiver,
+	]);
+	return inheritOriginLoc(
+		b.conditional(
+			b.call('_$mapSlot', evaluated, method),
+			fast,
+			ssrCall(
+				'ssrChild',
+				[
+					b.call('_$mapSlot', receiver, method, rewriteJsxValues(mapCall.callback, ctx)),
+					b.id('__s'),
+				],
+				node,
+			),
+		),
+		node,
+	);
 }
 
 function ssrEmitSwitch(node, ctx, name, inlinedSubs, parentNs, cssHash, componentNs) {
@@ -10006,6 +10134,9 @@ function compileComponent(node, ctx, options) {
  */
 function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null, options = null) {
 	const returnedOutput = options?.returnedOutput === true;
+	const prevMapTemps = ctx.currentMapTemps;
+	const mapTemps = [];
+	ctx.currentMapTemps = mapTemps;
 	const prevAutoMemoOffset = ctx.currentAutoMemoOffset;
 	const prevAutoMemoCacheName = ctx.currentAutoMemoCacheName;
 	const prevAutoMemoCommittedName = ctx.currentAutoMemoCommittedName;
@@ -10310,6 +10441,9 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 			),
 		);
 	}
+	if (mapTemps.length > 0) {
+		bodyStatements.push(...mapTemps.map((temp) => inheritOriginLoc(b.let(temp), node)));
+	}
 	bodyStatements.push(...rewrittenStatements);
 	// Inlined sub-helpers (children render fns, legacy-placement construct
 	// bodies, hoisted `<tsrx>` blocks) are function DECLARATION nodes embedded
@@ -10404,6 +10538,7 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 	ctx.currentHookMemoOffset = prevHookMemoOffset;
 	ctx.currentHookMemoCacheProperty = prevHookMemoCacheProperty;
 	ctx.currentHookMemoNames = prevHookMemoNames;
+	ctx.currentMapTemps = prevMapTemps;
 	// ONE FunctionDeclaration node — the caller prints it (once, with the full
 	// esrap map for top-level components) or embeds it in an enclosing body.
 	return inheritOriginLoc(
@@ -13062,34 +13197,60 @@ function compileReturnJsxFunction(node, ctx, options) {
 	// can hold a directive this body must fold. Publishing the fold here is what
 	// keeps that form compiling on the client; the server already reaches it through
 	// compileServerComponent, and without this the two emitters disagree.
+	// Returned JSX keeps its descriptor ABI, but the compiled fragment inside
+	// that descriptor still owns ordinary keyed-list render regions. Give those
+	// regions the same component-local purity/capture analysis as `@{}` bodies;
+	// otherwise JSX `.map()` always misses the existing PURE and autoMemo paths.
 	const prevValueDirectiveLowering = ctx._valueDirectiveLowering;
+	const prevLocals = ctx.currentComponentLocals;
+	const prevAutoMemoCallsitesSafe = ctx.currentAutoMemoCallsitesSafe;
+	const prevMapTemps = ctx.currentMapTemps;
+	const mapTemps = [];
 	ctx._valueDirectiveLowering = lowerBodyValueDirective;
-	const newStatements = (node.body.body || []).map((sourceStatement) => {
-		// A return-based component's undefined output is ambiguous with the compiled
-		// void-body signal at runtime. Preserve JSX roots for the specialized lowering
-		// below, but normalize every other owned return to an explicit empty value.
-		const s = normalizeOwnRenderableReturns(sourceStatement, true);
-		const prepared =
-			s.type === 'ReturnStatement' && s.argument && isJsxNode(s.argument)
-				? s
-				: lowerSetupValueDirectives(s, lowerBodyValueDirective);
-		// Same hook handling as the `@{}` path: base hooks take a trailing hook slot,
-		// custom hooks are wrapped in withSlot (unified across both component forms).
-		const h = rewriteHookCalls(prepared, ctx, name);
-		// The `return <jsx>` output → a compiled-fragment descriptor (reconcile path),
-		// not the host-string de-opt (rebuild). Other JSX in setup keeps value-lowering.
-		if (h.type === 'ReturnStatement' && h.argument && isJsxNode(h.argument)) {
-			return { ...h, argument: lowerReturnJsx(h.argument, ctx, compInlinedSubs, cssHash) };
-		}
-		return rewriteJsxValues(h, ctx);
-	});
-	ctx._valueDirectiveLowering = prevValueDirectiveLowering;
+	ctx.currentComponentLocals = collectComponentLocals(node);
+	ctx.currentAutoMemoCallsitesSafe = ctx.componentInfo.get(name)?.autoMemoCallsitesSafe !== false;
+	ctx.currentMapTemps = mapTemps;
+	let newStatements;
+	try {
+		newStatements = (node.body.body || []).map((sourceStatement) => {
+			// A return-based component's undefined output is ambiguous with the compiled
+			// void-body signal at runtime. Preserve JSX roots for the specialized lowering
+			// below, but normalize every other owned return to an explicit empty value.
+			const s = normalizeOwnRenderableReturns(sourceStatement, true);
+			const prepared =
+				s.type === 'ReturnStatement' && s.argument && isJsxNode(s.argument)
+					? s
+					: lowerSetupValueDirectives(s, lowerBodyValueDirective);
+			// Same hook handling as the `@{}` path: base hooks take a trailing hook slot,
+			// custom hooks are wrapped in withSlot (unified across both component forms).
+			const h = rewriteHookCalls(prepared, ctx, name);
+			// The `return <jsx>` output → a compiled-fragment descriptor (reconcile path),
+			// not the host-string de-opt (rebuild). Other JSX in setup keeps value-lowering.
+			if (h.type === 'ReturnStatement' && h.argument && isJsxNode(h.argument)) {
+				return { ...h, argument: lowerReturnJsx(h.argument, ctx, compInlinedSubs, cssHash) };
+			}
+			return rewriteJsxValues(h, ctx);
+		});
+	} finally {
+		ctx._valueDirectiveLowering = prevValueDirectiveLowering;
+		ctx.currentComponentLocals = prevLocals;
+		ctx.currentAutoMemoCallsitesSafe = prevAutoMemoCallsitesSafe;
+		ctx.currentMapTemps = prevMapTemps;
+	}
 	// The rebuilt function shell maps to the authored declaration. Hoisted
 	// helper fns (compInlinedSubs — filled by the statement mapping above) are
 	// function DECLARATION nodes embedded at the top of the body, matching the
 	// historical after-the-`{` splice.
 	const fn = inheritOriginLoc(
-		b.function_declaration(node.id, node.params, b.block([...compInlinedSubs, ...newStatements])),
+		b.function_declaration(
+			node.id,
+			node.params,
+			b.block([
+				...mapTemps.map((temp) => inheritOriginLoc(b.let(temp), node)),
+				...compInlinedSubs,
+				...newStatements,
+			]),
+		),
 		node,
 	);
 	// M2 AST emit: return the function declaration NODE plus any HMR-rebind /
@@ -13314,7 +13475,7 @@ function extractFragment(node, ctx, holeProps, parentNs = 'html') {
 	const fragChildren = ctx._foldCtx
 		? (node.children || []).map((child) =>
 				child && child.type === 'JSXExpressionContainer'
-					? mapCallToForOf(child.expression) || child
+					? mapCallToForOf(child.expression, ctx) || child
 					: child,
 			)
 		: node.children || [];
@@ -13466,11 +13627,44 @@ function extractFragment(node, ctx, holeProps, parentNs = 'html') {
 			// See the `@else` claim above — the same rewrite happens here.
 			registerClauseOrigin(ctx, forNode.emptyKeyword, [rec.emptyHelper]);
 			const itemsHole = `h${holeProps.length}`;
-			holeProps.push(objectProp(itemsHole, rewriteJsxValues(forNode.right, ctx)));
-			const bodyHole = `h${holeProps.length}`;
-			holeProps.push(objectProp(bodyHole, b.id(rec.bodyHelper)));
+			const mapCall = forNode.nativeArrayMap;
+			const itemsValue = mapCall
+				? mapCall.methodName === null
+					? b.id(mapCall.receiverName)
+					: b.sequence([
+							...(mapCall.directReceiver
+								? []
+								: [b.assignment('=', b.id(mapCall.receiverName), mapCall.receiver)]),
+							b.assignment(
+								'=',
+								b.id(mapCall.methodName),
+								b.member(b.id(mapCall.receiverName), 'map'),
+							),
+							b.id(mapCall.receiverName),
+						])
+				: forNode.right;
+			holeProps.push(objectProp(itemsHole, rewriteJsxValues(itemsValue, ctx)));
 			rec.itemsExpr = memberProps(itemsHole, forNode.right);
-			rec.bodyHelper = `props.${bodyHole}`;
+			if (!mapCall) {
+				const bodyHole = `h${holeProps.length}`;
+				holeProps.push(objectProp(bodyHole, b.id(rec.bodyHelper)));
+				rec.bodyHelper = `props.${bodyHole}`;
+			}
+			if (mapCall) {
+				const methodHole = `h${holeProps.length}`;
+				holeProps.push(
+					objectProp(
+						methodHole,
+						mapCall.methodName === null
+							? b.member(b.id(mapCall.receiverName), 'map')
+							: b.id(mapCall.methodName),
+					),
+				);
+				rec.mapMethodExpr = memberProps(methodHole, mapCall.callback);
+				const callbackHole = `h${holeProps.length}`;
+				holeProps.push(objectProp(callbackHole, rewriteJsxValues(mapCall.callback, ctx)));
+				rec.mapCallbackExpr = memberProps(callbackHole, mapCall.callback);
+			}
 			if (rec.emptyHelper && rec.emptyHelper !== 'null') {
 				const emptyHole = `h${holeProps.length}`;
 				holeProps.push(objectProp(emptyHole, b.id(rec.emptyHelper)));
@@ -13487,10 +13681,24 @@ function extractFragment(node, ctx, holeProps, parentNs = 'html') {
 				return expression;
 			};
 			if (rec.depNames.length) {
-				// Thread each dep value as its own hole so the reconciler's deps-equality
-				// check (and the Phase 2 env stamp — deps doubles as the helpers' env
-				// tuple) sees the component-scope values, not undefined renderer locals.
-				rec.depNames = rec.depNames.map(captureDependency);
+				if (
+					mapCall &&
+					rec.hasPerItemEventClosure &&
+					rec.autoMemoDeps === null &&
+					rec.depNames.length > 1
+				) {
+					// Event-bearing mapped rows cannot share the whole-list cache. Their
+					// helpers already receive one deps/env array, so capture that complete
+					// tuple as one fragment hole instead of forwarding each local separately.
+					const depHole = `h${holeProps.length}`;
+					holeProps.push(objectProp(depHole, b.array(rec.depNames.map((name) => b.id(name)))));
+					rec.packedDepsExpr = memberProps(depHole, forNode);
+				} else {
+					// Thread each dep value as its own hole so the reconciler's deps-equality
+					// check (and the Phase 2 env stamp — deps doubles as the helpers' env
+					// tuple) sees component-scope values, not undefined renderer locals.
+					rec.depNames = rec.depNames.map(captureDependency);
+				}
 			}
 			if (rec.autoMemoDeps !== null) {
 				// The whole-list cache guard is emitted inside the hoisted renderer too.
@@ -13796,7 +14004,7 @@ function prepareSetupValueDirective(directive, ctx, componentName) {
 		// the server does not mistake the code-block node for another setup value
 		// and recurse indefinitely. normalizeChildren also owns the durable error
 		// for setup-bearing child blocks, keeping client/server diagnostics aligned.
-		return inheritOriginLoc(b.jsx_fragment(normalizeChildren([opaque])), opaque);
+		return inheritOriginLoc(b.jsx_fragment(normalizeChildren([opaque], false, ctx)), opaque);
 	} finally {
 		ctx._puInlineLowering = prevPuInlineLowering;
 	}
@@ -14981,7 +15189,7 @@ function emitHeadServer(headNodes, ctx) {
 // `inSvg`: the children being normalized sit inside an SVG-namespace subtree.
 // SVG has its own `<title>` (the accessibility tooltip element) — it must stay
 // where it is, NOT hoist to document.head (React 19 makes the same exception).
-function normalizeChildren(nodes, inSvg = false) {
+function normalizeChildren(nodes, inSvg = false, ctx = null) {
 	const out = [];
 	if (!nodes) return out;
 	for (const n of nodes) {
@@ -15012,7 +15220,7 @@ function normalizeChildren(nodes, inSvg = false) {
 			// server stay in lockstep (required for hydration). The client .tsx
 			// host-fragment path does the same conversion in extractFragment (which
 			// hoists the items array as a hole before this runs).
-			const mapForNode = mapCallToForOf(n.expression);
+			const mapForNode = mapCallToForOf(n.expression, ctx);
 			if (mapForNode) {
 				out.push(mapForNode);
 				continue;
@@ -15056,10 +15264,10 @@ function normalizeChildren(nodes, inSvg = false) {
 					const refInner =
 						refVal && refVal.type === 'JSXExpressionContainer' ? refVal.expression : refVal;
 					out.push({ type: 'FragmentStart', refExpr: refInner });
-					out.push(...normalizeChildren(n.children || [], inSvg));
+					out.push(...normalizeChildren(n.children || [], inSvg, ctx));
 					out.push({ type: 'FragmentEnd' });
 				} else {
-					out.push(...normalizeChildren(n.children || [], inSvg));
+					out.push(...normalizeChildren(n.children || [], inSvg, ctx));
 				}
 				continue;
 			}
@@ -15121,7 +15329,7 @@ function normalizeChildren(nodes, inSvg = false) {
 			}
 			out.push(element);
 		} else if (n.type === 'Tsx' || n.type === 'Tsrx' || n.type === 'JSXFragment') {
-			out.push(...normalizeChildren(n.children || [], inSvg));
+			out.push(...normalizeChildren(n.children || [], inSvg, ctx));
 		} else if (n.type === 'JSXStyleElement') {
 			// Drop a `<style>` block at child position — its CSS gets registered
 			// via the @tsrx/core scoping pipeline (applyCssScoping / applyStyleMap);
@@ -15133,7 +15341,7 @@ function normalizeChildren(nodes, inSvg = false) {
 			// still template output, not setup JavaScript. Unwrap it before lowering
 			// so both client and server compilation route it through their construct
 			// emitters rather than asking esrap to print a TSRX-only expression.
-			out.push(...normalizeChildren([n.expression], inSvg));
+			out.push(...normalizeChildren([n.expression], inSvg, ctx));
 		} else if (n.type === 'JSXIfExpression') {
 			// `@if (cond) { ... } @else { ... }` — lower to the old IfStatement
 			// shape so the existing makeIfCall path picks it up. `consequent` and
@@ -15198,7 +15406,7 @@ function normalizeChildren(nodes, inSvg = false) {
 			if (body.length === 0 && render === null) continue;
 			if (body.length === 0 && render !== null) {
 				// Recurse — render is a single JSX node, treat as a sibling child.
-				out.push(...normalizeChildren([render], inSvg));
+				out.push(...normalizeChildren([render], inSvg, ctx));
 			} else {
 				throw new Error(
 					'`@{ … }` with setup statements is not supported at JSX child position. ' +
@@ -15616,7 +15824,7 @@ function planJsx(
 	// `null` outside dev → zero work, prod output byte-identical.
 	const _prevElemLocs = ctx._elemLocs;
 	ctx._elemLocs = ctx.dev ? new Map() : null;
-	const allNodes = normalizeChildren(jsxNodesRaw, parentNs === 'svg');
+	const allNodes = normalizeChildren(jsxNodesRaw, parentNs === 'svg', ctx);
 	// Partition hoisted `<title>`/`<meta>`/`<link>` out of the BODY-root set:
 	// `jsxNodes` (the body) drives single/multi-root + the template, while head
 	// elements are mounted out-of-band into document.head. Excluding them (like
@@ -16451,10 +16659,16 @@ function planJsx(
 				: null;
 	const pushAfterStmt = (id, org, node) => pushAfter(id, inheritOriginLoc(node, org));
 	for (const fc of forCalls) {
-		ctx.runtimeNeeded.add('forBlock');
+		const isMappedList = fc.mapMethodExpr !== null;
+		ctx.runtimeNeeded.add(isMappedList ? 'mapSlot' : 'forBlock');
 		const slotIndex = fc.slotIndex;
 		const org = fc.origin ?? planOrigin;
-		registerDirectiveOrigin(ctx, org, ['_$forBlock', fc.keyHelper, fc.bodyHelper, fc.emptyHelper]);
+		registerDirectiveOrigin(ctx, org, [
+			isMappedList ? '_$mapSlot' : '_$forBlock',
+			fc.keyHelper,
+			fc.bodyHelper,
+			fc.emptyHelper,
+		]);
 		registerClauseOrigin(ctx, fc.emptyKeyword, [fc.emptyHelper]);
 		// Control-flow-only bodies have no bag: the host is __block.parentNode directly.
 		const hostExpr = () => hostNodeFor(`_for$${fc.id}`);
@@ -16507,9 +16721,11 @@ function planJsx(
 				),
 			);
 		}
-		const tailArgs = [helperRefNode(fc.keyHelper), helperRefNode(fc.bodyHelper)];
+		const keyNode = fc.inlineKey || helperRefNode(fc.keyHelper);
+		const depsNode = fc.packedDepsExpr || b.array(fc.depNames.map(depNode));
+		const tailArgs = [keyNode, helperRefNode(fc.bodyHelper)];
 		if (flags || fc.singleRootExpr || hasDeps || hasEmpty || hasAnchor) tailArgs.push(flagsExpr);
-		if (hasDeps) tailArgs.push(b.array(fc.depNames.map(depNode)));
+		if (hasDeps) tailArgs.push(depsNode);
 		else if (hasEmpty || hasAnchor) tailArgs.push(undefinedNode());
 		// Anchor the `@empty` arm at its own keyword: every other token of the
 		// lowering maps to the `@for`, which would leave `@empty` unreachable.
@@ -16521,6 +16737,71 @@ function planJsx(
 		// list's trailing boundary. Let forBlock reuse it as its end marker instead
 		// of retaining it beside a newly-created `/for` comment.
 		if (fc.anchorVar) tailArgs.push(b.literal(true));
+		if (isMappedList) {
+			const nativeName = allocCompilerName(ctx, '__mapNative');
+			if (fc.autoMemoDeps !== null) {
+				const mappedCall = b.stmt(
+					b.call(
+						'_$mapSlot',
+						b.id('__s'),
+						b.literal(slotIndex),
+						hostExpr(),
+						b.id('_v'),
+						fc.mapMethodExpr,
+						b.id(nativeName),
+						fc.mapCallbackExpr,
+						keyNode,
+						helperRefNode(fc.bodyHelper),
+						flagsExpr,
+						hasDeps ? depsNode : undefinedNode(),
+						hasAnchor ? anchorExpr : nullNode(),
+						fc.anchorVar ? b.literal(1) : undefinedNode(),
+					),
+				);
+				const prefix = [
+					b.const('_v', fc.itemsExpr),
+					b.const(nativeName, b.call('_$mapSlot', b.id('_v'), fc.mapMethodExpr)),
+				];
+				const witnessMiss = fc.autoMemoWitnesses.length
+					? witnessMissChain(fc.autoMemoWitnesses)
+					: null;
+				const customMiss = b.unary('!', b.id(nativeName));
+				const forcedMiss = witnessMiss ? b.logical('||', customMiss, witnessMiss) : customMiss;
+				const guarded = emitAutoMemoRegion(
+					ctx,
+					['_v', ...fc.autoMemoDeps],
+					slotIndex,
+					mappedCall,
+					forcedMiss,
+					fc.autoMemoContextAware,
+					depNode,
+				);
+				pushAfterStmt(fc.id, org, b.block([...prefix, guarded]));
+			} else {
+				pushAfterStmt(
+					fc.id,
+					org,
+					b.stmt(
+						b.call(
+							'_$mapSlot',
+							b.id('__s'),
+							b.literal(slotIndex),
+							hostExpr(),
+							fc.itemsExpr,
+							fc.mapMethodExpr,
+							fc.mapCallbackExpr,
+							keyNode,
+							helperRefNode(fc.bodyHelper),
+							flagsExpr,
+							hasDeps ? depsNode : undefinedNode(),
+							hasAnchor ? anchorExpr : nullNode(),
+							fc.anchorVar ? b.literal(1) : undefinedNode(),
+						),
+					),
+				);
+			}
+			continue;
+		}
 		if (fc.autoMemoDeps !== null) {
 			const witnessMiss = fc.autoMemoWitnesses.length
 				? witnessMissChain(fc.autoMemoWitnesses)
@@ -19186,7 +19467,7 @@ function emitElementHtml(
 		appendTemplatePart(html, escapeInlineScriptContent(authoredStaticScriptContent), 'raw');
 	}
 
-	const children = normalizeChildren(sourceChildren, childNs === 'svg');
+	const children = normalizeChildren(sourceChildren, childNs === 'svg', ctx);
 	// Special case: a single Text child (only-child text fast path).
 	if (children.length === 1 && children[0].type === 'Text') {
 		const txtChild = children[0];
@@ -20655,7 +20936,20 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 	// the key arrow's own origin, then the module origin.
 	const keyHelper = `_key$${ctx.nextHelperId++}`;
 	const keyOrigin = node.loc ? node : keyFn.loc ? keyFn : ctx._moduleOrigin;
-	ctx.hoistedHelpers.push(inheritOriginLoc(b.const(keyHelper, keyFn), keyOrigin));
+	const keyBody = keyFn.body;
+	const inlineKey =
+		node.nativeArrayMap !== undefined &&
+		mapCallbackHasEventClosure(node.nativeArrayMap.callback) &&
+		!isDestructured &&
+		!node.index &&
+		keyBody?.type === 'MemberExpression' &&
+		keyBody.computed !== true &&
+		keyBody.object?.type === 'Identifier' &&
+		keyBody.object.name === itemName &&
+		keyBody.property?.name === 'id';
+	if (!inlineKey) {
+		ctx.hoistedHelpers.push(inheritOriginLoc(b.const(keyHelper, keyFn), keyOrigin));
+	}
 
 	// When the for-of header declared `index <name>`, expose it as a `const`
 	// at the top of the body — the runtime stamps `block.itemIndex` per item
@@ -20704,6 +20998,8 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 	let autoMemoDeps = null;
 	let autoMemoWitnesses = [];
 	let autoMemoContextAware = false;
+	const hasPerItemEventClosure =
+		node.nativeArrayMap !== undefined && mapCallbackHasEventClosure(node.nativeArrayMap.callback);
 	if (ctx.currentComponentLocals) {
 		const bodyScope = new Set([itemName]);
 		if (node.index) bodyScope.add(node.index.name);
@@ -20806,6 +21102,7 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 		}
 		let listSafe =
 			ctx.autoMemo === true &&
+			!hasPerItemEventClosure &&
 			isAutoMemoCalculationDependency(node.right) &&
 			!hasHook &&
 			!containsRenderCall(regionStmts, ctx) &&
@@ -20888,10 +21185,15 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 	const itemAllStmts = [...indexInjection, ...destructureInjection, ...subStmts];
 	// The synthetic item param maps to the authored for-of binding.
 	const itemParams = [b.id(itemName, leftDeclId)];
-	const envNames = unionEnv(ctx, [
+	let envNames = unionEnv(ctx, [
 		{ stmts: itemAllStmts, params: itemParams },
 		emptyStmts && { stmts: emptyStmts, params: [] },
 	]);
+	if (hasPerItemEventClosure && envNames !== null && envNames.length > 1) {
+		// The helper and its packed tuple share this internal ordering. Grouping
+		// event-row captures in the same order improves the compressed fragment.
+		envNames = [envNames[1], envNames[0], ...envNames.slice(2)];
+	}
 	// The helper destructures only component-local captures (`envNames`) from the
 	// tuple prefix. Compiler memoization may additionally need live imported
 	// bindings as dependency witnesses; append them without disturbing that ABI.
@@ -20980,13 +21282,36 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 		}
 	}
 
+	const mapCall = node.nativeArrayMap || null;
 	return {
 		id: ctx.nextHelperId++,
 		loc: devLoc(ctx, node),
 		origin: node,
-		itemsExpr: node.right, // the fold replaces this with a `props.hN` member read
+		itemsExpr: mapCall
+			? mapCall.methodName === null
+				? b.id(mapCall.receiverName)
+				: b.sequence([
+						...(mapCall.directReceiver
+							? []
+							: [b.assignment('=', b.id(mapCall.receiverName), mapCall.receiver)]),
+						b.assignment(
+							'=',
+							b.id(mapCall.methodName),
+							b.member(b.id(mapCall.receiverName), 'map'),
+						),
+						b.id(mapCall.receiverName),
+					])
+			: node.right, // the fold replaces this with a `props.hN` member read
+		mapMethodExpr: mapCall
+			? mapCall.methodName === null
+				? b.member(b.id(mapCall.receiverName), 'map')
+				: b.id(mapCall.methodName)
+			: null,
+		mapCallbackExpr: mapCall ? rewriteJsxValues(mapCall.callback, ctx) : null,
 		keyHelper,
+		inlineKey: inlineKey ? keyFn : null,
 		bodyHelper: itemHelperName,
+		hasPerItemEventClosure,
 		pure,
 		singleRoot,
 		singleRootExpr,
@@ -21017,6 +21342,35 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 		emptyKeyword: node.emptyKeyword ?? null,
 		hostPath: null,
 	};
+}
+
+function mapCallbackHasEventClosure(callback) {
+	const stack = [callback.body];
+	while (stack.length > 0) {
+		const node = stack.pop();
+		if (!node || typeof node !== 'object') continue;
+		if (Array.isArray(node)) {
+			stack.push(...node);
+			continue;
+		}
+		if (node.type === 'JSXAttribute' || node.type === 'Attribute') {
+			const name = node.name?.name || node.name;
+			const expression =
+				node.value?.type === 'JSXExpressionContainer' ? node.value.expression : node.value;
+			if (
+				typeof name === 'string' &&
+				/^on[A-Z]/.test(name) &&
+				(expression?.type === 'ArrowFunctionExpression' ||
+					expression?.type === 'FunctionExpression')
+			) {
+				return true;
+			}
+		}
+		for (const key in node) {
+			if (!AST_WALK_SKIP_KEYS.has(key)) stack.push(node[key]);
+		}
+	}
+	return false;
 }
 
 // ===========================================================================

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -14680,6 +14680,12 @@ function jsxElementToCreateElement(node, ctx, eagerRoot = false) {
 	}
 	const propsNode = inheritOriginLoc(b.object(properties), node);
 	const childrenNeedRenderScope = jsxValueChildrenNeedRenderScope(node);
+	const eagerProviderChildren =
+		eagerRoot &&
+		componentTag &&
+		childrenNeedRenderScope &&
+		(nameNode?.type === 'MemberExpression' || nameNode?.type === 'JSXMemberExpression') &&
+		nameNode.property?.name === 'Provider';
 	const loweredChildren = [];
 	// Children → trailing `createElement(type, props, ...children)` args, each
 	// lowered recursively (host child → createElement, `{expr}` → expr, text →
@@ -14697,10 +14703,14 @@ function jsxElementToCreateElement(node, ctx, eagerRoot = false) {
 		}
 	} else {
 		for (const child of node.children || []) {
-			const lowered = lowerJsxChild(
-				componentTag ? rewriteOpaqueTitles(child, ctx, 'opaque') : child,
-				ctx,
-			);
+			const authoredChild = componentTag ? rewriteOpaqueTitles(child, ctx, 'opaque') : child;
+			// The provider still defers its children; once its own readChildren
+			// callback runs, a direct JSX root already owns that provider scope.
+			const lowered =
+				eagerProviderChildren &&
+				(authoredChild?.type === 'Element' || authoredChild?.type === 'JSXElement')
+					? jsxElementToCreateElement(authoredChild, ctx, true)
+					: lowerJsxChild(authoredChild, ctx);
 			if (lowered !== null) loweredChildren.push(lowered);
 		}
 	}
@@ -15827,6 +15837,7 @@ function emitAutoMemoRegion(
 	extraMiss,
 	contextAware,
 	depNode,
+	initValue = null,
 ) {
 	const cell = allocAutoMemoCell(ctx, dependencies.length + (contextAware ? 1 : 0));
 	const contextIndex = contextAware ? cell.base + dependencies.length : null;
@@ -15864,7 +15875,8 @@ function emitAutoMemoRegion(
 			b.stmt(b.assignment('=', b.id(cache), b.call(b.member(b.id(cache), 'slice')))),
 			null,
 		);
-	const markInit = () => b.stmt(b.assignment('=', cacheAt(cell.init), b.literal(true)));
+	const markInit = () =>
+		b.stmt(b.assignment('=', cacheAt(cell.init), initValue ?? b.literal(true)));
 	// `statement` is the guarded region's statement NODE; the returned region is
 	// a statement node too — the caller stamps the origin.
 	if (!contextAware) {
@@ -16870,6 +16882,7 @@ function planJsx(
 					forcedMiss,
 					fc.autoMemoContextAware,
 					depNode,
+					b.id(nativeName),
 				);
 				pushAfterStmt(fc.id, org, b.block([...prefix, guarded]));
 			} else {

--- a/packages/octane/src/index.ts
+++ b/packages/octane/src/index.ts
@@ -179,6 +179,7 @@ export {
 	delegateEvents,
 	delegateCaptureEvents,
 	forBlock,
+	mapSlot,
 	ifBlock,
 	tryBlock,
 	switchBlock,

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -78,6 +78,30 @@ import {
 import { formatServerError } from './error-codes.server.generated.js';
 export { EXTERNAL_HYDRATION_PROMISE, HYDRATION_RANGE_BOUNDARY, normalizeClass };
 
+const NATIVE_ARRAY_MAP = Array.prototype.map;
+const NATIVE_REFLECT_APPLY = Reflect.apply;
+const NATIVE_ARRAY_SPECIES_GETTER = Object.getOwnPropertyDescriptor(Array, Symbol.species)?.get;
+
+/** Server twin of the compiler's guarded native-array map ABI. */
+export function mapSlot(receiver: any, method: any, callback?: (...args: any[]) => any): any {
+	if (arguments.length === 3) return NATIVE_REFLECT_APPLY(method, receiver, [callback]);
+	if (
+		!Array.isArray(receiver) ||
+		Object.getPrototypeOf(receiver) !== Array.prototype ||
+		method !== NATIVE_ARRAY_MAP ||
+		Object.prototype.hasOwnProperty.call(receiver, 'constructor') ||
+		Object.getOwnPropertyDescriptor(Array.prototype, 'constructor')?.value !== Array ||
+		Object.getOwnPropertyDescriptor(Array, Symbol.species)?.get !== NATIVE_ARRAY_SPECIES_GETTER
+	) {
+		return false;
+	}
+	for (let index = 0; index < receiver.length; index++) {
+		const descriptor = Object.getOwnPropertyDescriptor(receiver, index);
+		if (descriptor === undefined || descriptor.get !== undefined) return false;
+	}
+	return true;
+}
+
 interface SSRScope {
 	parent: SSRScope | null;
 	/** Context Provider values stamped on this scope (lazily allocated). */

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -84,7 +84,25 @@ const NATIVE_ARRAY_SPECIES_GETTER = Object.getOwnPropertyDescriptor(Array, Symbo
 
 /** Server twin of the compiler's guarded native-array map ABI. */
 export function mapSlot(receiver: any, method: any, callback?: (...args: any[]) => any): any {
-	if (arguments.length === 3) return NATIVE_REFLECT_APPLY(method, receiver, [callback]);
+	if (arguments.length === 3) {
+		let mapped = NATIVE_REFLECT_APPLY(method, receiver, [callback]);
+		if (Array.isArray(mapped)) {
+			let packed: any[] | null = null;
+			for (let index = 0; index < mapped.length; index++) {
+				if (!(index in mapped)) {
+					packed = [];
+					break;
+				}
+			}
+			if (packed !== null) {
+				for (let index = 0; index < mapped.length; index++) {
+					if (index in mapped) packed.push(mapped[index]);
+				}
+				mapped = packed;
+			}
+		}
+		return mapped;
+	}
 	if (
 		!Array.isArray(receiver) ||
 		Object.getPrototypeOf(receiver) !== Array.prototype ||

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -8540,6 +8540,13 @@ export function clone<T extends Node>(node: T, loc?: string): T {
 			(adopted as Element).localName === (expected as Element).localName &&
 			(adopted as Element).namespaceURI === (expected as Element).namespaceURI
 		) {
+			for (let child = adopted.firstChild; child !== null; child = child.nextSibling) {
+				detachDeoptTreeRefs(child, null);
+			}
+			(adopted as Element).replaceChildren();
+			for (let child = expected.firstChild; child !== null; child = child.nextSibling) {
+				adopted.appendChild(child.cloneNode(true));
+			}
 			return adopted as T;
 		}
 		const replacement = expected.cloneNode(true);
@@ -8680,13 +8687,6 @@ export function htext(el: Node, value: unknown): Text {
 	const text = coerceText(value);
 	const hydration = activeHydration();
 	if (hydration !== null) return hydration.htext(el, text);
-	if (MAPPED_ITEM_ADOPTION !== null) {
-		const existing = el.firstChild;
-		if (existing?.nodeType === 3 && existing.nextSibling === null) {
-			if (existing.nodeValue !== text) existing.nodeValue = text;
-			return existing as Text;
-		}
-	}
 	const t = document.createTextNode(text);
 	el.appendChild(t);
 	return t;
@@ -8710,10 +8710,6 @@ export function htextSwap(posNode: Node | null, value: unknown): Text {
 	const text = coerceText(value);
 	const hydration = activeHydration();
 	if (hydration !== null) return hydration.htextSwap(posNode, text);
-	if (MAPPED_ITEM_ADOPTION !== null && posNode?.nodeType === 3) {
-		if (posNode.nodeValue !== text) posNode.nodeValue = text;
-		return posNode as Text;
-	}
 	// Fresh mount: posNode is the `<!>` placeholder — replace it in place.
 	const t = document.createTextNode(text);
 	const parent = posNode!.parentNode!;

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -8521,7 +8521,18 @@ function parseSeedJson(raw: string): unknown[] | null {
 	}
 }
 
+// A mapped-list fallback owns its host through the descriptor reconciler. On
+// the first transition to the compiled item body, let that body's existing
+// clone() mount adopt the same host and initialize its ordinary binding bag.
+// Armed only around that one mapped survivor render; all other clones see null.
+let MAPPED_ITEM_ADOPTION: { node: Node | null } | null = null;
+
 export function clone<T extends Node>(node: T, loc?: string): T {
+	if (MAPPED_ITEM_ADOPTION !== null && MAPPED_ITEM_ADOPTION.node !== null) {
+		const adopted = MAPPED_ITEM_ADOPTION.node;
+		MAPPED_ITEM_ADOPTION.node = null;
+		return adopted as T;
+	}
 	// Compiler templates are inert module-scope tokens. Parse each concrete
 	// namespace on its first real mount, then clone the cached node thereafter.
 	// Non-compiler callers can still hand clone() an ordinary DOM Node directly.
@@ -8651,6 +8662,13 @@ export function htext(el: Node, value: unknown): Text {
 	const text = coerceText(value);
 	const hydration = activeHydration();
 	if (hydration !== null) return hydration.htext(el, text);
+	if (MAPPED_ITEM_ADOPTION !== null) {
+		const existing = el.firstChild;
+		if (existing?.nodeType === 3 && existing.nextSibling === null) {
+			if (existing.nodeValue !== text) existing.nodeValue = text;
+			return existing as Text;
+		}
+	}
 	const t = document.createTextNode(text);
 	el.appendChild(t);
 	return t;
@@ -8674,6 +8692,10 @@ export function htextSwap(posNode: Node | null, value: unknown): Text {
 	const text = coerceText(value);
 	const hydration = activeHydration();
 	if (hydration !== null) return hydration.htextSwap(posNode, text);
+	if (MAPPED_ITEM_ADOPTION !== null && posNode?.nodeType === 3) {
+		if (posNode.nodeValue !== text) posNode.nodeValue = text;
+		return posNode as Text;
+	}
 	// Fresh mount: posNode is the `<!>` placeholder — replace it in place.
 	const t = document.createTextNode(text);
 	const parent = posNode!.parentNode!;
@@ -13310,12 +13332,21 @@ export function createScopedElement<P>(
 	const children = (): unknown => {
 		const scope = CURRENT_SCOPE;
 		const epoch = COMPILER_CACHE_CONTEXT_EPOCH;
-		if (!resolved || resolvedScope !== scope || resolvedEpoch !== epoch) {
+		const sameScope =
+			resolvedScope === scope ||
+			(resolvedScope !== null && scope !== null && scope.block.parentBlock === resolvedScope.block);
+		if (!resolved || !sameScope || resolvedEpoch !== epoch) {
 			const nextChildren = readChildren();
 			resolvedScope = scope;
 			resolvedEpoch = epoch;
 			resolvedChildren = nextChildren;
 			resolved = true;
+		} else if (resolvedScope !== scope) {
+			// Host classification previews scoped children in the parent block before
+			// hostElementBody immediately renders them in its direct child block.
+			// Reuse that same-context preview once, then move ownership to the child
+			// so sibling/provider scopes cannot inherit another subtree's values.
+			resolvedScope = scope;
 		}
 		return resolvedChildren;
 	};
@@ -15573,7 +15604,11 @@ function deoptItemBody(item: any, scope: Scope): void {
 	}
 	// Switching Blocks → pure: unmount the childSlot content the Blocks path mounted
 	// (effect cleanups + DOM) by reconciling it to null. Idempotent once cleared.
-	if (scope.slots[0] !== undefined && scope.slots[0] !== null) {
+	if (
+		scope.slots[0] !== undefined &&
+		scope.slots[0] !== null &&
+		(scope.slots[0] as any).__kind === 'childSlot'
+	) {
 		childSlot(scope, 0, block.parentNode, null, block.endMarker);
 	}
 	// Pure host/text item → reconcile in place, REUSING the item's existing node so
@@ -15971,6 +16006,133 @@ function isPortalTarget(block: Block, domParent: Node): boolean {
 	return false;
 }
 
+const NATIVE_ARRAY_MAP = Array.prototype.map;
+const NATIVE_REFLECT_APPLY = Reflect.apply;
+const NATIVE_ARRAY_SPECIES_GETTER = Object.getOwnPropertyDescriptor(Array, Symbol.species)?.get;
+// Components hand the reconciler immutable array snapshots. Memoizing indexed
+// accessor classification by snapshot identity avoids a descriptor allocation
+// per row on every unchanged parent render; holes and intrinsic overrides are
+// still rechecked each time. Mutating an existing data index into an accessor
+// without changing the snapshot identity/length is outside that contract.
+const NATIVE_ARRAY_ACCESSORS = new WeakMap<object, { length: number; accessor: boolean }>();
+
+/** Shared compiler ABI: native-array eligibility query plus stable keyed map dispatch. */
+export function mapSlot(
+	scopeOrItems: any,
+	slotOrMethod: any,
+	domParent?: Node,
+	items?: any,
+	method?: any,
+	native?: boolean | ((...args: any[]) => any),
+	callback?: (...args: any[]) => any,
+	getKey?: (item: any, index: number) => any,
+	itemBody?: (item: any, scope: Scope) => void,
+	flags?: number,
+	deps?: any[],
+	anchor?: Node | null,
+	ownEnd?: boolean | 1,
+): boolean | void {
+	if (arguments.length === 2) {
+		const receiver = scopeOrItems;
+		if (
+			!Array.isArray(receiver) ||
+			Object.getPrototypeOf(receiver) !== Array.prototype ||
+			slotOrMethod !== NATIVE_ARRAY_MAP ||
+			Object.prototype.hasOwnProperty.call(receiver, 'constructor') ||
+			Object.getOwnPropertyDescriptor(Array.prototype, 'constructor')?.value !== Array ||
+			Object.getOwnPropertyDescriptor(Array, Symbol.species)?.get !== NATIVE_ARRAY_SPECIES_GETTER
+		) {
+			return false;
+		}
+		const length = receiver.length;
+		let accessor = NATIVE_ARRAY_ACCESSORS.get(receiver);
+		if (accessor === undefined || accessor.length !== length) {
+			let found = false;
+			for (let index = 0; index < length; index++) {
+				const descriptor = Object.getOwnPropertyDescriptor(receiver, index);
+				if (descriptor === undefined || descriptor.get !== undefined) {
+					found = true;
+					break;
+				}
+			}
+			accessor = { length, accessor: found };
+			NATIVE_ARRAY_ACCESSORS.set(receiver, accessor);
+		}
+		if (accessor.accessor) return false;
+		for (let index = 0; index < length; index++) {
+			if (!(index in receiver)) return false;
+		}
+		return true;
+	}
+	// Unmemoized mapped regions do not need the eligibility answer separately.
+	// Accept their compact one-call ABI and run the same guard exactly once.
+	if (typeof native === 'function') {
+		ownEnd = anchor as boolean | 1 | undefined;
+		anchor = deps as Node | null | undefined;
+		deps = flags as any[] | undefined;
+		flags = itemBody as unknown as number | undefined;
+		itemBody = getKey as unknown as (item: any, scope: Scope) => void;
+		getKey = callback as (item: any, index: number) => any;
+		callback = native;
+		native = mapSlot(items, method) as boolean;
+	}
+	if (ownEnd === 1) ownEnd = true;
+	if (native === true) {
+		childSlot(
+			scopeOrItems,
+			slotOrMethod,
+			domParent!,
+			items,
+			anchor,
+			ownEnd,
+			undefined,
+			false,
+			true,
+			itemBody,
+			getKey,
+			flags,
+			deps,
+		);
+	} else {
+		let mapped = NATIVE_REFLECT_APPLY(method, items, [callback]);
+		if (Array.isArray(mapped)) {
+			let packed: any[] | null = null;
+			for (let index = 0; index < mapped.length; index++) {
+				if (!(index in mapped)) {
+					packed = [];
+					break;
+				}
+			}
+			if (packed !== null) {
+				for (let index = 0; index < mapped.length; index++) {
+					if (index in mapped) packed.push(mapped[index]);
+				}
+				mapped = packed;
+			}
+		}
+		childSlot(
+			scopeOrItems,
+			slotOrMethod,
+			domParent!,
+			mapped,
+			anchor,
+			ownEnd,
+			undefined,
+			false,
+			true,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			true,
+		);
+		const state = (scopeOrItems as Scope).slots[slotOrMethod] as ChildSlot | undefined;
+		if (state?.forSlot !== null && state?.forSlot !== undefined) {
+			state.forSlot.mappedNative = false;
+		}
+	}
+}
+
 export function childSlot(
 	parentScope: Scope,
 	slotKey: number,
@@ -15994,6 +16156,11 @@ export function childSlot(
 	// nested child slot must render the descriptor directly rather than wrap it
 	// in another one-item list.
 	includeKeyedSingle: boolean = true,
+	compiledMapBody?: (item: any, scope: Scope) => void,
+	compiledMapKey?: (item: any, index: number) => any,
+	compiledMapFlags?: number,
+	compiledMapDeps?: any[],
+	mappedFallback?: boolean,
 ): void {
 	// Reading the host's tag costs two DOM accessors and this runs for every
 	// renderable hole on every render, so lead with the cheap facts. A de-opt list
@@ -16031,6 +16198,11 @@ export function childSlot(
 				ownsHost,
 				compactable,
 				includeKeyedSingle,
+				compiledMapBody,
+				compiledMapKey,
+				compiledMapFlags,
+				compiledMapDeps,
+				mappedFallback,
 			),
 		);
 		return;
@@ -16067,7 +16239,10 @@ export function childSlot(
 		)?.[HYDRATION_RANGE_BOUNDARY] !== 'owner';
 	const iterable = iterableChildArray(value);
 	if (iterable !== null) value = iterable;
-	const preparedList = prepareDeoptList(value, false, includeKeyedSingle);
+	const preparedList =
+		compiledMapBody !== undefined
+			? { items: value as any[], keys: null }
+			: prepareDeoptList(value, false, includeKeyedSingle);
 	// A LONE PURE-HOST descriptor (host/text-only subtree — no components, no
 	// portals, no render functions). Computed once per call: the slot init below
 	// uses it to pick the ANCHORLESS regime, the promotion after it to detect a
@@ -16117,6 +16292,11 @@ export function childSlot(
 				ownsHost,
 				compactable,
 				includeKeyedSingle,
+				compiledMapBody,
+				compiledMapKey,
+				compiledMapFlags,
+				compiledMapDeps,
+				mappedFallback,
 			);
 			return;
 		}
@@ -16316,16 +16496,139 @@ export function childSlot(
 			}
 		}
 		const { items, keys } = preparedList;
-		const getKey = (_item: any, i: number) => keys[i];
+		const markerlessMappedFallback =
+			mappedFallback === true && hydration !== null && !hydration.isOpen(hydration.node);
+		const getKey = compiledMapKey
+			? (item: any, index: number) => 'k' + String(compiledMapKey(item, index))
+			: (_item: any, i: number) => keys![i];
+		const wasMappedNative = state.forSlot.mappedNative === true;
+		let body = compiledMapBody || (deoptItemBody as any);
+		if (compiledMapBody === undefined && wasMappedNative && state.forSlot.size > 0) {
+			for (let index = 0; index < items.length; index++) {
+				const item = items[index];
+				if (!isHostDescriptor(item)) continue;
+				const block = state.forSlot.items.get(getKey(item, index));
+				if (
+					block !== undefined &&
+					block.startMarker !== null &&
+					block.startMarker === block.endMarker &&
+					block.startMarker.nodeType === 1 &&
+					(block.startMarker as Element).localName === item.type
+				) {
+					const root = block.startMarker as Element;
+					const text = root.firstChild;
+					if (text?.nodeType === 3 && text.nextSibling === null) {
+						const children = Object.getOwnPropertyDescriptor(item, 'children');
+						const primitive =
+							children !== undefined &&
+							'value' in children &&
+							(typeof children.value === 'string' ||
+								typeof children.value === 'number' ||
+								typeof children.value === 'bigint');
+						if (primitive) {
+							(text as any).$$deoptKey = 0;
+						} else if (children?.get !== undefined) {
+							// Scoped JSX descriptors defer children until their represented
+							// render scope. Prove this node came from the compiled binding bag
+							// without invoking that scope-sensitive accessor in the parent.
+							const bag = block.slots[0];
+							if (bag !== null && bag !== undefined) {
+								for (const field in bag) {
+									if (bag[field] === text) {
+										(text as any).$$deoptKey = 0;
+										break;
+									}
+								}
+							}
+						}
+					}
+					block.deoptNode = block.startMarker;
+				}
+			}
+		}
+		if (compiledMapBody !== undefined) {
+			if (state.forSlot.mappedNative === false) {
+				body = (item: any, scope: Scope, extra?: any[]): void => {
+					const adopted = scope.slots[0] === undefined ? scope.block.deoptNode : null;
+					if (adopted === null || adopted.nodeType !== 1) {
+						(compiledMapBody as any)(item, scope, extra);
+						return;
+					}
+					const previous = MAPPED_ITEM_ADOPTION;
+					const adoption = { node: adopted };
+					MAPPED_ITEM_ADOPTION = adoption;
+					try {
+						(compiledMapBody as any)(item, scope, extra);
+						if (adoption.node === null) scope.block.deoptNode = null;
+					} finally {
+						MAPPED_ITEM_ADOPTION = previous;
+					}
+				};
+			}
+			state.forSlot.mappedNative = true;
+		}
+		if (markerlessMappedFallback) {
+			const descriptorBody = body;
+			body = (item: any, scope: Scope): void => {
+				const root = scope.block.startMarker;
+				if (
+					root !== null &&
+					root === scope.block.endMarker &&
+					root.nodeType === 1 &&
+					scope.block.deoptNode === null
+				) {
+					scope.block.deoptNode = root;
+				}
+				descriptorBody(item, scope);
+			};
+		}
+		const fastFlags = compiledMapFlags || 0;
+		const ssrMarkerless =
+			compiledMapBody === undefined ? markerlessMappedFallback : (fastFlags & 16) !== 0;
+		let pure = (fastFlags & 1) !== 0;
+		let lite = false;
+		if (compiledMapBody !== undefined) {
+			state.forSlot.env = compiledMapDeps;
+			if ((fastFlags & 4) !== 0 && compiledMapDeps !== undefined) {
+				if (
+					state.forSlot.cachedDeps !== null &&
+					depsEqual(state.forSlot.cachedDeps, compiledMapDeps)
+				) {
+					pure = true;
+				} else {
+					lite = true;
+				}
+				state.forSlot.cachedDeps = compiledMapDeps;
+			}
+		}
 		// singleRoot=2 (marker-elision M4): pure single-element items self-mark —
 		// no `it` pair per item — resolved per item value in mountItem; shape
 		// flips promote to a minted pair in place (deoptItemBody).
 		// First fill dispatches to the linear pass directly (see mountItemsLinear)
 		// so a de-opt list's hydration adopt skips the full reconciler too.
 		if (state.forSlot.size === 0) {
-			mountItemsLinear(parentBlock, state.forSlot, items, getKey, deoptItemBody as any, 2, false);
+			mountItemsLinear(
+				parentBlock,
+				state.forSlot,
+				items,
+				getKey,
+				body,
+				compiledMapBody === undefined ? 2 : (fastFlags & 2) !== 0,
+				ssrMarkerless,
+			);
 		} else {
-			reconcileKeyed(parentBlock, state.forSlot, items, getKey, deoptItemBody as any, false, 2);
+			reconcileKeyed(
+				parentBlock,
+				state.forSlot,
+				items,
+				getKey,
+				body,
+				pure,
+				compiledMapBody === undefined ? 2 : (fastFlags & 2) !== 0,
+				lite,
+				(fastFlags & 8) !== 0,
+				ssrMarkerless,
+			);
 		}
 		// Upgrade adoption: nodes the empty→fill mount didn't consume (old
 		// children whose keys have no new item) are orphans inside the range —
@@ -20666,6 +20969,9 @@ interface ForSlot {
 	// focus, input state survive — React parity) instead of rebuilding.
 	// Consumed and nulled within the same render.
 	adopt: Array<{ key: any; node: Node }> | null;
+	// Present only on a childSlot owned by the compiler's guarded map ABI.
+	// Keeps descriptor↔compiled adoption off every ordinary descriptor list.
+	mappedNative?: boolean;
 }
 
 export function forBlock<T>(

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -8531,7 +8531,25 @@ export function clone<T extends Node>(node: T, loc?: string): T {
 	if (MAPPED_ITEM_ADOPTION !== null && MAPPED_ITEM_ADOPTION.node !== null) {
 		const adopted = MAPPED_ITEM_ADOPTION.node;
 		MAPPED_ITEM_ADOPTION.node = null;
-		return adopted as T;
+		const lazy =
+			(node as any).nodeType === undefined
+				? ((node as any)[LAZY_TEMPLATE] as LazyTemplateRecord | undefined)
+				: undefined;
+		const expected = lazy === undefined ? node : resolveLazyTemplate(lazy);
+		if (
+			(adopted as Element).localName === (expected as Element).localName &&
+			(adopted as Element).namespaceURI === (expected as Element).namespaceURI
+		) {
+			return adopted as T;
+		}
+		const replacement = expected.cloneNode(true);
+		const block = CURRENT_SCOPE!.block;
+		detachDeoptTreeRefs(adopted, null);
+		adopted.parentNode!.replaceChild(replacement, adopted);
+		if (block.startMarker === adopted) block.startMarker = replacement;
+		if (block.endMarker === adopted) block.endMarker = replacement;
+		block.deoptNode = null;
+		return replacement as T;
 	}
 	// Compiler templates are inert module-scope tokens. Parse each concrete
 	// namespace on its first real mount, then clone the cached node thereafter.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -15647,6 +15647,58 @@ function deoptItemBody(item: any, scope: Scope): void {
 	block.deoptNode = node;
 }
 
+// Guarded native maps invoke componentSlot directly from their compiled item
+// body. Keep that same slot ownership when a custom map returns the matching
+// component descriptors, so switching dispatch modes preserves the component
+// Block, its hooks/effects, and its DOM without aliasing it as a ChildSlot.
+function mappedDeoptItemBody(item: any, scope: Scope): void {
+	const state = scope.slots[0] as CompSlot | ChildSlot | undefined;
+	const block = scope.block;
+	if (isElementDescriptor(item) && typeof item.type === 'function') {
+		if (state === undefined || state.__kind === 'componentSlotSlot') {
+			const stale = block.deoptNode;
+			if (stale !== null) {
+				detachDeoptTreeRefs(stale, null);
+				if (stale.parentNode === block.parentNode) block.parentNode.removeChild(stale);
+				block.deoptNode = null;
+			}
+			componentSlot(
+				scope,
+				0,
+				block.parentNode,
+				item.type,
+				item.props,
+				block.endMarker,
+				undefined,
+				true,
+				true,
+			);
+			return;
+		}
+	} else if (state?.__kind === 'componentSlotSlot') {
+		// An exotic map may replace a keyed component with a host or empty value.
+		// Preserve the item's boundaries before disposing its self-marked child;
+		// the ordinary descriptor reconciler can then fill that same keyed range.
+		const root = block.startMarker;
+		if (
+			root !== null &&
+			root === block.endMarker &&
+			root.nodeType !== 8 &&
+			root.parentNode !== null
+		) {
+			const start = document.createComment('it');
+			const end = document.createComment('/it');
+			root.parentNode.insertBefore(start, root);
+			root.parentNode.insertBefore(end, root.nextSibling);
+			block.startMarker = start;
+			block.endMarker = end;
+		}
+		disposeReturnSlot(block, state);
+		block.deoptNode = null;
+	}
+	deoptItemBody(item, scope);
+}
+
 // True when `value` (a descriptor, an array, or a primitive) contains a COMPONENT
 // descriptor anywhere in its tree. Such a subtree can't be a raw host reconcile —
 // its components need reconcilable, unmountable Blocks — so the de-opt
@@ -16078,6 +16130,37 @@ export function mapSlot(
 	}
 	if (ownEnd === 1) ownEnd = true;
 	if (native === true) {
+		const previous = ((scopeOrItems as Scope).slots[slotOrMethod] as ChildSlot | undefined)
+			?.forSlot;
+		if (
+			previous?.mappedNative === false &&
+			previous.head !== null &&
+			(previous.head.slots[0] as CompSlot | undefined)?.__kind === 'componentSlotSlot'
+		) {
+			// A custom receiver may have reordered keyed component survivors. Its
+			// first native successor must still execute the authored map callback in
+			// ascending source order, before the reconciler walks the prior order.
+			const mapped = NATIVE_REFLECT_APPLY(method, items, [callback]);
+			childSlot(
+				scopeOrItems,
+				slotOrMethod,
+				domParent!,
+				mapped,
+				anchor,
+				ownEnd,
+				undefined,
+				false,
+				true,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				true,
+			);
+			const next = (scopeOrItems as Scope).slots[slotOrMethod] as ChildSlot;
+			if (next.forSlot !== null) next.forSlot.mappedNative = true;
+			return;
+		}
 		childSlot(
 			scopeOrItems,
 			slotOrMethod,
@@ -16502,7 +16585,8 @@ export function childSlot(
 			? (item: any, index: number) => 'k' + String(compiledMapKey(item, index))
 			: (_item: any, i: number) => keys![i];
 		const wasMappedNative = state.forSlot.mappedNative === true;
-		let body = compiledMapBody || (deoptItemBody as any);
+		let body =
+			compiledMapBody || (mappedFallback === true ? mappedDeoptItemBody : (deoptItemBody as any));
 		if (compiledMapBody === undefined && wasMappedNative && state.forSlot.size > 0) {
 			for (let index = 0; index < items.length; index++) {
 				const item = items[index];

--- a/packages/octane/src/server/index.ts
+++ b/packages/octane/src/server/index.ts
@@ -142,6 +142,7 @@ export {
 	ssrBlock,
 	ssrActivity,
 	ssrForBlock,
+	mapSlot,
 	ssrControl,
 	ssrArm,
 	ssrTry,

--- a/packages/octane/tests/_fixtures/tsx-auto-memo.tsx
+++ b/packages/octane/tests/_fixtures/tsx-auto-memo.tsx
@@ -1,0 +1,195 @@
+/** @jsxImportSource octane */
+
+import { useState } from 'octane';
+import { AutoMemoChild, AutoMemoContext } from './auto-memo-child.tsrx';
+
+type Row = { id: number; label: string };
+type MappableRows = {
+	map: <T>(callback: (item: Row, index: number) => T, thisArg?: unknown) => T[];
+};
+
+export function TsxCustomMapApp(props: {
+	rows: MappableRows;
+	prefix: string;
+	onItem: (id: number, index: number) => string;
+}) {
+	const rows = props.rows;
+
+	return (
+		<ul id="tsx-custom-map-rows">
+			{rows.map((item, index) => (
+				<li key={item.id} data-callback={props.onItem(item.id, index)}>
+					{`${props.prefix}:${index}:${item.label}`}
+				</li>
+			))}
+		</ul>
+	);
+}
+
+export function TsxBoundMapApp(props: {
+	rows: MappableRows;
+	receiver: { prefix: string };
+	onItem: (id: number, index: number) => string;
+}) {
+	return (
+		<ul id="tsx-bound-map-rows">
+			{props.rows.map(function (this: { prefix: string }, item, index) {
+				return (
+					<li key={item.id} data-callback={props.onItem(item.id, index)}>
+						{`${this.prefix}:${index}:${item.label}`}
+					</li>
+				);
+			}, props.receiver)}
+		</ul>
+	);
+}
+
+export function TsxGetterMapApp(props: {
+	source: { readonly rows: MappableRows };
+	prefix: string;
+	onItem: (id: number, index: number) => string;
+}) {
+	return (
+		<ul id="tsx-getter-map-rows">
+			{props.source.rows.map((item, index) => (
+				<li key={item.id} data-callback={props.onItem(item.id, index)}>
+					{`${props.prefix}:${index}:${item.label}`}
+				</li>
+			))}
+		</ul>
+	);
+}
+
+export function TsxMapExtraArgumentApp(props: {
+	rows: Row[];
+	prefix: string;
+	makeThisArg: () => unknown;
+	onItem: (id: number, index: number) => string;
+}) {
+	const rows = props.rows;
+
+	return (
+		<ul id="tsx-extra-map-rows">
+			{rows.map(
+				(item, index) => (
+					<li key={item.id} data-callback={props.onItem(item.id, index)}>
+						{`${props.prefix}:${index}:${item.label}`}
+					</li>
+				),
+				props.makeThisArg(),
+			)}
+		</ul>
+	);
+}
+
+export function TsxStatefulMappedApp(props: { rows: MappableRows; prefix: string; theme: string }) {
+	return (
+		<AutoMemoContext.Provider value={props.theme}>
+			<ul id="tsx-stateful-mapped-rows">
+				{props.rows.map((item, index) => (
+					<AutoMemoChild
+						key={item.id}
+						id={item.id}
+						label={`${props.prefix}:${index}:${item.label}`}
+					/>
+				))}
+			</ul>
+		</AutoMemoContext.Provider>
+	);
+}
+
+function TsxRows(props: { items: Row[]; prefix: string }) {
+	const items = props.items;
+	const prefix = props.prefix;
+
+	return (
+		<ul id="tsx-auto-rows">
+			{items.map((item, index) => (
+				<AutoMemoChild key={item.id} id={item.id} label={`${prefix}:${index}:${item.label}`} />
+			))}
+		</ul>
+	);
+}
+
+export function TsxAutoMemoApp() {
+	const [items, setItems] = useState<Row[]>([
+		{ id: 1, label: 'a' },
+		{ id: 2, label: 'b' },
+	]);
+	const [theme, setTheme] = useState('t0');
+	const [prefix, setPrefix] = useState('p0');
+	const [version, setVersion] = useState(0);
+
+	return (
+		<section>
+			<button id="tsx-auto-tick" onClick={() => setVersion((value) => value + 1)}>
+				{version}
+			</button>
+			<button id="tsx-auto-theme" onClick={() => setTheme((value) => value + '!')}>
+				context
+			</button>
+			<button id="tsx-auto-prefix" onClick={() => setPrefix((value) => value + '!')}>
+				prefix
+			</button>
+			<button
+				id="tsx-auto-item"
+				onClick={() =>
+					setItems((current) =>
+						current.map((item) => (item.id === 1 ? { ...item, label: item.label + '!' } : item)),
+					)
+				}
+			>
+				item
+			</button>
+			<button
+				id="tsx-auto-item-theme"
+				onClick={() => {
+					setItems((current) =>
+						current.map((item) => (item.id === 1 ? { ...item, label: item.label + '!' } : item)),
+					);
+					setTheme((value) => value + '!');
+				}}
+			>
+				item and context
+			</button>
+			<button id="tsx-auto-reorder" onClick={() => setItems((current) => current.toReversed())}>
+				reorder
+			</button>
+			<AutoMemoContext.Provider value={theme}>
+				<TsxRows items={items} prefix={prefix} />
+			</AutoMemoContext.Provider>
+		</section>
+	);
+}
+
+type LiveRow = { id: number; read: () => string };
+
+export function TsxImpureRowsApp() {
+	const [source] = useState({ value: 'v0' });
+	const [items] = useState<LiveRow[]>([
+		{ id: 1, read: () => 'first:' + source.value },
+		{ id: 2, read: () => 'second:' + source.value },
+	]);
+	const [version, setVersion] = useState(0);
+
+	return (
+		<section>
+			<button
+				id="tsx-impure-advance"
+				onClick={() => {
+					source.value = 'v' + (version + 1);
+					setVersion((value) => value + 1);
+				}}
+			>
+				advance
+			</button>
+			<ul id="tsx-impure-rows">
+				{items.map((item) => (
+					<li key={item.id} className="tsx-impure-row">
+						{item.read()}
+					</li>
+				))}
+			</ul>
+		</section>
+	);
+}

--- a/packages/octane/tests/_fixtures/tsx-auto-memo.tsx
+++ b/packages/octane/tests/_fixtures/tsx-auto-memo.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource octane */
 
-import { useState } from 'octane';
+import { useContext, useEffect, useState } from 'octane';
 import { AutoMemoChild, AutoMemoContext } from './auto-memo-child.tsrx';
 
 type Row = { id: number; label: string };
@@ -94,6 +94,61 @@ export function TsxStatefulMappedApp(props: { rows: MappableRows; prefix: string
 					/>
 				))}
 			</ul>
+		</AutoMemoContext.Provider>
+	);
+}
+
+type MappedComponentProps = {
+	rows: MappableRows;
+	prefix: string;
+	theme: string;
+	onEffect: (event: string) => void;
+	onItem: (id: number, index: number) => string;
+};
+
+function TsxTrackedMappedRow(props: {
+	id: number;
+	label: string;
+	onEffect: (event: string) => void;
+}) {
+	const theme = useContext(AutoMemoContext);
+	const [own, setOwn] = useState(0);
+
+	useEffect(() => {
+		props.onEffect(`mount:${props.id}`);
+		return () => props.onEffect(`cleanup:${props.id}`);
+	}, [props.id, props.onEffect]);
+
+	return (
+		<li data-id={props.id}>
+			<button className={`tracked-own-${props.id}`} onClick={() => setOwn(own + 1)}>
+				{`${theme}:${props.label}:${own}`}
+			</button>
+		</li>
+	);
+}
+
+function TsxMappedComponentRows(props: MappedComponentProps) {
+	const rows = props.rows;
+
+	return (
+		<ul id="tsx-mapped-component-rows">
+			{rows.map((item, index) => (
+				<TsxTrackedMappedRow
+					key={item.id}
+					id={item.id}
+					label={`${props.prefix}:${props.onItem(item.id, index)}:${item.label}`}
+					onEffect={props.onEffect}
+				/>
+			))}
+		</ul>
+	);
+}
+
+export function TsxMappedComponentApp(props: MappedComponentProps) {
+	return (
+		<AutoMemoContext.Provider value={props.theme}>
+			<TsxMappedComponentRows {...props} />
 		</AutoMemoContext.Provider>
 	);
 }

--- a/packages/octane/tests/auto-memo.test.ts
+++ b/packages/octane/tests/auto-memo.test.ts
@@ -268,6 +268,84 @@ describe('compiler-owned component-region memoization', () => {
 		root.unmount();
 	});
 
+	it('replaces incompatible keyed host rows when a custom map switches to native rendering', () => {
+		const source = `
+			function TaggedMapApp(props) {
+				const rows = props.rows;
+				return (
+					<ul id="tsx-tagged-map-rows">
+						{rows.map((item, index) => (
+							<li
+								key={item.id}
+								data-native={props.onItem(item.id, index)}
+								onClick={() => props.onClick(item.id)}
+							>
+								{props.prefix + ':' + index + ':' + item.label}
+							</li>
+						))}
+					</ul>
+				);
+			}
+			export const App = TaggedMapApp;
+		`;
+		const client = loadCompiledFixtureSource(source, {
+			id: 'tsx-tagged-map-transition.tsx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: false },
+		});
+		const items = [
+			{ id: 1, label: 'first' },
+			{ id: 2, label: 'second' },
+		];
+		const events: string[] = [];
+		const customRows = {
+			map<T>(callback: (item: (typeof items)[number], index: number) => T): T[] {
+				if (this !== customRows) throw new Error('tagged map lost its receiver');
+				events.push('custom:start');
+				callback(items[0]!, 7);
+				const compatible = callback(items[1]!, 3);
+				events.push('custom:end');
+				return [
+					createElement(
+						'span',
+						{
+							key: 1,
+							'data-custom': 'wrong-tag',
+							onClick: () => events.push('custom:click'),
+						},
+						'custom:first',
+					) as T,
+					compatible,
+				];
+			},
+		};
+		const onItem = (id: number, index: number): string => {
+			events.push(`callback:${id}:${index}`);
+			return `${id}:${index}`;
+		};
+		const onClick = (id: number) => events.push(`native:click:${id}`);
+		const root = mount(client.App, { rows: customRows, prefix: 'custom', onItem, onClick });
+		expect(events).toEqual(['custom:start', 'callback:1:7', 'callback:2:3', 'custom:end']);
+		const originalRows = root.findAll('#tsx-tagged-map-rows > *');
+		expect(originalRows.map((row) => row.tagName)).toEqual(['SPAN', 'LI']);
+		expect(originalRows.map((row) => row.textContent)).toEqual(['custom:first', 'custom:3:second']);
+		root.click('[data-custom="wrong-tag"]');
+		expect(events.at(-1)).toBe('custom:click');
+
+		events.length = 0;
+		root.update(client.App, { rows: items, prefix: 'native', onItem, onClick });
+		expect(events).toEqual(['callback:1:0', 'callback:2:1']);
+		const nativeRows = root.findAll('#tsx-tagged-map-rows > *');
+		expect(nativeRows.map((row) => row.tagName)).toEqual(['LI', 'LI']);
+		expect(nativeRows[0]).not.toBe(originalRows[0]);
+		expect(nativeRows[1]).toBe(originalRows[1]);
+		expect(nativeRows.map((row) => row.getAttribute('data-native'))).toEqual(['1:0', '2:1']);
+		expect(nativeRows.map((row) => row.textContent)).toEqual(['native:0:first', 'native:1:second']);
+		root.click('[data-native="1:0"]');
+		expect(events.at(-1)).toBe('native:click:1');
+		root.unmount();
+	});
+
 	it('preserves child state, context, and callback indices while map receivers change', () => {
 		const items = [
 			{ id: 1, label: 'first' },

--- a/packages/octane/tests/auto-memo.test.ts
+++ b/packages/octane/tests/auto-memo.test.ts
@@ -932,6 +932,74 @@ describe('compiler-owned component-region memoization', () => {
 		root.unmount();
 	});
 
+	it('restores native mapped order when a stable array loses its own map override', () => {
+		const source = `
+			function StableMapReceiverApp(props) {
+				const rows = props.rows;
+				return (
+					<ul id="tsx-stable-map-receiver">
+						{rows.map((item) => <li key={item.id}>{item.label}</li>)}
+					</ul>
+				);
+			}
+			export const App = StableMapReceiverApp;
+		`;
+		const client = loadCompiledFixtureSource(source, {
+			id: 'tsx-stable-map-receiver.tsx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: false },
+		});
+		const rows = [
+			{ id: 1, label: 'first' },
+			{ id: 2, label: 'second' },
+		];
+		const props = { rows };
+		const events: string[] = [];
+		const root = mount(client.App, props);
+		const originalRows = root.findAll('#tsx-stable-map-receiver li');
+		expect(originalRows.map((row) => row.textContent)).toEqual(['first', 'second']);
+
+		try {
+			Object.defineProperty(rows, 'map', {
+				configurable: true,
+				value<T>(
+					this: typeof rows,
+					callback: (item: (typeof rows)[number], index: number, array: typeof rows) => T,
+					thisArg?: unknown,
+				): T[] {
+					if (this !== rows) throw new Error('stable map lost its receiver');
+					events.push('custom:start');
+					events.push('callback:2:1');
+					const second = callback.call(thisArg, rows[1]!, 1, rows);
+					events.push('callback:1:0');
+					const first = callback.call(thisArg, rows[0]!, 0, rows);
+					events.push('custom:end');
+					return [second, first];
+				},
+			});
+
+			root.update(client.App, props);
+			expect(events).toEqual(['custom:start', 'callback:2:1', 'callback:1:0', 'custom:end']);
+			expect(root.findAll('#tsx-stable-map-receiver li')).toEqual([
+				originalRows[1],
+				originalRows[0],
+			]);
+
+			events.length = 0;
+			delete (rows as { map?: unknown }).map;
+			root.update(client.App, props);
+			expect(events).toEqual([]);
+			expect(root.findAll('#tsx-stable-map-receiver li')).toEqual(originalRows);
+			expect(root.findAll('#tsx-stable-map-receiver li').map((row) => row.textContent)).toEqual([
+				'first',
+				'second',
+			]);
+		} finally {
+			delete (rows as { map?: unknown }).map;
+			root.unmount();
+		}
+	});
+
 	it('honors an Array.prototype.map replacement installed after the component module loads', () => {
 		const events: string[] = [];
 		const rows = [

--- a/packages/octane/tests/auto-memo.test.ts
+++ b/packages/octane/tests/auto-memo.test.ts
@@ -701,6 +701,86 @@ describe('compiler-owned component-region memoization', () => {
 		container.remove();
 	});
 
+	it.each(['native', 'custom', 'inherited'] as const)(
+		'hydrates packed rows from a %s sparse map without replacing server-rendered nodes',
+		(receiver) => {
+			const { server, client } = loadMappedHydrationComponents();
+			const items = [
+				{ id: 1, label: 'first' },
+				{ id: 2, label: 'second' },
+				{ id: 3, label: 'third' },
+			];
+			const events: string[] = [];
+			let rows: unknown;
+			let expectedEvents: string[];
+			let expectedText: string[];
+
+			if (receiver === 'native') {
+				const sparse: (typeof items)[number][] = [];
+				sparse[1] = items[0]!;
+				sparse[3] = items[1]!;
+				rows = sparse;
+				expectedEvents = ['callback:1:1', 'callback:2:3'];
+				expectedText = ['hydrated:1:first', 'hydrated:3:second'];
+			} else if (receiver === 'custom') {
+				const customRows = {
+					map<T>(callback: (item: (typeof items)[number], index: number) => T): T[] {
+						if (this !== customRows) throw new Error('sparse map lost its receiver');
+						events.push('custom:start');
+						const sparse: T[] = [];
+						sparse[1] = callback(items[1]!, 7);
+						sparse[3] = callback(items[0]!, 3);
+						events.push('custom:end');
+						return sparse;
+					},
+				};
+				rows = customRows;
+				expectedEvents = ['custom:start', 'callback:2:7', 'callback:1:3', 'custom:end'];
+				expectedText = ['hydrated:7:second', 'hydrated:3:first'];
+			} else {
+				const inherited = Object.create(Array.prototype) as object;
+				Object.defineProperty(inherited, '1', {
+					configurable: true,
+					get() {
+						events.push('get:inherited');
+						return items[1]!;
+					},
+				});
+				const sparse: (typeof items)[number][] = [];
+				sparse[0] = items[0]!;
+				sparse[3] = items[2]!;
+				Object.setPrototypeOf(sparse, inherited);
+				rows = sparse;
+				expectedEvents = ['callback:1:0', 'get:inherited', 'callback:2:1', 'callback:3:3'];
+				expectedText = ['hydrated:0:first', 'hydrated:1:second', 'hydrated:3:third'];
+			}
+
+			const onItem = (itemId: number, index: number): string => {
+				events.push(`callback:${itemId}:${index}`);
+				return `${itemId}:${index}`;
+			};
+			const props = { rows, prefix: 'hydrated', onItem };
+			const { html } = ServerRuntime.renderToString(server.App, props);
+			expect(events).toEqual(expectedEvents);
+
+			const container = document.createElement('div');
+			document.body.appendChild(container);
+			container.innerHTML = html;
+			const list = container.querySelector('ul')!;
+			const originalRows = Array.from(list.querySelectorAll('li'));
+			expect(originalRows.map((row) => row.textContent)).toEqual(expectedText);
+
+			events.length = 0;
+			const root = hydrateRoot(container, client.App as any, props);
+			flushSync(() => {});
+			expect(events).toEqual(expectedEvents);
+			expect(Array.from(list.querySelectorAll('li'))).toEqual(originalRows);
+			expect(originalRows.map((row) => row.textContent)).toEqual(expectedText);
+			root.unmount();
+			container.remove();
+		},
+	);
+
 	it('serializes native mapped host rows without per-item hydration comments', () => {
 		const { server } = loadMappedHydrationComponents();
 		const rows = [

--- a/packages/octane/tests/auto-memo.test.ts
+++ b/packages/octane/tests/auto-memo.test.ts
@@ -1,8 +1,20 @@
 import { describe, expect, it } from 'vitest';
+import * as ServerRuntime from 'octane/server';
 import { compile } from '../src/compiler/compile.js';
+import { flushSync, hydrateRoot } from '../src/index.js';
 import { mount } from './_helpers';
+import { loadCompiledFixtureSource } from './_server-fixture.js';
 import { AutoMemoApp } from './_fixtures/auto-memo.tsrx';
 import { ParentCaptureApp } from './_fixtures/auto-memo-parent-capture.tsrx';
+import {
+	TsxAutoMemoApp,
+	TsxBoundMapApp,
+	TsxCustomMapApp,
+	TsxGetterMapApp,
+	TsxImpureRowsApp,
+	TsxMapExtraArgumentApp,
+	TsxStatefulMappedApp,
+} from './_fixtures/tsx-auto-memo.tsx';
 
 function trailingVersion(text: string | null): number {
 	return Number(text?.match(/(\d+)$/)?.[1]);
@@ -26,6 +38,37 @@ function expectCompilerRegion(code: string): void {
 function expectNoCompilerRegion(code: string): void {
 	expect(code).not.toContain('__memoCommitted');
 	expect(code).not.toContain('compilerCacheContext');
+}
+
+function loadMappedHydrationComponents() {
+	const source = `
+		function AppImpl(props) {
+			const rows = props.rows;
+			return (
+				<ul id="tsx-custom-map-hydration">
+					{rows.map((item, index) => (
+						<li key={item.id} data-callback={props.onItem(item.id, index)}>
+							{props.prefix + ':' + index + ':' + item.label}
+						</li>
+					))}
+				</ul>
+			);
+		}
+		export const App = AppImpl;
+	`;
+	const id = 'tsx-custom-map-hydration.tsx';
+	return {
+		server: loadCompiledFixtureSource(source, {
+			id,
+			mode: 'server',
+			compileOptions: { hmr: false, dev: false },
+		}),
+		client: loadCompiledFixtureSource(source, {
+			id,
+			mode: 'client',
+			compileOptions: { hmr: false, dev: false },
+		}),
+	};
 }
 
 describe('compiler-owned component-region memoization', () => {
@@ -79,6 +122,1053 @@ describe('compiler-owned component-region memoization', () => {
 		root.click('#capture-item');
 		expect(cells()).toEqual(['ax!!', 'b!!']);
 
+		root.unmount();
+	});
+
+	it('preserves keyed rows while switching between native, custom, and subclass map receivers', () => {
+		const events: string[] = [];
+		const items = [
+			{ id: 1, label: 'first' },
+			{ id: 2, label: 'second' },
+		];
+		const customRows = {
+			map<T>(callback: (item: (typeof items)[number], index: number) => T): T[] {
+				if (this !== customRows) throw new Error('custom map lost its receiver');
+				events.push('custom:start');
+				const mapped = [callback(items[1]!, 6), callback(items[0]!, 3)];
+				const descriptor = mapped[0] as {
+					type: unknown;
+					key: unknown;
+					props: { 'data-callback': unknown };
+				};
+				events.push(
+					`custom:descriptor:${String(descriptor.type)}:${String(descriptor.key)}:${String(
+						descriptor.props['data-callback'],
+					)}`,
+				);
+				events.push('custom:end');
+				return mapped;
+			},
+		};
+
+		class SubclassRows extends Array<(typeof items)[number]> {
+			override map<T>(
+				callback: (
+					item: (typeof items)[number],
+					index: number,
+					array: (typeof items)[number][],
+				) => T,
+				thisArg?: unknown,
+			): T[] {
+				if (this !== subclassRows) throw new Error('subclass map lost its receiver');
+				events.push('subclass:start');
+				const mapped = [
+					callback.call(thisArg, this[0]!, 8, this),
+					callback.call(thisArg, this[1]!, 4, this),
+				];
+				events.push('subclass:end');
+				return mapped;
+			}
+		}
+
+		const subclassRows = new SubclassRows(items[0]!, items[1]!);
+		const onItem = (id: number, index: number): string => {
+			events.push(`callback:${id}:${index}`);
+			return `${id}:${index}`;
+		};
+		const root = mount(TsxCustomMapApp, { rows: items, prefix: 'native', onItem });
+		const originalRows = root.findAll('#tsx-custom-map-rows li');
+		expect(events).toEqual(['callback:1:0', 'callback:2:1']);
+
+		events.length = 0;
+		root.update(TsxCustomMapApp, { rows: customRows, prefix: 'custom', onItem });
+		expect(events).toEqual([
+			'custom:start',
+			'callback:2:6',
+			'callback:1:3',
+			'custom:descriptor:li:2:2:6',
+			'custom:end',
+		]);
+		expect(root.findAll('#tsx-custom-map-rows li')).toEqual([originalRows[1], originalRows[0]]);
+		expect(root.findAll('#tsx-custom-map-rows li').map((row) => row.textContent)).toEqual([
+			'custom:6:second',
+			'custom:3:first',
+		]);
+
+		events.length = 0;
+		root.update(TsxCustomMapApp, { rows: subclassRows, prefix: 'subclass', onItem });
+		expect(events).toEqual(['subclass:start', 'callback:1:8', 'callback:2:4', 'subclass:end']);
+		expect(root.findAll('#tsx-custom-map-rows li')).toEqual(originalRows);
+		expect(root.findAll('#tsx-custom-map-rows li').map((row) => row.textContent)).toEqual([
+			'subclass:8:first',
+			'subclass:4:second',
+		]);
+
+		events.length = 0;
+		root.update(TsxCustomMapApp, { rows: items, prefix: 'native again', onItem });
+		expect(events).toEqual(['callback:1:0', 'callback:2:1']);
+		expect(root.findAll('#tsx-custom-map-rows li')).toEqual(originalRows);
+		expect(root.findAll('#tsx-custom-map-rows li').map((row) => row.textContent)).toEqual([
+			'native again:0:first',
+			'native again:1:second',
+		]);
+		root.unmount();
+	});
+
+	it('preserves child state, context, and callback indices while map receivers change', () => {
+		const items = [
+			{ id: 1, label: 'first' },
+			{ id: 2, label: 'second' },
+		];
+		const customRows = {
+			map<T>(callback: (item: (typeof items)[number], index: number) => T): T[] {
+				return [callback(items[1]!, 7), callback(items[0]!, 3)];
+			},
+		};
+		const root = mount(TsxStatefulMappedApp, {
+			rows: items,
+			prefix: 'native',
+			theme: 't0',
+		});
+		const first = root.find('.own-1');
+		const second = root.find('.own-2');
+		root.click('.own-1');
+		expect(first.textContent).toBe('t0:native:0:first:1');
+
+		root.update(TsxStatefulMappedApp, {
+			rows: customRows,
+			prefix: 'custom',
+			theme: 't1',
+		});
+		expect(root.findAll('#tsx-stateful-mapped-rows button')).toEqual([second, first]);
+		expect(first.textContent).toBe('t1:custom:3:first:1');
+		expect(second.textContent).toBe('t1:custom:7:second:0');
+
+		root.update(TsxStatefulMappedApp, {
+			rows: items,
+			prefix: 'native again',
+			theme: 't2',
+		});
+		expect(root.findAll('#tsx-stateful-mapped-rows button')).toEqual([first, second]);
+		expect(first.textContent).toBe('t2:native again:0:first:1');
+		expect(second.textContent).toBe('t2:native again:1:second:0');
+		root.unmount();
+	});
+
+	it('preserves keyed survivors and callback indices across dense and sparse array transitions', () => {
+		const events: string[] = [];
+		const denseRows = [
+			{ id: 1, label: 'first' },
+			{ id: 2, label: 'second' },
+		];
+		const sparseRows: typeof denseRows = [];
+		sparseRows[1] = denseRows[0]!;
+		sparseRows[3] = denseRows[1]!;
+		const onItem = (id: number, index: number): string => {
+			events.push(`callback:${id}:${index}`);
+			return `${id}:${index}`;
+		};
+		const root = mount(TsxCustomMapApp, { rows: denseRows, prefix: 'dense', onItem });
+		const originalRows = root.findAll('#tsx-custom-map-rows li');
+		expect(events).toEqual(['callback:1:0', 'callback:2:1']);
+
+		events.length = 0;
+		root.update(TsxCustomMapApp, { rows: sparseRows, prefix: 'sparse', onItem });
+		expect(events).toEqual(['callback:1:1', 'callback:2:3']);
+		expect(root.findAll('#tsx-custom-map-rows li')).toEqual(originalRows);
+		expect(root.findAll('#tsx-custom-map-rows li').map((row) => row.textContent)).toEqual([
+			'sparse:1:first',
+			'sparse:3:second',
+		]);
+
+		events.length = 0;
+		root.update(TsxCustomMapApp, { rows: denseRows, prefix: 'dense again', onItem });
+		expect(events).toEqual(['callback:1:0', 'callback:2:1']);
+		expect(root.findAll('#tsx-custom-map-rows li')).toEqual(originalRows);
+		expect(root.findAll('#tsx-custom-map-rows li').map((row) => row.textContent)).toEqual([
+			'dense again:0:first',
+			'dense again:1:second',
+		]);
+		root.unmount();
+	});
+
+	it('adopts server-rendered custom map output without changing receiver or callback semantics', () => {
+		const { server, client } = loadMappedHydrationComponents();
+		const events: string[] = [];
+		const rows = {
+			map<T>(callback: (item: { id: number; label: string }, index: number) => T): T[] {
+				if (this !== rows) throw new Error('hydration map lost its receiver');
+				events.push('map:start');
+				const output = [
+					callback({ id: 2, label: 'second' }, 6),
+					callback({ id: 1, label: 'first' }, 2),
+				];
+				events.push('map:end');
+				return output;
+			},
+		};
+		const onItem = (itemId: number, index: number): string => {
+			events.push(`callback:${itemId}:${index}`);
+			return `${itemId}:${index}`;
+		};
+		const props = { rows, prefix: 'hydrated', onItem };
+		const { html } = ServerRuntime.renderToString(server.App, props);
+		expect(events).toEqual(['map:start', 'callback:2:6', 'callback:1:2', 'map:end']);
+
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		container.innerHTML = html;
+		const originalRows = Array.from(container.querySelectorAll('li'));
+		expect(originalRows.map((row) => row.textContent)).toEqual([
+			'hydrated:6:second',
+			'hydrated:2:first',
+		]);
+
+		events.length = 0;
+		const root = hydrateRoot(container, client.App as any, props);
+		flushSync(() => {});
+		expect(events).toEqual(['map:start', 'callback:2:6', 'callback:1:2', 'map:end']);
+		expect(Array.from(container.querySelectorAll('li'))).toEqual(originalRows);
+		expect(originalRows.map((row) => row.getAttribute('data-callback'))).toEqual(['2:6', '1:2']);
+		root.unmount();
+		container.remove();
+	});
+
+	it('serializes native mapped host rows without per-item hydration comments', () => {
+		const { server } = loadMappedHydrationComponents();
+		const rows = [
+			{ id: 1, label: 'first' },
+			{ id: 2, label: 'second' },
+			{ id: 3, label: 'third' },
+		];
+		const { html } = ServerRuntime.renderToString(server.App, {
+			rows,
+			prefix: 'server',
+			onItem: (id: number, index: number) => `${id}:${index}`,
+		});
+		const container = document.createElement('div');
+		container.innerHTML = html;
+		const list = container.querySelector('ul')!;
+
+		expect(Array.from(list.children).map((row) => row.textContent)).toEqual([
+			'server:0:first',
+			'server:1:second',
+			'server:2:third',
+		]);
+		expect(Array.from(list.childNodes).filter((node) => node.nodeType === 8)).toHaveLength(2);
+	});
+
+	it.each([
+		{ serverReceiver: 'native', clientReceiver: 'custom' },
+		{ serverReceiver: 'custom', clientReceiver: 'native' },
+	])(
+		'adopts keyed rows when server rendering uses $serverReceiver map and hydration uses $clientReceiver map',
+		({ serverReceiver, clientReceiver }) => {
+			const { server, client } = loadMappedHydrationComponents();
+			const items = [
+				{ id: 1, label: 'first' },
+				{ id: 2, label: 'second' },
+			];
+			const events: string[] = [];
+			const customRows = {
+				map<T>(callback: (item: (typeof items)[number], index: number) => T): T[] {
+					events.push('custom:map');
+					return items.map(callback);
+				},
+			};
+			const onItem = (itemId: number, index: number): string => {
+				events.push(`callback:${itemId}:${index}`);
+				return `${itemId}:${index}`;
+			};
+			const serverRows = serverReceiver === 'native' ? items : customRows;
+			const clientRows = clientReceiver === 'native' ? items : customRows;
+			const serverProps = { rows: serverRows, prefix: 'hydrated', onItem };
+			const clientProps = { rows: clientRows, prefix: 'hydrated', onItem };
+			const { html } = ServerRuntime.renderToString(server.App, serverProps);
+			expect(events).toEqual([
+				...(serverReceiver === 'custom' ? ['custom:map'] : []),
+				'callback:1:0',
+				'callback:2:1',
+			]);
+
+			const container = document.createElement('div');
+			document.body.appendChild(container);
+			container.innerHTML = html;
+			const originalRows = Array.from(container.querySelectorAll('li'));
+			expect(originalRows.map((row) => row.textContent)).toEqual([
+				'hydrated:0:first',
+				'hydrated:1:second',
+			]);
+
+			events.length = 0;
+			const root = hydrateRoot(container, client.App as any, clientProps);
+			flushSync(() => {});
+			expect(events).toEqual([
+				...(clientReceiver === 'custom' ? ['custom:map'] : []),
+				'callback:1:0',
+				'callback:2:1',
+			]);
+			expect(Array.from(container.querySelectorAll('li'))).toEqual(originalRows);
+
+			events.length = 0;
+			root.render(client.App, {
+				rows: [items[1], items[0]],
+				prefix: 'reordered',
+				onItem,
+			});
+			flushSync(() => {});
+			expect(events.toSorted()).toEqual(['callback:1:1', 'callback:2:0']);
+			expect(Array.from(container.querySelectorAll('li'))).toEqual([
+				originalRows[1],
+				originalRows[0],
+			]);
+			expect(Array.from(container.querySelectorAll('li')).map((row) => row.textContent)).toEqual([
+				'reordered:0:second',
+				'reordered:1:first',
+			]);
+			root.unmount();
+			container.remove();
+		},
+	);
+
+	it.each(['Array', 'Object', 'Reflect', 'globalThis'])(
+		'preserves client rendering and server hydration when a module binding shadows %s',
+		(binding) => {
+			const source = `
+				const ${binding} = null;
+				function ShadowedMapApp(props) {
+					return (
+						<ul id="tsx-shadowed-map">
+							{props.rows.map((item, index) => (
+								<li key={item.id}>{props.prefix + ':' + index + ':' + item.label}</li>
+							))}
+						</ul>
+					);
+				}
+				export const App = ShadowedMapApp;
+			`;
+			const id = `tsx-shadowed-${binding}.tsx`;
+			const client = loadCompiledFixtureSource(source, {
+				id,
+				mode: 'client',
+				compileOptions: { hmr: false, dev: false },
+			});
+			const rows = [
+				{ id: 1, label: 'first' },
+				{ id: 2, label: 'second' },
+			];
+
+			const mounted = mount(client.App, { rows, prefix: 'mounted' });
+			expect(mounted.findAll('#tsx-shadowed-map li').map((row) => row.textContent)).toEqual([
+				'mounted:0:first',
+				'mounted:1:second',
+			]);
+			mounted.update(client.App, { rows, prefix: 'updated' });
+			expect(mounted.findAll('#tsx-shadowed-map li').map((row) => row.textContent)).toEqual([
+				'updated:0:first',
+				'updated:1:second',
+			]);
+			mounted.unmount();
+
+			const server = loadCompiledFixtureSource(source, {
+				id,
+				mode: 'server',
+				compileOptions: { hmr: false, dev: false },
+			});
+			const props = { rows, prefix: 'hydrated' };
+			const { html } = ServerRuntime.renderToString(server.App, props);
+			const container = document.createElement('div');
+			document.body.appendChild(container);
+			container.innerHTML = html;
+			const originalRows = Array.from(container.querySelectorAll('li'));
+			expect(originalRows.map((row) => row.textContent)).toEqual([
+				'hydrated:0:first',
+				'hydrated:1:second',
+			]);
+
+			const root = hydrateRoot(container, client.App as any, props);
+			flushSync(() => {});
+			expect(Array.from(container.querySelectorAll('li'))).toEqual(originalRows);
+			root.render(client.App, { rows: [rows[1], rows[0]], prefix: 'reordered' });
+			flushSync(() => {});
+			expect(Array.from(container.querySelectorAll('li'))).toEqual([
+				originalRows[1],
+				originalRows[0],
+			]);
+			expect(Array.from(container.querySelectorAll('li')).map((row) => row.textContent)).toEqual([
+				'reordered:0:second',
+				'reordered:1:first',
+			]);
+			root.unmount();
+			container.remove();
+		},
+	);
+
+	it('honors an own map override on an ordinary Array instance', () => {
+		const events: string[] = [];
+		const rows = [
+			{ id: 1, label: 'first' },
+			{ id: 2, label: 'second' },
+		];
+
+		Object.defineProperty(rows, 'map', {
+			configurable: true,
+			get() {
+				events.push('instance:get');
+				return function map<T>(
+					this: typeof rows,
+					callback: (item: (typeof rows)[number], index: number, array: typeof rows) => T,
+					thisArg?: unknown,
+				): T[] {
+					if (this !== rows) throw new Error('instance map lost its receiver');
+					events.push('instance:start');
+					const result = [
+						callback.call(thisArg, rows[1]!, 5, rows),
+						callback.call(thisArg, rows[0]!, 2, rows),
+					];
+					events.push('instance:end');
+					return result;
+				};
+			},
+		});
+
+		const onItem = (id: number, index: number): string => {
+			events.push(`callback:${id}:${index}`);
+			return `${id}:${index}`;
+		};
+		const root = mount(TsxCustomMapApp, { rows, prefix: 'instance', onItem });
+		expect(events).toEqual([
+			'instance:get',
+			'instance:start',
+			'callback:2:5',
+			'callback:1:2',
+			'instance:end',
+		]);
+		expect(root.findAll('#tsx-custom-map-rows li').map((row) => row.textContent)).toEqual([
+			'instance:5:second',
+			'instance:2:first',
+		]);
+
+		events.length = 0;
+		root.update(TsxCustomMapApp, { rows, prefix: 'updated instance', onItem });
+		expect(events).toEqual([
+			'instance:get',
+			'instance:start',
+			'callback:2:5',
+			'callback:1:2',
+			'instance:end',
+		]);
+		expect(root.findAll('#tsx-custom-map-rows li').map((row) => row.textContent)).toEqual([
+			'updated instance:5:second',
+			'updated instance:2:first',
+		]);
+		root.unmount();
+	});
+
+	it('honors an Array.prototype.map replacement installed after the component module loads', () => {
+		const events: string[] = [];
+		const rows = [
+			{ id: 1, label: 'first' },
+			{ id: 2, label: 'second' },
+		];
+		const originalMap = Array.prototype.map;
+		const patchedMap = function <Item, Result>(
+			this: Item[],
+			callback: (item: Item, index: number, items: Item[]) => Result,
+			thisArg?: unknown,
+		): Result[] {
+			if ((this as unknown) === rows) events.push('prototype:map');
+			return originalMap.call(this, callback, thisArg) as Result[];
+		};
+		const onItem = (id: number, index: number): string => {
+			events.push(`callback:${id}:${index}`);
+			return `${id}:${index}`;
+		};
+		const root = mount(TsxCustomMapApp, { rows, prefix: 'native', onItem });
+		const originalRows = root.findAll('#tsx-custom-map-rows li');
+		expect(events).toEqual(['callback:1:0', 'callback:2:1']);
+
+		events.length = 0;
+		Array.prototype.map = patchedMap;
+		try {
+			root.update(TsxCustomMapApp, { rows, prefix: 'patched', onItem });
+			expect(events).toEqual(['prototype:map', 'callback:1:0', 'callback:2:1']);
+			expect(root.findAll('#tsx-custom-map-rows li')).toEqual(originalRows);
+			expect(root.findAll('#tsx-custom-map-rows li').map((row) => row.textContent)).toEqual([
+				'patched:0:first',
+				'patched:1:second',
+			]);
+
+			events.length = 0;
+			Array.prototype.map = originalMap;
+			root.update(TsxCustomMapApp, { rows, prefix: 'native again', onItem });
+			expect(events).toEqual(['callback:1:0', 'callback:2:1']);
+			expect(root.findAll('#tsx-custom-map-rows li')).toEqual(originalRows);
+			expect(root.findAll('#tsx-custom-map-rows li').map((row) => row.textContent)).toEqual([
+				'native again:0:first',
+				'native again:1:second',
+			]);
+		} finally {
+			Array.prototype.map = originalMap;
+			root.unmount();
+		}
+	});
+
+	it('preserves map callback receiver binding and callback side effects', () => {
+		const events: string[] = [];
+		const rows = [
+			{ id: 1, label: 'first' },
+			{ id: 2, label: 'second' },
+		];
+		const onItem = (id: number, index: number): string => {
+			events.push(`callback:${id}:${index}`);
+			return `${id}:${index}`;
+		};
+
+		const root = mount(TsxBoundMapApp, {
+			rows,
+			receiver: { prefix: 'bound' },
+			onItem,
+		});
+		expect(events).toEqual(['callback:1:0', 'callback:2:1']);
+		expect(root.findAll('#tsx-bound-map-rows li').map((row) => row.textContent)).toEqual([
+			'bound:0:first',
+			'bound:1:second',
+		]);
+
+		events.length = 0;
+		root.update(TsxBoundMapApp, {
+			rows,
+			receiver: { prefix: 'rebound' },
+			onItem,
+		});
+		expect(events).toEqual(['callback:1:0', 'callback:2:1']);
+		expect(root.findAll('#tsx-bound-map-rows li').map((row) => row.textContent)).toEqual([
+			'rebound:0:first',
+			'rebound:1:second',
+		]);
+		root.unmount();
+	});
+
+	it.each([
+		{
+			kind: 'defaulted item',
+			callback:
+				"(item = { id: 2, label: 'default' }, index) => <li key={item.id}>{index + ':' + item.label}</li>",
+			rows: [{ id: 1, label: 'first' }, undefined],
+			expected: ['0:first', '1:default'],
+		},
+		{
+			kind: 'rest arguments',
+			callback:
+				"(...args) => <li key={args[0].id}>{args.length + ':' + args[1] + ':' + args[0].label}</li>",
+			rows: [
+				{ id: 1, label: 'first' },
+				{ id: 2, label: 'second' },
+			],
+			expected: ['3:0:first', '3:1:second'],
+		},
+		{
+			kind: 'destructured item',
+			callback: "({ id, label }, index) => <li key={id}>{index + ':' + label}</li>",
+			rows: [
+				{ id: 1, label: 'first' },
+				{ id: 2, label: 'second' },
+			],
+			expected: ['0:first', '1:second'],
+		},
+	])(
+		'preserves $kind map callback parameters on the client and server',
+		({ callback, rows, expected }) => {
+			const source = `
+			function CallbackShapeApp(props) {
+				return <ul id="tsx-map-callback-shape">{props.rows.map(${callback})}</ul>;
+			}
+			export const App = CallbackShapeApp;
+		`;
+			const client = loadCompiledFixtureSource(source, {
+				id: 'tsx-map-callback-shape.tsx',
+				mode: 'client',
+				compileOptions: { hmr: false, dev: false },
+			});
+			const root = mount(client.App, { rows });
+			expect(root.findAll('#tsx-map-callback-shape li').map((row) => row.textContent)).toEqual(
+				expected,
+			);
+			root.unmount();
+
+			const server = loadCompiledFixtureSource(source, {
+				id: 'tsx-map-callback-shape.tsx',
+				mode: 'server',
+				compileOptions: { hmr: false, dev: false },
+			});
+			const { html } = ServerRuntime.renderToString(server.App, { rows });
+			const container = document.createElement('div');
+			container.innerHTML = html;
+			expect(Array.from(container.querySelectorAll('li')).map((row) => row.textContent)).toEqual(
+				expected,
+			);
+		},
+	);
+
+	it('preserves promise-valued children from async map callbacks', () => {
+		const source = `
+			import { Suspense } from 'octane';
+			function AsyncMapApp(props) {
+				return (
+					<Suspense fallback={<span id="tsx-async-map-pending">pending</span>}>
+						<ul id="tsx-async-map-rows">
+							{props.rows.map(async (item) => (
+								<li key={item.id} data-callback={props.onItem(item.id)}>{item.label}</li>
+							))}
+						</ul>
+					</Suspense>
+				);
+			}
+			export const App = AsyncMapApp;
+		`;
+		const rows = [{ id: 1, label: 'first' }];
+		const events: string[] = [];
+		const onItem = (id: number): string => {
+			events.push(`callback:${id}`);
+			return String(id);
+		};
+		const client = loadCompiledFixtureSource(source, {
+			id: 'tsx-async-map.tsx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: false },
+		});
+		expect(() => mount(client.App, { rows, onItem })).toThrow(
+			/Objects are not valid as an Octane child.*\[object Promise\]/,
+		);
+		expect(events).toEqual(['callback:1']);
+
+		events.length = 0;
+		const server = loadCompiledFixtureSource(source, {
+			id: 'tsx-async-map.tsx',
+			mode: 'server',
+			compileOptions: { hmr: false, dev: false },
+		});
+		expect(() => ServerRuntime.renderToString(server.App, { rows, onItem })).toThrow(
+			/Objects are not valid as an Octane child.*\[object Promise\]/,
+		);
+		expect(events).toEqual(['callback:1']);
+	});
+
+	it.each([
+		{ capture: 'arguments', expression: 'arguments[0].prefix', receiver: 'native' },
+		{ capture: 'arguments', expression: 'arguments[0].prefix', receiver: 'custom' },
+		{
+			capture: 'this',
+			expression: "this === owner ? props.prefix : 'wrong-this'",
+			receiver: 'native',
+		},
+		{
+			capture: 'this',
+			expression: "this === owner ? props.prefix : 'wrong-this'",
+			receiver: 'custom',
+		},
+	])(
+		'preserves lexical arrow $capture for $receiver map receivers on client and server',
+		({ capture, expression, receiver }) => {
+			const source = `
+				function LexicalMapApp(props) {
+					const owner = this;
+					return (
+						<ul id="tsx-lexical-map">
+							{props.rows.map((item, index) => (
+								<li key={item.id}>{(${expression}) + ':' + index + ':' + item.label}</li>
+							))}
+						</ul>
+					);
+				}
+				export const App = LexicalMapApp;
+			`;
+			const items = [
+				{ id: 1, label: 'first' },
+				{ id: 2, label: 'second' },
+			];
+			const events: string[] = [];
+			const customRows = {
+				map<T>(callback: (item: (typeof items)[number], index: number) => T): T[] {
+					if (this !== customRows) throw new Error('lexical map lost its receiver');
+					events.push('custom:map');
+					return items.map(callback);
+				},
+			};
+			const rows = receiver === 'native' ? items : customRows;
+			const client = loadCompiledFixtureSource(source, {
+				id: `tsx-map-lexical-${capture}-${receiver}.tsx`,
+				mode: 'client',
+				compileOptions: { hmr: false, dev: false },
+			});
+			const root = mount(client.App, { rows, prefix: 'client' });
+			expect(root.findAll('#tsx-lexical-map li').map((row) => row.textContent)).toEqual([
+				'client:0:first',
+				'client:1:second',
+			]);
+			expect(events).toEqual(receiver === 'custom' ? ['custom:map'] : []);
+			root.unmount();
+
+			events.length = 0;
+			const server = loadCompiledFixtureSource(source, {
+				id: `tsx-map-lexical-${capture}-${receiver}.tsx`,
+				mode: 'server',
+				compileOptions: { hmr: false, dev: false },
+			});
+			const { html } = ServerRuntime.renderToString(server.App, { rows, prefix: 'server' });
+			const container = document.createElement('div');
+			container.innerHTML = html;
+			expect(Array.from(container.querySelectorAll('li')).map((row) => row.textContent)).toEqual([
+				'server:0:first',
+				'server:1:second',
+			]);
+			expect(events).toEqual(receiver === 'custom' ? ['custom:map'] : []);
+		},
+	);
+
+	it('reads native-array indexed getters exactly once in callback order on every render', () => {
+		const events: string[] = [];
+		const items = [
+			{ id: 1, label: 'first' },
+			{ id: 2, label: 'second' },
+		];
+		const rows: typeof items = [];
+		Object.defineProperty(rows, '0', {
+			configurable: true,
+			enumerable: true,
+			get() {
+				events.push('get:0');
+				return items[0];
+			},
+		});
+		Object.defineProperty(rows, '1', {
+			configurable: true,
+			enumerable: true,
+			get() {
+				events.push('get:1');
+				return items[1];
+			},
+		});
+		const onItem = (id: number, index: number): string => {
+			events.push(`callback:${id}:${index}`);
+			return `${id}:${index}`;
+		};
+		const root = mount(TsxCustomMapApp, { rows, prefix: 'getter', onItem });
+		expect(events).toEqual(['get:0', 'callback:1:0', 'get:1', 'callback:2:1']);
+		expect(root.findAll('#tsx-custom-map-rows li').map((row) => row.textContent)).toEqual([
+			'getter:0:first',
+			'getter:1:second',
+		]);
+
+		events.length = 0;
+		root.update(TsxCustomMapApp, { rows, prefix: 'updated getter', onItem });
+		expect(events).toEqual(['get:0', 'callback:1:0', 'get:1', 'callback:2:1']);
+		expect(root.findAll('#tsx-custom-map-rows li').map((row) => row.textContent)).toEqual([
+			'updated getter:0:first',
+			'updated getter:1:second',
+		]);
+		root.unmount();
+	});
+
+	it('re-reads accessor-backed pure component rows when their array identity is unchanged', () => {
+		const events: string[] = [];
+		let current = { id: 1, label: 'first' };
+		const rows: Array<typeof current> = [];
+		Object.defineProperty(rows, '0', {
+			configurable: true,
+			enumerable: true,
+			get() {
+				events.push('get:0');
+				return current;
+			},
+		});
+		const props = { rows, prefix: 'stable', theme: 't0' };
+		const root = mount(TsxStatefulMappedApp, props);
+		const button = root.find('.own-1');
+		expect(events).toEqual(['get:0']);
+		expect(button.textContent).toBe('t0:stable:0:first:0');
+		root.click('.own-1');
+		expect(button.textContent).toBe('t0:stable:0:first:1');
+
+		events.length = 0;
+		current = { id: 1, label: 'updated' };
+		root.update(TsxStatefulMappedApp, props);
+		expect(events).toEqual(['get:0']);
+		expect(root.find('.own-1')).toBe(button);
+		expect(button.textContent).toBe('t0:stable:0:updated:1');
+		root.unmount();
+	});
+
+	it('reads inherited sparse-array getters once without skipping their callback index', () => {
+		const events: string[] = [];
+		const first = { id: 1, label: 'first' };
+		const inherited = { id: 2, label: 'inherited' };
+		const third = { id: 3, label: 'third' };
+
+		class InheritedRows extends Array<typeof first> {}
+		const rows = new InheritedRows();
+		rows[0] = first;
+		rows[2] = third;
+		Object.defineProperty(InheritedRows.prototype, '1', {
+			configurable: true,
+			get() {
+				events.push('get:inherited');
+				return inherited;
+			},
+		});
+		const onItem = (id: number, index: number): string => {
+			events.push(`callback:${id}:${index}`);
+			return `${id}:${index}`;
+		};
+		const root = mount(TsxCustomMapApp, { rows, prefix: 'inherited', onItem });
+		expect(events).toEqual(['callback:1:0', 'get:inherited', 'callback:2:1', 'callback:3:2']);
+		expect(root.findAll('#tsx-custom-map-rows li').map((row) => row.textContent)).toEqual([
+			'inherited:0:first',
+			'inherited:1:inherited',
+			'inherited:2:third',
+		]);
+
+		events.length = 0;
+		root.update(TsxCustomMapApp, { rows, prefix: 'updated inherited', onItem });
+		expect(events).toEqual(['callback:1:0', 'get:inherited', 'callback:2:1', 'callback:3:2']);
+		expect(root.findAll('#tsx-custom-map-rows li').map((row) => row.textContent)).toEqual([
+			'updated inherited:0:first',
+			'updated inherited:1:inherited',
+			'updated inherited:2:third',
+		]);
+		root.unmount();
+	});
+
+	it('re-reads inherited proxy-array values in a pure mapped list on every parent render', () => {
+		const events: string[] = [];
+		const first = { id: 1, label: 'first' };
+		let inherited = { id: 2, label: 'inherited' };
+		const target = [first];
+		target.length = 2;
+		const rows = new Proxy(target, {
+			has(items, property) {
+				return property === '1' || Reflect.has(items, property);
+			},
+			get(items, property, receiver) {
+				if (property === '1') {
+					events.push('get:inherited');
+					return inherited;
+				}
+				return Reflect.get(items, property, receiver);
+			},
+		});
+		const props = { rows, prefix: 'stable', theme: 't0' };
+		const root = mount(TsxStatefulMappedApp, props);
+		const button = root.find('.own-2');
+		expect(events).toEqual(['get:inherited']);
+		expect(button.textContent).toBe('t0:stable:1:inherited:0');
+		root.click('.own-2');
+		expect(button.textContent).toBe('t0:stable:1:inherited:1');
+
+		events.length = 0;
+		inherited = { id: 2, label: 'updated' };
+		root.update(TsxStatefulMappedApp, props);
+		expect(events).toEqual(['get:inherited']);
+		expect(root.find('.own-2')).toBe(button);
+		expect(button.textContent).toBe('t0:stable:1:updated:1');
+		root.unmount();
+	});
+
+	it('preserves array constructor and Symbol.species side effects on every map render', () => {
+		const events: string[] = [];
+		const rows = [
+			{ id: 1, label: 'first' },
+			{ id: 2, label: 'second' },
+		];
+		function Species(length: number): unknown[] {
+			events.push(`species:new:${length}`);
+			return new Array(length);
+		}
+		const customConstructor = {
+			get [Symbol.species]() {
+				events.push('species:get');
+				return Species;
+			},
+		};
+		Object.defineProperty(rows, 'constructor', {
+			configurable: true,
+			get() {
+				events.push('constructor:get');
+				return customConstructor;
+			},
+		});
+		const onItem = (id: number, index: number): string => {
+			events.push(`callback:${id}:${index}`);
+			return `${id}:${index}`;
+		};
+		const root = mount(TsxCustomMapApp, { rows, prefix: 'species', onItem });
+		expect(events).toEqual([
+			'constructor:get',
+			'species:get',
+			'species:new:2',
+			'callback:1:0',
+			'callback:2:1',
+		]);
+		expect(root.findAll('#tsx-custom-map-rows li').map((row) => row.textContent)).toEqual([
+			'species:0:first',
+			'species:1:second',
+		]);
+
+		events.length = 0;
+		root.update(TsxCustomMapApp, { rows, prefix: 'updated species', onItem });
+		expect(events).toEqual([
+			'constructor:get',
+			'species:get',
+			'species:new:2',
+			'callback:1:0',
+			'callback:2:1',
+		]);
+		expect(root.findAll('#tsx-custom-map-rows li').map((row) => row.textContent)).toEqual([
+			'updated species:0:first',
+			'updated species:1:second',
+		]);
+		root.unmount();
+	});
+
+	it('evaluates a side-effecting map receiver getter exactly once per render', () => {
+		const events: string[] = [];
+		const rows = [
+			{ id: 1, label: 'first' },
+			{ id: 2, label: 'second' },
+		];
+		const source = {
+			get rows() {
+				events.push('receiver:get');
+				return rows;
+			},
+		};
+		const onItem = (id: number, index: number): string => {
+			events.push(`callback:${id}:${index}`);
+			return `${id}:${index}`;
+		};
+
+		const root = mount(TsxGetterMapApp, { source, prefix: 'initial', onItem });
+		expect(events).toEqual(['receiver:get', 'callback:1:0', 'callback:2:1']);
+		expect(root.findAll('#tsx-getter-map-rows li').map((row) => row.textContent)).toEqual([
+			'initial:0:first',
+			'initial:1:second',
+		]);
+
+		events.length = 0;
+		root.update(TsxGetterMapApp, { source, prefix: 'updated', onItem });
+		expect(events).toEqual(['receiver:get', 'callback:1:0', 'callback:2:1']);
+		expect(root.findAll('#tsx-getter-map-rows li').map((row) => row.textContent)).toEqual([
+			'updated:0:first',
+			'updated:1:second',
+		]);
+		root.unmount();
+	});
+
+	it('evaluates a map thisArg expression before invoking its callback', () => {
+		const events: string[] = [];
+		const rows = [
+			{ id: 1, label: 'first' },
+			{ id: 2, label: 'second' },
+		];
+		const makeThisArg = () => {
+			events.push('thisArg');
+			return { prefix: 'ignored by arrow' };
+		};
+		const onItem = (id: number, index: number): string => {
+			events.push(`callback:${id}:${index}`);
+			return `${id}:${index}`;
+		};
+
+		const root = mount(TsxMapExtraArgumentApp, {
+			rows,
+			prefix: 'initial',
+			makeThisArg,
+			onItem,
+		});
+		expect(events).toEqual(['thisArg', 'callback:1:0', 'callback:2:1']);
+		expect(root.findAll('#tsx-extra-map-rows li').map((row) => row.textContent)).toEqual([
+			'initial:0:first',
+			'initial:1:second',
+		]);
+
+		events.length = 0;
+		root.update(TsxMapExtraArgumentApp, {
+			rows,
+			prefix: 'updated',
+			makeThisArg,
+			onItem,
+		});
+		expect(events).toEqual(['thisArg', 'callback:1:0', 'callback:2:1']);
+		expect(root.findAll('#tsx-extra-map-rows li').map((row) => row.textContent)).toEqual([
+			'updated:0:first',
+			'updated:1:second',
+		]);
+		root.unmount();
+	});
+
+	it('keeps returned-JSX keyed children reactive to context, their own state, and changed items', () => {
+		const root = mount(TsxAutoMemoApp);
+		const first = root.find('.own-1');
+		const second = root.find('.own-2');
+		expect(first.textContent).toBe('t0:p0:0:a:0');
+		expect(second.textContent).toBe('t0:p0:1:b:0');
+
+		root.click('.own-1');
+		expect(first.textContent).toBe('t0:p0:0:a:1');
+
+		root.click('#tsx-auto-tick');
+		expect(root.find('.own-1')).toBe(first);
+		expect(root.find('.own-2')).toBe(second);
+		expect(first.textContent).toBe('t0:p0:0:a:1');
+
+		root.click('#tsx-auto-theme');
+		expect(first.textContent).toBe('t0!:p0:0:a:1');
+		expect(second.textContent).toBe('t0!:p0:1:b:0');
+
+		root.click('#tsx-auto-item');
+		expect(root.find('.own-1')).toBe(first);
+		expect(root.find('.own-2')).toBe(second);
+		expect(first.textContent).toBe('t0!:p0:0:a!:1');
+		expect(second.textContent).toBe('t0!:p0:1:b:0');
+
+		root.click('#tsx-auto-item-theme');
+		expect(root.find('.own-1')).toBe(first);
+		expect(root.find('.own-2')).toBe(second);
+		expect(first.textContent).toBe('t0!!:p0:0:a!!:1');
+		expect(second.textContent).toBe('t0!!:p0:1:b:0');
+		root.unmount();
+	});
+
+	it('refreshes returned-JSX keyed survivors when a parent capture or their index changes', () => {
+		const root = mount(TsxAutoMemoApp);
+		const first = root.find('.own-1');
+		const second = root.find('.own-2');
+
+		root.click('.own-1');
+		root.click('#tsx-auto-prefix');
+		expect(root.find('.own-1')).toBe(first);
+		expect(root.find('.own-2')).toBe(second);
+		expect(first.textContent).toBe('t0:p0!:0:a:1');
+		expect(second.textContent).toBe('t0:p0!:1:b:0');
+
+		root.click('#tsx-auto-reorder');
+		expect(root.findAll('#tsx-auto-rows button')).toEqual([second, first]);
+		expect(second.textContent).toBe('t0:p0!:0:b:0');
+		expect(first.textContent).toBe('t0:p0!:1:a:1');
+		root.unmount();
+	});
+
+	it('re-reads mutable accessors in returned-JSX lists when item identities stay unchanged', () => {
+		const root = mount(TsxImpureRowsApp);
+		const rows = () => root.findAll('.tsx-impure-row').map((row) => row.textContent);
+		expect(rows()).toEqual(['first:v0', 'second:v0']);
+
+		root.click('#tsx-impure-advance');
+		expect(rows()).toEqual(['first:v1', 'second:v1']);
+
+		root.click('#tsx-impure-advance');
+		expect(rows()).toEqual(['first:v2', 'second:v2']);
 		root.unmount();
 	});
 

--- a/packages/octane/tests/auto-memo.test.ts
+++ b/packages/octane/tests/auto-memo.test.ts
@@ -1194,6 +1194,135 @@ describe('compiler-owned component-region memoization', () => {
 		},
 	);
 
+	it.each([
+		{
+			capture: 'object default using lexical this',
+			callback: '({ id, label = this.prefix }) => <li key={id}>{label}</li>',
+			rows: [{ id: 1 }],
+			expected: (_prefix: string) => 'receiver',
+		},
+		{
+			capture: 'array default using lexical this',
+			callback: '([id, label = this.prefix]) => <li key={id}>{label}</li>',
+			rows: [[1]],
+			expected: (_prefix: string) => 'receiver',
+		},
+		{
+			capture: 'object default using lexical arguments',
+			callback: '({ id, label = arguments[0].prefix }) => <li key={id}>{label}</li>',
+			rows: [{ id: 1 }],
+			expected: (prefix: string) => prefix,
+		},
+		{
+			capture: 'array default using lexical arguments',
+			callback: '([id, label = arguments[0].prefix]) => <li key={id}>{label}</li>',
+			rows: [[1]],
+			expected: (prefix: string) => prefix,
+		},
+		{
+			capture: 'computed object key using lexical this',
+			callback: '({ id, [this.field]: label }) => <li key={id}>{label}</li>',
+			rows: [{ id: 1, label: 'computed' }],
+			expected: (_prefix: string) => 'computed',
+		},
+		{
+			capture: 'computed object key using lexical arguments',
+			callback: '({ id, [arguments[0].field]: label }) => <li key={id}>{label}</li>',
+			rows: [{ id: 1, label: 'computed' }],
+			expected: (_prefix: string) => 'computed',
+		},
+		{
+			capture: 'computed object key using lexical this and arguments',
+			callback:
+				'({ id, [this.fieldStart + arguments[0].fieldEnd]: label }) => <li key={id}>{label}</li>',
+			rows: [{ id: 1, label: 'computed' }],
+			expected: (_prefix: string) => 'computed',
+		},
+	])(
+		'preserves $capture in arrow map parameters on client and server',
+		({ capture, callback, rows, expected }) => {
+			const source = `
+				const owner = { prefix: 'receiver', field: 'label', fieldStart: 'lab' };
+				function LexicalParameterMapApp(props) {
+					return <ul id="tsx-lexical-parameter-map">{props.rows.map(${callback})}</ul>;
+				}
+				export const App = LexicalParameterMapApp.bind(owner);
+			`;
+			const id = `tsx-map-lexical-parameter-${capture.replaceAll(' ', '-')}.tsx`;
+			const client = loadCompiledFixtureSource(source, {
+				id,
+				mode: 'client',
+				compileOptions: { hmr: false, dev: false },
+			});
+			const root = mount(client.App, { rows, prefix: 'client', field: 'label', fieldEnd: 'el' });
+			expect(root.findAll('#tsx-lexical-parameter-map li').map((row) => row.textContent)).toEqual([
+				expected('client'),
+			]);
+			root.unmount();
+
+			const compiled = compile(source, id, { hmr: false, dev: false }).code;
+			expect(compiled).not.toContain('mapSlot');
+
+			const server = loadCompiledFixtureSource(source, {
+				id,
+				mode: 'server',
+				compileOptions: { hmr: false, dev: false },
+			});
+			const { html } = ServerRuntime.renderToString(server.App, {
+				rows,
+				prefix: 'server',
+				field: 'label',
+				fieldEnd: 'el',
+			});
+			const container = document.createElement('div');
+			container.innerHTML = html;
+			expect(Array.from(container.querySelectorAll('li')).map((row) => row.textContent)).toEqual([
+				expected('server'),
+			]);
+		},
+	);
+
+	it.each([
+		{
+			kind: 'safe object destructuring',
+			callback: '({ id, label }) => <li key={id}>{label}</li>',
+			rows: [{ id: 1, label: 'safe' }],
+			expected: 'safe',
+		},
+		{
+			kind: 'safe array destructuring',
+			callback: '([id, label]) => <li key={id}>{label}</li>',
+			rows: [[1, 'safe']],
+			expected: 'safe',
+		},
+		{
+			kind: 'nested normal-function receiver and arguments',
+			callback:
+				"({ id, label = (function () { return this.prefix + ':' + arguments[0]; }).call({ prefix: 'nested' }, 'own') }) => <li key={id}>{label}</li>",
+			rows: [{ id: 1 }],
+			expected: 'nested:own',
+		},
+	])('keeps $kind in arrow map parameters optimized', ({ kind, callback, rows, expected }) => {
+		const source = `
+			function SafeParameterMapApp(props) {
+				return <ul id="tsx-safe-parameter-map">{props.rows.map(${callback})}</ul>;
+			}
+			export const App = SafeParameterMapApp;
+		`;
+		const id = `tsx-map-safe-parameter-${kind.replaceAll(' ', '-')}.tsx`;
+		const client = loadCompiledFixtureSource(source, {
+			id,
+			mode: 'client',
+			compileOptions: { hmr: false, dev: false },
+		});
+		const root = mount(client.App, { rows });
+		expect(root.findAll('#tsx-safe-parameter-map li').map((row) => row.textContent)).toEqual([
+			expected,
+		]);
+		root.unmount();
+		expect(compile(source, id, { hmr: false, dev: false }).code).toContain('mapSlot');
+	});
+
 	it('reads native-array indexed getters exactly once in callback order on every render', () => {
 		const events: string[] = [];
 		const items = [

--- a/packages/octane/tests/auto-memo.test.ts
+++ b/packages/octane/tests/auto-memo.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import * as ServerRuntime from 'octane/server';
 import { compile } from '../src/compiler/compile.js';
-import { flushSync, hydrateRoot } from '../src/index.js';
-import { mount } from './_helpers';
+import { createElement, flushSync, hydrateRoot } from '../src/index.js';
+import { flushEffects, mount } from './_helpers';
 import { loadCompiledFixtureSource } from './_server-fixture.js';
 import { AutoMemoApp } from './_fixtures/auto-memo.tsrx';
 import { ParentCaptureApp } from './_fixtures/auto-memo-parent-capture.tsrx';
@@ -12,6 +12,7 @@ import {
 	TsxCustomMapApp,
 	TsxGetterMapApp,
 	TsxImpureRowsApp,
+	TsxMappedComponentApp,
 	TsxMapExtraArgumentApp,
 	TsxStatefulMappedApp,
 } from './_fixtures/tsx-auto-memo.tsx';
@@ -57,6 +58,58 @@ function loadMappedHydrationComponents() {
 		export const App = AppImpl;
 	`;
 	const id = 'tsx-custom-map-hydration.tsx';
+	return {
+		server: loadCompiledFixtureSource(source, {
+			id,
+			mode: 'server',
+			compileOptions: { hmr: false, dev: false },
+		}),
+		client: loadCompiledFixtureSource(source, {
+			id,
+			mode: 'client',
+			compileOptions: { hmr: false, dev: false },
+		}),
+	};
+}
+
+function loadMappedComponentHydrationComponents() {
+	const source = `
+		import { createContext, useContext, useState } from 'octane';
+
+		const Theme = createContext('default');
+
+		function Row(props) {
+			const theme = useContext(Theme);
+			const [own, setOwn] = useState(0);
+			return (
+				<li data-id={props.id}>
+					<button className={'hydrated-own-' + props.id} onClick={() => setOwn(own + 1)}>
+						{theme + ':' + props.label + ':' + own}
+					</button>
+				</li>
+			);
+		}
+
+		function Rows(props) {
+			const rows = props.rows;
+			return (
+				<ul id="tsx-mapped-component-hydration">
+					{rows.map((item, index) => (
+						<Row
+							key={item.id}
+							id={item.id}
+							label={props.prefix + ':' + props.onItem(item.id, index) + ':' + item.label}
+						/>
+					))}
+				</ul>
+			);
+		}
+
+		export function App(props) {
+			return <Theme.Provider value={props.theme}><Rows {...props} /></Theme.Provider>;
+		}
+	`;
+	const id = 'tsx-mapped-component-hydration.tsx';
 	return {
 		server: loadCompiledFixtureSource(source, {
 			id,
@@ -254,6 +307,320 @@ describe('compiler-owned component-region memoization', () => {
 		expect(second.textContent).toBe('t2:native again:1:second:0');
 		root.unmount();
 	});
+
+	it('preserves keyed component state and effects across native and custom map receivers', () => {
+		const compiled = compile(
+			`import { Row } from './row';
+			export function App(props) {
+				const rows = props.rows;
+				return <ul>{rows.map((item, index) => <Row key={item.id} label={index} />)}</ul>;
+			}`,
+			'tsx-mapped-component-roundtrip.tsx',
+			{ hmr: false, dev: false },
+		).code;
+		expect(compiled).toContain('mapSlot');
+		expect(compiled).toContain('componentSlot');
+
+		const items = [
+			{ id: 1, label: 'first' },
+			{ id: 2, label: 'second' },
+		];
+		const calls: string[] = [];
+		const effects: string[] = [];
+		const customRows = {
+			map<T>(callback: (item: (typeof items)[number], index: number) => T): T[] {
+				if (this !== customRows) throw new Error('component map lost its receiver');
+				calls.push('custom:start');
+				const mapped = [callback(items[1]!, 7), callback(items[0]!, 3)];
+				const first = mapped[0] as { type: unknown; key: unknown; props: { id: unknown } };
+				calls.push(`custom:component:${typeof first.type}:${String(first.key)}:${first.props.id}`);
+				calls.push('custom:end');
+				return mapped;
+			},
+		};
+		const onEffect = (event: string) => effects.push(event);
+		const onItem = (id: number, index: number): string => {
+			calls.push(`callback:${id}:${index}`);
+			return String(index);
+		};
+		const root = mount(TsxMappedComponentApp, {
+			rows: items,
+			prefix: 'native',
+			theme: 't0',
+			onEffect,
+			onItem,
+		});
+		flushEffects();
+		const first = root.find('.tracked-own-1');
+		const second = root.find('.tracked-own-2');
+		expect(calls).toEqual(['callback:1:0', 'callback:2:1']);
+		expect(effects).toEqual(['mount:1', 'mount:2']);
+		root.click('.tracked-own-1');
+		expect(first.textContent).toBe('t0:native:0:first:1');
+
+		calls.length = 0;
+		root.update(TsxMappedComponentApp, {
+			rows: customRows,
+			prefix: 'custom',
+			theme: 't1',
+			onEffect,
+			onItem,
+		});
+		flushEffects();
+		expect(calls).toEqual([
+			'custom:start',
+			'callback:2:7',
+			'callback:1:3',
+			'custom:component:function:2:2',
+			'custom:end',
+		]);
+		expect(root.findAll('#tsx-mapped-component-rows button')).toEqual([second, first]);
+		expect(first.textContent).toBe('t1:custom:3:first:1');
+		expect(second.textContent).toBe('t1:custom:7:second:0');
+		expect(effects).toEqual(['mount:1', 'mount:2']);
+
+		calls.length = 0;
+		root.update(TsxMappedComponentApp, {
+			rows: items,
+			prefix: 'native again',
+			theme: 't2',
+			onEffect,
+			onItem,
+		});
+		flushEffects();
+		expect(calls).toEqual(['callback:1:0', 'callback:2:1']);
+		expect(root.findAll('#tsx-mapped-component-rows button')).toEqual([first, second]);
+		expect(first.textContent).toBe('t2:native again:0:first:1');
+		expect(second.textContent).toBe('t2:native again:1:second:0');
+		expect(effects).toEqual(['mount:1', 'mount:2']);
+
+		root.unmount();
+		flushEffects();
+		expect(effects.slice(2).toSorted()).toEqual(['cleanup:1', 'cleanup:2']);
+	});
+
+	it('preserves components first mounted by a custom map when native maps take ownership', () => {
+		const items = [
+			{ id: 1, label: 'first' },
+			{ id: 2, label: 'second' },
+		];
+		const calls: string[] = [];
+		const effects: string[] = [];
+		const customRows = {
+			map<T>(callback: (item: (typeof items)[number], index: number) => T): T[] {
+				if (this !== customRows) throw new Error('initial component map lost its receiver');
+				calls.push('custom:map');
+				return [callback(items[1]!, 8), callback(items[0]!, 4)];
+			},
+		};
+		const onEffect = (event: string) => effects.push(event);
+		const onItem = (id: number, index: number): string => {
+			calls.push(`callback:${id}:${index}`);
+			return String(index);
+		};
+		const root = mount(TsxMappedComponentApp, {
+			rows: customRows,
+			prefix: 'custom',
+			theme: 't0',
+			onEffect,
+			onItem,
+		});
+		flushEffects();
+		const first = root.find('.tracked-own-1');
+		const second = root.find('.tracked-own-2');
+		expect(calls).toEqual(['custom:map', 'callback:2:8', 'callback:1:4']);
+		expect(root.findAll('#tsx-mapped-component-rows button')).toEqual([second, first]);
+		expect(effects).toEqual(['mount:2', 'mount:1']);
+		root.click('.tracked-own-2');
+		expect(second.textContent).toBe('t0:custom:8:second:1');
+
+		calls.length = 0;
+		root.update(TsxMappedComponentApp, {
+			rows: items,
+			prefix: 'native',
+			theme: 't1',
+			onEffect,
+			onItem,
+		});
+		flushEffects();
+		expect(calls).toEqual(['callback:1:0', 'callback:2:1']);
+		expect(root.findAll('#tsx-mapped-component-rows button')).toEqual([first, second]);
+		expect(first.textContent).toBe('t1:native:0:first:0');
+		expect(second.textContent).toBe('t1:native:1:second:1');
+		expect(effects).toEqual(['mount:2', 'mount:1']);
+
+		root.unmount();
+		flushEffects();
+		expect(effects.slice(2).toSorted()).toEqual(['cleanup:1', 'cleanup:2']);
+	});
+
+	it('reconciles mixed custom-map host and empty results before restoring keyed components', () => {
+		const items = [
+			{ id: 1, label: 'first' },
+			{ id: 2, label: 'second' },
+		];
+		const effects: string[] = [];
+		const customRows = {
+			map<T>(callback: (item: (typeof items)[number], index: number) => T): T[] {
+				if (this !== customRows) throw new Error('mixed component map lost its receiver');
+				const first = callback(items[0]!, 0);
+				callback(items[1]!, 1);
+				return [
+					first,
+					createElement('li', { key: 2, 'data-mixed': 'host' }, 'host replacement') as T,
+					null as T,
+				];
+			},
+		};
+		const onEffect = (event: string) => effects.push(event);
+		const onItem = (_id: number, index: number): string => String(index);
+		const root = mount(TsxMappedComponentApp, {
+			rows: items,
+			prefix: 'native',
+			theme: 't0',
+			onEffect,
+			onItem,
+		});
+		flushEffects();
+		const first = root.find('.tracked-own-1');
+		root.click('.tracked-own-1');
+		expect(effects).toEqual(['mount:1', 'mount:2']);
+
+		root.update(TsxMappedComponentApp, {
+			rows: customRows,
+			prefix: 'mixed',
+			theme: 't1',
+			onEffect,
+			onItem,
+		});
+		flushEffects();
+		expect(root.find('.tracked-own-1')).toBe(first);
+		expect(first.textContent).toBe('t1:mixed:0:first:1');
+		expect(root.findAll('.tracked-own-2')).toHaveLength(0);
+		expect(root.find('[data-mixed="host"]').textContent).toBe('host replacement');
+		expect(effects).toEqual(['mount:1', 'mount:2', 'cleanup:2']);
+
+		root.update(TsxMappedComponentApp, {
+			rows: items,
+			prefix: 'restored',
+			theme: 't2',
+			onEffect,
+			onItem,
+		});
+		flushEffects();
+		expect(root.find('.tracked-own-1')).toBe(first);
+		expect(first.textContent).toBe('t2:restored:0:first:1');
+		expect(root.find('.tracked-own-2').textContent).toBe('t2:restored:1:second:0');
+		expect(root.findAll('[data-mixed="host"]')).toHaveLength(0);
+		expect(effects).toEqual(['mount:1', 'mount:2', 'cleanup:2', 'mount:2']);
+
+		root.unmount();
+		flushEffects();
+		expect(effects.filter((event) => event === 'cleanup:1')).toHaveLength(1);
+		expect(effects.filter((event) => event === 'cleanup:2')).toHaveLength(2);
+	});
+
+	it.each([
+		{ serverReceiver: 'native', clientReceiver: 'custom' },
+		{ serverReceiver: 'custom', clientReceiver: 'native' },
+	])(
+		'adopts keyed component rows when server rendering uses $serverReceiver map and hydration uses $clientReceiver map',
+		({ serverReceiver, clientReceiver }) => {
+			const { server, client } = loadMappedComponentHydrationComponents();
+			const items = [
+				{ id: 1, label: 'first' },
+				{ id: 2, label: 'second' },
+			];
+			const events: string[] = [];
+			const customRows = {
+				map<T>(callback: (item: (typeof items)[number], index: number) => T): T[] {
+					if (this !== customRows) throw new Error('hydrated component map lost its receiver');
+					events.push('custom:start');
+					const mapped = [callback(items[0]!, 0), callback(items[1]!, 1)];
+					const first = mapped[0] as { type: unknown; key: unknown };
+					events.push(`custom:component:${typeof first.type}:${String(first.key)}`);
+					events.push('custom:end');
+					return mapped;
+				},
+			};
+			const onItem = (id: number, index: number): string => {
+				events.push(`callback:${id}:${index}`);
+				return String(index);
+			};
+			const serverRows = serverReceiver === 'native' ? items : customRows;
+			const clientRows = clientReceiver === 'native' ? items : customRows;
+			const serverProps = {
+				rows: serverRows,
+				prefix: 'hydrated',
+				theme: 't0',
+				onItem,
+			};
+			const clientProps = { ...serverProps, rows: clientRows };
+			const { html } = ServerRuntime.renderToString(server.App, serverProps);
+			expect(events).toEqual([
+				...(serverReceiver === 'custom' ? ['custom:start'] : []),
+				'callback:1:0',
+				'callback:2:1',
+				...(serverReceiver === 'custom' ? ['custom:component:function:1', 'custom:end'] : []),
+			]);
+
+			const container = document.createElement('div');
+			document.body.appendChild(container);
+			container.innerHTML = html;
+			const originalRows = Array.from(container.querySelectorAll('li'));
+			const originalButtons = Array.from(container.querySelectorAll('button'));
+			expect(originalButtons.map((button) => button.textContent)).toEqual([
+				't0:hydrated:0:first:0',
+				't0:hydrated:1:second:0',
+			]);
+
+			events.length = 0;
+			const root = hydrateRoot(container, client.App as any, clientProps);
+			flushSync(() => {});
+			expect(events).toEqual([
+				...(clientReceiver === 'custom' ? ['custom:start'] : []),
+				'callback:1:0',
+				'callback:2:1',
+				...(clientReceiver === 'custom' ? ['custom:component:function:1', 'custom:end'] : []),
+			]);
+			expect(Array.from(container.querySelectorAll('li'))).toEqual(originalRows);
+			expect(Array.from(container.querySelectorAll('button'))).toEqual(originalButtons);
+
+			flushSync(() => originalButtons[0]!.click());
+			expect(originalButtons[0]!.textContent).toBe('t0:hydrated:0:first:1');
+
+			events.length = 0;
+			root.render(client.App, {
+				...clientProps,
+				rows: clientReceiver === 'native' ? customRows : items,
+				prefix: 'switched',
+				theme: 't1',
+			});
+			flushSync(() => {});
+			expect(Array.from(container.querySelectorAll('li'))).toEqual(originalRows);
+			expect(Array.from(container.querySelectorAll('button'))).toEqual(originalButtons);
+			expect(originalButtons[0]!.textContent).toBe('t1:switched:0:first:1');
+
+			root.render(client.App, {
+				...clientProps,
+				rows: [items[1]!, items[0]!],
+				prefix: 'reordered',
+				theme: 't2',
+			});
+			flushSync(() => {});
+			expect(Array.from(container.querySelectorAll('li'))).toEqual([
+				originalRows[1],
+				originalRows[0],
+			]);
+			expect(Array.from(container.querySelectorAll('button'))).toEqual([
+				originalButtons[1],
+				originalButtons[0],
+			]);
+			expect(originalButtons[0]!.textContent).toBe('t2:reordered:1:first:1');
+			root.unmount();
+			container.remove();
+		},
+	);
 
 	it('preserves keyed survivors and callback indices across dense and sparse array transitions', () => {
 		const events: string[] = [];

--- a/packages/octane/tests/auto-memo.test.ts
+++ b/packages/octane/tests/auto-memo.test.ts
@@ -346,6 +346,117 @@ describe('compiler-owned component-region memoization', () => {
 		root.unmount();
 	});
 
+	it.each([
+		{
+			shape: 'dynamic text',
+			content: "{props.prefix + ':' + index + ':' + item.label}",
+			expected: ['native:0:first', 'native:1:second'],
+		},
+		{
+			shape: 'empty content',
+			content: '',
+			expected: ['', ''],
+		},
+		{
+			shape: 'nested static host and dynamic text',
+			content: '<strong data-child="native">{item.label}</strong>{props.prefix + \':\' + index}',
+			expected: ['firstnative:0', 'secondnative:1'],
+		},
+	])(
+		'repairs $shape inside preserved keyed hosts when a custom map switches to native rendering',
+		({ shape, content, expected }) => {
+			const source = `
+				function StructuredMapApp(props) {
+					const rows = props.rows;
+					return (
+						<ul id="tsx-structured-map-rows">
+							{rows.map((item, index) => (
+								<li
+									key={item.id}
+									data-native={props.onItem(item.id, index)}
+									onClick={() => props.onClick(item.id)}
+								>${content}</li>
+							))}
+						</ul>
+					);
+				}
+				export const App = StructuredMapApp;
+			`;
+			const client = loadCompiledFixtureSource(source, {
+				id: `tsx-structured-map-${shape.replaceAll(' ', '-')}.tsx`,
+				mode: 'client',
+				compileOptions: { hmr: false, dev: false },
+			});
+			const items = [
+				{ id: 1, label: 'first' },
+				{ id: 2, label: 'second' },
+			];
+			const events: string[] = [];
+			const staleRefs: (Element | null)[] = [];
+			const customRows = {
+				map<T>(callback: (item: (typeof items)[number], index: number) => T): T[] {
+					if (this !== customRows) throw new Error('structured map lost its receiver');
+					events.push('custom:start');
+					callback(items[0]!, 7);
+					const compatible = callback(items[1]!, 3);
+					events.push('custom:end');
+					return [
+						createElement(
+							'li',
+							{
+								key: 1,
+								'data-custom': 'stale',
+								onClick: () => events.push('custom:click'),
+							},
+							createElement(
+								'span',
+								{
+									'data-stale': 'child',
+									ref: (value: Element | null) => staleRefs.push(value),
+								},
+								'stale',
+							),
+							'legacy',
+						) as T,
+						compatible,
+					];
+				},
+			};
+			const onItem = (id: number, index: number): string => {
+				events.push(`callback:${id}:${index}`);
+				return `${id}:${index}`;
+			};
+			const onClick = (id: number) => events.push(`native:click:${id}`);
+			const root = mount(client.App, { rows: customRows, prefix: 'custom', onItem, onClick });
+			expect(events).toEqual(['custom:start', 'callback:1:7', 'callback:2:3', 'custom:end']);
+			const originalRows = root.findAll('#tsx-structured-map-rows > li');
+			const staleChild = root.find('[data-stale="child"]');
+			expect(staleRefs).toEqual([staleChild]);
+			expect(originalRows[0]?.textContent).toBe('stalelegacy');
+			root.click('[data-custom="stale"]');
+			expect(events.at(-1)).toBe('custom:click');
+
+			events.length = 0;
+			root.update(client.App, { rows: items, prefix: 'native', onItem, onClick });
+			expect(events).toEqual(['callback:1:0', 'callback:2:1']);
+			const nativeRows = root.findAll('#tsx-structured-map-rows > li');
+			expect(nativeRows).toEqual(originalRows);
+			expect(nativeRows.map((row) => row.textContent)).toEqual(expected);
+			expect(nativeRows.map((row) => row.getAttribute('data-native'))).toEqual(['1:0', '2:1']);
+			expect(root.findAll('[data-stale="child"]')).toHaveLength(0);
+			expect(staleRefs).toEqual([staleChild, null]);
+			if (shape === 'nested static host and dynamic text') {
+				expect(nativeRows.map((row) => row.querySelector('strong')?.textContent)).toEqual([
+					'first',
+					'second',
+				]);
+			}
+			root.click('[data-native="1:0"]');
+			expect(events.at(-1)).toBe('native:click:1');
+			root.unmount();
+		},
+	);
+
 	it('preserves child state, context, and callback indices while map receivers change', () => {
 		const items = [
 			{ id: 1, label: 'first' },

--- a/packages/rspeedy-plugin-octane/src/toolchain-lanes.js
+++ b/packages/rspeedy-plugin-octane/src/toolchain-lanes.js
@@ -1,4 +1,6 @@
 const SHARED_PACKAGES = Object.freeze({
+	'@emnapi/core': '1.11.2',
+	'@emnapi/runtime': '1.11.2',
 	'@lynx-js/cache-events-webpack-plugin': '0.2.0',
 	'@lynx-js/chunk-loading-webpack-plugin': '0.4.1',
 	'@lynx-js/css-extract-webpack-plugin': '0.9.0',
@@ -15,6 +17,7 @@ const SHARED_PACKAGES = Object.freeze({
 	'@lynx-js/webpack-dev-transport': '0.3.0',
 	'@lynx-js/webpack-runtime-globals': '0.0.7',
 	'@lynx-js/websocket': '0.0.4',
+	'@napi-rs/wasm-runtime': '1.1.6',
 	'@rsbuild/core': '2.1.4',
 	'@rsbuild/plugin-css-minimizer': '2.0.0',
 	'@rsdoctor/rspack-plugin': '1.5.18',

--- a/packages/rspeedy-plugin-octane/tests/toolchain.test.ts
+++ b/packages/rspeedy-plugin-octane/tests/toolchain.test.ts
@@ -119,6 +119,11 @@ describe('Milestone 9 Lynx toolchain guard', () => {
 		expect(LYNX_TOOLCHAIN_LANES.current.packages.webpack).toBe(
 			LYNX_TOOLCHAIN_LANES.minimum.packages.webpack,
 		);
+		for (const lane of Object.values(LYNX_TOOLCHAIN_LANES)) {
+			expect(lane.packages['@napi-rs/wasm-runtime']).toBe('1.1.6');
+			expect(lane.packages['@emnapi/core']).toBe('1.11.2');
+			expect(lane.packages['@emnapi/runtime']).toBe('1.11.2');
+		}
 		expect(Object.isFrozen(LYNX_TOOLCHAIN_LANES.current.packages)).toBe(true);
 	});
 

--- a/packages/rspeedy-plugin-octane/types/index.d.ts
+++ b/packages/rspeedy-plugin-octane/types/index.d.ts
@@ -57,6 +57,8 @@ export interface LynxToolchainLane {
 	readonly targetSdk: '3.9';
 	readonly packages: Readonly<
 		Record<
+			| '@emnapi/core'
+			| '@emnapi/runtime'
 			| '@lynx-js/cache-events-webpack-plugin'
 			| '@lynx-js/chunk-loading-webpack-plugin'
 			| '@lynx-js/css-extract-webpack-plugin'
@@ -73,6 +75,7 @@ export interface LynxToolchainLane {
 			| '@lynx-js/webpack-dev-transport'
 			| '@lynx-js/webpack-runtime-globals'
 			| '@lynx-js/websocket'
+			| '@napi-rs/wasm-runtime'
 			| '@rsbuild/core'
 			| '@rsbuild/plugin-css-minimizer'
 			| '@rsdoctor/rspack-plugin'


### PR DESCRIPTION
## Summary

- Bring compiled TSX/JSX keyed-list updates substantially closer to TSRX without assuming an arbitrary `.map` is `Array.prototype.map`.
- Reduce unchanged 1,000-row JSX updates from approximately **0.163 ms to 0.00122 ms** (~**134x faster**) and single-row updates from approximately **0.166 ms to 0.046 ms** (~**3.6x faster**).
- Stack cleanly on #361 at `9a5c0e2d42e0afb486ebd8d8be52ae1f088abb90`, including its scoped JSX, deep-SSR, lazy child-accessor, dynamic-fragment, and i18next compatibility fixes.

## Implementation

- Enable purity and automatic memoization analysis for eligible returned JSX; share TSRX's keyed-list reconciliation and per-item reuse while preserving JSX's normal public descriptor boundary.
- Guard the optimized path to genuine dense native Arrays and the original intrinsic `Array.prototype.map`; evaluate the receiver and method once, then dispatch exotic/custom/overridden/subclass/species/sparse/accessor cases through the original method with its original receiver.
- Preserve callback indices, indexed getters, constructor/`Symbol.species` effects, lexical `this`/`arguments`, context invalidation, server rendering, hydration identity, foreign DOM ownership, and transitions between native and custom receivers.
- Add exhaustive development/production compiler, runtime, server, hydration, and integration regressions, deterministic JSX/TSRX compiled-work assertions, stronger production benchmark ceilings, and an Octane patch changeset.

## Validation

- Focused integrated scoped JSX, exotic maps, directive lowering, deep Fizz, foreign/portal ownership, Docusaurus, i18next, and i18next SSR: **23 files / 865 tests passed**.
- Full integrated suite across `octane`, `octane-prod`, `docusaurus`, `i18next`, and `i18next-ssr`: **790 files / 10,322 tests passed** (`./node_modules/.bin/vitest run --project octane --project octane-prod --project docusaurus --project i18next --project i18next-ssr --reporter=dot`).
- `node node_modules/prettier/bin/prettier.cjs --check .`
- `./node_modules/.bin/tsgo --noEmit -p packages/octane/tsconfig.json`
- `./node_modules/.bin/tsgo --noEmit -p packages/octane/typetests/tsconfig.json`
- `node scripts/check-changesets.js`
- `node scripts/check-test-markers.mjs`
- `node scripts/check-tsrx-module-decls.mjs`
- JSX/TSRX normalized gzip ceilings remain intact: application **2882 / 2402 = 1.19983x < 1.2x**, framework **33820 / 17975 = 1.88153x < 1.9x**, and total **36702 / 20377 = 1.80115x < 1.82x**.
- Fresh production Chromium comparisons pass the tightened JSX/TSRX guards: unchanged **5.17x < 6x** (previous ceiling 600x), one-row change **7.57x < 10x** (previously 32x), context fanout **2.19x < 2.25x** (previously 3x), and mount **1.34x < 1.6x**. Deterministic work checks require just **three JSX descriptors and zero keyed-survivor visits** on unchanged updates, and exactly one row/item body on single-row updates.
- Direct-host SSR remains byte-identical for 1,000 rows: **29,817 raw bytes / 4,865 gzip bytes / exactly two outer markers**, with server node identity retained during hydration and reordering.
- Existing aggregate codegen-size ceiling is already red on the unchanged #361 base: **26,035 / 24,233 = 1.07436x > 1.04x**; this branch measures **26,175 / 24,233 = 1.08014x** (+140 gzip bytes in the JSX corpus, with all 15 TSRX fixtures byte-identical). No existing ceiling was weakened.

## Integration

Depends on #361. Its commits currently appear in this PR while #361 is open; once #361 merges, the comparison collapses to this single focused performance commit. Preserve #361's directive-aware return lowering, lazy scoped descriptors, dynamic fragment classifier/i18next compatibility, and deep-SSR replay behavior when integrating.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core compiler lowering and client/server reconciliation for JSX lists; incorrect guarding or keyed reuse would cause subtle render bugs, though behavior is heavily regression-tested.
> 
> **Overview**
> **Returned JSX keyed lists** now participate in the same purity, whole-list autoMemo, and per-key survivor reuse as TSRX `@for`, while keeping the normal return-descriptor wrapper and JSX children semantics.
> 
> Eligible `{items.map(...)}` lowers through a **guarded** synthetic loop: receiver and `map` are evaluated once, then **`mapSlot`** checks for a dense native `Array.prototype.map` before emitting compiled keyed reconciliation; exotic receivers, sparse arrays, extra arguments, lexical `this`/`arguments` in callbacks, and overridden `map` stay on ordinary dispatch. Return-JSX components get component-local capture analysis so list regions can be memoized; SSR mirrors the same branch via `mapSlot` + `ssrChild`.
> 
> **Runtime** adds client/server `mapSlot`, extends `childSlot` for compiled map bodies (including native↔custom transitions, component rows, hydration adoption), and small scoped-children fixes for providers.
> 
> **Benchmarks/docs:** memo-wall README and `work.mjs` gain `WORK_DIALECT=jsx`; wall-B expectations reflect cached helper output; `ratios.json` tightens JSX vs TSRX ceilings (e.g. equal parent rerender **600→6**). Large **`auto-memo.test.ts`** coverage for maps, hydration, and edge cases. Patch changeset for `octane`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bff72b4ce851ef9924c8765c76b56e6bfd40f24f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->