### PR TITLE
feat(website): add SPA navigation benchmark

### DIFF
--- a/benchmarks/baselines/local/spa-navigation.json
+++ b/benchmarks/baselines/local/spa-navigation.json
@@ -1,0 +1,1100 @@
+{
+  "suite": "spa-navigation",
+  "iterations": 20,
+  "targets": [
+    {
+      "name": "octane-tsrx",
+      "ops": {
+        "nav_deep": {
+          "score": 2.350000023841858,
+          "median": 2.3000001907348633,
+          "min": 2.1999998092651367,
+          "mean": 2.3050000190734865,
+          "p95": 2.4000000953674316,
+          "sd": 0.0759154707413413,
+          "rme": 1.541393724700211,
+          "scoreRme": 1.9018832279350182,
+          "warmupRatio": 0.9680851371431844,
+          "samples": 20
+        },
+        "nav_teardown": {
+          "score": 1.1749999523162842,
+          "median": 1.1999998092651367,
+          "min": 1.0999999046325684,
+          "mean": 1.1849999666213988,
+          "p95": 1.3000001907348633,
+          "sd": 0.058714362824102695,
+          "rme": 2.3188905173671603,
+          "scoreRme": 5.031920582187853,
+          "warmupRatio": 1.0106383388859501,
+          "samples": 20
+        },
+        "nav_mount": {
+          "score": 1.5250000357627869,
+          "median": 1.5,
+          "min": 1.3000001907348633,
+          "mean": 1.515000057220459,
+          "p95": 1.700000286102295,
+          "sd": 0.11367082230720085,
+          "rme": 3.511483103333949,
+          "scoreRme": 5.675423244199865,
+          "warmupRatio": 1.0163934656895153,
+          "samples": 20
+        },
+        "nav_nested": {
+          "score": 0.18750005960464478,
+          "median": 0.20000028610229492,
+          "min": 0.09999990463256836,
+          "mean": 0.2450000286102295,
+          "p95": 0.40000009536743164,
+          "sd": 0.09445134167596735,
+          "rme": 18.04247976320705,
+          "scoreRme": 28.579545125738864,
+          "warmupRatio": 0.9333334181043568,
+          "samples": 20
+        },
+        "nav_deep_6x": {
+          "score": 14.812499940395355,
+          "median": 14.900000095367432,
+          "min": 13.699999809265137,
+          "mean": 14.965000009536743,
+          "p95": 17.600000381469727,
+          "sd": 0.8664962991002072,
+          "rme": 2.7098435695359324,
+          "scoreRme": 3.511503492084769,
+          "warmupRatio": 0.984810132959463,
+          "samples": 20
+        }
+      },
+      "meta": {
+        "gates": "pass",
+        "dom": {
+          "deep": {
+            "root": "#main",
+            "total": 7170,
+            "elements": 2052,
+            "text": 1025,
+            "comments": 4093,
+            "emptyText": 0,
+            "whitespaceText": 0,
+            "hydrationMarkersPhysical": 0,
+            "hydrationMarkersLogical": 0,
+            "hydrationMarkersCounted": 0,
+            "hydrationMarkerMaxMultiplicity": 0,
+            "leadingHydrationStartsPhysical": 0,
+            "leadingHydrationStartsLogical": 0,
+            "commentsByData": {
+              "/comp": 2046,
+              "comp": 2046,
+              "": 1
+            },
+            "commentParents": {
+              "div.n": 4092,
+              "div.outlet": 1
+            }
+          },
+          "nested": {
+            "root": "#main",
+            "total": 229,
+            "elements": 70,
+            "text": 33,
+            "comments": 126,
+            "emptyText": 0,
+            "whitespaceText": 0,
+            "hydrationMarkersPhysical": 0,
+            "hydrationMarkersLogical": 0,
+            "hydrationMarkersCounted": 0,
+            "hydrationMarkerMaxMultiplicity": 0,
+            "leadingHydrationStartsPhysical": 0,
+            "leadingHydrationStartsLogical": 0,
+            "commentsByData": {
+              "/comp": 62,
+              "comp": 62,
+              "": 2
+            },
+            "commentParents": {
+              "div.n": 124,
+              "div.outlet": 1,
+              "div.outlet-inner": 1
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "octane-jsx",
+      "ops": {
+        "nav_deep": {
+          "score": 7.662500023841858,
+          "median": 7.5,
+          "min": 7.099999904632568,
+          "mean": 7.560000014305115,
+          "p95": 8.199999809265137,
+          "sd": 0.34853072222399645,
+          "rme": 2.157612752906655,
+          "scoreRme": 2.9706106074353715,
+          "warmupRatio": 0.9575856460596628,
+          "samples": 20
+        },
+        "nav_teardown": {
+          "score": 3.237499952316284,
+          "median": 3.299999713897705,
+          "min": 3.0999999046325684,
+          "mean": 3.2899999618530273,
+          "p95": 3.5,
+          "sd": 0.11192103016932171,
+          "rme": 1.5920988788761077,
+          "scoreRme": 2.3660857808066913,
+          "warmupRatio": 1.0308880387072477,
+          "samples": 20
+        },
+        "nav_mount": {
+          "score": 4.112499952316284,
+          "median": 4.199999809265137,
+          "min": 4,
+          "mean": 4.13999993801117,
+          "p95": 4.300000190734863,
+          "sd": 0.08207824492881119,
+          "rme": 0.9278589415183924,
+          "scoreRme": 1.6967524821532889,
+          "warmupRatio": 1.015197568565271,
+          "samples": 20
+        },
+        "nav_nested": {
+          "score": 0.47499996423721313,
+          "median": 0.5,
+          "min": 0.3000001907348633,
+          "mean": 0.49499998092651365,
+          "p95": 0.8000001907348633,
+          "sd": 0.13945381390477404,
+          "rme": 13.184979064276595,
+          "scoreRme": 22.56277724947946,
+          "warmupRatio": 0.9473684672833844,
+          "samples": 20
+        },
+        "nav_deep_6x": {
+          "score": 46.425000071525574,
+          "median": 46.5,
+          "min": 45.30000019073486,
+          "mean": 46.41000008583069,
+          "p95": 47.200000286102295,
+          "sd": 0.6137888938119116,
+          "rme": 0.6189587219758892,
+          "scoreRme": 1.0966142484282948,
+          "warmupRatio": 1.0013462586862327,
+          "samples": 20
+        }
+      },
+      "meta": {
+        "gates": "pass",
+        "dom": {
+          "deep": {
+            "root": "#main",
+            "total": 11261,
+            "elements": 2052,
+            "text": 1025,
+            "comments": 8184,
+            "emptyText": 0,
+            "whitespaceText": 0,
+            "hydrationMarkersPhysical": 0,
+            "hydrationMarkersLogical": 0,
+            "hydrationMarkersCounted": 0,
+            "hydrationMarkerMaxMultiplicity": 0,
+            "leadingHydrationStartsPhysical": 0,
+            "leadingHydrationStartsLogical": 0,
+            "commentsByData": {
+              "": 4092,
+              "/it": 2046,
+              "it": 2046
+            },
+            "commentParents": {
+              "div.n": 8182,
+              "div.page": 2
+            }
+          },
+          "nested": {
+            "root": "#main",
+            "total": 351,
+            "elements": 70,
+            "text": 33,
+            "comments": 248,
+            "emptyText": 0,
+            "whitespaceText": 0,
+            "hydrationMarkersPhysical": 0,
+            "hydrationMarkersLogical": 0,
+            "hydrationMarkersCounted": 0,
+            "hydrationMarkerMaxMultiplicity": 0,
+            "leadingHydrationStartsPhysical": 0,
+            "leadingHydrationStartsLogical": 0,
+            "commentsByData": {
+              "": 124,
+              "/it": 62,
+              "it": 62
+            },
+            "commentParents": {
+              "div.n": 246,
+              "div.section": 2
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "react",
+      "ops": {
+        "nav_deep": {
+          "score": 1.5250000357627869,
+          "median": 1.5,
+          "min": 1.4000000953674316,
+          "mean": 1.525,
+          "p95": 1.6000003814697266,
+          "sd": 0.05501194217393903,
+          "rme": 1.6882679061116426,
+          "scoreRme": 3.877049353519166,
+          "warmupRatio": 0.9918032476127363,
+          "samples": 20
+        },
+        "nav_teardown": {
+          "score": 0.8125000596046448,
+          "median": 0.8000001907348633,
+          "min": 0.6999998092651367,
+          "mean": 0.7999999761581421,
+          "p95": 0.9000000953674316,
+          "sd": 0.04588315771411993,
+          "rme": 2.684216583641461,
+          "scoreRme": 3.6384429306487824,
+          "warmupRatio": 0.984615106977675,
+          "samples": 20
+        },
+        "nav_mount": {
+          "score": 1.2874999642372131,
+          "median": 1.299999713897705,
+          "min": 1.0999999046325684,
+          "mean": 1.2799999475479127,
+          "p95": 1.4000000953674316,
+          "sd": 0.08335088016451263,
+          "rme": 3.047575467302738,
+          "scoreRme": 4.162064214162104,
+          "warmupRatio": 0.999999953705129,
+          "samples": 20
+        },
+        "nav_nested": {
+          "score": 0.2250000238418579,
+          "median": 0.3000001907348633,
+          "min": 0.09999990463256836,
+          "mean": 0.3000000238418579,
+          "p95": 0.40000009536743164,
+          "sd": 0.1025978352087341,
+          "rme": 16.005569761061906,
+          "scoreRme": 38.46673602763499,
+          "warmupRatio": 1,
+          "samples": 20
+        },
+        "nav_deep_6x": {
+          "score": 9.875,
+          "median": 9.700000286102295,
+          "min": 8.799999713897705,
+          "mean": 9.974999952316285,
+          "p95": 13.199999809265137,
+          "sd": 0.9898830413784994,
+          "rme": 4.64435290163078,
+          "scoreRme": 5.407581479543588,
+          "warmupRatio": 1.0443037853965276,
+          "samples": 20
+        }
+      },
+      "meta": {
+        "gates": "pass",
+        "dom": {
+          "deep": {
+            "root": "#main",
+            "total": 3077,
+            "elements": 2052,
+            "text": 1025,
+            "comments": 0,
+            "emptyText": 0,
+            "whitespaceText": 0,
+            "hydrationMarkersPhysical": 0,
+            "hydrationMarkersLogical": 0,
+            "hydrationMarkersCounted": 0,
+            "hydrationMarkerMaxMultiplicity": 0,
+            "leadingHydrationStartsPhysical": 0,
+            "leadingHydrationStartsLogical": 0,
+            "commentsByData": {},
+            "commentParents": {}
+          },
+          "nested": {
+            "root": "#main",
+            "total": 103,
+            "elements": 70,
+            "text": 33,
+            "comments": 0,
+            "emptyText": 0,
+            "whitespaceText": 0,
+            "hydrationMarkersPhysical": 0,
+            "hydrationMarkersLogical": 0,
+            "hydrationMarkersCounted": 0,
+            "hydrationMarkerMaxMultiplicity": 0,
+            "leadingHydrationStartsPhysical": 0,
+            "leadingHydrationStartsLogical": 0,
+            "commentsByData": {},
+            "commentParents": {}
+          }
+        }
+      }
+    },
+    {
+      "name": "solid",
+      "ops": {
+        "nav_deep": {
+          "score": 1.8125,
+          "median": 1.8000001907348633,
+          "min": 1.700000286102295,
+          "mean": 1.825,
+          "p95": 1.9000000953674316,
+          "sd": 0.055011896553910714,
+          "rme": 1.4107432448009563,
+          "scoreRme": 1.6310362604814586,
+          "warmupRatio": 1.027586213473616,
+          "samples": 20
+        },
+        "nav_teardown": {
+          "score": 0.5375000238418579,
+          "median": 0.5,
+          "min": 0.5,
+          "mean": 0.5349999904632569,
+          "p95": 0.6000003814697266,
+          "sd": 0.04893603515904906,
+          "rme": 4.280842363005176,
+          "scoreRme": 8.05118036353177,
+          "warmupRatio": 0.9999998891076426,
+          "samples": 20
+        },
+        "nav_mount": {
+          "score": 1.8125,
+          "median": 1.8000001907348633,
+          "min": 1.6999998092651367,
+          "mean": 1.8199999570846557,
+          "p95": 2,
+          "sd": 0.07677720790043112,
+          "rme": 1.974309190415909,
+          "scoreRme": 3.8498709458376252,
+          "warmupRatio": 1.0206896683265423,
+          "samples": 20
+        },
+        "nav_nested": {
+          "score": 0.23750007152557373,
+          "median": 0.2999997138977051,
+          "min": 0.09999990463256836,
+          "mean": 0.25000007152557374,
+          "p95": 0.40000009536743164,
+          "sd": 0.07608856793714878,
+          "rme": 14.244050604201721,
+          "scoreRme": 18.221064553276857,
+          "warmupRatio": 0.9473684870965394,
+          "samples": 20
+        },
+        "nav_deep_6x": {
+          "score": 12.849999964237213,
+          "median": 12.699999809265137,
+          "min": 11.900000095367432,
+          "mean": 12.684999942779541,
+          "p95": 13.700000286102295,
+          "sd": 0.4648429634799915,
+          "rme": 1.7150232900944529,
+          "scoreRme": 3.9809314473481408,
+          "warmupRatio": 0.9892996117928602,
+          "samples": 20
+        }
+      },
+      "meta": {
+        "gates": "pass",
+        "dom": {
+          "deep": {
+            "root": "#main",
+            "total": 5123,
+            "elements": 2052,
+            "text": 1025,
+            "comments": 2046,
+            "emptyText": 0,
+            "whitespaceText": 0,
+            "hydrationMarkersPhysical": 0,
+            "hydrationMarkersLogical": 0,
+            "hydrationMarkersCounted": 0,
+            "hydrationMarkerMaxMultiplicity": 0,
+            "leadingHydrationStartsPhysical": 0,
+            "leadingHydrationStartsLogical": 0,
+            "commentsByData": {
+              "": 2046
+            },
+            "commentParents": {
+              "div.n": 2046
+            }
+          },
+          "nested": {
+            "root": "#main",
+            "total": 165,
+            "elements": 70,
+            "text": 33,
+            "comments": 62,
+            "emptyText": 0,
+            "whitespaceText": 0,
+            "hydrationMarkersPhysical": 0,
+            "hydrationMarkersLogical": 0,
+            "hydrationMarkersCounted": 0,
+            "hydrationMarkerMaxMultiplicity": 0,
+            "leadingHydrationStartsPhysical": 0,
+            "leadingHydrationStartsLogical": 0,
+            "commentsByData": {
+              "": 62
+            },
+            "commentParents": {
+              "div.n": 62
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "vue-vapor",
+      "ops": {
+        "nav_deep": {
+          "score": 2.6125000715255737,
+          "median": 2.6999998092651367,
+          "min": 2.5,
+          "mean": 2.6450000286102293,
+          "p95": 2.8000001907348633,
+          "sd": 0.07591548727069007,
+          "rme": 1.3432564461214773,
+          "scoreRme": 2.051164546906465,
+          "warmupRatio": 1.0239234443210954,
+          "samples": 20
+        },
+        "nav_teardown": {
+          "score": 0.75,
+          "median": 0.7000002861022949,
+          "min": 0.5999999046325684,
+          "mean": 0.7400000333786011,
+          "p95": 0.8000001907348633,
+          "sd": 0.05982431423022856,
+          "rme": 3.7835564692235555,
+          "scoreRme": 5.959234174672567,
+          "warmupRatio": 0.9500000476837158,
+          "samples": 20
+        },
+        "nav_mount": {
+          "score": 2.5625000596046448,
+          "median": 2.5,
+          "min": 2.3000001907348633,
+          "mean": 2.5200000286102293,
+          "p95": 2.700000286102295,
+          "sd": 0.11050120395886698,
+          "rme": 2.0522047792183025,
+          "scoreRme": 2.4277816351020243,
+          "warmupRatio": 0.9756097334045379,
+          "samples": 20
+        },
+        "nav_nested": {
+          "score": 0.3125000596046448,
+          "median": 0.3000001907348633,
+          "min": 0.19999980926513672,
+          "mean": 0.33500003814697266,
+          "p95": 0.5,
+          "sd": 0.09333015850016448,
+          "rme": 13.03861246568523,
+          "scoreRme": 22.329222655896647,
+          "warmupRatio": 1.0399997634888147,
+          "samples": 20
+        },
+        "nav_deep_6x": {
+          "score": 17.737499952316284,
+          "median": 17.200000286102295,
+          "min": 16.600000381469727,
+          "mean": 17.375000071525573,
+          "p95": 18.799999713897705,
+          "sd": 0.671898227136122,
+          "rme": 1.8098096960840793,
+          "scoreRme": 4.062506781421228,
+          "warmupRatio": 0.9689922573877063,
+          "samples": 20
+        }
+      },
+      "meta": {
+        "gates": "pass",
+        "dom": {
+          "deep": {
+            "root": "#main",
+            "total": 5125,
+            "elements": 2052,
+            "text": 3073,
+            "comments": 0,
+            "emptyText": 2048,
+            "whitespaceText": 0,
+            "hydrationMarkersPhysical": 0,
+            "hydrationMarkersLogical": 0,
+            "hydrationMarkersCounted": 0,
+            "hydrationMarkerMaxMultiplicity": 0,
+            "leadingHydrationStartsPhysical": 0,
+            "leadingHydrationStartsLogical": 0,
+            "commentsByData": {},
+            "commentParents": {}
+          },
+          "nested": {
+            "root": "#main",
+            "total": 169,
+            "elements": 70,
+            "text": 99,
+            "comments": 0,
+            "emptyText": 66,
+            "whitespaceText": 0,
+            "hydrationMarkersPhysical": 0,
+            "hydrationMarkersLogical": 0,
+            "hydrationMarkersCounted": 0,
+            "hydrationMarkerMaxMultiplicity": 0,
+            "leadingHydrationStartsPhysical": 0,
+            "leadingHydrationStartsLogical": 0,
+            "commentsByData": {},
+            "commentParents": {}
+          }
+        }
+      }
+    },
+    {
+      "name": "octane-tsrx-work",
+      "ops": {
+        "nav_deep_renderBlock": {
+          "median": 5119,
+          "min": 5119,
+          "samples": 1
+        },
+        "nav_deep_componentSlot": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_deep_componentSlotVoid": {
+          "median": 3070,
+          "min": 3070,
+          "samples": 1
+        },
+        "nav_deep_componentSlotLite": {
+          "median": 2,
+          "min": 2,
+          "samples": 1
+        },
+        "nav_deep_childSlot": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_deep_createElement": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_deep_hostElementBody": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_deep_deoptItemBody": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_deep_reconcileKeyed": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_deep_updateSurvivor": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_deep_setText": {
+          "median": 1,
+          "min": 1,
+          "samples": 1
+        },
+        "nav_deep_unmountBlock": {
+          "median": 5118,
+          "min": 5118,
+          "samples": 1
+        },
+        "nav_deep_unmountScope": {
+          "median": 5120,
+          "min": 5120,
+          "samples": 1
+        },
+        "nav_teardown_renderBlock": {
+          "median": 160,
+          "min": 160,
+          "samples": 1
+        },
+        "nav_teardown_componentSlot": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_teardown_componentSlotVoid": {
+          "median": 94,
+          "min": 94,
+          "samples": 1
+        },
+        "nav_teardown_componentSlotLite": {
+          "median": 3,
+          "min": 3,
+          "samples": 1
+        },
+        "nav_teardown_childSlot": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_teardown_createElement": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_teardown_hostElementBody": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_teardown_deoptItemBody": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_teardown_reconcileKeyed": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_teardown_updateSurvivor": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_teardown_setText": {
+          "median": 1,
+          "min": 1,
+          "samples": 1
+        },
+        "nav_teardown_unmountBlock": {
+          "median": 5118,
+          "min": 5118,
+          "samples": 1
+        },
+        "nav_teardown_unmountScope": {
+          "median": 5120,
+          "min": 5120,
+          "samples": 1
+        },
+        "nav_mount_renderBlock": {
+          "median": 5119,
+          "min": 5119,
+          "samples": 1
+        },
+        "nav_mount_componentSlot": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_mount_componentSlotVoid": {
+          "median": 3070,
+          "min": 3070,
+          "samples": 1
+        },
+        "nav_mount_componentSlotLite": {
+          "median": 2,
+          "min": 2,
+          "samples": 1
+        },
+        "nav_mount_childSlot": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_mount_createElement": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_mount_hostElementBody": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_mount_deoptItemBody": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_mount_reconcileKeyed": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_mount_updateSurvivor": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_mount_setText": {
+          "median": 1,
+          "min": 1,
+          "samples": 1
+        },
+        "nav_mount_unmountBlock": {
+          "median": 159,
+          "min": 159,
+          "samples": 1
+        },
+        "nav_mount_unmountScope": {
+          "median": 162,
+          "min": 162,
+          "samples": 1
+        },
+        "nav_nested_renderBlock": {
+          "median": 160,
+          "min": 160,
+          "samples": 1
+        },
+        "nav_nested_componentSlot": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_nested_componentSlotVoid": {
+          "median": 94,
+          "min": 94,
+          "samples": 1
+        },
+        "nav_nested_componentSlotLite": {
+          "median": 3,
+          "min": 3,
+          "samples": 1
+        },
+        "nav_nested_childSlot": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_nested_createElement": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_nested_hostElementBody": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_nested_deoptItemBody": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_nested_reconcileKeyed": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_nested_updateSurvivor": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_nested_setText": {
+          "median": 1,
+          "min": 1,
+          "samples": 1
+        },
+        "nav_nested_unmountBlock": {
+          "median": 158,
+          "min": 158,
+          "samples": 1
+        },
+        "nav_nested_unmountScope": {
+          "median": 160,
+          "min": 160,
+          "samples": 1
+        }
+      },
+      "meta": {
+        "gates": "pass"
+      }
+    },
+    {
+      "name": "octane-jsx-work",
+      "ops": {
+        "nav_deep_renderBlock": {
+          "median": 7169,
+          "min": 7169,
+          "samples": 1
+        },
+        "nav_deep_componentSlot": {
+          "median": 2051,
+          "min": 2051,
+          "samples": 1
+        },
+        "nav_deep_componentSlotVoid": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_deep_componentSlotLite": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_deep_childSlot": {
+          "median": 4094,
+          "min": 4094,
+          "samples": 1
+        },
+        "nav_deep_createElement": {
+          "median": 4099,
+          "min": 4099,
+          "samples": 1
+        },
+        "nav_deep_hostElementBody": {
+          "median": 1023,
+          "min": 1023,
+          "samples": 1
+        },
+        "nav_deep_deoptItemBody": {
+          "median": 2046,
+          "min": 2046,
+          "samples": 1
+        },
+        "nav_deep_reconcileKeyed": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_deep_updateSurvivor": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_deep_setText": {
+          "median": 1,
+          "min": 1,
+          "samples": 1
+        },
+        "nav_deep_unmountBlock": {
+          "median": 7166,
+          "min": 7166,
+          "samples": 1
+        },
+        "nav_deep_unmountScope": {
+          "median": 7166,
+          "min": 7166,
+          "samples": 1
+        },
+        "nav_teardown_renderBlock": {
+          "median": 227,
+          "min": 227,
+          "samples": 1
+        },
+        "nav_teardown_componentSlot": {
+          "median": 68,
+          "min": 68,
+          "samples": 1
+        },
+        "nav_teardown_componentSlotVoid": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_teardown_componentSlotLite": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_teardown_childSlot": {
+          "median": 127,
+          "min": 127,
+          "samples": 1
+        },
+        "nav_teardown_createElement": {
+          "median": 133,
+          "min": 133,
+          "samples": 1
+        },
+        "nav_teardown_hostElementBody": {
+          "median": 31,
+          "min": 31,
+          "samples": 1
+        },
+        "nav_teardown_deoptItemBody": {
+          "median": 62,
+          "min": 62,
+          "samples": 1
+        },
+        "nav_teardown_reconcileKeyed": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_teardown_updateSurvivor": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_teardown_setText": {
+          "median": 1,
+          "min": 1,
+          "samples": 1
+        },
+        "nav_teardown_unmountBlock": {
+          "median": 7166,
+          "min": 7166,
+          "samples": 1
+        },
+        "nav_teardown_unmountScope": {
+          "median": 7166,
+          "min": 7166,
+          "samples": 1
+        },
+        "nav_mount_renderBlock": {
+          "median": 7169,
+          "min": 7169,
+          "samples": 1
+        },
+        "nav_mount_componentSlot": {
+          "median": 2051,
+          "min": 2051,
+          "samples": 1
+        },
+        "nav_mount_componentSlotVoid": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_mount_componentSlotLite": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_mount_childSlot": {
+          "median": 4094,
+          "min": 4094,
+          "samples": 1
+        },
+        "nav_mount_createElement": {
+          "median": 4099,
+          "min": 4099,
+          "samples": 1
+        },
+        "nav_mount_hostElementBody": {
+          "median": 1023,
+          "min": 1023,
+          "samples": 1
+        },
+        "nav_mount_deoptItemBody": {
+          "median": 2046,
+          "min": 2046,
+          "samples": 1
+        },
+        "nav_mount_reconcileKeyed": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_mount_updateSurvivor": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_mount_setText": {
+          "median": 1,
+          "min": 1,
+          "samples": 1
+        },
+        "nav_mount_unmountBlock": {
+          "median": 224,
+          "min": 224,
+          "samples": 1
+        },
+        "nav_mount_unmountScope": {
+          "median": 224,
+          "min": 224,
+          "samples": 1
+        },
+        "nav_nested_renderBlock": {
+          "median": 227,
+          "min": 227,
+          "samples": 1
+        },
+        "nav_nested_componentSlot": {
+          "median": 68,
+          "min": 68,
+          "samples": 1
+        },
+        "nav_nested_componentSlotVoid": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_nested_componentSlotLite": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_nested_childSlot": {
+          "median": 127,
+          "min": 127,
+          "samples": 1
+        },
+        "nav_nested_createElement": {
+          "median": 133,
+          "min": 133,
+          "samples": 1
+        },
+        "nav_nested_hostElementBody": {
+          "median": 31,
+          "min": 31,
+          "samples": 1
+        },
+        "nav_nested_deoptItemBody": {
+          "median": 62,
+          "min": 62,
+          "samples": 1
+        },
+        "nav_nested_reconcileKeyed": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_nested_updateSurvivor": {
+          "median": 0,
+          "min": 0,
+          "samples": 1
+        },
+        "nav_nested_setText": {
+          "median": 1,
+          "min": 1,
+          "samples": 1
+        },
+        "nav_nested_unmountBlock": {
+          "median": 222,
+          "min": 222,
+          "samples": 1
+        },
+        "nav_nested_unmountScope": {
+          "median": 222,
+          "min": 222,
+          "samples": 1
+        }
+      },
+      "meta": {
+        "gates": "pass"
+      }
+    }
+  ],
+  "harnessExit": 0
+}

--- a/website/src/content/benchmarks.ts
+++ b/website/src/content/benchmarks.ts
@@ -26,6 +26,7 @@ import news from '../../../benchmarks/baselines/local/news.json';
 import portalSwarm from '../../../benchmarks/baselines/local/portal-swarm.json';
 import recursiveContext from '../../../benchmarks/baselines/local/recursive-context.json';
 import signalFavoring from '../../../benchmarks/baselines/local/signal-favoring.json';
+import spaNavigation from '../../../benchmarks/baselines/local/spa-navigation.json';
 import ssrThroughput from '../../../benchmarks/baselines/local/ssr-throughput.json';
 import streamingSsr from '../../../benchmarks/baselines/local/streaming-ssr.json';
 import svgDashboard from '../../../benchmarks/baselines/local/svg-dashboard.json';
@@ -329,6 +330,19 @@ export const FRAMEWORK_CARDS: BenchCard[] = [
 		'recursive-context',
 		'recursive-context',
 		'A deep recursive tree driven by context updates — mount, root and partial updates, unmount.',
+	),
+	frameworkCard(
+		spaNavigation,
+		'spa-navigation',
+		'spa-navigation',
+		'Full-page client navigation — routed-subtree teardown and mount while the app shell survives, including nested-layout reuse and a 6× CPU-throttled route swap.',
+		{
+			nav_deep: 'deep route swap',
+			nav_teardown: 'deep → nested',
+			nav_mount: 'nested → deep',
+			nav_nested: 'nested route swap',
+			nav_deep_6x: 'deep route swap (6× CPU)',
+		},
 	),
 	frameworkCard(
 		signalFavoring,

--- a/website/src/content/home-benchmark.ts
+++ b/website/src/content/home-benchmark.ts
@@ -126,6 +126,13 @@ export const HOME_SUMMARY: BenchCard = {
 			'vue-vapor': 1.089363136548616,
 		},
 		{
+			op: 'spa-navigation',
+			'octane-tsrx': 1,
+			react: 0.7876095285861537,
+			solid: 0.8564444703063577,
+			'vue-vapor': 1.1893337025984867,
+		},
+		{
 			op: 'signal-favoring',
 			'octane-tsrx': 1,
 			react: 2.959092712040432,

--- a/website/tests/benchmark-explorer.test.ts
+++ b/website/tests/benchmark-explorer.test.ts
@@ -55,12 +55,13 @@ describe('benchmark explorer — bar chart', () => {
 describe('benchmark explorer — heatmap', () => {
 	it('excludes null cells from the grid, rendering them as "—"', async () => {
 		const { container } = await mountExplorer();
-		// HOME_SUMMARY has ten gaps: async-waterfall/Vue, streaming-ssr/Svelte,
-		// streaming-ssr/Vue, svg-dashboard/Preact/Ripple/Vue, and the two
-		// weather-app rows' Ripple/Vue-Vapor columns (those fixtures run plain
-		// Vue). They render as neutral "—" cells, not colored ones.
+		// HOME_SUMMARY has thirteen gaps: async-waterfall/Vue,
+		// streaming-ssr/Svelte/Vue, svg-dashboard/Preact/Ripple/Vue,
+		// spa-navigation/Preact/Svelte/Ripple, and the two weather-app rows'
+		// Ripple/Vue-Vapor columns (those fixtures run plain Vue). They render as
+		// neutral "—" cells, not colored ones.
 		const nullCells = container.querySelectorAll('.bx-cell-null');
-		expect(nullCells.length).toBe(10);
+		expect(nullCells.length).toBe(13);
 		nullCells.forEach((cell) => expect(cell.textContent!.trim()).toBe('—'));
 	});
 
@@ -72,7 +73,7 @@ describe('benchmark explorer — heatmap', () => {
 		fireEvent.click(seg('vs fastest'));
 
 		// Mode B: every suite row now has exactly one outlined 1× winner.
-		await waitFor(() => expect(container.querySelectorAll('.bx-cell-fastest').length).toBe(18));
+		await waitFor(() => expect(container.querySelectorAll('.bx-cell-fastest').length).toBe(19));
 		container
 			.querySelectorAll('.bx-cell-fastest')
 			.forEach((cell) => expect(cell.textContent!.trim()).toBe('1×'));

--- a/website/tests/smoke.test.ts
+++ b/website/tests/smoke.test.ts
@@ -167,20 +167,22 @@ describe('website routes', () => {
 			const keys = card.series.map((series) => series.key);
 			if (card.id === 'svg-dashboard') {
 				expect(keys).toEqual(['octane-tsrx', 'react', 'solid', 'svelte']);
+			} else if (card.id === 'spa-navigation') {
+				expect(keys).toEqual(['octane-tsrx', 'octane-jsx', 'react', 'solid', 'vue-vapor']);
 			} else {
 				expect(keys, card.id).toContain('preact');
 			}
-			if (card.id === 'streaming-ssr') {
+			if (card.id === 'streaming-ssr' || card.id === 'spa-navigation') {
 				expect(keys, card.id).not.toContain('svelte');
 			} else {
 				expect(keys, card.id).toContain('svelte');
 			}
 
 			for (const row of card.rows) {
-				if (card.id !== 'svg-dashboard') {
+				if (card.id !== 'svg-dashboard' && card.id !== 'spa-navigation') {
 					expect(typeof row.preact, `${card.id}/${row.op}/preact`).toBe('number');
 				}
-				if (card.id !== 'streaming-ssr') {
+				if (card.id !== 'streaming-ssr' && card.id !== 'spa-navigation') {
 					expect(typeof row.svelte, `${card.id}/${row.op}/svelte`).toBe('number');
 				}
 			}


### PR DESCRIPTION
## Summary

- Publish the checked-in 20-iteration SPA navigation baseline on the website benchmark page.
- Add the suite to the at-a-glance comparison and preserve sparse-roster behavior for its five framework fixtures.

## Why

PR #614 added the SPA navigation benchmark, but the website reads only committed files from `benchmarks/baselines/local`. Without this follow-up, the suite is available to the runner and MCP tool but absent from the public benchmark catalog.

## Changes

- Record the full SPA navigation timing and deterministic-work baseline with every semantic gate passing.
- Add a website benchmark card with readable labels for deep, teardown, mount, nested, and 6× CPU operations.
- Update the compact homepage comparison snapshot and website tests for the new row and fixture roster.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 1,606 test files / 17,237 tests
- [x] targeted tests: website benchmark explorer and route smoke suites — 30 tests
- [x] `pnpm --dir website build`
- [x] `node benchmarks/bench.mjs --record spa-navigation` — all semantic and deterministic work gates passed
- [x] `pnpm sync`

## Risk / follow-ups

- Low risk: website data, presentation metadata, and tests only; no framework runtime behavior changes.
- The added baseline is 29.6 KB raw and about 3.6 KB compressed, smaller than adjacent recursive benchmark baselines.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!--
Tick the box above whenever an agent wrote the change, no matter which account
pushes it. Leaving it clear or omitting this section asserts a human wrote the
diff; either form keeps the label workflow successful.

A bot reads this box and applies the label, so nothing here needs repository
permissions and it works the same from a fork. The type label comes from the
conventional-commit type in the title. Do not apply either by hand.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Website-only baseline data, catalog metadata, and test expectations; no runtime or benchmark harness logic changes in this diff.
> 
> **Overview**
> Publishes the **spa-navigation** suite on the public benchmarks site by checking in a 20-iteration local baseline and wiring it through the same build-time baseline import path as other suites.
> 
> Adds a **framework comparison card** with human-readable labels for deep route swap, teardown/mount between deep and nested routes, nested swap, and a 6× CPU-throttled deep swap. The card uses a **sparse five-framework roster** (Octane `.tsrx`/`.tsx`, React, Solid, Vue Vapor) rather than the full cross-framework grid.
> 
> Extends the **homepage at-a-glance summary** with a `spa-navigation` row (normalized × vs Octane) and updates **explorer/smoke tests** for three additional heatmap “—” cells, 19 suite rows in “vs fastest” mode, and assertions that `spa-navigation` omits Preact/Svelte like `streaming-ssr` does.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a65d8222087339c2fd5b79fe693319356661bc70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->