### PR TITLE
perf: skip unchanged conditional keyed rows

### DIFF
--- a/.changeset/conditional-keyed-row-memoization.md
+++ b/.changeset/conditional-keyed-row-memoization.md
@@ -1,0 +1,8 @@
+---
+'octane': patch
+---
+
+Skip unchanged keyed-list rows in production when their nested conditional
+content contains only host elements and every captured dependency is stable.
+Preserve conditional ownership, hydration, transitions, and existing keyed
+selection behavior while avoiding redundant DOM updates in TodoMVC-shaped apps.

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -617,6 +617,14 @@
   },
   {
     "suite": "todomvc",
+    "op": "row_class_writes_complete25",
+    "target": "octane-tsrx",
+    "reference": "react",
+    "maxRatio": 2.0,
+    "note": "Twenty-five immutable TodoMVC row updates should write only the 25 changed row classes. The host-only conditional survivor bailout reduces Octane from 2,500 writes to React's 25; 2x allows implementation variation while catching a return to list-wide writes."
+  },
+  {
+    "suite": "todomvc",
     "op": "nodes_100",
     "target": "octane-tsrx",
     "reference": "react",

--- a/benchmarks/todomvc/README.md
+++ b/benchmarks/todomvc/README.md
@@ -42,6 +42,8 @@ routing, no storage, no PRNG: fully deterministic.
 - `edit10` — dblclick label, set `.edit`, Enter — first 10 items
 - `clearCompleted` — at 75/25 split
 - `destroy25` — 25 first-item `.destroy` clicks
+- `row_class_writes_complete25` — exact row-class attribute mutations during a
+  separately verified `complete25` pass; unchanged-value writes are included
 - `comments_100` — comment-node DOM weight at 100 mounted todos (marker-elision
   tripwire, deterministic)
 
@@ -49,9 +51,8 @@ Timing protocol matches ../js-framework/run.mjs: interactions dispatch inside
 one `page.evaluate`, frameworks commit synchronously in the window (or via the
 awaited `__benchFlush` hook), `--expose-gc` + a gc() before each sample.
 
-React's column runs its dev-mode transform under the vite dev server (same as
-the js-framework react column) — compare react-to-react across commits, not
-react-to-compiled-frameworks absolute.
+The unified suite runner production-builds every framework and serves its Vite
+preview, so the published columns compare production output across frameworks.
 
 The target matrix also includes native **Preact** on `:5261` and runes-mode
 **Svelte 5** on `:5272`. Both preserve the same native input/change semantics,

--- a/benchmarks/todomvc/run.mjs
+++ b/benchmarks/todomvc/run.mjs
@@ -253,6 +253,39 @@ async function timeOp(page, op) {
 	})()`);
 }
 
+async function countRowClassWritesDuringComplete25(page) {
+	await ensureState(page, 'items');
+	return await page.evaluate(`(async () => {
+		${HELPERS}
+		const flush = window.__benchFlush;
+		let writes = 0;
+		const countWrites = (records) => {
+			for (const record of records) {
+				if (record.target.localName === 'li') writes++;
+			}
+		};
+		const observer = new MutationObserver(countWrites);
+		observer.observe($('.todo-list'), {
+			attributes: true,
+			attributeFilter: ['class'],
+			subtree: true,
+		});
+		try {
+			const toggles = $$('.todo-list li .toggle');
+			for (let i = 0; i < ${N}; i += 4) {
+				toggles[i].click();
+				if (flush) await flush();
+			}
+			countWrites(observer.takeRecords());
+		} finally {
+			observer.disconnect();
+		}
+		expect(count('.todo-list li.completed') === 25, 'class-write sample completed count');
+		expect($('.todo-count strong').textContent === '75', 'class-write sample remaining count');
+		return writes;
+	})()`);
+}
+
 async function runTarget(t) {
 	const browser = await chromium.launch({
 		headless: true,
@@ -279,6 +312,13 @@ async function runTarget(t) {
 		}
 		results[op.name] = summarizeSamples(samples);
 	}
+
+	// Exact browser-observed work for the 25 immutable single-row updates. A
+	// MutationObserver also records writes that repeat the existing class value,
+	// so it catches a keyed-survivor bailout disappearing without timer noise.
+	results.row_class_writes_complete25 = deterministicCount(
+		await countRowClassWritesDuringComplete25(page),
+	);
 
 	// Full steady-state DOM shape (100 todos mounted). Element/text counts are
 	// semantic controls beside the bookkeeping-node total.
@@ -317,6 +357,7 @@ async function runTarget(t) {
 		console.log(row.join('| '));
 	}
 	for (const [label, op] of [
+		['#rowCls25', 'row_class_writes_complete25'],
 		['#nodes', 'nodes_100'],
 		['#elems', 'elements_100'],
 		['#text', 'text_100'],

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -3344,6 +3344,65 @@ function containsComponentCallOrControlFlow(stmts) {
 }
 
 /**
+ * A host-only conditional can share its keyed row's immutable item/dependency
+ * proof, but entering that conditional still needs the row's active scope. Keep
+ * components and every other control-flow boundary on their existing path.
+ */
+function hasOnlyHostConditionalItemBodies(stmts) {
+	let hasConditional = false;
+	let disallowed = false;
+	const seen = new WeakSet();
+	function walk(node) {
+		if (disallowed || !node) return;
+		if (Array.isArray(node)) {
+			for (const child of node) walk(child);
+			return;
+		}
+		if (typeof node !== 'object') return;
+		const type = node.type;
+		if (!type || seen.has(node)) return;
+		seen.add(node);
+		if (
+			type === 'ArrowFunctionExpression' ||
+			type === 'FunctionExpression' ||
+			type === 'FunctionDeclaration'
+		) {
+			return;
+		}
+		if ((type === 'Element' || type === 'JSXElement') && isComponentTag(node)) {
+			disallowed = true;
+			return;
+		}
+		if (type === 'IfStatement' || type === 'JSXIfExpression') {
+			hasConditional = true;
+		} else if (
+			type === 'ForStatement' ||
+			type === 'ForInStatement' ||
+			type === 'ForOfStatement' ||
+			type === 'WhileStatement' ||
+			type === 'DoWhileStatement' ||
+			type === 'TryStatement' ||
+			type === 'SwitchStatement' ||
+			type === 'JSXForExpression' ||
+			type === 'JSXTryExpression' ||
+			type === 'JSXSwitchExpression' ||
+			((type === 'TSRXExpression' || type === 'JSXExpressionContainer') &&
+				node.expression &&
+				isCreatePortalCall(node.expression))
+		) {
+			disallowed = true;
+			return;
+		}
+		for (const key in node) {
+			if (AST_WALK_SKIP_KEYS.has(key)) continue;
+			walk(node[key]);
+		}
+	}
+	for (const statement of stmts) walk(statement);
+	return hasConditional && !disallowed;
+}
+
+/**
  * Classify the narrow opaque shape that an automatically memoized keyed item
  * may safely contain: ordinary JSX component calls, but no template control
  * flow or portals. Imported callees are validated at runtime on the first
@@ -17326,16 +17385,18 @@ function planJsx(
 		//        bit 3 = indexIndependent (body binds no `index` → a pure reorder
 		//        that only changes a survivor's position need not re-render it),
 		//        bit 4 = SSR emitted markerless direct-host items; hydrate them by root,
-		//        bit 5 = keyed selection; bits 6+ carry its zero-based deps index.
-		// The dedicated eligibility bit distinguishes dependency zero from an
-		// ordinary list without adding a positional argument or tuple allocation.
+		//        bit 5 = conditional item bodies require their active scope,
+		//        bits 6+ = the zero-based keyedForBlock selection dependency index.
+		// keyedForBlock itself identifies a selection, including dependency zero;
+		// ordinary forBlock reuses bit 5 without an argument or tuple allocation.
 		const flags =
 			(fc.pure ? 1 : 0) |
 			(fc.singleRoot ? 2 : 0) |
 			(fc.depEligible ? 4 : 0) |
 			(fc.indexIndependent ? 8 : 0) |
 			(fc.ssrMarkerless ? 16 : 0) |
-			(fc.keyedSelectionIndex >= 0 ? 32 | (fc.keyedSelectionIndex << 6) : 0);
+			(fc.requiresScope ? 32 : 0) |
+			(fc.keyedSelectionIndex >= 0 ? fc.keyedSelectionIndex << 6 : 0);
 		// Arg layout: forBlock(__s, slot, host, items, keyFn, body, flags?, deps?,
 		// emptyBody?, anchor?, ownEnd?).
 		// Optional args backfill positionally: `flags`/`deps` placeholders
@@ -21720,16 +21781,16 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 	// - PURE: body closes over nothing parent-reactive, no hooks, no comps,
 	//   no control flow. Reconciler skips renderBlock when item ref + index
 	//   unchanged. Identified by `pure = true`.
-	// - DEP-PURE: body DOES close over parent locals but is otherwise as
-	//   clean as PURE. The compiler emits an explicit deps array at the
-	//   forBlock call site so the reconciler can do ONE deps-equality check
-	//   per parent render and, if unchanged, treat the body as PURE for the
-	//   survivor short-circuit. Saves the body call entirely for
-	//   item-ref-and-index-stable survivors — no per-row snapshot work.
+	// - DEP-PURE: body DOES close over parent locals but has no hooks or opaque
+	//   components. Proven host-only conditional content is permitted when the
+	//   runtime preserves the row's active scope. The compiler emits an explicit
+	//   deps array so the reconciler can do ONE equality check per parent render
+	//   and, if unchanged, skip item-ref-and-index-stable survivors entirely.
 	// - NORMAL: anything else → body runs every render.
 	let pure = false;
 	const depNames = [];
 	let depEligible = false;
+	let requiresScope = false;
 	let itemMemo = false;
 	let itemMemoContextAware = false;
 	let itemMemoWitnesses = [];
@@ -21903,8 +21964,23 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 		// survivor shortcut has no compiler-cache epoch cell to consult).
 		if (itemMemoContextAware && autoMemoDeps === null) itemMemo = false;
 		const hostPure = !hasParentClosure && !hasHook && !hasNestedComp && !hasRenderCall;
+		const conditionalHostDepEligible =
+			ctx.autoMemo === true &&
+			hasNestedComp &&
+			hasParentClosure &&
+			!hasHook &&
+			!hasRenderCall &&
+			node.nativeArrayMap === undefined &&
+			autoMemoDeps !== null &&
+			autoMemoDeps.every((name) => seenDeps.has(name)) &&
+			!containsAutoMemoContextRead(bodyAst, ctx) &&
+			hasOnlyHostConditionalItemBodies(subStmts);
 		const hostDepEligible =
-			!hostPure && !hasHook && hasParentClosure && !hasNestedComp && !hasRenderCall;
+			!hostPure &&
+			!hasHook &&
+			hasParentClosure &&
+			(!hasNestedComp || conditionalHostDepEligible) &&
+			!hasRenderCall;
 		if (itemMemo && itemMemoWitnesses.length > 0) {
 			pure = hostPure;
 			depEligible = hostDepEligible;
@@ -21913,6 +21989,7 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 			pure = hostPure || (itemMemo && depNames.length === 0);
 			depEligible = !pure && !hasHook && (hostDepEligible || (itemMemo && depNames.length > 0));
 		}
+		requiresScope = depEligible && conditionalHostDepEligible;
 		depNames.sort();
 	}
 
@@ -21947,6 +22024,7 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 	const keyedSelectionIndex =
 		ctx.autoMemo === true &&
 		depEligible &&
+		!requiresScope &&
 		!itemMemo &&
 		autoMemoDeps !== null &&
 		!isDestructured &&
@@ -22095,6 +22173,7 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 		// Component-local entries remain the tuple prefix the helpers destructure;
 		// any appended import witnesses are comparison-only.
 		depEligible,
+		requiresScope,
 		itemMemoWitnesses,
 		itemMemoFlags,
 		autoMemoDeps,

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -3383,9 +3383,11 @@ function hasOnlyHostConditionalItemBodies(stmts) {
 			type === 'DoWhileStatement' ||
 			type === 'TryStatement' ||
 			type === 'SwitchStatement' ||
+			type === 'ActivityStatement' ||
 			type === 'JSXForExpression' ||
 			type === 'JSXTryExpression' ||
 			type === 'JSXSwitchExpression' ||
+			type === 'JSXActivityExpression' ||
 			((type === 'TSRXExpression' || type === 'JSXExpressionContainer') &&
 				node.expression &&
 				isCreatePortalCall(node.expression))

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -22695,10 +22695,10 @@ interface ForSlot {
 	size: number; // count of item Blocks
 	// Last-render snapshot of the body's closed-over parent locals. The compiler
 	// emits a fresh `deps` array on every parent render for DEP-PURE for-of
-	// calls (impure body, no hooks/comps/control-flow). When this render's deps
-	// match last render's element-by-element, the runtime treats the body as
-	// PURE for the survivor short-circuit — saving the entire body call for
-	// every item whose ref + position are unchanged.
+	// calls (hookless host bodies, optionally with proven host-only conditional
+	// content). When this render's deps match last render's element-by-element,
+	// the runtime treats the body as PURE for the survivor short-circuit — saving
+	// the entire body call for every item whose ref + position are unchanged.
 	cachedDeps: any[] | null;
 	// `@for (...) { ... } @empty { ... }` support: mounted-empty-branch Block,
 	// or null when there are items (or no `@empty` branch was compiled). The
@@ -22747,7 +22747,9 @@ export function forBlock<T>(
 	// promote body to PURE when unchanged), bit 3 = indexIndependent (the body
 	// binds no `index` name → a pure reorder that only moves a survivor's
 	// position need not re-render it), bit 4 = the server emitted direct-host
-	// items without per-item pairs. Packed into one numeric literal.
+	// items without per-item pairs, bit 5 = a nested host conditional requires
+	// its owning Block's scope whenever an item body does need to render.
+	// Packed into one numeric literal.
 	const parentBlock = parentScope.block;
 	const hydration = activeHydration();
 	let state = parentScope.slots[slotKey] as ForSlot | undefined;
@@ -22915,22 +22917,29 @@ export function forBlock<T>(
 	// and last render's snapshot matches this render's, we can treat the body
 	// as PURE for the survivor short-circuit. The body still runs for moved/
 	// mounted/removed items — only stable survivors get skipped.
-	// `lite` = body is depEligible but did NOT promote to pure this render.
-	// depEligible (see makeForCall's body analysis in compile.js, packed into
-	// the forBlock `flags` bits) means no hooks, no nested comps, no
-	// control flow → the body can't observe CURRENT_SCOPE / CURRENT_BLOCK and
-	// never throws Suspense. We skip renderBlock's activeBlock plumbing and
-	// call itemBody directly. Saves ~10 ops/survivor — meaningful on the
-	// select-row tick where `selected` changes and 1000 survivors all
-	// re-evaluate but only 2 actually flip their class.
+	// `lite` = an unstructured depEligible body did NOT promote to pure this
+	// render. Such a body has no hooks, nested components, or control flow, so
+	// it cannot observe CURRENT_SCOPE / CURRENT_BLOCK and can run directly.
+	// Host-only nested conditionals may also qualify for the survivor skip, but
+	// need their owning Block's scope when a dependency actually changes.
+	// In particular, transition rollback must snapshot each row's own bag.
 	let lite = false;
 	if ((f & 4) !== 0 && deps !== undefined) {
-		if (state.cachedDeps !== null && depsEqual(state.cachedDeps, deps)) {
-			pure = true;
+		const requiresScope = (f & 32) !== 0;
+		if (requiresScope && TRANSITION_JOURNAL !== null) {
+			// The list journal restores membership and DOM, not this dependency
+			// snapshot. A suspended attempt must never leave a rolled-back list
+			// believing that its uncommitted dependencies are still current.
+			state.cachedDeps = null;
+			pure = false;
 		} else {
-			lite = true;
+			if (state.cachedDeps !== null && depsEqual(state.cachedDeps, deps)) {
+				pure = true;
+			} else {
+				lite = !requiresScope;
+			}
+			state.cachedDeps = deps;
 		}
-		state.cachedDeps = deps;
 	}
 	if (state.size === 0) {
 		// First fill (hydration adopt / fresh mount / update-path 0 → N): the
@@ -22971,7 +22980,7 @@ export function forBlock<T>(
 /**
  * Compiler-only keyed-selection entry. Keeping the specialization outside
  * forBlock lets applications without a proven selection tree-shake its cost.
- * Bit 5 identifies the proof; bits 6+ hold its captured dependency index.
+ * This entry point identifies the proof; bits 6+ hold its dependency index.
  */
 export function keyedForBlock<T>(
 	parentScope: Scope,

--- a/packages/octane/tests/_fixtures/for.tsrx
+++ b/packages/octane/tests/_fixtures/for.tsrx
@@ -1,4 +1,11 @@
-import { createContext, type OctaneNode, startTransition, use, useState } from 'octane';
+import {
+	Activity as ActivitySentinel,
+	createContext,
+	type OctaneNode,
+	startTransition,
+	use,
+	useState,
+} from 'octane';
 
 export function List(props: { items: Array<{ id: number; label: string }> }) @{
 	<ul>
@@ -210,6 +217,41 @@ export function NestedConditionalList(props: {
 				@if (editing === row.id) {
 					<input class="nested-conditional-editor" defaultValue={row.label} />
 				}
+			</li>
+		}
+	</ul>
+}
+
+const Activity = ActivitySentinel as unknown as
+	(props: {
+		mode: 'hidden' | 'visible';
+		children?: OctaneNode;
+	}) => null;
+
+let nestedConditionalActivityMode: 'hidden' | 'visible' = 'visible';
+
+function readNestedConditionalActivityMode() {
+	return nestedConditionalActivityMode;
+}
+
+export function setNestedConditionalActivityMode(mode: 'hidden' | 'visible') {
+	nestedConditionalActivityMode = mode;
+}
+
+export function NestedConditionalActivityList(props: {
+	items: SelectionRow[];
+	visible: boolean;
+}) @{
+	const visible = props.visible;
+	<ul id="nested-conditional-activity-list">
+		@for (const row of props.items; key row.id) {
+			<li>
+				@if (visible) {
+					<span class="nested-conditional-activity-label">{row.label as string}</span>
+				}
+				<Activity mode={readNestedConditionalActivityMode()}>
+					<span class="nested-conditional-activity-content">{row.label as string}</span>
+				</Activity>
 			</li>
 		}
 	</ul>

--- a/packages/octane/tests/_fixtures/for.tsrx
+++ b/packages/octane/tests/_fixtures/for.tsrx
@@ -1,6 +1,6 @@
 import { createContext, type OctaneNode, startTransition, use, useState } from 'octane';
 
-export function List(props) @{
+export function List(props: { items: Array<{ id: number; label: string }> }) @{
 	<ul>
 		@for (const item of props.items; key item.id) {
 			<li>{item.label as string}</li>
@@ -11,7 +11,7 @@ export function List(props) @{
 // `@for (...) @empty { ... }` — empty branch mounts when the iterable is empty,
 // unmounts when items return. Hooks declared in the empty body have their own
 // Block boundary, so re-entering the empty state mounts a fresh state.
-export function ListWithEmpty(props) @{
+export function ListWithEmpty(props: { items: Array<{ id: number; label: string }> }) @{
 	<ul class="outer">
 		@for (const item of props.items; key item.id) {
 			<li class="row">{item.label as string}</li>
@@ -97,7 +97,7 @@ export function MutableList() @{
 // dep still promotes stable survivors to pure — the test observes the promotion via
 // EXTERNAL: a promoted (skipped) body never re-reads it.
 let EXTERNAL = 'tick0';
-export function setExternal(v) {
+export function setExternal(v: string) {
 	EXTERNAL = v;
 }
 
@@ -120,6 +120,23 @@ export function CallBodyList() @{
 		<ul>
 			@for (const item of callItems; key item.id) {
 				<li class="cb-row">{item.read()}</li>
+			}
+		</ul>
+	</div>
+}
+
+export function NestedConditionalCallBodyList() @{
+	const [, setN] = useState(0);
+	const [visible] = useState(true);
+	<div>
+		<button id="nested-call-rerender" onClick={() => setN((n) => n + 1)}>{'go'}</button>
+		<ul>
+			@for (const item of callItems; key item.id) {
+				<li>
+					@if (visible) {
+						<span class="nested-call-row">{item.read()}</span>
+					}
+				</li>
 			}
 		</ul>
 	</div>
@@ -173,6 +190,29 @@ export function PlainCalleeList() @{
 interface SelectionRow {
 	id: number;
 	label: string;
+}
+
+export function NestedConditionalList(props: {
+	items: Array<SelectionRow & { completed?: boolean }>;
+	editing: number | null;
+	prefix: string;
+	onSelect: (id: number, prefix: string) => void;
+}) @{
+	const editing = props.editing;
+	const prefix = props.prefix;
+	const onSelect = props.onSelect;
+	<ul id="nested-conditional-list">
+		@for (const row of props.items; key row.id) {
+			<li class={{ completed: row.completed, editing: editing === row.id }} data-prefix={prefix}>
+				<button class="nested-conditional-action" onClick={() => onSelect(row.id, prefix)}>
+					<span class="nested-conditional-label">{row.label as string}</span>
+				</button>
+				@if (editing === row.id) {
+					<input class="nested-conditional-editor" defaultValue={row.label} />
+				}
+			</li>
+		}
+	</ul>
 }
 
 export function KeyedSelectionList(props: {
@@ -449,4 +489,43 @@ export function FastSuspendingGetterList(props: {
 			onClick={reset}
 		>{(error as Error).message as string}</button>
 	}
+}
+
+export function NestedConditionalTransition(props: {
+	items: SelectionRow[];
+	initialPromise: Promise<string>;
+	nextPromise: Promise<string>;
+}) @{
+	const [prefix, setPrefix] = useState('initial');
+	const [resource, setResource] = useState(props.initialPromise);
+	<div>
+		<button
+			id="nested-transition-bump"
+			onClick={() => startTransition(() => {
+				setPrefix('pending');
+				setResource(props.nextPromise);
+			})}
+		>{'update rows'}</button>
+		<button
+			id="nested-transition-urgent"
+			onClick={() => setPrefix('urgent')}
+		>{'update urgently'}</button>
+		@try {
+			<>
+				<ul id="nested-transition-list">
+					@for (const row of props.items; key row.id) {
+						<li class={{ editing: row.id === 1 }} data-prefix={prefix}>
+							<span class="nested-transition-label">{prefix + ':' + row.label}</span>
+							@if (row.id === 1) {
+								<strong class="nested-transition-detail">{prefix + ':' + row.label}</strong>
+							}
+						</li>
+					}
+				</ul>
+				<SelectionTransitionValue promise={resource} />
+			</>
+		} @pending {
+			<span id="nested-transition-fallback">{'loading'}</span>
+		}
+	</div>
 }

--- a/packages/octane/tests/for.test.ts
+++ b/packages/octane/tests/for.test.ts
@@ -10,6 +10,7 @@ import {
 	ToggleableEmpty,
 	DepPureList,
 	CallBodyList,
+	NestedConditionalActivityList,
 	NestedConditionalCallBodyList,
 	NestedConditionalList,
 	NestedConditionalTransition,
@@ -33,6 +34,7 @@ import {
 	FastMappedBoundaryList,
 	FastSuspendingGetterList,
 	setExternal,
+	setNestedConditionalActivityMode,
 } from './_fixtures/for.tsrx';
 
 const labels = (r: ReturnType<typeof mount>) => r.findAll('li').map((li) => li.textContent);
@@ -258,6 +260,29 @@ describe('keyed rows with nested conditional content', () => {
 		{ id: 2, label: 'second' },
 		{ id: 3, label: 'third' },
 	];
+
+	it('updates Activity visibility in stable keyed rows alongside host conditionals', () => {
+		const items = [{ id: 1, label: 'first' }];
+		const r = mount(NestedConditionalActivityList, { items, visible: true });
+		const content = r.find('.nested-conditional-activity-content') as HTMLElement;
+
+		try {
+			expect(content.style.display).toBe('');
+
+			setNestedConditionalActivityMode('hidden');
+			r.update(NestedConditionalActivityList, { items: [...items], visible: true });
+			expect(content.style.display).toBe('none');
+			expect(r.find('.nested-conditional-activity-content')).toBe(content);
+
+			setNestedConditionalActivityMode('visible');
+			r.update(NestedConditionalActivityList, { items: [...items], visible: true });
+			expect(content.style.display).toBe('');
+			expect(r.find('.nested-conditional-activity-label').textContent).toBe('first');
+		} finally {
+			r.unmount();
+			setNestedConditionalActivityMode('visible');
+		}
+	});
 
 	it('preserves surviving rows while updating immutable values, editing state, and callbacks', () => {
 		const initialItems = makeRows();

--- a/packages/octane/tests/for.test.ts
+++ b/packages/octane/tests/for.test.ts
@@ -10,6 +10,9 @@ import {
 	ToggleableEmpty,
 	DepPureList,
 	CallBodyList,
+	NestedConditionalCallBodyList,
+	NestedConditionalList,
+	NestedConditionalTransition,
 	PlainCalleeList,
 	KeyedSelectionList,
 	KeyedSelectionTransition,
@@ -210,6 +213,23 @@ describe('forBlock — render-time calls defeat the survivor short-circuit', () 
 		r.unmount();
 		setExternal('tick0'); // reset the module-level fixture state
 	});
+
+	it('re-evaluates item methods inside nested conditional markup', () => {
+		const r = mount(NestedConditionalCallBodyList);
+		expect(r.findAll('.nested-call-row').map((row) => row.textContent)).toEqual([
+			'r1:tick0',
+			'r2:tick0',
+		]);
+
+		setExternal('tick1');
+		r.click('#nested-call-rerender');
+		expect(r.findAll('.nested-call-row').map((row) => row.textContent)).toEqual([
+			'r1:tick1',
+			'r2:tick1',
+		]);
+		r.unmount();
+		setExternal('tick0');
+	});
 });
 
 describe('forBlock — DEP-PURE promotion compares deps with Object.is', () => {
@@ -229,6 +249,172 @@ describe('forBlock — DEP-PURE promotion compares deps with Object.is', () => {
 		expect(r.findAll('.dp-row').map((li) => li.textContent)).toEqual(['row1:tick0', 'row2:tick0']);
 		r.unmount();
 		setExternal('tick0'); // reset the module-level fixture state
+	});
+});
+
+describe('keyed rows with nested conditional content', () => {
+	const makeRows = () => [
+		{ id: 1, label: 'first' },
+		{ id: 2, label: 'second' },
+		{ id: 3, label: 'third' },
+	];
+
+	it('preserves surviving rows while updating immutable values, editing state, and callbacks', () => {
+		const initialItems = makeRows();
+		const calls: string[] = [];
+		const originalHandler = (id: number, prefix: string) => {
+			calls.push('original:' + prefix + ':' + id);
+		};
+		const initialProps = {
+			items: initialItems,
+			editing: 2,
+			prefix: 'before',
+			onSelect: originalHandler,
+		};
+		const r = mount(NestedConditionalList, initialProps);
+		const originalRows = r.findAll('li');
+		const editor = r.find('.nested-conditional-editor') as HTMLInputElement;
+		editor.value = 'uncommitted draft';
+
+		const updatedItems = [
+			initialItems[0]!,
+			{ ...initialItems[1]!, label: 'updated second', completed: true },
+			initialItems[2]!,
+		];
+		r.update(NestedConditionalList, { ...initialProps, items: updatedItems });
+		expect(r.findAll('li')).toEqual(originalRows);
+		expect(r.find('.completed .nested-conditional-label').textContent).toBe('updated second');
+		expect(r.find('.nested-conditional-editor')).toBe(editor);
+		expect(editor.value).toBe('uncommitted draft');
+
+		const nextHandler = (id: number, prefix: string) => {
+			calls.push('updated:' + prefix + ':' + id);
+		};
+		r.update(NestedConditionalList, {
+			items: updatedItems,
+			editing: 3,
+			prefix: 'after',
+			onSelect: nextHandler,
+		});
+		expect(r.findAll('li')).toEqual(originalRows);
+		expect(r.findAll('li').map((row) => row.getAttribute('data-prefix'))).toEqual([
+			'after',
+			'after',
+			'after',
+		]);
+		expect(r.find('.editing .nested-conditional-label').textContent).toBe('third');
+		expect((r.find('.nested-conditional-editor') as HTMLInputElement).value).toBe('third');
+		r.click('.editing .nested-conditional-action');
+		expect(calls).toEqual(['updated:after:3']);
+		r.unmount();
+	});
+
+	it('preserves conditional DOM and live events when surviving rows move or disappear', () => {
+		const initialItems = makeRows();
+		const selected: number[] = [];
+		const props = {
+			items: initialItems,
+			editing: 2,
+			prefix: 'row',
+			onSelect: (id: number) => {
+				selected.push(id);
+			},
+		};
+		const r = mount(NestedConditionalList, props);
+		const originalRows = r.findAll('li');
+		const editor = r.find('.nested-conditional-editor') as HTMLInputElement;
+		editor.value = 'keep my draft';
+
+		const reordered = [initialItems[2]!, initialItems[1]!, initialItems[0]!];
+		r.update(NestedConditionalList, { ...props, items: reordered });
+		expect(r.findAll('li')).toEqual([originalRows[2], originalRows[1], originalRows[0]]);
+		expect(r.find('.nested-conditional-editor')).toBe(editor);
+		expect(editor.value).toBe('keep my draft');
+		r.click('.editing .nested-conditional-action');
+
+		r.update(NestedConditionalList, {
+			...props,
+			items: [reordered[0]!, reordered[2]!],
+			editing: null,
+		});
+		expect(r.findAll('li')).toEqual([originalRows[2], originalRows[0]]);
+		expect(r.findAll('.nested-conditional-editor')).toHaveLength(0);
+		r.click('.nested-conditional-action');
+		expect(selected).toEqual([2, 3]);
+		r.unmount();
+	});
+
+	it('adopts server-rendered conditional rows while preserving inputs and live handlers', () => {
+		const items = makeRows();
+		const selected: number[] = [];
+		const props = {
+			items,
+			editing: 2,
+			prefix: 'hydrated',
+			onSelect: (id: number) => {
+				selected.push(id);
+			},
+		};
+		const server = loadServerFixture('packages/octane/tests/_fixtures/for.tsrx', {
+			compileOptions: { hmr: false, dev: false },
+		});
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		container.innerHTML = ServerRuntime.renderToString(server.NestedConditionalList, props).html;
+		const originalRows = Array.from(container.querySelectorAll('li'));
+		const originalEditor = container.querySelector(
+			'.nested-conditional-editor',
+		) as HTMLInputElement;
+		originalEditor.value = 'typed before hydration';
+		const root = hydrateRoot(container, NestedConditionalList, props);
+		flushSync(() => {});
+
+		expect(Array.from(container.querySelectorAll('li'))).toEqual(originalRows);
+		expect(container.querySelector('.nested-conditional-editor')).toBe(originalEditor);
+		expect(originalEditor.value).toBe('typed before hydration');
+
+		flushSync(() => root.render(NestedConditionalList, { ...props, editing: 3 }));
+		expect(Array.from(container.querySelectorAll('li'))).toEqual(originalRows);
+		expect(container.querySelector('.editing .nested-conditional-label')?.textContent).toBe(
+			'third',
+		);
+		(container.querySelector('.editing .nested-conditional-action') as HTMLButtonElement).click();
+		expect(selected).toEqual([3]);
+
+		root.unmount();
+		container.remove();
+	});
+
+	it('keeps committed conditional-row bindings intact while a later transition sibling suspends', async () => {
+		const items = makeRows();
+		const initialPromise = Promise.resolve('initial');
+		let resolveNext!: (value: string) => void;
+		const nextPromise = new Promise<string>((resolve) => {
+			resolveNext = resolve;
+		});
+		await Promise.resolve();
+		const r = mount(NestedConditionalTransition, { items, initialPromise, nextPromise });
+		await act(() => {});
+		const originalRows = r.findAll('#nested-transition-list li');
+		const rowLabels = () => r.findAll('.nested-transition-label').map((row) => row.textContent);
+		expect(rowLabels()).toEqual(['initial:first', 'initial:second', 'initial:third']);
+		expect(r.find('.nested-transition-detail').textContent).toBe('initial:first');
+
+		r.click('#nested-transition-bump');
+		expect(r.findAll('#nested-transition-list li')).toEqual(originalRows);
+		expect(rowLabels()).toEqual(['initial:first', 'initial:second', 'initial:third']);
+		expect(r.find('.nested-transition-detail').textContent).toBe('initial:first');
+		expect(r.findAll('#nested-transition-fallback')).toHaveLength(0);
+
+		await act(() => resolveNext('resolved'));
+		expect(r.findAll('#nested-transition-list li')).toEqual(originalRows);
+		expect(rowLabels()).toEqual(['pending:first', 'pending:second', 'pending:third']);
+		expect(r.find('.nested-transition-detail').textContent).toBe('pending:first');
+
+		r.click('#nested-transition-urgent');
+		expect(rowLabels()).toEqual(['urgent:first', 'urgent:second', 'urgent:third']);
+		expect(r.find('.nested-transition-detail').textContent).toBe('urgent:first');
+		r.unmount();
 	});
 });
 


### PR DESCRIPTION
## Summary

- Extend production keyed-list survivor memoization to compiler-proven rows containing only host-element conditionals.
- Preserve conditional row ownership, hydration, uncontrolled input values, event freshness, keyed identity, and suspended transition rollback.
- Add a deterministic seven-framework TodoMVC regression guard and an `octane` patch changeset.

## Why

TodoMVC rows contain `@if (editing === item.id)`, which previously disabled the existing DEP-PURE survivor bailout for the whole list. Immutable updates consequently rerendered every unchanged row and rewrote unchanged class attributes.

Controlled 24-iteration production measurements before/after the optimization:

| Operation | Before | After | Total class writes |
| --- | ---: | ---: | ---: |
| Add 100 todos | 2.61 ms | 0.73 ms | 5,350 → 400 |
| Complete 25 todos | 1.70 ms | 0.36 ms | 2,575 → 100 |
| Delete 25 todos | 1.50 ms | 0.19 ms | 2,250 → 75 |

The deterministic row-only measurement drops from **2,500 to 25 class writes** for 25 immutable updates, matching React. DOM shape is unchanged, generated application code does not grow, and the shared production runtime grows by approximately 22 bytes gzipped.

## Changes

- Conservatively recognize host-only nested `@if` rows with complete stable dependency witnesses; continue rejecting hooks, components, opaque calls, refs, portals, spreads, and other control-flow boundaries.
- Reserve a keyed-list flag for rows that require their active scope, keep full `renderBlock` execution when dependencies change, and invalidate dependency snapshots while a transition is journaled.
- Cover immutable row updates, callback replacement, reordering, uncontrolled drafts, server hydration, fail-closed opaque calls, and suspended transition rollback.
- Count real browser-observed row-class mutations separately from timing samples and enforce an Octane/React ratio guard.

## Validation

- [ ] `pnpm format:check` — repository-wide formatting was not run; scoped formatting passed.
- [ ] `pnpm typecheck` — repository-wide typechecking was not run; all four touched Octane source/test files passed `tsrx-tsc`.
- [ ] `pnpm test` — the full monorepo is blocked by pre-existing broken cross-worktree dependency symlinks and Node 26's experimental `localStorage`; both Octane projects were tested directly.
- [x] `pnpm_config_verify_deps_before_run=warn pnpm sync`
- [x] `pnpm_config_verify_deps_before_run=warn pnpm format:files:check benchmarks/baselines/ratios.json benchmarks/todomvc/README.md benchmarks/todomvc/run.mjs packages/octane/src/compiler/compile.js packages/octane/src/runtime.ts packages/octane/tests/_fixtures/for.tsrx packages/octane/tests/for.test.ts .changeset/conditional-keyed-row-memoization.md`
- [x] `pnpm_config_verify_deps_before_run=warn pnpm typecheck:files packages/octane/src/runtime.ts packages/octane/src/compiler/compile.js packages/octane/tests/for.test.ts packages/octane/tests/_fixtures/for.tsrx`
- [x] `NODE_OPTIONS=--no-experimental-webstorage ./node_modules/.bin/vitest run packages/octane/tests/for.test.ts packages/octane/tests/compiler/compiler-ast-immutability.test.ts packages/octane/tests/compiler/compiler-map-coverage.test.ts --project octane --project octane-prod --maxWorkers=4 --reporter=dot` — 109 tests passed.
- [x] `NODE_OPTIONS=--no-experimental-webstorage ./node_modules/.bin/vitest run --project octane --project octane-prod --testNamePattern '^(?!.*transforms installed raw Octane packages but preserves manual-slot sources).*$' --maxWorkers=8 --reporter=dot` — 770 files and 10,861 tests passed; one pre-existing broken-installed-workspace test is excluded in each project.
- [x] `pnpm_config_verify_deps_before_run=warn node benchmarks/bench.mjs --quick --ratios todomvc` — all seven production targets passed, including four applicable ratio guards and exactly 25 Octane row-class writes.
- [x] `pnpm_config_verify_deps_before_run=warn pnpm changeset:check`

## Risk / follow-ups

- Production-only optimization; unsafe row shapes fail closed, and transition attempts intentionally disable the bailout.
- Upstream's new certified fast-host mounting remains excluded for conditional rows; existing fast keyed-selection coverage passes with the reused flag bit.
- Editing still invalidates all rows. A future scope-aware keyed-selection specialization could target only the previously and newly edited items.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production keyed-list reconciliation, compiler purity flags, and transition journaling; incorrect bailout could cause stale DOM or wrong conditional branches, though the change is gated conservatively and heavily tested.
> 
> **Overview**
> Extends **production keyed-list survivor memoization** so TodoMVC-style rows with nested `@if` (host elements only) can bail out when parent deps are unchanged, instead of re-rendering every row and rewriting unchanged `class` attributes.
> 
> The **compiler** adds `hasOnlyHostConditionalItemBodies` and a narrow `conditionalHostDepEligible` path: DEP-PURE rows may include proven host-only conditionals when dependency witnesses are complete; unsafe shapes (hooks, components, opaque calls, other control flow) stay on the normal path. **Flag bit 5** now means the row needs its active `Block` scope (replacing the prior keyed-selection marker on ordinary `forBlock`); rows that need scope are excluded from `keyedForBlock` selection specialization.
> 
> The **runtime** still promotes survivors when `deps` match, but for scope-required rows it avoids the `lite` direct-body path, clears cached deps during journaled transitions so rollback cannot leave stale bailout state, and only skips work when dependencies are stable.
> 
> **Benchmarks** add `row_class_writes_complete25` (MutationObserver on `li` class during `complete25`) plus a **2× Octane/React ratio guard** targeting ~25 writes vs list-wide churn. TodoMVC docs note production preview builds for cross-framework columns.
> 
> **Tests** cover nested conditional lists (immutable updates, reorder/remove, hydration, Activity + components, transition suspend/rollback) and confirm member-call bodies still re-run inside nested `@if`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8430c63ab319acb04bbb04963b18c5407f712a83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->