### PR TITLE
feat(app-core): fail on a server-function id collision

### DIFF
--- a/.changeset/rpc-id-collision-guard.md
+++ b/.changeset/rpc-id-collision-guard.md
@@ -1,0 +1,26 @@
+---
+'@octanejs/app-core': patch
+'@octanejs/vite-plugin': patch
+---
+
+Fail the boot on a `module server` function id collision instead of silently
+rerouting one function's calls to another.
+
+An id is `strong_hash("<module>#<export>")`, a SHA-256 truncated to 8 hex
+characters, whose own documentation calls it "fine for identification, not for
+authentication". Both registration paths were a plain Map set, which resolves a
+collision by overwriting: one function became unreachable and every call to it
+executed the other one instead, under whatever authorization that other function
+carries. Nothing reported it, and which function wins depends on module
+evaluation order.
+
+Dev registers through `globalThis.rpc_modules`, which is now built by
+`createRpcRegistry()` and rejects a second declaration under an id another export
+already took. Re-registering the same export stays a no-op, which module reloads
+depend on. Production builds its descriptor map from the server manifest and
+throws from `createHandler` on a duplicate id, before serving a request.
+
+Both report the two colliding module paths and export names, and say that
+renaming either export resolves it. This does not widen the id: 32 bits stays
+narrow enough to collide at scale, but the failure is now loud and happens at
+build or boot rather than in production traffic.

--- a/packages/app-core/src/index.js
+++ b/packages/app-core/src/index.js
@@ -18,3 +18,4 @@ export {
 } from './middleware.js';
 export { handleRpcRequest } from './server/rpc.js';
 export { getRequestContext, tryGetRequestContext } from './server/request-context.js';
+export { createRpcRegistry } from './server/rpc-registry.js';

--- a/packages/app-core/src/server/production.js
+++ b/packages/app-core/src/server/production.js
@@ -25,6 +25,7 @@
 import { createRouter } from './router.js';
 import { createContext, runMiddlewareChain } from './middleware.js';
 import { handleRpcRequest } from './rpc.js';
+import { rpcIdCollision } from './rpc-registry.js';
 import { handleServerRoute } from './server-route.js';
 import { composeHtmlStream } from './html-stream.js';
 import {
@@ -110,7 +111,14 @@ function buildRpcDescriptors(rpcModules, hashFn) {
 	const descriptors = new Map();
 	for (const [entryPath, serverObj] of Object.entries(rpcModules)) {
 		for (const funcName of Object.keys(serverObj)) {
-			descriptors.set(hashFn(entryPath + '#' + funcName), { module: entryPath, export: funcName });
+			const id = hashFn(entryPath + '#' + funcName);
+			// Each manifest entry is listed once, so an id already taken here is a
+			// genuine collision. `build_rpc_lookup` would resolve it by overwriting.
+			const existing = descriptors.get(id);
+			if (existing !== undefined) {
+				throw rpcIdCollision(id, existing, { module: entryPath, export: funcName });
+			}
+			descriptors.set(id, { module: entryPath, export: funcName });
 		}
 	}
 	return descriptors;

--- a/packages/app-core/src/server/rpc-registry.js
+++ b/packages/app-core/src/server/rpc-registry.js
@@ -1,0 +1,62 @@
+// @ts-check
+/**
+ * Collision guard for `module server` function ids.
+ *
+ * An id is a truncated SHA-256 of `"<module>#<export>"`, so two different
+ * exports can produce the same one. Both registration paths are a plain Map
+ * set, which resolves a collision by overwriting: one function becomes
+ * unreachable and its calls execute the other one instead, silently and with
+ * whatever authorization that other function carries. Fail the boot instead.
+ */
+
+/**
+ * @typedef {{ module: string, export: string }} RpcDeclaration
+ */
+
+/**
+ * @param {string} id
+ * @param {RpcDeclaration} first
+ * @param {RpcDeclaration} second
+ * @returns {Error}
+ */
+export function rpcIdCollision(id, first, second) {
+	return new Error(
+		`[octane] Two server functions share the id "${id}": \`${first.export}\` in ${first.module} ` +
+			`and \`${second.export}\` in ${second.module}. An id is a truncated hash of the module ` +
+			'path and export name, so renaming either export resolves it.',
+	);
+}
+
+/**
+ * `globalThis.rpc_modules`, rejecting a second declaration under an id already
+ * taken by a different one. Re-registering the same export is a no-op, which
+ * dev module reloads depend on.
+ */
+class RpcRegistry extends Map {
+	/**
+	 * @param {string} id
+	 * @param {[modulePath: string, exportName: string]} declaration
+	 * @returns {this}
+	 */
+	set(id, declaration) {
+		const existing = this.get(id);
+		if (
+			existing !== undefined &&
+			(existing[0] !== declaration[0] || existing[1] !== declaration[1])
+		) {
+			throw rpcIdCollision(
+				id,
+				{ module: existing[0], export: existing[1] },
+				{ module: declaration[0], export: declaration[1] },
+			);
+		}
+		return super.set(id, declaration);
+	}
+}
+
+/**
+ * @returns {Map<string, [modulePath: string, exportName: string]>}
+ */
+export function createRpcRegistry() {
+	return new RpcRegistry();
+}

--- a/packages/app-core/tests/rpc.test.ts
+++ b/packages/app-core/tests/rpc.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Context, Middleware } from '@octanejs/app-core';
 import { createHandler } from '../src/server/production.js';
 import { getRequestContext, tryGetRequestContext } from '../src/server/request-context.js';
+import { createRpcRegistry } from '../src/server/rpc-registry.js';
 
 const TEMPLATE = `<!doctype html>
 <html><head><!--ssr-head--></head><body><div id="root"><!--ssr-body--></div>
@@ -18,6 +19,7 @@ interface RpcTestOptions {
 	middlewares?: Middleware[];
 	trustProxy?: boolean;
 	action?: (...args: unknown[]) => unknown;
+	rpcModules?: Record<string, Record<string, Function>>;
 }
 
 function createRpcHandler(options: RpcTestOptions = {}) {
@@ -34,7 +36,7 @@ function createRpcHandler(options: RpcTestOptions = {}) {
 				...(options.allowedOrigins === undefined ? {} : { allowedOrigins: options.allowedOrigins }),
 				...(options.maxBodyBytes === undefined ? {} : { maxBodyBytes: options.maxBodyBytes }),
 			},
-			rpcModules: { '/src/actions.ts': { action } },
+			rpcModules: options.rpcModules ?? { '/src/actions.ts': { action } },
 			runtime: {
 				hash: () => 'deadbeef',
 				createAsyncContext: <T>() => {
@@ -519,6 +521,14 @@ describe('server-function HTTP security', () => {
 		expect(target).toEqual({ id: 'aaaaaaaa', module: null, export: null });
 	});
 
+	it('refuses to boot when two server functions share an id', () => {
+		expect(() =>
+			createRpcHandler({
+				rpcModules: { '/src/actions.ts': { first: () => 'a', second: () => 'b' } },
+			}),
+		).toThrow(/share the id "deadbeef"/);
+	});
+
 	it('does not disclose server-action exception messages', async () => {
 		const secret = 'private database password';
 		const loggedError = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -551,5 +561,25 @@ describe('server-function HTTP security', () => {
 		expect(await response.text()).not.toContain(secret);
 		expect(action).not.toHaveBeenCalled();
 		expect(loggedError).toHaveBeenCalledOnce();
+	});
+});
+
+describe('server-function id registry', () => {
+	it('rejects a second declaration under an id another export already took', () => {
+		const registry = createRpcRegistry();
+		registry.set('deadbeef', ['/src/a.ts', 'run']);
+
+		expect(() => registry.set('deadbeef', ['/src/b.ts', 'run'])).toThrow(
+			/Two server functions share the id "deadbeef"/,
+		);
+		expect(registry.get('deadbeef')).toEqual(['/src/a.ts', 'run']);
+	});
+
+	it('accepts re-registering the same export across a module reload', () => {
+		const registry = createRpcRegistry();
+		registry.set('deadbeef', ['/src/a.ts', 'run']);
+
+		expect(() => registry.set('deadbeef', ['/src/a.ts', 'run'])).not.toThrow();
+		expect(registry.get('deadbeef')).toEqual(['/src/a.ts', 'run']);
 	});
 });

--- a/packages/app-core/types/index.d.ts
+++ b/packages/app-core/types/index.d.ts
@@ -209,6 +209,18 @@ export function getRequestContext(): Context;
 /** {@link getRequestContext}, returning `null` outside a request instead of throwing. */
 export function tryGetRequestContext(): Context | null;
 
+/**
+ * The `globalThis.rpc_modules` registry compiled `module server` declarations
+ * register into, guarding against an id collision.
+ *
+ * An id is a truncated hash of the module path and export name, so two exports
+ * can produce the same one. A plain Map would resolve that by overwriting, which
+ * makes one function unreachable and routes its calls to the other. This throws
+ * instead. Re-registering the same export is a no-op, which module reloads rely
+ * on.
+ */
+export function createRpcRegistry(): Map<string, [modulePath: string, exportName: string]>;
+
 // ============================================================================
 // Configuration
 // ============================================================================

--- a/packages/vite-plugin-octane/src/server/render-route.js
+++ b/packages/vite-plugin-octane/src/server/render-route.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { createRpcRegistry } from '@octanejs/app-core';
 import { composeHtmlStream } from './html-stream.js';
 import {
 	getContextNonce,
@@ -61,7 +62,7 @@ export async function handleRenderRoute(route, context, vite, octaneConfig) {
 		// declarations during SSR module loading (renderer-agnostic; harmless when
 		// the app uses no RPC).
 		if (!(/** @type {any} */ (globalThis).rpc_modules)) {
-			/** @type {any} */ (globalThis).rpc_modules = new Map();
+			/** @type {any} */ (globalThis).rpc_modules = createRpcRegistry();
 		}
 
 		// Load the octane streaming renderer. The wrappers call components


### PR DESCRIPTION
## Summary

- A `module server` function id collision now fails the build or boot, instead of silently rerouting one function's calls to another.

Third in the RPC hardening series, after #375 (request context, merged) and #380 (per-function identity). Stacked on #380 — its base branch is `feat/rpc-per-function-authz`, so review that one first and this diff stays the three files below.

## Why

An id is `strong_hash("<module>#<export>")` — SHA-256 truncated to 8 hex characters, 32 bits. Its own docstring in `@tsrx/core` says it is "fine for identification, not for authentication".

Both registration paths were a plain Map set, so a collision resolved by overwriting. One function became unreachable and every call to it executed the other one, under whatever authorization that other function carries. Nothing reported it, and which of the two won depends on module evaluation order. That is a security-grade failure mode reached by an ordinary rename.

## Changes

- `createRpcRegistry()` (new, `@octanejs/app-core`) backs `globalThis.rpc_modules` in dev and rejects a second declaration under an id another export already took. Re-registering the *same* export stays a no-op, which dev module reloads depend on — that distinction is the whole reason this is a guarded `set` rather than a plain `has` check.
- Production has no such Map: it builds descriptors from the server manifest, so the guard lives in `buildRpcDescriptors` and throws from `createHandler`, before a request is served. Each manifest entry is listed once, so any duplicate id there is a genuine collision.
- Both errors name the two colliding module paths and export names and say that renaming either export resolves it.

No compiler change: compiled output already calls `rpc_modules.set(...)` unconditionally, so replacing the Map at its single initialization site intercepts every registration.

## Gotchas

- **This does not widen the id.** 32 bits stays narrow enough to collide at scale (~1.2% per build at 10k server functions, negligible below ~1k). Widening means a wider `strong_hash` in `@tsrx/core`, which I do not own, plus a wire-format change: the endpoint's `/^[a-f0-9]{8}$/` would have to move and browsers holding a previous bundle would start getting 400s across a deploy. The guard is the correctness fix and stands on its own; widening is a separate call.
- Two different modules exporting the same function name hash differently (the module path is in the hash input), so this cannot false-positive on same-named exports.
- Cost is one extra Map lookup per registration, all of it at boot. Nothing on the request path.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] targeted: `packages/app-core` 93 passed
- [x] regression proof: neutralizing both guards (registry → plain `Map`, production check removed) fails exactly the two tests that assert rejection, and leaves the reload no-op test passing

## Risk / follow-ups

- Checked that no other integration registers server functions: the rsbuild/rspack/rspeedy plugins only mention `module server` in comments, the adapters and the generated server entry go through `manifest.rpcModules`. The Vite plugin is the only dev registration site.
- Remaining in the series: a typed error channel (every throw from a server function is an opaque 500 today, so there is no way to return an expected validation or authorization error), abort/timeout propagation into server functions, and the duplicate body parse in `readBoundedRpcBody` (a full `JSON.parse` for a shape check, then a full `devalue.parse`, on bodies up to 1 MiB).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches RPC registration and production boot paths where a collision could previously mis-route calls and authorization; behavior change is intentional fail-fast with no request-path logic changes.
> 
> **Overview**
> **Server function id collisions now fail loudly at boot or handler creation** instead of silently overwriting one export with another in a `Map`.
> 
> Dev SSR initializes `globalThis.rpc_modules` via **`createRpcRegistry()`**, which throws when a second *different* export registers under the same truncated hash id; re-registering the same module/export stays allowed for HMR reloads. Production **`buildRpcDescriptors`** applies the same rule when building the manifest lookup inside **`createHandler`**, using shared **`rpcIdCollision`** errors that name both colliding paths and exports.
> 
> The registry is exported from **`@octanejs/app-core`** (types included); the Vite dev render path is wired to use it. Tests cover production boot failure and registry reject/accept behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 082cba2b937a45486ba847a8503c51fa56aac8ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->