### PR TITLE
fix(base-ui): preserve committed previous-value history

### DIFF
--- a/.changeset/base-ui-linked-previous-value.md
+++ b/.changeset/base-ui-linked-previous-value.md
@@ -1,0 +1,5 @@
+---
+'@octanejs/base-ui': patch
+---
+
+Keep previous-value history anchored to committed Base UI renders when Suspense abandons a source.

--- a/packages/base-ui/src/utils/usePreviousValue.ts
+++ b/packages/base-ui/src/utils/usePreviousValue.ts
@@ -1,25 +1,33 @@
 // Ported from .base-ui/packages/utils/src/usePreviousValue.ts. Returns the argument's previous
-// value (null before there is one), updating during render rather than in an effect so the
-// previous value is available on the same render the current one changes.
+// value (null before there is one). Linked state makes the previous committed value available
+// on the same render the current one changes without publishing abandoned render history.
 //
 // SLOT: plain-`.ts` hook; the trailing arg is the caller's slot.
-import { useState } from 'octane';
+import { type LinkedStatePrevious, useLinkedState } from 'octane';
 
 import { S, splitSlot, subSlot } from '../internal';
+
+function previousCommittedValue<Value>(
+	_current: Value,
+	previous: LinkedStatePrevious<Value, Value | null> | undefined,
+): Value | null {
+	return previous === undefined ? null : previous.source;
+}
+
+const PREVIOUS_VALUE_OPTIONS = {
+	sourceEqual: <Value>(previous: Value, next: Value) => previous === next,
+};
 
 export function usePreviousValue<T>(...args: any[]): T | null {
 	const [user, slotArg] = splitSlot(args);
 	const slot = slotArg ?? S('usePreviousValue');
 	const value = user[0] as T;
 
-	const [state, setState] = useState<{ current: T; previous: T | null }>(
-		{ current: value, previous: null },
+	const [previous] = useLinkedState<T, T | null>(
+		value,
+		previousCommittedValue,
+		PREVIOUS_VALUE_OPTIONS,
 		subSlot(slot, 'st'),
 	);
-
-	if (value !== state.current) {
-		setState({ current: value, previous: state.current });
-	}
-
-	return state.previous;
+	return previous;
 }

--- a/packages/base-ui/tests/previous-value.test.ts
+++ b/packages/base-ui/tests/previous-value.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { createElement, Suspense, use } from 'octane';
+import { mount } from '../../octane/tests/_helpers';
+import { usePreviousValue } from '../src/utils/usePreviousValue';
+
+interface PreviousValueProps {
+	value: string | number;
+	resource?: Promise<void> | null;
+}
+
+const PREVIOUS_VALUE_SLOT = Symbol('base-ui-previous-value');
+
+function PreviousValue(props: PreviousValueProps) {
+	const previous = usePreviousValue<string | number>(props.value, PREVIOUS_VALUE_SLOT);
+	if (props.resource != null) use(props.resource);
+	return createElement('output', { 'data-testid': 'previous-value' }, previous ?? 'initial');
+}
+
+function PreviousValueBoundary(props: PreviousValueProps) {
+	return createElement(
+		Suspense,
+		{ fallback: createElement('output', { 'data-testid': 'pending' }, 'pending') },
+		createElement(PreviousValue, props),
+	);
+}
+
+describe('@octanejs/base-ui — previous distinct value', () => {
+	it('starts empty and retains the previous distinct committed value', () => {
+		const result = mount(PreviousValueBoundary, { value: 'first' });
+		try {
+			expect(result.find('[data-testid="previous-value"]').textContent).toBe('initial');
+
+			result.update(PreviousValueBoundary, { value: 'second' });
+			expect(result.find('[data-testid="previous-value"]').textContent).toBe('first');
+
+			result.update(PreviousValueBoundary, { value: 'second' });
+			expect(result.find('[data-testid="previous-value"]').textContent).toBe('first');
+
+			result.update(PreviousValueBoundary, { value: 'third' });
+			expect(result.find('[data-testid="previous-value"]').textContent).toBe('second');
+		} finally {
+			result.unmount();
+		}
+	});
+
+	it('does not treat positive and negative zero as distinct values', () => {
+		const result = mount(PreviousValueBoundary, { value: 0 });
+		try {
+			result.update(PreviousValueBoundary, { value: -0 });
+			expect(result.find('[data-testid="previous-value"]').textContent).toBe('initial');
+		} finally {
+			result.unmount();
+		}
+	});
+
+	it('does not publish previous-value history from an abandoned Suspense render', () => {
+		const pending = new Promise<void>(() => {});
+		const result = mount(PreviousValueBoundary, { value: 'committed' });
+		try {
+			result.update(PreviousValueBoundary, { value: 'abandoned', resource: pending });
+
+			result.update(PreviousValueBoundary, { value: 'replacement', resource: null });
+			expect(result.find('[data-testid="previous-value"]').textContent).toBe('committed');
+		} finally {
+			result.unmount();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

<!-- What changed, and why. -->

Series **5/7**, targeting `main`. Tracks [octanejs/octane#365](https://github.com/octanejs/octane/issues/365).

- Base UI's `usePreviousValue` synchronized a `{ current, previous }` pair through a guarded render-phase setter, allowing an abandoned Suspense render to poison later committed history.
- Derive the previous committed source directly with existing `useLinkedState` and retain the binding's explicit manual subslot; hoist the pure reconciler and stable strict-equality options to module scope so the migration adds no per-render callback/options allocations.
- Preserve Base UI's initial `null` return, updates only for distinct values, repeated-render stability, and its existing strict-`===` equality semantics, including `+0`/`-0`.
- Add a package-owned public DOM/Suspense regression proving speculative `"abandoned"` values never replace the last `"committed"` value.
- Add the patch changeset `.changeset/base-ui-linked-previous-value.md` for `@octanejs/base-ui`.

## Validation

<!-- What you ran, and anything you deliberately left unverified. -->

- [x] `pnpm format:check`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [x] targeted tests: `pnpm vitest run --project base-ui --project base-ui-ssr --reporter=dot --maxWorkers=2` — **227 client and SSR tests passed across 23 files**.
- [x] Red-first public Suspense/DOM regression failed before the migration with `expected 'abandoned' to be 'committed'` and passes afterward; initial `null` and signed-zero compatibility are covered.
- [x] Package type check: `pnpm exec tsgo --noEmit -p packages/base-ui/tsconfig.json`.
- [x] Scoped formatting: `pnpm format:files:check packages/base-ui/src/utils/usePreviousValue.ts packages/base-ui/tests/previous-value.test.ts .changeset/base-ui-linked-previous-value.md`.
- [x] Generated-file synchronization: `pnpm sync`.

- [x] Integrated final stack: `pnpm exec vitest run --project octane --project octane-prod --project apollo-client --project apollo-client-ssr --project aria --project aria-ssr --project base-ui --project base-ui-ssr --project tanstack-router --project radix --maxWorkers=4 --reporter=dot --silent=passed-only` — **11,473 tests passed across 879 files**.

The remaining unchecked boxes are intentional: full-workspace typecheck and test commands were not run.

## Risk / follow-ups

The explicit comparator intentionally preserves this binding's historical strict-equality behavior instead of adopting `Object.is` signed-zero semantics. The initial previous value remains `null`.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!--
Tick the box above whenever an agent wrote the change, no matter which account
pushes it. Leaving it clear or omitting this section asserts a human wrote the
diff; either form keeps the label workflow successful.

A bot reads this box and applies the label, so nothing here needs repository
permissions and it works the same from a fork. The type label comes from the
conventional-commit type in the title. Do not apply either by hand.

When updating an existing pull request, merge this template content into the
current body. Preserve every bot-managed HTML comment region and all existing
maintainer-authored text; never replace the body from a fresh template.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized hook implementation change with explicit regression tests; public API and equality semantics are preserved.
> 
> **Overview**
> **`usePreviousValue`** no longer keeps `{ current, previous }` via a render-phase **`useState`** update. It now derives the last **committed** prior value through **`useLinkedState`**, so a Suspense-abandoned render cannot leak speculative values into later committed history.
> 
> Behavior stays the same for consumers: initial **`null`**, updates only when the source changes under strict **`===`** (including **`+0`/`-0`**), with module-scoped reconciler and equality options to avoid extra per-render allocations.
> 
> New **`previous-value.test.ts`** covers normal transitions, signed-zero, and the Suspense abandonment regression; patch changeset for **`@octanejs/base-ui`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf8ccda5729aa2e8b10a47fb923c0ba7199bfc1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->