### PR TITLE
perf: cache stable renderable regions and prune sync warming

### DIFF
--- a/.changeset/compiler-cached-renderable-regions.md
+++ b/.changeset/compiler-cached-renderable-regions.md
@@ -1,0 +1,8 @@
+---
+'octane': patch
+---
+
+Avoid reconciling unchanged compiler-cached renderable children while preserving
+context and hidden-tree effect lifecycles, cache safe derived values in
+hook-using JSX components, and omit fetch-warming scaffolding from component
+trees proven to contain no asynchronous work.

--- a/benchmarks/memo-wall/README.md
+++ b/benchmarks/memo-wall/README.md
@@ -9,9 +9,10 @@ re-render exactly one row, and a context bump above the wall must refresh only
 the leaf consumers without re-running any bailed body. Both Octane dialects
 exercise production `autoMemo` on wall A: TSRX can skip the entire pure `RowsA`
 region, while returned JSX preserves its descriptor boundary and skips the
-unchanged compiled keyed list inside `RowsA`. Wall B remains the descriptor
-control; its imported calculation may be reused when its inputs are unchanged,
-while changed inputs still exercise the value-comparing memo bail.
+unchanged compiled keyed list inside `RowsA`. Both dialects reuse wall B's
+imported descriptor calculation when its inputs are unchanged. TSRX additionally
+skips the unchanged renderable region while preserving context updates; changed
+inputs still exercise the value-comparing memo bail.
 
 This is the canonical home for octane's `shallowEqualProps` and
 `refreshContextConsumers` numbers — if a store-fanout suite lands later it must
@@ -86,10 +87,11 @@ how `<Row>` is put on screen:
   `createElement(Row, props)` descriptors that reach the DOM through a
   `{rows}` children hole → `childSlot`'s keyed de-opt list → the **childSlot
   arm** of `tryMemoBail`. This is the shape every `@octanejs/*` binding
-  produces. A fresh descriptor + fresh props object is allocated every parent
-  render unless automatic calculation memoization reuses the imported helper's
-  result for unchanged inputs. When its input changes, the bail must succeed on
-  prop VALUES, not object identity.
+  produces. Both dialects cache the imported helper's result against its input.
+  TSRX can also reuse the compiler-proven immutable renderable region, refreshing
+  existing context consumers directly when a Provider changes. When the input
+  changes, fresh descriptors still exercise memo bailouts on prop VALUES, not
+  object identity.
 
 For React the A/B distinction collapses (JSX IS `createElement`); both walls
 are kept so the op list and DOM stay identical across targets. The vanilla
@@ -124,8 +126,10 @@ A it requires zero list helpers, keyed survivor visits, descriptors, shallow
 memo comparisons, and row bodies (context A additionally requires exactly 1000
 Leaf refreshes). JSX retains its normal `RowsA`/descriptor entry but likewise
 requires zero keyed survivor visits, item helpers, and memo comparisons on an
-unchanged list. Wall B verifies both reused unchanged calculations and changed
-descriptor lists. Mount and one-change A/B also carry exact compiled-work gates.
+unchanged list. Wall B requires both dialects to reuse unchanged calculations;
+TSRX additionally requires zero keyed survivor visits and memo comparisons for
+equal/context-only updates, while context updates still refresh exactly 1000
+leaves. Mount and one-change A/B also carry exact compiled-work gates.
 
 The React Row/Inner/Leaf counters likewise make those component bodies impure,
 so React Compiler conservatively leaves them alone; the explicit `memo`

--- a/benchmarks/memo-wall/work.mjs
+++ b/benchmarks/memo-wall/work.mjs
@@ -27,6 +27,7 @@ const METRICS = [
 	'buildValueRows',
 	'createElement',
 	'shallowEqualProps',
+	'restampCachedContextScope',
 	'RowImpl',
 	'InnerImpl',
 	'Leaf',
@@ -109,18 +110,20 @@ const OPS = [
 		},
 	},
 	// Wall B's imported helper is cached against its `items` argument by
-	// production auto-calculation. Equal/context-only TSRX parent updates reuse
-	// that descriptor array; changed items still rebuild it in one_change_B.
+	// production auto-calculation. Equal/context-only parent updates reuse that
+	// descriptor array. TSRX also caches its proven-immutable renderable region,
+	// so unchanged rows never enter keyed reconciliation; context updates still
+	// refresh their mounted leaf consumers directly.
 	{
 		name: 'context_B',
 		hook: '__ctxB',
 		expect: {
 			RowsA: 0,
-			updateSurvivor: ROWS,
+			updateSurvivor: 0,
 			itemBody: 0,
 			buildValueRows: 0,
 			createElement: 0,
-			shallowEqualProps: ROWS,
+			shallowEqualProps: 0,
 			RowImpl: 0,
 			InnerImpl: 0,
 			Leaf: ROWS,
@@ -131,11 +134,11 @@ const OPS = [
 		hook: '__tickB',
 		expect: {
 			RowsA: 0,
-			updateSurvivor: ROWS,
+			updateSurvivor: 0,
 			itemBody: 0,
 			buildValueRows: 0,
 			createElement: 0,
-			shallowEqualProps: ROWS,
+			shallowEqualProps: 0,
 			RowImpl: 0,
 			InnerImpl: 0,
 			Leaf: 0,
@@ -154,8 +157,18 @@ const JSX_EXPECTATIONS = {
 	one_change_A: { createElement: 8 },
 	context_A: { RowsA: 1, createElement: ROWS + 3 },
 	one_change_B: { createElement: ROWS + 6 },
-	context_B: { buildValueRows: 1, createElement: ROWS * 2 + 1 },
-	equal_B_control: { buildValueRows: 1, createElement: ROWS + 1 },
+	context_B: {
+		updateSurvivor: ROWS,
+		buildValueRows: 0,
+		createElement: ROWS + 1,
+		shallowEqualProps: ROWS,
+	},
+	equal_B_control: {
+		updateSurvivor: ROWS,
+		buildValueRows: 0,
+		createElement: 1,
+		shallowEqualProps: ROWS,
+	},
 };
 
 function callCounts(coverage) {
@@ -219,7 +232,13 @@ try {
 	for (const op of OPS) {
 		const counts = await measure(browser, op);
 		results[op.name] = counts;
-		const expected = DIALECT === 'jsx' ? { ...op.expect, ...JSX_EXPECTATIONS[op.name] } : op.expect;
+		const expected = {
+			...op.expect,
+			...(DIALECT === 'jsx' ? JSX_EXPECTATIONS[op.name] : {}),
+			// Legacy context-aware list regions must never walk their memoized rows
+			// merely because the owning JSX fragment has an implicit-bail ancestor.
+			restampCachedContextScope: 0,
+		};
 		for (const metric of METRICS) {
 			if (counts[metric] !== expected[metric]) {
 				failures.push(`${op.name}.${metric}: ${counts[metric]} !== expected ${expected[metric]}`);
@@ -231,15 +250,15 @@ try {
 }
 
 console.log(
-	'Operation       | RowsA | survivors | item body | buildB | descriptors | memo cmp | Row/Inner/Leaf',
+	'Operation       | RowsA | survivors | item body | buildB | descriptors | memo cmp | restamp | Row/Inner/Leaf',
 );
 console.log(
-	'----------------+-------+-----------+-----------+--------+-------------+----------+---------------',
+	'----------------+-------+-----------+-----------+--------+-------------+----------+---------+---------------',
 );
 for (const op of OPS) {
 	const c = results[op.name];
 	console.log(
-		`${op.name.padEnd(15)} | ${String(c.RowsA).padStart(5)} | ${String(c.updateSurvivor).padStart(9)} | ${String(c.itemBody).padStart(9)} | ${String(c.buildValueRows).padStart(6)} | ${String(c.createElement).padStart(11)} | ${String(c.shallowEqualProps).padStart(8)} | ${c.RowImpl}/${c.InnerImpl}/${c.Leaf}`,
+		`${op.name.padEnd(15)} | ${String(c.RowsA).padStart(5)} | ${String(c.updateSurvivor).padStart(9)} | ${String(c.itemBody).padStart(9)} | ${String(c.buildValueRows).padStart(6)} | ${String(c.createElement).padStart(11)} | ${String(c.shallowEqualProps).padStart(8)} | ${String(c.restampCachedContextScope).padStart(7)} | ${c.RowImpl}/${c.InnerImpl}/${c.Leaf}`,
 	);
 }
 

--- a/benchmarks/signal-favoring/README.md
+++ b/benchmarks/signal-favoring/README.md
@@ -167,8 +167,10 @@ two fully-warmed sample sets are combined for TSX/TSRX ratio guards.
 counters, which would change the program presented to the compiler. It caps
 blocks, aggregate component-slot dispatch, child slots, descriptors, and
 teardown work at the current production levels while allowing every count to
-fall. Every row requires live production-bundle coverage. C1/C51/C91 must still
-perform exactly one text write, and the ancestor-first batch exactly ten.
+fall. It also forbids fetch-warming registrations in this fully synchronous
+component tree. Every row requires live production-bundle coverage. C1/C51/C91
+must still perform exactly one text write, and the ancestor-first batch exactly
+ten.
 
 The TSX chain's private, hookless components reuse their existing compiled host
 renderers through lightweight component slots. Its shallow update is limited to

--- a/benchmarks/signal-favoring/work.mjs
+++ b/benchmarks/signal-favoring/work.mjs
@@ -20,6 +20,7 @@ const METRICS = [
 	'childSlot',
 	'createElement',
 	'setText',
+	'useBatch',
 	'unmountBlock',
 	'unmountScope',
 ];
@@ -200,16 +201,16 @@ try {
 }
 
 console.log(
-	'Operation              | render | full | void | lite | child | descriptors | text | unmount block/scope',
+	'Operation              | render | full | void | lite | child | descriptors | text | warm | unmount block/scope',
 );
 console.log(
-	'-----------------------+--------+------+------+------+-------+-------------+------+--------------------',
+	'-----------------------+--------+------+------+------+-------+-------------+------+------+--------------------',
 );
 for (const target of TARGETS) {
 	for (const op of OPS) {
 		const c = results[target.name][op.name];
 		console.log(
-			`${`${target.name}.${op.name}`.padEnd(22)} | ${String(c.renderBlock).padStart(6)} | ${String(c.componentSlot).padStart(4)} | ${String(c.componentSlotVoid).padStart(4)} | ${String(c.componentSlotLite).padStart(4)} | ${String(c.childSlot).padStart(5)} | ${String(c.createElement).padStart(11)} | ${String(c.setText).padStart(4)} | ${c.unmountBlock}/${c.unmountScope}`,
+			`${`${target.name}.${op.name}`.padEnd(22)} | ${String(c.renderBlock).padStart(6)} | ${String(c.componentSlot).padStart(4)} | ${String(c.componentSlotVoid).padStart(4)} | ${String(c.componentSlotLite).padStart(4)} | ${String(c.childSlot).padStart(5)} | ${String(c.createElement).padStart(11)} | ${String(c.setText).padStart(4)} | ${String(c.useBatch).padStart(4)} | ${c.unmountBlock}/${c.unmountScope}`,
 		);
 	}
 }

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -2336,6 +2336,68 @@ function rewriteAutoCalculation(stmt, componentLocals, renderReadNames, ctx) {
 	};
 }
 
+// A cached calculation can own a renderable array only when its value never
+// escapes into setup, a callback, a component prop, or another expression. The
+// bare renderable holes are the sole permitted reads: then the same immutable
+// projection contract that admitted the calculation also witnesses the whole
+// array. Preserve the exact Identifier nodes rather than just their spelling so
+// a nested shadow cannot accidentally inherit an outer calculation's proof.
+function collectAutoCalculatedRenderableRefs(statements, jsxNodes, calculated) {
+	if (calculated.size === 0) return null;
+	const references = new Map();
+	const seen = new WeakSet();
+	function visit(node, isJsxChild = false) {
+		if (node === null || typeof node !== 'object') return;
+		if (Array.isArray(node)) {
+			for (const child of node) visit(child, isJsxChild);
+			return;
+		}
+		if (seen.has(node)) return;
+		seen.add(node);
+		if (node.type === 'Element' || node.type === 'JSXElement') {
+			visit(node.children, true);
+			return;
+		}
+		if (
+			isJsxChild &&
+			(node.type === 'Text' ||
+				node.type === 'TSRXExpression' ||
+				node.type === 'JSXExpressionContainer')
+		) {
+			const expression = node.expression;
+			if (expression?.type === 'Identifier' && calculated.has(expression.name)) {
+				let nodes = references.get(expression.name);
+				if (nodes === undefined) references.set(expression.name, (nodes = new Set()));
+				nodes.add(expression);
+			}
+			return;
+		}
+		for (const key in node) {
+			if (AST_WALK_SKIP_KEYS.has(key)) continue;
+			visit(node[key], key === 'children');
+		}
+	}
+	visit(jsxNodes, true);
+
+	let proven = null;
+	for (const [name, declaration] of calculated) {
+		const nodes = references.get(name);
+		if (nodes === undefined) continue;
+		let escaped = false;
+		for (const statement of statements) {
+			if (statement === declaration) continue;
+			if (collectFreeIdentifiers(statement, []).has(name)) {
+				escaped = true;
+				break;
+			}
+		}
+		if (escaped || collectFreeIdentifiers(jsxNodes, [], nodes).has(name)) continue;
+		if (proven === null) proven = new WeakSet();
+		for (const node of nodes) proven.add(node);
+	}
+	return proven;
+}
+
 // Names the render tree actually reads, resolved against the scopes the
 // statement walker cannot see (nested functions, loops, `@for` item bindings,
 // directive-arm blocks) so a shadowing inner binding never nominates an
@@ -3775,6 +3837,143 @@ function collectImmutableModuleFunctions(body) {
 	}
 	walk(body);
 	return declared;
+}
+
+// A child warm plan is useful only if that child can reach an async creation.
+// Same-module declarations are the only closed call graph we can prove: an
+// imported/dynamic component, custom hook, helper call, or lazy state initializer
+// may suspend behind an opaque boundary, so each keeps its existing warm edge.
+// A useState call with a primitive literal initializer and publishing its stable
+// setter are synchronous, so neither turns a synchronous tree into a warm plan.
+function classifySameModuleWarmPotential(ctx) {
+	for (const [, info] of ctx.componentInfo) {
+		const component = info.node;
+		const statements = component.body.body || [];
+		const locals = collectComponentLocals(component);
+		const invariant = computeInvariantLocals(statements, locals, false);
+		const dependencies = new Set();
+		const seen = new WeakSet();
+		// A reassigned function binding can point at an async component by the
+		// time its warm edge runs. Destructuring/default/rest parameters can also
+		// invoke user code before the authored component body is reached.
+		let opaque =
+			!ctx.moduleFunctionDeclarations.has(component.id?.name) ||
+			(component.params || []).some((parameter) => parameter.type !== 'Identifier');
+
+		function walk(node) {
+			if (opaque || node === null || typeof node !== 'object') return;
+			if (Array.isArray(node)) {
+				for (const child of node) walk(child);
+				return;
+			}
+			if (seen.has(node)) return;
+			seen.add(node);
+
+			// Deferred handlers do not execute during this component's render. State
+			// initializers are admitted only when proven primitive and non-callable.
+			if (FN_TYPES.has(node.type)) return;
+
+			if ((node.type === 'Element' || node.type === 'JSXElement') && isComponentTag(node)) {
+				const name = tagBindingName(node);
+				if (
+					name === null ||
+					locals.has(name) ||
+					ctx._octaneBoundaryNames.has(name) ||
+					!ctx.componentInfo.has(name)
+				) {
+					opaque = true;
+					return;
+				}
+				dependencies.add(name);
+			} else if (node.type === 'CallExpression' || node.type === 'NewExpression') {
+				const hook = stableHookCallName(node);
+				if (
+					hook !== 'useState' ||
+					node.arguments.length > 1 ||
+					(node.arguments.length === 1 && !isInvariantLiteral(unwrapTsExpr(node.arguments[0])))
+				) {
+					opaque = true;
+					return;
+				}
+			} else if (node.type === 'VariableDeclarator' && node.id?.type === 'ArrayPattern') {
+				// The built-in state tuple is the only iterator this proof owns. Any
+				// other destructuring can execute a custom iterator or rest/default.
+				if (
+					stableHookCallName(unwrapTsExpr(node.init)) !== 'useState' ||
+					node.id.elements.some((element) => element !== null && element.type !== 'Identifier')
+				) {
+					opaque = true;
+					return;
+				}
+			} else if (node.type === 'AssignmentExpression') {
+				if (
+					node.operator !== '=' ||
+					node.left?.type !== 'Identifier' ||
+					node.right?.type !== 'Identifier' ||
+					!invariant.has(node.right.name)
+				) {
+					opaque = true;
+					return;
+				}
+			} else if (
+				node.type === 'AwaitExpression' ||
+				node.type === 'YieldExpression' ||
+				node.type === 'MemberExpression' ||
+				node.type === 'JSXMemberExpression' ||
+				node.type === 'OptionalMemberExpression' ||
+				node.type === 'OptionalCallExpression' ||
+				node.type === 'SpreadElement' ||
+				node.type === 'SpreadAttribute' ||
+				node.type === 'JSXSpreadAttribute' ||
+				node.type === 'ObjectPattern' ||
+				node.type === 'AssignmentPattern' ||
+				node.type === 'RestElement' ||
+				node.type === 'ForOfStatement' ||
+				node.type === 'JSXForExpression' ||
+				node.type === 'ForInStatement' ||
+				node.type === 'ForStatement' ||
+				node.type === 'WhileStatement' ||
+				node.type === 'DoWhileStatement' ||
+				node.type === 'ThrowStatement' ||
+				node.type === 'TryStatement' ||
+				node.type === 'JSXTryExpression' ||
+				node.type === 'ImportExpression' ||
+				node.type === 'TaggedTemplateExpression' ||
+				node.type === 'UpdateExpression'
+			) {
+				opaque = true;
+				return;
+			}
+
+			for (const key in node) {
+				if (AST_WALK_SKIP_KEYS.has(key)) continue;
+				walk(node[key]);
+			}
+		}
+
+		walk(statements);
+		walk(component.body.render);
+		info.warmPotential = opaque;
+		info.warmDependencies = dependencies;
+	}
+
+	// Propagate async reachability through forward references and recursive
+	// same-module chains. An all-synchronous cycle stays false; one opaque or
+	// async descendant makes every component that can reach it conservative.
+	let changed = true;
+	while (changed) {
+		changed = false;
+		for (const [, info] of ctx.componentInfo) {
+			if (info.warmPotential) continue;
+			for (const name of info.warmDependencies) {
+				if (ctx.componentInfo.get(name)?.warmPotential !== false) {
+					info.warmPotential = true;
+					changed = true;
+					break;
+				}
+			}
+		}
+	}
 }
 
 // Omitting a JSX descriptor also omits its live `Component.defaultProps` read.
@@ -6396,6 +6595,7 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 		currentAutoMemoOffset: 0, // flat compiler-cache cell offset for the body being emitted
 		currentAutoMemoCacheName: null, // collision-free local bound to the body's cache array
 		currentAutoMemoCommittedName: null, // committed cache snapshot (copy-on-write source)
+		currentAutoCalculatedRenderableRefs: null, // proven non-escaping calculation holes, inherited by lexical child bodies
 		nextAutoMemoCacheId: 0, // unique non-index slots property per compiled render function
 		inlineHookMemo: inlineHookMemoEnabled, // de-callbacked useMemo/useCallback + pu creations
 		_puInlineLowering: false, // true only while a body pipeline ends in inlineHookMemoPass
@@ -6649,6 +6849,16 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 				voidOutput: isVoidJsxCodeBlockFunction(compNode),
 			});
 		}
+	}
+	// Return-based JSX functions never attach fetch-tree warm plans, and a sole
+	// same-module component already rejects a self-only warm edge below. Avoid a
+	// whole-module graph walk unless a compiled-void body can actually reach a
+	// distinct same-module declaration.
+	if (
+		ctx.componentInfo.size > 1 &&
+		[...ctx.componentInfo.values()].some((info) => info.node.body?.type === 'JSXCodeBlock')
+	) {
+		classifySameModuleWarmPotential(ctx);
 	}
 	ctx.privateUnescapedComponents = ctx.autoMemo
 		? collectPrivateUnescapedComponents(ast.body, ctx)
@@ -10599,6 +10809,8 @@ function compileComponent(node, ctx, options) {
  */
 function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null, options = null) {
 	const returnedOutput = options?.returnedOutput === true;
+	const previousAutoCalculatedRenderableRefs = ctx.currentAutoCalculatedRenderableRefs;
+	let autoCalculatedDeclarations = null;
 	const prevMapTemps = ctx.currentMapTemps;
 	const mapTemps = [];
 	ctx.currentMapTemps = mapTemps;
@@ -10724,9 +10936,21 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 		if (ctx.currentComponentLocals && ctx.mode !== 'server') {
 			const renderReadNames = collectRenderReadNames(jsxNodes, ctx);
 			if (renderReadNames.size > 0) {
-				workingStatements = workingStatements.map((statement) =>
-					rewriteAutoCalculation(statement, ctx.currentComponentLocals, renderReadNames, ctx),
-				);
+				workingStatements = workingStatements.map((statement) => {
+					const rewritten = rewriteAutoCalculation(
+						statement,
+						ctx.currentComponentLocals,
+						renderReadNames,
+						ctx,
+					);
+					if (ctx.autoMemo && rewritten !== statement) {
+						(autoCalculatedDeclarations ??= new Map()).set(
+							statement.declarations[0].id.name,
+							statement,
+						);
+					}
+					return rewritten;
+				});
 			}
 		}
 		workingStatements = parallelUseMemoizePass(workingStatements, ctx, name, creations, [], null);
@@ -10835,6 +11059,19 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 	// node itself always does.
 	const prevFnOrigin = ctx._fnOrigin;
 	ctx._fnOrigin = node.loc ? node : (node.id ?? prevFnOrigin);
+	if (autoCalculatedDeclarations !== null) {
+		const refs = collectAutoCalculatedRenderableRefs(
+			statements,
+			jsxNodes,
+			autoCalculatedDeclarations,
+		);
+		if (refs !== null) {
+			ctx.currentAutoCalculatedRenderableRefs = {
+				nodes: refs,
+				parent: previousAutoCalculatedRenderableRefs,
+			};
+		}
+	}
 	// Located origin for the function SHELL itself: synthetic helper shapes
 	// (hoisted @for bodies, `__tsrx$N` sub-templates) carry no loc of their
 	// own — their scaffolding inherits the nearest located enclosing origin.
@@ -10867,6 +11104,7 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 	ctx.currentBodyIsComponentScope = prevBodyIsComponentScope;
 	ctx._inheritBody = prevInheritBody;
 	ctx._fnOrigin = prevFnOrigin;
+	ctx.currentAutoCalculatedRenderableRefs = previousAutoCalculatedRenderableRefs;
 	ctx._foldedDirectiveCalls = prevFDC;
 	ctx._valueDirectiveLowering = prevValueDirectiveLowering;
 
@@ -12618,6 +12856,12 @@ function buildWarmArtifacts(node, ctx, componentName, creations, warmChildren) {
 	const warmKids = warmChildren.filter(
 		(w) =>
 			guardOk(w.guards, w.locals) &&
+			// Server and universal-renderer warm plans have independent compilation
+			// contexts. Only the DOM client's closed same-module graph can prove
+			// that this edge and every descendant are synchronously render-only.
+			(ctx.mode === 'server' ||
+				ctx._universalRuntimeUnit != null ||
+				ctx.componentInfo.get(w.compName)?.warmPotential !== false) &&
 			!paramNames.has(w.compName) &&
 			!(locals && locals.has(w.compName)) &&
 			!(w.locals && w.locals.has(w.compName)) &&
@@ -13738,11 +13982,32 @@ function compileReturnJsxFunction(node, ctx, options) {
 	ctx.currentMapTemps = mapTemps;
 	let newStatements;
 	try {
-		newStatements = (node.body.body || []).map((sourceStatement) => {
+		const authoredStatements = node.body.body || [];
+		const renderedRoots = authoredStatements
+			.filter((statement) => statement.type === 'ReturnStatement' && isJsxNode(statement.argument))
+			.map((statement) => statement.argument);
+		const renderReadNames = collectRenderReadNames(renderedRoots, ctx);
+		let renderScopeEstablished = false;
+		newStatements = authoredStatements.map((sourceStatement) => {
+			// Return-JSX functions keep their ordinary callable ABI. Introducing a
+			// cache into a hookless function would make an existing direct call
+			// require a render scope, so only declarations following an authored,
+			// unconditional Octane hook may use the existing calculation lowering.
+			const calculated = renderScopeEstablished
+				? rewriteAutoCalculation(sourceStatement, ctx.currentComponentLocals, renderReadNames, ctx)
+				: sourceStatement;
+			if (!renderScopeEstablished && sourceStatement.type === 'VariableDeclaration') {
+				renderScopeEstablished = (sourceStatement.declarations || []).some(
+					(declaration) => stableHookCallName(unwrapTsExpr(declaration.init)) !== null,
+				);
+			} else if (!renderScopeEstablished && sourceStatement.type === 'ExpressionStatement') {
+				renderScopeEstablished =
+					stableHookCallName(unwrapTsExpr(sourceStatement.expression)) !== null;
+			}
 			// A return-based component's undefined output is ambiguous with the compiled
 			// void-body signal at runtime. Preserve JSX roots for the specialized lowering
 			// below, but normalize every other owned return to an explicit empty value.
-			const s = normalizeOwnRenderableReturns(sourceStatement, true);
+			const s = normalizeOwnRenderableReturns(calculated, true);
 			const prepared =
 				s.type === 'ReturnStatement' && s.argument && isJsxNode(s.argument)
 					? s
@@ -16427,6 +16692,7 @@ function emitAutoMemoRegion(
 	contextAware,
 	depNode,
 	initValue = null,
+	restoreCachedContext = false,
 ) {
 	const cell = allocAutoMemoCell(ctx, dependencies.length + (contextAware ? 1 : 0));
 	const contextIndex = contextAware ? cell.base + dependencies.length : null;
@@ -16476,7 +16742,15 @@ function emitAutoMemoRegion(
 	}
 	ctx.runtimeNeeded.add('compilerCacheContext');
 	const cacheContextCall = () =>
-		b.call('_$compilerCacheContext', b.id('__s'), b.literal(slotIndex), cacheAt(contextIndex));
+		restoreCachedContext
+			? b.call(
+					'_$compilerCacheContext',
+					b.id('__s'),
+					b.literal(slotIndex),
+					cacheAt(contextIndex),
+					b.literal(true),
+				)
+			: b.call('_$compilerCacheContext', b.id('__s'), b.literal(slotIndex), cacheAt(contextIndex));
 	return b.block([
 		...depDecls,
 		b.if(
@@ -17667,6 +17941,59 @@ function planJsx(
 					continue;
 				}
 				ctx.runtimeNeeded.add('setText');
+				const updateHole = () =>
+					b.if(
+						b.logical('||', b.id('_o'), b.binary('!==', chp(), V())),
+						b.block([
+							b.const('_t', chv()),
+							b.if(
+								andChain([
+									b.binary('!=', b.id('_t'), b.literal(null)),
+									b.unary('!', b.id('_o')),
+									b.binary('!==', V(), b.literal(null)),
+								]),
+								b.stmt(b.call('_$setText', b.id('_t'), V())),
+								b.stmt(
+									b.assignment(
+										'=',
+										chv(),
+										b.call(
+											'_$childTextHole',
+											b.id('__s'),
+											b.literal(slotIndex),
+											hostExpr(),
+											V(),
+											b.id('_t'),
+										),
+									),
+								),
+							),
+							b.stmt(b.assignment('=', chp(), V())),
+						]),
+						null,
+					);
+				const ordinary = updateHole();
+				let update = ordinary;
+				if (cc.autoMemoValue === true) {
+					// Only a compiler-owned, non-escaping plain data array may skip
+					// descriptor reconciliation. Accessor-backed, nested, or deferred
+					// children must still be observed on every parent render; the
+					// runtime caches eligibility by immutable snapshot identity.
+					ctx.runtimeNeeded.add('compilerCacheArray');
+					const cached = emitAutoMemoRegion(
+						ctx,
+						['_v'],
+						slotIndex,
+						updateHole(),
+						// Array → scalar → the same array must reconstruct the list.
+						b.binary('!==', chp(), V()),
+						true,
+						undefined,
+						null,
+						true,
+					);
+					update = b.if(b.call('_$compilerCacheArray', V(), chp()), cached, ordinary);
+				}
 				pushAfterStmt(
 					cc.id,
 					org,
@@ -17684,36 +18011,7 @@ function planJsx(
 								),
 							),
 						),
-						b.if(
-							b.logical('||', b.id('_o'), b.binary('!==', chp(), V())),
-							b.block([
-								b.const('_t', chv()),
-								b.if(
-									andChain([
-										b.binary('!=', b.id('_t'), b.literal(null)),
-										b.unary('!', b.id('_o')),
-										b.binary('!==', V(), b.literal(null)),
-									]),
-									b.stmt(b.call('_$setText', b.id('_t'), V())),
-									b.stmt(
-										b.assignment(
-											'=',
-											chv(),
-											b.call(
-												'_$childTextHole',
-												b.id('__s'),
-												b.literal(slotIndex),
-												hostExpr(),
-												V(),
-												b.id('_t'),
-											),
-										),
-									),
-								),
-								b.stmt(b.assignment('=', chp(), V())),
-							]),
-							null,
-						),
+						update,
 					]),
 				);
 				continue;
@@ -20953,7 +21251,7 @@ function soleRenderPropChild(children) {
 // expression remains AST throughout so a nested `() => @{…}` sub-template
 // hoists (and server-mode `use(thenable)` calls get their stable keys).
 function makeChildCall(expr, ctx, componentName, inlinedSubs, cssHash) {
-	return {
+	const child = {
 		id: ctx.nextHelperId++,
 		loc: devLoc(ctx, expr),
 		origin: expr,
@@ -20965,6 +21263,27 @@ function makeChildCall(expr, ctx, componentName, inlinedSubs, cssHash) {
 			inlinedSubs,
 		),
 	};
+	if (
+		ctx.autoMemo &&
+		// Imported calculations do not expose their return type. Restrict the
+		// array guard to deferred component-child bodies, where cached descriptor
+		// lists otherwise cross an expensive value-position boundary; an ordinary
+		// scalar directly in its owning component must not acquire this region.
+		ctx.currentBodyIsComponentScope !== true &&
+		expr?.type === 'Identifier'
+	) {
+		for (
+			let proof = ctx.currentAutoCalculatedRenderableRefs;
+			proof !== null;
+			proof = proof.parent
+		) {
+			if (proof.nodes.has(expr)) {
+				child.autoMemoValue = true;
+				break;
+			}
+		}
+	}
+	return child;
 }
 
 const AST_STRUCTURAL_KEY_SKIP = new Set([

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -3658,15 +3658,16 @@ function containsRenderCall(stmts, memoCtx = null) {
 }
 
 // A hook call is identified by naming convention — the same signal React and
-// React Compiler key on — plus React's own `unstable_` staging prefix, which
-// bindings mirror (`unstable_useRouterState` in @octanejs/remix-router). The
-// prefix is enumerated rather than matched as "any `_use`" so an ordinary
-// helper cannot be mistaken for a hook by spelling alone.
+// React Compiler key on — plus the exact `unstable_` and `UNSTABLE_` staging
+// prefixes bindings expose (`unstable_useRouterState` in @octanejs/remix-router
+// and `UNSTABLE_useTreeGridState` in @octanejs/aria). Enumerate the prefixes
+// rather than matching "any `_use`" so ordinary helpers are not mistaken for
+// hooks by spelling alone.
 //
 // Getting this wrong in the permissive direction is not a staleness bug: a
 // cache wrapped around a hook call freezes its subscription and its state cell
 // for the life of the component.
-const HOOK_NAME_CONVENTION_RE = /^(?:unstable_)?use(?:$|[A-Z])/;
+const HOOK_NAME_CONVENTION_RE = /^(?:(?:unstable|UNSTABLE)_)?use(?:$|[A-Z])/;
 
 function isHookCalleeName(name) {
 	return HOOK_NAME_CONVENTION_RE.test(name);

--- a/packages/octane/src/index.ts
+++ b/packages/octane/src/index.ts
@@ -195,6 +195,7 @@ export {
 	componentSlot,
 	componentSlotVoid,
 	componentSlotLite,
+	compilerCacheArray,
 	compilerCacheContext,
 	markSingleRoot,
 	// Compact compiler ABI; keep the descriptive export for older compiled output.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -17427,7 +17427,74 @@ const NATIVE_ARRAY_SPECIES_GETTER = Object.getOwnPropertyDescriptor(Array, Symbo
 // per row on every unchanged parent render; holes and intrinsic overrides are
 // still rechecked each time. Mutating an existing data index into an accessor
 // without changing the snapshot identity/length is outside that contract.
-const NATIVE_ARRAY_ACCESSORS = new WeakMap<object, { length: number; accessor: boolean }>();
+const NATIVE_ARRAY_ACCESSORS = new WeakMap<
+	object,
+	{ length: number; accessor: boolean; renderable?: boolean }
+>();
+
+/**
+ * Compiler ABI for a safely reusable value-position array. A plain dense array
+ * of ordinary descriptor snapshots can skip reconciliation while its identity
+ * holds; indexed getters, nested collections, Fragments, and scope-sensitive
+ * descriptors must stay on the ordinary live-render path. A fresh array will
+ * be reconciled regardless, so inspect its entries only when that same identity
+ * can actually skip a later render. Classification is cached by immutable
+ * snapshot identity, just like the existing mapped-array accessor proof, so
+ * subsequent cache hits remain constant-time without penalizing fresh lists.
+ * @internal
+ */
+export function compilerCacheArray(value: unknown, previous: unknown): boolean {
+	if (!Array.isArray(value) || Object.getPrototypeOf(value) !== Array.prototype) return false;
+	// The region's existing identity-miss guard guarantees a changed value runs
+	// its ordinary reconciliation. No safety classification is needed until a
+	// previously rendered array could actually be reused.
+	if (value !== previous) return true;
+	const length = value.length;
+	const cached = NATIVE_ARRAY_ACCESSORS.get(value);
+	if (cached !== undefined && cached.length === length) {
+		if (cached.accessor) return false;
+		if (cached.renderable !== undefined) return cached.renderable;
+	}
+
+	let accessor = false;
+	let renderable = true;
+	for (let index = 0; index < length; index++) {
+		const descriptor = Object.getOwnPropertyDescriptor(value, index);
+		if (descriptor === undefined || descriptor.get !== undefined || descriptor.set !== undefined) {
+			accessor = true;
+			renderable = false;
+			break;
+		}
+		const item = descriptor.value;
+		if (Array.isArray(item)) {
+			renderable = false;
+			continue;
+		}
+		if (item !== null && typeof item === 'object') {
+			if (item.$$kind !== ELEMENT_TAG) {
+				renderable = false;
+				continue;
+			}
+			// A scoped-value descriptor exposes type/props through getters. Check its
+			// private marker before touching either field or moving context reads.
+			if ((item as ScopedValueDescriptor<any>)[SCOPED_VALUE_RECORD] !== undefined) {
+				renderable = false;
+				continue;
+			}
+			// Hosts and Fragments own child collections that may hide live getters;
+			// only ordinary component descriptor snapshots are independently safe.
+			if (typeof item.type !== 'function' || SCOPED_ELEMENT_PROPS.has(item.props as object)) {
+				renderable = false;
+			}
+		} else if (typeof item === 'function' || typeof item === 'symbol') {
+			renderable = false;
+		}
+	}
+	// Continue scanning after a nested/scoped rejection: mapSlot shares this
+	// record and still needs its accessor verdict to cover every array index.
+	NATIVE_ARRAY_ACCESSORS.set(value, { length, accessor, renderable });
+	return renderable;
+}
 
 /** Shared compiler ABI: native-array eligibility query plus stable keyed map dispatch. */
 export function mapSlot(
@@ -18764,6 +18831,49 @@ function restampCtxDeps(block: Block): void {
 	}
 }
 
+// A cached output region bypasses the memo/implicit bailouts that normally
+// restore a skipped subtree's context dependencies onto rerendered ancestors.
+// Descend only until the first stamped boundary: its aggregate already covers
+// the entire live subtree. Lite child scopes are not Blocks, so continue
+// through them rather than mistaking their owning block for a fresh boundary.
+function restampCachedContextScope(scope: Scope): void {
+	if (scope.block === scope) {
+		const block = scope as Block;
+		if ((block.body as any)?.__memo === true || block.$$implicitBail === true) {
+			restampCtxDeps(block);
+			return;
+		}
+		if (block.$$ctxDirect !== null && block.$$ctxDirect.size !== 0) {
+			restampCtxDeps(block);
+		}
+	}
+	forEachSubtreeChild(scope, restampCachedContextScope);
+}
+
+function restampCachedSlotContext(slot: any): void {
+	if (slot.__kind === 'forBlockSlot') {
+		for (let item: Block | null = slot.head; item !== null; item = item.nextSibling) {
+			restampCachedContextScope(item);
+		}
+		if (slot.emptyBlock !== null) restampCachedContextScope(slot.emptyBlock);
+		return;
+	}
+	if (slot.block !== undefined && slot.block !== null) {
+		restampCachedContextScope(slot.block);
+		return;
+	}
+	if (slot.__kind !== 'childSlot') return;
+	if (slot.forSlot !== null) {
+		const list = slot.forSlot as ForSlot;
+		for (let item: Block | null = list.head; item !== null; item = item.nextSibling) {
+			restampCachedContextScope(item);
+		}
+		if (list.emptyBlock !== null) restampCachedContextScope(list.emptyBlock);
+	} else if (slot.portal?.block !== undefined && slot.portal.block !== null) {
+		restampCachedContextScope(slot.portal.block);
+	}
+}
+
 function refreshBlockForContext(block: Block): void {
 	if (ctxDirectChanged(block)) {
 		// This child directly consumes the changed context (or shares its block
@@ -18788,30 +18898,70 @@ function refreshBlockForContext(block: Block): void {
  * Compiler ABI for a flat output-cache hit. Context consumers are normally
  * reached while their parent slot reconciles; a cache hit intentionally skips
  * that reconciliation, so an intervening Provider commit must refresh the
- * slot's existing Block(s) directly. The common path is one numeric equality
- * check. `previous === undefined` snapshots the epoch after a cache miss
- * without refreshing the freshly-rendered subtree.
+ * slot's existing Block(s) directly. Activity/Suspense reveals must also
+ * reconnect effects retained by a skipped subtree, in its live source order,
+ * and opted-in renderable-array regions restore their descendants' context
+ * reads onto memoized ancestors. Existing mapped regions keep their original
+ * constant-time hit; only array-region hits inspect precomputed memo ancestry.
+ * `previous === undefined` snapshots the epoch after a cache miss without
+ * revisiting the freshly-rendered subtree.
  * @internal
  */
 export function compilerCacheContext(
 	scope: Scope,
 	slotKey: number,
 	previous: number | undefined,
+	restampMemoAncestors: boolean = false,
 ): number {
 	const current = COMPILER_CACHE_CONTEXT_EPOCH;
-	if (previous === undefined || previous === current) return current;
+	if (previous === undefined) return current;
+	const reconnect = EFFECT_RECONNECT_CONTEXT !== null;
+	const restamp = restampMemoAncestors && scope.block.memoInChain;
+	if (previous === current && !reconnect && !restamp) return current;
 	const slot = scope.slots[slotKey];
 	if (slot === undefined || slot === null) return current;
-	if (slot.__kind === 'forBlockSlot') {
-		for (const item of slot.items.values()) refreshBlockForContext(item);
-		if (slot.emptyBlock) refreshBlockForContext(slot.emptyBlock);
-	} else if (slot.block) {
-		refreshBlockForContext(slot.block);
-	} else if (slot.__kind === 'childSlot' && slot.forSlot) {
-		for (const item of slot.forSlot.items.values()) refreshBlockForContext(item);
-	} else if (slot.__kind === 'childSlot' && slot.portal?.block) {
-		refreshBlockForContext(slot.portal.block);
+	if (reconnect) {
+		const contextChanged = previous !== current;
+		const list =
+			slot.__kind === 'forBlockSlot'
+				? (slot as ForSlot)
+				: slot.__kind === 'childSlot'
+					? (slot.forSlot as ForSlot | null)
+					: null;
+		if (list !== null) {
+			// Map insertion order stays unchanged when keyed survivors reorder;
+			// effects must reconnect in the live linked chain's source order.
+			for (let item: Block | null = list.head; item !== null; item = item.nextSibling) {
+				if (contextChanged) refreshBlockForContext(item);
+				reconnectBailedEffects(item);
+			}
+			if (list.emptyBlock !== null) {
+				if (contextChanged) refreshBlockForContext(list.emptyBlock);
+				reconnectBailedEffects(list.emptyBlock);
+			}
+		} else {
+			const block = slot.block ?? (slot.__kind === 'childSlot' ? slot.portal?.block : null);
+			if (block !== undefined && block !== null) {
+				if (contextChanged) refreshBlockForContext(block);
+				reconnectBailedEffects(block);
+			}
+		}
+		if (restamp) restampCachedSlotContext(slot);
+		return current;
 	}
+	if (previous !== current) {
+		if (slot.__kind === 'forBlockSlot') {
+			for (const item of slot.items.values()) refreshBlockForContext(item);
+			if (slot.emptyBlock) refreshBlockForContext(slot.emptyBlock);
+		} else if (slot.block) {
+			refreshBlockForContext(slot.block);
+		} else if (slot.__kind === 'childSlot' && slot.forSlot) {
+			for (const item of slot.forSlot.items.values()) refreshBlockForContext(item);
+		} else if (slot.__kind === 'childSlot' && slot.portal?.block) {
+			refreshBlockForContext(slot.portal.block);
+		}
+	}
+	if (restamp) restampCachedSlotContext(slot);
 	return current;
 }
 

--- a/packages/octane/tests/_fixtures/auto-calculation-helpers.ts
+++ b/packages/octane/tests/_fixtures/auto-calculation-helpers.ts
@@ -2,10 +2,20 @@
 // opaque to the importing module's compilation, so these exist to exercise the
 // admitted-projection path rather than to hide behavior.
 
+import { useState } from 'octane';
+
 export function projectRows(rows: ReadonlyArray<{ id: number; n: number }>): string[] {
 	return rows.map((r) => `r${r.id}:${r.n}`);
 }
 
 export function tagged(value: string): string {
 	return `[${value}]`;
+}
+
+export function UNSTABLE_useProjectedCounter(): {
+	value: number;
+	increment: () => void;
+} {
+	const [value, setValue] = useState(0);
+	return { value, increment: () => setValue((current) => current + 1) };
 }

--- a/packages/octane/tests/_fixtures/auto-memo-value-position.tsrx
+++ b/packages/octane/tests/_fixtures/auto-memo-value-position.tsrx
@@ -1,0 +1,308 @@
+import {
+	Activity as ActivitySentinel,
+	createContext,
+	createElement,
+	memo,
+	type OctaneNode,
+	startTransition,
+	use,
+	useContext,
+	useEffect,
+	useLayoutEffect,
+	useMemo,
+	useState,
+} from 'octane';
+
+interface ValuePositionRow {
+	id: number;
+	label: string;
+}
+
+const ValuePositionTheme = createContext('initial');
+const ValuePositionBoundaryContext = createContext('unrelated');
+const Activity = ActivitySentinel as unknown as
+	(props: {
+		mode: 'hidden' | 'visible';
+		children?: OctaneNode;
+	}) => null;
+
+function ValuePositionRowBody(props: ValuePositionRow) @{
+	const theme = useContext(ValuePositionTheme);
+	const [own, setOwn] = useState(0);
+	<div class="memo-value-row" data-id={props.id}>
+		<input class={'memo-value-input-' + props.id} defaultValue={props.label} />
+		<button class={'memo-value-own-' + props.id} onClick={() => setOwn(own + 1)}>
+			{theme + ':' + props.label + ':' + own}
+		</button>
+	</div>
+}
+
+const MemoValuePositionRow = memo(ValuePositionRowBody);
+
+function buildValuePositionRows(items: ValuePositionRow[]) {
+	return [
+		createElement(MemoValuePositionRow, {
+			key: items[0]!.id,
+			id: items[0]!.id,
+			label: items[0]!.label,
+		}),
+		createElement(MemoValuePositionRow, {
+			key: items[1]!.id,
+			id: items[1]!.id,
+			label: items[1]!.label,
+		}),
+	];
+}
+
+export function CachedValuePositionRows() @{
+	const [items, setItems] = useState<ValuePositionRow[]>([
+		{ id: 1, label: 'first' },
+		{ id: 2, label: 'second' },
+	]);
+	const [theme, setTheme] = useState('initial');
+	const [tick, setTick] = useState(0);
+	const rows = buildValuePositionRows(items);
+	<section>
+		<button id="memo-value-tick" onClick={() => setTick(tick + 1)}>{tick as number}</button>
+		<button id="memo-value-theme" onClick={() => setTheme(theme + '!')}>{'theme'}</button>
+		<button
+			id="memo-value-change"
+			onClick={() => setItems([{ ...items[0]!, label: items[0]!.label + '!' }, items[1]!])}
+		>{'change'}</button>
+		<button
+			id="memo-value-reorder"
+			onClick={() => setItems([items[1]!, items[0]!])}
+		>{'reorder'}</button>
+		<ValuePositionTheme.Provider value={theme}>
+			<div id="memo-value-rows">{rows}</div>
+		</ValuePositionTheme.Provider>
+	</section>
+}
+
+function ValuePositionMemoBoundaryBody(props: { items: ValuePositionRow[]; tick: number }) @{
+	const items = props.items;
+	const rows = buildValuePositionRows(items);
+	<ValuePositionBoundaryContext.Provider value="unrelated">
+		<div id="memo-value-boundary-rows" data-tick={props.tick}>{rows}</div>
+	</ValuePositionBoundaryContext.Provider>
+}
+
+const MemoValuePositionBoundary = memo(ValuePositionMemoBoundaryBody);
+
+export function CachedValuePositionMemoContext() @{
+	const [items] = useState<ValuePositionRow[]>([
+		{ id: 1, label: 'first' },
+		{ id: 2, label: 'second' },
+	]);
+	const [theme, setTheme] = useState('initial');
+	const [tick, setTick] = useState(0);
+	<section>
+		<button
+			id="memo-value-boundary-tick"
+			onClick={() => setTick(tick + 1)}
+		>{tick as number}</button>
+		<button id="memo-value-boundary-theme" onClick={() => setTheme(theme + '!')}>{'theme'}</button>
+		<ValuePositionTheme.Provider value={theme}>
+			<MemoValuePositionBoundary items={items} tick={tick} />
+		</ValuePositionTheme.Provider>
+	</section>
+}
+
+function selectValuePositionOutput(
+	rows: ReturnType<typeof buildValuePositionRows>,
+	visible: boolean,
+) {
+	return visible ? rows : 'temporarily hidden';
+}
+
+export function CachedValuePositionRoundTrip() @{
+	const [items] = useState<ValuePositionRow[]>([
+		{ id: 1, label: 'first' },
+		{ id: 2, label: 'second' },
+	]);
+	const [visible, setVisible] = useState(true);
+	const [theme, setTheme] = useState('initial');
+	const stableRows = useMemo(() => buildValuePositionRows(items), [items]);
+	const output = selectValuePositionOutput(stableRows, visible);
+	<section>
+		<button
+			id="memo-value-round-trip-toggle"
+			onClick={() => setVisible(!visible)}
+		>{'toggle rows'}</button>
+		<button
+			id="memo-value-round-trip-theme"
+			onClick={() => setTheme(theme + '!')}
+		>{'change theme'}</button>
+		<ValuePositionTheme.Provider value={theme}>
+			<div id="memo-value-round-trip-rows">{output}</div>
+		</ValuePositionTheme.Provider>
+	</section>
+}
+
+export function EscapedValuePositionRows() @{
+	const [items] = useState<ValuePositionRow[]>([
+		{ id: 1, label: 'first' },
+		{ id: 2, label: 'second' },
+	]);
+	const [tick, setTick] = useState(0);
+	const rows = buildValuePositionRows(items);
+	<section>
+		<button
+			id="memo-value-mutate"
+			onClick={() => {
+				rows.reverse();
+				setTick(tick + 1);
+			}}
+		>{tick as number}</button>
+		<div id="memo-value-escaped-rows">{rows}</div>
+	</section>
+}
+
+export function SetupEscapedValuePositionRows() @{
+	const [items] = useState<ValuePositionRow[]>([
+		{ id: 1, label: 'first' },
+		{ id: 2, label: 'second' },
+	]);
+	const [tick, setTick] = useState(0);
+	const rows = buildValuePositionRows(items);
+	const mutate = () => rows.reverse();
+	<section>
+		<button
+			id="memo-value-setup-mutate"
+			onClick={() => {
+				mutate();
+				setTick(tick + 1);
+			}}
+		>{tick as number}</button>
+		<div id="memo-value-setup-rows">{rows}</div>
+	</section>
+}
+
+const valuePositionActivityEffects: string[] = [];
+const valuePositionLayoutEffects: string[] = [];
+
+export function drainValuePositionActivityEffects(): string[] {
+	return valuePositionActivityEffects.splice(0);
+}
+
+export function drainValuePositionLayoutEffects(): string[] {
+	return valuePositionLayoutEffects.splice(0);
+}
+
+function ValuePositionEffectRow(props: ValuePositionRow) @{
+	useLayoutEffect(() => {
+		valuePositionLayoutEffects.push('mount:' + props.id);
+		return () => {
+			valuePositionLayoutEffects.push('cleanup:' + props.id);
+		};
+	}, [props.id]);
+	useEffect(() => {
+		valuePositionActivityEffects.push('mount:' + props.id);
+		return () => {
+			valuePositionActivityEffects.push('cleanup:' + props.id);
+		};
+	}, [props.id]);
+	<span class="memo-value-activity-row">{props.label as string}</span>
+}
+
+const MemoValuePositionEffectRow = memo(ValuePositionEffectRow);
+
+function buildValuePositionEffectRows(items: ValuePositionRow[]) {
+	return [
+		createElement(MemoValuePositionEffectRow, {
+			key: items[0]!.id,
+			id: items[0]!.id,
+			label: items[0]!.label,
+		}),
+		createElement(MemoValuePositionEffectRow, {
+			key: items[1]!.id,
+			id: items[1]!.id,
+			label: items[1]!.label,
+		}),
+	];
+}
+
+export function CachedValuePositionActivity(props: { mode: 'visible' | 'hidden' }) @{
+	const [items, setItems] = useState<ValuePositionRow[]>([
+		{ id: 1, label: 'first' },
+		{ id: 2, label: 'second' },
+	]);
+	const rows = buildValuePositionEffectRows(items);
+	<section>
+		<button
+			id="memo-value-activity-reorder"
+			onClick={() => setItems([items[1]!, items[0]!])}
+		>{'reorder'}</button>
+		<Activity mode={props.mode}>
+			<ValuePositionTheme.Provider value="initial">
+				<div id="memo-value-activity-rows">{rows}</div>
+			</ValuePositionTheme.Provider>
+		</Activity>
+	</section>
+}
+
+function ValuePositionSuspender(props: { promise: PromiseLike<string> }) @{
+	const value = use(props.promise);
+	<span id="memo-value-suspense-detail">{value as string}</span>
+}
+
+export function CachedValuePositionSuspense(props: { promise: PromiseLike<string> }) @{
+	const [items] = useState<ValuePositionRow[]>([
+		{ id: 1, label: 'first' },
+		{ id: 2, label: 'second' },
+	]);
+	const rows = buildValuePositionEffectRows(items);
+	<section>
+		@try {
+			<>
+				<ValuePositionTheme.Provider value="initial">
+					<div id="memo-value-suspense-rows">{rows}</div>
+				</ValuePositionTheme.Provider>
+				<ValuePositionSuspender promise={props.promise} />
+			</>
+		} @pending {
+			<span id="memo-value-suspense-pending">{'loading'}</span>
+		}
+	</section>
+}
+
+export function CachedValuePositionTransition(props: {
+	initialPromise: PromiseLike<string>;
+	nextPromise: PromiseLike<string>;
+}) @{
+	const [items, setItems] = useState<ValuePositionRow[]>([
+		{ id: 1, label: 'first' },
+		{ id: 2, label: 'second' },
+	]);
+	const [resource, setResource] = useState(props.initialPromise);
+	const rows = buildValuePositionRows(items);
+	<section>
+		<button
+			id="memo-value-transition-bump"
+			onClick={() => startTransition(() => {
+				setItems([
+					{ id: 2, label: 'pending second' },
+					{ id: 1, label: 'pending first' },
+				]);
+				setResource(props.nextPromise);
+			})}
+		>{'start transition'}</button>
+		<button
+			id="memo-value-transition-urgent"
+			onClick={() => setItems([
+				{ id: 2, label: 'urgent second' },
+				{ id: 1, label: 'urgent first' },
+			])}
+		>{'update urgently'}</button>
+		@try {
+			<>
+				<ValuePositionTheme.Provider value="initial">
+					<div id="memo-value-transition-rows">{rows}</div>
+				</ValuePositionTheme.Provider>
+				<ValuePositionSuspender promise={resource} />
+			</>
+		} @pending {
+			<span id="memo-value-transition-pending">{'loading'}</span>
+		}
+	</section>
+}

--- a/packages/octane/tests/_fixtures/parallel-use.tsrx
+++ b/packages/octane/tests/_fixtures/parallel-use.tsrx
@@ -256,6 +256,42 @@ function AdjacentPanels(props) @{
 	</main>
 }
 
+// Declare the synchronous bridges before their callees so warm reachability
+// must propagate through both forward same-module references.
+interface SyncWarmProps {
+	load: (key: string, version: number) => Promise<string>;
+	version: number;
+}
+
+function SyncWarmOuter(props: SyncWarmProps) @{
+	<section class="sync-warm-outer">
+		<SyncWarmInner load={props.load} version={props.version} />
+	</section>
+}
+
+function SyncWarmInner(props: SyncWarmProps) @{
+	<div class="sync-warm-inner">
+		<SyncWarmLeaf load={props.load} version={props.version} />
+	</div>
+}
+
+function SyncWarmLeaf(props: SyncWarmProps) @{
+	const value = use(props.load('sync-warm-leaf', props.version));
+	<span class="sync-warm-leaf">{value as string}</span>
+}
+
+function SyncWarmDirect(props: SyncWarmProps) @{
+	const value = use(props.load('sync-warm-direct', props.version));
+	<span class="sync-warm-direct">{value as string}</span>
+}
+
+function SyncWarmBranches(props: SyncWarmProps) @{
+	<main>
+		<SyncWarmDirect load={props.load} version={props.version} />
+		<SyncWarmOuter load={props.load} version={props.version} />
+	</main>
+}
+
 function VersionedPanel(props) @{
 	const value = use(props.load(props.resource, props.version));
 	<span class={props.resource}>{value as string}</span>
@@ -394,6 +430,16 @@ export function AdjacentPanelsHost(props) @{
 			}
 		} @pending {
 			<div class="fallback">{'panels-loading'}</div>
+		}
+	</>
+}
+
+export function SyncWarmBranchesHost(props: SyncWarmProps) @{
+	<>
+		@try {
+			<SyncWarmBranches load={props.load} version={props.version} />
+		} @pending {
+			<div class="fallback">{'sync-warm-loading'}</div>
 		}
 	</>
 }

--- a/packages/octane/tests/_fixtures/tsx-auto-memo.tsx
+++ b/packages/octane/tests/_fixtures/tsx-auto-memo.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource octane */
 
 import { useContext, useEffect, useState } from 'octane';
+import { projectRows } from './auto-calculation-helpers';
 import { AutoMemoChild, AutoMemoContext } from './auto-memo-child.tsrx';
 
 type Row = { id: number; label: string };
@@ -247,4 +248,67 @@ export function TsxImpureRowsApp() {
 			</ul>
 		</section>
 	);
+}
+
+const derivedIdentities = new WeakMap<object, number>();
+let nextDerivedIdentity = 0;
+
+function derivedIdentity(value: object): string {
+	let identity = derivedIdentities.get(value);
+	if (identity === undefined) {
+		identity = ++nextDerivedIdentity;
+		derivedIdentities.set(value, identity);
+	}
+	return `derived-${identity}`;
+}
+
+export function TsxDerivedIdentity() {
+	const [items, setItems] = useState([{ id: 1, n: 1 }]);
+	const [tick, setTick] = useState(0);
+	const visible = projectRows(items);
+
+	return (
+		<section>
+			<button id="tsx-derived-tick" onClick={() => setTick(tick + 1)}>
+				{tick}
+			</button>
+			<button
+				id="tsx-derived-add"
+				onClick={() => setItems([...items, { id: items.length + 1, n: items.length + 1 }])}
+			>
+				add
+			</button>
+			<span id="tsx-derived-identity">{derivedIdentity(visible)}</span>
+			<span id="tsx-derived-values">{visible.join(',')}</span>
+		</section>
+	);
+}
+
+export function TsxLiveReceiverCalculation() {
+	const [source] = useState(() => {
+		let next = 0;
+		return { read: () => `reading-${++next}` };
+	});
+	const [tick, setTick] = useState(0);
+	const reading = source.read();
+
+	return (
+		<section>
+			<button id="tsx-receiver-tick" onClick={() => setTick(tick + 1)}>
+				{tick}
+			</button>
+			<span id="tsx-receiver-value">{reading}</span>
+		</section>
+	);
+}
+
+function TsxCallableProjection(props: { rows: ReadonlyArray<{ id: number; n: number }> }) {
+	const visible = projectRows(props.rows);
+	return <span id="tsx-callable-values">{visible.join(',')}</span>;
+}
+
+export function callTsxCallableProjection(props: {
+	rows: ReadonlyArray<{ id: number; n: number }>;
+}) {
+	return TsxCallableProjection(props);
 }

--- a/packages/octane/tests/_fixtures/tsx-auto-memo.tsx
+++ b/packages/octane/tests/_fixtures/tsx-auto-memo.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource octane */
 
 import { useContext, useEffect, useState } from 'octane';
-import { projectRows } from './auto-calculation-helpers';
+import { projectRows, UNSTABLE_useProjectedCounter } from './auto-calculation-helpers';
 import { AutoMemoChild, AutoMemoContext } from './auto-memo-child.tsrx';
 
 type Row = { id: number; label: string };
@@ -280,6 +280,23 @@ export function TsxDerivedIdentity() {
 			</button>
 			<span id="tsx-derived-identity">{derivedIdentity(visible)}</span>
 			<span id="tsx-derived-values">{visible.join(',')}</span>
+		</section>
+	);
+}
+
+export function TsxUnstablePrefixedHook() {
+	const [tick, setTick] = useState(0);
+	const state = UNSTABLE_useProjectedCounter();
+
+	return (
+		<section>
+			<button id="tsx-unstable-hook-tick" onClick={() => setTick(tick + 1)}>
+				{tick}
+			</button>
+			<button id="tsx-unstable-hook-increment" onClick={state.increment}>
+				increment
+			</button>
+			<span id="tsx-unstable-hook-value">{state.value}</span>
 		</section>
 	);
 }

--- a/packages/octane/tests/auto-calculation.test.ts
+++ b/packages/octane/tests/auto-calculation.test.ts
@@ -9,6 +9,11 @@ import {
 	LiveReceiverCalculation,
 	resetIdentities,
 } from './_fixtures/auto-calculation.tsrx';
+import {
+	callTsxCallableProjection,
+	TsxDerivedIdentity,
+	TsxLiveReceiverCalculation,
+} from './_fixtures/tsx-auto-memo.tsx';
 
 // A derived `const` whose initializer reaches a render-time call is cached on
 // its component-local inputs. The observable contract is identity stability —
@@ -158,5 +163,47 @@ describe('auto-calculation — a member call on a live receiver is never cached'
 		r.click('#lr-tick');
 		expect(r.find('#lr-reading').textContent).not.toBe(second);
 		r.unmount();
+	});
+});
+
+describe('auto-calculation — React-style return components', () => {
+	it('preserves derived identity across unrelated updates and invalidates changed inputs', () => {
+		const root = mount(TsxDerivedIdentity);
+		const first = root.find('#tsx-derived-identity').textContent;
+		expect(root.find('#tsx-derived-values').textContent).toBe('r1:1');
+
+		root.click('#tsx-derived-tick');
+		expect(root.find('#tsx-derived-identity').textContent).toBe(first);
+
+		root.click('#tsx-derived-add');
+		const second = root.find('#tsx-derived-identity').textContent;
+		expect(second).not.toBe(first);
+		expect(root.find('#tsx-derived-values').textContent).toBe('r1:1,r2:2');
+
+		root.click('#tsx-derived-tick');
+		expect(root.find('#tsx-derived-identity').textContent).toBe(second);
+		root.unmount();
+	});
+
+	it('keeps a live method-backed calculation reactive', () => {
+		const root = mount(TsxLiveReceiverCalculation);
+		const first = root.find('#tsx-receiver-value').textContent;
+
+		root.click('#tsx-receiver-tick');
+		const second = root.find('#tsx-receiver-value').textContent;
+		expect(second).not.toBe(first);
+
+		root.click('#tsx-receiver-tick');
+		expect(root.find('#tsx-receiver-value').textContent).not.toBe(second);
+		root.unmount();
+	});
+
+	it('keeps hookless return components callable outside a render scope', () => {
+		const rows = [{ id: 1, n: 1 }];
+		expect(() => callTsxCallableProjection({ rows })).not.toThrow();
+
+		const root = mount(callTsxCallableProjection, { rows });
+		expect(root.find('#tsx-callable-values').textContent).toBe('r1:1');
+		root.unmount();
 	});
 });

--- a/packages/octane/tests/auto-calculation.test.ts
+++ b/packages/octane/tests/auto-calculation.test.ts
@@ -13,6 +13,7 @@ import {
 	callTsxCallableProjection,
 	TsxDerivedIdentity,
 	TsxLiveReceiverCalculation,
+	TsxUnstablePrefixedHook,
 } from './_fixtures/tsx-auto-memo.tsx';
 
 // A derived `const` whose initializer reaches a render-time call is cached on
@@ -195,6 +196,21 @@ describe('auto-calculation — React-style return components', () => {
 
 		root.click('#tsx-receiver-tick');
 		expect(root.find('#tsx-receiver-value').textContent).not.toBe(second);
+		root.unmount();
+	});
+
+	it('keeps an imported uppercase UNSTABLE_ custom hook live after a built-in hook', () => {
+		const root = mount(TsxUnstablePrefixedHook);
+		expect(root.find('#tsx-unstable-hook-value').textContent).toBe('0');
+
+		root.click('#tsx-unstable-hook-increment');
+		expect(root.find('#tsx-unstable-hook-value').textContent).toBe('1');
+
+		root.click('#tsx-unstable-hook-tick');
+		expect(root.find('#tsx-unstable-hook-value').textContent).toBe('1');
+
+		root.click('#tsx-unstable-hook-increment');
+		expect(root.find('#tsx-unstable-hook-value').textContent).toBe('2');
 		root.unmount();
 	});
 

--- a/packages/octane/tests/auto-memo-value-position.test.ts
+++ b/packages/octane/tests/auto-memo-value-position.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from 'vitest';
+import * as ServerRuntime from 'octane/server';
+import { flushSync, hydrateRoot } from '../src/index.js';
+import { act, flushEffects, mount } from './_helpers';
+import { loadServerFixture } from './_server-fixture';
+import {
+	CachedValuePositionRows,
+	CachedValuePositionActivity,
+	CachedValuePositionMemoContext,
+	CachedValuePositionRoundTrip,
+	CachedValuePositionSuspense,
+	CachedValuePositionTransition,
+	drainValuePositionActivityEffects,
+	drainValuePositionLayoutEffects,
+	EscapedValuePositionRows,
+	SetupEscapedValuePositionRows,
+} from './_fixtures/auto-memo-value-position.tsrx';
+
+function fulfilledValue(value: string): PromiseLike<string> {
+	const promise = Promise.resolve(value) as Promise<string> & {
+		status: 'fulfilled';
+		value: string;
+	};
+	promise.status = 'fulfilled';
+	promise.value = value;
+	return promise;
+}
+
+describe('cached value-position children', () => {
+	it('keeps cached rows reactive to context, their own state, and immutable parent changes', () => {
+		const root = mount(CachedValuePositionRows);
+		const first = root.find('.memo-value-row');
+		const input = root.find('.memo-value-input-1') as HTMLInputElement;
+		input.value = 'preserved draft';
+
+		root.click('.memo-value-own-1');
+		expect(root.find('.memo-value-own-1').textContent).toBe('initial:first:1');
+
+		root.click('#memo-value-tick');
+		expect(root.find('.memo-value-row')).toBe(first);
+		expect(input.value).toBe('preserved draft');
+
+		root.click('#memo-value-theme');
+		expect(root.find('.memo-value-own-1').textContent).toBe('initial!:first:1');
+		expect(root.find('.memo-value-own-2').textContent).toBe('initial!:second:0');
+
+		root.click('#memo-value-change');
+		expect(root.find('.memo-value-row')).toBe(first);
+		expect(root.find('.memo-value-own-1').textContent).toBe('initial!:first!:1');
+		expect(input.value).toBe('preserved draft');
+
+		root.click('#memo-value-reorder');
+		expect(root.findAll('.memo-value-row').map((row) => row.getAttribute('data-id'))).toEqual([
+			'2',
+			'1',
+		]);
+		expect(root.findAll('.memo-value-row')[1]).toBe(first);
+		expect(root.find('.memo-value-own-1').textContent).toBe('initial!:first!:1');
+		root.unmount();
+	});
+
+	it('keeps outer context live after a memo ancestor re-renders past cached rows', () => {
+		const root = mount(CachedValuePositionMemoContext);
+		expect(root.find('.memo-value-own-1').textContent).toBe('initial:first:0');
+		expect(root.find('.memo-value-own-2').textContent).toBe('initial:second:0');
+
+		root.click('#memo-value-boundary-tick');
+		expect(root.find('#memo-value-boundary-rows').getAttribute('data-tick')).toBe('1');
+		expect(root.find('.memo-value-own-1').textContent).toBe('initial:first:0');
+
+		root.click('#memo-value-boundary-theme');
+		expect(root.find('.memo-value-own-1').textContent).toBe('initial!:first:0');
+		expect(root.find('.memo-value-own-2').textContent).toBe('initial!:second:0');
+		root.unmount();
+	});
+
+	it('rebuilds a previously cached array after its value position temporarily holds text', () => {
+		const root = mount(CachedValuePositionRoundTrip);
+		const original = root.find('.memo-value-own-1');
+		expect(original.textContent).toBe('initial:first:0');
+
+		root.click('#memo-value-round-trip-toggle');
+		expect(root.find('#memo-value-round-trip-rows').textContent).toBe('temporarily hidden');
+		expect(root.findAll('.memo-value-row')).toHaveLength(0);
+
+		root.click('#memo-value-round-trip-toggle');
+		const restored = root.find('.memo-value-own-1');
+		expect(restored).not.toBe(original);
+		expect(restored.textContent).toBe('initial:first:0');
+		expect(root.findAll('.memo-value-row')).toHaveLength(2);
+
+		root.click('#memo-value-round-trip-theme');
+		expect(restored.textContent).toBe('initial!:first:0');
+		root.click('.memo-value-own-1');
+		expect(restored.textContent).toBe('initial!:first:1');
+		root.unmount();
+	});
+
+	it('reconciles a derived array that escapes into an event handler and mutates in place', () => {
+		const root = mount(EscapedValuePositionRows);
+		const before = root.findAll('.memo-value-row');
+
+		root.click('#memo-value-mutate');
+		expect(root.findAll('.memo-value-row')).toEqual([before[1], before[0]]);
+
+		root.click('#memo-value-mutate');
+		expect(root.findAll('.memo-value-row')).toEqual(before);
+		root.unmount();
+	});
+
+	it('reconciles a derived array that escapes into a setup closure and mutates in place', () => {
+		const root = mount(SetupEscapedValuePositionRows);
+		const before = root.findAll('.memo-value-row');
+
+		root.click('#memo-value-setup-mutate');
+		expect(root.findAll('.memo-value-row')).toEqual([before[1], before[0]]);
+		root.unmount();
+	});
+
+	it('adopts cached rows during hydration and preserves drafts, events, and context updates', () => {
+		const server = loadServerFixture(
+			'packages/octane/tests/_fixtures/auto-memo-value-position.tsrx',
+			{
+				compileOptions: { hmr: false, dev: false },
+			},
+		);
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		container.innerHTML = ServerRuntime.renderToString(server.CachedValuePositionRows).html;
+		const originalRows = Array.from(container.querySelectorAll('.memo-value-row'));
+		const originalInput = container.querySelector('.memo-value-input-1') as HTMLInputElement;
+		originalInput.value = 'typed before hydration';
+
+		const root = hydrateRoot(container, CachedValuePositionRows);
+		flushSync(() => {});
+		expect(Array.from(container.querySelectorAll('.memo-value-row'))).toEqual(originalRows);
+		expect(container.querySelector('.memo-value-input-1')).toBe(originalInput);
+		expect(originalInput.value).toBe('typed before hydration');
+
+		flushSync(() => (container.querySelector('#memo-value-theme') as HTMLButtonElement).click());
+		expect(container.querySelector('.memo-value-own-1')?.textContent).toBe('initial!:first:0');
+		expect(container.querySelector('.memo-value-own-2')?.textContent).toBe('initial!:second:0');
+		expect(originalInput.value).toBe('typed before hydration');
+		root.unmount();
+		container.remove();
+	});
+
+	it('reconnects reordered memo-row effects in source order when an Activity becomes visible', () => {
+		drainValuePositionActivityEffects();
+		drainValuePositionLayoutEffects();
+		const root = mount(CachedValuePositionActivity, { mode: 'visible' as const });
+		flushEffects();
+		expect(drainValuePositionActivityEffects()).toEqual(['mount:1', 'mount:2']);
+		expect(drainValuePositionLayoutEffects()).toEqual(['mount:1', 'mount:2']);
+
+		root.click('#memo-value-activity-reorder');
+		flushEffects();
+		expect(root.findAll('.memo-value-activity-row').map((row) => row.textContent)).toEqual([
+			'second',
+			'first',
+		]);
+		expect(drainValuePositionActivityEffects()).toEqual([]);
+		expect(drainValuePositionLayoutEffects()).toEqual([]);
+
+		root.update(CachedValuePositionActivity, { mode: 'hidden' });
+		flushEffects();
+		expect(drainValuePositionActivityEffects()).toEqual(['cleanup:2', 'cleanup:1']);
+		expect(drainValuePositionLayoutEffects()).toEqual(['cleanup:2', 'cleanup:1']);
+
+		root.update(CachedValuePositionActivity, { mode: 'visible' });
+		flushEffects();
+		expect(drainValuePositionActivityEffects()).toEqual(['mount:2', 'mount:1']);
+		expect(drainValuePositionLayoutEffects()).toEqual(['mount:2', 'mount:1']);
+		root.unmount();
+		drainValuePositionActivityEffects();
+		drainValuePositionLayoutEffects();
+	});
+
+	it('reconnects cached memo-row layout effects after a Suspense fallback reveals', async () => {
+		drainValuePositionActivityEffects();
+		drainValuePositionLayoutEffects();
+		let resolve!: (value: string) => void;
+		const pending = new Promise<string>((complete) => {
+			resolve = complete;
+		});
+		const root = mount(CachedValuePositionSuspense, { promise: fulfilledValue('initial') });
+		flushEffects();
+		expect(drainValuePositionActivityEffects()).toEqual(['mount:1', 'mount:2']);
+		expect(drainValuePositionLayoutEffects()).toEqual(['mount:1', 'mount:2']);
+
+		root.update(CachedValuePositionSuspense, { promise: pending });
+		flushEffects();
+		expect(root.find('#memo-value-suspense-pending').textContent).toBe('loading');
+		expect(drainValuePositionLayoutEffects()).toEqual(['cleanup:1', 'cleanup:2']);
+		expect(drainValuePositionActivityEffects()).toEqual([]);
+
+		await act(() => resolve('resolved'));
+		flushEffects();
+		expect(root.findAll('#memo-value-suspense-pending')).toHaveLength(0);
+		expect(root.find('#memo-value-suspense-detail').textContent).toBe('resolved');
+		expect(drainValuePositionLayoutEffects()).toEqual(['mount:1', 'mount:2']);
+		expect(drainValuePositionActivityEffects()).toEqual([]);
+		root.unmount();
+		drainValuePositionActivityEffects();
+		drainValuePositionLayoutEffects();
+	});
+
+	it('rolls cached rows back during a held transition and reapplies them when it resolves', async () => {
+		const initialPromise = fulfilledValue('initial');
+		let resolve!: (value: string) => void;
+		const nextPromise = new Promise<string>((complete) => {
+			resolve = complete;
+		});
+		const root = mount(CachedValuePositionTransition, { initialPromise, nextPromise });
+		const initialRows = root.findAll('#memo-value-transition-rows .memo-value-row');
+		const labels = () =>
+			root.findAll('#memo-value-transition-rows button').map((row) => row.textContent);
+		expect(labels()).toEqual(['initial:first:0', 'initial:second:0']);
+
+		root.click('#memo-value-transition-bump');
+		expect(root.findAll('#memo-value-transition-rows .memo-value-row')).toEqual(initialRows);
+		expect(labels()).toEqual(['initial:first:0', 'initial:second:0']);
+		expect(root.findAll('#memo-value-transition-pending')).toHaveLength(0);
+
+		await act(() => resolve('resolved'));
+		expect(root.findAll('#memo-value-transition-rows .memo-value-row')).toEqual([
+			initialRows[1],
+			initialRows[0],
+		]);
+		expect(labels()).toEqual(['initial:pending second:0', 'initial:pending first:0']);
+		expect(root.find('#memo-value-suspense-detail').textContent).toBe('resolved');
+
+		root.click('#memo-value-transition-urgent');
+		expect(labels()).toEqual(['initial:urgent second:0', 'initial:urgent first:0']);
+		root.unmount();
+	});
+});

--- a/packages/octane/tests/auto-memo.test.ts
+++ b/packages/octane/tests/auto-memo.test.ts
@@ -1733,6 +1733,126 @@ describe('compiler-owned component-region memoization', () => {
 		root.unmount();
 	});
 
+	it.each([
+		{ shape: 'direct', shared: 'dynamic' },
+		{ shape: 'nested', shared: '[dynamic]' },
+		{
+			shape: 'fragment-wrapped',
+			shared: "[createElement(Fragment, { key: 'wrapper' }, dynamic)]",
+		},
+	])(
+		're-reads $shape derived renderable array getters on later parent renders',
+		({ shape, shared }) => {
+			const source = `
+			import { Fragment, createContext, createElement, useState } from 'octane';
+
+			let label = 'initial';
+			const dynamic = [];
+			Object.defineProperty(dynamic, '0', {
+				configurable: true,
+				enumerable: true,
+				get() {
+					return createElement(Row, { key: 'row', label });
+				},
+			});
+			const shared = ${shared};
+			const Context = createContext(null);
+
+			function Row(props) @{
+				<span id="derived-accessor-row">{props.label as string}</span>
+			}
+
+			function selectRows(items) {
+				return shared;
+			}
+
+			export function App() @{
+				const [items] = useState([0]);
+				const [tick, setTick] = useState(0);
+				const rows = selectRows(items);
+				<section>
+					<button
+						id="derived-accessor-update"
+						onClick={() => {
+							label = 'updated';
+							setTick(tick + 1);
+						}}
+					>{tick as number}</button>
+					<Context.Provider value={null}>
+						<div id="derived-accessor-rows">{rows}</div>
+					</Context.Provider>
+				</section>
+			}
+		`;
+			const client = loadCompiledFixtureSource(source, {
+				id: `derived-${shape}-array-accessor.tsrx`,
+				mode: 'client',
+				compileOptions: { hmr: false, dev: false },
+			});
+			const root = mount(client.App);
+			const row = root.find('#derived-accessor-row');
+			expect(row.textContent).toBe('initial');
+
+			root.click('#derived-accessor-update');
+			expect(root.find('#derived-accessor-row')).toBe(row);
+			expect(row.textContent).toBe('updated');
+			root.unmount();
+		},
+	);
+
+	it.each([
+		{
+			shape: 'deferred component props',
+			entry: '<Row key="row" label={use(Theme)} />',
+		},
+		{
+			shape: 'deferred host children',
+			entry: '<span key="row" id="derived-scoped-row">{use(Theme)}</span>',
+		},
+	])('keeps $shape inside derived renderable arrays reactive to context', ({ shape, entry }) => {
+		const source = `
+			import { createContext, use, useState } from 'octane';
+
+			const Theme = createContext('initial');
+
+			function Row(props) @{
+				<span id="derived-scoped-row">{props.label as string}</span>
+			}
+
+			const shared = [${entry}];
+			function selectRows(items) {
+				return shared;
+			}
+
+			export function App() @{
+				const [items] = useState([0]);
+				const [theme, setTheme] = useState('initial');
+				const rows = selectRows(items);
+				<section>
+					<button id="derived-scoped-update" onClick={() => setTheme('updated')}>
+						{'update context'}
+					</button>
+					<Theme.Provider value={theme}>
+						<div id="derived-scoped-rows">{rows}</div>
+					</Theme.Provider>
+				</section>
+			}
+		`;
+		const client = loadCompiledFixtureSource(source, {
+			id: `derived-${shape.replaceAll(' ', '-')}.tsrx`,
+			mode: 'client',
+			compileOptions: { hmr: false, dev: false },
+		});
+		const root = mount(client.App);
+		const row = root.find('#derived-scoped-row');
+		expect(row.textContent).toBe('initial');
+
+		root.click('#derived-scoped-update');
+		expect(root.find('#derived-scoped-row')).toBe(row);
+		expect(row.textContent).toBe('updated');
+		root.unmount();
+	});
+
 	it('reads inherited sparse-array getters once without skipping their callback index', () => {
 		const events: string[] = [];
 		const first = { id: 1, label: 'first' };

--- a/packages/octane/tests/parallel-use.test.ts
+++ b/packages/octane/tests/parallel-use.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { mount, act } from './_helpers';
+import { loadCompiledFixtureSource } from './_server-fixture';
 import {
 	ChainHost,
 	DependentChain,
@@ -14,6 +15,7 @@ import {
 	ImportedCapturedHookHost,
 	ImportedDependentHookHost,
 	AdjacentPanelsHost,
+	SyncWarmBranchesHost,
 	EarlyReturnPanelsHost,
 	VersionedSiblingsHost,
 	RepeatedPanelsHost,
@@ -503,6 +505,89 @@ describe('parallel use() — adjacent async component trees', () => {
 		expect(r.find('.insights-chart').textContent).toBe('insights-chart-v0');
 		expect([...resources.calls].sort()).toEqual(expected);
 		r.unmount();
+	});
+
+	it('warms an async descendant through multiple forward-declared synchronous wrappers', async () => {
+		const resources = resourceFetcher();
+		const root = mount(SyncWarmBranchesHost, { load: resources.load, version: 0 });
+		const expected = ['sync-warm-direct:0', 'sync-warm-leaf:0'];
+
+		expect([...resources.calls].sort()).toEqual(expected);
+		expect(root.find('.fallback').textContent).toBe('sync-warm-loading');
+
+		await act(() => {
+			resources.settle('sync-warm-direct', 0);
+			resources.settle('sync-warm-leaf', 0);
+		});
+
+		expect(root.find('.sync-warm-direct').textContent).toBe('sync-warm-direct-v0');
+		expect(root.find('.sync-warm-leaf').textContent).toBe('sync-warm-leaf-v0');
+		expect([...resources.calls].sort()).toEqual(expected);
+		root.unmount();
+	});
+
+	it('starts async work hidden behind a reassigned same-module component before its sibling resolves', async () => {
+		const source = `
+			import { use } from 'octane';
+
+			function MutableComponent(props) {
+				return <span>initially synchronous</span>;
+			}
+
+			function AsyncReplacement(props) @{
+				const value = use(props.load('mutable-reassigned', props.version));
+				<span class="mutable-warm-reassigned">{value as string}</span>
+			}
+
+			function AsyncSibling(props) @{
+				const value = use(props.load('mutable-sibling', props.version));
+				<span class="mutable-warm-sibling">{value as string}</span>
+			}
+
+			function Wrapper(props) @{
+				<MutableComponent load={props.load} version={props.version} />
+			}
+
+			MutableComponent = AsyncReplacement;
+
+			function Branches(props) @{
+				<main>
+					<AsyncSibling load={props.load} version={props.version} />
+					<Wrapper load={props.load} version={props.version} />
+				</main>
+			}
+
+			export function App(props) @{
+				<>
+					@try {
+						<Branches load={props.load} version={props.version} />
+					} @pending {
+						<span class="mutable-warm-pending">loading</span>
+					}
+				</>
+			}
+		`;
+		const client = loadCompiledFixtureSource(source, {
+			id: 'mutable-component-warming.tsrx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: false },
+		});
+		const resources = resourceFetcher();
+		const root = mount(client.App, { load: resources.load, version: 0 });
+		const expected = ['mutable-reassigned:0', 'mutable-sibling:0'];
+
+		expect([...resources.calls].sort()).toEqual(expected);
+		expect(root.find('.mutable-warm-pending').textContent).toBe('loading');
+
+		await act(() => {
+			resources.settle('mutable-reassigned', 0);
+			resources.settle('mutable-sibling', 0);
+		});
+
+		expect(root.find('.mutable-warm-reassigned').textContent).toBe('mutable-reassigned-v0');
+		expect(root.find('.mutable-warm-sibling').textContent).toBe('mutable-sibling-v0');
+		expect([...resources.calls].sort()).toEqual(expected);
+		root.unmount();
 	});
 
 	it('warms again when an update returns to previously consumed dependency values', async () => {


### PR DESCRIPTION
## Summary

- Cache compiler-proven immutable renderable regions so unchanged memo-wall rows avoid reconciliation without sacrificing context, hydration, transition, Activity, or Suspense behavior.
- Bring safe derived-calculation caching to hookful return-JSX components.
- Remove fetch-warming scaffolding from same-module component trees proven entirely synchronous while preserving real asynchronous prefetching.

## Why

Memo-wall previously traversed and compared all 1,000 unchanged descriptor rows on every parent update, while return-JSX rebuilt 1,001 descriptors. Signal-favoring registered 100 empty asynchronous warming plans during mount and 92 more during each shallow update even though its entire component graph is synchronous.

## Changes

- Add conservative compiler-owned renderable-region caching with lazy dense-array classification, explicit memo-ancestor context restamping, and cold-path effect reconnection.
- Reject indexed getters, nested arrays, Fragments, scoped JSX descriptors, escaping or mutable arrays, reassigned component bindings, opaque callbacks, and other unproven structures.
- Add observable regressions for context propagation, hydration, child-owned state, reordering, array/text transitions, Activity/Suspense effects, held transition rollback, deferred descriptors, and asynchronous warming.
- Tighten deterministic memo-wall and signal-favoring work gates, including a zero-restamp guard protecting existing JSX fast paths.
- Add the required patch changeset for `octane`.

## Performance

Matched production builds, 20 samples, identical Node.js and Chromium:

| Scenario | Before | After | Change |
| --- | ---: | ---: | ---: |
| Memo-wall TSRX unchanged update | 0.11055 ms | 0.000309 ms | **358× faster** |
| Memo-wall TSRX context update | 0.49115 ms | 0.37958 ms | **22.7% faster** |
| Memo-wall JSX unchanged update | 0.27750 ms | 0.20948 ms | **24.5% faster** |
| Signal-favoring TSRX sweep | 0.02950 ms | 0.02050 ms | **30.5% faster** |

The official nine-framework memo-wall run places Octane's unchanged TSRX operation **5.96× ahead of React Compiler**. Signal benchmark generated output shrinks from 70,712 to 52,064 bytes (**26.4%**) and from 4,168 to 3,362 bytes gzipped (**19.3%**); the complete signal bundle is 1,699 bytes smaller gzipped. The existing 16-fixture code-generation corpus is byte-for-byte unchanged.

## Validation

- [ ] `pnpm format:check` — repository-wide formatting was not run; explicit Prettier checks passed for every changed file.
- [ ] `pnpm typecheck` — repository-wide typechecking was not run; the complete Octane package and scoped compiler/runtime/new TSRX fixture checks passed.
- [ ] `pnpm test` — the root monorepo wrapper was not run; both complete Octane development and production projects passed.
- [x] `NODE_NO_WARNINGS=1 pnpm_config_verify_deps_before_run=warn pnpm sync`
- [x] `NODE_NO_WARNINGS=1 ./node_modules/.bin/vitest run --project octane --project octane-prod --maxWorkers=4 --testNamePattern '^(?!.*transforms installed raw Octane packages)' --silent=passed-only --reporter=dot` — **772 files, 10,901 tests passed**; two instances of an existing broken external-workspace-link case were skipped.
- [x] Post-rebase targeted development/production regressions, keyed reconciliation, SSR, public exports, frozen ASTs, source maps, and universal compiler capabilities — **433 tests passed**.
- [x] Final latest-upstream development/production smoke, including the newly merged bootstrap side-effect contract — **312 tests passed**.
- [x] `NODE_NO_WARNINGS=1 ./node_modules/.bin/tsgo --noEmit -p packages/octane/tsconfig.json`
- [x] `pnpm_config_verify_deps_before_run=warn pnpm typecheck:files packages/octane/src/compiler/compile.js packages/octane/src/index.ts packages/octane/src/runtime.ts packages/octane/tests/_fixtures/auto-memo-value-position.tsrx`
- [x] Explicit changed-file `prettier --check`, `git diff --check`, and `node scripts/check-changesets.js`.
- [x] `pnpm_config_verify_deps_before_run=warn node benchmarks/bench.mjs --ratios memo-wall signal-favoring` — **11/11 ratio guards passed** across 17 production framework targets.
- [x] `pnpm_config_verify_deps_before_run=warn node benchmarks/bench.mjs --quick --ratios async-waterfall` — **6/6 ratio guards passed**.
- [x] `pnpm_config_verify_deps_before_run=warn node benchmarks/bench.mjs --quick --ratios bundle-reachability` — **30/30 raw, gzip, and brotli budgets passed** across all ten public-import scenarios.

## Risk / follow-ups

- Changed-row memo-wall updates are approximately 6–7% slower; memo-wall bundles grow by 547 bytes gzipped for TSRX and 832 bytes for JSX.
- Array safety classification is deferred until an actual repeated-identity cache hit; legacy mapped caches never opt into the new context-restamping walk.
- Further signal improvements would require a separate proof for skipping lightweight component-slot traversal while preserving independently scheduled state updates and context propagation.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core compiler lowering and runtime reconciliation/context/effect paths; incorrect cache eligibility or restamping could cause stale UI or missed updates across memo, Suspense, and Activity flows.
> 
> **Overview**
> Adds **compiler-owned caching** for immutable renderable child regions (dense descriptor arrays that never escape setup) so unchanged memo-wall-style lists skip keyed reconciliation while **context consumers, hidden-tree effects, hydration, Activity, Suspense, and transitions** still update correctly via extended `compilerCacheContext` / `restampCachedContextScope` and cold-path effect reconnection.
> 
> The compiler proves non-escaping auto-calculated holes (`collectAutoCalculatedRenderableRefs`), gates cache emission with runtime **`compilerCacheArray`** safety checks (rejecting getters, nested arrays, Fragments, scoped descriptors, etc.), and enables **auto-calculation for return-JSX** only after an authored Octane hook establishes a render scope. Hook detection now treats **`UNSTABLE_`** like `unstable_`.
> 
> **Fetch-warming** is omitted for same-module trees **`classifySameModuleWarmPotential`** proves entirely synchronous; opaque or async-reachable graphs stay conservative.
> 
> Benchmark work gates and new fixtures/tests cover memo-wall TSRX/JSX expectations, signal-favoring `useBatch` counts, and regressions for context, reorder, array↔text round-trips, and parallel-use warming edges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cee1cff7640eec8e6583032b93df12f9c9b1e10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->