### PR TITLE
perf(cli): specialize disposable SPA starter roots

### DIFF
--- a/.changeset/cli-disposable-root-specialization.md
+++ b/.changeset/cli-disposable-root-specialization.md
@@ -1,0 +1,5 @@
+---
+'@octanejs/cli': patch
+---
+
+Generate disposable SPA application roots in the form recognized by Octane's production compiler, reducing scaffolded application bundle size without changing reusable root behavior.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -253,8 +253,8 @@ runtime cost separately. App-shaped
 sets use `todo_*`, `chat_*`, and `weather_*` operation prefixes; weather's shared
 service and formatting modules count as app code in both framework builds.
 
-`bundle-reachability` builds twenty independent public-entry feature fixtures
-across twenty-seven production builds with the production Octane compiler,
+`bundle-reachability` builds twenty-one independent public-entry feature fixtures
+across twenty-eight production builds with the production Octane compiler,
 disabled HMR/profiling, and normalized esbuild minification. The seven package
 side-effect fixtures each run through both Vite and esbuild. Each measured IIFE
 executes unchanged in an isolated jsdom realm; its visible DOM, interaction,
@@ -269,7 +269,10 @@ the component-owned-effects entry verifies that unused sibling styles, delegated
 events, and ViewTransition initialization disappear while retained styles and
 click handlers remain live.
 
-The two static-root fixtures deliberately measure different public contracts.
+The generated SPA scenario loads the actual CLI entry and complete landing-page
+templates without maintaining duplicate fixture sources; its compiled bundle
+must render the public page while excluding the reusable-root runtime. The two
+static-root fixtures deliberately measure different public contracts.
 `root-static-specialized` matches an application's disposable top-level
 `createRoot(container).render(ImportedComponent)` entry, allowing the production
 compiler to specialize the root. `root-static` retains an escaped, reusable
@@ -280,7 +283,7 @@ real and must not be disguised as the specialized entry.
 ceilings for every feature. Budgets leave about 3% deterministic headroom, with
 small byte-aligned allowances for tiny isolated entries. Each scenario publishes
 its committed ceiling as a
-same-run `*-budget` reference target, so eighty-one `maxRatio: 1` entries in
+same-run `*-budget` reference target, so eighty-four `maxRatio: 1` entries in
 `baselines/ratios.json` enforce all three metrics in the existing weekly/manual
 Bench CI workflow. Run the complete executable and byte guard directly with:
 

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -26,6 +26,30 @@
   {
     "suite": "bundle-reachability",
     "op": "raw",
+    "target": "cli-spa-starter",
+    "reference": "cli-spa-starter-budget",
+    "maxRatio": 1,
+    "note": "The CLI-generated disposable SPA entry and complete landing page retain compiler-proven root specialization; deterministic production raw bytes must not exceed the committed same-run budget."
+  },
+  {
+    "suite": "bundle-reachability",
+    "op": "gzip",
+    "target": "cli-spa-starter",
+    "reference": "cli-spa-starter-budget",
+    "maxRatio": 1,
+    "note": "The CLI-generated disposable SPA entry and complete landing page retain compiler-proven root specialization; deterministic production gzip bytes must not exceed the committed same-run budget."
+  },
+  {
+    "suite": "bundle-reachability",
+    "op": "brotli",
+    "target": "cli-spa-starter",
+    "reference": "cli-spa-starter-budget",
+    "maxRatio": 1,
+    "note": "The CLI-generated disposable SPA entry and complete landing page retain compiler-proven root specialization; deterministic production brotli bytes must not exceed the committed same-run budget."
+  },
+  {
+    "suite": "bundle-reachability",
+    "op": "raw",
     "target": "root-static-specialized",
     "reference": "root-static-specialized-budget",
     "maxRatio": 1,

--- a/benchmarks/bundle-size/minimal-budgets.json
+++ b/benchmarks/bundle-size/minimal-budgets.json
@@ -4,6 +4,11 @@
     "gzip": 1728,
     "brotli": 1536
   },
+  "cli-spa-starter": {
+    "raw": 80736,
+    "gzip": 27936,
+    "brotli": 24768
+  },
   "root-static-specialized": {
     "raw": 49760,
     "gzip": 16736,

--- a/benchmarks/bundle-size/run-minimal.mjs
+++ b/benchmarks/bundle-size/run-minimal.mjs
@@ -11,6 +11,7 @@ import { build as buildEsbuild } from 'esbuild';
 import { createOctaneCompiler } from 'octane/compiler/bundler';
 import { octane } from 'octane/compiler/vite';
 import { build as buildVite } from 'vite';
+import { appComponent, clientEntry } from '../../packages/cli/src/commands/init/templates.js';
 import { verifyScenario } from './verify-reachability.mjs';
 
 const directory = path.dirname(fileURLToPath(import.meta.url));
@@ -20,6 +21,7 @@ const budgetFile = path.join(directory, 'minimal-budgets.json');
 const budgets = JSON.parse(fs.readFileSync(budgetFile, 'utf8'));
 const existingScenarios = [
 	['capture-only', 'ts'],
+	['cli-spa-starter', 'ts'],
 	['root-static-specialized', 'ts'],
 	['root-static', 'tsrx'],
 	['hooks-state', 'tsrx'],
@@ -187,6 +189,39 @@ assert.deepEqual(
 
 const payload = { suite: 'bundle-reachability', iterations: 1, targets: [] };
 
+function cliStarterPlugin(entry) {
+	const component = path.join(fixtures, 'cli-spa-starter-App.tsrx');
+	return {
+		name: 'octane-reachability-generated-cli-starter',
+		enforce: 'pre',
+		resolveId(source, importer) {
+			if (source === entry) return entry;
+			if (source === './App.tsrx' && importer === entry) return component;
+			return null;
+		},
+		load(id) {
+			if (id === component) return appComponent('spa');
+			if (id !== entry) return null;
+			return `${clientEntry}
+export function run(container) {
+	const page = container.querySelector('main.page');
+	const title = page?.querySelector('h1');
+	const quickStart = container.querySelector('a[href="https://octanejs.dev/docs/quick-start"]');
+	const scopedStyle = document.head.querySelector('style[data-octane]');
+	return {
+		page: page !== null,
+		title: title?.textContent,
+		quickStart: quickStart?.querySelector('.link-title')?.textContent,
+		quickStartHref: quickStart?.getAttribute('href'),
+		links: container.querySelectorAll('a').length,
+		styled: scopedStyle?.textContent?.includes('.page') ?? false,
+	};
+}
+`;
+		},
+	};
+}
+
 async function buildScenario(scenario, entry) {
 	if (scenario.bundler === 'esbuild') {
 		const result = await buildEsbuild({
@@ -245,7 +280,10 @@ async function buildScenario(scenario, entry) {
 		root: directory,
 		mode: 'production',
 		logLevel: 'error',
-		plugins: [octane({ hmr: false })],
+		plugins: [
+			...(scenario.id === 'cli-spa-starter' ? [cliStarterPlugin(entry)] : []),
+			octane({ hmr: false }),
+		],
 		define: productionDefines,
 		build: {
 			write: false,
@@ -315,7 +353,7 @@ try {
 		} else if (id !== 'binding-motion' && id !== 'binding-aria') {
 			assert.equal(hasRuntime, true, `${name}: executable feature omitted the client runtime`);
 		}
-		if (id === 'root-static-specialized') {
+		if (id === 'root-static-specialized' || id === 'cli-spa-starter') {
 			assert.equal(
 				runtimeExports.includes('__createVoidRoot'),
 				true,
@@ -383,7 +421,7 @@ try {
 				hasServerRuntime,
 				hasVanillaStore,
 				...(scenario.package ? { bundler: scenario.bundler, package: scenario.package } : null),
-				...(id.startsWith('root-static') ? { runtimeExports } : null),
+				...(id.startsWith('root-static') || id === 'cli-spa-starter' ? { runtimeExports } : null),
 				snapshot,
 			},
 		});

--- a/benchmarks/bundle-size/verify-reachability.mjs
+++ b/benchmarks/bundle-size/verify-reachability.mjs
@@ -6,6 +6,14 @@ const EXPECTED_SNAPSHOTS = Object.freeze({
 		prevented: true,
 		bubbled: false,
 	},
+	'cli-spa-starter': {
+		page: true,
+		title: 'octane',
+		quickStart: 'Quick start',
+		quickStartHref: 'https://octanejs.dev/docs/quick-start',
+		links: 4,
+		styled: true,
+	},
 	'root-static': {
 		text: 'Octane',
 		cleaned: true,
@@ -133,7 +141,7 @@ export async function verifyScenario(id, code) {
 	});
 	const { window } = dom;
 	const container = window.document.createElement('div');
-	container.id = 'octane-reachability-root';
+	container.id = id === 'cli-spa-starter' ? 'root' : 'octane-reachability-root';
 	window.document.body.appendChild(container);
 	const focusBefore = window.HTMLElement.prototype.focus;
 	const listeners = { document: new Set(), body: new Set(), window: new Set() };

--- a/packages/cli/src/commands/init/templates.js
+++ b/packages/cli/src/commands/init/templates.js
@@ -593,12 +593,12 @@ export const indexHtml = (mode) => (mode === 'fullstack' ? SSR_INDEX_HTML : SPA_
 /**
  * The client bootstrap, `spa` only. `render(App)` is the body-and-props
  * overload, which keeps the entry plain TypeScript with no JSX pragma to carry.
+ * Chaining the disposable mount lets eligible builds omit reusable-root machinery.
  */
 export const clientEntry = `import { createRoot } from "octane";
 import { App } from "./App.tsrx";
 
-const root = createRoot(document.getElementById("root")!);
-root.render(App);
+createRoot(document.getElementById("root")!).render(App);
 `;
 
 /**

--- a/packages/cli/tests/create.test.js
+++ b/packages/cli/tests/create.test.js
@@ -63,7 +63,11 @@ describe('octane create', () => {
 		expect(JSON.parse(read(app, 'package.json')).name).toBe('my-app');
 		expect(read(app, 'vite.config.ts')).toContain('from "octane/compiler/vite"');
 		expect(read(app, 'index.html')).toContain('<script type="module" src="/src/main.ts">');
-		expect(read(app, 'src/main.ts')).toContain('createRoot');
+		// The starter never reuses its root, so a chained mount lets production
+		// builds discard the generic reusable-root machinery.
+		expect(read(app, 'src/main.ts')).toContain(
+			'createRoot(document.getElementById("root")!).render(App)',
+		);
 		expect(read(app, 'src/App.tsrx')).toContain('export function App()');
 		// The landing page is the app: it links into the documentation rather than
 		// leaving a placeholder to delete, and it mounts standalone, because this

--- a/packages/cli/tests/init.test.js
+++ b/packages/cli/tests/init.test.js
@@ -71,7 +71,11 @@ describe('octane init', () => {
 		// A wired-up bundler still serves nothing without a page and an entry to
 		// mount, so `vite` has to have something to open.
 		expect(read(root, 'index.html')).toContain('<script type="module" src="/src/main.ts">');
-		expect(read(root, 'src/main.ts')).toContain('createRoot');
+		// This disposable root must not be retained: its chained mount lets
+		// production builds discard the generic reusable-root machinery.
+		expect(read(root, 'src/main.ts')).toContain(
+			'createRoot(document.getElementById("root")!).render(App)',
+		);
 		expect(read(root, 'src/App.tsrx')).toContain('export function App()');
 		// The SSR-only files belong to the other mode.
 		expect(existsSync(path.join(root, 'octane.config.ts'))).toBe(false);


### PR DESCRIPTION
## Summary

- Generate the existing disposable chained-root form for SPA applications created by both `octane init` and `octane create`.
- Build and execute the actual generated entry and complete landing-page template through the existing production reachability harness, preserving rendered content, documentation links, and scoped styles.
- Reduce the generated SPA from **118,268 to 78,369 raw bytes**, **39,247 to 27,115 gzip bytes** (**12,132 bytes / 30.9% smaller**), and **34,253 to 24,045 Brotli bytes** under the same production build and behavioral oracle.
- Add committed raw/gzip/Brotli budgets and a patch changeset for `@octanejs/cli`.

References #632 (Workstream 3); other roadmap work remains open.

## Why

The SPA starter previously assigned `createRoot(...)` to a variable before calling `render`. That root does not escape, but the existing production compiler intentionally specializes only a directly chained, compiler-proven disposable root. The starter therefore retained the complete generic reusable-root implementation unnecessarily. Changing the generated entry to the already supported chained form fixes the missed optimization without changing the compiler or runtime.

## Changes

- Update the single shared SPA template used by both public scaffolding commands.
- Add regressions proving both commands emit the disposable public starter form.
- Add an executable production scenario sourced directly from the actual CLI entry and complete generated SPA component; assert the landing page, heading, four documentation links, quick-start URL, and injected scoped stylesheet.
- Verify the specialized root remains reachable and the generic reusable-root API does not; keep the existing reusable-root scenario unchanged.
- Extend the existing benchmark to **28 production builds and 84 enforced raw/gzip/Brotli guards** without introducing duplicate fixtures or new dependencies.

## Validation

- [x] `pnpm format:check`
- [ ] `pnpm typecheck` (repository-wide; scoped and complete CLI-package checks below passed)
- [ ] `pnpm test` (repository-wide; 256 relevant targeted tests below passed)
- [x] `pnpm sync`
- [x] `pnpm format:files:check .changeset/cli-disposable-root-specialization.md benchmarks/README.md benchmarks/baselines/ratios.json benchmarks/bundle-size/minimal-budgets.json benchmarks/bundle-size/run-minimal.mjs benchmarks/bundle-size/verify-reachability.mjs packages/cli/src/commands/init/templates.js packages/cli/tests/create.test.js packages/cli/tests/init.test.js`
- [x] `pnpm typecheck:files packages/cli/src/commands/init/templates.js`
- [x] `./node_modules/.bin/tsgo --noEmit -p packages/cli/tsconfig.typecheck.json`
- [x] `./node_modules/.bin/vitest run --project cli --project create-octane --reporter=dot --silent=passed-only` — **163 tests**.
- [x] `./node_modules/.bin/vitest run packages/octane/tests/compiler/bundler-compiler.test.ts packages/octane/tests/external-hook-slot.test.ts --project octane --reporter=dot --silent=passed-only` — **76 tests**, including HMR, escaped/reused roots, and trusted compiled-output proof.
- [x] `./node_modules/.bin/vitest run packages/rspack-plugin-octane/tests/loader.integration.test.ts --project rspack-plugin --reporter=dot --silent=passed-only` — **17 tests**, including Rspack's fail-closed generic-root behavior.
- [x] `node benchmarks/bench.mjs --quick --ratios bundle-reachability` — **28 executable production builds / 84 passing size guards**.
- [x] `pnpm changeset:check`
- [x] `node scripts/generate-scaffold-manifest.mjs --check`
- [x] `node scripts/generate-cli-data.mjs --check`

## Risk / follow-ups

- Only disposable Vite SPA starter shape changes; existing reusable, HMR-owned, and escaping roots retain their public generic contract.
- Rspack/Rsbuild specialization remains intentionally fail-closed and is not changed here.
- Other #632 workstreams remain open.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only the disposable SPA starter template and benchmark/test wiring change; reusable, HMR, and escaping roots keep their existing contracts.
> 
> **Overview**
> **SPA scaffolds** from `octane init` and `octane create` now emit a **chained** mount (`createRoot(...).render(App)`) instead of assigning the root to a variable first. That matches the shape the production compiler already specializes, so new apps can drop the generic reusable-root path from the bundle without changing compiler or runtime behavior for roots that are actually reused.
> 
> **Regression coverage** adds a `cli-spa-starter` **bundle-reachability** scenario that builds from the real `clientEntry` and `appComponent('spa')` templates (no duplicate fixtures), checks the landing page in jsdom, and asserts `__createVoidRoot` is present while `createRoot` is not. Committed raw/gzip/brotli budgets and three new ratio guards extend the suite to 28 builds / 84 byte guards; docs and a patch changeset for `@octanejs/cli` are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d74cb178628e981ec3600c312e6ba579c134d556. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->