### PR TITLE
feat(octane): complete React Fragment ref parity

### DIFF
--- a/.changeset/fragment-ref-react-parity.md
+++ b/.changeset/fragment-ref-react-parity.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Complete React Fragment ref parity across JSX aliases and spreads, direct element descriptors, server rendering and hydration, strongly typed refs, text and portal ownership, events, observers, focus, geometry, document positioning, and scrolling.

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -738,6 +738,44 @@ function Search({ ref }) @{
 A ref may be a callback, a `{ current }` object, or an array of refs as shown
 above.
 
+### Fragment refs
+
+An explicit `<Fragment ref={ref}>` provides a typed `FragmentInstance` without
+adding a wrapper element. This matches React's Canary Fragment-ref API; the
+`<>...</>` shorthand cannot accept a ref.
+
+Refs also work through imported aliases, namespace members, JSX spreads, and
+`createElement(Fragment, { ref }, ...)` descriptors.
+
+```tsx
+import { Fragment, type FragmentInstance, useRef } from 'octane';
+
+function SearchFields() {
+  const fields = useRef<FragmentInstance | null>(null);
+
+  return (
+    <Fragment ref={fields}>
+      <input />
+      <button onClick={() => fields.current?.focus()}>Focus first field</button>
+    </Fragment>
+  );
+}
+```
+
+`FragmentInstance` exposes `addEventListener`, `removeEventListener`,
+`dispatchEvent`, `focus`, `focusLast`, `blur`, `observeUsing`, `unobserveUsing`,
+`getClientRects`, `getRootNode`, `compareDocumentPosition`, and
+`scrollIntoView`. Event listeners, observers, geometry, and scrolling target the
+Fragment's first-level DOM children; focus searches descendants depth-first.
+`scrollIntoView` accepts only an optional alignment boolean, not an options
+object. First-level children expose their owning instances through
+`reactFragments: Set<FragmentInstance>`.
+
+Fragment refs are inactive during server rendering and attach during client
+hydration. Octane roots require an `Element`, so React's empty-fragment scrolling
+fallbacks for roots mounted directly into a `ShadowRoot` or `DocumentFragment`
+are outside the supported root-container surface.
+
 ## SSR and streaming
 
 ### Rendering surface

--- a/docs/react-parity-coverage.md
+++ b/docs/react-parity-coverage.md
@@ -85,8 +85,8 @@ Every concrete case in either pinned inventory has exactly one ledger dispositio
 
 | Baseline | Cases | Untriaged | Planned | In progress | Covered | Documented | Blocked |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| stable | 5,345 | 0 | 2,071 | 0 | 849 | 2,425 | 0 |
-| canary | 5,413 | 0 | 2,124 | 0 | 890 | 2,399 | 0 |
+| stable | 5,345 | 0 | 2,026 | 0 | 894 | 2,425 | 0 |
+| canary | 5,413 | 0 | 2,063 | 0 | 951 | 2,399 | 0 |
 
 Classifications are `portable`, `adaptable`, `divergence`, and `non_goal`. A covered case requires live local test evidence; divergence and non-goal dispositions require a rationale.
 
@@ -123,7 +123,8 @@ Suite policies are machine-readable in `react-upstreams.json`; the first matchin
 | Legacy and class case-level surfaces | 77 / 79 | 79 / 81 | low | documented | out of scope | Cases whose individual outcome requires class components, legacy roots/context, StrictMode double invocation, forwardRef/createRef/findDOMNode, or string refs are explicit non-goals even when they live in an otherwise modern React suite; supported function-component outcomes in the same files remain planned or covered independently. |
 | External-store compatibility packages | 12 / 12 | 12 / 12 | medium | planned | runtime | The standalone compatibility packages are not shipped by Octane, but their observable subscription, snapshot, and notification semantics are actionable through Octane's useSyncExternalStore API. |
 | React core residual audit | 79 / 79 | 78 / 78 | medium | planned | public API + runtime | Remaining function-component, element, JSX-runtime, context, transition, and diagnostic outcomes require exact Octane public-API evidence or a narrower case-level divergence disposition. |
-| React DOM residual audit | 1,417 / 1,431 | 1,470 / 1,484 | high | planned | runtime + SSR + hydration | Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition. |
+| Fragment refs | 45 / 45 | 61 / 61 | high | covered | runtime + compiler + SSR + hydration | All 61 stable/canary FragmentInstance scenarios have exact executable public evidence for typed refs, lifecycle, native listeners, observers, focus, geometry, document position, scrolling, portals, Activity visibility, and text nodes; buffered/streaming SSR and matching hydration additionally prove server refs stay inactive until client attachment. |
+| React DOM residual audit | 1,372 / 1,386 | 1,409 / 1,423 | high | planned | runtime + SSR + hydration | Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition. |
 | React reconciler residual audit | 755 / 755 | 781 / 781 | high | planned | runtime | Remaining function-component hooks, effects, context, Suspense, transitions, Activity, batching, error recovery, and reconciliation outcomes require exact observable Octane evidence; Fiber-only mechanics will receive case-level non-goal dispositions. |
 | Residual repository surface | 0 / 0 | 0 / 0 | low | planned | parity audit | This final audited catch-all keeps newly discovered or uncommon React suites visible and actionable until they receive executable public evidence or a narrower documented non-goal/divergence disposition. |
 

--- a/packages/cli/src/data/octane-data.json
+++ b/packages/cli/src/data/octane-data.json
@@ -1226,6 +1226,16 @@
       "message": "octane SSR: %s consecutive streaming passes completed no boundary — a use(thenable) never resolved. If promises are re-created on every render pass (e.g. created in an ancestor render and passed down through props), create them at their use() site or hoist them out of render.",
       "runtime": ["server"],
       "status": "active"
+    },
+    "49": {
+      "message": "FragmentInstance.scrollIntoView() does not support scrollIntoViewOptions. Use the alignToTop boolean instead.",
+      "runtime": ["client"],
+      "status": "active"
+    },
+    "50": {
+      "message": "Unclosed server-rendered Fragment descriptor.",
+      "runtime": ["client"],
+      "status": "active"
     }
   }
 }

--- a/packages/octane/audit/react-conformance-ledger.json
+++ b/packages/octane/audit/react-conformance-ledger.json
@@ -1450,15 +1450,27 @@
     },
     {
       "caseId": "react-case-v1:041fdaa40423fbb1ddfe",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "handles empty fragment instances",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “marks empty-fragment sibling positions as implementation-specific” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-position.test.ts",
+          "testName": "marks empty-fragment sibling positions as implementation-specific",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-position.test.ts",
+          "testName": "reports exact parent and ancestor flags for empty fragments",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:042e3e7c677ecb76023d",
@@ -2080,15 +2092,27 @@
     },
     {
       "caseId": "react-case-v1:0656d8c2f0ae875addf9",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "handles multiple portals to the same element",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “validates logical position when sibling portals share the same host” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-parity-ledger.test.ts",
+          "testName": "validates logical position when sibling portals share the same host",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-parity-ledger.test.ts",
+          "testName": "distinguishes multiple Fragment-owned portals sharing one foreign target",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:065bc978f82e495d9f45",
@@ -4879,15 +4903,22 @@
     },
     {
       "caseId": "react-case-v1:0ecd921450d3affe00a4",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "returns the topmost disconnected element if the fragment and parent are unmounted",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "The upstream title describes a future TODO, but its executable assertion returns the FragmentInstance itself; the local unmount oracle verifies that exact current React behavior.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
+          "testName": "returns the captured fragment instance after it has been unmounted",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:0ed024dc7b1f228424c1",
@@ -5467,15 +5498,22 @@
     },
     {
       "caseId": "react-case-v1:116d56e35cce2924f26c",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "focuses deeply nested focusable children, depth first",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “focuses deeply nested focusable children depth-first with focusLast()” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-parity-ledger.test.ts",
+          "testName": "focuses deeply nested focusable children depth-first with focusLast()",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:1175aa2e84e6427ca3a1",
@@ -9303,15 +9341,22 @@
     },
     {
       "caseId": "react-case-v1:1f0c66661b9c83c7719f",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "fires events on self, and only self if bubbles=false",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “delivers non-bubbling events only to listeners attached to the fragment” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-position.test.ts",
+          "testName": "delivers non-bubbling events only to listeners attached to the fragment",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:1f186bc09d19a3f73dc5",
@@ -10666,15 +10711,42 @@
     },
     {
       "caseId": "react-case-v1:23949c272332c1d6d6c1",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "returns the relationship between the fragment instance and a given node",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “returns PRECEDING for a sibling rendered BEFORE the fragment” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-position.test.ts",
+          "testName": "returns PRECEDING for a sibling rendered BEFORE the fragment",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-position.test.ts",
+          "testName": "returns FOLLOWING for a sibling rendered AFTER the fragment",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-position.test.ts",
+          "testName": "returns exactly CONTAINED_BY for a child inside the fragment",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-position.test.ts",
+          "testName": "reports that ancestors precede and contain a nonempty fragment",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-position.test.ts",
+          "testName": "returns DISCONNECTED for a node in a different tree",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:2398df958cd9d886f0aa",
@@ -13598,15 +13670,22 @@
     },
     {
       "caseId": "react-case-v1:2e0695c3fe0d8e2a4268",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "scrollIntoView works on text-only fragment using Range API",
       "baselines": ["canary"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “scrolls text nodes through their Range geometry” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
+          "testName": "scrolls text nodes through their Range geometry",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:2e1314e68cb6d9c5e788",
@@ -14507,15 +14586,22 @@
     },
     {
       "caseId": "react-case-v1:316b267707a069d15187",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "focuses the first focusable child in a fieldset",
       "baselines": ["canary"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “focuses the first focusable child in a fieldset” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-focus.test.ts",
+          "testName": "focuses the first focusable child in a fieldset",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:31742d208d6c771dabe9",
@@ -14925,15 +15011,27 @@
     },
     {
       "caseId": "react-case-v1:32c22401baf414f567f9",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "warns when unobserveUsing() is called with an observer that was not observed",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “warns without unobserving when the observer was never registered” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-observers.test.ts",
+          "testName": "warns without unobserving when the observer was never registered",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-observers.test.ts",
+          "testName": "warns without touching a different observer while keeping the registered one",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:32c71cf3d1f38a811314",
@@ -16085,15 +16183,32 @@
     },
     {
       "caseId": "react-case-v1:35d5bc87428c28449118",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "attaches a ref to Fragment",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence verifies FragmentInstance attachment; buffered/streaming SSR keeps refs inactive, and matching hydration attaches the same public ref without replacing server-rendered nodes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs.test.ts",
+          "testName": "attaches a FragmentInstance to an object ref",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/ssr.test.ts",
+          "testName": "renders Fragment refs without attaching them and keeps static markup markerless",
+          "modes": ["server-string", "server-stream", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/control-fold.test.ts",
+          "testName": "hydrates a returned Fragment ref without replacing existing stateful children",
+          "modes": ["server-string", "hydrate-match", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:35ec3918e5b346381639",
@@ -16217,15 +16332,22 @@
     },
     {
       "caseId": "react-case-v1:367bfb5780a4a79b2232",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "adds and removes event listeners from children with multiple fragments",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “adds and removes event listeners from children with multiple fragments” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-parity-ledger.test.ts",
+          "testName": "adds and removes event listeners from children with multiple fragments",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:36844f75cf34a2c591cb",
@@ -17833,15 +17955,22 @@
     },
     {
       "caseId": "react-case-v1:3b4b6e0069e08961dda5",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "allows adding and cleaning up listeners in effects",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “allows adding and cleaning up listeners in effects” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs.test.ts",
+          "testName": "allows adding and cleaning up listeners in effects",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:3b4cbca5c3ab6ffd9b99",
@@ -18399,15 +18528,22 @@
     },
     {
       "caseId": "react-case-v1:3d75738d4902fac81efd",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "focuses the first focusable child",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “focus() focuses the first focusable child in tree order” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-focus.test.ts",
+          "testName": "focus() focuses the first focusable child in tree order",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:3d9ef04bfe60138640f8",
@@ -19140,15 +19276,22 @@
     },
     {
       "caseId": "react-case-v1:3fb3431d530b43122080",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "returns the root node of the parent",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “returns the document when the fragment is rendered into the main tree” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-observers.test.ts",
+          "testName": "returns the document when the fragment is rendered into the main tree",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:3fc44375f0deeea2a3d2",
@@ -20388,15 +20531,22 @@
     },
     {
       "caseId": "react-case-v1:442d7e4d1437c778a697",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "accepts a ref callback",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “accepts a callback ref and fires it with the FragmentInstance” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs.test.ts",
+          "testName": "accepts a callback ref and fires it with the FragmentInstance",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:44333e4c44e15a2b07b6",
@@ -20770,15 +20920,22 @@
     },
     {
       "caseId": "react-case-v1:4527bf998e0cc7b3965e",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "does not remove focus from elements outside of the Fragment",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “blur() is a no-op when the focused element is OUTSIDE the fragment” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-focus.test.ts",
+          "testName": "blur() is a no-op when the focused element is OUTSIDE the fragment",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:4537db70213c37e28dc5",
@@ -21395,15 +21552,32 @@
     },
     {
       "caseId": "react-case-v1:4768a94d52bec599c860",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "attaches intersection observers to children",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “observeUsing forwards .observe to every direct fragment child” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-observers.test.ts",
+          "testName": "observeUsing forwards .observe to every direct fragment child",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-observers.test.ts",
+          "testName": "unobserveUsing forwards .unobserve to every direct fragment child",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/fragment-future-children.test.ts",
+          "testName": "observes each retained or added child only when it first joins the fragment",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:47899b37f97008d1d115",
@@ -22129,15 +22303,22 @@
     },
     {
       "caseId": "react-case-v1:4a0e893cdce7c0eabf84",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "getClientRects includes both text and element bounds",
       "baselines": ["canary"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “preserves document order across mixed text and element rectangles” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
+          "testName": "preserves document order across mixed text and element rectangles",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:4a2c179f7ef0613293e7",
@@ -24585,15 +24766,32 @@
     },
     {
       "caseId": "react-case-v1:5293aa4b0eb351fe1a8f",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "attaches fragment handles to nodes",
       "baselines": ["canary"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “publishes fragment handles for existing, added, and removed children” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-future-children.test.ts",
+          "testName": "publishes fragment handles for existing, added, and removed children",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/fragment-future-children.test.ts",
+          "testName": "records both fragment handles on children shared by nested fragments",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
+          "testName": "publishes fragment ownership on direct text nodes",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:529e0cc56dd6118e107e",
@@ -30605,15 +30803,22 @@
     },
     {
       "caseId": "react-case-v1:6690c335519aeef3aebd",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "is available in effects",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “is populated by the time useLayoutEffect AND useEffect run” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs.test.ts",
+          "testName": "is populated by the time useLayoutEffect AND useEffect run",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:66b790106a842abbdb9a",
@@ -31901,15 +32106,22 @@
     },
     {
       "caseId": "react-case-v1:6b29697621bf1110b570",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "compareDocumentPosition works with text children",
       "baselines": ["canary"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “reports exact containment for direct text children” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-position.test.ts",
+          "testName": "reports exact containment for direct text children",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:6b2a397f55d5cf7536b7",
@@ -33195,15 +33407,27 @@
     },
     {
       "caseId": "react-case-v1:700812d6940eac0f16de",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "handles Activity modes switching",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “disconnects preserved hidden children and reconnects them when Activity reveals” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-activity.test.ts",
+          "testName": "disconnects preserved hidden children and reconnects them when Activity reveals",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-activity.test.ts",
+          "testName": "excludes logically owned portal children while their Activity is hidden",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:700fe59b480918133db6",
@@ -34116,15 +34340,27 @@
     },
     {
       "caseId": "react-case-v1:731fb899f22fcdc6de5f",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "attaches handles to observed elements to allow caching of observers",
       "baselines": ["canary"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “records both fragment handles on children shared by nested fragments” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-future-children.test.ts",
+          "testName": "records both fragment handles on children shared by nested fragments",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/fragment-future-children.test.ts",
+          "testName": "includes only logically owned portal children in handles, listeners, and observers",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:732fa4aa635962e37d42",
@@ -36766,15 +37002,22 @@
     },
     {
       "caseId": "react-case-v1:7d03654b5ab64cf98a39",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "handles portaled elements",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “marks logically owned portaled children as implementation-specific” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-position.test.ts",
+          "testName": "marks logically owned portaled children as implementation-specific",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:7d1d2409a71d981cd068",
@@ -37252,15 +37495,22 @@
     },
     {
       "caseId": "react-case-v1:7e9f9e85bfc66ab23448",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "applies event listeners to host children nested within non-host children",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “applies event listeners to host children nested within non-host children” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs.test.ts",
+          "testName": "applies event listeners to host children nested within non-host children",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:7ebcb648e61c6352ad84",
@@ -39330,15 +39580,22 @@
     },
     {
       "caseId": "react-case-v1:85982959e1580268e736",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "handles empty fragments",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “compares an empty Fragment rendered into a portal” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-parity-ledger.test.ts",
+          "testName": "compares an empty Fragment rendered into a portal",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:85bd80af6389dcf9cb01",
@@ -41439,15 +41696,22 @@
     },
     {
       "caseId": "react-case-v1:8c27bddd50dc4df19ec2",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "calls scrollIntoView on the last child if alignToTop is false",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “scrolls children in tree order when aligning to the bottom” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
+          "testName": "scrolls children in tree order when aligning to the bottom",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:8c456100810f08f5b9d0",
@@ -41907,15 +42171,27 @@
     },
     {
       "caseId": "react-case-v1:8de6a39bb4dca5fbb3c7",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "applies event listeners to portaled children",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “includes only logically owned portal children in handles, listeners, and observers” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-future-children.test.ts",
+          "testName": "includes only logically owned portal children in handles, listeners, and observers",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/fragment-future-children.test.ts",
+          "testName": "inherits and removes Fragment bindings when a conditional portal mounts and unmounts",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:8de72e5781320b235ab0",
@@ -42450,15 +42726,22 @@
     },
     {
       "caseId": "react-case-v1:8fb520604b2e579a256a",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "handles portaled elements -- different scroll container",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “scrolls portaled children in order across different scroll containers” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-parity-ledger.test.ts",
+          "testName": "scrolls portaled children in order across different scroll containers",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:8fbc270ed918adee7950",
@@ -42954,15 +43237,22 @@
     },
     {
       "caseId": "react-case-v1:916f6cd728a763d665ff",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "calls scrollIntoView on the prev sibling if alignToTop is false",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “scrolls toward the previous sibling for bottom-aligned empty fragments” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
+          "testName": "scrolls toward the previous sibling for bottom-aligned empty fragments",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:9181b63208a7dc5530f8",
@@ -44874,15 +45164,22 @@
     },
     {
       "caseId": "react-case-v1:98e1614147450a8fb338",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "treats passive:true and passive:false as same listener per DOM spec",
       "baselines": ["canary"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “treats passive:true and passive:false as same listener per DOM spec” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-events.test.ts",
+          "testName": "treats passive:true and passive:false as same listener per DOM spec",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:991a7e659eb45955b2a1",
@@ -45379,15 +45676,22 @@
     },
     {
       "caseId": "react-case-v1:9b1847125334393a6990",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "calls scrollIntoView on the next sibling by default, or if alignToTop=true",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “scrolls toward the next sibling for empty fragments by default” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
+          "testName": "scrolls toward the next sibling for empty fragments by default",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:9b34f755256112b37e8d",
@@ -45704,15 +46008,22 @@
     },
     {
       "caseId": "react-case-v1:9c2870a5515f335fa072",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "focuses deeply nested focusable children, depth first",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “focuses deeply nested focusable children depth-first with focus()” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-parity-ledger.test.ts",
+          "testName": "focuses deeply nested focusable children depth-first with focus()",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:9c5785aad9ca755d61fe",
@@ -46838,15 +47149,22 @@
     },
     {
       "caseId": "react-case-v1:a05d84773b15410d1bbb",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "returns self when only the fragment was unmounted",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “returns the captured fragment instance after it has been unmounted” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
+          "testName": "returns the captured fragment instance after it has been unmounted",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:a078d1d8465ffbe11871",
@@ -47288,15 +47606,27 @@
     },
     {
       "caseId": "react-case-v1:a1a1e1b12b467ccbf3a5",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "adds and removes event listeners from children",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “addEventListener attaches the listener to ALL direct fragment children” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-events.test.ts",
+          "testName": "addEventListener attaches the listener to ALL direct fragment children",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-events.test.ts",
+          "testName": "removeEventListener detaches the listener from every direct child",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:a1b64012843fa133d868",
@@ -48161,15 +48491,22 @@
     },
     {
       "caseId": "react-case-v1:a498a77e4bdbad99defd",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "keeps focus on a nested child if already focused",
       "baselines": ["canary"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “keeps focus on a nested child if already focused” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-parity-ledger.test.ts",
+          "testName": "keeps focus on a nested child if already focused",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:a4a62a13b9ef428fd5b2",
@@ -48288,15 +48625,22 @@
     },
     {
       "caseId": "react-case-v1:a52c6c7e687bdf1b1def",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "preserves document order when adding and removing children",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “preserves document order when adding and removing focusable children” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-parity-ledger.test.ts",
+          "testName": "preserves document order when adding and removing focusable children",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:a534f872607cb6c98b99",
@@ -48761,15 +49105,22 @@
     },
     {
       "caseId": "react-case-v1:a6b52c753673261f070a",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "does not apply event listeners to hidden trees",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “excludes hidden Activity children from listeners and fragment ownership” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-activity.test.ts",
+          "testName": "excludes hidden Activity children from listeners and fragment ownership",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:a6b8e80ea67e620352d6",
@@ -50477,15 +50828,22 @@
     },
     {
       "caseId": "react-case-v1:ace6a30b720022c65b60",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "removes a capture listener registered with boolean when removed with options object",
       "baselines": ["canary"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “removes a capture listener registered with boolean when removed with options object” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-events.test.ts",
+          "testName": "removes a capture listener registered with boolean when removed with options object",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:acebc7fd28d462938df6",
@@ -51624,15 +51982,22 @@
     },
     {
       "caseId": "react-case-v1:b0e42d4b956975616588",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "calls scrollIntoView on the parent if there are no siblings",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “scrolls the parent when an empty fragment has no siblings” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
+          "testName": "scrolls the parent when an empty fragment has no siblings",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:b0eb83a6710b84594296",
@@ -54334,15 +54699,22 @@
     },
     {
       "caseId": "react-case-v1:b964f2da0ce9712cc2fa",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "removes a capture listener registered with options object when removed with boolean",
       "baselines": ["canary"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “removes a capture listener registered with options object when removed with boolean” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-events.test.ts",
+          "testName": "removes a capture listener registered with options object when removed with boolean",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:b9660a84f03656b1f3d9",
@@ -54495,15 +54867,22 @@
     },
     {
       "caseId": "react-case-v1:b9fa428077b26f92c54e",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "adds an event listener to a newly added child",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “a listener added before a child existed still fires on that child once it mounts” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-future-children.test.ts",
+          "testName": "a listener added before a child existed still fires on that child once it mounts",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:b9fe26cb94bd610e247d",
@@ -54848,15 +55227,27 @@
     },
     {
       "caseId": "react-case-v1:bbd224db0e1ba8fd9c25",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "handles nested children",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “inner fragment.contains a child only of the inner range” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
+          "testName": "inner fragment.contains a child only of the inner range",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-position.test.ts",
+          "testName": "returns exactly CONTAINED_BY for a descendant of a fragment child",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:bbecf8eb04ff88db71a5",
@@ -55818,15 +56209,22 @@
     },
     {
       "caseId": "react-case-v1:bea592a31d269ae9f177",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "keeps focus on the first focusable child if already focused",
       "baselines": ["canary"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “does not refocus an already focused first child” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-focus.test.ts",
+          "testName": "does not refocus an already focused first child",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:bea5f71c6511b4f4641b",
@@ -56848,15 +57246,27 @@
     },
     {
       "caseId": "react-case-v1:c292e0a6dc7e37126618",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "applies event listeners to visible trees",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “disconnects preserved hidden children and reconnects them when Activity reveals” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-activity.test.ts",
+          "testName": "disconnects preserved hidden children and reconnects them when Activity reveals",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-activity.test.ts",
+          "testName": "connects an initially hidden portal only after its Activity reveals",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:c29357777c98818aa4f4",
@@ -57121,15 +57531,22 @@
     },
     {
       "caseId": "react-case-v1:c3241a23bf573696d49b",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "does not yet support options",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “rejects scroll options objects instead of passing them to DOM elements” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
+          "testName": "rejects scroll options objects instead of passing them to DOM elements",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:c33c9eed58315f728723",
@@ -57427,15 +57844,22 @@
     },
     {
       "caseId": "react-case-v1:c4056310f68da7c2778f",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "focus is a no-op on text-only fragment",
       "baselines": ["canary"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “focus / focusLast / blur are no-ops” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
+          "testName": "focus / focusLast / blur are no-ops",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:c41936a14958d7f8be55",
@@ -58733,15 +59157,22 @@
     },
     {
       "caseId": "react-case-v1:c7c9b30edb12d0eac8d8",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "focuses the last focusable child",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “focusLast() focuses the LAST focusable child in tree order” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-focus.test.ts",
+          "testName": "focusLast() focuses the LAST focusable child in tree order",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:c7cb6118b145cfb48f1c",
@@ -59421,15 +59852,22 @@
     },
     {
       "caseId": "react-case-v1:ca4a79c5455e43cb1485",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "does not apply removed event listeners to new children",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “removeEventListener stops future children from getting the listener” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-future-children.test.ts",
+          "testName": "removeEventListener stops future children from getting the listener",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:ca4bd6dcc1265c24676f",
@@ -59980,15 +60418,27 @@
     },
     {
       "caseId": "react-case-v1:cb6d851c376a456c1fa6",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "removes focus from an element inside of the Fragment",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “blur() blurs an active element that lives inside the fragment” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-focus.test.ts",
+          "testName": "blur() blurs an active element that lives inside the fragment",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-parity-ledger.test.ts",
+          "testName": "removes focus from a nested element inside the Fragment",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:cb759a759584c4426cbd",
@@ -63568,15 +64018,22 @@
     },
     {
       "caseId": "react-case-v1:d766abb61dd5ac915e90",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "getClientRects includes text node bounds",
       "baselines": ["canary"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “includes text-node client rectangles when the Range API provides them” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
+          "testName": "includes text-node client rectangles when the Range API provides them",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:d76947e79014045a38a6",
@@ -63953,15 +64410,22 @@
     },
     {
       "caseId": "react-case-v1:d896ffd5097f17bd9080",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "focusLast is a no-op on text-only fragment",
       "baselines": ["canary"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “focus / focusLast / blur are no-ops” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
+          "testName": "focus / focusLast / blur are no-ops",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:d89d1703277db6e26e19",
@@ -64020,15 +64484,32 @@
     },
     {
       "caseId": "react-case-v1:d8d42281a83467c3bf65",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "handles fragment instances with one child",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “returns PRECEDING for a sibling rendered BEFORE the fragment” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-position.test.ts",
+          "testName": "returns PRECEDING for a sibling rendered BEFORE the fragment",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-position.test.ts",
+          "testName": "returns FOLLOWING for a sibling rendered AFTER the fragment",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-position.test.ts",
+          "testName": "returns exactly CONTAINED_BY for a child inside the fragment",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:d8e0010c5e7314270e6c",
@@ -65682,15 +66163,22 @@
     },
     {
       "caseId": "react-case-v1:de8b75bcb79bda8bb79a",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "warns when observeUsing is called on text-only fragment",
       "baselines": ["canary"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “warns when an observer is attached to a fragment containing only text” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-observers.test.ts",
+          "testName": "warns when an observer is attached to a fragment containing only text",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:de950c5617a92d80bcfc",
@@ -66845,15 +67333,22 @@
     },
     {
       "caseId": "react-case-v1:e260d2777bc35a1d741f",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "compares a root-level Fragment",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “compares a root-level Fragment and its empty Fragment sibling” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-parity-ledger.test.ts",
+          "testName": "compares a root-level Fragment and its empty Fragment sibling",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:e273b8577509edc25b64",
@@ -67169,15 +67664,27 @@
     },
     {
       "caseId": "react-case-v1:e35dab67a2154ef1a78e",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "fires events on the host parent if bubbles=true",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “dispatches on the parent host element and bubbles to its listeners” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-position.test.ts",
+          "testName": "dispatches on the parent host element and bubbles to its listeners",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-position.test.ts",
+          "testName": "delivers bubbling events to the fragment before their host parent",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:e365e0867402afc834b4",
@@ -67411,15 +67918,22 @@
     },
     {
       "caseId": "react-case-v1:e428fad5293d20d9c6cb",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "settles scroll on the first child by default, or if alignToTop=true",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “scrolls children in reverse order so the first child receives final focus” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
+          "testName": "scrolls children in reverse order so the first child receives final focus",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:e44005d824716b525b20",
@@ -69106,15 +69620,22 @@
     },
     {
       "caseId": "react-case-v1:ea5f7a6138b443c3fc9f",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "returns disconnected for comparison with an unmounted fragment instance",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “returns disconnected for comparison with an unmounted fragment instance” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-parity-ledger.test.ts",
+          "testName": "returns disconnected for comparison with an unmounted fragment instance",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:ea6272128aa272849989",
@@ -69602,15 +70123,22 @@
     },
     {
       "caseId": "react-case-v1:ebcf97cd31c5cf4621b8",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "returns the bounding client rects of all children",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “returns the concatenated rects of every direct fragment child in tree order” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-observers.test.ts",
+          "testName": "returns the concatenated rects of every direct fragment child in tree order",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:ebdd6ba7debad55b8a9c",
@@ -73301,15 +73829,22 @@
     },
     {
       "caseId": "react-case-v1:f851b1903939625f1ec5",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "removes a listener registered with passive:false when removed with passive:true",
       "baselines": ["canary"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “removes a listener registered with passive:false when removed with passive:true” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-events.test.ts",
+          "testName": "removes a listener registered with passive:false when removed with passive:true",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:f8656a65d339df828d5c",
@@ -75255,15 +75790,22 @@
     },
     {
       "caseId": "react-case-v1:ffa5750e9f0140c80bec",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js",
       "title": "handles portaled elements -- same scroll container",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
-      "owner": "runtime + SSR + hydration",
-      "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "owner": "runtime + compiler + SSR + hydration",
+      "workstream": "Fragment refs",
+      "rationale": "Executable client and production-compile evidence in “measures and scrolls portaled children in their authored logical order” verifies the exact upstream FragmentInstance public outcome.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
+          "testName": "measures and scrolls portaled children in their authored logical order",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:ffaff32cb060f212e22d",

--- a/packages/octane/audit/react-upstreams.json
+++ b/packages/octane/audit/react-upstreams.json
@@ -326,6 +326,16 @@
       "rationale": "Remaining function-component, element, JSX-runtime, context, transition, and diagnostic outcomes require exact Octane public-API evidence or a narrower case-level divergence disposition."
     },
     {
+      "id": "fragment-refs",
+      "workstream": "Fragment refs",
+      "filePattern": "/ReactDOMFragmentRefs-test\\.js$",
+      "risk": "high",
+      "status": "covered",
+      "classification": "adaptable",
+      "owner": "runtime + compiler + SSR + hydration",
+      "rationale": "All 61 stable/canary FragmentInstance scenarios have exact executable public evidence for typed refs, lifecycle, native listeners, observers, focus, geometry, document position, scrolling, portals, Activity visibility, and text nodes; buffered/streaming SSR and matching hydration additionally prove server refs stay inactive until client attachment."
+    },
+    {
       "id": "react-dom-residual",
       "workstream": "React DOM residual audit",
       "filePattern": "^packages/react-dom/",

--- a/packages/octane/error-codes/codes.json
+++ b/packages/octane/error-codes/codes.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "nextCode": 49,
+  "nextCode": 51,
   "codes": {
     "1": {
       "message": "Maximum update depth exceeded. Octane limits the number of nested updates to prevent infinite loops.",
@@ -288,6 +288,18 @@
       "message": "octane SSR: %s consecutive streaming passes completed no boundary — a use(thenable) never resolved. If promises are re-created on every render pass (e.g. created in an ancestor render and passed down through props), create them at their use() site or hoist them out of render.",
       "argumentCount": 1,
       "runtime": ["server"],
+      "status": "active"
+    },
+    "49": {
+      "message": "FragmentInstance.scrollIntoView() does not support scrollIntoViewOptions. Use the alignToTop boolean instead.",
+      "argumentCount": 0,
+      "runtime": ["client"],
+      "status": "active"
+    },
+    "50": {
+      "message": "Unclosed server-rendered Fragment descriptor.",
+      "argumentCount": 0,
+      "runtime": ["client"],
       "status": "active"
     }
   }

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -6851,8 +6851,8 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 		// Server (SSR) codegen: static markup + dynamic holes + control flow +
 		// nested components + scoped CSS, emitted as HTML-string-building bodies
 		// (with hydration markers) importing the server runtime from 'octane/server'.
-		// Fragment refs remain client-only because there is no server-side DOM range
-		// object for their imperative API.
+		// Fragment refs keep their client hydration boundaries, but their ref values
+		// are never attached while rendering without a DOM.
 		const compiled = compileServer(
 			source,
 			filename,
@@ -8181,9 +8181,6 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 // control-flow emitters (@if/@for/@switch/@try) — wrapping every dynamic site in
 // the hydration markers (`constants.ts`) the client `hydrateRoot` adopts. The
 // client path (template/clone + bindings) is left completely untouched.
-//
-// Still rejected with a clear diagnostic (see ssrUnsupported): fragment refs
-// (`<Fragment ref={…}>`).
 // ===========================================================================
 
 function ssrUnsupported(what) {
@@ -8501,14 +8498,14 @@ function compileServerComponent(node, ctx) {
 	return nodes;
 }
 
-function ssrReturnedJsxNode(argument) {
+function ssrReturnedJsxNode(argument, ctx) {
 	const returnedHostRoot =
 		(argument.type === 'Element' || argument.type === 'JSXElement') && !isComponentTag(argument);
 	if (
 		argument.type === 'JSXFragment' ||
 		argument.type === 'Fragment' ||
-		isFragmentLongForm(argument) ||
-		(!returnedHostRoot && requiresTemplateNormalization(argument))
+		isFragmentLongForm(argument, ctx) ||
+		(!returnedHostRoot && requiresTemplateNormalization(argument, 'html', true, ctx))
 	) {
 		return {
 			type: 'TSRXExpression',
@@ -8574,7 +8571,7 @@ function ssrCompileBodyWithMapTemps(
 			? (node.body.body || []).map(normalizeOwnRenderableReturns)
 			: node.body.body || [];
 		jsxNodes = node.body.render
-			? [returnedOutput ? ssrReturnedJsxNode(node.body.render) : node.body.render]
+			? [returnedOutput ? ssrReturnedJsxNode(node.body.render, ctx) : node.body.render]
 			: [];
 	} else {
 		// `node.body` may be a BlockStatement (`function f() { … return <jsx> }`, the
@@ -8595,7 +8592,7 @@ function ssrCompileBodyWithMapTemps(
 				// range per item); fragments or component/sentinel roots containing
 				// template-only syntax lower to one compiled renderer component. Route both
 				// through ssrEmitTsrxExpression so the server mirrors that exact boundary.
-				jsxNodes.push(ssrReturnedJsxNode(child.argument));
+				jsxNodes.push(ssrReturnedJsxNode(child.argument, ctx));
 			} else if (isJsxNode(child)) {
 				if (child.type === 'Element' && elementTagName(child) === 'style') continue;
 				jsxNodes.push(child);
@@ -9101,8 +9098,15 @@ function ssrEmitNode(
 		case 'ActivityStatement':
 			return ssrEmitActivity(node, ctx, name, inlinedSubs, parentNs, cssHash, componentNs);
 		case 'FragmentStart':
+			ctx.runtimeNeeded.add('ssrFragmentMarker');
+			return ssrCall(
+				'ssrFragmentMarker',
+				[b.literal(true, 'true'), tsrxExprNode(node.refExpr, ctx, name, inlinedSubs)],
+				node.refExpr ?? ctx._moduleOrigin,
+			);
 		case 'FragmentEnd':
-			return ssrUnsupported('fragment refs (`<Fragment ref={…}>`)');
+			ctx.runtimeNeeded.add('ssrFragmentMarker');
+			return ssrCall('ssrFragmentMarker', [b.literal(false, 'false')], ctx._moduleOrigin);
 		default:
 			return ssrUnsupported(`node type ${node.type}`);
 	}
@@ -10044,10 +10048,10 @@ function ssrEmitComponent(node, ctx, name, inlinedSubs, parentNs, cssHash, compo
 		);
 	} else if (sourceChildren.length > 0) {
 		const children = rewriteOpaqueTitles(sourceChildren, ctx, 'opaque');
-		const opaqueChildren = !isActivityLongForm(node) && !isFragmentLongForm(node);
+		const opaqueChildren = !isActivityLongForm(node) && !isFragmentLongForm(node, ctx);
 		const descriptorChildren =
 			ctx._tsxValuePos ||
-			(returnedFragmentTemplate && !requiresTemplateNormalization(node, parentNs));
+			(returnedFragmentTemplate && !requiresTemplateNormalization(node, parentNs, true, ctx));
 		if (descriptorChildren) {
 			// VALUE position (a React-style `.tsx` `return <jsx>` body), or an ordinary
 			// component left as a descriptor hole inside a returned-fragment renderer:
@@ -10662,7 +10666,7 @@ function ssrControlKey(kind, node) {
 // renderer component so its template scopes and hydration range both survive.
 function ssrEmitTsrxExpression(node, ctx, name, inlinedSubs, parentNs, cssHash, componentNs) {
 	const expr = node.expression;
-	if (node.returnedJsxValue === true && requiresTemplateNormalization(expr)) {
+	if (node.returnedJsxValue === true && requiresTemplateNormalization(expr, 'html', true, ctx)) {
 		// A returned JSX value that contains template-only syntax is one compiled
 		// renderer on the client (rather than a descriptor array whose value
 		// lowering cannot represent directives, sentinels, head hoists, or child
@@ -14937,16 +14941,60 @@ function hasJsxAttribute(node, name) {
 	);
 }
 
+function hasJsxSpreadAttribute(node) {
+	return (node.attributes || node.openingElement?.attributes || []).some(
+		(attr) => attr.type === 'SpreadAttribute' || attr.type === 'JSXSpreadAttribute',
+	);
+}
+
+// Merge the complete Fragment config in authored order: object-spread getters,
+// explicit values, key expressions, and the final ref all evaluate exactly once.
+function fragmentSpreadRefExpression(node) {
+	const properties = [];
+	for (const attr of node.attributes || node.openingElement?.attributes || []) {
+		if (attr.type === 'SpreadAttribute' || attr.type === 'JSXSpreadAttribute') {
+			properties.push(inheritOriginLoc(b.spread(attr.argument), attr));
+			continue;
+		}
+		if (attr.type !== 'Attribute' && attr.type !== 'JSXAttribute') continue;
+		const attrName = attr.name.name || attr.name;
+		let value;
+		if (attr.value == null) {
+			value = inheritOriginLoc(b.literal(true), attr);
+		} else if (attr.value.type === 'JSXExpressionContainer') {
+			value = attr.value.expression;
+		} else {
+			value = inheritOriginLoc(
+				b.literal(attr.value.value, JSON.stringify(attr.value.value)),
+				attr.value,
+			);
+		}
+		properties.push(
+			inheritOriginLoc(
+				b.prop(
+					'init',
+					/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(attrName)
+						? inheritOriginLoc(b.id(attrName), attr.name)
+						: inheritOriginLoc(b.literal(attrName), attr.name),
+					value,
+				),
+				attr,
+			),
+		);
+	}
+	return inheritOriginLoc(b.member(inheritOriginLoc(b.object(properties), node), 'ref'), node);
+}
+
 // Activity is always compiler-owned template syntax. Long-form Fragment only
 // needs template routing when it carries a ref (marker-pair expansion) or owns a
 // descendant that itself needs normalization. An ordinary/no-ref/keyed Fragment
 // remains a runtime descriptor so its explicit reconciliation boundary survives.
-function isLongFormTemplateSentinel(node, parentNs = 'html', allowHeadHoists = true) {
+function isLongFormTemplateSentinel(node, parentNs = 'html', allowHeadHoists = true, ctx = null) {
 	if (isActivityLongForm(node)) return true;
-	if (!isFragmentLongForm(node)) return false;
-	if (hasJsxAttribute(node, 'ref')) return true;
+	if (!isFragmentLongForm(node, ctx)) return false;
+	if (hasJsxAttribute(node, 'ref') || hasJsxSpreadAttribute(node)) return true;
 	return (node.children || []).some((child) =>
-		requiresTemplateNormalization(child, parentNs, allowHeadHoists),
+		requiresTemplateNormalization(child, parentNs, allowHeadHoists, ctx),
 	);
 }
 
@@ -14959,7 +15007,12 @@ function isLongFormTemplateSentinel(node, parentNs = 'html', allowHeadHoists = t
 //
 // JSXStyleElement is intentionally absent. Returned scoped style needs the
 // component-level CSS scoping/hash pipeline, not merely template routing.
-function requiresTemplateNormalization(node, parentNs = 'html', allowHeadHoists = true) {
+function requiresTemplateNormalization(
+	node,
+	parentNs = 'html',
+	allowHeadHoists = true,
+	ctx = null,
+) {
 	if (!node) return false;
 	const t = node.type;
 	if (
@@ -14982,11 +15035,11 @@ function requiresTemplateNormalization(node, parentNs = 'html', allowHeadHoists 
 	}
 	if (t === 'Fragment' || t === 'JSXFragment' || t === 'Tsx' || t === 'Tsrx') {
 		return (node.children || []).some((child) =>
-			requiresTemplateNormalization(child, parentNs, allowHeadHoists),
+			requiresTemplateNormalization(child, parentNs, allowHeadHoists, ctx),
 		);
 	}
 	if (t !== 'Element' && t !== 'JSXElement') return false;
-	if (isLongFormTemplateSentinel(node, parentNs, allowHeadHoists)) return true;
+	if (isLongFormTemplateSentinel(node, parentNs, allowHeadHoists, ctx)) return true;
 
 	const tag = jsxTagName(node) || elementTagName(node);
 	const selfNs = typeof tag === 'string' ? nsForSelf(tag, parentNs) : parentNs;
@@ -15012,9 +15065,9 @@ function requiresTemplateNormalization(node, parentNs = 'html', allowHeadHoists 
 	// reconciliation can then use the actual host namespace chosen at runtime.
 	const childAllowsHeadHoists =
 		allowHeadHoists &&
-		(!isComponentTag(node) || isActivityLongForm(node) || isFragmentLongForm(node));
+		(!isComponentTag(node) || isActivityLongForm(node) || isFragmentLongForm(node, ctx));
 	return (node.children || []).some((child) =>
-		requiresTemplateNormalization(child, childNs, childAllowsHeadHoists),
+		requiresTemplateNormalization(child, childNs, childAllowsHeadHoists, ctx),
 	);
 }
 
@@ -15046,7 +15099,7 @@ function lowerReturnJsx(node, ctx, compInlinedSubs, cssHash = null) {
 	) {
 		return lowerHostFragment(rewritten, ctx, compInlinedSubs, 'opaque', cssHash, true);
 	}
-	if (requiresTemplateNormalization(rewritten)) {
+	if (requiresTemplateNormalization(rewritten, 'html', true, ctx)) {
 		return lowerHostFragment(rewritten, ctx, compInlinedSubs, 'opaque', cssHash, true);
 	}
 	if (rewritten.type === 'Element' || rewritten.type === 'JSXElement') {
@@ -15128,7 +15181,29 @@ function isStaticReturnedFragmentComponent(node, ctx) {
 function extractFragment(node, ctx, holeProps, parentNs = 'html') {
 	const attrs = node.attributes || node.openingElement?.attributes || [];
 	const newAttrs = [];
-	for (const attr of attrs) {
+	const mergedFragmentSpread = isFragmentLongForm(node, ctx) && hasJsxSpreadAttribute(node);
+	if (mergedFragmentSpread) {
+		// Hoisting each spread operand separately delays its getters until the
+		// renderer runs, after later attributes and child holes already evaluated.
+		// One merged hole preserves JSX's interleaved expression/getter order.
+		const expression = fragmentSpreadRefExpression(node);
+		const hn = `h${holeProps.length}`;
+		holeProps.push(objectProp(hn, rewriteJsxValues(expression, ctx)));
+		const value = b.jsx_expression_container(memberProps(hn, expression));
+		const authoredRef = attrs.find(
+			(attr) =>
+				(attr.type === 'Attribute' || attr.type === 'JSXAttribute') &&
+				jsxAttrRawName(attr) === 'ref',
+		);
+		newAttrs.push(
+			authoredRef
+				? { ...authoredRef, value }
+				: markSynthesizedAttr(
+						inheritOriginLoc(b.jsx_attribute(b.jsx_id('ref'), value), node.openingElement || node),
+					),
+		);
+	}
+	for (const attr of mergedFragmentSpread ? [] : attrs) {
 		if (attr.type === 'SpreadAttribute' || attr.type === 'JSXSpreadAttribute') {
 			// `{...expr}` — the spread expression is a DYNAMIC input too. Thread it out
 			// as an `hN` hole (exactly like an attribute value) so any prop/local it
@@ -15222,12 +15297,12 @@ function extractFragment(node, ctx, holeProps, parentNs = 'html') {
 				newChildren.push(b.jsx_expression_container(rendered));
 			}
 		} else if (t === 'Element' || t === 'JSXElement') {
-			if (isLongFormTemplateSentinel(child, childNs)) {
+			if (isLongFormTemplateSentinel(child, childNs, true, ctx)) {
 				newChildren.push(extractFragment(child, ctx, holeProps, childNs));
 			} else if (
 				isComponentTag(child) &&
 				ctx._foldCtx?.templateComponentChildren === true &&
-				requiresTemplateNormalization(child, childNs)
+				requiresTemplateNormalization(child, childNs, true, ctx)
 			) {
 				// Component children normally become descriptor children at return-value
 				// position. A directive cannot be represented by lowerJsxChild, though, so
@@ -15575,7 +15650,7 @@ function extractFragmentRoot(node, ctx, holeProps, parentNs = 'html') {
 		(node.type === 'Element' || node.type === 'JSXElement') &&
 		isComponentTag(node) &&
 		!isActivityLongForm(node) &&
-		!isFragmentLongForm(node)
+		!isFragmentLongForm(node, ctx)
 	) {
 		return extractFragmentComponent(node, ctx, holeProps, parentNs);
 	}
@@ -15599,7 +15674,7 @@ function lowerHostFragment(
 	// extractFragment reads `ctx._foldCtx` for any directive child it folds (and to
 	// route helper defs into the component). Save/restore so it never leaks.
 	const prevFold = ctx._foldCtx;
-	const templateComponentChildren = requiresTemplateNormalization(node, parentNs);
+	const templateComponentChildren = requiresTemplateNormalization(node, parentNs, true, ctx);
 	ctx._foldCtx =
 		compInlinedSubs !== undefined
 			? {
@@ -16801,7 +16876,7 @@ function rewriteOpaqueTitles(node, ctx, namespace = 'html') {
 	if (type === 'Element' || type === 'JSXElement') {
 		const tag = jsxTagName(node) || elementTagName(node);
 		const ordinaryComponent =
-			isComponentTag(node) && !isActivityLongForm(node) && !isFragmentLongForm(node);
+			isComponentTag(node) && !isActivityLongForm(node) && !isFragmentLongForm(node, ctx);
 		if (
 			!ordinaryComponent &&
 			tag === 'title' &&
@@ -17057,24 +17132,31 @@ function normalizeChildren(nodes, inSvg = false, ctx = null) {
 			// element template gets `<!--frag-->` markers + a fragmentRef
 			// binding pairing them. Without a ref, treat it identically to the
 			// `<>` shorthand and just inline the children (no wasted markers).
-			// Detection is by source-name only; the runtime `Fragment` export
-			// exists as a sentinel for `import { Fragment }` parity, but the
-			// compiler matches the identifier here. Routing this BEFORE the
+			// Resolve imported aliases and namespaces through the module's Octane
+			// import bindings, while preserving unrelated or shadowed components.
+			// Routing this BEFORE the
 			// generic Element branch is required — `Fragment` would otherwise
 			// hit `isComponentTag` and route through `componentSlot`, which
 			// has no notion of marker pairs.
-			if (isFragmentLongForm(n)) {
-				const refAttr = (n.openingElement.attributes || []).find(
+			if (isFragmentLongForm(n, ctx)) {
+				const attributes = n.openingElement.attributes || [];
+				const refAttr = attributes.find(
 					(a) =>
 						(a.type === 'Attribute' || a.type === 'JSXAttribute') &&
 						a.name &&
 						(a.name.name || a.name) === 'ref',
 				);
-				if (refAttr) {
-					const refVal = refAttr.value;
-					const refInner =
-						refVal && refVal.type === 'JSXExpressionContainer' ? refVal.expression : refVal;
-					out.push({ type: 'FragmentStart', refExpr: refInner });
+				const hasSpread = hasJsxSpreadAttribute(n);
+				if (refAttr || hasSpread) {
+					let refExpr;
+					if (hasSpread) {
+						refExpr = fragmentSpreadRefExpression(n);
+					} else {
+						const refVal = refAttr.value;
+						refExpr =
+							refVal && refVal.type === 'JSXExpressionContainer' ? refVal.expression : refVal;
+					}
+					out.push({ type: 'FragmentStart', refExpr });
 					out.push(...normalizeChildren(n.children || [], inSvg, ctx));
 					out.push({ type: 'FragmentEnd' });
 				} else {
@@ -18257,11 +18339,14 @@ function planJsx(
 	});
 	mountConstructs(tryCalls, 'tryHost', { anchorKey: 'tryAnchor' });
 	mountConstructs(ctx._switchCalls, 'switchHost', { anchorKey: 'switchAnchor' });
-	// Portal hosts — the element containing the createPortal JSX position, stashed
+	// Portal hosts — the logical parent of the createPortal JSX position, stashed
 	// so the runtime can stamp $$portalParent on the portal's mounted children
-	// pointing here (React-shape bubble-out semantics). No LOC stamp, no `<!>`
-	// anchor — the portal's content renders into a foreign target.
-	mountConstructs(ctx._portalCalls, 'portalHost', { stampLoc: false });
+	// pointing here (React-shape bubble-out semantics). Fragment-owned portals
+	// additionally retain a stable source-order anchor; ordinary portals do not.
+	mountConstructs(ctx._portalCalls, 'portalHost', {
+		anchorKey: 'portalAnchor',
+		stampLoc: false,
+	});
 	// Flush the deferred sibling-text-hole mounts now that every element walk is emitted —
 	// `htextSwap` can safely detach its `<!>` placeholder without breaking later navigation.
 	for (const line of deferredTextMounts) mountLines.push(line);
@@ -19126,6 +19211,21 @@ function planJsx(
 		const org = pc.origin ?? planOrigin;
 		ctx.runtimeNeeded.add('portal');
 		const portalEnv = envNodeFor(pc);
+		const portalTrailing = portalEnv ? [portalEnv] : [];
+		if (pc.fragmentBindings !== undefined || pc.sourceAnchorOnly === true) {
+			if (!portalEnv) portalTrailing.push(undefinedNode());
+			if (pc.fragmentBindings !== undefined) {
+				const owners = pc.fragmentBindings.map((fragment) =>
+					bagFieldNode(bag, `_fi$${fragment.id}`),
+				);
+				portalTrailing.push(
+					owners.length === 1 ? owners[0] : inheritOriginLoc(b.array(owners), org),
+				);
+			} else {
+				portalTrailing.push(undefinedNode());
+			}
+			portalTrailing.push(bagFieldNode(bag, `_portalAnchor$${pc.id}`));
+		}
 		pushAfterStmt(
 			pc.id,
 			org,
@@ -19138,7 +19238,7 @@ function planJsx(
 					pc.bodyExpr,
 					pc.propsExpr,
 					hostNodeFor(`_portalHost$${pc.id}`),
-					...(portalEnv ? [portalEnv] : []),
+					...portalTrailing,
 				),
 			),
 		);
@@ -20451,13 +20551,37 @@ function emitNodeHtml(
 		return templatePart('<!>', 'anchor');
 	}
 	// `{createPortal(...)}` / a JSX-bearing ternary / a `.map()` etc. at a top-level
-	// or fragment-root position (no enclosing host element). The element-child loop
-	// lowers `{createPortal(...)}` to a `portal()` fast path because it HAS a host to
-	// stamp; here there's none, so route the value through the de-opt childSlot hole
-	// (the AST transform preserves the createPortal call → the runtime renders the
-	// PortalDescriptor; any inner JSX lowers to createElement). Without this a
-	// top-level rich hole compiled to nothing.
+	// or fragment-root position. An owned portal must retain its logical Fragment
+	// ancestry even without an enclosing host element. A portal whose body needs
+	// template normalization also requires a compiled helper: value descriptors
+	// cannot represent a Fragment ref or template-only control flow in that body.
+	// Ordinary root portals keep their existing descriptor/childSlot lowering.
 	if (node.type === 'TSRXExpression') {
+		const fragmentBindings = ctx._fragRefStack;
+		if (
+			isCreatePortalCall(node.expression) &&
+			(fragmentBindings?.length > 0 ||
+				requiresTemplateNormalization(node.expression.arguments[0], parentNs, true, ctx))
+		) {
+			const owners = fragmentBindings?.length > 0 ? fragmentBindings.slice() : null;
+			const pc = makePortalCall(
+				node.expression,
+				ctx,
+				componentName,
+				inlinedSubs,
+				parentNs,
+				cssHash,
+			);
+			pc.hostPath = path.slice(0, -1);
+			pc.anchorPath = path;
+			if (owners !== null) {
+				pc.fragmentBindings = owners;
+			} else {
+				pc.sourceAnchorOnly = true;
+			}
+			(ctx._portalCalls ??= []).push(pc);
+			return templatePart('<!>', 'anchor');
+		}
 		const ch = makeChildCall(node.expression, ctx, componentName, inlinedSubs, cssHash);
 		ch.hostPath = path.slice(0, -1);
 		ch.anchorPath = path;
@@ -21700,6 +21824,10 @@ function emitElementHtml(
 					// pointing back at it. That makes events bubble OUT of the portal
 					// up through this element — matching React's per-fiber portal walk.
 					pc.hostPath = path;
+					if (fragRefStack.length > 0) {
+						pc.fragmentBindings = fragRefStack.slice();
+						pc.anchorPath = [...path, childIdx];
+					}
 					(ctx._portalCalls ??= []).push(pc);
 				} else if (isConditionalJsx(expr)) {
 					// Lower `{cond ? A : B}` (where A or B is JSX) to an IfStatement so
@@ -22074,16 +22202,33 @@ function isActivityLongForm(node) {
 // Component-as-tag — `<Foo>...</Foo>`, `<ctx.Provider>...</ctx.Provider>`
 // ===========================================================================
 
-// Long-form `<Fragment>…</Fragment>` (capital-F sentinel for fragment refs).
-// Matches a JSXElement / Element whose tag identifier is exactly the word
-// "Fragment". Used in normalizeChildren to expand into a FragmentStart /
-// children / FragmentEnd sequence BEFORE isComponentTag would route the
-// element through the componentSlot path.
-function isFragmentLongForm(node) {
+// Long-form Fragments can use their conventional unbound spelling, an Octane
+// named-import alias, or the Fragment member of an Octane namespace import.
+// Resolve aliases against their import bindings so a foreign or locally
+// shadowed component retains its ordinary component semantics.
+function isFragmentLongForm(node, ctx = null) {
 	const name = node.openingElement?.name || node.id;
 	if (!name) return false;
-	if (name.type !== 'Identifier' && name.type !== 'JSXIdentifier') return false;
-	return name.name === 'Fragment';
+	if (name.type === 'Identifier' || name.type === 'JSXIdentifier') {
+		const local = name.name;
+		if (ctx?.currentComponentLocals?.has(local)) return false;
+		const imported = ctx?.octaneImportLocals?.get(local);
+		if (imported !== undefined) return imported === 'Fragment';
+		if (ctx?.foreignImportLocals?.has(local)) return false;
+		if (ctx?.componentInfo?.has(local)) return false;
+		return local === 'Fragment';
+	}
+	if (name.type !== 'MemberExpression' && name.type !== 'JSXMemberExpression') return false;
+	const object = name.object;
+	const property = name.property;
+	return (
+		name.computed !== true &&
+		(object?.type === 'Identifier' || object?.type === 'JSXIdentifier') &&
+		(property?.type === 'Identifier' || property?.type === 'JSXIdentifier') &&
+		property.name === 'Fragment' &&
+		ctx?.octaneImportNamespaces?.has(object.name) === true &&
+		!ctx.currentComponentLocals?.has(object.name)
+	);
 }
 
 function isComponentTag(node) {
@@ -22422,7 +22567,7 @@ function makeCompCall(
 	} else if (sourceChildren.length > 0) {
 		const children = rewriteOpaqueTitles(sourceChildren, ctx, 'opaque');
 		const childrenParentNs =
-			!isActivityLongForm(node) && !isFragmentLongForm(node) ? 'opaque' : parentNs;
+			!isActivityLongForm(node) && !isFragmentLongForm(node, ctx) ? 'opaque' : parentNs;
 		// Compile children as a render function: (scope) => { renders JSX into scope }.
 		// The function is inlined inside the parent component body so its closures
 		// capture the parent's locals (props, state, etc.).

--- a/packages/octane/src/error-codes.client.generated.ts
+++ b/packages/octane/src/error-codes.client.generated.ts
@@ -36,6 +36,8 @@ type ClientErrorArguments = {
 	28: [];
 	29: [];
 	46: [unknown, unknown];
+	49: [];
+	50: [];
 };
 
 export function formatClientError<Code extends keyof ClientErrorArguments>(
@@ -176,6 +178,13 @@ export function formatClientError<Code extends keyof ClientErrorArguments>(
 					'Expected %s listener to be a function, instead got a value of `%s` type.',
 					args,
 				);
+			case 49:
+				return formatDevErrorMessage(
+					'FragmentInstance.scrollIntoView() does not support scrollIntoViewOptions. Use the alignToTop boolean instead.',
+					args,
+				);
+			case 50:
+				return formatDevErrorMessage('Unclosed server-rendered Fragment descriptor.', args);
 			default:
 				return formatUnknownDevErrorMessage(code);
 		}

--- a/packages/octane/src/jsx-runtime.d.ts
+++ b/packages/octane/src/jsx-runtime.d.ts
@@ -34,7 +34,7 @@
  * `.tsx` sources) can type-check JSX against octane's real contract.
  */
 import type * as React from 'react';
-import type { ElementDescriptor } from './index.js';
+import type { ElementDescriptor, FragmentInstance } from './index.js';
 
 /**
  * Octane's element type — the analog of React's `ReactElement`, and what a
@@ -566,5 +566,5 @@ export declare function jsxDEV(
 export declare function Fragment(props: {
 	children?: unknown;
 	key?: Octane.Key | null | undefined;
-	ref?: Octane.Ref<unknown>;
+	ref?: Octane.Ref<FragmentInstance>;
 }): OctaneElement;

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -15,8 +15,8 @@
  * server renderer does — effects no-op, memo runs once, ids are deterministic).
  * Every dynamic site is
  * wrapped in the hydration markers (`constants.ts`) the client `hydrateRoot`
- * cursor adopts. Events and refs are dropped (no DOM on the server); fragment
- * refs (`<Fragment ref={…}>`) are rejected by the compiler in server mode.
+ * cursor adopts. Events and refs are dropped (no DOM on the server); Fragment
+ * refs retain their range markers only when producing hydratable output.
  */
 
 // ---------------------------------------------------------------------------
@@ -668,6 +668,27 @@ function fragmentDescriptorChildren(value: ElementDescriptor): any[] {
 	return Array.isArray(children) ? children : [children];
 }
 
+/** Server counterpart of the client's cold ref-bearing Fragment wrapper. */
+function fragmentRefDescriptor(value: ElementDescriptor): ElementDescriptor {
+	return {
+		$$kind: ELEMENT_TAG,
+		type: renderFragmentRefDescriptor,
+		props: value,
+		key: value.key,
+		ref: null,
+		children: null,
+	};
+}
+
+/** Retain the exact range adopted by the client without attaching its ref. */
+function renderFragmentRefDescriptor(descriptor: ElementDescriptor, scope: SSRScope): string {
+	return (
+		ssrFragmentMarker(true, descriptor.ref) +
+		ssrChild(descriptor.children, scope) +
+		ssrFragmentMarker(false)
+	);
+}
+
 type SsrDeoptWrapperKind = 'array' | 'fragment';
 
 interface PreparedSsrDeoptList {
@@ -708,6 +729,11 @@ function flattenSsrChildContainer(
 	for (let i = 0; i < count; i++) {
 		const item = children[i];
 		if (isFragmentDescriptor(item)) {
+			if (item.ref != null || Object.prototype.hasOwnProperty.call(item.props, 'ref')) {
+				outItems.push(fragmentRefDescriptor(item));
+				outKeys.push(scopedSsrDeoptKey(path, item, i, ssrDeoptKey(item, i)));
+				continue;
+			}
 			const nested = fragmentDescriptorChildren(item);
 			if (item.key != null) {
 				flattenSsrChildContainer(outItems, outKeys, nested, 'fragment', [
@@ -747,6 +773,12 @@ function prepareSsrDeoptList(value: any, includeKeyedSingle: boolean): PreparedS
 	// descriptor, text, null) is the common one — build the two output arrays only
 	// once a list regime is established. Mirrors prepareDeoptList in runtime.ts.
 	if (isFragmentDescriptor(value)) {
+		if (value.ref != null || Object.prototype.hasOwnProperty.call(value.props, 'ref')) {
+			return {
+				items: [fragmentRefDescriptor(value)],
+				keys: [scopedSsrDeoptKey([], value, 0, value.key ?? 0)],
+			};
+		}
 		const items: any[] = [];
 		const keys: any[] = [];
 		const path = value.key == null ? [] : ['keyed-fragment', value.key];
@@ -1557,6 +1589,15 @@ function ssrDescriptorContent(v: unknown, scope: SSRScope): string {
  */
 export function ssrBlock(content: string): string {
 	return MARKERS ? BLOCK_OPEN + content + BLOCK_CLOSE : content;
+}
+
+/**
+ * Preserve a Fragment ref's authored evaluation order without attaching its
+ * value. Hydratable output needs the exact comments its client template adopts;
+ * static markup omits them along with every other hydration-only marker.
+ */
+export function ssrFragmentMarker(open: boolean, _ref?: unknown): string {
+	return MARKERS ? (open ? '<!--frag-->' : '<!--/frag-->') : '';
 }
 
 /**

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -11282,10 +11282,7 @@ export class FragmentInstance {
 	 */
 	scrollIntoView(alignToTop?: boolean): void {
 		if (typeof alignToTop === 'object') {
-			throw new Error(
-				'FragmentInstance.scrollIntoView() does not support scrollIntoViewOptions. ' +
-					'Use the alignToTop boolean instead.',
-			);
+			throw new Error(formatClientError(49));
 		}
 		if (this._destroyed) return;
 		const alignStart = alignToTop !== false;
@@ -17190,7 +17187,7 @@ function renderFragmentRefDescriptor(descriptor: ElementDescriptor, scope: Scope
 				}
 				cursor = cursor.nextSibling;
 			}
-			if (cursor === null) throw new Error('Unclosed server-rendered Fragment descriptor.');
+			if (cursor === null) throw new Error(formatClientError(50));
 			end = cursor as Comment;
 			hydration!.node = start.nextSibling;
 		} else {

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -2495,6 +2495,9 @@ const refAttachQueue: RefAttach[] = [];
 // trampoline. The common drain remains branch-free, and Fragment instances do not
 // allocate a getter closure.
 function attachLiveFragmentRef(instance: FragmentInstance): void {
+	// Portal slots mount after the fragment binding but before commit. Publish all
+	// logically owned child handles before handing the instance to its callback.
+	instance._reapply();
 	attachRef(instance._currentRef, instance);
 }
 
@@ -2550,12 +2553,10 @@ interface OffscreenWip {
 	refDetachCheckpoint: number;
 }
 
-// FragmentInstances that currently hold event listeners and/or observers. After
-// each commit we re-apply their stored bindings to their CURRENT children, so a
-// child that mounts into a fragment later picks up the listeners/observers added
-// earlier — React's `commitNewChildToFragmentInstance` future-children contract.
-// Empty for any app that doesn't use fragment-ref listeners (the common case),
-// so the per-commit cost is a single `size` check.
+// Live fragment refs need a commit-time child diff even before a listener or
+// observer is installed: each current first-level host child exposes its owning
+// FragmentInstances through `reactFragments`. Apps without fragment refs keep
+// the same single-size-check commit fast path.
 const activeFragments = new Set<FragmentInstance>();
 
 function reapplyFragmentBindings(): void {
@@ -10800,8 +10801,8 @@ export function attachRef(
 
 /** Fragment ref forms (fragment-refs parity): callback, object, or arrays. */
 type FragmentRefValue =
-	| ((instance: unknown) => void | (() => void))
-	| { current: unknown }
+	| ((instance: FragmentInstance | null) => void | (() => void))
+	| { current: FragmentInstance | null }
 	| readonly FragmentRefValue[]
 	| null;
 
@@ -10835,13 +10836,19 @@ export class FragmentInstance {
 	_endMarker: Comment;
 	_destroyed: boolean;
 	/**
+	 * Committed direct hosts and a reusable scratch set. Swapping the sets at
+	 * each commit avoids allocating per render while ensuring registrations are
+	 * applied only to genuinely new children.
+	 */
+	_children: Set<Element | Text>;
+	_pendingChildren: Set<Element | Text>;
+	/** Following DOM anchor -> logically owned portal ranges; allocated on demand. */
+	_portalAnchors: Map<Node, Set<PortalSlot>> | null;
+	/**
 	 * Registry of listeners added via addEventListener, deduped by
 	 * (type, listener, capture). `null` until the first addEventListener — zero
-	 * per-instance cost for fragments that never use the listener API. Stored
-	 * (not snapshotted onto specific elements) so they can be RE-APPLIED to
-	 * children that mount later: `_reapply` (run after every commit) attaches
-	 * each stored listener to the current children, matching React's
-	 * future-children contract.
+	 * listener-registry cost for fragments that never use the listener API.
+	 * Stored bindings apply only when a new direct child joins the fragment.
 	 */
 	_listeners: Array<{
 		type: string;
@@ -10849,8 +10856,8 @@ export class FragmentInstance {
 		options: AddEventListenerOptions | boolean | undefined;
 	}> | null;
 	/**
-	 * Observers registered via observeUsing, re-applied to future children the
-	 * same way as `_listeners`. `null` until the first observeUsing.
+	 * Observers registered via observeUsing. New direct children inherit each
+	 * observer; retained children are never redundantly observed on commit.
 	 */
 	_observers: Set<{ observe(target: Element): void; unobserve(target: Element): void }> | null;
 	/**
@@ -10865,113 +10872,157 @@ export class FragmentInstance {
 		this._startMarker = startMarker;
 		this._endMarker = endMarker;
 		this._destroyed = false;
+		this._children = new Set();
+		this._pendingChildren = new Set();
+		this._portalAnchors = null;
 		this._listeners = null;
 		this._observers = null;
 		this._currentRef = null;
+		for (const child of fragmentDirectNodes(this)) {
+			this._children.add(child);
+			this._attachChild(child);
+		}
+		activeFragments.add(this);
 	}
 
 	_destroy(): void {
 		this._destroyed = true;
 		activeFragments.delete(this);
-		// Detach any still-registered listeners from the current children (cleanups
-		// run before the DOM range is removed, so the children are still attached)
-		// so stale closures don't keep nodes/scopes alive after unmount. Observers
-		// are NOT explicitly unobserved — like React, we rely on the browser
-		// dropping disconnected nodes; the observer's owner manages its lifecycle.
-		if (this._listeners) {
-			for (const el of fragmentDirectChildren(this)) {
-				for (const e of this._listeners) {
-					el.removeEventListener(e.type, e.listener, e.options as any);
-				}
-			}
-			this._listeners = null;
-		}
+		// React removes listeners and fragment handles from disappearing children,
+		// but does not call observer.unobserve during deletion or fragment teardown.
+		for (const child of this._children) this._detachChild(child);
+		this._children.clear();
+		this._pendingChildren.clear();
+		this._portalAnchors?.clear();
+		this._portalAnchors = null;
+		this._listeners = null;
 		this._observers = null;
 	}
 
-	/** Deregister from the commit re-apply set once no bindings remain. */
-	_maybeDeactivate(): void {
-		if (
-			(this._listeners === null || this._listeners.length === 0) &&
-			(this._observers === null || this._observers.size === 0)
-		) {
-			activeFragments.delete(this);
+	/** Associate a foreign portal range with its authored following sibling. */
+	_registerPortal(portal: PortalSlot, anchor: Node): void {
+		if (this._destroyed) return;
+		const anchors = (this._portalAnchors ??= new Map());
+		let portals = anchors.get(anchor);
+		if (portals === undefined) anchors.set(anchor, (portals = new Set()));
+		portals.add(portal);
+	}
+
+	/** Forget a removed portal before its foreign DOM range is torn down. */
+	_unregisterPortal(portal: PortalSlot, anchor: Node): void {
+		const anchors = this._portalAnchors;
+		const portals = anchors?.get(anchor);
+		if (portals === undefined || !portals.delete(portal)) return;
+		if (portals.size === 0) anchors!.delete(anchor);
+		if (anchors!.size === 0) this._portalAnchors = null;
+		let child: ChildNode | null = portal.start?.nextSibling ?? null;
+		while (child !== null && child !== portal.end) {
+			const next = child.nextSibling;
+			if (
+				(child.nodeType === 1 || child.nodeType === 3) &&
+				this._children.delete(child as Element | Text)
+			) {
+				this._detachChild(child as Element | Text);
+			}
+			child = next;
 		}
 	}
 
+	/** Attach inherited bindings and publish this fragment's public DOM handle. */
+	_attachChild(child: Element | Text): void {
+		if (this._listeners !== null) {
+			for (const entry of this._listeners) {
+				child.addEventListener(entry.type, entry.listener, entry.options as any);
+			}
+		}
+		if (child.nodeType === 1 && this._observers !== null) {
+			for (const observer of this._observers) observer.observe(child as Element);
+		}
+		const host = child as (Element | Text) & { reactFragments?: Set<FragmentInstance> };
+		(host.reactFragments ??= new Set()).add(this);
+	}
+
+	/** Remove only this fragment's registrations; nested fragment handles stay. */
+	_detachChild(child: Element | Text): void {
+		if (this._listeners !== null) {
+			for (const entry of this._listeners) {
+				child.removeEventListener(entry.type, entry.listener, entry.options as any);
+			}
+		}
+		(child as (Element | Text) & { reactFragments?: Set<FragmentInstance> }).reactFragments?.delete(
+			this,
+		);
+	}
+
 	/**
-	 * Re-apply every stored listener + observer to the CURRENT direct children.
-	 * Run after each commit (reapplyFragmentBindings) so children that mounted
-	 * since the last pass pick up the fragment's bindings. addEventListener and
-	 * observer.observe are idempotent for an already-wired (element, binding)
-	 * pair, so re-applying is safe.
+	 * Diff current hosts after each commit. Reattaching a retained listener would
+	 * revive an exhausted `{ once: true }` registration; calling observe again is
+	 * also observable, so only newly inserted children inherit those bindings.
 	 */
 	_reapply(): void {
 		if (this._destroyed) return;
-		for (const el of fragmentDirectChildren(this)) {
-			if (this._listeners) {
-				for (const e of this._listeners) el.addEventListener(e.type, e.listener, e.options as any);
-			}
-			if (this._observers) {
-				for (const ob of this._observers) ob.observe(el);
-			}
+		const previous = this._children;
+		const current = this._pendingChildren;
+		for (const child of fragmentDirectNodes(this)) {
+			current.add(child);
+			if (!previous.has(child)) this._attachChild(child);
 		}
+		for (const child of previous) {
+			if (!current.has(child)) this._detachChild(child);
+		}
+		previous.clear();
+		this._children = current;
+		this._pendingChildren = previous;
 	}
 
 	// ─── focus / focusLast / blur (Stage 2) ─────────────────────────────
 	/**
-	 * Focus the first focusable element inside the fragment, in tree order.
-	 * Mirrors React FragmentInstance.focus: matches `<input>`, `<button>`,
-	 * `<select>`, `<textarea>`, `<a href>`, `[contenteditable="true"]`, and
-	 * anything with an explicit tabIndex >= 0. Skips disabled/hidden and
-	 * tabIndex=-1 elements. No-op if the fragment has no focusable descendants.
+	 * Focus the first element for which the browser actually accepts focus.
+	 * Listening for the focus event handles labels, shadow delegation, disabled
+	 * controls, and programmatically focusable tabIndex=-1 elements correctly.
 	 */
 	focus(options?: FocusOptions): void {
 		if (this._destroyed) return;
 		for (const el of fragmentDescendants(this)) {
-			if (isFocusable(el)) {
-				(el as HTMLElement).focus(options);
-				return;
-			}
+			if (focusFragmentElement(el, options)) return;
 		}
 	}
 
 	/**
-	 * Focus the LAST focusable element inside the fragment, in tree order.
-	 * Same focusability rules as `focus()`.
+	 * Focus the last programmatically focusable element, trying descendants in
+	 * reverse tree order until the browser accepts one.
 	 */
 	focusLast(options?: FocusOptions): void {
 		if (this._destroyed) return;
-		let last: Element | null = null;
-		for (const el of fragmentDescendants(this)) {
-			if (isFocusable(el)) last = el;
+		const descendants = Array.from(fragmentDescendants(this));
+		for (let i = descendants.length - 1; i >= 0; i--) {
+			if (focusFragmentElement(descendants[i], options)) return;
 		}
-		if (last) (last as HTMLElement).focus(options);
 	}
 
 	/**
-	 * Blur the currently-focused element if it's inside the fragment range.
-	 * No-op if focus is outside the fragment (matches React's "owned" scope —
-	 * we don't blur arbitrary other elements just because they happen to be
-	 * active when blur() is called).
+	 * Blur the focused element only when a logical fragment child owns it,
+	 * including children rendered into foreign portal containers.
 	 */
 	blur(): void {
 		if (this._destroyed) return;
 		const doc = this._startMarker.ownerDocument || document;
 		const active = doc.activeElement;
 		if (!active || active === doc.body) return;
-		if (isInsideFragment(this, active)) {
-			(active as HTMLElement).blur();
+		for (const child of fragmentDirectChildren(this)) {
+			if (child === active || child.contains(active)) {
+				(active as HTMLElement).blur();
+				return;
+			}
 		}
 	}
 
 	// ─── addEventListener / removeEventListener (Stage 3) ───────────────
 	/**
-	 * Attaches a listener to every DIRECT (host-Element) child of the fragment.
-	 * The (type, listener, capture) tuple is stored and RE-APPLIED after each
-	 * commit, so children inserted into the fragment LATER also get the listener
-	 * — React's future-children contract. Deduped by (type, listener, capture)
-	 * like the DOM, so repeat calls are no-ops.
+	 * Attaches a listener to every first-level Element or Text child.
+	 * The (type, listener, capture) tuple is stored so children inserted into
+	 * the fragment later inherit the listener. Deduped by that same tuple,
+	 * matching the DOM's listener identity rules.
 	 */
 	addEventListener(
 		type: string,
@@ -10991,10 +11042,9 @@ export class FragmentInstance {
 			}
 		}
 		this._listeners.push({ type, listener, options });
-		for (const el of fragmentDirectChildren(this)) {
-			el.addEventListener(type, listener, options as any);
+		for (const child of fragmentDirectNodes(this)) {
+			child.addEventListener(type, listener, options as any);
 		}
-		activeFragments.add(this);
 	}
 
 	/**
@@ -11016,11 +11066,10 @@ export class FragmentInstance {
 			if (entry.type !== type) continue;
 			if (entry.listener !== listener) continue;
 			if (listenerCapturePhase(entry.options) !== wantCapture) continue;
-			for (const el of fragmentDirectChildren(this)) {
-				el.removeEventListener(type, listener, entry.options as any);
+			for (const child of fragmentDirectNodes(this)) {
+				child.removeEventListener(type, listener, entry.options as any);
 			}
 			this._listeners.splice(i, 1);
-			this._maybeDeactivate();
 			return;
 		}
 	}
@@ -11038,131 +11087,238 @@ export class FragmentInstance {
 		unobserve(target: Element): void;
 	}): void {
 		if (this._destroyed) return;
+		if (process.env.NODE_ENV !== 'production') {
+			let hasText = false;
+			let hasElement = false;
+			for (const child of this._children) {
+				if (child.nodeType === 1) {
+					hasElement = true;
+					break;
+				}
+				if (child.nodeType === 3) hasText = true;
+			}
+			if (hasText && !hasElement) {
+				console.error(
+					'observeUsing() was called on a FragmentInstance with only text children. ' +
+						'Observers do not work on text nodes.',
+				);
+			}
+		}
 		if (!this._observers) this._observers = new Set();
 		this._observers.add(observer);
 		for (const el of fragmentDirectChildren(this)) observer.observe(el);
-		activeFragments.add(this);
 	}
 
 	/**
 	 * Stops observing with the given observer: unobserves the current children
-	 * and stops re-applying it to future ones. (The walk runs even without a
-	 * preceding observeUsing, matching the DOM's tolerant unobserve.)
+	 * and stops applying it to future ones. An unregistered observer is not
+	 * touched and produces React's diagnostic in development.
 	 */
 	unobserveUsing(observer: {
 		observe(target: Element): void;
 		unobserve(target: Element): void;
 	}): void {
 		if (this._destroyed) return;
-		if (this._observers) this._observers.delete(observer);
+		if (this._observers === null || !this._observers.has(observer)) {
+			if (process.env.NODE_ENV !== 'production') {
+				console.error(
+					'You are calling unobserveUsing() with an observer that is not being observed with this fragment ' +
+						'instance. First attach the observer with observeUsing()',
+				);
+			}
+			return;
+		}
+		this._observers.delete(observer);
 		for (const el of fragmentDirectChildren(this)) observer.unobserve(el);
-		this._maybeDeactivate();
 	}
 
 	/**
-	 * Concatenates the client rects of every direct fragment child. The
-	 * returned array is a flat list of DOMRects in tree order — useful for
-	 * tooltip positioning that needs to span multiple sibling elements.
-	 * After unmount returns [].
+	 * Concatenates direct host-element and text-node rectangles in logical tree
+	 * order. Text uses Range because Text does not expose getClientRects itself.
 	 */
 	getClientRects(): DOMRect[] {
 		const out: DOMRect[] = [];
 		if (this._destroyed) return out;
-		let node: ChildNode | null = this._startMarker.nextSibling;
-		while (node && node !== this._endMarker) {
-			if (node.nodeType === 1) {
+		for (const node of fragmentDirectNodes(this)) {
+			if (node.nodeType === 3) {
+				const range = node.ownerDocument.createRange();
+				range.selectNodeContents(node);
+				// Lightweight DOM environments do not implement Range geometry.
+				if (typeof range.getClientRects !== 'function') continue;
+				const rects = range.getClientRects();
+				for (let i = 0; i < rects.length; i++) out.push(rects[i]);
+			} else {
 				const rects = (node as Element).getClientRects();
 				for (let i = 0; i < rects.length; i++) out.push(rects[i]);
 			}
-			node = node.nextSibling;
 		}
 		return out;
 	}
 
 	/**
-	 * Returns the rootNode of the fragment (its document or shadow root).
-	 * Falls back to the start-marker's owner document if the fragment has
-	 * no direct children yet — keeps the contract "always returns a Node"
-	 * so callers don't need null-checks.
+	 * Resolve the owning host parent's root, forwarding composed shadow-root
+	 * options. A detached FragmentInstance is its own root, matching React.
 	 */
-	getRootNode(): Node {
-		if (this._destroyed) return this._startMarker.getRootNode();
-		let node: ChildNode | null = this._startMarker.nextSibling;
-		while (node && node !== this._endMarker) {
-			if (node.nodeType === 1) return (node as Element).getRootNode();
-			node = node.nextSibling;
-		}
-		return this._startMarker.getRootNode();
+	getRootNode(options?: GetRootNodeOptions): Node | FragmentInstance {
+		if (this._destroyed) return this;
+		const parent = this._startMarker.parentNode;
+		return parent === null ? this : parent.getRootNode(options);
 	}
 
 	// ─── compareDocumentPosition / dispatchEvent (Stage 5) ──────────────
 	/**
-	 * Compares `other` against the fragment's span. The returned bitmask
-	 * uses the same Node constants the platform's compareDocumentPosition
-	 * uses, with `CONTAINED_BY` indicating that `other` lives strictly
-	 * between the fragment's start and end markers (in document order).
-	 *
-	 *   - other before the start marker     → DOCUMENT_POSITION_PRECEDING
-	 *   - other after the end marker        → DOCUMENT_POSITION_FOLLOWING
-	 *   - other between start & end markers → DOCUMENT_POSITION_CONTAINED_BY |
-	 *                                          DOCUMENT_POSITION_FOLLOWING
-	 *   - other not in the same tree        → DOCUMENT_POSITION_DISCONNECTED
+	 * Preserve the platform's directional/ancestor bits while returning exact
+	 * CONTAINED_BY for logical children. Empty ranges have no DOM position of
+	 * their own, so their derived result is IMPLEMENTATION_SPECIFIC.
 	 */
 	compareDocumentPosition(other: Node): number {
 		if (this._destroyed) return Node.DOCUMENT_POSITION_DISCONNECTED;
-		const startRel = this._startMarker.compareDocumentPosition(other);
-		if (startRel & Node.DOCUMENT_POSITION_DISCONNECTED) return startRel;
-		const endRel = this._endMarker.compareDocumentPosition(other);
-		const followsStart = (startRel & Node.DOCUMENT_POSITION_FOLLOWING) !== 0;
-		const precedesEnd = (endRel & Node.DOCUMENT_POSITION_PRECEDING) !== 0;
-		if (followsStart && precedesEnd) {
-			return Node.DOCUMENT_POSITION_CONTAINED_BY | Node.DOCUMENT_POSITION_FOLLOWING;
+		const parent = this._startMarker.parentNode;
+		if (parent === null) return Node.DOCUMENT_POSITION_DISCONNECTED;
+
+		let first: Element | Text | null = null;
+		let last: Element | Text | null = null;
+		for (const child of fragmentDirectNodes(this)) {
+			first ??= child;
+			last = child;
+			if (child === other || (child.nodeType === 1 && (child as Element).contains(other))) {
+				return parent.contains(child)
+					? Node.DOCUMENT_POSITION_CONTAINED_BY
+					: Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC;
+			}
 		}
-		if (startRel & Node.DOCUMENT_POSITION_PRECEDING) {
-			return Node.DOCUMENT_POSITION_PRECEDING;
+
+		if (first === null || last === null) {
+			// A Fragment rendered directly inside a portal has a physical parent
+			// in the foreign container, but its ordering is relative to the portal's
+			// authored host. Portal mounting stamps that logical host on its direct
+			// children, including this Fragment's boundary comment.
+			const logicalParent =
+				(this._startMarker as Comment & { $$portalParent?: Node }).$$portalParent ?? parent;
+			let result = logicalParent.compareDocumentPosition(other);
+			if (logicalParent === other) {
+				result = Node.DOCUMENT_POSITION_CONTAINS;
+			} else if ((result & Node.DOCUMENT_POSITION_CONTAINED_BY) !== 0) {
+				const next = fragmentNearestSibling(this._endMarker, true);
+				result =
+					next !== null &&
+					(next === other ||
+						(next.compareDocumentPosition(other) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0)
+						? Node.DOCUMENT_POSITION_FOLLOWING
+						: Node.DOCUMENT_POSITION_PRECEDING;
+			}
+			return result | Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC;
 		}
-		return Node.DOCUMENT_POSITION_FOLLOWING;
+
+		const firstResult = first.compareDocumentPosition(other);
+		if ((firstResult & Node.DOCUMENT_POSITION_DISCONNECTED) !== 0) return firstResult;
+		const lastResult = last.compareDocumentPosition(other);
+		if (
+			parent.contains(first) &&
+			parent.contains(last) &&
+			(firstResult & Node.DOCUMENT_POSITION_FOLLOWING) !== 0 &&
+			(lastResult & Node.DOCUMENT_POSITION_PRECEDING) !== 0
+		) {
+			return Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC;
+		}
+		// A portal moves its entire Fragment outside the authored host. A node
+		// still inside that host cannot have a trustworthy DOM position relative
+		// to the Fragment's foreign range, so React reports a logical-tree/DOM
+		// mismatch instead of leaking the foreign container's document order.
+		const portalMarker = this._startMarker as Comment & {
+			$$portalParent?: Node;
+			$$portalSourceAnchor?: Node;
+		};
+		const logicalParent = portalMarker.$$portalParent;
+		if (logicalParent !== undefined && logicalParent !== parent && logicalParent.contains(other)) {
+			const sourceAnchor = portalMarker.$$portalSourceAnchor;
+			if (sourceAnchor === undefined) return Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC;
+			const directionMask = Node.DOCUMENT_POSITION_PRECEDING | Node.DOCUMENT_POSITION_FOLLOWING;
+			const logicalDirection = sourceAnchor.compareDocumentPosition(other) & directionMask;
+			if ((firstResult & directionMask) !== logicalDirection) {
+				return Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC;
+			}
+		}
+		return firstResult;
 	}
 
 	/**
-	 * Dispatches `event` on the fragment's parent host element so the
-	 * event bubbles into the surrounding handler tree the way native
-	 * EventTarget.dispatchEvent does. Mirrors React's FragmentInstance:
-	 * because the fragment itself has no DOM node, the dispatch target is
-	 * the parent (`return.stateNode` in React's fiber model).
-	 *
-	 * Returns false if the event's default action was cancelled — matches
-	 * EventTarget.dispatchEvent's return contract so callers can branch
-	 * on preventDefault() like they would on any other DOM dispatch.
+	 * Dispatch bubbling events directly on the parent unless fragment listeners
+	 * or a non-bubbling event require React's temporary fragment-local target.
 	 */
 	dispatchEvent(event: Event): boolean {
 		if (this._destroyed) return true;
 		const parent = this._startMarker.parentNode;
 		if (!parent) return true;
-		return (parent as unknown as EventTarget).dispatchEvent(event);
+		const listeners = this._listeners;
+		if (event.bubbles && (listeners === null || listeners.length === 0)) {
+			return parent.dispatchEvent(event);
+		}
+
+		const target = (parent.ownerDocument || document).createTextNode('');
+		if (listeners !== null) {
+			for (const entry of listeners) {
+				target.addEventListener(entry.type, entry.listener, entry.options);
+			}
+		}
+		parent.appendChild(target);
+		try {
+			return target.dispatchEvent(event);
+		} finally {
+			if (listeners !== null) {
+				for (const entry of listeners) {
+					target.removeEventListener(entry.type, entry.listener, entry.options);
+				}
+			}
+			if (target.parentNode === parent) parent.removeChild(target);
+		}
 	}
 
 	// ─── scrollIntoView (Stage 6) ───────────────────────────────────────
 	/**
-	 * Scrolls the fragment into view. Picks the first focusable descendant
-	 * if one exists (matches what tab-focus would land on), falling back to
-	 * the first element child otherwise. Mirrors React's FragmentInstance
-	 * choice — for tooltip / anchor-scroll use cases the "natural target"
-	 * is usually a focusable element, not an arbitrary wrapper div.
+	 * Scroll every logical first-level host child so the final scroll position
+	 * settles on the first child by default, or the last child for `false`.
+	 * Empty fragments use their nearest sibling, then their host parent.
 	 */
-	scrollIntoView(arg?: boolean | ScrollIntoViewOptions): void {
-		if (this._destroyed) return;
-		let firstFocusable: Element | null = null;
-		let firstAny: Element | null = null;
-		for (const el of fragmentDescendants(this)) {
-			if (!firstAny) firstAny = el;
-			if (isFocusable(el)) {
-				firstFocusable = el;
-				break;
-			}
+	scrollIntoView(alignToTop?: boolean): void {
+		if (typeof alignToTop === 'object') {
+			throw new Error(
+				'FragmentInstance.scrollIntoView() does not support scrollIntoViewOptions. ' +
+					'Use the alignToTop boolean instead.',
+			);
 		}
-		const target = firstFocusable || firstAny;
-		if (target) (target as HTMLElement).scrollIntoView(arg as any);
+		if (this._destroyed) return;
+		const alignStart = alignToTop !== false;
+		const children = Array.from(fragmentDirectNodes(this));
+		if (children.length === 0) {
+			const following = fragmentNearestSibling(this._endMarker, true);
+			const preceding = fragmentNearestSibling(this._startMarker, false);
+			const target = alignStart
+				? following || preceding || this._startMarker.parentNode
+				: preceding || following;
+			if (target === null || target === undefined || target.nodeType === 9) return;
+			if (target.nodeType === 11) {
+				const host = (target as ShadowRoot).host;
+				if (host) host.scrollIntoView(alignToTop);
+				return;
+			}
+			if (target.nodeType === 3) {
+				scrollFragmentTextNode(target as Text, alignStart);
+			} else {
+				(target as Element).scrollIntoView(alignToTop);
+			}
+			return;
+		}
+
+		for (
+			let index = alignStart ? children.length - 1 : 0;
+			alignStart ? index >= 0 : index < children.length;
+			index += alignStart ? -1 : 1
+		) {
+			const child = children[index];
+			if (child.nodeType === 3) scrollFragmentTextNode(child as Text, alignStart);
+			else (child as Element).scrollIntoView(alignToTop);
+		}
 	}
 }
 
@@ -11178,83 +11334,108 @@ function listenerCapturePhase(o: AddEventListenerOptions | boolean | undefined):
 }
 
 /**
- * Walk every Element strictly between the start and end markers of the
- * fragment, in document (tree) order. Uses a TreeWalker rooted at each
- * top-level child between the markers so the iteration is O(n) over the
- * fragment's subtree (not the whole document). Comment / Text nodes are
- * skipped — fragment ref methods only care about Elements.
+ * Yield first-level authored host nodes in logical order. Comment boundaries
+ * are implementation details; text remains observable to fragment geometry.
  */
-function* fragmentDescendants(fi: FragmentInstance): Generator<Element> {
+function* fragmentDirectNodes(fi: FragmentInstance): Generator<Element | Text> {
+	const portalAnchors = fi._portalAnchors;
 	let node: ChildNode | null = fi._startMarker.nextSibling;
-	while (node && node !== fi._endMarker) {
+	while (node !== null) {
 		const next = node.nextSibling;
-		if (node.nodeType === 1) {
-			const top = node as Element;
-			yield top;
-			// SHOW_ELEMENT (filter 1) keeps us off Text/Comment.
-			const walker = (top.ownerDocument || document).createTreeWalker(top, 1);
-			let descendant = walker.nextNode() as Element | null;
-			while (descendant) {
-				yield descendant;
-				descendant = walker.nextNode() as Element | null;
+		const portals = portalAnchors === null ? undefined : portalAnchors.get(node);
+		if (portals !== undefined) {
+			// A portal containing a Fragment ref may grow around a later independent
+			// portal targeting the same container. Empty entries identify those
+			// foreign ranges without changing the ordinary direct-child fast path.
+			if (portals.size === 0) {
+				const foreignEnd = (node as any).$$portalEnd as Node | undefined;
+				if (foreignEnd !== undefined) {
+					node = nodeAfterPortalRange(node, foreignEnd) as ChildNode | null;
+					continue;
+				}
 			}
+			for (const portal of portals) {
+				// Portals are physically outside Activity's hidden host range. Their
+				// logical Block ancestry, not their target DOM, determines visibility.
+				if (portal.block === null || findHiddenActivity(portal.block) !== null) continue;
+				let child: ChildNode | null = portal.start?.nextSibling ?? null;
+				while (child !== null && child !== portal.end) {
+					const nextChild = child.nextSibling;
+					if ((child.nodeType === 1 || child.nodeType === 3) && fragmentHostVisible(child)) {
+						yield child as Element | Text;
+					}
+					child = nextChild;
+				}
+			}
+		}
+		if (node === fi._endMarker) return;
+		if ((node.nodeType === 1 || node.nodeType === 3) && fragmentHostVisible(node)) {
+			yield node as Element | Text;
 		}
 		node = next;
 	}
 }
 
 /**
- * Yield the DIRECT (first-level) Element children between the fragment markers,
- * in document order. This is the membership set for the per-child operations
- * (event listeners, observers) — matching React's first-level traverse — as
- * opposed to fragmentDescendants which deep-walks (used by focus/scrollIntoView).
+ * First-level host elements are the membership set for fragment listeners,
+ * observers, and public `reactFragments` handles.
  */
 function* fragmentDirectChildren(fi: FragmentInstance): Generator<Element> {
-	let node: ChildNode | null = fi._startMarker.nextSibling;
-	while (node && node !== fi._endMarker) {
-		const next = node.nextSibling;
+	for (const node of fragmentDirectNodes(fi)) {
 		if (node.nodeType === 1) yield node as Element;
-		node = next;
 	}
 }
 
-/**
- * Is `node` strictly between the fragment's start and end markers in
- * document order? Uses compareDocumentPosition so the check works for
- * arbitrary descendants — not just immediate children — and returns false
- * for detached / unrelated nodes (which is what blur containment expects).
- */
-function isInsideFragment(fi: FragmentInstance, node: Node): boolean {
-	const startRel = fi._startMarker.compareDocumentPosition(node);
-	const endRel = fi._endMarker.compareDocumentPosition(node);
-	const followsStart = (startRel & Node.DOCUMENT_POSITION_FOLLOWING) !== 0;
-	const precedesEnd = (endRel & Node.DOCUMENT_POSITION_PRECEDING) !== 0;
-	return followsStart && precedesEnd;
+/** Deep-walk each first-level host subtree without scanning the entire document. */
+function* fragmentDescendants(fi: FragmentInstance): Generator<Element> {
+	for (const top of fragmentDirectChildren(fi)) {
+		yield top;
+		const walker = (top.ownerDocument || document).createTreeWalker(top, 1);
+		let descendant = walker.nextNode() as Element | null;
+		while (descendant) {
+			yield descendant;
+			descendant = walker.nextNode() as Element | null;
+		}
+	}
 }
 
-/**
- * Mirrors the focusability check React's FragmentInstance uses:
- *  - inherently-focusable tags: <input>, <select>, <textarea>, <button>
- *    (not disabled), <a> (with href).
- *  - explicit tabIndex >= 0 OR contenteditable="true" on any tag.
- *  - tabIndex === -1 → not in sequential order, NOT picked by focus() /
- *    focusLast(). (Still focusable via .focus() directly — we just skip
- *    them when walking, matching React's behavior.)
- *  - hidden / disabled → never focusable.
- */
-function isFocusable(el: Element): boolean {
-	if ((el as HTMLElement).hidden === true) return false;
-	const tabAttr = el.getAttribute('tabindex');
-	const explicitTab = tabAttr === null ? null : parseInt(tabAttr, 10);
-	if (explicitTab !== null && explicitTab < 0) return false;
-	const tag = el.tagName;
-	if (tag === 'BUTTON' || tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA') {
-		return !(el as HTMLInputElement).disabled;
+/** Ask the DOM whether focusing succeeded, including delegated/redirected focus. */
+function focusFragmentElement(node: Element, options?: FocusOptions): boolean {
+	const element = node as HTMLElement;
+	const owner = element.ownerDocument;
+	if (owner.activeElement === element) return true;
+	let focused = false;
+	const onFocus = () => {
+		focused = true;
+	};
+	owner.addEventListener('focus', onFocus, true);
+	try {
+		(element.focus || HTMLElement.prototype.focus).call(element, options);
+	} finally {
+		owner.removeEventListener('focus', onFocus, true);
 	}
-	if (tag === 'A' && el.hasAttribute('href')) return true;
-	if (explicitTab !== null && explicitTab >= 0) return true;
-	if (el.getAttribute('contenteditable') === 'true') return true;
-	return false;
+	return focused;
+}
+
+/** Skip implementation-only markers when locating an empty fragment's host sibling. */
+function fragmentNearestSibling(marker: Node, forward: boolean): Element | Text | null {
+	let sibling = forward ? marker.nextSibling : marker.previousSibling;
+	while (sibling !== null) {
+		if (sibling.nodeType === 1 || sibling.nodeType === 3) return sibling as Element | Text;
+		sibling = forward ? sibling.nextSibling : sibling.previousSibling;
+	}
+	return null;
+}
+
+/** Text nodes expose geometry through Range rather than Element.scrollIntoView. */
+function scrollFragmentTextNode(node: Text, alignToTop: boolean): void {
+	const range = node.ownerDocument.createRange();
+	range.selectNodeContents(node);
+	if (typeof range.getBoundingClientRect !== 'function') return;
+	const rect = range.getBoundingClientRect();
+	const view = node.ownerDocument.defaultView || window;
+	const y = alignToTop ? view.scrollY + rect.top : view.scrollY + rect.bottom - view.innerHeight;
+	view.scrollTo(view.scrollX + rect.left, y);
 }
 
 /**
@@ -14650,6 +14831,10 @@ interface PortalSlot {
 	target: Element | null;
 	start: Comment | null;
 	end: Comment | null;
+	fragmentOwners?: FragmentInstance | readonly FragmentInstance[];
+	fragmentAnchor?: Node;
+	sourceAnchor?: Node;
+	interleavedFragment?: FragmentInstance;
 }
 
 /**
@@ -14668,8 +14853,19 @@ export function portal(
 	// Hoisted-helper env tuple (compiled-output Phase 2): the `__portal$N`
 	// body's captured parent locals — stamped as block.extra below.
 	env?: any[],
+	// Present only when this portal is a direct logical child of Fragment refs.
+	fragmentOwners?: FragmentInstance | readonly FragmentInstance[],
+	fragmentAnchor?: Node,
 ): void {
 	const prev = parentScope.slots[slotKey] as PortalSlot | undefined;
+	if (
+		fragmentAnchor !== undefined &&
+		fragmentOwners === undefined &&
+		prev !== undefined &&
+		prev.target === target
+	) {
+		prepareFragmentPortalInterleaving(prev);
+	}
 	const state = renderPortalState(
 		prev ?? null,
 		parentScope.block,
@@ -14687,6 +14883,198 @@ export function portal(
 	if (prev !== state) {
 		parentScope.slots[slotKey] = state;
 		registerSlot(parentScope, state);
+	}
+	if (fragmentOwners !== undefined && fragmentAnchor !== undefined) {
+		registerFragmentPortalOwners(state, fragmentOwners, fragmentAnchor);
+	} else if (fragmentAnchor !== undefined) {
+		// A Fragment ref rendered inside this portal belongs to its source-tree
+		// position, not the foreign target's physical position. Only the rare
+		// compiler-normalized root portal passes this ownerless source anchor.
+		state.sourceAnchor = fragmentAnchor;
+		let child: ChildNode | null = state.start!.nextSibling;
+		while (child !== null && child !== state.end) {
+			if (child.nodeType === 8) {
+				const foreignEnd = (child as any).$$portalEnd as Node | undefined;
+				if (foreignEnd !== undefined) {
+					child = nodeAfterPortalRange(child, foreignEnd) as ChildNode | null;
+					continue;
+				}
+				(child as any).$$portalSourceAnchor = fragmentAnchor;
+			}
+			child = child.nextSibling;
+		}
+	}
+}
+
+/**
+ * Match React's append-to-container semantics for the narrow case where a
+ * portal-root Fragment gains a trailing child after another portal mounted in
+ * the same target. Keep foreign ranges inside the owner's markers temporarily;
+ * a cold cleanup evacuates them before its ordinary contiguous-range teardown.
+ */
+function prepareFragmentPortalInterleaving(portal: PortalSlot): void {
+	const start = portal.start;
+	const end = portal.end;
+	const target = portal.target;
+	const block = portal.block;
+	if (start === null || end === null || target === null || block === null) return;
+	const firstForeign = end.nextSibling;
+	if (firstForeign === null || (firstForeign as any).$$portalEnd === undefined) return;
+
+	let fragment = portal.interleavedFragment;
+	if (fragment === undefined) {
+		for (const candidate of activeFragments) {
+			if (
+				candidate._ownerBlock === block &&
+				candidate._startMarker.previousSibling === start &&
+				candidate._endMarker.nextSibling === end
+			) {
+				fragment = candidate;
+				break;
+			}
+		}
+		if (fragment === undefined) return;
+	}
+
+	let lastChild: Element | Text | null = null;
+	for (const child of fragmentDirectNodes(fragment)) lastChild = child;
+	const tail = lastChild === null ? fragment._startMarker.nextSibling : lastChild.nextSibling;
+	if (tail === null || tail === end) return;
+	for (let node: ChildNode | null = tail; node !== end; node = node.nextSibling) {
+		if (node === null || node.nodeType !== 8) return;
+	}
+
+	const foreignStarts: Node[] = [];
+	let after: ChildNode | null = firstForeign;
+	while (after !== null) {
+		const foreignEnd = (after as any).$$portalEnd as Node | undefined;
+		if (foreignEnd === undefined || foreignEnd.parentNode !== target) break;
+		foreignStarts.push(after);
+		after = foreignEnd.nextSibling;
+	}
+	if (foreignStarts.length === 0) return;
+
+	let cursor: ChildNode | null = tail;
+	while (cursor !== null) {
+		const next: ChildNode | null = cursor.nextSibling;
+		target.insertBefore(cursor, after);
+		if (cursor === end) break;
+		cursor = next;
+	}
+
+	const anchors = (fragment._portalAnchors ??= new Map());
+	for (const foreignStart of foreignStarts) anchors.set(foreignStart, new Set());
+	if (portal.interleavedFragment === undefined) {
+		portal.interleavedFragment = fragment;
+		(block.cleanups ??= []).push(() => evacuateInterleavedPortalRanges(portal));
+	}
+}
+
+/** Move independent nested portal ranges outside their temporary owner. */
+function evacuateInterleavedPortalRanges(portal: PortalSlot): void {
+	const start = portal.start;
+	const end = portal.end;
+	const target = portal.target;
+	if (start === null || end === null || target === null || end.parentNode !== target) return;
+	const destination = end.nextSibling;
+	let node: ChildNode | null = start.nextSibling;
+	while (node !== null && node !== end) {
+		const foreignEnd = (node as any).$$portalEnd as Node | undefined;
+		if (foreignEnd === undefined || foreignEnd.parentNode !== target) {
+			node = node.nextSibling;
+			continue;
+		}
+		const following = foreignEnd.nextSibling;
+		let cursor: Node | null = node;
+		while (cursor !== null) {
+			const next: Node | null = cursor.nextSibling;
+			target.insertBefore(cursor, destination);
+			if (cursor === foreignEnd) break;
+			cursor = next;
+		}
+		node = following;
+	}
+}
+
+function registerFragmentPortalOwners(
+	portal: PortalSlot,
+	owners: FragmentInstance | readonly FragmentInstance[],
+	anchor: Node,
+): void {
+	const previous = portal.fragmentOwners;
+	if (previous !== undefined) {
+		if (portal.fragmentAnchor === anchor) {
+			if (!Array.isArray(previous) && !Array.isArray(owners) && previous === owners) return;
+			if (Array.isArray(previous) && Array.isArray(owners) && previous.length === owners.length) {
+				let sameOwners = true;
+				for (let index = 0; index < previous.length; index++) {
+					if (previous[index] !== owners[index]) {
+						sameOwners = false;
+						break;
+					}
+				}
+				if (sameOwners) return;
+			}
+		}
+		unregisterFragmentPortalOwners(portal);
+	}
+	portal.fragmentOwners = owners;
+	portal.fragmentAnchor = anchor;
+	if (Array.isArray(owners)) {
+		for (const owner of owners) owner._registerPortal(portal, anchor);
+	} else {
+		(owners as FragmentInstance)._registerPortal(portal, anchor);
+	}
+	if (previous === undefined) {
+		(portal.block!.cleanups ??= []).push(() => unregisterFragmentPortalOwners(portal));
+	}
+}
+
+function unregisterFragmentPortalOwners(portal: PortalSlot): void {
+	const owners = portal.fragmentOwners;
+	const anchor = portal.fragmentAnchor;
+	if (owners === undefined || anchor === undefined) return;
+	portal.fragmentOwners = undefined;
+	portal.fragmentAnchor = undefined;
+	if (Array.isArray(owners)) {
+		for (const owner of owners) owner._unregisterPortal(portal, anchor);
+	} else {
+		(owners as FragmentInstance)._unregisterPortal(portal, anchor);
+	}
+}
+
+/** Infer owner refs for a value-position portal from its stable source anchor. */
+function registerValuePortalFragmentOwners(
+	portal: PortalSlot,
+	parentBlock: Block,
+	anchor: Node,
+): void {
+	let firstOwner: FragmentInstance | null = null;
+	let nestedOwners: FragmentInstance[] | null = null;
+	for (const fragment of activeFragments) {
+		const owner = fragment._ownerBlock;
+		if (owner !== parentBlock && !blockIsAncestorOf(owner, parentBlock)) continue;
+		if (fragment._startMarker.parentNode !== anchor.parentNode) continue;
+		if (
+			(fragment._startMarker.compareDocumentPosition(anchor) & Node.DOCUMENT_POSITION_FOLLOWING) ===
+			0
+		) {
+			continue;
+		}
+		if (
+			(fragment._endMarker.compareDocumentPosition(anchor) & Node.DOCUMENT_POSITION_PRECEDING) ===
+			0
+		) {
+			continue;
+		}
+		if (firstOwner === null) {
+			firstOwner = fragment;
+		} else {
+			(nestedOwners ??= [firstOwner]).push(fragment);
+		}
+	}
+	if (firstOwner !== null) {
+		registerFragmentPortalOwners(portal, nestedOwners ?? firstOwner, anchor);
 	}
 }
 
@@ -14767,9 +15155,21 @@ function renderPortalState(
 	// continuing into the portal target's natural ancestors — mirroring React's
 	// per-fiber portal walk so a click inside a modal bubbles up the logical tree.
 	let n: ChildNode | null = state.start!.nextSibling;
-	while (n !== null && n !== state.end) {
-		(n as any).$$portalParent = host;
-		n = n.nextSibling;
+	if (state.interleavedFragment === undefined) {
+		while (n !== null && n !== state.end) {
+			(n as any).$$portalParent = host;
+			n = n.nextSibling;
+		}
+	} else {
+		while (n !== null && n !== state.end) {
+			const foreignEnd = (n as any).$$portalEnd as Node | undefined;
+			if (foreignEnd !== undefined) {
+				n = nodeAfterPortalRange(n, foreignEnd) as ChildNode | null;
+				continue;
+			}
+			(n as any).$$portalParent = host;
+			n = n.nextSibling;
+		}
 	}
 	return state;
 }
@@ -16758,6 +17158,62 @@ function fragmentDescriptorChildren(value: ElementDescriptor): any[] {
 	return Array.isArray(children) ? children : [children];
 }
 
+/** Preserve a ref-bearing public Fragment descriptor as a real lifecycle boundary. */
+function fragmentRefDescriptor(value: ElementDescriptor): ElementDescriptor<ElementDescriptor> {
+	return {
+		$$kind: ELEMENT_TAG,
+		type: renderFragmentRefDescriptor,
+		props: value,
+		key: value.key,
+		ref: null,
+		children: null,
+	};
+}
+
+/** Cold component body used only by `createElement(Fragment, { ref }, ...)`. */
+function renderFragmentRefDescriptor(descriptor: ElementDescriptor, scope: Scope): void {
+	const block = scope.block;
+	let instance = block.slots[1] as FragmentInstance | undefined;
+	if (instance === undefined) {
+		const hydration = activeHydration();
+		let start: Comment;
+		let end: Comment;
+		const opening = hydration?.node;
+		if (opening?.nodeType === 8 && (opening as Comment).data === 'frag') {
+			start = opening as Comment;
+			let depth = 1;
+			let cursor: Node | null = start.nextSibling;
+			while (cursor !== null) {
+				if (cursor.nodeType === 8) {
+					if ((cursor as Comment).data === 'frag') depth++;
+					else if ((cursor as Comment).data === '/frag' && --depth === 0) break;
+				}
+				cursor = cursor.nextSibling;
+			}
+			if (cursor === null) throw new Error('Unclosed server-rendered Fragment descriptor.');
+			end = cursor as Comment;
+			hydration!.node = start.nextSibling;
+		} else {
+			start = document.createComment('frag');
+			end = document.createComment('/frag');
+			block.parentNode.insertBefore(start, block.endMarker);
+			block.parentNode.insertBefore(end, block.endMarker);
+		}
+		instance = mountFragmentRef(scope, start, end, descriptor.ref);
+		block.slots[0] = { a: instance };
+		block.slots[1] = instance;
+		block.refFields = ['f', 'a', ''];
+	} else if (instance._currentRef !== descriptor.ref) {
+		if (instance._currentRef != null) queueRefDetach(instance._currentRef, instance);
+		if (descriptor.ref != null) queueRefAttach(scope, descriptor.ref, instance);
+		instance._currentRef = descriptor.ref;
+	}
+
+	childSlot(scope, 2, block.parentNode, descriptor.children, instance._endMarker);
+	const hydration = activeHydration();
+	if (hydration !== null) hydration.node = instance._endMarker.nextSibling;
+}
+
 function deoptWrapperKind(value: any[]): DeoptWrapperKind {
 	return POSITIONAL_CHILDREN.has(value as object) ? 'fragment' : 'array';
 }
@@ -16804,6 +17260,11 @@ function flattenReactChildContainer(
 	for (let i = 0; i < count; i++) {
 		const item = children[i];
 		if (isFragmentDescriptor(item)) {
+			if (item.ref != null || hasOwnProp.call(item.props, 'ref')) {
+				outItems.push(fragmentRefDescriptor(item));
+				outKeys.push(scopedDeoptKey(path, item, i, keyFn(item, i)));
+				continue;
+			}
 			const nested = fragmentDescriptorChildren(item);
 			if (item.key != null) {
 				flattenReactChildContainer(outItems, outKeys, nested, 'fragment', [
@@ -16847,6 +17308,12 @@ function prepareDeoptList(
 	// non-list answer (a lone component descriptor, text, null) is the common one
 	// — build the two output arrays only once a list regime is established.
 	if (isFragmentDescriptor(value)) {
+		if (value.ref != null || hasOwnProp.call(value.props, 'ref')) {
+			return {
+				items: [fragmentRefDescriptor(value)],
+				keys: [scopedDeoptKey([], value, 0, value.key ?? 0)],
+			};
+		}
 		const items: any[] = [];
 		const keys: any[] = [];
 		const path = value.key == null ? [] : ['keyed-fragment', value.key];
@@ -18294,6 +18761,12 @@ export function childSlot(
 			// The DOM element containing this hole is the portal's logical parent.
 			domParent,
 		);
+		// Conditional portals and portals inside directive helpers use childSlot
+		// rather than the compiler's direct portal helper. Their retained end anchor
+		// still locates the authored position inside any enclosing Fragment refs.
+		if (activeFragments.size !== 0 && state.end !== null) {
+			registerValuePortalFragmentOwners(state.portal, parentBlock, state.end);
+		}
 		return;
 	}
 
@@ -19545,6 +20018,33 @@ interface SuspenseHiddenDom {
 // restore it only after the last owner reveals, independent of hide/reveal order.
 const HIDDEN_DISPLAYS = new WeakMap<HTMLElement, HiddenDisplay>();
 const HIDDEN_TEXTS = new WeakMap<Text, HiddenText>();
+let HIDDEN_ACTIVITY_NODES: WeakMap<Node, number> | null = null;
+let hiddenActivityNodeOwners = 0;
+
+function retainHiddenActivityNode(node: Node): void {
+	const hidden = (HIDDEN_ACTIVITY_NODES ??= new WeakMap<Node, number>());
+	hidden.set(node, (hidden.get(node) ?? 0) + 1);
+	hiddenActivityNodeOwners++;
+}
+
+function releaseHiddenActivityNode(node: Node): void {
+	const hidden = HIDDEN_ACTIVITY_NODES;
+	const owners = hidden?.get(node);
+	if (owners === undefined) return;
+	if (owners === 1) hidden!.delete(node);
+	else hidden!.set(node, owners - 1);
+	hiddenActivityNodeOwners--;
+}
+
+/** Activity hides exclude their preserved hosts from every Fragment-ref API. */
+function fragmentHostVisible(node: Node): boolean {
+	if (hiddenActivityNodeOwners === 0) return true;
+	const hidden = HIDDEN_ACTIVITY_NODES!;
+	for (let current: Node | null = node; current !== null; current = current.parentNode) {
+		if (hidden.has(current)) return false;
+	}
+	return true;
+}
 
 function enforceHiddenDisplay(el: HTMLElement): void {
 	const hidden = HIDDEN_DISPLAYS.get(el);
@@ -22902,6 +23402,8 @@ interface ActivitySlot {
 	__kind: 'activityBlockSlot';
 	block: Block | null;
 	hidden: boolean;
+	/** Hidden-host ownership is released even when a hidden Activity unmounts. */
+	fragmentVisibilityCleanupRegistered: boolean;
 	/** Invalidates a queued visible→hidden commit when a newer render wins. */
 	commitVersion: number;
 	/** The visible effects still need their commit-phase deactivation. */
@@ -22925,18 +23427,27 @@ interface ActivitySlot {
 function hideActivityRange(state: ActivitySlot): void {
 	const b = state.block;
 	if (!b) return;
+	if (!state.fragmentVisibilityCleanupRegistered) {
+		state.fragmentVisibilityCleanupRegistered = true;
+		(b.cleanups ??= []).push(() => {
+			for (const el of state.hiddenDisplays) releaseHiddenActivityNode(el);
+			for (const text of state.hiddenTexts) releaseHiddenActivityNode(text);
+		});
+	}
 	// Branch switches and HMR can replace direct roots while the Activity stays
 	// hidden. Drop detached entries now so a long-hidden, frequently updated
 	// boundary does not retain every outgoing host node until it reveals.
 	for (const el of state.hiddenDisplays) {
 		if (el.parentNode !== b.parentNode) {
 			state.hiddenDisplays.delete(el);
+			releaseHiddenActivityNode(el);
 			releaseHiddenDisplay(el, false);
 		}
 	}
 	for (const text of state.hiddenTexts) {
 		if (text.parentNode !== b.parentNode) {
 			state.hiddenTexts.delete(text);
+			releaseHiddenActivityNode(text);
 			releaseHiddenText(text);
 		}
 	}
@@ -22946,6 +23457,7 @@ function hideActivityRange(state: ActivitySlot): void {
 			const el = node as HTMLElement;
 			if (!state.hiddenDisplays.has(el)) {
 				state.hiddenDisplays.add(el);
+				retainHiddenActivityNode(el);
 				retainHiddenDisplay(el, false);
 			} else {
 				enforceHiddenDisplay(el);
@@ -22954,6 +23466,7 @@ function hideActivityRange(state: ActivitySlot): void {
 			const t = node as Text;
 			if (!state.hiddenTexts.has(t)) {
 				state.hiddenTexts.add(t);
+				retainHiddenActivityNode(t);
 				retainHiddenText(t);
 			}
 			enforceHiddenText(t);
@@ -22972,9 +23485,15 @@ function rehideActivityAfterDescendantRender(state: ActivitySlot): void {
 
 /** Release this Activity's hide ownership, restoring nodes with no other owner. */
 function showActivityRange(state: ActivitySlot): void {
-	for (const el of state.hiddenDisplays) releaseHiddenDisplay(el, false);
+	for (const el of state.hiddenDisplays) {
+		releaseHiddenActivityNode(el);
+		releaseHiddenDisplay(el, false);
+	}
 	state.hiddenDisplays.clear();
-	for (const text of state.hiddenTexts) releaseHiddenText(text);
+	for (const text of state.hiddenTexts) {
+		releaseHiddenActivityNode(text);
+		releaseHiddenText(text);
+	}
 	state.hiddenTexts.clear();
 }
 
@@ -23048,6 +23567,7 @@ export function activityBlock(
 			__kind: 'activityBlockSlot',
 			block: b,
 			hidden: false,
+			fragmentVisibilityCleanupRegistered: false,
 			commitVersion: 0,
 			deactivationPending: false,
 			hiddenDisplays: new Set(),

--- a/packages/octane/src/server/index.ts
+++ b/packages/octane/src/server/index.ts
@@ -149,6 +149,7 @@ export {
 	ssrComponentNS,
 	ssrInNamespace,
 	ssrBlock,
+	ssrFragmentMarker,
 	ssrActivity,
 	ssrForBlock,
 	mapSlot,

--- a/packages/octane/tests/_fixtures/control-fold-fragment-ref.tsrx
+++ b/packages/octane/tests/_fixtures/control-fold-fragment-ref.tsrx
@@ -1,15 +1,16 @@
-import { Fragment, useState } from 'octane';
+import { Fragment, type FragmentInstance, useState } from 'octane';
 
-function StatefulFragmentDraft(props) {
+type FragmentObject = { current: FragmentInstance | null };
+
+function StatefulFragmentDraft(props: { id: string; prefix: string }) {
 	const [edits, setEdits] = useState(0);
 	return <button id={props.id} onClick={() => setEdits((count) => count + 1)}>{props.prefix +
 		edits as string}</button>;
 }
 
-// Kept in a client-only fixture because Octane intentionally rejects Fragment
-// refs during server compilation. The returned outer fragment must still route
-// this compiler sentinel through template extraction on the client.
-export function ReturnedFragmentRefMailbox(props) {
+// The returned outer fragment must route this compiler sentinel through
+// template extraction on the client and preserve its range during hydration.
+export function ReturnedFragmentRefMailbox(props: { groupRef: FragmentObject; title: string }) {
 	return <>
 		<h2 id="fragment-ref-title">{props.title as string}</h2>
 		<Fragment ref={props.groupRef}>
@@ -21,10 +22,39 @@ export function ReturnedFragmentRefMailbox(props) {
 
 // Direct Fragment refs also require template markers. Multiple roots ensure the
 // compiled return renderer cannot claim a markerless single-root shape.
-export function DirectReturnedFragmentRefMailbox(props) {
-	return <Fragment ref={props.observe('ref', props.groupRef)}>
+export function DirectReturnedFragmentRefMailbox(props: {
+	groupRef: FragmentObject;
+	title: string;
+	observe: (phase: string, value: FragmentObject | string) => FragmentObject | string;
+}) {
+	return <Fragment ref={props.observe('ref', props.groupRef) as FragmentObject}>
 		<h2 id="direct-fragment-title">{props.observe('child', props.title) as string}</h2>
 		<StatefulFragmentDraft id="direct-fragment-draft" prefix="Direct grouped edits: " />
 		<span id="direct-fragment-tail">Direct grouped draft ready</span>
 	</Fragment>;
+}
+
+export function EmptyFragmentRef(props: { groupRef: FragmentObject }) {
+	return <section>
+		<span>before</span>
+		<Fragment ref={props.groupRef} />
+		<span>after</span>
+	</section>;
+}
+
+export function TextFragmentRef(props: { groupRef: FragmentObject; label: string }) {
+	return <section>
+		<Fragment ref={props.groupRef}>{props.label as string}</Fragment>
+	</section>;
+}
+
+export function NestedFragmentRefs(props: { groupRef: FragmentObject; innerRef: FragmentObject }) {
+	return <section>
+		<Fragment ref={props.groupRef}>
+			<span id="nested-outer">outer</span>
+			<Fragment ref={props.innerRef}>
+				<span id="nested-inner">inner</span>
+			</Fragment>
+		</Fragment>
+	</section>;
 }

--- a/packages/octane/tests/conformance/_fixtures/fragment-future.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/fragment-future.tsrx
@@ -1,12 +1,28 @@
-import { Fragment, useState } from 'octane';
+import { Fragment, createPortal, useState, type FragmentInstance } from 'octane';
 
-// A fragment whose child set GROWS at runtime: #a is always present, #b mounts
-// when the toggle flips. Used to prove fragment listeners/observers added before
-// #b existed still apply to #b (React future-children contract).
-export function FutureChildren(props) @{
+type FragmentRef =
+	| ((fragment: FragmentInstance | null) => void | (() => void))
+	| { current: FragmentInstance | null }
+	| null;
+
+interface FragmentProps {
+	fragRef: FragmentRef;
+}
+
+interface FragmentPortalProps extends FragmentProps {
+	target: Element;
+}
+
+// A fragment whose child set changes at runtime: #a is always present, #b
+// mounts and unmounts whenever the toggle flips.
+export function FutureChildren(props: FragmentProps) @{
 	const [show, setShow] = useState(false);
 	<div id="host">
-		<button id="toggle" type="button" onClick={() => setShow(true)}>{'toggle'}</button>
+		<button
+			id="toggle"
+			type="button"
+			onClick={() => setShow((current) => !current)}
+		>{'toggle'}</button>
 		<Fragment ref={props.fragRef}>
 			<button id="a" type="button">{'a'}</button>
 			@if (show) {
@@ -18,10 +34,139 @@ export function FutureChildren(props) @{
 
 // A <Fragment ref> whose ref expression can change across renders (props.pick),
 // to exercise the compiler's fragmentRef update path.
-export function FragmentRefUpdate(props) @{
+export function FragmentRefUpdate(props: { pick: FragmentRef }) @{
 	<div id="host">
 		<Fragment ref={props.pick}>
 			<span id="x">{'x'}</span>
 		</Fragment>
+	</div>
+}
+
+export function FragmentPortalChildren(props: FragmentPortalProps) @{
+	<div id="fragment-portal-parent">
+		{createPortal(<button id="unowned-portal">{'outside'}</button>, props.target)}
+		<Fragment ref={props.fragRef}>
+			<button id="inline-before">{'before'}</button>
+			{createPortal(<button id="owned-portal">{'portal'}</button>, props.target)}
+			<button id="inline-after">{'after'}</button>
+		</Fragment>
+	</div>
+}
+
+export function NestedFragmentPortals(props: {
+	outerRef: FragmentRef;
+	innerRef: FragmentRef;
+	target: Element;
+}) @{
+	<div id="nested-portal-parent">
+		<Fragment ref={props.outerRef}>
+			<button id="outer-inline">{'outer'}</button>
+			<Fragment ref={props.innerRef}>
+				{createPortal(<button id="shared-portal">{'shared'}</button>, props.target)}
+				<button id="inner-inline">{'inner'}</button>
+			</Fragment>
+			{createPortal(<button id="outer-portal">{'outer portal'}</button>, props.target)}
+		</Fragment>
+	</div>
+}
+
+export function RootFragmentPortals(props: FragmentPortalProps) @{
+	<Fragment ref={props.fragRef}>
+		{createPortal(<button id="root-portal-before">{'before'}</button>, props.target)}
+		<button id="root-inline">{'inline'}</button>
+		{createPortal(<button id="root-portal-after">{'after'}</button>, props.target)}
+	</Fragment>
+}
+
+export function ConditionalFragmentPortal(props: FragmentPortalProps) @{
+	const [show, setShow] = useState(false);
+	<div id="conditional-portal-parent">
+		<button
+			id="conditional-toggle"
+			onClick={() => setShow((current) => !current)}
+		>{'toggle'}</button>
+		<Fragment ref={props.fragRef}>
+			<button id="conditional-before">{'before'}</button>
+			{show
+				? createPortal(<button id="conditional-portal">{'portal'}</button>, props.target)
+				: null}
+			<button id="conditional-after">{'after'}</button>
+		</Fragment>
+	</div>
+}
+
+function ReturnedFragmentPortal(props: { target: Element }) {
+	return createPortal(<button id="component-portal">{'portal'}</button>, props.target);
+}
+
+export function ComponentFragmentPortal(props: FragmentPortalProps) @{
+	<div id="component-portal-parent">
+		<Fragment ref={props.fragRef}>
+			<button id="component-before">{'before'}</button>
+			<ReturnedFragmentPortal target={props.target} />
+			<button id="component-after">{'after'}</button>
+		</Fragment>
+	</div>
+}
+
+interface InterleavedPortalProps extends FragmentPortalProps {
+	showOwned: boolean;
+	showSibling: boolean;
+	showLate: boolean;
+	onSiblingClick(): void;
+}
+
+function InterleavedOwnedPortal(props: InterleavedPortalProps) @{
+	<Fragment>{createPortal(
+		<Fragment ref={props.fragRef}>
+			<button id="interleaved-owned-first" type="button">{'first'}</button>
+			@if (props.showLate) {
+				<button id="interleaved-owned-late" type="button">{'late'}</button>
+			}
+		</Fragment>,
+		props.target,
+	)}</Fragment>
+}
+
+function InterleavedIndependentPortal(props: InterleavedPortalProps) {
+	return createPortal(
+		<button
+			id="interleaved-independent"
+			type="button"
+			onClick={props.onSiblingClick}
+		>{'independent'}</button>,
+		props.target,
+	);
+}
+
+export function InterleavedFragmentPortals(props: InterleavedPortalProps) @{
+	<Fragment>
+		@if (props.showOwned) {
+			<InterleavedOwnedPortal {...props} />
+		}
+		@if (props.showSibling) {
+			<InterleavedIndependentPortal {...props} />
+		}
+	</Fragment>
+}
+
+function ThrowAfterFragment(props: { capture(node: Element): void }) {
+	const child = document.querySelector('#aborted-fragment-child');
+	if (child !== null) props.capture(child);
+	throw new Error('discard fragment');
+}
+
+export function AbortedFragmentOwnership(props: FragmentProps & { capture(node: Element): void }) @{
+	<div id="aborted-fragment-parent">
+		@try {
+			<>
+				<Fragment ref={props.fragRef}>
+					<button id="aborted-fragment-child">{'aborted'}</button>
+				</Fragment>
+				<ThrowAfterFragment capture={props.capture} />
+			</>
+		} @catch (error) {
+			<span id="aborted-fragment-fallback">{'fallback'}</span>
+		}
 	</div>
 }

--- a/packages/octane/tests/conformance/_fixtures/fragment-refs-activity.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/fragment-refs-activity.tsrx
@@ -1,0 +1,77 @@
+import {
+	Activity as ActivitySentinel,
+	Fragment,
+	createPortal,
+	type FragmentInstance,
+	type OctaneNode,
+} from 'octane';
+
+type ActivityMode = 'visible' | 'hidden';
+type FragmentReference = { current: FragmentInstance | null };
+const Activity = ActivitySentinel as unknown as
+	(props: {
+		mode: ActivityMode;
+		children?: OctaneNode;
+	}) => null;
+
+export function ActivityFragmentGroup(props: {
+	mode: ActivityMode;
+	fragmentRef: FragmentReference;
+	innerRef: FragmentReference;
+	wrappedRef: FragmentReference;
+}) @{
+	<main id="activity-fragment-host">
+		<Fragment ref={props.fragmentRef}>
+			<Activity mode={props.mode}>
+				<button id="activity-first" type="button">{'first'}</button>
+				<Fragment ref={props.innerRef}>
+					<button id="activity-nested" type="button">{'nested'}</button>
+				</Fragment>
+				<div id="activity-wrapped">
+					<Fragment ref={props.wrappedRef}>
+						<button id="activity-wrapped-child" type="button">{'wrapped'}</button>
+					</Fragment>
+				</div>
+				{'activity text' as string}
+			</Activity>
+			<button id="activity-visible" type="button">{'visible'}</button>
+			<div id="authored-hidden" style="display: none">{'authored'}</div>
+			<Activity mode={props.mode}>
+				<button id="activity-last" type="button">{'last'}</button>
+			</Activity>
+		</Fragment>
+	</main>
+}
+
+export function NestedActivityFragmentGroup(props: {
+	outerMode: ActivityMode;
+	innerMode: ActivityMode;
+	fragmentRef: FragmentReference;
+}) @{
+	<main id="nested-activity-fragment-host">
+		<Fragment ref={props.fragmentRef}>
+			<Activity mode={props.outerMode}>
+				<Activity mode={props.innerMode}>
+					<button id="double-hidden" type="button">{'nested'}</button>
+				</Activity>
+			</Activity>
+			<button id="nested-visible" type="button">{'visible'}</button>
+		</Fragment>
+	</main>
+}
+
+export function ActivityFragmentPortal(props: {
+	mode: ActivityMode;
+	fragmentRef: FragmentReference;
+	target: Element;
+}) @{
+	<main id="activity-portal-host">
+		<Fragment ref={props.fragmentRef}>
+			<button id="activity-portal-inline" type="button">{'inline'}</button>
+			<Activity mode={props.mode}>{createPortal(
+				<button id="activity-portal-child" type="button">{'portal'}</button>,
+				props.target,
+			)}</Activity>
+		</Fragment>
+	</main>
+}

--- a/packages/octane/tests/conformance/_fixtures/fragment-refs-descriptors.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/fragment-refs-descriptors.tsrx
@@ -1,0 +1,58 @@
+import {
+	Activity as ActivitySentinel,
+	Fragment,
+	createElement,
+	use,
+	type FragmentInstance,
+	type OctaneNode,
+} from 'octane';
+
+type FragmentReference = { current: FragmentInstance | null };
+const Activity = ActivitySentinel as unknown as
+	(props: {
+		mode: 'visible' | 'hidden';
+		children?: OctaneNode;
+	}) => null;
+
+export function ActivityDescriptorFragment(props: {
+	fragmentRef: FragmentReference;
+	mode: 'visible' | 'hidden';
+}) @{
+	<main id="descriptor-activity-host">
+		<Activity mode={props.mode}>{createElement(
+			Fragment,
+			{ ref: props.fragmentRef },
+			createElement('button', { id: 'descriptor-activity-child' }, 'activity'),
+		)}</Activity>
+	</main>
+}
+
+function DescriptorSuspendGate(props: { promise: Promise<string> }) @{
+	const value = use(props.promise);
+	<span id="descriptor-suspend-value">{value as string}</span>
+}
+
+function DescriptorSuspenseContent(props: {
+	fragmentRef: FragmentReference;
+	promise: Promise<string>;
+}) {
+	return createElement(
+		Fragment,
+		{ ref: props.fragmentRef },
+		createElement('button', { id: 'descriptor-suspense-child' }, 'suspense'),
+		createElement(DescriptorSuspendGate, { promise: props.promise }),
+	);
+}
+
+export function SuspenseDescriptorFragment(props: {
+	fragmentRef: FragmentReference;
+	promise: Promise<string>;
+}) @{
+	<main id="descriptor-suspense-host">
+		@try {
+			<DescriptorSuspenseContent fragmentRef={props.fragmentRef} promise={props.promise} />
+		} @pending {
+			<span id="descriptor-suspense-fallback">{'loading'}</span>
+		}
+	</main>
+}

--- a/packages/octane/tests/conformance/_fixtures/fragment-refs-focus.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/fragment-refs-focus.tsrx
@@ -1,7 +1,11 @@
-import { Fragment } from 'octane';
+import { Fragment, type FragmentInstance } from 'octane';
+
+interface FragmentProps {
+	fragRef: { current: FragmentInstance | null };
+}
 
 // Two focusable inputs side-by-side — covers basic focus() and focusLast().
-export function TwoInputs(props) @{
+export function TwoInputs(props: FragmentProps) @{
 	<div id="parent">
 		<Fragment ref={props.fragRef}>
 			<input id="a" />
@@ -11,7 +15,7 @@ export function TwoInputs(props) @{
 }
 
 // disabled button must be skipped by focus() / focusLast().
-export function DisabledThenButton(props) @{
+export function DisabledThenButton(props: FragmentProps) @{
 	<div id="parent">
 		<Fragment ref={props.fragRef}>
 			<button id="bad" disabled>x</button>
@@ -21,7 +25,7 @@ export function DisabledThenButton(props) @{
 }
 
 // Non-focusable elements at the head — focus() must walk past them.
-export function NonFocusableBeforeButton(props) @{
+export function NonFocusableBeforeButton(props: FragmentProps) @{
 	<div id="parent">
 		<Fragment ref={props.fragRef}>
 			<div>not focusable</div>
@@ -31,8 +35,20 @@ export function NonFocusableBeforeButton(props) @{
 	</div>
 }
 
+export function FocusableFieldset(props: FragmentProps) @{
+	<div id="parent">
+		<Fragment ref={props.fragRef}>
+			<fieldset>
+				<legend>Shipping</legend>
+				<input id="street" />
+				<input id="city" />
+			</fieldset>
+		</Fragment>
+	</div>
+}
+
 // Nothing focusable — focus() and focusLast() must no-op.
-export function NoFocusable(props) @{
+export function NoFocusable(props: FragmentProps) @{
 	<div id="parent">
 		<Fragment ref={props.fragRef}>
 			<div>a</div>
@@ -42,7 +58,7 @@ export function NoFocusable(props) @{
 }
 
 // Explicit tabIndex=0 on a div makes it focusable.
-export function ExplicitTabIndex(props) @{
+export function ExplicitTabIndex(props: FragmentProps) @{
 	<div id="parent">
 		<Fragment ref={props.fragRef}>
 			<div id="tabbable" tabIndex={0}>tabbable</div>
@@ -50,9 +66,9 @@ export function ExplicitTabIndex(props) @{
 	</div>
 }
 
-// tabIndex=-1 makes an otherwise-focusable element non-focusable for
-// focus() / focusLast() — they should pick the next eligible element.
-export function SkipsNegativeTabIndex(props) @{
+// tabIndex=-1 remains programmatically focusable even though keyboard tabbing
+// skips it; FragmentInstance.focus() still chooses it in document order.
+export function SkipsNegativeTabIndex(props: FragmentProps) @{
 	<div id="parent">
 		<Fragment ref={props.fragRef}>
 			<input id="skip" tabIndex={-1} />
@@ -62,7 +78,7 @@ export function SkipsNegativeTabIndex(props) @{
 }
 
 // blur() target — a single focused input inside the fragment.
-export function BlurInside(props) @{
+export function BlurInside(props: FragmentProps) @{
 	<div id="parent">
 		<Fragment ref={props.fragRef}>
 			<input id="inside" />
@@ -73,7 +89,7 @@ export function BlurInside(props) @{
 // blur() must be a no-op when focus is OUTSIDE the fragment. Provides
 // both an outside input and an inside fragment (no focusable elements
 // in the fragment, so any focused element is necessarily outside).
-export function BlurOutside(props) @{
+export function BlurOutside(props: FragmentProps) @{
 	<div id="parent">
 		<input id="outside" />
 		<Fragment ref={props.fragRef}>

--- a/packages/octane/tests/conformance/_fixtures/fragment-refs-misc.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/fragment-refs-misc.tsrx
@@ -1,7 +1,15 @@
-import { Fragment, useState } from 'octane';
+import { Fragment, useState, type FragmentInstance } from 'octane';
+
+type FragmentReference =
+	| { current: FragmentInstance | null }
+	| ((fragment: FragmentInstance | null) => void | (() => void));
+
+interface FragmentProps {
+	fragRef: FragmentReference;
+}
 
 // scrollIntoView target — single focusable child.
-export function ScrollTarget(props) @{
+export function ScrollTarget(props: FragmentProps) @{
 	<div id="parent">
 		<Fragment ref={props.fragRef}>
 			<button id="btn">go</button>
@@ -11,7 +19,7 @@ export function ScrollTarget(props) @{
 
 // scrollIntoView falls back to first child element when nothing is
 // focusable — used to verify the picking logic.
-export function ScrollNonFocusable(props) @{
+export function ScrollNonFocusable(props: FragmentProps) @{
 	<div id="parent">
 		<Fragment ref={props.fragRef}>
 			<div id="first">first</div>
@@ -20,16 +28,62 @@ export function ScrollNonFocusable(props) @{
 	</div>
 }
 
+export function ScrollNestedFocusable(props: FragmentProps) @{
+	<div id="parent">
+		<Fragment ref={props.fragRef}>
+			<div id="first">
+				<button id="nested">nested</button>
+			</div>
+			<div id="second">second</div>
+		</Fragment>
+	</div>
+}
+
+export function EmptyFragmentWithSiblings(props: FragmentProps) @{
+	<div id="parent">
+		<div id="before">before</div>
+		<Fragment ref={props.fragRef}></Fragment>
+		<div id="after">after</div>
+	</div>
+}
+
+export function EmptyFragmentWithoutSiblings(props: FragmentProps) @{
+	<div id="parent">
+		<Fragment ref={props.fragRef}></Fragment>
+	</div>
+}
+
+export function EmptyFragmentWithTextSiblings(props: FragmentProps) @{
+	<div id="parent">
+		{'before' as string}
+		<Fragment ref={props.fragRef}></Fragment>
+		{'after' as string}
+	</div>
+}
+
 // Text-only fragment — no host element children.
 // (TSRX text expressions become Text nodes between the markers.)
-export function TextOnly(props) @{
+export function TextOnly(props: FragmentProps) @{
 	<div id="parent">
 		<Fragment ref={props.fragRef}>{'just text' as string}</Fragment>
 	</div>
 }
 
+export function MixedTextAndElements(props: FragmentProps) @{
+	<div id="parent">
+		<Fragment ref={props.fragRef}>
+			{'before' as string}
+			<span id="middle">middle</span>
+			{'after' as string}
+		</Fragment>
+	</div>
+}
+
 // Nested fragments — each ref binds to its own marker range.
-export function NestedFragments(props) @{
+export function NestedFragments(props: {
+	outerRef: FragmentReference;
+	innerRef: FragmentReference;
+}) @{
 	<div id="parent">
 		<Fragment ref={props.outerRef}>
 			<div id="outer-a">a</div>
@@ -43,7 +97,10 @@ export function NestedFragments(props) @{
 }
 
 // Two sibling fragments — refs must NOT cross-contaminate.
-export function SiblingFragments(props) @{
+export function SiblingFragments(props: {
+	leftRef: FragmentReference;
+	rightRef: FragmentReference;
+}) @{
 	<div id="parent">
 		<Fragment ref={props.leftRef}>
 			<div id="L1">L1</div>
@@ -58,7 +115,7 @@ export function SiblingFragments(props) @{
 
 // Array refs on a Fragment — attachRef supports the same multi-ref
 // shape as element-level refs.
-export function ArrayRef(props) @{
+export function ArrayRef(props: { refA: FragmentReference; refB: FragmentReference }) @{
 	<div id="parent">
 		<Fragment ref={[props.refA, props.refB]}>
 			<button id="btn">x</button>
@@ -68,11 +125,11 @@ export function ArrayRef(props) @{
 
 // Conditional fragment — when toggled in, ref attaches; when toggled
 // out, ref is cleared (object refs → null, callback refs → null).
-let _setShow = null;
-export function setShow(v) {
+let _setShow: ((value: boolean | ((previous: boolean) => boolean)) => void) | null = null;
+export function setShow(v: boolean): void {
 	if (_setShow) _setShow(v);
 }
-export function ConditionalFragment(props) @{
+export function ConditionalFragment(props: FragmentProps) @{
 	const [show, setShow] = useState(true);
 	_setShow = setShow;
 	<div id="parent">
@@ -86,7 +143,7 @@ export function ConditionalFragment(props) @{
 
 // dispatchEvent through a fragment whose parent has a delegated click
 // handler — verifies the event arrives at the parent's listener.
-export function DispatchParent(props) @{
+export function DispatchParent(props: FragmentProps & { onParent: (event: MouseEvent) => void }) @{
 	<div id="parent" onClick={props.onParent}>
 		<Fragment ref={props.fragRef}>
 			<div id="child">child</div>

--- a/packages/octane/tests/conformance/_fixtures/fragment-refs-parity-ledger.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/fragment-refs-parity-ledger.tsrx
@@ -1,0 +1,127 @@
+import { Fragment, createPortal, type FragmentInstance } from 'octane';
+
+type FragmentReference = { current: FragmentInstance | null };
+
+export function LedgerNestedFocus(props: { fragmentRef: FragmentReference }) @{
+	<main id="ledger-focus-host">
+		<Fragment ref={props.fragmentRef}>
+			<div id="ledger-focus-wrapper">
+				<div id="ledger-focus-first" tabIndex={0}>
+					<a id="ledger-focus-first-nested" href="/">{'first nested'}</a>
+				</div>
+			</div>
+			<div id="ledger-focus-last-parent" tabIndex={0}>
+				<a id="ledger-focus-last-before" href="/">{'before last'}</a>
+				<a id="ledger-focus-last-nested" href="/">{'last nested'}</a>
+			</div>
+		</Fragment>
+	</main>
+}
+
+export function LedgerDynamicFocus(props: {
+	fragmentRef: FragmentReference;
+	showFirst: boolean;
+	showSecond: boolean;
+}) @{
+	<main id="ledger-dynamic-focus-host">
+		<Fragment ref={props.fragmentRef}>
+			@if (props.showFirst) {
+				<a id="ledger-dynamic-first" href="/">{'first'}</a>
+			}
+			@if (props.showSecond) {
+				<a id="ledger-dynamic-second" href="/">{'second'}</a>
+			}
+		</Fragment>
+	</main>
+}
+
+export function LedgerRootPositions(props: {
+	fragmentRef: FragmentReference;
+	emptyRef: FragmentReference;
+}) @{
+	<Fragment>
+		<button id="ledger-root-before" type="button">{'before'}</button>
+		<Fragment ref={props.fragmentRef}>
+			<button id="ledger-root-child" type="button">{'child'}</button>
+		</Fragment>
+		<Fragment ref={props.emptyRef}></Fragment>
+		<button id="ledger-root-after" type="button">{'after'}</button>
+	</Fragment>
+}
+
+export function LedgerRemovableFragment(props: {
+	fragmentRef: FragmentReference;
+	mounted: boolean;
+}) @{
+	<main id="ledger-removable-parent">
+		@if (props.mounted) {
+			<Fragment ref={props.fragmentRef}>
+				<button id="ledger-removable-child" type="button">{'child'}</button>
+			</Fragment>
+		}
+	</main>
+}
+
+export function LedgerPortaledEmptyFragment(props: {
+	fragmentRef: FragmentReference;
+	target: Element;
+}) @{
+	<main id="ledger-empty-portal-source">
+		<button id="ledger-empty-before" type="button">{'before'}</button>
+		{createPortal(<Fragment ref={props.fragmentRef}></Fragment>, props.target)}
+		<button id="ledger-empty-after" type="button">{'after'}</button>
+	</main>
+}
+
+export function LedgerPortalScrollContainers(props: {
+	fragmentRef: FragmentReference;
+	firstTarget: Element;
+	secondTarget: Element;
+}) @{
+	<main id="ledger-portal-scroll-source">
+		{createPortal(
+			<button id="ledger-portal-outside" type="button">{'outside'}</button>,
+			props.secondTarget,
+		)}
+		<Fragment ref={props.fragmentRef}>
+			{createPortal(
+				<button id="ledger-portal-first" type="button">{'first'}</button>,
+				props.firstTarget,
+			)}
+			{createPortal(
+				<button id="ledger-portal-second" type="button">{'second'}</button>,
+				props.secondTarget,
+			)}
+			{createPortal(
+				<button id="ledger-portal-third" type="button">{'third'}</button>,
+				props.secondTarget,
+			)}
+		</Fragment>
+	</main>
+}
+
+export function LedgerInterleavedPortals(props: {
+	fragmentRef: FragmentReference;
+	target: Element;
+	showLate: boolean;
+}) @{
+	<Fragment>
+		<button id="ledger-shared-source-before" type="button">{'source before'}</button>
+		{createPortal(
+			<Fragment ref={props.fragmentRef}>
+				<button id="ledger-shared-first" type="button">{'first'}</button>
+				@if (props.showLate) {
+					<div id="ledger-shared-late">
+						<button id="ledger-shared-nested" type="button">{'nested'}</button>
+					</div>
+				}
+			</Fragment>,
+			props.target,
+		)}
+		{createPortal(
+			<button id="ledger-shared-outside" type="button">{'outside'}</button>,
+			props.target,
+		)}
+		<button id="ledger-shared-source-after" type="button">{'source after'}</button>
+	</Fragment>
+}

--- a/packages/octane/tests/conformance/_fixtures/fragment-refs-position.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/fragment-refs-position.tsrx
@@ -1,8 +1,12 @@
-import { Fragment } from 'octane';
+import { Fragment, type FragmentInstance } from 'octane';
+
+interface FragmentProps {
+	fragRef: { current: FragmentInstance | null };
+}
 
 // Sibling before the fragment, fragment with one child, sibling after —
 // exercises every region compareDocumentPosition can report.
-export function SurroundedFragment(props) @{
+export function SurroundedFragment(props: FragmentProps) @{
 	<div id="parent">
 		<div id="before">before</div>
 		<Fragment ref={props.fragRef}>
@@ -14,10 +18,28 @@ export function SurroundedFragment(props) @{
 
 // Just the parent + a single fragment child — used by dispatchEvent test
 // to verify the event reaches a listener on the parent.
-export function ParentWithFragmentChild(props) @{
+export function ParentWithFragmentChild(props: FragmentProps) @{
 	<div id="parent">
 		<Fragment ref={props.fragRef}>
 			<div id="child">x</div>
+		</Fragment>
+	</div>
+}
+
+export function EmptySurroundedFragment(props: FragmentProps) @{
+	<div id="parent">
+		<div id="before">before</div>
+		<Fragment ref={props.fragRef}></Fragment>
+		<div id="after">after</div>
+	</div>
+}
+
+export function NestedPositionFragment(props: FragmentProps) @{
+	<div id="parent">
+		<Fragment ref={props.fragRef}>
+			<div id="inside">
+				<span id="nested">nested</span>
+			</div>
 		</Fragment>
 	</div>
 }

--- a/packages/octane/tests/conformance/_fixtures/fragment-refs.tsrx
+++ b/packages/octane/tests/conformance/_fixtures/fragment-refs.tsrx
@@ -1,7 +1,17 @@
-import { Fragment, useLayoutEffect, useEffect, useState } from 'octane';
+import * as Octane from 'octane';
+import {
+	Fragment,
+	Fragment as Group,
+	type FragmentInstance,
+	useLayoutEffect,
+	useEffect,
+	useState,
+} from 'octane';
+import { ValueFragment as ForeignGroup } from '../../_fixtures/fragments.tsrx';
 
 type FragmentCallback = (instance: unknown) => void;
-type FragmentObject = { current: unknown };
+type FragmentObject = { current: FragmentInstance | null };
+type HostObject = { current: HTMLButtonElement | null };
 
 // Stage 1 — basic fragment ref attach. React parity: rendering
 // `<Fragment ref={r}>` populates `r.current` with a FragmentInstance.
@@ -9,6 +19,148 @@ export function FragmentObjectRef(props: { fragRef: FragmentObject }) @{
 	<div id="parent">
 		<Fragment ref={props.fragRef}>
 			<div id="child">{'hi' as string}</div>
+		</Fragment>
+	</div>
+}
+
+export function AliasedFragmentObjectRef(props: { fragRef: FragmentObject }) @{
+	<div id="alias-parent">
+		<Group ref={props.fragRef}>
+			<button id="alias-child">{'aliased'}</button>
+		</Group>
+	</div>
+}
+
+export function NamespacedFragmentObjectRef(props: { fragRef: FragmentObject }) @{
+	<div id="namespace-parent">
+		<Octane.Fragment ref={props.fragRef}>
+			<button id="namespace-child">{'namespaced'}</button>
+		</Octane.Fragment>
+	</div>
+}
+
+export function SpreadFragmentObjectRef(props: { spread: { ref?: FragmentObject | null } }) @{
+	<div id="spread-parent">
+		<Fragment {...props.spread}>
+			<button id="spread-child">{'spread'}</button>
+		</Fragment>
+	</div>
+}
+
+export function AliasedSpreadFragmentObjectRef(props: {
+	spread: { ref?: FragmentObject | null };
+}) @{
+	<div id="spread-alias-parent">
+		<Group {...props.spread}>
+			<button id="spread-alias-child">{'spread alias'}</button>
+		</Group>
+	</div>
+}
+
+export function NamespacedSpreadFragmentObjectRef(props: {
+	spread: { ref?: FragmentObject | null };
+}) @{
+	<div id="spread-namespace-parent">
+		<Octane.Fragment {...props.spread}>
+			<button id="spread-namespace-child">{'spread namespace'}</button>
+		</Octane.Fragment>
+	</div>
+}
+
+export function ExplicitThenSpreadFragmentRef(props: {
+	fragRef: FragmentObject;
+	spread: { ref?: FragmentObject | null };
+}) @{
+	<Fragment ref={props.fragRef} {...props.spread}>
+		<button id="explicit-then-spread">{'explicit then spread'}</button>
+	</Fragment>
+}
+
+export function SpreadThenExplicitFragmentRef(props: {
+	fragRef: FragmentObject;
+	spread: { ref?: FragmentObject | null };
+}) @{
+	<Fragment {...props.spread} ref={props.fragRef}>
+		<button id="spread-then-explicit">{'spread then explicit'}</button>
+	</Fragment>
+}
+
+export function OrderedFragmentSpreadEvaluation(props: {
+	first: { ref?: FragmentObject | null };
+	last: { ref?: FragmentObject | null };
+	explicit: FragmentObject;
+	observe: (label: string, value: any) => any;
+}) @{
+	<Fragment
+		{...props.observe('first:expression', props.first)}
+		ref={props.observe('explicit', props.explicit)}
+		{...props.observe('last:expression', props.last)}
+	>
+		<button id="ordered-spread-child">{props.observe('child', 'ordered spread') as string}</button>
+	</Fragment>
+}
+
+export function ReturnedNamespacedFragmentSpreadEvaluation(props: {
+	first: { ref?: FragmentObject | null };
+	last: { ref?: FragmentObject | null };
+	explicit: FragmentObject;
+	observe: (label: string, value: any) => any;
+}) {
+	return <Octane.Fragment
+		{...props.observe('first:expression', props.first)}
+		ref={props.observe('explicit', props.explicit)}
+		{...props.observe('last:expression', props.last)}
+	>
+		<span id="returned-namespace-ordered-spread-child">{props.observe(
+			'child',
+			'ordered spread',
+		) as string}</span>
+	</Octane.Fragment>;
+}
+
+export function ReturnedAliasedFragmentObjectRef(props: { fragRef: FragmentObject }) {
+	return <Group ref={props.fragRef}>
+		<button id="returned-alias-child">{'returned alias'}</button>
+	</Group>;
+}
+
+export function ReturnedNamespacedFragmentObjectRef(props: { fragRef: FragmentObject }) {
+	return <Octane.Fragment ref={props.fragRef}>
+		<button id="returned-namespace-child">{'returned namespace'}</button>
+	</Octane.Fragment>;
+}
+
+function LocalRefTarget(props: { ref: HostObject }) @{
+	<button id="local-ref-target" ref={props.ref}>{'local component'}</button>
+}
+
+export function ShadowedFragmentAlias(props: { fragRef: HostObject }) @{
+	const Group = LocalRefTarget;
+	<Group ref={props.fragRef} />
+}
+
+export function ShadowedFragmentNamespace(props: { fragRef: HostObject }) @{
+	const Octane = { Fragment: LocalRefTarget };
+	<Octane.Fragment ref={props.fragRef} />
+}
+
+export function ForeignFragmentAlias(props: { fragRef: FragmentObject }) @{
+	<ForeignGroup {...{ ref: props.fragRef } as object} />
+}
+
+function FragmentChildPassthrough(props: { children?: unknown }) {
+	return props.children;
+}
+
+export function FragmentWrappedHostChildren(props: { fragRef: FragmentObject }) @{
+	<div id="wrapped-parent">
+		<Fragment ref={props.fragRef}>
+			<button id="wrapped-direct">{'direct'}</button>
+			<FragmentChildPassthrough>
+				<FragmentChildPassthrough>
+					<button id="wrapped-nested">{'nested'}</button>
+				</FragmentChildPassthrough>
+			</FragmentChildPassthrough>
 		</Fragment>
 	</div>
 }
@@ -61,4 +213,19 @@ export function FragmentEffectVisibility(props: {
 			<div id="child">{'hi' as string}</div>
 		</Fragment>
 	</div>
+}
+
+export function FragmentEffectListener(props: {
+	fragRef: FragmentObject;
+	onClick: EventListener;
+	revision: number;
+}) @{
+	useEffect(() => {
+		const fragment = props.fragRef.current as FragmentInstance;
+		fragment.addEventListener('click', props.onClick);
+		return () => fragment.removeEventListener('click', props.onClick);
+	}, [props.onClick, props.revision]);
+	<Fragment ref={props.fragRef}>
+		<button id="effect-listener-child">{'effect listener'}</button>
+	</Fragment>
 }

--- a/packages/octane/tests/conformance/_fixtures/fragment-refs.tsx
+++ b/packages/octane/tests/conformance/_fixtures/fragment-refs.tsx
@@ -1,0 +1,66 @@
+/** @jsxImportSource octane */
+import * as Octane from 'octane';
+import { Fragment as Group, type FragmentInstance } from 'octane';
+
+type FragmentReference = { current: FragmentInstance | null };
+
+export function AutomaticJsxAliasedFragmentRef(props: { fragRef: FragmentReference }) {
+	return (
+		<section id="tsx-alias-parent">
+			<Group ref={props.fragRef}>
+				<button id="tsx-alias-child">automatic alias</button>
+			</Group>
+		</section>
+	);
+}
+
+export function AutomaticJsxNamespacedFragmentRef(props: { fragRef: FragmentReference }) {
+	return (
+		<section id="tsx-namespace-parent">
+			<Octane.Fragment ref={props.fragRef}>
+				<button id="tsx-namespace-child">automatic namespace</button>
+			</Octane.Fragment>
+		</section>
+	);
+}
+
+export function AutomaticJsxSpreadFragmentRef(props: {
+	spread: { ref?: FragmentReference | null };
+}) {
+	return (
+		<section id="tsx-spread-parent">
+			<Group {...props.spread}>
+				<button id="tsx-spread-child">automatic spread</button>
+			</Group>
+		</section>
+	);
+}
+
+export function AutomaticJsxNamespacedSpreadFragmentRef(props: {
+	spread: { ref?: FragmentReference | null };
+}) {
+	return (
+		<section id="tsx-spread-namespace-parent">
+			<Octane.Fragment {...props.spread}>
+				<button id="tsx-spread-namespace-child">automatic namespace spread</button>
+			</Octane.Fragment>
+		</section>
+	);
+}
+
+export function AutomaticJsxReturnedSpreadEvaluation(props: {
+	first: { ref?: FragmentReference | null };
+	last: { ref?: FragmentReference | null };
+	explicit: FragmentReference;
+	observe: (label: string, value: any) => any;
+}) {
+	return (
+		<Group
+			{...props.observe('first:expression', props.first)}
+			ref={props.observe('explicit', props.explicit)}
+			{...props.observe('last:expression', props.last)}
+		>
+			<span id="automatic-ordered-spread-child">{props.observe('child', 'ordered spread')}</span>
+		</Group>
+	);
+}

--- a/packages/octane/tests/conformance/fragment-future-children.test.ts
+++ b/packages/octane/tests/conformance/fragment-future-children.test.ts
@@ -1,7 +1,20 @@
 import { describe, it, expect } from 'vitest';
 import { mount } from '../_helpers';
 import { FragmentInstance } from '../../src/index.js';
-import { FutureChildren, FragmentRefUpdate } from './_fixtures/fragment-future.tsrx';
+import {
+	FutureChildren,
+	FragmentRefUpdate,
+	FragmentPortalChildren,
+	NestedFragmentPortals,
+	RootFragmentPortals,
+	ConditionalFragmentPortal,
+	ComponentFragmentPortal,
+	InterleavedFragmentPortals,
+	AbortedFragmentOwnership,
+} from './_fixtures/fragment-future.tsrx';
+import { NestedFragments } from './_fixtures/fragment-refs-misc.tsrx';
+
+type FragmentHostElement = Element & { reactFragments?: Set<FragmentInstance> };
 
 // React canary enableFragmentRefs: listeners/observers added to a FragmentInstance
 // apply to children that mount LATER, and are detached from children that unmount.
@@ -24,6 +37,113 @@ describe('FragmentInstance — future children', () => {
 		r.find('#b').dispatchEvent(new MouseEvent('click', { bubbles: true }));
 		expect(count).toBe(2);
 
+		r.unmount();
+	});
+
+	// Per ReactDOMFragmentRefs-test.js:118.
+	it('publishes fragment handles for existing, added, and removed children', () => {
+		const fragRef: { current: FragmentInstance | null } = { current: null };
+		const r = mount(FutureChildren, { fragRef });
+		const fragment = fragRef.current!;
+		const first = r.find('#a') as FragmentHostElement;
+		expect(first.reactFragments?.has(fragment)).toBe(true);
+
+		r.click('#toggle');
+		const added = r.find('#b') as FragmentHostElement;
+		expect(added.reactFragments?.has(fragment)).toBe(true);
+
+		r.click('#toggle');
+		expect(r.findAll('#b')).toHaveLength(0);
+		expect(added.reactFragments).toBeInstanceOf(Set);
+		expect(added.reactFragments?.has(fragment)).toBe(false);
+		expect(first.reactFragments?.has(fragment)).toBe(true);
+
+		r.unmount();
+		expect(first.reactFragments?.has(fragment)).toBe(false);
+	});
+
+	// Per ReactDOMFragmentRefs-test.js:118.
+	it('records both fragment handles on children shared by nested fragments', () => {
+		const outerRef: { current: FragmentInstance | null } = { current: null };
+		const innerRef: { current: FragmentInstance | null } = { current: null };
+		const r = mount(NestedFragments, { outerRef, innerRef });
+		const outerOnly = r.find('#outer-a') as FragmentHostElement;
+		const shared = r.find('#inner-a') as FragmentHostElement;
+
+		expect(outerOnly.reactFragments?.has(outerRef.current!)).toBe(true);
+		expect(outerOnly.reactFragments?.has(innerRef.current!)).toBe(false);
+		expect(shared.reactFragments?.has(outerRef.current!)).toBe(true);
+		expect(shared.reactFragments?.has(innerRef.current!)).toBe(true);
+
+		const outer = outerRef.current!;
+		const inner = innerRef.current!;
+		r.unmount();
+		expect(shared.reactFragments?.has(outer)).toBe(false);
+		expect(shared.reactFragments?.has(inner)).toBe(false);
+	});
+
+	// Per ReactDOMFragmentRefs-test.js:118.
+	it('publishes existing child handles before invoking the fragment callback ref', () => {
+		let attachedToChild = false;
+		const fragRef = (fragment: FragmentInstance | null) => {
+			if (fragment === null) return;
+			const first = document.querySelector('#a') as FragmentHostElement;
+			attachedToChild = first.reactFragments?.has(fragment) === true;
+		};
+		const r = mount(FutureChildren, { fragRef });
+		expect(attachedToChild).toBe(true);
+		r.unmount();
+	});
+
+	it('removes eager DOM fragment handles when a later sibling aborts the render', () => {
+		const captured: FragmentHostElement[] = [];
+		const attached: FragmentInstance[] = [];
+		const r = mount(AbortedFragmentOwnership, {
+			fragRef: (fragment: FragmentInstance | null) => {
+				if (fragment !== null) attached.push(fragment);
+			},
+			capture: (node: Element) => captured.push(node as FragmentHostElement),
+		});
+		expect(r.find('#aborted-fragment-fallback').textContent).toBe('fallback');
+		expect(attached).toEqual([]);
+		expect(captured).toHaveLength(1);
+		expect(captured[0].reactFragments).toBeInstanceOf(Set);
+		expect(Array.from(captured[0].reactFragments!)).toEqual([]);
+		r.unmount();
+	});
+
+	// Per ReactDOMFragmentRefs-test.js:867.
+	it('detaches fragment listeners from children removed while the fragment remains mounted', () => {
+		const fragRef: { current: FragmentInstance | null } = { current: null };
+		const r = mount(FutureChildren, { fragRef });
+		let fired = 0;
+		fragRef.current!.addEventListener('click', () => fired++);
+		r.click('#toggle');
+		const removed = r.find('#b');
+		removed.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(fired).toBe(1);
+
+		r.click('#toggle');
+		removed.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(fired).toBe(1);
+		r.unmount();
+	});
+
+	// Per ReactDOMFragmentRefs-test.js:867.
+	it('does not revive an exhausted once listener when another child mounts', () => {
+		const fragRef: { current: FragmentInstance | null } = { current: null };
+		const r = mount(FutureChildren, { fragRef });
+		let fired = 0;
+		fragRef.current!.addEventListener('click', () => fired++, { once: true });
+		r.find('#a').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(fired).toBe(1);
+
+		r.click('#toggle');
+		r.find('#a').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(fired).toBe(1);
+		r.find('#b').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		r.find('#b').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(fired).toBe(2);
 		r.unmount();
 	});
 
@@ -55,6 +175,330 @@ describe('FragmentInstance — future children', () => {
 		const b = r.find('#b');
 		expect(observed).toContain(b);
 		r.unmount();
+	});
+
+	// Per ReactDOMFragmentRefs-test.js:1194.
+	it('observes each retained or added child only when it first joins the fragment', () => {
+		const fragRef: { current: FragmentInstance | null } = { current: null };
+		const observed: Element[] = [];
+		const unobserved: Element[] = [];
+		const observer = {
+			observe: (element: Element) => observed.push(element),
+			unobserve: (element: Element) => unobserved.push(element),
+		};
+		const r = mount(FutureChildren, { fragRef });
+		const first = r.find('#a');
+		fragRef.current!.observeUsing(observer);
+		expect(observed).toEqual([first]);
+
+		r.click('#toggle');
+		const added = r.find('#b');
+		expect(observed).toEqual([first, added]);
+
+		r.update(FutureChildren, { fragRef });
+		expect(observed).toEqual([first, added]);
+
+		r.click('#toggle');
+		expect(observed).toEqual([first, added]);
+		expect(unobserved).toEqual([]);
+		r.unmount();
+		expect(unobserved).toEqual([]);
+	});
+});
+
+describe('FragmentInstance — portaled children', () => {
+	// Per ReactDOMFragmentRefs-test.js:924 and :1287.
+	it('includes only logically owned portal children in handles, listeners, and observers', () => {
+		const target = document.createElement('section');
+		document.body.appendChild(target);
+		const fragRef: { current: FragmentInstance | null } = { current: null };
+		const r = mount(FragmentPortalChildren, { fragRef, target });
+		try {
+			const fragment = fragRef.current!;
+			const owned = target.querySelector('#owned-portal') as FragmentHostElement;
+			const outside = target.querySelector('#unowned-portal') as FragmentHostElement;
+			expect(owned.reactFragments?.has(fragment)).toBe(true);
+			expect(outside.reactFragments?.has(fragment)).not.toBe(true);
+
+			const observed: Element[] = [];
+			const observer = { observe: (element: Element) => observed.push(element), unobserve() {} };
+			fragment.observeUsing(observer);
+			expect(observed.map((element) => element.id)).toEqual([
+				'inline-before',
+				'owned-portal',
+				'inline-after',
+			]);
+
+			const clicked: string[] = [];
+			fragment.addEventListener('click', (event) => clicked.push((event.target as Element).id));
+			outside.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+			owned.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+			r.find('#inline-after').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+			expect(clicked).toEqual(['owned-portal', 'inline-after']);
+		} finally {
+			r.unmount();
+			target.remove();
+		}
+	});
+
+	// Per ReactDOMFragmentRefs-test.js:118 and :1287.
+	it('gives nested fragment owners the same portaled child without leaking to siblings', () => {
+		const target = document.createElement('section');
+		document.body.appendChild(target);
+		const outerRef: { current: FragmentInstance | null } = { current: null };
+		const innerRef: { current: FragmentInstance | null } = { current: null };
+		const r = mount(NestedFragmentPortals, { outerRef, innerRef, target });
+		try {
+			const outer = outerRef.current!;
+			const inner = innerRef.current!;
+			const shared = target.querySelector('#shared-portal') as FragmentHostElement;
+			const outerOnly = target.querySelector('#outer-portal') as FragmentHostElement;
+			expect(shared.reactFragments?.has(outer)).toBe(true);
+			expect(shared.reactFragments?.has(inner)).toBe(true);
+			expect(outerOnly.reactFragments?.has(outer)).toBe(true);
+			expect(outerOnly.reactFragments?.has(inner)).toBe(false);
+
+			const observed: string[] = [];
+			outer.observeUsing({ observe: (element) => observed.push(element.id), unobserve() {} });
+			expect(observed).toEqual(['outer-inline', 'shared-portal', 'inner-inline', 'outer-portal']);
+
+			const nestedClicks: string[] = [];
+			inner.addEventListener('click', (event) => nestedClicks.push((event.target as Element).id));
+			outerOnly.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+			shared.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+			expect(nestedClicks).toEqual(['shared-portal']);
+		} finally {
+			r.unmount();
+			target.remove();
+		}
+	});
+
+	it('moves fragment registrations when a logically owned portal changes target', () => {
+		const firstTarget = document.createElement('section');
+		const secondTarget = document.createElement('section');
+		document.body.append(firstTarget, secondTarget);
+		const fragRef: { current: FragmentInstance | null } = { current: null };
+		const r = mount(FragmentPortalChildren, { fragRef, target: firstTarget });
+		try {
+			const fragment = fragRef.current!;
+			const removed = firstTarget.querySelector('#owned-portal') as FragmentHostElement;
+			const clicked: Element[] = [];
+			fragment.addEventListener('click', (event) => clicked.push(event.target as Element));
+
+			r.update(FragmentPortalChildren, { fragRef, target: secondTarget });
+			const replacement = secondTarget.querySelector('#owned-portal') as FragmentHostElement;
+			expect(firstTarget.querySelector('#owned-portal')).toBeNull();
+			expect(removed.reactFragments?.has(fragment)).toBe(false);
+			expect(replacement.reactFragments?.has(fragment)).toBe(true);
+			removed.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+			replacement.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+			expect(clicked).toEqual([replacement]);
+		} finally {
+			r.unmount();
+			firstTarget.remove();
+			secondTarget.remove();
+		}
+	});
+
+	it('keeps portal ownership and authored order when the Fragment is the component root', () => {
+		const target = document.createElement('section');
+		document.body.appendChild(target);
+		const fragRef: { current: FragmentInstance | null } = { current: null };
+		const r = mount(RootFragmentPortals, { fragRef, target });
+		try {
+			const fragment = fragRef.current!;
+			const before = target.querySelector('#root-portal-before') as FragmentHostElement;
+			const after = target.querySelector('#root-portal-after') as FragmentHostElement;
+			expect(before.reactFragments?.has(fragment)).toBe(true);
+			expect(after.reactFragments?.has(fragment)).toBe(true);
+
+			const observed: string[] = [];
+			fragment.observeUsing({ observe: (element) => observed.push(element.id), unobserve() {} });
+			expect(observed).toEqual(['root-portal-before', 'root-inline', 'root-portal-after']);
+
+			const clicked: string[] = [];
+			fragment.addEventListener('click', (event) => clicked.push((event.target as Element).id));
+			before.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+			after.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+			expect(clicked).toEqual(['root-portal-before', 'root-portal-after']);
+		} finally {
+			r.unmount();
+			target.remove();
+		}
+	});
+
+	it('inherits and removes Fragment bindings when a conditional portal mounts and unmounts', () => {
+		const target = document.createElement('section');
+		document.body.appendChild(target);
+		const fragRef: { current: FragmentInstance | null } = { current: null };
+		const r = mount(ConditionalFragmentPortal, { fragRef, target });
+		try {
+			const fragment = fragRef.current!;
+			const observed: Element[] = [];
+			const clicked: string[] = [];
+			fragment.observeUsing({ observe: (element) => observed.push(element), unobserve() {} });
+			fragment.addEventListener('click', (event) => clicked.push((event.target as Element).id));
+			expect(observed.map((element) => element.id)).toEqual([
+				'conditional-before',
+				'conditional-after',
+			]);
+
+			r.click('#conditional-toggle');
+			const added = target.querySelector('#conditional-portal') as FragmentHostElement;
+			expect(added.reactFragments?.has(fragment)).toBe(true);
+			expect(observed).toContain(added);
+			added.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+			expect(clicked).toEqual(['conditional-portal']);
+
+			r.click('#conditional-toggle');
+			expect(target.querySelector('#conditional-portal')).toBeNull();
+			expect(added.reactFragments?.has(fragment)).toBe(false);
+			added.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+			expect(clicked).toEqual(['conditional-portal']);
+
+			r.click('#conditional-toggle');
+			const replacement = target.querySelector('#conditional-portal') as FragmentHostElement;
+			expect(replacement).not.toBe(added);
+			expect(replacement.reactFragments?.has(fragment)).toBe(true);
+			replacement.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+			expect(clicked).toEqual(['conditional-portal', 'conditional-portal']);
+		} finally {
+			r.unmount();
+			target.remove();
+		}
+	});
+
+	it('owns a portal returned through a nested child component', () => {
+		const target = document.createElement('section');
+		document.body.appendChild(target);
+		const fragRef: { current: FragmentInstance | null } = { current: null };
+		const r = mount(ComponentFragmentPortal, { fragRef, target });
+		try {
+			const fragment = fragRef.current!;
+			const portaled = target.querySelector('#component-portal') as FragmentHostElement;
+			expect(portaled.reactFragments?.has(fragment)).toBe(true);
+
+			const observed: string[] = [];
+			fragment.observeUsing({ observe: (element) => observed.push(element.id), unobserve() {} });
+			expect(observed).toEqual(['component-before', 'component-portal', 'component-after']);
+
+			let fired = 0;
+			fragment.addEventListener('click', () => fired++);
+			portaled.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+			expect(fired).toBe(1);
+		} finally {
+			r.unmount();
+			target.remove();
+		}
+	});
+
+	it('preserves an independent shared-target portal when its interleaved owner unmounts', () => {
+		const target = document.createElement('section');
+		document.body.appendChild(target);
+		const fragRef: { current: FragmentInstance | null } = { current: null };
+		let siblingClicks = 0;
+		const props = {
+			fragRef,
+			target,
+			showOwned: true,
+			showSibling: true,
+			showLate: false,
+			onSiblingClick: () => siblingClicks++,
+		};
+		const r = mount(InterleavedFragmentPortals, props);
+		try {
+			const sibling = target.querySelector('#interleaved-independent')!;
+			r.update(InterleavedFragmentPortals, { ...props, showLate: true });
+			expect(Array.from(target.querySelectorAll('button')).map((node) => node.id)).toEqual([
+				'interleaved-owned-first',
+				'interleaved-independent',
+				'interleaved-owned-late',
+			]);
+
+			r.update(InterleavedFragmentPortals, { ...props, showOwned: false });
+			expect(fragRef.current).toBeNull();
+			expect(target.querySelector('#interleaved-independent')).toBe(sibling);
+			expect(target.querySelector('#interleaved-owned-first')).toBeNull();
+			expect(target.querySelector('#interleaved-owned-late')).toBeNull();
+			sibling.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+			expect(siblingClicks).toBe(1);
+		} finally {
+			r.unmount();
+			expect(target.childNodes).toHaveLength(0);
+			target.remove();
+		}
+	});
+
+	it('removes an interleaved independent portal without disturbing its Fragment owner', () => {
+		const target = document.createElement('section');
+		document.body.appendChild(target);
+		const fragRef: { current: FragmentInstance | null } = { current: null };
+		const props = {
+			fragRef,
+			target,
+			showOwned: true,
+			showSibling: true,
+			showLate: false,
+			onSiblingClick() {},
+		};
+		const r = mount(InterleavedFragmentPortals, props);
+		try {
+			const fragment = fragRef.current!;
+			const first = target.querySelector('#interleaved-owned-first');
+			r.update(InterleavedFragmentPortals, { ...props, showLate: true });
+			const late = target.querySelector('#interleaved-owned-late');
+			r.update(InterleavedFragmentPortals, {
+				...props,
+				showSibling: false,
+				showLate: true,
+			});
+			expect(fragRef.current).toBe(fragment);
+			expect(target.querySelector('#interleaved-owned-first')).toBe(first);
+			expect(target.querySelector('#interleaved-owned-late')).toBe(late);
+			expect(target.querySelector('#interleaved-independent')).toBeNull();
+		} finally {
+			r.unmount();
+			expect(target.childNodes).toHaveLength(0);
+			target.remove();
+		}
+	});
+
+	it('keeps shared-target ordering and ownership across repeated late-child toggles', () => {
+		const target = document.createElement('section');
+		document.body.appendChild(target);
+		const fragRef: { current: FragmentInstance | null } = { current: null };
+		const props = {
+			fragRef,
+			target,
+			showOwned: true,
+			showSibling: true,
+			showLate: false,
+			onSiblingClick() {},
+		};
+		const r = mount(InterleavedFragmentPortals, props);
+		try {
+			const fragment = fragRef.current!;
+			for (let iteration = 0; iteration < 3; iteration++) {
+				r.update(InterleavedFragmentPortals, { ...props, showLate: true });
+				const late = target.querySelector('#interleaved-owned-late') as FragmentHostElement;
+				expect(Array.from(target.querySelectorAll('button')).map((node) => node.id)).toEqual([
+					'interleaved-owned-first',
+					'interleaved-independent',
+					'interleaved-owned-late',
+				]);
+				expect(late.reactFragments?.has(fragment)).toBe(true);
+				r.update(InterleavedFragmentPortals, { ...props, showLate: false });
+				expect(late.reactFragments?.has(fragment)).toBe(false);
+				expect(Array.from(target.querySelectorAll('button')).map((node) => node.id)).toEqual([
+					'interleaved-owned-first',
+					'interleaved-independent',
+				]);
+			}
+		} finally {
+			r.unmount();
+			expect(target.childNodes).toHaveLength(0);
+			target.remove();
+		}
 	});
 });
 

--- a/packages/octane/tests/conformance/fragment-refs-activity.test.ts
+++ b/packages/octane/tests/conformance/fragment-refs-activity.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mount, type MountResult } from '../_helpers';
+import { FragmentInstance } from '../../src/index.js';
+import {
+	ActivityFragmentGroup,
+	ActivityFragmentPortal,
+	NestedActivityFragmentGroup,
+} from './_fixtures/fragment-refs-activity.tsrx';
+
+type FragmentHost = Element & { reactFragments?: Set<FragmentInstance> };
+
+let mounted: MountResult | null = null;
+let portalTarget: HTMLElement | null = null;
+
+afterEach(() => {
+	try {
+		mounted?.unmount();
+	} finally {
+		mounted = null;
+		portalTarget?.remove();
+		portalTarget = null;
+		vi.restoreAllMocks();
+	}
+});
+
+function renderGroup(mode: 'visible' | 'hidden') {
+	const fragmentRef: { current: FragmentInstance | null } = { current: null };
+	const innerRef: { current: FragmentInstance | null } = { current: null };
+	const wrappedRef: { current: FragmentInstance | null } = { current: null };
+	const props = { mode, fragmentRef, innerRef, wrappedRef };
+	mounted = mount(ActivityFragmentGroup, props);
+	return {
+		result: mounted,
+		props,
+		fragment: fragmentRef.current!,
+		inner: innerRef.current!,
+		wrapped: wrappedRef.current!,
+	};
+}
+
+describe('Fragment refs and Activity visibility', () => {
+	// Per ReactDOMFragmentRefs-test.js:959.
+	it('excludes hidden Activity children from listeners and fragment ownership', () => {
+		const { result, fragment, inner, wrapped } = renderGroup('hidden');
+		const fired: string[] = [];
+		fragment.addEventListener('click', (event) => {
+			fired.push((event.target as Element).id);
+		});
+
+		for (const id of [
+			'activity-first',
+			'activity-nested',
+			'activity-wrapped-child',
+			'activity-visible',
+			'authored-hidden',
+			'activity-last',
+		]) {
+			result.find('#' + id).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		}
+
+		expect(fired).toEqual(['activity-visible', 'authored-hidden']);
+		expect((result.find('#activity-first') as FragmentHost).reactFragments?.has(fragment)).not.toBe(
+			true,
+		);
+		expect(
+			(result.find('#activity-nested') as FragmentHost).reactFragments?.has(fragment),
+		).not.toBe(true);
+		expect((result.find('#activity-nested') as FragmentHost).reactFragments?.has(inner)).not.toBe(
+			true,
+		);
+		expect(
+			(result.find('#activity-wrapped-child') as FragmentHost).reactFragments?.has(wrapped),
+		).not.toBe(true);
+		expect((result.find('#activity-visible') as FragmentHost).reactFragments?.has(fragment)).toBe(
+			true,
+		);
+		expect((result.find('#authored-hidden') as FragmentHost).reactFragments?.has(fragment)).toBe(
+			true,
+		);
+	});
+
+	// Per ReactDOMFragmentRefs-test.js:1025.
+	it('disconnects preserved hidden children and reconnects them when Activity reveals', () => {
+		const { result, props, fragment, inner } = renderGroup('visible');
+		const first = result.find('#activity-first') as FragmentHost;
+		const nested = result.find('#activity-nested') as FragmentHost;
+		const fired: string[] = [];
+		fragment.addEventListener('click', (event) => fired.push((event.target as Element).id));
+		first.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(fired).toEqual(['activity-first']);
+		expect(nested.reactFragments?.has(fragment)).toBe(true);
+		expect(nested.reactFragments?.has(inner)).toBe(true);
+
+		result.update(ActivityFragmentGroup, { ...props, mode: 'hidden' });
+		first.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		nested.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(fired).toEqual(['activity-first']);
+		expect(first.reactFragments?.has(fragment)).toBe(false);
+		expect(nested.reactFragments?.has(fragment)).toBe(false);
+		expect(nested.reactFragments?.has(inner)).toBe(false);
+
+		result.update(ActivityFragmentGroup, { ...props, mode: 'visible' });
+		first.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		nested.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(fired).toEqual(['activity-first', 'activity-first', 'activity-nested']);
+		expect(first.reactFragments?.has(fragment)).toBe(true);
+		expect(nested.reactFragments?.has(fragment)).toBe(true);
+		expect(nested.reactFragments?.has(inner)).toBe(true);
+	});
+
+	it('observes and measures only visible Fragment children', () => {
+		const { result, fragment } = renderGroup('hidden');
+		const observer = { observe: vi.fn(), unobserve: vi.fn() };
+		fragment.observeUsing(observer);
+		expect(observer.observe.mock.calls.map(([element]) => element.id)).toEqual([
+			'activity-visible',
+			'authored-hidden',
+		]);
+
+		for (const element of result.findAll('button, #authored-hidden')) {
+			vi.spyOn(element, 'getClientRects').mockReturnValue([
+				{ id: element.id } as unknown as DOMRect,
+			] as unknown as DOMRectList);
+		}
+		expect(fragment.getClientRects().map((rect) => (rect as unknown as { id: string }).id)).toEqual(
+			['activity-visible', 'authored-hidden'],
+		);
+	});
+
+	it('restores Activity-owned text geometry only after the boundary reveals', () => {
+		const { result, props, fragment } = renderGroup('hidden');
+		const rect = { width: 72, height: 16 } as DOMRect;
+		const createRange = document.createRange.bind(document);
+		vi.spyOn(document, 'createRange').mockImplementation(() => {
+			const range = createRange();
+			range.getClientRects = () => [rect] as unknown as DOMRectList;
+			return range;
+		});
+
+		expect(fragment.getClientRects()).toEqual([]);
+
+		result.update(ActivityFragmentGroup, { ...props, mode: 'visible' });
+		expect(fragment.getClientRects()).toEqual([rect]);
+	});
+
+	it('focuses and scrolls only visible Fragment children', () => {
+		const { result, fragment } = renderGroup('hidden');
+		const visible = result.find('#activity-visible') as HTMLButtonElement;
+		fragment.focus();
+		expect(document.activeElement).toBe(visible);
+		fragment.focusLast();
+		expect(document.activeElement).toBe(visible);
+
+		const calls: string[] = [];
+		for (const element of result.findAll('button, #authored-hidden')) {
+			(element as HTMLElement).scrollIntoView = () => calls.push(element.id);
+		}
+		fragment.scrollIntoView();
+		expect(calls).toEqual(['authored-hidden', 'activity-visible']);
+	});
+
+	it('retains hidden ownership until every nested Activity has revealed', () => {
+		const fragmentRef: { current: FragmentInstance | null } = { current: null };
+		const props = { outerMode: 'hidden' as const, innerMode: 'hidden' as const, fragmentRef };
+		mounted = mount(NestedActivityFragmentGroup, props);
+		const result = mounted;
+		const fragment = fragmentRef.current!;
+		const child = result.find('#double-hidden') as FragmentHost;
+		expect(child.reactFragments?.has(fragment)).not.toBe(true);
+
+		result.update(NestedActivityFragmentGroup, { ...props, outerMode: 'visible' });
+		expect(child.reactFragments?.has(fragment)).not.toBe(true);
+
+		result.update(NestedActivityFragmentGroup, {
+			...props,
+			outerMode: 'visible',
+			innerMode: 'visible',
+		});
+		expect(child.reactFragments?.has(fragment)).toBe(true);
+	});
+
+	it('excludes logically owned portal children while their Activity is hidden', () => {
+		portalTarget = document.createElement('section');
+		document.body.appendChild(portalTarget);
+		const fragmentRef: { current: FragmentInstance | null } = { current: null };
+		const props = { mode: 'visible' as const, fragmentRef, target: portalTarget };
+		mounted = mount(ActivityFragmentPortal, props);
+		const fragment = fragmentRef.current!;
+		const portaled = portalTarget.querySelector('#activity-portal-child') as FragmentHost;
+		const fired: string[] = [];
+		fragment.addEventListener('click', (event) => fired.push((event.target as Element).id));
+		portaled.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(fired).toEqual(['activity-portal-child']);
+		expect(portaled.reactFragments?.has(fragment)).toBe(true);
+
+		mounted.update(ActivityFragmentPortal, { ...props, mode: 'hidden' });
+		portaled.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(fired).toEqual(['activity-portal-child']);
+		expect(portaled.reactFragments?.has(fragment)).toBe(false);
+
+		mounted.update(ActivityFragmentPortal, { ...props, mode: 'visible' });
+		portaled.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(fired).toEqual(['activity-portal-child', 'activity-portal-child']);
+		expect(portaled.reactFragments?.has(fragment)).toBe(true);
+	});
+
+	it('connects an initially hidden portal only after its Activity reveals', () => {
+		portalTarget = document.createElement('section');
+		document.body.appendChild(portalTarget);
+		const fragmentRef: { current: FragmentInstance | null } = { current: null };
+		const props = { mode: 'hidden' as const, fragmentRef, target: portalTarget };
+		mounted = mount(ActivityFragmentPortal, props);
+		const fragment = fragmentRef.current!;
+		const portaled = portalTarget.querySelector('#activity-portal-child') as FragmentHost;
+		const fired: string[] = [];
+		fragment.addEventListener('click', (event) => fired.push((event.target as Element).id));
+		portaled.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(fired).toEqual([]);
+		expect(portaled.reactFragments?.has(fragment)).not.toBe(true);
+
+		mounted.update(ActivityFragmentPortal, { ...props, mode: 'visible' });
+		portaled.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(fired).toEqual(['activity-portal-child']);
+		expect(portaled.reactFragments?.has(fragment)).toBe(true);
+	});
+});

--- a/packages/octane/tests/conformance/fragment-refs-descriptors.test.ts
+++ b/packages/octane/tests/conformance/fragment-refs-descriptors.test.ts
@@ -1,0 +1,379 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act } from '../_helpers';
+import {
+	Fragment,
+	FragmentInstance,
+	cloneElement,
+	createElement,
+	createRoot,
+	flushSync,
+	type ElementDescriptor,
+} from '../../src/index.js';
+import {
+	ActivityDescriptorFragment,
+	SuspenseDescriptorFragment,
+} from './_fixtures/fragment-refs-descriptors.tsrx';
+
+type FragmentReference = { current: FragmentInstance | null };
+type PublicRoot = ReturnType<typeof createRoot>;
+
+let root: PublicRoot | null = null;
+let container: HTMLDivElement | null = null;
+
+afterEach(() => {
+	try {
+		root?.unmount();
+	} finally {
+		root = null;
+		container?.remove();
+		container = null;
+		vi.restoreAllMocks();
+	}
+});
+
+function render<Props>(value: ElementDescriptor<Props>): HTMLDivElement {
+	if (root === null) {
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		root = createRoot(container);
+	}
+	flushSync(() => root!.render(value));
+	return container!;
+}
+
+describe('Fragment refs on public createElement descriptors', () => {
+	it('attaches an object ref to a directly rendered Fragment descriptor', () => {
+		const ref: FragmentReference = { current: null };
+		const host = render(
+			createElement(
+				Fragment,
+				{ ref },
+				createElement('button', { id: 'descriptor-direct' }, 'direct'),
+			),
+		);
+		const child = host.querySelector('#descriptor-direct')!;
+		expect(ref.current).toBeInstanceOf(FragmentInstance);
+		expect(ref.current!.compareDocumentPosition(child)).toBe(Node.DOCUMENT_POSITION_CONTAINED_BY);
+		expect(
+			(child as Element & { reactFragments?: Set<FragmentInstance> }).reactFragments,
+		).toContain(ref.current!);
+	});
+
+	it('attaches a ref inside a host descriptor without adding a wrapper element', () => {
+		const ref: FragmentReference = { current: null };
+		const host = render(
+			createElement(
+				'main',
+				{ id: 'descriptor-host' },
+				createElement('i', { id: 'descriptor-before' }, 'before'),
+				createElement(
+					Fragment,
+					{ ref },
+					createElement('button', { id: 'descriptor-child' }, 'child'),
+				),
+				createElement('i', { id: 'descriptor-after' }, 'after'),
+			),
+		);
+		const main = host.querySelector('#descriptor-host')!;
+		expect(Array.from(main.children).map((element) => element.id)).toEqual([
+			'descriptor-before',
+			'descriptor-child',
+			'descriptor-after',
+		]);
+		expect(ref.current).toBeInstanceOf(FragmentInstance);
+		expect(ref.current!.compareDocumentPosition(main.querySelector('#descriptor-child')!)).toBe(
+			Node.DOCUMENT_POSITION_CONTAINED_BY,
+		);
+		expect(
+			ref.current!.compareDocumentPosition(main.querySelector('#descriptor-before')!) &
+				Node.DOCUMENT_POSITION_CONTAINED_BY,
+		).toBe(0);
+	});
+
+	it('calls descriptor callback refs and their React 19 cleanup on unmount', () => {
+		const calls: string[] = [];
+		const callback = (fragment: FragmentInstance | null) => {
+			if (fragment === null) {
+				calls.push('null');
+				return;
+			}
+			calls.push('attach');
+			return () => calls.push('cleanup');
+		};
+		render(createElement(Fragment, { ref: callback }, createElement('span', null, 'callback')));
+		expect(calls).toEqual(['attach']);
+		root!.unmount();
+		root = null;
+		expect(calls).toEqual(['attach', 'cleanup']);
+	});
+
+	it('attaches nested arrays of descriptor refs to the same FragmentInstance', () => {
+		const first: FragmentReference = { current: null };
+		const second: FragmentReference = { current: null };
+		let callbackValue: FragmentInstance | null = null;
+		render(
+			createElement(
+				Fragment,
+				{
+					ref: [first, [second, (instance: FragmentInstance | null) => (callbackValue = instance)]],
+				},
+				createElement('span', null, 'array'),
+			),
+		);
+		expect(first.current).toBeInstanceOf(FragmentInstance);
+		expect(second.current).toBe(first.current);
+		expect(callbackValue).toBe(first.current);
+		root!.unmount();
+		root = null;
+		expect(first.current).toBeNull();
+		expect(second.current).toBeNull();
+		expect(callbackValue).toBeNull();
+	});
+
+	it('keeps nested descriptor Fragment refs independent and shares inner children', () => {
+		const outer: FragmentReference = { current: null };
+		const inner: FragmentReference = { current: null };
+		const host = render(
+			createElement(
+				Fragment,
+				{ ref: outer },
+				createElement('span', { id: 'descriptor-outer' }, 'outer'),
+				createElement(
+					Fragment,
+					{ ref: inner },
+					createElement('button', { id: 'descriptor-inner' }, 'inner'),
+				),
+			),
+		);
+		const outerChild = host.querySelector('#descriptor-outer')!;
+		const innerChild = host.querySelector('#descriptor-inner')!;
+		expect(outer.current).toBeInstanceOf(FragmentInstance);
+		expect(inner.current).toBeInstanceOf(FragmentInstance);
+		expect(outer.current).not.toBe(inner.current);
+		expect(outer.current!.compareDocumentPosition(innerChild)).toBe(
+			Node.DOCUMENT_POSITION_CONTAINED_BY,
+		);
+		expect(inner.current!.compareDocumentPosition(innerChild)).toBe(
+			Node.DOCUMENT_POSITION_CONTAINED_BY,
+		);
+		expect(
+			inner.current!.compareDocumentPosition(outerChild) & Node.DOCUMENT_POSITION_CONTAINED_BY,
+		).toBe(0);
+	});
+
+	it('updates a descriptor ref without replacing its instance or existing host', () => {
+		const first: FragmentReference = { current: null };
+		const second: FragmentReference = { current: null };
+		const descriptor = (ref: FragmentReference, label: string) =>
+			createElement(Fragment, { ref }, createElement('button', { id: 'descriptor-stable' }, label));
+		const host = render(descriptor(first, 'before'));
+		const instance = first.current!;
+		const child = host.querySelector('#descriptor-stable')!;
+		expect(instance).toBeInstanceOf(FragmentInstance);
+
+		render(descriptor(second, 'after'));
+		expect(first.current).toBeNull();
+		expect(second.current).toBe(instance);
+		expect(host.querySelector('#descriptor-stable')).toBe(child);
+		expect(child.textContent).toBe('after');
+	});
+
+	it('uses a cloned Fragment descriptor ref without attaching the original ref', () => {
+		const original: FragmentReference = { current: null };
+		const replacement: FragmentReference = { current: null };
+		const initial = createElement(
+			Fragment,
+			{ ref: original },
+			createElement('button', { id: 'descriptor-clone' }, 'cloned'),
+		);
+		const cloned = cloneElement(initial, { ref: replacement });
+		const host = render(cloned);
+		expect(original.current).toBeNull();
+		expect(replacement.current).toBeInstanceOf(FragmentInstance);
+		expect(
+			replacement.current!.compareDocumentPosition(host.querySelector('#descriptor-clone')!),
+		).toBe(Node.DOCUMENT_POSITION_CONTAINED_BY);
+	});
+
+	it('preserves child identity when descriptor Fragment refs are added and removed', () => {
+		const first: FragmentReference = { current: null };
+		const second: FragmentReference = { current: null };
+		const descriptor = (ref: FragmentReference | null) =>
+			createElement(
+				Fragment,
+				{ ref },
+				createElement('input', { id: 'descriptor-ref-toggle', defaultValue: 'initial' }),
+			);
+		const host = render(descriptor(null));
+		const input = host.querySelector('#descriptor-ref-toggle') as HTMLInputElement;
+		input.value = 'user editing';
+
+		render(descriptor(first));
+		expect(first.current).toBeInstanceOf(FragmentInstance);
+		expect(host.querySelector('#descriptor-ref-toggle')).toBe(input);
+		expect(input.value).toBe('user editing');
+
+		render(descriptor(null));
+		expect(first.current).toBeNull();
+		expect(host.querySelector('#descriptor-ref-toggle')).toBe(input);
+		expect(input.value).toBe('user editing');
+
+		render(descriptor(second));
+		expect(second.current).toBeInstanceOf(FragmentInstance);
+		expect(host.querySelector('#descriptor-ref-toggle')).toBe(input);
+		expect(input.value).toBe('user editing');
+	});
+
+	it('remounts keyed descriptor Fragments only when their key changes', () => {
+		const ref: FragmentReference = { current: null };
+		const descriptor = (key: string, label: string) =>
+			createElement(
+				'main',
+				null,
+				createElement(
+					Fragment,
+					{ key, ref },
+					createElement('button', { id: 'descriptor-keyed' }, label),
+				),
+			);
+		const host = render(descriptor('first', 'before'));
+		const original = ref.current!;
+		const originalChild = host.querySelector('#descriptor-keyed')!;
+		expect(original).toBeInstanceOf(FragmentInstance);
+
+		render(descriptor('first', 'updated'));
+		expect(ref.current).toBe(original);
+		expect(host.querySelector('#descriptor-keyed')).toBe(originalChild);
+		expect(originalChild.textContent).toBe('updated');
+
+		render(descriptor('second', 'replacement'));
+		expect(ref.current).toBeInstanceOf(FragmentInstance);
+		expect(ref.current).not.toBe(original);
+		expect(host.querySelector('#descriptor-keyed')).not.toBe(originalChild);
+	});
+
+	it('attaches refs to empty and text-only descriptor Fragments', () => {
+		const empty: FragmentReference = { current: null };
+		const text: FragmentReference = { current: null };
+		const host = render(
+			createElement(
+				'main',
+				null,
+				createElement(Fragment, { key: 'empty', ref: empty }),
+				createElement(Fragment, { key: 'text', ref: text }, 'descriptor text'),
+			),
+		);
+		expect(empty.current).toBeInstanceOf(FragmentInstance);
+		expect(text.current).toBeInstanceOf(FragmentInstance);
+		expect(empty.current!.getClientRects()).toEqual([]);
+		expect(host.textContent).toBe('descriptor text');
+	});
+
+	it('attaches a Fragment descriptor returned by a normal JavaScript component', () => {
+		const ref: FragmentReference = { current: null };
+		function DescriptorComponent() {
+			return createElement(
+				Fragment,
+				{ ref },
+				createElement('button', { id: 'descriptor-component' }, 'component'),
+			);
+		}
+		const host = render(createElement(DescriptorComponent, null));
+		expect(ref.current).toBeInstanceOf(FragmentInstance);
+		expect(ref.current!.compareDocumentPosition(host.querySelector('#descriptor-component')!)).toBe(
+			Node.DOCUMENT_POSITION_CONTAINED_BY,
+		);
+	});
+
+	it('preserves keyed descriptor Fragment instances and hosts through list reordering', () => {
+		const first: FragmentReference = { current: null };
+		const second: FragmentReference = { current: null };
+		const descriptor = (reverse: boolean) => {
+			const children = [
+				createElement(
+					Fragment,
+					{ key: 'first', ref: first },
+					createElement('input', { id: 'descriptor-list-first', defaultValue: 'first' }),
+				),
+				createElement(
+					Fragment,
+					{ key: 'second', ref: second },
+					createElement('input', { id: 'descriptor-list-second', defaultValue: 'second' }),
+				),
+			];
+			return createElement('main', null, reverse ? children.reverse() : children);
+		};
+		const host = render(descriptor(false));
+		const firstInstance = first.current!;
+		const secondInstance = second.current!;
+		const firstInput = host.querySelector('#descriptor-list-first') as HTMLInputElement;
+		const secondInput = host.querySelector('#descriptor-list-second') as HTMLInputElement;
+		firstInput.value = 'edited first';
+		secondInput.value = 'edited second';
+
+		render(descriptor(true));
+		expect(first.current).toBe(firstInstance);
+		expect(second.current).toBe(secondInstance);
+		expect(host.querySelector('#descriptor-list-first')).toBe(firstInput);
+		expect(host.querySelector('#descriptor-list-second')).toBe(secondInput);
+		expect(firstInput.value).toBe('edited first');
+		expect(secondInput.value).toBe('edited second');
+		expect(Array.from(host.querySelectorAll('input')).map((input) => input.id)).toEqual([
+			'descriptor-list-second',
+			'descriptor-list-first',
+		]);
+	});
+
+	it('keeps descriptor refs attached while Activity hides and reveals their hosts', () => {
+		const fragmentRef: FragmentReference = { current: null };
+		const host = render(
+			createElement(ActivityDescriptorFragment, { fragmentRef, mode: 'visible' as const }),
+		);
+		const fragment = fragmentRef.current!;
+		const child = host.querySelector('#descriptor-activity-child') as HTMLButtonElement & {
+			reactFragments?: Set<FragmentInstance>;
+		};
+		expect(fragment).toBeInstanceOf(FragmentInstance);
+		expect(child.reactFragments?.has(fragment)).toBe(true);
+
+		render(createElement(ActivityDescriptorFragment, { fragmentRef, mode: 'hidden' as const }));
+		expect(fragmentRef.current).toBe(fragment);
+		expect(host.querySelector('#descriptor-activity-child')).toBe(child);
+		expect(child.style.display).toBe('none');
+		expect(child.reactFragments?.has(fragment)).toBe(false);
+
+		render(createElement(ActivityDescriptorFragment, { fragmentRef, mode: 'visible' as const }));
+		expect(fragmentRef.current).toBe(fragment);
+		expect(host.querySelector('#descriptor-activity-child')).toBe(child);
+		expect(child.style.display).toBe('');
+		expect(child.reactFragments?.has(fragment)).toBe(true);
+	});
+
+	it('detaches and restores descriptor refs when Suspense hides and reveals a committed tree', async () => {
+		const ready = Promise.resolve('ready') as Promise<string> & {
+			status?: string;
+			value?: string;
+		};
+		ready.status = 'fulfilled';
+		ready.value = 'ready';
+		const fragmentRef: FragmentReference = { current: null };
+		const host = render(createElement(SuspenseDescriptorFragment, { fragmentRef, promise: ready }));
+		const fragment = fragmentRef.current!;
+		const child = host.querySelector('#descriptor-suspense-child') as HTMLButtonElement;
+		expect(fragment).toBeInstanceOf(FragmentInstance);
+		expect(host.querySelector('#descriptor-suspend-value')?.textContent).toBe('ready');
+
+		let resolve!: (value: string) => void;
+		const pending = new Promise<string>((done) => {
+			resolve = done;
+		});
+		render(createElement(SuspenseDescriptorFragment, { fragmentRef, promise: pending }));
+		expect(host.querySelector('#descriptor-suspense-fallback')?.textContent).toBe('loading');
+		expect(fragmentRef.current).toBeNull();
+
+		await act(() => resolve('revealed'));
+		expect(fragmentRef.current).toBe(fragment);
+		expect(host.querySelector('#descriptor-suspense-child')).toBe(child);
+		expect(host.querySelector('#descriptor-suspend-value')?.textContent).toBe('revealed');
+	});
+});

--- a/packages/octane/tests/conformance/fragment-refs-edges.test.ts
+++ b/packages/octane/tests/conformance/fragment-refs-edges.test.ts
@@ -11,7 +11,7 @@
 //   - Fragments WITHOUT a ref still flatten their children (the non-ref
 //     path stays identical to `<>` shorthand)
 //   - long-form `<Fragment>` with no ref does not allocate a FragmentInstance
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { mount } from '../_helpers';
 import { FragmentInstance, flushSync } from '../../src/index.js';
 import {
@@ -104,18 +104,26 @@ describe('FragmentInstance.observeUsing — repeated calls', () => {
 		r.unmount();
 	});
 
-	it('unobserveUsing without a preceding observe still walks and calls .unobserve (DOM-spec parity)', () => {
+	// Per ReactDOMFragmentRefs-test.js:1255.
+	it('unobserveUsing without a preceding observe warns and leaves the observer untouched', () => {
 		const fragRef = makeRef();
 		const r = mount(Single, { fragRef });
 		const obs = {
 			seen: [] as Element[],
+			observe() {},
 			unobserve(t: Element) {
 				this.seen.push(t);
 			},
 		};
-		fragRef.current!.unobserveUsing(obs);
-		expect(obs.seen).toHaveLength(1);
-		r.unmount();
+		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			fragRef.current!.unobserveUsing(obs);
+			expect(error).toHaveBeenCalledOnce();
+			expect(obs.seen).toHaveLength(0);
+		} finally {
+			error.mockRestore();
+			r.unmount();
+		}
 	});
 });
 

--- a/packages/octane/tests/conformance/fragment-refs-events.test.ts
+++ b/packages/octane/tests/conformance/fragment-refs-events.test.ts
@@ -132,6 +132,68 @@ describe('FragmentInstance.addEventListener / removeEventListener', () => {
 		r.unmount();
 	});
 
+	// Per ReactDOMFragmentRefs-test.js:2872.
+	it('treats passive:true and passive:false as same listener per DOM spec', () => {
+		const fragRef = makeRef();
+		const r = mount(SingleChild, { fragRef });
+		const child = r.find('#k');
+		let fired = 0;
+		const handler = () => fired++;
+		fragRef.current!.addEventListener('click', handler, { passive: false });
+		fragRef.current!.addEventListener('click', handler, { passive: true });
+		child.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(fired).toBe(1);
+		r.unmount();
+	});
+
+	// Per ReactDOMFragmentRefs-test.js:2911.
+	it('removes a listener registered with passive:false when removed with passive:true', () => {
+		const fragRef = makeRef();
+		const r = mount(SingleChild, { fragRef });
+		const child = r.find('#k');
+		let fired = 0;
+		const handler = () => fired++;
+		fragRef.current!.addEventListener('click', handler, { passive: false });
+		child.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(fired).toBe(1);
+		fragRef.current!.removeEventListener('click', handler, { passive: true });
+		child.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(fired).toBe(1);
+		r.unmount();
+	});
+
+	// Per ReactDOMFragmentRefs-test.js:850.
+	it('removes a capture listener registered with boolean when removed with options object', () => {
+		const fragRef = makeRef();
+		const r = mount(SingleChild, { fragRef });
+		const child = r.find('#k');
+		let fired = 0;
+		const handler = () => fired++;
+		fragRef.current!.addEventListener('click', handler, true);
+		child.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(fired).toBe(1);
+		fragRef.current!.removeEventListener('click', handler, { capture: true });
+		child.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(fired).toBe(1);
+		r.unmount();
+	});
+
+	// Per ReactDOMFragmentRefs-test.js:887.
+	it('removes a capture listener registered with options object when removed with boolean', () => {
+		const fragRef = makeRef();
+		const r = mount(SingleChild, { fragRef });
+		const child = r.find('#k');
+		let fired = 0;
+		const handler = () => fired++;
+		fragRef.current!.addEventListener('click', handler, { capture: true });
+		child.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(fired).toBe(1);
+		fragRef.current!.removeEventListener('click', handler, true);
+		child.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(fired).toBe(1);
+		r.unmount();
+	});
+
 	it('addEventListener supports object listeners ({ handleEvent })', () => {
 		const fragRef = makeRef();
 		const r = mount(SingleChild, { fragRef });

--- a/packages/octane/tests/conformance/fragment-refs-focus.test.ts
+++ b/packages/octane/tests/conformance/fragment-refs-focus.test.ts
@@ -4,17 +4,18 @@
 //   - tree order, depth-first
 //   - inherently focusable tags (input/button/select/textarea/a[href]) +
 //     elements with tabIndex >= 0 OR contenteditable="true"
-//   - disabled and tabIndex < 0 → skipped
+//   - disabled controls are skipped; programmatically focusable tabIndex < 0 is valid
 //   - hidden → skipped
 //   - blur() only affects the active element when it lives INSIDE the
 //     fragment range (no surprise blurs of elements outside the scope)
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { mount } from '../_helpers';
 import { FragmentInstance } from '../../src/index.js';
 import {
 	TwoInputs,
 	DisabledThenButton,
 	NonFocusableBeforeButton,
+	FocusableFieldset,
 	NoFocusable,
 	ExplicitTabIndex,
 	SkipsNegativeTabIndex,
@@ -50,6 +51,20 @@ describe('FragmentInstance.focus / focusLast / blur', () => {
 		r.unmount();
 	});
 
+	// Per ReactDOMFragmentRefs-test.js: "keeps focus on the first focusable child if already focused".
+	it('does not refocus an already focused first child', () => {
+		const fragRef = makeRef();
+		const r = mount(TwoInputs, { fragRef });
+		const first = r.find('#a') as HTMLInputElement;
+		first.focus();
+		const focus = vi.spyOn(first, 'focus');
+		fragRef.current!.focus();
+		expect(document.activeElement).toBe(first);
+		expect(focus).not.toHaveBeenCalled();
+		focus.mockRestore();
+		r.unmount();
+	});
+
 	it('focus() skips disabled controls', () => {
 		const fragRef = makeRef();
 		const r = mount(DisabledThenButton, { fragRef });
@@ -64,6 +79,15 @@ describe('FragmentInstance.focus / focusLast / blur', () => {
 		const r = mount(NonFocusableBeforeButton, { fragRef });
 		fragRef.current!.focus();
 		expect(document.activeElement).toBe(r.find('#target'));
+		r.unmount();
+	});
+
+	// Per ReactDOMFragmentRefs-test.js: "focuses the first focusable child in a fieldset".
+	it('focuses the first focusable child in a fieldset', () => {
+		const fragRef = makeRef();
+		const r = mount(FocusableFieldset, { fragRef });
+		fragRef.current!.focus();
+		expect(document.activeElement).toBe(r.find('#street'));
 		r.unmount();
 	});
 
@@ -85,11 +109,12 @@ describe('FragmentInstance.focus / focusLast / blur', () => {
 		r.unmount();
 	});
 
-	it('focus() / focusLast() skip elements with tabIndex=-1', () => {
+	// Per React's setFocusIfFocusable: tabIndex=-1 excludes tab order, not programmatic focus.
+	it('focus() includes programmatically focusable elements with tabIndex=-1', () => {
 		const fragRef = makeRef();
 		const r = mount(SkipsNegativeTabIndex, { fragRef });
 		fragRef.current!.focus();
-		expect(document.activeElement).toBe(r.find('#keep'));
+		expect(document.activeElement).toBe(r.find('#skip'));
 		fragRef.current!.focusLast();
 		expect(document.activeElement).toBe(r.find('#keep'));
 		r.unmount();

--- a/packages/octane/tests/conformance/fragment-refs-misc.test.ts
+++ b/packages/octane/tests/conformance/fragment-refs-misc.test.ts
@@ -1,21 +1,26 @@
 // FragmentInstance — remaining React canary parity tests.
 //
 // Stage 6 covers:
-//   - scrollIntoView (prefers focusable child, falls back to first element)
-//   - text-only fragments (no host children → every method is a no-op)
+//   - React's first-level-child scrolling, alignment, and empty-fragment fallbacks
+//   - text-node geometry and scrolling
 //   - nested fragments (each ref binds to its own marker range)
 //   - sibling fragments (refs don't cross-contaminate)
 //   - array refs (multi-ref attach)
 //   - conditional fragments (ref attaches on mount, clears on unmount)
 //   - dispatchEvent integration with the surrounding component event tree
 //   - re-mount semantics (ref toggles correctly on remount)
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mount, flushEffects } from '../_helpers';
-import { FragmentInstance, flushSync } from '../../src/index.js';
+import { FragmentInstance, createRoot, flushSync } from '../../src/index.js';
 import {
 	ScrollTarget,
 	ScrollNonFocusable,
+	ScrollNestedFocusable,
+	EmptyFragmentWithSiblings,
+	EmptyFragmentWithoutSiblings,
+	EmptyFragmentWithTextSiblings,
 	TextOnly,
+	MixedTextAndElements,
 	NestedFragments,
 	SiblingFragments,
 	ArrayRef,
@@ -23,13 +28,15 @@ import {
 	setShow,
 	DispatchParent,
 } from './_fixtures/fragment-refs-misc.tsrx';
+import { FragmentPortalChildren } from './_fixtures/fragment-future.tsrx';
 
 function makeRef(): { current: FragmentInstance | null } {
 	return { current: null };
 }
 
 describe('FragmentInstance.scrollIntoView', () => {
-	it('calls scrollIntoView on the first focusable descendant', () => {
+	// Per ReactDOMFragmentRefs-test.js: "settles scroll on the first child by default".
+	it('forwards the original argument to its first-level host child', () => {
 		const fragRef = makeRef();
 		const r = mount(ScrollTarget, { fragRef });
 		const btn = r.find('#btn') as HTMLButtonElement;
@@ -37,27 +44,69 @@ describe('FragmentInstance.scrollIntoView', () => {
 		btn.scrollIntoView = function (arg?: any) {
 			calls.push(arg);
 		};
-		fragRef.current!.scrollIntoView({ block: 'center' });
-		expect(calls).toEqual([{ block: 'center' }]);
+		fragRef.current!.scrollIntoView();
+		expect(calls).toEqual([undefined]);
 		r.unmount();
 	});
 
-	it('falls back to the first descendant element when nothing is focusable', () => {
+	it('scrolls children in reverse order so the first child receives final focus', () => {
 		const fragRef = makeRef();
 		const r = mount(ScrollNonFocusable, { fragRef });
 		const first = r.find('#first') as HTMLElement;
 		const second = r.find('#second') as HTMLElement;
-		let firstCalled = 0;
-		let secondCalled = 0;
+		const calls: string[] = [];
 		first.scrollIntoView = () => {
-			firstCalled++;
+			calls.push('first');
 		};
 		second.scrollIntoView = () => {
-			secondCalled++;
+			calls.push('second');
 		};
 		fragRef.current!.scrollIntoView();
-		expect(firstCalled).toBe(1);
-		expect(secondCalled).toBe(0);
+		expect(calls).toEqual(['second', 'first']);
+		calls.length = 0;
+		fragRef.current!.scrollIntoView(true);
+		expect(calls).toEqual(['second', 'first']);
+		r.unmount();
+	});
+
+	// Per ReactDOMFragmentRefs-test.js: "calls scrollIntoView on the last child if alignToTop is false".
+	it('scrolls children in tree order when aligning to the bottom', () => {
+		const fragRef = makeRef();
+		const r = mount(ScrollNonFocusable, { fragRef });
+		const calls: Array<[string, boolean | undefined]> = [];
+		for (const id of ['first', 'second']) {
+			(r.find('#' + id) as HTMLElement).scrollIntoView = (alignToTop?: boolean) => {
+				calls.push([id, alignToTop]);
+			};
+		}
+		fragRef.current!.scrollIntoView(false);
+		expect(calls).toEqual([
+			['first', false],
+			['second', false],
+		]);
+		r.unmount();
+	});
+
+	it('scrolls first-level children, not their focusable descendants', () => {
+		const fragRef = makeRef();
+		const r = mount(ScrollNestedFocusable, { fragRef });
+		const calls: string[] = [];
+		for (const id of ['first', 'second', 'nested']) {
+			(r.find('#' + id) as HTMLElement).scrollIntoView = () => calls.push(id);
+		}
+		fragRef.current!.scrollIntoView();
+		expect(calls).toEqual(['second', 'first']);
+		r.unmount();
+	});
+
+	// Per ReactDOMFragmentRefs-test.js: "does not yet support options".
+	it('rejects scroll options objects instead of passing them to DOM elements', () => {
+		const fragRef = makeRef();
+		const r = mount(ScrollTarget, { fragRef });
+		expect(() => fragRef.current!.scrollIntoView({ block: 'center' } as any)).toThrow(
+			'FragmentInstance.scrollIntoView() does not support scrollIntoViewOptions. Use the alignToTop boolean instead.',
+		);
+		expect(() => fragRef.current!.scrollIntoView(null as any)).toThrow(/alignToTop boolean/);
 		r.unmount();
 	});
 
@@ -71,6 +120,43 @@ describe('FragmentInstance.scrollIntoView', () => {
 		};
 		fragRef.current!.scrollIntoView(true);
 		expect(calls).toEqual([true]);
+		r.unmount();
+	});
+
+	// Per ReactDOMFragmentRefs-test.js: "calls scrollIntoView on the next sibling by default".
+	it('scrolls toward the next sibling for empty fragments by default', () => {
+		const fragRef = makeRef();
+		const r = mount(EmptyFragmentWithSiblings, { fragRef });
+		const calls: string[] = [];
+		(r.find('#before') as HTMLElement).scrollIntoView = () => calls.push('before');
+		(r.find('#after') as HTMLElement).scrollIntoView = () => calls.push('after');
+		fragRef.current!.scrollIntoView();
+		fragRef.current!.scrollIntoView(true);
+		expect(calls).toEqual(['after', 'after']);
+		r.unmount();
+	});
+
+	// Per ReactDOMFragmentRefs-test.js: "calls scrollIntoView on the prev sibling if alignToTop is false".
+	it('scrolls toward the previous sibling for bottom-aligned empty fragments', () => {
+		const fragRef = makeRef();
+		const r = mount(EmptyFragmentWithSiblings, { fragRef });
+		const calls: string[] = [];
+		(r.find('#before') as HTMLElement).scrollIntoView = () => calls.push('before');
+		(r.find('#after') as HTMLElement).scrollIntoView = () => calls.push('after');
+		fragRef.current!.scrollIntoView(false);
+		expect(calls).toEqual(['before']);
+		r.unmount();
+	});
+
+	// Per ReactDOMFragmentRefs-test.js: "calls scrollIntoView on the parent if there are no siblings".
+	it('scrolls the parent when an empty fragment has no siblings', () => {
+		const fragRef = makeRef();
+		const r = mount(EmptyFragmentWithoutSiblings, { fragRef });
+		const parent = r.find('#parent') as HTMLElement;
+		const scroll = vi.fn();
+		parent.scrollIntoView = scroll;
+		fragRef.current!.scrollIntoView();
+		expect(scroll).toHaveBeenCalledWith(undefined);
 		r.unmount();
 	});
 });
@@ -94,6 +180,106 @@ describe('FragmentInstance — text-only fragment (no host children)', () => {
 		r.unmount();
 	});
 
+	// Per ReactDOMFragmentRefs-test.js: "getClientRects includes text node bounds".
+	it('includes text-node client rectangles when the Range API provides them', () => {
+		const fragRef = makeRef();
+		const r = mount(TextOnly, { fragRef });
+		const rect = { width: 80, height: 16 } as DOMRect;
+		const selected: Node[] = [];
+		const createRange = vi.spyOn(document, 'createRange').mockImplementation(
+			() =>
+				({
+					selectNodeContents(node: Node) {
+						selected.push(node);
+					},
+					getClientRects: () => [rect],
+				}) as unknown as Range,
+		);
+		try {
+			expect(fragRef.current!.getClientRects()).toEqual([rect]);
+			expect(selected.map((node) => node.textContent)).toEqual(['just text']);
+		} finally {
+			createRange.mockRestore();
+			r.unmount();
+		}
+	});
+
+	// Per ReactDOMFragmentRefs-test.js: "getClientRects includes both text and element bounds".
+	it('preserves document order across mixed text and element rectangles', () => {
+		const fragRef = makeRef();
+		const r = mount(MixedTextAndElements, { fragRef });
+		const elementRect = { width: 100 } as DOMRect;
+		(r.find('#middle') as HTMLElement).getClientRects = () => [elementRect] as any;
+		const createRange = vi.spyOn(document, 'createRange').mockImplementation(() => {
+			let node: Node;
+			return {
+				selectNodeContents(selected: Node) {
+					node = selected;
+				},
+				getClientRects: () => [{ width: node.textContent === 'before' ? 60 : 40 }],
+			} as unknown as Range;
+		});
+		try {
+			expect(fragRef.current!.getClientRects().map((rect) => rect.width)).toEqual([60, 100, 40]);
+		} finally {
+			createRange.mockRestore();
+			r.unmount();
+		}
+	});
+
+	// Per ReactDOMFragmentRefs-test.js: "scrollIntoView works on text-only fragment using Range API".
+	it('scrolls text nodes through their Range geometry', () => {
+		const fragRef = makeRef();
+		const r = mount(TextOnly, { fragRef });
+		const createRange = vi.spyOn(document, 'createRange').mockImplementation(
+			() =>
+				({
+					selectNodeContents() {},
+					getBoundingClientRect: () => ({ left: 100, top: 200, bottom: 216 }),
+				}) as unknown as Range,
+		);
+		const scroll = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+		try {
+			fragRef.current!.scrollIntoView();
+			expect(scroll).toHaveBeenLastCalledWith(window.scrollX + 100, window.scrollY + 200);
+			fragRef.current!.scrollIntoView(false);
+			expect(scroll).toHaveBeenLastCalledWith(
+				window.scrollX + 100,
+				window.scrollY + 216 - window.innerHeight,
+			);
+		} finally {
+			scroll.mockRestore();
+			createRange.mockRestore();
+			r.unmount();
+		}
+	});
+
+	// Per ReactDOMFragmentRefs-test.js: "scrollIntoView scrolls to text siblings of an empty fragment".
+	it('uses the correct neighboring text node when an empty fragment scrolls', () => {
+		const fragRef = makeRef();
+		const r = mount(EmptyFragmentWithTextSiblings, { fragRef });
+		const selected: string[] = [];
+		const createRange = vi.spyOn(document, 'createRange').mockImplementation(
+			() =>
+				({
+					selectNodeContents(node: Node) {
+						selected.push(node.textContent!);
+					},
+					getBoundingClientRect: () => ({ left: 0, top: 0, bottom: 10 }),
+				}) as unknown as Range,
+		);
+		const scroll = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+		try {
+			fragRef.current!.scrollIntoView();
+			fragRef.current!.scrollIntoView(false);
+			expect(selected).toEqual(['after', 'before']);
+		} finally {
+			scroll.mockRestore();
+			createRange.mockRestore();
+			r.unmount();
+		}
+	});
+
 	it('getRootNode falls back to the start marker document', () => {
 		const fragRef = makeRef();
 		const r = mount(TextOnly, { fragRef });
@@ -103,15 +289,113 @@ describe('FragmentInstance — text-only fragment (no host children)', () => {
 		r.unmount();
 	});
 
-	it('addEventListener is a no-op (no children to attach to)', () => {
+	// Per ReactDOMFragmentRefs-test.js: "returns self when only the fragment was unmounted".
+	it('returns the captured fragment instance after it has been unmounted', () => {
 		const fragRef = makeRef();
 		const r = mount(TextOnly, { fragRef });
-		let fired = 0;
-		fragRef.current!.addEventListener('click', () => fired++);
-		// No host children → nothing to dispatch on. The fragment's text
-		// content stays unaffected. Verifies no crash and no spurious wire-up.
-		expect(fired).toBe(0);
+		const instance = fragRef.current!;
 		r.unmount();
+		expect(instance.getRootNode()).toBe(instance);
+	});
+
+	it('forwards composed root lookup options through shadow boundaries', () => {
+		const fragRef = makeRef();
+		const host = document.createElement('div');
+		document.body.appendChild(host);
+		const shadow = host.attachShadow({ mode: 'open' });
+		const container = document.createElement('div');
+		shadow.appendChild(container);
+		const root = createRoot(container);
+		try {
+			root.render(ScrollTarget, { fragRef });
+			flushSync(() => {});
+			expect(fragRef.current!.getRootNode()).toBe(shadow);
+			expect(fragRef.current!.getRootNode({ composed: true })).toBe(document);
+		} finally {
+			root.unmount();
+			host.remove();
+		}
+	});
+
+	// Per ReactFiberConfigDOM: text hosts retain their owning Fragment handles.
+	it('publishes fragment ownership on direct text nodes', () => {
+		const fragRef = makeRef();
+		const r = mount(TextOnly, { fragRef });
+		const text = Array.from(r.find('#parent').childNodes).find(
+			(node) => node.nodeType === Node.TEXT_NODE,
+		) as Text & { reactFragments?: Set<FragmentInstance> };
+		const fragment = fragRef.current!;
+		expect(text.reactFragments?.has(fragment)).toBe(true);
+		r.unmount();
+		expect(text.reactFragments?.has(fragment)).toBe(false);
+	});
+
+	// Per ReactFiberConfigDOM: fragment event listeners include direct text hosts.
+	it('attaches and removes event listeners on direct text children', () => {
+		const fragRef = makeRef();
+		const r = mount(TextOnly, { fragRef });
+		const text = Array.from(r.find('#parent').childNodes).find(
+			(node) => node.nodeType === Node.TEXT_NODE,
+		)!;
+		let fired = 0;
+		const listener = () => fired++;
+		fragRef.current!.addEventListener('customping', listener);
+		text.dispatchEvent(new Event('customping'));
+		expect(fired).toBe(1);
+		fragRef.current!.removeEventListener('customping', listener);
+		text.dispatchEvent(new Event('customping'));
+		expect(fired).toBe(1);
+		r.unmount();
+	});
+});
+
+describe('FragmentInstance — portaled imperative children', () => {
+	// Per ReactDOMFragmentRefs-test.js: "handles portaled elements -- same scroll container".
+	it('measures and scrolls portaled children in their authored logical order', () => {
+		const target = document.createElement('section');
+		document.body.appendChild(target);
+		const fragRef = makeRef();
+		const r = mount(FragmentPortalChildren, { fragRef, target });
+		try {
+			const before = r.find('#inline-before') as HTMLElement;
+			const portal = target.querySelector('#owned-portal') as HTMLElement;
+			const after = r.find('#inline-after') as HTMLElement;
+			const children = [before, portal, after];
+			for (const child of children) {
+				child.getClientRects = () => [{ width: children.indexOf(child) + 1 }] as any;
+			}
+			expect(fragRef.current!.getClientRects().map((rect) => rect.width)).toEqual([1, 2, 3]);
+
+			const calls: string[] = [];
+			for (const child of children) child.scrollIntoView = () => calls.push(child.id);
+			fragRef.current!.scrollIntoView();
+			expect(calls).toEqual(['inline-after', 'owned-portal', 'inline-before']);
+			calls.length = 0;
+			fragRef.current!.scrollIntoView(false);
+			expect(calls).toEqual(['inline-before', 'owned-portal', 'inline-after']);
+		} finally {
+			r.unmount();
+			target.remove();
+		}
+	});
+
+	it('focuses and blurs the logically owned focusable portal child', () => {
+		const target = document.createElement('section');
+		document.body.appendChild(target);
+		const fragRef = makeRef();
+		const r = mount(FragmentPortalChildren, { fragRef, target });
+		try {
+			(r.find('#inline-before') as HTMLButtonElement).disabled = true;
+			(r.find('#inline-after') as HTMLButtonElement).disabled = true;
+			const portal = target.querySelector('#owned-portal') as HTMLButtonElement;
+			fragRef.current!.focus();
+			expect(document.activeElement).toBe(portal);
+			fragRef.current!.blur();
+			expect(document.activeElement).not.toBe(portal);
+		} finally {
+			r.unmount();
+			target.remove();
+		}
 	});
 });
 

--- a/packages/octane/tests/conformance/fragment-refs-observers.test.ts
+++ b/packages/octane/tests/conformance/fragment-refs-observers.test.ts
@@ -6,10 +6,12 @@
 // order. getRootNode delegates to the first child (falling back to the
 // start marker's document when the fragment has no children) so tooltip
 // libraries can resolve the right ownerDocument / ShadowRoot.
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { mount } from '../_helpers';
 import { FragmentInstance } from '../../src/index.js';
 import { ThreeSiblings } from './_fixtures/fragment-refs-observers.tsrx';
+import { TextOnly } from './_fixtures/fragment-refs-misc.tsrx';
+import { EmptyFragment } from './_fixtures/fragment-refs-events.tsrx';
 
 function makeRef(): { current: FragmentInstance | null } {
 	return { current: null };
@@ -52,6 +54,79 @@ describe('FragmentInstance.observeUsing / unobserveUsing', () => {
 		fragRef.current!.unobserveUsing(obs);
 		expect(obs.unobserved.map((e) => e.id)).toEqual(['x', 'y', 'z']);
 		r.unmount();
+	});
+
+	// Per ReactDOMFragmentRefs-test.js:1255.
+	it('warns without unobserving when the observer was never registered', () => {
+		const fragRef = makeRef();
+		const r = mount(ThreeSiblings, { fragRef });
+		const observer = makeMockObserver();
+		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			fragRef.current!.unobserveUsing(observer);
+			expect(error).toHaveBeenCalledWith(
+				'You are calling unobserveUsing() with an observer that is not being observed with this fragment ' +
+					'instance. First attach the observer with observeUsing()',
+			);
+			expect(observer.unobserved).toEqual([]);
+		} finally {
+			error.mockRestore();
+			r.unmount();
+		}
+	});
+
+	// Per ReactDOMFragmentRefs-test.js:1255.
+	it('warns without touching a different observer while keeping the registered one', () => {
+		const fragRef = makeRef();
+		const r = mount(ThreeSiblings, { fragRef });
+		const registered = makeMockObserver();
+		const unrelated = makeMockObserver();
+		fragRef.current!.observeUsing(registered);
+		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			fragRef.current!.unobserveUsing(unrelated);
+			expect(error).toHaveBeenCalledOnce();
+			expect(unrelated.unobserved).toEqual([]);
+			fragRef.current!.unobserveUsing(registered);
+			expect(registered.unobserved.map((element) => element.id)).toEqual(['x', 'y', 'z']);
+		} finally {
+			error.mockRestore();
+			r.unmount();
+		}
+	});
+
+	// Per ReactDOMFragmentRefs-test.js:2774.
+	it('warns when an observer is attached to a fragment containing only text', () => {
+		const fragRef = makeRef();
+		const r = mount(TextOnly, { fragRef });
+		const observer = makeMockObserver();
+		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			fragRef.current!.observeUsing(observer);
+			expect(error).toHaveBeenCalledWith(
+				'observeUsing() was called on a FragmentInstance with only text children. ' +
+					'Observers do not work on text nodes.',
+			);
+			expect(observer.observed).toEqual([]);
+		} finally {
+			error.mockRestore();
+			r.unmount();
+		}
+	});
+
+	it('does not warn when an observer is attached to an empty fragment', () => {
+		const fragRef = makeRef();
+		const r = mount(EmptyFragment, { fragRef });
+		const observer = makeMockObserver();
+		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			fragRef.current!.observeUsing(observer);
+			expect(error).not.toHaveBeenCalled();
+			expect(observer.observed).toEqual([]);
+		} finally {
+			error.mockRestore();
+			r.unmount();
+		}
 	});
 });
 

--- a/packages/octane/tests/conformance/fragment-refs-parity-ledger.test.ts
+++ b/packages/octane/tests/conformance/fragment-refs-parity-ledger.test.ts
@@ -1,0 +1,236 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mount, type MountResult } from '../_helpers';
+import { FragmentInstance } from '../../src/index.js';
+import {
+	LedgerDynamicFocus,
+	LedgerInterleavedPortals,
+	LedgerNestedFocus,
+	LedgerPortaledEmptyFragment,
+	LedgerPortalScrollContainers,
+	LedgerRemovableFragment,
+	LedgerRootPositions,
+} from './_fixtures/fragment-refs-parity-ledger.tsrx';
+import { NestedFragments } from './_fixtures/fragment-refs-misc.tsrx';
+
+let mounted: MountResult | null = null;
+const portalTargets: Element[] = [];
+
+afterEach(() => {
+	try {
+		mounted?.unmount();
+	} finally {
+		mounted = null;
+		for (const target of portalTargets) target.remove();
+		portalTargets.length = 0;
+		vi.restoreAllMocks();
+	}
+});
+
+function makeRef(): { current: FragmentInstance | null } {
+	return { current: null };
+}
+
+describe('Fragment refs — upstream parity audit oracles', () => {
+	it('focuses deeply nested focusable children depth-first with focus()', () => {
+		const fragmentRef = makeRef();
+		mounted = mount(LedgerNestedFocus, { fragmentRef });
+		fragmentRef.current!.focus();
+		expect(document.activeElement).toBe(mounted.find('#ledger-focus-first'));
+	});
+
+	it('focuses deeply nested focusable children depth-first with focusLast()', () => {
+		const fragmentRef = makeRef();
+		mounted = mount(LedgerNestedFocus, { fragmentRef });
+		fragmentRef.current!.focusLast();
+		expect(document.activeElement).toBe(mounted.find('#ledger-focus-last-nested'));
+	});
+
+	it('keeps focus on a nested child if already focused', () => {
+		const fragmentRef = makeRef();
+		mounted = mount(LedgerNestedFocus, { fragmentRef });
+		const nested = mounted.find('#ledger-focus-first') as HTMLElement;
+		nested.focus();
+		const focus = vi.spyOn(nested, 'focus');
+		fragmentRef.current!.focus();
+		expect(document.activeElement).toBe(nested);
+		expect(focus).not.toHaveBeenCalled();
+	});
+
+	it('preserves document order when adding and removing focusable children', () => {
+		const fragmentRef = makeRef();
+		const props = { fragmentRef, showFirst: true, showSecond: false };
+		mounted = mount(LedgerDynamicFocus, props);
+		const fragment = fragmentRef.current!;
+		fragment.focus();
+		expect(document.activeElement).toBe(mounted.find('#ledger-dynamic-first'));
+		(document.activeElement as HTMLElement).blur();
+
+		mounted.update(LedgerDynamicFocus, { ...props, showSecond: true });
+		fragment.focus();
+		expect(document.activeElement).toBe(mounted.find('#ledger-dynamic-first'));
+		(document.activeElement as HTMLElement).blur();
+
+		mounted.update(LedgerDynamicFocus, { ...props, showFirst: false, showSecond: true });
+		fragment.focus();
+		expect(document.activeElement).toBe(mounted.find('#ledger-dynamic-second'));
+	});
+
+	it('removes focus from a nested element inside the Fragment', () => {
+		const fragmentRef = makeRef();
+		mounted = mount(LedgerNestedFocus, { fragmentRef });
+		const nested = mounted.find('#ledger-focus-first-nested') as HTMLElement;
+		nested.focus();
+		expect(document.activeElement).toBe(nested);
+		fragmentRef.current!.blur();
+		expect(document.activeElement).not.toBe(nested);
+	});
+
+	it('adds and removes event listeners from children with multiple fragments', () => {
+		const outerRef = makeRef();
+		const innerRef = makeRef();
+		mounted = mount(NestedFragments, { outerRef, innerRef });
+		const fired: string[] = [];
+		const onOuter = () => fired.push('outer');
+		const onInner = () => fired.push('inner');
+		outerRef.current!.addEventListener('click', onOuter);
+		innerRef.current!.addEventListener('click', onInner);
+		mounted.find('#inner-a').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(fired).toEqual(['outer', 'inner']);
+
+		fired.length = 0;
+		mounted.find('#outer-a').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(fired).toEqual(['outer']);
+
+		outerRef.current!.removeEventListener('click', onOuter);
+		mounted.find('#inner-a').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(fired).toEqual(['outer', 'inner']);
+		innerRef.current!.removeEventListener('click', onInner);
+		mounted.find('#inner-a').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(fired).toEqual(['outer', 'inner']);
+	});
+
+	it('returns disconnected for comparison with an unmounted fragment instance', () => {
+		const fragmentRef = makeRef();
+		mounted = mount(LedgerRemovableFragment, { fragmentRef, mounted: true });
+		const fragment = fragmentRef.current!;
+		const parent = mounted.find('#ledger-removable-parent');
+		expect(fragment.compareDocumentPosition(parent)).toBe(
+			Node.DOCUMENT_POSITION_PRECEDING | Node.DOCUMENT_POSITION_CONTAINS,
+		);
+
+		mounted.update(LedgerRemovableFragment, { fragmentRef, mounted: false });
+		expect(fragment.compareDocumentPosition(parent)).toBe(Node.DOCUMENT_POSITION_DISCONNECTED);
+	});
+
+	it('compares a root-level Fragment and its empty Fragment sibling', () => {
+		const fragmentRef = makeRef();
+		const emptyRef = makeRef();
+		mounted = mount(LedgerRootPositions, { fragmentRef, emptyRef });
+		const fragment = fragmentRef.current!;
+		const empty = emptyRef.current!;
+		const before = mounted.find('#ledger-root-before');
+		const child = mounted.find('#ledger-root-child');
+		const after = mounted.find('#ledger-root-after');
+		expect(fragment.compareDocumentPosition(child)).toBe(Node.DOCUMENT_POSITION_CONTAINED_BY);
+		expect(fragment.compareDocumentPosition(before)).toBe(Node.DOCUMENT_POSITION_PRECEDING);
+		expect(fragment.compareDocumentPosition(after)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+		expect(empty.compareDocumentPosition(child)).toBe(
+			Node.DOCUMENT_POSITION_PRECEDING | Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC,
+		);
+		expect(empty.compareDocumentPosition(after)).toBe(
+			Node.DOCUMENT_POSITION_FOLLOWING | Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC,
+		);
+	});
+
+	it('compares an empty Fragment rendered into a portal', () => {
+		const fragmentRef = makeRef();
+		mounted = mount(LedgerPortaledEmptyFragment, { fragmentRef, target: document.body });
+		const fragment = fragmentRef.current!;
+		expect(fragment.compareDocumentPosition(document.body)).toBe(
+			Node.DOCUMENT_POSITION_PRECEDING |
+				Node.DOCUMENT_POSITION_CONTAINS |
+				Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC,
+		);
+		for (const selector of ['#ledger-empty-before', '#ledger-empty-after']) {
+			expect(fragment.compareDocumentPosition(mounted.find(selector))).toBe(
+				Node.DOCUMENT_POSITION_PRECEDING | Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC,
+			);
+		}
+	});
+
+	it('distinguishes multiple Fragment-owned portals sharing one foreign target', () => {
+		const firstTarget = document.createElement('section');
+		const secondTarget = document.createElement('section');
+		document.body.append(firstTarget, secondTarget);
+		portalTargets.push(firstTarget, secondTarget);
+		const fragmentRef = makeRef();
+		mounted = mount(LedgerPortalScrollContainers, { fragmentRef, firstTarget, secondTarget });
+		for (const id of ['ledger-portal-second', 'ledger-portal-third']) {
+			const portaled = secondTarget.querySelector('#' + id)!;
+			expect(fragmentRef.current!.compareDocumentPosition(portaled)).toBe(
+				Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC,
+			);
+		}
+		const outside = secondTarget.querySelector('#ledger-portal-outside')!;
+		expect(
+			fragmentRef.current!.compareDocumentPosition(outside) & Node.DOCUMENT_POSITION_CONTAINED_BY,
+		).toBe(0);
+	});
+
+	it('validates logical position when sibling portals share the same host', () => {
+		const fragmentRef = makeRef();
+		const props = { fragmentRef, target: document.body, showLate: false };
+		mounted = mount(LedgerInterleavedPortals, props);
+		expect(fragmentRef.current).toBeInstanceOf(FragmentInstance);
+		mounted.update(LedgerInterleavedPortals, { ...props, showLate: true });
+		expect(fragmentRef.current).toBeInstanceOf(FragmentInstance);
+		const fragment = fragmentRef.current!;
+		const first = document.querySelector('#ledger-shared-first')!;
+		const outside = document.querySelector('#ledger-shared-outside')!;
+		const late = document.querySelector('#ledger-shared-late')!;
+		const nested = document.querySelector('#ledger-shared-nested')!;
+		const sourceBefore = mounted.find('#ledger-shared-source-before');
+		const sourceAfter = mounted.find('#ledger-shared-source-after');
+		expect(
+			Array.from(
+				document.querySelectorAll(
+					'#ledger-shared-first, #ledger-shared-outside, #ledger-shared-late',
+				),
+			).map((element) => element.id),
+		).toEqual(['ledger-shared-first', 'ledger-shared-outside', 'ledger-shared-late']);
+		expect(fragment.compareDocumentPosition(document.body)).toBe(
+			Node.DOCUMENT_POSITION_PRECEDING | Node.DOCUMENT_POSITION_CONTAINS,
+		);
+		for (const child of [first, late, nested]) {
+			expect(fragment.compareDocumentPosition(child)).toBe(Node.DOCUMENT_POSITION_CONTAINED_BY);
+		}
+		expect(fragment.compareDocumentPosition(sourceBefore)).toBe(Node.DOCUMENT_POSITION_PRECEDING);
+		expect(fragment.compareDocumentPosition(outside)).toBe(
+			Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC,
+		);
+		expect(fragment.compareDocumentPosition(sourceAfter)).toBe(
+			Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC,
+		);
+	});
+
+	it('scrolls portaled children in order across different scroll containers', () => {
+		const firstTarget = document.createElement('section');
+		const secondTarget = document.createElement('section');
+		document.body.append(firstTarget, secondTarget);
+		portalTargets.push(firstTarget, secondTarget);
+		const fragmentRef = makeRef();
+		mounted = mount(LedgerPortalScrollContainers, { fragmentRef, firstTarget, secondTarget });
+		const calls: string[] = [];
+		for (const target of [firstTarget, secondTarget]) {
+			for (const child of target.querySelectorAll('button')) {
+				child.scrollIntoView = () => calls.push(child.id);
+			}
+		}
+
+		fragmentRef.current!.scrollIntoView();
+		expect(calls).toEqual(['ledger-portal-third', 'ledger-portal-second', 'ledger-portal-first']);
+		calls.length = 0;
+		fragmentRef.current!.scrollIntoView(false);
+		expect(calls).toEqual(['ledger-portal-first', 'ledger-portal-second', 'ledger-portal-third']);
+	});
+});

--- a/packages/octane/tests/conformance/fragment-refs-position.test.ts
+++ b/packages/octane/tests/conformance/fragment-refs-position.test.ts
@@ -1,19 +1,19 @@
 // FragmentInstance.compareDocumentPosition / dispatchEvent — React canary parity.
 //
-// compareDocumentPosition uses the platform's bitmask, with CONTAINED_BY
-// indicating that the supplied node lives between the fragment's markers
-// (and DISCONNECTED indicating the node isn't in the same tree).
-//
-// dispatchEvent dispatches on the parent host node (the fragment itself
-// has no DOM, so the parent is the closest meaningful target) and returns
-// the dispatch result.
+// compareDocumentPosition preserves React's exact containment and empty-fragment
+// bitmasks. dispatchEvent distinguishes fragment-local listeners from bubbling
+// listeners on surrounding host elements.
 import { describe, it, expect } from 'vitest';
 import { mount } from '../_helpers';
 import { FragmentInstance } from '../../src/index.js';
 import {
 	SurroundedFragment,
 	ParentWithFragmentChild,
+	EmptySurroundedFragment,
+	NestedPositionFragment,
 } from './_fixtures/fragment-refs-position.tsrx';
+import { FragmentPortalChildren } from './_fixtures/fragment-future.tsrx';
+import { TextOnly } from './_fixtures/fragment-refs-misc.tsrx';
 
 function makeRef(): { current: FragmentInstance | null } {
 	return { current: null };
@@ -42,15 +42,71 @@ describe('FragmentInstance.compareDocumentPosition', () => {
 		r.unmount();
 	});
 
-	it('returns CONTAINED_BY | FOLLOWING for a child inside the fragment', () => {
+	// Per ReactDOMFragmentRefs-test.js: "handles multiple children".
+	it('returns exactly CONTAINED_BY for a child inside the fragment', () => {
 		const fragRef = makeRef();
 		const r = mount(SurroundedFragment, { fragRef });
 		const inside = r.find('#inside');
 		const flags = fragRef.current!.compareDocumentPosition(inside);
-		expect(flags & Node.DOCUMENT_POSITION_CONTAINED_BY).toBeTruthy();
-		expect(flags & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-		// Not PRECEDING — the inside child comes AFTER the start marker.
-		expect(flags & Node.DOCUMENT_POSITION_PRECEDING).toBeFalsy();
+		expect(flags).toBe(Node.DOCUMENT_POSITION_CONTAINED_BY);
+		r.unmount();
+	});
+
+	it('returns exactly CONTAINED_BY for a descendant of a fragment child', () => {
+		const fragRef = makeRef();
+		const r = mount(NestedPositionFragment, { fragRef });
+		expect(fragRef.current!.compareDocumentPosition(r.find('#nested'))).toBe(
+			Node.DOCUMENT_POSITION_CONTAINED_BY,
+		);
+		r.unmount();
+	});
+
+	// Per ReactDOMFragmentRefs-test.js: "compareDocumentPosition works with text children".
+	it('reports exact containment for direct text children', () => {
+		const fragRef = makeRef();
+		const r = mount(TextOnly, { fragRef });
+		const text = Array.from(r.find('#parent').childNodes).find(
+			(node) => node.nodeType === Node.TEXT_NODE,
+		)!;
+		expect(fragRef.current!.compareDocumentPosition(text)).toBe(
+			Node.DOCUMENT_POSITION_CONTAINED_BY,
+		);
+		r.unmount();
+	});
+
+	it('reports that ancestors precede and contain a nonempty fragment', () => {
+		const fragRef = makeRef();
+		const r = mount(SurroundedFragment, { fragRef });
+		const expected = Node.DOCUMENT_POSITION_PRECEDING | Node.DOCUMENT_POSITION_CONTAINS;
+		expect(fragRef.current!.compareDocumentPosition(r.find('#parent'))).toBe(expected);
+		expect(fragRef.current!.compareDocumentPosition(document.body)).toBe(expected);
+		r.unmount();
+	});
+
+	// Per ReactDOMFragmentRefs-test.js: "handles empty fragment instances".
+	it('marks empty-fragment sibling positions as implementation-specific', () => {
+		const fragRef = makeRef();
+		const r = mount(EmptySurroundedFragment, { fragRef });
+		expect(fragRef.current!.compareDocumentPosition(r.find('#before'))).toBe(
+			Node.DOCUMENT_POSITION_PRECEDING | Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC,
+		);
+		expect(fragRef.current!.compareDocumentPosition(r.find('#after'))).toBe(
+			Node.DOCUMENT_POSITION_FOLLOWING | Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC,
+		);
+		r.unmount();
+	});
+
+	it('reports exact parent and ancestor flags for empty fragments', () => {
+		const fragRef = makeRef();
+		const r = mount(EmptySurroundedFragment, { fragRef });
+		expect(fragRef.current!.compareDocumentPosition(r.find('#parent'))).toBe(
+			Node.DOCUMENT_POSITION_CONTAINS | Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC,
+		);
+		expect(fragRef.current!.compareDocumentPosition(document.body)).toBe(
+			Node.DOCUMENT_POSITION_PRECEDING |
+				Node.DOCUMENT_POSITION_CONTAINS |
+				Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC,
+		);
 		r.unmount();
 	});
 
@@ -61,6 +117,27 @@ describe('FragmentInstance.compareDocumentPosition', () => {
 		const flags = fragRef.current!.compareDocumentPosition(detached);
 		expect(flags & Node.DOCUMENT_POSITION_DISCONNECTED).toBeTruthy();
 		r.unmount();
+	});
+
+	// Per ReactDOMFragmentRefs-test.js: "handles portaled elements".
+	it('marks logically owned portaled children as implementation-specific', () => {
+		const target = document.createElement('section');
+		document.body.appendChild(target);
+		const fragRef = makeRef();
+		const r = mount(FragmentPortalChildren, { fragRef, target });
+		try {
+			const owned = target.querySelector('#owned-portal')!;
+			const outside = target.querySelector('#unowned-portal')!;
+			expect(fragRef.current!.compareDocumentPosition(owned)).toBe(
+				Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC,
+			);
+			expect(
+				fragRef.current!.compareDocumentPosition(outside) & Node.DOCUMENT_POSITION_PRECEDING,
+			).toBeTruthy();
+		} finally {
+			r.unmount();
+			target.remove();
+		}
 	});
 });
 
@@ -75,7 +152,7 @@ describe('FragmentInstance.dispatchEvent', () => {
 			expect(e.type).toBe('customping');
 		};
 		parent.addEventListener('customping', handler);
-		const result = fragRef.current!.dispatchEvent(new Event('customping'));
+		const result = fragRef.current!.dispatchEvent(new Event('customping', { bubbles: true }));
 		expect(fired).toBe(1);
 		expect(result).toBe(true);
 		parent.removeEventListener('customping', handler);
@@ -88,9 +165,61 @@ describe('FragmentInstance.dispatchEvent', () => {
 		const parent = r.find('#parent') as HTMLElement;
 		const handler = (e: Event) => e.preventDefault();
 		parent.addEventListener('customping', handler);
-		const result = fragRef.current!.dispatchEvent(new Event('customping', { cancelable: true }));
+		const result = fragRef.current!.dispatchEvent(
+			new Event('customping', { bubbles: true, cancelable: true }),
+		);
 		expect(result).toBe(false);
 		parent.removeEventListener('customping', handler);
+		r.unmount();
+	});
+
+	// Per ReactDOMFragmentRefs-test.js: "fires events on self, and only self if bubbles=false".
+	it('delivers non-bubbling events only to listeners attached to the fragment', () => {
+		const fragRef = makeRef();
+		const r = mount(ParentWithFragmentChild, { fragRef });
+		const parent = r.find('#parent') as HTMLElement;
+		const events: string[] = [];
+		parent.addEventListener('customping', () => events.push('parent'));
+		fragRef.current!.addEventListener('customping', () => events.push('fragment'));
+		const before = parent.innerHTML;
+		expect(fragRef.current!.dispatchEvent(new Event('customping'))).toBe(true);
+		expect(events).toEqual(['fragment']);
+		expect(parent.innerHTML).toBe(before);
+		r.unmount();
+	});
+
+	it('delivers bubbling events to the fragment before their host parent', () => {
+		const fragRef = makeRef();
+		const r = mount(ParentWithFragmentChild, { fragRef });
+		const parent = r.find('#parent') as HTMLElement;
+		const events: string[] = [];
+		parent.addEventListener('customping', () => events.push('parent'));
+		fragRef.current!.addEventListener('customping', () => events.push('fragment'));
+		fragRef.current!.dispatchEvent(new Event('customping', { bubbles: true }));
+		expect(events).toEqual(['fragment', 'parent']);
+		r.unmount();
+	});
+
+	it('does not deliver non-bubbling events to host parents when no fragment listener exists', () => {
+		const fragRef = makeRef();
+		const r = mount(ParentWithFragmentChild, { fragRef });
+		const parent = r.find('#parent') as HTMLElement;
+		let fired = false;
+		parent.addEventListener('customping', () => {
+			fired = true;
+		});
+		expect(fragRef.current!.dispatchEvent(new Event('customping'))).toBe(true);
+		expect(fired).toBe(false);
+		r.unmount();
+	});
+
+	it('returns false when a fragment-local listener prevents a cancelable event', () => {
+		const fragRef = makeRef();
+		const r = mount(ParentWithFragmentChild, { fragRef });
+		fragRef.current!.addEventListener('customping', (event) => event.preventDefault());
+		expect(fragRef.current!.dispatchEvent(new Event('customping', { cancelable: true }))).toBe(
+			false,
+		);
 		r.unmount();
 	});
 });

--- a/packages/octane/tests/conformance/fragment-refs.test.ts
+++ b/packages/octane/tests/conformance/fragment-refs.test.ts
@@ -9,12 +9,35 @@ import { describe, it, expect } from 'vitest';
 import { mount, flushEffects } from '../_helpers';
 import { FragmentInstance } from '../../src/index.js';
 import {
+	AliasedFragmentObjectRef,
+	AliasedSpreadFragmentObjectRef,
+	ExplicitThenSpreadFragmentRef,
+	ForeignFragmentAlias,
 	FragmentObjectRef,
 	FragmentCallbackRef,
 	FragmentChangingCallbackRef,
+	FragmentEffectListener,
 	FragmentRenderPhaseCallbackRef,
 	FragmentEffectVisibility,
+	FragmentWrappedHostChildren,
+	NamespacedFragmentObjectRef,
+	NamespacedSpreadFragmentObjectRef,
+	OrderedFragmentSpreadEvaluation,
+	ReturnedAliasedFragmentObjectRef,
+	ReturnedNamespacedFragmentObjectRef,
+	ReturnedNamespacedFragmentSpreadEvaluation,
+	ShadowedFragmentAlias,
+	ShadowedFragmentNamespace,
+	SpreadFragmentObjectRef,
+	SpreadThenExplicitFragmentRef,
 } from './_fixtures/fragment-refs.tsrx';
+import {
+	AutomaticJsxAliasedFragmentRef,
+	AutomaticJsxNamespacedFragmentRef,
+	AutomaticJsxNamespacedSpreadFragmentRef,
+	AutomaticJsxReturnedSpreadEvaluation,
+	AutomaticJsxSpreadFragmentRef,
+} from './_fixtures/fragment-refs.tsx';
 
 describe('Fragment refs — basic attach (React enableFragmentRefs parity)', () => {
 	it('attaches a FragmentInstance to an object ref', () => {
@@ -31,6 +54,214 @@ describe('Fragment refs — basic attach (React enableFragmentRefs parity)', () 
 		r.unmount();
 		// Object refs are nulled on unmount.
 		expect(fragRef.current).toBeNull();
+	});
+
+	it.each([
+		['aliased', AliasedFragmentObjectRef, '#alias-child', 'aliased'],
+		['namespaced', NamespacedFragmentObjectRef, '#namespace-child', 'namespaced'],
+		[
+			'returned aliased',
+			ReturnedAliasedFragmentObjectRef,
+			'#returned-alias-child',
+			'returned alias',
+		],
+		[
+			'returned namespaced',
+			ReturnedNamespacedFragmentObjectRef,
+			'#returned-namespace-child',
+			'returned namespace',
+		],
+		[
+			'automatic JSX aliased',
+			AutomaticJsxAliasedFragmentRef,
+			'#tsx-alias-child',
+			'automatic alias',
+		],
+		[
+			'automatic JSX namespaced',
+			AutomaticJsxNamespacedFragmentRef,
+			'#tsx-namespace-child',
+			'automatic namespace',
+		],
+	] as const)(
+		'attaches a FragmentInstance through an %s Octane import',
+		(_kind, App, selector, text) => {
+			const fragRef: { current: FragmentInstance | null } = { current: null };
+			const root = mount(App, { fragRef });
+			expect(fragRef.current).toBeInstanceOf(FragmentInstance);
+			expect(root.find(selector).textContent).toBe(text);
+			root.unmount();
+			expect(fragRef.current).toBeNull();
+		},
+	);
+
+	it.each([
+		['ordinary', SpreadFragmentObjectRef, '#spread-child', 'spread'],
+		['aliased', AliasedSpreadFragmentObjectRef, '#spread-alias-child', 'spread alias'],
+		[
+			'namespaced',
+			NamespacedSpreadFragmentObjectRef,
+			'#spread-namespace-child',
+			'spread namespace',
+		],
+		['automatic JSX', AutomaticJsxSpreadFragmentRef, '#tsx-spread-child', 'automatic spread'],
+		[
+			'automatic JSX namespace',
+			AutomaticJsxNamespacedSpreadFragmentRef,
+			'#tsx-spread-namespace-child',
+			'automatic namespace spread',
+		],
+	] as const)(
+		'attaches a FragmentInstance through an %s spread ref',
+		(_kind, App, selector, text) => {
+			const fragRef: { current: FragmentInstance | null } = { current: null };
+			const root = mount(App, { spread: { ref: fragRef } });
+			expect(fragRef.current).toBeInstanceOf(FragmentInstance);
+			expect(root.find(selector).textContent).toBe(text);
+			root.unmount();
+			expect(fragRef.current).toBeNull();
+		},
+	);
+
+	it('lets a later spread override an explicit Fragment ref', () => {
+		const explicit: { current: FragmentInstance | null } = { current: null };
+		const spread: { current: FragmentInstance | null } = { current: null };
+		const root = mount(ExplicitThenSpreadFragmentRef, {
+			fragRef: explicit,
+			spread: { ref: spread },
+		});
+
+		expect(explicit.current).toBeNull();
+		expect(spread.current).toBeInstanceOf(FragmentInstance);
+		root.unmount();
+		expect(spread.current).toBeNull();
+	});
+
+	it('lets a later explicit Fragment ref override a spread', () => {
+		const explicit: { current: FragmentInstance | null } = { current: null };
+		const spread: { current: FragmentInstance | null } = { current: null };
+		const root = mount(SpreadThenExplicitFragmentRef, {
+			fragRef: explicit,
+			spread: { ref: spread },
+		});
+
+		expect(spread.current).toBeNull();
+		expect(explicit.current).toBeInstanceOf(FragmentInstance);
+		root.unmount();
+		expect(explicit.current).toBeNull();
+	});
+
+	it.each([
+		['template', OrderedFragmentSpreadEvaluation],
+		['returned automatic JSX', AutomaticJsxReturnedSpreadEvaluation],
+		['returned namespaced TSRX', ReturnedNamespacedFragmentSpreadEvaluation],
+	] as const)(
+		'evaluates %s Fragment spreads and getters once in authored order before children',
+		(_kind, App) => {
+			const calls: string[] = [];
+			const firstRef: { current: FragmentInstance | null } = { current: null };
+			const explicit: { current: FragmentInstance | null } = { current: null };
+			const lastRef: { current: FragmentInstance | null } = { current: null };
+			const first = {
+				get ref() {
+					calls.push('first:getter');
+					return firstRef;
+				},
+			};
+			const last = {
+				get ref() {
+					calls.push('last:getter');
+					return lastRef;
+				},
+			};
+			const root = mount(App, {
+				first,
+				last,
+				explicit,
+				observe: (label: string, value: unknown) => {
+					calls.push(label);
+					return value;
+				},
+			});
+
+			expect(calls).toEqual([
+				'first:expression',
+				'first:getter',
+				'explicit',
+				'last:expression',
+				'last:getter',
+				'child',
+			]);
+			expect(firstRef.current).toBeNull();
+			expect(explicit.current).toBeNull();
+			expect(lastRef.current).toBeInstanceOf(FragmentInstance);
+			root.unmount();
+		},
+	);
+
+	it('accepts a Fragment spread without a ref', () => {
+		const root = mount(SpreadFragmentObjectRef, { spread: {} });
+		expect(root.find('#spread-child').textContent).toBe('spread');
+		root.unmount();
+	});
+
+	it.each([null, undefined])('accepts a nullish Fragment spread (%s)', (spread) => {
+		const root = mount(SpreadFragmentObjectRef, { spread: spread as never });
+		expect(root.find('#spread-child').textContent).toBe('spread');
+		root.unmount();
+	});
+
+	it('updates spread-supplied refs without replacing the FragmentInstance', () => {
+		const first: { current: FragmentInstance | null } = { current: null };
+		const second: { current: FragmentInstance | null } = { current: null };
+		const root = mount(SpreadFragmentObjectRef, { spread: { ref: first } });
+		const fragment = first.current;
+
+		root.update(SpreadFragmentObjectRef, { spread: { ref: second } });
+		expect(first.current).toBeNull();
+		expect(second.current).toBe(fragment);
+
+		root.update(SpreadFragmentObjectRef, { spread: {} });
+		expect(second.current).toBeNull();
+
+		root.update(SpreadFragmentObjectRef, { spread: { ref: first } });
+		expect(first.current).toBe(fragment);
+		root.unmount();
+		expect(first.current).toBeNull();
+	});
+
+	it.each([
+		['aliased', ShadowedFragmentAlias],
+		['namespaced', ShadowedFragmentNamespace],
+	] as const)('preserves a locally shadowed %s Fragment component', (_kind, App) => {
+		const targetRef: { current: HTMLButtonElement | null } = { current: null };
+		const root = mount(App, { fragRef: targetRef });
+		expect(targetRef.current).toBe(root.find('#local-ref-target'));
+		expect(targetRef.current).not.toBeInstanceOf(FragmentInstance);
+		root.unmount();
+		expect(targetRef.current).toBeNull();
+	});
+
+	it('does not reinterpret an unrelated imported component as an Octane Fragment', () => {
+		const fragRef: { current: FragmentInstance | null } = { current: null };
+		const root = mount(ForeignFragmentAlias, { fragRef });
+		expect(root.findAll('p').map((element) => element.textContent)).toEqual(['1', '2']);
+		expect(fragRef.current).toBeNull();
+		root.unmount();
+	});
+
+	// Per ReactDOMFragmentRefs-test.js:737.
+	it('applies event listeners to host children nested within non-host children', () => {
+		const fragRef: { current: FragmentInstance | null } = { current: null };
+		const root = mount(FragmentWrappedHostChildren, { fragRef });
+		const clicked: string[] = [];
+		fragRef.current!.addEventListener('click', (event) => {
+			clicked.push((event.target as Element).id);
+		});
+		root.click('#wrapped-direct');
+		root.click('#wrapped-nested');
+		expect(clicked).toEqual(['wrapped-direct', 'wrapped-nested']);
+		root.unmount();
 	});
 
 	it('accepts a callback ref and fires it with the FragmentInstance', () => {
@@ -118,5 +349,29 @@ describe('Fragment refs — basic attach (React enableFragmentRefs parity)', () 
 		expect(layoutSeen).toBe(passiveSeen);
 		expect(layoutSeen).toBe(fragRef.current);
 		r.unmount();
+	});
+
+	// Per ReactDOMFragmentRefs-test.js:772.
+	it('allows adding and cleaning up listeners in effects', () => {
+		const fragRef: { current: FragmentInstance | null } = { current: null };
+		const clicked: string[] = [];
+		const onClick: EventListener = (event) => {
+			clicked.push((event.currentTarget as Element).id);
+		};
+		const root = mount(FragmentEffectListener, { fragRef, onClick, revision: 0 });
+		flushEffects();
+		const child = root.find('#effect-listener-child') as HTMLElement;
+		child.click();
+		expect(clicked).toEqual(['effect-listener-child']);
+
+		root.update(FragmentEffectListener, { fragRef, onClick, revision: 1 });
+		flushEffects();
+		expect(root.find('#effect-listener-child')).toBe(child);
+		child.click();
+		expect(clicked).toEqual(['effect-listener-child', 'effect-listener-child']);
+
+		root.unmount();
+		child.click();
+		expect(clicked).toEqual(['effect-listener-child', 'effect-listener-child']);
 	});
 });

--- a/packages/octane/tests/control-fold.test.ts
+++ b/packages/octane/tests/control-fold.test.ts
@@ -32,7 +32,10 @@ import {
 } from './_fixtures/control-fold.tsrx';
 import {
 	DirectReturnedFragmentRefMailbox,
+	EmptyFragmentRef,
+	NestedFragmentRefs,
 	ReturnedFragmentRefMailbox,
+	TextFragmentRef,
 } from './_fixtures/control-fold-fragment-ref.tsrx';
 import { Count as RetCount } from './_fixtures/return-count.tsrx';
 import { AtBraceCount } from './_fixtures/atbrace-count.tsrx';
@@ -399,21 +402,162 @@ describe('template directives in a returned fragment', () => {
 		expect(groupRef.current).toBeNull();
 	});
 
-	it('rejects nested and direct returned Fragment refs during server compilation', () => {
-		expect(() =>
-			compile(
-				`export function Nested(p) { return <><Fragment ref={p.ref}><span>nested</span></Fragment></>; }`,
-				'returned-nested-fragment-ref.tsrx',
-				{ mode: 'server' },
-			),
-		).toThrow(/does not support fragment refs/);
-		expect(() =>
-			compile(
-				`export function Direct(p) { return <Fragment ref={p.ref}><span>direct</span></Fragment>; }`,
-				'returned-direct-fragment-ref.tsrx',
-				{ mode: 'server' },
-			),
-		).toThrow(/does not support fragment refs/);
+	it('server-renders nested and directly returned Fragment refs without attaching them', () => {
+		const server = loadServerFixture(
+			'packages/octane/tests/_fixtures/control-fold-fragment-ref.tsrx',
+		);
+		const groupRef: { current: FragmentInstance | null } = { current: null };
+		const nested = ServerRT.renderToString(server.ReturnedFragmentRefMailbox, {
+			groupRef,
+			title: 'Server drafts',
+		});
+		const parsed = document.createElement('div');
+		parsed.innerHTML = nested.html;
+		expect(parsed.querySelector('#fragment-ref-title')?.textContent).toBe('Server drafts');
+		expect(parsed.querySelector('#fragment-draft')?.textContent).toBe('Grouped edits: 0');
+		expect(groupRef.current).toBeNull();
+
+		const calls: string[] = [];
+		const direct = ServerRT.renderToString(server.DirectReturnedFragmentRefMailbox, {
+			groupRef,
+			title: 'Direct server drafts',
+			observe: (phase: string, value: unknown) => {
+				calls.push(phase);
+				return value;
+			},
+		});
+		expect(direct.html).toContain('Direct server drafts');
+		expect(calls.slice(0, 2)).toEqual(['ref', 'child']);
+		expect(groupRef.current).toBeNull();
+		expect(
+			ServerRT.renderToStaticMarkup(server.ReturnedFragmentRefMailbox, {
+				groupRef,
+				title: 'Static drafts',
+			}).html,
+		).toBe(
+			'<h2 id="fragment-ref-title">Static drafts</h2>' +
+				'<button id="fragment-draft">Grouped edits: 0</button>' +
+				'<span id="fragment-ref-tail">Grouped draft ready</span>',
+		);
+	});
+
+	it('hydrates a returned Fragment ref without replacing existing stateful children', () => {
+		const server = loadServerFixture(
+			'packages/octane/tests/_fixtures/control-fold-fragment-ref.tsrx',
+		);
+		const groupRef: { current: FragmentInstance | null } = { current: null };
+		const props = { groupRef, title: 'Hydrated drafts' };
+		const { html } = ServerRT.renderToString(server.ReturnedFragmentRefMailbox, props);
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		container.innerHTML = html;
+		const title = container.querySelector('#fragment-ref-title');
+		const draft = container.querySelector('#fragment-draft') as HTMLButtonElement;
+		const tail = container.querySelector('#fragment-ref-tail');
+
+		const root = hydrateRoot(container, ReturnedFragmentRefMailbox, props);
+		flushSync(() => {});
+
+		expect(container.querySelector('#fragment-ref-title')).toBe(title);
+		expect(container.querySelector('#fragment-draft')).toBe(draft);
+		expect(container.querySelector('#fragment-ref-tail')).toBe(tail);
+		expect(groupRef.current).toBeInstanceOf(FragmentInstance);
+		flushSync(() => draft.click());
+		expect(draft.textContent).toBe('Grouped edits: 1');
+		root.unmount();
+		expect(groupRef.current).toBeNull();
+		container.remove();
+	});
+
+	it('hydrates directly returned multi-root Fragment refs in place', () => {
+		const server = loadServerFixture(
+			'packages/octane/tests/_fixtures/control-fold-fragment-ref.tsrx',
+		);
+		const groupRef: { current: FragmentInstance | null } = { current: null };
+		const props = {
+			groupRef,
+			title: 'Direct hydrated drafts',
+			observe: (_phase: string, value: unknown) => value,
+		};
+		const { html } = ServerRT.renderToString(server.DirectReturnedFragmentRefMailbox, props);
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		container.innerHTML = html;
+		const title = container.querySelector('#direct-fragment-title');
+		const draft = container.querySelector('#direct-fragment-draft') as HTMLButtonElement;
+		const tail = container.querySelector('#direct-fragment-tail');
+
+		const root = hydrateRoot(container, DirectReturnedFragmentRefMailbox, props);
+		flushSync(() => {});
+
+		expect(container.querySelector('#direct-fragment-title')).toBe(title);
+		expect(container.querySelector('#direct-fragment-draft')).toBe(draft);
+		expect(container.querySelector('#direct-fragment-tail')).toBe(tail);
+		expect(groupRef.current).toBeInstanceOf(FragmentInstance);
+		flushSync(() => draft.click());
+		expect(draft.textContent).toBe('Direct grouped edits: 1');
+		root.unmount();
+		expect(groupRef.current).toBeNull();
+		container.remove();
+	});
+
+	it.each([
+		['empty', 'EmptyFragmentRef', EmptyFragmentRef, ''],
+		['text-only', 'TextFragmentRef', TextFragmentRef, 'hydrated text'],
+	] as const)(
+		'hydrates %s Fragment refs without replacing sibling or text nodes',
+		(_kind, name, Client, label) => {
+			const server = loadServerFixture(
+				'packages/octane/tests/_fixtures/control-fold-fragment-ref.tsrx',
+			);
+			const groupRef: { current: FragmentInstance | null } = { current: null };
+			const props = { groupRef, label };
+			const { html } = ServerRT.renderToString(server[name], props);
+			const container = document.createElement('div');
+			document.body.appendChild(container);
+			container.innerHTML = html;
+			const section = container.querySelector('section')!;
+			const serverNodes = [...section.childNodes];
+
+			const root = hydrateRoot(container, Client, props);
+			flushSync(() => {});
+
+			expect(container.querySelector('section')).toBe(section);
+			expect([...section.childNodes]).toEqual(serverNodes);
+			expect(groupRef.current).toBeInstanceOf(FragmentInstance);
+			expect(section.textContent).toBe(label || 'beforeafter');
+			root.unmount();
+			expect(groupRef.current).toBeNull();
+			container.remove();
+		},
+	);
+
+	it('hydrates independently nested Fragment refs without replacing their shared children', () => {
+		const server = loadServerFixture(
+			'packages/octane/tests/_fixtures/control-fold-fragment-ref.tsrx',
+		);
+		const groupRef: { current: FragmentInstance | null } = { current: null };
+		const innerRef: { current: FragmentInstance | null } = { current: null };
+		const props = { groupRef, innerRef };
+		const { html } = ServerRT.renderToString(server.NestedFragmentRefs, props);
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		container.innerHTML = html;
+		const outer = container.querySelector('#nested-outer');
+		const inner = container.querySelector('#nested-inner');
+
+		const root = hydrateRoot(container, NestedFragmentRefs, props);
+		flushSync(() => {});
+
+		expect(container.querySelector('#nested-outer')).toBe(outer);
+		expect(container.querySelector('#nested-inner')).toBe(inner);
+		expect(groupRef.current).toBeInstanceOf(FragmentInstance);
+		expect(innerRef.current).toBeInstanceOf(FragmentInstance);
+		expect(groupRef.current).not.toBe(innerRef.current);
+		root.unmount();
+		expect(groupRef.current).toBeNull();
+		expect(innerRef.current).toBeNull();
+		container.remove();
 	});
 
 	it('retains an ordinary keyed Fragment descriptor boundary', () => {

--- a/packages/octane/tests/ssr.test.ts
+++ b/packages/octane/tests/ssr.test.ts
@@ -3,8 +3,15 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { compile } from 'octane/compiler';
 import * as RT from 'octane/server';
-import { flushSync, hydrateRoot } from '../src/index.js';
+import {
+	createElement as createClientElement,
+	flushSync,
+	Fragment as ClientFragment,
+	FragmentInstance,
+	hydrateRoot,
+} from '../src/index.js';
 import { Counter as ClientCounter } from './_fixtures/basic.tsrx';
+import { SpreadFragmentObjectRef as ClientSpreadFragment } from './conformance/_fixtures/fragment-refs.tsrx';
 
 const FIXTURES = join(process.cwd(), 'packages/octane/tests/_fixtures');
 
@@ -16,6 +23,10 @@ const FIXTURES = join(process.cwd(), 'packages/octane/tests/_fixtures');
 function evalServer(source: string, file: string): Record<string, any> {
 	let { code } = compile(source, file, { mode: 'server' });
 	// Bind the server-runtime import to the live module, and capture exports.
+	code = code.replace(
+		/import\s+\*\s+as\s+(\w+)\s+from\s+['"]octane\/server['"];?/g,
+		'const $1 = __rt;',
+	);
 	code = code.replace(
 		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
 		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
@@ -261,14 +272,174 @@ describe('SSR Phase 1 — semantics', () => {
 		expect(onRender).not.toHaveBeenCalled();
 	});
 
-	it('still rejects server-side Fragment refs', () => {
-		expect(() =>
-			compile(
-				`export function C(p) @{ <Fragment ref={p.ref}><span>{'a'}</span></Fragment> }`,
-				'fragment-ref.tsrx',
-				{ mode: 'server' },
-			),
-		).toThrow(/does not support fragment refs/);
+	it('renders Fragment refs without attaching them and keeps static markup markerless', async () => {
+		const fragment = evalServer(
+			`export function C(props) @{ <main><Fragment ref={props.ref}><span>{props.label as string}</span></Fragment></main> }`,
+			'fragment-ref.tsrx',
+		);
+		const callback = vi.fn();
+		const props = { ref: callback, label: 'server fragment' };
+		const { html } = RT.renderToString(fragment.C, props);
+		const parsed = document.createElement('div');
+		parsed.innerHTML = html;
+
+		expect(parsed.querySelector('main > span')?.textContent).toBe('server fragment');
+		expect(callback).not.toHaveBeenCalled();
+		expect(RT.renderToStaticMarkup(fragment.C, props).html).toBe(
+			'<main><span>server fragment</span></main>',
+		);
+		expect(callback).not.toHaveBeenCalled();
+
+		const stream = await RT.renderToReadableStream(fragment.C, props);
+		expect(await new Response(stream).text()).toBe(html);
+		expect(callback).not.toHaveBeenCalled();
+	});
+
+	it('evaluates Fragment ref expressions before children without attaching the ref', () => {
+		const fragment = evalServer(
+			`export function C(props) @{ <Fragment ref={props.observe('ref', props.ref)}><span>{props.observe('child', props.label) as string}</span></Fragment> }`,
+			'fragment-ref-order.tsrx',
+		);
+		const calls: string[] = [];
+		const callback = vi.fn();
+		const { html } = RT.renderToString(fragment.C, {
+			ref: callback,
+			label: 'ordered',
+			observe: (phase: string, value: unknown) => {
+				calls.push(phase);
+				return value;
+			},
+		});
+
+		const parsed = document.createElement('div');
+		parsed.innerHTML = html;
+		expect(parsed.querySelector('span')?.textContent).toBe('ordered');
+		expect(calls).toEqual(['ref', 'child']);
+		expect(callback).not.toHaveBeenCalled();
+	});
+
+	it('server-renders, streams, and hydrates spread-supplied Fragment refs', async () => {
+		const fragment = evalServer(
+			`import { Fragment } from 'octane'; export function C(props) @{ <div id="spread-parent"><Fragment {...props.spread}><button id="spread-child">{'spread'}</button></Fragment></div> }`,
+			'fragment-ref-spread.tsrx',
+		);
+		const fragRef: { current: FragmentInstance | null } = { current: null };
+		const props = { spread: { ref: fragRef } };
+		const { html } = RT.renderToString(fragment.C, props);
+		const container = document.createElement('div');
+		container.innerHTML = html;
+		const serverChild = container.querySelector('#spread-child');
+
+		expect(serverChild?.textContent).toBe('spread');
+		expect(fragRef.current).toBeNull();
+		expect(RT.renderToStaticMarkup(fragment.C, props).html).toBe(
+			'<div id="spread-parent"><button id="spread-child">spread</button></div>',
+		);
+		expect(fragRef.current).toBeNull();
+		const stream = await RT.renderToReadableStream(fragment.C, props);
+		expect(await new Response(stream).text()).toBe(html);
+		expect(fragRef.current).toBeNull();
+
+		const root = hydrateRoot(container, ClientSpreadFragment, props);
+		flushSync(() => {});
+		expect(container.querySelector('#spread-child')).toBe(serverChild);
+		expect(fragRef.current).toBeInstanceOf(FragmentInstance);
+		root.unmount();
+		expect(fragRef.current).toBeNull();
+	});
+
+	it.each([
+		[
+			'template',
+			`export function C(props) @{ <Fragment {...props.observe('first:expression', props.first)} ref={props.observe('explicit', props.explicit)} {...props.observe('last:expression', props.last)}><span>{props.observe('child', 'ordered') as string}</span></Fragment> }`,
+			'tsrx',
+		],
+		[
+			'returned automatic JSX',
+			`/** @jsxImportSource octane */ import { Fragment as Group } from 'octane'; export function C(props) { return <Group {...props.observe('first:expression', props.first)} ref={props.observe('explicit', props.explicit)} {...props.observe('last:expression', props.last)}><span>{props.observe('child', 'ordered')}</span></Group>; }`,
+			'tsx',
+		],
+		[
+			'returned namespaced TSRX',
+			`import * as Octane from 'octane'; export function C(props) { return <Octane.Fragment {...props.observe('first:expression', props.first)} ref={props.observe('explicit', props.explicit)} {...props.observe('last:expression', props.last)}><span>{props.observe('child', 'ordered') as string}</span></Octane.Fragment>; }`,
+			'tsrx',
+		],
+	] as const)(
+		'evaluates %s spread Fragment refs and getters once in authored order on the server',
+		async (_kind, source, extension) => {
+			const fragment = evalServer(source, `fragment-ref-spread-order.${extension}`);
+			const calls: string[] = [];
+			const firstRef = vi.fn();
+			const explicit = vi.fn();
+			const lastRef = vi.fn();
+			const first = {
+				get ref() {
+					calls.push('first:getter');
+					return firstRef;
+				},
+			};
+			const last = {
+				get ref() {
+					calls.push('last:getter');
+					return lastRef;
+				},
+			};
+			const props = {
+				first,
+				last,
+				explicit,
+				observe: (label: string, value: unknown) => {
+					calls.push(label);
+					return value;
+				},
+			};
+			const expected = [
+				'first:expression',
+				'first:getter',
+				'explicit',
+				'last:expression',
+				'last:getter',
+				'child',
+			];
+
+			const { html } = RT.renderToString(fragment.C, props);
+			expect(calls).toEqual(expected);
+			calls.length = 0;
+			expect(RT.renderToStaticMarkup(fragment.C, props).html).toBe('<span>ordered</span>');
+			expect(calls).toEqual(expected);
+			calls.length = 0;
+			const stream = await RT.renderToReadableStream(fragment.C, props);
+			expect(await new Response(stream).text()).toBe(html);
+			expect(calls).toEqual(expected);
+			expect(firstRef).not.toHaveBeenCalled();
+			expect(explicit).not.toHaveBeenCalled();
+			expect(lastRef).not.toHaveBeenCalled();
+		},
+	);
+
+	it.each([
+		[
+			'aliased',
+			`import { Fragment as Group } from 'octane'; export function C(props) @{ <main><Group ref={props.ref}><span>{props.label as string}</span></Group></main> }`,
+		],
+		[
+			'namespaced',
+			`import * as Octane from 'octane'; export function C(props) @{ <main><Octane.Fragment ref={props.ref}><span>{props.label as string}</span></Octane.Fragment></main> }`,
+		],
+		[
+			'automatic-jsx',
+			`/** @jsxImportSource octane */ import { Fragment as Group } from 'octane'; export function C(props) { return <main><Group ref={props.ref}><span>{props.label as string}</span></Group></main>; }`,
+		],
+	] as const)('renders a %s imported Fragment without attaching its ref', (kind, source) => {
+		const extension = kind === 'automatic-jsx' ? 'tsx' : 'tsrx';
+		const fragment = evalServer(source, `fragment-ref-${kind}.${extension}`);
+		const callback = vi.fn();
+		const props = { ref: callback, label: 'server alias' };
+
+		expect(RT.renderToStaticMarkup(fragment.C, props).html).toBe(
+			'<main><span>server alias</span></main>',
+		);
+		expect(callback).not.toHaveBeenCalled();
 	});
 });
 
@@ -394,6 +565,164 @@ describe('SSR — plain-.ts root returning a createElement descriptor', () => {
 		const { html: empty } = await RT.renderToString((() => null) as any);
 		expect(empty).not.toContain('[object Object]');
 	});
+
+	it('server-renders and hydrates nested public Fragment descriptors with refs', async () => {
+		const outerRef: { current: FragmentInstance | null } = { current: null };
+		const innerRef = vi.fn();
+		const props = { outerRef, innerRef };
+		const ServerRoot = (input: typeof props) =>
+			RT.createElement(
+				RT.Fragment,
+				{ ref: input.outerRef },
+				RT.createElement('span', { id: 'descriptor-first' }, 'first'),
+				RT.createElement(
+					RT.Fragment,
+					{ ref: input.innerRef, key: 'inner' },
+					RT.createElement('strong', { id: 'descriptor-inner' }, 'inner'),
+				),
+			);
+		const ClientRoot = (input: typeof props) =>
+			createClientElement(
+				ClientFragment,
+				{ ref: input.outerRef },
+				createClientElement('span', { id: 'descriptor-first' }, 'first'),
+				createClientElement(
+					ClientFragment,
+					{ ref: input.innerRef, key: 'inner' },
+					createClientElement('strong', { id: 'descriptor-inner' }, 'inner'),
+				),
+			);
+
+		const { html } = RT.renderToString(ServerRoot as any, props);
+		const container = document.createElement('div');
+		container.innerHTML = html;
+		const first = container.querySelector('#descriptor-first');
+		const inner = container.querySelector('#descriptor-inner');
+		expect(first?.textContent).toBe('first');
+		expect(inner?.textContent).toBe('inner');
+		expect(outerRef.current).toBeNull();
+		expect(innerRef).not.toHaveBeenCalled();
+		expect(RT.renderToStaticMarkup(ServerRoot as any, props).html).toBe(
+			'<span id="descriptor-first">first</span><strong id="descriptor-inner">inner</strong>',
+		);
+		expect(outerRef.current).toBeNull();
+		expect(innerRef).not.toHaveBeenCalled();
+		const stream = await RT.renderToReadableStream(ServerRoot as any, props);
+		expect(await new Response(stream).text()).toBe(html);
+		expect(innerRef).not.toHaveBeenCalled();
+
+		const root = hydrateRoot(container, ClientRoot, props);
+		flushSync(() => {});
+		expect(container.querySelector('#descriptor-first')).toBe(first);
+		expect(container.querySelector('#descriptor-inner')).toBe(inner);
+		expect(outerRef.current).toBeInstanceOf(FragmentInstance);
+		expect(innerRef).toHaveBeenCalledOnce();
+		expect(innerRef.mock.calls[0]?.[0]).toBeInstanceOf(FragmentInstance);
+		root.unmount();
+		expect(outerRef.current).toBeNull();
+		expect(innerRef.mock.calls.at(-1)?.[0]).toBeNull();
+	});
+
+	it('hydrates empty, text, and populated Fragment descriptors inside a host in place', () => {
+		const emptyRef: { current: FragmentInstance | null } = { current: null };
+		const populatedRef: { current: FragmentInstance | null } = { current: null };
+		const textRef: { current: FragmentInstance | null } = { current: null };
+		const props = { emptyRef, populatedRef, textRef };
+		const ServerRoot = (input: typeof props) =>
+			RT.createElement(
+				'main',
+				{ id: 'descriptor-host' },
+				RT.createElement(RT.Fragment, { ref: input.emptyRef, key: 'empty' }),
+				RT.createElement(
+					RT.Fragment,
+					{ ref: input.populatedRef },
+					RT.createElement('span', { id: 'descriptor-populated' }, 'populated'),
+				),
+				RT.createElement(RT.Fragment, { ref: input.textRef }, 'descriptor text'),
+				RT.createElement('em', { id: 'descriptor-after' }, 'after'),
+			);
+		const ClientRoot = (input: typeof props) =>
+			createClientElement(
+				'main',
+				{ id: 'descriptor-host' },
+				createClientElement(ClientFragment, { ref: input.emptyRef, key: 'empty' }),
+				createClientElement(
+					ClientFragment,
+					{ ref: input.populatedRef },
+					createClientElement('span', { id: 'descriptor-populated' }, 'populated'),
+				),
+				createClientElement(ClientFragment, { ref: input.textRef }, 'descriptor text'),
+				createClientElement('em', { id: 'descriptor-after' }, 'after'),
+			);
+
+		const container = document.createElement('div');
+		container.innerHTML = RT.renderToString(ServerRoot as any, props).html;
+		const host = container.querySelector('#descriptor-host');
+		const populated = container.querySelector('#descriptor-populated');
+		const after = container.querySelector('#descriptor-after');
+		expect(emptyRef.current).toBeNull();
+		expect(populatedRef.current).toBeNull();
+		expect(textRef.current).toBeNull();
+		expect(RT.renderToStaticMarkup(ServerRoot as any, props).html).toBe(
+			'<main id="descriptor-host"><span id="descriptor-populated">populated</span>descriptor text<em id="descriptor-after">after</em></main>',
+		);
+
+		const root = hydrateRoot(container, ClientRoot, props);
+		flushSync(() => {});
+		expect(container.querySelector('#descriptor-host')).toBe(host);
+		expect(container.querySelector('#descriptor-populated')).toBe(populated);
+		expect(container.querySelector('#descriptor-after')).toBe(after);
+		expect(emptyRef.current).toBeInstanceOf(FragmentInstance);
+		expect(populatedRef.current).toBeInstanceOf(FragmentInstance);
+		expect(textRef.current).toBeInstanceOf(FragmentInstance);
+		root.unmount();
+		expect(emptyRef.current).toBeNull();
+		expect(populatedRef.current).toBeNull();
+		expect(textRef.current).toBeNull();
+	});
+
+	it.each([null, undefined])(
+		'preserves a hydrated Fragment descriptor when an explicit %s ref becomes live',
+		(initialRef) => {
+			type DescriptorProps = {
+				fragmentRef: { current: FragmentInstance | null } | null | undefined;
+			};
+			const ServerRoot = (input: DescriptorProps) =>
+				RT.createElement(
+					RT.Fragment,
+					{ ref: input.fragmentRef },
+					RT.createElement('span', { id: 'descriptor-toggle' }, 'toggle'),
+				);
+			const ClientRoot = (input: DescriptorProps) =>
+				createClientElement(
+					ClientFragment,
+					{ ref: input.fragmentRef },
+					createClientElement('span', { id: 'descriptor-toggle' }, 'toggle'),
+				);
+			const container = document.createElement('div');
+			container.innerHTML = RT.renderToString(ServerRoot as any, { fragmentRef: initialRef }).html;
+			const serverChild = container.querySelector('#descriptor-toggle');
+			const root = hydrateRoot(container, ClientRoot, { fragmentRef: initialRef });
+			flushSync(() => {});
+			expect(container.querySelector('#descriptor-toggle')).toBe(serverChild);
+
+			const liveRef: { current: FragmentInstance | null } = { current: null };
+			flushSync(() => root.render(ClientRoot, { fragmentRef: liveRef }));
+			const fragment = liveRef.current;
+			expect(fragment).toBeInstanceOf(FragmentInstance);
+			expect(container.querySelector('#descriptor-toggle')).toBe(serverChild);
+
+			flushSync(() => root.render(ClientRoot, { fragmentRef: null }));
+			expect(liveRef.current).toBeNull();
+			expect(container.querySelector('#descriptor-toggle')).toBe(serverChild);
+
+			flushSync(() => root.render(ClientRoot, { fragmentRef: liveRef }));
+			expect(liveRef.current).toBe(fragment);
+			expect(container.querySelector('#descriptor-toggle')).toBe(serverChild);
+			root.unmount();
+			expect(liveRef.current).toBeNull();
+		},
+	);
 });
 
 // `headChannel: 'separate'` exists for hosts that render into a `<head>`-bearing

--- a/packages/octane/typetests/jsx-runtime.test-d.tsx
+++ b/packages/octane/typetests/jsx-runtime.test-d.tsx
@@ -4,8 +4,8 @@
  * with octane's exceptions. Compile-only (tsgo --noEmit); never executed and
  * never imported by runtime code.
  */
-import { Fragment } from 'octane';
-import type { JSX as OctaneJSX } from 'octane/jsx-runtime';
+import { Fragment, type FragmentInstance } from 'octane';
+import { Fragment as AutomaticRuntimeFragment, type JSX as OctaneJSX } from 'octane/jsx-runtime';
 import type * as React from 'react';
 
 declare function use<T>(value: T): void;
@@ -21,6 +21,8 @@ use<true>(octaneCoversEveryReactTag);
 export function TypeSurface() {
 	const cb = (el: HTMLDivElement | null) => {};
 	const obj: { current: HTMLDivElement | null } = { current: null };
+	const fragmentObject: { current: FragmentInstance | null } = { current: null };
+	const fragmentCallback = (instance: FragmentInstance | null) => {};
 
 	return (
 		<main>
@@ -85,12 +87,34 @@ export function TypeSurface() {
 			<div>{null}</div>
 
 			{/* ── Fragment: children, key, and fragment refs ── */}
-			<Fragment ref={(instance) => {}}>
+			<Fragment
+				ref={(instance) => {
+					use<FragmentInstance | null>(instance);
+					instance?.focus();
+					instance?.focusLast({ preventScroll: true });
+					instance?.getRootNode({ composed: true });
+					instance?.scrollIntoView(false);
+				}}
+			>
 				<span />
 			</Fragment>
+			<Fragment ref={fragmentObject} />
+			<Fragment ref={[fragmentObject, fragmentCallback]} />
+			<AutomaticRuntimeFragment
+				ref={(instance) => {
+					use<FragmentInstance | null>(instance);
+					instance?.focus();
+				}}
+			/>
+			{/* @ts-expect-error — fragment refs receive an instance, not an element */}
+			<Fragment ref={(instance: HTMLDivElement | null) => {}} />
 		</main>
 	);
 }
+
+declare const fragmentInstance: FragmentInstance;
+// @ts-expect-error — fragment scrolling accepts only its boolean alignment argument.
+fragmentInstance.scrollIntoView({ block: 'center' });
 
 // ── Elements are not promises — the poisoned protocol holds octane-side too ──
 // `Octane.JSX.Element`'s `Promise<React.ReactNode>` parent exists only for the


### PR DESCRIPTION
## Summary

- Complete React Canary Fragment-ref parity across Octane's client runtime, compiler, public types, SSR, hydration, portals, Activity, and Suspense.
- Cover all **45 stable-source** and **61 canary-source** upstream Fragment-ref cases with **84 executable conformance-evidence links**.

## Why

Octane already exposed Fragment refs and the `FragmentInstance` method names, but several observable behaviors diverged from React: direct text ownership, event and observer lifecycles, scrolling and geometry, document-position flags, portal ordering, Activity visibility, JSX spread evaluation, public element descriptors, and server rendering/hydration.

## Changes

- Match React across all 12 `FragmentInstance` APIs, including native listener identity/cleanup, observer warnings and lifecycle, deep focus, text ranges, root lookup, document positions, and boolean-only scrolling.
- Track element and text ownership with public `reactFragments` handles across dynamic children, nested/shared portals, hidden Activity trees, Suspense transitions, and independent portal teardown.
- Support imported Fragment aliases, namespace members, automatic JSX, spread precedence/getter evaluation, and `createElement`/`cloneElement` Fragment refs with strongly typed callback, object, and array refs.
- Render Fragment refs safely in buffered, streaming, and static SSR; never attach server refs; hydrate existing server DOM in place.
- Add targeted behavioral regressions, a dedicated React-conformance policy and generated report, public documentation, and a patch changeset.

## Validation

- [x] `pnpm sync`
- [x] `pnpm format:check`
- [x] `pnpm typecheck` — complete monorepo, including Solana, all bindings, core/plugin packages, website, examples, and benchmarks.
- [x] `pnpm react-parity:validate` — 5,345 stable and 5,413 canary cases validated; Fragment refs: **45/45 stable, 61/61 canary**.
- [x] Core package and JSX typetests: `tsgo --noEmit -p packages/octane/tsconfig.json` and `tsgo --noEmit -p packages/octane/typetests/tsconfig.json`.
- [x] Scoped `pnpm typecheck:files` across all modified/new `.tsrx` and `.tsx` fixtures.
- [x] Complete Octane development and production suites: **11,637 tests across 804 files**.
- [x] Post-rebase focused runtime matrix: **837 tests across 67 development/production suites**.
- [x] Post-rebase compiler/SSR matrix: **1,067 tests across 25 development/production suites**, including frozen ASTs and upstream conditional-return optimization.
- [x] Independent router SSR integration: **7/7 tests pass** when the existing mixed client/server project receives the correct server-runtime alias.
- [x] Exact clean-upstream compiler benchmark: **0/16 changed corpus outputs**; both revisions produce raw **152,623 B**, minified **75,339 B**, and gzip **26,655 B**.
- [x] Newly upstreamed Solana package source, type tests, and pristine upstream type tests after offline dependency recovery.
- [ ] Complete-monorepo Vitest run: interrupted by an external-network approval cancellation; unrelated mixed client/server router failures were independently reproduced against the clean upstream parent. The complete Octane development/production matrix passes.

## Risk / follow-ups

- Fragment bookkeeping and portal interleaving are gated to Fragment-ref paths; ordinary compiled output is unchanged across the complete benchmark corpus.
- React Fragment refs remain a Canary feature. Octane's existing Element-only root-container contract excludes React's newer ShadowRoot/DocumentFragment-root-only empty-scroll cases, as documented.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large surface area across compiler codegen, hydration, portals, Activity, and DOM-facing FragmentInstance APIs; mistakes could affect ref attachment, event routing, or SSR/hydration cursor alignment.
> 
> **Overview**
> Delivers **React Canary `<Fragment ref>` parity** end-to-end: typed `FragmentInstance` refs, compiler recognition of imported aliases/namespaces/JSX spreads, and client hydration that attaches refs only after adopt (never on the server).
> 
> **Compiler and SSR** no longer reject Fragment refs on the server. Hydratable output emits `<!--frag-->` / `<!--/frag-->` via `ssrFragmentMarker` while evaluating spread/ref expressions in authored order; static markup omits those markers. Portal lowering now threads **Fragment ownership** (`fragmentBindings`, source anchors) so portaled children keep logical Fragment ancestry at root and nested positions.
> 
> **Conformance and docs** move the dedicated **Fragment refs** workstream to **covered** (45 stable / 61 canary ledger cases linked to new `fragment-refs*.test.ts` suites). Public docs describe the `FragmentInstance` API and SSR/hydration behavior; new client error codes **49** (unsupported `scrollIntoView` options) and **50** (unclosed server Fragment descriptor) align CLI and runtime messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4563f1625fb09c85a8522b048b7b14cb6f1e12ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->