### PR TITLE
fix(octane): hold a Suspense boundary whole through a transition

### DIFF
--- a/.changeset/transition-atomic-boundaries.md
+++ b/.changeset/transition-atomic-boundaries.md
@@ -1,0 +1,26 @@
+---
+'octane': patch
+---
+
+Hold a Suspense boundary whole through a transition.
+
+A transition that suspended used to leave part of the new screen on top of the
+old one. Rendering and mutating happen in one walk, so a component patched its
+own attributes and text on the way down and only afterwards found that a child
+below it was still loading — the boundary kept its old content but the markup
+around it had already moved on. The same thing happened when a held boundary
+replayed its body and only some of the data had arrived: the resolved parts
+committed and the rest stayed behind.
+
+A suspended attempt now undoes its own binding writes, so the boundary either
+updates completely or not at all. The undo runs in the same flush as the change,
+so nothing intermediate is ever painted and transitions stay monotonic — no
+visible rollback, no invalid intermediate structure.
+
+`benchmarks/async-composition` records zero exposed intermediate states for a
+transition update, level with React, with its ceiling tightened from one to zero.
+
+Content the same transition patches outside a suspended boundary still updates
+early — that is what keeps `useTransition`'s `isPending` cue responsive — and
+structural changes such as a keyed list reordering above the boundary are not
+covered.

--- a/benchmarks/async-composition/README.md
+++ b/benchmarks/async-composition/README.md
@@ -127,3 +127,20 @@ Every independent request starts before the first 50ms network wave settles;
 `owner` alone waits for `project.ownerId`. The remaining single mixed update
 signature is transition atomicity work rather than an async-discovery waterfall,
 and stays visible under its tightened one-state ceiling.
+
+## Atomic transitions (2026-07-29)
+
+The last mixed signature is gone. It was the held boundary replaying its body:
+`project`, `viewer`, and `badge` had arrived and patched their nodes, then
+`owner` suspended again behind its data dependency, leaving three v1 values
+beside five v0 ones.
+
+A suspended attempt now undoes its own binding writes, so the boundary holds
+whole. Both the waves and the exposed states are level with React:
+
+| target | update | waves (init / update) | calls (init / update) | observed mixed update states |
+| --- | ---: | ---: | ---: | ---: |
+| octane-tsrx | 2 waves | 2 / 2 | 8 / 8 | 0 |
+| React | 3 waves | 6 / 3 | 35 / 25 | 0 |
+
+The update ceiling is now zero, so any reintroduced tear fails the suite.

--- a/benchmarks/async-composition/run.mjs
+++ b/benchmarks/async-composition/run.mjs
@@ -26,7 +26,7 @@ const expectedSignature = (version) =>
 const OBSERVATION_CEILINGS = {
 	'octane-tsrx': {
 		init: { waves: 2, calls: 8, mixedStates: 0 },
-		update: { waves: 2, calls: 8, mixedStates: 1 },
+		update: { waves: 2, calls: 8, mixedStates: 0 },
 	},
 	react: {
 		init: { mixedStates: 0 },

--- a/benchmarks/baselines/local/async-composition.json
+++ b/benchmarks/baselines/local/async-composition.json
@@ -78,11 +78,11 @@
           "samples": 10
         },
         "update_mixed_states": {
-          "score": 1,
-          "median": 1,
-          "min": 1,
-          "mean": 1,
-          "p95": 1,
+          "score": 0,
+          "median": 0,
+          "min": 0,
+          "mean": 0,
+          "p95": 0,
           "sd": 0,
           "rme": 0,
           "scoreRme": 0,
@@ -147,10 +147,8 @@
           "wavePatterns": [
             "project+viewer+badge+activity+activity-summary+insights+insights-chart -> owner"
           ],
-          "mixedStateCounts": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
-          "mixedStateSignatures": [
-            "project=project:v1|viewer=viewer:v1|badge=badge:v1|owner=owner:v0:owner-0|activity=activity:v0|activity-summary=activity-summary:v0|insights=insights:v0|insights-chart=insights-chart:v0"
-          ]
+          "mixedStateCounts": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          "mixedStateSignatures": []
         }
       }
     },

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -563,21 +563,28 @@ dashboard fixture reads eight resources — seven independent, one truly depende
 | --- | --- |
 | Independent `use()` calls inside an imported custom hook | Start together: plain TypeScript custom hooks get the same memoize-and-batch treatment as component-local `use()` |
 | Adjacent async children under a parent with no `use()` | Start together: child warm plans register with active ancestors, so the first suspending descendant starts its siblings |
-| A transition-wrapped update | Can expose one mixed old/new state instead of holding the whole previous screen |
+| A transition-wrapped update | Holds the boundary whole: no mixed old/new state, matching React |
 
-The first two shapes reach the workload's true dependency floor — 2 waves and 8
-requests for both cold mount and transition update, against React's 6/3 waves and
-35/25 requests — so only `owner` waits, on `project.ownerId`.
+All three reach the workload's true dependency floor — 2 waves and 8 requests for
+both cold mount and transition update, against React's 6/3 waves and 35/25
+requests — so only `owner` waits, on `project.ownerId`, and the update exposes
+zero intermediate states, the same as React.
 
-The remaining gap is transition atomicity, not fetch scheduling. Octane renders
-and mutates in one eager walk with no global work-in-progress tree, so a
-same-identity parent can patch its own bindings before a descendant suspends,
-leaving updated parent markup beside a held boundary's prior content. React
-renders the whole tree off-screen and commits atomically, so it holds the entire
-previous screen. The transition result is still monotonic: it never rolls back,
-never exposes invalid intermediate structure, and a dependent value never renders
-against stale input. The benchmark pins the exposed-state count at a one-way
-ceiling of one so the gap can only close.
+A held boundary holds all of its own content. Octane renders and mutates in one
+walk, so a transition patches a boundary's bindings on the way down and only then
+finds that a descendant suspends; the same happens when a held boundary replays
+its body and part of the data has arrived. Both cases record what each binding
+replaced and put it back if the attempt suspends, inside the flush that made the
+change — nothing reaches the screen in between. Transitions stay monotonic: no
+visible rollback, no invalid intermediate structure, and a dependent value never
+renders against stale input.
+
+Content the same transition patched OUTSIDE a suspended boundary still updates
+early, and so does a structural change (a keyed list reordering above the
+boundary) rather than a binding. Holding those needs the global work-in-progress
+tree Octane deliberately does not have; see
+[Suspense divergence #4](../packages/octane/audit/SUSPENSE_DIVERGENCE.md). The
+benchmark pins the exposed-state count at zero.
 
 ## Root component entry points and container ownership
 

--- a/packages/octane/audit/SUSPENSE_DIVERGENCE.md
+++ b/packages/octane/audit/SUSPENSE_DIVERGENCE.md
@@ -92,15 +92,26 @@ are visible, the coordinator (Divergence #1) retries detached primaries to compl
 reveals their DOM plus ref/layout lifecycle in one batch. Independent per-swap WIPs also
 retain their old content until ready (`entangled-commit.test.ts`).
 
-**Remaining limitation:** this is still not a global WIP. During an ordinary synchronous
-transition, a same-identity parent can patch bindings outside a suspending `@try` before a
-descendant throws. octane then holds the old boundary content beside already-updated
-parent/sibling UI; React retains the whole prior screen. The async Action batching in #6
-prevents that tear while an Action is in flight, but does not close the synchronous case.
-Likewise, a pre-timeout live boundary retry can resolve one use() and then suspend on a
-later true dependency after an earlier staged sibling has started committing; preventing
-that requires the same absent global WIP. Fallback-visible retries are capture-safe and do
-not have this limitation.
+**Binding tear inside a held boundary — CLOSED (2026-07-29).** A same-identity parent used
+to patch its own bindings on the way down and only then have a descendant throw, so the
+boundary held old content beside already-updated markup of its own. A pre-timeout live
+retry had the same shape: resolve one use(), patch, then suspend on a later true
+dependency. Both now run inside a journal (`TRANSITION_JOURNAL` in runtime.ts) that records
+what each binding write replaced — plus the compiled bag that guards it, or the guard would
+skip the re-patch on resume — and replays it if the attempt suspends into a hold. The undo
+happens in the flush that made the change, so no intermediate state is ever painted.
+`benchmarks/async-composition` pins the update at zero exposed states, level with React;
+`transitions.test.ts` covers the in-place and replay shapes.
+
+**Remaining limitation:** this is still not a global WIP, so the journal is scoped to the
+boundary. Content the same transition patched OUTSIDE a suspended boundary keeps its new
+value — which is what lets the `isPending` cue turn on while its content holds, but also
+means unrelated shell markup updates early where React would hold the whole prior screen.
+Structural mutations (a keyed list reordering above the boundary) are not journaled either:
+the reconciler navigates live DOM, so undoing writes it has already read back is not sound
+without the absent global WIP. The async Action batching in #6 prevents the shell tear while
+an Action is in flight, but does not close the synchronous case. Fallback-visible retries
+are capture-safe and never had this limitation.
 Time-based cross-boundary fallback throttling is the separate Divergence #5.
 
 ---

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -1051,6 +1051,164 @@ let flushingStagedReveals = false;
 let deferringStagedRevealEffects = false;
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Transition binding journal.
+//
+// Rendering and mutating happen in one walk, so a transition render patches a
+// boundary's own bindings on the way down and only afterwards discovers that a
+// descendant suspends. The boundary then holds its prior content, but those
+// earlier patches have already landed — the boundary shows part of the new
+// screen next to the old one. React renders the whole tree off the current one
+// and commits in a single step, so its boundary stays whole.
+//
+// While a VISIBLE try body re-renders and a hold is possible, each binding write
+// records what it replaced. If the body suspends and the boundary holds, the log
+// is replayed backwards to the checkpoint taken when that body started, leaving
+// the boundary exactly as it was. This all happens inside the flush that made
+// the change, so nothing reached the screen in between: there is no visible
+// rollback, only a boundary that never split.
+//
+// The log is scoped to the boundary, not the flush, so anything the same render
+// patched OUTSIDE the boundary keeps its new value. That is what lets the
+// `isPending` cue turn on while the content it describes stays put — React gets
+// the same result from a separate urgent render. Content outside a boundary that
+// belongs to the transition itself does still update early; holding that too
+// needs the global work-in-progress tree octane deliberately does not have
+// (SUSPENSE_DIVERGENCE.md #4).
+//
+// Compiled bindings guard on a cached copy of the last value (`if (_b.d !== _v)`)
+// and never read the DOM, so restoring a node without restoring that cache would
+// leave the guard convinced the node is already current and the value would
+// never reappear. The first write into a bag therefore snapshots the whole bag
+// next to the DOM entry.
+//
+// Controlled `value`/`checked` stay out. They are browser-owned state tracked
+// alongside the DOM in a per-element controlled record, and putting the node back
+// without that record would leave the two disagreeing about what the user last
+// typed. An input inside a boundary can therefore still show its new value early.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const JOURNAL_TEXT = 0;
+const JOURNAL_ATTR = 1;
+const JOURNAL_BAG = 2;
+/** Flat undo log, four slots per entry: kind, target, a, b. */
+let TRANSITION_JOURNAL: any[] | null = null;
+/** Bags already captured in the open window, so each is snapshotted once. */
+let TRANSITION_JOURNAL_BAGS: Set<object> | null = null;
+/** Open windows. Boundaries nest, and only the outermost may drop the log. */
+let TRANSITION_JOURNAL_DEPTH = 0;
+
+/**
+ * Snapshot the rendering scope's binding bag the first time it is written in the
+ * open window. Called from the binding helpers, which the compiler always emits
+ * BEFORE the matching `_b.x = _v`, so the captured values are the pre-render
+ * ones.
+ *
+ * Slot 0 only holds a bag when the body has a template root; a body made purely
+ * of control flow puts its first block slot there instead (`tryBlock(__s, 0, …)`).
+ * Every runtime slot is tagged with `__kind` and no compiler bag is, so that tag
+ * is the discriminator — restoring a boundary's own `branch`/`transitionHeld`
+ * from a "bag" snapshot would corrupt the very state driving the hold.
+ */
+function journalBag(): void {
+	const scope = CURRENT_SCOPE;
+	if (scope === null) return;
+	const bag = scope.slots[0];
+	if (bag === null || typeof bag !== 'object' || (bag as any).__kind !== undefined) return;
+	const seen = TRANSITION_JOURNAL_BAGS!;
+	if (seen.has(bag)) return;
+	seen.add(bag);
+	const keys = Object.keys(bag);
+	const values: any[] = [];
+	for (let i = 0; i < keys.length; i++) values.push((bag as any)[keys[i]]);
+	TRANSITION_JOURNAL!.push(JOURNAL_BAG, bag, keys, values);
+}
+
+function journalText(node: Text): void {
+	TRANSITION_JOURNAL!.push(JOURNAL_TEXT, node, node.nodeValue, null);
+	journalBag();
+}
+
+function journalAttr(el: Element, name: string): void {
+	TRANSITION_JOURNAL!.push(JOURNAL_ATTR, el, name, el.getAttribute(name));
+	journalBag();
+}
+
+/**
+ * Open a journal window for a visible try body that is about to re-render, and
+ * return the checkpoint to roll back to. `-1` means "not journaling": either the
+ * boundary cannot hold (nothing committed to keep) or no transition is in play,
+ * which is the overwhelmingly common case and costs one comparison.
+ *
+ * The arming test mirrors handleSuspense's hold conditions. The body inherits
+ * its mode from the block currently rendering it (renderBlockInner walks
+ * `pendingMode ?? parent's mode`), so the ambient block answers "is this a
+ * transition" before the body runs. `transitionHeld` covers the boundary that is
+ * already holding and re-suspends at urgent priority — the useSuspenseQuery
+ * shape, where the observer notifies a macrotask after the transition window
+ * closed and handleSuspense continues the hold regardless of priority.
+ */
+function armTransitionJournal(state: TrySlot): number {
+	if (
+		!state.hasResolved ||
+		state.hiddenDom !== null ||
+		!(
+			state.transitionHeld ||
+			(state.tryBlock?.pendingMode ?? CURRENT_BLOCK?.currentRenderMode) === 'transition'
+		)
+	)
+		return -1;
+	TRANSITION_JOURNAL ??= [];
+	TRANSITION_JOURNAL_BAGS ??= new Set();
+	TRANSITION_JOURNAL_DEPTH++;
+	return TRANSITION_JOURNAL.length;
+}
+
+/**
+ * Close the window opened by `armTransitionJournal`.
+ *
+ * A committed inner boundary deliberately LEAVES its entries in the log: an
+ * enclosing boundary that suspends later still has to undo them, because its
+ * content includes everything the inner boundary just wrote. Only the outermost
+ * window drops the log — before that there is always someone left who might need
+ * to replay it.
+ */
+function disarmTransitionJournal(checkpoint: number): void {
+	if (checkpoint < 0) return;
+	if (--TRANSITION_JOURNAL_DEPTH === 0) {
+		TRANSITION_JOURNAL = null;
+		TRANSITION_JOURNAL_BAGS = null;
+	}
+}
+
+/** Undo every binding write recorded since `checkpoint`, newest first. */
+function rollbackTransitionJournal(checkpoint: number): void {
+	if (checkpoint < 0) return;
+	const log = TRANSITION_JOURNAL;
+	if (log === null) return;
+	for (let i = log.length - 4; i >= checkpoint; i -= 4) {
+		const target = log[i + 1];
+		const a = log[i + 2];
+		const b = log[i + 3];
+		switch (log[i]) {
+			case JOURNAL_TEXT:
+				(target as Text).nodeValue = a;
+				break;
+			case JOURNAL_ATTR:
+				if (b === null) (target as Element).removeAttribute(a);
+				else (target as Element).setAttribute(a, b);
+				break;
+			default:
+				for (let k = 0; k < a.length; k++) target[a[k]] = b[k];
+				// This bag is back to its pre-window values, so a later write in an
+				// enclosing window has to snapshot it again rather than trust the
+				// entry that just got replayed.
+				TRANSITION_JOURNAL_BAGS!.delete(target);
+		}
+	}
+	log.length = checkpoint;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // View Transitions (docs/view-transitions-plan.md, Phase 1).
 //
 // Octane renders AND mutates in one eager walk (flush → drainQueue) — there is
@@ -9152,6 +9310,7 @@ export function setText(node: Text, value: any): void {
 	// mutation choke point AND is prev-guarded (only ACTUAL changes reach it).
 	// The optional driver marks the innermost boundary only during a wrapped drain.
 	VIEW_TRANSITION_DRIVER?.markDirty();
+	if (TRANSITION_JOURNAL !== null) journalText(node);
 	//
 	// Write via `nodeValue` (a `Node`-level accessor) rather than `data` (which
 	// lives on `CharacterData` one prototype hop deeper) — it's measurably faster
@@ -10165,6 +10324,7 @@ export function setAttribute(el: Element, name: string, value: any): void {
 	const hydration = activeHydration();
 	if (hydration !== null && !hydration.allowAttribute(el, name, next)) return;
 	const ns = attrNamespace(name);
+	if (TRANSITION_JOURNAL !== null) journalAttr(el, name);
 	if (next === null) {
 		if (ns) {
 			const colon = name.indexOf(':');
@@ -10240,6 +10400,7 @@ export function setStringData(el: Element, name: string, value: unknown): void {
 	}
 	const hydration = activeHydration();
 	if (hydration !== null && !hydration.allowAttribute(el, name, next)) return;
+	if (TRANSITION_JOURNAL !== null) journalAttr(el, name);
 	if (next === null) el.removeAttribute(name);
 	else el.setAttribute(name, next);
 }
@@ -10256,6 +10417,7 @@ export function setBooleanAttribute(el: Element, name: string, value: unknown): 
 	const next = !value || type === 'function' || type === 'symbol' ? null : '';
 	const hydration = activeHydration();
 	if (hydration !== null && !hydration.allowAttribute(el, name, next)) return;
+	if (TRANSITION_JOURNAL !== null) journalAttr(el, name);
 	if (next === null) el.removeAttribute(name);
 	else el.setAttribute(name, next);
 }
@@ -10270,6 +10432,7 @@ export function setAriaAttribute(el: Element, name: string, value: unknown): voi
 	const next = value == null ? null : String(value);
 	const hydration = activeHydration();
 	if (hydration !== null && !hydration.allowAttribute(el, name, next)) return;
+	if (TRANSITION_JOURNAL !== null) journalAttr(el, name);
 	if (next === null) el.removeAttribute(name);
 	else el.setAttribute(name, next);
 }
@@ -10443,6 +10606,7 @@ export function setClassName(el: Element, value: unknown): void {
 	// an empty STRING still writes `class=""` — the differential rig pins that
 	// distinction against React). Same raw-value rule as setClassAttr: composition
 	// erases the null-vs-'' difference, so the check must be on `value`.
+	if (TRANSITION_JOURNAL !== null) journalAttr(el, 'class');
 	if (value == null || value === false) el.removeAttribute('class');
 	else (el as any).className = cls;
 }
@@ -10460,6 +10624,7 @@ export function setClassAttr(el: Element, value: unknown): void {
 		hydration.queueClass(el, cls, false, true, cls === null);
 		return;
 	}
+	if (TRANSITION_JOURNAL !== null) journalAttr(el, 'class');
 	if (cls === null) el.removeAttribute('class');
 	else el.setAttribute('class', cls);
 }
@@ -10494,6 +10659,9 @@ export function setStyle(el: HTMLElement | SVGElement, value: any, prev: any): v
 	// `suppressHydrationWarning` keeps the complete server style unchanged.
 	const hydration = activeHydration();
 	if (hydration !== null && hydration.applyStyle(el, value, prev)) return;
+	// The whole style attribute, not the individual declarations applyStyleValue
+	// is about to touch: restoring the attribute text restores every one of them.
+	if (TRANSITION_JOURNAL !== null) journalAttr(el, 'style');
 	applyStyleValue(style, value, prev);
 }
 
@@ -18298,6 +18466,9 @@ export function tryBlock(
 		// whether to preserve the DOM (keep) or swap to pending (default).
 		s.tryBlock.body = s.tryBody;
 		s.tryBlock.extra = s.env;
+		// Everything this body patches is undoable until it either commits or
+		// suspends into a hold, so the boundary can never be left half-updated.
+		const journalCheckpoint = armTransitionJournal(s);
 		try {
 			renderBlock(s.tryBlock);
 			// Successful commit — this supersedes any in-flight transition
@@ -18314,8 +18485,10 @@ export function tryBlock(
 			if (isHostContextRequest(err)) throw err;
 			if (isSuspenseException(err)) {
 				if (s.propagateSuspense) throw err;
-				handleSuspense(s, err.thenable, s.tryBlock);
+				handleSuspense(s, err.thenable, s.tryBlock, journalCheckpoint);
 			} else switchToCatch(s, err);
+		} finally {
+			disarmTransitionJournal(journalCheckpoint);
 		}
 	} else {
 		mountTry(s);
@@ -18601,7 +18774,15 @@ function releaseHeldTransition(state: TrySlot): void {
 	}
 }
 
-function handleSuspense(state: TrySlot, thenable: TrackedThenable<any>, sourceBlock: Block): void {
+function handleSuspense(
+	state: TrySlot,
+	thenable: TrackedThenable<any>,
+	sourceBlock: Block,
+	// Journal position to restore if this suspend turns into a hold. `-1` from
+	// every caller that renders outside an armed window (a fresh mount or a
+	// retry, neither of which has committed content to keep whole).
+	journalCheckpoint = -1,
+): void {
 	// Transition-priority suspends on an ALREADY-committed try block keep the
 	// prior DOM visible — matches React's `useTransition` contract that the
 	// previous screen stays mounted until the new tree is fully ready. We also
@@ -18659,6 +18840,11 @@ function handleSuspense(state: TrySlot, thenable: TrackedThenable<any>, sourceBl
 		state.branch === 1 &&
 		state.hiddenDom === null
 	) {
+		// The body got part of the way through patching this boundary before the
+		// suspend, so put back what it changed. Nothing has been painted since —
+		// the render and this undo are the same synchronous flush — so the
+		// boundary simply never shows half of the new screen.
+		rollbackTransitionJournal(journalCheckpoint);
 		if (!state.transitionHeld) {
 			state.transitionHeld = true;
 			tickTransitionCount(+1);
@@ -18969,6 +19155,12 @@ function commitResumeInner(state: TrySlot): void {
 				// Mark the replay window: useThenable's fresh-thenable reuse leniency
 				// and the waterfall diagnostic apply only while a resolved suspension
 				// is being replayed (ordinary updates must keep replacing thenables).
+				// A held boundary replaying its body is the other way it can end up
+				// half-updated: the resources that just resolved patch their nodes,
+				// and then a still-pending one behind a data dependency suspends
+				// again. The effects and refs of that attempt are already discarded
+				// below; its DOM writes need the same treatment.
+				const journalCheckpoint = armTransitionJournal(state);
 				const resumeCapture = createOffscreenCapture();
 				const effectDeps = snapshotSubtreeEffectDeps(tryBlock);
 				const previousCapture = WIP_CAPTURE;
@@ -18990,6 +19182,10 @@ function commitResumeInner(state: TrySlot): void {
 				} finally {
 					WIP_CAPTURE = previousCapture;
 					RESUME_REPLAY = prevReplay;
+					// A completed replay has nothing to undo, so close its window here
+					// where the unwind is already guaranteed. A suspended one keeps it
+					// open: handleSuspense below is what replays it.
+					if (!didThrow) disarmTransitionJournal(journalCheckpoint);
 				}
 				if (!didThrow) {
 					if (state.detachedRefs !== null) {
@@ -18999,13 +19195,21 @@ function commitResumeInner(state: TrySlot): void {
 					spliceOffscreenCapture(resumeCapture);
 					state.hasResolved = true;
 				} else {
-					refDetachQueue.splice(refDetachCheckpoint);
-					restoreSubtreeEffectDeps(tryBlock, effectDeps);
-					discardOffscreenCapture(resumeCapture);
-					if (isSuspenseException(renderError)) {
-						handleSuspense(state, renderError.thenable, tryBlock);
-					} else {
-						switchToCatch(state, renderError);
+					// The journal has to outlive handleSuspense, which is what replays it,
+					// so it is closed here rather than around the render — in a finally, or
+					// a throw out of switchToCatch would strand the window open and let the
+					// next boundary undo more than its own writes.
+					try {
+						refDetachQueue.splice(refDetachCheckpoint);
+						restoreSubtreeEffectDeps(tryBlock, effectDeps);
+						discardOffscreenCapture(resumeCapture);
+						if (isSuspenseException(renderError)) {
+							handleSuspense(state, renderError.thenable, tryBlock, journalCheckpoint);
+						} else {
+							switchToCatch(state, renderError);
+						}
+					} finally {
+						disarmTransitionJournal(journalCheckpoint);
 					}
 					if (state.parentBlock.disposed) return;
 				}

--- a/packages/octane/tests/_fixtures/transitions.tsrx
+++ b/packages/octane/tests/_fixtures/transitions.tsrx
@@ -372,3 +372,75 @@ export function AsyncTransitionKeepsDom(props) @{
 		}
 	</div>
 }
+
+// ---------------------------------------------------------------------------
+// The panel is the same component before and after the transition, so it
+// updates its own attribute and heading straight away, and only then does the
+// child under it start loading. React keeps the whole old screen up until the
+// new one is ready, so nothing here should change early.
+// ---------------------------------------------------------------------------
+function AtomicityValue(props) @{
+	const value = use(props.load(props.version));
+	<span id="value">{value as string}</span>
+}
+
+function AtomicityPanel(props) @{
+	<section id="panel" data-version={props.version as string}>
+		<h2 id="heading">{'v' + props.version}</h2>
+		<AtomicityValue version={props.version} load={props.load} />
+	</section>
+}
+
+export function TransitionAtomicity(props) @{
+	const [version, setVersion] = useState(0);
+	const [isPending, start] = useTransition();
+	<div>
+		<span id="pending">
+			{isPending ? 'pending' : 'idle'}
+		</span>
+		<button
+			id="bump"
+			onClick={() => start(() => setVersion((value: number) => value + 1))}
+		>{'bump'}</button>
+		@try {
+			<AtomicityPanel version={version} load={props.load} />
+		} @pending {
+			<span id="fallback">{'fallback'}</span>
+		}
+	</div>
+}
+
+// ---------------------------------------------------------------------------
+// Two leaves under one boundary. A transition moves both to the next step and
+// then only the first one's data arrives, so replaying the body commits that
+// leaf while the other suspends again. The boundary has to stay on the old step
+// until both are ready.
+// ---------------------------------------------------------------------------
+function ResumeLeafA(props) @{
+	const value = use(props.load('a', props.step));
+	<span id="a">{value as string}</span>
+}
+
+function ResumeLeafB(props) @{
+	const value = use(props.load('b', props.step));
+	<span id="b">{value as string}</span>
+}
+
+export function TransitionResumeAtomicity(props) @{
+	const [step, setStep] = useState(0);
+	const [isPending, start] = useTransition();
+	<div>
+		<span id="pending">
+			{isPending ? 'pending' : 'idle'}
+		</span>
+		<button id="bump" onClick={() => start(() => setStep(1))}>{'bump'}</button>
+		@try {
+			<>
+				<ResumeLeafA load={props.load} step={step} />
+				<ResumeLeafB load={props.load} step={step} />
+			</>
+		} @pending {
+			<span id="fallback">{'fallback'}</span>
+		}
+	</div>
+}

--- a/packages/octane/tests/_fixtures/transitions.tsrx
+++ b/packages/octane/tests/_fixtures/transitions.tsrx
@@ -444,3 +444,31 @@ export function TransitionResumeAtomicity(props) @{
 		}
 	</div>
 }
+
+// ---------------------------------------------------------------------------
+// A namespaced attribute inside a boundary. The write goes through
+// setAttributeNS, while the undo puts the old value back by qualified name —
+// which has to land on the same namespaced attribute rather than adding a plain
+// one beside it.
+// ---------------------------------------------------------------------------
+function NamespacedValue(props) @{
+	const value = use(props.load(props.step));
+	<span id="value">{value as string}</span>
+}
+
+export function TransitionNamespacedAttr(props) @{
+	const [step, setStep] = useState(0);
+	<div>
+		<button id="bump" onClick={() => startTransition(() => setStep(1))}>{'bump'}</button>
+		@try {
+			<>
+				<svg>
+					<use id="use-el" xlink:href={'#icon-' + step} />
+				</svg>
+				<NamespacedValue load={props.load} step={step} />
+			</>
+		} @pending {
+			<span id="fallback">{'fallback'}</span>
+		}
+	</div>
+}

--- a/packages/octane/tests/transitions.test.ts
+++ b/packages/octane/tests/transitions.test.ts
@@ -16,6 +16,8 @@ import {
 	UrgentSupersedesTransition,
 	AsyncStartTransition,
 	AsyncTransitionKeepsDom,
+	TransitionAtomicity,
+	TransitionResumeAtomicity,
 } from './_fixtures/transitions.tsrx';
 
 interface Deferred<T> {
@@ -552,6 +554,91 @@ describe('useTransition — async actions (React 19)', () => {
 			d2.resolve('two');
 		});
 		expect(r.find('#value').textContent).toBe('two');
+		expect(r.find('#pending').textContent).toBe('idle');
+		r.unmount();
+	});
+});
+
+describe('useTransition — the old screen stays whole', () => {
+	it('a parent that renders in place does not update before its suspended child', async () => {
+		const first = deferred<string>();
+		const second = deferred<string>();
+		const promises = [first.promise, second.promise];
+		const load = (version: number) => promises[version];
+
+		const r = mount(TransitionAtomicity, { load });
+		await act(() => {
+			first.resolve('one');
+		});
+		expect(r.find('#panel').getAttribute('data-version')).toBe('0');
+		expect(r.find('#heading').textContent).toBe('v0');
+		expect(r.find('#value').textContent).toBe('one');
+
+		// The transition bumps to v1 and the child suspends on the new promise.
+		// The panel is the same component, so today it patches its own attribute
+		// and heading on the way down and leaves them ahead of the held value.
+		r.click('#bump');
+		expect(r.find('#pending').textContent).toBe('pending');
+		expect(r.findAll('#fallback')).toHaveLength(0);
+		expect(r.find('#value').textContent).toBe('one');
+		expect(r.find('#panel').getAttribute('data-version')).toBe('0');
+		expect(r.find('#heading').textContent).toBe('v0');
+
+		// Once the promise settles the whole screen moves to v1 together.
+		await act(() => {
+			second.resolve('two');
+		});
+		expect(r.find('#panel').getAttribute('data-version')).toBe('1');
+		expect(r.find('#heading').textContent).toBe('v1');
+		expect(r.find('#value').textContent).toBe('two');
+		expect(r.find('#pending').textContent).toBe('idle');
+		r.unmount();
+	});
+
+	it('a boundary replaying its body does not commit one resolved value beside an old one', async () => {
+		const entries = new Map<string, Deferred<string>>();
+		const load = (name: string, step: number) => {
+			const key = `${name}${step}`;
+			let entry = entries.get(key);
+			if (entry === undefined) {
+				entry = deferred<string>();
+				entries.set(key, entry);
+			}
+			return entry.promise;
+		};
+		load('a', 0);
+		load('b', 0);
+		entries.get('a0')!.resolve('a0');
+		entries.get('b0')!.resolve('b0');
+
+		const r = mount(TransitionResumeAtomicity, { load });
+		await act(() => {});
+		expect(r.find('#a').textContent).toBe('a0');
+		expect(r.find('#b').textContent).toBe('b0');
+
+		// Both leaves move to step 1 and both suspend, so the boundary holds.
+		r.click('#bump');
+		expect(r.findAll('#fallback')).toHaveLength(0);
+		expect(r.find('#a').textContent).toBe('a0');
+		expect(r.find('#b').textContent).toBe('b0');
+
+		// Only the first leaf's data arrives. The replay renders it and then
+		// suspends again on the second, which must leave the boundary untouched
+		// rather than showing the new value next to the old one.
+		await act(() => {
+			entries.get('a1')!.resolve('a1');
+		});
+		expect(r.find('#a').textContent).toBe('a0');
+		expect(r.find('#b').textContent).toBe('b0');
+		expect(r.find('#pending').textContent).toBe('pending');
+		expect(r.findAll('#fallback')).toHaveLength(0);
+
+		// Second one lands and both step together.
+		await act(() => {
+			entries.get('b1')!.resolve('b1');
+		});
+		expect(r.find('#a').textContent).toBe('a1');
+		expect(r.find('#b').textContent).toBe('b1');
 		expect(r.find('#pending').textContent).toBe('idle');
 		r.unmount();
 	});

--- a/packages/octane/tests/transitions.test.ts
+++ b/packages/octane/tests/transitions.test.ts
@@ -18,6 +18,7 @@ import {
 	AsyncTransitionKeepsDom,
 	TransitionAtomicity,
 	TransitionResumeAtomicity,
+	TransitionNamespacedAttr,
 } from './_fixtures/transitions.tsrx';
 
 interface Deferred<T> {
@@ -640,6 +641,45 @@ describe('useTransition — the old screen stays whole', () => {
 		expect(r.find('#a').textContent).toBe('a1');
 		expect(r.find('#b').textContent).toBe('b1');
 		expect(r.find('#pending').textContent).toBe('idle');
+		r.unmount();
+	});
+
+	it('restores a namespaced attribute onto the same attribute, not a plain copy', async () => {
+		const XLINK = 'http://www.w3.org/1999/xlink';
+		const entries = new Map<number, Deferred<string>>();
+		const load = (step: number) => {
+			let entry = entries.get(step);
+			if (entry === undefined) {
+				entry = deferred<string>();
+				entries.set(step, entry);
+			}
+			return entry.promise;
+		};
+		load(0);
+		entries.get(0)!.resolve('zero');
+
+		const r = mount(TransitionNamespacedAttr, { load });
+		await act(() => {});
+		const use = r.find('#use-el');
+		expect(use.getAttributeNS(XLINK, 'href')).toBe('#icon-0');
+
+		// The transition patches the attribute and then the sibling suspends, so
+		// the undo has to put '#icon-0' back on the namespaced attribute itself.
+		r.click('#bump');
+		expect(r.findAll('#fallback')).toHaveLength(0);
+		expect(use.getAttributeNS(XLINK, 'href')).toBe('#icon-0');
+		expect(use.getAttribute('xlink:href')).toBe('#icon-0');
+		// A plain restore alongside the namespaced one would show up as a second
+		// attribute with a null namespace.
+		expect(use.attributes.length).toBe(2);
+		expect(use.getAttributeNode('xlink:href')!.namespaceURI).toBe(XLINK);
+
+		await act(() => {
+			entries.get(1)!.resolve('one');
+		});
+		expect(use.getAttributeNS(XLINK, 'href')).toBe('#icon-1');
+		expect(use.getAttributeNode('xlink:href')!.namespaceURI).toBe(XLINK);
+		expect(r.find('#value').textContent).toBe('one');
 		r.unmount();
 	});
 });


### PR DESCRIPTION
## Summary

A transition that suspends now holds its Suspense boundary whole, instead of
leaving part of the new screen on top of the old one.

`benchmarks/async-composition` drops from **1 exposed intermediate state to 0**
for a transition update — level with React — with no change to its 2-wave /
8-request dependency floor.

## Why

Octane renders and mutates in one walk. A component therefore patches its own
attributes and text on the way down, and only afterwards discovers that a child
below it is still loading. The boundary held its old content, but the markup
around it had already moved on.

Two shapes produced this:

1. **In place.** A same-identity parent inside the boundary patches its bindings,
   then a descendant suspends.
2. **On replay.** A held boundary re-renders when some of its data arrives; the
   resolved parts commit and then a still-pending one suspends again. This is the
   one the benchmark was recording — `project`, `viewer` and `badge` at v1 beside
   five v0 values, with `owner` still waiting on `project.ownerId`.

The replay path already discarded the effects and refs of a suspended attempt.
Its DOM writes just weren't covered by the same idea.

## Changes

- **`packages/octane/src/runtime.ts`** — a binding journal, opened only while a
  visible try body re-renders and a hold is possible. Each binding write records
  what it replaced; if the attempt suspends into a hold, the log replays
  backwards to the checkpoint taken when that body started. Both the in-place
  (`tryBlock`) and replay (`commitResumeInner`) paths are armed.

  Compiled bindings guard on a cached copy of the last value (`if (_b.d !== _v)`)
  and never read the DOM, so restoring a node without restoring that cache would
  leave the guard convinced the node was already current and the value would
  never reappear. The first write into a bag therefore snapshots the whole bag
  next to the DOM entry.

  The undo happens inside the flush that made the change, so nothing intermediate
  is ever painted — there is no visible rollback, only a boundary that never
  splits. Transitions stay monotonic.

- **Tests** — two regression tests in `transitions.test.ts`, one per shape, plus
  their fixtures. Both were watched failing before the fix and again with each
  half of the fix individually disabled.

- **Benchmark** — the update ceiling in `run.mjs` tightens from 1 to 0, and the
  `update_mixed_states` entry in the committed baseline follows. Only that
  deterministic counter was edited by hand; the timing numbers in that file are
  the author's machine's and were left alone rather than overwritten with mine.

- **Docs** — `docs/differences-from-react.md` and `SUSPENSE_DIVERGENCE.md` #4
  updated to record what closed and what did not.

## Scope — what is deliberately still not held

- **Content outside the boundary** that the same transition patched. The journal
  is scoped to the boundary, which is exactly what lets `useTransition`'s
  `isPending` cue turn on while the content it describes holds — React gets the
  same result from a separate urgent render. Unrelated shell markup does still
  update early.
- **Structural mutations**, such as a keyed list reordering above the boundary.
  The reconciler navigates live DOM, so undoing writes it has already read back
  is not sound without a global work-in-progress tree.
- **Controlled `value`/`checked`**, which are browser-owned state tracked in a
  per-element record; putting the node back without that record would leave the
  two disagreeing about what the user last typed.

All three are documented in `SUSPENSE_DIVERGENCE.md` #4 as the retained
global-WIP limitation.

## Validation

- [x] `pnpm test` — 15,647 passed, 1453 files, 0 failures
- [x] `pnpm typecheck` — clean
- [x] `pnpm format:check` — clean
- [x] `node benchmarks/bench.mjs async-composition` — `update_mixed_states` 1 → 0,
      waves 2/2 and calls 8/8 unchanged; passes the tightened ceiling
- [x] `node benchmarks/bench.mjs js-framework` — baseline vs candidate on the same
      machine, taken by stashing only the runtime change:

      | op | base | cand | ratio |
      | --- | ---: | ---: | ---: |
      | run | 2.48 | 2.46 | 0.99 |
      | replace | 5.04 | 5.10 | 1.01 |
      | add | 2.04 | 1.96 | 0.96 |
      | runlots | 14.38 | 14.18 | 0.99 |
      | clear | 19.10 | 21.04 | 1.10 |

      All within noise (`clear` carries 13.6% rme and performs no binding writes).
      Sub-ms ops (`update`, `select`, `swap`, `remove`) are excluded: 24–97% rme.

The cost on the common path is one `TRANSITION_JOURNAL !== null` comparison per
binding write, never taken outside a transition. Everything else — the log, the
bag snapshots — is allocated only inside an armed window.

## Self-review findings that changed the implementation

- **Nested boundaries corrupted the log.** An inner window closing at checkpoint 0
  nulled the journal while an outer one was still open, and truncating on inner
  success would have robbed the outer boundary of entries it still needed to undo.
  Replaced with a depth counter; only the outermost window drops the log, and a
  committed inner boundary deliberately leaves its entries behind.
- **`slots[0]` is not always a binding bag.** A body made purely of control flow
  puts its first block slot there instead (`tryBlock(__s, 0, …)`), so a snapshot
  could have restored a boundary's own `branch`/`transitionHeld` and corrupted the
  state driving the hold. Guarded on the `__kind` tag that every runtime slot
  carries and no compiler bag does.
- **A throw out of `switchToCatch` would have stranded a window open**, letting the
  next boundary undo more than its own writes. Disarm moved into `finally`.
- Dropped an unused property-journal path rather than leaving it as speculative
  generality.

## Risk / follow-ups

- Arming keys off the ambient render mode, which the try body inherits. A render
  that is armed but turns out to be urgent simply discards its log, so a
  false positive is inert; a false negative would only mean the old behavior.
- Not covered by the added tests: controlled inputs inside a boundary that
  suspends mid-transition, since those are excluded by design.
- Closing the remaining shell and structural cases needs the global
  work-in-progress tree Octane deliberately does not have.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Suspense transition hold logic and every hot-path binding write (guarded by a journal null check); behavior is heavily tested and benchmark-pinned, but incorrect journal scoping could cause subtle UI rollback bugs.
> 
> **Overview**
> **Transition suspends no longer leave half-updated markup inside a held `@try` boundary.** Octane used to patch text/attributes while walking down, then discover a child still loading—so old async content sat next to new parent bindings. The same tear happened when a held boundary replayed after partial data arrived.
> 
> This adds a **`TRANSITION_JOURNAL`** in `runtime.ts`: while a visible try body re-renders under transition (or an already-held boundary), binding writes snapshot prior DOM text/attrs and compiled binding bags. If the attempt suspends into a hold, the log replays backward in the same flush—nothing intermediate is painted. Arming covers in-place try re-renders and held-boundary resume replays; `handleSuspense` calls rollback before keeping prior DOM.
> 
> **Regression coverage:** new `transitions.test.ts` cases (in-place parent, partial replay, namespaced attr undo) and **`async-composition`** update mixed-state ceiling tightened **1 → 0** (baseline + README). Docs record parity with React for boundary content while noting shell/structural updates outside the boundary are still not journaled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d840671ad98358dc588c5ce46c009f3807525181. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->