### PR TITLE
fix: preserve side-effect-only bootstrap entrypoints

### DIFF
--- a/.changeset/preserve-bundled-bootstrap-side-effects.md
+++ b/.changeset/preserve-bundled-bootstrap-side-effects.md
@@ -1,0 +1,8 @@
+---
+'octane': patch
+'@octanejs/tanstack-start': patch
+---
+
+Preserve compiler-hook registration and TanStack Start client hydration when
+their bootstrap entrypoints are imported for side effects in production bundles,
+while keeping unrelated package modules tree-shakeable.

--- a/packages/octane/package.json
+++ b/packages/octane/package.json
@@ -3,7 +3,10 @@
   "version": "0.1.29",
   "license": "MIT",
   "type": "module",
-  "sideEffects": false,
+  "sideEffects": [
+    "./src/compiler/register.js",
+    "./dist/compiler/register.js"
+  ],
   "engines": {
     "node": ">=22.22.2"
   },

--- a/packages/octane/tests/register-hook.test.ts
+++ b/packages/octane/tests/register-hook.test.ts
@@ -1,10 +1,43 @@
+// @vitest-environment node
+
 import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { build } from 'esbuild';
 import { describe, expect, it } from 'vitest';
 
 const FIXTURE_DIRECTORY = resolve('packages/octane/tests/_fixtures/register-hook');
 
 describe('direct server script compilation', () => {
+	it('preserves compiler registration when its side-effect-only preload is bundled', async () => {
+		const bundle = await build({
+			stdin: {
+				contents: "import 'octane/compiler/register';",
+				loader: 'js',
+				resolveDir: resolve(import.meta.dirname, '..'),
+				sourcefile: 'bundled-server-preload.js',
+			},
+			bundle: true,
+			external: ['@tsrx/core', 'esrap', 'esrap/*', 'es-module-lexer'],
+			format: 'esm',
+			logLevel: 'silent',
+			minify: true,
+			platform: 'node',
+			treeShaking: true,
+			write: false,
+		});
+		const entry = pathToFileURL(resolve(FIXTURE_DIRECTORY, 'entry.ts')).href;
+		const result = spawnSync(process.execPath, ['--no-warnings', '--input-type=module'], {
+			cwd: FIXTURE_DIRECTORY,
+			encoding: 'utf8',
+			input: `${bundle.outputFiles[0].text}\nawait import(${JSON.stringify(entry)});\n`,
+		});
+
+		expect(result.stderr).toBe('');
+		expect(result.status).toBe(0);
+		expect(result.stdout).toBe('<main>Hello, Octane!</main>');
+	});
+
 	it('prerenders an extensionless TypeScript component import through the public preload', () => {
 		const result = spawnSync(
 			process.execPath,

--- a/packages/tanstack-start/package.json
+++ b/packages/tanstack-start/package.json
@@ -103,7 +103,9 @@
     },
     "./package.json": "./package.json"
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "./src/default-entry/client.js"
+  ],
   "scripts": {
     "test": "cd ../.. && vitest run --project tanstack-start"
   },

--- a/packages/tanstack-start/tests/package-boundary.test.ts
+++ b/packages/tanstack-start/tests/package-boundary.test.ts
@@ -1,5 +1,9 @@
+// @vitest-environment node
+
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { runInNewContext } from 'node:vm';
+import { build } from 'esbuild';
 import { describe, expect, it } from 'vitest';
 
 const packageDirectory = resolve(import.meta.dirname, '..');
@@ -12,6 +16,135 @@ function collectFiles(entryPath: string): Array<string> {
 }
 
 describe('@octanejs/tanstack-start package boundary', () => {
+	it('preserves hydration when a production consumer imports the default client entry for its effects', async () => {
+		const clientEntry = resolve(packageDirectory, 'src/default-entry/client.js');
+		const result = await build({
+			stdin: {
+				contents: `import ${JSON.stringify(clientEntry)};`,
+				resolveDir: repositoryRoot,
+				sourcefile: 'start-consumer-bootstrap.js',
+			},
+			bundle: true,
+			format: 'iife',
+			logLevel: 'silent',
+			minify: true,
+			platform: 'browser',
+			treeShaking: true,
+			write: false,
+			plugins: [
+				{
+					name: 'start-consumer-bootstrap-dependencies',
+					setup(builder) {
+						builder.onResolve({ filter: /^octane$/ }, () => ({
+							path: 'octane',
+							namespace: 'start-consumer-bootstrap',
+						}));
+						builder.onResolve({ filter: /^\.\.\/client\.js$/ }, () => ({
+							path: 'start-client',
+							namespace: 'start-consumer-bootstrap',
+						}));
+						builder.onLoad({ filter: /^octane$/, namespace: 'start-consumer-bootstrap' }, () => ({
+							contents: `
+export function initializeHydrationEventCapture() {
+	globalThis.bootstrap.capture();
+}
+export function hydrateRoot(container, component, options) {
+	globalThis.bootstrap.hydrate(container, component, options);
+}
+`,
+							loader: 'js',
+						}));
+						builder.onLoad(
+							{ filter: /^start-client$/, namespace: 'start-consumer-bootstrap' },
+							() => ({
+								contents: `
+export const StartClient = globalThis.bootstrap.component;
+export function hydrateStart() {
+	return globalThis.bootstrap.start();
+}
+`,
+								loader: 'js',
+							}),
+						);
+					},
+				},
+			],
+		});
+		const container = { id: '__app' };
+		const router = { id: 'hydrated-router' };
+		const component = () => undefined;
+		const calls: {
+			capture: number;
+			start: number;
+			hydrations: Array<{ container: unknown; component: unknown; router: unknown }>;
+		} = { capture: 0, start: 0, hydrations: [] };
+		const context = {
+			document: {
+				getElementById: (id: string) => (id === '__app' ? container : null),
+			},
+			bootstrap: {
+				component,
+				capture() {
+					calls.capture++;
+				},
+				start() {
+					calls.start++;
+					return Promise.resolve(router);
+				},
+				hydrate(root: unknown, client: unknown, options: { router: unknown }) {
+					calls.hydrations.push({ container: root, component: client, router: options.router });
+				},
+			},
+		};
+
+		runInNewContext(result.outputFiles[0].text, context);
+
+		expect(calls.capture).toBe(1);
+		expect(calls.start).toBe(1);
+
+		await Promise.resolve();
+
+		expect(calls.hydrations).toEqual([{ container, component, router }]);
+	});
+
+	it('continues tree-shaking an unused package-root import from production consumer bundles', async () => {
+		const packageEntry = resolve(packageDirectory, 'src/index.js');
+		const result = await build({
+			stdin: {
+				contents: `import '@octanejs/tanstack-start'; globalThis.consumerExecuted = true;`,
+				resolveDir: packageDirectory,
+				sourcefile: 'start-consumer-unused-import.js',
+			},
+			bundle: true,
+			format: 'iife',
+			logLevel: 'silent',
+			metafile: true,
+			minify: true,
+			platform: 'browser',
+			treeShaking: true,
+			write: false,
+			plugins: [
+				{
+					name: 'unused-start-package-dependencies',
+					setup(builder) {
+						builder.onResolve({ filter: /.*/ }, (args) =>
+							args.importer === packageEntry ? { path: args.path, external: true } : undefined,
+						);
+					},
+				},
+			],
+		});
+		const context = { consumerExecuted: false };
+		const includedModules = Object.keys(Object.values(result.metafile!.outputs)[0].inputs);
+
+		runInNewContext(result.outputFiles[0].text, context);
+
+		expect(context.consumerExecuted).toBe(true);
+		expect(includedModules.some((entry) => resolve(repositoryRoot, entry) === packageEntry)).toBe(
+			false,
+		);
+	});
+
 	it('publishes only repository-owned Start and router integration', () => {
 		const manifestPath = resolve(packageDirectory, 'package.json');
 		const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as {


### PR DESCRIPTION
## Summary

- Preserve both source and published `octane/compiler/register` entrypoints when a consumer bundles the preload solely for its compiler-hook registration.
- Preserve TanStack Start's default hydration bootstrap while keeping unrelated modules in both packages tree-shakeable.
- Add executable consumer-level production-bundle regressions and a patch changeset covering both published packages.

Refs #632, workstream 2. This PR intentionally does not close the umbrella issue because its package-classification, CLI, SSR, and compiler-output workstreams remain open.

## Validation

- [x] `pnpm format:check`
- [ ] `pnpm typecheck` — full-workspace lane not run; both affected package projects, TanStack type tests, and the two changed test files passed targeted type checks.
- [ ] `pnpm test` — full-workspace lane not run; the complete affected binding project and core development/production suites passed focused runs.
- [x] targeted tests: `./node_modules/.bin/vitest run --project tanstack-start --reporter=dot --silent=passed-only` — 9 files, 55 tests.
- [x] targeted tests: `./node_modules/.bin/vitest run packages/octane/tests/register-hook.test.ts packages/octane/tests/compiler/production-bundle.test.ts --project octane --project octane-prod --reporter=dot --silent=passed-only` — 3 project/file combinations, 10 tests.
- [x] `node --test scripts/package-pack-canaries.test.mjs` — 10 package-canary tests.
- [x] `node benchmarks/bundle-size/run-minimal.mjs` — all 10 executable production scenarios and 30 raw/gzip/Brotli budgets pass.
- [x] `pnpm typecheck:files packages/octane/tests/register-hook.test.ts packages/tanstack-start/tests/package-boundary.test.ts`
- [x] `./node_modules/.bin/tsgo --noEmit -p packages/octane/tsconfig.json`
- [x] `./node_modules/.bin/tsgo --noEmit -p packages/tanstack-start/tsconfig.json`
- [x] `./node_modules/.bin/tsgo --noEmit -p packages/tanstack-start/typetests/tsconfig.json`
- [x] `pnpm --filter octane build` — generated `dist/compiler/register.js` passes the published-package import verification.
- [x] Independently bundled and executed both source and built-dist compiler preloads against the real extensionless SSR fixture; both render `<main>Hello, Octane!</main>`, while a forced false-purity counterfactual fails.
- [x] `pnpm sync`
- [x] `pnpm changeset:check`

## Risk / follow-ups

- Effectful-module allowlists are deliberately narrow; production-bundle negative controls prove unused package-root imports still disappear.
- TanStack Start's standard production integration already uses a direct entrypoint. The regression protects bundled side-effect-only/custom-consumer imports without claiming the ordinary production path was broken.
- Remaining optimization work stays tracked in #632.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging metadata and targeted bundle-boundary tests only; narrow sideEffects paths limit bundle-size impact while fixing silent breakage in custom production entrypoints.
> 
> **Overview**
> **Replaces blanket `sideEffects: false` with narrow allowlists** so production bundlers stop stripping bootstrap modules that are imported only for their side effects.
> 
> `octane` now marks **`compiler/register`** (source and published `dist`) as effectful, so minified Node bundles still register compiler hooks when consumers bundle a side-effect-only preload. **`@octanejs/tanstack-start`** marks **`default-entry/client.js`** the same way so client hydration bootstrap (capture, `hydrateStart`, `hydrateRoot`) survives browser production bundles.
> 
> Unrelated package entrypoints stay tree-shakeable; new **esbuild** regression tests cover bundled preload SSR, bundled client hydration, and unused package-root imports still dropping out. Patch changeset for both packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e3f7f1cbe5b60164440096c7b04db5382221445. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->