### PR TITLE
perf: make Three bundles smaller than React Three Fiber

### DIFF
--- a/.changeset/slimmer-three-renderer-bundles.md
+++ b/.changeset/slimmer-three-renderer-bundles.md
@@ -1,0 +1,8 @@
+---
+'octane': patch
+'@octanejs/three': patch
+---
+
+Tree-shake unused Three.js constructors from compiled scenes and keep direct
+Three renderer roots independent of the DOM runtime while preserving full
+Canvas catalogues, context providers, and mixed-renderer scheduling.

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -1404,16 +1404,16 @@
     "op": "js_gzip",
     "target": "octane-min",
     "reference": "r3f-min",
-    "maxRatio": 2.4,
-    "note": "Minimal direct-root production gzip, with built bundles executed and scene-checked in Chromium. The refreshed observable-scene baseline recorded 305165 / 188008 = 1.62x on 2026-07-17."
+    "maxRatio": 1.0,
+    "note": "Minimal direct-root production gzip must not exceed React Three Fiber; each built bundle renders and verifies the same real Mesh in Chromium."
   },
   {
     "suite": "three-bundle-size",
     "op": "js_gzip",
     "target": "octane-full",
     "reference": "r3f-full",
-    "maxRatio": 1.8,
-    "note": "Full-catalogue production gzip, with namespace retention and a real Mesh checked in Chromium. The refreshed observable-scene baseline recorded 304757 / 250306 = 1.22x on 2026-07-17."
+    "maxRatio": 1.0,
+    "note": "Full-catalogue production gzip must not exceed React Three Fiber; each built bundle verifies the complete Three namespace and the same real Mesh in Chromium."
   },
   {
     "suite": "react-hosted-islands",

--- a/benchmarks/three/README.md
+++ b/benchmarks/three/README.md
@@ -44,10 +44,12 @@ built entry is then loaded in Chromium and must produce one real named Three
 `Mesh`; full-catalogue entries must additionally prove that the Three namespace
 was retained.
 
-Octane Three currently registers its built-in Three namespace when a root is
-created, so its minimal result truthfully includes that implementation choice.
-The paired full entry makes the cost visible instead of assuming catalogue
-tree-shaking that the current runtime does not provide.
+Compiled Three scenes register only the built-in constructors their authored
+intrinsics use, and constructor-form `extend` registers only its own class.
+Direct roots therefore let unused Three exports and the DOM renderer tree-shake
+from minimal applications. The full-catalogue entries explicitly retain the
+complete Three namespace. Both Octane gzip results have same-run ratio guards
+requiring them to be no larger than their React Three Fiber counterparts.
 
 Run through the unified harness:
 

--- a/packages/octane/src/compiler/compile-universal.js
+++ b/packages/octane/src/compiler/compile-universal.js
@@ -10,6 +10,232 @@
 import { builders as b, clone_ast_node, parseModule } from '@tsrx/core';
 import { normalizeUniversalRuntime } from './universal-runtime.js';
 
+// Keep this catalogue in the compiler, never in generated application code. It
+// is the union of actual constructor exports from Three r156, r172, and r183,
+// so an authored built-in gets a tree-shakable named import while custom host
+// names and primitives remain on their explicit-registration paths.
+const THREE_BUILTIN_CONSTRUCTORS = new Set([
+	'AmbientLight',
+	'AmbientLightProbe',
+	'AnimationAction',
+	'AnimationClip',
+	'AnimationLoader',
+	'AnimationMixer',
+	'AnimationObjectGroup',
+	'AnimationUtils',
+	'ArcCurve',
+	'ArrayCamera',
+	'ArrowHelper',
+	'Audio',
+	'AudioAnalyser',
+	'AudioContext',
+	'AudioListener',
+	'AudioLoader',
+	'AxesHelper',
+	'BatchedMesh',
+	'BezierInterpolant',
+	'Bone',
+	'BooleanKeyframeTrack',
+	'Box2',
+	'Box3',
+	'Box3Helper',
+	'BoxGeometry',
+	'BoxHelper',
+	'BufferAttribute',
+	'BufferGeometry',
+	'BufferGeometryLoader',
+	'Camera',
+	'CameraHelper',
+	'CanvasTexture',
+	'CapsuleGeometry',
+	'CatmullRomCurve3',
+	'CircleGeometry',
+	'Clock',
+	'Color',
+	'ColorKeyframeTrack',
+	'CompressedArrayTexture',
+	'CompressedCubeTexture',
+	'CompressedTexture',
+	'CompressedTextureLoader',
+	'ConeGeometry',
+	'Controls',
+	'CubeCamera',
+	'CubeDepthTexture',
+	'CubeTexture',
+	'CubeTextureLoader',
+	'CubicBezierCurve',
+	'CubicBezierCurve3',
+	'CubicInterpolant',
+	'Curve',
+	'CurvePath',
+	'CylinderGeometry',
+	'Cylindrical',
+	'Data3DTexture',
+	'DataArrayTexture',
+	'DataTexture',
+	'DataTextureLoader',
+	'DataUtils',
+	'DepthTexture',
+	'DirectionalLight',
+	'DirectionalLightHelper',
+	'DiscreteInterpolant',
+	'DodecahedronGeometry',
+	'EdgesGeometry',
+	'EllipseCurve',
+	'Euler',
+	'EventDispatcher',
+	'ExternalTexture',
+	'ExtrudeGeometry',
+	'FileLoader',
+	'Float16BufferAttribute',
+	'Float32BufferAttribute',
+	'Float64BufferAttribute',
+	'Fog',
+	'FogExp2',
+	'FramebufferTexture',
+	'Frustum',
+	'FrustumArray',
+	'GLBufferAttribute',
+	'GridHelper',
+	'Group',
+	'HemisphereLight',
+	'HemisphereLightHelper',
+	'HemisphereLightProbe',
+	'IcosahedronGeometry',
+	'ImageBitmapLoader',
+	'ImageLoader',
+	'ImageUtils',
+	'InstancedBufferAttribute',
+	'InstancedBufferGeometry',
+	'InstancedInterleavedBuffer',
+	'InstancedMesh',
+	'Int16BufferAttribute',
+	'Int32BufferAttribute',
+	'Int8BufferAttribute',
+	'InterleavedBuffer',
+	'InterleavedBufferAttribute',
+	'Interpolant',
+	'KeyframeTrack',
+	'LOD',
+	'LatheGeometry',
+	'Layers',
+	'Light',
+	'LightProbe',
+	'Line',
+	'Line3',
+	'LineBasicMaterial',
+	'LineCurve',
+	'LineCurve3',
+	'LineDashedMaterial',
+	'LineLoop',
+	'LineSegments',
+	'LinearInterpolant',
+	'Loader',
+	'LoaderUtils',
+	'LoadingManager',
+	'Material',
+	'MaterialLoader',
+	'Matrix2',
+	'Matrix3',
+	'Matrix4',
+	'Mesh',
+	'MeshBasicMaterial',
+	'MeshDepthMaterial',
+	'MeshDistanceMaterial',
+	'MeshLambertMaterial',
+	'MeshMatcapMaterial',
+	'MeshNormalMaterial',
+	'MeshPhongMaterial',
+	'MeshPhysicalMaterial',
+	'MeshStandardMaterial',
+	'MeshToonMaterial',
+	'NumberKeyframeTrack',
+	'Object3D',
+	'ObjectLoader',
+	'OctahedronGeometry',
+	'OrthographicCamera',
+	'PMREMGenerator',
+	'Path',
+	'PerspectiveCamera',
+	'Plane',
+	'PlaneGeometry',
+	'PlaneHelper',
+	'PointLight',
+	'PointLightHelper',
+	'Points',
+	'PointsMaterial',
+	'PolarGridHelper',
+	'PolyhedronGeometry',
+	'PositionalAudio',
+	'PropertyBinding',
+	'PropertyMixer',
+	'QuadraticBezierCurve',
+	'QuadraticBezierCurve3',
+	'Quaternion',
+	'QuaternionKeyframeTrack',
+	'QuaternionLinearInterpolant',
+	'RawShaderMaterial',
+	'Ray',
+	'Raycaster',
+	'RectAreaLight',
+	'RenderTarget',
+	'RenderTarget3D',
+	'RenderTargetArray',
+	'RingGeometry',
+	'Scene',
+	'ShaderMaterial',
+	'ShadowMaterial',
+	'Shape',
+	'ShapeGeometry',
+	'ShapePath',
+	'ShapeUtils',
+	'Skeleton',
+	'SkeletonHelper',
+	'SkinnedMesh',
+	'Source',
+	'Sphere',
+	'SphereGeometry',
+	'Spherical',
+	'SphericalHarmonics3',
+	'SplineCurve',
+	'SpotLight',
+	'SpotLightHelper',
+	'Sprite',
+	'SpriteMaterial',
+	'StereoCamera',
+	'StringKeyframeTrack',
+	'TetrahedronGeometry',
+	'Texture',
+	'TextureLoader',
+	'TextureUtils',
+	'Timer',
+	'TorusGeometry',
+	'TorusKnotGeometry',
+	'Triangle',
+	'TubeGeometry',
+	'Uint16BufferAttribute',
+	'Uint32BufferAttribute',
+	'Uint8BufferAttribute',
+	'Uint8ClampedBufferAttribute',
+	'Uniform',
+	'UniformsGroup',
+	'Vector2',
+	'Vector3',
+	'Vector4',
+	'VectorKeyframeTrack',
+	'VideoFrameTexture',
+	'VideoTexture',
+	'WebGL1Renderer',
+	'WebGL3DRenderTarget',
+	'WebGLArrayRenderTarget',
+	'WebGLCubeRenderTarget',
+	'WebGLMultipleRenderTargets',
+	'WebGLRenderTarget',
+	'WebGLRenderer',
+	'WebXRController',
+	'WireframeGeometry',
+]);
+
 const UNIVERSAL_RUNTIME_IMPORTS = new Set([
 	'Activity',
 	'createContext',
@@ -1811,6 +2037,62 @@ function collectComponentNames(ast) {
 	return names;
 }
 
+function collectExplicitThreeHostIntrinsics(ast, renderer) {
+	if (renderer.id !== 'three' || renderer.module !== '@octanejs/three/renderer') return null;
+	const aliases = new Set();
+	for (const statement of ast.body ?? []) {
+		if (
+			statement.type !== 'ImportDeclaration' ||
+			statement.importKind === 'type' ||
+			statement.source?.value !== '@octanejs/three'
+		) {
+			continue;
+		}
+		for (const specifier of statement.specifiers ?? []) {
+			if (
+				specifier.type === 'ImportSpecifier' &&
+				specifier.importKind !== 'type' &&
+				(specifier.imported?.name ?? specifier.imported?.value) === 'extend' &&
+				typeof specifier.local?.name === 'string'
+			) {
+				aliases.add(specifier.local.name);
+			}
+		}
+	}
+	if (aliases.size === 0) return null;
+	const intrinsics = new Map();
+	for (const statement of ast.body ?? []) {
+		if (statement.type !== 'ExpressionStatement') continue;
+		const call = statement.expression;
+		if (
+			call?.type !== 'CallExpression' ||
+			call.optional === true ||
+			call.callee?.type !== 'Identifier' ||
+			!aliases.has(call.callee.name) ||
+			call.arguments?.length !== 1 ||
+			call.arguments[0]?.type !== 'ObjectExpression' ||
+			typeof statement.end !== 'number'
+		) {
+			continue;
+		}
+		for (const property of call.arguments[0].properties ?? []) {
+			if (property.type !== 'Property' || property.kind !== 'init' || property.method === true) {
+				continue;
+			}
+			const key =
+				property.key?.type === 'Identifier' && property.computed !== true
+					? property.key.name
+					: property.key?.type === 'Literal' && typeof property.key.value === 'string'
+						? property.key.value
+						: null;
+			if (key !== null && THREE_BUILTIN_CONSTRUCTORS.has(key) && !intrinsics.has(key)) {
+				intrinsics.set(key, statement.end);
+			}
+		}
+	}
+	return intrinsics.size === 0 ? null : intrinsics;
+}
+
 function collectOwnerFreeThreeHostComponents(ast, state, development) {
 	if (
 		development ||
@@ -2617,6 +2899,37 @@ function addDynamicAst(context, expression) {
 	return withPlanOrigin({ kind: 'slot', slot }, expression);
 }
 
+function registerThreeHostIntrinsic(type, node, state) {
+	if (
+		state.renderer.id !== 'three' ||
+		state.renderer.module !== '@octanejs/three/renderer' ||
+		type === 'primitive'
+	) {
+		return;
+	}
+	let constructor = `${type[0].toUpperCase()}${type.slice(1)}`;
+	if (!THREE_BUILTIN_CONSTRUCTORS.has(constructor) && /^three[A-Z]/.test(type)) {
+		constructor = type.slice('three'.length);
+	}
+	if (!THREE_BUILTIN_CONSTRUCTORS.has(constructor)) return;
+	const explicitlyRegistered = state.explicitThreeHostIntrinsics?.get(constructor);
+	if (
+		explicitlyRegistered !== undefined &&
+		typeof node.start === 'number' &&
+		explicitlyRegistered < node.start
+	) {
+		return;
+	}
+	const intrinsics = (state.threeHostIntrinsics ??= new Map());
+	if (intrinsics.has(constructor)) return;
+	const prefix = state.planPrefix ?? '__octaneThree';
+	intrinsics.set(constructor, {
+		local: allocName(state, `${prefix}${constructor}`),
+		origin: node,
+	});
+	state.helpers.threeRegisterIntrinsic ??= allocName(state, `${prefix}RegisterIntrinsic`);
+}
+
 function compileHostElementAst(node, context, state) {
 	const type = jsxName(node);
 	if (type === 'Activity') return compileActivityElementAst(node, context, state);
@@ -2629,6 +2942,7 @@ function compileHostElementAst(node, context, state) {
 		);
 	}
 	if (!/^[a-z]/.test(type)) return compileComponentElementAst(node, context, state);
+	registerThreeHostIntrinsic(type, node, state);
 	const attributes = node.openingElement?.attributes ?? node.attributes ?? [];
 	if (isMainThreadRenderOnly(state)) {
 		const spread = attributes.find(
@@ -3311,6 +3625,9 @@ function universalHelperImportAst(state, extraPairs = [], origin = null) {
 		...(state.helpers.hostComponentLeafPlan === undefined
 			? []
 			: [['universalHostComponentLeafPlan', state.helpers.hostComponentLeafPlan]]),
+		...(state.helpers.threeRegisterIntrinsic === undefined
+			? []
+			: [['registerThreeIntrinsic', state.helpers.threeRegisterIntrinsic]]),
 		['universalProps', state.helpers.props],
 		['universalIf', state.helpers.if],
 		['universalSwitch', state.helpers.switch],
@@ -3332,6 +3649,36 @@ function universalHelperImportAst(state, extraPairs = [], origin = null) {
 		...extraPairs,
 	];
 	return inheritGeneratedOrigin(b.imports(pairs, state.renderer.module), origin);
+}
+
+function threeHostIntrinsicStatementsAst(state, origin = null) {
+	if (state.threeHostIntrinsics === undefined) return { imports: [], registrations: [] };
+	const entries = [...state.threeHostIntrinsics];
+	const imports = [
+		inheritGeneratedOrigin(
+			b.imports(
+				entries.map(([constructor, { local }]) => [constructor, local]),
+				'three',
+			),
+			origin,
+		),
+	];
+	const registrations = entries.map(([constructor, entry]) =>
+		inheritGeneratedOrigin(
+			b.stmt(
+				generatedCall(
+					state.helpers.threeRegisterIntrinsic,
+					[
+						b.literal(constructor, JSON.stringify(constructor)),
+						generatedIdentifier(entry.local, entry.origin),
+					],
+					entry.origin,
+				),
+			),
+			entry.origin,
+		),
+	);
+	return { imports, registrations };
 }
 
 function universalProfileImportAst(state, origin = null) {
@@ -3649,6 +3996,10 @@ export function lowerUniversalRendererRegionAst(
 		planPrefix: prefix,
 		validationImportReferences: [],
 	};
+	state.explicitThreeHostIntrinsics = collectExplicitThreeHostIntrinsics(
+		options.authoredAst ?? analysisAst,
+		renderer,
+	);
 	state.helpers.component = allocName(state, `${prefix}Define`);
 	state.helpers.plan = allocName(state, `${prefix}Plan`);
 	state.helpers.value = allocName(state, `${prefix}Value`);
@@ -3857,6 +4208,7 @@ export function lowerUniversalRendererRegionAst(
 	specializationBindings.add(componentName);
 	const hmrBlocks = buildUniversalHmrBlocksAst(state, origin);
 	const profileImport = universalProfileImportAst(state, origin);
+	const threeHostIntrinsics = threeHostIntrinsicStatementsAst(state, origin);
 	const helperImportPairs = [
 		['rendererRegion', regionHelper],
 		...runtimeImports.map(({ imported, local }) => [imported, local]),
@@ -3902,8 +4254,10 @@ export function lowerUniversalRendererRegionAst(
 		}),
 		statements: Object.freeze([
 			universalHelperImportAst(state, helperImportPairs, origin),
+			...threeHostIntrinsics.imports,
 			...(profileImport === null ? [] : [profileImport]),
 			...hmrBlocks.prelude,
+			...threeHostIntrinsics.registrations,
 			...universalPlanDeclarationsAst(state, origin),
 			...(state.threadFunctionRegistrationsAst ?? []),
 			...emittedComponents,
@@ -3959,6 +4313,7 @@ export function compileUniversal(
 		componentNames: collectComponentNames(ast),
 		runtimeImports: new Map(),
 	};
+	state.explicitThreeHostIntrinsics = collectExplicitThreeHostIntrinsics(ast, renderer);
 	state.ownerFreeThreeHostComponents = collectOwnerFreeThreeHostComponents(
 		ast,
 		state,
@@ -4033,12 +4388,15 @@ export function compileUniversal(
 		components: state.components,
 	};
 	const profileImport = universalProfileImportAst(state, moduleOrigin);
+	const threeHostIntrinsics = threeHostIntrinsicStatementsAst(state, moduleOrigin);
 	const program = {
 		...ast,
 		body: [
 			universalHelperImportAst(state, [], moduleOrigin),
+			...threeHostIntrinsics.imports,
 			...(profileImport === null ? [] : [profileImport]),
 			...hmrBlocks.prelude,
+			...threeHostIntrinsics.registrations,
 			...universalPlanDeclarationsAst(state, moduleOrigin),
 			...(state.threadFunctionRegistrationsAst ?? []),
 			...emitted,

--- a/packages/octane/src/renderer-bridge.ts
+++ b/packages/octane/src/renderer-bridge.ts
@@ -1,0 +1,60 @@
+/**
+ * Optional renderer coordination without importing either renderer runtime.
+ *
+ * Native-only and DOM-only applications must never retain the opposite runtime
+ * merely because another renderer can participate in the same application.
+ */
+export type RendererHostFlusher = <T>(run: () => T) => T;
+
+type RendererContextProvider = (
+	context: unknown,
+	props: { value: unknown; children?: unknown },
+	scope: object,
+) => unknown;
+
+let clientContextProvider: RendererContextProvider | undefined;
+let serverContextProvider: RendererContextProvider | undefined;
+let hostFlusher: RendererHostFlusher | undefined;
+const rendererContexts = new WeakSet<Function>();
+
+/** Brand renderer-local contexts without observing authored function properties. */
+export function registerRendererContext(context: Function): void {
+	rendererContexts.add(context);
+}
+
+/** Recognize only renderer-local Providers at a dynamic JSX descriptor boundary. */
+export function isRendererContext(value: Function): boolean {
+	return rendererContexts.has(value);
+}
+
+/** Install the client adapters only after a real DOM root becomes active. */
+export function registerClientRendererBridge(
+	contextProvider: RendererContextProvider,
+	flush: RendererHostFlusher,
+): void {
+	clientContextProvider = contextProvider;
+	hostFlusher = flush;
+}
+
+/** Server rendering can coexist with the client runtime in the same process. */
+export function registerServerRendererContextProvider(provider: RendererContextProvider): void {
+	serverContextProvider = provider;
+}
+
+/** Render a renderer-local context through the owner matching its actual scope. */
+export function renderRendererContextProvider(
+	context: unknown,
+	props: { value: unknown; children?: unknown },
+	scope: object,
+): unknown {
+	const provider = 'block' in scope ? clientContextProvider : serverContextProvider;
+	if (provider === undefined) {
+		throw new Error('A renderer-local context provider requires an active renderer owner.');
+	}
+	return provider(context, props, scope);
+}
+
+/** Read the optional owner scheduler without importing the DOM runtime. */
+export function getRendererHostFlusher(): RendererHostFlusher | undefined {
+	return hostFlusher;
+}

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -76,6 +76,7 @@ import {
 	markComponentFlags,
 } from './component-flags.js';
 import { formatServerError } from './error-codes.server.generated.js';
+import { isRendererContext, registerServerRendererContextProvider } from './renderer-bridge.js';
 export { EXTERNAL_HYDRATION_PROMISE, HYDRATION_RANGE_BOUNDARY, normalizeClass };
 
 const NATIVE_ARRAY_MAP = Array.prototype.map;
@@ -616,6 +617,9 @@ export function createElement(
 	props?: any,
 	...children: any[]
 ): ElementDescriptor {
+	if (typeof type === 'function' && isRendererContext(type)) {
+		registerServerRendererContextProvider(renderServerContextProvider);
+	}
 	const src = (props ?? null) as any;
 	const key = hasElementConfigKey(src) ? '' + src.key : null;
 	let kids = children.length > 0 ? (children.length === 1 ? children[0] : children) : src?.children;
@@ -3655,23 +3659,29 @@ export interface Context<T> {
 
 export function createContext<T>(defaultValue: T): Context<T> {
 	const ctx = function ProviderBody(props, scope) {
-		if (scope.$$ctxValues === null) scope.$$ctxValues = new Map();
-		scope.$$ctxValues.set(ctx, props.value);
-		const children = props.children;
-		if (children == null) return '';
-		// `.tsrx` threads children as a render function (call it directly). `.tsx`
-		// `<Ctx.Provider>…</Ctx.Provider>` lowers to `createElement(Provider, {}, …)`,
-		// so children arrive as a descriptor / array / primitive — render whichever
-		// shape through the generic child serializer (the same path every other
-		// descriptor child uses), or direct-JSX provider SSR would drop its content.
-		return typeof children === 'function'
-			? (children(undefined, scope) ?? '')
-			: ssrChild(children, scope);
+		return renderServerContextProvider(ctx, props, scope);
 	} as Context<T>;
 	ctx.$$kind = CONTEXT_TAG;
 	ctx.defaultValue = defaultValue;
 	ctx.Provider = ctx;
 	return ctx;
+}
+
+function renderServerContextProvider(
+	context: unknown,
+	props: { value: unknown; children?: unknown },
+	renderScope: object,
+): string {
+	const scope = renderScope as SSRScope;
+	if (scope.$$ctxValues === null) scope.$$ctxValues = new Map();
+	scope.$$ctxValues.set(context, props.value);
+	const children = props.children;
+	if (children == null) return '';
+	// `.tsrx` children are render functions; `.tsx` children are descriptors,
+	// arrays, or primitives and must keep the ordinary server serializer.
+	return typeof children === 'function'
+		? (children(undefined, scope) ?? '')
+		: ssrChild(children, scope);
 }
 
 function readContext<T>(ctx: Context<T>): T {

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -104,6 +104,7 @@ import {
 	isRendererStreamToken,
 	rendererRangeClose,
 } from './stream-protocol.js';
+import { isRendererContext, registerClientRendererBridge } from './renderer-bridge.js';
 
 export { EXTERNAL_HYDRATION_PROMISE, HYDRATION_RANGE_BOUNDARY };
 
@@ -6502,63 +6503,74 @@ export function createContext<T>(defaultValue: T): Context<T> {
 	// provider the context object, then retain `.Provider` as an identity alias
 	// for existing code and React 18-shaped libraries.
 	const ctx = function ProviderBody(props, scope) {
-		// Stash on the scope (not block) so siblings of the Provider don't see it.
-		// $$ctxValues is pre-initialised to null on every Scope/Block so this
-		// assignment is a hidden-class-stable update (not a late stamp).
-		if (scope.$$ctxValues === null) scope.$$ctxValues = new Map();
-		// Bump the context version when an EXISTING value actually changes. This
-		// runs before children() below, so the memo bailout downstream already
-		// sees the new version when the cascade reaches it. First-set is NOT a
-		// change: adding a Provider always creates a fresh scope for its
-		// descendants, so a memoized consumer can't carry pre-Provider state — it's
-		// always freshly mounted within the Provider's scope and reads the value
-		// directly (no memo bailout to invalidate). (Bumping on first-set would
-		// over-invalidate every memo'd consumer of this context elsewhere.)
-		if (scope.$$ctxValues.has(ctx) && !Object.is(scope.$$ctxValues.get(ctx), props.value)) {
-			ctx.$$version++;
-			COMPILER_CACHE_CONTEXT_EPOCH++;
-		}
-		scope.$$ctxValues.set(ctx, props.value);
-		// Children between the Provider tags reach us in one of two shapes:
-		//   - a compiled render-body FUNCTION — the `.tsrx` `{props.children}` lowering;
-		//   - an element descriptor / renderable — a React-style `.tsx` parent, where
-		//     `<Ctx.Provider>…</Ctx.Provider>` lowers to `createElement(Ctx.Provider,
-		//     { value }, …children)` and `createElement` mirrors the positional children
-		//     into `props.children` (a descriptor, an array, or text — never a function).
-		// `childrenAsBody` normalizes either shape to a callable body, so both dialects
-		// render their children inside the Provider's scope (and thus under its context).
-		//
-		// The two dialects both claim `scope.slots[0]` — a compiled body stores its binding
-		// bag there, while the descriptor path's `childSlot(scope, 0, …)` stores a childSlot
-		// record. A parent that wraps its children conditionally (common in ported React
-		// bindings) flips between them across renders, so the incoming dialect would read the
-		// outgoing one's record as its own and corrupt the tree. Remount the children on a
-		// flip instead: the two sides are structurally different code, which is the same
-		// contract React gives an element-type change.
-		if (props.children != null) {
-			// Steady state is one map read and an integer compare — the write happens only on the
-			// first render and on an actual flip.
-			const dialect = typeof props.children === 'function' ? 1 : 2;
-			const previous = scope.hooks?.get(CHILDREN_DIALECT_SLOT);
-			if (previous !== dialect) {
-				if (previous !== undefined) {
-					resetScopeChildren(scope);
-					// The reset runs user cleanups, so it can throw into the enclosing boundary and
-					// switch it to its catch arm — which disposes this block. Rendering children
-					// into a disposed block writes into the catch range, so bail out here, as every
-					// other mid-render teardown site does after `unmountBlock`.
-					if (scope.block.disposed) return;
-				}
-				ensureHooks(scope).set(CHILDREN_DIALECT_SLOT, dialect);
-			}
-			childrenAsBody(props.children)(undefined, scope, undefined);
-		}
+		return renderClientContextProvider(ctx, props, scope);
 	} as Context<T>;
 	ctx.$$kind = CONTEXT_TAG;
 	ctx.defaultValue = defaultValue;
 	ctx.$$version = 0;
 	ctx.Provider = ctx;
 	return ctx;
+}
+
+/** Renderer-boundary adapter; ordinary DOM roots never retain this by themselves. */
+export function renderClientContextProvider<T>(
+	context: unknown,
+	props: { value: unknown; children?: unknown },
+	renderScope: object,
+): void {
+	const ctx = context as Context<T>;
+	const scope = renderScope as Scope;
+	// Stash on the scope (not block) so siblings of the Provider don't see it.
+	// $$ctxValues is pre-initialised to null on every Scope/Block so this
+	// assignment is a hidden-class-stable update (not a late stamp).
+	if (scope.$$ctxValues === null) scope.$$ctxValues = new Map();
+	// Bump the context version when an EXISTING value actually changes. This
+	// runs before children() below, so the memo bailout downstream already
+	// sees the new version when the cascade reaches it. First-set is NOT a
+	// change: adding a Provider always creates a fresh scope for its
+	// descendants, so a memoized consumer can't carry pre-Provider state — it's
+	// always freshly mounted within the Provider's scope and reads the value
+	// directly (no memo bailout to invalidate). (Bumping on first-set would
+	// over-invalidate every memo'd consumer of this context elsewhere.)
+	if (scope.$$ctxValues.has(ctx) && !Object.is(scope.$$ctxValues.get(ctx), props.value)) {
+		ctx.$$version++;
+		COMPILER_CACHE_CONTEXT_EPOCH++;
+	}
+	scope.$$ctxValues.set(ctx, props.value);
+	// Children between the Provider tags reach us in one of two shapes:
+	//   - a compiled render-body FUNCTION — the `.tsrx` `{props.children}` lowering;
+	//   - an element descriptor / renderable — a React-style `.tsx` parent, where
+	//     `<Ctx.Provider>…</Ctx.Provider>` lowers to `createElement(Ctx.Provider,
+	//     { value }, …children)` and `createElement` mirrors the positional children
+	//     into `props.children` (a descriptor, an array, or text — never a function).
+	// `childrenAsBody` normalizes either shape to a callable body, so both dialects
+	// render their children inside the Provider's scope (and thus under its context).
+	//
+	// The two dialects both claim `scope.slots[0]` — a compiled body stores its binding
+	// bag there, while the descriptor path's `childSlot(scope, 0, …)` stores a childSlot
+	// record. A parent that wraps its children conditionally (common in ported React
+	// bindings) flips between them across renders, so the incoming dialect would read the
+	// outgoing one's record as its own and corrupt the tree. Remount the children on a
+	// flip instead: the two sides are structurally different code, which is the same
+	// contract React gives an element-type change.
+	if (props.children != null) {
+		// Steady state is one map read and an integer compare — the write happens only on the
+		// first render and on an actual flip.
+		const dialect = typeof props.children === 'function' ? 1 : 2;
+		const previous = scope.hooks?.get(CHILDREN_DIALECT_SLOT);
+		if (previous !== dialect) {
+			if (previous !== undefined) {
+				resetScopeChildren(scope);
+				// The reset runs user cleanups, so it can throw into the enclosing boundary and
+				// switch it to its catch arm — which disposes this block. Rendering children
+				// into a disposed block writes into the catch range, so bail out here, as every
+				// other mid-render teardown site does after `unmountBlock`.
+				if (scope.block.disposed) return;
+			}
+			ensureHooks(scope).set(CHILDREN_DIALECT_SLOT, dialect);
+		}
+		childrenAsBody(props.children)(undefined, scope, undefined);
+	}
 }
 
 /**
@@ -15035,6 +15047,9 @@ export function createElement<P>(
 	props?: P,
 	...children: any[]
 ): ElementDescriptor<P> {
+	if (typeof type === 'function' && isRendererContext(type)) {
+		registerClientRendererBridge(renderClientContextProvider, flushSync);
+	}
 	const src = (props ?? null) as any;
 	const hasKey = hasElementConfigKey(src);
 	const key = hasKey ? '' + src.key : null;

--- a/packages/octane/src/universal-core.ts
+++ b/packages/octane/src/universal-core.ts
@@ -18,6 +18,7 @@ import {
 	__profileSchedule,
 	__profileTrackComponent,
 } from './profiling.js';
+import { getRendererHostFlusher } from './renderer-bridge.js';
 
 declare const __OCTANE_PROFILE_ENABLED__: boolean;
 
@@ -9946,6 +9947,11 @@ function flushUniversalPassiveWave(): void {
 export type UniversalSyncFlusher = <T>(run: () => T) => T;
 
 const INLINE_UNIVERSAL_FLUSHER: UniversalSyncFlusher = (run) => run();
+
+/** Discover a mounted owner scheduler without retaining the owner renderer. */
+export function getUniversalHostFlusher(): UniversalSyncFlusher | undefined {
+	return getRendererHostFlusher();
+}
 
 function runUniversalSyncBoundary<T>(
 	run: () => T,

--- a/packages/octane/src/universal-dom-boundary.ts
+++ b/packages/octane/src/universal-dom-boundary.ts
@@ -1,5 +1,7 @@
 import {
+	flushSync,
 	readContextFromScope,
+	renderClientContextProvider,
 	useInsertionEffect as useDomInsertionEffect,
 	useLayoutEffect as useDomLayoutEffect,
 	useRendererThenable as useDomRendererThenable,
@@ -16,6 +18,7 @@ import {
 	type UniversalPreparedAttempt,
 	type UniversalRoot,
 } from './universal-core.js';
+import { registerClientRendererBridge } from './renderer-bridge.js';
 
 const UNIVERSAL_BOUNDARY = Symbol.for('octane.universal.boundary');
 
@@ -74,6 +77,11 @@ function assertRendererId(value: unknown): asserts value is string {
 	}
 }
 
+/** Coordinate real mixed-renderer owners without charging DOM-only roots. */
+export function registerUniversalHostBridge(): void {
+	registerClientRendererBridge(renderClientContextProvider, flushSync);
+}
+
 export function createUniversalHostBoundary(renderer: string): ((
 	props: HostBoundaryProps,
 	scope: Scope,
@@ -81,6 +89,7 @@ export function createUniversalHostBoundary(renderer: string): ((
 	readonly [UNIVERSAL_BOUNDARY]: UniversalBoundaryMetadata;
 } {
 	assertRendererId(renderer);
+	registerUniversalHostBridge();
 	const boundary = ((props: HostBoundaryProps, scope: Scope) => {
 		if (props.root.renderer !== renderer) {
 			throw new Error(

--- a/packages/octane/src/universal-native.ts
+++ b/packages/octane/src/universal-native.ts
@@ -14,6 +14,7 @@ import {
 	type UniversalContextValue,
 	type UniversalRenderable,
 } from './universal-core.js';
+import { registerRendererContext, renderRendererContextProvider } from './renderer-bridge.js';
 
 const CONTEXT_TAG = Symbol.for('octane.context');
 
@@ -28,15 +29,22 @@ export interface NativeUniversalContext<T> extends UniversalContext<T> {
 /** Create a context whose Provider can be lowered without a DOM Scope. */
 /* @__NO_SIDE_EFFECTS__ */
 export function createContext<T>(defaultValue: T): NativeUniversalContext<T> {
-	const context = ((props: {
-		value: T;
-		children?: UniversalRenderable | (() => UniversalRenderable);
-	}) => universalContext(context, props.value, props.children)) as NativeUniversalContext<T>;
+	const context = ((
+		props: {
+			value: T;
+			children?: UniversalRenderable | (() => UniversalRenderable);
+		},
+		scope?: object,
+	) =>
+		scope === undefined
+			? universalContext(context, props.value, props.children)
+			: renderRendererContextProvider(context, props, scope)) as NativeUniversalContext<T>;
 	Object.defineProperties(context, {
 		$$kind: { value: CONTEXT_TAG, enumerable: true },
 		defaultValue: { value: defaultValue, enumerable: true },
 		Provider: { value: context, enumerable: true },
 		$$version: { value: 0, enumerable: true, writable: true },
 	});
+	registerRendererContext(context);
 	return context;
 }

--- a/packages/octane/src/universal.ts
+++ b/packages/octane/src/universal.ts
@@ -8,4 +8,7 @@
 export * from './universal-core.js';
 
 export { createContext } from './runtime.js';
-export { createUniversalHostBoundary } from './universal-dom-boundary.js';
+export {
+	createUniversalHostBoundary,
+	registerUniversalHostBridge,
+} from './universal-dom-boundary.js';

--- a/packages/octane/tests/compiler/universal-compiler-capabilities.test.ts
+++ b/packages/octane/tests/compiler/universal-compiler-capabilities.test.ts
@@ -369,3 +369,222 @@ describe('compact intrinsic host loops', () => {
 		expect(args[2].body.type).toBe('BlockStatement');
 	});
 });
+
+describe('tree-shakable Three intrinsic registration', () => {
+	function compiledModule(source: string, options: Record<string, any> = {}): any {
+		return parseModule(
+			compile(source, '/src/Scene.three.tsrx', {
+				renderer: threeRenderer,
+				hmr: false,
+				...options,
+			}).code,
+			'/dist/Scene.three.js',
+		);
+	}
+
+	function namedThreeImports(ast: any): string[] {
+		return ast.body
+			.filter((statement: any) => statement.type === 'ImportDeclaration')
+			.filter((statement: any) => statement.source.value === 'three')
+			.flatMap((statement: any) =>
+				(statement.specifiers ?? [])
+					.filter((specifier: any) => specifier.type === 'ImportSpecifier')
+					.map((specifier: any) => specifier.imported.name ?? specifier.imported.value),
+			);
+	}
+
+	it('imports and registers only the built-in constructors actually authored', () => {
+		const ast = compiledModule(`
+			export function Scene() @{
+				<group>
+					<mesh><boxGeometry /><meshBasicMaterial /></mesh>
+					<mesh />
+				</group>
+			}
+		`);
+
+		expect(namedThreeImports(ast).sort()).toEqual(
+			['Group', 'Mesh', 'BoxGeometry', 'MeshBasicMaterial'].sort(),
+		);
+		const rendererImport = ast.body.find(
+			(statement: any) =>
+				statement.type === 'ImportDeclaration' &&
+				statement.source.value === '@octanejs/three/renderer',
+		);
+		const registration = rendererImport.specifiers.find(
+			(specifier: any) =>
+				(specifier.imported?.name ?? specifier.imported?.value) === 'registerThreeIntrinsic',
+		);
+		expect(registration).toBeDefined();
+		const registrations = ast.body.filter(
+			(statement: any) =>
+				statement.type === 'ExpressionStatement' &&
+				statement.expression.type === 'CallExpression' &&
+				statement.expression.callee.name === registration.local.name,
+		);
+		expect(
+			registrations.map((statement: any) => statement.expression.arguments[0].value).sort(),
+		).toEqual(['Group', 'Mesh', 'BoxGeometry', 'MeshBasicMaterial'].sort());
+	});
+
+	it('keeps custom and primitive host names on their explicit registration path', () => {
+		const ast = compiledModule(`
+			export function Scene({ object }) @{
+				<group><customObject /><primitive object={object} /></group>
+			}
+		`);
+
+		expect(namedThreeImports(ast)).toEqual(['Group']);
+	});
+
+	it.each([
+		['ordinary object key', 'register({ BatchedMesh: Polyfill })'],
+		['quoted object key', 'register({ "BatchedMesh": Polyfill })'],
+		['statically computed object key', 'register({ ["BatchedMesh"]: Polyfill })'],
+		['shorthand object key', 'register({ BatchedMesh })'],
+	])('keeps older-Three polyfills with an explicitly registered %s', (_label, registration) => {
+		const ast = compiledModule(`
+			import { extend as register } from '@octanejs/three';
+			class Polyfill {}
+			const BatchedMesh = Polyfill;
+			${registration};
+			export function Scene() @{ <group><batchedMesh /></group> }
+		`);
+
+		expect(namedThreeImports(ast)).toEqual(['Group']);
+	});
+
+	it('does not mistake a shadowed or conditional extension for a registered built-in', () => {
+		const ast = compiledModule(`
+			import { extend as register } from '@octanejs/three';
+			class Polyfill {}
+			function later(register) { register({ BatchedMesh: Polyfill }); }
+			if (globalThis.installPolyfill) register({ Matrix2: Polyfill });
+			export function Scene() @{ <group><batchedMesh /><matrix2 /></group> }
+		`);
+
+		expect(namedThreeImports(ast).sort()).toEqual(['Group', 'BatchedMesh', 'Matrix2'].sort());
+	});
+
+	it('registers built-ins before authored extensions so custom overrides remain authoritative', () => {
+		const ast = compiledModule(`
+			import { Mesh as ExternalMesh } from 'three';
+			import { extend } from '@octanejs/three';
+			const externalExtensions = { Mesh: ExternalMesh };
+			extend(externalExtensions);
+			export function Scene() @{ <mesh /> }
+		`);
+		const rendererImport = ast.body.find(
+			(statement: any) =>
+				statement.type === 'ImportDeclaration' &&
+				statement.source.value === '@octanejs/three/renderer',
+		);
+		const registration = rendererImport.specifiers.find(
+			(specifier: any) =>
+				(specifier.imported?.name ?? specifier.imported?.value) === 'registerThreeIntrinsic',
+		);
+		const registrationIndex = ast.body.findIndex(
+			(statement: any) =>
+				statement.type === 'ExpressionStatement' &&
+				statement.expression.callee?.name === registration.local.name,
+		);
+		const extensionIndex = ast.body.findIndex(
+			(statement: any) =>
+				statement.type === 'ExpressionStatement' && statement.expression.callee?.name === 'extend',
+		);
+
+		expect(registrationIndex).toBeGreaterThanOrEqual(0);
+		expect(extensionIndex).toBeGreaterThan(registrationIndex);
+	});
+
+	it('recognizes built-ins available across the advertised minimum and current Three releases', () => {
+		const ast = compiledModule(`
+			export function Scene() @{
+				<group><ambientLightProbe /><batchedMesh /><matrix2 /><webXRController /></group>
+			}
+		`);
+
+		expect(namedThreeImports(ast).sort()).toEqual(
+			['Group', 'AmbientLightProbe', 'BatchedMesh', 'Matrix2', 'WebXRController'].sort(),
+		);
+	});
+
+	it('resolves historical Three JSX aliases without importing nonexistent named exports', () => {
+		const ast = compiledModule(`
+			export function Scene() @{
+				<group><threeAudio /><threeLine /><threePath /><threeSource /></group>
+			}
+		`);
+
+		expect(namedThreeImports(ast).sort()).toEqual(
+			['Group', 'Audio', 'Line', 'Path', 'Source'].sort(),
+		);
+	});
+
+	it.each([
+		['development', { dev: true }],
+		['Vite HMR', { hmr: true }],
+		['Webpack HMR', { hmr: 'webpack' }],
+		['profiling', { profile: true }],
+	])('keeps ordinary Three intrinsics available during %s', (_label, options) => {
+		const ast = compiledModule('export function Scene() @{ <mesh /> }', options);
+
+		expect(namedThreeImports(ast)).toEqual(['Mesh']);
+	});
+
+	it.each([
+		['Vite', true],
+		['Webpack', 'webpack'],
+	])('registers built-ins before %s HMR host plans are evaluated', (_dialect, hmr) => {
+		const ast = compiledModule('export function Scene() @{ <mesh /> }', { hmr });
+		const rendererImport = ast.body.find(
+			(statement: any) =>
+				statement.type === 'ImportDeclaration' &&
+				statement.source.value === '@octanejs/three/renderer',
+		);
+		const registration = rendererImport.specifiers.find(
+			(specifier: any) =>
+				(specifier.imported?.name ?? specifier.imported?.value) === 'registerThreeIntrinsic',
+		);
+		const plan = rendererImport.specifiers.find(
+			(specifier: any) =>
+				(specifier.imported?.name ?? specifier.imported?.value) === 'universalPlan',
+		);
+		const registrationIndex = ast.body.findIndex(
+			(statement: any) =>
+				statement.type === 'ExpressionStatement' &&
+				statement.expression.callee?.name === registration.local.name,
+		);
+		const planIndex = ast.body.findIndex(
+			(statement: any) =>
+				statement.type === 'VariableDeclaration' &&
+				statement.declarations.some(
+					(declaration: any) => declaration.init?.callee?.name === plan.local.name,
+				),
+		);
+
+		expect(registrationIndex).toBeGreaterThanOrEqual(0);
+		expect(planIndex).toBeGreaterThan(registrationIndex);
+	});
+
+	it('does not add a Three dependency to other universal renderers', () => {
+		const ast = compiledModule('export function Scene() @{ <mesh /> }', {
+			renderer: { ...baseRenderer, text: 'ignore' },
+		});
+
+		expect(namedThreeImports(ast)).toEqual([]);
+	});
+
+	it('keeps component-only and unknown-host modules free of implicit Three imports', () => {
+		const component = compiledModule(`
+			import { extend } from '@octanejs/three';
+			import { Mesh } from 'three';
+			const MeshNode = extend(Mesh);
+			export function Scene() @{ <MeshNode /> }
+		`);
+		const unknown = compiledModule('export function Scene() @{ <customObject /> }');
+
+		expect(namedThreeImports(component)).toEqual(['Mesh']);
+		expect(namedThreeImports(unknown)).toEqual([]);
+	});
+});

--- a/packages/octane/tests/hydration/provider-ssr-hydrate.test.ts
+++ b/packages/octane/tests/hydration/provider-ssr-hydrate.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { compile } from 'octane/compiler';
-import { hydrateRoot, flushSync } from '../../src/index.js';
+import {
+	createElement,
+	flushSync,
+	hydrateRoot,
+	useContext as useClientContext,
+} from '../../src/index.js';
+import { createContext as createNativeContext } from '../../src/universal-native.js';
 import * as ServerRT from 'octane/server';
 import { App } from '../_fixtures/ssr-provider.tsx';
 import { ProviderApp } from '../_fixtures/jsx-context-children.tsx';
@@ -53,6 +59,47 @@ describe('hydration — .tsx <Context.Provider> descriptor children', () => {
 		expect(after.physicalPairs).toBeLessThan(before.physicalPairs);
 		expect(after.countedPairs).toBeGreaterThanOrEqual(1);
 		root.unmount();
+	});
+
+	it('renders a renderer-local provider on the server and hydrates the same context identity', () => {
+		const Theme = createNativeContext('default');
+		const ServerReader = () =>
+			ServerRT.createElement(
+				'span',
+				{ className: 'renderer-local-provider' },
+				ServerRT.useContext(Theme as any),
+			);
+		const ServerProvider = () =>
+			ServerRT.createElement(
+				Theme.Provider as any,
+				{ value: 'server-provided' },
+				ServerRT.createElement(ServerReader as any, null),
+			);
+		const { html } = ServerRT.renderToString(ServerProvider);
+		expect(html).toContain('server-provided');
+		container.innerHTML = html;
+		const adopted = container.querySelector('.renderer-local-provider');
+
+		const ClientReader = () =>
+			createElement(
+				'span',
+				{ className: 'renderer-local-provider' },
+				useClientContext(Theme as any),
+			);
+		const ClientProvider = () =>
+			createElement(
+				Theme.Provider as any,
+				{ value: 'server-provided' },
+				createElement(ClientReader, null),
+			);
+		const root = hydrateRoot(container, ClientProvider as any);
+		try {
+			flushSync(() => {});
+			expect(container.querySelector('.renderer-local-provider')).toBe(adopted);
+			expect(adopted?.textContent).toBe('server-provided');
+		} finally {
+			root.unmount();
+		}
 	});
 
 	// A de-opt HOST element whose children are COMPONENTS (`<div><Comp/><Comp/></div>`

--- a/packages/octane/tests/universal-native.test.ts
+++ b/packages/octane/tests/universal-native.test.ts
@@ -222,6 +222,36 @@ globalThis.renderedValue = container.children[0].props.value;
 		expect(output).not.toMatch(/\b(?:document|window|MutationObserver|HTMLElement)\b/);
 	});
 
+	it('keeps a DOM-only public root independent of universal renderer modules', async () => {
+		const result = await build({
+			stdin: {
+				contents:
+					"import { createRoot } from 'octane'; globalThis.__octaneCreateRoot = createRoot;",
+				resolveDir: resolve(import.meta.dirname, '..'),
+				sourcefile: 'dom-only-consumer.ts',
+			},
+			bundle: true,
+			define: { __OCTANE_PROFILE_ENABLED__: 'false' },
+			format: 'iife',
+			metafile: true,
+			minify: true,
+			platform: 'browser',
+			target: 'esnext',
+			treeShaking: true,
+			write: false,
+		});
+		const inputs = Object.keys(Object.values(result.metafile!.outputs)[0].inputs);
+
+		expect(inputs).toEqual(
+			expect.arrayContaining([expect.stringMatching(/packages\/octane\/src\/runtime\.ts$/)]),
+		);
+		expect(
+			inputs.some((input) =>
+				/packages\/octane\/src\/universal-(?:core|native|dom-boundary)\.ts$/.test(input),
+			),
+		).toBe(false);
+	});
+
 	it('requires a host scheduler when queueMicrotask is absent and preserves thrown errors', async () => {
 		const result = await build({
 			stdin: {

--- a/packages/octane/tests/universal-renderer-boundaries.test.ts
+++ b/packages/octane/tests/universal-renderer-boundaries.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
-import { createRoot, flushSync, type ComponentBody } from '../src/index.js';
+import {
+	createElement,
+	createRoot,
+	flushSync,
+	useContext as useDomContext,
+	type ComponentBody,
+} from '../src/index.js';
+import { createContext as createNativeContext } from '../src/universal-native.js';
+import * as UniversalRuntime from '../src/universal.js';
 import {
 	createObjectContainer,
 	createObjectDriver,
@@ -154,6 +162,64 @@ async function flushBridgeWork(): Promise<void> {
 }
 
 describe('compiler-owned renderer child regions', () => {
+	it('renders renderer-local context providers through DOM owners without replacing their children', () => {
+		const Theme = createNativeContext('default');
+		const Reader = () =>
+			createElement('span', { className: 'renderer-local-theme' }, useDomContext(Theme as any));
+		const Provider = ({ theme }: { theme: string }) =>
+			createElement(Theme.Provider as any, { value: theme }, createElement(Reader, null));
+		const mounted = mount(Provider as unknown as ComponentBody<{ theme: string }>, {
+			theme: 'dark',
+		});
+
+		try {
+			const label = mounted.find('.renderer-local-theme');
+			expect(label.textContent).toBe('dark');
+			mounted.update(Provider as unknown as ComponentBody<{ theme: string }>, {
+				theme: 'light',
+			});
+			expect(mounted.find('.renderer-local-theme')).toBe(label);
+			expect(label.textContent).toBe('light');
+		} finally {
+			mounted.unmount();
+		}
+	});
+
+	it('settles DOM-owned universal work using the active host scheduler automatically', () => {
+		const bridged = objectRoot();
+		const plan = universalPlan('object', {
+			kind: 'host',
+			type: 'bridged',
+			bindings: [['version', 0]],
+		});
+		let setDomVersion!: (value: number) => void;
+		const BridgedScene = defineUniversalComponent('object', (props: { version: number }) =>
+			universalValue(plan, [props.version]),
+		);
+		const mounted = mount(UniversalSchedulerBridgeApp, {
+			root: bridged.root,
+			component: BridgedScene,
+			captureUpdate(update: (value: number) => void) {
+				setDomVersion = update;
+			},
+			onUniversalLayout() {},
+		});
+
+		try {
+			const hostRuntime = UniversalRuntime as typeof UniversalRuntime & {
+				getUniversalHostFlusher?: () => typeof flushSync | undefined;
+			};
+			const result = flushUniversalSync(() => {
+				setDomVersion(1);
+				return 'settled';
+			}, hostRuntime.getUniversalHostFlusher?.());
+			expect(result).toBe('settled');
+			expect(bridged.container.children[0].props.version).toBe(1);
+		} finally {
+			mounted.unmount();
+		}
+	});
+
 	it('settles direct and DOM-owned universal cascades in one host scheduler boundary', () => {
 		const direct = objectRoot();
 		const bridged = objectRoot();

--- a/packages/three/README.md
+++ b/packages/three/README.md
@@ -137,6 +137,19 @@ root.render(Scene, { color: 'hotpink' });
 root.store.getState().advance(1 / 60);
 ```
 
+Compiled Three scene modules import and register only the built-in constructors
+used by their authored intrinsic tags, so direct roots do not retain the entire
+Three namespace. Both extension forms remain selective: `extend({ CustomMesh })`
+registers the named constructor, while `extend(CustomMesh)` returns a stable
+callable component without registering unrelated built-ins. An explicit
+extension always takes precedence over a compiler-registered constructor.
+
+`Canvas` registers the complete Three namespace when it first renders, retaining
+the familiar R3F-compatible catalogue for dynamic or otherwise uncompiled scene
+content. Code that constructs low-level universal host plans by hand instead
+of compiling a `.three.tsrx` scene must register each constructor itself before
+rendering, for example `extend({ Mesh })` for a manually authored `mesh` plan.
+
 Direct-root scheduling uses Octane's public `act` and `flushSync` semantics.
 Call `root.unmount()` directly, or use
 `unmountComponentAtNode(canvas, optionalCallback)` to remove the root registered

--- a/packages/three/src/core/catalogue.ts
+++ b/packages/three/src/core/catalogue.ts
@@ -14,6 +14,7 @@ import {
 	universalValue,
 } from 'octane/universal';
 import type { EventHandlers } from './events.js';
+import { registerTrustedThreeConstructor } from './constructors.js';
 
 export const THREE_RENDERER_ID = 'three';
 
@@ -182,11 +183,23 @@ function toPascalCase(type: string): string {
 	return type.length === 0 ? type : `${type[0].toUpperCase()}${type.slice(1)}`;
 }
 
-/** Register the built-in Three namespace once, at driver creation time. */
+/** Register one compiler-selected built-in without replacing an authored extension. */
+export function registerThreeIntrinsic(name: string, Constructor: ConstructorRepresentation): void {
+	registerTrustedThreeConstructor(Constructor);
+	if (!Object.hasOwn(catalogue, name)) catalogue[name] = Constructor;
+}
+
+/** Register the complete Three namespace only for Canvas's compatibility surface. */
 export function registerThreeNamespace(): void {
 	if (namespaceRegistered) return;
 	namespaceRegistered = true;
-	Object.assign(catalogue, THREE);
+	for (const name of Object.keys(THREE)) {
+		const Constructor = (THREE as unknown as Catalogue)[name];
+		registerTrustedThreeConstructor(Constructor);
+		if (!Object.hasOwn(catalogue, name)) {
+			catalogue[name] = Constructor;
+		}
+	}
 }
 
 /** Resolve conflicting `threeLine`-style host names without shadowing explicit extensions. */
@@ -242,9 +255,6 @@ export function extend<T extends Catalogue>(objects: T): void;
 export function extend<T extends Catalogue | ConstructorRepresentation>(
 	objects: T,
 ): UniversalComponent<any> | void {
-	// Seed built-ins before user entries so an explicit extension can override a
-	// catalogue name deterministically, independent of driver creation order.
-	registerThreeNamespace();
 	if (typeof objects !== 'function') {
 		Object.assign(catalogue, objects);
 		return;

--- a/packages/three/src/core/constructors.ts
+++ b/packages/three/src/core/constructors.ts
@@ -1,0 +1,36 @@
+import {
+	Color,
+	Euler,
+	Layers,
+	Matrix3,
+	Matrix4,
+	Quaternion,
+	Vector2,
+	Vector3,
+	Vector4,
+} from 'three';
+
+// These value classes occur on ordinary Three objects even when they are not
+// authored as scene intrinsics. Keep their identities explicit so bundlers can
+// discard the rest of the Three namespace and custom subclasses stay untrusted.
+const TRUSTED_THREE_CONSTRUCTORS = new WeakSet<Function>([
+	Color,
+	Euler,
+	Layers,
+	Matrix3,
+	Matrix4,
+	Quaternion,
+	Vector2,
+	Vector3,
+	Vector4,
+]);
+
+/** Accept constructors obtained from compiler-owned or full Three namespace registration. */
+export function registerTrustedThreeConstructor(value: unknown): void {
+	if (typeof value === 'function') TRUSTED_THREE_CONSTRUCTORS.add(value);
+}
+
+/** Only an exact Three constructor, never a derived custom class, is trusted. */
+export function isTrustedThreeConstructor(value: unknown): boolean {
+	return typeof value === 'function' && TRUSTED_THREE_CONSTRUCTORS.has(value);
+}

--- a/packages/three/src/core/driver.ts
+++ b/packages/three/src/core/driver.ts
@@ -26,7 +26,6 @@ import {
 } from './store.js';
 import {
 	createThreeObject,
-	registerThreeNamespace,
 	resolveThreeConstructor,
 	THREE_RENDERER_ID,
 	type ConstructorRepresentation,
@@ -1858,7 +1857,6 @@ export function applyProps<T extends object>(
 export function createThreeDriver(
 	renderer = THREE_RENDERER_ID,
 ): UniversalHostDriver<ThreeHostContainer, object> {
-	registerThreeNamespace();
 	return {
 		id: renderer,
 		capabilities: {

--- a/packages/three/src/core/props.ts
+++ b/packages/three/src/core/props.ts
@@ -12,6 +12,7 @@
  * properties only; renderer-reserved callbacks never become object fields.
  */
 import * as THREE from 'three';
+import { isTrustedThreeConstructor } from './constructors.js';
 
 export type ThreePropBag = Readonly<Record<string, unknown>>;
 
@@ -53,11 +54,6 @@ export const THREE_RESERVED_PROPS = Object.freeze([
 const EVENT_PROP = /^on(Pointer|Click|DoubleClick|ContextMenu|Wheel)/;
 const COLOR_MAPS = new Set(['map', 'emissiveMap', 'sheenColorMap', 'specularColorMap', 'envMap']);
 const MEMOIZED_PROTOTYPES = new Map<Function, any>();
-const THREE_CONSTRUCTORS = new Set<Function>(
-	Object.values(THREE as unknown as Record<string, unknown>).filter(
-		(value) => typeof value === 'function',
-	) as Function[],
-);
 const UNKNOWN_SHAPE = Symbol('unknown Three property shape');
 
 function isObject(value: unknown): value is Record<string, any> {
@@ -373,7 +369,7 @@ function resolveShadowProperty(state: ShadowState, key: string): ResolvedShadowP
 
 function isKnownThreeValue(value: unknown): boolean {
 	const Constructor = (value as { constructor?: unknown } | null)?.constructor;
-	return typeof Constructor === 'function' && THREE_CONSTRUCTORS.has(Constructor);
+	return isTrustedThreeConstructor(Constructor);
 }
 
 function isCanonicalThreeMethod(value: unknown, key: string, method: unknown): boolean {

--- a/packages/three/src/core/store.ts
+++ b/packages/three/src/core/store.ts
@@ -6,13 +6,8 @@
  * components. Zustand remains the framework-neutral storage primitive.
  */
 import * as THREE from 'three';
-import {
-	createContext,
-	useContext,
-	useRef,
-	useSyncExternalStore,
-	withSlot,
-} from 'octane/universal';
+import { useContext, useRef, useSyncExternalStore, withSlot } from 'octane/universal';
+import { createContext } from 'octane/universal/native';
 import { createStore as createVanillaStore, type StoreApi } from 'zustand/vanilla';
 import type {
 	DomEvent,

--- a/packages/three/src/renderer.ts
+++ b/packages/three/src/renderer.ts
@@ -7,6 +7,7 @@
  */
 export * from 'octane/universal';
 export * from './core/index.js';
+export { registerThreeIntrinsic } from './core/catalogue.js';
 // Resolve the deliberate name overlap with the capability-gated universal
 // primitive in favor of Three's R3F-shaped state-enclave adapter.
 export { createPortal } from './core/portal.js';

--- a/packages/three/src/scheduling.ts
+++ b/packages/three/src/scheduling.ts
@@ -1,6 +1,10 @@
 import * as Octane from 'octane';
-import { flushSync as clientFlushSync } from 'octane';
-import { flushUniversalAct, flushUniversalSync, type UniversalSyncFlusher } from 'octane/universal';
+import {
+	flushUniversalAct,
+	flushUniversalSync,
+	getUniversalHostFlusher,
+	type UniversalSyncFlusher,
+} from 'octane/universal';
 
 export type Act = typeof import('octane').act;
 type FlushSync = typeof import('octane').flushSync;
@@ -67,7 +71,7 @@ function runClientAct<T>(callback: () => T | Promise<T>, clientAct: Act): Promis
 
 /** Flushes both the DOM scheduler and mounted universal Three roots. */
 export const flushSync: FlushSync = (callback) => {
-	return flushUniversalSync(callback, clientFlushSync);
+	return flushUniversalSync(callback, getUniversalHostFlusher());
 };
 
 /** R3F-compatible test helper backed by Octane's client scheduler when available. */
@@ -78,7 +82,7 @@ export const act: Act = (callback) => {
 	const clientAct = Reflect.get(Octane, 'act') as Act | undefined;
 	if (typeof clientAct === 'function') return runClientAct(callback, clientAct);
 	try {
-		return Promise.resolve(runActCallback(callback, clientFlushSync));
+		return Promise.resolve(runActCallback(callback, getUniversalHostFlusher()));
 	} catch (error) {
 		return Promise.reject(error);
 	}

--- a/packages/three/src/web/Canvas.tsrx
+++ b/packages/three/src/web/Canvas.tsrx
@@ -2,6 +2,7 @@ import { useInsertionEffect, useLayoutEffect, useRef, useState } from 'octane';
 import type { OctaneNode } from 'octane';
 import { createUniversalHostBoundary } from 'octane/universal';
 import type { RendererRegion } from 'octane/universal';
+import { registerThreeNamespace } from '../core/catalogue.js';
 import type { ComputeFunction, DomEvent } from '../core/events.js';
 import { createRoot, createThreeBoundaryMount } from '../core/root.js';
 import type { RenderProps, ThreeBoundaryMount, ThreeRoot } from '../core/root.js';
@@ -208,6 +209,7 @@ export function Canvas({
 		let cancelled = false;
 		let root = rootRef.current;
 		if (root === null) {
+			registerThreeNamespace();
 			root = createRoot(canvas);
 			rootRef.current = root;
 		}

--- a/packages/three/src/web/dom-region.ts
+++ b/packages/three/src/web/dom-region.ts
@@ -1,6 +1,10 @@
 import * as Octane from 'octane';
 import type { ComponentBody, Root } from 'octane';
-import { isRendererRegion, type RendererRegion } from 'octane/universal';
+import {
+	isRendererRegion,
+	registerUniversalHostBridge,
+	type RendererRegion,
+} from 'octane/universal';
 
 export type DOMRegionTarget = HTMLElement | { current: HTMLElement | null };
 
@@ -28,6 +32,7 @@ export interface DOMRegionBinding {
 }
 
 export function createDOMRegionBinding(): DOMRegionBinding {
+	registerUniversalHostBridge();
 	const createRoot = Reflect.get(Octane, 'createRoot') as
 		typeof import('octane').createRoot | undefined;
 	if (typeof createRoot !== 'function' || typeof document === 'undefined') {

--- a/packages/three/tests/canvas.test.ts
+++ b/packages/three/tests/canvas.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync } from 'octane';
+import { TorusKnotGeometry } from 'three';
 import { events as createPointerEvents } from '../src/index.js';
+import { createThreeObject } from '../src/core/catalogue.js';
 import type { EventManager, Renderer, RootState } from '../src/core/index.js';
 import { mount, type MountResult } from '../../octane/tests/_helpers.js';
 import {
@@ -110,6 +112,21 @@ describe('Canvas', () => {
 	afterEach(() => {
 		mounted?.unmount();
 		vi.unstubAllGlobals();
+	});
+
+	it('registers the full Three catalogue only when a measured client Canvas becomes active', async () => {
+		const { factory } = rendererHarness();
+		const createRareGeometry = () => createThreeObject('torusKnotGeometry', {});
+		expect(createRareGeometry).toThrow('Call extend({ TorusKnotGeometry })');
+
+		mounted = mount(EmptyCanvasApp, { gl: factory, onCreated: undefined });
+		expect(createRareGeometry).toThrow('Call extend({ TorusKnotGeometry })');
+
+		ControlledResizeObserver.instances[0].emit({ width: 240, height: 160 });
+		await flushCanvasWork();
+		const { object } = createRareGeometry();
+		expect(object).toBeInstanceOf(TorusKnotGeometry);
+		object.dispose();
 	});
 
 	it('waits for positive layout, then mounts and resizes one retained Three scene', async () => {

--- a/packages/three/tests/catalogue-props.test.ts
+++ b/packages/three/tests/catalogue-props.test.ts
@@ -5,6 +5,7 @@ import { createThreeTestRenderer } from '@octanejs/three/testing';
 import { defineUniversalComponent, universalComponent, universalProps } from 'octane/universal';
 import {
 	createThreeObject,
+	registerThreeIntrinsic,
 	registerThreeNamespace,
 	validateThreeInstance,
 } from '../src/core/catalogue.js';
@@ -12,6 +13,30 @@ import { attachString, detachAttachment, getEffectiveAttachment } from '../src/c
 import { applyThreeProps } from '../src/core/props.js';
 
 describe('@octanejs/three catalogue', () => {
+	it('registers built-in constructors selectively without replacing explicit extensions', () => {
+		class SelectiveMesh extends THREE.Mesh {}
+		class OverriddenMesh extends THREE.Mesh {}
+
+		registerThreeIntrinsic('SelectiveMesh', SelectiveMesh);
+		registerThreeIntrinsic('SelectiveMesh', THREE.Mesh);
+		expect(createThreeObject('selectiveMesh', {}).object).toBeInstanceOf(SelectiveMesh);
+
+		extend({ SelectiveMesh: OverriddenMesh });
+		registerThreeIntrinsic('SelectiveMesh', SelectiveMesh);
+		expect(createThreeObject('selectiveMesh', {}).object).toBeInstanceOf(OverriddenMesh);
+	});
+
+	it('retains explicit built-in overrides when the full Canvas catalogue is registered later', () => {
+		class OverriddenMesh extends THREE.Mesh {}
+		extend({ Mesh: OverriddenMesh });
+		try {
+			registerThreeNamespace();
+			expect(createThreeObject('mesh', {}).object).toBeInstanceOf(OverriddenMesh);
+		} finally {
+			extend({ Mesh: THREE.Mesh });
+		}
+	});
+
 	it('validates built-ins and preserves primitive identity and ownership', () => {
 		registerThreeNamespace();
 

--- a/packages/three/tests/driver.test.ts
+++ b/packages/three/tests/driver.test.ts
@@ -11,6 +11,7 @@ import {
 	universalValue,
 } from 'octane/universal';
 import { applyProps, extend } from '@octanejs/three';
+import { registerThreeIntrinsic, registerThreeNamespace } from '../src/core/catalogue.js';
 import {
 	createThreeContainer,
 	createThreeDriver,
@@ -19,6 +20,13 @@ import {
 } from '../src/core/driver.js';
 
 function createRoot(scene = new THREE.Scene(), environment: ThreeHostEnvironment = {}) {
+	registerThreeIntrinsic('BoxGeometry', THREE.BoxGeometry);
+	registerThreeIntrinsic('Color', THREE.Color);
+	registerThreeIntrinsic('Group', THREE.Group);
+	registerThreeIntrinsic('Mesh', THREE.Mesh);
+	registerThreeIntrinsic('MeshBasicMaterial', THREE.MeshBasicMaterial);
+	registerThreeIntrinsic('Object3D', THREE.Object3D);
+	registerThreeIntrinsic('SphereGeometry', THREE.SphereGeometry);
 	const container = createThreeContainer({
 		scene,
 		environment: {
@@ -735,6 +743,120 @@ describe('Three universal driver', () => {
 
 		root.unmount();
 		container.flushDisposals();
+	});
+
+	it('rejects overridden Three value-class setters before attaching into the committed value', () => {
+		class UnsafeVector extends THREE.Vector3 {
+			child: unknown = { leaf: {} };
+
+			override fromArray(array: ArrayLike<number>, offset = 0): this {
+				super.fromArray(array, offset);
+				this.child = null;
+				return this;
+			}
+		}
+		class UnsafeVectorParent extends THREE.Object3D {
+			readonly offset = new UnsafeVector();
+		}
+		extend({ UnsafeVectorParent });
+		const colorPlan = universalPlan('three', {
+			kind: 'host',
+			type: 'color',
+			propsSlot: 0,
+		});
+		const parentPlan = universalPlan('three', {
+			kind: 'host',
+			type: 'unsafeVectorParent',
+			propsSlot: 0,
+			children: [{ kind: 'slot', slot: 1 }],
+		});
+		const Scene = defineUniversalComponent('three', (props: { child: boolean }) =>
+			universalValue(parentPlan, [
+				universalProps(props.child ? [['set', 'offset', [1, 2, 3]]] : []),
+				universalList(props.child ? ['child'] : [], (key) =>
+					universalKey(
+						key,
+						universalValue(colorPlan, [
+							universalProps([
+								['set', 'args', ['white']],
+								['set', 'attach', 'offset-child-leaf'],
+							]),
+						]),
+					),
+				),
+			]),
+		);
+		const { container, root, scene } = createRoot();
+		root.render(Scene, { child: false });
+		const parent = scene.children[0] as UnsafeVectorParent;
+		const originalChild = parent.offset.child;
+
+		expect(() => root.prepare(Scene, { child: true })).toThrow(
+			/custom setter makes its final parent shape uncertain/,
+		);
+		expect(parent.offset.toArray()).toEqual([0, 0, 0]);
+		expect(parent.offset.child).toBe(originalChild);
+		expect(parent.children).toEqual([]);
+
+		root.unmount();
+		container.flushDisposals();
+	});
+
+	it('accepts safe Three value setters from selective and complete constructor catalogues', () => {
+		const verifyAttachment = (
+			createBounds: () => THREE.Box2 | THREE.Box3,
+			values: [THREE.Vector2, THREE.Vector2] | [THREE.Vector3, THREE.Vector3],
+		) => {
+			class TrustedBoundsParent extends THREE.Object3D {
+				readonly bounds = createBounds();
+			}
+			extend({ TrustedBoundsParent });
+			const colorPlan = universalPlan('three', {
+				kind: 'host',
+				type: 'color',
+				propsSlot: 0,
+			});
+			const parentPlan = universalPlan('three', {
+				kind: 'host',
+				type: 'trustedBoundsParent',
+				propsSlot: 0,
+				children: [{ kind: 'slot', slot: 1 }],
+			});
+			const Scene = defineUniversalComponent('three', (props: { child: boolean }) =>
+				universalValue(parentPlan, [
+					universalProps(props.child ? [['set', 'bounds', values]] : []),
+					universalList(props.child ? ['child'] : [], (key) =>
+						universalKey(
+							key,
+							universalValue(colorPlan, [
+								universalProps([
+									['set', 'args', ['white']],
+									['set', 'attach', 'bounds-min'],
+								]),
+							]),
+						),
+					),
+				]),
+			);
+			const { container, root, scene } = createRoot();
+			root.render(Scene, { child: false });
+			const parent = scene.children[0] as TrustedBoundsParent;
+
+			expect(() => root.render(Scene, { child: true })).not.toThrow();
+			expect(parent.bounds.min).toBeInstanceOf(THREE.Color);
+
+			root.unmount();
+			container.flushDisposals();
+		};
+
+		registerThreeIntrinsic('Box3', THREE.Box3);
+		verifyAttachment(
+			() => new THREE.Box3(),
+			[new THREE.Vector3(-1, -2, -3), new THREE.Vector3(1, 2, 3)],
+		);
+
+		registerThreeNamespace();
+		verifyAttachment(() => new THREE.Box2(), [new THREE.Vector2(-1, -2), new THREE.Vector2(1, 2)]);
 	});
 
 	it('rejects behavior-changing method and accessor writes before mutation', () => {

--- a/packages/three/tests/lifecycle.test.ts
+++ b/packages/three/tests/lifecycle.test.ts
@@ -10,9 +10,11 @@ import {
 	universalProps,
 	universalValue,
 } from 'octane/universal';
+import { registerThreeIntrinsic } from '../src/core/catalogue.js';
 import { createThreeContainer, createThreeDriver } from '../src/core/driver.js';
 
 function createRoot() {
+	registerThreeIntrinsic('Group', THREE.Group);
 	const scene = new THREE.Scene();
 	const container = createThreeContainer({
 		scene,


### PR DESCRIPTION
## Summary

Make both supported `@octanejs/three` production bundle configurations smaller than React Three Fiber while preserving the existing renderer-performance wins, complete Canvas catalogues, and cross-renderer context/scheduling semantics.

| Production bundle | Current `main` | This PR | React Three Fiber |
| --- | ---: | ---: | ---: |
| Minimal Three scene, gzip | 279,464 B | **182,976 B** | 187,392 B |
| Full Three catalogue, gzip | 279,012 B | **244,560 B** | 249,637 B |

- Reduce the minimal bundle by **96,488 B / 34.5%** and the full-catalogue bundle by **34,452 B / 12.3%** against the same-machine `main` baseline.
- Compile authored Three intrinsics to selective named constructor imports; keep custom extensions, constructor-form `extend`, custom overrides, older-peer polyfills, and full client-side Canvas catalogues compatible.
- Replace full-namespace property inspection with exact trusted constructor identities, preserving transactional setter safety and Three r156 compatibility.
- Decouple renderer-local contexts and synchronous scheduling from Octane's DOM runtime using a lazy mixed-renderer bridge that preserves DOM providers, SSR/hydration, and DOMRegion behavior.
- Tighten both committed bundle-size ratio guards to **1.0**; the existing eight renderer-performance guards also remain green.

## Validation

- [x] `pnpm format:check`
- [ ] `pnpm typecheck` (full workspace is blocked by unrelated, locally unavailable `@solana/kit` workspace dependencies; core source/public types, Three source/public types, and actual Three r156 source/public type lanes passed)
- [ ] `pnpm test` (full monorepo not run; all affected package, compiler, renderer, browser, and adapter suites listed below passed)
- [x] targeted tests: `pnpm sync`; `pnpm --filter octane build`; `pnpm typecheck:files` for every changed production source; Three current **139 tests** and real Three r156 **134 tests**; Octane renderer/context/hydration/SSR suites **332 tests**; compiler/Lynx/transport **1,412 tests**; Vite/Rspack/Rsbuild adapters **185 tests**; actual Three production-browser integrations **8 tests**; upstream export crosswalk and published TSRX declaration checks.
- [x] `node benchmarks/bench.mjs --ratios --results-dir=/private/tmp/octane-three-bundle-pr-final three-renderer three-bundle-size` — **10/10 strict ratio guards passed**, with 20 production-browser samples per renderer operation and all six size bundles executed and scene-verified in Chromium.
- [x] Reciprocal DOM-only/universal-only bundle reachability tests and the full 28-fixture reachability audit: no newly introduced failures. The existing `suspense-transition` raw/gzip/Brotli budgets already fail on untouched `main`; the affected bytes are exactly identical before and after this change.

## Risk / follow-ups

- Direct low-level host plans authored manually, without compiling a `.three.tsrx` scene or using `Canvas`, must explicitly register their constructors with `extend`, matching React Three Fiber's low-level root behavior.
- Compiler-generated imports are version-aware across the audited Three r156, r172, and current constructor surfaces; explicit same-module polyfills remain supported.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches compiler emission, Three catalogue registration order, cross-renderer context/SSR bridging, and transactional prop safety; manual low-level plans must explicitly register constructors like R3F.
> 
> **Overview**
> **Shrinks `@octanejs/three` production bundles** by compiling authored intrinsic tags into **named `three` imports** plus `registerThreeIntrinsic` calls, instead of retaining the full namespace on every direct root. Explicit `extend` registrations and polyfills still win over compiler defaults; **`Canvas` alone** registers the complete catalogue when it mounts.
> 
> **Stops eager full-namespace registration** at driver/`extend` time and replaces whole-`THREE` constructor scanning with a **trusted-constructor allowlist** for property/setter safety, so bundlers can drop unused exports.
> 
> Adds a **`renderer-bridge`** so native universal contexts and `flushSync` scheduling wire up only when a DOM or mixed-renderer owner is active—DOM-only apps no longer pull universal modules, while SSR, hydration, and `DOMRegion` keep working.
> 
> Benchmark **gzip ratio guards vs React Three Fiber are tightened to 1.0** for minimal and full-catalogue builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad8b8fe231f9cde48b4bd0f9a53512e45f902fc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->