### PR TITLE
fix(rspeedy-plugin): render the first screen immediately on Lynx for Web

### DIFF
--- a/.changeset/lynx-web-immediate-first-screen.md
+++ b/.changeset/lynx-web-immediate-first-screen.md
@@ -1,0 +1,9 @@
+---
+'@octanejs/rspeedy-plugin': patch
+---
+
+Render the first screen immediately on Lynx for Web instead of deferring it to the engine.
+
+The generated main-thread entry hardcoded `firstScreenRender: 'engine'` for every platform. `engine` mode exists for native, where the engine installs the decoded PageConfig on the ElementManager only after script evaluation (`DidVMExecute`), so elements created during evaluation bake unconfigured overflow defaults and clip (#419). Lynx for Web has neither problem: `@lynx-js/web-core` never dispatches `__RenderPage`, and its renderer has no config-gated overflow default. Deferring there only couples the first screen to the background readiness handshake for no benefit — and turns any handshake failure into a fully blank screen instead of a painted-but-not-yet-interactive one.
+
+The plugin now selects the mode per platform through a build-time define the entry reads: `engine` on native, `immediate` on web. On web the first screen paints during evaluation, decoupled from the handshake and more robust, with no visual change. Verified by mounting the swiper tutorial port through `@lynx-js/web-core` in Chromium: both modes render pixel-identically (no clipping, `overflow: visible`, same timing), so the switch is safe.

--- a/packages/rspeedy-plugin-octane/src/application.js
+++ b/packages/rspeedy-plugin-octane/src/application.js
@@ -19,6 +19,9 @@ const TRAILING_FILENAME_HASHES =
 	/((?:\.\[(?:fullhash|chunkhash|contenthash|hash)(?::[^\]]+)?\])+)$/;
 const MAIN_THREAD_SUFFIX = '__octane_main_thread';
 const MAIN_THREAD_ASSET = /main-thread(?:\.[A-Fa-f0-9]+)?\.js$/;
+// Build-time constant the generated main-thread entry reads to pick its
+// first-screen render mode per platform. See FirstScreenRenderModePlugin.
+const FIRST_SCREEN_RENDER_DEFINE = '__OCTANE_LYNX_FIRST_SCREEN_RENDER__';
 const ENTRY_METADATA_KEYS = new Set([
 	'asyncChunks',
 	'baseUri',
@@ -66,6 +69,34 @@ class MarkMainThreadAssetPlugin {
 				},
 			);
 		});
+	}
+}
+
+/**
+ * Inject the platform-selected first-screen render mode as a build-time constant
+ * the generated main-thread entry reads.
+ *
+ * `engine` defers the one-shot first screen to the engine's post-evaluation
+ * `__RenderPage` lifecycle, which native needs so elements are created after the
+ * decoded PageConfig reaches the ElementManager (otherwise they bake unconfigured
+ * overflow defaults and clip — see #419). Lynx for Web never dispatches
+ * `__RenderPage` and has no config-gated overflow default, so deferring there
+ * only couples the first screen to the background readiness handshake for no
+ * benefit; `immediate` paints during evaluation, decoupled and more robust.
+ */
+class FirstScreenRenderModePlugin {
+	constructor(mode) {
+		this.mode = mode;
+	}
+
+	apply(compiler) {
+		const DefinePlugin = compiler.webpack?.DefinePlugin;
+		if (typeof DefinePlugin !== 'function') {
+			throw new TypeError(
+				`${PLUGIN_NAME}: this Rspack compiler does not expose webpack.DefinePlugin.`,
+			);
+		}
+		new DefinePlugin({ [FIRST_SCREEN_RENDER_DEFINE]: JSON.stringify(this.mode) }).apply(compiler);
 	}
 }
 
@@ -321,6 +352,9 @@ export function applyLynxApplication(chain, context, rspeedyConfig, options) {
 		]);
 	}
 
+	chain
+		.plugin(`${PLUGIN_NAME}:first-screen-render`)
+		.use(FirstScreenRenderModePlugin, [kind === 'web' ? 'immediate' : 'engine']);
 	chain.plugin(`${PLUGIN_NAME}:mark-main-thread`).use(MarkMainThreadAssetPlugin);
 	if (kind === 'lynx') {
 		chain.plugin(`${PLUGIN_NAME}:runtime-wrapper`).use(RuntimeWrapperWebpackPlugin, [

--- a/packages/rspeedy-plugin-octane/src/main-thread-entry.js
+++ b/packages/rspeedy-plugin-octane/src/main-thread-entry.js
@@ -1,3 +1,4 @@
+/* global __OCTANE_LYNX_FIRST_SCREEN_RENDER__ */
 import { installLynxMainThread } from '@octanejs/lynx/main-thread';
 
 import { installMainThreadProcessData } from './main-thread-process-data.js';
@@ -9,5 +10,14 @@ installMainThreadProcessData();
 installLynxMainThread({
 	firstScreen: true,
 	firstScreenSync: 'manual',
-	firstScreenRender: 'engine',
+	// The plugin defines __OCTANE_LYNX_FIRST_SCREEN_RENDER__ per platform: 'engine'
+	// on native (defer to the engine's __RenderPage lifecycle so elements see the
+	// decoded PageConfig), 'immediate' on Lynx for Web (no __RenderPage, no
+	// config-gated overflow default, so paint during evaluation instead of
+	// coupling the first screen to the readiness handshake). Falls back to 'engine'
+	// if the entry is bundled without the define.
+	firstScreenRender:
+		typeof __OCTANE_LYNX_FIRST_SCREEN_RENDER__ === 'string'
+			? __OCTANE_LYNX_FIRST_SCREEN_RENDER__
+			: 'engine',
 });

--- a/packages/rspeedy-plugin-octane/tests/plugin.test.ts
+++ b/packages/rspeedy-plugin-octane/tests/plugin.test.ts
@@ -416,6 +416,24 @@ describe('@octanejs/rspeedy-plugin', () => {
 		);
 	});
 
+	it('selects the first-screen render mode per platform: engine on native, immediate on web', () => {
+		// Native must defer the first screen to __RenderPage so elements see the
+		// decoded PageConfig (#419). Lynx for Web never sends __RenderPage and has no
+		// config-gated overflow default, so deferring only couples the first screen
+		// to the readiness handshake for no benefit — it must paint immediately.
+		const nativeMode = applyPlugin(
+			undefined,
+			'lynx',
+			{},
+			{ app: ['./src/App.lynx.tsrx'] },
+		).plugins.get('@octanejs/rspeedy-plugin:first-screen-render')?.options[0];
+		const webMode = applyPlugin(undefined, 'web', {}, { app: ['./src/App.lynx.tsrx'] }).plugins.get(
+			'@octanejs/rspeedy-plugin:first-screen-render',
+		)?.options[0];
+		expect(nativeMode).toBe('engine');
+		expect(webMode).toBe('immediate');
+	});
+
 	it('removes hot-update entries when hmr is explicitly false in development', () => {
 		const state = applyPlugin(
 			{ hmr: false },


### PR DESCRIPTION
## Summary

- Select the first-screen render mode **per platform**: `engine` on native, `immediate` on **Lynx for Web**. The generated main-thread entry previously hardcoded `firstScreenRender: 'engine'` for every platform.

## Why

`engine` mode (added in #419) defers the one-shot first screen to the engine's `__RenderPage` lifecycle. Native needs that: it installs the decoded PageConfig on the ElementManager only *after* script evaluation (`DidVMExecute`), so elements created during evaluation bake unconfigured overflow defaults and clip (the swiper slides painting black on device).

Lynx for Web has neither condition: `@lynx-js/web-core` never dispatches `__RenderPage`, and its renderer has no config-gated overflow default. Deferring there only **couples the first screen to the background readiness handshake for no benefit** — and turns any handshake hiccup into a fully blank screen instead of a painted-but-not-yet-interactive one (which is exactly how the cross-realm handshake bug in #459 surfaced: engine-on-web went blank; immediate would still have painted).

## Changes

- `application.js`: a `FirstScreenRenderModePlugin` injects a build-time define (`__OCTANE_LYNX_FIRST_SCREEN_RENDER__`) per environment — `'engine'` for `lynx`, `'immediate'` for `web`.
- `main-thread-entry.js`: reads the define, falling back to `'engine'` if bundled without it.
- `plugin.test.ts`: asserts native resolves to `engine` and web to `immediate`.

## Validation

- [x] `pnpm typecheck` (scoped to changed files)
- [x] `pnpm format:check` (changed files)
- [x] targeted tests: `plugin.test.ts` — 19 passed, incl. the new per-platform assertion
- [x] **Manual browser check**: built the swiper tutorial port for web and mounted it through `@lynx-js/web-core` in Chromium (Playwright). `immediate` and `engine` render **pixel-identically** — full product image, `overflow: visible`, no clipping, 8 slides, same ~200ms time-to-first-paint, zero page errors. So the switch has no visual/perf downside on web and removes the handshake coupling.
- [ ] full `pnpm test` (ran the plugin project + scoped typecheck; not every project)

## Risk / follow-ups

- Behavior change is limited to the **web** environment's generated entry; native keeps `engine` (default fallback also `engine`). Existing native suites and #585's web smoke test are unaffected (a tap still updates state on web).
- The mode isn't yet a public `pluginOctane()` option; a downstream host with an unusual lifecycle still can't override it. Straightforward follow-up if wanted.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is scoped to the web environment’s generated main-thread entry; native and the engine fallback are unchanged.
> 
> **Overview**
> **Lynx for Web** no longer hardcodes deferred first-screen rendering (`engine`). The rspeedy plugin injects **`__OCTANE_LYNX_FIRST_SCREEN_RENDER__`** at build time: **`immediate`** for web environments, **`engine`** for native—matching why native still waits for `__RenderPage` / PageConfig (#419) while web has no equivalent lifecycle.
> 
> The generated **main-thread entry** reads that define (default **`engine`** if missing) instead of always passing `firstScreenRender: 'engine'`. On web, the first screen paints during script evaluation rather than waiting on the background readiness handshake, which avoids a fully blank screen when that handshake fails.
> 
> A **plugin test** asserts native resolves to `engine` and web to `immediate`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91a57e02419975683c814cd4abb8a2844eda2fed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->