### PR TITLE
ci: switch to vercel using preview branch

### DIFF
--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -1,73 +1,74 @@
 name: Vercel preview
 
-# A preview is a maintainer-requested snapshot, not a side effect of every
-# commit. Removing and reapplying `deploy-preview` runs this again for the pull
-# request's current head. Each Vercel project independently reuses a usable
-# deployment for that SHA or creates the missing preview.
+# Vercel's GitHub App understands Git refs, not pull request labels. A
+# maintainer-applied `deploy-preview` label publishes the pull request's current
+# head as a temporary branch in this repository. Vercel is configured to deploy
+# only that branch namespace and main, so the label is the authorization step.
 on:
   pull_request_target:
-    types: [labeled]
+    types: [labeled, unlabeled, closed]
 
 jobs:
   deploy:
     name: deploy website previews
-    if: github.event.label.name == 'deploy-preview'
-    # Keep concurrency below the label guard. Workflow-level concurrency also
-    # admits skipped jobs, so an unrelated label event could otherwise replace
-    # a pending preview run in GitHub's single pending slot.
+    if: github.event.action == 'closed' || github.event.label.name == 'deploy-preview'
+    # Keep unrelated labels out of the queue and serialize publication with
+    # cleanup for the same pull request.
     concurrency:
-      # Do not cancel a run after it has asked Vercel to build. A following run
-      # is serialized and will reuse the deployment if the SHA is still current.
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
       cancel-in-progress: false
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Pull requests are issues to GitHub's comment API. The workflow only reads
-    # PR state and writes its one marker-owned comment; it never reads or writes
-    # repository contents.
+    # `pull_request_target` loads this script from the trusted base branch. It
+    # never checks out or executes pull request code; contents:write only moves
+    # the one preview ref that asks the installed Vercel GitHub App to build.
     permissions:
+      contents: write
+      deployments: read
       issues: write
       pull-requests: read
 
     steps:
-      - name: Resolve or create Vercel previews
+      - name: Publish preview branch and report Vercel deployments
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
-          VERCEL_WEBSITE_PROJECT_ID: ${{ vars.VERCEL_WEBSITE_PROJECT_ID }}
-          VERCEL_MCP_PROJECT_ID: ${{ vars.VERCEL_MCP_PROJECT_ID }}
         with:
           script: |
             const LABEL = "deploy-preview";
+            const BRANCH_PREFIX = "deploy-preview-pr-";
             const COMMENT_MARKER = "<!-- octane-vercel-preview -->";
-            const ACTIVE_STATES = new Set(["READY", "BUILDING", "INITIALIZING", "QUEUED"]);
-            const TERMINAL_STATES = new Set(["READY", "ERROR", "CANCELED", "BLOCKED"]);
+            const POLL_INTERVAL_MS = 5000;
+            const POLL_TIMEOUT_MS = 12 * 60 * 1000;
+            const TERMINAL_STATES = new Set(["success", "failure", "error", "inactive"]);
             const projects = [
-              { label: "Website", id: process.env.VERCEL_WEBSITE_PROJECT_ID },
-              { label: "MCP website", id: process.env.VERCEL_MCP_PROJECT_ID },
+              { label: "Website", environment: "Preview – octane-website" },
+              { label: "MCP website", environment: "Preview – octane-website-mcp" },
             ];
-
-            const required = {
-              VERCEL_TOKEN: process.env.VERCEL_TOKEN,
-              VERCEL_ORG_ID: process.env.VERCEL_ORG_ID,
-              VERCEL_WEBSITE_PROJECT_ID: process.env.VERCEL_WEBSITE_PROJECT_ID,
-              VERCEL_MCP_PROJECT_ID: process.env.VERCEL_MCP_PROJECT_ID,
-            };
-            const missing = Object.entries(required)
-              .filter(([, value]) => !value)
-              .map(([name]) => name);
-            if (missing.length > 0) {
-              core.setFailed(`Missing GitHub Actions configuration: ${missing.join(", ")}`);
-              return;
-            }
-            core.setSecret(required.VERCEL_TOKEN);
 
             const { owner, repo } = context.repo;
             const number = context.payload.pull_request.number;
-            // The event payload may have waited behind another label run. The
-            // API response is the source of truth for the open PR, current
-            // label, and latest head SHA that the maintainer requested.
+            const branch = `${BRANCH_PREFIX}${number}`;
+            const ref = `heads/${branch}`;
+
+            const deletePreviewRef = async () => {
+              try {
+                await github.rest.git.deleteRef({ owner, repo, ref });
+                core.notice(`Deleted temporary Vercel preview branch ${branch}.`);
+              } catch (error) {
+                if (error.status === 404) {
+                  core.notice(`Temporary Vercel preview branch ${branch} is already absent.`);
+                  return;
+                }
+                throw error;
+              }
+            };
+
+            if (context.payload.action === "unlabeled" || context.payload.action === "closed") {
+              await deletePreviewRef();
+              return;
+            }
+
+            // The event may have waited behind another run. Read the live pull
+            // request so the ref always publishes the currently authorized SHA.
             const { data: pull } = await github.rest.pulls.get({
               owner,
               repo,
@@ -77,105 +78,41 @@ jobs:
               core.notice(`Skipping #${number}: ${LABEL} is no longer applied to an open pull request.`);
               return;
             }
-            if (!pull.head?.repo?.id || !pull.head.ref || !pull.head.sha) {
+            if (!pull.head?.sha) {
               core.setFailed(`Pull request #${number} has no deployable GitHub head.`);
               return;
             }
 
-            const teamId = required.VERCEL_ORG_ID;
-            const token = required.VERCEL_TOKEN;
-            const api = async (path, options = {}) => {
-              const response = await fetch(`https://api.vercel.com${path}`, {
-                ...options,
-                headers: {
-                  Accept: "application/json",
-                  Authorization: `Bearer ${token}`,
-                  ...(options.body ? { "Content-Type": "application/json" } : {}),
-                  ...options.headers,
-                },
-              });
-              if (!response.ok) {
-                const detail = (await response.text()).slice(0, 1000);
-                throw new Error(
-                  `Vercel ${options.method ?? "GET"} ${path} failed (${response.status})${detail ? `: ${detail}` : ""}`,
-                );
-              }
-              return response.json();
-            };
-            const stateOf = (deployment) => deployment.readyState ?? deployment.state ?? "QUEUED";
-            const deploymentIdOf = (deployment) => deployment.uid ?? deployment.id;
-            const deploymentUrlOf = (deployment) => {
-              if (!deployment.url) return null;
-              return deployment.url.startsWith("http") ? deployment.url : `https://${deployment.url}`;
-            };
+            let existingRef = null;
+            try {
+              const response = await github.rest.git.getRef({ owner, repo, ref });
+              existingRef = response.data;
+            } catch (error) {
+              if (error.status !== 404) throw error;
+            }
 
-            const resolveProject = async (project) => {
-              const query = new URLSearchParams({
-                projectId: project.id,
+            if (existingRef) {
+              if (existingRef.object.sha === pull.head.sha) {
+                core.notice(`${branch} already points at ${pull.head.sha}.`);
+              } else {
+                await github.rest.git.updateRef({
+                  owner,
+                  repo,
+                  ref,
+                  sha: pull.head.sha,
+                  force: true,
+                });
+                core.notice(`Updated ${branch} to ${pull.head.sha}.`);
+              }
+            } else {
+              await github.rest.git.createRef({
+                owner,
+                repo,
+                ref: `refs/${ref}`,
                 sha: pull.head.sha,
-                target: "preview",
-                limit: "20",
-                teamId,
               });
-              const listed = await api(`/v7/deployments?${query}`);
-              const deployments = listed.deployments ?? [];
-              const existing = deployments.find((deployment) =>
-                ACTIVE_STATES.has(stateOf(deployment)),
-              );
-              if (existing) {
-                return { ...project, deployment: existing, reused: true };
-              }
-
-              const projectInfo = await api(
-                `/v9/projects/${encodeURIComponent(project.id)}?${new URLSearchParams({ teamId })}`,
-              );
-              const createQuery = new URLSearchParams({ teamId });
-              // A previous terminal failure for this SHA must not win Vercel's
-              // normal deduplication. Successful and active deployments were
-              // returned above and are never forcibly rebuilt.
-              if (deployments.length > 0) createQuery.set("forceNew", "1");
-              const deployment = await api(`/v13/deployments?${createQuery}`, {
-                method: "POST",
-                body: JSON.stringify({
-                  name: projectInfo.name,
-                  project: project.id,
-                  gitSource: {
-                    type: "github",
-                    repoId: pull.head.repo.id,
-                    ref: pull.head.ref,
-                    sha: pull.head.sha,
-                  },
-                  meta: {
-                    githubCommitSha: pull.head.sha,
-                    githubCommitRef: pull.head.ref,
-                    githubCommitRepoId: String(pull.head.repo.id),
-                    githubPrId: String(number),
-                  },
-                }),
-              });
-              return { ...project, deployment, reused: false };
-            };
-
-            const commentBody = (results) => {
-              const rows = results.map((result) => {
-                if (result.error) {
-                  return `| ${result.label} | Request failed; see the workflow log | ❌ |`;
-                }
-                const state = stateOf(result.deployment);
-                const url = deploymentUrlOf(result.deployment);
-                const source = result.reused ? "reused" : "requested";
-                const preview = url ? `[Open preview](${url})` : "URL pending";
-                return `| ${result.label} | ${preview} | ${state} (${source}) |`;
-              });
-              return [
-                COMMENT_MARKER,
-                `Vercel previews for \`${pull.head.sha.slice(0, 7)}\`:`,
-                "",
-                "| Project | Preview | Status |",
-                "| --- | --- | --- |",
-                ...rows,
-              ].join("\n");
-            };
+              core.notice(`Created ${branch} at ${pull.head.sha}.`);
+            }
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner,
@@ -188,6 +125,24 @@ jobs:
                 candidate.user?.login === "github-actions[bot]" &&
                 candidate.body?.includes(COMMENT_MARKER),
             );
+
+            const commentBody = (results) => {
+              const rows = results.map((result) => {
+                const url = result.status?.environment_url ?? result.status?.target_url;
+                const preview = url ? `[Open preview](${url})` : "URL pending";
+                const state = result.status?.state ?? "queued";
+                return `| ${result.label} | ${preview} | ${state.toUpperCase()} |`;
+              });
+              return [
+                COMMENT_MARKER,
+                `Vercel previews for \`${pull.head.sha.slice(0, 7)}\` via \`${branch}\`:`,
+                "",
+                "| Project | Preview | Status |",
+                "| --- | --- | --- |",
+                ...rows,
+              ].join("\n");
+            };
+
             const writeComment = async (results) => {
               const body = commentBody(results);
               if (comment) {
@@ -209,55 +164,65 @@ jobs:
               }
             };
 
-            const resolved = await Promise.all(
-              projects.map(async (project) => {
-                try {
-                  return await resolveProject(project);
-                } catch (error) {
-                  core.warning(`${project.label}: ${error.message}`);
-                  return { ...project, error };
-                }
-              }),
-            );
-            // Publish URLs as soon as Vercel accepts the requests. A slow build
-            // therefore still leaves the requested preview discoverable.
-            await writeComment(resolved);
+            const waiting = projects.map((project) => ({ ...project, deployment: null, status: null }));
+            await writeComment(waiting);
 
-            const waitForTerminalState = async (result) => {
-              if (result.error || TERMINAL_STATES.has(stateOf(result.deployment))) return result;
-              const id = deploymentIdOf(result.deployment);
-              if (!id) {
-                return { ...result, error: new Error("Vercel returned a deployment without an ID.") };
-              }
-              const deadline = Date.now() + 12 * 60 * 1000;
-              while (Date.now() < deadline) {
-                await new Promise((resolve) => setTimeout(resolve, 5000));
-                try {
-                  result.deployment = await api(
-                    `/v13/deployments/${encodeURIComponent(id)}?${new URLSearchParams({ teamId })}`,
+            const readVercelDeployments = async () => {
+              const { data: deployments } = await github.rest.repos.listDeployments({
+                owner,
+                repo,
+                sha: pull.head.sha,
+                per_page: 100,
+              });
+              return Promise.all(
+                projects.map(async (project) => {
+                  const deployment = deployments.find(
+                    (candidate) =>
+                      candidate.environment === project.environment &&
+                      candidate.creator?.login === "vercel[bot]",
                   );
-                } catch (error) {
-                  return { ...result, error };
-                }
-                if (TERMINAL_STATES.has(stateOf(result.deployment))) return result;
-              }
-              return { ...result, error: new Error(`Timed out waiting for Vercel deployment ${id}.`) };
+                  if (!deployment) return { ...project, deployment: null, status: null };
+                  const { data: statuses } = await github.rest.repos.listDeploymentStatuses({
+                    owner,
+                    repo,
+                    deployment_id: deployment.id,
+                    per_page: 1,
+                  });
+                  return { ...project, deployment, status: statuses[0] ?? null };
+                }),
+              );
             };
 
-            const needsPolling = resolved.some(
-              (result) => !result.error && !TERMINAL_STATES.has(stateOf(result.deployment)),
-            );
-            const completed = await Promise.all(resolved.map(waitForTerminalState));
-            if (needsPolling) await writeComment(completed);
+            const deadline = Date.now() + POLL_TIMEOUT_MS;
+            let results = waiting;
+            while (Date.now() < deadline) {
+              try {
+                results = await readVercelDeployments();
+                if (
+                  results.every(
+                    (result) =>
+                      result.deployment &&
+                      result.status &&
+                      TERMINAL_STATES.has(result.status.state),
+                  )
+                ) {
+                  break;
+                }
+              } catch (error) {
+                core.warning(`Unable to read Vercel deployment status from GitHub: ${error.message}`);
+              }
+              await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+            }
 
-            const failures = completed.filter(
-              (result) => result.error || stateOf(result.deployment) !== "READY",
-            );
+            await writeComment(results);
+            const failures = results.filter((result) => result.status?.state !== "success");
             if (failures.length > 0) {
               core.setFailed(
                 failures
                   .map((result) =>
-                    `${result.label}: ${result.error?.message ?? stateOf(result.deployment)}`,
+                    result.deployment
+                      ? `${result.label}: ${result.status?.state ?? "no deployment status was reported"}`
+                      : `${result.label}: Vercel did not report a deployment for ${pull.head.sha}`,
                   )
                   .join("\n"),
               );

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -817,32 +817,84 @@ describe('Vercel preview workflow', () => {
 		},
 	};
 
-	function jsonResponse(body, status = 200) {
-		return {
-			ok: status >= 200 && status < 300,
-			status,
-			json: async () => structuredClone(body),
-			text: async () => JSON.stringify(body),
-		};
-	}
-
 	async function runPreview({
+		action = 'labeled',
+		labelName = action === 'closed' ? undefined : 'deploy-preview',
 		pullResponse = pull,
 		comments = [],
-		handleFetch = () => {
-			throw new Error('unexpected Vercel request');
-		},
+		existingRef = null,
+		deploymentSnapshots = [],
 	} = {}) {
-		const requests = [];
+		const gitCalls = [];
+		const deploymentQueries = [];
 		const writtenComments = [];
 		const warnings = [];
 		const failures = [];
 		const notices = [];
-		const secrets = [];
+		let currentRef = existingRef;
+		let activeSnapshot = [];
+		let deploymentRead = 0;
 		let nextCommentId = 900;
+		let now = 0;
 		const github = {
 			rest: {
 				pulls: { get: async () => ({ data: structuredClone(pullResponse) }) },
+				git: {
+					getRef: async (input) => {
+						gitCalls.push({ operation: 'get', ...input });
+						if (currentRef === null) {
+							throw Object.assign(new Error('missing ref'), { status: 404 });
+						}
+						return { data: { object: { sha: currentRef } } };
+					},
+					createRef: async (input) => {
+						gitCalls.push({ operation: 'create', ...input });
+						currentRef = input.sha;
+						return { data: { ref: input.ref, object: { sha: input.sha } } };
+					},
+					updateRef: async (input) => {
+						gitCalls.push({ operation: 'update', ...input });
+						currentRef = input.sha;
+						return { data: { ref: input.ref, object: { sha: input.sha } } };
+					},
+					deleteRef: async (input) => {
+						gitCalls.push({ operation: 'delete', ...input });
+						if (currentRef === null) {
+							throw Object.assign(new Error('missing ref'), { status: 404 });
+						}
+						currentRef = null;
+					},
+				},
+				repos: {
+					listDeployments: async (input) => {
+						deploymentQueries.push({ operation: 'deployments', ...input });
+						activeSnapshot =
+							deploymentSnapshots[
+								Math.min(deploymentRead++, Math.max(deploymentSnapshots.length - 1, 0))
+							] ?? [];
+						return {
+							data: activeSnapshot.map(({ state: _state, url: _url, ...deployment }) =>
+								structuredClone(deployment),
+							),
+						};
+					},
+					listDeploymentStatuses: async (input) => {
+						deploymentQueries.push({ operation: 'statuses', ...input });
+						const deployment = activeSnapshot.find(
+							(candidate) => candidate.id === input.deployment_id,
+						);
+						return {
+							data: deployment
+								? [
+										{
+											state: deployment.state,
+											environment_url: deployment.url,
+										},
+									]
+								: [],
+						};
+					},
+				},
 				issues: {
 					listComments: async () => undefined,
 					createComment: async ({ body }) => {
@@ -871,42 +923,65 @@ describe('Vercel preview workflow', () => {
 			'github',
 			'context',
 			'core',
-			'process',
-			'fetch',
+			'Date',
 			'setTimeout',
-			stepScript(vercelPreviewWorkflow, 'Resolve or create Vercel previews'),
+			stepScript(vercelPreviewWorkflow, 'Publish preview branch and report Vercel deployments'),
 		);
 		await execute(
 			github,
 			{
 				repo: { owner: 'octanejs', repo: 'octane' },
-				payload: { pull_request: { number: pullResponse.number } },
+				payload: {
+					action,
+					label: labelName ? { name: labelName } : undefined,
+					pull_request: { number: pullResponse.number },
+				},
 			},
 			{
 				notice: (message) => notices.push(message),
 				setFailed: (message) => failures.push(message),
-				setSecret: (value) => secrets.push(value),
 				warning: (message) => warnings.push(message),
 			},
-			{
-				env: {
-					VERCEL_TOKEN: 'vercel-token',
-					VERCEL_ORG_ID: 'team_octane',
-					VERCEL_WEBSITE_PROJECT_ID: 'prj_website',
-					VERCEL_MCP_PROJECT_ID: 'prj_mcp',
-				},
+			class extends Date {
+				static now() {
+					return now;
+				}
 			},
-			async (url, options = {}) => {
-				requests.push({ url, options });
-				return handleFetch(new URL(url), options, jsonResponse);
+			(callback, delay) => {
+				now += delay;
+				callback();
 			},
-			(callback) => callback(),
 		);
-		return { requests, writtenComments, warnings, failures, notices, secrets };
+		return {
+			currentRef,
+			deploymentQueries,
+			gitCalls,
+			writtenComments,
+			warnings,
+			failures,
+			notices,
+		};
 	}
 
-	test('reuses both projects at the current SHA and refreshes the existing PR link', async () => {
-		const { requests, writtenComments, failures, secrets } = await runPreview({
+	const successfulDeployments = [
+		{
+			id: 101,
+			environment: 'Preview – octane-website',
+			creator: { login: 'vercel[bot]' },
+			state: 'success',
+			url: 'https://website-preview.vercel.app',
+		},
+		{
+			id: 102,
+			environment: 'Preview – octane-website-mcp',
+			creator: { login: 'vercel[bot]' },
+			state: 'success',
+			url: 'https://mcp-preview.vercel.app',
+		},
+	];
+
+	test('publishes the authorized SHA and refreshes the existing PR comment from GitHub deployments', async () => {
+		const { deploymentQueries, gitCalls, writtenComments, failures } = await runPreview({
 			comments: [
 				{
 					id: 71,
@@ -914,137 +989,150 @@ describe('Vercel preview workflow', () => {
 					user: { login: 'github-actions[bot]' },
 				},
 			],
-			handleFetch(url, options, response) {
-				assert.equal(options.method, undefined);
-				assert.equal(url.pathname, '/v7/deployments');
-				assert.equal(url.searchParams.get('sha'), sha);
-				assert.equal(url.searchParams.get('target'), 'preview');
-				assert.equal(url.searchParams.get('teamId'), 'team_octane');
-				const project = url.searchParams.get('projectId');
-				return response({
-					deployments: [
-						{
-							uid: `dpl_${project}`,
-							url: `${project}.vercel.app`,
-							readyState: 'READY',
-						},
-					],
-				});
-			},
+			deploymentSnapshots: [[], successfulDeployments],
 		});
 
-		assert.equal(requests.length, 2);
-		assert.ok(requests.every((request) => request.options.method === undefined));
+		assert.deepEqual(
+			gitCalls.filter((call) => call.operation === 'create'),
+			[
+				{
+					operation: 'create',
+					owner: 'octanejs',
+					repo: 'octane',
+					ref: 'refs/heads/deploy-preview-pr-612',
+					sha,
+				},
+			],
+		);
+		assert.ok(
+			deploymentQueries
+				.filter((query) => query.operation === 'deployments')
+				.every((query) => query.sha === sha && query.per_page === 100),
+		);
 		assert.ok(writtenComments.every((comment) => comment.operation === 'update'));
 		assert.ok(writtenComments.every((comment) => comment.id === 71));
-		assert.match(writtenComments.at(-1).body, /Vercel previews for `aaaaaaa`/);
-		assert.match(writtenComments.at(-1).body, /https:\/\/prj_website\.vercel\.app/);
-		assert.match(writtenComments.at(-1).body, /https:\/\/prj_mcp\.vercel\.app/);
-		assert.match(writtenComments.at(-1).body, /READY \(reused\)/);
+		assert.match(writtenComments.at(-1).body, /via `deploy-preview-pr-612`/);
+		assert.match(writtenComments.at(-1).body, /https:\/\/website-preview\.vercel\.app/);
+		assert.match(writtenComments.at(-1).body, /https:\/\/mcp-preview\.vercel\.app/);
+		assert.match(writtenComments.at(-1).body, /SUCCESS/);
 		assert.deepEqual(failures, []);
-		assert.deepEqual(secrets, ['vercel-token']);
 	});
 
-	test('creates only a missing project from the pull request head and publishes its URL', async () => {
-		let polled = false;
-		const { requests, writtenComments, failures } = await runPreview({
-			handleFetch(url, options, response) {
-				if (url.pathname === '/v7/deployments') {
-					const project = url.searchParams.get('projectId');
-					return response({
-						deployments:
-							project === 'prj_website'
-								? [
-										{
-											uid: 'dpl_website',
-											url: 'website-existing.vercel.app',
-											readyState: 'READY',
-										},
-									]
-								: [],
-					});
-				}
-				if (url.pathname === '/v9/projects/prj_mcp') {
-					return response({ name: 'octane-mcp' });
-				}
-				if (url.pathname === '/v13/deployments' && options.method === 'POST') {
-					assert.equal(url.searchParams.has('forceNew'), false);
-					const body = JSON.parse(options.body);
-					assert.equal(body.name, 'octane-mcp');
-					assert.equal(body.project, 'prj_mcp');
-					assert.deepEqual(body.gitSource, {
-						type: 'github',
-						repoId: 12345,
-						ref: 'feature/preview-this',
-						sha,
-					});
-					assert.equal(body.target, undefined);
-					return response({
-						uid: 'dpl_mcp',
-						url: 'mcp-requested.vercel.app',
-						readyState: 'QUEUED',
-					});
-				}
-				if (url.pathname === '/v13/deployments/dpl_mcp') {
-					polled = true;
-					return response({
-						uid: 'dpl_mcp',
-						url: 'mcp-requested.vercel.app',
-						readyState: 'READY',
-					});
-				}
-				throw new Error(`unexpected Vercel request: ${url}`);
-			},
+	test('moves an existing preview branch to the latest authorized SHA', async () => {
+		const previousSha = 'b'.repeat(40);
+		const { currentRef, gitCalls, failures } = await runPreview({
+			existingRef: previousSha,
+			deploymentSnapshots: [successfulDeployments],
 		});
 
-		assert.equal(requests.filter((request) => request.options.method === 'POST').length, 1);
-		assert.equal(polled, true);
-		assert.equal(writtenComments[0].operation, 'create');
-		assert.ok(writtenComments.slice(1).every((comment) => comment.operation === 'update'));
-		assert.match(writtenComments.at(-1).body, /website-existing\.vercel\.app/);
-		assert.match(writtenComments.at(-1).body, /mcp-requested\.vercel\.app/);
-		assert.match(writtenComments.at(-1).body, /READY \(requested\)/);
+		assert.equal(currentRef, sha);
+		assert.deepEqual(
+			gitCalls.filter((call) => call.operation === 'update'),
+			[
+				{
+					operation: 'update',
+					owner: 'octanejs',
+					repo: 'octane',
+					ref: 'heads/deploy-preview-pr-612',
+					sha,
+					force: true,
+				},
+			],
+		);
 		assert.deepEqual(failures, []);
 	});
 
-	test('does nothing if the label was removed before a queued run starts', async () => {
-		const { requests, writtenComments, notices } = await runPreview({
+	test('does not publish a ref if the label was removed before a queued run starts', async () => {
+		const { deploymentQueries, gitCalls, writtenComments, notices } = await runPreview({
 			pullResponse: { ...pull, labels: [] },
 		});
 
-		assert.deepEqual(requests, []);
+		assert.deepEqual(gitCalls, []);
+		assert.deepEqual(deploymentQueries, []);
 		assert.deepEqual(writtenComments, []);
 		assert.match(notices.join('\n'), /deploy-preview is no longer applied/);
 	});
 
-	test('keeps unrelated label events out of the preview concurrency queue', () => {
-		assert.doesNotMatch(vercelPreviewWorkflow, /^concurrency:/m);
-		assert.match(
-			vercelPreviewWorkflow,
-			/jobs:\n {2}deploy:\n(?:.*\n)*? {4}if: github\.event\.label\.name == 'deploy-preview'\n(?:.*\n)*? {4}concurrency:\n {6}# Do not cancel/,
+	test('deletes the temporary branch when preview authorization is removed', async () => {
+		const { currentRef, deploymentQueries, gitCalls, writtenComments, failures } = await runPreview(
+			{ action: 'unlabeled', existingRef: sha },
 		);
-		assert.match(
-			vercelPreviewWorkflow,
-			/^ {6}group: \$\{\{ github\.workflow \}\}-\$\{\{ github\.event\.pull_request\.number \}\}$/m,
-		);
-		assert.match(vercelPreviewWorkflow, /^ {6}cancel-in-progress: false$/m);
+
+		assert.equal(currentRef, null);
+		assert.deepEqual(gitCalls, [
+			{
+				operation: 'delete',
+				owner: 'octanejs',
+				repo: 'octane',
+				ref: 'heads/deploy-preview-pr-612',
+			},
+		]);
+		assert.deepEqual(deploymentQueries, []);
+		assert.deepEqual(writtenComments, []);
+		assert.deepEqual(failures, []);
 	});
 
-	test('keeps production automatic and makes the privileged workflow API-only', () => {
+	test('treats cleanup after the pull request closes as idempotent', async () => {
+		const { gitCalls, failures, notices } = await runPreview({ action: 'closed' });
+
+		assert.equal(gitCalls.length, 1);
+		assert.equal(gitCalls[0].operation, 'delete');
+		assert.match(notices.join('\n'), /already absent/);
+		assert.deepEqual(failures, []);
+	});
+
+	test('reports a terminal Vercel failure on the pull request and workflow', async () => {
+		const failedDeployments = structuredClone(successfulDeployments);
+		failedDeployments[1].state = 'failure';
+		const { failures, writtenComments } = await runPreview({
+			deploymentSnapshots: [failedDeployments],
+		});
+
+		assert.match(failures.join('\n'), /MCP website: failure/);
+		assert.match(writtenComments.at(-1).body, /FAILURE/);
+	});
+
+	test('fails with a useful diagnostic when Vercel never reports either deployment', async () => {
+		const { failures, writtenComments } = await runPreview();
+
+		assert.match(failures.join('\n'), /Website: Vercel did not report a deployment/);
+		assert.match(failures.join('\n'), /MCP website: Vercel did not report a deployment/);
+		assert.match(writtenComments.at(-1).body, /URL pending/);
+	});
+
+	test('keeps production automatic and delegates labeled previews to the Vercel GitHub App', () => {
 		for (const config of [websiteVercelConfig, mcpVercelConfig]) {
 			assert.deepEqual(config.git.deploymentEnabled, {
 				'*': false,
 				'**': false,
 				main: true,
+				'deploy-preview-pr-*': true,
 			});
 		}
 
-		assert.match(vercelPreviewWorkflow, /on:\n {2}pull_request_target:\n {4}types: \[labeled\]/);
-		assert.match(vercelPreviewWorkflow, /if: github\.event\.label\.name == 'deploy-preview'/);
+		assert.match(
+			vercelPreviewWorkflow,
+			/on:\n {2}pull_request_target:\n {4}types: \[labeled, unlabeled, closed\]/,
+		);
+		assert.match(
+			vercelPreviewWorkflow,
+			/if: github\.event\.action == 'closed' \|\| github\.event\.label\.name == 'deploy-preview'/,
+		);
+		assert.match(vercelPreviewWorkflow, /^ {6}contents: write$/m);
+		assert.match(vercelPreviewWorkflow, /^ {6}deployments: read$/m);
 		assert.match(vercelPreviewWorkflow, /^ {6}issues: write$/m);
 		assert.match(vercelPreviewWorkflow, /^ {6}pull-requests: read$/m);
+		assert.match(
+			vercelPreviewWorkflow,
+			/^ {6}group: \$\{\{ github\.workflow \}\}-\$\{\{ github\.event\.pull_request\.number \}\}$/m,
+		);
+		assert.match(vercelPreviewWorkflow, /^ {6}cancel-in-progress: false$/m);
+		assert.match(vercelPreviewWorkflow, /BRANCH_PREFIX = "deploy-preview-pr-"/);
+		assert.match(vercelPreviewWorkflow, /github\.rest\.git\.createRef/);
+		assert.match(vercelPreviewWorkflow, /github\.rest\.repos\.listDeployments/);
 		assert.doesNotMatch(vercelPreviewWorkflow, /actions\/checkout/);
-		assert.doesNotMatch(vercelPreviewWorkflow, /^ {6}contents:/m);
+		assert.doesNotMatch(vercelPreviewWorkflow, /VERCEL_/);
+		assert.doesNotMatch(vercelPreviewWorkflow, /fetch\(/);
 		assert.doesNotMatch(vercelPreviewWorkflow, /^ {8}run:/m);
 	});
 });

--- a/website-mcp/vercel.json
+++ b/website-mcp/vercel.json
@@ -5,7 +5,8 @@
     "deploymentEnabled": {
       "*": false,
       "**": false,
-      "main": true
+      "main": true,
+      "deploy-preview-pr-*": true
     }
   }
 }

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -5,7 +5,8 @@
     "deploymentEnabled": {
       "*": false,
       "**": false,
-      "main": true
+      "main": true,
+      "deploy-preview-pr-*": true
     }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds `contents: write` on `pull_request_target` and changes how previews are authorized; scope is limited to one ref namespace and trusted base-branch script, but misconfiguration could affect preview deploy behavior.
> 
> **Overview**
> **Maintainer `deploy-preview` labels now publish the PR head to a temporary `deploy-preview-pr-<number>` branch** so the installed Vercel GitHub App builds previews, instead of the workflow calling the Vercel REST API with `VERCEL_TOKEN` and project IDs.
> 
> The workflow gains **`contents: write`** to create/update/delete that ref, runs on **unlabeled** and **closed** to tear the branch down, and **polls GitHub Deployments** from `vercel[bot]` (Website and MCP preview environments) to update the PR comment and fail the job on missing or failed deploys. **`website/vercel.json`** and **`website-mcp/vercel.json`** enable deployments only for **`main`** and **`deploy-preview-pr-*`**.
> 
> **`scripts/ci-workflow.test.mjs`** is updated to exercise git ref lifecycle, deployment polling, cleanup, and the new workflow contract (no `VERCEL_*`, no `fetch`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb6a689bbcab964eb1c6abb6a81b13d7e81403b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->