### PR TITLE
fix(website): return instead of hanging on an empty gesture step list

### DIFF
--- a/website/src/components/go/lynx-view/auto-gesture.ts
+++ b/website/src/components/go/lynx-view/auto-gesture.ts
@@ -131,6 +131,10 @@ export function playAutoGesture(host: HTMLElement, options: AutoGestureOptions):
 		});
 
 	async function run(): Promise<void> {
+		// Nothing to play. Without this the `do`/`while` below never reaches an
+		// `await`, so it spins synchronously and no timer or event can ever set
+		// `stopped` — the tab hangs rather than doing nothing.
+		if (steps.length === 0) return;
 		await wait(startDelayMs);
 		do {
 			for (const step of steps) {

--- a/website/tests/lynx-view.test.ts
+++ b/website/tests/lynx-view.test.ts
@@ -206,6 +206,28 @@ describe('automatic gesture playback', () => {
 		expect(events.at(-1)).toBe('pointerup');
 	});
 
+	it('does nothing, rather than hanging, when given no steps', async () => {
+		// `steps: []` type-checks. Without a guard the playback loop never reaches
+		// an `await`, so it spins synchronously and neither a timer nor `stop()`
+		// can ever break it — the tab hangs. Fake timers make that observable:
+		// `runAllTimersAsync` cannot settle against a loop that never yields.
+		vi.useFakeTimers();
+		const host = document.createElement('div');
+		document.body.append(host);
+
+		const playback = playAutoGesture(host, {
+			steps: [],
+			loop: true,
+			showPointer: false,
+			startDelayMs: 0,
+			stopOnUserInput: false,
+		});
+
+		await vi.runAllTimersAsync();
+		expect(playback.stop).toBeTypeOf('function');
+		playback.stop();
+	});
+
 	it('keeps driving an example on a browser that refuses `new Touch()`', async () => {
 		// Safari declares `Touch` and throws `Illegal constructor` when you call
 		// it, while still shipping the legacy `document.createTouch` factory and


### PR DESCRIPTION
## Summary
- `playAutoGesture` hangs the tab when given an empty step list.
- Guard it, and cover it with a test whose pre-fix behaviour is a hang, not a failure.

## Why
`steps: []` satisfies `AutoGestureOptions`. With `loop: true`, the `for` body never runs, so the `do`/`while` never reaches an `await`. It spins synchronously — which means neither a timer nor an event can set `stopped`, and `stop()` has nothing to interrupt.

This is not hypothetical for the preview: `steps` comes from `preview.json` per example, so an example shipped with an empty or mistyped `steps` array takes the docs page down with it rather than simply not demonstrating anything.

## Changes
- `website/src/components/go/lynx-view/auto-gesture.ts`: return early when there is nothing to play.
- `website/tests/lynx-view.test.ts`: a case that drives `steps: []` with `loop: true` under fake timers.

## Validation
- [x] `pnpm format:files` / `pnpm typecheck:files` on both changed files
- [x] `vitest run --project website-unit` — 22 files, **329 passed**
- [x] Pre-fix behaviour confirmed: with the guard removed, `vitest run website/tests/lynx-view.test.ts` never returns — `timeout 75` kills it with exit code **124**, and no test result is ever printed. With the guard, 21 tests pass in 1.1s.
- [x] `pnpm sync` clean
- [ ] `pnpm format:check` (repo-wide) — not run; change is two files
- [ ] `pnpm test` (full) — not run; ran the `website-unit` project instead

## Credit
Caught by CodeRabbit reviewing a vendored copy of this module in lynx-family/lynx-website#1282. Fixed upstream in the same shape as lynx-community/go-web#82, so the two copies stay in step.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized guard in demo playback with a unit test; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes a **tab hang** when `playAutoGesture` is called with `steps: []` (valid per `AutoGestureOptions`), especially with `loop: true`. The `do`/`while` loop never hit an `await`, so playback spun synchronously and timers/`stop()` could not interrupt it.
> 
> **`auto-gesture.ts`** returns immediately from `run()` when there are no steps, so preview auto-gestures from `preview.json` with an empty or mistyped list fail safely instead of freezing the docs page.
> 
> **`lynx-view.test.ts`** adds a regression test that runs `steps: []` with fake timers and expects `runAllTimersAsync` to settle—behavior that previously never completed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 645bfcbdfea9b70b3a5ee96d4355257dbf54af1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->