### PR TITLE
perf: speed up server-rendered HTML escaping

### DIFF
--- a/.changeset/faster-server-html-escaping.md
+++ b/.changeset/faster-server-html-escaping.md
@@ -1,0 +1,6 @@
+---
+'octane': patch
+---
+
+Reduce server-rendered HTML escaping time and temporary allocations while
+preserving iterable snapshots, text security, streaming output, and hydration.

--- a/benchmarks/ssr-throughput/README.md
+++ b/benchmarks/ssr-throughput/README.md
@@ -74,8 +74,14 @@ Octane-specific server paths.
   (hydration markers legitimately differ). **The headline number is the
   plain/compiled ratio** — the SSR authoring cliff a binding-heavy page pays.
 - **`escape-heavy`** — 10k text holes whose every value contains `&<>"'`.
-  Isolates the multi-pass regex `escapeHtml`; a regression here is that one
-  function.
+  Isolates `escapeHtml`. After timing and memory measurement, a deterministic
+  work gate renders the fixture again, checks that its complete response is
+  unchanged, and rejects regular-expression escaping passes. It also reports
+  the number and size of eager list snapshots without changing their semantics.
+  Production profiling attributed about 0.64% of sampled allocated bytes to
+  the list snapshot; its independently measured cost was about 0.025% of
+  render time. Preserving that snapshot protects custom iterators, observable
+  getters, and render-time mutations.
 
 ## Running
 

--- a/benchmarks/ssr-throughput/run.mjs
+++ b/benchmarks/ssr-throughput/run.mjs
@@ -337,6 +337,62 @@ async function deoptGate(mod) {
 	return { fast, plain };
 }
 
+// Sample the escaping work after all timed and memory-growth renders. Native
+// literal replacement avoids three RegExp replacement passes per escaped hole;
+// preserve the eager list snapshot and compare the entire observable response.
+async function escapeWorkGate(mod) {
+	const expected = (await mod.renderEscapeHeavy()).body;
+	const originalReplace = RegExp.prototype[Symbol.replace];
+	const originalArrayFrom = Array.from;
+	let regexEscapePasses = 0;
+	let arraySnapshotCopies = 0;
+	let arraySnapshotEntries = 0;
+	let actual;
+
+	try {
+		RegExp.prototype[Symbol.replace] = function (value, replacement) {
+			if (
+				this.flags === 'g' &&
+				((this.source === '&' && replacement === '&amp;') ||
+					(this.source === '<' && replacement === '&lt;') ||
+					(this.source === '>' && replacement === '&gt;'))
+			) {
+				regexEscapePasses++;
+			}
+			return Reflect.apply(originalReplace, this, [value, replacement]);
+		};
+		Array.from = function (...args) {
+			const result = Reflect.apply(originalArrayFrom, this, args);
+			if (Array.isArray(args[0])) {
+				arraySnapshotCopies++;
+				arraySnapshotEntries += result.length;
+			}
+			return result;
+		};
+		actual = (await mod.renderEscapeHeavy()).body;
+	} finally {
+		RegExp.prototype[Symbol.replace] = originalReplace;
+		Array.from = originalArrayFrom;
+	}
+
+	if (actual !== expected) {
+		throw new Error('escape work instrumentation changed the rendered response');
+	}
+	if (regexEscapePasses !== 0) {
+		throw new Error(
+			`escape-heavy performed ${regexEscapePasses} regular-expression escaping passes`,
+		);
+	}
+	if (arraySnapshotCopies !== 1 || arraySnapshotEntries !== 10000) {
+		throw new Error(
+			`escape-heavy expected one eager 10000-entry snapshot, got ` +
+				`${arraySnapshotCopies} copies containing ${arraySnapshotEntries} entries`,
+		);
+	}
+
+	return { regexEscapePasses, arraySnapshotCopies, arraySnapshotEntries };
+}
+
 configs.push({
 	name: 'deopt-page/octane-fast',
 	group: 'deopt-page',
@@ -366,6 +422,7 @@ configs.push({
 		if (holes !== 10000) throw new Error(`expected 10000 holes, got ${holes}`);
 		return bodyMeta(body);
 	},
+	work: escapeWorkGate,
 });
 
 // ── run ───────────────────────────────────────────────────────────────────────
@@ -388,12 +445,13 @@ for (const cfg of selected) {
 		const fn = cfg.fn(mod);
 		const stats = await timeLoop(fn);
 		const mem = await memGrowth(fn, cfg.batch ? Math.ceil(MEM_RENDERS / cfg.batch) : MEM_RENDERS);
+		const work = cfg.work === undefined ? undefined : await cfg.work(mod);
 		if (cfg.batch) {
 			mem.memRenders *= cfg.batch;
 			// stats time whole batches; surface the effective per-render throughput.
 			meta.rendersPerSec = stats.opsPerSec * cfg.batch;
 		}
-		results.push({ name: cfg.name, group: cfg.group, stats, meta: { ...meta, ...mem } });
+		results.push({ name: cfg.name, group: cfg.group, stats, meta: { ...meta, ...mem, ...work } });
 	} catch (err) {
 		failures.push(`${cfg.name}: ${err.message}`);
 		console.error(`  ✗ ${err.message}`);

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -1099,7 +1099,7 @@ export function createPortal(body: unknown, target: unknown, props: any = undefi
 
 // Guarded escapers: a single .test() scan first, so the common no-escape case
 // returns the ORIGINAL string with zero allocation (~5x on clean text). When
-// something does need escaping, the chained native .replace passes are kept —
+// something does need escaping, native replacement passes are kept —
 // measured faster than an exec-loop or replace-with-callback single pass on V8
 // for both sparse and dense escape densities.
 const HTML_ESCAPE_RE = /[&<>]/g;
@@ -1107,7 +1107,7 @@ export function escapeHtml(v: unknown): string {
 	const s = typeof v === 'string' ? v : String(v);
 	HTML_ESCAPE_RE.lastIndex = 0;
 	if (!HTML_ESCAPE_RE.test(s)) return s;
-	return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+	return s.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
 }
 
 const ATTR_ESCAPE_RE = /[&"]/g;

--- a/packages/octane/tests/ssr.test.ts
+++ b/packages/octane/tests/ssr.test.ts
@@ -3,6 +3,8 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { compile } from 'octane/compiler';
 import * as RT from 'octane/server';
+import { flushSync, hydrateRoot } from '../src/index.js';
+import { Counter as ClientCounter } from './_fixtures/basic.tsrx';
 
 const FIXTURES = join(process.cwd(), 'packages/octane/tests/_fixtures');
 
@@ -129,6 +131,82 @@ describe('SSR Phase 1 — semantics', () => {
 		const out = await RT.renderToString(basic.Greet, { name: '<script>"x"' });
 		expect(out.html).toContain('&lt;script&gt;');
 		expect(out.html).not.toContain('<script>');
+	});
+
+	it.each([
+		['ordinary text and quotes', 'safe "quoted" text', 'safe "quoted" text'],
+		['an ampersand', '&', '&amp;'],
+		['an opening angle bracket', '<', '&lt;'],
+		['a closing angle bracket', '>', '&gt;'],
+		['interleaved sensitive characters', '<&><&>', '&lt;&amp;&gt;&lt;&amp;&gt;'],
+		['existing entities', '&amp;&lt;&#60;', '&amp;amp;&amp;lt;&amp;#60;'],
+		[
+			'hostile markup',
+			'<img src=x onerror=alert(1)>&"',
+			'&lt;img src=x onerror=alert(1)&gt;&amp;"',
+		],
+		[
+			'unpaired surrogates and null characters',
+			'😀\ud800&\udfff<\u0000>',
+			'😀\ud800&amp;\udfff&lt;\u0000&gt;',
+		],
+	])('escapes %s identically in buffered and static markup', (_label, value, expected) => {
+		const expectedMarkup = `<span>${expected}</span>`;
+		expect(RT.renderToString(basic.Counter, { n: value }).html).toBe(expectedMarkup);
+		expect(RT.renderToStaticMarkup(basic.Counter, { n: value }).html).toBe(expectedMarkup);
+	});
+
+	it('coerces escaped text exactly once and keeps nested server rendering isolated', () => {
+		const coercions: string[] = [];
+		const value = {
+			[Symbol.toPrimitive](hint: string) {
+				coercions.push(hint);
+				expect(RT.renderToString(basic.Counter, { n: '<nested>&' }).html).toBe(
+					'<span>&lt;nested&gt;&amp;</span>',
+				);
+				return '&<outer>';
+			},
+		};
+
+		expect(RT.renderToString(basic.Counter, { n: value }).html).toBe(
+			'<span>&amp;&lt;outer&gt;</span>',
+		);
+		expect(coercions).toEqual(['string']);
+	});
+
+	it('propagates text coercion failures without retrying coercion', () => {
+		const failure = new Error('text coercion failed');
+		const coerce = vi.fn(() => {
+			throw failure;
+		});
+
+		expect(() => RT.renderToString(basic.Counter, { n: { [Symbol.toPrimitive]: coerce } })).toThrow(
+			failure,
+		);
+		expect(coerce).toHaveBeenCalledTimes(1);
+	});
+
+	it('streams escaped text without introducing executable markup', async () => {
+		const value = '&<script>alert("x")</script>&amp;';
+		const stream = await RT.renderToReadableStream(basic.Counter, { n: value });
+		const html = await new Response(stream).text();
+
+		expect(html).toBe('<span>&amp;&lt;script&gt;alert("x")&lt;/script&gt;&amp;amp;</span>');
+		expect(html).not.toContain('<script>');
+	});
+
+	it('hydrates escaped text by adopting the existing server-rendered node', () => {
+		const value = '&<script>"quoted"</script>&amp;';
+		const container = document.createElement('div');
+		container.innerHTML = RT.renderToString(basic.Counter, { n: value }).html;
+		const serverNode = container.querySelector('span');
+		const root = hydrateRoot(container, ClientCounter, { n: value });
+		flushSync(() => {});
+
+		expect(container.querySelector('span')).toBe(serverNode);
+		expect(serverNode?.textContent).toBe(value);
+		expect(container.querySelector('script')).toBeNull();
+		root.unmount();
 	});
 
 	it('hooks render their initial value; effects do NOT run on the server', async () => {


### PR DESCRIPTION
## Summary

- Investigate phase four of #611 against untouched production SSR builds before changing server-loop behavior.
- Reject array-snapshot removal: the existing `Array.from` copy consumes approximately 0.64% of sampled allocated bytes and 0.025% of total render time, while alternatives that preserve custom iterators, proxies, getter ordering, eager mutation snapshots, and suspension were 6–20 times slower.
- Preserve the exact eager array snapshot and instead replace the three dirty-text regular-expression escaping passes with equivalent native literal replacement passes.
- Add consumer-visible coverage for hostile markup, pre-escaped entities, Unicode/surrogates, coercion and reentrant rendering, errors, streaming, and hydration adoption.
- Extend the existing SSR throughput benchmark with an untimed deterministic gate requiring zero regex escaping passes, exactly one 10,000-item eager array snapshot, and byte-identical rendered HTML.

Same-session balanced production measurements:

| Measurement | Upstream | This change |
| --- | ---: | ---: |
| Escape-heavy SSR, 120 balanced renders | 3.7462 ms | 2.9676 ms (-20.8%) |
| Sampled allocation volume | 249.04 MB | 213.98 MB (-14.1%) |
| Compiled application SSR, 160 balanced pairs | 1.0161 ms | 1.0106 ms (neutral) |
| Streaming SSR, 56 balanced pairs | 1.3967 ms | 1.3950 ms (neutral) |
| Server production bundle gzip | baseline | +14 bytes |
| Eager array snapshot | 1 copy / 10,000 entries | 1 copy / 10,000 entries |

The compiled, streaming, and escaped HTML outputs remain byte-identical.

Part of #611.

## Validation

- [x] `pnpm format:check`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [x] targeted tests: the exhaustive Octane core development suite (401 files; 5,937 tests) and production suite (365 files; 4,876 tests), totaling 10,813 passing tests.
- [x] `./node_modules/.bin/tsgo --noEmit -p packages/octane/tsconfig.json`.
- [x] `./node_modules/.bin/tsgo --noEmit -p packages/octane/typetests/tsconfig.json`.
- [x] `CONFIGS=escape,deopt,waterfall,parallel node benchmarks/ssr-throughput/run.mjs 0.1 --quick --no-build` across seven Octane SSR scenarios, including the new deterministic work gate.
- [x] `TARGETS=octane node benchmarks/streaming-ssr/run.mjs 3 --no-build` across staggered and all-fast modes.
- [x] `pnpm sync`.
- [x] 120-render production ABBA, 160-pair ordinary SSR control, 56-pair streaming control, allocation sampling, and exact HTML hashes.

## Risk / follow-ups

- The clean-text guard, attribute escaper, iterator protocol, snapshot timing, generated compiler output, client bundle, and hydration markers are unchanged.
- A deliberately broken `<` escaping implementation makes the new buffered, hostile-markup, and streamed-output tests fail; restoring it makes both compile modes pass.
- The latest upstream lockfile contains Preact and Ripple packages unavailable from the configured package registry. Validation therefore uses the exact locked, cached Octane dependencies and faithful repository-root core development/production configurations. Exactly two unrelated installed-binding discovery suites (`external-hook-slot.test.ts` and `register-hook.test.ts`) are excluded because their optional packages cannot be installed; every SSR, security, streaming, hydration, compiler, and runtime suite remains included. Full cross-framework workspace checks are explicitly not claimed.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!--
Tick the box above whenever an agent wrote the change, no matter which account
pushes it. Leaving it clear or omitting this section asserts a human wrote the
diff; either form keeps the label workflow successful.

A bot reads this box and applies the label, so nothing here needs repository
permissions and it works the same from a fork. The type label comes from the
conventional-commit type in the title, with the type-prefixed head branch as a
fallback. Do not apply either by hand.

When updating an existing pull request, merge this template content into the
current body. Preserve every bot-managed HTML comment region and all existing
maintainer-authored text; never replace the body from a fresh template.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-sensitive HTML escaping on the server; behavior is heavily tested and benchmark-gated, but any escaper regression could affect XSS safety.
> 
> **Overview**
> **Server `escapeHtml`** still uses a single pre-scan on clean text; when escaping is needed, the three global-regex `.replace` passes are swapped for **`String.prototype.replaceAll`** with literal targets (`&`, `<`, `>`). The attribute escaper, list snapshot behavior, and streaming/hydration paths are intentionally unchanged.
> 
> The **escape-heavy SSR benchmark** gains a post-run **work gate** that re-renders under instrumentation: it fails if HTML escaping still goes through the old regex replacement pattern, if the 10k-item list is not snapshotted exactly once via `Array.from`, or if the response body differs. README and changeset document the perf goal and preserved semantics.
> 
> **SSR tests** expand coverage for escaped text across buffered/static markup, coercion and errors, streaming output, and hydration adopting server nodes—without changing production behavior beyond the escaper implementation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13a0de5943be7ab52a4551878796550cdc7a0bec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->