### PR TITLE
fix(lynx): expose SystemInfo global on the main thread

### DIFF
--- a/packages/lynx/src/main-thread.ts
+++ b/packages/lynx/src/main-thread.ts
@@ -484,6 +484,13 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 			'Octane Lynx main-thread receiver requires ContextProxy dispatchEvent/addEventListener/removeEventListener.',
 		);
 	}
+	// The native main thread exposes SystemInfo only as `lynx.SystemInfo`, but
+	// authored `'main thread'` functions read the documented bare global; expose
+	// it exactly as ReactLynx's worklet environment setup does.
+	const environmentTarget = target as { SystemInfo?: unknown; lynx?: { SystemInfo?: unknown } };
+	if (environmentTarget.SystemInfo === undefined) {
+		environmentTarget.SystemInfo = environmentTarget.lynx?.SystemInfo ?? {};
+	}
 	const papi: LynxElementPAPI<Node> = createLynxElementPAPI<Node>(rawTarget);
 	const componentId = options.componentId ?? '0';
 	if (typeof componentId !== 'string' || componentId.length === 0) {


### PR DESCRIPTION
## Summary
- `installLynxMainThread()` exposes `SystemInfo` as a bare global on the main-thread target when the engine only provides it as `lynx.SystemInfo`.

## Why
- On the native main thread, `SystemInfo` is not a global — it lives at `lynx.SystemInfo`. Authored `'main thread'` functions use the documented bare global (for example the official Product Gallery tutorial's scrollbar math), and on device they threw `ReferenceError: SystemInfo is not defined` (Lynx Explorer 3.9, iOS).
- ReactLynx's main-thread environment setup does exactly this bridge (`setupLynxEnv`: `globalThis.SystemInfo = lynx.SystemInfo ?? {}`); Octane's main runtime installs its receiver on the same context and needs the same bridge.

## Changes
- `main-thread.ts`: during install, if `target.SystemInfo` is undefined, assign `target.lynx?.SystemInfo ?? {}`. An explicit test-provided global is never overwritten.

## Validation
- [x] `vitest run --project lynx` — 259 tests passed
- [x] `tsgo --noEmit -p packages/lynx/tsconfig.json`
- [x] `prettier --check` on the changed file
- [x] device evidence: `'main thread'` functions reading `SystemInfo.pixelHeight` / `pixelRatio` run on Lynx Explorer 3.9 (iOS) with this change

## Risk / follow-ups
- The bridge is install-time, idempotent, and skipped when a host already defines the global (JS testing environment installs its own). No changeset: `@octanejs/lynx` is private.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, idempotent install-time global alias with no overwrite of host-provided `SystemInfo`; limited to main-thread environment setup.
> 
> **Overview**
> **`installLynxMainThread()`** now bridges the documented bare **`SystemInfo`** global when the native main thread only exposes it as **`lynx.SystemInfo`**, matching ReactLynx worklet env setup.
> 
> During install, if **`target.SystemInfo`** is missing, it is set to **`lynx.SystemInfo`** or **`{}`**; an existing global (e.g. from tests) is left unchanged. This fixes **`ReferenceError: SystemInfo is not defined`** for authored **`'main thread'`** worklets that read **`SystemInfo.pixelHeight`** / **`pixelRatio`** on device.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81a09e5af322ad54afe682f2b03af9f146d5a74e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->