### PR TITLE
fix(ci): repair PR label workflow failures

### DIFF
--- a/.claude/skills/create-a-pr/SKILL.md
+++ b/.claude/skills/create-a-pr/SKILL.md
@@ -173,10 +173,11 @@ from a maintainer.
 ## Labels
 
 Do not apply labels. Both are applied by the bot above: the type label (`feat`,
-`fix`, `docs`, `test`, `perf`, `refactor`, `chore`, `ci`) from the PR title, and
-`agent-authored` from the box. Retitling moves the type label, and a title the
-regex cannot read leaves the PR unlabelled, which is the signal to fix the title.
-`bug` and `enhancement` belong to issues.
+`fix`, `docs`, `test`, `perf`, `refactor`, `chore`, `ci`) from the PR title, with
+the type-prefixed head branch as a fallback, and `agent-authored` from the box.
+Retitling to another supported type moves the type label. A title and branch the
+parser cannot read leave the PR unlabelled. `bug` and `enhancement` belong to
+issues.
 
 ## Final response
 

--- a/.cursor/skills/create-a-pr/SKILL.md
+++ b/.cursor/skills/create-a-pr/SKILL.md
@@ -170,10 +170,11 @@ from a maintainer.
 ## Labels
 
 Do not apply labels. Both are applied by the bot above: the type label (`feat`,
-`fix`, `docs`, `test`, `perf`, `refactor`, `chore`, `ci`) from the PR title, and
-`agent-authored` from the box. Retitling moves the type label, and a title the
-regex cannot read leaves the PR unlabelled, which is the signal to fix the title.
-`bug` and `enhancement` belong to issues.
+`fix`, `docs`, `test`, `perf`, `refactor`, `chore`, `ci`) from the PR title, with
+the type-prefixed head branch as a fallback, and `agent-authored` from the box.
+Retitling to another supported type moves the type label. A title and branch the
+parser cannot read leave the PR unlabelled. `bug` and `enhancement` belong to
+issues.
 
 ## Final response
 

--- a/.gemini/skills/create-a-pr/SKILL.md
+++ b/.gemini/skills/create-a-pr/SKILL.md
@@ -173,10 +173,11 @@ from a maintainer.
 ## Labels
 
 Do not apply labels. Both are applied by the bot above: the type label (`feat`,
-`fix`, `docs`, `test`, `perf`, `refactor`, `chore`, `ci`) from the PR title, and
-`agent-authored` from the box. Retitling moves the type label, and a title the
-regex cannot read leaves the PR unlabelled, which is the signal to fix the title.
-`bug` and `enhancement` belong to issues.
+`fix`, `docs`, `test`, `perf`, `refactor`, `chore`, `ci`) from the PR title, with
+the type-prefixed head branch as a fallback, and `agent-authored` from the box.
+Retitling to another supported type moves the type label. A title and branch the
+parser cannot read leave the PR unlabelled. `bug` and `enhancement` belong to
+issues.
 
 ## Final response
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,7 +26,8 @@ diff; either form keeps the label workflow successful.
 
 A bot reads this box and applies the label, so nothing here needs repository
 permissions and it works the same from a fork. The type label comes from the
-conventional-commit type in the title. Do not apply either by hand.
+conventional-commit type in the title, with the type-prefixed head branch as a
+fallback. Do not apply either by hand.
 
 When updating an existing pull request, merge this template content into the
 current body. Preserve every bot-managed HTML comment region and all existing

--- a/.github/skills/create-a-pr/SKILL.md
+++ b/.github/skills/create-a-pr/SKILL.md
@@ -173,10 +173,11 @@ from a maintainer.
 ## Labels
 
 Do not apply labels. Both are applied by the bot above: the type label (`feat`,
-`fix`, `docs`, `test`, `perf`, `refactor`, `chore`, `ci`) from the PR title, and
-`agent-authored` from the box. Retitling moves the type label, and a title the
-regex cannot read leaves the PR unlabelled, which is the signal to fix the title.
-`bug` and `enhancement` belong to issues.
+`fix`, `docs`, `test`, `perf`, `refactor`, `chore`, `ci`) from the PR title, with
+the type-prefixed head branch as a fallback, and `agent-authored` from the box.
+Retitling to another supported type moves the type label. A title and branch the
+parser cannot read leave the PR unlabelled. `bug` and `enhancement` belong to
+issues.
 
 ## Final response
 

--- a/.github/workflows/draft-agent-prs.yml
+++ b/.github/workflows/draft-agent-prs.yml
@@ -26,6 +26,7 @@ jobs:
     # `pull_request_target` is what gives a fork pull request a writable token.
     # Nothing here checks out or executes the pull request's code.
     permissions:
+      contents: write
       issues: read
       pull-requests: write
 
@@ -33,11 +34,10 @@ jobs:
       - name: Convert an agent-authored pull request back to draft
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
-          # Draft state is not repository content, so the job stays off
-          # `contents`. GITHUB_TOKEN has been reported to answer draft mutations
-          # with "Resource not accessible by integration" (actions/toolkit#1165)
-          # and GraphQL publishes no permission table to check that against, so
-          # an app or PAT secret takes over wherever the repository defines one.
+          # GitHub's GraphQL permission mapping requires `contents: write`
+          # alongside `pull-requests: write` for this mutation, even though no
+          # repository content changes. An app or PAT can still take over where
+          # the repository defines one.
           github-token: ${{ secrets.DRAFT_PR_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -3,7 +3,7 @@ name: Label PR
 # Both labels are things the author cannot apply themselves: a fork
 # contributor's token has no rights to label the base repository at all. A
 # `pull_request_target` job has the write token, so the author only has to state
-# the facts, in the title and in the body, and this turns them into labels.
+# the facts, in the title or branch and in the body, and this turns them into labels.
 on:
   pull_request_target:
     types: [opened, reopened, edited]
@@ -22,6 +22,7 @@ jobs:
     # `pull_request_target` is what gives a fork pull request a writable token.
     # Nothing here checks out or executes the pull request's code.
     permissions:
+      contents: write
       issues: read
       pull-requests: write
 
@@ -49,10 +50,13 @@ jobs:
             const add = [];
             const remove = [];
 
-            const titled = /^\s*([a-z]+)\s*(?:\([^)]*\))?\s*!?:/.exec(pull.title);
-            const type = titled && TYPES.includes(titled[1]) ? titled[1] : null;
-            // An invalid retitle must not leave a stale type behind. No type
-            // label is the visible signal that the title needs fixing.
+            const titled = /^\s*([a-z]+)(?:\s*(?:\([^)]*\))?\s*!?:|\/)/.exec(pull.title);
+            const branched = /^([a-z]+)\//.exec(pull.head.ref);
+            const titleType = titled && TYPES.includes(titled[1]) ? titled[1] : null;
+            const branchType = branched && TYPES.includes(branched[1]) ? branched[1] : null;
+            const type = titleType ?? branchType;
+            // Prefer the title, then use the repository's type-prefixed branch
+            // convention when GitHub supplied a plain or branch-shaped title.
             remove.push(
               ...current.filter((name) => name !== type && TYPES.includes(name)),
             );
@@ -62,8 +66,9 @@ jobs:
               if (!current.includes(type)) add.push(type);
             } else {
               core.notice(
-                `#${number} has no conventional-commit type in its title, so no type label was applied. ` +
-                  `Retitle it as one of ${TYPES.join(", ")} and this runs again.`,
+                `#${number} has no conventional-commit type in its title and no supported type prefix ` +
+                  `in its head branch, so no type label was applied. Retitle it or prefix the branch ` +
+                  `with one of ${TYPES.join(", ")} and this runs again.`,
               );
             }
 
@@ -139,11 +144,10 @@ jobs:
         if: always()
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
-          # Draft state is not repository content, so the job stays off
-          # `contents`. GITHUB_TOKEN has been reported to answer draft mutations
-          # with "Resource not accessible by integration" (actions/toolkit#1165)
-          # and GraphQL publishes no permission table to check that against, so
-          # an app or PAT secret takes over wherever the repository defines one.
+          # GitHub's GraphQL permission mapping requires `contents: write`
+          # alongside `pull-requests: write` for this mutation, even though no
+          # repository content changes. An app or PAT can still take over where
+          # the repository defines one.
           github-token: ${{ secrets.DRAFT_PR_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;

--- a/.rulesync/skills/create-a-pr/SKILL.md
+++ b/.rulesync/skills/create-a-pr/SKILL.md
@@ -172,10 +172,11 @@ from a maintainer.
 ## Labels
 
 Do not apply labels. Both are applied by the bot above: the type label (`feat`,
-`fix`, `docs`, `test`, `perf`, `refactor`, `chore`, `ci`) from the PR title, and
-`agent-authored` from the box. Retitling moves the type label, and a title the
-regex cannot read leaves the PR unlabelled, which is the signal to fix the title.
-`bug` and `enhancement` belong to issues.
+`fix`, `docs`, `test`, `perf`, `refactor`, `chore`, `ci`) from the PR title, with
+the type-prefixed head branch as a fallback, and `agent-authored` from the box.
+Retitling to another supported type moves the type label. A title and branch the
+parser cannot read leave the PR unlabelled. `bug` and `enhancement` belong to
+issues.
 
 ## Final response
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -256,9 +256,9 @@ Octane is 0.x, so every changeset stays on the `patch` track. `major` and
   validate it. Call out anything you deliberately left unverified.
 - Every pull request carries exactly one type label: `feat`, `fix`, `docs`,
   `test`, `perf`, `refactor`, `chore`, or `ci`. You do not apply it;
-  `.github/workflows/label-pr.yml` reads it off the title, so a
-  conventional-commit title is all it takes. `bug` and `enhancement` belong to
-  issues.
+  `.github/workflows/label-pr.yml` reads it off a conventional-commit title and
+  falls back to the `feat/…`, `fix/…`, or other type-prefixed head branch when
+  the title does not declare one. `bug` and `enhancement` belong to issues.
 
 CI intentionally runs nothing while a pull request is a draft and starts on the
 `ready_for_review` event. From there it runs the sharded test suite on Node 22 and

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -455,9 +455,9 @@ describe('Agent pull request draft policy', () => {
 		assert.match(draftWorkflow, /^ {6}issues: read$/m);
 		assert.match(draftWorkflow, /contains\(github\.event\.pull_request\.labels\.\*\.name/);
 		assert.doesNotMatch(draftWorkflow, /actions\/checkout/);
-		// Converting to draft changes no repository content, and the fallback
-		// secret is the answer to a token that cannot run the mutation.
-		assert.doesNotMatch(draftWorkflow, /contents: write/);
+		// GitHub's GraphQL permission mapping requires both grants even though
+		// converting a pull request to draft does not change repository content.
+		assert.match(draftWorkflow, /^ {6}contents: write$/m);
 		assert.match(
 			draftWorkflow,
 			/github-token: \$\{\{ secrets\.DRAFT_PR_TOKEN \|\| secrets\.GITHUB_TOKEN \}\}/,
@@ -486,6 +486,7 @@ describe('Pull request labels', () => {
 
 	function runLabeller({
 		title = 'chore: a thing',
+		headRef = 'topic/a-thing',
 		body = `## Provenance\n\n${EMPTY}\n`,
 		labels = [],
 		state = 'open',
@@ -504,6 +505,7 @@ describe('Pull request labels', () => {
 			state,
 			title,
 			body,
+			head: { ref: headRef },
 			labels: labels.map((name) => ({ name })),
 		};
 		const github = {
@@ -573,9 +575,23 @@ describe('Pull request labels', () => {
 		}
 	});
 
+	test('falls back to a type-prefixed title or head branch', async () => {
+		for (const [title, headRef, type] of [
+			['fix/gallery-list-fills-wrapper', 'topic/gallery-list', 'fix'],
+			['Add Solana bindings', 'feat/solana-react-binding', 'feat'],
+		]) {
+			const { added, removed, failures } = await runLabeller({ title, headRef });
+
+			assert.deepEqual(added, [type], `${title} (${headRef})`);
+			assert.deepEqual(removed, []);
+			assert.deepEqual(failures, []);
+		}
+	});
+
 	test('moves the type label when a pull request is retitled', async () => {
 		const { added, removed } = await runLabeller({
 			title: 'fix(compiler): render the non-JSX arm',
+			headRef: 'feat/old-compiler-work',
 			labels: ['feat', 'blocked'],
 		});
 
@@ -791,6 +807,7 @@ describe('Pull request labels', () => {
 		);
 		assert.match(labelWorkflow, /^ {6}issues: read$/m);
 		assert.match(labelWorkflow, /^ {6}pull-requests: write$/m);
+		assert.match(labelWorkflow, /^ {6}contents: write$/m);
 		assert.match(
 			labelWorkflow,
 			/- name: Convert an agent-authored pull request back to draft[\s\S]*?if: always\(\)/,
@@ -800,7 +817,6 @@ describe('Pull request labels', () => {
 			/github-token: \$\{\{ secrets\.DRAFT_PR_TOKEN \|\| secrets\.GITHUB_TOKEN \}\}/,
 		);
 		assert.doesNotMatch(labelWorkflow, /actions\/checkout/);
-		assert.doesNotMatch(labelWorkflow, /contents: write/);
 	});
 });
 


### PR DESCRIPTION
## Summary

- Make PR type labeling accept scoped conventional titles and type-prefixed title or head-branch fallbacks.
- Give the agent-draft mutation the complete workflow permission set so a successful label run does not fail afterward.
- Keep contributor documentation and generated agent skills aligned with the workflow behavior.

## Why

The label step in the reported PR successfully applied `fix`, but the same job then failed while converting the `agent-authored` PR to draft with `Resource not accessible by integration`. Plain GitHub-generated titles and branches such as `fix/...` or `feat/...` also need a reliable type fallback.

Reported run: https://github.com/octanejs/octane/actions/runs/31198718208/job/92933498127?pr=616

## Changes

- Prefer supported conventional-commit or type-prefixed PR titles, then fall back to the head branch prefix.
- Preserve title precedence when the title and branch declare different supported types.
- Grant `contents: write` alongside `pull-requests: write` to both workflows that call `convertPullRequestToDraft`; neither workflow checks out or executes PR code.
- Add regression coverage for title/branch parsing and the draft-mutation permission contract.

## Validation

- [ ] `pnpm format:check` — not run; targeted formatting check passed.
- [ ] `pnpm typecheck` — not run; no TypeScript or package API changed.
- [ ] `pnpm test` — not run; focused workflow suite passed.
- [x] targeted tests: `pnpm ci:workflow:test` (73 passed)
- [x] `pnpm format:files:check .github/workflows/label-pr.yml .github/workflows/draft-agent-prs.yml scripts/ci-workflow.test.mjs`
- [x] `pnpm rules:check`
- [x] `pnpm sync`
- [x] `git diff --check`

## Risk / follow-ups

- The draft mutation now receives `contents: write`, but the workflows remain pinned, do not check out code, and do not execute pull-request-controlled code.
- Live verification of the GitHub permission change requires the workflow to run from the merged base revision.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Widens `pull_request_target` workflow token permissions to `contents: write`, though jobs still avoid checking out or running PR-controlled code; live GitHub behavior should be confirmed after merge.
> 
> **Overview**
> Fixes **PR automation** so type labeling and agent **draft conversion** can finish in one run instead of failing after labels apply.
> 
> **Type labels** now come from scoped conventional titles, **type-prefixed titles** (e.g. `fix/…`), or the **head branch prefix** when the title does not declare a type; the title still wins when title and branch disagree.
> 
> Both **`label-pr.yml`** and **`draft-agent-prs.yml`** grant **`contents: write`** alongside **`pull-requests: write`** for the `convertPullRequestToDraft` GraphQL mutation (no checkout or execution of PR code). Contributor docs, the PR template, and generated **create-a-pr** skills describe the branch fallback; **`ci-workflow.test.mjs`** adds regression tests for parsing and permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc6386cc3a08fa40ff557c895034479770afa86e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->