### PR TITLE
fix(runtime): hydration recovery corrupts DOM on a misadopted branch range

### DIFF
--- a/.changeset/branch-misadopted-range-recovery.md
+++ b/.changeset/branch-misadopted-range-recovery.md
@@ -1,0 +1,24 @@
+---
+'octane': patch
+---
+
+Fix hydration mismatch recovery corrupting the DOM when a branch adopts a
+non-spanning server range.
+
+When an `@if`/`@switch` (or an `@if`-lowered ternary) hydrates a slot whose
+server content leads with a nested `<!--[-->…<!--]-->` pair, the branch adopted
+that first pair as its own range without checking that the pair spans the whole
+slot. Against a differently-encoded server shape — for example a legacy
+value-hole list serialized as an outer pair plus one pair per keyed item — the
+branch then owned only a prefix of the slot: the next branch swap left the
+stranded remainder on screen next to the new arm, and re-entering the original
+arm mounted into detached anchors, rendering nothing (or throwing
+`NotFoundError` on insertion, depending on the shape). Recovery must never
+crash or leak — it is the production safety net for stale server HTML.
+
+The branch adoption now verifies the nested pair reaches the slot's close
+marker. When it does not, the runtime treats it as a structural hydration
+mismatch: it warns in development, discards the server range, and client-builds
+the branch fresh with hydration suspended for that subtree, so cursor-greedy
+adoption (such as a keyed list's markerless item path) cannot claim the slot's
+own close marker.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -21146,10 +21146,39 @@ function renderBranchSlot(
 				let bStart: Node;
 				let bEnd: Node;
 				let borrowed = false;
+				let rebuild = false;
+				let inner: Comment | null = null;
+				let innerEnd: Comment | null = null;
 				if (hydration !== null && hydration.isOpen(state.start.nextSibling)) {
-					bStart = state.start.nextSibling as Comment;
-					bEnd = hydration.close(bStart);
-					hydration.node = bStart.nextSibling;
+					inner = state.start.nextSibling as Comment;
+					innerEnd = hydration.close(inner);
+					if (innerEnd !== state.end && innerEnd.nextSibling !== state.end) {
+						// The first nested pair does not SPAN the slot's adopted range, so it
+						// cannot be this branch's own range — the server encoded this slot
+						// differently (e.g. a legacy value-hole list: an outer pair plus one
+						// pair per item). Adopting the prefix pair would strand the rest of
+						// the server content outside the branch: the next swap leaves it on
+						// screen and later re-entries insert against detached anchors.
+						// STRUCTURAL mismatch — discard the server range and client-build the
+						// branch fresh into the borrowed slot markers below.
+						if (process.env.NODE_ENV !== 'production') {
+							const mmLoc = siteLoc(parentScope, slotKey);
+							if (mmLoc)
+								hydration.warnStructural(
+									mmLoc,
+									'a single branch range',
+									hydration.describe(innerEnd.nextSibling),
+								);
+						}
+						removeRange(state.start.nextSibling, state.end);
+						inner = null;
+						rebuild = true;
+					}
+				}
+				if (inner !== null) {
+					bStart = inner;
+					bEnd = innerEnd as Comment;
+					hydration!.node = inner.nextSibling;
 				} else {
 					bStart = state.start;
 					bEnd = state.end as Node;
@@ -21173,7 +21202,17 @@ function renderBranchSlot(
 				);
 				if (borrowed) b.exclusiveMarkers = true;
 				state.block = b;
-				renderBlock(b);
+				if (rebuild) {
+					// The discarded range left nothing to adopt, but the cursor still sits
+					// inside the live document. Suspend hydration for the whole branch
+					// subtree so cursor-greedy adoption (e.g. a keyed list's markerless item
+					// path) client-builds instead of claiming the slot's own close marker,
+					// then park the cursor after the slot for the next sibling.
+					hydration!.suspend(() => renderBlock(b));
+					hydration!.node = (state.end as Node).nextSibling;
+				} else {
+					renderBlock(b);
+				}
 			} else if (hydration !== null && state.start.nextSibling !== state.end) {
 				// EMPTY client branch, but the server rendered content in this slot (e.g. an
 				// `@else` with content on the server, empty `@if` on the client). Discard the

--- a/packages/octane/tests/_fixtures/ternary-mixed-arms.tsrx
+++ b/packages/octane/tests/_fixtures/ternary-mixed-arms.tsrx
@@ -1,0 +1,38 @@
+// Mixed-arm ternaries written INLINE in a sole-child hole: one arm a keyed
+// array, the other a component. A statically JSX-armed ternary lowers to an
+// @if-style block whose branch hosts the keyed list, not a value hole (the
+// setup-assigned value-hole variants live in hole-kind-flip.tsrx).
+
+import { useState } from 'octane';
+
+function Chip() @{
+	<em>{'chip'}</em>
+}
+
+export function MapArm() @{
+	const [mode, setMode] = useState(0);
+	<div>
+		<button class="next" onClick={() => setMode(mode + 1)}>{'next'}</button>
+		<div class="host">
+			{mode % 2 === 0 ? ['x', 'y'].map((id) => <i key={id}>{id as string}</i>) : <Chip />}
+		</div>
+	</div>
+}
+
+// The same shape written as directives: identical branch-slot + keyed-list
+// runtime path, with the keyed list as the branch's sole root.
+export function ForArm() @{
+	const [mode, setMode] = useState(0);
+	<div>
+		<button class="next" onClick={() => setMode(mode + 1)}>{'next'}</button>
+		<div class="host">
+			@if (mode % 2 === 0) {
+				@for (const id of ['x', 'y']; key id) {
+					<i>{id as string}</i>
+				}
+			} @else {
+				<Chip />
+			}
+		</div>
+	</div>
+}

--- a/packages/octane/tests/hydration/mismatch-structural.test.ts
+++ b/packages/octane/tests/hydration/mismatch-structural.test.ts
@@ -22,6 +22,7 @@ const NESTEDSWAP = join(
 	process.cwd(),
 	'packages/octane/tests/hydration/_fixtures/nested-swap.tsrx',
 );
+const TERNARY = join(process.cwd(), 'packages/octane/tests/_fixtures/ternary-mixed-arms.tsrx');
 
 function serverModule(fixture: string, file: string): Record<string, any> {
 	let { code } = compile(readFileSync(fixture, 'utf8'), file, { mode: 'server' });
@@ -582,6 +583,103 @@ describe.each([
 			expect(recoveredAction.textContent?.trim()).toBe('inside:1');
 			flushSync(() => outsideAction.click());
 			expect(outsideAction.textContent?.trim()).toBe('outside:1');
+			expectDiagnostics();
+		} finally {
+			root.unmount();
+		}
+	});
+});
+
+// The server HTML below is a LEGACY shape for a sole-child mixed-arm-ternary hole:
+// an outer value pair wrapping one pair per keyed item. Today's client claims that
+// hole as an @if-lowered block whose branch hosts the keyed list, so every adopted
+// pair sits one nesting level off from where the client expects it. Recovery from
+// that misalignment must rebuild the subtree and never throw — stale server HTML
+// (an older octane version, a cached edge response) is exactly what the prod
+// recovery safety net exists for.
+describe.each([
+	{
+		name: 'development compile',
+		client: devClientModule(TERNARY, 'ternary-mixed-arms.tsrx'),
+		warns: true,
+	},
+	{
+		name: 'production compile',
+		client: prodClientModule(TERNARY, 'ternary-mixed-arms.tsrx'),
+		warns: false,
+	},
+])('hydrateRoot — recovery inside a misadopted range ($name)', ({ client, warns: shouldWarn }) => {
+	let container: HTMLElement;
+	let errSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		container.remove();
+		errSpy.mockRestore();
+	});
+
+	function expectDiagnostics(): void {
+		const messages = errSpy.mock.calls
+			.map((call) => String(call[0]))
+			.filter((message) => message.includes('hydration mismatch'));
+		if (shouldWarn) expect(messages.length).toBeGreaterThanOrEqual(1);
+		else expect(messages).toEqual([]);
+	}
+
+	const LEGACY_HTML =
+		'<div><button class="next">next</button><div class="host">' +
+		'<!--[--><!--[--><i>x</i><!--]--><!--[--><i>y</i><!--]--><!--]-->' +
+		'</div></div>';
+
+	it('legacy nested-pair list shape: rebuilds the keyed list and stays interactive', () => {
+		container.innerHTML = LEGACY_HTML;
+		const root = hydrateRoot(container, client.ForArm);
+		flushSync(() => {});
+
+		try {
+			const itemTexts = () =>
+				Array.from(container.querySelectorAll('.host i'), (n) => n.textContent);
+			expect(itemTexts()).toEqual(['x', 'y']);
+
+			// The rebuilt block must leave a coherent slot boundary behind: flip to the
+			// component arm and back to the keyed list through the live click handler.
+			const next = container.querySelector<HTMLButtonElement>('.next')!;
+			flushSync(() => next.click());
+			expect(container.querySelector('.host i')).toBeNull();
+			expect(container.querySelector('.host em')?.textContent).toBe('chip');
+			flushSync(() => next.click());
+			expect(itemTexts()).toEqual(['x', 'y']);
+			expect(container.querySelector('.host em')).toBeNull();
+			expectDiagnostics();
+		} finally {
+			root.unmount();
+		}
+	});
+
+	// The inline-ternary form of the same shape. Its keyed-array arm currently
+	// renders empty on a pure client mount (a compiler lowering gap, owned by the
+	// compiler's ternary tests), so this case pins only what RECOVERY owns: no
+	// throw, the stale server list fully discarded (never leaked into later
+	// arms), and a slot boundary the swaps can keep using.
+	it('legacy nested-pair list shape under the inline ternary: discards, never throws or leaks', () => {
+		container.innerHTML = LEGACY_HTML;
+		const root = hydrateRoot(container, client.MapArm);
+		flushSync(() => {});
+
+		try {
+			const next = container.querySelector<HTMLButtonElement>('.next')!;
+			flushSync(() => next.click());
+			// Component arm on screen; no stale server <i> may survive alongside it.
+			expect(container.querySelector('.host i')).toBeNull();
+			expect(container.querySelector('.host em')?.textContent).toBe('chip');
+			flushSync(() => next.click());
+			// Back on the array arm: the chip must be gone through the same boundary.
+			expect(container.querySelector('.host em')).toBeNull();
 			expectDiagnostics();
 		} finally {
 			root.unmount();


### PR DESCRIPTION
## Summary

- Hydration mismatch recovery could corrupt the DOM instead of rebuilding when an `@if`/`@switch` (or `@if`-lowered ternary) slot hydrated against a server range it did not fully own: a later branch swap left stranded server nodes on screen, and re-entering the original arm mounted into detached anchors — rendering nothing, or throwing `NotFoundError` on insertion depending on the shape. Recovery is the production safety net for stale server HTML and must never crash or leak.

## Why

- `renderBranchSlot`'s hydration path adopted the first nested `<!--[-->…<!--]-->` after the slot's open marker as the branch's own range without checking that the pair spans the slot. Against a differently-encoded server shape — e.g. a legacy value-hole list serialized as an outer pair plus one pair per keyed item — the branch owned only a strict prefix of the slot content, so teardown and later swaps operated on a corrupted boundary.
- Repro shape (byte-for-byte what the pre-symmetry server emits for a mixed-arm ternary hole): `<!--[--><!--[--><i>x</i><!--]--><!--[--><i>y</i><!--]--><!--]-->` hydrated by a client that claims the hole as an `@if`-lowered block whose branch hosts a keyed list.

## Changes

- `packages/octane/src/runtime.ts` (`renderBranchSlot`): the branch adopts the inner pair only when it reaches the slot's close marker (tolerant of fused multiplicity closes). Otherwise it is a structural hydration mismatch: warn in development, discard the server range, and client-build the branch into the borrowed slot markers.
- The rebuild runs under `hydration.suspend()` (mirroring the `@for` `@empty` recovery), so cursor-greedy adoption — e.g. the keyed list's markerless item path — client-builds instead of claiming the slot's own close marker; the cursor then parks after the slot for the next sibling.
- Regression tests in `tests/hydration/mismatch-structural.test.ts` with new shared fixture `tests/_fixtures/ternary-mixed-arms.tsrx`, run across dev/prod compiles and both vitest projects: `ForArm` (`@if` + keyed `@for`, the same runtime path) pins the strict contract — rebuild to `x, y`, live click handler, chip⇄list round trip, no leaks; `MapArm` pins the inline-ternary scenario on recovery-owned behavior only (no throw, warning, full discard, coherent swaps). All 8 instances fail without the runtime fix.
- Changeset (patch).

Post-hydration swaps (`hydration === null`) are untouched; the aligned adopt path gains one comparison and no allocations, so no benchmark run was warranted.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 15,513 tests / 1,444 files green (also proves no legitimate server emission trips the new spanning guard)
- [x] targeted tests: `vitest run packages/octane/tests/hydration/mismatch-structural.test.ts` — 56 passed; the 8 new instances confirmed red against the unpatched runtime

## Risk / follow-ups

- `MapArm`'s keyed-array arm still renders empty on a pure client mount — a pre-existing compiler lowering gap with a separate in-flight fix (client/server ternary symmetry). This PR deliberately does not touch the compiler; the `MapArm` test avoids pinning arm content so that fix can land without churn here.
- Same-class residual gap, unreproduced: sole-hole cursor adoptions in `forBlock`/try arms/component slots also adopt pairs without an outer-contract check. The new guard intercepts first in every shape I could construct; left alone rather than speculatively hardening hot paths.
- `findMatchingClose` still walks off the document on truncated HTML with no matching close (pre-existing, unreachable from well-formed pairs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hot-path hydration in `renderBranchSlot` for control-flow slots; behavior change is narrowly scoped to mis-encoded server ranges, with regression tests and unchanged post-hydration swap path.
> 
> **Overview**
> Fixes **hydration mismatch recovery** in `renderBranchSlot` when `@if`/`@switch` (or `@if`-lowered ternary) arms hydrate against server HTML whose first nested `<!--[-->…<!--]-->` pair does **not** reach the slot’s close marker—e.g. legacy value-hole lists with an outer pair plus per-item pairs.
> 
> The runtime now **verifies spanning** before adopting that inner pair. If the shape doesn’t match, it treats it as a **structural mismatch**: dev warning, **discards** the server range, and **client-rebuilds** the branch under **`hydration.suspend()`** so greedy list adoption can’t steal the slot’s close marker; the hydration cursor is parked after the slot.
> 
> Adds regression coverage (`ternary-mixed-arms.tsrx`, dev/prod `mismatch-structural` cases with legacy HTML) and an **octane patch** changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b901b4a56325a0843c120ac75ad0cb88c5586829. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->