### PR TITLE
perf(compiler): admit destructured props params into autoMemo regions

### DIFF
--- a/.changeset/auto-memo-destructured-props.md
+++ b/.changeset/auto-memo-destructured-props.md
@@ -1,0 +1,14 @@
+---
+'octane': patch
+---
+
+Compiler-inferred component memoization now admits destructured props
+parameters. `function Child({ rows })` is the same one-props snapshot as
+`function Child(props)`, so production call sites of such components gain the
+whole-region dependency cache and skip the child entirely when their props are
+reference-stable — patterns that evaluate expressions of their own (defaults,
+computed keys), bind `current`, or use array destructuring still fall back.
+Call-site eligibility is also no longer vetoed body-wide by an unrelated
+`ref.current` or live-import member read elsewhere in the parent: the reads
+that actually flow into a site (directly or laundered through a local) still
+reject that site, everything else keeps its region.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -4144,11 +4144,12 @@ function containsDeferredRefRead(root) {
 	return found;
 }
 
-// Both probes visit the identical node set, so one pass answers both. The ref
-// probe loses its early exit; it finds nothing in 97% of components anyway.
+// Imported component tags rendered anywhere in the body — the auto-memo
+// region's runtime witnesses. (Deferred-ref reads are no longer collected
+// body-wide here: they gate per call site and per local through
+// collectAutoMemoLocalHazards.)
 function scanComponentBody(root, importedNames) {
 	const importedComponents = new Set();
-	let readsDeferredRef = false;
 	const seen = new WeakSet();
 	function walk(node) {
 		if (!node || typeof node !== 'object') return;
@@ -4158,7 +4159,6 @@ function scanComponentBody(root, importedNames) {
 		}
 		if (seen.has(node)) return;
 		seen.add(node);
-		if (!readsDeferredRef && isDeferredRefRead(node)) readsDeferredRef = true;
 		const imported = importedComponentTag(node, importedNames);
 		if (imported !== null) importedComponents.add(imported);
 		for (const key in node) {
@@ -4167,7 +4167,7 @@ function scanComponentBody(root, importedNames) {
 		}
 	}
 	walk(root);
-	return { importedComponents, readsDeferredRef };
+	return { importedComponents };
 }
 
 // A JSX member chain bottoms out at a JSXIdentifier, so the base test below
@@ -4201,6 +4201,107 @@ function containsImportedMemberRead(root, importedNames) {
 	}
 	walk(root);
 	return found;
+}
+
+/**
+ * Component locals whose values a region's dependency tuple cannot witness.
+ *
+ * A region dep on a LOCAL compares the local's per-render value. Locals
+ * re-initialize on every body entry, so a plain value local — however it is
+ * conditionally reassigned during render — is always an exact witness of
+ * itself. What it CANNOT witness is a value drawn from mutable state whose
+ * container identity hides the drift:
+ *
+ *   - a ref read (`.current` / any computed member — `isDeferredRefRead`'s
+ *     definition): ref contents mutate outside render without scheduling one,
+ *     and a stable-identity closure (`useCallback(() => ref.current, [])`)
+ *     hands a skipped subtree a LIVE read whose changes nothing witnesses —
+ *     so the classification descends into nested function values;
+ *   - an imported binding's member read: a live import's property can move
+ *     while the import's identity (the only thing a dep can hold) stays
+ *     fixed.
+ *
+ * A name is tainted when such a read reaches its value through the
+ * declaration initializer, any assignment's right-hand side, or a for-of /
+ * for-in feed — directly or through another tainted local (fixed point, so
+ * declaration order and arrow-hoisted back-references cannot hide a hazard).
+ * Props params and same-module function declarations never taint: the former
+ * are the witnessed snapshot itself, the latter are immutable identities
+ * whose render-time CALLS the per-site render-call gate already rejects.
+ *
+ * The direct forms of these reads inside a call site's own props are rejected
+ * per site (containsAutoMemoUnsafeStructure / containsImportedMemberRead);
+ * this set covers the same reads laundered through a local.
+ */
+function collectAutoMemoLocalHazards(stmts, importedNames) {
+	const hazards = new Set();
+	// name -> union of free identifiers across its clean value sources; a name
+	// with a directly hazardous source moves to `hazards` and leaves this map.
+	const sourceFrees = new Map();
+	const feed = (pattern, rhs) => {
+		if (!rhs) return;
+		const names = new Set();
+		collectBindings(pattern, names);
+		if (names.size === 0) return;
+		const direct = containsDeferredRefRead(rhs) || containsImportedMemberRead(rhs, importedNames);
+		for (const name of names) {
+			if (hazards.has(name)) continue;
+			if (direct) {
+				hazards.add(name);
+				sourceFrees.delete(name);
+				continue;
+			}
+			let set = sourceFrees.get(name);
+			if (set === undefined) sourceFrees.set(name, (set = new Set()));
+			for (const id of collectFreeIdentifiers(rhs, [])) set.add(id);
+		}
+	};
+	for (const stmt of stmts) {
+		if (stmt.type !== 'VariableDeclaration') continue;
+		for (const d of stmt.declarations || []) feed(d.id, d.init);
+	}
+	// Assignment/loop feeds anywhere in the body, including nested functions:
+	// a deferred write targets a PREVIOUS render's binding and can never leak
+	// into the next render's dep snapshot, but walking uniformly is cheaper
+	// than proving which writes are deferred, and only hazardous right-hand
+	// sides taint anyway.
+	const seen = new WeakSet();
+	(function walk(n) {
+		if (!n) return;
+		if (Array.isArray(n)) {
+			for (const x of n) walk(x);
+			return;
+		}
+		if (typeof n !== 'object' || !n.type || seen.has(n)) return;
+		seen.add(n);
+		if (n.type === 'AssignmentExpression' && n.left?.type !== 'MemberExpression') {
+			feed(n.left, n.right);
+		} else if (
+			(n.type === 'ForOfStatement' || n.type === 'ForInStatement') &&
+			n.left &&
+			n.left.type !== 'VariableDeclaration'
+		) {
+			feed(n.left, n.right);
+		}
+		for (const key in n) {
+			if (AST_WALK_SKIP_KEYS.has(key)) continue;
+			walk(n[key]);
+		}
+	})(stmts);
+	let changed = true;
+	while (changed) {
+		changed = false;
+		for (const [name, free] of sourceFrees) {
+			for (const id of free) {
+				if (!hazards.has(id)) continue;
+				hazards.add(name);
+				sourceFrees.delete(name);
+				changed = true;
+				break;
+			}
+		}
+	}
+	return hazards;
 }
 
 function containsAutoMemoUnsafeStructure(stmts) {
@@ -4319,6 +4420,54 @@ function containsAutoMemoUnsafeStructure(stmts) {
 	}
 	for (const s of stmts) walk(s);
 	return found;
+}
+
+/**
+ * Can this props parameter stand in for autoMemo's "one ordinary props
+ * snapshot"? A bare Identifier always can. A destructuring ObjectPattern can
+ * when destructuring it evaluates NO expressions and reads NOTHING mutable:
+ * every binding it introduces is already a component local
+ * (collectComponentLocals walks patterns), so the body's free-identifier and
+ * capture analysis is complete for it — the pattern itself is the only part
+ * those walks never see, because they take the body root, not the params.
+ *
+ * Fail closed on exactly the shapes whose evaluation escapes that analysis or
+ * reads outside the snapshot:
+ *   - defaults (`{ a = expr }`): `expr` evaluates at destructure time, and its
+ *     reads are invisible to the body walks;
+ *   - computed keys (`{ [k]: v }`): same, for the key expression;
+ *   - a `current` binding at any depth: the same mutable-ref hazard the body
+ *     walk rejects for ObjectPattern declarations (a ref's identity is not a
+ *     complete witness for its contents);
+ *   - array patterns: destructuring runs the iterator protocol, which is
+ *     arbitrary user code on a non-Array prop;
+ *   - rest (`...rest`) with anything but a plain Identifier target.
+ * Rest itself is admitted: object rest is an engine-level own-property copy of
+ * the same snapshot, and spread-bearing call sites never receive a region
+ * anyway (callSiteOk excludes them), so a getter-bearing props object cannot
+ * reach a cached region.
+ */
+function isAutoMemoPropsParam(param) {
+	if (param == null) return false;
+	if (param.type === 'Identifier') return true;
+	if (param.type !== 'ObjectPattern') return false;
+	const admissible = (pattern) => {
+		if (pattern == null || pattern.type !== 'ObjectPattern') return false;
+		for (const p of pattern.properties || []) {
+			if (p.type === 'RestElement') {
+				if (p.argument?.type !== 'Identifier') return false;
+				continue;
+			}
+			if (p.type !== 'Property' || p.computed) return false;
+			const key = p.key?.name ?? p.key?.value;
+			if (key === 'current') return false;
+			const value = p.value;
+			if (value?.type === 'Identifier') continue;
+			if (!admissible(value)) return false;
+		}
+		return true;
+	};
+	return admissible(param);
 }
 
 /**
@@ -6953,6 +7102,7 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 				eligible: false,
 				autoMemoSafe: false,
 				autoMemoCallsitesSafe: true,
+				autoMemoLocalHazards: null,
 				autoMemoCaptures: [],
 				autoMemoComponentDeps: [],
 				autoMemoImportedComponents: [],
@@ -6985,16 +7135,26 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 		if (compNode.body.render) stmts.push(compNode.body.render);
 		const root = b.block(stmts);
 		const free = collectFreeIdentifiers(root, locals);
-		const { importedComponents: autoMemoImportedComponents, readsDeferredRef } = scanComponentBody(
+		const { importedComponents: autoMemoImportedComponents } = scanComponentBody(
 			root,
 			ctx.importedNames,
 		);
-		// Both proofs below ask this of the same root. Kept lazy because the
-		// short-circuits ahead of each use skip it entirely for some components.
+		// The callee-side proof below asks this of the same root. Kept lazy because
+		// the short-circuits ahead of its use skip it entirely for some components.
 		let importedMemberRead = null;
 		const readsImportedMember = () =>
 			(importedMemberRead ??= containsImportedMemberRead(root, ctx.importedNames));
-		let autoMemoCallsitesSafe = !readsDeferredRef && !readsImportedMember();
+		// Call-site regions inside this body are gated per site: the site's own
+		// props are walked directly (containsAutoMemoUnsafeStructure /
+		// containsImportedMemberRead over the JSX node), and ref/imported-member
+		// reads laundered through a body local are carried by this hazard set —
+		// a site whose free identifiers touch a tainted local falls back. The
+		// free-name loop below still vetoes the whole body for names no dep can
+		// witness at all (boundary wrappers, namespaces, ambient module state).
+		const autoMemoLocalHazards = ctx.autoMemo
+			? collectAutoMemoLocalHazards(stmts, ctx.importedNames)
+			: null;
+		let autoMemoCallsitesSafe = true;
 		for (const name of free) {
 			if (
 				ctx._octaneBoundaryNames.has(name) ||
@@ -7008,13 +7168,14 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 				break;
 			}
 		}
-		// autoMemo's first proof is intentionally narrower than lite eligibility.
-		// It models a pure component as a function of one ordinary props snapshot;
-		// destructuring/default/rest parameters can be admitted once their evaluation
-		// is included in the shared dependency/purity analysis.
+		// autoMemo models a pure component as a function of one ordinary props
+		// snapshot. A destructuring param is that same snapshot read once at
+		// entry, admitted only while the pattern evaluates no expressions of its
+		// own — see isAutoMemoPropsParam for the exact fail-closed shapes
+		// (defaults, computed keys, `current`, array patterns).
 		const ordinaryPropsParam =
 			(compNode.params?.length ?? 0) <= 1 &&
-			(compNode.params?.length !== 1 || compNode.params[0]?.type === 'Identifier');
+			(compNode.params?.length !== 1 || isAutoMemoPropsParam(compNode.params[0]));
 		let autoMemoSafe =
 			ordinaryPropsParam &&
 			!containsRenderCall(stmts, ctx) &&
@@ -7052,6 +7213,7 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 		}
 		info.autoMemoSafe = autoMemoSafe;
 		info.autoMemoCallsitesSafe = autoMemoCallsitesSafe;
+		info.autoMemoLocalHazards = autoMemoLocalHazards;
 		info.autoMemoCaptures = autoMemoSafe ? autoMemoCaptures.sort() : [];
 		info.autoMemoComponentDeps = autoMemoSafe ? autoMemoComponentDeps.sort() : [];
 		info.autoMemoImportedComponents = autoMemoSafe ? [...autoMemoImportedComponents].sort() : [];
@@ -10854,11 +11016,13 @@ function compileComponent(node, ctx, options) {
 	// locals.
 	const prevLocals = ctx.currentComponentLocals;
 	const prevAutoMemoCallsitesSafe = ctx.currentAutoMemoCallsitesSafe;
+	const prevAutoMemoLocalHazards = ctx.currentAutoMemoLocalHazards;
 	const prevKnownStr = ctx.knownStringLocals;
 	const prevProfileComponentId = ctx.currentProfileComponentId;
 	const previousComponentOwner = ctx.currentComponentOwner;
 	ctx.currentComponentLocals = collectComponentLocals(node);
 	ctx.currentAutoMemoCallsitesSafe = ctx.componentInfo.get(name)?.autoMemoCallsitesSafe !== false;
+	ctx.currentAutoMemoLocalHazards = ctx.componentInfo.get(name)?.autoMemoLocalHazards ?? null;
 	ctx.knownStringLocals = collectKnownStringLocals(node);
 	ctx.currentComponentOwner = owner;
 	if (ctx.profile) ctx.currentProfileComponentId = profileComponentId(ctx, name, node);
@@ -10876,6 +11040,7 @@ function compileComponent(node, ctx, options) {
 	} finally {
 		ctx.currentComponentLocals = prevLocals;
 		ctx.currentAutoMemoCallsitesSafe = prevAutoMemoCallsitesSafe;
+		ctx.currentAutoMemoLocalHazards = prevAutoMemoLocalHazards;
 		ctx.knownStringLocals = prevKnownStr;
 		ctx.currentProfileComponentId = prevProfileComponentId;
 		ctx.currentComponentOwner = previousComponentOwner;
@@ -14243,11 +14408,13 @@ function compileReturnJsxFunction(node, ctx, options) {
 	const prevValueDirectiveLowering = ctx._valueDirectiveLowering;
 	const prevLocals = ctx.currentComponentLocals;
 	const prevAutoMemoCallsitesSafe = ctx.currentAutoMemoCallsitesSafe;
+	const prevAutoMemoLocalHazards = ctx.currentAutoMemoLocalHazards;
 	const prevMapTemps = ctx.currentMapTemps;
 	const mapTemps = [];
 	ctx._valueDirectiveLowering = lowerBodyValueDirective;
 	ctx.currentComponentLocals = collectComponentLocals(node);
 	ctx.currentAutoMemoCallsitesSafe = ctx.componentInfo.get(name)?.autoMemoCallsitesSafe !== false;
+	ctx.currentAutoMemoLocalHazards = ctx.componentInfo.get(name)?.autoMemoLocalHazards ?? null;
 	ctx.currentMapTemps = mapTemps;
 	let newStatements;
 	try {
@@ -14295,6 +14462,7 @@ function compileReturnJsxFunction(node, ctx, options) {
 		ctx._valueDirectiveLowering = prevValueDirectiveLowering;
 		ctx.currentComponentLocals = prevLocals;
 		ctx.currentAutoMemoCallsitesSafe = prevAutoMemoCallsitesSafe;
+		ctx.currentAutoMemoLocalHazards = prevAutoMemoLocalHazards;
 		ctx.currentMapTemps = prevMapTemps;
 	}
 	if (
@@ -21898,7 +22066,13 @@ function makeCompCall(
 					}
 					for (const name of free) {
 						if (name === compName) continue;
-						if (ctx.importNamespaceNames.has(name)) {
+						if (
+							ctx.importNamespaceNames.has(name) ||
+							// A local laundering a ref or live-import member read (see
+							// collectAutoMemoLocalHazards) — its per-render value is not a
+							// complete witness, so the site keeps ordinary entry semantics.
+							ctx.currentAutoMemoLocalHazards?.has(name) === true
+						) {
 							depsSafe = false;
 						} else if (ctx.currentComponentLocals.has(name) || ctx.importedNames.has(name)) {
 							if (!callsiteDeps.coveredRoots.has(name)) deps.add(name);

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -4221,13 +4221,21 @@ function containsImportedMemberRead(root, importedNames) {
  *     while the import's identity (the only thing a dep can hold) stays
  *     fixed.
  *
- * A name is tainted when such a read reaches its value through the
- * declaration initializer, any assignment's right-hand side, or a for-of /
- * for-in feed — directly or through another tainted local (fixed point, so
- * declaration order and arrow-hoisted back-references cannot hide a hazard).
- * Props params and same-module function declarations never taint: the former
- * are the witnessed snapshot itself, the latter are immutable identities
- * whose render-time CALLS the per-site render-call gate already rejects.
+ * A name is tainted when such a read reaches its value through ANY feed —
+ * declaration initializers at every nesting depth, destructuring patterns
+ * that carry the read themselves (`const { current: el } = ref`, a default or
+ * computed key reading a ref or live import), assignment right-hand sides, or
+ * a for-of/for-in source — directly or through another tainted local (fixed
+ * point, so declaration order and arrow-hoisted back-references cannot hide a
+ * hazard). Nested and loop-scoped names are not component locals, so tainting
+ * them is inert at call sites directly (unknown names already fail closed),
+ * but it is what lets a hazard PROPAGATE through them into a top-level local
+ * (`let out; for (const x of ref.current.items) out = x`). Shadowing is
+ * folded by name — an inner binding's hazard taints its outer namesake —
+ * which only ever declines more. Props params and same-module function
+ * declarations never taint: the former are the witnessed snapshot itself, the
+ * latter are immutable identities whose render-time CALLS the per-site
+ * render-call gate already rejects.
  *
  * The direct forms of these reads inside a call site's own props are rejected
  * per site (containsAutoMemoUnsafeStructure / containsImportedMemberRead);
@@ -4243,7 +4251,21 @@ function collectAutoMemoLocalHazards(stmts, importedNames) {
 		const names = new Set();
 		collectBindings(pattern, names);
 		if (names.size === 0) return;
-		const direct = containsDeferredRefRead(rhs) || containsImportedMemberRead(rhs, importedNames);
+		// The pattern side can carry the read itself: a `current`/computed
+		// binding key destructures ref contents off the source, and a default's
+		// expression evaluates at destructure time. Both walks descend the whole
+		// pattern, so nested shapes and defaults are covered together.
+		const direct =
+			containsDeferredRefRead(rhs) ||
+			containsImportedMemberRead(rhs, importedNames) ||
+			containsDeferredRefRead(pattern) ||
+			containsImportedMemberRead(pattern, importedNames);
+		// Default expressions inside the pattern read values too; their free
+		// identifiers (which include the pattern's own bound names — inert
+		// self-loops) join the clean-source union.
+		const frees = direct
+			? null
+			: [...collectFreeIdentifiers(rhs, []), ...collectFreeIdentifiers(pattern, [])];
 		for (const name of names) {
 			if (hazards.has(name)) continue;
 			if (direct) {
@@ -4253,18 +4275,14 @@ function collectAutoMemoLocalHazards(stmts, importedNames) {
 			}
 			let set = sourceFrees.get(name);
 			if (set === undefined) sourceFrees.set(name, (set = new Set()));
-			for (const id of collectFreeIdentifiers(rhs, [])) set.add(id);
+			for (const id of frees) set.add(id);
 		}
 	};
-	for (const stmt of stmts) {
-		if (stmt.type !== 'VariableDeclaration') continue;
-		for (const d of stmt.declarations || []) feed(d.id, d.init);
-	}
-	// Assignment/loop feeds anywhere in the body, including nested functions:
-	// a deferred write targets a PREVIOUS render's binding and can never leak
-	// into the next render's dep snapshot, but walking uniformly is cheaper
-	// than proving which writes are deferred, and only hazardous right-hand
-	// sides taint anyway.
+	// One walk feeds every binding form at every depth, including inside
+	// nested function values: a deferred write targets a PREVIOUS render's
+	// binding and can never leak into the next render's dep snapshot, but
+	// walking uniformly is cheaper than proving which writes are deferred, and
+	// only hazardous sources taint anyway.
 	const seen = new WeakSet();
 	(function walk(n) {
 		if (!n) return;
@@ -4274,14 +4292,19 @@ function collectAutoMemoLocalHazards(stmts, importedNames) {
 		}
 		if (typeof n !== 'object' || !n.type || seen.has(n)) return;
 		seen.add(n);
-		if (n.type === 'AssignmentExpression' && n.left?.type !== 'MemberExpression') {
+		if (n.type === 'VariableDeclaration') {
+			for (const d of n.declarations || []) feed(d.id, d.init);
+		} else if (n.type === 'AssignmentExpression' && n.left?.type !== 'MemberExpression') {
 			feed(n.left, n.right);
-		} else if (
-			(n.type === 'ForOfStatement' || n.type === 'ForInStatement') &&
-			n.left &&
-			n.left.type !== 'VariableDeclaration'
-		) {
-			feed(n.left, n.right);
+		} else if ((n.type === 'ForOfStatement' || n.type === 'ForInStatement') && n.left) {
+			// The loop source feeds the bound names whether the left declares
+			// (`for (const x of src)` — declarator inits are null, so the
+			// declaration arm above cannot see src) or reuses an outer binding.
+			if (n.left.type === 'VariableDeclaration') {
+				for (const d of n.left.declarations || []) feed(d.id, n.right);
+			} else {
+				feed(n.left, n.right);
+			}
 		}
 		for (const key in n) {
 			if (AST_WALK_SKIP_KEYS.has(key)) continue;

--- a/packages/octane/tests/_fixtures/auto-memo.tsrx
+++ b/packages/octane/tests/_fixtures/auto-memo.tsrx
@@ -18,6 +18,18 @@ function Rows(props) @{
 	</ul>
 }
 
+// The destructured-param twin of Rows: `{ items }` is the same one-props
+// snapshot read at entry, so the caller's region caches this list by the same
+// dependency — while context refreshes and child state must behave exactly as
+// they do for the props-object form above.
+function DestructuredRows({ items }: { items: { id: number; label: string }[] }) @{
+	<ul id="auto-memo-rows-destructured">
+		@for (const item of items; key item.id) {
+			<AutoMemoChild id={'d' + item.id} label={item.label} />
+		}
+	</ul>
+}
+
 // The imported child owns a custom comparator. The compiler-owned region must
 // fall back, so the explicit comparator remains observable.
 function CustomRows() @{
@@ -84,6 +96,7 @@ export function AutoMemoApp() @{
 		>{'item + context'}</button>
 		<AutoMemoContext.Provider value={theme}>
 			<Rows items={items} />
+			<DestructuredRows items={items} />
 		</AutoMemoContext.Provider>
 		<ReturnedValue value={theme} />
 		<CustomRows />

--- a/packages/octane/tests/auto-memo.test.ts
+++ b/packages/octane/tests/auto-memo.test.ts
@@ -129,6 +129,10 @@ describe('compiler-owned component-region memoization', () => {
 		const root = mount(AutoMemoApp);
 		const initialOpaqueVersion = trailingVersion(root.find('.opaque').textContent);
 		expect(root.find('.own-1').textContent).toBe('t0:a:0');
+		// The destructured-param twin renders through the same cached-region
+		// machinery and must be behaviorally indistinguishable from the
+		// props-object form throughout this scenario.
+		expect(root.find('.own-d1').textContent).toBe('t0:a:0');
 		expect(trailingVersion(root.find('.custom').textContent)).toBe(initialOpaqueVersion);
 		expect(trailingVersion(root.find('.returned-opaque-a').textContent)).toBe(initialOpaqueVersion);
 
@@ -143,13 +147,17 @@ describe('compiler-owned component-region memoization', () => {
 
 		root.click('.own-1');
 		expect(root.find('.own-1').textContent).toBe('t0:a:1');
+		root.click('.own-d1');
+		expect(root.find('.own-d1').textContent).toBe('t0:a:1');
 
 		root.click('#auto-context');
 		expect(root.find('.own-1').textContent).toBe('t0!:a:1');
+		expect(root.find('.own-d1').textContent).toBe('t0!:a:1');
 		expect(root.find('#auto-returned').textContent).toBe('returned t0!');
 
 		root.click('#auto-item');
 		expect(root.find('.own-1').textContent).toBe('t0!:a!:1');
+		expect(root.find('.own-d1').textContent).toBe('t0!:a!:1');
 
 		// A dependency miss and Provider change can commit in the same render. The
 		// changed row re-enters through the keyed list, while the unchanged row must
@@ -157,6 +165,8 @@ describe('compiler-owned component-region memoization', () => {
 		root.click('#auto-item-context');
 		expect(root.find('.own-1').textContent).toBe('t0!!:a!!:1');
 		expect(root.find('.own-2').textContent).toBe('t0!!:b:0');
+		expect(root.find('.own-d1').textContent).toBe('t0!!:a!!:1');
+		expect(root.find('.own-d2').textContent).toBe('t0!!:b:0');
 
 		root.unmount();
 	});
@@ -2237,6 +2247,118 @@ describe('compiler-owned component-region memoization', () => {
 			{ hmr: false, autoMemo: true },
 		).code;
 		expect(transitiveCapture.match(/const __memoDep[\w$]* = \(?live\)?;/g)).toHaveLength(2);
+	});
+
+	it('memoizes destructured-props callees while pattern-evaluating shapes fall back', () => {
+		// A destructuring param is the same one-props snapshot as `(props)`,
+		// read once at entry, so these callees earn the region cache.
+		const admitted = [
+			`function Child({ rows }) @{ <ul>@for (const r of rows; key r.id) { <li>{r.label}</li> }</ul> }`,
+			`function Child({ rows: list }) @{ <div>{list.length}</div> }`,
+			`function Child({ data: { rows } }) @{ <div>{rows.length}</div> }`,
+			`function Child({ label, ...rest }) @{ <div>{label + rest.suffix}</div> }`,
+		];
+		for (const child of admitted) {
+			const code = compile(
+				`${child}\nexport function App(props) @{ <Child rows={props.rows} label={props.label} data={props.data} /> }`,
+				'auto-memo-destructured.tsrx',
+				{ hmr: false, autoMemo: true },
+			).code;
+			expectCompilerRegion(code);
+			expect(code).toMatch(/__memoCache[\w$]*\[\d+\] !== __memoDep[\w$]*\) \{\s*_\$componentSlot/);
+		}
+
+		// Patterns that evaluate expressions of their own (defaults, computed
+		// keys), read mutable ref contents (`current`), or run the iterator
+		// protocol (array patterns) keep ordinary entry semantics.
+		const rejected = [
+			`import { fallback } from './live'; function Child({ label = fallback }) @{ <div>{label}</div> }`,
+			`import { field } from './live'; function Child({ [field]: value }) @{ <div>{value}</div> }`,
+			`function Child({ current }) @{ <div>{current}</div> }`,
+			`function Child({ box: { current } }) @{ <div>{current}</div> }`,
+			`function Child({ pair: [a, b] }) @{ <div>{a + b}</div> }`,
+			`function Child({ label }, extra) @{ <div>{label}</div> }`,
+		];
+		for (const child of rejected) {
+			// The caller passes only site-clean props, so a fallback here is the
+			// CALLEE pattern's verdict, not a call-site rejection.
+			const code = compile(
+				`${child}\nexport function App(props) @{ <Child label={props.label} box={props.box} pair={props.pair} /> }`,
+				'auto-memo-destructured-fallback.tsrx',
+				{ hmr: false, autoMemo: true },
+			).code;
+			expectNoCompilerRegion(code);
+		}
+	});
+
+	it('scopes ref and live-import laundering to the call sites that read it', () => {
+		// A ref read elsewhere in the body must not veto an unrelated call site:
+		// the site's own props are walked directly, and reads laundered through a
+		// local are carried by the per-local hazard set.
+		const unrelatedRefRead = compile(
+			`import { useRef } from 'octane';
+			 function Child(props) @{ <div>{props.value}</div> }
+			 export function App(props) @{
+				const overlayRef = useRef(null);
+				<div>
+					<span ref={overlayRef}>{(overlayRef.current !== null ? 'y' : 'n') as string}</span>
+					<Child value={props.value} />
+				</div>
+			 }`,
+			'auto-memo-hazard-unrelated.tsrx',
+			{ hmr: false, autoMemo: true },
+		).code;
+		expectCompilerRegion(unrelatedRefRead);
+		expect(unrelatedRefRead).toMatch(
+			/__memoCache[\w$]*\[\d+\] !== __memoDep[\w$]*\) \{\s*_\$componentSlot[\w$]*\([^;]*, Child,/,
+		);
+
+		// Laundering the read through locals — directly, transitively, or via a
+		// reassignment whose write site the declaration no longer accounts for —
+		// still keeps ordinary entry semantics for the sites that consume them.
+		const launderedLocals = [
+			`function Child(props) @{ <div>{props.value}</div> }
+			 export function App(props) @{
+				const first = props.refObj.current;
+				const second = first + 1;
+				<Child value={second} />
+			 }`,
+			`import { cell } from './live';
+			 function Child(props) @{ <div>{props.value}</div> }
+			 export function App(props) @{
+				const base = cell.value;
+				const derived = base + 1;
+				<Child value={derived} />
+			 }`,
+			`function Child(props) @{ <div>{props.value}</div> }
+			 export function App(props) @{
+				let value = props.base;
+				if (props.useOverlay) value = props.refObj.current;
+				<Child value={value} />
+			 }`,
+		];
+		for (const source of launderedLocals) {
+			const code = compile(source, 'auto-memo-hazard-laundered.tsrx', {
+				hmr: false,
+				autoMemo: true,
+			}).code;
+			expectNoCompilerRegion(code);
+		}
+
+		// A conditionally reassigned plain-value local stays a complete witness
+		// of itself — locals re-initialize on every body entry — so the site
+		// keeps its region.
+		const reassignedClean = compile(
+			`function Child(props) @{ <div>{props.value}</div> }
+			 export function App(props) @{
+				let value = props.base;
+				if (props.flip) value = props.other;
+				<Child value={value} />
+			 }`,
+			'auto-memo-hazard-clean-reassign.tsrx',
+			{ hmr: false, autoMemo: true },
+		).code;
+		expectCompilerRegion(reassignedClean);
 	});
 
 	it('judges each component in a module on its own imported reads', () => {

--- a/packages/octane/tests/auto-memo.test.ts
+++ b/packages/octane/tests/auto-memo.test.ts
@@ -2316,7 +2316,39 @@ describe('compiler-owned component-region memoization', () => {
 		// Laundering the read through locals — directly, transitively, or via a
 		// reassignment whose write site the declaration no longer accounts for —
 		// still keeps ordinary entry semantics for the sites that consume them.
+		// The pattern side of a declaration can carry the read itself (a
+		// `current` binding, a default reading a live import), and hazards can
+		// route through nested-block or loop declarations before reaching a
+		// top-level local; all of these must taint like their expression forms.
 		const launderedLocals = [
+			`function Child(props) @{ <div>{props.value}</div> }
+			 export function App(props) @{
+				const { current: el } = props.refObj;
+				<Child value={el} />
+			 }`,
+			`import { cell } from './live';
+			 function Child(props) @{ <div>{props.value}</div> }
+			 export function App(props) @{
+				const { label = cell.value } = props;
+				<Child value={label} />
+			 }`,
+			`function Child(props) @{ <div>{props.value}</div> }
+			 export function App(props) @{
+				let latest = null;
+				for (const sample of props.refObj.current.samples) {
+					latest = sample;
+				}
+				<Child value={latest} />
+			 }`,
+			`function Child(props) @{ <div>{props.value}</div> }
+			 export function App(props) @{
+				let out = null;
+				if (props.enabled) {
+					const grabbed = props.refObj.current;
+					out = grabbed;
+				}
+				<Child value={out} />
+			 }`,
 			`function Child(props) @{ <div>{props.value}</div> }
 			 export function App(props) @{
 				const first = props.refObj.current;


### PR DESCRIPTION
## Summary
- Compiler-inferred component memoization (autoMemo, prod-only) now admits components with destructured props parameters: `function Child({ rows })` is treated as the same one-props snapshot as `function Child(props)`, so stable-prop call sites of such components gain the whole-region dependency cache and skip the child's update entirely.
- Call-site eligibility is no longer vetoed body-wide by an unrelated `ref.current`/computed-member/live-import member read elsewhere in the parent. Those reads now gate per call site and per tainted local, so e.g. a portal-mount `overlayRef.current` guard no longer disables memoization for every sibling subtree.

## Why
- The svg-dashboard suite (#635) exposed that with app state colocated idiomatically (all domains in `App`, children like `<Topology topo={topo} />` behind reference-stable snapshots), a ui-only commit re-entered every subtree: ~148µs per commit vs ~1.7µs for the fixture's Viewport-leaf workaround, 960-commit `pan_zoom` samples at 142ms vs 1.6ms.
- Root cause was not the region machinery — it never engaged: every child used destructured props (`ordinaryPropsParam` failed), and the one `overlayRef.current` read in the body killed `autoMemoCallsitesSafe` for all call sites.
- With this change (measured on top of #635's suite locally), `Defs`/`ChartsStrip`/`Sparks`/`IconLayer` — including the 150-icon `createElement` de-opt layer — bail completely on ui commits; the dashboard minus the spread-bearing `Topology` drops from ~228µs to ~3–6µs per commit in-page, with the harness's Node-replay byte-parity gates green throughout. `Topology` itself still cannot bail because its rows carry `{...e.attrs}` spread bags, which the callee proof correctly fails closed on today (follow-up below).

## Changes
- `isAutoMemoPropsParam` (compile.js): admits an `ObjectPattern` props param when destructuring it evaluates nothing — fails closed on defaults, computed keys, any `current` binding at any depth, array patterns (iterator protocol), and non-identifier rest targets.
- `collectAutoMemoLocalHazards` (compile.js): per-local taint replacing the body-wide `readsDeferredRef`/`readsImportedMember` veto. A local is tainted when a ref or live-import member read reaches its value through its initializer, any assignment right-hand side, or a for-of/for-in feed — transitively, including inside nested function values (`useCallback(() => ref.current, [])`). A site whose free identifiers touch a tainted local falls back; plain-value conditionally-reassigned locals stay clean witnesses (locals re-initialize every body entry).
- `scanComponentBody` no longer collects the now-unused body-wide ref flag.
- Tests: two compile-shape tests (admission matrix incl. every fail-closed pattern; hazard scoping incl. laundered/transitive/assignment-fed rejection and the clean-reassignment non-regression) — both verified failing against the pre-change compiler. The `AutoMemoApp` runtime fixture gains a destructured-param twin of `Rows` with mirrored context-refresh/child-state assertions, running in both the dev and `octane-prod` vitest projects.
- Changeset (`octane`, patch).

## Validation
- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 1567 files / 16,965 tests green on this branch (also green twice on the #635 base during development)
- [x] targeted tests: `auto-memo.test.ts`, `auto-memo-value-position.test.ts`, `automemo-render-calls.test.ts` (184 tests), `packages/octane/tests/compiler` (1,061 tests); new tests confirmed red pre-fix
- [x] `pnpm sync` — no generated changes
- svg-dashboard bench (run locally on top of #635, 4 flavors, exit 0): all ratio guards pass — `pan_zoom` 0.31x react (guard ≤0.7), `drag_nodes` 1.64x (≤2.2), `style_spread_pulse` 1.99x (≤3.0); octane absolute numbers flat-to-better vs same-server pre-change baseline; full harness correctness gates (byte-parity Node replay, namespace census, survivor identity) green with regions skipping.

## Risk / follow-ups
- The pinned conservative semantics are preserved: ref-derived or live-import-derived locals still reject their sites (existing `nonlocalCallSites` expectations unchanged), and dev/HMR/profile/server builds still emit no regions.
- Callee bodies containing host-element spread bags (`{...attrs}`) remain excluded from the proof — the measured remaining gap (svg-dashboard `Topology`, ~130µs of the inline-shape commit); tracked as a separate investigation.
- For-list caches (`listSafe`/`itemMemo`) accept locals as deps without hazard filtering — pre-existing behavior, deliberately not tightened here.
- Hydration coverage for destructured-callee regions rides the existing props-form hydration tests; the emitted call-site shape is identical, only eligibility widened.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compiler correctness boundaries for production-only memo regions (refs, live imports, destructuring); semantics are fail-closed and heavily tested, but misclassification could skip caches or risk stale subtrees.
> 
> **Overview**
> Widens **autoMemo** (prod compiler-inferred region caching) so more real-world components and call sites actually get memo regions instead of falling back globally.
> 
> **Destructured props callees:** `isAutoMemoPropsParam` treats a plain `ObjectPattern` param like `(props)` — one snapshot at entry — while still rejecting defaults, computed keys, any `current` binding, array patterns, and multi-param signatures. Callees such as `function Child({ rows })` can now be `autoMemoSafe` and emit dependency-cached regions when props stay reference-stable.
> 
> **Per-site hazard gating:** The body-wide `readsDeferredRef` veto is removed from `scanComponentBody` / `autoMemoCallsitesSafe`. `collectAutoMemoLocalHazards` taints component locals that absorb ref reads or live-import member reads (including via destructuring defaults, loops, assignments, and transitive locals). Only call sites whose free identifiers touch a tainted local lose the region; unrelated siblings (e.g. a portal `ref.current` guard elsewhere) keep caching. Plain locals with only value reassignment stay eligible.
> 
> Component analysis stores `autoMemoLocalHazards` on `componentInfo` and threads it through compile via `ctx.currentAutoMemoLocalHazards` for per-site `depsSafe` checks. Tests cover admission/rejection matrices, hazard scoping, and a runtime twin for destructured `Rows`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ba5e6d35819595680afcd58c0212cbfea3ae485. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->