### PR TITLE
docs: vscode extension for tsrx

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ docs into a `.tsx` file and it runs. Or author in `.tsrx`, the spiritual
 successor to JSX, and get template directives (`@if`, `@for`, `@switch`, `@try`)
 that compile to keyed fast paths, plus an `@{ … }` shorthand that puts setup next
 to the output. Mix both dialects in one app and import across the boundary.
+[TSRX for VS Code](https://marketplace.visualstudio.com/items?itemName=Ripple-TS.ripple-ts-vscode-plugin)
+adds syntax highlighting, diagnostics, navigation, and completions for `.tsrx`
+files.
 
 **Write the closure, not its dependency list.** Omit the array from `useEffect`,
 `useMemo`, `useCallback`, and friends, and the compiler derives it from what the

--- a/packages/create-octane/README.md
+++ b/packages/create-octane/README.md
@@ -91,8 +91,9 @@ to install by hand is printed instead.
 
 ## Editor support
 
-An Octane project builds, typechecks, and runs from the scaffold alone. Making
-an editor understand `.tsrx` is separate: the extension is not published yet, so
-until it is, a `.tsrx` import may show as unresolved even though `npm run
-typecheck` passes. `tsrx-tsc` carries its own TypeScript and is the reliable
-answer on whether the project is type-correct.
+An Octane project builds, typechecks, and runs from the scaffold alone. Install
+[TSRX for VS Code](https://marketplace.visualstudio.com/items?itemName=Ripple-TS.ripple-ts-vscode-plugin)
+for syntax highlighting, diagnostics, navigation, completions, and TypeScript-aware
+editor support in `.tsrx` files. Pair it with the official Prettier extension for
+format on save. The scaffold's `tsrx-tsc` typecheck remains the command-line and
+CI check.

--- a/website-mcp/src/content/docs.ts
+++ b/website-mcp/src/content/docs.ts
@@ -14,6 +14,7 @@ import deferredHydrationMd from '../../../docs/deferred-hydration.md?raw';
 export interface McpDocSection {
 	id: string;
 	title: string;
+	searchTerms?: readonly string[];
 }
 
 export interface McpDoc {

--- a/website-mcp/src/content/search.ts
+++ b/website-mcp/src/content/search.ts
@@ -2,6 +2,7 @@
 // website's ⌘K dialog uses (docs-search-core.ts), built eagerly at module scope
 // from the build-time snapshot instead of lazily in the browser.
 import {
+	addSearchTerms,
 	recordsFor,
 	searchDocs,
 	type SearchGroup,
@@ -38,14 +39,19 @@ export const SEARCH_INDEX: readonly SearchRecord[] = DOCS.flatMap((doc, order) =
 	const records = recordsFor(doc.slug, doc.title, order, source);
 	// Extra ranking hints (the bindings catalog names every package) attach to
 	// the doc's first section — mirrors the website's loadSearchIndex.
-	if (doc.searchTerms?.length) {
-		const target = records.find((record) => record.id === doc.sections[0]?.id) ?? records[0];
-		if (target) {
-			const block = { text: doc.searchTerms.join(' · '), code: false };
-			target.blocks.push(block);
-			target.text += ' ' + block.text;
-			target.haystack += ' ' + block.text.toLowerCase();
+	addSearchTerms(
+		records.find((record) => record.id === doc.sections[0]?.id) ?? records[0],
+		doc.searchTerms,
+	);
+	for (const section of doc.sections) {
+		if (!section.searchTerms?.length) continue;
+		const target = records.find((record) => record.id === section.id);
+		if (!target) {
+			throw new Error(
+				`Search terms for ${doc.slug}#${section.id} must target an indexed h2 section`,
+			);
 		}
+		addSearchTerms(target, section.searchTerms);
 	}
 	return records;
 });

--- a/website-mcp/tests/search.test.ts
+++ b/website-mcp/tests/search.test.ts
@@ -38,4 +38,10 @@ describe('docs search over the snapshot', () => {
 	it('finds bindings via package-name search terms', () => {
 		expect(slugsFor('zustand')).toContain('bindings');
 	});
+
+	it('finds section-specific aliases at their exact documentation anchor', () => {
+		const [top] = search('vscode');
+		expect(top.slug).toBe('quick-start');
+		expect(top.id).toBe('tsrx-at-a-glance');
+	});
 });

--- a/website/src/content/docs-meta.ts
+++ b/website/src/content/docs-meta.ts
@@ -10,6 +10,8 @@ import { FRAMEWORK_INTEGRATIONS, FRAMEWORK_INTEGRATION_COUNT } from './framework
 export interface DocSection {
 	id: string;
 	title: string;
+	/** Metadata-only aliases that should land on this exact indexed `<h2>` in search. */
+	searchTerms?: readonly string[];
 	// Heading depth for the "On this page" tree: 2 for a top-level `<h2>` section
 	// (the default), 3 for an `<h2>` subsection anchored by an `<h3>`. Only the
 	// table of contents reads this; the search index is built from `<h2>` anchors.
@@ -44,9 +46,13 @@ export const docsMeta: DocMeta[] = [
 		sections: [
 			{ id: 'scaffold', title: 'Create a new app' },
 			{ id: 'install', title: 'Install into an existing project' },
-			{ id: 'first-component', title: 'Your first component' },
+			{ id: 'first-component', title: 'Build your first component' },
 			{ id: 'mount', title: 'Connect it to the page' },
-			{ id: 'tsrx-at-a-glance', title: 'TSRX at a glance' },
+			{
+				id: 'tsrx-at-a-glance',
+				title: 'TSRX at a glance',
+				searchTerms: ['VSCode', 'VSCode extension', 'TSRX VSCode'],
+			},
 			{ id: 'next', title: 'Next' },
 		],
 	},
@@ -61,10 +67,10 @@ export const docsMeta: DocMeta[] = [
 			{ id: 'rspack', title: 'Rspack' },
 			{ id: 'rsbuild', title: 'Rsbuild' },
 			{ id: 'strong-mode', title: 'Strong mode' },
+			{ id: 'mixed-toolchains', title: 'Mixed toolchains and file ownership' },
 			{ id: 'full-app-configuration', title: 'Full app configuration' },
 			{ id: 'production-and-preview', title: 'Production and preview' },
 			{ id: 'renderer-targets', title: 'Renderer targets' },
-			{ id: 'mixed-toolchains', title: 'Mixed toolchains and file ownership' },
 		],
 	},
 	{
@@ -142,22 +148,42 @@ export const docsMeta: DocMeta[] = [
 			{ id: 'mental-model', title: 'The mental model' },
 			{ id: 'components-and-props', title: 'Components and props' },
 			{ id: 'state-and-events', title: 'State and events' },
-			{ id: 'use-linked-state', title: 'useLinkedState', level: 3 },
-			{ id: 'strong-mode', title: 'Strong mode', level: 3 },
+			{
+				id: 'use-linked-state',
+				title: 'Keep editable state in sync with useLinkedState',
+				level: 3,
+			},
+			{ id: 'strong-mode', title: 'Catch state mistakes with Strong mode', level: 3 },
 			{ id: 'lists-and-conditions', title: 'Lists and conditions' },
-			{ id: 'context', title: 'Sharing data' },
+			{ id: 'context', title: 'Sharing data with context' },
 			{ id: 'refs-and-effects', title: 'Refs and effects' },
-			{ id: 'use-sync-external-store', title: 'useSyncExternalStore', level: 3 },
+			{
+				id: 'use-sync-external-store',
+				title: 'Subscribe to external state with useSyncExternalStore',
+				level: 3,
+			},
 			{ id: 'async-ui', title: 'Loading data and code' },
 			{ id: 'deferred-hydration', title: 'Deferred hydration' },
-			{ id: 'responsive-updates', title: 'Responsive updates' },
-			{ id: 'use-transition', title: 'useTransition', level: 3 },
-			{ id: 'use-deferred-value', title: 'useDeferredValue', level: 3 },
-			{ id: 'view-transitions', title: 'ViewTransition', level: 3 },
+			{ id: 'responsive-updates', title: 'Responsive updates and actions' },
+			{
+				id: 'use-transition',
+				title: 'Keep the current screen with useTransition',
+				level: 3,
+			},
+			{
+				id: 'use-deferred-value',
+				title: 'Let a slow view lag with useDeferredValue',
+				level: 3,
+			},
+			{
+				id: 'view-transitions',
+				title: 'Animate visual changes with ViewTransition',
+				level: 3,
+			},
 			{ id: 'roots-and-rendering', title: 'Roots and rendering' },
-			{ id: 'create-portal', title: 'createPortal', level: 3 },
-			{ id: 'server-rendering', title: 'Server rendering' },
-			{ id: 'api-index', title: 'API index' },
+			{ id: 'create-portal', title: 'Render an overlay with createPortal', level: 3 },
+			{ id: 'server-rendering', title: 'Server and static rendering' },
+			{ id: 'api-index', title: 'API index by job' },
 			{ id: 'practice', title: 'Practice' },
 			{ id: 'next-steps', title: 'Next steps' },
 		],
@@ -169,9 +195,14 @@ export const docsMeta: DocMeta[] = [
 		group: 'Learn Octane',
 		sections: [
 			{ id: 'which-should-i-use', title: 'Which should I use?' },
-			{ id: 'component-bodies', title: 'Component bodies' },
-			{ id: 'rendered-control-flow', title: 'Rendered control flow' },
-			{ id: 'text-holes', title: 'Text holes' },
+			{ id: 'component-bodies', title: 'The same component, with less ceremony' },
+			{ id: 'rendered-control-flow', title: 'Branches and lists that read top to bottom' },
+			{ id: 'text-holes', title: 'Text holes make the output explicit' },
+			{
+				id: 'editor-support',
+				title: 'Editor support',
+				searchTerms: ['VSCode', 'VSCode extension', 'TSRX VSCode'],
+			},
 			{ id: 'next', title: 'Next' },
 		],
 	},
@@ -181,12 +212,12 @@ export const docsMeta: DocMeta[] = [
 		description: 'The deliberate divergences — everything else matching React is the point.',
 		group: 'Explore',
 		sections: [
-			{ id: 'hooks', title: 'Hooks' },
-			{ id: 'strong-mode', title: 'Strong mode' },
-			{ id: 'events-and-dom', title: 'Events and the DOM' },
-			{ id: 'async-work', title: 'Async work' },
+			{ id: 'hooks', title: 'Hooks fit the code' },
+			{ id: 'strong-mode', title: 'Strong mode is optional' },
+			{ id: 'events-and-dom', title: 'Events come from the browser' },
+			{ id: 'async-work', title: 'Transitions without time slicing' },
 			{ id: 'errors-and-server', title: 'Errors and server rendering' },
-			{ id: 'not-supported', title: 'APIs left out' },
+			{ id: 'not-supported', title: 'APIs Octane leaves out' },
 		],
 	},
 	{
@@ -239,10 +270,10 @@ export const docsMeta: DocMeta[] = [
 		],
 		sections: [
 			{ id: 'source-package-contract', title: 'The source-package contract' },
-			{ id: 'package-the-source', title: 'Package the source' },
+			{ id: 'package-the-source', title: 'Package the complete source graph' },
 			{ id: 'authoring-and-types', title: 'Authoring and types' },
-			{ id: 'package-metadata', title: 'Package metadata' },
-			{ id: 'verify-the-package', title: 'Verify the package' },
+			{ id: 'package-metadata', title: 'Use package metadata only for real exceptions' },
+			{ id: 'verify-the-package', title: 'Verify what users receive' },
 		],
 	},
 	{
@@ -256,9 +287,9 @@ export const docsMeta: DocMeta[] = [
 			...category.packages,
 		]),
 		sections: [
-			{ id: 'find-a-binding', title: 'Find a binding' },
-			{ id: 'install-and-use', title: 'Install and use' },
-			{ id: 'check-support', title: 'Check support' },
+			{ id: 'find-a-binding', title: 'Pick by the job' },
+			{ id: 'install-and-use', title: 'Install it, then change the import' },
+			{ id: 'check-support', title: 'Check the part you plan to use' },
 		],
 	},
 ];

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -54,15 +54,6 @@ The scaffolder is `octane create`, and [the CLI guide](/docs/cli#create) documen
 flags — including `--no-install`, which prints the dependency list instead of installing
 it.
 
-<aside className="doc-callout note">
-	<p className="doc-callout-title">Your editor and .tsrx</p>
-	<p>
-		{
-			'A scaffolded project builds, typechecks, and runs straight away. Making an editor understand .tsrx is separate: the extension is not published yet, so a .tsrx import may show as unresolved even while npm run typecheck passes. tsrx-tsc carries its own TypeScript and is the reliable answer on whether the project is type-correct.'
-		}
-	</p>
-</aside>
-
 <h2 id="install">Install into an existing project</h2>
 
 The rest of this page is the same work by hand, against a Vite project you already have.
@@ -171,6 +162,19 @@ export function TodoList(props) @{
 	</ul>
 }
 ```
+
+<aside className="doc-callout tip">
+	<p className="doc-callout-title">Make .tsrx feel native in VS Code</p>
+	<p>
+		Install{' '}
+		<a href="https://marketplace.visualstudio.com/items?itemName=Ripple-TS.ripple-ts-vscode-plugin">
+			TSRX for VS Code
+		</a>{' '}
+		for syntax highlighting, diagnostics, navigation, completions, and TypeScript-aware editor
+		support. Pair it with the official Prettier extension for format on save. Your project's{' '}
+		<code>tsrx-tsc</code> typecheck remains the command-line and CI check.
+	</p>
+</aside>
 
 The same family includes `@if` for two-way branches, `@switch` for several choices, and
 `@try` for loading and error states. Plain JavaScript still belongs in the setup part of

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -166,13 +166,15 @@ export function TodoList(props) @{
 <aside className="doc-callout tip">
 	<p className="doc-callout-title">Make .tsrx feel native in VS Code</p>
 	<p>
-		Install{' '}
+		{
+			'For syntax highlighting, diagnostics, navigation, completions, and TypeScript-aware editor support in '
+		}
+		<code>.tsrx</code>
+		{' files, install '}
 		<a href="https://marketplace.visualstudio.com/items?itemName=Ripple-TS.ripple-ts-vscode-plugin">
-			TSRX for VS Code
-		</a>{' '}
-		for syntax highlighting, diagnostics, navigation, completions, and TypeScript-aware editor
-		support. Pair it with the official Prettier extension for format on save. Your project's{' '}
-		<code>tsrx-tsc</code> typecheck remains the command-line and CI check.
+			{'TSRX for VS Code'}
+		</a>
+		{'.'}
 	</p>
 </aside>
 

--- a/website/src/content/docs/tsrx-vs-tsx.mdx
+++ b/website/src/content/docs/tsrx-vs-tsx.mdx
@@ -145,22 +145,27 @@ React.
 	<p className="doc-callout-title">The file extension does not change the framework</p>
 	<p>
 		{
-			'Both dialects use the same hooks, context, portals, Suspense, transitions, native events, SSR, and hydration. The Vite, Rspack, and Rsbuild integrations compile both.'
+			'Both dialects use the same hooks, context, portals, Suspense, transitions, native events, SSR, and hydration. The Vite, Rspack, and Rsbuild integrations compile both, while octane/compiler/volar adds editor support for .tsrx.'
 		}
-	</p>
-	<p>
-		For syntax highlighting, diagnostics, navigation, completions, and TypeScript-aware editor
-		support in <code>.tsrx</code> files, install{' '}
-		<a href="https://marketplace.visualstudio.com/items?itemName=Ripple-TS.ripple-ts-vscode-plugin">
-			TSRX for VS Code
-		</a>
-		.
 	</p>
 </aside>
 
 One rule also applies to both: do not call a slot-based hook directly in a plain
 JavaScript loop. Use keyed `@for`, or move the hook into a row component rendered by a
 keyed `.map()`.
+
+<h2 id="editor-support">Editor support</h2>
+
+{
+'For syntax highlighting, diagnostics, navigation, completions, and TypeScript-aware editor support in '
+}
+
+<code>.tsrx</code>
+{' files, install '}
+<a href="https://marketplace.visualstudio.com/items?itemName=Ripple-TS.ripple-ts-vscode-plugin">
+	{'TSRX for VS Code'}
+</a>
+{'.'}
 
 <h2 id="next">Next</h2>
 

--- a/website/src/content/docs/tsrx-vs-tsx.mdx
+++ b/website/src/content/docs/tsrx-vs-tsx.mdx
@@ -145,8 +145,16 @@ React.
 	<p className="doc-callout-title">The file extension does not change the framework</p>
 	<p>
 		{
-			'Both dialects use the same hooks, context, portals, Suspense, transitions, native events, SSR, and hydration. The Vite, Rspack, and Rsbuild integrations compile both, while octane/compiler/volar adds editor support for .tsrx.'
+			'Both dialects use the same hooks, context, portals, Suspense, transitions, native events, SSR, and hydration. The Vite, Rspack, and Rsbuild integrations compile both.'
 		}
+	</p>
+	<p>
+		For syntax highlighting, diagnostics, navigation, completions, and TypeScript-aware editor
+		support in <code>.tsrx</code> files, install{' '}
+		<a href="https://marketplace.visualstudio.com/items?itemName=Ripple-TS.ripple-ts-vscode-plugin">
+			TSRX for VS Code
+		</a>
+		.
 	</p>
 </aside>
 

--- a/website/src/lib/docs-search-core.ts
+++ b/website/src/lib/docs-search-core.ts
@@ -30,6 +30,12 @@ export interface SearchRecord {
 	order: number;
 }
 
+export interface DocHeading {
+	id: string;
+	title: string;
+	level: 2 | 3;
+}
+
 /** One section of one document, with the lines inside it that matched. */
 export interface SearchGroup {
 	key: string;
@@ -108,6 +114,18 @@ function blocksFor(raw: string): SearchBlock[] {
 }
 
 const HEADING = /<h2\s+id="([^"]+)"[^>]*>([\s\S]*?)<\/h2>/g;
+const DOC_HEADING = /<h([23])\s+id="([^"]+)"[^>]*>([\s\S]*?)<\/h\1>/g;
+
+/** Read the authored section anchors and their rendered titles from raw MDX. */
+export function headingsFor(source: string): DocHeading[] {
+	const body = source.replace(/^---[\s\S]*?---/, '');
+	DOC_HEADING.lastIndex = 0;
+	return Array.from(body.matchAll(DOC_HEADING), (match) => ({
+		level: Number(match[1]) as 2 | 3,
+		id: match[2],
+		title: cleanProse(match[3]),
+	}));
+}
 
 export function recordsFor(
 	slug: string,
@@ -145,6 +163,18 @@ export function recordsFor(
 		push(id, title, body.slice(start, match ? match.index : body.length));
 	}
 	return records;
+}
+
+/** Add metadata-only aliases to one section without putting them in rendered prose. */
+export function addSearchTerms(
+	record: SearchRecord | undefined,
+	terms: readonly string[] | undefined,
+): void {
+	if (!record || !terms?.length) return;
+	const block = { text: terms.join(' · '), code: false };
+	record.blocks.push(block);
+	record.text += ' ' + block.text;
+	record.haystack += ' ' + block.text.toLowerCase();
 }
 
 function escapeRegExp(term: string): string {

--- a/website/src/lib/docs-search.ts
+++ b/website/src/lib/docs-search.ts
@@ -6,7 +6,7 @@
 // The sectionizer and ranking live in docs-search-core.ts (pure, shared with
 // the remote MCP server); this module owns the lazy index build over the raw
 // MDX glob and re-exports the core surface for the dialog and tests.
-import { recordsFor, type SearchRecord } from './docs-search-core.ts';
+import { addSearchTerms, recordsFor, type SearchRecord } from './docs-search-core.ts';
 
 export * from './docs-search-core.ts';
 
@@ -33,14 +33,20 @@ export function loadSearchIndex(): Promise<SearchRecord[]> {
 					const doc = order === -1 ? undefined : docs[order];
 					const rank = order === -1 ? docs.length : order;
 					const records = recordsFor(slug, doc?.title ?? slug, rank, await load());
-					if (doc?.searchTerms?.length) {
-						const target =
-							records.find((record) => record.id === doc.sections?.[0]?.id) ?? records[0];
-						if (target) {
-							const block = { text: doc.searchTerms.join(' · '), code: false };
-							target.blocks.push(block);
-							target.text += ' ' + block.text;
-							target.haystack += ' ' + block.text.toLowerCase();
+					if (doc) {
+						addSearchTerms(
+							records.find((record) => record.id === doc.sections?.[0]?.id) ?? records[0],
+							doc.searchTerms,
+						);
+						for (const section of doc.sections ?? []) {
+							if (!section.searchTerms?.length) continue;
+							const target = records.find((record) => record.id === section.id);
+							if (!target) {
+								throw new Error(
+									`Search terms for ${doc.slug}#${section.id} must target an indexed h2 section`,
+								);
+							}
+							addSearchTerms(target, section.searchTerms);
 						}
 					}
 					return records;

--- a/website/tests/docs-search.test.ts
+++ b/website/tests/docs-search.test.ts
@@ -5,7 +5,23 @@ import { cleanup, fireEvent, render, waitFor } from '@octanejs/testing-library';
 import { RouterProvider, createMemoryHistory } from '@octanejs/tanstack-router';
 import { getRouter } from '../src/router.ts';
 import { docs } from '../src/content/docs.ts';
-import { loadSearchIndex, searchDocs } from '../src/lib/docs-search.ts';
+import { headingsFor, loadSearchIndex, searchDocs } from '../src/lib/docs-search.ts';
+
+const rawDocs = import.meta.glob('../src/content/docs/*.mdx', {
+	query: '?raw',
+	import: 'default',
+	eager: true,
+}) as Record<string, string>;
+
+function rawDoc(slug: string): string {
+	const entry = Object.entries(rawDocs).find(([path]) => path.endsWith(`/${slug}.mdx`));
+	if (!entry) throw new Error(`missing raw doc for ${slug}`);
+	return entry[1];
+}
+
+function frontmatterTitle(source: string): string | undefined {
+	return source.match(/^---\s*$([\s\S]*?)^---\s*$/m)?.[1].match(/^title:\s*(.+)$/m)?.[1];
+}
 
 afterEach(cleanup);
 
@@ -20,6 +36,29 @@ async function renderRoute(url: string) {
 }
 
 describe('docs search index', () => {
+	it('keeps page and section metadata aligned with the authored headings', () => {
+		for (const doc of docs) {
+			const source = rawDoc(doc.slug);
+			const headings = headingsFor(source);
+
+			expect(frontmatterTitle(source), `${doc.slug} page title`).toBe(doc.title);
+			for (const section of doc.sections ?? []) {
+				const heading = headings.find((candidate) => candidate.id === section.id);
+				expect(heading, `${doc.slug}#${section.id}`).toEqual({
+					id: section.id,
+					title: section.title,
+					level: section.level ?? 2,
+				});
+			}
+
+			// Every top-level authored section belongs in the registry, in page order.
+			expect(
+				(doc.sections ?? []).filter((section) => (section.level ?? 2) === 2).map(({ id }) => id),
+				`${doc.slug} top-level sections`,
+			).toEqual(headings.filter(({ level }) => level === 2).map(({ id }) => id));
+		}
+	});
+
 	it('indexes every document, and every section anchor the registry advertises', async () => {
 		const index = await loadSearchIndex();
 
@@ -124,6 +163,20 @@ describe('docs search ranking', () => {
 
 		expect(top.slug).toBe('framework-integrations');
 		expect(top.id).toBe('astro');
+	});
+
+	it('deep links compact and spaced VS Code searches to the TSRX editor guidance', async () => {
+		const index = await loadSearchIndex();
+		const expected = [
+			{ query: 'vscode', slug: 'quick-start', id: 'tsrx-at-a-glance' },
+			{ query: 'vs code', slug: 'tsrx-vs-tsx', id: 'editor-support' },
+		];
+
+		for (const { query, slug, id } of expected) {
+			const [top] = searchDocs(index, query);
+			expect(top.slug, query).toBe(slug);
+			expect(top.id, query).toBe(id);
+		}
 	});
 
 	it('requires every term to match, and ignores queries shorter than two characters', async () => {

--- a/website/tests/smoke.test.ts
+++ b/website/tests/smoke.test.ts
@@ -346,6 +346,27 @@ describe('website routes', () => {
 		expect(container.querySelector('.prose pre.shiki code')).toBeTruthy();
 	});
 
+	it.each([
+		{
+			path: '/docs/quick-start',
+			title: 'Make .tsrx feel native in VS Code',
+		},
+		{
+			path: '/docs/tsrx-vs-tsx',
+			title: 'The file extension does not change the framework',
+		},
+	])('$path keeps inline callout prose and links inline', async ({ path, title }) => {
+		const { container } = await renderRoute(path);
+		const callout = Array.from(container.querySelectorAll<HTMLElement>('.doc-callout')).find(
+			(candidate) => candidate.querySelector('.doc-callout-title')?.textContent === title,
+		);
+
+		expect(callout).toBeTruthy();
+		expect(callout!.querySelector('p p')).toBeNull();
+		expect(callout!.querySelector('a p')).toBeNull();
+		expect(callout!.querySelector('a')?.textContent).toBe('TSRX for VS Code');
+	});
+
 	it('/docs/publishing-libraries renders the package-manager dry-run selector', async () => {
 		const { container } = await renderRoute('/docs/publishing-libraries');
 		const firstSection = container.querySelector<HTMLElement>('h2#source-package-contract')!;

--- a/website/tests/smoke.test.ts
+++ b/website/tests/smoke.test.ts
@@ -346,25 +346,34 @@ describe('website routes', () => {
 		expect(container.querySelector('.prose pre.shiki code')).toBeTruthy();
 	});
 
-	it.each([
-		{
-			path: '/docs/quick-start',
-			title: 'Make .tsrx feel native in VS Code',
-		},
-		{
-			path: '/docs/tsrx-vs-tsx',
-			title: 'The file extension does not change the framework',
-		},
-	])('$path keeps inline callout prose and links inline', async ({ path, title }) => {
-		const { container } = await renderRoute(path);
+	it('/docs/quick-start keeps inline callout prose and links inline', async () => {
+		const { container } = await renderRoute('/docs/quick-start');
 		const callout = Array.from(container.querySelectorAll<HTMLElement>('.doc-callout')).find(
-			(candidate) => candidate.querySelector('.doc-callout-title')?.textContent === title,
+			(candidate) =>
+				candidate.querySelector('.doc-callout-title')?.textContent ===
+				'Make .tsrx feel native in VS Code',
 		);
 
 		expect(callout).toBeTruthy();
 		expect(callout!.querySelector('p p')).toBeNull();
 		expect(callout!.querySelector('a p')).toBeNull();
 		expect(callout!.querySelector('a')?.textContent).toBe('TSRX for VS Code');
+	});
+
+	it('/docs/tsrx-vs-tsx keeps the editor-support link inline', async () => {
+		const { container } = await renderRoute('/docs/tsrx-vs-tsx');
+		const heading = container.querySelector('h2#editor-support')!;
+		let element = heading.nextElementSibling;
+		let link: HTMLAnchorElement | null = null;
+
+		while (element && element.tagName !== 'H2') {
+			if (element instanceof HTMLAnchorElement) link = element;
+			else link ??= element.querySelector('a');
+			element = element.nextElementSibling;
+		}
+
+		expect(link?.textContent).toBe('TSRX for VS Code');
+		expect(link?.querySelector('p')).toBeNull();
 	});
 
 	it('/docs/publishing-libraries renders the package-manager dry-run selector', async () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are documentation, search metadata, and tests only—no runtime product or auth/data paths.
> 
> **Overview**
> Documentation now treats **TSRX for VS Code** as the recommended editor setup instead of saying the extension is unpublished. The root README, create-octane scaffold README, quick-start, and a new **Editor support** section on the TSRX vs TSX guide link to the marketplace extension and describe highlighting, diagnostics, navigation, completions, and pairing with Prettier; the old quick-start callout that warned about unresolved `.tsrx` imports is removed.
> 
> Docs navigation metadata gets clearer section titles (especially Core APIs and related guides) and a small reorder in build-tools. Search is extended so **section-level `searchTerms`** (e.g. VSCode aliases) attach to the correct `<h2>` anchor via shared `addSearchTerms` / `headingsFor` in `docs-search-core`, with the website and website-mcp indexes both using that path and throwing if terms target a non-indexed section.
> 
> Tests assert VS Code queries deep-link to `quick-start#tsrx-at-a-glance` and `tsrx-vs-tsx#editor-support`, registry headings stay aligned with MDX, and callout prose keeps the extension link inline without invalid nested `<p>` markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe7a3030f5159c9a39e40d6ee8b287e4759c43d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->