### PR TITLE
fix(octane): hold controlled inputs through a suspended transition

### DIFF
--- a/.changeset/transition-atomic-boundaries.md
+++ b/.changeset/transition-atomic-boundaries.md
@@ -20,7 +20,9 @@ visible rollback, no invalid intermediate structure.
 `benchmarks/async-composition` records zero exposed intermediate states for a
 transition update, level with React, with its ceiling tightened from one to zero.
 
-Content the same transition patches outside a suspended boundary still updates
-early — that is what keeps `useTransition`'s `isPending` cue responsive — and
-structural changes such as a keyed list reordering above the boundary are not
-covered.
+Controlled `value`, `checked` and `selected` are held too, along with their
+`default*` mirrors and the record of what was last projected.
+
+Two things a transition can still change early: content it patched outside a
+suspended boundary, and a structural change above one such as a keyed list
+reordering.

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -579,10 +579,17 @@ change — nothing reaches the screen in between. Transitions stay monotonic: no
 visible rollback, no invalid intermediate structure, and a dependent value never
 renders against stale input.
 
-Content the same transition patched OUTSIDE a suspended boundary still updates
-early, and so does a structural change (a keyed list reordering above the
-boundary) rather than a binding. Holding those needs the global work-in-progress
-tree Octane deliberately does not have; see
+Controlled `value`, `checked` and `selected` are held too. Each carries a
+`default*` mirror and a record of what was last projected, and all of it goes
+back together — restoring the node alone would leave the record believing the new
+value had already landed, so re-projecting it on resume would be skipped.
+
+Two things a transition can still change early: content it patched OUTSIDE a
+suspended boundary, and a structural change above one, such as a keyed list
+reordering. Both need the transition to become a deferred commit — a keyed
+removal disposes blocks and runs their cleanups, which cannot be undone, and
+reverting content outside a boundary needs the reveal to re-render where the
+transition began rather than just the boundary. See
 [Suspense divergence #4](../packages/octane/audit/SUSPENSE_DIVERGENCE.md). The
 benchmark pins the exposed-state count at zero.
 

--- a/packages/octane/audit/SUSPENSE_DIVERGENCE.md
+++ b/packages/octane/audit/SUSPENSE_DIVERGENCE.md
@@ -103,15 +103,32 @@ happens in the flush that made the change, so no intermediate state is ever pain
 `benchmarks/async-composition` pins the update at zero exposed states, level with React;
 `transitions.test.ts` covers the in-place and replay shapes.
 
-**Remaining limitation:** this is still not a global WIP, so the journal is scoped to the
-boundary. Content the same transition patched OUTSIDE a suspended boundary keeps its new
-value — which is what lets the `isPending` cue turn on while its content holds, but also
-means unrelated shell markup updates early where React would hold the whole prior screen.
-Structural mutations (a keyed list reordering above the boundary) are not journaled either:
-the reconciler navigates live DOM, so undoing writes it has already read back is not sound
-without the absent global WIP. The async Action batching in #6 prevents the shell tear while
-an Action is in flight, but does not close the synchronous case. Fallback-visible retries
-are capture-safe and never had this limitation.
+Controlled `value`/`checked`/`selected` are covered as of 2026-07-29 as well. Each needs
+more than the node: the `default*` mirror and the per-element record of what was last
+projected go back with it, or the record would believe the new value had already landed and
+skip re-projecting it on resume.
+
+**Remaining limitation — one project, not two.** Content the same transition patched OUTSIDE
+a suspended boundary still keeps its new value, and so does a structural change above the
+boundary. These were previously filed as separate gaps; they are not. Both need the
+transition render to become a deferred commit unit, for two reasons found while attempting
+the first:
+
+1. *Reveal scope.* Reverting content outside the boundary strands it. The reveal path
+   re-renders the try block only, so a restored bag outside it is never re-patched and the
+   content stays on the old value permanently. The hold would have to record the block the
+   transition originated from and re-render that instead.
+2. *Destruction is not undoable.* A keyed removal disposes blocks, running user cleanups and
+   discarding hook state. Moves and inserts journal fine (`node`, `parent`, `nextSibling`),
+   but removals need disposals collected during the render and executed only on commit.
+
+Effects are the third piece: a rolled-back region outside a boundary would otherwise run
+effects against DOM that was reverted underneath them, so that region needs the same
+capture-and-splice treatment the resume path already uses.
+
+The async Action batching in #6 prevents the shell tear while an Action is in flight, but
+does not close the synchronous case. Fallback-visible retries are capture-safe and never had
+this limitation.
 Time-based cross-boundary fallback throttling is the separate Divergence #5.
 
 ---

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -1146,7 +1146,46 @@ function journalControlled(el: Element, prop: string, defaultProp: string): void
 	log.push(JOURNAL_PROP, el, defaultProp, (el as any)[defaultProp]);
 	const ctrl = (el as any).$$ctrl;
 	if (ctrl !== undefined) journalObjectOnce(ctrl);
+	const input = el as HTMLInputElement;
+	if (prop === 'checked' && input.type === 'radio' && input.name !== '') journalRadioCousins(input);
 	journalBag();
+}
+
+/**
+ * Record the cousin a radio write is about to clear.
+ *
+ * Checking a radio makes the platform uncheck its same-name siblings as a side
+ * effect, so a cousin cannot record its own prior state: by the time its binding
+ * runs it has already been cleared, and an uncontrolled cousin never records at
+ * all. Only a currently-checked cousin can be cleared, and a well-formed group
+ * has at most one, so this scans the group but adds at most one entry.
+ *
+ * Group scope mirrors restoreRadioCousins: same non-empty name, same form owner
+ * when there is one. Re-recording a cousin across several writes in one window
+ * is harmless — the replay runs newest-first, so the earliest value is the one
+ * left standing.
+ */
+function journalRadioCousins(input: HTMLInputElement): void {
+	const name = input.name;
+	const group: ArrayLike<Node> =
+		input.form !== null
+			? input.form.elements
+			: typeof document !== 'undefined'
+				? document.getElementsByName(name)
+				: [];
+	for (let i = 0; i < group.length; i++) {
+		const other = group[i] as HTMLInputElement;
+		if (
+			other === input ||
+			!other.checked ||
+			other.localName !== 'input' ||
+			other.type !== 'radio' ||
+			other.name !== name
+		) {
+			continue;
+		}
+		TRANSITION_JOURNAL!.push(JOURNAL_PROP, other, 'checked', true);
+	}
 }
 
 function journalControlledOption(option: HTMLOptionElement, withDefault: boolean): void {

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -1081,15 +1081,17 @@ let deferringStagedRevealEffects = false;
 // never reappear. The first write into a bag therefore snapshots the whole bag
 // next to the DOM entry.
 //
-// Controlled `value`/`checked` stay out. They are browser-owned state tracked
-// alongside the DOM in a per-element controlled record, and putting the node back
-// without that record would leave the two disagreeing about what the user last
-// typed. An input inside a boundary can therefore still show its new value early.
+// Controlled `value`/`checked`/`selected` are covered too, but need more than the
+// node: each carries a `default*` mirror and a per-element record of what was
+// last projected. All three go back together — restoring the node alone would
+// leave the record believing it had already projected the new value, so
+// re-projecting it on resume would be skipped as unchanged.
 // ─────────────────────────────────────────────────────────────────────────────
 
 const JOURNAL_TEXT = 0;
 const JOURNAL_ATTR = 1;
 const JOURNAL_BAG = 2;
+const JOURNAL_PROP = 3;
 /** Flat undo log, four slots per entry: kind, target, a, b. */
 let TRANSITION_JOURNAL: any[] | null = null;
 /** Bags already captured in the open window, so each is snapshotted once. */
@@ -1114,13 +1116,43 @@ function journalBag(): void {
 	if (scope === null) return;
 	const bag = scope.slots[0];
 	if (bag === null || typeof bag !== 'object' || (bag as any).__kind !== undefined) return;
+	journalObjectOnce(bag);
+}
+
+/** Record every own value of `obj`, once per window, so it can be put back. */
+function journalObjectOnce(obj: object): void {
 	const seen = TRANSITION_JOURNAL_BAGS!;
-	if (seen.has(bag)) return;
-	seen.add(bag);
-	const keys = Object.keys(bag);
+	if (seen.has(obj)) return;
+	seen.add(obj);
+	const keys = Object.keys(obj);
 	const values: any[] = [];
-	for (let i = 0; i < keys.length; i++) values.push((bag as any)[keys[i]]);
-	TRANSITION_JOURNAL!.push(JOURNAL_BAG, bag, keys, values);
+	for (let i = 0; i < keys.length; i++) values.push((obj as any)[keys[i]]);
+	TRANSITION_JOURNAL!.push(JOURNAL_BAG, obj, keys, values);
+}
+
+/**
+ * A controlled input keeps three things in step: the live DOM property, the
+ * `default*` mirror that form.reset() and SSR compare against, and the
+ * per-element record of what was last projected. Undoing one without the others
+ * would leave the record and the node disagreeing about what the user last
+ * typed, so all three go into the log together.
+ *
+ * Called once the element is armed (so the record exists) and before the write
+ * touches any of them.
+ */
+function journalControlled(el: Element, prop: string, defaultProp: string): void {
+	const log = TRANSITION_JOURNAL!;
+	log.push(JOURNAL_PROP, el, prop, (el as any)[prop]);
+	log.push(JOURNAL_PROP, el, defaultProp, (el as any)[defaultProp]);
+	const ctrl = (el as any).$$ctrl;
+	if (ctrl !== undefined) journalObjectOnce(ctrl);
+	journalBag();
+}
+
+function journalControlledOption(option: HTMLOptionElement, withDefault: boolean): void {
+	TRANSITION_JOURNAL!.push(JOURNAL_PROP, option, 'selected', option.selected);
+	if (withDefault)
+		TRANSITION_JOURNAL!.push(JOURNAL_PROP, option, 'defaultSelected', option.defaultSelected);
 }
 
 function journalText(node: Text): void {
@@ -1196,6 +1228,9 @@ function rollbackTransitionJournal(checkpoint: number): void {
 			case JOURNAL_ATTR:
 				if (b === null) (target as Element).removeAttribute(a);
 				else (target as Element).setAttribute(a, b);
+				break;
+			case JOURNAL_PROP:
+				(target as any)[a] = b;
 				break;
 			default:
 				for (let k = 0; k < a.length; k++) target[a[k]] = b[k];
@@ -12666,6 +12701,7 @@ function setNativeChangeDiagnosticMetadata(el: Element, value: unknown): void {
 export function setValue(el: Element, value: unknown): void {
 	const input = el as HTMLInputElement | HTMLTextAreaElement;
 	const ctrl = armControlled(el);
+	if (TRANSITION_JOURNAL !== null) journalControlled(el, 'value', 'defaultValue');
 	const first = !ctrl.sawV;
 	ctrl.sawV = true;
 	if (value == null) {
@@ -12774,7 +12810,9 @@ function inActivationWindow(input: HTMLInputElement): boolean {
 }
 
 export function setChecked(el: Element, value: unknown): void {
-	setCheckedState(el as HTMLInputElement, value, armControlled(el));
+	const ctrl = armControlled(el);
+	if (TRANSITION_JOURNAL !== null) journalControlled(el, 'checked', 'defaultChecked');
+	setCheckedState(el as HTMLInputElement, value, ctrl);
 }
 
 /**
@@ -12783,7 +12821,9 @@ export function setChecked(el: Element, value: unknown): void {
  * and event restoration contract, but cannot need text-composition listeners.
  */
 export function setCheckedCheckable(el: Element, value: unknown): void {
-	setCheckedState(el as HTMLInputElement, value, armControlledBase(el));
+	const ctrl = armControlledBase(el);
+	if (TRANSITION_JOURNAL !== null) journalControlled(el, 'checked', 'defaultChecked');
+	setCheckedState(el as HTMLInputElement, value, ctrl);
 }
 
 /**
@@ -12796,6 +12836,10 @@ export function setCheckedCheckable(el: Element, value: unknown): void {
 export function setSelectValue(el: Element, value: unknown): void {
 	const sel = el as HTMLSelectElement;
 	const ctrl = armControlled(el);
+	if (TRANSITION_JOURNAL !== null) {
+		journalObjectOnce(ctrl);
+		journalBag();
+	}
 	const first = !ctrl.sawV;
 	ctrl.sawV = true;
 	if (value == null) {
@@ -12857,6 +12901,13 @@ function projectSelectValue(
 	setDefaultSelected: boolean,
 ): void {
 	const options = sel.options;
+	// The selection lives on the options, not the select, so each one that can
+	// move has to be recorded before the projection walks over it.
+	if (TRANSITION_JOURNAL !== null) {
+		for (let i = 0; i < options.length; i++) {
+			journalControlledOption(options[i], setDefaultSelected);
+		}
+	}
 	if (typeof sv !== 'string') {
 		for (let i = 0; i < options.length; i++) {
 			const selected = sv.has(options[i].value);

--- a/packages/octane/tests/_fixtures/transitions.tsrx
+++ b/packages/octane/tests/_fixtures/transitions.tsrx
@@ -472,3 +472,29 @@ export function TransitionNamespacedAttr(props) @{
 		}
 	</div>
 }
+
+// ---------------------------------------------------------------------------
+// A controlled input and checkbox inside a boundary. Their values live on the
+// DOM properties AND in a per-element record, so a suspended transition has to
+// put both back or the two disagree about what was last projected.
+// ---------------------------------------------------------------------------
+function ControlledValue(props) @{
+	const value = use(props.load(props.step));
+	<span id="value">{value as string}</span>
+}
+
+export function TransitionControlledInput(props) @{
+	const [step, setStep] = useState(0);
+	<div>
+		<button id="bump" onClick={() => startTransition(() => setStep(1))}>{'bump'}</button>
+		@try {
+			<>
+				<input id="text" value={'step-' + step} onInput={() => {}} />
+				<input id="box" type="checkbox" checked={step === 1} onChange={() => {}} />
+				<ControlledValue load={props.load} step={step} />
+			</>
+		} @pending {
+			<span id="fallback">{'fallback'}</span>
+		}
+	</div>
+}

--- a/packages/octane/tests/_fixtures/transitions.tsrx
+++ b/packages/octane/tests/_fixtures/transitions.tsrx
@@ -498,3 +498,25 @@ export function TransitionControlledInput(props) @{
 		}
 	</div>
 }
+
+// ---------------------------------------------------------------------------
+// A radio group inside a boundary. Checking one radio makes the platform clear
+// its same-name cousins, so by the time a cousin's own binding runs it has
+// already been cleared — recording it there would capture the wrong state and
+// the group would come back with nothing selected.
+// ---------------------------------------------------------------------------
+export function TransitionRadioGroup(props) @{
+	const [step, setStep] = useState(0);
+	<div>
+		<button id="bump" onClick={() => startTransition(() => setStep(1))}>{'bump'}</button>
+		@try {
+			<>
+				<input id="r-a" type="radio" name="pick-group" checked={step === 1} onChange={() => {}} />
+				<input id="r-b" type="radio" name="pick-group" checked={step === 0} onChange={() => {}} />
+				<ControlledValue load={props.load} step={step} />
+			</>
+		} @pending {
+			<span id="fallback">{'fallback'}</span>
+		}
+	</div>
+}

--- a/packages/octane/tests/transitions.test.ts
+++ b/packages/octane/tests/transitions.test.ts
@@ -20,6 +20,7 @@ import {
 	TransitionResumeAtomicity,
 	TransitionNamespacedAttr,
 	TransitionControlledInput,
+	TransitionRadioGroup,
 } from './_fixtures/transitions.tsrx';
 
 interface Deferred<T> {
@@ -722,6 +723,42 @@ describe('useTransition — the old screen stays whole', () => {
 		expect(text.value).toBe('step-1');
 		expect(box.checked).toBe(true);
 		expect(r.find('#value').textContent).toBe('one');
+		r.unmount();
+	});
+
+	it('holds a radio group, including the cousin the platform cleared', async () => {
+		const entries = new Map<number, Deferred<string>>();
+		const load = (step: number) => {
+			let entry = entries.get(step);
+			if (entry === undefined) {
+				entry = deferred<string>();
+				entries.set(step, entry);
+			}
+			return entry.promise;
+		};
+		load(0);
+		entries.get(0)!.resolve('zero');
+
+		const r = mount(TransitionRadioGroup, { load });
+		await act(() => {});
+		const a = r.find('#r-a') as HTMLInputElement;
+		const b = r.find('#r-b') as HTMLInputElement;
+		expect(a.checked).toBe(false);
+		expect(b.checked).toBe(true);
+
+		// Step 1 checks a, which makes the platform clear b before b's own
+		// binding runs. The boundary then suspends, so the group has to go back
+		// to b — not to nothing selected.
+		r.click('#bump');
+		expect(r.findAll('#fallback')).toHaveLength(0);
+		expect(a.checked).toBe(false);
+		expect(b.checked).toBe(true);
+
+		await act(() => {
+			entries.get(1)!.resolve('one');
+		});
+		expect(a.checked).toBe(true);
+		expect(b.checked).toBe(false);
 		r.unmount();
 	});
 });

--- a/packages/octane/tests/transitions.test.ts
+++ b/packages/octane/tests/transitions.test.ts
@@ -19,6 +19,7 @@ import {
 	TransitionAtomicity,
 	TransitionResumeAtomicity,
 	TransitionNamespacedAttr,
+	TransitionControlledInput,
 } from './_fixtures/transitions.tsrx';
 
 interface Deferred<T> {
@@ -679,6 +680,47 @@ describe('useTransition — the old screen stays whole', () => {
 		});
 		expect(use.getAttributeNS(XLINK, 'href')).toBe('#icon-1');
 		expect(use.getAttributeNode('xlink:href')!.namespaceURI).toBe(XLINK);
+		expect(r.find('#value').textContent).toBe('one');
+		r.unmount();
+	});
+
+	it('holds a controlled input and checkbox, records included', async () => {
+		const entries = new Map<number, Deferred<string>>();
+		const load = (step: number) => {
+			let entry = entries.get(step);
+			if (entry === undefined) {
+				entry = deferred<string>();
+				entries.set(step, entry);
+			}
+			return entry.promise;
+		};
+		load(0);
+		entries.get(0)!.resolve('zero');
+
+		const r = mount(TransitionControlledInput, { load });
+		await act(() => {});
+		const text = r.find('#text') as HTMLInputElement;
+		const box = r.find('#box') as HTMLInputElement;
+		expect(text.value).toBe('step-0');
+		expect(box.checked).toBe(false);
+
+		// The transition projects step 1 onto both controls and then the sibling
+		// suspends, so both have to go back to step 0.
+		r.click('#bump');
+		expect(r.findAll('#fallback')).toHaveLength(0);
+		expect(text.value).toBe('step-0');
+		expect(text.defaultValue).toBe('step-0');
+		expect(box.checked).toBe(false);
+		expect(box.defaultChecked).toBe(false);
+
+		// The per-element record has to come back too. If it still believed it had
+		// projected 'step-1', re-projecting that same value would be skipped as
+		// unchanged and the input would stay on step-0 forever.
+		await act(() => {
+			entries.get(1)!.resolve('one');
+		});
+		expect(text.value).toBe('step-1');
+		expect(box.checked).toBe(true);
 		expect(r.find('#value').textContent).toBe('one');
 		r.unmount();
 	});


### PR DESCRIPTION
Follow-up to #379, which held plain bindings through a suspended transition but
left controlled form state out.

## Summary

A controlled input inside a held boundary still showed its new value while
everything around it held. It is now held too.

## Why it needed more than the node

A controlled input keeps three things in step:

1. the live DOM property (`value` / `checked` / `selected`),
2. the `default*` mirror that `form.reset()`, SSR output and the differential
   byte-compares are aligned against,
3. a per-element `$$ctrl` record of what was last projected.

Restoring only the node would have been worse than not restoring it. The record
would still believe the new value had landed, so re-projecting that same value on
resume would be skipped as unchanged and the input would stay behind
permanently. All three now go into the log together.

`<select>` needed one extra step: the selection lives on the options, not on the
select, so `projectSelectValue` records each option's `selected` (and
`defaultSelected` when it stamps the mount-time baseline) before it walks them.

## Changes

- `journalObjectOnce` factored out of `journalBag`, so the `$$ctrl` record is
  snapshotted by the same once-per-window mechanism as a compiled binding bag.
- `journalControlled` records the property, its `default*` mirror and the record.
  Called from `setValue`, `setChecked` and `setCheckedCheckable` once the element
  is armed and before the write touches anything.
- `setSelectValue` records the record; `projectSelectValue` records the options.
- `JOURNAL_PROP` reinstated for property writes.

## Validation

- [x] `pnpm test` — see the note below
- [x] `pnpm typecheck` — clean
- [x] `pnpm format:check` — clean
- [x] New regression test in `transitions.test.ts`: a controlled text input and
      checkbox beside a suspending sibling. Asserts both hold at step 0 with
      their `default*` mirrors, and — the part that catches a node-only restore —
      that both reach step 1 once the promise settles. Watched failing before the
      fix.

**On the full suite:** four runs on this branch gave 1, 2, 0 and 0 failures, all
confined to `hydration/deferred-hydration.test.ts` under `octane-prod`, which
passes in isolation both here and on `main`. A run of clean `main` in the same
environment gave 3 failures across 2 files. The flakiness is environmental
(timing-sensitive hydration tests under full-suite parallelism), pre-existing,
and not introduced here — but it is real and I would rather flag it than round it
to "all green".

No performance measurement: the added work is a `TRANSITION_JOURNAL !== null`
comparison on the controlled-write paths, which are not hot (one per controlled
binding per render) and are already doing property reads and dev diagnostics.

## Scope note — the two remaining gaps are one project

#379 listed three things a transition could still change early. This closes the
controlled-input one. The other two turned out to be the same problem, and I have
corrected `SUSPENSE_DIVERGENCE.md` #4 accordingly:

- **Content outside a suspended boundary.** Reverting it strands it. The reveal
  path re-renders the try block only, so a restored bag outside the boundary is
  never re-patched and the content stays on the old value for good. The hold
  would have to record the block the transition originated from and re-render
  that instead.
- **Structural changes above the boundary.** Moves and inserts journal fine
  (`node`, `parent`, `nextSibling`). Removals do not: the reconciler disposes
  blocks, running user cleanups and discarding hook state, and a cleanup cannot
  be un-run. Those disposals have to be collected during the render and executed
  only on commit.

Both need the transition render to become a deferred commit unit, along with
capture-and-splice for the rolled-back region's effects so they do not run
against DOM that was reverted underneath them. That is one piece of work, not two
follow-ups.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hot controlled-input commit paths in `runtime.ts` behind a journal guard, with subtle radio/select edge cases; scope is bounded to transition suspend undo and regression tests.
> 
> **Overview**
> Extends the transition **binding journal** so controlled **`value`**, **`checked`**, and **`selected`** stay on the old screen when a Suspense boundary holds, not just text/attributes/bags.
> 
> Adds **`JOURNAL_PROP`** and **`journalControlled`** / **`journalObjectOnce`** to snapshot the live DOM property, its **`default*`** mirror, the per-element **`$$ctrl`** projection record, and (for **`<select>`**) each option’s **`selected`** / **`defaultSelected`** before writes. **`setValue`**, **`setChecked`**, **`setCheckedCheckable`**, **`setSelectValue`**, and **`projectSelectValue`** call into the journal when **`TRANSITION_JOURNAL`** is open; radio groups also journal the **cousin** the platform clears when another member is checked.
> 
> Docs and **`SUSPENSE_DIVERGENCE.md`** now treat controlled form state as closed and fold the remaining “outside boundary” / structural gaps into **one deferred-commit** limitation. New **`transitions.test.ts`** coverage covers controlled text/checkbox and radio groups beside a suspending sibling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b06e54a3daf9501ec3a4cc3945b545393c106a79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->