### PR TITLE
perf: skip unchanged nested keyed rows in streaming chat

### DIFF
--- a/.changeset/compiler-nested-host-list-memoization.md
+++ b/.changeset/compiler-nested-host-list-memoization.md
@@ -1,0 +1,6 @@
+---
+'octane': patch
+---
+
+Skip unchanged keyed rows containing nested host-only lists or conditionals
+while preserving imported dependency invalidation and structured row ownership.

--- a/benchmarks/chat-stream/README.md
+++ b/benchmarks/chat-stream/README.md
@@ -69,9 +69,10 @@ sample, so scaling is more conversation, not artificial repetition.
   state round-trip (the value prop reasserts from state).
 - `comments_conv` — comment-node DOM weight at steady state (marker tripwire).
 
-The `bundle-size` suite builds these apps too (`chat_*` ops) and the octane
-source is in the `codegen-size` corpus. React's column uses a production build
-with React Compiler enabled, served through Vite's production preview.
+The `bundle-size` suite builds these apps too (`chat_*` ops), and the Octane
+source is in the `codegen-size` corpus. The suite runner builds every framework
+in production mode before starting its preview server; React's production build
+also enables React Compiler.
 
 Native **Preact** (`:5262`) and runes-mode **Svelte 5** (`:5273`) fixtures use
 the same deterministic corpus and window contract. Their state is immutable at
@@ -83,3 +84,18 @@ the conversation/message boundary and timed commits finish before returning.
 node benchmarks/bench.mjs chat-stream       # via the suite runner (starts servers)
 node benchmarks/bench.mjs --quick chat-stream
 ```
+
+The separate, untimed production-work gate uses Chromium precise coverage to
+check that one token update in a 200-message history rerenders only the changed
+message. It also verifies unchanged message identity and content, the updated
+reply, and an unrelated controlled-composer update:
+
+```bash
+CHAT_STREAM_WORK=1 pnpm --filter octane-tsrx-chat-stream build
+pnpm --filter octane-tsrx-chat-stream preview
+pnpm --dir benchmarks/chat-stream bench:work
+```
+
+`TARGET_URL` overrides the preview address, and `WORK_JSON` saves the measured
+counts. The work build is deliberately unminified; the normal benchmark keeps
+its minified production bundle.

--- a/benchmarks/chat-stream/octane-tsrx/vite.config.js
+++ b/benchmarks/chat-stream/octane-tsrx/vite.config.js
@@ -8,7 +8,9 @@ export default defineConfig({
 	},
 	build: {
 		target: 'esnext',
-		minify: 'terser',
+		// Keep production function names available for the separate, untimed
+		// precise-coverage gate; normal timing runs retain their terser build.
+		minify: process.env.CHAT_STREAM_WORK === '1' ? false : 'terser',
 		terserOptions: {
 			compress: { passes: 5, reduce_vars: false, inline: 0, toplevel: true },
 			mangle: { toplevel: true },

--- a/benchmarks/chat-stream/package.json
+++ b/benchmarks/chat-stream/package.json
@@ -6,7 +6,8 @@
   "description": "Streaming-chat benchmark umbrella - drives each framework's chat app through deterministic token-stream drains via Playwright.",
   "scripts": {
     "bench": "node run.mjs",
-    "bench:long": "node run.mjs 16"
+    "bench:long": "node run.mjs 16",
+    "bench:work": "node work.mjs"
   },
   "dependencies": {
     "playwright": "catalog:default"

--- a/benchmarks/chat-stream/work.mjs
+++ b/benchmarks/chat-stream/work.mjs
@@ -1,0 +1,189 @@
+// Untimed production-work gate for the Octane streaming-chat fixture.
+// Chromium precise coverage observes generated row helpers without adding
+// source-level probes that would invalidate the compiler's purity proof.
+
+import fs from 'node:fs';
+import { chromium } from 'playwright';
+
+const URL = process.env.TARGET_URL || 'http://localhost:5250/';
+const METRICS = ['ChatApp', 'renderBlockInner', 'forBlock', 'updateSurvivor', 'segText', 'setText'];
+const OPS = [
+	{
+		name: 'history_pump',
+		streaming: true,
+		exact: { ChatApp: 1, setText: 1 },
+		max: {
+			renderBlockInner: 7,
+			itemBodies: 4,
+			forBlock: 3,
+			updateSurvivor: 206,
+			segText: 2,
+		},
+	},
+	{
+		name: 'history_type',
+		streaming: false,
+		exact: { ChatApp: 1 },
+		max: {
+			renderBlockInner: 1,
+			itemBodies: 0,
+			forBlock: 0,
+			updateSurvivor: 0,
+			segText: 0,
+			setText: 0,
+		},
+	},
+];
+
+function callCounts(coverage) {
+	const counts = Object.fromEntries(METRICS.map((metric) => [metric, 0]));
+	counts.itemBodies = 0;
+	for (const script of coverage.result) {
+		if (!script.url.includes('/assets/')) continue;
+		for (const fn of script.functions) {
+			const calls = fn.ranges[0]?.count ?? 0;
+			if (fn.functionName.startsWith('__item$')) counts.itemBodies += calls;
+			if (Object.prototype.hasOwnProperty.call(counts, fn.functionName)) {
+				counts[fn.functionName] += calls;
+			}
+		}
+	}
+	if (counts.ChatApp === 0 || counts.renderBlockInner === 0) {
+		throw new Error('Missing named production call coverage; rebuild with CHAT_STREAM_WORK=1.');
+	}
+	return counts;
+}
+
+async function prepare(page, streaming) {
+	await page.goto(URL, { waitUntil: 'load' });
+	await page.waitForSelector('.prompt', { timeout: 10_000 });
+	await page.evaluate((needsStreaming) => {
+		window.__reset();
+		document.querySelector('.conv-tab[data-conv="1"]').click();
+		if (document.querySelectorAll('.messages .message').length !== 200) {
+			throw new Error('Expected the 200-message conversation.');
+		}
+		if (!needsStreaming) return;
+		const input = document.querySelector('.prompt');
+		Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set.call(
+			input,
+			'Benchmark: stream into long history',
+		);
+		input.dispatchEvent(new Event('input', { bubbles: true }));
+		document.querySelector('.send').click();
+		if (document.querySelectorAll('.messages .message').length !== 202) {
+			throw new Error('Expected one user message and one streaming reply.');
+		}
+		if (document.querySelectorAll('.messages .streaming').length !== 1) {
+			throw new Error('Expected exactly one streaming reply.');
+		}
+	}, streaming);
+}
+
+async function measure(browser, op) {
+	const context = await browser.newContext();
+	const page = await context.newPage();
+	const cdp = await context.newCDPSession(page);
+	let profiling = false;
+	try {
+		await cdp.send('Profiler.enable');
+		await cdp.send('Profiler.startPreciseCoverage', {
+			callCount: true,
+			detailed: true,
+			allowTriggeredUpdates: false,
+		});
+		profiling = true;
+		await prepare(page, op.streaming);
+		await cdp.send('Profiler.takePreciseCoverage');
+		await page.evaluate((streaming) => {
+			const rows = Array.from(document.querySelectorAll('.messages .message'));
+			const texts = rows.map((row) => row.textContent);
+			if (streaming) {
+				const remaining = window.__pump(8);
+				if (remaining <= 0) throw new Error('Token pump unexpectedly settled the reply.');
+			} else {
+				const input = document.querySelector('.prompt');
+				Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set.call(input, 'x');
+				input.dispatchEvent(new Event('input', { bubbles: true }));
+				if (input.value !== 'x') throw new Error('Controlled composer lost its updated value.');
+			}
+
+			const nextRows = Array.from(document.querySelectorAll('.messages .message'));
+			if (nextRows.length !== rows.length) throw new Error('Message count changed.');
+			for (let index = 0; index < rows.length; index++) {
+				if (nextRows[index] !== rows[index]) {
+					throw new Error(`Message ${index} unexpectedly lost its DOM identity.`);
+				}
+				if (streaming && index === rows.length - 1) {
+					if (nextRows[index].textContent === texts[index]) {
+						throw new Error('Streaming reply did not receive its new tokens.');
+					}
+				} else if (nextRows[index].textContent !== texts[index]) {
+					throw new Error(`Untouched message ${index} unexpectedly changed.`);
+				}
+			}
+		}, op.streaming);
+		return callCounts(await cdp.send('Profiler.takePreciseCoverage'));
+	} finally {
+		if (profiling) {
+			await cdp.send('Profiler.stopPreciseCoverage').catch(() => {});
+			await cdp.send('Profiler.disable').catch(() => {});
+		}
+		await context.close();
+	}
+}
+
+const browser = await chromium.launch({
+	headless: true,
+	args: ['--no-sandbox', '--js-flags=--jitless'],
+});
+const results = {};
+const failures = [];
+
+try {
+	for (const op of OPS) {
+		const counts = await measure(browser, op);
+		results[op.name] = counts;
+		for (const [metric, expected] of Object.entries(op.exact)) {
+			if (counts[metric] !== expected) {
+				failures.push(`${op.name}.${metric}: ${counts[metric]} !== ${expected}`);
+			}
+		}
+		for (const [metric, ceiling] of Object.entries(op.max)) {
+			if (counts[metric] > ceiling) {
+				failures.push(`${op.name}.${metric}: ${counts[metric]} exceeds ${ceiling}`);
+			}
+		}
+	}
+} finally {
+	await browser.close();
+}
+
+console.log(
+	'Operation     | app | render | item bodies | lists | survivors | text helpers | writes',
+);
+console.log(
+	'--------------+-----+--------+-------------+-------+-----------+--------------+-------',
+);
+for (const op of OPS) {
+	const counts = results[op.name];
+	console.log(
+		`${op.name.padEnd(13)} | ${String(counts.ChatApp).padStart(3)} | ${String(counts.renderBlockInner).padStart(6)} | ${String(counts.itemBodies).padStart(11)} | ${String(counts.forBlock).padStart(5)} | ${String(counts.updateSurvivor).padStart(9)} | ${String(counts.segText).padStart(12)} | ${String(counts.setText).padStart(5)}`,
+	);
+}
+
+if (process.env.WORK_JSON) {
+	fs.writeFileSync(
+		process.env.WORK_JSON,
+		JSON.stringify({ suite: 'chat-stream-work', target: URL, results, failures }, null, '\t') +
+			'\n',
+	);
+}
+
+if (failures.length > 0) {
+	console.error(`\n${failures.length} deterministic work gate failure(s):`);
+	for (const failure of failures) console.error(`  - ${failure}`);
+	process.exit(1);
+}
+
+console.log('\nAll deterministic streaming-chat work gates passed.');

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -3466,9 +3466,11 @@ function containsComponentCallOrControlFlow(stmts) {
 }
 
 /**
- * A host-only conditional can share its keyed row's immutable item/dependency
- * proof, but entering that conditional still needs the row's active scope. Keep
- * components and every other control-flow boundary on their existing path.
+ * A host-only conditional can share its containing row's immutable
+ * item/dependency proof, including through a narrowly proven nested keyed list.
+ * Entering either construct still needs the row's active scope. Lists without a
+ * conditional, components, opaque list expressions, and every other
+ * control-flow boundary remain on their existing path.
  */
 function hasOnlyHostConditionalItemBodies(stmts) {
 	let hasConditional = false;
@@ -3497,6 +3499,28 @@ function hasOnlyHostConditionalItemBodies(stmts) {
 		}
 		if (type === 'IfStatement' || type === 'JSXIfExpression') {
 			hasConditional = true;
+		} else if (type === 'JSXForExpression') {
+			const declaration = node.left;
+			const item = declaration?.declarations?.[0]?.id;
+			const key = unwrapTsExpr(node.key);
+			if (
+				node.await === true ||
+				node.index != null ||
+				node.nativeArrayMap !== undefined ||
+				declaration?.type !== 'VariableDeclaration' ||
+				declaration.declarations?.length !== 1 ||
+				item?.type !== 'Identifier' ||
+				!isAutoMemoCalculationDependency(node.right) ||
+				key?.type !== 'MemberExpression' ||
+				key.computed === true ||
+				key.optional === true ||
+				key.object?.type !== 'Identifier' ||
+				key.object.name !== item.name ||
+				key.property?.type !== 'Identifier'
+			) {
+				disallowed = true;
+				return;
+			}
 		} else if (
 			type === 'ForStatement' ||
 			type === 'ForInStatement' ||
@@ -3506,7 +3530,6 @@ function hasOnlyHostConditionalItemBodies(stmts) {
 			type === 'TryStatement' ||
 			type === 'SwitchStatement' ||
 			type === 'ActivityStatement' ||
-			type === 'JSXForExpression' ||
 			type === 'JSXTryExpression' ||
 			type === 'JSXSwitchExpression' ||
 			type === 'JSXActivityExpression' ||
@@ -22767,7 +22790,7 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 		// survivor shortcut has no compiler-cache epoch cell to consult).
 		if (itemMemoContextAware && autoMemoDeps === null) itemMemo = false;
 		const hostPure = !hasParentClosure && !hasHook && !hasNestedComp && !hasRenderCall;
-		const conditionalHostDepEligible =
+		const structuredHostDepEligible =
 			ctx.autoMemo === true &&
 			hasNestedComp &&
 			hasParentClosure &&
@@ -22775,14 +22798,24 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 			!hasRenderCall &&
 			node.nativeArrayMap === undefined &&
 			autoMemoDeps !== null &&
-			autoMemoDeps.every((name) => seenDeps.has(name)) &&
+			autoMemoDeps.every((name) => seenDeps.has(name) || ctx.importedNames.has(name)) &&
 			!containsAutoMemoContextRead(bodyAst, ctx) &&
 			hasOnlyHostConditionalItemBodies(subStmts);
+		if (structuredHostDepEligible) {
+			// The whole-list cache already witnesses imported projections. A row
+			// survivor now makes the same decision independently, so its existing
+			// dependency tuple must witness those live bindings as well.
+			for (const name of autoMemoDeps) {
+				if (seenDeps.has(name)) continue;
+				seenDeps.add(name);
+				depNames.push(name);
+			}
+		}
 		const hostDepEligible =
 			!hostPure &&
 			!hasHook &&
 			hasParentClosure &&
-			(!hasNestedComp || conditionalHostDepEligible) &&
+			(!hasNestedComp || structuredHostDepEligible) &&
 			!hasRenderCall;
 		if (itemMemo && itemMemoWitnesses.length > 0) {
 			pure = hostPure;
@@ -22792,7 +22825,7 @@ function makeForCall(node, ctx, inlinedSubs, parentNs = 'html', cssHash = null) 
 			pure = hostPure || (itemMemo && depNames.length === 0);
 			depEligible = !pure && !hasHook && (hostDepEligible || (itemMemo && depNames.length > 0));
 		}
-		requiresScope = depEligible && conditionalHostDepEligible;
+		requiresScope = depEligible && structuredHostDepEligible;
 		depNames.sort();
 	}
 

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -4390,6 +4390,9 @@ function renderBlockInner(block: Block): void {
 		)
 			__profileEndRender(profileFrame, profileDidThrow, profileThrown);
 		if (!renderCompleted) {
+			// A suspended or throwing keyed survivor already received its next item.
+			// Its incomplete body must run on retry instead of taking a stale pure bail.
+			if (block.forSlot !== null) block.forSlot.cachedDeps = null;
 			effectEventTarget.length = effectEventCheckpoint;
 			effectEventActionTarget.length = effectEventActionCheckpoint;
 		}

--- a/packages/octane/tests/_fixtures/for.tsrx
+++ b/packages/octane/tests/_fixtures/for.tsrx
@@ -1,6 +1,7 @@
 import {
 	Activity as ActivitySentinel,
 	createContext,
+	normalizeClass,
 	type OctaneNode,
 	startTransition,
 	use,
@@ -570,6 +571,124 @@ export function NestedConditionalTransition(props: {
 			<span id="nested-transition-fallback">{'loading'}</span>
 		}
 	</div>
+}
+
+interface NestedProjectedSegment {
+	id: number;
+	label: string;
+	code: boolean;
+}
+
+interface NestedProjectedGroup {
+	id: number;
+	label: string;
+	segments: NestedProjectedSegment[];
+}
+
+export function NestedProjectedHostList(props: {
+	groups: NestedProjectedGroup[];
+	prefix: string;
+	onPick: (groupId: number, segmentId: number, prefix: string) => void;
+}) @{
+	const prefix = props.prefix;
+	const onPick = props.onPick;
+	<section id="nested-projected-list">
+		@for (const group of props.groups; key group.id) {
+			<article class="nested-projected-group" data-projected-group={'' + group.id}>
+				<h3>{prefix + ':' + group.label}</h3>
+				<ul>
+					@for (const segment of group.segments; key segment.id) {
+						@if (segment.code) {
+							<li class="nested-projected-code" data-projected-segment={'' + segment.id}>
+								<button onClick={() => onPick(group.id, segment.id, prefix)}>
+									{prefix + ':' + normalizeClass(segment.label)}
+								</button>
+								<input class="nested-projected-input" defaultValue={segment.label} />
+							</li>
+						} @else {
+							<li class="nested-projected-text" data-projected-segment={'' + segment.id}>
+								<button onClick={() => onPick(group.id, segment.id, prefix)}>
+									{prefix + ':' + normalizeClass(segment.label)}
+								</button>
+							</li>
+						}
+					} @empty {
+						<li class="nested-projected-empty">{prefix + ':' + group.label + ':empty'}</li>
+					}
+				</ul>
+			</article>
+		}
+	</section>
+}
+
+export function NestedProjectedHostBoundary(props: {
+	groups: NestedProjectedGroup[];
+	prefix: string;
+	onPick: (groupId: number, segmentId: number, prefix: string) => void;
+}) @{
+	@try {
+		<NestedProjectedHostList groups={props.groups} prefix={props.prefix} onPick={props.onPick} />
+	} @pending {
+		<span id="nested-projected-pending">{'loading'}</span>
+	} @catch (error, reset) {
+		<button
+			id="nested-projected-retry"
+			onClick={reset}
+		>{(error as Error).message as string}</button>
+	}
+}
+
+export function NestedProjectedMethodList(props: {
+	groups: Array<{ id: number; segments: Array<{ id: number; read: () => string }> }>;
+	prefix: string;
+}) @{
+	const prefix = props.prefix;
+	<section id="nested-projected-method-list">
+		@for (const group of props.groups; key group.id) {
+			<article>
+				@for (const segment of group.segments; key segment.id) {
+					@if (segment.id > 0) {
+						<span class="nested-projected-method">{prefix + ':' + segment.read()}</span>
+					}
+				}
+			</article>
+		}
+	</section>
+}
+
+function NestedProjectedContextProbe(props: {
+	label: string;
+	onRef: (element: HTMLSpanElement | null) => void;
+}) @{
+	const value = use(FastRowContext);
+	<span class="nested-projected-context" ref={props.onRef}>{value + ':' + props.label}</span>
+}
+
+export function NestedProjectedOpaqueList(props: {
+	groups: NestedProjectedGroup[];
+	value: string;
+	visible: boolean;
+	onRef: (element: HTMLSpanElement | null) => void;
+}) @{
+	const visible = props.visible;
+	const onRef = props.onRef;
+	<FastRowContext.Provider value={props.value}>
+		<section id="nested-projected-opaque-list">
+			@for (const group of props.groups; key group.id) {
+				<article>
+					@for (const segment of group.segments; key segment.id) {
+						@if (visible) {
+							<Activity mode={readNestedConditionalActivityMode()}>
+								<NestedProjectedContextProbe label={normalizeClass(segment.label)} onRef={onRef} />
+							</Activity>
+						} @else {
+							<span class="nested-projected-opaque-placeholder">{'hidden'}</span>
+						}
+					}
+				</article>
+			}
+		</section>
+	</FastRowContext.Provider>
 }
 
 interface NestedReorderGroup {

--- a/packages/octane/tests/for.test.ts
+++ b/packages/octane/tests/for.test.ts
@@ -14,6 +14,10 @@ import {
 	NestedConditionalCallBodyList,
 	NestedConditionalList,
 	NestedConditionalTransition,
+	NestedProjectedHostBoundary,
+	NestedProjectedHostList,
+	NestedProjectedMethodList,
+	NestedProjectedOpaqueList,
 	PlainCalleeList,
 	KeyedSelectionList,
 	KeyedSelectionTransition,
@@ -1023,6 +1027,260 @@ describe('large keyed list fills', () => {
 		);
 		expect(r.find('#fast-host-transition-value').textContent).toBe('resolved');
 		r.unmount();
+	});
+});
+
+describe('nested keyed host projections', () => {
+	const makeGroups = () => [
+		{
+			id: 1,
+			label: 'first',
+			segments: [
+				{ id: 11, label: 'one', code: false },
+				{ id: 12, label: 'two', code: true },
+			],
+		},
+		{
+			id: 2,
+			label: 'second',
+			segments: [{ id: 21, label: 'three', code: false }],
+		},
+		{ id: 3, label: 'third', segments: [] },
+	];
+
+	it('keeps stable nested rows while refreshing immutable values, dependencies, and handlers', () => {
+		const groups = makeGroups();
+		const selected: string[] = [];
+		const onPick = (groupId: number, segmentId: number, prefix: string) => {
+			selected.push(`before:${groupId}:${segmentId}:${prefix}`);
+		};
+		const props = { groups, prefix: 'before', onPick };
+		const root = mount(NestedProjectedHostList, props);
+		const originalGroups = root.findAll('.nested-projected-group');
+		const input = root.find('.nested-projected-input') as HTMLInputElement;
+		input.value = 'unfinished edit';
+
+		const updated = [
+			groups[0]!,
+			{
+				...groups[1]!,
+				segments: [{ ...groups[1]!.segments[0]!, label: 'updated', code: true }],
+			},
+			groups[2]!,
+		];
+		root.update(NestedProjectedHostList, { ...props, groups: updated });
+		expect(root.findAll('.nested-projected-group')).toEqual(originalGroups);
+		expect(root.find('[data-projected-segment="21"] button').textContent).toBe('before:updated');
+		expect(root.find('.nested-projected-input')).toBe(input);
+		expect(input.value).toBe('unfinished edit');
+
+		const nextPick = (groupId: number, segmentId: number, prefix: string) => {
+			selected.push(`after:${groupId}:${segmentId}:${prefix}`);
+		};
+		root.update(NestedProjectedHostList, { groups: updated, prefix: 'after', onPick: nextPick });
+		expect(root.findAll('.nested-projected-group h3').map((title) => title.textContent)).toEqual([
+			'after:first',
+			'after:second',
+			'after:third',
+		]);
+		expect(root.find('.nested-projected-empty').textContent).toBe('after:third:empty');
+		expect(input.value).toBe('unfinished edit');
+		root.click('[data-projected-segment="12"] button');
+		expect(selected).toEqual(['after:1:12:after']);
+		root.unmount();
+	});
+
+	it('preserves keyed identities through nested reordering, removal, and empty-arm changes', () => {
+		const groups = makeGroups();
+		const props = { groups, prefix: 'group', onPick: () => {} };
+		const root = mount(NestedProjectedHostList, props);
+		const groupNodes = new Map(
+			root
+				.findAll('.nested-projected-group')
+				.map((group) => [Number(group.getAttribute('data-projected-group')), group]),
+		);
+		const segmentNodes = new Map(
+			root
+				.findAll('[data-projected-segment]')
+				.map((segment) => [Number(segment.getAttribute('data-projected-segment')), segment]),
+		);
+		const reorderedFirst = { ...groups[0]!, segments: groups[0]!.segments.toReversed() };
+		const reordered = [groups[2]!, reorderedFirst, groups[1]!];
+
+		root.update(NestedProjectedHostList, { ...props, groups: reordered });
+		expect(
+			root
+				.findAll('.nested-projected-group')
+				.map((group) => Number(group.getAttribute('data-projected-group'))),
+		).toEqual([3, 1, 2]);
+		expect(root.find('[data-projected-group="1"]')).toBe(groupNodes.get(1));
+		expect(root.find('[data-projected-segment="12"]')).toBe(segmentNodes.get(12));
+		expect(root.find('[data-projected-segment="11"]')).toBe(segmentNodes.get(11));
+		expect(
+			Array.from(
+				root.find('[data-projected-group="1"]').querySelectorAll('[data-projected-segment]'),
+			).map((segment) => Number(segment.getAttribute('data-projected-segment'))),
+		).toEqual([12, 11]);
+
+		const emptiedFirst = { ...reorderedFirst, segments: [] };
+		root.update(NestedProjectedHostList, {
+			...props,
+			groups: [groups[2]!, emptiedFirst, groups[1]!],
+		});
+		expect(root.find('[data-projected-group="1"]')).toBe(groupNodes.get(1));
+		expect(root.find('[data-projected-group="1"] .nested-projected-empty').textContent).toBe(
+			'group:first:empty',
+		);
+
+		const filledThird = {
+			...groups[2]!,
+			segments: [{ id: 31, label: 'restored', code: false }],
+		};
+		root.update(NestedProjectedHostList, { ...props, groups: [filledThird, emptiedFirst] });
+		expect(root.find('[data-projected-group="3"]')).toBe(groupNodes.get(3));
+		expect(root.find('[data-projected-segment="31"] button').textContent).toBe('group:restored');
+		expect(root.findAll('[data-projected-group="2"]')).toHaveLength(0);
+		root.unmount();
+	});
+
+	it('retries suspended nested conditional rows before finishing an outer and inner reorder', async () => {
+		const groups = makeGroups();
+		let resolve!: (value: string) => void;
+		const promise = new Promise<string>((done) => {
+			resolve = done;
+		});
+		const props = { groups, prefix: 'group', onPick: () => {} };
+		const root = mount(NestedProjectedHostBoundary, props);
+		const first = groups[0]!;
+		const reordered = [
+			groups[2]!,
+			groups[1]!,
+			{
+				...first,
+				segments: first.segments.toReversed().map((segment) =>
+					segment.id === 11
+						? {
+								id: segment.id,
+								code: segment.code,
+								get label() {
+									return use(promise);
+								},
+							}
+						: { ...segment },
+				),
+			},
+		];
+
+		root.update(NestedProjectedHostBoundary, { ...props, groups: reordered });
+		expect(root.find('#nested-projected-pending').textContent).toBe('loading');
+
+		await act(() => resolve('resolved one'));
+		expect(
+			root
+				.findAll('.nested-projected-group')
+				.map((group) => Number(group.getAttribute('data-projected-group'))),
+		).toEqual([3, 2, 1]);
+		expect(
+			Array.from(
+				root.find('[data-projected-group="1"]').querySelectorAll('[data-projected-segment]'),
+			).map((segment) => Number(segment.getAttribute('data-projected-segment'))),
+		).toEqual([12, 11]);
+		expect(root.find('[data-projected-segment="11"] button').textContent).toBe(
+			'group:resolved one',
+		);
+		root.unmount();
+	});
+
+	it('continues reading live nested receiver methods when outer item identities are stable', () => {
+		let current = 'initial';
+		const group = { id: 1, segments: [{ id: 11, read: () => current }] };
+		const props = { groups: [group], prefix: 'value' };
+		const root = mount(NestedProjectedMethodList, props);
+		expect(root.find('.nested-projected-method').textContent).toBe('value:initial');
+
+		current = 'updated';
+		root.update(NestedProjectedMethodList, { ...props, groups: [group] });
+		expect(root.find('.nested-projected-method').textContent).toBe('value:updated');
+		root.unmount();
+	});
+
+	it('keeps nested Activity visibility, context consumers, and callback refs live', () => {
+		const first = makeGroups()[0]!;
+		const group = { ...first, segments: [first.segments[0]!] };
+		const refs: Array<HTMLSpanElement | null> = [];
+		const onRef = (element: HTMLSpanElement | null) => {
+			refs.push(element);
+		};
+		const props = { groups: [group], value: 'initial', visible: true, onRef };
+		const root = mount(NestedProjectedOpaqueList, props);
+		const original = root.find('.nested-projected-context') as HTMLSpanElement;
+
+		try {
+			expect(original.textContent).toBe('initial:one');
+			expect(refs).toEqual([original]);
+
+			setNestedConditionalActivityMode('hidden');
+			root.update(NestedProjectedOpaqueList, { ...props, groups: [group] });
+			expect(original.style.display).toBe('none');
+
+			setNestedConditionalActivityMode('visible');
+			root.update(NestedProjectedOpaqueList, { ...props, groups: [group], value: 'updated' });
+			expect(root.find('.nested-projected-context')).toBe(original);
+			expect(original.style.display).toBe('');
+			expect(original.textContent).toBe('updated:one');
+
+			root.update(NestedProjectedOpaqueList, {
+				...props,
+				groups: [group],
+				value: 'updated',
+				visible: false,
+			});
+			expect(root.findAll('.nested-projected-context')).toHaveLength(0);
+			expect(root.find('.nested-projected-opaque-placeholder').textContent).toBe('hidden');
+			expect(refs.at(-1)).toBeNull();
+		} finally {
+			root.unmount();
+			setNestedConditionalActivityMode('visible');
+		}
+	});
+
+	it('adopts nested projected rows and preserves pre-hydration edits and live handlers', () => {
+		const groups = makeGroups();
+		const picked: string[] = [];
+		const onPick = (groupId: number, segmentId: number, prefix: string) => {
+			picked.push(`${groupId}:${segmentId}:${prefix}`);
+		};
+		const props = { groups, prefix: 'server', onPick };
+		const server = loadServerFixture('packages/octane/tests/_fixtures/for.tsrx', {
+			compileOptions: { hmr: false, dev: false },
+		});
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		container.innerHTML = ServerRuntime.renderToString(server.NestedProjectedHostList, props).html;
+		const originalGroups = Array.from(container.querySelectorAll('.nested-projected-group'));
+		const input = container.querySelector('.nested-projected-input') as HTMLInputElement;
+		input.value = 'typed before hydration';
+		const root = hydrateRoot(container, NestedProjectedHostList, props);
+		flushSync(() => {});
+
+		expect(Array.from(container.querySelectorAll('.nested-projected-group'))).toEqual(
+			originalGroups,
+		);
+		expect(container.querySelector('.nested-projected-input')).toBe(input);
+		expect(input.value).toBe('typed before hydration');
+
+		flushSync(() => root.render(NestedProjectedHostList, { ...props, prefix: 'client' }));
+		expect(Array.from(container.querySelectorAll('.nested-projected-group'))).toEqual(
+			originalGroups,
+		);
+		expect(container.querySelector('[data-projected-segment="12"] button')?.textContent).toBe(
+			'client:two',
+		);
+		expect(input.value).toBe('typed before hydration');
+		(container.querySelector('[data-projected-segment="12"] button') as HTMLButtonElement).click();
+		expect(picked).toEqual(['1:12:client']);
+		root.unmount();
+		container.remove();
 	});
 });
 


### PR DESCRIPTION
## Summary

- Extend production keyed-row optimization to narrowly proven nested keyed lists and host-only conditionals, including imported dependency witnesses and active row-scope preservation.
- Invalidate incomplete keyed-row dependency snapshots only when rendering throws or suspends, preserving nested reorder/retry correctness without adding work to successful renders.
- Add consumer-visible coverage for immutable updates, nested reordering and empty branches, hydration, callbacks, context/Activity/ref exclusions, and suspended getter retries; add an untimed Chromium precise-coverage ChatStream work gate.
- A frozen, same-browser 50-pair production audit measured history streaming at **0.583 → 0.286 ms (51% faster)** and fine streaming at **0.519 → 0.425 ms (18.2% faster)**; unchanged-history message-row renders dropped **202 → 1** and total block renders **208 → 7**.

## Validation

- [ ] `pnpm format:check` — repository-wide command not run; explicit formatting checks pass for all nine changed files.
- [ ] `pnpm typecheck` — repository-wide command not run; the complete Octane package and scoped compiler/runtime/TSRX fixture/test checks pass.
- [ ] `pnpm test` — root wrapper not run; the direct development/production/ARIA/SSR Vitest sweep passes below.
- [x] targeted tests: **823 files, 11,383 tests passed, 2 existing skips, 0 failures** across `octane`, `octane-prod`, `aria`, and `aria-ssr` after rebasing onto current upstream.
- [x] Focused post-transplant keyed-list, suspended-retry, compiler frozen-AST, emission, and source-map suites: **397 passed**.
- [x] `pnpm sync`; changeset validation; scoped formatting, full Octane-package typechecking, and scoped compiler/runtime/TSRX typechecking.
- [x] Fresh production precise-coverage gate: **7 block renders, 4 total item helpers, 1 changed message row, 1 text write**; controlled composer updates perform zero message-list work.
- [x] Current-upstream seven-framework ChatStream benchmark and ratio guards: **3/3 passed**; Octane ties fastest for fine/coarse streaming and is fastest for long-history updates.
- [x] Clean-upstream bundle audit: the broader bundle-size suite's **14 existing failures are not introduced**. The borderline cross-dialect guard already fails clean upstream (**2914/2371 = 1.2290 > 1.2**) and candidate (**2915/2370 = 1.2300**); both affected applications have byte-identical compiler output.

## Risk / follow-ups

- The optimization remains restricted to proven host-only conditional/nested keyed structures; components, context, Activity, refs, opaque methods, unsafe keys, and unsupported loop forms keep their existing conservative behavior.
- Suspended or throwing survivors invalidate only on the existing failed-render path. The normalized ChatStream application grows **1 gzip byte**; its framework/application total grows **44 gzip bytes**.
- Existing upstream/toolchain bundle-ratio failures remain out of scope and were reproduced independently on the same machine.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches compiler purity/memo eligibility and runtime keyed-list survivor caching; incorrect bail-out could skip updates in nested lists, though scope is restricted to proven host-only structures and suspend/throw invalidation is added.
> 
> **Overview**
> **Compiler/runtime:** Keyed `@for` survivors can now bail out when dependencies are unchanged for rows whose bodies are only host markup, `@if` branches, and narrowly proven inner keyed lists (`item.id`-style keys on auto-memo iterables). Eligibility is renamed to `structuredHostDepEligible`; imported bindings count toward row dependency witnesses, and row scope stays active for these structured bodies. On render throw or suspend, `forSlot.cachedDeps` is cleared so retries do not reuse a stale pure skip.
> 
> **Benchmarks:** Chat-stream adds an untimed `bench:work` Playwright gate (Chromium precise coverage) that caps block/item/survivor work for a single token pump in a 200-message history and expects zero list work on composer-only updates; the Octane Vite build can disable minify via `CHAT_STREAM_WORK=1` so named helpers stay observable.
> 
> **Tests:** New nested projected-host fixtures and Vitest coverage for stable DOM through nested reorder/empty arms, hydration, suspended getter retries, live method reads, and exclusions (Activity, context, refs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4505e3e2afc7d731f10eb5b4d7b8df4043fa253. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->