### PR TITLE
fix(octane): enforce Strong-mode hook callback purity

### DIFF
--- a/.changeset/strong-hook-callback-purity.md
+++ b/.changeset/strong-hook-callback-purity.md
@@ -1,0 +1,7 @@
+---
+'octane': patch
+---
+
+Enforce Strong-mode render purity inside lazy state initializers, linked-state
+reconcilers, and their source/value equality callbacks without restricting
+deferred work or compatibility-mode applications.

--- a/packages/octane/src/compiler/strong-mode.js
+++ b/packages/octane/src/compiler/strong-mode.js
@@ -676,7 +676,9 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				target.bindings.set(declaration.id.name, { kind: 'linked-key', value: initial.value });
 			} else if (
 				declarationKind === 'const' &&
-				(initial?.type === 'ObjectExpression' || initial?.type === 'ConditionalExpression') &&
+				(initial?.type === 'ObjectExpression' ||
+					initial?.type === 'ConditionalExpression' ||
+					initial?.type === 'LogicalExpression') &&
 				linkedStateOptionsExpression(initial, scope)
 			) {
 				target.bindings.set(declaration.id.name, {
@@ -686,7 +688,7 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				});
 			} else if (
 				declarationKind === 'const' &&
-				initial?.type === 'ConditionalExpression' &&
+				(initial?.type === 'ConditionalExpression' || initial?.type === 'LogicalExpression') &&
 				synchronousCallbackExpression(initial, scope)
 			) {
 				target.bindings.set(declaration.id.name, {
@@ -722,6 +724,52 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		);
 	}
 
+	function logicalExpressionBranches(expression, scope) {
+		const left = unwrap(expression.left);
+		let truthy;
+		let nullish;
+		if (left?.type === 'Literal') {
+			truthy = Boolean(left.value);
+			nullish = left.value == null;
+		} else if (
+			FUNCTION_TYPES.has(left?.type) ||
+			left?.type === 'ObjectExpression' ||
+			left?.type === 'ArrayExpression' ||
+			stateTupleUpdater(left, scope)
+		) {
+			truthy = true;
+			nullish = false;
+		} else if (left?.type === 'Identifier') {
+			const binding = resolve(scope, left.name);
+			if (binding == null && left.name === 'undefined') {
+				truthy = false;
+				nullish = true;
+			} else if (
+				binding?.kind === 'callback' ||
+				binding?.kind === 'setter' ||
+				binding?.kind === 'ref' ||
+				binding?.kind === 'state-tuple' ||
+				(binding?.kind === 'linked-options' && unwrap(binding.node)?.type === 'ObjectExpression') ||
+				binding?.kind === 'linked-key' ||
+				binding?.kind === 'hook' ||
+				binding?.kind === 'namespace'
+			) {
+				truthy = true;
+				nullish = false;
+			}
+		}
+		if (expression.operator === '??') {
+			return nullish === true ? 2 : nullish === false ? 1 : 3;
+		}
+		if (expression.operator === '||') {
+			return truthy === true ? 1 : truthy === false ? 2 : 3;
+		}
+		if (expression.operator === '&&') {
+			return truthy === true ? 2 : truthy === false ? 1 : 3;
+		}
+		return 3;
+	}
+
 	function visitSynchronousHookCallback(value, scope, phase) {
 		const callback = unwrap(value);
 		if (FUNCTION_TYPES.has(callback?.type)) {
@@ -731,11 +779,22 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			visitSynchronousHookCallback(callback.consequent, scope, phase);
 			visitSynchronousHookCallback(callback.alternate, scope, phase);
 			return true;
+		} else if (callback?.type === 'LogicalExpression') {
+			const branches = logicalExpressionBranches(callback, scope);
+			if ((branches & 1) !== 0) visitSynchronousHookCallback(callback.left, scope, phase);
+			if ((branches & 2) !== 0) visitSynchronousHookCallback(callback.right, scope, phase);
+			return true;
 		} else if (callback?.type === 'Identifier') {
 			const binding = resolve(scope, callback.name);
 			if (binding?.kind === 'callback') visitCallback(binding.node, binding.scope, phase);
 			else if (binding?.kind === 'callback-choice') {
-				visitSynchronousHookCallback(binding.node, binding.scope, phase);
+				if (activeCallbacks.has(binding.node)) return true;
+				activeCallbacks.add(binding.node);
+				try {
+					visitSynchronousHookCallback(binding.node, binding.scope, phase);
+				} finally {
+					activeCallbacks.delete(binding.node);
+				}
 			} else if (binding?.kind === 'setter' && (phase === 'render' || phase === 'effect')) {
 				reportSetter(callback, phase);
 			}
@@ -758,6 +817,13 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			return (
 				synchronousCallbackExpression(callback.consequent, scope) ||
 				synchronousCallbackExpression(callback.alternate, scope)
+			);
+		}
+		if (callback?.type === 'LogicalExpression') {
+			const branches = logicalExpressionBranches(callback, scope);
+			return (
+				((branches & 1) !== 0 && synchronousCallbackExpression(callback.left, scope)) ||
+				((branches & 2) !== 0 && synchronousCallbackExpression(callback.right, scope))
 			);
 		}
 		return false;
@@ -785,10 +851,14 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		if (options?.type === 'Identifier') {
 			return resolve(scope, options.name)?.kind === 'linked-options';
 		}
-		if (options?.type === 'ConditionalExpression') {
+		if (options?.type === 'ConditionalExpression' || options?.type === 'LogicalExpression') {
+			const logical = options.type === 'LogicalExpression';
+			const branches = logical ? logicalExpressionBranches(options, scope) : 3;
 			return (
-				linkedStateOptionsExpression(options.consequent, scope) ||
-				linkedStateOptionsExpression(options.alternate, scope)
+				((branches & 1) !== 0 &&
+					linkedStateOptionsExpression(logical ? options.left : options.consequent, scope)) ||
+				((branches & 2) !== 0 &&
+					linkedStateOptionsExpression(logical ? options.right : options.alternate, scope))
 			);
 		}
 		return (
@@ -811,7 +881,9 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			scope = binding.scope;
 		}
 		if (
-			(options?.type !== 'ObjectExpression' && options?.type !== 'ConditionalExpression') ||
+			(options?.type !== 'ObjectExpression' &&
+				options?.type !== 'ConditionalExpression' &&
+				options?.type !== 'LogicalExpression') ||
 			activeOptions?.has(options)
 		) {
 			return;
@@ -820,25 +892,27 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		activeOptions ??= new Set();
 		activeOptions.add(options);
 		try {
-			if (options.type === 'ConditionalExpression') {
-				const consequentOverrides = new Set(overridden);
-				const alternateOverrides = new Set(overridden);
-				visitLinkedStateComparators(
-					options.consequent,
-					scope,
-					phase,
-					consequentOverrides,
-					activeOptions,
-				);
-				visitLinkedStateComparators(
-					options.alternate,
-					scope,
-					phase,
-					alternateOverrides,
-					activeOptions,
-				);
-				for (const name of consequentOverrides) {
-					if (alternateOverrides.has(name)) overridden.add(name);
+			if (options.type === 'ConditionalExpression' || options.type === 'LogicalExpression') {
+				const logical = options.type === 'LogicalExpression';
+				const branches = logical ? logicalExpressionBranches(options, scope) : 3;
+				const first = logical ? options.left : options.consequent;
+				const second = logical ? options.right : options.alternate;
+				if (branches !== 3) {
+					visitLinkedStateComparators(
+						branches === 1 ? first : second,
+						scope,
+						phase,
+						overridden,
+						activeOptions,
+					);
+					return;
+				}
+				const firstOverrides = new Set(overridden);
+				const secondOverrides = new Set(overridden);
+				visitLinkedStateComparators(first, scope, phase, firstOverrides, activeOptions);
+				visitLinkedStateComparators(second, scope, phase, secondOverrides, activeOptions);
+				for (const name of firstOverrides) {
+					if (secondOverrides.has(name)) overridden.add(name);
 				}
 				return;
 			}

--- a/packages/octane/src/compiler/strong-mode.js
+++ b/packages/octane/src/compiler/strong-mode.js
@@ -18,6 +18,7 @@ const NULLISH_VALUE = 1;
 const FALSY_VALUE = 2;
 const TRUTHY_VALUE = 4;
 const UNKNOWN_VALUE = NULLISH_VALUE | FALSY_VALUE | TRUTHY_VALUE;
+const UNKNOWN_PRIMITIVE = Symbol('unknown primitive');
 const SKIP_KEYS = new Set([
 	'type',
 	'start',
@@ -650,6 +651,20 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			const element = declaration.id.elements?.[1];
 			const setter = element?.type === 'AssignmentPattern' ? element.left : element;
 			if (setter?.type === 'Identifier') target.bindings.set(setter.name, { kind: 'setter' });
+		} else if (declaration.id?.type === 'ObjectPattern' && stateTuple) {
+			for (const property of declaration.id.properties ?? []) {
+				if (property.type !== 'Property') continue;
+				const key = property.computed
+					? staticPrimitiveValue(property.key, scope)
+					: property.key?.type === 'Identifier'
+						? property.key.name
+						: property.key?.value;
+				const value = property.value;
+				const setter = value?.type === 'AssignmentPattern' ? value.left : value;
+				if ((key === 1 || key === '1') && setter?.type === 'Identifier') {
+					target.bindings.set(setter.name, { kind: 'setter' });
+				}
+			}
 		} else if (declaration.id?.type === 'Identifier') {
 			if (stateTuple) {
 				target.bindings.set(declaration.id.name, { kind: 'state-tuple' });
@@ -658,6 +673,8 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				importedHook(initial.callee, scope) === 'useRef'
 			) {
 				target.bindings.set(declaration.id.name, { kind: 'ref' });
+			} else if (declarationKind === 'const' && stateTupleUpdater(initial, scope)) {
+				target.bindings.set(declaration.id.name, { kind: 'setter' });
 			} else if (declarationKind === 'const' && initial?.type === 'Identifier') {
 				const value = resolve(scope, initial.name);
 				if (
@@ -671,16 +688,22 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				) {
 					target.bindings.set(declaration.id.name, value);
 				} else if (value == null && initial.name === 'undefined') {
-					target.bindings.set(declaration.id.name, { kind: 'constant', value: NULLISH_VALUE });
+					target.bindings.set(declaration.id.name, {
+						kind: 'constant',
+						value: NULLISH_VALUE,
+						primitive: undefined,
+					});
 				}
 			} else if (declarationKind === 'const' && FUNCTION_TYPES.has(initial?.type)) {
 				target.bindings.set(declaration.id.name, { kind: 'callback', node: initial, scope });
 			} else if (
 				declarationKind === 'const' &&
-				initial?.type === 'Literal' &&
-				(initial.value === 'sourceEqual' || initial.value === 'valueEqual')
+				staticLinkedStateComparatorKey(initial, scope) !== null
 			) {
-				target.bindings.set(declaration.id.name, { kind: 'linked-key', value: initial.value });
+				target.bindings.set(declaration.id.name, {
+					kind: 'linked-key',
+					value: staticLinkedStateComparatorKey(initial, scope),
+				});
 			} else if (
 				declarationKind === 'const' &&
 				(initial?.type === 'ObjectExpression' ||
@@ -709,7 +732,11 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			} else if (declarationKind === 'const') {
 				const value = staticExpressionValue(initial, scope);
 				if (value !== UNKNOWN_VALUE) {
-					target.bindings.set(declaration.id.name, { kind: 'constant', value });
+					target.bindings.set(declaration.id.name, {
+						kind: 'constant',
+						value,
+						primitive: staticPrimitiveValue(initial, scope),
+					});
 				}
 			}
 		}
@@ -730,13 +757,78 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 	function stateTupleUpdater(value, scope) {
 		const member = unwrap(value);
 		if (member?.type !== 'MemberExpression' || member.computed !== true) return false;
-		const property = unwrap(member.property);
+		const property = staticPrimitiveValue(member.property, scope);
 		return (
-			property?.type === 'Literal' &&
-			(property.value === 1 || property.value === '1') &&
+			(property === 1 || property === '1') &&
 			unwrap(member.object)?.type === 'Identifier' &&
 			resolve(scope, unwrap(member.object).name)?.kind === 'state-tuple'
 		);
+	}
+
+	function staticPrimitiveValue(value, scope) {
+		const expression = unwrap(value);
+		if (expression?.type === 'Literal') return expression.value;
+		if (expression?.type === 'Identifier') {
+			const binding = resolve(scope, expression.name);
+			if (binding?.kind === 'linked-key') return binding.value;
+			if (binding?.kind === 'constant') return binding.primitive;
+			if (binding == null && expression.name === 'undefined') return undefined;
+			return UNKNOWN_PRIMITIVE;
+		}
+		if (expression?.type === 'TemplateLiteral') {
+			let result = '';
+			for (let index = 0; index < (expression.quasis?.length ?? 0); index++) {
+				const text = expression.quasis[index]?.value?.cooked;
+				if (text == null) return UNKNOWN_PRIMITIVE;
+				result += text;
+				if (index < (expression.expressions?.length ?? 0)) {
+					const part = staticPrimitiveValue(expression.expressions[index], scope);
+					if (
+						part === UNKNOWN_PRIMITIVE ||
+						(part !== null && typeof part === 'object') ||
+						typeof part === 'function' ||
+						typeof part === 'symbol'
+					) {
+						return UNKNOWN_PRIMITIVE;
+					}
+					result += String(part);
+				}
+			}
+			return result;
+		}
+		if (expression?.type === 'BinaryExpression' && expression.operator === '+') {
+			const left = staticPrimitiveValue(expression.left, scope);
+			const right = staticPrimitiveValue(expression.right, scope);
+			return typeof left === 'string' && typeof right === 'string'
+				? left + right
+				: UNKNOWN_PRIMITIVE;
+		}
+		if (expression?.type === 'SequenceExpression') {
+			const expressions = expression.expressions ?? [];
+			return staticPrimitiveValue(expressions[expressions.length - 1], scope);
+		}
+		if (expression?.type === 'ConditionalExpression') {
+			const branches = conditionalExpressionBranches(expression, scope);
+			return branches === 1
+				? staticPrimitiveValue(expression.consequent, scope)
+				: branches === 2
+					? staticPrimitiveValue(expression.alternate, scope)
+					: UNKNOWN_PRIMITIVE;
+		}
+		if (expression?.type === 'LogicalExpression') {
+			const branches = logicalExpressionBranches(expression, scope);
+			return branches === 1
+				? staticPrimitiveValue(expression.left, scope)
+				: branches === 2
+					? staticPrimitiveValue(expression.right, scope)
+					: UNKNOWN_PRIMITIVE;
+		}
+		return UNKNOWN_PRIMITIVE;
+	}
+
+	function staticLinkedStateComparatorKey(value, scope) {
+		const key = staticPrimitiveValue(value, scope);
+		return key === 'sourceEqual' || key === 'valueEqual' ? key : null;
 	}
 
 	function staticExpressionValue(value, scope) {
@@ -754,6 +846,13 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			stateTupleUpdater(expression, scope)
 		) {
 			return TRUTHY_VALUE;
+		} else if (expression?.type === 'TemplateLiteral') {
+			const primitive = staticPrimitiveValue(expression, scope);
+			return primitive === UNKNOWN_PRIMITIVE
+				? UNKNOWN_VALUE
+				: primitive
+					? TRUTHY_VALUE
+					: FALSY_VALUE;
 		} else if (expression?.type === 'Identifier') {
 			const binding = resolve(scope, expression.name);
 			if (binding == null && expression.name === 'undefined') return NULLISH_VALUE;
@@ -928,17 +1027,12 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 	function linkedStateComparatorName(property, scope) {
 		if (property?.type !== 'Property' || property.kind !== 'init') return null;
 		const key = unwrap(property.key);
-		let name;
-		if (property.computed !== true) {
-			name = key?.type === 'Identifier' ? key.name : key?.value;
-		} else if (key?.type === 'Identifier') {
-			const binding = resolve(scope, key.name);
-			name = binding?.kind === 'linked-key' ? binding.value : null;
-		} else if (key?.type === 'TemplateLiteral' && (key.expressions?.length ?? 0) === 0) {
-			name = key.quasis?.[0]?.value?.cooked;
-		} else {
-			name = key?.type === 'Literal' ? key.value : null;
-		}
+		const name =
+			property.computed !== true
+				? key?.type === 'Identifier'
+					? key.name
+					: key?.value
+				: staticPrimitiveValue(key, scope);
 		return name === 'sourceEqual' || name === 'valueEqual' ? name : null;
 	}
 

--- a/packages/octane/src/compiler/strong-mode.js
+++ b/packages/octane/src/compiler/strong-mode.js
@@ -1249,6 +1249,14 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 					calleeBinding?.kind === 'callback'
 				) {
 					visitCallback(calleeBinding.node, calleeBinding.scope, executionPhase);
+				} else if (
+					(executionPhase === 'render' || executionPhase === 'effect') &&
+					(calleeBinding?.kind === 'callback-choice' ||
+						callee?.type === 'SequenceExpression' ||
+						callee?.type === 'ConditionalExpression' ||
+						callee?.type === 'LogicalExpression')
+				) {
+					visitSynchronousHookCallback(callee, scope, executionPhase);
 				}
 				return;
 			}

--- a/packages/octane/src/compiler/strong-mode.js
+++ b/packages/octane/src/compiler/strong-mode.js
@@ -730,12 +730,16 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 					scope,
 				});
 			} else if (declarationKind === 'const') {
-				const value = staticExpressionValue(initial, scope);
+				const primitive = staticPrimitiveValue(initial, scope);
+				let value = staticExpressionValue(initial, scope);
+				if (value === UNKNOWN_VALUE && primitive !== UNKNOWN_PRIMITIVE) {
+					value = primitive == null ? NULLISH_VALUE : primitive ? TRUTHY_VALUE : FALSY_VALUE;
+				}
 				if (value !== UNKNOWN_VALUE) {
 					target.bindings.set(declaration.id.name, {
 						kind: 'constant',
 						value,
-						primitive: staticPrimitiveValue(initial, scope),
+						primitive,
 					});
 				}
 			}
@@ -799,9 +803,53 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		if (expression?.type === 'BinaryExpression' && expression.operator === '+') {
 			const left = staticPrimitiveValue(expression.left, scope);
 			const right = staticPrimitiveValue(expression.right, scope);
-			return typeof left === 'string' && typeof right === 'string'
-				? left + right
-				: UNKNOWN_PRIMITIVE;
+			if (
+				left === UNKNOWN_PRIMITIVE ||
+				right === UNKNOWN_PRIMITIVE ||
+				(left !== null && typeof left === 'object') ||
+				(right !== null && typeof right === 'object') ||
+				typeof left === 'function' ||
+				typeof right === 'function' ||
+				typeof left === 'symbol' ||
+				typeof right === 'symbol'
+			) {
+				return UNKNOWN_PRIMITIVE;
+			}
+			if (
+				(typeof left === 'bigint' || typeof right === 'bigint') &&
+				typeof left !== 'string' &&
+				typeof right !== 'string' &&
+				(typeof left !== 'bigint' || typeof right !== 'bigint')
+			) {
+				return UNKNOWN_PRIMITIVE;
+			}
+			return left + right;
+		}
+		if (expression?.type === 'UnaryExpression') {
+			if (expression.operator === 'void') return undefined;
+			const argument = staticPrimitiveValue(expression.argument, scope);
+			if (expression.operator === '!') {
+				if (argument !== UNKNOWN_PRIMITIVE) return !argument;
+				const value = staticExpressionValue(expression.argument, scope);
+				return value === TRUTHY_VALUE
+					? false
+					: value !== UNKNOWN_VALUE && (value & TRUTHY_VALUE) === 0
+						? true
+						: UNKNOWN_PRIMITIVE;
+			}
+			if (
+				argument === UNKNOWN_PRIMITIVE ||
+				(argument !== null && typeof argument === 'object') ||
+				typeof argument === 'function' ||
+				typeof argument === 'symbol'
+			) {
+				return UNKNOWN_PRIMITIVE;
+			}
+			if (expression.operator === '+') {
+				return typeof argument === 'bigint' ? UNKNOWN_PRIMITIVE : +argument;
+			}
+			if (expression.operator === '-') return -argument;
+			if (expression.operator === '~') return ~argument;
 		}
 		if (expression?.type === 'SequenceExpression') {
 			const expressions = expression.expressions ?? [];
@@ -846,13 +894,20 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			stateTupleUpdater(expression, scope)
 		) {
 			return TRUTHY_VALUE;
-		} else if (expression?.type === 'TemplateLiteral') {
+		} else if (
+			expression?.type === 'TemplateLiteral' ||
+			(expression?.type === 'BinaryExpression' && expression.operator === '+') ||
+			(expression?.type === 'UnaryExpression' &&
+				(expression.operator === '+' || expression.operator === '-' || expression.operator === '~'))
+		) {
 			const primitive = staticPrimitiveValue(expression, scope);
 			return primitive === UNKNOWN_PRIMITIVE
 				? UNKNOWN_VALUE
-				: primitive
-					? TRUTHY_VALUE
-					: FALSY_VALUE;
+				: primitive == null
+					? NULLISH_VALUE
+					: primitive
+						? TRUTHY_VALUE
+						: FALSY_VALUE;
 		} else if (expression?.type === 'Identifier') {
 			const binding = resolve(scope, expression.name);
 			if (binding == null && expression.name === 'undefined') return NULLISH_VALUE;

--- a/packages/octane/src/compiler/strong-mode.js
+++ b/packages/octane/src/compiler/strong-mode.js
@@ -656,11 +656,44 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				target.bindings.set(declaration.id.name, { kind: 'ref' });
 			} else if (declarationKind === 'const' && initial?.type === 'Identifier') {
 				const value = resolve(scope, initial.name);
-				if (value?.kind === 'setter' || value?.kind === 'ref' || value?.kind === 'callback') {
+				if (
+					value?.kind === 'setter' ||
+					value?.kind === 'ref' ||
+					value?.kind === 'callback' ||
+					value?.kind === 'callback-choice' ||
+					value?.kind === 'linked-options' ||
+					value?.kind === 'linked-key'
+				) {
 					target.bindings.set(declaration.id.name, value);
 				}
 			} else if (declarationKind === 'const' && FUNCTION_TYPES.has(initial?.type)) {
 				target.bindings.set(declaration.id.name, { kind: 'callback', node: initial, scope });
+			} else if (
+				declarationKind === 'const' &&
+				initial?.type === 'Literal' &&
+				(initial.value === 'sourceEqual' || initial.value === 'valueEqual')
+			) {
+				target.bindings.set(declaration.id.name, { kind: 'linked-key', value: initial.value });
+			} else if (
+				declarationKind === 'const' &&
+				(initial?.type === 'ObjectExpression' || initial?.type === 'ConditionalExpression') &&
+				linkedStateOptionsExpression(initial, scope)
+			) {
+				target.bindings.set(declaration.id.name, {
+					kind: 'linked-options',
+					node: initial,
+					scope,
+				});
+			} else if (
+				declarationKind === 'const' &&
+				initial?.type === 'ConditionalExpression' &&
+				synchronousCallbackExpression(initial, scope)
+			) {
+				target.bindings.set(declaration.id.name, {
+					kind: 'callback-choice',
+					node: initial,
+					scope,
+				});
 			}
 		}
 		visit(declaration.init, scope, phase);
@@ -694,10 +727,16 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		if (FUNCTION_TYPES.has(callback?.type)) {
 			visitCallback(callback, scope, phase);
 			return true;
+		} else if (callback?.type === 'ConditionalExpression') {
+			visitSynchronousHookCallback(callback.consequent, scope, phase);
+			visitSynchronousHookCallback(callback.alternate, scope, phase);
+			return true;
 		} else if (callback?.type === 'Identifier') {
 			const binding = resolve(scope, callback.name);
 			if (binding?.kind === 'callback') visitCallback(binding.node, binding.scope, phase);
-			else if (binding?.kind === 'setter' && (phase === 'render' || phase === 'effect')) {
+			else if (binding?.kind === 'callback-choice') {
+				visitSynchronousHookCallback(binding.node, binding.scope, phase);
+			} else if (binding?.kind === 'setter' && (phase === 'render' || phase === 'effect')) {
 				reportSetter(callback, phase);
 			}
 			return true;
@@ -706,6 +745,119 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			return true;
 		}
 		return false;
+	}
+
+	function synchronousCallbackExpression(value, scope) {
+		const callback = unwrap(value);
+		if (FUNCTION_TYPES.has(callback?.type) || stateTupleUpdater(callback, scope)) return true;
+		if (callback?.type === 'Identifier') {
+			const kind = resolve(scope, callback.name)?.kind;
+			return kind === 'callback' || kind === 'callback-choice' || kind === 'setter';
+		}
+		if (callback?.type === 'ConditionalExpression') {
+			return (
+				synchronousCallbackExpression(callback.consequent, scope) ||
+				synchronousCallbackExpression(callback.alternate, scope)
+			);
+		}
+		return false;
+	}
+
+	function linkedStateComparatorName(property, scope) {
+		if (property?.type !== 'Property' || property.kind !== 'init') return null;
+		const key = unwrap(property.key);
+		let name;
+		if (property.computed !== true) {
+			name = key?.type === 'Identifier' ? key.name : key?.value;
+		} else if (key?.type === 'Identifier') {
+			const binding = resolve(scope, key.name);
+			name = binding?.kind === 'linked-key' ? binding.value : null;
+		} else if (key?.type === 'TemplateLiteral' && (key.expressions?.length ?? 0) === 0) {
+			name = key.quasis?.[0]?.value?.cooked;
+		} else {
+			name = key?.type === 'Literal' ? key.value : null;
+		}
+		return name === 'sourceEqual' || name === 'valueEqual' ? name : null;
+	}
+
+	function linkedStateOptionsExpression(value, scope) {
+		const options = unwrap(value);
+		if (options?.type === 'Identifier') {
+			return resolve(scope, options.name)?.kind === 'linked-options';
+		}
+		if (options?.type === 'ConditionalExpression') {
+			return (
+				linkedStateOptionsExpression(options.consequent, scope) ||
+				linkedStateOptionsExpression(options.alternate, scope)
+			);
+		}
+		return (
+			options?.type === 'ObjectExpression' &&
+			(options.properties ?? []).some((property) =>
+				property.type === 'SpreadElement'
+					? linkedStateOptionsExpression(property.argument, scope)
+					: linkedStateComparatorName(property, scope) !== null,
+			)
+		);
+	}
+
+	function visitLinkedStateComparators(value, parentScope, phase, overridden, activeOptions) {
+		let options = unwrap(value);
+		let scope = parentScope;
+		if (options?.type === 'Identifier') {
+			const binding = resolve(scope, options.name);
+			if (binding?.kind !== 'linked-options') return;
+			options = binding.node;
+			scope = binding.scope;
+		}
+		if (
+			(options?.type !== 'ObjectExpression' && options?.type !== 'ConditionalExpression') ||
+			activeOptions?.has(options)
+		) {
+			return;
+		}
+		overridden ??= new Set();
+		activeOptions ??= new Set();
+		activeOptions.add(options);
+		try {
+			if (options.type === 'ConditionalExpression') {
+				const consequentOverrides = new Set(overridden);
+				const alternateOverrides = new Set(overridden);
+				visitLinkedStateComparators(
+					options.consequent,
+					scope,
+					phase,
+					consequentOverrides,
+					activeOptions,
+				);
+				visitLinkedStateComparators(
+					options.alternate,
+					scope,
+					phase,
+					alternateOverrides,
+					activeOptions,
+				);
+				for (const name of consequentOverrides) {
+					if (alternateOverrides.has(name)) overridden.add(name);
+				}
+				return;
+			}
+			const properties = options.properties ?? [];
+			for (let index = properties.length - 1; index >= 0; index--) {
+				const property = properties[index];
+				if (property.type === 'SpreadElement') {
+					visitLinkedStateComparators(property.argument, scope, phase, overridden, activeOptions);
+					continue;
+				}
+				const name = linkedStateComparatorName(property, scope);
+				if (name !== null && !overridden.has(name)) {
+					overridden.add(name);
+					visitSynchronousHookCallback(property.value, scope, phase);
+				}
+			}
+		} finally {
+			activeOptions.delete(options);
+		}
 	}
 
 	function visit(node, scope, phase) {
@@ -860,10 +1012,17 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 					visit(node.callee, scope, phase);
 				}
 				let executionPhase = phaseAfter(node.callee, phase, true, node.optional === true);
-				const synchronousHook = EFFECT_HOOKS.has(hook) || hook === 'useMemo';
+				const synchronousCallbackIndex =
+					hook === 'useLinkedState'
+						? 1
+						: hook === 'useReducer'
+							? 2
+							: hook === 'useState' || hook === 'useMemo' || EFFECT_HOOKS.has(hook)
+								? 0
+								: -1;
 				for (let index = 0; index < (node.arguments?.length ?? 0); index++) {
 					const argument = node.arguments[index];
-					if (index !== 0 || !synchronousHook || !FUNCTION_TYPES.has(unwrap(argument)?.type)) {
+					if (index !== synchronousCallbackIndex || !FUNCTION_TYPES.has(unwrap(argument)?.type)) {
 						visit(argument, scope, executionPhase);
 					}
 					executionPhase = phaseAfter(argument, executionPhase);
@@ -878,8 +1037,17 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 					visitSynchronousHookCallback(node.arguments?.[0], scope, 'effect');
 					return;
 				}
-				if (hook === 'useMemo') {
+				if (hook === 'useState' || hook === 'useMemo') {
 					visitSynchronousHookCallback(node.arguments?.[0], scope, executionPhase);
+					return;
+				}
+				if (hook === 'useReducer') {
+					visitSynchronousHookCallback(node.arguments?.[2], scope, executionPhase);
+					return;
+				}
+				if (hook === 'useLinkedState') {
+					visitSynchronousHookCallback(node.arguments?.[1], scope, executionPhase);
+					visitLinkedStateComparators(node.arguments?.[2], scope, executionPhase);
 					return;
 				}
 				if (FUNCTION_TYPES.has(callee?.type)) {

--- a/packages/octane/src/compiler/strong-mode.js
+++ b/packages/octane/src/compiler/strong-mode.js
@@ -14,6 +14,10 @@ const TRANSPARENT_EXPRESSIONS = new Set([
 	'TSSatisfiesExpression',
 	'TSTypeAssertion',
 ]);
+const NULLISH_VALUE = 1;
+const FALSY_VALUE = 2;
+const TRUTHY_VALUE = 4;
+const UNKNOWN_VALUE = NULLISH_VALUE | FALSY_VALUE | TRUTHY_VALUE;
 const SKIP_KEYS = new Set([
 	'type',
 	'start',
@@ -662,9 +666,12 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 					value?.kind === 'callback' ||
 					value?.kind === 'callback-choice' ||
 					value?.kind === 'linked-options' ||
-					value?.kind === 'linked-key'
+					value?.kind === 'linked-key' ||
+					value?.kind === 'constant'
 				) {
 					target.bindings.set(declaration.id.name, value);
+				} else if (value == null && initial.name === 'undefined') {
+					target.bindings.set(declaration.id.name, { kind: 'constant', value: NULLISH_VALUE });
 				}
 			} else if (declarationKind === 'const' && FUNCTION_TYPES.has(initial?.type)) {
 				target.bindings.set(declaration.id.name, { kind: 'callback', node: initial, scope });
@@ -696,6 +703,11 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 					node: initial,
 					scope,
 				});
+			} else if (declarationKind === 'const') {
+				const value = staticExpressionValue(initial, scope);
+				if (value !== UNKNOWN_VALUE) {
+					target.bindings.set(declaration.id.name, { kind: 'constant', value });
+				}
 			}
 		}
 		visit(declaration.init, scope, phase);
@@ -724,48 +736,106 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		);
 	}
 
-	function logicalExpressionBranches(expression, scope) {
-		const left = unwrap(expression.left);
-		let truthy;
-		let nullish;
-		if (left?.type === 'Literal') {
-			truthy = Boolean(left.value);
-			nullish = left.value == null;
+	function staticExpressionValue(value, scope) {
+		const expression = unwrap(value);
+		if (expression?.type === 'Literal') {
+			return expression.value == null
+				? NULLISH_VALUE
+				: expression.value
+					? TRUTHY_VALUE
+					: FALSY_VALUE;
 		} else if (
-			FUNCTION_TYPES.has(left?.type) ||
-			left?.type === 'ObjectExpression' ||
-			left?.type === 'ArrayExpression' ||
-			stateTupleUpdater(left, scope)
+			FUNCTION_TYPES.has(expression?.type) ||
+			expression?.type === 'ObjectExpression' ||
+			expression?.type === 'ArrayExpression' ||
+			stateTupleUpdater(expression, scope)
 		) {
-			truthy = true;
-			nullish = false;
-		} else if (left?.type === 'Identifier') {
-			const binding = resolve(scope, left.name);
-			if (binding == null && left.name === 'undefined') {
-				truthy = false;
-				nullish = true;
-			} else if (
+			return TRUTHY_VALUE;
+		} else if (expression?.type === 'Identifier') {
+			const binding = resolve(scope, expression.name);
+			if (binding == null && expression.name === 'undefined') return NULLISH_VALUE;
+			if (binding?.kind === 'constant') return binding.value;
+			if (
 				binding?.kind === 'callback' ||
 				binding?.kind === 'setter' ||
 				binding?.kind === 'ref' ||
 				binding?.kind === 'state-tuple' ||
-				(binding?.kind === 'linked-options' && unwrap(binding.node)?.type === 'ObjectExpression') ||
 				binding?.kind === 'linked-key' ||
 				binding?.kind === 'hook' ||
 				binding?.kind === 'namespace'
 			) {
-				truthy = true;
-				nullish = false;
+				return TRUTHY_VALUE;
 			}
+			if (binding?.kind === 'callback-choice' || binding?.kind === 'linked-options') {
+				if (activeCallbacks.has(binding.node)) return UNKNOWN_VALUE;
+				activeCallbacks.add(binding.node);
+				try {
+					return staticExpressionValue(binding.node, binding.scope);
+				} finally {
+					activeCallbacks.delete(binding.node);
+				}
+			}
+		} else if (expression?.type === 'LogicalExpression') {
+			const left = staticExpressionValue(expression.left, scope);
+			if (expression.operator === '??') {
+				return (
+					(left & (FALSY_VALUE | TRUTHY_VALUE)) |
+					((left & NULLISH_VALUE) !== 0 ? staticExpressionValue(expression.right, scope) : 0)
+				);
+			}
+			if (expression.operator === '||') {
+				return (
+					(left & TRUTHY_VALUE) |
+					((left & (NULLISH_VALUE | FALSY_VALUE)) !== 0
+						? staticExpressionValue(expression.right, scope)
+						: 0)
+				);
+			}
+			if (expression.operator === '&&') {
+				return (
+					(left & (NULLISH_VALUE | FALSY_VALUE)) |
+					((left & TRUTHY_VALUE) !== 0 ? staticExpressionValue(expression.right, scope) : 0)
+				);
+			}
+		} else if (expression?.type === 'ConditionalExpression') {
+			const test = staticExpressionValue(expression.test, scope);
+			return (
+				((test & TRUTHY_VALUE) !== 0 ? staticExpressionValue(expression.consequent, scope) : 0) |
+				((test & (NULLISH_VALUE | FALSY_VALUE)) !== 0
+					? staticExpressionValue(expression.alternate, scope)
+					: 0)
+			);
+		} else if (expression?.type === 'UnaryExpression' && expression.operator === 'void') {
+			return NULLISH_VALUE;
+		} else if (expression?.type === 'UnaryExpression' && expression.operator === '!') {
+			const argument = staticExpressionValue(expression.argument, scope);
+			return (
+				((argument & TRUTHY_VALUE) !== 0 ? FALSY_VALUE : 0) |
+				((argument & (NULLISH_VALUE | FALSY_VALUE)) !== 0 ? TRUTHY_VALUE : 0)
+			);
 		}
+		return UNKNOWN_VALUE;
+	}
+
+	function logicalExpressionBranches(expression, scope) {
+		const left = staticExpressionValue(expression.left, scope);
 		if (expression.operator === '??') {
-			return nullish === true ? 2 : nullish === false ? 1 : 3;
+			return (
+				((left & (FALSY_VALUE | TRUTHY_VALUE)) !== 0 ? 1 : 0) |
+				((left & NULLISH_VALUE) !== 0 ? 2 : 0)
+			);
 		}
 		if (expression.operator === '||') {
-			return truthy === true ? 1 : truthy === false ? 2 : 3;
+			return (
+				((left & TRUTHY_VALUE) !== 0 ? 1 : 0) |
+				((left & (NULLISH_VALUE | FALSY_VALUE)) !== 0 ? 2 : 0)
+			);
 		}
 		if (expression.operator === '&&') {
-			return truthy === true ? 2 : truthy === false ? 1 : 3;
+			return (
+				((left & (NULLISH_VALUE | FALSY_VALUE)) !== 0 ? 1 : 0) |
+				((left & TRUTHY_VALUE) !== 0 ? 2 : 0)
+			);
 		}
 		return 3;
 	}
@@ -781,7 +851,9 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			return true;
 		} else if (callback?.type === 'LogicalExpression') {
 			const branches = logicalExpressionBranches(callback, scope);
-			if ((branches & 1) !== 0) visitSynchronousHookCallback(callback.left, scope, phase);
+			if ((branches & 1) !== 0 && callback.operator !== '&&') {
+				visitSynchronousHookCallback(callback.left, scope, phase);
+			}
 			if ((branches & 2) !== 0) visitSynchronousHookCallback(callback.right, scope, phase);
 			return true;
 		} else if (callback?.type === 'Identifier') {
@@ -822,7 +894,9 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		if (callback?.type === 'LogicalExpression') {
 			const branches = logicalExpressionBranches(callback, scope);
 			return (
-				((branches & 1) !== 0 && synchronousCallbackExpression(callback.left, scope)) ||
+				((branches & 1) !== 0 &&
+					callback.operator !== '&&' &&
+					synchronousCallbackExpression(callback.left, scope)) ||
 				((branches & 2) !== 0 && synchronousCallbackExpression(callback.right, scope))
 			);
 		}
@@ -856,6 +930,7 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			const branches = logical ? logicalExpressionBranches(options, scope) : 3;
 			return (
 				((branches & 1) !== 0 &&
+					(!logical || options.operator !== '&&') &&
 					linkedStateOptionsExpression(logical ? options.left : options.consequent, scope)) ||
 				((branches & 2) !== 0 &&
 					linkedStateOptionsExpression(logical ? options.right : options.alternate, scope))
@@ -895,7 +970,8 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			if (options.type === 'ConditionalExpression' || options.type === 'LogicalExpression') {
 				const logical = options.type === 'LogicalExpression';
 				const branches = logical ? logicalExpressionBranches(options, scope) : 3;
-				const first = logical ? options.left : options.consequent;
+				const first =
+					logical && options.operator === '&&' ? null : logical ? options.left : options.consequent;
 				const second = logical ? options.right : options.alternate;
 				if (branches !== 3) {
 					visitLinkedStateComparators(

--- a/packages/octane/src/compiler/strong-mode.js
+++ b/packages/octane/src/compiler/strong-mode.js
@@ -685,7 +685,8 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				declarationKind === 'const' &&
 				(initial?.type === 'ObjectExpression' ||
 					initial?.type === 'ConditionalExpression' ||
-					initial?.type === 'LogicalExpression') &&
+					initial?.type === 'LogicalExpression' ||
+					initial?.type === 'SequenceExpression') &&
 				linkedStateOptionsExpression(initial, scope)
 			) {
 				target.bindings.set(declaration.id.name, {
@@ -695,7 +696,9 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				});
 			} else if (
 				declarationKind === 'const' &&
-				(initial?.type === 'ConditionalExpression' || initial?.type === 'LogicalExpression') &&
+				(initial?.type === 'ConditionalExpression' ||
+					initial?.type === 'LogicalExpression' ||
+					initial?.type === 'SequenceExpression') &&
 				synchronousCallbackExpression(initial, scope)
 			) {
 				target.bindings.set(declaration.id.name, {
@@ -775,6 +778,9 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 					activeCallbacks.delete(binding.node);
 				}
 			}
+		} else if (expression?.type === 'SequenceExpression') {
+			const expressions = expression.expressions ?? [];
+			return staticExpressionValue(expressions[expressions.length - 1], scope);
 		} else if (expression?.type === 'LogicalExpression') {
 			const left = staticExpressionValue(expression.left, scope);
 			if (expression.operator === '??') {
@@ -817,6 +823,13 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		return UNKNOWN_VALUE;
 	}
 
+	function conditionalExpressionBranches(expression, scope) {
+		const test = staticExpressionValue(expression.test, scope);
+		return (
+			((test & TRUTHY_VALUE) !== 0 ? 1 : 0) | ((test & (NULLISH_VALUE | FALSY_VALUE)) !== 0 ? 2 : 0)
+		);
+	}
+
 	function logicalExpressionBranches(expression, scope) {
 		const left = staticExpressionValue(expression.left, scope);
 		if (expression.operator === '??') {
@@ -845,9 +858,13 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		if (FUNCTION_TYPES.has(callback?.type)) {
 			visitCallback(callback, scope, phase);
 			return true;
+		} else if (callback?.type === 'SequenceExpression') {
+			const expressions = callback.expressions ?? [];
+			return visitSynchronousHookCallback(expressions[expressions.length - 1], scope, phase);
 		} else if (callback?.type === 'ConditionalExpression') {
-			visitSynchronousHookCallback(callback.consequent, scope, phase);
-			visitSynchronousHookCallback(callback.alternate, scope, phase);
+			const branches = conditionalExpressionBranches(callback, scope);
+			if ((branches & 1) !== 0) visitSynchronousHookCallback(callback.consequent, scope, phase);
+			if ((branches & 2) !== 0) visitSynchronousHookCallback(callback.alternate, scope, phase);
 			return true;
 		} else if (callback?.type === 'LogicalExpression') {
 			const branches = logicalExpressionBranches(callback, scope);
@@ -885,10 +902,15 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			const kind = resolve(scope, callback.name)?.kind;
 			return kind === 'callback' || kind === 'callback-choice' || kind === 'setter';
 		}
+		if (callback?.type === 'SequenceExpression') {
+			const expressions = callback.expressions ?? [];
+			return synchronousCallbackExpression(expressions[expressions.length - 1], scope);
+		}
 		if (callback?.type === 'ConditionalExpression') {
+			const branches = conditionalExpressionBranches(callback, scope);
 			return (
-				synchronousCallbackExpression(callback.consequent, scope) ||
-				synchronousCallbackExpression(callback.alternate, scope)
+				((branches & 1) !== 0 && synchronousCallbackExpression(callback.consequent, scope)) ||
+				((branches & 2) !== 0 && synchronousCallbackExpression(callback.alternate, scope))
 			);
 		}
 		if (callback?.type === 'LogicalExpression') {
@@ -925,9 +947,15 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		if (options?.type === 'Identifier') {
 			return resolve(scope, options.name)?.kind === 'linked-options';
 		}
+		if (options?.type === 'SequenceExpression') {
+			const expressions = options.expressions ?? [];
+			return linkedStateOptionsExpression(expressions[expressions.length - 1], scope);
+		}
 		if (options?.type === 'ConditionalExpression' || options?.type === 'LogicalExpression') {
 			const logical = options.type === 'LogicalExpression';
-			const branches = logical ? logicalExpressionBranches(options, scope) : 3;
+			const branches = logical
+				? logicalExpressionBranches(options, scope)
+				: conditionalExpressionBranches(options, scope);
 			return (
 				((branches & 1) !== 0 &&
 					(!logical || options.operator !== '&&') &&
@@ -958,7 +986,8 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		if (
 			(options?.type !== 'ObjectExpression' &&
 				options?.type !== 'ConditionalExpression' &&
-				options?.type !== 'LogicalExpression') ||
+				options?.type !== 'LogicalExpression' &&
+				options?.type !== 'SequenceExpression') ||
 			activeOptions?.has(options)
 		) {
 			return;
@@ -967,9 +996,22 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		activeOptions ??= new Set();
 		activeOptions.add(options);
 		try {
+			if (options.type === 'SequenceExpression') {
+				const expressions = options.expressions ?? [];
+				visitLinkedStateComparators(
+					expressions[expressions.length - 1],
+					scope,
+					phase,
+					overridden,
+					activeOptions,
+				);
+				return;
+			}
 			if (options.type === 'ConditionalExpression' || options.type === 'LogicalExpression') {
 				const logical = options.type === 'LogicalExpression';
-				const branches = logical ? logicalExpressionBranches(options, scope) : 3;
+				const branches = logical
+					? logicalExpressionBranches(options, scope)
+					: conditionalExpressionBranches(options, scope);
 				const first =
 					logical && options.operator === '&&' ? null : logical ? options.left : options.consequent;
 				const second = logical ? options.right : options.alternate;

--- a/packages/octane/tests/compiler/strong-mode.test.ts
+++ b/packages/octane/tests/compiler/strong-mode.test.ts
@@ -384,6 +384,42 @@ export function App(props) @{
 			'const tuple = useState(0); const index = `1`; const update = tuple[index]; useState(update);',
 		],
 		[
+			'immutable concatenated tuple indexes',
+			'const tuple = useState(0); const index = "" + "1"; const update = tuple[index]; useState(update);',
+		],
+		[
+			'aliased concatenated tuple index fragments',
+			'const tuple = useState(0); const fragment = "" + ""; const index = fragment + "1"; const update = tuple[index]; useState(update);',
+		],
+		[
+			'immutable numeric addition tuple indexes',
+			'const tuple = useState(0); const index = 0 + 1; const update = tuple[index]; useState(update);',
+		],
+		[
+			'immutable unary numeric tuple indexes',
+			'const tuple = useState(0); const index = +1; const update = tuple[index]; useState(update);',
+		],
+		[
+			'immutable boolean-coerced tuple indexes',
+			'const tuple = useState(0); const enabled = !false; const index = +enabled; const update = tuple[index]; useState(update);',
+		],
+		[
+			'immutable mixed string and numeric tuple indexes',
+			'const tuple = useState(0); const index = "" + 1; const update = tuple[index]; useState(update);',
+		],
+		[
+			'sequence-selected concatenated tuple indexes',
+			'const tuple = useState(0); const index = (props.trace, "" + "1"); const update = tuple[index]; useState(update);',
+		],
+		[
+			'conditionally selected concatenated tuple indexes',
+			'const tuple = useState(0); const index = true ? "" + "1" : "0"; const update = tuple[index]; useState(update);',
+		],
+		[
+			'logically selected concatenated tuple indexes',
+			'const tuple = useState(0); const index = "" || ("" + "1"); const update = tuple[index]; useState(update);',
+		],
+		[
 			'inline template tuple indexes',
 			'const tuple = useState(0); const update = tuple[`1`]; useState(update);',
 		],
@@ -394,6 +430,10 @@ export function App(props) @{
 		[
 			'computed object-pattern tuple setter aliases',
 			'const tuple = useState(0); const index = 1; const { [index]: update } = tuple; useState(update);',
+		],
+		[
+			'computed concatenated object-pattern tuple setter aliases',
+			'const tuple = useState(0); const index = "" + "1"; const { [index]: update } = tuple; useState(update);',
 		],
 		[
 			'TypeScript-wrapped setter aliases',
@@ -457,6 +497,34 @@ export function App(props) @{
 			'const key = "source" + "Equal"; useLinkedState(count, (value) => value, { [key]: setCount });',
 		],
 		[
+			'aliased concatenated source comparator fragments',
+			'const prefix = "sou" + "rce"; const key = prefix + "Equal"; useLinkedState(count, (value) => value, { [key]: setCount });',
+		],
+		[
+			'aliased concatenated value comparator fragments',
+			'const suffix = "Equ" + "al"; const key = "value" + suffix; useLinkedState(count, (value) => value, { [key]: setCount });',
+		],
+		[
+			'chained concatenated comparator fragments',
+			'const first = "so" + "u"; const second = first + "rce"; const key = `${second}Equal`; useLinkedState(count, (value) => value, { [key]: setCount });',
+		],
+		[
+			'sequence-selected concatenated comparator fragments',
+			'const prefix = (props.trace, "sou" + "rce"); const key = `${prefix}Equal`; useLinkedState(count, (value) => value, { [key]: setCount });',
+		],
+		[
+			'conditionally selected concatenated comparator fragments',
+			'const prefix = true ? "sou" + "rce" : "other"; const key = prefix + "Equal"; useLinkedState(count, (value) => value, { [key]: setCount });',
+		],
+		[
+			'logically selected concatenated comparator fragments',
+			'const prefix = null ?? ("sou" + "rce"); const key = prefix + "Equal"; useLinkedState(count, (value) => value, { [key]: setCount });',
+		],
+		[
+			'falsy concatenated comparator selection flags',
+			'const disabled = "" + ""; const key = disabled ? "other" : "valueEqual"; useLinkedState(count, (value) => value, { [key]: setCount });',
+		],
+		[
 			'inline statically concatenated comparator keys',
 			'useLinkedState(count, (value) => value, { ["value" + "Equal"]: setCount });',
 		],
@@ -479,6 +547,10 @@ export function App(props) @{
 		[
 			'template-keyed spread comparators',
 			'const key = `sourceEqual`; const options = { [key]: setCount }; useLinkedState(count, (value) => value, { ...options });',
+		],
+		[
+			'fragment-keyed spread comparators',
+			'const prefix = "sou" + "rce"; const key = `${prefix}Equal`; const options = { [key]: setCount }; useLinkedState(count, (value) => value, { ...options });',
 		],
 		[
 			'template-keyed aliased tuple comparators',
@@ -783,6 +855,22 @@ export function App(props) @{
 		expect(() => compile(source, '/src/App.tsrx')).toThrow(RENDER_REF_WRITE);
 	});
 
+	it('rejects ref writes from aliased concatenated comparator fragments', () => {
+		const source = `"use strong";
+import { useLinkedState, useRef } from 'octane';
+export function App(props) @{
+  const ref = useRef(0);
+  const prefix = "sou" + "rce";
+  const key = \`\${prefix}Equal\`;
+  useLinkedState(props.value, (value) => value, {
+    [key]: (previous, next) => { ref.current = next; return previous === next; },
+  });
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(RENDER_REF_WRITE);
+	});
+
 	it.each([
 		[
 			'aliased state imports',
@@ -1045,6 +1133,35 @@ export function App(props) @{
   const known = \`sourceEqual\`;
   useLinkedState(tuple[0], (value) => value, {
     [unrelated]: tuple[1],
+    [dynamic]: tuple[1],
+    [known]: tuple[1],
+    sourceEqual: Object.is,
+  });
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('keeps computed primitive truthiness, overrides, and dynamic fragments precise', () => {
+		const source = `"use strong";
+import { useLinkedState, useState } from 'octane';
+export function App(props) @{
+  const tuple = useState(0);
+  const empty = "" + "";
+  const truthy = "x" + "";
+  const negativeZero = -0;
+  useState(empty && tuple[1]);
+  useState(negativeZero && tuple[1]);
+  useState(truthy || tuple[1]);
+  useState(("x" + "") ? (() => 0) : tuple[1]);
+  let mutable = "sou" + "rce";
+  mutable = props.prefix;
+  const dynamic = props.prefix + "Equal";
+  const prefix = "sou" + "rce";
+  const known = prefix + "Equal";
+  useLinkedState(tuple[0], (value) => value, {
+    [mutable + "Equal"]: tuple[1],
     [dynamic]: tuple[1],
     [known]: tuple[1],
     sourceEqual: Object.is,
@@ -1471,6 +1588,10 @@ export function App(props) @{
 	it.each([
 		['effect callbacks', 'useEffect(update, []);'],
 		['direct calls in effect setup', 'useEffect(() => { update(1); }, []);'],
+		[
+			'concatenated tuple indexes in effect setup',
+			'useEffect(() => { const index = "" + "1"; const selected = tuple[index]; selected(1); }, []);',
+		],
 	])('rejects aliased tuple setters used as %s', (_label, effect) => {
 		const source = `"use strong";
 import { useEffect, useState } from 'octane';

--- a/packages/octane/tests/compiler/strong-mode.test.ts
+++ b/packages/octane/tests/compiler/strong-mode.test.ts
@@ -405,6 +405,58 @@ export function App(props) @{
 	});
 
 	it.each([
+		['state initializer values', 'useState((props.trace, setCount));'],
+		['inline state initializer callbacks', 'useState((props.trace, () => setCount(count + 1)));'],
+		[
+			'named and aliased state initializers',
+			'const initialize = (props.trace, setCount); const alias = initialize; useState(alias);',
+		],
+		['nested state initializer sequences', 'useState((props.first, (props.second, setCount)));'],
+		['reducer initializers', 'useReducer((value) => value, count, (props.trace, setCount));'],
+		['memo callbacks', 'useMemo((props.trace, setCount), [count]);'],
+		['linked-state reconcilers', 'useLinkedState(count, (props.trace, setCount));'],
+		[
+			'source comparators',
+			'useLinkedState(count, (value) => value, { sourceEqual: (props.trace, setCount) });',
+		],
+		[
+			'named value comparators',
+			'const compare = (props.trace, setCount); useLinkedState(count, (value) => value, { valueEqual: compare });',
+		],
+		[
+			'linked-state options',
+			'useLinkedState(count, (value) => value, (props.trace, { sourceEqual: setCount }));',
+		],
+		[
+			'named and aliased linked-state options',
+			'const options = (props.trace, { valueEqual: setCount }); const alias = options; useLinkedState(count, (value) => value, alias);',
+		],
+		[
+			'linked-state option spreads',
+			'useLinkedState(count, (value) => value, { ...(props.trace, { sourceEqual: setCount }) });',
+		],
+		[
+			'nested logical linked-state options',
+			'useLinkedState(count, (value) => value, props.options ?? (props.trace, { valueEqual: setCount }));',
+		],
+		[
+			'state-tuple updater results',
+			'const tuple = useState(0); useState((props.trace, tuple[1]));',
+		],
+		['immediately executed earlier operands', 'useState((setCount(count + 1), () => count));'],
+	])('rejects render updates from sequence-selected %s', (_label, setup) => {
+		const source = `"use strong";
+import { useLinkedState, useMemo, useReducer, useState } from 'octane';
+export function App(props) @{
+  const [count, setCount] = useState(0);
+  ${setup}
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(RENDER_STATE_UPDATE);
+	});
+
+	it.each([
 		[
 			'inline reducer initializers',
 			'useReducer((value) => value, count, () => { setCount(count + 1); return count; });',
@@ -497,6 +549,32 @@ export function App() @{
 	])('rejects render-time ref writes hidden by logical %s', (_label, setup) => {
 		const source = `"use strong";
 import { useLinkedState, useReducer, useRef, useState } from 'octane';
+export function App(props) @{
+  const ref = useRef(0);
+  ${setup}
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(RENDER_REF_WRITE);
+	});
+
+	it.each([
+		[
+			'state initializer callbacks',
+			'useState((props.trace, () => { ref.current = 1; return 0; }));',
+		],
+		[
+			'linked-state reconciler callbacks',
+			'useLinkedState(0, (props.trace, (value) => { ref.current = value; return value; }));',
+		],
+		[
+			'named linked-state option spreads',
+			'const options = (props.trace, { sourceEqual: (previous, next) => { ref.current = next; return previous === next; } }); useLinkedState(0, (value) => value, { ...options });',
+		],
+		['immediately executed earlier operands', 'useState((ref.current = 1, () => 0));'],
+	])('rejects ref writes from sequence-selected %s', (_label, setup) => {
+		const source = `"use strong";
+import { useLinkedState, useRef, useState } from 'octane';
 export function App(props) @{
   const ref = useRef(0);
   ${setup}
@@ -692,6 +770,58 @@ import { useLinkedState, useRef, useState } from 'octane';
 export function App(props) @{
   const [count, setCount] = useState(0);
   const ref = useRef(0);
+  ${setup}
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it.each([
+		['known true state initializers', 'useState(true ? () => count : setCount);'],
+		['known false state initializers', 'useState(false ? setCount : () => count);'],
+		[
+			'aliased immutable conditional flags',
+			'const enabled = true; const active = enabled; useState(active ? () => count : setCount);',
+		],
+		[
+			'nested immutable conditional flags',
+			'const disabled = false; useState(disabled ? setCount : (true ? () => count : setCount));',
+		],
+		[
+			'known conditional linked-state reconcilers',
+			'const enabled = true; useLinkedState(count, enabled ? (value) => value : setCount);',
+		],
+		[
+			'known conditional linked-state comparators',
+			'useLinkedState(count, (value) => value, { valueEqual: false ? setCount : Object.is });',
+		],
+		[
+			'known conditional linked-state options',
+			'const enabled = true; useLinkedState(count, (value) => value, enabled ? { sourceEqual: Object.is } : { sourceEqual: setCount });',
+		],
+		[
+			'named known conditional linked-state options',
+			'const disabled = false; const options = disabled ? { sourceEqual: setCount } : { sourceEqual: Object.is }; useLinkedState(count, (value) => value, options);',
+		],
+		[
+			'known conditional spread overrides',
+			'const enabled = true; useLinkedState(count, (value) => value, { sourceEqual: setCount, ...(enabled ? { sourceEqual: Object.is } : { sourceEqual: setCount }) });',
+		],
+		['discarded earlier callback identities', 'useState((setCount, () => count));'],
+		[
+			'discarded earlier comparator options',
+			'useLinkedState(count, (value) => value, ({ sourceEqual: setCount }, { sourceEqual: Object.is }));',
+		],
+		[
+			'false sequence-result aliases',
+			'const disabled = (props.trace, false); useState(disabled && setCount);',
+		],
+	])('accepts unreachable sequence and conditional callbacks from %s', (_label, setup) => {
+		const source = `"use strong";
+import { useLinkedState, useState } from 'octane';
+export function App(props) @{
+  const [count, setCount] = useState(0);
   ${setup}
   <div />
 }`;

--- a/packages/octane/tests/compiler/strong-mode.test.ts
+++ b/packages/octane/tests/compiler/strong-mode.test.ts
@@ -638,6 +638,87 @@ export function App(props) @{
 		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
 	});
 
+	it.each([
+		['immutable false aliases', 'const disabled = false; useState(disabled && setCount);'],
+		[
+			'chained immutable false aliases',
+			'const disabled = false; const alias = disabled; useState(alias && setCount);',
+		],
+		['immutable true aliases', 'const enabled = true; useState(enabled || setCount);'],
+		['immutable null aliases', 'const missing = null; useState(missing && setCount);'],
+		['immutable undefined aliases', 'const missing = undefined; useState(missing && setCount);'],
+		['immutable empty-string aliases', "const empty = ''; useState(empty && setCount);"],
+		['immutable numeric aliases', 'const zero = 0; useState(zero && setCount);'],
+		[
+			'immutable object aliases',
+			'const value = {}; useState(value ?? setCount); useState(value || setCount);',
+		],
+		['immutable array aliases', 'const value = []; useState(value || setCount);'],
+		[
+			'nested non-null callback choices',
+			'const safe = (value) => value; useState((safe ?? setCount) || setCount);',
+		],
+		[
+			'conditional callbacks on logical AND left operands',
+			'const selected = props.enabled ? setCount : false; useState(selected && (() => count));',
+		],
+		[
+			'inline callbacks on logical AND left operands',
+			'useState((props.enabled ? setCount : false) && (() => count));',
+		],
+		[
+			'nested callbacks on logical AND left operands',
+			'useState((props.enabled && setCount) && (() => count));',
+		],
+		[
+			'comparator choices on logical AND left operands',
+			'useLinkedState(count, (value) => value, { sourceEqual: (props.enabled ? setCount : false) && Object.is });',
+		],
+		[
+			'option choices on logical AND left operands',
+			'const selected = props.enabled ? { sourceEqual: setCount } : false; useLinkedState(count, (value) => value, selected && { sourceEqual: Object.is });',
+		],
+		[
+			'spread option choices on logical AND left operands',
+			'const selected = props.enabled ? { sourceEqual: setCount } : false; useLinkedState(count, (value) => value, { ...(selected && { sourceEqual: Object.is }) });',
+		],
+		[
+			'ref-writing callbacks behind immutable false aliases',
+			'const disabled = false; useState(disabled && (() => { ref.current = 1; return 0; }));',
+		],
+	])('accepts logically unreachable synchronous callbacks from %s', (_label, setup) => {
+		const source = `"use strong";
+import { useLinkedState, useRef, useState } from 'octane';
+export function App(props) @{
+  const [count, setCount] = useState(0);
+  const ref = useRef(0);
+  ${setup}
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it.each([
+		['falsy immutable OR aliases', 'const disabled = false; useState(disabled || setCount);'],
+		['nullish immutable fallback aliases', 'const missing = null; useState(missing ?? setCount);'],
+		['truthy immutable AND aliases', 'const enabled = true; useState(enabled && setCount);'],
+		[
+			'mutable aliases',
+			'let disabled = false; disabled = props.enabled; useState(disabled && setCount);',
+		],
+	])('continues rejecting reachable callbacks behind %s', (_label, setup) => {
+		const source = `"use strong";
+import { useState } from 'octane';
+export function App(props) @{
+  const [count, setCount] = useState(0);
+  ${setup}
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(RENDER_STATE_UPDATE);
+	});
+
 	it('reports logical callback violations in TypeScript and editor diagnostics', () => {
 		const source = `"use strong";
 import { useMemo, useState } from 'octane';

--- a/packages/octane/tests/compiler/strong-mode.test.ts
+++ b/packages/octane/tests/compiler/strong-mode.test.ts
@@ -314,6 +314,97 @@ export function App() @{
 	});
 
 	it.each([
+		['nullish state initializers', 'useState(props.initialize ?? (() => setCount(count + 1)));'],
+		['logical OR state initializers', 'useState(props.initialize || (() => setCount(count + 1)));'],
+		['logical AND state initializers', 'useState(props.enabled && (() => setCount(count + 1)));'],
+		[
+			'named and aliased nullish state initializers',
+			'const fallback = () => setCount(count + 1); const initialize = props.initialize ?? fallback; const alias = initialize; useState(alias);',
+		],
+		[
+			'logical reducer initializers',
+			'useReducer((value) => value, count, props.initialize ?? setCount);',
+		],
+		['logical memo callbacks', 'useMemo(props.calculate || (() => setCount(count + 1)), [count]);'],
+		['nullish linked-state reconcilers', 'useLinkedState(count, props.reconcile ?? setCount);'],
+		[
+			'named and aliased logical OR reconcilers',
+			'const reconcile = props.reconcile || setCount; const alias = reconcile; useLinkedState(count, alias);',
+		],
+		['logical AND linked-state reconcilers', 'useLinkedState(count, props.enabled && setCount);'],
+		[
+			'nested logical and conditional reconcilers',
+			'const reconcile = props.reconcile ?? (props.enabled ? Object.is : setCount); useLinkedState(count, reconcile);',
+		],
+		[
+			'nullish source comparators',
+			'useLinkedState(count, (value) => value, { sourceEqual: props.compare ?? setCount });',
+		],
+		[
+			'named and aliased logical OR value comparators',
+			'const compare = props.compare || setCount; const alias = compare; useLinkedState(count, (value) => value, { valueEqual: alias });',
+		],
+		[
+			'logical AND source comparators',
+			'useLinkedState(count, (value) => value, { sourceEqual: props.enabled && setCount });',
+		],
+		[
+			'nullish linked-state options',
+			'useLinkedState(count, (value) => value, props.options ?? { sourceEqual: setCount });',
+		],
+		[
+			'named and aliased logical OR linked-state options',
+			'const options = props.options || { valueEqual: setCount }; const alias = options; useLinkedState(count, (value) => value, alias);',
+		],
+		[
+			'nullable logical linked-state option aliases',
+			'const maybe = props.enabled && { sourceEqual: Object.is }; const options = maybe || { sourceEqual: setCount }; useLinkedState(count, (value) => value, options);',
+		],
+		[
+			'nullable conditional linked-state option aliases',
+			'const maybe = props.enabled ? { sourceEqual: Object.is } : null; const options = maybe ?? { sourceEqual: setCount }; useLinkedState(count, (value) => value, options);',
+		],
+		[
+			'nullable linked-state option alias spreads',
+			'const maybe = props.enabled ? { sourceEqual: Object.is } : null; useLinkedState(count, (value) => value, { ...(maybe || { sourceEqual: setCount }) });',
+		],
+		[
+			'logical AND linked-state options',
+			'useLinkedState(count, (value) => value, props.enabled && { sourceEqual: setCount });',
+		],
+		[
+			'nullish linked-state option spreads',
+			'useLinkedState(count, (value) => value, { ...(props.options ?? { sourceEqual: setCount }) });',
+		],
+		[
+			'logical AND linked-state option spreads',
+			'useLinkedState(count, (value) => value, { ...(props.enabled && { valueEqual: setCount }) });',
+		],
+		[
+			'nested logical linked-state options',
+			'const options = props.options ?? (props.enabled && { sourceEqual: setCount }); useLinkedState(count, (value) => value, { ...options });',
+		],
+		[
+			'conditionally overridden earlier comparators',
+			'useLinkedState(count, (value) => value, { sourceEqual: setCount, ...(props.enabled && { sourceEqual: Object.is }) });',
+		],
+		[
+			'logical state-tuple updater fallbacks',
+			'const tuple = useState(0); useState(props.initialize ?? tuple[1]);',
+		],
+	])('rejects render updates hidden by logical %s', (_label, setup) => {
+		const source = `"use strong";
+import { useLinkedState, useMemo, useReducer, useState } from 'octane';
+export function App(props) @{
+  const [count, setCount] = useState(0);
+  ${setup}
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(RENDER_STATE_UPDATE);
+	});
+
+	it.each([
 		[
 			'inline reducer initializers',
 			'useReducer((value) => value, count, () => { setCount(count + 1); return count; });',
@@ -374,6 +465,39 @@ export function App() @{
 		const source = `"use strong";
 import { useLinkedState, useReducer, useRef, useState } from 'octane';
 export function App() @{
+  const ref = useRef(0);
+  ${setup}
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(RENDER_REF_WRITE);
+	});
+
+	it.each([
+		[
+			'nullish state initializers',
+			'useState(props.initialize ?? (() => { ref.current = 1; return 0; }));',
+		],
+		[
+			'logical OR linked-state reconcilers',
+			'useLinkedState(0, props.reconcile || ((value) => { ref.current = value; return value; }));',
+		],
+		[
+			'logical AND linked-state comparators',
+			'useLinkedState(0, (value) => value, { valueEqual: props.enabled && ((previous, next) => { ref.current = next; return previous === next; }) });',
+		],
+		[
+			'named logical linked-state option spreads',
+			'const options = props.options ?? { sourceEqual: (previous, next) => { ref.current = next; return previous === next; } }; useLinkedState(0, (value) => value, { ...options });',
+		],
+		[
+			'logical reducer initializers',
+			'useReducer((value) => value, 0, props.initialize || (() => { ref.current = 1; return 0; }));',
+		],
+	])('rejects render-time ref writes hidden by logical %s', (_label, setup) => {
+		const source = `"use strong";
+import { useLinkedState, useReducer, useRef, useState } from 'octane';
+export function App(props) @{
   const ref = useRef(0);
   ${setup}
   <div />
@@ -485,6 +609,63 @@ export function App(props) @{
 }`;
 
 		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('keeps unreachable, overridden, deferred, and dynamic logical callbacks legal', () => {
+		const source = `"use strong";
+import { useLinkedState, useMemo, useState } from 'octane';
+export function App(props) @{
+  const [count, setCount] = useState(0);
+  const unsafe = (value) => setCount(value);
+  const safe = (value) => value;
+  const knownOptions = { sourceEqual: Object.is };
+  useState(false && unsafe);
+  useState(safe || unsafe);
+  useState((() => count) ?? unsafe);
+  useMemo(safe || unsafe, [count]);
+  useLinkedState(count, props.reconcile ?? safe, {
+    ...(props.options ?? { sourceEqual: unsafe }),
+    sourceEqual: Object.is,
+    valueEqual: props.compare && safe,
+    [props.comparatorName]: unsafe,
+    onSettled: props.onSettled || unsafe,
+  });
+  useLinkedState(count, safe, knownOptions || { sourceEqual: unsafe });
+  useLinkedState(count, safe, false && { sourceEqual: unsafe });
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('reports logical callback violations in TypeScript and editor diagnostics', () => {
+		const source = `"use strong";
+import { useMemo, useState } from 'octane';
+export function useValue(value, calculate) {
+  const [, update] = useState(0);
+  return useMemo(calculate || update, [value]);
+}`;
+		const editorSource = `"use strong";
+import { useLinkedState, useRef } from 'octane';
+export function App(props) @{
+  const ref = useRef(0);
+  useLinkedState(props.value, (value) => value, props.options ?? {
+    valueEqual: props.compare || ((previous, next) => {
+      ref.current = next;
+      return previous === next;
+    }),
+  });
+  <div />
+}`;
+		const diagnostics = compileToVolarMappings(editorSource, '/src/App.tsrx');
+
+		expect(() => slotHooks(source, '/src/useValue.ts')).toThrow(RENDER_STATE_UPDATE);
+		expect(diagnostics.diagnostics).toContainEqual(
+			expect.objectContaining({ code: RENDER_REF_WRITE, severity: 'error' }),
+		);
+		expect(diagnostics.errors).toContainEqual(
+			expect.objectContaining({ code: RENDER_REF_WRITE, type: 'usage' }),
+		);
 	});
 
 	it('reports spread and conditional callback violations in TypeScript and editor diagnostics', () => {

--- a/packages/octane/tests/compiler/strong-mode.test.ts
+++ b/packages/octane/tests/compiler/strong-mode.test.ts
@@ -148,6 +148,51 @@ export function App() @{
 	});
 
 	it.each([
+		['sequence-selected setters', '(props.trace, setCount)(count + 1);'],
+		['conditional setters', '(props.enabled ? setCount : (value) => value)(count + 1);'],
+		['logically selected setters', '(props.update ?? setCount)(count + 1);'],
+		[
+			'named sequence-selected setters',
+			'const selected = (props.trace, setCount); selected(count + 1);',
+		],
+		[
+			'aliased sequence-selected callback bodies',
+			'const selected = (props.trace, () => setCount(count + 1)); const alias = selected; alias();',
+		],
+		[
+			'named logical callback choices',
+			'const selected = props.update || setCount; selected(count + 1);',
+		],
+		[
+			'sequence-selected state tuple updaters',
+			'const tuple = useState(0); (props.trace, tuple[1])(1);',
+		],
+	])('rejects immediately invoked %s', (_label, setup) => {
+		const source = `"use strong";
+import { useState } from 'octane';
+export function App(props) @{
+  const [count, setCount] = useState(0);
+  ${setup}
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(RENDER_STATE_UPDATE);
+	});
+
+	it('rejects ref writes from immediately invoked selected callback bodies', () => {
+		const source = `"use strong";
+import { useRef } from 'octane';
+export function App(props) @{
+  const ref = useRef(0);
+  const selected = (props.trace, () => { ref.current = 1; });
+  selected();
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(RENDER_REF_WRITE);
+	});
+
+	it.each([
 		[
 			'named function declarations',
 			'function apply() { setCount(count + 1); } useMemo(apply, [count]);',
@@ -1221,6 +1266,48 @@ export function App() @{
 		)}`;
 
 		expect(() => compile(source, '/src/Counter.tsrx')).toThrow(EFFECT_STATE_UPDATE);
+	});
+
+	it.each([
+		['sequence-selected setters', '(props.trace, setCount)(1);'],
+		[
+			'aliased callback choices',
+			'const selected = (props.trace, () => setCount(1)); const alias = selected; alias();',
+		],
+		['conditional setters', '(props.enabled ? setCount : (value) => value)(1);'],
+	])('rejects immediately invoked %s during effect setup', (_label, invocation) => {
+		const source = `"use strong";
+import { useEffect, useState } from 'octane';
+export function App(props) @{
+  const [, setCount] = useState(0);
+  useEffect(() => { ${invocation} }, []);
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(EFFECT_STATE_UPDATE);
+	});
+
+	it('keeps selected callbacks legal after async render and effect work has yielded', () => {
+		const source = `"use strong";
+import { useEffect, useState } from 'octane';
+export function App(props) @{
+  const [, setCount] = useState(0);
+  (async () => {
+    await Promise.resolve();
+    const selected = (props.trace, setCount);
+    selected(1);
+    (props.enabled ? setCount : () => {})(1);
+  })();
+  useEffect(() => {
+    (async () => {
+      await Promise.resolve();
+      (props.trace, setCount)(1);
+    })();
+  }, []);
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
 	});
 
 	it('allows cleanup callbacks and asynchronous state updates from effects', () => {

--- a/packages/octane/tests/compiler/strong-mode.test.ts
+++ b/packages/octane/tests/compiler/strong-mode.test.ts
@@ -173,6 +173,377 @@ export function App() @{
 	});
 
 	it.each([
+		['inline state initializers', 'useState(() => { setCount(count + 1); return count; });'],
+		[
+			'named state initializers',
+			'function initialize() { setCount(count + 1); return count; } useState(initialize);',
+		],
+		[
+			'aliased state initializers',
+			'const initialize = () => setCount(count + 1); const initial = initialize; useState(initial);',
+		],
+		['state updaters passed as initializers', 'useState(setCount);'],
+		[
+			'state tuple updaters passed as initializers',
+			'const tuple = useState(0); useState(tuple[1]);',
+		],
+		[
+			'inline linked-state reconcilers',
+			'useLinkedState(count, (value) => { setCount(value + 1); return value; });',
+		],
+		[
+			'named linked-state reconcilers',
+			'function reconcile(value) { setCount(value + 1); return value; } useLinkedState(count, reconcile);',
+		],
+		[
+			'aliased linked-state reconcilers',
+			'const reconcile = (value) => setCount(value); const calculate = reconcile; useLinkedState(count, calculate);',
+		],
+		['state updaters passed as linked-state reconcilers', 'useLinkedState(count, setCount);'],
+		[
+			'inline source comparators',
+			'useLinkedState(count, (value) => value, { sourceEqual: (previous, next) => { setCount(next); return previous === next; } });',
+		],
+		[
+			'inline value comparators',
+			'useLinkedState(count, (value) => value, { valueEqual: (previous, next) => { setCount(next); return previous === next; } });',
+		],
+		[
+			'named source comparators',
+			'function compare(previous, next) { setCount(next); return previous === next; } useLinkedState(count, (value) => value, { sourceEqual: compare });',
+		],
+		[
+			'aliased value comparators',
+			'const compare = (previous, next) => setCount(next); const equal = compare; useLinkedState(count, (value) => value, { valueEqual: equal });',
+		],
+		[
+			'state updaters passed as source comparators',
+			'useLinkedState(count, (value) => value, { sourceEqual: setCount });',
+		],
+		[
+			'source comparator methods',
+			'useLinkedState(count, (value) => value, { sourceEqual(previous, next) { setCount(next); return previous === next; } });',
+		],
+		[
+			'wrapped computed comparator names',
+			"useLinkedState(count, (value) => value, { ['valueEqual' as const]: (previous, next) => { setCount(next); return previous === next; } });",
+		],
+		[
+			'named comparator options',
+			'const options = { sourceEqual: (previous, next) => { setCount(next); return previous === next; } }; useLinkedState(count, (value) => value, options);',
+		],
+		[
+			'aliased comparator options',
+			'const options = { valueEqual: (previous, next) => { setCount(next); return previous === next; } }; const comparisons = options; useLinkedState(count, (value) => value, comparisons);',
+		],
+	])('rejects render updates from %s', (_label, setup) => {
+		const source = `"use strong";\n${stateComponent(setup, 'useState, useLinkedState')}`;
+
+		expect(() => compile(source, '/src/Counter.tsrx')).toThrow(RENDER_STATE_UPDATE);
+	});
+
+	it.each([
+		[
+			'inline options spreads',
+			'useLinkedState(count, (value) => value, { ...{ sourceEqual: (previous, next) => { setCount(next); return previous === next; } } });',
+		],
+		[
+			'named options spreads',
+			'const options = { valueEqual: (previous, next) => { setCount(next); return previous === next; } }; useLinkedState(count, (value) => value, { ...options });',
+		],
+		[
+			'aliased and nested options spreads',
+			'const compare = (previous, next) => { setCount(next); return previous === next; }; const options = { sourceEqual: compare }; const alias = options; const spread = { ...alias }; useLinkedState(count, (value) => value, { ...spread });',
+		],
+		[
+			'options spreads overriding an earlier comparator',
+			'const options = { sourceEqual: setCount }; useLinkedState(count, (value) => value, { sourceEqual: Object.is, ...options });',
+		],
+		[
+			'inline conditional linked-state reconcilers',
+			'useLinkedState(count, count > 0 ? (value) => value : (value) => { setCount(value); return value; });',
+		],
+		[
+			'named conditional linked-state reconcilers',
+			'const reconcile = count > 0 ? (value) => { setCount(value); return value; } : (value) => value; useLinkedState(count, reconcile);',
+		],
+		[
+			'aliased conditional linked-state reconcilers',
+			'const reconcile = (value) => { setCount(value); return value; }; const selected = count > 0 ? Object.is : reconcile; const alias = selected; useLinkedState(count, alias);',
+		],
+		[
+			'conditional state initializers',
+			'useState(count > 0 ? () => count : () => setCount(count + 1));',
+		],
+		[
+			'inline conditional linked-state comparators',
+			'useLinkedState(count, (value) => value, { sourceEqual: count > 0 ? Object.is : (previous, next) => { setCount(next); return previous === next; } });',
+		],
+		[
+			'named conditional linked-state comparators',
+			'const compare = count > 0 ? Object.is : (previous, next) => { setCount(next); return previous === next; }; useLinkedState(count, (value) => value, { valueEqual: compare });',
+		],
+		[
+			'conditional linked-state options',
+			'useLinkedState(count, (value) => value, count > 0 ? { sourceEqual: Object.is } : { sourceEqual: setCount });',
+		],
+		[
+			'named conditional linked-state options',
+			'const options = count > 0 ? { valueEqual: Object.is } : { valueEqual: setCount }; useLinkedState(count, (value) => value, options);',
+		],
+		[
+			'conditional linked-state option spreads',
+			'const options = count > 0 ? { sourceEqual: Object.is } : { sourceEqual: setCount }; useLinkedState(count, (value) => value, { ...options });',
+		],
+		[
+			'named computed source comparators',
+			"const key = 'sourceEqual'; useLinkedState(count, (value) => value, { [key]: setCount });",
+		],
+		[
+			'aliased computed value comparators',
+			"const key = 'valueEqual' as const; const alias = key; useLinkedState(count, (value) => value, { [alias]: setCount });",
+		],
+		[
+			'computed template-literal comparators',
+			'useLinkedState(count, (value) => value, { [`sourceEqual`]: setCount });',
+		],
+	])('rejects render updates hidden by %s', (_label, setup) => {
+		const source = `"use strong";\n${stateComponent(setup, 'useState, useLinkedState')}`;
+
+		expect(() => compile(source, '/src/Counter.tsrx')).toThrow(RENDER_STATE_UPDATE);
+	});
+
+	it.each([
+		[
+			'inline reducer initializers',
+			'useReducer((value) => value, count, () => { setCount(count + 1); return count; });',
+		],
+		[
+			'named reducer initializers',
+			'const initialize = () => setCount(count + 1); useReducer((value) => value, count, initialize);',
+		],
+		[
+			'conditional reducer initializers',
+			'useReducer((value) => value, count, count > 0 ? () => count : setCount);',
+		],
+	])('rejects render updates from lazy %s', (_label, setup) => {
+		const source = `"use strong";\n${stateComponent(setup, 'useState, useReducer')}`;
+
+		expect(() => compile(source, '/src/Counter.tsrx')).toThrow(RENDER_STATE_UPDATE);
+	});
+
+	it.each([
+		['state initializers', 'useState(() => { ref.current = 1; return 0; });'],
+		[
+			'linked-state reconcilers',
+			'useLinkedState(0, (value) => { ref.current = value; return value; });',
+		],
+		[
+			'source comparators',
+			'useLinkedState(0, (value) => value, { sourceEqual: (previous, next) => { ref.current = next; return previous === next; } });',
+		],
+		[
+			'value comparator methods',
+			'useLinkedState(0, (value) => value, { valueEqual(previous, next) { ref.current = next; return previous === next; } });',
+		],
+		[
+			'aliased named comparators',
+			'const compare = (previous, next) => { ref.current = next; return previous === next; }; const equal = compare; useLinkedState(0, (value) => value, { sourceEqual: equal });',
+		],
+		[
+			'named comparator options',
+			'const options = { valueEqual: (previous, next) => { ref.current = next; return previous === next; } }; useLinkedState(0, (value) => value, options);',
+		],
+		[
+			'spread comparator options',
+			'const options = { sourceEqual: (previous, next) => { ref.current = next; return previous === next; } }; useLinkedState(0, (value) => value, { ...options });',
+		],
+		[
+			'conditional reconcilers',
+			'useLinkedState(0, ref.current ? (value) => value : (value) => { ref.current = value; return value; });',
+		],
+		[
+			'named computed comparators',
+			"const key = 'valueEqual'; useLinkedState(0, (value) => value, { [key]: (previous, next) => { ref.current = next; return previous === next; } });",
+		],
+		[
+			'lazy reducer initializers',
+			'useReducer((value) => value, 0, () => { ref.current = 1; return 0; });',
+		],
+	])('rejects render-time ref writes from %s', (_label, setup) => {
+		const source = `"use strong";
+import { useLinkedState, useReducer, useRef, useState } from 'octane';
+export function App() @{
+  const ref = useRef(0);
+  ${setup}
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(RENDER_REF_WRITE);
+	});
+
+	it.each([
+		[
+			'aliased state imports',
+			`import { useState as state } from 'octane';
+export function App() @{ const [, update] = state(0); state(() => update(1)); <div /> }`,
+		],
+		[
+			'aliased linked-state imports',
+			`import { useLinkedState as linked, useState } from 'octane';
+export function App() @{ const [, update] = useState(0); linked(0, () => update(1)); <div /> }`,
+		],
+		[
+			'namespace state imports',
+			`import * as Octane from 'octane';
+export function App() @{ const [, update] = Octane.useState(0); Octane.useState(() => update(1)); <div /> }`,
+		],
+		[
+			'namespace linked-state imports',
+			`import * as Octane from 'octane';
+export function App() @{ const [, update] = Octane.useState(0); Octane.useLinkedState(0, (value) => value, { valueEqual: update }); <div /> }`,
+		],
+		[
+			'wrapped namespace linked-state properties',
+			`import * as Octane from 'octane';
+export function App() @{ const [, update] = Octane.useState(0); Octane['useLinkedState' as const](0, update); <div /> }`,
+		],
+	])('tracks synchronous state callbacks through %s', (_label, source) => {
+		expect(() => compile(`"use strong";\n${source}`, '/src/App.tsrx')).toThrow(RENDER_STATE_UPDATE);
+	});
+
+	it.each([
+		{ mode: 'client', dev: true },
+		{ mode: 'client', dev: false },
+		{ mode: 'server', dev: true },
+		{ mode: 'server', dev: false },
+	])('rejects linked comparator writes during $mode compilation with dev=$dev', (options) => {
+		const source = `"use strong";\n${stateComponent(
+			'useLinkedState(count, (value) => value, { sourceEqual: () => setCount(count + 1) });',
+			'useState, useLinkedState',
+		)}`;
+
+		expect(() => compile(source, '/src/Counter.tsrx?octane-hydrate=Counter', options)).toThrow(
+			RENDER_STATE_UPDATE,
+		);
+	});
+
+	it('keeps synchronous state callbacks compatible when Strong mode is disabled', () => {
+		const source = stateComponent(
+			'useState(count > 0 ? () => count : setCount); useReducer((value) => value, count, setCount); useLinkedState(count, count > 0 ? (value) => value : setCount, { ...{ sourceEqual: setCount } });',
+			'useState, useReducer, useLinkedState',
+		);
+
+		expect(() => compile(source, '/src/Counter.tsrx')).not.toThrow();
+		expect(() => compile(source, '/src/Counter.tsrx', { strong: false } as any)).not.toThrow();
+	});
+
+	it('keeps deferred and unknown callbacks inside state initializers and linked options legal', () => {
+		const source = `"use strong";
+import { useLinkedState, useRef, useState } from 'octane';
+export function App(props) @{
+  const [count, setCount] = useState(0);
+  const ref = useRef(0);
+  useState(() => () => setCount(count + 1));
+  const reconcile = (value) => {
+    setTimeout(() => setCount(value + 1), 0);
+    return value;
+  };
+  const compare = (previous, next) => {
+    queueMicrotask(() => { ref.current = next; });
+    return previous === next;
+  };
+  useLinkedState(count, reconcile, {
+    sourceEqual: compare,
+    valueEqual: props.compare,
+    onSettled: () => setCount(count + 1),
+  });
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('keeps overridden, deferred, dynamic, and unrelated linked-state comparators legal', () => {
+		const source = `"use strong";
+import { useLinkedState, useReducer, useState } from 'octane';
+export function App(props) @{
+  const [count, setCount] = useState(0);
+  const later = (value) => { setTimeout(() => setCount(value), 0); return value; };
+  const unsafe = (value) => setCount(value);
+  const overridden = { sourceEqual: unsafe };
+  const dynamicKey = props.comparatorName;
+  useReducer((value) => value, count, count > 0 ? later : props.initialize);
+  useLinkedState(count, count > 0 ? later : props.reconcile, {
+    ...overridden,
+    sourceEqual: Object.is,
+    [dynamicKey]: unsafe,
+    valueEqual: count > 0 ? Object.is : props.compare,
+    onSettled: unsafe,
+  });
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('reports spread and conditional callback violations in TypeScript and editor diagnostics', () => {
+		const source = `"use strong";
+import { useLinkedState, useState } from 'octane';
+export function useValue(value) {
+  const [, update] = useState(0);
+  const options = { sourceEqual: update };
+  return useLinkedState(value, (next) => next, { ...options });
+}`;
+		const editorSource = `"use strong";
+import { useLinkedState, useRef } from 'octane';
+export function App(props) @{
+  const ref = useRef(0);
+  const key = 'valueEqual';
+  useLinkedState(props.value, (value) => value, {
+    [key]: props.value ? Object.is : (previous, next) => { ref.current = next; return previous === next; },
+  });
+  <div />
+}`;
+		const diagnostics = compileToVolarMappings(editorSource, '/src/App.tsrx');
+
+		expect(() => slotHooks(source, '/src/useValue.ts')).toThrow(RENDER_STATE_UPDATE);
+		expect(diagnostics.diagnostics).toContainEqual(
+			expect.objectContaining({ code: RENDER_REF_WRITE, severity: 'error' }),
+		);
+		expect(diagnostics.errors).toContainEqual(
+			expect.objectContaining({ code: RENDER_REF_WRITE, type: 'usage' }),
+		);
+	});
+
+	it('reports synchronous linked-state callback violations in plain TypeScript and editor diagnostics', () => {
+		const source = `"use strong";
+import { useLinkedState, useRef, useState } from 'octane';
+export function useValue(value) {
+  const [, update] = useState(0);
+  return useLinkedState(value, () => update(value));
+}`;
+		const editorSource = `"use strong";
+import { useLinkedState, useRef } from 'octane';
+export function App(props) @{
+  const ref = useRef(0);
+  useLinkedState(props.value, (value) => value, {
+    valueEqual: (previous, next) => { ref.current = next; return previous === next; },
+  });
+  <div />
+}`;
+		const diagnostics = compileToVolarMappings(editorSource, '/src/App.tsrx');
+
+		expect(() => slotHooks(source, '/src/useValue.ts')).toThrow(RENDER_STATE_UPDATE);
+		expect(diagnostics.diagnostics).toContainEqual(
+			expect.objectContaining({ code: RENDER_REF_WRITE, severity: 'error' }),
+		);
+		expect(diagnostics.errors).toContainEqual(
+			expect.objectContaining({ code: RENDER_REF_WRITE, type: 'usage' }),
+		);
+	});
+
+	it.each([
 		[
 			'aliased imports',
 			`import { useMemo as memo, useState } from 'octane';

--- a/packages/octane/tests/compiler/strong-mode.test.ts
+++ b/packages/octane/tests/compiler/strong-mode.test.ts
@@ -359,6 +359,144 @@ export function App(props) @{
 	});
 
 	it.each([
+		[
+			'lazy state initializers',
+			'const tuple = useState(0); const update = tuple[1]; useState(update);',
+		],
+		[
+			'chained setter aliases',
+			'const tuple = useState(0); const update = tuple[1]; const alias = update; useState(alias);',
+		],
+		[
+			'TypeScript-wrapped tuple indexes',
+			'const tuple = useState(0); const update = tuple[1 as const]; useState(update);',
+		],
+		[
+			'immutable numeric tuple indexes',
+			'const tuple = useState(0); const index = 1; const update = tuple[index]; useState(update);',
+		],
+		[
+			'immutable string tuple indexes',
+			'const tuple = useState(0); const index = "1"; const update = tuple[index]; useState(update);',
+		],
+		[
+			'immutable template tuple indexes',
+			'const tuple = useState(0); const index = `1`; const update = tuple[index]; useState(update);',
+		],
+		[
+			'inline template tuple indexes',
+			'const tuple = useState(0); const update = tuple[`1`]; useState(update);',
+		],
+		[
+			'object-pattern tuple setter aliases',
+			'const tuple = useState(0); const { 1: update } = tuple; useState(update);',
+		],
+		[
+			'computed object-pattern tuple setter aliases',
+			'const tuple = useState(0); const index = 1; const { [index]: update } = tuple; useState(update);',
+		],
+		[
+			'TypeScript-wrapped setter aliases',
+			'const tuple = useState(0); const update = tuple[1] as (value: number) => void; useState(update);',
+		],
+		[
+			'direct setter invocation',
+			'const tuple = useState(0); const update = tuple[1]; update(count + 1);',
+		],
+		[
+			'lazy reducer initializers',
+			'const tuple = useState(0); const update = tuple[1]; useReducer((value) => value, count, update);',
+		],
+		[
+			'linked-state reconcilers',
+			'const tuple = useState(0); const update = tuple[1]; useLinkedState(count, update);',
+		],
+		[
+			'linked-state comparators',
+			'const tuple = useState(0); const update = tuple[1]; useLinkedState(count, (value) => value, { sourceEqual: update });',
+		],
+		[
+			'reducer dispatch aliases',
+			'const tuple = useReducer((value) => value, 0); const update = tuple[1]; useState(update);',
+		],
+		[
+			'linked-state setter aliases',
+			'const tuple = useLinkedState(count, (value) => value); const update = tuple[1]; useState(update);',
+		],
+	])('rejects render updates through aliased tuple setters in %s', (_label, setup) => {
+		const source = `"use strong";
+import { useLinkedState, useReducer, useState } from 'octane';
+export function App(props) @{
+  const [count] = useState(0);
+  ${setup}
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(RENDER_STATE_UPDATE);
+	});
+
+	it.each([
+		[
+			'named template source comparator keys',
+			'const key = `sourceEqual`; useLinkedState(count, (value) => value, { [key]: setCount });',
+		],
+		[
+			'named template value comparator keys',
+			'const key = `valueEqual`; useLinkedState(count, (value) => value, { [key]: setCount });',
+		],
+		[
+			'aliased template comparator keys',
+			'const key = `sourceEqual`; const alias = key; useLinkedState(count, (value) => value, { [alias]: setCount });',
+		],
+		[
+			'TypeScript-wrapped template comparator keys',
+			'const key = `valueEqual` as const; useLinkedState(count, (value) => value, { [key]: setCount });',
+		],
+		[
+			'statically concatenated comparator keys',
+			'const key = "source" + "Equal"; useLinkedState(count, (value) => value, { [key]: setCount });',
+		],
+		[
+			'inline statically concatenated comparator keys',
+			'useLinkedState(count, (value) => value, { ["value" + "Equal"]: setCount });',
+		],
+		[
+			'statically interpolated comparator keys',
+			'const key = `source${"Equal"}`; useLinkedState(count, (value) => value, { [key]: setCount });',
+		],
+		[
+			'sequence-selected comparator keys',
+			'const key = (props.trace, "sourceEqual"); useLinkedState(count, (value) => value, { [key]: setCount });',
+		],
+		[
+			'known conditional comparator keys',
+			'const key = true ? "valueEqual" : "other"; useLinkedState(count, (value) => value, { [key]: setCount });',
+		],
+		[
+			'known logical comparator keys',
+			'const key = null ?? "sourceEqual"; useLinkedState(count, (value) => value, { [key]: setCount });',
+		],
+		[
+			'template-keyed spread comparators',
+			'const key = `sourceEqual`; const options = { [key]: setCount }; useLinkedState(count, (value) => value, { ...options });',
+		],
+		[
+			'template-keyed aliased tuple comparators',
+			'const tuple = useState(0); const update = tuple[1]; const key = `valueEqual`; useLinkedState(count, (value) => value, { [key]: update });',
+		],
+	])('rejects render updates hidden by %s', (_label, setup) => {
+		const source = `"use strong";
+import { useLinkedState, useState } from 'octane';
+export function App(props) @{
+  const [count, setCount] = useState(0);
+  ${setup}
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(RENDER_STATE_UPDATE);
+	});
+
+	it.each([
 		['nullish state initializers', 'useState(props.initialize ?? (() => setCount(count + 1)));'],
 		['logical OR state initializers', 'useState(props.initialize || (() => setCount(count + 1)));'],
 		['logical AND state initializers', 'useState(props.enabled && (() => setCount(count + 1)));'],
@@ -629,6 +767,22 @@ export function App(props) @{
 		expect(() => compile(source, '/src/App.tsrx')).toThrow(RENDER_REF_WRITE);
 	});
 
+	it('rejects ref writes from aliased template comparator keys', () => {
+		const source = `"use strong";
+import { useLinkedState, useRef } from 'octane';
+export function App(props) @{
+  const ref = useRef(0);
+  const key = \`sourceEqual\`;
+  const alias = key;
+  useLinkedState(props.value, (value) => value, {
+    [alias]: (previous, next) => { ref.current = next; return previous === next; },
+  });
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(RENDER_REF_WRITE);
+	});
+
 	it.each([
 		[
 			'aliased state imports',
@@ -868,6 +1022,33 @@ import { useLinkedState, useState } from 'octane';
 export function App(props) @{
   const [count, setCount] = useState(0);
   ${setup}
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('keeps mutable tuple aliases and dynamic or overridden template comparator keys legal', () => {
+		const source = `"use strong";
+import { useLinkedState, useState } from 'octane';
+export function App(props) @{
+  const tuple = useState(0);
+  let mutable = tuple[1];
+  mutable = (value) => value;
+  useState(mutable);
+  let mutableIndex = 1;
+  mutableIndex = props.index;
+  const dynamicUpdate = tuple[mutableIndex];
+  useState(dynamicUpdate);
+  const unrelated = \`onSettled\`;
+  const dynamic = \`\${props.prefix}Equal\`;
+  const known = \`sourceEqual\`;
+  useLinkedState(tuple[0], (value) => value, {
+    [unrelated]: tuple[1],
+    [dynamic]: tuple[1],
+    [known]: tuple[1],
+    sourceEqual: Object.is,
+  });
   <div />
 }`;
 
@@ -1281,6 +1462,22 @@ import { useEffect, useState } from 'octane';
 export function App(props) @{
   const [, setCount] = useState(0);
   useEffect(() => { ${invocation} }, []);
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(EFFECT_STATE_UPDATE);
+	});
+
+	it.each([
+		['effect callbacks', 'useEffect(update, []);'],
+		['direct calls in effect setup', 'useEffect(() => { update(1); }, []);'],
+	])('rejects aliased tuple setters used as %s', (_label, effect) => {
+		const source = `"use strong";
+import { useEffect, useState } from 'octane';
+export function App() @{
+  const tuple = useState(0);
+  const update = tuple[1];
+  ${effect}
   <div />
 }`;
 


### PR DESCRIPTION
## Summary

<!-- What changed, and why. -->

Series **1/7**, targeting `main`. Tracks [octanejs/octane#365](https://github.com/octanejs/octane/issues/365).

- Strong mode classified synchronous hook callbacks as deferred, so render-phase state updates and ref writes escaped diagnostics inside lazy `useState`/`useReducer` initializers, `useLinkedState` reconcilers, and linked-state `sourceEqual`/`valueEqual` comparators.
- Teach the owning compiler analysis to follow actual synchronous callback argument positions through named/aliased and conditional callbacks, inline/aliased/nested comparator-option spreads, conditional options, constant computed keys, methods, and setter identities; honor object-spread last-write-wins overrides.
- Close **24 red-first hardening bypasses**, including ref writes and TypeScript/Volar paths; add negative controls proving deferred callbacks, dynamic keys/options, and subsequently overridden properties retain their existing behavior.
- Preserve client/SSR behavior, existing linked-state semantics, compiler integrations, editor diagnostics, and compatibility mode.
- Add the patch changeset `.changeset/strong-hook-callback-purity.md` for `octane`.

## Validation

<!-- What you ran, and anything you deliberately left unverified. -->

- [x] `pnpm format:check`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [x] targeted tests: `pnpm exec vitest run --project octane packages/octane/tests/compiler/strong-mode.test.ts packages/octane/tests/compiler/linked-state-compiler.test.ts packages/octane/tests/compiler/volar.test.ts packages/octane/tests/compiler/bundler-compiler.test.ts packages/octane/tests/compiler/compiler-vite-options.test.ts packages/octane/tests/linked-state.test.ts packages/octane/tests/linked-state-ssr-hydration.test.ts --silent=passed-only --reporter=dot` — **446 tests passed across seven files on the final hardened commit**.
- [x] Complete Octane development and production projects: `pnpm exec vitest run --project octane --project octane-prod --maxWorkers=3 --reporter=dot --silent=passed-only` — **10,621 tests passed across 768 files**.
- [x] Red-first reproduction: `pnpm exec vitest run packages/octane/tests/compiler/strong-mode.test.ts --project octane -t 'rejects render updates from inline state initializers|rejects render updates from inline linked-state reconcilers|rejects render updates from inline source comparators|rejects render updates from inline value comparators|rejects render-time ref writes from state initializers' --reporter=dot --silent=passed-only` — all five regressions failed before the fix.
- [x] Follow-up red-first hardening audit: **24 previously missed synchronous-callback cases** failed before the hardening and pass afterward, covering nested/aliased object spreads and last-write-wins overrides, conditional callbacks/options, constant computed keys, lazy `useReducer` initialization, ref writes, and TypeScript/Volar; deferred, dynamic, and overridden negative controls remain accepted.
- [x] Package and changed-file type checks: `pnpm exec tsgo --noEmit -p packages/octane/tsconfig.json` and `pnpm typecheck:files packages/octane/src/compiler/strong-mode.js packages/octane/tests/compiler/strong-mode.test.ts`.
- [x] Scoped formatting: `pnpm format:files:check packages/octane/src/compiler/strong-mode.js packages/octane/tests/compiler/strong-mode.test.ts .changeset/strong-hook-callback-purity.md`.
- [x] Changeset/synchronization gates: `pnpm changeset:check` and `pnpm sync`.

- [x] Integrated final stack: `pnpm exec vitest run --project octane --project octane-prod --project apollo-client --project apollo-client-ssr --project aria --project aria-ssr --project base-ui --project base-ui-ssr --project tanstack-router --project radix --maxWorkers=4 --reporter=dot --silent=passed-only` — **11,473 tests passed across 879 files**.

The remaining unchecked boxes are intentional: full-workspace typecheck and test commands were not run.

## Risk / follow-ups

Synchronous callback discovery is deliberately limited to known render-time hook boundaries and statically knowable option properties; deferred callbacks, dynamically unresolved keys/options, and overridden comparator values retain their prior treatment. Object spreads obey last-write-wins semantics. Companion pull requests migrate package-owned consumers without introducing a new state primitive.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!--
Tick the box above whenever an agent wrote the change, no matter which account
pushes it. Leaving it clear or omitting this section asserts a human wrote the
diff; either form keeps the label workflow successful.

A bot reads this box and applies the label, so nothing here needs repository
permissions and it works the same from a fork. The type label comes from the
conventional-commit type in the title. Do not apply either by hand.

When updating an existing pull request, merge this template content into the
current body. Preserve every bot-managed HTML comment region and all existing
maintainer-authored text; never replace the body from a fresh template.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Compiler-only behavior change for `"use strong"` modules with broad static-analysis heuristics; false positives/negatives are possible on edge cases, but compatibility mode and deferred/async paths are explicitly preserved in tests.
> 
> **Overview**
> **Strong mode** now treats lazy `useState`/`useReducer` initializers, `useLinkedState` reconcilers, and `sourceEqual`/`valueEqual` comparators as synchronous render boundaries, so state updates and `ref.current` writes inside those callbacks are diagnosed instead of slipping through.
> 
> The `strong-mode` compiler analysis gains **static evaluation** (constants, logical/conditional branches, computed keys, tuple index `1`) and richer binding kinds (`setter`, `linked-options`, `callback-choice`) so it can follow aliases, sequence/logical/conditional selections, object-pattern destructuring, spread overrides, and namespace imports to the real callback bodies.
> 
> **`useState`**, **`useReducer`** (lazy init arg), and **`useLinkedState`** (reconciler + options) each get the correct synchronous-argument index; immediately invoked selected setters/callbacks are caught in render and effect setup, while post-`await` work stays allowed.
> 
> Adds a large **`strong-mode.test.ts`** matrix (reject bypasses, accept deferred/dynamic/overridden cases, Volar/TS diagnostics) and patch changeset **`strong-hook-callback-purity.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91d1662f7ddd6bd0216782e8471020b0d831715e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->