### PR TITLE
fix(cli): reject arguments after a bare -- instead of dropping them

### DIFF
--- a/.changeset/cli-reject-dropped-args.md
+++ b/.changeset/cli-reject-dropped-args.md
@@ -1,0 +1,18 @@
+---
+'@octanejs/cli': patch
+---
+
+Reject arguments after a bare `--` instead of dropping them.
+
+No command reads the tokens after `--`, so every one of them was discarded in
+silence. That is reachable by an ordinary route: npm consumes the `--` itself
+and forwards what follows, so `npm create octane app -- --template spa` is the
+correct npm spelling, and the identical line under pnpm or yarn hands the `--`
+through to the CLI. The flags then vanished and the run failed reporting that
+`--template` was required, naming the one flag that was sitting in the caller's
+command line.
+
+Those tokens are now a usage error that names them and says which package
+managers need the `--`. A command that wants to read them declares
+`passthrough`, and a bare `--` with nothing after it discards nothing and stays
+valid.

--- a/packages/cli/src/kernel/command.js
+++ b/packages/cli/src/kernel/command.js
@@ -18,6 +18,9 @@
  * @property {CommandEntry[]} [subcommands]
  * @property {boolean} [requiresProject] refuse to run outside a package.json,
  *   for commands that write into one
+ * @property {boolean} [passthrough] read the tokens after a bare `--` as
+ *   `input.rest`. Without it they are a usage error rather than a silent drop,
+ *   on the same reasoning as an unknown flag
  * @property {(ctx: import('./context.js').Ctx, input: CommandInput) => Promise<CommandResult>} [run]
  */
 

--- a/packages/cli/src/kernel/main.js
+++ b/packages/cli/src/kernel/main.js
@@ -109,6 +109,20 @@ async function dispatch(argv, options) {
 		return EXIT.OK;
 	}
 
+	// A command that has not asked for `rest` would drop these on the floor. That
+	// is the same failure the parser refuses for an unknown flag, and it arrives
+	// here by an ordinary route: npm eats the `--` and forwards what follows, so
+	// `npm create octane app -- --template spa` is correct and the identical line
+	// under pnpm or yarn hands the `--` straight through. Dropped silently, the
+	// run then fails saying --template is required, naming the one flag that was
+	// in fact supplied.
+	if (parsed.rest.length > 0 && !module.passthrough) {
+		throw usageError(
+			`Unexpected arguments after --: ${parsed.rest.join(' ')}`,
+			'npm needs `--` to forward flags. pnpm and yarn forward them already, so drop it there.',
+		);
+	}
+
 	// Commands that write into a project need one to exist. Without this they
 	// fail deep inside an fs call with a raw ENOENT stack.
 	if (module.requiresProject && ctx.project().manifestPath === null) {

--- a/packages/cli/tests/cli.test.js
+++ b/packages/cli/tests/cli.test.js
@@ -94,6 +94,27 @@ describe('the CLI kernel', () => {
 		expect(result.stderr).toMatch(/Unknown command: banana/);
 	});
 
+	it('rejects tokens after a bare -- for a command that does not read them', async () => {
+		// npm consumes the `--` itself and forwards what follows, so
+		// `npm create octane app -- --template spa` is the correct npm spelling and
+		// the identical line hands the `--` straight through under pnpm and yarn.
+		// No command reads `rest`, so those flags used to be dropped in silence and
+		// the run then failed reporting --template missing, naming the very flag
+		// that was sitting in the caller's command line.
+		const result = await runCli(['create', 'app', '--', '--yes', '--template', 'spa']);
+
+		expect(result.exitCode).toBe(2);
+		expect(result.stderr).toMatch(/Unexpected arguments after --: --yes --template spa/);
+		expect(result.stderr).not.toMatch(/--template is required/);
+	});
+
+	it('leaves a trailing -- with nothing after it alone', async () => {
+		// The terminator on its own discards nothing, so it is not a usage error.
+		const result = await runCli(['doctor', '--help', '--']);
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain('--fix');
+	});
+
 	it('reports errors as JSON when --json is set, in either spelling', async () => {
 		for (const flag of ['--json', '--json=true']) {
 			const result = await runCli(['banana', flag]);


### PR DESCRIPTION
## Summary

Arguments after a bare `--` were dropped in silence. No command reads
`input.rest`, so every token after the terminator was discarded, for every
command. They are now a usage error that names them.

This is reachable by an ordinary route rather than a typo. npm consumes the `--`
itself and forwards only what follows, so the `--` is **required** under npm and
**wrong** under pnpm, which hands it straight through:

```
npm  create octane app -- --template spa   # correct
pnpm create octane app -- --template spa   # the same line, `--` reaches the CLI
```

Under pnpm those flags vanished and `create` then failed with:

```
--template is required when the CLI is not interactive.
```

naming the one flag that was sitting in the caller's command line. That is the
worst shape a diagnostic can take: it points at the argument that was supplied
and says nothing about the one that was not understood. Now:

```
Unexpected arguments after --: --yes --template spa
npm needs `--` to forward flags. pnpm and yarn forward them already, so drop it there.
```

Exit code is `USAGE` (2) before and after. What changed is that the message
names the discarded tokens and points at the real mistake.

## Changes

- `packages/cli/src/kernel/main.js` — the check, in `dispatch`. It sits after the
  help/version branches so `--help` still answers, and before `run`.
- `packages/cli/src/kernel/command.js` — a `passthrough` opt-in on
  `CommandModule`. A command that wants `rest` declares it and keeps the current
  behavior. `rest` is kept rather than deleted: a future `octane mcp -- <server
  args>` is the obvious consumer, and this leaves the plumbing intact and typed.
- `packages/cli/tests/cli.test.js` — two tests.

`parseArgs` is untouched. Splitting on `--` is the parser's job and
`tests/args.test.js:62` still covers it; the policy about what a command may
ignore belongs at dispatch.

This matches the reasoning already written into the parser for an unknown flag —
that a token silently reinterpreted is the worst failure mode for a command that
writes to a project.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 16044 passed, 1516 files
- [x] targeted tests: `vitest run --project cli --project create-octane`, 150 passed

Pre-fix failure confirmed rather than assumed: with the check disabled, the
regression test fails on the old misleading message
(`expected '--template is required when the CLI…'`). The oracle asserts both
that the discarded tokens are named and that `--template is required` is gone,
so a fix that only reworded the error would not pass it.

The second test (`doctor --help --`) guards the opposite direction: a bare `--`
discards nothing, so it must remain a success. It passes with and without the
fix, which is the point — it fails only on an over-correction that rejects every
`--`.

Also verified by hand against the real binary: the pnpm-shaped invocation now
exits 2 with the new message, and the correct pnpm form still scaffolds.

## Risk / follow-ups

- Behavior change for anyone currently passing `--` with trailing tokens. They
  were being ignored, so no working invocation breaks — a run that appeared to
  succeed with dropped flags now fails loudly, which is the intent.
- This makes the failure legible; it does not make the npm-style line work under
  pnpm. Honoring post-`--` tokens as flags was the alternative and I argue
  against it: it would quietly accept two spellings and make `--` meaningless if
  a command later wants real passthrough.
- Not addressed here: `create-octane@0.0.1` on npm is broken independently of
  this. It pins `@octanejs/cli@0.0.1`, which has no `create` command, so its bin
  calls `main(['create', …])` against a CLI that cannot dispatch it and exits 2
  with `Unknown command: create`. Anyone who ran `npm create octane` before
  `0.0.2` published has it pinned in their npx cache under the `create-octane@*`
  key and stays broken until they clear it or pass `@latest`. Worth a
  `npm deprecate` — maintainer call, not done here.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small dispatch-time behavior change: invocations that previously ignored trailing post-`--` args now fail loudly with usage code 2; no commands use `passthrough` yet.
> 
> **Overview**
> Tokens after a bare `--` used to be parsed into `input.rest` and **silently ignored** when no command consumed them—often surfacing later as misleading errors (e.g. “`--template` is required” after `pnpm create octane app -- --template spa`).
> 
> **Dispatch** now fails with **usage exit 2** when `parsed.rest` is non-empty and the command has not opted in via a new **`passthrough`** flag on `CommandModule`, listing the unexpected tokens and hinting that npm needs `--` to forward flags while pnpm/yarn should omit it. A lone `--` with nothing after it is unchanged.
> 
> Tests cover the rejected post-`--` case and that `doctor --help --` still succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a62cf59cbeb89664ba082ebfed97ff68be5f751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->