### PR TITLE
ci: track ready for review prs via comment and label

### DIFF
--- a/.github/workflows/review-readiness-label.yml
+++ b/.github/workflows/review-readiness-label.yml
@@ -1,0 +1,79 @@
+name: Review readiness label
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+concurrency:
+  # Keep label updates for the same pull request from racing.
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  update:
+    name: update label
+    if: github.event.issue.pull_request
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Apply the latest review readiness command
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const READY = "READY FOR REVIEW";
+            const WITHDRAWN = "REVIEW WITHDRAWN";
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.issue.number;
+
+            // Commands are case-sensitive standalone lines, so they can be
+            // accompanied by an explanation without matching ordinary prose.
+            const commands = context.payload.comment.body
+              .split(/\r?\n/)
+              .map((line) => line.trim())
+              .filter((line) => line === READY || line === WITHDRAWN);
+            const command = commands.at(-1);
+            if (!command) {
+              return;
+            }
+
+            // Refetch because another comment-driven run may have changed the
+            // labels since this event was queued.
+            const { data: issue } = await github.rest.issues.get({
+              owner,
+              repo,
+              issue_number,
+            });
+            const labels = issue.labels.map((label) =>
+              typeof label === "string" ? label : label.name,
+            );
+            const hasLabel = labels.includes(READY);
+
+            try {
+              if (command === READY && !hasLabel) {
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number,
+                  labels: [READY],
+                });
+                core.notice(`Applied ${READY} to #${issue_number}.`);
+              } else if (command === WITHDRAWN && hasLabel) {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number,
+                  name: READY,
+                });
+                core.notice(`Removed ${READY} from #${issue_number}.`);
+              } else {
+                core.notice(
+                  `${READY} is already ${hasLabel ? "applied to" : "absent from"} #${issue_number}.`,
+                );
+              }
+            } catch (error) {
+              core.setFailed(
+                `Could not update ${READY} on #${issue_number}: ${error.message}`,
+              );
+            }

--- a/.github/workflows/review-readiness-label.yml
+++ b/.github/workflows/review-readiness-label.yml
@@ -15,7 +15,8 @@ jobs:
     if: github.event.issue.pull_request
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      issues: read
+      pull-requests: write
 
     steps:
       - name: Apply the latest review readiness command

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -27,6 +27,10 @@ const draftWorkflow = readFileSync(
 	'utf8',
 );
 const labelWorkflow = readFileSync(path.join(REPO, '.github/workflows/label-pr.yml'), 'utf8');
+const reviewReadinessWorkflow = readFileSync(
+	path.join(REPO, '.github/workflows/review-readiness-label.yml'),
+	'utf8',
+);
 const vercelPreviewWorkflow = readFileSync(
 	path.join(REPO, '.github/workflows/vercel-preview.yml'),
 	'utf8',
@@ -817,6 +821,19 @@ describe('Pull request labels', () => {
 			/github-token: \$\{\{ secrets\.DRAFT_PR_TOKEN \|\| secrets\.GITHUB_TOKEN \}\}/,
 		);
 		assert.doesNotMatch(labelWorkflow, /actions\/checkout/);
+	});
+});
+
+describe('Review readiness label', () => {
+	test('handles only pull request comments with permission to update pull request labels', () => {
+		assert.match(
+			reviewReadinessWorkflow,
+			/on:\n {2}issue_comment:\n {4}types: \[created, edited\]/,
+		);
+		assert.match(reviewReadinessWorkflow, /^ {4}if: github\.event\.issue\.pull_request$/m);
+		assert.match(reviewReadinessWorkflow, /^ {6}issues: read$/m);
+		assert.match(reviewReadinessWorkflow, /^ {6}pull-requests: write$/m);
+		assert.doesNotMatch(reviewReadinessWorkflow, /actions\/checkout/);
 	});
 });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Automation-only change limited to PR label updates from trusted comment text; no application or auth code paths.
> 
> **Overview**
> Adds a **Review readiness label** GitHub Action so PR authors can signal review intent from comments instead of relying only on GitHub’s ready/draft UI.
> 
> On **created or edited** issue comments on pull requests, the workflow looks for case-sensitive standalone lines **`READY FOR REVIEW`** or **`REVIEW WITHDRAWN`** (last matching line wins), refetches current labels to avoid races, then **adds** or **removes** the **`READY FOR REVIEW`** label. Runs are serialized per PR via workflow concurrency; it uses `issues: read` and `pull-requests: write` with no checkout.
> 
> **`scripts/ci-workflow.test.mjs`** gains a small regression test that the workflow’s trigger, PR-only guard, permissions, and lack of checkout match expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 190f39e37b04b99519366d1b3b4c127d0c6e883d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->