### PR TITLE
ci: only run checks on non-draft prs to save runners

### DIFF
--- a/.claude/skills/create-a-pr/SKILL.md
+++ b/.claude/skills/create-a-pr/SKILL.md
@@ -92,10 +92,11 @@ Open every PR as a draft and stop there. Nothing has run against the pushed diff
 yet, and the draft state is what says so. Marking it ready for review is the
 maintainer's job, and so is merging. Report the PR URL and end the task.
 
-Do not sit on `gh pr checks --watch` either. CI registers from the `pull_request`
-event a moment after the PR exists, so a watch started right away often finds an
-empty Checks API and exits non-zero, which reads as a failed suite when nothing
-has started yet. The maintainer reads the run on the PR.
+Do not sit on `gh pr checks --watch` either. Repository CI intentionally skips
+every job while the pull request is a draft and starts on the
+`ready_for_review` event. Cursor Bugbot still reviews every pull request,
+including drafts, outside Actions, so people can watch and respond to its issue
+comments before making a draft ready. Vercel may also report separately.
 
 `.github/workflows/draft-agent-prs.yml` converts an `agent-authored` PR that was
 opened outside draft back into a draft, so a forgotten `--draft` costs a round

--- a/.cursor/skills/create-a-pr/SKILL.md
+++ b/.cursor/skills/create-a-pr/SKILL.md
@@ -89,10 +89,11 @@ Open every PR as a draft and stop there. Nothing has run against the pushed diff
 yet, and the draft state is what says so. Marking it ready for review is the
 maintainer's job, and so is merging. Report the PR URL and end the task.
 
-Do not sit on `gh pr checks --watch` either. CI registers from the `pull_request`
-event a moment after the PR exists, so a watch started right away often finds an
-empty Checks API and exits non-zero, which reads as a failed suite when nothing
-has started yet. The maintainer reads the run on the PR.
+Do not sit on `gh pr checks --watch` either. Repository CI intentionally skips
+every job while the pull request is a draft and starts on the
+`ready_for_review` event. Cursor Bugbot still reviews every pull request,
+including drafts, outside Actions, so people can watch and respond to its issue
+comments before making a draft ready. Vercel may also report separately.
 
 `.github/workflows/draft-agent-prs.yml` converts an `agent-authored` PR that was
 opened outside draft back into a draft, so a forgotten `--draft` costs a round

--- a/.gemini/skills/create-a-pr/SKILL.md
+++ b/.gemini/skills/create-a-pr/SKILL.md
@@ -92,10 +92,11 @@ Open every PR as a draft and stop there. Nothing has run against the pushed diff
 yet, and the draft state is what says so. Marking it ready for review is the
 maintainer's job, and so is merging. Report the PR URL and end the task.
 
-Do not sit on `gh pr checks --watch` either. CI registers from the `pull_request`
-event a moment after the PR exists, so a watch started right away often finds an
-empty Checks API and exits non-zero, which reads as a failed suite when nothing
-has started yet. The maintainer reads the run on the PR.
+Do not sit on `gh pr checks --watch` either. Repository CI intentionally skips
+every job while the pull request is a draft and starts on the
+`ready_for_review` event. Cursor Bugbot still reviews every pull request,
+including drafts, outside Actions, so people can watch and respond to its issue
+comments before making a draft ready. Vercel may also report separately.
 
 `.github/workflows/draft-agent-prs.yml` converts an `agent-authored` PR that was
 opened outside draft back into a draft, so a forgotten `--draft` costs a round

--- a/.github/skills/create-a-pr/SKILL.md
+++ b/.github/skills/create-a-pr/SKILL.md
@@ -92,10 +92,11 @@ Open every PR as a draft and stop there. Nothing has run against the pushed diff
 yet, and the draft state is what says so. Marking it ready for review is the
 maintainer's job, and so is merging. Report the PR URL and end the task.
 
-Do not sit on `gh pr checks --watch` either. CI registers from the `pull_request`
-event a moment after the PR exists, so a watch started right away often finds an
-empty Checks API and exits non-zero, which reads as a failed suite when nothing
-has started yet. The maintainer reads the run on the PR.
+Do not sit on `gh pr checks --watch` either. Repository CI intentionally skips
+every job while the pull request is a draft and starts on the
+`ready_for_review` event. Cursor Bugbot still reviews every pull request,
+including drafts, outside Actions, so people can watch and respond to its issue
+comments before making a draft ready. Vercel may also report separately.
 
 `.github/workflows/draft-agent-prs.yml` converts an `agent-authored` PR that was
 opened outside draft back into a draft, so a forgotten `--draft` costs a round

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
 
 concurrency:
   # Only the newest state of a pull request or main can still ship.
@@ -22,6 +23,9 @@ env:
 jobs:
   release_change:
     name: classify changeset release
+    # GitHub still emits workflow events while a pull request is a draft. Keep
+    # every job behind this guard so those events consume no runner time.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -392,7 +396,7 @@ jobs:
     # generates its metadata-only release commit. Keep the post-merge CI run
     # (publishing waits for it), but do not repeat the full suite once the merge
     # has been authenticated above.
-    if: ${{ always() && !cancelled() && needs.release_change.outputs.is_release != 'true' && needs.release_change.outputs.full_ci != 'false' }}
+    if: ${{ always() && !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && needs.release_change.outputs.is_release != 'true' && needs.release_change.outputs.full_ci != 'false' }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -456,7 +460,7 @@ jobs:
     needs: [release_change, test_shard, website_e2e, heavy_integration]
     # The release PR does not need test contexts. The post-merge release run does:
     # publish.yml verifies these stable aggregate names before publishing.
-    if: ${{ always() && !cancelled() && needs.release_change.outputs.is_release_pr != 'true' }}
+    if: ${{ always() && !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && needs.release_change.outputs.is_release_pr != 'true' }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -488,7 +492,7 @@ jobs:
     needs: release_change
     # Same authenticated-release skip as the shards above: a metadata-only
     # Changesets merge has already passed this on its parent commit.
-    if: ${{ always() && !cancelled() && needs.release_change.outputs.is_release != 'true' && needs.release_change.outputs.full_ci != 'false' }}
+    if: ${{ always() && !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && needs.release_change.outputs.is_release != 'true' && needs.release_change.outputs.full_ci != 'false' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -531,7 +535,7 @@ jobs:
     needs: release_change
     # Run build and browser coverage once on the newest supported Node. The
     # ordinary suite still runs on both Node 22 and 24 above.
-    if: ${{ always() && !cancelled() && needs.release_change.outputs.is_release != 'true' && needs.release_change.outputs.full_ci != 'false' }}
+    if: ${{ always() && !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && needs.release_change.outputs.is_release != 'true' && needs.release_change.outputs.full_ci != 'false' }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -583,7 +587,7 @@ jobs:
     needs: release_change
     # A skipped job reports success, including when it is a required check. The
     # classifier only takes this path for the exact bot-owned metadata commit.
-    if: ${{ always() && !cancelled() && needs.release_change.outputs.is_release_pr != 'true' }}
+    if: ${{ always() && !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && needs.release_change.outputs.is_release_pr != 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -729,7 +733,7 @@ jobs:
   typecheck:
     name: typecheck
     needs: release_change
-    if: ${{ always() && !cancelled() && needs.release_change.outputs.is_release_pr != 'true' && needs.release_change.outputs.full_ci != 'false' }}
+    if: ${{ always() && !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && needs.release_change.outputs.is_release_pr != 'true' && needs.release_change.outputs.full_ci != 'false' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -757,7 +761,7 @@ jobs:
   example_shard:
     name: example apps (${{ matrix.shard }})
     needs: release_change
-    if: ${{ always() && !cancelled() && needs.release_change.outputs.is_release_pr != 'true' && needs.release_change.outputs.full_ci != 'false' }}
+    if: ${{ always() && !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && needs.release_change.outputs.is_release_pr != 'true' && needs.release_change.outputs.full_ci != 'false' }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -796,7 +800,7 @@ jobs:
   examples:
     name: examples
     needs: [release_change, example_shard]
-    if: ${{ always() && !cancelled() && needs.release_change.outputs.is_release_pr != 'true' }}
+    if: ${{ always() && !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && needs.release_change.outputs.is_release_pr != 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -814,7 +818,7 @@ jobs:
   three_compat:
     name: Three compatibility (${{ matrix.lane }})
     needs: release_change
-    if: ${{ always() && !cancelled() && needs.release_change.outputs.is_release_pr != 'true' && needs.release_change.outputs.full_ci != 'false' }}
+    if: ${{ always() && !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && needs.release_change.outputs.is_release_pr != 'true' && needs.release_change.outputs.full_ci != 'false' }}
     runs-on: ubuntu-latest
     # This matrix intentionally rewrites one importer without changing the
     # repository lockfile after the frozen base install.
@@ -876,7 +880,7 @@ jobs:
   lynx_compat:
     name: Lynx compatibility (${{ matrix.lane }})
     needs: release_change
-    if: ${{ always() && !cancelled() && needs.release_change.outputs.is_release_pr != 'true' && needs.release_change.outputs.full_ci != 'false' }}
+    if: ${{ always() && !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && needs.release_change.outputs.is_release_pr != 'true' && needs.release_change.outputs.full_ci != 'false' }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -916,7 +920,7 @@ jobs:
   package:
     name: validate publishable packages
     needs: release_change
-    if: ${{ always() && !cancelled() && needs.release_change.outputs.is_release_pr != 'true' && needs.release_change.outputs.full_ci != 'false' }}
+    if: ${{ always() && !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && needs.release_change.outputs.is_release_pr != 'true' && needs.release_change.outputs.full_ci != 'false' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -954,7 +958,7 @@ jobs:
   provenance:
     name: CI provenance
     needs: [release_change, test, lint, typecheck, examples, three_compat, lynx_compat, package]
-    if: ${{ always() && !cancelled() && needs.release_change.outputs.is_release_pr != 'true' }}
+    if: ${{ always() && !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && needs.release_change.outputs.is_release_pr != 'true' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/draft-agent-prs.yml
+++ b/.github/workflows/draft-agent-prs.yml
@@ -81,11 +81,11 @@ jobs:
             } catch (error) {
               core.setFailed(
                 `Could not convert #${number} to a draft: ${error.message}. ` +
-                  "Convert it manually and mark it ready once its checks pass.",
+                  "Convert it manually; repository CI starts after a maintainer marks it ready.",
               );
               return;
             }
 
             core.notice(
-              `Converted #${number} to a draft. Agent-authored pull requests open as drafts and are marked ready once their checks pass.`,
+              `Converted #${number} to a draft. Repository CI will start after a maintainer marks it ready for review.`,
             );

--- a/.rulesync/skills/create-a-pr/SKILL.md
+++ b/.rulesync/skills/create-a-pr/SKILL.md
@@ -91,10 +91,11 @@ Open every PR as a draft and stop there. Nothing has run against the pushed diff
 yet, and the draft state is what says so. Marking it ready for review is the
 maintainer's job, and so is merging. Report the PR URL and end the task.
 
-Do not sit on `gh pr checks --watch` either. CI registers from the `pull_request`
-event a moment after the PR exists, so a watch started right away often finds an
-empty Checks API and exits non-zero, which reads as a failed suite when nothing
-has started yet. The maintainer reads the run on the PR.
+Do not sit on `gh pr checks --watch` either. Repository CI intentionally skips
+every job while the pull request is a draft and starts on the
+`ready_for_review` event. Cursor Bugbot still reviews every pull request,
+including drafts, outside Actions, so people can watch and respond to its issue
+comments before making a draft ready. Vercel may also report separately.
 
 `.github/workflows/draft-agent-prs.yml` converts an `agent-authored` PR that was
 opened outside draft back into a draft, so a forgotten `--draft` costs a round

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -23,6 +23,16 @@ function jobSource(job) {
 	return workflow.slice(start, nextJob === -1 ? undefined : bodyStart + nextJob);
 }
 
+function workflowJobs() {
+	const jobsMarker = '\njobs:\n';
+	const jobsStart = workflow.indexOf(jobsMarker);
+	assert.notEqual(jobsStart, -1, 'missing jobs block');
+
+	return [
+		...workflow.slice(jobsStart + jobsMarker.length).matchAll(/^  ([a-zA-Z][a-zA-Z0-9_]*):$/gm),
+	].map((match) => match[1]);
+}
+
 function stepScript(workflowSource, stepName) {
 	const stepMarker = `      - name: ${stepName}\n`;
 	const stepStart = workflowSource.indexOf(stepMarker);
@@ -42,6 +52,21 @@ function stepScript(workflowSource, stepName) {
 }
 
 describe('CI workflow aggregation', () => {
+	test('runs no jobs for draft pull requests and starts when they become ready', () => {
+		assert.match(
+			workflow,
+			/^  pull_request:\n    branches: \[main\]\n    types: \[opened, reopened, synchronize, ready_for_review, converted_to_draft\]$/m,
+		);
+
+		const draftGuard =
+			/github\.event_name != 'pull_request' \|\| github\.event\.pull_request\.draft == false/;
+		const jobs = workflowJobs();
+		assert.ok(jobs.length > 0, 'expected CI workflow jobs');
+		for (const job of jobs) {
+			assert.match(jobSource(job), draftGuard, `${job} must not run on a draft pull request`);
+		}
+	});
+
 	test('does not turn a superseded run into failed aggregate checks', () => {
 		for (const job of ['test', 'examples', 'lint', 'provenance']) {
 			assert.match(jobSource(job), /if:.*always\(\).*!\s*cancelled\(\)/);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes when required PR checks run (draft vs ready), which affects merge gating; behavior is encoded in workflow conditionals and a new regression test rather than application code.
> 
> **Overview**
> **GitHub Actions no longer runs CI jobs while a pull request is a draft**, saving runner time on work-in-progress PRs (especially agent-opened drafts). Jobs run after a maintainer marks the PR **ready for review**; pushes to `main` are unchanged.
> 
> The `pull_request` trigger now listens for `ready_for_review` and `converted_to_draft` (along with the usual events). **Every job** in `ci.yml` is gated with `github.event.pull_request.draft == false` on PR events.
> 
> Docs and agent **create-a-pr** skills were updated: don’t `gh pr checks --watch` on drafts; note that **Cursor Bugbot** can still review drafts outside Actions. **`draft-agent-prs.yml`** messages now say CI starts when the PR is marked ready, not when checks pass.
> 
> **`scripts/ci-workflow.test.mjs`** asserts the new trigger types and that each job includes the draft guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93aa09cd29db4b7ca7a60171b68c9464a45552d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->