### PR TITLE
fix: avoid creating requests for server-seeded hydration data

### DIFF
--- a/.changeset/hydration-seed-request-creation.md
+++ b/.changeset/hydration-seed-request-creation.md
@@ -1,0 +1,7 @@
+---
+'octane': patch
+---
+
+Reuse server-provided hydration data before creating compiler-owned async
+requests, preventing duplicate client fetches while preserving Suspense and
+external hydration ownership.

--- a/docs/ssr.md
+++ b/docs/ssr.md
@@ -283,6 +283,9 @@ policy applies to Vite, Rsbuild, and generated Node or Web Worker servers.
   full pass, so hydration byte-format is identical either way. Resolved values
   and versioned rejection metadata are serialized into the seed script so
   hydration does not re-fetch, re-suspend, or replace a server `@catch` arm.
+  Compiler-owned request factories consult their matching server-provided seed
+  before running, while existing promises, contexts, and externally owned
+  hydration promises retain their original ownership.
   Rejection records preserve primitive and JSON-safe plain-object reasons plus
   Error names, messages, and enumerable custom fields. Cyclic fields are
   bounded and marked, while hostile or opaque values degrade to fixed safe

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -12804,6 +12804,18 @@ function parallelUseMemoizePass(stmts, ctx, componentName, creations, guards, lo
 	function rewriteUseCall(call, activeGuards) {
 		const arg = unwrapTsExpr(call.arguments[0]);
 		if (isTrivialUseArg(arg)) return call;
+		// Only a direct creation can be paired with this exact use() on both
+		// compiles. Existing thenables, conditional references, creation chains,
+		// and another renderer's runtime must retain their original ownership.
+		const hydrationSite =
+			ctx._universalRuntimeUnit == null &&
+			call.arguments.length === 1 &&
+			(arg.type === 'CallExpression' || arg.type === 'NewExpression') &&
+			arg.optional !== true
+				? `${(ctx._hydrationSourceHash ??= hookSlotHash(ctx.mapSource))}:${
+						call.start ?? `${call.loc?.start.line ?? 0}:${call.loc?.start.column ?? 0}`
+					}`
+				: null;
 		const memoCall = makeCreationMemoCall(
 			ctx,
 			componentName,
@@ -12812,8 +12824,14 @@ function parallelUseMemoizePass(stmts, ctx, componentName, creations, guards, lo
 			locals,
 			creations,
 			call,
+			null,
+			hydrationSite,
 		);
-		return { ...call, arguments: [memoCall, ...call.arguments.slice(1)] };
+		return {
+			...call,
+			arguments: [memoCall, ...call.arguments.slice(1)],
+			...(hydrationSite === null ? null : { _octaneHydrationSite: hydrationSite }),
+		};
 	}
 }
 
@@ -12830,6 +12848,7 @@ function makeCreationMemoCall(
 	creations,
 	siteNode,
 	coarsenDepRoots = null,
+	hydrationSite = null,
 ) {
 	const symVar = allocHookSymbol(
 		ctx,
@@ -12884,10 +12903,24 @@ function makeCreationMemoCall(
 			? rtAlias(memoHelper)
 			: requireRuntimeForContext(ctx, memoHelper);
 	creations.push({ symVar, expr, deps, guards: [...guards], locals });
+	// Keep the original expression in the warm plan and on the server. Only
+	// the client-owned direct creation can consult its matching seeded site;
+	// production lowering places this callback strictly on the puTake miss.
+	const memoExpr =
+		hydrationSite !== null && ctx.mode !== 'server'
+			? inheritOriginLoc(
+					b.call(
+						requireRuntimeForContext(ctx, 'seedOrCreate'),
+						b.literal(hydrationSite, JSON.stringify(hydrationSite)),
+						b.arrow([], expr),
+					),
+					expr,
+				)
+			: expr;
 	// The minted memo wrapper maps to the authored creation expression.
 	return inheritOriginLoc(
 		{
-			...b.call(memoAlias, b.arrow([], expr), b.array(deps), b.id(symVar)),
+			...b.call(memoAlias, b.arrow([], memoExpr), b.array(deps), b.id(symVar)),
 			// Marks a compiler-minted creation memo so the inline hook-memo tier
 			// can later lower the `const x = _$useMemo(…)` statement form to the
 			// closure-free puTake/puPub ABI (production client compile).
@@ -14660,6 +14693,15 @@ function rewriteHookCalls(node, ctx, componentName, localRoot = false) {
 					const withSlotAlias = requireRuntimeForContext(ctx, 'withSlot');
 					return b.call(withSlotAlias, b.id(symVar), n.callee, ...args, b.id(symVar));
 				}
+				const hookArgs = appendHookSlotArgument(name, args, slot, numericSlot, n);
+				if (isServerUse && n._octaneHydrationSite !== undefined) {
+					hookArgs.push(
+						inheritOriginLoc(
+							b.literal(n._octaneHydrationSite, JSON.stringify(n._octaneHydrationSite)),
+							n,
+						),
+					);
+				}
 				return {
 					...n,
 					callee:
@@ -14668,7 +14710,7 @@ function rewriteHookCalls(node, ctx, componentName, localRoot = false) {
 							: n.callee._octaneGenerated
 								? b.id(runtimeAliasForContext(ctx, name))
 								: n.callee,
-					arguments: appendHookSlotArgument(name, args, slot, numericSlot, n),
+					arguments: hookArgs,
 				};
 			}
 		}

--- a/packages/octane/src/index.ts
+++ b/packages/octane/src/index.ts
@@ -221,6 +221,7 @@ export {
 	// Compiler-emitted parallel use(): batched stratum unwrap + fetch-tree
 	// warming (docs/suspense-parallel-use-plan.md).
 	useBatch,
+	seedOrCreate,
 	warmMemo,
 	warmChild,
 	// Closure-free creation take/publish ABI (inline hook-memo tier).

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -3368,14 +3368,18 @@ const hydrate = /* @__PURE__ */ markComponentFlags(
 						permanentStaticAncestor,
 						streamTokenForPendingHtml(children),
 					);
-					const seedSidecar =
+					const seedJson =
 						permanentStaticAncestor || childSeeds.length === 0
+							? null
+							: serializeSuspenseSeedJson(childSeeds);
+					const seedSidecar =
+						seedJson === null || seedJson === '[]'
 							? ''
 							: '<script type="application/json" ' +
 								HYDRATE_SEED_ATTR +
 								NONCE_ATTR +
 								'>' +
-								serializeSuspenseSeedJson(childSeeds) +
+								seedJson +
 								'</script>';
 
 					return '<div' + attrs + '>' + children + seedSidecar + '</div>';
@@ -3756,8 +3760,14 @@ type HydrationRejectionPayload =
 	| { kind: 'fallback'; message: string };
 
 const HYDRATION_REJECTION_SEED = Symbol('octane.ssr.hydration-rejection-seed');
+const HYDRATION_SITE_EVENT = Symbol('octane.ssr.hydration-site');
 interface HydrationRejectionSeed {
 	[HYDRATION_REJECTION_SEED]: HydrationRejectionPayload;
+}
+
+interface HydrationSiteEvent {
+	[HYDRATION_SITE_EVENT]: string;
+	value: unknown;
 }
 
 interface ReasonSnapshotState {
@@ -3932,8 +3942,28 @@ function isHydrationRejectionSeed(value: unknown): value is HydrationRejectionSe
 	);
 }
 
-function recordHydrationRejection(serial: unknown[] | null, reason: unknown): void {
-	if (serial !== null) serial.push(hydrationRejectionSeed(reason));
+function recordHydrationSeed(serial: unknown[] | null, value: unknown, directSite?: string): void {
+	if (serial === null) return;
+	serial.push(
+		directSite === undefined
+			? value
+			: {
+					[HYDRATION_SITE_EVENT]: directSite,
+					value,
+				},
+	);
+}
+
+function recordSkippedHydrationSite(serial: unknown[] | null, directSite?: string): void {
+	if (directSite !== undefined) recordHydrationSeed(serial, HYDRATION_SITE_EVENT, directSite);
+}
+
+function recordHydrationRejection(
+	serial: unknown[] | null,
+	reason: unknown,
+	directSite?: string,
+): void {
+	recordHydrationSeed(serial, hydrationRejectionSeed(reason), directSite);
 }
 
 function hasExternalHydrationOwner(thenable: PromiseLike<unknown>): boolean {
@@ -3950,14 +3980,22 @@ function hasExternalHydrationOwner(thenable: PromiseLike<unknown>): boolean {
 export function use<T>(
 	usable: Context<T> | (PromiseLike<T> & { $$kind?: never }),
 	siteKey?: symbol | string,
+	directSite?: string,
 ): T;
 export function use<T>(
 	usable: Context<T> | (PromiseLike<T> & { $$kind?: never }),
 	siteKey?: ServerHookSlot,
+	directSite?: string,
 ): T {
-	if (usable && (usable as any).$$kind === CONTEXT_TAG) return readContext(usable as Context<T>);
-	const serial = hasExternalHydrationOwner(usable as PromiseLike<unknown>) ? null : SERIAL;
+	if (usable && (usable as any).$$kind === CONTEXT_TAG) {
+		recordSkippedHydrationSite(SERIAL, directSite);
+		return readContext(usable as Context<T>);
+	}
+	const externalOwner = hasExternalHydrationOwner(usable as PromiseLike<unknown>);
+	const serial = externalOwner ? null : SERIAL;
+	if (externalOwner) recordSkippedHydrationSite(SERIAL, directSite);
 	if (usable == null || typeof (usable as any).then !== 'function') {
+		if (!externalOwner) recordSkippedHydrationSite(SERIAL, directSite);
 		// Cold path: a FOREIGN host context inside a hosted server pass reads
 		// through the installed host hook (§6.4); anything else diagnoses.
 		return readHostedForeignContext(usable, 'use');
@@ -3996,10 +4034,10 @@ export function use<T>(
 			// Livelock-guard consumption mark (armed only after a first strike).
 			RESOLVED.pu.touched?.add(usable as PromiseLike<unknown>);
 			if ('reason' in entryT) {
-				recordHydrationRejection(serial, entryT.reason);
+				recordHydrationRejection(serial, entryT.reason, directSite);
 				throw entryT.reason;
 			}
-			if (serial !== null) serial.push(entryT.value);
+			recordHydrationSeed(serial, entryT.value, directSite);
 			return entryT.value as T;
 		}
 	}
@@ -4020,11 +4058,11 @@ export function use<T>(
 		// Serialize a typed rejection seed first so hydration takes the same catch
 		// arm even when the client receives a fresh, still-pending thenable.
 		if ('reason' in entry) {
-			recordHydrationRejection(serial, entry.reason);
+			recordHydrationRejection(serial, entry.reason, directSite);
 			throw entry.reason;
 		}
 		// Resolved → return it, and record it (in render order) for client seeding.
-		if (serial !== null) serial.push(entry.value);
+		recordHydrationSeed(serial, entry.value, directSite);
 		return entry.value as T;
 	}
 	// React-compatible instrumented thenables expose their synchronous state on
@@ -4040,11 +4078,11 @@ export function use<T>(
 	let status = instrumented.status;
 	const wasUninstrumented = status === undefined;
 	if (status === 'fulfilled') {
-		if (serial !== null) serial.push(instrumented.value);
+		recordHydrationSeed(serial, instrumented.value, directSite);
 		return instrumented.value as T;
 	}
 	if (status === 'rejected') {
-		recordHydrationRejection(serial, instrumented.reason);
+		recordHydrationRejection(serial, instrumented.reason, directSite);
 		throw instrumented.reason;
 	}
 	if (wasUninstrumented) {
@@ -4070,11 +4108,11 @@ export function use<T>(
 		);
 		status = instrumented.status;
 		if (status === 'fulfilled') {
-			if (serial !== null) serial.push(instrumented.value);
+			recordHydrationSeed(serial, instrumented.value, directSite);
 			return instrumented.value as T;
 		}
 		if (status === 'rejected') {
-			recordHydrationRejection(serial, instrumented.reason);
+			recordHydrationRejection(serial, instrumented.reason, directSite);
 			throw instrumented.reason;
 		}
 	}
@@ -4082,11 +4120,11 @@ export function use<T>(
 		instrumented.then(NOOP, NOOP);
 		status = instrumented.status;
 		if (status === 'fulfilled') {
-			if (serial !== null) serial.push(instrumented.value);
+			recordHydrationSeed(serial, instrumented.value, directSite);
 			return instrumented.value as T;
 		}
 		if (status === 'rejected') {
-			recordHydrationRejection(serial, instrumented.reason);
+			recordHydrationRejection(serial, instrumented.reason, directSite);
 			throw instrumented.reason;
 		}
 	}
@@ -5149,25 +5187,50 @@ export function getSsrSuspenseTimeout(): number {
 function serializeSuspenseSeedJson(values: unknown[]): string {
 	let wireValues: unknown[] | null = null;
 	let rejections: Array<[number, HydrationRejectionPayload]> | null = null;
+	let sites: Array<[string, number]> | null = null;
+	let hasSeededSite = false;
 	for (let i = 0; i < values.length; i++) {
-		const value = values[i];
-		if (!isHydrationRejectionSeed(value)) continue;
-		wireValues ??= values.slice();
-		rejections ??= [];
-		wireValues[i] = null;
-		rejections.push([i, value[HYDRATION_REJECTION_SEED]]);
+		let value = values[i];
+		if (
+			value !== null &&
+			typeof value === 'object' &&
+			Object.prototype.hasOwnProperty.call(value, HYDRATION_SITE_EVENT)
+		) {
+			wireValues ??= values.slice(0, i);
+			sites ??= [];
+			const event = value as HydrationSiteEvent;
+			value = event.value;
+			if (value === HYDRATION_SITE_EVENT) {
+				sites.push([event[HYDRATION_SITE_EVENT], -1]);
+				continue;
+			}
+			hasSeededSite = true;
+			sites.push([event[HYDRATION_SITE_EVENT], wireValues.length]);
+		}
+		if (isHydrationRejectionSeed(value)) {
+			wireValues ??= values.slice(0, i);
+			rejections ??= [];
+			rejections.push([wireValues.length, value[HYDRATION_REJECTION_SEED]]);
+			wireValues.push(null);
+		} else if (wireValues !== null) {
+			wireValues.push(value);
+		}
 	}
-	// Successful seeds retain the established compact array format. Rejections
-	// use renderer-owned TOP-LEVEL metadata, so a fulfilled user value shaped
-	// like the old in-band sentinel can never be mistaken for control data.
+	const actualValues = wireValues ?? values;
+	// Successful untagged seeds retain the established compact array format.
+	// Rejections and compiler-owned site outcomes use renderer-owned TOP-LEVEL
+	// metadata so fulfilled user values cannot collide with either protocol.
+	// Unseeded site outcomes matter only when a seeded site exists in the same
+	// scope; otherwise the client can safely execute every request factory.
 	const payload =
-		rejections === null
-			? values
+		rejections === null && !hasSeededSite
+			? actualValues
 			: {
 					[REJECTION_SENTINEL_KEY]: {
 						version: 1,
-						values: wireValues!,
-						rejections,
+						values: actualValues,
+						rejections: rejections ?? [],
+						...(hasSeededSite ? { sites: sites! } : {}),
 					},
 				};
 	const undefinedWire = SUSPENSE_SEED_WIRE_PREFIX + 'u';
@@ -5193,6 +5256,7 @@ function serializeSuspenseSeeds(values: unknown[], nonceAttr: string): string {
 	// the client — not `null`. Prefix-leading user strings are escaped first, so
 	// neither sentinel-shaped objects nor user strings can collide with it.
 	const json = serializeSuspenseSeedJson(values);
+	if (json === '[]') return '';
 	return (
 		'<script type="application/json" ' + SUSPENSE_SCRIPT_ATTR + nonceAttr + '>' + json + '</script>'
 	);
@@ -6810,8 +6874,15 @@ function segmentChunk(b: StreamBoundary, nonceAttr: string): string {
 	let seedScript = '';
 	if (b.seeds.length > 0) {
 		const json = serializeSuspenseSeedJson(b.seeds);
-		seedScript =
-			'<script type="application/json" ' + STREAM_SEED_ATTR + nonceAttr + '>' + json + '</script>';
+		if (json !== '[]') {
+			seedScript =
+				'<script type="application/json" ' +
+				STREAM_SEED_ATTR +
+				nonceAttr +
+				'>' +
+				json +
+				'</script>';
+		}
 	}
 	// ViewTransition arm candidates are renderer-only staging attributes. Strip
 	// them while this is still markup: once the parsing-safe carrier below turns

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -8382,9 +8382,32 @@ function isSuspenseException(x: any): x is SuspenseException {
 
 const HYDRATION_REJECTION_SEED = Symbol('octane.hydration.rejection-seed');
 const HYDRATION_REJECTION_EXCEPTION = Symbol('octane.hydration.rejection-exception');
+const HYDRATION_SITE_EVENTS = Symbol('octane.hydration.site-events');
+const HYDRATION_SEED_FACTORY = Symbol('octane.hydration.seed-factory');
 
 interface HydrationRejectionSeed {
 	[HYDRATION_REJECTION_SEED]: unknown;
+}
+
+interface HydrationSiteEvents {
+	queues: Map<string, number[]>;
+	offsets: Map<string, number>;
+}
+
+interface HydrationSeedArray extends Array<unknown> {
+	[HYDRATION_SITE_EVENTS]?: HydrationSiteEvents;
+}
+
+interface HydrationSeedFactory {
+	index: number;
+	factory: (() => unknown) | null;
+	value?: unknown;
+	error?: unknown;
+	failed?: boolean;
+}
+
+interface HydrationSeedThenable extends TrackedThenable {
+	[HYDRATION_SEED_FACTORY]: HydrationSeedFactory;
 }
 
 class HydrationRejectionException {
@@ -8467,10 +8490,11 @@ function isHydrationRejection(error: unknown): error is HydrationRejectionExcept
 
 /**
  * Hydration uses the server's settled value/reason as the canonical first-render
- * result, but evaluating the client component has already created its matching
- * thenable. Observe that thenable without letting its eventual result replace
- * the seed. Otherwise a later client-side rejection is reported as unhandled
- * even though the authored use() is visibly handled by its hydrated @catch arm.
+ * result. An externally supplied or otherwise unoptimized client thenable may
+ * already exist, so observe it without letting its eventual result replace the
+ * seed. Otherwise a later client-side rejection is reported as unhandled even
+ * though the authored use() is visibly handled by its hydrated @catch arm.
+ * Compiler-owned seeded factories never create a client thenable to observe.
  */
 function observeHydrationSeedThenable(thenable: TrackedThenable<unknown>): void {
 	thenable.then(
@@ -8485,6 +8509,36 @@ function hasExternalHydrationOwner(thenable: PromiseLike<unknown>): boolean {
 	} catch {
 		return false;
 	}
+}
+
+function materializeHydrationSeedFactory(record: HydrationSeedFactory): unknown {
+	if (record.failed === true) throw record.error;
+	if (record.factory !== null) {
+		const factory = record.factory;
+		record.factory = null;
+		try {
+			record.value = factory();
+		} catch (error) {
+			record.failed = true;
+			record.error = error;
+			throw error;
+		}
+	}
+	return record.value;
+}
+
+function getHydrationSeedFactory(thenable: TrackedThenable): HydrationSeedFactory | undefined {
+	try {
+		return (thenable as HydrationSeedThenable)[HYDRATION_SEED_FACTORY];
+	} catch {
+		return undefined;
+	}
+}
+
+/** Compiler-owned direct use() creations consult their server-proven site outcome first. */
+export function seedOrCreate<T>(site: string, factory: () => T): T {
+	const hydration = activeHydration();
+	return hydration === null ? factory() : hydration.seedOrCreate(site, factory);
 }
 
 function useThenable<T>(thenable: TrackedThenable<T>, replaceOnResume = false): T {
@@ -8505,20 +8559,7 @@ function useThenable<T>(thenable: TrackedThenable<T>, replaceOnResume = false): 
 		hydration.seeds !== null &&
 		hydration.seedCursor < hydration.seeds.length
 	) {
-		const seed = hydration.seeds[hydration.seedCursor++];
-		observeHydrationSeedThenable(thenable);
-		const rejection = hydration.rejectionFromSeed(seed);
-		if (rejection !== null) {
-			thenable.status = 'rejected';
-			thenable.reason = rejection.reason;
-			state[idx] = thenable;
-			throw rejection;
-		}
-		const value = seed as T;
-		thenable.status = 'fulfilled';
-		thenable.value = value;
-		state[idx] = thenable;
-		return value;
+		return hydration.useSeed(thenable, state, idx, replaceOnResume);
 	}
 
 	const stored = state[idx];
@@ -9687,6 +9728,74 @@ class HydrationCapability {
 		return hydrationRejectionFromSeed(seed);
 	}
 
+	seedOrCreate<T>(site: string, factory: () => T): T {
+		if (this.seeds === null) return factory();
+		const events = (this.seeds as HydrationSeedArray)[HYDRATION_SITE_EVENTS];
+		if (events === undefined) return factory();
+		const queue = events.queues.get(site);
+		if (queue === undefined) return factory();
+		const offset = events.offsets.get(site) ?? 0;
+		events.offsets.set(site, offset + 1);
+		const index = queue[offset];
+		if (index === undefined || index < this.seedCursor) return factory();
+
+		const record: HydrationSeedFactory = { index, factory };
+		const thenable: HydrationSeedThenable = {
+			[HYDRATION_SEED_FACTORY]: record,
+			then(onFulfilled, onRejected) {
+				if (thenable.status === 'fulfilled') {
+					return Promise.resolve(thenable.value).then(onFulfilled, onRejected);
+				}
+				if (thenable.status === 'rejected') {
+					return Promise.reject(thenable.reason).then(onFulfilled, onRejected);
+				}
+				return Promise.resolve(materializeHydrationSeedFactory(record)).then(
+					onFulfilled,
+					onRejected,
+				);
+			},
+		};
+		return thenable as T;
+	}
+
+	useSeed<T>(
+		thenable: TrackedThenable<T>,
+		state: TrackedThenable<any>[],
+		index: number,
+		replaceOnResume: boolean,
+	): T {
+		const factory = getHydrationSeedFactory(thenable);
+		if (factory !== undefined && factory.index !== this.seedCursor) {
+			CURRENT_BLOCK!.__thenableIdx = index;
+			const usable = materializeHydrationSeedFactory(factory);
+			if (
+				replaceOnResume &&
+				usable !== null &&
+				usable !== undefined &&
+				typeof (usable as PromiseLike<T>).then === 'function'
+			) {
+				return useThenable(usable as TrackedThenable<T>, true);
+			}
+			return use(usable as PromiseLike<T>) as T;
+		}
+
+		const seed = this.seeds![this.seedCursor++];
+		if (factory === undefined) observeHydrationSeedThenable(thenable);
+		else factory.factory = null;
+		const rejection = this.rejectionFromSeed(seed);
+		if (rejection !== null) {
+			thenable.status = 'rejected';
+			thenable.reason = rejection.reason;
+			state[index] = thenable;
+			throw rejection;
+		}
+		const value = seed as T;
+		thenable.status = 'fulfilled';
+		thenable.value = value;
+		state[index] = thenable;
+		return value;
+	}
+
 	/** Mark a client-built hydration replacement (and its descendants) as fresh DOM. */
 	markFresh(node: Node): void {
 		this.freshNodes.add(node);
@@ -10141,6 +10250,38 @@ function parseSeedJson(raw: string): unknown[] | null {
 			values[entry[0]] = {
 				[HYDRATION_REJECTION_SEED]: decodeHydrationRejectionPayload(entry[1]),
 			} satisfies HydrationRejectionSeed;
+		}
+		if (envelope.sites !== undefined) {
+			if (!Array.isArray(envelope.sites)) return null;
+			const queues = new Map<string, number[]>();
+			const seededSites = new Set<number>();
+			let previousSeedIndex = -1;
+			for (const entry of envelope.sites) {
+				if (
+					!Array.isArray(entry) ||
+					entry.length !== 2 ||
+					typeof entry[0] !== 'string' ||
+					entry[0] === '' ||
+					!Number.isInteger(entry[1]) ||
+					entry[1] < -1 ||
+					entry[1] >= values.length
+				)
+					return null;
+				const index = entry[1] as number;
+				if (index >= 0) {
+					if (index <= previousSeedIndex || seededSites.has(index)) return null;
+					previousSeedIndex = index;
+					seededSites.add(index);
+				}
+				const queue = queues.get(entry[0]);
+				if (queue === undefined) queues.set(entry[0], [index]);
+				else queue.push(index);
+			}
+			if (seededSites.size === 0) return null;
+			(values as HydrationSeedArray)[HYDRATION_SITE_EVENTS] = {
+				queues,
+				offsets: new Map(),
+			};
 		}
 		return values;
 	} catch {

--- a/packages/octane/tests/compiler/inline-hook-memo-codegen.test.ts
+++ b/packages/octane/tests/compiler/inline-hook-memo-codegen.test.ts
@@ -93,7 +93,7 @@ describe('inline hook-memo tier — compile-mode and shape routing', () => {
 			'inline-pu-dev.tsrx',
 			{ hmr: 'vite', dev: true },
 		).code;
-		expect(dev).toMatch(/useMemo\(\(\) => fetchUser/);
+		expect(dev).toMatch(/useMemo\(\s*\(\)\s*=>[\s\S]*?\(\)\s*=>\s*fetchUser\(id\)/);
 		expect(dev).not.toMatch(/puTake/);
 	});
 

--- a/packages/octane/tests/hydration/suspense-hydrate.test.ts
+++ b/packages/octane/tests/hydration/suspense-hydrate.test.ts
@@ -1,10 +1,18 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { compile } from 'octane/compiler';
-import { hydrateRoot, flushSync } from '../../src/index.js';
+import {
+	EXTERNAL_HYDRATION_PROMISE,
+	act,
+	createContext,
+	hydrateRoot,
+	flushSync,
+} from '../../src/index.js';
 import * as ServerRT from 'octane/server';
+import { condition } from 'octane/hydration';
 import { prerender } from 'octane/static';
+import { loadCompiledFixtureSource } from '../_server-fixture.js';
 // CLIENT-compiled components (normal .tsrx import path). Importing AsyncCounter
 // (which has an onClick) makes this module register click delegation at load.
 import { AsyncLeaf, AsyncCounter, AsyncUndef } from '../_fixtures/ssr-suspense.tsrx';
@@ -26,6 +34,129 @@ function serverModule(): Record<string, any> {
 	return fn(ServerRT, {});
 }
 const server = serverModule();
+
+const FACTORY_SOURCE = `
+	import { Hydrate, use } from 'octane';
+
+	export function SeededResource(props) @{
+		<main>
+			@try {
+				const value = use(props.load(props.id));
+				<span id="seeded-resource">{value as string}</span>
+			} @pending {
+				<span id="seeded-pending">loading</span>
+			} @catch (error) {
+				<span id="seeded-error">{error.message as string}</span>
+			}
+		</main>
+	}
+
+	export function SeededResourcePair(props) @{
+		<main>
+			@try {
+				const first = use(props.load('first', props.id));
+				const second = use(props.load('second', props.id));
+				<section>
+					<span id="first-seeded-resource">{first as string}</span>
+					<span id="second-seeded-resource">{second as string}</span>
+				</section>
+			} @pending {
+				<span id="seeded-pair-pending">loading</span>
+			}
+		</main>
+	}
+
+	export function SeededMixedPromises(props) @{
+		const before = use(props.before);
+		const value = use(props.load(props.id));
+		const after = use(props.after);
+		<div id="seeded-mixed-promises">{before + ':' + value + ':' + after as string}</div>
+	}
+
+	export function SeededContextAndResource(props) @{
+		const context = use(props.makeContext());
+		const value = use(props.load(props.id));
+		<div id="seeded-context-resource">{context + ':' + value as string}</div>
+	}
+
+	export function ContextWithoutSeed(props) @{
+		const context = use(props.makeContext());
+		<div id="context-without-seed">{context as string}</div>
+	}
+
+	export function SeededExternalAndResource(props) @{
+		const external = use(props.makeExternal(props.id));
+		const value = use(props.load(props.id));
+		<div id="seeded-external-resource">{external + ':' + value as string}</div>
+	}
+
+	export function ExternalWithoutSeed(props) @{
+		const external = use(props.makeExternal());
+		<div id="external-without-seed">{external as string}</div>
+	}
+
+	function RepeatedResource(props) @{
+		const value = use(props.load(props.kind));
+		<span data-resource-kind={props.kind}>{value as string}</span>
+	}
+
+	export function SeededRepeatedOwners(props) @{
+		<section id="seeded-repeated-owners">
+			<RepeatedResource kind="external" load={props.makeExternal} />
+			<RepeatedResource kind="ordinary" load={props.load} />
+		</section>
+	}
+
+	export function SeededNestedStream(props) @{
+		<main>
+			@try {
+				const outer = use(props.load('outer', props.id));
+				<section>
+					<span id="streamed-outer-resource">{outer as string}</span>
+					@try {
+						const inner = use(props.load('inner', props.id));
+						<span id="streamed-inner-resource">{inner as string}</span>
+					} @pending {
+						<span id="streamed-inner-pending">inner loading</span>
+					}
+				</section>
+			} @pending {
+				<span id="streamed-outer-pending">outer loading</span>
+			}
+		</main>
+	}
+
+	function DeferredResource(props) @{
+		const value = use(props.load(props.id));
+		<button id="deferred-seeded-resource">{value as string}</button>
+	}
+
+	export function DeferredSeededResource(props) @{
+		<Hydrate when={props.when} split={false}>
+			<DeferredResource load={props.load} id={props.id} />
+		</Hydrate>
+	}
+`;
+const factoryServer = loadCompiledFixtureSource(FACTORY_SOURCE, {
+	id: 'seeded-resource-factories.tsrx',
+	mode: 'server',
+	compileOptions: { hmr: false, dev: false },
+});
+const factoryClient = loadCompiledFixtureSource(FACTORY_SOURCE, {
+	id: 'seeded-resource-factories.tsrx',
+	mode: 'client',
+	compileOptions: { hmr: false, dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod' },
+});
+
+function externallyFulfilled(value: string) {
+	const promise = Promise.resolve(value);
+	return {
+		[EXTERNAL_HYDRATION_PROMISE]: true as const,
+		status: 'fulfilled' as const,
+		value,
+		then: promise.then.bind(promise),
+	};
+}
 
 let container: HTMLElement;
 beforeEach(() => {
@@ -55,6 +186,276 @@ describe('hydrateRoot — Suspense data seeding (SSR Phase 4)', () => {
 		expect(div.textContent).toBe('hello');
 		// The seed <script> was consumed and removed from the live DOM.
 		expect(container.querySelector('script[data-octane-suspense]')).toBeNull();
+		root.unmount();
+	});
+
+	it('adopts a fulfilled resource without starting a client request and refetches when its input changes', async () => {
+		const { html } = await prerender(factoryServer.SeededResource, {
+			id: 'initial',
+			load: (id: string) => Promise.resolve(`server-${id}`),
+		});
+		container.innerHTML = html;
+		const serverNode = container.querySelector('#seeded-resource');
+		const clientLoad = vi.fn((id: string) => Promise.resolve(`client-${id}`));
+
+		const root = hydrateRoot(container, factoryClient.SeededResource, {
+			id: 'initial',
+			load: clientLoad,
+		});
+		flushSync(() => {});
+
+		expect(container.querySelector('#seeded-resource')).toBe(serverNode);
+		expect(serverNode?.textContent).toBe('server-initial');
+		expect(clientLoad).not.toHaveBeenCalled();
+
+		await act(() => root.render(factoryClient.SeededResource, { id: 'updated', load: clientLoad }));
+
+		expect(clientLoad).toHaveBeenCalledExactlyOnceWith('updated');
+		expect(container.querySelector('#seeded-resource')?.textContent).toBe('client-updated');
+		root.unmount();
+	});
+
+	it('adopts a rejected resource without starting a client request or replacing the server catch', async () => {
+		const { html } = await prerender(factoryServer.SeededResource, {
+			id: 'rejected',
+			load: () => Promise.reject(new Error('server-rejection')),
+		});
+		container.innerHTML = html;
+		const serverCatch = container.querySelector('#seeded-error');
+		const clientLoad = vi.fn(() => Promise.resolve('client-success'));
+
+		const root = hydrateRoot(container, factoryClient.SeededResource, {
+			id: 'rejected',
+			load: clientLoad,
+		});
+		flushSync(() => {});
+
+		expect(container.querySelector('#seeded-error')).toBe(serverCatch);
+		expect(serverCatch?.textContent).toBe('server-rejection');
+		expect(clientLoad).not.toHaveBeenCalled();
+		root.unmount();
+	});
+
+	it('adopts independent hoisted resources in order without starting either client request', async () => {
+		const { html } = await prerender(factoryServer.SeededResourcePair, {
+			id: 'initial',
+			load: (name: string, id: string) => Promise.resolve(`${name}-${id}`),
+		});
+		container.innerHTML = html;
+		const firstNode = container.querySelector('#first-seeded-resource');
+		const secondNode = container.querySelector('#second-seeded-resource');
+		const clientLoad = vi.fn(() => Promise.resolve('client-value'));
+
+		const root = hydrateRoot(container, factoryClient.SeededResourcePair, {
+			id: 'initial',
+			load: clientLoad,
+		});
+		flushSync(() => {});
+
+		expect(container.querySelector('#first-seeded-resource')).toBe(firstNode);
+		expect(container.querySelector('#second-seeded-resource')).toBe(secondNode);
+		expect(firstNode?.textContent).toBe('first-initial');
+		expect(secondNode?.textContent).toBe('second-initial');
+		expect(clientLoad).not.toHaveBeenCalled();
+		root.unmount();
+	});
+
+	it('keeps existing promises on both sides of a skipped resource in their original seed positions', async () => {
+		const { html } = await prerender(factoryServer.SeededMixedPromises, {
+			id: 'middle',
+			before: Promise.resolve('server-before'),
+			after: Promise.resolve('server-after'),
+			load: (id: string) => Promise.resolve(`server-${id}`),
+		});
+		container.innerHTML = html;
+		const serverNode = container.querySelector('#seeded-mixed-promises');
+		const clientLoad = vi.fn(() => Promise.resolve('client-middle'));
+
+		const root = hydrateRoot(container, factoryClient.SeededMixedPromises, {
+			id: 'middle',
+			before: Promise.resolve('client-before'),
+			after: Promise.resolve('client-after'),
+			load: clientLoad,
+		});
+		flushSync(() => {});
+
+		expect(container.querySelector('#seeded-mixed-promises')).toBe(serverNode);
+		expect(serverNode?.textContent).toBe('server-before:server-middle:server-after');
+		expect(clientLoad).not.toHaveBeenCalled();
+		root.unmount();
+	});
+
+	it('evaluates an unseeded context factory without stealing the following resource seed', async () => {
+		const context = createContext('context-value');
+		const { html } = await prerender(factoryServer.SeededContextAndResource, {
+			id: 'context',
+			makeContext: () => context,
+			load: (id: string) => Promise.resolve(`server-${id}`),
+		});
+		container.innerHTML = html;
+		const serverNode = container.querySelector('#seeded-context-resource');
+		const makeContext = vi.fn(() => context);
+		const clientLoad = vi.fn(() => Promise.resolve('client-context'));
+
+		const root = hydrateRoot(container, factoryClient.SeededContextAndResource, {
+			id: 'context',
+			makeContext,
+			load: clientLoad,
+		});
+		flushSync(() => {});
+
+		expect(container.querySelector('#seeded-context-resource')).toBe(serverNode);
+		expect(serverNode?.textContent).toBe('context-value:server-context');
+		expect(makeContext).toHaveBeenCalledOnce();
+		expect(clientLoad).not.toHaveBeenCalled();
+		root.unmount();
+	});
+
+	it('evaluates an externally owned factory without stealing the following resource seed', async () => {
+		const { html } = await prerender(factoryServer.SeededExternalAndResource, {
+			id: 'external',
+			makeExternal: () => externallyFulfilled('external-value'),
+			load: (id: string) => Promise.resolve(`server-${id}`),
+		});
+		container.innerHTML = html;
+		const serverNode = container.querySelector('#seeded-external-resource');
+		const makeExternal = vi.fn(() => externallyFulfilled('external-value'));
+		const clientLoad = vi.fn(() => Promise.resolve('client-external'));
+
+		const root = hydrateRoot(container, factoryClient.SeededExternalAndResource, {
+			id: 'external',
+			makeExternal,
+			load: clientLoad,
+		});
+		flushSync(() => {});
+
+		expect(container.querySelector('#seeded-external-resource')).toBe(serverNode);
+		expect(serverNode?.textContent).toBe('external-value:server-external');
+		expect(makeExternal).toHaveBeenCalledExactlyOnceWith('external');
+		expect(clientLoad).not.toHaveBeenCalled();
+		root.unmount();
+	});
+
+	it('distinguishes external and ordinary owners at the same repeated resource site', async () => {
+		const { html } = await prerender(factoryServer.SeededRepeatedOwners, {
+			makeExternal: () => externallyFulfilled('external-value'),
+			load: (kind: string) => Promise.resolve(`server-${kind}`),
+		});
+		container.innerHTML = html;
+		const externalNode = container.querySelector('[data-resource-kind="external"]');
+		const ordinaryNode = container.querySelector('[data-resource-kind="ordinary"]');
+		const makeExternal = vi.fn(() => externallyFulfilled('external-value'));
+		const clientLoad = vi.fn(() => Promise.resolve('client-ordinary'));
+
+		const root = hydrateRoot(container, factoryClient.SeededRepeatedOwners, {
+			makeExternal,
+			load: clientLoad,
+		});
+		flushSync(() => {});
+
+		expect(container.querySelector('[data-resource-kind="external"]')).toBe(externalNode);
+		expect(container.querySelector('[data-resource-kind="ordinary"]')).toBe(ordinaryNode);
+		expect(externalNode?.textContent).toBe('external-value');
+		expect(ordinaryNode?.textContent).toBe('server-ordinary');
+		expect(makeExternal).toHaveBeenCalledExactlyOnceWith('external');
+		expect(clientLoad).not.toHaveBeenCalled();
+		root.unmount();
+	});
+
+	it('does not emit suspense seed scripts for context-only or externally owned resources', async () => {
+		const context = createContext('context-only');
+		const contextRender = await prerender(factoryServer.ContextWithoutSeed, {
+			makeContext: () => context,
+		});
+		expect(contextRender.html).toContain('context-only');
+		expect(contextRender.html).not.toContain('data-octane-suspense');
+
+		const externalRender = await prerender(factoryServer.ExternalWithoutSeed, {
+			makeExternal: () => externallyFulfilled('external-only'),
+		});
+		expect(externalRender.html).toContain('external-only');
+		expect(externalRender.html).not.toContain('data-octane-suspense');
+	});
+
+	it('adopts nested streamed resource scopes without starting either client request', async () => {
+		const chunks: string[] = [];
+		let finish!: () => void;
+		const completed = new Promise<void>((resolve) => {
+			finish = resolve;
+		});
+		ServerRT.renderToPipeableStream(factoryServer.SeededNestedStream, {
+			id: 'streamed',
+			load: (name: string, id: string) => Promise.resolve(`${name}-${id}`),
+		}).pipe({
+			write(chunk: string | Uint8Array) {
+				chunks.push(typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk));
+				return true;
+			},
+			end: finish,
+		});
+		await completed;
+		container.innerHTML = chunks.join('');
+
+		try {
+			for (const script of Array.from(container.querySelectorAll('script'))) {
+				if (script.getAttribute('type') === 'application/json') continue;
+				// eslint-disable-next-line no-eval
+				(0, eval)(script.textContent || '');
+				script.remove();
+			}
+
+			const outerNode = container.querySelector('#streamed-outer-resource');
+			const innerNode = container.querySelector('#streamed-inner-resource');
+			const clientLoad = vi.fn(() => Promise.resolve('client-streamed'));
+			const root = hydrateRoot(container, factoryClient.SeededNestedStream, {
+				id: 'streamed',
+				load: clientLoad,
+			});
+			flushSync(() => {});
+
+			expect(container.querySelector('#streamed-outer-resource')).toBe(outerNode);
+			expect(container.querySelector('#streamed-inner-resource')).toBe(innerNode);
+			expect(outerNode?.textContent).toBe('outer-streamed');
+			expect(innerNode?.textContent).toBe('inner-streamed');
+			expect(clientLoad).not.toHaveBeenCalled();
+			root.unmount();
+		} finally {
+			delete (window as any).$OCTS;
+			delete (window as any).$OCTRC;
+			delete (window as any).$OCTRX;
+		}
+	});
+
+	it('adopts a deferred resource after activation without starting a client request', async () => {
+		const dormant = condition(false);
+		const { html } = await prerender(factoryServer.DeferredSeededResource, {
+			id: 'deferred',
+			when: dormant,
+			load: (id: string) => Promise.resolve(`server-${id}`),
+		});
+		container.innerHTML = html;
+		const serverButton = container.querySelector('#deferred-seeded-resource');
+		const clientLoad = vi.fn(() => Promise.resolve('client-deferred'));
+		const root = hydrateRoot(container, factoryClient.DeferredSeededResource, {
+			id: 'deferred',
+			when: dormant,
+			load: clientLoad,
+		});
+		await act(() => {});
+		expect(container.querySelector('#deferred-seeded-resource')).toBe(serverButton);
+		expect(clientLoad).not.toHaveBeenCalled();
+
+		await act(() =>
+			root.render(factoryClient.DeferredSeededResource, {
+				id: 'deferred',
+				when: condition(true),
+				load: clientLoad,
+			}),
+		);
+
+		expect(container.querySelector('#deferred-seeded-resource')).toBe(serverButton);
+		expect(serverButton?.textContent).toBe('server-deferred');
+		expect(clientLoad).not.toHaveBeenCalled();
 		root.unmount();
 	});
 


### PR DESCRIPTION
## Summary

- Consult server-provided hydration seeds before invoking eligible compiler-owned `use(factory(...))` request creators.
- Preserve fulfilled and rejected values, existing promise ownership, repeated request sites, streamed boundaries, deferred hydration, and subsequent dependency changes.
- Add a patch changeset and document the hydration behavior.

Part of #673.

## Why

Previously, hydration adopted the server result only after evaluating the client-side request factory. That started a duplicate request even though its result was immediately discarded. Independent request creation can also move ahead of `use()` consumption, so a positional seed lookup alone can incorrectly claim a context, externally owned promise, or another component occurrence.

## Changes

- Give eligible direct request sites the same source-derived identity in server and client compiler output.
- Record actual server-owned seed outcomes and skipped context/external outcomes per occurrence; extend the existing rejection envelope only when ownership metadata is necessary.
- Defer client request creation until the matching site outcome is known, consume seeds in their original `use()` order, and retain normal request creation when metadata is missing or invalid.
- Keep seed ownership attached to existing root, streamed, nested, and deferred hydration scopes without changing the legacy wire format for unrelated promises.
- Move adoption behind the hydration capability so client-only bundles tree-shake the new protocol.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm --config.enable-pre-post-scripts=false run typecheck` — full workspace typecheck body, including bindings, core typetests, integrations, website, 17 example apps, and benchmarks. The unrelated Solana `pretypecheck` was disabled because its dependencies are unavailable in the cached worktree installation.
- [x] `pnpm exec vitest run --project octane --project octane-prod --silent=passed-only` — **804 files, 11,657 tests passed**.
- [x] `pnpm exec vitest run packages/octane/tests/browser/suspense-hydration/suspense-hydration.test.ts --project octane-events-browser --silent=passed-only` — **11 real-browser streamed hydration tests passed**.
- [x] `./node_modules/.bin/vitest run packages/octane/tests/hydration/suspense-hydrate.test.ts --project octane --project octane-prod --silent=passed-only` — fulfilled/rejected seeds, zero request creation, independent sites, existing promises, contexts, external owners, repeated sites, streamed nesting, deferred activation, and dependency invalidation.
- [x] `node benchmarks/bench.mjs --quick async-composition` — production browser workload preserved **2 request waves, 8 actual requests per operation, and zero mixed states**.
- [x] `node benchmarks/bundle-size/run-minimal.mjs` — all production reachability scenarios execute successfully; client-only static/suspense entries shrink against the same-commit baseline.
- [x] `node benchmarks/codegen-size/run.mjs` — fixed corpus remains **152,623 raw / 75,339 minified bytes**.
- [x] `pnpm changeset:check`
- [x] `pnpm sync`
- [ ] `pnpm test` — full cross-workspace project matrix was not run; the complete Octane development/production matrix and browser hydration project were run instead.

## Risk / follow-ups

- The optimization intentionally applies only to compiler-owned direct call/new factories; existing promises, optional/conditional expressions, creation chains, custom renderer output, and unrecognized ownership retain their previous behavior.
- Hydration-enabled bundles grow approximately **0.55–0.58 KiB gzip** for the ownership protocol; ordinary client-only entries shrink approximately **50–70 bytes gzip**. Server-render grows **187 bytes gzip** and lands **84 raw bytes above** its existing 31,600-byte raw budget; its gzip/brotli budgets remain satisfied. Separate deferred-hydration and suspense raw budgets already fail on untouched canonical `main`.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SSR seed serialization, client hydration `use()` ordering, and compiler codegen for direct async creations; behavior is narrowed to compiler-owned sites but wire-format and hydration edge cases are easy to get wrong.
> 
> **Overview**
> Fixes hydration starting **duplicate client requests** when the server already resolved the same compiler-owned `use(call/new)` site—the factory used to run before the seed was consumed.
> 
> The compiler assigns a **stable hydration site id** to eligible direct creations and wraps client memo callbacks in **`seedOrCreate`**, which returns a lazy thenable tied to that site instead of invoking the factory immediately. Server **`use()`** records fulfilled/rejected outcomes (or “skipped” markers for context, external owners, and non-owned thenables) into the suspense seed wire format via optional **`sites`** metadata on the existing rejection envelope; empty seed arrays no longer emit seed `<script>` tags.
> 
> Client hydration decodes site queues, **`seedOrCreate`** consults them before running factories, and **`useSeed`** keeps positional seed consumption aligned with ordinary `use()` order—including nested stream, deferred `Hydrate`, and post-hydration prop updates that should refetch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c14b5e1b1b0aa8e719dcb06f9d3c2e35cd415413. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->