### PR TITLE
docs(website): chart every comparative benchmark suite

### DIFF
--- a/website/src/content/benchmarks.ts
+++ b/website/src/content/benchmarks.ts
@@ -30,6 +30,13 @@ import ssrThroughput from '../../../benchmarks/baselines/local/ssr-throughput.js
 import streamingSsr from '../../../benchmarks/baselines/local/streaming-ssr.json';
 import svgDashboard from '../../../benchmarks/baselines/local/svg-dashboard.json';
 import todoMvc from '../../../benchmarks/baselines/local/todomvc.json';
+import asyncComposition from '../../../benchmarks/baselines/local/async-composition.json';
+import ssrHttp from '../../../benchmarks/baselines/local/ssr-http.json';
+import tanstackStart from '../../../benchmarks/baselines/local/tanstack-start.json';
+import threeBundleSize from '../../../benchmarks/baselines/local/three-bundle-size.json';
+import threeRenderer from '../../../benchmarks/baselines/local/three-renderer.json';
+import weatherAppLighthouse from '../../../benchmarks/baselines/local/weather-app-lighthouse.json';
+import weatherApp from '../../../benchmarks/baselines/local/weather-app.json';
 
 // `score` is charted when present; older checked-in baselines fall back to
 // `median`. Other stats vary by suite, so they stay optional.
@@ -94,6 +101,9 @@ const FRAMEWORKS: SeriesDef[] = [
 	{ key: 'svelte', label: 'Svelte 5', color: '#f57547' },
 	{ key: 'ripple', label: 'Ripple 0.3', color: '#9085e9' },
 	{ key: 'vue-vapor', label: 'Vue Vapor 3.6 beta', color: '#e06ec4' },
+	// The weather-app fixtures publish plain `vue` (same 3.6 pin). Color follows
+	// the entity, and the two Vue keys never appear on the same card.
+	{ key: 'vue', label: 'Vue 3.6', color: '#e06ec4' },
 ];
 
 // Octane-internal variants — ordinal ramp of the brand hue, validated with
@@ -206,6 +216,33 @@ export const FRAMEWORK_CARDS: BenchCard[] = [
 			'clearCompleted',
 			'destroy25',
 		],
+	),
+	frameworkCard(
+		weatherApp,
+		'weather-app',
+		'weather-app',
+		'A real weather dashboard — cold start to interactive, keyed forecast churn, and async city search with error and recovery flows. The DOM-census counters in the baseline are diagnostics and stay out of the chart.',
+		{
+			initial_ready: 'cold ready',
+			forecast_cycle: 'forecast churn',
+			search_city: 'search city',
+			search_error: 'search error',
+			search_recover: 'search recover',
+		},
+		['initial_ready', 'forecast_cycle', 'search_city', 'search_error', 'search_recover'],
+	),
+	frameworkCard(
+		weatherAppLighthouse,
+		'weather-app-lighthouse',
+		'weather-app — Lighthouse',
+		'Desktop Lighthouse lab metrics for the same weather app — first and largest contentful paint, speed index, and total blocking time. Cumulative layout shift is unitless and omitted from the millisecond chart.',
+		{
+			first_contentful_paint: 'FCP',
+			largest_contentful_paint: 'LCP',
+			speed_index: 'speed index',
+			total_blocking_time: 'TBT',
+		},
+		['first_contentful_paint', 'largest_contentful_paint', 'speed_index', 'total_blocking_time'],
 	),
 	frameworkCard(
 		chatStream,
@@ -365,6 +402,136 @@ export const FRAMEWORK_CARDS: BenchCard[] = [
 		series,
 		rows,
 		iterations: b.iterations,
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Head-to-head targets — suites whose roster is a specific stack rather than
+// the whole field: octane against React on real HTTP servers, composed async
+// trees and TanStack Start, plus the Three.js renderer column. These stay off
+// the home summary, which aggregates only the full-roster cards above.
+// ---------------------------------------------------------------------------
+export const TARGET_CARDS: BenchCard[] = [
+	frameworkCard(
+		asyncComposition,
+		'async-composition',
+		'async-composition',
+		'Composed async use() trees — Octane\u2019s compiled parallel-use batching against React\u2019s render-and-suspend loop. The wave, call and span counts in the baseline are deterministic diagnostics and stay out of the chart.',
+		{ init: 'initial render', update: 'update' },
+		['init', 'update'],
+	),
+	frameworkCard(
+		ssrHttp,
+		'ssr-http',
+		'ssr-http',
+		'Real production HTTP servers rendering the news page — renderer import, cold spawn/listen/first-byte, and streamed shell and completion times over HTTP for staggered and all-fast Suspense.',
+		{
+			import_renderer: 'import renderer',
+			cold_spawn_to_listen: 'cold spawn\u2192listen',
+			cold_listen_to_first_byte: 'cold listen\u2192first byte',
+			cold_spawn_to_first_byte: 'cold spawn\u2192first byte',
+			http_shell_staggered: 'staggered shell',
+			http_total_staggered: 'staggered complete',
+			http_shell_allfast: 'all-fast shell',
+			http_total_allfast: 'all-fast complete',
+		},
+	),
+];
+
+{
+	const b = tanstackStart as SuiteBaseline;
+	const series: SeriesDef[] = [
+		{ key: 'octane-minimal', label: 'Octane Start (minimal server)', color: VARIANT_COLORS.tuned },
+		{ key: 'octane-nitro', label: 'Octane Start (nitro)', color: VARIANT_COLORS.dark },
+		{ key: 'react', label: 'React (TanStack Start)', color: '#1e93b0' },
+	];
+	TARGET_CARDS.push({
+		id: 'tanstack-start',
+		title: 'tanstack-start',
+		description:
+			'The same TanStack Start app served by React and by the Octane port — cold start to first byte, warm TTFB and completion for the posts and deferred routes, the deferred stream tail, and sequential home requests.',
+		series,
+		rows: rowsFor(b, series, {
+			cold_spawn_to_listen: 'cold spawn\u2192listen',
+			cold_listen_to_first_byte: 'cold listen\u2192first byte',
+			cold_spawn_to_first_byte: 'cold spawn\u2192first byte',
+			warm_ttfb_posts: 'warm TTFB /posts',
+			warm_total_posts: 'warm total /posts',
+			warm_ttfb_deferred: 'warm TTFB /deferred',
+			warm_total_deferred: 'warm total /deferred',
+			warm_stream_tail_deferred: 'deferred stream tail',
+			warm_seq_request_home: 'sequential home requests',
+		}),
+		iterations: b.iterations,
+	});
+}
+
+// The imperative Three.js column is the no-framework control, so it wears the
+// control blue (react-uncompiled\u2019s slot — the two never share a card).
+const THREE_SERIES = {
+	octane: { label: 'Octane Three', color: VARIANT_COLORS.tuned },
+	r3f: { label: 'React Three Fiber 9', color: '#1e93b0' },
+	plain: { label: 'Plain Three.js', color: '#4bafe7' },
+} as const;
+
+{
+	const b = threeRenderer as SuiteBaseline;
+	const series: SeriesDef[] = [
+		{ key: 'octane', ...THREE_SERIES.octane },
+		{ key: 'r3f-9.6.1', ...THREE_SERIES.r3f },
+		{ key: 'plain-three', ...THREE_SERIES.plain },
+	];
+	TARGET_CARDS.push({
+		id: 'three-renderer',
+		title: 'three-renderer',
+		description:
+			'Object lifecycle at 1,000 meshes — mount, update, reorder, unmount, reconstruct with dispose, a frame with 1,000 subscribers, and raycast events — for the Octane Three renderer, React Three Fiber, and hand-written Three.js.',
+		series,
+		rows: rowsFor(b, series, {
+			mount_1k: 'mount 1k',
+			update_1k: 'update 1k',
+			reorder_1k: 'reorder 1k',
+			unmount_tree_1k: 'unmount 1k',
+			reconstruct_dispose_1k: 'reconstruct + dispose 1k',
+			frame_1k_subscribers: 'frame, 1k subscribers',
+			raycast_event: 'raycast event',
+		}),
+		iterations: b.iterations,
+	});
+}
+
+// three-bundle-size targets are named `<renderer>-<scene>` — regroup into one
+// row per scene with one gzip-bytes column per renderer.
+{
+	const b = threeBundleSize as SuiteBaseline;
+	const series: SeriesDef[] = [
+		{ key: 'octane', ...THREE_SERIES.octane },
+		{ key: 'r3f', ...THREE_SERIES.r3f },
+		{ key: 'plain', ...THREE_SERIES.plain },
+	];
+	const byName = new Map(b.targets.map((t) => [t.name, t]));
+	const rows: BenchRow[] = (
+		[
+			['min', 'minimal scene'],
+			['full', 'full helpers'],
+		] as const
+	).map(([scene, label]) => {
+		const row: BenchRow = { op: label };
+		for (const s of series) {
+			const target = byName.get(`${s.key}-${scene}`);
+			if (target) row[s.key] = statValue(target.ops.js_gzip);
+		}
+		return row;
+	});
+	TARGET_CARDS.push({
+		id: 'three-bundle-size',
+		title: 'three-bundle-size',
+		description:
+			'Shipped gzip JavaScript for a minimal scene and a helpers-heavy scene across the three renderers.',
+		series,
+		rows,
+		iterations: b.iterations,
+		format: 'bytes',
 	});
 }
 

--- a/website/src/content/home-benchmark.ts
+++ b/website/src/content/home-benchmark.ts
@@ -43,6 +43,22 @@ export const HOME_SUMMARY: BenchCard = {
 			'vue-vapor': 1.4835252389642104,
 		},
 		{
+			op: 'weather-app',
+			'octane-tsrx': 1,
+			react: 1.266323042693476,
+			preact: 1.353766384351486,
+			solid: 1.1342379468942232,
+			svelte: 0.9485618664070963,
+		},
+		{
+			op: 'weather-app-lighthouse',
+			'octane-tsrx': 1,
+			react: 0.9996733289781274,
+			preact: 0.7975309525150063,
+			solid: 0.8299742559835969,
+			svelte: 0.8251639678323414,
+		},
+		{
 			op: 'chat-stream',
 			'octane-tsrx': 1,
 			react: 3.602823130812655,

--- a/website/src/pages/benchmarks/Benchmarks.tsrx
+++ b/website/src/pages/benchmarks/Benchmarks.tsrx
@@ -1,15 +1,16 @@
 // /benchmarks — the checked-in runtime, SSR, async, and size baselines, charted
 // as deterministic plain-div bar cards (the same bar view the explorer uses).
-// Three sections: the normalized at-a-glance explorer (the same linked bar/heatmap
+// Four sections: the normalized at-a-glance explorer (the same linked bar/heatmap
 // component the home page stages, fed the matrix recomputed from FRAMEWORK_CARDS so
 // it can never drift from the cards below), then the cross-framework comparisons,
-// then the octane-internal de-opt ("authoring cliff") suites. All numbers are the
+// then the head-to-head stack targets, then the octane-internal de-opt
+// ("authoring cliff") suites. All numbers are the
 // checked-in benchmark scores; the page cannot drift from the repo because the
 // JSON is imported at build time.
 import { BenchBars } from '../../components/BenchBars.tsrx';
 import { BenchmarkExplorer } from '../../components/BenchmarkExplorer.tsrx';
 import { OnThisPage } from '../../components/OnThisPage.tsrx';
-import { FRAMEWORK_CARDS, OCTANE_CARDS } from '../../content/benchmarks.ts';
+import { FRAMEWORK_CARDS, OCTANE_CARDS, TARGET_CARDS } from '../../content/benchmarks.ts';
 import { createHomeSummary } from '../../content/home-benchmark.ts';
 import { useAnimatedMobileNavigation } from '../../hooks/use-animated-mobile-navigation.ts';
 import { useTitle } from '../../hooks/use-title.ts';
@@ -31,6 +32,8 @@ export const BENCH_SECTIONS: readonly { id: string; title: string; level?: 2 | 3
 	...FRAMEWORK_CARDS.map(
 		(card) => ({ id: cardAnchor(card), title: card.title, level: 3 as const }),
 	),
+	{ id: 'bench-targets', title: 'Head-to-head targets' },
+	...TARGET_CARDS.map((card) => ({ id: cardAnchor(card), title: card.title, level: 3 as const })),
 	{ id: 'bench-internal', title: 'The authoring cliff' },
 	...OCTANE_CARDS.map((card) => ({ id: cardAnchor(card), title: card.title, level: 3 as const })),
 ];
@@ -111,6 +114,29 @@ export function Benchmarks() @{
 					</p>
 					<div class="benchpage-grid">
 						@for (const card of FRAMEWORK_CARDS; key card.id) {
+							<div
+								class="benchpage-anchor"
+								id={cardAnchor(card)}
+								role="group"
+								aria-label={card.title}
+							>
+								<BenchBars card={card} />
+							</div>
+						}
+					</div>
+				</section>
+
+				<section class="benchpage-section" aria-labelledby="bench-targets">
+					<h2 id="bench-targets" class="benchpage-h2">Head-to-head targets</h2>
+					<p class="benchpage-note">
+						Suites whose roster is a specific stack rather than the whole field: Octane against
+						React on real HTTP servers, composed async trees and the same TanStack Start app, and
+						the Octane Three renderer against React Three Fiber and hand-written Three.js. These
+						cards stay out of the at-a-glance grid above, which aggregates only the full-roster
+						suites.
+					</p>
+					<div class="benchpage-grid">
+						@for (const card of TARGET_CARDS; key card.id) {
 							<div
 								class="benchpage-anchor"
 								id={cardAnchor(card)}

--- a/website/tests/benchmark-explorer.test.ts
+++ b/website/tests/benchmark-explorer.test.ts
@@ -55,11 +55,12 @@ describe('benchmark explorer — bar chart', () => {
 describe('benchmark explorer — heatmap', () => {
 	it('excludes null cells from the grid, rendering them as "—"', async () => {
 		const { container } = await mountExplorer();
-		// HOME_SUMMARY has six gaps: async-waterfall/Vue, streaming-ssr/Svelte,
-		// streaming-ssr/Vue, and svg-dashboard/Preact/Ripple/Vue. They render as
-		// neutral "—" cells, not colored ones.
+		// HOME_SUMMARY has ten gaps: async-waterfall/Vue, streaming-ssr/Svelte,
+		// streaming-ssr/Vue, svg-dashboard/Preact/Ripple/Vue, and the two
+		// weather-app rows' Ripple/Vue-Vapor columns (those fixtures run plain
+		// Vue). They render as neutral "—" cells, not colored ones.
 		const nullCells = container.querySelectorAll('.bx-cell-null');
-		expect(nullCells.length).toBe(6);
+		expect(nullCells.length).toBe(10);
 		nullCells.forEach((cell) => expect(cell.textContent!.trim()).toBe('—'));
 	});
 
@@ -71,7 +72,7 @@ describe('benchmark explorer — heatmap', () => {
 		fireEvent.click(seg('vs fastest'));
 
 		// Mode B: every suite row now has exactly one outlined 1× winner.
-		await waitFor(() => expect(container.querySelectorAll('.bx-cell-fastest').length).toBe(16));
+		await waitFor(() => expect(container.querySelectorAll('.bx-cell-fastest').length).toBe(18));
 		container
 			.querySelectorAll('.bx-cell-fastest')
 			.forEach((cell) => expect(cell.textContent!.trim()).toBe('1×'));

--- a/website/tests/smoke.test.ts
+++ b/website/tests/smoke.test.ts
@@ -18,6 +18,7 @@ import {
 	FRAMEWORK_CARDS,
 	HOME_SUMMARY,
 	OCTANE_CARDS,
+	TARGET_CARDS,
 	type BenchCard,
 } from '../src/content/benchmarks.ts';
 import { createHomeSummary } from '../src/content/home-benchmark.ts';
@@ -346,7 +347,9 @@ describe('website routes', () => {
 		const mobileToggle = container.querySelector('.benchpage-sidebar-toggle');
 		expect(container.querySelectorAll('.benchpage-sidebar-toggle')).toHaveLength(1);
 		expect(mobileToggle?.textContent).toContain('Benchmarks');
-		expect(BENCH_SECTIONS.length).toBe(3 + FRAMEWORK_CARDS.length + OCTANE_CARDS.length);
+		expect(BENCH_SECTIONS.length).toBe(
+			4 + FRAMEWORK_CARDS.length + TARGET_CARDS.length + OCTANE_CARDS.length,
+		);
 		for (const section of BENCH_SECTIONS) {
 			expect(findLink(toc, `#${section.id}`)?.textContent).toContain(section.title);
 			const target = container.querySelector(`#${section.id}`)!;

--- a/website/tests/ssr-smoke.test.ts
+++ b/website/tests/ssr-smoke.test.ts
@@ -14,7 +14,7 @@ import { beforeAll, describe, it, expect, inject } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { waitForReadyState } from './support/server-process.ts';
-import { FRAMEWORK_CARDS, OCTANE_CARDS } from '../src/content/benchmarks.ts';
+import { FRAMEWORK_CARDS, OCTANE_CARDS, TARGET_CARDS } from '../src/content/benchmarks.ts';
 
 const origin = inject('productionOrigin');
 const outputDir = inject('productionOutputDir');
@@ -133,7 +133,7 @@ describe('built Start server', () => {
 	// slower CI runners.
 	it('server-renders /benchmarks with complete bar charts and table data', async () => {
 		const { response, html } = await get('/benchmarks');
-		const cards = [...FRAMEWORK_CARDS, ...OCTANE_CARDS];
+		const cards = [...FRAMEWORK_CARDS, ...TARGET_CARDS, ...OCTANE_CARDS];
 		// Each card server-renders its default "overall" view: one geomean bar per
 		// series with a computable ratio vs the reference (rows where either side
 		// is missing or zero drop out); single-series cards chart every operation.
@@ -160,6 +160,7 @@ describe('built Start server', () => {
 		expect(response.status).toBe(200);
 		expect(classCount(html, 'benchpage')).toBeGreaterThan(0);
 		expect(html).toContain('aria-labelledby="bench-frameworks"');
+		expect(html).toContain('aria-labelledby="bench-targets"');
 		expect(html).toContain('aria-labelledby="bench-internal"');
 		// Every no-JS benchmark card ships both the real chart and its accessible table.
 		expect(classCount(html, 'bench-card')).toBe(cards.length);


### PR DESCRIPTION
## Summary

The /benchmarks page charted 19 of the checked-in baselines; seven comparative suites were missing. This adds all seven and answers "which suites are deliberately not charted" in one place.

- **`weather-app`** and **`weather-app — Lighthouse`** join "Octane vs the field" (full roster including plain Vue — a new `vue` series def wearing the Vue entity hue; the two Vue keys never share a card). The five timing ops are charted for the app card and the four millisecond Lighthouse metrics for the lab card; DOM-census counters and unitless CLS stay out. Both rows now appear on the home at-a-glance grid.
- A new **"Head-to-head targets"** section (page + scroll-spy sidebar) for suites whose roster is a specific stack rather than the whole field: `async-composition` and `ssr-http` (octane vs react), `tanstack-start` (React Start vs the Octane port's minimal and nitro servers), `three-renderer` (Octane Three vs React Three Fiber vs hand-written Three.js), and `three-bundle-size` (regrouped to one row per scene, gzip bytes per renderer). These stay off the home summary, which aggregates only the full-roster cards — that keeps the smoke test's roster contract ("every field card carries preact and svelte") intact instead of growing its exemption list.

## Why

Dominic asked which benchmarks were missing from the website after svg-dashboard landed there via #644. The at-a-glance story was silently incomplete — notably weather-app, whose bundle bytes were already charted on the bundle-size card while its timings were not.

## Changes

- `website/src/content/benchmarks.ts` — seven baseline imports, the `vue` series def, two `frameworkCard` entries, and the exported `TARGET_CARDS` group (custom series defs for the TanStack/Three columns; imperative Three.js wears the control blue, documented inline).
- `website/src/pages/benchmarks/Benchmarks.tsrx` — fourth section + sidebar entries.
- `website/src/content/home-benchmark.ts` — HOME_SUMMARY regenerated (18 rows) with the same JS math the smoke test recomputes, so the snapshot check stays ULP-exact.
- Tests updated where they pin derived counts: explorer heatmap gaps 6 → 10 (the weather rows have no Ripple/Vue-Vapor columns) and per-row winners 16 → 18; smoke sidebar formula gains the fourth section; ssr-smoke card census includes `TARGET_CARDS` and asserts the new section's landmark.

Deliberately still uncharted (stated here so the next audit doesn't re-litigate): `list-clear`, `codegen-size`, `react-hosted-islands`, and `ssr-workerd` — octane-only or count-based diagnostics with no cross-framework chart to draw.

## Validation

- [x] `pnpm format:check` (scoped `format:files:check` over `website/`; repo-wide not re-run)
- [x] `pnpm typecheck`
- [ ] `pnpm test` — not run in full; targeted projects below cover every touched file
- [x] targeted tests: `website-unit` 328/328 and `website-integration` 65/65 (the latter builds the real Start server, asserts the no-JS SSR card census, and drives every route — including /benchmarks — in headless Chromium watching for hydration mismatches); page also verified in a live dev server (26 cards, all five head-to-head anchors present).

## Risk / follow-ups

- Content-only: no runtime, compiler, or benchmark-harness changes; the charted numbers are the same checked-in baselines the repo already gates.
- The `weather-app-lighthouse` card charts lab metrics next to benchmark scores; if that reads as apples-to-oranges on the page, dropping that one card is a one-line revert.
- When #635 (svg-dashboard suite) merges, its baseline refresh will change svg-dashboard's charted numbers on the next website refresh — independent of this PR.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Website content and test expectations only; numbers come from existing checked-in baselines with no runtime or harness changes.
> 
> **Overview**
> Charts **seven** previously missing checked-in benchmark baselines on `/benchmarks` and extends the home at-a-glance grid where those suites use the full cross-framework roster.
> 
> **Octane vs the field** gains **`weather-app`** (timing ops) and **`weather-app — Lighthouse`** (FCP/LCP/speed index/TBT), with a new **`vue`** series for plain Vue on those fixtures. Both rows are added to **`HOME_SUMMARY`** (18 suite rows).
> 
> A new **Head-to-head targets** section and exported **`TARGET_CARDS`** cover stack-specific comparisons—`async-composition`, `ssr-http`, `tanstack-start`, `three-renderer`, and regrouped **`three-bundle-size`**—without folding them into the home summary. The benchmarks page sidebar, SSR smoke card census, and explorer/smoke counts are updated for the extra section and heatmap gaps on the weather rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dd04b9c25b9bc238688d5406464371b900e360c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->