### PR TITLE
fix(lynx): unwrap main-thread event props in first-screen host batches

### DIFF
--- a/packages/lynx/src/core/host-driver.ts
+++ b/packages/lynx/src/core/host-driver.ts
@@ -50,7 +50,11 @@ import type {
 	LynxListComponentAtIndexes,
 	LynxListEnqueueComponent,
 } from './papi.js';
-import type { LynxActivatedMainThreadWorklet, LynxMainThreadWorkletRegistry } from './worklets.js';
+import {
+	getThreadFunctionDescriptor,
+	type LynxActivatedMainThreadWorklet,
+	type LynxMainThreadWorkletRegistry,
+} from './worklets.js';
 import {
 	decodeLynxPortalTargetId,
 	isLynxPortalTargetHandle,
@@ -428,7 +432,22 @@ function cloneProps(value: unknown, label: string): Readonly<Record<string, unkn
 	if (value === null || typeof value !== 'object' || Array.isArray(value)) {
 		throw hostError(`${label} must be a plain object.`);
 	}
-	const clone = cloneHostValue(value, new WeakMap());
+	// The render-only main graph authors `main-thread:` event props as tagged
+	// callables. Unwrap them to their plain worklet descriptors here, exactly as
+	// the background client driver does before transport; an untagged function
+	// still fails through cloneHostValue below.
+	let source = value as Record<string, unknown>;
+	let rewritten: Record<string, unknown> | null = null;
+	for (const [name, item] of Object.entries(source)) {
+		if (!name.startsWith('main-thread:') || name === 'main-thread:ref') continue;
+		if (typeof item !== 'function') continue;
+		const descriptor = getThreadFunctionDescriptor(item);
+		if (descriptor === null) continue;
+		if (rewritten === null) rewritten = { ...source };
+		rewritten[name] = descriptor;
+	}
+	if (rewritten !== null) source = rewritten;
+	const clone = cloneHostValue(source, new WeakMap());
 	if (clone === null || typeof clone !== 'object' || Array.isArray(clone)) {
 		throw hostError(`${label} must be a plain object.`);
 	}


### PR DESCRIPTION
## Summary
- The host driver's `cloneProps` unwraps `main-thread:` event props from compiler-tagged callables to their plain worklet descriptors, mirroring what the background client driver already does before transport.

## Why
- In the render-only main graph, a `main-thread:bind*` prop's value is the compiler-tagged callable returned by `bindThreadFunction`. The background path converts these to descriptors in `prepareLynxClientWorkletBatch`, but the synchronous first-screen path fed the raw function into `cloneHostValue`, which rejects functions — so any page authoring a `main-thread:` event failed its first-screen render on device with `Octane Lynx host: host props contain unsupported value function bound() …` (Lynx Explorer 3.9, iOS) and fell back to the failed-first-screen path.
- With the unwrap, first screens carrying `main-thread:` events render synchronously and their worklet listeners install through the existing `planLynxHostPropPatch` path.

## Changes
- `host-driver.ts`: `cloneProps` rewrites `main-thread:*` (except `main-thread:ref`) function values through `getThreadFunctionDescriptor` before cloning; untagged functions still fail through `cloneHostValue` exactly as before.

## Validation
- [x] `vitest run --project lynx` — 259 tests passed
- [x] `tsgo --noEmit -p packages/lynx/tsconfig.json`
- [x] `prettier --check` on the changed file
- [x] device evidence: the Product Detail (swiper) tutorial port — `main-thread:bindtouchstart/move/end` + `main-thread:ref` on the first screen — renders synchronously and is draggable on Lynx Explorer 3.9 (iOS) with this change

## Risk / follow-ups
- Only `main-thread:`-prefixed props are affected; ordinary `bind*` first-screen handlers keep their event-marker replacement. Depends conceptually on the sibling worklet-capture fixes for full device behavior but is independently correct and mergeable. No changeset: `@octanejs/lynx` is private.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to first-screen prop cloning for main-thread event props only; aligns host behavior with the existing client driver path and leaves ordinary bind handlers unchanged.
> 
> **Overview**
> Fixes synchronous first-screen rendering when pages use **`main-thread:`** event handlers (e.g. `main-thread:bindtouchstart`) in the render-only main graph.
> 
> **`cloneProps`** in the host driver now unwraps compiler-tagged callables on `main-thread:*` props (except **`main-thread:ref`**) to plain worklet descriptors via **`getThreadFunctionDescriptor`** before **`cloneHostValue`** runs—matching what the background client driver already does before transport. Previously the first-screen path passed raw functions into cloning, which rejected them and broke the initial render on device.
> 
> Untagged functions and non–main-thread props behave as before; worklet listeners still install through the existing **`planLynxHostPropPatch`** path once descriptors are in props.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d6064ba92109cd9d579a1989702c8a92a71e1bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->