### PR TITLE
fix: restore React-compatible autofocus and focus across DOM commits

### DIFF
--- a/.changeset/autofocus-focus-restoration.md
+++ b/.changeset/autofocus-focus-restoration.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Match React's autofocus behavior during server rendering, client mounting, and hydration, and restore focus and text selection after DOM updates.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -578,6 +578,9 @@ function bakeStaticAttr(attrName, lv, tag, namespace = 'html') {
 	const isCustom =
 		(namespace === 'html' || namespace === 'opaque') && tag !== undefined && tag.includes('-');
 	const lower = attrName.toLowerCase();
+	// The client emitter intercepts autoFocus before this shared helper; only SSR
+	// bakes its initial browser autofocus attribute.
+	if (!isCustom && attrName === 'autoFocus') return lv ? ' autofocus=""' : '';
 	// class/className compose clsx-style at every apply site. Literal false/null
 	// drop above/below; every other literal writes the normalized class string.
 	if (attrName === 'class') {
@@ -642,6 +645,7 @@ function needsDevStaticAttrValidation(attrName, lv, tag, namespace = 'html') {
 	if (isCustom || attrName.startsWith('aria-') || attrName.startsWith('data-')) return false;
 	const lower = attrName.toLowerCase();
 	return !(
+		attrName === 'autoFocus' ||
 		isEnumeratedBooleanAttr(lower) ||
 		BOOLEAN_ATTR_PROPS.has(lower) ||
 		MUST_USE_PROPERTY_PROPS.has(lower) ||
@@ -9059,15 +9063,6 @@ function ssrEmitElement(node, ctx, name, inlinedSubs, parentNs, cssHash, compone
 			continue;
 		}
 		if (isEventAttrName(rawAttrName)) {
-			bindDiscardedAttributeValue(attr.value);
-			continue;
-		}
-		// `autoFocus` never serializes (React DOM server parity — the client
-		// focuses at its mount commit; custom elements keep raw props).
-		if (
-			rawAttrName === 'autoFocus' &&
-			!((selfNs === 'html' || selfNs === 'opaque') && tag.includes('-'))
-		) {
 			bindDiscardedAttributeValue(attr.value);
 			continue;
 		}

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -1743,6 +1743,11 @@ export function ssrAttr(
 	// setAttribute writes (hydration parity). Custom elements get their props
 	// VERBATIM (no alias tables) — React parity.
 	if (!isCustomTag) {
+		// Server markup carries browser-native autofocus even though client mounts
+		// perform focus at commit without writing this attribute.
+		if (name === 'autoFocus') {
+			return v && typeof v !== 'function' && typeof v !== 'symbol' ? ' autofocus=""' : '';
+		}
 		const alias = ATTRIBUTE_ALIASES.get(name);
 		if (alias !== undefined) name = alias;
 	}
@@ -1966,9 +1971,6 @@ function ssrAttrEntry(
 	)
 		return '';
 	if (k.length > 2 && k[0] === 'o' && k[1] === 'n' && k[2] >= 'A' && k[2] <= 'Z') return '';
-	// `autoFocus` never serializes (client focuses at its mount commit).
-	if (k === 'autoFocus' && (namespace !== 'html' || tag === undefined || tag.indexOf('-') === -1))
-		return '';
 	if (k === 'style') return ssrStyle(v);
 	if (k === 'className' || k === 'class') return ssrAttr('class', v, tag, namespace);
 	if (VALID_ATTR_NAME.test(k)) return ssrAttr(k, v, tag, namespace);
@@ -2069,11 +2071,6 @@ export function ssrAttrs(
 			const c = rawName.charCodeAt(2);
 			if (c >= 65 && c <= 90) continue;
 		}
-		if (
-			rawName === 'autoFocus' &&
-			(namespace !== 'html' || tag === undefined || tag.indexOf('-') === -1)
-		)
-			continue;
 		const name = normalizeSsrAttributeName(rawName, tag, namespace);
 		if (!VALID_ATTR_NAME.test(name)) continue;
 		// Attribute identity is ASCII-case-insensitive in the HTML namespace.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -2924,6 +2924,167 @@ function flush(): void {
 	flushWork();
 }
 
+interface FocusSelectionSnapshot {
+	focused: HTMLElement;
+	start: number;
+	end: number;
+	contentEditable: boolean;
+}
+
+/** Resolve the focused element in the root's own document and same-origin frames. */
+function activeElementForDocument(doc: Document): Element | null {
+	try {
+		let focused = doc.activeElement;
+		while (focused !== null && focused.localName === 'iframe') {
+			let nested: Document | null;
+			try {
+				nested = (focused as HTMLIFrameElement).contentDocument;
+			} catch {
+				break;
+			}
+			if (nested === null) break;
+			const inner = nested.activeElement;
+			if (inner === null) break;
+			focused = inner;
+		}
+		return focused;
+	} catch {
+		// Reading activeElement on a torn-down document can throw.
+		return null;
+	}
+}
+
+function hasTextSelection(element: HTMLElement): boolean {
+	if (element.localName === 'textarea') return true;
+	if (element.localName !== 'input') return false;
+	switch ((element as HTMLInputElement).type) {
+		case 'text':
+		case 'search':
+		case 'tel':
+		case 'url':
+		case 'password':
+			return true;
+	}
+	return false;
+}
+
+/** Capture selection only when a render pass could actually mutate focused DOM. */
+function captureFocusSelection(doc: Document): FocusSelectionSnapshot | null {
+	const focused = activeElementForDocument(doc) as HTMLElement | null;
+	if (focused === null || focused === focused.ownerDocument.body) return null;
+	if (hasTextSelection(focused)) {
+		const input = focused as HTMLInputElement | HTMLTextAreaElement;
+		return {
+			focused,
+			start: input.selectionStart ?? 0,
+			end: input.selectionEnd ?? 0,
+			contentEditable: false,
+		};
+	}
+	if (focused.contentEditable === 'true' || focused.getAttribute('contenteditable') === 'true') {
+		const selection = focused.ownerDocument.getSelection();
+		if (
+			selection !== null &&
+			selection.anchorNode !== null &&
+			selection.focusNode !== null &&
+			focused.contains(selection.anchorNode) &&
+			focused.contains(selection.focusNode)
+		) {
+			const range = focused.ownerDocument.createRange();
+			range.selectNodeContents(focused);
+			range.setEnd(selection.anchorNode, selection.anchorOffset);
+			const start = range.toString().length;
+			range.setEnd(selection.focusNode, selection.focusOffset);
+			return { focused, start, end: range.toString().length, contentEditable: true };
+		}
+	}
+	return { focused, start: -1, end: -1, contentEditable: false };
+}
+
+/** Convert a content-editable text offset back into its current text-node position. */
+function contentEditablePosition(element: HTMLElement, offset: number): [Node, number] {
+	const walker = element.ownerDocument.createTreeWalker(element, 4 /* SHOW_TEXT */);
+	let node = walker.nextNode();
+	let last: Node | null = null;
+	while (node !== null) {
+		const length = node.textContent?.length ?? 0;
+		if (offset <= length) return [node, offset];
+		offset -= length;
+		last = node;
+		node = walker.nextNode();
+	}
+	return last === null ? [element, 0] : [last, last.textContent?.length ?? 0];
+}
+
+function restoreFocusSelection(snapshot: FocusSelectionSnapshot | null): void {
+	if (snapshot === null) return;
+	const { focused } = snapshot;
+	const doc = focused.ownerDocument;
+	if (activeElementForDocument(doc) === focused || !doc.documentElement.contains(focused)) return;
+	if (snapshot.start !== -1) {
+		if (snapshot.contentEditable) {
+			const selection = doc.getSelection();
+			if (selection !== null) {
+				const [anchorNode, anchorOffset] = contentEditablePosition(focused, snapshot.start);
+				const [focusNode, focusOffset] = contentEditablePosition(focused, snapshot.end);
+				const range = doc.createRange();
+				range.setStart(anchorNode, anchorOffset);
+				range.collapse(true);
+				selection.removeAllRanges();
+				selection.addRange(range);
+				selection.extend(focusNode, focusOffset);
+			}
+		} else {
+			const input = focused as HTMLInputElement | HTMLTextAreaElement;
+			input.setSelectionRange(snapshot.start, Math.min(snapshot.end, input.value.length));
+		}
+	}
+	// Refocusing a moved control may scroll every containing element. Preserve
+	// those positions only on this cold, focus-was-actually-lost branch.
+	const ancestors: Array<{ element: HTMLElement; left: number; top: number }> = [];
+	let parent = focused.parentElement;
+	while (parent !== null) {
+		ancestors.push({ element: parent, left: parent.scrollLeft, top: parent.scrollTop });
+		parent = parent.parentElement;
+	}
+	focused.focus();
+	for (let i = 0; i < ancestors.length; i++) {
+		const ancestor = ancestors[i];
+		ancestor.element.scrollLeft = ancestor.left;
+		ancestor.element.scrollTop = ancestor.top;
+	}
+}
+
+type FocusSelectionBatch = FocusSelectionSnapshot | FocusSelectionSnapshot[] | null;
+
+/** A global scheduler drain may contain independently focused documents. */
+function captureQueuedFocusSelection(): FocusSelectionBatch {
+	if (QUEUE.length === 0) return null;
+	const firstDocument = QUEUE[0].parentNode.ownerDocument;
+	if (firstDocument === null) return null;
+	let snapshots: FocusSelectionBatch = captureFocusSelection(firstDocument);
+	let documents: Document[] | null = null;
+	for (let i = 1; i < QUEUE.length; i++) {
+		const doc = QUEUE[i].parentNode.ownerDocument;
+		if (doc === null || doc === firstDocument || documents?.includes(doc)) continue;
+		(documents ??= [firstDocument]).push(doc);
+		const snapshot = captureFocusSelection(doc);
+		if (snapshot === null) continue;
+		if (snapshots === null) snapshots = snapshot;
+		else if (Array.isArray(snapshots)) snapshots.push(snapshot);
+		else snapshots = [snapshots, snapshot];
+	}
+	return snapshots;
+}
+
+function restoreQueuedFocusSelection(snapshots: FocusSelectionBatch): void {
+	if (Array.isArray(snapshots)) {
+		for (let i = 0; i < snapshots.length; i++) restoreFocusSelection(snapshots[i]);
+	} else {
+		restoreFocusSelection(snapshots);
+	}
+}
+
 /**
  * The flush body proper — render+mutate drain plus the effect commit. Shared
  * verbatim by the plain flush() path and the view-transition update callback
@@ -2949,7 +3110,9 @@ function flushWork(): void {
 		// drain as the new children's listener-attach effects — re-ordering them child-first
 		// and letting a child observe an event announcing its own mount.
 		if (QUEUE.length > 0) drainPassivesBeforeRender();
+		const focused = QUEUE.length === 0 ? null : captureQueuedFocusSelection();
 		const pendingError = drainQueue();
+		if (focused !== null) restoreQueuedFocusSelection(focused);
 		commitEffects();
 		if (pendingError !== null) throw pendingError.err;
 	} finally {
@@ -3244,7 +3407,9 @@ export function flushSync<T>(fn: () => T): T {
 			// passive effects (useEffect) still fire AFTER paint via the regular scheduler —
 			// exactly what commitEffects already does.
 			if (QUEUE.length > 0) drainPassivesBeforeRender();
+			const focused = QUEUE.length === 0 ? null : captureQueuedFocusSelection();
 			pendingError = drainQueue();
+			if (focused !== null) restoreQueuedFocusSelection(focused);
 			commitEffects();
 			// A sync-committed effect (a LAYOUT effect calling setState) can schedule MORE
 			// renders. While `syncFlush` is set, scheduleRender pushes to QUEUE without arming a
@@ -3268,7 +3433,9 @@ export function flushSync<T>(fn: () => T): T {
 					// Each convergence iteration is a new render pass — flush pending passives
 					// first (React's rule; see flush()).
 					drainPassivesBeforeRender();
+					const focused = QUEUE.length === 0 ? null : captureQueuedFocusSelection();
 					const err = drainQueue();
+					if (focused !== null) restoreQueuedFocusSelection(focused);
 					if (err !== null && pendingError === null) pendingError = err;
 					commitEffects();
 					for (let i = 0; i < QUEUE.length; i++) {
@@ -12038,6 +12205,9 @@ export function setSpread(
 		// reassert every commit (the DOM may have drifted; the helper's own
 		// DOM-diff makes the call cheap).
 		if (v === pv && !isControlledHostProp(el, k)) continue;
+		// React only honors autoFocus from the final props of the element's mount.
+		// An absent initial spread must not turn a later update into a mount.
+		if (prev !== undefined && k === 'autoFocus' && !isHtmlCustomElement(el)) continue;
 		setAttribute(el, k, v);
 	}
 	if (process.env.NODE_ENV !== 'production') queueDevFormDiagnostic(el, mountScope);
@@ -13337,16 +13507,27 @@ function hasControlledSyncs(): boolean {
 }
 
 /**
- * Compiler-emitted binding for `autoFocus` (React parity): never an
- * attribute — the element is focused ONCE, in the commit phase of its mount
- * (after the render pass built the tree, before layout effects — so a layout
- * effect that moves focus still wins, like React's commitMount ordering).
- * Later updates are ignored (React treats autoFocus as mount-only).
+ * Compiler-emitted binding for `autoFocus` (React parity): client mounts never
+ * write an attribute and focus supported controls once, before layout effects.
+ * Server-rendered controls keep their existing autofocus attribute but are
+ * never refocused during hydration; later updates are likewise ignored.
  */
 export function setAutoFocus(el: Element, value: unknown): void {
 	if ((el as any).$$afSeen !== undefined) return; // mount-only
 	(el as any).$$afSeen = true;
-	if (value) AUTOFOCUS_QUEUE.push(el);
+	if (!value) return;
+	switch (el.localName) {
+		case 'button':
+		case 'input':
+		case 'select':
+		case 'textarea':
+			break;
+		default:
+			return;
+	}
+	const hydration = activeHydration();
+	if (hydration !== null && !hydration.isFresh(el)) return;
+	AUTOFOCUS_QUEUE.push(el);
 }
 
 /** Text-entry controls (IME-capable; their diagnostic specifically requires onInput). */
@@ -16185,6 +16366,8 @@ function patchDeoptProps(el: Element, prevProps: any, nextProps: any, ownerBlock
 			// Controlled `value`/`checked` bypass the prev-diff skip (reassert
 			// on every commit; the helper's DOM-diff keeps the call cheap).
 			if (prevProps == null || prevProps[name] !== nv || isControlledHostProp(el, name)) {
+				// This path always reuses an existing host; autoFocus is mount-only.
+				if (name === 'autoFocus' && !isHtmlCustomElement(el)) continue;
 				// `applyDeoptProp` is the FRESH-element helper — its style arm passes
 				// prev=undefined, which on a REUSED element leaves declarations dropped
 				// from the style object stale (applyStyleValue can only remove keys it
@@ -16342,7 +16525,7 @@ function applyHostProps(el: Element, props: any, scope: Scope, state: HostCompon
 					delegateEvents([ev.type]);
 				}
 				(el as any)[ev.key] = process.env.NODE_ENV !== 'production' ? devEventListener(name, v) : v;
-			} else {
+			} else if (prev === undefined || name !== 'autoFocus' || isHtmlCustomElement(el)) {
 				setAttribute(el, name, v);
 			}
 		}

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -2968,6 +2968,55 @@ function hasTextSelection(element: HTMLElement): boolean {
 	return false;
 }
 
+/** Resolve editable selection offsets without materializing its text every commit. */
+function captureContentEditableSelection(
+	focused: HTMLElement,
+	anchorNode: Node,
+	anchorOffset: number,
+	focusNode: Node,
+	focusOffset: number,
+): FocusSelectionSnapshot | null {
+	let node: Node = focused;
+	let parent: Node | null = null;
+	let length = 0;
+	let start = -1;
+	let end = -1;
+	let anchorChildIndex = 0;
+	let focusChildIndex = 0;
+
+	selection: for (;;) {
+		for (;;) {
+			if (node === anchorNode && (anchorOffset === 0 || node.nodeType === 3)) {
+				start = length + anchorOffset;
+			}
+			if (node === focusNode && (focusOffset === 0 || node.nodeType === 3)) {
+				end = length + focusOffset;
+			}
+			if (start !== -1 && end !== -1) break selection;
+			if (node.nodeType === 3) length += node.nodeValue!.length;
+			const child = node.firstChild;
+			if (child === null) break;
+			parent = node;
+			node = child;
+		}
+		for (;;) {
+			if (node === focused) break selection;
+			if (parent === anchorNode && ++anchorChildIndex === anchorOffset) start = length;
+			if (parent === focusNode && ++focusChildIndex === focusOffset) end = length;
+			if (start !== -1 && end !== -1) break selection;
+			const sibling = node.nextSibling;
+			if (sibling !== null) {
+				node = sibling;
+				break;
+			}
+			node = parent!;
+			parent = node.parentNode;
+		}
+	}
+
+	return start === -1 || end === -1 ? null : { focused, start, end, contentEditable: true };
+}
+
 /** Capture selection only when a render pass could actually mutate focused DOM. */
 function captureFocusSelection(doc: Document): FocusSelectionSnapshot | null {
 	const focused = activeElementForDocument(doc) as HTMLElement | null;
@@ -2990,12 +3039,41 @@ function captureFocusSelection(doc: Document): FocusSelectionSnapshot | null {
 			focused.contains(selection.anchorNode) &&
 			focused.contains(selection.focusNode)
 		) {
-			const range = focused.ownerDocument.createRange();
-			range.selectNodeContents(focused);
-			range.setEnd(selection.anchorNode, selection.anchorOffset);
-			const start = range.toString().length;
-			range.setEnd(selection.focusNode, selection.focusOffset);
-			return { focused, start, end: range.toString().length, contentEditable: true };
+			const anchorNode = selection.anchorNode;
+			const focusNode = selection.focusNode;
+			if (anchorNode === focusNode && anchorNode.nodeType === 3) {
+				// A direct first text child has no preceding text to count.
+				if (anchorNode === focused.firstChild) {
+					return {
+						focused,
+						start: selection.anchorOffset,
+						end: selection.focusOffset,
+						contentEditable: true,
+					};
+				}
+				// Below 256 UTF-16 code units, one native prefix walk beats JS traversal;
+				// shared-node offset arithmetic also preserves selection direction.
+				if (anchorNode.nodeValue!.length < 256) {
+					const range = focused.ownerDocument.createRange();
+					range.selectNodeContents(focused);
+					range.setEnd(anchorNode, selection.anchorOffset);
+					const start = range.toString().length;
+					return {
+						focused,
+						start,
+						end: start + selection.focusOffset - selection.anchorOffset,
+						contentEditable: true,
+					};
+				}
+			}
+			const snapshot = captureContentEditableSelection(
+				focused,
+				anchorNode,
+				selection.anchorOffset,
+				focusNode,
+				selection.focusOffset,
+			);
+			if (snapshot !== null) return snapshot;
 		}
 	}
 	return { focused, start: -1, end: -1, contentEditable: false };

--- a/packages/octane/tests/browser/suspense-hydration/main.ts
+++ b/packages/octane/tests/browser/suspense-hydration/main.ts
@@ -12,6 +12,7 @@ import {
 	DirectRootRefUnmountApp,
 	SuspensePreservationApp,
 } from '../../_fixtures/suspense-preserves-dom.tsrx';
+import { FastHostControlledList } from '../../_fixtures/for.tsrx';
 
 type Controls = {
 	urgent(next: string): void;
@@ -244,6 +245,58 @@ function mountDirectRefUnmountCase(): void {
 	};
 }
 
+function mountFocusRestorationCase(): void {
+	const container = document.querySelector('#suspense-root') as HTMLElement;
+	const initialRows = [
+		{ id: 1, label: 'first field' },
+		{ id: 2, label: 'selected browser value' },
+		{ id: 3, label: 'third field' },
+		{ id: 4, label: 'fourth field' },
+	];
+	const root = createRoot(container);
+	root.render(FastHostControlledList, { items: initialRows });
+	flushSync(() => {});
+	const scroller = container.querySelector('#fast-host-controlled-list') as HTMLElement;
+	scroller.style.height = '36px';
+	scroller.style.overflow = 'auto';
+	for (const control of scroller.querySelectorAll<HTMLInputElement>('.fast-host-controlled-row')) {
+		control.style.display = 'block';
+		control.style.height = '32px';
+	}
+	const input = container.querySelectorAll<HTMLInputElement>('.fast-host-controlled-row')[1]!;
+	input.focus();
+	input.setSelectionRange(2, 9);
+	scroller.scrollTop = 7;
+
+	function snapshot() {
+		return {
+			inputSame: container.querySelectorAll('.fast-host-controlled-row')[2] === input,
+			inputConnected: input.isConnected,
+			activeValue: (document.activeElement as HTMLInputElement | null)?.value ?? '',
+			selectionStart: input.selectionStart,
+			selectionEnd: input.selectionEnd,
+			scrollTop: scroller.scrollTop,
+			values: Array.from(
+				container.querySelectorAll<HTMLInputElement>('.fast-host-controlled-row'),
+				(element) => element.value,
+			),
+			globalFailures: globalFailures.slice(),
+		};
+	}
+
+	window.__suspenseHydration = {
+		kind: 'focus-restoration',
+		urgent() {
+			flushSync(() => root.render(FastHostControlledList, { items: initialRows.toReversed() }));
+		},
+		resolve() {},
+		unmount() {
+			root.unmount();
+		},
+		snapshot,
+	};
+}
+
 function mountReactBaselineCase(): void {
 	const container = document.querySelector('#suspense-root') as HTMLElement;
 	const routeB = deferred<string>();
@@ -305,12 +358,14 @@ function mountReactBaselineCase(): void {
 if (testCase === 'hydration') mountHydrationCase();
 else if (testCase === 'suspense') mountSuspenseCase();
 else if (testCase === 'direct-ref-unmount') mountDirectRefUnmountCase();
+else if (testCase === 'focus-restoration') mountFocusRestorationCase();
 else if (testCase === 'react-baseline') mountReactBaselineCase();
 
 declare global {
 	interface Window {
 		__suspenseHydration: {
-			kind: 'hydration' | 'suspense' | 'react-baseline' | 'direct-ref-unmount';
+			kind:
+				'hydration' | 'suspense' | 'react-baseline' | 'direct-ref-unmount' | 'focus-restoration';
 			prepareInput?: () => any;
 			prepareRange?: () => any;
 			urgent?: () => void;

--- a/packages/octane/tests/browser/suspense-hydration/main.ts
+++ b/packages/octane/tests/browser/suspense-hydration/main.ts
@@ -1,4 +1,5 @@
 import {
+	createElement,
 	createRoot,
 	flushSync,
 	hydrateRoot,
@@ -297,6 +298,127 @@ function mountFocusRestorationCase(): void {
 	};
 }
 
+function mountEditableFocusRestorationCase(): void {
+	const container = document.querySelector('#suspense-root') as HTMLElement;
+	const react = search.get('implementation') === 'react';
+	const element: (...args: any[]) => any = react ? React.createElement : createElement;
+	const root = react ? createReactRoot(container) : createRoot(container);
+	const initialRows = [1, 2, 3, 4];
+
+	function EditableRows(props: { items: number[] }) {
+		return element(
+			'section',
+			{ id: 'focus-editable-list' },
+			props.items.map((id) =>
+				element(
+					'div',
+					{
+						key: id,
+						id: `focus-editable-${id}`,
+						'data-editable-row': id,
+						'data-segment': 'editable',
+						contentEditable: true,
+						suppressContentEditableWarning: true,
+					},
+					element(
+						'span',
+						{ 'data-segment': 'first' },
+						element('strong', { 'data-part': 'first' }, 'alpha'),
+						element('em', { 'data-part': 'second' }, ' beta'),
+					),
+					element(
+						'span',
+						{ 'data-segment': 'middle' },
+						element('b', { 'data-part': 'third' }, ' middle'),
+						element('i', { 'data-part': 'fourth' }, ' words'),
+					),
+					element(
+						'span',
+						{ 'data-segment': 'last' },
+						element('u', { 'data-part': 'last' }, ' omega'),
+					),
+				),
+			),
+		);
+	}
+
+	function render(items: number[]): void {
+		const update = () => root.render(element(EditableRows, { items }));
+		if (react) flushReactSync(update);
+		else flushSync(update);
+	}
+
+	render(initialRows);
+	const editable = container.querySelector('#focus-editable-2') as HTMLElement;
+	const first = editable.querySelector('[data-part="first"]')!.firstChild!;
+	const last = editable.querySelector('[data-part="last"]')!.firstChild!;
+	editable.focus();
+	const selection = document.getSelection()!;
+	// Focusing an editable host implicitly creates a collapsed Chromium range.
+	selection.removeAllRanges();
+	if (search.get('selection') === 'boundary') {
+		selection.setBaseAndExtent(editable.querySelector('[data-segment="first"]')!, 1, editable, 2);
+	} else {
+		selection.setBaseAndExtent(last, 4, first, 2);
+	}
+
+	function describeSelectionNode(node: Node | null): string {
+		if (node === null) return '';
+		if (node.nodeType === Node.TEXT_NODE) {
+			return `text:${node.parentElement?.getAttribute('data-part') ?? ''}`;
+		}
+		return `element:${(node as Element).getAttribute('data-segment') ?? ''}`;
+	}
+
+	function selectionOffset(node: Node | null, offset: number): number {
+		if (node === null || !editable.contains(node)) return -1;
+		const range = document.createRange();
+		range.selectNodeContents(editable);
+		range.setEnd(node, offset);
+		return range.toString().length;
+	}
+
+	function snapshot() {
+		const current = document.getSelection();
+		const anchorPosition = selectionOffset(current?.anchorNode ?? null, current?.anchorOffset ?? 0);
+		const focusPosition = selectionOffset(current?.focusNode ?? null, current?.focusOffset ?? 0);
+		return {
+			editableSame: container.querySelector('#focus-editable-2') === editable,
+			editableConnected: editable.isConnected,
+			activeId: (document.activeElement as HTMLElement | null)?.id ?? '',
+			anchorNode: describeSelectionNode(current?.anchorNode ?? null),
+			anchorOffset: current?.anchorOffset ?? -1,
+			focusNode: describeSelectionNode(current?.focusNode ?? null),
+			focusOffset: current?.focusOffset ?? -1,
+			anchorPosition,
+			focusPosition,
+			direction:
+				anchorPosition > focusPosition
+					? 'backward'
+					: anchorPosition < focusPosition
+						? 'forward'
+						: 'collapsed',
+			selectedText: current?.toString() ?? '',
+			rows: Array.from(container.querySelectorAll('[data-editable-row]'), (row) =>
+				Number(row.getAttribute('data-editable-row')),
+			),
+			globalFailures: globalFailures.slice(),
+		};
+	}
+
+	window.__suspenseHydration = {
+		kind: 'editable-focus-restoration',
+		urgent() {
+			render(initialRows.toReversed());
+		},
+		resolve() {},
+		unmount() {
+			root.unmount();
+		},
+		snapshot,
+	};
+}
+
 function mountReactBaselineCase(): void {
 	const container = document.querySelector('#suspense-root') as HTMLElement;
 	const routeB = deferred<string>();
@@ -359,13 +481,19 @@ if (testCase === 'hydration') mountHydrationCase();
 else if (testCase === 'suspense') mountSuspenseCase();
 else if (testCase === 'direct-ref-unmount') mountDirectRefUnmountCase();
 else if (testCase === 'focus-restoration') mountFocusRestorationCase();
+else if (testCase === 'editable-focus-restoration') mountEditableFocusRestorationCase();
 else if (testCase === 'react-baseline') mountReactBaselineCase();
 
 declare global {
 	interface Window {
 		__suspenseHydration: {
 			kind:
-				'hydration' | 'suspense' | 'react-baseline' | 'direct-ref-unmount' | 'focus-restoration';
+				| 'hydration'
+				| 'suspense'
+				| 'react-baseline'
+				| 'direct-ref-unmount'
+				| 'focus-restoration'
+				| 'editable-focus-restoration';
 			prepareInput?: () => any;
 			prepareRange?: () => any;
 			urgent?: () => void;

--- a/packages/octane/tests/browser/suspense-hydration/suspense-hydration.test.ts
+++ b/packages/octane/tests/browser/suspense-hydration/suspense-hydration.test.ts
@@ -199,6 +199,68 @@ describe.sequential('real-browser Suspense and async hydration evidence', () => 
 		expect(after.globalFailures).toEqual([]);
 	});
 
+	it.each([
+		{
+			selection: 'backward',
+			anchorNode: 'text:last',
+			anchorOffset: 4,
+			focusNode: 'text:first',
+			focusOffset: 2,
+			anchorPosition: 27,
+			focusPosition: 2,
+			direction: 'backward',
+			selectedText: 'pha beta middle words ome',
+		},
+		{
+			selection: 'boundary',
+			anchorNode: 'element:first',
+			anchorOffset: 1,
+			focusNode: 'element:editable',
+			focusOffset: 2,
+			anchorPosition: 5,
+			focusPosition: 23,
+			direction: 'forward',
+			selectedText: ' beta middle words',
+		},
+	])(
+		'preserves nested $selection editable selection across a keyed reorder like React',
+		async ({ selection, ...initial }) => {
+			await openCase(`case=editable-focus-restoration&implementation=react&selection=${selection}`);
+			const reactBefore = await snapshot();
+			expect(reactBefore).toMatchObject({
+				...initial,
+				editableSame: true,
+				editableConnected: true,
+				activeId: 'focus-editable-2',
+				rows: [1, 2, 3, 4],
+				globalFailures: [],
+			});
+
+			await page!.evaluate(() => window.__suspenseHydration.urgent!());
+			const reactAfter = await snapshot();
+			expect(reactAfter).toMatchObject({
+				editableSame: true,
+				editableConnected: true,
+				activeId: 'focus-editable-2',
+				anchorPosition: initial.anchorPosition,
+				focusPosition: initial.focusPosition,
+				direction: initial.direction,
+				selectedText: initial.selectedText,
+				rows: [4, 3, 2, 1],
+				globalFailures: [],
+			});
+			await page!.close();
+			page = undefined;
+
+			await openCase(
+				`case=editable-focus-restoration&implementation=octane&selection=${selection}`,
+			);
+			expect(await snapshot()).toEqual(reactBefore);
+			await page!.evaluate(() => window.__suspenseHydration.urgent!());
+			expect(await snapshot()).toEqual(reactAfter);
+		},
+	);
+
 	it('contains async hydration recovery and preserves an interactive outside sibling', async () => {
 		const page = await openCase('case=hydration');
 		let state = await snapshot();
@@ -356,7 +418,12 @@ declare global {
 	interface Window {
 		__suspenseHydration: {
 			kind:
-				'hydration' | 'suspense' | 'react-baseline' | 'direct-ref-unmount' | 'focus-restoration';
+				| 'hydration'
+				| 'suspense'
+				| 'react-baseline'
+				| 'direct-ref-unmount'
+				| 'focus-restoration'
+				| 'editable-focus-restoration';
 			prepareInput?: () => any;
 			prepareRange?: () => any;
 			urgent?: () => void;

--- a/packages/octane/tests/browser/suspense-hydration/suspense-hydration.test.ts
+++ b/packages/octane/tests/browser/suspense-hydration/suspense-hydration.test.ts
@@ -176,6 +176,29 @@ async function expectUrgentPreservation(shape: 'same' | 'swap'): Promise<void> {
 }
 
 describe.sequential('real-browser Suspense and async hydration evidence', () => {
+	it('restores focused input and its selected text after a keyed DOM reorder', async () => {
+		await openCase('case=focus-restoration');
+		const before = await snapshot();
+		expect(before.activeValue).toBe('selected browser value');
+		expect([before.selectionStart, before.selectionEnd]).toEqual([2, 9]);
+		expect(before.scrollTop).toBe(7);
+
+		await page!.evaluate(() => window.__suspenseHydration.urgent!());
+		const after = await snapshot();
+		expect(after.values).toEqual([
+			'fourth field',
+			'third field',
+			'selected browser value',
+			'first field',
+		]);
+		expect(after.inputSame).toBe(true);
+		expect(after.inputConnected).toBe(true);
+		expect(after.activeValue).toBe('selected browser value');
+		expect([after.selectionStart, after.selectionEnd]).toEqual([2, 9]);
+		expect(after.scrollTop).toBe(7);
+		expect(after.globalFailures).toEqual([]);
+	});
+
 	it('contains async hydration recovery and preserves an interactive outside sibling', async () => {
 		const page = await openCase('case=hydration');
 		let state = await snapshot();
@@ -332,7 +355,8 @@ describe.sequential('real-browser Suspense and async hydration evidence', () => 
 declare global {
 	interface Window {
 		__suspenseHydration: {
-			kind: 'hydration' | 'suspense' | 'react-baseline' | 'direct-ref-unmount';
+			kind:
+				'hydration' | 'suspense' | 'react-baseline' | 'direct-ref-unmount' | 'focus-restoration';
 			prepareInput?: () => any;
 			prepareRange?: () => any;
 			urgent?: () => void;

--- a/packages/octane/tests/conformance/_fixtures/dom-attributes.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/dom-attributes.tsrx
@@ -1,3 +1,5 @@
+import { createElement, useLayoutEffect } from 'octane';
+
 // ============================================================================
 // DOM attribute matrix fixtures — ports of ReactDOMAttribute-test.js +
 // DOMPropertyOperations-test.js (+ the empty-string src/href/action core from
@@ -159,4 +161,74 @@ export function AutoFocusInput(props) @{
 }
 export function AutoFocusBare(props) @{
 	<input id="afb" autoFocus />
+}
+
+export function AutoFocusButton() @{
+	<button id="af-button" autoFocus>{'button'}</button>
+}
+
+export function AutoFocusSelect() @{
+	<select id="af-select" autoFocus>
+		<option>{'option'}</option>
+	</select>
+}
+
+export function AutoFocusTextarea() @{
+	<textarea id="af-textarea" autoFocus />
+}
+
+export function AutoFocusUnsupported() @{
+	<div>
+		<div id="af-div" tabIndex={0} autoFocus />
+		<a id="af-anchor" href="#autofocus" autoFocus>{'link'}</a>
+		<svg id="af-svg" tabIndex={0} autoFocus>
+			<circle id="af-circle" autoFocus />
+		</svg>
+	</div>
+}
+
+export function AutoFocusCustom(props) @{
+	<my-autofocus-element id="af-custom" tabIndex={0} autoFocus={props.v} />
+}
+
+export function AutoFocusSpread(props) @{
+	<input id="af-spread" {...props.attributes} />
+}
+
+export function AutoFocusMixed(props) @{
+	<input id="af-mixed" {...props.before} autoFocus={props.direct} {...props.after} />
+}
+
+export function AutoFocusDescriptor(props) {
+	return createElement('input', { id: 'af-descriptor', ...props.attributes });
+}
+
+export function LowercaseAutoFocus(props) @{
+	<input id="af-lowercase" autofocus={props.value} />
+}
+
+export function AutoFocusMultiple() @{
+	<div>
+		<input id="af-first" autoFocus />
+		<input id="af-second" autoFocus />
+	</div>
+}
+
+export function AutoFocusInserted(props) @{
+	<div>
+		@if (props.show) {
+			<input id="af-inserted" autoFocus={props.focus} />
+		}
+	</div>
+}
+
+export function AutoFocusLayout(props) @{
+	useLayoutEffect(() => {
+		props.observe(document.activeElement?.id ?? '');
+		document.getElementById('af-layout-target')?.focus();
+	}, [props.observe]);
+	<div>
+		<input id="af-layout-input" autoFocus />
+		<button id="af-layout-target">{'target'}</button>
+	</div>
 }

--- a/packages/octane/tests/conformance/dom-attributes.test.ts
+++ b/packages/octane/tests/conformance/dom-attributes.test.ts
@@ -29,6 +29,18 @@ import {
 	CustomElChangeInput,
 	AutoFocusInput,
 	AutoFocusBare,
+	AutoFocusButton,
+	AutoFocusSelect,
+	AutoFocusTextarea,
+	AutoFocusUnsupported,
+	AutoFocusCustom,
+	AutoFocusSpread,
+	AutoFocusMixed,
+	AutoFocusDescriptor,
+	LowercaseAutoFocus,
+	AutoFocusMultiple,
+	AutoFocusInserted,
+	AutoFocusLayout,
 } from './_fixtures/dom-attributes.tsrx';
 
 // ============================================================================
@@ -813,9 +825,8 @@ describe('enumerated + overloaded boolean attributes', () => {
 });
 
 describe('autoFocus — commit-phase focus, never an attribute (React parity, 2026-07-08)', () => {
-	// Per ReactDOMComponent's autoFocus handling: React writes NO attribute and
-	// calls .focus() at commitMount. octane queues the focus into the commit
-	// (drained before layout effects, so a layout effect moving focus wins).
+	// Per ReactDOM-test.js:354, client mounts focus supported controls after DOM
+	// insertion without writing an attribute; server markup is covered separately.
 	it('focuses the element at mount commit and writes no attribute', () => {
 		const r = mount(AutoFocusBare);
 		const el = r.find('#afb') as HTMLInputElement;
@@ -833,5 +844,155 @@ describe('autoFocus — commit-phase focus, never an attribute (React parity, 20
 		r.update(AutoFocusInput, { v: true });
 		expect(document.activeElement).not.toBe(el);
 		r.unmount();
+	});
+
+	it('focuses buttons, selects, and textareas without writing an attribute', () => {
+		for (const [component, selector] of [
+			[AutoFocusButton, '#af-button'],
+			[AutoFocusSelect, '#af-select'],
+			[AutoFocusTextarea, '#af-textarea'],
+		] as const) {
+			const r = mount(component);
+			try {
+				const el = r.find(selector);
+				expect(document.activeElement).toBe(el);
+				expect(el.hasAttribute('autofocus')).toBe(false);
+			} finally {
+				r.unmount();
+			}
+		}
+	});
+
+	it('does not focus divs, anchors, or SVG elements', () => {
+		const outside = document.createElement('button');
+		document.body.appendChild(outside);
+		outside.focus();
+		const r = mount(AutoFocusUnsupported);
+		try {
+			expect(document.activeElement).toBe(outside);
+			for (const selector of ['#af-div', '#af-anchor', '#af-svg', '#af-circle']) {
+				expect(r.find(selector).hasAttribute('autofocus')).toBe(false);
+			}
+		} finally {
+			r.unmount();
+			outside.remove();
+		}
+	});
+
+	it('keeps custom-element autoFocus as a raw attribute without focusing it', () => {
+		const outside = document.createElement('button');
+		document.body.appendChild(outside);
+		outside.focus();
+		const r = mount(AutoFocusCustom, { v: true });
+		try {
+			expect(r.find('#af-custom').getAttribute('autofocus')).toBe('');
+			expect(document.activeElement).toBe(outside);
+		} finally {
+			r.unmount();
+			outside.remove();
+		}
+	});
+
+	it('focuses a spread-supplied autoFocus only when the element mounts', () => {
+		const focused = mount(AutoFocusSpread, { attributes: { autoFocus: true } });
+		try {
+			const el = focused.find('#af-spread');
+			expect(document.activeElement).toBe(el);
+			expect(el.hasAttribute('autofocus')).toBe(false);
+		} finally {
+			focused.unmount();
+		}
+
+		const unfocused = mount(AutoFocusSpread, { attributes: { autoFocus: false } });
+		try {
+			const el = unfocused.find('#af-spread');
+			unfocused.update(AutoFocusSpread, { attributes: { autoFocus: true } });
+			expect(document.activeElement).not.toBe(el);
+		} finally {
+			unfocused.unmount();
+		}
+
+		const omitted = mount(AutoFocusSpread, { attributes: {} });
+		try {
+			const el = omitted.find('#af-spread');
+			omitted.update(AutoFocusSpread, { attributes: { autoFocus: true } });
+			expect(document.activeElement).not.toBe(el);
+		} finally {
+			omitted.unmount();
+		}
+	});
+
+	it('resolves direct and spread autoFocus before deciding mount focus', () => {
+		for (const [before, direct, after, shouldFocus] of [
+			[{}, false, { autoFocus: true }, true],
+			[{}, true, { autoFocus: false }, false],
+			[{ autoFocus: true }, false, {}, false],
+		] as const) {
+			const r = mount(AutoFocusMixed, { before, direct, after });
+			try {
+				expect(document.activeElement === r.find('#af-mixed')).toBe(shouldFocus);
+			} finally {
+				r.unmount();
+			}
+		}
+	});
+
+	it('does not focus an existing descriptor when autoFocus is added later', () => {
+		const r = mount(AutoFocusDescriptor, { attributes: {} });
+		try {
+			const el = r.find('#af-descriptor');
+			r.update(AutoFocusDescriptor, { attributes: { autoFocus: true } });
+			expect(r.find('#af-descriptor')).toBe(el);
+			expect(document.activeElement).not.toBe(el);
+		} finally {
+			r.unmount();
+		}
+	});
+
+	it('keeps lowercase autofocus as an invalid raw attribute, not a focus request', () => {
+		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const r = mount(LowercaseAutoFocus, { value: true });
+		try {
+			const el = r.find('#af-lowercase');
+			expect(el.hasAttribute('autofocus')).toBe(false);
+			expect(document.activeElement).not.toBe(el);
+			r.update(LowercaseAutoFocus, { value: 'literal' });
+			expect(el.getAttribute('autofocus')).toBe('literal');
+			expect(document.activeElement).not.toBe(el);
+			expectDevError(error, 'Invalid DOM property `autofocus`. Did you mean `autoFocus`?');
+		} finally {
+			r.unmount();
+			error.mockRestore();
+		}
+	});
+
+	it('focuses a newly inserted element during an update', () => {
+		const r = mount(AutoFocusInserted, { show: false, focus: true });
+		try {
+			r.update(AutoFocusInserted, { show: true, focus: true });
+			expect(document.activeElement).toBe(r.find('#af-inserted'));
+		} finally {
+			r.unmount();
+		}
+	});
+
+	it('focuses multiple mounted controls in their DOM order', () => {
+		const r = mount(AutoFocusMultiple);
+		try {
+			expect(document.activeElement).toBe(r.find('#af-second'));
+		} finally {
+			r.unmount();
+		}
+	});
+
+	it('focuses before layout effects, which can intentionally move focus', () => {
+		const observed: string[] = [];
+		const r = mount(AutoFocusLayout, { observe: (id: string) => observed.push(id) });
+		try {
+			expect(observed).toEqual(['af-layout-input']);
+			expect(document.activeElement).toBe(r.find('#af-layout-target'));
+		} finally {
+			r.unmount();
+		}
 	});
 });

--- a/packages/octane/tests/conformance/dom-component-ssr.test.ts
+++ b/packages/octane/tests/conformance/dom-component-ssr.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { compile } from 'octane/compiler';
 import * as Server from 'octane/server';
 import { createElement } from '../../src/index.js';
@@ -87,6 +87,158 @@ describe('ReactDOMComponent — SSR open-tag markup', () => {
 		expect(html).toContain('b&amp;ckground');
 		const el = parse(html).querySelector('div')!;
 		expect(el.getAttribute('style')).toBe('b&ckground:<3;');
+	});
+});
+
+describe('ReactServerRenderingHydration — server autoFocus attributes', () => {
+	const standard = evalServer(
+		`export function Static() @{
+			<section>
+				<input id="input" autoFocus />
+				<button id="button" autoFocus />
+				<select id="select" autoFocus />
+				<textarea id="textarea" autoFocus />
+				<div id="div" autoFocus />
+				<svg id="svg" autoFocus><circle id="circle" autoFocus /></svg>
+				<math id="math" autoFocus><mi id="mi" autoFocus /></math>
+			</section>
+		}
+		export function StaticValues() @{
+			<section>
+				<input id="static-true" autoFocus={true} />
+				<input id="static-string" autoFocus={'yes'} />
+				<input id="static-number" autoFocus={1} />
+				<input id="static-false" autoFocus={false} />
+				<input id="static-empty" autoFocus={''} />
+				<input id="static-zero" autoFocus={0} />
+			</section>
+		}
+		export function Dynamic(p) @{ <input id="dynamic" autoFocus={p.value} /> }
+		export function Lowercase(p) @{ <input id="lowercase" autofocus={p.value} /> }
+		export function Spread(p) @{ <input id="spread" {...p.attributes} /> }
+		export function Mixed(p) @{
+			<input id="mixed" {...p.before} autoFocus={p.direct} {...p.after} />
+		}
+		export function NamespacedSpread(p) @{
+			<svg {...p.attributes}><circle {...p.attributes} /></svg>
+		}
+		export function Descriptor(p) { return p.node; }`,
+		'dc-autofocus-standard.tsrx',
+	);
+	const custom = evalServer(
+		`export function Direct(p) @{ <my-autofocus-element autoFocus={p.value} /> }
+		export function Spread(p) @{ <my-autofocus-element {...p.attributes} /> }`,
+		'dc-autofocus-custom.tsrx',
+	);
+
+	// Per ReactServerRenderingHydration-test.js:161, SSR emits autofocus while a
+	// client mount performs focus without writing that attribute.
+	it('serializes static autoFocus on standard HTML, SVG, and MathML elements', () => {
+		const { html } = Server.renderToString(standard.Static);
+		expect(Array.from(parse(html).querySelectorAll('[autofocus]'), (el) => el.id)).toEqual([
+			'input',
+			'button',
+			'select',
+			'textarea',
+			'div',
+			'svg',
+			'circle',
+			'math',
+			'mi',
+		]);
+		expect(html.match(/ autofocus=""/g)).toHaveLength(9);
+		expect(html).not.toContain(' autoFocus');
+	});
+
+	it('applies boolean presence semantics to compile-time literal values', () => {
+		const { html } = Server.renderToString(standard.StaticValues);
+		expect(Array.from(parse(html).querySelectorAll('[autofocus]'), (el) => el.id)).toEqual([
+			'static-true',
+			'static-string',
+			'static-number',
+		]);
+		expect(html.match(/ autofocus=""/g)).toHaveLength(3);
+	});
+
+	it('applies boolean presence semantics to direct and spread autoFocus', () => {
+		for (const value of [true, 'yes', 1]) {
+			for (const [component, props] of [
+				[standard.Dynamic, { value }],
+				[standard.Spread, { attributes: { autoFocus: value } }],
+			] as const) {
+				const { html } = Server.renderToString(component, props);
+				expect(parse(html).querySelector('input')?.getAttribute('autofocus')).toBe('');
+				expect(html).toContain(' autofocus=""');
+			}
+		}
+		for (const value of [false, '', 0, null, undefined]) {
+			for (const [component, props] of [
+				[standard.Dynamic, { value }],
+				[standard.Spread, { attributes: { autoFocus: value } }],
+			] as const) {
+				const { html } = Server.renderToString(component, props);
+				expect(parse(html).querySelector('input')?.hasAttribute('autofocus')).toBe(false);
+			}
+		}
+	});
+
+	it('resolves direct and spread autoFocus by the last authored writer', () => {
+		for (const [before, direct, after, expected] of [
+			[{ autoFocus: true }, false, {}, false],
+			[{ autoFocus: false }, false, { autoFocus: true }, true],
+			[{ autoFocus: true }, true, { autoFocus: false }, false],
+		] as const) {
+			const { html } = Server.renderToString(standard.Mixed, { before, direct, after });
+			expect(parse(html).querySelector('#mixed')?.hasAttribute('autofocus')).toBe(expected);
+		}
+	});
+
+	it('does not turn lowercase autofocus into a boolean React prop', () => {
+		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			const booleanHtml = Server.renderToString(standard.Lowercase, { value: true }).html;
+			expect(parse(booleanHtml).querySelector('input')?.hasAttribute('autofocus')).toBe(false);
+			const stringHtml = Server.renderToString(standard.Lowercase, { value: 'literal' }).html;
+			expect(parse(stringHtml).querySelector('input')?.getAttribute('autofocus')).toBe('literal');
+		} finally {
+			error.mockRestore();
+		}
+	});
+
+	it('serializes spread and descriptor autoFocus in standard namespaces', () => {
+		const spreadHtml = Server.renderToString(standard.NamespacedSpread, {
+			attributes: { autoFocus: true },
+		}).html;
+		expect(spreadHtml.match(/ autofocus=""/g)).toHaveLength(2);
+
+		const descriptorHtml = Server.renderToString(standard.Descriptor, {
+			node: createElement('svg', { autoFocus: true }, createElement('circle', { autoFocus: true })),
+		}).html;
+		expect(descriptorHtml.match(/ autofocus=""/g)).toHaveLength(2);
+	});
+
+	it('preserves raw casing and scalar values for custom elements', () => {
+		for (const value of [true, 'yes', '', 0]) {
+			for (const [component, props] of [
+				[custom.Direct, { value }],
+				[custom.Spread, { attributes: { autoFocus: value } }],
+			] as const) {
+				const { html } = Server.renderToString(component, props);
+				expect(html).toContain(' autoFocus');
+				expect(parse(html).querySelector('my-autofocus-element')?.getAttribute('autofocus')).toBe(
+					value === true ? '' : String(value),
+				);
+			}
+		}
+		for (const component of [custom.Direct, custom.Spread]) {
+			const props =
+				component === custom.Direct ? { value: false } : { attributes: { autoFocus: false } };
+			expect(
+				parse(Server.renderToString(component, props).html)
+					.querySelector('my-autofocus-element')
+					?.hasAttribute('autofocus'),
+			).toBe(false);
+		}
 	});
 });
 

--- a/packages/octane/tests/focus-restoration.test.ts
+++ b/packages/octane/tests/focus-restoration.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createElement, createRoot, flushSync, useLayoutEffect } from '../src/index.js';
+import { mount } from './_helpers';
+import { FastHostControlledList } from './_fixtures/for.tsrx';
+
+const rows = [
+	{ id: 1, label: 'first value' },
+	{ id: 2, label: 'selected value' },
+	{ id: 3, label: 'third value' },
+	{ id: 4, label: 'fourth value' },
+];
+
+type FocusRow = (typeof rows)[number];
+
+interface ObservedRowsProps {
+	items: FocusRow[];
+	observe?: (focused: Element | null) => void;
+	moveFocus?: boolean;
+	addAutoFocus?: boolean;
+}
+
+const layoutSlot = Symbol('focus-restoration layout');
+
+function ObservedRows(props: ObservedRowsProps) {
+	useLayoutEffect(
+		() => {
+			props.observe?.(document.activeElement);
+			if (props.moveFocus) document.getElementById('focus-override')?.focus();
+		},
+		[props.items, props.observe, props.moveFocus, props.addAutoFocus],
+		layoutSlot,
+	);
+	return createElement('section', {
+		children: [
+			createElement(FastHostControlledList, { key: 'rows', items: props.items }),
+			createElement('button', { key: 'override', id: 'focus-override', children: 'override' }),
+			props.addAutoFocus
+				? createElement('input', { key: 'autofocus', id: 'focus-new', autoFocus: true })
+				: null,
+		],
+	});
+}
+
+function EditableRows(props: { items: FocusRow[] }) {
+	return createElement('section', {
+		children: props.items.map((row) =>
+			createElement('div', {
+				key: row.id,
+				id: `focus-editable-${row.id}`,
+				contentEditable: true,
+				suppressContentEditableWarning: true,
+				children: [
+					createElement('span', { key: 'first', children: 'first words' }),
+					createElement('span', { key: 'second', children: ' second words' }),
+				],
+			}),
+		),
+	});
+}
+
+describe('focus and text selection survive DOM updates', () => {
+	// Per ReactDOM-test.js, "preserves focus": DOM mutations may blur a
+	// surviving control, but focus must be restored before the commit ends.
+	it('keeps the focused keyed input and its selected text when its row moves', () => {
+		const rendered = mount(FastHostControlledList, { items: rows });
+		try {
+			const input = rendered.findAll('input')[1] as HTMLInputElement;
+			input.focus();
+			input.setSelectionRange(2, 9, 'backward');
+
+			rendered.update(FastHostControlledList, { items: rows.toReversed() });
+
+			expect(rendered.findAll('input')[2]).toBe(input);
+			expect(document.activeElement).toBe(input);
+			expect([input.selectionStart, input.selectionEnd]).toEqual([2, 9]);
+		} finally {
+			rendered.unmount();
+		}
+	});
+
+	it('restores focus when an update is committed by its normal scheduled flush', async () => {
+		const rendered = mount(FastHostControlledList, { items: rows });
+		try {
+			const input = rendered.findAll('input')[1] as HTMLInputElement;
+			input.focus();
+			input.setSelectionRange(2, 9);
+
+			rendered.root.render(FastHostControlledList, { items: rows.toReversed() });
+			await Promise.resolve();
+
+			expect(rendered.findAll('input')[2]).toBe(input);
+			expect(document.activeElement).toBe(input);
+			expect([input.selectionStart, input.selectionEnd]).toEqual([2, 9]);
+		} finally {
+			rendered.unmount();
+		}
+	});
+
+	it('restores selected text if moving the control resets its selection', () => {
+		const rendered = mount(FastHostControlledList, { items: rows });
+		const parent = rendered.find('#fast-host-controlled-list');
+		const originalInsert = parent.insertBefore;
+		const input = rendered.findAll('input')[1] as HTMLInputElement;
+		input.focus();
+		input.setSelectionRange(2, 9);
+		const move = vi.spyOn(parent, 'insertBefore').mockImplementation(function <T extends Node>(
+			node: T,
+			anchor: Node | null,
+		): T {
+			const result = originalInsert.call(this, node, anchor) as T;
+			if (document.activeElement !== input) input.setSelectionRange(0, 0);
+			return result;
+		});
+		try {
+			rendered.update(FastHostControlledList, { items: rows.toReversed() });
+
+			expect(document.activeElement).toBe(input);
+			expect([input.selectionStart, input.selectionEnd]).toEqual([2, 9]);
+		} finally {
+			move.mockRestore();
+			rendered.unmount();
+		}
+	});
+
+	it('restores focus before layout effects observe the updated DOM', () => {
+		const observed: Array<Element | null> = [];
+		const observe = (focused: Element | null) => observed.push(focused);
+		const rendered = mount(ObservedRows, { items: rows, observe });
+		try {
+			const input = rendered.findAll('input')[1] as HTMLInputElement;
+			input.focus();
+			observed.length = 0;
+
+			rendered.update(ObservedRows, { items: rows.toReversed(), observe });
+
+			expect(observed).toEqual([input]);
+			expect(document.activeElement).toBe(input);
+		} finally {
+			rendered.unmount();
+		}
+	});
+
+	it('lets a layout effect deliberately move focus after restoration', () => {
+		const observed: Array<Element | null> = [];
+		const observe = (focused: Element | null) => observed.push(focused);
+		const rendered = mount(ObservedRows, { items: rows, observe });
+		try {
+			const input = rendered.findAll('input')[1] as HTMLInputElement;
+			input.focus();
+			observed.length = 0;
+
+			rendered.update(ObservedRows, { items: rows.toReversed(), observe, moveFocus: true });
+
+			expect(observed).toEqual([input]);
+			expect(document.activeElement).toBe(rendered.find('#focus-override'));
+		} finally {
+			rendered.unmount();
+		}
+	});
+
+	it('restores the previous control before a newly mounted autoFocus control wins', () => {
+		const events: string[] = [];
+		const observe = (focused: Element | null) => events.push(`layout:${focused?.id}`);
+		const rendered = mount(ObservedRows, { items: rows, observe });
+		try {
+			const previous = rendered.findAll('input')[1] as HTMLInputElement;
+			previous.focus();
+			events.length = 0;
+			rendered.container.addEventListener('focusin', (event) => {
+				const focused = event.target as HTMLInputElement;
+				events.push(focused.id || focused.value);
+			});
+
+			rendered.update(ObservedRows, {
+				items: rows.toReversed(),
+				observe,
+				addAutoFocus: true,
+			});
+
+			expect(events).toEqual(['selected value', 'focus-new', 'layout:focus-new']);
+			expect(document.activeElement).toBe(rendered.find('#focus-new'));
+		} finally {
+			rendered.unmount();
+		}
+	});
+
+	it('does not refocus a control removed by the update', () => {
+		const rendered = mount(FastHostControlledList, { items: rows });
+		const input = rendered.findAll('input')[1] as HTMLInputElement;
+		input.focus();
+		const focus = vi.spyOn(input, 'focus');
+		try {
+			rendered.update(FastHostControlledList, {
+				items: rows.filter((row) => row.id !== 2),
+			});
+
+			expect(input.isConnected).toBe(false);
+			expect(focus).not.toHaveBeenCalled();
+			expect(document.activeElement).not.toBe(input);
+		} finally {
+			focus.mockRestore();
+			rendered.unmount();
+		}
+	});
+
+	it('restores a still-connected focused control outside the updating root', () => {
+		const outside = document.createElement('button');
+		document.body.appendChild(outside);
+		const rendered = mount(FastHostControlledList, { items: rows });
+		const parent = rendered.find('#fast-host-controlled-list');
+		const originalInsert = parent.insertBefore;
+		outside.focus();
+		const move = vi.spyOn(parent, 'insertBefore').mockImplementation(function <T extends Node>(
+			node: T,
+			anchor: Node | null,
+		): T {
+			const result = originalInsert.call(this, node, anchor) as T;
+			outside.blur();
+			return result;
+		});
+		try {
+			rendered.update(FastHostControlledList, { items: rows.toReversed() });
+
+			expect(
+				rendered.findAll('input').map((element) => (element as HTMLInputElement).value),
+			).toEqual(rows.toReversed().map((row) => row.label));
+			expect(document.activeElement).toBe(outside);
+		} finally {
+			move.mockRestore();
+			rendered.unmount();
+			outside.remove();
+		}
+	});
+
+	it('restores focus to a moved content-editable host with an active selection', () => {
+		const rendered = mount(EditableRows, { items: rows });
+		try {
+			const editable = rendered.find('#focus-editable-2') as HTMLElement;
+			const first = editable.querySelectorAll('span')[0]!.firstChild!;
+			const second = editable.querySelectorAll('span')[1]!.firstChild!;
+			editable.focus();
+			const range = document.createRange();
+			range.setStart(second, 4);
+			range.collapse(true);
+			const selection = document.getSelection()!;
+			selection.removeAllRanges();
+			selection.addRange(range);
+			selection.extend(first, 2);
+			expect(selection.toString()).toBe('rst words sec');
+
+			rendered.update(EditableRows, { items: rows.toReversed() });
+
+			expect(rendered.find('#focus-editable-2')).toBe(editable);
+			expect(document.activeElement).toBe(editable);
+		} finally {
+			document.getSelection()?.removeAllRanges();
+			rendered.unmount();
+		}
+	});
+
+	// Per ReactDOMFiber-test.js, "should restore selection in the correct
+	// window": the owning document, not the ambient document, owns focus.
+	it('restores focus and selection in the root container’s owner document', () => {
+		const frame = document.createElement('iframe');
+		document.body.appendChild(frame);
+		const frameDocument = frame.contentDocument!;
+		const container = frameDocument.createElement('div');
+		frameDocument.body.appendChild(container);
+		const root = createRoot(container);
+		try {
+			root.render(FastHostControlledList, { items: rows });
+			flushSync(() => {});
+			const input = container.querySelectorAll('input')[1]!;
+			input.focus();
+			input.setSelectionRange(2, 9);
+
+			flushSync(() => root.render(FastHostControlledList, { items: rows.toReversed() }));
+
+			expect(container.querySelectorAll('input')[2]).toBe(input);
+			expect(frameDocument.activeElement).toBe(input);
+			expect([input.selectionStart, input.selectionEnd]).toEqual([2, 9]);
+		} finally {
+			root.unmount();
+			frame.remove();
+		}
+	});
+});

--- a/packages/octane/tests/host-component-props.test.ts
+++ b/packages/octane/tests/host-component-props.test.ts
@@ -60,4 +60,48 @@ describe('hostComponent — no stale props/events on the reused element', () => 
 		expect(captured).toBe(1);
 		r.unmount();
 	});
+
+	it('honors autoFocus on mount but not when added to an existing host', () => {
+		const initial = mount(HostBody as any, {
+			tag: 'input',
+			hp: { id: 'host-initial-autofocus', autoFocus: true },
+		});
+		try {
+			expect(document.activeElement).toBe(initial.find('#host-initial-autofocus'));
+		} finally {
+			initial.unmount();
+		}
+
+		const existing = mount(HostBody as any, {
+			tag: 'input',
+			hp: { id: 'host-later-autofocus' },
+		});
+		try {
+			const el = existing.find('#host-later-autofocus');
+			existing.update(HostBody as any, {
+				tag: 'input',
+				hp: { id: 'host-later-autofocus', autoFocus: true },
+			});
+			expect(existing.find('#host-later-autofocus')).toBe(el);
+			expect(document.activeElement).not.toBe(el);
+		} finally {
+			existing.unmount();
+		}
+	});
+
+	it('still adds a raw autoFocus attribute to an existing custom host', () => {
+		const r = mount(HostBody as any, {
+			tag: 'my-autofocus-element',
+			hp: { id: 'host-custom-autofocus' },
+		});
+		try {
+			r.update(HostBody as any, {
+				tag: 'my-autofocus-element',
+				hp: { id: 'host-custom-autofocus', autoFocus: true },
+			});
+			expect(r.find('#host-custom-autofocus').getAttribute('autofocus')).toBe('');
+		} finally {
+			r.unmount();
+		}
+	});
 });

--- a/packages/octane/tests/hydration/_fixtures/attr-matrix.tsrx
+++ b/packages/octane/tests/hydration/_fixtures/attr-matrix.tsrx
@@ -57,6 +57,10 @@ export function FormAttrs(props) @{
 	</form>
 }
 
+export function AutoFocusSpread(props) @{
+	<input id="hydrated-autofocus-spread" {...props.attributes} />
+}
+
 export function NamespacedTags(props) @{
 	<div>
 		<svg class="s1" viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">

--- a/packages/octane/tests/hydration/attr-matrix.test.ts
+++ b/packages/octane/tests/hydration/attr-matrix.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { compile } from 'octane/compiler';
@@ -10,6 +10,7 @@ import {
 	EnumeratedAndAria,
 	NamedAndAliased,
 	FormAttrs,
+	AutoFocusSpread,
 	NamespacedTags,
 	WhitespaceSensitive,
 	ClassComposition,
@@ -104,4 +105,79 @@ describe('client and SSR attribute policy agree', () => {
 			});
 		}
 	}
+});
+
+describe('server autofocus survives hydration without stealing focus', () => {
+	// Per ReactServerRenderingHydration-test.js:161, the server attribute enables
+	// browser autofocus before hydration, but adoption must never call focus().
+	it('adopts a direct server autofocus attribute and preserves existing focus', () => {
+		const props = { on: true, text: '#form' };
+		const { html } = ServerRT.renderToString(server.FormAttrs, props);
+		const container = document.createElement('div');
+		const outside = document.createElement('button');
+		document.body.append(container, outside);
+		container.innerHTML = html;
+		const input = container.querySelector('.f3') as HTMLInputElement;
+		expect(input.getAttribute('autofocus')).toBe('');
+		outside.focus();
+		let root: ReturnType<typeof hydrateRoot> | undefined;
+		try {
+			root = hydrateRoot(container, FormAttrs, props);
+			flushSync(() => {});
+			expect(container.querySelector('.f3')).toBe(input);
+			expect(input.getAttribute('autofocus')).toBe('');
+			expect(document.activeElement).toBe(outside);
+
+			flushSync(() => root!.render(FormAttrs, { on: false, text: '#form' }));
+			flushSync(() => root!.render(FormAttrs, props));
+			expect(document.activeElement).toBe(outside);
+		} finally {
+			root?.unmount();
+			container.remove();
+			outside.remove();
+		}
+	});
+
+	it('adopts spread-supplied autofocus without focusing the server element', () => {
+		const props = { attributes: { autoFocus: true } };
+		const { html } = ServerRT.renderToString(server.AutoFocusSpread, props);
+		const container = document.createElement('div');
+		const outside = document.createElement('button');
+		document.body.append(container, outside);
+		container.innerHTML = html;
+		const input = container.querySelector('input') as HTMLInputElement;
+		expect(input.getAttribute('autofocus')).toBe('');
+		outside.focus();
+		let root: ReturnType<typeof hydrateRoot> | undefined;
+		try {
+			root = hydrateRoot(container, AutoFocusSpread, props);
+			flushSync(() => {});
+			expect(container.querySelector('input')).toBe(input);
+			expect(input.getAttribute('autofocus')).toBe('');
+			expect(document.activeElement).toBe(outside);
+		} finally {
+			root?.unmount();
+			container.remove();
+			outside.remove();
+		}
+	});
+
+	it('still focuses a fresh client element replacing mismatched server markup', () => {
+		const props = { attributes: { autoFocus: true } };
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		container.innerHTML = '<span id="stale-server-element"></span>';
+		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+		let root: ReturnType<typeof hydrateRoot> | undefined;
+		try {
+			root = hydrateRoot(container, AutoFocusSpread, props);
+			flushSync(() => {});
+			expect(document.activeElement).toBe(container.querySelector('input'));
+			expect(container.querySelector('#stale-server-element')).toBeNull();
+		} finally {
+			root?.unmount();
+			error.mockRestore();
+			container.remove();
+		}
+	});
 });


### PR DESCRIPTION
## Summary

- Make `autoFocus` match React across client mounting, server rendering, hydration, updates, and custom elements.
- Restore the previously focused element, text selection, and ancestor scroll positions after DOM mutations, before autofocus and layout effects run.

## Why

- Octane previously omitted React's server-rendered `autofocus` attribute, focused unsupported elements, could steal focus during hydration or updates, and lost focus when keyed reconciliation moved a surviving control.

## Changes

- Serialize standard-host `autoFocus` as `autofocus=""` in HTML, SVG, and MathML while preserving invalid lowercase spelling and custom-element semantics.
- Imperatively autofocus only newly mounted `button`, `input`, `select`, and `textarea` controls; preserve hydration adoption, fresh mismatch mounts, source precedence, and mount-only behavior for compiled spreads, descriptor-backed elements, and persistent host components.
- Snapshot each queued root's owner-document focus and supported selection before DOM mutation, restore still-connected elements and ancestor scroll positions afterward, and preserve layout-effect/autofocus ordering and Suspense's existing no-refocus behavior.
- Add development/production regression coverage plus real-Chromium keyed-reorder, selection, scrolling, and exact React differential tests for backward and element-boundary rich-text selections.

## Validation

- [ ] `pnpm format:check` — repository-wide check not run; scoped formatting verification passed for every changed file.
- [ ] `pnpm typecheck` — the latest upstream base introduces workspace packages whose dependencies are absent from the existing shared installation; `tsgo --noEmit -p packages/octane/tsconfig.json` and scoped runtime/compiler typechecks both passed.
- [ ] `pnpm test` — the shared worktree installation resolves selected bindings into the original checkout; the full core run passed 11,125 of 11,131 tests, with six failures confined to missing installed-package links and a duplicate runtime in pre-existing Web3 integration fixtures.
- [x] targeted tests: 6,591 compiler, conformance, differential, hydration, server-rendering, host-prop, Suspense, scheduling, and regression tests passed across 370 development/production suites.
- [x] all seven real-Chromium integration suites: 31 tests passed, including exact React rich-text selection parity, focus, scrolling, hydration, native events, portals, and the React/Web3 browser scenario.
- [x] focus-specific regression suite: 20 tests passed across development and production.
- [x] `pnpm sync` completed with no generated-file changes.
- [x] production list-clear benchmark, twice before and after: baseline `[1.380, 2.700, 2.600]` / `[1.420, 2.920, 2.500]` ms; updated `[1.420, 2.940, 2.660]` / `[1.300, 2.660, 2.400]` ms.
- [x] production rich-text performance audit: 4 warmups and 10 interleaved, order-rotated Chromium samples per variant; across 80 unrelated updates with 1,024 editor text nodes, a 1 MiB editor improved from 33.7 ms to 5.2 ms (-84.6%) and a 1 KiB editor improved from 1.2 ms to 0.7 ms (-41.7%). Ordinary unfocused/focused updates add 0.125/0.25 µs per commit; 1,000-block queues remain within measurement noise.

## Risk / follow-ups

- Focus snapshots are skipped for empty queues and unfocused documents; ancestor scroll snapshots allocate only when focus actually changes.
- A matched production app grows from 102,552 B raw / 32,835 B gzip on upstream to 105,990 B raw / 33,930 B gzip with the complete feature (+1,095 B gzip; +3.33%). The adaptive rich-text optimization adds 260 B gzip over the initial PR while eliminating its measured dense-editor cliff.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sit on every commit flush path and user-visible focus/selection behavior, but behavior is scoped to React parity and backed by broad regression and browser tests.
> 
> **Overview**
> **React-style `autoFocus`:** Standard hosts now get `autofocus=""` in server markup (compiler + `runtime.server`); the client still focuses at commit without setting that attribute. Imperative focus is limited to newly mounted `button`/`input`/`select`/`textarea`, skipped on hydrated nodes and on updates (including spreads and host-component paths), while custom elements keep raw `autoFocus` attributes.
> 
> **Focus preservation:** Before each queued render drain (`flushWork`, `flushSync`, and layout cascades), the runtime snapshots the active element, text selection (inputs and nested `contentEditable`), and ancestor scroll positions per document, then restores them after DOM mutation and before layout effects / mount `autoFocus`.
> 
> **Coverage:** Expanded conformance, hydration, unit, and real-Chromium keyed-reorder tests for focus, selection, and SSR/hydration autofocus behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd37fff67e7b7a142e42eec155fc4c9ded562bf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->