### PR TITLE
fix(lynx): emit unquoted nodes-ref attribute selector for native SelectorQuery

### DIFF
--- a/packages/lynx/src/core/nodes-ref.ts
+++ b/packages/lynx/src/core/nodes-ref.ts
@@ -8,7 +8,10 @@ export function createLynxNodesRefSelector(root: number, id: number, generation:
 	positiveSafeInteger(root, 'selector root');
 	positiveSafeInteger(id, 'selector id');
 	positiveSafeInteger(generation, 'selector generation');
-	return `[${LYNX_NODES_REF_ATTRIBUTE}="r${root}-h${id}-g${generation}"]`;
+	// Native Lynx attribute-selector matching compares the text after `=`
+	// verbatim without stripping quotes, so the value must stay unquoted; the
+	// token is a plain CSS identifier, so DOM `querySelector` accepts it too.
+	return `[${LYNX_NODES_REF_ATTRIBUTE}=r${root}-h${id}-g${generation}]`;
 }
 
 /** Immutable native identity captured by one background query handle. */


### PR DESCRIPTION
## Summary
- Emit the NodesRef attribute selector without quotes: `[octane-ref=r1-h2-g3]` instead of `[octane-ref="r1-h2-g3"]`.

## Why
- Native Lynx attribute-selector matching takes the text after `=` **verbatim, quotes included** (`core/renderer/dom/selector/matching/attribute_selector_matching.cc` in lynx-family/lynx: `GetSelectorAttrKeyOpValue` slices the raw selector string and compares with `EQ`). The quoted form therefore never matches a native element, and every selector-query operation — `invoke`, `measure`, `fields`, `setNativeProps` — failed with native code 2 (node not found) on device.
- Observed on Lynx Explorer 3.9 (iOS): `ref.invoke('autoScroll', …)` from the Product Gallery tutorial port rejected with `Octane Lynx NodesRef invoke failed with native code 2`; with this change it scrolls.
- The token is a plain CSS identifier (`r<digits>-h<digits>-g<digits>`), so the unquoted form stays valid for DOM `querySelector` in the JavaScript testing environment — the existing selector-shaped tests pass unchanged.

## Changes
- `createLynxNodesRefSelector` emits the unquoted form, with a comment pinning the native constraint.

## Validation
- [x] `vitest run --project lynx` — 259 tests passed
- [x] `tsgo --noEmit -p packages/lynx/tsconfig.json`
- [x] `prettier --check` on the changed file
- [x] device evidence: `invoke('autoScroll')` succeeds on Lynx Explorer 3.9 (iOS) with this change

## Risk / follow-ups
- If a future ref token ever needs non-identifier characters the selector would need escaping instead; today's tokens are digits and dashes only. No changeset: `@octanejs/lynx` is private.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the selector string used for all native NodesRef operations; wrong format breaks every selector-query call on device, but the change is narrowly scoped and validated on Lynx Explorer.
> 
> **Overview**
> **Fixes Lynx selector-query node lookup** by changing `createLynxNodesRefSelector` to emit `[octane-ref=r1-h2-g3]` instead of a quoted value after `=`.
> 
> Native Lynx attribute matching compares the substring after `=` literally (quotes included), so the old quoted form never matched elements and **invoke, measure, fields, and setNativeProps** failed with native code 2 (node not found) on device. Ref tokens are plain CSS identifiers, so the unquoted selector stays valid for DOM `querySelector` in tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9aebf644cb16fe78402aa3d7063325951e0e0ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->