### PR TITLE
fix(apollo-client): reconcile query state without render updates

### DIFF
--- a/.changeset/apollo-linked-query-state.md
+++ b/.changeset/apollo-linked-query-state.md
@@ -1,0 +1,7 @@
+---
+'@octanejs/apollo-client': patch
+---
+
+Update Apollo query state immediately when its client or query changes without
+calling a state setter during render. Preserve the previous query result,
+observable lifecycle, and compatibility with Octane Strong mode.

--- a/packages/apollo-client/src/react/hooks/useQuery.js
+++ b/packages/apollo-client/src/react/hooks/useQuery.js
@@ -26,6 +26,11 @@ import { isCompilerSite } from './internal/site.js';
 import { useApolloClient } from './useApolloClient.js';
 import { useSyncExternalStore } from './useSyncExternalStore.js';
 const lastWatchOptions = Symbol();
+const linkedQueryStateOptions = {
+	sourceEqual(previous, next) {
+		return previous.client === next.client && previous.query === next.query;
+	},
+};
 export const useQuery = function useQuery(query, options) {
 	'use no memo';
 	if (isCompilerSite(options, skipToken)) options = undefined;
@@ -54,16 +59,11 @@ function useQuery_(query, options = {}) {
 			},
 		};
 	}
-	let [state, setState] = React.useState(createState);
-	if (client !== state.client || query !== state.query) {
-		// If the client or query have changed, we need to create a new InternalState.
-		// This will trigger a re-render with the new state, but it will also continue
-		// to run the current render function to completion.
-		// Since we sometimes trigger some side-effects in the render function, we
-		// re-assign `state` to the new state to ensure that those side-effects are
-		// triggered with the new state.
-		setState((state = createState(state)));
-	}
+	const [state] = React.useLinkedState(
+		{ client, query },
+		(_source, previous) => createState(previous?.value),
+		linkedQueryStateOptions,
+	);
 	const { observable, resultData } = state;
 	useInitialFetchPolicyIfNecessary(watchQueryOptions, observable);
 	useResubscribeIfNecessary(

--- a/packages/apollo-client/tests/_fixtures/client.tsrx
+++ b/packages/apollo-client/tests/_fixtures/client.tsrx
@@ -104,6 +104,30 @@ export function QueryApp(props: { client: any }) @{
 	</ApolloProvider>
 }
 
+function QuerySourcePanel(props: { query: any; onResult: (result: any) => void }) @{
+	const result = useQuery(props.query, { fetchPolicy: 'network-only' });
+	props.onResult(result);
+	const current = JSON.stringify(result.data ?? null);
+	const previous = JSON.stringify(result.previousData ?? null);
+	<section id="query-source-result">
+		<output id="query-source-status">
+			{result.loading ? 'loading' : 'ready'}
+		</output>
+		<output id="query-source-current">{current as string}</output>
+		<output id="query-source-previous">{previous as string}</output>
+	</section>
+}
+
+export function QuerySourceApp(props: {
+	client: any;
+	query: any;
+	onResult: (result: any) => void;
+}) @{
+	<ApolloProvider client={props.client}>
+		<QuerySourcePanel query={props.query} onResult={props.onResult} />
+	</ApolloProvider>
+}
+
 function SuspenseQueryPanel() @{
 	const result = useSuspenseQuery(GET_VALUE, { fetchPolicy: 'network-only' });
 	const value = (result.data as { value?: string } | undefined)?.value;

--- a/packages/apollo-client/tests/conformance/client.test.ts
+++ b/packages/apollo-client/tests/conformance/client.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import {
 	ApolloClient,
 	ApolloLink,
@@ -6,6 +8,7 @@ import {
 	makeVar,
 	type FetchResult,
 } from '@apollo/client';
+import { createOctaneCompiler } from 'octane/compiler/bundler';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -19,6 +22,7 @@ import {
 	MutationApp,
 	ProviderApp,
 	QueryApp,
+	QuerySourceApp,
 	ReactiveVarApp,
 	SkippedSuspenseQueryApp,
 	SubscriptionApp,
@@ -34,6 +38,14 @@ type PendingOperation = {
 	next(data: Record<string, unknown>): void;
 	complete(): void;
 	fail(error: Error): void;
+};
+
+type QuerySnapshot = {
+	client: ApolloClient;
+	observable: unknown;
+	data: Record<string, unknown> | undefined;
+	previousData: Record<string, unknown> | undefined;
+	loading: boolean;
 };
 
 function createControlledClient() {
@@ -65,6 +77,16 @@ function createControlledClient() {
 }
 
 describe('@octanejs/apollo-client client hooks', () => {
+	it('useQuery source is accepted when its package opts into Strong mode', () => {
+		const packageRoot = resolve(process.cwd(), 'packages/apollo-client');
+		const filename = resolve(packageRoot, 'src/react/hooks/useQuery.js');
+		const compiler = createOctaneCompiler({ root: packageRoot, strong: true });
+
+		expect(compiler.transform(readFileSync(filename, 'utf8'), filename)?.code).toEqual(
+			expect.any(String),
+		);
+	});
+
 	it('ApolloProvider supplies useApolloClient and the explicit override wins', () => {
 		const context = createControlledClient().client;
 		const override = createControlledClient().client;
@@ -111,6 +133,165 @@ describe('@octanejs/apollo-client client hooks', () => {
 		} finally {
 			mounted.unmount();
 			client.stop();
+		}
+	});
+
+	// Per @apollo/client@4.2.6 src/react/hooks/__tests__/useQuery.test.tsx:9621.
+	it('should persist result.previousData even if query changes', async () => {
+		const { client, operations } = createControlledClient();
+		const watchQuery = vi.spyOn(client, 'watchQuery');
+		const snapshots: QuerySnapshot[] = [];
+		const onResult = (result: QuerySnapshot) => snapshots.push(result);
+		const mounted = mount(QuerySourceApp, { client, query: GET_VALUE, onResult });
+
+		try {
+			expect(mounted.find('#query-source-status').textContent).toBe('loading');
+			expect(mounted.find('#query-source-current').textContent).toBe('null');
+			expect(mounted.find('#query-source-previous').textContent).toBe('null');
+			await settle();
+			expect(operations.map(({ operationName }) => operationName)).toEqual(['GetValue']);
+
+			operations[0].resolve({ value: 'first-query' });
+			await settle();
+			expect(mounted.find('#query-source-current').textContent).toBe(
+				JSON.stringify({ value: 'first-query' }),
+			);
+			const originalObservable = snapshots.at(-1)?.observable;
+			const sourceChange = snapshots.length;
+
+			mounted.update(QuerySourceApp, { client, query: GET_MOCKED_VALUE, onResult });
+			expect(mounted.find('#query-source-status').textContent).toBe('loading');
+			expect(mounted.find('#query-source-current').textContent).toBe('null');
+			expect(mounted.find('#query-source-previous').textContent).toBe(
+				JSON.stringify({ value: 'first-query' }),
+			);
+			expect(snapshots.slice(sourceChange)).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						client,
+						data: undefined,
+						loading: true,
+						previousData: { value: 'first-query' },
+					}),
+				]),
+			);
+			expect(
+				snapshots.slice(sourceChange).every(({ observable }) => observable !== originalObservable),
+			).toBe(true);
+			await settle();
+			expect(operations.map(({ operationName }) => operationName)).toEqual([
+				'GetValue',
+				'GetMockedValue',
+			]);
+			expect(watchQuery).toHaveBeenCalledTimes(2);
+			const replacementObservable = snapshots.at(-1)?.observable;
+
+			operations[1].resolve({ mockedValue: 'second-query' });
+			await settle();
+			expect(mounted.find('#query-source-status').textContent).toBe('ready');
+			expect(mounted.find('#query-source-current').textContent).toBe(
+				JSON.stringify({ mockedValue: 'second-query' }),
+			);
+			expect(mounted.find('#query-source-previous').textContent).toBe(
+				JSON.stringify({ value: 'first-query' }),
+			);
+			expect(snapshots.at(-1)?.observable).toBe(replacementObservable);
+
+			mounted.update(QuerySourceApp, { client, query: GET_MOCKED_VALUE, onResult });
+			await settle();
+			expect(watchQuery).toHaveBeenCalledTimes(2);
+			expect(operations.map(({ operationName }) => operationName)).toEqual([
+				'GetValue',
+				'GetMockedValue',
+			]);
+			expect(snapshots.at(-1)?.observable).toBe(replacementObservable);
+		} finally {
+			mounted.unmount();
+			watchQuery.mockRestore();
+			client.stop();
+		}
+	});
+
+	it('switches Apollo clients without publishing stale query data or retaining the old observable', async () => {
+		const first = createControlledClient();
+		const second = createControlledClient();
+		const firstWatchQuery = vi.spyOn(first.client, 'watchQuery');
+		const secondWatchQuery = vi.spyOn(second.client, 'watchQuery');
+		const snapshots: QuerySnapshot[] = [];
+		const onResult = (result: QuerySnapshot) => snapshots.push(result);
+		const mounted = mount(QuerySourceApp, {
+			client: first.client,
+			query: GET_VALUE,
+			onResult,
+		});
+
+		try {
+			await settle();
+			expect(first.operations.map(({ operationName }) => operationName)).toEqual(['GetValue']);
+			first.operations[0].resolve({ value: 'first-client' });
+			await settle();
+			expect(mounted.find('#query-source-current').textContent).toBe(
+				JSON.stringify({ value: 'first-client' }),
+			);
+			const originalObservable = snapshots.at(-1)?.observable;
+			const sourceChange = snapshots.length;
+
+			mounted.update(QuerySourceApp, {
+				client: second.client,
+				query: GET_VALUE,
+				onResult,
+			});
+			expect(mounted.find('#query-source-status').textContent).toBe('loading');
+			expect(mounted.find('#query-source-current').textContent).toBe('null');
+			expect(mounted.find('#query-source-previous').textContent).toBe(
+				JSON.stringify({ value: 'first-client' }),
+			);
+			expect(
+				snapshots
+					.slice(sourceChange)
+					.every(
+						({ client, observable }) =>
+							client === second.client && observable !== originalObservable,
+					),
+			).toBe(true);
+			await settle();
+			expect(firstWatchQuery).toHaveBeenCalledTimes(1);
+			expect(secondWatchQuery).toHaveBeenCalledTimes(1);
+			expect(second.operations.map(({ operationName }) => operationName)).toEqual(['GetValue']);
+
+			first.client.writeQuery({ query: GET_VALUE, data: { value: 'retired-client' } });
+			await settle();
+			expect(mounted.find('#query-source-status').textContent).toBe('loading');
+			expect(mounted.find('#query-source-current').textContent).toBe('null');
+			expect(mounted.find('#query-source-previous').textContent).toBe(
+				JSON.stringify({ value: 'first-client' }),
+			);
+
+			second.operations[0].resolve({ value: 'second-client' });
+			await settle();
+			expect(mounted.find('#query-source-status').textContent).toBe('ready');
+			expect(mounted.find('#query-source-current').textContent).toBe(
+				JSON.stringify({ value: 'second-client' }),
+			);
+			expect(mounted.find('#query-source-previous').textContent).toBe(
+				JSON.stringify({ value: 'first-client' }),
+			);
+			expect(snapshots.at(-1)?.client).toBe(second.client);
+
+			second.client.writeQuery({ query: GET_VALUE, data: { value: 'second-client-update' } });
+			await settle();
+			expect(mounted.find('#query-source-current').textContent).toBe(
+				JSON.stringify({ value: 'second-client-update' }),
+			);
+			expect(mounted.find('#query-source-previous').textContent).toBe(
+				JSON.stringify({ value: 'second-client' }),
+			);
+		} finally {
+			mounted.unmount();
+			firstWatchQuery.mockRestore();
+			secondWatchQuery.mockRestore();
+			first.client.stop();
+			second.client.stop();
 		}
 	});
 


### PR DESCRIPTION
## Summary

<!-- What changed, and why. -->

Series **3/7**, targeting `main`. Tracks [octanejs/octane#365](https://github.com/octanejs/octane/issues/365).

- Apollo's inherited React adapter guarded a `useState` setter during render whenever its client or query identity changed; Strong compilation correctly rejected the binding and the setter risked an unnecessary intermediate replay.
- Reconcile query internals with the existing `useLinkedState` primitive, keyed by a composite `{ client, query }` source and an explicit identity comparator; retain the existing manual-slot layout and callback contracts.
- Preserve `previousData` across query/client replacement, observable/`watchQuery` ownership and cleanup, repeated-render stability, retirement of stale-client updates, and the absence of stale intermediate DOM; pin the behavioral parity case to Apollo Client's real upstream test.
- Add package-owned Strong/render and client-switch regressions plus client/SSR/hydration coverage.
- Add the patch changeset `.changeset/apollo-linked-query-state.md` for `@octanejs/apollo-client`.

## Validation

<!-- What you ran, and anything you deliberately left unverified. -->

- [x] `pnpm format:check`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [x] targeted tests: `pnpm exec vitest run --project apollo-client --project apollo-client-ssr --reporter=dot` — **27 client, SSR, and hydration tests passed across four files**.
- [x] Red-first reproduction: `pnpm exec vitest run --project apollo-client packages/apollo-client/tests/conformance/client.test.ts --reporter=verbose` initially failed the new Strong regression with `OCTANE_STRONG_RENDER_STATE_UPDATE`; after the migration all **16 conformance tests passed**.
- [x] Package and public type tests: `pnpm exec tsgo --noEmit -p packages/apollo-client/tsconfig.json` and `pnpm exec tsgo --noEmit -p packages/apollo-client/typetests/tsconfig.json`.
- [x] Scoped formatting: `pnpm format:files:check packages/apollo-client/src/react/hooks/useQuery.js packages/apollo-client/tests/conformance/client.test.ts packages/apollo-client/tests/_fixtures/client.tsrx .changeset/apollo-linked-query-state.md`.
- [x] Upstream React-parity inventory: `pnpm react-parity:validate` — **5,345 stable / 5,413 canary cases**.
- [x] Repository compatibility gates: `node scripts/check-test-markers.mjs`, `node scripts/check-tsrx-module-decls.mjs`, `node scripts/check-changesets.js`, and `pnpm sync`.

- [x] Integrated final stack: `pnpm exec vitest run --project octane --project octane-prod --project apollo-client --project apollo-client-ssr --project aria --project aria-ssr --project base-ui --project base-ui-ssr --project tanstack-router --project radix --maxWorkers=4 --reporter=dot --silent=passed-only` — **11,473 tests passed across 879 files**.

The remaining unchecked boxes are intentional: full-workspace typecheck and test commands were not run.

## Risk / follow-ups

Composite source equality intentionally compares both client and query identities; preserving `previousData` and obsolete-observable retirement is covered at the public DOM/observable boundary. No new hook or public API is introduced.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!--
Tick the box above whenever an agent wrote the change, no matter which account
pushes it. Leaving it clear or omitting this section asserts a human wrote the
diff; either form keeps the label workflow successful.

A bot reads this box and applies the label, so nothing here needs repository
permissions and it works the same from a fork. The type label comes from the
conventional-commit type in the title. Do not apply either by hand.

When updating an existing pull request, merge this template content into the
current body. Preserve every bot-managed HTML comment region and all existing
maintainer-authored text; never replace the body from a fresh template.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core useQuery lifecycle (observables, previousData, client/query identity) but behavior is pinned to upstream Apollo tests and Strong compile checks.
> 
> **Overview**
> **`useQuery`** no longer calls **`setState` during render** when the Apollo **client** or **query** identity changes—a pattern that broke **Octane Strong** compilation and could force an extra replay.
> 
> Internal query state is now reconciled with **`React.useLinkedState`**, keyed by **`{ client, query }`** and a custom **`sourceEqual`** comparator. **`createState`** still seeds **`previousData`** from the prior result so **`result.previousData`** stays continuous across query or client swaps, with a fresh **`watchQuery`** observable when the source changes.
> 
> Conformance coverage adds a **Strong-mode compile** check on **`useQuery.js`**, **`QuerySourceApp`** fixtures, and tests aligned with upstream Apollo for **query changes** and **client switches** (loading/null current data, preserved previous data, no stale observables or retired-client updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d1001e541d03a7f739159432d2c1a3493d91b54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->