### PR TITLE
fix: avoid false async warm plans for synchronous prop reads

### DIFF
--- a/.changeset/synchronous-prop-warm-plans.md
+++ b/.changeset/synchronous-prop-warm-plans.md
@@ -1,0 +1,6 @@
+---
+'octane': patch
+---
+
+Avoid unnecessary asynchronous warming for synchronous components that read plain
+props, preventing speculative getter evaluation and reducing generated render work.

--- a/benchmarks/signal-favoring/gen.mjs
+++ b/benchmarks/signal-favoring/gen.mjs
@@ -42,7 +42,9 @@ function genRippleNew() {
 	// (TSRX hoists function declarations, but ordering keeps the file readable).
 	for (let i = N; i >= 1; i--) {
 		if (i === N) {
-			out += `function C${i}(props) @{ <span class='leaf'>${i}</span> }\n`;
+			out += `function C${i}(props) @{ <span class={props.kind}>${i}</span> }\n`;
+		} else if (i === N - 1) {
+			out += `function C${i}({ kind }) @{ <div class={kind}>${i} <C${i + 1} kind="leaf" /></div> }\n`;
 		} else if (isStateful(i)) {
 			out += `function C${i}(props) @{\n`;
 			out += `  const [v, set] = useState(0);\n`;
@@ -50,7 +52,8 @@ function genRippleNew() {
 			out += `  <div class='c'>${i}:{v as number} <C${i + 1} /></div>\n`;
 			out += `}\n`;
 		} else {
-			out += `function C${i}(props) @{ <div class='c'>${i} <C${i + 1} /></div> }\n`;
+			const childProps = i === N - 2 ? ' kind="c"' : '';
+			out += `function C${i}(props) @{ <div class='c'>${i} <C${i + 1}${childProps} /></div> }\n`;
 		}
 	}
 	out += '\nexport default function App(props) @{ <C1 /> }\n';

--- a/benchmarks/signal-favoring/octane-tsrx/src/App.tsrx
+++ b/benchmarks/signal-favoring/octane-tsrx/src/App.tsrx
@@ -46,18 +46,18 @@ export function bumpAt91() {
 }
 
 function C100(props) @{
-	<span class="leaf">100</span>
+	<span class={props.kind}>100</span>
 }
-function C99(props) @{
-	<div class="c">
+function C99({ kind }) @{
+	<div class={kind}>
 		99
-		<C100 />
+		<C100 kind="leaf" />
 	</div>
 }
 function C98(props) @{
 	<div class="c">
 		98
-		<C99 />
+		<C99 kind="c" />
 	</div>
 }
 function C97(props) @{

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -3927,12 +3927,55 @@ function collectImmutableModuleFunctions(body) {
 	return declared;
 }
 
+// A component whose synchronous proof reads its props is safe only at JSX
+// edges that construct every read property as an own data field. Missing keys
+// can reach an inherited getter, and `__proto__` changes an object literal's
+// prototype. Warm records carry plain `{ key, value }` entries; graph edges
+// retain their original immutable JSX attributes.
+function warmCallsiteOwnsRequiredProps(info, props) {
+	const required = info.warmRequiredProps;
+	if (required === null || required === undefined || required.size === 0) return true;
+	if (!Array.isArray(props)) return false;
+
+	for (let index = 0; index < props.length; index++) {
+		const prop = props[index];
+		let name;
+		if (prop?.type === 'JSXAttribute' || prop?.type === 'Attribute') {
+			const key = prop.name;
+			if (typeof key === 'string') name = key;
+			else if (key?.type === 'JSXIdentifier' || key?.type === 'Identifier') name = key.name;
+			else return false;
+		} else if (prop?.type === undefined && typeof prop?.key === 'string') {
+			name = prop.key;
+		} else {
+			return false;
+		}
+		if (name === '__proto__' || name === 'key' || name === 'ref') return false;
+	}
+
+	for (const name of required) {
+		let found = false;
+		for (let index = 0; index < props.length; index++) {
+			const prop = props[index];
+			const own = prop.key ?? (typeof prop.name === 'string' ? prop.name : prop.name.name);
+			if (own === name) {
+				found = true;
+				break;
+			}
+		}
+		if (!found) return false;
+	}
+	return true;
+}
+
 // A child warm plan is useful only if that child can reach an async creation.
 // Same-module declarations are the only closed call graph we can prove: an
 // imported/dynamic component, custom hook, helper call, or lazy state initializer
 // may suspend behind an opaque boundary, so each keeps its existing warm edge.
 // A useState call with a primitive literal initializer and publishing its stable
 // setter are synchronous, so neither turns a synchronous tree into a warm plan.
+// Flat props destructuring and direct props reads are also synchronous when
+// every traversed call site proves those keys are compiler-owned data fields.
 function classifySameModuleWarmPotential(ctx) {
 	for (const [, info] of ctx.componentInfo) {
 		const component = info.node;
@@ -3941,12 +3984,45 @@ function classifySameModuleWarmPotential(ctx) {
 		const invariant = computeInvariantLocals(statements, locals, false);
 		const dependencies = new Set();
 		const seen = new WeakSet();
+		const parameters = component.params || [];
+		let propsName = null;
+		let requiredProps = null;
 		// A reassigned function binding can point at an async component by the
-		// time its warm edge runs. Destructuring/default/rest parameters can also
-		// invoke user code before the authored component body is reached.
-		let opaque =
-			!ctx.moduleFunctionDeclarations.has(component.id?.name) ||
-			(component.params || []).some((parameter) => parameter.type !== 'Identifier');
+		// time its warm edge runs. Defaults, computed/rest/nested patterns, and
+		// unknown parameters may invoke user code before its body is reached.
+		let opaque = !ctx.moduleFunctionDeclarations.has(component.id?.name);
+		for (let index = 0; !opaque && index < parameters.length; index++) {
+			const parameter = parameters[index];
+			if (parameter.type === 'Identifier') {
+				if (index === 0) propsName = parameter.name;
+				continue;
+			}
+			if (index !== 0 || parameters.length !== 1 || parameter.type !== 'ObjectPattern') {
+				opaque = true;
+				break;
+			}
+			for (const property of parameter.properties || []) {
+				if (
+					property.type !== 'Property' ||
+					property.computed ||
+					property.value?.type !== 'Identifier'
+				) {
+					opaque = true;
+					break;
+				}
+				const key =
+					property.key?.type === 'Identifier'
+						? property.key.name
+						: property.key?.type === 'Literal' && typeof property.key.value === 'string'
+							? property.key.value
+							: null;
+				if (key === null || key === '__proto__' || key === 'current') {
+					opaque = true;
+					break;
+				}
+				(requiredProps ??= new Set()).add(key);
+			}
+		}
 
 		function walk(node) {
 			if (opaque || node === null || typeof node !== 'object') return;
@@ -3959,7 +4035,10 @@ function classifySameModuleWarmPotential(ctx) {
 
 			// Deferred handlers do not execute during this component's render. State
 			// initializers are admitted only when proven primitive and non-callable.
-			if (FN_TYPES.has(node.type)) return;
+			if (FN_TYPES.has(node.type)) {
+				if (node.type === 'FunctionDeclaration' && node.id?.name === propsName) opaque = true;
+				return;
+			}
 
 			if ((node.type === 'Element' || node.type === 'JSXElement') && isComponentTag(node)) {
 				const name = tagBindingName(node);
@@ -3972,7 +4051,9 @@ function classifySameModuleWarmPotential(ctx) {
 					opaque = true;
 					return;
 				}
-				dependencies.add(name);
+				// Keep the immutable JSX node so the fixed point can prove the
+				// descendant's required own props separately for each call site.
+				dependencies.add(node);
 			} else if (node.type === 'CallExpression' || node.type === 'NewExpression') {
 				const hook = stableHookCallName(node);
 				if (
@@ -3988,15 +4069,39 @@ function classifySameModuleWarmPotential(ctx) {
 				// other destructuring can execute a custom iterator or rest/default.
 				if (
 					stableHookCallName(unwrapTsExpr(node.init)) !== 'useState' ||
-					node.id.elements.some((element) => element !== null && element.type !== 'Identifier')
+					node.id.elements.some(
+						(element) =>
+							element !== null && (element.type !== 'Identifier' || element.name === propsName),
+					)
 				) {
 					opaque = true;
 					return;
 				}
+			} else if (node.type === 'VariableDeclarator' && node.id?.name === propsName) {
+				// A nested lexical binding with the same name is not the props object.
+				opaque = true;
+				return;
+			} else if (node.type === 'MemberExpression') {
+				const owner = unwrapTsExpr(node.object);
+				const key = node.property;
+				if (
+					node.computed ||
+					node.optional ||
+					owner?.type !== 'Identifier' ||
+					owner.name !== propsName ||
+					key?.type !== 'Identifier' ||
+					key.name === '__proto__' ||
+					key.name === 'current'
+				) {
+					opaque = true;
+					return;
+				}
+				(requiredProps ??= new Set()).add(key.name);
 			} else if (node.type === 'AssignmentExpression') {
 				if (
 					node.operator !== '=' ||
 					node.left?.type !== 'Identifier' ||
+					node.left.name === propsName ||
 					node.right?.type !== 'Identifier' ||
 					!invariant.has(node.right.name)
 				) {
@@ -4006,7 +4111,6 @@ function classifySameModuleWarmPotential(ctx) {
 			} else if (
 				node.type === 'AwaitExpression' ||
 				node.type === 'YieldExpression' ||
-				node.type === 'MemberExpression' ||
 				node.type === 'JSXMemberExpression' ||
 				node.type === 'OptionalMemberExpression' ||
 				node.type === 'OptionalCallExpression' ||
@@ -4027,7 +4131,9 @@ function classifySameModuleWarmPotential(ctx) {
 				node.type === 'JSXTryExpression' ||
 				node.type === 'ImportExpression' ||
 				node.type === 'TaggedTemplateExpression' ||
-				node.type === 'UpdateExpression'
+				node.type === 'UpdateExpression' ||
+				(node.type === 'UnaryExpression' && node.operator === 'delete') ||
+				(node.type === 'ClassDeclaration' && node.id?.name === propsName)
 			) {
 				opaque = true;
 				return;
@@ -4042,6 +4148,7 @@ function classifySameModuleWarmPotential(ctx) {
 		walk(statements);
 		walk(component.body.render);
 		info.warmPotential = opaque;
+		info.warmRequiredProps = requiredProps;
 		info.warmDependencies = dependencies;
 	}
 
@@ -4053,8 +4160,15 @@ function classifySameModuleWarmPotential(ctx) {
 		changed = false;
 		for (const [, info] of ctx.componentInfo) {
 			if (info.warmPotential) continue;
-			for (const name of info.warmDependencies) {
-				if (ctx.componentInfo.get(name)?.warmPotential !== false) {
+			for (const dependency of info.warmDependencies) {
+				const target = ctx.componentInfo.get(tagBindingName(dependency));
+				if (
+					target?.warmPotential !== false ||
+					!warmCallsiteOwnsRequiredProps(
+						target,
+						dependency.openingElement?.attributes ?? dependency.attributes,
+					)
+				) {
 					info.warmPotential = true;
 					changed = true;
 					break;
@@ -13376,7 +13490,8 @@ function buildWarmArtifacts(node, ctx, componentName, creations, warmChildren) {
 			// that this edge and every descendant are synchronously render-only.
 			(ctx.mode === 'server' ||
 				ctx._universalRuntimeUnit != null ||
-				ctx.componentInfo.get(w.compName)?.warmPotential !== false) &&
+				ctx.componentInfo.get(w.compName)?.warmPotential !== false ||
+				!warmCallsiteOwnsRequiredProps(ctx.componentInfo.get(w.compName), w.props)) &&
 			!paramNames.has(w.compName) &&
 			!(locals && locals.has(w.compName)) &&
 			!(w.locals && w.locals.has(w.compName)) &&

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -3950,7 +3950,7 @@ function warmCallsiteOwnsRequiredProps(info, props) {
 		} else {
 			return false;
 		}
-		if (name === '__proto__' || name === 'key' || name === 'ref') return false;
+		if (name === '__proto__') return false;
 	}
 
 	for (const name of required) {
@@ -3958,6 +3958,8 @@ function warmCallsiteOwnsRequiredProps(info, props) {
 		for (let index = 0; index < props.length; index++) {
 			const prop = props[index];
 			const own = prop.key ?? (typeof prop.name === 'string' ? prop.name : prop.name.name);
+			// Reconciliation consumes `key`; `ref` remains an ordinary own prop.
+			if (own === 'key') continue;
 			if (own === name) {
 				found = true;
 				break;

--- a/packages/octane/tests/parallel-use.test.ts
+++ b/packages/octane/tests/parallel-use.test.ts
@@ -526,6 +526,142 @@ describe('parallel use() — adjacent async component trees', () => {
 		root.unmount();
 	});
 
+	it.each([
+		['destructured props', '{ label }', 'label'],
+		['aliased destructured props', '{ label: name }', 'name'],
+		['direct prop access', 'props', 'props.label'],
+	])(
+		'does not read a synchronous child with %s before an earlier sibling resolves',
+		async (description, parameter, label) => {
+			const source = `
+				import { use, useState } from 'octane';
+
+				function SynchronousChild(${parameter}) @{
+					const [revision] = useState(0);
+					<span class="synchronous-profile">{${label} + revision as string}</span>
+				}
+
+				function AsyncSibling(props) @{
+					const value = use(props.load('profile-sibling', props.version));
+					<span class="profile-sibling">{value as string}</span>
+				}
+
+				function Branches(props) @{
+					<main>
+						<AsyncSibling load={props.load} version={props.version} />
+						<SynchronousChild label={props.profile.label} />
+					</main>
+				}
+
+				export function App(props) @{
+					<>
+						@try {
+							<Branches load={props.load} version={props.version} profile={props.profile} />
+						} @pending {
+							<span class="profile-pending">loading</span>
+						}
+					</>
+				}
+			`;
+			const client = loadCompiledFixtureSource(source, {
+				id: `${description.replace(/\W+/g, '-')}-synchronous-child.tsrx`,
+				mode: 'client',
+				compileOptions: { hmr: false, dev: false },
+			});
+			const resources = resourceFetcher();
+			const reads: string[] = [];
+			const profile = new Proxy(
+				{ label: 'Ada' },
+				{
+					get(target, property, receiver) {
+						if (property === 'label') reads.push(property);
+						return Reflect.get(target, property, receiver);
+					},
+				},
+			);
+			const root = mount(client.App, { load: resources.load, version: 0, profile });
+
+			expect(resources.calls).toEqual(['profile-sibling:0']);
+			expect(root.find('.profile-pending').textContent).toBe('loading');
+			expect(reads).toEqual([]);
+
+			await act(() => resources.settle('profile-sibling', 0));
+
+			expect(root.find('.profile-sibling').textContent).toBe('profile-sibling-v0');
+			expect(root.find('.synchronous-profile').textContent).toBe('Ada0');
+			expect(reads).toEqual(['label']);
+			root.unmount();
+		},
+	);
+
+	it.each([
+		['destructured props', '{ load, version }', 'load', 'version'],
+		['aliased destructured props', '{ load: fetch, version: revision }', 'fetch', 'revision'],
+		['direct prop access', 'props', 'props.load', 'props.version'],
+	])(
+		'starts an async descendant through a stateful wrapper with %s',
+		async (description, parameter, load, version) => {
+			const source = `
+				import { use, useState } from 'octane';
+
+				function Wrapper(${parameter}) @{
+					const [count] = useState(0);
+					<section data-count={count}>
+						<AsyncLeaf load={${load}} version={${version}} />
+					</section>
+				}
+
+				function AsyncLeaf(props) @{
+					const value = use(props.load('prop-wrapper-leaf', props.version));
+					<span class="prop-wrapper-leaf">{value as string}</span>
+				}
+
+				function AsyncSibling(props) @{
+					const value = use(props.load('prop-wrapper-sibling', props.version));
+					<span class="prop-wrapper-sibling">{value as string}</span>
+				}
+
+				function Branches(props) @{
+					<main>
+						<AsyncSibling load={props.load} version={props.version} />
+						<Wrapper load={props.load} version={props.version} />
+					</main>
+				}
+
+				export function App(props) @{
+					<>
+						@try {
+							<Branches load={props.load} version={props.version} />
+						} @pending {
+							<span class="prop-wrapper-pending">loading</span>
+						}
+					</>
+				}
+			`;
+			const client = loadCompiledFixtureSource(source, {
+				id: `${description.replace(/\W+/g, '-')}-async-wrapper.tsrx`,
+				mode: 'client',
+				compileOptions: { hmr: false, dev: false },
+			});
+			const resources = resourceFetcher();
+			const root = mount(client.App, { load: resources.load, version: 0 });
+			const expected = ['prop-wrapper-leaf:0', 'prop-wrapper-sibling:0'];
+
+			expect([...resources.calls].sort()).toEqual(expected);
+			expect(root.find('.prop-wrapper-pending').textContent).toBe('loading');
+
+			await act(() => {
+				resources.settle('prop-wrapper-leaf', 0);
+				resources.settle('prop-wrapper-sibling', 0);
+			});
+
+			expect(root.find('.prop-wrapper-leaf').textContent).toBe('prop-wrapper-leaf-v0');
+			expect(root.find('.prop-wrapper-sibling').textContent).toBe('prop-wrapper-sibling-v0');
+			expect([...resources.calls].sort()).toEqual(expected);
+			root.unmount();
+		},
+	);
+
 	it('starts async work hidden behind a reassigned same-module component before its sibling resolves', async () => {
 		const source = `
 			import { use } from 'octane';

--- a/packages/octane/tests/parallel-use.test.ts
+++ b/packages/octane/tests/parallel-use.test.ts
@@ -595,6 +595,88 @@ describe('parallel use() — adjacent async component trees', () => {
 	);
 
 	it.each([
+		['key', 'key="stable"', ''],
+		['ref', 'ref={props.capture}', ' ref={props.ref}'],
+	])(
+		'does not read a synchronous child with a %s before an earlier sibling resolves',
+		async (kind, componentAttribute, hostAttribute) => {
+			const source = `
+				import { use } from 'octane';
+
+				function SynchronousChild(props) @{
+					<span class="decorated-profile"${hostAttribute}>{props.label as string}</span>
+				}
+
+				function Wrapper(props) @{
+					<SynchronousChild ${componentAttribute} label={props.label} />
+				}
+
+				function AsyncSibling(props) @{
+					const value = use(props.load('decorated-sibling', props.version));
+					<span class="decorated-sibling">{value as string}</span>
+				}
+
+				function Branches(props) @{
+					<main>
+						<AsyncSibling load={props.load} version={props.version} />
+						<Wrapper label={props.profile.label} capture={props.capture} />
+					</main>
+				}
+
+				export function App(props) @{
+					<>
+						@try {
+							<Branches
+								load={props.load}
+								version={props.version}
+								profile={props.profile}
+								capture={props.capture}
+							/>
+						} @pending {
+							<span class="decorated-pending">loading</span>
+						}
+					</>
+				}
+			`;
+			const client = loadCompiledFixtureSource(source, {
+				id: `${kind}-synchronous-child.tsrx`,
+				mode: 'client',
+				compileOptions: { hmr: false, dev: false },
+			});
+			const resources = resourceFetcher();
+			const reads: string[] = [];
+			const attachments: (Element | null)[] = [];
+			const capture = (node: Element | null) => {
+				attachments.push(node);
+			};
+			const profile = new Proxy(
+				{ label: 'Ada' },
+				{
+					get(target, property, receiver) {
+						if (property === 'label') reads.push(property);
+						return Reflect.get(target, property, receiver);
+					},
+				},
+			);
+			const root = mount(client.App, { load: resources.load, version: 0, profile, capture });
+
+			expect(resources.calls).toEqual(['decorated-sibling:0']);
+			expect(root.find('.decorated-pending').textContent).toBe('loading');
+			expect(reads).toEqual([]);
+			expect(attachments).toEqual([]);
+
+			await act(() => resources.settle('decorated-sibling', 0));
+
+			const child = root.find('.decorated-profile');
+			expect(child.textContent).toBe('Ada');
+			expect(root.find('.decorated-sibling').textContent).toBe('decorated-sibling-v0');
+			expect(attachments).toEqual(kind === 'ref' ? [child] : []);
+			root.unmount();
+			expect(attachments).toEqual(kind === 'ref' ? [child, null] : []);
+		},
+	);
+
+	it.each([
 		['destructured props', '{ load, version }', 'load', 'version'],
 		['aliased destructured props', '{ load: fetch, version: revision }', 'fetch', 'revision'],
 		['direct prop access', 'props', 'props.load', 'props.version'],


### PR DESCRIPTION
## Summary

- Teach same-module async reachability to recognize flat props destructuring, aliased destructuring, and direct prop reads when each JSX edge supplies the required keys as compiler-owned own-data properties.
- Keep genuine async descendants, imported/opaque components, missing or inherited keys, getters, spreads, defaults/rest patterns, prototype-sensitive keys, reassigned props, and shadowed bindings on their existing conservative paths.
- Add consumer-visible Suspense regressions and strengthen the existing production component-chain benchmark without changing its output or weakening any work ceilings.

Part of #673: **P0 — Avoid false asynchronous warm plans**. This PR does not close the broader tracking issue.

## Why

Previously, a synchronous prop-reading child was conservatively treated as potentially asynchronous. Its parent emitted an empty warm batch and eagerly evaluated child props even when the child had no async plan. With an earlier suspended sibling, a Proxy-backed prop getter ran twice before the child was actually reached.

The new proof is attached to each JSX call site rather than assuming a component's props are globally safe. Async reachability still propagates transitively, and server/universal warming behavior is unchanged.

## Performance

Existing production-browser work gate, with equivalent rendered output:

| Scenario | Warm registrations before | Warm registrations after |
| --- | ---: | ---: |
| Mount | 100 | 0 |
| Shallow update | 92 | 0 |
| Middle update | 42 | 0 |
| Deep update | 2 | 0 |
| Batched update | 92 | 0 |

The realistic 100-component fixture shrank from **70,799** to **52,101** generated bytes. The independent 16-file fixed corpus improved by **808 raw bytes**, **363 minified bytes**, and **44 gzip bytes**.

## Validation

- [x] `pnpm sync`
- [x] `pnpm format:check`
- [ ] `pnpm typecheck` — its unrelated Solana `pretypecheck` cannot run in this worktree because a required uncached registry package returns HTTP 403.
- [x] `pnpm --config.enable-pre-post-scripts=false run typecheck` — the complete root typecheck body passed; only that unrelated prehook was skipped.
- [ ] `pnpm test` — the entire monorepo suite was not run.
- [x] `pnpm exec vitest run --project octane --project octane-prod --silent=passed-only` — **788 files / 11,283 tests passed**.
- [x] `pnpm exec vitest run packages/octane/tests/parallel-use.test.ts packages/octane/tests/ssr-parallel-use.test.ts --project octane --project octane-prod --silent=passed-only` — **90 tests passed after the final sync**.
- [x] `pnpm --dir benchmarks/signal-favoring bench:work` — all **12 existing production operation gates** pass without changed ceilings.
- [x] `node benchmarks/bench.mjs --quick compiler-throughput codegen-size`
- [x] `pnpm changeset:check`
- [x] Adversarial frozen-AST/source-location probes for missing own keys, inherited keys, defaults, rest, computed/nested access, prototype keys, reassignment, lexical shadowing, async descendants, server output, and universal output.

## Risk / follow-ups

The optimization is limited to the DOM client's existing same-module warm graph. Unsafe or unproven call sites continue to retain their previous warming behavior; no public API, authoring contract, runtime representation, or server plan changes.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compiler warm-graph logic on the client Suspense/parallel-use path; unproven call sites keep conservative behavior, but incorrect proofs could skip needed warming or change render timing.
> 
> **Overview**
> The DOM client compiler no longer treats **synchronous** same-module children that only read plain props as async warm targets when each JSX call site passes those keys as **own** attributes—so parents stop emitting empty warm batches that **eagerly evaluate child props** while an earlier sibling is still suspended.
> 
> **`classifySameModuleWarmPotential`** now records which prop keys a component reads (flat destructuring, aliases, `props.foo`) and tracks **per–call-site** JSX edges instead of component names only. A fixed-point pass and **`warmCallsiteOwnsRequiredProps`** require every required key at that edge (rejecting spreads, `__proto__`, missing keys, etc.); unsafe patterns still force the old conservative warming. **`warmKids`** filtering uses the same proof so prop reads are not warmed speculatively.
> 
> Adds Suspense regressions (Proxy-backed props, `key`/`ref`) and extends the signal-favoring benchmark chain with passed-through `kind` props to stress this path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca9dcb7fb3335024df0d903897f2b5ffb933decb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->