### PR TITLE
feat: add behavior-only roots and external DOM ownership

### DIFF
--- a/.changeset/behavior-only-external-dom-ownership.md
+++ b/.changeset/behavior-only-external-dom-ownership.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Add behavior-only roots for server-rendered and externally streamed DOM, with explicit range ownership, readiness, trusted native event adoption, cancellation, and DOM-preserving disposal.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -637,6 +637,10 @@ jobs:
         if: ${{ matrix.chromium && matrix.lane != 'astro' }}
         run: pnpm --filter website exec playwright install --with-deps chromium
 
+      - name: Install Playwright WebKit for cross-browser ownership coverage
+        if: ${{ matrix.lane == 'browser' }}
+        run: pnpm --filter octane exec playwright install --with-deps webkit
+
       - name: Install Playwright Chromium (astro)
         if: ${{ matrix.lane == 'astro' }}
         run: pnpm --filter @octanejs/astro exec playwright install --with-deps chromium

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ they are written down in
 - **Deferred hydration.** `<Hydrate>` keeps server HTML visible but inert until
   it is worth activating, and splits its children into their own chunk by
   default.
+- **Behavior-only roots for externally owned DOM.** Attach abortable behavior
+  and delegated native events to server-rendered or independently streamed
+  markup without rendering it or taking reconciliation ownership.
 - **`class` / `className` composes clsx-style** everywhere: strings, arrays,
   objects, and nesting, at every apply site.
 - **A current-state getter.** `useState` and `useReducer` return

--- a/docs/deferred-hydration.md
+++ b/docs/deferred-hydration.md
@@ -271,6 +271,92 @@ fallback has already flushed, a later rejection or abort terminalizes that
 server-owned range and retains the fallback; it cannot request client recovery
 because its client graph does not exist.
 
+## Behavior-only roots and external ownership
+
+A permanently static boundary intentionally never installs its descendant
+component handlers: its client component graph does not exist. When another
+system owns that markup, attach independent behavior through `octane/behavior`
+instead of hydrating or rendering the externally managed range:
+
+```ts
+import { attachBehaviorRoot } from 'octane/behavior';
+
+const lifetime = new AbortController();
+const root = attachBehaviorRoot(document.querySelector('#app')!, {
+	signal: lifetime.signal,
+});
+const streamOwner = Symbol('article stream');
+
+root.registerExternalRange(document.querySelector('#article')!, {
+	owner: streamOwner,
+	ready: articleStream.allReady,
+});
+
+let activateAnnotation: (event: Event, element: Element) => void;
+
+root.registerBehavior({
+	id: 'article-annotations',
+	owner: streamOwner,
+	target: '[data-annotation]',
+	events: ['click'],
+	ready: import('./annotations.js').then((module) => {
+		activateAnnotation = module.activateAnnotation;
+	}),
+	adopt(element, { signal }) {
+		return observeAnnotation(element, signal);
+	},
+	handleEvent(event, element) {
+		activateAnnotation(event, element);
+	},
+});
+
+await root.ready;
+
+// Aborts pending work, disconnects observers/listeners, and runs every
+// adoption cleanup exactly once. Existing DOM is preserved by default.
+root.dispose();
+```
+
+`attachBehaviorRoot` neither renders nor hydrates its container. Existing DOM,
+attributes, and externally streamed updates retain their identity; a single
+root-scoped observer discovers later matching elements and releases behavior
+when elements leave the container. Importing the focused `octane/behavior`
+entry does not load the component runtime, compiler, or server renderer. The
+same API and public types are also exported by `octane`.
+
+Each external range belongs to its declared `owner`. Strictly nested ranges are
+allowed, and the closest registered range determines ownership for behaviors
+with an `owner` constraint. Registering the same element for another owner
+throws unless `{ replace: true }` explicitly hands the range to its new owner;
+handoff aborts the displaced range and invalidates stale asynchronous work.
+An already-canceled replacement never evicts a healthy existing owner.
+Ranges must belong to the root's document and container. Their optional `ready`
+promise delays adoption without preventing the external owner from updating
+markup. Individual ranges and behavior registrations expose their cancellation
+signal, readiness, and an idempotent `dispose()` method.
+
+Named behaviors may list already registered `dependencies` and incompatible
+`conflicts`. Registration fails for unknown dependencies, duplicate IDs, or an
+active conflict. Adoption waits for dependencies, the entry's optional `ready`
+promise, and its closest external range. Root readiness reflects the active
+registrations and ranges at the instant `root.ready` is read.
+
+Delegated `events` begin listening immediately. If an interaction arrives
+before its target is adopted, `handleEvent` later receives the exact original
+same-document `Event`, including its genuine `isTrusted` value. Octane does not
+redispatch the event, synthesize trust, repeat native link or form activation,
+or restore transient user activation that expired during asynchronous loading.
+Code requiring transient activation must run synchronously while the original
+event is being dispatched.
+
+Root identity is scoped to its document and container. A second root for the
+same live container requires `{ replace: true }`, which disposes the old root
+without removing markup; creating a root for a replacement document never adopts
+listeners or ranges from its predecessor. Disposing an independently owned
+nested root immediately restores eligible behavior belonging to its surviving
+ancestor root. Pass `{ preserveDOM: false }` to `root.dispose()` only when the
+root should explicitly clear its container.
+
 ## Correctness and nesting
 
 Deferred hydration is a performance hint. An update outside a dormant boundary

--- a/docs/deferred-hydration.md
+++ b/docs/deferred-hydration.md
@@ -280,6 +280,7 @@ instead of hydrating or rendering the externally managed range:
 
 ```ts
 import { attachBehaviorRoot } from 'octane/behavior';
+import { articleStream } from './article-stream.js';
 
 const lifetime = new AbortController();
 const root = attachBehaviorRoot(document.querySelector('#app')!, {
@@ -293,6 +294,7 @@ root.registerExternalRange(document.querySelector('#article')!, {
 });
 
 let activateAnnotation: (event: Event, element: Element) => void;
+let observeAnnotation: (element: Element, signal: AbortSignal) => () => void;
 
 root.registerBehavior({
 	id: 'article-annotations',
@@ -301,6 +303,7 @@ root.registerBehavior({
 	events: ['click'],
 	ready: import('./annotations.js').then((module) => {
 		activateAnnotation = module.activateAnnotation;
+		observeAnnotation = module.observeAnnotation;
 	}),
 	adopt(element, { signal }) {
 		return observeAnnotation(element, signal);

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -84,7 +84,7 @@ All publishable packages share the enforced Node.js engine baseline `>=22.22.2`.
 | `@octanejs/wagmi` | [`packages/wagmi`](../packages/wagmi) | framework binding | `0.0.12` | 3 |
 | `@octanejs/zustand` | [`packages/zustand`](../packages/zustand) | framework binding | `0.1.31` | 5 |
 | `create-octane` | [`packages/create-octane`](../packages/create-octane) | project scaffolder | `0.0.7` | 1 |
-| `octane` | [`packages/octane`](../packages/octane) | core runtime + compiler | `0.1.32` | 21 |
+| `octane` | [`packages/octane`](../packages/octane) | core runtime + compiler | `0.1.32` | 22 |
 
 ## Private packages
 

--- a/docs/ssr.md
+++ b/docs/ssr.md
@@ -36,6 +36,14 @@ The server build must compile components with the Octane compiler in
 `mode: 'server'` (`@octanejs/vite-plugin` handles this automatically; SSR module
 loading through Vite picks the server transform automatically).
 
+If another renderer or an independent stream owns part of the server-rendered
+DOM, use a permanent-static `<Hydrate split={false} when={never()}>` boundary to
+preserve that range and `attachBehaviorRoot` from `octane/behavior` to attach
+behavior without claiming reconciliation ownership. The
+[behavior-only roots and external ownership guide](./deferred-hydration.md#behavior-only-roots-and-external-ownership)
+covers range readiness, nested owners, delegated native interactions, and
+disposal.
+
 ### Run an SSG script directly
 
 When a server or SSG entry runs outside Vite, preload Octane's compiler before

--- a/packages/octane/README.md
+++ b/packages/octane/README.md
@@ -21,6 +21,12 @@ Direct Node or Bun server scripts can preload `octane/compiler/register` to
 compile imported Octane components without going through Vite. See the
 [SSR guide](https://github.com/octanejs/octane/blob/main/docs/ssr.md#run-an-ssg-script-directly).
 
+Applications that stream or update their own server-rendered DOM can import
+`attachBehaviorRoot` from `octane/behavior`. Behavior-only roots attach native
+interactions and disposable behavior without creating a component root or
+taking ownership of the existing markup. See the
+[external ownership guide](https://github.com/octanejs/octane/blob/main/docs/deferred-hydration.md#behavior-only-roots-and-external-ownership).
+
 For the full story, see the
 [main README](https://github.com/octanejs/octane#readme).
 

--- a/packages/octane/package.json
+++ b/packages/octane/package.json
@@ -35,6 +35,7 @@
     "./tsrx-spread": "./src/tsrx-spread.ts",
     "./react": "./src/react/index.ts",
     "./hydration": "./src/hydration/index.ts",
+    "./behavior": "./src/behavior-root.ts",
     "./react/server": "./src/react/server.ts",
     "./server": "./src/server/index.ts",
     "./static": "./src/static/index.ts",
@@ -84,6 +85,10 @@
       "./hydration": {
         "types": "./dist/hydration/index.d.ts",
         "default": "./dist/hydration/index.js"
+      },
+      "./behavior": {
+        "types": "./dist/behavior-root.d.ts",
+        "default": "./dist/behavior-root.js"
       },
       "./react/server": {
         "types": "./dist/react/server.d.ts",

--- a/packages/octane/scripts/verify-dist.mjs
+++ b/packages/octane/scripts/verify-dist.mjs
@@ -39,6 +39,7 @@ export const REQUIRED_PUBLIC_VALUE_EXPORTS = {
 		'act',
 		'activityBlock',
 		'addTransitionType',
+		'attachBehaviorRoot',
 		'attachRef',
 		'bag0',
 		'bag1',
@@ -204,6 +205,7 @@ export const REQUIRED_PUBLIC_VALUE_EXPORTS = {
 		'never',
 		'visible',
 	],
+	'./behavior': ['attachBehaviorRoot'],
 	'./react/server': ['OctaneCompat'],
 	'./server': [
 		'Activity',

--- a/packages/octane/src/behavior-root.ts
+++ b/packages/octane/src/behavior-root.ts
@@ -499,7 +499,7 @@ function ensureObserver(root: RootRecord): void {
 		// final containment before cleanup so a move preserves its live adoption.
 		for (const record of [...root.behaviors]) reconcileBehavior(record);
 	});
-	root.observer.observe(root.container, { childList: true, subtree: true });
+	root.observer.observe(root.container, { attributes: true, childList: true, subtree: true });
 }
 
 function targetElement(event: Event): Element | null {

--- a/packages/octane/src/behavior-root.ts
+++ b/packages/octane/src/behavior-root.ts
@@ -1,0 +1,928 @@
+/** A behavior-only root observes existing DOM without taking reconciliation ownership. */
+export interface BehaviorRootOptions {
+	/** Dispose this root when the enclosing page or document lifetime ends. */
+	signal?: AbortSignal;
+	/** Explicitly dispose an existing behavior root attached to this container. */
+	replace?: boolean;
+}
+
+export interface BehaviorDisposeOptions {
+	/** Existing DOM is retained unless its removal is explicitly requested. */
+	preserveDOM?: boolean;
+}
+
+export interface ExternalRangeOptions {
+	/** Identity of the component, stream, or application owning this subtree. */
+	owner: unknown;
+	/** Delay adoption until the independently owned stream is ready. */
+	ready?: PromiseLike<unknown>;
+	signal?: AbortSignal;
+	/** Explicitly hand the same subtree from its previous owner to this owner. */
+	replace?: boolean;
+}
+
+export interface ExternalRange {
+	readonly element: Element;
+	readonly owner: unknown;
+	readonly signal: AbortSignal;
+	readonly ready: Promise<void>;
+	dispose(): void;
+}
+
+export interface BehaviorContext {
+	/** Per-element lifetime, canceled when its adoption or registration ends. */
+	readonly signal: AbortSignal;
+	/** The original native interaction when adoption was started by that event. */
+	readonly event?: Event;
+	/** The closest externally owned range, if this target belongs to one. */
+	readonly range?: ExternalRange;
+}
+
+export type BehaviorCleanup = () => void;
+
+export interface BehaviorEntry {
+	id?: string;
+	target: string | Element;
+	/** Restrict adoption to the closest range belonging to this exact owner. */
+	owner?: unknown;
+	events?: readonly string[];
+	ready?: PromiseLike<unknown>;
+	dependencies?: readonly string[];
+	conflicts?: readonly string[];
+	signal?: AbortSignal;
+	adopt(
+		element: Element,
+		context: BehaviorContext,
+	): void | BehaviorCleanup | PromiseLike<void | BehaviorCleanup>;
+	handleEvent?(event: Event, element: Element, context: BehaviorContext): void;
+}
+
+export interface BehaviorRegistration {
+	readonly id?: string;
+	readonly signal: AbortSignal;
+	readonly ready: Promise<void>;
+	dispose(): void;
+}
+
+export interface BehaviorRoot {
+	readonly container: Element;
+	readonly signal: AbortSignal;
+	/** A snapshot of currently active ranges, registrations, and asynchronous adoptions. */
+	readonly ready: Promise<void>;
+	registerExternalRange(element: Element, options: ExternalRangeOptions): ExternalRange;
+	registerBehavior(entry: BehaviorEntry): BehaviorRegistration;
+	dispose(options?: BehaviorDisposeOptions): void;
+}
+
+type Readiness = {
+	promise: Promise<void>;
+	resolve: () => void;
+	reject: (reason: unknown) => void;
+	settled: boolean;
+};
+
+type DocumentRegistry = {
+	roots: Map<Element, RootRecord>;
+	ranges: Map<Element, RangeRecord>;
+};
+
+type RootRecord = {
+	container: Element;
+	document: Document;
+	registry: DocumentRegistry;
+	controller: AbortController;
+	behaviors: Set<EntryRecord>;
+	behaviorsById: Map<string, EntryRecord>;
+	ranges: Set<RangeRecord>;
+	pending: Set<Promise<void>>;
+	listeners: Map<string, EventListener>;
+	observer: MutationObserver | null;
+	disposed: boolean;
+	unlinkSignal: (() => void) | null;
+};
+
+type RangeRecord = {
+	root: RootRecord;
+	element: Element;
+	owner: unknown;
+	controller: AbortController;
+	readiness: Readiness;
+	status: 'pending' | 'ready' | 'failed' | 'disposed';
+	unlinks: Array<() => void>;
+	publicRange: ExternalRange;
+};
+
+type EntryRecord = {
+	root: RootRecord;
+	entry: BehaviorEntry;
+	controller: AbortController;
+	readiness: Readiness;
+	status: 'pending' | 'active' | 'failed' | 'disposed';
+	adoptions: Map<Element, AdoptionRecord>;
+	waitingRanges: Set<RangeRecord>;
+	queuedEvents: Array<{ event: Event; element: Element; range: RangeRecord | undefined }>;
+	unlinks: Array<() => void>;
+	initialScanComplete: boolean;
+};
+
+type AdoptionRecord = {
+	entry: EntryRecord;
+	element: Element;
+	range: RangeRecord | undefined;
+	controller: AbortController;
+	unlinks: Array<() => void>;
+	cleanup: BehaviorCleanup | undefined;
+	pending: boolean;
+	disposed: boolean;
+};
+
+const documentRegistries = /* @__PURE__ */ new WeakMap<Document, DocumentRegistry>();
+const CANCELED = /* @__PURE__ */ Symbol('octane.behavior.canceled');
+
+function createReadiness(): Readiness {
+	let resolvePromise!: () => void;
+	let rejectPromise!: (reason: unknown) => void;
+	const promise = new Promise<void>((resolve, reject) => {
+		resolvePromise = resolve;
+		rejectPromise = reject;
+	});
+	// A consumer may register a failing module without reading its handle. Keep
+	// the original promise rejectable while preventing host-level unhandled noise.
+	void promise.catch(() => undefined);
+	const readiness: Readiness = {
+		promise,
+		settled: false,
+		resolve() {
+			if (readiness.settled) return;
+			readiness.settled = true;
+			resolvePromise();
+		},
+		reject(reason) {
+			if (readiness.settled) return;
+			readiness.settled = true;
+			rejectPromise(reason);
+		},
+	};
+	return readiness;
+}
+
+function createController(document: Document): AbortController {
+	const Controller = document.defaultView?.AbortController ?? globalThis.AbortController;
+	return new Controller();
+}
+
+function linkSignal(signal: AbortSignal, controller: AbortController): () => void {
+	if (signal.aborted) {
+		controller.abort(signal.reason);
+		return () => undefined;
+	}
+	const abort = () => controller.abort(signal.reason);
+	signal.addEventListener('abort', abort, { once: true });
+	return () => signal.removeEventListener('abort', abort);
+}
+
+/** A never-settling third-party promise must not hold a canceled owner open. */
+function waitUntilReady(source: PromiseLike<unknown>, signal: AbortSignal): Promise<unknown> {
+	if (signal.aborted) {
+		// Attach both continuations even after cancellation: a retained third-party
+		// promise may still reject later and must not become an unhandled rejection.
+		void Promise.resolve(source).then(undefined, () => undefined);
+		return Promise.resolve(CANCELED);
+	}
+	return new Promise((resolve, reject) => {
+		let settled = false;
+		const cancel = () => {
+			if (settled) return;
+			settled = true;
+			resolve(CANCELED);
+		};
+		signal.addEventListener('abort', cancel, { once: true });
+		Promise.resolve(source).then(
+			(value) => {
+				if (settled) return;
+				settled = true;
+				signal.removeEventListener('abort', cancel);
+				resolve(value);
+			},
+			(error) => {
+				if (settled) return;
+				settled = true;
+				signal.removeEventListener('abort', cancel);
+				reject(error);
+			},
+		);
+	});
+}
+
+function trackPending(root: RootRecord, promise: Promise<void>): void {
+	root.pending.add(promise);
+	void promise.then(
+		() => root.pending.delete(promise),
+		() => root.pending.delete(promise),
+	);
+}
+
+function isElement(value: unknown): value is Element {
+	return typeof value === 'object' && value !== null && (value as Node).nodeType === 1;
+}
+
+function contains(root: RootRecord, element: Element): boolean {
+	return (
+		element.ownerDocument === root.document &&
+		(element === root.container || root.container.contains(element))
+	);
+}
+
+function assertActiveRoot(root: RootRecord): void {
+	if (root.disposed || root.controller.signal.aborted) {
+		throw new Error('Cannot register behavior on a disposed behavior root.');
+	}
+}
+
+function assertContainedElement(
+	root: RootRecord,
+	element: unknown,
+	label: string,
+): asserts element is Element {
+	if (!isElement(element) || !contains(root, element)) {
+		throw new Error(`${label} must belong to the behavior root container and document.`);
+	}
+}
+
+function nearestRange(root: RootRecord, element: Element): RangeRecord | undefined {
+	let current: Element | null = element;
+	while (current !== null) {
+		const range = root.registry.ranges.get(current);
+		if (range !== undefined && range.status !== 'disposed' && range.status !== 'failed') {
+			return range;
+		}
+		if (current === root.container) return undefined;
+		current = current.parentElement;
+	}
+	return undefined;
+}
+
+function matchesTarget(record: EntryRecord, element: Element): boolean {
+	return typeof record.entry.target === 'string'
+		? element.matches(record.entry.target)
+		: record.entry.target === element;
+}
+
+function rangeMatches(record: EntryRecord, range: RangeRecord | undefined): boolean {
+	return (
+		record.entry.owner === undefined ||
+		(range !== undefined && Object.is(record.entry.owner, range.owner))
+	);
+}
+
+function dependsOnRange(record: EntryRecord, range: RangeRecord): boolean {
+	if (record.waitingRanges.has(range)) return true;
+	if (
+		record.entry.owner === undefined ||
+		!Object.is(record.entry.owner, range.owner) ||
+		!contains(record.root, range.element)
+	) {
+		return false;
+	}
+	if (typeof record.entry.target !== 'string') {
+		return (
+			range.element.contains(record.entry.target) &&
+			nearestRange(record.root, record.entry.target) === range
+		);
+	}
+	if (
+		range.element.matches(record.entry.target) &&
+		nearestRange(record.root, range.element) === range
+	) {
+		return true;
+	}
+	for (const element of range.element.querySelectorAll(record.entry.target)) {
+		if (nearestRange(record.root, element) === range) return true;
+	}
+	return false;
+}
+
+function adoptionContext(adoption: AdoptionRecord, event?: Event): BehaviorContext {
+	const context: BehaviorContext = {
+		signal: adoption.controller.signal,
+		...(adoption.range === undefined ? {} : { range: adoption.range.publicRange }),
+		...(event === undefined ? {} : { event }),
+	};
+	return context;
+}
+
+function disposeAdoption(adoption: AdoptionRecord): void {
+	if (adoption.disposed) return;
+	adoption.disposed = true;
+	adoption.entry.adoptions.delete(adoption.element);
+	adoption.controller.abort();
+	for (const unlink of adoption.unlinks) unlink();
+	adoption.unlinks.length = 0;
+	const cleanup = adoption.cleanup;
+	adoption.cleanup = undefined;
+	cleanup?.();
+}
+
+function flushQueuedEvents(record: EntryRecord): void {
+	if (record.status !== 'active') return;
+	while (record.queuedEvents.length !== 0) {
+		const queued = record.queuedEvents[0];
+		if (!contains(record.root, queued.element)) {
+			record.queuedEvents.shift();
+			continue;
+		}
+		const range = nearestRange(record.root, queued.element);
+		if (range !== queued.range || !rangeMatches(record, range)) {
+			record.queuedEvents.shift();
+			continue;
+		}
+		if (range?.status === 'pending') return;
+		let adoption = record.adoptions.get(queued.element);
+		if (adoption === undefined) {
+			adoption = adoptElement(record, queued.element, range, queued.event);
+		}
+		if (adoption === undefined || adoption.pending) return;
+		record.queuedEvents.shift();
+		record.entry.handleEvent?.(
+			queued.event,
+			queued.element,
+			adoptionContext(adoption, queued.event),
+		);
+	}
+}
+
+function completeBehavior(record: EntryRecord): void {
+	if (record.status !== 'active' || !record.initialScanComplete) return;
+	for (const range of [...record.waitingRanges]) {
+		if (range.status === 'pending') return;
+		record.waitingRanges.delete(range);
+	}
+	for (const adoption of record.adoptions.values()) {
+		if (adoption.pending) return;
+	}
+	flushQueuedEvents(record);
+	if (record.queuedEvents.length !== 0) return;
+	record.readiness.resolve();
+}
+
+function failBehavior(record: EntryRecord, error: unknown): void {
+	if (record.status === 'disposed' || record.status === 'failed') return;
+	record.status = 'failed';
+	record.readiness.reject(error);
+	disposeBehavior(record);
+}
+
+function adoptElement(
+	record: EntryRecord,
+	element: Element,
+	range: RangeRecord | undefined,
+	event?: Event,
+): AdoptionRecord | undefined {
+	if (
+		record.status !== 'active' ||
+		!contains(record.root, element) ||
+		!rangeMatches(record, range)
+	) {
+		return undefined;
+	}
+	if (range?.status === 'pending') {
+		record.waitingRanges.add(range);
+		return undefined;
+	}
+	const existing = record.adoptions.get(element);
+	if (existing !== undefined) return existing;
+	const controller = createController(record.root.document);
+	const adoption: AdoptionRecord = {
+		entry: record,
+		element,
+		range,
+		controller,
+		unlinks: [linkSignal(record.controller.signal, controller)],
+		cleanup: undefined,
+		pending: false,
+		disposed: false,
+	};
+	if (range !== undefined) adoption.unlinks.push(linkSignal(range.controller.signal, controller));
+	if (controller.signal.aborted) return undefined;
+	record.adoptions.set(element, adoption);
+	let result: ReturnType<BehaviorEntry['adopt']>;
+	try {
+		result = record.entry.adopt(element, adoptionContext(adoption, event));
+	} catch (error) {
+		disposeAdoption(adoption);
+		failBehavior(record, error);
+		return undefined;
+	}
+	if (typeof result === 'function') {
+		if (adoption.disposed || controller.signal.aborted) result();
+		else adoption.cleanup = result;
+		return adoption;
+	}
+	if (typeof result === 'object' && result !== null && typeof result.then === 'function') {
+		adoption.pending = true;
+		// The underlying adoption must still be observed after cancellation so a
+		// late cleanup can run exactly once, but public readiness races its signal.
+		const settled = Promise.resolve(result).then(
+			(cleanup) => {
+				adoption.pending = false;
+				if (typeof cleanup === 'function') {
+					if (adoption.disposed || adoption.controller.signal.aborted) cleanup();
+					else adoption.cleanup = cleanup;
+				}
+				if (!adoption.disposed) {
+					flushQueuedEvents(record);
+					completeBehavior(record);
+				}
+			},
+			(error) => {
+				adoption.pending = false;
+				if (adoption.disposed || record.controller.signal.aborted) return;
+				disposeAdoption(adoption);
+				failBehavior(record, error);
+			},
+		);
+		const cancelable = waitUntilReady(settled, adoption.controller.signal).then(() => undefined);
+		trackPending(record.root, cancelable);
+	}
+	return adoption;
+}
+
+function reconcileBehavior(record: EntryRecord): void {
+	if (record.status !== 'active') return;
+	record.waitingRanges.clear();
+	for (const [element, adoption] of [...record.adoptions]) {
+		const range = contains(record.root, element) ? nearestRange(record.root, element) : undefined;
+		if (
+			!contains(record.root, element) ||
+			!matchesTarget(record, element) ||
+			!rangeMatches(record, range) ||
+			range !== adoption.range ||
+			range?.status === 'pending'
+		) {
+			disposeAdoption(adoption);
+		}
+	}
+	let elements: Element[];
+	if (typeof record.entry.target === 'string') {
+		elements = Array.from(record.root.container.querySelectorAll(record.entry.target));
+		if (record.root.container.matches(record.entry.target)) elements.unshift(record.root.container);
+	} else {
+		elements = contains(record.root, record.entry.target) ? [record.entry.target] : [];
+	}
+	for (const element of elements) {
+		const range = nearestRange(record.root, element);
+		if (!rangeMatches(record, range)) continue;
+		if (range?.status === 'pending') {
+			record.waitingRanges.add(range);
+			continue;
+		}
+		adoptElement(record, element, range);
+	}
+	record.initialScanComplete = true;
+	completeBehavior(record);
+}
+
+function refreshDocument(registry: DocumentRegistry): void {
+	for (const root of [...registry.roots.values()]) {
+		if (root.disposed) continue;
+		for (const record of [...root.behaviors]) reconcileBehavior(record);
+	}
+}
+
+function ensureObserver(root: RootRecord): void {
+	if (root.observer !== null || root.disposed) return;
+	const Observer = root.document.defaultView?.MutationObserver ?? globalThis.MutationObserver;
+	if (Observer === undefined) return;
+	root.observer = new Observer(() => {
+		if (root.disposed) return;
+		// MutationObserver delivers both sides of a same-tree move together. Check
+		// final containment before cleanup so a move preserves its live adoption.
+		for (const record of [...root.behaviors]) reconcileBehavior(record);
+	});
+	root.observer.observe(root.container, { childList: true, subtree: true });
+}
+
+function targetElement(event: Event): Element | null {
+	const target = event.target;
+	if (!target || typeof (target as Node).nodeType !== 'number') return null;
+	return (target as Node).nodeType === 1
+		? (target as Element)
+		: ((target as Node).parentElement ?? null);
+}
+
+function handleDelegatedEvent(root: RootRecord, event: Event): void {
+	if (root.disposed) return;
+	const target = targetElement(event);
+	if (target === null || !contains(root, target)) return;
+	for (const record of [...root.behaviors]) {
+		if (
+			record.status === 'disposed' ||
+			record.status === 'failed' ||
+			!record.entry.events?.includes(event.type)
+		) {
+			continue;
+		}
+		let matched: Element | null = target;
+		while (matched !== null && contains(root, matched) && !matchesTarget(record, matched)) {
+			if (matched === root.container) {
+				matched = null;
+				break;
+			}
+			matched = matched.parentElement;
+		}
+		if (matched === null || !contains(root, matched)) continue;
+		const range = nearestRange(root, matched);
+		if (!rangeMatches(record, range)) continue;
+		if (record.status !== 'active' || range?.status === 'pending') {
+			record.queuedEvents.push({ event, element: matched, range });
+			if (range?.status === 'pending') record.waitingRanges.add(range);
+			continue;
+		}
+		const adoption = record.adoptions.get(matched) ?? adoptElement(record, matched, range, event);
+		if (adoption === undefined || adoption.pending || record.queuedEvents.length !== 0) {
+			record.queuedEvents.push({ event, element: matched, range });
+			flushQueuedEvents(record);
+			continue;
+		}
+		record.entry.handleEvent?.(event, matched, adoptionContext(adoption, event));
+	}
+}
+
+function installListeners(root: RootRecord, events: readonly string[] | undefined): void {
+	if (events === undefined) return;
+	for (const event of new Set(events)) {
+		if (typeof event !== 'string' || event.length === 0) {
+			throw new Error('Behavior event names must be non-empty strings.');
+		}
+		if (root.listeners.has(event)) continue;
+		const listener: EventListener = (nativeEvent) => handleDelegatedEvent(root, nativeEvent);
+		root.listeners.set(event, listener);
+		root.container.addEventListener(event, listener, true);
+	}
+}
+
+function removeUnusedListeners(root: RootRecord): void {
+	for (const [event, listener] of root.listeners) {
+		let used = false;
+		for (const record of root.behaviors) {
+			if (record.entry.events?.includes(event)) {
+				used = true;
+				break;
+			}
+		}
+		if (used) continue;
+		root.container.removeEventListener(event, listener, true);
+		root.listeners.delete(event);
+	}
+	if (root.behaviors.size === 0) {
+		root.observer?.disconnect();
+		root.observer = null;
+	}
+}
+
+function disposeBehavior(record: EntryRecord): void {
+	if (record.status === 'disposed') return;
+	const failed = record.status === 'failed';
+	record.status = 'disposed';
+	record.controller.abort();
+	for (const unlink of record.unlinks) unlink();
+	record.unlinks.length = 0;
+	record.root.behaviors.delete(record);
+	if (record.entry.id !== undefined && record.root.behaviorsById.get(record.entry.id) === record) {
+		record.root.behaviorsById.delete(record.entry.id);
+	}
+	record.queuedEvents.length = 0;
+	record.waitingRanges.clear();
+	let firstError: unknown;
+	for (const adoption of [...record.adoptions.values()]) {
+		try {
+			disposeAdoption(adoption);
+		} catch (error) {
+			firstError ??= error;
+		}
+	}
+	if (!failed) record.readiness.resolve();
+	removeUnusedListeners(record.root);
+	if (firstError !== undefined) throw firstError;
+}
+
+function activateBehavior(record: EntryRecord): void {
+	if (record.status !== 'pending' || record.controller.signal.aborted) return;
+	record.status = 'active';
+	reconcileBehavior(record);
+}
+
+function registerBehavior(root: RootRecord, entry: BehaviorEntry): BehaviorRegistration {
+	assertActiveRoot(root);
+	if (entry === null || typeof entry !== 'object' || typeof entry.adopt !== 'function') {
+		throw new Error('A behavior entry requires an adopt(element, context) function.');
+	}
+	if (typeof entry.target !== 'string') {
+		assertContainedElement(root, entry.target, 'A behavior target');
+	} else {
+		// Validate selector syntax synchronously, before claiming any registration.
+		root.container.matches(entry.target);
+	}
+	if (entry.id !== undefined && root.behaviorsById.has(entry.id)) {
+		throw new Error(`A behavior with identity ${JSON.stringify(entry.id)} is already registered.`);
+	}
+	const dependencies: EntryRecord[] = [];
+	for (const id of entry.dependencies ?? []) {
+		const dependency = root.behaviorsById.get(id);
+		if (dependency === undefined) {
+			throw new Error(`Behavior dependency ${JSON.stringify(id)} is not registered.`);
+		}
+		dependencies.push(dependency);
+	}
+	for (const existing of root.behaviors) {
+		if (
+			(entry.id !== undefined && existing.entry.conflicts?.includes(entry.id)) ||
+			(existing.entry.id !== undefined && entry.conflicts?.includes(existing.entry.id))
+		) {
+			throw new Error('The requested behavior conflicts with an existing behavior registration.');
+		}
+	}
+	const controller = createController(root.document);
+	const readiness = createReadiness();
+	const record: EntryRecord = {
+		root,
+		entry,
+		controller,
+		readiness,
+		status: 'pending',
+		adoptions: new Map(),
+		waitingRanges: new Set(),
+		queuedEvents: [],
+		unlinks: [linkSignal(root.controller.signal, controller)],
+		initialScanComplete: false,
+	};
+	const registration: BehaviorRegistration = {
+		...(entry.id === undefined ? {} : { id: entry.id }),
+		signal: controller.signal,
+		ready: readiness.promise,
+		dispose: () => disposeBehavior(record),
+	};
+	if (entry.signal !== undefined) record.unlinks.push(linkSignal(entry.signal, controller));
+	if (controller.signal.aborted) {
+		disposeBehavior(record);
+		return registration;
+	}
+	root.behaviors.add(record);
+	if (entry.id !== undefined) root.behaviorsById.set(entry.id, record);
+	controller.signal.addEventListener('abort', () => disposeBehavior(record), { once: true });
+	try {
+		installListeners(root, entry.events);
+		ensureObserver(root);
+	} catch (error) {
+		disposeBehavior(record);
+		throw error;
+	}
+	const blockers: PromiseLike<unknown>[] = [];
+	if (entry.ready !== undefined) blockers.push(entry.ready);
+	for (const dependency of dependencies) {
+		if (!dependency.readiness.settled) blockers.push(dependency.readiness.promise);
+	}
+	if (blockers.length === 0) {
+		activateBehavior(record);
+	} else {
+		const gate = Promise.all(
+			blockers.map((blocker) => waitUntilReady(blocker, controller.signal)),
+		).then(
+			(results) => {
+				if (results.includes(CANCELED) || controller.signal.aborted) return;
+				activateBehavior(record);
+			},
+			(error) => {
+				if (!controller.signal.aborted) failBehavior(record, error);
+			},
+		);
+		trackPending(root, gate);
+	}
+	return registration;
+}
+
+function disposeRange(record: RangeRecord): void {
+	if (record.status === 'disposed') return;
+	const failed = record.status === 'failed';
+	record.status = 'disposed';
+	record.controller.abort();
+	for (const unlink of record.unlinks) unlink();
+	record.unlinks.length = 0;
+	record.root.ranges.delete(record);
+	if (record.root.registry.ranges.get(record.element) === record) {
+		record.root.registry.ranges.delete(record.element);
+	}
+	if (!failed) record.readiness.resolve();
+	if (!record.root.disposed) refreshDocument(record.root.registry);
+}
+
+function registerExternalRange(
+	root: RootRecord,
+	element: Element,
+	options: ExternalRangeOptions,
+): ExternalRange {
+	assertActiveRoot(root);
+	assertContainedElement(root, element, 'An externally owned range');
+	if (options === null || typeof options !== 'object' || !('owner' in options)) {
+		throw new Error('An external range requires an explicit owner identity.');
+	}
+	const existing = root.registry.ranges.get(element);
+	if (existing !== undefined) {
+		if (existing.root === root && Object.is(existing.owner, options.owner) && !options.replace) {
+			return existing.publicRange;
+		}
+		if (!options.replace) {
+			throw new Error('External ownership conflict: pass replace: true to hand this range off.');
+		}
+		if (!options.signal?.aborted) disposeRange(existing);
+	}
+	const controller = createController(root.document);
+	const readiness = createReadiness();
+	const record: RangeRecord = {
+		root,
+		element,
+		owner: options.owner,
+		controller,
+		readiness,
+		status: options.ready === undefined ? 'ready' : 'pending',
+		unlinks: [linkSignal(root.controller.signal, controller)],
+		publicRange: undefined as unknown as ExternalRange,
+	};
+	const range: ExternalRange = {
+		element,
+		owner: options.owner,
+		signal: controller.signal,
+		ready: readiness.promise,
+		dispose: () => disposeRange(record),
+	};
+	record.publicRange = range;
+	if (options.signal !== undefined) record.unlinks.push(linkSignal(options.signal, controller));
+	if (controller.signal.aborted) {
+		disposeRange(record);
+		return range;
+	}
+	root.ranges.add(record);
+	root.registry.ranges.set(element, record);
+	controller.signal.addEventListener('abort', () => disposeRange(record), { once: true });
+	refreshDocument(root.registry);
+	if (options.ready === undefined) {
+		readiness.resolve();
+	} else {
+		const gate = waitUntilReady(options.ready, controller.signal).then(
+			(result) => {
+				if (result === CANCELED || record.status !== 'pending') return;
+				record.status = 'ready';
+				refreshDocument(root.registry);
+				readiness.resolve();
+			},
+			(error) => {
+				if (controller.signal.aborted || record.status !== 'pending') return;
+				try {
+					for (const candidateRoot of [...root.registry.roots.values()]) {
+						for (const behavior of [...candidateRoot.behaviors]) {
+							if (!dependsOnRange(behavior, record)) continue;
+							try {
+								failBehavior(behavior, error);
+							} catch {
+								// An adoption cleanup must not replace the originating stream
+								// failure or prevent another affected owner from releasing.
+							}
+						}
+					}
+				} finally {
+					record.status = 'failed';
+					readiness.reject(error);
+					try {
+						disposeRange(record);
+					} catch {
+						// Refresh callbacks are secondary to releasing the failed range
+						// and preserving its original public readiness failure.
+					}
+				}
+			},
+		);
+		trackPending(root, gate);
+	}
+	return range;
+}
+
+function disposeRoot(root: RootRecord, options: BehaviorDisposeOptions = {}): void {
+	if (root.disposed) return;
+	const releasedExternalOwnership = root.ranges.size !== 0;
+	root.disposed = true;
+	root.controller.abort();
+	root.unlinkSignal?.();
+	root.unlinkSignal = null;
+	root.observer?.disconnect();
+	root.observer = null;
+	let firstError: unknown;
+	for (const behavior of [...root.behaviors]) {
+		try {
+			disposeBehavior(behavior);
+		} catch (error) {
+			firstError ??= error;
+		}
+	}
+	for (const range of [...root.ranges]) {
+		try {
+			disposeRange(range);
+		} catch (error) {
+			firstError ??= error;
+		}
+	}
+	for (const [event, listener] of root.listeners) {
+		root.container.removeEventListener(event, listener, true);
+	}
+	root.listeners.clear();
+	if (root.registry.roots.get(root.container) === root) {
+		root.registry.roots.delete(root.container);
+	}
+	if (root.registry.roots.size === 0 && root.registry.ranges.size === 0) {
+		documentRegistries.delete(root.document);
+	}
+	if (options.preserveDOM === false) root.container.replaceChildren();
+	if (releasedExternalOwnership && root.registry.roots.size !== 0) {
+		try {
+			refreshDocument(root.registry);
+		} catch (error) {
+			firstError ??= error;
+		}
+	}
+	if (firstError !== undefined) throw firstError;
+}
+
+/**
+ * Attach behavior to existing DOM without rendering, replacing, or reconciling it.
+ * Every owner, observer, listener, and constructor is scoped to the container's
+ * own Document, including elements imported from another JavaScript realm.
+ */
+export function attachBehaviorRoot(
+	container: Element,
+	options: BehaviorRootOptions = {},
+): BehaviorRoot {
+	if (!isElement(container) || container.ownerDocument === null) {
+		throw new Error('A behavior root requires an element with an owner document.');
+	}
+	const document = container.ownerDocument;
+	let registry = documentRegistries.get(document);
+	if (registry === undefined) {
+		registry = { roots: new Map(), ranges: new Map() };
+		documentRegistries.set(document, registry);
+	}
+	const existing = registry.roots.get(container);
+	const canceledReplacement = existing !== undefined && options.replace && options.signal?.aborted;
+	if (existing !== undefined) {
+		if (!options.replace) {
+			throw new Error(
+				'This container already has a behavior root; pass replace: true to replace it.',
+			);
+		}
+		if (!canceledReplacement) {
+			disposeRoot(existing);
+			registry = documentRegistries.get(document);
+			if (registry === undefined) {
+				registry = { roots: new Map(), ranges: new Map() };
+				documentRegistries.set(document, registry);
+			}
+		}
+	}
+	const controller = createController(document);
+	const record: RootRecord = {
+		container,
+		document,
+		registry,
+		controller,
+		behaviors: new Set(),
+		behaviorsById: new Map(),
+		ranges: new Set(),
+		pending: new Set(),
+		listeners: new Map(),
+		observer: null,
+		disposed: false,
+		unlinkSignal: null,
+	};
+	const root: BehaviorRoot = {
+		container,
+		signal: controller.signal,
+		get ready() {
+			const waiting: Promise<void>[] = [...record.pending];
+			for (const range of record.ranges) waiting.push(range.readiness.promise);
+			for (const behavior of record.behaviors) waiting.push(behavior.readiness.promise);
+			const ready = Promise.all(waiting).then(() => undefined);
+			void ready.catch(() => undefined);
+			return ready;
+		},
+		registerExternalRange: (element, rangeOptions) =>
+			registerExternalRange(record, element, rangeOptions),
+		registerBehavior: (entry) => registerBehavior(record, entry),
+		dispose: (disposeOptions) => disposeRoot(record, disposeOptions),
+	};
+	if (!canceledReplacement) registry.roots.set(container, record);
+	if (options.signal !== undefined) record.unlinkSignal = linkSignal(options.signal, controller);
+	if (controller.signal.aborted) {
+		disposeRoot(record);
+	} else {
+		controller.signal.addEventListener('abort', () => disposeRoot(record), { once: true });
+	}
+	return root;
+}

--- a/packages/octane/src/index.ts
+++ b/packages/octane/src/index.ts
@@ -2,6 +2,10 @@
 // read `version` can tree-shake this module and the package.json payload in full.
 export { version } from './version.js';
 export { initializeHydrationEventCapture } from './hydration/event-capture.js';
+// Keep external DOM ownership separate from the reconciling runtime so
+// behavior-only consumers never retain component or hydration machinery.
+export { attachBehaviorRoot } from './behavior-root.js';
+export type * from './behavior-root.js';
 
 // Profiling's application API and compiler ABI live at `octane/profiling`;
 // neither belongs on the React-shaped main namespace.

--- a/packages/octane/tests/behavior-root-bundle.test.ts
+++ b/packages/octane/tests/behavior-root-bundle.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+
+import { resolve, sep } from 'node:path';
+import { build } from 'esbuild';
+import { JSDOM } from 'jsdom';
+import { describe, expect, it } from 'vitest';
+
+async function bundleConsumer(contents: string) {
+	const result = await build({
+		stdin: {
+			contents,
+			loader: 'ts',
+			resolveDir: resolve(import.meta.dirname, '..'),
+			sourcefile: 'behavior-consumer.ts',
+		},
+		bundle: true,
+		define: { 'process.env.NODE_ENV': JSON.stringify('production') },
+		format: 'esm',
+		logLevel: 'silent',
+		metafile: true,
+		minify: true,
+		platform: 'browser',
+		target: 'esnext',
+		treeShaking: true,
+		write: false,
+	});
+
+	return {
+		contents: result.outputFiles[0].contents,
+		inputs: Object.entries(Object.values(result.metafile.outputs)[0].inputs)
+			.filter(([, metadata]) => metadata.bytesInOutput > 0)
+			.map(([input]) => input.split(sep).join('/')),
+	};
+}
+
+describe('production behavior-root entry points', () => {
+	for (const entry of ['octane', 'octane/behavior']) {
+		it(`${entry} attaches behavior without retaining a renderer`, async () => {
+			const bundle = await bundleConsumer(`export { attachBehaviorRoot } from '${entry}';`);
+			const { attachBehaviorRoot } = (await import(
+				`data:text/javascript;base64,${Buffer.from(bundle.contents).toString('base64')}`
+			)) as typeof import('../src/behavior-root.js');
+			const document = new JSDOM('<main><button>Existing</button></main>').window.document;
+			const container = document.querySelector('main')!;
+			const existing = container.firstElementChild;
+			const root = attachBehaviorRoot(container);
+
+			expect(container.firstElementChild).toBe(existing);
+			expect(bundle.inputs).toEqual(
+				expect.arrayContaining([
+					expect.stringMatching(/packages\/octane\/src\/behavior-root\.ts$/),
+				]),
+			);
+			expect(
+				bundle.inputs.some((input) =>
+					/\/packages\/octane\/src\/(?:runtime(?:\.server)?\.ts|compiler\/|server\/)/.test(input),
+				),
+			).toBe(false);
+
+			root.dispose();
+			expect(container.firstElementChild).toBe(existing);
+		});
+	}
+
+	it('does not retain behavior ownership in ordinary component-root bundles', async () => {
+		const bundle = await bundleConsumer("export { createRoot } from 'octane';");
+
+		expect(bundle.inputs.some((input) => /\/behavior-root\.ts$/.test(input))).toBe(false);
+	});
+});

--- a/packages/octane/tests/behavior-root.test.ts
+++ b/packages/octane/tests/behavior-root.test.ts
@@ -1,0 +1,1326 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { attachBehaviorRoot, flushSync, hydrateRoot } from 'octane';
+import { renderToReadableStream, renderToString } from 'octane/server';
+import { flushEffects } from './_helpers.js';
+import { loadServerFixture } from './_server-fixture.js';
+import * as staticClient from './hydration/_fixtures/deferred-hydration-static.tsrx';
+
+const STATIC_FIXTURE = 'packages/octane/tests/hydration/_fixtures/deferred-hydration-static.tsrx';
+const staticServer = loadServerFixture<typeof staticClient>(STATIC_FIXTURE);
+
+function deferred<T>(): {
+	promise: Promise<T>;
+	resolve: (value: T | PromiseLike<T>) => void;
+	reject: (reason?: unknown) => void;
+} {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((complete, fail) => {
+		resolve = complete;
+		reject = fail;
+	});
+	return { promise, resolve, reject };
+}
+
+describe('behavior-only roots', () => {
+	let container: HTMLElement;
+	let roots: Array<ReturnType<typeof attachBehaviorRoot>>;
+	let hydratedRoot: ReturnType<typeof hydrateRoot> | undefined;
+
+	function attach(
+		target: Element = container,
+		options?: Parameters<typeof attachBehaviorRoot>[1],
+	): ReturnType<typeof attachBehaviorRoot> {
+		const root = attachBehaviorRoot(target, options);
+		roots.push(root);
+		return root;
+	}
+
+	beforeEach(() => {
+		container = document.createElement('main');
+		document.body.appendChild(container);
+		roots = [];
+		hydratedRoot = undefined;
+	});
+
+	afterEach(() => {
+		for (const root of roots) root.dispose();
+		hydratedRoot?.unmount();
+		container.remove();
+	});
+
+	it('attaches to existing DOM without replacing nodes or mutating protected attributes', async () => {
+		container.setAttribute('data-external-owner', 'stream');
+		container.innerHTML =
+			'<article id="existing" data-owned="server" aria-live="polite"><button>Action</button></article>';
+		const article = container.firstElementChild!;
+		const button = article.firstElementChild!;
+		const initialMarkup = container.innerHTML;
+		const initialAttributes = [...container.attributes].map(({ name, value }) => [name, value]);
+
+		const root = attach();
+		await root.ready;
+
+		expect(root.container).toBe(container);
+		expect(root.signal.aborted).toBe(false);
+		expect(container.innerHTML).toBe(initialMarkup);
+		expect([...container.attributes].map(({ name, value }) => [name, value])).toEqual(
+			initialAttributes,
+		);
+		expect(container.firstElementChild).toBe(article);
+		expect(article.firstElementChild).toBe(button);
+		expect(article.getAttribute('data-owned')).toBe('server');
+		expect(article.getAttribute('aria-live')).toBe('polite');
+	});
+
+	it('preserves externally owned DOM when disposed by default', async () => {
+		container.innerHTML = '<section data-owner="stream"><button>Action</button></section>';
+		const section = container.firstElementChild!;
+		const button = section.firstElementChild!;
+		const cleanup = vi.fn();
+		const root = attach();
+		const registration = root.registerBehavior({
+			target: 'button',
+			adopt: () => cleanup,
+		});
+		await registration.ready;
+
+		root.dispose();
+		root.dispose();
+		registration.dispose();
+
+		expect(root.signal.aborted).toBe(true);
+		expect(registration.signal.aborted).toBe(true);
+		expect(cleanup).toHaveBeenCalledOnce();
+		expect(container.firstElementChild).toBe(section);
+		expect(section.firstElementChild).toBe(button);
+		expect(section.getAttribute('data-owner')).toBe('stream');
+	});
+
+	it('removes externally managed descendants only when explicitly requested', () => {
+		container.innerHTML = '<article><button>Action</button></article>';
+		const root = attach();
+
+		root.dispose({ preserveDOM: false });
+
+		expect(root.signal.aborted).toBe(true);
+		expect(container.isConnected).toBe(true);
+		expect(container.childNodes).toHaveLength(0);
+	});
+
+	it('adopts selector targets and an explicitly supplied element without rendering', async () => {
+		container.innerHTML =
+			'<button id="first" data-action>First</button><button id="second" data-action>Second</button>';
+		const first = container.querySelector('#first')!;
+		const second = container.querySelector('#second')!;
+		const adopted = vi.fn();
+		const explicitlyAdopted = vi.fn();
+		const root = attach();
+		const selected = root.registerBehavior({
+			id: 'selector',
+			target: '[data-action]',
+			adopt: adopted,
+		});
+		const explicit = root.registerBehavior({
+			id: 'explicit',
+			target: second,
+			adopt: explicitlyAdopted,
+		});
+
+		await Promise.all([selected.ready, explicit.ready, root.ready]);
+
+		expect(adopted.mock.calls.map(([element]) => element)).toEqual([first, second]);
+		expect(explicitlyAdopted.mock.calls.map(([element]) => element)).toEqual([second]);
+		expect(container.children).toHaveLength(2);
+		expect(container.children[0]).toBe(first);
+		expect(container.children[1]).toBe(second);
+	});
+
+	it('adopts streamed insertions and cleans up removed nodes exactly once', async () => {
+		container.innerHTML = '<section><button id="initial" data-action>Initial</button></section>';
+		const section = container.firstElementChild!;
+		const initial = section.firstElementChild!;
+		const adopted: Element[] = [];
+		const cleaned: Element[] = [];
+		const root = attach();
+		const registration = root.registerBehavior({
+			target: '[data-action]',
+			adopt(element) {
+				adopted.push(element);
+				return () => cleaned.push(element);
+			},
+		});
+		await registration.ready;
+
+		const streamed = document.createElement('button');
+		streamed.id = 'streamed';
+		streamed.setAttribute('data-action', '');
+		streamed.textContent = 'Streamed';
+		section.appendChild(streamed);
+		await vi.waitFor(() => expect(adopted).toEqual([initial, streamed]));
+
+		initial.remove();
+		await vi.waitFor(() => expect(cleaned).toEqual([initial]));
+		registration.dispose();
+		registration.dispose();
+
+		expect(cleaned).toEqual([initial, streamed]);
+		expect(section.firstElementChild).toBe(streamed);
+	});
+
+	it('updates :empty behavior when streamed mutations add or remove only text nodes', async () => {
+		container.innerHTML = '<section id="streamed-text"></section>';
+		const range = container.firstElementChild!;
+		const adopted: Element[] = [];
+		const cleaned: Element[] = [];
+		const root = attach();
+		const behavior = root.registerBehavior({
+			target: '#streamed-text:empty',
+			adopt(element) {
+				adopted.push(element);
+				return () => cleaned.push(element);
+			},
+		});
+		await behavior.ready;
+		expect(adopted).toEqual([range]);
+
+		const streamedText = document.createTextNode('Progressively streamed text');
+		range.appendChild(streamedText);
+		await vi.waitFor(() => expect(cleaned).toEqual([range]));
+		expect(range.firstChild).toBe(streamedText);
+		expect(range.textContent).toBe('Progressively streamed text');
+
+		streamedText.remove();
+		await vi.waitFor(() => expect(adopted).toEqual([range, range]));
+		expect(range.matches(':empty')).toBe(true);
+	});
+
+	it('keeps an existing adoption when its node moves inside the same ownership range', async () => {
+		container.innerHTML =
+			'<section id="left"><button data-action>Move</button></section><section id="right"></section>';
+		const button = container.querySelector('button')!;
+		const right = container.querySelector('#right')!;
+		const cleanup = vi.fn();
+		const adopt = vi.fn(() => cleanup);
+		const root = attach();
+		const registration = root.registerBehavior({ target: '[data-action]', adopt });
+		await registration.ready;
+
+		right.appendChild(button);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(right.firstElementChild).toBe(button);
+		expect(adopt).toHaveBeenCalledOnce();
+		expect(cleanup).not.toHaveBeenCalled();
+
+		root.dispose();
+		expect(cleanup).toHaveBeenCalledOnce();
+	});
+
+	it('waits for an external range while preserving mutations before and during readiness', async () => {
+		container.innerHTML =
+			'<section data-stream><button id="stale" data-action>Stale</button></section>';
+		const range = container.firstElementChild!;
+		const owner = { name: 'stream' };
+		const streamSettled = deferred<void>();
+		const adopted = vi.fn();
+		const root = attach();
+		const ownership = root.registerExternalRange(range, {
+			owner,
+			ready: streamSettled.promise,
+		});
+		const behavior = root.registerBehavior({
+			id: 'stream-action',
+			owner,
+			target: '[data-action]',
+			adopt: adopted,
+		});
+
+		const inserted = document.createElement('button');
+		inserted.id = 'streamed';
+		inserted.setAttribute('data-action', '');
+		inserted.textContent = 'Inserted while pending';
+		range.replaceChildren(inserted);
+		await Promise.resolve();
+		expect(adopted).not.toHaveBeenCalled();
+		expect(range.firstElementChild).toBe(inserted);
+
+		streamSettled.resolve(undefined);
+		await Promise.all([ownership.ready, behavior.ready, root.ready]);
+
+		expect(adopted.mock.calls.map(([element]) => element)).toEqual([inserted]);
+		expect(range.firstElementChild).toBe(inserted);
+		expect(inserted.textContent).toBe('Inserted while pending');
+	});
+
+	it('adopts matching nodes when an owner range is registered after its behavior', async () => {
+		container.innerHTML = '<section><button data-action>Late range</button></section>';
+		const range = container.firstElementChild!;
+		const button = range.firstElementChild!;
+		const owner = { name: 'late-owner' };
+		const adopted = vi.fn();
+		const root = attach();
+		const behavior = root.registerBehavior({ owner, target: '[data-action]', adopt: adopted });
+
+		await Promise.resolve();
+		expect(adopted).not.toHaveBeenCalled();
+
+		const ownership = root.registerExternalRange(range, { owner });
+		await Promise.all([ownership.ready, behavior.ready]);
+		await vi.waitFor(() =>
+			expect(adopted.mock.calls.map(([element]) => element)).toEqual([button]),
+		);
+	});
+
+	it('gives a late nested range ownership over the closest matching descendants', async () => {
+		container.innerHTML =
+			'<section id="outer"><button id="outer-action" data-action>Outer</button><article id="inner"><button id="inner-action" data-action>Inner</button></article></section>';
+		const outer = container.querySelector('#outer')!;
+		const inner = container.querySelector('#inner')!;
+		const outerButton = container.querySelector('#outer-action')!;
+		const innerButton = container.querySelector('#inner-action')!;
+		const outerOwner = { name: 'outer' };
+		const innerOwner = { name: 'inner' };
+		const outerAdoptions: Element[] = [];
+		const outerCleanups: Element[] = [];
+		const innerAdoptions: Element[] = [];
+		const root = attach();
+		root.registerExternalRange(outer, { owner: outerOwner });
+		const outerBehavior = root.registerBehavior({
+			id: 'outer-actions',
+			owner: outerOwner,
+			target: '[data-action]',
+			adopt(element) {
+				outerAdoptions.push(element);
+				return () => outerCleanups.push(element);
+			},
+		});
+		await outerBehavior.ready;
+		expect(outerAdoptions).toEqual([outerButton, innerButton]);
+
+		root.registerExternalRange(inner, { owner: innerOwner });
+		const innerBehavior = root.registerBehavior({
+			id: 'inner-actions',
+			owner: innerOwner,
+			target: '[data-action]',
+			adopt(element) {
+				innerAdoptions.push(element);
+			},
+		});
+		await innerBehavior.ready;
+
+		expect(outerCleanups).toEqual([innerButton]);
+		expect(innerAdoptions).toEqual([innerButton]);
+		expect(inner.firstElementChild).toBe(innerButton);
+		expect(outer.firstElementChild).toBe(outerButton);
+	});
+
+	it('hands an adopted node between nested owners as external updates move it', async () => {
+		container.innerHTML =
+			'<section id="outer"><button id="moving" data-action>Move</button><article id="inner"></article></section>';
+		const outer = container.querySelector('#outer')!;
+		const inner = container.querySelector('#inner')!;
+		const moving = container.querySelector('#moving')!;
+		const outerOwner = { name: 'outer-owner' };
+		const innerOwner = { name: 'inner-owner' };
+		const outerAdoptions: Element[] = [];
+		const innerAdoptions: Element[] = [];
+		const outerCleanups: Element[] = [];
+		const innerCleanups: Element[] = [];
+		const root = attach();
+		root.registerExternalRange(outer, { owner: outerOwner });
+		root.registerExternalRange(inner, { owner: innerOwner });
+		const outerBehavior = root.registerBehavior({
+			owner: outerOwner,
+			target: '[data-action]',
+			adopt(element) {
+				outerAdoptions.push(element);
+				return () => outerCleanups.push(element);
+			},
+		});
+		const innerBehavior = root.registerBehavior({
+			owner: innerOwner,
+			target: '[data-action]',
+			adopt(element) {
+				innerAdoptions.push(element);
+				return () => innerCleanups.push(element);
+			},
+		});
+		await Promise.all([outerBehavior.ready, innerBehavior.ready]);
+		expect(outerAdoptions).toEqual([moving]);
+
+		inner.appendChild(moving);
+		await vi.waitFor(() => {
+			expect(outerCleanups).toEqual([moving]);
+			expect(innerAdoptions).toEqual([moving]);
+		});
+
+		outer.insertBefore(moving, inner);
+		await vi.waitFor(() => {
+			expect(innerCleanups).toEqual([moving]);
+			expect(outerAdoptions).toEqual([moving, moving]);
+		});
+		expect(outer.firstElementChild).toBe(moving);
+	});
+
+	it('restores enclosing ownership when a nested behavior root is disposed without replacing DOM', async () => {
+		container.innerHTML =
+			'<section id="outer-range"><article id="nested-root"><button data-action>Nested</button></article></section>';
+		const outerRange = container.querySelector('#outer-range')!;
+		const nestedContainer = container.querySelector('#nested-root')!;
+		const button = nestedContainer.firstElementChild!;
+		const outerOwner = { name: 'enclosing-owner' };
+		const nestedOwner = { name: 'nested-owner' };
+		const outerAdoptions: Element[] = [];
+		const outerCleanups: Element[] = [];
+		const nestedCleanup = vi.fn();
+		const outerRoot = attach();
+		outerRoot.registerExternalRange(outerRange, { owner: outerOwner });
+		const enclosingBehavior = outerRoot.registerBehavior({
+			owner: outerOwner,
+			target: '[data-action]',
+			adopt(element) {
+				outerAdoptions.push(element);
+				return () => outerCleanups.push(element);
+			},
+		});
+		await enclosingBehavior.ready;
+		expect(outerAdoptions).toEqual([button]);
+
+		const nestedRoot = attach(nestedContainer);
+		nestedRoot.registerExternalRange(nestedContainer, { owner: nestedOwner });
+		const nestedBehavior = nestedRoot.registerBehavior({
+			owner: nestedOwner,
+			target: '[data-action]',
+			adopt: () => nestedCleanup,
+		});
+		await nestedBehavior.ready;
+		expect(outerCleanups).toEqual([button]);
+
+		nestedRoot.dispose();
+
+		expect(nestedCleanup).toHaveBeenCalledOnce();
+		expect(outerRoot.signal.aborted).toBe(false);
+		expect(nestedContainer.firstElementChild).toBe(button);
+		await vi.waitFor(() => expect(outerAdoptions).toEqual([button, button]));
+	});
+
+	it('rejects conflicting owners and hands a range off only when replacement is explicit', async () => {
+		container.innerHTML = '<section><button data-action>Owned</button></section>';
+		const range = container.firstElementChild!;
+		const button = range.firstElementChild!;
+		const initialOwner = { name: 'initial' };
+		const nextOwner = { name: 'replacement' };
+		const cleanup = vi.fn();
+		const root = attach();
+		const initialRange = root.registerExternalRange(range, { owner: initialOwner });
+		const initialBehavior = root.registerBehavior({
+			owner: initialOwner,
+			target: '[data-action]',
+			adopt: () => cleanup,
+		});
+		await initialBehavior.ready;
+
+		expect(() => root.registerExternalRange(range, { owner: nextOwner })).toThrow(
+			/conflict|own|replace/i,
+		);
+		const replacement = root.registerExternalRange(range, {
+			owner: nextOwner,
+			replace: true,
+		});
+		const adopted = vi.fn();
+		const replacementBehavior = root.registerBehavior({
+			owner: nextOwner,
+			target: '[data-action]',
+			adopt: adopted,
+		});
+		await Promise.all([replacement.ready, replacementBehavior.ready]);
+
+		expect(initialRange.signal.aborted).toBe(true);
+		expect(replacement.signal.aborted).toBe(false);
+		expect(cleanup).toHaveBeenCalledOnce();
+		expect(adopted.mock.calls.map(([element]) => element)).toEqual([button]);
+		expect(range.firstElementChild).toBe(button);
+	});
+
+	it('ignores a superseded owner readiness promise after a range handoff', async () => {
+		container.innerHTML = '<section><button data-action>Owned</button></section>';
+		const range = container.firstElementChild!;
+		const previousOwner = { name: 'previous' };
+		const nextOwner = { name: 'next' };
+		const staleReadiness = deferred<void>();
+		const staleAdoption = vi.fn();
+		const currentAdoption = vi.fn();
+		const root = attach();
+		const staleRange = root.registerExternalRange(range, {
+			owner: previousOwner,
+			ready: staleReadiness.promise,
+		});
+		root.registerBehavior({ owner: previousOwner, target: '[data-action]', adopt: staleAdoption });
+
+		const currentRange = root.registerExternalRange(range, {
+			owner: nextOwner,
+			replace: true,
+		});
+		const currentBehavior = root.registerBehavior({
+			owner: nextOwner,
+			target: '[data-action]',
+			adopt: currentAdoption,
+		});
+		await Promise.all([currentRange.ready, currentBehavior.ready]);
+
+		staleReadiness.resolve(undefined);
+		await staleRange.ready.catch(() => {});
+		await Promise.resolve();
+
+		expect(staleRange.signal.aborted).toBe(true);
+		expect(staleAdoption).not.toHaveBeenCalled();
+		expect(currentAdoption).toHaveBeenCalledOnce();
+	});
+
+	it('drops queued interactions from an owner generation replaced before its behavior loads', async () => {
+		container.innerHTML = '<section><button data-action>Owned</button></section>';
+		const rangeElement = container.firstElementChild!;
+		const button = rangeElement.firstElementChild!;
+		const owner = { name: 'replaced-owner' };
+		const oldRangeReady = deferred<void>();
+		const moduleReady = deferred<void>();
+		const handled = vi.fn();
+		const root = attach();
+		const oldRange = root.registerExternalRange(rangeElement, {
+			owner,
+			ready: oldRangeReady.promise,
+		});
+		const behavior = root.registerBehavior({
+			owner,
+			target: '[data-action]',
+			events: ['click'],
+			ready: moduleReady.promise,
+			adopt() {},
+			handleEvent: handled,
+		});
+		button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(handled).not.toHaveBeenCalled();
+
+		const replacement = root.registerExternalRange(rangeElement, { owner, replace: true });
+		moduleReady.resolve(undefined);
+		await Promise.all([replacement.ready, behavior.ready]);
+		oldRangeReady.resolve(undefined);
+		await oldRange.ready;
+
+		expect(oldRange.signal.aborted).toBe(true);
+		expect(replacement.signal.aborted).toBe(false);
+		expect(handled).not.toHaveBeenCalled();
+		expect(rangeElement.firstElementChild).toBe(button);
+	});
+
+	it('passes the exact queued interaction to a late behavior without redispatching it', async () => {
+		container.innerHTML = '<button data-action><span>Action</span></button>';
+		const button = container.querySelector('button')!;
+		const label = container.querySelector('span')!;
+		const moduleReady = deferred<void>();
+		const nativeListener = vi.fn();
+		const handled = vi.fn();
+		button.addEventListener('click', nativeListener);
+		const root = attach();
+		const behavior = root.registerBehavior({
+			target: '[data-action]',
+			events: ['click'],
+			ready: moduleReady.promise,
+			adopt() {},
+			handleEvent: handled,
+		});
+		const original = new MouseEvent('click', { bubbles: true, cancelable: true });
+
+		expect(label.dispatchEvent(original)).toBe(true);
+		expect(nativeListener).toHaveBeenCalledOnce();
+		expect(nativeListener.mock.calls[0][0]).toBe(original);
+		expect(original.defaultPrevented).toBe(false);
+		expect(handled).not.toHaveBeenCalled();
+
+		moduleReady.resolve(undefined);
+		await behavior.ready;
+
+		expect(handled).toHaveBeenCalledOnce();
+		expect(handled.mock.calls[0][0]).toBe(original);
+		expect(handled.mock.calls[0][1]).toBe(button);
+		expect(handled.mock.calls[0][2].signal.aborted).toBe(false);
+		expect(nativeListener).toHaveBeenCalledOnce();
+		expect(original.defaultPrevented).toBe(false);
+	});
+
+	it('handles delegated behavior on descendants inserted after registration', async () => {
+		container.innerHTML = '<section data-stream></section>';
+		const stream = container.firstElementChild!;
+		const handled = vi.fn();
+		const root = attach();
+		const behavior = root.registerBehavior({
+			target: '[data-action]',
+			events: ['click'],
+			adopt() {},
+			handleEvent: handled,
+		});
+		await behavior.ready;
+
+		const inserted = document.createElement('button');
+		inserted.setAttribute('data-action', '');
+		stream.appendChild(inserted);
+		const event = new MouseEvent('click', { bubbles: true });
+		inserted.dispatchEvent(event);
+
+		expect(handled).toHaveBeenCalledOnce();
+		expect(handled.mock.calls[0][0]).toBe(event);
+		expect(handled.mock.calls[0][1]).toBe(inserted);
+		expect(stream.firstElementChild).toBe(inserted);
+	});
+
+	it('never activates native form submission twice for queued or repeated clicks', async () => {
+		container.innerHTML = '<form><button type="submit" data-action>Send</button></form>';
+		const form = container.querySelector('form')!;
+		const button = container.querySelector('button')!;
+		const moduleReady = deferred<void>();
+		const nativeClicks: Event[] = [];
+		const nativeSubmits: Event[] = [];
+		const handled = vi.fn();
+		button.addEventListener('click', (event) => nativeClicks.push(event));
+		form.addEventListener('submit', (event) => {
+			event.preventDefault();
+			nativeSubmits.push(event);
+		});
+		const root = attach();
+		const behavior = root.registerBehavior({
+			target: '[data-action]',
+			events: ['click'],
+			ready: moduleReady.promise,
+			adopt() {},
+			handleEvent: handled,
+		});
+
+		button.click();
+		button.click();
+		expect(nativeClicks).toHaveLength(2);
+		expect(nativeSubmits).toHaveLength(2);
+		expect(handled).not.toHaveBeenCalled();
+
+		moduleReady.resolve(undefined);
+		await behavior.ready;
+
+		expect(handled.mock.calls.map(([event]) => event)).toEqual(nativeClicks);
+		expect(nativeSubmits).toHaveLength(2);
+
+		button.click();
+		expect(nativeClicks).toHaveLength(3);
+		expect(nativeSubmits).toHaveLength(3);
+		expect(handled.mock.calls.map(([event]) => event)).toEqual(nativeClicks);
+	});
+
+	it('honors behavior dependency readiness before adopting a dependent entry', async () => {
+		container.innerHTML = '<button data-action>Action</button>';
+		const foundationReady = deferred<void>();
+		const order: string[] = [];
+		const root = attach();
+		const foundation = root.registerBehavior({
+			id: 'foundation',
+			target: '[data-action]',
+			ready: foundationReady.promise,
+			adopt() {
+				order.push('foundation');
+			},
+		});
+		const widget = root.registerBehavior({
+			id: 'widget',
+			target: '[data-action]',
+			dependencies: ['foundation'],
+			adopt() {
+				order.push('widget');
+			},
+		});
+		await Promise.resolve();
+		expect(order).toEqual([]);
+
+		foundationReady.resolve(undefined);
+		await Promise.all([foundation.ready, widget.ready, root.ready]);
+
+		expect(order).toEqual(['foundation', 'widget']);
+	});
+
+	it('rejects a behavior dependency that was never registered', () => {
+		container.innerHTML = '<button data-action>Action</button>';
+		const root = attach();
+
+		expect(() =>
+			root.registerBehavior({
+				id: 'widget',
+				target: '[data-action]',
+				dependencies: ['missing-foundation'],
+				adopt() {},
+			}),
+		).toThrow(/depend|unknown|missing/i);
+	});
+
+	it('rejects conflicting behavior entries and duplicate behavior identities', async () => {
+		container.innerHTML = '<button data-action>Action</button>';
+		const root = attach();
+		const first = root.registerBehavior({
+			id: 'annotations',
+			target: '[data-action]',
+			conflicts: ['widgets'],
+			adopt() {},
+		});
+		await first.ready;
+
+		expect(() =>
+			root.registerBehavior({ id: 'widgets', target: '[data-action]', adopt() {} }),
+		).toThrow(/conflict/i);
+		expect(() =>
+			root.registerBehavior({ id: 'annotations', target: '[data-action]', adopt() {} }),
+		).toThrow(/conflict|duplicate|already/i);
+
+		root.registerBehavior({ id: 'existing', target: '[data-action]', adopt() {} });
+		expect(() =>
+			root.registerBehavior({
+				id: 'declared-later',
+				target: '[data-action]',
+				conflicts: ['existing'],
+				adopt() {},
+			}),
+		).toThrow(/conflict/i);
+	});
+
+	it('propagates a rejected external range readiness without adopting protected descendants', async () => {
+		container.innerHTML = '<section><button data-action>Unavailable</button></section>';
+		const range = container.firstElementChild!;
+		const owner = { name: 'failed-stream' };
+		const streamReady = deferred<void>();
+		const failure = new Error('stream failed before ownership settled');
+		const adopted = vi.fn();
+		const root = attach();
+		const ownership = root.registerExternalRange(range, { owner, ready: streamReady.promise });
+		const behavior = root.registerBehavior({ owner, target: '[data-action]', adopt: adopted });
+		const ownershipFailure = expect(ownership.ready).rejects.toBe(failure);
+		const behaviorFailure = expect(behavior.ready).rejects.toBe(failure);
+		const rootFailure = expect(root.ready).rejects.toBe(failure);
+
+		streamReady.reject(failure);
+		await Promise.all([ownershipFailure, behaviorFailure, rootFailure]);
+
+		expect(adopted).not.toHaveBeenCalled();
+		expect(container.firstElementChild).toBe(range);
+	});
+
+	it('finalizes a rejected external range when an affected behavior cleanup throws', async () => {
+		container.innerHTML =
+			'<section id="healthy"><button id="shared-action" data-action>Healthy action</button>' +
+			'<button id="independent-action" data-independent>Independent</button></section>' +
+			'<section id="failed"><button id="pending-action" data-action>Pending action</button></section>';
+		const healthyElement = container.querySelector('#healthy')!;
+		const failedElement = container.querySelector('#failed')!;
+		const healthyAction = container.querySelector('#shared-action')!;
+		const independentAction = container.querySelector('#independent-action')!;
+		const owner = { name: 'partially-failed-stream' };
+		const ready = deferred<void>();
+		const failure = new Error('external stream failed');
+		const throwingCleanup = vi.fn(() => {
+			throw new Error('an adopted cleanup also failed');
+		});
+		const followingCleanup = vi.fn();
+		const independentCleanup = vi.fn();
+		const root = attach();
+		const healthyRange = root.registerExternalRange(healthyElement, { owner });
+		const failedRange = root.registerExternalRange(failedElement, {
+			owner,
+			ready: ready.promise,
+		});
+		const firstBehavior = root.registerBehavior({
+			id: 'throws-while-cleaning',
+			owner,
+			target: '[data-action]',
+			adopt: () => throwingCleanup,
+		});
+		const followingBehavior = root.registerBehavior({
+			id: 'still-cleans',
+			owner,
+			target: '[data-action]',
+			adopt: () => followingCleanup,
+		});
+		const independentBehavior = root.registerBehavior({
+			id: 'independent',
+			owner,
+			target: '[data-independent]',
+			adopt: () => independentCleanup,
+		});
+		await independentBehavior.ready;
+		const failedRangeOutcome = expect(failedRange.ready).rejects.toBe(failure);
+		const firstBehaviorOutcome = expect(firstBehavior.ready).rejects.toBe(failure);
+		const followingBehaviorOutcome = expect(followingBehavior.ready).rejects.toBe(failure);
+		const rootOutcome = expect(root.ready).rejects.toBe(failure);
+
+		ready.reject(failure);
+		await Promise.all([
+			failedRangeOutcome,
+			firstBehaviorOutcome,
+			followingBehaviorOutcome,
+			rootOutcome,
+		]);
+
+		expect(throwingCleanup).toHaveBeenCalledOnce();
+		expect(followingCleanup).toHaveBeenCalledOnce();
+		expect(independentCleanup).not.toHaveBeenCalled();
+		expect(failedRange.signal.aborted).toBe(true);
+		expect(firstBehavior.signal.aborted).toBe(true);
+		expect(followingBehavior.signal.aborted).toBe(true);
+		expect(healthyRange.signal.aborted).toBe(false);
+		expect(independentBehavior.signal.aborted).toBe(false);
+		expect(healthyElement.querySelector('#shared-action')).toBe(healthyAction);
+		expect(healthyElement.querySelector('#independent-action')).toBe(independentAction);
+		expect(container.querySelector('#failed')).toBe(failedElement);
+
+		const recovered = root.registerExternalRange(failedElement, {
+			owner: { name: 'recovered-owner' },
+		});
+		await recovered.ready;
+		expect(recovered.signal.aborted).toBe(false);
+	});
+
+	it('rejects an owner-constrained behavior when its range fails before its own module loads', async () => {
+		container.innerHTML = '<section><button data-action>Unavailable</button></section>';
+		const range = container.firstElementChild!;
+		const owner = { name: 'failed-before-load' };
+		const streamReady = deferred<void>();
+		const moduleReady = deferred<void>();
+		const failure = new Error('stream failed while the behavior module was pending');
+		const adopted = vi.fn();
+		const root = attach();
+		const ownership = root.registerExternalRange(range, { owner, ready: streamReady.promise });
+		const behavior = root.registerBehavior({
+			owner,
+			target: '[data-action]',
+			ready: moduleReady.promise,
+			adopt: adopted,
+		});
+		const ownershipFailure = expect(ownership.ready).rejects.toBe(failure);
+		const behaviorFailure = expect(behavior.ready).rejects.toBe(failure);
+		const rootFailure = expect(root.ready).rejects.toBe(failure);
+
+		streamReady.reject(failure);
+		await Promise.all([ownershipFailure, rootFailure]);
+		moduleReady.resolve(undefined);
+		await behaviorFailure;
+
+		expect(adopted).not.toHaveBeenCalled();
+		expect(behavior.signal.aborted).toBe(true);
+		expect(container.firstElementChild).toBe(range);
+	});
+
+	it('keeps a same-owner behavior in a disjoint root alive when another external range fails', async () => {
+		container.innerHTML =
+			'<section><button id="failed-action" data-action>Failed</button></section>';
+		const independentContainer = document.createElement('main');
+		independentContainer.innerHTML =
+			'<section><button id="healthy-action" data-action>Healthy</button></section>';
+		document.body.appendChild(independentContainer);
+		try {
+			const owner = { name: 'shared-external-owner' };
+			const failedReady = deferred<void>();
+			const healthyModule = deferred<void>();
+			const failure = new Error('only the first independently owned range failed');
+			const adopted = vi.fn();
+			const failedRoot = attach();
+			const healthyRoot = attach(independentContainer);
+			const failedRange = failedRoot.registerExternalRange(container.firstElementChild!, {
+				owner,
+				ready: failedReady.promise,
+			});
+			healthyRoot.registerExternalRange(independentContainer.firstElementChild!, { owner });
+			const healthyBehavior = healthyRoot.registerBehavior({
+				owner,
+				target: '#healthy-action',
+				ready: healthyModule.promise,
+				adopt: adopted,
+			});
+			const rangeFailure = expect(failedRange.ready).rejects.toBe(failure);
+			const rootFailure = expect(failedRoot.ready).rejects.toBe(failure);
+
+			failedReady.reject(failure);
+			await Promise.all([rangeFailure, rootFailure]);
+
+			expect(healthyRoot.signal.aborted).toBe(false);
+			expect(healthyBehavior.signal.aborted).toBe(false);
+			healthyModule.resolve(undefined);
+			await Promise.all([healthyBehavior.ready, healthyRoot.ready]);
+			expect(adopted.mock.calls[0][0]).toBe(independentContainer.querySelector('#healthy-action'));
+		} finally {
+			independentContainer.remove();
+		}
+	});
+
+	it('propagates a rejected behavior readiness without running stale adoption', async () => {
+		container.innerHTML = '<button data-action>Unavailable</button>';
+		const moduleReady = deferred<void>();
+		const failure = new Error('behavior module failed to load');
+		const adopted = vi.fn();
+		const root = attach();
+		const behavior = root.registerBehavior({
+			target: '[data-action]',
+			ready: moduleReady.promise,
+			adopt: adopted,
+		});
+		const behaviorFailure = expect(behavior.ready).rejects.toBe(failure);
+		const rootFailure = expect(root.ready).rejects.toBe(failure);
+
+		moduleReady.reject(failure);
+		await Promise.all([behaviorFailure, rootFailure]);
+
+		expect(adopted).not.toHaveBeenCalled();
+		expect(container.querySelector('[data-action]')).not.toBeNull();
+	});
+
+	it('aborts adopted behavior and keeps preserved DOM when its source signal is canceled', async () => {
+		container.innerHTML = '<button data-action>Action</button>';
+		const button = container.firstElementChild!;
+		const lifetime = new AbortController();
+		const cleanup = vi.fn();
+		const root = attach(container, { signal: lifetime.signal });
+		const behavior = root.registerBehavior({ target: '[data-action]', adopt: () => cleanup });
+		await behavior.ready;
+
+		lifetime.abort();
+		lifetime.abort();
+
+		expect(root.signal.aborted).toBe(true);
+		expect(behavior.signal.aborted).toBe(true);
+		expect(cleanup).toHaveBeenCalledOnce();
+		expect(container.firstElementChild).toBe(button);
+	});
+
+	it('returns a settled disposed root for a pre-aborted signal without retaining container ownership', async () => {
+		container.innerHTML = '<button data-action>Preserved</button>';
+		const button = container.firstElementChild!;
+		const canceled = new AbortController();
+		canceled.abort();
+		const disposed = attach(container, { signal: canceled.signal });
+		let settled = false;
+		void disposed.ready.then(
+			() => (settled = true),
+			() => (settled = true),
+		);
+
+		await vi.waitFor(() => expect(settled).toBe(true));
+		expect(disposed.signal.aborted).toBe(true);
+		expect(container.firstElementChild).toBe(button);
+
+		const replacement = attach();
+		expect(replacement.signal.aborted).toBe(false);
+		expect(container.firstElementChild).toBe(button);
+	});
+
+	it('does not evict a healthy root when its explicitly requested replacement is already canceled', async () => {
+		container.innerHTML = '<button data-action>Still active</button>';
+		const cleanup = vi.fn();
+		const current = attach();
+		const activeBehavior = current.registerBehavior({
+			target: '[data-action]',
+			adopt: () => cleanup,
+		});
+		await activeBehavior.ready;
+		const canceled = new AbortController();
+		canceled.abort();
+
+		const abandoned = attach(container, { replace: true, signal: canceled.signal });
+		await abandoned.ready;
+
+		expect(abandoned.signal.aborted).toBe(true);
+		expect(current.signal.aborted).toBe(false);
+		expect(activeBehavior.signal.aborted).toBe(false);
+		expect(cleanup).not.toHaveBeenCalled();
+		expect(container.querySelector('[data-action]')).not.toBeNull();
+	});
+
+	it('returns a settled canceled range for a pre-aborted owner without retaining its claim', async () => {
+		container.innerHTML = '<section><button data-action>Preserved</button></section>';
+		const range = container.firstElementChild!;
+		const owner = { name: 'pre-aborted-owner' };
+		const canceled = new AbortController();
+		canceled.abort();
+		const neverReady = new Promise<void>(() => {});
+		const root = attach();
+		const inactive = root.registerExternalRange(range, {
+			owner,
+			signal: canceled.signal,
+			ready: neverReady,
+		});
+		let settled = false;
+		void inactive.ready.then(
+			() => (settled = true),
+			() => (settled = true),
+		);
+
+		await vi.waitFor(() => expect(settled).toBe(true));
+		expect(inactive.signal.aborted).toBe(true);
+		expect(root.signal.aborted).toBe(false);
+
+		const active = root.registerExternalRange(range, { owner });
+		await active.ready;
+		expect(active.signal.aborted).toBe(false);
+		expect(container.firstElementChild).toBe(range);
+	});
+
+	it('does not evict a healthy external owner when its replacement is already canceled', async () => {
+		container.innerHTML = '<section><button data-action>Still owned</button></section>';
+		const rangeElement = container.firstElementChild!;
+		const currentOwner = { name: 'active-owner' };
+		const abandonedOwner = { name: 'abandoned-owner' };
+		const cleanup = vi.fn();
+		const root = attach();
+		const current = root.registerExternalRange(rangeElement, { owner: currentOwner });
+		const activeBehavior = root.registerBehavior({
+			owner: currentOwner,
+			target: '[data-action]',
+			adopt: () => cleanup,
+		});
+		await activeBehavior.ready;
+		const canceled = new AbortController();
+		canceled.abort();
+
+		const abandoned = root.registerExternalRange(rangeElement, {
+			owner: abandonedOwner,
+			replace: true,
+			signal: canceled.signal,
+		});
+		await abandoned.ready;
+
+		expect(abandoned.signal.aborted).toBe(true);
+		expect(current.signal.aborted).toBe(false);
+		expect(activeBehavior.signal.aborted).toBe(false);
+		expect(cleanup).not.toHaveBeenCalled();
+		expect(container.firstElementChild).toBe(rangeElement);
+	});
+
+	it('returns a settled canceled behavior for a pre-aborted entry without adopting or retaining its ID', async () => {
+		container.innerHTML = '<button data-action>Preserved</button>';
+		const canceled = new AbortController();
+		canceled.abort();
+		const neverReady = new Promise<void>(() => {});
+		const staleAdoption = vi.fn();
+		const currentAdoption = vi.fn();
+		const root = attach();
+		const inactive = root.registerBehavior({
+			id: 'replaceable',
+			target: '[data-action]',
+			signal: canceled.signal,
+			ready: neverReady,
+			adopt: staleAdoption,
+		});
+		let settled = false;
+		void inactive.ready.then(
+			() => (settled = true),
+			() => (settled = true),
+		);
+
+		await vi.waitFor(() => expect(settled).toBe(true));
+		expect(inactive.signal.aborted).toBe(true);
+		expect(staleAdoption).not.toHaveBeenCalled();
+		expect(root.signal.aborted).toBe(false);
+
+		const active = root.registerBehavior({
+			id: 'replaceable',
+			target: '[data-action]',
+			adopt: currentAdoption,
+		});
+		await active.ready;
+		expect(currentAdoption).toHaveBeenCalledOnce();
+	});
+
+	it('settles all canceled readiness promises even when external readiness never resolves', async () => {
+		container.innerHTML = '<section><button data-action>Waiting</button></section>';
+		const range = container.firstElementChild!;
+		const owner = { name: 'pending-owner' };
+		const neverReady = new Promise<void>(() => {});
+		const root = attach();
+		const ownership = root.registerExternalRange(range, { owner, ready: neverReady });
+		const behavior = root.registerBehavior({
+			owner,
+			target: '[data-action]',
+			ready: neverReady,
+			adopt() {},
+		});
+		const settled = { root: false, ownership: false, behavior: false };
+		void root.ready.then(
+			() => (settled.root = true),
+			() => (settled.root = true),
+		);
+		void ownership.ready.then(
+			() => (settled.ownership = true),
+			() => (settled.ownership = true),
+		);
+		void behavior.ready.then(
+			() => (settled.behavior = true),
+			() => (settled.behavior = true),
+		);
+
+		root.dispose();
+
+		await vi.waitFor(() =>
+			expect(settled).toEqual({ root: true, ownership: true, behavior: true }),
+		);
+		expect(range.isConnected).toBe(true);
+	});
+
+	it('cancels a behavior registration without disposing its root or removing its target', async () => {
+		container.innerHTML = '<button data-action>Action</button>';
+		const button = container.firstElementChild!;
+		const lifetime = new AbortController();
+		const cleanup = vi.fn();
+		const root = attach();
+		const behavior = root.registerBehavior({
+			target: '[data-action]',
+			signal: lifetime.signal,
+			adopt: () => cleanup,
+		});
+		await behavior.ready;
+
+		lifetime.abort();
+
+		expect(behavior.signal.aborted).toBe(true);
+		expect(root.signal.aborted).toBe(false);
+		expect(cleanup).toHaveBeenCalledOnce();
+		expect(container.firstElementChild).toBe(button);
+	});
+
+	it('cancels external ownership without disposing independently owned root behavior', async () => {
+		container.innerHTML = '<section><button data-action>Owned</button></section>';
+		const range = container.firstElementChild!;
+		const owner = { name: 'stream' };
+		const lifetime = new AbortController();
+		const cleanup = vi.fn();
+		const root = attach();
+		const ownership = root.registerExternalRange(range, { owner, signal: lifetime.signal });
+		const behavior = root.registerBehavior({
+			owner,
+			target: '[data-action]',
+			adopt: () => cleanup,
+		});
+		await behavior.ready;
+
+		lifetime.abort();
+
+		expect(ownership.signal.aborted).toBe(true);
+		expect(root.signal.aborted).toBe(false);
+		expect(cleanup).toHaveBeenCalledOnce();
+		expect(container.firstElementChild).toBe(range);
+	});
+
+	it('runs an asynchronously returned cleanup once when adoption settles after disposal', async () => {
+		container.innerHTML = '<button data-action>Pending</button>';
+		const pendingAdoption = deferred<() => void>();
+		const cleanup = vi.fn();
+		const adopt = vi.fn(() => pendingAdoption.promise);
+		const root = attach();
+		const behavior = root.registerBehavior({ target: '[data-action]', adopt });
+		await vi.waitFor(() => expect(adopt).toHaveBeenCalledOnce());
+		const readiness = behavior.ready.catch(() => {});
+
+		root.dispose();
+		pendingAdoption.resolve(cleanup);
+		await readiness;
+		await vi.waitFor(() => expect(cleanup).toHaveBeenCalledOnce());
+
+		behavior.dispose();
+		root.dispose();
+		expect(cleanup).toHaveBeenCalledOnce();
+		expect(container.querySelector('[data-action]')).not.toBeNull();
+	});
+
+	it('does not adopt a stale asynchronously loaded behavior after its root is disposed', async () => {
+		container.innerHTML = '<button data-action>Pending</button>';
+		const moduleReady = deferred<void>();
+		const adopted = vi.fn();
+		const root = attach();
+		const behavior = root.registerBehavior({
+			target: '[data-action]',
+			ready: moduleReady.promise,
+			adopt: adopted,
+		});
+
+		root.dispose();
+		moduleReady.resolve(undefined);
+		await behavior.ready.catch(() => {});
+		await Promise.resolve();
+
+		expect(adopted).not.toHaveBeenCalled();
+		expect(behavior.signal.aborted).toBe(true);
+	});
+
+	it('runs cleanup once when disposal reenters the root lifecycle', async () => {
+		container.innerHTML = '<button data-action>Action</button>';
+		const root = attach();
+		const cleanup = vi.fn(() => root.dispose());
+		const behavior = root.registerBehavior({ target: '[data-action]', adopt: () => cleanup });
+		await behavior.ready;
+
+		root.dispose();
+		behavior.dispose();
+
+		expect(cleanup).toHaveBeenCalledOnce();
+		expect(container.querySelector('[data-action]')).not.toBeNull();
+	});
+
+	it('requires explicit root replacement and releases the previous root exactly once', async () => {
+		container.innerHTML = '<button data-action>Action</button>';
+		const button = container.firstElementChild!;
+		const cleanup = vi.fn();
+		const previous = attach();
+		const registration = previous.registerBehavior({
+			target: '[data-action]',
+			adopt: () => cleanup,
+		});
+		await registration.ready;
+
+		expect(() => attachBehaviorRoot(container)).toThrow(/conflict|root|replace|already/i);
+		const replacement = attach(container, { replace: true });
+
+		expect(previous.signal.aborted).toBe(true);
+		expect(registration.signal.aborted).toBe(true);
+		expect(replacement.signal.aborted).toBe(false);
+		expect(cleanup).toHaveBeenCalledOnce();
+		expect(container.firstElementChild).toBe(button);
+	});
+
+	it('scopes root and ownership identity to each document and rejects cross-document ranges', async () => {
+		container.innerHTML = '<section><button data-action>Local</button></section>';
+		const localRange = container.firstElementChild!;
+		const iframe = document.createElement('iframe');
+		document.body.appendChild(iframe);
+		try {
+			const foreignDocument = iframe.contentDocument!;
+			const foreignContainer = foreignDocument.createElement('main');
+			foreignContainer.innerHTML = '<section><button data-action>Foreign</button></section>';
+			foreignDocument.body.appendChild(foreignContainer);
+			const foreignRange = foreignContainer.firstElementChild!;
+			const owner = { name: 'document-scoped' };
+			const localAdoption = vi.fn();
+			const foreignAdoption = vi.fn();
+			const localRoot = attach();
+			const foreignRoot = attach(foreignContainer);
+			localRoot.registerExternalRange(localRange, { owner });
+			foreignRoot.registerExternalRange(foreignRange, { owner });
+			const localBehavior = localRoot.registerBehavior({
+				id: 'document-action',
+				owner,
+				target: '[data-action]',
+				adopt: localAdoption,
+			});
+			const foreignBehavior = foreignRoot.registerBehavior({
+				id: 'document-action',
+				owner,
+				target: '[data-action]',
+				adopt: foreignAdoption,
+			});
+			await Promise.all([localBehavior.ready, foreignBehavior.ready]);
+
+			expect(localAdoption.mock.calls[0][0]).toBe(localRange.firstElementChild);
+			expect(foreignAdoption.mock.calls[0][0]).toBe(foreignRange.firstElementChild);
+			expect(() => localRoot.registerExternalRange(foreignRange, { owner })).toThrow(
+				/document|container|range|belong/i,
+			);
+			expect(() => foreignRoot.registerExternalRange(localRange, { owner })).toThrow(
+				/document|container|range|belong/i,
+			);
+		} finally {
+			iframe.remove();
+		}
+	});
+
+	it('adds behavior to permanent-static SSR DOM without claiming surrounding hydration', async () => {
+		const onStaticRender = vi.fn();
+		container.innerHTML = renderToString(staticServer.PermanentExternallyPatched, {
+			html: '<button id="server-action" data-action>Server action</button>',
+			label: 'Server label',
+		}).html;
+		const range = container.querySelector('#server-owned-range')!;
+		const button = range.querySelector('#server-action')!;
+		const owner = { name: 'server-stream' };
+		const handled = vi.fn();
+		const root = attach();
+		root.registerExternalRange(range, { owner });
+		const behavior = root.registerBehavior({
+			owner,
+			target: '[data-action]',
+			events: ['click'],
+			adopt() {},
+			handleEvent: handled,
+		});
+		await behavior.ready;
+
+		hydratedRoot = hydrateRoot(container, staticClient.PermanentExternallyPatched, {
+			html: '<p>Client must not reconcile externally owned markup</p>',
+			label: 'Server label',
+			onStaticRender,
+		});
+		flushSync(() => {});
+		flushEffects();
+		const first = new MouseEvent('click', { bubbles: true });
+		button.dispatchEvent(first);
+
+		const inserted = document.createElement('button');
+		inserted.id = 'streamed-action';
+		inserted.setAttribute('data-action', '');
+		range.appendChild(inserted);
+		flushSync(() =>
+			hydratedRoot!.render(staticClient.PermanentExternallyPatched, {
+				html: '<p>Updated client content must not own the range</p>',
+				label: 'Updated label',
+				onStaticRender,
+			}),
+		);
+		flushEffects();
+		const second = new MouseEvent('click', { bubbles: true });
+		inserted.dispatchEvent(second);
+
+		expect(container.querySelector('#server-owned-range')).toBe(range);
+		expect(range.querySelector('#server-action')).toBe(button);
+		expect(range.querySelector('#streamed-action')).toBe(inserted);
+		expect(container.querySelector('#server-owned-live-label')?.textContent).toBe('Updated label');
+		expect(handled.mock.calls.map(([event]) => event)).toEqual([first, second]);
+		expect(onStaticRender).not.toHaveBeenCalled();
+
+		root.dispose();
+		expect(range.querySelector('#server-action')).toBe(button);
+		expect(range.querySelector('#streamed-action')).toBe(inserted);
+	});
+
+	it('adopts permanent-static markup produced by standards-based ReadableStream SSR', async () => {
+		const stream = await renderToReadableStream(staticServer.PermanentExternallyPatched, {
+			html: '<button id="readable-action" data-action>Streamed action</button>',
+			label: 'Readable stream label',
+		});
+		container.innerHTML = await new Response(stream).text();
+		const range = container.querySelector('#server-owned-range')!;
+		const button = container.querySelector('#readable-action')!;
+		const owner = { name: 'readable-stream-owner' };
+		const handled = vi.fn();
+		const root = attach();
+		root.registerExternalRange(range, { owner });
+		const behavior = root.registerBehavior({
+			owner,
+			target: '[data-action]',
+			events: ['click'],
+			adopt() {},
+			handleEvent: handled,
+		});
+		await behavior.ready;
+
+		const interaction = new MouseEvent('click', { bubbles: true });
+		button.dispatchEvent(interaction);
+
+		expect(handled).toHaveBeenCalledOnce();
+		expect(handled.mock.calls[0][0]).toBe(interaction);
+		expect(handled.mock.calls[0][1]).toBe(button);
+		expect(container.querySelector('#server-owned-range')).toBe(range);
+		expect(range.firstElementChild).toBe(button);
+		expect(container.querySelector('#server-owned-live-label')?.textContent).toBe(
+			'Readable stream label',
+		);
+	});
+});

--- a/packages/octane/tests/behavior-root.test.ts
+++ b/packages/octane/tests/behavior-root.test.ts
@@ -168,6 +168,104 @@ describe('behavior-only roots', () => {
 		expect(section.firstElementChild).toBe(streamed);
 	});
 
+	it('adopts existing elements when externally patched attributes toggle selector eligibility', async () => {
+		container.innerHTML =
+			'<section data-owner="stream"><button id="action" aria-label="Original">Action</button></section>';
+		const section = container.firstElementChild!;
+		const button = section.firstElementChild!;
+		const originalMarkup = container.innerHTML;
+		const cleaned: Element[] = [];
+		const adopted = vi.fn((element: Element) => () => cleaned.push(element));
+		const root = attach();
+		const registration = root.registerBehavior({ target: '[data-action]', adopt: adopted });
+		await registration.ready;
+		expect(adopted).not.toHaveBeenCalled();
+
+		button.setAttribute('data-action', 'annotation');
+		await vi.waitFor(() => expect(adopted).toHaveBeenCalledOnce());
+		expect(adopted.mock.calls[0]?.[0]).toBe(button);
+
+		button.removeAttribute('data-action');
+		await vi.waitFor(() => expect(cleaned).toEqual([button]));
+
+		button.setAttribute('data-action', 'annotation');
+		await vi.waitFor(() => expect(adopted).toHaveBeenCalledTimes(2));
+		button.removeAttribute('data-action');
+		await vi.waitFor(() => expect(cleaned).toEqual([button, button]));
+		registration.dispose();
+
+		expect(cleaned).toEqual([button, button]);
+		expect(container.innerHTML).toBe(originalMarkup);
+		expect(container.firstElementChild).toBe(section);
+		expect(section.firstElementChild).toBe(button);
+	});
+
+	it.each([
+		{
+			change: 'an existing element changes class',
+			selector: '.is-interactive',
+			mutateAncestor: false,
+			className: 'is-interactive',
+		},
+		{
+			change: 'an unchanged descendant gains an attribute-selected ancestor',
+			selector: '[data-enabled] [data-action]',
+			mutateAncestor: true,
+			attribute: 'data-enabled',
+		},
+		{
+			change: 'an unchanged descendant gains a class-selected ancestor',
+			selector: '.is-enabled [data-action]',
+			mutateAncestor: true,
+			className: 'is-enabled',
+		},
+	])(
+		'updates existing behavior when $change',
+		async ({ selector, mutateAncestor, attribute, className }) => {
+			container.innerHTML =
+				'<section class="external" data-owner="stream"><button id="action" class="stable" data-action>Action</button></section>';
+			const section = container.firstElementChild!;
+			const button = section.firstElementChild!;
+			const originalMarkup = container.innerHTML;
+			const owner = Symbol('external stream');
+			const cleaned: Element[] = [];
+			const adopted = vi.fn((element: Element) => () => cleaned.push(element));
+			const root = attach();
+			root.registerExternalRange(section, { owner });
+			const behavior = root.registerBehavior({ owner, target: selector, adopt: adopted });
+			await behavior.ready;
+			expect(adopted).not.toHaveBeenCalled();
+
+			const patched = mutateAncestor ? section : button;
+			const enable = () => {
+				if (attribute) patched.setAttribute(attribute, '');
+				else patched.classList.add(className!);
+			};
+			const disable = () => {
+				if (attribute) patched.removeAttribute(attribute);
+				else patched.classList.remove(className!);
+			};
+
+			enable();
+			await vi.waitFor(() => expect(adopted).toHaveBeenCalledOnce());
+			expect(adopted.mock.calls[0]?.[0]).toBe(button);
+
+			disable();
+			await vi.waitFor(() => expect(cleaned).toEqual([button]));
+
+			enable();
+			await vi.waitFor(() => expect(adopted).toHaveBeenCalledTimes(2));
+			disable();
+			await vi.waitFor(() => expect(cleaned).toEqual([button, button]));
+			behavior.dispose();
+
+			expect(cleaned).toEqual([button, button]);
+			expect(container.innerHTML).toBe(originalMarkup);
+			expect(container.firstElementChild).toBe(section);
+			expect(section.firstElementChild).toBe(button);
+		},
+	);
+
 	it('updates :empty behavior when streamed mutations add or remove only text nodes', async () => {
 		container.innerHTML = '<section id="streamed-text"></section>';
 		const range = container.firstElementChild!;

--- a/packages/octane/tests/browser/behavior-root/behavior-root.test.ts
+++ b/packages/octane/tests/browser/behavior-root/behavior-root.test.ts
@@ -253,6 +253,95 @@ for (const [name, engine] of [
 			]);
 		});
 
+		it('updates existing owned widgets as element and ancestor attributes change', async () => {
+			const page = await openPage();
+			await page.evaluate(() => window.__behaviorRootBrowser.mountChangingSelectors());
+			const before = await page.evaluate(() => window.__behaviorRootBrowser.state());
+			expect(before.adoptions).toEqual([]);
+
+			await page.evaluate(() => {
+				document.querySelector('#initial-widget')!.setAttribute('data-enhanced-action', 'ready');
+				document.querySelector('#annotation-link')!.classList.add('interactive-annotation');
+				document.querySelector('#nested-range')!.setAttribute('data-live', 'true');
+			});
+			await page.waitForFunction(() => window.__behaviorRootBrowser.state().adoptions.length === 3);
+			await page.locator('#initial-widget').click();
+			await page.locator('#annotation-link').click();
+			await page.locator('#nested-widget').click();
+
+			const adopted = await page.evaluate(() => window.__behaviorRootBrowser.state());
+			expect(adopted.identity).toEqual(before.identity);
+			expect(adopted.adoptions.toSorted()).toEqual([
+				'annotation-link',
+				'initial-widget',
+				'nested-widget',
+			]);
+			expect(adopted.interactions).toEqual([
+				expect.objectContaining({
+					id: 'initial-widget',
+					original: true,
+					owner: 'stream',
+					trusted: true,
+				}),
+				expect.objectContaining({
+					id: 'annotation-link',
+					original: true,
+					owner: 'stream',
+					trusted: true,
+				}),
+				expect.objectContaining({
+					id: 'nested-widget',
+					original: true,
+					owner: 'nested',
+					trusted: true,
+				}),
+			]);
+
+			await page.evaluate(() => {
+				document.querySelector('#initial-widget')!.removeAttribute('data-enhanced-action');
+				document.querySelector('#annotation-link')!.classList.remove('interactive-annotation');
+				document.querySelector('#nested-range')!.removeAttribute('data-live');
+			});
+			await page.waitForFunction(() => window.__behaviorRootBrowser.state().cleanups.length === 3);
+			const released = await page.evaluate(() => window.__behaviorRootBrowser.state());
+			expect(released.cleanups.toSorted()).toEqual(adopted.adoptions.toSorted());
+			expect(released.identity).toEqual(before.identity);
+			await page.locator('#initial-widget').click();
+			await page.locator('#nested-widget').click();
+			expect(
+				(await page.evaluate(() => window.__behaviorRootBrowser.state())).interactions,
+			).toEqual(adopted.interactions);
+
+			await page.evaluate(() => {
+				document.querySelector('#initial-widget')!.setAttribute('data-enhanced-action', 'again');
+			});
+			await page.waitForFunction(
+				() =>
+					window.__behaviorRootBrowser.state().adoptions.filter((id) => id === 'initial-widget')
+						.length === 2,
+			);
+			await page.locator('#initial-widget').click();
+			const readopted = await page.evaluate(() => window.__behaviorRootBrowser.state());
+			expect(readopted.interactions.at(-1)).toMatchObject({
+				id: 'initial-widget',
+				nativeDispatches: 3,
+				original: true,
+				owner: 'stream',
+				trusted: true,
+			});
+			await page.evaluate(() => {
+				document.querySelector('#initial-widget')!.removeAttribute('data-enhanced-action');
+			});
+			await page.waitForFunction(
+				() =>
+					window.__behaviorRootBrowser.state().cleanups.filter((id) => id === 'initial-widget')
+						.length === 2,
+			);
+			expect((await page.evaluate(() => window.__behaviorRootBrowser.state())).identity).toEqual(
+				before.identity,
+			);
+		});
+
 		it('preserves streaming and genuine queued interactions before and after range readiness', async () => {
 			const page = await openPage();
 			await page.evaluate(() => window.__behaviorRootBrowser.mountPendingRange());

--- a/packages/octane/tests/browser/behavior-root/behavior-root.test.ts
+++ b/packages/octane/tests/browser/behavior-root/behavior-root.test.ts
@@ -1,0 +1,411 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { chromium, webkit, type Browser, type Page } from 'playwright';
+import { createServer, type ViteDevServer } from 'vite';
+import { octane } from 'octane/compiler/vite';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+let server: ViteDevServer;
+let baseUrl: string;
+
+beforeAll(async () => {
+	server = await createServer({
+		configFile: false,
+		root: HERE,
+		logLevel: 'error',
+		plugins: [octane()],
+		server: { host: '127.0.0.1', port: 0 },
+	});
+	await server.listen();
+	const address = server.httpServer!.address();
+	if (!address || typeof address === 'string') throw new Error('Vite did not expose a TCP port');
+	baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+afterAll(async () => {
+	await server?.close();
+});
+
+for (const [name, engine] of [
+	['Chromium', chromium],
+	['WebKit', webkit],
+] as const) {
+	describe.sequential(`${name} externally owned behavior lifecycle`, () => {
+		let browser: Browser;
+		let page: Page | undefined;
+		let failures: string[] = [];
+
+		beforeAll(async () => {
+			try {
+				browser = await engine.launch({ headless: true });
+			} catch (error) {
+				throw new Error(`${name} is required for externally owned behavior evidence: ${error}`);
+			}
+		});
+
+		afterEach(async () => {
+			const currentFailures = failures.slice();
+			try {
+				await page?.evaluate(() => window.__behaviorRootBrowser?.dispose());
+				await page?.close();
+			} finally {
+				page = undefined;
+				failures = [];
+			}
+			expect(currentFailures).toEqual([]);
+		});
+
+		afterAll(async () => {
+			await browser?.close();
+		});
+
+		async function openPage(): Promise<Page> {
+			page = await browser.newPage();
+			failures = [];
+			page.on('pageerror', (error) => failures.push(`pageerror: ${error.message}`));
+			page.on('console', (message) => {
+				if (message.type() === 'error' || message.type() === 'warning') {
+					failures.push(`${message.type()}: ${message.text()}`);
+				}
+			});
+			await page.goto(baseUrl);
+			await page.waitForFunction(() => Boolean(window.__behaviorRootBrowser));
+			return page;
+		}
+
+		it('adopts progressively streamed widgets while preserving server DOM and nested ownership', async () => {
+			const page = await openPage();
+			await page.evaluate(() => window.__behaviorRootBrowser.mountStreaming());
+
+			const before = await page.evaluate(() => window.__behaviorRootBrowser.state());
+			expect(before.identity).toEqual({
+				article: true,
+				external: true,
+				initialWidget: true,
+				mathRow: true,
+				nested: true,
+				shell: true,
+				svgGroup: true,
+			});
+			expect(before.namespaces).toEqual({
+				math: 'http://www.w3.org/1998/Math/MathML',
+				svg: 'http://www.w3.org/2000/svg',
+			});
+			expect(before.patchedBeforeAttachment).toBe(true);
+			expect(before.protectedAttributes).toEqual({
+				range: 'server-range',
+				shell: 'server-shell',
+			});
+
+			await page.evaluate(() =>
+				window.__behaviorRootBrowser.appendStreamedMarkup([
+					{ text: 'Progressively streamed text' },
+					{
+						html: '<button id="streamed-widget" type="button" data-stream-action>Widget</button>',
+					},
+					{
+						html: '<a id="streamed-annotation" href="#streamed" data-stream-action>Annotation</a>',
+					},
+					{
+						html: '<button id="nested-streamed-widget" type="button" data-stream-action>Nested</button>',
+						owner: 'nested',
+					},
+				]),
+			);
+			await page.waitForFunction(() => {
+				const adopted = window.__behaviorRootBrowser.state().adoptions;
+				return adopted.includes('streamed-widget') && adopted.includes('nested-streamed-widget');
+			});
+			await page.locator('#initial-widget').click();
+			await page.locator('#streamed-widget').click();
+			await page.locator('#nested-widget').click();
+			await page.locator('#nested-streamed-widget').click();
+			await page.locator('#streamed-annotation').click();
+
+			const streamed = await page.evaluate(() => window.__behaviorRootBrowser.state());
+			expect(streamed.identity).toEqual(before.identity);
+			expect(streamed.namespaces).toEqual(before.namespaces);
+			expect(streamed.protectedAttributes).toEqual(before.protectedAttributes);
+			expect(streamed.patchedBeforeAttachment).toBe(true);
+			expect(streamed.text).toBe('Progressively streamed text');
+			expect(streamed.hash).toBe('#streamed');
+			expect(streamed.interactions).toEqual([
+				{
+					id: 'initial-widget',
+					nativeDispatches: 1,
+					original: true,
+					owner: 'stream',
+					trusted: true,
+					type: 'click',
+				},
+				{
+					id: 'streamed-widget',
+					nativeDispatches: 1,
+					original: true,
+					owner: 'stream',
+					trusted: true,
+					type: 'click',
+				},
+				{
+					id: 'nested-widget',
+					nativeDispatches: 1,
+					original: true,
+					owner: 'nested',
+					trusted: true,
+					type: 'click',
+				},
+				{
+					id: 'nested-streamed-widget',
+					nativeDispatches: 1,
+					original: true,
+					owner: 'nested',
+					trusted: true,
+					type: 'click',
+				},
+				{
+					id: 'streamed-annotation',
+					nativeDispatches: 1,
+					original: true,
+					owner: 'stream',
+					trusted: true,
+					type: 'click',
+				},
+			]);
+
+			await page.evaluate(() => window.__behaviorRootBrowser.dispose());
+			await page.locator('#streamed-widget').click();
+			const disposed = await page.evaluate(() => window.__behaviorRootBrowser.state());
+			expect(disposed.identity).toEqual(before.identity);
+			expect(disposed.interactions).toEqual(streamed.interactions);
+			expect(disposed.cleanups.toSorted()).toEqual(disposed.adoptions.toSorted());
+			await page.evaluate(() => window.__behaviorRootBrowser.dispose());
+			expect((await page.evaluate(() => window.__behaviorRootBrowser.state())).cleanups).toEqual(
+				disposed.cleanups,
+			);
+		});
+
+		it('delivers genuine pending interactions without redispatching links or repeated forms', async () => {
+			const page = await openPage();
+			await page.evaluate(() => window.__behaviorRootBrowser.mountPendingInteractions());
+
+			await page.locator('#initial-widget').click();
+			await page.locator('#annotation-link').click();
+			await page.locator('#submit-action').click();
+			await page.waitForFunction(() => window.__behaviorRootBrowser.state().hashChanges === 1);
+
+			const pending = await page.evaluate(() => window.__behaviorRootBrowser.state());
+			expect(pending.interactions).toEqual([]);
+			expect(pending.hash).toBe('#annotation');
+			expect(pending.nativeSubmissions).toBe(1);
+			expect(pending.trustedSubmissions).toBe(1);
+			expect(pending.nativeDispatches).toMatchObject({
+				'annotation-link': 1,
+				'initial-widget': 1,
+				'submit-action': 1,
+			});
+
+			await page.evaluate(() => window.__behaviorRootBrowser.resolvePending());
+			await page.waitForFunction(
+				() => window.__behaviorRootBrowser.state().interactions.length === 3,
+			);
+			const adopted = await page.evaluate(() => window.__behaviorRootBrowser.state());
+			expect(adopted.interactions).toEqual([
+				{
+					id: 'initial-widget',
+					nativeDispatches: 1,
+					original: true,
+					owner: 'stream',
+					trusted: true,
+					type: 'click',
+				},
+				{
+					id: 'annotation-link',
+					nativeDispatches: 1,
+					original: true,
+					owner: 'stream',
+					trusted: true,
+					type: 'click',
+				},
+				{
+					id: 'submit-action',
+					nativeDispatches: 1,
+					original: true,
+					owner: 'stream',
+					trusted: true,
+					type: 'click',
+				},
+			]);
+			expect(adopted.hashChanges).toBe(1);
+			expect(adopted.nativeSubmissions).toBe(1);
+
+			await page.locator('#submit-action').click();
+			const repeated = await page.evaluate(() => window.__behaviorRootBrowser.state());
+			expect(repeated.nativeSubmissions).toBe(2);
+			expect(repeated.trustedSubmissions).toBe(2);
+			expect(repeated.nativeDispatches['submit-action']).toBe(2);
+			expect(repeated.interactions.map((interaction) => interaction.id)).toEqual([
+				'initial-widget',
+				'annotation-link',
+				'submit-action',
+				'submit-action',
+			]);
+		});
+
+		it('preserves streaming and genuine queued interactions before and after range readiness', async () => {
+			const page = await openPage();
+			await page.evaluate(() => window.__behaviorRootBrowser.mountPendingRange());
+			await page.evaluate(() =>
+				window.__behaviorRootBrowser.appendStreamedMarkup([
+					{ text: 'Revealed while the external owner is pending' },
+					{
+						html: '<button id="pending-range-widget" type="button" data-stream-action>Pending widget</button>',
+					},
+				]),
+			);
+			await page.locator('#initial-widget').click();
+			await page.locator('#pending-range-widget').click();
+
+			const pending = await page.evaluate(() => window.__behaviorRootBrowser.state());
+			expect(pending.adoptions).toEqual([]);
+			expect(pending.interactions).toEqual([]);
+			expect(pending.text).toBe('Revealed while the external owner is pending');
+			expect(pending.identity).toEqual({
+				article: true,
+				external: true,
+				initialWidget: true,
+				mathRow: true,
+				nested: true,
+				shell: true,
+				svgGroup: true,
+			});
+
+			await page.evaluate(() => window.__behaviorRootBrowser.resolvePending());
+			await page.waitForFunction(
+				() => window.__behaviorRootBrowser.state().interactions.length === 2,
+			);
+			const ready = await page.evaluate(() => window.__behaviorRootBrowser.state());
+			expect(ready.interactions).toEqual([
+				{
+					id: 'initial-widget',
+					nativeDispatches: 1,
+					original: true,
+					owner: 'stream',
+					trusted: true,
+					type: 'click',
+				},
+				{
+					id: 'pending-range-widget',
+					nativeDispatches: 1,
+					original: true,
+					owner: 'stream',
+					trusted: true,
+					type: 'click',
+				},
+			]);
+
+			await page.evaluate(() =>
+				window.__behaviorRootBrowser.appendStreamedMarkup([
+					{
+						html: '<button id="ready-range-widget" type="button" data-stream-action>Ready widget</button>',
+					},
+				]),
+			);
+			await page.locator('#ready-range-widget').click();
+			await page.waitForFunction(
+				() => window.__behaviorRootBrowser.state().interactions.length === 3,
+			);
+			const streamed = await page.evaluate(() => window.__behaviorRootBrowser.state());
+			expect(streamed.interactions.at(-1)).toEqual({
+				id: 'ready-range-widget',
+				nativeDispatches: 1,
+				original: true,
+				owner: 'stream',
+				trusted: true,
+				type: 'click',
+			});
+			expect(streamed.text).toBe('Revealed while the external owner is pending');
+		});
+
+		it('rejects ownership conflicts, supports explicit handoff, and scopes replacement documents', async () => {
+			const page = await openPage();
+			await page.evaluate(() => window.__behaviorRootBrowser.mountStreaming());
+
+			const conflict = await page.evaluate(() => window.__behaviorRootBrowser.conflict());
+			expect(conflict).toEqual(expect.any(String));
+			await page.evaluate(() => window.__behaviorRootBrowser.handoffNestedOwner());
+			await page.locator('#nested-widget').click();
+			const handedOff = await page.evaluate(() => window.__behaviorRootBrowser.state());
+			expect(handedOff.interactions).toEqual([
+				{
+					id: 'nested-widget',
+					nativeDispatches: 1,
+					original: true,
+					owner: 'replacement',
+					trusted: true,
+					type: 'click',
+				},
+			]);
+
+			await page.evaluate(() => window.__behaviorRootBrowser.replaceDocumentRoot());
+			await page.locator('#initial-widget').click();
+			await page.frameLocator('#replacement-document').locator('#replacement-widget').click();
+
+			const replacement = await page.evaluate(() => window.__behaviorRootBrowser.state());
+			expect(replacement.documentScoped).toBe(true);
+			expect(replacement.identity).toEqual({
+				article: true,
+				external: true,
+				initialWidget: true,
+				mathRow: true,
+				nested: true,
+				shell: true,
+				svgGroup: true,
+			});
+			expect(replacement.interactions).toEqual([
+				...handedOff.interactions,
+				{
+					id: 'replacement-widget',
+					nativeDispatches: 1,
+					original: true,
+					owner: 'replacement-document',
+					trusted: true,
+					type: 'click',
+				},
+			]);
+		});
+
+		it('cleans adopted behavior exactly once and ignores interactions after abort', async () => {
+			const page = await openPage();
+			await page.evaluate(() => window.__behaviorRootBrowser.mountAbortedInteractions());
+			await page.waitForFunction(() =>
+				window.__behaviorRootBrowser.state().adoptions.includes('initial-widget'),
+			);
+			await page.locator('#annotation-link').click();
+			await page.evaluate(() => {
+				window.__behaviorRootBrowser.abort();
+				window.__behaviorRootBrowser.resolvePending();
+			});
+			await page.evaluate(() => new Promise<void>((resolve) => setTimeout(resolve, 0)));
+
+			const aborted = await page.evaluate(() => window.__behaviorRootBrowser.state());
+			expect(aborted.adoptions).toEqual(['initial-widget']);
+			expect(aborted.cleanups).toEqual(['initial-widget']);
+			expect(aborted.interactions).toEqual([]);
+			expect(aborted.hash).toBe('#annotation');
+			expect(aborted.nativeDispatches['annotation-link']).toBe(1);
+			expect(aborted.streamCanceled).toBe(true);
+			expect(aborted.text).toBe('Streamed before cancellation');
+			expect(aborted.identity).toEqual({
+				article: true,
+				external: true,
+				initialWidget: true,
+				mathRow: true,
+				nested: true,
+				shell: true,
+				svgGroup: true,
+			});
+		});
+	});
+}

--- a/packages/octane/tests/browser/behavior-root/index.html
+++ b/packages/octane/tests/browser/behavior-root/index.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Octane externally owned behavior roots</title>
+	</head>
+	<body>
+		<main id="behavior-shell" data-protected="server-shell">
+			<section id="external-range" data-protected="server-range">
+				<article id="streamed-text">Server-rendered text</article>
+				<button id="initial-widget" type="button" data-stream-action data-pending-action>
+					Initial widget
+				</button>
+				<a id="annotation-link" href="#annotation" data-pending-action>Annotation</a>
+				<form id="repeated-form" action="#submitted">
+					<button id="submit-action" type="submit" data-pending-action>Submit</button>
+				</form>
+				<svg id="external-svg" width="20" height="20">
+					<g id="external-svg-group"><circle cx="10" cy="10" r="5" /></g>
+				</svg>
+				<math id="external-math"
+					><mrow id="external-math-row"><mi>x</mi></mrow></math
+				>
+				<section id="nested-range">
+					<button id="nested-widget" type="button" data-stream-action>Nested widget</button>
+				</section>
+			</section>
+		</main>
+		<script type="module" src="/main.ts"></script>
+	</body>
+</html>

--- a/packages/octane/tests/browser/behavior-root/main.ts
+++ b/packages/octane/tests/browser/behavior-root/main.ts
@@ -104,6 +104,22 @@ async function mountStreaming(): Promise<void> {
 	await root.ready;
 }
 
+async function mountChangingSelectors(): Promise<void> {
+	root = attachBehaviorRoot(shell);
+	root.registerExternalRange(external, { owner: 'stream' });
+	root.registerExternalRange(nested, { owner: 'nested' });
+	registerActions('stream', '#initial-widget[data-enhanced-action]', {
+		id: 'attribute-actions',
+	});
+	registerActions('stream', '#annotation-link.interactive-annotation', {
+		id: 'class-actions',
+	});
+	registerActions('nested', '#nested-range[data-live] #nested-widget', {
+		id: 'ancestor-actions',
+	});
+	await root.ready;
+}
+
 async function appendStreamedMarkup(chunks: StreamChunk[]): Promise<void> {
 	const stream = new ReadableStream<StreamChunk>({
 		start(controller) {
@@ -263,6 +279,7 @@ const harness = {
 	},
 	handoffNestedOwner,
 	mountAbortedInteractions,
+	mountChangingSelectors,
 	mountPendingInteractions,
 	mountPendingRange,
 	mountStreaming,

--- a/packages/octane/tests/browser/behavior-root/main.ts
+++ b/packages/octane/tests/browser/behavior-root/main.ts
@@ -1,0 +1,282 @@
+import { attachBehaviorRoot } from '../../../src/index.js';
+
+type BehaviorRoot = ReturnType<typeof attachBehaviorRoot>;
+type BehaviorRegistration = ReturnType<BehaviorRoot['registerBehavior']>;
+type StreamChunk = { html?: string; owner?: 'outer' | 'nested'; text?: string };
+type InteractionRecord = {
+	id: string;
+	nativeDispatches: number;
+	original: boolean;
+	owner: string | null;
+	trusted: boolean;
+	type: string;
+};
+
+const shell = document.querySelector('#behavior-shell') as HTMLElement;
+const external = shell.querySelector('#external-range') as HTMLElement;
+const nested = shell.querySelector('#nested-range') as HTMLElement;
+const article = shell.querySelector('#streamed-text') as HTMLElement;
+const initialWidget = shell.querySelector('#initial-widget') as HTMLButtonElement;
+const form = shell.querySelector('#repeated-form') as HTMLFormElement;
+const svgGroup = shell.querySelector('#external-svg-group')!;
+const mathRow = shell.querySelector('#external-math-row')!;
+
+const originalEvents = new Map<string, Event>();
+const nativeDispatches = new Map<string, number>();
+const adoptions: string[] = [];
+const cleanups: string[] = [];
+const interactions: InteractionRecord[] = [];
+
+let root: BehaviorRoot | undefined;
+let resolvePending: (() => void) | undefined;
+let abortController: AbortController | undefined;
+let nativeSubmissions = 0;
+let trustedSubmissions = 0;
+let hashChanges = 0;
+let streamCanceled = false;
+
+function observeOriginalEvents(container: HTMLElement): void {
+	container.ownerDocument.addEventListener(
+		'click',
+		(event) => {
+			const target = event.target as Element | null;
+			if (target === null || !container.contains(target)) return;
+			originalEvents.set(target.id, event);
+			nativeDispatches.set(target.id, (nativeDispatches.get(target.id) ?? 0) + 1);
+		},
+		true,
+	);
+}
+
+observeOriginalEvents(shell);
+form.addEventListener('submit', (event) => {
+	event.preventDefault();
+	nativeSubmissions++;
+	if (event.isTrusted) trustedSubmissions++;
+});
+window.addEventListener('hashchange', () => hashChanges++);
+
+function registerActions(
+	owner: string,
+	target: string,
+	options: { id?: string; ready?: Promise<void> } = {},
+): BehaviorRegistration {
+	return root!.registerBehavior({
+		id: options.id ?? `${owner}:${target}`,
+		target,
+		owner,
+		events: ['click'],
+		...(options.ready === undefined ? {} : { ready: options.ready }),
+		adopt(element) {
+			adoptions.push(element.id);
+			return () => cleanups.push(element.id);
+		},
+		handleEvent(event, element, context) {
+			interactions.push({
+				id: element.id,
+				nativeDispatches: nativeDispatches.get(element.id) ?? 0,
+				original: originalEvents.get(element.id) === event,
+				owner: typeof context.range?.owner === 'string' ? context.range.owner : null,
+				trusted: event.isTrusted,
+				type: event.type,
+			});
+		},
+	});
+}
+
+function deferred(): Promise<void> {
+	return new Promise<void>((resolve) => {
+		resolvePending = resolve;
+	});
+}
+
+async function mountStreaming(): Promise<void> {
+	const patched = document.createElement('strong');
+	patched.id = 'patched-before-attachment';
+	patched.textContent = 'Patched before attachment';
+	external.insertBefore(patched, article);
+
+	root = attachBehaviorRoot(shell);
+	root.registerExternalRange(external, { owner: 'stream' });
+	root.registerExternalRange(nested, { owner: 'nested' });
+	registerActions('stream', '[data-stream-action]', { id: 'stream-actions' });
+	registerActions('nested', '[data-stream-action]', { id: 'nested-actions' });
+	await root.ready;
+}
+
+async function appendStreamedMarkup(chunks: StreamChunk[]): Promise<void> {
+	const stream = new ReadableStream<StreamChunk>({
+		start(controller) {
+			for (const chunk of chunks) controller.enqueue(chunk);
+			controller.close();
+		},
+	});
+	const reader = stream.getReader();
+	for (;;) {
+		const result = await reader.read();
+		if (result.done) break;
+		const chunk = result.value;
+		if (chunk.text !== undefined) article.textContent = chunk.text;
+		if (chunk.html !== undefined) {
+			const template = document.createElement('template');
+			template.innerHTML = chunk.html;
+			if (chunk.owner === 'nested') nested.appendChild(template.content);
+			else external.insertBefore(template.content, nested);
+		}
+	}
+}
+
+function mountPendingInteractions(): void {
+	root = attachBehaviorRoot(shell);
+	root.registerExternalRange(external, { owner: 'stream' });
+	registerActions('stream', '[data-pending-action]', {
+		id: 'pending-actions',
+		ready: deferred(),
+	});
+}
+
+function mountPendingRange(): void {
+	root = attachBehaviorRoot(shell);
+	root.registerExternalRange(external, { owner: 'stream', ready: deferred() });
+	registerActions('stream', '[data-stream-action]', { id: 'pending-range-actions' });
+}
+
+function mountAbortedInteractions(): void {
+	abortController = new AbortController();
+	const reader = new ReadableStream<StreamChunk>({
+		start(controller) {
+			controller.enqueue({ text: 'Streamed before cancellation' });
+		},
+		cancel() {
+			streamCanceled = true;
+		},
+	}).getReader();
+	void reader.read().then((result) => {
+		if (!result.done && !abortController!.signal.aborted) {
+			article.textContent = result.value.text ?? '';
+		}
+	});
+	abortController.signal.addEventListener('abort', () => void reader.cancel(), { once: true });
+	root = attachBehaviorRoot(shell, { signal: abortController.signal });
+	root.registerExternalRange(external, { owner: 'stream' });
+	registerActions('stream', '#initial-widget', { id: 'active-action' });
+	registerActions('stream', '#annotation-link', {
+		id: 'aborted-action',
+		ready: deferred(),
+	});
+	void root.ready.catch(() => {});
+}
+
+function conflict(): string | null {
+	try {
+		root!.registerExternalRange(nested, { owner: 'replacement' });
+		return null;
+	} catch (error) {
+		return error instanceof Error ? error.message : String(error);
+	}
+}
+
+async function handoffNestedOwner(): Promise<void> {
+	root!.registerExternalRange(nested, { owner: 'replacement', replace: true });
+	registerActions('replacement', '[data-stream-action]', { id: 'replacement-actions' });
+	await root!.ready;
+}
+
+async function replaceDocumentRoot(): Promise<void> {
+	root!.dispose({ preserveDOM: true });
+
+	const frame = document.createElement('iframe');
+	frame.id = 'replacement-document';
+	const loaded = new Promise<void>((resolve) => {
+		frame.addEventListener('load', () => resolve(), { once: true });
+	});
+	frame.srcdoc =
+		'<main id="replacement-shell"><section id="replacement-range">' +
+		'<button id="replacement-widget" type="button" data-stream-action>' +
+		'Replacement widget</button></section></main>';
+	document.body.appendChild(frame);
+	await loaded;
+
+	const replacementShell = frame.contentDocument!.querySelector(
+		'#replacement-shell',
+	) as HTMLElement;
+	observeOriginalEvents(replacementShell);
+	root = attachBehaviorRoot(replacementShell);
+	root.registerExternalRange(replacementShell.querySelector('#replacement-range') as HTMLElement, {
+		owner: 'replacement-document',
+	});
+	registerActions('replacement-document', '[data-stream-action]', {
+		id: 'replacement-document-action',
+	});
+	await root.ready;
+}
+
+function state() {
+	const frame = document.querySelector('#replacement-document') as HTMLIFrameElement | null;
+	return {
+		adoptions: adoptions.slice(),
+		cleanups: cleanups.slice(),
+		documentScoped:
+			frame?.contentDocument === undefined || frame?.contentDocument === null
+				? null
+				: root?.container.ownerDocument === frame.contentDocument &&
+					root.container.ownerDocument !== shell.ownerDocument,
+		hash: location.hash,
+		hashChanges,
+		identity: {
+			article: shell.querySelector('#streamed-text') === article,
+			external: shell.querySelector('#external-range') === external,
+			initialWidget: shell.querySelector('#initial-widget') === initialWidget,
+			mathRow: shell.querySelector('#external-math-row') === mathRow,
+			nested: shell.querySelector('#nested-range') === nested,
+			shell: document.querySelector('#behavior-shell') === shell,
+			svgGroup: shell.querySelector('#external-svg-group') === svgGroup,
+		},
+		interactions: interactions.map((interaction) => ({ ...interaction })),
+		nativeDispatches: Object.fromEntries(nativeDispatches),
+		nativeSubmissions,
+		namespaces: {
+			math: mathRow.namespaceURI,
+			svg: svgGroup.namespaceURI,
+		},
+		patchedBeforeAttachment: external.querySelector('#patched-before-attachment') !== null,
+		protectedAttributes: {
+			range: external.getAttribute('data-protected'),
+			shell: shell.getAttribute('data-protected'),
+		},
+		streamCanceled,
+		text: article.textContent,
+		trustedSubmissions,
+	};
+}
+
+const harness = {
+	abort() {
+		abortController!.abort();
+		abortController!.abort();
+		root!.dispose({ preserveDOM: true });
+	},
+	appendStreamedMarkup,
+	conflict,
+	dispose() {
+		root?.dispose({ preserveDOM: true });
+	},
+	handoffNestedOwner,
+	mountAbortedInteractions,
+	mountPendingInteractions,
+	mountPendingRange,
+	mountStreaming,
+	replaceDocumentRoot,
+	resolvePending() {
+		resolvePending!();
+	},
+	state,
+};
+
+window.__behaviorRootBrowser = harness;
+
+declare global {
+	interface Window {
+		__behaviorRootBrowser: typeof harness;
+	}
+}

--- a/packages/octane/typetests/behavior-root.test-d.ts
+++ b/packages/octane/typetests/behavior-root.test-d.ts
@@ -1,0 +1,65 @@
+import {
+	attachBehaviorRoot,
+	type BehaviorCleanup,
+	type BehaviorContext,
+	type BehaviorEntry,
+	type BehaviorRegistration,
+	type BehaviorRoot,
+	type ExternalRange,
+} from 'octane';
+import { attachBehaviorRoot as attachFocusedBehaviorRoot } from 'octane/behavior';
+
+const container = document.createElement('main');
+const owner = Symbol('external stream');
+const lifetime = new AbortController();
+
+const root: BehaviorRoot = attachBehaviorRoot(container, { signal: lifetime.signal });
+const focusedRoot: BehaviorRoot = attachFocusedBehaviorRoot(container, { replace: true });
+const range: ExternalRange = focusedRoot.registerExternalRange(container, {
+	owner,
+	ready: Promise.resolve(),
+});
+
+const entry: BehaviorEntry = {
+	id: 'annotations',
+	target: '[data-annotation]',
+	owner,
+	events: ['click'],
+	ready: Promise.resolve(),
+	dependencies: [],
+	conflicts: [],
+	adopt(element, context: BehaviorContext) {
+		const signal: AbortSignal = context.signal;
+		const adopted: Element = element;
+		adopted.addEventListener('click', () => {}, { signal });
+		const cleanup: BehaviorCleanup = () => adopted.removeAttribute('data-adopted');
+		return cleanup;
+	},
+	handleEvent(event, element, context) {
+		const original: Event = event;
+		const adopted: Element = element;
+		const signal: AbortSignal = context.signal;
+		if (!signal.aborted && original.type === 'click') adopted.matches('[data-annotation]');
+	},
+};
+
+const registration: BehaviorRegistration = focusedRoot.registerBehavior(entry);
+const rangeReady: Promise<void> = range.ready;
+const behaviorReady: Promise<void> = registration.ready;
+const rootReady: Promise<void> = focusedRoot.ready;
+
+registration.dispose();
+range.dispose();
+root.dispose({ preserveDOM: true });
+
+// @ts-expect-error — a behavior root adopts an element, not an arbitrary node.
+attachBehaviorRoot(document.createTextNode('not a container'));
+
+// @ts-expect-error — every externally owned range declares its owner.
+focusedRoot.registerExternalRange(container, {});
+
+// @ts-expect-error — behavior targets must be a selector or an element.
+focusedRoot.registerBehavior({ target: 123, adopt() {} });
+
+// @ts-expect-error — adoption cleanup cannot return an arbitrary value.
+focusedRoot.registerBehavior({ target: 'button', adopt: () => 123 });

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -326,6 +326,15 @@ describe('CI workflow aggregation', () => {
 		assert.deepEqual(projects.get('rspeedy-plugin-browser').test.include, [browserGlob]);
 	});
 
+	test('installs WebKit only for the cross-browser integration lane', () => {
+		const heavyIntegration = jobSource('heavy_integration');
+
+		assert.match(
+			heavyIntegration,
+			/- name: Install Playwright WebKit for cross-browser ownership coverage\n\s+if: \$\{\{ matrix\.lane == 'browser' \}\}\n\s+run: pnpm --filter octane exec playwright install --with-deps webkit/,
+		);
+	});
+
 	test('derives sharded projects generically from execution-group ownership', () => {
 		const projects = configureShardedProjects([
 			{ test: { name: 'ordinary', include: ['ordinary/**/*.test.ts'] } },

--- a/website-mcp/tests/content.test.ts
+++ b/website-mcp/tests/content.test.ts
@@ -105,6 +105,31 @@ describe('llms text', () => {
 		}
 	});
 
+	it('documents behavior-only ownership in the summary and full website corpus', () => {
+		const ownershipGuide = LLMS_TXT.split(
+			'## Behavior-only roots and external ownership\n',
+		)[1]?.split('\n## ')[0];
+		expect(ownershipGuide).toBeDefined();
+
+		for (const marker of [
+			'attachBehaviorRoot',
+			'octane/behavior',
+			'registerExternalRange',
+			'registerBehavior',
+			'preserveDOM',
+			'/docs/core-apis#behavior-only-roots',
+		]) {
+			expect(ownershipGuide, marker).toContain(marker);
+		}
+
+		const coreApis = docBySlug('core-apis')!;
+		expect(coreApis.sections).toContainEqual(
+			expect.objectContaining({ id: 'behavior-only-roots' }),
+		);
+		expect(coreApis.markdown).toContain('attachBehaviorRoot');
+		expect(LLMS_FULL_TXT).toContain(coreApis.markdown.trim());
+	});
+
 	it('lists the catalogued bindings package-for-package', () => {
 		const bindingsGuide = LLMS_TXT.split(
 			'Bindings — reach for these when asked about the React equivalent:\n',

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -20,6 +20,7 @@ Key facts for answering questions about Octane:
 - `class`/`className` compose clsx-style (strings, numbers, arrays, objects, nesting; falsy drops out).
 - Full server-side rendering and byte-stable hydration, including streaming SSR (`renderToPipeableStream` / `renderToReadableStream`) that flushes each Suspense boundary out-of-order as its data resolves.
 - `<Hydrate>` can leave initial server HTML visible but inert until `load()`, idle time, visibility, a media query, interaction, an application condition, or never. Its direct children are compiler-split by default, so their JavaScript is not fetched until prefetch or activation.
+- `attachBehaviorRoot` from `octane/behavior` attaches abortable, delegated behavior to existing server-rendered or independently streamed DOM without hydrating, rendering, replacing nodes, or taking reconciliation ownership. Nested external owners, asynchronous readiness, genuine native interactions, and exactly-once cleanup have explicit lifecycle contracts.
 - No class components, no Server Components, no StrictMode double-invoke.
 - Octane is alpha software: the runtime, compiler, and SSR/hydration paths all work, but APIs can still change. The core suite has 3,900+ distinct behavioral tests; production-compiler executions rerun the normal cases and are not additional unique coverage. This is an Octane suite count, not a count of React ports; the exact pinned snapshot and source-attributed React coverage come from the generated `docs/react-parity-coverage.md` ledger report.
 
@@ -49,7 +50,7 @@ An uncontrolled field that intentionally saves only when the browser commits the
 - [Build tools](https://octanejs.dev/docs/build-tools): Configure the recommended Vite integration or the matching Rspack and Rsbuild plugins, including routing, SSR, hydration, production, and preview.
 - [CLI](https://octanejs.dev/docs/cli): The `octane` command line — `create` scaffolds a new app into an empty directory (this is what `npm create octane my-app` runs, so the two are the same command reached two ways); `doctor` diagnoses the misconfigurations that fail quietly (a duplicated runtime, a missing `jsxImportSource`, plain `tsc` over `.tsrx`, a wildcard `declare module '*.tsrx'`) and `--fix` repairs the mechanical ones; `analyze` compiles every `.tsrx` through the project's own octane and reports the compiler diagnostics; `init` wires Octane into an existing project; `add` installs a binding by the React package it ports; `explain` decodes a minified production error; `mcp add` registers the MCP server with Claude Code, Codex, Cursor, or VS Code. Every command emits `--json` and uses fixed exit codes (`3` = doctor found problems).
 - [Profiling](https://octanejs.dev/docs/profiling): Enable `profile: true` with Vite, Rspack, or Rsbuild to inspect component render/DOM time, self time, render counts, causes, bails, scheduling delay, and Chrome trace data.
-- [Core APIs](https://octanejs.dev/docs/core-apis): Roots, components, state and effect hooks, current-state getters, context, Suspense, deferred hydration and code splitting, transitions, actions, events, and SSR/static rendering.
+- [Core APIs](https://octanejs.dev/docs/core-apis): Roots, components, state and effect hooks, current-state getters, context, Suspense, deferred hydration and code splitting, behavior-only roots and external DOM ownership, transitions, actions, events, and SSR/static rendering.
 - [TSRX vs TSX/JSX](https://octanejs.dev/docs/tsrx-vs-tsx): When to author in `.tsrx` versus standard `.tsx`/`.jsx`, and what each dialect unlocks (compiled collections, template control flow, the `@{ … }` shorthand, text holes).
 - [Publishing libraries](https://octanejs.dev/docs/publishing-libraries): Ship the complete authored source graph, including `.tsrx`, `.tsx`, `.ts`, and `.js`, point package exports at that source, and let the consuming application compile it. Do not publish precompiled Octane output.
 - [Differences from React](https://octanejs.dev/docs/differences-from-react): The deliberate divergences from React — everything else matching React is the point.
@@ -121,6 +122,57 @@ A procedural prefetch can prepare code and data. Awaited work blocks activation 
 The procedural context also exposes `waitFor(strategy)` for the same five prefetch strategies and the persistent boundary `element`. Procedural prefetch works with either split mode; strategy prefetch requires splitting.
 
 The remaining public props are `fallback`, client-only loading UI for a later client mount or suspension, and `onHydrated`, called once after the child successfully commits on the client, including a client-only mount. Initial server HTML remains visible while its strategy or first activation suspension waits; `fallback` does not replace it. `children` is the server-rendered subtree. See the [Core APIs guide](https://octanejs.dev/docs/core-apis#deferred-hydration) and [complete deferred hydration reference](https://github.com/octanejs/octane/blob/main/docs/deferred-hydration.md).
+
+## Behavior-only roots and external ownership
+
+`<Hydrate split={false} when={never()}>` preserves externally managed server DOM without a wrapper, but its descendant client component graph is deliberately erased, so component event handlers inside that range never attach. Use `attachBehaviorRoot` to add separately owned behavior without creating a component root or claiming reconciliation ownership:
+
+```ts
+import { attachBehaviorRoot } from 'octane/behavior';
+import { articleStream } from './article-stream.js';
+
+const lifetime = new AbortController();
+const owner = Symbol('article stream');
+const root = attachBehaviorRoot(document.querySelector('#app')!, {
+	signal: lifetime.signal,
+});
+
+root.registerExternalRange(document.querySelector('#article')!, {
+	owner,
+	ready: articleStream.allReady,
+});
+
+let activateAnnotation: (event: Event, element: Element) => void;
+let observeAnnotation: (element: Element, signal: AbortSignal) => () => void;
+
+root.registerBehavior({
+	id: 'article-annotations',
+	owner,
+	target: '[data-annotation]',
+	events: ['click'],
+	ready: import('./annotations.js').then((module) => {
+		activateAnnotation = module.activateAnnotation;
+		observeAnnotation = module.observeAnnotation;
+	}),
+	adopt(element, { signal }) {
+		return observeAnnotation(element, signal);
+	},
+	handleEvent(event, element) {
+		activateAnnotation(event, element);
+	},
+});
+
+await root.ready;
+root.dispose(); // Abort behavior and preserve the existing DOM.
+```
+
+- Import the focused, renderer-free entry from `octane/behavior`, or import the same API and public types from `octane`. Behavior roots neither render nor hydrate; existing nodes, protected attributes, HTML/SVG/MathML namespaces, and independent streamed updates remain externally owned. Selector targets discover subsequently inserted matching elements.
+- `registerExternalRange(element, { owner, ready?, signal?, replace? })` explicitly declares external ownership. The closest registered nested range wins. A second owner for the same element requires `replace: true`; an already-aborted replacement never evicts a live owner. Root and range identity are scoped to their document and container.
+- `registerBehavior({ target, adopt, id?, owner?, events?, ready?, dependencies?, conflicts?, signal?, handleEvent? })` accepts a selector or element. `adopt(element, { signal, event?, range? })` may return synchronous or asynchronous cleanup; named dependencies must already exist and conflicts or duplicate IDs fail deterministically. Adoption waits for behavior, dependency, and matching range readiness.
+- Delegated interactions are observed immediately, including before asynchronously loaded behavior or externally streamed ranges become ready. `handleEvent` receives the exact original same-document `Event` and its genuine `isTrusted` value; Octane never redispatches it, invents trusted events, repeats native link/form activation, or restores expired transient user activation. This direct delivery is distinct from `<Hydrate when={interaction()}>` hydration replay.
+- `root.ready` snapshots active ranges and behaviors; each registration exposes its own `ready`, `signal`, and idempotent `dispose()`. Root cancellation aborts pending work, ignores stale async completions, disconnects listeners/observers, and runs adopted cleanup exactly once. `root.dispose()` preserves DOM by default; use `root.dispose({ preserveDOM: false })` only to explicitly clear descendants. Replacing a live root on the same container requires `attachBehaviorRoot(container, { replace: true })`.
+
+See the [behavior-only roots guide](https://octanejs.dev/docs/core-apis#behavior-only-roots) and [complete external ownership reference](https://github.com/octanejs/octane/blob/main/docs/deferred-hydration.md#behavior-only-roots-and-external-ownership).
 
 ## Core state APIs
 

--- a/website/src/content/docs-meta.ts
+++ b/website/src/content/docs-meta.ts
@@ -164,6 +164,22 @@ export const docsMeta: DocMeta[] = [
 			},
 			{ id: 'async-ui', title: 'Loading data and code' },
 			{ id: 'deferred-hydration', title: 'Deferred hydration' },
+			{
+				id: 'behavior-only-roots',
+				title: 'Behavior-only roots and external ownership',
+				searchTerms: [
+					'attachBehaviorRoot',
+					'octane/behavior',
+					'registerExternalRange',
+					'registerBehavior',
+					'external ownership',
+					'externally owned DOM',
+					'behavior-only root',
+					'permanent static',
+					'streamed DOM',
+					'preserveDOM',
+				],
+			},
 			{ id: 'responsive-updates', title: 'Responsive updates and actions' },
 			{
 				id: 'use-transition',

--- a/website/src/content/docs/core-apis.mdx
+++ b/website/src/content/docs/core-apis.mdx
@@ -864,6 +864,142 @@ For compiler constraints, nesting behavior, event details, and the full procedur
 context, read the
 [deferred hydration guide](https://github.com/octanejs/octane/blob/main/docs/deferred-hydration.md).
 
+<h2 id="behavior-only-roots">Behavior-only roots and external ownership</h2>
+
+Sometimes another system owns the HTML: a streaming renderer appends paragraphs, a
+content platform replaces article sections, or a separate application controls a
+widget. `attachBehaviorRoot` adds client behavior to those existing elements without
+rendering, hydrating, reconciling, or taking ownership of their markup.
+
+Choose the ownership model before deciding how to make the page interactive:
+
+| Approach                                 | Who owns the DOM?        | What runs on the client?                       |
+| ---------------------------------------- | ------------------------ | ---------------------------------------------- |
+| `hydrateRoot(container, App)`            | Octane's component tree. | The hydrated components, effects, and events.  |
+| `<Hydrate when={visible()}>`             | Octane after activation. | The deferred component tree when it activates. |
+| `<Hydrate split={false} when={never()}>` | The server or a stream.  | No descendant component tree or handlers.      |
+| `attachBehaviorRoot(container)`          | The existing owner.      | Only the explicitly registered behaviors.      |
+
+The last two approaches work together: keep an externally owned server range static,
+then attach only the independent behavior it actually needs.
+
+### Keep the streamed HTML permanently static
+
+Use the exact two-attribute form below when Octane should render a range on the server
+but never create its descendant component graph on the client:
+
+```tsrx
+import { Hydrate } from 'octane';
+import { never } from 'octane/hydration';
+
+export function ArticleShell() @{
+	<main id="article-shell">
+		<Hydrate split={false} when={never()}>
+			<article id="streamed-article">
+				<a href="#annotation" data-annotation>Open annotation</a>
+			</article>
+		</Hydrate>
+	</main>
+}
+```
+
+The server emits the children without a wrapper; the client preserves those exact nodes
+without evaluating, hydrating, or reconciling them. `Hydrate` and `never` must be
+direct imports, although locally renamed imports are supported, and the opening tag
+must have exactly `split={false}` and `when={never()}`. Extra attributes, spreads, or
+indirect values fall back to ordinary deferred-hydration behavior. Component event
+handlers inside this permanently static range do not run because their client
+component tree does not exist.
+
+### Attach behavior without claiming the DOM
+
+Use the focused `octane/behavior` entry when this is all the client needs. It does not
+pull in the component runtime, compiler, or server renderer. The same API and public
+types are also available from `octane` when an application already uses that entry.
+
+```ts
+import { attachBehaviorRoot } from 'octane/behavior';
+import { articleStream } from './article-stream.js';
+
+const page = new AbortController();
+const shell = document.querySelector<HTMLElement>('#article-shell')!;
+const article = shell.querySelector<HTMLElement>('#streamed-article')!;
+const owner = Symbol('article stream');
+
+const root = attachBehaviorRoot(shell, { signal: page.signal });
+
+root.registerExternalRange(article, {
+	owner,
+	ready: articleStream.allReady,
+});
+
+let openAnnotation: (event: Event, element: Element) => void;
+let observeAnnotation: (element: Element, signal: AbortSignal) => () => void;
+
+const annotations = root.registerBehavior({
+	id: 'article-annotations',
+	owner,
+	target: '[data-annotation]',
+	events: ['click'],
+	ready: import('./annotations.js').then((module) => {
+		openAnnotation = module.openAnnotation;
+		observeAnnotation = module.observeAnnotation;
+	}),
+	adopt(element, { signal }) {
+		return observeAnnotation(element, signal);
+	},
+	handleEvent(event, element) {
+		openAnnotation(event, element);
+	},
+});
+
+await root.ready;
+
+// Remove this behavior independently while retaining its existing markup.
+annotations.dispose();
+
+// Dispose every range and behavior, again preserving the container's DOM.
+root.dispose();
+```
+
+`registerExternalRange` identifies who owns a subtree and can wait for that owner's
+stream to finish. `registerBehavior` adopts existing selector matches and discovers
+matching elements added later; its optional `ready` promise waits for client code or
+other preparation. A behavior can also target one `Element` directly. Removing a match,
+moving it outside the root, or changing its closest owner aborts its per-element signal
+and runs the returned cleanup exactly once. The external owner remains free to stream,
+replace, or move its own DOM throughout.
+
+### Coordinate ownership, readiness, and native events
+
+External ranges and roots are scoped to their original document. A registered range
+must belong to its root's container; strictly nested ranges are allowed, and the
+closest range determines which owner-constrained behaviors apply. Claiming the same
+element for another owner throws unless `{ replace: true }` explicitly transfers
+ownership. A replacement whose signal is already aborted never displaces a healthy
+owner. Disposing a separately managed nested root immediately restores eligible
+behavior from its surviving ancestor.
+
+Named behaviors can declare already-registered `dependencies` and mutually exclusive
+`conflicts`. Adoption waits for those dependencies, the behavior's own `ready` promise,
+and its closest external range. `root.ready` snapshots the ranges, registrations, and
+asynchronous adoptions that are active when you read it; each range and behavior also
+exposes its own `ready`, `signal`, and idempotent `dispose()`. An underlying readiness
+failure preserves its original error, while cancellation settles promptly even when
+third-party preparation never finishes.
+
+Delegated event listeners start immediately, before asynchronous behavior is ready. If
+an interaction arrives during that wait, the eventual `handleEvent` receives the exact
+same original native `Event`, including its genuine `isTrusted` value. Octane does not
+redispatch the event, invent trust, repeat a link navigation or form submission, or
+restore transient user activation after it expires. Code requiring transient activation
+must execute synchronously during the original browser event.
+
+Attaching a second root to the same live container requires `{ replace: true }`; the
+previous root is disposed without deleting the DOM. `root.dispose()` and parent-signal
+aborts preserve existing markup by default. Pass `root.dispose({ preserveDOM: false })`
+only when clearing the container is explicitly intended.
+
 <h2 id="responsive-updates">Responsive updates and actions</h2>
 
 Some updates should feel immediate, such as typing. Others may reveal UI that needs to
@@ -1342,6 +1478,10 @@ handlers; return here when you have a specific problem to solve.
 				{' / '}
 				<code>hydrateRoot</code>
 				<span>Start a client tree or adopt server HTML.</span>
+			</li>
+			<li>
+				<code>attachBehaviorRoot</code>
+				<span>Attach behavior to existing DOM without rendering or taking ownership.</span>
 			</li>
 			<li>
 				<code>preload</code>

--- a/website/tests/core-apis-docs.test.ts
+++ b/website/tests/core-apis-docs.test.ts
@@ -54,6 +54,14 @@ describe('Core APIs documentation', () => {
 		// heading→registry direction itself: an `<h2>` no entry names is missing
 		// from this table of contents and from what the MCP server serves.
 		expectRegisteredHeadings(container, coreDoc);
+		expect(container.querySelector('h2#behavior-only-roots')?.textContent).toBe(
+			'Behavior-only roots and external ownership',
+		);
+		expect(toc.querySelector('a[href="#behavior-only-roots"]')?.textContent).toContain(
+			'Behavior-only roots and external ownership',
+		);
+		expect(container.textContent).toContain('same original native');
+		expect(container.textContent).toContain('preserveDOM');
 
 		expect(container.querySelectorAll('.topic-grid a')).toHaveLength(7);
 		expect(container.querySelectorAll('[data-demo]')).toHaveLength(9);
@@ -114,6 +122,10 @@ describe('Core APIs documentation', () => {
 			'<Hydrate when={visible({ rootMargin:',
 			'<Hydrate when={idle()} split={false}>',
 			'<Hydrate when={interaction()} prefetch={idle()}>',
+			'<Hydrate split={false} when={never()}>',
+			"import { attachBehaviorRoot } from 'octane/behavior';",
+			'root.registerExternalRange(article,',
+			'root.registerBehavior({',
 			'const [isPending, startTransition] = useTransition();',
 			'const deferredQuery = useDeferredValue(query);',
 			'<ViewTransition enter="notice-in" exit="notice-out">',
@@ -137,6 +149,11 @@ describe('Core APIs documentation', () => {
 		expect(groupedApiCodeCount('isChildrenBlock')).toBe(3);
 		expect(
 			apiRows.some((row) => row.querySelector(':scope > code')?.textContent === 'Hydrate'),
+		).toBe(true);
+		expect(
+			apiRows.some(
+				(row) => row.querySelector(':scope > code')?.textContent === 'attachBehaviorRoot',
+			),
 		).toBe(true);
 		expect(
 			apiRows.some((row) => row.querySelector(':scope > code')?.textContent === 'useLinkedState'),

--- a/website/tests/docs-search.test.ts
+++ b/website/tests/docs-search.test.ts
@@ -130,6 +130,24 @@ describe('docs search ranking', () => {
 		expect(top.id).toBe('deferred-hydration');
 	});
 
+	it('deep links behavior-root API and external-ownership searches to their guide', async () => {
+		const index = await loadSearchIndex();
+
+		for (const query of [
+			'attachBehaviorRoot',
+			'octane/behavior',
+			'registerExternalRange',
+			'external ownership',
+			'permanent static',
+		]) {
+			const [top] = searchDocs(index, query);
+
+			expect(top, query).toBeDefined();
+			expect(top.slug, query).toBe('core-apis');
+			expect(top.id, query).toBe('behavior-only-roots');
+		}
+	});
+
 	it('deep links Strong-mode searches to the build configuration guide', async () => {
 		const index = await loadSearchIndex();
 		const [top] = searchDocs(index, 'strong mode');

--- a/website/tests/ssr-smoke.test.ts
+++ b/website/tests/ssr-smoke.test.ts
@@ -126,6 +126,10 @@ describe('built Start server', () => {
 		expect(classCount(html, 'shiki')).toBeGreaterThan(0);
 		expect(html).toContain('id="deferred-hydration"');
 		expect(html).toContain('Deferred hydration');
+		expect(html).toContain('id="behavior-only-roots"');
+		expect(html).toContain('Behavior-only roots and external ownership');
+		expect(html).toContain('attachBehaviorRoot');
+		expect(html).toContain('octane/behavior');
 	});
 
 	// This route deliberately renders every chart and accessible data table; give


### PR DESCRIPTION
## Summary

- Add renderer-independent `attachBehaviorRoot` from both `octane` and the focused `octane/behavior` entry point; behavior-only bundles retain no component runtime, compiler, or server modules.
- Coordinate document-scoped external DOM ownership, nearest-owner nesting, explicit conflict/replacement/handoff, readiness and dependencies, cancellation, stale async work, deterministic cleanup, and DOM-preserving disposal.
- Reconcile existing behavior targets when their own or an ancestor’s attributes/classes change; regression coverage verifies repeated adoption, nearest-owner routing, trusted native events, and exactly-once cleanup in development, production, Chromium, and WebKit.
- Adopt server-rendered and progressively streamed nodes while preserving actual native `Event` identity/trust, original node identity and namespaces, and once-only native link/form activation without synthetic redispatch.
- Document behavior-only roots and external ownership throughout the public website Core APIs guide, table of contents, API index, search, and hand-maintained `llms.txt`; automatically expose the same material through MCP `/llms.txt`, `/llms-full.txt`, and documentation search.
- Add 46 public lifecycle cases in development and production, Chromium/WebKit integration coverage, buffered/Web `ReadableStream` SSR regressions, public typings, package/distribution and production-bundle guards, documentation, a patch changeset, and WebKit installation only in the existing browser CI lane.

Closes #650.

## Validation

- [x] `pnpm format:check`
- [ ] `pnpm typecheck` — the full 251-project workspace was not typechecked; both TypeScript 5.9 and `tsgo` pass for the complete Octane package and public typetests.
- [ ] `pnpm test` — every unscoped monorepo project was not run; the actual root test command, package prechecks, and complete Octane development/production projects passed below.
- [x] targeted tests:
  - `pnpm exec vitest run --project website-unit --maxWorkers=4 --reporter=dot` — **332 public-website tests passed**.
  - `pnpm exec vitest run --project website-mcp-unit --reporter=dot` — **41 MCP content, search, and HTTP endpoint tests passed**.
  - `pnpm exec vitest run --project website-integration website/tests/ssr-smoke.test.ts --reporter=dot` — **8 production Vercel-build and SSR tests passed**, including the rendered behavior-root guide.
  - `cmp website/public/llms.txt website/.vercel/output/static/llms.txt` — deployed model-facing asset exactly matches its hand-authored source.
  - `pnpm --dir website typecheck` and `pnpm exec tsgo --noEmit -p website-mcp/tsconfig.json`.
  - `pnpm sync`
  - `pnpm test --project octane --project octane-prod --maxWorkers=4 --reporter=json --outputFile=/private/tmp/octane-671-review-core-results.json` — **11,251 passed across 2,557 suites**, including all package prechecks.
  - `pnpm exec vitest run --project octane-events-browser packages/octane/tests/browser/behavior-root/behavior-root.test.ts --reporter=verbose --silent=false` — **12 passed across Chromium and WebKit**.
  - `pnpm exec vitest run --project octane --project octane-prod packages/octane/tests/behavior-root-bundle.test.ts` — isolated public entry points and existing root reachability.
  - `pnpm --filter octane build` — production modules, declarations, and public distribution/export verification.
  - `pnpm exec tsc --noEmit -p packages/octane/tsconfig.json` and `pnpm exec tsc --noEmit -p packages/octane/typetests/tsconfig.json`.
  - `pnpm exec tsgo --noEmit -p packages/octane/tsconfig.json` and `pnpm exec tsgo --noEmit -p packages/octane/typetests/tsconfig.json`.
  - `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false pnpm ci:workflow:test` — **81 passed**.
  - `node benchmarks/bundle-size/run-minimal.mjs` — all **28 production builds and executable semantic oracles passed**; no existing scenario retains the new behavior module.
  - `pnpm packages:inventory:check` and `pnpm changeset:check`.

Existing measured bundle sizes match the exact current-`main` baseline: `createRoot` **94,620 raw / 31,274 gzip**, `hydrateRoot` **109,856 / 36,065**, and hydration event capture **3,117 / 1,418**. The standalone behavior entry is **12,038 bytes minified / 3,741 gzip** and contains only the behavior module.

## Risk / follow-ups

- `node benchmarks/bench.mjs --quick --ratios bundle-reachability` passes **82/84** local ratio guards. The two `suspense-transition` ceilings already fail identically on untouched upstream `main` under local Node 26: **120,585 > 120,448 raw** and **34,303 > 34,288 brotli**. A same-HEAD baseline rebuild proves the proposed change causes neither failure; CI pins Node 24.
- Behavior roots intentionally reconcile text-node and attribute/class mutations so selectors such as `:empty` and ancestor combinators remain correct. Attribute-heavy external streams pay for a selector rescan per observer delivery; selector-aware streaming optimizations can be evaluated separately.
- Delayed handlers receive the original trusted native event, but browser transient user activation cannot be recreated after an asynchronous readiness boundary.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New client lifecycle surface (ownership, async readiness, event queuing) with broad test coverage; existing `createRoot`/`hydrateRoot` bundles are guarded not to pull it in unintentionally.
> 
> **Overview**
> Adds **`attachBehaviorRoot`** and a tree-shakeable **`octane/behavior`** entry so apps can wire delegated native events and disposable **`adopt`** hooks onto server-rendered or independently streamed markup **without** hydrating, rendering, or reconciling that DOM.
> 
> The new runtime tracks **document-scoped** roots, **external ranges** with explicit owners and optional **`ready`** gates, nested nearest-owner resolution, **`replace`** handoffs, behavior **dependencies/conflicts**, **queued** interactions that replay the **original trusted `Event`** (no redispatch or double form/link activation), **MutationObserver** reconciliation for streamed/attribute changes, and **DOM-preserving** disposal by default.
> 
> **`octane`** re-exports the same API/types; docs (Core APIs, deferred hydration, SSR, `llms.txt`), search/MCP metadata, a patch changeset, dist verification, extensive unit/integration tests (including Chromium/WebKit Playwright), and CI WebKit install for the browser lane land with the feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ae47e7e85a44c22952b30032539df90a6bfe33b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->