### PR TITLE
feat(tanstack-start): export cloudflareExternals() plugin

### DIFF
--- a/.changeset/tanstack-start-cloudflare-externals.md
+++ b/.changeset/tanstack-start-cloudflare-externals.md
@@ -1,0 +1,5 @@
+---
+'@octanejs/tanstack-start': patch
+---
+
+Export `cloudflareExternals()` from `@octanejs/tanstack-start/plugin/vite`. Compose it for Cloudflare-targeted deployments to externalize `cloudflare:*` modules (e.g. `cloudflare:workers`) in the server build, where the workerd runtime provides them. It only externalizes server-runtime modules — it does not supply a local Cloudflare runtime or deployment integration.

--- a/packages/tanstack-start/src/plugin-vite.d.ts
+++ b/packages/tanstack-start/src/plugin-vite.d.ts
@@ -26,6 +26,15 @@ export type TanStackOctaneStartViteInputConfig = TanStackStartViteInputConfig & 
 	octane?: OctaneCompilerOptions;
 };
 
+/**
+ * Externalize `cloudflare:*` modules (e.g. `cloudflare:workers`) in the
+ * server build. Compose this for Cloudflare-targeted deployments, where
+ * the workerd runtime provides those modules at runtime. It only
+ * externalizes server-runtime modules; it does not provide a local
+ * Cloudflare runtime or deployment integration.
+ */
+export declare function cloudflareExternals(): PluginOption;
+
 export declare function tanstackStart(
 	options?: TanStackOctaneStartViteInputConfig,
 ): Array<PluginOption>;

--- a/packages/tanstack-start/src/plugin-vite.js
+++ b/packages/tanstack-start/src/plugin-vite.js
@@ -27,6 +27,26 @@ const WORKSPACE_SOURCE_INCLUDES = [
 	'@octanejs/tanstack-start > @tanstack/router-core/isServer',
 ];
 
+// Cloudflare-targeted deployments: `cloudflare:*` modules (e.g.
+// `cloudflare:workers` for bindings) are provided by the workerd runtime,
+// not npm. Externalize them in the server build so the bundle builds
+// standalone; workerd resolves them at runtime. This plugin only
+// externalizes server-runtime modules — it does not provide a local
+// Cloudflare runtime or deployment integration. Opt-in by composition:
+// a non-Cloudflare target that imports `cloudflare:` should fail the
+// build, not defer the error to runtime.
+export function cloudflareExternals() {
+	return {
+		name: 'octanejs-tanstack-start:cloudflare-externals',
+		applyToEnvironment: (environment) => environment.name === START_ENVIRONMENT_NAMES.server,
+		resolveId(id) {
+			if (id.startsWith('cloudflare:')) {
+				return { id, external: true };
+			}
+		},
+	};
+}
+
 export function tanstackStart(options) {
 	const { octane: octaneOptions, ...startOptions } = options ?? {};
 	validateOctaneCompilerOptions(octaneOptions);

--- a/packages/tanstack-start/tests/plugin.test.ts
+++ b/packages/tanstack-start/tests/plugin.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { Plugin, PluginOption } from 'vite';
-import { tanstackStart } from '@octanejs/tanstack-start/plugin/vite';
+import { build, type Plugin, type PluginOption } from 'vite';
+import { cloudflareExternals, tanstackStart } from '@octanejs/tanstack-start/plugin/vite';
 
 function flattenPlugins(options: Array<PluginOption>): Array<Plugin> {
 	const plugins: Array<Plugin> = [];
@@ -28,6 +28,71 @@ describe('TanStack Start Vite integration', () => {
 
 		expect(compilerIndex).toBeGreaterThanOrEqual(0);
 		expect(generatorIndex).toBeGreaterThan(compilerIndex);
+	});
+});
+
+describe('cloudflare externals', () => {
+	const plugin = cloudflareExternals() as Plugin;
+
+	it('externalizes cloudflare: specifiers in the server environment only', () => {
+		const applyToEnvironment = plugin.applyToEnvironment as (environment: {
+			name: string;
+		}) => boolean;
+		expect(applyToEnvironment({ name: 'ssr' })).toBe(true);
+		expect(applyToEnvironment({ name: 'client' })).toBe(false);
+
+		const resolveId = plugin.resolveId as (id: string) => unknown;
+		expect(resolveId('cloudflare:workers')).toEqual({
+			id: 'cloudflare:workers',
+			external: true,
+		});
+		expect(resolveId('cloudflare:email')).toEqual({
+			id: 'cloudflare:email',
+			external: true,
+		});
+	});
+
+	it('leaves other specifiers to the normal resolver', () => {
+		const plugin = cloudflareExternals() as Plugin;
+		const resolveId = plugin.resolveId as (id: string) => unknown;
+
+		expect(resolveId('vite')).toBeUndefined();
+		expect(resolveId('./relative.js')).toBeUndefined();
+	});
+
+	it('keeps cloudflare: imports external in a real server build', async () => {
+		const plugin = cloudflareExternals() as Plugin;
+		const result = (await build({
+			configFile: false,
+			logLevel: 'silent',
+			build: {
+				write: false,
+				ssr: true,
+				rollupOptions: { input: 'virtual:entry' },
+			},
+			plugins: [
+				{
+					name: 'test-server-entry',
+					resolveId(id) {
+						if (id === 'virtual:entry') return id;
+					},
+					load(id) {
+						if (id === 'virtual:entry') {
+							return 'import * as cf from "cloudflare:workers"; export default cf.env;';
+						}
+					},
+				},
+				plugin,
+			],
+		})) as unknown as {
+			output: Array<{ type: string; code?: string }>;
+		};
+
+		const code = result.output
+			.filter((entry) => entry.type === 'chunk' && entry.code !== undefined)
+			.map((entry) => entry.code!)
+			.join('\n');
+		expect(code).toContain('cloudflare:workers');
 	});
 });
 


### PR DESCRIPTION
## Summary

Exports a composable `cloudflareExternals()` plugin from `@octanejs/tanstack-start/plugin/vite`:

```ts
import { tanstackStart, cloudflareExternals } from '@octanejs/tanstack-start/plugin/vite'

export default defineConfig({
  plugins: [tanstackStart(), cloudflareExternals()],
})
```

`cloudflare:*` modules (e.g. `cloudflare:workers` for bindings) are workerd runtime modules, not npm packages, so plain Vite/Rolldown cannot resolve them. Cloudflare-targeted Start apps read bindings through them; without externalization their standalone `vite build` fails. This plugin externalizes `cloudflare:` specifiers in the server environment; workerd resolves them at runtime.

Design decisions:

- **Composable plugin, not an option.** Mirrors the ecosystem pattern of composing `@cloudflare/vite-plugin` alongside `tanstackStart()` (per Cloudflare's official Start docs). An option key on `tanstackStart()` would collide with upstream's pass-through options surface and overpromise: this plugin only externalizes server-runtime modules, it does not provide a local Cloudflare runtime or deployment integration (`@cloudflare/vite-plugin` remains the full dev/deploy integration).
- **Opt-in by composition.** A non-Cloudflare target that imports `cloudflare:` should fail the build, not defer the error to runtime.
- **Server environment only** (the framework's own `ssr` environment name — the same name Cloudflare's plugin targets via `viteEnvironment`).

## Changes

- `src/plugin-vite.js`: export `cloudflareExternals()` (server-env-scoped `resolveId` externalizing `cloudflare:` prefixes).
- `src/plugin-vite.d.ts`: declare the factory.
- `tests/plugin.test.ts`: behavior coverage — `applyToEnvironment` gates `ssr` / not `client`, `resolveId('cloudflare:workers'|'cloudflare:email')` → external, other specifiers pass through, plus a real programmatic `vite.build` (SSR env) asserting the bundle keeps `cloudflare:workers` external.

## Validation

- [x] `pnpm format:files` on changed files
- [x] `pnpm typecheck:files` on changed files
- [x] targeted tests: `pnpm vitest run --project tanstack-start` (10 files, 58 tests)
- [ ] `pnpm format:check`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- Not run: full-repo format/typecheck/test. JS-only change; scoped checks and the `tanstack-start` project suite ran instead.

## Risk / follow-ups

Verified pattern in production: the alchemy example (`examples/cloudflare-octane-tanstack`) uses an identical externalization (app-level mini-plugin) and builds standalone; this export gives that app and the other Cloudflare Start examples a durable, package-owned replacement. The runtime side (serving client assets via `env.ASSETS.fetch`) is PR #665. A future official Cloudflare/TanStack integration may supersede this; it is intentionally minimal (externalization only).

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in build-time resolver change with no default behavior change to `tanstackStart()`; limited to externalizing `cloudflare:` specifiers in the server environment.
> 
> **Overview**
> Adds an opt-in **`cloudflareExternals()`** Vite plugin on `@octanejs/tanstack-start/plugin/vite` for Cloudflare-targeted Start apps. Compose it next to `tanstackStart()` so the **server (`ssr`) build** treats `cloudflare:*` specifiers (e.g. `cloudflare:workers`) as **externals** instead of failing resolution—workerd supplies those modules at runtime. The plugin does **not** add Cloudflare dev/deploy integration; it only externalizes server-runtime imports.
> 
> Implementation is a small server-scoped `resolveId` hook; **`tanstackStart()` behavior is unchanged** unless you add the plugin. Type declarations and a patch changeset document the export. Tests cover environment gating, non-`cloudflare:` passthrough, and an SSR `vite.build` that keeps `cloudflare:workers` in the bundle output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 815ffa6c4f8f937c4fd6eace6a1b7acdbe8afac7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->