### PR TITLE
docs: label PRs by type and mark agent-authored ones

### DIFF
--- a/.claude/skills/create-a-pr/SKILL.md
+++ b/.claude/skills/create-a-pr/SKILL.md
@@ -76,10 +76,34 @@ git add <files>
 git commit -m "<type>: <summary>"
 git push -u origin <branch>
 gh pr create --fill
+gh pr edit <number> --add-label <type> --add-label agent-authored
 ```
 
 If using `gh pr create --body-file`, write the PR body to a temp file and pass it explicitly.
 
+Label after the PR exists rather than with `gh pr create --label`, so a rejected
+label cannot cost you the PR. An outside contributor's token has no rights to
+label at all; when the edit fails, leave the PR open and name the intended labels
+in the final response.
+
+## Labels
+
+Every PR carries exactly one type label. Every PR whose diff an agent produced
+also carries `agent-authored`.
+
+- Type: the conventional-commit type already in the PR title, one of `feat`,
+  `fix`, `docs`, `test`, `perf`, `refactor`, `chore`, `ci`. A `feat(lynx): …`
+  title takes `feat`. Never apply two.
+- `agent-authored`: apply whenever an agent wrote the change, no matter which
+  account pushes it. The author field cannot show this, because an agent commits
+  under the human's credentials, so the label is the only signal that separates
+  human PRs from agent PRs. Absence of the label asserts a human wrote the diff:
+  never drop it to make a PR read as hand-written. Humans add nothing, and
+  `-label:agent-authored` is the human-authored filter.
+- `bug` and `enhancement` belong to issues. Do not put them on a PR.
+- Do not invent labels. `gh label list` is the full set; adding a type means
+  creating the label in the repo first.
+
 ## Final response
 
-Return PR URL, branch, commit summary, and validation evidence.
+Return PR URL, branch, commit summary, labels applied, and validation evidence.

--- a/.claude/skills/handle-issue/SKILL.md
+++ b/.claude/skills/handle-issue/SKILL.md
@@ -72,3 +72,8 @@ Notes:
 8. **Labels/comments**
    - Use `gh issue edit`/`gh issue comment` only when asked or when operating autonomously with permission.
    - Do not close issues without maintainer instruction unless explicitly authorized.
+   - Classify issues with the existing `bug`/`enhancement`/`documentation`/`question` set. The
+     `feat`/`fix`/`docs`/`test`/`perf`/`refactor`/`chore`/`ci` type labels are for PRs.
+   - Add `agent-authored` to an issue an agent filed. When an agent only comments on someone
+     else's issue, say so in the comment rather than relabelling their issue.
+   - A PR that closes the issue is labelled by `create-a-pr`, not here.

--- a/.cursor/skills/create-a-pr/SKILL.md
+++ b/.cursor/skills/create-a-pr/SKILL.md
@@ -73,10 +73,34 @@ git add <files>
 git commit -m "<type>: <summary>"
 git push -u origin <branch>
 gh pr create --fill
+gh pr edit <number> --add-label <type> --add-label agent-authored
 ```
 
 If using `gh pr create --body-file`, write the PR body to a temp file and pass it explicitly.
 
+Label after the PR exists rather than with `gh pr create --label`, so a rejected
+label cannot cost you the PR. An outside contributor's token has no rights to
+label at all; when the edit fails, leave the PR open and name the intended labels
+in the final response.
+
+## Labels
+
+Every PR carries exactly one type label. Every PR whose diff an agent produced
+also carries `agent-authored`.
+
+- Type: the conventional-commit type already in the PR title, one of `feat`,
+  `fix`, `docs`, `test`, `perf`, `refactor`, `chore`, `ci`. A `feat(lynx): …`
+  title takes `feat`. Never apply two.
+- `agent-authored`: apply whenever an agent wrote the change, no matter which
+  account pushes it. The author field cannot show this, because an agent commits
+  under the human's credentials, so the label is the only signal that separates
+  human PRs from agent PRs. Absence of the label asserts a human wrote the diff:
+  never drop it to make a PR read as hand-written. Humans add nothing, and
+  `-label:agent-authored` is the human-authored filter.
+- `bug` and `enhancement` belong to issues. Do not put them on a PR.
+- Do not invent labels. `gh label list` is the full set; adding a type means
+  creating the label in the repo first.
+
 ## Final response
 
-Return PR URL, branch, commit summary, and validation evidence.
+Return PR URL, branch, commit summary, labels applied, and validation evidence.

--- a/.cursor/skills/handle-issue/SKILL.md
+++ b/.cursor/skills/handle-issue/SKILL.md
@@ -70,3 +70,8 @@ Notes:
 8. **Labels/comments**
    - Use `gh issue edit`/`gh issue comment` only when asked or when operating autonomously with permission.
    - Do not close issues without maintainer instruction unless explicitly authorized.
+   - Classify issues with the existing `bug`/`enhancement`/`documentation`/`question` set. The
+     `feat`/`fix`/`docs`/`test`/`perf`/`refactor`/`chore`/`ci` type labels are for PRs.
+   - Add `agent-authored` to an issue an agent filed. When an agent only comments on someone
+     else's issue, say so in the comment rather than relabelling their issue.
+   - A PR that closes the issue is labelled by `create-a-pr`, not here.

--- a/.gemini/skills/create-a-pr/SKILL.md
+++ b/.gemini/skills/create-a-pr/SKILL.md
@@ -76,10 +76,34 @@ git add <files>
 git commit -m "<type>: <summary>"
 git push -u origin <branch>
 gh pr create --fill
+gh pr edit <number> --add-label <type> --add-label agent-authored
 ```
 
 If using `gh pr create --body-file`, write the PR body to a temp file and pass it explicitly.
 
+Label after the PR exists rather than with `gh pr create --label`, so a rejected
+label cannot cost you the PR. An outside contributor's token has no rights to
+label at all; when the edit fails, leave the PR open and name the intended labels
+in the final response.
+
+## Labels
+
+Every PR carries exactly one type label. Every PR whose diff an agent produced
+also carries `agent-authored`.
+
+- Type: the conventional-commit type already in the PR title, one of `feat`,
+  `fix`, `docs`, `test`, `perf`, `refactor`, `chore`, `ci`. A `feat(lynx): …`
+  title takes `feat`. Never apply two.
+- `agent-authored`: apply whenever an agent wrote the change, no matter which
+  account pushes it. The author field cannot show this, because an agent commits
+  under the human's credentials, so the label is the only signal that separates
+  human PRs from agent PRs. Absence of the label asserts a human wrote the diff:
+  never drop it to make a PR read as hand-written. Humans add nothing, and
+  `-label:agent-authored` is the human-authored filter.
+- `bug` and `enhancement` belong to issues. Do not put them on a PR.
+- Do not invent labels. `gh label list` is the full set; adding a type means
+  creating the label in the repo first.
+
 ## Final response
 
-Return PR URL, branch, commit summary, and validation evidence.
+Return PR URL, branch, commit summary, labels applied, and validation evidence.

--- a/.gemini/skills/handle-issue/SKILL.md
+++ b/.gemini/skills/handle-issue/SKILL.md
@@ -72,3 +72,8 @@ Notes:
 8. **Labels/comments**
    - Use `gh issue edit`/`gh issue comment` only when asked or when operating autonomously with permission.
    - Do not close issues without maintainer instruction unless explicitly authorized.
+   - Classify issues with the existing `bug`/`enhancement`/`documentation`/`question` set. The
+     `feat`/`fix`/`docs`/`test`/`perf`/`refactor`/`chore`/`ci` type labels are for PRs.
+   - Add `agent-authored` to an issue an agent filed. When an agent only comments on someone
+     else's issue, say so in the comment rather than relabelling their issue.
+   - A PR that closes the issue is labelled by `create-a-pr`, not here.

--- a/.github/skills/create-a-pr/SKILL.md
+++ b/.github/skills/create-a-pr/SKILL.md
@@ -76,10 +76,34 @@ git add <files>
 git commit -m "<type>: <summary>"
 git push -u origin <branch>
 gh pr create --fill
+gh pr edit <number> --add-label <type> --add-label agent-authored
 ```
 
 If using `gh pr create --body-file`, write the PR body to a temp file and pass it explicitly.
 
+Label after the PR exists rather than with `gh pr create --label`, so a rejected
+label cannot cost you the PR. An outside contributor's token has no rights to
+label at all; when the edit fails, leave the PR open and name the intended labels
+in the final response.
+
+## Labels
+
+Every PR carries exactly one type label. Every PR whose diff an agent produced
+also carries `agent-authored`.
+
+- Type: the conventional-commit type already in the PR title, one of `feat`,
+  `fix`, `docs`, `test`, `perf`, `refactor`, `chore`, `ci`. A `feat(lynx): …`
+  title takes `feat`. Never apply two.
+- `agent-authored`: apply whenever an agent wrote the change, no matter which
+  account pushes it. The author field cannot show this, because an agent commits
+  under the human's credentials, so the label is the only signal that separates
+  human PRs from agent PRs. Absence of the label asserts a human wrote the diff:
+  never drop it to make a PR read as hand-written. Humans add nothing, and
+  `-label:agent-authored` is the human-authored filter.
+- `bug` and `enhancement` belong to issues. Do not put them on a PR.
+- Do not invent labels. `gh label list` is the full set; adding a type means
+  creating the label in the repo first.
+
 ## Final response
 
-Return PR URL, branch, commit summary, and validation evidence.
+Return PR URL, branch, commit summary, labels applied, and validation evidence.

--- a/.github/skills/handle-issue/SKILL.md
+++ b/.github/skills/handle-issue/SKILL.md
@@ -72,3 +72,8 @@ Notes:
 8. **Labels/comments**
    - Use `gh issue edit`/`gh issue comment` only when asked or when operating autonomously with permission.
    - Do not close issues without maintainer instruction unless explicitly authorized.
+   - Classify issues with the existing `bug`/`enhancement`/`documentation`/`question` set. The
+     `feat`/`fix`/`docs`/`test`/`perf`/`refactor`/`chore`/`ci` type labels are for PRs.
+   - Add `agent-authored` to an issue an agent filed. When an agent only comments on someone
+     else's issue, say so in the comment rather than relabelling their issue.
+   - A PR that closes the issue is labelled by `create-a-pr`, not here.

--- a/.rulesync/skills/create-a-pr/SKILL.md
+++ b/.rulesync/skills/create-a-pr/SKILL.md
@@ -75,10 +75,34 @@ git add <files>
 git commit -m "<type>: <summary>"
 git push -u origin <branch>
 gh pr create --fill
+gh pr edit <number> --add-label <type> --add-label agent-authored
 ```
 
 If using `gh pr create --body-file`, write the PR body to a temp file and pass it explicitly.
 
+Label after the PR exists rather than with `gh pr create --label`, so a rejected
+label cannot cost you the PR. An outside contributor's token has no rights to
+label at all; when the edit fails, leave the PR open and name the intended labels
+in the final response.
+
+## Labels
+
+Every PR carries exactly one type label. Every PR whose diff an agent produced
+also carries `agent-authored`.
+
+- Type: the conventional-commit type already in the PR title, one of `feat`,
+  `fix`, `docs`, `test`, `perf`, `refactor`, `chore`, `ci`. A `feat(lynx): …`
+  title takes `feat`. Never apply two.
+- `agent-authored`: apply whenever an agent wrote the change, no matter which
+  account pushes it. The author field cannot show this, because an agent commits
+  under the human's credentials, so the label is the only signal that separates
+  human PRs from agent PRs. Absence of the label asserts a human wrote the diff:
+  never drop it to make a PR read as hand-written. Humans add nothing, and
+  `-label:agent-authored` is the human-authored filter.
+- `bug` and `enhancement` belong to issues. Do not put them on a PR.
+- Do not invent labels. `gh label list` is the full set; adding a type means
+  creating the label in the repo first.
+
 ## Final response
 
-Return PR URL, branch, commit summary, and validation evidence.
+Return PR URL, branch, commit summary, labels applied, and validation evidence.

--- a/.rulesync/skills/handle-issue/SKILL.md
+++ b/.rulesync/skills/handle-issue/SKILL.md
@@ -72,3 +72,8 @@ Notes:
 8. **Labels/comments**
    - Use `gh issue edit`/`gh issue comment` only when asked or when operating autonomously with permission.
    - Do not close issues without maintainer instruction unless explicitly authorized.
+   - Classify issues with the existing `bug`/`enhancement`/`documentation`/`question` set. The
+     `feat`/`fix`/`docs`/`test`/`perf`/`refactor`/`chore`/`ci` type labels are for PRs.
+   - Add `agent-authored` to an issue an agent filed. When an agent only comments on someone
+     else's issue, say so in the comment rather than relabelling their issue.
+   - A PR that closes the issue is labelled by `create-a-pr`, not here.


### PR DESCRIPTION
## Summary

- `create-a-pr` now requires exactly one conventional-commit type label on every PR (`feat`, `fix`, `docs`, `test`, `perf`, `refactor`, `chore`, `ci`), plus `agent-authored` when an agent produced the diff.
- `handle-issue` keeps issues on the existing `bug`/`enhancement`/`documentation`/`question` set and hands PR labelling back to `create-a-pr`.
- The nine labels are already created in the repo.

## Why

An agent commits under the human's credentials, so the PR author field cannot tell you who actually wrote a diff. `agent-authored` is the only signal that does, and `-label:agent-authored` becomes the human-authored filter. The type label is free on top of it: it is the prefix already sitting in the PR title, so it costs no extra judgment and gives the PR list a filter it currently lacks (none of the last 20 PRs carry any label).

## Changes

- `.rulesync/skills/create-a-pr/SKILL.md`: new Labels section, `gh pr edit --add-label` step in the CLI block, labels added to the required final response.
- `.rulesync/skills/handle-issue/SKILL.md`: three bullets under step 8 splitting issue labels from PR labels.
- Regenerated `.claude/`, `.cursor/`, `.gemini/`, `.github/` skill copies.

Labels are applied after `gh pr create` rather than through `gh pr create --label`, so a rejected label cannot cost you the PR. That matters for outside contributors, whose tokens cannot label at all.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm rules:check` (generated copies in sync)
- [ ] `pnpm typecheck`: not run, no TypeScript touched
- [ ] `pnpm test`: not run, markdown-only change

## Risk / follow-ups

Compliance is self-reported, so the filter is honest-effort rather than an audit trail: an agent that skips the step, or a human who opens the PR by hand after an agent wrote the code, both slip through. If that becomes a problem, the type half can be derived automatically in CI from the title prefix, which leaves only `agent-authored` depending on the agent.

`feat` was created rather than reusing GitHub's default `enhancement`, since a `feature` label alongside `enhancement` would be two names for one thing. `bug` and `enhancement` stay for issues; neither existing label was deleted or renamed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only agent workflow documentation with no runtime, auth, or application code changes.
> 
> **Overview**
> Updates agent **create-a-pr** and **handle-issue** skills (RuleSync source plus regenerated `.claude/`, `.cursor/`, `.gemini/`, `.github/` copies) so GitHub labeling is explicit and consistent.
> 
> **create-a-pr** now adds a post-create `gh pr edit --add-label` step (type from the PR title plus `agent-authored` when an agent wrote the diff), documents why labeling happens after create, defines the full label rules, and requires reporting **labels applied** in the final response.
> 
> **handle-issue** step 8 now separates issue labels (`bug` / `enhancement` / etc.) from PR type labels, when to use `agent-authored` on issues, and that PR labeling is owned by **create-a-pr**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e996aff5b928eacce8c61c6a8e7dc9758f739690. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->