### PR TITLE
test: keep export function declarations hoisted in compiled-fixture loader

### DIFF
--- a/packages/octane/tests/_server-fixture.ts
+++ b/packages/octane/tests/_server-fixture.ts
@@ -51,10 +51,20 @@ export function loadCompiledFixtureSource<T extends CompiledFixtureModule = Comp
 			`const {${names.replace(/\s+as\s+/g, ': ')}} = __hydrationRuntime;`,
 	);
 
+	// `export function X` must stay a real function *declaration*: compiled
+	// modules reference exported components by name after the declaration (the
+	// compiler's module tail stamps `X.$$singleRoot = true;`, and sibling
+	// components call each other directly). Strip only the `export ` keyword
+	// here and register the exports at the end of the module — declarations
+	// hoist, so end-of-module registration is safe and also observes any later
+	// reassignment of the binding.
+	const functionExports: string[] = [];
 	code = code.replace(
 		/export\s+(async\s+)?function\s+(\w+)/g,
-		(_match: string, asyncKeyword: string | undefined, name: string) =>
-			`__exports.${name} = ${asyncKeyword ?? ''}function ${name}`,
+		(_match: string, asyncKeyword: string | undefined, name: string) => {
+			functionExports.push(name);
+			return `${asyncKeyword ?? ''}function ${name}`;
+		},
 	);
 	code = code.replace(
 		/export\s+(const|let|var)\s+(\w+)\s*=/g,
@@ -66,6 +76,10 @@ export function loadCompiledFixtureSource<T extends CompiledFixtureModule = Comp
 		throw new Error(
 			`Compiled fixture ${id} contains an import/export shape the shared loader cannot evaluate.`,
 		);
+	}
+
+	for (const name of functionExports) {
+		code += `\n__exports.${name} = ${name};`;
 	}
 
 	const evaluate = new Function(

--- a/packages/octane/tests/fixture-loader.test.ts
+++ b/packages/octane/tests/fixture-loader.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Loader-level contract: `loadCompiledFixtureSource` must keep every
+ * `export function` as a real module-scope function declaration. Compiled
+ * modules reference exported components by name after their declaration —
+ * the compiler's module tail stamps metadata on them, and sibling components
+ * call each other directly — so a rewrite into a function *expression*
+ * assignment (which has no module-scope binding) makes evaluation throw
+ * `ReferenceError: <Component> is not defined` even though the compiled
+ * module is correct under a real bundler.
+ */
+import { describe, expect, it } from 'vitest';
+import { mount } from './_helpers.js';
+import { loadCompiledFixtureSource } from './_server-fixture.js';
+
+// Two exported components where the second renders the first by name; both
+// are single-root, so the compiled module tail references both names.
+const source = `
+export function Item({ label }: { label: string }) {
+	return <li>{label as string}</li>;
+}
+
+export function List() {
+	return (
+		<ul>
+			<Item label="a" />
+			<Item label="b" />
+		</ul>
+	);
+}
+`;
+
+describe('loadCompiledFixtureSource', () => {
+	it('evaluates client modules whose tail and siblings reference exported components by name', () => {
+		const mod = loadCompiledFixtureSource(source, {
+			id: '/packages/octane/tests/_fixtures/fixture-loader-exports.tsx',
+			mode: 'client',
+		});
+
+		expect(typeof mod.Item).toBe('function');
+		expect(typeof mod.List).toBe('function');
+
+		const { container, unmount } = mount(mod.List);
+		try {
+			const items = Array.from(container.querySelectorAll('ul > li'), (li) => li.textContent);
+			expect(items).toEqual(['a', 'b']);
+		} finally {
+			unmount();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

`loadCompiledFixtureSource` in `packages/octane/tests/_server-fixture.ts` rewrote `export function X` into `__exports.X = function X` — a named function *expression*, whose name binds only inside its own body. That destroyed both hoisting and the module-scope binding, so compiled modules that reference an exported component by name after its declaration threw `ReferenceError: X is not defined` at evaluation, even though the compiled module is correct under a real bundler. Two real shapes hit this:

- the compiler's module-tail stamp (`X.$$singleRoot = true;`), emitted for every single-root exported component;
- a sibling component calling `X` directly (`_$createElement(X, …)`).

The loader now strips only the `export ` keyword — keeping a real, hoisted function declaration — collects the names, and appends `__exports.X = X;` registrations at the end of the evaluated module. Declarations hoist, so end-of-module registration is safe, and reading the binding at the end also picks up any later reassignment. The existing guard that throws on leftover import/export syntax is unchanged.

Adds a loader-level regression test (`packages/octane/tests/fixture-loader.test.ts`) that compiles a two-component client module — the second component renders the first by name, and both are single-root so the module tail references both names — evaluates it through `loadCompiledFixtureSource`, and mounts one export. Pre-fix it failed with `ReferenceError: Item is not defined` in both the `octane` and `octane-prod` projects; the assertions are behavioral (rendered `<li>` contents), with no dependence on `$$…` properties or emitted-code shape.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [ ] `pnpm test` (full monorepo run not executed)
- [x] targeted tests: full `packages/octane/tests` run — 794 files / 11,215 tests passed across the `octane` and `octane-prod` projects. This directory is the loader's only consumer (verified by grep), so binding/website suites were deliberately left unrun.

`pnpm typecheck:files` on these test files reports a pre-existing `octane/compiler` / `.tsrx` resolution failure in the scoped tsgo path; it reproduces on untouched files (e.g. `component-hoisting.test.ts`) and the repo-wide `pnpm typecheck` passes.

## Risk / follow-ups

- Test infrastructure only; nothing shipped, so no changeset.
- `export function*` generators would still be rejected by the leftover-`export` guard, same as before this change; no compiled fixture emits one today.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect Octane test fixture loading (`_server-fixture.ts`); nothing in shipped runtime or compiler output.
> 
> **Overview**
> Fixes **test-only** evaluation of compiled Octane fixtures in `loadCompiledFixtureSource`: `export function` components are no longer rewritten to `__exports.X = function X` (which broke module-scope bindings and hoisting). The loader now strips `export`, keeps real function declarations, and appends `__exports.X = X` at module end so compiler tail stamps (`X.$$singleRoot`) and sibling JSX references resolve like they do under a real bundler.
> 
> Adds **`fixture-loader.test.ts`** — a regression that compiles a two-export client module (`List` renders `Item`), loads it through the fixture loader, and asserts mount output (`['a', 'b']`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a89f4bc256fb8be648cad00aa4e6c76908090f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->