### PR TITLE
Fix #568: test: harden full-suite integration probes under local concu

### DIFF
--- a/packages/rsbuild-plugin-octane/tests/rsbuild.integration.test.ts
+++ b/packages/rsbuild-plugin-octane/tests/rsbuild.integration.test.ts
@@ -868,7 +868,10 @@ export function Page() @{
 `,
 			);
 			let updatedBody = '';
-			const deadline = Date.now() + 20_000;
+			// The rebuild takes ~1s on an idle machine, but this suite shares the
+			// box with the rest of the full run. Poll well inside the case budget
+			// so a saturated machine reports the real HTML rather than a stale one.
+			const deadline = Date.now() + 60_000;
 			while (Date.now() < deadline) {
 				await new Promise((resolveDelay) => setTimeout(resolveDelay, 100));
 				updatedBody = await (await fetch(`${origin}/`)).text();

--- a/packages/rspeedy-plugin-octane/tests/demo.test.ts
+++ b/packages/rspeedy-plugin-octane/tests/demo.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync, spawn, spawnSync, type ChildProcess } from 'node:child_process';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { get as httpGet } from 'node:http';
 import { createServer } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -36,6 +37,29 @@ function delay(milliseconds: number): Promise<void> {
 	return new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds));
 }
 
+// These two probes talk to a loopback development server, so they use
+// `node:http` rather than global `fetch`: Undici configures socket options the
+// loopback path can reject, and it raises that failure outside the request
+// promise, where an awaited `catch` cannot see it.
+function request(url: string, timeoutMs: number): Promise<{ status: number; body: Buffer }> {
+	return new Promise((resolveRequest, reject) => {
+		// No connection pooling: each probe asks the server a fresh question, and
+		// a pooled socket outliving the shutdown would answer the wrong one.
+		const client = httpGet(url, { agent: false }, (response) => {
+			const chunks: Buffer[] = [];
+			response.on('data', (chunk: Buffer) => chunks.push(chunk));
+			response.once('error', reject);
+			response.once('end', () => {
+				resolveRequest({ status: response.statusCode ?? 0, body: Buffer.concat(chunks) });
+			});
+		});
+		client.setTimeout(timeoutMs, () => {
+			client.destroy(new Error(`Timed out requesting ${url}.`));
+		});
+		client.once('error', reject);
+	});
+}
+
 async function waitForBundle(
 	child: ChildProcess,
 	url: string,
@@ -48,13 +72,16 @@ async function waitForBundle(
 			throw new Error(`Lynx demo exited before serving ${url}.\n${output()}`);
 		}
 		try {
-			const response = await fetch(url);
-			if (response.ok) {
+			// The timeout is socket inactivity, not total duration, so it tolerates
+			// a dev server holding the connection open across its first compile
+			// while still bounding a wedged socket inside the loop's deadline.
+			const response = await request(url, 15_000);
+			if (response.status >= 200 && response.status < 300) {
 				await delay(50);
 				if (child.exitCode !== null || child.signalCode !== null) {
 					throw new Error(`Lynx demo exited while serving ${url}.\n${output()}`);
 				}
-				return Buffer.from(await response.arrayBuffer());
+				return response.body;
 			}
 		} catch (error) {
 			if (error instanceof Error && error.message.startsWith('Lynx demo exited')) throw error;
@@ -107,7 +134,7 @@ async function waitForServerStop(url: string, timeoutMs: number): Promise<void> 
 	const deadline = Date.now() + timeoutMs;
 	while (Date.now() <= deadline) {
 		try {
-			await fetch(url, { signal: AbortSignal.timeout(500) });
+			await request(url, 500);
 		} catch {
 			return;
 		}

--- a/website/tests/ssr-hydration.e2e.test.ts
+++ b/website/tests/ssr-hydration.e2e.test.ts
@@ -479,6 +479,18 @@ async function assertControlFlowKeywordMapping(baseUrl: string) {
 			);
 		};
 
+		// CodeMirror only mounts the lines around its scroll position, and the
+		// probes leave a pane deep in the document. Rewind it before waiting on
+		// text from the top of the file, which is otherwise never mounted.
+		// `0` is the source pane, `1` the output pane.
+		const rewindPane = (pane: 0 | 1) =>
+			page.evaluate((index) => {
+				const scroller = document
+					.querySelectorAll('.pg-editor .cm-content')
+					[index]?.closest('.cm-scroller');
+				if (scroller) scroller.scrollTop = 0;
+			}, pane);
+
 		for (const target of ['client', 'server']) {
 			await outputSelector.selectOption(target);
 			await page.waitForFunction(
@@ -570,15 +582,9 @@ async function assertControlFlowKeywordMapping(baseUrl: string) {
 			{ timeout: PLAYWRIGHT_ACTION_TIMEOUT },
 		);
 		await outputSelector.selectOption('client');
-		// CodeMirror renders only the lines around its scroll position, and the
-		// clicks above left the output pane deep in the document. Rewind it, then
-		// wait on the import header at the top of the emit.
-		await page.evaluate(() => {
-			const scroller = document
-				.querySelectorAll('.pg-editor .cm-content')[1]
-				?.closest('.cm-scroller');
-			if (scroller) scroller.scrollTop = 0;
-		});
+		// The clicks above left the output pane deep in the document, so rewind
+		// it before waiting on the import header at the top of the emit.
+		await rewindPane(1);
 		await page.waitForFunction(
 			() =>
 				(document.querySelectorAll('.pg-editor .cm-content')[1]?.textContent ?? '').includes(
@@ -613,6 +619,9 @@ async function assertControlFlowKeywordMapping(baseUrl: string) {
 			).toContain(keyword);
 		}
 		await outputSelector.selectOption('client');
+		// The types probes just above scrolled the output pane past the import
+		// header, and the switch back to `client` keeps that offset.
+		await rewindPane(1);
 		await page.waitForFunction(
 			() =>
 				(document.querySelectorAll('.pg-editor .cm-content')[1]?.textContent ?? '').includes(
@@ -700,15 +709,9 @@ async function assertControlFlowKeywordMapping(baseUrl: string) {
 			null,
 			{ timeout: PLAYWRIGHT_ACTION_TIMEOUT },
 		);
-		// The probes above left the SOURCE pane scrolled deep into another example,
-		// and CodeMirror renders only around its scroll position — rewind so the
-		// whole form is inside the rendered range.
-		await page.evaluate(() => {
-			const scroller = document
-				.querySelectorAll('.pg-editor .cm-content')[0]
-				?.closest('.cm-scroller');
-			if (scroller) scroller.scrollTop = 0;
-		});
+		// The probes above left the SOURCE pane scrolled deep into another example
+		// — rewind so the whole form is inside the rendered range.
+		await rewindPane(0);
 		await page.waitForFunction(
 			() =>
 				(document.querySelectorAll('.cm-content')[0]?.textContent ?? '').includes('defaultValue'),


### PR DESCRIPTION
Closes #568.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only test harness timing and HTTP probing; no application, auth, or build-plugin logic changes.
> 
> **Overview**
> Addresses flaky integration and e2e behavior when the full test suite runs under load (closes **#568**). Changes are **test-only**—no production runtime behavior.
> 
> **Rsbuild integration** — After an on-disk edit in the dev SSR streaming case, the poll for updated HTML now runs up to **60s** (was 20s) so a busy CI runner can see the HMR rebuild instead of timing out on stale markup.
> 
> **Lynx demo integration** — Loopback probes (`waitForBundle`, `waitForServerStop`) use a small **`node:http`** helper instead of global **`fetch`**: no connection pooling (`agent: false`), per-request socket timeouts, and errors that stay inside the promise (Undici/loopback socket issues were escaping `catch`). Status checks use HTTP status codes instead of `response.ok`.
> 
> **Playground SSR-hydration e2e** — Introduces shared **`rewindPane`** to reset CodeMirror source/output scroll to the top before assertions that read header text. Extra rewind calls after keyword probes and output-mode switches so virtualized editors still mount lines at the top of the file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bee2d11f1b7628cfa1ae6a2f9a771342833ac8a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->