### PR TITLE
docs(octane): distinguish shipped Strong-state behavior from proposals

### DIFF
--- a/docs/strict-state-plan.md
+++ b/docs/strict-state-plan.md
@@ -4,10 +4,65 @@
 > plus review. Line references are against the 2026-07-17 working tree and will
 > drift; function and constant names are the stable anchors.
 >
-> **Status: PROPOSED. Nothing below is implemented.** Today's runtime
-> intentionally supports React's full render-phase-update semantics
-> (`derived-state.test.ts` pins them); this plan does not change those semantics
-> for compat code — it introduces a strict mode alongside them.
+> **Status: HISTORICAL DESIGN PROPOSAL; PARTIALLY SUPERSEDED.**
+> [`useLinkedState` shipped in #366](https://github.com/octanejs/octane/pull/366),
+> and [opt-in, compiler-only Strong mode shipped in
+> #376](https://github.com/octanejs/octane/pull/376). The proposed runtime phase
+> guards, per-cell policies, `stateWrites` flags, package declarations, and
+> staged rollout below did not ship. They remain historical design context, not
+> descriptions of current behavior.
+
+## Current implementation
+
+The shipped replacement for guarded prop/source-driven state updates is
+`useLinkedState(source, reconcile, options?)`, not `useKeyedState`:
+
+```ts
+const [selection, setSelection, getSelection] = useLinkedState(
+	items,
+	(nextItems, previous) =>
+		nextItems.find((item) => item.id === previous?.value?.id) ?? null,
+);
+```
+
+The reconciler receives `undefined` initially and the previous committed
+`{ source, value }` on later source changes. Its result is available in the same
+render. Sources and values default to `Object.is`, including array sources;
+composite sources need an explicit `sourceEqual` comparator. The optional
+`valueEqual` comparator and compiler-selected third getter are supported across
+client, server, hydration, and universal rendering.
+
+Strong mode is an optional **compiler check**, not a runtime state policy:
+
+```ts
+// octane.config.ts
+export default {
+	compiler: {
+		strong: true,
+	},
+};
+```
+
+A module can also opt itself in by placing `"use strong"` before its imports.
+Project-wide configuration applies only to application-owned modules; dependency
+and separate workspace packages retain React-compatible behavior unless their own
+module opts in. No package compatibility declaration or exception list is needed.
+Vite, Rspack, and Rsbuild also accept `strong: true` in their plugin options.
+
+Opted-in modules reject statically provable updater calls during render or direct
+effect setup, along with render-time `ref.current` writes. Synchronously evaluated
+state initializers, linked-state reconcilers, and linked-state equality callbacks
+are render contexts too. Genuinely deferred callbacks remain valid. There is no
+runtime phase guard, hook-cell policy, runtime-only enforcement, cleanup ban, or
+`stateWrites` configuration in the shipped model.
+
+For current authoring guidance, see [State that follows another
+value](./tsrx-basics.md#state-that-follows-another-value),
+[Strong mode](./tsrx-basics.md#strong-mode), and [Differences from
+React](./differences-from-react.md#optional-strong-mode). The numbered sections
+below preserve the original, more ambitious proposal; statements about runtime
+policy or additional primitives are conditional future ideas unless explicitly
+identified as shipped.
 
 ## 1. Thesis
 
@@ -48,9 +103,10 @@ a second state machine.
 
 ## 2. The invariant and who enforces what
 
-Strictness is defined **dynamically**, by the runtime's execution-context
-stack — not syntactically. A function boundary does not prove deferred
-execution:
+The original proposal would define strictness **dynamically**, using a future
+runtime execution-context stack rather than only compiler analysis. That runtime
+stack and its setter guards are not implemented. A function boundary does not
+prove deferred execution:
 
 ```ts
 useEffect(() => {
@@ -60,8 +116,9 @@ useEffect(() => {
 });
 ```
 
-All three writes execute while the effect frame is on the stack and are
-illegal in strict code — in development **and production** — regardless of how
+Under the proposed runtime policy, all three writes would execute while the
+effect frame is on the stack and would be illegal in development **and
+production**, regardless of how
 many function boundaries they pass through. Conversely, static classification
 of "the synchronous body" would miss all of them if the calls were hidden in
 an imported helper. The boundary is a **causal turn**, not a function frame:
@@ -74,7 +131,7 @@ after that stack has returned              → legal causal transition
 
 Where a callback was *created* is irrelevant; only when it *executes* matters.
 Registering callbacks is exactly what effect setup is for, so both of these
-are legal strict code, no wrapper required:
+would remain legal, with no wrapper required:
 
 ```ts
 useEffect(() => {
@@ -90,25 +147,31 @@ The third line of the illegal example — `subscribe` — names the one nuance:
 a subscription that **replays synchronously** invokes its callback before
 effect setup returns, so that first invocation is still part of the commit
 cascade and is rejected; later notifications arrive on new turns and are
-legal. The initial value belongs in an initializer or snapshot read —
-`useSource` (§6.4) bakes this split in so sync-replaying stores are handled
-by construction rather than by user discipline.
+legal. The initial value would belong in an initializer or snapshot read. The
+proposed, unimplemented `useSource` (§6.4) could encode this split for
+sync-replaying stores.
 
 Three layers, with distinct jobs:
 
-| Layer                   | Scope                                          | Job                                                                                                                             |
-| ----------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| Compiler                | statically provable writes in compiled modules | Fail early with rich, pattern-specific fix-its. The ergonomic layer — **not** the semantic defense.                              |
-| Runtime phase guard     | every user-callable setter/dispatcher          | **The semantic defense.** Dev + prod, all renderers. Rich diagnostics in dev; compact error code + component name in prod.       |
-| Compat mode             | modules that declare `stateWrites: 'compat'`   | React semantics unchanged: guarded replay, the 25-pass cap, "Too many re-renders", SSR/universal replay loops.                   |
+| Layer | Current status | Intended role |
+| ----- | -------------- | ------------- |
+| Compiler | **Shipped**, opt-in Strong mode | Reject statically provable render/effect-setup updates and render-time ref writes with actionable diagnostics. |
+| Runtime phase guard | **Not implemented**; historical proposal | Enforce a future runtime policy for user-callable setters/dispatchers in development and production. |
+| Dependency compatibility | **Shipped** through package containment | Keep dependencies and separate workspace packages in their existing mode unless their own module opts into Strong mode. |
+| Per-cell `stateWrites` policy | **Not implemented**; historical proposal | Attach a hypothetical strict/compat policy to hook cells if runtime enforcement is ever introduced. |
 
-The guard lives on user-callable setters and dispatchers — never on
+Any future runtime guard would live on user-callable setters and dispatchers —
+never on
 `scheduleRender`, which legitimate internal work (external stores, Suspense,
-actions, hydration, deferred values) also uses. It fires **before evaluating a
-functional updater and before the `Object.is` eager bailout**, so illegal
-writes cannot hide behind same-value sets or run updater side effects first.
+actions, hydration, deferred values) also uses. It would fire **before evaluating
+a functional updater and before the `Object.is` eager bailout**, so illegal
+writes could not hide behind same-value sets or run updater side effects first.
 
 ## 3. Rule table (strict semantics)
+
+This table describes the **proposed runtime-backed contract**, not the complete
+shipped Strong-mode feature set. In particular, cleanup restrictions, callback-ref
+restrictions, runtime guards, and hook-cell policies are not implemented.
 
 | Context                                                                        | Policy                                                                              |
 | ------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
@@ -116,7 +179,7 @@ writes cannot hide behind same-value sets or run updater side effects first.
 | `useMemo` / `useCallback` bodies, `useState`/`useReducer` initializers         | Hard error (purity)                                                                 |
 | Reducers and functional updaters                                               | Hard error, guarded **before** the updater/reducer evaluates                        |
 | `useInsertionEffect` setup                                                     | Hard error                                                                          |
-| Effect setup frames (`useEffect`, `useLayoutEffect`) — any sync call depth     | Hard error (phase 3 flip; see §8)                                                   |
+| Effect setup frames (`useEffect`, `useLayoutEffect`) — any sync call depth     | Proposed runtime hard error; only statically provable setup writes are rejected today |
 | Effect cleanup frames — all effect kinds, update and unmount                   | Hard error                                                                          |
 | Callback refs during commit                                                    | Same policy as layout-effect setup; `useLayoutSnapshot` covers measurement (§9 OQ)  |
 | DOM event handlers, actions, form actions                                      | Allowed, batched                                                                    |
@@ -128,33 +191,38 @@ writes cannot hide behind same-value sets or run updater side effects first.
 
 ## 4. Policy provenance and the compat boundary
 
-**Declaration is module-level.** A new compiler option joins the existing bag
-(`hmr`, `mode`, `dev`, `autoMemo`, … in `compile.js`): `stateWrites: 'strict' |
-'compat'`. The vite plugin compiles application code strict by default;
-ported packages declare compat in their build config. There is **no inline
-suppression** — no pragma comment, no per-call option. Agents cargo-cult
-suppression comments the way they cargo-cult `eslint-disable`; a whole-module
-policy flip is the right amount of friction and maps to the real use case
-(porting React code, which is file-scoped anyway).
+**Shipped declaration is opt-in and compiler-owned.** `compiler.strong` defaults
+to `false`; `compiler: { strong: true }` applies to application-owned source, and
+an individual module can opt in with `"use strong"`. Dependencies, including
+separate workspace packages nested inside the project root, do not inherit the
+application setting. They need no package flag, compatibility allowlist, or
+hook-slot ABI change.
 
-**Policy travels with the hook cell, not the executing block.** This is the
-load-bearing mechanic. A compat hook called from a strict component —
+The rest of this section preserves the **unimplemented historical proposal**.
+`stateWrites: 'strict' | 'compat'`, strict-by-default application compilation,
+manifest-level compatibility declarations, and per-cell policy propagation do not
+exist in the shipped API.
+
+**A future runtime policy could travel with the hook cell, not the executing
+block.** This was the historical load-bearing proposal. A compat hook called
+from a strict component —
 `packages/base-ui/src/utils/useTransitionStatus.ts` doing render-phase writes
 while a strict app component is the current block — must keep working, or
-compat bindings become unusable from strict apps. So each hook cell captures
-its policy at allocation, from the declared mode of the module whose code
+compat bindings would become unusable from strict apps. In that future design,
+each hook cell would capture its policy at allocation from the module that
 allocated it:
 
-- Compiled modules (`.tsrx` / full-compiled `.tsx`): the compiler conveys the
+- Compiled modules (`.tsrx` / full-compiled `.tsx`): the compiler would convey the
   bit through the emitted call site (encoding: §9 open question — slot-channel
   encoding vs. a registration table).
 - Plain-`.ts` manual-slot callers — the semi-public bindings contract
-  (`S`/`subSlot` style) — default to **compat**. This surface is documented as
+  (`S`/`subSlot` style) — could default to **compat** in the proposed runtime
+  model. This surface is documented as
   not-for-app-code already (tier 2 in `index.ts`); app code on the paved road
-  never allocates a compat cell by accident.
-- `octane/react` is always compat.
+  would not allocate a hypothetical compat cell by accident.
+- `octane/react` would remain compatible under the proposed runtime model.
 
-A strict cell then refuses illegal writes **everywhere**: client
+A future strict cell would refuse illegal writes **everywhere**: client
 (`drainQueue`'s replay only engages compat cells), SSR (the Fizz-style
 render-phase replay loop in `runtime.server.ts`, `didScheduleRenderPhaseUpdate`
 region), universal rendering (`executeOwner`'s renderCount retry in
@@ -163,7 +231,7 @@ region), universal rendering (`executeOwner`'s renderCount retry in
 
 **The replay machinery is permanent.** `octane/react`, the ported bindings,
 and the conformance suite keep it load-bearing indefinitely. The permanent
-runtime becomes policy-aware, nothing more:
+runtime would become policy-aware, nothing more:
 
 ```
 strict render/effect-frame write → throw
@@ -172,58 +240,50 @@ ordinary callback write          → schedule normally
 ```
 
 A future strict-only specialized build could elide the replay paths, but that
-is not a payoff this plan claims. The honest benefits are: deterministic
-strict application code, no discarded render pass for native reset patterns,
-identical development and production guarantees, better agent diagnostics,
-simpler reasoning and profiling for strict components, and compat code that
-remains fully supported and separately identifiable. The conformance
-render-phase suite (`conformance/derived-state.test.ts`), the differential
-rig, and the SSR replay tests compile their fixtures with an explicit
-`stateWrites: 'compat'`, the same way `prod-mode-hydrate.test.ts` pins
-explicit prod options.
+is not a payoff this plan claims. Potential benefits would include deterministic
+application code, identical development and production guarantees, better agent
+diagnostics, simpler reasoning, and compatibility that remains separately
+identifiable. Today the conformance render-phase suite
+(`conformance/derived-state.test.ts`), differential rig, and SSR replay tests
+retain their existing behavior without any `stateWrites` option.
 
 **Current blast radius** (rough lower-bound audit, 2026-07-17): ~25 non-test
 direct render-phase writes and ~76 synchronous effect-body writes across the
 repo, spanning genuinely different cases:
 
-- Apollo replaces its internal state instance during render when
-  client/query identity changes (`useQuery.js`) — maps exactly to
-  `useKeyedState([client, query], createState)`.
+- Apollo replaces its internal state instance during render when client/query
+  identity changes (`useQuery.js`). Its migration can use
+  `useLinkedState([client, query], (_source, previous) =>
+  createState(previous?.value), { sourceEqual: sameClientAndQuery })`, preserving
+  `previousData` while comparing the composite source explicitly.
 - Radix `use-size.ts` mixes an initial layout-effect measurement (→
   `useLayoutSnapshot`) with later `ResizeObserver` callback writes (legal —
   callbacks are events).
 - Lexical `LexicalContentEditable.tsrx` mixes an immediate layout write with
   an editor-subscription callback — same split.
 
-These packages stay compat until (and unless) their migrable cases move to the
-primitives; nothing forces a migration date.
+These packages already retain compatibility through package containment until
+(and unless) their migrable cases move to the shipped or future primitives;
+nothing forces a migration date.
 
 ## 5. Enforcement mechanics
 
 ### 5.1 Compiler
 
-The pieces mostly exist. The compiler already identifies setters, dispatchers,
-and state getters from tuple position — they are "stability sources" for dep
-inference (`compile.js`, stability-sources block) — and already tracks them
-through local custom hooks (#148) and classifies render-time calls for
-PURE/DEP-PURE decisions. The new work is a phase/effect classification pass
-that tracks known writers through aliases and local helpers and labels each
-call site: render body, memo/initializer/reducer/updater, effect setup,
-cleanup, event handler, or deferred callback.
+The shipped Strong-mode compiler already identifies setters and dispatchers from
+tuple positions, tracks local aliases and helpers, distinguishes synchronous
+render/effect-setup execution from deferred callbacks, and reports stable
+diagnostic codes. Cleanup enforcement, runtime-only/opaque callback enforcement,
+and policy propagation remain future design work rather than existing compiler
+guarantees.
 
 Diagnostics are machine-readable and carry both ends — the setter's
 declaration site and the illegal call site — plus a pattern-specific rewrite:
 
 ```
-error[strict-state/render-write]: `setSelection` is called while <Gallery> renders.
-  --> src/Gallery.tsrx:14
-   |  declared: src/Gallery.tsrx:6 (useState)
-   |
-   = Deriving from `items`? `useKeyedState(items, () => null)` resets in the
-     same pass — no extra render.
-   = Responding to a user action? Call it from the event handler.
-   = Porting React code? Declare `stateWrites: 'compat'` for this module's
-     package (there is no inline suppression).
+src/Gallery.tsrx:14: [OCTANE_STRONG_RENDER_STATE_UPDATE]
+Strong mode does not allow state updates during render.
+Use useLinkedState when state needs to reset or change with another value.
 ```
 
 The compiler **proves or stays silent**. It errors only on writes it can
@@ -238,52 +298,55 @@ foo.thing(() => setValue(1)); // sync or async invocation? statically unknowable
 
 Static analysis cannot know whether `thing` invokes its callback
 synchronously (inside the frame — illegal) or asynchronously (a later turn —
-legal), and guessing in either direction is worse than deferring to the
-runtime guard, which catches the synchronous case identically in dev and
-prod. For the same reason there is **no laundering diagnostic**: deliberate
+legal), and guessing in either direction is worse than staying silent. A future
+runtime guard could catch the synchronous case identically in development and
+production, but no such guard exists today. For the same reason there is **no
+laundering diagnostic**: deliberate
 deferral via `queueMicrotask`/`setTimeout` is a sanctioned escape hatch (§7),
 not a smell to police at build time. Callback timing is the runtime's
 question, full stop.
 
-### 5.2 Runtime phase stack
+### 5.2 Runtime phase stack (future proposal; not implemented)
 
 The runtime already carries most of the phase truth as scattered counters:
 `EFFECT_BODY_DEPTH`, `REF_CALLBACK_DEPTH`, `STORE_SYNC_DEPTH`
 (`runtime.ts` ~683) and the render-phase classification
-(`renderPhaseSelf` / `renderPhaseOther`, ~1652). Formalize these into an
-explicit execution-context stack of `{ kind, block }` frames — render, effect
+(`renderPhaseSelf` / `renderPhaseOther`, ~1652). The historical proposal would
+formalize these into an explicit execution-context stack of `{ kind, block }`
+frames — render, effect
 setup, cleanup, ref callback, updater evaluation, event/action — because raw
 `CURRENT_BLOCK` is ambiguous (cleanup can run while an outer render frame
 remains ambient).
 
-The user-dispatcher path then checks: if the cell is strict and the top frame
-is a lifecycle frame, throw. Before updater evaluation, before the eager
-bailout. Development throws the rich message with source LOC and the same
-pattern suggestions as the compiler; production throws a compact
+The proposed user-dispatcher path would then check whether a hypothetical strict
+cell is executing under a lifecycle frame and throw before updater evaluation or
+the eager bailout. Development would throw the rich message with source LOC and
+the same pattern suggestions as the compiler; production would throw a compact
 `Octane strict-state violation (E##) in <Gallery>` — enforcement is identical
 in both, only verbosity differs (the inverse of the hydration-mismatch split,
 where recovery ships to prod and warnings are dev-only).
 
-### 5.3 Renderer parity
+### 5.3 Renderer parity (future runtime proposal)
 
-The same stack and the same guard run under DOM, SSR, hydration, and
-universal rendering. The server and universal replay loops consult the cell's
-policy: compat cells replay exactly as today; a strict cell dispatching during
-a server render is the same error it would be on the client.
+A future runtime stack and guard would need equivalent behavior under DOM, SSR,
+hydration, and universal rendering. Today Strong diagnostics are compiler checks
+across those authored compilation paths; server and universal runtimes do not
+consult a strict/compat hook-cell policy.
 
 ## 6. Replacement primitives
 
-All are tier-1 exports — "React parity plus deliberately documented Octane
-extensions" (`index.ts` tier comment). Each exists because a forbidden pattern
-has a physically legitimate core that deserves a managed home.
+Only `useLinkedState`, the existing state getter, and already established hooks
+such as `useSyncExternalStore` are shipped Octane APIs in this section.
+`useLayoutSnapshot`, a core `useHydrated`, and `useSource` are retained future
+ideas, not current exports.
 
-### 6.1 `useKeyedState(key, initializer)`
+### 6.1 `useLinkedState(source, reconcile, options?)` — shipped
 
 Replaces: "adjust/reset state when an input changes" — the pattern React
 blesses as a guarded render-phase set, at the cost of a thrown-away render.
 
 ```ts
-const [selection, setSelection, getSelection] = useKeyedState(
+const [selection, setSelection, getSelection] = useLinkedState(
 	items,
 	() => null,
 );
@@ -291,21 +354,24 @@ const [selection, setSelection, getSelection] = useKeyedState(
 
 - Tuple shape matches `useState`, including the compiler-driven third
   `getState` member.
-- On each render the hook compares `key` against the stored key — `Object.is`,
-  or element-wise `Object.is` when `key` is an array (dependency-array
-  semantics). On change, the initializer re-runs **inline in the same pass**:
-  single-pass, no scheduled retry, no discarded render. This is strictly
-  cheaper than React's blessed pattern, not just cleaner.
-- A key change starts a new generation: updates queued against the old
+- On each render the hook compares `source` against the committed source with
+  `Object.is` by default, **including when the source is an array**. Arrays are
+  not implicitly treated as dependency tuples. Supply `sourceEqual` explicitly
+  for element-wise composite identity.
+- On a source change, `reconcile(source, previous)` runs **inline in the same
+  pass**. `previous` contains the last committed `{ source, value }`, so useful
+  local state can survive reconciliation without a render-phase setter.
+- A source change starts a new generation: updates queued against the old
   generation are discarded (the reset wins).
-- Between key changes it is exactly `useState`.
-- SSR/hydration: the initializer is pure per-pass computation; server and
-  client derive identically from the same key. No replay machinery involved.
-- `useKeyedState(propValue, (v) => v)` is the "follow the prop unless the user
+- Between source changes the value remains independently editable.
+- SSR/hydration: the reconciler is pure per-pass computation; server and
+  client derive identically from the same source.
+- `useLinkedState(propValue, (value) => value)` is the "follow the prop unless
+  the user
   overrode it since" idiom that controlled/uncontrolled widget internals
   hand-roll today.
 
-### 6.2 `useLayoutSnapshot(measure, options?)`
+### 6.2 `useLayoutSnapshot(measure, options?)` — future proposal
 
 Replaces: "measure the DOM after commit, then set state" — physically
 legitimate (the DOM did not exist earlier), which argues for a managed
@@ -317,24 +383,26 @@ const height = useLayoutSnapshot(() => ref.current?.offsetHeight, {
 });
 ```
 
-- `measure` runs at layout timing after commit (post-mutation, pre-paint).
-- The result is compared with the previous snapshot — `Object.is` by default,
+- `measure` would run at layout timing after commit (post-mutation, pre-paint).
+- The result would be compared with the previous snapshot — `Object.is` by default,
   `options.equal` for rect-like shapes — and only a change schedules the
   re-render in which the hook returns the new value. The equality guard being
   **built in** removes the single most common infinite-loop bug in React
   apps; the convergence budget is bounded with dev source attribution.
-- First render and SSR return `options.initial` (else `undefined`); `measure`
-  never runs on the server.
-- Continuous observation (`ResizeObserver`, scroll) stays in callbacks, which
-  are legal transition sites; the primitive covers commit-coupled measurement
+- First render and SSR would return `options.initial` (else `undefined`);
+  `measure` would never run on the server.
+- Continuous observation (`ResizeObserver`, scroll) would stay in callbacks,
+  which are legal transition sites; the primitive would cover commit-coupled
+  measurement
   only.
 
-### 6.3 `useHydrated()`
+### 6.3 Core `useHydrated()` — future proposal
 
-Replaces: `const [mounted, setMounted] = useState(false)` + mount effect.
-Returns `false` on the server and during the first client (hydration) pass,
-`true` after mount — runtime-owned, so no user-visible effect, no
-hydration-mismatch hazard.
+This proposed core hook would replace
+`const [mounted, setMounted] = useState(false)` plus a mount effect. It would
+return `false` on the server and during the first client hydration pass, then
+`true` after mount. Octane does not currently export this core hook; a
+package-specific hook with the same name does not change that status.
 
 ### 6.4 Already shipped, part of the same story
 
@@ -342,13 +410,11 @@ hydration-mismatch hazard.
   for async reads" (`docs/differences-from-react.md`, current-state getters).
 - Parallel `use()`, route loaders, and the query/resource bindings cover async
   data — the largest historical source of effect-chain state machines.
-- `useSyncExternalStore` covers external subscriptions today; a friendlier
-  Octane-native `useSource(subscribe, read)` (deliberately not specified here;
-  ships with phase 4) bakes in the causal-turn split from §2 — the initial
-  value arrives via a synchronous snapshot read, and only post-setup
-  notifications are transitions — so sync-replaying stores are correct by
-  construction. It is the **preferred abstraction, not required
-  authorization**: bare setters in genuine later callbacks stay legal (§7).
+- `useSyncExternalStore` covers external subscriptions today. A friendlier
+  Octane-native `useSource(subscribe, read)` remains an unimplemented future
+  idea, with no scheduled rollout phase. If added, it could separate the initial
+  synchronous snapshot from later subscription notifications. Bare setters in
+  genuinely later callbacks remain legal (§7).
 
 ### 6.5 Naming non-goal
 
@@ -356,8 +422,8 @@ hydration-mismatch hazard.
 `useSynchronize` would steer agent priors before any error fires, but it cuts
 against Octane's core adoption thesis (same hook API), and an agent typing
 `useEffect` into a framework without it gets a *less* instructive error than a
-targeted rule violation with a fix-it. This is empirically decidable: gate C
-(§8) runs three arms in the evals corpus — (a) `useEffect` plus targeted
+targeted rule violation with a fix-it. This is empirically decidable: a possible
+future evaluation could run three arms in the evals corpus — (a) `useEffect` plus targeted
 diagnostics, (b) both names exported with native docs preferring
 `useSynchronize`, (c) a renamed native surface — measuring first-pass semantic
 correctness, one-iteration recovery, and **evasion mode**: whether agents
@@ -393,11 +459,12 @@ like any other callback-turn transition. What deferral gives up is only the
 `setTimeout` instead of the intended primitive gets working code, not an
 error. The response to that is quality pressure, not prohibition:
 
-- fix-its and docs route the common cases to the primitives that carry the
-  intent (`useKeyedState`, `useLayoutSnapshot`, `useSource`, actions);
-- evals evasion-mode monitoring (gate C's metric, continuous from phase 4)
-  watches whether agent output drifts toward deferral *instead of* those
-  primitives — a drift is a diagnostics/docs quality signal first.
+- fix-its and docs route the common cases to shipped `useLinkedState` and
+  actions, with `useLayoutSnapshot` and `useSource` remaining possible future
+  primitives;
+- possible future evaluation could monitor whether agent output drifts toward
+  deferral instead of those primitives; no continuous phase-4 monitor is
+  currently implemented.
 
 The **declared-boundary option** — state transitions only at declared causal
 boundaries (events/actions, sources, resources), making a bare setter from an
@@ -409,52 +476,48 @@ carries prerequisites (a complete paved road, adoption evidence, a
 context-propagation story such as platform `AsyncContext`) that make it a
 deliberate, evidence-driven step — the ceremony cliff — never a default.
 
-Compat cells are unaffected at every stage — tightening strict semantics
-never re-breaks ported bindings.
+Shipped package containment preserves existing dependency behavior. Hypothetical
+strict/compat hook cells do not exist.
 
 ## 8. Rollout and eval gates
 
-Every enforcement flip is gated on an `@octanejs/evals` run, not a calendar.
-The metrics per gate: rule hit-rate in agent output, first-attempt success,
-and **one-iteration recovery** — given the error text alone, does the agent
-land on the intended pattern in the next attempt?
+The original staged rollout was **not executed**. Current status is:
 
-| Phase | Contents                                                                                                                                                              | Gate                                                                       |
-| ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| 0     | Report-only compiler diagnostics; classify the repo (CI artifact of every hit); ship the rules + the four-cause vocabulary to `@octanejs/mcp-server` so agents get them **before** the first error. | —                                                                          |
-| 1     | Land `useKeyedState`, `useLayoutSnapshot`, `useHydrated` + codemods; migrate the repo's migrable strict-side cases; bindings declare compat explicitly.                  | Primitives differential-tested; repo classification reaches zero strict-side hits. |
-| 2     | Render-context writes (rows 1–4 of §3) become hard errors in strict code, compiler + runtime, all renderers.                                                            | **Gate A**: evals recovery ≥ baseline; no eval-suite regression.           |
-| 3     | Effect setup/cleanup frame writes become hard errors in strict code.                                                                                                    | **Gate B**: same bar, after phase-1 migrations prove the primitives cover the real cases. |
-| 4     | Ship `useSource`; callback-ref decision (§9); evasion-mode monitoring goes continuous.                                                                                  | Evals evasion-pattern monitoring stays flat.                               |
-| 5     | *(Conditional — may never be taken.)* Declared-boundary tightening per §7. The causal-turn rule is the permanent floor either way.                                       | **Gate D**: paved-road adoption metric; explicit sign-off — this is the ceremony cliff. |
-| C     | (any time) `useEffect` naming eval, three arms per §6.5.                                                                                                                | Measurement decides; record the outcome here.                              |
+| Historical milestone | What actually shipped or remains proposed |
+| -------------------- | ---------------------------------------- |
+| Report-only diagnostics, repository inventory, and codemods | Not implemented; they were not prerequisites for opt-in Strong mode. |
+| Replacement primitives | `useLinkedState` shipped in [#366](https://github.com/octanejs/octane/pull/366); `useLayoutSnapshot`, a core `useHydrated`, and `useSource` remain proposals. |
+| Render-context enforcement | Opt-in compiler diagnostics shipped in [#376](https://github.com/octanejs/octane/pull/376); runtime phase guards and per-cell policy did not. |
+| Effect setup and cleanup | Provable synchronous setup updates are compiler errors in opted-in modules; cleanup restrictions remain unimplemented. |
+| Dependency compatibility | Package containment is automatic; no manifest flag, compatibility exception list, or consumer approval is required. |
+| Evaluation gates and later policy tightening | Historical ideas only; no completed or scheduled phase/gate is implied. |
 
-Bookkeeping when phases land: an intentional-divergence entry in
-`docs/react-parity-migration-plan.md` (semantics divergence for strict cells,
-policy divergence overall; conformance stays pinned via compat compiles), a
-section in `docs/differences-from-react.md`, a changeset (`octane` +
-`@octanejs/vite-plugin`), and the `index.ts` tier-1 comment gains the three
-primitives.
+The shipped intentional divergence and authoring surface are documented in
+[Differences from React](./differences-from-react.md#optional-strong-mode) and
+[TSRX basics](./tsrx-basics.md#strong-mode). Future runtime enforcement or
+additional public primitives would need their own design, tests, changesets,
+and rollout decisions.
 
 ## 9. Open questions
 
-- **Cell-policy encoding**: slot-channel encoding (numeric slots already
+- **Future cell-policy encoding, if runtime enforcement is ever adopted**:
+  slot-channel encoding (numeric slots already
   distinguish compiled call sites from symbol-ranged binding boundaries in
   prod compiles) vs. an explicit registration table. Needs a perf-neutral
   answer on the two-item `useState` fast path.
-- **Callback refs**: strict error (measurement belongs to
+- **Future callback-ref policy**: strict error (measurement belongs to
   `useLayoutSnapshot`) or event-like allowance (attach *is* a DOM event of
-  sorts)? Current lean: error, revisit at phase 4 with audit data.
-- **`useKeyedState` edges**: nested-array keys (flat element-wise only, like
-  deps), omitted initializer (`useKeyedState(key)` ≡ `(k) => k`?), interaction
-  with transitions (does a key change during a transition render participate
-  in the deferred lane?).
-- **`useLayoutSnapshot` equality**: is `Object.is` + user `equal` enough, or
+  sorts)? The shipped compiler does not impose the proposed callback-ref ban.
+- **Linked-state adoption**: composite sources already use `Object.is` unless a
+  `sourceEqual` comparator is supplied; prior source/value and transition
+  generation behavior are implemented. Remaining work concerns migrating real
+  bindings rather than designing a separate `useKeyedState` hook.
+- **Future `useLayoutSnapshot` equality**: is `Object.is` + user `equal` enough, or
   does a built-in rect comparator earn its place?
-- **Plain-`.ts` app modules**: they default to compat via the manual-slot
-  surface, which is a real (documented) hole in strict coverage. Acceptable
-  as the cost of the bindings contract, or worth a strict variant of the
-  manual-slot API later?
+- **Plain-`.ts` modules**: application-owned custom hooks inherit application
+  Strong mode. Dependency/manual-slot modules remain compatible unless they
+  explicitly opt in with `"use strong"`; future runtime policy would need a
+  separate ABI decision.
 - **`autoMemo` interaction**: strict purity rules strengthen the soundness
   assumptions of compiler region caching (PR #104) — worth folding into the
   default-on analysis for autoMemo.

--- a/docs/strict-state-policy-options.md
+++ b/docs/strict-state-policy-options.md
@@ -1,13 +1,56 @@
 # Strict-state policy naming and compatibility options
 
-> **Status: DECISION MEMO — no option is selected.** Prepared 2026-07-19 as a
-> companion to [`strict-state-plan.md`](./strict-state-plan.md). This memo is for
-> choosing the public configuration vocabulary and the third-party compatibility
-> boundary; it does not reopen the underlying state-phase semantics.
+> **Status: HISTORICAL DECISION MEMO; NOT THE SHIPPED CONFIGURATION.** Prepared
+> 2026-07-19 as a companion to
+> [`strict-state-plan.md`](./strict-state-plan.md). None of the five policy
+> objects, manifest flags, runtime guards, or package approval mechanisms below
+> were implemented. Octane instead shipped `useLinkedState` in
+> [#366](https://github.com/octanejs/octane/pull/366) and opt-in, compiler-only
+> Strong mode in [#376](https://github.com/octanejs/octane/pull/376).
+
+## Current implementation
+
+The public configuration is already selected:
+
+```ts
+// octane.config.ts
+export default {
+	compiler: {
+		strong: true,
+	},
+};
+```
+
+Strong mode defaults to `false`. A module can also opt itself in with a top-level
+`"use strong"` directive. Application configuration applies only to
+application-owned source: dependencies and separately manifested workspace
+packages retain their existing React-compatible behavior unless their own module
+opts in. Vite, Rspack, and Rsbuild also expose a `strong: true` plugin option.
+
+The shipped enforcement is **compile-time only**: it rejects statically provable
+state updates during render or synchronous effect setup and render-time
+`ref.current` writes. State initializers, `useLinkedState` reconcilers, and its
+`sourceEqual`/`valueEqual` callbacks execute synchronously during render;
+genuinely deferred callbacks remain valid. `useLinkedState` replaces the
+originally proposed keyed-reset hook and compares sources with `Object.is` by
+default, including arrays; composite comparisons require `sourceEqual`.
+
+There is no runtime execution-phase guard, strict/compat hook-cell policy,
+package-manifest state-policy field, compatibility allowlist, package approval
+flow, or policy inventory. Published Octane packages ship authored source, not
+precompiled policy-bearing artifacts. See the current [Strong-mode
+guide](./tsrx-basics.md#strong-mode), [linked-state
+guide](./tsrx-basics.md#state-that-follows-another-value), and [documented React
+differences](./differences-from-react.md#optional-strong-mode).
+
+The remainder preserves naming and containment ideas that could inform a future,
+explicitly proposed runtime-backed policy. Example configuration and manifest
+fields below are illustrative only; none are current Octane APIs.
 
 ## 1. Decision to make
 
-Octane needs one build-time policy with two behaviors:
+The historical proposal considered a possible future runtime-backed policy with
+two behaviors:
 
 - **Native behavior:** authored state transitions are allowed at causal boundaries
   such as events, actions, and later callback turns. They are rejected while render,
@@ -16,9 +59,11 @@ Octane needs one build-time policy with two behaviors:
 - **React-compatible behavior:** existing render-phase replay and lifecycle update
   behavior remains available for code that has not migrated yet.
 
-The policy needs both a project default, so the work can roll out without an atomic
-repository migration, and a narrow way to retain React behavior for third-party
-Octane packages.
+A hypothetical policy could need both a project default and a narrow way to
+retain React behavior for third-party Octane packages. The shipped implementation
+already achieves application/dependency containment through optional
+`compiler.strong` and package ownership, without any of the proposed policy
+objects or manifest exceptions.
 
 The naming decision has three independent parts:
 
@@ -27,54 +72,64 @@ The naming decision has three independent parts:
 3. Is the API presented as a choice between two models, a positive Octane feature,
    or a React compatibility exception?
 
-The five proposals below intentionally vary all three.
+The five historical proposals below intentionally varied all three. None was
+selected or implemented.
 
 ## 2. Shared contract across every proposal
 
-The choice of spelling must not change these mechanics.
+These mechanics belong to the **unimplemented runtime-backed proposal**. They
+are not claims about shipped compiler-only Strong mode.
 
 ### 2.1 Enforcement
 
-- The runtime is the semantic defense in development and production. The compiler
-  adds earlier, richer diagnostics where execution timing is statically provable.
+- A future runtime guard could provide semantic defense in development and
+  production; today the compiler is the only Strong-mode enforcement surface.
 - `useCallback` creation is never itself illegal. The compiler follows local aliases
   and calls and reports only a callback proven to execute synchronously from a
   forbidden phase. Passing a callback to an opaque subscription remains a runtime
   question because registration does not prove synchronous invocation.
 - A later timer, observer, subscription notification, async continuation, or
   deliberate deferral is a legal causal transition.
-- Internal runtime scheduling remains outside the user-dispatcher guard.
+- Internal runtime scheduling would remain outside any future user-dispatcher
+  guard.
 
 ### 2.2 Compatibility containment
 
-Compatibility must not leak from a dependency into application-authored code. In a
-forbidden phase, the intended composition rule is:
+Compatibility must not leak from a dependency into application-authored code.
+The shipped compiler already contains its application-wide setting by package.
+If a future runtime introduced policy-bearing hook cells, its proposed
+composition rule would be:
 
 | Executing code     | Native cell | React-compatible cell |
 | ------------------ | ----------- | --------------------- |
 | Native             | Throw       | Throw                 |
 | React-compatible   | Throw       | Existing behavior     |
 
-Outside a forbidden phase, ordinary updates remain legal in every combination.
-This permits a React-compatible package to manage its own state while preventing a
-native application from laundering a lifecycle write through a setter returned by
-that package.
+Outside a forbidden phase, ordinary updates would remain legal in every
+combination. These strict/compatible cell distinctions do not exist in the
+shipped runtime.
 
 ### 2.3 Third-party packages
 
-The package boundary is the initial compatibility granularity:
+The shipped package boundary already prevents application Strong configuration
+from claiming dependencies. The following manifest declarations, consumer
+approvals, and cell-level propagation are **future proposals, not existing
+configuration**:
 
-- Package authors can declare that their package requires React-compatible
+- Package authors could declare that their package requires React-compatible
   behavior in the existing `octane` object in their `package.json`. Whether that
   declaration is self-authorizing or instead requires consumer approval is an open
   decision called out below.
-- Applications can approve a dependency explicitly in compiler configuration.
-- Consumer exceptions use exact npm package names. They do not accept filesystem
+- Applications could approve a dependency explicitly in future compiler
+  configuration.
+- Hypothetical consumer exceptions would use exact npm package names. They would
+  not accept filesystem
   globs, source paths, export subpaths, or inline comments.
-- An exception cannot target the application package itself. A nested workspace
+- An exception would not target the application package itself. A nested workspace
   package with its own manifest is a separate package, even when it is physically
   inside the bundler root.
-- Package behavior is non-transitive. Native children and native callbacks passed
+- A future runtime package policy would be non-transitive. Native children and
+  native callbacks passed
   into a compatible package retain their originating behavior, and a native setter
   remains native when passed into compatible code.
 - A usage-site `compat(Component)` wrapper is not part of the initial design. It is
@@ -84,12 +139,14 @@ The package boundary is the initial compatibility granularity:
   hook-slot ownership, whereas a compatible package must still compile so its
   policy can be encoded.
 
-The compiler already has a watched nearest-manifest resolver in
+The shipped compiler already uses a watched nearest-manifest resolver for package
+ownership in
 [`bundler.js`](../packages/octane/src/compiler/bundler.js). The implementation should
-extend that resolver rather than matching `node_modules` paths, which are unstable
-across package managers and symlinks.
+extend that resolver if a future policy is designed, rather than matching
+`node_modules` paths, which are unstable across package managers and symlinks.
 
-There are two viable authorization models for package metadata:
+There were two proposed authorization models for future package metadata; neither
+exists today:
 
 1. **Self-declaration:** the package manifest is sufficient to select compatible
    behavior, and the build inventory makes that decision visible.
@@ -104,13 +161,16 @@ documentation for port authors can describe it separately.
 
 ### 2.4 Distribution and auditability
 
+These are possible requirements for a future runtime-backed policy, not current
+distribution behavior or build outputs:
+
 - Full `.tsrx`/`.tsx` compilation and plain `.ts`/`.js` hook slotting resolve the
   same package policy.
 - Manual-slot packages need the policy encoded in their slot-family ABI rather than
   being permanently defaulted to compatibility.
-- New precompiled output needs a versioned policy marker. The treatment of older
-  unmarked output—automatic existing behavior reported as `legacy-precompiled`, or
-  an explicit consumer approval—is an open migration decision.
+- Octane currently publishes authored source, not precompiled compiler output.
+  The historical idea of versioned precompiled policy markers would matter only
+  if that packaging contract changed; it is not needed today.
 - Client, SSR, hydration, and universal compilation must resolve the same policy.
 - Builds emit a deterministic inventory containing package name, version, resolved
   root, and policy origin (`package-declared`, `consumer-exception`, or
@@ -122,7 +182,7 @@ documentation for port authors can describe it separately.
 - Evaluation runs count adding a compatibility exception as evasion rather than a
   successful repair.
 
-## 3. Proposal A — `stateSemantics`
+## 3. Historical proposal A — `stateSemantics` (not implemented)
 
 This presents the setting as a choice between two explicitly named semantic models.
 
@@ -171,7 +231,7 @@ Risks:
 - The short value `react` could be read as claiming complete React equivalence rather
   than compatibility for this state behavior alone.
 
-## 4. Proposal B — `stateModel`
+## 4. Historical proposal B — `stateModel` (not implemented)
 
 This uses framework names instead of introducing a new conceptual value.
 
@@ -217,7 +277,7 @@ Risks:
   renderer or authoring profile with the same phase rules.
 - Framework-name values can age poorly if React changes its own behavior.
 
-## 5. Proposal C — `causalState`
+## 5. Historical proposal C — `causalState` (not implemented)
 
 This presents the design as one positive Octane feature with compatibility
 exceptions, using a boolean for rollout.
@@ -263,7 +323,7 @@ Risks:
   rather than an execution-phase rule.
 - The list shape is less extensible if another behavior is ever introduced.
 
-## 6. Proposal D — `stateUpdatePolicy`
+## 6. Historical proposal D — `stateUpdatePolicy` (not implemented)
 
 This optimizes for precision and uses fully descriptive values, accepting a more
 verbose public API.
@@ -310,7 +370,7 @@ Risks:
   priority.
 - `policy` sounds administrative rather than like a core programming model.
 
-## 7. Proposal E — `reactCompatibility.stateUpdates`
+## 7. Historical proposal E — `reactCompatibility.stateUpdates` (not implemented)
 
 This leaves the native behavior unnamed and configures only the compatibility
 surface. The default boolean doubles as the rollout flag.


### PR DESCRIPTION
## Summary

<!-- What changed, and why. -->

Series **2/7**, targeting `main`; merge after [Strong callback-purity #603](https://github.com/octanejs/octane/pull/603). Tracks [octanejs/octane#365](https://github.com/octanejs/octane/issues/365).

- Correct two historical state-policy proposals that still described the shipped implementation as entirely unimplemented, suggested no option had been selected, and presented obsolete `useKeyedState`, package-level `stateWrites` controls, runtime guards, and strict-by-default rollout as current architecture.
- Preserve the original proposals and context while clearly separating **implemented**, **superseded**, and **still-unimplemented** items.
- Document the actual `useLinkedState` contract: previous committed source/value, lazy reconciliation, default `Object.is` equality, explicit comparators for composite sources, and package-owned integration migrations.
- Explain that Strong mode is opt-in compiler analysis (`"use strong"` / `compiler.strong`), including synchronous initializer/reconciler/comparator callback purity delivered by the companion Strong callback-purity PR; point readers to current authoring guidance and follow-up issues.
- Documentation only; no package changeset is required.

## Validation

<!-- What you ran, and anything you deliberately left unverified. -->

- [x] `pnpm format:check`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [x] targeted tests: `pnpm exec vitest run packages/octane/tests/compiler/strong-mode.test.ts packages/octane/tests/compiler/bundler-compiler.test.ts --project octane --maxWorkers=2 --reporter=dot --silent=passed-only` — **340 compiler/package-boundary tests passed across two files**.
- [x] Historical-statement audit: verified the edited claims against the shipped compiler, linked-state contract, authoring documentation, and companion callback-purity change.
- [x] Scoped formatting: `pnpm format:files:check docs/strict-state-plan.md docs/strict-state-policy-options.md`.
- [x] Repository documentation/synchronization checks: `pnpm context:budget:check`, `pnpm sync`, and `git diff --check`.

- [x] Integrated final stack: `pnpm exec vitest run --project octane --project octane-prod --project apollo-client --project apollo-client-ssr --project aria --project aria-ssr --project base-ui --project base-ui-ssr --project tanstack-router --project radix --maxWorkers=4 --reporter=dot --silent=passed-only` — **11,473 tests passed across 879 files**.

The remaining unchecked boxes are intentional: full-workspace typechecking and test commands were not run.

## Risk / follow-ups

Historical proposals remain available and are explicitly contextualized rather than deleted. This PR changes neither runtime/compiler behavior nor published packages and should merge after the Strong callback-purity PR for claims about newly covered synchronous callbacks.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!--
Tick the box above whenever an agent wrote the change, no matter which account
pushes it. Leaving it clear or omitting this section asserts a human wrote the
diff; either form keeps the label workflow successful.

A bot reads this box and applies the label, so nothing here needs repository
permissions and it works the same from a fork. The type label comes from the
conventional-commit type in the title. Do not apply either by hand.

When updating an existing pull request, merge this template content into the
current body. Preserve every bot-managed HTML comment region and all existing
maintainer-authored text; never replace the body from a fresh template.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime or compiler behavior changes.
> 
> **Overview**
> Marks **`strict-state-plan.md`** and **`strict-state-policy-options.md`** as historical / partially superseded instead of describing unimplemented runtime policy as current architecture.
> 
> Adds **Current implementation** sections that document what actually shipped: **`useLinkedState`** (reconciler, `Object.is` / explicit comparators) and **opt-in Strong mode** via `compiler.strong` or `"use strong"`, with dependencies isolated by package containment—no `stateWrites`, runtime phase guards, or manifest compatibility APIs.
> 
> Reframes the original body as **proposals or future work** (`useKeyedState` → `useLinkedState`, staged rollout table replaced with shipped-vs-proposed milestones, five naming options labeled not implemented) and points readers to **`tsrx-basics`** and **`differences-from-react`** for authoring guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6ab4e8fabc1ca0efce357e4e5a7e72bb7e674df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->