### PR TITLE
perf: specialize compiler-proven keyed selection updates

### DIFF
--- a/.changeset/keyed-selection-local-updates.md
+++ b/.changeset/keyed-selection-local-updates.md
@@ -1,0 +1,8 @@
+---
+'octane': patch
+---
+
+Update only the previously selected and newly selected keyed-list rows when the
+production compiler can prove that a row's selection depends solely on its own
+key. Preserve component rerenders, immutable updates, and existing lifecycle
+behavior without requiring a new public API.

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -113,6 +113,14 @@
   },
   {
     "suite": "js-framework",
+    "op": "select_lots",
+    "target": "octane-tsrx",
+    "reference": "octane-jsx",
+    "maxRatio": 0.5,
+    "note": "Alternating selection across 10,000 keyed rows escapes the browser timer floor. TSRX updates only the previously selected and newly selected rows; the JSX compatibility path remains a same-run list-wide control. The ceiling catches loss of compiler-proven O(1) invalidation with generous timing headroom."
+  },
+  {
+    "suite": "js-framework",
     "op": "swap",
     "target": "octane-tsrx",
     "reference": "react",

--- a/benchmarks/js-framework/README.md
+++ b/benchmarks/js-framework/README.md
@@ -99,12 +99,21 @@ machine-readable copy of the results when `BENCH_JSON=<path>` is set
 with a top-level `"failed"` field).
 
 Output is a table of median + min millis per operation: `run`, `replace`,
-`add`, `update`, `select`, `swap`, `remove`, `runlots`, `clear`. The harness
-uses `page.evaluate(el.click)` to fire clicks synchronously inside the page —
-avoids per-click CDP IPC overhead (~10ms each on Chromium) so the numbers
-reflect the renderer's wall time, not Playwright transport. Before warmup, each
-target receives the same seeded `Math.random` stream so generated label lengths
-and allocation patterns cannot drift between dialects.
+`add`, `update`, `select`, `swap`, `remove`, `runlots`, `select_lots`, `clear`.
+The harness uses `page.evaluate(el.click)` to fire clicks synchronously inside
+the page — avoids per-click CDP IPC overhead (~10ms each on Chromium) so the
+numbers reflect the renderer's wall time, not Playwright transport. Before
+warmup, each target receives the same seeded `Math.random` stream so generated
+label lengths and allocation patterns cannot drift between dialects.
+
+Selection samples alternate between the fifth and sixth rows so every click
+changes the selected key instead of measuring an equal-value state bailout.
+`select_lots` reuses the 10,000 rows from `runlots` and alternates between rows
+5,000 and 5,001, moving list-wide selection work above the browser's timer
+resolution. Its same-run TSRX/JSX ratio protects compiler-proven keyed selection
+without depending on machine-specific absolute timings. After each timed
+selection, an untimed correctness gate verifies that exactly the clicked row
+carries the selected class.
 
 ## Keyed-reorder matrix (`run-reorder.mjs`)
 

--- a/benchmarks/js-framework/run.mjs
+++ b/benchmarks/js-framework/run.mjs
@@ -55,10 +55,21 @@ const OPS = [
 	// next op's ensureState sees 2000 rows ≠ 1000 and rebuilds via #run.
 	{ name: 'add', pre: 'rows', click: '#add' },
 	{ name: 'update', pre: 'rows', click: '#update' },
-	{ name: 'select', pre: 'rows', click: 'tbody tr:nth-child(5) td:nth-child(2) a' },
+	{
+		name: 'select',
+		pre: 'rows',
+		click: 'tbody tr:nth-child(5) td:nth-child(2) a',
+		alternateClick: 'tbody tr:nth-child(6) td:nth-child(2) a',
+	},
 	{ name: 'swap', pre: 'rows', click: '#swaprows' },
 	{ name: 'remove', pre: 'rows', click: 'tbody tr:nth-child(5) td:nth-child(3) a' },
 	{ name: 'runlots', pre: 'empty', click: '#runlots' },
+	{
+		name: 'select_lots',
+		pre: 'rows-large',
+		click: 'tbody tr:nth-child(5000) td:nth-child(2) a',
+		alternateClick: 'tbody tr:nth-child(5001) td:nth-child(2) a',
+	},
 	// Canonical js-framework-benchmark `clear` measures clearing the
 	// 10K-row table that `runlots` populated — NOT the 1K-row table from
 	// `run`. The previous `pre: 'rows'` rebuilt 1K rows before the timed
@@ -141,6 +152,22 @@ async function timeClick(page, sel) {
 	}, sel);
 }
 
+async function verifySelection(page, selector) {
+	await page.evaluate((selector) => {
+		const expected = document.querySelector(selector)?.closest('tr');
+		const selected = document.querySelectorAll('tbody tr.danger');
+		if (expected && selected.length === 1 && selected[0] === expected) return;
+
+		const rowId = (row) => row.querySelector('td')?.textContent || '(missing id)';
+		throw new Error(
+			'selection gate failed: expected only ' +
+				(expected ? rowId(expected) : '(missing row)') +
+				', found ' +
+				(Array.from(selected, rowId).join(', ') || '(none)'),
+		);
+	}, selector);
+}
+
 async function runTarget(t) {
 	const browser = await chromium.launch({
 		headless: true,
@@ -165,7 +192,9 @@ async function runTarget(t) {
 		const samples = [];
 		for (let i = 0; i < ITER; i++) {
 			await ensureState(page, op.pre);
-			const dt = await timeClick(page, op.click);
+			const selector = i % 2 === 1 && op.alternateClick ? op.alternateClick : op.click;
+			const dt = await timeClick(page, selector);
+			if (op.alternateClick) await verifySelection(page, selector);
 			samples.push(dt);
 			await sleep(60);
 		}

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -17035,11 +17035,16 @@ function planJsx(
 	const pushAfterStmt = (id, org, node) => pushAfter(id, inheritOriginLoc(node, org));
 	for (const fc of forCalls) {
 		const isMappedList = fc.mapMethodExpr !== null;
-		ctx.runtimeNeeded.add(isMappedList ? 'mapSlot' : 'forBlock');
+		const forHelper = isMappedList
+			? 'mapSlot'
+			: fc.keyedSelectionIndex >= 0
+				? 'keyedForBlock'
+				: 'forBlock';
+		ctx.runtimeNeeded.add(forHelper);
 		const slotIndex = fc.slotIndex;
 		const org = fc.origin ?? planOrigin;
 		registerDirectiveOrigin(ctx, org, [
-			isMappedList ? '_$mapSlot' : '_$forBlock',
+			rtAlias(forHelper),
 			fc.keyHelper,
 			fc.bodyHelper,
 			fc.emptyHelper,
@@ -17052,13 +17057,17 @@ function planJsx(
 		//        for survivors when deps unchanged this render),
 		//        bit 3 = indexIndependent (body binds no `index` → a pure reorder
 		//        that only changes a survivor's position need not re-render it),
-		//        bit 4 = SSR emitted markerless direct-host items; hydrate them by root.
+		//        bit 4 = SSR emitted markerless direct-host items; hydrate them by root,
+		//        bit 5 = keyed selection; bits 6+ carry its zero-based deps index.
+		// The dedicated eligibility bit distinguishes dependency zero from an
+		// ordinary list without adding a positional argument or tuple allocation.
 		const flags =
 			(fc.pure ? 1 : 0) |
 			(fc.singleRoot ? 2 : 0) |
 			(fc.depEligible ? 4 : 0) |
 			(fc.indexIndependent ? 8 : 0) |
-			(fc.ssrMarkerless ? 16 : 0);
+			(fc.ssrMarkerless ? 16 : 0) |
+			(fc.keyedSelectionIndex >= 0 ? 32 | (fc.keyedSelectionIndex << 6) : 0);
 		// Arg layout: forBlock(__s, slot, host, items, keyFn, body, flags?, deps?,
 		// emptyBody?, anchor?, ownEnd?).
 		// Optional args backfill positionally: `flags`/`deps` placeholders
@@ -17188,7 +17197,7 @@ function planJsx(
 				slotIndex,
 				b.stmt(
 					b.call(
-						'_$forBlock',
+						rtAlias(forHelper),
 						b.id('__s'),
 						b.literal(slotIndex),
 						hostExpr(),
@@ -17207,7 +17216,7 @@ function planJsx(
 				org,
 				b.stmt(
 					b.call(
-						'_$forBlock',
+						rtAlias(forHelper),
 						b.id('__s'),
 						b.literal(slotIndex),
 						hostExpr(),
@@ -21196,6 +21205,96 @@ function makeSwitchCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = nul
 // for-of inside element children → forBlock call
 // ===========================================================================
 
+/**
+ * Prove that one parent dependency affects a keyed host row only through its
+ * root class's strict comparison with the row key. The runtime can then update
+ * only the old/new selected blocks when every other dependency and the iterable
+ * snapshot remain unchanged.
+ *
+ * This recognizes `selected === item.id` (or its reverse) under `key item.id`,
+ * and the same proof for any other explicit, noncomputed item property.
+ * Dynamic ternary arms, extra references to
+ * `selected` anywhere in the row (including deferred event callbacks), spreads,
+ * and anything other than one direct host root all fail closed.
+ */
+function keyedSelectionDepIndex(itemName, keyBody, subStmts, runtimeDepNames, ctx) {
+	if (subStmts.length !== 1 || !isPlainHostRoot(subStmts[0])) return -1;
+	const root = subStmts[0];
+	const attrs = root.attributes || root.openingElement?.attributes || [];
+	if (attrs.some((attr) => attr.type !== 'Attribute' && attr.type !== 'JSXAttribute')) {
+		return -1;
+	}
+	const classAttrs = attrs.filter((attr) => {
+		const name = attr.name?.name || attr.name;
+		return name === 'class' || name === 'className';
+	});
+	if (classAttrs.length !== 1) return -1;
+	const value = classAttrs[0].value;
+	const conditional = unwrapTsExpr(
+		value?.type === 'JSXExpressionContainer' ? value.expression : value,
+	);
+	if (conditional?.type !== 'ConditionalExpression') return -1;
+	const consequent = unwrapTsExpr(conditional.consequent);
+	const alternate = unwrapTsExpr(conditional.alternate);
+	if (
+		consequent?.type !== 'Literal' ||
+		typeof consequent.value !== 'string' ||
+		alternate?.type !== 'Literal' ||
+		typeof alternate.value !== 'string'
+	) {
+		return -1;
+	}
+
+	const test = unwrapTsExpr(conditional.test);
+	if (test?.type !== 'BinaryExpression' || test.operator !== '===') return -1;
+	const key = unwrapTsExpr(keyBody);
+	if (
+		key?.type !== 'MemberExpression' ||
+		key.computed === true ||
+		key.optional === true ||
+		key.object?.type !== 'Identifier' ||
+		key.object.name !== itemName ||
+		key.property?.type !== 'Identifier'
+	) {
+		return -1;
+	}
+	const keyProperty = key.property.name;
+	const isItemKey = (expression) => {
+		const member = unwrapTsExpr(expression);
+		return (
+			member?.type === 'MemberExpression' &&
+			member.computed !== true &&
+			member.optional !== true &&
+			member.object?.type === 'Identifier' &&
+			member.object.name === itemName &&
+			member.property?.type === 'Identifier' &&
+			member.property.name === keyProperty
+		);
+	};
+	const left = unwrapTsExpr(test.left);
+	const right = unwrapTsExpr(test.right);
+	const selected = isItemKey(left) ? right : isItemKey(right) ? left : null;
+	if (
+		selected?.type !== 'Identifier' ||
+		selected.name === itemName ||
+		!ctx.currentComponentLocals?.has(selected.name)
+	) {
+		return -1;
+	}
+	// Ignore this exact comparison operand, then use the existing scope-aware
+	// reference walker to detect any other capture of the same outer binding.
+	// Shadowed callback parameters therefore stay harmless while a real event
+	// closure over the selection correctly disables the specialization.
+	if (
+		collectFreeIdentifiers(b.block(subStmts), new Set([itemName]), new Set([selected])).has(
+			selected.name,
+		)
+	) {
+		return -1;
+	}
+	return runtimeDepNames.indexOf(selected.name);
+}
+
 function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) {
 	// `@for await (...)` (async iteration) has no meaning for the runtime's
 	// synchronous keyed reconciler. The TSRX parser currently rejects the surface
@@ -21565,6 +21664,22 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 		envNames === null
 			? depNames
 			: [...envNames, ...depNames.filter((name) => !envNames.includes(name))];
+	// Restrict targeted invalidation to the existing production-only pure-render
+	// contract. The whole-list memo proof rules out render-time mutations and
+	// opaque state, while DEP-PURE guarantees a hookless host-only item body.
+	// Native `.map()` uses a distinct mapSlot ABI and stays on its current path.
+	const keyedSelectionIndex =
+		ctx.autoMemo === true &&
+		depEligible &&
+		!itemMemo &&
+		autoMemoDeps !== null &&
+		!isDestructured &&
+		!node.index &&
+		!emptyStmts &&
+		node.nativeArrayMap === undefined &&
+		node.key != null
+			? keyedSelectionDepIndex(itemName, keyFn.body, subStmts, runtimeDepNames, ctx)
+			: -1;
 	let emptyHelperName = 'null';
 	if (emptyStmts) {
 		emptyHelperName = hoistBodyHelper(
@@ -21691,6 +21806,7 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 		autoMemoDeps,
 		autoMemoWitnesses,
 		autoMemoContextAware,
+		keyedSelectionIndex,
 		depNames: runtimeDepNames,
 		// True only when the header binds NO `index <name>` — the body then can't
 		// observe an item's position, so a pure reorder (same item ref, position

--- a/packages/octane/src/index.ts
+++ b/packages/octane/src/index.ts
@@ -183,6 +183,7 @@ export {
 	delegateEvents,
 	delegateCaptureEvents,
 	forBlock,
+	keyedForBlock,
 	mapSlot,
 	ifBlock,
 	tryBlock,

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -22757,6 +22757,9 @@ interface ForSlot {
 	// Present only on a childSlot owned by the compiler's guarded map ABI.
 	// Keeps descriptor↔compiled adoption off every ordinary descriptor list.
 	mappedNative?: boolean;
+	// Present only when the compiler proved a keyed equality selection. Identity
+	// gates the two-row update without retaining extra state on ordinary lists.
+	selectionItems?: ArrayLike<any>;
 }
 
 export function forBlock<T>(
@@ -23002,6 +23005,62 @@ export function forBlock<T>(
 }
 
 /**
+ * Compiler-only keyed-selection entry. Keeping the specialization outside
+ * forBlock lets applications without a proven selection tree-shake its cost.
+ * Bit 5 identifies the proof; bits 6+ hold its captured dependency index.
+ */
+export function keyedForBlock<T>(
+	parentScope: Scope,
+	slotKey: number,
+	domParent: Node,
+	items: ArrayLike<T>,
+	getKey: (item: T, index: number) => any,
+	itemBody: (item: T, scope: Scope) => void,
+	flags: number,
+	deps: any[],
+	emptyBody?: ComponentBody | null,
+	anchor?: Node | null,
+	ownEnd?: boolean,
+): void {
+	const state = parentScope.slots[slotKey] as ForSlot | undefined;
+	if (TRANSITION_JOURNAL !== null) {
+		if (state !== undefined) {
+			// A transition can commit or roll back without journaling this cache.
+			// Invalidate both snapshots so its next ordinary render re-primes them.
+			state.cachedDeps = null;
+			state.selectionItems = undefined;
+		}
+		// DEP-PURE's direct body call leaves CURRENT_SCOPE on the parent. Force
+		// full row rendering so reversible DOM writes journal each row's own bag.
+		flags &= ~4;
+	} else if (
+		state !== undefined &&
+		activeHydration() === null &&
+		state.cachedDeps !== null &&
+		tryUpdateKeyedSelection(state, items, itemBody, state.cachedDeps, deps, flags >>> 6)
+	) {
+		return;
+	}
+
+	forBlock(
+		parentScope,
+		slotKey,
+		domParent,
+		items,
+		getKey,
+		itemBody,
+		flags,
+		deps,
+		emptyBody,
+		anchor,
+		ownEnd,
+	);
+	if (TRANSITION_JOURNAL === null) {
+		(parentScope.slots[slotKey] as ForSlot).selectionItems = items;
+	}
+}
+
+/**
  * STRUCTURAL recovery for an @for where the SERVER rendered MORE items than the client now
  * renders: after reconcile adopts the client's items, the cursor sits on the first unconsumed
  * server item's marker (or at `end`). Discard everything between the cursor and `end` so the
@@ -23040,6 +23099,60 @@ function depsEqual(a: any[], b: any[]): boolean {
 	if (n !== b.length) return false;
 	for (let i = 0; i < n; i++) {
 		if (!Object.is(a[i], b[i])) return false;
+	}
+	return true;
+}
+
+/**
+ * A compiler-proven equality against the list key changes at most two rows.
+ * The immutable source identity and every other captured dependency must stay
+ * unchanged; anything else falls back to the ordinary keyed reconciliation.
+ */
+function tryUpdateKeyedSelection<T>(
+	state: ForSlot,
+	items: ArrayLike<T>,
+	itemBody: (item: T, scope: Scope) => void,
+	previousDeps: any[],
+	deps: any[],
+	selectionIndex: number,
+): boolean {
+	if (
+		state.selectionItems !== items ||
+		state.size !== items.length ||
+		state.items.size !== state.size ||
+		previousDeps.length !== deps.length ||
+		selectionIndex >= deps.length
+	) {
+		return false;
+	}
+	for (let i = 0; i < deps.length; i++) {
+		if (i !== selectionIndex && !Object.is(previousDeps[i], deps[i])) return false;
+	}
+	const previous = previousDeps[selectionIndex];
+	const next = deps[selectionIndex];
+	// Publish the same snapshots as forBlock before any row can run user code;
+	// reentrant updates must observe the selection currently being committed.
+	state.cachedDeps = deps;
+	state.env = deps;
+	if (Object.is(previous, next)) return true;
+
+	let first = state.items.get(previous) as Block | undefined;
+	let second = state.items.get(next) as Block | undefined;
+	if (first === second) second = undefined;
+	if (first !== undefined && second !== undefined && first.itemIndex > second.itemIndex) {
+		const swap = first;
+		first = second;
+		second = swap;
+	}
+	if (first !== undefined) {
+		first.body = itemBody as ComponentBody;
+		first.extra = deps;
+		(itemBody as any)(first.props, first, deps);
+	}
+	if (second !== undefined) {
+		second.body = itemBody as ComponentBody;
+		second.extra = deps;
+		(itemBody as any)(second.props, second, deps);
 	}
 	return true;
 }

--- a/packages/octane/tests/_fixtures/for.tsrx
+++ b/packages/octane/tests/_fixtures/for.tsrx
@@ -1,4 +1,4 @@
-import { useState } from 'octane';
+import { startTransition, use, useState } from 'octane';
 
 export function List(props) @{
 	<ul>
@@ -167,5 +167,105 @@ export function PlainCalleeList() @{
 				<li class="pc-row">{fmtRow(item)}</li>
 			}
 		</ul>
+	</div>
+}
+
+interface SelectionRow {
+	id: number;
+	label: string;
+}
+
+export function KeyedSelectionList(props: {
+	items: SelectionRow[];
+	selected: number | null;
+	prefix?: string;
+}) @{
+	const selected = props.selected;
+	const prefix = props.prefix ?? 'row';
+	<ul id="keyed-selection-list">
+		@for (const row of props.items; key row.id) {
+			<li
+				class={selected === row.id ? 'selected' : ''}
+				data-prefix={prefix}
+			>{row.label as string}</li>
+		}
+	</ul>
+}
+
+export function KeyedSelectionUuidList(props: {
+	items: Array<{ uuid: string; label: string }>;
+	selected: string | null;
+}) @{
+	const selected = props.selected;
+	<ul id="keyed-selection-uuid-list">
+		@for (const row of props.items; key row.uuid) {
+			<li class={row.uuid === selected ? 'selected' : ''}>{row.label as string}</li>
+		}
+	</ul>
+}
+
+export function MismatchedKeyedSelectionList(props: {
+	items: Array<{ uuid: string; id: string; label: string }>;
+	selected: string | null;
+}) @{
+	const selected = props.selected;
+	<ul id="mismatched-keyed-selection-list">
+		@for (const row of props.items; key row.uuid) {
+			<li class={selected === row.id ? 'selected' : ''}>{row.label as string}</li>
+		}
+	</ul>
+}
+
+export function SharedKeyedSelectionList(props: {
+	items: SelectionRow[];
+	selected: number | null;
+}) @{
+	const selected = props.selected;
+	<ul id="shared-keyed-selection-list">
+		@for (const row of props.items; key row.id) {
+			<li
+				class={selected === row.id ? 'selected' : ''}
+				data-selected={selected}
+			>{row.label as string}</li>
+		}
+	</ul>
+}
+
+function SelectionTransitionValue(props: { promise: Promise<string> }) @{
+	const value = use(props.promise);
+	<span id="selection-transition-value">{value as string}</span>
+}
+
+export function KeyedSelectionTransition(props: {
+	items: SelectionRow[];
+	initialPromise: Promise<string>;
+	nextPromise: Promise<string>;
+}) @{
+	const [selected, setSelected] = useState(1);
+	const [resource, setResource] = useState(props.initialPromise);
+	<div>
+		<button
+			id="selection-transition-bump"
+			onClick={() => startTransition(() => {
+				setSelected(2);
+				setResource(props.nextPromise);
+			})}
+		>{'select next'}</button>
+		<button
+			id="selection-transition-urgent"
+			onClick={() => setSelected(3)}
+		>{'select urgently'}</button>
+		@try {
+			<>
+				<ul id="selection-transition-list">
+					@for (const row of props.items; key row.id) {
+						<li class={selected === row.id ? 'selected' : ''}>{row.label as string}</li>
+					}
+				</ul>
+				<SelectionTransitionValue promise={resource} />
+			</>
+		} @pending {
+			<span id="selection-transition-fallback">{'loading'}</span>
+		}
 	</div>
 }

--- a/packages/octane/tests/for.test.ts
+++ b/packages/octane/tests/for.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { mount } from './_helpers';
+import * as ServerRuntime from 'octane/server';
+import { flushSync, hydrateRoot } from '../src/index.js';
+import { act, mount } from './_helpers';
+import { loadServerFixture } from './_server-fixture';
 import {
 	List,
 	MutableList,
@@ -8,6 +11,11 @@ import {
 	DepPureList,
 	CallBodyList,
 	PlainCalleeList,
+	KeyedSelectionList,
+	KeyedSelectionTransition,
+	KeyedSelectionUuidList,
+	MismatchedKeyedSelectionList,
+	SharedKeyedSelectionList,
 	setExternal,
 } from './_fixtures/for.tsrx';
 
@@ -208,5 +216,207 @@ describe('forBlock — DEP-PURE promotion compares deps with Object.is', () => {
 		expect(r.findAll('.dp-row').map((li) => li.textContent)).toEqual(['row1:tick0', 'row2:tick0']);
 		r.unmount();
 		setExternal('tick0'); // reset the module-level fixture state
+	});
+});
+
+describe('keyed list selection', () => {
+	const makeRows = () => [
+		{ id: 1, label: 'first' },
+		{ id: 2, label: 'second' },
+		{ id: 3, label: 'third' },
+	];
+
+	it('updates the previous and next selected rows without replacing their DOM nodes', () => {
+		const items = makeRows();
+		const r = mount(KeyedSelectionList, { items, selected: 1 });
+		const originalRows = r.findAll('li');
+
+		r.update(KeyedSelectionList, { items, selected: 3 });
+		expect(r.findAll('li.selected').map((row) => row.textContent)).toEqual(['third']);
+		expect(r.findAll('li')).toEqual(originalRows);
+
+		r.update(KeyedSelectionList, { items, selected: 2 });
+		expect(r.findAll('li.selected').map((row) => row.textContent)).toEqual(['second']);
+		expect(r.findAll('li')).toEqual(originalRows);
+		r.unmount();
+	});
+
+	it('handles missing, cleared, and repeated selections', () => {
+		const items = makeRows();
+		const r = mount(KeyedSelectionList, { items, selected: null });
+		expect(r.findAll('li.selected')).toHaveLength(0);
+
+		r.update(KeyedSelectionList, { items, selected: 99 });
+		expect(r.findAll('li.selected')).toHaveLength(0);
+
+		r.update(KeyedSelectionList, { items, selected: 2 });
+		expect(r.find('.selected').textContent).toBe('second');
+
+		r.update(KeyedSelectionList, { items, selected: 2 });
+		expect(r.findAll('.selected')).toHaveLength(1);
+		expect(r.find('.selected').textContent).toBe('second');
+
+		r.update(KeyedSelectionList, { items, selected: null });
+		expect(r.findAll('li.selected')).toHaveLength(0);
+		r.unmount();
+	});
+
+	it('matches selection against the authored custom key property', () => {
+		const items = [
+			{ uuid: 'a-1', label: 'first' },
+			{ uuid: 'b-2', label: 'second' },
+			{ uuid: 'c-3', label: 'third' },
+		];
+		const r = mount(KeyedSelectionUuidList, { items, selected: 'a-1' });
+		const originalRows = r.findAll('li');
+
+		r.update(KeyedSelectionUuidList, { items, selected: 'c-3' });
+		expect(r.find('.selected').textContent).toBe('third');
+		expect(r.findAll('li')).toEqual(originalRows);
+
+		r.update(KeyedSelectionUuidList, { items, selected: 'missing' });
+		expect(r.findAll('.selected')).toHaveLength(0);
+		r.unmount();
+	});
+
+	it('updates every matching row when the selection property differs from the key', () => {
+		const items = [
+			{ uuid: 'a-1', id: 'shared', label: 'first' },
+			{ uuid: 'b-2', id: 'other', label: 'second' },
+			{ uuid: 'c-3', id: 'shared', label: 'third' },
+		];
+		const r = mount(MismatchedKeyedSelectionList, { items, selected: 'other' });
+
+		r.update(MismatchedKeyedSelectionList, { items, selected: 'shared' });
+		expect(r.findAll('.selected').map((row) => row.textContent)).toEqual(['first', 'third']);
+		r.unmount();
+	});
+
+	it('updates every row when the selected value also drives another binding', () => {
+		const items = makeRows();
+		const r = mount(SharedKeyedSelectionList, { items, selected: 1 });
+
+		r.update(SharedKeyedSelectionList, { items, selected: 3 });
+		expect(r.findAll('li').map((row) => row.getAttribute('data-selected'))).toEqual([
+			'3',
+			'3',
+			'3',
+		]);
+		expect(r.find('.selected').textContent).toBe('third');
+		r.unmount();
+	});
+
+	it('updates every row when another captured parent value changes', () => {
+		const items = makeRows();
+		const r = mount(KeyedSelectionList, { items, selected: 1, prefix: 'before' });
+
+		r.update(KeyedSelectionList, { items, selected: 3, prefix: 'after' });
+		expect(r.findAll('li').map((row) => row.getAttribute('data-prefix'))).toEqual([
+			'after',
+			'after',
+			'after',
+		]);
+		expect(r.find('.selected').textContent).toBe('third');
+
+		r.update(KeyedSelectionList, { items, selected: 2, prefix: 'after' });
+		expect(r.find('.selected').textContent).toBe('second');
+		r.unmount();
+	});
+
+	it('preserves immutable keyed-row updates when the selection changes together', () => {
+		const initialItems = makeRows();
+		const r = mount(KeyedSelectionList, { items: initialItems, selected: 1 });
+		const originalRows = r.findAll('li');
+		const updatedItems = [
+			initialItems[0]!,
+			{ ...initialItems[1]!, label: 'updated second' },
+			initialItems[2]!,
+		];
+
+		r.update(KeyedSelectionList, { items: updatedItems, selected: 2 });
+		expect(labels(r)).toEqual(['first', 'updated second', 'third']);
+		expect(r.find('.selected').textContent).toBe('updated second');
+		expect(r.findAll('li')).toEqual(originalRows);
+
+		r.update(KeyedSelectionList, { items: updatedItems, selected: 3 });
+		expect(r.find('.selected').textContent).toBe('third');
+		expect(labels(r)).toEqual(['first', 'updated second', 'third']);
+		r.unmount();
+	});
+
+	it('keeps selection correct across reordering, removal, clearing, and refill', () => {
+		const initialItems = makeRows();
+		const r = mount(KeyedSelectionList, { items: initialItems, selected: 2 });
+		const selectedRow = r.find('.selected');
+		const reordered = [initialItems[2]!, initialItems[1]!, initialItems[0]!];
+
+		r.update(KeyedSelectionList, { items: reordered, selected: 2 });
+		expect(labels(r)).toEqual(['third', 'second', 'first']);
+		expect(r.find('.selected')).toBe(selectedRow);
+
+		const withoutSelected = [reordered[0]!, reordered[2]!];
+		r.update(KeyedSelectionList, { items: withoutSelected, selected: 2 });
+		expect(labels(r)).toEqual(['third', 'first']);
+		expect(r.findAll('.selected')).toHaveLength(0);
+
+		r.update(KeyedSelectionList, { items: [], selected: null });
+		expect(r.findAll('li')).toHaveLength(0);
+
+		r.update(KeyedSelectionList, { items: initialItems, selected: 3 });
+		expect(labels(r)).toEqual(['first', 'second', 'third']);
+		expect(r.find('.selected').textContent).toBe('third');
+		r.unmount();
+	});
+
+	it('adopts server-rendered rows and keeps them live when selection changes', () => {
+		const items = makeRows();
+		const props = { items, selected: 1, prefix: 'hydrated' };
+		const server = loadServerFixture('packages/octane/tests/_fixtures/for.tsrx', {
+			compileOptions: { hmr: false, dev: false },
+		});
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		container.innerHTML = ServerRuntime.renderToString(server.KeyedSelectionList, props).html;
+		const originalRows = Array.from(container.querySelectorAll('li'));
+		const root = hydrateRoot(container, KeyedSelectionList, props);
+		flushSync(() => {});
+
+		expect(Array.from(container.querySelectorAll('li'))).toEqual(originalRows);
+		expect(container.querySelector('.selected')?.textContent).toBe('first');
+
+		flushSync(() => root.render(KeyedSelectionList, { ...props, selected: 3 }));
+		expect(Array.from(container.querySelectorAll('li'))).toEqual(originalRows);
+		expect(container.querySelector('.selected')?.textContent).toBe('third');
+
+		root.unmount();
+		container.remove();
+	});
+
+	it('keeps the committed selection while a later transition sibling suspends', async () => {
+		const items = makeRows();
+		const initialPromise = Promise.resolve('initial');
+		let resolveNext!: (value: string) => void;
+		const nextPromise = new Promise<string>((resolve) => {
+			resolveNext = resolve;
+		});
+		await Promise.resolve();
+		const r = mount(KeyedSelectionTransition, { items, initialPromise, nextPromise });
+		await act(() => {});
+		expect(r.find('#selection-transition-list .selected').textContent).toBe('first');
+		expect(r.find('#selection-transition-value').textContent).toBe('initial');
+
+		r.click('#selection-transition-bump');
+		expect(r.find('#selection-transition-list .selected').textContent).toBe('first');
+		expect(r.find('#selection-transition-value').textContent).toBe('initial');
+		expect(r.findAll('#selection-transition-fallback')).toHaveLength(0);
+
+		await act(() => resolveNext('resolved'));
+		expect(r.find('#selection-transition-list .selected').textContent).toBe('second');
+		expect(r.find('#selection-transition-value').textContent).toBe('resolved');
+
+		r.click('#selection-transition-urgent');
+		expect(r.findAll('#selection-transition-list .selected')).toHaveLength(1);
+		expect(r.find('#selection-transition-list .selected').textContent).toBe('third');
+		r.unmount();
 	});
 });


### PR DESCRIPTION
## Summary

- Automatically recognize production `@for` rows whose class depends only on a strict comparison between the selected value and the row's authored key. Emit a tree-shakable compiler-only capability that updates only the previously selected and newly selected keyed rows while preserving component rerenders and existing public APIs.
- Fall back to ordinary reconciliation for immutable row replacements, changed parent dependencies, mismatched keys, additional selection captures, hydration, and suspended transitions. Add behavioral coverage for each case, including transition rollback followed by an urgent update.
- Repair the framework benchmark's repeated-selection no-op, validate the selected DOM outside the timed window, and add a 10,000-row same-run TSRX/JSX regression guard.
- Part of #611.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` — **1,555 test files / 16,519 tests passed** (`NODE_OPTIONS=--no-experimental-webstorage` restores jsdom storage under local Node 26; CI uses Node 22/24).
- [x] targeted tests: `pnpm exec vitest run --project octane --project octane-prod packages/octane/tests/for.test.ts packages/octane/tests/transitions.test.ts packages/octane/tests/hydration/for-hydrate.test.ts packages/octane/tests/auto-memo.test.ts` — 236 passing tests; compiler suite: 852 passing tests.
- [x] `node benchmarks/bench.mjs --quick --ratios js-framework` — all eight framework targets and all nine applicable ratio guards pass; 10,000-row selection: **0.10 ms TSRX vs. 1.10 ms JSX**.
- [x] Browser precise coverage: **1,000 → 2** row-body executions, **1,000 → 0** survivor visits, and **5,052 → 57** observed production calls. Order-balanced baseline/candidate timing at 10,000 rows: **0.225 ms → 0.0125 ms (18× faster)**.
- [x] `node benchmarks/bench.mjs --quick codegen-size bundle-size` — eligible corpus adds 4 gzip bytes; a noneligible TodoMVC app and framework chunks are byte-for-byte identical to upstream HEAD.

## Risk / follow-ups

- Specialization is intentionally restricted to production-only, host-only, explicitly keyed `@for` rows with one static-arm class comparison. JSX `.map()` and more general selection expressions remain future work.
- Existing global codegen/bundle ratio ceilings are stale on upstream HEAD itself: the untouched HEAD compiler already measures `26,530 / 24,722 = 1.073×` against the historical `1.04×` ceiling. The new same-run selection guard passes, and nonparticipating applications pay zero shipped bytes.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compiler emission and `@for` runtime reconciliation for a narrow, proof-gated pattern; fallbacks and broad tests limit blast radius, but incorrect proofs could cause stale row UI.
> 
> **Overview**
> Adds a **compiler-proven keyed selection fast path** for production `@for` rows where the host root’s sole `class`/`className` is a static ternary comparing a captured parent value to the row’s authored key (`selected === item.id` or the reverse). Eligible lists emit tree-shakable **`keyedForBlock`** (not `forBlock`) and encode the selection dependency in `forBlock` flags; everything else keeps ordinary keyed reconciliation.
> 
> **Runtime:** When the items snapshot and non-selection deps are unchanged, **`tryUpdateKeyedSelection`** re-invokes only the blocks for the old and new selected keys instead of walking the full list. Transitions, hydration, iterable identity changes, extra captures of `selected`, shared bindings, and mismatched key vs selection property **fail closed** to full `forBlock` behavior.
> 
> **Benchmarks:** `select` alternates rows so timing isn’t a no-op; new **`select_lots`** on 10k rows plus an untimed DOM selection gate; **`ratios.json`** adds a same-run TSRX vs JSX ceiling for `select_lots`.
> 
> **Tests:** New fixtures and cases cover DOM identity, custom keys, hydration, reorder/remove, immutable item updates, and selection during suspended transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faaea44c559580fed0a1ab74df098dfb178fbf52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->