### PR TITLE
fix: better fix for event handler

### DIFF
--- a/.changeset/quiet-handlers-defer.md
+++ b/.changeset/quiet-handlers-defer.md
@@ -1,0 +1,20 @@
+---
+'octane': patch
+---
+
+Evaluate an inline event handler's arguments when the event fires, not on every
+render. `onClick={() => setData(makeData(1000))}` compiled to a `{ fn, args }`
+bundle whose argument was lifted into the component body, so `makeData(1000)`
+ran on mount and on every subsequent render even if the button was never
+clicked. An argument is now bundled only when evaluating it early is
+observationally equivalent to evaluating it on the event: identifiers, plain
+member paths, literals, and operators over those. Calls, fresh array/object/regex
+literals, mutations, `ref.current` (the ref attaches after the mount that would
+read it, so the first event received the pre-attach `null`), and computed member
+keys keep the ordinary closure handler.
+
+Inline handlers that read nothing which can change between renders are now
+installed once at mount instead of being rebuilt and reassigned on every render,
+matching what a named handler already received. Handlers inside a keyed `@for`
+row are excluded, since a surviving row can be handed a different item without
+remounting.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -3944,17 +3944,33 @@ function containsAutoMemoUnsafeStructure(stmts) {
  * otherwise rebuilds the whole dataset on every unrelated render, and the user
  * never sees a call they can attribute to the click that did not happen.
  *
- * The whitelist is deliberately narrower than "pure", because a fresh identity
- * per evaluation also defeats the runtime arg diff the bundle exists for — an
- * `ArrayExpression`/`ObjectExpression`/arrow arg can never compare equal, so it
- * would pay a per-render allocation to skip nothing. Regex is rejected for the
- * same reason `isInvariantLiteral` rejects it. Anything outside the whitelist
- * keeps the ordinary closure handler, which evaluates the body exactly when the
- * event fires.
+ * The whitelist is deliberately narrower than "pure", for two reasons.
  *
- * Member paths stay in: `() => select(row.id)` is the shape the bundle was
- * built for, and hoisting a property read is the cost the optimisation trades
- * against a per-render closure.
+ * A fresh identity per evaluation defeats the runtime arg diff the bundle
+ * exists for — an `ArrayExpression`/`ObjectExpression`/arrow arg can never
+ * compare equal, so it would pay a per-render allocation to skip nothing.
+ * Regex is rejected for the same reason `isInvariantLiteral` rejects it.
+ *
+ * The line is drawn at VALUE STABILITY, not at "provably pure". An accepted
+ * expression must yield at render time what it would have yielded at click
+ * time, and must not do unbounded or author-visible work to get there. A
+ * property read can reach a getter and `a + b` can reach `valueOf` — but that
+ * is the standing premise of the optimization, not a new risk: `select(row.id)`
+ * is the shape it was built for, and refusing property reads would leave it
+ * with nothing to optimize. Refusing arithmetic while accepting `row.id` would
+ * draw the same line in two places, so both stay.
+ *
+ * What cannot stay are the expressions that break value stability outright:
+ * a CALL does unbounded work and can be observed happening (`makeData(1000)`
+ * rebuilt a whole dataset per render), a fresh array/object/regex allocates an
+ * identity that can never compare equal, and an assignment or `++` mutates.
+ *
+ * `.current` is rejected because a ref genuinely returns the WRONG VALUE here,
+ * not merely an early one: `queueRefAttach` runs AFTER the mount that reads it,
+ * so a hoisted `ref.current` hands the first click the `null` it held before
+ * the ref was attached. Computed members fail closed for the same reason —
+ * `ref[key]` can spell `current` without saying so, and
+ * `isAutoMemoCalculationDependency` already refuses every computed key.
  */
 function isDeferralSafeBundleArg(node) {
 	const value = unwrapTsExpr(node);
@@ -3967,15 +3983,16 @@ function isDeferralSafeBundleArg(node) {
 		case 'ChainExpression':
 			return isDeferralSafeBundleArg(value.expression);
 		case 'MemberExpression':
-			return (
-				isDeferralSafeBundleArg(value.object) &&
-				(!value.computed || isDeferralSafeBundleArg(value.property))
-			);
+			// Computed keys fail closed: the key is only known at runtime, so
+			// `ref[k]` can reach `.current` without naming it.
+			if (value.computed) return false;
+			if (value.property?.name === 'current') return false;
+			return isDeferralSafeBundleArg(value.object);
 		case 'TemplateLiteral':
 			// A fresh string still compares by VALUE, so the arg diff works.
 			return (value.expressions || []).every(isDeferralSafeBundleArg);
 		case 'UnaryExpression':
-			// `delete` mutates; the rest are pure reads of their operand.
+			// `delete` mutates; the rest only read their operand.
 			return value.operator !== 'delete' && isDeferralSafeBundleArg(value.argument);
 		case 'BinaryExpression':
 		case 'LogicalExpression':
@@ -6129,6 +6146,7 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 		nextHookMemoCacheId: 0, // unique non-index slots property per compiled render function
 		currentInvariantLocals: null, // Set<string> of component-lifetime-stable local values
 		currentEventInvariantLocals: null, // Set<string> safe to retain in native event slots
+		currentBodyIsComponentScope: false, // planning the component body itself, not a nested arm
 		currentProfileComponentId: null,
 		knownStringLocals: null, // Set<string> of provably-string locals (text-hole inference)
 		nextHookSymId: 0,
@@ -10519,6 +10537,11 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 	}
 	ctx.currentInvariantLocals = invariantLocals;
 	ctx.currentEventInvariantLocals = eventInvariantLocals;
+	// Same gate `findMountEventCallbackSinks` uses: the lifetime proof below is
+	// defined relative to the COMPONENT's scope, so it is only sound while
+	// planning that scope's own JSX.
+	const prevBodyIsComponentScope = ctx.currentBodyIsComponentScope;
+	ctx.currentBodyIsComponentScope = options?.autoCallback === true;
 	// M3 inherit-range: only a real `@{ … }` (JSXCodeBlock) component body spans
 	// its block's whole range — synthetic sub-bodies (@if/@for/@try arms,
 	// children render-fns) pass statement arrays and stay unflagged. planJsx
@@ -10552,6 +10575,7 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 	}
 	ctx.currentInvariantLocals = prevInvariantLocals;
 	ctx.currentEventInvariantLocals = prevEventInvariantLocals;
+	ctx.currentBodyIsComponentScope = prevBodyIsComponentScope;
 	ctx._inheritBody = prevInheritBody;
 	ctx._fnOrigin = prevFnOrigin;
 	ctx._foldedDirectiveCalls = prevFDC;
@@ -11121,6 +11145,49 @@ function isEventHandlerInvariantExpr(node, ctx) {
 			value.type === 'Identifier' &&
 			ctx.currentEventInvariantLocals?.has(value.name) === true)
 	);
+}
+
+/**
+ * An inline `onClick={() => …}` arrow is rebuilt and reassigned to its DOM slot
+ * on every render. When nothing the arrow reads can change, that write is dead
+ * work: the handler can be installed once at mount and left alone, which is
+ * already what a NAMED handler gets through `findMountEventCallbackSinks`.
+ * Recognising the inline form closes the gap between the two spellings.
+ *
+ * "Nothing it reads can change" means every free identifier is either proven
+ * event-invariant for this component (a useState setter, a ref object, a
+ * useEffectEvent wrapper, …) or is not a component local at all — module scope,
+ * an import, or a global, each fixed for the module's lifetime. That second
+ * clause is the same inference `isArrowStableOver` makes.
+ *
+ * Sound only while planning the component body's own JSX.
+ * `collectComponentLocals` deliberately ignores nested blocks, so inside a
+ * `@for` item body the loop variable is absent from the set and would read as
+ * module scope — and a keyed survivor can be handed a different item without
+ * remounting, which would freeze the first item's capture in the slot forever.
+ */
+function isMountStableInlineHandler(node, ctx) {
+	if (ctx.hmr || ctx.profile || !ctx.currentBodyIsComponentScope) return false;
+	const value = unwrapTsExpr(node);
+	// A FunctionExpression is reachable through its own binding name and carries
+	// its own `this`/`arguments`; only the arrow form is a pure lexical capture.
+	if (value?.type !== 'ArrowFunctionExpression') return false;
+	const locals = ctx.currentComponentLocals;
+	if (!locals) return false;
+	const paramScope = new Set();
+	for (const p of value.params || []) collectBindings(p, paramScope);
+	// Params are walked alongside the body: their names are already bound in
+	// `paramScope`, but a default (`(e, x = n) => …`) is an ordinary expression
+	// that runs per call and can reach a changing local.
+	for (const name of collectFreeIdentifiers([value.body, ...(value.params || [])], paramScope)) {
+		// `arguments` is the render call's own, and a DIRECT `eval` resolves
+		// component locals this walk cannot see — either would tie the installed
+		// closure to whatever the first render happened to hold.
+		if (name === 'arguments' || name === 'eval') return false;
+		if (!locals.has(name)) continue;
+		if (ctx.currentEventInvariantLocals?.has(name) !== true) return false;
+	}
+	return true;
 }
 
 // Object/array/function literals allocate a new identity on every evaluation,
@@ -19546,7 +19613,8 @@ function emitElementHtml(
 					slotKey,
 					ns: hostNs,
 					dev: ctx.dev,
-					mountOnly: isEventHandlerInvariantExpr(inner, ctx),
+					mountOnly:
+						isEventHandlerInvariantExpr(inner, ctx) || isMountStableInlineHandler(inner, ctx),
 				});
 			}
 		} else if (attrName === 'class') {

--- a/packages/octane/tests/_fixtures/attrs-events.tsrx
+++ b/packages/octane/tests/_fixtures/attrs-events.tsrx
@@ -92,6 +92,22 @@ export function DeferredEventArgument(props) @{
 	</div>
 }
 
+// An inline handler that reads nothing changeable is installed once at mount.
+// One that captures render state must keep seeing the LATEST capture, which is
+// what makes the install-once proof load-bearing rather than cosmetic.
+const stableLabel = () => 'stable';
+
+export function MountStableHandlers() @{
+	const [log, setLog] = useState('none');
+	const [n, setN] = useState(0);
+	<div>
+		<button id="bump" onClick={() => setN((current) => current + 1)}>{n as string}</button>
+		<button id="stable" onClick={() => setLog(stableLabel())}>{'stable'}</button>
+		<button id="capturing" onClick={() => setLog('n=' + n)}>{'capturing'}</button>
+		<output>{log as string}</output>
+	</div>
+}
+
 export function StableNativeEventCallbacks(props) @{
 	const [n, setN] = useState(0);
 	const increment = () => setN((value) => value + 1);

--- a/packages/octane/tests/attrs-events.test.ts
+++ b/packages/octane/tests/attrs-events.test.ts
@@ -19,6 +19,7 @@ import {
 	RegexCallbackDependency,
 	RegexEventArgument,
 	DeferredEventArgument,
+	MountStableHandlers,
 	StableNativeEventCallbacks,
 	AriaStaticLiterals,
 } from './_fixtures/attrs-events.tsrx';
@@ -226,6 +227,27 @@ describe('events + useState', () => {
 		r.click('#refresh');
 		expect(built).toEqual([2]);
 		expect(r.find('#refresh').textContent).toBe('built:2');
+		r.unmount();
+	});
+
+	it('keeps a capturing inline handler on the latest render while installing a stable one once', () => {
+		const r = mount(MountStableHandlers);
+
+		r.click('#bump');
+		r.click('#bump');
+		expect(r.find('#bump').textContent).toBe('2');
+
+		// The load-bearing half: this handler captures `n`, so freezing it at
+		// mount would report the mount-time 0 forever.
+		r.click('#capturing');
+		expect(r.find('output').textContent).toBe('n=2');
+
+		// The install-once half still dispatches after many renders.
+		r.click('#stable');
+		expect(r.find('output').textContent).toBe('stable');
+		r.click('#bump');
+		r.click('#stable');
+		expect(r.find('output').textContent).toBe('stable');
 		r.unmount();
 	});
 

--- a/packages/octane/tests/compiler/event-callback-codegen.test.ts
+++ b/packages/octane/tests/compiler/event-callback-codegen.test.ts
@@ -114,8 +114,10 @@ describe('compiler-owned native event callbacks', () => {
 		const handler = (arg: string) =>
 			compile(
 				`
+        import { useRef } from 'octane';
         export function App(props) @{
-          const { select, row, n, build } = props;
+          const box = useRef(null);
+          const { select, row, n, build, flag, key } = props;
           <button onClick={() => select(${arg})}>go</button>
         }
       `,
@@ -124,20 +126,177 @@ describe('compiler-owned native event callbacks', () => {
 			).code;
 		const bundled = (arg: string) => /_\$evt\d+\(/.test(handler(arg));
 
-		// The shapes the bundle exists for: a stable callee plus args the runtime
-		// can identity-diff without paying for the evaluation.
-		expect(bundled('row.id')).toBe(true);
-		expect(bundled('row?.id')).toBe(true);
-		expect(bundled('n + 1')).toBe(true);
-		expect(bundled('`row-${row.id}`')).toBe(true);
+		// Value-stable and cheap: what the expression yields at render time is
+		// what it would have yielded at click time. A getter behind `row.id` or a
+		// `valueOf` behind `n + 1` is the optimization's standing premise, so the
+		// two are admitted on the same terms rather than one being refused.
+		for (const arg of [
+			'row',
+			'row.id',
+			'row?.id',
+			"'go'",
+			'!flag',
+			'n + 1',
+			'+n',
+			'n < 1',
+			'`row-${row.id}`',
+			'row.id ?? n',
+			'flag ? n : 0',
+		])
+			expect(bundled(arg)).toBe(true);
 
-		// Hoisting these out of the arrow would run them on every render: a call
-		// is arbitrary user work, and a fresh literal or regex can never compare
-		// equal anyway, so the bundle would allocate per render to skip nothing.
-		for (const arg of ['build(n)', '[row]', '{ row }', '/x/g', 'n++']) {
+		// These break value stability outright: a call does unbounded, observable
+		// work; a fresh array/object/regex allocates an identity that can never
+		// compare equal; `++` mutates. `box.current` is the sharpest case — the
+		// ref attaches AFTER the mount that would read it, so the first click
+		// would receive the pre-attach `null`. Computed keys fail closed because
+		// `box[key]` can spell `current` without saying so.
+		for (const arg of [
+			'build(n)',
+			'[row]',
+			'{ row }',
+			'/x/g',
+			'n++',
+			'box.current',
+			"box['current']",
+			'box[key]',
+			'row[n]',
+		]) {
 			expect(handler(arg)).toContain(`() => select(${arg})`);
 			expect(bundled(arg)).toBe(false);
 		}
+	});
+
+	it('installs an inline handler once only when nothing it reads can change', () => {
+		// Reaches only module scope + a useState setter, so the slot never needs
+		// rewriting; the capturing cases must keep their update write.
+		const compileBody = (body: string, options = { hmr: false, dev: false }) =>
+			compile(
+				`
+        import { useState, useRef, useEffectEvent } from 'octane';
+        const label = () => 'x';
+        export function App(props) @{
+          ${body}
+        }
+      `,
+				'inline-handler-lifetime.tsrx',
+				options,
+			).code;
+		// Shape-independent: a handler the update path rewrites is EMITTED twice
+		// (mount + update), whichever lowering carries it — closure assignment,
+		// the bundle's `evtNu` helper, or a spread's source resolver.
+		const emitCount = (code: string) => (code.match(/setLog\(|setN\(|ev\(\)/g) || []).length;
+		const rewritesOnUpdate = (code: string) => /_\$evt\d+u\(/.test(code) || emitCount(code) > 1;
+
+		const installedOnce = (body: string) => !rewritesOnUpdate(compileBody(body));
+
+		// Nothing changeable is reachable: module function, useState setter,
+		// useRef object (the arrow still reads `.current` at click time), and a
+		// useEffectEvent wrapper that forwards to its latest committed body.
+		expect(
+			installedOnce(`
+        const [, setLog] = useState('');
+        <button onClick={() => setLog(label())}>go</button>
+      `),
+		).toBe(true);
+		expect(
+			installedOnce(`
+        const [, setN] = useState(0);
+        <button onClick={() => setN((current) => current + 1)}>go</button>
+      `),
+		).toBe(true);
+		expect(
+			installedOnce(`
+        const box = useRef(null);
+        const [, setLog] = useState('');
+        <button onClick={() => setLog(box.current)}>go</button>
+      `),
+		).toBe(true);
+		expect(
+			installedOnce(`
+        const ev = useEffectEvent(() => props.log(props.value));
+        <button onClick={() => ev()}>go</button>
+      `),
+		).toBe(true);
+
+		// Captures render state, so the slot must follow each render.
+		expect(
+			installedOnce(`
+        const [n, setN] = useState(0);
+        <button onClick={() => setN(n + 1)}>go</button>
+      `),
+		).toBe(false);
+		// `props` is a component local that is not lifetime-invariant.
+		expect(
+			installedOnce(`
+        const [, setLog] = useState('');
+        <button onClick={() => setLog(props.value)}>go</button>
+      `),
+		).toBe(false);
+		// A derived const is recomputed every render even though it is `const`.
+		expect(
+			installedOnce(`
+        const [n, setN] = useState(0);
+        const doubled = n * 2;
+        <button onClick={() => setN(doubled)}>go</button>
+      `),
+		).toBe(false);
+
+		// A direct `eval` resolves component locals the free-name walk cannot
+		// see, so the handler must not be treated as reading only module scope.
+		expect(
+			installedOnce(`
+        const [n, setN] = useState(0);
+        <button onClick={() => setLog(eval('n'))}>go</button>
+      `),
+		).toBe(false);
+
+		// Hot replacement has to be able to swap an edited handler body, and a
+		// spread on the same element can overwrite the slot.
+		expect(
+			rewritesOnUpdate(
+				compileBody(
+					`
+        const [, setLog] = useState('');
+        <button onClick={() => setLog(label())}>go</button>
+      `,
+					{ hmr: true, dev: true },
+				),
+			),
+		).toBe(true);
+		expect(
+			installedOnce(`
+        const [, setLog] = useState('');
+        <button {...props.attrs} onClick={() => setLog(label())}>go</button>
+      `),
+		).toBe(false);
+	});
+
+	it('keeps a keyed row handler live, where the item can change without a remount', () => {
+		// `collectComponentLocals` does not descend into the row body, so an
+		// unguarded lifetime proof would read `item` as module scope and freeze
+		// the first item's capture into the surviving row's slot.
+		const code = compile(
+			`
+        import { useState } from 'octane';
+        export function App(props) @{
+          const [, setPicked] = useState(null);
+          <ul>
+            @for (const item of props.items; key item.id) {
+              <li><button onClick={() => setPicked(item.label)}>go</button></li>
+            }
+          </ul>
+        }
+      `,
+			'keyed-row-handler.tsrx',
+			{ hmr: false, dev: false },
+		).code;
+
+		const rowBody = code.slice(code.indexOf('function __item'));
+		expect(rowBody).toContain('function __item');
+		// `item.label` is a member path, so the row takes the bundle lowering;
+		// the update helper is the proof its slot still follows the item.
+		expect(rowBody).toMatch(/_\$evt\d+u\(/);
 	});
 
 	it('retains an Effect Event mount wrapper only for an unshared native event slot', () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes compiler semantics for native events and bundled args; incorrect whitelist or mount-only proofs could cause stale handlers or extra per-render work, but behavior is heavily tested.
> 
> **Overview**
> Tightens **when** the compiler hoists inline event-handler work out of the click path, and adds a **mount-once** path for inline arrows that never need a fresh closure.
> 
> **Bundled handler arguments** are only lifted into the render/bundle path when they are *value-stable* at render vs click time. **Computed** member access and **`.current`** (including `ref[key]`) no longer qualify—refs attach after the mount that would read them, so hoisting could hand the first click a pre-attach `null`. Calls, fresh object/array/regex literals, and mutations still use the normal closure handler.
> 
> **Inline `onClick={() => …}` arrows** that only touch module scope or *event-invariant* locals (setters, ref objects, `useEffectEvent`, etc.) are marked **`mountOnly`**, like named handlers—no per-render slot rewrite. Handlers that capture changing render state (`n`, `props`, derived `const`s), use `eval`/`arguments`, sit under **HMR**, share the slot with a **spread**, or live in a **keyed `@for` row** keep updating on each render.
> 
> Tests cover bundle-arg codegen, mount-stable vs capturing behavior, and keyed-row exclusions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29b51c68cf30d9e0968da6c795c48cce2f659147. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->