### PR TITLE
fix: restore React parity for resource load and error handlers

### DIFF
--- a/.changeset/hoisted-resource-event-handler-lifecycle.md
+++ b/.changeset/hoisted-resource-event-handler-lifecycle.md
@@ -1,0 +1,7 @@
+---
+'octane': patch
+---
+
+Preserve React-compatible inline placement and event propagation for resource
+links with explicit load or error handlers. Keep dynamically hoisted metadata
+listeners synchronized across capture and bubble updates, hydration, and unmount.

--- a/packages/octane/audit/react-conformance-ledger.json
+++ b/packages/octane/audit/react-conformance-ledger.json
@@ -13630,11 +13630,11 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “fires onLoad/onError on a (head-hoisted) <link> element” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in “keeps a <link> with onLoad/onError inline and fires both handlers” covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-events.test.ts",
-          "testName": "fires onLoad/onError on a (head-hoisted) <link> element",
+          "testName": "keeps a <link> with onLoad/onError inline and fires both handlers",
           "modes": ["client", "production-compile"]
         }
       ]
@@ -25252,11 +25252,11 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “fires onLoad/onError on a (head-hoisted) <link> element” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in “keeps a <link> with onLoad/onError inline and fires both handlers” covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-events.test.ts",
-          "testName": "fires onLoad/onError on a (head-hoisted) <link> element",
+          "testName": "keeps a <link> with onLoad/onError inline and fires both handlers",
           "modes": ["client", "production-compile"]
         }
       ]

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -14710,11 +14710,16 @@ function requiresTemplateNormalization(node, parentNs = 'html', allowHeadHoists 
 	const tag = jsxTagName(node) || elementTagName(node);
 	const selfNs = typeof tag === 'string' ? nsForSelf(tag, parentNs) : parentNs;
 	if (tag === 'head') return true;
-	// meta/link are document resources in every namespace. Only title is
+	// Meta and eligible links are document resources in every namespace. Only title is
 	// ambiguous across an opaque component boundary (HTML document title vs SVG
 	// accessibility title), so suppressing the recursive title classification
 	// must not accidentally suppress the other singleton kinds.
-	if (selfNs !== 'svg' && HOISTABLE_HEAD_TAGS.has(tag) && (tag !== 'title' || allowHeadHoists))
+	if (
+		selfNs !== 'svg' &&
+		HOISTABLE_HEAD_TAGS.has(tag) &&
+		(tag !== 'title' || allowHeadHoists) &&
+		(tag !== 'link' || isHoistableHeadElementNode(node))
+	)
 		return true;
 
 	const childNs =
@@ -16339,14 +16344,15 @@ function allocHookSymbol(ctx, debugName, profile = null, forceSymbol = false, pr
 // Hoisted document metadata (<title>/<meta>/<link>) — React-19 model
 // ===========================================================================
 //
-// `<title>`, `<meta>`, `<link>` rendered ANYWHERE in a component are NOT body
-// DOM: like `<style>` (→ CSS), they are lifted to the document head — emitted as
+// `<title>`, `<meta>`, and eligible `<link>` elements rendered in a component are
+// NOT body DOM: like `<style>` (→ CSS), they are lifted to the document head as
 // a `headBlock(__s, …)` call on the client (creates/adopts/updates/removes the
 // element in document.head, reactively, tied to the owning scope's lifecycle)
 // and an `ssrHeadEl(…)` call on the server (serializes into render().head,
 // prefixed with a `<!--key-->` marker the client headBlock adopts on hydration).
 // Lifting them out of the body-root set also collapses the remaining single body
 // element to the single-root path (no `<octane-frag>`).
+// Links with explicit `onLoad`/`onError` remain in their authored DOM position.
 
 const HOISTABLE_HEAD_TAGS = new Set(['title', 'meta', 'link']);
 
@@ -16364,7 +16370,21 @@ function isHeadElementNode(n) {
 
 /** @param {any} n @returns {boolean} */
 function isHoistableHeadElementNode(n) {
-	return Boolean(n && n.type === 'JSXElement' && HOISTABLE_HEAD_TAGS.has(jsxTagName(n)));
+	if (n == null || (n.type !== 'JSXElement' && n.type !== 'Element')) return false;
+	const tag = jsxTagName(n) || elementTagName(n);
+	if (!HOISTABLE_HEAD_TAGS.has(tag)) return false;
+	if (tag !== 'link') return true;
+
+	// React keeps links with explicit load/error handlers in their authored DOM
+	// position, preserving resource-event propagation through logical ancestors.
+	// Spread keys remain unknowable here and keep the existing head-hoist path.
+	const attrs = n.attributes || n.openingElement?.attributes || [];
+	for (const attr of attrs) {
+		if (attr.type !== 'Attribute' && attr.type !== 'JSXAttribute') continue;
+		const name = jsxAttrRawName(attr);
+		if (name === 'onLoad' || name === 'onError') return false;
+	}
+	return true;
 }
 
 // Deterministic per-element key bridging the client `headBlock` (its scope-state
@@ -16608,8 +16628,8 @@ function headElementArgNodes(node, index, ctx) {
 		// refs/key have no head semantics; `class` is the CSS-scoping stamp
 		// (meaningless on title/meta/link) — drop them. EVENTS pass through: a
 		// hoisted element lives in document.head, outside every delegation root,
-		// so the client headBlock attaches on* props as DIRECT listeners
-		// (`<link onLoad={…}>` — React parity); the server ssrHeadEl skips them.
+		// so the client headBlock attaches spread-provided on* props as DIRECT
+		// listeners; the server ssrHeadEl skips them.
 		if (attrName === 'key' || attrName === 'ref' || attrName === 'class') continue;
 		const val = a.value;
 		if (val == null) {
@@ -16687,7 +16707,7 @@ function emitHeadServer(headNodes, ctx) {
  *     (ForOfStatement) so it takes the keyed forBlock/ssrBlock fast path
  *   - JSXElement → `Element` (with `<Fragment ref>` expanded to a
  *     FragmentStart/…/FragmentEnd sequence, `<Activity>` lowered to an
- *     ActivityStatement, `<title>/<meta>/<link>` hoisted as `HeadHoist`,
+ *     ActivityStatement, eligible `<title>/<meta>/<link>` hoisted as `HeadHoist`,
  *     and `<head>` rejected)
  *   - Fragments (`<>…</>`, Tsx/Tsrx) → flattened (children inlined)
  *   - JSXStyleElement → dropped (its CSS is handled by the scoping pipeline)
@@ -16809,11 +16829,10 @@ function normalizeChildren(nodes, inSvg = false, ctx = null) {
 						'document.head automatically, React-19-style.',
 				);
 			}
-			// `<title>`/`<meta>`/`<link>` → hoist to the document-head channel (NOT
+			// `<title>`/`<meta>`/eligible `<link>` → hoist to the document-head channel (NOT
 			// body DOM). Kept in `out` as a synthetic node so planJsx / ssrCompileBody
 			// can partition it out and emit it via headBlock (client) / ssrHeadEl
-			// (server). Lifted from wherever they appear in the output — EXCEPT an
-			// SVG `<title>`, which is the SVG tooltip element and stays in place.
+			// (server). SVG `<title>` and explicit resource-handler links stay inline.
 			if (isHoistableHeadElementNode(n) && !(inSvg && jsxTagName(n) === 'title')) {
 				out.push({ type: 'HeadHoist', element: n });
 				continue;
@@ -17346,7 +17365,7 @@ function planJsx(
 	const _prevElemLocs = ctx._elemLocs;
 	ctx._elemLocs = ctx.dev ? new Map() : null;
 	const allNodes = normalizeChildren(jsxNodesRaw, parentNs === 'svg', ctx);
-	// Partition hoisted `<title>`/`<meta>`/`<link>` out of the BODY-root set:
+	// Partition hoisted `<title>`/`<meta>`/eligible `<link>` out of the BODY-root set:
 	// `jsxNodes` (the body) drives single/multi-root + the template, while head
 	// elements are mounted out-of-band into document.head. Excluding them (like
 	// `<style>`) is what collapses a `<title> + <style> + <div>` page to single-root.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -12051,9 +12051,10 @@ export function setSpread(
 const _injectedStyles = new Set<string>();
 
 // ---------------------------------------------------------------------------
-// Hoisted document metadata (React-19-shape) — `<title>`, `<meta>`, `<link>`
-// rendered ANYWHERE in a component are lifted to <document.head> by the compiler
-// emitting one `headBlock(scope, slot, key, tag, attrs, text)` call per element
+// Hoisted document metadata (React-19-shape) — `<title>`, `<meta>`, and `<link>`
+// are lifted to <document.head>, except links with explicit `onLoad`/`onError`
+// handlers, which stay inline. The compiler emits one
+// `headBlock(scope, slot, key, tag, attrs, text)` call per hoisted element
 // (instead of placing it in the body template). Because octane re-invokes a
 // component body on every render, this call recurs each render: the element is
 // created/adopted ONCE (held in `scope.slots[slot]`; `key` is the content hash for
@@ -12067,8 +12068,19 @@ const _injectedStyles = new Set<string>();
 
 interface HeadSlot {
 	el: Element;
-	/** Direct listeners for on* props — head elements sit outside delegation roots. */
+	/** Direct listeners keyed by prop name so capture and bubble phases stay independent. */
 	handlers?: Map<string, EventListener>;
+}
+
+function removeHeadEventListeners(state: HeadSlot, attrs: Record<string, any> | null): void {
+	const handlers = state.handlers;
+	if (handlers === undefined) return;
+	for (const [name, listener] of handlers) {
+		if (attrs !== null && name in attrs) continue;
+		const event = eventSlot(name)!;
+		state.el.removeEventListener(event.type, listener, event.capture);
+		handlers.delete(name);
+	}
 }
 
 // Find the server-rendered `tag` inside `key`'s paired marker interval in <head>,
@@ -12142,11 +12154,13 @@ export function headBlock(
 		// Removed once, on the owning scope's unmount (NOT between re-renders) —
 		// scope.cleanups fire only on teardown, mirroring the spread-ref cleanup.
 		(scope.cleanups ??= []).push(() => {
+			removeHeadEventListeners(state!, null);
 			state!.el.remove();
 			scope.slots[slot] = undefined;
 		});
 	}
 	const el = state.el;
+	if (state.handlers !== undefined) removeHeadEventListeners(state, attrs);
 	if (attrs !== null) {
 		for (const k in attrs) {
 			// Hoisted head elements live in document.head — OUTSIDE every delegation
@@ -12156,14 +12170,18 @@ export function headBlock(
 			if (ev !== null) {
 				const v = attrs[k];
 				const listener = process.env.NODE_ENV !== 'production' ? devEventListener(k, v) : v;
-				const hs = (state.handlers ??= new Map<string, EventListener>());
-				const prevH = hs.get(ev.type);
-				if (prevH) el.removeEventListener(ev.type, prevH, ev.capture);
+				const hs = state.handlers;
+				const prevH = hs?.get(k);
+				if (prevH === listener) continue;
+				if (prevH !== undefined) el.removeEventListener(ev.type, prevH, ev.capture);
 				if (typeof listener === 'function') {
 					el.addEventListener(ev.type, listener as EventListener, ev.capture);
-					hs.set(ev.type, listener as EventListener);
+					(hs ?? (state.handlers = new Map<string, EventListener>())).set(
+						k,
+						listener as EventListener,
+					);
 				} else {
-					hs.delete(ev.type);
+					hs?.delete(k);
 				}
 				continue;
 			}
@@ -12203,6 +12221,7 @@ export function namespaceHead(props: NamespaceHeadProps, scope: Scope): ElementD
 		// before returning the inline descriptor for this pass.
 		const state = scope.slots[slot] as HeadSlot | undefined;
 		if (state !== undefined) {
+			removeHeadEventListeners(state, null);
 			state.el.remove();
 			scope.slots[slot] = undefined;
 		}

--- a/packages/octane/tests/conformance/_fixtures/dom-component-events.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/dom-component-events.tsrx
@@ -16,10 +16,70 @@ export function SvgImageEvents(props) @{
 	</svg>
 }
 
-// NOTE: <link> is hoisted document metadata in octane (lifted into <head> by the
-// compiler), so the test queries document.head for it.
+// React keeps links with resource lifecycle handlers in their authored DOM
+// position so capture and bubble events still reach their logical ancestors.
 export function LinkEvents(props) @{
-	<link href="http://example.org/link" onLoad={props.onLoad} onError={props.onError} />
+	<link
+		rel="preload"
+		as="style"
+		href="http://example.org/link"
+		onLoad={props.onLoad}
+		onError={props.onError}
+	/>
+}
+
+export function LoadOnlyLink(props: { handler: (event: Event) => void }) @{
+	<link rel="preload" as="style" href="http://example.org/load-only" onLoad={props.handler} />
+}
+
+export function ErrorOnlyLink(props: { handler: (event: Event) => void }) @{
+	<link rel="preload" as="style" href="http://example.org/error-only" onError={props.handler} />
+}
+
+export function CaptureOnlyLink(props: { handler: (event: Event) => void }) @{
+	<link
+		rel="canonical"
+		href="http://example.org/capture-only"
+		onLoadCapture={props.handler}
+		onErrorCapture={props.handler}
+	/>
+}
+
+type ResourceEventHandlers = {
+	onLoad?: (event: Event) => void;
+	onLoadCapture?: (event: Event) => void;
+	onError?: (event: Event) => void;
+	onErrorCapture?: (event: Event) => void;
+};
+
+export function LinkSpreadEvents(props: { handlers: ResourceEventHandlers }) @{
+	<link href="http://example.org/spread-link" {...props.handlers} />
+}
+
+export function NestedLinkEvents(props: {
+	ancestor: ResourceEventHandlers;
+	target: ResourceEventHandlers;
+}) @{
+	<>
+		<link rel="canonical" href="http://example.org/canonical-link" />
+		<div
+			class="link-parent"
+			onLoad={props.ancestor.onLoad}
+			onLoadCapture={props.ancestor.onLoadCapture}
+			onError={props.ancestor.onError}
+			onErrorCapture={props.ancestor.onErrorCapture}
+		>
+			<link
+				rel="preload"
+				as="style"
+				href="http://example.org/nested-link"
+				onLoad={props.target.onLoad}
+				onLoadCapture={props.target.onLoadCapture}
+				onError={props.target.onError}
+				onErrorCapture={props.target.onErrorCapture}
+			/>
+		</div>
+	</>
 }
 
 // Nested-roots ordering — outer app hosts the inner root's container.

--- a/packages/octane/tests/conformance/dom-component-events.test.ts
+++ b/packages/octane/tests/conformance/dom-component-events.test.ts
@@ -5,6 +5,11 @@ import {
 	SourceError,
 	SvgImageEvents,
 	LinkEvents,
+	LoadOnlyLink,
+	ErrorOnlyLink,
+	CaptureOnlyLink,
+	LinkSpreadEvents,
+	NestedLinkEvents,
 	OuterApp,
 	InnerApp,
 	TapClick,
@@ -51,14 +56,8 @@ describe('ReactDOMComponent — non-bubbling resource events', () => {
 
 	// Per ReactDOMComponent-test.js:1992 — should receive a load event on <link> elements
 	// Per ReactDOMComponent-test.js:2010 — should receive an error event on <link> elements
-	// GAP: octane hoists <link> into document.head (headBlock), which sits
-	// OUTSIDE every event-delegation target (delegation roots are createRoot
-	// containers + portal targets) — the capture-phase delegated error/load
-	// listener never sees events fired on the hoisted element, so onLoad/onError
-	// on a <link> never fire. React attaches to the element and both fire.
-	// Runtime location: headBlock hoisting + registerDelegationTarget
-	// (runtime.ts) — hoisted head elements need direct listeners.
-	it('fires onLoad/onError on a (head-hoisted) <link> element', () => {
+	// React keeps links with resource event handlers in their authored position.
+	it('keeps a <link> with onLoad/onError inline and fires both handlers', () => {
 		const calls: string[] = [];
 		const before = document.head.querySelectorAll('link').length;
 		const r = mount(LinkEvents, {
@@ -66,20 +65,239 @@ describe('ReactDOMComponent — non-bubbling resource events', () => {
 			onError: () => calls.push('error'),
 		});
 		try {
-			const links = document.head.querySelectorAll('link');
-			const link = links[links.length - 1];
-			expect(links.length).toBe(before + 1);
+			const link = r.container.querySelector('link[href="http://example.org/link"]');
+			expect(link).not.toBeNull();
+			expect(document.head.querySelectorAll('link')).toHaveLength(before);
 			const loadEvent = document.createEvent('Event');
 			loadEvent.initEvent('load', false, false);
-			link.dispatchEvent(loadEvent);
+			link!.dispatchEvent(loadEvent);
 			expect(calls).toEqual(['load']);
 			const errorEvent = document.createEvent('Event');
 			errorEvent.initEvent('error', false, false);
-			link.dispatchEvent(errorEvent);
+			link!.dispatchEvent(errorEvent);
 			expect(calls).toEqual(['load', 'error']);
 		} finally {
 			r.unmount();
 		}
+	});
+
+	// Per ReactDOMComponent-test.js:1992/:2010 — either resource handler
+	// independently prevents an otherwise hoistable link from moving to <head>.
+	it.each([
+		{ event: 'load', href: 'http://example.org/load-only', component: LoadOnlyLink },
+		{ event: 'error', href: 'http://example.org/error-only', component: ErrorOnlyLink },
+	])('keeps a <link> with only an on$event handler inline', ({ event, href, component }) => {
+		const calls: string[] = [];
+		const r = mount(component, { handler: (received: Event) => calls.push(received.type) });
+		try {
+			const selector = `link[href="${href}"]`;
+			const link = r.container.querySelector(selector);
+			expect(link).not.toBeNull();
+			expect(document.head.querySelector(selector)).toBeNull();
+			link!.dispatchEvent(new Event(event, { bubbles: false }));
+			expect(calls).toEqual([event]);
+		} finally {
+			r.unmount();
+		}
+	});
+
+	// Per ReactDOMComponent-test.js:1992/:2010 — capture-only listeners do not
+	// disable resource hoisting, but remain live on the hoisted link.
+	it('keeps capture-only resource links hoisted and delivers both events', () => {
+		const calls: string[] = [];
+		const r = mount(CaptureOnlyLink, { handler: (event: Event) => calls.push(event.type) });
+		try {
+			const selector = 'link[href="http://example.org/capture-only"]';
+			expect(r.container.querySelector(selector)).toBeNull();
+			const link = document.head.querySelector(selector);
+			expect(link).not.toBeNull();
+			link!.dispatchEvent(new Event('load', { bubbles: false }));
+			link!.dispatchEvent(new Event('error', { bubbles: false }));
+			expect(calls).toEqual(['load', 'error']);
+		} finally {
+			r.unmount();
+		}
+	});
+
+	// Per ReactDOMComponent-test.js:1992/:2010 and
+	// ReactDOMEventPropagation-test.js:983/:1015 — resource handlers keep their
+	// authored DOM position and propagate through capture and bubble ancestors.
+	it('propagates nested link load/error through the authored ancestor while metadata stays hoisted', () => {
+		const calls: string[] = [];
+		const handlers = (location: string) => ({
+			onLoad: () => calls.push(`load:${location}:bubble`),
+			onLoadCapture: () => calls.push(`load:${location}:capture`),
+			onError: () => calls.push(`error:${location}:bubble`),
+			onErrorCapture: () => calls.push(`error:${location}:capture`),
+		});
+		const r = mount(NestedLinkEvents, {
+			ancestor: handlers('ancestor'),
+			target: handlers('target'),
+		});
+		try {
+			const parent = r.find('.link-parent');
+			const link = parent.querySelector('link[href="http://example.org/nested-link"]');
+			expect(link).not.toBeNull();
+			expect(document.head.querySelector('link[href="http://example.org/nested-link"]')).toBeNull();
+			expect(
+				document.head.querySelector(
+					'link[rel="canonical"][href="http://example.org/canonical-link"]',
+				),
+			).not.toBeNull();
+
+			link!.dispatchEvent(new Event('load', { bubbles: false }));
+			link!.dispatchEvent(new Event('error', { bubbles: false }));
+			expect(calls).toEqual([
+				'load:ancestor:capture',
+				'load:target:capture',
+				'load:target:bubble',
+				'load:ancestor:bubble',
+				'error:ancestor:capture',
+				'error:target:capture',
+				'error:target:bubble',
+				'error:ancestor:bubble',
+			]);
+		} finally {
+			r.unmount();
+		}
+	});
+
+	// Per ReactDOMEventPropagation-test.js:983/:1015 — stopping an inline
+	// resource event at its target prevents the ancestor bubble handler.
+	it('honors stopPropagation for nested link load/error target handlers', () => {
+		const calls: string[] = [];
+		const stop = (event: Event) => {
+			calls.push(`${event.type}:target:bubble`);
+			event.stopPropagation();
+		};
+		const r = mount(NestedLinkEvents, {
+			ancestor: {
+				onLoad: () => calls.push('load:ancestor:bubble'),
+				onLoadCapture: () => calls.push('load:ancestor:capture'),
+				onError: () => calls.push('error:ancestor:bubble'),
+				onErrorCapture: () => calls.push('error:ancestor:capture'),
+			},
+			target: {
+				onLoad: stop,
+				onLoadCapture: () => calls.push('load:target:capture'),
+				onError: stop,
+				onErrorCapture: () => calls.push('error:target:capture'),
+			},
+		});
+		try {
+			const link = r.container.querySelector('link[href="http://example.org/nested-link"]');
+			expect(link).not.toBeNull();
+			link!.dispatchEvent(new Event('load', { bubbles: false }));
+			link!.dispatchEvent(new Event('error', { bubbles: false }));
+			expect(calls).toEqual([
+				'load:ancestor:capture',
+				'load:target:capture',
+				'load:target:bubble',
+				'error:ancestor:capture',
+				'error:target:capture',
+				'error:target:bubble',
+			]);
+		} finally {
+			r.unmount();
+		}
+	});
+
+	// Per ReactDOMComponent-test.js:1992/:2010 — removed resource handlers
+	// must stop receiving events when a later prop spread omits them.
+	it('removes hoisted link onLoad/onError handlers omitted from an updated spread', () => {
+		const calls: string[] = [];
+		const r = mount(LinkSpreadEvents, {
+			handlers: {
+				onLoad: () => calls.push('load'),
+				onError: () => calls.push('error'),
+			},
+		});
+		try {
+			const link = document.head.querySelector('link[href="http://example.org/spread-link"]')!;
+			link.dispatchEvent(new Event('load'));
+			link.dispatchEvent(new Event('error'));
+			expect(calls).toEqual(['load', 'error']);
+
+			r.update(LinkSpreadEvents, { handlers: {} });
+			expect(document.head.querySelector('link[href="http://example.org/spread-link"]')).toBe(link);
+			link.dispatchEvent(new Event('load'));
+			link.dispatchEvent(new Event('error'));
+			expect(calls).toEqual(['load', 'error']);
+		} finally {
+			r.unmount();
+		}
+	});
+
+	// Per ReactDOMComponent-test.js:1992/:2010 — capture and bubble handlers
+	// on the same resource event are independent props across updates.
+	it('replaces hoisted link load/error capture and bubble handlers without stale callbacks', () => {
+		const calls: string[] = [];
+		const handlers = (version: string) => ({
+			onLoad: () => calls.push(`${version}:load:bubble`),
+			onLoadCapture: () => calls.push(`${version}:load:capture`),
+			onError: () => calls.push(`${version}:error:bubble`),
+			onErrorCapture: () => calls.push(`${version}:error:capture`),
+		});
+		const r = mount(LinkSpreadEvents, { handlers: handlers('first') });
+		try {
+			const link = document.head.querySelector('link[href="http://example.org/spread-link"]')!;
+			link.dispatchEvent(new Event('load'));
+			link.dispatchEvent(new Event('error'));
+			expect(calls).toEqual([
+				'first:load:capture',
+				'first:load:bubble',
+				'first:error:capture',
+				'first:error:bubble',
+			]);
+
+			const replacement = handlers('second');
+			r.update(LinkSpreadEvents, { handlers: replacement });
+			link.dispatchEvent(new Event('load'));
+			link.dispatchEvent(new Event('error'));
+			expect(calls).toEqual([
+				'first:load:capture',
+				'first:load:bubble',
+				'first:error:capture',
+				'first:error:bubble',
+				'second:load:capture',
+				'second:load:bubble',
+				'second:error:capture',
+				'second:error:bubble',
+			]);
+
+			r.update(LinkSpreadEvents, { handlers: replacement });
+			link.dispatchEvent(new Event('load'));
+			link.dispatchEvent(new Event('error'));
+			expect(calls.slice(-4)).toEqual([
+				'second:load:capture',
+				'second:load:bubble',
+				'second:error:capture',
+				'second:error:bubble',
+			]);
+			expect(calls).toHaveLength(12);
+		} finally {
+			r.unmount();
+		}
+	});
+
+	// Per ReactDOMComponent-test.js:1992/:2010 — unmounting a resource must
+	// disconnect its event props even if consumer code retains its DOM node.
+	it('stops hoisted link load/error capture and bubble handlers after unmount', () => {
+		const calls: string[] = [];
+		const r = mount(LinkSpreadEvents, {
+			handlers: {
+				onLoad: () => calls.push('load:bubble'),
+				onLoadCapture: () => calls.push('load:capture'),
+				onError: () => calls.push('error:bubble'),
+				onErrorCapture: () => calls.push('error:capture'),
+			},
+		});
+		const link = document.head.querySelector('link[href="http://example.org/spread-link"]')!;
+		r.unmount();
+		expect(link.isConnected).toBe(false);
+		link.dispatchEvent(new Event('load'));
+		link.dispatchEvent(new Event('error'));
+		expect(calls).toEqual([]);
 	});
 });
 
@@ -147,10 +365,6 @@ describe('ReactDOMComponent — iOS tap highlight', () => {
 	});
 
 	// Per ReactDOMComponent-test.js:3832 — adds onclick handler to a portal root
-	// GAP: same Safari workaround on the portal TARGET (React stamps onclick on
-	// the portal container). Octane registers the target for delegation but
-	// leaves target.onclick untouched. Runtime location:
-	// registerDelegationTarget (runtime.ts ~4107).
 	it('stamps a noop onclick property on a portal root', () => {
 		const portalContainer = document.createElement('div');
 		document.body.appendChild(portalContainer);

--- a/packages/octane/tests/hydration/head-hydrate.test.ts
+++ b/packages/octane/tests/hydration/head-hydrate.test.ts
@@ -299,6 +299,141 @@ describe('hoisted document metadata — hydration', () => {
 		expect(document.head.querySelectorAll('meta[name="description"]').length).toBe(0);
 	});
 
+	it.each([
+		{
+			form: 'TSRX template',
+			id: '/src/inline-resource-events.tsrx',
+			wrap: (element: string) =>
+				`export function Page(props: Record<string, () => void>) @{ ${element} }`,
+		},
+		{
+			form: 'TSX returned JSX',
+			id: '/src/inline-resource-events.tsx',
+			wrap: (element: string) =>
+				`/** @jsxImportSource octane */\nfunction ResourcePage(props: Record<string, () => void>) { return (${element}); }\nexport const Page = ResourcePage;`,
+		},
+	])(
+		'keeps $form resource handlers inline through server rendering and hydration',
+		({ id, wrap }) => {
+			interface ResourceModule extends CompiledFixtureModule {
+				Page: (props: Record<string, () => void>) => unknown;
+			}
+
+			const source = wrap(`
+<section onLoad={props.onAncestorLoad} onError={props.onAncestorError}>
+	<link
+		rel="stylesheet"
+		href="/inline-resource.css"
+		onLoad={props.onLoad}
+		onError={props.onError}
+	/>
+	<span>hydrated resource</span>
+</section>
+`);
+			const client = loadCompiledFixtureSource<ResourceModule>(source, { id, mode: 'client' });
+			const serverModule = loadCompiledFixtureSource<ResourceModule>(source, {
+				id,
+				mode: 'server',
+			});
+			const calls: string[] = [];
+			const props = {
+				onLoad: () => calls.push('target:load'),
+				onError: () => calls.push('target:error'),
+				onAncestorLoad: () => calls.push('ancestor:load'),
+				onAncestorError: () => calls.push('ancestor:error'),
+			};
+			const { html } = ServerRT.renderToString(serverModule.Page, props);
+			expect(html).not.toMatch(/on(?:load|error)/i);
+			container.innerHTML = html;
+			const section = container.querySelector('section')!;
+			const link = section.querySelector('link[href="/inline-resource.css"]')!;
+			const span = section.querySelector('span')!;
+			expect(link).not.toBeNull();
+			expect(document.head.querySelector('link[href="/inline-resource.css"]')).toBeNull();
+
+			const root = hydrateRoot(container, client.Page, props);
+			flushSync(() => {});
+
+			expect(container.querySelector('section')).toBe(section);
+			expect(section.querySelector('link[href="/inline-resource.css"]')).toBe(link);
+			expect(section.querySelector('span')).toBe(span);
+			expect(document.head.querySelector('link[href="/inline-resource.css"]')).toBeNull();
+
+			link.dispatchEvent(new Event('load', { bubbles: false }));
+			link.dispatchEvent(new Event('error', { bubbles: false }));
+			expect(calls).toEqual(['target:load', 'ancestor:load', 'target:error', 'ancestor:error']);
+			root.unmount();
+		},
+	);
+
+	it('adopts a server-rendered resource and keeps load/error handlers current through unmount', () => {
+		interface ResourceModule extends CompiledFixtureModule {
+			Page: (props: { handlers: Record<string, () => void> }) => unknown;
+		}
+
+		const source = `
+export function Page(props: { handlers: Record<string, () => void> }) @{
+	<>
+		<link rel="stylesheet" href="/hydrated-resource.css" {...props.handlers} />
+		<main>hydrated</main>
+	</>
+}
+`;
+		const id = '/src/hydrated-resource-events.tsrx';
+		const client = loadCompiledFixtureSource<ResourceModule>(source, { id, mode: 'client' });
+		const serverModule = loadCompiledFixtureSource<ResourceModule>(source, { id, mode: 'server' });
+		const calls: string[] = [];
+		const handlers = (version: string) => ({
+			onLoad: () => calls.push(`${version}:load:bubble`),
+			onLoadCapture: () => calls.push(`${version}:load:capture`),
+			onError: () => calls.push(`${version}:error:bubble`),
+			onErrorCapture: () => calls.push(`${version}:error:capture`),
+		});
+		const expected = (version: string) => [
+			`${version}:load:capture`,
+			`${version}:load:bubble`,
+			`${version}:error:capture`,
+			`${version}:error:bubble`,
+		];
+		const initial = handlers('initial');
+		const { html } = ServerRT.renderToString(serverModule.Page, { handlers: initial });
+		const bodyStart = html.indexOf('<main');
+		if (bodyStart === -1) throw new Error('Expected hydrated resource body markup');
+		document.head.innerHTML = html.slice(0, bodyStart);
+		container.innerHTML = html.slice(bodyStart);
+		const link = document.head.querySelector('link[href="/hydrated-resource.css"]')!;
+		const body = container.querySelector('main')!;
+		const dispatch = () => {
+			link.dispatchEvent(new Event('load'));
+			link.dispatchEvent(new Event('error'));
+		};
+		const root = hydrateRoot(container, client.Page, { handlers: initial });
+		flushSync(() => {});
+
+		expect(document.head.querySelector('link[href="/hydrated-resource.css"]')).toBe(link);
+		expect(container.querySelector('main')).toBe(body);
+		dispatch();
+		expect(calls).toEqual(expected('initial'));
+
+		flushSync(() => root.render(client.Page, { handlers: handlers('updated') }));
+		dispatch();
+		expect(calls).toEqual([...expected('initial'), ...expected('updated')]);
+
+		flushSync(() => root.render(client.Page, { handlers: {} }));
+		dispatch();
+		expect(calls).toEqual([...expected('initial'), ...expected('updated')]);
+
+		flushSync(() => root.render(client.Page, { handlers: handlers('retained') }));
+		dispatch();
+		const beforeUnmount = [...expected('initial'), ...expected('updated'), ...expected('retained')];
+		expect(calls).toEqual(beforeUnmount);
+
+		root.unmount();
+		expect(link.isConnected).toBe(false);
+		dispatch();
+		expect(calls).toEqual(beforeUnmount);
+	});
+
 	it('skips an interposed foreign element and adopts the intended head element', () => {
 		const { html } = ServerRT.renderToString(server.Page, { params: {} });
 		const bodyStart = html.indexOf('<section');


### PR DESCRIPTION
## Summary

- Match React's placement rules for `<link onLoad>` and `<link onError>` so resource events remain inline and propagate through their authored ancestors.
- Keep dynamically hoisted resource listeners synchronized across capture/bubble updates, omitted props, hydration, namespace changes, and unmount.

## Why

Octane already handled ordinary image/resource events, but explicitly handled links were incorrectly hoisted or dropped when nested. Hoisted spread handlers also leaked across updates and teardown.

## Changes

- Classify explicitly handled links as ordinary DOM in both client and server compilation without changing canonical, capture-only, or spread-authored metadata.
- Track direct head listeners by phase-specific prop identity, remove disappeared listeners, avoid reinstalling unchanged callbacks, and clean up on teardown.
- Add React conformance coverage plus `.tsrx`/`.tsx` SSR and hydration regressions; include an `octane` patch changeset.

## Validation

- [x] `pnpm --config.verify-deps-before-run=false sync`
- [x] Scoped Prettier check for all six changed files.
- [x] `pnpm --config.verify-deps-before-run=false typecheck:files packages/octane/src/compiler/compile.js packages/octane/src/runtime.ts`
- [x] Full `octane` and `octane-prod` Vitest projects: 776 files and 11,087 tests passed; two instances of the same pre-existing broken installed-package probe were skipped using a temporary local alias overlay.
- [x] `seo` and `seo-ssr` Vitest projects: 104 tests.
- [x] Production bundle, namespace, event-propagation, SSR, and hydration coverage.
- [x] `benchmarks/codegen-size/run.mjs` with a worktree-pinned compiler loader: upstream baseline and candidate both produce exactly 153,431 raw / 75,702 minified / 26,698 gzip bytes.
- [ ] `pnpm format:check` (scoped equivalent run).
- [ ] `pnpm typecheck` (upstream's five newest packages do not have dependencies installed in this shared worktree).
- [ ] `pnpm test` (full monorepo has the same unavailable upstream-package dependencies; both complete core projects were exercised instead).

## Risk / follow-ups

Only explicitly authored `onLoad`/`onError` links change DOM placement. Spread-provided handler names cannot be known statically, so those links retain their existing head-hoisting behavior with corrected listener lifecycle.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compiler hoisting rules and head metadata event wiring, which affects SSR output and hydration for resource links, but the behavior is narrowly scoped to explicit load/error links and hoisted head listener lifecycle.
> 
> **Overview**
> **Aligns `<link>` placement and resource events with React** by not hoisting links that declare explicit `onLoad` or `onError`, so load/error handling stays in the authored tree and can propagate through logical ancestors. Canonical links and capture-only resource handlers still use the existing head-hoist path; spread-provided handler names remain statically unknown and keep hoisting.
> 
> **Hardens `headBlock` direct listeners** for metadata that remains in `document.head`: listeners are tracked per prop name (capture vs bubble stay separate), removed when props disappear or the scope tears down, and skipped when the callback is unchanged—covering spread updates, hydration adoption, and namespace head teardown.
> 
> Conformance ledger entries, DOM event tests, and SSR/hydration regressions were expanded accordingly; includes an `octane` patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cec0dce50fe3f7abec3ca11abb27fb88b869b1d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->