### PR TITLE
fix(lynx): defer the application first screen until the engine's __RenderPage lifecycle

### DIFF
--- a/packages/lynx/src/first-screen.ts
+++ b/packages/lynx/src/first-screen.ts
@@ -4,7 +4,11 @@ import type { LynxFirstScreenRenderResult } from './main-renderer.js';
 
 /** Main-thread root contract installed by the generated receiver entry. */
 export interface LynxFirstScreenHost {
-	render<Props>(component: UniversalComponent<Props>, props: Props): LynxFirstScreenRenderResult;
+	/** Returns null when the receiver defers rendering to the engine lifecycle. */
+	render<Props>(
+		component: UniversalComponent<Props>,
+		props: Props,
+	): LynxFirstScreenRenderResult | null;
 	markSyncReady(): void;
 	unmount(): void;
 }
@@ -37,7 +41,7 @@ function requireHost(): LynxFirstScreenHost {
 export interface LynxFirstScreenRoot {
 	readonly renderer: 'lynx';
 	readonly ready: Promise<void>;
-	render<Props>(component: LynxComponent<Props>, props?: Props): LynxFirstScreenRenderResult;
+	render<Props>(component: LynxComponent<Props>, props?: Props): LynxFirstScreenRenderResult | null;
 	flushTransport(): Promise<void>;
 	unmount(): Promise<void>;
 }

--- a/packages/lynx/src/main-thread.ts
+++ b/packages/lynx/src/main-thread.ts
@@ -105,6 +105,16 @@ export interface InstallLynxMainThreadOptions {
 	 * initialization. `automatic` releases background work after `root.render()`.
 	 */
 	readonly firstScreenSync?: 'automatic' | 'manual';
+	/**
+	 * `engine` defers the one-shot first-screen render until the engine's
+	 * `__RenderPage` lifecycle arrives. Native decodes the template's PageConfig
+	 * onto the ElementManager only after main-thread script evaluation
+	 * (`TemplateAssembler::DidVMExecute`), so elements created during evaluation
+	 * see config-dependent defaults — `defaultOverflowVisible` above all — as
+	 * unset and paint clipped. `immediate` keeps the evaluation-time render used
+	 * by source and JavaScript-host tests.
+	 */
+	readonly firstScreenRender?: 'immediate' | 'engine';
 	readonly onDiagnostic?: (error: Error) => void;
 	readonly executeMainThreadWorklet?: (
 		worklet: import('./core/protocol.js').LynxMainThreadWorkletWireDescriptor,
@@ -464,6 +474,16 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 	if (options.firstScreen !== true && options.firstScreenSync !== undefined) {
 		throw new TypeError('Octane Lynx firstScreenSync requires firstScreen: true.');
 	}
+	if (
+		options.firstScreenRender !== undefined &&
+		options.firstScreenRender !== 'immediate' &&
+		options.firstScreenRender !== 'engine'
+	) {
+		throw new TypeError('Octane Lynx firstScreenRender must be immediate or engine.');
+	}
+	if (options.firstScreen !== true && options.firstScreenRender !== undefined) {
+		throw new TypeError('Octane Lynx firstScreenRender requires firstScreen: true.');
+	}
 	const firstScreenEnabled = options.firstScreen === true;
 	const firstScreenSync = options.firstScreenSync ?? 'automatic';
 	const rawTarget = options.target ?? globalThis;
@@ -520,6 +540,9 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 	let firstScreenState: 'open' | 'painted' | 'skipped' | 'failed' | 'cleanup-pending' =
 		firstScreenEnabled ? 'open' : 'skipped';
 	let firstScreenSyncReady = !firstScreenEnabled;
+	const firstScreenRenderMode = options.firstScreenRender ?? 'immediate';
+	let pendingFirstScreenRender: (() => void) | null = null;
+	let firstScreenRenderReleased = firstScreenRenderMode !== 'engine';
 	let firstTree: LynxFirstTree<Node> | null = null;
 	let failedFirstScreenSource: LynxHostContainer<Node> | null = null;
 	let awaitingAdoption: UniversalTransportIdentity | null = null;
@@ -646,6 +669,10 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 			);
 		} catch (error) {
 			report(error, 'Octane Lynx received malformed __RenderPage data.');
+		} finally {
+			// The engine dispatches __RenderPage after script evaluation, once the
+			// decoded PageConfig is installed; a deferred first screen renders here.
+			releaseFirstScreenRender();
 		}
 	};
 
@@ -1590,6 +1617,10 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 	const abortKey = (identity: UniversalTransportIdentity) => `${identity.root}:${identity.version}`;
 
 	const handleReady = (message: LynxMainReadyRequest): void => {
+		// A background ready request also proves script evaluation has finished;
+		// hosts without the typed __RenderPage lifecycle release the deferred
+		// first screen here.
+		releaseFirstScreenRender();
 		if (
 			dispatchingReadyRequest === message.request ||
 			completedReadyRequests.has(message.request)
@@ -1603,7 +1634,7 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 		if (canAnnounceReady()) announceReady();
 	};
 
-	const renderFirstScreen = <Props>(
+	const renderFirstScreenNow = <Props>(
 		component: UniversalComponent<Props>,
 		props: Props,
 	): LynxFirstScreenRenderResult => {
@@ -1658,6 +1689,49 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 		}
 	};
 
+	const renderFirstScreen = <Props>(
+		component: UniversalComponent<Props>,
+		props: Props,
+	): LynxFirstScreenRenderResult | null => {
+		if (firstScreenRenderReleased) return renderFirstScreenNow(component, props);
+		if (closed) throw new Error('Octane Lynx first-screen root rendered after receiver close.');
+		if (firstScreenState !== 'open' || pendingFirstScreenRender !== null) {
+			throw new Error(
+				'Octane Lynx first-screen root is one-shot and its render window has closed.',
+			);
+		}
+		// Element creation must wait for the engine's post-evaluation lifecycle:
+		// PageConfig reaches the ElementManager only after main-thread script
+		// evaluation, and elements created earlier bake in unconfigured defaults.
+		pendingFirstScreenRender = () => {
+			renderFirstScreenNow(component, props);
+		};
+		return null;
+	};
+
+	const releaseFirstScreenRender = (): void => {
+		if (firstScreenRenderReleased) return;
+		firstScreenRenderReleased = true;
+		const pending = pendingFirstScreenRender;
+		pendingFirstScreenRender = null;
+		if (closed) return;
+		if (pending !== null && firstScreenState === 'open') {
+			try {
+				pending();
+			} catch {
+				// renderFirstScreenNow reported the failure and transitioned the
+				// first-screen state; there is no authored caller left to rethrow to.
+			}
+			return;
+		}
+		// The entry finished evaluation without rendering a first screen; settle
+		// the window exactly as an immediate-mode markFirstScreenSyncReady would.
+		if (firstScreenState === 'open' && firstScreenSyncReady) {
+			firstScreenState = 'skipped';
+			announceReady();
+		}
+	};
+
 	const markFirstScreenSyncReady = (): void => {
 		if (!firstScreenEnabled) {
 			throw new Error('Octane Lynx first-screen synchronization is not enabled.');
@@ -1665,7 +1739,13 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 		if (closed) throw new Error('Octane Lynx first-screen synchronization ran after close.');
 		if (firstScreenSyncReady) return;
 		firstScreenSyncReady = true;
-		if (firstScreenState === 'open') firstScreenState = 'skipped';
+		if (
+			firstScreenState === 'open' &&
+			firstScreenRenderReleased &&
+			pendingFirstScreenRender === null
+		) {
+			firstScreenState = 'skipped';
+		}
 		announceReady();
 	};
 
@@ -2253,6 +2333,8 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 				render: renderFirstScreen,
 				markSyncReady: markFirstScreenSyncReady,
 				unmount() {
+					pendingFirstScreenRender = null;
+					firstScreenRenderReleased = true;
 					queuedNativeEvents.length = 0;
 					awaitingAdoption = null;
 					// Unmount closes the authored synchronous window immediately. Cleanup

--- a/packages/lynx/tests/first-screen.test.ts
+++ b/packages/lynx/tests/first-screen.test.ts
@@ -216,6 +216,7 @@ function backgroundContext(): LynxContextProxy {
 
 function installEnvironment(
 	configurePAPI?: (target: Record<string, unknown>) => void,
+	installOptions?: Partial<Parameters<typeof installLynxMainThread>[0]>,
 ): InstalledEnvironment {
 	const dom = new JSDOM('<!doctype html><html><body></body></html>');
 	installLynxTestingEnv(globalThis, {
@@ -235,7 +236,11 @@ function installEnvironment(
 		registrations.push(Object.freeze({ listener }));
 		addEvent(node, kind, name, listener);
 	};
-	const main = installLynxMainThread({ firstScreen: true, firstScreenSync: 'manual' });
+	const main = installLynxMainThread({
+		firstScreen: true,
+		firstScreenSync: 'manual',
+		...installOptions,
+	});
 	return (installed = { dom, main, registrations });
 }
 
@@ -400,6 +405,53 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 			firstTree: { root: 1, version: 1 },
 		});
 		expect((ready[0] as { request: number }).request).toBeGreaterThan(0);
+	});
+
+	it('defers an engine-mode first screen until __RenderPage arrives', () => {
+		// Native installs the decoded PageConfig on the ElementManager only after
+		// main-thread script evaluation, so an engine-mode receiver must not
+		// create elements during evaluation; the render runs when the engine's
+		// __RenderPage lifecycle proves evaluation has finished.
+		const engineListeners = new Map<string, Set<(event: LynxContextProxyEvent) => void>>();
+		const engineContext: LynxContextProxy = {
+			dispatchEvent(event) {
+				for (const listener of [...(engineListeners.get(event.type) ?? [])]) listener(event);
+			},
+			addEventListener(type, listener) {
+				let entries = engineListeners.get(type);
+				if (entries === undefined) engineListeners.set(type, (entries = new Set()));
+				entries.add(listener);
+			},
+			removeEventListener(type, listener) {
+				engineListeners.get(type)?.delete(listener);
+			},
+		};
+		const { dom, main } = installEnvironment(
+			(target) => {
+				(target.lynx as Record<string, unknown>).getEngine = () => engineContext;
+			},
+			{ firstScreenRender: 'engine' },
+		);
+		const props: SceneProps = {
+			id: 'engine-mode',
+			items: ['a'],
+			onTap() {},
+			onEffect() {},
+		};
+
+		const deferred = firstScreenRoot.render(MainScene as UniversalComponent<SceneProps>, props);
+		expect(deferred).toBeNull();
+		expect(dom.window.document.querySelector('#engine-mode')).toBeNull();
+
+		main.markFirstScreenSyncReady();
+		expect(dom.window.document.querySelector('#engine-mode')).toBeNull();
+		expect(main.firstScreenSnapshot()).toBeNull();
+
+		engineContext.dispatchEvent({ type: '__RenderPage', data: [{}, {}] });
+		expect(dom.window.document.querySelector('#engine-mode')).not.toBeNull();
+		expect(dom.window.document.querySelector('#a')).not.toBeNull();
+		expect(main.firstScreenSnapshot()).toMatchObject({ root: 1, version: 1 });
+		expect(main.diagnostics()).toEqual([]);
 	});
 
 	it('repairs a nondeterministic first tree and reports the typed mismatch', () => {

--- a/packages/rspeedy-plugin-octane/src/main-thread-entry.js
+++ b/packages/rspeedy-plugin-octane/src/main-thread-entry.js
@@ -6,4 +6,8 @@ import { installMainThreadProcessData } from './main-thread-process-data.js';
 // lifecycle events. Octane consumes those events directly, so its processor is
 // intentionally the identity function.
 installMainThreadProcessData();
-installLynxMainThread({ firstScreen: true, firstScreenSync: 'manual' });
+installLynxMainThread({
+	firstScreen: true,
+	firstScreenSync: 'manual',
+	firstScreenRender: 'engine',
+});


### PR DESCRIPTION
## Summary
- Add a `firstScreenRender: 'engine'` mode that defers the one-shot first-screen render until the engine's `__RenderPage` lifecycle arrives, and use it in the Rspeedy application entry. This fixes adopted first-screen trees painting with `overflow: hidden` semantics on native — most visibly, offscreen `<image>` content that never appeared when transformed onscreen.

## Why
- Native installs the decoded PageConfig on the ElementManager only **after** main-thread script evaluation: `TemplateAssembler::LoadTemplateInternal` runs `VMExecute → DidVMExecute (→ OnPageConfigDecoded → ElementManager::SetConfig) → RenderTemplate` (lynx-family/lynx, `core/renderer/template_assembler.cc`; the numbered pipeline comment sits right above `LoadTemplateInternal`). `ElementManager::GetDefaultOverflowVisible()` returns `false` while `config_` is unset (`core/renderer/dom/element_manager.h`).
- Octane's generated entry rendered the first screen **during evaluation**, so every element baked in the unconfigured defaults — `defaultOverflowVisible` above all — and the created platform UIs clipped their children permanently. ReactLynx never hits this because it builds elements inside the engine-invoked `renderPage`, after `DidVMExecute`.
- On device (Lynx Explorer 3.9, iOS): the Product Detail (swiper) tutorial port translated a `display: linear` container with `translateX`, and every slide beyond the first rendered black — the subtree outside the container's own bounds was never displayed, and no later attribute/style/`triggerLayout`/element-replacement touch could recover it. A full main-thread PAPI call-sequence trace showed the adopted and background-mounted flows to be equivalent, isolating the divergence to evaluation-time element creation.

## Changes
- `main-thread.ts`: new validated `firstScreenRender` option (default `immediate`, preserving existing behavior for source and JavaScript-host tests). In `engine` mode the render is captured and released by the engine's `__RenderPage` lifecycle (or, as a fallback on hosts without the typed lifecycle, by the first background ready request — both prove evaluation has finished). `markFirstScreenSyncReady` no longer seals a window that is still waiting for the engine; an entry that finishes evaluation without rendering settles to `skipped` exactly as before. Unmount clears a pending deferred render.
- `first-screen.ts`: the host/root `render` contract returns `null` when the render is deferred.
- `main-thread-entry.js` (`@octanejs/rspeedy-plugin`): the generated application receiver opts into `firstScreenRender: 'engine'`.
- `first-screen.test.ts`: regression driving the mode through a mock engine context — nothing paints during evaluation or on `markFirstScreenSyncReady`, and dispatching `__RenderPage` paints the tree and captures the first-tree snapshot.

## Validation
- [x] `vitest run --project lynx` — 23 files, 264 tests passed
- [x] `tsgo --noEmit` for `packages/lynx/tsconfig.json` and `tsconfig.testing.json`
- [x] `prettier --check` on changed files
- [x] device evidence (Lynx Explorer 3.9, iOS simulator): the swiper tutorial port now paints every slide when translated onscreen, matching the ReactLynx original side-by-side, with a clean error console on a cold session; the gallery and bank-cards ports keep their previous behavior

## Risk / follow-ups
- `immediate` remains the default, so only the Rspeedy application graph changes behavior; all existing JS-host suites run unchanged.
- In `engine` mode a host that never delivers `__RenderPage` *and* has no background falls back to never painting the first screen; the background-ready fallback covers every real transport we have.
- Follow-up: the examples PR (#414) documents this as a known limitation in `examples/swiper/README.md`; that section should be updated to reference this fix once merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes first-screen timing for the Rspeedy application entry only (`immediate` stays default elsewhere), but incorrect release on unusual hosts could leave the first screen unpainted; core main-thread lifecycle and readiness paths are involved.
> 
> **Overview**
> Adds **`firstScreenRender`** (`immediate` | `engine`, default **`immediate`**) so the one-shot main-thread first screen can wait until native **PageConfig** is on the ElementManager. In **`engine`** mode, `root.render()` queues work and returns **`null`**; the actual paint runs on **`__RenderPage`** (with a background **main-ready** fallback when that lifecycle is missing).
> 
> **`markFirstScreenSyncReady`** no longer closes the window while a deferred render is still pending; entries that finish evaluation without rendering still settle to **skipped** once release runs. Unmount clears any pending deferred render.
> 
> The Rspeedy **`main-thread-entry`** switches to **`firstScreenRender: 'engine'`**, aligning first-screen element creation with ReactLynx-style timing and fixing cases where evaluation-time trees baked unconfigured overflow defaults (e.g. translated swiper slides painting black on device). Tests cover deferral through a mock engine context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f317e1cc8c019b81efde6a37b6cadf257765c2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->