### PR TITLE
fix(lynx): keep main-thread flushes and list first screens working on Lynx for Web

### DIFF
--- a/.changeset/lynx-first-screen-declines-native-list.md
+++ b/.changeset/lynx-first-screen-declines-native-list.md
@@ -1,0 +1,41 @@
+---
+'@octanejs/lynx': patch
+---
+
+Decline a synchronous first screen holding a native `<list>` instead of faulting on it.
+
+A first screen containing a `<list>` was rendered in full, rejected at capture,
+torn back out, and reported as an uncaught host fault. The page still ended up
+correct, because the background root re-rendered it from scratch, so the visible
+cost was a main-thread render that was always discarded plus a crash-looking
+error — on exactly the app shape a fast first screen exists for. It reproduced on
+`examples/gallery`, a faithful port of the official Lynx Product Gallery tutorial,
+as `native list materializations cannot be captured as a first tree`.
+
+The guard itself was right. A native `<list>` does not own its rows: the platform
+materializes them through the `componentAtIndex`/`enqueueComponent` callbacks
+handed to `listPAPI.create`, and it owns the resulting cell state. A first tree is
+a clone-safe description the background *adopts*, so a list cannot cross that
+boundary — and skipping its children would not help, because the list node is
+itself the part that cannot be handed over.
+
+What was wrong is that this was classified as a fault. `captureLynxFirstTree` had
+one failure channel, so an unsupported composition and a broken host came out the
+same way, and an application using a documented element was told its host was
+broken. Capture now returns `null` for a well-formed tree the background cannot
+adopt, while every genuine capture fault still throws — a host whose
+`__GetElementUniqueID` breaks keeps failing exactly as before. On `null` the
+main-thread runtime retires the first screen the way an entry that never rendered
+one settles: the nodes come back out so the background does not render beneath a
+duplicate, readiness is announced immediately with the same `main-ready` signal,
+and no error is raised.
+
+The synchronous first screen is still unavailable for pages containing a `<list>`;
+this makes that outcome ordinary and quiet rather than a reported defect. Two
+things are deliberately left open. The render is still performed before the
+`<list>` is discovered, because nothing knows it is coming until the batch has
+been applied — avoiding that needs a static signal from the compiler, which would
+not cover dynamically composed trees and so would need this runtime behavior
+underneath it anyway. And portals reject capture through the same channel; they
+look like the same shape, but no reported case drove this change, so they were
+left throwing rather than reclassified on speculation.

--- a/.changeset/lynx-first-screen-declines-native-list.md
+++ b/.changeset/lynx-first-screen-declines-native-list.md
@@ -12,12 +12,25 @@ error — on exactly the app shape a fast first screen exists for. It reproduced
 `examples/gallery`, a faithful port of the official Lynx Product Gallery tutorial,
 as `native list materializations cannot be captured as a first tree`.
 
-The guard itself was right. A native `<list>` does not own its rows: the platform
-materializes them through the `componentAtIndex`/`enqueueComponent` callbacks
-handed to `listPAPI.create`, and it owns the resulting cell state. A first tree is
-a clone-safe description the background *adopts*, so a list cannot cross that
-boundary — and skipping its children would not help, because the list node is
-itself the part that cannot be handed over.
+The guard itself was right for the design we have. A native `<list>` does not own
+its rows: the platform materializes them through the
+`componentAtIndex`/`enqueueComponent` callbacks handed to `listPAPI.create`, and
+it owns the resulting cell state. Octane builds those callbacks as per-instance
+closures with no cross-thread handle space, so a first tree — a clone-safe
+description the background *adopts* — has nothing it can hand over, and skipping
+the list's children would not help because the list node is itself the
+unhandoverable part.
+
+That is a limit of this design, not an inherent one. ReactLynx's element-template
+runtime carries lists across the same boundary by never transferring the callbacks
+at all: its hydration payload strips `component-at-index`,
+`component-at-indexes`, `enqueue-component`, and `update-list-info`; the callbacks
+are installed once as stable identities that read mutable list state rather than
+being recreated per update; and what crosses is a serializable descriptor — the
+remaining attributes plus item metadata keyed by a stable id shared between the
+background command stream, the main-thread registry, and native's list callbacks.
+Adopting a list here would mean adopting that shape. Declining is the right
+behavior until then, not a permanent verdict.
 
 What was wrong is that this was classified as a fault. `captureLynxFirstTree` had
 one failure channel, so an unsupported composition and a broken host came out the

--- a/.changeset/lynx-first-screen-declines-native-list.md
+++ b/.changeset/lynx-first-screen-declines-native-list.md
@@ -44,11 +44,16 @@ duplicate, readiness is announced immediately with the same `main-ready` signal,
 and no error is raised.
 
 The synchronous first screen is still unavailable for pages containing a `<list>`;
-this makes that outcome ordinary and quiet rather than a reported defect. Two
-things are deliberately left open. The render is still performed before the
-`<list>` is discovered, because nothing knows it is coming until the batch has
-been applied — avoiding that needs a static signal from the compiler, which would
-not cover dynamically composed trees and so would need this runtime behavior
-underneath it anyway. And portals reject capture through the same channel; they
-look like the same shape, but no reported case drove this change, so they were
-left throwing rather than reclassified on speculation.
+this makes that outcome ordinary and quiet rather than a reported defect.
+
+One thing is deliberately left open. The first screen is still built and then torn
+back out, and that is avoidable: the batch is prepared before any of it is
+applied, and preparation already stages each node's type, so the decline could
+happen before a single element is created. Taking it there needs the prepared
+batch to publish what it staged, which is a wider change than this fix; until
+then a page with a `<list>` pays for a screen it never keeps.
+
+Portals reject capture through the same function and keep throwing. That is not a
+half-finished migration: the main renderer rejects a portal while rendering, so
+those guards are unreachable from the first-screen path and defend only a direct
+call, where a fault is the right report.

--- a/.changeset/lynx-main-thread-flush-reentrancy.md
+++ b/.changeset/lynx-main-thread-flush-reentrancy.md
@@ -1,0 +1,28 @@
+---
+'@octanejs/lynx': patch
+---
+
+Keep a `'main thread'` handler's `__FlushElementTree()` working on Lynx for Web.
+
+The documented Lynx main-thread scripting pattern is to write element styles in a
+`'main thread'` handler and publish them with `__FlushElementTree()`. On Lynx for
+Web that flush threw `recursive use of an object detected which would lead to
+unsafe aliasing in rust` on every event, and because the throw escaped through
+the host's own frames it surfaced as an uncaught page error rather than anything
+the application could catch. A handler bound to a per-frame event — a
+`main-thread:bindscroll` on an auto-scrolling `<list>`, say — produced hundreds
+of them in seconds.
+
+The cause is in `@lynx-js/web-core`, not in Octane: its wasm element context is
+still borrowed by `common_event_handler` when that calls `runWorklet`, so the
+`__FlushElementTree` it installed rejects the re-entrant call. Replacing Octane's
+`runWorklet` with a bare `() => __FlushElementTree()` reproduces it exactly, on
+both 0.22.2 and the current 0.23.1, so nothing about the framework on top
+changes the outcome.
+
+Octane owns the seam that runs the handler, so the main-thread runtime now takes
+the flush where such a host can accept it: the inline call is still attempted
+first, and only a host that rejects one moves that flush to the end of the
+dispatch, coalescing repeated requests into a single publish. Hosts that permit a
+re-entrant flush — every native Lynx runtime — keep their existing synchronous
+timing, and the element writes themselves were never affected.

--- a/packages/lynx/src/core/host-driver.ts
+++ b/packages/lynx/src/core/host-driver.ts
@@ -1942,8 +1942,16 @@ function firstTreeOwner<Node extends LynxElementRef>(
  * can retire an unadoptable first screen quietly and still surface a broken
  * host. A native `<list>` is the one such composition today: the platform
  * materializes its rows through the `componentAtIndex`/`enqueueComponent`
- * callbacks created for `listPAPI.create`, and it owns the resulting cell state,
- * so neither can cross to the background the way a described node can.
+ * callbacks created for `listPAPI.create`, and it owns the resulting cell state.
+ * Those callbacks are per-instance closures with no cross-thread handle space, so
+ * a described tree has nothing to hand over. That is a limit of this design, not
+ * an inherent one — a list can cross such a boundary when the callbacks stay
+ * host-local and only a descriptor keyed by a stable id travels.
+ *
+ * The portal guards below keep throwing rather than joining this channel because
+ * they are unreachable from the first-screen path: the main renderer rejects a
+ * portal while rendering, long before a host container exists. They defend only
+ * a direct call to this function, where a fault is the right report.
  */
 export function captureLynxFirstTree<Node extends LynxElementRef>(
 	container: LynxHostContainer<Node>,

--- a/packages/lynx/src/core/host-driver.ts
+++ b/packages/lynx/src/core/host-driver.ts
@@ -1935,11 +1935,20 @@ function firstTreeOwner<Node extends LynxElementRef>(
 /**
  * Freeze the accepted main-runtime tree into a clone-safe description while
  * retaining PAPI references in a single-consumer, main-local journal.
+ *
+ * Returns `null` when the tree is well-formed but holds a composition the
+ * background cannot adopt, which is a property of the rendered page rather than
+ * a defect in the host. Every genuine capture fault still throws, so a caller
+ * can retire an unadoptable first screen quietly and still surface a broken
+ * host. A native `<list>` is the one such composition today: the platform
+ * materializes its rows through the `componentAtIndex`/`enqueueComponent`
+ * callbacks created for `listPAPI.create`, and it owns the resulting cell state,
+ * so neither can cross to the background the way a described node can.
  */
 export function captureLynxFirstTree<Node extends LynxElementRef>(
 	container: LynxHostContainer<Node>,
 	options: CaptureLynxFirstTreeOptions = {},
-): LynxFirstTree<Node> {
+): LynxFirstTree<Node> | null {
 	const state = container[LYNX_HOST_STATE];
 	if (state.disposed || state.disposing || state.faulted || state.applying) {
 		throw hostError('first tree can only be captured from a stable accepted root.');
@@ -1953,9 +1962,7 @@ export function captureLynxFirstTree<Node extends LynxElementRef>(
 	) {
 		throw hostError('first-tree plan must be a non-empty string when provided.');
 	}
-	if (state.lists.size !== 0) {
-		throw hostError('native list materializations cannot be captured as a first tree.');
-	}
+	if (state.lists.size !== 0) return null;
 	if (state.portalChildren.size !== 0) {
 		throw hostError('portals cannot be captured before background adoption.');
 	}
@@ -1970,9 +1977,9 @@ export function captureLynxFirstTree<Node extends LynxElementRef>(
 		if (isPortalParent(record.parent)) {
 			throw hostError('portals cannot be captured before background adoption.');
 		}
-		if (record.type === 'list') {
-			throw hostError('native list hosts cannot be captured as a first tree.');
-		}
+		// A `<list>` whose native state was never materialized is still a list the
+		// background cannot adopt.
+		if (record.type === 'list') return null;
 		if (!state.ownedNodes.has(record.node)) {
 			throw hostError(`first-tree host ${id} is missing from the physical ownership journal.`);
 		}

--- a/packages/lynx/src/first-screen.ts
+++ b/packages/lynx/src/first-screen.ts
@@ -4,7 +4,12 @@ import type { LynxFirstScreenRenderResult } from './main-renderer.js';
 
 /** Main-thread root contract installed by the generated receiver entry. */
 export interface LynxFirstScreenHost {
-	/** Returns null when the receiver defers rendering to the engine lifecycle. */
+	/**
+	 * Returns null when no synchronous first screen was painted: either the
+	 * receiver deferred rendering to the engine lifecycle, or it declined a
+	 * rendered screen the background cannot adopt. Both mean the background owns
+	 * the page; neither reports a fault.
+	 */
 	render<Props>(
 		component: UniversalComponent<Props>,
 		props: Props,
@@ -41,6 +46,7 @@ function requireHost(): LynxFirstScreenHost {
 export interface LynxFirstScreenRoot {
 	readonly renderer: 'lynx';
 	readonly ready: Promise<void>;
+	/** Null when no synchronous first screen was painted; see {@link LynxFirstScreenHost.render}. */
 	render<Props>(component: LynxComponent<Props>, props?: Props): LynxFirstScreenRenderResult | null;
 	flushTransport(): Promise<void>;
 	unmount(): Promise<void>;

--- a/packages/lynx/src/main-thread.ts
+++ b/packages/lynx/src/main-thread.ts
@@ -1074,7 +1074,12 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 	});
 	const hostGlobals = rawTarget as Record<string, unknown>;
 	const previousRunWorklet = hostGlobals.runWorklet;
+	// Captured before the wrapper is installed, because installing it creates an
+	// own property either way. `papi` resolved the same entry earlier and holds it
+	// bound, so Octane's own commit flushes deliberately bypass this wrapper —
+	// they never run inside a host dispatch.
 	const hostFlush = hostGlobals.__FlushElementTree as (...values: unknown[]) => void;
+	const hostOwnsFlush = Object.prototype.hasOwnProperty.call(hostGlobals, '__FlushElementTree');
 
 	// A host may dispatch a `'main thread'` event handler from inside its own
 	// element-tree work rather than from a clean stack. Lynx for Web does: its
@@ -1082,18 +1087,20 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 	// `runWorklet`, so the host's own `__FlushElementTree` — the documented way a
 	// main-thread handler publishes its mutations — throws "recursive use of an
 	// object detected which would lead to unsafe aliasing in rust" for the whole
-	// life of the page. The mutations themselves land, because that host applies
-	// each element write eagerly; only the flush's own bookkeeping is lost, and
-	// the throw escapes through the host's frames as an uncaught error once per
-	// event.
+	// life of the page, and the throw escapes through the host's frames as an
+	// uncaught error once per event. Most of that host's element PAPIs take the
+	// same borrow and would fail the same way; only the ones backed by free wasm
+	// functions are unaffected.
 	//
-	// The flush is the one element PAPI whose effect survives being moved past
-	// the end of the dispatch, so take it there when the host cannot take it
-	// inline. The inline call is still attempted first, which leaves every host
-	// that permits a re-entrant flush on exactly its previous timing; only a host
-	// that rejects one latches into the deferred path. Deferred requests coalesce
-	// onto a single microtask, so a handler bound to a per-frame event flushes
-	// once per checkpoint instead of queueing one job per event.
+	// This wraps the flush alone, not because the others are safe, but because
+	// the flush is the only one whose effect survives being moved past the end of
+	// the dispatch — every other PAPI has a return value or an ordering the
+	// handler depends on. The inline call is still attempted first, which leaves
+	// every host that permits a re-entrant flush on exactly its previous timing;
+	// only a host that rejects one latches into the deferred path. A deferred
+	// request holds the latest arguments and publishes once per microtask
+	// checkpoint, so a handler bound to a per-frame event does not queue one job
+	// per event.
 	let hostDispatchDepth = 0;
 	let hostTakesInlineFlush = true;
 	let deferredFlush: readonly unknown[] | null = null;
@@ -1113,6 +1120,8 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 		}
 	};
 
+	// Last request wins: a second flush inside one checkpoint replaces the first
+	// rather than queueing behind it, so its `node`/`options` are what publish.
 	const deferHostFlush = (args: readonly unknown[]): void => {
 		const alreadyScheduled = deferredFlush !== null;
 		deferredFlush = args;
@@ -1151,7 +1160,10 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 		// A flush still owed to a torn-down page has nothing left to publish.
 		deferredFlush = null;
 		if (hostGlobals.__FlushElementTree === installedFlush) {
-			hostGlobals.__FlushElementTree = hostFlush;
+			// Restoring by assignment would leave a permanent own-property shadow on a
+			// target that only inherits the PAPI, which an explicit `target` may.
+			if (hostOwnsFlush) hostGlobals.__FlushElementTree = hostFlush;
+			else delete hostGlobals.__FlushElementTree;
 		}
 		if (hostGlobals.runWorklet !== installedRunWorklet) return;
 		if (previousRunWorklet === undefined) delete hostGlobals.runWorklet;
@@ -1309,6 +1321,32 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 			if (treeComplete && sourceComplete) return true;
 		}
 		return false;
+	};
+
+	/**
+	 * Take a rendered first screen back out and release the background, whether it
+	 * was declined as unadoptable or lost to a fault. Both outcomes retain the
+	 * source first so a throwing remove/flush stays retryable rather than leaking
+	 * an unreachable tree the background would then duplicate.
+	 */
+	const retireFirstScreen = (
+		source: LynxHostContainer<Node> | null,
+		settled: 'skipped' | 'failed',
+		reason: string,
+	): void => {
+		firstScreenState = 'cleanup-pending';
+		firstScreenSyncReady = true;
+		if (firstTree === null && source !== null) failedFirstScreenSource = source;
+		if (retryFirstScreenCleanup()) {
+			firstScreenState = settled;
+		} else {
+			report(
+				new Error(
+					`Octane Lynx withheld background readiness because ${reason} first-screen cleanup remains incomplete.`,
+				),
+			);
+		}
+		announceReady();
 	};
 
 	const forceCloseWorkletRuntime = (): void => {
@@ -1738,24 +1776,15 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 				// The page rendered correctly but holds a composition the background
 				// cannot adopt — today a native `<list>`, whose rows the platform
 				// materializes through main-local callbacks. That is a property of the
-				// page, not a broken host, so the first screen is retired the same way
-				// an entry that never rendered one settles: the nodes come back out so
-				// the background does not duplicate them, readiness is announced, and
-				// no error is raised against an application that is entitled to the
-				// element. `null` tells the caller its synchronous paint was declined.
-				failedFirstScreenSource = source;
-				firstScreenSyncReady = true;
-				if (disposeFailedFirstScreenSource()) {
-					firstScreenState = 'skipped';
-				} else {
-					firstScreenState = 'cleanup-pending';
-					report(
-						new Error(
-							'Octane Lynx withheld background readiness because unadoptable first-screen cleanup remains incomplete.',
-						),
-					);
-				}
-				announceReady();
+				// page, not a broken host, so it settles as `skipped` rather than
+				// `failed` and raises no error against an application that is entitled
+				// to the element. `null` tells the caller its paint was declined.
+				//
+				// The batch is built before any of this is applied, so a `<list>` is in
+				// principle knowable before the tree is created; declining that early
+				// would avoid building and tearing down a first screen that is never
+				// kept. That needs the prepared batch to publish what it stages.
+				retireFirstScreen(source, 'skipped', 'unadoptable');
 				return null;
 			}
 			firstTree = captured;
@@ -1764,24 +1793,7 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 			announceReady();
 			return result;
 		} catch (error) {
-			firstScreenState = 'cleanup-pending';
-			firstScreenSyncReady = true;
-			if (firstTree === null && source !== null) {
-				// Retain the only native ownership journal before cleanup. A throwing
-				// remove/flush must remain retryable rather than leaking an unreachable
-				// first tree and allowing the background root to duplicate it.
-				failedFirstScreenSource = source;
-			}
-			if (retryFirstScreenCleanup()) {
-				firstScreenState = 'failed';
-			} else {
-				report(
-					new Error(
-						'Octane Lynx withheld background readiness because failed first-screen cleanup remains incomplete.',
-					),
-				);
-			}
-			announceReady();
+			retireFirstScreen(source, 'failed', 'failed');
 			throw report(error, 'Octane Lynx could not render its synchronous first screen.');
 		} finally {
 			firstScreenRenderInProgress = false;

--- a/packages/lynx/src/main-thread.ts
+++ b/packages/lynx/src/main-thread.ts
@@ -567,7 +567,7 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 	let nextThreadCall = 1;
 	let uninstallWorkletRegistry: (() => void) | null = null;
 	let uninstallCallBridge: (() => void) | null = null;
-	let restoreRunWorklet: (() => void) | null = null;
+	let restoreHostHooks: (() => void) | null = null;
 	let worklets: LynxMainThreadWorkletRegistry;
 	let mainCallPublication: UniversalTransportIdentity | null = null;
 	let nativeDestroyListenerRegistered = false;
@@ -1072,16 +1072,90 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 			).promise;
 		},
 	});
-	const runWorkletTarget = rawTarget as Record<string, unknown>;
-	const previousRunWorklet = runWorkletTarget.runWorklet;
+	const hostGlobals = rawTarget as Record<string, unknown>;
+	const previousRunWorklet = hostGlobals.runWorklet;
+	const hostFlush = hostGlobals.__FlushElementTree as (...values: unknown[]) => void;
+
+	// A host may dispatch a `'main thread'` event handler from inside its own
+	// element-tree work rather than from a clean stack. Lynx for Web does: its
+	// wasm element context holds a live borrow across `common_event_handler` ->
+	// `runWorklet`, so the host's own `__FlushElementTree` — the documented way a
+	// main-thread handler publishes its mutations — throws "recursive use of an
+	// object detected which would lead to unsafe aliasing in rust" for the whole
+	// life of the page. The mutations themselves land, because that host applies
+	// each element write eagerly; only the flush's own bookkeeping is lost, and
+	// the throw escapes through the host's frames as an uncaught error once per
+	// event.
+	//
+	// The flush is the one element PAPI whose effect survives being moved past
+	// the end of the dispatch, so take it there when the host cannot take it
+	// inline. The inline call is still attempted first, which leaves every host
+	// that permits a re-entrant flush on exactly its previous timing; only a host
+	// that rejects one latches into the deferred path. Deferred requests coalesce
+	// onto a single microtask, so a handler bound to a per-frame event flushes
+	// once per checkpoint instead of queueing one job per event.
+	let hostDispatchDepth = 0;
+	let hostTakesInlineFlush = true;
+	let deferredFlush: readonly unknown[] | null = null;
+
+	const runHostFlush = (args: readonly unknown[]): void => {
+		hostFlush.apply(hostGlobals, args as unknown[]);
+	};
+
+	const drainDeferredFlush = (): void => {
+		const args = deferredFlush;
+		if (args === null) return;
+		deferredFlush = null;
+		try {
+			runHostFlush(args);
+		} catch (error) {
+			report(error, 'Octane Lynx could not flush the element tree after a main-thread event.');
+		}
+	};
+
+	const deferHostFlush = (args: readonly unknown[]): void => {
+		const alreadyScheduled = deferredFlush !== null;
+		deferredFlush = args;
+		if (!alreadyScheduled) void Promise.resolve().then(drainDeferredFlush);
+	};
+
+	const installedFlush = (...args: unknown[]): void => {
+		if (hostDispatchDepth === 0) {
+			runHostFlush(args);
+			return;
+		}
+		if (!hostTakesInlineFlush) {
+			deferHostFlush(args);
+			return;
+		}
+		try {
+			runHostFlush(args);
+		} catch {
+			hostTakesInlineFlush = false;
+			deferHostFlush(args);
+		}
+	};
+
 	const installedRunWorklet = (
 		descriptor: import('./core/worklets.js').LynxMainThreadWorkletDescriptor,
 		args?: readonly unknown[],
-	) => worklets.runWorklet(descriptor, args);
-	restoreRunWorklet = () => {
-		if (runWorkletTarget.runWorklet !== installedRunWorklet) return;
-		if (previousRunWorklet === undefined) delete runWorkletTarget.runWorklet;
-		else runWorkletTarget.runWorklet = previousRunWorklet;
+	) => {
+		hostDispatchDepth++;
+		try {
+			return worklets.runWorklet(descriptor, args);
+		} finally {
+			hostDispatchDepth--;
+		}
+	};
+	restoreHostHooks = () => {
+		// A flush still owed to a torn-down page has nothing left to publish.
+		deferredFlush = null;
+		if (hostGlobals.__FlushElementTree === installedFlush) {
+			hostGlobals.__FlushElementTree = hostFlush;
+		}
+		if (hostGlobals.runWorklet !== installedRunWorklet) return;
+		if (previousRunWorklet === undefined) delete hostGlobals.runWorklet;
+		else hostGlobals.runWorklet = previousRunWorklet;
 	};
 	try {
 		uninstallWorkletRegistry = installLynxMainThreadWorkletRegistry(worklets);
@@ -1100,10 +1174,11 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 				};
 			},
 		});
-		runWorkletTarget.runWorklet = installedRunWorklet;
+		hostGlobals.runWorklet = installedRunWorklet;
+		hostGlobals.__FlushElementTree = installedFlush;
 	} catch (error) {
-		restoreRunWorklet?.();
-		restoreRunWorklet = null;
+		restoreHostHooks?.();
+		restoreHostHooks = null;
 		uninstallCallBridge?.();
 		uninstallCallBridge = null;
 		uninstallWorkletRegistry?.();
@@ -1237,8 +1312,8 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 	};
 
 	const forceCloseWorkletRuntime = (): void => {
-		restoreRunWorklet?.();
-		restoreRunWorklet = null;
+		restoreHostHooks?.();
+		restoreHostHooks = null;
 		uninstallCallBridge?.();
 		uninstallCallBridge = null;
 		uninstallWorkletRegistry?.();
@@ -1637,7 +1712,7 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 	const renderFirstScreenNow = <Props>(
 		component: UniversalComponent<Props>,
 		props: Props,
-	): LynxFirstScreenRenderResult => {
+	): LynxFirstScreenRenderResult | null => {
 		if (closed) throw new Error('Octane Lynx first-screen root rendered after receiver close.');
 		if (firstScreenState !== 'open') {
 			throw new Error(
@@ -1658,7 +1733,32 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 			if (!prepared.mutationStarted) {
 				throw new Error('Octane Lynx first-screen host batch did not cross its apply boundary.');
 			}
-			firstTree = captureLynxFirstTree(source);
+			const captured = captureLynxFirstTree(source);
+			if (captured === null) {
+				// The page rendered correctly but holds a composition the background
+				// cannot adopt — today a native `<list>`, whose rows the platform
+				// materializes through main-local callbacks. That is a property of the
+				// page, not a broken host, so the first screen is retired the same way
+				// an entry that never rendered one settles: the nodes come back out so
+				// the background does not duplicate them, readiness is announced, and
+				// no error is raised against an application that is entitled to the
+				// element. `null` tells the caller its synchronous paint was declined.
+				failedFirstScreenSource = source;
+				firstScreenSyncReady = true;
+				if (disposeFailedFirstScreenSource()) {
+					firstScreenState = 'skipped';
+				} else {
+					firstScreenState = 'cleanup-pending';
+					report(
+						new Error(
+							'Octane Lynx withheld background readiness because unadoptable first-screen cleanup remains incomplete.',
+						),
+					);
+				}
+				announceReady();
+				return null;
+			}
+			firstTree = captured;
 			firstScreenState = 'painted';
 			if (firstScreenSync === 'automatic') firstScreenSyncReady = true;
 			announceReady();

--- a/packages/lynx/tests/first-screen.test.ts
+++ b/packages/lynx/tests/first-screen.test.ts
@@ -84,6 +84,24 @@ const MainSingleHost = defineFirstScreenComponent('lynx', (props: { readonly id:
 	firstScreenValue(mainPlan, [firstScreenProps([['set', 'id', props.id]])]),
 );
 
+const feedPlan = firstScreenPlan('lynx', {
+	kind: 'host',
+	type: 'view',
+	bindings: [['id', 0]],
+	children: [
+		{
+			kind: 'host',
+			type: 'list',
+			bindings: [['id', 1]],
+			children: [{ kind: 'host', type: 'list-item', bindings: [['item-key', 2]] }],
+		},
+	],
+});
+
+const FeedScene = defineFirstScreenComponent('lynx', () =>
+	firstScreenValue(feedPlan, ['feed-shell', 'feed', 'row-0']),
+);
+
 interface FirstScreenLinkedRuntime {
 	useLinkedState?<Source, Value>(
 		source: Source,
@@ -624,6 +642,54 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 		expect(dom.window.document.querySelector('#cleanup-retry')).toBeNull();
 		expect(main.firstScreenSnapshot()).toBeNull();
 		expect(inbound).toEqual([expect.objectContaining({ type: 'main-ready', request: 43 })]);
+	});
+
+	// A `<list>` is a documented element an application is entitled to use, and
+	// the background genuinely cannot adopt one: the platform materializes its
+	// rows through main-local callbacks and owns the resulting cells. Declining
+	// the synchronous paint is therefore an ordinary outcome, and must not be
+	// reported the way the broken host in the next test is.
+	it('declines a synchronous first screen holding a native list without faulting', () => {
+		// The renderer captures the flush when the runtime installs, so this has to
+		// wrap it before that; each flush reports the page as the batch left it.
+		const painted: string[] = [];
+		const { dom, main } = installEnvironment((target) => {
+			const hostFlush = target.__FlushElementTree as (...args: unknown[]) => void;
+			target.__FlushElementTree = (...args: unknown[]) => {
+				hostFlush.apply(target, args);
+				painted.push((args[0] as { innerHTML?: string } | undefined)?.innerHTML ?? '');
+			};
+		});
+		const inbound: LynxBackgroundInboundMessage[] = [];
+		mainContext().addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
+			inbound.push(event.data as LynxBackgroundInboundMessage);
+		});
+
+		expect(firstScreenRoot.render(FeedScene, {})).toBeNull();
+
+		// The tree really was built, then retired, so the background owns the page
+		// alone rather than rendering beneath a duplicate.
+		expect(painted.some((html) => html.includes('id="feed"'))).toBe(true);
+		expect(dom.window.document.querySelector('#feed')).toBeNull();
+		expect(dom.window.document.querySelector('#feed-shell')).toBeNull();
+		expect(main.firstScreenSnapshot()).toBeNull();
+		expect(main.diagnostics()).toEqual([]);
+
+		backgroundContext().dispatchEvent({
+			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
+			data: {
+				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
+				renderer: LYNX_TRANSPORT_RENDERER,
+				type: 'main-ready-request',
+				request: 51,
+			},
+		});
+		// Declining settles readiness immediately, exactly as an entry that never
+		// rendered a first screen does, so the background is not left waiting.
+		expect(inbound).toEqual([
+			expect.objectContaining({ type: 'main-ready', request: 0 }),
+			expect.objectContaining({ type: 'main-ready', request: 51 }),
+		]);
 	});
 
 	it('retains a failed pre-capture source and retries cleanup for background readiness', () => {

--- a/packages/lynx/tests/first-screen.test.ts
+++ b/packages/lynx/tests/first-screen.test.ts
@@ -692,6 +692,30 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 		]);
 	});
 
+	it('retries cleanup for a declined first screen instead of withholding readiness', () => {
+		let removalFailures = 0;
+		const { dom, main } = installEnvironment((target) => {
+			const remove = target.__RemoveElement as (parent: object, child: object) => unknown;
+			target.__RemoveElement = (parent: object, child: object) => {
+				if (removalFailures++ < 1) throw new Error('transient declined-source remove failure');
+				return remove(parent, child);
+			};
+		});
+		const inbound: LynxBackgroundInboundMessage[] = [];
+		mainContext().addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
+			inbound.push(event.data as LynxBackgroundInboundMessage);
+		});
+
+		expect(firstScreenRoot.render(FeedScene, {})).toBeNull();
+
+		// A removal that fails once and succeeds on retry is still an ordinary
+		// decline: the nodes come out and the background is released immediately.
+		expect(removalFailures).toBeGreaterThan(1);
+		expect(dom.window.document.querySelector('#feed-shell')).toBeNull();
+		expect(main.firstScreenSnapshot()).toBeNull();
+		expect(inbound).toEqual([expect.objectContaining({ type: 'main-ready', request: 0 })]);
+	});
+
 	it('retains a failed pre-capture source and retries cleanup for background readiness', () => {
 		const captureFailure = new Error('capture unique ID failed');
 		let uniqueIdCalls = 0;

--- a/packages/lynx/tests/main-thread-events.test.ts
+++ b/packages/lynx/tests/main-thread-events.test.ts
@@ -791,23 +791,16 @@ describe.sequential('Lynx main-thread worklet dispatch', () => {
 	interface FlushHost {
 		readonly controller: LynxMainThreadController;
 		readonly flushes: readonly (readonly unknown[])[];
+		readonly globals: Record<string, unknown>;
 		dispatch(worklet: unknown, args?: readonly unknown[]): unknown;
-		endDispatch(): void;
 		close(): void;
 	}
 
-	let flushHost: { close(): void } | null = null;
-	// An authored `'main thread'` handler publishes through whichever object the
-	// runtime installed the element PAPI onto. That is the bare global on a real
-	// host, but the Lynx testing environment rebuilds `globalThis` from its own
-	// per-thread bag on every thread switch, so these hosts hand the runtime an
-	// object that survives those switches and the handlers read the same one.
-	let hostGlobals: Record<string, unknown> | null = null;
+	let flushHost: FlushHost | null = null;
 
 	afterEach(() => {
 		flushHost?.close();
 		flushHost = null;
-		hostGlobals = null;
 	});
 
 	/**
@@ -825,8 +818,12 @@ describe.sequential('Lynx main-thread worklet dispatch', () => {
 		});
 		const env = globalThis.lynxTestingEnv;
 		env.switchToMainThread();
+		// An authored `'main thread'` handler publishes through whichever object the
+		// runtime installed the element PAPI onto — the bare global on a real host.
+		// The Lynx testing environment rebuilds `globalThis` from its own per-thread
+		// bag on every thread switch, so the runtime is handed an object that
+		// survives those switches and the handlers read that same one.
 		const target = Object.create(globalThis) as Record<string, unknown>;
-		hostGlobals = target;
 		const hostFlush = target.__FlushElementTree as (...args: unknown[]) => void;
 		target.__FlushElementTree = (...args: unknown[]) => {
 			if (dispatching && rejectsInlineFlush) {
@@ -846,12 +843,15 @@ describe.sequential('Lynx main-thread worklet dispatch', () => {
 		const host: FlushHost = {
 			controller,
 			flushes,
+			globals: target,
 			dispatch(worklet, args) {
+				// The borrow the host holds is released as its dispatch unwinds.
 				dispatching = true;
-				return runWorklet(worklet, args);
-			},
-			endDispatch() {
-				dispatching = false;
+				try {
+					return runWorklet(worklet, args);
+				} finally {
+					dispatching = false;
+				}
 			},
 			close() {
 				controller.close();
@@ -864,21 +864,20 @@ describe.sequential('Lynx main-thread worklet dispatch', () => {
 		return host;
 	}
 
-	function activateFlushingHandler(id: string): unknown {
+	function activateFlushingHandler(id: string, host: FlushHost): unknown {
 		const descriptor = registerMainThreadWorklet(id, undefined, function () {
-			(hostGlobals as unknown as { __FlushElementTree(): void }).__FlushElementTree();
+			(host.globals as unknown as { __FlushElementTree(): void }).__FlushElementTree();
 		});
 		return activateLynxMainThreadWorklet(descriptor);
 	}
 
 	it('publishes a handler flush the host refuses to take during its own dispatch', async () => {
 		const host = installFlushHost(true);
-		const handler = activateFlushingHandler('test:flush-during-dispatch');
+		const handler = activateFlushingHandler('test:flush-during-dispatch', host);
 
 		expect(() => host.dispatch(handler)).not.toThrow();
 		expect(host.flushes).toEqual([]);
 
-		host.endDispatch();
 		await Promise.resolve();
 		expect(host.flushes).toEqual([[]]);
 		expect(host.controller.diagnostics()).toEqual([]);
@@ -886,7 +885,7 @@ describe.sequential('Lynx main-thread worklet dispatch', () => {
 
 	it('coalesces the flushes of a handler that fires repeatedly within one dispatch', async () => {
 		const host = installFlushHost(true);
-		const handler = activateFlushingHandler('test:flush-every-frame');
+		const handler = activateFlushingHandler('test:flush-every-frame', host);
 
 		// A `scroll-event-throttle={0}` handler fires once per frame, and every one
 		// of those flushes is refused inline. They must not each queue work.
@@ -894,7 +893,6 @@ describe.sequential('Lynx main-thread worklet dispatch', () => {
 		host.dispatch(handler);
 		host.dispatch(handler);
 
-		host.endDispatch();
 		await Promise.resolve();
 		expect(host.flushes).toEqual([[]]);
 		expect(host.controller.diagnostics()).toEqual([]);
@@ -902,7 +900,7 @@ describe.sequential('Lynx main-thread worklet dispatch', () => {
 
 	it('leaves a host that takes an inline flush on its own synchronous timing', () => {
 		const host = installFlushHost(false);
-		const handler = activateFlushingHandler('test:flush-inline');
+		const handler = activateFlushingHandler('test:flush-inline', host);
 
 		host.dispatch(handler);
 		// Native Lynx publishes within the dispatch, so the flush must already have

--- a/packages/lynx/tests/main-thread-events.test.ts
+++ b/packages/lynx/tests/main-thread-events.test.ts
@@ -21,6 +21,7 @@ import {
 	type LynxContextProxyEvent,
 } from '../src/core/protocol.js';
 import { encodeLynxPortalTargetId } from '../src/core/portal.js';
+import { activateLynxMainThreadWorklet, registerMainThreadWorklet } from '../src/core/worklets.js';
 
 type Handler = ((payload: unknown) => void) | null;
 
@@ -783,6 +784,131 @@ describe.sequential('Lynx main-thread native event bridge', () => {
 		).rejects.toThrow('injected accepted flush fault');
 		expect(faultLog).toEqual([]);
 		expect(faulted.main.activeIdentity()).toMatchObject({ version: 1 });
+	});
+});
+
+describe.sequential('Lynx main-thread worklet dispatch', () => {
+	interface FlushHost {
+		readonly controller: LynxMainThreadController;
+		readonly flushes: readonly (readonly unknown[])[];
+		dispatch(worklet: unknown, args?: readonly unknown[]): unknown;
+		endDispatch(): void;
+		close(): void;
+	}
+
+	let flushHost: { close(): void } | null = null;
+	// An authored `'main thread'` handler publishes through whichever object the
+	// runtime installed the element PAPI onto. That is the bare global on a real
+	// host, but the Lynx testing environment rebuilds `globalThis` from its own
+	// per-thread bag on every thread switch, so these hosts hand the runtime an
+	// object that survives those switches and the handlers read the same one.
+	let hostGlobals: Record<string, unknown> | null = null;
+
+	afterEach(() => {
+		flushHost?.close();
+		flushHost = null;
+		hostGlobals = null;
+	});
+
+	/**
+	 * A host that refuses a flush taken from inside its own event dispatch. Lynx
+	 * for Web is one: its wasm element context is still borrowed by
+	 * `common_event_handler` when it calls `runWorklet`, so `__FlushElementTree`
+	 * throws for as long as the dispatch is on the stack.
+	 */
+	function installFlushHost(rejectsInlineFlush: boolean): FlushHost {
+		const flushes: (readonly unknown[])[] = [];
+		let dispatching = false;
+		const dom = new JSDOM('<!doctype html><html><body></body></html>');
+		installLynxTestingEnv(globalThis, {
+			window: dom.window as unknown as Window & typeof globalThis,
+		});
+		const env = globalThis.lynxTestingEnv;
+		env.switchToMainThread();
+		const target = Object.create(globalThis) as Record<string, unknown>;
+		hostGlobals = target;
+		const hostFlush = target.__FlushElementTree as (...args: unknown[]) => void;
+		target.__FlushElementTree = (...args: unknown[]) => {
+			if (dispatching && rejectsInlineFlush) {
+				throw new Error(
+					'recursive use of an object detected which would lead to unsafe aliasing in rust',
+				);
+			}
+			flushes.push(Object.freeze(args));
+			hostFlush.apply(target, args);
+		};
+		const controller = installLynxMainThread({ target });
+		env.switchToBackgroundThread();
+		const runWorklet = target.runWorklet as (
+			worklet: unknown,
+			args?: readonly unknown[],
+		) => unknown;
+		const host: FlushHost = {
+			controller,
+			flushes,
+			dispatch(worklet, args) {
+				dispatching = true;
+				return runWorklet(worklet, args);
+			},
+			endDispatch() {
+				dispatching = false;
+			},
+			close() {
+				controller.close();
+				env.clearGlobal();
+				uninstallLynxTestingEnv(globalThis);
+				dom.window.close();
+			},
+		};
+		flushHost = host;
+		return host;
+	}
+
+	function activateFlushingHandler(id: string): unknown {
+		const descriptor = registerMainThreadWorklet(id, undefined, function () {
+			(hostGlobals as unknown as { __FlushElementTree(): void }).__FlushElementTree();
+		});
+		return activateLynxMainThreadWorklet(descriptor);
+	}
+
+	it('publishes a handler flush the host refuses to take during its own dispatch', async () => {
+		const host = installFlushHost(true);
+		const handler = activateFlushingHandler('test:flush-during-dispatch');
+
+		expect(() => host.dispatch(handler)).not.toThrow();
+		expect(host.flushes).toEqual([]);
+
+		host.endDispatch();
+		await Promise.resolve();
+		expect(host.flushes).toEqual([[]]);
+		expect(host.controller.diagnostics()).toEqual([]);
+	});
+
+	it('coalesces the flushes of a handler that fires repeatedly within one dispatch', async () => {
+		const host = installFlushHost(true);
+		const handler = activateFlushingHandler('test:flush-every-frame');
+
+		// A `scroll-event-throttle={0}` handler fires once per frame, and every one
+		// of those flushes is refused inline. They must not each queue work.
+		host.dispatch(handler);
+		host.dispatch(handler);
+		host.dispatch(handler);
+
+		host.endDispatch();
+		await Promise.resolve();
+		expect(host.flushes).toEqual([[]]);
+		expect(host.controller.diagnostics()).toEqual([]);
+	});
+
+	it('leaves a host that takes an inline flush on its own synchronous timing', () => {
+		const host = installFlushHost(false);
+		const handler = activateFlushingHandler('test:flush-inline');
+
+		host.dispatch(handler);
+		// Native Lynx publishes within the dispatch, so the flush must already have
+		// landed when the handler returns rather than waiting for a checkpoint.
+		expect(host.flushes).toEqual([[]]);
+		expect(host.controller.diagnostics()).toEqual([]);
 	});
 });
 

--- a/packages/rspeedy-plugin-octane/tests/_fixtures/main-thread-flush/package.json
+++ b/packages/rspeedy-plugin-octane/tests/_fixtures/main-thread-flush/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@octanejs/rspeedy-main-thread-flush-fixture",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/packages/rspeedy-plugin-octane/tests/_fixtures/main-thread-flush/src/App.lynx.tsrx
+++ b/packages/rspeedy-plugin-octane/tests/_fixtures/main-thread-flush/src/App.lynx.tsrx
@@ -1,0 +1,28 @@
+/** @jsxImportSource @octanejs/lynx/intrinsics */
+import { useMainThreadRef } from '@octanejs/lynx';
+
+/**
+ * The documented Lynx main-thread scripting pattern: a `'main thread'` handler
+ * writes an element style and publishes it with `__FlushElementTree()`. Hosts
+ * that dispatch the handler from inside their own element-tree work cannot take
+ * that flush inline, so this is the shape the runtime has to keep working.
+ */
+export function App() @{
+	const barRef = useMainThreadRef<object>();
+	const heightRef = useMainThreadRef<number>(8);
+
+	const onTapMTS = () => {
+		'main thread';
+		const bar = barRef.current;
+		if (bar === null || bar === undefined) return;
+		const height = heightRef.current + 8;
+		heightRef.current = height;
+		__AddInlineStyle(bar, 'height', height + 'px');
+		__FlushElementTree();
+	};
+
+	<view id="flush-probe" main-thread:bindtap={onTapMTS}>
+		<view id="flush-bar" main-thread:ref={barRef} style="width: 40px; height: 8px" />
+		<text>{'Tap to flush'}</text>
+	</view>
+}

--- a/packages/rspeedy-plugin-octane/tests/_fixtures/main-thread-flush/src/index.ts
+++ b/packages/rspeedy-plugin-octane/tests/_fixtures/main-thread-flush/src/index.ts
@@ -1,0 +1,5 @@
+import { root } from '@octanejs/lynx';
+
+import { App } from './App.lynx.tsrx';
+
+void root.render(App);

--- a/packages/rspeedy-plugin-octane/tests/_fixtures/main-thread-flush/src/lynx-env.d.ts
+++ b/packages/rspeedy-plugin-octane/tests/_fixtures/main-thread-flush/src/lynx-env.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Element PAPI functions exist only in the Lynx main-thread runtime and may be
+ * referenced only inside `'main thread'` functions.
+ */
+declare function __AddInlineStyle(element: object, name: string, value: string): void;
+declare function __FlushElementTree(): void;

--- a/packages/rspeedy-plugin-octane/tests/browser/web-host.test.ts
+++ b/packages/rspeedy-plugin-octane/tests/browser/web-host.test.ts
@@ -152,14 +152,26 @@ async function launchChromium(): Promise<Awaited<ReturnType<typeof chromium.laun
 	}
 }
 
-it('mounts the demo through Lynx for Web and handles a native tap', async () => {
-	const temporaryRoot = await mkdtemp(resolve(tmpdir(), 'octane-lynx-web-host-'));
+/**
+ * Build a fixture, serve it to a real Chromium against `@lynx-js/web-core`, and
+ * run `visit` against the mounted page. Mounting a Lynx bundle must never fault
+ * the host, so both error channels are asserted empty on the way out for every
+ * caller rather than being restated per test.
+ */
+async function withWebHostPage(
+	fixtureRoot: string,
+	prefix: string,
+	visit: (
+		page: Awaited<ReturnType<Awaited<ReturnType<typeof chromium.launch>>['newPage']>>,
+	) => Promise<void>,
+): Promise<void> {
+	const temporaryRoot = await mkdtemp(resolve(tmpdir(), prefix));
 	const outputRoot = resolve(temporaryRoot, 'dist');
 	let host: Awaited<ReturnType<typeof startHost>> | undefined;
 	let browser: Awaited<ReturnType<typeof chromium.launch>> | undefined;
 
 	try {
-		await buildWebBundle(DEMO_ROOT, outputRoot);
+		await buildWebBundle(fixtureRoot, outputRoot);
 
 		host = await startHost(resolve(outputRoot, 'main.web.bundle'));
 		browser = await launchChromium();
@@ -169,15 +181,8 @@ it('mounts the demo through Lynx for Web and handles a native tap', async () => 
 		page.on('pageerror', (error) => pageErrors.push(error.message));
 
 		await page.goto(host.url, { waitUntil: 'domcontentloaded' });
-		const initialCount = page.getByText('Count 0', { exact: true });
-		await initialCount.waitFor({ state: 'visible' });
-		expect(await initialCount.count()).toBe(1);
-		expect(await page.locator('lynx-view *').count()).toBeGreaterThan(0);
+		await visit(page);
 
-		await page.getByText('Tap to increment', { exact: true }).click();
-		const updatedCount = page.getByText('Count 1', { exact: true });
-		await updatedCount.waitFor({ state: 'visible' });
-		expect(await updatedCount.count()).toBe(1);
 		expect(pageErrors).toEqual([]);
 		expect(
 			await page.evaluate<string[]>(
@@ -189,6 +194,20 @@ it('mounts the demo through Lynx for Web and handles a native tap', async () => 
 		await host?.close();
 		await rm(temporaryRoot, { recursive: true, force: true });
 	}
+}
+
+it('mounts the demo through Lynx for Web and handles a native tap', async () => {
+	await withWebHostPage(DEMO_ROOT, 'octane-lynx-web-host-', async (page) => {
+		const initialCount = page.getByText('Count 0', { exact: true });
+		await initialCount.waitFor({ state: 'visible' });
+		expect(await initialCount.count()).toBe(1);
+		expect(await page.locator('lynx-view *').count()).toBeGreaterThan(0);
+
+		await page.getByText('Tap to increment', { exact: true }).click();
+		const updatedCount = page.getByText('Count 1', { exact: true });
+		await updatedCount.waitFor({ state: 'visible' });
+		expect(await updatedCount.count()).toBe(1);
+	});
 }, 90_000);
 
 // Lynx for Web calls a `'main thread'` handler from inside its own wasm element
@@ -197,22 +216,7 @@ it('mounts the demo through Lynx for Web and handles a native tap', async () => 
 // handler as an uncaught page error — one per event, so a handler bound to a
 // per-frame event flooded the console for as long as the page lived.
 it('publishes a main-thread handler flush without faulting the Web host', async () => {
-	const temporaryRoot = await mkdtemp(resolve(tmpdir(), 'octane-lynx-web-flush-'));
-	const outputRoot = resolve(temporaryRoot, 'dist');
-	let host: Awaited<ReturnType<typeof startHost>> | undefined;
-	let browser: Awaited<ReturnType<typeof chromium.launch>> | undefined;
-
-	try {
-		await buildWebBundle(MAIN_THREAD_FLUSH_ROOT, outputRoot);
-
-		host = await startHost(resolve(outputRoot, 'main.web.bundle'));
-		browser = await launchChromium();
-		const page = await browser.newPage();
-		page.setDefaultTimeout(30_000);
-		const pageErrors: string[] = [];
-		page.on('pageerror', (error) => pageErrors.push(error.message));
-
-		await page.goto(host.url, { waitUntil: 'domcontentloaded' });
+	await withWebHostPage(MAIN_THREAD_FLUSH_ROOT, 'octane-lynx-web-flush-', async (page) => {
 		const probe = page.getByText('Tap to flush', { exact: true });
 		await probe.waitFor({ state: 'visible' });
 
@@ -225,15 +229,5 @@ it('publishes a main-thread handler flush without faulting the Web host', async 
 		// The style writes prove the handler ran, so an empty error list is not the
 		// vacuous pass of an event that never reached the main thread.
 		await expect.poll(barHeight).toBe('24px');
-		expect(pageErrors).toEqual([]);
-		expect(
-			await page.evaluate<string[]>(
-				() => (window as typeof window & { __lynxHostErrors: string[] }).__lynxHostErrors,
-			),
-		).toEqual([]);
-	} finally {
-		await browser?.close();
-		await host?.close();
-		await rm(temporaryRoot, { recursive: true, force: true });
-	}
+	});
 }, 90_000);

--- a/packages/rspeedy-plugin-octane/tests/browser/web-host.test.ts
+++ b/packages/rspeedy-plugin-octane/tests/browser/web-host.test.ts
@@ -13,6 +13,7 @@ import { expect, it } from 'vitest';
 import { pluginOctane } from '../../src/index.js';
 
 const DEMO_ROOT = resolve(import.meta.dirname, '../../examples/demo');
+const MAIN_THREAD_FLUSH_ROOT = resolve(import.meta.dirname, '../_fixtures/main-thread-flush');
 const WEB_CORE_ROOT = resolve(
 	dirname(fileURLToPath(import.meta.resolve('@lynx-js/web-core/package.json'))),
 	'dist/client_prod',
@@ -111,6 +112,46 @@ async function startHost(bundlePath: string): Promise<{
 	};
 }
 
+async function buildWebBundle(cwd: string, outputRoot: string): Promise<void> {
+	const rspeedy = await createRspeedy({
+		cwd,
+		loadEnv: false,
+		environment: ['web'],
+		rspeedyConfig: {
+			mode: 'production',
+			environments: { web: {} },
+			dev: { hmr: false, liveReload: false },
+			output: {
+				cleanDistPath: true,
+				distPath: { root: outputRoot },
+				filenameHash: false,
+				sourceMap: false,
+			},
+			source: { entry: { main: './src/index.ts' } },
+			splitChunks: false,
+			plugins: [pluginOctane({ dev: false, hmr: false })],
+		},
+	});
+	let build: Awaited<ReturnType<typeof rspeedy.build>> | undefined;
+	try {
+		build = await rspeedy.build();
+	} finally {
+		await build?.close();
+	}
+}
+
+async function launchChromium(): Promise<Awaited<ReturnType<typeof chromium.launch>>> {
+	try {
+		return await chromium.launch({ headless: true });
+	} catch (error) {
+		throw new Error(
+			'Chromium is required for the Lynx Web host smoke test ' +
+				'(run `pnpm --filter @octanejs/rspeedy-plugin exec playwright install chromium`): ' +
+				(error instanceof Error ? error.message.split('\n')[0] : String(error)),
+		);
+	}
+}
+
 it('mounts the demo through Lynx for Web and handles a native tap', async () => {
 	const temporaryRoot = await mkdtemp(resolve(tmpdir(), 'octane-lynx-web-host-'));
 	const outputRoot = resolve(temporaryRoot, 'dist');
@@ -118,42 +159,10 @@ it('mounts the demo through Lynx for Web and handles a native tap', async () => 
 	let browser: Awaited<ReturnType<typeof chromium.launch>> | undefined;
 
 	try {
-		const rspeedy = await createRspeedy({
-			cwd: DEMO_ROOT,
-			loadEnv: false,
-			environment: ['web'],
-			rspeedyConfig: {
-				mode: 'production',
-				environments: { web: {} },
-				dev: { hmr: false, liveReload: false },
-				output: {
-					cleanDistPath: true,
-					distPath: { root: outputRoot },
-					filenameHash: false,
-					sourceMap: false,
-				},
-				source: { entry: { main: './src/index.ts' } },
-				splitChunks: false,
-				plugins: [pluginOctane({ dev: false, hmr: false })],
-			},
-		});
-		let build: Awaited<ReturnType<typeof rspeedy.build>> | undefined;
-		try {
-			build = await rspeedy.build();
-		} finally {
-			await build?.close();
-		}
+		await buildWebBundle(DEMO_ROOT, outputRoot);
 
 		host = await startHost(resolve(outputRoot, 'main.web.bundle'));
-		try {
-			browser = await chromium.launch({ headless: true });
-		} catch (error) {
-			throw new Error(
-				'Chromium is required for the Lynx Web host smoke test ' +
-					'(run `pnpm --filter @octanejs/rspeedy-plugin exec playwright install chromium`): ' +
-					(error instanceof Error ? error.message.split('\n')[0] : String(error)),
-			);
-		}
+		browser = await launchChromium();
 		const page = await browser.newPage();
 		page.setDefaultTimeout(30_000);
 		const pageErrors: string[] = [];
@@ -169,6 +178,53 @@ it('mounts the demo through Lynx for Web and handles a native tap', async () => 
 		const updatedCount = page.getByText('Count 1', { exact: true });
 		await updatedCount.waitFor({ state: 'visible' });
 		expect(await updatedCount.count()).toBe(1);
+		expect(pageErrors).toEqual([]);
+		expect(
+			await page.evaluate<string[]>(
+				() => (window as typeof window & { __lynxHostErrors: string[] }).__lynxHostErrors,
+			),
+		).toEqual([]);
+	} finally {
+		await browser?.close();
+		await host?.close();
+		await rm(temporaryRoot, { recursive: true, force: true });
+	}
+}, 90_000);
+
+// Lynx for Web calls a `'main thread'` handler from inside its own wasm element
+// context, which then refuses the `__FlushElementTree()` that the documented
+// main-thread scripting pattern ends with. Every refusal used to escape the
+// handler as an uncaught page error — one per event, so a handler bound to a
+// per-frame event flooded the console for as long as the page lived.
+it('publishes a main-thread handler flush without faulting the Web host', async () => {
+	const temporaryRoot = await mkdtemp(resolve(tmpdir(), 'octane-lynx-web-flush-'));
+	const outputRoot = resolve(temporaryRoot, 'dist');
+	let host: Awaited<ReturnType<typeof startHost>> | undefined;
+	let browser: Awaited<ReturnType<typeof chromium.launch>> | undefined;
+
+	try {
+		await buildWebBundle(MAIN_THREAD_FLUSH_ROOT, outputRoot);
+
+		host = await startHost(resolve(outputRoot, 'main.web.bundle'));
+		browser = await launchChromium();
+		const page = await browser.newPage();
+		page.setDefaultTimeout(30_000);
+		const pageErrors: string[] = [];
+		page.on('pageerror', (error) => pageErrors.push(error.message));
+
+		await page.goto(host.url, { waitUntil: 'domcontentloaded' });
+		const probe = page.getByText('Tap to flush', { exact: true });
+		await probe.waitFor({ state: 'visible' });
+
+		const barHeight = () =>
+			page.locator('#flush-bar').evaluate((element) => (element as HTMLElement).style.height);
+		expect(await barHeight()).toBe('8px');
+
+		await probe.click();
+		await probe.click();
+		// The style writes prove the handler ran, so an empty error list is not the
+		// vacuous pass of an event that never reached the main thread.
+		await expect.poll(barHeight).toBe('24px');
 		expect(pageErrors).toEqual([]);
 		expect(
 			await page.evaluate<string[]>(


### PR DESCRIPTION
## Summary

Two independent defects that both surfaced while mounting `examples/gallery` — a faithful port of the official Lynx Product Gallery tutorial — on Lynx for Web. Together they produced ~670 uncaught page errors in a twelve-second run. The example now mounts with zero.

Both are in `@octanejs/lynx`; no example or app code was changed to work around either.

### 1. A `'main thread'` handler's `__FlushElementTree()` threw on every event

The documented Lynx main-thread scripting pattern — write element styles in a `'main thread'` handler, publish with `__FlushElementTree()` — threw on every event:

```
Error: recursive use of an object detected which would lead to unsafe aliasing in rust
    at s.take_timing_flags (client.js)
    at __FlushElementTree (web-core-main-chunk.js)
```

The throw escapes through the host's own frames, so it lands as an uncaught page error rather than anything the application can catch. A handler bound to a per-frame event (`main-thread:bindscroll` on an auto-scrolling `<list>`) produced hundreds in seconds.

**The cause is in `@lynx-js/web-core`, not Octane.** Its wasm element context is still borrowed by `common_event_handler` when that calls `runWorklet`, so the `__FlushElementTree` it installed rejects the re-entrant call — `take_timing_flags` is a method on the borrowed `wasmContext`, while `__AddInlineStyle` survives because it calls free wasm functions. Replacing Octane's `runWorklet` on web-core's main-thread realm with a bare `function(){ __FlushElementTree() }` reproduces it with every line of Octane's worklet machinery out of the loop, on 0.22.2 and the current 0.23.1. Filed upstream as [lynx-family/lynx-stack#3395](https://github.com/lynx-family/lynx-stack/issues/3395); it remains unfixed there.

Octane owns the seam that runs the handler — it installs `runWorklet` on the host global, the same object carrying `__FlushElementTree` — so the main-thread runtime now attempts the inline flush first and only a host that *refuses* one latches into publishing it past the end of the dispatch, coalescing repeats into a single publish. Every host that permits a re-entrant flush, which is every native Lynx runtime, keeps its exact previous synchronous timing. No platform sniffing.

Deliberately scoped to `__FlushElementTree`. Deferring a setter or an element creation would be wrong; their re-entrancy remains web-core's to fix.

### 2. A first screen containing a `<list>` was built, discarded, and reported as a host fault

```
Error: Octane Lynx host: native list materializations cannot be captured as a first tree.
```

The guard is right for the design we have: a native `<list>` does not own its rows. The platform materializes them through the `componentAtIndex`/`enqueueComponent` callbacks handed to `listPAPI.create`, and owns the resulting cell state. Octane builds those callbacks as per-instance closures with no cross-thread handle space, so a first tree — a clone-safe description the background *adopts* — has nothing to hand over, and skipping the list's children would not help because the list node is itself the unhandoverable part.

That is a limit of this design, not an inherent one. ReactLynx's element-template runtime carries lists across the same boundary by never transferring the callbacks: `getStableSerializedListAttributes` strips `component-at-index`, `component-at-indexes`, `enqueue-component`, and `update-list-info` from the hydration payload; the callbacks are installed once as stable identities that read mutable `ETListState` rather than being recreated per update; and what crosses is a serializable descriptor — the remaining attributes plus `options.listChildren` item metadata keyed by a stable `uid` shared between the background command stream, the main-thread registry, and native's list callbacks. Adopting a list here would mean adopting that shape. Declining is right until then, not a permanent verdict.

What was wrong is the classification. `captureLynxFirstTree` had one failure channel, so an unsupported composition and a broken host came out identically, and an application using a documented element was told its host was broken — after paying for a full main-thread render that was always discarded. Snapshotting `page.innerHTML` at each flush during the render shows the cost directly:

```
1: <view id="shell"><list id="feed" update-list-info="[insert row-0]"></list></view>
2: ""
```

Capture now returns `null` for a well-formed tree the background cannot adopt, while every genuine capture fault still throws — the existing test for a host whose `__GetElementUniqueID` breaks passes unchanged. On `null` the runtime retires the first screen the way an entry that never rendered one settles: nodes back out so the background does not render beneath a duplicate, readiness announced with the same `main-ready` signal, no error raised.

## Validation

- [x] `pnpm format:check` (see note)
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [x] targeted tests: `--project lynx --project rspeedy-plugin --project rspeedy-plugin-browser` — 336 passed.

`pnpm format:check` passes for every file in this diff. The repo-wide run reports two files, `lynx-web-e2e.mjs` and `swiper-web-probe.mjs`, which are untracked local scratch scripts not part of this branch.

Each regression was confirmed to fail on the pre-fix tree:

- `packages/lynx/tests/main-thread-events.test.ts` — three contract tests. Two fail without the fix; the third asserts that a host which *accepts* an inline flush stays synchronous, and passes on both sides, guarding native timing.
- `packages/rspeedy-plugin-octane/tests/browser/web-host.test.ts` — real `@lynx-js/web-core` end-to-end against a new `tests/_fixtures/main-thread-flush` fixture. Fails pre-fix with the two literal `recursive use of an object…` errors.
- `packages/lynx/tests/first-screen.test.ts` — two tests, placed directly above the capture-fault test so the contrast is explicit. The decline test fails pre-fix with the exact reported error. The retry test covers a Cursor Bugbot finding on the first revision: the decline path called `disposeFailedFirstScreenSource()` once where the fault path retries, so a host removal that failed transiently turned an ordinary decline into withheld readiness and a reported error — the exact outcome this PR removes. Both paths are now one `retireFirstScreen()` helper, and reverting only that call still fails the test.

End-to-end: `examples/gallery` built with a `web` environment and mounted in headless Chromium against `@lynx-js/web-core`'s `dist/client_prod` goes from 744 uncaught errors in twelve seconds to 0, with 304 nodes painting and the main-thread scrollbar still driven. Confirmed on web-core 0.22.2 and 0.23.1.

**`pnpm test` was run and is not green on this machine**, but not because of this change. Three files fail — `packages/phosphor-icons/tests/bundle.test.ts`, `packages/octane/tests/browser/native-change/native-change.test.ts`, and `packages/rsbuild-plugin-octane/tests/renderer-config.test.ts`. They fail identically with this diff stashed, and the failure count varies between runs (14 → 3 → 14, with `rsbuild-plugin` passing on a rerun), so they are pre-existing and flaky here. I did not investigate them.

## Risk / follow-ups

- The upstream `@lynx-js/web-core` re-entrancy is filed as [lynx-family/lynx-stack#3395](https://github.com/lynx-family/lynx-stack/issues/3395) and is still unfixed there. It affects any framework whose `runWorklet` calls the handler synchronously, which is the only way it can work, so this is a mitigation at the layer we own rather than a fix.
- **A first screen containing a `<list>` is still built and torn back out, and that is avoidable.** The batch is prepared before any of it is applied, and preparation already stages each node's type, so the decline could happen before a single element is created. Taking it there needs the prepared batch to publish what it staged — wider than this fix, so a page with a `<list>` currently pays for a screen it never keeps. My earlier claim that this was unknowable before apply was wrong.
- Most of web-core's element PAPIs take the same wasm borrow, not just the flush — `__SetCSSId`, `__AddEvent`, `__SetDataset`, the `__Create*` family and `__SetClasses` would all throw the same way from inside a dispatch. Only the flush is wrapped, because it is the only one whose effect survives being moved past the end of the dispatch; the rest have a return value or an ordering the handler depends on.
- The deferred flush is last-wins, not accumulating: a second flush in one checkpoint replaces the first, so its `node`/`options` are what publish. Harmless on Web (the host ignores the subtree) and unreachable on native, but the wrapper is generic.
- The inline-flush latch is permanent and trips on any throw, so one transient failure moves later in-dispatch flushes to a microtask for the page's life. Noted so it is not rediscovered as a mystery.
- Portals reject capture through the same function and keep throwing. That is not a half-finished migration: the main renderer rejects a portal while rendering, so those guards are unreachable from the first-screen path and defend only a direct call, where a fault is the right report.
- `examples/gallery` still has no `web` environment on `main`; I reproduced with one added locally and reverted it, since that rollout is separate in-flight work.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches main-thread host globals and first-screen lifecycle on every Lynx entry; behavior is host-specific but wrong timing or decline handling would affect all pages, not only Web or list UIs.
> 
> **Overview**
> Two `@octanejs/lynx` fixes for Lynx for Web, mainly seen when mounting gallery-style pages with `<list>` and main-thread handlers.
> 
> **Main-thread flush on Lynx for Web:** The runtime wraps `__FlushElementTree` and tracks depth around `runWorklet`. It still tries an inline flush first; if the host rejects re-entrancy (web-core’s wasm borrow), later flushes in the same dispatch are deferred to a microtask, coalesced last-wins. Native hosts that allow inline flushes keep the old synchronous behavior.
> 
> **First screen with `<list>`:** `captureLynxFirstTree` now returns `null` for trees the background cannot adopt (native lists), while real capture bugs still throw. On `null`, `retireFirstScreen` tears down the painted tree, announces `main-ready` without error, and `render` returns `null`—documented on the first-screen APIs. Failed capture cleanup shares the same helper so retry behavior matches.
> 
> Tests cover list decline, cleanup retry, worklet flush deferral/coalescing, and a Playwright web-core fixture for tap-to-flush.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcd25915ad745f442f46b01cbbbbcb17868d7a78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



