### PR TITLE
fix(aria): reconcile number fields with linked state

### DIFF
--- a/.changeset/aria-linked-number-field-state.md
+++ b/.changeset/aria-linked-number-field-state.md
@@ -1,0 +1,8 @@
+---
+'@octanejs/aria': patch
+---
+
+Synchronize number-field drafts with controlled values, locales, and formatting
+options through `useLinkedState` instead of updating four state cells during
+render. Preserve in-progress edits, parser and formatter behavior, user-selected
+numbering systems, server rendering, and compatibility with Strong mode.

--- a/packages/aria/src/stately/numberfield/useNumberFieldState.ts
+++ b/packages/aria/src/stately/numberfield/useNumberFieldState.ts
@@ -18,7 +18,7 @@ import type {
 	ValueBase,
 } from '@react-types/shared';
 import { NumberFormatter, NumberParser } from '@internationalized/number';
-import { useCallback, useMemo, useState } from 'octane';
+import { useCallback, useLinkedState, useMemo, useState } from 'octane';
 
 import type { FocusableProps } from '../../interactions/useFocusable';
 
@@ -111,6 +111,12 @@ export interface NumberFieldStateOptions extends NumberFieldProps {
 	locale: string;
 }
 
+interface NumberFieldInputSource {
+	value: number;
+	locale: string;
+	formatOptions: Intl.NumberFormatOptions | undefined;
+}
+
 /**
  * Provides state management for a number field component. Number fields allow users to enter a
  * number, and increment or decrement the value using stepper buttons.
@@ -169,16 +175,51 @@ export function useNumberFieldState(...args: any[]): NumberFieldState {
 		subSlot(slot, 'number'),
 	);
 	let [initialValue] = useState(numberValue, subSlot(slot, 'initial'));
-	let [inputValue, setInputValue] = useState(
-		() =>
-			isNaN(numberValue) ? '' : new NumberFormatter(locale, formatOptions).format(numberValue),
-		subSlot(slot, 'input'),
-	);
-
-	let numberParser = useMemo(
-		() => new NumberParser(locale, formatOptions),
+	// Normalize parser rounding options before linked-source comparison or formatting.
+	let [numberParser, normalizedFormatOptions] = useMemo(
+		() => {
+			let normalizedOptions = formatOptions;
+			if (
+				normalizedOptions?.roundingIncrement != null &&
+				normalizedOptions.roundingIncrement !== 1 &&
+				(normalizedOptions.minimumFractionDigits == null ||
+					normalizedOptions.maximumFractionDigits == null)
+			) {
+				const fractionDigits =
+					normalizedOptions.minimumFractionDigits ?? normalizedOptions.maximumFractionDigits ?? 0;
+				normalizedOptions = {
+					...normalizedOptions,
+					minimumFractionDigits: normalizedOptions.minimumFractionDigits ?? fractionDigits,
+					maximumFractionDigits: normalizedOptions.maximumFractionDigits ?? fractionDigits,
+				};
+			}
+			return [new NumberParser(locale, normalizedOptions), normalizedOptions] as const;
+		},
 		[locale, formatOptions],
 		subSlot(slot, 'parser'),
+	);
+	formatOptions = normalizedFormatOptions;
+	let [inputValue, setInputValue] = useLinkedState<NumberFieldInputSource, string>(
+		{ value: numberValue, locale, formatOptions },
+		(source, previous) => {
+			if (isNaN(source.value)) {
+				return '';
+			}
+
+			let options = source.formatOptions;
+			if (previous !== undefined) {
+				const numberingSystem = numberParser.getNumberingSystem(previous.value);
+				options = { ...source.formatOptions, numberingSystem };
+			}
+			return new NumberFormatter(source.locale, options).format(source.value);
+		},
+		{
+			sourceEqual: (previous, next) =>
+				Object.is(previous.value, next.value) &&
+				previous.locale === next.locale &&
+				isEqualFormatOptions(previous.formatOptions, next.formatOptions),
+		},
+		subSlot(slot, 'input'),
 	);
 	let numberingSystem = useMemo(
 		() => numberParser.getNumberingSystem(inputValue),
@@ -208,26 +249,6 @@ export function useNumberFieldState(...args: any[]): NumberFieldState {
 	let clampStep = step !== undefined && !isNaN(step) ? step : 1;
 	if (intlOptions.style === 'percent' && (step === undefined || isNaN(step))) {
 		clampStep = 0.01;
-	}
-
-	// Update the input value when the number value or format options change. This is done
-	// in a useEffect so that the controlled behavior is correct and we only update the
-	// textfield after prop changes.
-	let [prevValue, setPrevValue] = useState(numberValue, subSlot(slot, 'prevValue'));
-	let [prevLocale, setPrevLocale] = useState(locale, subSlot(slot, 'prevLocale'));
-	let [prevFormatOptions, setPrevFormatOptions] = useState(
-		formatOptions,
-		subSlot(slot, 'prevFormat'),
-	);
-	if (
-		!Object.is(numberValue, prevValue) ||
-		locale !== prevLocale ||
-		!isEqualFormatOptions(formatOptions, prevFormatOptions)
-	) {
-		setInputValue(format(numberValue));
-		setPrevValue(numberValue);
-		setPrevLocale(locale);
-		setPrevFormatOptions(formatOptions);
 	}
 
 	let parsedValue = useMemo(

--- a/packages/aria/src/stately/numberfield/useNumberFieldState.ts
+++ b/packages/aria/src/stately/numberfield/useNumberFieldState.ts
@@ -175,6 +175,7 @@ export function useNumberFieldState(...args: any[]): NumberFieldState {
 		subSlot(slot, 'number'),
 	);
 	let [initialValue] = useState(numberValue, subSlot(slot, 'initial'));
+	const providedFormatOptions = formatOptions;
 	// Normalize parser rounding options before linked-source comparison or formatting.
 	let [numberParser, normalizedFormatOptions] = useMemo(
 		() => {
@@ -206,7 +207,14 @@ export function useNumberFieldState(...args: any[]): NumberFieldState {
 				return '';
 			}
 
-			let options = source.formatOptions;
+			// React formats initial currencies before their parser normalizes rounding digits.
+			let options =
+				previous === undefined &&
+				providedFormatOptions?.style === 'currency' &&
+				providedFormatOptions.minimumFractionDigits == null &&
+				providedFormatOptions.maximumFractionDigits == null
+					? providedFormatOptions
+					: source.formatOptions;
 			if (previous !== undefined) {
 				const numberingSystem = numberParser.getNumberingSystem(previous.value);
 				options = { ...source.formatOptions, numberingSystem };

--- a/packages/aria/tests/_fixtures/aria-diff-leaf.tsrx
+++ b/packages/aria/tests/_fixtures/aria-diff-leaf.tsrx
@@ -9,7 +9,7 @@ import {
 	useTextField,
 	useToggleButton,
 } from '@octanejs/aria';
-import { useRadioGroupState, useToggleState } from '@octanejs/aria/stately';
+import { useNumberFieldState, useRadioGroupState, useToggleState } from '@octanejs/aria/stately';
 
 // Phase-1 leaf-hook differential fixtures: the SAME components run through
 // @octanejs/aria and the real react-aria/react-stately (tests/differential/_setup.ts
@@ -123,5 +123,32 @@ export function ProgressSpec() {
 	const { progressBarProps, labelProps } = useProgressBar({ label: 'Loading', value: 30 });
 	return <div id="progress" {...progressBarProps}>
 		<span {...labelProps}>Loading</span>
+	</div>;
+}
+
+export function NumberFieldStateSpec() {
+	const [value, setValue] = useState(1234.5);
+	const [locale, setLocale] = useState('en-US');
+	const [fractionDigits, setFractionDigits] = useState(1);
+	const [, refresh] = useState(0);
+	const state = useNumberFieldState({
+		value,
+		locale,
+		formatOptions: { minimumFractionDigits: fractionDigits, maximumFractionDigits: 3 },
+		onChange: setValue,
+	});
+
+	return <div>
+		<button id="number-draft" onClick={() => state.setInputValue('9,876.500')}>edit</button>
+		<button id="number-latin" onClick={() => state.setInputValue('9876.5')}>latin</button>
+		<button id="number-refresh" onClick={() => refresh((current: number) => current + 1)}>
+			refresh
+		</button>
+		<button id="number-value" onClick={() => setValue(2500.25)}>value</button>
+		<button id="number-german" onClick={() => setLocale('de-DE')}>german</button>
+		<button id="number-arabic" onClick={() => setLocale('ar-EG')}>arabic</button>
+		<button id="number-precision" onClick={() => setFractionDigits(2)}>precision</button>
+		<output id="number-input">{state.inputValue as string}</output>
+		<output id="number-parsed">{String(state.numberValue) as string}</output>
 	</div>;
 }

--- a/packages/aria/tests/_fixtures/aria-diff-leaf.tsrx
+++ b/packages/aria/tests/_fixtures/aria-diff-leaf.tsrx
@@ -152,3 +152,35 @@ export function NumberFieldStateSpec() {
 		<output id="number-parsed">{String(state.numberValue) as string}</output>
 	</div>;
 }
+
+export function NumberFieldCurrencyRoundingSpec(props: {
+	currency: string;
+	locale?: string;
+	initiallyFormatted?: boolean;
+}) {
+	const [formatOptions, setFormatOptions] = useState(
+		props.initiallyFormatted === false
+			? undefined
+			: { style: 'currency' as const, currency: props.currency, roundingIncrement: 5 },
+	);
+	const state = useNumberFieldState({
+		value: 12.27,
+		locale: props.locale ?? 'en-US',
+		formatOptions,
+	});
+
+	return <div>
+		<button
+			id="currency-enable"
+			onClick={() => setFormatOptions({
+				style: 'currency',
+				currency: props.currency,
+				roundingIncrement: 5,
+			})}
+		>
+			enable
+		</button>
+		<output id="currency-input">{state.inputValue as string}</output>
+		<output id="currency-parsed">{String(state.numberValue) as string}</output>
+	</div>;
+}

--- a/packages/aria/tests/_fixtures/stately-collections-states.tsx
+++ b/packages/aria/tests/_fixtures/stately-collections-states.tsx
@@ -10,7 +10,10 @@ import { useMenuTriggerState } from '../../src/stately/menu/useMenuTriggerState'
 import { useSubmenuTriggerState } from '../../src/stately/menu/useSubmenuTriggerState';
 import { useSelectState } from '../../src/stately/select/useSelectState';
 import { useComboBoxState } from '../../src/stately/combobox/useComboBoxState';
-import { useNumberFieldState } from '../../src/stately/numberfield/useNumberFieldState';
+import {
+	useNumberFieldState,
+	type NumberFieldStateOptions,
+} from '../../src/stately/numberfield/useNumberFieldState';
 import { useSliderState } from '../../src/stately/slider/useSliderState';
 
 // --- useListState (dynamic items + render function, multiple selection) ---
@@ -336,6 +339,25 @@ export function NumberFieldHarness() {
 				{'p:' + state.validate('12') + ',' + state.validate('abc') + ',' + state.validate('-')}
 			</output>
 			<output data-testid="log">{'log:' + log}</output>
+		</div>
+	);
+}
+
+export function ControlledNumberFieldHarness(props: NumberFieldStateOptions & { draft: string }) {
+	const { draft, ...options } = props;
+	const state = useNumberFieldState(options);
+
+	return (
+		<div>
+			<button data-testid="edit" onClick={() => state.setInputValue(draft)}>
+				{'edit'}
+			</button>
+			<button data-testid="commit" onClick={() => state.commit()}>
+				{'commit'}
+			</button>
+			<output data-testid="input">{'in:' + state.inputValue}</output>
+			<output data-testid="number">{'n:' + state.numberValue}</output>
+			<output data-testid="valid">{'valid:' + state.validate(draft)}</output>
 		</div>
 	);
 }

--- a/packages/aria/tests/differential/parity-leaf.test.ts
+++ b/packages/aria/tests/differential/parity-leaf.test.ts
@@ -7,7 +7,7 @@
  * useControlledState + useField id plumbing, and useProgressBar over useLabel +
  * useNumberFormatter.
  */
-import { describe, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { resolve } from 'node:path';
 import { mountDifferential } from '../../../octane/tests/differential/_rig.js';
 
@@ -98,6 +98,63 @@ describe('differential: @octanejs/aria Phase-1 leaf hooks vs real react-aria', (
 	it('useProgressBar: aria value attributes + formatted valuetext, byte-identical', async () => {
 		const d = await mountDifferential(FIXTURE, 'ProgressSpec', undefined, CACHE);
 		await d.step('mount', () => {});
+		d.unmount();
+	});
+
+	it('useNumberFieldState: controlled values and unfinished edits match pinned react-stately', async () => {
+		const d = await mountDifferential(FIXTURE, 'NumberFieldStateSpec', undefined, CACHE);
+		await d.step('initial controlled format', () => {
+			expect(d.octane.find('#number-input').textContent).toBe('1,234.5');
+		});
+		await d.step('preserve unfinished user-entered precision', async (octane, react) => {
+			await octane.click('#number-draft');
+			await react.click('#number-draft');
+			expect(octane.find('#number-input').textContent).toBe('9,876.500');
+		});
+		await d.step('keep the draft when equivalent options are recreated', async (octane, react) => {
+			await octane.click('#number-refresh');
+			await react.click('#number-refresh');
+			expect(octane.find('#number-input').textContent).toBe('9,876.500');
+		});
+		await d.step('reconcile a new controlled value and parser together', async (octane, react) => {
+			await octane.click('#number-value');
+			await react.click('#number-value');
+			expect(octane.find('#number-input').textContent).toBe('2,500.25');
+			expect(octane.find('#number-parsed').textContent).toBe('2500.25');
+		});
+		d.unmount();
+	});
+
+	it('useNumberFieldState: locale, formatting and user-selected numerals match react-stately', async () => {
+		const d = await mountDifferential(FIXTURE, 'NumberFieldStateSpec', undefined, CACHE);
+		await d.step('switch locale and parser', async (octane, react) => {
+			await octane.click('#number-german');
+			await react.click('#number-german');
+			expect(octane.find('#number-input').textContent).toBe('1.234,5');
+			expect(octane.find('#number-parsed').textContent).toBe('1234.5');
+		});
+		await d.step('reformat when effective format options change', async (octane, react) => {
+			await octane.click('#number-precision');
+			await react.click('#number-precision');
+			expect(octane.find('#number-input').textContent).toBe('1.234,50');
+		});
+		await d.step('switch to an Arabic locale', async (octane, react) => {
+			await octane.click('#number-arabic');
+			await react.click('#number-arabic');
+		});
+		await d.step('honor a user-selected Latin numbering system', async (octane, react) => {
+			await octane.click('#number-latin');
+			await react.click('#number-latin');
+			expect(octane.find('#number-input').textContent).toBe('9876.5');
+		});
+		await d.step(
+			'retain user-selected numerals for the next controlled value',
+			async (octane, react) => {
+				await octane.click('#number-value');
+				await react.click('#number-value');
+				expect(octane.find('#number-input').textContent).toBe('2,500.25');
+			},
+		);
 		d.unmount();
 	});
 });

--- a/packages/aria/tests/differential/parity-leaf.test.ts
+++ b/packages/aria/tests/differential/parity-leaf.test.ts
@@ -157,4 +157,61 @@ describe('differential: @octanejs/aria Phase-1 leaf hooks vs real react-aria', (
 		);
 		d.unmount();
 	});
+
+	it.each([
+		['USD', '$12.25', '12.25'],
+		['JPY', '¥10', '10'],
+		['BHD', 'BHD\u00a012.270', '12.27'],
+		['KWD', 'KWD\u00a012.270', '12.27'],
+	] as const)(
+		'useNumberFieldState: %s rounding increments retain the same minor units as pinned react-stately',
+		async (currency, formattedValue, parsedValue) => {
+			const d = await mountDifferential(
+				FIXTURE,
+				'NumberFieldCurrencyRoundingSpec',
+				{ currency },
+				CACHE,
+			);
+
+			try {
+				await d.step('initial currency formatting retains ISO minor units', (octane, react) => {
+					expect(react.find('#currency-input').textContent).toBe(formattedValue);
+					expect(react.find('#currency-parsed').textContent).toBe(parsedValue);
+					expect(octane.find('#currency-input').textContent).toBe(formattedValue);
+					expect(octane.find('#currency-parsed').textContent).toBe(parsedValue);
+				});
+			} finally {
+				d.unmount();
+			}
+		},
+	);
+
+	it.each([
+		['USD', '$10'],
+		['JPY', '¥10'],
+		['BHD', 'BHD\u00a010'],
+		['KWD', 'KWD\u00a010'],
+	] as const)(
+		'useNumberFieldState: changing to %s rounding options retains pinned react-stately source-update behavior',
+		async (currency, formattedValue) => {
+			const d = await mountDifferential(
+				FIXTURE,
+				'NumberFieldCurrencyRoundingSpec',
+				{ currency, locale: 'en-US-u-ca-gregory', initiallyFormatted: false },
+				CACHE,
+			);
+
+			try {
+				await d.step('unformatted initial value', () => {});
+				await d.step('currency options change after initial mount', async (octane, react) => {
+					await octane.click('#currency-enable');
+					await react.click('#currency-enable');
+					expect(react.find('#currency-input').textContent).toBe(formattedValue);
+					expect(octane.find('#currency-input').textContent).toBe(formattedValue);
+				});
+			} finally {
+				d.unmount();
+			}
+		},
+	);
 });

--- a/packages/aria/tests/ssr/_fixtures/server.tsx
+++ b/packages/aria/tests/ssr/_fixtures/server.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource octane */
 import { useState } from 'octane';
 import { I18nProvider, SSRProvider, useId, useIsSSR, useLocale } from '@octanejs/aria';
+import { useNumberFieldState } from '@octanejs/aria/stately';
 
 function AriaServerContents() {
 	const labelId = useId('aria-hydration-label');
@@ -29,5 +30,19 @@ export function AriaServerFixture(props: { locale: string }) {
 				<AriaServerContents />
 			</I18nProvider>
 		</SSRProvider>
+	);
+}
+
+export function AriaNumberFieldServerFixture(props: {
+	locale: string;
+	value: number;
+	formatOptions?: Intl.NumberFormatOptions;
+}) {
+	const state = useNumberFieldState(props);
+
+	return (
+		<output id="aria-server-number" data-number={state.numberValue}>
+			{state.inputValue}
+		</output>
 	);
 }

--- a/packages/aria/tests/ssr/ssr.test.ts
+++ b/packages/aria/tests/ssr/ssr.test.ts
@@ -37,4 +37,23 @@ describe('@octanejs/aria server rendering', () => {
 		expect(html).toContain('data-number="1234.5"');
 		expect(html).toContain('>1.234,50</output>');
 	});
+
+	it.each([
+		['USD', '$12.25', '12.25'],
+		['JPY', '¥10', '10'],
+		['BHD', 'BHD\u00a012.270', '12.27'],
+		['KWD', 'KWD\u00a012.270', '12.27'],
+	] as const)(
+		'preserves %s minor units when server-rendered rounding increments omit precision',
+		(currency, formattedValue, parsedValue) => {
+			const { html } = renderToString(AriaNumberFieldServerFixture, {
+				locale: 'en-US',
+				value: 12.27,
+				formatOptions: { style: 'currency', currency, roundingIncrement: 5 },
+			});
+
+			expect(html).toContain('data-number="' + parsedValue + '"');
+			expect(html).toContain('>' + formattedValue + '</output>');
+		},
+	);
 });

--- a/packages/aria/tests/ssr/ssr.test.ts
+++ b/packages/aria/tests/ssr/ssr.test.ts
@@ -1,7 +1,7 @@
 import { renderToString } from 'octane/server';
 import { describe, expect, it } from 'vitest';
 
-import { AriaServerFixture } from './_fixtures/server.tsx';
+import { AriaNumberFieldServerFixture, AriaServerFixture } from './_fixtures/server.tsx';
 
 describe('@octanejs/aria server rendering', () => {
 	it('renders stable label relationships and reads the server snapshot without a DOM', () => {
@@ -23,5 +23,18 @@ describe('@octanejs/aria server rendering', () => {
 		expect(html).toContain('data-locale="ar-AE"');
 		expect(html).toContain('data-direction="rtl"');
 		expect(html).toContain('aria-labelledby="aria-hydration-label"');
+	});
+
+	it('formats and parses controlled number fields on the server without a DOM', () => {
+		expect(typeof document).toBe('undefined');
+		const { html } = renderToString(AriaNumberFieldServerFixture, {
+			locale: 'de-DE',
+			value: 1234.5,
+			formatOptions: { minimumFractionDigits: 2 },
+		});
+
+		expect(html).toContain('id="aria-server-number"');
+		expect(html).toContain('data-number="1234.5"');
+		expect(html).toContain('>1.234,50</output>');
 	});
 });

--- a/packages/aria/tests/stately-collections-states.test.ts
+++ b/packages/aria/tests/stately-collections-states.test.ts
@@ -285,6 +285,9 @@ describe('@octanejs/aria/stately — useNumberFieldState', () => {
 		[{ roundingIncrement: 5, maximumFractionDigits: 2 }, '12.25', '12.25'],
 		[{ roundingIncrement: 25, minimumFractionDigits: 2 }, '12.25', '12.25'],
 		[{ style: 'currency', currency: 'USD', roundingIncrement: 5 }, '$10', '10'],
+		[{ style: 'currency', currency: 'JPY', roundingIncrement: 5 }, '¥10', '10'],
+		[{ style: 'currency', currency: 'BHD', roundingIncrement: 5 }, 'BHD\u00a010', '10'],
+		[{ style: 'currency', currency: 'KWD', roundingIncrement: 5 }, 'KWD\u00a010', '10'],
 		[
 			{ style: 'currency', currency: 'USD', roundingIncrement: 5, minimumFractionDigits: 2 },
 			'$12.25',

--- a/packages/aria/tests/stately-collections-states.test.ts
+++ b/packages/aria/tests/stately-collections-states.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { compile } from 'octane/compiler';
 import { act, mount } from '../../octane/tests/_helpers';
 import {
 	ListHarness,
@@ -11,6 +14,7 @@ import {
 	SelectEmptyHarness,
 	ComboBoxHarness,
 	NumberFieldHarness,
+	ControlledNumberFieldHarness,
 	SliderHarness,
 } from './_fixtures/stately-collections-states.tsx';
 
@@ -246,6 +250,157 @@ describe('@octanejs/aria/stately — useComboBoxState', () => {
 });
 
 describe('@octanejs/aria/stately — useNumberFieldState', () => {
+	it('compiles the published number-field hook with Strong render-purity checks enabled', () => {
+		const filename = resolve(__dirname, '../src/stately/numberfield/useNumberFieldState.ts');
+
+		expect(() => compile(readFileSync(filename, 'utf8'), filename, { strong: true })).not.toThrow();
+	});
+
+	it('preserves unfinished controlled edits when equivalent formatting options are recreated', async () => {
+		const props = {
+			value: 1234.5,
+			locale: 'en-US',
+			formatOptions: { minimumFractionDigits: 2, maximumFractionDigits: 3 },
+			draft: '9,876.500',
+		};
+		const r = mount(ControlledNumberFieldHarness, props);
+		expect(text(r, 'input')).toBe('in:1,234.50');
+
+		await act(() => click(r, 'edit'));
+		expect(text(r, 'input')).toBe('in:9,876.500');
+		expect(text(r, 'number')).toBe('n:9876.5');
+
+		r.update(ControlledNumberFieldHarness, {
+			...props,
+			formatOptions: { ...props.formatOptions },
+		});
+		expect(text(r, 'input')).toBe('in:9,876.500');
+		expect(text(r, 'number')).toBe('n:9876.5');
+		r.unmount();
+	});
+
+	it.each([
+		[{ roundingIncrement: 5 }, '10', '10'],
+		[{ roundingIncrement: 5, minimumFractionDigits: 2 }, '12.25', '12.25'],
+		[{ roundingIncrement: 5, maximumFractionDigits: 2 }, '12.25', '12.25'],
+		[{ roundingIncrement: 25, minimumFractionDigits: 2 }, '12.25', '12.25'],
+		[{ style: 'currency', currency: 'USD', roundingIncrement: 5 }, '$10', '10'],
+		[
+			{ style: 'currency', currency: 'USD', roundingIncrement: 5, minimumFractionDigits: 2 },
+			'$12.25',
+			'12.25',
+		],
+	] as const)(
+		'formats controlled values when rounding increments are added without paired fraction options: %j',
+		(formatOptions, formattedValue, parsedValue) => {
+			const props = { value: 12.27, locale: 'en-US', draft: '9.875' };
+			const r = mount(ControlledNumberFieldHarness, props);
+
+			r.update(ControlledNumberFieldHarness, { ...props, formatOptions });
+
+			expect(text(r, 'input')).toBe('in:' + formattedValue);
+			expect(text(r, 'number')).toBe('n:' + parsedValue);
+			r.unmount();
+		},
+	);
+
+	it('preserves unfinished drafts when equivalent rounding options are recreated before normalization', async () => {
+		const props = {
+			value: 15,
+			locale: 'en-US',
+			formatOptions: {
+				roundingIncrement: 5,
+				minimumFractionDigits: 0,
+				maximumFractionDigits: 0,
+			},
+			draft: '17',
+		};
+		const r = mount(ControlledNumberFieldHarness, props);
+
+		await act(() => click(r, 'edit'));
+		expect(text(r, 'input')).toBe('in:17');
+
+		r.update(ControlledNumberFieldHarness, {
+			...props,
+			formatOptions: { roundingIncrement: 5, maximumFractionDigits: 0 },
+		});
+
+		expect(text(r, 'input')).toBe('in:17');
+		expect(text(r, 'number')).toBe('n:17');
+		r.unmount();
+	});
+
+	it('reconciles a changed controlled number with the displayed and parsed values', async () => {
+		const props = { value: 1234.5, locale: 'en-US', draft: '9,876.5' };
+		const r = mount(ControlledNumberFieldHarness, props);
+
+		await act(() => click(r, 'edit'));
+		expect(text(r, 'input')).toBe('in:9,876.5');
+
+		r.update(ControlledNumberFieldHarness, { ...props, value: 2500.25 });
+		expect(text(r, 'input')).toBe('in:2,500.25');
+		expect(text(r, 'number')).toBe('n:2500.25');
+		r.unmount();
+	});
+
+	it('reformats and reparses controlled values when locale or formatting options change', async () => {
+		const props = { value: 1234.5, locale: 'en-US', draft: '9,876.5' };
+		const r = mount(ControlledNumberFieldHarness, props);
+
+		await act(() => click(r, 'edit'));
+		r.update(ControlledNumberFieldHarness, {
+			...props,
+			locale: 'de-DE',
+			draft: '9.876,5',
+		});
+		expect(text(r, 'input')).toBe('in:1.234,5');
+		expect(text(r, 'number')).toBe('n:1234.5');
+		expect(text(r, 'valid')).toBe('valid:true');
+
+		r.update(ControlledNumberFieldHarness, {
+			...props,
+			locale: 'de-DE',
+			draft: '9.876,5',
+			formatOptions: { minimumFractionDigits: 2 },
+		});
+		expect(text(r, 'input')).toBe('in:1.234,50');
+		expect(text(r, 'number')).toBe('n:1234.5');
+		r.unmount();
+	});
+
+	it('retains the numbering system selected by user-entered digits on a controlled update', async () => {
+		const props = { value: 1234.5, locale: 'ar-EG', draft: '9876.5' };
+		const r = mount(ControlledNumberFieldHarness, props);
+
+		await act(() => click(r, 'edit'));
+		expect(text(r, 'input')).toBe('in:9876.5');
+		expect(text(r, 'number')).toBe('n:9876.5');
+
+		r.update(ControlledNumberFieldHarness, { ...props, value: 2500.25 });
+		expect(text(r, 'input')).toBe('in:2,500.25');
+		expect(text(r, 'number')).toBe('n:2500.25');
+		r.unmount();
+	});
+
+	it('commits locale-formatted edits without replacing an unchanged controlled value', async () => {
+		const changes: number[] = [];
+		const r = mount(ControlledNumberFieldHarness, {
+			value: 1234.5,
+			locale: 'de-DE',
+			draft: '4.321,25',
+			onChange: (value: number) => changes.push(value),
+		});
+
+		await act(() => click(r, 'edit'));
+		expect(text(r, 'number')).toBe('n:4321.25');
+		await act(() => click(r, 'commit'));
+
+		expect(changes).toEqual([4321.25]);
+		expect(text(r, 'input')).toBe('in:1.234,5');
+		expect(text(r, 'number')).toBe('n:1234.5');
+		r.unmount();
+	});
+
 	it('increments, decrements, and clamps to min/max', async () => {
 		const r = mount(NumberFieldHarness);
 		expect(text(r, 'input')).toBe('in:5');


### PR DESCRIPTION
## Summary

<!-- What changed, and why. -->

Series **4/7**, targeting `main`. Tracks [octanejs/octane#365](https://github.com/octanejs/octane/issues/365).

- React-Stately's inherited number-field adapter used render-phase setters to synchronize its editable input, numeric value, locale, and formatting options; Strong compilation rejected this package-owned render impurity.
- Replace that render synchronization with existing `useLinkedState` over a composite `{ value, locale, formatOptions }` source, an explicit equality policy for effective formatting inputs, and the established manual subslot.
- Preserve controlled/uncontrolled behavior, unfinished fractional drafts and user precision, repeated equivalent option objects, locale/format changes, user-selected numbering systems, callback contracts, and SSR output.
- Normalize `Intl.NumberFormat` rounding options before parser creation, linked-source equality, or formatter construction: valid decimal and currency `roundingIncrement` changes no longer throw `RangeError`, and semantically equivalent recreated option sources no longer erase an unfinished draft.
- Reorder parser creation so reconciliation can retain the numbering system implied by the previous editable draft; exercise two pinned real React-Stately differential scenarios plus public DOM, decimal/currency rounding-option normalization-order, and server-rendered output.
- Add the patch changeset `.changeset/aria-linked-number-field-state.md` for `@octanejs/aria`.

## Validation

<!-- What you ran, and anything you deliberately left unverified. -->

- [x] `pnpm format:check`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [x] targeted tests: `pnpm exec vitest run --project aria --project aria-ssr --silent=passed-only --reporter=dot` — **388 client, upstream-differential, and SSR tests passed across 48 files**.
- [x] Red-first reproduction: `pnpm exec vitest run --project aria packages/aria/tests/stately-collections-states.test.ts --testNamePattern='Strong render-purity' --silent=passed-only --reporter=verbose` failed before the change with `[OCTANE_STRONG_RENDER_STATE_UPDATE] ...useNumberFieldState.ts:227:3`.
- [x] Red-first public DOM compatibility reproduction: `pnpm exec vitest run --project aria packages/aria/tests/stately-collections-states.test.ts --testNamePattern='rounding' --silent=passed-only --reporter=verbose` expanded to **six failures across seven scenarios** before the compatibility fix: `formats controlled values when rounding increments are added without paired fraction options` raised `RangeError: maximumFractionDigits value is out of range.`, and `preserves unfinished drafts when equivalent rounding options are recreated before normalization` failed with `expected 'in:15' to be 'in:17'`. The passing matrix now covers missing, minimum-only, and maximum-only fraction options; increments `5` and `25`; currency defaults (`$10`) and explicit precision (`$12.25`); and equivalent-option draft retention.
- [x] Package and changed-source type checks: `pnpm exec tsgo --noEmit -p packages/aria/tsconfig.json` and `pnpm typecheck:files packages/aria/src/stately/numberfield/useNumberFieldState.ts`.
- [x] Scoped formatting: `pnpm format:files:check .changeset/aria-linked-number-field-state.md packages/aria/src/stately/numberfield/useNumberFieldState.ts packages/aria/tests/_fixtures/stately-collections-states.tsx packages/aria/tests/_fixtures/aria-diff-leaf.tsrx packages/aria/tests/stately-collections-states.test.ts packages/aria/tests/differential/parity-leaf.test.ts packages/aria/tests/ssr/_fixtures/server.tsx packages/aria/tests/ssr/ssr.test.ts`.
- [x] Changeset and synchronization checks: `node scripts/check-changesets.js`, `git diff --check`, and `pnpm sync`.

- [x] Integrated final stack: `pnpm exec vitest run --project octane --project octane-prod --project apollo-client --project apollo-client-ssr --project aria --project aria-ssr --project base-ui --project base-ui-ssr --project tanstack-router --project radix --maxWorkers=4 --reporter=dot --silent=passed-only` — **11,473 tests passed across 879 files**.

The remaining unchecked boxes are intentional: full-workspace typecheck and test commands were not run.

## Risk / follow-ups

Number-format comparison deliberately follows normalized effective formatting behavior rather than treating every recreated option-source identity as a change; normalization must precede parser creation, linked-source equality, and formatter option construction. Pinned upstream differential cases cover numbering-system retention, while SSR and public DOM coverage guard decimal/currency `roundingIncrement` updates, equivalent-option draft retention, and externally observable compatibility.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!--
Tick the box above whenever an agent wrote the change, no matter which account
pushes it. Leaving it clear or omitting this section asserts a human wrote the
diff; either form keeps the label workflow successful.

A bot reads this box and applies the label, so nothing here needs repository
permissions and it works the same from a fork. The type label comes from the
conventional-commit type in the title. Do not apply either by hand.

When updating an existing pull request, merge this template content into the
current body. Preserve every bot-managed HTML comment region and all existing
maintainer-authored text; never replace the body from a fresh template.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches controlled input reconciliation and Intl formatting edge cases (currency, locales, drafts); behavior is heavily tested against react-stately but public number-field output is user-visible.
> 
> **Overview**
> **`useNumberFieldState`** no longer syncs the displayed string during render via multiple `setState` calls (which broke **Strong** mode). Display text is derived with **`useLinkedState`** from `{ numberValue, locale, formatOptions }`, with shallow format-option equality so in-progress drafts survive recreated option objects.
> 
> **Rounding / currency:** `Intl` options are **normalized** (fraction digits paired with `roundingIncrement`) before building the parser and comparing linked sources, avoiding `RangeError` and keeping ISO minor-unit behavior aligned with pinned **react-stately**.
> 
> Coverage adds differential parity, SSR formatting, Strong compile checks, and controlled-field harness tests for drafts, locales, numbering systems, and currency rounding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30b3fc7a4cec62d2595b9ef77e2e5875190cf2ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->