### PR TITLE
fix: lynx - retireFirstScreen produces 2 outcomes, follow up #595

### DIFF
--- a/packages/lynx/src/main-thread.ts
+++ b/packages/lynx/src/main-thread.ts
@@ -537,8 +537,14 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 	let firstScreenRenderInProgress = false;
 	let closePending = false;
 	let finalizeDeferredClose: (() => void) | null = null;
-	let firstScreenState: 'open' | 'painted' | 'skipped' | 'failed' | 'cleanup-pending' =
-		firstScreenEnabled ? 'open' : 'skipped';
+	type FirstScreenState =
+		| 'open'
+		| 'painted'
+		| 'skipped'
+		| 'failed'
+		| 'cleanup-pending:skipped'
+		| 'cleanup-pending:failed';
+	let firstScreenState: FirstScreenState = firstScreenEnabled ? 'open' : 'skipped';
 	let firstScreenSyncReady = !firstScreenEnabled;
 	const firstScreenRenderMode = options.firstScreenRender ?? 'immediate';
 	let pendingFirstScreenRender: (() => void) | null = null;
@@ -1209,9 +1215,12 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 		}
 	};
 
+	const isFirstScreenCleanupPending = () =>
+		firstScreenState === 'cleanup-pending:skipped' || firstScreenState === 'cleanup-pending:failed';
+
 	const canAnnounceReady = () =>
 		!firstScreenEnabled ||
-		(firstScreenState !== 'open' && firstScreenState !== 'cleanup-pending' && firstScreenSyncReady);
+		(firstScreenState !== 'open' && !isFirstScreenCleanupPending() && firstScreenSyncReady);
 
 	const dispatchReady = (request: number): boolean => {
 		// Request 0 is an unsolicited availability hint and can be emitted before a
@@ -1318,7 +1327,13 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 		for (let attempt = 0; attempt < MAX_CLOSE_CLEANUP_ATTEMPTS; attempt++) {
 			const treeComplete = disposeAvailableFirstTree();
 			const sourceComplete = disposeFailedFirstScreenSource();
-			if (treeComplete && sourceComplete) return true;
+			if (treeComplete && sourceComplete) {
+				// Ready, fault, dispose, and unmount retries all finish here; preserve
+				// the outcome chosen when retirement began.
+				if (firstScreenState === 'cleanup-pending:skipped') firstScreenState = 'skipped';
+				else if (firstScreenState === 'cleanup-pending:failed') firstScreenState = 'failed';
+				return true;
+			}
 		}
 		return false;
 	};
@@ -1334,12 +1349,10 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 		settled: 'skipped' | 'failed',
 		reason: string,
 	): void => {
-		firstScreenState = 'cleanup-pending';
+		firstScreenState = settled === 'skipped' ? 'cleanup-pending:skipped' : 'cleanup-pending:failed';
 		firstScreenSyncReady = true;
 		if (firstTree === null && source !== null) failedFirstScreenSource = source;
-		if (retryFirstScreenCleanup()) {
-			firstScreenState = settled;
-		} else {
+		if (!retryFirstScreenCleanup()) {
 			report(
 				new Error(
 					`Octane Lynx withheld background readiness because ${reason} first-screen cleanup remains incomplete.`,
@@ -1741,9 +1754,7 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 			return;
 		}
 		queuedReadyRequests.add(message.request);
-		if (firstScreenState === 'cleanup-pending' && retryFirstScreenCleanup()) {
-			firstScreenState = 'failed';
-		}
+		if (isFirstScreenCleanupPending()) retryFirstScreenCleanup();
 		if (canAnnounceReady()) announceReady();
 	};
 
@@ -2453,7 +2464,9 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 					// can still gate readiness until a retry succeeds.
 					firstScreenSyncReady = true;
 					if (!retryFirstScreenCleanup()) {
-						firstScreenState = 'cleanup-pending';
+						if (!isFirstScreenCleanupPending()) {
+							firstScreenState = 'cleanup-pending:skipped';
+						}
 						report(
 							new Error(
 								'Octane Lynx withheld background readiness because first-screen unmount cleanup remains incomplete.',
@@ -2461,11 +2474,7 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 						);
 						return;
 					}
-					if (
-						firstScreenState === 'open' ||
-						firstScreenState === 'painted' ||
-						firstScreenState === 'cleanup-pending'
-					) {
+					if (firstScreenState === 'open' || firstScreenState === 'painted') {
 						firstScreenState = 'skipped';
 					}
 					announceReady();

--- a/packages/lynx/tests/first-screen.test.ts
+++ b/packages/lynx/tests/first-screen.test.ts
@@ -692,12 +692,12 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 		]);
 	});
 
-	it('retries cleanup for a declined first screen instead of withholding readiness', () => {
-		let removalFailures = 0;
+	it('retries deferred cleanup for a declined first screen before announcing readiness', () => {
+		let allowCleanup = false;
 		const { dom, main } = installEnvironment((target) => {
 			const remove = target.__RemoveElement as (parent: object, child: object) => unknown;
 			target.__RemoveElement = (parent: object, child: object) => {
-				if (removalFailures++ < 1) throw new Error('transient declined-source remove failure');
+				if (!allowCleanup) throw new Error('transient declined-source remove failure');
 				return remove(parent, child);
 			};
 		});
@@ -708,12 +708,24 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 
 		expect(firstScreenRoot.render(FeedScene, {})).toBeNull();
 
-		// A removal that fails once and succeeds on retry is still an ordinary
-		// decline: the nodes come out and the background is released immediately.
-		expect(removalFailures).toBeGreaterThan(1);
+		expect(dom.window.document.querySelector('#feed-shell')).not.toBeNull();
+		expect(main.firstScreenSnapshot()).toBeNull();
+		expect(inbound).toEqual([]);
+
+		allowCleanup = true;
+		backgroundContext().dispatchEvent({
+			type: LYNX_BACKGROUND_TO_MAIN_EVENT,
+			data: {
+				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
+				renderer: LYNX_TRANSPORT_RENDERER,
+				type: 'main-ready-request',
+				request: 52,
+			},
+		});
+
 		expect(dom.window.document.querySelector('#feed-shell')).toBeNull();
 		expect(main.firstScreenSnapshot()).toBeNull();
-		expect(inbound).toEqual([expect.objectContaining({ type: 'main-ready', request: 0 })]);
+		expect(inbound).toEqual([expect.objectContaining({ type: 'main-ready', request: 52 })]);
 	});
 
 	it('retains a failed pre-capture source and retries cleanup for background readiness', () => {


### PR DESCRIPTION
follow up to: https://github.com/octanejs/octane/pull/595#discussion_r3731238124

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches main-thread first-screen lifecycle and when background receives `main-ready`, which can affect startup ordering if cleanup retries fail or timing changes.
> 
> **Overview**
> **First-screen retirement** now records **`cleanup-pending:skipped`** vs **`cleanup-pending:failed`** instead of a single **`cleanup-pending`**, so when **`retryFirstScreenCleanup`** finishes it can settle to the outcome chosen at retirement (**`skipped`** or **`failed`**) instead of callers guessing.
> 
> **Background readiness** stays blocked while either cleanup-pending variant is active (**`canAnnounceReady`** / **`isFirstScreenCleanupPending`**). **`retireFirstScreen`** no longer flips to **`skipped`/`failed`** immediately on successful cleanup; **`handleReady`** retries cleanup without forcing **`failed`** on every ready request. **Unmount** enters **`cleanup-pending:skipped`** only when cleanup is still incomplete and not already pending.
> 
> The **declined `<list>` first-screen** test now expects **no `main-ready`** and **DOM nodes to remain** until a **`main-ready-request`** arrives and removal succeeds—matching deferred cleanup rather than announcing readiness while teardown is still failing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 236d77f353ce2eb606aa2f355a7d7de541175c6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->