### PR TITLE
ci and docs: docs lightweight, publish lib rule, keep cursor desc

### DIFF
--- a/.claude/skills/create-a-pr/SKILL.md
+++ b/.claude/skills/create-a-pr/SKILL.md
@@ -68,6 +68,29 @@ Targeted alternatives are acceptable for small changes, but PR body must say wha
 - ...
 ```
 
+## Preserve managed sections when updating an existing PR
+
+The template above is for creating a new pull request. Before editing an
+existing pull request body, fetch its current body with `gh pr view` and merge
+the desired changes into that body. Never replace it from a newly generated
+template.
+
+Treat paired bot-managed HTML comment regions as opaque and preserve them
+byte-for-byte. In particular, Cursor Bugbot owns this region:
+
+```md
+<!-- CURSOR_SUMMARY -->
+...
+<!-- /CURSOR_SUMMARY -->
+```
+
+Refetch the body immediately before writing because a bot can update it after a
+commit is pushed. After `gh pr edit`, fetch it again and verify that every
+managed region remains. If an edit races with a bot and removes one, recover the
+latest region from the pull request's edit history and restore it before ending
+the task. Adding or checking provenance is never a reason to discard an
+existing summary, description, comment region, or maintainer-authored text.
+
 ## Create PR with GitHub CLI
 
 Immediately before committing and pushing, synchronize the repository and

--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -113,6 +113,12 @@ Typecheck any program containing `.tsrx` with `tsrx-tsc --noEmit`, never plain
 `tsc`. Octane-owned `.tsx` files carry a leading `/** @jsxImportSource octane */`
 pragma. Use `OctaneNode` for renderables, never `React.ReactNode`.
 
+## Published packages
+
+Ship every importable `.tsrx`, `.tsx`, `.ts`, and `.js` module as authored and
+point package exports at that source. Never publish Octane compiler output; the
+consuming application compiles the source with its own toolchain.
+
 ## Working here
 
 ```bash

--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -45,12 +45,10 @@ trigger first arises, even if it is a later step you chose:
 Each skill is `.rulesync/skills/<name>/SKILL.md`, with a generated per-tool copy;
 read that path directly if your tool cannot load a skill by name.
 
-One `create-a-pr` rule must survive not loading it: keep the PR template's
-provenance section and tick its box when an agent produced the diff. An agent
-commits under a human's credentials, so nothing else tells the two apart and a
-clear or missing box asserts a human wrote it. A bot turns a checked box into
-`agent-authored` and derives the type label from the title, so never apply labels
-yourself.
+Without `create-a-pr`: keep and tick provenance for agent work (clear or missing
+asserts human); never apply PR labels. Existing PR body edits must merge,
+preserve `<!-- CURSOR_SUMMARY -->` through `<!-- /CURSOR_SUMMARY -->`
+byte-for-byte, refetch before writing, and verify after.
 
 ## Your React instincts are the main failure mode here
 

--- a/.cursor/skills/create-a-pr/SKILL.md
+++ b/.cursor/skills/create-a-pr/SKILL.md
@@ -65,6 +65,29 @@ Targeted alternatives are acceptable for small changes, but PR body must say wha
 - ...
 ```
 
+## Preserve managed sections when updating an existing PR
+
+The template above is for creating a new pull request. Before editing an
+existing pull request body, fetch its current body with `gh pr view` and merge
+the desired changes into that body. Never replace it from a newly generated
+template.
+
+Treat paired bot-managed HTML comment regions as opaque and preserve them
+byte-for-byte. In particular, Cursor Bugbot owns this region:
+
+```md
+<!-- CURSOR_SUMMARY -->
+...
+<!-- /CURSOR_SUMMARY -->
+```
+
+Refetch the body immediately before writing because a bot can update it after a
+commit is pushed. After `gh pr edit`, fetch it again and verify that every
+managed region remains. If an edit races with a bot and removes one, recover the
+latest region from the pull request's edit history and restore it before ending
+the task. Adding or checking provenance is never a reason to discard an
+existing summary, description, comment region, or maintainer-authored text.
+
 ## Create PR with GitHub CLI
 
 Immediately before committing and pushing, synchronize the repository and

--- a/.gemini/skills/create-a-pr/SKILL.md
+++ b/.gemini/skills/create-a-pr/SKILL.md
@@ -68,6 +68,29 @@ Targeted alternatives are acceptable for small changes, but PR body must say wha
 - ...
 ```
 
+## Preserve managed sections when updating an existing PR
+
+The template above is for creating a new pull request. Before editing an
+existing pull request body, fetch its current body with `gh pr view` and merge
+the desired changes into that body. Never replace it from a newly generated
+template.
+
+Treat paired bot-managed HTML comment regions as opaque and preserve them
+byte-for-byte. In particular, Cursor Bugbot owns this region:
+
+```md
+<!-- CURSOR_SUMMARY -->
+...
+<!-- /CURSOR_SUMMARY -->
+```
+
+Refetch the body immediately before writing because a bot can update it after a
+commit is pushed. After `gh pr edit`, fetch it again and verify that every
+managed region remains. If an edit races with a bot and removes one, recover the
+latest region from the pull request's edit history and restore it before ending
+the task. Adding or checking provenance is never a reason to discard an
+existing summary, description, comment region, or maintainer-authored text.
+
 ## Create PR with GitHub CLI
 
 Immediately before committing and pushing, synchronize the repository and

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -108,6 +108,12 @@ Typecheck any program containing `.tsrx` with `tsrx-tsc --noEmit`, never plain
 `tsc`. Octane-owned `.tsx` files carry a leading `/** @jsxImportSource octane */`
 pragma. Use `OctaneNode` for renderables, never `React.ReactNode`.
 
+## Published packages
+
+Ship every importable `.tsrx`, `.tsx`, `.ts`, and `.js` module as authored and
+point package exports at that source. Never publish Octane compiler output; the
+consuming application compiles the source with its own toolchain.
+
 ## Working here
 
 ```bash

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,12 +40,10 @@ trigger first arises, even if it is a later step you chose:
 Each skill is `.rulesync/skills/<name>/SKILL.md`, with a generated per-tool copy;
 read that path directly if your tool cannot load a skill by name.
 
-One `create-a-pr` rule must survive not loading it: keep the PR template's
-provenance section and tick its box when an agent produced the diff. An agent
-commits under a human's credentials, so nothing else tells the two apart and a
-clear or missing box asserts a human wrote it. A bot turns a checked box into
-`agent-authored` and derives the type label from the title, so never apply labels
-yourself.
+Without `create-a-pr`: keep and tick provenance for agent work (clear or missing
+asserts human); never apply PR labels. Existing PR body edits must merge,
+preserve `<!-- CURSOR_SUMMARY -->` through `<!-- /CURSOR_SUMMARY -->`
+byte-for-byte, refetch before writing, and verify after.
 
 ## Your React instincts are the main failure mode here
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,4 +27,8 @@ diff; either form keeps the label workflow successful.
 A bot reads this box and applies the label, so nothing here needs repository
 permissions and it works the same from a fork. The type label comes from the
 conventional-commit type in the title. Do not apply either by hand.
+
+When updating an existing pull request, merge this template content into the
+current body. Preserve every bot-managed HTML comment region and all existing
+maintainer-authored text; never replace the body from a fresh template.
 -->

--- a/.github/skills/create-a-pr/SKILL.md
+++ b/.github/skills/create-a-pr/SKILL.md
@@ -68,6 +68,29 @@ Targeted alternatives are acceptable for small changes, but PR body must say wha
 - ...
 ```
 
+## Preserve managed sections when updating an existing PR
+
+The template above is for creating a new pull request. Before editing an
+existing pull request body, fetch its current body with `gh pr view` and merge
+the desired changes into that body. Never replace it from a newly generated
+template.
+
+Treat paired bot-managed HTML comment regions as opaque and preserve them
+byte-for-byte. In particular, Cursor Bugbot owns this region:
+
+```md
+<!-- CURSOR_SUMMARY -->
+...
+<!-- /CURSOR_SUMMARY -->
+```
+
+Refetch the body immediately before writing because a bot can update it after a
+commit is pushed. After `gh pr edit`, fetch it again and verify that every
+managed region remains. If an edit races with a bot and removes one, recover the
+latest region from the pull request's edit history and restore it before ending
+the task. Adding or checking provenance is never a reason to discard an
+existing summary, description, comment region, or maintainer-authored text.
+
 ## Create PR with GitHub CLI
 
 Immediately before committing and pushing, synchronize the repository and

--- a/.rulesync/rules/project.md
+++ b/.rulesync/rules/project.md
@@ -47,12 +47,10 @@ trigger first arises, even if it is a later step you chose:
 Each skill is `.rulesync/skills/<name>/SKILL.md`, with a generated per-tool copy;
 read that path directly if your tool cannot load a skill by name.
 
-One `create-a-pr` rule must survive not loading it: keep the PR template's
-provenance section and tick its box when an agent produced the diff. An agent
-commits under a human's credentials, so nothing else tells the two apart and a
-clear or missing box asserts a human wrote it. A bot turns a checked box into
-`agent-authored` and derives the type label from the title, so never apply labels
-yourself.
+Without `create-a-pr`: keep and tick provenance for agent work (clear or missing
+asserts human); never apply PR labels. Existing PR body edits must merge,
+preserve `<!-- CURSOR_SUMMARY -->` through `<!-- /CURSOR_SUMMARY -->`
+byte-for-byte, refetch before writing, and verify after.
 
 ## Your React instincts are the main failure mode here
 

--- a/.rulesync/rules/project.md
+++ b/.rulesync/rules/project.md
@@ -115,6 +115,12 @@ Typecheck any program containing `.tsrx` with `tsrx-tsc --noEmit`, never plain
 `tsc`. Octane-owned `.tsx` files carry a leading `/** @jsxImportSource octane */`
 pragma. Use `OctaneNode` for renderables, never `React.ReactNode`.
 
+## Published packages
+
+Ship every importable `.tsrx`, `.tsx`, `.ts`, and `.js` module as authored and
+point package exports at that source. Never publish Octane compiler output; the
+consuming application compiles the source with its own toolchain.
+
 ## Working here
 
 ```bash

--- a/.rulesync/skills/create-a-pr/SKILL.md
+++ b/.rulesync/skills/create-a-pr/SKILL.md
@@ -67,6 +67,29 @@ Targeted alternatives are acceptable for small changes, but PR body must say wha
 - ...
 ```
 
+## Preserve managed sections when updating an existing PR
+
+The template above is for creating a new pull request. Before editing an
+existing pull request body, fetch its current body with `gh pr view` and merge
+the desired changes into that body. Never replace it from a newly generated
+template.
+
+Treat paired bot-managed HTML comment regions as opaque and preserve them
+byte-for-byte. In particular, Cursor Bugbot owns this region:
+
+```md
+<!-- CURSOR_SUMMARY -->
+...
+<!-- /CURSOR_SUMMARY -->
+```
+
+Refetch the body immediately before writing because a bot can update it after a
+commit is pushed. After `gh pr edit`, fetch it again and verify that every
+managed region remains. If an edit races with a bot and removes one, recover the
+latest region from the pull request's edit history and restore it before ending
+the task. Adding or checking provenance is never a reason to discard an
+existing summary, description, comment region, or maintainer-authored text.
+
 ## Create PR with GitHub CLI
 
 Immediately before committing and pushing, synchronize the repository and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,12 +57,10 @@ trigger first arises, even if it is a later step you chose:
 Each skill is `.rulesync/skills/<name>/SKILL.md`, with a generated per-tool copy;
 read that path directly if your tool cannot load a skill by name.
 
-One `create-a-pr` rule must survive not loading it: keep the PR template's
-provenance section and tick its box when an agent produced the diff. An agent
-commits under a human's credentials, so nothing else tells the two apart and a
-clear or missing box asserts a human wrote it. A bot turns a checked box into
-`agent-authored` and derives the type label from the title, so never apply labels
-yourself.
+Without `create-a-pr`: keep and tick provenance for agent work (clear or missing
+asserts human); never apply PR labels. Existing PR body edits must merge,
+preserve `<!-- CURSOR_SUMMARY -->` through `<!-- /CURSOR_SUMMARY -->`
+byte-for-byte, refetch before writing, and verify after.
 
 ## Your React instincts are the main failure mode here
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,12 @@ Typecheck any program containing `.tsrx` with `tsrx-tsc --noEmit`, never plain
 `tsc`. Octane-owned `.tsx` files carry a leading `/** @jsxImportSource octane */`
 pragma. Use `OctaneNode` for renderables, never `React.ReactNode`.
 
+## Published packages
+
+Ship every importable `.tsrx`, `.tsx`, `.ts`, and `.js` module as authored and
+point package exports at that source. Never publish Octane compiler output; the
+consuming application compiles the source with its own toolchain.
+
 ## Working here
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,12 @@ Typecheck any program containing `.tsrx` with `tsrx-tsc --noEmit`, never plain
 `tsc`. Octane-owned `.tsx` files carry a leading `/** @jsxImportSource octane */`
 pragma. Use `OctaneNode` for renderables, never `React.ReactNode`.
 
+## Published packages
+
+Ship every importable `.tsrx`, `.tsx`, `.ts`, and `.js` module as authored and
+point package exports at that source. Never publish Octane compiler output; the
+consuming application compiles the source with its own toolchain.
+
 ## Working here
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,12 +40,10 @@ trigger first arises, even if it is a later step you chose:
 Each skill is `.rulesync/skills/<name>/SKILL.md`, with a generated per-tool copy;
 read that path directly if your tool cannot load a skill by name.
 
-One `create-a-pr` rule must survive not loading it: keep the PR template's
-provenance section and tick its box when an agent produced the diff. An agent
-commits under a human's credentials, so nothing else tells the two apart and a
-clear or missing box asserts a human wrote it. A bot turns a checked box into
-`agent-authored` and derives the type label from the title, so never apply labels
-yourself.
+Without `create-a-pr`: keep and tick provenance for agent work (clear or missing
+asserts human); never apply PR labels. Existing PR body edits must merge,
+preserve `<!-- CURSOR_SUMMARY -->` through `<!-- /CURSOR_SUMMARY -->`
+byte-for-byte, refetch before writing, and verify after.
 
 ## Your React instincts are the main failure mode here
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -267,6 +267,13 @@ label check successful. Agents must therefore keep and tick the section;
 `gh pr create --fill` drops the template and would make an agent-produced diff
 look human-authored, so use `--body-file` instead.
 
+When an agent updates an existing pull request body, it must merge its changes
+into the current body rather than replace it from a template. Bot-managed
+regions are opaque and must be preserved byte-for-byte, including Cursor
+Bugbot's `<!-- CURSOR_SUMMARY -->` through `<!-- /CURSOR_SUMMARY -->` block.
+The agent refetches immediately before the edit and verifies the body afterward
+so a concurrent bot update is not silently lost.
+
 The repository ships its own agent context: `AGENTS.md` (and its per-tool
 siblings) plus task skills for branching, issues, bug hunting, core changes,
 performance audits, and binding ports. Point your agent at those rather than

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -57,12 +57,10 @@ trigger first arises, even if it is a later step you chose:
 Each skill is `.rulesync/skills/<name>/SKILL.md`, with a generated per-tool copy;
 read that path directly if your tool cannot load a skill by name.
 
-One `create-a-pr` rule must survive not loading it: keep the PR template's
-provenance section and tick its box when an agent produced the diff. An agent
-commits under a human's credentials, so nothing else tells the two apart and a
-clear or missing box asserts a human wrote it. A bot turns a checked box into
-`agent-authored` and derives the type label from the title, so never apply labels
-yourself.
+Without `create-a-pr`: keep and tick provenance for agent work (clear or missing
+asserts human); never apply PR labels. Existing PR body edits must merge,
+preserve `<!-- CURSOR_SUMMARY -->` through `<!-- /CURSOR_SUMMARY -->`
+byte-for-byte, refetch before writing, and verify after.
 
 ## Your React instincts are the main failure mode here
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -125,6 +125,12 @@ Typecheck any program containing `.tsrx` with `tsrx-tsc --noEmit`, never plain
 `tsc`. Octane-owned `.tsx` files carry a leading `/** @jsxImportSource octane */`
 pragma. Use `OctaneNode` for renderables, never `React.ReactNode`.
 
+## Published packages
+
+Ship every importable `.tsrx`, `.tsx`, `.ts`, and `.js` module as authored and
+point package exports at that source. Never publish Octane compiler output; the
+consuming application compiles the source with its own toolchain.
+
 ## Working here
 
 ```bash

--- a/packages/octane-mcp-server/skills/build-octane-software.md
+++ b/packages/octane-mcp-server/skills/build-octane-software.md
@@ -34,6 +34,9 @@ details but do not replace these gates.
   hydration with production-compiled output and preserve abort/error behavior.
 - Treat bundle size and dependency cost as performance. Check for an official
   binding before adding a compatibility layer or a second framework runtime.
+- Publish every importable `.tsrx`, `.tsx`, `.ts`, and `.js` module as authored
+  and point package exports at that source. Do not ship Octane compiler output;
+  let the consuming application compile the source with its own toolchain.
 - When you do port a React package yourself, work from a pinned copy of that
   release's source kept beside your port, cover its exports rather than the demo
   path, and write down what parity could not reach. The `bridge-react-package`

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -16,6 +16,11 @@ const createPrSkill = readFileSync(
 	path.join(REPO, '.rulesync/skills/create-a-pr/SKILL.md'),
 	'utf8',
 );
+const projectRule = readFileSync(path.join(REPO, '.rulesync/rules/project.md'), 'utf8');
+const pullRequestTemplate = readFileSync(
+	path.join(REPO, '.github/pull_request_template.md'),
+	'utf8',
+);
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
 
 function jobSource(job) {
@@ -260,9 +265,14 @@ describe('Agent pull request body policy', () => {
 	test('preserves bot-managed summaries when updating an existing pull request', () => {
 		assert.match(createPrSkill, /fetch its current body with `gh pr view`/);
 		assert.match(createPrSkill, /preserve them\s+byte-for-byte/);
-		assert.match(createPrSkill, /<!-- CURSOR_SUMMARY -->/);
-		assert.match(createPrSkill, /<!-- \/CURSOR_SUMMARY -->/);
 		assert.match(createPrSkill, /After `gh pr edit`, fetch it again and verify/);
+
+		for (const source of [createPrSkill, projectRule]) {
+			assert.match(source, /<!-- CURSOR_SUMMARY -->/);
+			assert.match(source, /<!-- \/CURSOR_SUMMARY -->/);
+		}
+		assert.match(pullRequestTemplate, /Preserve every bot-managed HTML comment region/);
+		assert.match(pullRequestTemplate, /never replace the body from a fresh template/);
 	});
 });
 
@@ -485,13 +495,12 @@ describe('Pull request labels', () => {
 	});
 
 	test('reads the checked-in template as a declaration either way', async () => {
-		const template = readFileSync(path.join(REPO, '.github/pull_request_template.md'), 'utf8');
-		assert.ok(template.includes(EMPTY), 'the template must carry the provenance box');
+		assert.ok(pullRequestTemplate.includes(EMPTY), 'the template must carry the provenance box');
 
-		const human = await runLabeller({ title: 'fix: a thing', body: template });
+		const human = await runLabeller({ title: 'fix: a thing', body: pullRequestTemplate });
 		const agent = await runLabeller({
 			title: 'fix: a thing',
-			body: template.replace(EMPTY, TICKED),
+			body: pullRequestTemplate.replace(EMPTY, TICKED),
 		});
 
 		assert.deepEqual(human.added, ['fix']);

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -12,6 +12,10 @@ const draftWorkflow = readFileSync(
 	'utf8',
 );
 const labelWorkflow = readFileSync(path.join(REPO, '.github/workflows/label-pr.yml'), 'utf8');
+const createPrSkill = readFileSync(
+	path.join(REPO, '.rulesync/skills/create-a-pr/SKILL.md'),
+	'utf8',
+);
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
 
 function jobSource(job) {
@@ -249,6 +253,16 @@ describe('Agent pull request draft policy', () => {
 			draftWorkflow,
 			/github-token: \$\{\{ secrets\.DRAFT_PR_TOKEN \|\| secrets\.GITHUB_TOKEN \}\}/,
 		);
+	});
+});
+
+describe('Agent pull request body policy', () => {
+	test('preserves bot-managed summaries when updating an existing pull request', () => {
+		assert.match(createPrSkill, /fetch its current body with `gh pr view`/);
+		assert.match(createPrSkill, /preserve them\s+byte-for-byte/);
+		assert.match(createPrSkill, /<!-- CURSOR_SUMMARY -->/);
+		assert.match(createPrSkill, /<!-- \/CURSOR_SUMMARY -->/);
+		assert.match(createPrSkill, /After `gh pr edit`, fetch it again and verify/);
 	});
 });
 

--- a/scripts/classify-ci-change.mjs
+++ b/scripts/classify-ci-change.mjs
@@ -16,7 +16,9 @@ const LIGHTWEIGHT_PATHS = [
 	/^\.rulesync\//,
 	/^\.vscode\//,
 	/^\.github\//,
+	/^packages\/octane-mcp-server\/skills\/[^/]+\.md$/,
 	/^scripts\/(?:classify-ci-change(?:\.test)?|ci-workflow\.test|file-selection|format-files(?:\.test)?|typecheck-files(?:\.test)?)\.mjs$/,
+	/^website\/public\/llms\.txt$/,
 	/^(?:AGENTS|CLAUDE|GEMINI)\.md$/,
 	/^(?:CODE_OF_CONDUCT|CONTRIBUTING|LICENSE|README|SECURITY)(?:\.md)?$/,
 ];

--- a/scripts/classify-ci-change.test.mjs
+++ b/scripts/classify-ci-change.test.mjs
@@ -23,6 +23,13 @@ describe('classifyCiChange', () => {
 		assert.equal(classify(['docs/ssr.md', '.changeset/friendly-dogs.md']), false);
 		assert.equal(classify(['AGENTS.md', '.rulesync/rules/root.md']), false);
 		assert.equal(classify(['benchmarks/baselines/local/dbmon.json']), false);
+		assert.equal(
+			classify([
+				'packages/octane-mcp-server/skills/build-octane-software.md',
+				'website/public/llms.txt',
+			]),
+			false,
+		);
 	});
 
 	test('runs full CI when any executable file changes', () => {

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -51,6 +51,7 @@ An uncontrolled field that intentionally saves only when the browser commits the
 - [Profiling](https://octanejs.dev/docs/profiling): Enable `profile: true` with Vite, Rspack, or Rsbuild to inspect component render/DOM time, self time, render counts, causes, bails, scheduling delay, and Chrome trace data.
 - [Core APIs](https://octanejs.dev/docs/core-apis): Roots, components, state and effect hooks, current-state getters, context, Suspense, deferred hydration and code splitting, transitions, actions, events, and SSR/static rendering.
 - [TSRX vs TSX/JSX](https://octanejs.dev/docs/tsrx-vs-tsx): When to author in `.tsrx` versus standard `.tsx`/`.jsx`, and what each dialect unlocks (compiled collections, template control flow, the `@{ … }` shorthand, text holes).
+- [Publishing libraries](https://octanejs.dev/docs/publishing-libraries): Ship the complete authored source graph, including `.tsrx`, `.tsx`, `.ts`, and `.js`, point package exports at that source, and let the consuming application compile it. Do not publish precompiled Octane output.
 - [Differences from React](https://octanejs.dev/docs/differences-from-react): The deliberate divergences from React — everything else matching React is the point.
 - [Bindings](https://octanejs.dev/docs/bindings): The `@octanejs/*` ports of the React ecosystem.
 - [Playground](https://octanejs.dev/playground): Write TSRX or TSX in the browser and see the compiled octane output and the live rendered result side by side.


### PR DESCRIPTION
## Summary

- Document that published Octane libraries ship authored source for the consuming toolchain to compile.
- Keep the known MCP skill and public `llms.txt` documentation surfaces on the lightweight CI path.

## Why

- The publishing contract needs to be consistent across maintainer guidance, MCP guidance, and the public LLM index.
- These prose-only changes do not benefit from Octane's expensive runtime, compatibility, browser, and package matrices.

## Changes

- Propagate the published-package guidance through RuleSync-generated agent instructions.
- Update the bundled `build-octane-software` skill and public `llms.txt` index.
- Narrowly classify `packages/octane-mcp-server/skills/*.md` and `website/public/llms.txt` as lightweight.
- Add regression coverage for the documentation paths changed by this PR.

## Validation

- [ ] `pnpm format:check` (not run; targeted formatting check passed)
- [ ] `pnpm typecheck` (not run; no TypeScript or API changes)
- [ ] `pnpm test` (not run; targeted CI workflow tests passed)
- [x] `pnpm ci:workflow:test`
- [x] `pnpm format:files:check scripts/classify-ci-change.mjs scripts/classify-ci-change.test.mjs`
- [x] `pnpm sync`
- [x] PR base/head scope reproduction returns `full_ci=false`

## Risk / follow-ups

- Low risk. The exemptions are limited to Markdown files in the bundled MCP skill directory and the exact public `llms.txt` path; executable package and website files still require full CI.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, CI classification, and agent workflow text only; lightweight CI exemptions are narrow Markdown paths with regression tests.
> 
> **Overview**
> Documents that **published Octane libraries ship authored source** (`.tsrx`/`.tsx`/`.ts`/`.js`) for consumers to compile—**not** prebuilt Octane compiler output—across RuleSync-generated agent rules, the MCP `build-octane-software` skill, and `website/public/llms.txt` (with a link to the publishing-libraries doc).
> 
> **CI scope:** `scripts/classify-ci-change.mjs` treats `packages/octane-mcp-server/skills/*.md` and `website/public/llms.txt` as lightweight so prose-only updates there skip the full matrix; tests lock that in.
> 
> **Agent PR hygiene:** `create-a-pr` skills and `CONTRIBUTING.md` now require merging into an existing PR body via `gh pr view`, preserving bot regions (especially `<!-- CURSOR_SUMMARY -->`) byte-for-byte, with refetch/verify around `gh pr edit`; `ci-workflow.test.mjs` asserts those strings in the canonical skill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7274da048a1912058bda63ac7c08e82c823e63ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->