### PR TITLE
fix(radix): preserve committed previous-value history

### DIFF
--- a/.changeset/radix-linked-previous-value.md
+++ b/.changeset/radix-linked-previous-value.md
@@ -1,0 +1,5 @@
+---
+'@octanejs/radix': patch
+---
+
+Preserve committed previous-value history across abandoned Suspense renders in Radix controls.

--- a/packages/radix/src/use-previous.ts
+++ b/packages/radix/src/use-previous.ts
@@ -1,28 +1,30 @@
 // Ported from @radix-ui/react-use-previous (source:
 // .radix-primitives/packages/react/use-previous/src/use-previous.tsx). Returns the
 // value from the previous render in which `value` differed from the current one.
-import { useMemo, useRef } from 'octane';
+import { type LinkedStatePrevious, useLinkedState } from 'octane';
 
 import { S, splitSlot, subSlot } from './internal';
+
+function previousCommittedValue<Value>(
+	current: Value,
+	previous: LinkedStatePrevious<Value, Value> | undefined,
+): Value {
+	return previous === undefined ? current : previous.source;
+}
+
+const PREVIOUS_VALUE_OPTIONS = {
+	sourceEqual: <Value>(previous: Value, next: Value) => previous === next,
+};
 
 export function usePrevious<T>(...args: any[]): T {
 	const [user, slotArg] = splitSlot(args);
 	const slot = slotArg ?? S('usePrevious');
 	const value = user[0] as T;
-	const ref = useRef({ value, previous: value }, subSlot(slot, 'ref'));
-
-	// We compare values before making an update to ensure that
-	// a change has been made. This ensures the previous value is
-	// persisted correctly between renders.
-	return useMemo(
-		() => {
-			if (ref.current.value !== value) {
-				ref.current.previous = ref.current.value;
-				ref.current.value = value;
-			}
-			return ref.current.previous;
-		},
-		[value],
-		subSlot(slot, 'm'),
+	const [previous] = useLinkedState<T, T>(
+		value,
+		previousCommittedValue,
+		PREVIOUS_VALUE_OPTIONS,
+		subSlot(slot, 'previous'),
 	);
+	return previous;
 }

--- a/packages/radix/tests/foundation.test.ts
+++ b/packages/radix/tests/foundation.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
+import { createElement, Suspense, use } from 'octane';
 import { mount } from '../../octane/tests/_helpers';
+import { usePrevious } from '../src/use-previous';
 import { SepPlain, SepDecorative, LabelPlain, SepAsChild, SlotMerge } from './_fixtures/proof.tsx';
 
 // @octanejs/radix Phase 0 — the composition foundation (Slot / Primitive / asChild) +
@@ -59,5 +61,73 @@ describe('@octanejs/radix — Slot / asChild', () => {
 		expect(btn.textContent).toBe('go'); // child children preserved
 		expect(btn.className.split(' ').sort()).toEqual(['btn', 'from-slot']); // class composes
 		r.unmount();
+	});
+});
+
+interface PreviousRadixValueProps {
+	value: string | number;
+	resource?: Promise<void> | null;
+}
+
+const PREVIOUS_RADIX_VALUE_SLOT = Symbol('radix-previous-value');
+
+function PreviousRadixValue(props: PreviousRadixValueProps) {
+	const previous = usePrevious<string | number>(props.value, PREVIOUS_RADIX_VALUE_SLOT);
+	if (props.resource != null) use(props.resource);
+	return createElement(
+		'output',
+		{ 'data-testid': 'previous-value' },
+		Object.is(previous, -0) ? '-0' : String(previous),
+	);
+}
+
+function PreviousRadixValueBoundary(props: PreviousRadixValueProps) {
+	return createElement(
+		Suspense,
+		{ fallback: createElement('output', { 'data-testid': 'pending' }, 'pending') },
+		createElement(PreviousRadixValue, props),
+	);
+}
+
+describe('@octanejs/radix — previous distinct value', () => {
+	it('starts at the current value and retains the previous distinct committed value', () => {
+		const result = mount(PreviousRadixValueBoundary, { value: 'first' });
+		try {
+			expect(result.find('[data-testid="previous-value"]').textContent).toBe('first');
+
+			result.update(PreviousRadixValueBoundary, { value: 'second' });
+			expect(result.find('[data-testid="previous-value"]').textContent).toBe('first');
+
+			result.update(PreviousRadixValueBoundary, { value: 'second' });
+			expect(result.find('[data-testid="previous-value"]').textContent).toBe('first');
+
+			result.update(PreviousRadixValueBoundary, { value: 'third' });
+			expect(result.find('[data-testid="previous-value"]').textContent).toBe('second');
+		} finally {
+			result.unmount();
+		}
+	});
+
+	it('does not treat positive and negative zero as distinct values', () => {
+		const result = mount(PreviousRadixValueBoundary, { value: 0 });
+		try {
+			result.update(PreviousRadixValueBoundary, { value: -0 });
+			result.update(PreviousRadixValueBoundary, { value: 1 });
+			expect(result.find('[data-testid="previous-value"]').textContent).toBe('0');
+		} finally {
+			result.unmount();
+		}
+	});
+
+	it('does not publish previous-value history from an abandoned Suspense render', () => {
+		const pending = new Promise<void>(() => {});
+		const result = mount(PreviousRadixValueBoundary, { value: 'committed' });
+		try {
+			result.update(PreviousRadixValueBoundary, { value: 'abandoned', resource: pending });
+			result.update(PreviousRadixValueBoundary, { value: 'replacement', resource: null });
+			expect(result.find('[data-testid="previous-value"]').textContent).toBe('committed');
+		} finally {
+			result.unmount();
+		}
 	});
 });


### PR DESCRIPTION
## Summary

<!-- What changed, and why. -->

Series **7/7**, targeting `main`. Tracks [octanejs/octane#365](https://github.com/octanejs/octane/issues/365).

- Radix's `usePrevious` wrote to a ref inside a render-time `useMemo` callback, violating render purity and allowing an abandoned Suspense attempt to leak into later committed history.
- Replace the memo/ref pair with existing `useLinkedState` so reconciliation receives only the previous committed source; retain the helper's established manual subslot and hoist its pure reconciler and stable strict-equality options so no callback/options objects are allocated per render.
- Preserve Radix's deliberately distinct first-render contract: **the initial previous value is the current value**, not `null`. Keep previous-distinct-value behavior, repeated-value stability, and strict-`===` signed-zero compatibility.
- Add a package-owned foundation regression that observes committed-versus-abandoned values through real DOM/Suspense behavior.
- Add the patch changeset `.changeset/radix-linked-previous-value.md` for `@octanejs/radix`.

## Validation

<!-- What you ran, and anything you deliberately left unverified. -->

- [x] `pnpm format:check`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [x] targeted tests: `pnpm vitest run --project radix --reporter=dot --maxWorkers=2` — **132 Radix tests passed across 22 files**.
- [x] Red-first public Suspense/DOM regression failed before the migration with `expected 'abandoned' to be 'committed'` and passes afterward; initial-current-value and signed-zero compatibility are covered.
- [x] Package type check: `pnpm exec tsgo --noEmit -p packages/radix/tsconfig.json`.
- [x] Scoped formatting: `pnpm format:files:check packages/radix/src/use-previous.ts packages/radix/tests/foundation.test.ts .changeset/radix-linked-previous-value.md`.
- [x] Generated-file synchronization: `pnpm sync`.

- [x] Integrated final stack: `pnpm exec vitest run --project octane --project octane-prod --project apollo-client --project apollo-client-ssr --project aria --project aria-ssr --project base-ui --project base-ui-ssr --project tanstack-router --project radix --maxWorkers=4 --reporter=dot --silent=passed-only` — **11,473 tests passed across 879 files**.

The remaining unchecked boxes are intentional: full-workspace typecheck and test commands were not run.

## Risk / follow-ups

Radix intentionally differs from Base UI and TanStack Router by returning the **current** value initially; the explicit comparator also preserves historical strict equality instead of changing signed-zero behavior.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!--
Tick the box above whenever an agent wrote the change, no matter which account
pushes it. Leaving it clear or omitting this section asserts a human wrote the
diff; either form keeps the label workflow successful.

A bot reads this box and applies the label, so nothing here needs repository
permissions and it works the same from a fork. The type label comes from the
conventional-commit type in the title. Do not apply either by hand.

When updating an existing pull request, merge this template content into the
current body. Preserve every bot-managed HTML comment region and all existing
maintainer-authored text; never replace the body from a fresh template.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a shared primitive used by Radix controls; behavior is intentionally preserved except for the Suspense leak fix, but any consumer relying on the old impure path could see different edge-case timing.
> 
> **Overview**
> **`usePrevious`** no longer updates a ref inside render-time **`useMemo`**; it now derives the previous distinct value through **`useLinkedState`** with a hoisted reconciler and strict **`===`** equality, so only **committed** renders affect history.
> 
> Radix’s existing contract stays the same: the first “previous” is the **current** value (not `null`), repeated inputs keep the same previous, and **+0 / -0** are not treated as a change. Abandoned Suspense attempts can no longer leak an intermediate value into later commits.
> 
> Adds foundation tests (including DOM + **Suspense**) and a patch changeset for **`@octanejs/radix`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa9bba40dcb1fb44e62873bc494ab5f224c254ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->