### PR TITLE
feat(docusaurus): add document and classic theme phase

### DIFF
--- a/.changeset/calm-docs-orchestrate.md
+++ b/.changeset/calm-docs-orchestrate.md
@@ -1,0 +1,8 @@
+---
+'@octanejs/docusaurus': patch
+---
+
+Add Docusaurus document and client-module asset orchestration, a full SSR HTML
+composer, and the initial Octane-native classic documentation theme. Nested
+Docusaurus layout routes that share an absolute pathname now map correctly onto
+the Remix route hierarchy.

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -23,7 +23,7 @@ All publishable packages share the enforced Node.js engine baseline `>=22`.
 | `@octanejs/devtools` | [`packages/devtools`](../packages/devtools) | framework binding | `0.0.7` | 1 |
 | `@octanejs/dexie` | [`packages/dexie`](../packages/dexie) | framework binding | `0.1.12` | 1 |
 | `@octanejs/dnd-kit` | [`packages/dnd-kit`](../packages/dnd-kit) | framework binding | `0.1.14` | 4 |
-| `@octanejs/docusaurus` | [`packages/docusaurus`](../packages/docusaurus) | metaframework | `0.0.3` | 7 |
+| `@octanejs/docusaurus` | [`packages/docusaurus`](../packages/docusaurus) | metaframework | `0.0.3` | 8 |
 | `@octanejs/floating-ui` | [`packages/floating-ui`](../packages/floating-ui) | framework binding | `0.1.18` | 1 |
 | `@octanejs/hook-form` | [`packages/hook-form`](../packages/hook-form) | framework binding | `0.1.16` | 1 |
 | `@octanejs/i18next` | [`packages/i18next`](../packages/i18next) | framework binding | `0.1.14` | 3 |

--- a/packages/docusaurus/README.md
+++ b/packages/docusaurus/README.md
@@ -39,6 +39,8 @@ The manifest contains:
 
 - nested routes with `component`, `modules`, `props`, and plugin context;
 - generated global data and per-document metadata;
+- serializable site config, locale/document attributes, and plugin HTML tags;
+- client modules discovered through the Docusaurus plugin lifecycle;
 - `@site`, `@generated`, `~docs`, `@theme`, `@theme-original`, and
   `@theme-init` resolution;
 - the exact Docusaurus version and route-path inventory.
@@ -64,7 +66,32 @@ export default defineConfig({
 
 The bridge publishes `virtual:octane-docusaurus-manifest` and resolves
 Docusaurus aliases. Its MDX plugin chooses Octane client/server compilation per
-Vite environment and injects metadata discovered by the content plugins.
+Vite environment and injects metadata discovered by the content plugins. The
+route virtual module also imports plugin client modules, so theme CSS and other
+side-effect assets participate in the client and SSR build graphs.
+
+## Octane classic theme
+
+Add the first-party Octane theme beside the content plugins in
+`docusaurus.config.mjs`:
+
+```js
+import octaneClassicTheme from '@octanejs/docusaurus/theme';
+
+export default {
+	title: 'My documentation',
+	url: 'https://docs.example.com',
+	baseUrl: '/',
+	themes: [octaneClassicTheme],
+	plugins: ['@docusaurus/plugin-content-docs'],
+};
+```
+
+The theme supplies Octane-native `DocsRoot`, `DocVersionRoot`, `DocRoot`,
+`DocItem`, category-index, and tag-page route modules. Its initial classic shell
+renders configured navbar/footer links, recursive documentation sidebars,
+document metadata, canonical links, previous/next navigation, and responsive
+CSS. React-authored theme modules and swizzles still need Octane equivalents.
 
 ## Client routing
 
@@ -103,30 +130,50 @@ navigation.
 ## Static rendering and hydration
 
 The server entry resolves the requested lazy route branch through Remix's
-static handler, then prerenders fully resolved Octane markup. Hoisted metadata
-is returned separately in `head` so a static-site host can place it in the real
-document head:
+static handler, then prerenders fully resolved Octane markup. Use the route API
+when a host owns the outer HTML, or the document API to compose Docusaurus
+plugin tags, metadata, scoped CSS, build assets, and the hydration entry into a
+complete page:
 
 ```ts
-import { prerenderDocusaurusRoute } from '@octanejs/docusaurus/server';
+import { prerenderDocusaurusDocument } from '@octanejs/docusaurus/server';
 import {
 	manifest,
 	routeModules,
 } from 'virtual:octane-docusaurus-routes';
 
-const rendered = await prerenderDocusaurusRoute(
+const rendered = await prerenderDocusaurusDocument(
 	new Request('https://docs.example.com/guide/intro'),
 	manifest,
 	routeModules,
+	{
+		document: {
+			assets: {
+				stylesheets: ['assets/site.css'],
+				modulePreloads: ['assets/intro.js'],
+			},
+			hydrate: 'assets/hydrate.js',
+		},
+	},
 );
 
 if (rendered instanceof Response) {
 	return rendered;
 }
 
-const { html, head, css, context } = rendered;
+const { html, bodyHtml, head, css, context } = rendered;
 ```
 
+`html` is the complete `<!DOCTYPE html>` document. `bodyHtml` remains the
+prerendered router root for integrations that need both forms. Relative asset
+paths resolve against `manifest.baseUrl`; URL attributes are escaped, duplicate
+asset entries are removed without reordering, and `nonce` from the render
+options is carried onto module scripts. Docusaurus `injectHtmlTags` output is
+trusted site configuration and retains upstream ordering around the
+`#__docusaurus` root.
+
+`prerenderDocusaurusRoute()` remains available and returns hoisted metadata in
+`head` so an existing static-site host can place it in its own document head.
 `context.statusCode`, `loaderHeaders`, and `actionHeaders` preserve the static
 router result for the surrounding build or request handler. Generate a site by
 calling this function for the paths in `manifest.routesPaths`; each render
@@ -141,7 +188,7 @@ import {
 	routeModules,
 } from 'virtual:octane-docusaurus-routes';
 
-const container = document.getElementById('root');
+const container = document.getElementById('__docusaurus');
 if (container === null) throw new Error('Missing Docusaurus root.');
 
 const { root, router } = await hydrateDocusaurusRoot(
@@ -183,8 +230,9 @@ remain composable.
 
 ## Current scope
 
-Phases 1–5 are implemented here: headless loading, manifest/Vite integration,
-MDX compilation, lazy client routing, static route rendering, and hydration.
-Document/asset orchestration and an Octane classic theme remain the next theme
-phase; the CLI therefore does not present `start` or `build` as working commands
-yet.
+Phases 1–6 are implemented here: headless loading, manifest/Vite integration,
+MDX compilation, lazy client routing, static route rendering, hydration,
+document/asset orchestration, and the initial Octane classic documentation
+theme. A complete `start`/`build` CLI workflow and broader classic-theme feature
+parity remain later phases, so the CLI does not present those commands as
+working yet.

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -57,6 +57,11 @@
       "import": "./src/server.js",
       "default": "./src/server.js"
     },
+    "./theme": {
+      "types": "./types/theme.d.ts",
+      "import": "./src/theme.js",
+      "default": "./src/theme.js"
+    },
     "./vite": {
       "types": "./types/vite.d.ts",
       "import": "./src/vite.js",
@@ -70,6 +75,7 @@
   "dependencies": {
     "@octanejs/mdx": "workspace:*",
     "@octanejs/remix-router": "workspace:*",
+    "@octanejs/seo": "workspace:*",
     "github-slugger": "1.5.0"
   },
   "peerDependencies": {

--- a/packages/docusaurus/src/client-components.tsrx
+++ b/packages/docusaurus/src/client-components.tsrx
@@ -7,6 +7,7 @@ import {
 	useNavigate,
 	useParams,
 } from '@octanejs/remix-router';
+import { Head, Meta, Seo } from '@octanejs/seo';
 
 type DocusaurusPluginIdentifier = {
 	name: string;
@@ -20,6 +21,13 @@ type DocusaurusRouteContextValue = {
 
 type DocusaurusManifestValue = {
 	baseUrl: string;
+	site: {
+		title: string;
+		url: string;
+		favicon?: string;
+		noIndex: boolean;
+		themeConfig: Record<string, unknown>;
+	};
 };
 
 type DocusaurusRoute = {
@@ -31,6 +39,18 @@ type DocusaurusRoute = {
 
 const ManifestContext = createContext<DocusaurusManifestValue | null>(null);
 const RouteContext = createContext<DocusaurusRouteContextValue | null>(null);
+
+function DocusaurusSiteMetadata(props: { manifest: DocusaurusManifestValue }) @{
+	const site = props.manifest.site;
+	<>
+		<Seo
+			title={site.title}
+			openGraph={{ title: site.title }}
+			robots={site.noIndex ? { index: false, follow: false } : undefined}
+		/>
+		<Meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	</>
+}
 
 function mergeRouteContext(
 	parent: DocusaurusRouteContextValue | null,
@@ -62,7 +82,10 @@ export function DocusaurusRouterProvider(props: {
 	router: DataRouter;
 }) @{
 	<ManifestContext.Provider value={props.manifest}>
-		<RouterProvider router={props.router} />
+		<Head>
+			<DocusaurusSiteMetadata manifest={props.manifest} />
+			<RouterProvider router={props.router} />
+		</Head>
 	</ManifestContext.Provider>
 }
 

--- a/packages/docusaurus/src/document.js
+++ b/packages/docusaurus/src/document.js
@@ -1,0 +1,153 @@
+import { escapeAttr } from 'octane/server';
+
+const ATTRIBUTE_NAME = /^[A-Za-z_:][A-Za-z0-9_.:-]*$/;
+const ABSOLUTE_ASSET = /^(?:[a-z][a-z\d+.-]*:|\/\/|\/|#)/i;
+
+function escapeDocumentAttribute(value) {
+	const escaped = escapeAttr(value);
+	return /[<>]/.test(escaped) ? escaped.replace(/</g, '&lt;').replace(/>/g, '&gt;') : escaped;
+}
+
+function attributeString(attributes) {
+	let result = '';
+	for (const [name, value] of Object.entries(attributes ?? {})) {
+		if (!ATTRIBUTE_NAME.test(name)) {
+			throw new TypeError(`Invalid Docusaurus document attribute name: ${JSON.stringify(name)}.`);
+		}
+		if (value === undefined || value === null || value === false) continue;
+		result += value === true ? ` ${name}` : ` ${name}="${escapeDocumentAttribute(String(value))}"`;
+	}
+	return result;
+}
+
+function assetSource(asset, name) {
+	if (typeof asset === 'string') return asset;
+	if (asset !== null && typeof asset === 'object' && typeof asset[name] === 'string') {
+		return asset[name];
+	}
+	throw new TypeError(`Expected a Docusaurus ${name} asset.`);
+}
+
+function assetUrl(baseUrl, value) {
+	if (ABSOLUTE_ASSET.test(value)) return value;
+	return `${baseUrl}${value.replace(/^\.\//, '')}`;
+}
+
+function assetAttributes(asset, sourceName, baseUrl, baseAttributes) {
+	if (typeof asset === 'string') {
+		return {
+			...baseAttributes,
+			[sourceName]: assetUrl(baseUrl, asset),
+		};
+	}
+	const { integrity, crossOrigin, referrerPolicy, media, async, defer, type } = asset;
+	return {
+		...baseAttributes,
+		[sourceName]: assetUrl(baseUrl, assetSource(asset, sourceName)),
+		...(integrity === undefined ? {} : { integrity }),
+		...(crossOrigin === undefined ? {} : { crossorigin: crossOrigin }),
+		...(referrerPolicy === undefined ? {} : { referrerpolicy: referrerPolicy }),
+		...(media === undefined ? {} : { media }),
+		...(async === undefined ? {} : { async }),
+		...(defer === undefined ? {} : { defer }),
+		...(type === undefined ? {} : { type }),
+	};
+}
+
+function uniqueAssets(assets, sourceName) {
+	const result = [];
+	const seen = new Set();
+	for (const asset of assets ?? []) {
+		const source = assetSource(asset, sourceName);
+		if (seen.has(source)) continue;
+		seen.add(source);
+		result.push(asset);
+	}
+	return result;
+}
+
+function renderAssets(manifest, assets, nonce) {
+	const stylesheets = uniqueAssets(assets?.stylesheets, 'href').map((asset) => {
+		const attributes = assetAttributes(asset, 'href', manifest.baseUrl, {
+			rel: 'stylesheet',
+		});
+		return `<link${attributeString(attributes)}>`;
+	});
+	const modulePreloads = uniqueAssets(assets?.modulePreloads, 'href').map((asset) => {
+		const attributes = assetAttributes(asset, 'href', manifest.baseUrl, {
+			rel: 'modulepreload',
+		});
+		return `<link${attributeString(attributes)}>`;
+	});
+	const scripts = uniqueAssets(assets?.scripts, 'src').map((asset) => {
+		const attributes = assetAttributes(asset, 'src', manifest.baseUrl, {
+			type: 'module',
+			...(nonce === undefined ? {} : { nonce }),
+		});
+		return `<script${attributeString(attributes)}></script>`;
+	});
+	return [...stylesheets, ...modulePreloads, ...scripts];
+}
+
+function renderHydrationEntry(manifest, hydrate, nonce) {
+	if (hydrate === undefined) return '';
+	const attributes = assetAttributes(hydrate, 'src', manifest.baseUrl, {
+		type: 'module',
+		'data-octane-hydrate': true,
+		...(nonce === undefined ? {} : { nonce }),
+	});
+	return `<script${attributeString(attributes)}></script>`;
+}
+
+function renderFavicon(manifest) {
+	if (manifest.site.favicon === undefined) return '';
+	return `<link${attributeString({
+		rel: 'icon',
+		href: assetUrl(manifest.baseUrl, manifest.site.favicon),
+	})}>`;
+}
+
+/**
+ * Compose one route render into the real Docusaurus HTML document.
+ *
+ * Plugin-provided head/body tag strings were produced by Docusaurus's
+ * `injectHtmlTags` lifecycle and are intentionally treated as trusted site
+ * configuration. Attributes and build asset descriptors supplied here are
+ * escaped before insertion.
+ */
+export function renderDocusaurusDocument(rendered, manifest, options = {}) {
+	const htmlAttributes = {
+		...manifest.document.htmlAttributes,
+		...options.htmlAttributes,
+	};
+	const head = [
+		'<meta charset="UTF-8">',
+		`<meta name="generator" content="Docusaurus v${escapeDocumentAttribute(
+			manifest.docusaurusVersion,
+		)}">`,
+		renderFavicon(manifest),
+		manifest.document.headTags,
+		rendered.head,
+		rendered.css,
+		...renderAssets(manifest, options.assets, options.nonce),
+	].filter((value) => value !== '');
+	const hydration = renderHydrationEntry(manifest, options.hydrate, options.nonce);
+	const body = [
+		manifest.document.preBodyTags,
+		`<div id="${escapeDocumentAttribute(options.rootId ?? '__docusaurus')}">${rendered.html}</div>`,
+		manifest.document.postBodyTags,
+		hydration,
+	].filter((value) => value !== '');
+
+	return [
+		'<!DOCTYPE html>',
+		`<html${attributeString(htmlAttributes)}>`,
+		'<head>',
+		...head,
+		'</head>',
+		`<body${attributeString(options.bodyAttributes)}>`,
+		...body,
+		'</body>',
+		'</html>',
+	].join('\n');
+}

--- a/packages/docusaurus/src/manifest.js
+++ b/packages/docusaurus/src/manifest.js
@@ -162,6 +162,68 @@ async function createThemeAliases(plugins, siteDir) {
 	return { theme, themeOriginal, themeInit };
 }
 
+async function clientModules(plugins) {
+	const modules = [];
+	const seen = new Set();
+	for (const plugin of plugins) {
+		if (typeof plugin.getClientModules !== 'function') continue;
+		for (const supplied of (await plugin.getClientModules()) ?? []) {
+			if (typeof supplied !== 'string') {
+				throw new TypeError(
+					`Docusaurus plugin ${JSON.stringify(plugin.name)} returned a non-string client module.`,
+				);
+			}
+			const resolved = path.isAbsolute(supplied) ? supplied : path.resolve(plugin.path, supplied);
+			if (seen.has(resolved)) continue;
+			seen.add(resolved);
+			modules.push(resolved);
+		}
+	}
+	return modules;
+}
+
+function siteManifest(siteConfig) {
+	return toJsonValue(
+		{
+			title: siteConfig.title,
+			tagline: siteConfig.tagline,
+			url: siteConfig.url,
+			baseUrl: siteConfig.baseUrl,
+			favicon: siteConfig.favicon,
+			noIndex: siteConfig.noIndex,
+			trailingSlash: siteConfig.trailingSlash,
+			themeConfig: siteConfig.themeConfig,
+			customFields: siteConfig.customFields,
+		},
+		'$.site',
+	);
+}
+
+function i18nManifest(i18n) {
+	return toJsonValue(
+		{
+			defaultLocale: i18n.defaultLocale,
+			locales: i18n.locales,
+			currentLocale: i18n.currentLocale,
+			localeConfigs: i18n.localeConfigs,
+		},
+		'$.i18n',
+	);
+}
+
+function documentManifest(props) {
+	const locale = props.i18n.localeConfigs[props.i18n.currentLocale];
+	return {
+		htmlAttributes: {
+			lang: String(locale.htmlLang),
+			dir: String(locale.direction),
+		},
+		headTags: String(props.headTags ?? ''),
+		preBodyTags: String(props.preBodyTags ?? ''),
+		postBodyTags: String(props.postBodyTags ?? ''),
+	};
+}
+
 function readJsonIfPresent(filename, fallback) {
 	if (!existsSync(filename)) return fallback;
 	return JSON.parse(readFileSync(filename, 'utf8'));
@@ -193,7 +255,11 @@ function contentMetadata(generatedFilesDir) {
 export async function createDocusaurusManifest(loaded) {
 	const { props } = loaded.site;
 	const { siteDir, generatedFilesDir } = props;
-	const themeAliases = await createThemeAliases(props.plugins ?? [], siteDir);
+	const plugins = props.plugins ?? [];
+	const [themeAliases, discoveredClientModules] = await Promise.all([
+		createThemeAliases(plugins, siteDir),
+		clientModules(plugins),
+	]);
 	return {
 		schemaVersion: 1,
 		docusaurusVersion: loaded.docusaurusVersion,
@@ -201,6 +267,13 @@ export async function createDocusaurusManifest(loaded) {
 		generatedFilesDir,
 		outDir: props.outDir,
 		baseUrl: props.baseUrl,
+		site: siteManifest(props.siteConfig),
+		i18n: i18nManifest(props.i18n),
+		siteMetadata: toJsonValue(props.siteMetadata, '$.siteMetadata'),
+		document: documentManifest(props),
+		assets: {
+			clientModules: discoveredClientModules,
+		},
 		routesPaths: [...props.routesPaths],
 		routes: props.routes.map((route, index) => normalizeRoute(route, index)),
 		globalData: readJsonIfPresent(path.join(generatedFilesDir, 'globalData.json'), {}),

--- a/packages/docusaurus/src/routes.js
+++ b/packages/docusaurus/src/routes.js
@@ -66,15 +66,25 @@ async function loadRouteModules(value, registry, cache) {
 	return value;
 }
 
-function routePath(route) {
+function routePath(route, parentPath) {
+	let pathname = route.path;
+	if (parentPath !== undefined && pathname.startsWith('/')) {
+		if (pathname === parentPath) {
+			pathname = '';
+		} else {
+			const prefix = parentPath.endsWith('/') ? parentPath : `${parentPath}/`;
+			if (pathname.startsWith(prefix)) pathname = pathname.slice(prefix.length);
+		}
+	}
 	if (
-		route.path === '*' ||
+		pathname === '' ||
+		pathname === '*' ||
 		route.exact === true ||
 		(route.children !== undefined && route.children.length > 0)
 	) {
-		return route.path;
+		return pathname;
 	}
-	return route.path.endsWith('/') ? `${route.path}*` : `${route.path}/*`;
+	return pathname.endsWith('/') ? `${pathname}*` : `${pathname}/*`;
 }
 
 function createRouteComponent(route, Component, modules, context) {
@@ -88,10 +98,10 @@ function createRouteComponent(route, Component, modules, context) {
 	};
 }
 
-function createRoute(route, registry, cache) {
+function createRoute(route, registry, cache, parentPath) {
 	return {
 		id: route.id,
-		path: routePath(route),
+		path: routePath(route, parentPath),
 		handle: {
 			docusaurus: route,
 		},
@@ -111,7 +121,9 @@ function createRoute(route, registry, cache) {
 				Component: createRouteComponent(route, Component, modules, context),
 			};
 		},
-		children: (route.children ?? []).map((child) => createRoute(child, registry, cache)),
+		children: (route.children ?? []).map((child) =>
+			createRoute(child, registry, cache, route.path),
+		),
 	};
 }
 

--- a/packages/docusaurus/src/server.js
+++ b/packages/docusaurus/src/server.js
@@ -1,7 +1,10 @@
 import { prerender } from 'octane/static';
 import { createStaticHandler, createStaticRouter } from '@octanejs/remix-router';
 import { DocusaurusRouterProvider } from './client-components.tsrx';
+import { renderDocusaurusDocument } from './document.js';
 import { createDocusaurusRoutes } from './routes.js';
+
+export { renderDocusaurusDocument };
 
 function toRequest(value) {
 	if (value instanceof Request) return value;
@@ -42,5 +45,20 @@ export async function prerenderDocusaurusRoute(request, manifest, registry, opti
 	return {
 		...result,
 		context,
+	};
+}
+
+export async function prerenderDocusaurusDocument(request, manifest, registry, options = {}) {
+	const { document: documentOptions = {}, ...renderOptions } = options;
+	const result = await prerenderDocusaurusRoute(request, manifest, registry, renderOptions);
+	if (result instanceof Response) return result;
+	const bodyHtml = result.html;
+	return {
+		...result,
+		bodyHtml,
+		html: renderDocusaurusDocument(result, manifest, {
+			...documentOptions,
+			nonce: documentOptions.nonce ?? renderOptions.nonce,
+		}),
 	};
 }

--- a/packages/docusaurus/src/theme-components.tsrx
+++ b/packages/docusaurus/src/theme-components.tsrx
@@ -1,0 +1,452 @@
+import { createContext, useContext, type ComponentBody, type OctaneNode } from 'octane';
+import { Link as RouterLink, type Location } from '@octanejs/remix-router';
+import { Head, Seo } from '@octanejs/seo';
+import { useDocusaurusManifest } from './client-components.tsrx';
+
+type NavigationItem = {
+	label: string;
+	href?: string;
+	to?: string;
+	position?: 'left' | 'right';
+};
+
+type NavbarConfig = {
+	title?: string;
+	logo?: {
+		alt?: string;
+		href?: string;
+		src: string;
+	};
+	items?: NavigationItem[];
+};
+
+type FooterItem = {
+	label: string;
+	href?: string;
+	to?: string;
+};
+
+type FooterConfig = {
+	copyright?: string;
+	links?: Array<{
+		title: string;
+		items: FooterItem[];
+	}>;
+};
+
+type ClassicThemeConfig = {
+	navbar?: NavbarConfig;
+	footer?: FooterConfig;
+};
+
+type SidebarItem = {
+	type: string;
+	label: string;
+	href?: string;
+	key?: string;
+	items?: SidebarItem[];
+};
+
+type DocLink = {
+	title: string;
+	permalink: string;
+	description?: string;
+};
+
+type DocsVersion = {
+	label: string;
+	noIndex?: boolean;
+	docsSidebars: Record<string, SidebarItem[]>;
+};
+
+type DocMetadata = {
+	title?: string;
+	description?: string;
+	permalink?: string;
+	previous?: DocLink;
+	next?: DocLink;
+};
+
+type DocContent =
+	ComponentBody<Record<string, unknown>> & {
+		contentTitle?: string;
+		frontMatter?: {
+			title?: string;
+			description?: string;
+			noIndex?: boolean;
+		};
+		metadata?: DocMetadata;
+	};
+
+type RouteProps = {
+	attributes?: Record<string, unknown>;
+	routes?: RouteProps[];
+	path?: string;
+};
+
+const VersionContext = createContext<DocsVersion | null>(null);
+
+function isExternal(href: string): boolean {
+	return /^(?:[a-z][a-z\d+.-]*:|\/\/)/i.test(href);
+}
+
+function resolvedHref(item: { href?: string; to?: string }): string | null {
+	return item.to ?? item.href ?? null;
+}
+
+function withBaseUrl(baseUrl: string, href: string): string {
+	if (isExternal(href) || href.startsWith('/') || href.startsWith('#')) return href;
+	return `${baseUrl}${href.replace(/^\.\//, '')}`;
+}
+
+function absoluteUrl(siteUrl: string, href: string): string {
+	try {
+		return new URL(href, siteUrl).href;
+	} catch {
+		return href;
+	}
+}
+
+function sidebarKey(item: SidebarItem): string {
+	return item.key ?? item.href ?? `${item.type}:${item.label}`;
+}
+
+function navigationKey(item: NavigationItem | FooterItem): string {
+	return resolvedHref(item) ?? item.label;
+}
+
+function findSidebarCategory(items: SidebarItem[], href: string): SidebarItem | null {
+	for (const item of items) {
+		if (item.type !== 'category') continue;
+		if (item.href === href) return item;
+		const nested = findSidebarCategory(item.items ?? [], href);
+		if (nested !== null) return nested;
+	}
+	return null;
+}
+
+function categoryItems(version: DocsVersion, href: string): DocLink[] {
+	for (const sidebar of Object.values(version.docsSidebars)) {
+		const category = findSidebarCategory(sidebar, href);
+		if (category === null) continue;
+		return (category.items ?? []).flatMap(
+			(item) => item.href === undefined
+				? []
+				: [
+						{
+							title: item.label,
+							permalink: item.href,
+						},
+					],
+		);
+	}
+	return [];
+}
+
+function useDocsVersion(): DocsVersion {
+	const version = useContext(VersionContext);
+	if (version === null) {
+		throw new Error('[@octanejs/docusaurus] The classic DocRoot requires DocVersionRoot.');
+	}
+	return version;
+}
+
+function ThemeLink(props: {
+	href: string;
+	class?: string;
+	'aria-current'?: 'page';
+	children?: OctaneNode;
+}) @{
+	@if (isExternal(props.href)) {
+		<a
+			href={props.href}
+			class={props.class}
+			aria-current={props['aria-current']}
+		>{props.children}</a>
+	} @else {
+		<RouterLink
+			to={props.href}
+			class={props.class}
+			aria-current={props['aria-current']}
+		>{props.children}</RouterLink>
+	}
+}
+
+function Navbar(props: { config?: NavbarConfig }) @{
+	const manifest = useDocusaurusManifest();
+	const title = props.config?.title ?? manifest.site.title;
+	const brandHref = props.config?.logo?.href ?? manifest.baseUrl;
+	const items = props.config?.items ?? [];
+
+	<header class="octane-docs-navbar">
+		<ThemeLink href={brandHref} class="octane-docs-navbar__brand">
+			@if (props.config?.logo !== undefined) {
+				<img
+					src={withBaseUrl(manifest.baseUrl, props.config.logo.src)}
+					alt={props.config.logo.alt ?? title}
+				/>
+			}
+			<span>{title}</span>
+		</ThemeLink>
+		@if (items.length > 0) {
+			<nav aria-label="Primary">
+				<ul class="octane-docs-navbar__items">
+					@for (const item of items; key navigationKey(item)) {
+						@if (resolvedHref(item) !== null) {
+							<li>
+								<ThemeLink href={resolvedHref(item)!}>{item.label}</ThemeLink>
+							</li>
+						}
+					}
+				</ul>
+			</nav>
+		}
+	</header>
+}
+
+function Footer(props: { config?: FooterConfig }) @{
+	const groups = props.config?.links ?? [];
+	const copyright = props.config?.copyright;
+
+	@if (groups.length > 0 || copyright !== undefined) {
+		<footer class="octane-docs-footer">
+			@if (groups.length > 0) {
+				<ul class="octane-docs-footer__links">
+					@for (const group of groups; key group.title) {
+						<li>
+							<strong>{group.title}</strong>
+							<ul class="octane-docs-footer__items">
+								@for (const item of group.items; key navigationKey(item)) {
+									@if (resolvedHref(item) !== null) {
+										<li>
+											<ThemeLink href={resolvedHref(item)!}>{item.label}</ThemeLink>
+										</li>
+									}
+								}
+							</ul>
+						</li>
+					}
+				</ul>
+			}
+			@if (copyright !== undefined) {
+				<p class="octane-docs-footer__copyright">{copyright}</p>
+			}
+		</footer>
+	}
+}
+
+function SidebarItems(props: { items: SidebarItem[]; pathname: string }) @{
+	<ul>
+		@for (const item of props.items; key sidebarKey(item)) {
+			<li>
+				@if (item.type === 'category' && item.items !== undefined) {
+					<>
+						@if (item.href !== undefined) {
+							<ThemeLink
+								href={item.href}
+								class="octane-docs-sidebar__category"
+								aria-current={item.href === props.pathname ? 'page' : undefined}
+							>{item.label}</ThemeLink>
+						} @else {
+							<span class="octane-docs-sidebar__category">{item.label}</span>
+						}
+						<SidebarItems items={item.items} pathname={props.pathname} />
+					</>
+				} @else if (item.href !== undefined) {
+					<ThemeLink
+						href={item.href}
+						aria-current={item.href === props.pathname ? 'page' : undefined}
+					>{item.label}</ThemeLink>
+				} @else {
+					<span>{item.label}</span>
+				}
+			</li>
+		}
+	</ul>
+}
+
+function PageMetadata(props: {
+	title?: string;
+	description?: string;
+	permalink?: string;
+	noIndex?: boolean;
+}) @{
+	const manifest = useDocusaurusManifest();
+	const title =
+		props.title === undefined || props.title === manifest.site.title
+			? manifest.site.title
+			: `${props.title} | ${manifest.site.title}`;
+
+	<Head>
+		<Seo
+			title={title}
+			description={props.description}
+			canonical={props.permalink === undefined
+				? undefined
+				: absoluteUrl(manifest.site.url, props.permalink)}
+			openGraph={{ title, description: props.description }}
+			robots={props.noIndex === true ? { index: false, follow: false } : undefined}
+		/>
+	</Head>
+}
+
+function Paginator(props: { previous?: DocLink; next?: DocLink }) @{
+	@if (props.previous !== undefined || props.next !== undefined) {
+		<nav class="octane-docs-paginator" aria-label="Documentation pages">
+			<div>
+				@if (props.previous !== undefined) {
+					<ThemeLink href={props.previous.permalink}>← {props.previous.title}</ThemeLink>
+				}
+			</div>
+			<div class="octane-docs-paginator__next">
+				@if (props.next !== undefined) {
+					<ThemeLink href={props.next.permalink}>{props.next.title} →</ThemeLink>
+				}
+			</div>
+		</nav>
+	}
+}
+
+function CardList(props: { items: DocLink[] }) @{
+	<ul class="octane-docs-card-list">
+		@for (const item of props.items; key item.permalink) {
+			<li class="octane-docs-card">
+				<ThemeLink href={item.permalink}>{item.title}</ThemeLink>
+				@if (item.description !== undefined) {
+					<p>{item.description}</p>
+				}
+			</li>
+		}
+	</ul>
+}
+
+export function Root(props: { children?: OctaneNode }) @{
+	<>
+		{props.children}
+	</>
+}
+
+export function DocsRoot(props: { children?: OctaneNode }) @{
+	const manifest = useDocusaurusManifest();
+	const themeConfig = manifest.site.themeConfig as ClassicThemeConfig;
+
+	<div class="octane-docusaurus">
+		<Navbar config={themeConfig.navbar} />
+		{props.children}
+		<Footer config={themeConfig.footer} />
+	</div>
+}
+
+export function DocVersionRoot(props: { children?: OctaneNode; version: DocsVersion }) @{
+	<VersionContext.Provider value={props.version}>{props.children}</VersionContext.Provider>
+}
+
+export function DocRoot(props: {
+	children?: OctaneNode;
+	location: Location;
+	route: RouteProps;
+}) @{
+	const version = useDocsVersion();
+	const activeRoute = props.route.routes?.find((route) => route.path === props.location.pathname);
+	const sidebarId = activeRoute?.attributes?.sidebar;
+	const sidebar =
+		typeof sidebarId === 'string' ? version.docsSidebars[sidebarId] ?? [] : [];
+
+	<div class="octane-docs-layout">
+		@if (sidebar.length > 0) {
+			<aside class="octane-docs-sidebar" aria-label="Documentation sidebar">
+				<SidebarItems items={sidebar} pathname={props.location.pathname} />
+			</aside>
+		}
+		<main class="octane-docs-main">{props.children}</main>
+	</div>
+}
+
+export function DocItem(props: { content: DocContent }) @{
+	const manifest = useDocusaurusManifest();
+	const version = useDocsVersion();
+	const Content = props.content;
+	const metadata = Content.metadata ?? {};
+	const frontMatter = Content.frontMatter ?? {};
+	const title = frontMatter.title ?? metadata.title ?? Content.contentTitle;
+	const description = frontMatter.description ?? metadata.description;
+
+	<>
+		<PageMetadata
+			title={title}
+			description={description}
+			permalink={metadata.permalink}
+			noIndex={frontMatter.noIndex === true || version.noIndex === true || manifest.site.noIndex}
+		/>
+		<article class="octane-docs-article">
+			<Content />
+			<Paginator previous={metadata.previous} next={metadata.next} />
+		</article>
+	</>
+}
+
+export function DocCategoryGeneratedIndexPage(props: {
+	categoryGeneratedIndex: {
+		title: string;
+		description?: string;
+		permalink: string;
+		navigation?: {
+			previous?: DocLink;
+			next?: DocLink;
+		};
+	};
+}) @{
+	const version = useDocsVersion();
+	const page = props.categoryGeneratedIndex;
+	const items = categoryItems(version, page.permalink);
+	<div class="octane-docs-list-page">
+		<PageMetadata
+			title={page.title}
+			description={page.description}
+			permalink={page.permalink}
+			noIndex={version.noIndex}
+		/>
+		<h1>{page.title}</h1>
+		@if (page.description !== undefined) {
+			<p>{page.description}</p>
+		}
+		<CardList items={items} />
+		<Paginator previous={page.navigation?.previous} next={page.navigation?.next} />
+	</div>
+}
+
+export function DocTagsListPage(props: {
+	tags: Array<{ label: string; permalink: string; description?: string }>;
+	location: Location;
+}) @{
+	const version = useDocsVersion();
+	<div class="octane-docs-list-page">
+		<PageMetadata title="Tags" permalink={props.location.pathname} noIndex={version.noIndex} />
+		<h1>Tags</h1>
+		<CardList items={props.tags.map((tag) => ({ ...tag, title: tag.label }))} />
+	</div>
+}
+
+export function DocTagDocListPage(props: {
+	tag: {
+		label: string;
+		description?: string;
+		permalink: string;
+		items: DocLink[];
+	};
+}) @{
+	const version = useDocsVersion();
+	<div class="octane-docs-list-page">
+		<PageMetadata
+			title={props.tag.label}
+			description={props.tag.description}
+			permalink={props.tag.permalink}
+			noIndex={version.noIndex}
+		/>
+		<h1>{props.tag.label}</h1>
+		@if (props.tag.description !== undefined) {
+			<p>{props.tag.description}</p>
+		}
+		<CardList items={props.tag.items} />
+	</div>
+}

--- a/packages/docusaurus/src/theme.js
+++ b/packages/docusaurus/src/theme.js
@@ -1,0 +1,25 @@
+import { fileURLToPath } from 'node:url';
+
+const THEME_PATH = fileURLToPath(new URL('./theme', import.meta.url));
+const STYLES_PATH = fileURLToPath(new URL('./theme/styles.css', import.meta.url));
+
+/**
+ * Docusaurus theme plugin exposing Octane-authored docs route components.
+ *
+ * Add this function to `themes` in `docusaurus.config.*`. Docusaurus remains
+ * responsible for content/plugin loading; the Octane Vite bridge resolves the
+ * returned theme modules and imports the client stylesheet.
+ */
+export default function octaneClassicTheme() {
+	return {
+		name: '@octanejs/docusaurus-theme-classic',
+		getThemePath() {
+			return THEME_PATH;
+		},
+		getClientModules() {
+			return [STYLES_PATH];
+		},
+	};
+}
+
+export { octaneClassicTheme };

--- a/packages/docusaurus/src/theme/DocCategoryGeneratedIndexPage.js
+++ b/packages/docusaurus/src/theme/DocCategoryGeneratedIndexPage.js
@@ -1,0 +1,1 @@
+export { DocCategoryGeneratedIndexPage as default } from '../theme-components.tsrx';

--- a/packages/docusaurus/src/theme/DocItem.js
+++ b/packages/docusaurus/src/theme/DocItem.js
@@ -1,0 +1,1 @@
+export { DocItem as default } from '../theme-components.tsrx';

--- a/packages/docusaurus/src/theme/DocRoot.js
+++ b/packages/docusaurus/src/theme/DocRoot.js
@@ -1,0 +1,1 @@
+export { DocRoot as default } from '../theme-components.tsrx';

--- a/packages/docusaurus/src/theme/DocTagDocListPage.js
+++ b/packages/docusaurus/src/theme/DocTagDocListPage.js
@@ -1,0 +1,1 @@
+export { DocTagDocListPage as default } from '../theme-components.tsrx';

--- a/packages/docusaurus/src/theme/DocTagsListPage.js
+++ b/packages/docusaurus/src/theme/DocTagsListPage.js
@@ -1,0 +1,1 @@
+export { DocTagsListPage as default } from '../theme-components.tsrx';

--- a/packages/docusaurus/src/theme/DocVersionRoot.js
+++ b/packages/docusaurus/src/theme/DocVersionRoot.js
@@ -1,0 +1,1 @@
+export { DocVersionRoot as default } from '../theme-components.tsrx';

--- a/packages/docusaurus/src/theme/DocsRoot.js
+++ b/packages/docusaurus/src/theme/DocsRoot.js
@@ -1,0 +1,1 @@
+export { DocsRoot as default } from '../theme-components.tsrx';

--- a/packages/docusaurus/src/theme/Root.js
+++ b/packages/docusaurus/src/theme/Root.js
@@ -1,0 +1,1 @@
+export { Root as default } from '../theme-components.tsrx';

--- a/packages/docusaurus/src/theme/styles.css
+++ b/packages/docusaurus/src/theme/styles.css
@@ -1,0 +1,183 @@
+.octane-docusaurus {
+	--octane-docs-accent: #5a45ff;
+	--octane-docs-border: #d9dce5;
+	--octane-docs-muted: #5f6574;
+	--octane-docs-surface: #f7f7fa;
+	color: #1d2029;
+	font-family:
+		Inter,
+		ui-sans-serif,
+		system-ui,
+		-apple-system,
+		BlinkMacSystemFont,
+		'Segoe UI',
+		sans-serif;
+	line-height: 1.6;
+}
+
+.octane-docusaurus a {
+	color: var(--octane-docs-accent);
+	text-decoration-thickness: 0.08em;
+	text-underline-offset: 0.16em;
+}
+
+.octane-docs-navbar {
+	align-items: center;
+	border-bottom: 1px solid var(--octane-docs-border);
+	display: flex;
+	gap: 1.5rem;
+	min-height: 3.75rem;
+	padding: 0 1.5rem;
+}
+
+.octane-docs-navbar__brand {
+	color: inherit;
+	font-size: 1.05rem;
+	font-weight: 700;
+	text-decoration: none;
+}
+
+.octane-docs-navbar__items {
+	align-items: center;
+	display: flex;
+	gap: 1rem;
+	list-style: none;
+	margin: 0 0 0 auto;
+	padding: 0;
+}
+
+.octane-docs-layout {
+	display: grid;
+	grid-template-columns: minmax(13rem, 17rem) minmax(0, 1fr);
+	margin: 0 auto;
+	max-width: 90rem;
+	min-height: calc(100vh - 7.5rem);
+}
+
+.octane-docs-sidebar {
+	border-right: 1px solid var(--octane-docs-border);
+	padding: 1.5rem;
+}
+
+.octane-docs-sidebar ul {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.octane-docs-sidebar ul ul {
+	border-left: 1px solid var(--octane-docs-border);
+	margin: 0.35rem 0 0.75rem 0.45rem;
+	padding-left: 0.85rem;
+}
+
+.octane-docs-sidebar a {
+	border-radius: 0.35rem;
+	color: inherit;
+	display: block;
+	padding: 0.35rem 0.5rem;
+	text-decoration: none;
+}
+
+.octane-docs-sidebar a[aria-current='page'] {
+	background: color-mix(in srgb, var(--octane-docs-accent) 12%, transparent);
+	color: var(--octane-docs-accent);
+	font-weight: 650;
+}
+
+.octane-docs-sidebar__category {
+	color: var(--octane-docs-muted);
+	display: block;
+	font-size: 0.8rem;
+	font-weight: 700;
+	letter-spacing: 0.045em;
+	margin: 0.75rem 0 0.25rem;
+	text-transform: uppercase;
+}
+
+.octane-docs-main {
+	min-width: 0;
+	padding: clamp(1.5rem, 4vw, 4rem);
+}
+
+.octane-docs-article,
+.octane-docs-list-page {
+	margin: 0 auto;
+	max-width: 52rem;
+}
+
+.octane-docs-paginator {
+	border-top: 1px solid var(--octane-docs-border);
+	display: grid;
+	gap: 1rem;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	margin-top: 3rem;
+	padding-top: 1.5rem;
+}
+
+.octane-docs-paginator__next {
+	text-align: right;
+}
+
+.octane-docs-card-list {
+	display: grid;
+	gap: 1rem;
+	list-style: none;
+	padding: 0;
+}
+
+.octane-docs-card {
+	border: 1px solid var(--octane-docs-border);
+	border-radius: 0.6rem;
+	padding: 1rem 1.15rem;
+}
+
+.octane-docs-footer {
+	background: var(--octane-docs-surface);
+	border-top: 1px solid var(--octane-docs-border);
+	padding: 2rem 1.5rem;
+}
+
+.octane-docs-footer__links {
+	display: grid;
+	gap: 2rem;
+	grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+	list-style: none;
+	margin: 0 auto 1.5rem;
+	max-width: 70rem;
+	padding: 0;
+}
+
+.octane-docs-footer__items {
+	list-style: none;
+	padding: 0;
+}
+
+.octane-docs-footer__copyright {
+	color: var(--octane-docs-muted);
+	margin: 0 auto;
+	max-width: 70rem;
+}
+
+@media (max-width: 48rem) {
+	.octane-docs-navbar {
+		align-items: flex-start;
+		flex-direction: column;
+		gap: 0.5rem;
+		padding-block: 0.85rem;
+	}
+
+	.octane-docs-navbar__items {
+		flex-wrap: wrap;
+		margin-left: 0;
+	}
+
+	.octane-docs-layout {
+		display: block;
+	}
+
+	.octane-docs-sidebar {
+		border-bottom: 1px solid var(--octane-docs-border);
+		border-right: 0;
+	}
+}

--- a/packages/docusaurus/src/vite.js
+++ b/packages/docusaurus/src/vite.js
@@ -31,13 +31,16 @@ function serializableManifest(manifest) {
 }
 
 function clientRoutesModule(manifest) {
+	const clientModules = manifest.assets.clientModules
+		.map((specifier) => `import ${JSON.stringify(specifier)};\n`)
+		.join('');
 	const importers = [...collectDocusaurusRouteModuleReferences(manifest.routes)]
 		.sort(([left], [right]) => left.localeCompare(right))
 		.map(
 			([key, specifier]) => `\t${JSON.stringify(key)}: () => import(${JSON.stringify(specifier)}),`,
 		)
 		.join('\n');
-	return `import { createDocusaurusRoutes } from "@octanejs/docusaurus/client";
+	return `${clientModules}import { createDocusaurusRoutes } from "@octanejs/docusaurus/client";
 import manifest from ${JSON.stringify(DOCUSAURUS_MANIFEST_ID)};
 
 export { manifest };
@@ -136,6 +139,9 @@ export function docusaurusBridge(options = {}, shared = createSharedState(option
 			for (const source of Object.keys(manifest.content)) {
 				const resolved = path.isAbsolute(source) ? source : resolveDocusaurusId(source, manifest);
 				if (resolved !== null) this.addWatchFile?.(cleanId(resolved));
+			}
+			for (const clientModule of manifest.assets.clientModules) {
+				this.addWatchFile?.(cleanId(clientModule));
 			}
 		},
 		async watchChange() {

--- a/packages/docusaurus/tests/_fixtures/docusaurus-app.ts
+++ b/packages/docusaurus/tests/_fixtures/docusaurus-app.ts
@@ -10,6 +10,46 @@ export function createDocusaurusTestManifest(): DocusaurusManifest {
 		generatedFilesDir: '/site/.docusaurus',
 		outDir: '/site/build',
 		baseUrl: '/docs/',
+		site: {
+			title: 'Octane Docs',
+			tagline: 'Compiler-first documentation',
+			url: 'https://octane.example',
+			baseUrl: '/docs/',
+			favicon: 'img/favicon.svg',
+			noIndex: false,
+			themeConfig: {},
+			customFields: {},
+		},
+		i18n: {
+			defaultLocale: 'en',
+			locales: ['en'],
+			currentLocale: 'en',
+			localeConfigs: {
+				en: {
+					label: 'English',
+					direction: 'ltr',
+					htmlLang: 'en',
+					calendar: 'gregory',
+					path: 'en',
+					translate: false,
+					url: 'https://octane.example',
+					baseUrl: '/docs/',
+				},
+			},
+		},
+		siteMetadata: {
+			docusaurusVersion: '3.10.1',
+			pluginVersions: {},
+		},
+		document: {
+			htmlAttributes: { lang: 'en', dir: 'ltr' },
+			headTags: '',
+			preBodyTags: '',
+			postBodyTags: '',
+		},
+		assets: {
+			clientModules: [],
+		},
 		routesPaths: ['/docs/guide/intro', '/docs/guide/advanced'],
 		routes: [
 			{

--- a/packages/docusaurus/tests/_fixtures/site/docusaurus.config.mjs
+++ b/packages/docusaurus/tests/_fixtures/site/docusaurus.config.mjs
@@ -30,6 +30,33 @@ function fixtureContentPlugin(context) {
 		getPathsToWatch() {
 			return [path.join(context.siteDir, 'watched.txt')];
 		},
+		getClientModules() {
+			return [path.join(context.siteDir, 'src/client-module.css')];
+		},
+		injectHtmlTags() {
+			return {
+				headTags: [
+					{
+						tagName: 'meta',
+						attributes: { name: 'fixture-plugin', content: 'head' },
+					},
+				],
+				preBodyTags: [
+					{
+						tagName: 'div',
+						attributes: { id: 'fixture-before' },
+						innerHTML: 'before',
+					},
+				],
+				postBodyTags: [
+					{
+						tagName: 'div',
+						attributes: { id: 'fixture-after' },
+						innerHTML: 'after',
+					},
+				],
+			};
+		},
 	};
 }
 
@@ -53,8 +80,19 @@ function fixtureInitialThemePlugin(context) {
 
 export default {
 	title: 'Octane Docusaurus fixture',
+	tagline: 'A renderer-neutral fixture',
 	url: 'https://example.test',
 	baseUrl: '/docs/',
+	favicon: 'img/favicon.svg',
+	themeConfig: {
+		navbar: {
+			title: 'Fixture docs',
+			items: [{ label: 'Guide', to: '/docs/guide/intro' }],
+		},
+		footer: {
+			copyright: 'Fixture project',
+		},
+	},
 	onBrokenLinks: 'throw',
 	plugins: [
 		[

--- a/packages/docusaurus/tests/_fixtures/site/src/client-module.css
+++ b/packages/docusaurus/tests/_fixtures/site/src/client-module.css
@@ -1,0 +1,3 @@
+.fixture-client-module {
+	color: rebeccapurple;
+}

--- a/packages/docusaurus/tests/headless.test.ts
+++ b/packages/docusaurus/tests/headless.test.ts
@@ -33,6 +33,34 @@ describe('headless Docusaurus site loading', () => {
 
 		expect(manifest.docusaurusVersion).toBe(SUPPORTED_DOCUSARUS_VERSION);
 		expect(manifest.baseUrl).toBe('/docs/');
+		expect(manifest.site).toEqual(
+			expect.objectContaining({
+				title: 'Octane Docusaurus fixture',
+				tagline: 'A renderer-neutral fixture',
+				url: 'https://example.test',
+				baseUrl: '/docs/',
+				favicon: 'img/favicon.svg',
+				themeConfig: expect.objectContaining({
+					navbar: expect.objectContaining({ title: 'Fixture docs' }),
+				}),
+			}),
+		);
+		expect(manifest.i18n).toEqual(
+			expect.objectContaining({
+				defaultLocale: 'en',
+				currentLocale: 'en',
+				locales: ['en'],
+			}),
+		);
+		expect(manifest.document).toEqual({
+			htmlAttributes: { lang: 'en', dir: 'ltr' },
+			headTags: expect.stringContaining('name="fixture-plugin"'),
+			preBodyTags: expect.stringContaining('id="fixture-before"'),
+			postBodyTags: expect.stringContaining('id="fixture-after"'),
+		});
+		expect(manifest.assets.clientModules).toEqual([
+			path.join(fixture.siteDir, 'src/client-module.css'),
+		]);
 		expect(manifest.routesPaths).toEqual(expect.arrayContaining(['/custom', '/docs/guide/intro']));
 		expect(routes).toEqual(
 			expect.arrayContaining([

--- a/packages/docusaurus/tests/helpers.ts
+++ b/packages/docusaurus/tests/helpers.ts
@@ -3,17 +3,12 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 const PACKAGE_ROOT = path.resolve(import.meta.dirname, '..');
-const REPOSITORY_ROOT = path.resolve(PACKAGE_ROOT, '../..');
 const FIXTURE_ROOT = path.join(import.meta.dirname, '_fixtures/site');
 
 export function createSiteFixture() {
 	const siteDir = mkdtempSync(path.join(tmpdir(), 'octane-docusaurus-'));
 	cpSync(FIXTURE_ROOT, siteDir, { recursive: true });
-	symlinkSync(
-		path.join(REPOSITORY_ROOT, 'node_modules'),
-		path.join(siteDir, 'node_modules'),
-		'dir',
-	);
+	symlinkSync(path.join(PACKAGE_ROOT, 'node_modules'), path.join(siteDir, 'node_modules'), 'dir');
 	return {
 		siteDir,
 		dispose() {

--- a/packages/docusaurus/tests/hydration.test.ts
+++ b/packages/docusaurus/tests/hydration.test.ts
@@ -14,6 +14,7 @@ const originalUrl = window.location.href;
 
 afterEach(() => {
 	window.history.replaceState(null, '', originalUrl);
+	document.head.replaceChildren();
 	document.body.replaceChildren();
 });
 
@@ -50,10 +51,12 @@ describe('Docusaurus hydration', () => {
 			url,
 		);
 		window.history.replaceState(null, '', url);
+		document.head.innerHTML = serverResult.head ?? '';
 
 		const container = document.createElement('div');
 		container.innerHTML = serverResult.html;
 		document.body.appendChild(container);
+		const serverTitle = document.head.querySelector('title');
 		const serverSection = container.querySelector('section');
 		const serverArticle = container.querySelector('article');
 		const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -68,6 +71,8 @@ describe('Docusaurus hydration', () => {
 			expect(errors).not.toHaveBeenCalled();
 			expect(container.querySelector('section')).toBe(serverSection);
 			expect(container.querySelector('article')).toBe(serverArticle);
+			expect(document.head.querySelector('title')).toBe(serverTitle);
+			expect(document.head.querySelectorAll('title')).toHaveLength(1);
 			expect(container.querySelector('h1')?.textContent).toBe('Introduction');
 			expect(loads).not.toContain('advanced');
 

--- a/packages/docusaurus/tests/package-boundary.test.ts
+++ b/packages/docusaurus/tests/package-boundary.test.ts
@@ -18,9 +18,11 @@ describe('@octanejs/docusaurus package boundary', () => {
 				'.': expect.any(Object),
 				'./client': expect.any(Object),
 				'./mdx': expect.any(Object),
+				'./theme': expect.any(Object),
 				'./vite': expect.any(Object),
 			}),
 		);
 		expect(manifest.dependencies['@octanejs/remix-router']).toBe('workspace:*');
+		expect(manifest.dependencies['@octanejs/seo']).toBe('workspace:*');
 	});
 });

--- a/packages/docusaurus/tests/ssr/_fixtures/classic-theme.tsrx
+++ b/packages/docusaurus/tests/ssr/_fixtures/classic-theme.tsrx
@@ -1,0 +1,6 @@
+export function ClassicIntroContent() @{
+	<>
+		<h1>Introduction</h1>
+		<p>Classic theme body</p>
+	</>
+}

--- a/packages/docusaurus/tests/ssr/server.test.ts
+++ b/packages/docusaurus/tests/ssr/server.test.ts
@@ -1,9 +1,145 @@
 import { describe, expect, it } from 'vitest';
-import { prerenderDocusaurusRoute } from '@octanejs/docusaurus/server';
+import { prerenderDocusaurusDocument, prerenderDocusaurusRoute } from '@octanejs/docusaurus/server';
+import {
+	DocCategoryGeneratedIndexPage,
+	DocItem,
+	DocRoot,
+	DocsRoot,
+	DocVersionRoot,
+} from '../../src/theme-components.tsrx';
+import type { DocusaurusRouteModuleRegistry } from '../../types/client.js';
+import type { DocusaurusManifest } from '../../types/index.js';
 import {
 	createDocusaurusTestManifest,
 	createDocusaurusTestRegistry,
 } from '../_fixtures/docusaurus-app.js';
+import { ClassicIntroContent } from './_fixtures/classic-theme.tsrx';
+
+function classicThemeFixture(): {
+	manifest: DocusaurusManifest;
+	registry: DocusaurusRouteModuleRegistry;
+} {
+	const manifest = createDocusaurusTestManifest();
+	manifest.site.themeConfig = {
+		navbar: {
+			title: 'Octane',
+			items: [{ label: 'Guide', to: '/docs/guide/intro' }],
+		},
+		footer: {
+			links: [
+				{
+					title: 'Learn',
+					items: [{ label: 'Introduction', to: '/docs/guide/intro' }],
+				},
+			],
+			copyright: 'Octane project',
+		},
+	};
+	manifest.routes = [
+		{
+			id: 'root/docs',
+			path: '/docs/guide',
+			component: 'classic:DocsRoot',
+			exact: false,
+			plugin: { name: 'docusaurus-plugin-content-docs', id: 'default' },
+			children: [
+				{
+					id: 'root/docs/version',
+					path: '/docs/guide',
+					component: 'classic:DocVersionRoot',
+					exact: false,
+					props: {
+						version: {
+							label: 'Next',
+							noIndex: false,
+							docsSidebars: {
+								guide: [
+									{
+										type: 'category',
+										label: 'Start',
+										href: '/docs/guide/start',
+										items: [
+											{
+												type: 'link',
+												label: 'Introduction',
+												href: '/docs/guide/intro',
+											},
+										],
+									},
+								],
+							},
+						},
+					},
+					children: [
+						{
+							id: 'root/docs/version/root',
+							path: '/docs/guide',
+							component: 'classic:DocRoot',
+							exact: false,
+							children: [
+								{
+									id: 'root/docs/version/root/intro',
+									path: '/docs/guide/intro',
+									component: 'classic:DocItem',
+									exact: true,
+									modules: { content: 'classic:IntroContent' },
+									attributes: { sidebar: 'guide' },
+									children: [],
+								},
+								{
+									id: 'root/docs/version/root/start',
+									path: '/docs/guide/start',
+									component: 'classic:Category',
+									exact: true,
+									props: {
+										categoryGeneratedIndex: {
+											title: 'Start',
+											description: 'Begin with the Octane guide.',
+											permalink: '/docs/guide/start',
+											navigation: {
+												next: {
+													title: 'Introduction',
+													permalink: '/docs/guide/intro',
+												},
+											},
+										},
+									},
+									attributes: { sidebar: 'guide' },
+									children: [],
+								},
+							],
+						},
+					],
+				},
+			],
+		},
+	];
+	const module = (value: unknown) => async () => ({ default: value });
+	return {
+		manifest,
+		registry: {
+			'classic:DocsRoot': module(DocsRoot),
+			'classic:DocVersionRoot': module(DocVersionRoot),
+			'classic:DocRoot': module(DocRoot),
+			'classic:DocItem': module(DocItem),
+			'classic:Category': module(DocCategoryGeneratedIndexPage),
+			'classic:IntroContent': async () => ({
+				default: ClassicIntroContent,
+				contentTitle: 'Introduction',
+				frontMatter: {},
+				metadata: {
+					title: 'Introduction',
+					description: 'Start building with Octane.',
+					permalink: '/docs/guide/intro',
+					next: {
+						title: 'Advanced',
+						permalink: '/docs/guide/advanced',
+					},
+				},
+			}),
+		},
+	};
+}
 
 describe('Docusaurus static rendering', () => {
 	it('prerenders a manifest route pathname without loading sibling content', async () => {
@@ -24,8 +160,102 @@ describe('Docusaurus static rendering', () => {
 		expect(result.html).toContain('<h1>Introduction</h1>');
 		expect(result.html).toContain('<p>Introduction body</p>');
 		expect(result.html).not.toContain('Advanced body');
-		expect(result.head).toBe('');
+		expect(result.head).toContain('<title>Octane Docs</title>');
+		expect(result.head).toContain('name="viewport"');
 		expect(result.css).toBe('');
 		expect(loads).toEqual(['layout', 'plugin', 'section', 'item', 'intro', 'related', 'kind']);
+	});
+
+	it('renders the Octane classic docs shell and page metadata', async () => {
+		const { manifest, registry } = classicThemeFixture();
+		const result = await prerenderDocusaurusRoute('/docs/guide/intro', manifest, registry);
+
+		expect(result).not.toBeInstanceOf(Response);
+		if (result instanceof Response) throw new Error('Unexpected redirect response.');
+
+		expect(result.html).toContain('class="octane-docs-navbar"');
+		expect(result.html).toContain('aria-label="Documentation sidebar"');
+		expect(result.html).toContain('aria-current="page"');
+		expect(result.html).toContain('<p>Classic theme body</p>');
+		expect(result.html).toContain('href="/docs/guide/advanced"');
+		expect(result.html).toContain('Octane project');
+		expect(result.head).toContain('<title>Introduction | Octane Docs</title>');
+		expect(result.head).toContain('content="Start building with Octane."');
+		expect(result.head).toContain('href="https://octane.example/docs/guide/intro"');
+	});
+
+	it('derives generated category cards from Docusaurus sidebar metadata', async () => {
+		const { manifest, registry } = classicThemeFixture();
+		const result = await prerenderDocusaurusRoute('/docs/guide/start', manifest, registry);
+
+		expect(result).not.toBeInstanceOf(Response);
+		if (result instanceof Response) throw new Error('Unexpected redirect response.');
+
+		expect(result.html).toContain('<h1>Start</h1>');
+		expect(result.html).toContain('Begin with the Octane guide.');
+		expect(result.html).toContain('class="octane-docs-card"');
+		expect(result.html).toContain('href="/docs/guide/intro"');
+		expect(result.head).toContain('<title>Start | Octane Docs</title>');
+		expect(result.head).toContain('href="https://octane.example/docs/guide/start"');
+	});
+
+	it('composes route output, plugin tags, build assets, and hydration into a document', async () => {
+		const manifest = createDocusaurusTestManifest();
+		manifest.document = {
+			htmlAttributes: { lang: 'en', dir: 'ltr' },
+			headTags: '<meta name="plugin-head" content="ready">',
+			preBodyTags: '<div id="before-root">before</div>',
+			postBodyTags: '<div id="after-root">after</div>',
+		};
+		const result = await prerenderDocusaurusDocument(
+			'/docs/guide/intro',
+			manifest,
+			createDocusaurusTestRegistry(),
+			{
+				nonce: 'phase-6',
+				document: {
+					htmlAttributes: { 'data-build': '<phase&6>' },
+					bodyAttributes: { class: 'docs-body', 'data-ready': true },
+					assets: {
+						stylesheets: [
+							'assets/site.css',
+							{
+								href: '/shared.css',
+								integrity: 'sha384-fixture',
+								crossOrigin: 'anonymous',
+							},
+						],
+						modulePreloads: ['assets/route.js', 'assets/route.js'],
+						scripts: [{ src: 'assets/vendor.js', async: true }],
+					},
+					hydrate: 'assets/hydrate.js',
+				},
+			},
+		);
+
+		expect(result).not.toBeInstanceOf(Response);
+		if (result instanceof Response) throw new Error('Unexpected redirect response.');
+
+		expect(result.bodyHtml).toContain('<h1>Introduction</h1>');
+		expect(result.html).toMatch(/^<!DOCTYPE html>\n<html lang="en" dir="ltr"/);
+		expect(result.html).toContain('data-build="&lt;phase&amp;6&gt;"');
+		expect(result.html).toContain('<meta charset="UTF-8">');
+		expect(result.html).toContain('content="Docusaurus v3.10.1"');
+		expect(result.html).toContain('<meta name="plugin-head" content="ready">');
+		expect(result.html).toContain('<link rel="stylesheet" href="/docs/assets/site.css">');
+		expect(result.html).toContain(
+			'<link rel="stylesheet" href="/shared.css" integrity="sha384-fixture" crossorigin="anonymous">',
+		);
+		expect(result.html.match(/rel="modulepreload"/g)).toHaveLength(1);
+		expect(result.html).toContain(
+			'<script type="module" nonce="phase-6" src="/docs/assets/vendor.js" async></script>',
+		);
+		expect(result.html).toContain('<body class="docs-body" data-ready>');
+		expect(result.html).toContain('<div id="before-root">before</div>');
+		expect(result.html).toContain('<div id="__docusaurus">');
+		expect(result.html).toContain('<div id="after-root">after</div>');
+		expect(result.html).toContain(
+			'<script type="module" data-octane-hydrate nonce="phase-6" src="/docs/assets/hydrate.js"></script>',
+		);
 	});
 });

--- a/packages/docusaurus/tests/theme.test.ts
+++ b/packages/docusaurus/tests/theme.test.ts
@@ -1,0 +1,62 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { createDocusaurusManifest, loadDocusaurusSite } from '../src/index.js';
+import octaneClassicTheme, { octaneClassicTheme as namedTheme } from '../src/theme.js';
+import { createSiteFixture } from './helpers.js';
+
+describe('Octane Docusaurus classic theme', () => {
+	it('exposes concrete Octane theme modules and its client stylesheet', () => {
+		const plugin = octaneClassicTheme();
+		const themePath = plugin.getThemePath();
+
+		expect(namedTheme).toBe(octaneClassicTheme);
+		expect(plugin.name).toBe('@octanejs/docusaurus-theme-classic');
+		expect(path.isAbsolute(themePath)).toBe(true);
+		for (const moduleName of [
+			'Root',
+			'DocsRoot',
+			'DocVersionRoot',
+			'DocRoot',
+			'DocItem',
+			'DocCategoryGeneratedIndexPage',
+			'DocTagsListPage',
+			'DocTagDocListPage',
+		]) {
+			expect(existsSync(path.join(themePath, `${moduleName}.js`))).toBe(true);
+		}
+		expect(plugin.getClientModules()).toEqual([path.join(themePath, 'styles.css')]);
+	});
+
+	it('loads through the real Docusaurus theme lifecycle', async () => {
+		const fixture = createSiteFixture();
+		try {
+			const configFile = path.join(fixture.siteDir, 'docusaurus.config.mjs');
+			const themeModule = pathToFileURL(path.resolve(import.meta.dirname, '../src/theme.js')).href;
+			const config = readFileSync(configFile, 'utf8')
+				.replace(
+					"import path from 'node:path';",
+					`import path from 'node:path';\nimport octaneClassicTheme from ${JSON.stringify(themeModule)};`,
+				)
+				.replace(
+					'themes: [fixtureInitialThemePlugin, fixtureThemePlugin],',
+					'themes: [fixtureInitialThemePlugin, fixtureThemePlugin, octaneClassicTheme],',
+				);
+			writeFileSync(configFile, config);
+
+			const manifest = await createDocusaurusManifest(
+				await loadDocusaurusSite({ siteDir: fixture.siteDir }),
+			);
+			const themePath = octaneClassicTheme().getThemePath();
+
+			expect(manifest.aliases.theme.DocItem).toBe(path.join(themePath, 'DocItem.js'));
+			expect(manifest.aliases.theme.DocRoot).toBe(path.join(themePath, 'DocRoot.js'));
+			expect(manifest.assets.clientModules).toEqual(
+				expect.arrayContaining([path.join(themePath, 'styles.css')]),
+			);
+		} finally {
+			fixture.dispose();
+		}
+	});
+});

--- a/packages/docusaurus/tests/vite.test.ts
+++ b/packages/docusaurus/tests/vite.test.ts
@@ -45,6 +45,9 @@ describe('Docusaurus Vite bridge', () => {
 		expect(virtualModule).toContain(
 			'import { createDocusaurusRoutes } from "@octanejs/docusaurus/client";',
 		);
+		expect(virtualModule).toContain(
+			`import ${JSON.stringify(path.join(fixture.siteDir, 'src/client-module.css'))};`,
+		);
 		expect(virtualModule).toContain('import("@site/src/pages/custom.js")');
 		expect(virtualModule).toContain('import("@theme/DocItem")');
 		expect(virtualModule).toContain('import("@site/docs/intro.md")');
@@ -89,6 +92,7 @@ describe('Docusaurus Vite bridge', () => {
 
 		expect(addWatchFile).toHaveBeenCalledWith(path.join(fixture.siteDir, 'docusaurus.config.mjs'));
 		expect(addWatchFile).toHaveBeenCalledWith(path.join(fixture.siteDir, 'watched.txt'));
+		expect(addWatchFile).toHaveBeenCalledWith(path.join(fixture.siteDir, 'src/client-module.css'));
 		expect(
 			addWatchFile.mock.calls.some(
 				([value]) => value === path.join(fixture.siteDir, 'docs/intro.md'),

--- a/packages/docusaurus/types/index.d.ts
+++ b/packages/docusaurus/types/index.d.ts
@@ -77,6 +77,46 @@ export interface DocusaurusManifestAliases {
 	themeInit: Record<string, string>;
 }
 
+export interface DocusaurusManifestSite {
+	title: string;
+	tagline: string;
+	url: string;
+	baseUrl: string;
+	favicon?: string;
+	noIndex: boolean;
+	trailingSlash?: boolean;
+	themeConfig: Record<string, any>;
+	customFields: Record<string, any>;
+}
+
+export interface DocusaurusLocaleConfig {
+	label: string;
+	direction: 'ltr' | 'rtl';
+	htmlLang: string;
+	calendar: string;
+	path: string;
+	translate: boolean;
+	url: string;
+	baseUrl: string;
+}
+
+export interface DocusaurusManifestI18n {
+	defaultLocale: string;
+	locales: string[];
+	currentLocale: string;
+	localeConfigs: Record<string, DocusaurusLocaleConfig>;
+}
+
+export interface DocusaurusManifestDocument {
+	htmlAttributes: {
+		lang: string;
+		dir: string;
+	};
+	headTags: string;
+	preBodyTags: string;
+	postBodyTags: string;
+}
+
 export interface DocusaurusManifest {
 	schemaVersion: 1;
 	docusaurusVersion: string;
@@ -84,6 +124,13 @@ export interface DocusaurusManifest {
 	generatedFilesDir: string;
 	outDir: string;
 	baseUrl: string;
+	site: DocusaurusManifestSite;
+	i18n: DocusaurusManifestI18n;
+	siteMetadata: Record<string, any>;
+	document: DocusaurusManifestDocument;
+	assets: {
+		clientModules: string[];
+	};
 	routesPaths: string[];
 	routes: DocusaurusManifestRoute[];
 	globalData: Record<string, unknown>;

--- a/packages/docusaurus/types/server.d.ts
+++ b/packages/docusaurus/types/server.d.ts
@@ -8,8 +8,49 @@ export interface DocusaurusPrerenderOptions extends RenderOptions {
 	requestContext?: unknown;
 }
 
+export interface DocusaurusLinkAsset {
+	href: string;
+	integrity?: string;
+	crossOrigin?: 'anonymous' | 'use-credentials';
+	referrerPolicy?: string;
+	media?: string;
+}
+
+export interface DocusaurusScriptAsset {
+	src: string;
+	type?: string;
+	async?: boolean;
+	defer?: boolean;
+	integrity?: string;
+	crossOrigin?: 'anonymous' | 'use-credentials';
+	referrerPolicy?: string;
+}
+
+export interface DocusaurusDocumentAssets {
+	stylesheets?: Array<string | DocusaurusLinkAsset>;
+	modulePreloads?: Array<string | DocusaurusLinkAsset>;
+	scripts?: Array<string | DocusaurusScriptAsset>;
+}
+
+export interface DocusaurusDocumentOptions {
+	rootId?: string;
+	nonce?: string;
+	htmlAttributes?: Record<string, string | boolean | null | undefined>;
+	bodyAttributes?: Record<string, string | boolean | null | undefined>;
+	assets?: DocusaurusDocumentAssets;
+	hydrate?: string | DocusaurusScriptAsset;
+}
+
+export interface DocusaurusDocumentPrerenderOptions extends DocusaurusPrerenderOptions {
+	document?: DocusaurusDocumentOptions;
+}
+
 export interface DocusaurusPrerenderResult extends RenderResult {
 	context: StaticHandlerContext;
+}
+
+export interface DocusaurusDocumentPrerenderResult extends DocusaurusPrerenderResult {
+	bodyHtml: string;
 }
 
 export declare function createDocusaurusStaticHandler(
@@ -24,3 +65,16 @@ export declare function prerenderDocusaurusRoute(
 	registry: DocusaurusRouteModuleRegistry,
 	options?: DocusaurusPrerenderOptions,
 ): Promise<DocusaurusPrerenderResult | Response>;
+
+export declare function renderDocusaurusDocument(
+	rendered: RenderResult,
+	manifest: DocusaurusManifest,
+	options?: DocusaurusDocumentOptions,
+): string;
+
+export declare function prerenderDocusaurusDocument(
+	request: Request | string | URL,
+	manifest: DocusaurusManifest,
+	registry: DocusaurusRouteModuleRegistry,
+	options?: DocusaurusDocumentPrerenderOptions,
+): Promise<DocusaurusDocumentPrerenderResult | Response>;

--- a/packages/docusaurus/types/theme.d.ts
+++ b/packages/docusaurus/types/theme.d.ts
@@ -1,0 +1,8 @@
+export interface OctaneDocusaurusThemePlugin {
+	name: '@octanejs/docusaurus-theme-classic';
+	getThemePath(): string;
+	getClientModules(): string[];
+}
+
+export declare function octaneClassicTheme(): OctaneDocusaurusThemePlugin;
+export default octaneClassicTheme;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3990,6 +3990,9 @@ importers:
       '@octanejs/remix-router':
         specifier: workspace:*
         version: link:../remix-router
+      '@octanejs/seo':
+        specifier: workspace:*
+        version: link:../seo
       github-slugger:
         specifier: 1.5.0
         version: 1.5.0


### PR DESCRIPTION
## Summary
- add serializable Docusaurus document, i18n, site metadata, and client-module discovery
- add full document composition with plugin tags, build assets, hydration, base-URL handling, and CSP nonces
- add a first-party Octane classic docs theme and correct nested repeated-path route adaptation

## Why
- Phase 5 stopped at route SSR and hydration; a complete Docusaurus site still needed the document shell, plugin assets, and Octane-native theme components.

## Changes
- expose `@octanejs/docusaurus/theme` with docs, navbar, footer, sidebar, generated-category, tags, pagination, and SEO components
- feed plugin client modules into Vite and preserve Docusaurus-injected head/body tags
- add `renderDocusaurusDocument` and `prerenderDocusaurusDocument`
- relativize nested Docusaurus absolute route paths and fix clean-worktree fixture dependency resolution
- add a patch changeset and update package inventory and phase documentation

## Validation
- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [ ] `pnpm test` (full suite not run)
- [x] targeted tests: `pnpm exec vitest run --project docusaurus --project docusaurus-ssr` (29 passed)
- [x] `pnpm packages:inventory:check`
- [x] `pnpm tsrx-decls:check`
- [x] `pnpm changeset:check`
- [x] `pnpm packages:pack:check` (57 package tarballs)

## Risk / follow-ups
- The initial classic theme intentionally covers docs routes; broader classic-theme parity and CLI `start`/`build` remain later phases.
- React theme modules and swizzles still require Octane equivalents.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SSR HTML assembly (trusted plugin HTML vs escaped assets), routing correctness for nested docs layouts, and new public `./theme` and document APIs; scope is bounded to the docusaurus package with strong test coverage.
> 
> **Overview**
> **Phase 6** for `@octanejs/docusaurus`: full HTML document composition, richer manifests, plugin client assets in Vite, an Octane-native classic docs theme, and a fix for nested layout routes that reuse the same absolute path.
> 
> The manifest now carries **serializable site config**, **i18n**, **plugin-injected HTML tags**, and **discovered client modules** (`getClientModules`). The Vite route virtual module **side-effect-imports** those modules so theme CSS enters client/SSR graphs, with matching watch entries.
> 
> **`prerenderDocusaurusDocument`** / **`renderDocusaurusDocument`** wrap route prerender output in a complete `<!DOCTYPE html>` page: locale `html` attrs, favicon, trusted plugin head/body tags, escaped build assets (deduped), optional **CSP `nonce`**, hydration script on `#__docusaurus`, plus **`bodyHtml`** for hosts that only need the router root. **`prerenderDocusaurusRoute`** still exists for custom outer HTML.
> 
> New **`@octanejs/docusaurus/theme`** (`octaneClassicTheme`) supplies Octane route modules (navbar/footer, recursive sidebar, doc/tag/category pages, prev/next, **`@octanejs/seo`** metadata). The router provider injects default site **SEO/viewport** in `<Head>`.
> 
> **Nested Docusaurus routes** that share an absolute pathname are **relativized** when building the Remix route tree so layout nesting matches upstream.
> 
> Docs, changeset, and tests cover headless manifest fields, document composition, classic SSR shell, theme lifecycle, and Vite client-module wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b663a3457313ac6e44f06f6312c1bf7d6f760453. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->