### PR TITLE
fix(runtime): sole-child hole crashes when re-entering array mode

### DIFF
--- a/.changeset/hole-kind-roundtrip-crash.md
+++ b/.changeset/hole-kind-roundtrip-crash.md
@@ -1,0 +1,16 @@
+---
+'octane': patch
+---
+
+Fix a crash when a sole-child value hole leaves and re-enters array mode.
+
+An element whose only child is a `{expr}` hole renders markerless (the slot
+owns the whole element), and an array value lazily mints a comment marker pair
+inside the element to anchor the keyed list. Clearing the slot on a later kind
+flip swept those markers out of the DOM but kept the slot's references to
+them, so the next mount anchored on detached comments: flipping
+array → text/null/host → array crashed with
+`Cannot read properties of null (reading 'nodeType')`, and array → component
+threw `NotFoundError` while inserting the new content. The owns-parent clear
+now forgets the swept marker pair, so re-entering array mode re-mints a live
+pair and every other regime returns to the markerless baseline.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -15362,6 +15362,14 @@ function clearChildContent(state: ChildSlot): void {
 			host.removeChild(n);
 			n = next;
 		}
+		// An owns-parent slot has no markers in any value regime EXCEPT a live
+		// array, whose lazily-minted ForSlot pair sits INSIDE the host — so the
+		// sweep above just detached it. Forget the pair: the array branch re-mints
+		// on re-entry, and every other regime expects the markerless baseline.
+		// Stale refs here would anchor the next mount (ForSlot, createBlock, or an
+		// offscreen swap) on detached comments and insert into a null parent.
+		state.start = null;
+		state.end = null;
 	} else if (state.start !== null) {
 		// Component (or hydrated) range: sweep everything between the markers —
 		// covers a multi-node component body as well as any leftover text node.

--- a/packages/octane/tests/_fixtures/hole-kind-flip.tsrx
+++ b/packages/octane/tests/_fixtures/hole-kind-flip.tsrx
@@ -1,0 +1,64 @@
+// Sole-child value holes whose kind flips into and out of the keyed-array
+// regime (array <-> text / null / component / pure host). Round-tripping back
+// to an array must remount items cleanly every cycle.
+//
+// Where a flip target is JSX, it is assigned in setup: a statically JSX-armed
+// ternary lowers to an @if-style block instead of the value hole under test.
+
+import { useState } from 'octane';
+
+function Chip() @{
+	<b>{'chip'}</b>
+}
+
+export function HoleKindRoundTrip() @{
+	const [mode, setMode] = useState(0);
+	const rows =
+		mode % 2 === 0 ? ['a', 'b'] : null;
+	<div>
+		<button id="next" onClick={() => setMode(mode + 1)}>{'next'}</button>
+		<div id="host">
+			{rows === null ? 'plain' : rows.map((id) => <i key={id}>{id as string}</i>)}
+		</div>
+	</div>
+}
+
+export function ArrayNullRoundTrip() @{
+	const [mode, setMode] = useState(0);
+	const rows =
+		mode % 2 === 0 ? ['a', 'b'] : null;
+	<div>
+		<button id="next" onClick={() => setMode(mode + 1)}>{'next'}</button>
+		<div id="host">
+			{rows === null ? null : rows.map((id) => <i key={id}>{id as string}</i>)}
+		</div>
+	</div>
+}
+
+export function ArrayComponentRoundTrip() @{
+	const [mode, setMode] = useState(0);
+	let content;
+	if (mode % 2 === 0) {
+		content = ['a', 'b'].map((id) => <i key={id}>{id as string}</i>);
+	} else {
+		content = <Chip />;
+	}
+	<div>
+		<button id="next" onClick={() => setMode(mode + 1)}>{'next'}</button>
+		<div id="host">{content}</div>
+	</div>
+}
+
+export function ArrayHostRoundTrip() @{
+	const [mode, setMode] = useState(0);
+	let content;
+	if (mode % 2 === 0) {
+		content = ['a', 'b'].map((id) => <i key={id}>{id as string}</i>);
+	} else {
+		content = <em>{'solo'}</em>;
+	}
+	<div>
+		<button id="next" onClick={() => setMode(mode + 1)}>{'next'}</button>
+		<div id="host">{content}</div>
+	</div>
+}

--- a/packages/octane/tests/hole-kind-roundtrip.test.ts
+++ b/packages/octane/tests/hole-kind-roundtrip.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from './_helpers';
+import {
+	HoleKindRoundTrip,
+	ArrayNullRoundTrip,
+	ArrayComponentRoundTrip,
+	ArrayHostRoundTrip,
+} from './_fixtures/hole-kind-flip.tsrx';
+
+// A sole-child value hole may change kind on any render. Leaving the keyed
+// array regime and re-entering it later must keep working — repeatedly — and
+// the intermediate kind must render correctly too.
+describe('value hole kind round-trip', () => {
+	it('survives array -> text -> array on a sole-child hole', () => {
+		const r = mount(HoleKindRoundTrip);
+		expect(r.findAll('#host i').map((el) => el.textContent)).toEqual(['a', 'b']);
+		r.click('#next');
+		expect(r.find('#host').textContent).toBe('plain');
+		expect(r.findAll('#host i')).toEqual([]);
+		r.click('#next');
+		expect(r.findAll('#host i').map((el) => el.textContent)).toEqual(['a', 'b']);
+		// A second full cycle proves the re-entered array mode is itself sound.
+		r.click('#next');
+		expect(r.find('#host').textContent).toBe('plain');
+		r.click('#next');
+		expect(r.findAll('#host i').map((el) => el.textContent)).toEqual(['a', 'b']);
+		r.unmount();
+	});
+
+	it('survives array -> null -> array on a sole-child hole', () => {
+		const r = mount(ArrayNullRoundTrip);
+		expect(r.findAll('#host i').map((el) => el.textContent)).toEqual(['a', 'b']);
+		r.click('#next');
+		expect(r.find('#host').textContent).toBe('');
+		r.click('#next');
+		expect(r.findAll('#host i').map((el) => el.textContent)).toEqual(['a', 'b']);
+		r.click('#next');
+		expect(r.find('#host').textContent).toBe('');
+		r.click('#next');
+		expect(r.findAll('#host i').map((el) => el.textContent)).toEqual(['a', 'b']);
+		r.unmount();
+	});
+
+	it('survives array -> component -> array on a sole-child hole', () => {
+		const r = mount(ArrayComponentRoundTrip);
+		expect(r.findAll('#host i').map((el) => el.textContent)).toEqual(['a', 'b']);
+		r.click('#next');
+		expect(r.find('#host').textContent).toBe('chip');
+		r.click('#next');
+		expect(r.findAll('#host i').map((el) => el.textContent)).toEqual(['a', 'b']);
+		r.click('#next');
+		expect(r.find('#host').textContent).toBe('chip');
+		r.click('#next');
+		expect(r.findAll('#host i').map((el) => el.textContent)).toEqual(['a', 'b']);
+		r.unmount();
+	});
+
+	it('survives array -> pure host -> array on a sole-child hole', () => {
+		const r = mount(ArrayHostRoundTrip);
+		expect(r.findAll('#host i').map((el) => el.textContent)).toEqual(['a', 'b']);
+		r.click('#next');
+		expect(r.find('#host').textContent).toBe('solo');
+		expect(r.find('#host em').textContent).toBe('solo');
+		r.click('#next');
+		expect(r.findAll('#host i').map((el) => el.textContent)).toEqual(['a', 'b']);
+		r.click('#next');
+		expect(r.find('#host em').textContent).toBe('solo');
+		r.click('#next');
+		expect(r.findAll('#host i').map((el) => el.textContent)).toEqual(['a', 'b']);
+		r.unmount();
+	});
+});


### PR DESCRIPTION
## Summary

- Fix a pre-existing runtime crash: a sole-child value hole that flips array → text → array dies with `Cannot read properties of null` (`nodeType` / `insertBefore`). Reproduces on clean main, no transitions involved.

## Why

An owns-parent slot (a `{expr}` hole that is its element's only child) renders markerless in every value regime except a live array, which lazily mints a ForSlot comment pair *inside* the host (childSlot's "OWNS-PARENT slot entering array mode" branch). `clearChildContent`'s owns-parent sweep removes every child of the host — including that minted pair — but left `state.start`/`state.end` pointing at the detached comments. Any later consumer then anchored on detached nodes:

- array → text / null / pure-host → **array**: the array-entry branch sees a non-null `state.end`, skips re-minting, and `mountItemsLinear`/`mountItem` mount items into a null parent.
- array → **component**: `createBlock` receives the detached pair and the mount throws `NotFoundError: The child can not be found in the parent`.

A probe matrix over the adjacent kind flips showed all four shapes crash on main from this one dangling-refs defect.

## Changes

- `clearChildContent` (owns-parent branch, `packages/octane/src/runtime.ts`): after sweeping the host, null `state.start`/`state.end` — the sweep just detached them. Array re-entry re-mints a live pair, and every other regime returns to the documented markerless owns-parent baseline. Fixing the detach site covers all four broken flips with two field writes; a guard at the array-entry mint (the originally spiked fix) would have repaired the three re-entry flips but not the array → component `NotFoundError`, which crashes before any re-entry.
- Regression tests: `packages/octane/tests/hole-kind-roundtrip.test.ts` + `packages/octane/tests/_fixtures/hole-kind-flip.tsrx` — four sole-child round-trips (text, null, component, pure host), each driven for two full cycles. All four fail on main and pass with the fix, in both the `octane` and `octane-prod` projects.
- Changeset: patch for `octane`.

## Note: the de-opt item symptom on clean main

Clean main fails the original repro with a different surface symptom than the spike branch did: `deoptChildNamespace` reading `nodeType` of null (`deoptItemBody` → `deoptChildNamespace(block.parentNode)` where the item block's `parentNode` came from the detached end marker). That crash sits *downstream* of the same stale pair — the de-opt item path itself needs no separate guard once the pair can never dangle, which the detach-site fix guarantees. The new tests pin this: three of the four round-trips crashed exactly there pre-fix.

## Validation

- [x] Pre-fix red on this base: all four new tests fail (`deoptChildNamespace` TypeError ×3, `NotFoundError` ×1); all pass with the fix
- [x] Targeted suites (both `octane` and `octane-prod`): hole-kind-roundtrip, children-block, code-block-child, control, control-fold, anchorless-host, deopt-child-key-aliasing, deopt-fragment-sibling-keys, deopt-item-path-switch, deopt-item-selfmark, deopt-pure-host-upgrade, deopt-tag-swap-children, for, for-batch-clear, fragments, host-children-renderfn — 244 tests passed
- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 1444 files / 15505 tests passed, exit 0. (A first run hit 4 failures in `packages/shadcn/tests/differential/parity.test.ts` where the **React reference side** rendered empty at mount; the file passes 5/5 in isolation with and without this fix, the whole `shadcn` project passes 108/108, the full re-run is clean, and CI is green on the same base — a load-order flake unrelated to this change.)

## Performance

`clearChildContent` runs only on child-slot kind flips and teardown, never on steady-state updates, and the change is two null stores on that cold branch. No hot path is touched; there is no measurable benchmark signal to report.

## Risk / follow-ups

- Hydration is unaffected by construction: `ownerHost` is never set while hydrating, so the changed branch is unreachable there (hydrated holes adopt server marker pairs in the marked regime). SSR emits once and never flips kinds.
- The nulling also closes a latent hazard where a stale non-null `state.end` could wrongly qualify an owns-parent slot for the offscreen transition swap against a detached anchor.
- Found in passing, tracked separately: a statically JSX-armed ternary hole (`{cond ? xs.map(…) : <Chip/>}`) lowers to an ifBlock that silently drops the non-JSX arm's value and renders nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches child-slot teardown in the Octane runtime on kind-flip paths only; scope is narrow but incorrect marker handling could affect DOM mounting for owns-parent holes.
> 
> **Overview**
> Fixes crashes when a **sole-child `{expr}` hole** leaves keyed **array** mode and later comes back (or mounts a component).
> 
> In `clearChildContent`'s **owns-parent** path, sweeping the host removed the lazily minted **ForSlot** comment pair but left `state.start` / `state.end` pointing at detached nodes. The next mount then skipped re-minting or inserted against a null parent (`nodeType` / `NotFoundError`). The clear path now **nulls those refs** so array mode can mint a fresh pair and other kinds stay markerless.
> 
> Adds **hole-kind round-trip** fixtures and tests (array ↔ text, null, component, pure host, two cycles each) plus an **octane** patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62118538c37138b61b50fe3757adcbd1e623f84b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->