### PR TITLE
fix: unpublished and attached refs in suspend

### DIFF
--- a/.changeset/silent-suspended-refs.md
+++ b/.changeset/silent-suspended-refs.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Keep host refs unpublished while an initial Suspense primary is hidden, and avoid detaching replacement refs that never committed before a suspended update.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -18285,14 +18285,19 @@ function emitBindingMount(bind, elVar, bag) {
 			// shared across elements (ref={registerItem} on every @for row)
 			// releases ITS row's React-19 cleanup, not another row's.
 			// Both deferred operations retain the bound element. `_ref$` must be a LIVE
-			// cleanup read because updates re-point it; the attach queues this render's
-			// exact `_r` so Suspense can identify work that never committed.
+			// cleanup read because updates re-point it. Assigning both bag locals inside
+			// the queue call evaluates each mount value once while avoiding throwaway
+			// temporaries; Suspense still receives the exact ref/target pair.
 			return st(
 				b.block([
-					b.const('_r', bind.expr),
-					b.stmt(b.assignment('=', local(`_ref$${bind.id}`), b.id('_r'))),
-					b.stmt(b.assignment('=', local(`_el$${bind.id}`), el())),
-					b.stmt(b.call('_$queueRefAttach', b.id('__s'), b.id('_r'), el())),
+					b.stmt(
+						b.call(
+							'_$queueRefAttach',
+							b.id('__s'),
+							b.assignment('=', local(`_ref$${bind.id}`), bind.expr),
+							b.assignment('=', local(`_el$${bind.id}`), el()),
+						),
+					),
 					cleanupsPush(
 						b.arrow(
 							[],
@@ -18314,22 +18319,13 @@ function emitBindingMount(bind, elVar, bag) {
 			// the user's ref, and registers a single cleanup that detaches
 			// the ref + destroys the instance on unmount.
 			return st(
-				b.block([
-					b.const('_r', bind.expr),
-					b.stmt(
-						b.assignment(
-							'=',
-							local(`_fi$${bind.id}`),
-							b.call(
-								'_$mountFragmentRef',
-								b.id('__s'),
-								el(),
-								hostVarNode(bind.endElVar),
-								b.id('_r'),
-							),
-						),
+				b.stmt(
+					b.assignment(
+						'=',
+						local(`_fi$${bind.id}`),
+						b.call('_$mountFragmentRef', b.id('__s'), el(), hostVarNode(bind.endElVar), bind.expr),
 					),
-				]),
+				),
 			);
 		}
 	}

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -16713,12 +16713,10 @@ function planJsx(
 			ctx.runtimeNeeded.add('queueRefDetach'); // unmount-detach of a spread-supplied ref
 		}
 		if (b.kind === 'ref') {
-			ctx.runtimeNeeded.add('attachRef');
 			ctx.runtimeNeeded.add('queueRefAttach'); // deferred mount attach (commit-phase timing)
 			ctx.runtimeNeeded.add('queueRefDetach'); // deferred unmount detach (same phasing)
 		}
 		if (b.kind === 'fragmentRef') {
-			ctx.runtimeNeeded.add('attachRef');
 			ctx.runtimeNeeded.add('mountFragmentRef');
 			ctx.runtimeNeeded.add('queueRefAttach'); // deferred update re-attach
 			ctx.runtimeNeeded.add('queueRefDetach'); // deferred update/unmount detach
@@ -18286,20 +18284,15 @@ function emitBindingMount(bind, elVar, bag) {
 			// bound element rides along as the cleanup target, so a callback ref
 			// shared across elements (ref={registerItem} on every @for row)
 			// releases ITS row's React-19 cleanup, not another row's.
-			// Both deferred closures read through the captured `_b` (committed by the
-			// time attach/cleanup run); `_ref$` must be a LIVE read — updates re-point it.
+			// Both deferred operations retain the bound element. `_ref$` must be a LIVE
+			// cleanup read because updates re-point it; the attach queues this render's
+			// exact `_r` so Suspense can identify work that never committed.
 			return st(
 				b.block([
 					b.const('_r', bind.expr),
 					b.stmt(b.assignment('=', local(`_ref$${bind.id}`), b.id('_r'))),
 					b.stmt(b.assignment('=', local(`_el$${bind.id}`), el())),
-					b.stmt(
-						b.call(
-							'_$queueRefAttach',
-							b.id('__s'),
-							b.arrow([], b.call('_$attachRef', b.id('_r'), bagFieldNode(bag, `_el$${bind.id}`))),
-						),
-					),
+					b.stmt(b.call('_$queueRefAttach', b.id('__s'), b.id('_r'), el())),
 					cleanupsPush(
 						b.arrow(
 							[],
@@ -18596,13 +18589,7 @@ function emitBindingUpdate(bind, bag) {
 							),
 							b.if(
 								b.binary('!=', b.id('_r'), nullNode()),
-								b.stmt(
-									b.call(
-										'_$queueRefAttach',
-										b.id('__s'),
-										b.arrow([], b.call('_$attachRef', b.id('_r'), F('_el'))),
-									),
-								),
+								b.stmt(b.call('_$queueRefAttach', b.id('__s'), b.id('_r'), F('_el'))),
 								null,
 							),
 							b.stmt(b.assignment('=', F('_ref'), b.id('_r'))),
@@ -18635,13 +18622,7 @@ function emitBindingUpdate(bind, bag) {
 							),
 							b.if(
 								b.binary('!=', b.id('_r'), nullNode()),
-								b.stmt(
-									b.call(
-										'_$queueRefAttach',
-										b.id('__s'),
-										b.arrow([], b.call('_$attachRef', b.id('_r'), fi())),
-									),
-								),
+								b.stmt(b.call('_$queueRefAttach', b.id('__s'), b.id('_r'), fi())),
 								null,
 							),
 							b.stmt(b.assignment('=', cur(), b.id('_r'))),

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -2453,7 +2453,9 @@ const storeSyncQueue: StoreInst<any>[] = [];
 // callback refs see a connected node and ref.current is populated by the time a
 // layout effect runs — matching React's commit-phase ref attachment.
 interface RefAttach {
-	fn: () => void;
+	/** Exact queued ref; initial Fragment mounts use the live-ref trampoline below. */
+	ref: any;
+	el: Element | FragmentInstance;
 	/** Enqueue sequence (DFS pre-order) — see commitSeq / comparePostOrder. */
 	seq: number;
 	block: Block | null;
@@ -2466,6 +2468,13 @@ interface SuspenseRefEntry {
 	scope: Scope;
 }
 const refAttachQueue: RefAttach[] = [];
+// A Fragment can re-point its ref during a render-phase replay before the mount
+// commit drains. Preserve that existing live-read contract with a shared callback
+// trampoline. The common drain remains branch-free, and Fragment instances do not
+// allocate a getter closure.
+function attachLiveFragmentRef(instance: FragmentInstance): void {
+	attachRef(instance._currentRef, instance);
+}
 
 // Off-screen (WIP) effect capture. While a transition swaps in a NEW subtree that
 // may suspend, that subtree is rendered "off-screen" (its DOM kept out of the slot's
@@ -3261,9 +3270,10 @@ const LAYOUT_CASCADE_LIMIT = 50;
  * commit every detach drains before every attach — a ref hopping between
  * elements never ends null, whichever binding updates first.
  */
-export function queueRefAttach(scope: Scope, fn: () => void): void {
+export function queueRefAttach(scope: Scope, ref: any, el: Element | FragmentInstance): void {
 	(WIP_CAPTURE !== null ? WIP_CAPTURE.refs : refAttachQueue).push({
-		fn,
+		ref,
+		el,
 		seq: commitSeq++,
 		block: scope.block,
 	});
@@ -3373,7 +3383,7 @@ function drainRefAttaches(): void {
 		try {
 			REF_CALLBACK_DEPTH++;
 			try {
-				r.fn();
+				attachRef(r.ref, r.el);
 			} finally {
 				REF_CALLBACK_DEPTH--;
 			}
@@ -3396,21 +3406,44 @@ function blockSubtreeDisposed(block: Block | null): boolean {
 	return false;
 }
 
-function discardSubtreeRefAttachesFrom(queue: RefAttach[], root: Block): void {
+type UncommittedRefAttaches = Map<Element | FragmentInstance, Set<any>>;
+
+function discardSubtreeRefAttachesFrom(
+	queue: RefAttach[],
+	root: Block,
+	uncommitted: UncommittedRefAttaches,
+): void {
 	let write = 0;
 	for (let read = 0; read < queue.length; read++) {
 		const entry = queue[read];
 		const owner = entry.block;
-		if (owner === root || (owner !== null && blockIsAncestorOf(root, owner))) continue;
+		if (owner === root || (owner !== null && blockIsAncestorOf(root, owner))) {
+			let refs = uncommitted.get(entry.el);
+			if (refs === undefined) uncommitted.set(entry.el, (refs = new Set()));
+			refs.add(
+				entry.ref === attachLiveFragmentRef
+					? (entry.el as FragmentInstance)._currentRef
+					: entry.ref,
+			);
+			continue;
+		}
 		queue[write++] = entry;
 	}
 	queue.length = write;
 }
 
-/** Drop commit-phase attaches owned by a primary that has just become hidden. */
-function discardSubtreeRefAttaches(root: Block): void {
-	discardSubtreeRefAttachesFrom(refAttachQueue, root);
-	if (WIP_CAPTURE !== null) discardSubtreeRefAttachesFrom(WIP_CAPTURE.refs, root);
+/**
+ * Drop commit-phase attaches owned by a primary that has just become hidden and
+ * index their exact ref/target pairs. The hide walk uses this cold-path index to
+ * distinguish a ref that committed earlier from one that only reached the queue.
+ */
+function discardSubtreeRefAttaches(
+	root: Block,
+	uncommitted: UncommittedRefAttaches = new Map(),
+): UncommittedRefAttaches {
+	discardSubtreeRefAttachesFrom(refAttachQueue, root, uncommitted);
+	if (WIP_CAPTURE !== null) discardSubtreeRefAttachesFrom(WIP_CAPTURE.refs, root, uncommitted);
+	return uncommitted;
 }
 
 function commitEffects(): void {
@@ -10208,21 +10241,6 @@ function dangerouslySetInnerHTMLOwnsChild(parent: Node, value: unknown): boolean
 // keep the `ref(null)` detach contract.
 const refCleanups = new WeakMap<(el: any) => unknown, WeakMap<object, () => void>>();
 const refLastCleanupTarget = new WeakMap<(el: any) => unknown, object>();
-// `refCleanups` is also the commit witness for cleanup-return callbacks. Legacy
-// callbacks need the same per-target witness so Suspense does not manufacture
-// `ref(null)` when a later sibling suspends before their queued attach commits.
-// Weak keys and targets ensure the witness cannot retain application objects.
-const attachedLegacyRefTargets = new WeakMap<(el: any) => unknown, WeakSet<object>>();
-
-function isRefTargetAttached(ref: any, target: Element | FragmentInstance): boolean {
-	if (typeof ref === 'function') {
-		return (
-			refCleanups.get(ref)?.has(target) === true ||
-			attachedLegacyRefTargets.get(ref)?.has(target) === true
-		);
-	}
-	return ref !== null && typeof ref === 'object' && ref.current === target;
-}
 
 export function attachRef(
 	ref: any,
@@ -10242,7 +10260,6 @@ export function attachRef(
 				if (refLastCleanupTarget.get(ref) === target) refLastCleanupTarget.delete(ref);
 				cleanup();
 			} else {
-				if (target != null) attachedLegacyRefTargets.get(ref)?.delete(target);
 				ref(null);
 			}
 		} else {
@@ -10252,10 +10269,6 @@ export function attachRef(
 				if (perTarget === undefined) refCleanups.set(ref, (perTarget = new WeakMap()));
 				perTarget.set(el, cleanup as () => void);
 				refLastCleanupTarget.set(ref, el);
-			} else {
-				let targets = attachedLegacyRefTargets.get(ref);
-				if (targets === undefined) attachedLegacyRefTargets.set(ref, (targets = new WeakSet()));
-				targets.add(el);
 			}
 		}
 		return;
@@ -10266,16 +10279,6 @@ export function attachRef(
 	}
 	ref.current = el;
 }
-
-/** Detach only ref leaves whose commit-phase attach actually ran. */
-function detachAttachedRef(ref: any, target: Element | FragmentInstance): void {
-	if (Array.isArray(ref)) {
-		for (let i = 0; i < ref.length; i++) detachAttachedRef(ref[i], target);
-	} else if (isRefTargetAttached(ref, target)) {
-		attachRef(ref, null, target);
-	}
-}
-
 // ─────────────────────────────────────────────────────────────────────────────
 // Fragment refs (React canary `enableFragmentRefs` parity).
 //
@@ -10770,10 +10773,11 @@ export function mountFragmentRef(
 	fi._currentRef = ref;
 	// Defer the attach to commit (after DOM insertion, before layout effects) so
 	// the fragment's markers/children are connected when a callback ref fires —
-	// same React-19 timing as element refs. Read `_currentRef` (not the captured
-	// `ref`) so a ref the compiler re-points via the update path is honored, and
-	// so the detach cleanup always releases whatever ref is current on unmount.
-	queueRefAttach(scope, () => attachRef(fi._currentRef, fi));
+	// same React-19 timing as element refs. A render-phase replay may re-point the
+	// Fragment before this mount commit drains, so the shared trampoline resolves
+	// `_currentRef` at drain/cancellation time. The structured target still lets a
+	// Suspense hide distinguish this uncommitted attach from an older committed ref.
+	queueRefAttach(scope, attachLiveFragmentRef, fi);
 	(scope.cleanups ??= []).push(() => {
 		// Detach at commit, not inline (queueRefDetach) — unmount cleanups run
 		// mid-render, and a state-setter ref firing null synchronously can render
@@ -11764,7 +11768,7 @@ export function setSpread(
 			// across elements. Compiled callers pass their scope on BOTH mount and
 			// update so the attach lands at commit (connected node, ordered after
 			// all detaches); the scope-less inline fallback serves external callers.
-			if (mountScope) queueRefAttach(mountScope, () => attachRef(v, el));
+			if (mountScope) queueRefAttach(mountScope, v, el);
 			else attachRef(v, el);
 			continue;
 		}
@@ -15931,7 +15935,7 @@ export function positionalChildren(children: any[]): any[] {
 // setAttribute + `$$type` delegated-event slots + deferred ref attach).
 function applyDeoptProp(el: Element, name: string, v: any, ownerBlock: Block): void {
 	if (name === 'ref') {
-		if (v != null) queueRefAttach(ownerBlock, () => attachRef(v, el));
+		if (v != null) queueRefAttach(ownerBlock, v, el);
 	} else if (name === 'className' || name === 'class') {
 		setDeoptClass(el, v);
 	} else if (name === 'style') {
@@ -16157,7 +16161,7 @@ function applyHostProps(el: Element, props: any, scope: Scope, state: HostCompon
 				// regardless of which element's props apply first (React's
 				// mutation→layout phasing; see queueRefDetach).
 				if (state.ref != null) queueRefDetach(state.ref, el);
-				if (v != null) queueRefAttach(scope, () => attachRef(v, el));
+				if (v != null) queueRefAttach(scope, v, el);
 				state.ref = v;
 			}
 		} else if (name === 'className' || name === 'class') {
@@ -19733,8 +19737,10 @@ function hideTryContentAndMountPending(
 		const persistent = state.tryBlock;
 		// A ref mounted before the suspending sibling queued an attach but has not
 		// reached the commit phase. The fallback commit must discard that work;
-		// reveal will enumerate the primary's current manifests and attach them.
-		discardSubtreeRefAttaches(persistent);
+		// reveal will enumerate the primary's current manifests and attach them. The
+		// exact canceled pairs also tell the detach walk which current refs never
+		// committed, without retaining a witness for every callback ref in the app.
+		const uncommittedRefs = discardSubtreeRefAttaches(persistent);
 		deactivateScope(persistent, false);
 		// Effect cleanups are user code and may synchronously replace/unmount this
 		// root. Never continue a half-finished fallback commit into detached markers.
@@ -19745,16 +19751,20 @@ function hideTryContentAndMountPending(
 			state.detachedRefs = [];
 			// Nested boundaries may already have detached their hidden primary refs.
 			// Visit only each nested boundary's visible arm here so an outer hide
-			// cannot detach the preserved inner primary a second time. The attach
-			// witness checked by detachSubtreeRefs excludes refs that only reached the
-			// queue before this suspension; reveal attaches the current manifests.
-			detachSubtreeRefs(persistent, state.detachedRefs, true, false);
+			// cannot detach the preserved inner primary a second time. The canceled
+			// pair index excludes refs that only reached the queue before this
+			// suspension; reveal attaches the current manifests.
+			detachSubtreeRefs(persistent, state.detachedRefs, true, false, uncommittedRefs);
 		}
 		// Callback refs (and React-19 ref cleanups) are user code too. In particular,
 		// ref(null) may synchronously unmount an independent or owning root.
 		if (state.parentBlock.disposed || persistent.disposed || state.tryBlock !== persistent) {
 			return false;
 		}
+		// Ref callbacks can synchronously render. Any fresh attaches they queued for
+		// this still-hidden primary are uncommitted work too; do not publish them at
+		// the fallback commit.
+		discardSubtreeRefAttaches(persistent, uncommittedRefs);
 		persistent.inactive = true;
 	}
 	if (!mountPendingBody(state)) return false;
@@ -20192,7 +20202,7 @@ function queueCurrentHiddenRefs(state: TrySlot): void {
 	collectVisibleSubtreeRefs(state.tryBlock, refs);
 	for (let i = 0; i < refs.length; i++) {
 		const entry = refs[i];
-		queueRefAttach(entry.scope, () => attachRef(entry.ref, entry.el));
+		queueRefAttach(entry.scope, entry.ref, entry.el);
 	}
 }
 
@@ -22110,12 +22120,13 @@ function detachSubtreeRefs(
 	out: SuspenseRefEntry[],
 	shouldDetach: boolean = true,
 	includeHiddenTry: boolean = true,
+	uncommitted: UncommittedRefAttaches | null = null,
 ): void {
 	// A block managing a de-opt host subtree (deoptItemBody / pure-host items):
 	// every node the de-opt reconciler built carries its descriptor (DEOPT_DESC),
 	// whose props may hold a ref — walk the DOM subtree for them.
 	const deoptRoot = (scope as any).deoptNode as Node | null | undefined;
-	if (deoptRoot != null) detachDeoptTreeRefs(deoptRoot, out, shouldDetach, scope);
+	if (deoptRoot != null) detachDeoptTreeRefs(deoptRoot, out, shouldDetach, scope, uncommitted);
 	const rm = scope.refFields;
 	if (rm !== null) {
 		const bag = scope.slots[0];
@@ -22128,7 +22139,9 @@ function detachSubtreeRefs(
 					if (ref == null) continue;
 					const el = bag[rm[j + 2]];
 					out.push({ ref, el, scope });
-					if (shouldDetach) detachAttachedRef(ref, el);
+					if (shouldDetach && uncommitted?.get(el)?.has(ref) !== true) {
+						attachRef(ref, null, el);
+					}
 				} else if (kind === 's') {
 					// Spread binding: the committed spread object may carry a ref.
 					const ref = bag[rm[j + 1]]?.ref;
@@ -22136,14 +22149,18 @@ function detachSubtreeRefs(
 					const el = bag[rm[j + 2]];
 					if (el == null) continue;
 					out.push({ ref, el, scope });
-					if (shouldDetach) detachAttachedRef(ref, el);
+					if (shouldDetach && uncommitted?.get(el)?.has(ref) !== true) {
+						attachRef(ref, null, el);
+					}
 				} else {
 					// 'f' — <Fragment ref>: detach the FragmentInstance's current ref;
 					// reveal re-attaches the same instance.
 					const fi = bag[rm[j + 1]];
 					if (fi == null || fi._currentRef == null) continue;
 					out.push({ ref: fi._currentRef, el: fi, scope });
-					if (shouldDetach) detachAttachedRef(fi._currentRef, fi);
+					if (shouldDetach && uncommitted?.get(fi)?.has(fi._currentRef) !== true) {
+						attachRef(fi._currentRef, null, fi);
+					}
 				}
 			}
 		}
@@ -22155,16 +22172,18 @@ function detachSubtreeRefs(
 		// De-opt host element slot (value-position `<tag>` / motion-style): { el, anchor, ref }.
 		if (s.ref != null && s.anchor !== undefined && s.el instanceof Element) {
 			out.push({ ref: s.ref, el: s.el, scope });
-			if (shouldDetach) detachAttachedRef(s.ref, s.el);
+			if (shouldDetach && uncommitted?.get(s.el)?.has(s.ref) !== true) {
+				attachRef(s.ref, null, s.el);
+			}
 		}
 		// childSlot managing a pure-host de-opt node — same DEOPT_DESC walk.
 		if (s.__kind === 'childSlot' && s.hostNode != null) {
-			detachDeoptTreeRefs(s.hostNode, out, shouldDetach, scope);
+			detachDeoptTreeRefs(s.hostNode, out, shouldDetach, scope, uncommitted);
 		}
 	}
 	forEachSubtreeChild(
 		scope,
-		(child) => detachSubtreeRefs(child, out, shouldDetach, includeHiddenTry),
+		(child) => detachSubtreeRefs(child, out, shouldDetach, includeHiddenTry, uncommitted),
 		includeHiddenTry,
 	);
 }
@@ -22186,13 +22205,16 @@ function detachDeoptTreeRefs(
 	out: SuspenseRefEntry[] | null,
 	shouldDetach: boolean = true,
 	ownerScope?: Scope,
+	uncommitted: UncommittedRefAttaches | null = null,
 ): void {
 	const ref = getDeoptDesc(node)?.props?.ref;
 	if (ref != null) {
 		if (out !== null) {
 			// Suspense-hide: detach NOW (the caller re-attaches on reveal).
 			out.push({ ref, el: node as Element, scope: ownerScope! });
-			if (shouldDetach) detachAttachedRef(ref, node as Element);
+			if (shouldDetach && uncommitted?.get(node as Element)?.has(ref) !== true) {
+				attachRef(ref, null, node as Element);
+			}
 		} else {
 			// Teardown: DEFER the detach to commit (drainRefDetaches), before the
 			// mount attaches. Teardown runs mid-render (reconcile/unmount), and a
@@ -22215,7 +22237,7 @@ function detachDeoptTreeRefs(
 			c = nodeAfterPortalRange(c, rangeEnd);
 			continue;
 		}
-		detachDeoptTreeRefs(c, out, shouldDetach, ownerScope);
+		detachDeoptTreeRefs(c, out, shouldDetach, ownerScope, uncommitted);
 		c = c.nextSibling;
 	}
 }

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -3396,6 +3396,23 @@ function blockSubtreeDisposed(block: Block | null): boolean {
 	return false;
 }
 
+function discardSubtreeRefAttachesFrom(queue: RefAttach[], root: Block): void {
+	let write = 0;
+	for (let read = 0; read < queue.length; read++) {
+		const entry = queue[read];
+		const owner = entry.block;
+		if (owner === root || (owner !== null && blockIsAncestorOf(root, owner))) continue;
+		queue[write++] = entry;
+	}
+	queue.length = write;
+}
+
+/** Drop commit-phase attaches owned by a primary that has just become hidden. */
+function discardSubtreeRefAttaches(root: Block): void {
+	discardSubtreeRefAttachesFrom(refAttachQueue, root);
+	if (WIP_CAPTURE !== null) discardSubtreeRefAttachesFrom(WIP_CAPTURE.refs, root);
+}
+
 function commitEffects(): void {
 	// No-work fast path: every commit queue the drains below consume is empty —
 	// the common case for a hydration adoption or an effect-free app's flush.
@@ -10191,6 +10208,21 @@ function dangerouslySetInnerHTMLOwnsChild(parent: Node, value: unknown): boolean
 // keep the `ref(null)` detach contract.
 const refCleanups = new WeakMap<(el: any) => unknown, WeakMap<object, () => void>>();
 const refLastCleanupTarget = new WeakMap<(el: any) => unknown, object>();
+// `refCleanups` is also the commit witness for cleanup-return callbacks. Legacy
+// callbacks need the same per-target witness so Suspense does not manufacture
+// `ref(null)` when a later sibling suspends before their queued attach commits.
+// Weak keys and targets ensure the witness cannot retain application objects.
+const attachedLegacyRefTargets = new WeakMap<(el: any) => unknown, WeakSet<object>>();
+
+function isRefTargetAttached(ref: any, target: Element | FragmentInstance): boolean {
+	if (typeof ref === 'function') {
+		return (
+			refCleanups.get(ref)?.has(target) === true ||
+			attachedLegacyRefTargets.get(ref)?.has(target) === true
+		);
+	}
+	return ref !== null && typeof ref === 'object' && ref.current === target;
+}
 
 export function attachRef(
 	ref: any,
@@ -10210,6 +10242,7 @@ export function attachRef(
 				if (refLastCleanupTarget.get(ref) === target) refLastCleanupTarget.delete(ref);
 				cleanup();
 			} else {
+				if (target != null) attachedLegacyRefTargets.get(ref)?.delete(target);
 				ref(null);
 			}
 		} else {
@@ -10219,6 +10252,10 @@ export function attachRef(
 				if (perTarget === undefined) refCleanups.set(ref, (perTarget = new WeakMap()));
 				perTarget.set(el, cleanup as () => void);
 				refLastCleanupTarget.set(ref, el);
+			} else {
+				let targets = attachedLegacyRefTargets.get(ref);
+				if (targets === undefined) attachedLegacyRefTargets.set(ref, (targets = new WeakSet()));
+				targets.add(el);
 			}
 		}
 		return;
@@ -10228,6 +10265,15 @@ export function attachRef(
 		return;
 	}
 	ref.current = el;
+}
+
+/** Detach only ref leaves whose commit-phase attach actually ran. */
+function detachAttachedRef(ref: any, target: Element | FragmentInstance): void {
+	if (Array.isArray(ref)) {
+		for (let i = 0; i < ref.length; i++) detachAttachedRef(ref[i], target);
+	} else if (isRefTargetAttached(ref, target)) {
+		attachRef(ref, null, target);
+	}
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -19685,6 +19731,10 @@ function hideTryContentAndMountPending(
 	}
 	if (state.tryBlock) {
 		const persistent = state.tryBlock;
+		// A ref mounted before the suspending sibling queued an attach but has not
+		// reached the commit phase. The fallback commit must discard that work;
+		// reveal will enumerate the primary's current manifests and attach them.
+		discardSubtreeRefAttaches(persistent);
 		deactivateScope(persistent, false);
 		// Effect cleanups are user code and may synchronously replace/unmount this
 		// root. Never continue a half-finished fallback commit into detached markers.
@@ -19695,7 +19745,9 @@ function hideTryContentAndMountPending(
 			state.detachedRefs = [];
 			// Nested boundaries may already have detached their hidden primary refs.
 			// Visit only each nested boundary's visible arm here so an outer hide
-			// cannot detach the preserved inner primary a second time.
+			// cannot detach the preserved inner primary a second time. The attach
+			// witness checked by detachSubtreeRefs excludes refs that only reached the
+			// queue before this suspension; reveal attaches the current manifests.
 			detachSubtreeRefs(persistent, state.detachedRefs, true, false);
 		}
 		// Callback refs (and React-19 ref cleanups) are user code too. In particular,
@@ -22076,7 +22128,7 @@ function detachSubtreeRefs(
 					if (ref == null) continue;
 					const el = bag[rm[j + 2]];
 					out.push({ ref, el, scope });
-					if (shouldDetach) attachRef(ref, null, el);
+					if (shouldDetach) detachAttachedRef(ref, el);
 				} else if (kind === 's') {
 					// Spread binding: the committed spread object may carry a ref.
 					const ref = bag[rm[j + 1]]?.ref;
@@ -22084,14 +22136,14 @@ function detachSubtreeRefs(
 					const el = bag[rm[j + 2]];
 					if (el == null) continue;
 					out.push({ ref, el, scope });
-					if (shouldDetach) attachRef(ref, null, el);
+					if (shouldDetach) detachAttachedRef(ref, el);
 				} else {
 					// 'f' — <Fragment ref>: detach the FragmentInstance's current ref;
 					// reveal re-attaches the same instance.
 					const fi = bag[rm[j + 1]];
 					if (fi == null || fi._currentRef == null) continue;
 					out.push({ ref: fi._currentRef, el: fi, scope });
-					if (shouldDetach) attachRef(fi._currentRef, null, fi);
+					if (shouldDetach) detachAttachedRef(fi._currentRef, fi);
 				}
 			}
 		}
@@ -22103,7 +22155,7 @@ function detachSubtreeRefs(
 		// De-opt host element slot (value-position `<tag>` / motion-style): { el, anchor, ref }.
 		if (s.ref != null && s.anchor !== undefined && s.el instanceof Element) {
 			out.push({ ref: s.ref, el: s.el, scope });
-			if (shouldDetach) attachRef(s.ref, null, s.el);
+			if (shouldDetach) detachAttachedRef(s.ref, s.el);
 		}
 		// childSlot managing a pure-host de-opt node — same DEOPT_DESC walk.
 		if (s.__kind === 'childSlot' && s.hostNode != null) {
@@ -22140,7 +22192,7 @@ function detachDeoptTreeRefs(
 		if (out !== null) {
 			// Suspense-hide: detach NOW (the caller re-attaches on reveal).
 			out.push({ ref, el: node as Element, scope: ownerScope! });
-			if (shouldDetach) attachRef(ref, null, node as Element);
+			if (shouldDetach) detachAttachedRef(ref, node as Element);
 		} else {
 			// Teardown: DEFER the detach to commit (drainRefDetaches), before the
 			// mount attaches. Teardown runs mid-render (reconcile/unmount), and a

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -2391,9 +2391,8 @@ const effectEventQueue: PendingEffectEvent[] = [];
 // transaction below, so an aborted enclosing render drops them.
 const effectEventCommitActions: Array<() => void> = [];
 let passiveScheduled = false;
-// Monotonic enqueue counter — tags each PendingEffect AND deferred ref attach with its
-// DFS pre-order position so the commit drains them in React's post-order (see
-// PendingEffect.seq / comparePostOrder). Shared so refs and effects sequence consistently.
+// Monotonic enqueue counter — tags each PendingEffect with its DFS pre-order position
+// so the effect drains can reconstruct React's post-order (see comparePostOrder).
 let commitSeq = 0;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -2456,8 +2455,6 @@ interface RefAttach {
 	/** Exact queued ref; initial Fragment mounts use the live-ref trampoline below. */
 	ref: any;
 	el: Element | FragmentInstance;
-	/** Enqueue sequence (DFS pre-order) — see commitSeq / comparePostOrder. */
-	seq: number;
 	block: Block | null;
 }
 
@@ -3263,18 +3260,16 @@ const LAYOUT_CASCADE_LIMIT = 50;
  * Compiler-emitted on a host element's ref MOUNT. Defers the attach until commit
  * (drainRefAttaches) so the node is connected when a callback ref fires and
  * ref.current is set before layout effects run. Each entry records its owning
- * `block` plus an enqueue-order `seq`; drainRefAttaches sorts with
- * comparePostOrder (post-order via the parentBlock chain, seq as tiebreak) for
- * child-before-parent ordering, matching effect ordering. Ref identity UPDATES
- * queue here too (paired with a queueRefDetach of the old ref), so within one
- * commit every detach drains before every attach — a ref hopping between
- * elements never ends null, whichever binding updates first.
+ * `block`; drainRefAttaches preserves enqueue order for disjoint subtrees and
+ * only reorders ancestor/descendant pairs for child-before-parent ordering.
+ * Ref identity UPDATES queue here too (paired with a queueRefDetach of the old
+ * ref), so within one commit every detach drains before every attach — a ref
+ * hopping between elements never ends null, whichever binding updates first.
  */
 export function queueRefAttach(scope: Scope, ref: any, el: Element | FragmentInstance): void {
 	(WIP_CAPTURE !== null ? WIP_CAPTURE.refs : refAttachQueue).push({
 		ref,
 		el,
-		seq: commitSeq++,
 		block: scope.block,
 	});
 }
@@ -3371,8 +3366,9 @@ function drainRefDetaches(): void {
 function drainRefAttaches(): void {
 	if (refAttachQueue.length === 0) return;
 	const q = refAttachQueue.splice(0);
-	// Post-order, same as effects (refs attach child-first, siblings in tree order).
-	q.sort((a, b) => comparePostOrder(a.block, a.seq, b.block, b.seq));
+	// ES stable sort preserves the queue's DFS/source order for disjoint subtrees;
+	// comparePostOrder moves only descendants ahead of their queued ancestors.
+	q.sort((a, b) => comparePostOrder(a.block, 0, b.block, 0));
 	for (const r of q) {
 		// Skip attaches whose owning subtree was unmounted earlier in THIS flush
 		// (e.g. a try boundary caught a mount-time throw and ran unmountBlock +
@@ -3406,7 +3402,19 @@ function blockSubtreeDisposed(block: Block | null): boolean {
 	return false;
 }
 
-type UncommittedRefAttaches = Map<Element | FragmentInstance, Set<any>>;
+// A target has one effective ref binding; array refs remain one composite value.
+// If render-phase replays queue several identities for the same target, the last
+// canceled attach is the manifest's current ref and therefore the only one the
+// hide walk can attempt to detach.
+type UncommittedRefAttaches = Map<Element | FragmentInstance, any>;
+
+function refAttachWasDiscarded(
+	uncommitted: UncommittedRefAttaches | null,
+	el: Element | FragmentInstance,
+	ref: any,
+): boolean {
+	return uncommitted !== null && uncommitted.get(el) === ref;
+}
 
 function discardSubtreeRefAttachesFrom(
 	queue: RefAttach[],
@@ -3418,9 +3426,8 @@ function discardSubtreeRefAttachesFrom(
 		const entry = queue[read];
 		const owner = entry.block;
 		if (owner === root || (owner !== null && blockIsAncestorOf(root, owner))) {
-			let refs = uncommitted.get(entry.el);
-			if (refs === undefined) uncommitted.set(entry.el, (refs = new Set()));
-			refs.add(
+			uncommitted.set(
+				entry.el,
 				entry.ref === attachLiveFragmentRef
 					? (entry.el as FragmentInstance)._currentRef
 					: entry.ref,
@@ -3686,10 +3693,11 @@ function blockIsAncestorOf(anc: Block, node: Block): boolean {
 // and disjoint subtrees fire in tree order. We reconstruct that from the flat queues:
 // descendant-before-ancestor via the parentBlock chain; everything else (disjoint
 // subtrees, and multiple entries on the SAME block) falls back to enqueue order, which
-// IS tree order because rendering is top-down DFS pre-order. This is correct where a
-// plain depth sort was not — a shallow node in an earlier sibling subtree must fire
-// before a deeper node in a LATER sibling subtree, which depth alone gets backwards.
-// Shared by the effect queues AND the deferred ref-attach queue so both commit in order.
+// IS tree order because rendering is top-down DFS pre-order. Effects pass their explicit
+// sequence; refs pass equal sequence values and rely on ES stable sort to retain their
+// queue order. This is correct where a plain depth sort was not — a shallow node in an
+// earlier sibling subtree must fire before a deeper node in a LATER sibling subtree,
+// which depth alone gets backwards.
 function comparePostOrder(
 	aBlock: Block | null,
 	aSeq: number,
@@ -20384,15 +20392,13 @@ function compareStagedRevealDomOrder(a: TrySlot, b: TrySlot): number {
 	return 0;
 }
 
-/** Rebase speculative enqueue order onto final source/tree commit order. */
-function rebaseOffscreenCaptureSeq(capture: OffscreenCapture): void {
+/** Rebase speculative effect enqueue order onto final source/tree commit order. */
+function rebaseOffscreenEffectSeq(capture: OffscreenCapture): void {
 	const effects = capture.effects[INSERTION].concat(
 		capture.effects[LAYOUT],
 		capture.effects[PASSIVE],
 	).sort((a, b) => a.seq - b.seq);
 	for (let i = 0; i < effects.length; i++) effects[i].seq = commitSeq++;
-	const refs = capture.refs.slice().sort((a, b) => a.seq - b.seq);
-	for (let i = 0; i < refs.length; i++) refs[i].seq = commitSeq++;
 }
 
 function flushStagedReveals(): void {
@@ -20428,10 +20434,10 @@ function flushStagedReveals(): void {
 			const deferEffects = batch.every((state) => state.stagedCapture !== null);
 			if (deferEffects) {
 				// Promise resolution order is not source order. Commit left-to-right and
-				// rebase each capture's enqueue sequence so the shared effect/ref drain
-				// preserves sibling tree order even when the right boundary readies first.
+				// rebase each capture's effect sequence. Ref captures splice in this same
+				// sorted order and retain it through their stable post-order sort.
 				batch.sort(compareStagedRevealDomOrder);
-				for (const state of batch) rebaseOffscreenCaptureSeq(state.stagedCapture!);
+				for (const state of batch) rebaseOffscreenEffectSeq(state.stagedCapture!);
 			}
 			const previousDeferral = deferringStagedRevealEffects;
 			deferringStagedRevealEffects = deferEffects;
@@ -22139,7 +22145,7 @@ function detachSubtreeRefs(
 					if (ref == null) continue;
 					const el = bag[rm[j + 2]];
 					out.push({ ref, el, scope });
-					if (shouldDetach && uncommitted?.get(el)?.has(ref) !== true) {
+					if (shouldDetach && !refAttachWasDiscarded(uncommitted, el, ref)) {
 						attachRef(ref, null, el);
 					}
 				} else if (kind === 's') {
@@ -22149,7 +22155,7 @@ function detachSubtreeRefs(
 					const el = bag[rm[j + 2]];
 					if (el == null) continue;
 					out.push({ ref, el, scope });
-					if (shouldDetach && uncommitted?.get(el)?.has(ref) !== true) {
+					if (shouldDetach && !refAttachWasDiscarded(uncommitted, el, ref)) {
 						attachRef(ref, null, el);
 					}
 				} else {
@@ -22158,7 +22164,7 @@ function detachSubtreeRefs(
 					const fi = bag[rm[j + 1]];
 					if (fi == null || fi._currentRef == null) continue;
 					out.push({ ref: fi._currentRef, el: fi, scope });
-					if (shouldDetach && uncommitted?.get(fi)?.has(fi._currentRef) !== true) {
+					if (shouldDetach && !refAttachWasDiscarded(uncommitted, fi, fi._currentRef)) {
 						attachRef(fi._currentRef, null, fi);
 					}
 				}
@@ -22172,7 +22178,7 @@ function detachSubtreeRefs(
 		// De-opt host element slot (value-position `<tag>` / motion-style): { el, anchor, ref }.
 		if (s.ref != null && s.anchor !== undefined && s.el instanceof Element) {
 			out.push({ ref: s.ref, el: s.el, scope });
-			if (shouldDetach && uncommitted?.get(s.el)?.has(s.ref) !== true) {
+			if (shouldDetach && !refAttachWasDiscarded(uncommitted, s.el, s.ref)) {
 				attachRef(s.ref, null, s.el);
 			}
 		}
@@ -22212,7 +22218,7 @@ function detachDeoptTreeRefs(
 		if (out !== null) {
 			// Suspense-hide: detach NOW (the caller re-attaches on reveal).
 			out.push({ ref, el: node as Element, scope: ownerScope! });
-			if (shouldDetach && uncommitted?.get(node as Element)?.has(ref) !== true) {
+			if (shouldDetach && !refAttachWasDiscarded(uncommitted, node as Element, ref)) {
 				attachRef(ref, null, node as Element);
 			}
 		} else {

--- a/packages/octane/tests/_fixtures/suspense-ref-regressions.tsrx
+++ b/packages/octane/tests/_fixtures/suspense-ref-regressions.tsrx
@@ -1,13 +1,58 @@
 import { use } from 'octane';
 
-function RenderProbe(props) @{
+type ElementRef = (element: Element | null) => void;
+
+function RenderProbe(props: { value: string }) @{
 	<i class="render-probe" data-value={props.value}>{'probe'}</i>
+}
+
+function InitialRefChild(props: { innerRef: ElementRef }) @{
+	<li class="initial-ref-item" ref={props.innerRef}>{'ref item'}</li>
+}
+
+function InitialSuspendingChild(props: { promise: Promise<string> }) @{
+	const value = use(props.promise);
+	<li class="initial-resolved">{value as string}</li>
+}
+
+export function SuspendedInitialHostRef(props: {
+	innerRef: ElementRef;
+	promise: Promise<string>;
+}) @{
+	<ul>
+		@try {
+			<>
+				<InitialRefChild innerRef={props.innerRef} />
+				<InitialSuspendingChild promise={props.promise} />
+			</>
+		} @pending {
+			<li class="initial-fallback">{'loading'}</li>
+		}
+	</ul>
+}
+
+export function SuspendedHostRefUpdate(props: {
+	innerRef: ElementRef;
+	promise: Promise<string>;
+}) @{
+	@try {
+		<>
+			<li class="updated-ref-item" ref={props.innerRef}>{'ref item'}</li>
+			<InitialSuspendingChild promise={props.promise} />
+		</>
+	} @pending {
+		<li class="updated-ref-fallback">{'loading'}</li>
+	}
 }
 
 // A parent can replace a pending promise with an already-ready one. The hidden
 // primary reveals during that parent update, but its preserved refs still belong
 // to the commit phase after every later sibling has rendered.
-export function SupersededRefOrder(props) @{
+export function SupersededRefOrder(props: {
+	cbRef: ElementRef;
+	promise: Promise<string>;
+	sentinel: string;
+}) @{
 	<>
 		@try {
 			const value = use(props.promise);

--- a/packages/octane/tests/conformance/_fixtures/fragment-refs.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/fragment-refs.tsrx
@@ -1,8 +1,11 @@
-import { Fragment, useLayoutEffect, useEffect } from 'octane';
+import { Fragment, useLayoutEffect, useEffect, useState } from 'octane';
+
+type FragmentCallback = (instance: unknown) => void;
+type FragmentObject = { current: unknown };
 
 // Stage 1 — basic fragment ref attach. React parity: rendering
 // `<Fragment ref={r}>` populates `r.current` with a FragmentInstance.
-export function FragmentObjectRef(props) @{
+export function FragmentObjectRef(props: { fragRef: FragmentObject }) @{
 	<div id="parent">
 		<Fragment ref={props.fragRef}>
 			<div id="child">{'hi' as string}</div>
@@ -12,7 +15,7 @@ export function FragmentObjectRef(props) @{
 
 // Stage 1 — callback-ref shape: the user-supplied callback gets the
 // FragmentInstance directly (and `null` on unmount via attachRef).
-export function FragmentCallbackRef(props) @{
+export function FragmentCallbackRef(props: { cb: FragmentCallback }) @{
 	<div id="parent">
 		<Fragment ref={props.cb}>
 			<div id="child">{'hi' as string}</div>
@@ -20,10 +23,33 @@ export function FragmentCallbackRef(props) @{
 	</div>
 }
 
+export function FragmentChangingCallbackRef(props: { cb: FragmentCallback }) @{
+	<div id="changing-parent">
+		<Fragment ref={props.cb}>
+			<div id="changing-child">{'hi'}</div>
+		</Fragment>
+	</div>
+}
+
+export function FragmentRenderPhaseCallbackRef(props: {
+	first: FragmentCallback;
+	second: FragmentCallback;
+}) @{
+	const [useSecond, setUseSecond] = useState(false);
+	if (!useSecond) setUseSecond(true);
+	<Fragment ref={useSecond ? props.second : props.first}>
+		<div id="render-phase-child">{'hi'}</div>
+	</Fragment>
+}
+
 // Stage 1 — fragment ref must be populated by the time useLayoutEffect
 // AND useEffect run. Effects report what they saw via props callbacks
 // so the test can assert without leaning on module-level mutable state.
-export function FragmentEffectVisibility(props) @{
+export function FragmentEffectVisibility(props: {
+	fragRef: FragmentObject;
+	onLayout: FragmentCallback;
+	onPassive: FragmentCallback;
+}) @{
 	useLayoutEffect(() => {
 		props.onLayout(props.fragRef.current);
 	}, []);

--- a/packages/octane/tests/conformance/fragment-refs.test.ts
+++ b/packages/octane/tests/conformance/fragment-refs.test.ts
@@ -11,6 +11,8 @@ import { FragmentInstance } from '../../src/index.js';
 import {
 	FragmentObjectRef,
 	FragmentCallbackRef,
+	FragmentChangingCallbackRef,
+	FragmentRenderPhaseCallbackRef,
 	FragmentEffectVisibility,
 } from './_fixtures/fragment-refs.tsrx';
 
@@ -34,7 +36,8 @@ describe('Fragment refs — basic attach (React enableFragmentRefs parity)', () 
 	it('accepts a callback ref and fires it with the FragmentInstance', () => {
 		let captured: FragmentInstance | null | undefined;
 		const log: Array<FragmentInstance | null> = [];
-		const cb = (fi: FragmentInstance | null) => {
+		const cb = (value: unknown) => {
+			const fi = value as FragmentInstance | null;
 			captured = fi;
 			log.push(fi);
 		};
@@ -49,17 +52,60 @@ describe('Fragment refs — basic attach (React enableFragmentRefs parity)', () 
 		expect(log[log.length - 1]).toBeNull();
 	});
 
+	it('detaches a changed callback before attaching its replacement to the same instance', () => {
+		const log: string[] = [];
+		let firstInstance: FragmentInstance | null = null;
+		let secondInstance: FragmentInstance | null = null;
+		const first = (value: unknown) => {
+			const instance = value as FragmentInstance | null;
+			log.push(instance === null ? 'first:detach' : 'first:attach');
+			if (instance !== null) firstInstance = instance;
+		};
+		const second = (value: unknown) => {
+			const instance = value as FragmentInstance | null;
+			log.push(instance === null ? 'second:detach' : 'second:attach');
+			if (instance !== null) secondInstance = instance;
+		};
+		const r = mount(FragmentChangingCallbackRef, { cb: first });
+
+		r.update(FragmentChangingCallbackRef, { cb: second });
+		expect(log).toEqual(['first:attach', 'first:detach', 'second:attach']);
+		expect(secondInstance).toBe(firstInstance);
+
+		r.unmount();
+		expect(log).toEqual(['first:attach', 'first:detach', 'second:attach', 'second:detach']);
+	});
+
+	it('does not attach a Fragment ref discarded by a render-phase replay', () => {
+		const discardedAttachments: unknown[] = [];
+		const committedAttachments: unknown[] = [];
+		const r = mount(FragmentRenderPhaseCallbackRef, {
+			first: (value: unknown) => {
+				if (value !== null) discardedAttachments.push(value);
+			},
+			second: (value: unknown) => {
+				if (value !== null) committedAttachments.push(value);
+			},
+		});
+
+		expect(discardedAttachments).toEqual([]);
+		expect(committedAttachments.length).toBeGreaterThan(0);
+		expect(new Set(committedAttachments).size).toBe(1);
+		expect(committedAttachments[0]).toBeInstanceOf(FragmentInstance);
+		r.unmount();
+	});
+
 	it('is populated by the time useLayoutEffect AND useEffect run', () => {
 		const fragRef: { current: FragmentInstance | null } = { current: null };
 		let layoutSeen: FragmentInstance | null | undefined;
 		let passiveSeen: FragmentInstance | null | undefined;
 		const r = mount(FragmentEffectVisibility, {
 			fragRef,
-			onLayout: (v: FragmentInstance | null) => {
-				layoutSeen = v;
+			onLayout: (value: unknown) => {
+				layoutSeen = value as FragmentInstance | null;
 			},
-			onPassive: (v: FragmentInstance | null) => {
-				passiveSeen = v;
+			onPassive: (value: unknown) => {
+				passiveSeen = value as FragmentInstance | null;
 			},
 		});
 		// useLayoutEffect is sync at commit, so layoutSeen is already populated.

--- a/packages/octane/tests/suspense-ref-regressions.test.ts
+++ b/packages/octane/tests/suspense-ref-regressions.test.ts
@@ -42,6 +42,30 @@ it('does not publish a host ref from a suspended initial mount', async () => {
 	r.unmount();
 });
 
+it('keeps every member of an array ref unpublished until a suspended mount reveals', async () => {
+	const pending = deferred<string>();
+	const calls: string[] = [];
+	const first = (element: Element | null) => {
+		calls.push(`first:${element ? 'attach' : 'detach'}`);
+	};
+	const second = (element: Element | null) => {
+		calls.push(`second:${element ? 'attach' : 'detach'}`);
+	};
+	const r = mount(SuspendedInitialHostRef as any, {
+		innerRef: [first, second],
+		promise: pending.promise,
+	});
+
+	expect(r.find('.initial-fallback').textContent).toBe('loading');
+	expect(calls).toEqual([]);
+
+	await act(() => pending.resolve('ready'));
+	expect(calls).toEqual(['first:attach', 'second:attach']);
+
+	r.unmount();
+	expect(calls).toEqual(['first:attach', 'second:attach', 'first:detach', 'second:detach']);
+});
+
 it('does not detach a replacement ref from a suspended update before it attaches', async () => {
 	const pending = deferred<string>();
 	const calls: string[] = [];

--- a/packages/octane/tests/suspense-ref-regressions.test.ts
+++ b/packages/octane/tests/suspense-ref-regressions.test.ts
@@ -1,6 +1,10 @@
 import { expect, it } from 'vitest';
-import { mount } from './_helpers';
-import { SupersededRefOrder } from './_fixtures/suspense-ref-regressions.tsrx';
+import { act, mount } from './_helpers';
+import {
+	SuspendedHostRefUpdate,
+	SuspendedInitialHostRef,
+	SupersededRefOrder,
+} from './_fixtures/suspense-ref-regressions.tsrx';
 
 function deferred<T>() {
 	let resolve!: (value: T) => void;
@@ -18,6 +22,53 @@ function fulfilled(value: string) {
 	return promise;
 }
 
+it('does not publish a host ref from a suspended initial mount', async () => {
+	const pending = deferred<string>();
+	const calls: Array<Element | null> = [];
+	const r = mount(SuspendedInitialHostRef, {
+		innerRef: (element: Element | null) => {
+			calls.push(element);
+		},
+		promise: pending.promise,
+	});
+
+	expect(r.find('.initial-fallback').textContent).toBe('loading');
+	expect(calls).toEqual([]);
+
+	await act(() => pending.resolve('ready'));
+	const resolvedRef = r.find('.initial-ref-item');
+	expect(r.find('.initial-resolved').textContent).toBe('ready');
+	expect(calls).toEqual([resolvedRef]);
+	r.unmount();
+});
+
+it('does not detach a replacement ref from a suspended update before it attaches', async () => {
+	const pending = deferred<string>();
+	const calls: string[] = [];
+	const firstRef = (element: Element | null) => {
+		calls.push(`first:${element ? 'attach' : 'detach'}`);
+	};
+	const secondRef = (element: Element | null) => {
+		calls.push(`second:${element ? 'attach' : 'detach'}`);
+	};
+	const r = mount(SuspendedHostRefUpdate, {
+		innerRef: firstRef,
+		promise: fulfilled('first'),
+	});
+	expect(calls).toEqual(['first:attach']);
+
+	r.update(SuspendedHostRefUpdate, {
+		innerRef: secondRef,
+		promise: pending.promise,
+	});
+	expect(r.find('.updated-ref-fallback').textContent).toBe('loading');
+	expect(calls).toEqual(['first:attach', 'first:detach']);
+
+	await act(() => pending.resolve('ready'));
+	expect(calls).toEqual(['first:attach', 'first:detach', 'second:attach']);
+	r.unmount();
+});
+
 it('re-attaches a superseded primary ref after later siblings commit', () => {
 	const pending = deferred<string>();
 	const observedSiblingValues: string[] = [];
@@ -28,21 +79,21 @@ it('re-attaches a superseded primary ref after later siblings commit', () => {
 			observedSiblingValues.push(sibling?.getAttribute('data-value') ?? '');
 		}
 	};
-	const r = mount(SupersededRefOrder as any, {
+	const r = mount(SupersededRefOrder, {
 		promise: fulfilled('first'),
 		cbRef,
 		sentinel: 'first',
 	});
 	observe = true;
 
-	r.update(SupersededRefOrder as any, {
+	r.update(SupersededRefOrder, {
 		promise: pending.promise,
 		cbRef,
 		sentinel: 'pending',
 	});
 	expect(r.find('.superseded-fallback').textContent).toBe('loading');
 
-	r.update(SupersededRefOrder as any, {
+	r.update(SupersededRefOrder, {
 		promise: fulfilled('current'),
 		cbRef,
 		sentinel: 'current',


### PR DESCRIPTION
fixes #503 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes commit-phase ref attach/detach and Suspense hide/reveal wiring—areas where subtle ordering bugs affect user ref callbacks and array refs.
> 
> **Overview**
> Fixes incorrect ref callback timing when a **Suspense** boundary hides its primary before commit (fixes #503).
> 
> **Suspense hide path:** When the primary is hidden for fallback, the runtime now **drops** deferred ref attaches for that subtree (including WIP capture) and records which ref/target pairs never committed. The hide detach walk skips those pairs so a replacement ref is not `null`’d before it ever attached, while still detaching refs that were already live. Ref callbacks queued during hide detach are discarded again so they are not published on the fallback commit; reveal re-attaches from current manifests.
> 
> **Deferred attach pipeline:** `queueRefAttach` now takes `(scope, ref, el)` instead of a closure; the compiler emits ref and element directly. Fragment mounts use a shared `attachLiveFragmentRef` trampoline so render-phase ref swaps resolve at drain/cancel time. Ref attach ordering relies on stable sort plus ancestor reordering (refs no longer share effect `commitSeq`).
> 
> Tests cover initial suspended mounts (including array refs), suspended ref swaps, fragment callback churn/replay, and the existing superseded-ref ordering case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fde4b87fba72047e2d1ea00afcdcdb70234c35e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->