### PR TITLE
perf(runtime): wholesale unmount DOM detach + gated de-opt ref walk

### DIFF
--- a/.changeset/teardown-wholesale-detach.md
+++ b/.changeset/teardown-wholesale-detach.md
@@ -1,0 +1,11 @@
+---
+'octane': patch
+---
+
+Unmount teardown now removes a deleted subtree's DOM once at the outermost
+detached block instead of per-descendant range (portals still self-detach from
+their foreign targets), and the de-opt ref-detach walk is skipped for subtrees
+that never stamped a descriptor ref. A full-page teardown drops from thousands
+of `removeChild` calls to one per top-level node, and deletion cleanups now
+observe the entire deleted subtree still attached — matching React's
+commitDeletionEffects order.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -577,6 +577,14 @@ export interface Block extends Scope {
 	 * (the host-element-with-component-children renderer). Null for every other Block.
 	 */
 	deoptNode: Node | null;
+	/**
+	 * True when a de-opt descriptor carrying a `ref` was stamped anywhere in this
+	 * block's subtree. Set at stamp time and propagated up the parentBlock chain
+	 * (monotone — never cleared). Gates the teardown ref-detach walk over
+	 * `deoptNode`: a region that never stamped a ref has nothing to detach, so
+	 * the per-DOM-node descriptor scan is skipped entirely.
+	 */
+	deoptRefs: boolean;
 	/** Set on item Blocks: pointer to the enclosing for-block's slot. */
 	forSlot: ForSlot | null;
 	/** Item position within the enclosing for-block. 0 for non-item blocks. */
@@ -4124,6 +4132,8 @@ class BlockImpl {
 	// De-opt host node managed by this Block (deoptItemBody / hostElementBody), reused
 	// across renders. Null for all other blocks; declared so the shape stays monomorphic.
 	deoptNode: Node | null;
+	// A de-opt descriptor with a `ref` was stamped in this subtree (see Block).
+	deoptRefs: boolean;
 	// Per-scope dense slot array (binding bag + control-flow/component/child slots),
 	// indexed by compile-time slot index. Keeps the scope shape monomorphic.
 	slots: any[];
@@ -4196,6 +4206,7 @@ class BlockImpl {
 		this.effectEventRenderVersion = 0;
 		this.effectEventCompletedVersion = 0;
 		this.deoptNode = null;
+		this.deoptRefs = false;
 		this.slots = [];
 		this.forSlot = null;
 		this.prevSibling = null;
@@ -4833,10 +4844,28 @@ function unmountBlockInner(block: Block, detachDom: boolean): void {
 	// (batchClearItems, clearChildContent) remove the DOM themselves, but the
 	// teardown is just as permanent. Before unmountScope: a deleted host's ref
 	// detaches before its component descendants' cleanups (React's pre-order
-	// deletion walk).
-	if (block.deoptNode !== null) detachDeoptTreeRefs(block.deoptNode, null);
+	// deletion walk). `deoptRefs` gates the walk: it is set (and propagated up
+	// the parentBlock chain) whenever a descriptor carrying a ref is stamped
+	// anywhere in this block's subtree, so a ref-free region skips the
+	// whole-DOM descriptor scan.
+	if (block.deoptNode !== null && block.deoptRefs) detachDeoptTreeRefs(block.deoptNode, null);
+	// When THIS call removes the block's entire DOM range below, descendants must
+	// not detach their own ranges first: every non-portal descendant's DOM lies
+	// inside this range (portals always self-detach — unmountScopeChildrenAndSlotsOnly
+	// forces their flag), so one wholesale removal replaces O(nodes) removeChild
+	// calls, and every deletion cleanup observes the subtree still attached —
+	// React's commitDeletionEffects order, which runs all destroys before it
+	// detaches the single host. A cleanup that itself moves or removes the
+	// block's markers forfeits the removal (the loop below guards on the live
+	// parent), exactly as it would have forfeited its own range before.
+	const removesOwnDom =
+		detachDom &&
+		(block.kind === 'root' ||
+			(block.startMarker !== null &&
+				block.endMarker !== null &&
+				block.startMarker.parentNode !== null));
 	// Depth-first cleanup of all scopes reachable from this block.
-	unmountScope(block, detachDom);
+	unmountScope(block, detachDom && !removesOwnDom);
 	if (!detachDom) return;
 	// Remove DOM range.
 	if (block.startMarker && block.endMarker) {
@@ -16093,11 +16122,32 @@ export function positionalChildren(children: any[]): any[] {
 	return children;
 }
 
+// Whether ANY de-opt descriptor carrying a `ref` was ever stamped (monotone).
+// Gates every detachDeoptTreeRefs walk: an app that never puts a ref on a
+// de-opt element never pays the per-DOM-node descriptor scan on teardown.
+let DEOPT_REFS_STAMPED = false;
+
+// Record a stamped de-opt ref on its owner block and every ancestor, so the
+// teardown walk over any enclosing `deoptNode` region knows refs may be below.
+// The early exit bounds repeat stamping: the chain above the first flagged
+// block is already flagged.
+function noteDeoptRef(block: Block): void {
+	DEOPT_REFS_STAMPED = true;
+	let b: Block | null = block;
+	while (b !== null && !b.deoptRefs) {
+		b.deoptRefs = true;
+		b = b.parentBlock;
+	}
+}
+
 // Apply ONE host prop, reusing the same helpers the compiler emits (className/style/
 // setAttribute + `$$type` delegated-event slots + deferred ref attach).
 function applyDeoptProp(el: Element, name: string, v: any, ownerBlock: Block): void {
 	if (name === 'ref') {
-		if (v != null) queueRefAttach(ownerBlock, v, el);
+		if (v != null) {
+			noteDeoptRef(ownerBlock);
+			queueRefAttach(ownerBlock, v, el);
+		}
 	} else if (name === 'className' || name === 'class') {
 		setDeoptClass(el, v);
 	} else if (name === 'style') {
@@ -22932,6 +22982,9 @@ function detachDeoptTreeRefs(
 	ownerScope?: Scope,
 	uncommitted: UncommittedRefAttaches | null = null,
 ): void {
+	// No de-opt descriptor ref was ever stamped → nothing to detach or collect
+	// anywhere; skip the subtree scan. (Monotone flag — see noteDeoptRef.)
+	if (!DEOPT_REFS_STAMPED) return;
 	const ref = getDeoptDesc(node)?.props?.ref;
 	if (ref != null) {
 		if (out !== null) {
@@ -24539,8 +24592,9 @@ function batchClearItems(state: ForSlot, oldItems: Map<any, Block>): void {
 			// Pure-host de-opt item (deoptItemBody with no component descendants):
 			// nothing to unmount scope-wise, but its subtree may carry stamped refs
 			// that must not keep pointing at the batch-removed DOM. Guarded so the
-			// common template-row clear stays a single null check.
-			if (b.deoptNode !== null) detachDeoptTreeRefs(b.deoptNode, null);
+			// common template-row clear stays a single null check; `deoptRefs`
+			// additionally skips the subtree scan for ref-free items.
+			if (b.deoptNode !== null && b.deoptRefs) detachDeoptTreeRefs(b.deoptNode, null);
 			b.disposed = true;
 		}
 	}

--- a/packages/octane/tests/_fixtures/deopt-suspense-ref.tsrx
+++ b/packages/octane/tests/_fixtures/deopt-suspense-ref.tsrx
@@ -1,0 +1,29 @@
+import { use } from 'octane';
+
+interface DeoptRefInBoundaryProps {
+	promise: Promise<string>;
+	r: { current: Element | null } | ((el: Element | null) => void);
+}
+
+function Value(props: { promise: Promise<string> }) @{
+	<i class="v">{use(props.promise) as string}</i>
+}
+
+// A VALUE-POSITION host descriptor with a ref (de-opt renderer path) mounted
+// inside a @try boundary next to a suspendable sibling. Hiding the boundary
+// must detach the descriptor's ref; the reveal must re-attach it.
+export function DeoptRefInBoundary(props: DeoptRefInBoundaryProps) @{
+	const host = <b id="deopt-target" ref={props.r}>
+		x
+	</b>;
+	<div class="wrap">
+		@try {
+			<div class="content">
+				{host}
+				<Value promise={props.promise} />
+			</div>
+		} @pending {
+			<span class="fallback">loading</span>
+		}
+	</div>
+}

--- a/packages/octane/tests/_fixtures/unmount-observe.tsrx
+++ b/packages/octane/tests/_fixtures/unmount-observe.tsrx
@@ -1,0 +1,91 @@
+import { useLayoutEffect } from 'octane';
+
+// Deletion-phase observation fixtures: each Observed leaf records, at the
+// moment its LAYOUT cleanup fires, what `observe()` can still see in the
+// document. React runs every deletion destroy before it removes any DOM, so a
+// cleanup must be able to observe the ENTIRE deleted subtree still connected —
+// including siblings whose cleanups already ran.
+
+interface ObservedProps {
+	id: string;
+	log: (entry: string) => void;
+	observe: () => string;
+}
+
+export function Observed(props: ObservedProps) @{
+	useLayoutEffect(() => {
+		return () => props.log(props.id + ' cleanup sees ' + props.observe());
+	}, []);
+	<span class={'obs ' + props.id}>{props.id}</span>
+}
+
+interface PairProps {
+	log: (entry: string) => void;
+	observe: () => string;
+}
+
+// Two component children of one host — each child renders through its own
+// block, which is the shape where a per-block DOM detach would let the second
+// cleanup observe the first sibling already gone.
+export function Pair(props: PairProps) @{
+	<div class="pair">
+		<Observed id="first" log={props.log} observe={props.observe} />
+		<Observed id="second" log={props.log} observe={props.observe} />
+	</div>
+}
+
+interface ToggleProps {
+	show: boolean;
+	log: (entry: string) => void;
+	observe: () => string;
+}
+
+export function Toggle(props: ToggleProps) @{
+	<div class="host">
+		@if (props.show) {
+			<Pair log={props.log} observe={props.observe} />
+		} @else {
+			<em class="off">off</em>
+		}
+	</div>
+}
+
+interface RouteProps {
+	route: string;
+	log: (entry: string) => void;
+	observe: () => string;
+}
+
+// The SPA-navigation shape: a @switch outlet swapping route arms.
+export function Routes(props: RouteProps) @{
+	<div class="outlet">
+		@switch (props.route) {
+			@case 'a': {
+				<section class="page-a">
+					<Pair log={props.log} observe={props.observe} />
+				</section>
+			}
+			@default: {
+				<section class="page-b">page b</section>
+			}
+		}
+	</div>
+}
+
+interface ListProps {
+	items: { id: string }[];
+	log: (entry: string) => void;
+	observe: () => string;
+}
+
+// Keyed item removal: the removed item's cleanup must observe its own item
+// subtree still connected.
+export function List(props: ListProps) @{
+	<ul class="list">
+		@for (const item of props.items; key item.id) {
+			<li class={'item ' + item.id}>
+				<Observed id={item.id} log={props.log} observe={props.observe} />
+			</li>
+		}
+	</ul>
+}

--- a/packages/octane/tests/deopt-host-ref.test.ts
+++ b/packages/octane/tests/deopt-host-ref.test.ts
@@ -155,6 +155,28 @@ describe('de-opt keyed list / wholesale-unmount ref detach', () => {
 		m.unmount();
 	});
 
+	it('detaches a ref that was ADDED by a later update, on removal', () => {
+		// The ref arrives via the reuse/diff path (no ref on mount, added on
+		// update) — its removal-time detach must work exactly like a mount-time
+		// ref's.
+		const r = ref();
+		function MaybeRef(props: any) {
+			return createElement('div', props.withRef ? { id: 'mr', ref: props.r } : { id: 'mr' });
+		}
+		const m = mount(Gate as any, { show: true, comp: MaybeRef, props: { withRef: false, r } });
+		expect(r.current).toBeNull();
+
+		m.root.render(Gate as any, { show: true, comp: MaybeRef, props: { withRef: true, r } });
+		flushSync(() => {});
+		expect(r.current).toBe(m.container.querySelector('#mr'));
+
+		m.root.render(Gate as any, { show: false, comp: MaybeRef, props: { withRef: true, r } });
+		flushSync(() => {});
+		expect(m.container.querySelector('#mr')).toBeNull();
+		expect(r.current).toBeNull();
+		m.unmount();
+	});
+
 	it('detaches item refs on root unmount', () => {
 		const a = { id: 1, r: ref() };
 		const m = mount(KeyedList as any, { items: [a] });

--- a/packages/octane/tests/deopt-suspense-ref.test.ts
+++ b/packages/octane/tests/deopt-suspense-ref.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { act, mount } from './_helpers';
+import { DeoptRefInBoundary } from './_fixtures/deopt-suspense-ref.tsrx';
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((res) => (resolve = res));
+	return { promise, resolve };
+}
+
+function fulfilled(value: string) {
+	const promise = Promise.resolve(value) as Promise<string> & {
+		status?: string;
+		value?: string;
+	};
+	promise.status = 'fulfilled';
+	promise.value = value;
+	return promise;
+}
+
+// A de-opt (value-position descriptor) host ref inside a @try boundary: hiding
+// the boundary detaches the ref, the reveal re-attaches it. Protects the
+// suspense hide/reveal walk over descriptor-stamped subtrees.
+describe('de-opt descriptor refs across suspense hide/reveal', () => {
+	it('detaches on hide and re-attaches on reveal (object ref)', async () => {
+		const r: { current: Element | null } = { current: null };
+		const m = mount(DeoptRefInBoundary as any, { promise: fulfilled('one'), r });
+		expect((r.current as Element | null)?.id).toBe('deopt-target');
+
+		const pending = deferred<string>();
+		m.update(DeoptRefInBoundary as any, { promise: pending.promise, r });
+		expect(m.container.querySelector('.fallback')).not.toBeNull();
+		expect(r.current).toBeNull(); // hidden content's ref is detached
+
+		await act(() => pending.resolve('two'));
+		expect(m.container.querySelector('.fallback')).toBeNull();
+		expect((r.current as Element | null)?.id).toBe('deopt-target'); // re-attached
+		m.unmount();
+		expect(r.current).toBeNull();
+	});
+});

--- a/packages/octane/tests/unmount-detach.test.ts
+++ b/packages/octane/tests/unmount-detach.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { mount, createLog } from './_helpers';
+import { Toggle, Routes, List } from './_fixtures/unmount-observe.tsrx';
+
+// React parity: every deletion cleanup runs BEFORE any of the deleted subtree's
+// DOM is removed (commitDeletionEffects detaches the host once, after the
+// destroy walk). A layout cleanup must therefore be able to observe the whole
+// deleted subtree still in the document — including a SIBLING component whose
+// own cleanup already fired. The DOM must still be fully gone afterwards.
+
+// What each Observed leaf reports at cleanup time: connectivity of both leaf
+// spans and their shared host wrapper.
+function observer(container: () => HTMLElement) {
+	return () => {
+		const c = container();
+		const see = (sel: string) => {
+			const el = c.querySelector(sel);
+			return el !== null && el.isConnected;
+		};
+		return `first=${see('.obs.first')} second=${see('.obs.second')} pair=${see('.pair')}`;
+	};
+}
+
+describe('deletion cleanups observe the whole deleted subtree still attached', () => {
+	it('conditional-branch removal: both sibling cleanups see the full pair', () => {
+		const log = createLog();
+		let m!: ReturnType<typeof mount>;
+		m = mount(Toggle as any, { show: true, log: log.push, observe: observer(() => m.container) });
+		log.clear();
+
+		m.update(Toggle as any, { show: false, log: log.push, observe: observer(() => m.container) });
+
+		// The second sibling's cleanup fires after the first's — it must STILL see
+		// the first sibling's DOM connected.
+		expect(log.drain()).toEqual([
+			'first cleanup sees first=true second=true pair=true',
+			'second cleanup sees first=true second=true pair=true',
+		]);
+		// The deletion still completes: the branch's DOM is gone afterwards.
+		expect(m.container.querySelector('.pair')).toBeNull();
+		expect(m.container.querySelector('.obs')).toBeNull();
+		expect(m.container.querySelector('.off')).not.toBeNull();
+		m.unmount();
+	});
+
+	it('route-swap removal (@switch outlet): outgoing page cleanups see the full page', () => {
+		const log = createLog();
+		let m!: ReturnType<typeof mount>;
+		m = mount(Routes as any, { route: 'a', log: log.push, observe: observer(() => m.container) });
+		log.clear();
+
+		m.update(Routes as any, { route: 'b', log: log.push, observe: observer(() => m.container) });
+
+		expect(log.drain()).toEqual([
+			'first cleanup sees first=true second=true pair=true',
+			'second cleanup sees first=true second=true pair=true',
+		]);
+		expect(m.container.querySelector('.page-a')).toBeNull();
+		expect(m.container.querySelector('.page-b')).not.toBeNull();
+		m.unmount();
+	});
+
+	it('root.unmount(): both sibling cleanups see the full pair', () => {
+		const log = createLog();
+		let m!: ReturnType<typeof mount>;
+		m = mount(Toggle as any, { show: true, log: log.push, observe: observer(() => m.container) });
+		log.clear();
+
+		m.root.unmount();
+
+		expect(log.drain()).toEqual([
+			'first cleanup sees first=true second=true pair=true',
+			'second cleanup sees first=true second=true pair=true',
+		]);
+		expect(m.container.querySelector('*')).toBeNull();
+		m.container.remove();
+	});
+
+	it('keyed item removal: the removed item cleanup sees its own item subtree', () => {
+		const log = createLog();
+		let m!: ReturnType<typeof mount>;
+		const observe = () => {
+			const el = m.container.querySelector('.item.b');
+			return `item-b=${el !== null && el.isConnected}`;
+		};
+		m = mount(List as any, {
+			items: [{ id: 'a' }, { id: 'b' }],
+			log: log.push,
+			observe,
+		});
+		log.clear();
+		const survivor = m.container.querySelector('.item.a');
+
+		m.update(List as any, { items: [{ id: 'a' }], log: log.push, observe });
+
+		expect(log.drain()).toEqual(['b cleanup sees item-b=true']);
+		expect(m.container.querySelector('.item.b')).toBeNull();
+		// Survivor keeps identity.
+		expect(m.container.querySelector('.item.a')).toBe(survivor);
+		m.unmount();
+	});
+});


### PR DESCRIPTION
## Summary

- Unmount teardown now removes a deleted subtree's DOM **once, at the outermost detached block**, instead of every descendant block detaching its own marker range node-by-node. Portals are unaffected — they already force self-detach from their foreign targets.
- The de-opt ref-detach walk (`detachDeoptTreeRefs`) is now **gated on refs actually existing**: stamping a descriptor `ref` sets a monotone flag on the owner block and its `parentBlock` chain (plus a module-level "ever stamped" flag), and teardown/hide walks skip the per-DOM-node descriptor scan when clear.

## Why

The new spa-navigation suite (#614) showed teardown is where Octane loses on full-page navigations. Profiling the production fixtures:

- A 1024-leaf route teardown issued **6,140 `removeChild` calls (tsrx) / 8,186 (jsx)**; React does **1**, Solid does 1 `replaceChild`. Raw `removeChild` alone was 21% of the tsrx navigation profile.
- `detachDeoptTreeRefs` was **20.4% of the octane-jsx profile (~1ms per teardown)** in a tree containing **zero refs** — it walks every DOM node of each block's `deoptNode` subtree (nested blocks re-walk the same DOM, so it is O(nodes x depth)).

Both fixes also move deletion semantics closer to React: every deletion cleanup now observes the entire deleted subtree still attached (React's `commitDeletionEffects` runs all destroys before detaching the single host). Previously a later sibling's cleanup saw an earlier sibling's DOM already removed.

## Changes

- `unmountBlockInner`: compute `removesOwnDom` (this call will remove the block's own range or clear the root container) and recurse with `detachDom=false` in that case, so only the outermost detaching block touches the DOM. The existing `detachDom=false` contract (`batchClearItems`, `clearChildContent`, parked blocks) is unchanged, as is the forced self-detach for `portalSlotSlot` and hidden-try content.
- `Block.deoptRefs` (new monomorphic boolean field) + `noteDeoptRef` called from `applyDeoptProp`'s ref branch (covers fresh apply, reuse/diff re-attach, and hydration adoption). Gates the `deoptNode` walks in `unmountBlockInner` and `batchClearItems`; a module-level `DEOPT_REFS_STAMPED` flag short-circuits `detachDeoptTreeRefs` itself for every other call site (clearChildContent sweeps, suspense hide/reveal collection, hydration recovery).

## Benchmarks (same machine, same day, 20 iterations, medians in ms)

`node benchmarks/bench.mjs spa-navigation` — baseline was main earlier the same day; candidate ran twice (a concurrent-load run and a clean run; clean run shown, sd 0.05–0.10 on the sub-ms ops):

| op | tsrx before | tsrx after | jsx before | jsx after | react | solid |
| --- | --- | --- | --- | --- | --- | --- |
| nav_teardown | 1.20 | **0.60** | 3.70 | **0.90** | 0.80 | 0.60 |
| nav_deep | 2.20 | **1.80** | 7.00 | **4.50** | 1.50 | 1.90 |
| nav_mount | 1.70 | 1.70 | 3.90 | 4.10 | 1.30 | 1.80 |
| nav_deep_6x | 14.80 | **11.20** | 47.40 | **29.80** | 10.20 | 13.50 |

`nav_teardown` halves and now ties Solid (was 2.24x); `nav_deep` edges past Solid and `nav_deep_6x` (the mobile signal) is now clearly ahead of it. `nav_mount` is unchanged — expected, the mount path is untouched, which is itself evidence the deltas are the teardown mechanism and not noise. The deterministic work counters (`work.mjs`) are **byte-identical to baseline** — renderBlock/unmountBlock/unmountScope counts unchanged — so the semantic work is proven equal; only DOM calls and the ref walk were removed. All semantic gates (shell/layout survival by node identity) and work gates pass. list-clear and effectful-list (the other teardown-heavy suites) ran without anomaly; their clear paths already used the batched contract this change extends.

## Validation

- [x] `pnpm test` — 1,610 files / 17,249 tests pass (includes the octane-prod project)
- [x] `pnpm typecheck`
- [x] `pnpm format:files:check` on changed files
- [x] targeted: new `unmount-detach.test.ts` (deletion cleanups observe the whole subtree attached — **failed before the fix**: `second cleanup sees first=false`), new `deopt-suspense-ref.test.ts` (hide/reveal detach/re-attach across the gated walk), `deopt-host-ref.test.ts` extended with an update-added-ref case — **32/36 of these fail if the gate is deliberately broken** (verified), plus portal, ref-cleanup/dispose, suspense-ref-regressions, effect-ordering-deletion suites.

## Risk / follow-ups

- Observable divergence-toward-React: deletion cleanups now see sibling DOM still attached; MutationObserver users see one subtree removal instead of per-node removals. Both match React.
- A cleanup that removes/moves its own block's markers mid-teardown now forfeits the wholesale removal for that range (guarded on the live parent) — same containment contract as before, noted in a comment.
- `deoptRefs` is monotone; a region that once had a ref keeps paying the (previous) walk cost. Finer invalidation was not worth the bookkeeping.
- Follow-ups from the same audit (not in this PR): static multi-hole marker elision (mount-side; 4,092 comments per 1024-leaf mount), and the `.tsx` dialect lowering gaps (multi-return bodies de-opt; single-return components keep the generic descriptor ABI).

## Provenance

- [x] An agent produced this diff (`agent-authored`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core unmount/teardown in the runtime: DOM removal order and what deletion cleanups can observe now match React, which can affect MutationObserver users and any code that assumed per-block incremental detach.
> 
> **Overview**
> **Teardown** now strips a deleted subtree's DOM in **one pass** at the outermost block that owns the marker range (`removesOwnDom` in `unmountBlockInner`), instead of every descendant block calling `removeChild` on its own slice. Descendant unmounts run with `detachDom=false` in that case so layout/deletion cleanups still see sibling DOM connected until the parent removes the range — matching React's `commitDeletionEffects` (destroys before a single host detach). Portals keep self-detaching from foreign targets.
> 
> **De-opt ref teardown** is gated: stamping a descriptor `ref` sets monotone `Block.deoptRefs` up the `parentBlock` chain and a module `DEOPT_REFS_STAMPED` flag; `detachDeoptTreeRefs` and related walks in `unmountBlockInner` / `batchClearItems` skip the per-DOM-node scan when a subtree never had refs.
> 
> Adds regression tests for deletion cleanup observation (`unmount-detach`), suspense hide/reveal on de-opt refs (`deopt-suspense-ref`), and refs added on a later update (`deopt-host-ref`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3197f027d71b3f1266a8b2f0d80c832170a16862. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->