### PR TITLE
perf: reduce weather startup bundle and expose actual paint timings

### DIFF
--- a/.changeset/weather-startup-capabilities.md
+++ b/.changeset/weather-startup-capabilities.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Preserve proven single-root memo component shapes and keep catch-only error boundaries independent of optional Suspense and transition startup capabilities.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -254,15 +254,17 @@ sets use `todo_*`, `chat_*`, and `weather_*` operation prefixes; weather's share
 service and formatting modules count as app code in both framework builds.
 
 `bundle-size/app-budgets.json` independently caps all four complete Octane TSRX
-applications. Each set has separate application, framework, and total raw, gzip,
-and brotli ceilings: thirty-six deterministic limits in total. The harness
-publishes those committed values as one same-run `octane-tsrx-budget` target,
-and thirty-six `maxRatio: 1` guards enforce them alongside the existing
-cross-framework comparisons. Ceilings retain at least 32 bytes of headroom and
-are rounded to 32-byte boundaries, so small changes in another framework cannot
-hide Octane application or runtime growth. Refresh a ceiling only with a
-reviewed explanation and a production measurement using the pinned CI Node
-version.
+applications, while `bundle-size/jsx-budgets.json` separately caps the Octane JSX
+rows application. Each fixture has application, framework, and total raw, gzip,
+and brotli ceilings: forty-five deterministic limits in total. The harness
+publishes those committed values as separate same-run `octane-tsrx-budget` and
+`octane-jsx-budget` targets, and forty-five `maxRatio: 1` guards enforce them
+alongside the existing cross-framework comparisons. Independent dialect budgets
+allow either runtime to shrink without making the other dialect look larger by
+comparison. Ceilings retain at least 32 bytes of headroom and are rounded to
+32-byte boundaries, so small changes in another framework cannot hide Octane
+application or runtime growth. Refresh a ceiling only with a reviewed explanation
+and a production measurement using the pinned CI Node version.
 
 `bundle-reachability` builds twenty-one independent public-entry feature fixtures
 across twenty-eight production builds with the production Octane compiler,

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -626,19 +626,75 @@
   },
   {
     "suite": "bundle-size",
-    "op": "js_gzip",
+    "op": "app_raw",
     "target": "octane-jsx",
-    "reference": "octane-tsrx",
-    "maxRatio": 1.82,
-    "note": "Deterministic TSX/TSRX total-gzip gap. Two clean production runs on 2026-07-19 were byte-identical at 33765 / 18754 = 1.8004x; 1.82 catches retained runtime graph growth while allowing improvements."
+    "reference": "octane-jsx-budget",
+    "maxRatio": 1,
+    "note": "Rows JSX application production raw bytes must not exceed the committed 32-byte-aligned same-run ceiling."
+  },
+  {
+    "suite": "bundle-size",
+    "op": "app_gzip",
+    "target": "octane-jsx",
+    "reference": "octane-jsx-budget",
+    "maxRatio": 1,
+    "note": "Rows JSX application production gzip bytes must not exceed the committed 32-byte-aligned same-run ceiling."
+  },
+  {
+    "suite": "bundle-size",
+    "op": "app_brotli",
+    "target": "octane-jsx",
+    "reference": "octane-jsx-budget",
+    "maxRatio": 1,
+    "note": "Rows JSX application production brotli bytes must not exceed the committed 32-byte-aligned same-run ceiling."
+  },
+  {
+    "suite": "bundle-size",
+    "op": "fw_raw",
+    "target": "octane-jsx",
+    "reference": "octane-jsx-budget",
+    "maxRatio": 1,
+    "note": "Rows JSX framework production raw bytes must not exceed the committed 32-byte-aligned same-run ceiling."
   },
   {
     "suite": "bundle-size",
     "op": "fw_gzip",
     "target": "octane-jsx",
-    "reference": "octane-tsrx",
-    "maxRatio": 1.9,
-    "note": "Deterministic TSX/TSRX framework-gzip gap: 30974 / 16407 = 1.8879x on 2026-07-19. This isolates the generic descriptor/runtime graph from application code."
+    "reference": "octane-jsx-budget",
+    "maxRatio": 1,
+    "note": "Rows JSX framework production gzip bytes must not exceed the committed 32-byte-aligned same-run ceiling."
+  },
+  {
+    "suite": "bundle-size",
+    "op": "fw_brotli",
+    "target": "octane-jsx",
+    "reference": "octane-jsx-budget",
+    "maxRatio": 1,
+    "note": "Rows JSX framework production brotli bytes must not exceed the committed 32-byte-aligned same-run ceiling."
+  },
+  {
+    "suite": "bundle-size",
+    "op": "js_raw",
+    "target": "octane-jsx",
+    "reference": "octane-jsx-budget",
+    "maxRatio": 1,
+    "note": "Rows JSX total production raw bytes must not exceed the committed 32-byte-aligned same-run ceiling."
+  },
+  {
+    "suite": "bundle-size",
+    "op": "js_gzip",
+    "target": "octane-jsx",
+    "reference": "octane-jsx-budget",
+    "maxRatio": 1,
+    "note": "Rows JSX total production gzip bytes must not exceed the committed 32-byte-aligned same-run ceiling."
+  },
+  {
+    "suite": "bundle-size",
+    "op": "js_brotli",
+    "target": "octane-jsx",
+    "reference": "octane-jsx-budget",
+    "maxRatio": 1,
+    "note": "Rows JSX total production brotli bytes must not exceed the committed 32-byte-aligned same-run ceiling."
   },
   {
     "suite": "bundle-size",

--- a/benchmarks/bundle-size/jsx-budgets.json
+++ b/benchmarks/bundle-size/jsx-budgets.json
@@ -1,0 +1,17 @@
+{
+  "app": {
+    "raw": 8672,
+    "gzip": 2976,
+    "brotli": 2624
+  },
+  "framework": {
+    "raw": 101536,
+    "gzip": 33344,
+    "brotli": 29504
+  },
+  "total": {
+    "raw": 110112,
+    "gzip": 36224,
+    "brotli": 32000
+  }
+}

--- a/benchmarks/bundle-size/run.mjs
+++ b/benchmarks/bundle-size/run.mjs
@@ -69,6 +69,7 @@ const SETS = [
 	},
 ];
 const APP_BUDGETS = JSON.parse(fs.readFileSync(path.join(__dirname, 'app-budgets.json'), 'utf8'));
+const JSX_BUDGETS = JSON.parse(fs.readFileSync(path.join(__dirname, 'jsx-budgets.json'), 'utf8'));
 assert.deepEqual(
 	Object.keys(APP_BUDGETS).sort(),
 	SETS.map(({ prefix }) => (prefix ? prefix.slice(0, -1) : 'rows')).sort(),
@@ -186,10 +187,7 @@ for (const set of SETS)
 		});
 		entry.meta.files.push(...files.map((f) => ({ ...f, set: px || 'js' })));
 	}
-const budgetOps = {};
-for (const { prefix } of SETS) {
-	const name = prefix ? prefix.slice(0, -1) : 'rows';
-	const budget = APP_BUDGETS[name];
+function appendBudgetOperations(operations, budget, name, prefix = '') {
 	assert.deepEqual(
 		Object.keys(budget).sort(),
 		['app', 'framework', 'total'],
@@ -212,11 +210,21 @@ for (const { prefix } of SETS) {
 				true,
 				`${name}/${bucket}: invalid committed ${metric} byte budget`,
 			);
-			budgetOps[prefix + operation + '_' + metric] = val(bytes);
+			operations[prefix + operation + '_' + metric] = val(bytes);
 		}
 	}
 }
-targets.push({ name: 'octane-tsrx-budget', ops: budgetOps });
+
+const tsrxBudgetOps = {};
+for (const { prefix } of SETS) {
+	const name = prefix ? prefix.slice(0, -1) : 'rows';
+	appendBudgetOperations(tsrxBudgetOps, APP_BUDGETS[name], name, prefix);
+}
+targets.push({ name: 'octane-tsrx-budget', ops: tsrxBudgetOps });
+
+const jsxBudgetOps = {};
+appendBudgetOperations(jsxBudgetOps, JSX_BUDGETS, 'rows-jsx');
+targets.push({ name: 'octane-jsx-budget', ops: jsxBudgetOps });
 
 const payload = { suite: 'bundle-size', iterations: 1, targets };
 

--- a/benchmarks/weather-app/README.md
+++ b/benchmarks/weather-app/README.md
@@ -65,11 +65,23 @@ measurements beside these semantic controls.
 `weather-app-lighthouse` runs all six production apps through Lighthouse's desktop Dense 4G
 simulation with a fresh Chromium profile for every sample. It records performance,
 accessibility, best-practices, and SEO scores together with first and largest contentful
-paint, Speed Index, total blocking time, and cumulative layout shift. The upstream
-80/90/80/90 category thresholds are retained in result metadata; the stable
+paint, Speed Index, total blocking time, and cumulative layout shift. The existing
+`first_contentful_paint` and `largest_contentful_paint` operations are Lighthouse's
+**simulated** desktop-network estimates. Separate `observed_first_contentful_paint` and
+`observed_largest_contentful_paint` operations report the corresponding unthrottled
+browser-trace measurements from the same navigation; they are not interchangeable with
+the simulated values. Result metadata also reports the total JavaScript response
+transfer bytes, uncompressed resource bytes, and number of JavaScript requests. The
+upstream 80/90/80/90 category thresholds are retained in result metadata; the stable
 accessibility, best-practices, and SEO thresholds are gates, while the noisier
 performance threshold remains diagnostic. A browser preflight verifies visible London
 weather, and every audit must load the local mock without making external requests.
+
+Lighthouse's desktop model uses discrete network round trips, so compressed JavaScript
+can change its paint estimates in roughly 40 ms steps even when observed paint and
+application behavior are unchanged. Compare the modeled and observed measurements
+separately and inspect the actual response transfer bytes before attributing a modeled
+paint difference to rendering work.
 
 The repository-wide `bundle-size` suite also builds all six weather targets with the same
 normalized production minifier used for its other app comparisons. Its `weather_*`
@@ -79,11 +91,31 @@ an independently compressed response and sums the app and framework buckets; it 
 inspect a server's content encoding. The framework bucket includes the Octane workspace
 runtime or the reference framework's dependencies together with bundler virtual helpers.
 
+`pnpm --filter octane-weather-app-benchmarks bench:work` is an untimed production
+regression gate for Octane's compressed JavaScript and bookkeeping DOM nodes. Start the
+Octane production preview first. The gate verifies London weather, all seven forecast
+rows, expansion and collapse with preserved row identity, a live Tokyo search, rejected
+invalid-city input, Paris recovery, local storage, and the existing application semantics
+before enforcing its gzip and comment budgets. It never substitutes marker counts for
+those observable correctness controls.
+
+`pnpm --filter octane-weather-app-benchmarks bench:delivery` runs a separate,
+explicitly labeled client-rendered versus streamed-server-shell delivery experiment.
+Octane and React both use their native streaming renderer and hydrate an equivalent
+server-rendered shell; the existing six-framework client-rendered Lighthouse suite and
+its ratio guards remain unchanged. Server effects do not run, so the shell does not
+pretend to contain prefetched weather: both streamed targets still fetch the same local
+mock after hydration and must satisfy the same weather and interaction checks.
+
 ## Run
 
 ```bash
 node benchmarks/bench.mjs weather-app
 node benchmarks/bench.mjs --quick weather-app weather-app-lighthouse bundle-size
+pnpm --filter octane-tsrx-weather-app-bench build
+pnpm --filter octane-tsrx-weather-app-bench preview
+pnpm --filter octane-weather-app-benchmarks bench:work
+pnpm --filter octane-weather-app-benchmarks bench:delivery
 ```
 
 ## Attribution

--- a/benchmarks/weather-app/delivery.mjs
+++ b/benchmarks/weather-app/delivery.mjs
@@ -1,0 +1,403 @@
+// Compare genuinely streamed HTML plus hydration with the unchanged CSR build.
+// Effects never execute on the server: this streams the shared header/search
+// shell, not preloaded weather data, and reports the modes separately.
+
+process.env.NODE_ENV = 'production';
+
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import { createServer } from 'node:http';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { PassThrough } from 'node:stream';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { gzipSync } from 'node:zlib';
+import { chromium } from 'playwright';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const fixtureRequire = createRequire(new URL('./octane-tsrx/package.json', import.meta.url));
+const { build } = await import(pathToFileURL(fixtureRequire.resolve('vite')).href);
+const FRAMEWORKS = [
+	{ name: 'octane-tsrx', extension: 'js' },
+	{ name: 'react', extension: 'jsx' },
+];
+const positional = process.argv.slice(2).filter((argument) => !argument.startsWith('--'));
+const ITERATIONS = Number.parseInt(positional[0] ?? '3', 10);
+const VERIFY_ONLY = process.argv.includes('--verify-only');
+const KEEP_ARTIFACTS = process.argv.includes('--keep-artifacts');
+
+if (!Number.isSafeInteger(ITERATIONS) || ITERATIONS < 1) {
+	throw new Error('Weather delivery iterations must be a positive integer');
+}
+
+const artifacts = fs.mkdtempSync(path.join(os.tmpdir(), 'octane-weather-delivery-'));
+const servers = [];
+let browser;
+
+function assert(condition, message) {
+	if (!condition) throw new Error(`weather-app delivery verify failed: ${message}`);
+}
+
+// The canonical browser fixture intentionally assumes browser globals. Keep its
+// authored source and client bundle unchanged; only make the separately built
+// server module acknowledge that deterministic mock mode is safe during SSR.
+function serverMockMode() {
+	return {
+		name: 'weather-delivery-server-mock-mode',
+		enforce: 'pre',
+		transform(source, id, options) {
+			if (
+				!options?.ssr ||
+				path.normalize(id.split('?')[0]) !== path.join(HERE, 'shared', 'src', 'WeatherService.js')
+			) {
+				return null;
+			}
+
+			const signature = 'shouldUseMockData() {';
+			assert(source.includes(signature), 'WeatherService no longer exposes its mock-mode check');
+			return source.replace(
+				signature,
+				`${signature}\n\t\tif (typeof window === 'undefined') return true;`,
+			);
+		},
+	};
+}
+
+function outputChunks(result) {
+	const outputs = Array.isArray(result) ? result : [result];
+	return outputs.flatMap((output) => output.output ?? []);
+}
+
+async function buildFramework(framework) {
+	const root = path.join(HERE, framework.name);
+	const directory = path.join(artifacts, framework.name);
+	const csrDirectory = path.join(directory, 'csr');
+	const hydrationDirectory = path.join(directory, 'hydration');
+	const serverDirectory = path.join(directory, 'server');
+	const clientEntry = path.join(root, 'src', `entry-delivery-client.${framework.extension}`);
+	const serverEntry = path.join(root, 'src', `entry-delivery-server.${framework.extension}`);
+	const shared = { root, configFile: path.join(root, 'vite.config.js'), logLevel: 'error' };
+	fs.mkdirSync(directory, { recursive: true });
+	fs.symlinkSync(path.join(root, 'node_modules'), path.join(directory, 'node_modules'), 'dir');
+
+	console.error(`Building ${framework.name} CSR and streamed-shell hydration fixtures…`);
+	await build({
+		...shared,
+		build: { outDir: csrDirectory, emptyOutDir: true },
+	});
+
+	const hydration = await build({
+		...shared,
+		build: {
+			outDir: hydrationDirectory,
+			emptyOutDir: true,
+			rollupOptions: { input: { 'delivery-client': clientEntry } },
+		},
+	});
+	const hydrationEntry = outputChunks(hydration).find(
+		(chunk) => chunk.type === 'chunk' && chunk.isEntry,
+	);
+	assert(hydrationEntry, `${framework.name} hydration bundle has no client entry`);
+
+	const server = await build({
+		...shared,
+		plugins: [serverMockMode()],
+		build: { ssr: serverEntry, outDir: serverDirectory, emptyOutDir: true },
+	});
+	const serverOutput = outputChunks(server).find(
+		(chunk) => chunk.type === 'chunk' && chunk.isEntry,
+	);
+	assert(serverOutput, `${framework.name} server build has no render entry`);
+	const { renderApp } = await import(
+		pathToFileURL(path.join(serverDirectory, serverOutput.fileName)).href
+	);
+	assert(typeof renderApp === 'function', `${framework.name} server does not export renderApp`);
+
+	const template = fs.readFileSync(path.join(csrDirectory, 'index.html'), 'utf8');
+	const csrScript = template.match(/<script type="module" crossorigin src="([^"]+)"><\/script>/);
+	assert(csrScript, `${framework.name} CSR template has no production entry script`);
+	const hydrationScript = `/${hydrationEntry.fileName}`;
+	const streamedTemplate = template.replace(csrScript[1], hydrationScript);
+	const rootMarker = '<div id="main"></div>';
+	assert(streamedTemplate.includes(rootMarker), `${framework.name} template has no empty #main`);
+	const [prefix, suffix] = streamedTemplate.split(rootMarker);
+
+	return {
+		...framework,
+		csrDirectory,
+		hydrationDirectory,
+		prefix,
+		renderApp,
+		suffix,
+		template,
+	};
+}
+
+const CONTENT_TYPES = {
+	'.css': 'text/css; charset=utf-8',
+	'.html': 'text/html; charset=utf-8',
+	'.js': 'text/javascript; charset=utf-8',
+	'.json': 'application/json; charset=utf-8',
+	'.mjs': 'text/javascript; charset=utf-8',
+	'.svg': 'image/svg+xml',
+};
+
+function respondFile(request, response, file) {
+	const contents = fs.readFileSync(file);
+	response.setHeader(
+		'content-type',
+		CONTENT_TYPES[path.extname(file)] ?? 'application/octet-stream',
+	);
+	response.setHeader('cache-control', 'no-cache');
+	if (contents.length >= 1024 && /\bgzip\b/.test(request.headers['accept-encoding'] ?? '')) {
+		response.setHeader('content-encoding', 'gzip');
+		response.end(gzipSync(contents));
+		return;
+	}
+	response.end(contents);
+}
+
+function resolveAsset(directory, pathname) {
+	const file = path.resolve(directory, `.${decodeURIComponent(pathname)}`);
+	if (!file.startsWith(`${directory}${path.sep}`)) return null;
+	if (!fs.existsSync(file) || !fs.statSync(file).isFile()) return null;
+	return file;
+}
+
+function streamShell(framework, response) {
+	let controller;
+	let ready = false;
+	let started = false;
+	const body = new PassThrough();
+	const fail = (error) => {
+		const message = error instanceof Error ? error.message : String(error);
+		if (!response.headersSent) {
+			response.statusCode = 500;
+			response.end(message);
+			return;
+		}
+		response.destroy(new Error(message));
+	};
+
+	body.on('data', (chunk) => response.write(chunk));
+	body.once('error', fail);
+	body.once('end', () => {
+		response.end(
+			'</div><script>window.__weatherDelivery={' +
+				'mode:"streamed_shell",hydrationCalls:0,' +
+				'serverHeader:document.querySelector(".header"),' +
+				'serverSearch:document.querySelector("[data-testid=search-form]")' +
+				'};</script>' +
+				framework.suffix,
+		);
+	});
+
+	function flushShell() {
+		if (!ready || !controller || started) return;
+		started = true;
+		response.statusCode = 200;
+		response.setHeader('content-type', CONTENT_TYPES['.html']);
+		response.write(`${framework.prefix}<div id="main">`);
+		controller.pipe(body);
+	}
+
+	try {
+		controller = framework.renderApp({
+			onShellReady() {
+				ready = true;
+				flushShell();
+			},
+			onShellError: fail,
+			onError: fail,
+		});
+		flushShell();
+	} catch (error) {
+		fail(error);
+	}
+}
+
+async function serveFramework(framework) {
+	const server = createServer((request, response) => {
+		try {
+			const url = new URL(request.url ?? '/', 'http://127.0.0.1');
+			if (url.pathname === '/') {
+				if (url.searchParams.get('delivery') === 'streamed_shell') {
+					streamShell(framework, response);
+				} else {
+					respondFile(request, response, path.join(framework.csrDirectory, 'index.html'));
+				}
+				return;
+			}
+
+			const file =
+				resolveAsset(framework.hydrationDirectory, url.pathname) ??
+				resolveAsset(framework.csrDirectory, url.pathname);
+			if (file) {
+				respondFile(request, response, file);
+				return;
+			}
+			response.statusCode = 404;
+			response.end('Not found');
+		} catch (error) {
+			response.statusCode = 500;
+			response.end(error instanceof Error ? error.message : String(error));
+		}
+	});
+
+	await new Promise((resolve, reject) => {
+		server.once('error', reject);
+		server.listen(0, '127.0.0.1', resolve);
+	});
+	servers.push(server);
+	const address = server.address();
+	assert(address && typeof address !== 'string', `${framework.name} exposed no HTTP port`);
+	return `http://127.0.0.1:${address.port}/`;
+}
+
+async function verifyDelivery(framework, origin) {
+	const streamUrl = `${origin}?delivery=streamed_shell&mock=true&benchmark=true`;
+	const shell = await fetch(streamUrl).then((response) => response.text());
+	assert(shell.includes('Weather Front'), `${framework.name} streamed no server header`);
+	assert(shell.includes('data-testid="search-form"'), `${framework.name} streamed no search form`);
+	assert(
+		!shell.includes('London, United Kingdom'),
+		`${framework.name} unexpectedly preloaded weather`,
+	);
+
+	for (const mode of ['client', 'streamed_shell']) {
+		const context = await browser.newContext({ locale: 'en-US', timezoneId: 'UTC' });
+		const page = await context.newPage();
+		const errors = [];
+		page.on('pageerror', (error) => errors.push(error.message));
+		page.on('console', (message) => {
+			if (message.type() === 'error') errors.push(message.text());
+		});
+		try {
+			await page.goto(`${origin}?delivery=${mode}&mock=true&benchmark=true`, {
+				waitUntil: 'load',
+			});
+			await page.waitForFunction(
+				() =>
+					document.querySelector('[data-testid="current-location"]')?.textContent ===
+					'London, United Kingdom',
+				undefined,
+				{ timeout: 15_000 },
+			);
+			assert(
+				(await page.locator('[data-testid="forecast-item"]').count()) === 7,
+				`${framework.name}/${mode} did not render seven forecasts`,
+			);
+			if (mode === 'streamed_shell') {
+				const adoption = await page.evaluate(() => ({
+					hydrationCalls: window.__weatherDelivery?.hydrationCalls,
+					headerAdopted:
+						document.querySelector('.header') === window.__weatherDelivery?.serverHeader,
+					searchAdopted:
+						document.querySelector('[data-testid="search-form"]') ===
+						window.__weatherDelivery?.serverSearch,
+				}));
+				assert(adoption.hydrationCalls === 1, `${framework.name} did not hydrate exactly once`);
+				assert(adoption.headerAdopted, `${framework.name} replaced the server-rendered header`);
+				assert(
+					adoption.searchAdopted,
+					`${framework.name} replaced the server-rendered search form`,
+				);
+			}
+
+			await page.locator('[data-testid="search-input"]').fill('Tokyo');
+			await page.locator('[data-testid="search-button"]').click();
+			await page.waitForFunction(
+				() =>
+					document.querySelector('[data-testid="current-location"]')?.textContent ===
+					'Tokyo, Japan',
+				undefined,
+				{ timeout: 15_000 },
+			);
+			assert(
+				(await page.evaluate(() => localStorage.getItem('weather-app-location'))) === 'Tokyo',
+				`${framework.name}/${mode} did not persist the searched city`,
+			);
+			assert(errors.length === 0, `${framework.name}/${mode} browser errors: ${errors.join('; ')}`);
+		} finally {
+			await context.close();
+		}
+	}
+}
+
+async function runLighthouse(targets) {
+	const report = path.join(artifacts, 'delivery-lighthouse.json');
+	const environment = {
+		...process.env,
+		BENCH_JSON: report,
+		TARGETS: JSON.stringify(targets),
+		NO_PROXY: 'localhost,127.0.0.1,::1',
+		no_proxy: 'localhost,127.0.0.1,::1',
+	};
+	for (const proxy of [
+		'HTTP_PROXY',
+		'HTTPS_PROXY',
+		'ALL_PROXY',
+		'http_proxy',
+		'https_proxy',
+		'all_proxy',
+		'NODE_USE_ENV_PROXY',
+	]) {
+		delete environment[proxy];
+	}
+	await new Promise((resolve, reject) => {
+		const child = spawn(process.execPath, [path.join(HERE, 'lighthouse.mjs'), String(ITERATIONS)], {
+			env: environment,
+			stdio: 'inherit',
+		});
+		child.once('error', reject);
+		child.once('exit', (code) => {
+			if (code === 0) resolve();
+			else reject(new Error(`delivery Lighthouse exited with status ${code}`));
+		});
+	});
+
+	const payload = JSON.parse(fs.readFileSync(report, 'utf8'));
+	payload.suite = 'weather-app-delivery';
+	payload.delivery = {
+		modes: ['client', 'streamed_shell'],
+		serverPrefetchedWeather: false,
+		hydrationAdoptsServerShell: true,
+	};
+	if (process.env.BENCH_JSON) {
+		fs.writeFileSync(process.env.BENCH_JSON, `${JSON.stringify(payload, null, '\t')}\n`);
+	}
+	return payload;
+}
+
+try {
+	const frameworks = [];
+	for (const framework of FRAMEWORKS) {
+		frameworks.push(await buildFramework(framework));
+	}
+
+	browser = await chromium.launch({ headless: true });
+	const targets = [];
+	for (const framework of frameworks) {
+		const origin = await serveFramework(framework);
+		await verifyDelivery(framework, origin);
+		for (const mode of ['client', 'streamed_shell']) {
+			targets.push({ name: `${framework.name}-${mode}`, url: `${origin}?delivery=${mode}` });
+		}
+	}
+	await browser.close();
+	browser = undefined;
+
+	if (VERIFY_ONLY) {
+		console.log(
+			'Weather delivery: both frameworks adopted streamed shells and preserved interactions.',
+		);
+	} else {
+		await runLighthouse(targets);
+	}
+} finally {
+	if (browser) await browser.close();
+	await Promise.all(servers.map((server) => new Promise((resolve) => server.close(resolve))));
+	if (KEEP_ARTIFACTS) console.error(`Weather delivery artifacts: ${artifacts}`);
+	else fs.rmSync(artifacts, { recursive: true, force: true });
+}

--- a/benchmarks/weather-app/lighthouse.mjs
+++ b/benchmarks/weather-app/lighthouse.mjs
@@ -27,6 +27,11 @@ const METRICS = {
 	total_blocking_time: 'total-blocking-time',
 	cumulative_layout_shift: 'cumulative-layout-shift',
 };
+const OBSERVED_METRICS = {
+	observed_first_contentful_paint: 'observedFirstContentfulPaint',
+	observed_largest_contentful_paint: 'observedLargestContentfulPaint',
+};
+const OPERATIONS = [...Object.keys(METRICS), ...Object.keys(OBSERVED_METRICS)];
 const TARGETS = process.env.TARGETS
 	? JSON.parse(process.env.TARGETS)
 	: [
@@ -146,6 +151,12 @@ async function auditTarget(target, sample) {
 			assert(Number.isFinite(value) && value >= 0, `${target.name} ${audit} is unavailable`);
 			metrics[operation] = value;
 		}
+		const observedMetrics = lhr.audits.metrics?.details?.items?.[0];
+		for (const [operation, field] of Object.entries(OBSERVED_METRICS)) {
+			const value = observedMetrics?.[field];
+			assert(Number.isFinite(value) && value >= 0, `${target.name} ${field} is unavailable`);
+			metrics[operation] = value;
+		}
 
 		const expectedUrl = new URL(target.url);
 		const finalUrl = new URL(lhr.finalDisplayedUrl);
@@ -166,6 +177,23 @@ async function auditTarget(target, sample) {
 		assert(
 			externalRequests.length === 0,
 			`${target.name} made external requests: ${externalRequests.join(', ')}`,
+		);
+		const javascriptRequests = networkRequests.filter(
+			(request) => request.resourceType === 'Script',
+		);
+		assert(javascriptRequests.length > 0, `${target.name} did not load production JavaScript`);
+		const javascript = {
+			requests: javascriptRequests.length,
+			transferBytes: javascriptRequests.reduce((total, request) => total + request.transferSize, 0),
+			resourceBytes: javascriptRequests.reduce((total, request) => total + request.resourceSize, 0),
+		};
+		assert(
+			Number.isFinite(javascript.transferBytes) && javascript.transferBytes > 0,
+			`${target.name} JavaScript transfer size is unavailable`,
+		);
+		assert(
+			Number.isFinite(javascript.resourceBytes) && javascript.resourceBytes > 0,
+			`${target.name} JavaScript resource size is unavailable`,
 		);
 
 		const suboptimalAudits = {};
@@ -189,10 +217,31 @@ async function auditTarget(target, sample) {
 			chromeUserAgent: lhr.environment.hostUserAgent,
 			runWarnings: lhr.runWarnings,
 			networkRequestCount: networkRequests.length,
+			javascript,
 		};
 	} finally {
 		await chrome.kill();
 	}
+}
+
+async function auditTargetWithTransportRetry(target, sample) {
+	for (let attempt = 1; attempt <= 3; attempt++) {
+		try {
+			return await auditTarget(target, sample);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			const failedLocalDevTools =
+				/^Failed to fetch browser webSocket URL from http:\/\/(?:127\.0\.0\.1|localhost)(?::\d+)?\/json\/version\b/.test(
+					message,
+				) && /(?:HTTP Bad Gateway|fetch failed|ECONNREFUSED)/.test(message);
+			if (!failedLocalDevTools || attempt === 3) throw error;
+			console.error(
+				`Retrying ${target.name} sample ${sample + 1} after local DevTools startup failure ` +
+					`(${attempt}/2)…`,
+			);
+		}
+	}
+	throw new Error('unreachable Lighthouse transport retry state');
 }
 
 const values = new Map(
@@ -201,7 +250,7 @@ const values = new Map(
 		{
 			target,
 			categories: Object.fromEntries(CATEGORIES.map((category) => [category, []])),
-			metrics: Object.fromEntries(Object.keys(METRICS).map((operation) => [operation, []])),
+			metrics: Object.fromEntries(OPERATIONS.map((operation) => [operation, []])),
 			reports: [],
 		},
 	]),
@@ -214,12 +263,12 @@ try {
 		const orderedTargets = sample % 2 === 0 ? TARGETS : [...TARGETS].reverse();
 		for (const target of orderedTargets) {
 			console.error(`Lighthouse ${target.name} sample ${sample + 1}/${ITER}…`);
-			const report = await auditTarget(target, sample);
+			const report = await auditTargetWithTransportRetry(target, sample);
 			const targetValues = values.get(target.name);
 			for (const category of CATEGORIES) {
 				targetValues.categories[category].push(report.categories[category]);
 			}
-			for (const operation of Object.keys(METRICS)) {
+			for (const operation of OPERATIONS) {
 				targetValues.metrics[operation].push(report.metrics[operation]);
 			}
 			targetValues.reports.push(report);
@@ -274,8 +323,10 @@ const targets = TARGETS.map((target) => {
 			chromeUserAgent: lastReport?.chromeUserAgent ?? null,
 			runWarnings: lastReport?.runWarnings ?? [],
 			networkRequestCount: lastReport?.networkRequestCount ?? null,
+			javascript: lastReport?.javascript ?? null,
 			formFactor: 'desktop',
 			throttlingMethod: 'simulate',
+			observedMetrics: 'unthrottled-trace',
 			mockMode: true,
 		},
 	};

--- a/benchmarks/weather-app/octane-tsrx/src/entry-delivery-client.js
+++ b/benchmarks/weather-app/octane-tsrx/src/entry-delivery-client.js
@@ -1,0 +1,13 @@
+import { hydrateRoot } from 'octane';
+import { App } from './App.tsrx';
+
+const target = document.getElementById('main');
+if (!target) throw new Error('missing #main hydration root');
+
+const delivery = window.__weatherDelivery;
+if (!delivery || delivery.mode !== 'streamed_shell') {
+	throw new Error('missing server-rendered weather shell');
+}
+
+delivery.hydrationCalls++;
+hydrateRoot(target, App);

--- a/benchmarks/weather-app/octane-tsrx/src/entry-delivery-server.js
+++ b/benchmarks/weather-app/octane-tsrx/src/entry-delivery-server.js
@@ -1,0 +1,6 @@
+import { renderToPipeableStream } from 'octane/server';
+import { App } from './App.tsrx';
+
+export function renderApp(options) {
+	return renderToPipeableStream(App, {}, options);
+}

--- a/benchmarks/weather-app/package.json
+++ b/benchmarks/weather-app/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "bench": "node run.mjs",
     "bench:lighthouse": "node lighthouse.mjs",
+    "bench:delivery": "node delivery.mjs",
+    "bench:work": "node work.mjs",
     "bench:long": "node run.mjs 16"
   },
   "dependencies": {

--- a/benchmarks/weather-app/react/src/entry-delivery-client.jsx
+++ b/benchmarks/weather-app/react/src/entry-delivery-client.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { hydrateRoot } from 'react-dom/client';
+import App from './App.jsx';
+
+const target = document.getElementById('main');
+if (!target) throw new Error('missing #main hydration root');
+
+const delivery = window.__weatherDelivery;
+if (!delivery || delivery.mode !== 'streamed_shell') {
+	throw new Error('missing server-rendered weather shell');
+}
+
+delivery.hydrationCalls++;
+hydrateRoot(
+	target,
+	<React.StrictMode>
+		<App />
+	</React.StrictMode>,
+);

--- a/benchmarks/weather-app/react/src/entry-delivery-server.jsx
+++ b/benchmarks/weather-app/react/src/entry-delivery-server.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { renderToPipeableStream } from 'react-dom/server';
+import App from './App.jsx';
+
+export function renderApp(options) {
+	return renderToPipeableStream(
+		<React.StrictMode>
+			<App />
+		</React.StrictMode>,
+		options,
+	);
+}

--- a/benchmarks/weather-app/work.mjs
+++ b/benchmarks/weather-app/work.mjs
@@ -1,0 +1,259 @@
+// Deterministic production bundle and DOM-work gate for the Octane weather app.
+// Internal comment budgets are meaningful only alongside the visible app,
+// interaction, DOM-identity, persistence, and same-origin request controls.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { constants, gzipSync } from 'node:zlib';
+import { chromium } from 'playwright';
+import { censusDomNodes } from '../lib/dom-nodes.mjs';
+
+const ROOT = path.dirname(fileURLToPath(import.meta.url));
+const DIST = process.env.WEATHER_DIST || path.join(ROOT, 'octane-tsrx', 'dist');
+const TARGET = new URL(process.env.TARGET_URL || 'http://localhost:5292/');
+TARGET.searchParams.set('mock', 'true');
+TARGET.searchParams.set('benchmark', 'true');
+
+const MAX_GZIP_BYTES = 30_000;
+const MAX_COMMENTS = 18;
+const ELEMENTS = { loaded: 116, expanded: 135 };
+
+function assert(condition, message) {
+	if (!condition) throw new Error(`weather-app-work verify failed: ${message}`);
+}
+
+function javascriptFiles(directory) {
+	const entries = fs.readdirSync(directory, { withFileTypes: true });
+	return entries.flatMap((entry) => {
+		const filename = path.join(directory, entry.name);
+		if (entry.isDirectory()) return javascriptFiles(filename);
+		return /\.(?:m?js)$/.test(entry.name) ? [filename] : [];
+	});
+}
+
+const files = javascriptFiles(DIST);
+assert(files.length > 0, `no production JavaScript in ${DIST}; build the Octane app first`);
+const bundles = files.map((filename) => {
+	const contents = fs.readFileSync(filename);
+	return {
+		file: path.relative(DIST, filename),
+		rawBytes: contents.length,
+		gzipBytes: gzipSync(contents, { level: constants.Z_BEST_COMPRESSION }).length,
+	};
+});
+const javascript = {
+	files: bundles,
+	rawBytes: bundles.reduce((total, bundle) => total + bundle.rawBytes, 0),
+	gzipBytes: bundles.reduce((total, bundle) => total + bundle.gzipBytes, 0),
+};
+
+const browser = await chromium.launch({ headless: true });
+const pageErrors = [];
+const externalRequests = [];
+const mockRequests = [];
+let results;
+
+try {
+	const context = await browser.newContext({ locale: 'en-US', timezoneId: 'UTC' });
+	const page = await context.newPage();
+	page.on('pageerror', (error) => pageErrors.push(error.message));
+	page.on('request', (request) => {
+		const url = new URL(request.url());
+		if (url.origin !== TARGET.origin) externalRequests.push(url.href);
+		if (url.pathname === '/mocks/weather-data.json') mockRequests.push(url.href);
+	});
+	await page.goto(TARGET.href, { waitUntil: 'load' });
+	await page.waitForFunction(() => {
+		const content = document.querySelector('[data-testid="weather-content"]');
+		const loading = document.querySelector('[data-testid="loading"]');
+		const location = document.querySelector('[data-testid="current-location"]');
+		return Boolean(
+			content &&
+			!content.hidden &&
+			loading?.hidden &&
+			location?.textContent === 'London, United Kingdom',
+		);
+	});
+
+	const loaded = await page.evaluate(censusDomNodes, '#main');
+	const initial = await page.evaluate(() => ({
+		location: document.querySelector('[data-testid="current-location"]')?.textContent,
+		temperature: document.querySelector('[data-testid="current-temperature"]')?.textContent,
+		pressure: document.querySelector('[data-testid="pressure"]')?.textContent,
+		forecastItems: document.querySelectorAll('[data-testid="forecast-item"]').length,
+		search: document.querySelector('[data-testid="search-input"]')?.value,
+	}));
+	assert(initial.location === 'London, United Kingdom', `initial location is ${initial.location}`);
+	assert(initial.temperature === '16°C', `initial temperature is ${initial.temperature}`);
+	assert(initial.pressure === '1015 hPa', `initial pressure is ${initial.pressure}`);
+	assert(initial.forecastItems === 7, `initial forecast contains ${initial.forecastItems} rows`);
+	assert(initial.search === 'London', `initial search input is ${initial.search}`);
+	assert(loaded.elements === ELEMENTS.loaded, `loaded element count is ${loaded.elements}`);
+
+	const expansion = await page.evaluate(async () => {
+		const rows = Array.from(document.querySelectorAll('[data-testid="forecast-item"]'));
+		const first = rows[0];
+		first.click();
+		await new Promise((resolve, reject) => {
+			const observer = new MutationObserver(check);
+			const timeout = window.setTimeout(() => {
+				observer.disconnect();
+				reject(new Error('forecast did not expand'));
+			}, 5_000);
+			function check() {
+				if (
+					!first.classList.contains('active') ||
+					!first.querySelector('.forecast-item__details')
+				) {
+					return;
+				}
+				observer.disconnect();
+				window.clearTimeout(timeout);
+				resolve();
+			}
+			observer.observe(first, { attributes: true, childList: true, subtree: true });
+			check();
+		});
+		const currentRows = Array.from(document.querySelectorAll('[data-testid="forecast-item"]'));
+		return {
+			forecastItems: currentRows.length,
+			preservedRows: currentRows.every((row, index) => row === rows[index]),
+			details: document.querySelectorAll('.forecast-detail-item').length,
+			activeRows: document.querySelectorAll('.forecast-item.active').length,
+		};
+	});
+	assert(expansion.forecastItems === 7, 'forecast expansion changed the row count');
+	assert(expansion.preservedRows, 'forecast expansion replaced an existing row');
+	assert(expansion.details === 6, `forecast expansion contains ${expansion.details} details`);
+	assert(expansion.activeRows === 1, `forecast expansion selected ${expansion.activeRows} rows`);
+	const expanded = await page.evaluate(censusDomNodes, '#main');
+	assert(expanded.elements === ELEMENTS.expanded, `expanded element count is ${expanded.elements}`);
+
+	await page.locator('[data-testid="forecast-item"]').first().click();
+	await page.waitForFunction(
+		() => document.querySelectorAll('.forecast-item.active, .forecast-item__details').length === 0,
+	);
+
+	await page.evaluate(() => {
+		const input = document.querySelector('[data-testid="search-input"]');
+		const form = document.querySelector('[data-testid="search-form"]');
+		if (!(input instanceof HTMLInputElement) || !(form instanceof HTMLFormElement)) {
+			throw new Error('search controls are missing');
+		}
+		input.value = 'Tokyo';
+		input.dispatchEvent(new InputEvent('input', { bubbles: true, data: 'Tokyo' }));
+		form.requestSubmit();
+	});
+	await page.waitForFunction(() => {
+		const content = document.querySelector('[data-testid="weather-content"]');
+		const loading = document.querySelector('[data-testid="loading"]');
+		const location = document.querySelector('[data-testid="current-location"]');
+		return Boolean(
+			content && !content.hidden && loading?.hidden && location?.textContent === 'Tokyo, Japan',
+		);
+	});
+	const searched = await page.evaluate(() => ({
+		location: document.querySelector('[data-testid="current-location"]')?.textContent,
+		storedLocation: localStorage.getItem('weather-app-location'),
+		forecastItems: document.querySelectorAll('[data-testid="forecast-item"]').length,
+		temperature: document.querySelector('[data-testid="current-temperature"]')?.textContent,
+		pressure: document.querySelector('[data-testid="pressure"]')?.textContent,
+	}));
+	assert(searched.location === 'Tokyo, Japan', `searched location is ${searched.location}`);
+	assert(searched.storedLocation === 'Tokyo', 'successful search was not persisted');
+	assert(searched.forecastItems === 7, 'successful search changed the forecast row count');
+	assert(searched.temperature === '16°C', `searched temperature is ${searched.temperature}`);
+	assert(searched.pressure === '1015 hPa', `searched pressure is ${searched.pressure}`);
+
+	await page.locator('[data-testid="search-input"]').fill('Invalid 123');
+	await page.locator('[data-testid="search-form"]').evaluate((form) => form.requestSubmit());
+	await page.waitForFunction(() => {
+		const error = document.querySelector('[data-testid="error"]');
+		const content = document.querySelector('[data-testid="weather-content"]');
+		const loading = document.querySelector('[data-testid="loading"]');
+		return Boolean(error && !error.hidden && content?.hidden && loading?.hidden);
+	});
+	const rejected = await page.evaluate(() => ({
+		message: document
+			.querySelector('[data-testid="error"] .error__message')
+			?.textContent?.replace(/\s+/g, ' ')
+			.trim(),
+		storedLocation: localStorage.getItem('weather-app-location'),
+	}));
+	assert(
+		rejected.message === 'Unable to find location. Please check the city name and try again.',
+		`invalid-city error is ${rejected.message}`,
+	);
+	assert(rejected.storedLocation === 'Tokyo', 'failed search overwrote the last successful city');
+
+	await page.locator('[data-testid="search-input"]').fill('Paris');
+	await page.locator('[data-testid="search-form"]').evaluate((form) => form.requestSubmit());
+	await page.waitForFunction(() => {
+		const content = document.querySelector('[data-testid="weather-content"]');
+		const error = document.querySelector('[data-testid="error"]');
+		const loading = document.querySelector('[data-testid="loading"]');
+		const location = document.querySelector('[data-testid="current-location"]');
+		return Boolean(
+			content &&
+			!content.hidden &&
+			error?.hidden &&
+			loading?.hidden &&
+			location?.textContent === 'Paris, France',
+		);
+	});
+	const recovered = await page.evaluate(() => ({
+		location: document.querySelector('[data-testid="current-location"]')?.textContent,
+		storedLocation: localStorage.getItem('weather-app-location'),
+		forecastItems: document.querySelectorAll('[data-testid="forecast-item"]').length,
+		temperature: document.querySelector('[data-testid="current-temperature"]')?.textContent,
+		pressure: document.querySelector('[data-testid="pressure"]')?.textContent,
+	}));
+	assert(recovered.location === 'Paris, France', `recovered location is ${recovered.location}`);
+	assert(recovered.storedLocation === 'Paris', 'recovered search was not persisted');
+	assert(recovered.forecastItems === 7, 'recovered search changed the forecast row count');
+	assert(recovered.temperature === '16°C', `recovered temperature is ${recovered.temperature}`);
+	assert(recovered.pressure === '1015 hPa', `recovered pressure is ${recovered.pressure}`);
+	assert(
+		mockRequests.length === 3,
+		`expected three local mock requests, received ${mockRequests.length}`,
+	);
+	assert(externalRequests.length === 0, `external requests: ${externalRequests.join(', ')}`);
+	assert(pageErrors.length === 0, `uncaught page errors: ${pageErrors.join('; ')}`);
+
+	results = { initial, loaded, expansion, expanded, searched, rejected, recovered, javascript };
+} finally {
+	await browser.close();
+}
+
+const failures = [];
+if (results.loaded.comments > MAX_COMMENTS) {
+	failures.push(`loaded comments: ${results.loaded.comments} exceeds ${MAX_COMMENTS}`);
+}
+if (results.expanded.comments > MAX_COMMENTS) {
+	failures.push(`expanded comments: ${results.expanded.comments} exceeds ${MAX_COMMENTS}`);
+}
+if (javascript.gzipBytes > MAX_GZIP_BYTES) {
+	failures.push(`production JavaScript gzip: ${javascript.gzipBytes} exceeds ${MAX_GZIP_BYTES}`);
+}
+
+console.log(`Loaded DOM: ${results.loaded.total} nodes, ${results.loaded.comments} comments`);
+console.log(`Expanded DOM: ${results.expanded.total} nodes, ${results.expanded.comments} comments`);
+console.log(
+	`Production JavaScript: ${javascript.rawBytes} raw, ${javascript.gzipBytes} gzip bytes`,
+);
+
+if (process.env.WORK_JSON) {
+	fs.writeFileSync(
+		process.env.WORK_JSON,
+		JSON.stringify(
+			{ suite: 'weather-app-work', target: TARGET.href, results, failures },
+			null,
+			'\t',
+		) + '\n',
+	);
+}
+if (failures.length > 0) {
+	console.error(failures.join('\n'));
+	process.exitCode = 1;
+}

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -1309,10 +1309,10 @@ function annotatePureLazyCalls(ast) {
 }
 
 /**
- * Lower the exact imported `<ErrorBoundary>` builtin to the same tryBlock IR
- * as `@try/@catch` when its fallback is statically compilable. This removes the
- * generic component/children dispatcher while preserving the public JSX API.
- * Dynamic props, spreads, keys, and shadowed imports stay on the runtime path.
+ * Lower the exact imported `<ErrorBoundary>` builtin to catch-only boundary IR
+ * when its fallback is statically compilable. Client output uses errorBlock;
+ * server output keeps the existing ssrTry wire contract. Dynamic props,
+ * spreads, keys, and shadowed imports stay on the generic runtime path.
  */
 function lowerImportedErrorBoundaries(ast) {
 	const boundaryLocals = new Set();
@@ -7515,7 +7515,11 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 			// `const el = <App/>`) to createElement(...) before printing — esrap
 			// can't print raw JSX, and this is what makes root.render(<App/>) match
 			// React's shape.
-			const lowered = stampAnonymousDefaultFunctionLoc(rewriteModuleJsxValues(hooked, ctx), ctx);
+			const lowered = markSingleRootMemoInitializers(
+				stampAnonymousDefaultFunctionLoc(rewriteModuleJsxValues(hooked, ctx), ctx),
+				ctx,
+				memoImportNames,
+			);
 			// Top-level passthrough (imports, plain consts/functions): already a
 			// rewritten statement node — embedded directly in the module AST.
 			bodyNodes.push(lowered);
@@ -10940,6 +10944,43 @@ function stripNonReferenceText(source) {
 function singleRootInitializer(ctx, component) {
 	ctx.runtimeNeeded.add('__s');
 	return markPure(b.call('_$__s', component));
+}
+
+// An exact public memo wrapper preserves the already-proven host output of its
+// immutable local component. Stamp only the fresh compiler-owned wrapper:
+// probing arbitrary component metadata would invoke observable getters, and
+// dev/HMR, custom comparators, imported components, and renderer units remain
+// deliberately opaque.
+function markSingleRootMemoInitializers(node, ctx, memoImportNames) {
+	if (ctx.hmr || ctx.dev || ctx.profile || memoImportNames.size === 0) return node;
+	const exported = node.type === 'ExportNamedDeclaration';
+	const declaration = exported ? node.declaration : node;
+	if (declaration?.type !== 'VariableDeclaration' || declaration.kind !== 'const') return node;
+	let changed = false;
+	const declarations = declaration.declarations.map((item) => {
+		const init = item.init;
+		const wrapped = init?.arguments?.[0];
+		if (
+			item.id?.type !== 'Identifier' ||
+			!ctx.defaultMemoBindings.has(item.id.name) ||
+			init?.type !== 'CallExpression' ||
+			init.callee?.type !== 'Identifier' ||
+			!memoImportNames.has(init.callee.name) ||
+			init.arguments.length !== 1 ||
+			wrapped?.type !== 'Identifier' ||
+			!ctx.moduleFunctionDeclarations.has(wrapped.name) ||
+			ctx.componentInfo.get(wrapped.name)?.singleRoot !== true ||
+			ctx._universalRuntimeUnitsByBinding.has(item.id.name) ||
+			ctx._universalRuntimeUnitsByBinding.has(wrapped.name)
+		) {
+			return item;
+		}
+		changed = true;
+		return { ...item, init: inheritOriginLoc(singleRootInitializer(ctx, init), init) };
+	});
+	if (!changed) return node;
+	const next = { ...declaration, declarations };
+	return exported ? { ...node, declaration: next } : next;
 }
 
 function finalizeComponentInitializers(ctx, bodyNodes) {
@@ -18807,8 +18848,11 @@ function planJsx(
 	for (const tc of tryCalls) {
 		const slotIndex = tc.slotIndex;
 		const org = tc.origin ?? planOrigin;
-		ctx.runtimeNeeded.add('tryBlock');
-		registerDirectiveOrigin(ctx, org, ['_$tryBlock', tc.tryHelper]);
+		const catchOnly =
+			tc.propagateSuspense && tc.pendingHelper === 'null' && tc.catchHelper !== 'null';
+		const boundaryHelper = catchOnly ? 'errorBlock' : 'tryBlock';
+		ctx.runtimeNeeded.add(boundaryHelper);
+		registerDirectiveOrigin(ctx, org, [rtAlias(boundaryHelper), tc.tryHelper]);
 		registerClauseOrigin(ctx, tc.handlerKeyword, [tc.catchHelper]);
 		registerClauseOrigin(ctx, tc.pendingKeyword, [tc.pendingHelper]);
 		// Anchor selection — see anchorNodeFor (mirrors ifBlock, including the
@@ -18816,24 +18860,25 @@ function planJsx(
 		const tryAnchor = anchorNodeFor(tc, 'tryAnchor');
 		const tryEnv = envNodeFor(tc);
 		const trailing = [];
-		if (tryAnchor || tryEnv || tc.propagateSuspense) trailing.push(tryAnchor || undefinedNode());
-		if (tryEnv || tc.propagateSuspense) trailing.push(tryEnv || undefinedNode());
-		if (tc.propagateSuspense) trailing.push(b.literal(true));
+		if (tryAnchor || tryEnv || (!catchOnly && tc.propagateSuspense)) {
+			trailing.push(tryAnchor || undefinedNode());
+		}
+		if (tryEnv || (!catchOnly && tc.propagateSuspense)) trailing.push(tryEnv || undefinedNode());
+		if (!catchOnly && tc.propagateSuspense) trailing.push(b.literal(true));
+		const boundaryArgs = [
+			b.id('__s'),
+			b.literal(slotIndex),
+			hostNodeFor(`_tryHost$${tc.id}`),
+			helperRefNode(tc.tryHelper),
+			inheritOriginLoc(helperRefNode(tc.catchHelper), tc.handlerKeyword),
+		];
+		if (!catchOnly) {
+			boundaryArgs.push(inheritOriginLoc(helperRefNode(tc.pendingHelper), tc.pendingKeyword));
+		}
 		pushAfterStmt(
 			tc.id,
 			org,
-			b.stmt(
-				b.call(
-					'_$tryBlock',
-					b.id('__s'),
-					b.literal(slotIndex),
-					hostNodeFor(`_tryHost$${tc.id}`),
-					helperRefNode(tc.tryHelper),
-					inheritOriginLoc(helperRefNode(tc.catchHelper), tc.handlerKeyword),
-					inheritOriginLoc(helperRefNode(tc.pendingHelper), tc.pendingKeyword),
-					...trailing,
-				),
-			),
+			b.stmt(b.call(rtAlias(boundaryHelper), ...boundaryArgs, ...trailing)),
 		);
 	}
 	for (const sc of ctx._switchCalls) {

--- a/packages/octane/src/index.ts
+++ b/packages/octane/src/index.ts
@@ -189,6 +189,7 @@ export {
 	keyedForBlock,
 	mapSlot,
 	ifBlock,
+	errorBlock,
 	tryBlock,
 	switchBlock,
 	activityBlock,

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -2777,6 +2777,24 @@ function sortWaveByDepth(wave: Block[]): Block[] {
 	return wave;
 }
 
+// Hidden-owner scheduling is optional: roots without Suspense or hidden
+// Activity must not retain either feature's concrete reveal implementation.
+interface ScheduledVisibilityDriver {
+	find: typeof findHiddenRenderOwner;
+	reveal: typeof attemptHiddenReveal;
+	rehide: typeof rehideActivityAfterDescendantRender;
+}
+
+let SCHEDULED_VISIBILITY_DRIVER: ScheduledVisibilityDriver | null = null;
+
+function ensureScheduledVisibilityDriver(): void {
+	SCHEDULED_VISIBILITY_DRIVER ??= {
+		find: findHiddenRenderOwner,
+		reveal: attemptHiddenReveal,
+		rehide: rehideActivityAfterDescendantRender,
+	};
+}
+
 // Drain QUEUE. Order ancestors before descendants so a parent's cascade coalesces
 // queued descendants regardless of the order their setStates ran. The flush is
 // synchronous, so we sort and drain the LIVE array in place — no per-flush snapshot
@@ -2808,7 +2826,8 @@ function drainQueue(): { err: any } | null {
 		}
 		const crossRenderUpdate = block.crossRenderUpdate;
 		block.crossRenderUpdate = false;
-		const hiddenOwner = findHiddenRenderOwner(block, true);
+		const visibilityDriver = SCHEDULED_VISIBILITY_DRIVER;
+		const hiddenOwner = visibilityDriver === null ? null : visibilityDriver.find(block, true);
 		let hiddenActivity: ActivitySlot | null = null;
 		let hiddenTry: TrySlot | null = null;
 		if (hiddenOwner !== null) {
@@ -2827,7 +2846,7 @@ function drainQueue(): { err: any } | null {
 			// retries the render; if it no longer suspends (an external store flipped
 			// before the suspending promise resolved), the boundary reveals now.
 			if (hiddenTry !== null) {
-				attemptHiddenReveal(hiddenTry, block.pendingMode ?? 'urgent');
+				visibilityDriver!.reveal(hiddenTry, block.pendingMode ?? 'urgent');
 				continue;
 			}
 			// Guarded render-phase updates (derived state) converge in a couple of
@@ -2881,7 +2900,7 @@ function drainQueue(): { err: any } | null {
 			// A descendant render can replace an Activity's direct host root. The
 			// Activity itself did not render, so reapply its visual hide after the
 			// complete attempt (including a captured error or Suspense retry).
-			if (hiddenActivity !== null) rehideActivityAfterDescendantRender(hiddenActivity);
+			if (hiddenActivity !== null) visibilityDriver!.rehide(hiddenActivity);
 		}
 	}
 	QUEUE.length = 0;
@@ -4965,7 +4984,7 @@ function unmountScopeChildrenAndSlotsOnly(scope: Scope, detachDom: boolean): voi
 	if (slots !== null) {
 		for (let i = 0, n = slots.length; i < n; i++) {
 			const val = slots[i];
-			if ((val.__flags & SLOT_FLAG_TEARDOWN) !== 0) val.__teardown(val);
+			if ((val.__flags & SLOT_FLAG_TEARDOWN) !== 0) val.__teardown(val, detachDom);
 			// Read __kind ONCE per slot — the property access is megamorphic across
 			// six slot shapes, so caching the local saves three repeat IC walks.
 			const k = val.__kind;
@@ -5004,50 +5023,12 @@ function unmountScopeChildrenAndSlotsOnly(scope: Scope, detachDom: boolean): voi
 				// unmountBlock's deoptNode hook).
 				if (val.hostNode != null) detachDeoptTreeRefs(val.hostNode, null);
 			} else {
-				// componentSlotSlot | portalSlotSlot | trySlotSlot
+				// componentSlotSlot | portalSlotSlot | optional boundary slots
 				// Portal DOM lives in a FOREIGN target — the root-level batched clear
 				// never reaches it, so portals must always self-detach individually.
 				const childDetach = k === 'portalSlotSlot' ? true : detachDom;
 				if (val.block) unmountBlock(val.block, childDetach);
-				// A pending trySlot keeps its hidden `tryBlock` ALIVE beside the visible
-				// fallback. Tear that persistent block down explicitly so its effects,
-				// subscriptions, portals, and non-ref cleanups cannot outlive the boundary.
-				// Its refs already cycled to null when the fallback appeared, so suppress
-				// only the duplicate permanent detach while doing the full teardown.
-				if (k === 'trySlotSlot') {
-					discardOffscreenCapture(val.stagedCapture);
-					val.stagedCapture = null;
-					val.stagedEffectDeps = null;
-					const hadDetachedRefs = val.detachedRefs !== null;
-					val.detachedRefs = null;
-					val.pendingThenable = null;
-					if (val.tryBlock && val.tryBlock !== val.block) {
-						const hiddenTry = val.tryBlock;
-						let suppressedRefs: SuspenseRefEntry[] | null = null;
-						if (hadDetachedRefs) {
-							suppressedRefs = [];
-							collectVisibleSubtreeRefs(hiddenTry, suppressedRefs);
-						}
-						showTryBlock(val);
-						withRefDetachSuppression(suppressedRefs, () => {
-							unmountBlock(hiddenTry, true);
-						});
-						val.tryBlock = null;
-					}
-					// Unmounted while holding for a transition — leave the entangled group
-					// so staged siblings aren't left waiting on a boundary that's now gone.
-					abandonHeldTransition(val);
-					// Cancel any in-flight transition-fallback timeout so the callback
-					// can't fire after the slot's owning scope is gone.
-					if (val.transitionTimeoutId !== null) {
-						clearTimeout(val.transitionTimeoutId);
-						val.transitionTimeoutId = null;
-					}
-					// The DevTools boundary registry follows the TrySlot lifetime.
-					// Reset through the shared branch mutation point so profile
-					// builds remove this slot from the registry on teardown.
-					setTryBranch(val, -1);
-				} else if (k === 'portalSlotSlot' && val.target) {
+				if (k === 'portalSlotSlot' && val.target) {
 					unregisterDelegationTarget(val.target);
 				}
 			}
@@ -19276,8 +19257,42 @@ function releaseHiddenText(text: Text): void {
 	}
 }
 
+// Keep Suspense-specific teardown out of the always-live generic slot walk.
+// The visible arm must still unmount before its preserved hidden primary.
+function teardownTrySlot(state: TrySlot, detachDom: boolean): void {
+	if (state.block !== null) unmountBlock(state.block, detachDom);
+	discardOffscreenCapture(state.stagedCapture);
+	state.stagedCapture = null;
+	state.stagedEffectDeps = null;
+	const hadDetachedRefs = state.detachedRefs !== null;
+	state.detachedRefs = null;
+	state.pendingThenable = null;
+	if (state.tryBlock !== null && state.tryBlock !== state.block) {
+		const hiddenTry = state.tryBlock;
+		let suppressedRefs: SuspenseRefEntry[] | null = null;
+		if (hadDetachedRefs) {
+			suppressedRefs = [];
+			collectVisibleSubtreeRefs(hiddenTry, suppressedRefs);
+		}
+		showTryBlock(state);
+		withRefDetachSuppression(suppressedRefs, () => {
+			unmountBlock(hiddenTry, true);
+		});
+		state.tryBlock = null;
+	}
+	abandonHeldTransition(state);
+	if (state.transitionTimeoutId !== null) {
+		clearTimeout(state.transitionTimeoutId);
+		state.transitionTimeoutId = null;
+	}
+	setTryBranch(state, -1);
+	state.block = null;
+}
+
 interface TrySlot {
 	__kind: 'trySlotSlot';
+	__flags: typeof SLOT_FLAG_TEARDOWN;
+	__teardown: typeof teardownTrySlot;
 	start: Comment;
 	end: Comment;
 	// -1 init, 0 catch, 1 try (resolved), 2 pending
@@ -19366,11 +19381,39 @@ interface TrySlot {
 	reset: () => void;
 }
 
-// Single mutation point for `TrySlot.branch`. The bare assignment is the hot
+/** Catch-only JSX boundaries never preserve a hidden Suspense primary. */
+interface ErrorSlot {
+	__kind: 'errorSlotSlot';
+	__flags: typeof SLOT_FLAG_TEARDOWN;
+	__teardown: typeof teardownErrorSlot;
+	start: Comment;
+	end: Comment;
+	branch: -1 | 0 | 1 | 2;
+	block: Block | null;
+	tryBody: ComponentBody;
+	catchBody: ComponentBody;
+	env: any[] | undefined;
+	hasResolved: boolean;
+	err: any;
+	detachedRefs: null;
+	domParent: Node;
+	parentBlock: Block;
+	idState: RootIdState;
+	passthrough: boolean;
+	reset: () => void;
+}
+
+function teardownErrorSlot(state: ErrorSlot, detachDom: boolean): void {
+	if (state.block !== null) unmountBlock(state.block, detachDom);
+	state.block = null;
+	setTryBranch(state, -1);
+}
+
+// Single mutation point for boundary branches. The bare assignment is the hot
 // path; the devtools probe is fully behind the profile gate (dead-code
 // eliminated in non-profile builds), so this adds only a boolean-guarded call
 // over the plain assignment and no allocation/closure when unobserved.
-function setTryBranch(slot: TrySlot, next: -1 | 0 | 1 | 2): void {
+function setTryBranch(slot: TrySlot | ErrorSlot, next: -1 | 0 | 1 | 2): void {
 	slot.branch = next;
 	if (typeof __OCTANE_PROFILE_ENABLED__ !== 'undefined' && __OCTANE_PROFILE_ENABLED__) {
 		if (next === -1) {
@@ -19504,6 +19547,221 @@ function renderPassthroughTry(state: TrySlot): void {
 	}
 }
 
+/**
+ * Exact imported JSX ErrorBoundary lowering. Unlike @try, these boundaries
+ * only catch application errors: suspension belongs to an enclosing Suspense.
+ * Keeping their state independent lets catch-only applications discard the
+ * hidden-primary, transition-hold, and off-screen rendering implementations.
+ */
+export function errorBlock(
+	parentScope: Scope,
+	slotKey: number,
+	domParent: Node,
+	tryBody: ComponentBody,
+	catchBody: ComponentBody,
+	anchor?: Node | null,
+	env?: any[],
+): () => void {
+	const parentBlock = parentScope.block;
+	const hydration = activeHydration();
+	let state = parentScope.slots[slotKey] as ErrorSlot | undefined;
+	if (state === undefined) {
+		const passthrough = hydration?.passthroughRanges === true;
+		const open = passthrough ? null : (hydration?.resolveOpen(anchor, domParent) ?? null);
+		let start: Comment;
+		let end: Comment;
+		if (passthrough) {
+			start = document.createComment('passthrough-try');
+			end = document.createComment('/passthrough-try');
+		} else if (open !== null) {
+			start = open;
+			end = hydration!.close(open);
+		} else {
+			start = document.createComment('try');
+			end = document.createComment('/try');
+			domParent.insertBefore(start, anchor ?? null);
+			domParent.insertBefore(end, anchor ?? null);
+		}
+		let newState: ErrorSlot;
+		newState = {
+			__kind: 'errorSlotSlot',
+			__flags: SLOT_FLAG_TEARDOWN,
+			__teardown: teardownErrorSlot,
+			start,
+			end,
+			branch: -1,
+			block: null,
+			tryBody,
+			catchBody,
+			env,
+			hasResolved: false,
+			err: null,
+			detachedRefs: null,
+			domParent,
+			parentBlock,
+			idState: parentBlock.idState,
+			passthrough,
+			reset: () => requestReset(newState),
+		};
+		parentScope.slots[slotKey] = newState;
+		registerSlot(parentScope, newState);
+		state = newState;
+	} else {
+		state.tryBody = tryBody;
+		state.catchBody = catchBody;
+		state.env = env;
+	}
+
+	if (state.branch === 0) {
+		const caught = state.block!;
+		caught.body = state.catchBody;
+		caught.props = { err: state.err, reset: state.reset };
+		caught.extra = state.env;
+		renderBlock(caught);
+		return state.reset;
+	}
+
+	if (state.branch === 1 && state.block !== null) {
+		const current = state.block;
+		current.body = state.tryBody;
+		current.extra = state.env;
+		try {
+			renderBlock(current);
+		} catch (error) {
+			if (isHostContextRequest(error) || isSuspenseException(error)) throw error;
+			switchErrorToCatch(state, error);
+		}
+		return state.reset;
+	}
+
+	if (state.block !== null) {
+		const previous = state.block;
+		state.block = null;
+		unmountBlock(previous);
+		if (state.parentBlock.disposed || state.block !== null) return state.reset;
+	}
+	setTryBranch(state, 1);
+	let start: Node | null = null;
+	let end: Node | null = null;
+	if (!state.passthrough) {
+		const cursor = state.start.nextSibling;
+		if (hydration !== null && hydration.isOpen(cursor)) {
+			start = cursor;
+			end = hydration.close(cursor);
+			hydration.node = start.nextSibling;
+		} else {
+			start = document.createComment('try-b');
+			end = document.createComment('/try-b');
+			state.domParent.insertBefore(start, state.end);
+			state.domParent.insertBefore(end, state.end);
+			if (hydration !== null) {
+				hydration.markFresh(start);
+				hydration.markFresh(end);
+			}
+		}
+	}
+	const body = createBlock(
+		'control-flow',
+		state.parentBlock,
+		state.domParent,
+		start,
+		end,
+		state.tryBody,
+		undefined,
+		state.env,
+	);
+	body.idState = state.idState;
+	(body as any).$$tryHandler = (error: unknown) => switchErrorToCatch(state!, error);
+	state.block = body;
+	try {
+		renderBlock(body);
+		state.hasResolved = true;
+	} catch (error) {
+		if (isHostContextRequest(error) || isSuspenseException(error)) throw error;
+		const adoptServerCatch = hydration?.isRejection(error) === true;
+		switchErrorToCatch(
+			state,
+			error,
+			adoptServerCatch && start !== null ? start : undefined,
+			adoptServerCatch && end !== null ? end : undefined,
+		);
+	}
+	return state.reset;
+}
+
+function switchErrorToCatch(
+	state: ErrorSlot,
+	error: any,
+	adoptedStart?: Node,
+	adoptedEnd?: Node,
+): void {
+	const hydration = activeHydration();
+	const adopting = adoptedStart !== undefined && adoptedEnd !== undefined;
+	const previous = state.block;
+	if (previous !== null) {
+		state.block = null;
+		unmountBlock(previous, !adopting);
+		if (state.parentBlock.disposed || state.block !== null) return;
+	}
+	const rejection = hydration?.isRejection(error) === true;
+	const caughtError = rejection ? error.reason : error;
+	state.hasResolved = false;
+	setTryBranch(state, 0);
+	state.err = caughtError;
+	let start: Node | null = null;
+	let end: Node | null = null;
+	if (!state.passthrough) {
+		start = adoptedStart ?? document.createComment('catch-b');
+		end = adoptedEnd ?? document.createComment('/catch-b');
+		if (!adopting) {
+			if (hydration !== null) {
+				if (hydration.isClose(state.end)) {
+					removeRange(state.start.nextSibling, state.end);
+					hydration.node = state.end;
+				}
+				hydration.markFresh(start);
+				hydration.markFresh(end);
+			}
+			state.domParent.insertBefore(start, state.end);
+			state.domParent.insertBefore(end, state.end);
+		} else if (hydration !== null) {
+			hydration.node = start.nextSibling;
+		}
+	}
+	const caught = createBlock(
+		'control-flow',
+		state.parentBlock,
+		state.domParent,
+		start,
+		end,
+		state.catchBody,
+		{ err: caughtError, reset: state.reset },
+		state.env,
+	);
+	caught.idState = state.idState;
+	state.block = caught;
+	try {
+		if (!adopting && !state.passthrough && hydration !== null) {
+			hydration.suspend(() => renderBlock(caught));
+		} else {
+			renderBlock(caught);
+		}
+	} catch (nextError) {
+		const rethrowsReason = rejection && Object.is(nextError, caughtError);
+		if (state.block !== null) {
+			unmountBlock(state.block, !(adopting && rethrowsReason));
+			state.block = null;
+		}
+		const propagated = rethrowsReason ? error : nextError;
+		if (CURRENT_BLOCK !== null && (rethrowsReason || findTryHandler(state.parentBlock) !== null)) {
+			throw propagated;
+		}
+		const parent = findTryHandler(state.parentBlock);
+		if (parent !== null) parent(propagated);
+		else console.error('catch body threw, no outer tryBlock:', nextError);
+	}
+}
+
 export function tryBlock(
 	parentScope: Scope,
 	slotKey: number,
@@ -19555,6 +19813,8 @@ export function tryBlock(
 		let newState: TrySlot;
 		newState = {
 			__kind: 'trySlotSlot',
+			__flags: SLOT_FLAG_TEARDOWN,
+			__teardown: teardownTrySlot,
 			start,
 			end,
 			branch: -1,
@@ -19920,6 +20180,9 @@ function handleSuspense(
 	// retry, neither of which has committed content to keep whole).
 	journalCheckpoint = -1,
 ): void {
+	// Ordinary roots do not need hidden-subtree ancestry walks. Install this
+	// capability before the first boundary can preserve a suspended primary.
+	ensureScheduledVisibilityDriver();
 	// Transition-priority suspends on an ALREADY-committed try block keep the
 	// prior DOM visible — matches React's `useTransition` contract that the
 	// previous screen stays mounted until the new tree is fully ready. We also
@@ -21497,7 +21760,7 @@ export function useDeferredValue<T>(value: T, ...rest: any[]): T {
 	return s.current;
 }
 
-function requestReset(state: TrySlot): void {
+function requestReset(state: TrySlot | ErrorSlot): void {
 	if (state.parentBlock.disposed || state.branch !== 0) return;
 	// React parity for catch reset(): don't synchronously re-run the try body.
 	// Rewind slot state and schedule the parent — sibling setState calls in
@@ -22399,6 +22662,7 @@ export function activityBlock(
 	// Hoisted-helper env tuple (compiled-output Phase 2) — see renderBranchSlot.
 	env?: any[],
 ): void {
+	if (mode === 'hidden') ensureScheduledVisibilityDriver();
 	const parentBlock = parentScope.block;
 	const hydration = activeHydration();
 	const wantHidden = mode === 'hidden';

--- a/packages/octane/tests/_fixtures/boundary.tsrx
+++ b/packages/octane/tests/_fixtures/boundary.tsrx
@@ -1,4 +1,4 @@
-import { Suspense, ErrorBoundary, use, useState } from 'octane';
+import { Suspense, ErrorBoundary, use, useEffect, useLayoutEffect, useState } from 'octane';
 
 export function Suspender(props) @{
 	const v = use(props.promise);
@@ -82,5 +82,87 @@ export function RetainedResetSuspenseHost(props) @{
 		<Suspense fallback={<span id="retained-pending">pending</span>}>
 			<Suspender promise={props.promise} />
 		</Suspense>
+	</ErrorBoundary>
+}
+
+interface EffectFailureProps {
+	phase: 'layout' | 'passive';
+}
+
+function EffectFailure(props: EffectFailureProps) @{
+	if (props.phase === 'layout') {
+		useLayoutEffect(() => {
+			throw new Error('layout failed');
+		}, []);
+	} else {
+		useEffect(() => {
+			throw new Error('passive failed');
+		}, []);
+	}
+	<span id="effect-before-error">{'before effect'}</span>
+}
+
+export function EffectErrorHost(props: EffectFailureProps) @{
+	<ErrorBoundary
+		fallback={(error: unknown) =>
+			<strong id="effect-error">{(error as Error).message as string}</strong>}
+	>
+		<EffectFailure phase={props.phase} />
+	</ErrorBoundary>
+}
+
+interface BoundaryLifecycleProps {
+	fail: boolean;
+	log: string[];
+	hostRef?: (node: Element | null) => void;
+	onCleanup?: () => void;
+}
+
+function BoundaryLifecycleChild(props: BoundaryLifecycleProps) @{
+	useLayoutEffect(() => {
+		props.log.push('setup');
+		return () => {
+			props.log.push('cleanup');
+			props.onCleanup?.();
+		};
+	}, []);
+	if (props.fail) throw new Error('lifecycle failed');
+	<span id="boundary-primary" ref={props.hostRef}>{'primary'}</span>
+}
+
+export function LifecycleErrorHost(props: BoundaryLifecycleProps) @{
+	<ErrorBoundary
+		fallback={(error: unknown) =>
+			<strong id="lifecycle-error">{(error as Error).message as string}</strong>}
+	>
+		<BoundaryLifecycleChild
+			fail={props.fail}
+			log={props.log}
+			hostRef={props.hostRef}
+			onCleanup={props.onCleanup}
+		/>
+	</ErrorBoundary>
+}
+
+interface BoundaryRefProps {
+	keep: boolean;
+	hostRef: (node: Element | null) => void;
+}
+
+function RemovableRef(props: BoundaryRefProps) @{
+	<section>
+		@if (props.keep) {
+			<span id="boundary-ref" ref={props.hostRef}>{'ref'}</span>
+		}
+		<span id="boundary-ref-sibling">{'sibling'}</span>
+	</section>
+}
+
+export function RefDetachErrorHost(props: BoundaryRefProps) @{
+	<ErrorBoundary
+		fallback={(error: unknown) =>
+			<strong id="ref-error">{(error as Error).message as string}</strong>}
+	>
+		<RemovableRef keep={props.keep} hostRef={props.hostRef} />
 	</ErrorBoundary>
 }

--- a/packages/octane/tests/auto-memo.test.ts
+++ b/packages/octane/tests/auto-memo.test.ts
@@ -171,6 +171,32 @@ describe('compiler-owned component-region memoization', () => {
 		root.unmount();
 	});
 
+	it('keeps imported memoized row hosts focused and stateful across parent and context updates', () => {
+		const root = mount(AutoMemoApp);
+		const firstRow = root.find('#auto-memo-rows > li');
+		const firstButton = root.find('.own-1') as HTMLButtonElement;
+
+		root.click('.own-1');
+		firstButton.focus();
+		expect(document.activeElement).toBe(firstButton);
+
+		root.click('#auto-tick');
+		expect(root.find('#auto-memo-rows > li')).toBe(firstRow);
+		expect(root.find('.own-1')).toBe(firstButton);
+		expect(document.activeElement).toBe(firstButton);
+		expect(firstButton.textContent).toBe('t0:a:1');
+
+		root.click('#auto-item-context');
+		expect(root.find('#auto-memo-rows > li')).toBe(firstRow);
+		expect(root.find('.own-1')).toBe(firstButton);
+		expect(document.activeElement).toBe(firstButton);
+		expect(firstButton.textContent).toBe('t0!:a!:1');
+
+		root.click('.own-1');
+		expect(firstButton.textContent).toBe('t0!:a!:2');
+		root.unmount();
+	});
+
 	it('re-renders keyed survivors when a captured parent local changes', () => {
 		const root = mount(ParentCaptureApp);
 		const cells = () =>

--- a/packages/octane/tests/boundary.test.ts
+++ b/packages/octane/tests/boundary.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { flushSync } from 'octane';
-import { mount, nextPaint } from './_helpers';
+import { act, flushEffects, mount, nextPaint } from './_helpers';
 import {
 	SuspenseHost,
 	SuspenseHostJsx,
@@ -8,6 +8,9 @@ import {
 	ResetErrorHost,
 	RetainedResetErrorHost,
 	RetainedResetSuspenseHost,
+	EffectErrorHost,
+	LifecycleErrorHost,
+	RefDetachErrorHost,
 } from './_fixtures/boundary.tsrx';
 
 describe('<Suspense> component', () => {
@@ -96,6 +99,63 @@ describe('<ErrorBoundary> component', () => {
 		resolve('ready');
 		await nextPaint();
 		expect(r.find('#v').textContent).toBe('v:ready');
+		r.unmount();
+	});
+
+	it.each(['layout', 'passive'] as const)(
+		'catches a descendant %s effect without retaining its failed content',
+		async (phase) => {
+			const r = mount(EffectErrorHost, { phase });
+			await act(async () => {});
+			flushEffects();
+			expect(r.find('#effect-error').textContent).toBe(`${phase} failed`);
+			expect(r.findAll('#effect-before-error')).toHaveLength(0);
+			r.unmount();
+		},
+	);
+
+	it('detaches a failed primary ref and runs its committed cleanup exactly once', () => {
+		const log: string[] = [];
+		const refs: Array<Element | null> = [];
+		const hostRef = (node: Element | null) => {
+			refs.push(node);
+		};
+		const r = mount(LifecycleErrorHost, { fail: false, log, hostRef });
+		const primary = r.find('#boundary-primary');
+		expect(refs).toEqual([primary]);
+		expect(log).toEqual(['setup']);
+
+		r.update(LifecycleErrorHost, { fail: true, log, hostRef });
+		expect(r.find('#lifecycle-error').textContent).toBe('lifecycle failed');
+		expect(r.findAll('#boundary-primary')).toHaveLength(0);
+		expect(refs).toEqual([primary, null]);
+		expect(log).toEqual(['setup', 'cleanup']);
+		r.unmount();
+		expect(log).toEqual(['setup', 'cleanup']);
+	});
+
+	it('stops committing fallback when primary cleanup unmounts its root', () => {
+		const log: string[] = [];
+		let mounted!: ReturnType<typeof mount>;
+		const onCleanup = () => mounted.unmount();
+		mounted = mount(LifecycleErrorHost, { fail: false, log, onCleanup });
+		expect(() => mounted.update(LifecycleErrorHost, { fail: true, log, onCleanup })).not.toThrow();
+		expect(mounted.container.childNodes).toHaveLength(0);
+		expect(log).toEqual(['setup', 'cleanup']);
+	});
+
+	it('catches a descendant ref-detach failure without leaving its previous subtree mounted', () => {
+		const calls: Array<Element | null> = [];
+		const hostRef = (node: Element | null) => {
+			calls.push(node);
+			if (node === null) throw new Error('ref detach failed');
+		};
+		const r = mount(RefDetachErrorHost, { keep: true, hostRef });
+		const primary = r.find('#boundary-ref');
+		expect(() => r.update(RefDetachErrorHost, { keep: false, hostRef })).not.toThrow();
+		expect(r.find('#ref-error').textContent).toBe('ref detach failed');
+		expect(r.findAll('#boundary-ref-sibling')).toHaveLength(0);
+		expect(calls).toEqual([primary, null]);
 		r.unmount();
 	});
 });

--- a/packages/octane/tests/compiler/bundler-compiler.test.ts
+++ b/packages/octane/tests/compiler/bundler-compiler.test.ts
@@ -951,8 +951,8 @@ export function App(p) @{
 			hmr: false,
 			dev: false,
 		});
-		expect(client?.code).toContain('_$tryBlock(');
-		expect(client?.code).toContain(', true);');
+		expect(client?.code).toContain('_$errorBlock(');
+		expect(client?.code).not.toContain('_$tryBlock(');
 		expect(client?.code).not.toContain('ErrorBoundary');
 
 		const server = compiler.transform(source, '/project/src/App.tsrx', {
@@ -972,6 +972,7 @@ export function App(p) @{ <Boundary fallback={p.fallback}><span>ok</span></Bound
 		);
 		expect(dynamic?.code).toContain('ErrorBoundary as Boundary');
 		expect(dynamic?.code).toContain('_$componentSlot(');
+		expect(dynamic?.code).not.toContain('_$errorBlock(');
 		expect(dynamic?.code).not.toContain('_$tryBlock(');
 
 		const mixedSource = `import { ErrorBoundary as Boundary } from 'octane';
@@ -981,7 +982,7 @@ export function App(p) @{ <><Boundary fallback={<span>static</span>}><span>ok</s
 			dev: false,
 		});
 		expect(mixed?.code).toContain('ErrorBoundary as Boundary');
-		expect(mixed?.code).toContain('_$tryBlock(');
+		expect(mixed?.code).toContain('_$errorBlock(');
 		expect(mixed?.code).toContain('_$componentSlot(');
 
 		const mixedServer = compiler.transform(mixedSource, '/project/src/MixedBoundary.tsrx', {
@@ -1000,7 +1001,51 @@ export function App() @{ <Boundary fallback={async (error) => String(error)}><sp
 		);
 		expect(asyncFallback?.code).toContain('ErrorBoundary as Boundary');
 		expect(asyncFallback?.code).toContain('_$componentSlot(');
+		expect(asyncFallback?.code).not.toContain('_$errorBlock(');
 		expect(asyncFallback?.code).not.toContain('_$tryBlock(');
+
+		const ordinaryTry = compiler.transform(
+			`export function App(p) @{ @try { <span>ok</span> } @catch (error) { <span>{String(error)}</span> } }`,
+			'/project/src/OrdinaryTry.tsrx',
+			{ hmr: false, dev: false },
+		);
+		expect(ordinaryTry?.code).toContain('_$tryBlock(');
+		expect(ordinaryTry?.code).not.toContain('_$errorBlock(');
+	});
+
+	it('preserves proven single-host roots through exact production memo wrappers only', () => {
+		const compiler = createOctaneCompiler({ root: '/project', hmr: false, dev: false });
+		const source = `
+import { memo as remember } from 'octane';
+import { External } from './external';
+function Host(props) @{ <li>{props.label as string}</li> }
+function Optional(props) @{ if (!props.visible) return null; <li>{props.label as string}</li> }
+const indirect = remember;
+export const Stable = remember(Host);
+export const Nullable = remember(Optional);
+export const Compared = remember(Host, () => true);
+export const Imported = remember(External);
+export const Indirect = indirect(Host);
+`;
+		const id = '/project/src/MemoRoots.tsrx';
+		const production = compiler.transform(source, id, { hmr: false, dev: false });
+		expect(production?.code).toMatch(
+			/Stable\s*=\s*(?:\/\*[^*]*\*\/\s*)?_\$__s\(remember\(Host\)\)/,
+		);
+		expect(production?.code).toMatch(/Nullable\s*=\s*remember\(Optional\)/);
+		expect(production?.code).toMatch(/Compared\s*=\s*remember\(Host,\s*\(\)\s*=>\s*true\)/);
+		expect(production?.code).toMatch(/Imported\s*=\s*remember\(External\)/);
+		expect(production?.code).toMatch(/Indirect\s*=\s*indirect\(Host\)/);
+
+		for (const options of [
+			{ hmr: false, dev: true },
+			{ hmr: 'vite' as const, dev: true },
+			{ hmr: false, dev: false, profile: true },
+			{ environment: 'server' as const, hmr: false, dev: false },
+		]) {
+			const output = compiler.transform(source, id, options);
+			expect(output?.code).not.toMatch(/_\$__s\(remember\(Host\)\)/);
+		}
 	});
 
 	it('applies profiling metadata only to client transforms', () => {

--- a/packages/octane/tests/hydration/_fixtures/trycatch-client-error.tsrx
+++ b/packages/octane/tests/hydration/_fixtures/trycatch-client-error.tsrx
@@ -1,4 +1,4 @@
-import { useState } from 'octane';
+import { ErrorBoundary, use, useState } from 'octane';
 
 // Hydration recovery for @try/@catch: the server rendered the SUCCESS arm, but on
 // the client the try body throws during hydration (the website analogue: a route
@@ -84,5 +84,52 @@ export function NestedPage(props) @{
 			<div class="outer-err">{'outer:' + err.message}</div>
 		}
 		<p id="after">after</p>
+	</div>
+}
+
+interface JsxBoundaryProps {
+	state: { failed: boolean };
+}
+
+type BoundaryReset = () => void;
+
+export function JsxBoundaryPage(props: JsxBoundaryProps) @{
+	<div id="jsx-boundary-page">
+		<h1 id="jsx-before">{'before'}</h1>
+		<ErrorBoundary
+			fallback={(error: unknown, reset: BoundaryReset) => <button
+				id="jsx-boundary-error"
+				onClick={() => {
+					props.state.failed = false;
+					reset();
+				}}
+			>
+				{'caught:' + (error as Error).message}
+			</button>}
+		>
+			<Inner boom={props.state.failed} />
+		</ErrorBoundary>
+		<p id="jsx-after">{'after'}</p>
+	</div>
+}
+
+interface JsxRejectedBoundaryProps {
+	promise: Promise<unknown>;
+}
+
+function JsxRejectedValue(props: JsxRejectedBoundaryProps) @{
+	const value = use(props.promise);
+	<span id="jsx-rejected-value">{String(value) as string}</span>
+}
+
+export function JsxRejectedBoundaryPage(props: JsxRejectedBoundaryProps) @{
+	<div id="jsx-rejected-page">
+		<ErrorBoundary
+			fallback={(error: unknown) =>
+				<span id="jsx-rejected-error" data-kind={typeof error}>{String(error) as string}</span>}
+		>
+			<JsxRejectedValue promise={props.promise} />
+		</ErrorBoundary>
+		<p id="jsx-rejected-after">{'after'}</p>
 	</div>
 }

--- a/packages/octane/tests/hydration/trycatch-client-error.test.ts
+++ b/packages/octane/tests/hydration/trycatch-client-error.test.ts
@@ -2,9 +2,16 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { compile } from 'octane/compiler';
+import { prerender } from 'octane/static';
 import { hydrateRoot, flushSync } from '../../src/index.js';
 import * as ServerRT from 'octane/server';
-import { Page, NestedPage, RouterShape } from './_fixtures/trycatch-client-error.tsrx';
+import {
+	Page,
+	NestedPage,
+	RouterShape,
+	JsxBoundaryPage,
+	JsxRejectedBoundaryPage,
+} from './_fixtures/trycatch-client-error.tsrx';
 
 // The server rendered a @try's SUCCESS arm, but on the client the try body throws
 // during hydration (the live report: a route module failed to import on a hot dev
@@ -167,6 +174,72 @@ describe('hydrateRoot — try body throws during hydration, @catch mounts', () =
 		expect(msg!.textContent).toBe('outer:boom');
 		expect(container.querySelector('#before')!.textContent).toBe('Title');
 		expect(container.querySelector('#after')!.textContent).toBe('after');
+		root.unmount();
+	});
+});
+
+describe('hydrateRoot — JSX error boundaries', () => {
+	it('adopts successful server content without replacing its stateful host', async () => {
+		const state = { failed: false };
+		const { html } = await ServerRT.renderToString(server.JsxBoundaryPage, { state });
+		container.innerHTML = html;
+		const before = container.querySelector('#jsx-before');
+		const button = container.querySelector('#ok') as HTMLButtonElement;
+		const after = container.querySelector('#jsx-after');
+
+		const root = hydrateRoot(container, JsxBoundaryPage, { state });
+		flushSync(() => {});
+		expect(container.querySelector('#jsx-before')).toBe(before);
+		expect(container.querySelector('#ok')).toBe(button);
+		expect(container.querySelector('#jsx-after')).toBe(after);
+		flushSync(() => button.click());
+		expect(button.textContent).toBe('ok:1');
+		expect(errSpy).not.toHaveBeenCalled();
+		root.unmount();
+	});
+
+	it('replaces client-failed server content without disturbing siblings, then recovers on reset', async () => {
+		const { html } = await ServerRT.renderToString(server.JsxBoundaryPage, {
+			state: { failed: false },
+		});
+		container.innerHTML = html;
+		const before = container.querySelector('#jsx-before');
+		const after = container.querySelector('#jsx-after');
+		const state = { failed: true };
+
+		const root = hydrateRoot(container, JsxBoundaryPage, { state });
+		flushSync(() => {});
+		const fallback = container.querySelector('#jsx-boundary-error') as HTMLButtonElement;
+		expect(fallback.textContent).toBe('caught:boom');
+		expect(container.querySelector('#ok')).toBeNull();
+		expect(container.querySelector('#jsx-before')).toBe(before);
+		expect(container.querySelector('#jsx-after')).toBe(after);
+		flushSync(() => fallback.click());
+		expect(container.querySelector('#ok')?.textContent).toBe('ok:0');
+		expect(container.querySelector('#jsx-boundary-error')).toBeNull();
+		expect(container.querySelector('#jsx-before')).toBe(before);
+		expect(container.querySelector('#jsx-after')).toBe(after);
+		expect(errSpy).not.toHaveBeenCalled();
+		root.unmount();
+	});
+
+	it('adopts a server-rendered rejection fallback and exposes its original primitive reason', async () => {
+		const { html } = await prerender(server.JsxRejectedBoundaryPage, {
+			promise: Promise.reject('server rejected'),
+		});
+		container.innerHTML = html;
+		const fallback = container.querySelector('#jsx-rejected-error');
+		const sibling = container.querySelector('#jsx-rejected-after');
+
+		const root = hydrateRoot(container, JsxRejectedBoundaryPage, {
+			promise: new Promise<string>(() => {}),
+		});
+		flushSync(() => {});
+		expect(container.querySelector('#jsx-rejected-error')).toBe(fallback);
+		expect(fallback?.textContent).toBe('server rejected');
+		expect(fallback?.getAttribute('data-kind')).toBe('string');
+		expect(container.querySelector('#jsx-rejected-after')).toBe(sibling);
+		expect(errSpy).not.toHaveBeenCalled();
 		root.unmount();
 	});
 });


### PR DESCRIPTION
## Summary

- Isolate optional Suspense visibility and teardown capabilities from ordinary client rendering, and lower compiler-proven catch-only error boundaries to a lightweight path while preserving public boundary, reset, effect, ref, transition, and hydration semantics.
- Preserve compiler-proven single-root metadata through safe `memo` wrappers: the weather app drops from **54 to 18 comment markers (-66.7%)** without changing its visible DOM or forecast-row identity.
- Against the verified upstream runtime baseline, the weather production bundle falls from **33,260 to 27,466 gzip bytes (-17.42%)**. Normalized framework bytes fall from **27,251 to 21,200 (-22.20%)**, application bytes change from **7,840 to 7,845 (+5)**, and total bytes fall from **35,091 to 29,045 (-17.23%)**. JSX framework bytes also fall from **37,751 to 33,241 (-11.95%)**.
- Replace two anti-monotonic JSX-versus-TSRX comparisons with **nine stricter independent JSX raw/gzip/Brotli budgets**, retaining all 36 existing TSRX budgets and the remaining comparisons.
- Add a semantic weather work gate, report observed and simulated Lighthouse timings separately, and add a fair optional Octane-versus-React streamed-shell delivery comparison.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — the root wrapper was not invoked; the direct `octane`, `octane-prod`, `aria`, and `aria-ssr` run passed **11,414 tests across 825 files**, with two existing skips.
- [x] `pnpm sync`; focused dual-mode boundary, Suspense, Activity, transitions, refs/effects, hydration, production-profile, compiler, memo, and source-map coverage.
- [x] Full normalized bundle-size suite: **63/63 applicable guards passed**, including all **45 independent byte budgets**. Unmodified upstream fails six newly tightened JSX framework/total ceilings.
- [x] Deterministic weather work gate and six-framework interaction parity: London, seven stable forecast rows, Tokyo persistence, invalid-city errors, Paris recovery, and exact same-origin request counts.
- [x] Six final upstream-rebased Lighthouse audits: every framework scores **100** in all four categories and all three Lighthouse ratio guards pass. A full 30-audit run also passed before the upstream rebase.
- [x] Native Octane and React streamed-shell hydration adopt the original server-rendered header/search nodes and preserve London-to-Tokyo interactions.

## Risk / follow-ups

- Only exact compiler-proven imported catch-only JSX boundaries use the new primitive; dynamic/public/reset-ref boundaries and server `ssrTry` remain unchanged.
- The streamed variant is an optional diagnostic that renders a genuine **loading shell** and still fetches weather client-side. Its larger hydration bundle can worsen Lighthouse's simulated network tier even when observed browser paint improves; passive effects retain their documented after-paint timing.
- Independent JSX budgets replace only comparisons that incorrectly failed when TSRX became smaller; no existing TSRX byte ceiling or remaining application/cross-framework guard is loosened.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core runtime scheduling, boundary teardown, compiler lowering, and hydration for error boundaries; scope is large but guarded by extensive boundary, memo, hydration, and byte-budget tests.
> 
> **Overview**
> Shrinks client startup by **deferring Suspense/Activity visibility scheduling** until a boundary actually needs it, and by routing **statically compilable catch-only `<ErrorBoundary>`** through a new **`errorBlock`** path instead of full **`tryBlock`** (Suspense pending, hidden primaries, transition holds). The production compiler also **stamps proven single-root metadata** through exact `memo(localHost)` wrappers so memoized row hosts keep stable DOM and focus.
> 
> **Benchmark and CI:** adds **`jsx-budgets.json`** and nine **`octane-jsx-budget`** ratio guards so JSX byte ceilings are independent of TSRX (replacing anti-monotonic JSX-vs-TSRX total/framework comparisons). Weather gains **`bench:work`** (semantic app checks plus gzip/comment budgets) and **`bench:delivery`** (Octane vs React streamed shell + hydrate, no server-prefetched weather). Lighthouse reports **observed** FCP/LCP alongside simulated paints, JS transfer/resource bytes, and DevTools transport retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c26ccd3df161a297cd3885f3a53b5b5098b3019. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->