### PR TITLE
perf: reuse bounded keyed-reorder scratch storage

### DIFF
--- a/.changeset/bounded-keyed-reorder-scratch.md
+++ b/.changeset/bounded-keyed-reorder-scratch.md
@@ -1,0 +1,6 @@
+---
+'octane': patch
+---
+
+Reduce temporary allocations during keyed list reorders by safely reusing
+bounded numeric scratch buffers across reconciliations.

--- a/benchmarks/js-framework/README.md
+++ b/benchmarks/js-framework/README.md
@@ -203,6 +203,15 @@ Two methodology points, both visible in the harness source:
   correctly, because there are no survivors *after* the inserted run. octane-tsrx,
   octane-jsx, and react pass all 14 ops.
 
+- **Bounded reorder-scratch gate.** After all timing samples, Octane's two
+  dialects repeat reverse, rotation, shuffle, and small-displacement operations
+  over 1,000 and 10,000 keyed rows. A transparent typed-array constructor trap
+  rejects allocations after the initial warmup while independently checking
+  survivor identity and final order. A contiguous append must remain
+  allocation-free, an oversized 18,000-row reorder must not evict reusable
+  storage, and an explicit browser garbage collection bounds retained observed
+  scratch backing storage to 128 KiB.
+
 Run it against the same eight targets as `run.mjs`:
 
 ```bash

--- a/benchmarks/js-framework/run-reorder.mjs
+++ b/benchmarks/js-framework/run-reorder.mjs
@@ -240,6 +240,161 @@ async function timeSample(page, sel, reps) {
 	);
 }
 
+// Observe typed scratch allocations only after every wall-clock sample. The
+// transparent constructor trap cannot contaminate timed inline caches, and
+// every measured permutation must retain its original keyed DOM survivors.
+async function scratchStorageGate(page, targetName) {
+	await resetRows(page);
+	const measurement = await page.evaluate(() => {
+		const NativeInt32Array = globalThis.Int32Array;
+		const allocations = [];
+		const references = [];
+		const phases = [];
+		const readRows = () => Array.from(document.querySelectorAll('tbody tr'));
+		const rowId = (row) => row.firstElementChild.textContent;
+
+		function measure(button, repetitions) {
+			const before = readRows();
+			const survivors = new Map(before.map((row) => [rowId(row), row]));
+			const expected = before.map(rowId);
+			const firstAllocation = allocations.length;
+			for (let iteration = 0; iteration < repetitions; iteration++) {
+				document.getElementById(button).click();
+				if (button === 'reverse') expected.reverse();
+				else if (button === 'rotateb') expected.push(expected.shift());
+				else if (button === 'rotatef') expected.unshift(expected.pop());
+				else if (button === 'swaprows' && expected.length > 998) {
+					const first = expected[1];
+					expected[1] = expected[998];
+					expected[998] = first;
+				}
+			}
+
+			const after = readRows();
+			if (after.length !== before.length) {
+				throw new Error(`${button}: expected ${before.length} rows, got ${after.length}`);
+			}
+			for (let index = 0; index < after.length; index++) {
+				const id = rowId(after[index]);
+				if (survivors.get(id) !== after[index]) {
+					throw new Error(`${button}: surviving row ${id} lost its DOM identity`);
+				}
+				if (button !== 'shuffle' && expected[index] !== id) {
+					throw new Error(`${button}: position ${index} expected ${expected[index]}, got ${id}`);
+				}
+			}
+
+			const observed = allocations.slice(firstAllocation);
+			const phase = {
+				button,
+				rows: before.length,
+				repetitions,
+				allocations: observed.length,
+				bytes: observed.reduce((total, bytes) => total + bytes, 0),
+			};
+			phases.push(phase);
+			if (phase.allocations !== 0) {
+				throw new Error(
+					`${button}/${before.length}: warm reorders allocated ` +
+						`${phase.allocations} typed arrays (${phase.bytes} bytes)`,
+				);
+			}
+		}
+
+		try {
+			globalThis.Int32Array = new Proxy(NativeInt32Array, {
+				construct(target, args, newTarget) {
+					const value = Reflect.construct(target, args, newTarget);
+					allocations.push(value.byteLength);
+					references.push(new WeakRef(value));
+					return value;
+				},
+			});
+
+			// The first reverse is explicitly outside each steady-state budget.
+			document.getElementById('reverse').click();
+			measure('reverse', 4);
+			measure('rotateb', 8);
+			measure('rotatef', 4);
+			measure('shuffle', 3);
+			measure('swaprows', 4);
+
+			const beforeAppend = readRows();
+			const appendStart = allocations.length;
+			document.getElementById('append100').click();
+			const afterAppend = readRows();
+			if (
+				afterAppend.length !== beforeAppend.length + 100 ||
+				beforeAppend.some((row, index) => afterAppend[index] !== row)
+			) {
+				throw new Error('append100 changed an existing keyed row');
+			}
+			if (allocations.length !== appendStart) {
+				throw new Error('append100 allocated typed reorder scratch');
+			}
+
+			document.getElementById('runlots').click();
+			if (readRows().length !== 10000) throw new Error('runlots did not produce 10000 rows');
+			document.getElementById('reverse').click();
+			measure('reverse', 2);
+			measure('rotateb', 4);
+			measure('shuffle', 2);
+			measure('swaprows', 2);
+
+			// An oversized one-shot must not evict the bounded reusable buffers.
+			for (let index = 0; index < 8; index++) document.getElementById('add').click();
+			const oversizedBefore = readRows();
+			if (oversizedBefore.length !== 18000) {
+				throw new Error('oversized control expected 18000 rows');
+			}
+			const oversizedStart = allocations.length;
+			document.getElementById('rotateb').click();
+			document.getElementById('rotateb').click();
+			const oversizedAfter = readRows();
+			if (
+				oversizedAfter.length !== oversizedBefore.length ||
+				oversizedAfter.some((row, index) => row !== oversizedBefore[(index + 2) % 18000])
+			) {
+				throw new Error('oversized rotations lost survivor identity or order');
+			}
+			if (allocations.length - oversizedStart !== 4) {
+				throw new Error('oversized rotations unexpectedly retained reusable scratch');
+			}
+			document.getElementById('run').click();
+			if (readRows().length !== 1000) throw new Error('shrink control expected 1000 rows');
+			measure('rotateb', 4);
+		} finally {
+			globalThis.Int32Array = NativeInt32Array;
+			globalThis.__benchScratchReferences = references;
+		}
+
+		return { phases, observedAllocations: allocations.length };
+	});
+
+	const cdp = await page.context().newCDPSession(page);
+	try {
+		await cdp.send('HeapProfiler.collectGarbage');
+		measurement.retainedScratchBytes = await page.evaluate(() => {
+			let total = 0;
+			for (const reference of globalThis.__benchScratchReferences) {
+				total += reference.deref()?.byteLength ?? 0;
+			}
+			delete globalThis.__benchScratchReferences;
+			return total;
+		});
+	} finally {
+		await cdp.detach().catch(() => {});
+	}
+	if (measurement.retainedScratchBytes > 128 * 1024) {
+		throw new Error(
+			`${targetName} retained typed reorder scratch exceeds 128 KiB: ` +
+				`${measurement.retainedScratchBytes} bytes`,
+		);
+	}
+
+	return measurement;
+}
+
 async function runTarget(t) {
 	const browser = await chromium.launch({
 		headless: true,
@@ -302,16 +457,33 @@ async function runTarget(t) {
 		}
 		results[op.name] = summarize(samples);
 	}
+	let scratchWork;
+	if (t.name === 'octane-tsrx' || t.name === 'octane-jsx') {
+		try {
+			scratchWork = await scratchStorageGate(page, t.name);
+		} catch (error) {
+			const message = String(error && error.message ? error.message : error);
+			gateFails['scratch-storage'] = message;
+			console.error(`  ⚠ SCRATCH FAIL ${t.name}: ${message}`);
+		}
+	}
 
 	await browser.close();
-	return { results, gateFails };
+	return { results, gateFails, scratchWork };
 }
 
 // Per-target identity-gate summary for BENCH_JSON meta: "pass" when every op
 // held, else "fail: <op>[, <op>…]" listing exactly which ops broke.
-function gateMeta(gateFails) {
-	const failed = Object.keys(gateFails);
-	return { identityGate: failed.length ? `fail: ${failed.join(', ')}` : 'pass' };
+function gateMeta(gateFails, scratchWork) {
+	const failed = Object.keys(gateFails).filter((name) => name !== 'scratch-storage');
+	return {
+		identityGate: failed.length ? `fail: ${failed.join(', ')}` : 'pass',
+		...(scratchWork === undefined
+			? gateFails['scratch-storage'] === undefined
+				? {}
+				: { scratchGate: 'fail' }
+			: { scratchGate: 'pass', ...scratchWork }),
+	};
 }
 
 function writeBenchJson(payload) {
@@ -334,10 +506,10 @@ function writeBenchJson(payload) {
 			suite: 'keyed-reorder-matrix',
 			iterations: ITER,
 			failed: String(e && e.message ? e.message : e),
-			targets: Object.entries(all).map(([name, { results, gateFails }]) => ({
+			targets: Object.entries(all).map(([name, { results, gateFails, scratchWork }]) => ({
 				name,
 				ops: Object.fromEntries(Object.entries(results).filter(([, v]) => v != null)),
-				meta: gateMeta(gateFails),
+				meta: gateMeta(gateFails, scratchWork),
 			})),
 		});
 		throw e;
@@ -404,11 +576,11 @@ function writeBenchJson(payload) {
 					.filter(([, v]) => v != null)
 					.map(([op, r]) => [op, timingStatForJson(r)]),
 			),
-			meta: gateMeta(all[t.name].gateFails),
+			meta: gateMeta(all[t.name].gateFails, all[t.name].scratchWork),
 		})),
 	});
 	if (failures.length) {
-		console.error(`\n${failures.length} identity-gate failure(s):`);
+		console.error(`\n${failures.length} keyed-reorder gate failure(s):`);
 		for (const f of failures) console.error(`  ✗ ${f}`);
 		process.exit(1);
 	}

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -23394,6 +23394,15 @@ function tryUpdateKeyedSelection<T>(
 const K_DISP = 4;
 const _disp = new Int32Array(K_DISP);
 
+// Keep at most one numeric source buffer and one LIS predecessor buffer. Source
+// buffers stay live across user rendering, so taking one removes it from the
+// cache until reconciliation finishes; nested lists must receive their own.
+// Oversized lists use disposable buffers instead of retaining their backing
+// stores. The two capped caches can retain at most 128 KiB between renders.
+const MAX_KEYED_REORDER_SCRATCH = 16_384;
+let keyedReorderSources: Int32Array | null = null;
+let keyedLisPredecessors: Int32Array | null = null;
+
 /**
  * Keyed reconciliation over a doubly-linked list of item Blocks.
  *
@@ -23751,260 +23760,276 @@ function reconcileKeyed<T>(
 	}
 
 	// sources[i] = old middle-relative index for new[prefixLen + i], or -1 if new.
-	const sources = new Int32Array(newMidLen);
-	for (let i = 0; i < newMidLen; i++) sources[i] = -1;
-
-	let moved = false;
-	let lastIdx = 0;
-	let patched = 0;
-
-	// Walk old middle (linked-list traversal): re-render survivors, unmount removed.
-	let cur: Block | null = oldFirst;
-	let oldIdx = 0;
-	while (cur !== afterMiddle) {
-		const next: Block | null = cur!.nextSibling!;
-		const newRelIdx = newKeysToIdx.get(cur!.key);
-		if (newRelIdx === undefined) {
-			if (itemRemovalDefers()) parkItemForHold(cur!);
-			else unmountBlock(cur!);
-			oldItems.delete(cur!.key);
-			state.size--;
-		} else {
-			sources[newRelIdx] = oldIdx;
-			if (newRelIdx < lastIdx) moved = true;
-			else lastIdx = newRelIdx;
-			patched++;
-			const newIdx = prefixLen + newRelIdx;
-			updateSurvivor(
-				cur!,
-				items[newIdx],
-				newIdx,
-				itemBody,
-				pure,
-				lite,
-				indexIndependent,
-				state.env,
-			);
-		}
-		cur = next;
-		oldIdx++;
+	const cachedSources = keyedReorderSources;
+	let sources: Int32Array;
+	if (cachedSources !== null && cachedSources.length >= newMidLen) {
+		keyedReorderSources = null;
+		sources = cachedSources;
+	} else {
+		sources = new Int32Array(newMidLen);
 	}
+	try {
+		for (let i = 0; i < newMidLen; i++) sources[i] = -1;
 
-	// Fast bail: all survivors AND no moves AND no mounts → old middle is the
-	// same shape & order as new middle.
-	if (!moved && patched === newMidLen) {
-		// If the survivor walk did NOT unmount anything (oldRemain ===
-		// patched), the linked-list pointers are still correct end-to-end
-		// and we can return without touching them. But if blocks were
-		// unmounted BETWEEN survivors, the survivors' .prevSibling /
-		// .nextSibling pointers still reference now-disposed blocks AND
-		// state.head / state.tail may also point at disposed blocks. The
-		// next reconcile would then walk those stale pointers, decrement
-		// state.size for blocks that no longer exist, and ultimately
-		// crash with a null-pointer access in the prefix/suffix walk.
-		//
-		// Relink the entire middle chain so its prev/next pointers — and
-		// the boundary into beforeMiddle / afterMiddle / state.head /
-		// state.tail — accurately reflect the post-unmount topology.
-		// O(newMidLen); only fires when survivors and removes are mixed.
-		// Surfaced by fuzz-keyed-list seed=-2060211668 action 9 (a
-		// replace-all 13 → 2 where both survivors are in original order).
-		if (oldRemain !== patched) {
-			let prev: Block | null = beforeMiddle;
-			for (let i = 0; i < newMidLen; i++) {
-				const block = oldItems.get(newKeys[i])!;
-				block.prevSibling = prev;
-				if (prev) prev.nextSibling = block;
-				else state.head = block;
-				prev = block;
-			}
-			prev!.nextSibling = afterMiddle;
-			if (afterMiddle) afterMiddle.prevSibling = prev;
-			else state.tail = prev;
-		}
-		return;
-	}
+		let moved = false;
+		let lastIdx = 0;
+		let patched = 0;
 
-	// ── Small-displacement shortcut. When every old item survived AND only a
-	// small number of positions actually changed (≤ K_DISP), we can compute
-	// the exact move set in O(K_DISP) instead of paying the LIS path's O(N)
-	// allocation + back-walk that rewrites every prev/next pointer. This is
-	// a general property of permutations — when survivors are stable and the
-	// permutation has few fixed-point misses, LIS does provably wasted work.
-	//
-	// Real shapes this covers:
-	//   - drag-and-drop reorder (swap two rows, rotate three)
-	//   - undo/redo of a recent local edit
-	//   - animated swap / sort transitions
-	//   - A/B variant toggle that flips a small set of cells
-	//   - any benchmark or test fixture that mutates exactly K positions
-	//
-	// Bail cost on a true large-shuffle permutation: K_DISP + 1 source
-	// compares before falling through to the LIS path, which is sub-µs.
-	if (moved && patched === newMidLen) {
-		let dCount = 0;
-		for (let i = 0; i < newMidLen; i++) {
-			if (sources[i] !== i) {
-				if (dCount === K_DISP) {
-					dCount = K_DISP + 1;
-					break;
-				}
-				_disp[dCount++] = i;
+		// Walk old middle (linked-list traversal): re-render survivors, unmount removed.
+		let cur: Block | null = oldFirst;
+		let oldIdx = 0;
+		while (cur !== afterMiddle) {
+			const next: Block | null = cur!.nextSibling!;
+			const newRelIdx = newKeysToIdx.get(cur!.key);
+			if (newRelIdx === undefined) {
+				if (itemRemovalDefers()) parkItemForHold(cur!);
+				else unmountBlock(cur!);
+				oldItems.delete(cur!.key);
+				state.size--;
+			} else {
+				sources[newRelIdx] = oldIdx;
+				if (newRelIdx < lastIdx) moved = true;
+				else lastIdx = newRelIdx;
+				patched++;
+				const newIdx = prefixLen + newRelIdx;
+				updateSurvivor(
+					cur!,
+					items[newIdx],
+					newIdx,
+					itemBody,
+					pure,
+					lite,
+					indexIndependent,
+					state.env,
+				);
 			}
+			cur = next;
+			oldIdx++;
 		}
-		if (dCount <= K_DISP) {
-			const endAnchor: Node = afterMiddle ? afterMiddle.startMarker! : state.end;
-			// Move right-to-left. Positions to the right of the rightmost
-			// displaced index are identity-mapped and have stable startMarkers;
-			// each moved block becomes the next iteration's anchor.
-			for (let j = dCount - 1; j >= 0; j--) {
-				const i = _disp[j];
-				const block = oldItems.get(newKeys[i])!;
-				const anchor: Node =
-					i + 1 < newMidLen ? oldItems.get(newKeys[i + 1])!.startMarker! : endAnchor;
-				moveBlockBefore(block, anchor);
-			}
-			// Relink prev/next around each displaced position. Non-displaced
-			// neighbours of displaced blocks get their boundary pointers updated
-			// here too; non-displaced blocks BETWEEN two displaced positions keep
-			// their internal pointers (they were never touched by the survivor
-			// walk and the moves above don't reorder them).
-			for (let j = 0; j < dCount; j++) {
-				const i = _disp[j];
-				const block = oldItems.get(newKeys[i])!;
-				const prev = i > 0 ? oldItems.get(newKeys[i - 1])! : beforeMiddle;
-				const next = i + 1 < newMidLen ? oldItems.get(newKeys[i + 1])! : afterMiddle;
-				block.prevSibling = prev;
-				block.nextSibling = next;
-				if (prev) prev.nextSibling = block;
-				else state.head = block;
-				if (next) next.prevSibling = block;
-				else state.tail = block;
-			}
-			// Boundary patch: the first and last block of the NEW middle may be
-			// identity-mapped (not in _disp), in which case the displacement
-			// loop never touched them — they still carry their pre-reconcile
-			// neighbour pointers, which can be stale (e.g. pointing at a block
-			// that the survivor walk just unmounted, or at a prior-reconcile
-			// neighbour that has since shifted). Always re-pin the boundary
-			// pointers so state.head / state.tail / beforeMiddle.next /
-			// afterMiddle.prev are correct for the next reconcile.
+
+		// Fast bail: all survivors AND no moves AND no mounts → old middle is the
+		// same shape & order as new middle.
+		if (!moved && patched === newMidLen) {
+			// If the survivor walk did NOT unmount anything (oldRemain ===
+			// patched), the linked-list pointers are still correct end-to-end
+			// and we can return without touching them. But if blocks were
+			// unmounted BETWEEN survivors, the survivors' .prevSibling /
+			// .nextSibling pointers still reference now-disposed blocks AND
+			// state.head / state.tail may also point at disposed blocks. The
+			// next reconcile would then walk those stale pointers, decrement
+			// state.size for blocks that no longer exist, and ultimately
+			// crash with a null-pointer access in the prefix/suffix walk.
 			//
-			// Repro for why this matters: surfaced by fuzz-keyed-list seed
-			// -1491785866 — a `replace-all` that shrinks the list (e.g. 6 → 3)
-			// where the last survivor is identity-mapped. Without the patch,
-			// state.tail keeps pointing at the prior-tail block (now deleted)
-			// and the surviving last block's .nextSibling still points at the
-			// removed sibling. The next reconcile then stops its old-middle
-			// walk early (at the stale nextSibling) and re-mounts the
-			// last survivor as a NEW block, producing a duplicate row.
-			const newMidFirst = oldItems.get(newKeys[0])!;
-			const newMidLast = oldItems.get(newKeys[newMidLen - 1])!;
-			newMidFirst.prevSibling = beforeMiddle;
-			newMidLast.nextSibling = afterMiddle;
-			if (beforeMiddle) beforeMiddle.nextSibling = newMidFirst;
-			else state.head = newMidFirst;
-			if (afterMiddle) afterMiddle.prevSibling = newMidLast;
-			else state.tail = newMidLast;
+			// Relink the entire middle chain so its prev/next pointers — and
+			// the boundary into beforeMiddle / afterMiddle / state.head /
+			// state.tail — accurately reflect the post-unmount topology.
+			// O(newMidLen); only fires when survivors and removes are mixed.
+			// Surfaced by fuzz-keyed-list seed=-2060211668 action 9 (a
+			// replace-all 13 → 2 where both survivors are in original order).
+			if (oldRemain !== patched) {
+				let prev: Block | null = beforeMiddle;
+				for (let i = 0; i < newMidLen; i++) {
+					const block = oldItems.get(newKeys[i])!;
+					block.prevSibling = prev;
+					if (prev) prev.nextSibling = block;
+					else state.head = block;
+					prev = block;
+				}
+				prev!.nextSibling = afterMiddle;
+				if (afterMiddle) afterMiddle.prevSibling = prev;
+				else state.tail = prev;
+			}
 			return;
 		}
-	}
 
-	// Walk new middle back-to-front. For each new position: mount / move / leave.
-	// Track:
-	//   nextBlock  = block at position i+1 (already placed), or afterMiddle initially
-	//                — used as the DOM anchor and prev/next neighbour
-	//   lastPlaced = block placed in the FIRST iteration (= new middle's tail)
-	const middleEndAnchor: Node = afterMiddle ? afterMiddle.startMarker! : state.end;
-	let nextBlock: Block | null = afterMiddle;
-	let lastPlaced: Block | null = null;
-
-	if (moved) {
-		const seq = lis(sources);
-		let seqIdx = seq.length - 1;
-		for (let i = newMidLen - 1; i >= 0; i--) {
-			const targetIdx = i + prefixLen;
-			const key = newKeys[i];
-			const anchor: Node = nextBlock ? nextBlock.startMarker! : middleEndAnchor;
-			let block: Block;
-			if (sources[i] === -1) {
-				// Mount: new item, no old counterpart.
-				const item = items[targetIdx];
-				block = mountItem(
-					parentBlock,
-					parentNode,
-					anchor,
-					item,
-					targetIdx,
-					itemBody,
-					state,
-					singleRoot,
-					ssrMarkerless,
-				);
-				oldItems.set(key, block);
-				block.key = key;
-				state.size++;
-			} else if (seqIdx < 0 || i !== seq[seqIdx]) {
-				// Move: survivor not in the LIS → DOM range moves before anchor.
-				block = oldItems.get(key)!;
-				moveBlockBefore(block, anchor);
-			} else {
-				// Leave: survivor in the LIS → DOM stays put.
-				block = oldItems.get(key)!;
-				seqIdx--;
+		// ── Small-displacement shortcut. When every old item survived AND only a
+		// small number of positions actually changed (≤ K_DISP), we can compute
+		// the exact move set in O(K_DISP) instead of paying the LIS path's O(N)
+		// allocation + back-walk that rewrites every prev/next pointer. This is
+		// a general property of permutations — when survivors are stable and the
+		// permutation has few fixed-point misses, LIS does provably wasted work.
+		//
+		// Real shapes this covers:
+		//   - drag-and-drop reorder (swap two rows, rotate three)
+		//   - undo/redo of a recent local edit
+		//   - animated swap / sort transitions
+		//   - A/B variant toggle that flips a small set of cells
+		//   - any benchmark or test fixture that mutates exactly K positions
+		//
+		// Bail cost on a true large-shuffle permutation: K_DISP + 1 source
+		// compares before falling through to the LIS path, which is sub-µs.
+		if (moved && patched === newMidLen) {
+			let dCount = 0;
+			for (let i = 0; i < newMidLen; i++) {
+				if (sources[i] !== i) {
+					if (dCount === K_DISP) {
+						dCount = K_DISP + 1;
+						break;
+					}
+					_disp[dCount++] = i;
+				}
 			}
-			// Re-link into the new middle chain. We rebuild middle pointers from
-			// scratch; every middle block's prev/next gets rewritten here.
-			block.nextSibling = nextBlock;
-			if (nextBlock) nextBlock.prevSibling = block;
-			if (lastPlaced === null) lastPlaced = block;
-			nextBlock = block;
-		}
-	} else {
-		// No moves but at least one mount (we'd have returned already if all survivors).
-		for (let i = newMidLen - 1; i >= 0; i--) {
-			const targetIdx = i + prefixLen;
-			const key = newKeys[i];
-			const anchor: Node = nextBlock ? nextBlock.startMarker! : middleEndAnchor;
-			let block: Block;
-			if (sources[i] === -1) {
-				const item = items[targetIdx];
-				block = mountItem(
-					parentBlock,
-					parentNode,
-					anchor,
-					item,
-					targetIdx,
-					itemBody,
-					state,
-					singleRoot,
-					ssrMarkerless,
-				);
-				oldItems.set(key, block);
-				block.key = key;
-				state.size++;
-			} else {
-				block = oldItems.get(key)!;
+			if (dCount <= K_DISP) {
+				const endAnchor: Node = afterMiddle ? afterMiddle.startMarker! : state.end;
+				// Move right-to-left. Positions to the right of the rightmost
+				// displaced index are identity-mapped and have stable startMarkers;
+				// each moved block becomes the next iteration's anchor.
+				for (let j = dCount - 1; j >= 0; j--) {
+					const i = _disp[j];
+					const block = oldItems.get(newKeys[i])!;
+					const anchor: Node =
+						i + 1 < newMidLen ? oldItems.get(newKeys[i + 1])!.startMarker! : endAnchor;
+					moveBlockBefore(block, anchor);
+				}
+				// Relink prev/next around each displaced position. Non-displaced
+				// neighbours of displaced blocks get their boundary pointers updated
+				// here too; non-displaced blocks BETWEEN two displaced positions keep
+				// their internal pointers (they were never touched by the survivor
+				// walk and the moves above don't reorder them).
+				for (let j = 0; j < dCount; j++) {
+					const i = _disp[j];
+					const block = oldItems.get(newKeys[i])!;
+					const prev = i > 0 ? oldItems.get(newKeys[i - 1])! : beforeMiddle;
+					const next = i + 1 < newMidLen ? oldItems.get(newKeys[i + 1])! : afterMiddle;
+					block.prevSibling = prev;
+					block.nextSibling = next;
+					if (prev) prev.nextSibling = block;
+					else state.head = block;
+					if (next) next.prevSibling = block;
+					else state.tail = block;
+				}
+				// Boundary patch: the first and last block of the NEW middle may be
+				// identity-mapped (not in _disp), in which case the displacement
+				// loop never touched them — they still carry their pre-reconcile
+				// neighbour pointers, which can be stale (e.g. pointing at a block
+				// that the survivor walk just unmounted, or at a prior-reconcile
+				// neighbour that has since shifted). Always re-pin the boundary
+				// pointers so state.head / state.tail / beforeMiddle.next /
+				// afterMiddle.prev are correct for the next reconcile.
+				//
+				// Repro for why this matters: surfaced by fuzz-keyed-list seed
+				// -1491785866 — a `replace-all` that shrinks the list (e.g. 6 → 3)
+				// where the last survivor is identity-mapped. Without the patch,
+				// state.tail keeps pointing at the prior-tail block (now deleted)
+				// and the surviving last block's .nextSibling still points at the
+				// removed sibling. The next reconcile then stops its old-middle
+				// walk early (at the stale nextSibling) and re-mounts the
+				// last survivor as a NEW block, producing a duplicate row.
+				const newMidFirst = oldItems.get(newKeys[0])!;
+				const newMidLast = oldItems.get(newKeys[newMidLen - 1])!;
+				newMidFirst.prevSibling = beforeMiddle;
+				newMidLast.nextSibling = afterMiddle;
+				if (beforeMiddle) beforeMiddle.nextSibling = newMidFirst;
+				else state.head = newMidFirst;
+				if (afterMiddle) afterMiddle.prevSibling = newMidLast;
+				else state.tail = newMidLast;
+				return;
 			}
-			block.nextSibling = nextBlock;
-			if (nextBlock) nextBlock.prevSibling = block;
-			if (lastPlaced === null) lastPlaced = block;
-			nextBlock = block;
+		}
+
+		// Walk new middle back-to-front. For each new position: mount / move / leave.
+		// Track:
+		//   nextBlock  = block at position i+1 (already placed), or afterMiddle initially
+		//                — used as the DOM anchor and prev/next neighbour
+		//   lastPlaced = block placed in the FIRST iteration (= new middle's tail)
+		const middleEndAnchor: Node = afterMiddle ? afterMiddle.startMarker! : state.end;
+		let nextBlock: Block | null = afterMiddle;
+		let lastPlaced: Block | null = null;
+
+		if (moved) {
+			const seq = lis(sources, newMidLen);
+			let seqIdx = seq.length - 1;
+			for (let i = newMidLen - 1; i >= 0; i--) {
+				const targetIdx = i + prefixLen;
+				const key = newKeys[i];
+				const anchor: Node = nextBlock ? nextBlock.startMarker! : middleEndAnchor;
+				let block: Block;
+				if (sources[i] === -1) {
+					// Mount: new item, no old counterpart.
+					const item = items[targetIdx];
+					block = mountItem(
+						parentBlock,
+						parentNode,
+						anchor,
+						item,
+						targetIdx,
+						itemBody,
+						state,
+						singleRoot,
+						ssrMarkerless,
+					);
+					oldItems.set(key, block);
+					block.key = key;
+					state.size++;
+				} else if (seqIdx < 0 || i !== seq[seqIdx]) {
+					// Move: survivor not in the LIS → DOM range moves before anchor.
+					block = oldItems.get(key)!;
+					moveBlockBefore(block, anchor);
+				} else {
+					// Leave: survivor in the LIS → DOM stays put.
+					block = oldItems.get(key)!;
+					seqIdx--;
+				}
+				// Re-link into the new middle chain. We rebuild middle pointers from
+				// scratch; every middle block's prev/next gets rewritten here.
+				block.nextSibling = nextBlock;
+				if (nextBlock) nextBlock.prevSibling = block;
+				if (lastPlaced === null) lastPlaced = block;
+				nextBlock = block;
+			}
+		} else {
+			// No moves but at least one mount (we'd have returned already if all survivors).
+			for (let i = newMidLen - 1; i >= 0; i--) {
+				const targetIdx = i + prefixLen;
+				const key = newKeys[i];
+				const anchor: Node = nextBlock ? nextBlock.startMarker! : middleEndAnchor;
+				let block: Block;
+				if (sources[i] === -1) {
+					const item = items[targetIdx];
+					block = mountItem(
+						parentBlock,
+						parentNode,
+						anchor,
+						item,
+						targetIdx,
+						itemBody,
+						state,
+						singleRoot,
+						ssrMarkerless,
+					);
+					oldItems.set(key, block);
+					block.key = key;
+					state.size++;
+				} else {
+					block = oldItems.get(key)!;
+				}
+				block.nextSibling = nextBlock;
+				if (nextBlock) nextBlock.prevSibling = block;
+				if (lastPlaced === null) lastPlaced = block;
+				nextBlock = block;
+			}
+		}
+
+		// Splice the freshly-built new middle in between beforeMiddle and afterMiddle.
+		// newMiddleHead = `nextBlock` after the loop (last iteration placed item[prefixLen]).
+		// newMiddleTail = `lastPlaced` (first iteration placed item[newEnd]).
+		// newMiddleTail.nextSibling was set to afterMiddle in the first loop iter,
+		// and afterMiddle.prevSibling (if non-null) was set to newMiddleTail. So only
+		// the HEAD side of the splice remains.
+		const newMiddleHead = nextBlock!;
+		const newMiddleTail = lastPlaced!;
+		newMiddleHead.prevSibling = beforeMiddle;
+		if (beforeMiddle) beforeMiddle.nextSibling = newMiddleHead;
+		else state.head = newMiddleHead;
+		if (!afterMiddle) state.tail = newMiddleTail;
+	} finally {
+		if (
+			sources.length <= MAX_KEYED_REORDER_SCRATCH &&
+			(keyedReorderSources === null || keyedReorderSources.length < sources.length)
+		) {
+			keyedReorderSources = sources;
 		}
 	}
-
-	// Splice the freshly-built new middle in between beforeMiddle and afterMiddle.
-	// newMiddleHead = `nextBlock` after the loop (last iteration placed item[prefixLen]).
-	// newMiddleTail = `lastPlaced` (first iteration placed item[newEnd]).
-	// newMiddleTail.nextSibling was set to afterMiddle in the first loop iter,
-	// and afterMiddle.prevSibling (if non-null) was set to newMiddleTail. So only
-	// the HEAD side of the splice remains.
-	const newMiddleHead = nextBlock!;
-	const newMiddleTail = lastPlaced!;
-	newMiddleHead.prevSibling = beforeMiddle;
-	if (beforeMiddle) beforeMiddle.nextSibling = newMiddleHead;
-	else state.head = newMiddleHead;
-	if (!afterMiddle) state.tail = newMiddleTail;
 }
 
 /**
@@ -24335,9 +24360,12 @@ function moveBlockBefore(block: Block, anchor: Node): void {
  * Skips entries where arr[i] === -1 (new items).
  * Ported from the standard O(n log n) patience-sort algorithm used by Ripple/Solid/Vue.
  */
-function lis(arr: Int32Array): number[] {
-	const n = arr.length;
-	const p = new Int32Array(n);
+function lis(arr: Int32Array, n: number): number[] {
+	let p = keyedLisPredecessors;
+	if (p === null || p.length < n) {
+		p = new Int32Array(n);
+		if (n <= MAX_KEYED_REORDER_SCRATCH) keyedLisPredecessors = p;
+	}
 	const result: number[] = [];
 	for (let i = 0; i < n; i++) {
 		const v = arr[i];

--- a/packages/octane/tests/_fixtures/for.tsrx
+++ b/packages/octane/tests/_fixtures/for.tsrx
@@ -571,3 +571,90 @@ export function NestedConditionalTransition(props: {
 		}
 	</div>
 }
+
+interface NestedReorderGroup {
+	id: number;
+	label: string;
+	rows: SelectionRow[];
+}
+
+export function NestedKeyedReorderList(props: {
+	groups: NestedReorderGroup[];
+	onPick: (groupId: number, rowId: number) => void;
+}) @{
+	const onPick = props.onPick;
+	<section id="nested-keyed-reorder-list">
+		@for (const group of props.groups; key group.id) {
+			<article class="nested-reorder-group" data-reorder-group={group.id}>
+				<h3>{group.label as string}</h3>
+				<ul>
+					@for (const row of group.rows; key row.id) {
+						<li class="nested-reorder-row" data-reorder-row={row.id}>
+							<button
+								type="button"
+								onClick={() => onPick(group.id, row.id)}
+							>{row.label as string}</button>
+						</li>
+					}
+				</ul>
+			</article>
+		}
+	</section>
+}
+
+export function NestedKeyedReorderBoundary(props: {
+	groups: NestedReorderGroup[];
+	onPick: (groupId: number, rowId: number) => void;
+}) @{
+	@try {
+		<NestedKeyedReorderList groups={props.groups} onPick={props.onPick} />
+	} @pending {
+		<span id="nested-reorder-pending">{'loading'}</span>
+	} @catch (error, reset) {
+		<button id="nested-reorder-retry" onClick={reset}>{(error as Error).message as string}</button>
+	}
+}
+
+function NestedKeyedReorderValue(props: { promise: Promise<string> }) @{
+	const value = use(props.promise);
+	<span id="nested-reorder-transition-value">{value as string}</span>
+}
+
+export function NestedKeyedReorderTransition(props: {
+	initialGroups: NestedReorderGroup[];
+	nextGroups: NestedReorderGroup[];
+	initialPromise: Promise<string>;
+	nextPromise: Promise<string>;
+	onPick: (groupId: number, rowId: number) => void;
+}) @{
+	const [groups, setGroups] = useState(props.initialGroups);
+	const [resource, setResource] = useState(props.initialPromise);
+	<div>
+		<button
+			id="nested-reorder-transition-start"
+			onClick={() => startTransition(() => {
+				setGroups(props.nextGroups);
+				setResource(props.nextPromise);
+			})}
+		>{'reorder'}</button>
+		<button
+			id="nested-reorder-transition-urgent"
+			onClick={() => setGroups(
+				props.nextGroups.map(
+					(group) => ({
+						...group,
+						rows: group.rows.map((row) => ({ ...row })),
+					}),
+				),
+			)}
+		>{'reorder urgently'}</button>
+		@try {
+			<>
+				<NestedKeyedReorderList groups={groups} onPick={props.onPick} />
+				<NestedKeyedReorderValue promise={resource} />
+			</>
+		} @pending {
+			<span id="nested-reorder-transition-pending">{'loading'}</span>
+		}
+	</div>
+}

--- a/packages/octane/tests/for.test.ts
+++ b/packages/octane/tests/for.test.ts
@@ -33,6 +33,9 @@ import {
 	FastMappedRenderableList,
 	FastMappedBoundaryList,
 	FastSuspendingGetterList,
+	NestedKeyedReorderList,
+	NestedKeyedReorderBoundary,
+	NestedKeyedReorderTransition,
 	setExternal,
 	setNestedConditionalActivityMode,
 } from './_fixtures/for.tsrx';
@@ -1019,6 +1022,297 @@ describe('large keyed list fills', () => {
 			items.map((row) => row.label),
 		);
 		expect(r.find('#fast-host-transition-value').textContent).toBe('resolved');
+		r.unmount();
+	});
+});
+
+describe('nested keyed list reordering', () => {
+	const makeGroups = (length = 11) =>
+		Array.from({ length }, (_, groupIndex) => {
+			const id = groupIndex + 1;
+			return {
+				id,
+				label: `group ${id}`,
+				rows: Array.from({ length: 17 + (groupIndex % 5) }, (_, rowIndex) => ({
+					id: id * 100 + rowIndex + 1,
+					label: `row ${id}:${rowIndex + 1}`,
+				})),
+			};
+		});
+
+	const reorderGroups = (groups: ReturnType<typeof makeGroups>, prefix = 'updated') =>
+		groups.toReversed().map((group) => ({
+			...group,
+			label: `${prefix} group ${group.id}`,
+			rows: group.rows.toReversed().map((row) => ({
+				...row,
+				label: `${prefix} row ${row.id}`,
+			})),
+		}));
+
+	const expectGroups = (r: ReturnType<typeof mount>, groups: ReturnType<typeof makeGroups>) => {
+		const renderedGroups = r.findAll('.nested-reorder-group');
+		expect(renderedGroups.map((group) => Number(group.getAttribute('data-reorder-group')))).toEqual(
+			groups.map((group) => group.id),
+		);
+		for (let index = 0; index < groups.length; index++) {
+			const group = groups[index]!;
+			const renderedGroup = renderedGroups[index]!;
+			expect(renderedGroup.querySelector('h3')?.textContent).toBe(group.label);
+			const rows = Array.from(renderedGroup.querySelectorAll('.nested-reorder-row'));
+			expect(rows.map((row) => Number(row.getAttribute('data-reorder-row')))).toEqual(
+				group.rows.map((row) => row.id),
+			);
+			expect(rows.map((row) => row.textContent)).toEqual(group.rows.map((row) => row.label));
+		}
+	};
+
+	it('keeps every group and row alive when both nesting levels reorder together', () => {
+		const warmRows = Array.from({ length: 29 }, (_, index) => ({
+			id: index + 1,
+			label: `warm row ${index + 1}`,
+		}));
+		const warm = mount(List, { items: warmRows });
+		warm.update(List, { items: warmRows.toReversed() });
+		warm.unmount();
+
+		const groups = makeGroups();
+		const picked: Array<[number, number]> = [];
+		const onPick = (groupId: number, rowId: number) => picked.push([groupId, rowId]);
+		const r = mount(NestedKeyedReorderList, { groups, onPick });
+		const groupNodes = new Map(
+			r
+				.findAll('.nested-reorder-group')
+				.map((group) => [Number(group.getAttribute('data-reorder-group')), group]),
+		);
+		const rowNodes = new Map(
+			r
+				.findAll('.nested-reorder-row')
+				.map((row) => [Number(row.getAttribute('data-reorder-row')), row]),
+		);
+		const preservedButton = r.find('[data-reorder-row="112"] button') as HTMLButtonElement;
+		preservedButton.focus();
+		expect(document.activeElement).toBe(preservedButton);
+
+		const reversed = groups.toReversed().map((group, groupIndex) => {
+			const split = 2 + (groupIndex % 5);
+			const rows = [...group.rows.slice(split), ...group.rows.slice(0, split)];
+			return {
+				...group,
+				label: `updated group ${group.id}`,
+				rows: rows.map((row) => ({ ...row, label: `updated row ${row.id}` })),
+			};
+		});
+		r.update(NestedKeyedReorderList, { groups: reversed, onPick });
+		expectGroups(r, reversed);
+		for (const group of reversed) {
+			expect(r.find(`[data-reorder-group="${group.id}"]`)).toBe(groupNodes.get(group.id));
+			for (const row of group.rows) {
+				expect(r.find(`[data-reorder-row="${row.id}"]`)).toBe(rowNodes.get(row.id));
+			}
+		}
+		expect(r.find('[data-reorder-row="112"] button')).toBe(preservedButton);
+		preservedButton.focus();
+		expect(document.activeElement).toBe(preservedButton);
+		r.click('[data-reorder-row="112"] button');
+		expect(picked).toEqual([[1, 112]]);
+
+		const shortened = reversed
+			.slice(0, 8)
+			.toReversed()
+			.map((group) => ({
+				...group,
+				label: `short group ${group.id}`,
+				rows: group.rows
+					.slice(0, 13)
+					.toReversed()
+					.map((row) => ({ ...row, label: `short row ${row.id}` })),
+			}));
+		r.update(NestedKeyedReorderList, { groups: shortened, onPick });
+		expectGroups(r, shortened);
+		for (const group of shortened) {
+			expect(r.find(`[data-reorder-group="${group.id}"]`)).toBe(groupNodes.get(group.id));
+			for (const row of group.rows) {
+				expect(r.find(`[data-reorder-row="${row.id}"]`)).toBe(rowNodes.get(row.id));
+			}
+		}
+		r.unmount();
+	});
+
+	it('adopts server-rendered nested rows and preserves their identity during both reorders', () => {
+		const groups = makeGroups(8);
+		const picked: Array<[number, number]> = [];
+		const onPick = (groupId: number, rowId: number) => picked.push([groupId, rowId]);
+		const props = { groups, onPick };
+		const server = loadServerFixture('packages/octane/tests/_fixtures/for.tsrx', {
+			compileOptions: { hmr: false, dev: false },
+		});
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		container.innerHTML = ServerRuntime.renderToString(server.NestedKeyedReorderList, props).html;
+		const groupNodes = new Map(
+			Array.from(container.querySelectorAll('.nested-reorder-group')).map((group) => [
+				Number(group.getAttribute('data-reorder-group')),
+				group,
+			]),
+		);
+		const rowNodes = new Map(
+			Array.from(container.querySelectorAll('.nested-reorder-row')).map((row) => [
+				Number(row.getAttribute('data-reorder-row')),
+				row,
+			]),
+		);
+		const root = hydrateRoot(container, NestedKeyedReorderList, props);
+		flushSync(() => {});
+		expect(Array.from(container.querySelectorAll('.nested-reorder-group'))).toEqual([
+			...groupNodes.values(),
+		]);
+
+		const reordered = reorderGroups(groups, 'hydrated');
+		flushSync(() => root.render(NestedKeyedReorderList, { groups: reordered, onPick }));
+		expect(
+			Array.from(container.querySelectorAll('.nested-reorder-group')).map((group) =>
+				Number(group.getAttribute('data-reorder-group')),
+			),
+		).toEqual(reordered.map((group) => group.id));
+		for (const group of reordered) {
+			expect(container.querySelector(`[data-reorder-group="${group.id}"]`)).toBe(
+				groupNodes.get(group.id),
+			);
+			for (const row of group.rows) {
+				expect(container.querySelector(`[data-reorder-row="${row.id}"]`)).toBe(
+					rowNodes.get(row.id),
+				);
+			}
+		}
+		flushSync(() =>
+			(container.querySelector('[data-reorder-row="112"] button') as HTMLButtonElement).click(),
+		);
+		expect(picked).toEqual([[1, 112]]);
+		root.unmount();
+		container.remove();
+	});
+
+	it('recovers when a nested survivor throws during simultaneous parent and child reorders', () => {
+		const groups = makeGroups();
+		const onPick = () => {};
+		const r = mount(NestedKeyedReorderBoundary, { groups, onPick });
+		let shouldThrow = true;
+		const reordered = reorderGroups(groups).map((group) => ({
+			...group,
+			rows: group.rows.map((row) =>
+				row.id === 112
+					? {
+							id: row.id,
+							get label() {
+								if (shouldThrow) throw new Error('nested row failed');
+								return 'recovered nested row';
+							},
+						}
+					: row,
+			),
+		}));
+
+		r.update(NestedKeyedReorderBoundary, { groups: reordered, onPick });
+		expect(r.findAll('.nested-reorder-row')).toHaveLength(0);
+		expect(r.find('#nested-reorder-retry').textContent).toBe('nested row failed');
+
+		shouldThrow = false;
+		r.click('#nested-reorder-retry');
+		expectGroups(r, reordered);
+		expect(r.find('[data-reorder-row="112"]').textContent).toBe('recovered nested row');
+		const resized = reorderGroups(reordered.slice(0, 7), 'after retry');
+		r.update(NestedKeyedReorderBoundary, { groups: resized, onPick });
+		expectGroups(r, resized);
+		r.unmount();
+	});
+
+	it('retries a nested survivor suspension and then reorders a differently sized list', async () => {
+		const groups = makeGroups();
+		const onPick = () => {};
+		const r = mount(NestedKeyedReorderBoundary, { groups, onPick });
+		let resolve!: (value: string) => void;
+		const promise = new Promise<string>((done) => {
+			resolve = done;
+		});
+		const reordered = reorderGroups(groups).map((group) => ({
+			...group,
+			rows: group.rows.map((row) =>
+				row.id === 112
+					? {
+							id: row.id,
+							get label() {
+								return use(promise);
+							},
+						}
+					: row,
+			),
+		}));
+
+		r.update(NestedKeyedReorderBoundary, { groups: reordered, onPick });
+		expect(r.find('#nested-reorder-pending').textContent).toBe('loading');
+
+		await act(() => resolve('row 1:12'));
+		const resolved = reordered.map((group) => ({
+			...group,
+			rows: group.rows.map((row) => ({
+				id: row.id,
+				label: row.id === 112 ? 'row 1:12' : row.label,
+			})),
+		}));
+		expectGroups(r, resolved);
+		const resized = reorderGroups(resolved.slice(0, 7), 'after resolution');
+		r.update(NestedKeyedReorderBoundary, { groups: resized, onPick });
+		expectGroups(r, resized);
+		r.unmount();
+	});
+
+	it('preserves committed nested rows through a suspended transition and a later urgent reorder', async () => {
+		const groups = makeGroups();
+		const nextGroups = groups.toReversed().map((group) => ({
+			...group,
+			rows: group.rows.toReversed().map((row) => ({ ...row })),
+		}));
+		const picked: Array<[number, number]> = [];
+		const onPick = (groupId: number, rowId: number) => picked.push([groupId, rowId]);
+		const initialPromise = Promise.resolve('initial');
+		let resolveNext!: (value: string) => void;
+		const nextPromise = new Promise<string>((resolve) => {
+			resolveNext = resolve;
+		});
+		await Promise.resolve();
+		const r = mount(NestedKeyedReorderTransition, {
+			initialGroups: groups,
+			nextGroups,
+			initialPromise,
+			nextPromise,
+			onPick,
+		});
+		await act(() => {});
+		const originalGroups = r.findAll('.nested-reorder-group');
+		const originalRows = new Map(
+			r
+				.findAll('.nested-reorder-row')
+				.map((row) => [Number(row.getAttribute('data-reorder-row')), row]),
+		);
+		expect(r.find('#nested-reorder-transition-value').textContent).toBe('initial');
+
+		r.click('#nested-reorder-transition-start');
+		expect(r.findAll('.nested-reorder-group')).toEqual(originalGroups);
+		expect(r.find('#nested-reorder-transition-value').textContent).toBe('initial');
+		expect(r.findAll('#nested-reorder-transition-pending')).toHaveLength(0);
+
+		await act(() => resolveNext('resolved'));
+		expect(r.find('#nested-reorder-transition-value').textContent).toBe('resolved');
+		r.click('#nested-reorder-transition-urgent');
+		expectGroups(r, nextGroups);
+		for (const group of nextGroups) {
+			for (const row of group.rows) {
+				expect(r.find(`[data-reorder-row="${row.id}"]`)).toBe(originalRows.get(row.id));
+			}
+		}
+		r.click('[data-reorder-row="112"] button');
+		expect(picked).toEqual([[1, 112]]);
 		r.unmount();
 	});
 });


### PR DESCRIPTION
## Summary

<!-- What changed, and why. -->

Part of #611 (phase 5).

- Reuse bounded numeric source and LIS-predecessor buffers only after keyed reconciliation reaches its general middle-section path.
- Lease source buffers exclusively across survivor rendering and release them on every return, error, suspension, or transition rollback; synchronous LIS work reuses its own buffer.
- Retain at most two 16,384-entry `Int32Array` buffers (128 KiB total), discard oversized buffers, and never retain keys, item objects, blocks, or DOM nodes.
- Add consumer-visible mixed parent/child reorder, hydration, error, Suspense, and transition regressions. Deliberately removing exclusive leasing makes the new nested-order test fail; restoring it makes the same test pass.
- Add a post-timing production benchmark gate for warmed allocation-free reorders, stable survivor identity, ordinary inserts, oversized-list disposal, and garbage-collected retained backing storage.

| Production measurement | Upstream | This change |
| --- | ---: | ---: |
| Warm 1,000-row general reorder | 2 typed arrays / 8,000 B | 0 |
| Warm 10,000-row general reorder | 2 typed arrays / 80,000 B | 0 |
| 5,000 warmed 1,000-row rotations | 40,000,000 B typed scratch | 0 |
| Retained scratch after 10,000-row and oversized reorders | 0 | 80,000 B; maximum 131,072 B |
| TSRX / JSX production gzip increase | — | +71 B / +77 B |

A balanced 64-pair, two-epoch 10,000-row reversal comparison preserved exactly 9,999 DOM moves: persistent-list medians were 11.375 ms upstream versus 11.3625 ms after this change; fresh-list medians were 6.3625 ms versus 6.25 ms. A 5,000-rotation Chrome trace showed transient ArrayBuffer backing growth of 96–560 KB upstream versus 15 B after reuse; median minor-GC counts were unchanged, so this change does not claim fewer collections.

## Validation

<!-- What you ran, and anything you deliberately left unverified. -->

- [x] `pnpm format:check`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [x] targeted tests:
  - Faithful repository-root Octane development project: **401 files / 5,948 tests passed**.
  - Faithful repository-root Octane production project: **365 files / 4,887 tests passed**.
  - Both projects preserve the root renderer registry, frozen-AST/location checks, cleanup, and existing excludes. Only `external-hook-slot.test.ts` and `register-hook.test.ts` were additionally excluded because this safely filtered offline workspace cannot install their optional binding dependencies.
  - `./node_modules/.bin/tsgo --noEmit -p packages/octane/tsconfig.json`
  - `./node_modules/.bin/tsgo --noEmit -p packages/octane/typetests/tsconfig.json`
  - `pnpm typecheck:files packages/octane/src/runtime.ts`
  - Official JSX/TSRX canonical production benchmark: previous list-mounting, DOM, selection, and production-call gates passed.
  - Official JSX/TSRX/React keyed-reorder benchmark: all identity and bounded-scratch gates passed; committed TSRX/React rotation ratio **0.331 <= 0.6**.
  - Newly merged upstream TodoMVC conditional-row guard: Octane and React both perform exactly **25 row-class writes**; ratio **1 <= 2**.
  - Permanent production gate verified red against unchanged upstream and green for both optimized Octane dialects.
  - `pnpm sync`
  - `node scripts/check-changesets.js`

Full workspace `pnpm typecheck` and `pnpm test` remain unavailable because the configured package registry cannot supply uncached optional Preact/Ripple binding dependencies; no registry override or substitute package source was used.

## Risk / follow-ups

- This is shared keyed-reconciler code, so all client bundles include the measured +71/+77 gzip-byte increase.
- Numeric scratch is intentionally bounded and retained between reconciliations; oversized lists allocate disposable buffers and cannot grow retained capacity beyond 128 KiB.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!--
Tick the box above whenever an agent wrote the change, no matter which account
pushes it. Leaving it clear or omitting this section asserts a human wrote the
diff; either form keeps the label workflow successful.

A bot reads this box and applies the label, so nothing here needs repository
permissions and it works the same from a fork. The type label comes from the
conventional-commit type in the title, with the type-prefixed head branch as a
fallback. Do not apply either by hand.

When updating an existing pull request, merge this template content into the
current body. Preserve every bot-managed HTML comment region and all existing
maintainer-authored text; never replace the body from a fresh template.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared `reconcileKeyed` / LIS paths used by all keyed lists; incorrect buffer leasing could corrupt nested reorders or retain unbounded memory, though new gates and tests target those failure modes.
> 
> **Overview**
> **Keyed list reconciliation** in `reconcileKeyed` no longer allocates fresh `Int32Array` scratch on every middle-section diff. It **leases** a reusable sources buffer (cleared from the module cache while survivor bodies run, then returned in a `finally` block) and **caches** a separate LIS predecessor buffer, keeping at most two 16,384-entry arrays (~128 KiB) and dropping oversized buffers instead of retaining them.
> 
> The **keyed-reorder benchmark** adds a post-timing **scratch-storage gate** for Octane TSRX/JSX: an `Int32Array` constructor trap checks that warmed reorders, append-only inserts, and shrink-back behavior stay allocation-free where expected, while very large lists may allocate disposable scratch without polluting the reusable pool; retained backing storage after GC must stay ≤128 KiB.
> 
> **Regression coverage** adds nested parent/child keyed reorder fixtures and tests (DOM identity, hydration, error boundaries, Suspense, and transitions) to guard exclusive buffer leasing when lists re-enter during rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8044a1184ac8aab5db3e64c3865d404538357630. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->