### PR TITLE
fix(lynx-examples): let the gallery list fill its wrapper

### DIFF
--- a/packages/rspeedy-plugin-octane/examples/gallery/src/Gallery.lynx.tsrx
+++ b/packages/rspeedy-plugin-octane/examples/gallery/src/Gallery.lynx.tsrx
@@ -11,6 +11,11 @@ interface GalleryScrollDetail {
 	deltaY: number;
 	scrollTop: number;
 	scrollHeight: number;
+	/**
+ * The list's own height in px. Native engines report it; Lynx for Web does
+ * not, so treat it as optional and fall back to the page height.
+ */
+	listHeight?: number;
 }
 
 export function NiceScrollbarMTS({
@@ -35,7 +40,15 @@ export function Gallery({ pictureData }: { pictureData: Picture[] }) @{
 		if (
 			scrollbar === null || scrollbar === undefined || gallery === null || gallery === undefined
 		) return;
-		const listHeight = SystemInfo.pixelHeight / SystemInfo.pixelRatio - 48;
+		// The viewport the scrollbar maps onto is the list's own box. Native
+		// engines report it directly; Lynx for Web does not, and there the list
+		// fills the page, so the page height is the same number.
+		//
+		// Deriving it from SystemInfo *minus a fixed 48px* — as this example used
+		// to — assumed a full-screen page behind Explorer's title bar. That was
+		// wrong on Web, wrong in Explorer's fullscreen mode, and it also left the
+		// list 48px short of its wrapper, which is where the black band came from.
+		const listHeight = event.detail.listHeight ?? SystemInfo.pixelHeight / SystemInfo.pixelRatio;
 		const scrollbarHeight = listHeight * (listHeight / event.detail.scrollHeight);
 		const scrollbarTop = listHeight * (event.detail.scrollTop / event.detail.scrollHeight);
 		__AddInlineStyle(scrollbar, 'height', scrollbarHeight + 'px');

--- a/packages/rspeedy-plugin-octane/examples/gallery/src/app.css
+++ b/packages/rspeedy-plugin-octane/examples/gallery/src/app.css
@@ -53,7 +53,7 @@
 	padding-bottom: 20px;
 	padding-left: 20px;
 	padding-right: 20px;
-	height: calc(100% - 48px);
+	height: 100%;
 	list-main-axis-gap: 10px;
 	list-cross-axis-gap: 10px;
 }


### PR DESCRIPTION
## Summary

The gallery example left a 48px black band under the grid in every environment.

## Why

`.list` was `height: calc(100% - 48px)` inside a `.gallery-wrapper` that is
`height: 100%` with a black background, and the main-thread scrollbar derived its
viewport from `SystemInfo.pixelHeight / SystemInfo.pixelRatio - 48`.

That 48 is **Lynx Explorer's title bar** — the upstream tutorial's QR schema turns
it on with `?bar_color=000000&back_button_style=dark&title=Popular Furniture`. But
`100%` is already the page area *below* that bar, so the example subtracted it a
second time. The band therefore appeared everywhere:

- on Lynx for Web, where there is no title bar at all;
- in Explorer's fullscreen mode, which this repo's QR uses (`?fullscreen=true`);
- and under the title bar itself, since a shorter list does not move content out
  from under a *top* bar anyway.

The constant has been there since `lynx-examples`' initial commit and no header
element was ever rendered, so this is inherited rather than introduced here.

## Changes

- `.list` fills its wrapper (`height: 100%`).
- The scrollbar takes its viewport from `event.detail.listHeight`, the list's own
  box, instead of guessing from the screen. Native engines report it; Lynx for Web
  does not (it is absent from `@lynx-js/web-core`'s bundle, matching the type's
  `@Android @iOS @Harmony @PC` annotation), and there the list fills the page, so
  the page height is the same number and serves as the fallback.

## Validation

- [x] `pnpm format:files`
- [x] `pnpm lynx:demo:typecheck`
- [x] targeted tests: `rspeedy-plugin` (62 passed)
- [ ] `pnpm test` — not run in full; the change is one example.

Measured through `@lynx-js/web-core` in headless Chromium:

| | before | after |
| --- | --- | --- |
| wrapper height | 700 | 700 |
| list height | 652 | **700** |
| band at bottom | **48px** | **0** |
| scrollbar inline style | `height: 64.6px; top: 55.4px` | `height: 69.3px; top: 59.5px` |

The first cut used `event.detail.listHeight` alone and silently broke the
scrollbar on Web — `listHeight` is undefined there, so the maths went `NaN` and
no inline style was written at all. That is why the fallback exists.

## Risk / follow-ups

- The same defect is in `lynx-examples` (ReactLynx) and `vue-lynx`, and both
  websites quote the CSS literally in their gallery tutorials. Companion PRs
  follow.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the rspeedy gallery example (CSS + scroll handler); no framework or production runtime changes.
> 
> **Overview**
> Fixes a **48px black band** under the gallery grid by stopping a double subtraction of Lynx Explorer’s title-bar height.
> 
> **`.list`** now uses **`height: 100%`** instead of **`calc(100% - 48px)`**, so the waterfall list fills the black **`gallery-wrapper`**.
> 
> The main-thread scrollbar uses **`event.detail.listHeight`** when the engine provides it, with **`SystemInfo.pixelHeight / SystemInfo.pixelRatio`** as the Lynx-for-Web fallback (no **`listHeight`** there). Scrollbar sizing and bottom-edge auto-scroll use that viewport instead of **`SystemInfo` minus 48px**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 172ace3a654372a434c4bf12b0d2cec07efa464d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->