### PR TITLE
ci: any reviewiers feedback not just cursor works with READY FOR REVIEW

### DIFF
--- a/.github/workflows/review-feedback-signal.yml
+++ b/.github/workflows/review-feedback-signal.yml
@@ -1,0 +1,19 @@
+name: Review feedback signal
+
+# Pull request review comment workflows receive a read-only token for fork PRs.
+# This unprivileged workflow only emits a completion event; the default-branch
+# readiness workflow performs the server-side reconciliation without consuming
+# code, artifacts, or other input from this run.
+on:
+  pull_request_review_comment:
+    types: [created]
+
+permissions: {}
+
+jobs:
+  signal:
+    name: signal review feedback
+    runs-on: ubuntu-latest
+    steps:
+      - name: Signal review feedback
+        run: "true"

--- a/.github/workflows/review-readiness-label.yml
+++ b/.github/workflows/review-readiness-label.yml
@@ -18,8 +18,7 @@ jobs:
     name: update label
     if: >-
       (github.event_name == 'issue_comment' && github.event.issue.pull_request) ||
-      (github.event_name == 'workflow_run' &&
-        github.event.workflow_run.conclusion == 'success')
+      github.event_name == 'workflow_run'
     runs-on: ubuntu-latest
     permissions:
       issues: read

--- a/.github/workflows/review-readiness-label.yml
+++ b/.github/workflows/review-readiness-label.yml
@@ -3,13 +3,14 @@ name: Review readiness label
 on:
   issue_comment:
     types: [created, edited]
-  check_run:
+  workflow_run:
+    workflows: [Review feedback signal]
     types: [completed]
 
 concurrency:
-  # A Cursor check on a fork commit does not carry a pull request number, so
-  # use its head SHA to serialize duplicate completion deliveries.
-  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.check_run.head_sha }}
+  # A review-feedback completion reconciles every labelled pull request, so
+  # serialize those global passes while keeping comment commands per PR.
+  group: ${{ github.workflow }}-${{ github.event.issue.number || 'review-feedback' }}
   cancel-in-progress: false
 
 jobs:
@@ -17,12 +18,10 @@ jobs:
     name: update label
     if: >-
       (github.event_name == 'issue_comment' && github.event.issue.pull_request) ||
-      (github.event_name == 'check_run' &&
-        github.event.check_run.app.slug == 'cursor' &&
-        github.event.check_run.name == 'Cursor Bugbot')
+      (github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     permissions:
-      checks: read
       issues: read
       pull-requests: write
 
@@ -33,11 +32,9 @@ jobs:
           script: |
             const READY = "READY FOR REVIEW";
             const WITHDRAWN = "REVIEW WITHDRAWN";
-            const CURSOR_LOGIN = "cursor";
-            const CURSOR_FINDING = "<!-- BUGBOT_BUG_ID:";
             const { owner, repo } = context.repo;
 
-            async function unresolvedCursorThreads(number) {
+            async function unresolvedReviewThreads(number) {
               const unresolved = [];
               let after = null;
               let hasNextPage;
@@ -52,8 +49,6 @@ jobs:
                             isResolved
                             comments(first: 1) {
                               nodes {
-                                author { login }
-                                body
                                 url
                               }
                             }
@@ -72,11 +67,7 @@ jobs:
 
                 for (const thread of threads.nodes) {
                   const first = thread.comments.nodes[0];
-                  if (
-                    !thread.isResolved &&
-                    first?.author?.login === CURSOR_LOGIN &&
-                    (first.body ?? "").includes(CURSOR_FINDING)
-                  ) {
+                  if (!thread.isResolved && first) {
                     unresolved.push(first.url);
                   }
                 }
@@ -87,7 +78,7 @@ jobs:
               return unresolved;
             }
 
-            async function openPullsAtHead(headSha) {
+            async function openReadyPulls() {
               const matches = [];
               let after = null;
               let hasNextPage;
@@ -97,7 +88,10 @@ jobs:
                   `query ($owner: String!, $repo: String!, $after: String) {
                     repository(owner: $owner, name: $repo) {
                       pullRequests(first: 100, after: $after, states: OPEN) {
-                        nodes { number headRefOid }
+                        nodes {
+                          number
+                          labels(first: 100) { nodes { name } }
+                        }
                         pageInfo { hasNextPage endCursor }
                       }
                     }
@@ -107,7 +101,9 @@ jobs:
                 const pulls = result.repository.pullRequests;
                 matches.push(
                   ...pulls.nodes
-                    .filter((pull) => pull.headRefOid === headSha)
+                    .filter((pull) =>
+                      pull.labels.nodes.some((label) => label.name === READY),
+                    )
                     .map((pull) => pull.number),
                 );
                 hasNextPage = pulls.pageInfo.hasNextPage;
@@ -149,15 +145,14 @@ jobs:
             }
 
             try {
-              if (context.eventName === "check_run") {
-                const headSha = context.payload.check_run.head_sha;
-                const numbers = await openPullsAtHead(headSha);
+              if (context.eventName === "workflow_run") {
+                const numbers = await openReadyPulls();
                 for (const number of numbers) {
                   const state = await pullState(number);
                   if (!state.isOpen || !state.hasLabel) {
                     continue;
                   }
-                  const unresolved = await unresolvedCursorThreads(number);
+                  const unresolved = await unresolvedReviewThreads(number);
                   if (unresolved.length === 0) {
                     continue;
                   }
@@ -167,8 +162,8 @@ jobs:
                     continue;
                   }
                   core.notice(
-                    `Removed ${READY} from #${number}: ${unresolved.length} unresolved Cursor ` +
-                      `finding${unresolved.length === 1 ? " remains" : "s remain"}. ` +
+                    `Removed ${READY} from #${number}: ${unresolved.length} unresolved review ` +
+                      `thread${unresolved.length === 1 ? " remains" : "s remain"}. ` +
                       unresolved.join(", "),
                   );
                 }
@@ -195,14 +190,14 @@ jobs:
               }
 
               if (command === READY) {
-                const unresolved = await unresolvedCursorThreads(number);
+                const unresolved = await unresolvedReviewThreads(number);
                 if (unresolved.length > 0) {
                   if (state.hasLabel) {
                     await removeReady(number);
                   }
                   core.notice(
-                    `Did not apply ${READY} to #${number}: ${unresolved.length} unresolved Cursor ` +
-                      `finding${unresolved.length === 1 ? " remains" : "s remain"}. ` +
+                    `Did not apply ${READY} to #${number}: ${unresolved.length} unresolved review ` +
+                      `thread${unresolved.length === 1 ? " remains" : "s remain"}. ` +
                       unresolved.join(", "),
                   );
                   return;

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -31,6 +31,10 @@ const reviewReadinessWorkflow = readFileSync(
 	path.join(REPO, '.github/workflows/review-readiness-label.yml'),
 	'utf8',
 );
+const reviewFeedbackWorkflow = readFileSync(
+	path.join(REPO, '.github/workflows/review-feedback-signal.yml'),
+	'utf8',
+);
 const vercelPreviewWorkflow = readFileSync(
 	path.join(REPO, '.github/workflows/vercel-preview.yml'),
 	'utf8',
@@ -826,16 +830,13 @@ describe('Pull request labels', () => {
 
 describe('Review readiness label', () => {
 	const READY = 'READY FOR REVIEW';
-	const HEAD_SHA = 'f'.repeat(40);
 
-	function cursorThread({ resolved = false } = {}) {
+	function reviewThread({ resolved = false } = {}) {
 		return {
 			isResolved: resolved,
 			comments: {
 				nodes: [
 					{
-						author: { login: 'cursor' },
-						body: '<!-- BUGBOT_BUG_ID: finding -->',
 						url: 'https://github.com/octanejs/octane/pull/487#discussion_r1',
 					},
 				],
@@ -848,8 +849,7 @@ describe('Review readiness label', () => {
 		body = READY,
 		labels = [],
 		threads = [],
-		headSha = HEAD_SHA,
-		matchingPulls = [{ number: 487, headRefOid: HEAD_SHA }],
+		matchingPulls = [{ number: 487, labels: { nodes: [{ name: READY }] } }],
 		removeErrorStatus,
 	} = {}) {
 		const added = [];
@@ -911,8 +911,8 @@ describe('Review readiness label', () => {
 			eventName,
 			repo: { owner: 'octanejs', repo: 'octane' },
 			payload:
-				eventName === 'check_run'
-					? { check_run: { head_sha: headSha } }
+				eventName === 'workflow_run'
+					? { workflow_run: { conclusion: 'success' } }
 					: { issue: { number: 487 }, comment: { body } },
 		};
 		const core = {
@@ -930,26 +930,35 @@ describe('Review readiness label', () => {
 		return { added, removed, notices, failures };
 	}
 
-	test('uses writable default-branch events without checking out pull request code', () => {
+	test('bridges unprivileged review comments to writable default-branch reconciliation', () => {
+		assert.match(
+			reviewFeedbackWorkflow,
+			/on:\n {2}pull_request_review_comment:\n {4}types: \[created\]/,
+		);
+		assert.match(reviewFeedbackWorkflow, /^permissions: \{\}$/m);
+		assert.doesNotMatch(reviewFeedbackWorkflow, /actions\/checkout/);
+
 		assert.match(
 			reviewReadinessWorkflow,
 			/on:\n {2}issue_comment:\n {4}types: \[created, edited\]/,
 		);
-		assert.match(reviewReadinessWorkflow, /check_run:\n {4}types: \[completed\]/);
+		assert.match(
+			reviewReadinessWorkflow,
+			/workflow_run:\n {4}workflows: \[Review feedback signal\]\n {4}types: \[completed\]/,
+		);
 		assert.match(
 			reviewReadinessWorkflow,
 			/github\.event_name == 'issue_comment' && github\.event\.issue\.pull_request/,
 		);
-		assert.match(reviewReadinessWorkflow, /github\.event\.check_run\.app\.slug == 'cursor'/);
-		assert.match(reviewReadinessWorkflow, /^ {6}checks: read$/m);
+		assert.match(reviewReadinessWorkflow, /github\.event\.workflow_run\.conclusion == 'success'/);
 		assert.match(reviewReadinessWorkflow, /^ {6}issues: read$/m);
 		assert.match(reviewReadinessWorkflow, /^ {6}pull-requests: write$/m);
 		assert.doesNotMatch(reviewReadinessWorkflow, /actions\/checkout/);
 	});
 
-	test('applies readiness when Cursor has no current unresolved findings', async () => {
+	test('applies readiness when every review thread is resolved', async () => {
 		const result = await runReadiness({
-			threads: [cursorThread({ resolved: true })],
+			threads: [reviewThread({ resolved: true })],
 		});
 
 		assert.deepEqual(result.added, [READY]);
@@ -957,8 +966,8 @@ describe('Review readiness label', () => {
 		assert.deepEqual(result.failures, []);
 	});
 
-	test('refuses readiness while a current Cursor finding is unresolved', async () => {
-		const result = await runReadiness({ threads: [cursorThread()] });
+	test('refuses readiness while any reviewer thread is unresolved', async () => {
+		const result = await runReadiness({ threads: [reviewThread()] });
 
 		assert.deepEqual(result.added, []);
 		assert.deepEqual(result.removed, []);
@@ -966,11 +975,11 @@ describe('Review readiness label', () => {
 		assert.deepEqual(result.failures, []);
 	});
 
-	test('removes readiness when Cursor completes with an unresolved finding', async () => {
+	test('removes readiness after new unresolved review feedback', async () => {
 		const result = await runReadiness({
-			eventName: 'check_run',
+			eventName: 'workflow_run',
 			labels: [READY],
-			threads: [cursorThread()],
+			threads: [reviewThread()],
 		});
 
 		assert.deepEqual(result.added, []);
@@ -981,9 +990,9 @@ describe('Review readiness label', () => {
 
 	test('treats a concurrently removed readiness label as already absent', async () => {
 		const result = await runReadiness({
-			eventName: 'check_run',
+			eventName: 'workflow_run',
 			labels: [READY],
-			threads: [cursorThread()],
+			threads: [reviewThread()],
 			removeErrorStatus: 404,
 		});
 
@@ -995,9 +1004,9 @@ describe('Review readiness label', () => {
 
 	test('still fails when readiness removal returns another API error', async () => {
 		const result = await runReadiness({
-			eventName: 'check_run',
+			eventName: 'workflow_run',
 			labels: [READY],
-			threads: [cursorThread()],
+			threads: [reviewThread()],
 			removeErrorStatus: 500,
 		});
 

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -950,7 +950,8 @@ describe('Review readiness label', () => {
 			reviewReadinessWorkflow,
 			/github\.event_name == 'issue_comment' && github\.event\.issue\.pull_request/,
 		);
-		assert.match(reviewReadinessWorkflow, /github\.event\.workflow_run\.conclusion == 'success'/);
+		assert.match(reviewReadinessWorkflow, /github\.event_name == 'workflow_run'/);
+		assert.doesNotMatch(reviewReadinessWorkflow, /github\.event\.workflow_run\.conclusion/);
 		assert.match(reviewReadinessWorkflow, /^ {6}issues: read$/m);
 		assert.match(reviewReadinessWorkflow, /^ {6}pull-requests: write$/m);
 		assert.doesNotMatch(reviewReadinessWorkflow, /actions\/checkout/);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions label automation with existing test coverage; no runtime or security-sensitive application code.
> 
> **Overview**
> **READY FOR REVIEW** gating no longer depends on Cursor Bugbot check runs or Bugbot-tagged threads. Any **unresolved review thread** blocks applying the label and can cause it to be removed.
> 
> A new **Review feedback signal** workflow runs on `pull_request_review_comment` with **no permissions** and only completes successfully (`run: "true"`). **Review readiness label** listens for that workflow’s `workflow_run` completion (instead of `check_run` for Cursor Bugbot) and, on that path, re-scans **all open PRs** that already carry **READY FOR REVIEW**, dropping the label when new unresolved threads appear. Concurrency for those global passes is serialized under a `review-feedback` group; comment commands stay per-PR.
> 
> `scripts/ci-workflow.test.mjs` asserts the bridge pattern and updates readiness tests for generic review threads and `workflow_run` events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c18f438011ce89366eea2dd4df3e07c7b8f1e6be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->