### PR TITLE
perf: skip unchanged returned JSX descriptor walls

### DIFF
--- a/.changeset/returned-jsx-wall-b-memoization.md
+++ b/.changeset/returned-jsx-wall-b-memoization.md
@@ -1,0 +1,7 @@
+---
+'octane': patch
+---
+
+Reuse unchanged derived JSX descriptor arrays inside context providers, avoiding
+unnecessary keyed reconciliation and memo comparisons while preserving context
+updates, component state, and hydration.

--- a/benchmarks/memo-wall/README.md
+++ b/benchmarks/memo-wall/README.md
@@ -10,9 +10,9 @@ the leaf consumers without re-running any bailed body. Both Octane dialects
 exercise production `autoMemo` on wall A: TSRX can skip the entire pure `RowsA`
 region, while returned JSX preserves its descriptor boundary and skips the
 unchanged compiled keyed list inside `RowsA`. Both dialects reuse wall B's
-imported descriptor calculation when its inputs are unchanged. TSRX additionally
-skips the unchanged renderable region while preserving context updates; changed
-inputs still exercise the value-comparing memo bail.
+imported descriptor calculation and skip its unchanged renderable region while
+preserving context updates; changed inputs still exercise the value-comparing
+memo bail.
 
 This is the canonical home for octane's `shallowEqualProps` and
 `refreshContextConsumers` numbers — if a store-fanout suite lands later it must
@@ -87,11 +87,11 @@ how `<Row>` is put on screen:
   `createElement(Row, props)` descriptors that reach the DOM through a
   `{rows}` children hole → `childSlot`'s keyed de-opt list → the **childSlot
   arm** of `tryMemoBail`. This is the shape every `@octanejs/*` binding
-  produces. Both dialects cache the imported helper's result against its input.
-  TSRX can also reuse the compiler-proven immutable renderable region, refreshing
-  existing context consumers directly when a Provider changes. When the input
-  changes, fresh descriptors still exercise memo bailouts on prop VALUES, not
-  object identity.
+  produces. Both dialects cache the imported helper's result against its input
+  and reuse the compiler-proven immutable renderable region, refreshing existing
+  context consumers directly when a Provider changes. When the input changes,
+  fresh descriptors still exercise memo bailouts on prop VALUES, not object
+  identity.
 
 For React the A/B distinction collapses (JSX IS `createElement`); both walls
 are kept so the op list and DOM stay identical across targets. The canonical
@@ -127,10 +127,11 @@ A it requires zero list helpers, keyed survivor visits, descriptors, shallow
 memo comparisons, and row bodies (context A additionally requires exactly 1000
 Leaf refreshes). JSX retains its normal `RowsA`/descriptor entry but likewise
 requires zero keyed survivor visits, item helpers, and memo comparisons on an
-unchanged list. Wall B requires both dialects to reuse unchanged calculations;
-TSRX additionally requires zero keyed survivor visits and memo comparisons for
-equal/context-only updates, while context updates still refresh exactly 1000
-leaves. Mount and one-change A/B also carry exact compiled-work gates.
+unchanged list. Wall B requires both dialects to reuse unchanged calculations
+with zero keyed survivor visits and memo comparisons for equal/context-only
+updates; context updates still refresh exactly 1000 leaves. Returned-JSX
+wrapper descriptor counts have upper ceilings rather than exact requirements.
+Mount and one-change A/B also carry exact compiled-work gates.
 
 The React Row/Inner/Leaf counters likewise make those component bodies impure,
 so React Compiler conservatively leaves them alone; the explicit `memo`

--- a/benchmarks/memo-wall/octane-jsx/vite.config.js
+++ b/benchmarks/memo-wall/octane-jsx/vite.config.js
@@ -11,7 +11,8 @@ export default defineConfig({
 	},
 	build: {
 		target: 'esnext',
-		minify: 'terser',
+		// Precise-call coverage needs unmangled names in its untimed production build.
+		minify: process.env.MEMO_WALL_WORK === '1' ? false : 'terser',
 		terserOptions: {
 			compress: {
 				passes: 5,

--- a/benchmarks/memo-wall/work.mjs
+++ b/benchmarks/memo-wall/work.mjs
@@ -111,9 +111,8 @@ const OPS = [
 	},
 	// Wall B's imported helper is cached against its `items` argument by
 	// production auto-calculation. Equal/context-only parent updates reuse that
-	// descriptor array. TSRX also caches its proven-immutable renderable region,
-	// so unchanged rows never enter keyed reconciliation; context updates still
-	// refresh their mounted leaf consumers directly.
+	// descriptor array. Both dialects must also skip the proven-immutable
+	// renderable region, while context updates refresh existing leaf consumers.
 	{
 		name: 'context_B',
 		hook: '__ctxB',
@@ -158,17 +157,25 @@ const JSX_EXPECTATIONS = {
 	context_A: { RowsA: 1, createElement: ROWS + 3 },
 	one_change_B: { createElement: ROWS + 6 },
 	context_B: {
-		updateSurvivor: ROWS,
+		updateSurvivor: 0,
 		buildValueRows: 0,
 		createElement: ROWS + 1,
-		shallowEqualProps: ROWS,
+		shallowEqualProps: 0,
 	},
 	equal_B_control: {
-		updateSurvivor: ROWS,
+		updateSurvivor: 0,
 		buildValueRows: 0,
 		createElement: 1,
-		shallowEqualProps: ROWS,
+		shallowEqualProps: 0,
 	},
+};
+
+// Wrapper descriptors are implementation work, not a required public effect.
+// These ceilings allow equivalent returned-JSX output to allocate fewer while
+// keeping row/context execution and keyed-list visits exact.
+const JSX_MAXIMUMS = {
+	context_B: { createElement: ROWS + 1 },
+	equal_B_control: { createElement: 1 },
 };
 
 function callCounts(coverage) {
@@ -240,7 +247,10 @@ try {
 			restampCachedContextScope: 0,
 		};
 		for (const metric of METRICS) {
-			if (counts[metric] !== expected[metric]) {
+			const maximum = DIALECT === 'jsx' ? JSX_MAXIMUMS[op.name]?.[metric] : undefined;
+			if (maximum !== undefined && counts[metric] > maximum) {
+				failures.push(`${op.name}.${metric}: ${counts[metric]} > maximum ${maximum}`);
+			} else if (maximum === undefined && counts[metric] !== expected[metric]) {
 				failures.push(`${op.name}.${metric}: ${counts[metric]} !== expected ${expected[metric]}`);
 			}
 		}

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -14850,6 +14850,7 @@ function compileReturnJsxFunction(node, ctx, options) {
 	const prevLocals = ctx.currentComponentLocals;
 	const prevAutoMemoCallsitesSafe = ctx.currentAutoMemoCallsitesSafe;
 	const prevAutoMemoLocalHazards = ctx.currentAutoMemoLocalHazards;
+	const prevAutoCalculatedRenderableRefs = ctx.currentAutoCalculatedRenderableRefs;
 	const prevMapTemps = ctx.currentMapTemps;
 	const mapTemps = [];
 	ctx._valueDirectiveLowering = lowerBodyValueDirective;
@@ -14864,6 +14865,7 @@ function compileReturnJsxFunction(node, ctx, options) {
 			.filter((statement) => statement.type === 'ReturnStatement' && isJsxNode(statement.argument))
 			.map((statement) => statement.argument);
 		const renderReadNames = collectRenderReadNames(renderedRoots, ctx);
+		let autoCalculatedDeclarations = null;
 		let renderScopeEstablished = false;
 		newStatements = authoredStatements.map((sourceStatement) => {
 			// Return-JSX functions keep their ordinary callable ABI. Introducing a
@@ -14873,6 +14875,12 @@ function compileReturnJsxFunction(node, ctx, options) {
 			const calculated = renderScopeEstablished
 				? rewriteAutoCalculation(sourceStatement, ctx.currentComponentLocals, renderReadNames, ctx)
 				: sourceStatement;
+			if (ctx.autoMemo && calculated !== sourceStatement) {
+				(autoCalculatedDeclarations ??= new Map()).set(
+					sourceStatement.declarations[0].id.name,
+					sourceStatement,
+				);
+			}
 			if (!renderScopeEstablished && sourceStatement.type === 'VariableDeclaration') {
 				renderScopeEstablished = (sourceStatement.declarations || []).some(
 					(declaration) => stableHookCallName(unwrapTsExpr(declaration.init)) !== null,
@@ -14895,6 +14903,25 @@ function compileReturnJsxFunction(node, ctx, options) {
 			// The `return <jsx>` output → a compiled-fragment descriptor (reconcile path),
 			// not the host-string de-opt (rebuild). Other JSX in setup keeps value-lowering.
 			if (h.type === 'ReturnStatement' && h.argument && isJsxNode(h.argument)) {
+				if (autoCalculatedDeclarations !== null) {
+					// Unlike a JSXCodeBlock, a returned-JSX body's statement list also
+					// contains its output. Do not mistake that owned return for a setup
+					// escape: the separate render-root walk checks its exact hole nodes.
+					const setupStatements = authoredStatements.filter(
+						(statement) => statement.type !== 'ReturnStatement' || !isJsxNode(statement.argument),
+					);
+					const refs = collectAutoCalculatedRenderableRefs(
+						setupStatements,
+						renderedRoots,
+						autoCalculatedDeclarations,
+					);
+					if (refs !== null) {
+						ctx.currentAutoCalculatedRenderableRefs = {
+							nodes: refs,
+							parent: prevAutoCalculatedRenderableRefs,
+						};
+					}
+				}
 				return { ...h, argument: lowerReturnJsx(h.argument, ctx, compInlinedSubs, cssHash) };
 			}
 			return rewriteJsxValues(h, ctx);
@@ -14904,6 +14931,7 @@ function compileReturnJsxFunction(node, ctx, options) {
 		ctx.currentComponentLocals = prevLocals;
 		ctx.currentAutoMemoCallsitesSafe = prevAutoMemoCallsitesSafe;
 		ctx.currentAutoMemoLocalHazards = prevAutoMemoLocalHazards;
+		ctx.currentAutoCalculatedRenderableRefs = prevAutoCalculatedRenderableRefs;
 		ctx.currentMapTemps = prevMapTemps;
 	}
 	if (
@@ -16410,6 +16438,96 @@ function jsxValueChildrenNeedRenderScope(node, descendantElementsOwnChildren = f
 	return false;
 }
 
+// A returned host preserves nested component children as inspectable
+// descriptors. An actual Octane Context can reuse its static host descriptor
+// while a compiler-proven plain descriptor array stays unchanged; the existing
+// implicit element bailout then skips its list without changing the children
+// representation or hydration ranges. Admit only one ordinary `.Provider`, its
+// `value`, and one static host whose sole child is the exact non-escaping
+// calculation Identifier.
+function autoMemoReturnedProviderChild(node, nameNode, ctx) {
+	if (
+		!ctx.autoMemo ||
+		ctx._universalRuntimeUnit != null ||
+		ctx._foldCtx?.immediateRenderedOutput !== true ||
+		!Array.isArray(ctx._foldCtx.compInlinedSubs) ||
+		ctx.currentAutoCalculatedRenderableRefs === null ||
+		(nameNode?.type !== 'MemberExpression' && nameNode?.type !== 'JSXMemberExpression') ||
+		(nameNode.object?.type !== 'Identifier' && nameNode.object?.type !== 'JSXIdentifier') ||
+		nameNode.property?.name !== 'Provider'
+	) {
+		return null;
+	}
+
+	const attributes = node.attributes || node.openingElement?.attributes || [];
+	if (attributes.length !== 1) return null;
+	const valueAttribute = attributes[0];
+	if (
+		(valueAttribute.type !== 'Attribute' && valueAttribute.type !== 'JSXAttribute') ||
+		jsxAttrRawName(valueAttribute) !== 'value'
+	) {
+		return null;
+	}
+	const value =
+		valueAttribute.value?.type === 'JSXExpressionContainer'
+			? unwrapTsExpr(valueAttribute.value.expression)
+			: valueAttribute.value;
+	if (
+		value == null ||
+		(value.type !== 'Identifier' && value.type !== 'Literal' && value.type !== 'StringLiteral')
+	) {
+		return null;
+	}
+
+	const onlyMeaningfulChild = (children) => {
+		let result = null;
+		for (const child of children || []) {
+			if (child?.type === 'JSXText' || child?.type === 'Text') {
+				const text = child.value ?? child.raw;
+				if (typeof text === 'string' && /^\s*$/.test(text) && /[\n\r]/.test(text)) {
+					continue;
+				}
+			}
+			if (result !== null) return null;
+			result = child;
+		}
+		return result;
+	};
+	const host = onlyMeaningfulChild(node.children);
+	if ((host?.type !== 'Element' && host?.type !== 'JSXElement') || isComponentTag(host)) {
+		return null;
+	}
+	for (const attribute of host.attributes || host.openingElement?.attributes || []) {
+		if (attribute.type !== 'Attribute' && attribute.type !== 'JSXAttribute') return null;
+		const name = jsxAttrRawName(attribute);
+		if (
+			name === 'key' ||
+			name === 'ref' ||
+			name === 'children' ||
+			name === 'dangerouslySetInnerHTML'
+		) {
+			return null;
+		}
+		if (
+			attribute.value != null &&
+			attribute.value.type !== 'Literal' &&
+			attribute.value.type !== 'StringLiteral'
+		) {
+			return null;
+		}
+	}
+	const child = onlyMeaningfulChild(host.children);
+	if (child?.type !== 'JSXExpressionContainer' || child.expression?.type !== 'Identifier') {
+		return null;
+	}
+	for (let proof = ctx.currentAutoCalculatedRenderableRefs; proof !== null; proof = proof.parent) {
+		if (proof.nodes.has(child.expression)) {
+			return { host, contextName: nameNode.object.name, rows: child.expression };
+		}
+	}
+	return null;
+}
+
 // Build a `createElement(Comp, { ...props })` CallExpression AST node from a
 // component Element node. Recurses into prop values so nested JSX values lower too.
 function jsxElementToCreateElement(node, ctx, eagerRoot = false) {
@@ -16494,6 +16612,9 @@ function jsxElementToCreateElement(node, ctx, eagerRoot = false) {
 		childrenNeedRenderScope &&
 		(nameNode?.type === 'MemberExpression' || nameNode?.type === 'JSXMemberExpression') &&
 		nameNode.property?.name === 'Provider';
+	const autoMemoProviderChild = eagerProviderChildren
+		? autoMemoReturnedProviderChild(node, nameNode, ctx)
+		: null;
 	const loweredChildren = [];
 	// Children → trailing `createElement(type, props, ...children)` args, each
 	// lowered recursively (host child → createElement, `{expr}` → expr, text →
@@ -16525,6 +16646,71 @@ function jsxElementToCreateElement(node, ctx, eagerRoot = false) {
 	let descriptor;
 	if (childrenNeedRenderScope && loweredChildren.length > 0) {
 		let childrenValue = loweredChildren[0];
+		let memoizedChildrenBody = null;
+		if (autoMemoProviderChild !== null && loweredChildren.length === 1) {
+			const { host, contextName, rows } = autoMemoProviderChild;
+			ctx.runtimeNeeded.add('compilerCacheArray');
+			// `.Provider` is a public property and can belong to any component.
+			// Ask the runtime whether this exact value is provided by the CURRENT
+			// scope. Its identity-map lookup never re-reads `.Provider`, invokes
+			// a fake component's `$$kind` getter, or observes a user Proxy trap.
+			const genuineContext = inheritOriginLoc(
+				b.call(
+					requireRuntimeForContext(ctx, 'compilerOwnsContextProvider'),
+					inheritOriginLoc(b.id(contextName), nameNode.object),
+				),
+				nameNode,
+			);
+			// The scoped descriptor's readChildren callback runs while this
+			// verified Provider owns CURRENT_SCOPE. Its compiler-minted Symbol
+			// therefore belongs to that stable Provider instance, never to an
+			// arbitrary component or to a descriptor inspected outside render.
+			// This site is client-only, so defer its Symbol until shared authored
+			// sites have claimed their ids in both the server and client compiles.
+			const slot = allocTailHookSymbol(ctx, `${contextName}.provider.child.memo`, {
+				componentName: contextName,
+				name: 'provider child memo',
+				kind: 'useMemo',
+				node: host,
+			});
+			const freshName = allocCompilerName(ctx, '__memoFresh');
+			const childName = allocCompilerName(ctx, '__memoChild');
+			const memoizedDescriptor = inheritOriginLoc(
+				b.call(
+					requireRuntimeForContext(ctx, 'useMemo'),
+					b.arrow(
+						[],
+						b.sequence([b.assignment('=', b.id(freshName), b.literal(true)), childrenValue]),
+					),
+					b.array([rows]),
+					b.id(slot),
+				),
+				host,
+			);
+			// A fresh descriptor must reconcile regardless of array contents.
+			// Inspect dense/accessor/scoped eligibility only when the memo HIT
+			// could actually skip reconciliation, just like compilerCacheArray's
+			// ordinary previous-value path. This keeps mount and changed inputs
+			// free of an extra linear scan.
+			const cacheable = b.logical(
+				'&&',
+				genuineContext,
+				b.sequence([
+					b.assignment('=', b.id(childName), memoizedDescriptor),
+					b.logical('||', b.id(freshName), b.call('_$compilerCacheArray', rows, rows)),
+				]),
+			);
+			memoizedChildrenBody = inheritOriginLoc(
+				b.block([
+					b.declaration('let', [
+						b.declarator(b.id(freshName), b.literal(false)),
+						b.declarator(b.id(childName), null),
+					]),
+					b.return(b.conditional(cacheable, b.id(childName), childrenValue)),
+				]),
+				host,
+			);
+		}
 		if (loweredChildren.length > 1) {
 			ctx.runtimeNeeded.add('positionalChildren');
 			childrenValue = inheritOriginLoc(
@@ -16533,7 +16719,7 @@ function jsxElementToCreateElement(node, ctx, eagerRoot = false) {
 			);
 		}
 		ctx.runtimeNeeded.add('createScopedElement');
-		const readChildren = inheritOriginLoc(b.arrow([], childrenValue), node);
+		const readChildren = inheritOriginLoc(b.arrow([], memoizedChildrenBody ?? childrenValue), node);
 		descriptor = inheritOriginLoc(
 			b.call('_$createScopedElement', compNode, propsNode, readChildren),
 			node,

--- a/packages/octane/src/index.ts
+++ b/packages/octane/src/index.ts
@@ -202,6 +202,7 @@ export {
 	componentSlotLite,
 	compilerCacheArray,
 	compilerCacheContext,
+	compilerOwnsContextProvider,
 	markSingleRoot,
 	// Compact compiler ABI; keep the descriptive export for older compiled output.
 	markSingleRoot as __s,

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -6513,6 +6513,15 @@ export function createContext<T>(defaultValue: T): Context<T> {
 	return ctx;
 }
 
+/**
+ * Identify the Context already provided by this deferred child's own scope
+ * without observing userland Provider accessors or Proxy traps.
+ * @internal
+ */
+export function compilerOwnsContextProvider(value: unknown): boolean {
+	return CURRENT_SCOPE?.$$ctxValues?.has(value as Context<any>) === true;
+}
+
 /** Renderer-boundary adapter; ordinary DOM roots never retain this by themselves. */
 export function renderClientContextProvider<T>(
 	context: unknown,

--- a/packages/octane/tests/auto-memo.test.ts
+++ b/packages/octane/tests/auto-memo.test.ts
@@ -1769,6 +1769,489 @@ describe('compiler-owned component-region memoization', () => {
 		root.unmount();
 	});
 
+	it('preserves returned-JSX descriptor rows, context, state, keys, refs, and effects', () => {
+		const source = `
+			import { createContext, createElement, memo, useContext, useEffect, useState } from 'octane';
+
+			const Theme = createContext('initial');
+
+			function RowImpl(props) {
+				const theme = useContext(Theme);
+				const [own, setOwn] = useState(0);
+				useEffect(() => {
+					props.onEffect('mount:' + props.id);
+					return () => props.onEffect('cleanup:' + props.id);
+				}, [props.id, props.onEffect]);
+				return (
+					<button
+						className={'returned-descriptor-row-' + props.id}
+						data-id={props.id}
+						ref={props.onRef}
+						onClick={() => setOwn(own + 1)}
+					>
+						{theme + ':' + props.label + ':' + own}
+					</button>
+				);
+			}
+			const Row = memo(RowImpl);
+
+			function selectRow(item, onEffect, onRef) {
+				return createElement(Row, {
+					key: item.id,
+					id: item.id,
+					label: item.label,
+					onEffect,
+					onRef,
+				});
+			}
+
+			function selectRows(items, onEffect, onRef) {
+				return [
+					selectRow(items[0], onEffect, onRef),
+					selectRow(items[1], onEffect, onRef),
+				];
+			}
+
+			export function App(props) {
+				const [items, setItems] = useState([
+					{ id: 1, label: 'first' },
+					{ id: 2, label: 'second' },
+				]);
+				const [theme, setTheme] = useState('initial');
+				const [tick, setTick] = useState(0);
+				const rows = selectRows(items, props.onEffect, props.onRef);
+				return (
+					<section>
+						<button id="returned-descriptor-tick" onClick={() => setTick(tick + 1)}>{tick}</button>
+						<button id="returned-descriptor-theme" onClick={() => setTheme('updated')}>theme</button>
+						<button
+							id="returned-descriptor-change"
+							onClick={() => setItems(items.map((item) => item.id === 1
+								? { ...item, label: 'changed' }
+								: item))}
+						>change</button>
+						<button id="returned-descriptor-reorder" onClick={() => setItems(items.toReversed())}>
+							reorder
+						</button>
+						<Theme.Provider value={theme}>
+							<div id="returned-descriptor-rows">{rows}</div>
+						</Theme.Provider>
+					</section>
+				);
+			}
+		`;
+		const client = loadCompiledFixtureSource(source, {
+			id: 'returned-descriptor-rows.tsx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: false },
+		});
+		const effects: string[] = [];
+		const attached: Element[] = [];
+		const detached: Element[] = [];
+		const root = mount(client.App, {
+			onEffect: (event: string) => effects.push(event),
+			onRef: (element: Element | null) => {
+				if (element !== null) {
+					attached.push(element);
+					return () => detached.push(element);
+				}
+			},
+		});
+		flushEffects();
+		const first = root.find('.returned-descriptor-row-1');
+		const second = root.find('.returned-descriptor-row-2');
+		expect(attached).toEqual([first, second]);
+		expect(effects).toEqual(['mount:1', 'mount:2']);
+		expect(first.textContent).toBe('initial:first:0');
+		expect(second.textContent).toBe('initial:second:0');
+
+		root.click('.returned-descriptor-row-1');
+		expect(first.textContent).toBe('initial:first:1');
+
+		root.click('#returned-descriptor-tick');
+		expect(root.findAll('#returned-descriptor-rows > button')).toEqual([first, second]);
+		expect(first.textContent).toBe('initial:first:1');
+		expect(attached).toEqual([first, second]);
+		expect(detached).toEqual([]);
+
+		root.click('#returned-descriptor-theme');
+		expect(first.textContent).toBe('updated:first:1');
+		expect(second.textContent).toBe('updated:second:0');
+
+		root.click('#returned-descriptor-change');
+		expect(root.findAll('#returned-descriptor-rows > button')).toEqual([first, second]);
+		expect(first.textContent).toBe('updated:changed:1');
+		expect(second.textContent).toBe('updated:second:0');
+
+		root.click('#returned-descriptor-reorder');
+		expect(root.findAll('#returned-descriptor-rows > button')).toEqual([second, first]);
+		expect(first.textContent).toBe('updated:changed:1');
+		expect(second.textContent).toBe('updated:second:0');
+		flushEffects();
+		expect(attached).toEqual([first, second]);
+		expect(detached).toEqual([]);
+		expect(effects).toEqual(['mount:1', 'mount:2']);
+
+		root.unmount();
+		flushEffects();
+		expect(detached).toHaveLength(2);
+		expect(detached).toEqual(expect.arrayContaining([first, second]));
+		expect(effects.slice(2).toSorted()).toEqual(['cleanup:1', 'cleanup:2']);
+	});
+
+	it('hydrates returned-JSX descriptor rows and preserves their nodes through provider updates', () => {
+		const source = `
+			import { createContext, createElement, memo, useContext, useState } from 'octane';
+
+			const Theme = createContext('default');
+
+			function RowImpl(props) {
+				const theme = useContext(Theme);
+				return <span id="returned-hydrated-row">{theme + ':' + props.label}</span>;
+			}
+			const Row = memo(RowImpl);
+
+			function selectRows(items) {
+				return [createElement(Row, { key: items[0].id, label: items[0].label })];
+			}
+
+			export function App(props) {
+				const [tick, setTick] = useState(0);
+				const theme = props.theme;
+				const rows = selectRows(props.items);
+				return (
+					<section>
+						<button id="returned-hydrated-tick" onClick={() => setTick(tick + 1)}>{tick}</button>
+						<Theme.Provider value={theme}>
+							<div id="returned-hydrated-rows">{rows}</div>
+						</Theme.Provider>
+					</section>
+				);
+			}
+		`;
+		const id = 'returned-descriptor-hydration.tsx';
+		const server = loadCompiledFixtureSource(source, {
+			id,
+			mode: 'server',
+			compileOptions: { hmr: false, dev: false },
+		});
+		const client = loadCompiledFixtureSource(source, {
+			id,
+			mode: 'client',
+			compileOptions: { hmr: false, dev: false },
+		});
+		const items = [{ id: 1, label: 'row' }];
+		const { html } = ServerRuntime.renderToString(server.App, { items, theme: 'initial' });
+		const container = document.createElement('div');
+		container.innerHTML = html;
+		document.body.appendChild(container);
+		const row = container.querySelector('#returned-hydrated-row');
+		const list = container.querySelector('#returned-hydrated-rows');
+
+		const root = hydrateRoot(container, client.App, { items, theme: 'initial' });
+		flushSync(() => {});
+		expect(container.querySelector('#returned-hydrated-row')).toBe(row);
+		expect(container.querySelector('#returned-hydrated-rows')).toBe(list);
+		expect(row?.textContent).toBe('initial:row');
+
+		flushSync(() => (container.querySelector('#returned-hydrated-tick') as HTMLElement).click());
+		expect(container.querySelector('#returned-hydrated-row')).toBe(row);
+		expect(row?.textContent).toBe('initial:row');
+
+		flushSync(() => root.render(client.App, { items, theme: 'updated' }));
+		expect(container.querySelector('#returned-hydrated-rows')).toBe(list);
+		expect(container.querySelector('#returned-hydrated-row')).toBe(row);
+		expect(row?.textContent).toBe('updated:row');
+		root.unmount();
+		container.remove();
+	});
+
+	it.each([
+		{ shape: 'direct', shared: 'dynamic' },
+		{ shape: 'nested', shared: '[dynamic]' },
+		{
+			shape: 'fragment-wrapped',
+			shared: "[createElement(Fragment, { key: 'wrapper' }, dynamic)]",
+		},
+	])(
+		'keeps $shape returned-JSX descriptor-array getters live across parent updates',
+		({ shape, shared }) => {
+			const source = `
+				import { Fragment, createContext, createElement, useState } from 'octane';
+
+				let label = 'initial';
+				const dynamic = [];
+				Object.defineProperty(dynamic, '0', {
+					configurable: true,
+					enumerable: true,
+					get() {
+						return createElement(Row, { key: 'row', label });
+					},
+				});
+				const shared = ${shared};
+				const Context = createContext(null);
+
+				function Row(props) {
+					return <span id="returned-accessor-row">{props.label}</span>;
+				}
+
+				function selectRows(items) {
+					return shared;
+				}
+
+				export function App() {
+					const [items] = useState([0]);
+					const [tick, setTick] = useState(0);
+					const rows = selectRows(items);
+					return (
+						<section>
+							<button
+								id="returned-accessor-update"
+								onClick={() => {
+									label = 'updated';
+									setTick(tick + 1);
+								}}
+							>{tick}</button>
+							<Context.Provider value={null}>
+								<div>{rows}</div>
+							</Context.Provider>
+						</section>
+					);
+				}
+			`;
+			const client = loadCompiledFixtureSource(source, {
+				id: `returned-${shape}-descriptor-accessor.tsx`,
+				mode: 'client',
+				compileOptions: { hmr: false, dev: false },
+			});
+			const root = mount(client.App);
+			const row = root.find('#returned-accessor-row');
+			expect(row.textContent).toBe('initial');
+
+			root.click('#returned-accessor-update');
+			expect(root.find('#returned-accessor-row')).toBe(row);
+			expect(row.textContent).toBe('updated');
+			root.unmount();
+		},
+	);
+
+	it.each([
+		{
+			shape: 'deferred component props',
+			entry: '<Row key="row" label={use(Theme)} />',
+		},
+		{
+			shape: 'deferred host children',
+			entry: '<span key="row" id="returned-scoped-row">{use(Theme)}</span>',
+		},
+	])('keeps returned-JSX $shape reactive inside derived descriptor arrays', ({ shape, entry }) => {
+		const source = `
+			import { createContext, use, useState } from 'octane';
+
+			const Theme = createContext('initial');
+
+			function Row(props) {
+				return <span id="returned-scoped-row">{props.label}</span>;
+			}
+
+			const shared = [${entry}];
+			function selectRows(items) {
+				return shared;
+			}
+
+			export function App() {
+				const [items] = useState([0]);
+				const [theme, setTheme] = useState('initial');
+				const rows = selectRows(items);
+				return (
+					<section>
+						<button id="returned-scoped-update" onClick={() => setTheme('updated')}>
+							update context
+						</button>
+						<Theme.Provider value={theme}>
+							<div>{rows}</div>
+						</Theme.Provider>
+					</section>
+				);
+			}
+		`;
+		const client = loadCompiledFixtureSource(source, {
+			id: `returned-${shape.replaceAll(' ', '-')}.tsx`,
+			mode: 'client',
+			compileOptions: { hmr: false, dev: false },
+		});
+		const root = mount(client.App);
+		const row = root.find('#returned-scoped-row');
+		expect(row.textContent).toBe('initial');
+
+		root.click('#returned-scoped-update');
+		expect(root.find('#returned-scoped-row')).toBe(row);
+		expect(row.textContent).toBe('updated');
+		root.unmount();
+	});
+
+	it('observes mutations to returned-JSX descriptor arrays that escape into callbacks', () => {
+		const source = `
+			import { createContext, createElement, useState } from 'octane';
+
+			const Context = createContext(null);
+
+			function Row(props) {
+				return <span id="returned-escaped-row">{props.label}</span>;
+			}
+
+			const shared = [createElement(Row, { key: 'row', label: 'initial' })];
+			function selectRows(items) {
+				return shared;
+			}
+
+			export function App() {
+				const [items] = useState([0]);
+				const [tick, setTick] = useState(0);
+				const rows = selectRows(items);
+				return (
+					<section>
+						<button
+							id="returned-escaped-update"
+							onClick={() => {
+								rows[0] = createElement(Row, { key: 'row', label: 'updated' });
+								setTick(tick + 1);
+							}}
+						>{tick}</button>
+						<Context.Provider value={null}>
+							<div>{rows}</div>
+						</Context.Provider>
+					</section>
+				);
+			}
+		`;
+		const client = loadCompiledFixtureSource(source, {
+			id: 'returned-escaped-descriptor-array.tsx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: false },
+		});
+		const root = mount(client.App);
+		const row = root.find('#returned-escaped-row');
+		expect(row.textContent).toBe('initial');
+
+		root.click('#returned-escaped-update');
+		expect(root.find('#returned-escaped-row')).toBe(row);
+		expect(row.textContent).toBe('updated');
+		root.unmount();
+	});
+
+	it.each([
+		{
+			shape: 'ordinary object',
+			provider: `
+				const Wrapper = {
+					Provider(props) {
+						props.value(isValidElement(props.children), props.children.type);
+						return props.children;
+					},
+				};
+			`,
+		},
+		{
+			shape: 'self-aliased function',
+			provider: `
+				function Wrapper(props) {
+					props.value(isValidElement(props.children), props.children.type);
+					return props.children;
+				}
+				Wrapper.Provider = Wrapper;
+			`,
+		},
+		{
+			shape: 'callable accessor',
+			provider: `
+				let providerReads = 0;
+				function Wrapper(props) {
+					const child = props.children;
+					props.value(isValidElement(child), child.type);
+					providerReads = 0;
+					return child;
+				}
+				Object.defineProperty(Wrapper, 'Provider', {
+					configurable: true,
+					get() {
+						if (++providerReads !== 1) {
+							throw new Error('Provider must only be read once');
+						}
+						return Wrapper;
+					},
+				});
+			`,
+		},
+		{
+			shape: 'throwing context-brand accessor',
+			provider: `
+				function Wrapper(props) {
+					props.value(isValidElement(props.children), props.children.type);
+					return props.children;
+				}
+				Wrapper.Provider = Wrapper;
+				Object.defineProperty(Wrapper, '$$kind', {
+					get() {
+						throw new Error('Custom provider context brand must not be inspected');
+					},
+				});
+			`,
+		},
+	])(
+		'preserves inspectable descriptor children for $shape components named Provider',
+		({ shape, provider }) => {
+			const source = `
+			import { createElement, isValidElement, useState } from 'octane';
+
+			${provider}
+
+			function Row(props) {
+				return <span id="returned-custom-provider-row">{props.label}</span>;
+			}
+
+			function selectRows(items) {
+				return [createElement(Row, { key: 'row', label: items[0] })];
+			}
+
+			export function App(props) {
+				const [items] = useState(['initial']);
+				const [tick, setTick] = useState(0);
+				const onChildren = props.onChildren;
+				const rows = selectRows(items);
+				return (
+					<section>
+						<button id="returned-custom-provider-tick" onClick={() => setTick(tick + 1)}>
+							{tick}
+						</button>
+						<Wrapper.Provider value={onChildren}>
+							<div>{rows}</div>
+						</Wrapper.Provider>
+					</section>
+				);
+			}
+		`;
+			const client = loadCompiledFixtureSource(source, {
+				id: `returned-${shape.replaceAll(' ', '-')}-provider-descriptor.tsx`,
+				mode: 'client',
+				compileOptions: { hmr: false, dev: false },
+			});
+			const children: Array<[boolean, unknown]> = [];
+			const root = mount(client.App, {
+				onChildren: (valid: boolean, type: unknown) => children.push([valid, type]),
+			});
+			const row = root.find('#returned-custom-provider-row');
+			expect(children.at(-1)).toEqual([true, 'div']);
+			expect(row.textContent).toBe('initial');
+
+			root.click('#returned-custom-provider-tick');
+			expect(children.at(-1)).toEqual([true, 'div']);
+			expect(root.find('#returned-custom-provider-row')).toBe(row);
+			expect(row.textContent).toBe('initial');
+			root.unmount();
+		},
+	);
+
 	it.each([
 		{ shape: 'direct', shared: 'dynamic' },
 		{ shape: 'nested', shared: '[dynamic]' },


### PR DESCRIPTION
## Summary

- Reuse unchanged, compiler-proven descriptor arrays in returned JSX without changing provider children, hydration ranges, or context semantics.
- Identify real active context providers through scope ownership instead of observing user-defined properties or proxies.
- Add independent wall-A/wall-B production-browser work gates and adversarial behavioral coverage.

Refs #673

## Why

Returned JSX already cached wall B's derived descriptor array, but recreated its surrounding scoped host descriptor every render. Equal and context-only updates consequently performed 1,000 keyed survivor visits and 1,000 shallow memo comparisons even when the rows were unchanged.

## Changes

- Carry nonescaping auto-calculated array provenance through returned-JSX lowering.
- Cache the original scoped host descriptor under its actual context provider while preserving public children, SSR output, and hydration identity.
- Allocate compiler-only memo slots after shared client/server slots and inspect array eligibility only when a memo hit can skip reconciliation.
- Keep unsafe accessors, nested arrays, fragments, deferred context reads, escaped mutable arrays, custom providers, and hostile provider getters on their original paths.
- Make JSX precise-call coverage use the same unminified production-only work mode as TSRX and tighten both dialects' unchanged-wall expectations.

## Performance

| Workload | Before | After |
| --- | ---: | ---: |
| JSX wall-B equal survivor visits | 1,000 | 0 |
| JSX wall-B equal memo comparisons | 1,000 | 0 |
| JSX wall-B equal update | 0.1891 ms | 0.0010 ms |
| JSX wall-B context update | 0.8000 ms | 0.6045 ms |
| JSX wall-B changed update | 0.2580 ms | 0.2560 ms |

Equal updates are approximately 188× faster. Context updates still refresh exactly 1,000 leaves, changed updates still reconcile the changed row, and context-restamping remains zero. The eligible fixture grows by 237 gzip bytes; unrelated production bundles and the fixed 16-file codegen corpus are byte-identical.

## Validation

- [x] `pnpm sync`
- [x] `pnpm format:files:check` on all eight changed files.
- [x] `pnpm --config.enable-pre-post-scripts=false run typecheck` — complete workspace TypeScript body; unrelated optional pretypecheck disabled.
- [x] `pnpm exec vitest run --project octane --project octane-prod --silent=passed-only` — **804 files / 11,681 tests passed**.
- [x] Focused compiler, frozen-AST, source-map, universal-renderer, SSR, and hydration suites — **66 files / 1,571 tests passed**.
- [x] Returned-JSX hydration and hostile/custom-provider regressions in development and production.
- [x] JSX and TSRX production Chromium memo-wall precise-call gates, including unchanged, context-only, changed-row, and wall-A controls.
- [x] Same-policy paired minified Chromium benchmarks and exact production bundle tree-shaking comparisons.
- [x] `node benchmarks/codegen-size/run.mjs` — fixed corpus unchanged.

## Risk / follow-ups

- Admission requires a compiler-proven, nonescaping descriptor array under the currently active context provider; unknown or unsafe shapes retain existing behavior.
- Generated memo slots are client-only tail slots, preserving server/client hook-site identity.
- Additive compiler-runtime helper is tree-shaken from applications without eligible returned-JSX sites.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compiler lowering and provider child reconciliation for a gated optimization path; incorrect admission could skip updates or break context/hydration, though fallbacks and extensive behavioral gates limit blast radius.
> 
> **Overview**
> **Returned-JSX wall B** no longer rebuilds and reconciles 1000 unchanged `memo(Row)` descriptors on equal or context-only parent updates. The compiler now threads **auto-calculated renderable-array provenance** through returned-JSX lowering (setup statements only, not the return root) and, for a narrow **`<Context.Provider value={…}><host>{rows}</host></Context.Provider>`** shape, wraps the scoped provider’s `readChildren` in **`useMemo` + `compilerCacheArray`** when `rows` is a proven non-escaping calculation.
> 
> Eligibility is gated at runtime by **`compilerOwnsContextProvider`**, which checks whether the provider value is already in `CURRENT_SCOPE.$$ctxValues` without re-reading `.Provider` or user getters/proxies. Ineligible patterns (custom `Provider` components, escaped/mutated arrays, accessors, deferred `use()`, etc.) keep the old path.
> 
> **Memo-wall** docs and **`work.mjs`** now expect **zero keyed survivors and zero `shallowEqualProps`** for JSX wall-B equal/context ops (TSRX-aligned), with **upper ceilings** on wrapper `createElement` counts. JSX work builds can disable minification via **`MEMO_WALL_WORK=1`** like TSRX. A large **`auto-memo.test.ts`** block covers descriptors, hydration, context, refs, effects, and hostile providers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7871550d3f6ec0de4ae01c0e27db9a6d2a4b3d59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->