### PR TITLE
perf: lower proven JSX components through compiled renderers

### DIFF
--- a/.changeset/tsx-component-dispatch-lowering.md
+++ b/.changeset/tsx-component-dispatch-lowering.md
@@ -1,0 +1,7 @@
+---
+'octane': patch
+---
+
+Reduce production JSX rendering overhead for compiler-proven nested components
+while preserving authored component returns, hooks, context, hydration, and
+existing public APIs.

--- a/benchmarks/signal-favoring/README.md
+++ b/benchmarks/signal-favoring/README.md
@@ -170,4 +170,10 @@ teardown work at the current production levels while allowing every count to
 fall. Every row requires live production-bundle coverage. C1/C51/C91 must still
 perform exactly one text write, and the ancestor-first batch exactly ten.
 
+The TSX chain's private, hookless components reuse their existing compiled host
+renderers through lightweight component slots. Its shallow update is limited to
+20 block renders, 10 full slots, 100 total slots, 9 child slots, and 19
+descriptors. Stateful or escaping components retain normal component boundaries
+and inspectable return values.
+
 Default: 5 warmups + 20 iters. Pass an integer to `bench` to override iters.

--- a/benchmarks/signal-favoring/work.mjs
+++ b/benchmarks/signal-favoring/work.mjs
@@ -75,38 +75,38 @@ const GATES = {
 	},
 	'octane-jsx': {
 		mount: {
-			maxFullSlotCalls: 101,
+			maxFullSlotCalls: 11,
 			maxSlotCalls: 101,
-			max: { renderBlock: 201, componentSlot: 101, childSlot: 109, createElement: 200 },
+			max: { renderBlock: 21, componentSlot: 11, childSlot: 19, createElement: 20 },
 		},
 		bump_shallow: {
-			maxFullSlotCalls: 100,
-			maxSlotCalls: 100,
-			max: { renderBlock: 200, componentSlot: 100, childSlot: 99, createElement: 199 },
-			exact: { setText: 1 },
-		},
-		bump_middle: {
-			maxFullSlotCalls: 50,
-			maxSlotCalls: 50,
-			max: { renderBlock: 100, componentSlot: 50, childSlot: 49, createElement: 99 },
-			exact: { setText: 1 },
-		},
-		bump_deep: {
 			maxFullSlotCalls: 10,
-			maxSlotCalls: 10,
+			maxSlotCalls: 100,
 			max: { renderBlock: 20, componentSlot: 10, childSlot: 9, createElement: 19 },
 			exact: { setText: 1 },
 		},
+		bump_middle: {
+			maxFullSlotCalls: 5,
+			maxSlotCalls: 50,
+			max: { renderBlock: 10, componentSlot: 5, childSlot: 4, createElement: 9 },
+			exact: { setText: 1 },
+		},
+		bump_deep: {
+			maxFullSlotCalls: 1,
+			maxSlotCalls: 10,
+			max: { renderBlock: 2, componentSlot: 1, childSlot: 0, createElement: 1 },
+			exact: { setText: 1 },
+		},
 		bump_batched: {
-			maxFullSlotCalls: 100,
+			maxFullSlotCalls: 10,
 			maxSlotCalls: 100,
-			max: { renderBlock: 200, componentSlot: 100, childSlot: 99, createElement: 199 },
+			max: { renderBlock: 20, componentSlot: 10, childSlot: 9, createElement: 19 },
 			exact: { setText: 10 },
 		},
 		unmount: {
 			maxFullSlotCalls: 0,
 			maxSlotCalls: 0,
-			max: { unmountBlock: 201, unmountScope: 201 },
+			max: { unmountBlock: 21, unmountScope: 111 },
 		},
 	},
 };

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -3716,6 +3716,65 @@ function collectImmutableModuleFunctions(body) {
 	return declared;
 }
 
+// Omitting a JSX descriptor also omits its live `Component.defaultProps` read.
+// Only private declarations whose every reference is an immediately rendered,
+// attribute-free host child can therefore bypass descriptor construction. JSX
+// descriptors returned/stored/passed elsewhere expose their `.type`, so those
+// sites count as escapes even though their tag looks equally static.
+function collectPrivateUnescapedComponents(body, ctx) {
+	const candidates = new Set();
+	for (const statement of body) {
+		if (
+			statement.type === 'FunctionDeclaration' &&
+			statement.id?.type === 'Identifier' &&
+			ctx.componentInfo.get(statement.id.name)?.returnJsx === true &&
+			ctx.moduleFunctionDeclarations.has(statement.id.name)
+		) {
+			candidates.add(statement.id.name);
+		}
+	}
+	if (candidates.size === 0) return candidates;
+
+	const allowed = new Set();
+	const visitHost = (host) => {
+		for (const child of host.children || []) {
+			if (child?.type !== 'Element' && child?.type !== 'JSXElement') continue;
+			if (!isComponentTag(child)) {
+				visitHost(child);
+				continue;
+			}
+			const name = tagBindingName(child);
+			const attrs = child.attributes || child.openingElement?.attributes || [];
+			if (name !== null && candidates.has(name) && attrs.length === 0 && !child.children?.length) {
+				allowed.add(child);
+			}
+		}
+	};
+	for (const info of ctx.componentInfo.values()) {
+		if (!info.returnJsx) continue;
+		for (const statement of info.node.body.body || []) {
+			if (statement.type === 'ReturnStatement' && isPlainHostRoot(statement.argument)) {
+				visitHost(statement.argument);
+			}
+		}
+	}
+
+	// An array deliberately does not introduce a synthetic module Block scope:
+	// sibling function references must remain free for the escape proof.
+	const escaped = collectFreeIdentifiers(body, [], allowed);
+	for (const name of candidates) {
+		if (escaped.has(name)) {
+			candidates.delete(name);
+			continue;
+		}
+		// A declaration binds its own name inside its body. Scan that disjoint
+		// subtree once more so self-assigned properties cannot hide behind it.
+		const declaration = ctx.moduleFunctionDeclarations.get(name);
+		if (collectFreeIdentifiers(declaration.body, [], allowed).has(name)) candidates.delete(name);
+	}
+	return candidates;
+}
+
 // Conservative semantic boundary for compiler-owned component-region memoization.
 // The cached region assumes React Compiler's pure-render / immutable-snapshot
 // contract, but still fails closed for constructs whose commit or retry behavior
@@ -6425,6 +6484,9 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 			});
 		}
 	}
+	ctx.privateUnescapedComponents = ctx.autoMemo
+		? collectPrivateUnescapedComponents(ast.body, ctx)
+		: new Set();
 	for (const [, info] of ctx.componentInfo) {
 		const compNode = info.node;
 		const locals = collectComponentLocals(compNode);
@@ -13535,6 +13597,30 @@ function compileReturnJsxFunction(node, ctx, options) {
 		ctx.currentAutoMemoCallsitesSafe = prevAutoMemoCallsitesSafe;
 		ctx.currentMapTemps = prevMapTemps;
 	}
+	if (
+		ctx.autoMemo &&
+		ctx.privateUnescapedComponents.has(name) &&
+		(node.params?.length ?? 0) === 0 &&
+		(node.body.body?.length ?? 0) === 1 &&
+		isPlainHostRoot(node.body.body[0]?.argument) &&
+		compInlinedSubs.length === 0 &&
+		mapTemps.length === 0 &&
+		cssHash === null
+	) {
+		const descriptor = newStatements[0]?.argument;
+		const renderer = descriptor?.arguments?.[0];
+		const props = descriptor?.arguments?.[1];
+		if (
+			descriptor?.type === 'CallExpression' &&
+			descriptor.callee?.type === 'Identifier' &&
+			descriptor.callee.name === '_$createElement' &&
+			descriptor.arguments.length === 2 &&
+			renderer?.type === 'Identifier' &&
+			isStaticFragmentRendererProps(props, ctx)
+		) {
+			ctx.componentInfo.get(name).staticFragmentRenderer = { name: renderer.name, props };
+		}
+	}
 	// The rebuilt function shell maps to the authored declaration. Hoisted
 	// helper fns (compInlinedSubs — filled by the statement mapping above) are
 	// function DECLARATION nodes embedded at the top of the body, matching the
@@ -13714,6 +13800,57 @@ function objectProp(hn, valNode) {
 	return b.prop('init', b.id(hn), valNode);
 }
 
+// A bare, immutable same-module component needs no descriptor when its JSX is
+// consumed immediately by a returned host. Keep every value/props boundary on
+// the ordinary path: only this attribute-free call can remain in the template
+// without moving authored expression evaluation into its hoisted renderer.
+function isStaticFragmentRendererProps(props, ctx) {
+	if (props?.type !== 'ObjectExpression') return false;
+	for (const property of props.properties || []) {
+		if (
+			property.type !== 'Property' ||
+			property.kind !== 'init' ||
+			property.computed ||
+			property.method ||
+			property.shorthand
+		) {
+			return false;
+		}
+		const descriptor = property.value;
+		const component = descriptor?.arguments?.[0];
+		const componentProps = descriptor?.arguments?.[1];
+		if (
+			descriptor?.type !== 'CallExpression' ||
+			descriptor.callee?.type !== 'Identifier' ||
+			descriptor.callee.name !== '_$createElement' ||
+			descriptor.arguments.length !== 2 ||
+			component?.type !== 'Identifier' ||
+			!ctx.privateUnescapedComponents.has(component.name) ||
+			componentProps?.type !== 'ObjectExpression' ||
+			componentProps.properties.length !== 0
+		) {
+			return false;
+		}
+	}
+	return true;
+}
+
+function isStaticReturnedFragmentComponent(node, ctx) {
+	if (!ctx.autoMemo || ctx._foldCtx?.immediateRenderedOutput !== true) return false;
+	const name = tagBindingName(node);
+	if (
+		name === null ||
+		ctx.currentComponentLocals == null ||
+		ctx.currentComponentLocals.has(name) ||
+		!ctx.privateUnescapedComponents.has(name) ||
+		ctx.componentInfo.get(name)?.staticFragmentRenderer === undefined
+	) {
+		return false;
+	}
+	const attrs = node.attributes || node.openingElement?.attributes || [];
+	return attrs.length === 0 && (node.children || []).length === 0;
+}
+
 // Walk a host element or JSX fragment, replacing each DYNAMIC part (an
 // attribute/child expression) with `props.hN` and collecting
 // `{ hN: <originalExpr> }` into `holeProps`. Static structure (tag, literal attrs,
@@ -13831,6 +13968,22 @@ function extractFragment(node, ctx, holeProps, parentNs = 'html') {
 				// a hole too, since it may be a local/member/dynamic tag that the hoisted
 				// renderer cannot reference directly.
 				newChildren.push(extractFragmentComponent(child, ctx, holeProps, childNs));
+			} else if (isComponentTag(child) && isStaticReturnedFragmentComponent(child, ctx)) {
+				// The original function remains callable and still returns its authored
+				// descriptor. Only this nonescaping call can reuse its already-hoisted,
+				// hookless fragment directly through the existing lite component ABI.
+				const extracted = extractFragment(child, ctx, holeProps, childNs);
+				newChildren.push({
+					...extracted,
+					openingElement: {
+						...extracted.openingElement,
+						metadata: {
+							...extracted.openingElement.metadata,
+							staticFragmentRenderer: ctx.componentInfo.get(tagBindingName(child))
+								.staticFragmentRenderer,
+						},
+					},
+				});
 			} else if (isComponentTag(child)) {
 				const hn = `h${holeProps.length}`;
 				holeProps.push(
@@ -20770,7 +20923,10 @@ function makeCompCall(
 ) {
 	const id = ctx.nextHelperId++;
 	const compName = tagBindingName(node);
-	const compNode = tagExprNode(node);
+	const staticFragmentRenderer = node.openingElement?.metadata?.staticFragmentRenderer;
+	const compNode = staticFragmentRenderer
+		? inheritOriginLoc(b.id(staticFragmentRenderer.name), node.openingElement?.name || node.id)
+		: tagExprNode(node);
 	// `</Card>` emits nothing — lend it the opening name's generated ranges so a
 	// closing tag is reachable for components the way it is for host elements.
 	registerOriginAlias(ctx, node.closingElement?.name, node.id || node.openingElement?.name);
@@ -20887,7 +21043,7 @@ function makeCompCall(
 	}
 
 	// The props object as a node; the call-site emit embeds it directly.
-	const propsExpr = inheritOriginLoc(b.object(propNodes), node);
+	const propsExpr = staticFragmentRenderer?.props ?? inheritOriginLoc(b.object(propNodes), node);
 
 	// Design (c) v0: decide whether the call site can use componentSlotLite
 	// (Scope-only, no Block / no Comment markers / no CompSlot wrapper).
@@ -20918,7 +21074,12 @@ function makeCompCall(
 	// elides iff the callee carries the definition-site `$$singleRoot` stamp
 	// (docs/comment-marker-elision-plan.md M1).
 	let maybeSingleRoot = false;
-	if (ctx.componentInfo && compName !== null) {
+	if (staticFragmentRenderer) {
+		// The renderer is already a void, hookless component body. A memo boundary
+		// would force a full Block and could hide a hookful descendant's update.
+		liteEligible = true;
+		voidComponent = true;
+	} else if (ctx.componentInfo && compName !== null) {
 		const callSiteOk = !hasSpreadProp && !hasChildrenProp;
 		const calleeInfo = ctx.componentInfo.get(compName);
 		if (calleeInfo) {

--- a/packages/octane/tests/_fixtures/jsx-context-children.tsx
+++ b/packages/octane/tests/_fixtures/jsx-context-children.tsx
@@ -1,4 +1,17 @@
-import { useState, createContext, use } from 'octane';
+/** @jsxImportSource octane */
+
+import {
+	Children,
+	ErrorBoundary,
+	Suspense,
+	cloneElement,
+	createContext,
+	isValidElement,
+	use,
+	useState,
+	type ElementDescriptor,
+	type OctaneNode,
+} from 'octane';
 
 // Regression fixtures for octane's JSX (`.tsx`) backwards-compat path:
 //   1. `<Ctx.Provider value={…}>` with an ELEMENT-descriptor child (not a render-fn)
@@ -116,5 +129,298 @@ export function InputListApp() {
 				<input className="li" data-idx={i as number} key={i as number} />
 			))}
 		</div>
+	);
+}
+
+function DirectNestedLeaf() {
+	const theme = use(Ctx);
+	const [count, setCount] = useState(0);
+
+	return (
+		<button className="direct-nested-leaf" onClick={() => setCount((value) => value + 1)}>
+			{`${theme}:${count}`}
+		</button>
+	);
+}
+
+function DirectNestedHost(props: { label: string }) {
+	return (
+		<section className="direct-nested-host" data-label={props.label}>
+			<DirectNestedLeaf />
+		</section>
+	);
+}
+
+export function DirectNestedApp(props: { label: string; theme: string }) {
+	return (
+		<Ctx.Provider value={props.theme}>
+			<DirectNestedHost label={props.label} />
+		</Ctx.Provider>
+	);
+}
+
+function StaticNestedLeaf() {
+	return <span className="static-nested-leaf">static</span>;
+}
+
+function StaticNestedMiddle() {
+	return (
+		<div className="static-nested-middle">
+			<StaticNestedLeaf />
+		</div>
+	);
+}
+
+export function StaticNestedApp() {
+	return (
+		<section className="static-nested-root">
+			<i className="static-nested-before">before</i>
+			<StaticNestedMiddle />
+			<i className="static-nested-after">after</i>
+		</section>
+	);
+}
+
+function PrivateNestedLeaf() {
+	return <span className="private-nested-leaf">private</span>;
+}
+
+function PrivateNestedMiddle() {
+	return (
+		<div className="private-nested-middle">
+			<PrivateNestedLeaf />
+		</div>
+	);
+}
+
+export function PrivateNestedApp() {
+	return (
+		<section className="private-nested-root">
+			<i className="private-nested-before">before</i>
+			<PrivateNestedMiddle />
+			<i className="private-nested-after">after</i>
+		</section>
+	);
+}
+
+export function directNestedReturnValue() {
+	return StaticNestedLeaf();
+}
+
+export function directNestedMiddleReturnValue() {
+	return StaticNestedMiddle();
+}
+
+function DescriptorEscapedLeaf() {
+	return <span className="descriptor-escaped-leaf">descriptor</span>;
+}
+
+export function escapedNestedDescriptor() {
+	const child = <DescriptorEscapedLeaf />;
+	return child;
+}
+
+export function DescriptorEscapedApp() {
+	return (
+		<section className="descriptor-escaped-root">
+			<DescriptorEscapedLeaf />
+		</section>
+	);
+}
+
+function MixedNestedShell() {
+	return (
+		<div className="mixed-nested-shell">
+			<DirectNestedLeaf />
+		</div>
+	);
+}
+
+function MixedNestedHost() {
+	return (
+		<section className="mixed-nested-host">
+			<StaticNestedMiddle />
+			<MixedNestedShell />
+		</section>
+	);
+}
+
+export function MixedNestedApp(props: { theme: string }) {
+	return (
+		<Ctx.Provider value={props.theme}>
+			<MixedNestedHost />
+		</Ctx.Provider>
+	);
+}
+
+let nestedDefaultEvents: string[] = [];
+let nestedDefaultVersion = '';
+
+function DefaultPropsPureLeaf() {
+	return <span className="default-props-pure">pure</span>;
+}
+
+Object.defineProperty(DefaultPropsPureLeaf, 'defaultProps', {
+	configurable: true,
+	get() {
+		const theme = use(Ctx);
+		nestedDefaultEvents.push(`pure:${theme}:${nestedDefaultVersion}`);
+		return {};
+	},
+});
+
+function DefaultPropsStatefulLeaf(props: { label?: string }) {
+	const [count, setCount] = useState(0);
+
+	return (
+		<button className="default-props-stateful" onClick={() => setCount((value) => value + 1)}>
+			{`${props.label}:${count}`}
+		</button>
+	);
+}
+
+Object.defineProperty(DefaultPropsStatefulLeaf, 'defaultProps', {
+	configurable: true,
+	get() {
+		const theme = use(Ctx);
+		nestedDefaultEvents.push(`stateful:${theme}:${nestedDefaultVersion}`);
+		return { label: `${theme}:${nestedDefaultVersion}` };
+	},
+});
+
+function DefaultPropsNestedShell() {
+	return (
+		<div className="default-props-shell">
+			<DefaultPropsPureLeaf />
+			<DefaultPropsStatefulLeaf />
+		</div>
+	);
+}
+
+export function DefaultPropsNestedApp(props: { theme: string; version: string }) {
+	nestedDefaultVersion = props.version;
+
+	return (
+		<Ctx.Provider value={props.theme}>
+			<DefaultPropsNestedShell />
+		</Ctx.Provider>
+	);
+}
+
+export function resetNestedDefaultEvents() {
+	nestedDefaultEvents = [];
+}
+
+export function readNestedDefaultEvents() {
+	return nestedDefaultEvents.slice();
+}
+
+function FallbackPropLeaf(props: { label: string; kind: string }) {
+	return <span data-fallback-kind={props.kind}>{props.label}</span>;
+}
+
+function FallbackRefLeaf(props: { ref?: (node: HTMLButtonElement | null) => void }) {
+	return (
+		<button className="fallback-ref" ref={props.ref}>
+			ref
+		</button>
+	);
+}
+
+function FallbackKeyedLeaf() {
+	const [count, setCount] = useState(0);
+
+	return (
+		<button className="fallback-keyed" onClick={() => setCount((value) => value + 1)}>
+			{count}
+		</button>
+	);
+}
+
+function FallbackChildrenLeaf(props: { children: OctaneNode }) {
+	const child = Children.only(props.children) as ElementDescriptor;
+
+	return (
+		<div className="fallback-children" data-valid={String(isValidElement(child))}>
+			{cloneElement(child, {})}
+		</div>
+	);
+}
+
+export function NestedFallbackApp(props: {
+	label: string;
+	identity: string;
+	onRef: (node: HTMLButtonElement | null) => void;
+}) {
+	return (
+		<section className="nested-fallback-root">
+			<FallbackPropLeaf label={props.label} kind="attribute" />
+			<FallbackPropLeaf {...{ label: props.label, kind: 'spread' }} />
+			<FallbackRefLeaf ref={props.onRef} />
+			<FallbackKeyedLeaf key={props.identity} />
+			<FallbackChildrenLeaf>
+				<StaticNestedLeaf />
+			</FallbackChildrenLeaf>
+		</section>
+	);
+}
+
+export function EscapedNestedApp() {
+	const child = <StaticNestedLeaf />;
+	const inspected = Children.only(child) as ElementDescriptor;
+
+	return (
+		<section className="escaped-nested-root" data-valid={String(isValidElement(inspected))}>
+			{cloneElement(inspected, {})}
+		</section>
+	);
+}
+
+function ThrowingNestedLeaf() {
+	throw new Error('nested child failed');
+	return <span className="nested-unreachable">unreachable</span>;
+}
+
+function ThrowingNestedHost() {
+	return (
+		<div className="nested-error-host">
+			<ThrowingNestedLeaf />
+		</div>
+	);
+}
+
+export function NestedErrorApp() {
+	return (
+		<ErrorBoundary fallback={<strong className="nested-error-fallback">caught</strong>}>
+			<ThrowingNestedHost />
+		</ErrorBoundary>
+	);
+}
+
+const NestedPromiseContext = createContext<Promise<string> | null>(null);
+
+function SuspendingNestedLeaf() {
+	const promise = use(NestedPromiseContext);
+	if (promise === null) throw new Error('missing nested promise');
+	const value = use(promise);
+
+	return <span className="nested-resolved">{value}</span>;
+}
+
+function SuspendingNestedHost() {
+	return (
+		<div className="nested-suspense-host">
+			<SuspendingNestedLeaf />
+		</div>
+	);
+}
+
+export function NestedSuspenseApp(props: { promise: Promise<string> }) {
+	return (
+		<Suspense fallback={<span className="nested-pending">pending</span>}>
+			<NestedPromiseContext.Provider value={props.promise}>
+				<SuspendingNestedHost />
+			</NestedPromiseContext.Provider>
+		</Suspense>
 	);
 }

--- a/packages/octane/tests/jsx-context-children.test.ts
+++ b/packages/octane/tests/jsx-context-children.test.ts
@@ -1,15 +1,32 @@
-import { it, expect, vi } from 'vitest';
-import { flushSync } from '../src/index.js';
-import { mount } from './_helpers';
+import { describe, expect, it, vi } from 'vitest';
+import * as ServerRuntime from 'octane/server';
+import { flushSync, hydrateRoot, isValidElement } from '../src/index.js';
+import { act, mount } from './_helpers';
+import { loadServerFixture } from './_server-fixture';
 import {
+	DefaultPropsNestedApp,
+	DescriptorEscapedApp,
+	DirectNestedApp,
+	EscapedNestedApp,
+	MixedNestedApp,
+	NestedErrorApp,
+	NestedFallbackApp,
+	NestedSuspenseApp,
 	ProviderApp,
 	ReconcileApp,
 	InputApp,
 	InputListApp,
+	PrivateNestedApp,
+	StaticNestedApp,
 	bumpCount,
+	directNestedMiddleReturnValue,
+	directNestedReturnValue,
+	escapedNestedDescriptor,
+	readNestedDefaultEvents,
 	reRenderParent,
 	reRenderField,
 	reRenderList,
+	resetNestedDefaultEvents,
 } from './_fixtures/jsx-context-children.tsx';
 
 // JSX backwards-compat: a React-style `.tsx` `<Ctx.Provider value>` with element
@@ -79,4 +96,268 @@ it('positional component children do NOT emit the de-opt "missing key" warning',
 	} finally {
 		warn.mockRestore();
 	}
+});
+
+describe('same-module JSX component children', () => {
+	it('renders nested components in their authored order without replacing their DOM', () => {
+		const r = mount(StaticNestedApp);
+		const root = r.find('.static-nested-root');
+		const middle = r.find('.static-nested-middle');
+		const leaf = r.find('.static-nested-leaf');
+
+		expect(leaf.textContent).toBe('static');
+		expect(root.textContent).toBe('beforestaticafter');
+		r.update(StaticNestedApp);
+		expect(r.find('.static-nested-root')).toBe(root);
+		expect(r.find('.static-nested-middle')).toBe(middle);
+		expect(r.find('.static-nested-leaf')).toBe(leaf);
+		r.unmount();
+	});
+
+	it('preserves nested hook state while parent props and context change', () => {
+		const r = mount(DirectNestedApp, { label: 'first', theme: 'light' });
+		const child = r.find('.direct-nested-leaf');
+
+		expect(child.textContent).toBe('light:0');
+		r.click('.direct-nested-leaf');
+		expect(child.textContent).toBe('light:1');
+
+		r.update(DirectNestedApp, { label: 'second', theme: 'light' });
+		expect(r.find('.direct-nested-host').getAttribute('data-label')).toBe('second');
+		expect(r.find('.direct-nested-leaf')).toBe(child);
+		expect(child.textContent).toBe('light:1');
+
+		r.update(DirectNestedApp, { label: 'second', theme: 'dark' });
+		expect(r.find('.direct-nested-leaf')).toBe(child);
+		expect(child.textContent).toBe('dark:1');
+		r.click('.direct-nested-leaf');
+		expect(child.textContent).toBe('dark:2');
+		r.unmount();
+	});
+
+	it('preserves live default-props getters, their context, and their authored evaluation order', () => {
+		resetNestedDefaultEvents();
+		const r = mount(DefaultPropsNestedApp, { theme: 'light', version: 'first' });
+		const child = r.find('.default-props-stateful');
+
+		expect(r.find('.default-props-pure').textContent).toBe('pure');
+		expect(child.textContent).toBe('light:first:0');
+		expect(readNestedDefaultEvents()).toEqual(['pure:light:first', 'stateful:light:first']);
+
+		r.click('.default-props-stateful');
+		expect(child.textContent).toBe('light:first:1');
+		expect(readNestedDefaultEvents()).toEqual(['pure:light:first', 'stateful:light:first']);
+
+		r.update(DefaultPropsNestedApp, { theme: 'dark', version: 'second' });
+		expect(r.find('.default-props-stateful')).toBe(child);
+		expect(child.textContent).toBe('dark:second:1');
+		expect(readNestedDefaultEvents()).toEqual([
+			'pure:light:first',
+			'stateful:light:first',
+			'pure:dark:second',
+			'stateful:dark:second',
+		]);
+		r.unmount();
+	});
+
+	it('preserves dynamic props, spreads, refs, keys, and inspectable children', () => {
+		const refs: Array<HTMLButtonElement | null> = [];
+		const onRef = (node: HTMLButtonElement | null) => refs.push(node);
+		const r = mount(NestedFallbackApp, { label: 'first', identity: 'a', onRef });
+		const refNode = r.find('.fallback-ref');
+		const firstKeyed = r.find('.fallback-keyed');
+
+		expect(r.find('[data-fallback-kind="attribute"]').textContent).toBe('first');
+		expect(r.find('[data-fallback-kind="spread"]').textContent).toBe('first');
+		expect(refs).toContain(refNode);
+		expect(r.find('.fallback-children').getAttribute('data-valid')).toBe('true');
+		expect(r.find('.fallback-children .static-nested-leaf').textContent).toBe('static');
+
+		r.click('.fallback-keyed');
+		expect(firstKeyed.textContent).toBe('1');
+		r.update(NestedFallbackApp, { label: 'second', identity: 'a', onRef });
+		expect(r.find('[data-fallback-kind="attribute"]').textContent).toBe('second');
+		expect(r.find('[data-fallback-kind="spread"]').textContent).toBe('second');
+		expect(r.find('.fallback-ref')).toBe(refNode);
+		expect(r.find('.fallback-keyed')).toBe(firstKeyed);
+		expect(firstKeyed.textContent).toBe('1');
+
+		r.update(NestedFallbackApp, { label: 'second', identity: 'b', onRef });
+		expect(r.find('.fallback-keyed')).not.toBe(firstKeyed);
+		expect(r.find('.fallback-keyed').textContent).toBe('0');
+		r.unmount();
+		expect(refs.at(-1)).toBeNull();
+	});
+
+	it('keeps escaped JSX and directly called component results as inspectable elements', () => {
+		expect(isValidElement(directNestedReturnValue())).toBe(true);
+		expect(isValidElement(directNestedMiddleReturnValue())).toBe(true);
+
+		const r = mount(EscapedNestedApp);
+		expect(r.find('.escaped-nested-root').getAttribute('data-valid')).toBe('true');
+		expect(r.find('.static-nested-leaf').textContent).toBe('static');
+		r.unmount();
+	});
+
+	it('observes default props installed through an escaped JSX element type', () => {
+		const descriptor = escapedNestedDescriptor();
+		expect(isValidElement(descriptor)).toBe(true);
+		const component = descriptor.type as object;
+		const reads: string[] = [];
+		Object.defineProperty(component, 'defaultProps', {
+			configurable: true,
+			get() {
+				reads.push('default props read');
+				return {};
+			},
+		});
+
+		try {
+			const r = mount(DescriptorEscapedApp);
+			expect(r.find('.descriptor-escaped-leaf').textContent).toBe('descriptor');
+			expect(reads).toEqual(['default props read']);
+			r.unmount();
+		} finally {
+			Reflect.deleteProperty(component, 'defaultProps');
+		}
+	});
+
+	it('hydrates static nested components and preserves their original sibling and element nodes', () => {
+		const server = loadServerFixture('packages/octane/tests/_fixtures/jsx-context-children.tsx');
+		const { html } = ServerRuntime.renderToString(server.StaticNestedApp);
+		const container = document.createElement('div');
+		container.innerHTML = html;
+		document.body.appendChild(container);
+		const original = {
+			root: container.querySelector('.static-nested-root'),
+			before: container.querySelector('.static-nested-before'),
+			middle: container.querySelector('.static-nested-middle'),
+			leaf: container.querySelector('.static-nested-leaf'),
+			after: container.querySelector('.static-nested-after'),
+		};
+
+		const root = hydrateRoot(container, StaticNestedApp);
+		flushSync(() => {});
+		expect(container.querySelector('.static-nested-root')).toBe(original.root);
+		expect(container.querySelector('.static-nested-before')).toBe(original.before);
+		expect(container.querySelector('.static-nested-middle')).toBe(original.middle);
+		expect(container.querySelector('.static-nested-leaf')).toBe(original.leaf);
+		expect(container.querySelector('.static-nested-after')).toBe(original.after);
+		expect(original.root?.textContent).toBe('beforestaticafter');
+
+		flushSync(() => root.render(StaticNestedApp));
+		expect(container.querySelector('.static-nested-middle')).toBe(original.middle);
+		expect(container.querySelector('.static-nested-leaf')).toBe(original.leaf);
+		expect(original.root?.textContent).toBe('beforestaticafter');
+		root.unmount();
+		container.remove();
+	});
+
+	it('hydrates wholly private nested components without replacing their siblings or elements', () => {
+		const server = loadServerFixture('packages/octane/tests/_fixtures/jsx-context-children.tsx');
+		const { html } = ServerRuntime.renderToString(server.PrivateNestedApp);
+		const container = document.createElement('div');
+		container.innerHTML = html;
+		document.body.appendChild(container);
+		const original = {
+			root: container.querySelector('.private-nested-root'),
+			before: container.querySelector('.private-nested-before'),
+			middle: container.querySelector('.private-nested-middle'),
+			leaf: container.querySelector('.private-nested-leaf'),
+			after: container.querySelector('.private-nested-after'),
+		};
+
+		const root = hydrateRoot(container, PrivateNestedApp);
+		flushSync(() => {});
+		expect(container.querySelector('.private-nested-root')).toBe(original.root);
+		expect(container.querySelector('.private-nested-before')).toBe(original.before);
+		expect(container.querySelector('.private-nested-middle')).toBe(original.middle);
+		expect(container.querySelector('.private-nested-leaf')).toBe(original.leaf);
+		expect(container.querySelector('.private-nested-after')).toBe(original.after);
+		expect(original.root?.textContent).toBe('beforeprivateafter');
+
+		flushSync(() => root.render(PrivateNestedApp));
+		expect(container.querySelector('.private-nested-middle')).toBe(original.middle);
+		expect(container.querySelector('.private-nested-leaf')).toBe(original.leaf);
+		expect(original.root?.textContent).toBe('beforeprivateafter');
+		root.unmount();
+		container.remove();
+	});
+
+	it('hydrates a hook-owning child through nested static component boundaries', () => {
+		const server = loadServerFixture('packages/octane/tests/_fixtures/jsx-context-children.tsx');
+		const { html } = ServerRuntime.renderToString(server.MixedNestedApp, { theme: 'light' });
+		const container = document.createElement('div');
+		container.innerHTML = html;
+		document.body.appendChild(container);
+		const host = container.querySelector('.mixed-nested-host');
+		const middle = container.querySelector('.static-nested-middle');
+		const shell = container.querySelector('.mixed-nested-shell');
+		const child = container.querySelector('.direct-nested-leaf');
+
+		const root = hydrateRoot(container, MixedNestedApp, { theme: 'light' });
+		flushSync(() => {});
+		expect(container.querySelector('.mixed-nested-host')).toBe(host);
+		expect(container.querySelector('.static-nested-middle')).toBe(middle);
+		expect(container.querySelector('.mixed-nested-shell')).toBe(shell);
+		expect(container.querySelector('.direct-nested-leaf')).toBe(child);
+		expect(child?.textContent).toBe('light:0');
+
+		flushSync(() => (child as HTMLButtonElement).click());
+		flushSync(() => root.render(MixedNestedApp, { theme: 'dark' }));
+		expect(container.querySelector('.mixed-nested-host')).toBe(host);
+		expect(container.querySelector('.mixed-nested-shell')).toBe(shell);
+		expect(container.querySelector('.direct-nested-leaf')).toBe(child);
+		expect(child?.textContent).toBe('dark:1');
+		root.unmount();
+		container.remove();
+	});
+
+	it('hydrates nested component DOM in place and preserves later state and context updates', () => {
+		const server = loadServerFixture('packages/octane/tests/_fixtures/jsx-context-children.tsx');
+		const props = { label: 'server', theme: 'light' };
+		const { html } = ServerRuntime.renderToString(server.DirectNestedApp, props);
+		const container = document.createElement('div');
+		container.innerHTML = html;
+		document.body.appendChild(container);
+		const host = container.querySelector('.direct-nested-host');
+		const child = container.querySelector('.direct-nested-leaf');
+
+		const root = hydrateRoot(container, DirectNestedApp, props);
+		flushSync(() => {});
+		expect(container.querySelector('.direct-nested-host')).toBe(host);
+		expect(container.querySelector('.direct-nested-leaf')).toBe(child);
+		expect(child?.textContent).toBe('light:0');
+
+		flushSync(() => (child as HTMLButtonElement).click());
+		expect(child?.textContent).toBe('light:1');
+		flushSync(() => root.render(DirectNestedApp, { label: 'client', theme: 'dark' }));
+		expect(container.querySelector('.direct-nested-host')).toBe(host);
+		expect(container.querySelector('.direct-nested-leaf')).toBe(child);
+		expect(host?.getAttribute('data-label')).toBe('client');
+		expect(child?.textContent).toBe('dark:1');
+		root.unmount();
+		container.remove();
+	});
+
+	it('routes errors from a nested child to its nearest error boundary', () => {
+		const r = mount(NestedErrorApp);
+		expect(r.find('.nested-error-fallback').textContent).toBe('caught');
+		expect(r.findAll('.nested-unreachable')).toHaveLength(0);
+		r.unmount();
+	});
+
+	it('suspends a nested child inside its boundary and retries when its promise resolves', async () => {
+		let resolve!: (value: string) => void;
+		const promise = new Promise<string>((complete) => {
+			resolve = complete;
+		});
+		const r = mount(NestedSuspenseApp, { promise });
+		expect(r.find('.nested-pending').textContent).toBe('pending');
+
+		await act(() => resolve('ready'));
+		expect(r.find('.nested-resolved').textContent).toBe('ready');
+		expect(r.findAll('.nested-pending')).toHaveLength(0);
+		r.unmount();
+	});
 });


### PR DESCRIPTION
## Summary

- Lower production-only, private, nonescaping, zero-argument, setup-free `.tsx` components through their existing compiled host renderers and lightweight component slots; preserve the original callable components and inspectable JSX descriptors.
- Fail closed for exported, stateful, escaped, dynamic, or `defaultProps`-sensitive components, and add behavioral regressions for hooks, context, live getters, descriptor escapes, spreads, refs, keys, Suspense, error boundaries, and SSR/hydration.
- Ratchet the existing production Chromium work gates to the measured reductions in renders, full component slots, child dispatch, descriptors, and teardown.
- Part of #611.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` — **16,797 tests across 1,556 files** (run with `NODE_OPTIONS=--no-experimental-webstorage` for local Node 26 compatibility).
- [x] targeted tests: 1,128 client/hydration behavioral cases across development and production, plus 1,061 compiler regressions covering frozen ASTs and source maps.
- [x] `node benchmarks/bench.mjs --quick --ratios signal-favoring js-framework` — all 11 applicable performance-ratio guards pass.
- [x] `node benchmarks/bench.mjs --quick codegen-size bundle-size` — the fixed code-generation corpus and normalized `.tsx`/`.tsrx` application/framework bundles are unchanged.
- [x] Production shallow-update work: component renders **200 → 20**, full component slots **100 → 10**, child slots **99 → 9**, JSX descriptors **199 → 19**; visible text updates remain exact.
- [x] Production mount renders **201 → 21**; teardown blocks **201 → 21** and scopes **201 → 111**.
- [x] Order-balanced shallow-update `.tsx`/`.tsrx` ratio improves **3.46× → 1.04×**; generated 100-component application output decreases **86,630 → 61,398 bytes**.
- [x] A 250-component compiler scaling probe decreases generated output **180,731 → 108,964 bytes** without quadratic analysis growth.

## Risk / follow-ups

- Eligibility is limited to same-module private components with no escaping references, parameters, setup, hooks, dynamic props, or unsafe descriptor holes; unsupported shapes retain the existing implementation.
- Existing `recursive-context` and global code-generation ratio ceilings already fail against checked-in upstream baselines. Recursive-context production output and all deterministic work counters are byte-for-byte unchanged; fixed code-generation and application bundles are unchanged.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Compiler-only optimization with conservative escape analysis; incorrect eligibility could change rendering or descriptor semantics, mitigated by extensive tests and unchanged paths for hooked or escaping components.
> 
> **Overview**
> **Production JSX** now routes **compiler-proven** same-module, private, hookless components through their **existing hoisted host renderers** and **`componentSlotLite`** instead of building descriptors and full component slots on every nested call.
> 
> Eligibility is **fail-closed**: `collectPrivateUnescapedComponents` only keeps module-local functions whose references never escape and that appear as **attribute-free, childless** JSX under an immediate host return; exported, hooked, dynamic, keyed, spread, or stored JSX still use the prior path. Fragment extraction threads **`staticFragmentRenderer`** metadata so call sites reuse the compiled renderer and static props while **authored component functions and inspectable descriptors** stay unchanged for direct calls and escapes.
> 
> **Benchmarks** tighten `octane-jsx` production work ceilings (e.g. shallow update: ~200→20 block renders, ~100→10 full slots, ~199→19 descriptors). **Tests** add nested-component fixtures and coverage for hooks, context, `defaultProps` getters, refs/keys/spreads, Suspense, error boundaries, and SSR hydration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8460cb9f6ffc3e69f0ece82d41ffb23f18df4fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->