### PR TITLE
chore(docs): guide for library publishers

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ Octane itself. Good places to start:
   each dialect and what TSRX unlocks.
 - [Differences from React](https://octanejs.dev/docs/differences-from-react): the
   deliberate divergences, and why everything else matching React is the point.
+- [Publishing libraries](https://octanejs.dev/docs/publishing-libraries): package
+  all importable authored code so applications compile libraries against their
+  own Octane runtime.
 - [Bindings](https://octanejs.dev/docs/bindings): the `@octanejs/*` ports of the
   React ecosystem.
 

--- a/website/public/sitemap.xml
+++ b/website/public/sitemap.xml
@@ -10,6 +10,7 @@
 	<url><loc>https://octanejs.dev/docs/differences-from-react</loc></url>
 	<url><loc>https://octanejs.dev/docs/react-compat</loc></url>
 	<url><loc>https://octanejs.dev/docs/profiling</loc></url>
+	<url><loc>https://octanejs.dev/docs/publishing-libraries</loc></url>
 	<url><loc>https://octanejs.dev/docs/bindings</loc></url>
 	<url><loc>https://octanejs.dev/benchmarks</loc></url>
 	<url><loc>https://octanejs.dev/playground</loc></url>

--- a/website/src/components/PackageInstall.tsrx
+++ b/website/src/components/PackageInstall.tsrx
@@ -1,10 +1,8 @@
-// An install snippet with a package-manager switcher: npm / pnpm / yarn / bun
-// tabs (pnpm is the default) over one terminal panel whose command is derived
-// per manager from the SAME package list — so a doc can never show a pnpm line
-// the npm tab contradicts. Docs use it for install fences only; script-running
-// fences (pnpm rsbuild dev, vite build …) stay ordinary code blocks. It owns
-// its own frame + copy button (rather than wrapping CodeBlock) so the tab bar
-// attaches seamlessly to the code as one panel.
+// A package-manager command with npm / pnpm / yarn / bun tabs (pnpm is the
+// default) over one terminal panel. Install commands are derived from one
+// package list, while named recipes cover commands whose shape differs by
+// manager. It owns its own frame + copy button (rather than wrapping CodeBlock)
+// so the tab bar attaches seamlessly to the code as one panel.
 import { useId, useRef, useState } from 'octane';
 import { useCopyToClipboard } from '../hooks/use-copy.ts';
 import copyUrl from '../assets/copy.svg';
@@ -22,11 +20,20 @@ const INSTALL: Record<PackageManager, { add: string; dev: string }> = {
 	bun: { add: 'bun add', dev: 'bun add -d' },
 };
 
+const PACK_DRY_RUN: Record<PackageManager, string> = {
+	npm: 'npm pack --dry-run',
+	pnpm: 'pnpm pack --dry-run',
+	yarn: 'yarn pack --dry-run',
+	bun: 'bun pm pack --dry-run',
+};
+
 interface PackageInstallProps {
 	/** Runtime packages, space-separated — rendered first. */
 	packages?: string;
 	/** Dev packages, space-separated — rendered as the -D line. */
 	dev?: string;
+	/** A package-manager-specific command recipe instead of an install command. */
+	command?: 'pack-dry-run';
 }
 
 // One rendered span in the code block. Newlines between command lines are their
@@ -66,8 +73,12 @@ export function PackageInstall(props: PackageInstallProps) @{
 	const id = useId();
 
 	const lines: string[] = [];
-	if (props.packages) lines.push(INSTALL[manager].add + ' ' + props.packages);
-	if (props.dev) lines.push(INSTALL[manager].dev + ' ' + props.dev);
+	if (props.command === 'pack-dry-run') {
+		lines.push(PACK_DRY_RUN[manager]);
+	} else {
+		if (props.packages) lines.push(INSTALL[manager].add + ' ' + props.packages);
+		if (props.dev) lines.push(INSTALL[manager].dev + ' ' + props.dev);
+	}
 	const tokens = toTokens(lines);
 
 	// textContent, not innerText: the element holds only our own token spans and a
@@ -264,3 +275,7 @@ export function PackageInstall(props: PackageInstallProps) @{
 		</style>
 	</div>
 }
+
+// New docs should use the general name for non-install recipes. Keep the
+// original export because install snippets already use it throughout the site.
+export const PackageManagerCommand = PackageInstall;

--- a/website/src/content/docs-meta.ts
+++ b/website/src/content/docs-meta.ts
@@ -169,6 +169,30 @@ export const docsMeta: DocMeta[] = [
 		],
 	},
 	{
+		slug: 'publishing-libraries',
+		title: 'Publishing libraries',
+		description:
+			'Ship complete importable Octane source so each application compiles libraries against its installed runtime.',
+		group: 'Explore',
+		searchTerms: [
+			'library author',
+			'package author',
+			'raw source',
+			'npm publish',
+			'npm pack',
+			'peerDependencies',
+			'package exports',
+			'hookSlots',
+		],
+		sections: [
+			{ id: 'source-package-contract', title: 'The source-package contract' },
+			{ id: 'package-the-source', title: 'Package the source' },
+			{ id: 'authoring-and-types', title: 'Authoring and types' },
+			{ id: 'package-metadata', title: 'Package metadata' },
+			{ id: 'verify-the-package', title: 'Verify the package' },
+		],
+	},
+	{
 		slug: 'bindings',
 		title: 'Bindings',
 		description: `Browse all ${BINDING_COUNT} Octane bindings for state, data, routing, UI, forms, and more.`,

--- a/website/src/content/docs.ts
+++ b/website/src/content/docs.ts
@@ -10,6 +10,7 @@ import CoreApis from './docs/core-apis.mdx';
 import TsrxVsTsx from './docs/tsrx-vs-tsx.mdx';
 import DifferencesFromReact from './docs/differences-from-react.mdx';
 import ReactCompat from './docs/react-compat.mdx';
+import PublishingLibraries from './docs/publishing-libraries.mdx';
 import Bindings from './docs/bindings.mdx';
 import Profiling from './docs/profiling.mdx';
 import { docsMeta, type DocMeta, type DocSection } from './docs-meta.ts';
@@ -29,6 +30,7 @@ const components: Record<string, DocEntry['component']> = {
 	'differences-from-react': DifferencesFromReact,
 	'react-compat': ReactCompat,
 	profiling: Profiling,
+	'publishing-libraries': PublishingLibraries,
 	bindings: Bindings,
 };
 

--- a/website/src/content/docs/build-tools.mdx
+++ b/website/src/content/docs/build-tools.mdx
@@ -29,6 +29,10 @@ All integrations use the same compiler, runtime selection, source maps, raw
 Octane dependency discovery, and cache dependencies. Choosing a bundler does
 not change component semantics.
 
+Publishing a package built on Octane? Ship its authored modules as a
+[source package](/docs/publishing-libraries) so the consuming application compiles
+the library with the same Octane compiler and runtime as its own code.
+
 All three integrations also accept `profile: true` for a client profiling
 build. See [Profiling](/docs/profiling) for Chrome tracks, render causes, the
 console API, and the recommended production-style workflow.

--- a/website/src/content/docs/publishing-libraries.mdx
+++ b/website/src/content/docs/publishing-libraries.mdx
@@ -1,0 +1,167 @@
+---
+title: Publishing libraries
+---
+
+import { PackageManagerCommand } from '../../components/PackageInstall.tsrx';
+
+<div className="doc-hero">
+	<p className="doc-eyebrow">Ship source, compile with the app</p>
+	<h1>Publishing libraries</h1>
+	<p className="doc-lede">
+		{
+			'Publish all importable code in the form it was authored. The consuming application compiles it with its own Octane toolchain so generated code and the installed runtime always agree.'
+		}
+	</p>
+</div>
+
+<h2 id="source-package-contract">The source-package contract</h2>
+
+An Octane library is a **source package**. Its public exports resolve to authored
+source, not to JavaScript previously emitted by the Octane compiler. The application’s
+Vite, Rspack, or Rsbuild integration compiles that source alongside the application.
+
+This is required because compiled Octane output is coupled to the compiler/runtime
+contract and to the build target. Compiling in the application gives the library the
+same Octane version, client or server runtime selection, production settings, and
+development behavior as the code importing it.
+
+<aside className="doc-callout note">
+	<p className="doc-callout-title">
+		Do not publish precompiled Octane output as the implementation
+	</p>
+	<p>
+		{
+			'A library build produced by one Octane compiler may not match the runtime installed by the consuming application. Point package exports at the authored source and let the application compile it.'
+		}
+	</p>
+</aside>
+
+<h2 id="package-the-source">Package the complete source graph</h2>
+
+Publish every file consumers can import through the package exports, plus every module
+and runtime asset those entry points transitively import. Preserve each file’s extension
+and relative path. That includes all `.tsrx`, `.tsx`, `.ts`, and `.js` modules in the
+importable graph, plus imported CSS, JSON, WebAssembly, or other runtime assets. Do not
+replace `.tsrx` or `.tsx` modules with compiler output during release packaging.
+
+“Complete source” means the importable graph consumers can execute. Tests, fixtures,
+benchmarks, examples, and repository-only tooling are outside that graph and should not
+be published unless the package intentionally exposes them.
+
+A simple package whose `src` directory contains only importable code can whitelist that
+whole directory:
+
+```text
+my-octane-library/
+├── package.json
+├── README.md
+└── src/
+    ├── index.ts
+    ├── Button.tsrx
+    ├── Icon.tsx
+    ├── useButton.ts
+    └── compatibility.js
+```
+
+```json
+{
+	"name": "@acme/octane-library",
+	"version": "1.0.0",
+	"type": "module",
+	"files": ["src", "README.md"],
+	"main": "./src/index.ts",
+	"module": "./src/index.ts",
+	"types": "./src/index.ts",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"peerDependencies": {
+		"octane": "^0.1.0"
+	}
+}
+```
+
+Choose the peer range you actually test and support. The important parts of the
+example are that `files` includes the complete source graph, `exports` resolves to raw
+source, and `octane` is a runtime peer rather than only a development dependency.
+
+For multiple public entry points, map every subpath to its source entry:
+
+```json
+{
+	"exports": {
+		".": "./src/index.ts",
+		"./button": "./src/Button.tsrx",
+		"./server": "./src/server.ts"
+	}
+}
+```
+
+The consuming application must declare your package in its dependencies. Octane’s
+bundler integrations discover installed source packages that depend on or peer-depend
+on `octane`, follow their runtime dependencies recursively, and keep them in the
+compiler pipeline. Applications do not need package-specific build aliases or
+`node_modules` include rules.
+
+<h2 id="authoring-and-types">Authoring and types</h2>
+
+Keep the original extensions because they tell the toolchain how to handle each module:
+
+- `.tsrx` and Octane-owned `.tsx` receive full compilation.
+- Plain `.ts` and `.js` remain source modules; when they define Octane custom hooks,
+  the compiler assigns the hook slots they need.
+- A `.tsx` file should start with `/** @jsxImportSource octane */` so TypeScript uses
+  Octane’s JSX types. Installed-package ownership still comes from the package manifest.
+
+Raw `.ts` entry points can also supply the public types, as in the manifest above. If a
+direct `.tsrx` export needs a generated declaration, ship its corresponding `.d.ts` and
+use a `types` export condition, but keep the `default` condition pointed at the raw
+`.tsrx` implementation. Declaration files supplement source; they do not replace it.
+
+Never add an ambient `declare module '*.tsrx'`. It hides real resolution errors and
+turns every matching import into `any`. Type-check a package containing `.tsrx` with
+`tsrx-tsc --noEmit`.
+
+<h2 id="package-metadata">Use package metadata only for real exceptions</h2>
+
+Most libraries need no top-level `octane` configuration object; declaring the runtime
+dependency is enough. In particular, do not copy this setting from another binding:
+
+```json
+{
+	"octane": {
+		"hookSlots": {
+			"manual": ["src"]
+		}
+	}
+}
+```
+
+`hookSlots.manual` disables automatic hook slotting under those directories. It is only
+for a library that deliberately implements and verifies slot forwarding itself. Leaving
+it out is the correct default for normal `.ts` and `.js` custom hooks.
+
+The Vite-specific `octane.vite.optimizeDeps.exclude` metadata is similarly narrow: use
+it only when an identity-sensitive dependency must stay outside Vite’s dependency
+optimizer. See [Build tools](/docs/build-tools#vite) for that escape hatch.
+
+<h2 id="verify-the-package">Verify what users receive</h2>
+
+Inspect the release tarball before publishing:
+
+<PackageManagerCommand command="pack-dry-run" />
+
+Confirm that:
+
+1. Every exported path exists in the tarball.
+2. Every relative import from those entries resolves to another included source file or
+   asset.
+3. Every `.tsrx`, `.tsx`, `.ts`, and `.js` file in the importable graph retains its
+   authored contents and extension.
+4. `octane` is present in `peerDependencies`, not only `devDependencies`.
+5. A fixture application can install the packed tarball, type-check with `tsrx-tsc`, and
+   build through one of Octane’s supported integrations.
+
+That packed-consumer test is the useful boundary: it catches missing `files` entries,
+incorrect export maps, undeclared runtime dependencies, and release steps that silently
+swap source for stale compiled output.

--- a/website/src/pages/doc-page/DocPage.tsrx
+++ b/website/src/pages/doc-page/DocPage.tsrx
@@ -123,6 +123,13 @@ export function DocPage() @{
 				border-top: 1px solid var(--border);
 				scroll-margin-top: 5.5rem;
 			}
+			/* The hero already ends with a divider. When a document opens directly
+			   with a section heading, do not draw the normal section divider again. */
+			.prose :global(.doc-hero + h2) {
+				margin-top: 0;
+				padding-top: 0;
+				border-top: none;
+			}
 			.prose :global(h3) {
 				font-size: 1.2rem;
 				letter-spacing: -0.01em;

--- a/website/tests/package-install.test.ts
+++ b/website/tests/package-install.test.ts
@@ -12,7 +12,7 @@ afterEach(() => {
 	vi.useRealTimers();
 });
 
-function mount(props: { packages?: string; dev?: string }) {
+function mount(props: { packages?: string; dev?: string; command?: 'pack-dry-run' }) {
 	const utils = render(PackageInstall as any, { props });
 	const tab = (name: string) =>
 		Array.from(utils.container.querySelectorAll<HTMLButtonElement>('[role="tab"]')).find(
@@ -50,6 +50,18 @@ describe('PackageInstall', () => {
 	it('renders a single line when there are no dev packages', () => {
 		const { command } = mount({ packages: '@octanejs/zustand' });
 		expect(command()).toBe('pnpm add @octanejs/zustand');
+	});
+
+	it('renders the native pack dry-run command for every manager', () => {
+		const { tab, command } = mount({ command: 'pack-dry-run' });
+
+		expect(command()).toBe('pnpm pack --dry-run');
+		fireEvent.click(tab('npm'));
+		expect(command()).toBe('npm pack --dry-run');
+		fireEvent.click(tab('yarn'));
+		expect(command()).toBe('yarn pack --dry-run');
+		fireEvent.click(tab('bun'));
+		expect(command()).toBe('bun pm pack --dry-run');
 	});
 
 	it('moves selection with arrow keys and keeps one tab in the tab order', () => {

--- a/website/tests/smoke.test.ts
+++ b/website/tests/smoke.test.ts
@@ -332,6 +332,17 @@ describe('website routes', () => {
 		expect(container.querySelector('.prose pre.shiki code')).toBeTruthy();
 	});
 
+	it('/docs/publishing-libraries renders the package-manager dry-run selector', async () => {
+		const { container } = await renderRoute('/docs/publishing-libraries');
+		const firstSection = container.querySelector<HTMLElement>('h2#source-package-contract')!;
+		const tabs = container.querySelectorAll('.pkg-tabs [role="tab"]');
+
+		expect(firstSection.previousElementSibling?.classList.contains('doc-hero')).toBe(true);
+		expect(getComputedStyle(firstSection).borderTopStyle).toBe('none');
+		expect(tabs).toHaveLength(4);
+		expect(container.querySelector('.pkg-code')?.textContent).toBe('pnpm pack --dry-run');
+	});
+
 	it('/docs/bindings links every first-party binding', async () => {
 		const { container } = await renderRoute('/docs/bindings');
 		const packages = BINDING_CATEGORIES.flatMap((category) => category.packages);


### PR DESCRIPTION
## Provenance

  - [ ] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and website UI/test changes only; no runtime or compiler behavior is modified.
> 
> **Overview**
> Adds a **Publishing libraries** doc that defines the Octane **source-package** model: ship authored `.tsrx`/`.tsx`/`.ts` (and assets) via `exports`, use `octane` as a **peerDependency**, and let the app’s bundler compile the library—plus guidance on types (`tsrx-tsc`), when **not** to use `hookSlots.manual`, and pre-publish verification.
> 
> Wires the page into the site (**`docs-meta`**, **`docs.ts`**, **sitemap**, **README**) and links it from **Build tools**.
> 
> Extends **`PackageInstall`** with a **`pack-dry-run`** recipe (per npm/pnpm/yarn/bun) and exports **`PackageManagerCommand`** for non-install snippets; **`DocPage`** drops the duplicate top border on the first **`h2`** after a doc hero. Tests cover the new command tabs and the publishing-libraries route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a1674710acfe1478b2167e4842e3ddfc48c159a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->