### PR TITLE
ci: fix version.ts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,7 @@ jobs:
                   file.filename.endsWith("/package.json") ||
                   file.filename === "docs/bindings-status.md" ||
                   file.filename === "docs/packages.md" ||
+                  file.filename === "packages/octane/src/version.ts" ||
                   file.filename.startsWith("packages/shadcn/registry/") ||
                   file.filename === "packages/cli/src/data/octane-data.json" ||
                   file.filename ===

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -352,6 +352,7 @@ jobs:
                 file.filename.endsWith("/package.json") ||
                 file.filename === "docs/bindings-status.md" ||
                 file.filename === "docs/packages.md" ||
+                file.filename === "packages/octane/src/version.ts" ||
                 file.filename.startsWith("packages/shadcn/registry/") ||
                 file.filename === "packages/cli/src/data/octane-data.json" ||
                 file.filename ===

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -22,6 +22,7 @@ const { configureShardedProjects, default: shardedVitestConfig } = await import(
 	pathToFileURL(path.join(REPO, 'vitest.ci-sharded.config.js'))
 );
 const publishWorkflow = readFileSync(path.join(REPO, '.github/workflows/publish.yml'), 'utf8');
+const releaseWorkflow = readFileSync(path.join(REPO, '.github/workflows/release.yml'), 'utf8');
 const draftWorkflow = readFileSync(
 	path.join(REPO, '.github/workflows/draft-agent-prs.yml'),
 	'utf8',
@@ -177,6 +178,19 @@ describe('CI workflow aggregation', () => {
 		assert.match(jobSource('test'), /\[ "\$FULL_CI" = false \]/);
 		assert.match(jobSource('examples'), /\[ "\$FULL_CI" = false \]/);
 		assert.match(jobSource('provenance'), /\[ "\$FULL_CI" = false \]/);
+	});
+
+	test('accepts the generated Octane version source as release metadata', () => {
+		const generatedVersionAllowance = /file\.filename === "packages\/octane\/src\/version\.ts"/;
+
+		assert.match(
+			stepScript(workflow, 'Identify a generated Changesets release change'),
+			generatedVersionAllowance,
+		);
+		assert.match(
+			stepScript(releaseWorkflow, 'Record lightweight release pull request checks'),
+			generatedVersionAllowance,
+		);
 	});
 
 	test('keeps cheap parity validation universal and full execution on Node 24', () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Workflow allowlist and test-only changes; no runtime or auth logic beyond release PR file validation.
> 
> **Overview**
> **Changesets release PR authentication** now treats **`packages/octane/src/version.ts`** as allowed generated metadata alongside changelogs, `package.json`, and other versioned artifacts. The same path is added in **CI** (`Identify a generated Changesets release change`) and **Release PR** (`Record lightweight release pull request checks`), so a Version Packages PR that bumps this file is no longer flagged as containing unexpected changes (which would force full CI or fail lightweight checks).
> 
> **`scripts/ci-workflow.test.mjs`** loads `release.yml` and asserts both steps include the `version.ts` allowance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 252bfc39db675a93ec557a013186716dd76c0252. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->