### PR TITLE
fix(octane): run mount effects a suspended boundary never committed

### DIFF
--- a/.changeset/suspended-mount-effects.md
+++ b/.changeset/suspended-mount-effects.md
@@ -1,0 +1,27 @@
+---
+'octane': patch
+---
+
+Run the mount effects of components a boundary rendered but never committed.
+
+A `useEffect` could be lost outright. When a Suspense boundary suspended on
+something rendered *after* a sibling — a `@for` of children followed by a
+component that calls `use()` on a pending promise, say — those earlier siblings
+had already run their hooks before the attempt was abandoned. Their effects were
+queued and then dropped along with the rest of the aborted attempt, but the
+slots kept the dependency arrays that attempt had stamped. When the promise
+resolved and the content was revealed, the re-render compared those deps, found
+them unchanged, and enqueued nothing. The mount body never ran, and neither did
+the cleanup it would have returned, so subscriptions, timers, and observers set
+up in `useEffect` silently never started. `useLayoutEffect` was unaffected.
+
+Hiding a boundary behind its fallback still leaves passive effects subscribed,
+which is what React does for content that is on screen and merely hidden. That
+now applies only to effects that actually ran. One that never ran has no
+subscription to preserve, so it resets like a layout effect and fires when the
+boundary finally commits — React fires every mount effect in the subtree when a
+suspended mount lands.
+
+This also covers a boundary that commits, then re-renders with a new child and
+suspends: the new child's effects mount on reveal while its already-committed
+siblings keep the subscriptions they had.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -21483,10 +21483,12 @@ function detachDeoptTreeRefs(
  * slots so the setups re-fire on reactivation. Used by activityBlock on hide
  * AND by the tryBlock suspense-hide path (hideTryContentAndMountPending):
  * Activity disconnects layout + passive effects. Suspense passes
- * `disconnectPassive=false`: layout effects disconnect, while passive effects
- * remain subscribed until actual deletion, matching React's hidden-primary
- * lifetime. State, DOM, and blocks stay alive in either case. Refs remain
- * attached for Activity; Suspense cycles them separately via detachSubtreeRefs.
+ * `disconnectPassive=false`: layout effects disconnect, while CONNECTED passive
+ * effects remain subscribed until actual deletion, matching React's
+ * hidden-primary lifetime. A passive effect that never connected is not part of
+ * that hidden primary and resets like a layout one (see below). State, DOM, and
+ * blocks stay alive in either case. Refs remain attached for Activity; Suspense
+ * cycles them separately via detachSubtreeRefs.
  */
 function deactivateScope(scope: Scope, disconnectPassive: boolean = true): void {
 	const hooks = scope.hooks;
@@ -21499,7 +21501,24 @@ function deactivateScope(scope: Scope, disconnectPassive: boolean = true): void 
 				// reveal re-render doesn't re-fire them. They own injected styles
 				// that must persist while a tree is merely hidden; only a real
 				// unmount (unmountScope's effect-slot walk) tears them down.
-				if (e.phase === INSERTION || (!disconnectPassive && e.phase === PASSIVE)) continue;
+				//
+				// Suspense's `disconnectPassive=false` spares passive effects for the
+				// same reason — but only ones that ACTUALLY connected. `connectedFn` is
+				// set exclusively by runEffectBody, so a null one has never run: it
+				// belongs to a subtree the boundary rendered but never committed —
+				// siblings ahead of the call that suspended, or children introduced by a
+				// later attempt. There is no subscription to preserve, and its deps are
+				// already stamped from that aborted attempt, so sparing it would let the
+				// reveal re-render compare equal deps and skip the enqueue, stranding the
+				// mount effect — and its cleanup — forever. React fires every mount effect
+				// in the subtree when a suspended mount finally commits, so an
+				// unconnected passive slot resets exactly like a layout one.
+				if (
+					e.phase === INSERTION ||
+					(!disconnectPassive && e.phase === PASSIVE && e.connectedFn !== null)
+				) {
+					continue;
+				}
 				if (typeof e.cleanup === 'function') {
 					const cleanup = e.cleanup;
 					// Clear it BEFORE firing so unmountScope's effect-slot walk sees

--- a/packages/octane/tests/_fixtures/suspense.tsrx
+++ b/packages/octane/tests/_fixtures/suspense.tsrx
@@ -1,4 +1,4 @@
-import { use, useState, useEffect, useMemo, useDeferredValue } from 'octane';
+import { use, useState, useEffect, useLayoutEffect, useMemo, useDeferredValue } from 'octane';
 
 // ---------------------------------------------------------------------------
 // Basic Suspense flow — try/pending/catch with a use(promise) inside try.
@@ -310,4 +310,67 @@ export function ReplayChurnBody(props) @{
 			<div class="fallback">{'loading'}</div>
 		}
 	</>
+}
+
+// ---------------------------------------------------------------------------
+// Mount effects of siblings rendered BEFORE the suspending one.
+// ---------------------------------------------------------------------------
+// On the boundary's FIRST mount attempt these children render fully — their
+// effect slots stamp deps and enqueue — and then a LATER sibling suspends, so
+// the attempt is aborted and the subtree is hidden before anything committed.
+// When the promise resolves and the content is revealed, React fires every
+// mount effect in the subtree; these children have never run theirs.
+function PreSuspendChild(props) @{
+	useLayoutEffect(() => {
+		props.log('layout mount ' + props.id);
+		return () => props.log('layout cleanup ' + props.id);
+	}, []);
+	useEffect(() => {
+		props.log('passive mount ' + props.id);
+		return () => props.log('passive cleanup ' + props.id);
+	}, []);
+	<li class="item">{props.id as string}</li>
+}
+
+function SuspendingChild(props) @{
+	const v = use(props.promise);
+	<li class="resolved">{v as string}</li>
+}
+
+// Keyed @for items plus a plain element sibling, all ahead of the suspender.
+export function PreSuspendSiblingEffects(props) @{
+	<ul>
+		@try {
+			<>
+				@for (const id of props.ids; key id) {
+					<PreSuspendChild id={id} log={props.log} />
+				}
+				<PreSuspendChild id="plain" log={props.log} />
+				<SuspendingChild promise={props.promise} />
+			</>
+		} @pending {
+			<li class="fallback">{'loading'}</li>
+		}
+	</ul>
+}
+
+// Same shape, but the boundary COMMITS first and only suspends on a later
+// attempt that also introduces a new child. The already-committed children keep
+// their passive subscriptions across the hide (React's hidden-primary lifetime);
+// the newly rendered one never committed, so its mount effect still owes a run.
+export function CommittedThenNewSibling(props) @{
+	<ul>
+		@try {
+			<>
+				@for (const id of props.ids; key id) {
+					<PreSuspendChild id={id} log={props.log} />
+				}
+				@if (props.suspend) {
+					<SuspendingChild promise={props.promise} />
+				}
+			</>
+		} @pending {
+			<li class="fallback">{'loading'}</li>
+		}
+	</ul>
 }

--- a/packages/octane/tests/suspense.test.ts
+++ b/packages/octane/tests/suspense.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mount, act } from './_helpers';
+import { mount, act, nextPaint } from './_helpers';
 import {
 	BasicSuspense,
 	CatchRejection,
@@ -18,6 +18,8 @@ import {
 	WaterfallBody,
 	ReplayChurnBody,
 	PendingPropSwap,
+	PreSuspendSiblingEffects,
+	CommittedThenNewSibling,
 } from './_fixtures/suspense.tsrx';
 
 interface Deferred<T> {
@@ -515,6 +517,82 @@ describe('Suspense — useDeferredValue (React 18 stale-data pattern)', () => {
 		});
 		expect(r.find('.data').textContent).toBe('second-data');
 		expect(r.find('.data').className).toBe('data fresh');
+		r.unmount();
+	});
+});
+
+describe('Suspense — effects of siblings rendered before the suspend', () => {
+	it('fires mount effects for pre-suspend siblings once the first mount reveals', async () => {
+		const d = deferred<string>();
+		const log: string[] = [];
+		const r = mount(PreSuspendSiblingEffects, {
+			ids: ['a', 'b'],
+			log: (m: string) => log.push(m),
+			promise: d.promise,
+		});
+		// Nothing committed: the boundary suspended before any of it landed.
+		expect(r.find('.fallback').textContent).toBe('loading');
+		expect(log).toEqual([]);
+
+		await act(() => {
+			d.resolve('R');
+		});
+		expect(r.find('.resolved').textContent).toBe('R');
+		expect(r.findAll('.item').map((n) => n.textContent)).toEqual(['a', 'b', 'plain']);
+		// React parity: a suspended initial mount fires every mount effect in the
+		// subtree when it finally commits.
+		expect(log).toEqual([
+			'layout mount a',
+			'layout mount b',
+			'layout mount plain',
+			'passive mount a',
+			'passive mount b',
+			'passive mount plain',
+		]);
+
+		// The mount effects really connected, so unmount tears them down: layout
+		// cleanups synchronously, passive ones deferred (see effect-timing).
+		log.length = 0;
+		r.unmount();
+		expect(log).toEqual(['layout cleanup a', 'layout cleanup b', 'layout cleanup plain']);
+		await nextPaint();
+		expect(log).toEqual([
+			'layout cleanup a',
+			'layout cleanup b',
+			'layout cleanup plain',
+			'passive cleanup a',
+			'passive cleanup b',
+			'passive cleanup plain',
+		]);
+	});
+
+	it('spares committed passive subscriptions but still mounts a new sibling', async () => {
+		const log: string[] = [];
+		const push = (m: string) => log.push(m);
+		const r = mount(CommittedThenNewSibling, { ids: ['a'], log: push, suspend: false });
+		await nextPaint();
+		expect(log).toEqual(['layout mount a', 'passive mount a']);
+
+		// Second attempt adds child 'b' AND suspends. 'a' is already committed.
+		const d = deferred<string>();
+		log.length = 0;
+		r.update(CommittedThenNewSibling, {
+			ids: ['a', 'b'],
+			log: push,
+			suspend: true,
+			promise: d.promise,
+		});
+		expect(r.find('.fallback').textContent).toBe('loading');
+		expect(log).toEqual(['layout cleanup a']);
+
+		log.length = 0;
+		await act(() => {
+			d.resolve('R');
+		});
+		expect(r.find('.resolved').textContent).toBe('R');
+		// 'a' kept its passive subscription across the hide, so only its layout
+		// effect recycles. 'b' never committed, so both of its mounts still owe a run.
+		expect(log).toEqual(['layout mount a', 'layout mount b', 'passive mount b']);
 		r.unmount();
 	});
 });


### PR DESCRIPTION
## Summary

- A `useEffect` inside a Suspense boundary could be lost outright — its mount body and its cleanup never ran — when a **later** sibling suspended on the boundary's first mount.
- Fixed in `deactivateScope`: a passive effect is spared on hide only if it actually connected.
- `useLayoutEffect` was never affected; this is a passive-only hole.

## Why

Reproduction: a `@try` whose body renders a `@for` of components each doing
`useEffect(() => { …; return () => … }, [])`, followed by a sibling component
that calls `use(promise)` on a promise that is pending at first mount. Mount,
resolve, and the mount logs never arrive. The same fixture without the
suspending sibling logs normally.

Those earlier siblings render *fully* before the boundary suspends, so their
effect slots stamp deps and enqueue. The attempt is then aborted: the subtree is
hidden and marked inactive, and the drain discards the enqueued effects. But the
stamped deps survive. On reveal the re-render compares `[]` against the stamped
`[]`, finds them equal, and enqueues nothing — so subscriptions, timers, and
observers set up in `useEffect` silently never start, and the cleanup that would
have torn them down never exists either.

The cause is in `deactivateScope`. The three Suspense-hide paths pass
`disconnectPassive = false`, which made it skip **every** passive slot — no
cleanup, and no `deps = undefined` reset. That is correct for content the
boundary already committed (React keeps a hidden primary's passive effects
subscribed across a hide) but wrong for a subtree that never committed: its
passive effects never subscribed in the first place, so there is nothing to
preserve. Layout effects were already fine because they take the reset path
unconditionally.

## Changes

`packages/octane/src/runtime.ts` — the passive skip now also requires
`e.connectedFn !== null`:

```ts
if (
    e.phase === INSERTION ||
    (!disconnectPassive && e.phase === PASSIVE && e.connectedFn !== null)
) {
    continue;
}
```

`connectedFn` is assigned exclusively by `runEffectBody`, so a null one has
provably never run. It resets like a layout effect and fires when the boundary
finally commits — React fires every mount effect in the subtree when a suspended
mount lands. Nothing else changes: `INSERTION` is untouched, a never-run effect
has no `cleanup` to fire, and `disconnected` is already guarded on the same
field.

The predicate is deliberately **per slot** rather than a boundary-level flag such
as `!state.hasResolved`. A boundary that commits, then re-renders with a new
child, then suspends holds both kinds of slot under it at once; the
boundary-level version would strand the new child. The second test pins exactly
that case.

Regression coverage in `packages/octane/tests/suspense.test.ts` with fixtures in
`packages/octane/tests/_fixtures/suspense.tsrx`:

1. **`fires mount effects for pre-suspend siblings once the first mount reveals`** —
   keyed `@for` items *and* a plain sibling ahead of the suspender; asserts both
   layout and passive mounts on reveal, and that unmount then tears them down
   (layout synchronously, passive deferred).
2. **`spares committed passive subscriptions but still mounts a new sibling`** —
   boundary commits with child `a`, then re-renders adding `b` and suspends.
   `a` keeps its passive subscription across the hide (only its layout effect
   recycles); `b` mounts both.

Both fail on the pre-fix runtime in dev **and** prod, and fail only on the
missing `passive mount …` entries — nothing incidental.

## Scope notes

- Not specific to `@for` — a plain sibling component ahead of the suspender was
  equally affected.
- The suspend has to come from a *child component*; a bare `use()` in the try
  body runs during setup before any sibling renders, so it strands nothing.
- The `Activity` hide path passes `disconnectPassive = true` and is unaffected.

## Validation

- [x] `pnpm format:check` — clean
- [x] `pnpm typecheck` — `tsgo --noEmit -p packages/octane/tsconfig.json` clean
- [x] `pnpm test` — 1459 files, 16231 tests, all passing, exit 0
- [x] targeted, post-rebase: `suspense`, `activity`, `effect-timing`,
      `nested-suspend`, `consecutive-suspend`, `suspense-preserves-dom`,
      `transition-descendant-suspend` — 14 files, 136 tests passing
- [x] pre-fix failure confirmed by stashing the runtime change: both new tests
      fail in the `octane` and `octane-prod` projects

The full-suite run was on the pre-rebase base (`75510594`); `origin/main` has
since added `89323b74`, which touches only `app-core` and `vite-plugin-octane`
— disjoint from this change. The targeted suites above were re-run after the
rebase.

## Risk / follow-ups

- Behavior change is confined to passive effect slots that never ran, inside a
  Suspense hide. Committed content keeps React's hidden-primary lifetime exactly
  as before.
- `deactivateScope` is not on a per-render hot path (Activity/Suspense hide
  only), and the addition is one property read inside an already-taken branch.
- Unrelated: this worktree's `node_modules` was stale (`@tsrx/core` 0.1.40
  against a `^0.1.56` catalog) and Vitest could not load its config until
  `pnpm install` was run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core effect lifecycle on Suspense hide paths; behavior change is narrow (unconnected passive slots only) but incorrect handling could still strand or double-fire effects.
> 
> **Overview**
> Fixes **`useEffect` mount bodies that never ran** when a Suspense boundary rendered siblings first, then suspended on a later child before anything committed. Aborted attempts dropped queued effects but left stamped deps, so on reveal the scheduler saw unchanged deps and skipped enqueueing—subscriptions and cleanups never started.
> 
> **`deactivateScope`** (Suspense hide with `disconnectPassive=false`) now keeps passive effects subscribed only when **`connectedFn !== null`** (effect actually committed). Passive slots that never connected reset like layout effects and run when the boundary finally commits, matching React’s “fire every mount effect in the subtree” behavior. Already-committed siblings still keep passive subscriptions across hide.
> 
> Adds suspense fixtures and tests for pre-suspend siblings (`@for` + plain sibling) and for commit-then-re-render-with-new-child-then-suspend.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 445ce08e3e30c7dc0611f381f9951393d37bde3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->