### PR TITLE
fix: Suspense content hidden when hydration resumes inside a hidden Activity

### DIFF
--- a/.changeset/activity-hydration-resume-rehide.md
+++ b/.changeset/activity-hydration-resume-rehide.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Keep freshly mounted Suspense content hidden when hydration resumes inside a hidden Activity.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -20083,7 +20083,7 @@ function commitResume(state: TrySlot): void {
 
 function commitResumeInner(state: TrySlot): void {
 	if (state.parentBlock.disposed) return;
-	const hiddenActivity = findHiddenActivity(state.tryBlock);
+	const hiddenActivity = findHiddenActivity(state.parentBlock);
 	const wasHeld = state.transitionHeld;
 	if (wasHeld) state.transitionHeld = false;
 	// Leave the coordination sets — this boundary is committing now (a re-suspend

--- a/packages/octane/tests/hydration/_fixtures/activity.tsrx
+++ b/packages/octane/tests/hydration/_fixtures/activity.tsrx
@@ -1,4 +1,4 @@
-import { Activity, useEffect, useId, useState } from 'octane';
+import { Activity, use, useEffect, useId, useState } from 'octane';
 
 function StatefulChild(props) @{
 	const [count, setCount] = useState(0);
@@ -46,4 +46,18 @@ export function ActivityIdHydration() @{
 		</Activity>
 		<IdChild className="visible-id" />
 	</div>
+}
+
+export function ActivitySuspenseHydration(props) @{
+	<section id="activity-suspense-host">
+		<Activity mode={props.mode}>
+			@try {
+				const value =
+					props.suspend ? use(props.promise) : 'server';
+				<span id="activity-resumed-content">{value as string}</span>
+			} @pending {
+				<span id="activity-resume-pending">{'loading'}</span>
+			}
+		</Activity>
+	</section>
 }

--- a/packages/octane/tests/hydration/activity-hydrate.test.ts
+++ b/packages/octane/tests/hydration/activity-hydrate.test.ts
@@ -8,6 +8,7 @@ import * as ServerRT from 'octane/server';
 import {
 	ActivityHydration,
 	ActivityIdHydration,
+	ActivitySuspenseHydration,
 	NestedActivityHydration,
 } from './_fixtures/activity.tsrx';
 
@@ -150,6 +151,48 @@ describe('hydrateRoot — <Activity>', () => {
 		expect(visible.id).toBe(serverId);
 		expect(hidden.id).not.toBe(serverId);
 		expect(hidden.style.display).toBe('none');
+		root.unmount();
+	});
+
+	it('re-hides try content freshly mounted by a hydration resume inside a hidden Activity', async () => {
+		const { html } = ServerRT.renderToString(server.ActivitySuspenseHydration, {
+			mode: 'visible',
+			suspend: false,
+			promise: Promise.resolve('unused'),
+		});
+		container.innerHTML = html;
+		const serverContent = container.querySelector('#activity-resumed-content');
+		expect(serverContent?.textContent).toBe('server');
+
+		let resolve!: (value: string) => void;
+		const promise = new Promise<string>((done) => (resolve = done));
+		const root = hydrateRoot(container, ActivitySuspenseHydration, {
+			mode: 'hidden',
+			suspend: true,
+			promise,
+		});
+		flushSync(() => {});
+
+		const pending = container.querySelector('#activity-resume-pending') as HTMLElement;
+		expect(container.querySelector('#activity-resumed-content')).toBeNull();
+		expect(pending.style.display).toBe('none');
+		resolve('client');
+		await Promise.resolve();
+		flushSync(() => {});
+
+		const resumed = container.querySelector('#activity-resumed-content') as HTMLElement;
+		expect(resumed).not.toBe(serverContent);
+		expect(resumed.textContent).toBe('client');
+		expect(resumed.style.display).toBe('none');
+
+		root.render(ActivitySuspenseHydration, {
+			mode: 'visible',
+			suspend: true,
+			promise,
+		});
+		flushSync(() => {});
+		expect(container.querySelector('#activity-resumed-content')).toBe(resumed);
+		expect(resumed.style.display).toBe('');
 		root.unmount();
 	});
 });


### PR DESCRIPTION
based on the feedback received on a closed pr: https://github.com/octanejs/octane/pull/581#discussion_r3724758302

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Suspense resume commit and Activity hide logic in the runtime; scope is a one-line ancestry fix plus targeted hydration coverage.
> 
> **Overview**
> Fixes a hydration bug where **Suspense `@try` content mounted on resume stayed visible** when it lived inside a **hidden `<Activity>`**.
> 
> In `commitResumeInner`, hidden-Activity detection now walks from **`state.parentBlock`** instead of **`state.tryBlock`**, so the enclosing hidden Activity is found on the Suspense boundary’s parent chain and **`rehideActivityAfterDescendantRender`** runs after resume commit.
> 
> Adds **`ActivitySuspenseHydration`** fixture and a hydration test that server-renders resolved try content, hydrates with hidden Activity + suspended client promise, asserts pending/resumed nodes stay `display: none`, then verifies visibility when Activity becomes visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a14aa6a8e4aa1c10cda5a9536c6e3454003ae591. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->