### PR TITLE
docs: framework integrations docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ Octane itself. Good places to start:
   own Octane runtime.
 - [Bindings](https://octanejs.dev/docs/bindings): the `@octanejs/*` ports of the
   React ecosystem.
+- [Framework integrations](https://octanejs.dev/docs/framework-integrations):
+  use Octane with Astro, Docusaurus, or TanStack Start.
 
 In this repository:
 

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -6,7 +6,7 @@ This inventory is derived from the manifests directly under `packages/`.
 Repository tooling imports the same discovery helper, so adding, renaming, or
 privatizing a package updates every package-wide check together.
 
-**66 publishable package(s), including 52 framework binding(s).**
+**66 publishable package(s), including 52 framework binding(s) and 3 framework integration(s).**
 
 All publishable packages share the enforced Node.js engine baseline `>=22`.
 
@@ -17,14 +17,14 @@ All publishable packages share the enforced Node.js engine baseline `>=22`.
 | `@octanejs/apollo-client` | [`packages/apollo-client`](../packages/apollo-client) | framework binding | `0.1.17` | 6 |
 | `@octanejs/app-core` | [`packages/app-core`](../packages/app-core) | metaframework core | `0.0.18` | 9 |
 | `@octanejs/aria` | [`packages/aria`](../packages/aria) | framework binding | `0.0.16` | 3 |
-| `@octanejs/astro` | [`packages/astro`](../packages/astro) | compiler integration | `0.0.1` | 5 |
+| `@octanejs/astro` | [`packages/astro`](../packages/astro) | framework integration | `0.0.1` | 5 |
 | `@octanejs/base-ui` | [`packages/base-ui`](../packages/base-ui) | framework binding | `0.1.20` | 2 |
 | `@octanejs/cli` | [`packages/cli`](../packages/cli) | developer tooling | `0.0.2` | 2 |
 | `@octanejs/cmdk` | [`packages/cmdk`](../packages/cmdk) | framework binding | `0.1.5` | 1 |
 | `@octanejs/devtools` | [`packages/devtools`](../packages/devtools) | framework binding | `0.0.10` | 1 |
 | `@octanejs/dexie` | [`packages/dexie`](../packages/dexie) | framework binding | `0.1.15` | 1 |
 | `@octanejs/dnd-kit` | [`packages/dnd-kit`](../packages/dnd-kit) | framework binding | `0.1.17` | 4 |
-| `@octanejs/docusaurus` | [`packages/docusaurus`](../packages/docusaurus) | metaframework | `0.0.6` | 8 |
+| `@octanejs/docusaurus` | [`packages/docusaurus`](../packages/docusaurus) | framework integration | `0.0.6` | 8 |
 | `@octanejs/floating-ui` | [`packages/floating-ui`](../packages/floating-ui) | framework binding | `0.1.21` | 1 |
 | `@octanejs/hook-form` | [`packages/hook-form`](../packages/hook-form) | framework binding | `0.1.19` | 1 |
 | `@octanejs/i18next` | [`packages/i18next`](../packages/i18next) | framework binding | `0.1.17` | 3 |
@@ -62,7 +62,7 @@ All publishable packages share the enforced Node.js engine baseline `>=22`.
 | `@octanejs/tanstack-query` | [`packages/tanstack-query`](../packages/tanstack-query) | framework binding | `0.1.21` | 1 |
 | `@octanejs/tanstack-router` | [`packages/tanstack-router`](../packages/tanstack-router) | framework binding | `0.1.21` | 6 |
 | `@octanejs/tanstack-router-ssr-query` | [`packages/tanstack-router-ssr-query`](../packages/tanstack-router-ssr-query) | framework binding | `0.0.11` | 1 |
-| `@octanejs/tanstack-start` | [`packages/tanstack-start`](../packages/tanstack-start) | metaframework | `0.1.11` | 12 |
+| `@octanejs/tanstack-start` | [`packages/tanstack-start`](../packages/tanstack-start) | framework integration | `0.1.11` | 12 |
 | `@octanejs/tanstack-store` | [`packages/tanstack-store`](../packages/tanstack-store) | framework binding | `0.0.16` | 1 |
 | `@octanejs/tanstack-table` | [`packages/tanstack-table`](../packages/tanstack-table) | framework binding | `0.1.19` | 5 |
 | `@octanejs/tanstack-virtual` | [`packages/tanstack-virtual`](../packages/tanstack-virtual) | framework binding | `0.1.19` | 1 |

--- a/scripts/workspace-packages.mjs
+++ b/scripts/workspace-packages.mjs
@@ -5,21 +5,25 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 export const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 export const PACKAGES_ROOT = path.join(REPO_ROOT, 'packages');
 export const INVENTORY_PATH = path.join(REPO_ROOT, 'docs/packages.md');
+export const FRAMEWORK_INTEGRATIONS_PATH = path.join(
+	REPO_ROOT,
+	'website/src/content/framework-integrations.json',
+);
 
 const SPECIAL_ROLES = new Map([
 	['octane', 'core runtime + compiler'],
 	['@octanejs/app-core', 'metaframework core'],
-	// Docusaurus owns application routing/content orchestration. This package
-	// adopts that metaframework boundary rather than binding a React library API.
-	['@octanejs/docusaurus', 'metaframework'],
+	// Host frameworks own application routing/content orchestration. These
+	// packages adopt that boundary rather than binding a React library API.
+	['@octanejs/docusaurus', 'framework integration'],
 	['@octanejs/rspack-plugin', 'compiler integration'],
 	['@octanejs/rspeedy-plugin', 'native compiler integration'],
-	['@octanejs/astro', 'compiler integration'],
+	['@octanejs/astro', 'framework integration'],
 	['@octanejs/rsbuild-plugin', 'metaframework'],
 	['@octanejs/vite-plugin', 'metaframework'],
-	// TanStack Start is a metaframework integration rather than a library
+	// TanStack Start is a framework integration rather than a library
 	// binding, so it stays outside the binding status/catalog contract.
-	['@octanejs/tanstack-start', 'metaframework'],
+	['@octanejs/tanstack-start', 'framework integration'],
 	['@octanejs/mcp-server', 'agent tooling'],
 	// The CLI inspects and configures other people's projects, including ones
 	// that have no Octane installed yet, which is exactly what `octane init`
@@ -91,6 +95,62 @@ export function getPublishablePackages() {
 
 export function getBindingPackages() {
 	return getPublishablePackages().filter((pkg) => pkg.role === 'framework binding');
+}
+
+export function getFrameworkIntegrationPackages() {
+	return getPublishablePackages().filter((pkg) => pkg.role === 'framework integration');
+}
+
+export function validateFrameworkIntegrationCatalog(packages = getWorkspacePackages()) {
+	const errors = [];
+	let catalog;
+	try {
+		catalog = readJson(FRAMEWORK_INTEGRATIONS_PATH);
+	} catch (error) {
+		return [`website/src/content/framework-integrations.json is not valid JSON: ${error.message}`];
+	}
+
+	if (!Array.isArray(catalog)) {
+		return ['website/src/content/framework-integrations.json must be an array'];
+	}
+
+	const catalogPackages = new Set();
+	for (const [index, integration] of catalog.entries()) {
+		const label = `website/src/content/framework-integrations.json entry ${index + 1}`;
+		if (!integration || typeof integration !== 'object') {
+			errors.push(`${label} must be an object`);
+			continue;
+		}
+		for (const field of ['title', 'packageName', 'model', 'description']) {
+			if (typeof integration[field] !== 'string' || !integration[field].trim()) {
+				errors.push(`${label} needs a non-empty "${field}"`);
+			}
+		}
+		if (typeof integration.packageName !== 'string') continue;
+		if (catalogPackages.has(integration.packageName)) {
+			errors.push(`${label} lists ${integration.packageName} more than once`);
+		}
+		catalogPackages.add(integration.packageName);
+	}
+
+	const integrations = packages.filter(
+		(pkg) => !pkg.private && pkg.role === 'framework integration',
+	);
+	const integrationNames = new Set(integrations.map((pkg) => pkg.name));
+	for (const integration of integrations) {
+		if (!catalogPackages.has(integration.name)) {
+			errors.push(`website/src/content/framework-integrations.json is missing ${integration.name}`);
+		}
+	}
+	for (const packageName of catalogPackages) {
+		if (!integrationNames.has(packageName)) {
+			errors.push(
+				`website/src/content/framework-integrations.json lists unknown framework integration ${packageName}`,
+			);
+		}
+	}
+
+	return errors;
 }
 
 export function validateWorkspacePackages(packages = getWorkspacePackages()) {
@@ -198,6 +258,7 @@ function exportCount(manifest) {
 export function renderWorkspaceInventory(packages = getWorkspacePackages()) {
 	const publishable = packages.filter((pkg) => !pkg.private);
 	const bindings = publishable.filter((pkg) => pkg.role === 'framework binding');
+	const frameworkIntegrations = publishable.filter((pkg) => pkg.role === 'framework integration');
 	let md = `# Package inventory (generated)
 
 <!-- GENERATED FILE — do not edit. Regenerate with \`pnpm packages:inventory\`. -->
@@ -206,7 +267,7 @@ This inventory is derived from the manifests directly under \`packages/\`.
 Repository tooling imports the same discovery helper, so adding, renaming, or
 privatizing a package updates every package-wide check together.
 
-**${publishable.length} publishable package(s), including ${bindings.length} framework binding(s).**
+**${publishable.length} publishable package(s), including ${bindings.length} framework binding(s) and ${frameworkIntegrations.length} framework integration(s).**
 
 All publishable packages share the enforced Node.js engine baseline \`>=22\`.
 
@@ -231,7 +292,10 @@ All publishable packages share the enforced Node.js engine baseline \`>=22\`.
 
 function runCli() {
 	const packages = getWorkspacePackages();
-	const errors = validateWorkspacePackages(packages);
+	const errors = [
+		...validateWorkspacePackages(packages),
+		...validateFrameworkIntegrationCatalog(packages),
+	];
 	if (errors.length) {
 		console.error(`package inventory is invalid:\n  - ${errors.join('\n  - ')}`);
 		process.exit(1);

--- a/website/public/sitemap.xml
+++ b/website/public/sitemap.xml
@@ -4,6 +4,7 @@
 	<url><loc>https://octanejs.dev/docs</loc></url>
 	<url><loc>https://octanejs.dev/docs/quick-start</loc></url>
 	<url><loc>https://octanejs.dev/docs/build-tools</loc></url>
+	<url><loc>https://octanejs.dev/docs/framework-integrations</loc></url>
 	<url><loc>https://octanejs.dev/docs/cli</loc></url>
 	<url><loc>https://octanejs.dev/docs/core-apis</loc></url>
 	<url><loc>https://octanejs.dev/docs/tsrx-vs-tsx</loc></url>

--- a/website/src/components/FrameworkIntegrationsDirectory.tsrx
+++ b/website/src/components/FrameworkIntegrationsDirectory.tsrx
@@ -1,0 +1,95 @@
+import {
+	FRAMEWORK_INTEGRATIONS,
+	frameworkIntegrationRepositoryHref,
+} from '../content/framework-integrations.ts';
+
+export function FrameworkIntegrationsDirectory() @{
+	<div class="framework-integration-directory">
+		@for (const integration of FRAMEWORK_INTEGRATIONS; key integration.packageName) {
+			<article class="framework-integration-card">
+				<header>
+					<span class="framework-integration-model">{integration.model as string}</span>
+					<h3>{integration.title as string}</h3>
+				</header>
+				<p>{integration.description as string}</p>
+				<a
+					class="framework-integration-link"
+					href={frameworkIntegrationRepositoryHref(integration.packageName)}
+				>
+					<code>{integration.packageName as string}</code>
+				</a>
+			</article>
+		}
+
+		<style>
+			.framework-integration-directory {
+				display: grid;
+				grid-template-columns: repeat(3, minmax(0, 1fr));
+				gap: 0.85rem;
+				margin: 1.5rem 0;
+			}
+			.framework-integration-card {
+				display: flex;
+				flex-direction: column;
+				align-items: flex-start;
+				padding: 1.1rem;
+				border: 1px solid var(--border);
+				border-radius: 0.9rem;
+				background: var(--surface-subtle);
+			}
+			.framework-integration-model {
+				display: inline-flex;
+				padding: 0.15rem 0.45rem;
+				border: 1px solid rgba(255, 93, 114, 0.24);
+				border-radius: 999px;
+				background: rgba(255, 65, 90, 0.08);
+				color: var(--danger-text);
+				font-size: 0.7rem;
+				font-weight: 750;
+				letter-spacing: 0.02em;
+			}
+			.framework-integration-card h3 {
+				margin: 0.65rem 0 0;
+				font-size: 1.05rem;
+			}
+			.framework-integration-card p {
+				flex: 1;
+				margin: 0.65rem 0 0.9rem;
+				color: var(--text-secondary);
+				font-size: 0.84rem;
+				line-height: 1.5;
+			}
+			.framework-integration-link {
+				display: inline-flex;
+				max-width: 100%;
+				border: 1px solid var(--border);
+				border-radius: 0.5rem;
+				background: var(--code-bg);
+				text-decoration: none;
+				transition:
+					border-color 0.15s,
+					background 0.15s;
+			}
+			.framework-integration-link:hover {
+				border-color: rgba(255, 93, 114, 0.55);
+				background: rgba(255, 65, 90, 0.08);
+			}
+			.framework-integration-card .framework-integration-link code {
+				overflow: hidden;
+				max-width: 100%;
+				padding: 0.35rem 0.5rem;
+				border: 0;
+				background: transparent;
+				color: var(--accent-text);
+				font-size: 0.75rem;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+			}
+			@media (max-width: 850px) {
+				.framework-integration-directory {
+					grid-template-columns: 1fr;
+				}
+			}
+		</style>
+	</div>
+}

--- a/website/src/content/docs-meta.ts
+++ b/website/src/content/docs-meta.ts
@@ -3,8 +3,9 @@
 // compiled MDX component. docs.ts zips this with the MDX imports for the
 // site; the remote MCP server (mcp/) imports only this file plus the raw
 // .mdx sources, so it never pulls compiled components into its bundle.
-// Its import chain must stay MDX-free (bindings.ts is JSON-only).
+// Its import chain must stay MDX-free (the imported catalogs are JSON-backed).
 import { BINDING_CATEGORIES, BINDING_COUNT } from './bindings.ts';
+import { FRAMEWORK_INTEGRATIONS, FRAMEWORK_INTEGRATION_COUNT } from './framework-integrations.ts';
 
 export interface DocSection {
 	id: string;
@@ -51,6 +52,32 @@ export const docsMeta: DocMeta[] = [
 			{ id: 'full-app-configuration', title: 'Full app configuration' },
 			{ id: 'production-and-preview', title: 'Production and preview' },
 			{ id: 'renderer-targets', title: 'Renderer targets' },
+		],
+	},
+	{
+		slug: 'framework-integrations',
+		title: 'Framework integrations',
+		description: `Use Octane with ${FRAMEWORK_INTEGRATION_COUNT} first-party integrations for Astro, Docusaurus, and TanStack Start.`,
+		group: 'Start here',
+		searchTerms: FRAMEWORK_INTEGRATIONS.flatMap((integration) => [
+			integration.title,
+			integration.packageName,
+			integration.model,
+			integration.description,
+			...(integration.packageName === '@octanejs/tanstack-start'
+				? [
+						'@octanejs/tanstack-router',
+						'@octanejs/tanstack-query',
+						'@octanejs/tanstack-form',
+						'TanStack bindings',
+					]
+				: []),
+		]),
+		sections: [
+			{ id: 'choose-a-framework', title: 'Choose a framework' },
+			{ id: 'astro', title: 'Astro islands' },
+			{ id: 'docusaurus', title: 'Docusaurus content sites' },
+			{ id: 'tanstack-start', title: 'TanStack Start applications' },
 		],
 	},
 	{

--- a/website/src/content/docs.ts
+++ b/website/src/content/docs.ts
@@ -5,6 +5,7 @@
 // MCP server); this module zips it with the compiled components.
 import QuickStart from './docs/quick-start.mdx';
 import BuildTools from './docs/build-tools.mdx';
+import FrameworkIntegrations from './docs/framework-integrations.mdx';
 import Cli from './docs/cli.mdx';
 import CoreApis from './docs/core-apis.mdx';
 import TsrxVsTsx from './docs/tsrx-vs-tsx.mdx';
@@ -24,6 +25,7 @@ export interface DocEntry extends DocMeta {
 const components: Record<string, DocEntry['component']> = {
 	'quick-start': QuickStart,
 	'build-tools': BuildTools,
+	'framework-integrations': FrameworkIntegrations,
 	cli: Cli,
 	'core-apis': CoreApis,
 	'tsrx-vs-tsx': TsrxVsTsx,

--- a/website/src/content/docs/bindings.mdx
+++ b/website/src/content/docs/bindings.mdx
@@ -81,6 +81,10 @@ in CI.
 			' provide full-app routing, server rendering, hydration, and production builds. @octanejs/rspack-plugin is the lower-level compiler integration. The '
 		}
 		<a href="/docs/build-tools">Build tools guide</a>
-		{' compares all three; bindings are the library adapters you add afterwards.'}
+		{
+			' compares all three; bindings are the library adapters you add afterwards. Astro, Docusaurus, and TanStack Start live in the '
+		}
+		<a href="/docs/framework-integrations">Framework integrations guide</a>
+		{'.'}
 	</p>
 </aside>

--- a/website/src/content/docs/framework-integrations.mdx
+++ b/website/src/content/docs/framework-integrations.mdx
@@ -1,0 +1,130 @@
+---
+title: Framework integrations
+---
+
+import { FrameworkIntegrationsDirectory } from '../../components/FrameworkIntegrationsDirectory.tsrx';
+import { FRAMEWORK_INTEGRATION_COUNT } from '../framework-integrations.ts';
+import { PackageInstall } from '../../components/PackageInstall.tsrx';
+
+<div className="doc-hero">
+	<p className="doc-eyebrow">
+		{FRAMEWORK_INTEGRATION_COUNT + ' first-party framework integrations'}
+	</p>
+	<h1>Framework integrations</h1>
+	<p className="doc-lede">
+		{
+			'Use Octane where another framework owns the application shell. These integrations connect Octane rendering and compilation to the framework’s routes, content, server lifecycle, or islands model.'
+		}
+	</p>
+</div>
+
+<h2 id="choose-a-framework">Choose the framework boundary</h2>
+
+Framework integrations are different from both build tools and bindings. Vite, Rspack,
+and Rsbuild choose the compilation pipeline. A binding adapts a library’s React-facing
+hooks or components. A framework integration connects Octane to a host that owns more of
+the application.
+
+<FrameworkIntegrationsDirectory />
+
+<aside className="doc-callout note">
+	<p className="doc-callout-title">TanStack Start, not TanStack as a whole</p>
+	<p>
+		<code>TanStack Start</code>
+		{
+			' is the full-stack framework. Router, Query, Form, Store, Table, Virtual, AI, and the other TanStack packages remain library bindings. '
+		}
+		<a href="/docs/bindings#find-a-binding">Browse the TanStack bindings</a>
+		{'.'}
+	</p>
+</aside>
+
+<h2 id="astro">Astro islands</h2>
+
+Use `@octanejs/astro` when Astro owns pages, layouts, routing, and the HTML shell while
+Octane owns individual islands. The integration compiles `.tsrx` and explicitly owned
+`.tsx` files, server-renders island HTML, and hydrates through Astro’s `client:*`
+directives.
+
+<PackageInstall packages="octane @octanejs/astro" />
+
+```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+import octane from '@octanejs/astro';
+
+export default defineConfig({
+	integrations: [octane()],
+});
+```
+
+```astro
+---
+import { Counter } from '../components/Counter.tsrx';
+---
+
+<Counter client:load start={0} />
+```
+
+Astro’s client directives decide when the outer island hydrates. Octane’s own deferred
+hydration can still control work inside the island. See the
+[`@octanejs/astro` package guide](https://github.com/octanejs/octane/tree/main/packages/astro)
+for client-only islands, mixed JSX frameworks, ownership filters, and all integration
+options.
+
+<h2 id="docusaurus">Docusaurus content sites</h2>
+
+`@octanejs/docusaurus` adopts Docusaurus’s headless content boundary: configuration,
+plugins, routes, generated data, and MDX. It provides an Octane-native router, static
+rendering and hydration helpers, and an initial classic documentation theme.
+
+<PackageInstall packages="octane @octanejs/docusaurus @docusaurus/core@3.10.1" />
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite';
+import { octane } from 'octane/compiler/vite';
+import { docusaurus } from '@octanejs/docusaurus/vite';
+
+export default defineConfig({
+	plugins: [...docusaurus(), octane()],
+});
+```
+
+This integration is a technical preview. It does not run React-authored themes or
+swizzles unchanged, and a complete `start`/`build` CLI workflow is not yet part of its
+supported surface. Read the
+[`@octanejs/docusaurus` package guide](https://github.com/octanejs/octane/tree/main/packages/docusaurus)
+for the pinned Docusaurus version, theme setup, and current scope.
+
+<h2 id="tanstack-start">TanStack Start applications</h2>
+
+`@octanejs/tanstack-start` is the full-stack TanStack Start integration for Octane. It
+owns file-route generation, route splitting, server functions, streaming SSR, hydration,
+and the Vite development and production environments. This website runs on it.
+
+<PackageInstall packages="octane @octanejs/tanstack-start @octanejs/tanstack-router" dev="vite" />
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite';
+import { tanstackStart } from '@octanejs/tanstack-start/plugin/vite';
+
+export default defineConfig({
+	plugins: [tanstackStart()],
+});
+```
+
+Application code imports Start APIs from the framework integration and routing APIs from
+the router binding:
+
+```ts
+import { createServerFn } from '@octanejs/tanstack-start';
+import { createFileRoute } from '@octanejs/tanstack-router';
+```
+
+See the
+[`@octanejs/tanstack-start` package guide](https://github.com/octanejs/octane/tree/main/packages/tanstack-start)
+for the public client, server, RPC, hydration, and Vite entries. For Query, Form, Store,
+Table, Virtual, Router utilities, and other library APIs, use the
+[TanStack bindings in the bindings directory](/docs/bindings#find-a-binding).

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -145,6 +145,8 @@ better fit.
 <h2 id="next">Next</h2>
 
 - [Build tools](/docs/build-tools) — choose Vite, Rspack, or Rsbuild.
+- [Framework integrations](/docs/framework-integrations) — use Octane with Astro,
+  Docusaurus, or TanStack Start.
 - [Core APIs](/docs/core-apis) — roots, hooks, boundaries, actions, and SSR.
 - [Differences from React](/docs/differences-from-react) — the deliberate
   divergences (everything else matching React is the point).

--- a/website/src/content/framework-integrations.json
+++ b/website/src/content/framework-integrations.json
@@ -1,0 +1,20 @@
+[
+  {
+    "title": "Astro",
+    "packageName": "@octanejs/astro",
+    "model": "Islands renderer",
+    "description": "Render Octane components as Astro islands with server rendering, client directives, and mixed-framework source ownership."
+  },
+  {
+    "title": "Docusaurus",
+    "packageName": "@octanejs/docusaurus",
+    "model": "Content framework bridge",
+    "description": "Adopt Docusaurus content, routes, MDX, and plugin data with an Octane-native renderer and theme layer."
+  },
+  {
+    "title": "TanStack Start",
+    "packageName": "@octanejs/tanstack-start",
+    "model": "Full-stack framework",
+    "description": "Build file-routed Octane applications with server functions, streaming SSR, hydration, and Vite development and production builds."
+  }
+]

--- a/website/src/content/framework-integrations.ts
+++ b/website/src/content/framework-integrations.ts
@@ -1,0 +1,20 @@
+// The website's curated framework-integration inventory. The workspace package
+// check verifies that every package classified as a framework integration
+// appears exactly once here, keeping this directory and its count in sync.
+import frameworkIntegrations from './framework-integrations.json';
+
+export interface FrameworkIntegration {
+	title: string;
+	packageName: string;
+	model: string;
+	description: string;
+}
+
+export const FRAMEWORK_INTEGRATIONS = frameworkIntegrations satisfies FrameworkIntegration[];
+
+export const FRAMEWORK_INTEGRATION_COUNT = FRAMEWORK_INTEGRATIONS.length;
+
+export function frameworkIntegrationRepositoryHref(packageName: string): string {
+	const directory = packageName.slice('@octanejs/'.length);
+	return `https://github.com/octanejs/octane/tree/main/packages/${directory}`;
+}

--- a/website/tests/docs-search.test.ts
+++ b/website/tests/docs-search.test.ts
@@ -118,6 +118,14 @@ describe('docs search ranking', () => {
 		expect(snippets.join(' ')).toContain('@octanejs/dexie');
 	});
 
+	it('finds Astro in the framework integrations guide', async () => {
+		const index = await loadSearchIndex();
+		const [top] = searchDocs(index, '@octanejs/astro');
+
+		expect(top.slug).toBe('framework-integrations');
+		expect(top.id).toBe('astro');
+	});
+
 	it('requires every term to match, and ignores queries shorter than two characters', async () => {
 		const index = await loadSearchIndex();
 

--- a/website/tests/smoke.test.ts
+++ b/website/tests/smoke.test.ts
@@ -8,6 +8,11 @@ import { getRouter } from '../src/router.ts';
 import { docs, defaultDoc, docGroups } from '../src/content/docs.ts';
 import { BINDING_CATEGORIES, BINDING_COUNT } from '../src/content/bindings.ts';
 import {
+	FRAMEWORK_INTEGRATIONS,
+	FRAMEWORK_INTEGRATION_COUNT,
+	frameworkIntegrationRepositoryHref,
+} from '../src/content/framework-integrations.ts';
+import {
 	FRAMEWORK_CARDS,
 	HOME_SUMMARY,
 	OCTANE_CARDS,
@@ -360,6 +365,28 @@ describe('website routes', () => {
 			const link = packageLinks.find((candidate) => candidate.getAttribute('href') === href);
 			expect(link?.textContent).toBe(packageName);
 		}
+	});
+
+	it('/docs/framework-integrations links every first-party framework integration', async () => {
+		const { container } = await renderRoute('/docs/framework-integrations');
+		const packageLinks = Array.from(
+			container.querySelectorAll<HTMLAnchorElement>(
+				'.framework-integration-directory a[href*="/packages/"]',
+			),
+		);
+
+		expect(packageLinks).toHaveLength(FRAMEWORK_INTEGRATION_COUNT);
+		expect(container.querySelector('.doc-eyebrow')?.textContent).toBe(
+			`${FRAMEWORK_INTEGRATION_COUNT} first-party framework integrations`,
+		);
+		for (const integration of FRAMEWORK_INTEGRATIONS) {
+			const href = frameworkIntegrationRepositoryHref(integration.packageName);
+			const link = packageLinks.find((candidate) => candidate.getAttribute('href') === href);
+			expect(link?.textContent).toBe(integration.packageName);
+		}
+		expect(findLink(container, '/docs/bindings#find-a-binding')?.textContent).toContain(
+			'TanStack bindings',
+		);
 	});
 
 	it('an unknown route renders the root notFoundComponent inside the layout', async () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation, generated inventory, and website content only; no runtime or package API behavior changes.
> 
> **Overview**
> Introduces a **framework integration** category distinct from build tools and library bindings, and documents Astro, Docusaurus, and TanStack Start as first-party host-framework packages.
> 
> A new **`/docs/framework-integrations`** page (MDX + `FrameworkIntegrationsDirectory` card grid driven by `framework-integrations.json`) explains how each integration fits and links to package READMEs. The docs registry, sitemap, README, quick-start/bindings cross-links, and search metadata are updated so the guide is discoverable alongside build tools and bindings.
> 
> **Workspace tooling** reclassifies `@octanejs/astro`, `@octanejs/docusaurus`, and `@octanejs/tanstack-start` from metaframework/compiler roles to `framework integration`, extends the generated `docs/packages.md` summary, and **validates** that the JSON catalog stays in sync with those packages during `pnpm packages:inventory`. Smoke and docs-search tests cover the new route and `@octanejs/astro` lookup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bc350885a3aee05fa593b0bc2daf25990de4756. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->