### PR TITLE
fix: hmr - clear slots on function swap

### DIFF
--- a/.changeset/fix-compiled-hmr-refresh.md
+++ b/.changeset/fix-compiled-hmr-refresh.md
@@ -1,0 +1,11 @@
+---
+'octane': patch
+---
+
+Refresh compiled component output correctly after accepted hot updates.
+
+Hot refresh now discards the outgoing compiler-owned template and slot layout before mounting the
+new body, while retaining the component block and its hook state. Markerless output is promoted to
+a durable component range during refresh, so static markup edits and newly added component calls
+update immediately in both mounted and hydrated applications instead of leaving stale DOM or
+throwing during insertion.

--- a/.changeset/fix-compiled-hmr-refresh.md
+++ b/.changeset/fix-compiled-hmr-refresh.md
@@ -5,7 +5,8 @@
 Refresh compiled component output correctly after accepted hot updates.
 
 Hot refresh now discards the outgoing compiler-owned template and slot layout before mounting the
-new body, while retaining the component block and its hook state. Markerless output is promoted to
-a durable component range during refresh, so static markup edits and newly added component calls
-update immediately in both mounted and hydrated applications instead of leaving stale DOM or
-throwing during insertion.
+new body, while retaining the component block and its hook state. Exclusively owned markerless
+output is promoted to a durable component range during refresh, so static markup edits and newly
+added component calls update immediately in both mounted and hydrated applications instead of
+leaving stale DOM or throwing during insertion. When an enclosing control-flow branch shares that
+root as its boundary, the update safely falls back to a page reload instead.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -306,6 +306,18 @@ function ensureHooks(scope: Scope): Map<HookSlot, any> {
 	return scope.hooks ?? (scope.hooks = new Map());
 }
 
+// HMR retains hook cells, so tag their long-lived subscriptions/listeners with
+// the existing HMR symbol. A refresh can then run render-owned cleanups while
+// preserving these entries without adding a field to every Scope.
+function registerHookCleanup(scope: Scope, cleanup: Cleanup): void {
+	if (process.env.NODE_ENV !== 'production') {
+		if ((scope.block.body as any)[HMR] !== undefined) {
+			(cleanup as Cleanup & { [HMR]?: true })[HMR] = true;
+		}
+	}
+	(scope.cleanups ??= []).push(cleanup);
+}
+
 // Production helper/custom-hook ABI: reserve a disjoint numeric range for each
 // evaluated module that needs globally composable Symbol descriptions. Direct
 // sites in compiler-owned render Scopes use smaller local numbers and never call
@@ -4898,7 +4910,7 @@ function unmountScope(scope: Scope, detachDom: boolean = true): void {
 // recursive teardown. A child may have finished rendering and queued an attach
 // before a later sibling aborts its parent; that child's attach never commits,
 // so its recursive cleanup must not manufacture a matching detach.
-function unmountScopeChildrenAndSlots(scope: Scope, detachDom: boolean): void {
+function runScopeCleanups(scope: Scope): void {
 	const c = scope.cleanups;
 	if (c !== null)
 		for (let i = c.length - 1; i >= 0; i--) {
@@ -4912,6 +4924,17 @@ function unmountScopeChildrenAndSlots(scope: Scope, detachDom: boolean): void {
 				reportTeardownError(err);
 			}
 		}
+}
+
+function unmountScopeChildrenAndSlots(scope: Scope, detachDom: boolean): void {
+	runScopeCleanups(scope);
+	unmountScopeChildrenAndSlotsOnly(scope, detachDom);
+}
+
+// Split from the current scope's own cleanup list so HMR can preserve the
+// component's hook-owned subscriptions while fully deleting rendered children.
+// Ordinary unmount still calls both halves above in the established order.
+function unmountScopeChildrenAndSlotsOnly(scope: Scope, detachDom: boolean): void {
 	// Then recurse into child scopes (parent → child order).
 	const children = scope.children;
 	if (children !== null)
@@ -6147,7 +6170,7 @@ export function useEffectEvent<F extends (...args: any[]) => any>(fn: F, slot?: 
 		s = { impl: fn, active: true };
 		ensureHooks(scope).set(slot, s);
 		const cell = s;
-		(scope.cleanups ??= []).push(() => {
+		registerHookCleanup(scope, () => {
 			cell.active = false;
 		});
 	} else {
@@ -6354,6 +6377,115 @@ function scopedChildrenAsBody(props: { children: unknown }): ComponentBody {
  * `slots` indices the two dialects contend over.
  */
 const CHILDREN_DIALECT_SLOT = Symbol('octane.childrenDialect') as HookSlot;
+
+function hasResettableHmrRange(block: Block): boolean {
+	const start = (block as { startMarker?: Node | null }).startMarker;
+	const end = (block as { endMarker?: Node | null }).endMarker;
+	// componentSlotLite exposes only an insertion context, not an owned Block
+	// range. Decline that handoff so the bundler reloads instead of mutating the
+	// parent Block through the lite scope's compatibility cast.
+	if (start === undefined || end === undefined) return false;
+	if (start === null || end === null) {
+		return (
+			start === null && end === null && (block.kind === 'root' || block.exclusiveMarkers === true)
+		);
+	}
+	if (start !== end) {
+		return start.parentNode === block.parentNode && end.parentNode === block.parentNode;
+	}
+	return start.parentNode === block.parentNode;
+}
+
+function promoteHmrBlockRange(block: Block): void {
+	const root = block.startMarker;
+	if (root === null || root !== block.endMarker) return;
+	const parent = block.parentNode;
+	const rangeStart = document.createComment('hmr');
+	const rangeEnd = document.createComment('/hmr');
+	parent.insertBefore(rangeStart, root);
+	parent.insertBefore(rangeEnd, root.nextSibling);
+	block.startMarker = rangeStart;
+	block.endMarker = rangeEnd;
+	block.exclusiveMarkers = false;
+}
+
+/**
+ * Rebuild one hot component's compiled output without replacing its Block.
+ *
+ * Compiler bodies use `slots[0]` as their mount/update discriminator and cache
+ * the exact template/binding layout in that scope. A newly compiled body cannot
+ * safely read the old layout: static edits would never touch the DOM, while an
+ * added binding/component can read a bag field that did not exist. Hot refresh
+ * therefore tears down the rendered structure and hands the new body an empty
+ * slot array, while retaining the Block and its Symbol.for-keyed hook cells.
+ *
+ * Hook-owned subscriptions stay registered; render-owned cleanup entries are
+ * fired because their refs/head/fragment/host state belongs to the outgoing
+ * DOM. Effects and memo callbacks have their deps invalidated so edited
+ * closures publish on the refresh even when their authored dependency arrays
+ * are unchanged. This is called only from HMR.update(), never a normal render.
+ */
+function resetHmrBlock(block: Block): void {
+	if (TEARDOWN_DEPTH === 0) {
+		TEARDOWN_HANDLER = findTryHandler(block.parentBlock) ?? rendererRegionTryHandler(block);
+	}
+	TEARDOWN_DEPTH++;
+	let abortedRefs: SuspenseRefEntry[] | null = null;
+	if (!block.mounted) {
+		abortedRefs = [];
+		collectVisibleSubtreeRefs(block, abortedRefs);
+	}
+	try {
+		withRefDetachSuppression(abortedRefs, () => {
+			if (block.deoptNode !== null) detachDeoptTreeRefs(block.deoptNode, null);
+			const cleanups = block.cleanups;
+			let preserved: Cleanup[] | null = null;
+			if (cleanups !== null) {
+				for (let i = cleanups.length - 1; i >= 0; i--) {
+					const cleanup = cleanups[i] as Cleanup & { [HMR]?: true };
+					if (cleanup[HMR] === true) continue;
+					try {
+						runEffectLifecycleCallback(cleanup);
+					} catch (err) {
+						reportTeardownError(err);
+					}
+				}
+				for (let i = 0; i < cleanups.length; i++) {
+					const cleanup = cleanups[i] as Cleanup & { [HMR]?: true };
+					if (cleanup[HMR] === true) (preserved ??= []).push(cleanup);
+				}
+			}
+
+			unmountScopeChildrenAndSlotsOnly(block, true);
+			removeRange(
+				block.startMarker !== null ? block.startMarker.nextSibling : block.parentNode.firstChild,
+				block.endMarker,
+			);
+
+			block.children = null;
+			block.cleanups = preserved;
+			block._slots = null;
+			block.refFields = null;
+			block.slots = [];
+			block.deoptNode = null;
+		});
+
+		const hooks = block.hooks;
+		if (hooks !== null) {
+			for (const value of hooks.values()) {
+				if (
+					value !== null &&
+					typeof value === 'object' &&
+					Object.prototype.hasOwnProperty.call(value, 'deps')
+				) {
+					value.deps = undefined;
+				}
+			}
+		}
+	} finally {
+		if (--TEARDOWN_DEPTH === 0) dispatchTeardownErrors();
+	}
+}
 
 /**
  * Tear down everything a scope rendered and hand it back empty, so a caller can re-render it from
@@ -18749,11 +18881,11 @@ export function memo<P>(
 //   2. Tracks every live Block currently using this wrapper in a plain (strong)
 //      Set, pruned lazily: disposed blocks are retained until the next
 //      `update()` call deletes them (dev-only, so retention is bounded by edit
-//      frequency). On `update(newFn)` we mutate each
-//      block's `body` to point at the new fn and re-render — hook state is
-//      preserved because the compiler emits `Symbol.for(stableId)` for hook
-//      slots (re-imports get the same Symbol identity, so the existing
-//      hooks Map continues to work).
+//      frequency). On `update(newFn)` we clear each block's compiler-owned
+//      template/slot state, point its `body` at the new fn, and re-render. Hook
+//      state is preserved because the Block stays live and the compiler emits
+//      `Symbol.for(stableId)` for hook slots (re-imports get the same Symbol
+//      identity, so the existing hooks Map continues to work).
 //   3. Marks the wrapper IDENTITY-stable: HMR wrappers `Foo` and `Foo` (post-
 //      reload) are the same wrapper, so `componentSlot`'s identity check
 //      (`comp !== state.currentComp`) doesn't tear down on every edit.
@@ -18789,14 +18921,25 @@ export function hmr<P>(fn: ComponentBody<P>): ComponentBody<P> {
 			// module instead of reusing a live scope with the incompatible layout.
 			if ((meta.fn as any).__octaneReturnedOutput !== (nextFn as any).__octaneReturnedOutput)
 				return false;
+			// A hot component may live in a single-element or inherited marker-elision
+			// regime. Reject only incoherent/detached ranges; the accepted path promotes
+			// a self-marked element to an HMR-owned comment range before removing it.
+			for (const b of meta.liveBlocks) {
+				if (b.disposed) {
+					meta.liveBlocks.delete(b);
+					continue;
+				}
+				if (!hasResettableHmrRange(b)) return false;
+			}
 			meta.fn = nextFn;
 			if (typeof __OCTANE_PROFILE_ENABLED__ !== 'undefined' && __OCTANE_PROFILE_ENABLED__)
 				__profileComponentSource(wrapper, meta.fn);
 			// Keep the forwarded fetch plan in sync with the swapped body.
 			(wrapper as any).__warm = (meta.fn as any).__warm;
-			// Mutate every live block's body in place and schedule a re-render.
-			// The hook map persists (stable Symbol.for-based keys), so useState/
-			// useEffect/etc. pick up their existing slots on the next render.
+			// Rebuild every live block's compiler-owned output, then schedule the new
+			// body. The Block + hook map persist (stable Symbol.for-based keys), while
+			// template/binding/component slots start from their mount path so arbitrary
+			// source edits cannot read the previous compilation's layout.
 			const it = meta.liveBlocks.values();
 			for (let r = it.next(); !r.done; r = it.next()) {
 				const b = r.value;
@@ -18807,6 +18950,8 @@ export function hmr<P>(fn: ComponentBody<P>): ComponentBody<P> {
 				b.body = wrapper as unknown as ComponentBody<any>;
 				if (typeof __OCTANE_PROFILE_ENABLED__ !== 'undefined' && __OCTANE_PROFILE_ENABLED__)
 					__profileSchedule(b, 'hmr');
+				promoteHmrBlockRange(b);
+				resetHmrBlock(b);
 				scheduleRender(b);
 			}
 			return true;
@@ -20646,7 +20791,7 @@ export function useTransition(
 			}
 		};
 		TRANSITION_LISTENERS.add(listener);
-		(scope.cleanups ??= []).push(() => TRANSITION_LISTENERS.delete(listener));
+		registerHookCleanup(scope, () => TRANSITION_LISTENERS.delete(listener));
 	}
 	return [s.isPending, s.start];
 }
@@ -20816,7 +20961,7 @@ export function useFormStatus(slot?: HookSlot): FormStatus {
 		s = { form: null, listener: null };
 		const slotRef = s;
 		ensureHooks(scope).set(slot, slotRef);
-		(scope.cleanups ??= []).push(() => {
+		registerHookCleanup(scope, () => {
 			if (slotRef.form && slotRef.listener)
 				FORM_STATUS_LISTENERS.get(slotRef.form)?.delete(slotRef.listener);
 		});
@@ -20938,7 +21083,7 @@ export function useOptimistic<S, V = S>(
 			if (TRANSITION_PENDING_COUNT === 0 && slotRef.armed) clear();
 		};
 		TRANSITION_LISTENERS.add(listener);
-		(scope.cleanups ??= []).push(() => TRANSITION_LISTENERS.delete(listener));
+		registerHookCleanup(scope, () => TRANSITION_LISTENERS.delete(listener));
 	}
 	s.updateFn = updateFn;
 	let optimistic = passthrough;

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -6393,6 +6393,11 @@ function hasResettableHmrRange(block: Block): boolean {
 	if (start !== end) {
 		return start.parentNode === block.parentNode && end.parentNode === block.parentNode;
 	}
+	// A sole-root control-flow or list-item ancestor can borrow this exact node.
+	// Promoting only the hot block would leave the borrowed boundary detached.
+	for (let parent = block.parentBlock; parent !== null; parent = parent.parentBlock) {
+		if (parent.startMarker === start && parent.endMarker === end) return false;
+	}
 	return start.parentNode === block.parentNode;
 }
 
@@ -18939,7 +18944,8 @@ export function hmr<P>(fn: ComponentBody<P>): ComponentBody<P> {
 			// Rebuild every live block's compiler-owned output, then schedule the new
 			// body. The Block + hook map persist (stable Symbol.for-based keys), while
 			// template/binding/component slots start from their mount path so arbitrary
-			// source edits cannot read the previous compilation's layout.
+			// source edits cannot read the previous compilation's layout. An exclusively
+			// owned self-marked root is promoted to a private range during the reset.
 			const it = meta.liveBlocks.values();
 			for (let r = it.next(); !r.done; r = it.next()) {
 				const b = r.value;

--- a/packages/octane/tests/hmr.test.ts
+++ b/packages/octane/tests/hmr.test.ts
@@ -1,13 +1,20 @@
 import { describe, it, expect } from 'vitest';
-import { hmr, HMR, useState, flushSync, type ComponentBody, type Scope } from '../src/index.js';
+import {
+	hmr,
+	HMR,
+	useState,
+	flushSync,
+	hydrateRoot,
+	type ComponentBody,
+	type Scope,
+} from '../src/index.js';
 import { mount } from './_helpers';
 
 /**
- * Direct runtime tests for the `hmr(...)` wrapper. We don't go through the
- * compiler emit here (the compiler's `import.meta.hot.accept` block needs
- * a real Vite dev server to fire); we exercise the wrapper itself by
- * calling `Foo[HMR].update(NewFoo)` manually, which is what the compiler-
- * emitted accept block does at dev time.
+ * Runtime tests for the `hmr(...)` wrapper. The focused unit cases use direct
+ * component bodies; the structural regressions evaluate real compiler output.
+ * In both cases we call `Foo[HMR].update(NewFoo)` manually, which is what the
+ * compiler-emitted accept block does after a dev server loads the new module.
  *
  * The component bodies here use the same `(props, scope, extra)` signature
  * the octane compiler emits. They follow the standard
@@ -32,6 +39,55 @@ function clearBlockRange(scope: Scope): void {
 	}
 }
 
+async function compileHmrComponent(
+	source: string,
+	exportName = 'App',
+	filename = '/src/App.tsrx',
+	modules: Record<string, Record<string, unknown>> = {},
+): Promise<ComponentBody<any>> {
+	const [{ compile }, runtime] = await Promise.all([
+		import('octane/compiler'),
+		import('../src/index.js'),
+	]);
+	const code = compile(source, filename, { hmr: 'webpack' }).code;
+	const transformed =
+		code
+			.replace(
+				/^import\s*\{([\s\S]*?)\}\s*from\s*(['"])octane\2;/m,
+				(_match: string, imports: string) => {
+					const properties = imports
+						.split(',')
+						.map((specifier) => specifier.trim().replace(/\s+as\s+/, ': '))
+						.join(', ');
+					return `const { ${properties} } = runtime;`;
+				},
+			)
+			.replace(
+				/^import\s*\{([\s\S]*?)\}\s*from\s*(['"])(\.\.?\/[^'"]+)\2;/gm,
+				(_match: string, imports: string, _quote: string, request: string) => {
+					const properties = imports
+						.split(',')
+						.map((specifier) => specifier.trim().replace(/\s+as\s+/, ': '))
+						.join(', ');
+					return `const { ${properties} } = modules[${JSON.stringify(request)}];`;
+				},
+			)
+			.replace(/\bexport let /g, 'let ')
+			.replaceAll('import.meta.webpackHot', 'hot') + `\nreturn ${exportName};`;
+	const hot = {
+		data: undefined,
+		dispose() {},
+		accept() {},
+		invalidate() {},
+	};
+	return Function(
+		'runtime',
+		'hot',
+		'modules',
+		transformed,
+	)(runtime, hot, modules) as ComponentBody<any>;
+}
+
 describe('hmr — runtime wrapper', () => {
 	it('renders the initial component body', () => {
 		const Foo = hmr(((_props: any, scope: Scope, _extra: any) => {
@@ -52,6 +108,21 @@ describe('hmr — runtime wrapper', () => {
 		expect(meta).toBeDefined();
 		expect(typeof meta.update).toBe('function');
 		expect(meta.liveBlocks instanceof Set).toBe(true);
+	});
+
+	it('declines a lite-scope handoff so the bundler can reload safely', () => {
+		const initialBody = (() => {}) as ComponentBody<any>;
+		const Foo = hmr(initialBody);
+		const parent = document.createElement('div');
+		const anchor = document.createComment('anchor');
+		parent.appendChild(anchor);
+		const liteScope = {
+			block: { parentNode: parent, endMarker: anchor, parentBlock: null },
+		} as unknown as Scope;
+		Foo({}, liteScope, undefined);
+
+		expect((Foo as any)[HMR].update(hmr((() => {}) as ComponentBody<any>))).toBe(false);
+		expect((Foo as any)[HMR].fn).toBe(initialBody);
 	});
 
 	it('update() swaps the body of live blocks + re-renders', () => {
@@ -84,6 +155,282 @@ describe('hmr — runtime wrapper', () => {
 		expect(r.find('.leaf').textContent).toBe('B');
 		expect(r.find('.leaf').classList.contains('v2')).toBe(true);
 
+		r.unmount();
+	});
+
+	it('replaces compiled static output while preserving hook state', async () => {
+		const initial = await compileHmrComponent(`
+			import { useState } from 'octane';
+			export function App(props) @{
+				const [count, setCount] = useState(0);
+				props.expose(setCount);
+				<main><p id="lede">before</p><output>{count as string}</output></main>
+			}
+		`);
+		const updated = await compileHmrComponent(`
+			import { useState } from 'octane';
+			export function App(props) @{
+				const [count, setCount] = useState(0);
+				props.expose(setCount);
+				<main><p id="lede">after</p><output>{count as string}</output></main>
+			}
+		`);
+		let setCount!: (value: number | ((current: number) => number)) => void;
+		const r = mount(initial, { expose: (setter: typeof setCount) => (setCount = setter) });
+		flushSync(() => setCount(7));
+
+		flushSync(() => {
+			expect((initial as any)[HMR].update(updated)).toBe(true);
+		});
+
+		expect(r.find('#lede').textContent).toBe('after');
+		expect(r.find('output').textContent).toBe('7');
+		r.unmount();
+	});
+
+	it('replaces compiled static output after hydration', async () => {
+		const initial = await compileHmrComponent(`
+			export function App() @{
+				<main><p id="lede">before</p></main>
+			}
+		`);
+		const updated = await compileHmrComponent(`
+			export function App() @{
+				<main><p id="lede">after</p></main>
+			}
+		`);
+		const container = document.createElement('div');
+		container.innerHTML = '<main><p id="lede">before</p></main>';
+		document.body.appendChild(container);
+		const adopted = container.firstElementChild;
+		const root = hydrateRoot(container, initial);
+		flushSync(() => {});
+		expect(container.firstElementChild).toBe(adopted);
+
+		flushSync(() => {
+			expect((initial as any)[HMR].update(updated)).toBe(true);
+		});
+
+		expect(container.querySelector('#lede')?.textContent).toBe('after');
+		root.unmount();
+		container.remove();
+	});
+
+	it('mounts a component call introduced by a compiled update', async () => {
+		const initial = await compileHmrComponent(`
+			export function App() @{
+				<main><h1>octane</h1></main>
+			}
+		`);
+		const updated = await compileHmrComponent(`
+			function Child() @{
+				<p id="child">CHILD ONE</p>
+			}
+			export function App() @{
+				<main><h1>octane</h1><Child /></main>
+			}
+		`);
+		const r = mount(initial);
+
+		expect(() => {
+			flushSync(() => {
+				expect((initial as any)[HMR].update(updated)).toBe(true);
+			});
+		}).not.toThrow();
+
+		expect(r.find('#child').textContent).toBe('CHILD ONE');
+		r.unmount();
+	});
+
+	it('refreshes a compiled child in place without duplicating its single root', async () => {
+		const initialChild = await compileHmrComponent(
+			`
+				import { useState } from 'octane';
+				export function Child(props) @{
+					const [count, setCount] = useState(0);
+					props.expose(setCount);
+					<p class="child">before:{count as string}</p>
+				}
+			`,
+			'Child',
+			'/src/Child.tsrx',
+		);
+		const updatedChild = await compileHmrComponent(
+			`
+				import { useState } from 'octane';
+				export function Child(props) @{
+					const [count, setCount] = useState(0);
+					props.expose(setCount);
+					<p class="child">after:{count as string}</p>
+				}
+			`,
+			'Child',
+			'/src/Child.tsrx',
+		);
+		const App = await compileHmrComponent(
+			`
+				import { Child } from './Child.tsrx';
+				export function App(props) @{
+					<main><Child expose={props.expose} /></main>
+				}
+			`,
+			'App',
+			'/src/App.tsrx',
+			{ './Child.tsrx': { Child: initialChild } },
+		);
+		let setCount!: (value: number | ((current: number) => number)) => void;
+		const r = mount(App, { expose: (setter: typeof setCount) => (setCount = setter) });
+		flushSync(() => setCount(3));
+
+		flushSync(() => {
+			expect((initialChild as any)[HMR].update(updatedChild)).toBe(true);
+		});
+
+		expect(r.findAll('.child')).toHaveLength(1);
+		expect(r.find('.child').textContent).toBe('after:3');
+		r.unmount();
+	});
+
+	it('refreshes a compiled child that borrows the root container range', async () => {
+		const initialChild = await compileHmrComponent(
+			`
+				import { useState } from 'octane';
+				export function Child(props) @{
+					const [count, setCount] = useState(0);
+					props.expose(setCount);
+					<p>before:{count as string}</p>
+				}
+			`,
+			'Child',
+			'/src/Child.tsrx',
+		);
+		const updatedChild = await compileHmrComponent(
+			`
+				import { useState } from 'octane';
+				export function Child(props) @{
+					const [count, setCount] = useState(0);
+					props.expose(setCount);
+					<section>after:{count as string}</section>
+				}
+			`,
+			'Child',
+			'/src/Child.tsrx',
+		);
+		const App = await compileHmrComponent(
+			`
+				import { Child } from './Child.tsrx';
+				export function App(props) @{
+					<Child expose={props.expose} />
+				}
+			`,
+			'App',
+			'/src/App.tsrx',
+			{ './Child.tsrx': { Child: initialChild } },
+		);
+		let setCount!: (value: number | ((current: number) => number)) => void;
+		const r = mount(App, { expose: (setter: typeof setCount) => (setCount = setter) });
+		flushSync(() => setCount(4));
+		const [block] = (initialChild as any)[HMR].liveBlocks as Set<Scope['block']>;
+		expect(block.startMarker).toBeNull();
+		expect(block.endMarker).toBeNull();
+		expect(block.exclusiveMarkers).toBe(true);
+
+		flushSync(() => {
+			expect((initialChild as any)[HMR].update(updatedChild)).toBe(true);
+		});
+
+		expect(r.find('section').textContent).toBe('after:4');
+		r.unmount();
+	});
+
+	it('publishes edited memo and effect closures during refresh', async () => {
+		const initial = await compileHmrComponent(`
+			import { useLayoutEffect, useMemo } from 'octane';
+			export function App(props) @{
+				const label = useMemo(() => 'memo before', []);
+				useLayoutEffect(() => {
+					props.log('mount before');
+					return () => props.log('cleanup before');
+				}, []);
+				<p>{label as string}</p>
+			}
+		`);
+		const updated = await compileHmrComponent(`
+			import { useLayoutEffect, useMemo } from 'octane';
+			export function App(props) @{
+				const label = useMemo(() => 'memo after', []);
+				useLayoutEffect(() => {
+					props.log('mount after');
+					return () => props.log('cleanup after');
+				}, []);
+				<p>{label as string}</p>
+			}
+		`);
+		const log: string[] = [];
+		const r = mount(initial, { log: (entry: string) => log.push(entry) });
+		expect(log.splice(0)).toEqual(['mount before']);
+
+		flushSync(() => {
+			expect((initial as any)[HMR].update(updated)).toBe(true);
+		});
+
+		expect(r.find('p').textContent).toBe('memo after');
+		expect(log.splice(0)).toEqual(['cleanup before', 'mount after']);
+		r.unmount();
+	});
+
+	it('keeps hook-owned resources active while replacing render-owned output', async () => {
+		const initial = await compileHmrComponent(`
+			import { useEffectEvent } from 'octane';
+			export function App(props) @{
+				const record = useEffectEvent(() => props.log('before'));
+				<button onClick={record}>before</button>
+			}
+		`);
+		const updated = await compileHmrComponent(`
+			import { useEffectEvent } from 'octane';
+			export function App(props) @{
+				const record = useEffectEvent(() => props.log('after'));
+				<button onClick={record}>after</button>
+			}
+		`);
+		const log: string[] = [];
+		const r = mount(initial, { log: (entry: string) => log.push(entry) });
+		r.click('button');
+
+		flushSync(() => {
+			expect((initial as any)[HMR].update(updated)).toBe(true);
+		});
+		r.click('button');
+
+		expect(r.find('button').textContent).toBe('after');
+		expect(log).toEqual(['before', 'after']);
+		r.unmount();
+	});
+
+	it('detaches outgoing refs before attaching refreshed output', async () => {
+		const initial = await compileHmrComponent(`
+			export function App(props) @{
+				<div ref={props.track}>before</div>
+			}
+		`);
+		const updated = await compileHmrComponent(`
+			export function App(props) @{
+				<span ref={props.track}>after</span>
+			}
+		`);
+		const seen: Array<string | null> = [];
+		const r = mount(initial, {
+			track: (node: Element | null) => seen.push(node?.tagName ?? null),
+		});
+		expect(seen.splice(0)).toEqual(['DIV']);
+
+		flushSync(() => {
+			expect((initial as any)[HMR].update(updated)).toBe(true);
+		});
+
+		expect(r.find('span').textContent).toBe('after');
+		expect(seen.splice(0)).toEqual([null, 'SPAN']);
 		r.unmount();
 	});
 

--- a/packages/octane/tests/hmr.test.ts
+++ b/packages/octane/tests/hmr.test.ts
@@ -291,6 +291,79 @@ describe('hmr — runtime wrapper', () => {
 		r.unmount();
 	});
 
+	it.each([
+		{
+			construct: '@if branch',
+			setup: `const [value, setValue] = useState(true);`,
+			output: `@if (value) { <Child /> } @else { <span id="fallback">fallback</span> }`,
+			next: false,
+		},
+		{
+			construct: '@switch branch',
+			setup: `const [value, setValue] = useState('child');`,
+			output: `
+				@switch (value) {
+					@case 'child': { <Child /> }
+					@default: { <span id="fallback">fallback</span> }
+				}
+			`,
+			next: 'fallback',
+		},
+		{
+			construct: '@for item',
+			setup: `const [value, setValue] = useState([{ id: 'child' }]);`,
+			output: `
+				@for (const item of value; key item.id) { <Child /> }
+				@empty { <span id="fallback">fallback</span> }
+			`,
+			next: [],
+		},
+	])('falls back to reload when a hot child is the sole root of an $construct', async (test) => {
+		const initialChild = await compileHmrComponent(
+			`
+				export function Child() @{
+					<p id="child">before</p>
+				}
+			`,
+			'Child',
+			'/src/Child.tsrx',
+		);
+		const updatedChild = await compileHmrComponent(
+			`
+				export function Child() @{
+					<p id="child">after</p>
+				}
+			`,
+			'Child',
+			'/src/Child.tsrx',
+		);
+		const App = await compileHmrComponent(
+			`
+				import { useState } from 'octane';
+				import { Child } from './Child.tsrx';
+				export function App(props) @{
+					${test.setup}
+					props.expose(setValue);
+					<main>
+						${test.output}
+					</main>
+				}
+			`,
+			'App',
+			'/src/App.tsrx',
+			{ './Child.tsrx': { Child: initialChild } },
+		);
+		let setValue!: (value: unknown) => void;
+		const r = mount(App, { expose: (setter: typeof setValue) => (setValue = setter) });
+
+		expect((initialChild as any)[HMR].update(updatedChild)).toBe(false);
+		expect(r.find('#child').textContent).toBe('before');
+		expect(() => flushSync(() => setValue(test.next))).not.toThrow();
+		expect(r.find('#fallback').textContent).toBe('fallback');
+		expect(r.findAll('#child')).toHaveLength(0);
+		r.unmount();
+	});
+
 	it('refreshes a compiled child that borrows the root container range', async () => {
 		const initialChild = await compileHmrComponent(
 			`


### PR DESCRIPTION
closes #571 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core runtime teardown, DOM range management, and the dev HMR path; incorrect resets could corrupt trees, though unsafe boundaries decline updates and force reload.
> 
> **Overview**
> **Compiled hot refresh** no longer only swaps the component `body` and schedules a render. On `HMR.update()`, each live block is checked for a **resettable DOM range** (`hasResettableHmrRange`); unsafe cases (lite scopes, borrowed control-flow roots, etc.) return `false` so the bundler can full-reload.
> 
> When accepted, the runtime **promotes** markerless exclusive roots to an HMR comment range, then **`resetHmrBlock`**: runs render-owned cleanups (refs, fragments), unmounts children/slots without wiping hook-tagged cleanups (`registerHookCleanup` + `[HMR]` on listener teardowns), removes the old DOM range, and clears `slots` / `_slots` / child state so the new compilation mounts from a fresh layout. **Hook maps stay** on the same `Block`; effect/memo **`deps` are cleared** so edited closures run after refresh.
> 
> Teardown is refactored so **`runScopeCleanups`** is separate from **`unmountScopeChildrenAndSlotsOnly`**, which HMR uses to preserve hook subscriptions while replacing rendered output.
> 
> Tests add **`compileHmrComponent`** regressions for static markup, hydration, new child calls, control-flow reload fallback, memo/effect/ref refresh, and hook preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 335a490f3b6882d625a9c2cae0d06e9715544423. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->