### PR TITLE
ci: apply PR labels from the title and a provenance box

### DIFF
--- a/.claude/skills/create-a-pr/SKILL.md
+++ b/.claude/skills/create-a-pr/SKILL.md
@@ -81,16 +81,16 @@ git status --short
 git add <files>
 git commit -m "<type>: <summary>"
 git push -u origin <branch>
-gh pr create --draft --fill
-gh pr edit <number> --add-label <type> --add-label agent-authored
+gh pr create --draft --body-file <file>
 ```
 
-If using `gh pr create --body-file`, write the PR body to a temp file and pass it explicitly.
+Write the body to a temp file and pass it explicitly. Do not use `--fill`: it
+builds the body from your commits and drops the template, taking the provenance
+section with it.
 
-Label after the PR exists rather than with `gh pr create --label`, so a rejected
-label cannot cost you the PR. An outside contributor's token has no rights to
-label at all; when the edit fails, leave the PR open and name the intended labels
-in the final response.
+Apply no labels, and never pass `--label`. Your token has no rights to label at
+all when the PR comes from a fork, and `.github/workflows/label-pr.yml` applies
+both labels as a bot, which does.
 
 ## Leave the PR as a draft
 
@@ -104,30 +104,41 @@ every job while the pull request is a draft and starts on the
 including drafts, outside Actions, so people can watch and respond to its issue
 comments before making a draft ready. Vercel may also report separately.
 
-`.github/workflows/draft-agent-prs.yml` converts an `agent-authored` PR that was
-opened outside draft back into a draft, so a forgotten `--draft` costs a round
-trip instead of passing unnoticed. It leaves the PR alone once anyone has marked
-it ready for review, so it never undoes `gh pr ready`.
+## Declare provenance in the PR body
+
+Keep the provenance section from `.github/pull_request_template.md` in the body
+you write, and tick the box, because an agent produced the diff:
+
+```md
+## Provenance
+
+- [x] An agent produced this diff (`agent-authored`)
+```
+
+Leaving the box clear is a positive claim that a human wrote the diff, so it is
+never the safe thing to do when unsure. An agent commits under a human's
+credentials, which is why nothing else in the PR can tell the two apart.
+
+`.github/workflows/label-pr.yml` reads the box and applies `agent-authored`. It
+runs as a bot with the repository's own token, so this works identically from a
+fork and needs nothing from a maintainer.
+
+Omitting the section **fails the check**, which is why `--fill` is not an option.
+It still labels the PR first, so the only thing left to fix is the body, and
+editing the body re-runs the check. A missing section never clears an existing
+label, because silence is not a denial, but do not lean on that: state the fact.
+Only generated bot pull requests are exempt.
 
 ## Labels
 
-Every PR carries exactly one type label. Every PR whose diff an agent produced
-also carries `agent-authored`.
-
-- Type: the conventional-commit type already in the PR title, one of `feat`,
-  `fix`, `docs`, `test`, `perf`, `refactor`, `chore`, `ci`. A `feat(lynx): …`
-  title takes `feat`. Never apply two.
-- `agent-authored`: apply whenever an agent wrote the change, no matter which
-  account pushes it. The author field cannot show this, because an agent commits
-  under the human's credentials, so the label is the only signal that separates
-  human PRs from agent PRs. Absence of the label asserts a human wrote the diff:
-  never drop it to make a PR read as hand-written. Humans add nothing, and
-  `-label:agent-authored` is the human-authored filter.
-- `bug` and `enhancement` belong to issues. Do not put them on a PR.
-- Do not invent labels. `gh label list` is the full set; adding a type means
-  creating the label in the repo first.
+Do not apply labels. Both are applied by the bot above: the type label (`feat`,
+`fix`, `docs`, `test`, `perf`, `refactor`, `chore`, `ci`) from the PR title, and
+`agent-authored` from the box. Retitling moves the type label, and a title the
+regex cannot read leaves the PR unlabelled, which is the signal to fix the title.
+`bug` and `enhancement` belong to issues.
 
 ## Final response
 
-Return PR URL, branch, commit summary, labels applied, and validation evidence.
+Return PR URL, branch, commit summary, provenance declared, and validation
+evidence.
 The PR stays a draft.

--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -42,6 +42,15 @@ trigger first arises, even if it is a later step you chose:
 - `authoring-tsrx`: writing a new `.tsrx` file.
 - `triage`: the owning area is unclear.
 
+Each skill is `.rulesync/skills/<name>/SKILL.md`, with a generated per-tool copy;
+read that path directly if your tool cannot load a skill by name.
+
+One `create-a-pr` rule must survive not loading it: keep the PR template's
+provenance section and tick its box when an agent produced the diff. An agent
+commits under a human's credentials, so nothing else tells the two apart and a
+clear box asserts a human wrote it. A bot turns it into `agent-authored` and
+derives the type label from the title, so never apply labels yourself.
+
 ## Your React instincts are the main failure mode here
 
 Octane looks like React but differs deliberately. Check

--- a/.cursor/skills/create-a-pr/SKILL.md
+++ b/.cursor/skills/create-a-pr/SKILL.md
@@ -78,16 +78,16 @@ git status --short
 git add <files>
 git commit -m "<type>: <summary>"
 git push -u origin <branch>
-gh pr create --draft --fill
-gh pr edit <number> --add-label <type> --add-label agent-authored
+gh pr create --draft --body-file <file>
 ```
 
-If using `gh pr create --body-file`, write the PR body to a temp file and pass it explicitly.
+Write the body to a temp file and pass it explicitly. Do not use `--fill`: it
+builds the body from your commits and drops the template, taking the provenance
+section with it.
 
-Label after the PR exists rather than with `gh pr create --label`, so a rejected
-label cannot cost you the PR. An outside contributor's token has no rights to
-label at all; when the edit fails, leave the PR open and name the intended labels
-in the final response.
+Apply no labels, and never pass `--label`. Your token has no rights to label at
+all when the PR comes from a fork, and `.github/workflows/label-pr.yml` applies
+both labels as a bot, which does.
 
 ## Leave the PR as a draft
 
@@ -101,30 +101,41 @@ every job while the pull request is a draft and starts on the
 including drafts, outside Actions, so people can watch and respond to its issue
 comments before making a draft ready. Vercel may also report separately.
 
-`.github/workflows/draft-agent-prs.yml` converts an `agent-authored` PR that was
-opened outside draft back into a draft, so a forgotten `--draft` costs a round
-trip instead of passing unnoticed. It leaves the PR alone once anyone has marked
-it ready for review, so it never undoes `gh pr ready`.
+## Declare provenance in the PR body
+
+Keep the provenance section from `.github/pull_request_template.md` in the body
+you write, and tick the box, because an agent produced the diff:
+
+```md
+## Provenance
+
+- [x] An agent produced this diff (`agent-authored`)
+```
+
+Leaving the box clear is a positive claim that a human wrote the diff, so it is
+never the safe thing to do when unsure. An agent commits under a human's
+credentials, which is why nothing else in the PR can tell the two apart.
+
+`.github/workflows/label-pr.yml` reads the box and applies `agent-authored`. It
+runs as a bot with the repository's own token, so this works identically from a
+fork and needs nothing from a maintainer.
+
+Omitting the section **fails the check**, which is why `--fill` is not an option.
+It still labels the PR first, so the only thing left to fix is the body, and
+editing the body re-runs the check. A missing section never clears an existing
+label, because silence is not a denial, but do not lean on that: state the fact.
+Only generated bot pull requests are exempt.
 
 ## Labels
 
-Every PR carries exactly one type label. Every PR whose diff an agent produced
-also carries `agent-authored`.
-
-- Type: the conventional-commit type already in the PR title, one of `feat`,
-  `fix`, `docs`, `test`, `perf`, `refactor`, `chore`, `ci`. A `feat(lynx): …`
-  title takes `feat`. Never apply two.
-- `agent-authored`: apply whenever an agent wrote the change, no matter which
-  account pushes it. The author field cannot show this, because an agent commits
-  under the human's credentials, so the label is the only signal that separates
-  human PRs from agent PRs. Absence of the label asserts a human wrote the diff:
-  never drop it to make a PR read as hand-written. Humans add nothing, and
-  `-label:agent-authored` is the human-authored filter.
-- `bug` and `enhancement` belong to issues. Do not put them on a PR.
-- Do not invent labels. `gh label list` is the full set; adding a type means
-  creating the label in the repo first.
+Do not apply labels. Both are applied by the bot above: the type label (`feat`,
+`fix`, `docs`, `test`, `perf`, `refactor`, `chore`, `ci`) from the PR title, and
+`agent-authored` from the box. Retitling moves the type label, and a title the
+regex cannot read leaves the PR unlabelled, which is the signal to fix the title.
+`bug` and `enhancement` belong to issues.
 
 ## Final response
 
-Return PR URL, branch, commit summary, labels applied, and validation evidence.
+Return PR URL, branch, commit summary, provenance declared, and validation
+evidence.
 The PR stays a draft.

--- a/.gemini/skills/create-a-pr/SKILL.md
+++ b/.gemini/skills/create-a-pr/SKILL.md
@@ -81,16 +81,16 @@ git status --short
 git add <files>
 git commit -m "<type>: <summary>"
 git push -u origin <branch>
-gh pr create --draft --fill
-gh pr edit <number> --add-label <type> --add-label agent-authored
+gh pr create --draft --body-file <file>
 ```
 
-If using `gh pr create --body-file`, write the PR body to a temp file and pass it explicitly.
+Write the body to a temp file and pass it explicitly. Do not use `--fill`: it
+builds the body from your commits and drops the template, taking the provenance
+section with it.
 
-Label after the PR exists rather than with `gh pr create --label`, so a rejected
-label cannot cost you the PR. An outside contributor's token has no rights to
-label at all; when the edit fails, leave the PR open and name the intended labels
-in the final response.
+Apply no labels, and never pass `--label`. Your token has no rights to label at
+all when the PR comes from a fork, and `.github/workflows/label-pr.yml` applies
+both labels as a bot, which does.
 
 ## Leave the PR as a draft
 
@@ -104,30 +104,41 @@ every job while the pull request is a draft and starts on the
 including drafts, outside Actions, so people can watch and respond to its issue
 comments before making a draft ready. Vercel may also report separately.
 
-`.github/workflows/draft-agent-prs.yml` converts an `agent-authored` PR that was
-opened outside draft back into a draft, so a forgotten `--draft` costs a round
-trip instead of passing unnoticed. It leaves the PR alone once anyone has marked
-it ready for review, so it never undoes `gh pr ready`.
+## Declare provenance in the PR body
+
+Keep the provenance section from `.github/pull_request_template.md` in the body
+you write, and tick the box, because an agent produced the diff:
+
+```md
+## Provenance
+
+- [x] An agent produced this diff (`agent-authored`)
+```
+
+Leaving the box clear is a positive claim that a human wrote the diff, so it is
+never the safe thing to do when unsure. An agent commits under a human's
+credentials, which is why nothing else in the PR can tell the two apart.
+
+`.github/workflows/label-pr.yml` reads the box and applies `agent-authored`. It
+runs as a bot with the repository's own token, so this works identically from a
+fork and needs nothing from a maintainer.
+
+Omitting the section **fails the check**, which is why `--fill` is not an option.
+It still labels the PR first, so the only thing left to fix is the body, and
+editing the body re-runs the check. A missing section never clears an existing
+label, because silence is not a denial, but do not lean on that: state the fact.
+Only generated bot pull requests are exempt.
 
 ## Labels
 
-Every PR carries exactly one type label. Every PR whose diff an agent produced
-also carries `agent-authored`.
-
-- Type: the conventional-commit type already in the PR title, one of `feat`,
-  `fix`, `docs`, `test`, `perf`, `refactor`, `chore`, `ci`. A `feat(lynx): …`
-  title takes `feat`. Never apply two.
-- `agent-authored`: apply whenever an agent wrote the change, no matter which
-  account pushes it. The author field cannot show this, because an agent commits
-  under the human's credentials, so the label is the only signal that separates
-  human PRs from agent PRs. Absence of the label asserts a human wrote the diff:
-  never drop it to make a PR read as hand-written. Humans add nothing, and
-  `-label:agent-authored` is the human-authored filter.
-- `bug` and `enhancement` belong to issues. Do not put them on a PR.
-- Do not invent labels. `gh label list` is the full set; adding a type means
-  creating the label in the repo first.
+Do not apply labels. Both are applied by the bot above: the type label (`feat`,
+`fix`, `docs`, `test`, `perf`, `refactor`, `chore`, `ci`) from the PR title, and
+`agent-authored` from the box. Retitling moves the type label, and a title the
+regex cannot read leaves the PR unlabelled, which is the signal to fix the title.
+`bug` and `enhancement` belong to issues.
 
 ## Final response
 
-Return PR URL, branch, commit summary, labels applied, and validation evidence.
+Return PR URL, branch, commit summary, provenance declared, and validation
+evidence.
 The PR stays a draft.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,6 +37,15 @@ trigger first arises, even if it is a later step you chose:
 - `authoring-tsrx`: writing a new `.tsrx` file.
 - `triage`: the owning area is unclear.
 
+Each skill is `.rulesync/skills/<name>/SKILL.md`, with a generated per-tool copy;
+read that path directly if your tool cannot load a skill by name.
+
+One `create-a-pr` rule must survive not loading it: keep the PR template's
+provenance section and tick its box when an agent produced the diff. An agent
+commits under a human's credentials, so nothing else tells the two apart and a
+clear box asserts a human wrote it. A bot turns it into `agent-authored` and
+derives the type label from the title, so never apply labels yourself.
+
 ## Your React instincts are the main failure mode here
 
 Octane looks like React but differs deliberately. Check

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## Summary
+
+<!-- What changed, and why. -->
+
+## Validation
+
+<!-- What you ran, and anything you deliberately left unverified. -->
+
+- [ ] `pnpm format:check`
+- [ ] `pnpm typecheck`
+- [ ] `pnpm test`
+- [ ] targeted tests:
+
+## Risk / follow-ups
+
+<!-- Delete if there are none. -->
+
+## Provenance
+
+- [ ] An agent produced this diff (`agent-authored`)
+
+<!--
+Tick the box above whenever an agent wrote the change, no matter which account
+pushes it. Leaving it clear asserts a human wrote the diff.
+
+A bot reads this box and applies the label, so nothing here needs repository
+permissions and it works the same from a fork. The type label comes from the
+conventional-commit type in the title. Do not apply either by hand.
+-->

--- a/.github/skills/create-a-pr/SKILL.md
+++ b/.github/skills/create-a-pr/SKILL.md
@@ -81,16 +81,16 @@ git status --short
 git add <files>
 git commit -m "<type>: <summary>"
 git push -u origin <branch>
-gh pr create --draft --fill
-gh pr edit <number> --add-label <type> --add-label agent-authored
+gh pr create --draft --body-file <file>
 ```
 
-If using `gh pr create --body-file`, write the PR body to a temp file and pass it explicitly.
+Write the body to a temp file and pass it explicitly. Do not use `--fill`: it
+builds the body from your commits and drops the template, taking the provenance
+section with it.
 
-Label after the PR exists rather than with `gh pr create --label`, so a rejected
-label cannot cost you the PR. An outside contributor's token has no rights to
-label at all; when the edit fails, leave the PR open and name the intended labels
-in the final response.
+Apply no labels, and never pass `--label`. Your token has no rights to label at
+all when the PR comes from a fork, and `.github/workflows/label-pr.yml` applies
+both labels as a bot, which does.
 
 ## Leave the PR as a draft
 
@@ -104,30 +104,41 @@ every job while the pull request is a draft and starts on the
 including drafts, outside Actions, so people can watch and respond to its issue
 comments before making a draft ready. Vercel may also report separately.
 
-`.github/workflows/draft-agent-prs.yml` converts an `agent-authored` PR that was
-opened outside draft back into a draft, so a forgotten `--draft` costs a round
-trip instead of passing unnoticed. It leaves the PR alone once anyone has marked
-it ready for review, so it never undoes `gh pr ready`.
+## Declare provenance in the PR body
+
+Keep the provenance section from `.github/pull_request_template.md` in the body
+you write, and tick the box, because an agent produced the diff:
+
+```md
+## Provenance
+
+- [x] An agent produced this diff (`agent-authored`)
+```
+
+Leaving the box clear is a positive claim that a human wrote the diff, so it is
+never the safe thing to do when unsure. An agent commits under a human's
+credentials, which is why nothing else in the PR can tell the two apart.
+
+`.github/workflows/label-pr.yml` reads the box and applies `agent-authored`. It
+runs as a bot with the repository's own token, so this works identically from a
+fork and needs nothing from a maintainer.
+
+Omitting the section **fails the check**, which is why `--fill` is not an option.
+It still labels the PR first, so the only thing left to fix is the body, and
+editing the body re-runs the check. A missing section never clears an existing
+label, because silence is not a denial, but do not lean on that: state the fact.
+Only generated bot pull requests are exempt.
 
 ## Labels
 
-Every PR carries exactly one type label. Every PR whose diff an agent produced
-also carries `agent-authored`.
-
-- Type: the conventional-commit type already in the PR title, one of `feat`,
-  `fix`, `docs`, `test`, `perf`, `refactor`, `chore`, `ci`. A `feat(lynx): …`
-  title takes `feat`. Never apply two.
-- `agent-authored`: apply whenever an agent wrote the change, no matter which
-  account pushes it. The author field cannot show this, because an agent commits
-  under the human's credentials, so the label is the only signal that separates
-  human PRs from agent PRs. Absence of the label asserts a human wrote the diff:
-  never drop it to make a PR read as hand-written. Humans add nothing, and
-  `-label:agent-authored` is the human-authored filter.
-- `bug` and `enhancement` belong to issues. Do not put them on a PR.
-- Do not invent labels. `gh label list` is the full set; adding a type means
-  creating the label in the repo first.
+Do not apply labels. Both are applied by the bot above: the type label (`feat`,
+`fix`, `docs`, `test`, `perf`, `refactor`, `chore`, `ci`) from the PR title, and
+`agent-authored` from the box. Retitling moves the type label, and a title the
+regex cannot read leaves the PR unlabelled, which is the signal to fix the title.
+`bug` and `enhancement` belong to issues.
 
 ## Final response
 
-Return PR URL, branch, commit summary, labels applied, and validation evidence.
+Return PR URL, branch, commit summary, provenance declared, and validation
+evidence.
 The PR stays a draft.

--- a/.github/workflows/draft-agent-prs.yml
+++ b/.github/workflows/draft-agent-prs.yml
@@ -1,8 +1,9 @@
 name: Draft agent PRs
 
-# An agent opens its pull request as a draft and labels it afterwards, so the
-# `labeled` event is the one that normally carries the policy. `opened` covers a
-# pull request that already arrives labelled.
+# `label-pr.yml` enforces this policy in the same run that applies its label:
+# events emitted with GITHUB_TOKEN cannot start another workflow. This remains
+# the safety net for a pull request that arrives labelled or receives the label
+# independently, for example from a maintainer or a GitHub App.
 on:
   pull_request_target:
     types: [opened, labeled]

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -62,11 +62,35 @@ jobs:
               );
             }
 
+            // A fenced example or a commented-out line is text about the box,
+            // not the box itself, and a pull request that documents this
+            // workflow quotes the line in both forms.
+            let fenced = false;
+            const live = (pull.body ?? "")
+              .replace(/<!--[\s\S]*?-->/g, "\n")
+              .split("\n")
+              .filter((line) => {
+                if (/^[ \t]*(?:```|~~~)/.test(line)) {
+                  fenced = !fenced;
+                  return false;
+                }
+                return !fenced;
+              })
+              .join("\n");
+
+            // The template's own section is the declaration, so a Validation
+            // item that happens to mention the label cannot outrank it. A body
+            // that dropped the heading but kept the line still declares.
+            const heading = /^[ \t]*#{1,6}[ \t]+provenance[ \t]*$/im.exec(live);
+            const after = heading ? live.slice(heading.index + heading[0].length) : live;
+            const nextHeading = heading ? /^[ \t]*#{1,6}[ \t]/m.exec(after) : null;
+            const scope = nextHeading ? after.slice(0, nextHeading.index) : after;
+
             // Three states, not two. A body with no checkbox at all is silence,
             // not a denial, so it must not strip a label somebody applied by
             // hand. Only an explicit empty box retracts the claim.
             const box = new RegExp(`^[ \\t]*[-*][ \\t]*\\[([^\\]]*)\\][^\\n]*${AGENT}`, "im").exec(
-              pull.body ?? "",
+              scope,
             );
             if (box) {
               const claimed = /x/i.test(box[1]);

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -22,6 +22,7 @@ jobs:
     # `pull_request_target` is what gives a fork pull request a writable token.
     # Nothing here checks out or executes the pull request's code.
     permissions:
+      issues: read
       pull-requests: write
 
     steps:
@@ -50,10 +51,14 @@ jobs:
 
             const titled = /^\s*([a-z]+)\s*(?:\([^)]*\))?\s*!?:/.exec(pull.title);
             const type = titled && TYPES.includes(titled[1]) ? titled[1] : null;
+            // An invalid retitle must not leave a stale type behind. No type
+            // label is the visible signal that the title needs fixing.
+            remove.push(
+              ...current.filter((name) => name !== type && TYPES.includes(name)),
+            );
             if (type) {
               // Exactly one type label is the rule, so a retitled pull request
               // has to take its previous type with it.
-              remove.push(...current.filter((name) => name !== type && TYPES.includes(name)));
               if (!current.includes(type)) add.push(type);
             } else {
               core.notice(
@@ -79,19 +84,19 @@ jobs:
               .join("\n");
 
             // The template's own section is the declaration, so a Validation
-            // item that happens to mention the label cannot outrank it. A body
-            // that dropped the heading but kept the line still declares.
+            // item that happens to mention the label cannot stand in for it.
             const heading = /^[ \t]*#{1,6}[ \t]+provenance[ \t]*$/im.exec(live);
-            const after = heading ? live.slice(heading.index + heading[0].length) : live;
+            const after = heading ? live.slice(heading.index + heading[0].length) : "";
             const nextHeading = heading ? /^[ \t]*#{1,6}[ \t]/m.exec(after) : null;
             const scope = nextHeading ? after.slice(0, nextHeading.index) : after;
 
             // Three states, not two. A body with no checkbox at all is silence,
             // not a denial, so it must not strip a label somebody applied by
             // hand. Only an explicit empty box retracts the claim.
-            const box = new RegExp(`^[ \\t]*[-*][ \\t]*\\[([^\\]]*)\\][^\\n]*${AGENT}`, "im").exec(
-              scope,
-            );
+            const box = new RegExp(
+              `^[ \\t]*[-*][ \\t]*\\[([ \\t]*[xX]?[ \\t]*)\\][^\\n]*${AGENT}`,
+              "im",
+            ).exec(scope);
             if (box) {
               const claimed = /x/i.test(box[1]);
               if (claimed && !current.includes(AGENT)) add.push(AGENT);
@@ -134,9 +139,76 @@ jobs:
             // template to keep, so bots are never asked to declare anything.
             if (!box && pull.user?.type !== "Bot") {
               core.setFailed(
-                `#${number} does not declare provenance. Add this line to the pull request body:\n` +
+                `#${number} does not declare provenance. Keep this section in the pull request body:\n` +
+                  "  ## Provenance\n\n" +
                   "  - [ ] An agent produced this diff (`agent-authored`)\n" +
                   "Tick it when an agent produced the diff, leave it clear when a human wrote it. " +
                   "Editing the body re-runs this check.",
               );
             }
+
+      - name: Convert an agent-authored pull request back to draft
+        # A label written with GITHUB_TOKEN cannot trigger the separate `labeled`
+        # workflow. Enforce the draft policy here, after the label API call, so a
+        # ready agent pull request is handled in the same workflow run.
+        if: always()
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          # Draft state is not repository content, so the job stays off
+          # `contents`. GITHUB_TOKEN has been reported to answer draft mutations
+          # with "Resource not accessible by integration" (actions/toolkit#1165)
+          # and GraphQL publishes no permission table to check that against, so
+          # an app or PAT secret takes over wherever the repository defines one.
+          github-token: ${{ secrets.DRAFT_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const number = context.payload.pull_request.number;
+
+            // Refetch after the preceding step: the event payload predates the
+            // label that this workflow may just have applied.
+            const { data: pull } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: number,
+            });
+            if (pull.draft || pull.state !== "open") {
+              return;
+            }
+            if (!pull.labels.some((label) => label.name === "agent-authored")) {
+              return;
+            }
+
+            // Marking a pull request ready for review is a deliberate act, and
+            // ordinary body edits keep arriving afterwards. Without this the
+            // next edit would drag a reviewed pull request back into draft.
+            const timeline = await github.paginate(
+              github.rest.issues.listEventsForTimeline,
+              { owner, repo, issue_number: number, per_page: 100 },
+            );
+            if (timeline.some((event) => event.event === "ready_for_review")) {
+              core.notice(
+                `#${number} was already marked ready for review; leaving it as is.`,
+              );
+              return;
+            }
+
+            try {
+              await github.graphql(
+                `mutation ($id: ID!) {
+                   convertPullRequestToDraft(input: { pullRequestId: $id }) {
+                     clientMutationId
+                   }
+                 }`,
+                { id: pull.node_id },
+              );
+            } catch (error) {
+              core.setFailed(
+                `Could not convert #${number} to a draft: ${error.message}. ` +
+                  "Convert it manually; repository CI starts after a maintainer marks it ready.",
+              );
+              return;
+            }
+
+            core.notice(
+              `Converted #${number} to a draft. Repository CI will start after a maintainer marks it ready for review.`,
+            );

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,0 +1,118 @@
+name: Label PR
+
+# Both labels are things the author cannot apply themselves: a fork
+# contributor's token has no rights to label the base repository at all. A
+# `pull_request_target` job has the write token, so the author only has to state
+# the facts, in the title and in the body, and this turns them into labels.
+on:
+  pull_request_target:
+    types: [opened, reopened, edited]
+
+concurrency:
+  # Serialize per pull request instead of cancelling: two runs racing on the
+  # same pull request would fight over which labels survive.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  label:
+    name: apply labels
+    if: github.event.pull_request.state == 'open'
+    runs-on: ubuntu-latest
+    # `pull_request_target` is what gives a fork pull request a writable token.
+    # Nothing here checks out or executes the pull request's code.
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Apply the labels the pull request declares
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const TYPES = ["feat", "fix", "docs", "test", "perf", "refactor", "chore", "ci"];
+            const AGENT = "agent-authored";
+            const { owner, repo } = context.repo;
+            const number = context.payload.pull_request.number;
+
+            // The event payload is a snapshot from before this run was queued.
+            const { data: pull } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: number,
+            });
+            if (pull.state !== "open") {
+              return;
+            }
+
+            const current = pull.labels.map((label) => label.name);
+            const add = [];
+            const remove = [];
+
+            const titled = /^\s*([a-z]+)\s*(?:\([^)]*\))?\s*!?:/.exec(pull.title);
+            const type = titled && TYPES.includes(titled[1]) ? titled[1] : null;
+            if (type) {
+              // Exactly one type label is the rule, so a retitled pull request
+              // has to take its previous type with it.
+              remove.push(...current.filter((name) => name !== type && TYPES.includes(name)));
+              if (!current.includes(type)) add.push(type);
+            } else {
+              core.notice(
+                `#${number} has no conventional-commit type in its title, so no type label was applied. ` +
+                  `Retitle it as one of ${TYPES.join(", ")} and this runs again.`,
+              );
+            }
+
+            // Three states, not two. A body with no checkbox at all is silence,
+            // not a denial, so it must not strip a label somebody applied by
+            // hand. Only an explicit empty box retracts the claim.
+            const box = new RegExp(`^[ \\t]*[-*][ \\t]*\\[([^\\]]*)\\][^\\n]*${AGENT}`, "im").exec(
+              pull.body ?? "",
+            );
+            if (box) {
+              const claimed = /x/i.test(box[1]);
+              if (claimed && !current.includes(AGENT)) add.push(AGENT);
+              if (!claimed && current.includes(AGENT)) remove.push(AGENT);
+            }
+
+            try {
+              for (const name of remove) {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: number,
+                  name,
+                });
+              }
+              if (add.length > 0) {
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: number,
+                  labels: add,
+                });
+              }
+            } catch (error) {
+              core.setFailed(
+                `Could not set labels on #${number}: ${error.message}. ` +
+                  `Intended: +[${add.join(", ")}] -[${remove.join(", ")}].`,
+              );
+              return;
+            }
+
+            if (add.length > 0 || remove.length > 0) {
+              core.notice(
+                `#${number}: applied [${add.join(", ") || "none"}], removed [${remove.join(", ") || "none"}].`,
+              );
+            }
+
+            // Labelling happens before this fails, so a red check leaves nothing
+            // to redo but the body itself. A generated pull request has no
+            // template to keep, so bots are never asked to declare anything.
+            if (!box && pull.user?.type !== "Bot") {
+              core.setFailed(
+                `#${number} does not declare provenance. Add this line to the pull request body:\n` +
+                  "  - [ ] An agent produced this diff (`agent-authored`)\n" +
+                  "Tick it when an agent produced the diff, leave it clear when a human wrote it. " +
+                  "Editing the body re-runs this check.",
+              );
+            }

--- a/.rulesync/rules/project.md
+++ b/.rulesync/rules/project.md
@@ -44,6 +44,15 @@ trigger first arises, even if it is a later step you chose:
 - `authoring-tsrx`: writing a new `.tsrx` file.
 - `triage`: the owning area is unclear.
 
+Each skill is `.rulesync/skills/<name>/SKILL.md`, with a generated per-tool copy;
+read that path directly if your tool cannot load a skill by name.
+
+One `create-a-pr` rule must survive not loading it: keep the PR template's
+provenance section and tick its box when an agent produced the diff. An agent
+commits under a human's credentials, so nothing else tells the two apart and a
+clear box asserts a human wrote it. A bot turns it into `agent-authored` and
+derives the type label from the title, so never apply labels yourself.
+
 ## Your React instincts are the main failure mode here
 
 Octane looks like React but differs deliberately. Check

--- a/.rulesync/skills/create-a-pr/SKILL.md
+++ b/.rulesync/skills/create-a-pr/SKILL.md
@@ -80,16 +80,16 @@ git status --short
 git add <files>
 git commit -m "<type>: <summary>"
 git push -u origin <branch>
-gh pr create --draft --fill
-gh pr edit <number> --add-label <type> --add-label agent-authored
+gh pr create --draft --body-file <file>
 ```
 
-If using `gh pr create --body-file`, write the PR body to a temp file and pass it explicitly.
+Write the body to a temp file and pass it explicitly. Do not use `--fill`: it
+builds the body from your commits and drops the template, taking the provenance
+section with it.
 
-Label after the PR exists rather than with `gh pr create --label`, so a rejected
-label cannot cost you the PR. An outside contributor's token has no rights to
-label at all; when the edit fails, leave the PR open and name the intended labels
-in the final response.
+Apply no labels, and never pass `--label`. Your token has no rights to label at
+all when the PR comes from a fork, and `.github/workflows/label-pr.yml` applies
+both labels as a bot, which does.
 
 ## Leave the PR as a draft
 
@@ -103,30 +103,41 @@ every job while the pull request is a draft and starts on the
 including drafts, outside Actions, so people can watch and respond to its issue
 comments before making a draft ready. Vercel may also report separately.
 
-`.github/workflows/draft-agent-prs.yml` converts an `agent-authored` PR that was
-opened outside draft back into a draft, so a forgotten `--draft` costs a round
-trip instead of passing unnoticed. It leaves the PR alone once anyone has marked
-it ready for review, so it never undoes `gh pr ready`.
+## Declare provenance in the PR body
+
+Keep the provenance section from `.github/pull_request_template.md` in the body
+you write, and tick the box, because an agent produced the diff:
+
+```md
+## Provenance
+
+- [x] An agent produced this diff (`agent-authored`)
+```
+
+Leaving the box clear is a positive claim that a human wrote the diff, so it is
+never the safe thing to do when unsure. An agent commits under a human's
+credentials, which is why nothing else in the PR can tell the two apart.
+
+`.github/workflows/label-pr.yml` reads the box and applies `agent-authored`. It
+runs as a bot with the repository's own token, so this works identically from a
+fork and needs nothing from a maintainer.
+
+Omitting the section **fails the check**, which is why `--fill` is not an option.
+It still labels the PR first, so the only thing left to fix is the body, and
+editing the body re-runs the check. A missing section never clears an existing
+label, because silence is not a denial, but do not lean on that: state the fact.
+Only generated bot pull requests are exempt.
 
 ## Labels
 
-Every PR carries exactly one type label. Every PR whose diff an agent produced
-also carries `agent-authored`.
-
-- Type: the conventional-commit type already in the PR title, one of `feat`,
-  `fix`, `docs`, `test`, `perf`, `refactor`, `chore`, `ci`. A `feat(lynx): …`
-  title takes `feat`. Never apply two.
-- `agent-authored`: apply whenever an agent wrote the change, no matter which
-  account pushes it. The author field cannot show this, because an agent commits
-  under the human's credentials, so the label is the only signal that separates
-  human PRs from agent PRs. Absence of the label asserts a human wrote the diff:
-  never drop it to make a PR read as hand-written. Humans add nothing, and
-  `-label:agent-authored` is the human-authored filter.
-- `bug` and `enhancement` belong to issues. Do not put them on a PR.
-- Do not invent labels. `gh label list` is the full set; adding a type means
-  creating the label in the repo first.
+Do not apply labels. Both are applied by the bot above: the type label (`feat`,
+`fix`, `docs`, `test`, `perf`, `refactor`, `chore`, `ci`) from the PR title, and
+`agent-authored` from the box. Retitling moves the type label, and a title the
+regex cannot read leaves the PR unlabelled, which is the signal to fix the title.
+`bug` and `enhancement` belong to issues.
 
 ## Final response
 
-Return PR URL, branch, commit summary, labels applied, and validation evidence.
+Return PR URL, branch, commit summary, provenance declared, and validation
+evidence.
 The PR stays a draft.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,15 @@ trigger first arises, even if it is a later step you chose:
 - `authoring-tsrx`: writing a new `.tsrx` file.
 - `triage`: the owning area is unclear.
 
+Each skill is `.rulesync/skills/<name>/SKILL.md`, with a generated per-tool copy;
+read that path directly if your tool cannot load a skill by name.
+
+One `create-a-pr` rule must survive not loading it: keep the PR template's
+provenance section and tick its box when an agent produced the diff. An agent
+commits under a human's credentials, so nothing else tells the two apart and a
+clear box asserts a human wrote it. A bot turns it into `agent-authored` and
+derives the type label from the title, so never apply labels yourself.
+
 ## Your React instincts are the main failure mode here
 
 Octane looks like React but differs deliberately. Check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,15 @@ trigger first arises, even if it is a later step you chose:
 - `authoring-tsrx`: writing a new `.tsrx` file.
 - `triage`: the owning area is unclear.
 
+Each skill is `.rulesync/skills/<name>/SKILL.md`, with a generated per-tool copy;
+read that path directly if your tool cannot load a skill by name.
+
+One `create-a-pr` rule must survive not loading it: keep the PR template's
+provenance section and tick its box when an agent produced the diff. An agent
+commits under a human's credentials, so nothing else tells the two apart and a
+clear box asserts a human wrote it. A bot turns it into `agent-authored` and
+derives the type label from the title, so never apply labels yourself.
+
 ## Your React instincts are the main failure mode here
 
 Octane looks like React but differs deliberately. Check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -254,10 +254,12 @@ positive claim that a human wrote the diff.
 
 `.github/workflows/label-pr.yml` reads the box and applies the `agent-authored`
 label for you. It runs with the repository's own token rather than yours, so this
-works identically from a fork and needs nothing from a maintainer. From there,
-`.github/workflows/draft-agent-prs.yml` converts the pull request back to draft
-if it was opened ready, and a maintainer marks it ready for review once it has
-been looked at.
+works identically from a fork and needs nothing from a maintainer. The same
+workflow converts the pull request back to draft if it was opened ready, because
+a label added by the repository token cannot trigger another workflow. The
+separate `draft-agent-prs.yml` workflow remains a fallback for labels applied by
+a maintainer or GitHub App. A maintainer marks the pull request ready for review
+once it has been looked at.
 
 Keep the section in the body you write, because a pull request that omits it
 fails a check. `gh pr create --fill` builds the body from your commits and drops

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,8 +227,10 @@ Octane is 0.x, so every changeset stays on the `patch` track. `major` and
 - The pull request body should say what changed, why, and what you ran to
   validate it. Call out anything you deliberately left unverified.
 - Every pull request carries exactly one type label: `feat`, `fix`, `docs`,
-  `test`, `perf`, `refactor`, `chore`, or `ci`, matching the title. `bug` and
-  `enhancement` belong to issues.
+  `test`, `perf`, `refactor`, `chore`, or `ci`. You do not apply it;
+  `.github/workflows/label-pr.yml` reads it off the title, so a
+  conventional-commit title is all it takes. `bug` and `enhancement` belong to
+  issues.
 
 CI intentionally runs nothing while a pull request is a draft and starts on the
 `ready_for_review` event. From there it runs the sharded test suite on Node 22 and
@@ -238,13 +240,30 @@ suite. Documentation-only changes take a lighter path.
 
 ## AI-assisted contributions
 
-Agent-written changes are welcome, with one rule: label the pull request
-`agent-authored` whenever an agent produced the diff, no matter which account
-pushes it. An agent commits under a human's credentials, so the author field
-cannot show it and the label is the only signal that separates the two.
-`.github/workflows/draft-agent-prs.yml` converts an `agent-authored` pull request
-back to draft if it was opened ready, and a maintainer marks it ready for review
-once it has been looked at.
+Agent-written changes are welcome, with one rule: tick the provenance box in the
+pull request template whenever an agent produced the diff, no matter which
+account pushes it.
+
+```md
+- [x] An agent produced this diff (`agent-authored`)
+```
+
+An agent commits under a human's credentials, so the author field cannot show
+this and the box is the only signal that separates the two. Leaving it clear is a
+positive claim that a human wrote the diff.
+
+`.github/workflows/label-pr.yml` reads the box and applies the `agent-authored`
+label for you. It runs with the repository's own token rather than yours, so this
+works identically from a fork and needs nothing from a maintainer. From there,
+`.github/workflows/draft-agent-prs.yml` converts the pull request back to draft
+if it was opened ready, and a maintainer marks it ready for review once it has
+been looked at.
+
+Keep the section in the body you write, because a pull request that omits it
+fails a check. `gh pr create --fill` builds the body from your commits and drops
+the template, so use `--body-file` instead. Labels are applied before that check
+fails, so the only thing left to fix is the body, and editing it re-runs the
+check. Generated bot pull requests are exempt.
 
 The repository ships its own agent context: `AGENTS.md` (and its per-tool
 siblings) plus task skills for branching, issues, bug hunting, core changes,

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -54,6 +54,15 @@ trigger first arises, even if it is a later step you chose:
 - `authoring-tsrx`: writing a new `.tsrx` file.
 - `triage`: the owning area is unclear.
 
+Each skill is `.rulesync/skills/<name>/SKILL.md`, with a generated per-tool copy;
+read that path directly if your tool cannot load a skill by name.
+
+One `create-a-pr` rule must survive not loading it: keep the PR template's
+provenance section and tick its box when an agent produced the diff. An agent
+commits under a human's credentials, so nothing else tells the two apart and a
+clear box asserts a human wrote it. A bot turns it into `agent-authored` and
+derives the type label from the title, so never apply labels yourself.
+
 ## Your React instincts are the main failure mode here
 
 Octane looks like React but differs deliberately. Check

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -11,6 +11,7 @@ const draftWorkflow = readFileSync(
 	path.join(REPO, '.github/workflows/draft-agent-prs.yml'),
 	'utf8',
 );
+const labelWorkflow = readFileSync(path.join(REPO, '.github/workflows/label-pr.yml'), 'utf8');
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
 
 function jobSource(job) {
@@ -248,5 +249,210 @@ describe('Agent pull request draft policy', () => {
 			draftWorkflow,
 			/github-token: \$\{\{ secrets\.DRAFT_PR_TOKEN \|\| secrets\.GITHUB_TOKEN \}\}/,
 		);
+	});
+});
+
+describe('Pull request labels', () => {
+	const TICKED = '- [x] An agent produced this diff (`agent-authored`)';
+	const EMPTY = '- [ ] An agent produced this diff (`agent-authored`)';
+
+	function runLabeller({
+		title = 'chore: a thing',
+		body = `## Provenance\n\n${EMPTY}\n`,
+		labels = [],
+		state = 'open',
+		user = { type: 'User' },
+	}) {
+		const added = [];
+		const removed = [];
+		const notices = [];
+		const failures = [];
+		const github = {
+			rest: {
+				pulls: {
+					get: async () => ({
+						data: {
+							number: 500,
+							state,
+							title,
+							body,
+							user,
+							labels: labels.map((name) => ({ name })),
+						},
+					}),
+				},
+				issues: {
+					addLabels: async ({ labels: names }) => added.push(...names),
+					removeLabel: async ({ name }) => removed.push(name),
+				},
+			},
+		};
+		const execute = new AsyncFunction(
+			'github',
+			'context',
+			'core',
+			stepScript(labelWorkflow, 'Apply the labels the pull request declares'),
+		);
+
+		return execute(
+			github,
+			{ repo: { owner: 'octanejs', repo: 'octane' }, payload: { pull_request: { number: 500 } } },
+			{
+				notice: (message) => notices.push(message),
+				setFailed: (message) => failures.push(message),
+			},
+		).then(() => ({ added, removed, notices, failures }));
+	}
+
+	test('reads the type off a conventional-commit title', async () => {
+		for (const [title, type] of [
+			['feat(lynx): add a thing', 'feat'],
+			['fix: repair a thing', 'fix'],
+			['perf!: drop a slow path', 'perf'],
+			['ci(workflows): only run when needed', 'ci'],
+		]) {
+			const { added, removed, failures } = await runLabeller({ title });
+
+			assert.deepEqual(added, [type], title);
+			assert.deepEqual(removed, []);
+			assert.deepEqual(failures, []);
+		}
+	});
+
+	test('moves the type label when a pull request is retitled', async () => {
+		const { added, removed } = await runLabeller({
+			title: 'fix(compiler): render the non-JSX arm',
+			labels: ['feat', 'blocked'],
+		});
+
+		assert.deepEqual(added, ['fix']);
+		// Only the superseded type goes. Everything else on the pull request is
+		// somebody's deliberate act.
+		assert.deepEqual(removed, ['feat']);
+	});
+
+	test('leaves the type alone when the title names no type', async () => {
+		const { added, removed, notices } = await runLabeller({ title: 'Format' });
+
+		assert.deepEqual(added, []);
+		assert.deepEqual(removed, []);
+		assert.match(notices.join('\n'), /no conventional-commit type/);
+	});
+
+	test('ignores an unknown type rather than inventing a label', async () => {
+		const { added } = await runLabeller({ title: 'wip(runtime): halfway there' });
+
+		assert.deepEqual(added, []);
+	});
+
+	test('applies agent-authored from a ticked box, whoever pushed it', async () => {
+		const { added, failures } = await runLabeller({
+			title: 'feat(zag): add bindings',
+			body: `## Summary\n\nA thing.\n\n${TICKED}\n`,
+		});
+
+		assert.deepEqual(added, ['feat', 'agent-authored']);
+		assert.deepEqual(failures, []);
+	});
+
+	test('tolerates the checkbox spellings a real body contains', async () => {
+		for (const line of [
+			'- [X] An agent produced this diff (`agent-authored`)',
+			'* [x] agent-authored',
+			'  - [x]   agent-authored, via Claude Code',
+		]) {
+			const { added } = await runLabeller({ title: 'docs: a thing', body: `Body\n\n${line}\n` });
+
+			assert.ok(added.includes('agent-authored'), line);
+		}
+	});
+
+	test('retracts the label when the box is unticked', async () => {
+		const { added, removed } = await runLabeller({
+			title: 'docs: a thing',
+			labels: ['docs', 'agent-authored'],
+		});
+
+		assert.deepEqual(added, []);
+		assert.deepEqual(removed, ['agent-authored']);
+	});
+
+	test('fails a body that skipped the template entirely', async () => {
+		const { failures } = await runLabeller({
+			title: 'feat: a thing',
+			body: 'Body written by `gh pr create --fill`.',
+		});
+
+		assert.equal(failures.length, 1);
+		assert.match(failures[0], /does not declare provenance/);
+		assert.match(failures[0], /Editing the body re-runs this check/);
+	});
+
+	test('labels the pull request before failing on a missing declaration', async () => {
+		// A red check must leave nothing to redo but the body itself.
+		const { added, failures } = await runLabeller({
+			title: 'feat: a thing',
+			body: 'No template here.',
+		});
+
+		assert.deepEqual(added, ['feat']);
+		assert.equal(failures.length, 1);
+	});
+
+	test('treats a missing declaration as silence, not a denial', async () => {
+		// `gh pr create --fill` drops the template, so stripping the label here
+		// would undo a maintainer while the check is already telling them to fix it.
+		const { added, removed } = await runLabeller({
+			title: 'docs: a thing',
+			body: 'No template here.',
+			labels: ['docs', 'agent-authored'],
+		});
+
+		assert.deepEqual(added, []);
+		assert.deepEqual(removed, []);
+	});
+
+	test('never asks a generated pull request to declare anything', async () => {
+		const { failures } = await runLabeller({
+			title: 'Version Packages',
+			body: 'Generated by Changesets.',
+			user: { type: 'Bot' },
+		});
+
+		assert.deepEqual(failures, []);
+	});
+
+	test('writes nothing when the labels already match the declaration', async () => {
+		const { added, removed, notices } = await runLabeller({
+			title: 'docs: split the README',
+			body: `Body\n\n${TICKED}\n`,
+			labels: ['docs', 'agent-authored'],
+		});
+
+		assert.deepEqual(added, []);
+		assert.deepEqual(removed, []);
+		assert.deepEqual(notices, []);
+	});
+
+	test('does nothing once the pull request has closed', async () => {
+		const { added, removed, failures } = await runLabeller({
+			title: 'feat: a thing',
+			body: 'No template here.',
+			state: 'closed',
+		});
+
+		assert.deepEqual(added, []);
+		assert.deepEqual(removed, []);
+		assert.deepEqual(failures, []);
+	});
+
+	test('runs with a writable token without checking out pull request code', () => {
+		assert.match(
+			labelWorkflow,
+			/on:\n {2}pull_request_target:\n {4}types: \[opened, reopened, edited\]/,
+		);
+		assert.match(labelWorkflow, /^ {6}pull-requests: write$/m);
+		assert.doesNotMatch(labelWorkflow, /actions\/checkout/);
+		assert.doesNotMatch(labelWorkflow, /contents: write/);
 	});
 });

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -262,46 +262,74 @@ describe('Pull request labels', () => {
 		labels = [],
 		state = 'open',
 		user = { type: 'User' },
+		runDraftPolicy = false,
+		timeline = [],
 	}) {
 		const added = [];
 		const removed = [];
+		const converted = [];
 		const notices = [];
 		const failures = [];
+		const pull = {
+			number: 500,
+			node_id: 'PR_node',
+			draft: false,
+			state,
+			title,
+			body,
+			user,
+			labels: labels.map((name) => ({ name })),
+		};
 		const github = {
 			rest: {
 				pulls: {
-					get: async () => ({
-						data: {
-							number: 500,
-							state,
-							title,
-							body,
-							user,
-							labels: labels.map((name) => ({ name })),
-						},
-					}),
+					get: async () => ({ data: pull }),
 				},
 				issues: {
-					addLabels: async ({ labels: names }) => added.push(...names),
-					removeLabel: async ({ name }) => removed.push(name),
+					addLabels: async ({ labels: names }) => {
+						added.push(...names);
+						pull.labels.push(...names.map((name) => ({ name })));
+					},
+					removeLabel: async ({ name }) => {
+						removed.push(name);
+						pull.labels = pull.labels.filter((label) => label.name !== name);
+					},
+					listEventsForTimeline: async () => undefined,
 				},
 			},
+			paginate: async () => timeline,
+			graphql: async (_query, variables) => {
+				converted.push(variables.id);
+				return {};
+			},
 		};
-		const execute = new AsyncFunction(
+		const executeLabeller = new AsyncFunction(
 			'github',
 			'context',
 			'core',
 			stepScript(labelWorkflow, 'Apply the labels the pull request declares'),
 		);
+		const context = {
+			repo: { owner: 'octanejs', repo: 'octane' },
+			payload: { pull_request: { number: 500 } },
+		};
+		const core = {
+			notice: (message) => notices.push(message),
+			setFailed: (message) => failures.push(message),
+		};
 
-		return execute(
-			github,
-			{ repo: { owner: 'octanejs', repo: 'octane' }, payload: { pull_request: { number: 500 } } },
-			{
-				notice: (message) => notices.push(message),
-				setFailed: (message) => failures.push(message),
-			},
-		).then(() => ({ added, removed, notices, failures }));
+		return executeLabeller(github, context, core)
+			.then(() => {
+				if (!runDraftPolicy) return;
+				const executeDraftPolicy = new AsyncFunction(
+					'github',
+					'context',
+					'core',
+					stepScript(labelWorkflow, 'Convert an agent-authored pull request back to draft'),
+				);
+				return executeDraftPolicy(github, context, core);
+			})
+			.then(() => ({ added, removed, converted, notices, failures }));
 	}
 
 	test('reads the type off a conventional-commit title', async () => {
@@ -339,6 +367,17 @@ describe('Pull request labels', () => {
 		assert.match(notices.join('\n'), /no conventional-commit type/);
 	});
 
+	test('removes a stale type when the pull request title becomes invalid', async () => {
+		const { added, removed, notices } = await runLabeller({
+			title: 'Work in progress',
+			labels: ['feat', 'blocked'],
+		});
+
+		assert.deepEqual(added, []);
+		assert.deepEqual(removed, ['feat']);
+		assert.match(notices.join('\n'), /no conventional-commit type/);
+	});
+
 	test('ignores an unknown type rather than inventing a label', async () => {
 		const { added } = await runLabeller({ title: 'wip(runtime): halfway there' });
 
@@ -348,11 +387,34 @@ describe('Pull request labels', () => {
 	test('applies agent-authored from a ticked box, whoever pushed it', async () => {
 		const { added, failures } = await runLabeller({
 			title: 'feat(zag): add bindings',
-			body: `## Summary\n\nA thing.\n\n${TICKED}\n`,
+			body: `## Summary\n\nA thing.\n\n## Provenance\n\n${TICKED}\n`,
 		});
 
 		assert.deepEqual(added, ['feat', 'agent-authored']);
 		assert.deepEqual(failures, []);
+	});
+
+	test('labels and drafts a ready agent pull request in one workflow run', async () => {
+		const { added, converted, failures } = await runLabeller({
+			title: 'feat(zag): add bindings',
+			body: `## Provenance\n\n${TICKED}\n`,
+			runDraftPolicy: true,
+		});
+
+		assert.deepEqual(added, ['feat', 'agent-authored']);
+		assert.deepEqual(converted, ['PR_node']);
+		assert.deepEqual(failures, []);
+	});
+
+	test('does not redraft an agent pull request after a deliberate ready transition', async () => {
+		const { converted, notices } = await runLabeller({
+			body: `## Provenance\n\n${TICKED}\n`,
+			runDraftPolicy: true,
+			timeline: [{ event: 'ready_for_review' }],
+		});
+
+		assert.deepEqual(converted, []);
+		assert.match(notices.join('\n'), /already marked ready for review/);
 	});
 
 	test('tolerates the checkbox spellings a real body contains', async () => {
@@ -361,7 +423,10 @@ describe('Pull request labels', () => {
 			'* [x] agent-authored',
 			'  - [x]   agent-authored, via Claude Code',
 		]) {
-			const { added } = await runLabeller({ title: 'docs: a thing', body: `Body\n\n${line}\n` });
+			const { added } = await runLabeller({
+				title: 'docs: a thing',
+				body: `## Provenance\n\n${line}\n`,
+			});
 
 			assert.ok(added.includes('agent-authored'), line);
 		}
@@ -375,6 +440,17 @@ describe('Pull request labels', () => {
 
 		assert.deepEqual(added, ['feat']);
 		assert.deepEqual(failures, []);
+	});
+
+	test('does not accept a provenance checkbox outside the provenance section', async () => {
+		const { added, failures } = await runLabeller({
+			title: 'feat: a thing',
+			body: `## Validation\n\n${TICKED}\n`,
+		});
+
+		assert.deepEqual(added, ['feat']);
+		assert.equal(failures.length, 1);
+		assert.match(failures[0], /does not declare provenance/);
 	});
 
 	test('does not read a declaration out of a quoted example', async () => {
@@ -472,7 +548,7 @@ describe('Pull request labels', () => {
 	test('writes nothing when the labels already match the declaration', async () => {
 		const { added, removed, notices } = await runLabeller({
 			title: 'docs: split the README',
-			body: `Body\n\n${TICKED}\n`,
+			body: `## Provenance\n\n${TICKED}\n`,
 			labels: ['docs', 'agent-authored'],
 		});
 
@@ -498,7 +574,16 @@ describe('Pull request labels', () => {
 			labelWorkflow,
 			/on:\n {2}pull_request_target:\n {4}types: \[opened, reopened, edited\]/,
 		);
+		assert.match(labelWorkflow, /^ {6}issues: read$/m);
 		assert.match(labelWorkflow, /^ {6}pull-requests: write$/m);
+		assert.match(
+			labelWorkflow,
+			/- name: Convert an agent-authored pull request back to draft[\s\S]*?if: always\(\)/,
+		);
+		assert.match(
+			labelWorkflow,
+			/github-token: \$\{\{ secrets\.DRAFT_PR_TOKEN \|\| secrets\.GITHUB_TOKEN \}\}/,
+		);
 		assert.doesNotMatch(labelWorkflow, /actions\/checkout/);
 		assert.doesNotMatch(labelWorkflow, /contents: write/);
 	});

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -367,6 +367,53 @@ describe('Pull request labels', () => {
 		}
 	});
 
+	test('reads the box in the provenance section, not an earlier mention', async () => {
+		const { added, failures } = await runLabeller({
+			title: 'feat: a thing',
+			body: `## Validation\n\n- [x] targeted tests: agent-authored fixtures\n\n## Provenance\n\n${EMPTY}\n`,
+		});
+
+		assert.deepEqual(added, ['feat']);
+		assert.deepEqual(failures, []);
+	});
+
+	test('does not read a declaration out of a quoted example', async () => {
+		const { added, failures } = await runLabeller({
+			title: 'ci: document the box',
+			body: `## Summary\n\nA body needs:\n\n\`\`\`md\n${TICKED}\n\`\`\`\n`,
+		});
+
+		assert.deepEqual(added, ['ci']);
+		assert.equal(failures.length, 1);
+		assert.match(failures[0], /does not declare provenance/);
+	});
+
+	test('does not read a declaration out of a commented-out box', async () => {
+		const { added, failures } = await runLabeller({
+			title: 'docs: a thing',
+			body: `## Provenance\n\n<!--\n${TICKED}\n-->\n`,
+		});
+
+		assert.deepEqual(added, ['docs']);
+		assert.equal(failures.length, 1);
+	});
+
+	test('reads the checked-in template as a declaration either way', async () => {
+		const template = readFileSync(path.join(REPO, '.github/pull_request_template.md'), 'utf8');
+		assert.ok(template.includes(EMPTY), 'the template must carry the provenance box');
+
+		const human = await runLabeller({ title: 'fix: a thing', body: template });
+		const agent = await runLabeller({
+			title: 'fix: a thing',
+			body: template.replace(EMPTY, TICKED),
+		});
+
+		assert.deepEqual(human.added, ['fix']);
+		assert.deepEqual(human.failures, []);
+		assert.deepEqual(agent.added, ['fix', 'agent-authored']);
+		assert.deepEqual(agent.failures, []);
+	});
+
 	test('retracts the label when the box is unticked', async () => {
 		const { added, removed } = await runLabeller({
 			title: 'docs: a thing',


### PR DESCRIPTION
## Summary

Agents declare AI-produced diffs by checking one box in the PR description. A
base-repository `pull_request_target` workflow turns that declaration into
`agent-authored`, derives the type label from the conventional-commit title, and
enforces the agent draft policy in the same workflow run—even for fork PRs.

## Why

Fork contributors cannot label the base repository, so the old
`gh pr edit --add-label` instruction failed with 403 for the contributions that
needed it most. Commit authorship cannot prove provenance either: an agent
commits under the human user's credentials.

The PR body is the trust boundary the contributor controls. The workflow runs
from the base branch with the repository token, translating the explicit
declaration into repository metadata without executing pull-request code.

GitHub does not start a new workflow for a `labeled` event emitted with the
default `GITHUB_TOKEN`. Draft enforcement therefore happens directly in the
label workflow instead of waiting for `draft-agent-prs.yml`.

## Changes

- Added `.github/pull_request_template.md` with an explicit `## Provenance`
  checkbox.
- Added `.github/workflows/label-pr.yml` for `opened`, `reopened`, and `edited`:
  - derives one allowlisted type label from the title and removes stale types
    after an invalid retitle;
  - reads only a live checkbox inside the Provenance section, ignoring HTML
    comments, fenced examples, and stray mentions;
  - adds or retracts `agent-authored`; a missing declaration is silence, fails
    the check, and never strips a manually applied label;
  - refetches the labelled PR and converts an agent-authored ready PR to draft
    in the same run;
  - preserves a deliberate later `ready_for_review` transition;
  - uses `issues: read` and `pull-requests: write`, pins
    `actions/github-script`, and never checks out or executes PR code.
- Retained `draft-agent-prs.yml` as a fallback for labels applied independently
  by a maintainer or GitHub App.
- Updated the authoritative RuleSync rule, generated agent instructions,
  `create-a-pr` skills, and `CONTRIBUTING.md`. Agents keep and tick the
  provenance section, use `--body-file`, and never apply labels themselves.
- Added executable tests for title changes, scoped provenance parsing,
  tri-state label behavior, missing declarations, bot exemptions, same-run
  draft conversion, and deliberate ready transitions.

## Validation

- [x] `pnpm sync`
- [x] `pnpm format:check`
- [x] `pnpm ci:workflow:test` (40 pass)
- [x] `pnpm rules:check`
- [x] `pnpm context:budget:check` (CLAUDE.md: 7,344 bytes)
- [ ] `pnpm typecheck` / `pnpm test`: not run; no TypeScript or package source
  changed.

The draft regression first failed because `label-pr.yml` had no same-run
conversion step. The stale-type and out-of-section provenance regressions also
failed against the previous implementation.

## Risk / follow-ups

- `pull_request_target` is privileged. This workflow executes only a
  commit-pinned action and base-branch inline script, requests least-necessary
  permissions, and never checks out untrusted code.
- The provenance check is not yet required by branch protection.
- Existing open PRs are not backfilled; their next `edited` or `reopened` event
  applies the policy.
- `draft-agent-prs.yml` remains useful only for labels created outside the
  default `GITHUB_TOKEN` path; bot-created label events cannot trigger it.
- This PR cannot exercise its own new `pull_request_target` workflow because
  GitHub loads it from the default branch. Its labels were applied manually.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PR governance and `pull_request_target` automation; agent-authored draft enforcement will start affecting real PRs once labels apply, though the workflow does not checkout PR code.
>
> **Overview**
> Moves **type** and **`agent-authored`** labeling off contributors and onto a new **`pull_request_target`** workflow (`.github/workflows/label-pr.yml`), so fork PRs get labels without `gh` write access.
>
> The workflow derives the type label from the conventional-commit **title**, applies **`agent-authored`** only from a checkbox under a **## Provenance** section (ignoring fenced/commented examples), fails the check if that section is missing for human PRs, and **re-drafts** ready agent-authored PRs in the same run so `GITHUB_TOKEN` label events do not need a separate workflow.
>
> Adds **`.github/pull_request_template.md`** with that provenance block. **`create-a-pr`** and root agent docs now require **`gh pr create --draft --body-file`** (not `--fill`) and **forbid manual labeling**. **`draft-agent-prs.yml`** is documented as a fallback only. **`scripts/ci-workflow.test.mjs`** gains extensive tests that execute the workflow scripts against mocks.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2de387c222e1efb71e49af1258271a1ca72a04c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
