### PR TITLE
docs: retire two closed parallel-use() gaps

### DIFF
--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -555,17 +555,29 @@ and remains sequential.
   thenable ("uncached promise" dev warning), and a replay that discovers a new
   pending `use()` behind a data dependency gets a dev waterfall diagnostic.
 
-Known gaps are regression-pinned in `benchmarks/async-composition`:
+Composition is regression-pinned in `benchmarks/async-composition`, whose
+dashboard fixture reads eight resources — seven independent, one truly dependent
+— through an imported custom hook and three sibling panels:
 
 | Shape | Current behavior |
 | --- | --- |
-| Independent `use()` calls inside an imported custom hook | Serialize because independence analysis stops at the module boundary |
-| Adjacent async children under a parent with no `use()` | Are discovered serially because the parent never triggers its warm plan |
-| A transition-wrapped update | Reveals resolved content progressively instead of holding the whole previous screen |
+| Independent `use()` calls inside an imported custom hook | Start together: plain TypeScript custom hooks get the same memoize-and-batch treatment as component-local `use()` |
+| Adjacent async children under a parent with no `use()` | Start together: child warm plans register with active ancestors, so the first suspending descendant starts its siblings |
+| A transition-wrapped update | Can expose one mixed old/new state instead of holding the whole previous screen |
 
-The transition result is monotonic: it never rolls back, and a dependent value
-never renders against stale input. The benchmark sets one-way ceilings so all
-three gaps can only improve.
+The first two shapes reach the workload's true dependency floor — 2 waves and 8
+requests for both cold mount and transition update, against React's 6/3 waves and
+35/25 requests — so only `owner` waits, on `project.ownerId`.
+
+The remaining gap is transition atomicity, not fetch scheduling. Octane renders
+and mutates in one eager walk with no global work-in-progress tree, so a
+same-identity parent can patch its own bindings before a descendant suspends,
+leaving updated parent markup beside a held boundary's prior content. React
+renders the whole tree off-screen and commits atomically, so it holds the entire
+previous screen. The transition result is still monotonic: it never rolls back,
+never exposes invalid intermediate structure, and a dependent value never renders
+against stale input. The benchmark pins the exposed-state count at a one-way
+ceiling of one so the gap can only close.
 
 ## Root component entry points and container ownership
 


### PR DESCRIPTION
## Summary

- `docs/differences-from-react.md` still advertised two parallel-`use()` composition gaps that were closed by #133 on 2026-07-17.
- Only one gap in that table is real today: transition atomicity.

## Why

The "Known gaps" table is the divergence contract users read to decide whether a
shape is safe. Two of its three rows described a fetch-scheduling waterfall that
no longer happens, so the doc made Octane look meaningfully more broken than it
is — and buried the one gap that does still need attention.

The benchmark that pins this section disproves both stale rows directly. Its
fixture is built to exercise exactly those shapes:

- `benchmarks/async-composition/shared/octane/useProjectBundle.ts` is an imported
  plain-TypeScript custom hook with two independent `use()` reads.
- `Dashboard` in `shared/octane/App.tsrx` is a parent with no `use()` of its own
  and three async sibling panels.

Yet `benchmarks/baselines/local/async-composition.json` records `init_waves: 2`,
`update_waves: 2`, `init_calls: 8`, `update_calls: 8` — the workload's true
dependency floor, where only `owner` waits on `project.ownerId`. Both shapes
start in the first wave. The same baseline still records
`update_mixed_states: 1`, which is the transition-atomicity gap.

## Changes

- Reframe the section from "Known gaps" to what the benchmark actually pins, and
  describe the fixture so the numbers are checkable.
- Rewrite the two stale rows to state the current behavior and the mechanism that
  closed each one (custom-hook memoize-and-batch; child warm plans registering
  with active ancestors).
- Keep the transition row, and explain the underlying cause rather than only the
  symptom: Octane renders and mutates in one eager walk with no global
  work-in-progress tree, so a same-identity parent can patch its own bindings
  before a descendant suspends. Cross-references the retained limitation already
  documented in `packages/octane/audit/SUSPENSE_DIVERGENCE.md` #4.
- Preserve the monotonicity guarantees and the one-way ceiling framing.

## Validation

- [x] `pnpm format:check` — passes
- [ ] `pnpm typecheck` — not run; docs-only change, no TypeScript touched
- [ ] `pnpm test` — not run; docs-only change, no source or test files touched

No changeset: docs-only, no published package behavior changes.

## Risk / follow-ups

- No runtime, compiler, or API risk.
- Follow-up: the transition-atomicity gap itself is still open. It needs the
  eager render/mutate walk to become transactional for transition-priority
  renders so a suspend cannot leave already-patched parent bindings on screen.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, compiler, or API impact.
> 
> **Overview**
> **Parallel `use()` composition** in `docs/differences-from-react.md` is reframed from a "known gaps" list to what `benchmarks/async-composition` actually pins, including a short description of the dashboard fixture (eight resources, imported custom hook, three sibling panels).
> 
> The table rows for **independent `use()` inside an imported custom hook** and **adjacent async siblings under a parent with no `use()`** now state current behavior—those shapes start together via custom-hook memoize-and-batch and child warm plans registering with active ancestors—and note they hit the workload’s dependency floor (2 waves / 8 requests vs React’s higher counts).
> 
> The **transition-wrapped update** row is kept as the sole remaining gap, with added explanation that the cause is **transition atomicity** (eager render/mutate without a global WIP tree), not fetch scheduling, plus preserved monotonicity guarantees and the one-way `update_mixed_states` ceiling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit feaee51b55b184d8176302b611d8cc2a3d28dab7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->