### PR TITLE
fix(ci): make labeled Vercel previews deploy

### DIFF
--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -84,8 +84,8 @@ jobs:
               core.setFailed(`Pull request #${number} has no deployable GitHub head.`);
               return;
             }
-            if (!pull.base?.sha || pull.base.sha === pull.head.sha) {
-              core.setFailed(`Pull request #${number} has no distinct base SHA for the Vercel push.`);
+            if (!pull.base?.sha) {
+              core.setFailed(`Pull request #${number} has no base SHA for the Vercel push.`);
               return;
             }
             const authorizer = context.payload.sender;

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -1,9 +1,10 @@
 name: Vercel preview
 
 # Vercel's GitHub App understands Git refs, not pull request labels. A
-# maintainer-applied `deploy-preview` label publishes the pull request's current
-# head as a temporary branch in this repository. Vercel is configured to deploy
-# only that branch namespace and main, so the label is the authorization step.
+# maintainer-applied `deploy-preview` label publishes the pull request's exact
+# tree as a temporary branch in this repository, attributed to that maintainer.
+# Vercel deploys only that branch namespace and main, so the label is the
+# authorization step.
 on:
   pull_request_target:
     types: [labeled, unlabeled, closed]
@@ -20,13 +21,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # `pull_request_target` loads this script from the trusted base branch. It
-    # never checks out or executes pull request code; contents:write only moves
-    # the one preview ref that asks the installed Vercel GitHub App to build.
+    # never checks out or executes pull request code; contents:write only creates
+    # a tree-identical deployment commit and moves the one preview ref that asks
+    # the installed Vercel GitHub App to build.
     permissions:
       contents: write
       deployments: read
       issues: write
-      pull-requests: read
+      pull-requests: write
 
     steps:
       - name: Publish preview branch and report Vercel deployments
@@ -82,6 +84,47 @@ jobs:
               core.setFailed(`Pull request #${number} has no deployable GitHub head.`);
               return;
             }
+            if (!pull.base?.sha || pull.base.sha === pull.head.sha) {
+              core.setFailed(`Pull request #${number} has no distinct base SHA for the Vercel push.`);
+              return;
+            }
+            const authorizer = context.payload.sender;
+            if (!authorizer?.login || !authorizer.id) {
+              core.setFailed(`The ${LABEL} event does not identify its authorizing GitHub user.`);
+              return;
+            }
+
+            // Give every label-triggered deployment a unique commit while
+            // preserving the pull request's exact tree. Vercel uses the
+            // commit author for deployment authorization, so the maintainer
+            // who applied the label intentionally owns this synthetic commit.
+            const { data: sourceCommit } = await github.rest.git.getCommit({
+              owner,
+              repo,
+              commit_sha: pull.head.sha,
+            });
+            const authoredAt = new Date().toISOString();
+            const deploymentAuthor = {
+              name: authorizer.login,
+              email: `${authorizer.id}+${authorizer.login}@users.noreply.github.com`,
+              date: authoredAt,
+            };
+            const { data: deploymentCommit } = await github.rest.git.createCommit({
+              owner,
+              repo,
+              message: [
+                `chore: deploy preview for #${number}`,
+                "",
+                `Authorized-by: @${authorizer.login}`,
+                `Source: ${pull.head.sha}`,
+                `Run: ${context.runId}/${context.runAttempt}`,
+              ].join("\n"),
+              tree: sourceCommit.tree.sha,
+              parents: [pull.head.sha],
+              author: deploymentAuthor,
+              committer: deploymentAuthor,
+            });
+            const deploymentSha = deploymentCommit.sha;
 
             let existingRef = null;
             try {
@@ -92,26 +135,32 @@ jobs:
             }
 
             if (existingRef) {
-              if (existingRef.object.sha === pull.head.sha) {
-                core.notice(`${branch} already points at ${pull.head.sha}.`);
-              } else {
-                await github.rest.git.updateRef({
-                  owner,
-                  repo,
-                  ref,
-                  sha: pull.head.sha,
-                  force: true,
-                });
-                core.notice(`Updated ${branch} to ${pull.head.sha}.`);
-              }
+              await github.rest.git.updateRef({
+                owner,
+                repo,
+                ref,
+                sha: deploymentSha,
+                force: true,
+              });
+              core.notice(`Updated ${branch} to deployment commit ${deploymentSha}.`);
             } else {
+              // Vercel did not react when the API created the branch directly
+              // at the source SHA. Create it at trusted base code, then update
+              // it so the push-driven Git integration receives a ref update.
               await github.rest.git.createRef({
                 owner,
                 repo,
                 ref: `refs/${ref}`,
-                sha: pull.head.sha,
+                sha: pull.base.sha,
               });
-              core.notice(`Created ${branch} at ${pull.head.sha}.`);
+              await github.rest.git.updateRef({
+                owner,
+                repo,
+                ref,
+                sha: deploymentSha,
+                force: true,
+              });
+              core.notice(`Created ${branch} at deployment commit ${deploymentSha}.`);
             }
 
             const comments = await github.paginate(github.rest.issues.listComments, {
@@ -135,7 +184,7 @@ jobs:
               });
               return [
                 COMMENT_MARKER,
-                `Vercel previews for \`${pull.head.sha.slice(0, 7)}\` via \`${branch}\`:`,
+                `Vercel previews for \`${pull.head.sha.slice(0, 7)}\` via \`${branch}\` (deployment commit \`${deploymentSha.slice(0, 7)}\`):`,
                 "",
                 "| Project | Preview | Status |",
                 "| --- | --- | --- |",
@@ -171,7 +220,7 @@ jobs:
               const { data: deployments } = await github.rest.repos.listDeployments({
                 owner,
                 repo,
-                sha: pull.head.sha,
+                sha: deploymentSha,
                 per_page: 100,
               });
               return Promise.all(
@@ -222,7 +271,7 @@ jobs:
                   .map((result) =>
                     result.deployment
                       ? `${result.label}: ${result.status?.state ?? "no deployment status was reported"}`
-                      : `${result.label}: Vercel did not report a deployment for ${pull.head.sha}`,
+                      : `${result.label}: Vercel did not report a deployment for ${deploymentSha}`,
                   )
                   .join("\n"),
               );

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -806,10 +806,13 @@ describe('Pull request labels', () => {
 
 describe('Vercel preview workflow', () => {
 	const sha = 'a'.repeat(40);
+	const deploymentSha = 'd'.repeat(40);
+	const treeSha = 'e'.repeat(40);
 	const pull = {
 		number: 612,
 		state: 'open',
 		labels: [{ name: 'deploy-preview' }],
+		base: { sha: 'b'.repeat(40) },
 		head: {
 			sha,
 			ref: 'feature/preview-this',
@@ -840,6 +843,14 @@ describe('Vercel preview workflow', () => {
 			rest: {
 				pulls: { get: async () => ({ data: structuredClone(pullResponse) }) },
 				git: {
+					getCommit: async (input) => {
+						gitCalls.push({ operation: 'get-commit', ...input });
+						return { data: { sha, tree: { sha: treeSha } } };
+					},
+					createCommit: async (input) => {
+						gitCalls.push({ operation: 'create-commit', ...input });
+						return { data: { sha: deploymentSha, tree: { sha: input.tree } } };
+					},
 					getRef: async (input) => {
 						gitCalls.push({ operation: 'get', ...input });
 						if (currentRef === null) {
@@ -935,7 +946,10 @@ describe('Vercel preview workflow', () => {
 					action,
 					label: labelName ? { name: labelName } : undefined,
 					pull_request: { number: pullResponse.number },
+					sender: { id: 329182, login: 'leonidaz' },
 				},
+				runId: 1234,
+				runAttempt: 1,
 			},
 			{
 				notice: (message) => notices.push(message),
@@ -943,6 +957,10 @@ describe('Vercel preview workflow', () => {
 				warning: (message) => warnings.push(message),
 			},
 			class extends Date {
+				constructor(...args) {
+					super(...(args.length > 0 ? args : [now]));
+				}
+
 				static now() {
 					return now;
 				}
@@ -993,6 +1011,35 @@ describe('Vercel preview workflow', () => {
 		});
 
 		assert.deepEqual(
+			gitCalls.filter((call) => call.operation === 'create-commit'),
+			[
+				{
+					operation: 'create-commit',
+					owner: 'octanejs',
+					repo: 'octane',
+					message: [
+						'chore: deploy preview for #612',
+						'',
+						'Authorized-by: @leonidaz',
+						`Source: ${sha}`,
+						'Run: 1234/1',
+					].join('\n'),
+					tree: treeSha,
+					parents: [sha],
+					author: {
+						name: 'leonidaz',
+						email: '329182+leonidaz@users.noreply.github.com',
+						date: '1970-01-01T00:00:00.000Z',
+					},
+					committer: {
+						name: 'leonidaz',
+						email: '329182+leonidaz@users.noreply.github.com',
+						date: '1970-01-01T00:00:00.000Z',
+					},
+				},
+			],
+		);
+		assert.deepEqual(
 			gitCalls.filter((call) => call.operation === 'create'),
 			[
 				{
@@ -1000,32 +1047,10 @@ describe('Vercel preview workflow', () => {
 					owner: 'octanejs',
 					repo: 'octane',
 					ref: 'refs/heads/deploy-preview-pr-612',
-					sha,
+					sha: pull.base.sha,
 				},
 			],
 		);
-		assert.ok(
-			deploymentQueries
-				.filter((query) => query.operation === 'deployments')
-				.every((query) => query.sha === sha && query.per_page === 100),
-		);
-		assert.ok(writtenComments.every((comment) => comment.operation === 'update'));
-		assert.ok(writtenComments.every((comment) => comment.id === 71));
-		assert.match(writtenComments.at(-1).body, /via `deploy-preview-pr-612`/);
-		assert.match(writtenComments.at(-1).body, /https:\/\/website-preview\.vercel\.app/);
-		assert.match(writtenComments.at(-1).body, /https:\/\/mcp-preview\.vercel\.app/);
-		assert.match(writtenComments.at(-1).body, /SUCCESS/);
-		assert.deepEqual(failures, []);
-	});
-
-	test('moves an existing preview branch to the latest authorized SHA', async () => {
-		const previousSha = 'b'.repeat(40);
-		const { currentRef, gitCalls, failures } = await runPreview({
-			existingRef: previousSha,
-			deploymentSnapshots: [successfulDeployments],
-		});
-
-		assert.equal(currentRef, sha);
 		assert.deepEqual(
 			gitCalls.filter((call) => call.operation === 'update'),
 			[
@@ -1034,7 +1059,66 @@ describe('Vercel preview workflow', () => {
 					owner: 'octanejs',
 					repo: 'octane',
 					ref: 'heads/deploy-preview-pr-612',
-					sha,
+					sha: deploymentSha,
+					force: true,
+				},
+			],
+		);
+		assert.ok(
+			deploymentQueries
+				.filter((query) => query.operation === 'deployments')
+				.every((query) => query.sha === deploymentSha && query.per_page === 100),
+		);
+		assert.ok(writtenComments.every((comment) => comment.operation === 'update'));
+		assert.ok(writtenComments.every((comment) => comment.id === 71));
+		assert.match(writtenComments.at(-1).body, /via `deploy-preview-pr-612`/);
+		assert.match(writtenComments.at(-1).body, /deployment commit `ddddddd`/);
+		assert.match(writtenComments.at(-1).body, /https:\/\/website-preview\.vercel\.app/);
+		assert.match(writtenComments.at(-1).body, /https:\/\/mcp-preview\.vercel\.app/);
+		assert.match(writtenComments.at(-1).body, /SUCCESS/);
+		assert.deepEqual(failures, []);
+	});
+
+	test('moves an existing preview branch to a unique authorized deployment commit', async () => {
+		const previousSha = 'c'.repeat(40);
+		const { currentRef, gitCalls, failures } = await runPreview({
+			existingRef: previousSha,
+			deploymentSnapshots: [successfulDeployments],
+		});
+
+		assert.equal(currentRef, deploymentSha);
+		assert.deepEqual(
+			gitCalls.filter((call) => call.operation === 'update'),
+			[
+				{
+					operation: 'update',
+					owner: 'octanejs',
+					repo: 'octane',
+					ref: 'heads/deploy-preview-pr-612',
+					sha: deploymentSha,
+					force: true,
+				},
+			],
+		);
+		assert.deepEqual(failures, []);
+	});
+
+	test('re-emits a push when the preview branch already points at the source SHA', async () => {
+		const { currentRef, gitCalls, failures } = await runPreview({
+			existingRef: sha,
+			deploymentSnapshots: [successfulDeployments],
+		});
+
+		assert.equal(currentRef, deploymentSha);
+		assert.deepEqual(
+			gitCalls.filter((call) => call.operation === 'update'),
+			[
+				{
+					operation: 'update',
+					owner: 'octanejs',
+					repo: 'octane',
+					ref: 'heads/deploy-preview-pr-612',
+					sha: deploymentSha,
 					force: true,
 				},
 			],
@@ -1121,7 +1205,7 @@ describe('Vercel preview workflow', () => {
 		assert.match(vercelPreviewWorkflow, /^ {6}contents: write$/m);
 		assert.match(vercelPreviewWorkflow, /^ {6}deployments: read$/m);
 		assert.match(vercelPreviewWorkflow, /^ {6}issues: write$/m);
-		assert.match(vercelPreviewWorkflow, /^ {6}pull-requests: read$/m);
+		assert.match(vercelPreviewWorkflow, /^ {6}pull-requests: write$/m);
 		assert.match(
 			vercelPreviewWorkflow,
 			/^ {6}group: \$\{\{ github\.workflow \}\}-\$\{\{ github\.event\.pull_request\.number \}\}$/m,
@@ -1129,6 +1213,8 @@ describe('Vercel preview workflow', () => {
 		assert.match(vercelPreviewWorkflow, /^ {6}cancel-in-progress: false$/m);
 		assert.match(vercelPreviewWorkflow, /BRANCH_PREFIX = "deploy-preview-pr-"/);
 		assert.match(vercelPreviewWorkflow, /github\.rest\.git\.createRef/);
+		assert.match(vercelPreviewWorkflow, /github\.rest\.git\.createCommit/);
+		assert.match(vercelPreviewWorkflow, /github\.rest\.git\.updateRef/);
 		assert.match(vercelPreviewWorkflow, /github\.rest\.repos\.listDeployments/);
 		assert.doesNotMatch(vercelPreviewWorkflow, /actions\/checkout/);
 		assert.doesNotMatch(vercelPreviewWorkflow, /VERCEL_/);

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -1126,6 +1126,17 @@ describe('Vercel preview workflow', () => {
 		assert.deepEqual(failures, []);
 	});
 
+	test('publishes a labeled preview when the pull request head matches its base', async () => {
+		const { currentRef, writtenComments, failures } = await runPreview({
+			pullResponse: { ...pull, base: { sha } },
+			deploymentSnapshots: [successfulDeployments],
+		});
+
+		assert.equal(currentRef, deploymentSha);
+		assert.match(writtenComments.at(-1).body, /SUCCESS/);
+		assert.deepEqual(failures, []);
+	});
+
 	test('does not publish a ref if the label was removed before a queued run starts', async () => {
 		const { deploymentQueries, gitCalls, writtenComments, notices } = await runPreview({
 			pullResponse: { ...pull, labels: [] },


### PR DESCRIPTION
## Summary

- make the credential-free `deploy-preview` label flow emit a real Vercel-observable branch update
- grant the workflow permission to write its preview-status comment

## Why

PR #596 reproduced two independent failures. The workflow created `deploy-preview-pr-596`, but Vercel reported no deployment for that API-created ref, and GitHub then rejected the workflow's PR comment with `Resource not accessible by integration`.

## Changes

- create a unique deployment commit with the PR head's exact tree and attribute it to the maintainer who applied `deploy-preview`
- create a new preview branch at trusted base code, then update it to the deployment commit so Vercel receives the branch push it expects
- poll GitHub Deployments by the unique deployment SHA while still reporting the source PR SHA
- request `pull-requests: write` for the status comment
- cover new-ref, existing-ref, equal base/head, cleanup, deployment reporting, and permission behavior in the CI workflow harness

## Validation

- [ ] `pnpm format:check`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [x] targeted tests: `pnpm ci:workflow:test` (71 passed)
- [x] `pnpm format:files:check .github/workflows/vercel-preview.yml scripts/ci-workflow.test.mjs`
- [x] `pnpm sync`
- [x] live diagnosis: updating `deploy-preview-pr-596` produced successful Website and MCP Website Vercel previews without Vercel credentials

## Risk / follow-ups

- `pull_request_target` executes the workflow from the default branch, so the unique-commit path can only be proven against Vercel after this change merges. The regression harness executes the complete embedded script with mocked GitHub APIs before merge.
- GitHub Actions also had an unrelated transient outage during #596: several CI jobs failed while downloading actions with 500/502/503 responses.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes trusted pull_request_target Git ref manipulation and commit attribution used for Vercel authorization; behavior is heavily tested but full Vercel integration only proves out after merge.
> 
> **Overview**
> Fixes **labeled Vercel preview deploys** that previously created `deploy-preview-pr-*` refs without triggering Vercel, and **PR status comments** that failed with insufficient token scope.
> 
> The workflow now builds a **tree-identical deployment commit** on each label (unique SHA, **author = maintainer who applied `deploy-preview`**) and moves the preview branch to that commit. **New** preview branches are created at the PR **base** SHA, then **force-updated** to the deployment commit so Vercel’s Git integration sees a push. **Existing** branches always update to a fresh deployment commit—even when already at the PR head—so redeploys still fire. Deployment polling and failure messages use the **deployment SHA**; the PR comment still shows the source PR SHA plus the deployment commit.
> 
> Grants **`pull-requests: write`** so the bot can post/update preview status. CI harness tests cover synthetic commits, base-then-update ref creation, redeploy when the branch already matches head, and the permission change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65cc66908c81549599b0e1517ef018e037c8f291. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
