### PR TITLE
fix(compiler): keep sibling order for all-component children that mount empty

### DIFF
--- a/.changeset/component-children-sibling-order.md
+++ b/.changeset/component-children-sibling-order.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Fix a sibling-ordering bug in hosts whose children are all components: a hookless child that rendered nothing at mount (for example a sole `@if` with no `@else`) inserted content produced by a later render after its later siblings instead of at its own source position. The compiler now keeps per-child anchors for such hosts, while hosts whose children provably hold their position keep the marker-elided form.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -4962,6 +4962,56 @@ function isSingleHostIfRoot(node) {
 }
 
 /**
+ * Local (non-transitive) anchorless-append shape of a lite component's body
+ * root, for the all-component-children emission (see emitElementHtml and
+ * makeCompCall's anchorlessAppendSafe). A componentSlotLite call with no
+ * anchor keeps NO positional record — its body inserts at `endMarker = null`
+ * (appendChild). The one runtime state that loses a position entirely is a
+ * root-position branch slot taking the NULL-BODY arm (an `@if` with no
+ * `@else`): the empty arm records a null anchor and mints nothing, so content
+ * rendered by a later toggle appends AFTER every later sibling. Every arm
+ * WITH a body leaves a durable boundary on mount (a single host self-marks;
+ * anything else — including empty component output, whose slot still mints
+ * its own comment pair — gets the branch pair minted around it), so we admit:
+ *   - one plain host root (the element is the boundary), and
+ *   - an @if with a FULL @else chain whose every arm is exactly one plain
+ *     host, one component tag (safe unless it lowers to an unsafe lite slot —
+ *     resolved transitively via `edges` by the componentInfo fixpoint), or a
+ *     nested chain of the same shape.
+ * Everything else (missing @else, @switch/@for/hole/fragment roots,
+ * multi-node arms) returns null: the call site keeps its `<!>` anchor.
+ * Note every admitted shape renders at least one node in every state, which
+ * is what keeps each mounted arm's boundary derivable.
+ *
+ * Returns { edges: string[] } when the shape qualifies, else null.
+ */
+function anchorlessRootShape(node) {
+	let render = null;
+	if (node?.body?.type === 'JSXCodeBlock') render = node.body.render;
+	else if (node?.body?.body?.length === 1 && node.body.body[0]?.type === 'ReturnStatement')
+		render = node.body.body[0].argument;
+	if (render == null) return null;
+	if (isPlainHostRoot(render)) return { edges: [] };
+	const edges = [];
+	const armOk = (arm) => {
+		const out = statementsOf(arm).filter((s) => isJsxNode(s) || isIfDirective(s));
+		if (out.length !== 1) return false;
+		const n = out[0];
+		if (isIfDirective(n)) return chainOk(n);
+		if (isPlainHostRoot(n)) return true;
+		if ((n.type === 'Element' || n.type === 'JSXElement') && isComponentTag(n)) {
+			const name = tagBindingName(n);
+			if (name != null) edges.push(name);
+			return true;
+		}
+		return false;
+	};
+	const chainOk = (ifNode) =>
+		ifNode.alternate != null && armOk(ifNode.consequent) && armOk(ifNode.alternate);
+	return isIfDirective(render) && chainOk(render) ? { edges } : null;
+}
+
+/**
  * True when an @for item is one direct host root on the wire.
  *
  * This is deliberately narrower than the client-only singleRoot proof below:
@@ -7436,6 +7486,32 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 				info.autoMemoImportedComponents = [...importedComponents].sort();
 				info.autoMemoMayReadContext = mayReadContext;
 				autoMemoCapturesChanged = true;
+			}
+		}
+	}
+	// Anchorless append-safety for componentSlotLite call sites (see
+	// anchorlessRootShape for the shape rules and the hazard). Optimistic
+	// fixpoint over the same-module component-arm edges: cycles of safe-shaped
+	// components stay safe; a locally-unsafe shape drains through its
+	// dependents, so declaration order and recursion do not matter (same scheme
+	// as the autoMemo loop above). An edge to a non-lite or cross-module callee
+	// is safe outright — its componentSlot mints its own positional markers.
+	for (const [, info] of ctx.componentInfo) {
+		info.anchorlessRootShape = anchorlessRootShape(info.node);
+		info.anchorlessRootSafe = info.anchorlessRootShape !== null;
+	}
+	let anchorlessChanged = true;
+	while (anchorlessChanged) {
+		anchorlessChanged = false;
+		for (const [, info] of ctx.componentInfo) {
+			if (!info.anchorlessRootSafe) continue;
+			for (const name of info.anchorlessRootShape.edges) {
+				const dep = ctx.componentInfo.get(name);
+				if (dep !== undefined && dep.eligible === true && dep.anchorlessRootSafe !== true) {
+					info.anchorlessRootSafe = false;
+					anchorlessChanged = true;
+					break;
+				}
 			}
 		}
 	}
@@ -21121,7 +21197,9 @@ function emitElementHtml(
 		// (componentSlot/Lite with no anchor → appendChild). Restricted to the
 		// all-component case so hydration's adopt cursor can simply descend into the
 		// host's child stream (host.firstChild); mixed static+component children keep
-		// their placeholders, where the cursor would otherwise mis-track.
+		// their placeholders, where the cursor would otherwise mis-track. The branch
+		// below still declines the elision when a child's own lowering cannot hold
+		// its position (see cc.anchorlessAppendSafe).
 		let allComponentChildren = children.length > 0;
 		for (const c of children) {
 			if (!(c.type === 'Element' && isComponentTag(c))) {
@@ -21129,8 +21207,57 @@ function emitElementHtml(
 				break;
 			}
 		}
-		for (let childI = 0; childI < children.length; childI++) {
-			const child = children[childI];
+		if (allComponentChildren) {
+			// Two phases: build every record first, because the append-vs-anchor
+			// choice depends on how each call site actually lowers
+			// (cc.anchorlessAppendSafe) and is all-or-nothing — anchoring only the
+			// unsafe child would desync hydration, whose adopt walk counts one
+			// logical sibling per child against the SAME server HTML in both
+			// regimes. Records are pushed in source order; only the anchor
+			// assignment waits for the decision. The LAST child is exempt from the
+			// safety check: nothing follows it inside the host, so content it
+			// appends on a later render is already at its source position.
+			const ccs = [];
+			for (const child of children) {
+				const cc = makeCompCall(
+					child,
+					ctx,
+					componentName,
+					inlinedSubs,
+					bindings,
+					forCalls,
+					ifCalls,
+					compCalls,
+					childNs,
+					cssHash,
+				);
+				cc.hostPath = path;
+				compCalls.push(cc);
+				ccs.push(cc);
+			}
+			let anchorless = true;
+			for (let i = 0; i < ccs.length - 1; i++) {
+				if (!ccs[i].anchorlessAppendSafe) {
+					anchorless = false;
+					break;
+				}
+			}
+			if (!anchorless) {
+				// A `<!>` anchor at each child's source-order position, exactly the
+				// mixed-children regime below: the slot mounts BEFORE its anchor, so
+				// a child that grows content after an empty mount keeps its place.
+				for (const cc of ccs) {
+					cc.anchorPath = [...path, childIdx];
+					appendTemplatePart(html, '<!>', 'anchor');
+					childIdx++;
+				}
+			}
+		}
+		// Mixed static+component children — walked in order. The all-component
+		// branch above already consumed every child, so it walks nothing.
+		const walkChildren = allComponentChildren ? [] : children;
+		for (let childI = 0; childI < walkChildren.length; childI++) {
+			const child = walkChildren[childI];
 			const prevBaked = prevBakedText;
 			prevBakedText = false;
 			if (child.type === 'FragmentStart') {
@@ -21228,22 +21355,15 @@ function emitElementHtml(
 						cssHash,
 					);
 					cc.hostPath = path;
-					if (allComponentChildren) {
-						// All-component children: append to the host in source order (no
-						// `<!>` placeholder, no anchor). Hydration adopts from the cursor
-						// descending into the host (see componentSlot/Lite).
-						compCalls.push(cc);
-					} else {
-						// Emit a `<!>` anchor at the component's source-order position so
-						// componentSlot inserts BEFORE this anchor — preserving sibling
-						// order when a Component appears before static-element/text
-						// siblings. Without this, the slot's start/end markers get
-						// appended to the parent host AFTER the static template content.
-						cc.anchorPath = [...path, childIdx];
-						compCalls.push(cc);
-						appendTemplatePart(html, '<!>', 'anchor');
-						childIdx++;
-					}
+					// Emit a `<!>` anchor at the component's source-order position so
+					// componentSlot inserts BEFORE this anchor — preserving sibling
+					// order when a Component appears before static-element/text
+					// siblings. Without this, the slot's start/end markers get
+					// appended to the parent host AFTER the static template content.
+					cc.anchorPath = [...path, childIdx];
+					compCalls.push(cc);
+					appendTemplatePart(html, '<!>', 'anchor');
+					childIdx++;
 				} else {
 					const childHtml = emitElementHtml(
 						child,
@@ -22261,6 +22381,18 @@ function makeCompCall(
 		}
 	}
 
+	// Append-safety for the anchorless all-component-children emission (see
+	// emitElementHtml). Only a componentSlotLite lowering can lose its
+	// position (no markers, no anchor, no record) — and only when the callee's
+	// body root can take a null-arm branch; anchorlessRootSafe carries that
+	// transitive proof (see anchorlessRootShape). Every non-lite lowering
+	// self-positions: componentSlot mints its marker pair, and the singleRoot
+	// regimes keep the root element from mount. (A staticFragmentRenderer fold
+	// registers only for single-plain-host-root callees, so its authored
+	// info's shape proof holds.)
+	const anchorlessAppendSafe =
+		!liteEligible || ctx.componentInfo?.get(compName)?.anchorlessRootSafe === true;
+
 	return {
 		id,
 		compNode,
@@ -22268,6 +22400,7 @@ function makeCompCall(
 		hostPath: null,
 		keyExpr,
 		liteEligible,
+		anchorlessAppendSafe,
 		autoMemoDeps,
 		autoMemoDepNodes,
 		autoMemoWitnesses,

--- a/packages/octane/tests/_fixtures/component-children-host.tsrx
+++ b/packages/octane/tests/_fixtures/component-children-host.tsrx
@@ -1,0 +1,76 @@
+/**
+ * All-component-children hosts: every child of the <section> is a component,
+ * so the compiler may mount the child slots by appending (no per-child
+ * anchors). These shapes pin the sibling-order contract for that regime,
+ * especially a child that renders NOTHING at mount and grows content on a
+ * later render (the conditional-panel pattern).
+ */
+
+function Leaf(props: { label: string }) @{
+	<span class="leaf">{props.label as string}</span>
+}
+
+function MaybePanel(props: { big?: boolean; label: string }) @{
+	@if (props.big) {
+		<div class="big">{props.label as string}</div>
+	}
+}
+
+/** A conditional panel ahead of an always-present leaf. */
+export function WideTrio(props: { bBig?: boolean }) @{
+	<section class="host">
+		<MaybePanel big={props.bBig} label="B" />
+		<Leaf label="C" />
+	</section>
+}
+
+/** Two independently toggled panels ahead of an always-present leaf. */
+export function WidePanels(props: { aBig?: boolean; bBig?: boolean }) @{
+	<section class="host">
+		<MaybePanel big={props.aBig} label="A" />
+		<MaybePanel big={props.bBig} label="B" />
+		<Leaf label="C" />
+	</section>
+}
+
+/** A conditional panel in TRAILING position — append-at-end is source order. */
+export function TrailingPanel(props: { zBig?: boolean }) @{
+	<section class="host">
+		<Leaf label="A" />
+		<MaybePanel big={props.zBig} label="Z" />
+	</section>
+}
+
+/** A full @if/@else chain: always renders exactly one element. */
+function EitherPanel(props: { big?: boolean; label: string }) @{
+	@if (props.big) {
+		<div class="big">{props.label as string}</div>
+	} @else {
+		<span class="small">{props.label as string}</span>
+	}
+}
+
+/** An always-rendering chain child ahead of a leaf. */
+export function ChainTrio(props: { aBig?: boolean }) @{
+	<section class="host">
+		<EitherPanel big={props.aBig} label="A" />
+		<Leaf label="C" />
+	</section>
+}
+
+/** A full chain whose taken arm mounts a MAY-RENDER-NOTHING panel. */
+function PanelViaChain(props: { off?: boolean; big?: boolean; label: string }) @{
+	@if (props.off) {
+		<span class="off">off</span>
+	} @else {
+		<MaybePanel big={props.big} label={props.label} />
+	}
+}
+
+/** The empty-mount hazard reached TRANSITIVELY through a chain child. */
+export function TransitiveTrio(props: { bBig?: boolean }) @{
+	<section class="host">
+		<PanelViaChain big={props.bBig} label="B" />
+		<Leaf label="C" />
+	</section>
+}

--- a/packages/octane/tests/component-children-host.test.ts
+++ b/packages/octane/tests/component-children-host.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { mount, type MountResult } from './_helpers';
+import {
+	WideTrio,
+	WidePanels,
+	TrailingPanel,
+	ChainTrio,
+	TransitiveTrio,
+} from './_fixtures/component-children-host.tsrx';
+
+// A host element whose children are ALL components mounts each child slot in
+// source order. The contract pinned here is sibling ORDER: a component child
+// that renders nothing at mount and produces content on a later render must
+// still place that content at its own source position — ahead of every later
+// sibling's content — and keep doing so across repeated toggles.
+//
+// Assertions read element order (`children`) and textContent, never raw
+// innerHTML: the dev and prod compiles legitimately differ in comment markers.
+
+const order = (r: MountResult) =>
+	[...r.find('section.host').children].map((el) => `${el.className}:${el.textContent}`);
+
+describe('all-component-children host sibling order', () => {
+	it('children that start with content mount in source order', () => {
+		const r = mount(WidePanels, { aBig: true, bBig: true });
+		expect(order(r)).toEqual(['big:A', 'big:B', 'leaf:C']);
+		r.unmount();
+	});
+
+	it('a panel that mounts EMPTY renders before its later sibling once it appears', () => {
+		const r = mount(WideTrio, { bBig: false });
+		expect(order(r)).toEqual(['leaf:C']);
+
+		r.update(WideTrio, { bBig: true });
+		expect(order(r)).toEqual(['big:B', 'leaf:C']);
+
+		// And the order survives toggling away and back.
+		r.update(WideTrio, { bBig: false });
+		expect(order(r)).toEqual(['leaf:C']);
+		r.update(WideTrio, { bBig: true });
+		expect(order(r)).toEqual(['big:B', 'leaf:C']);
+		r.unmount();
+	});
+
+	it('two empty-mounted panels interleave in source order regardless of toggle order', () => {
+		// B appears first, then A — A must still land ahead of B.
+		const r = mount(WidePanels, { aBig: false, bBig: false });
+		expect(order(r)).toEqual(['leaf:C']);
+
+		r.update(WidePanels, { aBig: false, bBig: true });
+		expect(order(r)).toEqual(['big:B', 'leaf:C']);
+
+		r.update(WidePanels, { aBig: true, bBig: true });
+		expect(order(r)).toEqual(['big:A', 'big:B', 'leaf:C']);
+
+		r.update(WidePanels, { aBig: false, bBig: true });
+		expect(order(r)).toEqual(['big:B', 'leaf:C']);
+
+		r.update(WidePanels, { aBig: true, bBig: true });
+		expect(order(r)).toEqual(['big:A', 'big:B', 'leaf:C']);
+		r.unmount();
+	});
+
+	it('a full @if/@else chain child keeps its place across branch swaps', () => {
+		const r = mount(ChainTrio, { aBig: false });
+		expect(order(r)).toEqual(['small:A', 'leaf:C']);
+
+		r.update(ChainTrio, { aBig: true });
+		expect(order(r)).toEqual(['big:A', 'leaf:C']);
+		r.update(ChainTrio, { aBig: false });
+		expect(order(r)).toEqual(['small:A', 'leaf:C']);
+		r.unmount();
+	});
+
+	it('an empty mount reached through a chain child still inserts in source order', () => {
+		// The may-render-nothing panel sits INSIDE a full-chain arm, so the
+		// hazard is only visible transitively through the chain component.
+		const r = mount(TransitiveTrio, { bBig: false });
+		expect(order(r)).toEqual(['leaf:C']);
+
+		r.update(TransitiveTrio, { bBig: true });
+		expect(order(r)).toEqual(['big:B', 'leaf:C']);
+		r.update(TransitiveTrio, { bBig: false });
+		expect(order(r)).toEqual(['leaf:C']);
+		r.update(TransitiveTrio, { bBig: true });
+		expect(order(r)).toEqual(['big:B', 'leaf:C']);
+		r.unmount();
+	});
+
+	it('a trailing panel that mounts empty appears after its earlier sibling', () => {
+		const r = mount(TrailingPanel, { zBig: false });
+		expect(order(r)).toEqual(['leaf:A']);
+
+		r.update(TrailingPanel, { zBig: true });
+		expect(order(r)).toEqual(['leaf:A', 'big:Z']);
+
+		r.update(TrailingPanel, { zBig: false });
+		expect(order(r)).toEqual(['leaf:A']);
+		r.update(TrailingPanel, { zBig: true });
+		expect(order(r)).toEqual(['leaf:A', 'big:Z']);
+		r.unmount();
+	});
+});

--- a/packages/octane/tests/hydration/component-children-order-hydrate.test.ts
+++ b/packages/octane/tests/hydration/component-children-order-hydrate.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { compile } from 'octane/compiler';
+import { hydrateRoot, flushSync } from '../../src/index.js';
+import * as ServerRT from 'octane/server';
+import { WideTrio, TrailingPanel } from '../_fixtures/component-children-host.tsrx';
+
+// All-component-children hosts across SSR + hydration: the client adopts each
+// child's server range, and a child whose branch was EMPTY on the server must
+// place content rendered by a post-hydration update at its own source position,
+// ahead of later siblings — the same sibling-order contract the client-mount
+// suite pins (component-children-host.test.ts).
+
+const FIXTURE = join(process.cwd(), 'packages/octane/tests/_fixtures/component-children-host.tsrx');
+
+function serverModule(): Record<string, any> {
+	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'component-children-host.tsrx', {
+		mode: 'server',
+	});
+	code = code.replace(
+		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
+	);
+	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
+	const fn = new Function('__rt', '__exports', code + '\nreturn __exports;');
+	return fn(ServerRT, {});
+}
+const server = serverModule();
+
+let container: HTMLElement;
+beforeEach(() => {
+	container = document.createElement('div');
+	document.body.appendChild(container);
+});
+afterEach(() => container.remove());
+
+const order = () =>
+	[...container.querySelector('section.host')!.children].map(
+		(el) => `${el.className}:${el.textContent}`,
+	);
+
+describe('hydrateRoot — all-component-children host sibling order', () => {
+	it('adopts children that rendered content on the server (same elements, source order)', () => {
+		const { html } = ServerRT.renderToString(server.WideTrio, { bBig: true });
+		container.innerHTML = html;
+		const big = container.querySelector('.big');
+		const leaf = container.querySelector('.leaf');
+
+		const root = hydrateRoot(container, WideTrio, { bBig: true });
+		flushSync(() => {});
+		expect(container.querySelector('.big')).toBe(big);
+		expect(container.querySelector('.leaf')).toBe(leaf);
+		expect(order()).toEqual(['big:B', 'leaf:C']);
+		root.unmount();
+	});
+
+	it('a server-EMPTY panel renders before its later sibling after a client update', () => {
+		const { html } = ServerRT.renderToString(server.WideTrio, { bBig: false });
+		container.innerHTML = html;
+		const leaf = container.querySelector('.leaf');
+
+		const root = hydrateRoot(container, WideTrio, { bBig: false });
+		flushSync(() => {});
+		expect(order()).toEqual(['leaf:C']);
+		expect(container.querySelector('.leaf')).toBe(leaf); // adopted, not rebuilt
+
+		flushSync(() => root.render(WideTrio, { bBig: true }));
+		expect(order()).toEqual(['big:B', 'leaf:C']);
+		expect(container.querySelector('.leaf')).toBe(leaf); // sibling undisturbed
+
+		flushSync(() => root.render(WideTrio, { bBig: false }));
+		expect(order()).toEqual(['leaf:C']);
+		flushSync(() => root.render(WideTrio, { bBig: true }));
+		expect(order()).toEqual(['big:B', 'leaf:C']);
+		root.unmount();
+	});
+
+	it('a server-EMPTY trailing panel appears after its earlier sibling on update', () => {
+		const { html } = ServerRT.renderToString(server.TrailingPanel, { zBig: false });
+		container.innerHTML = html;
+
+		const root = hydrateRoot(container, TrailingPanel, { zBig: false });
+		flushSync(() => {});
+		expect(order()).toEqual(['leaf:A']);
+
+		flushSync(() => root.render(TrailingPanel, { zBig: true }));
+		expect(order()).toEqual(['leaf:A', 'big:Z']);
+		root.unmount();
+	});
+});


### PR DESCRIPTION
## Summary
- Fixes a dev-visible sibling-ordering bug: in a host whose children are all components, a hookless child that rendered nothing at mount (e.g. a sole `@if` with no `@else`) inserted content produced by a later render **after** its later siblings instead of at its own source position.

## Why
- The all-component-children emission appends child slots with no `<!>` anchors (part of the marker-elision work). A `componentSlotLite` child there gets `LiteBlockImpl.endMarker = null`; when its body root takes a null-body branch arm on first render, the if-slot records `state.anchor = null` and mints no boundary — the only runtime state that loses a position entirely. The next toggle inserts before `null`, i.e. appends at the host end. Prod escapes in practice because autoMemo routes those sites to `componentSlot`, which mints its `comp` marker pair — hence the dev/prod divergence.

## Changes
- `compile.js`: the all-component-children emission is now two-phase — build every child's record, then keep the anchorless form only when each **non-last** child's actual lowering can hold its position (`cc.anchorlessAppendSafe`); otherwise every child gets its pre-elision `<!>` anchor. The decision is all-or-nothing per host because mixing anchored and unanchored children would desync hydration's adopt walk. The last child is exempt: append-at-end is its source position.
- `anchorlessRootShape` + an `anchorlessRootSafe` fixpoint (beside the autoMemo fixpoints) prove the safe lite shapes: a plain host root, or a full `@if/@else` chain whose arms are one host, one component tag (a transitive edge — an arm-mounted unsafe lite captures the arm block's null endMarker before the arm pair is minted), or a nested chain. Missing `@else`, `@switch`/`@for`/hole/fragment roots, and multi-node arms are declined conservatively.
- Regression tests: `component-children-host.test.ts` (client mount: empty-mount repro, toggle-order interleaving, content-at-mount, trailing panel, safe chain, transitive hazard) and `hydration/component-children-order-hydrate.test.ts` (SSR + adopt + post-hydration toggles). Oracles are marker-insensitive (element order + text), valid in both dev and prod projects.
- Changeset: `octane` patch.

## Reviewer notes
- Server emission and the runtime are untouched; only the client anchor decision changes, and both regimes hydrate against the same server HTML.
- Output cost was measured with a 470-file corpus probe (website + benchmarks + test fixtures): **prod output is byte-identical everywhere**; in dev the only changed file is the new regression fixture. An earlier draft keyed on a single-root-only proof and taxed `benchmarks/recursive-context` (+2 comment nodes per tree node in prod); its `Node` is a safe full-`@else` chain, which is why the transitive fixpoint exists.
- Both new suites were verified protective by deliberate breaks: skewed anchor indices turned the hydration suite red; disabling the fixpoint's edge propagation turned the transitive-hazard test red.

## Validation
- [x] `pnpm format:check` (scoped `pnpm format:files:check` on changed files — clean; formatter reported all unchanged)
- [x] `pnpm typecheck`
- [x] `pnpm test` (full run: 1616 files, 17,356 tests passed)
- [x] targeted tests: `packages/octane/tests/component-children-host.test.ts`, `packages/octane/tests/hydration/component-children-order-hydrate.test.ts` (both green in the `octane` and `octane-prod` projects; the empty-mount cases failed pre-fix in `octane` with `['leaf:C','big:B']`)

## Risk / follow-ups
- Shapes the proof declines keep one `<!>` comment per child in dev; the corpus probe shows no real-world hits beyond the new fixture.
- The proof intentionally stays conservative for `@switch`/`@for`/hole/fragment roots — widening it later must show the admitted shape can never record a positionless empty state.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core compiler DOM emission and hydration alignment for all-component hosts; behavior is conservative (extra anchors when proof fails) with broad test coverage but subtle ordering edge cases remain possible for shapes the proof declines.
> 
> **Overview**
> Fixes **sibling ordering** in hosts whose children are all components: a child that renders nothing on first mount (e.g. `@if` without `@else`) could later insert its content **after** later siblings when the compiler omitted per-child `<!>` anchors for anchorless `componentSlotLite` appends.
> 
> The **all-component-children** path in `emitElementHtml` is now **two-phase**—build every child’s `makeCompCall` record, then keep anchorless emission only if each **non-last** child is `anchorlessAppendSafe`; otherwise **every** child gets a `<!>` anchor (all-or-nothing so hydration’s adopt walk stays aligned). The last child stays exempt because append-at-end matches source order.
> 
> New compile-time analysis adds **`anchorlessRootShape`** and an **`anchorlessRootSafe`** fixpoint (alongside autoMemo) to decide when a lite callee’s body root always leaves a durable boundary (plain host root, or full `@if`/`@else` chains with safe arms, including transitive unsafe nested components). **`makeCompCall`** exposes `anchorlessAppendSafe` from that proof.
> 
> Regression coverage: client mount and SSR/hydration tests for empty-mount panels, toggles, chains, and transitive hazards; **octane** patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2166aa055d85c5dc5a3f92005d043df021fbddfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->