### PR TITLE
perf: extend returned-JSX provider region caching

### DIFF
--- a/.changeset/returned-jsx-provider-child-regions.md
+++ b/.changeset/returned-jsx-provider-child-regions.md
@@ -1,0 +1,6 @@
+---
+'octane': patch
+---
+
+Reuse proven stable returned-JSX component regions inside context providers while
+preserving context updates, component state, and server-rendered DOM adoption.

--- a/benchmarks/memo-wall/README.md
+++ b/benchmarks/memo-wall/README.md
@@ -8,11 +8,11 @@ gets absorbed by 1000 shallow-equal prop comparisons, a single prop change must
 re-render exactly one row, and a context bump above the wall must refresh only
 the leaf consumers without re-running any bailed body. Both Octane dialects
 exercise production `autoMemo` on wall A: TSRX can skip the entire pure `RowsA`
-region, while returned JSX preserves its descriptor boundary and skips the
-unchanged compiled keyed list inside `RowsA`. Both dialects reuse wall B's
-imported descriptor calculation and skip its unchanged renderable region while
-preserving context updates; changed inputs still exercise the value-comparing
-memo bail.
+region, while returned JSX preserves and reuses its descriptor boundary,
+skipping `RowsA` and its unchanged compiled keyed list. Both dialects reuse
+wall B's imported descriptor calculation and skip its unchanged renderable
+region while preserving context updates; changed inputs still exercise the
+value-comparing memo bail.
 
 This is the canonical home for octane's `shallowEqualProps` and
 `refreshContextConsumers` numbers — if a store-fanout suite lands later it must
@@ -78,11 +78,11 @@ how `<Row>` is put on screen:
   the compiled forBlock under host-only ancestors; the Octane, React, and
   Preact fixtures keep the identical structure so those columns stay comparable.
   The default production `autoMemo` transform caches the TSRX call to pure
-  `RowsA` by its inferred `items` capture. For returned JSX, `RowsA` still
-  enters through its normal descriptor boundary, but its dense native Array
-  `.map` uses the same whole-list and per-item guards. Custom or overridden map
-  methods, sparse arrays, and calls with additional arguments retain normal
-  JavaScript dispatch.
+  `RowsA` by its inferred `items` capture. For returned JSX, the genuine
+  Provider reuses the private `RowsA` component descriptor when its dense
+  native Array `.map` has already passed the same whole-list and per-item
+  guards. Custom or overridden map methods, sparse arrays, and calls with
+  additional arguments retain normal JavaScript dispatch.
 - **wall B — value-position**: a plain-`.ts` helper (`src/wall-b.ts`) builds
   `createElement(Row, props)` descriptors that reach the DOM through a
   `{rows}` children hole → `childSlot`'s keyed de-opt list → the **childSlot
@@ -125,12 +125,13 @@ disable automatic memoization. `work.mjs` provides the stronger, untimed gate
 after compilation using Chromium precise call coverage. For TSRX equal/context
 A it requires zero list helpers, keyed survivor visits, descriptors, shallow
 memo comparisons, and row bodies (context A additionally requires exactly 1000
-Leaf refreshes). JSX retains its normal `RowsA`/descriptor entry but likewise
-requires zero keyed survivor visits, item helpers, and memo comparisons on an
-unchanged list. Wall B requires both dialects to reuse unchanged calculations
-with zero keyed survivor visits and memo comparisons for equal/context-only
-updates; context updates still refresh exactly 1000 leaves. Returned-JSX
-wrapper descriptor counts have upper ceilings rather than exact requirements.
+Leaf refreshes). JSX likewise requires zero `RowsA` entries, keyed survivor
+visits, item helpers, and memo comparisons on an unchanged list, retaining at
+most one wrapper descriptor (plus the 1000 refreshed Leaves for context A).
+Wall B requires both dialects to reuse unchanged calculations with zero keyed
+survivor visits and memo comparisons for equal/context-only updates; context
+updates still refresh exactly 1000 leaves. Returned-JSX wrapper descriptor
+counts have upper ceilings rather than exact requirements.
 Mount and one-change A/B also carry exact compiled-work gates.
 
 The React Row/Inner/Leaf counters likewise make those component bodies impure,
@@ -206,9 +207,10 @@ per-operation counts.
   successful prop bails around the single miss. This is the intended "one
   change amid a wall" workload, not a pure single-row-render cost.
 - The uncompiled React control's `parent_rerender_equal` recreates or reconciles
-  1000 row descriptions. Both Octane dialects skip wall A's unchanged keyed list; JSX
-  retains its descriptor-wrapper overhead. Unchanged wall-B helper output can
-  also be cached, while changed inputs exercise descriptor reconciliation.
+  1000 row descriptions. Both Octane dialects skip wall A's unchanged `RowsA`
+  region; JSX retains one outer descriptor wrapper. Unchanged wall-B helper
+  output can also be cached, while changed inputs exercise descriptor
+  reconciliation.
   React Compiler caches both the `.map` and imported helper call. The
   cross-framework ratio is the honest end-to-end cost of each production
   compiler, not an instruction-level apples-to-apples comparison.

--- a/benchmarks/memo-wall/work.mjs
+++ b/benchmarks/memo-wall/work.mjs
@@ -152,9 +152,9 @@ const OPS = [
 // visit the survivors but run exactly one item/row/inner/leaf body.
 const JSX_EXPECTATIONS = {
 	mount: { createElement: 11007 },
-	equal_A: { RowsA: 1, createElement: 3 },
+	equal_A: { RowsA: 0, createElement: 1 },
 	one_change_A: { createElement: 8 },
-	context_A: { RowsA: 1, createElement: ROWS + 3 },
+	context_A: { RowsA: 0, createElement: ROWS + 1 },
 	one_change_B: { createElement: ROWS + 6 },
 	context_B: {
 		updateSurvivor: 0,
@@ -174,6 +174,8 @@ const JSX_EXPECTATIONS = {
 // These ceilings allow equivalent returned-JSX output to allocate fewer while
 // keeping row/context execution and keyed-list visits exact.
 const JSX_MAXIMUMS = {
+	equal_A: { createElement: 1 },
+	context_A: { createElement: ROWS + 1 },
 	context_B: { createElement: ROWS + 1 },
 	equal_B_control: { createElement: 1 },
 };

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -4483,6 +4483,177 @@ function collectPrivateUnescapedComponents(body, ctx) {
 	return candidates;
 }
 
+function onlyMeaningfulJsxChild(children) {
+	let result = null;
+	for (const child of children || []) {
+		if (child?.type === 'JSXText' || child?.type === 'Text') {
+			const text = child.value ?? child.raw;
+			if (typeof text === 'string' && /^\s*$/.test(text) && /[\n\r]/.test(text)) continue;
+		}
+		if (result !== null) return null;
+		result = child;
+	}
+	return result;
+}
+
+// A Provider may retain one unchanged component descriptor only when that
+// private component does nothing except return a keyed native-map host. Every
+// reference to its FunctionDeclaration must be one of these exact JSX children:
+// escaping it would expose live defaultProps, identity, or an observable call.
+function collectPrivateMappedProviderComponents(body, ctx) {
+	const candidates = new Map();
+	for (const declaration of body) {
+		if (
+			declaration.type !== 'FunctionDeclaration' ||
+			declaration.id?.type !== 'Identifier' ||
+			ctx.componentInfo.get(declaration.id.name)?.returnJsx !== true ||
+			!ctx.moduleFunctionDeclarations.has(declaration.id.name) ||
+			declaration.params?.length !== 1 ||
+			declaration.params[0]?.type !== 'Identifier' ||
+			declaration.body.body?.length !== 1
+		) {
+			continue;
+		}
+		const statement = declaration.body.body[0];
+		const host = statement.type === 'ReturnStatement' ? statement.argument : null;
+		if ((host?.type !== 'Element' && host?.type !== 'JSXElement') || isComponentTag(host)) {
+			continue;
+		}
+		let hostSafe = true;
+		for (const attribute of host.attributes || host.openingElement?.attributes || []) {
+			if (
+				(attribute.type !== 'Attribute' && attribute.type !== 'JSXAttribute') ||
+				['key', 'ref', 'children', 'dangerouslySetInnerHTML'].includes(jsxAttrRawName(attribute)) ||
+				(attribute.value != null &&
+					attribute.value.type !== 'Literal' &&
+					attribute.value.type !== 'StringLiteral')
+			) {
+				hostSafe = false;
+				break;
+			}
+		}
+		if (!hostSafe) continue;
+		const child = onlyMeaningfulJsxChild(host.children);
+		const map = child?.type === 'JSXExpressionContainer' ? unwrapTsExpr(child.expression) : null;
+		const method = map?.callee;
+		const receiver = method?.object;
+		const callback = map?.arguments?.[0];
+		if (
+			map?.type !== 'CallExpression' ||
+			map.optional ||
+			map.arguments.length !== 1 ||
+			method?.type !== 'MemberExpression' ||
+			method.computed ||
+			method.optional ||
+			method.property?.name !== 'map' ||
+			receiver?.type !== 'MemberExpression' ||
+			receiver.computed ||
+			receiver.optional ||
+			receiver.object?.type !== 'Identifier' ||
+			receiver.object.name !== declaration.params[0].name ||
+			receiver.property?.type !== 'Identifier' ||
+			['key', 'ref', 'children', 'current', '__proto__'].includes(receiver.property.name) ||
+			callback?.type !== 'ArrowFunctionExpression' ||
+			callback.async ||
+			callback.params.length !== 1 ||
+			callback.params[0]?.type !== 'Identifier' ||
+			(callback.body?.type !== 'Element' && callback.body?.type !== 'JSXElement') ||
+			mapCallbackCapturesLexicalReceiver(callback.body) ||
+			containsRenderCall([callback.body], ctx) ||
+			containsAutoMemoUnsafeStructure([callback.body]) ||
+			containsImportedMemberRead(callback.body, ctx.importedNames)
+		) {
+			continue;
+		}
+		if (isComponentTag(callback.body)) {
+			const name = tagBindingName(callback.body);
+			if (name === null || (!ctx.importedNames.has(name) && !ctx.defaultMemoBindings.has(name))) {
+				continue;
+			}
+		}
+		const attributes = callback.body.attributes || callback.body.openingElement?.attributes || [];
+		if (!attributes.some((attribute) => jsxAttrRawName(attribute) === 'key')) continue;
+
+		const captures = new Set();
+		let safe = true;
+		for (const name of collectFreeIdentifiers(callback.body, new Set([callback.params[0].name]))) {
+			if (ctx.importNamespaceNames.has(name) || ctx._octaneBoundaryNames.has(name)) {
+				safe = false;
+				break;
+			}
+			if (ctx.importedNames.has(name)) {
+				captures.add(name);
+			} else if (!ctx.defaultMemoBindings.has(name) && !ctx.moduleFunctionDeclarations.has(name)) {
+				safe = false;
+				break;
+			}
+		}
+		if (!safe) continue;
+		candidates.set(declaration.id.name, {
+			prop: receiver.property.name,
+			captures: [...captures].sort(),
+			witnesses: [...collectImportedComponentReferences(callback.body, ctx.importedNames)].sort(),
+			calls: new Set(),
+		});
+	}
+	if (candidates.size === 0) return candidates;
+
+	const allowed = new Set();
+	const seen = new WeakSet();
+	(function walk(node) {
+		if (node === null || typeof node !== 'object' || seen.has(node)) return;
+		seen.add(node);
+		if (Array.isArray(node)) {
+			for (const child of node) walk(child);
+			return;
+		}
+		if (node.type === 'Element' || node.type === 'JSXElement') {
+			const name = node.openingElement?.name || node.id;
+			if (
+				(name?.type === 'MemberExpression' || name?.type === 'JSXMemberExpression') &&
+				name.property?.name === 'Provider'
+			) {
+				const child = onlyMeaningfulJsxChild(node.children);
+				const candidate =
+					child?.type === 'Element' || child?.type === 'JSXElement'
+						? candidates.get(tagBindingName(child))
+						: undefined;
+				const attributes = child?.attributes || child?.openingElement?.attributes || [];
+				const value = attributes[0]?.value;
+				if (
+					candidate !== undefined &&
+					attributes.length === 1 &&
+					(attributes[0].type === 'Attribute' || attributes[0].type === 'JSXAttribute') &&
+					jsxAttrRawName(attributes[0]) === candidate.prop &&
+					value?.type === 'JSXExpressionContainer' &&
+					unwrapTsExpr(value.expression)?.type === 'Identifier' &&
+					(child.children?.length ?? 0) === 0
+				) {
+					allowed.add(child);
+					candidate.calls.add(child);
+				}
+			}
+		}
+		for (const key in node) {
+			if (AST_WALK_SKIP_KEYS.has(key)) continue;
+			walk(node[key]);
+		}
+	})(body);
+
+	const escaped = collectFreeIdentifiers(body, [], allowed);
+	for (const [name, candidate] of candidates) {
+		const declaration = ctx.moduleFunctionDeclarations.get(name);
+		if (
+			candidate.calls.size === 0 ||
+			escaped.has(name) ||
+			collectFreeIdentifiers(declaration.body, [], allowed).has(name)
+		) {
+			candidates.delete(name);
+		}
+	}
+	return candidates;
+}
+
 // Conservative semantic boundary for compiler-owned component-region memoization.
 // The cached region assumes React Compiler's pure-render / immutable-snapshot
 // contract, but still fails closed for constructs whose commit or retry behavior
@@ -7916,7 +8087,10 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 			}
 		}
 	}
-	if (ctx.autoMemo) classifyStableHookfulChildCalls(ast.body, ctx);
+	if (ctx.autoMemo) {
+		classifyStableHookfulChildCalls(ast.body, ctx);
+		ctx.privateMappedProviderComponents = collectPrivateMappedProviderComponents(ast.body, ctx);
+	}
 	// Single-root output is transitive across same-module `@if` arms (see
 	// collectSingleRootIfDeps): flip false → true until stable so declaration
 	// order and recursion through a proven base case don't matter. Pessimistic —
@@ -16693,19 +16867,17 @@ function jsxValueChildrenNeedRenderScope(node, descendantElementsOwnChildren = f
 }
 
 // A returned host preserves nested component children as inspectable
-// descriptors. An actual Octane Context can reuse its static host descriptor
-// while a compiler-proven plain descriptor array stays unchanged; the existing
-// implicit element bailout then skips its list without changing the children
-// representation or hydration ranges. Admit only one ordinary `.Provider`, its
-// `value`, and one static host whose sole child is the exact non-escaping
-// calculation Identifier.
+// descriptors. An actual Octane Context can reuse either its static host over
+// one proven descriptor array, or one private mapped component over a receiver
+// already classified native. Both keep the original descriptor ownership and
+// hydration ranges; the component proof additionally rejects every escape that
+// could expose live defaultProps or the function's observable call identity.
 function autoMemoReturnedProviderChild(node, nameNode, ctx) {
 	if (
 		!ctx.autoMemo ||
 		ctx._universalRuntimeUnit != null ||
 		ctx._foldCtx?.immediateRenderedOutput !== true ||
 		!Array.isArray(ctx._foldCtx.compInlinedSubs) ||
-		ctx.currentAutoCalculatedRenderableRefs === null ||
 		(nameNode?.type !== 'MemberExpression' && nameNode?.type !== 'JSXMemberExpression') ||
 		(nameNode.object?.type !== 'Identifier' && nameNode.object?.type !== 'JSXIdentifier') ||
 		nameNode.property?.name !== 'Provider'
@@ -16733,24 +16905,48 @@ function autoMemoReturnedProviderChild(node, nameNode, ctx) {
 		return null;
 	}
 
-	const onlyMeaningfulChild = (children) => {
-		let result = null;
-		for (const child of children || []) {
-			if (child?.type === 'JSXText' || child?.type === 'Text') {
-				const text = child.value ?? child.raw;
-				if (typeof text === 'string' && /^\s*$/.test(text) && /[\n\r]/.test(text)) {
-					continue;
-				}
-			}
-			if (result !== null) return null;
-			result = child;
-		}
-		return result;
-	};
-	const host = onlyMeaningfulChild(node.children);
-	if ((host?.type !== 'Element' && host?.type !== 'JSXElement') || isComponentTag(host)) {
+	const host = onlyMeaningfulJsxChild(node.children);
+	if (host?.type !== 'Element' && host?.type !== 'JSXElement') {
 		return null;
 	}
+	if (isComponentTag(host)) {
+		const name = tagBindingName(host);
+		const candidate = ctx.privateMappedProviderComponents?.get(name);
+		if (candidate === undefined || ctx.currentComponentLocals?.has(name)) {
+			return null;
+		}
+		let provenCall = candidate.calls.has(host);
+		if (!provenCall && typeof host.start === 'number' && typeof host.end === 'number') {
+			for (const call of candidate.calls) {
+				if (call.start === host.start && call.end === host.end) {
+					provenCall = true;
+					break;
+				}
+			}
+		}
+		if (!provenCall) return null;
+		const attributes = host.attributes || host.openingElement?.attributes || [];
+		const items = unwrapTsExpr(attributes[0]?.value?.expression);
+		if (
+			items?.type !== 'Identifier' ||
+			!ctx.currentComponentLocals?.has(items.name) ||
+			ctx.currentAutoMemoLocalHazards?.has(items.name)
+		) {
+			return null;
+		}
+		for (const capture of candidate.captures) {
+			if (ctx.currentComponentLocals?.has(capture)) return null;
+		}
+		return {
+			host,
+			contextName: nameNode.object.name,
+			rows: items,
+			component: name,
+			captures: candidate.captures,
+			witnesses: candidate.witnesses,
+		};
+	}
+	if (ctx.currentAutoCalculatedRenderableRefs === null) return null;
 	for (const attribute of host.attributes || host.openingElement?.attributes || []) {
 		if (attribute.type !== 'Attribute' && attribute.type !== 'JSXAttribute') return null;
 		const name = jsxAttrRawName(attribute);
@@ -16770,7 +16966,7 @@ function autoMemoReturnedProviderChild(node, nameNode, ctx) {
 			return null;
 		}
 	}
-	const child = onlyMeaningfulChild(host.children);
+	const child = onlyMeaningfulJsxChild(host.children);
 	if (child?.type !== 'JSXExpressionContainer' || child.expression?.type !== 'Identifier') {
 		return null;
 	}
@@ -16902,8 +17098,8 @@ function jsxElementToCreateElement(node, ctx, eagerRoot = false) {
 		let childrenValue = loweredChildren[0];
 		let memoizedChildrenBody = null;
 		if (autoMemoProviderChild !== null && loweredChildren.length === 1) {
-			const { host, contextName, rows } = autoMemoProviderChild;
-			ctx.runtimeNeeded.add('compilerCacheArray');
+			const { host, contextName, rows, component, captures, witnesses } = autoMemoProviderChild;
+			if (component === undefined) ctx.runtimeNeeded.add('compilerCacheArray');
 			// `.Provider` is a public property and can belong to any component.
 			// Ask the runtime whether this exact value is provided by the CURRENT
 			// scope. Its identity-map lookup never re-reads `.Provider`, invokes
@@ -16936,22 +17132,30 @@ function jsxElementToCreateElement(node, ctx, eagerRoot = false) {
 						[],
 						b.sequence([b.assignment('=', b.id(freshName), b.literal(true)), childrenValue]),
 					),
-					b.array([rows]),
+					b.array([rows, ...(captures ?? []).map((name) => inheritOriginLoc(b.id(name), host))]),
 					b.id(slot),
 				),
 				host,
 			);
+			let reusable =
+				component === undefined
+					? b.call('_$compilerCacheArray', rows, rows)
+					: b.call(
+							requireRuntimeForContext(ctx, 'compilerCacheMappedArray'),
+							rows,
+							inheritOriginLoc(b.id(component), host),
+						);
+			if (witnesses?.length) reusable = b.logical('&&', reusable, witnessOkChain(witnesses));
 			// A fresh descriptor must reconcile regardless of array contents.
 			// Inspect dense/accessor/scoped eligibility only when the memo HIT
-			// could actually skip reconciliation, just like compilerCacheArray's
-			// ordinary previous-value path. This keeps mount and changed inputs
-			// free of an extra linear scan.
+			// could actually skip reconciliation. Mapped children reuse their
+			// existing native-map classification instead of rescanning every row.
 			const cacheable = b.logical(
 				'&&',
 				genuineContext,
 				b.sequence([
 					b.assignment('=', b.id(childName), memoizedDescriptor),
-					b.logical('||', b.id(freshName), b.call('_$compilerCacheArray', rows, rows)),
+					b.logical('||', b.id(freshName), reusable),
 				]),
 			);
 			memoizedChildrenBody = inheritOriginLoc(

--- a/packages/octane/src/index.ts
+++ b/packages/octane/src/index.ts
@@ -201,6 +201,7 @@ export {
 	componentSlotVoid,
 	componentSlotLite,
 	compilerCacheArray,
+	compilerCacheMappedArray,
 	compilerCacheContext,
 	compilerOwnsContextProvider,
 	markSingleRoot,

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -18446,6 +18446,40 @@ export function compilerCacheArray(value: unknown, previous: unknown): boolean {
 	return renderable;
 }
 
+/**
+ * Reuse only an immutable array snapshot already proven safe by native mapSlot.
+ *
+ * Probe the private WeakMap first: a custom receiver or observable map getter
+ * that never passed the native path must not acquire new proxy traps or getter
+ * reads merely because its parent region is eligible. Recheck the constant-size
+ * intrinsic/override surface without invoking those getters. Decline own or
+ * inherited default props so their public descriptor read stays observable;
+ * indexed stability follows the existing immutable-snapshot contract.
+ * @internal
+ */
+export function compilerCacheMappedArray(value: unknown, component: unknown): boolean {
+	const cached = NATIVE_ARRAY_ACCESSORS.get(value as object);
+	if (
+		cached === undefined ||
+		typeof component !== 'function' ||
+		'defaultProps' in component ||
+		cached.accessor ||
+		cached.renderable !== undefined ||
+		cached.length !== (value as any[]).length
+	) {
+		return false;
+	}
+
+	return (
+		Object.getPrototypeOf(value) === Array.prototype &&
+		!hasOwnProp.call(value, 'map') &&
+		!hasOwnProp.call(value, 'constructor') &&
+		Object.getOwnPropertyDescriptor(Array.prototype, 'map')?.value === NATIVE_ARRAY_MAP &&
+		Object.getOwnPropertyDescriptor(Array.prototype, 'constructor')?.value === Array &&
+		Object.getOwnPropertyDescriptor(Array, Symbol.species)?.get === NATIVE_ARRAY_SPECIES_GETTER
+	);
+}
+
 /** Shared compiler ABI: native-array eligibility query plus stable keyed map dispatch. */
 export function mapSlot(
 	scopeOrItems: any,

--- a/packages/octane/tests/auto-memo.test.ts
+++ b/packages/octane/tests/auto-memo.test.ts
@@ -124,6 +124,47 @@ function loadMappedComponentHydrationComponents() {
 	};
 }
 
+function loadReturnedProviderComponentMapFixture() {
+	const source = `
+		import { createContext, memo, useState } from 'octane';
+
+		const Theme = createContext(null);
+
+		function RowImpl(props) {
+			return <span className="returned-provider-map-row">{props.label}</span>;
+		}
+		const Row = memo(RowImpl);
+
+		function Rows(props) {
+			return (
+				<div id="returned-provider-map-rows">
+					{props.items.map((item) => <Row key={item.id} label={item.label} />)}
+				</div>
+			);
+		}
+
+		export function App(props) {
+			const [tick, setTick] = useState(0);
+			const items = props.items;
+			return (
+				<section>
+					<button id="returned-provider-map-update" onClick={() => setTick(tick + 1)}>
+						{tick}
+					</button>
+					<Theme.Provider value={null}>
+						<Rows items={items} />
+					</Theme.Provider>
+				</section>
+			);
+		}
+	`;
+	return loadCompiledFixtureSource(source, {
+		id: 'returned-provider-component-map.tsx',
+		mode: 'client',
+		compileOptions: { hmr: false, dev: false },
+	});
+}
+
 describe('compiler-owned component-region memoization', () => {
 	it('preserves an independently updating pure hookful child under its hookful parent', () => {
 		const source = `
@@ -2432,6 +2473,642 @@ describe('compiler-owned component-region memoization', () => {
 		expect(root.find('.own-1')).toBe(button);
 		expect(button.textContent).toBe('t0:stable:0:updated:1');
 		root.unmount();
+	});
+
+	it('preserves returned-JSX provider component rows, context, state, keys, refs, and effects', () => {
+		const source = `
+			import { createContext, memo, useContext, useEffect, useState } from 'octane';
+
+			const Theme = createContext('initial');
+
+			function RowImpl(props) {
+				const theme = useContext(Theme);
+				const [own, setOwn] = useState(0);
+				useEffect(() => {
+					props.onEffect('mount:' + props.id);
+					return () => props.onEffect('cleanup:' + props.id);
+				}, [props.id, props.onEffect]);
+				return (
+					<button
+						className={'provider-component-row-' + props.id}
+						ref={props.onRef}
+						onClick={() => setOwn(own + 1)}
+					>
+						{theme + ':' + props.label + ':' + own}
+					</button>
+				);
+			}
+			const Row = memo(RowImpl);
+
+			function Rows(props) {
+				return (
+					<div id="provider-component-rows">
+						{props.items.map((item) => (
+							<Row
+								key={item.id}
+								id={item.id}
+								label={item.label}
+								onEffect={item.onEffect}
+								onRef={item.onRef}
+							/>
+						))}
+					</div>
+				);
+			}
+
+			export function App(props) {
+				const [items, setItems] = useState(props.items);
+				const [theme, setTheme] = useState('initial');
+				const [tick, setTick] = useState(0);
+				return (
+					<section>
+						<button id="provider-component-tick" onClick={() => setTick(tick + 1)}>{tick}</button>
+						<button id="provider-component-theme" onClick={() => setTheme('updated')}>theme</button>
+						<button
+							id="provider-component-change"
+							onClick={() => setItems(items.map((item) => item.id === 1
+								? { ...item, label: 'changed' }
+								: item))}
+						>change</button>
+						<button id="provider-component-reorder" onClick={() => setItems(items.toReversed())}>
+							reorder
+						</button>
+						<Theme.Provider value={theme}>
+							<Rows items={items} />
+						</Theme.Provider>
+					</section>
+				);
+			}
+		`;
+		const client = loadCompiledFixtureSource(source, {
+			id: 'returned-provider-component-rows.tsx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: false },
+		});
+		const effects: string[] = [];
+		const attached: Element[] = [];
+		const detached: Element[] = [];
+		const onEffect = (event: string) => effects.push(event);
+		const onRef = (element: Element | null) => {
+			if (element !== null) {
+				attached.push(element);
+				return () => detached.push(element);
+			}
+		};
+		const items = [
+			{ id: 1, label: 'first', onEffect, onRef },
+			{ id: 2, label: 'second', onEffect, onRef },
+		];
+		const root = mount(client.App, { items });
+		flushEffects();
+		const first = root.find('.provider-component-row-1');
+		const second = root.find('.provider-component-row-2');
+		expect(attached).toEqual([first, second]);
+		expect(effects).toEqual(['mount:1', 'mount:2']);
+
+		root.click('.provider-component-row-1');
+		expect(first.textContent).toBe('initial:first:1');
+		root.click('#provider-component-tick');
+		expect(root.findAll('#provider-component-rows > button')).toEqual([first, second]);
+		expect(first.textContent).toBe('initial:first:1');
+
+		root.click('#provider-component-theme');
+		expect(first.textContent).toBe('updated:first:1');
+		expect(second.textContent).toBe('updated:second:0');
+		root.click('#provider-component-change');
+		expect(root.findAll('#provider-component-rows > button')).toEqual([first, second]);
+		expect(first.textContent).toBe('updated:changed:1');
+		root.click('#provider-component-reorder');
+		expect(root.findAll('#provider-component-rows > button')).toEqual([second, first]);
+		expect(first.textContent).toBe('updated:changed:1');
+		expect(attached).toEqual([first, second]);
+		expect(detached).toEqual([]);
+		flushEffects();
+		expect(effects).toEqual(['mount:1', 'mount:2']);
+
+		root.unmount();
+		flushEffects();
+		expect(detached).toEqual(expect.arrayContaining([first, second]));
+		expect(detached).toHaveLength(2);
+		expect(effects.slice(2).toSorted()).toEqual(['cleanup:1', 'cleanup:2']);
+	});
+
+	it('reruns effects in unmemoized returned-JSX provider component rows', () => {
+		const source = `
+			import { createContext, useEffect, useState } from 'octane';
+
+			const Theme = createContext(null);
+
+			function Row(props) {
+				useEffect(() => {
+					props.onEffect('effect:' + props.label);
+					return () => props.onEffect('cleanup:' + props.label);
+				}, null);
+				return <span id="provider-component-plain-row">{props.label}</span>;
+			}
+
+			function Rows(props) {
+				return (
+					<div id="provider-component-plain-rows">
+						{props.items.map((item) => (
+							<Row key={item.id} label={item.label} onEffect={item.onEffect} />
+						))}
+					</div>
+				);
+			}
+
+			export function App(props) {
+				const [tick, setTick] = useState(0);
+				const items = props.items;
+				return (
+					<section>
+						<button id="provider-component-plain-update" onClick={() => setTick(tick + 1)}>
+							{tick}
+						</button>
+						<Theme.Provider value={null}>
+							<Rows items={items} />
+						</Theme.Provider>
+					</section>
+				);
+			}
+		`;
+		const client = loadCompiledFixtureSource(source, {
+			id: 'returned-provider-component-plain-row-effect.tsx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: false },
+		});
+		const effects: string[] = [];
+		const root = mount(client.App, {
+			items: [{ id: 1, label: 'row', onEffect: (event: string) => effects.push(event) }],
+		});
+		flushEffects();
+		const row = root.find('#provider-component-plain-row');
+		expect(effects).toEqual(['effect:row']);
+
+		effects.length = 0;
+		root.click('#provider-component-plain-update');
+		flushEffects();
+		expect(root.find('#provider-component-plain-row')).toBe(row);
+		expect(effects).toEqual(['cleanup:row', 'effect:row']);
+		root.unmount();
+	});
+
+	it('preserves observable returned-JSX provider component map accessors and receivers', () => {
+		const client = loadReturnedProviderComponentMapFixture();
+		const events: string[] = [];
+		let label = 'initial';
+		const items = [{ id: 1, label: 'ignored' }];
+		Object.defineProperty(items, 'map', {
+			configurable: true,
+			get() {
+				events.push('get:map');
+				return function <Result>(
+					this: typeof items,
+					callback: (item: (typeof items)[number], index: number, array: typeof items) => Result,
+				): Result[] {
+					if (this !== items) throw new Error('custom map lost its receiver');
+					events.push('call:map');
+					return [callback({ id: 1, label }, 0, items)];
+				};
+			},
+		});
+		const root = mount(client.App, { items });
+		const row = root.find('.returned-provider-map-row');
+		expect(events).toEqual(['get:map', 'call:map']);
+		expect(row.textContent).toBe('initial');
+
+		events.length = 0;
+		label = 'updated';
+		root.click('#returned-provider-map-update');
+		expect(events).toEqual(['get:map', 'call:map']);
+		expect(root.find('.returned-provider-map-row')).toBe(row);
+		expect(row.textContent).toBe('updated');
+		root.unmount();
+	});
+
+	it('observes returned-JSX provider component map overrides installed after mounting', () => {
+		const client = loadReturnedProviderComponentMapFixture();
+		const items = [{ id: 1, label: 'native' }];
+		const originalMap = Array.prototype.map;
+		const root = mount(client.App, { items });
+		const row = root.find('.returned-provider-map-row');
+		expect(row.textContent).toBe('native');
+
+		try {
+			Object.defineProperty(items, 'map', {
+				configurable: true,
+				value<Result>(
+					this: typeof items,
+					callback: (item: (typeof items)[number], index: number, array: typeof items) => Result,
+				): Result[] {
+					if (this !== items) throw new Error('installed map lost its receiver');
+					return [callback({ id: 1, label: 'own override' }, 0, items)];
+				},
+			});
+			root.click('#returned-provider-map-update');
+			expect(root.find('.returned-provider-map-row')).toBe(row);
+			expect(row.textContent).toBe('own override');
+
+			delete (items as { map?: unknown }).map;
+			Array.prototype.map = function <Item, Result>(
+				this: Item[],
+				callback: (item: Item, index: number, array: Item[]) => Result,
+				thisArg?: unknown,
+			): Result[] {
+				if ((this as unknown) === items) {
+					return originalMap.call(
+						[{ id: 1, label: 'prototype override' }],
+						callback,
+						thisArg,
+					) as Result[];
+				}
+				return originalMap.call(this, callback, thisArg) as Result[];
+			};
+			root.click('#returned-provider-map-update');
+			expect(root.find('.returned-provider-map-row')).toBe(row);
+			expect(row.textContent).toBe('prototype override');
+
+			Array.prototype.map = originalMap;
+			root.click('#returned-provider-map-update');
+			expect(root.find('.returned-provider-map-row')).toBe(row);
+			expect(row.textContent).toBe('native');
+		} finally {
+			Array.prototype.map = originalMap;
+			delete (items as { map?: unknown }).map;
+			root.unmount();
+		}
+	});
+
+	it('preserves returned-JSX provider component proxy-backed map behavior', () => {
+		const client = loadReturnedProviderComponentMapFixture();
+		const events: string[] = [];
+		let label = 'initial';
+		const target = [{ id: 1, label: 'ignored' }];
+		const items = new Proxy(target, {
+			get(current, property, receiver) {
+				if (property === 'map') {
+					events.push('get:map');
+					return function <Result>(
+						this: typeof target,
+						callback: (
+							item: (typeof target)[number],
+							index: number,
+							array: typeof target,
+						) => Result,
+					): Result[] {
+						if (this !== items) throw new Error('proxy map lost its receiver');
+						events.push('call:map');
+						return [callback({ id: 1, label }, 0, items)];
+					};
+				}
+				return Reflect.get(current, property, receiver);
+			},
+			getPrototypeOf(current) {
+				events.push('get:prototype');
+				return Reflect.getPrototypeOf(current);
+			},
+			getOwnPropertyDescriptor(current, property) {
+				if (property === 'map') events.push('get:map descriptor');
+				return Reflect.getOwnPropertyDescriptor(current, property);
+			},
+		});
+		const root = mount(client.App, { items });
+		const row = root.find('.returned-provider-map-row');
+		expect(events).toEqual(['get:map', 'get:prototype', 'call:map']);
+		expect(row.textContent).toBe('initial');
+
+		events.length = 0;
+		label = 'updated';
+		root.click('#returned-provider-map-update');
+		expect(events).toEqual(['get:map', 'get:prototype', 'call:map']);
+		expect(root.find('.returned-provider-map-row')).toBe(row);
+		expect(row.textContent).toBe('updated');
+		root.unmount();
+	});
+
+	it.each(['sparse indexed accessor', 'custom array species'] as const)(
+		'preserves returned-JSX provider component rows with a %s',
+		(shape) => {
+			const client = loadReturnedProviderComponentMapFixture();
+			const events: string[] = [];
+			let current = { id: 1, label: 'initial' };
+			const items: Array<typeof current> = [];
+
+			if (shape === 'sparse indexed accessor') {
+				items.length = 2;
+				Object.defineProperty(items, '1', {
+					configurable: true,
+					enumerable: true,
+					get() {
+						events.push('get:item');
+						return current;
+					},
+				});
+			} else {
+				items.push(current);
+				Object.defineProperty(items, 'constructor', {
+					configurable: true,
+					value: {
+						[Symbol.species]: function (length: number) {
+							events.push('species');
+							return new Array(length);
+						},
+					},
+				});
+			}
+
+			const expected = shape === 'sparse indexed accessor' ? ['get:item'] : ['species'];
+			const root = mount(client.App, { items });
+			const row = root.find('.returned-provider-map-row');
+			expect(events).toEqual(expected);
+			expect(row.textContent).toBe('initial');
+
+			events.length = 0;
+			current = { id: 1, label: 'updated' };
+			root.click('#returned-provider-map-update');
+			expect(events).toEqual(expected);
+			expect(root.find('.returned-provider-map-row')).toBe(row);
+			expect(row.textContent).toBe(shape === 'sparse indexed accessor' ? 'updated' : 'initial');
+			root.unmount();
+		},
+	);
+
+	it('observes inherited returned-JSX provider component defaultProps accessors', () => {
+		const client = loadReturnedProviderComponentMapFixture();
+		const items = [{ id: 1, label: 'initial' }];
+		const events: string[] = [];
+		const root = mount(client.App, { items });
+		const row = root.find('.returned-provider-map-row');
+		const original = Object.getOwnPropertyDescriptor(Function.prototype, 'defaultProps');
+
+		try {
+			Object.defineProperty(Function.prototype, 'defaultProps', {
+				configurable: true,
+				get(this: Function) {
+					if (this.name === 'Rows') events.push('get:defaultProps');
+					return undefined;
+				},
+			});
+
+			root.click('#returned-provider-map-update');
+			expect(events).toEqual(['get:defaultProps']);
+			expect(root.find('.returned-provider-map-row')).toBe(row);
+			expect(row.textContent).toBe('initial');
+
+			events.length = 0;
+			root.update(client.App, { items: [{ id: 1, label: 'updated' }] });
+			expect(events).toEqual(['get:defaultProps']);
+			expect(root.find('.returned-provider-map-row')).toBe(row);
+			expect(row.textContent).toBe('updated');
+		} finally {
+			if (original === undefined) {
+				delete (Function.prototype as { defaultProps?: unknown }).defaultProps;
+			} else {
+				Object.defineProperty(Function.prototype, 'defaultProps', original);
+			}
+			root.unmount();
+		}
+	});
+
+	it('keeps returned-JSX provider component defaultProps accessors observable', () => {
+		const source = `
+			import { createContext, memo, useState } from 'octane';
+
+			const Theme = createContext(null);
+			let current = 'initial';
+			export function updateDefault() {
+				current = 'updated';
+			}
+
+			function RowImpl(props) {
+				return <span id="provider-component-default-row">{props.label}</span>;
+			}
+			const Row = memo(RowImpl);
+
+			function Rows(props) {
+				return (
+					<div id="provider-component-default-rows" data-default={props.suffix}>
+						{props.items.map((item) => <Row key={item.id} label={item.label} />)}
+					</div>
+				);
+			}
+			Object.defineProperty(Rows, 'defaultProps', {
+				configurable: true,
+				get() {
+					return { suffix: current };
+				},
+			});
+
+			export function App(props) {
+				const [tick, setTick] = useState(0);
+				const items = props.items;
+				return (
+					<section>
+						<button id="provider-component-default-update" onClick={() => setTick(tick + 1)}>
+							{tick}
+						</button>
+						<Theme.Provider value={null}>
+							<Rows items={items} />
+						</Theme.Provider>
+					</section>
+				);
+			}
+		`;
+		const client = loadCompiledFixtureSource(source, {
+			id: 'returned-provider-component-default-props.tsx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: false },
+		});
+		const root = mount(client.App, { items: [{ id: 1, label: 'row' }] });
+		const rows = root.find('#provider-component-default-rows');
+		expect(rows.getAttribute('data-default')).toBe('initial');
+
+		client.updateDefault();
+		root.click('#provider-component-default-update');
+		expect(root.find('#provider-component-default-rows')).toBe(rows);
+		expect(rows.getAttribute('data-default')).toBe('updated');
+		root.unmount();
+	});
+
+	it.each([
+		{
+			shape: 'ordinary object',
+			wrapper: 'const Wrapper = { Provider: Fake };',
+		},
+		{
+			shape: 'throwing provider accessor',
+			wrapper: `
+				let reads = 0;
+				const Wrapper = Fake;
+				Object.defineProperty(Wrapper, 'Provider', {
+					get() {
+						if (++reads !== 1) throw new Error('Provider getter read twice');
+						return Wrapper;
+					},
+				});
+			`,
+		},
+		{
+			shape: 'throwing callable proxy',
+			wrapper: `
+				const Wrapper = new Proxy(Fake, {
+					get(target, property, receiver) {
+						if (property === 'Provider') return receiver;
+						if (property === '$$kind') throw new Error('private brand getter must stay unread');
+						return Reflect.get(target, property, receiver);
+					},
+				});
+			`,
+		},
+	])(
+		'preserves inspectable returned-JSX provider component children for a $shape',
+		({ shape, wrapper }) => {
+			const source = `
+				import { isValidElement, useState } from 'octane';
+
+				function Rows(props) {
+					return (
+						<div id="provider-component-fake-rows">
+							{props.items.map((item) => <span key={item.id}>{item.label}</span>)}
+						</div>
+					);
+				}
+
+				function Fake(props) {
+					const child = props.children;
+					props.value(isValidElement(child), child.type.name === 'Rows');
+					${shape === 'throwing provider accessor' ? 'reads = 0;' : ''}
+					return child;
+				}
+				${wrapper}
+
+				export function App(props) {
+					const [tick, setTick] = useState(0);
+					const items = props.items;
+					const onChildren = props.onChildren;
+					return (
+						<section>
+							<button id="provider-component-fake-update" onClick={() => setTick(tick + 1)}>
+								{tick}
+							</button>
+							<Wrapper.Provider value={onChildren}>
+								<Rows items={items} />
+							</Wrapper.Provider>
+						</section>
+					);
+				}
+			`;
+			const client = loadCompiledFixtureSource(source, {
+				id: `returned-provider-component-${shape.replaceAll(' ', '-')}.tsx`,
+				mode: 'client',
+				compileOptions: { hmr: false, dev: false },
+			});
+			const observations: Array<[boolean, boolean]> = [];
+			const root = mount(client.App, {
+				items: [{ id: 1, label: 'initial' }],
+				onChildren: (valid: boolean, correctType: boolean) => {
+					observations.push([valid, correctType]);
+				},
+			});
+			const rows = root.find('#provider-component-fake-rows');
+			expect(rows.textContent).toBe('initial');
+			expect(observations.at(-1)).toEqual([true, true]);
+
+			root.click('#provider-component-fake-update');
+			expect(root.find('#provider-component-fake-rows')).toBe(rows);
+			expect(observations.at(-1)).toEqual([true, true]);
+			root.unmount();
+		},
+	);
+
+	it('hydrates returned-JSX provider component rows and preserves nodes across updates', () => {
+		const source = `
+			import { createContext, memo, useContext, useState } from 'octane';
+
+			const Theme = createContext('default');
+
+			function RowImpl(props) {
+				const theme = useContext(Theme);
+				const [own, setOwn] = useState(0);
+				return (
+					<button id="provider-component-hydrated-row" onClick={() => setOwn(own + 1)}>
+						{theme + ':' + props.label + ':' + own}
+					</button>
+				);
+			}
+			const Row = memo(RowImpl);
+
+			function Rows(props) {
+				return (
+					<div id="provider-component-hydrated-rows">
+						{props.items.map((item) => <Row key={item.id} label={item.label} />)}
+					</div>
+				);
+			}
+
+			export function App(props) {
+				const [tick, setTick] = useState(0);
+				const items = props.items;
+				const theme = props.theme;
+				return (
+					<section>
+						<button id="provider-component-hydrated-update" onClick={() => setTick(tick + 1)}>
+							{tick}
+						</button>
+						<Theme.Provider value={theme}>
+							<Rows items={items} />
+						</Theme.Provider>
+					</section>
+				);
+			}
+		`;
+		const id = 'returned-provider-component-hydration.tsx';
+		const server = loadCompiledFixtureSource(source, {
+			id,
+			mode: 'server',
+			compileOptions: { hmr: false, dev: false },
+		});
+		const client = loadCompiledFixtureSource(source, {
+			id,
+			mode: 'client',
+			compileOptions: { hmr: false, dev: false },
+		});
+		const items = [{ id: 1, label: 'initial' }];
+		const { html } = ServerRuntime.renderToString(server.App, { items, theme: 'initial' });
+		const container = document.createElement('div');
+		container.innerHTML = html;
+		document.body.appendChild(container);
+		const rows = container.querySelector('#provider-component-hydrated-rows');
+		const row = container.querySelector('#provider-component-hydrated-row');
+
+		const root = hydrateRoot(container, client.App, { items, theme: 'initial' });
+		flushSync(() => {});
+		expect(container.querySelector('#provider-component-hydrated-rows')).toBe(rows);
+		expect(container.querySelector('#provider-component-hydrated-row')).toBe(row);
+		expect(row?.textContent).toBe('initial:initial:0');
+
+		flushSync(() => (row as HTMLElement).click());
+		expect(row?.textContent).toBe('initial:initial:1');
+		flushSync(() =>
+			(container.querySelector('#provider-component-hydrated-update') as HTMLElement).click(),
+		);
+		expect(container.querySelector('#provider-component-hydrated-row')).toBe(row);
+		expect(row?.textContent).toBe('initial:initial:1');
+
+		flushSync(() => root.render(client.App, { items, theme: 'updated' }));
+		expect(container.querySelector('#provider-component-hydrated-rows')).toBe(rows);
+		expect(container.querySelector('#provider-component-hydrated-row')).toBe(row);
+		expect(row?.textContent).toBe('updated:initial:1');
+		flushSync(() =>
+			root.render(client.App, {
+				items: [{ id: 1, label: 'changed' }],
+				theme: 'updated',
+			}),
+		);
+		expect(container.querySelector('#provider-component-hydrated-row')).toBe(row);
+		expect(row?.textContent).toBe('updated:changed:1');
+		root.unmount();
+		container.remove();
 	});
 
 	it('preserves returned-JSX descriptor rows, context, state, keys, refs, and effects', () => {


### PR DESCRIPTION
## Summary

- Extend returned-JSX provider-region caching from the completed wall-B descriptor-array shape to compiler-proven private mapped child components.
- Reuse the original child descriptor only when the provider owns its scope, the mapped array has already passed Octane's native-array proof, component dependencies remain stable, and mapped children have safe default memo boundaries.
- Preserve ordinary rendering for custom or overridden array methods, sparse/indexed-accessor arrays, custom species, inherited `defaultProps`, unmemoized child effects, fake providers, and server-rendered DOM adoption.
- Tighten the existing production Chromium memo-wall work gates and document the new wall-A behavior; include an `octane` patch changeset.

## Why

Merged PR #684 eliminated redundant returned-JSX wall-B reconciliation, but unchanged wall-A updates still entered their `RowsA` component and created avoidable wrapper descriptors. This follow-up removes that remaining work without changing authored benchmark fixtures or the public returned-JSX descriptor ABI.

| Production Chromium operation | `RowsA` executions | Element descriptors | Required visible work |
| --- | ---: | ---: | --- |
| Unchanged wall A | 1 → 0 | 3 → 1 | Unchanged rows and DOM |
| Context-only wall A | 1 → 0 | 1,003 → 1,001 | Exactly 1,000 updated context leaves |
| Changed wall A | 1 → 1 | 8 → 8 | Exactly one changed row, inner component, and leaf |

Paired minified production measurements improved unchanged wall A from 0.001440 ms to 0.001032 ms (~28%) and context-only wall A from 0.620 ms to 0.582 ms (~6%); mount and changed-row timings remained stable. The affected benchmark bundle increased by 125 gzip bytes. The fixed 16-file code-generation corpus and unrelated production bundles remained byte-identical.

## Changes

- Add a conservative same-module compiler proof for private single-return mapped components and retain their descriptors inside genuine provider scopes using existing tail-owned memo slots.
- Add an internal constant-time native-array reuse guard backed by the existing array-classification WeakMap; check live map/constructor/species/default-prop boundaries without invoking observable getters.
- Preserve context ownership, imported memo witnesses, and immutable parser AST/source-map behavior.
- Add public-behavior regressions for context, independent state, refs, effects, keyed updates, custom maps/proxies/species, inherited defaults, fake providers, and SSR hydration.
- Require zero wall-A wrapper executions and reduced descriptor ceilings while retaining exact changed-item, context-leaf, wall-B, mount, and TSRX controls.

## Validation

- [x] `pnpm --config.verify-deps-before-run=false format:files:check .changeset/returned-jsx-provider-child-regions.md benchmarks/memo-wall/README.md benchmarks/memo-wall/work.mjs packages/octane/src/compiler/compile.js packages/octane/src/index.ts packages/octane/src/runtime.ts packages/octane/tests/auto-memo.test.ts`
- [x] `./node_modules/.bin/vitest run --project octane --project octane-prod --silent=passed-only` — **804 files, 11,725 tests passed**.
- [x] Broad affected compiler, frozen-AST, source-map, SSR, hydration, universal, context, memo, Suspense, and transition coverage — **74 files, 1,821 tests passed**.
- [x] Both returned-JSX and TSRX production Chromium memo-wall work gates, with exact DOM, row, context, and changed-item controls.
- [x] Paired minified production timing, compiler-throughput sampling, fixed code-generation corpus, and unrelated production-bundle tree-shaking checks.
- [x] `pnpm --config.verify-deps-before-run=false --config.enable-pre-post-scripts=false run typecheck` — complete workspace, bindings, packages, website, examples, and benchmarks passed.
- [x] `pnpm --config.verify-deps-before-run=false exec vitest run packages/octane/tests/browser/suspense-hydration/suspense-hydration.test.ts --project octane-events-browser --silent=passed-only` — **11 real-Chromium hydration tests passed**.
- [x] `pnpm --config.verify-deps-before-run=false sync` — generated files and agent rules remain synchronized; no additional tracked changes.

## Risk / follow-ups

- The optimization is limited to compiler-owned private components, previously classified dense native arrays, default memo boundaries, and the existing immutable-array-snapshot contract. All other shapes retain their original descriptor/render behavior.
- The benchmark-specific compiled application gained 125 gzip bytes; unrelated static and Suspense production bundles and the fixed compiler corpus did not change.

Refs #673.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches compiler auto-memo lowering and runtime reconciliation for context providers; optimization is gated conservatively but incorrect reuse could skip updates or break observable array/component semantics.
> 
> **Overview**
> **Returned-JSX provider regions** can now cache and reuse a **private child component** that only returns a host with a keyed `props.*.map(...)` list—not just the existing static host + precomputed descriptor-array shape.
> 
> The compiler adds **`collectPrivateMappedProviderComponents`**: it proves module-local returned-JSX components used solely as `<Context.Provider><Rows items={items} /></Context.Provider>` children, with conservative checks (no escapes, safe memo boundaries, genuine provider scope). **`autoMemoReturnedProviderChild`** emits memo slots that call **`compilerCacheMappedArray`** instead of rescanning rows via **`compilerCacheArray`**, including capture/witness dependencies for imported memo components.
> 
> **`compilerCacheMappedArray`** (new runtime ABI export) reuses eligibility from the existing native-array WeakMap and declines custom maps, accessors, species, and observable **`defaultProps`** without triggering new getter reads.
> 
> **memo-wall** work gates and README now expect **zero `RowsA` executions** and fewer wrapper **`createElement`** calls on unchanged returned-JSX wall A; extensive **`auto-memo`** tests cover context, state, keys, effects, hydration, proxies, and fake providers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 674e7574d09886078272d1119e746096361eadfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->