### PR TITLE
fix(benchmarks): remove js-framework DOM node metrics

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -132,15 +132,17 @@ after printing its normal tables:
   ssr-throughput is time-budgeted: its knob is a per-config seconds value and
   `--quick` passes the harness's own `--quick`.
 
-The DOM-heavy browser suites use `lib/dom-nodes.mjs` to publish a deterministic
-census alongside timings. `nodes_*`, `elements_*`, `text_*`, `comments_*`,
-`empty_text_*`, and `whitespace_text_*` are zero-variance operations suitable
-for ratio guards; detailed comment-payload and parent-element histograms live
-under `meta.dom`. Count the fixture root (`#main`, with `#app` fallback) unless
-the behavior intentionally escapes it: portal-swarm records both `#main` and
-the whole body so target-side portal ranges stay visible. Keep visible
-elements/text as independent guards—a lower total obtained by dropping
-user-visible content is a correctness failure, not an optimization.
+Some DOM-heavy browser suites, including TodoMVC, chat-stream, and portal-swarm,
+use `lib/dom-nodes.mjs` to publish a deterministic census alongside timings.
+TodoMVC and chat-stream expose `nodes_*`, `elements_*`, `text_*`, `comments_*`,
+`empty_text_*`, and `whitespace_text_*` as zero-variance operations suitable for
+ratio guards; detailed comment-payload and parent-element histograms live under
+`meta.dom`. Count the fixture root (`#main`, with `#app` fallback) unless the
+behavior intentionally escapes it: portal-swarm records both `#main` and the
+whole body so target-side portal ranges stay visible. Keep visible elements/text
+as independent guards—a lower total obtained by dropping user-visible content
+is a correctness failure, not an optimization. The js-framework suites report
+timings without a DOM census.
 
 Compiler-sensitive work counts use a separate production `work.mjs` invocation
 with jitless Chromium precise call coverage. This avoids source probes changing

--- a/benchmarks/baselines/local/js-framework-deopt.json
+++ b/benchmarks/baselines/local/js-framework-deopt.json
@@ -124,60 +124,6 @@
           "scoreRme": 12.79650315852296,
           "warmupRatio": 0.9463414636642573,
           "samples": 8
-        },
-        "nodes_1k": {
-          "median": 10074,
-          "min": 10074,
-          "samples": 1
-        },
-        "elements_1k": {
-          "median": 8051,
-          "min": 8051,
-          "samples": 1
-        },
-        "text_1k": {
-          "median": 2021,
-          "min": 2021,
-          "samples": 1
-        },
-        "comments_1k": {
-          "median": 2,
-          "min": 2,
-          "samples": 1
-        },
-        "empty_text_1k": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "whitespace_text_1k": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        }
-      },
-      "meta": {
-        "dom": {
-          "root": "#main",
-          "total": 10074,
-          "elements": 8051,
-          "text": 2021,
-          "comments": 2,
-          "emptyText": 0,
-          "whitespaceText": 0,
-          "hydrationMarkersPhysical": 0,
-          "hydrationMarkersLogical": 0,
-          "hydrationMarkersCounted": 0,
-          "hydrationMarkerMaxMultiplicity": 0,
-          "leadingHydrationStartsPhysical": 0,
-          "leadingHydrationStartsLogical": 0,
-          "commentsByData": {
-            "/for": 1,
-            "for": 1
-          },
-          "commentParents": {
-            "tbody": 2
-          }
         }
       }
     },
@@ -303,60 +249,6 @@
           "scoreRme": 12.290812321819715,
           "warmupRatio": 0.9384469738789416,
           "samples": 8
-        },
-        "nodes_1k": {
-          "median": 10074,
-          "min": 10074,
-          "samples": 1
-        },
-        "elements_1k": {
-          "median": 8051,
-          "min": 8051,
-          "samples": 1
-        },
-        "text_1k": {
-          "median": 2021,
-          "min": 2021,
-          "samples": 1
-        },
-        "comments_1k": {
-          "median": 2,
-          "min": 2,
-          "samples": 1
-        },
-        "empty_text_1k": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "whitespace_text_1k": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        }
-      },
-      "meta": {
-        "dom": {
-          "root": "#main",
-          "total": 10074,
-          "elements": 8051,
-          "text": 2021,
-          "comments": 2,
-          "emptyText": 0,
-          "whitespaceText": 0,
-          "hydrationMarkersPhysical": 0,
-          "hydrationMarkersLogical": 0,
-          "hydrationMarkersCounted": 0,
-          "hydrationMarkerMaxMultiplicity": 0,
-          "leadingHydrationStartsPhysical": 0,
-          "leadingHydrationStartsLogical": 0,
-          "commentsByData": {
-            "/for": 1,
-            "for": 1
-          },
-          "commentParents": {
-            "tbody": 2
-          }
         }
       }
     },
@@ -482,59 +374,6 @@
           "scoreRme": 16.28622658176491,
           "warmupRatio": 0.9380530973451326,
           "samples": 8
-        },
-        "nodes_1k": {
-          "median": 10074,
-          "min": 10074,
-          "samples": 1
-        },
-        "elements_1k": {
-          "median": 8051,
-          "min": 8051,
-          "samples": 1
-        },
-        "text_1k": {
-          "median": 2021,
-          "min": 2021,
-          "samples": 1
-        },
-        "comments_1k": {
-          "median": 2,
-          "min": 2,
-          "samples": 1
-        },
-        "empty_text_1k": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "whitespace_text_1k": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        }
-      },
-      "meta": {
-        "dom": {
-          "root": "#main",
-          "total": 10074,
-          "elements": 8051,
-          "text": 2021,
-          "comments": 2,
-          "emptyText": 0,
-          "whitespaceText": 0,
-          "hydrationMarkersPhysical": 0,
-          "hydrationMarkersLogical": 0,
-          "hydrationMarkersCounted": 0,
-          "hydrationMarkerMaxMultiplicity": 0,
-          "leadingHydrationStartsPhysical": 0,
-          "leadingHydrationStartsLogical": 0,
-          "commentsByData": {
-            "": 2
-          },
-          "commentParents": {
-            "tbody": 2
-          }
         }
       }
     },
@@ -660,55 +499,6 @@
           "scoreRme": 8.597402649335521,
           "warmupRatio": 0.9518005525588974,
           "samples": 8
-        },
-        "nodes_1k": {
-          "median": 10072,
-          "min": 10072,
-          "samples": 1
-        },
-        "elements_1k": {
-          "median": 8051,
-          "min": 8051,
-          "samples": 1
-        },
-        "text_1k": {
-          "median": 2021,
-          "min": 2021,
-          "samples": 1
-        },
-        "comments_1k": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "empty_text_1k": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "whitespace_text_1k": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        }
-      },
-      "meta": {
-        "dom": {
-          "root": "#main",
-          "total": 10072,
-          "elements": 8051,
-          "text": 2021,
-          "comments": 0,
-          "emptyText": 0,
-          "whitespaceText": 0,
-          "hydrationMarkersPhysical": 0,
-          "hydrationMarkersLogical": 0,
-          "hydrationMarkersCounted": 0,
-          "hydrationMarkerMaxMultiplicity": 0,
-          "leadingHydrationStartsPhysical": 0,
-          "leadingHydrationStartsLogical": 0,
-          "commentsByData": {},
-          "commentParents": {}
         }
       }
     }

--- a/benchmarks/baselines/local/js-framework.json
+++ b/benchmarks/baselines/local/js-framework.json
@@ -124,60 +124,6 @@
           "scoreRme": 13.422879511743474,
           "warmupRatio": 0.9500000007012311,
           "samples": 8
-        },
-        "nodes_1k": {
-          "median": 10074,
-          "min": 10074,
-          "samples": 1
-        },
-        "elements_1k": {
-          "median": 8051,
-          "min": 8051,
-          "samples": 1
-        },
-        "text_1k": {
-          "median": 2021,
-          "min": 2021,
-          "samples": 1
-        },
-        "comments_1k": {
-          "median": 2,
-          "min": 2,
-          "samples": 1
-        },
-        "empty_text_1k": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "whitespace_text_1k": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        }
-      },
-      "meta": {
-        "dom": {
-          "root": "#main",
-          "total": 10074,
-          "elements": 8051,
-          "text": 2021,
-          "comments": 2,
-          "emptyText": 0,
-          "whitespaceText": 0,
-          "hydrationMarkersPhysical": 0,
-          "hydrationMarkersLogical": 0,
-          "hydrationMarkersCounted": 0,
-          "hydrationMarkerMaxMultiplicity": 0,
-          "leadingHydrationStartsPhysical": 0,
-          "leadingHydrationStartsLogical": 0,
-          "commentsByData": {
-            "/for": 1,
-            "for": 1
-          },
-          "commentParents": {
-            "tbody": 2
-          }
         }
       }
     },
@@ -303,59 +249,6 @@
           "scoreRme": 14.231284670399146,
           "warmupRatio": 0.9416267951709802,
           "samples": 8
-        },
-        "nodes_1k": {
-          "median": 10074,
-          "min": 10074,
-          "samples": 1
-        },
-        "elements_1k": {
-          "median": 8051,
-          "min": 8051,
-          "samples": 1
-        },
-        "text_1k": {
-          "median": 2021,
-          "min": 2021,
-          "samples": 1
-        },
-        "comments_1k": {
-          "median": 2,
-          "min": 2,
-          "samples": 1
-        },
-        "empty_text_1k": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "whitespace_text_1k": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        }
-      },
-      "meta": {
-        "dom": {
-          "root": "#main",
-          "total": 10074,
-          "elements": 8051,
-          "text": 2021,
-          "comments": 2,
-          "emptyText": 0,
-          "whitespaceText": 0,
-          "hydrationMarkersPhysical": 0,
-          "hydrationMarkersLogical": 0,
-          "hydrationMarkersCounted": 0,
-          "hydrationMarkerMaxMultiplicity": 0,
-          "leadingHydrationStartsPhysical": 0,
-          "leadingHydrationStartsLogical": 0,
-          "commentsByData": {
-            "": 2
-          },
-          "commentParents": {
-            "tbody": 2
-          }
         }
       }
     },
@@ -481,55 +374,6 @@
           "scoreRme": 13.421890603695994,
           "warmupRatio": 0.947721821965009,
           "samples": 8
-        },
-        "nodes_1k": {
-          "median": 10072,
-          "min": 10072,
-          "samples": 1
-        },
-        "elements_1k": {
-          "median": 8051,
-          "min": 8051,
-          "samples": 1
-        },
-        "text_1k": {
-          "median": 2021,
-          "min": 2021,
-          "samples": 1
-        },
-        "comments_1k": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "empty_text_1k": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "whitespace_text_1k": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        }
-      },
-      "meta": {
-        "dom": {
-          "root": "#main",
-          "total": 10072,
-          "elements": 8051,
-          "text": 2021,
-          "comments": 0,
-          "emptyText": 0,
-          "whitespaceText": 0,
-          "hydrationMarkersPhysical": 0,
-          "hydrationMarkersLogical": 0,
-          "hydrationMarkersCounted": 0,
-          "hydrationMarkerMaxMultiplicity": 0,
-          "leadingHydrationStartsPhysical": 0,
-          "leadingHydrationStartsLogical": 0,
-          "commentsByData": {},
-          "commentParents": {}
         }
       }
     },
@@ -655,55 +499,6 @@
           "scoreRme": 10.424053011280387,
           "warmupRatio": 0.9473684170899961,
           "samples": 8
-        },
-        "nodes_1k": {
-          "median": 10074,
-          "min": 10074,
-          "samples": 1
-        },
-        "elements_1k": {
-          "median": 8051,
-          "min": 8051,
-          "samples": 1
-        },
-        "text_1k": {
-          "median": 2023,
-          "min": 2023,
-          "samples": 1
-        },
-        "comments_1k": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "empty_text_1k": {
-          "median": 2,
-          "min": 2,
-          "samples": 1
-        },
-        "whitespace_text_1k": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        }
-      },
-      "meta": {
-        "dom": {
-          "root": "#main",
-          "total": 10074,
-          "elements": 8051,
-          "text": 2023,
-          "comments": 0,
-          "emptyText": 2,
-          "whitespaceText": 0,
-          "hydrationMarkersPhysical": 0,
-          "hydrationMarkersLogical": 0,
-          "hydrationMarkersCounted": 0,
-          "hydrationMarkerMaxMultiplicity": 0,
-          "leadingHydrationStartsPhysical": 0,
-          "leadingHydrationStartsLogical": 0,
-          "commentsByData": {},
-          "commentParents": {}
         }
       }
     },
@@ -829,55 +624,6 @@
           "scoreRme": 13.04062696298196,
           "warmupRatio": 0.9450549493256155,
           "samples": 8
-        },
-        "nodes_1k": {
-          "median": 10072,
-          "min": 10072,
-          "samples": 1
-        },
-        "elements_1k": {
-          "median": 8051,
-          "min": 8051,
-          "samples": 1
-        },
-        "text_1k": {
-          "median": 2021,
-          "min": 2021,
-          "samples": 1
-        },
-        "comments_1k": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "empty_text_1k": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "whitespace_text_1k": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        }
-      },
-      "meta": {
-        "dom": {
-          "root": "#main",
-          "total": 10072,
-          "elements": 8051,
-          "text": 2021,
-          "comments": 0,
-          "emptyText": 0,
-          "whitespaceText": 0,
-          "hydrationMarkersPhysical": 0,
-          "hydrationMarkersLogical": 0,
-          "hydrationMarkersCounted": 0,
-          "hydrationMarkerMaxMultiplicity": 0,
-          "leadingHydrationStartsPhysical": 0,
-          "leadingHydrationStartsLogical": 0,
-          "commentsByData": {},
-          "commentParents": {}
         }
       }
     },
@@ -1003,55 +749,6 @@
           "scoreRme": 13.897331738812271,
           "warmupRatio": 0.9382352969225716,
           "samples": 8
-        },
-        "nodes_1k": {
-          "median": 10072,
-          "min": 10072,
-          "samples": 1
-        },
-        "elements_1k": {
-          "median": 8050,
-          "min": 8050,
-          "samples": 1
-        },
-        "text_1k": {
-          "median": 2022,
-          "min": 2022,
-          "samples": 1
-        },
-        "comments_1k": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "empty_text_1k": {
-          "median": 1,
-          "min": 1,
-          "samples": 1
-        },
-        "whitespace_text_1k": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        }
-      },
-      "meta": {
-        "dom": {
-          "root": "#app",
-          "total": 10072,
-          "elements": 8050,
-          "text": 2022,
-          "comments": 0,
-          "emptyText": 1,
-          "whitespaceText": 0,
-          "hydrationMarkersPhysical": 0,
-          "hydrationMarkersLogical": 0,
-          "hydrationMarkersCounted": 0,
-          "hydrationMarkerMaxMultiplicity": 0,
-          "leadingHydrationStartsPhysical": 0,
-          "leadingHydrationStartsLogical": 0,
-          "commentsByData": {},
-          "commentParents": {}
         }
       }
     },
@@ -1177,55 +874,6 @@
           "scoreRme": 11.632074408493924,
           "warmupRatio": 0.948619139464998,
           "samples": 8
-        },
-        "nodes_1k": {
-          "median": 10072,
-          "min": 10072,
-          "samples": 1
-        },
-        "elements_1k": {
-          "median": 8051,
-          "min": 8051,
-          "samples": 1
-        },
-        "text_1k": {
-          "median": 2021,
-          "min": 2021,
-          "samples": 1
-        },
-        "comments_1k": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "empty_text_1k": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        },
-        "whitespace_text_1k": {
-          "median": 0,
-          "min": 0,
-          "samples": 1
-        }
-      },
-      "meta": {
-        "dom": {
-          "root": "#main",
-          "total": 10072,
-          "elements": 8051,
-          "text": 2021,
-          "comments": 0,
-          "emptyText": 0,
-          "whitespaceText": 0,
-          "hydrationMarkersPhysical": 0,
-          "hydrationMarkersLogical": 0,
-          "hydrationMarkersCounted": 0,
-          "hydrationMarkerMaxMultiplicity": 0,
-          "leadingHydrationStartsPhysical": 0,
-          "leadingHydrationStartsLogical": 0,
-          "commentsByData": {},
-          "commentParents": {}
         }
       }
     },
@@ -1351,59 +999,6 @@
           "scoreRme": 10.852854544619953,
           "warmupRatio": 0.963317385158419,
           "samples": 8
-        },
-        "nodes_1k": {
-          "median": 10116,
-          "min": 10116,
-          "samples": 1
-        },
-        "elements_1k": {
-          "median": 8051,
-          "min": 8051,
-          "samples": 1
-        },
-        "text_1k": {
-          "median": 2045,
-          "min": 2045,
-          "samples": 1
-        },
-        "comments_1k": {
-          "median": 20,
-          "min": 20,
-          "samples": 1
-        },
-        "empty_text_1k": {
-          "median": 2,
-          "min": 2,
-          "samples": 1
-        },
-        "whitespace_text_1k": {
-          "median": 22,
-          "min": 22,
-          "samples": 1
-        }
-      },
-      "meta": {
-        "dom": {
-          "root": "#main",
-          "total": 10116,
-          "elements": 8051,
-          "text": 2045,
-          "comments": 20,
-          "emptyText": 2,
-          "whitespaceText": 22,
-          "hydrationMarkersPhysical": 0,
-          "hydrationMarkersLogical": 0,
-          "hydrationMarkersCounted": 0,
-          "hydrationMarkerMaxMultiplicity": 0,
-          "leadingHydrationStartsPhysical": 0,
-          "leadingHydrationStartsLogical": 0,
-          "commentsByData": {
-            "": 20
-          },
-          "commentParents": {
-            "div.row": 20
-          }
         }
       }
     }

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -812,50 +812,6 @@
     "note": "Cross-framework transition topology guard: Octane reaches the honest 2-wave dependency floor vs React's 3 waves in the 2026-07-17 record. The 1.5x ratio headroom allows reference improvements; the suite separately enforces Octane's exact seven-resource independent first wave and eight-call ceiling."
   },
   {
-    "suite": "js-framework",
-    "op": "nodes_1k",
-    "target": "octane-tsrx",
-    "reference": "react",
-    "maxRatio": 1.01,
-    "note": "Deterministic DOM census at 1k rows. Marker reuse leaves Octane at 10074 vs React 10072 nodes (2026-07-13); catches structural-node regressions without timing noise."
-  },
-  {
-    "suite": "js-framework",
-    "op": "elements_1k",
-    "target": "octane-tsrx",
-    "reference": "react",
-    "minRatio": 1.0,
-    "maxRatio": 1.0,
-    "note": "Semantic control for the node census: equivalent fixtures must render exactly the same 8051 elements."
-  },
-  {
-    "suite": "js-framework",
-    "op": "text_1k",
-    "target": "octane-tsrx",
-    "reference": "react",
-    "minRatio": 1.0,
-    "maxRatio": 1.0,
-    "note": "Semantic control for the node census: equivalent fixtures must render exactly the same 2021 text nodes."
-  },
-  {
-    "suite": "js-framework-deopt",
-    "op": "nodes_1k",
-    "target": "octane-tsrx-naive",
-    "reference": "octane-tsrx",
-    "minRatio": 1.0,
-    "maxRatio": 1.0,
-    "note": "A stamped sole-component row must share its host boundary: TSRX naive and tuned now both render 10074 nodes instead of the naive fixture carrying 2000 extra comments."
-  },
-  {
-    "suite": "js-framework-deopt",
-    "op": "nodes_1k",
-    "target": "octane-jsx-naive",
-    "reference": "octane-tsrx",
-    "minRatio": 1.0,
-    "maxRatio": 1.0,
-    "note": "Return-JSX single-root stamping plus keyed boundary sharing removes the JSX naive fixture's 4000 extra comments; its DOM shape must stay equal to tuned."
-  },
-  {
     "suite": "todomvc",
     "op": "row_class_writes_complete25",
     "target": "octane-tsrx",

--- a/benchmarks/js-framework/run.mjs
+++ b/benchmarks/js-framework/run.mjs
@@ -28,7 +28,7 @@
 
 import fs from 'node:fs';
 import { chromium } from 'playwright';
-import { censusDomNodes, deterministicCount } from '../lib/dom-nodes.mjs';
+import { deterministicCount } from '../lib/dom-nodes.mjs';
 import { scoreOf, summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
 
 const ITER = parseInt(process.argv[2] || '8', 10);
@@ -403,19 +403,6 @@ async function runTarget(t) {
 		results.production_calls_1k = deterministicCount(calls);
 	}
 
-	// Full steady-state DOM shape. Tracking element/text counts beside comments
-	// prevents a bookkeeping optimization from gaming the metric by replacing a
-	// comment with an invisible text node or dropping user-visible output.
-	await ensureState(page, 'rows');
-	const dom = await page.evaluate(censusDomNodes, '#main');
-	results.nodes_1k = deterministicCount(dom.total);
-	results.elements_1k = deterministicCount(dom.elements);
-	results.text_1k = deterministicCount(dom.text);
-	results.comments_1k = deterministicCount(dom.comments);
-	results.empty_text_1k = deterministicCount(dom.emptyText);
-	results.whitespace_text_1k = deterministicCount(dom.whitespaceText);
-	results.__dom = dom;
-
 	await browser.close();
 	return results;
 }
@@ -438,18 +425,6 @@ async function runTarget(t) {
 			const r = all[c][op.name];
 			row.push(`${r.median.toFixed(2)} (min ${r.min.toFixed(2)})`.padEnd(W));
 		}
-		console.log(row.join('| '));
-	}
-	for (const [label, op] of [
-		['#nodes', 'nodes_1k'],
-		['#elems', 'elements_1k'],
-		['#text', 'text_1k'],
-		['#cmnts', 'comments_1k'],
-		['#empty', 'empty_text_1k'],
-		['#ws', 'whitespace_text_1k'],
-	]) {
-		const row = [label.padEnd(8)];
-		for (const c of cols) row.push(String(all[c][op].median).padEnd(W));
 		console.log(row.join('| '));
 	}
 	for (const [label, op] of [
@@ -497,16 +472,13 @@ async function runTarget(t) {
 			targets: TARGETS.map((t) => ({
 				name: t.name,
 				ops: Object.fromEntries(
-					Object.entries(all[t.name])
-						.filter(([name]) => name !== '__dom')
-						.map(([name, r]) => [
-							name,
-							r.score == null
-								? { median: r.median, min: r.min, samples: r.samples.length }
-								: timingStatForJson(r),
-						]),
+					Object.entries(all[t.name]).map(([name, r]) => [
+						name,
+						r.score == null
+							? { median: r.median, min: r.min, samples: r.samples.length }
+							: timingStatForJson(r),
+					]),
 				),
-				meta: { dom: all[t.name].__dom },
 			})),
 		};
 		fs.writeFileSync(process.env.BENCH_JSON, JSON.stringify(payload, null, '\t') + '\n');

--- a/docs/comment-marker-elision-plan.md
+++ b/docs/comment-marker-elision-plan.md
@@ -86,27 +86,28 @@ descriptors — the cross-module signaling channel exists.
 
 ### M0 — Measurement first (same doctrine as the size plan)
 
-- **`comments_1k` op in the js-framework harness**: after the `run` op (1,000
-  rows), count comment nodes in-page. Deterministic per framework → works
-  with `--compare` AND cross-framework ratio guards (solid/ripple also use
-  marker comments — honest comparison). Record baselines.
-- **Deterministic DOM-weight benchmarks**: measure comment-node weight in the
-  js-framework harness and ratio system. Keep performance thresholds out of
-  correctness suites so implementation-preserving marker changes do not
-  require browser-test churn.
+The historical js-framework DOM census was later retired; structural coverage
+continues in TodoMVC, chat-stream, and portal-swarm.
+
+- **Historical `comments_1k` op in the js-framework harness**: after the `run`
+  op (1,000 rows), counted comment nodes in-page and recorded baselines.
+- **Historical js-framework DOM-weight benchmarks**: measured comment-node
+  weight in its harness and ratio system. Keep performance thresholds out of
+  correctness suites so implementation-preserving marker changes do not require
+  browser-test churn.
 - **Behavioral hydration coverage**: render representative wrapper, keyed,
   Suspense, and de-opt fixtures through SSR and hydration; assert DOM adoption,
   state, identity, events, and mismatch diagnostics rather than marker spelling.
 
 **M0 LANDED 2026-07-09.** Three layers, all green in both compile modes:
 
-- `comments_1k` op in the js-framework harness (payload now carries every
-  collected op). Recorded: **octane-tsrx 3 · octane-jsx 3 · react 0 ·
-  ripple 0 · solid 0** — the 1,000-row grid is already almost marker-free
-  (forBlock singleRoot at work), so this op is a singleRoot-regression
-  TRIPWIRE (+1 comment fails the absolute compare), not a ratio (references
-  are 0 — no ratio guard possible). Wrapper/de-opt weight is tracked by the
-  broader DOM-weight benchmarks and validated behaviorally during hydration.
+- Historical `comments_1k` op in the js-framework harness. Recorded:
+  **octane-tsrx 3 · octane-jsx 3 · react 0 · ripple 0 · solid 0** — the
+  1,000-row grid was already almost marker-free (forBlock singleRoot at work),
+  so this op was a singleRoot-regression TRIPWIRE (+1 comment failed the
+  absolute compare), not a ratio (references were 0 — no ratio guard was
+  possible). Wrapper/de-opt weight remains tracked by the broader DOM-weight
+  benchmarks and validated behaviorally during hydration.
 - Historical per-route measurements at landing: `/` 2,123 · `/docs` 379 ·
   `/benchmarks` **17,381** (the 12 recharts cards; the M2 number) ·
   `/playground` 185. Current DOM-weight regression coverage lives in the
@@ -337,9 +338,10 @@ equivalent to a range marker.
 The same js-framework fixture authored through the generic return-JSX paths
 lost its cliff: the naive TSRX variant went from 2,003 comments to **2**, and
 the naive JSX variant from 4,003 to **2**, matching the tuned fixture's DOM
-shape. Solid and Svelte are still reported separately by the harness because
-their compiled output deliberately uses extra text/comment nodes in several
-fixtures; element and meaningful-text equality is the semantic comparison.
+shape. Solid and Svelte were reported separately in this historical census
+because their compiled output deliberately uses extra text/comment nodes in
+several fixtures; element and meaningful-text equality was the semantic
+comparison.
 
 The attribution and changes are deliberately narrow:
 
@@ -369,14 +371,15 @@ The attribution and changes are deliberately narrow:
   `<Activity>` ranges, multi-root keyed items, order-bearing value-hole
   anchors, and adjacent-text SSR separators also remain load-bearing.
 
-`benchmarks/lib/dom-nodes.mjs` is the regression surface: js-framework,
-TodoMVC, chat-stream, and portal-swarm now emit deterministic `nodes_*`,
+`benchmarks/lib/dom-nodes.mjs` remains the regression surface for TodoMVC,
+chat-stream, and portal-swarm. TodoMVC and chat-stream emit deterministic `nodes_*`,
 `elements_*`, `text_*`, `comments_*`, `empty_text_*`, and
 `whitespace_text_*` operations plus comment-payload/parent histograms in
-`meta.dom`. Ratio guards cap total nodes while requiring Octane's visible
-element/text counts to equal React's. Portal-swarm records both the fixture
-root and whole-body census so target-side portal ranges cannot disappear from
-the accounting.
+`meta.dom`; the js-framework census and its DOM-weight ratio guards were
+retired. Remaining ratio guards cap total nodes while requiring Octane's
+visible element/text counts to equal React's. Portal-swarm records both the
+fixture root and whole-body census so target-side portal ranges cannot
+disappear from the accounting.
 
 The implementation plan was ordered by invariant risk: instrument first;
 reuse already-owned anchors/ranges; extend the existing single-root proof;
@@ -518,7 +521,8 @@ coextensive wrapper stack.
 - Perf: same-session A/B on js-framework/dbmon/effectful-list. Expected
   neutral-to-positive (fewer DOM nodes, shorter walks); the singleRoot item
   precedent showed no cost. Memory is where wins may show (dbmon).
-- Ratchet: `comments_1k` and the deterministic DOM-weight ratio guards tighten per phase.
+- Ratchet: deterministic DOM-weight ratio guards tighten per phase in the
+  remaining structural benchmark suites.
 
 ## 6. Open questions
 

--- a/website/src/content/home-benchmark.ts
+++ b/website/src/content/home-benchmark.ts
@@ -25,12 +25,12 @@ export const HOME_SUMMARY: BenchCard = {
 		{
 			op: 'js-framework',
 			'octane-tsrx': 1,
-			react: 3.1628437699777208,
-			preact: 2.8830352950529026,
-			solid: 1.5736534016482975,
-			svelte: 2.3445336979556464,
-			ripple: 1.6949511804042041,
-			'vue-vapor': 1.0755299105793,
+			react: 4.467964206999877,
+			preact: 3.9610796002257804,
+			solid: 1.8029780240427107,
+			svelte: 2.6144821652325283,
+			ripple: 1.985461156493767,
+			'vue-vapor': 1.099263414898243,
 		},
 		{
 			op: 'todomvc',

--- a/website/tests/bench-bars.test.ts
+++ b/website/tests/bench-bars.test.ts
@@ -44,6 +44,29 @@ describe('benchmark card bars', () => {
 	// js-framework: every framework measured on every operation.
 	const card = FRAMEWORK_CARDS[0];
 
+	it('keeps DOM-node census operations out of js-framework benchmark charts', async () => {
+		const nodeOperations = [
+			'nodes_1k',
+			'elements_1k',
+			'text_1k',
+			'comments_1k',
+			'empty_text_1k',
+			'whitespace_text_1k',
+		];
+		const deoptCard = OCTANE_CARDS.find((candidate) => candidate.id === 'js-framework-deopt')!;
+
+		for (const benchmark of [card, deoptCard]) {
+			const { container, unmount } = await mountCard(benchmark);
+			const operations = Array.from(container.querySelectorAll('.bench-op'), (button) =>
+				button.textContent!.trim(),
+			);
+
+			expect(operations).toContain('run');
+			for (const operation of nodeOperations) expect(operations).not.toContain(operation);
+			unmount();
+		}
+	});
+
 	it('opens on the overall summary: one ranked geomean bar per framework', async () => {
 		const { container, barLabels, barValues, opButton } = await mountCard(card);
 


### PR DESCRIPTION
## Summary

- Remove the six DOM-node census operations and their metadata from the shared js-framework benchmark harness.
- Clean both checked-in js-framework benchmark baselines and remove their five obsolete ratio guards.
- Refresh the homepage benchmark summary, keep node-count noise out of both website charts, and document the structural coverage retained by other suites.

## Why

DOM-node counts are not timing benchmarks, but they appeared as benchmark operations and distorted the website's overall performance comparisons.

## Changes

- Keep the ten real js-framework timing operations and existing mount/call instrumentation.
- Remove node, element, text, comment, empty-text, and whitespace-text metrics from both standard and deoptimized results.
- Add a rendered-chart regression test for both affected benchmark cards.

## Validation

- [ ] `pnpm format:check` — repository-wide formatting was not run; all eight changed files passed the scoped formatting check.
- [ ] `pnpm typecheck` — repository-wide typechecking was not run; both changed TypeScript files passed scoped typechecking.
- [ ] `pnpm test` — the full monorepo suite was not run; 33 relevant website tests passed.
- [x] `pnpm sync`
- [x] `pnpm format:files:check benchmarks/README.md benchmarks/baselines/local/js-framework-deopt.json benchmarks/baselines/local/js-framework.json benchmarks/baselines/ratios.json benchmarks/js-framework/run.mjs docs/comment-marker-elision-plan.md website/src/content/home-benchmark.ts website/tests/bench-bars.test.ts`
- [x] `pnpm typecheck:files website/src/content/home-benchmark.ts website/tests/bench-bars.test.ts`
- [x] `pnpm vitest run --project website-unit website/tests/bench-bars.test.ts website/tests/benchmark-explorer.test.ts website/tests/smoke.test.ts` — 33 tests passed.
- [x] `node benchmarks/bench.mjs --quick --ratios js-framework js-framework-deopt` — both browser suites passed; all six applicable ratio guards passed.

## Risk / follow-ups

- Structural DOM-census coverage remains available in TodoMVC, chat-stream, and portal-swarm; only the js-framework and js-framework-deopt census is retired.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark harness, baselines, docs, and website display only; DOM structural regression gates remain on other suites.
> 
> **Overview**
> **js-framework** and **js-framework-deopt** no longer run a post-`run` DOM census or emit `nodes_*` / `elements_*` / `text_*` / `comments_*` / empty-text / whitespace ops and `meta.dom` in **BENCH_JSON**; the harness keeps timing ops plus mount/call instrumentation.
> 
> Checked-in **js-framework** baselines and five **ratios.json** DOM-weight guards for those suites are removed. **benchmarks/README** and **comment-marker-elision-plan** now say structural DOM coverage lives in TodoMVC, chat-stream, and portal-swarm only.
> 
> The homepage **js-framework** summary ratios are refreshed (geomean over timing ops only), and **bench-bars** tests assert the six census operation names never appear on js-framework or deopt cards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc6be3ed17e4a409e573989ec50d669ff85dfc7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->