### PR TITLE
ci: open agent-authored PRs as drafts

### DIFF
--- a/.claude/skills/create-a-pr/SKILL.md
+++ b/.claude/skills/create-a-pr/SKILL.md
@@ -75,8 +75,10 @@ git checkout -b <branch>
 git add <files>
 git commit -m "<type>: <summary>"
 git push -u origin <branch>
-gh pr create --fill
+gh pr create --draft --fill
 gh pr edit <number> --add-label <type> --add-label agent-authored
+gh pr checks <number> --watch
+gh pr ready <number>
 ```
 
 If using `gh pr create --body-file`, write the PR body to a temp file and pass it explicitly.
@@ -85,6 +87,21 @@ Label after the PR exists rather than with `gh pr create --label`, so a rejected
 label cannot cost you the PR. An outside contributor's token has no rights to
 label at all; when the edit fails, leave the PR open and name the intended labels
 in the final response.
+
+## Draft until the checks pass
+
+Open every PR as a draft. Nothing has run against the pushed diff yet, and a
+draft cannot be merged or reviewed as finished work during that window. Wait for
+`gh pr checks --watch` to report every check green, then `gh pr ready`, and stop
+there. Merging is the maintainer's decision, not the agent's.
+
+A failing check means going back to the branch and pushing a fix, not marking the
+PR ready with a note about it.
+
+`.github/workflows/draft-agent-prs.yml` converts an `agent-authored` PR that was
+opened outside draft back into a draft, so a forgotten `--draft` costs a round
+trip instead of passing unnoticed. It leaves the PR alone once anyone has marked
+it ready for review, so it never undoes `gh pr ready`.
 
 ## Labels
 
@@ -106,4 +123,5 @@ also carries `agent-authored`.
 
 ## Final response
 
-Return PR URL, branch, commit summary, labels applied, and validation evidence.
+Return PR URL, branch, commit summary, labels applied, whether the PR is still a
+draft or was marked ready, and validation evidence.

--- a/.claude/skills/create-a-pr/SKILL.md
+++ b/.claude/skills/create-a-pr/SKILL.md
@@ -77,8 +77,6 @@ git commit -m "<type>: <summary>"
 git push -u origin <branch>
 gh pr create --draft --fill
 gh pr edit <number> --add-label <type> --add-label agent-authored
-gh pr checks <number> --watch
-gh pr ready <number>
 ```
 
 If using `gh pr create --body-file`, write the PR body to a temp file and pass it explicitly.
@@ -88,15 +86,16 @@ label cannot cost you the PR. An outside contributor's token has no rights to
 label at all; when the edit fails, leave the PR open and name the intended labels
 in the final response.
 
-## Draft until the checks pass
+## Leave the PR as a draft
 
-Open every PR as a draft. Nothing has run against the pushed diff yet, and a
-draft cannot be merged or reviewed as finished work during that window. Wait for
-`gh pr checks --watch` to report every check green, then `gh pr ready`, and stop
-there. Merging is the maintainer's decision, not the agent's.
+Open every PR as a draft and stop there. Nothing has run against the pushed diff
+yet, and the draft state is what says so. Marking it ready for review is the
+maintainer's job, and so is merging. Report the PR URL and end the task.
 
-A failing check means going back to the branch and pushing a fix, not marking the
-PR ready with a note about it.
+Do not sit on `gh pr checks --watch` either. CI registers from the `pull_request`
+event a moment after the PR exists, so a watch started right away often finds an
+empty Checks API and exits non-zero, which reads as a failed suite when nothing
+has started yet. The maintainer reads the run on the PR.
 
 `.github/workflows/draft-agent-prs.yml` converts an `agent-authored` PR that was
 opened outside draft back into a draft, so a forgotten `--draft` costs a round
@@ -123,5 +122,5 @@ also carries `agent-authored`.
 
 ## Final response
 
-Return PR URL, branch, commit summary, labels applied, whether the PR is still a
-draft or was marked ready, and validation evidence.
+Return PR URL, branch, commit summary, labels applied, and validation evidence.
+The PR stays a draft.

--- a/.cursor/skills/create-a-pr/SKILL.md
+++ b/.cursor/skills/create-a-pr/SKILL.md
@@ -74,8 +74,6 @@ git commit -m "<type>: <summary>"
 git push -u origin <branch>
 gh pr create --draft --fill
 gh pr edit <number> --add-label <type> --add-label agent-authored
-gh pr checks <number> --watch
-gh pr ready <number>
 ```
 
 If using `gh pr create --body-file`, write the PR body to a temp file and pass it explicitly.
@@ -85,15 +83,16 @@ label cannot cost you the PR. An outside contributor's token has no rights to
 label at all; when the edit fails, leave the PR open and name the intended labels
 in the final response.
 
-## Draft until the checks pass
+## Leave the PR as a draft
 
-Open every PR as a draft. Nothing has run against the pushed diff yet, and a
-draft cannot be merged or reviewed as finished work during that window. Wait for
-`gh pr checks --watch` to report every check green, then `gh pr ready`, and stop
-there. Merging is the maintainer's decision, not the agent's.
+Open every PR as a draft and stop there. Nothing has run against the pushed diff
+yet, and the draft state is what says so. Marking it ready for review is the
+maintainer's job, and so is merging. Report the PR URL and end the task.
 
-A failing check means going back to the branch and pushing a fix, not marking the
-PR ready with a note about it.
+Do not sit on `gh pr checks --watch` either. CI registers from the `pull_request`
+event a moment after the PR exists, so a watch started right away often finds an
+empty Checks API and exits non-zero, which reads as a failed suite when nothing
+has started yet. The maintainer reads the run on the PR.
 
 `.github/workflows/draft-agent-prs.yml` converts an `agent-authored` PR that was
 opened outside draft back into a draft, so a forgotten `--draft` costs a round
@@ -120,5 +119,5 @@ also carries `agent-authored`.
 
 ## Final response
 
-Return PR URL, branch, commit summary, labels applied, whether the PR is still a
-draft or was marked ready, and validation evidence.
+Return PR URL, branch, commit summary, labels applied, and validation evidence.
+The PR stays a draft.

--- a/.cursor/skills/create-a-pr/SKILL.md
+++ b/.cursor/skills/create-a-pr/SKILL.md
@@ -72,8 +72,10 @@ git checkout -b <branch>
 git add <files>
 git commit -m "<type>: <summary>"
 git push -u origin <branch>
-gh pr create --fill
+gh pr create --draft --fill
 gh pr edit <number> --add-label <type> --add-label agent-authored
+gh pr checks <number> --watch
+gh pr ready <number>
 ```
 
 If using `gh pr create --body-file`, write the PR body to a temp file and pass it explicitly.
@@ -82,6 +84,21 @@ Label after the PR exists rather than with `gh pr create --label`, so a rejected
 label cannot cost you the PR. An outside contributor's token has no rights to
 label at all; when the edit fails, leave the PR open and name the intended labels
 in the final response.
+
+## Draft until the checks pass
+
+Open every PR as a draft. Nothing has run against the pushed diff yet, and a
+draft cannot be merged or reviewed as finished work during that window. Wait for
+`gh pr checks --watch` to report every check green, then `gh pr ready`, and stop
+there. Merging is the maintainer's decision, not the agent's.
+
+A failing check means going back to the branch and pushing a fix, not marking the
+PR ready with a note about it.
+
+`.github/workflows/draft-agent-prs.yml` converts an `agent-authored` PR that was
+opened outside draft back into a draft, so a forgotten `--draft` costs a round
+trip instead of passing unnoticed. It leaves the PR alone once anyone has marked
+it ready for review, so it never undoes `gh pr ready`.
 
 ## Labels
 
@@ -103,4 +120,5 @@ also carries `agent-authored`.
 
 ## Final response
 
-Return PR URL, branch, commit summary, labels applied, and validation evidence.
+Return PR URL, branch, commit summary, labels applied, whether the PR is still a
+draft or was marked ready, and validation evidence.

--- a/.gemini/skills/create-a-pr/SKILL.md
+++ b/.gemini/skills/create-a-pr/SKILL.md
@@ -75,8 +75,10 @@ git checkout -b <branch>
 git add <files>
 git commit -m "<type>: <summary>"
 git push -u origin <branch>
-gh pr create --fill
+gh pr create --draft --fill
 gh pr edit <number> --add-label <type> --add-label agent-authored
+gh pr checks <number> --watch
+gh pr ready <number>
 ```
 
 If using `gh pr create --body-file`, write the PR body to a temp file and pass it explicitly.
@@ -85,6 +87,21 @@ Label after the PR exists rather than with `gh pr create --label`, so a rejected
 label cannot cost you the PR. An outside contributor's token has no rights to
 label at all; when the edit fails, leave the PR open and name the intended labels
 in the final response.
+
+## Draft until the checks pass
+
+Open every PR as a draft. Nothing has run against the pushed diff yet, and a
+draft cannot be merged or reviewed as finished work during that window. Wait for
+`gh pr checks --watch` to report every check green, then `gh pr ready`, and stop
+there. Merging is the maintainer's decision, not the agent's.
+
+A failing check means going back to the branch and pushing a fix, not marking the
+PR ready with a note about it.
+
+`.github/workflows/draft-agent-prs.yml` converts an `agent-authored` PR that was
+opened outside draft back into a draft, so a forgotten `--draft` costs a round
+trip instead of passing unnoticed. It leaves the PR alone once anyone has marked
+it ready for review, so it never undoes `gh pr ready`.
 
 ## Labels
 
@@ -106,4 +123,5 @@ also carries `agent-authored`.
 
 ## Final response
 
-Return PR URL, branch, commit summary, labels applied, and validation evidence.
+Return PR URL, branch, commit summary, labels applied, whether the PR is still a
+draft or was marked ready, and validation evidence.

--- a/.gemini/skills/create-a-pr/SKILL.md
+++ b/.gemini/skills/create-a-pr/SKILL.md
@@ -77,8 +77,6 @@ git commit -m "<type>: <summary>"
 git push -u origin <branch>
 gh pr create --draft --fill
 gh pr edit <number> --add-label <type> --add-label agent-authored
-gh pr checks <number> --watch
-gh pr ready <number>
 ```
 
 If using `gh pr create --body-file`, write the PR body to a temp file and pass it explicitly.
@@ -88,15 +86,16 @@ label cannot cost you the PR. An outside contributor's token has no rights to
 label at all; when the edit fails, leave the PR open and name the intended labels
 in the final response.
 
-## Draft until the checks pass
+## Leave the PR as a draft
 
-Open every PR as a draft. Nothing has run against the pushed diff yet, and a
-draft cannot be merged or reviewed as finished work during that window. Wait for
-`gh pr checks --watch` to report every check green, then `gh pr ready`, and stop
-there. Merging is the maintainer's decision, not the agent's.
+Open every PR as a draft and stop there. Nothing has run against the pushed diff
+yet, and the draft state is what says so. Marking it ready for review is the
+maintainer's job, and so is merging. Report the PR URL and end the task.
 
-A failing check means going back to the branch and pushing a fix, not marking the
-PR ready with a note about it.
+Do not sit on `gh pr checks --watch` either. CI registers from the `pull_request`
+event a moment after the PR exists, so a watch started right away often finds an
+empty Checks API and exits non-zero, which reads as a failed suite when nothing
+has started yet. The maintainer reads the run on the PR.
 
 `.github/workflows/draft-agent-prs.yml` converts an `agent-authored` PR that was
 opened outside draft back into a draft, so a forgotten `--draft` costs a round
@@ -123,5 +122,5 @@ also carries `agent-authored`.
 
 ## Final response
 
-Return PR URL, branch, commit summary, labels applied, whether the PR is still a
-draft or was marked ready, and validation evidence.
+Return PR URL, branch, commit summary, labels applied, and validation evidence.
+The PR stays a draft.

--- a/.github/skills/create-a-pr/SKILL.md
+++ b/.github/skills/create-a-pr/SKILL.md
@@ -75,8 +75,10 @@ git checkout -b <branch>
 git add <files>
 git commit -m "<type>: <summary>"
 git push -u origin <branch>
-gh pr create --fill
+gh pr create --draft --fill
 gh pr edit <number> --add-label <type> --add-label agent-authored
+gh pr checks <number> --watch
+gh pr ready <number>
 ```
 
 If using `gh pr create --body-file`, write the PR body to a temp file and pass it explicitly.
@@ -85,6 +87,21 @@ Label after the PR exists rather than with `gh pr create --label`, so a rejected
 label cannot cost you the PR. An outside contributor's token has no rights to
 label at all; when the edit fails, leave the PR open and name the intended labels
 in the final response.
+
+## Draft until the checks pass
+
+Open every PR as a draft. Nothing has run against the pushed diff yet, and a
+draft cannot be merged or reviewed as finished work during that window. Wait for
+`gh pr checks --watch` to report every check green, then `gh pr ready`, and stop
+there. Merging is the maintainer's decision, not the agent's.
+
+A failing check means going back to the branch and pushing a fix, not marking the
+PR ready with a note about it.
+
+`.github/workflows/draft-agent-prs.yml` converts an `agent-authored` PR that was
+opened outside draft back into a draft, so a forgotten `--draft` costs a round
+trip instead of passing unnoticed. It leaves the PR alone once anyone has marked
+it ready for review, so it never undoes `gh pr ready`.
 
 ## Labels
 
@@ -106,4 +123,5 @@ also carries `agent-authored`.
 
 ## Final response
 
-Return PR URL, branch, commit summary, labels applied, and validation evidence.
+Return PR URL, branch, commit summary, labels applied, whether the PR is still a
+draft or was marked ready, and validation evidence.

--- a/.github/skills/create-a-pr/SKILL.md
+++ b/.github/skills/create-a-pr/SKILL.md
@@ -77,8 +77,6 @@ git commit -m "<type>: <summary>"
 git push -u origin <branch>
 gh pr create --draft --fill
 gh pr edit <number> --add-label <type> --add-label agent-authored
-gh pr checks <number> --watch
-gh pr ready <number>
 ```
 
 If using `gh pr create --body-file`, write the PR body to a temp file and pass it explicitly.
@@ -88,15 +86,16 @@ label cannot cost you the PR. An outside contributor's token has no rights to
 label at all; when the edit fails, leave the PR open and name the intended labels
 in the final response.
 
-## Draft until the checks pass
+## Leave the PR as a draft
 
-Open every PR as a draft. Nothing has run against the pushed diff yet, and a
-draft cannot be merged or reviewed as finished work during that window. Wait for
-`gh pr checks --watch` to report every check green, then `gh pr ready`, and stop
-there. Merging is the maintainer's decision, not the agent's.
+Open every PR as a draft and stop there. Nothing has run against the pushed diff
+yet, and the draft state is what says so. Marking it ready for review is the
+maintainer's job, and so is merging. Report the PR URL and end the task.
 
-A failing check means going back to the branch and pushing a fix, not marking the
-PR ready with a note about it.
+Do not sit on `gh pr checks --watch` either. CI registers from the `pull_request`
+event a moment after the PR exists, so a watch started right away often finds an
+empty Checks API and exits non-zero, which reads as a failed suite when nothing
+has started yet. The maintainer reads the run on the PR.
 
 `.github/workflows/draft-agent-prs.yml` converts an `agent-authored` PR that was
 opened outside draft back into a draft, so a forgotten `--draft` costs a round
@@ -123,5 +122,5 @@ also carries `agent-authored`.
 
 ## Final response
 
-Return PR URL, branch, commit summary, labels applied, whether the PR is still a
-draft or was marked ready, and validation evidence.
+Return PR URL, branch, commit summary, labels applied, and validation evidence.
+The PR stays a draft.

--- a/.github/workflows/draft-agent-prs.yml
+++ b/.github/workflows/draft-agent-prs.yml
@@ -32,6 +32,12 @@ jobs:
       - name: Convert an agent-authored pull request back to draft
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
+          # Draft state is not repository content, so the job stays off
+          # `contents`. GITHUB_TOKEN has been reported to answer draft mutations
+          # with "Resource not accessible by integration" (actions/toolkit#1165)
+          # and GraphQL publishes no permission table to check that against, so
+          # an app or PAT secret takes over wherever the repository defines one.
+          github-token: ${{ secrets.DRAFT_PR_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
             const number = context.payload.pull_request.number;

--- a/.github/workflows/draft-agent-prs.yml
+++ b/.github/workflows/draft-agent-prs.yml
@@ -1,0 +1,85 @@
+name: Draft agent PRs
+
+# An agent opens its pull request as a draft and labels it afterwards, so the
+# `labeled` event is the one that normally carries the policy. `opened` covers a
+# pull request that already arrives labelled.
+on:
+  pull_request_target:
+    types: [opened, labeled]
+
+concurrency:
+  # Serialize per pull request instead of cancelling: a dropped run would leave
+  # an agent-authored pull request presenting itself as finished work.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  convert:
+    name: convert to draft
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.state == 'open' &&
+      (github.event.action == 'opened' || github.event.label.name == 'agent-authored') &&
+      contains(github.event.pull_request.labels.*.name, 'agent-authored')
+    runs-on: ubuntu-latest
+    # `pull_request_target` is what gives a fork pull request a writable token.
+    # Nothing here checks out or executes the pull request's code.
+    permissions:
+      issues: read
+      pull-requests: write
+
+    steps:
+      - name: Convert an agent-authored pull request back to draft
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const number = context.payload.pull_request.number;
+
+            // The event payload is a snapshot from before this run was queued.
+            const { data: pull } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: number,
+            });
+            if (pull.draft || pull.state !== "open") {
+              return;
+            }
+            if (!pull.labels.some((label) => label.name === "agent-authored")) {
+              return;
+            }
+
+            // Marking a pull request ready for review is a deliberate act, and
+            // ordinary label edits keep arriving afterwards. Without this the
+            // next label would drag a reviewed pull request back into draft.
+            const timeline = await github.paginate(
+              github.rest.issues.listEventsForTimeline,
+              { owner, repo, issue_number: number, per_page: 100 },
+            );
+            if (timeline.some((event) => event.event === "ready_for_review")) {
+              core.notice(
+                `#${number} was already marked ready for review; leaving it as is.`,
+              );
+              return;
+            }
+
+            try {
+              await github.graphql(
+                `mutation ($id: ID!) {
+                   convertPullRequestToDraft(input: { pullRequestId: $id }) {
+                     clientMutationId
+                   }
+                 }`,
+                { id: pull.node_id },
+              );
+            } catch (error) {
+              core.setFailed(
+                `Could not convert #${number} to a draft: ${error.message}. ` +
+                  "Convert it manually and mark it ready once its checks pass.",
+              );
+              return;
+            }
+
+            core.notice(
+              `Converted #${number} to a draft. Agent-authored pull requests open as drafts and are marked ready once their checks pass.`,
+            );

--- a/.rulesync/skills/create-a-pr/SKILL.md
+++ b/.rulesync/skills/create-a-pr/SKILL.md
@@ -74,8 +74,10 @@ git checkout -b <branch>
 git add <files>
 git commit -m "<type>: <summary>"
 git push -u origin <branch>
-gh pr create --fill
+gh pr create --draft --fill
 gh pr edit <number> --add-label <type> --add-label agent-authored
+gh pr checks <number> --watch
+gh pr ready <number>
 ```
 
 If using `gh pr create --body-file`, write the PR body to a temp file and pass it explicitly.
@@ -84,6 +86,21 @@ Label after the PR exists rather than with `gh pr create --label`, so a rejected
 label cannot cost you the PR. An outside contributor's token has no rights to
 label at all; when the edit fails, leave the PR open and name the intended labels
 in the final response.
+
+## Draft until the checks pass
+
+Open every PR as a draft. Nothing has run against the pushed diff yet, and a
+draft cannot be merged or reviewed as finished work during that window. Wait for
+`gh pr checks --watch` to report every check green, then `gh pr ready`, and stop
+there. Merging is the maintainer's decision, not the agent's.
+
+A failing check means going back to the branch and pushing a fix, not marking the
+PR ready with a note about it.
+
+`.github/workflows/draft-agent-prs.yml` converts an `agent-authored` PR that was
+opened outside draft back into a draft, so a forgotten `--draft` costs a round
+trip instead of passing unnoticed. It leaves the PR alone once anyone has marked
+it ready for review, so it never undoes `gh pr ready`.
 
 ## Labels
 
@@ -105,4 +122,5 @@ also carries `agent-authored`.
 
 ## Final response
 
-Return PR URL, branch, commit summary, labels applied, and validation evidence.
+Return PR URL, branch, commit summary, labels applied, whether the PR is still a
+draft or was marked ready, and validation evidence.

--- a/.rulesync/skills/create-a-pr/SKILL.md
+++ b/.rulesync/skills/create-a-pr/SKILL.md
@@ -76,8 +76,6 @@ git commit -m "<type>: <summary>"
 git push -u origin <branch>
 gh pr create --draft --fill
 gh pr edit <number> --add-label <type> --add-label agent-authored
-gh pr checks <number> --watch
-gh pr ready <number>
 ```
 
 If using `gh pr create --body-file`, write the PR body to a temp file and pass it explicitly.
@@ -87,15 +85,16 @@ label cannot cost you the PR. An outside contributor's token has no rights to
 label at all; when the edit fails, leave the PR open and name the intended labels
 in the final response.
 
-## Draft until the checks pass
+## Leave the PR as a draft
 
-Open every PR as a draft. Nothing has run against the pushed diff yet, and a
-draft cannot be merged or reviewed as finished work during that window. Wait for
-`gh pr checks --watch` to report every check green, then `gh pr ready`, and stop
-there. Merging is the maintainer's decision, not the agent's.
+Open every PR as a draft and stop there. Nothing has run against the pushed diff
+yet, and the draft state is what says so. Marking it ready for review is the
+maintainer's job, and so is merging. Report the PR URL and end the task.
 
-A failing check means going back to the branch and pushing a fix, not marking the
-PR ready with a note about it.
+Do not sit on `gh pr checks --watch` either. CI registers from the `pull_request`
+event a moment after the PR exists, so a watch started right away often finds an
+empty Checks API and exits non-zero, which reads as a failed suite when nothing
+has started yet. The maintainer reads the run on the PR.
 
 `.github/workflows/draft-agent-prs.yml` converts an `agent-authored` PR that was
 opened outside draft back into a draft, so a forgotten `--draft` costs a round
@@ -122,5 +121,5 @@ also carries `agent-authored`.
 
 ## Final response
 
-Return PR URL, branch, commit summary, labels applied, whether the PR is still a
-draft or was marked ready, and validation evidence.
+Return PR URL, branch, commit summary, labels applied, and validation evidence.
+The PR stays a draft.

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -202,5 +202,12 @@ describe('Agent pull request draft policy', () => {
 		assert.match(draftWorkflow, /^ {6}issues: read$/m);
 		assert.match(draftWorkflow, /contains\(github\.event\.pull_request\.labels\.\*\.name/);
 		assert.doesNotMatch(draftWorkflow, /actions\/checkout/);
+		// Converting to draft changes no repository content, and the fallback
+		// secret is the answer to a token that cannot run the mutation.
+		assert.doesNotMatch(draftWorkflow, /contents: write/);
+		assert.match(
+			draftWorkflow,
+			/github-token: \$\{\{ secrets\.DRAFT_PR_TOKEN \|\| secrets\.GITHUB_TOKEN \}\}/,
+		);
 	});
 });

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -7,6 +7,10 @@ import { describe, test } from 'node:test';
 const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const workflow = readFileSync(path.join(REPO, '.github/workflows/ci.yml'), 'utf8');
 const publishWorkflow = readFileSync(path.join(REPO, '.github/workflows/publish.yml'), 'utf8');
+const draftWorkflow = readFileSync(
+	path.join(REPO, '.github/workflows/draft-agent-prs.yml'),
+	'utf8',
+);
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
 
 function jobSource(job) {
@@ -118,5 +122,85 @@ describe('Publish workflow validation', () => {
 		assert.equal(outputs.get('sha'), run.head_sha);
 		assert.match(publishWorkflow, /successfulJobs\.has\("CI provenance"\)/);
 		assert.match(publishWorkflow, /legacyRequiredJobs/);
+	});
+});
+
+describe('Agent pull request draft policy', () => {
+	function runConversion({ pull, timeline = [] }) {
+		const converted = [];
+		const notices = [];
+		const failures = [];
+		const github = {
+			rest: {
+				pulls: { get: async () => ({ data: pull }) },
+				issues: { listEventsForTimeline: async () => undefined },
+			},
+			paginate: async () => timeline,
+			graphql: async (_query, variables) => {
+				converted.push(variables.id);
+				return {};
+			},
+		};
+		const execute = new AsyncFunction(
+			'github',
+			'context',
+			'core',
+			stepScript(draftWorkflow, 'Convert an agent-authored pull request back to draft'),
+		);
+
+		return execute(
+			github,
+			{
+				repo: { owner: 'octanejs', repo: 'octane' },
+				payload: { pull_request: { number: pull.number } },
+			},
+			{
+				notice: (message) => notices.push(message),
+				setFailed: (message) => failures.push(message),
+			},
+		).then(() => ({ converted, notices, failures }));
+	}
+
+	const agentPull = {
+		number: 423,
+		node_id: 'PR_node',
+		draft: false,
+		state: 'open',
+		labels: [{ name: 'feat' }, { name: 'agent-authored' }],
+	};
+
+	test('drafts an agent-authored pull request that was opened for review', async () => {
+		const { converted, failures } = await runConversion({ pull: agentPull });
+
+		assert.deepEqual(converted, ['PR_node']);
+		assert.deepEqual(failures, []);
+	});
+
+	test('leaves a pull request alone once it has been marked ready for review', async () => {
+		const { converted, notices } = await runConversion({
+			pull: agentPull,
+			timeline: [{ event: 'labeled' }, { event: 'ready_for_review' }],
+		});
+
+		assert.deepEqual(converted, []);
+		assert.match(notices.join('\n'), /already marked ready for review/);
+	});
+
+	test('ignores a pull request that is already a draft or carries no agent label', async () => {
+		const alreadyDraft = await runConversion({ pull: { ...agentPull, draft: true } });
+		const humanAuthored = await runConversion({
+			pull: { ...agentPull, labels: [{ name: 'feat' }] },
+		});
+
+		assert.deepEqual(alreadyDraft.converted, []);
+		assert.deepEqual(humanAuthored.converted, []);
+	});
+
+	test('runs with a writable token without checking out pull request code', () => {
+		assert.match(draftWorkflow, /on:\n {2}pull_request_target:\n {4}types: \[opened, labeled\]/);
+		assert.match(draftWorkflow, /^ {6}pull-requests: write$/m);
+		assert.match(draftWorkflow, /^ {6}issues: read$/m);
+		assert.match(draftWorkflow, /contains\(github\.event\.pull_request\.labels\.\*\.name/);
+		assert.doesNotMatch(draftWorkflow, /actions\/checkout/);
 	});
 });


### PR DESCRIPTION
## Summary

- Agents open every PR as a draft and stop there. Marking it ready for review and merging are the maintainer's.
- `.github/workflows/draft-agent-prs.yml` enforces it server side: an `agent-authored` PR that is open for review gets converted back to a draft.

## Why

A freshly pushed agent diff has had nothing run against it. Draft is the state that says so, and it keeps the PR out of the merge path until someone has actually read the run. Documentation alone would not hold, because the failure mode is a forgotten flag, so the label the repo already applies to agent PRs is used as the enforcement key.

The skill deliberately does not tell the agent to poll `gh pr checks --watch`: CI registers from the `pull_request` event a moment after the PR exists, so a watch started right away finds an empty Checks API and exits non-zero, which reads as a failed suite when nothing has started.

## Changes

- `create-a-pr`: `gh pr create --draft`, label, done, plus a section on why the PR stays a draft. Regenerated the four agent copies.
- New workflow on `pull_request_target: [opened, labeled]`. It re-reads the PR (the payload is a pre-queue snapshot), skips anything already draft or unlabelled, and converts through `convertPullRequestToDraft`.
- It skips a PR whose timeline already has a `ready_for_review` event, so an ordinary label edit cannot drag reviewed work back into draft.
- Four tests in `scripts/ci-workflow.test.mjs`, three of which execute the extracted script against mocked Octokit calls.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm ci:workflow:test`
- [x] `pnpm rules:check`, `pnpm context:budget:check`
- [ ] `pnpm typecheck` / `pnpm test`: not run locally, nothing here is in their scope; CI covers both.

## Risk / follow-ups

The workflow takes effect only once it is on `main`, so this PR was drafted by hand. `convertPullRequestToDraft` with the default `GITHUB_TOKEN` is the one thing that cannot be proven before merge: GraphQL publishes no permission table, and there are reports of draft mutations answering "Resource not accessible by integration" from Actions (actions/toolkit#1165). So a rejection fails the step with the PR number and the manual instruction instead of doing nothing quietly, and `secrets.DRAFT_PR_TOKEN` takes over the moment the repository defines it. The job stays off `contents` either way, because draft state is not repository content. No code is checked out, so `pull_request_target` carries no fork-execution risk.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Uses `pull_request_target` with PR write access, but the job does not run fork code; the main operational risk is draft conversion failing if `GITHUB_TOKEN` cannot run the GraphQL mutation until `DRAFT_PR_TOKEN` is configured.
> 
> **Overview**
> Agent **create-a-pr** skills now use **`gh pr create --draft --fill`**, add guidance to **leave PRs as drafts** (no **`gh pr checks --watch`**), and note that **ready-for-review** is for maintainers. The final response must state the PR **stays a draft**.
> 
> A new **`draft-agent-prs.yml`** workflow on **`pull_request_target`** (`opened`, `labeled`) **re-drafts** open, non-draft PRs labeled **`agent-authored`** via **`convertPullRequestToDraft`**, after re-fetching the PR and **skipping** if the timeline already has **`ready_for_review`**. It does not check out PR code and can use **`DRAFT_PR_TOKEN`**.
> 
> **`scripts/ci-workflow.test.mjs`** adds tests that exercise the conversion script with mocks and assert workflow shape (permissions, no checkout).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1ad1f621060a5e81d48d6dc704f388d5fdbdf62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->