### PR TITLE
fix(lynx-examples): align swiper snap duration with the final tutorial variant (300ms)

### DIFF
--- a/packages/rspeedy-plugin-octane/examples/swiper/src/App.lynx.tsrx
+++ b/packages/rspeedy-plugin-octane/examples/swiper/src/App.lynx.tsrx
@@ -10,6 +10,6 @@ const easing = (x: number) => {
 
 export function App() @{
 	<Page>
-		<Swiper data={picsArr} easing={easing} />
+		<Swiper data={picsArr} duration={300} easing={easing} />
 	</Page>
 }

--- a/packages/rspeedy-plugin-octane/examples/swiper/src/Swiper.lynx.tsrx
+++ b/packages/rspeedy-plugin-octane/examples/swiper/src/Swiper.lynx.tsrx
@@ -36,10 +36,12 @@ const publishIndexUpdate = (index: number) => {
 export function Swiper({
 	data,
 	itemWidth = SystemInfo.pixelWidth / SystemInfo.pixelRatio,
+	duration,
 	easing,
 }: {
 	data: string[];
 	itemWidth?: number;
+	duration?: number;
 	easing?: EasingFunction;
 }) @{
 	const [current, setCurrent] = useState(0);
@@ -102,7 +104,7 @@ export function Swiper({
 		cancelAnimate();
 		const from = currentOffsetRef.current;
 		const to = calcNearestPage(from);
-		const duration = 3000;
+		const snapDuration = duration ?? 3000;
 		const ease = easing ?? easings.easeInOutQuad;
 
 		let startTs = 0;
@@ -112,8 +114,8 @@ export function Swiper({
 				startTs = Number(ts);
 			}
 			// make sure progress can reach 100%
-			if (ts - startTs <= duration + 100) {
-				const progress = Math.max(Math.min(((ts - startTs) * 100) / duration, 100), 0) / 100;
+			if (ts - startTs <= snapDuration + 100) {
+				const progress = Math.max(Math.min(((ts - startTs) * 100) / snapDuration, 100), 0) / 100;
 				const easedProgress = ease(progress);
 				updateOffset(from + (to - from) * easedProgress);
 				rafId = requestAnimationFrame(step);


### PR DESCRIPTION
## Summary
- Align the swiper example's snap animation with the final tutorial variant: `Swiper` accepts a `duration` prop and the app passes `duration={300}` alongside the custom easing.

## Why
- The example was ported from the tutorial's `EasingDefault` teaching step, whose `animate()` falls back to a 3000 ms duration so readers can see the easing curve. The finished variant in `lynx-examples/examples/swiper` (`src/Swiper/App.tsx`) passes `duration={300}` and `main-thread:easing` explicitly — the 3 s snap in our port was tutorial-demo pacing, not the intended interaction feel (reported by a user testing on Explorer).

## Changes
- `Swiper.lynx.tsrx`: `duration?: number` prop, threaded into the main-thread snap loop (`snapDuration = duration ?? 3000` keeps the tutorial default when unset).
- `App.lynx.tsrx`: passes `duration={300}`, matching the upstream final variant.

## Validation
- [x] `pnpm typecheck:files` (tsrx-tsc over the two changed files)
- [x] `pnpm format:files:check`
- [x] `rspeedy build --root examples/swiper`
- [x] `pnpm sync` — no generated changes

## Risk / follow-ups
- Example-only change; the `duration` capture is a plain number, well inside the data-only thread-function contract.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only UI timing change; `duration` is a plain number passed into existing main-thread animation logic.
> 
> **Overview**
> The Octane swiper example no longer hard-codes a **3s** snap animation. **`Swiper`** now accepts an optional **`duration`** prop and drives the main-thread snap loop via **`snapDuration = duration ?? 3000`** (tutorial-style default when omitted). **`App`** passes **`duration={300}`** so the demo matches the finished **`lynx-examples`** swiper interaction instead of the slow tutorial easing step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 463d22968424cc2ad4c7dd9d520aa50613f663e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->