### PR TITLE
fix: race condition in release.yml Release PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,7 +267,67 @@ jobs:
               );
             }
 
-            const pull = matches[0];
+            let pull = matches[0];
+            let generated;
+            let lastObservedSnapshot = "not fetched";
+            const snapshotAttempts = 8;
+            const snapshotDelayMs = 2_000;
+
+            // changesets/action force-pushes the release branch immediately
+            // before this step. The pull request API can briefly return the
+            // previous head commit, so authenticate a freshly fetched snapshot
+            // and retry only while that snapshot has not converged on this
+            // workflow's main commit.
+            for (let attempt = 1; attempt <= snapshotAttempts; attempt += 1) {
+              const { data: candidate } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: pull.number,
+              });
+              const { data: candidateCommit } =
+                await github.rest.repos.getCommit({
+                  owner,
+                  repo,
+                  ref: candidate.head.sha,
+                });
+              const expectedReleaseCommit =
+                candidateCommit.commit.message === "Version Packages" &&
+                candidateCommit.commit.author?.email ===
+                  "41898282+github-actions[bot]@users.noreply.github.com" &&
+                candidateCommit.commit.committer?.email ===
+                  "41898282+github-actions[bot]@users.noreply.github.com";
+              const basedOnCurrentMain =
+                candidate.base.sha === context.sha &&
+                candidateCommit.parents.length === 1 &&
+                candidateCommit.parents[0].sha === context.sha;
+
+              if (expectedReleaseCommit && basedOnCurrentMain) {
+                pull = candidate;
+                generated = candidateCommit;
+                break;
+              }
+
+              lastObservedSnapshot = [
+                `head ${candidate.head.sha}`,
+                `base ${candidate.base.sha}`,
+                `parent ${candidateCommit.parents[0]?.sha ?? "none"}`,
+              ].join(", ");
+              if (attempt < snapshotAttempts) {
+                core.info(
+                  `Changesets PR #${pull.number} has not converged on ${context.sha} (${lastObservedSnapshot}); retrying snapshot ${attempt + 1}/${snapshotAttempts}.`,
+                );
+                await new Promise((resolve) =>
+                  setTimeout(resolve, snapshotDelayMs),
+                );
+              }
+            }
+
+            if (!generated) {
+              throw new Error(
+                `Changesets PR #${pull.number} is not the expected generated commit based directly on ${context.sha} after ${snapshotAttempts} snapshots; last observed ${lastObservedSnapshot}.`,
+              );
+            }
+
             const releaseFiles = await github.paginate(
               github.rest.pulls.listFiles,
               {
@@ -305,27 +365,6 @@ jobs:
                 .join(", ");
               throw new Error(
                 `Changesets PR #${pull.number} contains unexpected files${sample ? `: ${sample}` : ""}.`,
-              );
-            }
-
-            const { data: generated } = await github.rest.repos.getCommit({
-              owner,
-              repo,
-              ref: pull.head.sha,
-            });
-            const expectedReleaseCommit =
-              generated.commit.message === "Version Packages" &&
-              generated.commit.author?.email ===
-                "41898282+github-actions[bot]@users.noreply.github.com" &&
-              generated.commit.committer?.email ===
-                "41898282+github-actions[bot]@users.noreply.github.com";
-            const basedOnCurrentMain =
-              pull.base.sha === context.sha &&
-              generated.parents.length === 1 &&
-              generated.parents[0].sha === context.sha;
-            if (!expectedReleaseCommit || !basedOnCurrentMain) {
-              throw new Error(
-                `Changesets PR #${pull.number} is not the expected generated commit based directly on ${context.sha}.`,
               );
             }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only change to release PR check recording; reduces flakiness without altering application or release artifact logic.
> 
> **Overview**
> Fixes a **race in `release.yml`** where the "Record lightweight release pull request checks" step could read a **stale PR head** right after `changesets/action` force-pushes the release branch.
> 
> Instead of a single `pulls.get` + `repos.getCommit` validation, the step **re-fetches the PR and head commit up to 8 times** (2s apart) until the head is a **"Version Packages"** bot commit whose **sole parent is `context.sha`** and the PR **base matches that SHA**. File-list checks and check creation run only after that snapshot converges; failure messages include the **last observed head/base/parent**. The duplicate post-file-list commit validation was **removed** because it now happens inside the retry loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9b00f27aef74d9ffe9889d42f0f8b0e3ffe9bd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->