### PR TITLE
fix(lynx): unwrap native event element references in worklet arguments

### DIFF
--- a/packages/lynx/src/core/worklets.ts
+++ b/packages/lynx/src/core/worklets.ts
@@ -233,6 +233,12 @@ function markerCount(value: object): number {
 interface CloneState {
 	readonly active: Set<object>;
 	readonly clones: Map<object, LynxWorkletValue>;
+	/**
+	 * Unwrap the native event envelope's `{ elementRefptr }` wrappers to their
+	 * raw main-thread element by identity instead of rejecting them. Only legal
+	 * for worklet arguments, which never leave the main thread.
+	 */
+	readonly unwrapElementReferences?: boolean;
 }
 
 function cloneValue(value: unknown, label: string, state: CloneState): LynxWorkletValue {
@@ -253,6 +259,24 @@ function cloneValue(value: unknown, label: string, state: CloneState): LynxWorkl
 	if (state.active.has(value)) fail(label, 'contains a cycle.');
 	const existing = state.clones.get(value);
 	if (existing !== undefined) return existing;
+	if (
+		state.unwrapElementReferences === true &&
+		!Array.isArray(value) &&
+		own(value, 'elementRefptr')
+	) {
+		// The pinned Lynx event envelope marks element targets with a wrapper
+		// object; the worklet observes the raw main-thread element, matching the
+		// value a `main-thread:ref` cell holds.
+		// PrimJS surfaces the element as an engine-owned reference whose typeof is
+		// not necessarily 'object'; reject only a missing reference.
+		const node = (value as { elementRefptr: unknown }).elementRefptr;
+		if (node === null || node === undefined) {
+			fail(`${label}.elementRefptr`, 'must reference a native element.');
+		}
+		const reference = node as LynxWorkletValue;
+		state.clones.set(value, reference);
+		return reference;
+	}
 
 	state.active.add(value);
 	try {
@@ -343,6 +367,19 @@ export function isolateLynxWorkletValue<T extends LynxWorkletValue>(
 		active: new Set(),
 		clones: new Map(),
 	}) as T;
+}
+
+/**
+ * Validate and copy main-thread worklet arguments. Native event envelopes are
+ * data except for `{ elementRefptr }` target wrappers, which pass through as
+ * their raw main-thread element by identity.
+ */
+export function isolateLynxWorkletArguments(values: readonly unknown[]): readonly unknown[] {
+	return cloneValue(values as LynxWorkletValue[], 'worklet arguments', {
+		active: new Set(),
+		clones: new Map(),
+		unwrapElementReferences: true,
+	}) as unknown as readonly unknown[];
 }
 
 export function assertLynxWorkletValue(
@@ -715,8 +752,8 @@ export function createLynxMainThreadWorkletRegistry(
 			...(captures === undefined ? null : { _c: captures as LynxWorkletRecord }),
 			_owlt: token,
 		};
-		const args = isolateLynxWorkletValue(params as LynxWorkletValue[], 'worklet arguments');
-		return definition.implementation.apply(receiver, args);
+		const args = isolateLynxWorkletArguments(params);
+		return definition.implementation.apply(receiver, args as unknown[]);
 	};
 
 	return {

--- a/packages/lynx/tests/worklets-core.test.ts
+++ b/packages/lynx/tests/worklets-core.test.ts
@@ -122,6 +122,46 @@ describe('Lynx main-thread worklets', () => {
 		background.close();
 	});
 
+	it('unwraps native event element references in worklet arguments', () => {
+		// The pinned Lynx event envelope marks `target`/`currentTarget` with an
+		// `{ elementRefptr }` wrapper holding a raw main-thread element. That
+		// element must reach the worklet by identity while sibling event data is
+		// still isolated by copy.
+		const nativeNode = Object.freeze({ native: 'element' });
+		const seen: unknown[] = [];
+		const descriptor = registerMainThreadWorklet(
+			'test:event-envelope',
+			undefined,
+			function (event) {
+				seen.push(event);
+				return true;
+			},
+			{ file: 'worklets.test.ts', line: 1, column: 0 },
+		);
+		const registry = createLynxMainThreadWorkletRegistry();
+		const active = registry.activate(descriptor);
+		const detail = { scrollTop: 12, scrollHeight: 340 };
+		const event = {
+			type: 'scroll',
+			detail,
+			target: { elementRefptr: nativeNode },
+			currentTarget: { elementRefptr: nativeNode },
+		};
+
+		expect(registry.runWorklet(active, [event])).toBe(true);
+		const received = seen[0] as {
+			detail: typeof detail;
+			target: unknown;
+			currentTarget: unknown;
+		};
+		expect(received.target).toBe(nativeNode);
+		expect(received.currentTarget).toBe(nativeNode);
+		expect(received.detail).toEqual(detail);
+		expect(received.detail).not.toBe(detail);
+		registry.release(active);
+		registry.close();
+	});
+
 	it('keeps ref cells live only for an explicit worklet activation', () => {
 		const ref = createLynxMainThreadRefDescriptor('test:counter');
 		const descriptor = registerMainThreadWorklet(


### PR DESCRIPTION
## Summary
- Main-thread worklet arguments now unwrap the native event envelope's `{ elementRefptr }` target wrappers to the raw main-thread element instead of rejecting the whole event.

## Why
- On a native engine, Lynx dispatches worklet events whose `target`/`currentTarget` are `{ elementRefptr: <element> }` wrappers (the pinned ReactLynx envelope; its worklet runtime converts them to `Element` instances). Octane's strict data-only argument isolation rejected the wrapper, so **every `main-thread:bind*` handler threw on device**: `TypeError: Octane Lynx worklet arguments[0].currentTarget.elementRefptr: contains a non-clone-safe value.` (Lynx Explorer 3.9, iOS). The JavaScript testing environment never dispatches this envelope, so host tests could not see it.
- Octane's equivalent of ReactLynx's `Element` wrapper is the raw PAPI node — the same value a `main-thread:ref` cell holds — so the unwrap converges both element surfaces.

## Changes
- `worklets.ts`: `CloneState` gains an `unwrapElementReferences` mode used by a new `isolateLynxWorkletArguments()`; the worklet registry's `execute` isolates arguments through it. Wrappers unwrap by identity (registered in the clone map so aliases stay aliases); a nullish `elementRefptr` still fails validation. On PrimJS the element reference's `typeof` is not necessarily `'object'`, so only nullish is rejected.
- Captures, cross-thread calls, and every other isolation boundary keep the strict data-only behavior — the mode exists only for arguments, which never leave the main thread.
- `worklets-core.test.ts`: regression asserting the worklet receives the raw element **by identity** for both `target` and `currentTarget` while sibling event data is still isolated by copy.

## Validation
- [x] `vitest run --project lynx` — 260 tests passed
- [x] `tsgo --noEmit -p packages/lynx/tsconfig.json`
- [x] `prettier --check` on changed files
- [x] device evidence: `main-thread:bindscroll` (Product Gallery scrollbar) and `main-thread:bindtouchstart/move/end` (Product Detail swiper) execute per-frame on Lynx Explorer 3.9 (iOS) with this change

## Risk / follow-ups
- Worklets can now observe a live element through `event.target`; that matches the existing `main-thread:ref` contract and ReactLynx's envelope semantics. No changeset: `@octanejs/lynx` is private.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the main-thread worklet argument isolation contract so handlers can observe live native elements via events; scope is limited to args that never leave the main thread.
> 
> **Overview**
> Fixes **main-thread bind handlers** that threw on native Lynx because strict argument cloning rejected the pinned event envelope’s `{ elementRefptr }` wrappers on `target` / `currentTarget`.
> 
> **`cloneValue`** gains an **`unwrapElementReferences`** mode (only for worklet args): those wrappers pass through as the **raw main-thread element by identity** (same as `main-thread:ref`), with nullish `elementRefptr` still failing validation. **`isolateLynxWorkletArguments()`** uses that mode; the main-thread registry **`execute`** path switches from **`isolateLynxWorkletValue`** for params. Captures, cross-thread calls, and other isolation boundaries stay data-only.
> 
> Adds a regression test: worklet sees native element by identity for both targets while **`detail`** remains copy-isolated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 290774dc4a18cc19a892550649067a976c18d2cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->