### PR TITLE
fix(octane): park keyed rows only when a hold can restore them

### DIFF
--- a/.changeset/transition-park-only-restorable.md
+++ b/.changeset/transition-park-only-restorable.md
@@ -1,0 +1,16 @@
+---
+'octane': patch
+---
+
+Keyed-list parking only defers what a hold can restore.
+
+A value-position keyed list whose slot leaves array mode (the value stops
+being an array) discards the slot itself, so rows removed by that flip have
+nothing to be restored into. They no longer park for a possible hold — their
+teardown runs inline with the attempt that removed them, exactly as it did
+before rows learned to wait — instead of being deferred past the rest of the
+render as unrestorable.
+
+The rollback that puts a held list back also stops if a teardown cleanup
+flips the enclosing boundary to `@catch` mid-restore, instead of writing into
+a disposed range.

--- a/packages/octane/audit/SUSPENSE_DIVERGENCE.md
+++ b/packages/octane/audit/SUSPENSE_DIVERGENCE.md
@@ -129,6 +129,12 @@ the first:
    alongside dropped rows. `transitions.test.ts` pins the drop, the state survival, the
    cleanup timing, and both directions of the `@empty` swap.
 
+   Parking is gated on the slot's shape being journaled (`forSlotParkable`): a
+   value-position slot LEAVING array mode discards the slot itself, so its rows have
+   nothing to be restored into and tear down inline with the attempt, exactly as before —
+   that kind flip is part of the retained per-swap limitation above, and the flipped-in
+   content stays through a hold. `transitions.test.ts` pins the inline teardown order.
+
    **This one is NOT blocked by the pending cue, and it is the most visible of the two.** A
    keyed list between the `@try` and the suspending component sits inside the boundary's own
    journal window, so it needs no attempt-level widening. Reproduced 2026-07-29: a list of

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -1240,6 +1240,20 @@ function itemRemovalDefers(): boolean {
 }
 
 /**
+ * True when rows removed from `state` may defer their teardown for a possible
+ * hold. Parking is only sound when this list's shape went into the journal:
+ * restoreForSlot is the only thing that brings parked rows back, and it can
+ * only find them through a JOURNAL_FOR entry. A caller tearing rows down
+ * OUTSIDE the journal's knowledge — a value-position slot leaving array mode
+ * discards the slot itself — must remove immediately, as it always did:
+ * parking there would strand the rows as deferred-but-unrestorable and push
+ * their cleanups past the rest of the attempt.
+ */
+function forSlotParkable(state: ForSlot): boolean {
+	return TRANSITION_JOURNAL !== null && TRANSITION_JOURNAL_BAGS!.has(state);
+}
+
+/**
  * Record a keyed list's shape before a reconcile that may have to be undone.
  *
  * The list is restored as a whole rather than per operation: the chain, the key
@@ -1288,6 +1302,12 @@ function restoreForSlot(
 	for (let b: Block | null = state.head; b !== null; b = b.nextSibling) {
 		if (!kept.has(b)) unmountBlock(b, false);
 	}
+	// Those teardowns dispatch their cleanup errors immediately, and an error
+	// routed to the enclosing boundary flips it to @catch — disposing this
+	// slot's whole range out from under the restore. Same mid-render teardown
+	// invariant as renderReturnedValue's disposed check: stop here, and let
+	// flushParkedItems finish off whatever stayed parked.
+	if (state.end.parentNode === null) return;
 	state.head = snapshot.head;
 	state.tail = snapshot.tail;
 	state.size = snapshot.size;
@@ -1328,7 +1348,9 @@ function restoreForSlot(
 		if (state.emptyBlock !== null) unmountBlock(state.emptyBlock, false);
 		state.emptyBlock = snapshot.empty;
 	}
-	if (snapshot.empty !== null) {
+	// The @empty teardown above can dispose the range the same way the orphan
+	// walk can; re-check before inserting into it.
+	if (snapshot.empty !== null && state.end.parentNode !== null) {
 		const parkedEmpty = takeParkedItem(snapshot.empty);
 		const nodes = parkedEmpty ?? collectBlockRange(snapshot.empty);
 		for (let k = 0; k < nodes.length; k++) parent.insertBefore(nodes[k], state.end);
@@ -22798,9 +22820,11 @@ const RANGE_CLEAR_MIN_ITEMS = 512;
  */
 function batchClearItems(state: ForSlot, oldItems: Map<any, Block>): void {
 	// The bulk paths below drop the nodes wholesale, which cannot be undone.
-	// While a hold is still possible, take each row individually so its nodes
-	// are kept and its teardown waits for the outcome.
-	if (itemRemovalDefers()) {
+	// While a hold is still possible AND this list's shape is journaled (see
+	// forSlotParkable — reconcileKeyed and the @empty flip journal before they
+	// clear; teardownChildForSlot never does), take each row individually so
+	// its nodes are kept and its teardown waits for the outcome.
+	if (forSlotParkable(state)) {
 		let next: Block | null;
 		for (let b: Block | null = state.head; b !== null; b = next) {
 			next = b.nextSibling;

--- a/packages/octane/tests/_fixtures/transitions.tsrx
+++ b/packages/octane/tests/_fixtures/transitions.tsrx
@@ -1,6 +1,7 @@
 import {
 	use,
 	useEffect,
+	useLayoutEffect,
 	useReducer,
 	useState,
 	useTransition,
@@ -632,6 +633,47 @@ export function TransitionKeyedEmptyFill(props) @{
 					}
 				</ul>
 				<ControlledValue load={props.load} step={step} />
+			</>
+		} @pending {
+			<span id="fallback">{'fallback'}</span>
+		}
+	</div>
+}
+
+// ---------------------------------------------------------------------------
+// A value-position keyed list whose slot LEAVES array mode during the
+// transition (the value flips to plain text), and then a later sibling
+// suspends. The slot itself is discarded on the flip, so there is nothing for
+// a rollback to restore the rows into — the teardown must run inline with the
+// attempt, exactly as it did before rows learned to wait for a hold. The
+// layout cleanups' position relative to the tail's render pins that.
+// ---------------------------------------------------------------------------
+function FlipRow(props) @{
+	useLayoutEffect(() => {
+		props.log('mount:' + props.id);
+		return () => props.log('cleanup:' + props.id);
+	}, []);
+	<li id={'row-' + props.id}>{props.id as string}</li>
+}
+
+function FlipTail(props) @{
+	props.log('render:tail:' + props.step);
+	const value = use(props.load(props.step));
+	<span id="value">{value as string}</span>
+}
+
+export function TransitionArrayModeExit(props) @{
+	const [step, setStep] = useState(0);
+	const rows =
+		step === 0 ? ['a', 'b'] : null;
+	<div>
+		<button id="bump" onClick={() => startTransition(() => setStep(1))}>{'bump'}</button>
+		@try {
+			<>
+				<div id="host">
+					{rows === null ? 'plain' : rows.map((id) => <FlipRow key={id} id={id} log={props.log} />)}
+				</div>
+				<FlipTail load={props.load} step={step} log={props.log} />
 			</>
 		} @pending {
 			<span id="fallback">{'fallback'}</span>

--- a/packages/octane/tests/transitions.test.ts
+++ b/packages/octane/tests/transitions.test.ts
@@ -25,6 +25,7 @@ import {
 	TransitionListToEmpty,
 	TransitionKeyedAddition,
 	TransitionKeyedEmptyFill,
+	TransitionArrayModeExit,
 } from './_fixtures/transitions.tsrx';
 
 interface Deferred<T> {
@@ -896,5 +897,46 @@ describe('useTransition — the old screen stays whole', () => {
 		expect(ids()).toEqual(['row-d']);
 		expect(log.drain()).toEqual(['mount:d']);
 		r.unmount();
+	});
+
+	it('a slot leaving array mode tears its rows down inline, not deferred past the attempt', async () => {
+		const fulfilled = {
+			status: 'fulfilled',
+			value: 'zero',
+			then: (fn: (v: string) => void) => void fn('zero'),
+		} as unknown as Promise<string>;
+		const d1 = deferred<string>();
+		const load = (step: number) => (step === 0 ? fulfilled : d1.promise);
+		const log = createLog();
+
+		const r = mount(TransitionArrayModeExit, { load, log: log.push });
+		await act(() => {});
+		expect(r.findAll('#host li').map((li) => li.id)).toEqual(['row-a', 'row-b']);
+		expect(log.drain()).toEqual(['render:tail:0', 'mount:a', 'mount:b']);
+
+		// The flip discards the slot itself, so a hold has nothing to restore the
+		// rows into. Their teardown belongs to the attempt that removed them —
+		// layout cleanups fire before the tail's render, the pre-parking order —
+		// rather than parking them as deferred-but-unrestorable.
+		r.click('#bump');
+		expect(r.findAll('#fallback')).toHaveLength(0);
+		expect(log.drain()).toEqual(['cleanup:a', 'cleanup:b', 'render:tail:1']);
+		// The flipped-in text stays: a slot kind flip is not journaled (the
+		// retained per-swap limitation in SUSPENSE_DIVERGENCE.md #4), while the
+		// tail below it holds its prior value.
+		expect(r.find('#host').textContent).toBe('plain');
+		expect(r.find('#value').textContent).toBe('zero');
+
+		await act(() => {
+			d1.resolve('one');
+		});
+		expect(r.find('#host').textContent).toBe('plain');
+		expect(r.find('#value').textContent).toBe('one');
+		expect(log.drain()).toEqual(['render:tail:1']);
+
+		// Exactly-once: the rows were torn down by the flip and never again.
+		r.unmount();
+		await act(() => {});
+		expect(log.drain()).toEqual([]);
 	});
 });


### PR DESCRIPTION
Follow-up to #386, which merged seven minutes before Bugbot's second review
landed — so its two findings were never addressed on the branch. (The first
review's High finding did make the squash merge; `main` is not carrying that
leak.)

## Finding 1 — unjournaled parks on mode exit (Medium) — real, fixed

`batchClearItems` parked rows whenever a journal window was armed. But one of
its callers, `teardownChildForSlot`, runs when a value-position keyed list
leaves array mode (`{cond ? items.map(…) : 'text'}` flipping away) — and that
flip discards the slot itself (`state.forSlot = null`). No `JOURNAL_FOR` entry
exists and `restoreForSlot` is the only thing that brings parked rows back, so
those rows were stranded: deferred-but-unrestorable, torn down at window close
with their cleanups pushed past the rest of the attempt.

The observable regression #386 introduced there is teardown *order*: cleanups
used to fire inline at the flip, and parking deferred them past every later
sibling in the body. The new test pins the pre-#386 order via layout cleanups
logged against a later sibling's render — red on main
(`['render:tail:1', 'cleanup:a', 'cleanup:b']`), green with the fix
(`['cleanup:a', 'cleanup:b', 'render:tail:1']`), and red-verified by disabling
the gate.

Fix: parking is gated on the slot's shape being in the journal
(`forSlotParkable` — one `Set.has` on the armed path only). `reconcileKeyed`
and the `@empty` flip journal before they clear, so every restorable path
still parks; `teardownChildForSlot` never journals, so it tears down inline
as it always did. The invariant is now self-enforcing rather than relying on
callers to know the rule.

The kind flip itself (list → text) still commits through a hold — that is the
retained per-swap limitation already documented in `SUSPENSE_DIVERGENCE.md`
#4, now called out explicitly there, and the test asserts the current
behavior with a pointer to it.

## Finding 2 — missing disposal check after teardown (Low) — real, fixed

`restoreForSlot`'s orphan and `@empty` teardowns run cleanups whose errors
dispatch immediately; one routed to the enclosing boundary flips it to
`@catch`, disposing the slot's whole range while the restore keeps rewriting
bookkeeping and inserting into it. Added a bail after each teardown cluster
when `state.end.parentNode` is gone — the same mid-render teardown invariant
`renderReturnedValue` checks. `flushParkedItems` finishes off whatever stayed
parked, which is the correct outcome for a boundary that just died.

**No behavioral test for this one, deliberately**: reaching the guard requires
a render-time cleanup (not an effect cleanup — those never ran for these
blocks) to throw, and every render-time cleanup on these paths is
runtime-internal. Per the testing rules I did not mock internals to
manufacture a repro; the guard is invariant hardening with a comment naming
the invariant.

## Validation

- [x] transitions: 26/26 on `octane` and `octane-prod`
- [x] neighbors (suspense, held-audit, consecutive-suspend, control, children-block, code-block-child): green
- [x] `pnpm typecheck`, `pnpm format:check`: clean
- [x] `pnpm test`: 16,262/16,264 — the 2 failures are the cmdk differential
      under full-suite parallelism (React-side "overlapping act()" warnings),
      which passes 55/55 as a project in isolation and has failed the same way
      on clean main and on pre-change branches all day. Environmental.

No benchmark run: both changes are on armed-window (cold) paths; the unarmed
hot path gains nothing new.

## Risk

- `forSlotParkable` adds a `Set.has` per bulk clear only while a window is
  armed.
- The disposal bails change behavior only when a boundary dies mid-rollback,
  where continuing was writing into a disposed range.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transition-journal keyed-list teardown and rollback on armed-window paths; behavior changes are narrow but in suspense-critical runtime code.
> 
> **Overview**
> Follow-up to keyed-list **parking during transition holds**: parking now runs only when the list’s shape was **journaled** (`forSlotParkable`), not whenever a transition journal window is open.
> 
> When a value-position keyed list **leaves array mode** (e.g. `rows.map(...)` → plain text), the slot is discarded and there is no `restoreForSlot` target. Those rows **tear down inline** again—restoring pre-#386 **layout cleanup order** before later siblings render—instead of parking as unrestorable rows whose cleanups run at window close.
> 
> **`restoreForSlot`** now **stops** if orphan or `@empty` teardown flips the enclosing boundary to `@catch` and disposes the slot range (`state.end.parentNode` gone), avoiding further DOM inserts into a disposed range.
> 
> Docs (`SUSPENSE_DIVERGENCE.md`, changeset) and **`TransitionArrayModeExit`** pin inline teardown order and the retained “kind flip commits through a hold” limitation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea2cdb64d1d76a17220da08e551ca03d47395e17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->