### PR TITLE
fix(compiler): guard webpack HMR dispose data on first module evaluation

### DIFF
--- a/.changeset/webpack-hmr-first-eval-guard.md
+++ b/.changeset/webpack-hmr-first-eval-guard.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Guard `hot.data` in the universal webpack-HMR handoff: webpack and rspack leave `module.hot.data` undefined until a previous instance of the module has disposed, so the emitted `hot.data.__octaneUniversalComponents` read crashed every dev bundle on its first evaluation.

--- a/packages/octane/src/compiler/compile-universal.js
+++ b/packages/octane/src/compiler/compile-universal.js
@@ -3139,7 +3139,17 @@ function hmrHandoffStatements(state, hot, origin) {
 	for (const component of state.hmrComponents) {
 		const componentOrigin = component.origin ?? origin;
 		const existing = b.member(hmrComponentStore(hot, componentOrigin), component.name);
-		const test = b.logical('&&', hmrComponentStore(hot, componentOrigin), existing);
+		// Webpack/rspack leave `hot.data` undefined until a previous instance of
+		// the module has disposed, so first evaluation must guard the bag itself.
+		const test = b.logical(
+			'&&',
+			b.logical(
+				'&&',
+				memberPath(hot, ['data'], componentOrigin),
+				hmrComponentStore(hot, componentOrigin),
+			),
+			existing,
+		);
 		const update = b.stmt(
 			b.call(
 				b.member(b.member(existing, b.id(state.helpers.hmrSymbol), true), 'update'),

--- a/packages/octane/tests/universal-renderer.test.ts
+++ b/packages/octane/tests/universal-renderer.test.ts
@@ -2474,6 +2474,47 @@ export function Scene() @{
 		);
 	});
 
+	it('evaluates a webpack-HMR universal module before any dispose data exists', () => {
+		const source = `
+			export function Scene() @{ <scene /> }
+		`;
+		let output = compile(source, '/src/HotData.object.tsrx', { renderer, hmr: 'webpack' }).code;
+		output = output.replace(
+			/import\s*\{([\s\S]*?)\}\s*from\s*["']octane\/universal["'];/g,
+			(_match, specifiers: string) =>
+				`const {${specifiers.replace(/\s+as\s+/g, ': ')}} = __universal;`,
+		);
+		output = output.replaceAll('import.meta.webpackHot', '__hot');
+		output = output.replace('export let Scene =', 'let Scene =');
+		interface WebpackHot {
+			data: object | undefined;
+			dispose(callback: (data: object) => void): void;
+			accept(): void;
+		}
+		const evaluate = (hot: WebpackHot) =>
+			new Function('__universal', '__hot', `${output}\nreturn Scene;`)(
+				UniversalRuntime,
+				hot,
+			) as object;
+
+		// Webpack and rspack leave `hot.data` undefined until a previous instance
+		// of the module has disposed, so the first evaluation must not read it.
+		const disposals: Array<(data: object) => void> = [];
+		const first = evaluate({
+			data: undefined,
+			dispose: (callback) => disposals.push(callback),
+			accept: () => {},
+		});
+		expect(first).toBeTruthy();
+		expect(disposals).toHaveLength(1);
+
+		// A hot update hands the retained canonical component to the new module.
+		const bag = {};
+		disposals[0]!(bag);
+		const second = evaluate({ data: bag, dispose: () => {}, accept: () => {} });
+		expect(second).toBe(first);
+	});
+
 	it('warms adjacent universal component trees from a parent with no use()', async () => {
 		const source = `
 			import { use } from 'octane';


### PR DESCRIPTION
## Summary
- Guard `hot.data` in the universal renderer's webpack-HMR handoff so a module's first evaluation no longer crashes.

## Why
- webpack and rspack leave `module.hot.data` `undefined` until a previous instance of the module has disposed. The emitted handoff read `hot.data.__octaneUniversalComponents` unguarded, so **every** dev bundle compiled with the webpack HMR dialect threw `TypeError: cannot read property '__octaneUniversalComponents' of undefined` at module init.
- Found on a real device: any `pluginOctane({ dev: true, hmr: true })` Rspeedy bundle crashed on Lynx Explorer 3.9 (iOS) before rendering. The Vite dialect never hit this because Vite initializes `import.meta.hot.data` to `{}`; the DOM webpack dialect already guards through optional member access.

## Changes
- `compile-universal.js`: `hmrHandoffStatements` now emits `hot.data && hot.data.__octaneUniversalComponents && …` instead of dereferencing `hot.data` directly.
- `universal-renderer.test.ts`: new behavioral regression that compiles a webpack-HMR universal module and executes it against a webpack-shaped hot object with `data: undefined` (throws pre-fix with the exact device error), then replays the dispose bag and asserts the retained component keeps canonical identity.

## Validation
- [x] targeted tests: `vitest run packages/octane/tests/universal-renderer.test.ts` — 176 passed (octane + octane-prod projects)
- [x] pre-fix failure confirmed: with the compiler change stashed, the new test fails with `TypeError: Cannot read properties of undefined (reading '__octaneUniversalComponents')` in both projects
- [x] `prettier --check` on changed files
- [ ] full `pnpm test` / `pnpm typecheck` not run for this PR (compiler-local change; full lynx-project suite was run on the combined branch during device verification)

## Risk / follow-ups
- Behavior change is limited to generated dev/HMR output; production output is untouched. On update evaluations `hot.data` is defined and the handoff behaves exactly as before.
- Verified end-to-end on Lynx Explorer 3.9 (iOS simulator): dev bundles now evaluate and render.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to dev/HMR codegen in the universal compiler; production bundles are unaffected and hot-update paths behave the same when `hot.data` is defined.
> 
> **Overview**
> Fixes a **dev-only crash** on the first load of universal modules built with the **webpack/rspack HMR** dialect: emitted handoff code now checks **`hot.data`** exists before reading **`__octaneUniversalComponents`**, matching webpack/rspack semantics (dispose bag is undefined until the prior module instance disposes).
> 
> Adds a **behavioral regression test** that compiles a webpack-HMR universal module, evaluates it with `data: undefined`, then replays dispose and asserts component identity is preserved on hot update. **Production output is unchanged**; only generated HMR handoff differs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad5853057637b887ef1ba6e5141ab7af6576fc02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->