### PR TITLE
fix: direct plain-function component calls crashing in dev compile

### DIFF
--- a/.changeset/hmr-direct-component-call.md
+++ b/.changeset/hmr-direct-component-call.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Fix a dev-only crash ("Cannot read properties of undefined (reading 'block')") when a component is invoked as a plain function — for example `Row({ label })` inside another component's render or a `.map` callback. The HMR wrapper now stays transparent to scope-less direct calls, matching production behavior, and an edit still refreshes the call site's output through the caller's hot update.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -19411,9 +19411,14 @@ export function hmr<P>(fn: ComponentBody<P>): ComponentBody<P> {
 		},
 	};
 	function wrapper(props: P, scope: Scope, extra: any): unknown {
-		const block = scope.block;
-		// Register on first call; cleared lazily during update() if disposed.
-		meta.liveBlocks.add(block);
+		// Register on first call; cleared lazily during update() if disposed. A
+		// plain direct call (`Row({ … })` inside another component's render) has
+		// no scope of its own — stay transparent and register nothing. The call
+		// site's output still refreshes on edit: its owner's update() re-renders
+		// the owning block, which re-runs the direct call against the swapped-in
+		// body. Registering the AMBIENT block instead would let update() repoint
+		// that block's body at this wrapper, miswiring the caller.
+		if (scope !== undefined) meta.liveBlocks.add(scope.block);
 		// Propagate the wrapped body's return — a return-based (folded) component
 		// hands back a renderable descriptor that renderBlock must still mount.
 		return meta.fn(props as any, scope, extra);

--- a/packages/octane/tests/_fixtures/direct-call-in-list.tsx
+++ b/packages/octane/tests/_fixtures/direct-call-in-list.tsx
@@ -1,0 +1,11 @@
+/** @jsxImportSource octane */
+export function StampRow(props: { label: string }) {
+	if (props.label === '') return <li className="stamp empty">(empty)</li>;
+	return <li className="stamp">{props.label}</li>;
+}
+export function StampList(props: { labels: string[] }) {
+	return <ul className="stamps">{props.labels.map((label) => StampRow({ label }))}</ul>;
+}
+export function StampSingle(props: { label: string }) {
+	return <ul className="stamps">{StampRow({ label: props.label })}</ul>;
+}

--- a/packages/octane/tests/direct-call-in-list.test.ts
+++ b/packages/octane/tests/direct-call-in-list.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from './_helpers.js';
+import { StampList, StampRow, StampSingle } from './_fixtures/direct-call-in-list.tsx';
+
+// A return-JSX component may be invoked as a plain function (`StampRow({...})`)
+// rather than as JSX. When that direct call sits inside a `.map` callback of a
+// sibling component in the same module, each compiled wrapper must keep its own
+// body: the list renders one row per item and the row component stays usable
+// on its own.
+describe('direct component call inside a .map callback', () => {
+	it('renders one row per item through the sibling component', () => {
+		const r = mount(StampList as any, { labels: ['one', '', 'two'] });
+		const rows = r.findAll('.stamps li');
+		expect(rows.map((row) => row.textContent)).toEqual(['one', '(empty)', 'two']);
+		expect(rows[1].className).toBe('stamp empty');
+		r.unmount();
+	});
+
+	it('renders a bare direct call outside any callback', () => {
+		const r = mount(StampSingle as any, { label: 'only' });
+		expect(r.find('.stamps .stamp').textContent).toBe('only');
+		r.unmount();
+	});
+
+	it('keeps the row component independently mountable', () => {
+		const r = mount(StampRow as any, { label: 'solo' });
+		expect(r.find('.stamp').textContent).toBe('solo');
+		r.unmount();
+	});
+});

--- a/packages/octane/tests/hmr.test.ts
+++ b/packages/octane/tests/hmr.test.ts
@@ -73,6 +73,9 @@ async function compileHmrComponent(
 				},
 			)
 			.replace(/\bexport let /g, 'let ')
+			// Verbatim return-JSX functions emit `function X … export { X };`
+			// instead of `export let X = …`; drop the list form the same way.
+			.replace(/^export\s*\{[^}]*\};?\s*$/gm, '')
 			.replaceAll('import.meta.webpackHot', 'hot') + `\nreturn ${exportName};`;
 	const hot = {
 		data: undefined,
@@ -239,6 +242,42 @@ describe('hmr — runtime wrapper', () => {
 		}).not.toThrow();
 
 		expect(r.find('#child').textContent).toBe('CHILD ONE');
+		r.unmount();
+	});
+
+	// A component invoked as a plain function (`Row({ … })`) reaches the HMR
+	// wrapper without a scope. The wrapper must stay call-transparent — the
+	// wrapped module renders — and an edit still refreshes the call site's
+	// output through the CALLER's update, exactly as the emitted accept block
+	// drives it (callee first, then the caller whose new body closes over the
+	// new callee).
+	it('renders and refreshes a direct plain-function component call', async () => {
+		const v1 = `/** @jsxImportSource octane */
+			export function Row(props: { label: string }) {
+				if (props.label === '') return <li className="row empty">(empty)</li>;
+				return <li className="row">v1:{props.label}</li>;
+			}
+			export function App(props: { labels: string[] }) {
+				return <ul className="rows">{props.labels.map((label) => Row({ label }))}</ul>;
+			}
+		`;
+		const initialRow = await compileHmrComponent(v1, 'Row', '/src/App.tsx');
+		const initial = await compileHmrComponent(v1, 'App', '/src/App.tsx');
+		const v2 = v1.replace('v1:', 'v2:').replace('(empty)', '(none)');
+		const updatedRow = await compileHmrComponent(v2, 'Row', '/src/App.tsx');
+		const updated = await compileHmrComponent(v2, 'App', '/src/App.tsx');
+
+		const r = mount(initial, { labels: ['a', ''] });
+		expect(r.findAll('.row').map((el) => el.textContent)).toEqual(['v1:a', '(empty)']);
+
+		flushSync(() => {
+			// The direct-call-only component has no live blocks of its own; its
+			// update must still succeed so the module is not force-reloaded.
+			expect((initialRow as any)[HMR].update(updatedRow)).toBe(true);
+			expect((initial as any)[HMR].update(updated)).toBe(true);
+		});
+
+		expect(r.findAll('.row').map((el) => el.textContent)).toEqual(['v2:a', '(none)']);
 		r.unmount();
 	});
 


### PR DESCRIPTION
## Summary

A component invoked as a plain function — `Row({ label })` inside another component's render, e.g. from a `.map` callback — crashed in **dev compile only** with `Cannot read properties of undefined (reading 'block')`, while the same module worked in prod. The report that surfaced this described it as a compiler miswire ("StampRow's wrapper received StampList's body"), but the emitted module is correctly wired in every permutation (single vs `.map` call, declaration order, dev/hmr on and off); the actual defect was in the runtime's dev-only HMR wrapper.

In dev compile, exports are rebound to the HMR wrapper (`Row = _$hmr(Row)`), and the wrapper read `scope.block` unconditionally. The runtime always passes the block as `scope` when invoking a body (`renderBlockInner`), but a plain direct call passes only `props`, so `scope` is `undefined` and the read throws.

## Why

Direct plain-function calls of return-JSX components are legal and work in prod, so dev must behave identically. The fix keeps the wrapper transparent to scope-less calls: it registers a live block only when a scope is present.

Deliberately **not** done: registering the ambient (caller's) block for direct calls. `update()` repoints registered blocks' `body` at the wrapper (`b.body = wrapper`), so ambient registration would graft the callee's wrapper onto the caller's block — the exact "wrapper received the other component's body" miswire the original report described. Direct-call output still refreshes on edit through the caller's own hot update (module re-evaluation rebinds the caller's closure to the new callee); cross-module direct calls stay stale until the caller re-renders, matching React Fast Refresh's limitation for this pattern.

## Changes

- `packages/octane/src/runtime.ts` — the `hmr()` wrapper registers `scope.block` only when `scope !== undefined`, with a comment explaining why ambient registration would be wrong. Dev-only path; no prod hot-path cost.
- `packages/octane/tests/direct-call-in-list.test.ts` + `tests/_fixtures/direct-call-in-list.tsx` — behavioral regression mounting the compiled module in both the dev and prod vitest projects: the `.map` shape from the report, a bare direct call, and the callee mounted on its own.
- `packages/octane/tests/hmr.test.ts` — an update-path case: a direct-call-only component's `update()` succeeds (empty live-block set is not a failure) and the call site's output refreshes through the caller's update. The `compileHmrComponent` harness now also strips the `export { X };` statement form that verbatim return-JSX functions emit (they don't use `export let`).
- `.changeset/hmr-direct-component-call.md` — patch changeset for `octane`.

All three new tests were verified red against the pre-fix runtime (same crash signature as the report) and green with the fix.

## Validation

- [x] `pnpm format:check` (scoped `format:files:check` on changed files; unchanged)
- [x] `pnpm typecheck`
- [x] `pnpm test` — 17,333/17,334; the single failure is `packages/styled-components/tests/differential/parity.test.ts` timing out at 5s under full-suite contention, unrelated to this path, and passing in isolation in 191ms
- [x] targeted tests: `vitest run packages/octane/tests/direct-call-in-list.test.ts packages/octane/tests/hmr.test.ts` (dev + prod projects, 64 tests green)

## Risk / follow-ups

- Cross-module direct-call output does not hot-refresh until the caller re-renders (matches React Fast Refresh; noted in the wrapper comment).
- Separate finding, not addressed here: `loadCompiledFixtureSource` in `tests/_server-fixture.ts` corrupts compiled modules that use `export function` declarations (its rewrite drops the hoisted binding, so the compiler's module-tail `X.$$singleRoot = true` stamp throws a `ReferenceError` no real bundler would produce). Flagged for a follow-up task.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, dev-only HMR path change with targeted regression tests; no production hot-path behavior change.
> 
> **Overview**
> **Dev compile** crashed with `Cannot read properties of undefined (reading 'block')` when a component was invoked as a plain function (e.g. `Row({ label })` in a `.map`), while production worked. The HMR wrapper always read `scope.block` even though direct calls pass only props, so `scope` was `undefined`.
> 
> The **`hmr()` wrapper** in `runtime.ts` now adds a live block only when `scope !== undefined`, matching production transparency and avoiding miswiring the caller’s block if the ambient scope were registered.
> 
> **Tests** add mount coverage for direct calls in a list, a single call, and standalone mount, plus an HMR test that callee `update()` succeeds with no live blocks and the caller refresh updates list output. The HMR compile harness strips `export { X };` for verbatim return-JSX modules. A patch **changeset** documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05de990f10360c585ecce11286f5775861d17a9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->