### PR TITLE
feat: add opt-in Strong mode compiler checks

### DIFF
--- a/.changeset/strong-mode.md
+++ b/.changeset/strong-mode.md
@@ -1,0 +1,14 @@
+---
+'octane': patch
+'@octanejs/app-core': patch
+'@octanejs/vite-plugin': patch
+'@octanejs/rspack-plugin': patch
+'@octanejs/rsbuild-plugin': patch
+---
+
+Add optional Strong mode for clearer state and ref behavior. Enable it across an
+application with `compiler: { strong: true }`, in one module with `"use strong"`,
+or through the Vite, Rspack, and Rsbuild plugin options. Strong modules reject
+state updates during render, direct state updates while setting up an effect, and
+render-time writes to refs, with `useLinkedState` available for state that
+should follow another value.

--- a/README.md
+++ b/README.md
@@ -527,6 +527,63 @@ receive `{ source, value }`. Sources and values use `Object.is` by default. Pass
 comparisons. Like `useState`, `useLinkedState` also supports an optional third
 tuple item, `getValue`, for reading the latest value from a delayed callback.
 
+### Strong mode
+
+Strong mode is an optional compiler check for state and refs. Start with one
+module by placing `"use strong"` before its imports:
+
+```tsx
+"use strong";
+
+import { useLinkedState } from 'octane';
+
+export function ProfileEditor({ user }) {
+  const [name, setName] = useLinkedState(user.id, () => user.name);
+
+  return <input value={name} onInput={(event) => setName(event.currentTarget.value)} />;
+}
+```
+
+When the project is ready, enable it for all application-owned modules:
+
+```ts
+// octane.config.ts
+export default {
+  compiler: {
+    strong: true,
+  },
+};
+```
+
+The Vite and Rsbuild app integrations read this setting from `octane.config.ts`.
+Vite, Rspack, and Rsbuild also accept `strong: true` directly in their Octane
+plugin options; use the plugin option for a standalone Rspack setup. An
+explicit plugin setting takes precedence over `octane.config.ts`. Dependencies
+keep their existing behavior unless one of their own modules opts in with
+`"use strong"`.
+
+Strong mode reports three patterns as compile errors:
+
+- Calling a `useState`, `useReducer`, or `useLinkedState` updater during render.
+- Calling one of those updaters directly while an effect is being set up.
+- Assigning to a `useRef` object's `current` value during render.
+
+Update state in event handlers instead. When state should reset or adjust after
+an input changes, use `useLinkedState`. Effects that connect to external systems
+and refs used for DOM elements, timers, or event callbacks remain valid. Strong
+mode does not restrict `Date.now()`, `Math.random()`, or similar values.
+
+`"use strong"` only affects the current module. Put it at the top of the file,
+before imports or other code; comments and other directives may come first. In
+files that also use an Octane JSX ownership pragma, keep the pragma first:
+
+```tsx
+/** @jsxImportSource octane */
+"use strong";
+
+import { useState } from 'octane';
+```
+
 ### Conditional hooks
 
 Unlike React, a hook can sit behind a guard or after an early `return`:

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -268,6 +268,27 @@ so it can preserve useful parts of the old value. `sourceEqual` and `valueEqual`
 default to `Object.is`; pass custom comparators as an optional third argument.
 The tuple also supports the same optional latest-value getter as `useState`.
 
+## Optional Strong mode
+
+Strong mode adds compile-time checks for patterns that make rendering harder to
+reason about. Opt into one module with a directive before its imports:
+
+```tsx
+"use strong";
+
+import { useLinkedState } from 'octane';
+```
+
+Alternatively, enable it across application-owned modules with
+`compiler: { strong: true }` in `octane.config.ts`. Installed dependencies stay
+in compatibility mode unless their own source opts in.
+
+A Strong module cannot call a state updater during render or directly while
+setting up an effect, and it cannot assign to `ref.current` during render.
+Event handlers, effects that synchronize an external system, and normal DOM or
+timer refs remain supported. Replace prop-driven state resets with
+`useLinkedState` instead of calling a setter during render.
+
 ## JSX values follow the represented render scope
 
 Moving compiler-authored JSX into a variable, prop, array, or other value

--- a/packages/app-core/src/resolve-config.js
+++ b/packages/app-core/src/resolve-config.js
@@ -174,6 +174,9 @@ export function resolveOctaneConfig(raw, options = {}) {
 	) {
 		throw new Error('[octane] compiler must be an object when provided.');
 	}
+	if (raw.compiler?.strong !== undefined && typeof raw.compiler.strong !== 'boolean') {
+		throw new Error('[octane] compiler.strong must be a boolean when provided.');
+	}
 
 	if (raw.router?.routes !== undefined && !Array.isArray(raw.router.routes)) {
 		throw new Error('[octane] router.routes must be an array.');
@@ -232,6 +235,7 @@ export function resolveOctaneConfig(raw, options = {}) {
 		},
 		adapter: raw.adapter,
 		compiler: {
+			strong: raw.compiler?.strong ?? false,
 			renderers: normalizeRendererConfig(raw.compiler?.renderers),
 		},
 		router: {

--- a/packages/app-core/tests/config.test.ts
+++ b/packages/app-core/tests/config.test.ts
@@ -2,6 +2,29 @@
 import { describe, expect, it } from 'vitest';
 import { resolveOctaneConfig } from '../src/config.js';
 
+describe('Strong mode configuration', () => {
+	it('keeps Strong mode opt-in by default', () => {
+		expect(resolveOctaneConfig({}).compiler.strong).toBe(false);
+	});
+
+	it.each([true, false])('preserves compiler.strong=%s', (strong) => {
+		const config = resolveOctaneConfig({ compiler: { strong } });
+		expect(config.compiler.strong).toBe(strong);
+		expect(resolveOctaneConfig(config).compiler.strong).toBe(strong);
+	});
+
+	it.each(['true', 1, null, {}])('rejects non-boolean compiler.strong=%j', (strong) => {
+		expect(() =>
+			resolveOctaneConfig({
+				compiler: {
+					// @ts-expect-error JavaScript configuration still receives runtime validation.
+					strong,
+				},
+			}),
+		).toThrow('[octane] compiler.strong must be a boolean when provided.');
+	});
+});
+
 describe('adapter server targets', () => {
 	it('accepts the node server target without custom runtime primitives', () => {
 		const adapter = { serverTarget: 'node' as const };

--- a/packages/app-core/types/index.d.ts
+++ b/packages/app-core/types/index.d.ts
@@ -326,6 +326,8 @@ export interface OctaneConfigOptions {
 	adapter?: OctaneAdapter;
 	/** @experimental Compiler-owned configuration shared by all bundler integrations. */
 	compiler?: {
+		/** Reject unsafe state updates and ref writes in application-owned modules. @default false */
+		strong?: boolean;
 		renderers?: ExperimentalRendererConfigOptions;
 	};
 	router?: {
@@ -385,6 +387,8 @@ export interface ResolvedOctaneConfig {
 	};
 	adapter?: OctaneAdapter;
 	compiler: {
+		/** @default false */
+		strong: boolean;
 		renderers: ExperimentalResolvedRendererConfig;
 	};
 	router: {

--- a/packages/octane/src/compiler/bundler.js
+++ b/packages/octane/src/compiler/bundler.js
@@ -31,6 +31,7 @@ import { findLeadingJsxImportSourcePragma } from './pragma.js';
 import { normalizeUniversalRuntime } from './universal-runtime.js';
 import { formatCompileDiagnostic } from './native-change-diagnostics.js';
 import { findVoidComponentImports, findVoidRootImports, slotHooks } from './slot-hooks.js';
+import { assertStrongMode } from './strong-mode.js';
 import {
 	assertNoLiveClientOnlyImports,
 	createClientOnlyServerStub,
@@ -306,6 +307,9 @@ export function findVoidComponentExports(source, id) {
 
 class OctaneBundlerCompiler {
 	constructor(options) {
+		if (options.strong !== undefined && typeof options.strong !== 'boolean') {
+			throw new TypeError('Octane compiler `strong` must be a boolean when provided.');
+		}
 		this.root = nodePath.resolve(options.root ?? process.cwd());
 		try {
 			this.realRoot = nodeFs.realpathSync(this.root);
@@ -318,6 +322,7 @@ class OctaneBundlerCompiler {
 			hmr: normalizeHmrDialect(options.hmr),
 			dev: options.dev,
 			profile: options.profile === true,
+			strong: options.strong === true,
 			universalRuntime: normalizeUniversalRuntime(options.universalRuntime),
 		};
 		this.renderers = normalizeRendererConfig(options.renderers);
@@ -447,6 +452,22 @@ class OctaneBundlerCompiler {
 			: nodePath.resolve(this.root, file);
 		if (/(?:^|[\\/])node_modules(?:[\\/]|$)/.test(absoluteFile)) return false;
 		return isPathInside(this.root, absoluteFile) || isPathInside(this.realRoot, absoluteFile);
+	}
+
+	_hasApplicationStrongPolicy(file, collected) {
+		if (!this._isProjectOwnedSource(file)) return false;
+		const absoluteFile = nodePath.isAbsolute(file)
+			? nodePath.resolve(file)
+			: nodePath.resolve(this.root, file);
+		const application = this._nearestOctanePackageRule(this.root);
+		const source = this._nearestOctanePackageRule(nodePath.dirname(absoluteFile));
+		addMetadata(collected, application);
+		addMetadata(collected, source);
+		return (
+			application.rule === null ||
+			source.rule === null ||
+			application.rule.root === source.rule.root
+		);
 	}
 
 	_isInstalledOctaneSource(file, collected) {
@@ -816,6 +837,13 @@ class OctaneBundlerCompiler {
 		// of both HMR and dev hydration diagnostics. Server transforms stay byte-for-
 		// byte identical even when a shared client/server bundler configuration opts in.
 		const profile = environment === 'client' && (options.profile ?? this.defaults.profile) === true;
+		// An application's global policy never leaks into installed or linked
+		// compatibility packages, including workspace packages nested inside the
+		// project root. Modules may still opt themselves in with their own
+		// directive, which the authored-source compiler resolves separately.
+		const strong =
+			(options.strong ?? this.defaults.strong) === true &&
+			this._hasApplicationStrongPolicy(file, collected);
 		const universalRuntime = normalizeUniversalRuntime(
 			options.universalRuntime ?? this.defaults.universalRuntime,
 		);
@@ -892,6 +920,7 @@ class OctaneBundlerCompiler {
 				dev,
 				profile,
 				profileFilename,
+				...(strong ? { strong: true } : null),
 				...(universalRuntime === undefined ? null : { universalRuntime }),
 				// Keep the established DOM compiler call byte-for-byte equivalent. A
 				// renderer descriptor is an orthogonal compiler input only for the
@@ -971,6 +1000,14 @@ class OctaneBundlerCompiler {
 				return this._passThrough(code, collected);
 			}
 			if (this._hasManualHookSlots(file, collected)) {
+				// Hand-slotted bindings still own their authored policy. Opting one
+				// module in must not require changing its established slot ABI.
+				if (strong || code.includes('use strong')) {
+					const authoredSource = code;
+					assertStrongMode(parseModule(authoredSource, filename), authoredSource, filename, {
+						strong,
+					});
+				}
 				return this._passThrough(code, collected);
 			}
 			const profileFilename = profile ? this._profileModuleId(file, collected) : undefined;
@@ -981,6 +1018,7 @@ class OctaneBundlerCompiler {
 				hmr: !!hmr,
 				profile,
 				profileFilename,
+				...(strong ? { strong: true } : null),
 				...(specializeVoidRoot
 					? {
 							isVoidComponentImport: options.isVoidComponentImport,

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -56,6 +56,7 @@ import {
 import { assertNoLiveClientOnlyImports } from './client-only-server.js';
 import { nsForChildren, nsForSelf } from './jsx-namespace.js';
 import { analyzeNativeChangeDiagnostics } from './native-change-diagnostics.js';
+import { assertStrongMode } from './strong-mode.js';
 import { assertUniversalRuntimeTarget, normalizeUniversalRuntime } from './universal-runtime.js';
 
 // DOM truth tables shared with the client/server runtimes (via constants.ts) —
@@ -5653,7 +5654,7 @@ function instrumentProfileComponents(ast, ctx) {
  * Compile a .tsrx source string into JS targeting `octane`.
  * @param {string} source
  * @param {string} filename
- * @param {{ hmr?: boolean | 'vite' | 'webpack', mode?: 'client' | 'server', dev?: boolean, profile?: boolean, profileFilename?: string, autoMemo?: boolean, inlineHookMemo?: boolean, dataCallbackHooks?: readonly string[], renderer?: { id: string, module: string, target: 'dom' | 'universal', server?: string }, rendererBoundaries?: Readonly<Record<string, Readonly<Record<string, { ownerRenderer: string, childRenderer: string, prop: string, server?: string }>>>>, rendererRegistry?: Readonly<Record<string, { module: string, target: 'dom' | 'universal', server?: string }>>, clientOnlyImports?: readonly unknown[], __hydratePrepared?: boolean, __hydrateBoundaryModule?: boolean, __nativeChangeDiagnostics?: readonly unknown[], __nativeChangeAnalysis?: { diagnostics: readonly unknown[], classifications: Map<number, string> } }} [options] —
+ * @param {{ hmr?: boolean | 'vite' | 'webpack', mode?: 'client' | 'server', dev?: boolean, strong?: boolean, profile?: boolean, profileFilename?: string, autoMemo?: boolean, inlineHookMemo?: boolean, dataCallbackHooks?: readonly string[], renderer?: { id: string, module: string, target: 'dom' | 'universal', server?: string }, rendererBoundaries?: Readonly<Record<string, Readonly<Record<string, { ownerRenderer: string, childRenderer: string, prop: string, server?: string }>>>>, rendererRegistry?: Readonly<Record<string, { module: string, target: 'dom' | 'universal', server?: string }>>, clientOnlyImports?: readonly unknown[], __hydratePrepared?: boolean, __hydrateBoundaryModule?: boolean, __nativeChangeDiagnostics?: readonly unknown[], __nativeChangeAnalysis?: { diagnostics: readonly unknown[], classifications: Map<number, string> } }} [options] —
  *   `dev: true` emits client hydration source-location metadata (per-component
  *   `__s.locs`/`__s.locFile`) and, in server mode, source-located native-element
  *   scopes for invalid HTML nesting diagnostics. Both are strictly gated so
@@ -5705,6 +5706,7 @@ function compileAuthored(source, filename, options, bundlerMetadata) {
 	const analyzedAst = parseModule(source, cleanFilename);
 	analyzeTsrx(analyzedAst, cleanFilename);
 	adoptParserAst(analyzedAst);
+	assertStrongMode(analyzedAst, source, cleanFilename, options);
 	if (bundlerMetadata !== null) bundlerMetadata.hydrateAst = analyzedAst;
 	return compileInternal(source, filename, options, analyzedAst, mode, bundlerMetadata);
 }

--- a/packages/octane/src/compiler/slot-hooks.js
+++ b/packages/octane/src/compiler/slot-hooks.js
@@ -17,6 +17,7 @@
 import { parseModule } from '@tsrx/core';
 import { HOOK_NAMES, hookSlotHash } from './compile.js';
 import { annotateHookCalls } from './hook-deps.js';
+import { assertStrongMode } from './strong-mode.js';
 
 // Build a cheap import-presence gate. Precise call identity is annotated by the
 // lexical scope analysis in analyzeHookDependencies below; this gate only avoids
@@ -990,7 +991,7 @@ function walk(node, owner, st) {
  *
  * @param {string} source raw module text
  * @param {string} id     module id (embedded in the stable Symbol.for key)
- * @param {{ environment?: 'client' | 'server', hmr?: boolean, profile?: boolean, profileFilename?: string, isVoidComponentImport?: (request: string, imported: string) => boolean }} [options] `hmr: true` (dev serve) emits
+ * @param {{ environment?: 'client' | 'server', strong?: boolean, hmr?: boolean, profile?: boolean, profileFilename?: string, isVoidComponentImport?: (request: string, imported: string) => boolean }} [options] `hmr: true` (dev serve) emits
  *   `Symbol.for(stableKey)` so a re-imported module resolves the same hook
  *   slots (state survives HMR); off (ordinary prod builds and SSR) emits
  *   runtime-ranged Symbols. Profiling retains short described Symbols because
@@ -1010,6 +1011,7 @@ export function slotHooks(source, id, options) {
 	} catch {
 		return null; // let the normal pipeline surface the parse error
 	}
+	assertStrongMode(ast, source, id, options);
 	const importInfo = octaneHookLocals(ast);
 	const canSpecializeRoot =
 		!options?.hmr &&

--- a/packages/octane/src/compiler/strong-mode.js
+++ b/packages/octane/src/compiler/strong-mode.js
@@ -401,6 +401,24 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		}
 	}
 
+	function switchCaseAlwaysAwaits(cases, start) {
+		for (let index = start; index < cases.length; index++) {
+			for (const statement of cases[index].consequent ?? []) {
+				if (doWhileSynchronousControl(statement) !== 0) return false;
+				if (statementAlwaysAwaits(statement)) return true;
+				if (
+					statement.type === 'BreakStatement' ||
+					statement.type === 'ContinueStatement' ||
+					statement.type === 'ReturnStatement' ||
+					statement.type === 'ThrowStatement'
+				) {
+					return false;
+				}
+			}
+		}
+		return false;
+	}
+
 	function statementAlwaysAwaits(statement) {
 		switch (statement?.type) {
 			case 'ExpressionStatement':
@@ -436,7 +454,31 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			case 'WhileStatement':
 				return alwaysAwaits(statement.test);
 			case 'LabeledStatement':
-				return statement.body?.type === 'DoWhileStatement' && statementAlwaysAwaits(statement.body);
+				return (
+					statementAlwaysAwaits(statement.body) &&
+					(statement.body?.type === 'DoWhileStatement' ||
+						doWhileSynchronousControl(statement.body) === 0)
+				);
+			case 'SwitchStatement': {
+				if (alwaysAwaits(statement.discriminant)) return true;
+				const cases = statement.cases ?? [];
+				if (!cases.some((branch) => branch.test == null)) {
+					return alwaysAwaits(cases[0]?.test);
+				}
+				let searchAwaits = false;
+				const fallbackAwaits = cases.some((branch) => alwaysAwaits(branch.test));
+				for (let index = 0; index < cases.length; index++) {
+					const branch = cases[index];
+					if (branch.test != null && alwaysAwaits(branch.test)) searchAwaits = true;
+					if (
+						!(branch.test == null ? fallbackAwaits : searchAwaits) &&
+						!switchCaseAlwaysAwaits(cases, index)
+					) {
+						return false;
+					}
+				}
+				return true;
+			}
 			case 'DoWhileStatement': {
 				const control = doWhileSynchronousControl(statement.body);
 				const bodyAwaits = statementAlwaysAwaits(statement.body) && control === 0;
@@ -549,15 +591,20 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		}
 	}
 
-	function visitEffectCallback(value, scope) {
+	function visitSynchronousHookCallback(value, scope, phase) {
 		const callback = unwrap(value);
 		if (FUNCTION_TYPES.has(callback?.type)) {
-			visitCallback(callback, scope, 'effect');
+			visitCallback(callback, scope, phase);
+			return true;
 		} else if (callback?.type === 'Identifier') {
 			const binding = resolve(scope, callback.name);
-			if (binding?.kind === 'callback') visitCallback(binding.node, binding.scope, 'effect');
-			else if (binding?.kind === 'setter') reportSetter(callback, 'effect');
+			if (binding?.kind === 'callback') visitCallback(binding.node, binding.scope, phase);
+			else if (binding?.kind === 'setter' && (phase === 'render' || phase === 'effect')) {
+				reportSetter(callback, phase);
+			}
+			return true;
 		}
+		return false;
 	}
 
 	function visit(node, scope, phase) {
@@ -606,6 +653,52 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				visit(node.alternate, scope, branchPhase);
 				return;
 			}
+			case 'LabeledStatement':
+				visit(node.body, scope, phase);
+				return;
+			case 'SwitchStatement': {
+				visit(node.discriminant, scope, phase);
+				const initialPhase =
+					currentFunctionIsAsync && phase !== 'deferred' && alwaysAwaits(node.discriminant)
+						? 'deferred'
+						: phase;
+				const branches = node.cases ?? [];
+				const switchScope = createScope(scope, 'block');
+				for (const branch of branches) predeclareStatements(branch.consequent, switchScope);
+
+				let searchPhase = initialPhase;
+				for (const branch of branches) {
+					visit(branch.test, switchScope, searchPhase);
+					if (currentFunctionIsAsync && searchPhase !== 'deferred' && alwaysAwaits(branch.test)) {
+						searchPhase = 'deferred';
+					}
+				}
+
+				const fallbackPhase = searchPhase;
+				searchPhase = initialPhase;
+				let fallthroughPhase = null;
+				for (const branch of branches) {
+					if (currentFunctionIsAsync && searchPhase !== 'deferred' && alwaysAwaits(branch.test)) {
+						searchPhase = 'deferred';
+					}
+					const matchingPhase = branch.test == null ? fallbackPhase : searchPhase;
+					const branchPhase =
+						matchingPhase === 'deferred' &&
+						(fallthroughPhase == null || fallthroughPhase === 'deferred')
+							? 'deferred'
+							: phase;
+					const executionPhase = visitStatements(branch.consequent, switchScope, branchPhase);
+					const last = branch.consequent?.[branch.consequent.length - 1];
+					fallthroughPhase =
+						last?.type === 'BreakStatement' ||
+						last?.type === 'ContinueStatement' ||
+						last?.type === 'ReturnStatement' ||
+						last?.type === 'ThrowStatement'
+							? null
+							: executionPhase;
+				}
+				return;
+			}
 			case 'VariableDeclaration':
 				for (const declaration of node.declarations ?? []) {
 					bindDeclaration(declaration, node.kind, scope, phase);
@@ -633,15 +726,17 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				}
 				if (EFFECT_HOOKS.has(hook)) {
 					visit(node.callee, scope, phase);
-					visitEffectCallback(node.arguments?.[0], scope);
+					visitSynchronousHookCallback(node.arguments?.[0], scope, 'effect');
 					for (let index = 1; index < (node.arguments?.length ?? 0); index++) {
 						visit(node.arguments[index], scope, phase);
 					}
 					return;
 				}
-				if (hook === 'useMemo' && FUNCTION_TYPES.has(unwrap(node.arguments?.[0])?.type)) {
+				if (hook === 'useMemo') {
 					visit(node.callee, scope, phase);
-					visitFunction(unwrap(node.arguments[0]), scope, phase);
+					if (!visitSynchronousHookCallback(node.arguments?.[0], scope, phase)) {
+						visit(node.arguments?.[0], scope, phase);
+					}
 					for (let index = 1; index < node.arguments.length; index++) {
 						visit(node.arguments[index], scope, phase);
 					}

--- a/packages/octane/src/compiler/strong-mode.js
+++ b/packages/octane/src/compiler/strong-mode.js
@@ -149,8 +149,11 @@ function importedHook(callee, scope) {
 	if (object?.type !== 'Identifier' || resolve(scope, object.name)?.kind !== 'namespace') {
 		return null;
 	}
-	if (!value.computed && value.property?.type === 'Identifier') return value.property.name;
-	return value.computed && value.property?.type === 'Literal' ? value.property.value : null;
+	if (!value.computed) {
+		return value.property?.type === 'Identifier' ? value.property.name : null;
+	}
+	const property = unwrap(value.property);
+	return property?.type === 'Literal' ? property.value : null;
 }
 
 function currentRef(member, scope) {
@@ -158,9 +161,11 @@ function currentRef(member, scope) {
 	if (value?.type !== 'MemberExpression' || value.optional === true) return false;
 	const object = unwrap(value.object);
 	if (object?.type !== 'Identifier' || resolve(scope, object.name)?.kind !== 'ref') return false;
-	return value.computed
-		? value.property?.type === 'Literal' && value.property.value === 'current'
-		: value.property?.type === 'Identifier' && value.property.name === 'current';
+	if (!value.computed) {
+		return value.property?.type === 'Identifier' && value.property.name === 'current';
+	}
+	const property = unwrap(value.property);
+	return property?.type === 'Literal' && property.value === 'current';
 }
 
 function sourcePosition(node, boundary) {
@@ -321,6 +326,81 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		}
 	}
 
+	// Bit 1 exits this loop before an await; bit 2 reaches its test synchronously.
+	function doWhileSynchronousControl(statement, nestedBreaks = 0, nestedLoops = 0, labels = null) {
+		switch (statement?.type) {
+			case 'BreakStatement': {
+				if (statement.label == null) return nestedBreaks === 0 ? 1 : 0;
+				for (let label = labels; label; label = label.parent) {
+					if (label.name === statement.label.name) return 0;
+				}
+				return 1;
+			}
+			case 'ContinueStatement': {
+				if (statement.label == null) return nestedLoops === 0 ? 2 : 0;
+				for (let label = labels; label; label = label.parent) {
+					if (label.name === statement.label.name) return 0;
+				}
+				return 2;
+			}
+			case 'BlockStatement':
+			case 'JSXCodeBlock': {
+				let control = 0;
+				for (const child of statement.body ?? []) {
+					control |= doWhileSynchronousControl(child, nestedBreaks, nestedLoops, labels);
+					if (
+						statementAlwaysAwaits(child) ||
+						child.type === 'BreakStatement' ||
+						child.type === 'ContinueStatement' ||
+						child.type === 'ReturnStatement' ||
+						child.type === 'ThrowStatement'
+					) {
+						return control;
+					}
+				}
+				return control;
+			}
+			case 'IfStatement':
+				return alwaysAwaits(statement.test)
+					? 0
+					: doWhileSynchronousControl(statement.consequent, nestedBreaks, nestedLoops, labels) |
+							doWhileSynchronousControl(statement.alternate, nestedBreaks, nestedLoops, labels);
+			case 'LabeledStatement':
+				return doWhileSynchronousControl(statement.body, nestedBreaks, nestedLoops, {
+					name: statement.label.name,
+					parent: labels,
+				});
+			case 'SwitchStatement': {
+				if (alwaysAwaits(statement.discriminant)) return 0;
+				let control = 0;
+				for (const branch of statement.cases ?? []) {
+					for (const child of branch.consequent ?? []) {
+						control |= doWhileSynchronousControl(child, nestedBreaks + 1, nestedLoops, labels);
+						if (statementAlwaysAwaits(child) || child.type === 'BreakStatement') break;
+					}
+				}
+				return control;
+			}
+			case 'ForStatement':
+			case 'ForInStatement':
+			case 'ForOfStatement':
+			case 'WhileStatement':
+			case 'DoWhileStatement':
+				return statementAlwaysAwaits(statement)
+					? 0
+					: doWhileSynchronousControl(statement.body, nestedBreaks + 1, nestedLoops + 1, labels);
+			case 'TryStatement':
+				if (statement.finalizer != null && statementAlwaysAwaits(statement.finalizer)) return 0;
+				return (
+					doWhileSynchronousControl(statement.block, nestedBreaks, nestedLoops, labels) |
+					doWhileSynchronousControl(statement.handler?.body, nestedBreaks, nestedLoops, labels) |
+					doWhileSynchronousControl(statement.finalizer, nestedBreaks, nestedLoops, labels)
+				);
+			default:
+				return 0;
+		}
+	}
+
 	function statementAlwaysAwaits(statement) {
 		switch (statement?.type) {
 			case 'ExpressionStatement':
@@ -355,6 +435,13 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				return statement.await === true || alwaysAwaits(statement.right);
 			case 'WhileStatement':
 				return alwaysAwaits(statement.test);
+			case 'LabeledStatement':
+				return statement.body?.type === 'DoWhileStatement' && statementAlwaysAwaits(statement.body);
+			case 'DoWhileStatement': {
+				const control = doWhileSynchronousControl(statement.body);
+				const bodyAwaits = statementAlwaysAwaits(statement.body) && control === 0;
+				return (control & 1) === 0 && (bodyAwaits || alwaysAwaits(statement.test));
+			}
 			case 'TryStatement':
 				return (
 					(statement.finalizer != null && statementAlwaysAwaits(statement.finalizer)) ||
@@ -528,11 +615,13 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				const hook = importedHook(node.callee, scope);
 				const callee = unwrap(node.callee);
 				const calleeBinding = callee?.type === 'Identifier' ? resolve(scope, callee.name) : null;
+				const tupleProperty =
+					callee?.type === 'MemberExpression' && callee.computed === true
+						? unwrap(callee.property)
+						: null;
 				const tupleUpdater =
-					callee?.type === 'MemberExpression' &&
-					callee.computed === true &&
-					callee.property?.type === 'Literal' &&
-					(callee.property.value === 1 || callee.property.value === '1') &&
+					tupleProperty?.type === 'Literal' &&
+					(tupleProperty.value === 1 || tupleProperty.value === '1') &&
 					unwrap(callee.object)?.type === 'Identifier' &&
 					resolve(scope, unwrap(callee.object).name)?.kind === 'state-tuple';
 				if (
@@ -642,6 +731,18 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 						? 'deferred'
 						: phase;
 				visit(node.body, scope, executionPhase);
+				return;
+			}
+			case 'DoWhileStatement': {
+				visit(node.body, scope, phase);
+				const executionPhase =
+					currentFunctionIsAsync &&
+					phase !== 'deferred' &&
+					statementAlwaysAwaits(node.body) &&
+					(doWhileSynchronousControl(node.body) & 2) === 0
+						? 'deferred'
+						: phase;
+				visit(node.test, scope, executionPhase);
 				return;
 			}
 		}

--- a/packages/octane/src/compiler/strong-mode.js
+++ b/packages/octane/src/compiler/strong-mode.js
@@ -285,8 +285,16 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 						(node.arguments ?? []).some(alwaysAwaits) &&
 						!optionalChainCanSkip(node.callee))
 				);
+			case 'ClassExpression':
+				return alwaysAwaits(node.superClass);
 			case 'AssignmentExpression':
-				return alwaysAwaits(node.left) || alwaysAwaits(node.right);
+				return (
+					alwaysAwaits(node.left) ||
+					(node.operator !== '&&=' &&
+						node.operator !== '||=' &&
+						node.operator !== '??=' &&
+						alwaysAwaits(node.right))
+				);
 			case 'BinaryExpression':
 				return alwaysAwaits(node.left) || alwaysAwaits(node.right);
 			case 'LogicalExpression':
@@ -321,6 +329,27 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				return alwaysAwaits(node.argument);
 			case 'TemplateLiteral':
 				return (node.expressions ?? []).some(alwaysAwaits);
+			case 'TaggedTemplateExpression':
+				return alwaysAwaits(node.tag) || alwaysAwaits(node.quasi);
+			default:
+				return false;
+		}
+	}
+
+	function patternAlwaysAwaits(pattern) {
+		switch (pattern?.type) {
+			case 'ArrayPattern':
+				return (pattern.elements ?? []).some(patternAlwaysAwaits);
+			case 'ObjectPattern':
+				return (pattern.properties ?? []).some(
+					(property) =>
+						(property.computed === true && alwaysAwaits(property.key)) ||
+						patternAlwaysAwaits(property.argument ?? property.value),
+				);
+			case 'AssignmentPattern':
+				return patternAlwaysAwaits(pattern.left);
+			case 'RestElement':
+				return patternAlwaysAwaits(pattern.argument);
 			default:
 				return false;
 		}
@@ -424,7 +453,11 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			case 'ExpressionStatement':
 				return alwaysAwaits(statement.expression);
 			case 'VariableDeclaration':
-				return (statement.declarations ?? []).some((declaration) => alwaysAwaits(declaration.init));
+				return (statement.declarations ?? []).some(
+					(declaration) => alwaysAwaits(declaration.init) || patternAlwaysAwaits(declaration.id),
+				);
+			case 'ClassDeclaration':
+				return alwaysAwaits(statement.superClass);
 			case 'ReturnStatement':
 			case 'ThrowStatement':
 				return alwaysAwaits(statement.argument);
@@ -495,6 +528,48 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		}
 	}
 
+	function continuedChainAlwaysAwaits(expression, groupedOptional = false) {
+		if (expression?.type === 'ChainExpression') {
+			return groupedOptional
+				? continuedChainAlwaysAwaits(expression.expression)
+				: alwaysAwaits(expression);
+		}
+		const node = unwrap(expression);
+		if (node == null) return false;
+		if (node.type === 'MemberExpression') {
+			return (
+				continuedChainAlwaysAwaits(node.object) ||
+				(node.computed === true && alwaysAwaits(node.property))
+			);
+		}
+		if (node.type === 'CallExpression') {
+			return continuedChainAlwaysAwaits(node.callee) || (node.arguments ?? []).some(alwaysAwaits);
+		}
+		return alwaysAwaits(node);
+	}
+
+	function phaseAfter(expression, phase, continued = false, groupedOptional = false) {
+		if (!currentFunctionIsAsync || phase === 'deferred') return phase;
+		if (
+			alwaysAwaits(expression) ||
+			(continued &&
+				((optionalChainCanSkip(expression) && continuedChainAlwaysAwaits(expression)) ||
+					(groupedOptional && continuedChainAlwaysAwaits(expression, true))))
+		) {
+			return 'deferred';
+		}
+		return phase;
+	}
+
+	function visitExpressionList(expressions, scope, phase) {
+		let executionPhase = phase;
+		for (const expression of expressions ?? []) {
+			visit(expression, scope, executionPhase);
+			executionPhase = phaseAfter(expression, executionPhase);
+		}
+		return executionPhase;
+	}
+
 	function visitStatements(statements, scope, phase) {
 		let executionPhase = phase;
 		for (const statement of statements ?? []) {
@@ -534,19 +609,30 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 	}
 
 	function visitPatternExpressions(pattern, scope, phase) {
+		let executionPhase = phase;
 		if (pattern?.type === 'AssignmentPattern') {
-			visitPatternExpressions(pattern.left, scope, phase);
-			visit(pattern.right, scope, phase);
+			executionPhase = visitPatternExpressions(pattern.left, scope, executionPhase);
+			visit(pattern.right, scope, executionPhase);
 		} else if (pattern?.type === 'ArrayPattern') {
-			for (const element of pattern.elements ?? []) visitPatternExpressions(element, scope, phase);
+			for (const element of pattern.elements ?? []) {
+				executionPhase = visitPatternExpressions(element, scope, executionPhase);
+			}
 		} else if (pattern?.type === 'ObjectPattern') {
 			for (const property of pattern.properties ?? []) {
-				if (property.computed) visit(property.key, scope, phase);
-				visitPatternExpressions(property.argument ?? property.value, scope, phase);
+				if (property.computed) {
+					visit(property.key, scope, executionPhase);
+					executionPhase = phaseAfter(property.key, executionPhase);
+				}
+				executionPhase = visitPatternExpressions(
+					property.argument ?? property.value,
+					scope,
+					executionPhase,
+				);
 			}
 		} else if (pattern?.type === 'RestElement') {
-			visitPatternExpressions(pattern.argument, scope, phase);
+			executionPhase = visitPatternExpressions(pattern.argument, scope, executionPhase);
 		}
+		return executionPhase;
 	}
 
 	function bindDeclaration(declaration, declarationKind, scope, phase) {
@@ -577,8 +663,8 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				target.bindings.set(declaration.id.name, { kind: 'callback', node: initial, scope });
 			}
 		}
-		visitPatternExpressions(declaration.id, scope, phase);
 		visit(declaration.init, scope, phase);
+		return visitPatternExpressions(declaration.id, scope, phaseAfter(declaration.init, phase));
 	}
 
 	function visitCallback(node, parentScope, phase) {
@@ -589,6 +675,18 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		} finally {
 			activeCallbacks.delete(node);
 		}
+	}
+
+	function stateTupleUpdater(value, scope) {
+		const member = unwrap(value);
+		if (member?.type !== 'MemberExpression' || member.computed !== true) return false;
+		const property = unwrap(member.property);
+		return (
+			property?.type === 'Literal' &&
+			(property.value === 1 || property.value === '1') &&
+			unwrap(member.object)?.type === 'Identifier' &&
+			resolve(scope, unwrap(member.object).name)?.kind === 'state-tuple'
+		);
 	}
 
 	function visitSynchronousHookCallback(value, scope, phase) {
@@ -602,6 +700,9 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			else if (binding?.kind === 'setter' && (phase === 'render' || phase === 'effect')) {
 				reportSetter(callback, phase);
 			}
+			return true;
+		} else if (stateTupleUpdater(callback, scope)) {
+			if (phase === 'render' || phase === 'effect') reportSetter(callback, phase);
 			return true;
 		}
 		return false;
@@ -645,12 +746,56 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			}
 			case 'IfStatement': {
 				visit(node.test, scope, phase);
-				const branchPhase =
-					currentFunctionIsAsync && phase !== 'deferred' && alwaysAwaits(node.test)
-						? 'deferred'
-						: phase;
+				const branchPhase = phaseAfter(node.test, phase);
 				visit(node.consequent, scope, branchPhase);
 				visit(node.alternate, scope, branchPhase);
+				return;
+			}
+			case 'ConditionalExpression': {
+				visit(node.test, scope, phase);
+				const branchPhase = phaseAfter(node.test, phase);
+				visit(node.consequent, scope, branchPhase);
+				visit(node.alternate, scope, branchPhase);
+				return;
+			}
+			case 'LogicalExpression':
+			case 'BinaryExpression':
+				visit(node.left, scope, phase);
+				visit(node.right, scope, phaseAfter(node.left, phase));
+				return;
+			case 'SequenceExpression':
+				visitExpressionList(node.expressions, scope, phase);
+				return;
+			case 'ArrayExpression':
+				visitExpressionList(node.elements, scope, phase);
+				return;
+			case 'TemplateLiteral':
+				visitExpressionList(node.expressions, scope, phase);
+				return;
+			case 'ObjectExpression': {
+				let executionPhase = phase;
+				for (const property of node.properties ?? []) {
+					if (property.type === 'SpreadElement') {
+						visit(property.argument, scope, executionPhase);
+						executionPhase = phaseAfter(property.argument, executionPhase);
+						continue;
+					}
+					if (property.computed === true) {
+						visit(property.key, scope, executionPhase);
+						executionPhase = phaseAfter(property.key, executionPhase);
+					}
+					if (property.kind === 'init' && property.method !== true) {
+						visit(property.value, scope, executionPhase);
+						executionPhase = phaseAfter(property.value, executionPhase);
+					}
+				}
+				return;
+			}
+			case 'MemberExpression': {
+				visit(node.object, scope, phase);
+				if (node.computed === true) {
+					visit(node.property, scope, phaseAfter(node.object, phase, true, node.optional === true));
+				}
 				return;
 			}
 			case 'LabeledStatement':
@@ -699,68 +844,116 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				}
 				return;
 			}
-			case 'VariableDeclaration':
+			case 'VariableDeclaration': {
+				let declarationPhase = phase;
 				for (const declaration of node.declarations ?? []) {
-					bindDeclaration(declaration, node.kind, scope, phase);
+					declarationPhase = bindDeclaration(declaration, node.kind, scope, declarationPhase);
 				}
 				return;
+			}
 			case 'CallExpression': {
 				const hook = importedHook(node.callee, scope);
 				const callee = unwrap(node.callee);
 				const calleeBinding = callee?.type === 'Identifier' ? resolve(scope, callee.name) : null;
-				const tupleProperty =
-					callee?.type === 'MemberExpression' && callee.computed === true
-						? unwrap(callee.property)
-						: null;
-				const tupleUpdater =
-					tupleProperty?.type === 'Literal' &&
-					(tupleProperty.value === 1 || tupleProperty.value === '1') &&
-					unwrap(callee.object)?.type === 'Identifier' &&
-					resolve(scope, unwrap(callee.object).name)?.kind === 'state-tuple';
+				const tupleUpdater = stateTupleUpdater(callee, scope);
+				if (!FUNCTION_TYPES.has(callee?.type)) {
+					visit(node.callee, scope, phase);
+				}
+				let executionPhase = phaseAfter(node.callee, phase, true, node.optional === true);
+				const synchronousHook = EFFECT_HOOKS.has(hook) || hook === 'useMemo';
+				for (let index = 0; index < (node.arguments?.length ?? 0); index++) {
+					const argument = node.arguments[index];
+					if (index !== 0 || !synchronousHook || !FUNCTION_TYPES.has(unwrap(argument)?.type)) {
+						visit(argument, scope, executionPhase);
+					}
+					executionPhase = phaseAfter(argument, executionPhase);
+				}
 				if (
-					(phase === 'render' || phase === 'effect') &&
-					(calleeBinding?.kind === 'setter' || tupleUpdater) &&
-					!(currentFunctionIsAsync && (node.arguments ?? []).some(alwaysAwaits))
+					(executionPhase === 'render' || executionPhase === 'effect') &&
+					(calleeBinding?.kind === 'setter' || tupleUpdater)
 				) {
-					reportSetter(callee, phase);
+					reportSetter(callee, executionPhase);
 				}
 				if (EFFECT_HOOKS.has(hook)) {
-					visit(node.callee, scope, phase);
 					visitSynchronousHookCallback(node.arguments?.[0], scope, 'effect');
-					for (let index = 1; index < (node.arguments?.length ?? 0); index++) {
-						visit(node.arguments[index], scope, phase);
-					}
 					return;
 				}
 				if (hook === 'useMemo') {
-					visit(node.callee, scope, phase);
-					if (!visitSynchronousHookCallback(node.arguments?.[0], scope, phase)) {
-						visit(node.arguments?.[0], scope, phase);
-					}
-					for (let index = 1; index < node.arguments.length; index++) {
-						visit(node.arguments[index], scope, phase);
-					}
+					visitSynchronousHookCallback(node.arguments?.[0], scope, executionPhase);
 					return;
 				}
 				if (FUNCTION_TYPES.has(callee?.type)) {
-					visitCallback(callee, scope, phase);
-					for (const argument of node.arguments ?? []) visit(argument, scope, phase);
-					return;
+					visitCallback(callee, scope, executionPhase);
+				} else if (
+					(executionPhase === 'render' || executionPhase === 'effect') &&
+					calleeBinding?.kind === 'callback'
+				) {
+					visitCallback(calleeBinding.node, calleeBinding.scope, executionPhase);
 				}
-				if ((phase === 'render' || phase === 'effect') && calleeBinding?.kind === 'callback') {
-					visitCallback(calleeBinding.node, calleeBinding.scope, phase);
-					for (const argument of node.arguments ?? []) visit(argument, scope, phase);
-					return;
-				}
-				visit(node.callee, scope, phase);
-				for (const argument of node.arguments ?? []) visit(argument, scope, phase);
 				return;
 			}
-			case 'AssignmentExpression':
-				if (phase === 'render' && currentRef(node.left, scope)) reportRef(node.left);
-				visit(node.left, scope, phase);
-				visit(node.right, scope, phase);
+			case 'NewExpression': {
+				const callee = unwrap(node.callee);
+				const binding = callee?.type === 'Identifier' ? resolve(scope, callee.name) : null;
+				const inlineConstructor =
+					(callee?.type === 'FunctionExpression' || callee?.type === 'FunctionDeclaration') &&
+					callee.async !== true &&
+					callee.generator !== true;
+				if (!FUNCTION_TYPES.has(callee?.type)) visit(node.callee, scope, phase);
+				const executionPhase = visitExpressionList(
+					node.arguments,
+					scope,
+					phaseAfter(node.callee, phase),
+				);
+				if (inlineConstructor) {
+					visitCallback(callee, scope, executionPhase);
+				} else if (
+					(executionPhase === 'render' || executionPhase === 'effect') &&
+					binding?.kind === 'callback' &&
+					(binding.node.type === 'FunctionExpression' ||
+						binding.node.type === 'FunctionDeclaration') &&
+					binding.node.async !== true &&
+					binding.node.generator !== true
+				) {
+					visitCallback(binding.node, binding.scope, executionPhase);
+				}
 				return;
+			}
+			case 'TaggedTemplateExpression': {
+				const tag = unwrap(node.tag);
+				const binding = tag?.type === 'Identifier' ? resolve(scope, tag.name) : null;
+				if (!FUNCTION_TYPES.has(tag?.type)) visit(node.tag, scope, phase);
+				const tagPhase = phaseAfter(node.tag, phase, true);
+				visit(node.quasi, scope, tagPhase);
+				const executionPhase = phaseAfter(node.quasi, tagPhase);
+				if (
+					(executionPhase === 'render' || executionPhase === 'effect') &&
+					binding?.kind === 'setter'
+				) {
+					reportSetter(tag, executionPhase);
+				} else if (FUNCTION_TYPES.has(tag?.type)) {
+					visitCallback(tag, scope, executionPhase);
+				} else if (
+					(executionPhase === 'render' || executionPhase === 'effect') &&
+					binding?.kind === 'callback'
+				) {
+					visitCallback(binding.node, binding.scope, executionPhase);
+				}
+				return;
+			}
+			case 'AssignmentExpression': {
+				if (node.left?.type === 'ArrayPattern' || node.left?.type === 'ObjectPattern') {
+					visit(node.right, scope, phase);
+					visitPatternExpressions(node.left, scope, phaseAfter(node.right, phase));
+					return;
+				}
+				visit(node.left, scope, phase);
+				const rightPhase = phaseAfter(node.left, phase, true);
+				visit(node.right, scope, rightPhase);
+				const executionPhase = phaseAfter(node.right, rightPhase);
+				if (executionPhase === 'render' && currentRef(node.left, scope)) reportRef(node.left);
+				return;
+			}
 			case 'UpdateExpression':
 				if (phase === 'render' && currentRef(node.argument, scope)) reportRef(node.argument);
 				visit(node.argument, scope, phase);

--- a/packages/octane/src/compiler/strong-mode.js
+++ b/packages/octane/src/compiler/strong-mode.js
@@ -343,6 +343,18 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 						statementAlwaysAwaits(statement.consequent) &&
 						statementAlwaysAwaits(statement.alternate))
 				);
+			case 'ForStatement':
+				return (
+					(statement.init?.type === 'VariableDeclaration'
+						? statementAlwaysAwaits(statement.init)
+						: alwaysAwaits(statement.init)) || alwaysAwaits(statement.test)
+				);
+			case 'ForInStatement':
+				return alwaysAwaits(statement.right);
+			case 'ForOfStatement':
+				return statement.await === true || alwaysAwaits(statement.right);
+			case 'WhileStatement':
+				return alwaysAwaits(statement.test);
 			case 'TryStatement':
 				return (
 					(statement.finalizer != null && statementAlwaysAwaits(statement.finalizer)) ||
@@ -574,13 +586,62 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				visit(node.body, catchScope, phase);
 				return;
 			}
-			case 'ForStatement':
+			case 'ForStatement': {
+				const loop = createScope(scope, 'block');
+				if (node.init?.type === 'VariableDeclaration') {
+					const target = declarationScope(loop, node.init.kind);
+					const binding = { kind: 'other' };
+					for (const declaration of node.init.declarations ?? []) {
+						addPatternNames(declaration.id, target.bindings, binding);
+					}
+				}
+				let executionPhase = phase;
+				visit(node.init, loop, executionPhase);
+				if (
+					currentFunctionIsAsync &&
+					executionPhase !== 'deferred' &&
+					(node.init?.type === 'VariableDeclaration'
+						? statementAlwaysAwaits(node.init)
+						: alwaysAwaits(node.init))
+				) {
+					executionPhase = 'deferred';
+				}
+				visit(node.test, loop, executionPhase);
+				if (currentFunctionIsAsync && executionPhase !== 'deferred' && alwaysAwaits(node.test)) {
+					executionPhase = 'deferred';
+				}
+				visit(node.body, loop, executionPhase);
+				visit(node.update, loop, executionPhase);
+				return;
+			}
 			case 'ForInStatement':
 			case 'ForOfStatement': {
 				const loop = createScope(scope, 'block');
-				for (const key of ['init', 'left', 'right', 'test', 'update', 'body']) {
-					visit(node[key], loop, phase);
+				if (node.left?.type === 'VariableDeclaration') {
+					const target = declarationScope(loop, node.left.kind);
+					const binding = { kind: 'other' };
+					for (const declaration of node.left.declarations ?? []) {
+						addPatternNames(declaration.id, target.bindings, binding);
+					}
 				}
+				visit(node.right, loop, phase);
+				const executionPhase =
+					currentFunctionIsAsync &&
+					phase !== 'deferred' &&
+					(alwaysAwaits(node.right) || (node.type === 'ForOfStatement' && node.await === true))
+						? 'deferred'
+						: phase;
+				visit(node.left, loop, executionPhase);
+				visit(node.body, loop, executionPhase);
+				return;
+			}
+			case 'WhileStatement': {
+				visit(node.test, scope, phase);
+				const executionPhase =
+					currentFunctionIsAsync && phase !== 'deferred' && alwaysAwaits(node.test)
+						? 'deferred'
+						: phase;
+				visit(node.body, scope, executionPhase);
 				return;
 			}
 		}

--- a/packages/octane/src/compiler/strong-mode.js
+++ b/packages/octane/src/compiler/strong-mode.js
@@ -40,6 +40,22 @@ function unwrap(node) {
 	return value;
 }
 
+function optionalChainCanSkip(node) {
+	let current = node;
+	while (current != null) {
+		// Grouping ends a chain before an outer call or property access evaluates.
+		if (current.type === 'ChainExpression') return false;
+		if (TRANSPARENT_EXPRESSIONS.has(current.type)) {
+			current = current.expression;
+			continue;
+		}
+		if (current.type !== 'CallExpression' && current.type !== 'MemberExpression') return false;
+		if (current.optional === true) return true;
+		current = current.type === 'CallExpression' ? current.callee : current.object;
+	}
+	return false;
+}
+
 function addPatternNames(pattern, bindings, value) {
 	if (pattern == null) return;
 	switch (pattern.type) {
@@ -259,8 +275,10 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			case 'CallExpression':
 			case 'NewExpression':
 				return (
-					node.optional !== true &&
-					(alwaysAwaits(node.callee) || (node.arguments ?? []).some(alwaysAwaits))
+					alwaysAwaits(node.callee) ||
+					(node.optional !== true &&
+						(node.arguments ?? []).some(alwaysAwaits) &&
+						!optionalChainCanSkip(node.callee))
 				);
 			case 'AssignmentExpression':
 				return alwaysAwaits(node.left) || alwaysAwaits(node.right);
@@ -269,14 +287,19 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			case 'LogicalExpression':
 				return alwaysAwaits(node.left);
 			case 'ConditionalExpression':
-				return alwaysAwaits(node.test);
+				return (
+					alwaysAwaits(node.test) || (alwaysAwaits(node.consequent) && alwaysAwaits(node.alternate))
+				);
 			case 'UnaryExpression':
 			case 'UpdateExpression':
 				return alwaysAwaits(node.argument);
 			case 'MemberExpression':
 				return (
-					node.optional !== true &&
-					(alwaysAwaits(node.object) || (node.computed === true && alwaysAwaits(node.property)))
+					alwaysAwaits(node.object) ||
+					(node.optional !== true &&
+						node.computed === true &&
+						alwaysAwaits(node.property) &&
+						!optionalChainCanSkip(node.object))
 				);
 			case 'ArrayExpression':
 				return (node.elements ?? []).some(alwaysAwaits);
@@ -299,13 +322,51 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 	}
 
 	function statementAlwaysAwaits(statement) {
-		if (statement?.type === 'ExpressionStatement') return alwaysAwaits(statement.expression);
-		if (statement?.type === 'VariableDeclaration') {
-			return (statement.declarations ?? []).some((declaration) => alwaysAwaits(declaration.init));
+		switch (statement?.type) {
+			case 'ExpressionStatement':
+				return alwaysAwaits(statement.expression);
+			case 'VariableDeclaration':
+				return (statement.declarations ?? []).some((declaration) => alwaysAwaits(declaration.init));
+			case 'ReturnStatement':
+			case 'ThrowStatement':
+				return alwaysAwaits(statement.argument);
+			case 'BlockStatement':
+			case 'JSXCodeBlock':
+				for (const child of statement.body ?? []) {
+					if (statementAlwaysAwaits(child)) return true;
+				}
+				return false;
+			case 'IfStatement':
+				return (
+					alwaysAwaits(statement.test) ||
+					(statement.alternate != null &&
+						statementAlwaysAwaits(statement.consequent) &&
+						statementAlwaysAwaits(statement.alternate))
+				);
+			case 'TryStatement':
+				return (
+					(statement.finalizer != null && statementAlwaysAwaits(statement.finalizer)) ||
+					(statementAlwaysAwaits(statement.block) &&
+						(statement.handler == null || statementAlwaysAwaits(statement.handler.body)))
+				);
+			default:
+				return false;
 		}
-		return statement?.type === 'ReturnStatement' || statement?.type === 'ThrowStatement'
-			? alwaysAwaits(statement.argument)
-			: false;
+	}
+
+	function visitStatements(statements, scope, phase) {
+		let executionPhase = phase;
+		for (const statement of statements ?? []) {
+			visit(statement, scope, executionPhase);
+			if (
+				currentFunctionIsAsync &&
+				executionPhase !== 'deferred' &&
+				statementAlwaysAwaits(statement)
+			) {
+				executionPhase = 'deferred';
+			}
+		}
+		return executionPhase;
 	}
 
 	function visitFunction(node, parentScope, phase) {
@@ -321,17 +382,7 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				visitPatternExpressions(parameter, functionScope, phase);
 			}
 			if (body?.type === 'BlockStatement' || body?.type === 'JSXCodeBlock') {
-				let executionPhase = phase;
-				for (const statement of body.body ?? []) {
-					visit(statement, functionScope, executionPhase);
-					if (
-						currentFunctionIsAsync &&
-						executionPhase !== 'deferred' &&
-						statementAlwaysAwaits(statement)
-					) {
-						executionPhase = 'deferred';
-					}
-				}
+				const executionPhase = visitStatements(body.body, functionScope, phase);
 				if (body.render) visit(body.render, functionScope, executionPhase);
 			} else {
 				visit(body, functionScope, phase);
@@ -442,8 +493,18 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			case 'BlockStatement':
 			case 'JSXCodeBlock': {
 				const block = createScope(scope, 'block', node.body ?? []);
-				for (const statement of node.body ?? []) visit(statement, block, phase);
-				if (node.render) visit(node.render, block, phase);
+				const executionPhase = visitStatements(node.body, block, phase);
+				if (node.render) visit(node.render, block, executionPhase);
+				return;
+			}
+			case 'IfStatement': {
+				visit(node.test, scope, phase);
+				const branchPhase =
+					currentFunctionIsAsync && phase !== 'deferred' && alwaysAwaits(node.test)
+						? 'deferred'
+						: phase;
+				visit(node.consequent, scope, branchPhase);
+				visit(node.alternate, scope, branchPhase);
 				return;
 			}
 			case 'VariableDeclaration':

--- a/packages/octane/src/compiler/strong-mode.js
+++ b/packages/octane/src/compiler/strong-mode.js
@@ -1,0 +1,553 @@
+const STATE_HOOKS = new Set(['useState', 'useReducer', 'useLinkedState']);
+const EFFECT_HOOKS = new Set(['useEffect', 'useLayoutEffect', 'useInsertionEffect']);
+const FUNCTION_TYPES = new Set([
+	'FunctionDeclaration',
+	'FunctionExpression',
+	'ArrowFunctionExpression',
+]);
+const TRANSPARENT_EXPRESSIONS = new Set([
+	'ChainExpression',
+	'ParenthesizedExpression',
+	'TSAsExpression',
+	'TSInstantiationExpression',
+	'TSNonNullExpression',
+	'TSSatisfiesExpression',
+	'TSTypeAssertion',
+]);
+const SKIP_KEYS = new Set([
+	'type',
+	'start',
+	'end',
+	'loc',
+	'range',
+	'parent',
+	'metadata',
+	'comments',
+	'tokens',
+	'typeAnnotation',
+	'returnType',
+	'typeParameters',
+]);
+
+export const STRONG_RENDER_STATE_UPDATE = 'OCTANE_STRONG_RENDER_STATE_UPDATE';
+export const STRONG_EFFECT_STATE_UPDATE = 'OCTANE_STRONG_EFFECT_STATE_UPDATE';
+export const STRONG_RENDER_REF_WRITE = 'OCTANE_STRONG_RENDER_REF_WRITE';
+export const STRONG_DIRECTIVE_PLACEMENT = 'OCTANE_STRONG_DIRECTIVE_PLACEMENT';
+
+function unwrap(node) {
+	let value = node;
+	while (value && TRANSPARENT_EXPRESSIONS.has(value.type)) value = value.expression;
+	return value;
+}
+
+function addPatternNames(pattern, bindings, value) {
+	if (pattern == null) return;
+	switch (pattern.type) {
+		case 'Identifier':
+			bindings.set(pattern.name, value);
+			break;
+		case 'RestElement':
+			addPatternNames(pattern.argument, bindings, value);
+			break;
+		case 'AssignmentPattern':
+			addPatternNames(pattern.left, bindings, value);
+			break;
+		case 'ArrayPattern':
+			for (const element of pattern.elements ?? []) addPatternNames(element, bindings, value);
+			break;
+		case 'ObjectPattern':
+			for (const property of pattern.properties ?? []) {
+				addPatternNames(property.argument ?? property.value, bindings, value);
+			}
+	}
+}
+
+function declarationOf(statement) {
+	return statement?.type === 'ExportNamedDeclaration' ||
+		statement?.type === 'ExportDefaultDeclaration'
+		? statement.declaration
+		: statement;
+}
+
+function nearestFunctionScope(scope) {
+	let current = scope;
+	while (current?.parent && current.kind !== 'function') current = current.parent;
+	return current;
+}
+
+function declarationScope(scope, kind) {
+	return kind === 'var' ? nearestFunctionScope(scope) : scope;
+}
+
+function predeclareStatements(statements, scope) {
+	for (const original of statements ?? []) {
+		const node = declarationOf(original);
+		if (node?.type === 'ImportDeclaration') {
+			const octane = node.source?.value === 'octane' && node.importKind !== 'type';
+			for (const specifier of node.specifiers ?? []) {
+				if (!specifier.local?.name || specifier.importKind === 'type') continue;
+				if (octane && specifier.type === 'ImportNamespaceSpecifier') {
+					scope.bindings.set(specifier.local.name, { kind: 'namespace' });
+				} else if (octane && specifier.type === 'ImportSpecifier') {
+					const hook = specifier.imported?.name ?? specifier.imported?.value;
+					scope.bindings.set(specifier.local.name, { kind: 'hook', hook });
+				} else {
+					scope.bindings.set(specifier.local.name, { kind: 'other' });
+				}
+			}
+		} else if (node?.type === 'VariableDeclaration') {
+			const target = declarationScope(scope, node.kind);
+			for (const declaration of node.declarations ?? []) {
+				addPatternNames(declaration.id, target.bindings, { kind: 'other' });
+			}
+		} else if (node?.type === 'FunctionDeclaration' && node.id?.name) {
+			scope.bindings.set(node.id.name, { kind: 'callback', node, scope });
+		} else if (node?.type === 'ClassDeclaration' && node.id?.name) {
+			scope.bindings.set(node.id.name, { kind: 'other' });
+		}
+	}
+}
+
+function createScope(parent, kind, statements = [], params = []) {
+	const scope = { parent, kind, bindings: new Map() };
+	predeclareStatements(statements, scope);
+	for (const param of params) addPatternNames(param, scope.bindings, { kind: 'other' });
+	return scope;
+}
+
+function resolve(scope, name) {
+	for (let current = scope; current; current = current.parent) {
+		if (current.bindings.has(name)) return current.bindings.get(name);
+	}
+	return null;
+}
+
+function importedHook(callee, scope) {
+	const value = unwrap(callee);
+	if (value?.type === 'Identifier') {
+		const binding = resolve(scope, value.name);
+		return binding?.kind === 'hook' ? binding.hook : null;
+	}
+	if (value?.type !== 'MemberExpression' || value.optional === true) return null;
+	const object = unwrap(value.object);
+	if (object?.type !== 'Identifier' || resolve(scope, object.name)?.kind !== 'namespace') {
+		return null;
+	}
+	if (!value.computed && value.property?.type === 'Identifier') return value.property.name;
+	return value.computed && value.property?.type === 'Literal' ? value.property.value : null;
+}
+
+function currentRef(member, scope) {
+	const value = unwrap(member);
+	if (value?.type !== 'MemberExpression' || value.optional === true) return false;
+	const object = unwrap(value.object);
+	if (object?.type !== 'Identifier' || resolve(scope, object.name)?.kind !== 'ref') return false;
+	return value.computed
+		? value.property?.type === 'Literal' && value.property.value === 'current'
+		: value.property?.type === 'Identifier' && value.property.name === 'current';
+}
+
+function sourcePosition(node, boundary) {
+	const offset = boundary === 'end' ? (node?.end ?? node?.start ?? 0) : (node?.start ?? 0);
+	const position = boundary === 'end' ? (node?.loc?.end ?? node?.loc?.start) : node?.loc?.start;
+	return {
+		offset,
+		line: position?.line ?? 1,
+		column: position?.column ?? 0,
+	};
+}
+
+function diagnostic(code, filename, node, message, suggestions = []) {
+	return {
+		code,
+		severity: 'error',
+		filename,
+		start: sourcePosition(node, 'start'),
+		end: sourcePosition(node, 'end'),
+		message,
+		suggestions,
+	};
+}
+
+function strongDirectives(ast) {
+	let enabled = false;
+	let misplaced = null;
+	let prologue = true;
+	for (const statement of ast?.body ?? []) {
+		if (
+			prologue &&
+			statement.type === 'ExpressionStatement' &&
+			typeof statement.directive === 'string'
+		) {
+			if (statement.directive === 'use strong') enabled = true;
+			continue;
+		}
+		prologue = false;
+		if (
+			misplaced === null &&
+			statement.type === 'ExpressionStatement' &&
+			statement.expression?.value === 'use strong' &&
+			(statement.expression.raw === '"use strong"' || statement.expression.raw === "'use strong'")
+		) {
+			misplaced = statement.expression;
+		}
+	}
+	return { enabled, misplaced };
+}
+
+/**
+ * Analyze only modules that explicitly opted in. The authored parser tree is
+ * read-only: scope information stays in local maps instead of annotating AST
+ * nodes, so compile, SSR, hydration extraction, and Volar share one contract.
+ *
+ * @param {any} ast
+ * @param {string} source
+ * @param {string | undefined} filename
+ * @param {{ strong?: boolean }} [options]
+ */
+export function analyzeStrongMode(ast, source, filename, options = {}) {
+	if (options.strong !== true && !source.includes('use strong')) {
+		return { enabled: false, diagnostics: [] };
+	}
+	const diagnostics = [];
+	const directives = strongDirectives(ast);
+	if (directives.misplaced !== null) {
+		diagnostics.push(
+			diagnostic(
+				STRONG_DIRECTIVE_PLACEMENT,
+				filename,
+				directives.misplaced,
+				'Place "use strong" at the top of the file, before imports or other code.',
+			),
+		);
+	}
+	const enabled = options.strong === true || directives.enabled;
+	if (!enabled) return { enabled: false, diagnostics };
+
+	const moduleScope = createScope(null, 'module', ast.body ?? []);
+	const activeCallbacks = new Set();
+	let currentFunctionIsAsync = false;
+
+	function reportSetter(node, phase) {
+		const effect = phase === 'effect';
+		const code = effect ? STRONG_EFFECT_STATE_UPDATE : STRONG_RENDER_STATE_UPDATE;
+		const message = effect
+			? 'Strong mode does not allow synchronous state updates inside effect setup. Derive the value during render or use useLinkedState when state follows another value.'
+			: 'Strong mode does not allow state updates during render. Use useLinkedState when state needs to reset or change with another value.';
+		diagnostics.push(diagnostic(code, filename, node, message, [{ hook: 'useLinkedState' }]));
+	}
+
+	function reportRef(node) {
+		diagnostics.push(
+			diagnostic(
+				STRONG_RENDER_REF_WRITE,
+				filename,
+				node,
+				'Strong mode does not allow writing to useRef.current during render. Move the write to an event or effect, or express the value as state.',
+			),
+		);
+	}
+
+	function alwaysAwaits(expression) {
+		const node = unwrap(expression);
+		if (node == null) return false;
+		switch (node.type) {
+			case 'AwaitExpression':
+				return true;
+			case 'SequenceExpression':
+				return (node.expressions ?? []).some(alwaysAwaits);
+			case 'CallExpression':
+			case 'NewExpression':
+				return (
+					node.optional !== true &&
+					(alwaysAwaits(node.callee) || (node.arguments ?? []).some(alwaysAwaits))
+				);
+			case 'AssignmentExpression':
+				return alwaysAwaits(node.left) || alwaysAwaits(node.right);
+			case 'BinaryExpression':
+				return alwaysAwaits(node.left) || alwaysAwaits(node.right);
+			case 'LogicalExpression':
+				return alwaysAwaits(node.left);
+			case 'ConditionalExpression':
+				return alwaysAwaits(node.test);
+			case 'UnaryExpression':
+			case 'UpdateExpression':
+				return alwaysAwaits(node.argument);
+			case 'MemberExpression':
+				return (
+					node.optional !== true &&
+					(alwaysAwaits(node.object) || (node.computed === true && alwaysAwaits(node.property)))
+				);
+			case 'ArrayExpression':
+				return (node.elements ?? []).some(alwaysAwaits);
+			case 'ObjectExpression':
+				return (node.properties ?? []).some((property) =>
+					property.type === 'SpreadElement'
+						? alwaysAwaits(property.argument)
+						: (property.computed === true && alwaysAwaits(property.key)) ||
+							(property.kind === 'init' &&
+								property.method !== true &&
+								alwaysAwaits(property.value)),
+				);
+			case 'SpreadElement':
+				return alwaysAwaits(node.argument);
+			case 'TemplateLiteral':
+				return (node.expressions ?? []).some(alwaysAwaits);
+			default:
+				return false;
+		}
+	}
+
+	function statementAlwaysAwaits(statement) {
+		if (statement?.type === 'ExpressionStatement') return alwaysAwaits(statement.expression);
+		if (statement?.type === 'VariableDeclaration') {
+			return (statement.declarations ?? []).some((declaration) => alwaysAwaits(declaration.init));
+		}
+		return statement?.type === 'ReturnStatement' || statement?.type === 'ThrowStatement'
+			? alwaysAwaits(statement.argument)
+			: false;
+	}
+
+	function visitFunction(node, parentScope, phase) {
+		const enclosingFunctionIsAsync = currentFunctionIsAsync;
+		currentFunctionIsAsync = node.async === true;
+		try {
+			const body = node.body;
+			const statements =
+				body?.type === 'BlockStatement' || body?.type === 'JSXCodeBlock' ? body.body : [];
+			const functionScope = createScope(parentScope, 'function', statements, node.params ?? []);
+			if (node.id?.name) functionScope.bindings.set(node.id.name, { kind: 'other' });
+			for (const parameter of node.params ?? []) {
+				visitPatternExpressions(parameter, functionScope, phase);
+			}
+			if (body?.type === 'BlockStatement' || body?.type === 'JSXCodeBlock') {
+				let executionPhase = phase;
+				for (const statement of body.body ?? []) {
+					visit(statement, functionScope, executionPhase);
+					if (
+						currentFunctionIsAsync &&
+						executionPhase !== 'deferred' &&
+						statementAlwaysAwaits(statement)
+					) {
+						executionPhase = 'deferred';
+					}
+				}
+				if (body.render) visit(body.render, functionScope, executionPhase);
+			} else {
+				visit(body, functionScope, phase);
+			}
+		} finally {
+			currentFunctionIsAsync = enclosingFunctionIsAsync;
+		}
+	}
+
+	function visitPatternExpressions(pattern, scope, phase) {
+		if (pattern?.type === 'AssignmentPattern') {
+			visitPatternExpressions(pattern.left, scope, phase);
+			visit(pattern.right, scope, phase);
+		} else if (pattern?.type === 'ArrayPattern') {
+			for (const element of pattern.elements ?? []) visitPatternExpressions(element, scope, phase);
+		} else if (pattern?.type === 'ObjectPattern') {
+			for (const property of pattern.properties ?? []) {
+				if (property.computed) visit(property.key, scope, phase);
+				visitPatternExpressions(property.argument ?? property.value, scope, phase);
+			}
+		} else if (pattern?.type === 'RestElement') {
+			visitPatternExpressions(pattern.argument, scope, phase);
+		}
+	}
+
+	function bindDeclaration(declaration, declarationKind, scope, phase) {
+		const target = declarationScope(scope, declarationKind);
+		const initial = unwrap(declaration.init);
+		const stateTuple =
+			(initial?.type === 'CallExpression' &&
+				STATE_HOOKS.has(importedHook(initial.callee, scope))) ||
+			(initial?.type === 'Identifier' && resolve(scope, initial.name)?.kind === 'state-tuple');
+		if (declaration.id?.type === 'ArrayPattern' && stateTuple) {
+			const element = declaration.id.elements?.[1];
+			const setter = element?.type === 'AssignmentPattern' ? element.left : element;
+			if (setter?.type === 'Identifier') target.bindings.set(setter.name, { kind: 'setter' });
+		} else if (declaration.id?.type === 'Identifier') {
+			if (stateTuple) {
+				target.bindings.set(declaration.id.name, { kind: 'state-tuple' });
+			} else if (
+				initial?.type === 'CallExpression' &&
+				importedHook(initial.callee, scope) === 'useRef'
+			) {
+				target.bindings.set(declaration.id.name, { kind: 'ref' });
+			} else if (declarationKind === 'const' && initial?.type === 'Identifier') {
+				const value = resolve(scope, initial.name);
+				if (value?.kind === 'setter' || value?.kind === 'ref' || value?.kind === 'callback') {
+					target.bindings.set(declaration.id.name, value);
+				}
+			} else if (declarationKind === 'const' && FUNCTION_TYPES.has(initial?.type)) {
+				target.bindings.set(declaration.id.name, { kind: 'callback', node: initial, scope });
+			}
+		}
+		visitPatternExpressions(declaration.id, scope, phase);
+		visit(declaration.init, scope, phase);
+	}
+
+	function visitCallback(node, parentScope, phase) {
+		if (activeCallbacks.has(node)) return;
+		activeCallbacks.add(node);
+		try {
+			visitFunction(node, parentScope, phase);
+		} finally {
+			activeCallbacks.delete(node);
+		}
+	}
+
+	function visitEffectCallback(value, scope) {
+		const callback = unwrap(value);
+		if (FUNCTION_TYPES.has(callback?.type)) {
+			visitCallback(callback, scope, 'effect');
+		} else if (callback?.type === 'Identifier') {
+			const binding = resolve(scope, callback.name);
+			if (binding?.kind === 'callback') visitCallback(binding.node, binding.scope, 'effect');
+			else if (binding?.kind === 'setter') reportSetter(callback, 'effect');
+		}
+	}
+
+	function visit(node, scope, phase) {
+		if (node == null || typeof node !== 'object') return;
+		if (Array.isArray(node)) {
+			for (const child of node) visit(child, scope, phase);
+			return;
+		}
+		if (TRANSPARENT_EXPRESSIONS.has(node.type)) {
+			visit(node.expression, scope, phase);
+			return;
+		}
+		if (node.type?.startsWith('TS')) return;
+
+		switch (node.type) {
+			case 'ImportDeclaration':
+			case 'Identifier':
+			case 'JSXIdentifier':
+			case 'Literal':
+			case 'ThisExpression':
+			case 'Super':
+				return;
+			case 'ExportNamedDeclaration':
+			case 'ExportDefaultDeclaration':
+				visit(node.declaration, scope, phase);
+				return;
+			case 'FunctionDeclaration':
+			case 'FunctionExpression':
+			case 'ArrowFunctionExpression':
+				visitFunction(node, scope, phase === 'module' ? 'render' : 'deferred');
+				return;
+			case 'BlockStatement':
+			case 'JSXCodeBlock': {
+				const block = createScope(scope, 'block', node.body ?? []);
+				for (const statement of node.body ?? []) visit(statement, block, phase);
+				if (node.render) visit(node.render, block, phase);
+				return;
+			}
+			case 'VariableDeclaration':
+				for (const declaration of node.declarations ?? []) {
+					bindDeclaration(declaration, node.kind, scope, phase);
+				}
+				return;
+			case 'CallExpression': {
+				const hook = importedHook(node.callee, scope);
+				const callee = unwrap(node.callee);
+				const calleeBinding = callee?.type === 'Identifier' ? resolve(scope, callee.name) : null;
+				const tupleUpdater =
+					callee?.type === 'MemberExpression' &&
+					callee.computed === true &&
+					callee.property?.type === 'Literal' &&
+					(callee.property.value === 1 || callee.property.value === '1') &&
+					unwrap(callee.object)?.type === 'Identifier' &&
+					resolve(scope, unwrap(callee.object).name)?.kind === 'state-tuple';
+				if (
+					(phase === 'render' || phase === 'effect') &&
+					(calleeBinding?.kind === 'setter' || tupleUpdater) &&
+					!(currentFunctionIsAsync && (node.arguments ?? []).some(alwaysAwaits))
+				) {
+					reportSetter(callee, phase);
+				}
+				if (EFFECT_HOOKS.has(hook)) {
+					visit(node.callee, scope, phase);
+					visitEffectCallback(node.arguments?.[0], scope);
+					for (let index = 1; index < (node.arguments?.length ?? 0); index++) {
+						visit(node.arguments[index], scope, phase);
+					}
+					return;
+				}
+				if (hook === 'useMemo' && FUNCTION_TYPES.has(unwrap(node.arguments?.[0])?.type)) {
+					visit(node.callee, scope, phase);
+					visitFunction(unwrap(node.arguments[0]), scope, phase);
+					for (let index = 1; index < node.arguments.length; index++) {
+						visit(node.arguments[index], scope, phase);
+					}
+					return;
+				}
+				if (FUNCTION_TYPES.has(callee?.type)) {
+					visitCallback(callee, scope, phase);
+					for (const argument of node.arguments ?? []) visit(argument, scope, phase);
+					return;
+				}
+				if ((phase === 'render' || phase === 'effect') && calleeBinding?.kind === 'callback') {
+					visitCallback(calleeBinding.node, calleeBinding.scope, phase);
+					for (const argument of node.arguments ?? []) visit(argument, scope, phase);
+					return;
+				}
+				visit(node.callee, scope, phase);
+				for (const argument of node.arguments ?? []) visit(argument, scope, phase);
+				return;
+			}
+			case 'AssignmentExpression':
+				if (phase === 'render' && currentRef(node.left, scope)) reportRef(node.left);
+				visit(node.left, scope, phase);
+				visit(node.right, scope, phase);
+				return;
+			case 'UpdateExpression':
+				if (phase === 'render' && currentRef(node.argument, scope)) reportRef(node.argument);
+				visit(node.argument, scope, phase);
+				return;
+			case 'CatchClause': {
+				const catchScope = createScope(scope, 'block', [], node.param ? [node.param] : []);
+				visit(node.body, catchScope, phase);
+				return;
+			}
+			case 'ForStatement':
+			case 'ForInStatement':
+			case 'ForOfStatement': {
+				const loop = createScope(scope, 'block');
+				for (const key of ['init', 'left', 'right', 'test', 'update', 'body']) {
+					visit(node[key], loop, phase);
+				}
+				return;
+			}
+		}
+
+		for (const key in node) {
+			if (!SKIP_KEYS.has(key) && !key.startsWith('_octane')) visit(node[key], scope, phase);
+		}
+	}
+
+	for (const statement of ast.body ?? []) visit(statement, moduleScope, 'module');
+	return { enabled, diagnostics };
+}
+
+/** Throw the first Strong-mode violation using the original authored location. */
+export function assertStrongMode(ast, source, filename, options) {
+	if (options?.strong !== true && !source.includes('use strong')) return;
+	const result = analyzeStrongMode(ast, source, filename, options);
+	const violation = result.diagnostics[0];
+	if (violation === undefined) return result;
+	const { code, message } = violation;
+	const { line, column } = violation.start;
+	const error = new SyntaxError(
+		`${filename ?? '<anonymous>'}:${line}:${column + 1}: [${code}] ${message}`,
+	);
+	error.code = code;
+	error.filename = filename;
+	error.loc = { line, column };
+	error.pos = violation.start.offset;
+	error.end = violation.end.offset;
+	throw error;
+}

--- a/packages/octane/src/compiler/vite.d.ts
+++ b/packages/octane/src/compiler/vite.d.ts
@@ -66,6 +66,13 @@ export interface OctaneVitePluginOptions {
 	 */
 	profile?: boolean | 'auto';
 	/**
+	 * Reject state updates during render, synchronous effect state updates, and
+	 * render-time ref writes in application-owned modules. Individual modules
+	 * can opt in with a top-level `"use strong"` directive.
+	 * @default false
+	 */
+	strong?: boolean;
+	/**
 	 * Path fragments excluded from Octane's plain `.ts`/`.js` hook-slot pass.
 	 * Prefer package manifest `octane.hookSlots.manual` declarations for bindings.
 	 */

--- a/packages/octane/src/compiler/vite.js
+++ b/packages/octane/src/compiler/vite.js
@@ -150,6 +150,9 @@ function assertProfilingDefineAvailable(definitions, enabled) {
 }
 
 export function octane(options = {}) {
+	if (options.strong !== undefined && typeof options.strong !== 'boolean') {
+		throw new TypeError('octane/compiler/vite: `strong` must be a boolean when provided.');
+	}
 	if (options.parallelUse !== undefined) {
 		// Removed 2026-07-16: the parallel-use() pipeline is unconditional compiled
 		// semantics (docs/suspense-parallel-use-plan.md). Warn instead of throwing
@@ -194,6 +197,7 @@ export function octane(options = {}) {
 		root: projectRoot,
 		exclude: options.exclude,
 		profile: profileEnabled,
+		strong: options.strong,
 		renderers: options.renderers,
 		requireDirective,
 		warn,
@@ -207,6 +211,7 @@ export function octane(options = {}) {
 			root: projectRoot,
 			exclude: options.exclude,
 			profile: profileEnabled,
+			strong: options.strong,
 			renderers: options.renderers,
 			requireDirective,
 			warn,

--- a/packages/octane/src/compiler/volar.js
+++ b/packages/octane/src/compiler/volar.js
@@ -28,10 +28,12 @@ import {
 	createJsxTransform,
 	createVolarMappingsResult,
 	dedupeMappings,
+	error as collectCompileError,
 	parseModule,
 } from '@tsrx/core';
 import { buildFatSegments, decodeSourceMappings } from './fat-segments.js';
 import { analyzeNativeChangeDiagnostics } from './native-change-diagnostics.js';
+import { analyzeStrongMode } from './strong-mode.js';
 import { jsxImportSourcePragmaModule } from './pragma.js';
 import {
 	DOM_RENDERER_MODULE,
@@ -194,7 +196,7 @@ function markNativeTemplateBodies(root) {
  * `intrinsics`; when present, the virtual TSX gets a file-local pragma so host
  * element types cannot leak into files owned by another renderer.
  *
- * @param {{ loose?: boolean, renderers?: unknown }} [options]
+ * @param {{ loose?: boolean, renderers?: unknown, strong?: boolean }} [options]
  * @returns {import('@tsrx/core/types').VolarMappingsResult & {
  *   diagnostics: readonly unknown[],
  *   generatedAst: import('estree').Program,
@@ -228,6 +230,11 @@ export function compileToVolarMappings(source, filename, options) {
 		rendererBoundaries: rendererConfig.boundaries,
 		rendererRegistry: rendererConfig.registry,
 	}).diagnostics;
+	const strongDiagnostics =
+		options?.strong === true || source.includes('use strong')
+			? analyzeStrongMode(ast, source, filename, options).diagnostics
+			: null;
+	if (strongDiagnostics !== null) diagnostics.push(...strongDiagnostics);
 	// The renderer pragma belongs to the semantic comment set consumed by
 	// @tsrx/core's type-only Program print. This keeps code and mappings in one
 	// coordinate system instead of prepending text and shifting every mapping.
@@ -251,6 +258,25 @@ export function compileToVolarMappings(source, filename, options) {
 		errors,
 		comments: printComments,
 	});
+	if (strongDiagnostics !== null) {
+		for (const diagnostic of strongDiagnostics) {
+			collectCompileError(
+				diagnostic.message,
+				diagnostic.filename ?? null,
+				{
+					start: diagnostic.start.offset,
+					end: diagnostic.end.offset,
+					loc: {
+						start: { line: diagnostic.start.line, column: diagnostic.start.column },
+						end: { line: diagnostic.end.line, column: diagnostic.end.column },
+					},
+				},
+				errors,
+				undefined,
+				diagnostic.code,
+			);
+		}
+	}
 	// After the transform: the copy-on-write lowering must not observe the
 	// marker mid-flight, and `ast` is what ships below as `sourceAst`.
 	markNativeTemplateBodies(ast);

--- a/packages/octane/tests/bundler-compiler.test.ts
+++ b/packages/octane/tests/bundler-compiler.test.ts
@@ -26,6 +26,14 @@ const COMPONENT =
 const HOOK =
 	"import { useState } from 'octane';\n" + 'export function useCount() { return useState(0); }\n';
 
+const RENDER_STATE_UPDATE =
+	"import { useState } from 'octane';\n" +
+	'export function App(props) @{\n' +
+	'  const [value, setValue] = useState(props.value);\n' +
+	'  if (value !== props.value) setValue(props.value);\n' +
+	'  <p>{value as string}</p>\n' +
+	'}\n';
+
 function profileFiles(code: string | undefined): Set<string> {
 	if (code === undefined) return new Set();
 	const output = inspectProfileOutput(code);
@@ -37,6 +45,134 @@ function emittedHeadKey(code: string | undefined): string | undefined {
 }
 
 describe('bundler-neutral compiler integration', () => {
+	it('enforces project-wide Strong mode on both client and server without claiming dependencies', () => {
+		const compiler = createOctaneCompiler({ root: '/project', strong: true });
+
+		for (const environment of ['client', 'server'] as const) {
+			expect(() =>
+				compiler.transform(RENDER_STATE_UPDATE, '/project/src/App.tsrx', { environment }),
+			).toThrow(/OCTANE_STRONG_RENDER_STATE_UPDATE|useLinkedState/);
+			expect(() =>
+				compiler.transform(RENDER_STATE_UPDATE, '/project/node_modules/example/App.tsrx', {
+					environment,
+				}),
+			).not.toThrow();
+			expect(() =>
+				compiler.transform(RENDER_STATE_UPDATE, '/linked/example/App.tsrx', { environment }),
+			).not.toThrow();
+		}
+	});
+
+	it('does not apply application Strong mode to a separate package inside the project root', () => {
+		const root = mkdtempSync(join(tmpdir(), 'octane-strong-package-boundary-'));
+		try {
+			writeFileSync(
+				join(root, 'package.json'),
+				JSON.stringify({ name: 'application', private: true }),
+			);
+			const appDirectory = join(root, 'src');
+			const dependencyDirectory = join(root, 'packages', 'compatibility-binding');
+			mkdirSync(appDirectory, { recursive: true });
+			mkdirSync(dependencyDirectory, { recursive: true });
+			writeFileSync(
+				join(dependencyDirectory, 'package.json'),
+				JSON.stringify({ name: '@example/compatibility-binding', dependencies: { octane: '*' } }),
+			);
+			const compiler = createOctaneCompiler({ root, strong: true });
+
+			expect(() => compiler.transform(RENDER_STATE_UPDATE, join(appDirectory, 'App.tsrx'))).toThrow(
+				/OCTANE_STRONG_RENDER_STATE_UPDATE|useLinkedState/,
+			);
+			expect(() =>
+				compiler.transform(RENDER_STATE_UPDATE, join(dependencyDirectory, 'Binding.tsrx')),
+			).not.toThrow();
+			expect(() =>
+				compiler.transform(
+					`'use strong';\n${RENDER_STATE_UPDATE}`,
+					join(dependencyDirectory, 'Strong.tsrx'),
+				),
+			).toThrow(/OCTANE_STRONG_RENDER_STATE_UPDATE|useLinkedState/);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it('honors Strong directives in dependency modules that manage their own hook slots', () => {
+		const root = mkdtempSync(join(tmpdir(), 'octane-strong-manual-hook-slots-'));
+		try {
+			writeFileSync(
+				join(root, 'package.json'),
+				JSON.stringify({ name: 'application', private: true }),
+			);
+			const packageDirectory = join(root, 'packages', 'manual-binding');
+			const sourceDirectory = join(packageDirectory, 'src');
+			mkdirSync(sourceDirectory, { recursive: true });
+			writeFileSync(
+				join(packageDirectory, 'package.json'),
+				JSON.stringify({
+					name: '@example/manual-binding',
+					dependencies: { octane: '*' },
+					octane: { hookSlots: { manual: ['src'] } },
+				}),
+			);
+			const source =
+				"import { useState } from 'octane';\n" +
+				'export function useBroken() { const [value, update] = useState(0); update(value); }';
+			const compiler = createOctaneCompiler({ root, strong: true });
+			const filename = join(sourceDirectory, 'use-broken.ts');
+
+			expect(() => compiler.transform(source, filename)).not.toThrow();
+			expect(() => compiler.transform(`'use strong';\n${source}`, filename)).toThrow(
+				/OCTANE_STRONG_RENDER_STATE_UPDATE|useLinkedState/,
+			);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it('lets each module opt into Strong mode independently of the project setting', () => {
+		const compiler = createOctaneCompiler({ root: '/project', strong: false });
+		const optedIn = `'use strong';\n${RENDER_STATE_UPDATE}`;
+
+		expect(() => compiler.transform(RENDER_STATE_UPDATE, '/project/src/Legacy.tsrx')).not.toThrow();
+		expect(() => compiler.transform(optedIn, '/project/src/Strong.tsrx')).toThrow(
+			/OCTANE_STRONG_RENDER_STATE_UPDATE|useLinkedState/,
+		);
+		expect(() => compiler.transform(optedIn, '/project/node_modules/example/Strong.tsrx')).toThrow(
+			/OCTANE_STRONG_RENDER_STATE_UPDATE|useLinkedState/,
+		);
+	});
+
+	it('applies Strong mode to project-owned custom hooks without restricting deferred callbacks', () => {
+		const compiler = createOctaneCompiler({ root: '/project', strong: true });
+		const eagerHook =
+			"import { useState } from 'octane';\n" +
+			'export function useCount(value) { const [current, update] = useState(value); update(value); return current; }';
+		const deferredHook =
+			"import { useState } from 'octane';\n" +
+			'export function useCount(value) { const [current, update] = useState(value); return () => update(value); }';
+
+		expect(() => compiler.transform(eagerHook, '/project/src/use-count.ts')).toThrow(
+			/OCTANE_STRONG_RENDER_STATE_UPDATE|useLinkedState/,
+		);
+		expect(() => compiler.transform(deferredHook, '/project/src/use-count.js')).not.toThrow();
+	});
+
+	it('keeps Strong directives subordinate to mixed-toolchain ownership', () => {
+		const compiler = createOctaneCompiler({
+			root: '/project',
+			strong: true,
+			requireDirective: true,
+		});
+		const unowned = `'use strong';\n${RENDER_STATE_UPDATE}`;
+		const owned = `/** @jsxImportSource octane */\n${unowned}`;
+
+		expect(() => compiler.transform(unowned, '/project/src/Host.tsx')).not.toThrow();
+		expect(() => compiler.transform(owned, '/project/src/Island.tsx')).toThrow(
+			/OCTANE_STRONG_RENDER_STATE_UPDATE|useLinkedState/,
+		);
+	});
+
 	it('normalizes the canonical cross-adapter client-reference manifest', () => {
 		const first = {
 			id: 'octane-client-reference-v1:object:/src/First.object.tsrx',

--- a/packages/octane/tests/compiler-vite-options.test.ts
+++ b/packages/octane/tests/compiler-vite-options.test.ts
@@ -13,6 +13,14 @@ const STATEFUL_SOURCE =
 	'\t<main>{count as string}</main>\n' +
 	'}\n';
 
+const RENDER_STATE_UPDATE =
+	"import { useState } from 'octane';\n" +
+	'export function App(props) @{\n' +
+	'\tconst [count, setCount] = useState(props.count);\n' +
+	'\tif (count !== props.count) setCount(props.count);\n' +
+	'\t<main>{count as string}</main>\n' +
+	'}\n';
+
 function configure(plugin: Plugin, command: 'serve' | 'build', build: { ssr?: boolean } = {}) {
 	(plugin.config as (config: { root: string }) => unknown)({ root: ROOT });
 	(plugin.configResolved as (config: unknown) => void)({
@@ -35,6 +43,27 @@ async function transform(
 }
 
 describe('octane/compiler/vite public options', () => {
+	it('enforces the public Strong option for both client and server transforms', async () => {
+		for (const ssr of [false, true]) {
+			const plugin = octane({ hmr: false, strong: true });
+			configure(plugin, 'build', { ssr });
+
+			await expect(
+				Promise.resolve(transform(plugin, RENDER_STATE_UPDATE, `${ROOT}/src/App.tsrx`, { ssr })),
+			).rejects.toThrow(/OCTANE_STRONG_RENDER_STATE_UPDATE|useLinkedState/);
+		}
+	});
+
+	it('keeps Strong mode opt-in when its public option is disabled', async () => {
+		const plugin = octane({ hmr: false, strong: false });
+		configure(plugin, 'build');
+
+		expect(await transform(plugin, RENDER_STATE_UPDATE)).not.toBeNull();
+		await expect(
+			Promise.resolve(transform(plugin, `'use strong';\n${RENDER_STATE_UPDATE}`)),
+		).rejects.toThrow(/OCTANE_STRONG_RENDER_STATE_UPDATE|useLinkedState/);
+	});
+
 	it('changes emitted hot-update support for both hmr values', async () => {
 		const enabled = octane({ hmr: true });
 		const disabled = octane({ hmr: false });

--- a/packages/octane/tests/hydrate-compiler.test.ts
+++ b/packages/octane/tests/hydrate-compiler.test.ts
@@ -1,7 +1,10 @@
 import { parseModule } from '@tsrx/core';
 import { describe, expect, it } from 'vitest';
+import { act, flushSync, hydrateRoot } from '../src/index.js';
+import { renderToString } from 'octane/server';
 import { createOctaneCompiler } from '../src/compiler/bundler.js';
 import { compile } from '../src/compiler/compile.js';
+import { loadCompiledFixtureSource } from './_server-fixture.js';
 import { decodeMappings } from './_source-map.js';
 
 const ROOT = '/project';
@@ -157,6 +160,110 @@ function mappedOriginalPosition(code: string, map: any, needle: string) {
 }
 
 describe('Hydrate compiler splitting', () => {
+	it('hydrates a Strong-mode linked-state component and remains interactive across Suspense', async () => {
+		const source = `'use strong';
+import { Suspense, use, useLinkedState } from 'octane';
+function Draft(props) @{
+  const [value, setValue] = useLinkedState(props.source, (next) => 'draft:' + next);
+  if (props.resource !== null) use(props.resource);
+  <button id="strong-draft" onClick={() => setValue(value + '!')}>{value as string}</button>
+}
+export function App(props) @{
+  <Suspense fallback={<p id="strong-pending">loading</p>}>
+    <Draft source={props.source} resource={props.resource} />
+  </Suspense>
+}
+`;
+		const id = '/src/StrongSuspense.tsrx';
+		const server = loadCompiledFixtureSource(source, {
+			id,
+			mode: 'server',
+			compileOptions: { strong: true },
+		});
+		const client = loadCompiledFixtureSource(source, {
+			id,
+			mode: 'client',
+			compileOptions: { strong: true },
+		});
+		const container = document.createElement('div');
+		container.innerHTML = renderToString(server.App, { source: 'first', resource: null }).html;
+		const serverButton = container.querySelector('#strong-draft') as HTMLButtonElement;
+		const root = hydrateRoot(container, client.App, { source: 'first', resource: null });
+
+		try {
+			flushSync(() => {});
+			expect(container.querySelector('#strong-draft')).toBe(serverButton);
+			expect(serverButton.textContent).toBe('draft:first');
+
+			flushSync(() => serverButton.click());
+			expect(serverButton.textContent).toBe('draft:first!');
+			flushSync(() => root.render(client.App, { source: 'second', resource: null }));
+			expect(container.querySelector('#strong-draft')).toBe(serverButton);
+			expect(serverButton.textContent).toBe('draft:second');
+
+			let resolve!: () => void;
+			const resource = new Promise<void>((complete) => (resolve = complete));
+			flushSync(() => root.render(client.App, { source: 'third', resource }));
+			expect(container.querySelector('#strong-pending')?.textContent).toBe('loading');
+			await act(() => resolve());
+			expect(container.querySelector('#strong-draft')?.textContent).toBe('draft:third');
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('keeps Strong-mode state migration valid across Suspense, server rendering, and hydrate chunks', () => {
+		const source = `'use strong';
+import { Hydrate, Suspense, useLinkedState } from 'octane';
+export function App(props) @{
+  const [value, setValue] = useLinkedState(props.value);
+  <Suspense fallback={<p>loading</p>}>
+    <Hydrate when={props.ready}>
+      <button onClick={() => setValue('updated')}>{value as string}</button>
+    </Hydrate>
+  </Suspense>
+}
+`;
+		const instance = createOctaneCompiler({ root: ROOT, hmr: false, dev: false, strong: true });
+		const client = instance.transform(source, FILE, { environment: 'client' })!;
+		const child = instance.transform(source, `${FILE}?octane-hydrate=0`, {
+			environment: 'client',
+		})!;
+		const server = instance.transform(source, FILE, { environment: 'server' })!;
+
+		expect(dynamicImports(client.code)).toEqual(new Set(['./App.tsrx?octane-hydrate=0']));
+		expect(child.code).toContain('updated');
+		expect(server.code).toContain('<button>');
+		expect(server.code).not.toContain('updated');
+		expect(client.map.sourcesContent).toEqual([source]);
+		expect(child.map.sourcesContent).toEqual([source]);
+		expect(server.map.sourcesContent).toEqual([source]);
+	});
+
+	it('rejects render-phase updates consistently for server rendering and hydrate chunks', () => {
+		const source = `'use strong';
+import { Hydrate, Suspense, useState } from 'octane';
+export function App(props) @{
+  const [value, setValue] = useState(props.value);
+  if (value !== props.value) setValue(props.value);
+  <Suspense fallback={<p>loading</p>}>
+    <Hydrate when={props.ready}><p>{value as string}</p></Hydrate>
+  </Suspense>
+}
+`;
+		const instance = compiler();
+
+		for (const [id, environment] of [
+			[FILE, 'client'],
+			[`${FILE}?octane-hydrate=0`, 'client'],
+			[FILE, 'server'],
+		] as const) {
+			expect(() => instance.transform(source, id, { environment })).toThrow(
+				/OCTANE_STRONG_RENDER_STATE_UPDATE|useLinkedState/,
+			);
+		}
+	});
+
 	it('extracts aliased direct children, closes over local values, and leaves server children inline', () => {
 		const source = `
 import { Hydrate as Deferred } from 'octane';

--- a/packages/octane/tests/strong-mode.test.ts
+++ b/packages/octane/tests/strong-mode.test.ts
@@ -160,6 +160,114 @@ export function App() @{
 		expect(() => compile(source, '/src/App.tsrx')).toThrow(RENDER_STATE_UPDATE);
 	});
 
+	it.each([
+		['const assertions', '1 as const'],
+		['satisfies expressions', '1 satisfies number'],
+		['non-null assertions', '(1)!'],
+		['nested transparent wrappers', '((1 as const)!) satisfies number'],
+	])('rejects state tuple updates through computed keys with %s', (_label, key) => {
+		const source = `"use strong";
+import { useState } from 'octane';
+export function App() @{
+  const tuple = useState(0);
+  tuple[${key}](1);
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(RENDER_STATE_UPDATE);
+	});
+
+	it.each([
+		['const assertions', "'current' as const", '= 1'],
+		['satisfies expressions', "'current' satisfies string", '++'],
+		['non-null assertions', "'current'!", '= 1'],
+		['nested transparent wrappers', "(('current' as const)!) satisfies string", '++'],
+	])('rejects render-phase ref writes through computed keys with %s', (_label, key, operation) => {
+		const source = `"use strong";
+import { useRef } from 'octane';
+export function App() @{
+  const ref = useRef(0);
+  ref[${key}] ${operation};
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(RENDER_REF_WRITE);
+	});
+
+	it.each([
+		[
+			'state hook names',
+			`const tuple = Octane['useState' as const](0); tuple[1](1);`,
+			RENDER_STATE_UPDATE,
+		],
+		[
+			'effect hook names',
+			`const [, update] = Octane.useState(0); Octane['useEffect'!](() => update(1));`,
+			EFFECT_STATE_UPDATE,
+		],
+		[
+			'memo hook names',
+			`const [, update] = Octane.useState(0); Octane[('useMemo' satisfies string)](() => update(1));`,
+			RENDER_STATE_UPDATE,
+		],
+		[
+			'ref hook names',
+			`const ref = Octane['useRef' as const](0); ref.current = 1;`,
+			RENDER_REF_WRITE,
+		],
+	])('recognizes namespace hooks behind wrapped computed %s', (_label, setup, code) => {
+		const source = `"use strong";
+import * as Octane from 'octane';
+export function App() @{
+  ${setup}
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(code);
+	});
+
+	it('does not mistake genuinely dynamic computed keys for known hooks, setters, or refs', () => {
+		const source = `"use strong";
+import * as Octane from 'octane';
+export function App() @{
+  const tuple = Octane.useState(0);
+  const index = 0;
+  const ref = Octane.useRef({});
+  const property = 'value';
+  tuple[index];
+  ref[property] = 1;
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('reports wrapped computed-key violations in plain TypeScript and editor diagnostics', () => {
+		const source = `"use strong";
+import * as Octane from 'octane';
+export function useCounter() {
+  const tuple = Octane['useState' as const](0);
+  tuple[1 as const](1);
+  return tuple[0];
+}`;
+		const editorSource = `"use strong";
+import { useRef } from 'octane';
+export function App() @{
+  const ref = useRef(0);
+  ref['current'!] = 1;
+  <div />
+}`;
+		const diagnostics = compileToVolarMappings(editorSource, '/src/App.tsrx');
+
+		expect(() => slotHooks(source, '/src/useCounter.ts')).toThrow(RENDER_STATE_UPDATE);
+		expect(diagnostics.diagnostics).toContainEqual(
+			expect.objectContaining({ code: RENDER_REF_WRITE, severity: 'error' }),
+		);
+		expect(diagnostics.errors).toContainEqual(
+			expect.objectContaining({ code: RENDER_REF_WRITE, type: 'usage' }),
+		);
+	});
+
 	it('follows immutable aliases of state setters and ref objects', () => {
 		const setter = `"use strong";\n${stateComponent('const update = setCount; update(1);')}`;
 		const ref = `"use strong";
@@ -457,6 +565,42 @@ export function App() @{
 			'while (await Promise.resolve(false)) {} setCount(count + 1);',
 		],
 		[
+			'statements after an awaited false do-while test',
+			'do {} while (await Promise.resolve(false)); setCount(count + 1);',
+		],
+		[
+			'labeled do-while loops with awaited tests',
+			'outer: do {} while (await Promise.resolve(false)); setCount(count + 1);',
+		],
+		[
+			'do-while tests after an awaited loop body',
+			'do { await Promise.resolve(); } while (false); setCount(count + 1);',
+		],
+		[
+			'continue paths that still reach the awaited do-while test',
+			'do { if (count > 0) continue; } while (await Promise.resolve(false)); setCount(count + 1);',
+		],
+		[
+			'do-while test updates after yielding paths while other paths break',
+			'do { if (count > 0) break; await Promise.resolve(); } while ((setCount(count + 1), false));',
+		],
+		[
+			'breaks belonging to a nested while loop',
+			'do { while (true) { break; } } while (await Promise.resolve(false)); setCount(count + 1);',
+		],
+		[
+			'breaks belonging to a nested for loop',
+			'do { for (;;) { break; } } while (await Promise.resolve(false)); setCount(count + 1);',
+		],
+		[
+			'breaks belonging to a nested switch',
+			'do { switch (count) { case 0: break; default: break; } } while (await Promise.resolve(false)); setCount(count + 1);',
+		],
+		[
+			'breaks after an unavoidable await in the do-while body',
+			'do { await Promise.resolve(); break; } while (false); setCount(count + 1);',
+		],
+		[
 			'nested yielding loop heads',
 			'for (const values of [[count]]) { for (const value of await Promise.resolve(values)) { setCount(value); } }',
 		],
@@ -544,6 +688,34 @@ export function App() @{
 		[
 			'breaks that bypass an awaited do-while test',
 			'do { if (count > 0) break; } while (await Promise.resolve(false)); setCount(count + 1);',
+		],
+		[
+			'direct breaks that bypass an awaited do-while test',
+			'do { break; } while (await Promise.resolve(false)); setCount(count + 1);',
+		],
+		[
+			'labeled breaks that bypass an awaited do-while test',
+			'outer: do { break outer; } while (await Promise.resolve(false)); setCount(count + 1);',
+		],
+		[
+			'conditionally awaited do-while tests',
+			'do {} while (count > 0 && await Promise.resolve(false)); setCount(count + 1);',
+		],
+		[
+			'conditionally awaited do-while bodies with synchronous tests',
+			'do { if (count > 0) await Promise.resolve(); } while (false); setCount(count + 1);',
+		],
+		[
+			'unreachable awaits after escaping do-while breaks',
+			'do { break; await Promise.resolve(); } while (false); setCount(count + 1);',
+		],
+		[
+			'unreachable awaits after do-while continues',
+			'do { continue; await Promise.resolve(); } while (false); setCount(count + 1);',
+		],
+		[
+			'do-while test updates before their awaited condition',
+			'do {} while ((setCount(count + 1), await Promise.resolve(false)));',
 		],
 	])('still rejects updates in %s', (_label, body) => {
 		const render = `"use strong";\n${stateComponent(`(async () => { ${body} })();`)}`;

--- a/packages/octane/tests/strong-mode.test.ts
+++ b/packages/octane/tests/strong-mode.test.ts
@@ -403,6 +403,256 @@ export function App() @{
 	});
 
 	it.each([
+		['async iterator bodies', 'for await (const value of [count]) { setCount(value); }'],
+		[
+			'statements after empty async iterations',
+			'for await (const value of []) {} setCount(count + 1);',
+		],
+		[
+			'async iterator destructuring defaults',
+			'for await (const { value = setCount(count + 1) } of [{}]) {}',
+		],
+		[
+			'ordinary iterator bodies after an awaited iterable',
+			'for (const value of await Promise.resolve([count])) { setCount(value); }',
+		],
+		[
+			'statements after empty awaited iterables',
+			'for (const value of await Promise.resolve([])) {} setCount(count + 1);',
+		],
+		[
+			'ordinary iterator destructuring defaults after an awaited iterable',
+			'for (const { value = setCount(count + 1) } of await Promise.resolve([{}])) {}',
+		],
+		[
+			'for-in bodies after an awaited object',
+			'for (const key in await Promise.resolve({ count })) { setCount(count + 1); }',
+		],
+		[
+			'statements after empty awaited for-in objects',
+			'for (const key in await Promise.resolve({})) {} setCount(count + 1);',
+		],
+		[
+			'for-loop bodies after an awaited initializer',
+			'for (let index = await Promise.resolve(count); index < 1; index++) { setCount(index); }',
+		],
+		[
+			'statements after skipped loops with an awaited initializer',
+			'for (let index = await Promise.resolve(count); index < 0; index++) {} setCount(count + 1);',
+		],
+		[
+			'for-loop bodies after an awaited test',
+			'for (let index = 0; await Promise.resolve(index < 1); index++) { setCount(index); }',
+		],
+		[
+			'statements after an awaited false for-loop test',
+			'for (let index = 0; await Promise.resolve(index < 0); index++) {} setCount(count + 1);',
+		],
+		[
+			'while-loop bodies after an awaited test',
+			'while (await Promise.resolve(count > -1)) { setCount(count); break; }',
+		],
+		[
+			'statements after an awaited false while-loop test',
+			'while (await Promise.resolve(false)) {} setCount(count + 1);',
+		],
+		[
+			'nested yielding loop heads',
+			'for (const values of [[count]]) { for (const value of await Promise.resolve(values)) { setCount(value); } }',
+		],
+		[
+			'awaited setter arguments in loop updates',
+			'for (let index = 0; index < 1; setCount(await Promise.resolve(++index))) {}',
+		],
+	])('allows updates after guaranteed yields in %s', (_label, body) => {
+		const render = `"use strong";\n${stateComponent(`(async () => { ${body} })();`)}`;
+		const effect = `"use strong";\n${stateComponent(
+			`useEffect(() => { (async () => { ${body} })(); }, [count]);`,
+			'useState, useEffect',
+		)}`;
+		const asyncEffect = `"use strong";\n${stateComponent(
+			`useEffect(async () => { ${body} }, [count]);`,
+			'useState, useEffect',
+		)}`;
+
+		for (const source of [render, effect, asyncEffect]) {
+			expect(() => compile(source, '/src/Counter.tsrx')).not.toThrow();
+		}
+	});
+
+	it.each([
+		[
+			'async iterable expressions before the iterator yields',
+			'for await (const value of (setCount(count + 1), [count])) {}',
+		],
+		[
+			'ordinary iterable expressions before their awaited values',
+			'for (const value of (setCount(count + 1), await Promise.resolve([count]))) {}',
+		],
+		[
+			'ordinary iterator destructuring defaults before any await',
+			'for (const { value = setCount(count + 1) } of [{}]) {}',
+		],
+		[
+			'for-in sources before their awaited values',
+			'for (const key in (setCount(count + 1), await Promise.resolve({ count }))) {}',
+		],
+		[
+			'for-loop initializers before their awaited values',
+			'for (let index = (setCount(count + 1), await Promise.resolve(count)); index < 0; index++) {}',
+		],
+		[
+			'for-loop tests before their awaited values',
+			'for (; (setCount(count + 1), await Promise.resolve(false));) {}',
+		],
+		[
+			'first loop bodies before an awaited update',
+			'for (let index = 0; index < 1; await Promise.resolve(index++)) { setCount(index); }',
+		],
+		[
+			'statements after skipped loops with only an awaited update',
+			'for (let index = 0; index < 0; await Promise.resolve(index++)) {} setCount(count + 1);',
+		],
+		[
+			'statements after skipped loops whose only await is in the body',
+			'for (const value of []) { await Promise.resolve(); } setCount(count + 1);',
+		],
+		[
+			'conditionally awaited ordinary iterable expressions',
+			'for (const value of count > 0 ? await Promise.resolve([count]) : []) {} setCount(count + 1);',
+		],
+		[
+			'conditionally awaited for-in sources',
+			'for (const key in count > 0 ? await Promise.resolve({ count }) : {}) {} setCount(count + 1);',
+		],
+		[
+			'conditionally awaited for-loop initializers',
+			'for (let index = count > 0 ? await Promise.resolve(count) : 0; index < 0; index++) {} setCount(count + 1);',
+		],
+		[
+			'conditionally awaited for-loop tests',
+			'for (let index = 0; count > 0 && await Promise.resolve(index < 0); index++) {} setCount(count + 1);',
+		],
+		[
+			'conditionally awaited while-loop tests',
+			'while (count > 0 && await Promise.resolve(false)) {} setCount(count + 1);',
+		],
+		[
+			'do-while bodies before the first awaited test',
+			'do { setCount(count + 1); } while (await Promise.resolve(false));',
+		],
+		[
+			'breaks that bypass an awaited do-while test',
+			'do { if (count > 0) break; } while (await Promise.resolve(false)); setCount(count + 1);',
+		],
+	])('still rejects updates in %s', (_label, body) => {
+		const render = `"use strong";\n${stateComponent(`(async () => { ${body} })();`)}`;
+		const effect = `"use strong";\n${stateComponent(
+			`useEffect(async () => { ${body} }, [count]);`,
+			'useState, useEffect',
+		)}`;
+
+		expect(() => compile(render, '/src/Counter.tsrx')).toThrow(RENDER_STATE_UPDATE);
+		expect(() => compile(effect, '/src/Counter.tsrx')).toThrow(EFFECT_STATE_UPDATE);
+	});
+
+	it.each([
+		[
+			'classic loop initializers',
+			'for (let setCount = () => {}, index = 0; index < 1; index++) { setCount(); }',
+		],
+		['ordinary iteration bindings', 'for (const setCount of [() => {}]) { setCount(); }'],
+		['async iteration bindings', 'for await (const setCount of [() => {}]) { setCount(); }'],
+	])('does not mistake state updaters shadowed by %s', (_label, body) => {
+		const source = `"use strong";\n${stateComponent(`(async () => { ${body} })();`)}`;
+
+		expect(() => compile(source, '/src/Counter.tsrx')).not.toThrow();
+	});
+
+	it('does not mistake ref objects shadowed by iteration bindings', () => {
+		const source = `"use strong";
+import { useRef } from 'octane';
+export function App() @{
+  const ref = useRef(0);
+  for (const ref of [{ current: 0 }]) {
+    ref.current = 1;
+  }
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it.each([
+		{ mode: 'client', dev: true },
+		{ mode: 'client', dev: false },
+		{ mode: 'server', dev: true },
+		{ mode: 'server', dev: false },
+	])('preserves yielding loop heads during $mode compilation with dev=$dev', (options) => {
+		const source = `"use strong";\n${stateComponent(
+			`useEffect(async () => {
+      for await (const value of [count]) {
+        setCount(value);
+      }
+      for (const value of await Promise.resolve([])) {}
+      setCount(count + 1);
+    }, [count]);`,
+			'useState, useEffect',
+		)}`;
+
+		expect(() => compile(source, '/src/Counter.tsrx', options)).not.toThrow();
+	});
+
+	it('applies yielding loop rules to plain TypeScript custom hooks', () => {
+		const source = `"use strong";
+import { useEffect, useState } from 'octane';
+export function useCounter() {
+  const [count, setCount] = useState(0);
+  useEffect(async () => {
+    for await (const value of [count]) {
+      setCount(value);
+    }
+    for (const value of await Promise.resolve([])) {}
+    setCount(count + 1);
+  }, [count]);
+  return count;
+}`;
+		const synchronous = source.replace(
+			'for await (const value of [count])',
+			'for await (const value of (setCount(count + 1), [count]))',
+		);
+
+		expect(() => slotHooks(source, '/src/useCounter.ts')).not.toThrow();
+		expect(() => slotHooks(synchronous, '/src/useCounter.ts')).toThrow(EFFECT_STATE_UPDATE);
+	});
+
+	it('publishes editor errors only for synchronous updates in yielding loops', () => {
+		const source = `"use strong";\n${stateComponent(
+			`useEffect(async () => {
+      for await (const value of [count]) {
+        setCount(value);
+      }
+    }, [count]);`,
+			'useState, useEffect',
+		)}`;
+		const synchronous = source.replace(
+			'for await (const value of [count])',
+			'for await (const value of (setCount(count + 1), [count]))',
+		);
+		const valid = compileToVolarMappings(source, '/src/Counter.tsrx');
+		const rejected = compileToVolarMappings(synchronous, '/src/Counter.tsrx');
+
+		expect(valid.diagnostics).toEqual([]);
+		expect(valid.errors).toEqual([]);
+		expect(rejected.diagnostics).toContainEqual(
+			expect.objectContaining({ code: EFFECT_STATE_UPDATE, severity: 'error' }),
+		);
+		expect(rejected.errors).toContainEqual(
+			expect.objectContaining({ code: EFFECT_STATE_UPDATE, type: 'usage' }),
+		);
+	});
+
+	it.each([
 		{ mode: 'client', dev: true },
 		{ mode: 'client', dev: false },
 		{ mode: 'server', dev: true },

--- a/packages/octane/tests/strong-mode.test.ts
+++ b/packages/octane/tests/strong-mode.test.ts
@@ -147,6 +147,82 @@ export function App() @{
 		expect(() => compile(callback, '/src/App.tsrx')).toThrow(RENDER_STATE_UPDATE);
 	});
 
+	it.each([
+		[
+			'named function declarations',
+			'function apply() { setCount(count + 1); } useMemo(apply, [count]);',
+		],
+		[
+			'named function expressions',
+			'const apply = () => setCount(count + 1); useMemo(apply, [count]);',
+		],
+		[
+			'aliased named callbacks',
+			'const apply = () => setCount(count + 1); const calculate = apply; useMemo(calculate, [count]);',
+		],
+		['state updaters', 'useMemo(setCount, [count]);'],
+		['aliased state updaters', 'const update = setCount; useMemo(update, [count]);'],
+		[
+			'TypeScript-wrapped named callbacks',
+			'const apply = () => setCount(count + 1); useMemo((apply as () => void), [count]);',
+		],
+	])('rejects render updates through useMemo %s', (_label, setup) => {
+		const source = `"use strong";\n${stateComponent(setup, 'useState, useMemo')}`;
+
+		expect(() => compile(source, '/src/Counter.tsrx')).toThrow(RENDER_STATE_UPDATE);
+	});
+
+	it.each([
+		[
+			'aliased imports',
+			`import { useMemo as memo, useState } from 'octane';
+export function App() @{ const [, update] = useState(0); memo(update, []); <div /> }`,
+		],
+		[
+			'namespace imports',
+			`import * as Octane from 'octane';
+export function App() @{ const [, update] = Octane.useState(0); Octane.useMemo(update, []); <div /> }`,
+		],
+		[
+			'wrapped namespace properties',
+			`import * as Octane from 'octane';
+export function App() @{ const [, update] = Octane.useState(0); Octane['useMemo' as const](update, []); <div /> }`,
+		],
+	])('tracks named memo callbacks through %s', (_label, source) => {
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).toThrow(RENDER_STATE_UPDATE);
+	});
+
+	it('keeps deferred, unknown, and shadowed named memo callbacks legal', () => {
+		const source = `"use strong";
+import { useMemo, useState } from 'octane';
+export function App(props) @{
+  const [count, setCount] = useState(0);
+  const apply = () => setTimeout(() => setCount(count + 1), 0);
+  const external = props.calculate;
+  useMemo(apply, [count]);
+  useMemo(external, [count]);
+  useMemo(() => () => setCount(count + 1), [count]);
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('publishes named memo state updates as editor errors', () => {
+		const source = `"use strong";\n${stateComponent(
+			'const apply = () => setCount(count + 1); useMemo(apply, [count]);',
+			'useState, useMemo',
+		)}`;
+		const result = compileToVolarMappings(source, '/src/Counter.tsrx');
+
+		expect(result.diagnostics).toContainEqual(
+			expect.objectContaining({ code: RENDER_STATE_UPDATE, severity: 'error' }),
+		);
+		expect(result.errors).toContainEqual(
+			expect.objectContaining({ code: RENDER_STATE_UPDATE, type: 'usage' }),
+		);
+	});
+
 	it('recognizes state updater access through immutable state tuple aliases', () => {
 		const source = `"use strong";
 import { useState } from 'octane';
@@ -572,6 +648,51 @@ export function App() @{
 			'labeled do-while loops with awaited tests',
 			'outer: do {} while (await Promise.resolve(false)); setCount(count + 1);',
 		],
+		['labeled await expressions', 'completed: await Promise.resolve(); setCount(count + 1);'],
+		[
+			'labeled blocks with unavoidable awaits',
+			'completed: { await Promise.resolve(); } setCount(count + 1);',
+		],
+		[
+			'nested labeled blocks with unavoidable awaits',
+			'outer: { inner: { await Promise.resolve(); } } setCount(count + 1);',
+		],
+		[
+			'labeled while loops with awaited tests',
+			'outer: while (await Promise.resolve(false)) {} setCount(count + 1);',
+		],
+		[
+			'switch cases after an awaited discriminant',
+			'switch (await Promise.resolve(count)) { case 0: setCount(count + 1); break; }',
+		],
+		[
+			'statements after awaited switch discriminants',
+			'switch (await Promise.resolve(count)) {} setCount(count + 1);',
+		],
+		[
+			'switch case updates after an awaited case label',
+			'switch (count) { case await Promise.resolve(0): setCount(count + 1); break; }',
+		],
+		[
+			'statements after an unavoidable awaited first case label',
+			'switch (count) { case await Promise.resolve(0): break; } setCount(count + 1);',
+		],
+		[
+			'switch case updates after their own awaits',
+			'switch (count) { case 0: await Promise.resolve(); setCount(count + 1); break; }',
+		],
+		[
+			'statements after switches where every branch awaits',
+			'switch (count) { case 0: await Promise.resolve(); break; default: await Promise.resolve(); } setCount(count + 1);',
+		],
+		[
+			'fall-through switch branches with a shared unavoidable await',
+			'switch (count) { case 0: case 1: await Promise.resolve(); setCount(count + 1); break; default: await Promise.resolve(); }',
+		],
+		[
+			'labeled switches with an awaited discriminant',
+			'outer: switch (await Promise.resolve(count)) { case 0: break outer; } setCount(count + 1);',
+		],
 		[
 			'do-while tests after an awaited loop body',
 			'do { await Promise.resolve(); } while (false); setCount(count + 1);',
@@ -698,6 +819,30 @@ export function App() @{
 			'outer: do { break outer; } while (await Promise.resolve(false)); setCount(count + 1);',
 		],
 		[
+			'labeled block exits before their awaited statements',
+			'outer: { if (count > 0) break outer; await Promise.resolve(); } setCount(count + 1);',
+		],
+		[
+			'switches without a default when no awaited case matches',
+			'switch (count) { case 0: await Promise.resolve(); break; } setCount(count + 1);',
+		],
+		[
+			'switch cases that can break before their await',
+			'switch (count) { case 0: break; default: await Promise.resolve(); } setCount(count + 1);',
+		],
+		[
+			'direct switch-case entries that skip an earlier awaited fall-through',
+			'switch (count) { case 0: await Promise.resolve(); case 1: setCount(count + 1); break; }',
+		],
+		[
+			'conditionally awaited switch discriminants',
+			'switch (count > 0 ? await Promise.resolve(count) : count) {} setCount(count + 1);',
+		],
+		[
+			'labeled switch breaks before their awaited statements',
+			'outer: switch (count) { case 0: break outer; default: await Promise.resolve(); } setCount(count + 1);',
+		],
+		[
 			'conditionally awaited do-while tests',
 			'do {} while (count > 0 && await Promise.resolve(false)); setCount(count + 1);',
 		],
@@ -753,6 +898,14 @@ export function App() @{
 }`;
 
 		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('does not mistake state updaters shadowed by switch-scope declarations', () => {
+		const source = `"use strong";\n${stateComponent(
+			'switch (count) { case 0: { const setCount = () => {}; setCount(); break; } }',
+		)}`;
+
+		expect(() => compile(source, '/src/Counter.tsrx')).not.toThrow();
 	});
 
 	it.each([

--- a/packages/octane/tests/strong-mode.test.ts
+++ b/packages/octane/tests/strong-mode.test.ts
@@ -422,6 +422,35 @@ export function App() @{
 		expect(() => compile(source, '/src/Counter.tsrx')).toThrow(EFFECT_STATE_UPDATE);
 	});
 
+	it.each([
+		['memo callbacks', 'useMemo(state[1], []);', RENDER_STATE_UPDATE],
+		['wrapped memo callback indices', 'useMemo(state[1 as const], []);', RENDER_STATE_UPDATE],
+		['effect callbacks', 'useEffect(state[1], []);', EFFECT_STATE_UPDATE],
+		['wrapped effect callback indices', 'useEffect(state[1 as const], []);', EFFECT_STATE_UPDATE],
+	])('rejects state tuple updaters used as %s', (_label, callback, code) => {
+		const source = `"use strong";
+import { useEffect, useMemo, useState } from 'octane';
+export function App() @{
+  const state = useState(0);
+  ${callback}
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(code);
+	});
+
+	it('allows state tuple memo callbacks after yielded dependency arguments', () => {
+		const source = `"use strong";
+import { useMemo, useState } from 'octane';
+export function App() @{
+  const state = useState(0);
+  (async () => { useMemo(state[1], [await Promise.resolve(state[0])]); })();
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
 	it('catches synchronous local callback invocation inside effect setup', () => {
 		const source = `"use strong";\n${stateComponent(
 			'useEffect(() => { const apply = () => setCount(1); apply(); }, []);',
@@ -538,6 +567,283 @@ export function App() @{
 		for (const source of [render, effect, asyncEffect]) {
 			expect(() => compile(source, '/src/Counter.tsrx')).not.toThrow();
 		}
+	});
+
+	it.each([
+		[
+			'awaited ternary conditions',
+			'(await Promise.resolve(count > 0)) ? setCount(1) : setCount(2);',
+		],
+		[
+			'conditionally selected branches that yield before updating',
+			'count > 0 ? (await Promise.resolve(), setCount(1)) : count;',
+		],
+		[
+			'ternary branches that both yield before a later operand',
+			'(count > 0 ? await Promise.resolve(1) : await Promise.resolve(2), setCount(3));',
+		],
+		['awaited logical AND operands', '(await Promise.resolve(true)) && setCount(1);'],
+		['awaited logical OR operands', '(await Promise.resolve(false)) || setCount(1);'],
+		['awaited nullish-coalescing operands', '(await Promise.resolve(null)) ?? setCount(1);'],
+		[
+			'conditionally selected logical branches that yield before updating',
+			'count > 0 && (await Promise.resolve(), setCount(1));',
+		],
+		['comma expressions', '(await Promise.resolve(), setCount(1));'],
+		['later comma operands', '(count, await Promise.resolve(), setCount(1));'],
+		[
+			'transparently wrapped awaited operands',
+			'((await Promise.resolve(true)) as boolean) ? setCount(1) : setCount(2);',
+		],
+		['binary operands', '(await Promise.resolve(1)) + setCount(1);'],
+		['array elements', '[await Promise.resolve(count), setCount(1)];'],
+		['object properties', 'void ({ first: await Promise.resolve(count), second: setCount(1) });'],
+		['computed object properties', 'void ({ [await Promise.resolve("value")]: setCount(1) });'],
+		[
+			'object spread properties',
+			'void ({ ...(await Promise.resolve({ count })), value: setCount(1) });',
+		],
+		['function arguments', 'Promise.resolve(await Promise.resolve(count), setCount(1));'],
+		['callee expressions', '([() => {}][await Promise.resolve(0)])(setCount(1));'],
+		[
+			'immediately invoked function arguments',
+			'(() => setCount(1))(await Promise.resolve(count));',
+		],
+		[
+			'named synchronously invoked function arguments',
+			'const apply = () => setCount(1); apply(await Promise.resolve(count));',
+		],
+		[
+			'default parameters after yielded function arguments',
+			'((value = setCount(1)) => value)(await Promise.resolve(undefined));',
+		],
+		[
+			'constructor arguments',
+			'new Error(await Promise.resolve("message"), { cause: setCount(1) });',
+		],
+		[
+			'named constructors after yielded arguments',
+			'function Update() { setCount(1); } new Update(await Promise.resolve(count));',
+		],
+		[
+			'inline constructors after yielded arguments',
+			'new (function Update() { setCount(1); })(await Promise.resolve(count));',
+		],
+		[
+			'constructor arguments after yielded class heritage',
+			'new (class extends (await Promise.resolve(Object)) { constructor(value) { super(); } })(setCount(1));',
+		],
+		[
+			'optional-call arguments when their earlier arguments yield',
+			'const target = { update() {} }; target?.update(await Promise.resolve(count), setCount(1));',
+		],
+		['computed member properties', '(await Promise.resolve({}))[setCount(1)];'],
+		['optional computed member properties', '(await Promise.resolve({}))?.[setCount(1)];'],
+		[
+			'later properties in a continuous optional chain',
+			'const target = count > 0 ? { value: {} } : null; target?.[await Promise.resolve("value")][setCount(1)];',
+		],
+		[
+			'optional properties after a grouped optional chain',
+			'const target = count > 0 ? { value: {} } : null; (target?.[await Promise.resolve("value")])?.[setCount(1)];',
+		],
+		[
+			'optional calls after a grouped optional property',
+			'const target = count > 0 ? { update() {} } : null; (target?.[await Promise.resolve("update")])?.(setCount(1));',
+		],
+		[
+			'optional properties after a grouped optional call',
+			'const target = count > 0 ? () => ({}) : null; (target?.(await Promise.resolve(count)))?.[setCount(1)];',
+		],
+		[
+			'assignment expressions',
+			'const target = {}; target[await Promise.resolve("value")] = setCount(1);',
+		],
+		[
+			'conditionally evaluated logical-assignment branches',
+			'let value = count; value &&= (await Promise.resolve(), setCount(1));',
+		],
+		['template expressions', '`first ${await Promise.resolve(count)} second ${setCount(1)}`;'],
+		['tagged template expressions', '(await Promise.resolve(String.raw))`count ${setCount(1)}`;'],
+		[
+			'tagged callbacks after yielded substitutions',
+			'const apply = () => setCount(1); apply`count ${await Promise.resolve(count)}`;',
+		],
+		[
+			'later variable declarators',
+			'const previous = await Promise.resolve(count), next = setCount(1);',
+		],
+		[
+			'destructuring defaults after yielded initializers',
+			'const { value = setCount(1) } = await Promise.resolve({});',
+		],
+		[
+			'destructuring defaults after yielded computed keys',
+			'const { [await Promise.resolve("value")]: value = setCount(1) } = {};',
+		],
+		[
+			'destructuring assignments after yielded values',
+			'let value; ({ value = setCount(1) } = await Promise.resolve({}));',
+		],
+		[
+			'destructuring assignments after yielded computed keys',
+			'let value; ({ [await Promise.resolve("value")]: value = setCount(1) } = {});',
+		],
+		[
+			'array destructuring assignments after yielded values',
+			'let value; [value = setCount(1)] = await Promise.resolve([]);',
+		],
+	])('allows expression updates after guaranteed yields in %s', (_label, body) => {
+		const render = `"use strong";\n${stateComponent(`(async () => { ${body} })();`)}`;
+		const effect = `"use strong";\n${stateComponent(
+			`useEffect(() => { (async () => { ${body} })(); }, [count]);`,
+			'useState, useEffect',
+		)}`;
+		const asyncEffect = `"use strong";\n${stateComponent(
+			`useEffect(async () => { ${body} }, [count]);`,
+			'useState, useEffect',
+		)}`;
+
+		for (const source of [render, effect, asyncEffect]) {
+			expect(() => compile(source, '/src/Counter.tsrx')).not.toThrow();
+		}
+	});
+
+	it.each([
+		[
+			'ternary updates before their branch yields',
+			'count > 0 ? (setCount(1), await Promise.resolve()) : count;',
+		],
+		[
+			'ternary updates when only the other branch yields',
+			'count > 0 ? setCount(1) : await Promise.resolve();',
+		],
+		[
+			'updates after conditionally awaited ternary expressions',
+			'(count > 0 ? await Promise.resolve() : count, setCount(1));',
+		],
+		[
+			'updates after conditionally awaited logical expressions',
+			'(count > 0 && await Promise.resolve(), setCount(1));',
+		],
+		[
+			'logical updates before their selected branch yields',
+			'count > 0 && (setCount(1), await Promise.resolve());',
+		],
+		['comma operands before their await', '(setCount(1), await Promise.resolve());'],
+		['binary operands before their await', 'setCount(1) + (await Promise.resolve(count));'],
+		['array elements before their await', '[setCount(1), await Promise.resolve(count)];'],
+		[
+			'object properties before their await',
+			'void ({ first: setCount(1), second: await Promise.resolve(count) });',
+		],
+		[
+			'function arguments before their await',
+			'Promise.resolve(setCount(1), await Promise.resolve(count));',
+		],
+		[
+			'optional calls whose arguments can be skipped',
+			'const target = count > 0 ? { update() {} } : null; (target?.update(await Promise.resolve()), setCount(1));',
+		],
+		[
+			'optional computed properties that can be skipped',
+			'const target = count > 0 ? {} : null; (target?.[await Promise.resolve("value")], setCount(1));',
+		],
+		[
+			'grouped optional chains whose computed properties can be skipped',
+			'const target = count > 0 ? {} : null; (target?.[await Promise.resolve("value")])[setCount(1)];',
+		],
+		[
+			'grouped optional calls whose arguments can be skipped',
+			'const target = count > 0 ? () => ({}) : null; (target?.(await Promise.resolve(count)))[setCount(1)];',
+		],
+		[
+			'assignment operands before their await',
+			'const target = {}; target[setCount(1)] = await Promise.resolve(count);',
+		],
+		[
+			'logical AND assignments whose awaited right side can be skipped',
+			'let value = count; value &&= await Promise.resolve(1); setCount(1);',
+		],
+		[
+			'logical OR assignments whose awaited right side can be skipped',
+			'let value = count; value ||= await Promise.resolve(1); setCount(1);',
+		],
+		[
+			'nullish assignments whose awaited right side can be skipped',
+			'let value = count; value ??= await Promise.resolve(1); setCount(1);',
+		],
+		[
+			'template expressions before their await',
+			'`first ${setCount(1)} second ${await Promise.resolve(count)}`;',
+		],
+		[
+			'variable declarators before their await',
+			'const previous = setCount(1), next = await Promise.resolve(count);',
+		],
+		[
+			'destructuring assignments whose defaults run synchronously',
+			'let value; ({ value = setCount(1) } = {});',
+		],
+		[
+			'destructuring assignment defaults before a later computed-key await',
+			'let first, second; ({ first = setCount(1), [await Promise.resolve("second")]: second } = {});',
+		],
+		[
+			'immediately invoked tagged callbacks before an await',
+			'const apply = () => setCount(1); apply`count`;',
+		],
+		[
+			'named constructors invoked before an await',
+			'function Update() { setCount(1); } new Update();',
+		],
+		['inline constructors invoked before an await', 'new (function Update() { setCount(1); })();'],
+	])('still rejects expression updates in %s', (_label, body) => {
+		const render = `"use strong";\n${stateComponent(`(async () => { ${body} })();`)}`;
+		const effect = `"use strong";\n${stateComponent(
+			`useEffect(async () => { ${body} }, [count]);`,
+			'useState, useEffect',
+		)}`;
+
+		expect(() => compile(render, '/src/Counter.tsrx')).toThrow(RENDER_STATE_UPDATE);
+		expect(() => compile(effect, '/src/Counter.tsrx')).toThrow(EFFECT_STATE_UPDATE);
+	});
+
+	it.each([
+		['inline memo callbacks', 'useMemo(() => setCount(1), [await Promise.resolve(count)]);'],
+		[
+			'named memo callbacks',
+			'const calculate = () => setCount(1); useMemo(calculate, [await Promise.resolve(count)]);',
+		],
+		['state updaters as memo callbacks', 'useMemo(setCount, [await Promise.resolve(count)]);'],
+	])('allows %s when earlier arguments have yielded', (_label, body) => {
+		const source = `"use strong";\n${stateComponent(
+			`(async () => { ${body} })();`,
+			'useState, useMemo',
+		)}`;
+
+		expect(() => compile(source, '/src/Counter.tsrx')).not.toThrow();
+	});
+
+	it('still rejects memo callbacks when awaited arguments can be skipped', () => {
+		const source = `"use strong";\n${stateComponent(
+			'(async () => { useMemo(() => setCount(1), [count > 0 && await Promise.resolve(count)]); })();',
+			'useState, useMemo',
+		)}`;
+
+		expect(() => compile(source, '/src/Counter.tsrx')).toThrow(RENDER_STATE_UPDATE);
+	});
+
+	it.each([
+		['inline arrow functions', 'new (() => setCount(1))();'],
+		['named arrow functions', 'const Update = () => setCount(1); new Update();'],
+		['inline async functions', 'new (async function Update() { setCount(1); })();'],
+		['named async functions', 'async function Update() { setCount(1); } new Update();'],
+		['generator functions', 'new (function* Update() { setCount(1); })();'],
+	])('does not invoke nonconstructable %s during render', (_label, body) => {
+		const source = `"use strong";\n${stateComponent(`(async () => { ${body} })();`)}`;
+
+		expect(() => compile(source, '/src/Counter.tsrx')).not.toThrow();
 	});
 
 	it.each([
@@ -1056,6 +1362,103 @@ export function useCounter() {
 		expect(rejected.errors).toContainEqual(
 			expect.objectContaining({ code: EFFECT_STATE_UPDATE, type: 'usage' }),
 		);
+	});
+
+	it.each([
+		{ mode: 'client', dev: true },
+		{ mode: 'client', dev: false },
+		{ mode: 'server', dev: true },
+		{ mode: 'server', dev: false },
+	])(
+		'preserves yielded expression evaluation during $mode compilation with dev=$dev',
+		(options) => {
+			const source = `"use strong";\n${stateComponent(
+				`useEffect(async () => {
+      (await Promise.resolve(count > 0)) ? setCount(1) : setCount(2);
+      Promise.resolve(await Promise.resolve(count), setCount(3));
+      const { value = setCount(4) } = await Promise.resolve({});
+    }, [count]);`,
+				'useState, useEffect',
+			)}`;
+
+			expect(() => compile(source, '/src/Counter.tsrx', options)).not.toThrow();
+		},
+	);
+
+	it('applies yielded expression ordering to plain TypeScript custom hooks', () => {
+		const source = `"use strong";
+import { useEffect, useState } from 'octane';
+export function useCounter() {
+  const [count, setCount] = useState(0);
+  useEffect(async () => {
+    (await Promise.resolve(count > 0)) ? setCount(1) : setCount(2);
+    Promise.resolve(await Promise.resolve(count), setCount(3));
+  }, [count]);
+  return count;
+}`;
+		const synchronous = source.replace(
+			'(await Promise.resolve(count > 0)) ? setCount(1) : setCount(2);',
+			'count > 0 ? setCount(1) : await Promise.resolve(count);',
+		);
+
+		expect(() => slotHooks(source, '/src/useCounter.ts')).not.toThrow();
+		expect(() => slotHooks(synchronous, '/src/useCounter.ts')).toThrow(EFFECT_STATE_UPDATE);
+	});
+
+	it('publishes editor errors only for synchronously evaluated expression updates', () => {
+		const source = `"use strong";\n${stateComponent(
+			`useEffect(async () => {
+      (await Promise.resolve(count > 0)) ? setCount(1) : setCount(2);
+    }, [count]);`,
+			'useState, useEffect',
+		)}`;
+		const synchronous = source.replace(
+			'(await Promise.resolve(count > 0)) ? setCount(1) : setCount(2);',
+			'count > 0 ? setCount(1) : await Promise.resolve(count);',
+		);
+		const valid = compileToVolarMappings(source, '/src/Counter.tsrx');
+		const rejected = compileToVolarMappings(synchronous, '/src/Counter.tsrx');
+
+		expect(valid.diagnostics).toEqual([]);
+		expect(valid.errors).toEqual([]);
+		expect(rejected.diagnostics).toContainEqual(
+			expect.objectContaining({ code: EFFECT_STATE_UPDATE, severity: 'error' }),
+		);
+		expect(rejected.errors).toContainEqual(
+			expect.objectContaining({ code: EFFECT_STATE_UPDATE, type: 'usage' }),
+		);
+	});
+
+	it.each([
+		['assignments', 'ref.current = await Promise.resolve(1);'],
+		['compound assignments', 'ref.current += await Promise.resolve(1);'],
+		[
+			'awaited conditional tests',
+			'(await Promise.resolve(true)) ? (ref.current = 1) : (ref.current = 2);',
+		],
+		['later comma operands', '(await Promise.resolve(), ref.current++);'],
+	])('allows ref writes after yields in %s', (_label, body) => {
+		const source = `"use strong";
+import { useRef } from 'octane';
+export function App() @{
+  const ref = useRef(0);
+  (async () => { ${body} })();
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('still rejects ref writes evaluated before a later yield', () => {
+		const source = `"use strong";
+import { useRef } from 'octane';
+export function App() @{
+  const ref = useRef(0);
+  (async () => { ref.current = (ref.current++, await Promise.resolve(1)); })();
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(RENDER_REF_WRITE);
 	});
 
 	it.each(['ref.current = 1;', 'ref.current++;', "ref['current'] = 1;"])(

--- a/packages/octane/tests/strong-mode.test.ts
+++ b/packages/octane/tests/strong-mode.test.ts
@@ -306,6 +306,183 @@ export function App() @{
 		expect(() => compile(conditionalObject, '/src/Counter.tsrx')).toThrow(RENDER_STATE_UPDATE);
 	});
 
+	it.each([
+		['standalone blocks', '{ await Promise.resolve(); setCount(1); }'],
+		['statements after standalone blocks', '{ await Promise.resolve(); } setCount(1);'],
+		[
+			'deeply nested blocks',
+			'{ { const next = await Promise.resolve(count + 1); setCount(next); } }',
+		],
+		['conditional branches', 'if (count > -1) { await Promise.resolve(); setCount(1); }'],
+		[
+			'branches that both yield',
+			'if (count > 0) { await Promise.resolve(); } else { await Promise.resolve(); } setCount(1);',
+		],
+		['awaited conditional tests', 'if (await Promise.resolve(count > -1)) setCount(1);'],
+		[
+			'awaited optional-chain receivers',
+			'const target = { update: () => {} }; (await Promise.resolve(target))?.update(); setCount(1);',
+		],
+		[
+			'try blocks',
+			'try { const next = await Promise.resolve(count + 1); setCount(next); } catch {}',
+		],
+		[
+			'catch blocks',
+			'try { throw new Error("retry"); } catch { const next = await Promise.resolve(1); setCount(next); }',
+		],
+		[
+			'try and catch branches that both yield',
+			'try { await Promise.resolve(); } catch { await Promise.resolve(); } setCount(1);',
+		],
+		['finally blocks', 'try {} finally { await Promise.resolve(); setCount(1); }'],
+		[
+			'statements after awaited finally blocks',
+			'try {} finally { await Promise.resolve(); } setCount(1);',
+		],
+	])('allows updates after guaranteed awaits in nested %s', (_label, body) => {
+		const render = `"use strong";\n${stateComponent(`(async () => { ${body} })();`)}`;
+		const effect = `"use strong";\n${stateComponent(
+			`useEffect(() => { (async () => { ${body} })(); }, [count]);`,
+			'useState, useEffect',
+		)}`;
+		const asyncEffect = `"use strong";\n${stateComponent(
+			`useEffect(async () => { ${body} }, [count]);`,
+			'useState, useEffect',
+		)}`;
+
+		for (const source of [render, effect, asyncEffect]) {
+			expect(() => compile(source, '/src/Counter.tsrx')).not.toThrow();
+		}
+	});
+
+	it.each([
+		['updates before a nested await', '{ setCount(1); await Promise.resolve(); }'],
+		[
+			'conditionally executed nested awaits',
+			'{ if (count > 0) await Promise.resolve(); setCount(1); }',
+		],
+		[
+			'conditional branches without an alternative',
+			'if (count > 0) { await Promise.resolve(); } setCount(1);',
+		],
+		[
+			'branches where only one arm yields',
+			'if (count > 0) { await Promise.resolve(); } else {} setCount(1);',
+		],
+		['short-circuited awaits', 'count > 0 && await Promise.resolve(); setCount(1);'],
+		[
+			'optional chains that can skip awaited arguments',
+			'const target = count > 0 ? { update: () => {} } : null; target?.update(await Promise.resolve()); setCount(1);',
+		],
+		[
+			'updates before awaits in try blocks',
+			'try { setCount(1); await Promise.resolve(); } catch {}',
+		],
+		[
+			'updates before awaits in catch blocks',
+			'try { throw new Error("retry"); } catch { setCount(1); await Promise.resolve(); }',
+		],
+		[
+			'catch branches that can continue without yielding',
+			'try { await Promise.resolve(); } catch {} setCount(1);',
+		],
+		[
+			'finally blocks that can run synchronously',
+			'try { await Promise.resolve(); } finally { setCount(1); }',
+		],
+	])('still rejects %s', (_label, body) => {
+		const render = `"use strong";\n${stateComponent(`(async () => { ${body} })();`)}`;
+		const effect = `"use strong";\n${stateComponent(
+			`useEffect(async () => { ${body} }, [count]);`,
+			'useState, useEffect',
+		)}`;
+
+		expect(() => compile(render, '/src/Counter.tsrx')).toThrow(RENDER_STATE_UPDATE);
+		expect(() => compile(effect, '/src/Counter.tsrx')).toThrow(EFFECT_STATE_UPDATE);
+	});
+
+	it.each([
+		{ mode: 'client', dev: true },
+		{ mode: 'client', dev: false },
+		{ mode: 'server', dev: true },
+		{ mode: 'server', dev: false },
+	])('preserves nested async effect updates during $mode compilation with dev=$dev', (options) => {
+		const source = `"use strong";\n${stateComponent(
+			`useEffect(() => {
+      (async () => {
+        try {
+          const next = await Promise.resolve(count + 1);
+          setCount(next);
+        } catch {
+          await Promise.resolve();
+          setCount(0);
+        }
+      })();
+    }, [count]);`,
+			'useState, useEffect',
+		)}`;
+
+		expect(() => compile(source, '/src/Counter.tsrx', options)).not.toThrow();
+	});
+
+	it('accepts nested async effect updates in plain TypeScript custom hooks', () => {
+		const source = `"use strong";
+import { useEffect, useState } from 'octane';
+export function useCounter() {
+  const [count, setCount] = useState(0);
+  useEffect(() => {
+    (async () => {
+      try {
+        const next = await Promise.resolve(count + 1);
+        setCount(next);
+      } catch {
+        await Promise.resolve();
+        setCount(0);
+      }
+    })();
+  }, [count]);
+  return count;
+}`;
+		const synchronous = source.replace(
+			'const next = await Promise.resolve(count + 1);\n        setCount(next);',
+			'setCount(count + 1);\n        await Promise.resolve();',
+		);
+
+		expect(() => slotHooks(source, '/src/useCounter.ts')).not.toThrow();
+		expect(() => slotHooks(synchronous, '/src/useCounter.ts')).toThrow(EFFECT_STATE_UPDATE);
+	});
+
+	it('does not publish editor errors for legitimately deferred nested async updates', () => {
+		const source = `"use strong";\n${stateComponent(
+			`useEffect(async () => {
+      try {
+        const next = await Promise.resolve(count + 1);
+        setCount(next);
+      } catch {
+        await Promise.resolve();
+        setCount(0);
+      }
+    }, [count]);`,
+			'useState, useEffect',
+		)}`;
+		const result = compileToVolarMappings(source, '/src/Counter.tsrx');
+		const synchronous = source.replace(
+			'const next = await Promise.resolve(count + 1);\n        setCount(next);',
+			'setCount(count + 1);\n        await Promise.resolve();',
+		);
+		const rejected = compileToVolarMappings(synchronous, '/src/Counter.tsrx');
+
+		expect(result.diagnostics).toEqual([]);
+		expect(result.errors).toEqual([]);
+		expect(rejected.diagnostics).toContainEqual(
+			expect.objectContaining({ code: EFFECT_STATE_UPDATE, severity: 'error' }),
+		);
+		expect(rejected.errors).toContainEqual(
+			expect.objectContaining({ code: EFFECT_STATE_UPDATE, type: 'usage' }),
+		);
+	});
+
 	it.each(['ref.current = 1;', 'ref.current++;', "ref['current'] = 1;"])(
 		'rejects render-phase useRef writes: %s',
 		(write) => {

--- a/packages/octane/tests/strong-mode.test.ts
+++ b/packages/octane/tests/strong-mode.test.ts
@@ -1,0 +1,423 @@
+import { describe, expect, it } from 'vitest';
+import { compile } from '../src/compiler/compile.js';
+import { slotHooks } from '../src/compiler/slot-hooks.js';
+import { compileToVolarMappings } from '../src/compiler/volar.js';
+
+const RENDER_STATE_UPDATE = 'OCTANE_STRONG_RENDER_STATE_UPDATE';
+const EFFECT_STATE_UPDATE = 'OCTANE_STRONG_EFFECT_STATE_UPDATE';
+const RENDER_REF_WRITE = 'OCTANE_STRONG_RENDER_REF_WRITE';
+const DIRECTIVE_PLACEMENT = 'OCTANE_STRONG_DIRECTIVE_PLACEMENT';
+
+function stateComponent(setup: string, imports = 'useState'): string {
+	return `import { ${imports} } from 'octane';
+export function Counter() @{
+  const [count, setCount] = useState(0);
+  ${setup}
+  <button onClick={() => setCount(count + 1)}>{count as string}</button>
+}`;
+}
+
+describe('Strong mode compiler enforcement', () => {
+	it('preserves existing behavior until the compiler or module opts in', () => {
+		const source = stateComponent('setCount(count + 1);');
+
+		expect(() => compile(source, '/src/Counter.tsrx')).not.toThrow();
+		expect(() => compile(source, '/src/Counter.tsrx', { strong: false } as any)).not.toThrow();
+		expect(() => compile(source, '/src/Counter.tsrx', { strong: true } as any)).toThrow(
+			RENDER_STATE_UPDATE,
+		);
+		expect(() => compile(`"use strong";\n${source}`, '/src/Counter.tsrx')).toThrow(
+			RENDER_STATE_UPDATE,
+		);
+		expect(() =>
+			compile(`"use strong";\n${source}`, '/src/Counter.tsrx', { strong: false } as any),
+		).toThrow(RENDER_STATE_UPDATE);
+	});
+
+	it('does not change emitted client or server code for valid globally opted-in modules', () => {
+		const source = stateComponent('');
+
+		for (const mode of ['client', 'server'] as const) {
+			const standard = compile(source, '/src/Counter.tsrx', { mode });
+			const strong = compile(source, '/src/Counter.tsrx', { mode, strong: true } as any);
+
+			expect(strong.code).toBe(standard.code);
+			expect(strong.diagnostics).toEqual(standard.diagnostics);
+		}
+	});
+
+	it('only recognizes the exact module directive prologue', () => {
+		const source = stateComponent('setCount(count + 1);');
+
+		expect(() =>
+			compile(`/* license */\n"use strict";\n"use strong";\n${source}`, '/src/Counter.tsrx'),
+		).toThrow(RENDER_STATE_UPDATE);
+		expect(() => compile(`\uFEFF'use strong';\n${source}`, '/src/Counter.tsrx')).toThrow(
+			RENDER_STATE_UPDATE,
+		);
+		expect(() => compile(`"use\\x20strong";\n${source}`, '/src/Counter.tsrx')).not.toThrow();
+		expect(() => compile(`"use stronger";\n${source}`, '/src/Counter.tsrx')).not.toThrow();
+		expect(() =>
+			compile(stateComponent('"use strong"; setCount(count + 1);'), '/src/Counter.tsrx'),
+		).not.toThrow();
+	});
+
+	it('rejects misplaced top-level Strong directives instead of silently ignoring them', () => {
+		const source = `${stateComponent('setCount(count + 1);')}\n"use strong";`;
+
+		expect(() => compile(source, '/src/Counter.tsrx')).toThrow(DIRECTIVE_PLACEMENT);
+		expect(() => slotHooks(source, '/src/Counter.ts')).toThrow(DIRECTIVE_PLACEMENT);
+		expect(compileToVolarMappings(source, '/src/Counter.tsrx').diagnostics).toContainEqual(
+			expect.objectContaining({ code: DIRECTIVE_PLACEMENT, severity: 'error' }),
+		);
+	});
+
+	it.each([
+		{ mode: 'client', dev: true },
+		{ mode: 'client', dev: false },
+		{ mode: 'server', dev: true },
+		{ mode: 'server', dev: false },
+	])('enforces render purity during $mode compilation with dev=$dev', (options) => {
+		const source = `"use strong";\n${stateComponent('setCount(count + 1);')}`;
+
+		expect(() => compile(source, '/src/Counter.tsrx?octane-hydrate=Counter', options)).toThrow(
+			RENDER_STATE_UPDATE,
+		);
+	});
+
+	it.each([
+		[
+			'aliased state imports',
+			`import { useState as state } from 'octane';
+       export function App() @{ const [value, update] = state(0); update(value); <div /> }`,
+		],
+		[
+			'namespace state imports',
+			`import * as Octane from 'octane';
+       export function App() @{ const [value, update] = Octane.useState(0); update(value); <div /> }`,
+		],
+		[
+			'reducer dispatch',
+			`import { useReducer } from 'octane';
+       export function App() @{ const [value, dispatch] = useReducer((value) => value, 0); dispatch(value); <div /> }`,
+		],
+		[
+			'linked state setters',
+			`import { useLinkedState } from 'octane';
+       export function App(props) @{ const [value, update] = useLinkedState(props.value, (value) => value); update(value); <div /> }`,
+		],
+	])('rejects render-phase updates through %s', (_label, source) => {
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).toThrow(RENDER_STATE_UPDATE);
+	});
+
+	it('keeps event handlers, deferred callbacks, and shadowed setters legal', () => {
+		const source = `"use strong";
+import { useState } from 'octane';
+export function App() @{
+  const [count, setCount] = useState(0);
+  const later = () => setCount(count + 1);
+  setTimeout(() => setCount(count + 1), 0);
+  Promise.resolve().then(() => setCount(count + 1));
+  {
+    const setCount = () => {};
+    setCount();
+  }
+  <button onClick={() => setCount(count + 1)}>{count as string}</button>
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('rejects render updates inside immediately executed functions and useMemo callbacks', () => {
+		const immediate = `"use strong";\n${stateComponent('(() => setCount(count + 1))();')}`;
+		const memo = `"use strong";\n${stateComponent(
+			'useMemo(() => setCount(count + 1), [count]);',
+			'useState, useMemo',
+		)}`;
+		const named = `"use strong";\n${stateComponent(
+			'function apply() { setCount(count + 1); } apply();',
+		)}`;
+		const callback = `"use strong";\n${stateComponent(
+			'const apply = () => setCount(count + 1); apply();',
+		)}`;
+
+		expect(() => compile(immediate, '/src/App.tsrx')).toThrow(RENDER_STATE_UPDATE);
+		expect(() => compile(memo, '/src/App.tsrx')).toThrow(RENDER_STATE_UPDATE);
+		expect(() => compile(named, '/src/App.tsrx')).toThrow(RENDER_STATE_UPDATE);
+		expect(() => compile(callback, '/src/App.tsrx')).toThrow(RENDER_STATE_UPDATE);
+	});
+
+	it('recognizes state updater access through immutable state tuple aliases', () => {
+		const source = `"use strong";
+import { useState } from 'octane';
+export function App() @{
+  const tuple = useState(0);
+  const pair = tuple;
+  pair[1](1);
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(RENDER_STATE_UPDATE);
+	});
+
+	it('follows immutable aliases of state setters and ref objects', () => {
+		const setter = `"use strong";\n${stateComponent('const update = setCount; update(1);')}`;
+		const ref = `"use strong";
+import * as Octane from 'octane';
+export function App() @{
+  const initialRef = Octane.useRef(null);
+  const ref = initialRef;
+  ref.current = 1;
+  <div />
+}`;
+
+		expect(() => compile(setter, '/src/App.tsrx')).toThrow(RENDER_STATE_UPDATE);
+		expect(() => compile(ref, '/src/App.tsrx')).toThrow(RENDER_REF_WRITE);
+	});
+
+	it('does not mistake unrelated or lexically shadowed functions for Octane hooks', () => {
+		const source = `"use strong";
+import { useState as octaneState } from 'octane';
+function useState(value) { return [value, () => {}]; }
+export function App() @{
+  const [value, update] = useState(0);
+  update(value);
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it.each(['useEffect', 'useLayoutEffect', 'useInsertionEffect'])(
+		'rejects synchronous state updates in %s setup',
+		(effect) => {
+			const source = `"use strong";\n${stateComponent(
+				`${effect}(() => { setCount(count + 1); }, [count]);`,
+				`useState, ${effect}`,
+			)}`;
+
+			expect(() => compile(source, '/src/Counter.tsrx')).toThrow(EFFECT_STATE_UPDATE);
+		},
+	);
+
+	it('recognizes aliased and namespace effect imports', () => {
+		const aliased = `"use strong";
+import { useState, useEffect as effect } from 'octane';
+export function App() @{
+  const [, update] = useState(0);
+  effect(() => update(1));
+  <div />
+}`;
+		const namespace = `"use strong";
+import * as Octane from 'octane';
+export function App() @{
+  const [, update] = Octane.useState(0);
+  Octane.useEffect(() => update(1));
+  <div />
+}`;
+
+		expect(() => compile(aliased, '/src/App.tsrx')).toThrow(EFFECT_STATE_UPDATE);
+		expect(() => compile(namespace, '/src/App.tsrx')).toThrow(EFFECT_STATE_UPDATE);
+	});
+
+	it('recognizes named effect callbacks without banning later cleanup callbacks', () => {
+		const source = `"use strong";\n${stateComponent(
+			'function syncCount() { setCount(count + 1); } useEffect(syncCount, [count]);',
+			'useState, useEffect',
+		)}`;
+
+		expect(() => compile(source, '/src/Counter.tsrx')).toThrow(EFFECT_STATE_UPDATE);
+	});
+
+	it('rejects passing a state updater directly as an effect callback', () => {
+		const source = `"use strong";\n${stateComponent(
+			'useEffect(setCount, []);',
+			'useState, useEffect',
+		)}`;
+
+		expect(() => compile(source, '/src/Counter.tsrx')).toThrow(EFFECT_STATE_UPDATE);
+	});
+
+	it('catches synchronous local callback invocation inside effect setup', () => {
+		const source = `"use strong";\n${stateComponent(
+			'useEffect(() => { const apply = () => setCount(1); apply(); }, []);',
+			'useState, useEffect',
+		)}`;
+
+		expect(() => compile(source, '/src/Counter.tsrx')).toThrow(EFFECT_STATE_UPDATE);
+	});
+
+	it('allows cleanup callbacks and asynchronous state updates from effects', () => {
+		const source = `"use strong";\n${stateComponent(
+			`useEffect(() => {
+      setTimeout(() => setCount(count + 1), 0);
+      Promise.resolve().then(() => setCount(count + 1));
+      return () => setCount(count + 1);
+    }, [count]);`,
+			'useState, useEffect',
+		)}`;
+
+		expect(() => compile(source, '/src/Counter.tsrx')).not.toThrow();
+	});
+
+	it('allows state updates after an async function has yielded', () => {
+		const effect = `"use strong";\n${stateComponent(
+			'useEffect(() => { (async () => { await Promise.resolve(); setCount(1); })(); }, []);',
+			'useState, useEffect',
+		)}`;
+		const render = `"use strong";\n${stateComponent(
+			'(async () => { await Promise.resolve(); setCount(1); })();',
+		)}`;
+		const synchronous = `"use strong";\n${stateComponent(
+			'(async () => { setCount(1); await Promise.resolve(); })();',
+		)}`;
+		const awaitedArgument = `"use strong";\n${stateComponent(
+			'(async () => { setCount(await Promise.resolve(1)); })();',
+		)}`;
+		const effectAwaitedArgument = `"use strong";\n${stateComponent(
+			'useEffect(() => { (async () => { setCount(await Promise.resolve(1)); })(); }, []);',
+			'useState, useEffect',
+		)}`;
+		const conditional = `"use strong";\n${stateComponent(
+			'(async () => { if (false) await Promise.resolve(); setCount(1); })();',
+		)}`;
+		const awaitedObject = `"use strong";\n${stateComponent(
+			'(async () => { setCount({ value: await Promise.resolve(1) }); })();',
+		)}`;
+		const awaitedArray = `"use strong";\n${stateComponent(
+			'(async () => { setCount([await Promise.resolve(1)]); })();',
+		)}`;
+		const awaitedSpread = `"use strong";\n${stateComponent(
+			'(async () => { setCount({ ...(await Promise.resolve({ value: 1 })) }); })();',
+		)}`;
+		const conditionalObject = `"use strong";\n${stateComponent(
+			'(async () => { setCount({ value: false ? await Promise.resolve(1) : 1 }); })();',
+		)}`;
+
+		expect(() => compile(effect, '/src/Counter.tsrx')).not.toThrow();
+		expect(() => compile(render, '/src/Counter.tsrx')).not.toThrow();
+		expect(() => compile(awaitedArgument, '/src/Counter.tsrx')).not.toThrow();
+		expect(() => compile(effectAwaitedArgument, '/src/Counter.tsrx')).not.toThrow();
+		expect(() => compile(awaitedObject, '/src/Counter.tsrx')).not.toThrow();
+		expect(() => compile(awaitedArray, '/src/Counter.tsrx')).not.toThrow();
+		expect(() => compile(awaitedSpread, '/src/Counter.tsrx')).not.toThrow();
+		expect(() => compile(synchronous, '/src/Counter.tsrx')).toThrow(RENDER_STATE_UPDATE);
+		expect(() => compile(conditional, '/src/Counter.tsrx')).toThrow(RENDER_STATE_UPDATE);
+		expect(() => compile(conditionalObject, '/src/Counter.tsrx')).toThrow(RENDER_STATE_UPDATE);
+	});
+
+	it.each(['ref.current = 1;', 'ref.current++;', "ref['current'] = 1;"])(
+		'rejects render-phase useRef writes: %s',
+		(write) => {
+			const source = `"use strong";
+import { useRef } from 'octane';
+export function App() @{
+  const ref = useRef(0);
+  ${write}
+  <div />
+}`;
+
+			expect(() => compile(source, '/src/App.tsrx')).toThrow(RENDER_REF_WRITE);
+		},
+	);
+
+	it('preserves DOM refs and deferred imperative ref updates', () => {
+		const source = `"use strong";
+import { useRef } from 'octane';
+export function App() @{
+  const ref = useRef(null);
+  const clear = () => { ref.current = null; };
+  <button ref={ref} onClick={() => { ref.current = null; }} />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('applies the same rules to Octane-owned TSX component modules', () => {
+		const source = `/** @jsxImportSource octane */
+'use strong';
+import { useState } from 'octane';
+export function App() {
+  const [count, setCount] = useState(0);
+  setCount(count + 1);
+  return <button onClick={() => setCount(count + 1)}>{count}</button>;
+}`;
+
+		expect(() => compile(source, '/src/App.tsx')).toThrow(RENDER_STATE_UPDATE);
+	});
+
+	it('does not ban nondeterministic render values', () => {
+		const source = `"use strong";
+export function App() @{
+  const value = Date.now() + Math.random() + crypto.randomUUID();
+  <p>{value as string}</p>
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('reports the original filename, location, stable code, and migration guidance', () => {
+		const source = `"use strong";\n${stateComponent('setCount(count + 1);')}`;
+
+		try {
+			compile(source, '/src/Counter.tsrx');
+			throw new Error('expected Strong mode to reject the render-phase update');
+		} catch (error: any) {
+			expect(error).toMatchObject({
+				code: RENDER_STATE_UPDATE,
+				filename: '/src/Counter.tsrx',
+				loc: { line: 5 },
+			});
+			expect(error.message).toContain('useLinkedState');
+		}
+	});
+
+	it('enforces Strong mode in plain TypeScript and JavaScript custom-hook modules', () => {
+		const source = `import { useState } from 'octane';
+export function useCounter() {
+  const [count, update] = useState(0);
+  update(count + 1);
+  return count;
+}`;
+
+		expect(() => slotHooks(source, '/src/useCounter.ts')).not.toThrow();
+		expect(() => slotHooks(source, '/src/useCounter.ts', { strong: true } as any)).toThrow(
+			RENDER_STATE_UPDATE,
+		);
+		expect(() => slotHooks(`"use strong";\n${source}`, '/src/useCounter.js')).toThrow(
+			RENDER_STATE_UPDATE,
+		);
+	});
+
+	it('publishes matching source-located errors to Volar without throwing', () => {
+		const source = `"use strong";\n${stateComponent('setCount(count + 1);')}`;
+		const result = compileToVolarMappings(source, '/src/Counter.tsrx');
+
+		expect(result.diagnostics).toContainEqual(
+			expect.objectContaining({
+				code: RENDER_STATE_UPDATE,
+				severity: 'error',
+				filename: '/src/Counter.tsrx',
+				start: expect.objectContaining({ line: 5 }),
+			}),
+		);
+		expect(result.errors).toContainEqual(
+			expect.objectContaining({
+				code: RENDER_STATE_UPDATE,
+				type: 'usage',
+				fileName: '/src/Counter.tsrx',
+				pos: source.indexOf('setCount(count + 1);'),
+				loc: { start: { line: 5, column: 2 }, end: { line: 5, column: 10 } },
+			}),
+		);
+	});
+
+	it('honors the compiler-wide option in Volar while leaving compatibility files unchanged', () => {
+		const source = stateComponent('setCount(count + 1);');
+
+		expect(compileToVolarMappings(source, '/src/Counter.tsrx').diagnostics).toEqual([]);
+		expect(
+			compileToVolarMappings(source, '/src/Counter.tsrx', { strong: true } as any).diagnostics,
+		).toContainEqual(expect.objectContaining({ code: RENDER_STATE_UPDATE, severity: 'error' }));
+	});
+});

--- a/packages/rsbuild-plugin-octane/README.md
+++ b/packages/rsbuild-plugin-octane/README.md
@@ -75,8 +75,21 @@ Options are declarative and cache-stable:
 
 - `hmr` controls browser component handoff;
 - `profile` enables component profiling in the browser environment;
+- `strong` overrides the app's `compiler.strong` setting;
 - `exclude` skips path fragments in the plain `.ts`/`.js` hook-slot pass; and
 - `clientEnvironment` / `serverEnvironment` rename the generated environments.
+
+Enable Strong mode for the whole app in `octane.config.ts`:
+
+```ts
+export default defineConfig({
+	compiler: { strong: true },
+});
+```
+
+You can also pass `pluginOctane({ strong: true })`. The plugin option takes
+priority over the app config. Dependencies are unaffected unless they begin a
+module with `"use strong"`.
 
 App mode currently serves from the root path and uses Rsbuild's default asset
 prefix. Keep `server.base` at `/` and `output.assetPrefix` at `auto` or `/`; for

--- a/packages/rsbuild-plugin-octane/src/index.js
+++ b/packages/rsbuild-plugin-octane/src/index.js
@@ -132,8 +132,11 @@ function hasRoutes(config) {
 	return (config?.router.routes.length ?? 0) > 0;
 }
 
-/** @param {import('@octanejs/app-core').ResolvedOctaneConfig} config */
-function configSignature(config) {
+/**
+ * @param {import('@octanejs/app-core').ResolvedOctaneConfig} config
+ * @param {boolean | undefined} strongOverride
+ */
+function configSignature(config, strongOverride) {
 	return JSON.stringify({
 		build: config.build,
 		routes: config.router.routes.map((route) =>
@@ -150,7 +153,10 @@ function configSignature(config) {
 		preHydrate: config.router.preHydrate,
 		rootBoundary: config.rootBoundary,
 		server: config.server,
-		compiler: { renderers: config.compiler.renderers.signature },
+		compiler: {
+			renderers: config.compiler.renderers.signature,
+			strong: strongOverride ?? config.compiler.strong,
+		},
 	});
 }
 
@@ -228,6 +234,7 @@ function assertRootPublicPaths(config, clientEnvironment) {
  * @param {{
  *   hmr?: boolean,
  *   profile?: boolean,
+ *   strong?: boolean,
  *   exclude?: string[],
  *   requireDirective?: boolean,
  *   clientEnvironment?: string,
@@ -236,6 +243,9 @@ function assertRootPublicPaths(config, clientEnvironment) {
  * @returns {import('@rsbuild/core').RsbuildPlugin}
  */
 export function pluginOctane(inlineOptions = {}) {
+	if (inlineOptions.strong !== undefined && typeof inlineOptions.strong !== 'boolean') {
+		throw new TypeError('[@octanejs/rsbuild-plugin] `strong` must be a boolean.');
+	}
 	return {
 		name: PLUGIN_NAME,
 		enforce: 'pre',
@@ -253,14 +263,19 @@ export function pluginOctane(inlineOptions = {}) {
 					})
 				: null;
 			const initialConfig = initialLoaded?.config ?? null;
+			const strong = inlineOptions.strong ?? initialConfig?.compiler.strong;
 			const appEnabled = hasRoutes(initialConfig);
 			const buildTargetPlan =
 				initialConfig?.build.target === undefined
 					? null
 					: createBuildTargetPlan(initialConfig.build.target);
-			const neutralCompiler = appEnabled ? createOctaneCompiler({ root }) : null;
+			const neutralCompiler = appEnabled
+				? createOctaneCompiler({ root, ...(strong === undefined ? null : { strong }) })
+				: null;
 			let currentConfig = initialConfig;
-			let lastConfigSignature = initialLoaded ? configSignature(initialLoaded.config) : '';
+			let lastConfigSignature = initialLoaded
+				? configSignature(initialLoaded.config, inlineOptions.strong)
+				: '';
 			let configNeedsReload = false;
 			/** @type {import('@rsbuild/core').RsbuildDevServer | null} */
 			let devServer = null;
@@ -307,7 +322,7 @@ export function pluginOctane(inlineOptions = {}) {
 					throw error;
 				}
 				registerConfigDependencies(context, loaded);
-				const signature = configSignature(loaded.config);
+				const signature = configSignature(loaded.config, inlineOptions.strong);
 				if (lastConfigSignature && signature !== lastConfigSignature) configNeedsReload = true;
 				lastConfigSignature = signature;
 				currentConfig = loaded.config;
@@ -531,6 +546,7 @@ export function pluginOctane(inlineOptions = {}) {
 						root,
 						environment,
 						transpile: false,
+						...(strong === undefined ? null : { strong }),
 						...(inlineOptions.hmr === undefined ? null : { hmr: inlineOptions.hmr }),
 						...(inlineOptions.profile === undefined
 							? null

--- a/packages/rsbuild-plugin-octane/tests/renderer-config.test.ts
+++ b/packages/rsbuild-plugin-octane/tests/renderer-config.test.ts
@@ -38,7 +38,7 @@ function writeRendererConfig(root: string, module = '/src/object-renderer.js', p
 	);
 }
 
-function writeProject(root: string, withRoute: boolean) {
+function writeProject(root: string, withRoute: boolean, strong?: boolean) {
 	write(root, 'package.json', JSON.stringify({ private: true, type: 'module' }) + '\n');
 	write(root, 'index.html', '<body><div id="root"><!--ssr-body--></div></body>\n');
 	write(root, 'src/Page.tsrx', 'export function Page() @{ <main>ready</main> }\n');
@@ -50,7 +50,7 @@ function writeProject(root: string, withRoute: boolean) {
 import { renderers } from './renderer.config.ts';
 
 export default defineConfig({
-	compiler: { renderers },
+	compiler: { renderers${strong === undefined ? '' : `, strong: ${strong}`} },
 	router: { routes: ${withRoute ? "[new RenderRoute({ path: '/', entry: '/src/Page.tsrx' })]" : '[]'} },
 });
 `,
@@ -73,9 +73,9 @@ describe('Rsbuild renderer configuration', () => {
 	it('preserves asymmetric public compiler booleans through custom client/server environments', async () => {
 		writeProject(root, true);
 		for (const compilerOptions of [
-			{ hmr: true, profile: false, requireDirective: false },
-			{ hmr: false, profile: true, requireDirective: false },
-			{ hmr: false, profile: false, requireDirective: true },
+			{ hmr: true, profile: false, requireDirective: false, strong: false },
+			{ hmr: false, profile: true, requireDirective: false, strong: true },
+			{ hmr: false, profile: false, requireDirective: true, strong: false },
 		]) {
 			const instance = await createRsbuild({
 				cwd: root,
@@ -110,9 +110,55 @@ describe('Rsbuild renderer configuration', () => {
 				hmr: compilerOptions.hmr,
 				profile: false,
 				requireDirective: compilerOptions.requireDirective,
+				strong: compilerOptions.strong,
 				transpile: false,
 			});
 		}
+	});
+
+	it.each([
+		['application configuration', true, undefined, true],
+		['explicit compatibility override', true, false, false],
+		['explicit Strong override', false, true, true],
+		['default compatibility', undefined, undefined, false],
+	] as const)(
+		'uses %s for both client and server compilers',
+		async (_label, configStrong, inlineStrong, expectedStrong) => {
+			writeProject(root, true, configStrong);
+			const instance = await createRsbuild({
+				cwd: root,
+				rsbuildConfig: {
+					plugins: [pluginOctane(inlineStrong === undefined ? {} : { strong: inlineStrong })],
+				},
+			});
+			const configs = await instance.initConfigs({ action: 'build' });
+			const plugins = configs
+				.flatMap((config) => config.plugins ?? [])
+				.filter((plugin): plugin is OctaneRspackPlugin => plugin instanceof OctaneRspackPlugin);
+
+			expect(plugins).toHaveLength(2);
+			for (const plugin of plugins) expect(plugin.options.strong).toBe(expectedStrong);
+		},
+	);
+
+	it('rejects a non-boolean inline Strong-mode option', () => {
+		expect(() => pluginOctane({ strong: 'yes' } as any)).toThrow(/`strong` must be a boolean/);
+	});
+
+	it('enables Strong mode for compiler-only projects without an app config', async () => {
+		writeProject(root, false);
+		rmSync(join(root, 'octane.config.ts'));
+		const instance = await createRsbuild({
+			cwd: root,
+			rsbuildConfig: { plugins: [pluginOctane({ strong: true })] },
+		});
+		const configs = await instance.initConfigs({ action: 'build' });
+		const plugins = configs
+			.flatMap((config) => config.plugins ?? [])
+			.filter((plugin): plugin is OctaneRspackPlugin => plugin instanceof OctaneRspackPlugin);
+
+		expect(plugins).toHaveLength(1);
+		expect(plugins[0].options.strong).toBe(true);
 	});
 
 	it.each([
@@ -200,5 +246,33 @@ describe('Rsbuild renderer configuration', () => {
 			},
 		});
 		expect(restartedPlugin.options.renderers).not.toEqual(initialPlugin.options.renderers);
+	});
+
+	it('applies Strong-mode config changes after Rsbuild restarts', async () => {
+		writeProject(root, false, false);
+		const createCompilerPlugin = async () => {
+			const instance = await createRsbuild({
+				cwd: root,
+				rsbuildConfig: { plugins: [pluginOctane()] },
+			});
+			return (await instance.initConfigs({ action: 'dev' }))
+				.flatMap((config) => config.plugins ?? [])
+				.find((plugin): plugin is OctaneRspackPlugin => plugin instanceof OctaneRspackPlugin);
+		};
+
+		const initialPlugin = await createCompilerPlugin();
+		write(
+			root,
+			'octane.config.ts',
+			`import { defineConfig } from '@octanejs/rsbuild-plugin';
+import { renderers } from './renderer.config.ts';
+
+export default defineConfig({ compiler: { renderers, strong: true } });
+`,
+		);
+		const restartedPlugin = await createCompilerPlugin();
+
+		expect(initialPlugin?.options.strong).toBe(false);
+		expect(restartedPlugin?.options.strong).toBe(true);
 	});
 });

--- a/packages/rsbuild-plugin-octane/types/index.d.ts
+++ b/packages/rsbuild-plugin-octane/types/index.d.ts
@@ -14,6 +14,11 @@ export interface OctaneRsbuildPluginOptions {
 	/** Enable component profiling in the browser environment. */
 	profile?: boolean;
 	/**
+	 * Override `compiler.strong` for this integration. Strong mode applies to
+	 * project-owned modules; dependencies can opt in with `"use strong"`.
+	 */
+	strong?: boolean;
+	/**
 	 * Ad-hoc path fragments skipped by the plain TypeScript/JavaScript
 	 * hook-slot pass. With `requireDirective`, excluded paths are exempt from
 	 * Octane ownership entirely — including `.tsrx`/`.tsx` — for projects

--- a/packages/rspack-plugin-octane/README.md
+++ b/packages/rspack-plugin-octane/README.md
@@ -46,6 +46,17 @@ Set `transpile: false` when an existing rule already strips TypeScript. Set
 `hmr: false` to disable Octane HMR codegen even when Rspack HMR is active.
 Set `profile: true` to produce a client profiling build; server compilations
 always keep profiling disabled.
+
+Set `strong: true` to reject state updates during rendering, state updates from
+effects, and ref writes during rendering in your application code:
+
+```js
+new OctaneRspackPlugin({ strong: true });
+```
+
+Dependencies keep their existing behavior. Any module can opt in on its own by
+putting `"use strong"` before its imports.
+
 The experimental `renderers` option accepts the same declarative registry,
 filename rules, and module/export boundary metadata as `compiler.renderers` in
 Octane app config:

--- a/packages/rspack-plugin-octane/src/loader.js
+++ b/packages/rspack-plugin-octane/src/loader.js
@@ -110,6 +110,7 @@ export default function octaneLoader(source, inputSourceMap) {
 		const compiler = createOctaneCompiler({
 			root,
 			profile,
+			...(options.strong === undefined ? null : { strong: options.strong }),
 			...(options.exclude === undefined ? null : { exclude: options.exclude }),
 			...(compilerOptions.renderers === undefined
 				? null

--- a/packages/rspack-plugin-octane/src/plugin.js
+++ b/packages/rspack-plugin-octane/src/plugin.js
@@ -102,6 +102,7 @@ function createDiscoveryCompiler(options, root, profile, specialization) {
 	return createOctaneCompiler({
 		root,
 		profile,
+		...(options.strong === undefined ? null : { strong: options.strong }),
 		...(options.exclude === undefined ? null : { exclude: options.exclude }),
 		...(renderers === undefined ? null : { renderers }),
 		...(universalRuntime === undefined ? null : { universalRuntime }),
@@ -283,6 +284,7 @@ export class OctaneRspackPlugin {
 			hmr,
 			dev,
 			profile,
+			strong: this.options.strong === true,
 			exclude: this.options.exclude ?? [],
 			renderers: this.options.renderers?.signature,
 			runtime: this.options.runtime,
@@ -316,6 +318,7 @@ export class OctaneRspackPlugin {
 			root,
 			environment,
 			profile,
+			...(this.options.strong === undefined ? null : { strong: this.options.strong }),
 			...(this.options.hmr === undefined ? null : { hmr: this.options.hmr }),
 			...(this.options.dev === undefined ? null : { dev: this.options.dev }),
 			...(this.options.exclude === undefined ? null : { exclude: this.options.exclude }),

--- a/packages/rspack-plugin-octane/src/shared.js
+++ b/packages/rspack-plugin-octane/src/shared.js
@@ -40,6 +40,7 @@ const LOADER_OPTION_KEYS = new Set([
 	'hmr',
 	'dev',
 	'profile',
+	'strong',
 	'exclude',
 	'renderers',
 	'requireDirective',
@@ -177,6 +178,7 @@ function normalizeOptions(value, plugin) {
 	assertBooleanOption(options, 'hmr');
 	assertBooleanOption(options, 'dev');
 	assertBooleanOption(options, 'profile');
+	assertBooleanOption(options, 'strong');
 	assertBooleanOption(options, 'requireDirective');
 	if (
 		options.exclude !== undefined &&
@@ -196,6 +198,7 @@ function normalizeOptions(value, plugin) {
 		...(options.hmr === undefined ? null : { hmr: options.hmr }),
 		...(options.dev === undefined ? null : { dev: options.dev }),
 		...(options.profile === undefined ? null : { profile: options.profile }),
+		...(options.strong === undefined ? null : { strong: options.strong }),
 		...(options.exclude === undefined ? null : { exclude: [...options.exclude] }),
 		...(renderers === undefined ? null : { renderers }),
 		...(universalRuntime === undefined ? null : { universalRuntime }),

--- a/packages/rspack-plugin-octane/tests/loader.integration.test.ts
+++ b/packages/rspack-plugin-octane/tests/loader.integration.test.ts
@@ -152,6 +152,86 @@ describe('loader with the neutral compiler', () => {
 		expect(generated.App()).toBe('<p>server</p>');
 	});
 
+	it.each([
+		[
+			'render-phase state updates',
+			"import { useState } from 'octane';\nexport function App() @{ const [value, update] = useState(0); update(value); <p>ready</p> }\n",
+			/OCTANE_STRONG_RENDER_STATE_UPDATE/,
+		],
+		[
+			'effect-driven state updates',
+			"import { useEffect, useState } from 'octane';\nexport function App() @{ const [value, update] = useState(0); useEffect(() => update(value), [value]); <p>ready</p> }\n",
+			/OCTANE_STRONG_EFFECT_STATE_UPDATE/,
+		],
+		[
+			'render-phase ref writes',
+			"import { useRef } from 'octane';\nexport function App() @{ const value = useRef(0); value.current = 1; <p>ready</p> }\n",
+			/OCTANE_STRONG_RENDER_REF_WRITE/,
+		],
+	] as const)('enforces %s in client and server compilation', (_label, source, diagnostic) => {
+		const resourcePath = write(root, 'src/Strong.tsrx', source);
+		for (const target of ['web', 'node22']) {
+			expect(() =>
+				transform({ root, resourcePath, source, target, options: { strong: true } }),
+			).toThrow(diagnostic);
+		}
+
+		expect(() =>
+			transform({ root, resourcePath, source, options: { strong: false } }),
+		).not.toThrow();
+	});
+
+	it('enforces a module-level Strong directive without enabling the project globally', () => {
+		const source =
+			'"use strong";\n' +
+			"import { useState } from 'octane';\n" +
+			'export function App() @{ const [value, update] = useState(0); update(value); <p>ready</p> }\n';
+		const resourcePath = write(root, 'src/OptIn.tsrx', source);
+
+		expect(() => transform({ root, resourcePath, source, options: { strong: false } })).toThrow(
+			/OCTANE_STRONG_RENDER_STATE_UPDATE/,
+		);
+	});
+
+	it('enforces project Strong mode in plain custom-hook modules', () => {
+		const source =
+			"import { useState } from 'octane';\n" +
+			'export function useCounter() { const [value, update] = useState(0); update(value); return value; }\n';
+		const resourcePath = write(root, 'src/useCounter.ts', source);
+
+		expect(() => transform({ root, resourcePath, source, options: { strong: true } })).toThrow(
+			/OCTANE_STRONG_RENDER_STATE_UPDATE/,
+		);
+		expect(() =>
+			transform({ root, resourcePath, source, options: { strong: false } }),
+		).not.toThrow();
+	});
+
+	it('keeps dependency modules compatible unless they opt in themselves', () => {
+		const packageRoot = join(root, 'node_modules/@fixture/raw');
+		mkdirSync(packageRoot, { recursive: true });
+		writeFileSync(
+			join(packageRoot, 'package.json'),
+			'{"name":"@fixture/raw","dependencies":{"octane":"*"}}\n',
+		);
+		const body =
+			"import { useState } from 'octane';\n" +
+			'export function Dependency() @{ const [value, update] = useState(0); update(value); <p>ready</p> }\n';
+		const resourcePath = write(root, 'node_modules/@fixture/raw/index.tsrx', body);
+
+		expect(() =>
+			transform({ root, resourcePath, source: body, options: { strong: true } }),
+		).not.toThrow();
+
+		const optedIn = '"use strong";\n' + body;
+		writeFileSync(resourcePath, optedIn);
+		for (const strong of [true, false]) {
+			expect(() => transform({ root, resourcePath, source: optedIn, options: { strong } })).toThrow(
+				/OCTANE_STRONG_RENDER_STATE_UPDATE/,
+			);
+		}
+	});
+
 	it('attaches the same client-reference metadata to client code and its server stub', () => {
 		const source = `import './authored-setup.js';\nexport default function Scene() @{ <node /> }\n`;
 		const resourcePath = write(root, 'src/Scene.object.tsrx', source);

--- a/packages/rspack-plugin-octane/tests/loader.test.ts
+++ b/packages/rspack-plugin-octane/tests/loader.test.ts
@@ -250,6 +250,15 @@ describe('octane Rspack loader', () => {
 		);
 	});
 
+	it.each([true, false])('forwards strong: %s to the neutral compiler', (strong) => {
+		mocks.transform.mockReturnValue(null);
+		runLoader({ options: { strong } });
+
+		expect(mocks.createOctaneCompiler).toHaveBeenCalledWith(
+			expect.objectContaining({ root: '/project', strong }),
+		);
+	});
+
 	it('resolves a loader-only relative root from Rspack rootContext', () => {
 		mocks.transform.mockReturnValue(null);
 		runLoader({ options: { root: 'apps/site' } });

--- a/packages/rspack-plugin-octane/tests/plugin.test.ts
+++ b/packages/rspack-plugin-octane/tests/plugin.test.ts
@@ -188,6 +188,16 @@ describe('OctaneRspackPlugin', () => {
 		);
 	});
 
+	it.each([true, false])('forwards strong: %s to discovery and module compilation', (strong) => {
+		const compiler = createCompiler('web');
+		new OctaneRspackPlugin({ strong }).apply(compiler as any);
+
+		expect(mocks.createOctaneCompiler).toHaveBeenCalledWith(
+			expect.objectContaining({ root: '/project', strong }),
+		);
+		expect(compiler.options.module.rules[0].use[0].options).toMatchObject({ strong });
+	});
+
 	it('specializes compiler and runtime resolution by Rspack layer', () => {
 		const compiler = createCompiler('web');
 		const plugin = new OctaneRspackPlugin({
@@ -378,6 +388,15 @@ describe('OctaneRspackPlugin', () => {
 		new OctaneRspackPlugin({ requireDirective: true }).apply(directive as any);
 		expect((directive.options as any).cache.version).toMatch(/^user-cache\|octane-rspack@/);
 		expect((directive.options as any).cache.version).not.toBe((dom.options as any).cache.version);
+
+		const strong = createCachedCompiler();
+		const explicitCompatibility = createCachedCompiler();
+		new OctaneRspackPlugin({ strong: true }).apply(strong as any);
+		new OctaneRspackPlugin({ strong: false }).apply(explicitCompatibility as any);
+		expect((strong.options as any).cache.version).not.toBe((dom.options as any).cache.version);
+		expect((explicitCompatibility.options as any).cache.version).toBe(
+			(dom.options as any).cache.version,
+		);
 	});
 
 	it('resolves a relative root from the Rspack context', () => {
@@ -390,6 +409,9 @@ describe('OctaneRspackPlugin', () => {
 
 	it('rejects invalid options at the public constructor', () => {
 		expect(() => new OctaneRspackPlugin({ profile: 'yes' } as any)).toThrow(/profile/);
+		expect(() => new OctaneRspackPlugin({ strong: 'yes' } as any)).toThrow(
+			/`strong` must be a boolean/,
+		);
 		expect(() => new OctaneRspackPlugin({ parallelUse: false } as any)).toThrow(
 			/unknown option `parallelUse`/,
 		);

--- a/packages/rspack-plugin-octane/tests/shared.test.ts
+++ b/packages/rspack-plugin-octane/tests/shared.test.ts
@@ -78,6 +78,11 @@ describe('declarative options', () => {
 		);
 	});
 
+	it('preserves explicit Strong-mode choices for the plugin and standalone loader', () => {
+		expect(normalizePluginOptions({ strong: true })).toEqual({ strong: true });
+		expect(normalizeLoaderOptions({ strong: false })).toEqual({ strong: false });
+	});
+
 	it('normalizes compile-runtime metadata and a plugin-only runtime request', () => {
 		const universalRuntime = { runtime: 'lynx', thread: 'background' as const };
 		const options = normalizePluginOptions({
@@ -143,6 +148,7 @@ describe('declarative options', () => {
 	it.each([
 		[{ environment: 'worker' }, /environment/],
 		[{ hmr: 'webpack' }, /hmr/],
+		[{ strong: 'yes' }, /`strong` must be a boolean/],
 		[{ exclude: 'vendor' }, /exclude/],
 		[{ renderers: { default: 'missing' } }, /default references unknown renderer/],
 		[{ universalRuntime: { runtime: 'lynx', thread: 'worker' } }, /thread/],

--- a/packages/rspack-plugin-octane/types/index.d.ts
+++ b/packages/rspack-plugin-octane/types/index.d.ts
@@ -113,6 +113,12 @@ export interface OctaneRspackLoaderOptions {
 	/** Emit client profiling metadata and enable the profiling runtime. Default `false`. */
 	profile?: boolean;
 	/**
+	 * Enable Strong-mode compiler rules for project-owned modules. Dependencies
+	 * remain compatible unless their own module begins with `"use strong"`.
+	 * @default false
+	 */
+	strong?: boolean;
+	/**
 	 * Path fragments excluded from the plain `.ts`/`.js` hook-slot pass. With
 	 * `requireDirective`, excluded paths are exempt from Octane ownership
 	 * entirely — including `.tsrx`/`.tsx` — for projects routing those paths

--- a/packages/rspack-plugin-octane/types/options.test-d.ts
+++ b/packages/rspack-plugin-octane/types/options.test-d.ts
@@ -1,6 +1,7 @@
 import type { OctaneRspackLoaderOptions, OctaneRspackPluginOptions } from './index.js';
 
 const loaderOptions: OctaneRspackLoaderOptions = {
+	strong: true,
 	layerSpecializations: {
 		'native:main': {
 			renderers: {
@@ -19,6 +20,7 @@ const loaderOptions: OctaneRspackLoaderOptions = {
 };
 
 const pluginOptions: OctaneRspackPluginOptions = {
+	strong: false,
 	layerSpecializations: {
 		'native:main': {
 			runtime: '@fixture/native-main-runtime',

--- a/packages/vite-plugin-octane/src/index.js
+++ b/packages/vite-plugin-octane/src/index.js
@@ -221,7 +221,7 @@ function collect_hydrate_module_paths(config) {
  * it). An explicit `profile` (true or false) always takes precedence over
  * `devtools`.
  *
- * @param {{ hmr?: boolean, profile?: boolean, devtools?: boolean, exclude?: string[], requireDirective?: boolean, renderers?: import('@octanejs/app-core').ExperimentalRendererConfigOptions }} [inlineOptions]
+ * @param {{ hmr?: boolean, profile?: boolean, devtools?: boolean, strong?: boolean, exclude?: string[], requireDirective?: boolean, renderers?: import('@octanejs/app-core').ExperimentalRendererConfigOptions }} [inlineOptions]
  * @returns {Plugin[]}
  */
 export function octane(inlineOptions = {}) {
@@ -238,12 +238,12 @@ export function octane(inlineOptions = {}) {
 	/** @type {boolean} Is this the SSR sub-build closeBundle launches? */
 	let isSSRBuild = false;
 	/**
-	 * Config dependencies that select compiler renderers. A change requires a
-	 * server restart because the neutral compiler snapshots normalized renderer
-	 * metadata before the first module transform.
+	 * Config dependencies that select Strong mode or compiler renderers. A
+	 * change requires a server restart because the neutral compiler snapshots
+	 * its configuration before the first module transform.
 	 * @type {Set<string>}
 	 */
-	const rendererConfigWatchFiles = new Set();
+	const compilerConfigWatchFiles = new Set();
 	/** @type {Map<string, Promise<LoadedOctaneConfig | null>>} */
 	const startupConfigLoads = new Map();
 	/** @type {ResolvedOctaneConfig | null} Config loaded for the build (config hook, reused in closeBundle) */
@@ -494,8 +494,8 @@ export function octane(inlineOptions = {}) {
 		 * @param {ViteDevServer} vite
 		 */
 		configureServer(vite) {
-			if (rendererConfigWatchFiles.size > 0) {
-				vite.watcher.add([...rendererConfigWatchFiles]);
+			if (compilerConfigWatchFiles.size > 0) {
+				vite.watcher.add([...compilerConfigWatchFiles]);
 			}
 			/** @type {Promise<void> | null} */
 			let initPromise = null;
@@ -669,10 +669,9 @@ export function octane(inlineOptions = {}) {
 			order: 'pre',
 			async handler({ file, modules, server }) {
 				if (this.environment.name !== 'client') return;
-				if (rendererConfigWatchFiles.has(path.resolve(file))) {
-					// Renderer rules and boundary metadata are immutable inputs to every
-					// compiler environment. Rebuild the plugin/compiler snapshot instead
-					// of letting later transforms observe a mixture of old and new config.
+				if (compilerConfigWatchFiles.has(path.resolve(file))) {
+					// Strong mode and renderer metadata are immutable compiler inputs.
+					// Restart so later transforms cannot mix old and new configuration.
 					await server.restart();
 					return [];
 				}
@@ -881,6 +880,7 @@ export function octane(inlineOptions = {}) {
 	 * @type {{
 	 *   hmr?: boolean,
 	 *   profile?: boolean | 'auto',
+	 *   strong?: boolean,
 	 *   exclude?: string[],
 	 *   requireDirective?: boolean,
 	 *   renderers?: import('@octanejs/app-core').ExperimentalRendererConfigOptions,
@@ -892,6 +892,7 @@ export function octane(inlineOptions = {}) {
 	// command-aware `'auto'` signal the compiler resolves to DEV-only profiling.
 	if (inlineOptions.profile !== undefined) compilerOptions.profile = inlineOptions.profile;
 	else if (inlineOptions.devtools === true) compilerOptions.profile = 'auto';
+	if (inlineOptions.strong !== undefined) compilerOptions.strong = inlineOptions.strong;
 	if (inlineOptions.exclude !== undefined) compilerOptions.exclude = inlineOptions.exclude;
 	if (inlineOptions.requireDirective !== undefined) {
 		compilerOptions.requireDirective = inlineOptions.requireDirective;
@@ -900,31 +901,36 @@ export function octane(inlineOptions = {}) {
 	const compilerPlugin = /** @type {Plugin} */ (octaneCompiler(compilerOptions));
 	const compilerConfigHook = compilerPlugin.config;
 	if (typeof compilerConfigHook === 'function') {
-		compilerPlugin.config = function compilerConfigWithAppRenderers(userConfig, env) {
+		compilerPlugin.config = function compilerConfigWithAppOptions(userConfig, env) {
 			const projectRoot = userConfig.root ? path.resolve(userConfig.root) : process.cwd();
-			// Inline renderer metadata is an explicit full override. Preserve the
-			// synchronous no-config/inline path used by compiler-only SPA projects.
-			if (inlineOptions.renderers !== undefined) {
-				rendererConfigWatchFiles.clear();
+			// Both inline compiler options override app config independently. Preserve
+			// the synchronous path when neither needs to read octane.config.ts.
+			if (inlineOptions.renderers !== undefined && inlineOptions.strong !== undefined) {
+				compilerConfigWatchFiles.clear();
 				return compilerConfigHook.call(this, userConfig, env);
 			}
 
 			const configPath = getOctaneConfigPath(projectRoot);
 			if (!octaneConfigExists(projectRoot)) {
-				delete compilerOptions.renderers;
-				rendererConfigWatchFiles.clear();
-				// A newly-created octane.config.ts can introduce renderer rules. Watch
-				// the missing path so dev restarts into the configured compiler.
-				rendererConfigWatchFiles.add(path.resolve(configPath));
+				if (inlineOptions.renderers === undefined) delete compilerOptions.renderers;
+				if (inlineOptions.strong === undefined) delete compilerOptions.strong;
+				compilerConfigWatchFiles.clear();
+				// A new app config can introduce Strong mode or renderer rules.
+				compilerConfigWatchFiles.add(path.resolve(configPath));
 				return compilerConfigHook.call(this, userConfig, env);
 			}
 
 			return loadStartupConfig(projectRoot).then((loaded) => {
 				const config = /** @type {LoadedOctaneConfig} */ (loaded);
-				compilerOptions.renderers = config.config.compiler.renderers;
-				rendererConfigWatchFiles.clear();
+				if (inlineOptions.renderers === undefined) {
+					compilerOptions.renderers = config.config.compiler.renderers;
+				}
+				if (inlineOptions.strong === undefined) {
+					compilerOptions.strong = config.config.compiler.strong;
+				}
+				compilerConfigWatchFiles.clear();
 				for (const file of [...config.dependencies, ...config.missingDependencies]) {
-					rendererConfigWatchFiles.add(path.resolve(file));
+					compilerConfigWatchFiles.add(path.resolve(file));
 				}
 				return compilerConfigHook.call(this, userConfig, env);
 			});

--- a/packages/vite-plugin-octane/tests/plugin.test.ts
+++ b/packages/vite-plugin-octane/tests/plugin.test.ts
@@ -207,6 +207,111 @@ describe('octane() plugin factory', () => {
 		}
 	});
 
+	it.each([true, false])('forwards strong=%s to the bundled compiler', async (strong) => {
+		const [compiler] = octane({ hmr: false, strong });
+		await (compiler.config as (config: { root: string }) => unknown)({ root: '/repo' });
+		const transform = compiler.transform as (source: string, id: string) => { code: string };
+		const source =
+			"import { useState } from 'octane';\n" +
+			'export function App() @{\n' +
+			'  const [count, setCount] = useState(0);\n' +
+			'  setCount(count + 1);\n' +
+			'  <main />\n' +
+			'}\n';
+
+		if (strong) {
+			expect(() => transform.call({}, source, '/repo/src/App.tsrx')).toThrow(/useLinkedState/);
+		} else {
+			expect(transform.call({}, source, '/repo/src/App.tsrx').code).toContain('count');
+		}
+	});
+
+	it('rejects a non-boolean inline Strong-mode setting', () => {
+		expect(() =>
+			octane({
+				// @ts-expect-error JavaScript configuration still receives runtime validation.
+				strong: 'true',
+			}),
+		).toThrow('`strong` must be a boolean when provided.');
+	});
+
+	it('reads Strong mode from app config, honors inline overrides, and restarts for changes', async () => {
+		const root = await mkdtemp(join(tmpdir(), 'octane-vite-strong-mode-'));
+		const configPath = join(root, 'octane.config.ts');
+		const policyPath = join(root, 'strong.config.ts');
+		const source =
+			"import { useState } from 'octane';\n" +
+			'export function App() @{\n' +
+			'  const [count, setCount] = useState(0);\n' +
+			'  setCount(count + 1);\n' +
+			'  <main />\n' +
+			'}\n';
+		try {
+			await writeFile(policyPath, 'export const strong = true;\n');
+			await writeFile(
+				configPath,
+				"import { strong } from './strong.config.ts';\nexport default { compiler: { strong } };\n",
+			);
+
+			const [compiler, meta] = octane({ hmr: false });
+			await (compiler.config as (config: { root: string }) => unknown)({ root });
+			const transform = compiler.transform as (source: string, id: string) => { code: string };
+			expect(() => transform.call({}, source, join(root, 'src/App.tsrx'))).toThrow(
+				/useLinkedState/,
+			);
+
+			const [override] = octane({ hmr: false, strong: false });
+			await (override.config as (config: { root: string }) => unknown)({ root });
+			expect(
+				(override.transform as (source: string, id: string) => { code: string }).call(
+					{},
+					source,
+					join(root, 'src/App.tsrx'),
+				).code,
+			).toContain('count');
+			expect(() =>
+				(override.transform as (source: string, id: string) => { code: string }).call(
+					{},
+					'"use strong";\n' + source,
+					join(root, 'src/OptedIn.tsrx'),
+				),
+			).toThrow(/useLinkedState/);
+
+			const [inlineRenderers] = octane({
+				hmr: false,
+				renderers: { registry: { alternate: 'octane/universal' } },
+			});
+			await (inlineRenderers.config as (config: { root: string }) => unknown)({ root });
+			expect(() =>
+				(inlineRenderers.transform as (source: string, id: string) => { code: string }).call(
+					{},
+					source,
+					join(root, 'src/InlineRenderer.tsrx'),
+				),
+			).toThrow(/useLinkedState/);
+
+			const add = vi.fn();
+			(meta.configureServer as (server: unknown) => void)({
+				watcher: { add },
+				middlewares: { use: vi.fn() },
+			});
+			const watchedPolicyPath = await realpath(policyPath);
+			expect(add).toHaveBeenCalledWith(expect.arrayContaining([configPath, watchedPolicyPath]));
+
+			const restart = vi.fn(async () => undefined);
+			const hotUpdate = meta.hotUpdate as {
+				handler(context: unknown): Promise<unknown>;
+			};
+			await hotUpdate.handler.call(
+				{ environment: { name: 'client' } },
+				{ file: watchedPolicyPath, modules: [], server: { restart } },
+			);
+			expect(restart).toHaveBeenCalledOnce();
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
 	it.each([true, false])(
 		'preserves build.minify=%s and build.target=false in resolved Vite config',
 		async (minify) => {

--- a/packages/vite-plugin-octane/types/index.d.ts
+++ b/packages/vite-plugin-octane/types/index.d.ts
@@ -14,6 +14,8 @@ export interface OctanePluginOptions {
 	hmr?: boolean;
 	/** Enable component profiling in client transforms. */
 	profile?: boolean;
+	/** Enable Strong mode for app code, overriding `compiler.strong` in `octane.config.ts`. */
+	strong?: boolean;
 	/**
 	 * Path fragments the compiler's plain `.ts`/`.js` hook-slotting pass must
 	 * skip. Prefer package manifest `octane.hookSlots.manual` declarations.

--- a/website/env.d.ts
+++ b/website/env.d.ts
@@ -29,6 +29,7 @@ declare module 'octane/compiler' {
 			mode?: 'client' | 'server';
 			hmr?: boolean;
 			dev?: boolean;
+			strong?: boolean;
 			inspect?: boolean;
 		},
 	): {
@@ -104,6 +105,7 @@ declare module 'octane/compiler/volar' {
 		options?: {
 			loose?: boolean;
 			renderers?: unknown;
+			strong?: boolean;
 		},
 	): {
 		code: string;

--- a/website/src/content/docs-meta.ts
+++ b/website/src/content/docs-meta.ts
@@ -47,6 +47,7 @@ export const docsMeta: DocMeta[] = [
 			{ id: 'vite', title: 'Vite' },
 			{ id: 'rspack', title: 'Rspack' },
 			{ id: 'rsbuild', title: 'Rsbuild' },
+			{ id: 'strong-mode', title: 'Strong mode' },
 			{ id: 'full-app-configuration', title: 'Full app configuration' },
 			{ id: 'production-and-preview', title: 'Production and preview' },
 			{ id: 'renderer-targets', title: 'Renderer targets' },
@@ -92,6 +93,7 @@ export const docsMeta: DocMeta[] = [
 			{ id: 'components-and-props', title: 'Components and props' },
 			{ id: 'state-and-events', title: 'State and events' },
 			{ id: 'use-linked-state', title: 'useLinkedState', level: 3 },
+			{ id: 'strong-mode', title: 'Strong mode', level: 3 },
 			{ id: 'lists-and-conditions', title: 'Lists and conditions' },
 			{ id: 'context', title: 'Sharing data' },
 			{ id: 'refs-and-effects', title: 'Refs and effects' },
@@ -129,6 +131,7 @@ export const docsMeta: DocMeta[] = [
 		group: 'Explore',
 		sections: [
 			{ id: 'hooks', title: 'Hooks' },
+			{ id: 'strong-mode', title: 'Strong mode' },
 			{ id: 'events-and-dom', title: 'Events and the DOM' },
 			{ id: 'async-work', title: 'Async work' },
 			{ id: 'errors-and-server', title: 'Errors and server rendering' },

--- a/website/src/content/docs/build-tools.mdx
+++ b/website/src/content/docs/build-tools.mdx
@@ -134,6 +134,70 @@ Rspack's generated runtime. Rsbuild accepts one ES level, `modules`, `false`, or
 esbuild-style browser targets such as `['chrome100', 'firefox100']`; do not mix
 ES levels and browser targets in the same array.
 
+<h2 id="strong-mode">Strong mode</h2>
+
+Strong mode asks the compiler to reject a few state and ref patterns that make a
+component harder to follow. It is off by default, so you can try it in one file:
+
+```tsx
+'use strong';
+
+import { useLinkedState } from 'octane';
+
+export function ProfileEditor({ user }) {
+	const [name, setName] = useLinkedState(user.id, () => user.name);
+	return <input value={name} onInput={(event) => setName(event.currentTarget.value)} />;
+}
+```
+
+The directive applies only to its own module. Put it at the top of the file,
+before imports or other code; comments and other directives may come first. When
+a file needs an `@jsxImportSource octane` ownership pragma, put that comment
+first:
+
+```tsx
+/** @jsxImportSource octane */
+'use strong';
+
+import { useState } from 'octane';
+```
+
+When the whole application is ready, switch it on in the shared app config used
+by the Vite and Rsbuild integrations:
+
+```ts
+// octane.config.ts
+export default {
+	compiler: {
+		strong: true,
+	},
+};
+```
+
+Each bundler plugin also accepts the same option directly. A standalone Rspack
+setup uses its plugin option because it does not load `octane.config.ts`:
+
+```ts
+octane({ strong: true }); // Vite
+new OctaneRspackPlugin({ strong: true }); // Rspack
+pluginOctane({ strong: true }); // Rsbuild
+```
+
+An explicit plugin option wins over `octane.config.ts`. Application-wide mode
+does not change installed dependencies; a dependency can opt in with its own
+`"use strong"` directive.
+
+A Strong module cannot:
+
+- Call a state setter or reducer dispatcher while rendering.
+- Call one directly while an effect is being set up.
+- Assign to a ref's `current` value while rendering.
+
+Use `useLinkedState` when state should reset or adjust after an input changes.
+Event handlers may update state normally. Effects that connect to external
+systems and refs for DOM nodes, timers, or event callbacks are still useful and
+remain allowed. Values such as `Date.now()` and `Math.random()` are not banned.
+
 <h2 id="mixed-toolchains">Mixed toolchains and file ownership</h2>
 
 By default the Octane compiler owns every project `.tsrx` and `.tsx` module. In

--- a/website/src/content/docs/core-apis.mdx
+++ b/website/src/content/docs/core-apis.mdx
@@ -294,6 +294,30 @@ On the first render, `previous` is `undefined`. When the source changes, it is
 Like `useState`, the hook also offers an optional third tuple item, `getValue`, for
 reading the latest value inside an async or delayed callback.
 
+<h3 id="strong-mode">Catch state mistakes with Strong mode</h3>
+
+Strong mode is an optional compiler check. Add `"use strong"` before a module's
+imports to try it one file at a time, or set `compiler: { strong: true }` in
+`octane.config.ts` to cover your application.
+
+```tsx
+'use strong';
+
+import { useLinkedState } from 'octane';
+
+export function ProfileEditor({ user }) {
+	const [name, setName] = useLinkedState(user.id, () => user.name);
+	return <input value={name} onInput={(event) => setName(event.currentTarget.value)} />;
+}
+```
+
+A Strong module cannot update state while rendering, update state directly while
+setting up an effect, or write `ref.current` while rendering. Event handlers can
+still update state. Effects that synchronize external systems and refs for DOM
+nodes or timers are still valid. Use `useLinkedState` when editable state should
+follow an input; it returns the right value immediately without an effect or a
+render-time setter.
+
 <details className="deep-dive">
 	<summary>Octane deep dive: state getters and conditional hooks</summary>
 	<div>

--- a/website/src/content/docs/differences-from-react.mdx
+++ b/website/src/content/docs/differences-from-react.mdx
@@ -95,6 +95,20 @@ extra render to correct the old value. The calculation can also read the previou
 `{ source, value }`, which is useful when a selection should survive if it is still
 valid.
 
+<h2 id="strong-mode">Strong mode is optional</h2>
+
+Strong mode helps catch state and ref patterns that React applications sometimes
+use as workarounds. Enable it for a single module with `"use strong"` before its
+imports, or across your application with `compiler: { strong: true }` in
+`octane.config.ts`.
+
+The compiler rejects state updates during render, state updates made directly
+while an effect is being set up, and writes to `ref.current` during render. Use
+`useLinkedState` when editable state should follow a changing prop. Event
+handlers, effects that synchronize external systems, and normal DOM or timer
+refs remain supported. Installed dependencies keep their existing behavior
+unless they opt in themselves.
+
 <h2 id="events-and-dom">Events come from the browser</h2>
 
 Handlers receive the browser's real `Event` object, not a synthetic wrapper. Bubbling,

--- a/website/tests/core-apis-docs.test.ts
+++ b/website/tests/core-apis-docs.test.ts
@@ -66,6 +66,7 @@ describe('Core APIs documentation', () => {
 		}
 		for (const id of [
 			'use-linked-state',
+			'strong-mode',
 			'use-sync-external-store',
 			'hydrate-when',
 			'hydrate-split',
@@ -101,6 +102,7 @@ describe('Core APIs documentation', () => {
 		expect(highlightedSource.some((source) => source.includes('renderToString(App'))).toBe(true);
 		for (const sourceMarker of [
 			'useLinkedState(props.user.id, () => props.user.name)',
+			"'use strong';",
 			'nextItems.find((item) => item.id === previous?.value?.id)',
 			'export function NetworkStatus()',
 			'<Hydrate when={visible({ rootMargin:',

--- a/website/tests/docs-search.test.ts
+++ b/website/tests/docs-search.test.ts
@@ -89,6 +89,15 @@ describe('docs search ranking', () => {
 		expect(top.id).toBe('deferred-hydration');
 	});
 
+	it('deep links Strong-mode searches to the build configuration guide', async () => {
+		const index = await loadSearchIndex();
+		const [top] = searchDocs(index, 'strong mode');
+
+		expect(top).toBeDefined();
+		expect(top.slug).toBe('build-tools');
+		expect(top.id).toBe('strong-mode');
+	});
+
 	it('ranks a heading match above an incidental prose mention', async () => {
 		const index = await loadSearchIndex();
 		const [top] = searchDocs(index, 'install');


### PR DESCRIPTION
## Summary

- Add opt-in Strong mode through `compiler: { strong: true }` or a module-level `"use strong"` directive.
- Reject render-phase state updates, synchronous effect state updates, and render-phase ref writes with actionable `useLinkedState` migration guidance.
- Support direct compilation, editor diagnostics, Vite, Rspack, Rsbuild, SSR, hydration, and incrementally adopted compatibility packages.

## Why

Octane can prove and reject common state and ref workarounds at compile time while retaining compatibility by default. `useLinkedState` supplies the migration path for state that follows another value.

## Changes

- Add a conservative, source-located analyzer with scope-aware hook provenance, tuple and namespace aliases, synchronous helpers, effect timing, and async/await analysis.
- Add global and per-module opt-ins, package ownership boundaries, manual-slot compatibility, typed configuration, cache invalidation, and client/server parity.
- Update the README, adapter documentation, website guides, navigation and search, and include a five-package patch changeset.
- Cover compiler behavior, app configuration, Vite/Rspack/Rsbuild integrations, Suspense, streaming SSR, and hydration.

## Validation

- [x] `node_modules/.bin/vitest run --project octane --project octane-prod --maxWorkers=4 --reporter=dot` — **788 files / 10,680 tests passed**.
- [x] `node_modules/.bin/vitest run --project app-core --project vite-plugin --project rspack-plugin --project rsbuild-plugin --project website-unit --project website-mcp-unit --maxWorkers=2 --reporter=dot` — **52 files / 596 tests passed**, including Chromium SSR/hydration.
- [x] `node node_modules/prettier/bin/prettier.cjs --check .`
- [x] Affected and downstream package typechecks: Octane, app-core, Vite, Rspack, Rsbuild, CLI, deployment adapters, TanStack Start, and website MCP.
- [x] `node packages/octane/scripts/build.mjs`
- [x] Changeset, test-marker, TSRX declaration, package inventory, and `git diff --check` checks.

## Risk / follow-ups

- The analyzer follows proven static provenance and preserves compatibility outside opted-in modules.
- Module directives produce editor diagnostics; forwarding app-wide compiler settings into the separate upstream TypeScript plugin remains follow-up work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new static analyzer on the compile path, but behavior is opt-in only and default builds are unchanged; misclassification could block valid patterns in Strong-enabled modules.
> 
> **Overview**
> Introduces **Strong mode**, an opt-in compile-time guard for clearer state and ref usage. It stays off by default so existing apps are unchanged.
> 
> **Opt-in:** `compiler: { strong: true }` in `octane.config.ts`, a top-level `"use strong"` directive, or `strong: true` on the Vite/Rspack/Rsbuild Octane plugins (plugin wins over app config). Dependencies are not affected by app-wide Strong mode unless they use their own directive; nested workspace packages inside the repo are scoped so global policy does not leak into compatibility bindings.
> 
> **Rejected patterns** (with diagnostics pointing at `useLinkedState` where relevant): calling `useState` / `useReducer` / `useLinkedState` updaters during render; the same during synchronous effect setup; assigning to `useRef.current` during render. Valid code paths (handlers, deferred effect work, DOM refs) stay allowed; the analyzer tracks hooks, aliases, async/await, and control flow.
> 
> **Implementation:** new `strong-mode.js` analyzer hooked into full compile, plain `.ts`/`.js` hook slotting, manual-slot modules, Volar mappings, and the neutral bundler—with application ownership boundaries and cache invalidation when `strong` toggles.
> 
> **Also:** `compiler.strong` typing/validation in app-core, README and site docs, and broad test coverage (compiler, integrations, SSR/hydration).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd0fcf216ee02b28abc17f4d9a46e44749fa3ee5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->