### PR TITLE
fix(website): drive the Lynx preview gesture on Safari

### DIFF
--- a/website/src/components/go/lynx-view/auto-gesture.ts
+++ b/website/src/components/go/lynx-view/auto-gesture.ts
@@ -181,7 +181,11 @@ export function playAutoGesture(host: HTMLElement, options: AutoGestureOptions):
 		endActiveContact();
 	}
 
-	void run();
+	// A demonstration must never take the page down with it. Anything thrown
+	// mid-drag would otherwise surface as an unhandled rejection and leave the
+	// contact down, the circle drawn, and the example believing a finger is
+	// still on it.
+	void run().catch(() => stop());
 	return { stop };
 }
 
@@ -233,14 +237,120 @@ const POINTER_TYPE = {
 	touchend: 'pointerup',
 } as const;
 
+type TouchPoint = { clientX: number; clientY: number };
+type TouchType = 'touchstart' | 'touchmove' | 'touchend';
+type TouchEventFactory = (
+	target: Element,
+	type: TouchType,
+	identifier: number,
+	point: TouchPoint,
+) => TouchEvent;
+
+/** Safari's legacy touch factories, absent everywhere else. */
+type LegacyTouchDocument = Document & {
+	createTouch: (
+		view: Window,
+		target: EventTarget,
+		identifier: number,
+		pageX: number,
+		pageY: number,
+		screenX: number,
+		screenY: number,
+	) => Touch;
+	createTouchList: (...touches: Touch[]) => TouchList;
+};
+
+/** `new Touch()` plus plain arrays — every engine but Safari. */
+const standardTouchEvent: TouchEventFactory = (target, type, identifier, point) => {
+	const touch = new Touch({
+		identifier,
+		target,
+		clientX: point.clientX,
+		clientY: point.clientY,
+		pageX: point.clientX + window.scrollX,
+		pageY: point.clientY + window.scrollY,
+		screenX: point.clientX,
+		screenY: point.clientY,
+	});
+	return new TouchEvent(type, {
+		...TOUCH_EVENT_INIT,
+		touches: type === 'touchend' ? [] : [touch],
+		targetTouches: type === 'touchend' ? [] : [touch],
+		changedTouches: [touch],
+	});
+};
+
+/**
+ * Safari's path: `document.createTouch` for the contact, and `TouchList`s
+ * rather than arrays for the event.
+ *
+ * Both halves are load-bearing. Safari's `TouchEvent` constructor rejects a
+ * plain array with a bare "Type error", and `createTouch` takes *page*
+ * coordinates — it derives `clientX`/`clientY` by subtracting the scroll, so
+ * the scroll has to be added back, and a preview is usually well down the page
+ * by the time anyone sees it.
+ */
+const legacyTouchEvent: TouchEventFactory = (target, type, identifier, point) => {
+	const legacy = document as LegacyTouchDocument;
+	const touch = legacy.createTouch(
+		window,
+		target,
+		identifier,
+		point.clientX + window.scrollX,
+		point.clientY + window.scrollY,
+		point.clientX,
+		point.clientY,
+	);
+	const touches = type === 'touchend' ? legacy.createTouchList() : legacy.createTouchList(touch);
+	// The DOM lib types these as `Touch[]`, following the current spec. Safari
+	// implements the older IDL and rejects an array outright, so the `TouchList`s
+	// have to go through a cast rather than a wider parameter type.
+	return new TouchEvent(type, {
+		...TOUCH_EVENT_INIT,
+		touches,
+		targetTouches: touches,
+		changedTouches: legacy.createTouchList(touch),
+	} as unknown as TouchEventInit);
+};
+
+const TOUCH_EVENT_INIT = { bubbles: true, cancelable: true, composed: true } as const;
+
+let touchEventFactory: TouchEventFactory | null | undefined;
+
+/**
+ * How this browser lets a script build a `TouchEvent`, or `null` if it will not.
+ *
+ * `typeof` is not the question. Safari declares `Touch` and throws
+ * `Illegal constructor` when you call it, so an existence check passes and the
+ * constructor throws — which used to reject the playback loop and take the
+ * whole demonstration down with it. What it accepts instead is not derivable
+ * from what it declares, so each strategy is probed by building one throwaway
+ * event. Probe once and cache: on Safari the first branch throws every time,
+ * and this runs per frame.
+ */
+function resolveTouchEventFactory(): TouchEventFactory | null {
+	if (touchEventFactory !== undefined) return touchEventFactory;
+	for (const factory of [standardTouchEvent, legacyTouchEvent]) {
+		try {
+			void factory(document.body, 'touchstart', 0, { clientX: 0, clientY: 0 });
+			touchEventFactory = factory;
+			return factory;
+		} catch {
+			// Try the next strategy.
+		}
+	}
+	touchEventFactory = null;
+	return null;
+}
+
 /**
  * One contact, as the browser reports it.
  *
- * Real touch input produces a pointer event *and* a touch event for every
- * contact, and a consumer may listen for either — `@lynx-js/web-core` drives
- * its gestures from the pointer stream, so dispatching only `touchstart` /
- * `touchmove` / `touchend` reaches the right element and does nothing at all.
- * Both are sent, in the order Chrome sends them.
+ * `@lynx-js/web-core` binds `touchstart` / `touchend` / `touchcancel` and no
+ * pointer events at all, so the touch half below is the one that actually
+ * drives the example — where it cannot be synthesized, the gesture does
+ * nothing. The pointer event is sent because real touch input produces both,
+ * in the order Chrome sends them, and an example may listen for either.
  */
 function dispatchTouch(
 	target: Element,
@@ -267,30 +377,9 @@ function dispatchTouch(
 	};
 	target.dispatchEvent(new PointerEvent(POINTER_TYPE[type], pointerInit));
 
-	// Touch/TouchEvent are unavailable on desktop builds without touch support;
-	// the pointer half above still drives the example there.
-	if (typeof Touch === 'undefined' || typeof TouchEvent === 'undefined') return;
-	const touch = new Touch({
-		identifier,
-		target,
-		clientX: point.clientX,
-		clientY: point.clientY,
-		pageX: point.clientX,
-		pageY: point.clientY,
-		screenX: point.clientX,
-		screenY: point.clientY,
-	});
-	const touches = type === 'touchend' ? [] : [touch];
-	target.dispatchEvent(
-		new TouchEvent(type, {
-			bubbles: true,
-			cancelable: true,
-			composed: true,
-			touches,
-			targetTouches: touches,
-			changedTouches: [touch],
-		}),
-	);
+	const factory = resolveTouchEventFactory();
+	if (!factory) return;
+	target.dispatchEvent(factory(target, type, identifier, point));
 }
 
 /** The simulator-style contact circle. */

--- a/website/tests/lynx-view.test.ts
+++ b/website/tests/lynx-view.test.ts
@@ -155,6 +155,9 @@ describe('automatic gesture playback', () => {
 	afterEach(() => {
 		vi.useRealTimers();
 		vi.restoreAllMocks();
+		// `restoreAllMocks` does not undo `stubGlobal`, and a stubbed `Touch`
+		// would otherwise decide the next test's dispatch path.
+		vi.unstubAllGlobals();
 		if (elementFromPointDescriptor) {
 			Object.defineProperty(document, 'elementFromPoint', elementFromPointDescriptor);
 		} else {
@@ -201,6 +204,82 @@ describe('automatic gesture playback', () => {
 		expect(events.slice(0, 2)).toEqual(['pointerdown', 'pointermove']);
 		playback.stop();
 		expect(events.at(-1)).toBe('pointerup');
+	});
+
+	it('keeps driving an example on a browser that refuses `new Touch()`', async () => {
+		// Safari declares `Touch` and throws `Illegal constructor` when you call
+		// it, while still shipping the legacy `document.createTouch` factory and
+		// wanting `TouchList`s rather than arrays. The throw used to reject the
+		// playback loop on the very first contact, so the swiper never moved —
+		// and `@lynx-js/web-core` binds touch events, not pointer events, so the
+		// pointer half alone demonstrates nothing.
+		vi.useFakeTimers();
+		vi.stubGlobal(
+			'Touch',
+			class {
+				constructor() {
+					throw new TypeError('Illegal constructor');
+				}
+			},
+		);
+		const legacy = {
+			createTouch: (
+				_view: Window,
+				target: EventTarget,
+				identifier: number,
+				pageX: number,
+				pageY: number,
+			) => ({ target, identifier, pageX, pageY }),
+			createTouchList: (...touches: unknown[]) => touches,
+		};
+		for (const [name, value] of Object.entries(legacy)) {
+			Object.defineProperty(document, name, { configurable: true, value });
+		}
+
+		const host = document.createElement('div');
+		const target = document.createElement('div');
+		host.append(target);
+		document.body.append(host);
+		vi.spyOn(host, 'getBoundingClientRect').mockReturnValue(
+			DOMRect.fromRect({ x: 0, y: 0, width: 100, height: 100 }),
+		);
+		Object.defineProperty(document, 'elementFromPoint', {
+			configurable: true,
+			value: () => target,
+		});
+
+		const seen: string[] = [];
+		for (const type of ['touchstart', 'touchmove', 'touchend']) {
+			target.addEventListener(type, () => seen.push(type));
+		}
+
+		// A fresh module: the resolved factory is cached for the page's lifetime.
+		vi.resetModules();
+		const { playAutoGesture: play } =
+			await import('../src/components/go/lynx-view/auto-gesture.ts');
+		const playback = play(host, {
+			steps: [
+				{
+					path: [
+						{ x: 0.8, y: 0.5 },
+						{ x: 0.2, y: 0.5 },
+					],
+					durationMs: 0,
+					restMs: 0,
+				},
+			],
+			loop: false,
+			showPointer: false,
+			startDelayMs: 0,
+			stopOnUserInput: false,
+		});
+		await vi.runAllTimersAsync();
+		playback.stop();
+
+		// The whole gesture runs, rather than dying on the first contact.
+		expect(seen.at(0)).toBe('touchstart');
+		expect(seen.at(-1)).toBe('touchend');
+		for (const name of Object.keys(legacy)) Reflect.deleteProperty(document, name);
 	});
 
 	it('finishes each repeated direction before reversing', async () => {


### PR DESCRIPTION
## Summary
- The Lynx preview's auto-gesture was completely dead on Safari: the swiper never moved and the console carried an unhandled rejection.
- Probe how the browser will let a `TouchEvent` be built instead of inferring it from `typeof`, and cache the winner.
- Stop a mid-drag throw from silently killing playback.

## Why
Safari declares `Touch` and throws `Illegal constructor` when you call it. The old guard only checked `typeof Touch === 'undefined'`, so it passed, `new Touch()` threw on the first contact, and the rejection took the whole playback loop with it.

Falling back to pointer-only is not a fix. `@lynx-js/web-core` binds `touchstart` / `touchend` / `touchcancel` and no pointer events at all, so the touch half is the one that actually drives the example — I confirmed this by fixing the crash first and watching the swiper stay motionless. (This also corrects a comment in the module that claimed the opposite.)

What Safari accepts is not derivable from what it declares. Measured in headless WebKit:

| | Chromium | WebKit |
| --- | --- | --- |
| `new Touch()` | ok | **throws `Illegal constructor`** |
| `new TouchEvent()` | ok | ok |
| `document.createTouch()` | absent | ok |
| `TouchEvent` with a `Touch[]` | ok | **throws `Type error`** |
| `TouchEvent` with a `TouchList` | absent | ok |

So each strategy is probed by building one throwaway event, and the first that survives is cached for the page's lifetime — on Safari the standard branch throws every time, and this runs per frame.

## Changes
- `website/src/components/go/lynx-view/auto-gesture.ts`: replace the `typeof` guard with two probed `TouchEvent` factories — the standard one, and Safari's `document.createTouch` + `createTouchList` path. `createTouch` takes page coordinates, so the scroll offset is added back; a preview is usually well down the page.
- Same file: `run()` now catches, so anything thrown mid-drag lifts the contact rather than leaving the example believing a finger is still down.
- `website/tests/lynx-view.test.ts`: regression test driving a Safari-shaped environment, plus `vi.unstubAllGlobals()` in the teardown so a stubbed `Touch` cannot decide the next test's dispatch path.

## Validation
- [x] `pnpm format:files:check` on both changed files
- [x] `pnpm typecheck:files` on both changed files
- [x] targeted tests: `vitest run --project website-unit` — 22 files, 323 passed
- [x] end-to-end in headless WebKit **and** Chromium against `/docs/lynx`: the swiper's translation range goes **0 → 1875px** on WebKit, and stays 1875px on Chromium. Console clean in both.
- [x] pre-fix failure confirmed: reverting to the `typeof` guard makes the new test fail
- [ ] `pnpm format:check` (repo-wide) — not run; change is two files
- [ ] `pnpm test` (full) — not run; ran the `website-unit` project instead

## Risk / follow-ups
- The cast on the legacy `TouchEventInit` is unavoidable: the DOM lib types `touches` as `Touch[]` per the current spec, and Safari implements the older `TouchList` IDL.
- The same fix belongs upstream in lynx-community/go-web#79, which carries this module as `@lynx-js/go-web/lynx-view`. I am porting it there.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to website demo gesture playback and unit tests; no auth, data, or core runtime paths.
> 
> **Overview**
> **Restores the Lynx preview auto-gesture on Safari**, where `new Touch()` throws despite `Touch` being defined, which used to reject playback and leave the swiper static. **Touch synthesis no longer relies on `typeof Touch`**: it probes standard (`new Touch()` + array touch lists) vs Safari legacy (`document.createTouch` / `createTouchList`, page coords with scroll) once per page and caches the working factory.
> 
> The playback loop **`run()` is wrapped with `.catch(() => stop())`** so mid-drag failures lift the contact instead of an unhandled rejection. Comments in **`dispatchTouch`** now state that **`@lynx-js/web-core` listens on touch events**, not pointer-only fallback.
> 
> Tests add a **Safari-shaped regression** (illegal `Touch` constructor + legacy document APIs, fresh module for factory cache) and **`vi.unstubAllGlobals()`** in teardown so stubbed `Touch` does not leak across tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6842d8242fd49fc66320959081aa1f8b5551ae5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->