### PR TITLE
fix(compiler): render the non-JSX arm of ternary child holes

### DIFF
--- a/.changeset/ternary-hole-value-arms.md
+++ b/.changeset/ternary-hole-value-arms.md
@@ -1,0 +1,28 @@
+---
+'octane': patch
+---
+
+Render the non-JSX arm of a ternary child hole instead of discarding it, and
+stop crashing on a `null` consequent.
+
+`{cond ? A : B}` at a JSX child position lowers to an ifBlock when either arm
+is a JSX literal. The other arm's value — a keyed `.map(…)` array, a string, a
+variable holding an element, a nested ternary, a falsy primitive — was compiled
+into the branch helper as a bare expression statement, so its value was
+evaluated and dropped and the hole rendered empty. React renders that arm's
+value, and server rendering already did too, so the same component could ship
+content from the server that the hydrating client blanked out. A `null`
+consequent (`{cond ? null : <Jsx/>}`) did not compile at all: the lowering
+crashed reading the missing branch.
+
+A non-JSX arm now lowers to the authored-equivalent `<>{expr}</>`, so the
+branch renders the value through the fragment's child hole: keyed `.map` arms
+take the same keyed fast path as `@for`, nested ternaries become nested
+ifBlocks, and primitives (including `0`) render as text. A `null`/`false`
+consequent compiles to an ifBlock with an empty then branch, mirroring the
+long-supported `null` alternate. The server now claims template-form ternary
+holes symmetrically (`ssrControl` + arm ranges, exactly like an authored
+`@if`), so the hydrating client adopts the taken arm's DOM — including keyed
+list arms — instead of relying on shape coincidence. Value-form positions
+(returned `.tsx` trees, whose holes the client folds into descriptor value
+holes) keep their existing `ssrChild` output byte-for-byte.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -3995,11 +3995,20 @@ function isConditionalJsx(node) {
 	);
 }
 
-/** Wrap an expression as a BlockStatement body, so makeIfCall can consume it. */
+/** Wrap a ternary arm as a BlockStatement body, so makeIfCall can consume it. */
 function wrapAsBlockStmt(node) {
 	if (!node) return null;
 	// null / Literal(null) / Literal(false) → no branch
 	if (node.type === 'Literal' && (node.value === null || node.value === false)) return null;
+	if (!isJsxLike(node)) {
+		// A non-JSX arm (`{cond ? xs.map(…) : <Jsx/>}`, a string, a variable
+		// holding an element, a nested ternary) is the branch's render VALUE. As
+		// a bare statement the branch body would evaluate-and-discard it, so wrap
+		// it as the authored-equivalent `<>{expr}</>` — the branch renders the
+		// value through the fragment's child hole (a nested ternary re-enters
+		// this lowering there and becomes a nested ifBlock).
+		node = inheritOriginLoc(b.jsx_fragment([b.jsx_expression_container(node, node)]), node);
+	}
 	return b.block([node]);
 }
 
@@ -8925,18 +8934,33 @@ function ssrCompileSub(
 ) {
 	const fnName = `${baseName}$${ctx.nextHelperId++}`;
 	const synth = { params: paramNodes || [], body: bodyStmts };
-	const fn = ssrCompileBody(
-		synth,
-		ctx,
-		fnName,
-		cssHash,
-		[],
-		parentNs || 'html',
-		false,
-		componentNs,
-		returnedFragmentTemplate,
-		returnedFragmentRoot,
-	);
+	// Extracted-fragment subs — component template children (`__schildren`) and
+	// returned-tree mirrors (`__sfragment`) — fold expression holes into
+	// descriptor VALUE holes on the client (`props.hN` + childTextHole); only
+	// directive ARMS keep the template walk there. Mark them so
+	// ssrEmitTsrxExpression keeps `{cond ? A : B}` on ssrChild inside them,
+	// mirroring the client's fold instead of claiming an @if. Directive-arm
+	// subs reset the flag through this same save/restore, so an @if INSIDE
+	// children/mirrors claims again, exactly like the client.
+	const prevFoldedExprHoles = ctx._ssrFoldedExprHoles;
+	ctx._ssrFoldedExprHoles = baseName === '__schildren' || baseName === '__sfragment';
+	let fn;
+	try {
+		fn = ssrCompileBody(
+			synth,
+			ctx,
+			fnName,
+			cssHash,
+			[],
+			parentNs || 'html',
+			false,
+			componentNs,
+			returnedFragmentTemplate,
+			returnedFragmentRoot,
+		);
+	} finally {
+		ctx._ssrFoldedExprHoles = prevFoldedExprHoles;
+	}
 	return { fnName, fn };
 }
 
@@ -8944,10 +8968,19 @@ function ssrEmitIf(node, ctx, name, inlinedSubs, parentNs, cssHash, componentNs)
 	// rewriteHookCalls: key any `use(thenable)` in the @if test (it bypasses the
 	// setup rewrite, so without a stable key it collides with sibling/body use()).
 	const testExpr = rewriteHookCalls(node.test, ctx, name);
-	const thenStmts =
-		node.consequent.type === 'BlockStatement' ? node.consequent.body : [node.consequent];
-	const thenSub = ssrCompileSub(thenStmts, ctx, '__sif', [], cssHash, parentNs, componentNs);
-	inlinedSubs.push(thenSub.fn);
+	// A null consequent (`{cond ? null : <Jsx/>}` lowered by wrapAsBlockStmt)
+	// means "no then branch". It must emit like a MISSING @else — plain '' with
+	// no inner arm range — because the hydrating client renders that branch with
+	// a null body and adopts an empty slot range.
+	const thenStmts = node.consequent
+		? node.consequent.type === 'BlockStatement'
+			? node.consequent.body
+			: [node.consequent]
+		: null;
+	const thenSub = thenStmts
+		? ssrCompileSub(thenStmts, ctx, '__sif', [], cssHash, parentNs, componentNs)
+		: null;
+	if (thenSub) inlinedSubs.push(thenSub.fn);
 	let elseCall = ssrHtmlTemplate([], node, ctx);
 	let elseFnName = null;
 	if (node.alternate) {
@@ -8968,26 +9001,33 @@ function ssrEmitIf(node, ctx, name, inlinedSubs, parentNs, cssHash, componentNs)
 	ctx.runtimeNeeded.add('ssrBlock');
 	ctx.runtimeNeeded.add('ssrControl');
 	ctx.runtimeNeeded.add('ssrArm');
-	registerDirectiveOrigin(ctx, node, ['_$ssrControl', '_$ssrArm', thenSub.fnName, elseFnName]);
+	registerDirectiveOrigin(ctx, node, [
+		'_$ssrControl',
+		'_$ssrArm',
+		thenSub ? thenSub.fnName : null,
+		elseFnName,
+	]);
 	// Nested ranges: the OUTER ssrBlock is the if-slot; the INNER one wraps the
 	// taken branch's content. The client adopts BOTH on hydration (slot = outer,
 	// branch = inner) so no comment markers are inserted — byte-for-byte, exactly
 	// like @for. The not-taken arm emits no inner range (just `''`).
-	const thenInner = ssrCall(
-		'ssrArm',
-		[
-			b.literal('then', '"then"'),
-			ssrThunk(
-				ssrCall(
-					'ssrBlock',
-					[ssrSubCall(thenSub.fnName, [b.id('undefined')], node.consequent)],
-					node.consequent,
-				),
+	const thenInner = thenSub
+		? ssrCall(
+				'ssrArm',
+				[
+					b.literal('then', '"then"'),
+					ssrThunk(
+						ssrCall(
+							'ssrBlock',
+							[ssrSubCall(thenSub.fnName, [b.id('undefined')], node.consequent)],
+							node.consequent,
+						),
+						node.consequent,
+					),
+				],
 				node.consequent,
-			),
-		],
-		node.consequent,
-	);
+			)
+		: ssrHtmlTemplate([], node, ctx);
 	const elseInner = node.alternate
 		? ssrCall(
 				'ssrArm',
@@ -9440,6 +9480,28 @@ function ssrEmitTsrxExpression(node, ctx, name, inlinedSubs, parentNs, cssHash, 
 	) {
 		ctx.runtimeNeeded.add('ssrPortal');
 		return ssrCall('ssrPortal', [], node);
+	}
+	if (
+		node.returnedJsxValue !== true &&
+		ctx._tsxValuePos !== true &&
+		ctx._ssrFoldedExprHoles !== true &&
+		isConditionalJsx(expr)
+	) {
+		// Mirror the client's child-position lowering (emitElementHtml): in a
+		// TEMPLATE-form body a `{cond ? A : B}` hole with a JSX arm becomes an
+		// @if on BOTH sides, so each arm compiles as an ordinary arm body and
+		// the hydration shapes (control key, arm ranges, a keyed `.map` claimed
+		// inside a value arm) agree by construction. VALUE-form positions stay
+		// on ssrChild: the client folds returned `.tsx` trees' holes and
+		// extracted-fragment holes (component children, returned-tree mirrors)
+		// into descriptor value holes (`props.hN` + childTextHole), never
+		// ifBlock — `_tsxValuePos` and `_ssrFoldedExprHoles` are the server's
+		// mirrors of those two folds.
+		const asIf = {
+			...b.if(expr.test, wrapAsBlockStmt(expr.consequent), wrapAsBlockStmt(expr.alternate)),
+			loc: expr.loc, // same devLoc/control-key position as the client's claim
+		};
+		return ssrEmitIf(asIf, ctx, name, inlinedSubs, parentNs, cssHash, componentNs);
 	}
 	ctx.runtimeNeeded.add('ssrChild');
 	// rewriteHookCalls first (key any `use(thenable)` in the hole — it bypasses the
@@ -20169,10 +20231,16 @@ function hoistBodyHelper(
 // ===========================================================================
 
 function makeIfCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) {
-	// node.test, node.consequent (BlockStatement | Element), node.alternate (BlockStatement | IfStatement | null)
+	// node.test, node.consequent (BlockStatement | Element | null), node.alternate (BlockStatement | IfStatement | null)
+	// A null consequent (`{cond ? null : <Jsx/>}` lowered by wrapAsBlockStmt)
+	// means "no then branch" — same contract as the null alternate: the helper
+	// slot compiles to `null` and the runtime renders an empty branch.
 
-	const thenStmts =
-		node.consequent.type === 'BlockStatement' ? node.consequent.body : [node.consequent];
+	const thenStmts = node.consequent
+		? node.consequent.type === 'BlockStatement'
+			? node.consequent.body
+			: [node.consequent]
+		: null;
 	const elseStmts = node.alternate
 		? node.alternate.type === 'BlockStatement'
 			? node.alternate.body
@@ -20180,20 +20248,22 @@ function makeIfCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) {
 		: null;
 	// Phase 2: one shared env tuple for both branches (see unionEnv).
 	const envNames = unionEnv(ctx, [
-		{ stmts: thenStmts, params: [] },
+		thenStmts && { stmts: thenStmts, params: [] },
 		elseStmts && { stmts: elseStmts, params: [] },
 	]);
-	const thenHelperName = hoistBodyHelper(
-		ctx,
-		inlinedSubs,
-		'__then',
-		thenStmts,
-		[],
-		parentNs,
-		cssHash,
-		envNames,
-		directiveKeywordOrigin(ctx, node),
-	);
+	const thenHelperName = thenStmts
+		? hoistBodyHelper(
+				ctx,
+				inlinedSubs,
+				'__then',
+				thenStmts,
+				[],
+				parentNs,
+				cssHash,
+				envNames,
+				directiveKeywordOrigin(ctx, node),
+			)
+		: null;
 
 	let elseHelperName = null;
 	if (elseStmts) {

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -4005,8 +4005,10 @@ function wrapAsBlockStmt(node) {
 		// holding an element, a nested ternary) is the branch's render VALUE. As
 		// a bare statement the branch body would evaluate-and-discard it, so wrap
 		// it as the authored-equivalent `<>{expr}</>` — the branch renders the
-		// value through the fragment's child hole (a nested ternary re-enters
-		// this lowering there and becomes a nested ifBlock).
+		// value through the fragment's child hole. The hole sits at the
+		// fragment's ROOT, a value position on both compilers: a nested ternary
+		// stays a value hole here (it is NOT re-claimed into a nested ifBlock),
+		// which is why the server claim requires host-child position too.
 		node = inheritOriginLoc(b.jsx_fragment([b.jsx_expression_container(node, node)]), node);
 	}
 	return b.block([node]);
@@ -7491,7 +7493,15 @@ function ssrCompileBodyWithMapTemps(
 		((!!(node.body && node.body.type === 'JSXCodeBlock') && !returnedOutput) ||
 			returnedFragmentRoot) &&
 		inheritSoleCompRoot(bodyNodes, ctx);
+	// Body/sub ROOTS (including fragment-root children) are not host-element
+	// children: the client routes rich holes there through the de-opt value
+	// path (a portal has no host to stamp — see the emitNodeHtml root branch),
+	// so the ternary claim must stay off until an element's own children walk
+	// (ssrEmitElement) turns the flag on.
+	const prevHostChildPos = ctx._ssrHostChildPos;
+	ctx._ssrHostChildPos = false;
 	const htmlExpr = ssrEmitNodes(bodyNodes, ctx, name, inlinedSubs, parentNs, cssHash, componentNs);
+	ctx._ssrHostChildPos = prevHostChildPos;
 	ctx._ssrInheritRoot = prevInheritRoot;
 	ctx._returnedFragmentTemplate = prevReturnedFragmentTemplate;
 	ctx._tsxValuePos = prevValuePos;
@@ -8596,6 +8606,11 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash, compone
 		// pre/textarea/listing: the parser eats a '\n' right after the opening tag —
 		// the first text part must protect a leading newline (see ssrEmitNodes).
 		const nlGuardFirst = tag === 'pre' || tag === 'textarea' || tag === 'listing';
+		// These children sit directly under a host element — the one position
+		// where the client claims `{cond ? A : B}` holes (emitElementHtml). Root
+		// positions reset this in ssrCompileBody.
+		const prevHostChildPos = ctx._ssrHostChildPos;
+		ctx._ssrHostChildPos = true;
 		childrenExpr = ssrEmitNodes(
 			normChildren,
 			ctx,
@@ -8606,6 +8621,7 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash, compone
 			childComponentNs,
 			nlGuardFirst,
 		);
+		ctx._ssrHostChildPos = prevHostChildPos;
 	}
 	// `children=` and spread-held children are content props, not attributes.
 	// With no nested JSX children, the last present writer renders as the host's
@@ -8934,16 +8950,18 @@ function ssrCompileSub(
 ) {
 	const fnName = `${baseName}$${ctx.nextHelperId++}`;
 	const synth = { params: paramNodes || [], body: bodyStmts };
-	// Extracted-fragment subs — component template children (`__schildren`) and
-	// returned-tree mirrors (`__sfragment`) — fold expression holes into
-	// descriptor VALUE holes on the client (`props.hN` + childTextHole); only
-	// directive ARMS keep the template walk there. Mark them so
-	// ssrEmitTsrxExpression keeps `{cond ? A : B}` on ssrChild inside them,
-	// mirroring the client's fold instead of claiming an @if. Directive-arm
-	// subs reset the flag through this same save/restore, so an @if INSIDE
-	// children/mirrors claims again, exactly like the client.
+	// Returned-tree mirror subs (`__sfragment`): extractFragment folds EVERY
+	// expression hole in the mirrored tree into a descriptor value hole on the
+	// client (`props.hN` + childTextHole), even holes sitting inside host
+	// elements. Mark them so ssrEmitTsrxExpression keeps `{cond ? A : B}` on
+	// ssrChild throughout the mirror, matching that fold. Directive-arm subs
+	// reset the flag through this same save/restore, so an @if INSIDE a mirror
+	// claims again, exactly like the client. (Component `__schildren` subs are
+	// NOT folded wholesale — only their ROOT holes are the children-as-props
+	// value, which `_ssrHostChildPos` already leaves unclaimed — while a hole
+	// inside a host element within children claims like any template child.)
 	const prevFoldedExprHoles = ctx._ssrFoldedExprHoles;
-	ctx._ssrFoldedExprHoles = baseName === '__schildren' || baseName === '__sfragment';
+	ctx._ssrFoldedExprHoles = baseName === '__sfragment';
 	let fn;
 	try {
 		fn = ssrCompileBody(
@@ -9485,18 +9503,20 @@ function ssrEmitTsrxExpression(node, ctx, name, inlinedSubs, parentNs, cssHash, 
 		node.returnedJsxValue !== true &&
 		ctx._tsxValuePos !== true &&
 		ctx._ssrFoldedExprHoles !== true &&
+		ctx._ssrHostChildPos === true &&
 		isConditionalJsx(expr)
 	) {
-		// Mirror the client's child-position lowering (emitElementHtml): in a
-		// TEMPLATE-form body a `{cond ? A : B}` hole with a JSX arm becomes an
-		// @if on BOTH sides, so each arm compiles as an ordinary arm body and
-		// the hydration shapes (control key, arm ranges, a keyed `.map` claimed
-		// inside a value arm) agree by construction. VALUE-form positions stay
-		// on ssrChild: the client folds returned `.tsx` trees' holes and
-		// extracted-fragment holes (component children, returned-tree mirrors)
-		// into descriptor value holes (`props.hN` + childTextHole), never
-		// ifBlock — `_tsxValuePos` and `_ssrFoldedExprHoles` are the server's
-		// mirrors of those two folds.
+		// Mirror the client's claim EXACTLY: only emitElementHtml's children
+		// walk lowers `{cond ? A : B}` with a JSX arm to an @if, so both sides
+		// compile each arm as an ordinary arm body and the hydration shapes
+		// (control key, arm ranges, a keyed `.map` claimed inside a value arm)
+		// agree by construction. Everywhere else the hole is a VALUE on the
+		// client and must stay on ssrChild here: returned `.tsx` trees
+		// (`_tsxValuePos`), returned-tree mirrors whose holes extractFragment
+		// folds to `props.hN` (`_ssrFoldedExprHoles`), and every non-host-child
+		// position — body/arm/fragment roots and component-children roots,
+		// where a rich hole rides the de-opt value path because a portal there
+		// has no host to stamp (`_ssrHostChildPos`).
 		const asIf = {
 			...b.if(expr.test, wrapAsBlockStmt(expr.consequent), wrapAsBlockStmt(expr.alternate)),
 			loc: expr.loc, // same devLoc/control-key position as the client's claim

--- a/packages/octane/tests/_fixtures/ternary-mixed-arms.tsrx
+++ b/packages/octane/tests/_fixtures/ternary-mixed-arms.tsrx
@@ -120,6 +120,18 @@ export function ChildrenArm() @{
 	</div>
 }
 
+// The hole sits at a FRAGMENT-ROOT position (no enclosing host element). The
+// client deliberately routes root-position rich holes through the value path
+// (a portal there has no host to stamp), so this ternary renders as a VALUE on
+// both sides — it must never be claimed into branch ranges.
+export function RootFragArm() @{
+	const [on, setOn] = useState(false);
+	<>
+		<button class="flip" onClick={() => setOn(!on)}>{'flip'}</button>
+		{on ? <b>{'yes'}</b> : 'nope'}
+	</>
+}
+
 // A logical `&&` arm: `false` renders nothing, an element renders.
 export function AndArm() @{
 	const [n, setN] = useState(0);

--- a/packages/octane/tests/_fixtures/ternary-mixed-arms.tsrx
+++ b/packages/octane/tests/_fixtures/ternary-mixed-arms.tsrx
@@ -1,7 +1,9 @@
-// Mixed-arm ternaries written INLINE in a sole-child hole: one arm a keyed
-// array, the other a component. A statically JSX-armed ternary lowers to an
-// @if-style block whose branch hosts the keyed list, not a value hole (the
-// setup-assigned value-hole variants live in hole-kind-flip.tsrx).
+// `{cond ? A : B}` at a child hole is lowered to an ifBlock when EITHER arm is
+// a JSX literal (the setup-assigned value-hole variants live in
+// hole-kind-flip.tsrx). These components pin the contract for the OTHER arm: a
+// non-JSX arm is the branch's render VALUE (React renders it), never a dropped
+// setup statement. Every component mounts on the non-JSX arm first — the
+// regression rendered that arm as an empty host.
 
 import { useState } from 'octane';
 
@@ -9,6 +11,7 @@ function Chip() @{
 	<em>{'chip'}</em>
 }
 
+// The reported repro: a keyed `.map` array in one arm, a component in the other.
 export function MapArm() @{
 	const [mode, setMode] = useState(0);
 	<div>
@@ -33,6 +36,97 @@ export function ForArm() @{
 			} @else {
 				<Chip />
 			}
+		</div>
+	</div>
+}
+
+export function StringArm() @{
+	const [on, setOn] = useState(false);
+	<div>
+		<button class="flip" onClick={() => setOn(!on)}>{'flip'}</button>
+		<div class="host">
+			{on ? <b>{'yes'}</b> : 'nope'}
+		</div>
+	</div>
+}
+
+// The arm is an element held in a setup variable, not a JSX literal.
+export function VarArm() @{
+	const [on, setOn] = useState(false);
+	const alt = <i>{'alt'}</i>;
+	<div>
+		<button class="flip" onClick={() => setOn(!on)}>{'flip'}</button>
+		<div class="host">
+			{on ? <b>{'yes'}</b> : alt}
+		</div>
+	</div>
+}
+
+// A nested ternary chain: every level must keep rendering, including the
+// falsy-primitive tail (React renders `0`).
+export function NestedTernary() @{
+	const [n, setN] = useState(2);
+	<div>
+		<button class="next" onClick={() => setN(n + 1)}>{'next'}</button>
+		<div class="host">
+			{n % 3 === 0
+				? <b>{'a'}</b>
+				: n % 3 === 1
+					? <i>{'b'}</i>
+					: 0}
+		</div>
+	</div>
+}
+
+// A `null` consequent — this shape crashed the compiler outright.
+export function NullConsequent() @{
+	const [on, setOn] = useState(true);
+	<div>
+		<button class="flip" onClick={() => setOn(!on)}>{'flip'}</button>
+		<div class="host">
+			{on ? null : <b>{'no'}</b>}
+		</div>
+	</div>
+}
+
+// `undefined` renders nothing (an accidental pass before the fix — pinned so
+// the repaired arm routing keeps treating it as empty, like React).
+export function UndefinedArm() @{
+	const [on, setOn] = useState(false);
+	<div>
+		<button class="flip" onClick={() => setOn(!on)}>{'flip'}</button>
+		<div class="host">
+			{on ? <b>{'yes'}</b> : undefined}
+		</div>
+	</div>
+}
+
+function Box(props) @{
+	<section>{props.children}</section>
+}
+
+// Component-children position: the client folds this ternary into a descriptor
+// VALUE (it is never claimed as an ifBlock there), and the server mirrors the
+// fold — both arms must render and hydrate through the value path.
+export function ChildrenArm() @{
+	const [on, setOn] = useState(false);
+	<div>
+		<button class="flip" onClick={() => setOn(!on)}>{'flip'}</button>
+		<div class="host">
+			<Box>
+				{on ? <b>{'yes'}</b> : 'nope'}
+			</Box>
+		</div>
+	</div>
+}
+
+// A logical `&&` arm: `false` renders nothing, an element renders.
+export function AndArm() @{
+	const [n, setN] = useState(0);
+	<div>
+		<button class="next" onClick={() => setN(n + 1)}>{'next'}</button>
+		<div class="host">
+			{n % 3 === 0 ? n % 2 === 0 && <i>{'maybe'}</i> : <b>{'jsx'}</b>}
 		</div>
 	</div>
 }

--- a/packages/octane/tests/compiler/ternary-child-lowering.test.ts
+++ b/packages/octane/tests/compiler/ternary-child-lowering.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { compile } from 'octane/compiler';
+
+// Lowering contract for `{cond ? A : B}` at a JSX child position when exactly
+// one arm is a JSX literal. Two published properties:
+//   1. The ternary still lowers to the ifBlock machinery (each branch mounts
+//      real DOM) rather than de-opting the whole hole — a mixed arm must not
+//      silently change the JSX arm's mount strategy.
+//   2. The non-JSX arm's VALUE is routed into the branch's render output (the
+//      renderable-hole family), never discarded as a bare setup statement —
+//      and a `null` arm in either position compiles (a null consequent used
+//      to throw inside the compiler).
+// Runtime/differential/hydration suites assert the rendered behavior; these
+// pin the classification the same way known-string-holes.test.ts does.
+
+function importsOf(source: string, mode: 'client' | 'server'): Set<string> {
+	const { code } = compile(source, 'ternary-child-lowering.tsrx', { hmr: false, mode });
+	const match = code.match(/import\s*\{([^}]*)\}\s*from\s*['"]octane(?:\/server)?['"]/);
+	return new Set(
+		(match?.[1] ?? '')
+			.split(',')
+			.map((part) => part.trim().split(/\s+as\s+/)[0])
+			.filter(Boolean),
+	);
+}
+
+function octaneImports(source: string): Set<string> {
+	return importsOf(source, 'client');
+}
+
+describe('ternary child holes with one JSX arm — lowering contract', () => {
+	it('keeps the ifBlock claim and routes the value arm through a renderable hole', () => {
+		const imports = octaneImports(`
+			export function T(props) @{
+				<div id="host">{props.on ? <b>{'yes'}</b> : props.label}</div>
+			}
+		`);
+		expect(imports).toContain('ifBlock');
+		// The non-JSX arm renders through the renderable-hole family (whichever
+		// member the body shape selects), so its value cannot be dropped.
+		const holeFamily = ['textHole', 'childTextHole', 'textSlot', 'childSlot'];
+		expect(holeFamily.some((name) => imports.has(name))).toBe(true);
+	});
+
+	it('a `null` consequent compiles to an ifBlock with an empty then branch', () => {
+		const imports = octaneImports(`
+			export function T(props) @{
+				<div id="host">{props.on ? null : <b>{'no'}</b>}</div>
+			}
+		`);
+		expect(imports).toContain('ifBlock');
+	});
+
+	it('the server claims template-form ternary holes like an authored @if', () => {
+		const imports = importsOf(
+			`
+			export function T(props) @{
+				<div id="host">{props.on ? <b>{'yes'}</b> : props.label}</div>
+			}
+		`,
+			'server',
+		);
+		// Symmetric with the client's ifBlock claim: the arm ranges must match
+		// what the hydrating client adopts.
+		expect(imports).toContain('ssrControl');
+		expect(imports).toContain('ssrArm');
+	});
+
+	it('folded positions keep the value lowering on BOTH sides', () => {
+		// Component children and returned `.tsx` trees fold expression holes into
+		// descriptor value holes on the client — the ternary is never an ifBlock
+		// there, and the server must keep ssrChild for the same holes or the
+		// hydration shapes diverge.
+		const childrenSrc = `
+			function Box(props) @{ <section>{props.children}</section> }
+			export function T(props) @{
+				<div><Box>{props.on ? <b>{'yes'}</b> : 'nope'}</Box></div>
+			}
+		`;
+		expect(octaneImports(childrenSrc)).not.toContain('ifBlock');
+		expect(importsOf(childrenSrc, 'server')).not.toContain('ssrControl');
+
+		const returnedSrc = `
+			export function T(props) {
+				return <div>{props.on ? <b>{'yes'}</b> : 'nope'}</div>;
+			}
+		`;
+		expect(octaneImports(returnedSrc)).not.toContain('ifBlock');
+		expect(importsOf(returnedSrc, 'server')).not.toContain('ssrControl');
+	});
+});

--- a/packages/octane/tests/compiler/ternary-child-lowering.test.ts
+++ b/packages/octane/tests/compiler/ternary-child-lowering.test.ts
@@ -66,19 +66,20 @@ describe('ternary child holes with one JSX arm — lowering contract', () => {
 		expect(imports).toContain('ssrArm');
 	});
 
-	it('folded positions keep the value lowering on BOTH sides', () => {
-		// Component children and returned `.tsx` trees fold expression holes into
-		// descriptor value holes on the client — the ternary is never an ifBlock
-		// there, and the server must keep ssrChild for the same holes or the
-		// hydration shapes diverge.
-		const childrenSrc = `
+	it('value positions keep the value lowering on BOTH sides', () => {
+		// The claim exists only where the client claims: a hole that is the
+		// direct child of a host element in a template walk. Everywhere else —
+		// children-as-props roots, returned `.tsx` trees, body/fragment roots —
+		// the hole is a value, and the server must keep ssrChild for the same
+		// holes or the hydration shapes diverge.
+		const childrenRootSrc = `
 			function Box(props) @{ <section>{props.children}</section> }
 			export function T(props) @{
 				<div><Box>{props.on ? <b>{'yes'}</b> : 'nope'}</Box></div>
 			}
 		`;
-		expect(octaneImports(childrenSrc)).not.toContain('ifBlock');
-		expect(importsOf(childrenSrc, 'server')).not.toContain('ssrControl');
+		expect(octaneImports(childrenRootSrc)).not.toContain('ifBlock');
+		expect(importsOf(childrenRootSrc, 'server')).not.toContain('ssrControl');
 
 		const returnedSrc = `
 			export function T(props) {
@@ -87,5 +88,30 @@ describe('ternary child holes with one JSX arm — lowering contract', () => {
 		`;
 		expect(octaneImports(returnedSrc)).not.toContain('ifBlock');
 		expect(importsOf(returnedSrc, 'server')).not.toContain('ssrControl');
+
+		const rootFragmentSrc = `
+			export function T(props) @{
+				<>
+					<button>{'flip'}</button>
+					{props.on ? <b>{'yes'}</b> : 'nope'}
+				</>
+			}
+		`;
+		expect(octaneImports(rootFragmentSrc)).not.toContain('ifBlock');
+		expect(importsOf(rootFragmentSrc, 'server')).not.toContain('ssrControl');
+	});
+
+	it('a host-wrapped hole inside component children claims on BOTH sides', () => {
+		// Only the children ROOT is the children-as-props value; template
+		// content nested in a host element inside children claims like any
+		// other template child.
+		const src = `
+			function Box(props) @{ <section>{props.children}</section> }
+			export function T(props) @{
+				<div><Box><p>{props.on ? <b>{'yes'}</b> : 'nope'}</p></Box></div>
+			}
+		`;
+		expect(octaneImports(src)).toContain('ifBlock');
+		expect(importsOf(src, 'server')).toContain('ssrControl');
 	});
 });

--- a/packages/octane/tests/differential/ternary-mixed-arms.test.ts
+++ b/packages/octane/tests/differential/ternary-mixed-arms.test.ts
@@ -1,0 +1,120 @@
+import { describe, it } from 'vitest';
+import { mountDifferential } from './_rig.js';
+import { resolve } from 'node:path';
+
+// React is the oracle for `{cond ? A : B}` child holes where exactly ONE arm
+// is a JSX literal: the other arm's value (keyed `.map` array, string,
+// variable-held element, nested ternary, falsy primitive, `null`/`undefined`)
+// must render identically on every toggle. The regression rendered the
+// non-JSX arm as an empty hole; a `null` consequent didn't compile at all.
+const FIXTURE = resolve(__dirname, '../_fixtures/ternary-mixed-arms.tsrx');
+
+describe('differential: ternary-mixed-arms.tsrx — one JSX arm, one value arm', () => {
+	it('MapArm: keyed `.map` array ⇄ component stays byte-identical', async () => {
+		const d = await mountDifferential(FIXTURE, 'MapArm');
+		await d.step('mount (array arm)', () => {});
+		await d.step('to component arm', async (i, r) => {
+			await i.click('.next');
+			await r.click('.next');
+		});
+		await d.step('back to array arm', async (i, r) => {
+			await i.click('.next');
+			await r.click('.next');
+		});
+		d.unmount();
+	});
+
+	it('StringArm: string ⇄ element', async () => {
+		const d = await mountDifferential(FIXTURE, 'StringArm');
+		await d.step('mount (string arm)', () => {});
+		await d.step('to element', async (i, r) => {
+			await i.click('.flip');
+			await r.click('.flip');
+		});
+		await d.step('back to string', async (i, r) => {
+			await i.click('.flip');
+			await r.click('.flip');
+		});
+		d.unmount();
+	});
+
+	it('VarArm: variable-held element ⇄ literal element', async () => {
+		const d = await mountDifferential(FIXTURE, 'VarArm');
+		await d.step('mount (variable arm)', () => {});
+		await d.step('to literal element', async (i, r) => {
+			await i.click('.flip');
+			await r.click('.flip');
+		});
+		await d.step('back to variable arm', async (i, r) => {
+			await i.click('.flip');
+			await r.click('.flip');
+		});
+		d.unmount();
+	});
+
+	it('NestedTernary: chain walks every level including the 0 tail', async () => {
+		const d = await mountDifferential(FIXTURE, 'NestedTernary');
+		await d.step('mount (0 tail)', () => {});
+		for (const name of ['first arm', 'middle arm', 'tail again']) {
+			await d.step(name, async (i, r) => {
+				await i.click('.next');
+				await r.click('.next');
+			});
+		}
+		d.unmount();
+	});
+
+	it('NullConsequent: null arm ⇄ element', async () => {
+		const d = await mountDifferential(FIXTURE, 'NullConsequent');
+		await d.step('mount (null arm)', () => {});
+		await d.step('to element', async (i, r) => {
+			await i.click('.flip');
+			await r.click('.flip');
+		});
+		await d.step('back to null', async (i, r) => {
+			await i.click('.flip');
+			await r.click('.flip');
+		});
+		d.unmount();
+	});
+
+	it('UndefinedArm: undefined arm ⇄ element', async () => {
+		const d = await mountDifferential(FIXTURE, 'UndefinedArm');
+		await d.step('mount (undefined arm)', () => {});
+		await d.step('to element', async (i, r) => {
+			await i.click('.flip');
+			await r.click('.flip');
+		});
+		await d.step('back to undefined', async (i, r) => {
+			await i.click('.flip');
+			await r.click('.flip');
+		});
+		d.unmount();
+	});
+
+	it('ChildrenArm: ternary as component children stays byte-identical', async () => {
+		const d = await mountDifferential(FIXTURE, 'ChildrenArm');
+		await d.step('mount (string arm)', () => {});
+		await d.step('to element', async (i, r) => {
+			await i.click('.flip');
+			await r.click('.flip');
+		});
+		await d.step('back to string', async (i, r) => {
+			await i.click('.flip');
+			await r.click('.flip');
+		});
+		d.unmount();
+	});
+
+	it('AndArm: `&&` arm through truthy, JSX, and false states', async () => {
+		const d = await mountDifferential(FIXTURE, 'AndArm');
+		await d.step('mount (true && element)', () => {});
+		for (const name of ['jsx arm', 'jsx arm again', 'false && element']) {
+			await d.step(name, async (i, r) => {
+				await i.click('.next');
+				await r.click('.next');
+			});
+		}
+		d.unmount();
+	});
+});

--- a/packages/octane/tests/hydration/mismatch-structural.test.ts
+++ b/packages/octane/tests/hydration/mismatch-structural.test.ts
@@ -661,11 +661,10 @@ describe.each([
 		}
 	});
 
-	// The inline-ternary form of the same shape. Its keyed-array arm currently
-	// renders empty on a pure client mount (a compiler lowering gap, owned by the
-	// compiler's ternary tests), so this case pins only what RECOVERY owns: no
-	// throw, the stale server list fully discarded (never leaked into later
-	// arms), and a slot boundary the swaps can keep using.
+	// The inline-ternary form of the same shape (arm rendering itself is owned
+	// by the compiler's ternary suites). This case pins only what RECOVERY
+	// owns: no throw, the stale server list fully discarded (never leaked into
+	// later arms), and a slot boundary the swaps can keep using.
 	it('legacy nested-pair list shape under the inline ternary: discards, never throws or leaks', () => {
 		container.innerHTML = LEGACY_HTML;
 		const root = hydrateRoot(container, client.MapArm);

--- a/packages/octane/tests/hydration/ternary-mixed-arms-hydrate.test.ts
+++ b/packages/octane/tests/hydration/ternary-mixed-arms-hydrate.test.ts
@@ -3,7 +3,13 @@ import { join } from 'node:path';
 import { hydrateRoot, flushSync } from '../../src/index.js';
 import * as ServerRT from 'octane/server';
 import { loadServerFixture } from '../_server-fixture.js';
-import { MapArm, StringArm, ChildrenArm } from '../_fixtures/ternary-mixed-arms.tsrx';
+import {
+	MapArm,
+	StringArm,
+	ChildrenArm,
+	NestedTernary,
+	RootFragArm,
+} from '../_fixtures/ternary-mixed-arms.tsrx';
 
 // The server has always rendered BOTH arms of `{cond ? A : B}` correctly; the
 // client regression dropped the non-JSX arm's value, so SSR markup showed
@@ -62,6 +68,53 @@ describe('hydrateRoot — ternary child hole with one JSX arm', () => {
 
 		flushSync(() => (container.querySelector('.flip') as HTMLButtonElement).click());
 		expect(host.textContent).toBe('nope');
+		root.unmount();
+	});
+
+	it('adopts a nested ternary: the inner ternary is a value hole on both sides', async () => {
+		// The outer ternary claims branch ranges; the INNER one sits at the
+		// branch's fragment root, which renders as a value hole. Server and
+		// client must agree on that split or the adopted ranges misalign.
+		const { html } = await ServerRT.renderToString(server.NestedTernary, {});
+		expect(html).toContain('0'); // n=2 → the nested else tail
+
+		container.innerHTML = html;
+		const host = container.querySelector('.host') as HTMLElement;
+		const root = hydrateRoot(container, NestedTernary);
+		flushSync(() => {});
+
+		expect(container.querySelector('.host')).toBe(host); // adopted
+		expect(host.textContent).toBe('0');
+
+		// Walk every level through the live handler.
+		flushSync(() => (container.querySelector('.next') as HTMLButtonElement).click());
+		expect(host.querySelector('b')?.textContent).toBe('a'); // n=3 → outer then
+
+		flushSync(() => (container.querySelector('.next') as HTMLButtonElement).click());
+		expect(host.querySelector('i')?.textContent).toBe('b'); // n=4 → nested then
+
+		flushSync(() => (container.querySelector('.next') as HTMLButtonElement).click());
+		expect(host.textContent).toBe('0'); // n=5 → nested else again
+		root.unmount();
+	});
+
+	it('adopts a fragment-root ternary as a value hole', async () => {
+		const { html } = await ServerRT.renderToString(server.RootFragArm, {});
+		expect(html).toContain('nope');
+
+		container.innerHTML = html;
+		const btn = container.querySelector('.flip') as HTMLButtonElement;
+		const root = hydrateRoot(container, RootFragArm);
+		flushSync(() => {});
+
+		expect(container.querySelector('.flip')).toBe(btn); // adopted
+		expect(container.textContent).toBe('flipnope');
+
+		flushSync(() => btn.click());
+		expect(container.querySelector('b')?.textContent).toBe('yes');
+
+		flushSync(() => btn.click());
+		expect(container.textContent).toBe('flipnope');
 		root.unmount();
 	});
 

--- a/packages/octane/tests/hydration/ternary-mixed-arms-hydrate.test.ts
+++ b/packages/octane/tests/hydration/ternary-mixed-arms-hydrate.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { hydrateRoot, flushSync } from '../../src/index.js';
+import * as ServerRT from 'octane/server';
+import { loadServerFixture } from '../_server-fixture.js';
+import { MapArm, StringArm, ChildrenArm } from '../_fixtures/ternary-mixed-arms.tsrx';
+
+// The server has always rendered BOTH arms of `{cond ? A : B}` correctly; the
+// client regression dropped the non-JSX arm's value, so SSR markup showed
+// content the hydrating client would blank out. These tests pin client/server
+// agreement: the client adopts the server's non-JSX-arm content (same nodes,
+// no rebuild) and the branch stays interactive afterward.
+
+const FIXTURE = join(process.cwd(), 'packages/octane/tests/_fixtures/ternary-mixed-arms.tsrx');
+const server = loadServerFixture(FIXTURE);
+
+let container: HTMLElement;
+beforeEach(() => {
+	container = document.createElement('div');
+	document.body.appendChild(container);
+});
+afterEach(() => container.remove());
+
+describe('hydrateRoot — ternary child hole with one JSX arm', () => {
+	it('adopts the keyed `.map` array arm and swaps branches after a click', async () => {
+		const { html } = await ServerRT.renderToString(server.MapArm, {});
+		expect(html).toContain('<i>x</i>');
+		expect(html).toContain('<i>y</i>');
+
+		container.innerHTML = html;
+		const first = container.querySelector('.host i') as HTMLElement;
+		const root = hydrateRoot(container, MapArm);
+		flushSync(() => {});
+
+		// The server's array items were ADOPTED (same node), not rebuilt.
+		expect(container.querySelector('.host i')).toBe(first);
+		expect(Array.from(container.querySelectorAll('.host i')).map((n) => n.textContent)).toEqual([
+			'x',
+			'y',
+		]);
+
+		// The block is live: flipping reaches the component arm.
+		flushSync(() => (container.querySelector('.next') as HTMLButtonElement).click());
+		expect(container.querySelector('.host em')?.textContent).toBe('chip');
+		root.unmount();
+	});
+
+	it('adopts a string arm as text and stays interactive', async () => {
+		const { html } = await ServerRT.renderToString(server.StringArm, {});
+		expect(html).toContain('nope');
+
+		container.innerHTML = html;
+		const host = container.querySelector('.host') as HTMLElement;
+		const root = hydrateRoot(container, StringArm);
+		flushSync(() => {});
+
+		expect(container.querySelector('.host')).toBe(host); // adopted host
+		expect(host.textContent).toBe('nope');
+
+		flushSync(() => (container.querySelector('.flip') as HTMLButtonElement).click());
+		expect(host.querySelector('b')?.textContent).toBe('yes');
+
+		flushSync(() => (container.querySelector('.flip') as HTMLButtonElement).click());
+		expect(host.textContent).toBe('nope');
+		root.unmount();
+	});
+
+	it('adopts a component-children ternary (value fold on both sides)', async () => {
+		const { html } = await ServerRT.renderToString(server.ChildrenArm, {});
+		expect(html).toContain('nope');
+
+		container.innerHTML = html;
+		const section = container.querySelector('.host section') as HTMLElement;
+		const root = hydrateRoot(container, ChildrenArm);
+		flushSync(() => {});
+
+		expect(container.querySelector('.host section')).toBe(section); // adopted
+		expect(section.textContent).toBe('nope');
+
+		flushSync(() => (container.querySelector('.flip') as HTMLButtonElement).click());
+		expect(section.querySelector('b')?.textContent).toBe('yes');
+
+		flushSync(() => (container.querySelector('.flip') as HTMLButtonElement).click());
+		expect(section.textContent).toBe('nope');
+		root.unmount();
+	});
+});

--- a/packages/octane/tests/ternary-mixed-arms.test.ts
+++ b/packages/octane/tests/ternary-mixed-arms.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from './_helpers';
+import {
+	MapArm,
+	StringArm,
+	VarArm,
+	NestedTernary,
+	NullConsequent,
+	UndefinedArm,
+	AndArm,
+	ChildrenArm,
+} from './_fixtures/ternary-mixed-arms.tsrx';
+
+// `{cond ? A : B}` at a child hole renders the taken arm's VALUE whatever its
+// shape — matching React. The regression: when exactly one arm was a JSX
+// literal, the other arm's value (an array from `.map`, a string, a variable
+// holding an element, a nested ternary, a primitive) was silently discarded
+// and the hole rendered empty. A `null` consequent crashed the compiler.
+
+function host(r: ReturnType<typeof mount>): HTMLElement {
+	return r.find('.host') as HTMLElement;
+}
+
+describe('ternary child holes — non-JSX arm renders its value', () => {
+	it('keyed `.map` array arm ⇄ component arm (reported repro)', () => {
+		const r = mount(MapArm as any);
+		// mode 0 → the map arm: two keyed <i> items.
+		expect(r.findAll('.host i').map((n) => n.textContent)).toEqual(['x', 'y']);
+		expect(host(r).textContent).toBe('xy');
+
+		r.click('.next'); // mode 1 → <Chip/>
+		expect(r.findAll('.host i')).toHaveLength(0);
+		expect(r.find('.host em').textContent).toBe('chip');
+
+		r.click('.next'); // mode 2 → back to the array
+		expect(r.findAll('.host i').map((n) => n.textContent)).toEqual(['x', 'y']);
+		r.unmount();
+	});
+
+	it('string arm renders as text and survives round trips', () => {
+		const r = mount(StringArm as any);
+		expect(host(r).textContent).toBe('nope');
+
+		r.click('.flip');
+		expect(r.find('.host b').textContent).toBe('yes');
+
+		r.click('.flip');
+		expect(host(r).textContent).toBe('nope');
+		expect(host(r).querySelector('b')).toBeNull();
+		r.unmount();
+	});
+
+	it('element held in a setup variable renders', () => {
+		const r = mount(VarArm as any);
+		expect(r.find('.host i').textContent).toBe('alt');
+
+		r.click('.flip');
+		expect(r.find('.host b').textContent).toBe('yes');
+
+		r.click('.flip');
+		expect(r.find('.host i').textContent).toBe('alt');
+		r.unmount();
+	});
+
+	it('nested ternary chain renders every level, including a falsy 0 tail', () => {
+		const r = mount(NestedTernary as any);
+		expect(host(r).textContent).toBe('0'); // n=2 → the `0` tail must not vanish
+
+		r.click('.next'); // n=3 → first arm
+		expect(r.find('.host b').textContent).toBe('a');
+
+		r.click('.next'); // n=4 → middle arm
+		expect(r.find('.host i').textContent).toBe('b');
+
+		r.click('.next'); // n=5 → tail again
+		expect(host(r).textContent).toBe('0');
+		r.unmount();
+	});
+
+	it('null consequent compiles and renders an empty branch', () => {
+		const r = mount(NullConsequent as any);
+		expect(host(r).textContent).toBe('');
+		expect(host(r).children).toHaveLength(0);
+
+		r.click('.flip');
+		expect(r.find('.host b').textContent).toBe('no');
+
+		r.click('.flip');
+		expect(host(r).textContent).toBe('');
+		r.unmount();
+	});
+
+	it('undefined arm renders nothing, like React', () => {
+		const r = mount(UndefinedArm as any);
+		expect(host(r).textContent).toBe('');
+		expect(host(r).children).toHaveLength(0);
+
+		r.click('.flip');
+		expect(r.find('.host b').textContent).toBe('yes');
+
+		r.click('.flip');
+		expect(host(r).textContent).toBe('');
+		r.unmount();
+	});
+
+	it('component-children ternary renders both arms through the value path', () => {
+		const r = mount(ChildrenArm as any);
+		expect(r.find('.host section').textContent).toBe('nope');
+
+		r.click('.flip');
+		expect(r.find('.host section b').textContent).toBe('yes');
+
+		r.click('.flip');
+		expect(r.find('.host section').textContent).toBe('nope');
+		expect(r.find('.host section').querySelector('b')).toBeNull();
+		r.unmount();
+	});
+
+	it('logical && arm renders the element when truthy and nothing when false', () => {
+		const r = mount(AndArm as any);
+		expect(r.find('.host i').textContent).toBe('maybe'); // n=0 → true && <i>
+
+		r.click('.next'); // n=1 → JSX arm
+		expect(r.find('.host b').textContent).toBe('jsx');
+
+		r.click('.next'); // n=2 → JSX arm
+		expect(r.find('.host b').textContent).toBe('jsx');
+
+		r.click('.next'); // n=3 → false && <i> → empty
+		expect(host(r).textContent).toBe('');
+		expect(host(r).children).toHaveLength(0);
+		r.unmount();
+	});
+});


### PR DESCRIPTION
## Summary
- `{cond ? A : B}` at a child hole is claimed for ifBlock lowering when either arm is a JSX literal; the **other arm's value was silently discarded** — a keyed `.map(…)` array, a string, a variable holding an element, a nested ternary, or a falsy primitive rendered as an empty hole. A `null` consequent (`{cond ? null : <Jsx/>}`) crashed the compiler outright.
- The server always rendered these arms correctly (`ssrChild` keeps the ternary as a value), so SSR shipped content the hydrating client blanked out.
- Non-JSX arms now lower to the authored-equivalent `<>{expr}</>` inside their branch, and the server claims template-form ternary holes symmetrically, so both arms render, update, and hydrate-adopt.

## Why
- Silent empty render is data loss: the repro (`{mode % 2 === 0 ? ['x','y'].map((id) => <i key={id}>…</i>) : <Chip />}`) mounted `#host` empty while React — and Octane's own SSR — render the array. The then-branch compiled to a bare expression statement whose produced array went nowhere.
- `wrapAsBlockStmt` wrapped any non-JSX arm as a raw branch-body statement; `compileFunctionBody`'s body split routes non-JSX statements to setup, so the value was evaluated and dropped. `makeIfCall` also read `.type` off a null consequent.

## Changes
- **`wrapAsBlockStmt`**: a non-JSX arm becomes a synthetic `JSXFragment` + `JSXExpressionContainer` (`@tsrx/core` builders, copy-on-write over the frozen arm), so the branch renders the value through the fragment's child hole. Keyed `.map` arms are claimed onto the same keyed fast path as `@for`; nested ternaries re-enter the lowering and become nested ifBlocks; primitives (including `0`) render as text; `undefined`/`false` render nothing, like React.
- **`makeIfCall` / `ssrEmitIf`**: a null consequent now means "no then branch" on both compilers, mirroring the long-supported null alternate (`_$ifBlock(…, null, __else$N)`; the server emits it like a missing `@else` so the client adopts an empty range).
- **`ssrEmitTsrxExpression`**: template-form ternary holes (`@{}` bodies, directive arms) are claimed into the authored-`@if` SSR shape (`ssrControl` + arm ranges + inner blocks), so the hydrating client **adopts** the taken arm — including keyed list arms — instead of relying on marker coincidence.
- **Scope guards**: the server claim fires only where the client claims. Returned `.tsx` trees (`ctx._tsxValuePos`) and extracted fragments — component template children and returned-tree mirrors (new `ctx._ssrFoldedExprHoles`, set per `ssrCompileSub` kind and reset by directive-arm subs) — fold ternaries to descriptor value holes on the client, and keep byte-identical `ssrChild` output on the server (the visx SSR byte-baseline pins this literally).

## Validation
- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 1449 files / 15,539 tests, all green
- [x] targeted tests: `packages/octane/tests/ternary-mixed-arms.test.ts` (behavioral mounts/toggles), `tests/differential/ternary-mixed-arms.test.ts` (byte-equal vs real React per step), `tests/hydration/ternary-mixed-arms-hydrate.test.ts` (SSR → adoption identity → interactivity), `tests/compiler/ternary-child-lowering.test.ts` (claim/fold classification both modes, null-consequent compiles)
- Pre-fix failures were watched in stages: the null-consequent compiler crash first, then five behavioral value-drop failures (`expected [] to deeply equal ['x','y']`, `expected '' to be 'nope'`, …) after the crash fix alone.

## Risk / follow-ups
- SSR output shape changes for template-form ternary holes only: `ssrChild` descriptors → the authored-`@if` shape (~13 extra marker bytes per rendered arm, template-baked arms instead of per-render descriptor walking). No deterministic bench fixture contains this shape, so no measurement is claimed. Value-form positions are byte-identical (visx suite pins exact bytes).
- Old-shape server HTML meeting the new client (deploy-window skew) hydrates via the existing bridging path for simple arms; for keyed-map arms it hits hydration-mismatch **recovery**, which can crash (`NotFoundError`) — a pre-existing runtime defect with a verified repro, being fixed separately (branch-slot inner-pair adoption guard). That fix's regression tests also add a `tests/_fixtures/ternary-mixed-arms.tsrx` fixture — whichever PR lands second should merge the two fixtures keeping both export sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core compiler lowering and SSR hydration markers for a common JSX pattern; SSR HTML shape changes for host-child template ternaries, with deploy skew called out for legacy keyed-list markup.
> 
> **Overview**
> Fixes **silent empty holes** and a **compiler crash** for `{cond ? A : B}` when one arm is JSX and the other is a plain value (`.map` arrays, strings, variables, nested ternaries, primitives).
> 
> **Compiler:** Non-JSX arms are wrapped as `<>{expr}</>` so the branch actually renders the value instead of evaluating it in setup and dropping it. A **`null` consequent** (`{cond ? null : <Jsx/>}`) no longer crashes and compiles like an empty then-branch, matching a null alternate.
> 
> **SSR:** Template-form ternaries under a **host element’s children** now emit the same **`ssrControl` / arm-range** shape as an authored `@if`, gated by `_ssrHostChildPos` and related flags so **value positions** (returned TSX, fragment roots, component-children roots, folded fragment mirrors) still use **`ssrChild`** unchanged.
> 
> **Tests:** Expanded fixtures and new compiler, mount, differential-vs-React, and hydration adoption suites cover mixed arms, null consequent, and claim boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f33dae876ea3ce50f4209c235392c85b39f4408. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->