### PR TITLE
fix: finish the install when pnpm blocks a dependency build script

### DIFF
--- a/.changeset/cli-pnpm-blocked-build-scripts.md
+++ b/.changeset/cli-pnpm-blocked-build-scripts.md
@@ -1,0 +1,26 @@
+---
+'@octanejs/cli': patch
+---
+
+Finish the install when pnpm blocks a dependency build script.
+
+pnpm refuses to run a dependency's install script until the project records a
+decision about it, and since 11.0 it says so by failing the command, after the
+packages are already on disk. `octane init` and `octane create` read any
+non-zero exit as a dead install and stopped there, which left the dependencies
+installed and the dev dependencies missing: the generated app had no bundler,
+and `pnpm dev` died on `Cannot find package 'vite'`. Scaffolding a `fullstack`
+app with pnpm 11 hit this every time, since `esbuild` reaches that tree and
+carries an install script.
+
+Installs driven by the scaffold now name the build scripts the generated app
+needs, passing `--allow-build=esbuild` to pnpm: that install script is how
+vite's platform binary arrives. Only that package is approved, so a build script
+arriving through some other dependency stays the user's decision. pnpm older
+than 10.4 does not take the flag and the install is retried without it, and
+`--allow-build` is never passed to npm, yarn, or bun, which would read it as a
+package name.
+
+A blocked build script the CLI did not name no longer aborts the run either. The
+packages installed, so setup continues and the pending decision is reported
+under `Do this by hand` as a `pnpm approve-builds` step.

--- a/packages/cli/src/commands/add.js
+++ b/packages/cli/src/commands/add.js
@@ -90,7 +90,8 @@ export default defineCommand({
 			} else {
 				const spinner = ctx.ui.spinner(`Installing ${toInstall.join(', ')}`);
 				const ran = await installPackages(ctx, project, toInstall, { dev: input.flags.dev });
-				spinner.stop(ran);
+				spinner.stop(ran.command);
+				if (ran.warnings.length > 0) ctx.ui.note('Do this by hand', ran.warnings);
 			}
 		}
 

--- a/packages/cli/src/commands/init/index.js
+++ b/packages/cli/src/commands/init/index.js
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { defineCommand } from '../../kernel/command.js';
 import { setCompilerOption } from '../../kernel/edit.js';
 import { CliError, EXIT } from '../../kernel/errors.js';
-import { PACKAGE_MANAGERS, installPackages } from '../../kernel/install.js';
+import { PACKAGE_MANAGERS, PNPM_ALLOWED_BUILDS, installPackages } from '../../kernel/install.js';
 import {
 	MODES,
 	PRETTIER_CONFIG_FILES,
@@ -458,6 +458,11 @@ export async function applyInit(ctx, project, options) {
 
 	/** @type {string[]} */
 	const installed = [];
+	// Every install in this run hits the same blocked build script, and the same
+	// line three times reads like three problems.
+	const warn = (/** @type {string[]} */ lines) => {
+		for (const line of lines) if (!manual.includes(line)) manual.push(line);
+	};
 	if (options.install !== false && dependencies.length + devDependencies.length > 0) {
 		const spinner = ctx.ui.spinner(`Installing with ${installing.packageManager ?? 'npm'}`);
 		try {
@@ -466,9 +471,11 @@ export async function applyInit(ctx, project, options) {
 				[devDependencies, true],
 			]) {
 				if (/** @type {string[]} */ (names).length === 0) continue;
-				await installPackages(ctx, installing, /** @type {string[]} */ (names), {
+				const ran = await installPackages(ctx, installing, /** @type {string[]} */ (names), {
 					dev: Boolean(dev),
+					allowBuilds: PNPM_ALLOWED_BUILDS,
 				});
+				warn(ran.warnings);
 				installed.push(.../** @type {string[]} */ (names));
 			}
 
@@ -481,7 +488,11 @@ export async function applyInit(ctx, project, options) {
 				if (range === null) {
 					manual.push('Install typescript, at the range @tsrx/typescript-plugin declares.');
 				} else {
-					await installPackages(ctx, installing, [`typescript@${range}`], { dev: true });
+					const ran = await installPackages(ctx, installing, [`typescript@${range}`], {
+						dev: true,
+						allowBuilds: PNPM_ALLOWED_BUILDS,
+					});
+					warn(ran.warnings);
 					installed.push('typescript');
 				}
 			}

--- a/packages/cli/src/kernel/install.js
+++ b/packages/cli/src/kernel/install.js
@@ -9,6 +9,33 @@ const MANAGERS = {
 };
 
 /**
+ * Dependency install scripts pnpm should be told to run.
+ *
+ * pnpm blocks them until the project records a decision, and since 11.0 an
+ * undecided script fails the whole install rather than warning: the packages
+ * land on disk and pnpm still exits non-zero. A scaffold that says nothing
+ * therefore stops partway through, with the dependencies installed and the dev
+ * dependencies missing, which leaves an app whose `dev` script cannot start.
+ *
+ * esbuild is the one the generated projects cannot run without: its install
+ * script is how vite's platform binary arrives. Only packages named here are
+ * approved, so a build script arriving through some other dependency stays the
+ * user's call to make.
+ *
+ * npm and yarn run install scripts by default and need none of this. bun blocks
+ * them like pnpm but exits zero, so it never breaks the scaffold; teaching the
+ * templates `trustedDependencies` is a separate change.
+ */
+export const PNPM_ALLOWED_BUILDS = ['esbuild'];
+
+/** What pnpm calls the failure above. */
+const IGNORED_BUILDS = 'ERR_PNPM_IGNORED_BUILDS';
+
+/** Said once per run: the build script is the same one every install trips on. */
+const APPROVE_BUILDS =
+	'pnpm blocked a dependency install script. Run `pnpm approve-builds` to decide on it.';
+
+/**
  * The managers this CLI knows how to drive. Derived rather than written out, so
  * that a flag can never offer a manager `installCommand` would silently answer
  * with npm's spelling.
@@ -19,12 +46,18 @@ export const PACKAGE_MANAGERS = Object.keys(MANAGERS);
  * @param {import('./project.js').Project} project
  * @param {string[]} names
  * @param {boolean} dev
+ * @param {{ allowBuilds?: readonly string[] }} [options]
  * @returns {{ manager: string, args: string[] }}
  */
-export function installCommand(project, names, dev = false) {
+export function installCommand(project, names, dev = false, { allowBuilds = [] } = {}) {
 	const manager = project.packageManager ?? 'npm';
 	const recipe = MANAGERS[/** @type {keyof typeof MANAGERS} */ (manager)] ?? MANAGERS.npm;
-	return { manager, args: [...recipe.add, ...(dev ? [recipe.dev] : []), ...names] };
+	// `--allow-build` is pnpm's spelling, and npm would read it as a package name.
+	const approvals = manager === 'pnpm' ? allowBuilds.map((name) => `--allow-build=${name}`) : [];
+	return {
+		manager,
+		args: [...recipe.add, ...approvals, ...(dev ? [recipe.dev] : []), ...names],
+	};
 }
 
 /**
@@ -34,17 +67,42 @@ export function installCommand(project, names, dev = false) {
  * @param {import('./context.js').Ctx} ctx
  * @param {import('./project.js').Project} project
  * @param {string[]} names
- * @param {{ dev?: boolean }} [options]
- * @returns {Promise<string>} the command that ran
+ * @param {{ dev?: boolean, allowBuilds?: readonly string[] }} [options]
+ * @returns {Promise<{ command: string, warnings: string[] }>} the command that
+ *   ran, and anything the user has to settle themselves
  */
-export async function installPackages(ctx, project, names, { dev = false } = {}) {
-	const { manager, args } = installCommand(project, names, dev);
-	const result = await ctx.exec.run(manager, args, { cwd: project.root });
+export async function installPackages(
+	ctx,
+	project,
+	names,
+	{ dev = false, allowBuilds: approved = [] } = {},
+) {
+	const run = async (/** @type {readonly string[]} */ allowBuilds) => {
+		const { manager, args } = installCommand(project, names, dev, { allowBuilds });
+		const result = await ctx.exec.run(manager, args, { cwd: project.root });
+		return { result, command: `${manager} ${args.join(' ')}` };
+	};
+
+	let { result, command } = await run(approved);
+	let output = `${result.stdout}\n${result.stderr}`;
+
+	// `--allow-build` landed in pnpm 10.4. Older pnpm rejects the flag instead of
+	// installing, and asking it for its version first would cost a process on
+	// every run to spare one retry on almost none of them.
+	if (result.code !== 0 && /Unknown option.*allow-build/i.test(output)) {
+		({ result, command } = await run([]));
+		output = `${result.stdout}\n${result.stderr}`;
+	}
 
 	if (result.code !== 0) {
-		throw new CliError(`\`${manager} ${args.join(' ')}\` failed.`, {
+		// A blocked build script is reported by failing after the packages are
+		// already installed. Carrying on beats aborting: the install did its job,
+		// and stopping here would skip the rest of the setup over a decision that
+		// is the user's to make.
+		if (output.includes(IGNORED_BUILDS)) return { command, warnings: [APPROVE_BUILDS] };
+		throw new CliError(`\`${command}\` failed.`, {
 			hint: (result.stderr || result.stdout).trim() || 'Install the packages by hand.',
 		});
 	}
-	return `${manager} ${args.join(' ')}`;
+	return { command, warnings: [] };
 }

--- a/packages/cli/tests/init.test.js
+++ b/packages/cli/tests/init.test.js
@@ -323,6 +323,120 @@ describe('octane init', () => {
 		expect(ran[0]).toContain('add');
 	});
 
+	it('finishes the install when pnpm blocks a dependency build script', async () => {
+		// pnpm refuses to run a dependency's install script until the project
+		// records a decision, and since 11.0 it fails the command to say so, after
+		// the packages are already on disk. Treating that as a dead scaffold left
+		// the dev dependencies uninstalled, so the generated app had no bundler and
+		// `pnpm dev` died on `Cannot find package 'vite'`.
+		const { root } = fixture();
+		const exec = {
+			which: (/** @type {string} */ bin) => (bin === 'git' ? '/usr/bin/git' : `/usr/bin/${bin}`),
+			run: async (/** @type {string} */ file) =>
+				file === 'git'
+					? { code: 0, stdout: '', stderr: '' }
+					: {
+							code: 1,
+							stdout: '',
+							stderr: '[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.28.1',
+						},
+		};
+
+		const result = await runCli(
+			['init', '--cwd', root, '--mode', 'spa', '--yes', '--package-manager', 'pnpm', '--json'],
+			{ exec },
+		);
+
+		expect(result.exitCode).toBe(0);
+		// The dev dependencies are the half that used to be skipped.
+		expect(result.json().installed).toContain('vite');
+		// And the decision pnpm is waiting on is handed back to the user.
+		expect(result.json().manual.join('\n')).toContain('pnpm approve-builds');
+		// Said once, however many installs hit the same blocked script.
+		expect(
+			result.json().manual.filter((/** @type {string} */ l) => l.includes('approve-builds')).length,
+		).toBe(1);
+	});
+
+	it('still fails when the install itself fails', async () => {
+		// The tolerance above is for one specific pnpm exit, not for any non-zero
+		// code. A registry that refused the request leaves nothing installed, and
+		// carrying on would report a working scaffold that cannot run.
+		const { root } = fixture();
+		const exec = {
+			which: (/** @type {string} */ bin) => (bin === 'git' ? '/usr/bin/git' : `/usr/bin/${bin}`),
+			run: async (/** @type {string} */ file) =>
+				file === 'git'
+					? { code: 0, stdout: '', stderr: '' }
+					: { code: 1, stdout: '', stderr: 'ERR_PNPM_FETCH_404  GET https://registry...' },
+		};
+
+		const result = await runCli(
+			['init', '--cwd', root, '--mode', 'spa', '--yes', '--package-manager', 'pnpm'],
+			{ exec },
+		);
+
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain('failed');
+	});
+
+	it('tells pnpm to run the build script the generated app needs', async () => {
+		// esbuild's install script is how vite's platform binary arrives, so the
+		// app cannot start without it. Approving it up front is also what keeps
+		// pnpm from failing the install over an undecided script.
+		const { root } = fixture();
+		const recorder = recordingExec();
+
+		await runCli(['init', '--cwd', root, '--mode', 'spa', '--yes', '--package-manager', 'pnpm'], {
+			exec: recorder.exec,
+		});
+
+		const installs = recorder.args.filter((argv) => argv[0] === 'add');
+		expect(installs.length).toBeGreaterThan(0);
+		expect(installs.every((argv) => argv.includes('--allow-build=esbuild'))).toBe(true);
+	});
+
+	it('installs anyway when pnpm is too old to take the build approval', async () => {
+		// `--allow-build` landed in pnpm 10.4, and an older pnpm rejects the flag
+		// instead of installing. Retrying without it beats reporting a scaffold
+		// that never ran.
+		const { root } = fixture();
+		/** @type {string[][]} */
+		const ran = [];
+		const exec = {
+			which: (/** @type {string} */ bin) => (bin === 'git' ? '/usr/bin/git' : `/usr/bin/${bin}`),
+			run: async (/** @type {string} */ file, /** @type {string[]} */ argv) => {
+				if (file === 'git') return { code: 0, stdout: '', stderr: '' };
+				ran.push(argv);
+				return argv.some((arg) => arg.startsWith('--allow-build'))
+					? { code: 1, stdout: '', stderr: " ERROR  Unknown option: 'allow-build'" }
+					: { code: 0, stdout: '', stderr: '' };
+			},
+		};
+
+		const result = await runCli(
+			['init', '--cwd', root, '--mode', 'spa', '--yes', '--package-manager', 'pnpm', '--json'],
+			{ exec },
+		);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.json().installed).toContain('vite');
+		expect(ran.some((argv) => !argv.some((arg) => arg.startsWith('--allow-build')))).toBe(true);
+	});
+
+	it('keeps the pnpm build approval out of the other managers', async () => {
+		// `--allow-build` is pnpm's spelling. npm reads it as a package name and
+		// installs something nobody asked for.
+		const { root } = fixture();
+		const recorder = recordingExec();
+
+		await runCli(['init', '--cwd', root, '--mode', 'spa', '--yes', '--package-manager', 'npm'], {
+			exec: recorder.exec,
+		});
+
+		expect(recorder.args.flat().some((arg) => arg.startsWith('--allow-build'))).toBe(false);
+	});
+
 	it('rejects a package manager it cannot drive', async () => {
 		const { root } = fixture();
 


### PR DESCRIPTION
## Summary

`octane create` and `octane init` stopped partway through whenever pnpm blocked a dependency's install script, leaving an app that could not start. They now name the build script the generated app needs, and treat a blocked one they did not name as something to report rather than to die on.

## Why

pnpm refuses to run a dependency's install script until the project records a decision about it, and since 11.0 it reports that by failing the command, after the packages are already on disk. `installPackages` read any non-zero exit as a dead install and threw, which aborted the run between the two install steps: dependencies landed, dev dependencies never did.

Scaffolding a `fullstack` app with pnpm 11.20 hit it every time, because `esbuild` reaches that tree and carries an install script:

```
Install failed
`pnpm add octane @octanejs/vite-plugin` failed.
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.28.1
```

The resulting project had no `vite`, so `pnpm dev` died on `Cannot find package 'vite'`. Verified against pnpm 11.20.0 (fails) and 10.34.5 (warns, exits zero), so the abort is pnpm 11 and up. npm and yarn run install scripts by default; bun blocks them but exits zero, so neither breaks the scaffold today.

## Changes

- `installPackages` takes an `allowBuilds` list and passes `--allow-build=<pkg>` to pnpm. `init` passes `esbuild`, whose install script is how vite's platform binary arrives. Only that package is approved, so a build script arriving through some other dependency stays the user's decision.
- The flag goes to pnpm only. npm would read `--allow-build=esbuild` as a package name.
- pnpm older than 10.4 rejects the flag (`ERROR  Unknown option: 'allow-build'`, checked against pnpm 10.0.0). That one case retries without it, which costs a process only on the pnpm versions that need it, rather than probing `pnpm --version` on every run.
- `ERR_PNPM_IGNORED_BUILDS` no longer aborts. The packages installed, so setup continues and the pending decision is reported once under `Do this by hand` as a `pnpm approve-builds` step. Every other non-zero exit still throws.
- `installPackages` returns `{ command, warnings }`; `octane add` surfaces the warnings and approves no builds of its own.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` (1532 files, 16273 tests)
- [x] targeted tests: `vitest run --project cli`, 161 passing. Four new cases in `packages/cli/tests/init.test.js` cover finishing the install through a blocked build script, still failing on a real install failure, the pnpm-only flag, and the old-pnpm retry. With the `src/` changes stashed, the first and third fail; the rest are guards and pass either way.
- [x] end to end: the local CLI scaffolds a `fullstack` app with pnpm 11.20, reports `Installed 7 package(s)`, writes `allowBuilds: esbuild: true`, keeps every dev dependency, and `pnpm dev` answers HTTP 200. Before this change the same command stopped at `Install failed`.

## Risk / follow-ups

- The approved list is a constant in the CLI. A template that later needs another native toolchain has to add its package there, and until then that build script surfaces as the `approve-builds` note rather than running.
- bun blocks install scripts the same way and exits zero, so it never breaks the scaffold, but the generated app can still miss a binary. Teaching the templates `trustedDependencies` is left for a separate change.
- `pnpm typecheck:files packages/cli/tests/init.test.js` reports two fixture-typing errors at lines 164 and 201. They are present on `main` and untouched here; repo-wide `pnpm typecheck` is clean.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to CLI package-manager install wiring with targeted tests; real install failures still throw, and `--allow-build` is not sent to npm/yarn/bun.
> 
> **Overview**
> **pnpm 11+** can exit non-zero after packages are on disk when a dependency install script (e.g. **esbuild** for Vite) is not approved. `octane init` / `octane create` used to treat that as a fatal install and **stop before devDependencies**, leaving apps without Vite.
> 
> `installPackages` now passes **`--allow-build=esbuild` only for pnpm** (via `PNPM_ALLOWED_BUILDS`), **retries without the flag** when pnpm is too old to recognize it, and treats **`ERR_PNPM_IGNORED_BUILDS`** as a completed install with a **single** `pnpm approve-builds` note under **Do this by hand** instead of aborting. The helper returns **`{ command, warnings }`**; **init** dedupes warnings into `manual`, and **add** surfaces them the same way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 919d421a68b791e156708bd5080cfb5c31d7147e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->