### PR TITLE
fix: hydration of sibling `@if` and `@switch` blocks at fragment roots

### DIFF
--- a/.changeset/hydration-fragment-if-cursor.md
+++ b/.changeset/hydration-fragment-if-cursor.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Fix hydration of sibling `@if` and `@switch` blocks at fragment roots, including components rendered inside keyed `@for` lists.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -22017,6 +22017,13 @@ function renderBranchSlot(
 			);
 		}
 	}
+	// Hydration consumed the whole outer control-flow slot, not only the active
+	// branch nested inside it. Park the shared cursor after that outer range so a
+	// following sibling @if/@switch adopts its own markers instead of seeing this
+	// slot's close marker and mounting fresh DOM at the enclosing anchor.
+	if (hydration !== null && !state.borrowed && state.end !== null) {
+		hydration.node = state.end.nextSibling;
+	}
 }
 
 interface IfSlot extends BranchSlot {

--- a/packages/octane/tests/hydration/_fixtures/control.tsrx
+++ b/packages/octane/tests/hydration/_fixtures/control.tsrx
@@ -31,3 +31,60 @@ export function Pick(props) @{
 		}
 	</div>
 }
+
+function FragmentTags(props: {
+	provisional: boolean;
+	isLeg: boolean;
+	condition: 'sunny' | 'rainy' | 'none';
+}) @{
+	<>
+		@if (props.provisional) {
+			<span class="tag-confirm">{'confirm'}</span>
+		}
+		@if (props.isLeg) {
+			<span class="tag-mode">{'transit'}</span>
+		}
+		@if (props.condition === 'sunny') {
+			<span class="tag-weather">{'sunny'}</span>
+		}
+		@if (props.condition === 'rainy') {
+			<span class="tag-weather">{'rainy'}</span>
+		}
+	</>
+}
+
+function FragmentRow(props: {
+	name: string;
+	a: boolean;
+	b: boolean;
+	condition: 'sunny' | 'rainy' | 'none';
+}) @{
+	<>
+		<div class="time-row">
+			<span class="place">{props.name as string}</span>
+			<FragmentTags provisional={props.a} isLeg={props.b} condition={props.condition} />
+		</div>
+	</>
+}
+
+type FragmentRowData = {
+	id: string;
+	name: string;
+	a: boolean;
+	b: boolean;
+	condition: 'sunny' | 'rainy' | 'none';
+};
+
+export function FragmentIfRows() @{
+	const rows: FragmentRowData[] = [
+		{ id: 'r1', name: 'A', a: true, b: true, condition: 'none' },
+		{ id: 'r2', name: 'B', a: true, b: false, condition: 'sunny' },
+	];
+	<ol class="timeline">
+		@for (const row of rows; key row.id) {
+			<li>
+				<FragmentRow name={row.name} a={row.a} b={row.b} condition={row.condition} />
+			</li>
+		}
+	</ol>
+}

--- a/packages/octane/tests/hydration/control-hydrate.test.ts
+++ b/packages/octane/tests/hydration/control-hydrate.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { compile } from 'octane/compiler';
 import { hydrateRoot, flushSync } from '../../src/index.js';
 import * as ServerRT from 'octane/server';
-import { Toggle, Pick } from './_fixtures/control.tsrx';
+import { FragmentIfRows, Toggle, Pick } from './_fixtures/control.tsrx';
 
 // SSR Phase 6 (M3) — @if / @switch hydration: the client adopts the server's
 // taken-branch range (the branch element instance is reused, not rebuilt) and
@@ -97,6 +97,31 @@ describe('hydrateRoot — @switch (SSR Phase 6 / M3)', () => {
 		flushSync(() => {});
 		expect(container.querySelector('.b')).toBe(span); // adopted, not rebuilt
 		expect((container.querySelector('.b') as HTMLElement).textContent).toBe('BBB');
+		root.unmount();
+	});
+});
+
+describe('hydrateRoot — fragment-rooted @if blocks under @for', () => {
+	it('adopts every server-rendered row and tag without a hydration mismatch', () => {
+		const { html } = ServerRT.renderToString(server.FragmentIfRows);
+		container.innerHTML = html;
+		const rows = [...container.querySelectorAll('.time-row')];
+		const tags = [...container.querySelectorAll('.time-row > span:not(.place)')];
+		const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+		const root = hydrateRoot(container, FragmentIfRows);
+		flushSync(() => {});
+
+		const diagnostics = [...errSpy.mock.calls, ...warnSpy.mock.calls].filter((call) =>
+			String(call[0]).toLowerCase().includes('hydration mismatch'),
+		);
+		errSpy.mockRestore();
+		warnSpy.mockRestore();
+		expect(diagnostics).toEqual([]);
+		expect([...container.querySelectorAll('.time-row')]).toEqual(rows);
+		expect([...container.querySelectorAll('.time-row > span:not(.place)')]).toEqual(tags);
+		expect(tags.map((tag) => tag.textContent)).toEqual(['confirm', 'transit', 'confirm', 'sunny']);
 		root.unmount();
 	});
 });


### PR DESCRIPTION
fixes #591 - the fragment emissions was not the issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core control-flow hydration cursor logic in `runtime.ts`; wrong cursor advancement could affect any hydrated `@if`/`@switch` chains, though the change is narrow and guarded (`hydration`, `!borrowed`, `state.end`).
> 
> **Overview**
> Fixes **hydration of multiple sibling `@if` / `@switch` blocks** when they sit at a fragment root—common inside components rendered in keyed `@for` lists (issue #591).
> 
> After hydrating a control-flow slot, the runtime now **moves the shared hydration cursor to the node after the outer slot’s end marker**, not only past the active branch. Without that, a following sibling `@if`/`@switch` could treat the previous slot’s close marker as its own boundary and **mount fresh DOM**, causing hydration mismatches.
> 
> Adds a **fragment + `@for` fixture** (`FragmentIfRows` with stacked conditional tags per row) and a test that SSR → `hydrateRoot` reuses the same row/tag nodes and emits no hydration mismatch warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8dfbd73741f50002ba535a517ae3be5887a8f29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Provenance

- [x] An agent produced this diff (`agent-authored`)