### PR TITLE
fix(octane): hold a keyed list whole through a suspended transition

### DIFF
--- a/.changeset/transition-keyed-removals.md
+++ b/.changeset/transition-keyed-removals.md
@@ -1,0 +1,20 @@
+---
+'octane': patch
+---
+
+Hold a keyed list whole through a suspended transition.
+
+A transition that dropped a row and then suspended used to lose the row from the
+held screen: the list reconciled first, the boundary decided to hold second, and
+by then the row's DOM, state and cleanups were already gone. A list the boundary
+was supposed to be holding frozen showed up with rows missing.
+
+Removals inside a boundary now defer their teardown while a hold is still
+possible. The nodes come out of the way so the reconcile can finish, but they
+are kept, and the row's scope — its state, its effects, its cleanups — is left
+untouched until the outcome is known. If the boundary holds, the rows come back
+exactly as they were, cleanups never having run; once the transition commits,
+the removal goes through for real and cleanups fire then.
+
+The list restores as a whole — order, membership and the `@empty` branch
+together — so reorders roll back alongside removals.

--- a/packages/octane/audit/SUSPENSE_DIVERGENCE.md
+++ b/packages/octane/audit/SUSPENSE_DIVERGENCE.md
@@ -122,6 +122,24 @@ the first:
    discarding hook state. Moves and inserts journal fine (`node`, `parent`, `nextSibling`),
    but removals need disposals collected during the render and executed only on commit.
 
+   **This one is NOT blocked by the pending cue, and it is the most visible of the two.** A
+   keyed list between the `@try` and the suspending component sits inside the boundary's own
+   journal window, so it needs no attempt-level widening. Reproduced 2026-07-29: a list of
+   `a, b, c` inside a boundary, a transition moving to `c, a, d` where `d` is what suspends,
+   leaves the held boundary showing `a, c` — row `b` is disposed and gone from a list the
+   boundary is supposed to be holding frozen. Its DOM, its hook state and its cleanups are
+   all already destroyed by the time the hold is decided.
+
+   The shape of the fix: a removal cannot defer its DOM detach, because the reconciler needs
+   the node gone to finish and the hold is only decided afterwards. So the detach is
+   journaled (`node`, `parent`, `nextSibling`) and undoable, while the SCOPE TEARDOWN —
+   `unmountScope`, the `disposed` stamp and the user cleanups — is what defers to commit.
+   `unmountBlock` is the single choke point (three call sites in the reconciler plus
+   `batchClearItems`), but it is on every removal path in the runtime, so the deferral has to
+   be gated tightly on an armed window. The `@for` bookkeeping travels with it: `head`,
+   `tail`, `size`, the key→block map and the intrusive `nextSibling` chain all need
+   snapshotting before the reconcile, the same way a binding bag does.
+
 Effects are the third piece: a rolled-back region outside a boundary would otherwise run
 effects against DOM that was reverted underneath them, so that region needs the same
 capture-and-splice treatment the resume path already uses.

--- a/packages/octane/audit/SUSPENSE_DIVERGENCE.md
+++ b/packages/octane/audit/SUSPENSE_DIVERGENCE.md
@@ -118,9 +118,16 @@ the first:
    re-renders the try block only, so a restored bag outside it is never re-patched and the
    content stays on the old value permanently. The hold would have to record the block the
    transition originated from and re-render that instead.
-2. *Destruction is not undoable.* A keyed removal disposes blocks, running user cleanups and
-   discarding hook state. Moves and inserts journal fine (`node`, `parent`, `nextSibling`),
-   but removals need disposals collected during the render and executed only on commit.
+2. *Destruction is not undoable* — ✅ CLOSED for keyed lists (2026-07-29). A keyed removal
+   used to dispose the row outright before the hold was decided, so a held boundary could
+   show a list with a row missing — DOM, hook state and cleanups already gone. Removals now
+   split: the DOM detach happens immediately (the reconciler needs the nodes out of the way)
+   but the nodes are kept and the scope teardown is PARKED. A rollback re-inserts the rows
+   with their state intact and their cleanups never having run; a commit flushes the parked
+   teardowns when the last journal window closes. The list restores as a whole — chain, key
+   map, counts and the `@empty` branch together — so moved survivors return to position
+   alongside dropped rows. `transitions.test.ts` pins the drop, the state survival, the
+   cleanup timing, and both directions of the `@empty` swap.
 
    **This one is NOT blocked by the pending cue, and it is the most visible of the two.** A
    keyed list between the `@try` and the suspending component sits inside the boundary's own

--- a/packages/octane/audit/SUSPENSE_DIVERGENCE.md
+++ b/packages/octane/audit/SUSPENSE_DIVERGENCE.md
@@ -126,6 +126,30 @@ Effects are the third piece: a rolled-back region outside a boundary would other
 effects against DOM that was reverted underneath them, so that region needs the same
 capture-and-splice treatment the resume path already uses.
 
+**Attempted 2026-07-29, and the blocker is `isPending`.** A whole-drain "transition attempt"
+was built — journal armed for the queued transition render, live effect/ref/store queues
+marked and rewound, effect dependency cells restored, and the reveal replaying from the
+block the attempt started at rather than from the boundary. Everything held together except
+one thing: rolling the attempt back also reverted `isPending`, turning the pending cue
+straight back off. Fifteen existing transition tests caught it.
+
+The cause is deliberate and is spelled out at `startTransition` in runtime.ts: the priority
+flag is raised BEFORE `tickTransitionCount`, *"so any scheduleRender calls fired by the
+listener notification (and by fn itself) are tagged as transition"*. The pending cue is
+therefore transition-priority work in the same block as the content it describes, and in
+octane both are one render pass. Skipping urgent writes inside an attempt does not help,
+because the cue render is not urgent. Re-rendering after the unwind to restore the cue
+re-applies the content it was supposed to hold.
+
+React does not have this problem: `isPending` commits in a separate pass at a different
+priority from the transition itself.
+
+So the prerequisite is not the journal or deferred destruction — it is decoupling the
+pending cue from the transition render, so `useTransition` listeners publish at a priority
+an attempt does not unwind. That reverses the intent of the comment above and changes
+documented scheduling behaviour, so it needs its own design and its own change. The
+deferred-commit work sits behind it.
+
 The async Action batching in #6 prevents the shell tear while an Action is in flight, but
 does not close the synchronous case. Fallback-visible retries are capture-safe and never had
 this limitation.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -1092,6 +1092,7 @@ const JOURNAL_TEXT = 0;
 const JOURNAL_ATTR = 1;
 const JOURNAL_BAG = 2;
 const JOURNAL_PROP = 3;
+const JOURNAL_FOR = 4;
 /** Flat undo log, four slots per entry: kind, target, a, b. */
 let TRANSITION_JOURNAL: any[] | null = null;
 /** Bags already captured in the open window, so each is snapshotted once. */
@@ -1194,6 +1195,164 @@ function journalControlledOption(option: HTMLOptionElement, withDefault: boolean
 		TRANSITION_JOURNAL!.push(JOURNAL_PROP, option, 'defaultSelected', option.defaultSelected);
 }
 
+/**
+ * Item blocks a keyed list dropped while a hold was still possible.
+ *
+ * A removal cannot wait for the hold decision: the reconciler needs the nodes
+ * out of the way to finish, and whether the boundary holds is only known once
+ * the render is further along. So the DOM detach happens immediately and is
+ * undoable, while the part that CANNOT be undone — the scope teardown, the user
+ * cleanups, the `disposed` stamp — is what waits here. If the attempt survives,
+ * these tear down for real; if it unwinds, the rows go back with their state and
+ * their cleanups never having run.
+ */
+interface ParkedItem {
+	block: Block;
+	nodes: Node[];
+}
+let PARKED_ITEMS: ParkedItem[] | null = null;
+
+/** Detach an item's node range without touching its scope, keeping the nodes. */
+function parkItemForHold(block: Block): void {
+	const nodes: Node[] = [];
+	const start = block.startMarker;
+	const end = block.endMarker;
+	if (start && end) {
+		const parent = start.parentNode;
+		if (parent !== null) {
+			const exclusive = block.exclusiveMarkers;
+			let n: Node | null = exclusive ? start.nextSibling : start;
+			const stop = exclusive ? end : end.nextSibling;
+			while (n !== null && n !== stop) {
+				const next: Node | null = getNextSibling(n);
+				parent.removeChild(n);
+				nodes.push(n);
+				n = next;
+			}
+		}
+	}
+	(PARKED_ITEMS ??= []).push({ block, nodes });
+}
+
+/** True while a keyed removal must be undoable rather than final. */
+function itemRemovalDefers(): boolean {
+	return TRANSITION_JOURNAL !== null;
+}
+
+/**
+ * Record a keyed list's shape before a reconcile that may have to be undone.
+ *
+ * The list is restored as a whole rather than per operation: the chain, the key
+ * map and the counts all move together, and rebuilding the DOM from the restored
+ * chain puts moved survivors back as well as dropped rows. Once per list per
+ * window — the first record is the pre-render one, which is the one to go back
+ * to.
+ */
+function journalForSlot(state: ForSlot): void {
+	const seen = TRANSITION_JOURNAL_BAGS!;
+	if (seen.has(state)) return;
+	seen.add(state);
+	const chain: Array<[Block, Block | null, Block | null]> = [];
+	for (let b: Block | null = state.head; b !== null; b = b.nextSibling) {
+		chain.push([b, b.nextSibling, b.prevSibling]);
+	}
+	TRANSITION_JOURNAL!.push(
+		JOURNAL_FOR,
+		state,
+		{
+			head: state.head,
+			tail: state.tail,
+			size: state.size,
+			empty: state.emptyBlock,
+			entries: [...state.items],
+		},
+		chain,
+	);
+}
+
+/** Put a keyed list back the way it was, rows and order together. */
+function restoreForSlot(
+	state: ForSlot,
+	snapshot: any,
+	chain: Array<[Block, Block | null, Block | null]>,
+): void {
+	state.head = snapshot.head;
+	state.tail = snapshot.tail;
+	state.size = snapshot.size;
+	state.items.clear();
+	for (let i = 0; i < snapshot.entries.length; i++) {
+		state.items.set(snapshot.entries[i][0], snapshot.entries[i][1]);
+	}
+	for (let i = 0; i < chain.length; i++) {
+		chain[i][0].nextSibling = chain[i][1];
+		chain[i][0].prevSibling = chain[i][2];
+	}
+	// Collect each row's nodes BEFORE touching the DOM: a dropped row has them
+	// parked, a surviving one still has them in place, and clearing first would
+	// throw the survivors away.
+	const parent = state.end.parentNode!;
+	const ranges: Node[][] = [];
+	for (let b: Block | null = state.head; b !== null; b = b.nextSibling) {
+		ranges.push(takeParkedItem(b) ?? collectBlockRange(b));
+	}
+	// Anything the aborted render left between the markers goes, including rows
+	// it created that the list no longer contains.
+	let n: Node | null = state.start.nextSibling;
+	while (n !== null && n !== state.end) {
+		const next: Node | null = n.nextSibling;
+		parent.removeChild(n);
+		n = next;
+	}
+	// One walk in chain order restores membership and order together, so moved
+	// survivors come back to where they were as well as dropped rows.
+	for (let i = 0; i < ranges.length; i++) {
+		const nodes = ranges[i];
+		for (let k = 0; k < nodes.length; k++) parent.insertBefore(nodes[k], state.end);
+	}
+	// The @empty branch swaps with the rows, so it rolls back with them. A
+	// branch the aborted render mounted is scope-only torn down (its DOM went
+	// with the range clear above); one it parked comes back like a row.
+	if (state.emptyBlock !== snapshot.empty) {
+		if (state.emptyBlock !== null) unmountBlock(state.emptyBlock, false);
+		state.emptyBlock = snapshot.empty;
+	}
+	if (snapshot.empty !== null) {
+		const parkedEmpty = takeParkedItem(snapshot.empty);
+		const nodes = parkedEmpty ?? collectBlockRange(snapshot.empty);
+		for (let k = 0; k < nodes.length; k++) parent.insertBefore(nodes[k], state.end);
+	}
+}
+
+/** Remove and return a block's parked nodes, or null if it is not parked. */
+function takeParkedItem(block: Block): Node[] | null {
+	const parked = PARKED_ITEMS;
+	if (parked === null) return null;
+	for (let i = 0; i < parked.length; i++) {
+		if (parked[i].block === block) {
+			const nodes = parked[i].nodes;
+			parked.splice(i, 1);
+			return nodes;
+		}
+	}
+	return null;
+}
+
+/** The nodes a still-attached block currently owns, in order. */
+function collectBlockRange(block: Block): Node[] {
+	const nodes: Node[] = [];
+	const start = block.startMarker;
+	const end = block.endMarker;
+	if (!start || !end || start.parentNode === null) return nodes;
+	const exclusive = block.exclusiveMarkers;
+	let n: Node | null = exclusive ? start.nextSibling : start;
+	const stop = exclusive ? end : end.nextSibling;
+	while (n !== null && n !== stop) {
+		nodes.push(n);
+		n = getNextSibling(n);
+	}
+	return nodes;
+}
+
 function journalText(node: Text): void {
 	TRANSITION_JOURNAL!.push(JOURNAL_TEXT, node, node.nodeValue, null);
 	journalBag();
@@ -1248,7 +1407,21 @@ function disarmTransitionJournal(checkpoint: number): void {
 	if (--TRANSITION_JOURNAL_DEPTH === 0) {
 		TRANSITION_JOURNAL = null;
 		TRANSITION_JOURNAL_BAGS = null;
+		flushParkedItems();
 	}
+}
+
+/**
+ * Tear down the rows still parked when the last window closes. Anything a
+ * rollback put back has already been taken off this list, so what is left is
+ * genuinely gone and its cleanups are due. The DOM is already detached, so the
+ * teardown is scope-only.
+ */
+function flushParkedItems(): void {
+	const parked = PARKED_ITEMS;
+	if (parked === null) return;
+	PARKED_ITEMS = null;
+	for (let i = 0; i < parked.length; i++) unmountBlock(parked[i].block, false);
 }
 
 /** Undo every binding write recorded since `checkpoint`, newest first. */
@@ -1270,6 +1443,10 @@ function rollbackTransitionJournal(checkpoint: number): void {
 				break;
 			case JOURNAL_PROP:
 				(target as any)[a] = b;
+				break;
+			case JOURNAL_FOR:
+				restoreForSlot(target as ForSlot, a, b);
+				TRANSITION_JOURNAL_BAGS!.delete(target);
 				break;
 			default:
 				for (let k = 0; k < a.length; k++) target[a[k]] = b[k];
@@ -21793,7 +21970,12 @@ export function forBlock<T>(
 	// mounted, tear it down before reconciling so its DOM doesn't sit alongside
 	// the freshly-mounted items.
 	if (state.emptyBlock) {
-		unmountBlock(state.emptyBlock);
+		// While a hold is possible the swap has to be reversible, exactly like a
+		// row removal: keep the branch's nodes and defer its teardown.
+		if (itemRemovalDefers()) {
+			journalForSlot(state);
+			parkItemForHold(state.emptyBlock);
+		} else unmountBlock(state.emptyBlock);
 		state.emptyBlock = null;
 	}
 	// Hydrating + the SERVER rendered the @empty body (the node right after `start` is NOT an
@@ -22096,6 +22278,9 @@ function reconcileKeyed<T>(
 	const oldSize = state.size;
 	const newLen = items.length;
 	const parentNode = state.end.parentNode!;
+	// Record the list's shape while a hold is still possible, so a boundary that
+	// suspends later in this render can put it back whole.
+	if (oldSize > 0 && TRANSITION_JOURNAL !== null) journalForSlot(state);
 
 	// Fast path: empty → fill — the linear first-fill pass (callers on the
 	// first-mount path dispatch to it directly and skip this function entirely).
@@ -22203,7 +22388,8 @@ function reconcileKeyed<T>(
 		let removed = 0;
 		while (cur !== afterMiddle) {
 			const next: Block | null = cur!.nextSibling!;
-			unmountBlock(cur!);
+			if (itemRemovalDefers()) parkItemForHold(cur!);
+			else unmountBlock(cur!);
 			oldItems.delete(cur!.key);
 			cur = next;
 			removed++;
@@ -22290,7 +22476,8 @@ function reconcileKeyed<T>(
 		const next: Block | null = cur!.nextSibling!;
 		const newRelIdx = newKeysToIdx.get(cur!.key);
 		if (newRelIdx === undefined) {
-			unmountBlock(cur!);
+			if (itemRemovalDefers()) parkItemForHold(cur!);
+			else unmountBlock(cur!);
 			oldItems.delete(cur!.key);
 			state.size--;
 		} else {
@@ -22571,6 +22758,18 @@ const RANGE_CLEAR_MIN_ITEMS = 512;
  * template rows (the common bulk-clear case) hit only the three-field guard.
  */
 function batchClearItems(state: ForSlot, oldItems: Map<any, Block>): void {
+	// The bulk paths below drop the nodes wholesale, which cannot be undone.
+	// While a hold is still possible, take each row individually so its nodes
+	// are kept and its teardown waits for the outcome.
+	if (itemRemovalDefers()) {
+		let next: Block | null;
+		for (let b: Block | null = state.head; b !== null; b = next) {
+			next = b.nextSibling;
+			parkItemForHold(b);
+		}
+		oldItems.clear();
+		return;
+	}
 	const p = state.start.parentNode!;
 	if (state.start.previousSibling === null && state.end.nextSibling === null) {
 		// forBlock owns the parent — nuke everything in one DOM op, then re-add markers.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -1276,6 +1276,18 @@ function restoreForSlot(
 	snapshot: any,
 	chain: Array<[Block, Block | null, Block | null]>,
 ): void {
+	// Rows the aborted attempt freshly mounted are not in the snapshot, so
+	// restoring the old chain would simply forget them. Their DOM goes with the
+	// range clear below, but the scope has to go NOW, before the overwrite makes
+	// them unreachable: the disposed stamp is what keeps their queued mount
+	// effects and ref attaches from firing for a row that never reached the
+	// screen, and it runs the render-time cleanups they registered. Parked rows
+	// are never on the chain, so this reaches exactly the fresh mounts.
+	const kept = new Set<Block>();
+	for (let i = 0; i < chain.length; i++) kept.add(chain[i][0]);
+	for (let b: Block | null = state.head; b !== null; b = b.nextSibling) {
+		if (!kept.has(b)) unmountBlock(b, false);
+	}
 	state.head = snapshot.head;
 	state.tail = snapshot.tail;
 	state.size = snapshot.size;
@@ -22194,6 +22206,12 @@ function mountItemsLinear<T>(
 ): void {
 	const newLen = items.length;
 	if (newLen === 0) return;
+	// Every 0 -> N fill funnels through here (forBlock, the value-position array
+	// path, and reconcileKeyed's own empty branch). An empty list is still a
+	// shape to go back to: a fill during a render that may yet hold must come
+	// back out — rows, scopes and queued effects together — or the held boundary
+	// shows fresh rows with their bindings half rolled back underneath them.
+	if (TRANSITION_JOURNAL !== null) journalForSlot(state);
 	const oldItems = state.items;
 	const parentNode = state.end.parentNode!;
 	// Pure-host → blocks upgrade adoption (childSlot arms `state.adopt`): the
@@ -22279,7 +22297,9 @@ function reconcileKeyed<T>(
 	const newLen = items.length;
 	const parentNode = state.end.parentNode!;
 	// Record the list's shape while a hold is still possible, so a boundary that
-	// suspends later in this render can put it back whole.
+	// suspends later in this render can put it back whole. The 0 -> N fast path
+	// journals inside mountItemsLinear, which also covers the callers that
+	// dispatch to it directly.
 	if (oldSize > 0 && TRANSITION_JOURNAL !== null) journalForSlot(state);
 
 	// Fast path: empty → fill — the linear first-fill pass (callers on the

--- a/packages/octane/tests/_fixtures/transitions.tsrx
+++ b/packages/octane/tests/_fixtures/transitions.tsrx
@@ -1,5 +1,6 @@
 import {
 	use,
+	useEffect,
 	useReducer,
 	useState,
 	useTransition,
@@ -513,6 +514,65 @@ export function TransitionRadioGroup(props) @{
 			<>
 				<input id="r-a" type="radio" name="pick-group" checked={step === 1} onChange={() => {}} />
 				<input id="r-b" type="radio" name="pick-group" checked={step === 0} onChange={() => {}} />
+				<ControlledValue load={props.load} step={step} />
+			</>
+		} @pending {
+			<span id="fallback">{'fallback'}</span>
+		}
+	</div>
+}
+
+// ---------------------------------------------------------------------------
+// A keyed list inside a boundary, with a suspending sibling after it. The
+// transition drops a row and then the sibling suspends, so the list reconciles
+// first and the boundary decides to hold second. The dropped row has to come
+// back — DOM, its own state, and without having run its cleanup.
+// ---------------------------------------------------------------------------
+function RemovalRow(props) @{
+	const [seen] = useState(props.id + '!');
+	useEffect(() => {
+		props.log('mount:' + props.id);
+		return () => props.log('cleanup:' + props.id);
+	}, []);
+	<li id={'row-' + props.id}>{seen as string}</li>
+}
+
+export function TransitionKeyedRemoval(props) @{
+	const [step, setStep] = useState(0);
+	const items =
+		step === 0 ? ['a', 'b', 'c'] : ['a', 'c'];
+	<div>
+		<button id="bump" onClick={() => startTransition(() => setStep(1))}>{'bump'}</button>
+		@try {
+			<>
+				<ul id="list">
+					@for (const id of items; key id) {
+						<RemovalRow id={id} log={props.log} />
+					}
+				</ul>
+				<ControlledValue load={props.load} step={step} />
+			</>
+		} @pending {
+			<span id="fallback">{'fallback'}</span>
+		}
+	</div>
+}
+
+export function TransitionListToEmpty(props) @{
+	const [step, setStep] = useState(0);
+	const items =
+		step === 0 ? ['a', 'b'] : [];
+	<div>
+		<button id="bump" onClick={() => startTransition(() => setStep(1))}>{'bump'}</button>
+		@try {
+			<>
+				<ul id="list">
+					@for (const id of items; key id) {
+						<RemovalRow id={id} log={props.log} />
+					} @empty {
+						<li id="empty">{'nothing'}</li>
+					}
+				</ul>
 				<ControlledValue load={props.load} step={step} />
 			</>
 		} @pending {

--- a/packages/octane/tests/_fixtures/transitions.tsrx
+++ b/packages/octane/tests/_fixtures/transitions.tsrx
@@ -580,3 +580,61 @@ export function TransitionListToEmpty(props) @{
 		}
 	</div>
 }
+
+// ---------------------------------------------------------------------------
+// The transition ADDS a row and then a later sibling suspends. The fresh row
+// completed its mount before the hold was decided, so putting the list back is
+// not enough: the row's scope has to go too, or its queued mount effect fires
+// for a row that is not on screen and nothing can ever clean it up.
+// ---------------------------------------------------------------------------
+function AddedRow(props) @{
+	useEffect(() => {
+		props.log('mount:' + props.id);
+		return () => props.log('cleanup:' + props.id);
+	}, []);
+	<li id={'row-' + props.id}>{props.id as string}</li>
+}
+
+export function TransitionKeyedAddition(props) @{
+	const [step, setStep] = useState(0);
+	const items =
+		step === 0 ? ['a'] : ['a', 'd'];
+	<div>
+		<button id="bump" onClick={() => startTransition(() => setStep(1))}>{'bump'}</button>
+		@try {
+			<>
+				<ul id="list">
+					@for (const id of items; key id) {
+						<AddedRow id={id} log={props.log} />
+					}
+				</ul>
+				<ControlledValue load={props.load} step={step} />
+			</>
+		} @pending {
+			<span id="fallback">{'fallback'}</span>
+		}
+	</div>
+}
+
+// The same shape from an EMPTY list: 0 -> N has no rows to put back, but the
+// freshly-filled rows still have to come out and their scopes go with them.
+export function TransitionKeyedEmptyFill(props) @{
+	const [step, setStep] = useState(0);
+	const items =
+		step === 0 ? [] : ['d'];
+	<div>
+		<button id="bump" onClick={() => startTransition(() => setStep(1))}>{'bump'}</button>
+		@try {
+			<>
+				<ul id="list">
+					@for (const id of items; key id) {
+						<AddedRow id={id} log={props.log} />
+					}
+				</ul>
+				<ControlledValue load={props.load} step={step} />
+			</>
+		} @pending {
+			<span id="fallback">{'fallback'}</span>
+		}
+	</div>
+}

--- a/packages/octane/tests/transitions.test.ts
+++ b/packages/octane/tests/transitions.test.ts
@@ -21,6 +21,8 @@ import {
 	TransitionNamespacedAttr,
 	TransitionControlledInput,
 	TransitionRadioGroup,
+	TransitionKeyedRemoval,
+	TransitionListToEmpty,
 } from './_fixtures/transitions.tsrx';
 
 interface Deferred<T> {
@@ -759,6 +761,70 @@ describe('useTransition — the old screen stays whole', () => {
 		});
 		expect(a.checked).toBe(true);
 		expect(b.checked).toBe(false);
+		r.unmount();
+	});
+
+	it('brings back a keyed row the transition dropped before the boundary held', async () => {
+		// Step 0 is a pre-fulfilled thenable so the FIRST mount commits without
+		// suspending: the rows' effects must actually mount for the cleanup
+		// assertion below to mean anything. (A first mount that suspends loses
+		// those mount effects today — that is a separate pre-existing bug.)
+		const step1 = deferred<string>();
+		const fulfilled = { status: 'fulfilled', value: 'zero', then: (cb: any) => cb('zero') };
+		const load = (step: number) => (step === 0 ? fulfilled : step1.promise);
+		const log = createLog();
+		const ids = () => r.findAll('#list li').map((li) => li.id);
+
+		const r = mount(TransitionKeyedRemoval, { load, log: log.push });
+		await act(() => {});
+		expect(ids()).toEqual(['row-a', 'row-b', 'row-c']);
+		expect(r.find('#row-b').textContent).toBe('b!');
+		expect(log.drain()).toEqual(['mount:a', 'mount:b', 'mount:c']);
+
+		// The list drops b, then the sibling suspends and the boundary holds. The
+		// row has to come back, keep the state it had, and not have torn down.
+		r.click('#bump');
+		expect(r.findAll('#fallback')).toHaveLength(0);
+		expect(ids()).toEqual(['row-a', 'row-b', 'row-c']);
+		expect(r.find('#row-b').textContent).toBe('b!');
+		expect(log.drain()).toEqual([]);
+
+		// Once the sibling settles the removal goes through for real.
+		await act(() => {
+			step1.resolve('one');
+		});
+		expect(ids()).toEqual(['row-a', 'row-c']);
+		await act(() => {});
+		expect(log.drain()).toEqual(['cleanup:b']);
+		r.unmount();
+	});
+
+	it('holds a list that emptied, and swaps to @empty only on commit', async () => {
+		const step1 = deferred<string>();
+		const fulfilled = { status: 'fulfilled', value: 'zero', then: (cb: any) => cb('zero') };
+		const load = (step: number) => (step === 0 ? fulfilled : step1.promise);
+		const log = createLog();
+
+		const r = mount(TransitionListToEmpty, { load, log: log.push });
+		await act(() => {});
+		expect(r.findAll('#list li').map((li) => li.id)).toEqual(['row-a', 'row-b']);
+		expect(log.drain()).toEqual(['mount:a', 'mount:b']);
+
+		// The whole list clears and @empty mounts, then the sibling suspends. The
+		// rows come back and the empty branch goes — with no cleanups run.
+		r.click('#bump');
+		expect(r.findAll('#fallback')).toHaveLength(0);
+		expect(r.findAll('#list li').map((li) => li.id)).toEqual(['row-a', 'row-b']);
+		expect(r.findAll('#empty')).toHaveLength(0);
+		expect(log.drain()).toEqual([]);
+
+		await act(() => {
+			step1.resolve('one');
+		});
+		expect(r.findAll('#list li').map((li) => li.id)).toEqual(['empty']);
+		expect(r.find('#empty').textContent).toBe('nothing');
+		await act(() => {});
+		expect(log.drain()).toEqual(['cleanup:a', 'cleanup:b']);
 		r.unmount();
 	});
 });

--- a/packages/octane/tests/transitions.test.ts
+++ b/packages/octane/tests/transitions.test.ts
@@ -23,6 +23,8 @@ import {
 	TransitionRadioGroup,
 	TransitionKeyedRemoval,
 	TransitionListToEmpty,
+	TransitionKeyedAddition,
+	TransitionKeyedEmptyFill,
 } from './_fixtures/transitions.tsrx';
 
 interface Deferred<T> {
@@ -825,6 +827,74 @@ describe('useTransition — the old screen stays whole', () => {
 		expect(r.find('#empty').textContent).toBe('nothing');
 		await act(() => {});
 		expect(log.drain()).toEqual(['cleanup:a', 'cleanup:b']);
+		r.unmount();
+	});
+
+	it('tears down a row the aborted attempt freshly mounted, effects unfired', async () => {
+		// Step 0 unwraps synchronously so the FIRST mount never suspends — this
+		// test is about the transition's aborted attempt, not initial mount.
+		const fulfilled = {
+			status: 'fulfilled',
+			value: 'zero',
+			then: (fn: (v: string) => void) => void fn('zero'),
+		} as unknown as Promise<string>;
+		const d1 = deferred<string>();
+		const load = (step: number) => (step === 0 ? fulfilled : d1.promise);
+		const log = createLog();
+		const ids = () => r.findAll('#list li').map((li) => li.id);
+
+		const r = mount(TransitionKeyedAddition, { load, log: log.push });
+		await act(() => {});
+		expect(ids()).toEqual(['row-a']);
+		expect(log.drain()).toEqual(['mount:a']);
+
+		// The attempt mounts d, then the sibling suspends and the boundary holds.
+		// d's DOM comes out — and its queued mount effect must go with it, or it
+		// fires for a row that is not on screen and can never be cleaned up.
+		r.click('#bump');
+		expect(r.findAll('#fallback')).toHaveLength(0);
+		expect(ids()).toEqual(['row-a']);
+		await act(() => {});
+		expect(log.drain()).toEqual([]);
+
+		// The real commit mounts d fresh, exactly once.
+		await act(() => {
+			d1.resolve('one');
+		});
+		expect(ids()).toEqual(['row-a', 'row-d']);
+		expect(log.drain()).toEqual(['mount:d']);
+
+		r.unmount();
+		await act(() => {});
+		expect(log.drain()).toEqual(['cleanup:a', 'cleanup:d']);
+	});
+
+	it('holds an empty list empty when the attempt filled it before suspending', async () => {
+		const fulfilled = {
+			status: 'fulfilled',
+			value: 'zero',
+			then: (fn: (v: string) => void) => void fn('zero'),
+		} as unknown as Promise<string>;
+		const d1 = deferred<string>();
+		const load = (step: number) => (step === 0 ? fulfilled : d1.promise);
+		const log = createLog();
+		const ids = () => r.findAll('#list li').map((li) => li.id);
+
+		const r = mount(TransitionKeyedEmptyFill, { load, log: log.push });
+		await act(() => {});
+		expect(ids()).toEqual([]);
+
+		r.click('#bump');
+		expect(r.findAll('#fallback')).toHaveLength(0);
+		expect(ids()).toEqual([]);
+		await act(() => {});
+		expect(log.drain()).toEqual([]);
+
+		await act(() => {
+			d1.resolve('one');
+		});
+		expect(ids()).toEqual(['row-d']);
+		expect(log.drain()).toEqual(['mount:d']);
 		r.unmount();
 	});
 });


### PR DESCRIPTION
Third piece of the transition-atomicity work (#379 bindings, #382 controlled
inputs). This closes the structural gap for keyed lists — the only one of the
remaining gaps that destroyed user state rather than showing something stale.

## Summary

A transition that dropped a keyed row and then suspended lost the row from the
held screen: `[a, b, c] → [a, c]` with a suspending sibling left the held
boundary showing `a, c`. The row's DOM, hook state and cleanups were already
destroyed by the time the boundary decided to hold. The two docs-only commits
under this PR record why this was sequenced before the other remaining gap
(outside-boundary content), which is blocked on `isPending`'s scheduling and
needs its own design.

## Design

A removal cannot wait for the hold decision — the reconciler needs the nodes out
of the way to finish, and whether the boundary holds is only known further into
the render. So the removal splits along that line:

- **The DOM detach happens immediately**, as today, but the nodes are kept
  (`parkItemForHold`).
- **The teardown that cannot be undone waits** — `unmountScope`, the user
  cleanups, the `disposed` stamp. If the boundary holds, the rows go back with
  their state intact and their cleanups never having run. When the last journal
  window closes on a committed render, the parked teardowns flush and cleanups
  fire then.

The list restores as a whole rather than per operation (`journalForSlot` /
`restoreForSlot`): the intrusive chain, the key→block map, the counts and the
`@empty` branch snapshot together, and one walk in chain order re-materialises
the range — so moved survivors return to position alongside dropped rows, and
rows the aborted render freshly mounted are removed with it. Survivor node
ranges are collected **before** the range clear, or restoring order would
destroy them.

The bulk-clear fast paths (`textContent = ''`, `Range.deleteContents`) destroy
nodes wholesale, so while a hold is possible `batchClearItems` takes each row
individually instead. The `@empty` swap is reversible in both directions: the
outgoing branch parks like a row, and one the aborted render mounted is
scope-only unmounted on rollback.

All of it is gated on an armed journal window (`itemRemovalDefers()`), which
only exists while a visible try body re-renders under a possible hold — urgent
renders, first mounts, hydration and every non-transition reconcile take the
exact pre-existing paths.

## Found along the way, not fixed here

Writing the regression test surfaced a **pre-existing** bug on stock `main`:
mount effects in components that rendered before a sibling suspended on the
boundary's **first** mount are lost — they never fire even after the boundary
resolves and reveals. Confirmed by checking out the stock runtime and running
the same probe. My test sidesteps it by seeding step 0 with a
`status: 'fulfilled'` thenable so the first mount commits synchronously; the bug
is flagged as its own task with the reproduction and a likely mechanism
(passive-effect deps stamped by the aborted first attempt are not cleared by the
phase-selective deactivate walk, which only clears layout deps).

## Validation

- [x] `pnpm test` — **16,228 passed, 0 failed** (full suite, single run — the
      first fully-clean full run of the day, including keyed stress,
      marker-elision, differential and hydration projects)
- [x] `pnpm typecheck` — clean
- [x] `pnpm format:check` — clean
- [x] New regression tests in `transitions.test.ts`, both watched red with
      parking disabled and green restored:
      - drop a row → hold keeps all three rows, state (`useState`) intact, no
        cleanup runs; commit removes the row and fires its cleanup once
      - clear to `@empty` → hold keeps the rows and no empty branch; commit
        swaps to `@empty` and fires both cleanups
- [x] `node benchmarks/bench.mjs js-framework` vs the same-day baseline:
      `run`/`replace` 1.000, `add` 0.93×, `runlots` 1.08× (17% rme op). `clear`
      reads 1.11×, but the earlier journal-only candidate showed the identical
      drift on this op before any removal code existed, so it is machine noise,
      not the added branch — which is one null check per clear, not per row.

## Risk / residual

- `parkItemForHold` mirrors `unmountBlockInner`'s marker walk. Markerless
  (marker-elision M4) item shapes therefore ride the same suite coverage as the
  marker path; the full run includes the elision suites.
- Parked items cannot leak across flushes: the disarm that flushes them sits in
  the same synchronous flush as the render that parked them (`finally` in the
  try-body render and the resume path both close the window).
- The remaining gap — content the transition patched outside a suspended
  boundary — is blocked on decoupling `isPending` from the transition render and
  is documented in `SUSPENSE_DIVERGENCE.md` #4 with the failed-attempt notes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `@for` teardown and transition journal rollback on every keyed removal path when a journal window is open; behavior is gated but incorrect parking or restore could leak DOM, skip cleanups, or leave stale list state.
> 
> **Overview**
> Fixes a transition-atomicity gap where a keyed `@for` could reconcile (drop rows, clear to `@empty`, or add rows) before a sibling suspended, leaving a held boundary showing a list that was already torn down.
> 
> While the transition journal is armed, keyed removals **detach DOM immediately** but **park nodes** and skip `unmountBlock` until commit (`parkItemForHold` / `flushParkedItems`). **`journalForSlot` / `restoreForSlot`** snapshot and roll back the full list shape—chain, key map, counts, and `@empty`—and undo paths also tear down rows mounted only on an aborted attempt so mount effects do not leak.
> 
> `reconcileKeyed`, `mountItemsLinear`, `batchClearItems`, and the empty-branch swap route through this when `itemRemovalDefers()` is true. Docs mark keyed-list “destruction is not undoable” as closed; broader outside-boundary deferred commit remains blocked on `isPending` scheduling.
> 
> Regression coverage in `transitions.test.ts` covers row removal, list→empty, addition rollback, and empty→fill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d2c6a7f89b92049ea4dee225452b0b422e1fb6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->