### PR TITLE
test: deflake the sonner toaster and website dev-SSR suites

### DIFF
--- a/packages/sonner/tests/toaster.test.ts
+++ b/packages/sonner/tests/toaster.test.ts
@@ -18,16 +18,47 @@ async function wait(ms: number): Promise<void> {
 	await settle();
 }
 
+// A toast leaves the DOM one `TIME_BEFORE_UNMOUNT` timer after it is dismissed,
+// so sleeping for that exact budget makes every such assertion a race the test
+// loses whenever the machine is loaded. Poll for the state being asserted
+// instead; the caller still makes the real assertion afterwards.
+async function waitFor(condition: () => boolean, timeout = 2000): Promise<void> {
+	const deadline = Date.now() + timeout;
+	for (;;) {
+		await settle();
+		if (condition() || Date.now() >= deadline) return;
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+}
+
+// Toasts are delivered to every mounted Toaster, so a root left behind by a
+// failed assertion keeps rendering the next tests' toasts: it doubles
+// `onAutoClose` counts and strands the listeners its Toast children registered.
+// Unmounting only on the success path therefore turns one failure into several,
+// which hides the test that actually broke.
+const mountedRoots = new Set<{ unmount: () => void }>();
+
+function mountApp<P>(...args: Parameters<typeof mount<P>>): ReturnType<typeof mount<P>> {
+	const root = mount<P>(...args);
+	mountedRoots.add(root);
+	return root;
+}
+
+function unmountApp(root: { unmount: () => void }): void {
+	if (mountedRoots.delete(root)) root.unmount();
+}
+
 afterEach(async () => {
 	toast.dismiss();
 	await wait(220);
+	for (const root of [...mountedRoots]) unmountApp(root);
 	vi.restoreAllMocks();
 	vi.unstubAllGlobals();
 });
 
 describe('@octanejs/sonner — Toaster', () => {
 	it('renders the upstream accessibility, data-attribute, content and style contract', async () => {
-		const root = mount(ToasterApp, {
+		const root = mountApp(ToasterApp, {
 			theme: 'dark',
 			richColors: true,
 			position: 'top-center',
@@ -68,13 +99,13 @@ describe('@octanejs/sonner — Toaster', () => {
 		await settle();
 		expect(item.getAttribute('data-removed')).toBe('true');
 		expect(onDismiss).toHaveBeenCalledTimes(1);
-		await wait(220);
+		await waitFor(() => root.container.querySelector('[data-testid="contract-toast"]') === null);
 		expect(root.container.querySelector('[data-testid="contract-toast"]')).toBeNull();
-		root.unmount();
+		unmountApp(root);
 	});
 
 	it('updates a toast in place and exposes active toasts through useSonner', async () => {
-		const root = mount(SonnerStateProbe);
+		const root = mountApp(SonnerStateProbe);
 		await settle();
 		toast('Before', { id: 'update', duration: Infinity });
 		await settle();
@@ -93,11 +124,11 @@ describe('@octanejs/sonner — Toaster', () => {
 		expect(root.container.querySelector('[data-sonner-toast]')?.getAttribute('data-type')).toBe(
 			'success',
 		);
-		root.unmount();
+		unmountApp(root);
 	});
 
 	it('supports native action/cancel semantics and custom Octane elements', async () => {
-		const root = mount(ToasterApp);
+		const root = mountApp(ToasterApp);
 		await settle();
 		const action = vi.fn((event: MouseEvent) => event.preventDefault());
 		toast('Action toast', {
@@ -114,7 +145,7 @@ describe('@octanejs/sonner — Toaster', () => {
 		expect(root.container.querySelector('[data-sonner-toast]')).not.toBeNull();
 
 		flushSync(() => (root.container.querySelector('[data-cancel]') as HTMLButtonElement).click());
-		await wait(220);
+		await waitFor(() => root.container.querySelector('[data-sonner-toast]') === null);
 		expect(root.container.querySelector('[data-sonner-toast]')).toBeNull();
 
 		showCustom('custom');
@@ -128,11 +159,11 @@ describe('@octanejs/sonner — Toaster', () => {
 				?.closest('[data-sonner-toast]')
 				?.getAttribute('data-styled'),
 		).toBe('false');
-		root.unmount();
+		unmountApp(root);
 	});
 
 	it('routes targeted and global toasts to the matching Toaster', async () => {
-		const root = mount(DualToasterApp);
+		const root = mountApp(DualToasterApp);
 		await settle();
 		toast('Primary', { id: 'primary-toast', toasterId: 'primary', duration: Infinity });
 		toast('Secondary', {
@@ -150,11 +181,11 @@ describe('@octanejs/sonner — Toaster', () => {
 		expect(primary.textContent).not.toContain('Secondary');
 		expect(secondary.textContent).toContain('Secondary');
 		expect(root.container.textContent).toContain('Global');
-		root.unmount();
+		unmountApp(root);
 	});
 
 	it('collapses a targeted Toaster when only one of its own toasts remains', async () => {
-		const root = mount(DualToasterApp);
+		const root = mountApp(DualToasterApp);
 		await settle();
 		toast('Primary one', {
 			id: 'primary-one',
@@ -185,11 +216,14 @@ describe('@octanejs/sonner — Toaster', () => {
 		);
 
 		toast.dismiss('primary-two');
-		await wait(260);
+		await waitFor(
+			() =>
+				primaryList.querySelector('[data-sonner-toast]')?.getAttribute('data-expanded') === 'false',
+		);
 		expect(primaryList.querySelector('[data-sonner-toast]')?.getAttribute('data-expanded')).toBe(
 			'false',
 		);
-		root.unmount();
+		unmountApp(root);
 	});
 
 	it('uses the front toast height from each position list', async () => {
@@ -211,7 +245,7 @@ describe('@octanejs/sonner — Toaster', () => {
 				toJSON: () => ({}),
 			};
 		});
-		const root = mount(ToasterApp);
+		const root = mountApp(ToasterApp);
 		await settle();
 		toast('Bottom', { id: 'bottom-height', duration: Infinity });
 		toast('Top', {
@@ -226,11 +260,11 @@ describe('@octanejs/sonner — Toaster', () => {
 		const top = lists.find((list) => list.textContent?.includes('Top'))!;
 		expect(bottom.style.getPropertyValue('--front-toast-height')).toBe('30px');
 		expect(top.style.getPropertyValue('--front-toast-height')).toBe('70px');
-		root.unmount();
+		unmountApp(root);
 	});
 
 	it('runs promise loading, extended success, finally and unwrap semantics', async () => {
-		const root = mount(ToasterApp);
+		const root = mountApp(ToasterApp);
 		await settle();
 		let resolve!: (value: { name: string }) => void;
 		const pending = new Promise<{ name: string }>((done) => {
@@ -262,11 +296,11 @@ describe('@octanejs/sonner — Toaster', () => {
 		expect(item.textContent).toContain('Promise complete');
 		expect(item.getAttribute('data-type')).toBe('success');
 		expect(finallyCallback).toHaveBeenCalledTimes(1);
-		root.unmount();
+		unmountApp(root);
 	});
 
 	it('focuses with the default hotkey and restores the previously focused element', async () => {
-		const root = mount(ToasterApp);
+		const root = mountApp(ToasterApp);
 		await settle();
 		toast('Keyboard toast', { id: 'keyboard', duration: Infinity });
 		await settle();
@@ -282,11 +316,11 @@ describe('@octanejs/sonner — Toaster', () => {
 		origin.focus();
 		await settle();
 		expect(document.activeElement).toBe(origin);
-		root.unmount();
+		unmountApp(root);
 	});
 
 	it('auto-closes finite toasts and calls onAutoClose once', async () => {
-		const root = mount(ToasterApp);
+		const root = mountApp(ToasterApp);
 		await settle();
 		const onAutoClose = vi.fn();
 		toast('Timed toast', {
@@ -297,18 +331,22 @@ describe('@octanejs/sonner — Toaster', () => {
 		await settle();
 		expect(root.container.querySelector('[data-sonner-toast]')).not.toBeNull();
 
-		await wait(90);
+		await waitFor(
+			() =>
+				root.container.querySelector('[data-sonner-toast]')?.getAttribute('data-removed') ===
+				'true',
+		);
 		expect(onAutoClose).toHaveBeenCalledTimes(1);
 		expect(root.container.querySelector('[data-sonner-toast]')?.getAttribute('data-removed')).toBe(
 			'true',
 		);
-		await wait(220);
+		await waitFor(() => root.container.querySelector('[data-sonner-toast]') === null);
 		expect(root.container.querySelector('[data-sonner-toast]')).toBeNull();
-		root.unmount();
+		unmountApp(root);
 	});
 
 	it('dismisses with an allowed pointer swipe and reports its direction', async () => {
-		const root = mount(ToasterApp);
+		const root = mountApp(ToasterApp);
 		await settle();
 		const onDismiss = vi.fn();
 		toast('Swipe toast', {
@@ -339,14 +377,14 @@ describe('@octanejs/sonner — Toaster', () => {
 		expect(item.getAttribute('data-swipe-out')).toBe('true');
 		expect(item.getAttribute('data-swipe-direction')).toBe('right');
 		expect(onDismiss).toHaveBeenCalledTimes(1);
-		await wait(220);
+		await waitFor(() => root.container.querySelector('[data-sonner-toast]') === null);
 		expect(root.container.querySelector('[data-sonner-toast]')).toBeNull();
-		root.unmount();
+		unmountApp(root);
 	});
 
 	it('subscribes to toast state once for the lifetime of the Toaster', async () => {
 		const subscribe = vi.spyOn(ToastState, 'subscribe');
-		const root = mount(ToasterApp);
+		const root = mountApp(ToasterApp);
 		await settle();
 		expect(subscribe).toHaveBeenCalledTimes(1);
 
@@ -356,14 +394,14 @@ describe('@octanejs/sonner — Toaster', () => {
 		await settle();
 		expect(subscribe).toHaveBeenCalledTimes(1);
 
-		root.unmount();
+		unmountApp(root);
 		subscribe.mockRestore();
 	});
 
 	it('removes the document visibility listener when a toast unmounts', async () => {
 		const add = vi.spyOn(document, 'addEventListener');
 		const remove = vi.spyOn(document, 'removeEventListener');
-		const root = mount(ToasterApp);
+		const root = mountApp(ToasterApp);
 		await settle();
 		toast('Visibility', { id: 'visibility', duration: Infinity });
 		await settle();
@@ -372,7 +410,7 @@ describe('@octanejs/sonner — Toaster', () => {
 			([eventName]) => eventName === 'visibilitychange',
 		);
 		expect(visibilityRegistration).toBeDefined();
-		root.unmount();
+		unmountApp(root);
 		await settle();
 		expect(remove).toHaveBeenCalledWith('visibilitychange', visibilityRegistration?.[1]);
 
@@ -395,11 +433,11 @@ describe('@octanejs/sonner — Toaster', () => {
 			vi.fn(() => mediaQuery),
 		);
 
-		const root = mount(ToasterApp, { theme: 'system' });
+		const root = mountApp(ToasterApp, { theme: 'system' });
 		await settle();
 		expect(addEventListener).toHaveBeenCalledTimes(1);
 		const listener = addEventListener.mock.calls[0][1];
-		root.unmount();
+		unmountApp(root);
 		await settle();
 		expect(removeEventListener).toHaveBeenCalledWith('change', listener);
 	});

--- a/website/tests/ssr-hydration.e2e.test.ts
+++ b/website/tests/ssr-hydration.e2e.test.ts
@@ -198,11 +198,15 @@ async function loadRoute(
 	options: {
 		beforeNavigation?: (page: import('playwright').Page, errors: string[]) => Promise<void>;
 		waitForNetworkIdle?: boolean;
+		// Deliberate outlier for a caller that knowingly pays a cold dev server's
+		// on-demand compile, which is not an ordinary "wait for this to appear".
+		timeout?: number;
 	} = {},
 ) {
+	const actionTimeout = options.timeout ?? PLAYWRIGHT_ACTION_TIMEOUT;
 	const page = await browser!.newPage();
-	page.setDefaultTimeout(PLAYWRIGHT_ACTION_TIMEOUT);
-	page.setDefaultNavigationTimeout(PLAYWRIGHT_NAVIGATION_TIMEOUT);
+	page.setDefaultTimeout(actionTimeout);
+	page.setDefaultNavigationTimeout(options.timeout ?? PLAYWRIGHT_NAVIGATION_TIMEOUT);
 	const errors: string[] = [];
 	page.on('console', (m) => {
 		if (m.type() === 'error') errors.push(m.text());
@@ -225,14 +229,14 @@ async function loadRoute(
 							requestAnimationFrame(() => requestAnimationFrame(() => resolve(true))),
 						),
 					null,
-					{ timeout: PLAYWRIGHT_ACTION_TIMEOUT },
+					{ timeout: actionTimeout },
 				);
 				// Route preparation and a Vite recovery reload can both finish after
 				// `load`. The behavioral boundary is route-owned DOM, not an arbitrary
 				// two-frame delay. Wait for that boundary before reading the text; the
 				// callers still assert the route rendered user-visible content.
 				await page.waitForFunction(() => document.querySelector('main > *') !== null, null, {
-					timeout: PLAYWRIGHT_ACTION_TIMEOUT,
+					timeout: actionTimeout,
 				});
 				const main = (await page.evaluate(() => document.querySelector('main')?.textContent)) ?? '';
 				return { page, errors, main };
@@ -789,8 +793,19 @@ describe('website dev-SSR → hydration (real browser)', { concurrent: false }, 
 			'--strictPort',
 		]);
 		await waitForServer(server, `http://localhost:${DEV_PORT}/`, 60_000);
-		// Covers the production-build wait above plus the cold dev boot.
-	}, 420_000);
+		// Answering a request does not mean the client module graph is compiled:
+		// Vite transforms it on demand, and the route cases below run four-at-a-time,
+		// so without this the first of them each pay the shared app shell's compile
+		// at the same time, inside one ordinary action budget. Measured against this
+		// cold server, that left the worst route ~12s into its 20s budget on a fast
+		// machine, which a loaded CI runner has no headroom to absorb; compiling the
+		// shell once here first brings the worst route to ~5.5s. The cold start is
+		// still proven, because this load is the one that pays for it, on a budget
+		// that says so rather than an ordinary one.
+		const warmup = await loadRoute(`http://localhost:${DEV_PORT}`, '/docs', { timeout: 120_000 });
+		await warmup.page.close();
+		// Covers the production-build wait above, the cold dev boot, and the warm-up.
+	}, 540_000);
 
 	afterAll(async () => {
 		await stopServer(server);


### PR DESCRIPTION
## Summary

- Fix the two suites that failed CI on `main` at f8e5a00c (run 30622485972): three `packages/sonner/tests/toaster.test.ts` cases and one website dev-SSR route case.
- Both were tests measuring machine load rather than behavior. No product code changes, so no changeset.

## Why

**sonner.** Three cases asserted state a toast only reaches after sonner's 200ms `TIME_BEFORE_UNMOUNT` timer, but waited for it with a fixed 220ms or 260ms sleep. A loaded runner loses that margin.

Losing it once was enough to fail three cases, because each case unmounted its root only on the success path. A Toaster left mounted keeps receiving toasts, so the next case rendered its toast twice: `onAutoClose` fired twice, and the `visibilitychange` listener the second Toast registered was not the one the assertion had captured. That is why CI reported failures at lines 189, 301 and 377 rather than one. Forcing the first case to miss its window reproduces all three failures locally.

**website.** The dev-SSR cases run four-at-a-time against a server booted from a cleared optimize-deps cache, and `waitForServer` only proves it answers a request: Vite still transforms the client module graph on demand. So the first cases each paid the shared app shell's compile at the same time, inside the ordinary 20s action budget. `/docs/tsrx-vs-tsx` timed out waiting for `main > *` on this run and on 30588854853 the day before.

Measured against the cold dev server at the suite's own concurrency, on a 10-core machine:

| | worst route | 
|---|---|
| cold (today) | 12.7s / 11.9s of a 20s budget |
| after one warm-up load | 5.5s |

A loaded CI runner does not have the headroom the first number needs.

## Changes

- `packages/sonner/tests/toaster.test.ts`: poll for the state each case asserts instead of sleeping for it, and track mounted roots so `afterEach` unmounts whatever a failure left behind. The assertions are unchanged.
- `website/tests/ssr-hydration.e2e.test.ts`: load one docs route in `beforeAll` before the fan-out, on an explicit budget that says it is paying for a cold compile (`loadRoute` gained an optional `timeout` for that one caller). Raised the hook budget to 540s, since it now covers the production-build wait, the cold dev boot and the warm-up. The cold start is still exercised, just no longer split across four racing pages.

## Validation

- [ ] `pnpm format:check` (repo-wide not run; `pnpm format:files:check` clean on both files)
- [ ] `pnpm typecheck` (repo-wide not run; the two relevant projects pass, below)
- [ ] `pnpm test` (repo-wide not run locally; CI on `main` had every other job green)
- [x] targeted tests:
  - `vitest run --project sonner` (22 tests) passed 3/3 times under 14-way CPU saturation, plus the toaster file alone.
  - The exact CI command, `pnpm vitest run website/tests/core-apis-docs.test.ts website/tests/ssr-smoke.test.ts website/tests/ssr-hydration.e2e.test.ts --maxWorkers=1`: 3 files, 62 tests, green.
  - `tsgo --noEmit -p packages/sonner/tsconfig.json` and `pnpm --dir website typecheck` both clean.
- Cascade proof: forcing the first sonner case to fail produced 3 failures before this change and 1 after it.

## Risk / follow-ups

- The sonner polls cap at 2s against a 200ms budget, so a genuine regression still fails, just up to 2s later per assertion.
- The website warm-up adds one sequential page load (~10s cold locally) to `beforeAll` and removes contention from the 13 route cases; suite wall-clock was 79s locally.
- Unrelated, not addressed here: a local `pnpm test` globs into `packages/three/tests/_fixtures/ssr-app/node_modules/**`, running nested copies of octane's own suites (some fail there). Those directories are gitignored build artifacts, so a clean CI checkout does not hit it, but it makes local full runs noisy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only test helpers and e2e setup; no runtime or library behavior changes.
> 
> **Overview**
> **Test-only** changes to stop CI flakes from timing and leaked mounts—no product code.
> 
> **Sonner (`toaster.test.ts`):** Replaces fixed ~220–260ms sleeps (which raced sonner’s ~200ms unmount timer under load) with a **`waitFor`** poll until the asserted DOM/state is true. Adds **`mountApp` / `unmountApp`** and tears down every tracked root in **`afterEach`**, so a failed case doesn’t leave a Toaster mounted and cascade into duplicate toasts and wrong listener counts in later tests.
> 
> **Website dev-SSR (`ssr-hydration.e2e.test.ts`):** **`loadRoute`** accepts an optional **`timeout`** for slow cold-compile paths. **`beforeAll`** warms the Vite dev server with one **`/docs`** load (120s budget) before concurrent route cases, so four parallel pages don’t all pay the first on-demand app-shell compile inside the normal 20s action timeout. Hook timeout raised **420s → 540s** for that warm-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 102cd4978e37ca15bd5701e9c39ad2da703d67da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->