### PR TITLE
fix: ci - vercel preview was attempting to delete non-existent branch

### DIFF
--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -53,10 +53,26 @@ jobs:
 
             const deletePreviewRef = async () => {
               try {
+                await github.rest.git.getRef({ owner, repo, ref });
+              } catch (error) {
+                if (error.status === 404) {
+                  core.notice(`Temporary Vercel preview branch ${branch} is already absent.`);
+                  return;
+                }
+                throw error;
+              }
+
+              try {
                 await github.rest.git.deleteRef({ owner, repo, ref });
                 core.notice(`Deleted temporary Vercel preview branch ${branch}.`);
               } catch (error) {
-                if (error.status === 404) {
+                // GitHub reports a ref that disappears between the read and
+                // delete as 422 rather than 404.
+                if (
+                  error.status === 404 ||
+                  (error.status === 422 &&
+                    error.response?.data?.message === "Reference does not exist")
+                ) {
                   core.notice(`Temporary Vercel preview branch ${branch} is already absent.`);
                   return;
                 }

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -826,6 +826,7 @@ describe('Vercel preview workflow', () => {
 		pullResponse = pull,
 		comments = [],
 		existingRef = null,
+		deleteRefError = null,
 		deploymentSnapshots = [],
 	} = {}) {
 		const gitCalls = [];
@@ -870,6 +871,7 @@ describe('Vercel preview workflow', () => {
 					},
 					deleteRef: async (input) => {
 						gitCalls.push({ operation: 'delete', ...input });
+						if (deleteRefError) throw deleteRefError;
 						if (currentRef === null) {
 							throw Object.assign(new Error('missing ref'), { status: 404 });
 						}
@@ -1156,6 +1158,12 @@ describe('Vercel preview workflow', () => {
 		assert.equal(currentRef, null);
 		assert.deepEqual(gitCalls, [
 			{
+				operation: 'get',
+				owner: 'octanejs',
+				repo: 'octane',
+				ref: 'heads/deploy-preview-pr-612',
+			},
+			{
 				operation: 'delete',
 				owner: 'octanejs',
 				repo: 'octane',
@@ -1171,7 +1179,26 @@ describe('Vercel preview workflow', () => {
 		const { gitCalls, failures, notices } = await runPreview({ action: 'closed' });
 
 		assert.equal(gitCalls.length, 1);
-		assert.equal(gitCalls[0].operation, 'delete');
+		assert.equal(gitCalls[0].operation, 'get');
+		assert.match(notices.join('\n'), /already absent/);
+		assert.deepEqual(failures, []);
+	});
+
+	test('treats a preview branch removed during cleanup as already absent', async () => {
+		const deleteRefError = Object.assign(new Error('Reference does not exist'), {
+			status: 422,
+			response: { data: { message: 'Reference does not exist' } },
+		});
+		const { gitCalls, failures, notices } = await runPreview({
+			action: 'closed',
+			existingRef: sha,
+			deleteRefError,
+		});
+
+		assert.deepEqual(
+			gitCalls.map((call) => call.operation),
+			['get', 'delete'],
+		);
 		assert.match(notices.join('\n'), /already absent/);
 		assert.deepEqual(failures, []);
 	});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only change to preview branch teardown and test mocks; no production app or auth paths.
> 
> **Overview**
> **Vercel preview cleanup** no longer fails when the temporary `deploy-preview-pr-*` branch is already gone. `deletePreviewRef` first calls **`git.getRef`** and exits with a notice on **404** instead of calling **`deleteRef`** blindly.
> 
> If the ref disappears between **get** and **delete**, **`deleteRef`** errors with **422** and message **"Reference does not exist"** are handled the same way as **404** (notice only, no workflow failure).
> 
> **`scripts/ci-workflow.test.mjs`** updates expectations: unlabeled cleanup records **get** then **delete**; closed PR with no branch only **get**s; a new case simulates the **422** race via **`deleteRefError`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a68b4892f5a52aa4a313df6942beba3d2a2eba39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->