### PR TITLE
perf(compiler): admit host-element spread bags into autoMemo regions

### DIFF
--- a/.changeset/auto-memo-host-spread-bags.md
+++ b/.changeset/auto-memo-host-spread-bags.md
@@ -1,0 +1,15 @@
+---
+'octane': patch
+---
+
+Compiler-inferred component memoization now admits spread bags on host
+elements. `<path d={e.d} {...e.attrs}>` inside a component body no longer
+disqualifies that component's region cache or its keyed-list caches: a host
+spread is one runtime-diffed binding whose bag is reachable only from
+dependencies the region guard already witnesses, so skipping on unchanged
+dependencies is exactly the no-op a re-entry would have been. Re-entries keep
+full spread semantics — changed keys apply, vanished keys clear, and
+spread-supplied refs and event handlers attach, swap, and detach as before.
+Spreads on component tags keep failing closed: they build the child's props
+snapshot, which cached call sites must never construct from a getter-bearing
+bag.

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -1549,7 +1549,7 @@
     "target": "octane-tsrx",
     "reference": "solid",
     "maxRatio": 2.7,
-    "note": "Fresh-but-value-identical snapshot republish: octane walks every binding's prev-guard where solid's fine-grained graph skips at the signal layer. Observed 1.78x, 2026-08-07; this pins the diff-skip walk cost across ~2,400 elements from drifting further."
+    "note": "Fresh-but-value-identical snapshot republish: octane walks every binding's prev-guard where solid's fine-grained graph skips at the signal layer. Observed 1.78x, 2026-08-07; this pins the diff-skip walk cost from drifting further. Observed 0.36x, 2026-08-08, after the autoMemo host-spread admission: the unchanged topology/icon subtrees now bail on identity, so the walk covers only the republished charts strip."
   },
   {
     "suite": "svg-dashboard",
@@ -1557,7 +1557,7 @@
     "target": "octane-tsrx",
     "reference": "react",
     "maxRatio": 2.5,
-    "note": "Per-frame topology commits (10 node+icon transforms + ~26 incident edge d rebuilds, 30 frames). Observed 1.45x at introduction (2026-08-07) and 1.89x once the react fixture adopted the React Compiler rollout (#639, 2026-08-08) \u2014 a known octane gap: each topo commit re-walks the keyed row bindings including the 150 de-opt icon holes. Tripwire against the gap widening."
+    "note": "Per-frame topology commits (10 node+icon transforms + ~26 incident edge d rebuilds, 30 frames). Observed 1.45x at introduction (2026-08-07) and 1.89x once the react fixture adopted the React Compiler rollout (#639, 2026-08-08) \u2014 a known octane gap: each topo commit re-walks the keyed row bindings including the 150 de-opt icon holes. Tripwire against the gap widening. The autoMemo host-spread admission adds always-missing region guards to these commits; a same-session A/B (2026-08-08, pre-#639 react column) attributed only ~0.1 ms (~1.4%) of octane's 7.0 ms to them."
   },
   {
     "suite": "svg-dashboard",
@@ -1565,7 +1565,7 @@
     "target": "octane-tsrx",
     "reference": "solid",
     "maxRatio": 2.3,
-    "note": "960 tiny ui commits (viewBox + root transform only). Measures per-commit flush overhead with the dashboard subtrees isolated behind reference-stable descriptor props. Observed 1.53x, 2026-08-07; regression here means the children-prop bail-out stopped engaging."
+    "note": "960 tiny ui commits (viewBox + root transform only). Measures per-commit flush overhead with the dashboard subtrees isolated behind reference-stable descriptor props. Observed 1.53x, 2026-08-07; regression here means the children-prop bail-out stopped engaging. Since the autoMemo host-spread + destructured-props admissions (2026-08-08), the compiler-owned call-site regions also bail on the colocated shape: an inline-App probe (all three domains in App, subtrees as direct children) ran pan_zoom at 134.0 ms without the spread admission (Topology re-walk per commit) and 0.6 ms with it."
   },
   {
     "suite": "svg-dashboard",
@@ -1573,7 +1573,7 @@
     "target": "octane-tsrx",
     "reference": "react",
     "maxRatio": 0.7,
-    "note": "Observed 0.32x, 2026-08-07. Octane's per-commit overhead beats react's memo-cascade by 3x on viewport-only writes; approaching 0.7x means either octane's ui-commit path bloated or the descriptor-prop bail-out weakened."
+    "note": "Observed 0.32x, 2026-08-07. Octane's per-commit overhead beats react's memo-cascade by 3x on viewport-only writes; approaching 0.7x means either octane's ui-commit path bloated or the descriptor-prop bail-out weakened. The compiler-owned call-site regions now also cover host-spread callees (Topology's {...e.attrs} rows), so the Viewport descriptor-prop shape is a fixture choice rather than the only isolation keeping this op flat."
   },
   {
     "suite": "svg-dashboard",

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -4330,6 +4330,10 @@ function collectAutoMemoLocalHazards(stmts, importedNames) {
 function containsAutoMemoUnsafeStructure(stmts) {
 	let found = false;
 	const seen = new WeakSet();
+	// Spread bags on HOST elements, marked admissible by the owning element's
+	// visit below. Parents walk before their attributes, so membership is
+	// decided before the spread node itself is reached.
+	const hostSpreads = new WeakSet();
 	function walk(n) {
 		if (found || !n) return;
 		if (Array.isArray(n)) {
@@ -4361,12 +4365,28 @@ function containsAutoMemoUnsafeStructure(stmts) {
 			t === 'YieldExpression' ||
 			t === 'ThrowStatement' ||
 			t === 'TryStatement' ||
-			t === 'JSXTryExpression' ||
-			t === 'SpreadAttribute' ||
-			t === 'JSXSpreadAttribute'
+			t === 'JSXTryExpression'
 		) {
 			found = true;
 			return;
+		}
+		if (t === 'SpreadAttribute' || t === 'JSXSpreadAttribute') {
+			// A HOST element's spread bag is one setSpread binding re-diffed on every
+			// region entry. Its argument is composed of deps the region guard already
+			// witnesses (unwitnessed names fail closed independently), so a skip is
+			// the no-op a re-entry would have been — the same immutable-snapshot
+			// argument that admits `class={e.cls}` member reads; runtime keys the
+			// walk cannot see (ref/on*/value) diff per entry with full parity to
+			// their direct-attribute forms. A COMPONENT tag's spread instead builds
+			// the child's props snapshot (getter evaluation, hidden prop names) and
+			// stays rejected, matching the callSiteOk exclusion — which
+			// isAutoMemoPropsParam's rest admission relies on. The argument still
+			// walks below: accessors, computed members, and ref reads inside it keep
+			// failing closed.
+			if (!hostSpreads.has(n)) {
+				found = true;
+				return;
+			}
 		}
 		if (t === 'UnaryExpression' && n.operator === 'delete') {
 			found = true;
@@ -4434,6 +4454,13 @@ function containsAutoMemoUnsafeStructure(stmts) {
 			) {
 				found = true;
 				return;
+			}
+			if (!isComponentTag(n)) {
+				for (const attr of n.attributes || n.openingElement?.attributes || []) {
+					if (attr.type === 'SpreadAttribute' || attr.type === 'JSXSpreadAttribute') {
+						hostSpreads.add(attr);
+					}
+				}
 			}
 		}
 		for (const key in n) {

--- a/packages/octane/tests/auto-memo.test.ts
+++ b/packages/octane/tests/auto-memo.test.ts
@@ -2393,6 +2393,176 @@ describe('compiler-owned component-region memoization', () => {
 		expectCompilerRegion(reassignedClean);
 	});
 
+	it('caches regions whose host elements take spread bags', () => {
+		// A host spread is one runtime-diffed binding over a bag reachable only
+		// from deps the region guard already witnesses — the same immutable-
+		// snapshot read as a member-read attribute, so it cannot make a skip
+		// observable. Component-tag spreads instead build a child's props
+		// snapshot (getters run, prop names are hidden) and keep failing closed.
+		const admitted = [
+			`function Child(props) @{ <div class={props.cls} {...props.attrs}>{props.label}</div> }`,
+			// The svg-dashboard Topology shape: keyed rows spreading per-item bags.
+			`function Child({ topo }) @{
+				<g class="t">
+					@for (const e of topo.edges; key e.id) {
+						<path class={e.cls} d={e.d} {...e.attrs}></path>
+					}
+				</g>
+			 }`,
+		];
+		for (const child of admitted) {
+			const code = compile(
+				`${child}\nexport function App(props) @{ <Child cls={props.cls} attrs={props.attrs} label={props.label} topo={props.topo} /> }`,
+				'auto-memo-host-spread.tsrx',
+				{ hmr: false, autoMemo: true },
+			).code;
+			expectCompilerRegion(code);
+		}
+
+		// The tsx dialect's map-lowered keyed rows earn their list cache the same
+		// way (JSXSpreadAttribute instead of SpreadAttribute). mapSlot guards
+		// carry an extra native-receiver clause, so assert the cache pieces
+		// directly rather than through the componentSlot-shaped helper.
+		const tsxCode = compile(
+			`export function Rows(props) {
+				return (
+					<ul>
+						{props.rows.map((r) => (
+							<li key={r.id} className={r.cls} {...r.attrs}>{r.label}</li>
+						))}
+					</ul>
+				);
+			}`,
+			'auto-memo-host-spread.tsx',
+			{ hmr: false, autoMemo: true },
+		).code;
+		expect(tsxCode).toContain('__memoCommitted');
+		expect(tsxCode).toMatch(/__memoCache[\w$]*\[\d+\] !== __memoDep[\w$]*/);
+
+		const rejected = [
+			// A component-tag spread nested in the callee body…
+			`function Inner(props) @{ <b>{props.v}</b> }
+			 function Child(props) @{ <div><Inner {...props.bag} /></div> }
+			 export function App(props) @{ <Child bag={props.bag} /> }`,
+			// …and at the call site itself (callSiteOk) keep ordinary entry.
+			`function Child(props) @{ <div>{props.v}</div> }
+			 export function App(props) @{ <Child {...props.bag} /> }`,
+			// The spread ARGUMENT still walks under every other rule: accessors,
+			// computed members, and ref reads inside it keep failing closed.
+			`function Child(props) @{ <div {...{ get a() { return props.source.current; } }}></div> }
+			 export function App(props) @{ <Child source={props.source} /> }`,
+			`function Child(props) @{ <div {...props.bags[props.k]}></div> }
+			 export function App(props) @{ <Child bags={props.bags} k={props.k} /> }`,
+			// A statically witnessed ref keeps its pinned rejection; a bag
+			// alongside does not rescue it.
+			`function Child(props) @{ <div ref={props.refObj} {...props.attrs}></div> }
+			 export function App(props) @{ <Child refObj={props.refObj} attrs={props.attrs} /> }`,
+		];
+		for (const source of rejected) {
+			const code = compile(source, 'auto-memo-host-spread-fallback.tsrx', {
+				hmr: false,
+				autoMemo: true,
+			}).code;
+			expectNoCompilerRegion(code);
+		}
+	});
+
+	it('re-diffs and skips host spread bags through a cached region', () => {
+		const source = `
+			function SpreadRows({ rows }) @{
+				<ul id="auto-memo-spread-rows">
+					@for (const item of rows; key item.id) {
+						<li data-id={item.id} {...item.attrs}>{item.label as string}</li>
+					}
+				</ul>
+			}
+			export function App(props) @{
+				<div>
+					<span id="auto-memo-spread-version">{props.version as string}</span>
+					<SpreadRows rows={props.rows} />
+				</div>
+			}
+		`;
+		// The scenario below must exercise the cached path, so pin that this
+		// exact fixture earns its regions under the same compile options.
+		expectCompilerRegion(
+			compile(source, 'auto-memo-host-spread-runtime.tsrx', { hmr: false, dev: false }).code,
+		);
+		const client = loadCompiledFixtureSource(source, {
+			id: 'auto-memo-host-spread-runtime.tsrx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: false },
+		});
+
+		type Bag = Record<string, unknown>;
+		const events: string[] = [];
+		const firstRef: { current: Element | null } = { current: null };
+		const rows1 = [
+			{
+				id: 1,
+				label: 'alpha',
+				attrs: {
+					'data-x': 'a1',
+					title: 'first',
+					onClick: () => events.push('bag:1'),
+					ref: firstRef,
+				} as Bag,
+			},
+			{ id: 2, label: 'beta', attrs: { 'data-x': 'b1' } as Bag },
+		];
+		const root = mount(client.App, { version: 'v0', rows: rows1 });
+		const rowsBefore = root.findAll('#auto-memo-spread-rows > li');
+		expect(rowsBefore.map((row) => row.getAttribute('data-x'))).toEqual(['a1', 'b1']);
+		expect(rowsBefore[0]!.getAttribute('title')).toBe('first');
+		expect(firstRef.current).toBe(rowsBefore[0]);
+		root.click('[data-x="a1"]');
+		expect(events).toEqual(['bag:1']);
+
+		// Unchanged deps: the region skips. Under the immutable-snapshot
+		// contract an in-place bag mutation is invisible while `rows` keeps its
+		// identity — the same bail React.memo performs — and the bag's ref and
+		// handler stay live on the same node.
+		rows1[1]!.attrs['data-mutated'] = 'yes';
+		root.update(client.App, { version: 'v1', rows: rows1 });
+		expect(root.find('#auto-memo-spread-version')!.textContent).toBe('v1');
+		const rowsSkipped = root.findAll('#auto-memo-spread-rows > li');
+		expect(rowsSkipped[0]).toBe(rowsBefore[0]);
+		expect(rowsSkipped[1]!.hasAttribute('data-mutated')).toBe(false);
+		expect(firstRef.current).toBe(rowsBefore[0]);
+		root.click('[data-x="a1"]');
+		expect(events).toEqual(['bag:1', 'bag:1']);
+
+		// Changed deps: the region re-enters and re-diffs each bag — a changed
+		// key applies, a vanished key clears, and a swapped ref detaches the old
+		// holder before attaching the new. Keyed survivors keep DOM identity.
+		const secondRef: { current: Element | null } = { current: null };
+		const rows2 = [
+			{
+				id: 1,
+				label: 'alpha',
+				attrs: {
+					'data-x': 'a2',
+					onClick: () => events.push('bag:2'),
+					ref: secondRef,
+				} as Bag,
+			},
+			{ id: 2, label: 'beta', attrs: { 'data-x': 'b1' } as Bag },
+		];
+		root.update(client.App, { version: 'v2', rows: rows2 });
+		const rowsAfter = root.findAll('#auto-memo-spread-rows > li');
+		expect(rowsAfter[0]).toBe(rowsBefore[0]);
+		expect(rowsAfter[1]).toBe(rowsBefore[1]);
+		expect(rowsAfter[0]!.getAttribute('data-x')).toBe('a2');
+		expect(rowsAfter[0]!.hasAttribute('title')).toBe(false);
+		expect(firstRef.current).toBe(null);
+		expect(secondRef.current).toBe(rowsAfter[0]);
+		root.click('[data-x="a2"]');
+		expect(events).toEqual(['bag:1', 'bag:1', 'bag:2']);
+
+		root.unmount();
+		expect(secondRef.current).toBe(null);
+	});
+
 	it('judges each component in a module on its own imported reads', () => {
 		// Every component is analysed against its own body. Both declaration
 		// orders are checked because a verdict leaking from one component to the


### PR DESCRIPTION
## Summary

- The autoMemo callee proof (`containsAutoMemoUnsafeStructure`) now admits spread bags on **host** elements, so bodies like svg-dashboard Topology's `<path d={e.d} {...e.attrs}>` no longer disqualify the component's call-site region cache or its keyed-list caches. Component-tag spreads keep failing closed, and the spread argument still walks under every other rule (accessors, computed members, ref reads).

## Why

- A host spread compiles to one `setSpread` binding whose bag is reachable only from dependencies the region guard already witnesses (every free identifier of a region is classified by the existing proofs; unwitnessed names fail closed independently of spreads). A skip on unchanged deps is therefore the no-op a re-entry would have been — the same pure-render immutable-snapshot argument that already admits member-read bindings like `class={e.cls}`. The statically invisible bag keys hold up case by case:
  - **`ref` in a bag**: `setSpread` diffs refs by identity (unchanged value is a no-op even on re-entry), queues detach on removal/swap with commit ordering, and compiled teardown detaches spread-supplied refs on unmount. A skipped region keeps the same ref attached to the same element — identical to a `React.memo` bail. (The explicit `ref={…}` *attribute* rejection stays as the pinned static-escape philosophy.)
  - **Handlers in a bag**: delegated dispatch reads the current event slot at event time; there is no per-render re-subscription a skip could miss.
  - **Getter-bearing bags**: the same contract exposure as already-admitted member reads; getters the walk can see (inline accessor objects) still reject via the existing accessor rule.
- Component-tag spreads stay rejected because they build the child's props snapshot — `callSiteOk` excludes them, and `isAutoMemoPropsParam`'s rest admission documents that a getter-bearing props object must never reach a cached region.
- Measured motivation: with all three svg-dashboard state domains colocated in App (the idiomatic shape), Topology's non-bail accounted for ~130µs of every ui-only commit after #640.

## Changes

- `packages/octane/src/compiler/compile.js`: the walk marks spread attributes of `!isComponentTag` elements into a per-invocation WeakSet during the element's visit (parents walk before their attributes), and the blanket `SpreadAttribute`/`JSXSpreadAttribute` rejection exempts marked nodes. `hostMountSafe` stays spread-free through `isHostMountSafeTree`'s own attribute check; dev/server output is unchanged since every consumer gates on `ctx.autoMemo`.
- `packages/octane/tests/auto-memo.test.ts`: compiler admissions (props-object callee, destructured `@for` Topology shape, tsx map-lowered rows) and pinned rejections (component-tag spread in a body and at a call site, inline getter bag, computed-member argument, explicit ref beside a bag); plus a runtime cached-region scenario — bag applies on mount, a skip keeps the bag's ref and handler live (and pins mutation-invisibility under unchanged deps), re-entry applies changed keys, clears vanished keys, and swaps the bag ref old → null → new, unmount detaches.
- `benchmarks/baselines/ratios.json`: svg-dashboard guard notes updated with the 2026-08-08 observations (no ceiling changes).
- Changeset (`octane`, patch).

## Validation

- [x] `pnpm format:check` (scoped `format:files:check` over the changed files)
- [x] `pnpm typecheck`
- [x] `pnpm test` — full suite green on this branch's base
- [x] targeted tests: `packages/octane/tests/auto-memo.test.ts` (142 tests, octane + octane-prod projects); spread/ref/keyed neighbor suites. Red-checked both directions: without the widening the new tests fail (no region); with a deliberately neutered dep comparison the DOM re-diff assertions catch the wrong skip.
- Benchmarks (Playwright/Chromium, 20 iters): inline-App probe (ui state colocated in App) `pan_zoom` **134.0 ms → 0.6 ms**, `tooltip_swarm` 51.5 → 0.8 ms; committed-shape A/B isolating this change: `charts_tick` 4.2 → 2.9 ms, `tick_sparse` 3.7 → 0.8 ms, `series_toggle` 3.0 → 2.1 ms, always-miss ops flat within noise (`drag_nodes` +~0.1 ms, ~1.4%). Full 4-flavor `bench.mjs svg-dashboard --ratios` run passes all guards (re-run on this rebased base with the React-Compiler react column).

## Risk / follow-ups

- No dedicated hydration test for a spread bag inside a cached region: the first render is always a cache miss so the adoption path is unchanged, and the prod-hydrate suites pass, but the specific combination is untested.
- The svg-dashboard octane fixture keeps its Viewport descriptor-prop shape; flipping it to the idiomatic colocated shape is now viable (the pan_zoom guard notes record the probe numbers) but is a fixture/fairness decision for the bench suite, not this change.
- Contract note: an in-place bag mutation under unchanged region deps is invisible while the region skips — the same trade every autoMemo tier (and `React.memo`) already makes; the runtime test pins it deliberately.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Widens compiler memoization eligibility; correctness hinges on region guards and spread re-diff parity, though the new compiler and runtime tests target the risky cases.
> 
> **Overview**
> **autoMemo** no longer treats `{...bag}` on **host** elements as an automatic disqualifier. Patterns like `<path d={e.d} {...e.attrs}>` can keep **region** and **keyed-list** caches; **component-tag** spreads still fail closed, and unsafe spread arguments (getters, computed keys, refs) still do.
> 
> In `containsAutoMemoUnsafeStructure`, host-element visits register their spread attributes in a per-walk `WeakSet` before children are walked; only spreads **not** in that set trigger the old reject path.
> 
> New **auto-memo** tests cover admitted shapes (including Topology-style `@for` rows and TSX `map`), pinned rejections, and a runtime scenario where an unchanged-deps skip preserves DOM/refs/handlers while re-entry updates and clears spread keys. Benchmark ratio **notes** for svg-dashboard are refreshed; ceilings are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 241325b94630e520997181415005b6a05e2a0d7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->