### PR TITLE
fix: one-level method calls in inferred hook dependencies

### DIFF
--- a/.changeset/inferred-method-call-deps.md
+++ b/.changeset/inferred-method-call-deps.md
@@ -1,0 +1,27 @@
+---
+octane: patch
+---
+
+Track the receiver of one-level method calls in inferred hook dependencies
+(#542).
+
+`useMemo(() => count.toFixed(2))` used to infer `[count.toFixed]` — a function
+that lives on `Number.prototype` and therefore never changes identity, so the
+memo stayed frozen at its first value while `count` moved. The same hazard
+applied to any prototype method called on a one-level receiver, including
+instance methods of replaced class instances.
+
+Neither static alternative is right for every program: depending on `count`
+fixes primitives but would re-run `props.onChange(...)` hooks on every parent
+render, because `props` is a fresh container whose own function property is the
+real dependency. The inferred array now compiles such calls to
+`__methodDep(root, 'name')`, a new semi-public runtime helper that picks the
+comparable value per render: the member when it is an own property of the
+receiver, the receiver when the method is inherited, and `undefined` when the
+property is absent (so `props.onReady?.()` stays inert until a handler is
+passed). Own-property callbacks and absent optional handlers keep exactly their
+previous recompute behavior; inherited-method calls now correctly recompute
+when the receiver changes.
+
+Deeper callees (`a.b.c(...)`) and computed callees (`a[k](...)`) already
+tracked their receivers and are unchanged, as are explicit dependency arrays.

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -115,6 +115,20 @@ omitted. Mutating such an object in place is therefore not witnessed by a
 dependency array; state that should drive rendering belongs in state, context,
 or a store rather than a module singleton.
 
+A one-level method call tracks the value that can change between renders. The
+compiled array selects that value on each render, based on where the method
+lives:
+
+- An own function property tracks itself: `props.onChange(...)` tracks
+  `props.onChange`.
+- An inherited method tracks its receiver: `count.toFixed(2)` tracks `count`,
+  because `Number.prototype.toFixed` is one function for every number.
+- An absent handler in an optional call tracks a stable `undefined`:
+  `props.onReady?.()` does not re-run its hook until a handler is passed.
+
+Deeper calls such as `cart.items.push(x)` track their receiver path
+(`cart.items`), unchanged.
+
 ### Calls to custom wrappers
 
 Inferring a missing dependency argument at a **call to a custom wrapper** is a

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -41,7 +41,12 @@ import {
 import { print as esrapPrint } from 'esrap';
 import esrapTsx from 'esrap/languages/tsx';
 import { buildFatSegments } from './fat-segments.js';
-import { analyzeHookDependencies, applyHookDependencies, isInvariantLiteral } from './hook-deps.js';
+import {
+	METHOD_DEP_IMPORT,
+	analyzeHookDependencies,
+	applyHookDependencies,
+	isInvariantLiteral,
+} from './hook-deps.js';
 import { compileUniversal, UNIVERSAL_COMPILER_RUNTIME_IMPORTS } from './compile-universal.js';
 import {
 	expandDomRendererRegionsAst,
@@ -6064,12 +6069,16 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 			rendererBoundaryPreparation?.universalUnits,
 		),
 	});
+	let hookDepHelperNeeded = false;
 	ast = applyHookDependencies(ast, {
 		filename,
 		hookRuntimeModules: hookRuntimeModulesForCompile(
 			options,
 			rendererBoundaryPreparation?.universalUnits,
 		),
+		onRuntimeHelper: () => {
+			hookDepHelperNeeded = true;
+		},
 	});
 	const hmrOption = options && options.hmr;
 	const hmrDialect = hmrOption === true ? 'vite' : hmrOption || false;
@@ -6202,6 +6211,7 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 		// single module print must carry a loc (OCTANE_COMPILE_ASSERT_LOC).
 		_moduleOrigin: ast.body.find((n) => n?.loc != null) ?? ast,
 	};
+	if (hookDepHelperNeeded) ctx.runtimeNeeded.add(METHOD_DEP_IMPORT);
 	{
 		const imports = collectOctaneImportBindings(ast.body);
 		ctx.octaneImportLocals = imports.locals;
@@ -7122,9 +7132,13 @@ function compileServer(source, filename, options, analyzedAst = null) {
 	// Mirror the client transform exactly. Effects are server no-ops, but
 	// useMemo/useCallback execute during SSR and must receive the same inferred
 	// dependency shape as hydration's client compile.
+	let hookDepHelperNeeded = false;
 	ast = applyHookDependencies(ast, {
 		filename,
 		hookRuntimeModules: hookRuntimeModulesForCompile(options),
+		onRuntimeHelper: () => {
+			hookDepHelperNeeded = true;
+		},
 	});
 	const ctx = {
 		filename,
@@ -7168,6 +7182,7 @@ function compileServer(source, filename, options, analyzedAst = null) {
 		// Scaffolding without a more precise authored construct maps here.
 		_moduleOrigin: ast.body.find((n) => n?.loc != null) ?? ast,
 	};
+	if (hookDepHelperNeeded) ctx.runtimeNeeded.add(METHOD_DEP_IMPORT);
 	{
 		const imports = collectOctaneImportBindings(ast.body);
 		ctx.octaneImportLocals = imports.locals;

--- a/packages/octane/src/compiler/hook-deps.js
+++ b/packages/octane/src/compiler/hook-deps.js
@@ -819,7 +819,37 @@ function staticMemberInfo(node) {
 	return {
 		node: dependencyNode,
 		root,
+		name: current.property.name,
 		path: `${current.optional ? '?' : ''}.${current.property.name}`,
+	};
+}
+
+// The `octane` runtime export inferred method-call dependencies compile to.
+// Both emitters alias it: the full compiler through `ctx.runtimeNeeded` (its
+// `_$`-prefixed rtAlias convention is baked into methodDepNode below) and the
+// surgical pass through its own helper-import allocator.
+export const METHOD_DEP_IMPORT = '__methodDep';
+
+// The emitted dependency expression for a one-level method call:
+// `_$__methodDep(root, 'name')` — own property ? member value : receiver (see
+// the runtime helper's contract in src/method-dep.ts). The call node carries
+// the authored member's source range so source maps and the surgical pass's
+// offset expectations stay anchored to the authored expression, while the
+// cloned root identifier keeps its own authored position.
+function methodDepNode(dependency) {
+	// Every synthesized node is stamped with the authored member's origin — the
+	// bundler print path asserts a loc on each printed node, including the
+	// helper's callee identifier.
+	const call = b.call(
+		b.id(`_$${METHOD_DEP_IMPORT}`, dependency.node),
+		{ ...dependency.method.root },
+		b.literal(dependency.method.name, JSON.stringify(dependency.method.name), dependency.node),
+	);
+	return {
+		...call,
+		start: dependency.node.start,
+		end: dependency.node.end,
+		loc: dependency.node.loc,
 	};
 }
 
@@ -863,6 +893,40 @@ function collectDependencies(expression, callbackScope, analysis) {
 		}
 	}
 
+	// A one-level member CALLED as a method. The member value alone cannot
+	// witness a changed receiver when the method is inherited (issue #542:
+	// `count.toFixed` is `Number.prototype.toFixed` on every render), and the
+	// receiver alone would defeat memoization for own function properties on
+	// per-render containers (`props.onChange(...)`). Record the pair and let the
+	// emitted `__methodDep(root, 'name')` helper pick the comparable value at
+	// runtime. Deeper callees (`a.b.c(...)`) never reach here: their receiver
+	// path is recorded by the ordinary member walk, which cannot capture the
+	// method itself, so they were never exposed to the stale-method hazard.
+	function addMethodCall(info) {
+		const scope = analysis.nodeScopes.get(info.root);
+		const binding = scope ? resolveBinding(scope, info.root.name) : null;
+		if (
+			binding === null ||
+			binding.imported ||
+			binding.dependencyInvariant ||
+			(callbackScope !== null && scopeIsWithin(binding.scope, callbackScope))
+		) {
+			return;
+		}
+		// Distinct from the plain-read key: `x.m` read as a value elsewhere in the
+		// callback still contributes its own member dependency.
+		const key = `b${binding.id}${info.path}()`;
+		if (!seen.has(key)) {
+			seen.add(key);
+			dependencies.push({
+				node: info.node,
+				key,
+				binding,
+				method: { root: info.root, name: info.name },
+			});
+		}
+	}
+
 	function walk(node) {
 		if (!node || typeof node !== 'object') return;
 		if (Array.isArray(node)) {
@@ -878,6 +942,20 @@ function collectDependencies(expression, callbackScope, analysis) {
 			case 'Identifier':
 				addIdentifier(node);
 				return;
+			case 'CallExpression': {
+				// Optional spellings land here too: `a?.b(x)` and `a.b?.(x)` are a
+				// CallExpression under a ChainExpression whose callee is a bare
+				// (possibly optional) MemberExpression, which staticMemberInfo accepts.
+				const callee = unwrapValue(node.callee);
+				const info =
+					callee?.type === 'MemberExpression' || callee?.type === 'ChainExpression'
+						? staticMemberInfo(callee)
+						: null;
+				if (info) addMethodCall(info);
+				else walk(node.callee);
+				walk(node.arguments);
+				return;
+			}
 			case 'ChainExpression': {
 				const info = staticMemberInfo(node);
 				if (info) addStaticMember(info);
@@ -1163,7 +1241,7 @@ function rebuildWithHookMetadata(ast, analysis, inferred, insertDeps) {
 					args.splice(result.depsIndex, 0, {
 						...b.array(
 							result.dependencies.map((/** @type {any} */ dependency) =>
-								cloneDependency(dependency.node),
+								dependency.method ? methodDepNode(dependency) : cloneDependency(dependency.node),
 							),
 						),
 						start: node.start,
@@ -1197,8 +1275,22 @@ export function annotateHookCalls(ast, options = {}) {
  * dependency arrays inserted at each candidate call. Copy-on-write — the input
  * AST is never modified; callers must use the returned module.
  */
-/** @param {any} ast @param {{ onlyImported?: boolean, hookRuntimeModules?: readonly string[], filename?: string }} [options] */
+/** @param {any} ast @param {{ onlyImported?: boolean, hookRuntimeModules?: readonly string[], filename?: string, onRuntimeHelper?: (name: string) => void }} [options] */
 export function applyHookDependencies(ast, options = {}) {
 	const { analysis, inferred } = analyzeInternal(ast, options);
+	// The inserted `_$__methodDep(...)` calls need their aliased runtime import;
+	// the caller owns import assembly, so report the requirement rather than
+	// splicing an ImportDeclaration into a module whose runtime request
+	// ('octane' vs 'octane/server') this pass cannot know.
+	if (options.onRuntimeHelper !== undefined) {
+		outer: for (const result of inferred.values()) {
+			for (const dependency of result.dependencies) {
+				if (dependency.method) {
+					options.onRuntimeHelper(METHOD_DEP_IMPORT);
+					break outer;
+				}
+			}
+		}
+	}
 	return rebuildWithHookMetadata(ast, analysis, inferred, true).ast;
 }

--- a/packages/octane/src/compiler/slot-hooks.js
+++ b/packages/octane/src/compiler/slot-hooks.js
@@ -16,7 +16,7 @@
 
 import { parseModule } from '@tsrx/core';
 import { HOOK_NAMES, hookSlotHash } from './compile.js';
-import { annotateHookCalls } from './hook-deps.js';
+import { METHOD_DEP_IMPORT, annotateHookCalls } from './hook-deps.js';
 import { assertStrongMode } from './strong-mode.js';
 
 // Build a cheap import-presence gate. Precise call identity is annotated by the
@@ -940,9 +940,16 @@ function walk(node, owner, st) {
 				// The dependency callback is already the final user argument. Insert
 				// both the generated array and slot in one edit so equal-position edit
 				// ordering cannot reverse them. Dependency nodes retain original source
-				// offsets, preserving arbitrary TS syntax byte-for-byte.
+				// offsets, preserving arbitrary TS syntax byte-for-byte. Method-call
+				// dependencies are the one synthesized form: the helper call's root is
+				// a bare identifier and its name a JSON string, so no arbitrary TS
+				// syntax needs reprinting there either.
 				const deps = inferred.dependencies
-					.map((dependency) => st.source.slice(dependency.node.start, dependency.node.end))
+					.map((dependency) =>
+						dependency.method
+							? `${requireParallelHelper(st, METHOD_DEP_IMPORT)}(${dependency.method.root.name}, ${JSON.stringify(dependency.method.name)})`
+							: st.source.slice(dependency.node.start, dependency.node.end),
+					)
 					.join(', ');
 				st.edits.push({
 					pos: node.arguments[node.arguments.length - 1].end,

--- a/packages/octane/src/index.ts
+++ b/packages/octane/src/index.ts
@@ -254,3 +254,6 @@ export type {
 
 // Semi-public compiler target for `module server` browser stubs.
 export { __serverRpc } from './server-rpc-client.js';
+
+// Semi-public compiler target for inferred method-call dependencies.
+export { __methodDep } from './method-dep.js';

--- a/packages/octane/src/method-dep.ts
+++ b/packages/octane/src/method-dep.ts
@@ -1,0 +1,45 @@
+/**
+ * Runtime discriminator for compiler-inferred method-call dependencies.
+ *
+ * When a hook's dependency list is inferred and the callback contains a
+ * one-level method call `root.m(...)`, neither static choice of dependency
+ * value is correct for every program:
+ *
+ * - the member value `root.m` misses receiver changes whenever `m` is an
+ *   inherited method (`count.toFixed` is `Number.prototype.toFixed` on every
+ *   render, so a memo keyed on it never recomputes — issue #542);
+ * - the receiver `root` recomputes on every render when `root` is a fresh
+ *   container whose own function property is the real dependency
+ *   (`props.onChange(...)` with `props` rebuilt by each parent render).
+ *
+ * Where the method lives resolves the ambiguity at runtime: an own function
+ * property was placed on that specific object and carries the identity that
+ * matters, while an inherited method is one function shared by every receiver,
+ * leaving the receiver as the only value that can witness a change. Both
+ * results feed the ordinary `Object.is` slot comparison; if the property
+ * migrates between own and inherited across renders the two branches produce
+ * unequal values, so the worst case is a spurious recompute, never a missed
+ * one.
+ *
+ * A property that is absent altogether (`props.onReady?.()` with no `onReady`
+ * passed) contributes `undefined` — the same stable value the plain member
+ * read produced — rather than the receiver, so an optional call on a fresh
+ * container does not re-run its hook on every render while the callback stays
+ * unprovided.
+ *
+ * Primitives skip the object probes entirely — they cannot carry own
+ * properties and the guard avoids boxing them. `null`/`undefined` receivers
+ * (the optional call spellings `root?.m(...)` / `root.m?.(...)`) also fall
+ * through to the receiver branch instead of throwing. Compiled dependency
+ * arrays evaluate this helper on every render, so every branch must stay
+ * allocation-free.
+ */
+const hasOwnProp = Object.prototype.hasOwnProperty;
+
+export function __methodDep(receiver: unknown, name: string): unknown {
+	if ((typeof receiver !== 'object' || receiver === null) && typeof receiver !== 'function') {
+		return receiver;
+	}
+	if (hasOwnProp.call(receiver, name)) return (receiver as Record<string, unknown>)[name];
+	return name in (receiver as object) ? receiver : undefined;
+}

--- a/packages/octane/src/server/index.ts
+++ b/packages/octane/src/server/index.ts
@@ -23,6 +23,11 @@
 
 export { executeServerFunction } from './rpc.js';
 
+// Semi-public compiler target for inferred method-call dependencies — the
+// same helper the client entry ships, because inferred dependency arrays are
+// compiled identically for SSR (see applyHookDependencies' server call site).
+export { __methodDep } from '../method-dep.js';
+
 export {
 	// Entry — React `react-dom/server` parity (buffered; streaming lands in a
 	// later phase). `renderToString` is a single sync pass (fallbacks for

--- a/packages/octane/tests/_fixtures/auto-hook-deps-behavior.tsrx
+++ b/packages/octane/tests/_fixtures/auto-hook-deps-behavior.tsrx
@@ -242,3 +242,43 @@ export function StoreGetterSelectedEffect(props) @{
 	useEffect(() => props.log(value));
 	<span class="value">{value}</span>
 }
+
+// An optional call on a handler that is not provided must contribute a stable
+// dependency (`undefined`), not the per-render props container — the effect
+// stays inert until the handler appears.
+export function EffectFromOptionalMethodCall(props) @{
+	useEffect(() => {
+		props.log('run');
+		props.onPing?.();
+	});
+	<span>{props.noise as string}</span>
+}
+
+// Issue #542: `count.toFixed` lives on Number.prototype, so its identity never
+// changes — the receiver's value is what the memo actually depends on.
+export function MemoFromPrototypeMethodCall() @{
+	const [count, setCount] = useState(0);
+	const fixed = useMemo(() => count.toFixed(2));
+	<button class="step" onClick={() => setCount(count + 0.25)}>{fixed as string}</button>
+}
+
+class PrefixFormatter {
+	prefix;
+	constructor(prefix) {
+		this.prefix = prefix;
+	}
+	format(value) {
+		return `${this.prefix}:${value}`;
+	}
+}
+
+// The object flavor of the same contract: `formatter.format` is a shared
+// prototype method, so a replaced instance must still recompute the memo.
+export function MemoFromInstanceMethodCall(props) @{
+	const formatter = useMemo(() => new PrefixFormatter(props.prefix));
+	const label = useMemo(() => formatter.format(props.value));
+	<div>
+		<span class="value">{label as string}</span>
+		<span class="noise">{props.noise as string}</span>
+	</div>
+}

--- a/packages/octane/tests/auto-hook-deps-behavior.test.ts
+++ b/packages/octane/tests/auto-hook-deps-behavior.test.ts
@@ -9,6 +9,7 @@ import {
 	EffectFromDeferredWork,
 	EffectFromDestructuring,
 	EffectFromModuleScopeHelpers,
+	EffectFromOptionalMethodCall,
 	EffectFromProps,
 	EffectFromReferencedCallback,
 	EffectFromState,
@@ -18,9 +19,11 @@ import {
 	EffectWithFreshObject,
 	ExternalHookDependencies,
 	MemoFromComputedPath,
+	MemoFromInstanceMethodCall,
 	MemoFromNestedScope,
 	MemoFromOptionalPath,
 	MemoFromProps,
+	MemoFromPrototypeMethodCall,
 	MemoFromReferencedFactory,
 	MemoFromState,
 	MemoWithManyDependencies,
@@ -94,6 +97,32 @@ describe('inferred useEffect dependencies — behavior', () => {
 		r.unmount();
 		flushEffects();
 		expect(next).toEqual(['run:a', 'cleanup:a']);
+	});
+
+	it('stays inert across renders while an optionally called handler is absent', () => {
+		const entries: string[] = [];
+		const log = (entry: string) => entries.push(entry);
+		const r = mount(EffectFromOptionalMethodCall, { log, noise: 0 });
+		flushEffects();
+		expect(entries).toEqual(['run']);
+
+		// No handler on either render: the inferred dependency must be as stable
+		// as the plain `props.onPing` read it replaces, not the fresh props bag.
+		r.update(EffectFromOptionalMethodCall, { log, noise: 1 });
+		flushEffects();
+		expect(entries).toEqual(['run']);
+
+		const onPing = vi.fn();
+		r.update(EffectFromOptionalMethodCall, { log, onPing, noise: 2 });
+		flushEffects();
+		expect(entries).toEqual(['run', 'run']);
+		expect(onPing).toHaveBeenCalledTimes(1);
+
+		r.update(EffectFromOptionalMethodCall, { log, onPing, noise: 3 });
+		flushEffects();
+		expect(entries).toEqual(['run', 'run']);
+		expect(onPing).toHaveBeenCalledTimes(1);
+		r.unmount();
 	});
 
 	it('reacts to captured state but not sibling state', () => {
@@ -484,6 +513,33 @@ describe('inferred useMemo dependencies — behavior', () => {
 		r.update(MemoWithManyDependencies, { ...initial, e: 6, noise: 2 });
 		expect(r.find('.value').textContent).toBe('1:2:3:4:6');
 		expect(compute).toHaveBeenCalledTimes(2);
+		r.unmount();
+	});
+
+	it('recomputes a prototype-method call when its receiver value changes (issue #542)', () => {
+		const r = mount(MemoFromPrototypeMethodCall);
+		expect(r.find('.step').textContent).toBe('0.00');
+
+		r.click('.step');
+		expect(r.find('.step').textContent).toBe('0.25');
+
+		r.click('.step');
+		expect(r.find('.step').textContent).toBe('0.50');
+		r.unmount();
+	});
+
+	it('recomputes a prototype-method call when the receiver instance is replaced', () => {
+		const r = mount(MemoFromInstanceMethodCall, { prefix: 'a', value: 'x', noise: 0 });
+		expect(r.find('.value').textContent).toBe('a:x');
+
+		r.update(MemoFromInstanceMethodCall, { prefix: 'a', value: 'x', noise: 1 });
+		expect(r.find('.value').textContent).toBe('a:x');
+
+		r.update(MemoFromInstanceMethodCall, { prefix: 'b', value: 'x', noise: 2 });
+		expect(r.find('.value').textContent).toBe('b:x');
+
+		r.update(MemoFromInstanceMethodCall, { prefix: 'b', value: 'y', noise: 3 });
+		expect(r.find('.value').textContent).toBe('b:y');
 		r.unmount();
 	});
 

--- a/packages/octane/tests/compiler/auto-hook-deps-stability.test.ts
+++ b/packages/octane/tests/compiler/auto-hook-deps-stability.test.ts
@@ -32,9 +32,16 @@ const c = (source: string, options?: { mode?: 'client' | 'server'; filename?: st
 // The inferred array, read back from the emitted hook call. The trailing slot
 // argument is a numeric index in `.tsrx` output and a Symbol alias in `.tsx`
 // output; both forms anchor the match without being asserted themselves.
+// One-level method calls compile their dependency to a helper call (the
+// own-property discriminator — auto-hook-deps.test.ts pins that emission);
+// normalize it back to the authored member spelling because this suite's
+// subject is WHICH captures are tracked or omitted, not the comparison form.
 const depsOf = (code: string): string[] =>
 	[...code.matchAll(/\[([^[\]]*)\],\s*(?:\d+|_h\$\d+)\s*\)/g)].map((match) =>
-		match[1].replace(/\s+/g, ' ').trim(),
+		match[1]
+			.replace(/[\w$]*__methodDep[\w$]*\((\w+), "([^"]+)"\)/g, '$1.$2')
+			.replace(/\s+/g, ' ')
+			.trim(),
 	);
 
 describe('dependency stability — module-scope immutable identities', () => {

--- a/packages/octane/tests/compiler/auto-hook-deps.test.ts
+++ b/packages/octane/tests/compiler/auto-hook-deps.test.ts
@@ -31,7 +31,7 @@ describe('automatic hook dependencies — full compiler', () => {
     `);
 
 		expect(code).toMatch(
-			/useEffect\([\s\S]*?,\s*\[props\.onValue, props\.value, count\],\s*\d+\s*\)/,
+			/useEffect\([\s\S]*?,\s*\[_\$__methodDep\(props, "onValue"\), props\.value, count\],\s*\d+\s*\)/,
 		);
 	});
 
@@ -52,11 +52,15 @@ describe('automatic hook dependencies — full compiler', () => {
       }
     `);
 
-		expect(code).toMatch(/useEffect\([^;]+\[props\.passive, props\.value\]/);
-		expect(code).toMatch(/useLayoutEffect\([^;]+\[props\.layout, props\.value\]/);
-		expect(code).toMatch(/useInsertionEffect\([^;]+\[props\.insert, props\.value\]/);
+		expect(code).toMatch(/useEffect\([^;]+\[_\$__methodDep\(props, "passive"\), props\.value\]/);
+		expect(code).toMatch(
+			/useLayoutEffect\([^;]+\[_\$__methodDep\(props, "layout"\), props\.value\]/,
+		);
+		expect(code).toMatch(
+			/useInsertionEffect\([^;]+\[_\$__methodDep\(props, "insert"\), props\.value\]/,
+		);
 		expect(code).toMatch(/useMemo\([^;]+\[props\.value\]/);
-		expect(code).toMatch(/useCallback\([^;]+\[props\.onEvent, props\.value\]/);
+		expect(code).toMatch(/useCallback\([^;]+\[_\$__methodDep\(props, "onEvent"\), props\.value\]/);
 		expect(code).toMatch(/useImperativeHandle\([^;]+\[callback, memo\]/);
 	});
 
@@ -77,7 +81,9 @@ describe('automatic hook dependencies — full compiler', () => {
       }
     `);
 
-		expect(code).toMatch(/useEffect\([\s\S]*?,\s*\[local, outer, props\.log\],\s*\d+\s*\)/);
+		expect(code).toMatch(
+			/useEffect\([\s\S]*?,\s*\[local, outer, _\$__methodDep\(props, "log"\)\],\s*\d+\s*\)/,
+		);
 	});
 
 	it('tracks lexical bindings declared directly in switch cases', () => {
@@ -96,7 +102,7 @@ describe('automatic hook dependencies — full compiler', () => {
       }
     `);
 
-		expect(code).toMatch(/useEffect\([^;]+\[props\.log, selected\]/);
+		expect(code).toMatch(/useEffect\([^;]+\[_\$__methodDep\(props, "log"\), selected\]/);
 	});
 
 	it('tracks one-level receivers for deep reads and method calls', () => {
@@ -114,6 +120,87 @@ describe('automatic hook dependencies — full compiler', () => {
 		expect(code).toMatch(
 			/useEffect\([\s\S]*?,\s*\[props\.user, props\.order, props\.value\],\s*\d+\s*\)/,
 		);
+	});
+
+	it('routes one-level method-call receivers through the own-property discriminator', () => {
+		const code = c(`
+      import { useMemo, useState } from 'octane';
+      export function App(props) @{
+        const [count, setCount] = useState(0);
+        const fixed = useMemo(() => count.toFixed(2));
+        const optional = useMemo(() => count?.toFixed?.(2));
+        const guarded = useMemo(() => count.toFixed?.(2));
+        <button onClick={() => setCount(count + 0.25)}>{fixed as string}</button>
+      }
+    `);
+
+		// The method value alone can never witness a changed receiver
+		// (`Number.prototype.toFixed` is one shared function), so the inferred
+		// dependency defers the receiver-vs-member choice to the runtime helper.
+		expect(code).toMatch(/useMemo\([^;]+\[[\w$]+\(count, ["']toFixed["']\)\],\s*\d+\s*\)/);
+		expect(code).not.toMatch(/\[count\.toFixed\]/);
+		expect(code).not.toMatch(/\[count\?\.toFixed\]/);
+		// Every optional spelling funnels into the same null-safe helper form.
+		expect(code.match(/\(count, ["']toFixed["']\)/g)).toHaveLength(3);
+	});
+
+	it('keeps computed and deep method calls on their existing receiver deps', () => {
+		const code = c(`
+      import { useEffect } from 'octane';
+      export function App(props) @{
+        useEffect(() => {
+          props.handlers[props.kind](props.payload);
+          console.log(props.value.toFixed(2));
+        });
+        <div />
+      }
+    `);
+
+		// A computed callee already tracks receiver and key; a deep callee already
+		// tracks its receiver path. Neither needs the helper.
+		expect(code).toMatch(
+			/useEffect\([\s\S]*?,\s*\[props\.handlers, props\.kind, props\.payload, props\.value\],\s*\d+\s*\)/,
+		);
+	});
+
+	it('emits the method-call helper during server compilation', () => {
+		const code = c(
+			`
+        import { useMemo, useState } from 'octane';
+        export function App(props) @{
+          const [count, setCount] = useState(0);
+          const fixed = useMemo(() => count.toFixed(2));
+          <button onClick={() => setCount(count + 0.25)}>{fixed as string}</button>
+        }
+      `,
+			{ mode: 'server' },
+		);
+		expect(code).toMatch(/\[[\w$]+\(count, ["']toFixed["']\)\]/);
+		expect(code).toMatch(/import \{[^}]*__methodDep[^}]*\} from ['"]octane\/server['"]/);
+	});
+
+	it('compiles method-call deps inside custom hooks for the server print', () => {
+		// The shape that first tripped OCTANE_COMPILE_ASSERT_LOC (set for every
+		// vitest compile): a method call inside a hook callback of a module-level
+		// custom hook, whose print does not pass through the component body's
+		// deep origin inheritance — every synthesized dependency node must carry
+		// its own authored origin.
+		const code = c(
+			`
+        import { useLayoutEffect } from 'octane';
+        export function useReport(context, id) {
+          useLayoutEffect(() => {
+            context.report(id);
+          });
+        }
+        export function App(props) @{
+          useReport(props.context, props.id);
+          <div />
+        }
+      `,
+			{ mode: 'server' },
+		);
+		expect(code).toMatch(/\(context, ["']report["']\), id\]/);
 	});
 
 	it('does not treat simple assignment targets as value reads', () => {
@@ -155,7 +242,9 @@ describe('automatic hook dependencies — full compiler', () => {
 		// the only one a dependency array can witness. An import and a module-scope
 		// `const` are both fixed for the program's lifetime — see
 		// auto-hook-deps-stability.test.ts for that contract in full.
-		expect(code).toMatch(/useEffect\([\s\S]*?,\s*\[props\.log, moduleValue\],\s*\d+\s*\)/);
+		expect(code).toMatch(
+			/useEffect\([\s\S]*?,\s*\[_\$__methodDep\(props, "log"\), moduleValue\],\s*\d+\s*\)/,
+		);
 	});
 
 	it('emits valid chain expressions for deep optional reads', () => {
@@ -340,13 +429,13 @@ describe('automatic hook dependencies — full compiler', () => {
     `);
 
 		expect(code).toMatch(
-			/useOuter, \(\) => props\.log\(props\.value\), \[props\.log, props\.value\]/,
+			/useOuter, \(\) => props\.log\(props\.value\), \[_\$__methodDep\(props, "log"\), props\.value\]/,
 		);
 		expect(code).toContain('useOuter, () => props.log(props.always), null');
 		expect(code).toContain('useOuter, () => props.log(props.explicit), [props.explicit]');
 		expect(code).toContain('useOuter, () => props.log(props.undefined), undefined');
 		expect(code).toContain(
-			'useArrowEffect, () => props.log(props.arrow), [props.log, props.arrow]',
+			'useArrowEffect, () => props.log(props.arrow), [_$__methodDep(props, "log"), props.arrow]',
 		);
 		expect(code).toMatch(
 			/useHandle, props\.ref, \(\) => \(\{ value: props\.value \}\), \[props\.value\]/,
@@ -389,6 +478,20 @@ export function useThing<T extends { deep?: { name?: string } }>(value: T) {
 		expect(code).toMatch(
 			/memo\(\(\) => \[importedValue, moduleValue, value\?\.deep\?\.name\], \[moduleValue, value\?\.deep\], _h\$\d+\)/,
 		);
+	});
+
+	it('routes one-level method-call receivers through the imported helper', () => {
+		const source = `
+import { useMemo } from 'octane';
+export function useFixed(count: number) {
+  return useMemo(() => count.toFixed(2));
+}
+`;
+		const code = slotHooks(source, 'use-fixed.ts')!.code;
+		expect(code).toMatch(
+			/useMemo\(\(\) => count\.toFixed\(2\), \[[\w$]+\(count, ["']toFixed["']\)\], _h\$\d+\)/,
+		);
+		expect(code).toMatch(/import \{[^}]*__methodDep[^}]*\} from ['"]octane['"]/);
 	});
 
 	it('preserves complete referenced callback paths', () => {

--- a/packages/octane/tests/compiler/linked-state-compiler.test.ts
+++ b/packages/octane/tests/compiler/linked-state-compiler.test.ts
@@ -149,8 +149,16 @@ describe('useLinkedState compiler integration', () => {
 			inlineHookMemo: false,
 		}).code;
 		const effect = callsTo(code, importedLocal(code, 'useEffect')!)[0];
+		// `props.observe(...)` is a method call, so its dependency compiles to the
+		// own-property discriminator helper (see auto-hook-deps.test.ts).
 		expect(effect?.arguments[1]?.elements).toMatchObject([
-			{ type: 'MemberExpression', property: { name: 'observe' } },
+			{
+				type: 'CallExpression',
+				arguments: [
+					{ type: 'Identifier', name: 'props' },
+					{ type: 'Literal', value: 'observe' },
+				],
+			},
 			{ type: 'Identifier', name: 'value' },
 		]);
 	});


### PR DESCRIPTION
addresses the first issue in #542

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compiler-inferred dependency shapes for all one-level method calls in hooks, affecting memo/effect re-run semantics; scope is narrow and covered by new tests, but any app relying on the old (buggy) prototype-method behavior will see different updates.
> 
> **Overview**
> Address the first part of **#542**: inferred dependency arrays no longer use the method function alone for one-level calls like `count.toFixed(2)` or `props.onChange(...)`, which broke memos when the callee was a shared prototype method.
> 
> The compiler now emits **`__methodDep(root, 'name')`** in inferred arrays. At runtime the helper compares the **own property** when the method lives on the object, the **receiver** when it is inherited (e.g. `Number.prototype.toFixed`), and **`undefined`** when an optional handler is missing—so `props.onReady?.()` does not re-run every render. Deeper (`a.b.c(...)`) and computed callees are unchanged.
> 
> Wiring spans **`hook-deps.js`** (detection + AST), **client/server `compile.js`** and **`slot-hooks.js`** (imports), new **`method-dep.ts`**, and docs in **`differences-from-react.md`**, with behavioral and compiler tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37be5d0dac6cb4aabbb162b5928d0a8bee900172. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->