### PR TITLE
feat(app-core): expose the request context to server functions

### DIFF
--- a/.changeset/rpc-request-context.md
+++ b/.changeset/rpc-request-context.md
@@ -1,0 +1,42 @@
+---
+'@octanejs/app-core': patch
+---
+
+Give `module server` functions access to the request they are serving, via
+`getRequestContext()` and `tryGetRequestContext()`.
+
+The RPC boundary built a full `Context` for every request and handed it to the
+middleware chain, but the request store it ran the handler inside carried only
+`origin` and `platform`. A server function could therefore not read the headers,
+cookies, or middleware `state` for its own request, so the identity of the caller
+had to arrive as an argument from the browser, which is exactly the value a
+mutation must not trust. Render routes already received middleware state through
+`RenderRouteProps.state`; server functions now have the equivalent.
+
+```tsx
+module server {
+  import { getRequestContext } from '@octanejs/app-core';
+
+  export async function deletePost(id: string) {
+    const { state } = getRequestContext();
+    const user = state.get('user');
+    if (!user) throw new Error('Not signed in');
+    await db.posts.delete(id, user.id);
+  }
+}
+```
+
+The returned `Context` is the same instance the middleware chain observed,
+including its `state` mutations. `context.request.body` is already consumed by
+the time a server function runs, since the boundary reads it under the configured
+size limit before dispatching, so `bodyUsed` is `true`; headers, cookies, and
+`url` are unaffected. `getRequestContext()` throws outside a request because that
+is a programmer error, and `tryGetRequestContext()` returns `null` for code that
+has to run in both places.
+
+The active async context is published on a `Symbol.for` global, matching the
+existing fetch coordinator, so the accessor resolves the live store even though a
+server function is loaded through a separate module graph in dev and through the
+server manifest in production. Dev and production share the one boundary, so both
+behave identically. This does not yet cover SSR render routes, which never enter
+the request async context.

--- a/packages/app-core/src/index.js
+++ b/packages/app-core/src/index.js
@@ -17,3 +17,4 @@ export {
 	runMiddlewareChain,
 } from './middleware.js';
 export { handleRpcRequest } from './server/rpc.js';
+export { getRequestContext, tryGetRequestContext } from './server/request-context.js';

--- a/packages/app-core/src/server/request-context.js
+++ b/packages/app-core/src/server/request-context.js
@@ -1,0 +1,72 @@
+// @ts-check
+/**
+ * Request-scoped context lookup for `module server` functions.
+ *
+ * A server function is loaded through the SSR module graph in dev and through
+ * the server manifest in production, so the `@octanejs/app-core` instance it
+ * imports is not necessarily the one that handled the request. The active async
+ * context is therefore published on a `Symbol.for` global, the same technique
+ * the fetch coordinator uses, so every evaluated copy resolves the one live
+ * store.
+ *
+ * The holder tracks one boundary, which is what a process has: dev serves RPC
+ * through the plugin's single async context and production through the single
+ * fetch coordinator. A process running two boundaries concurrently would see the
+ * later registration win, and a server function under the earlier one reports no
+ * request rather than the wrong one.
+ */
+
+/**
+ * @typedef {import('@octanejs/app-core').Context} Context
+ * @typedef {import('@ripple-ts/adapter/rpc').AsyncContext<{ origin?: string, platform?: unknown, context?: Context }>} RequestAsyncContext
+ * @typedef {{ asyncContext: RequestAsyncContext }} RequestContextHolder
+ */
+
+const REQUEST_CONTEXT_KEY = Symbol.for('octane.app-core.request-context');
+
+const globals =
+	/** @type {typeof globalThis & { [REQUEST_CONTEXT_KEY]?: RequestContextHolder }} */ (globalThis);
+
+/**
+ * Publish the async context a request boundary runs its handler inside. Called
+ * per request from `handleRpcRequest` rather than once at construction so any
+ * embedder of that boundary is covered without a second registration step; the
+ * identity check keeps the steady state a read.
+ *
+ * @param {RequestAsyncContext} asyncContext
+ * @returns {void}
+ */
+export function setRequestContextSource(asyncContext) {
+	const current = globals[REQUEST_CONTEXT_KEY];
+	if (current === undefined) {
+		globals[REQUEST_CONTEXT_KEY] = { asyncContext };
+	} else if (current.asyncContext !== asyncContext) {
+		current.asyncContext = asyncContext;
+	}
+}
+
+/**
+ * The `Context` for the in-flight request, or `null` when there is none.
+ *
+ * @returns {Context | null}
+ */
+export function tryGetRequestContext() {
+	return globals[REQUEST_CONTEXT_KEY]?.asyncContext.getStore()?.context ?? null;
+}
+
+/**
+ * The `Context` for the in-flight request.
+ *
+ * @returns {Context}
+ */
+export function getRequestContext() {
+	const context = tryGetRequestContext();
+	if (context === null) {
+		throw new Error(
+			'[octane] getRequestContext() was called outside of a request. It is available inside ' +
+				'`module server` functions and the middleware chain that runs them. Use ' +
+				'tryGetRequestContext() for code that must also run outside a request.',
+		);
+	}
+	return context;
+}

--- a/packages/app-core/src/server/rpc.js
+++ b/packages/app-core/src/server/rpc.js
@@ -12,6 +12,7 @@ import { derive_origin } from '@ripple-ts/adapter/rpc';
 
 import { DEFAULT_RPC_MAX_BODY_BYTES } from '../constants.js';
 import { createContext, runMiddlewareChain } from './middleware.js';
+import { setRequestContextSource } from './request-context.js';
 
 const RPC_PATH_PREFIX = '/_$_ripple_rpc_$_/';
 
@@ -213,8 +214,14 @@ export async function handleRpcRequest(request, options) {
 	const corsOrigin = browserOrigin === origin ? null : browserOrigin;
 
 	const context = createContext(request, {}, options.platform);
+	// `context` rides the request store so a server function can read what the
+	// middleware chain established (auth, tenant) instead of trusting arguments
+	// the browser sent. The body is already consumed by the time it runs.
 	const store =
-		options.platform === undefined ? { origin } : { origin, platform: options.platform };
+		options.platform === undefined
+			? { origin, context }
+			: { origin, platform: options.platform, context };
+	setRequestContextSource(options.asyncContext);
 
 	try {
 		const response = await options.asyncContext.run(store, async () =>

--- a/packages/app-core/tests/rpc.test.ts
+++ b/packages/app-core/tests/rpc.test.ts
@@ -3,11 +3,13 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Context, Middleware } from '@octanejs/app-core';
 import { createHandler } from '../src/server/production.js';
+import { getRequestContext, tryGetRequestContext } from '../src/server/request-context.js';
 
 const TEMPLATE = `<!doctype html>
 <html><head><!--ssr-head--></head><body><div id="root"><!--ssr-body--></div>
 <script type="module" data-octane-hydrate src="/assets/hydrate.js"></script></body></html>`;
 const FETCH_COORDINATOR_KEY = Symbol.for('octane.app-core.fetch-coordinator');
+const REQUEST_CONTEXT_KEY = Symbol.for('octane.app-core.request-context');
 const originalFetch = globalThis.fetch;
 
 interface RpcTestOptions {
@@ -95,6 +97,7 @@ function rpcPreflight(origin: string, options: { method?: string; requestHeaders
 afterEach(() => {
 	globalThis.fetch = originalFetch;
 	delete (globalThis as typeof globalThis & Record<symbol, unknown>)[FETCH_COORDINATOR_KEY];
+	delete (globalThis as typeof globalThis & Record<symbol, unknown>)[REQUEST_CONTEXT_KEY];
 	vi.restoreAllMocks();
 });
 
@@ -423,6 +426,59 @@ describe('server-function HTTP security', () => {
 		expect(observedState).toBe(platform);
 		expect(action).toHaveBeenCalledOnce();
 		await expect(response.json()).resolves.toEqual({ value: platform });
+	});
+
+	it('gives a server action the same context instance its middleware saw', async () => {
+		let contextFromMiddleware: Context | undefined;
+		let contextFromAction: Context | undefined;
+		const middleware: Middleware = async (context, next) => {
+			context.state.set('user', { id: 'u1' });
+			contextFromMiddleware = context;
+			return next();
+		};
+		const { action, handler } = createRpcHandler({
+			middlewares: [middleware],
+			action: () => {
+				contextFromAction = getRequestContext();
+				return contextFromAction.state.get('user');
+			},
+		});
+		const response = await handler(rpcRequest());
+
+		expect(response.status).toBe(200);
+		expect(action).toHaveBeenCalledOnce();
+		await expect(response.json()).resolves.toEqual({ value: { id: 'u1' } });
+		expect(contextFromAction).toBe(contextFromMiddleware);
+	});
+
+	it('exposes the request headers but a consumed body to a server action', async () => {
+		let cookie: string | null = null;
+		let bodyUsed: boolean | undefined;
+		const { handler } = createRpcHandler({
+			action: () => {
+				const { request } = getRequestContext();
+				cookie = request.headers.get('cookie');
+				bodyUsed = request.bodyUsed;
+				return 'ok';
+			},
+		});
+		const response = await handler(rpcRequest({ headers: { Cookie: 'session=abc' } }));
+
+		expect(response.status).toBe(200);
+		expect(cookie).toBe('session=abc');
+		expect(bodyUsed).toBe(true);
+	});
+
+	it('reports no request context outside of a request', () => {
+		expect(tryGetRequestContext()).toBeNull();
+		expect(() => getRequestContext()).toThrow(/outside of a request/);
+	});
+
+	it('does not leak a request context after the response settles', async () => {
+		const { handler } = createRpcHandler();
+		await handler(rpcRequest());
+
+		expect(tryGetRequestContext()).toBeNull();
 	});
 
 	it('does not disclose server-action exception messages', async () => {

--- a/packages/app-core/types/index.d.ts
+++ b/packages/app-core/types/index.d.ts
@@ -143,7 +143,7 @@ export function is_rpc_request(pathname: string): boolean;
 export interface RpcRequestOptions {
 	resolveFunction: (hash: string) => Function | null | Promise<Function | null>;
 	executeServerFunction: (fn: Function, body: string) => Promise<string>;
-	asyncContext: AsyncContext<{ origin?: string; platform?: unknown }>;
+	asyncContext: AsyncContext<{ origin?: string; platform?: unknown; context?: Context }>;
 	trustProxy?: boolean;
 	middlewares?: Middleware[];
 	allowedOrigins?: readonly string[];
@@ -153,6 +153,26 @@ export interface RpcRequestOptions {
 
 /** Apply Octane's security policy and global middleware to a server function. */
 export function handleRpcRequest(request: Request, options: RpcRequestOptions): Promise<Response>;
+
+/**
+ * The `Context` for the in-flight request.
+ *
+ * Available inside a `module server` function and inside the middleware chain
+ * that runs it, so a server function can read the identity its middleware
+ * established rather than trusting an argument the browser supplied. It is the
+ * same `Context` instance the middleware saw, including `state` mutations.
+ *
+ * `context.request.body` is already consumed on the RPC path (the boundary
+ * reads it under the configured size limit before dispatching), so
+ * `bodyUsed` is `true`; headers, cookies, and `url` are unaffected.
+ *
+ * Throws outside a request. Use {@link tryGetRequestContext} in code that must
+ * also run outside one.
+ */
+export function getRequestContext(): Context;
+
+/** {@link getRequestContext}, returning `null` outside a request instead of throwing. */
+export function tryGetRequestContext(): Context | null;
 
 // ============================================================================
 // Configuration


### PR DESCRIPTION
## Summary

- `module server` functions can now read the request they are serving, via `getRequestContext()` / `tryGetRequestContext()` from `@octanejs/app-core`.

## Why

`handleRpcRequest` built a full `Context` for every request and handed it to the middleware chain, but the store it ran the handler inside carried only `origin` and `platform`. A server function could therefore not read the headers, cookies, or middleware `state` for its own request, so the caller's identity had to arrive as an argument from the browser, which is exactly the value a mutation must not trust. Render routes already got middleware state through `RenderRouteProps.state`; server functions now have the equivalent.

```tsx
module server {
  import { getRequestContext } from '@octanejs/app-core';

  export async function deletePost(id: string) {
    const { state } = getRequestContext();
    const user = state.get('user');
    if (!user) throw new Error('Not signed in');
    await db.posts.delete(id, user.id);
  }
}
```

## Changes

- `handleRpcRequest` puts `context` on the request store, next to `origin`/`platform`.
- New `src/server/request-context.js` with the two accessors. The active async context is published on a `Symbol.for` global, matching the existing fetch coordinator, because a server function resolves its own `@octanejs/app-core` instance through Vite's SSR module graph in dev and through the server manifest in production, so a module-level variable would be the wrong copy. Registration happens in `handleRpcRequest` rather than at handler construction so any embedder of that boundary is covered by one call site; the steady-state cost is a global read and an identity compare.
- Types + public export, changeset.

## Gotchas

- `context.request.body` is already consumed by the time a server function runs, since the boundary reads it under the configured size limit before dispatching. `bodyUsed` is `true`; headers, cookies, and `url` are fine. Documented on the type and pinned by a test.
- `getRequestContext()` throws outside a request (programmer error); `tryGetRequestContext()` returns `null`.
- The holder tracks one boundary, which is what a process has. Two concurrent boundaries would let the later registration win, and a server function under the earlier one reports no request rather than the wrong one. Noted in the module comment.
- Dev and production share the one boundary, so both behave identically. No compiler or client-bundle change: imports inside a `module server` block are already server-only.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 15623 passed, 1 unrelated flake (`octane-events-browser` native-change hit a Vite 504 "Outdated Optimize Dep" under the parallel run; passes in isolation, 12/12)
- [x] targeted: `packages/app-core` 87 passed
- [x] regression proof: reverting just the store change fails the two new behavioral tests and nothing else

## Risk / follow-ups

- Does not cover SSR render routes: they never enter the request async context at all (`asyncContext.run` has exactly one call site, in `rpc.js`). Wrapping the render path is a separate change that also fixes the same-origin fetch short-circuit losing its store during SSR.
- Next in this series: per-function authorization (`Context.rpc` + a cheap `describeFunction`, so middleware knows which function it is guarding and an unauthorized request never loads the target module), and the 32-bit RPC id collision guard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the RPC security boundary and how request identity is established; misuse could still trust client args, but the change is narrowly scoped to RPC with tests and documented body/consumption limits.
> 
> **Overview**
> **`module server` functions can now read the in-flight request** via `getRequestContext()` and `tryGetRequestContext()` from `@octanejs/app-core`, so auth/tenant identity from middleware `state`, headers, and cookies no longer has to be passed as trusted client arguments.
> 
> The RPC handler puts the same **`Context` instance** middleware already uses onto the async request store and registers that store through a **`Symbol.for` global** (same approach as the fetch coordinator), so server functions loaded via a separate dev SSR graph or production manifest still resolve the live context. **`context.request.body` is already consumed** when the action runs; headers and `bodyUsed` behavior are covered by new tests.
> 
> SSR render routes are **unchanged**—they still do not enter this async context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff0dd6ea4a7cb204e46c22854a61e62e18ca6ee8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->