### PR TITLE
fix(tanstack-router): preserve committed navigation history

### DIFF
--- a/.changeset/tanstack-router-linked-previous-value.md
+++ b/.changeset/tanstack-router-linked-previous-value.md
@@ -1,0 +1,5 @@
+---
+'@octanejs/tanstack-router': patch
+---
+
+Keep router transition history tied to committed values when Suspense abandons a navigation.

--- a/packages/tanstack-router/src/utils.ts
+++ b/packages/tanstack-router/src/utils.ts
@@ -1,18 +1,30 @@
 // Small hook utilities ported from react-router's utils.tsx. Plain-`.ts` hooks
 // forward the caller's compiler-injected slot (see internal.ts).
-import { useRef } from 'octane';
+import { type LinkedStatePrevious, useLinkedState } from 'octane';
 import { splitSlot, subSlot } from './internal';
 
+function previousCommittedValue<Value>(
+	_current: Value,
+	previous: LinkedStatePrevious<Value, Value | null> | undefined,
+): Value | null {
+	return previous === undefined ? null : previous.source;
+}
+
+const PREVIOUS_VALUE_OPTIONS = {
+	sourceEqual: <Value>(previous: Value, next: Value) => previous === next,
+};
+
 // Returns the value from the previous render (null on first render). Ported from
-// react-router's usePrevious — the previous/current pair lives in one ref cell and
-// rolls forward during render when the incoming value changes.
+// react-router's usePrevious — linked state advances only when a changed value commits,
+// keeping abandoned Suspense attempts out of the previous-distinct history.
 export function usePrevious(...args: any[]): any {
 	const [user, slot] = splitSlot(args);
 	const value = user[0];
-	const ref = useRef({ value, prev: null }, subSlot(slot, 'prev'));
-	const current = ref.current.value;
-	if (value !== current) {
-		ref.current = { value, prev: current };
-	}
-	return ref.current.prev;
+	const [previous] = useLinkedState(
+		value,
+		previousCommittedValue,
+		PREVIOUS_VALUE_OPTIONS,
+		subSlot(slot, 'prev'),
+	);
+	return previous;
 }

--- a/packages/tanstack-router/tests/conformance/hooks.test.ts
+++ b/packages/tanstack-router/tests/conformance/hooks.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
+import { createElement, Suspense, use } from 'octane';
 import { mount, nextPaint } from '../_helpers';
 import { RouterProvider } from '@octanejs/tanstack-router';
+import { usePrevious } from '../../src/utils';
 import { makeHooksRouter, navigateIdentities } from '../_fixtures/hooks.tsrx';
 
 async function flush() {
@@ -104,5 +106,68 @@ describe('@octanejs/tanstack-router — hooks', () => {
 		await flush();
 		expect(r.find('.search').textContent).toBe('{"q":""}');
 		r.unmount();
+	});
+});
+
+interface PreviousRouterValueProps {
+	value: string | number;
+	resource?: Promise<void> | null;
+}
+
+const PREVIOUS_ROUTER_VALUE_SLOT = Symbol('router-previous-value');
+
+function PreviousRouterValue(props: PreviousRouterValueProps) {
+	const previous = usePrevious(props.value, PREVIOUS_ROUTER_VALUE_SLOT);
+	if (props.resource != null) use(props.resource);
+	return createElement('output', { 'data-testid': 'previous-value' }, previous ?? 'initial');
+}
+
+function PreviousRouterValueBoundary(props: PreviousRouterValueProps) {
+	return createElement(
+		Suspense,
+		{ fallback: createElement('output', { 'data-testid': 'pending' }, 'pending') },
+		createElement(PreviousRouterValue, props),
+	);
+}
+
+describe('@octanejs/tanstack-router — previous distinct value', () => {
+	it('starts empty and retains the previous distinct committed value', () => {
+		const result = mount(PreviousRouterValueBoundary, { value: 'first' });
+		try {
+			expect(result.find('[data-testid="previous-value"]').textContent).toBe('initial');
+
+			result.update(PreviousRouterValueBoundary, { value: 'second' });
+			expect(result.find('[data-testid="previous-value"]').textContent).toBe('first');
+
+			result.update(PreviousRouterValueBoundary, { value: 'second' });
+			expect(result.find('[data-testid="previous-value"]').textContent).toBe('first');
+
+			result.update(PreviousRouterValueBoundary, { value: 'third' });
+			expect(result.find('[data-testid="previous-value"]').textContent).toBe('second');
+		} finally {
+			result.unmount();
+		}
+	});
+
+	it('does not treat positive and negative zero as distinct values', () => {
+		const result = mount(PreviousRouterValueBoundary, { value: 0 });
+		try {
+			result.update(PreviousRouterValueBoundary, { value: -0 });
+			expect(result.find('[data-testid="previous-value"]').textContent).toBe('initial');
+		} finally {
+			result.unmount();
+		}
+	});
+
+	it('does not publish previous-value history from an abandoned Suspense render', () => {
+		const pending = new Promise<void>(() => {});
+		const result = mount(PreviousRouterValueBoundary, { value: 'committed' });
+		try {
+			result.update(PreviousRouterValueBoundary, { value: 'abandoned', resource: pending });
+			result.update(PreviousRouterValueBoundary, { value: 'replacement', resource: null });
+			expect(result.find('[data-testid="previous-value"]').textContent).toBe('committed');
+		} finally {
+			result.unmount();
+		}
 	});
 });


### PR DESCRIPTION
## Summary

<!-- What changed, and why. -->

Series **6/7**, targeting `main`. Tracks [octanejs/octane#365](https://github.com/octanejs/octane/issues/365).

- TanStack Router's previous-value helper assigned `ref.current` during render, so a speculative navigation that suspended and never committed still replaced observable navigation history.
- Replace the render-phase ref write with existing `useLinkedState`, deriving history from the previous **committed** source while preserving the helper's established manual subslot; module-scope pure reconciliation and stable strict-equality options avoid adding per-render callback/options allocations.
- Retain the initial `null` value, previous-distinct-value contract, repeated-value stability, and existing strict-`===` comparator behavior including `+0`/`-0`.
- Add a package-owned conformance regression at the public DOM/Suspense boundary proving an abandoned navigation cannot poison the next committed value.
- Add the patch changeset `.changeset/tanstack-router-linked-previous-value.md` for `@octanejs/tanstack-router`.

## Validation

<!-- What you ran, and anything you deliberately left unverified. -->

- [x] `pnpm format:check`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [x] targeted tests: `pnpm vitest run --project tanstack-router --reporter=dot --maxWorkers=2` — **78 router tests passed across 14 files**.
- [x] Red-first public Suspense/navigation regression failed before the migration with `expected 'abandoned' to be 'committed'` and passes afterward; initial `null` and signed-zero compatibility are covered.
- [x] Package type check: `pnpm exec tsgo --noEmit -p packages/tanstack-router/tsconfig.json`.
- [x] Scoped formatting: `pnpm format:files:check packages/tanstack-router/src/utils.ts packages/tanstack-router/tests/conformance/hooks.test.ts .changeset/tanstack-router-linked-previous-value.md`.
- [x] Generated-file synchronization: `pnpm sync`.

- [x] Integrated final stack: `pnpm exec vitest run --project octane --project octane-prod --project apollo-client --project apollo-client-ssr --project aria --project aria-ssr --project base-ui --project base-ui-ssr --project tanstack-router --project radix --maxWorkers=4 --reporter=dot --silent=passed-only` — **11,473 tests passed across 879 files**.

The remaining unchecked boxes are intentional: full-workspace typecheck and test commands were not run.

## Risk / follow-ups

The explicit comparator retains the router's previous strict-equality semantics, particularly signed zero, while Suspense history now reflects committed renders only.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!--
Tick the box above whenever an agent wrote the change, no matter which account
pushes it. Leaving it clear or omitting this section asserts a human wrote the
diff; either form keeps the label workflow successful.

A bot reads this box and applies the label, so nothing here needs repository
permissions and it works the same from a fork. The type label comes from the
conventional-commit type in the title. Do not apply either by hand.

When updating an existing pull request, merge this template content into the
current body. Preserve every bot-managed HTML comment region and all existing
maintainer-authored text; never replace the body from a fresh template.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches router transition timing via `usePrevious` in `Transitioner` and loading/pending edge detection; scoped fix with targeted regression tests but behavior change for Suspense-abandoned navigations.
> 
> **Overview**
> **`usePrevious`** no longer updates history during render via a ref; it derives the last distinct value from **`useLinkedState`**, so speculative navigations that suspend and never commit do not overwrite what callers see as the previous committed value.
> 
> Behavior is unchanged for the normal case: first render still returns `null`, repeated values stay stable, and strict `===` equality (including `+0`/`-0`) is preserved via module-scoped options.
> 
> **`Transitioner`** and other consumers of `usePrevious` therefore get transition history aligned with committed router state rather than abandoned Suspense attempts.
> 
> Conformance tests cover the Suspense abandonment case at the public DOM boundary, plus signed-zero and previous-distinct-value contracts. Patch changeset for `@octanejs/tanstack-router`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccf36915ca4f45b5e363d473f7c913da6eabf3be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->