### PR TITLE
ci: disable auto vercel previews, use deploy-preview label

### DIFF
--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -1,0 +1,262 @@
+name: Vercel preview
+
+# A preview is a maintainer-requested snapshot, not a side effect of every
+# commit. Removing and reapplying `deploy-preview` runs this again for the pull
+# request's current head. Each Vercel project independently reuses a usable
+# deployment for that SHA or creates the missing preview.
+on:
+  pull_request_target:
+    types: [labeled]
+
+concurrency:
+  # Do not cancel a run after it has asked Vercel to build. A following run is
+  # serialized and will reuse the deployment if the SHA is still current.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: deploy website previews
+    if: github.event.label.name == 'deploy-preview'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Pull requests are issues to GitHub's comment API. The workflow only reads
+    # PR state and writes its one marker-owned comment; it never reads or writes
+    # repository contents.
+    permissions:
+      issues: write
+      pull-requests: read
+
+    steps:
+      - name: Resolve or create Vercel previews
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_WEBSITE_PROJECT_ID: ${{ vars.VERCEL_WEBSITE_PROJECT_ID }}
+          VERCEL_MCP_PROJECT_ID: ${{ vars.VERCEL_MCP_PROJECT_ID }}
+        with:
+          script: |
+            const LABEL = "deploy-preview";
+            const COMMENT_MARKER = "<!-- octane-vercel-preview -->";
+            const ACTIVE_STATES = new Set(["READY", "BUILDING", "INITIALIZING", "QUEUED"]);
+            const TERMINAL_STATES = new Set(["READY", "ERROR", "CANCELED", "BLOCKED"]);
+            const projects = [
+              { label: "Website", id: process.env.VERCEL_WEBSITE_PROJECT_ID },
+              { label: "MCP website", id: process.env.VERCEL_MCP_PROJECT_ID },
+            ];
+
+            const required = {
+              VERCEL_TOKEN: process.env.VERCEL_TOKEN,
+              VERCEL_ORG_ID: process.env.VERCEL_ORG_ID,
+              VERCEL_WEBSITE_PROJECT_ID: process.env.VERCEL_WEBSITE_PROJECT_ID,
+              VERCEL_MCP_PROJECT_ID: process.env.VERCEL_MCP_PROJECT_ID,
+            };
+            const missing = Object.entries(required)
+              .filter(([, value]) => !value)
+              .map(([name]) => name);
+            if (missing.length > 0) {
+              core.setFailed(`Missing GitHub Actions configuration: ${missing.join(", ")}`);
+              return;
+            }
+            core.setSecret(required.VERCEL_TOKEN);
+
+            const { owner, repo } = context.repo;
+            const number = context.payload.pull_request.number;
+            // The event payload may have waited behind another label run. The
+            // API response is the source of truth for the open PR, current
+            // label, and latest head SHA that the maintainer requested.
+            const { data: pull } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: number,
+            });
+            if (pull.state !== "open" || !pull.labels.some((label) => label.name === LABEL)) {
+              core.notice(`Skipping #${number}: ${LABEL} is no longer applied to an open pull request.`);
+              return;
+            }
+            if (!pull.head?.repo?.id || !pull.head.ref || !pull.head.sha) {
+              core.setFailed(`Pull request #${number} has no deployable GitHub head.`);
+              return;
+            }
+
+            const teamId = required.VERCEL_ORG_ID;
+            const token = required.VERCEL_TOKEN;
+            const api = async (path, options = {}) => {
+              const response = await fetch(`https://api.vercel.com${path}`, {
+                ...options,
+                headers: {
+                  Accept: "application/json",
+                  Authorization: `Bearer ${token}`,
+                  ...(options.body ? { "Content-Type": "application/json" } : {}),
+                  ...options.headers,
+                },
+              });
+              if (!response.ok) {
+                const detail = (await response.text()).slice(0, 1000);
+                throw new Error(
+                  `Vercel ${options.method ?? "GET"} ${path} failed (${response.status})${detail ? `: ${detail}` : ""}`,
+                );
+              }
+              return response.json();
+            };
+            const stateOf = (deployment) => deployment.readyState ?? deployment.state ?? "QUEUED";
+            const deploymentIdOf = (deployment) => deployment.uid ?? deployment.id;
+            const deploymentUrlOf = (deployment) => {
+              if (!deployment.url) return null;
+              return deployment.url.startsWith("http") ? deployment.url : `https://${deployment.url}`;
+            };
+
+            const resolveProject = async (project) => {
+              const query = new URLSearchParams({
+                projectId: project.id,
+                sha: pull.head.sha,
+                target: "preview",
+                limit: "20",
+                teamId,
+              });
+              const listed = await api(`/v7/deployments?${query}`);
+              const deployments = listed.deployments ?? [];
+              const existing = deployments.find((deployment) =>
+                ACTIVE_STATES.has(stateOf(deployment)),
+              );
+              if (existing) {
+                return { ...project, deployment: existing, reused: true };
+              }
+
+              const projectInfo = await api(
+                `/v9/projects/${encodeURIComponent(project.id)}?${new URLSearchParams({ teamId })}`,
+              );
+              const createQuery = new URLSearchParams({ teamId });
+              // A previous terminal failure for this SHA must not win Vercel's
+              // normal deduplication. Successful and active deployments were
+              // returned above and are never forcibly rebuilt.
+              if (deployments.length > 0) createQuery.set("forceNew", "1");
+              const deployment = await api(`/v13/deployments?${createQuery}`, {
+                method: "POST",
+                body: JSON.stringify({
+                  name: projectInfo.name,
+                  project: project.id,
+                  gitSource: {
+                    type: "github",
+                    repoId: pull.head.repo.id,
+                    ref: pull.head.ref,
+                    sha: pull.head.sha,
+                  },
+                  meta: {
+                    githubCommitSha: pull.head.sha,
+                    githubCommitRef: pull.head.ref,
+                    githubCommitRepoId: String(pull.head.repo.id),
+                    githubPrId: String(number),
+                  },
+                }),
+              });
+              return { ...project, deployment, reused: false };
+            };
+
+            const commentBody = (results) => {
+              const rows = results.map((result) => {
+                if (result.error) {
+                  return `| ${result.label} | Request failed; see the workflow log | ❌ |`;
+                }
+                const state = stateOf(result.deployment);
+                const url = deploymentUrlOf(result.deployment);
+                const source = result.reused ? "reused" : "requested";
+                const preview = url ? `[Open preview](${url})` : "URL pending";
+                return `| ${result.label} | ${preview} | ${state} (${source}) |`;
+              });
+              return [
+                COMMENT_MARKER,
+                `Vercel previews for \`${pull.head.sha.slice(0, 7)}\`:`,
+                "",
+                "| Project | Preview | Status |",
+                "| --- | --- | --- |",
+                ...rows,
+              ].join("\n");
+            };
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: number,
+              per_page: 100,
+            });
+            let comment = comments.find(
+              (candidate) =>
+                candidate.user?.login === "github-actions[bot]" &&
+                candidate.body?.includes(COMMENT_MARKER),
+            );
+            const writeComment = async (results) => {
+              const body = commentBody(results);
+              if (comment) {
+                const response = await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: comment.id,
+                  body,
+                });
+                comment = response.data;
+              } else {
+                const response = await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: number,
+                  body,
+                });
+                comment = response.data;
+              }
+            };
+
+            const resolved = await Promise.all(
+              projects.map(async (project) => {
+                try {
+                  return await resolveProject(project);
+                } catch (error) {
+                  core.warning(`${project.label}: ${error.message}`);
+                  return { ...project, error };
+                }
+              }),
+            );
+            // Publish URLs as soon as Vercel accepts the requests. A slow build
+            // therefore still leaves the requested preview discoverable.
+            await writeComment(resolved);
+
+            const waitForTerminalState = async (result) => {
+              if (result.error || TERMINAL_STATES.has(stateOf(result.deployment))) return result;
+              const id = deploymentIdOf(result.deployment);
+              if (!id) {
+                return { ...result, error: new Error("Vercel returned a deployment without an ID.") };
+              }
+              const deadline = Date.now() + 12 * 60 * 1000;
+              while (Date.now() < deadline) {
+                await new Promise((resolve) => setTimeout(resolve, 5000));
+                try {
+                  result.deployment = await api(
+                    `/v13/deployments/${encodeURIComponent(id)}?${new URLSearchParams({ teamId })}`,
+                  );
+                } catch (error) {
+                  return { ...result, error };
+                }
+                if (TERMINAL_STATES.has(stateOf(result.deployment))) return result;
+              }
+              return { ...result, error: new Error(`Timed out waiting for Vercel deployment ${id}.`) };
+            };
+
+            const needsPolling = resolved.some(
+              (result) => !result.error && !TERMINAL_STATES.has(stateOf(result.deployment)),
+            );
+            const completed = await Promise.all(resolved.map(waitForTerminalState));
+            if (needsPolling) await writeComment(completed);
+
+            const failures = completed.filter(
+              (result) => result.error || stateOf(result.deployment) !== "READY",
+            );
+            if (failures.length > 0) {
+              core.setFailed(
+                failures
+                  .map((result) =>
+                    `${result.label}: ${result.error?.message ?? stateOf(result.deployment)}`,
+                  )
+                  .join("\n"),
+              );
+            }

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -8,16 +8,18 @@ on:
   pull_request_target:
     types: [labeled]
 
-concurrency:
-  # Do not cancel a run after it has asked Vercel to build. A following run is
-  # serialized and will reuse the deployment if the SHA is still current.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: false
-
 jobs:
   deploy:
     name: deploy website previews
     if: github.event.label.name == 'deploy-preview'
+    # Keep concurrency below the label guard. Workflow-level concurrency also
+    # admits skipped jobs, so an unrelated label event could otherwise replace
+    # a pending preview run in GitHub's single pending slot.
+    concurrency:
+      # Do not cancel a run after it has asked Vercel to build. A following run
+      # is serialized and will reuse the deployment if the SHA is still current.
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Pull requests are issues to GitHub's comment API. The workflow only reads

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -962,6 +962,19 @@ describe('Vercel preview workflow', () => {
 		assert.match(notices.join('\n'), /deploy-preview is no longer applied/);
 	});
 
+	test('keeps unrelated label events out of the preview concurrency queue', () => {
+		assert.doesNotMatch(vercelPreviewWorkflow, /^concurrency:/m);
+		assert.match(
+			vercelPreviewWorkflow,
+			/jobs:\n {2}deploy:\n(?:.*\n)*? {4}if: github\.event\.label\.name == 'deploy-preview'\n(?:.*\n)*? {4}concurrency:\n {6}# Do not cancel/,
+		);
+		assert.match(
+			vercelPreviewWorkflow,
+			/^ {6}group: \$\{\{ github\.workflow \}\}-\$\{\{ github\.event\.pull_request\.number \}\}$/m,
+		);
+		assert.match(vercelPreviewWorkflow, /^ {6}cancel-in-progress: false$/m);
+	});
+
 	test('keeps production automatic and makes the privileged workflow API-only', () => {
 		for (const config of [websiteVercelConfig, mcpVercelConfig]) {
 			assert.deepEqual(config.git.deploymentEnabled, {

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -27,6 +27,16 @@ const draftWorkflow = readFileSync(
 	'utf8',
 );
 const labelWorkflow = readFileSync(path.join(REPO, '.github/workflows/label-pr.yml'), 'utf8');
+const vercelPreviewWorkflow = readFileSync(
+	path.join(REPO, '.github/workflows/vercel-preview.yml'),
+	'utf8',
+);
+const websiteVercelConfig = JSON.parse(
+	readFileSync(path.join(REPO, 'website/vercel.json'), 'utf8'),
+);
+const mcpVercelConfig = JSON.parse(
+	readFileSync(path.join(REPO, 'website-mcp/vercel.json'), 'utf8'),
+);
 const createPrSkill = readFileSync(
 	path.join(REPO, '.rulesync/skills/create-a-pr/SKILL.md'),
 	'utf8',
@@ -736,5 +746,236 @@ describe('Pull request labels', () => {
 		);
 		assert.doesNotMatch(labelWorkflow, /actions\/checkout/);
 		assert.doesNotMatch(labelWorkflow, /contents: write/);
+	});
+});
+
+describe('Vercel preview workflow', () => {
+	const sha = 'a'.repeat(40);
+	const pull = {
+		number: 612,
+		state: 'open',
+		labels: [{ name: 'deploy-preview' }],
+		head: {
+			sha,
+			ref: 'feature/preview-this',
+			repo: { id: 12345 },
+		},
+	};
+
+	function jsonResponse(body, status = 200) {
+		return {
+			ok: status >= 200 && status < 300,
+			status,
+			json: async () => structuredClone(body),
+			text: async () => JSON.stringify(body),
+		};
+	}
+
+	async function runPreview({
+		pullResponse = pull,
+		comments = [],
+		handleFetch = () => {
+			throw new Error('unexpected Vercel request');
+		},
+	} = {}) {
+		const requests = [];
+		const writtenComments = [];
+		const warnings = [];
+		const failures = [];
+		const notices = [];
+		const secrets = [];
+		let nextCommentId = 900;
+		const github = {
+			rest: {
+				pulls: { get: async () => ({ data: structuredClone(pullResponse) }) },
+				issues: {
+					listComments: async () => undefined,
+					createComment: async ({ body }) => {
+						const data = {
+							id: nextCommentId++,
+							body,
+							user: { login: 'github-actions[bot]' },
+						};
+						writtenComments.push({ operation: 'create', ...data });
+						return { data };
+					},
+					updateComment: async ({ comment_id, body }) => {
+						const data = {
+							id: comment_id,
+							body,
+							user: { login: 'github-actions[bot]' },
+						};
+						writtenComments.push({ operation: 'update', ...data });
+						return { data };
+					},
+				},
+			},
+			paginate: async () => structuredClone(comments),
+		};
+		const execute = new AsyncFunction(
+			'github',
+			'context',
+			'core',
+			'process',
+			'fetch',
+			'setTimeout',
+			stepScript(vercelPreviewWorkflow, 'Resolve or create Vercel previews'),
+		);
+		await execute(
+			github,
+			{
+				repo: { owner: 'octanejs', repo: 'octane' },
+				payload: { pull_request: { number: pullResponse.number } },
+			},
+			{
+				notice: (message) => notices.push(message),
+				setFailed: (message) => failures.push(message),
+				setSecret: (value) => secrets.push(value),
+				warning: (message) => warnings.push(message),
+			},
+			{
+				env: {
+					VERCEL_TOKEN: 'vercel-token',
+					VERCEL_ORG_ID: 'team_octane',
+					VERCEL_WEBSITE_PROJECT_ID: 'prj_website',
+					VERCEL_MCP_PROJECT_ID: 'prj_mcp',
+				},
+			},
+			async (url, options = {}) => {
+				requests.push({ url, options });
+				return handleFetch(new URL(url), options, jsonResponse);
+			},
+			(callback) => callback(),
+		);
+		return { requests, writtenComments, warnings, failures, notices, secrets };
+	}
+
+	test('reuses both projects at the current SHA and refreshes the existing PR link', async () => {
+		const { requests, writtenComments, failures, secrets } = await runPreview({
+			comments: [
+				{
+					id: 71,
+					body: '<!-- octane-vercel-preview -->\nOld preview',
+					user: { login: 'github-actions[bot]' },
+				},
+			],
+			handleFetch(url, options, response) {
+				assert.equal(options.method, undefined);
+				assert.equal(url.pathname, '/v7/deployments');
+				assert.equal(url.searchParams.get('sha'), sha);
+				assert.equal(url.searchParams.get('target'), 'preview');
+				assert.equal(url.searchParams.get('teamId'), 'team_octane');
+				const project = url.searchParams.get('projectId');
+				return response({
+					deployments: [
+						{
+							uid: `dpl_${project}`,
+							url: `${project}.vercel.app`,
+							readyState: 'READY',
+						},
+					],
+				});
+			},
+		});
+
+		assert.equal(requests.length, 2);
+		assert.ok(requests.every((request) => request.options.method === undefined));
+		assert.ok(writtenComments.every((comment) => comment.operation === 'update'));
+		assert.ok(writtenComments.every((comment) => comment.id === 71));
+		assert.match(writtenComments.at(-1).body, /Vercel previews for `aaaaaaa`/);
+		assert.match(writtenComments.at(-1).body, /https:\/\/prj_website\.vercel\.app/);
+		assert.match(writtenComments.at(-1).body, /https:\/\/prj_mcp\.vercel\.app/);
+		assert.match(writtenComments.at(-1).body, /READY \(reused\)/);
+		assert.deepEqual(failures, []);
+		assert.deepEqual(secrets, ['vercel-token']);
+	});
+
+	test('creates only a missing project from the pull request head and publishes its URL', async () => {
+		let polled = false;
+		const { requests, writtenComments, failures } = await runPreview({
+			handleFetch(url, options, response) {
+				if (url.pathname === '/v7/deployments') {
+					const project = url.searchParams.get('projectId');
+					return response({
+						deployments:
+							project === 'prj_website'
+								? [
+										{
+											uid: 'dpl_website',
+											url: 'website-existing.vercel.app',
+											readyState: 'READY',
+										},
+									]
+								: [],
+					});
+				}
+				if (url.pathname === '/v9/projects/prj_mcp') {
+					return response({ name: 'octane-mcp' });
+				}
+				if (url.pathname === '/v13/deployments' && options.method === 'POST') {
+					assert.equal(url.searchParams.has('forceNew'), false);
+					const body = JSON.parse(options.body);
+					assert.equal(body.name, 'octane-mcp');
+					assert.equal(body.project, 'prj_mcp');
+					assert.deepEqual(body.gitSource, {
+						type: 'github',
+						repoId: 12345,
+						ref: 'feature/preview-this',
+						sha,
+					});
+					assert.equal(body.target, undefined);
+					return response({
+						uid: 'dpl_mcp',
+						url: 'mcp-requested.vercel.app',
+						readyState: 'QUEUED',
+					});
+				}
+				if (url.pathname === '/v13/deployments/dpl_mcp') {
+					polled = true;
+					return response({
+						uid: 'dpl_mcp',
+						url: 'mcp-requested.vercel.app',
+						readyState: 'READY',
+					});
+				}
+				throw new Error(`unexpected Vercel request: ${url}`);
+			},
+		});
+
+		assert.equal(requests.filter((request) => request.options.method === 'POST').length, 1);
+		assert.equal(polled, true);
+		assert.equal(writtenComments[0].operation, 'create');
+		assert.ok(writtenComments.slice(1).every((comment) => comment.operation === 'update'));
+		assert.match(writtenComments.at(-1).body, /website-existing\.vercel\.app/);
+		assert.match(writtenComments.at(-1).body, /mcp-requested\.vercel\.app/);
+		assert.match(writtenComments.at(-1).body, /READY \(requested\)/);
+		assert.deepEqual(failures, []);
+	});
+
+	test('does nothing if the label was removed before a queued run starts', async () => {
+		const { requests, writtenComments, notices } = await runPreview({
+			pullResponse: { ...pull, labels: [] },
+		});
+
+		assert.deepEqual(requests, []);
+		assert.deepEqual(writtenComments, []);
+		assert.match(notices.join('\n'), /deploy-preview is no longer applied/);
+	});
+
+	test('keeps production automatic and makes the privileged workflow API-only', () => {
+		for (const config of [websiteVercelConfig, mcpVercelConfig]) {
+			assert.deepEqual(config.git.deploymentEnabled, {
+				'**': false,
+				main: true,
+			});
+		}
+
+		assert.match(vercelPreviewWorkflow, /on:\n {2}pull_request_target:\n {4}types: \[labeled\]/);
+		assert.match(vercelPreviewWorkflow, /if: github\.event\.label\.name == 'deploy-preview'/);
+		assert.match(vercelPreviewWorkflow, /^ {6}issues: write$/m);
+		assert.match(vercelPreviewWorkflow, /^ {6}pull-requests: read$/m);
+		assert.doesNotMatch(vercelPreviewWorkflow, /actions\/checkout/);
+		assert.doesNotMatch(vercelPreviewWorkflow, /^ {6}contents:/m);
+		assert.doesNotMatch(vercelPreviewWorkflow, /^ {8}run:/m);
 	});
 });

--- a/website-mcp/vercel.json
+++ b/website-mcp/vercel.json
@@ -1,4 +1,10 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "pnpm build"
+  "buildCommand": "pnpm build",
+  "git": {
+    "deploymentEnabled": {
+      "**": false,
+      "main": true
+    }
+  }
 }

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,4 +1,10 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "pnpm build"
+  "buildCommand": "pnpm build",
+  "git": {
+    "deploymentEnabled": {
+      "**": false,
+      "main": true
+    }
+  }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Uses `pull_request_target` with a Vercel token and PR comments, but the workflow is API-only with no repo checkout; misconfiguration of secrets/vars would fail previews rather than run arbitrary PR code.
> 
> **Overview**
> **Vercel no longer deploys every branch** for `website` and `website-mcp`: `vercel.json` now sets `git.deploymentEnabled` so only **`main`** gets automatic production deploys; all other refs are off.
> 
> **On-demand previews** run when a maintainer applies the **`deploy-preview`** label. A new `pull_request_target` workflow (labeled events only) calls the Vercel API for the Website and MCP website projects—reusing an active preview for the PR head SHA when possible, otherwise creating one (with `forceNew` when a prior terminal failure would block retry)—then creates or updates a single marker PR comment with links and status. It does not check out code (`issues: write`, `pull-requests: read` only), re-validates the label on the live PR, and uses job-level concurrency without cancel-in-progress.
> 
> **`scripts/ci-workflow.test.mjs`** adds harness tests for reuse vs create, label removal, concurrency placement, and the Vercel/git deployment policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b648f76a5605d92e487f53dfbb331cd43b6a812b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->