### PR TITLE
perf: specialize mixed static and dynamic style objects

### DIFF
--- a/.changeset/mixed-static-dynamic-style-objects.md
+++ b/.changeset/mixed-static-dynamic-style-objects.md
@@ -1,0 +1,6 @@
+---
+'octane': patch
+---
+
+Specialize proven mixed inline styles so static declarations enter the template
+and only changed dynamic properties update the DOM.

--- a/benchmarks/js-framework/README-naive.md
+++ b/benchmarks/js-framework/README-naive.md
@@ -41,9 +41,10 @@ ceded to a future event-dispatch-storm suite.
   `actions` imported): the event-bundle transform only fires for
   identifier-callee arrows, so every row re-render reassigns its `$$click`
   slots.
-- **inline style objects** (value-dependent, so they can't be folded into the
-  static template): fresh object identity per render forces `setStyle`'s
-  key-walk diff.
+- **inline style objects**: the TSRX fixture combines a static declaration with
+  one changing value. Its static prefix is baked into the template and only the
+  changing property is written; the JSX twin retains the ordinary whole-object
+  diff as an unchanged control.
 - **`octane-ts` / plain createElement**: everything above plus the whole tree is
   a fresh descriptor graph per render, reconciled by the runtime de-opt path
   (`childSlot` → `reconcileDeoptNode`/`reconcileDeoptChildren` keyed matching +
@@ -72,6 +73,20 @@ TARGETS='[{"name":"octane-tsrx","url":"http://localhost:5176/","ready":"#run"},
 
 The first target is the ratio baseline, so putting the tuned fixture first
 makes every printed ratio a naive/tuned cliff number directly.
+
+The production style-work gate measures existing row creation, selection, and
+unrelated updates with Chromium precise call coverage. It verifies complete CSS
+values, selected rows, row identity, and the unchanged JSX control:
+
+```bash
+# Build the existing naive fixtures with readable production helper names.
+pnpm --filter octane-tsrx-naive-jsbench exec vite build --minify false
+pnpm --filter octane-jsx-naive-jsbench exec vite build --minify false
+pnpm --filter octane-tsrx-naive-jsbench preview &
+pnpm --filter octane-jsx-naive-jsbench preview &
+pnpm --dir benchmarks/js-framework bench:style-work
+WORK_DIALECT=jsx pnpm --dir benchmarks/js-framework bench:style-work
+```
 
 The naive fixtures also carry the keyed-reorder buttons (mirroring the tuned
 set), so `run-reorder.mjs` can drive them the same way — but the canonical

--- a/benchmarks/js-framework/octane-tsrx-naive/src/Row.tsrx
+++ b/benchmarks/js-framework/octane-tsrx-naive/src/Row.tsrx
@@ -10,9 +10,8 @@ import { actions } from './actions.js';
 //     compiled per-binding write.
 //   * member-callee handlers via the imported `actions` object — defeats the
 //     event-bundle transform, so handler slots reassign on every row re-render.
-//   * an inline style OBJECT on a cell — value-dependent (a constant object
-//     literal would be folded into the static template), so a fresh object
-//     identity per render forces the style differ to walk its keys every time.
+//   * a mixed inline style object on a cell — its fixed declaration belongs
+//     in the static template while the changing font weight updates directly.
 //
 // `onSelect`/`onRemove` are also accepted as props (the React prop contract for
 // a list row); dispatch flows through the same imported `actions` module they
@@ -30,6 +29,9 @@ export default function Row({ item, selected, onSelect, onRemove }) @{
 				<span class="glyphicon glyphicon-remove" aria-hidden="true" />
 			</a>
 		</td>
-		<td class="col-md-6" style={{ fontWeight: selected ? 'bold' : 'normal' }} />
+		<td
+			class="col-md-6"
+			style={{ fontStyle: 'normal', fontWeight: selected ? 'bold' : 'normal' }}
+		/>
 	</tr>
 }

--- a/benchmarks/js-framework/package.json
+++ b/benchmarks/js-framework/package.json
@@ -6,6 +6,7 @@
   "description": "js-framework-benchmark umbrella that drives Octane and reference framework fixtures via Playwright.",
   "scripts": {
     "bench": "node run.mjs",
+    "bench:style-work": "node style-work.mjs",
     "bench:long": "node run.mjs 16",
     "bench:reorder": "node run-reorder.mjs",
     "bench:reorder:long": "node run-reorder.mjs 16"

--- a/benchmarks/js-framework/style-work.mjs
+++ b/benchmarks/js-framework/style-work.mjs
@@ -1,0 +1,225 @@
+// Deterministic mixed-inline-style work over the existing naive row fixtures.
+// Chromium precise coverage observes production helpers without adding probes
+// to authored components or changing the compiler's optimization input.
+
+import fs from 'node:fs';
+import { chromium } from 'playwright';
+
+const DIALECT = process.env.WORK_DIALECT || 'tsrx';
+if (DIALECT !== 'tsrx' && DIALECT !== 'jsx') {
+	throw new Error(`Unsupported WORK_DIALECT ${JSON.stringify(DIALECT)}; expected "tsrx" or "jsx".`);
+}
+
+const TSRX = DIALECT === 'tsrx';
+const URL = process.env.TARGET_URL || `http://localhost:${TSRX ? 5213 : 5214}/`;
+const ROWS = 1000;
+const METRICS = [
+	'setStyle',
+	'applyStyleValue',
+	'applyStyleProperty',
+	'setStyleProperty',
+	'Row',
+	'renderBlockInner',
+];
+const OPS = [
+	{ name: 'mount_1k', setup: [], action: 'mount', writes: ROWS },
+	{ name: 'select_one', setup: ['mount'], action: 'select4', writes: 1 },
+	{ name: 'select_another', setup: ['mount', 'select4'], action: 'select5', writes: 2 },
+	{ name: 'unrelated_update', setup: ['mount'], action: 'update', writes: 0 },
+];
+
+async function invoke(page, action) {
+	await page.evaluate(async (next) => {
+		if (next === 'mount') {
+			document.getElementById('run').click();
+		} else if (next === 'update') {
+			document.getElementById('update').click();
+		} else {
+			const row = document.querySelectorAll('tbody tr')[next === 'select4' ? 4 : 5];
+			row.querySelector('td:nth-child(2) a').click();
+		}
+		if (window.__benchFlush) await window.__benchFlush();
+	}, action);
+}
+
+function countCalls(coverage) {
+	const counts = Object.fromEntries(METRICS.map((name) => [name, 0]));
+	for (const script of coverage.result) {
+		if (!script.url.includes('/assets/')) continue;
+		for (const fn of script.functions) {
+			if (Object.prototype.hasOwnProperty.call(counts, fn.functionName)) {
+				counts[fn.functionName] += fn.ranges[0]?.count ?? 0;
+			}
+		}
+	}
+	if (counts.Row !== ROWS || counts.renderBlockInner === 0) {
+		throw new Error(
+			'Missing named production call coverage; rebuild with `vite build --minify false`.',
+		);
+	}
+	return counts;
+}
+
+async function measure(browser, operation) {
+	const context = await browser.newContext();
+	const page = await context.newPage();
+	const cdp = await context.newCDPSession(page);
+	let profiling = false;
+	try {
+		await cdp.send('Profiler.enable');
+		await cdp.send('Profiler.startPreciseCoverage', {
+			callCount: true,
+			detailed: true,
+			allowTriggeredUpdates: false,
+		});
+		profiling = true;
+		await page.goto(URL, { waitUntil: 'load' });
+		await page.waitForSelector('#run', { timeout: 10_000 });
+		for (const action of operation.setup) await invoke(page, action);
+		await cdp.send('Profiler.takePreciseCoverage');
+
+		const observed = await page.evaluate(
+			async ({ action, staticStyle, expectedRows }) => {
+				const before = Array.from(document.querySelectorAll('tbody tr'));
+				const labels = before.map((row) => row.querySelector('td:nth-child(2)').textContent);
+				const writes = { styleSets: 0, styleRemoves: 0, fontWeightWrites: 0, fontStyleWrites: 0 };
+				const set = CSSStyleDeclaration.prototype.setProperty;
+				const remove = CSSStyleDeclaration.prototype.removeProperty;
+				CSSStyleDeclaration.prototype.setProperty = function (name, value, priority) {
+					writes.styleSets++;
+					if (name === 'font-weight') writes.fontWeightWrites++;
+					if (name === 'font-style') writes.fontStyleWrites++;
+					return Reflect.apply(set, this, [name, value, priority]);
+				};
+				CSSStyleDeclaration.prototype.removeProperty = function (name) {
+					writes.styleRemoves++;
+					return Reflect.apply(remove, this, [name]);
+				};
+				try {
+					if (action === 'mount') {
+						document.getElementById('run').click();
+					} else if (action === 'update') {
+						document.getElementById('update').click();
+					} else {
+						const index = action === 'select4' ? 4 : 5;
+						document.querySelectorAll('tbody tr')[index].querySelector('td:nth-child(2) a').click();
+					}
+					if (window.__benchFlush) await window.__benchFlush();
+				} finally {
+					CSSStyleDeclaration.prototype.setProperty = set;
+					CSSStyleDeclaration.prototype.removeProperty = remove;
+				}
+
+				const rows = Array.from(document.querySelectorAll('tbody tr'));
+				if (rows.length !== expectedRows) {
+					throw new Error(`${action}: expected ${expectedRows} rows, received ${rows.length}.`);
+				}
+				if (before.length !== 0 && rows.some((row, index) => row !== before[index])) {
+					throw new Error(`${action}: an untouched row lost its DOM identity.`);
+				}
+
+				for (let index = 0; index < rows.length; index++) {
+					const row = rows[index];
+					const cell = row.querySelector('td:last-child');
+					const selected = row.classList.contains('danger');
+					if (cell.style.fontWeight !== (selected ? 'bold' : 'normal')) {
+						throw new Error(`${action}: row ${index} rendered the wrong font weight.`);
+					}
+					if (cell.style.fontStyle !== (staticStyle ? 'normal' : '')) {
+						throw new Error(`${action}: row ${index} lost its static style declaration.`);
+					}
+					if (before.length !== 0) {
+						const nextLabel = row.querySelector('td:nth-child(2)').textContent;
+						const expectedLabel =
+							action === 'update' && index % 10 === 0 ? labels[index] + ' !!!' : labels[index];
+						if (nextLabel !== expectedLabel) {
+							throw new Error(`${action}: row ${index} has an unexpected label.`);
+						}
+					}
+				}
+
+				const selected = rows.filter((row) => row.classList.contains('danger'));
+				if (action.startsWith('select')) {
+					const index = action === 'select4' ? 4 : 5;
+					if (selected.length !== 1 || selected[0] !== rows[index]) {
+						throw new Error(`${action}: row selection did not commit.`);
+					}
+				} else if (selected.length !== 0) {
+					throw new Error(`${action}: an unexpected row remained selected.`);
+				}
+				return { rows: rows.length, selected: selected.length, ...writes };
+			},
+			{ action: operation.action, staticStyle: TSRX, expectedRows: ROWS },
+		);
+
+		return { ...countCalls(await cdp.send('Profiler.takePreciseCoverage')), ...observed };
+	} finally {
+		if (profiling) {
+			await cdp.send('Profiler.stopPreciseCoverage').catch(() => {});
+			await cdp.send('Profiler.disable').catch(() => {});
+		}
+		await context.close();
+	}
+}
+
+const browser = await chromium.launch({
+	headless: true,
+	args: ['--no-sandbox', '--js-flags=--jitless'],
+});
+const results = {};
+const failures = [];
+try {
+	for (const operation of OPS) {
+		const counts = await measure(browser, operation);
+		results[operation.name] = counts;
+		const expected = {
+			setStyle: TSRX ? 0 : ROWS,
+			applyStyleValue: TSRX ? 0 : ROWS,
+			applyStyleProperty: operation.writes,
+			setStyleProperty: TSRX ? operation.writes : 0,
+			Row: ROWS,
+			renderBlockInner: TSRX ? 2001 : 3002,
+			styleSets: operation.writes,
+			styleRemoves: 0,
+			fontWeightWrites: operation.writes,
+			fontStyleWrites: 0,
+			rows: ROWS,
+			selected: operation.action.startsWith('select') ? 1 : 0,
+		};
+		for (const [metric, value] of Object.entries(expected)) {
+			if (counts[metric] !== value) {
+				failures.push(`${operation.name}.${metric}: ${counts[metric]} !== expected ${value}`);
+			}
+		}
+	}
+} finally {
+	await browser.close();
+}
+
+console.log('Operation        | map | scalar | property | CSS writes | static writes | rows');
+console.log('-----------------+-----+--------+----------+------------+---------------+-----');
+for (const operation of OPS) {
+	const count = results[operation.name];
+	console.log(
+		`${operation.name.padEnd(16)} | ${String(count.setStyle).padStart(3)} | ${String(count.setStyleProperty).padStart(6)} | ${String(count.applyStyleProperty).padStart(8)} | ${String(count.fontWeightWrites).padStart(10)} | ${String(count.fontStyleWrites).padStart(13)} | ${String(count.Row).padStart(4)}`,
+	);
+}
+
+if (process.env.WORK_JSON) {
+	fs.writeFileSync(
+		process.env.WORK_JSON,
+		JSON.stringify(
+			{ suite: 'js-framework-style-work', dialect: DIALECT, target: URL, results, failures },
+			null,
+			'\t',
+		) + '\n',
+	);
+}
+
+if (failures.length !== 0) {
+	console.error(`\n${failures.length} deterministic inline-style work gate failure(s):`);
+	for (const failure of failures) console.error(`  - ${failure}`);
+	process.exit(1);
+}
+
+console.log('\nAll deterministic inline-style work gates passed.');

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -386,6 +386,8 @@ function attrBindingHelper(bind) {
 			return 'setFormAction';
 		case 'style':
 			return 'setStyle';
+		case 'styleProperty':
+			return 'setStyleProperty';
 		// SVG/MathML `className` is read-only — setClassAttr sets the attribute and
 		// clsx-composes (setClassName composes on HTML).
 		case 'class':
@@ -1991,6 +1993,54 @@ function staticObjectToCssString(obj) {
 		parts.push(`${hyphenateStyleName(name)}: ${cssValue};`);
 	}
 	return parts.join(' ');
+}
+
+// Preserve both CSS declaration order and JavaScript object evaluation order:
+// only a nonempty literal prefix followed by exactly one dynamic own property
+// can move into the template plus an independently guarded scalar binding.
+function mixedStaticStyle(obj) {
+	if (obj?.type !== 'ObjectExpression' || obj.properties.length < 2) return null;
+	const seen = new Set();
+	const prefix = [];
+	let dynamic = null;
+	for (const property of obj.properties) {
+		if (
+			(property.type !== 'Property' && property.type !== 'ObjectProperty') ||
+			property.computed ||
+			property.method ||
+			(property.kind !== undefined && property.kind !== 'init')
+		) {
+			return null;
+		}
+		const key = property.key;
+		if (key?.type !== 'Identifier' && !(key?.type === 'Literal' && typeof key.value === 'string')) {
+			return null;
+		}
+		const name = key.type === 'Identifier' ? key.name : key.value;
+		const normalized = hyphenateStyleName(name);
+		if (name === '__proto__' || name === 'dangerouslySetInnerHTML' || seen.has(normalized)) {
+			return null;
+		}
+		seen.add(normalized);
+
+		const value = property.value;
+		if (value?.type === 'Literal') {
+			if (
+				dynamic !== null ||
+				(typeof value.value !== 'string' && typeof value.value !== 'number') ||
+				value.value === ''
+			) {
+				return null;
+			}
+			prefix.push(property);
+		} else {
+			if (dynamic !== null) return null;
+			dynamic = { name, key, value };
+		}
+	}
+	if (prefix.length === 0 || dynamic === null) return null;
+	const css = staticObjectToCssString({ properties: prefix });
+	return css === '' ? null : { css, ...dynamic };
 }
 
 // ===========================================================================
@@ -18700,15 +18750,22 @@ function planJsx(
 				cloneLocArg = b.literal(locString, JSON.stringify(locString));
 			}
 		}
-		mountLines.push(
-			inheritOriginLoc(
-				b.const(
-					'_root',
-					cloneLocArg ? b.call('_$clone', b.id(tpl), cloneLocArg) : b.call('_$clone', b.id(tpl)),
-				),
-				planOrigin,
-			),
-		);
+		let mixedStylePaths = '';
+		for (const binding of elementBindings) {
+			if (binding.kind === 'styleProperty') mixedStylePaths += `|${binding.path.join('.')}`;
+		}
+		const cloneCall =
+			mixedStylePaths !== ''
+				? b.call(
+						'_$clone',
+						b.id(tpl),
+						cloneLocArg ?? undefinedNode(),
+						b.literal(`${mixedStylePaths}|`),
+					)
+				: cloneLocArg
+					? b.call('_$clone', b.id(tpl), cloneLocArg)
+					: b.call('_$clone', b.id(tpl));
+		mountLines.push(inheritOriginLoc(b.const('_root', cloneCall), planOrigin));
 		elementVars = new Map();
 		let varCounter = 0;
 		// Does this template contain a control-flow / component / portal hole? If so
@@ -19076,9 +19133,15 @@ function planJsx(
 				),
 			);
 		}
-		// Const-seeded fields keep their registry strings ('null'/'undefined');
-		// resolve them to nodes only here at the factory call.
-		const constArgNode = (expr) => (expr === 'null' ? b.literal(null) : b.id(expr));
+		// Const-seeded fields keep their registry strings until the factory call.
+		// A mixed-style scalar starts at NaN so its first deferred write still runs
+		// for null/undefined; `0 / 0` cannot be shadowed by an authored `NaN`.
+		const constArgNode = (expr) =>
+			expr === 'null'
+				? b.literal(null)
+				: expr === 'style-unset'
+					? b.binary('/', b.literal(0), b.literal(0))
+					: b.id(expr);
 		const bagFieldValue = (f) => (f.constExpr !== null ? constArgNode(f.constExpr) : b.id(f.local));
 		const rootArg = () => (single ? b.id('_root') : b.literal(null));
 		if (bag.fields.length <= BAG_FACTORY_MAX) {
@@ -20083,6 +20146,7 @@ const DEFERRABLE_MOUNT_KINDS = new Set([
 	'ariaAttr',
 	'class',
 	'style',
+	'styleProperty',
 	'formAction',
 	'htmlOnlyChild',
 ]);
@@ -20285,9 +20349,12 @@ function commitSourceRows(sources, valueOf) {
 // `setClassName(el, undefined)` no-op on a freshly-cloned element (so the output
 // is byte-identical to the old unconditional mount write).
 function emitDeferredMount(bind, elVar, bag) {
-	// `style` diffs on `_sty`; attr / class / formAction / htmlOnlyChild on `_prev`.
+	// Whole-object `style` diffs on `_sty`; scalar styles and other values on `_prev`.
 	if (!(bind.kind === 'class' && bind.fresh)) {
-		bag.constField(bind.kind === 'style' ? `_sty$${bind.id}` : `_prev$${bind.id}`, 'undefined');
+		bag.constField(
+			bind.kind === 'style' ? `_sty$${bind.id}` : `_prev$${bind.id}`,
+			bind.kind === 'styleProperty' ? 'style-unset' : 'undefined',
+		);
 	}
 	const key = `_el$${bind.id}`;
 	if (!bag.host(key, elVar)) return null;
@@ -20823,6 +20890,29 @@ function emitBindingUpdate(bind, bag) {
 						b.block([
 							b.stmt(b.call(callee(), F('_el'), V(), F('_sty'))),
 							b.stmt(b.assignment('=', F('_sty'), V())),
+						]),
+						null,
+					),
+				]),
+			);
+		}
+		case 'styleProperty': {
+			return st(
+				b.block([
+					b.const('_v', bind.expr),
+					b.if(
+						b.binary('!==', F('_prev'), V()),
+						b.block([
+							b.stmt(
+								b.call(
+									callee(),
+									F('_el'),
+									inheritOriginLoc(b.literal(bind.name), bind.propertyOrigin),
+									V(),
+									inheritOriginLoc(b.literal(bind.staticCss), bind.staticOrigin),
+								),
+							),
+							b.stmt(b.assignment('=', F('_prev'), V())),
 						]),
 						null,
 					),
@@ -21891,6 +21981,37 @@ function emitElementHtml(
 					appendBakedAttribute(attrTemplate, chunk, attrName, attr.name, inner, ctx.inspect);
 				}
 				continue;
+			}
+			if (
+				firstSpreadIdx === -1 &&
+				ctx._universalRuntimeUnit == null &&
+				!directPropNames.has('suppressHydrationWarning')
+			) {
+				const mixed = mixedStaticStyle(inner);
+				if (mixed !== null) {
+					appendBakedAttribute(
+						attrTemplate,
+						` style="${escapeAttr(mixed.css)}"`,
+						attrName,
+						attr.name,
+						inner,
+						ctx.inspect,
+					);
+					registerAttrLoweringOrigin(ctx, mixed.key, null, mixed.name);
+					bindings.push({
+						id: bindings.length,
+						kind: 'styleProperty',
+						name: mixed.name,
+						expr: tsrxExprNode(mixed.value, ctx, componentName, inlinedSubs),
+						path,
+						ns: hostNs,
+						nameOrigin: attr.name,
+						propertyOrigin: mixed.key,
+						staticOrigin: inner,
+						staticCss: mixed.css,
+					});
+					continue;
+				}
 			}
 			bindings.push({
 				id: bindings.length,

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -19134,14 +19134,11 @@ function planJsx(
 			);
 		}
 		// Const-seeded fields keep their registry strings until the factory call.
-		// A mixed-style scalar starts at NaN so its first deferred write still runs
-		// for null/undefined; `0 / 0` cannot be shadowed by an authored `NaN`.
+		// A mixed-style scalar starts at its private owning scope so its first
+		// deferred write still runs for null/undefined. The same identity lets its
+		// setter distinguish a fresh mount from a preserved suspended retry.
 		const constArgNode = (expr) =>
-			expr === 'null'
-				? b.literal(null)
-				: expr === 'style-unset'
-					? b.binary('/', b.literal(0), b.literal(0))
-					: b.id(expr);
+			expr === 'null' ? b.literal(null) : expr === 'style-unset' ? b.id('__s') : b.id(expr);
 		const bagFieldValue = (f) => (f.constExpr !== null ? constArgNode(f.constExpr) : b.id(f.local));
 		const rootArg = () => (single ? b.id('_root') : b.literal(null));
 		if (bag.fields.length <= BAG_FACTORY_MAX) {
@@ -20910,6 +20907,7 @@ function emitBindingUpdate(bind, bag) {
 									inheritOriginLoc(b.literal(bind.name), bind.propertyOrigin),
 									V(),
 									inheritOriginLoc(b.literal(bind.staticCss), bind.staticOrigin),
+									F('_prev'),
 								),
 							),
 							b.stmt(b.assignment('=', F('_prev'), V())),

--- a/packages/octane/src/index.ts
+++ b/packages/octane/src/index.ts
@@ -158,6 +158,7 @@ export {
 	setClassAttr,
 	normalizeClass,
 	setStyle,
+	setStyleProperty,
 	setSpread,
 	snapshotSpread,
 	setHostPropSources,

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -476,7 +476,9 @@ function warnHydrationStructuralMismatch(
  * client + server from the same JSX, so a differing/absent one means a DIFFERENT branch —
  * e.g. `@switch` cases all `<span>` but with a different `class`). DYNAMIC attrs are NOT in
  * the template, so they aren't checked here — a value divergence on those is handled by
- * `setAttribute` (P2).
+ * `setAttribute` (P2). A compiler-specialized mixed style bakes only its static prefix;
+ * its exact template path is supplied separately so that one style attribute waits for
+ * the complete-value hydration check without weakening other static comparisons.
  *
  * DEV then recurses into the NESTED STATIC element structure, catching same-root branches that
  * differ only in nested static markup (`<div><span/></div>` vs `<div><p/></div>`). The recursion
@@ -486,7 +488,12 @@ function warnHydrationStructuralMismatch(
  * be compared positionally and is left to the per-site recovery. This makes the check safe
  * (never false-flags a hole-bearing template) while still catching pure-static divergences.
  */
-function hydrationNodeMatches(server: Node, template: Node): boolean {
+function hydrationNodeMatches(
+	server: Node,
+	template: Node,
+	partialStyles?: string,
+	path: string = '',
+): boolean {
 	if (server.nodeType !== template.nodeType) return false;
 	if (server.nodeType !== 1) return true;
 	const s = server as Element;
@@ -499,16 +506,41 @@ function hydrationNodeMatches(server: Node, template: Node): boolean {
 	const tAttrs = t.attributes;
 	for (let i = 0; i < tAttrs.length; i++) {
 		const a = tAttrs[i];
-		if (s.getAttribute(a.name) !== a.value) return false;
+		if (
+			s.getAttribute(a.name) !== a.value &&
+			!(
+				a.name === 'style' &&
+				partialStyles !== undefined &&
+				partialStyles.includes('|' + path + '|')
+			)
+		) {
+			return false;
+		}
 	}
 	let sc = s.firstChild;
 	let tc = t.firstChild;
+	let childIndex = 0;
 	while (sc !== null && tc !== null) {
 		if (sc.nodeType === 8 || tc.nodeType === 8) return true; // hole / marker — stop comparing
 		if (sc.nodeType !== tc.nodeType) return true; // text↔element shift — ambiguous, stop
-		if (tc.nodeType === 1 && !hydrationNodeMatches(sc, tc)) return false;
+		if (
+			tc.nodeType === 1 &&
+			!hydrationNodeMatches(
+				sc,
+				tc,
+				partialStyles,
+				partialStyles === undefined
+					? ''
+					: path === ''
+						? String(childIndex)
+						: path + '.' + childIndex,
+			)
+		) {
+			return false;
+		}
 		sc = sc.nextSibling;
 		tc = tc.nextSibling;
+		childIndex++;
 	}
 	return true; // any leftover could be holes — assume a match
 }
@@ -9853,16 +9885,27 @@ class HydrationCapability {
 		return cloned;
 	}
 
-	private fragmentRemainder(template: Node, cursor: Node | null): Node | null | undefined {
+	private fragmentRemainder(
+		template: Node,
+		cursor: Node | null,
+		partialStyles?: string,
+	): Node | null | undefined {
 		let expected = template.firstChild;
 		let actual = cursor;
+		let childIndex = 0;
 		while (expected !== null) {
 			if (actual === null) return undefined;
 			// A template comment is a dynamic logical hole. Its server form may be
 			// text or a marker range, so only static text/element roots compare shape.
-			if (expected.nodeType !== 8 && !hydrationNodeMatches(actual, expected)) return undefined;
+			if (
+				expected.nodeType !== 8 &&
+				!hydrationNodeMatches(actual, expected, partialStyles, String(childIndex))
+			) {
+				return undefined;
+			}
 			actual = this.sibling(actual, 1);
 			expected = expected.nextSibling;
+			childIndex++;
 		}
 		return actual;
 	}
@@ -9906,8 +9949,8 @@ class HydrationCapability {
 		this.abandoned = true;
 	}
 
-	clone<T extends Node>(template: T, loc?: string): T {
-		return this.adopt(template, null, loc) as T;
+	clone<T extends Node>(template: T, loc?: string, partialStyles?: string): T {
+		return this.adopt(template, null, loc, partialStyles) as T;
 	}
 
 	/**
@@ -9922,7 +9965,12 @@ class HydrationCapability {
 	}
 
 	/** `template` is null only in prod lazy mode (then `lazy` is set) — every cold path resolves it. */
-	private adopt(template: Node | null, lazy: LazyTemplateRecord | null, loc?: string): Node {
+	private adopt(
+		template: Node | null,
+		lazy: LazyTemplateRecord | null,
+		loc?: string,
+		partialStyles?: string,
+	): Node {
 		const cursor = this.node;
 		const isFragment =
 			template !== null ? (template as any).__oct_frag === true : isLazyFragment(lazy!);
@@ -9944,7 +9992,7 @@ class HydrationCapability {
 		// (Root claims happen once per hydrateRoot, so parsing here is cold.)
 		if (isFragment && claimsRoot) {
 			if (template === null) template = resolveLazyTemplate(lazy!);
-			const remainder = this.fragmentRemainder(template, cursor);
+			const remainder = this.fragmentRemainder(template, cursor, partialStyles);
 			if (remainder === undefined) {
 				this.abandonRoot(
 					`a fragment starting with ${describeHydrationNode(template.firstChild)}`,
@@ -9963,7 +10011,7 @@ class HydrationCapability {
 		if (
 			!isFragment &&
 			(template !== null
-				? !hydrationNodeMatches(cursor, template)
+				? !hydrationNodeMatches(cursor, template, partialStyles)
 				: !lazyRootMatches(cursor, lazy!))
 		) {
 			if (template === null) template = resolveLazyTemplate(lazy!);
@@ -10163,7 +10211,7 @@ class HydrationCapability {
 		}
 	}
 
-	applyStyle(el: HTMLElement | SVGElement, value: any, _prev: any): boolean {
+	applyStyle(el: HTMLElement | SVGElement, value: any, _prev: any, staticCss?: string): boolean {
 		const mode = hydrationMismatchMode(el);
 		if (mode === 1) return true;
 		const style = (el as HTMLElement).style;
@@ -10178,6 +10226,7 @@ class HydrationCapability {
 		// semantically and order-equivalent (`#fff` vs rgb(), compact whitespace),
 		// while still detecting reordered, missing, added, and empty styles.
 		const expectedStyle = document.createElement('div').style;
+		if (staticCss !== undefined) expectedStyle.cssText = staticCss;
 		applyStyleValue(expectedStyle, value, undefined);
 		const expected = expectedStyle.cssText;
 		const expectsStyleAttribute = expected !== '';
@@ -10304,7 +10353,7 @@ function parseSeedJson(raw: string): unknown[] | null {
 // Armed only around that one mapped survivor render; all other clones see null.
 let MAPPED_ITEM_ADOPTION: { node: Node | null } | null = null;
 
-export function clone<T extends Node>(node: T, loc?: string): T {
+export function clone<T extends Node>(node: T, loc?: string, partialStyles?: string): T {
 	if (MAPPED_ITEM_ADOPTION !== null && MAPPED_ITEM_ADOPTION.node !== null) {
 		const adopted = MAPPED_ITEM_ADOPTION.node;
 		MAPPED_ITEM_ADOPTION.node = null;
@@ -10353,10 +10402,14 @@ export function clone<T extends Node>(node: T, loc?: string): T {
 			return hydration.cloneLazy(lazy, loc) as unknown as T;
 		}
 		const parsed = resolveLazyTemplate(lazy);
-		return (hydration === null ? parsed.cloneNode(true) : hydration.clone(parsed, loc)) as T;
+		return (
+			hydration === null ? parsed.cloneNode(true) : hydration.clone(parsed, loc, partialStyles)
+		) as T;
 	}
 	const hydration = activeHydration();
-	return hydration === null ? (node.cloneNode(true) as T) : hydration.clone(node, loc);
+	return hydration === null
+		? (node.cloneNode(true) as T)
+		: hydration.clone(node, loc, partialStyles);
 }
 
 /**
@@ -12188,6 +12241,34 @@ export function setStyle(el: HTMLElement | SVGElement, value: any, prev: any): v
 	// is about to touch: restoring the attribute text restores every one of them.
 	if (TRANSITION_JOURNAL !== null) journalAttr(el, 'style');
 	applyStyleValue(style, value, prev);
+}
+
+/**
+ * Update one dynamic declaration after a compiler-baked static style prefix.
+ * Hydration still compares the complete style, while aborted transitions
+ * restore the entire attribute rather than only this declaration.
+ * @internal
+ */
+export function setStyleProperty(
+	el: HTMLElement | SVGElement,
+	name: string,
+	value: any,
+	staticCss: string,
+): void {
+	const hydration = activeHydration();
+	if (hydration !== null) {
+		hydration.applyStyle(el, { [name]: value }, undefined, staticCss);
+		return;
+	}
+	const remove = value == null || typeof value === 'boolean';
+	// An absent initial longhand must not erase a baked shorthand's value.
+	// The existing scope mount flag becomes true only after its body returns;
+	// later null/boolean updates still remove the authored dynamic declaration.
+	if (remove && CURRENT_SCOPE?.mounted !== true) return;
+	if (TRANSITION_JOURNAL !== null) journalAttr(el, 'style');
+	const style = (el as HTMLElement).style;
+	if (remove) style.removeProperty(styleName(name));
+	else applyStyleProperty(style, name, value);
 }
 
 function applyStyleValue(style: CSSStyleDeclaration, value: any, prev: any): void {

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -12254,6 +12254,7 @@ export function setStyleProperty(
 	name: string,
 	value: any,
 	staticCss: string,
+	previous: any,
 ): void {
 	const hydration = activeHydration();
 	if (hydration !== null) {
@@ -12261,10 +12262,9 @@ export function setStyleProperty(
 		return;
 	}
 	const remove = value == null || typeof value === 'boolean';
-	// An absent initial longhand must not erase a baked shorthand's value.
-	// The existing scope mount flag becomes true only after its body returns;
-	// later null/boolean updates still remove the authored dynamic declaration.
-	if (remove && CURRENT_SCOPE?.mounted !== true) return;
+	// The compiler seeds each binding with its private scope, distinguishing a
+	// genuinely absent initial longhand from a preserved suspended-mount retry.
+	if (remove && previous === CURRENT_SCOPE) return;
 	if (TRANSITION_JOURNAL !== null) journalAttr(el, 'style');
 	const style = (el as HTMLElement).style;
 	if (remove) style.removeProperty(styleName(name));

--- a/packages/octane/tests/style.test.ts
+++ b/packages/octane/tests/style.test.ts
@@ -306,6 +306,73 @@ describe('style prop — mixed static and dynamic inline objects', () => {
 	);
 
 	it.each([
+		{ shape: 'null', initial: 8, value: null },
+		{ shape: 'a boolean', initial: 8, value: true },
+		{ shape: 'null after a longhand matching its shorthand', initial: 4, value: null },
+	])(
+		'removes a stale mixed inline style longhand after a suspended mount retries with $shape',
+		async ({ initial, value }) => {
+			const source = `
+			import { use } from 'octane';
+
+			function Content(props) @{
+				const text = use(props.promise);
+				<span id="mixed-inline-style-retry-content">{text as string}</span>
+			}
+
+			function Panel(props) @{
+				<section
+					id="mixed-inline-style-retry-panel"
+					style={{ margin: '4px', marginTop: props.value }}
+				>
+					<Content promise={props.promise} />
+				</section>
+			}
+
+			export function App(props) @{
+				<main>
+					@try {
+						<Panel value={props.value} promise={props.promise} />
+					} @pending {
+						<span id="mixed-inline-style-retry-pending">{'pending'}</span>
+					}
+				</main>
+			}
+		`;
+			const client = loadMixedInlineStyle(source, 'mixed-inline-style-suspended-retry.tsrx');
+			let resolve!: (text: string) => void;
+			const promise = new Promise<string>((complete) => {
+				resolve = complete;
+			});
+			const root = mount(client.App, { promise, value: initial });
+
+			try {
+				expect(root.find('#mixed-inline-style-retry-pending').textContent).toBe('pending');
+				const preserved = root.find('#mixed-inline-style-retry-panel') as HTMLElement;
+				expect(preserved.style.marginTop).toBe(`${initial}px`);
+				expect(preserved.style.marginRight).toBe('4px');
+
+				root.update(client.App, { promise, value });
+				expect(root.find('#mixed-inline-style-retry-pending').textContent).toBe('pending');
+
+				await act(() => resolve('resolved'));
+				const panel = root.find('#mixed-inline-style-retry-panel') as HTMLElement;
+				expect(panel).toBe(preserved);
+				expect(root.find('#mixed-inline-style-retry-content').textContent).toBe('resolved');
+				expect(panel.style.marginTop).toBe('');
+				expect(panel.style.marginRight).toBe('4px');
+
+				root.update(client.App, { promise, value: 12 });
+				expect(root.find('#mixed-inline-style-retry-panel')).toBe(panel);
+				expect(panel.style.marginTop).toBe('12px');
+				expect(panel.style.marginRight).toBe('4px');
+			} finally {
+				root.unmount();
+			}
+		},
+	);
+
+	it.each([
 		{
 			shape: 'duplicate names',
 			style: "{ color: 'red', color: props.color, position: 'absolute' }",

--- a/packages/octane/tests/style.test.ts
+++ b/packages/octane/tests/style.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from 'vitest';
-import { mount } from './_helpers';
+import { describe, expect, it, vi } from 'vitest';
+import * as ServerRuntime from 'octane/server';
+import { flushSync, hydrateRoot } from '../src/index.js';
+import { act, mount } from './_helpers';
+import { loadCompiledFixtureSource } from './_server-fixture.js';
 import {
 	StaticStringStyle,
 	StaticObjectStyle,
@@ -25,6 +28,59 @@ import {
 	ScopedGlobal,
 	ScopedGlobalTag,
 } from './_fixtures/style.tsrx';
+
+const MIXED_INLINE_STYLE_SOURCE = `
+	export function MixedStyle(props) @{
+		<div
+			id="mixed-inline-style"
+			style={{
+				position: 'absolute',
+				display: 'block',
+				width: 120,
+				opacity: 0.5,
+				'--fixed': 12,
+				color: props.color,
+			}}
+		>
+			{'mixed'}
+		</div>
+	}
+
+	export function MixedLengthStyle(props) @{
+		<div
+			id="mixed-inline-length"
+			style={{ position: 'absolute', display: 'block', marginTop: props.offset }}
+		>
+			{'length'}
+		</div>
+	}
+
+	export function MixedCustomStyle(props) @{
+		<div
+			id="mixed-inline-custom"
+			style={{ position: 'absolute', display: 'block', '--accent': props.accent }}
+		>
+			{'custom'}
+		</div>
+	}
+
+	export function MixedSvgStyle(props) @{
+		<svg>
+			<rect
+				id="mixed-inline-svg-style"
+				style={{ fill: 'red', opacity: 0.5, stroke: props.stroke }}
+			/>
+		</svg>
+	}
+`;
+
+function loadMixedInlineStyle(source: string, id: string, mode: 'client' | 'server' = 'client') {
+	return loadCompiledFixtureSource(source, {
+		id,
+		mode,
+		compileOptions: { hmr: false, dev: false },
+	});
+}
 
 // Helper: find the module-level <style data-octane> tag for a given hash
 // and return its CSS text. Tests use this to assert how @tsrx/core's
@@ -62,6 +118,660 @@ describe('style prop — static forms', () => {
 		// Sanity: it landed in the HTML attribute, not via a runtime call.
 		expect(div.getAttribute('style')).toContain('background-color');
 		r.unmount();
+	});
+});
+
+describe('style prop — mixed static and dynamic inline objects', () => {
+	it('keeps mixed inline style literals, units, priorities, custom properties, and removals', () => {
+		const client = loadMixedInlineStyle(MIXED_INLINE_STYLE_SOURCE, 'mixed-inline-style.tsrx');
+		const root = mount(client.MixedStyle, { color: 'red !important' });
+		const element = root.find('#mixed-inline-style') as HTMLElement;
+		expect(element.style.position).toBe('absolute');
+		expect(element.style.display).toBe('block');
+		expect(element.style.width).toBe('120px');
+		expect(element.style.opacity).toBe('0.5');
+		expect(element.style.color).toBe('red');
+		expect(element.style.getPropertyPriority('color')).toBe('important');
+		expect(element.style.getPropertyValue('--fixed')).toBe('12');
+
+		root.update(client.MixedStyle, { color: 'blue' });
+		expect(root.find('#mixed-inline-style')).toBe(element);
+		expect(element.style.position).toBe('absolute');
+		expect(element.style.display).toBe('block');
+		expect(element.style.width).toBe('120px');
+		expect(element.style.opacity).toBe('0.5');
+		expect(element.style.color).toBe('blue');
+		expect(element.style.getPropertyPriority('color')).toBe('');
+		expect(element.style.getPropertyValue('--fixed')).toBe('12');
+
+		root.update(client.MixedStyle, { color: null });
+		expect(element.style.position).toBe('absolute');
+		expect(element.style.width).toBe('120px');
+		expect(element.style.color).toBe('');
+		expect(element.style.getPropertyValue('--fixed')).toBe('12');
+		root.unmount();
+
+		const lengthRoot = mount(client.MixedLengthStyle, { offset: 8 });
+		const length = lengthRoot.find('#mixed-inline-length') as HTMLElement;
+		expect(length.style.position).toBe('absolute');
+		expect(length.style.marginTop).toBe('8px');
+		lengthRoot.update(client.MixedLengthStyle, { offset: null });
+		expect(length.style.position).toBe('absolute');
+		expect(length.style.marginTop).toBe('');
+		lengthRoot.update(client.MixedLengthStyle, { offset: 0 });
+		expect(length.style.marginTop).toBe('0px');
+		lengthRoot.unmount();
+
+		const customRoot = mount(client.MixedCustomStyle, { accent: 12 });
+		const custom = customRoot.find('#mixed-inline-custom') as HTMLElement;
+		expect(custom.style.getPropertyValue('--accent')).toBe('12');
+		customRoot.update(client.MixedCustomStyle, { accent: undefined });
+		expect(custom.style.position).toBe('absolute');
+		expect(custom.style.getPropertyValue('--accent')).toBe('');
+		customRoot.update(client.MixedCustomStyle, { accent: 'restored' });
+		expect(custom.style.getPropertyValue('--accent')).toBe('restored');
+		customRoot.unmount();
+	});
+
+	it.each([
+		{ mode: 'production', dev: false },
+		{ mode: 'development', dev: true },
+	])('updates mixed inline style in $mode compiler output', ({ mode, dev }) => {
+		const client = loadCompiledFixtureSource(MIXED_INLINE_STYLE_SOURCE, {
+			id: `mixed-inline-style-${mode}.tsrx`,
+			mode: 'client',
+			compileOptions: { hmr: false, dev },
+		});
+		const root = mount(client.MixedLengthStyle, { offset: 8 });
+		const element = root.find('#mixed-inline-length') as HTMLElement;
+		expect(element.style.position).toBe('absolute');
+		expect(element.style.display).toBe('block');
+		expect(element.style.marginTop).toBe('8px');
+
+		root.update(client.MixedLengthStyle, { offset: 12 });
+		expect(root.find('#mixed-inline-length')).toBe(element);
+		expect(element.style.position).toBe('absolute');
+		expect(element.style.marginTop).toBe('12px');
+		root.unmount();
+	});
+
+	it('preserves mixed inline style and neighboring expression evaluation order', () => {
+		const source = `
+			export function App(props) @{
+				<div
+					id="mixed-inline-style-evaluation-order"
+					data-before={props.read('before')}
+					style={{ position: 'absolute', color: props.read('style') }}
+					data-after={props.read('after')}
+				>
+					{props.read('child') as string}
+				</div>
+			}
+		`;
+		const client = loadMixedInlineStyle(source, 'mixed-inline-style-evaluation-order.tsrx');
+		const events: string[] = [];
+		let color = 'red';
+		const read = (name: string) => {
+			events.push(name);
+			return name === 'style' ? color : name;
+		};
+		const root = mount(client.App, { read });
+		const element = root.find('#mixed-inline-style-evaluation-order') as HTMLElement;
+		expect(events).toEqual(['child', 'before', 'style', 'after']);
+		expect(element.style.position).toBe('absolute');
+		expect(element.style.color).toBe('red');
+		expect(element.textContent).toBe('child');
+
+		events.length = 0;
+		color = 'blue';
+		root.update(client.App, { read });
+		expect(events).toEqual(['child', 'before', 'style', 'after']);
+		expect(element.style.position).toBe('absolute');
+		expect(element.style.color).toBe('blue');
+		root.unmount();
+	});
+
+	it.each([
+		{
+			shape: 'a static shorthand before a dynamic longhand',
+			style: "{ margin: '4px', marginLeft: props.value }",
+			initial: '8px',
+			updated: '12px',
+		},
+		{
+			shape: 'a dynamic longhand before a static shorthand',
+			style: "{ marginLeft: props.value, margin: '4px' }",
+			initial: '4px',
+			updated: '12px',
+		},
+		{
+			shape: 'a dynamic shorthand before a static longhand',
+			style: "{ margin: props.value, marginLeft: '6px' }",
+			initial: '6px',
+			updated: '12px',
+		},
+	])('preserves mixed inline style order for $shape', ({ shape, style, initial, updated }) => {
+		const source = `
+			export function App(props) @{
+				<div id="mixed-inline-style-order" style={${style}}>{'order'}</div>
+			}
+		`;
+		const client = loadMixedInlineStyle(
+			source,
+			`mixed-inline-style-order-${shape.replaceAll(' ', '-')}.tsrx`,
+		);
+		const root = mount(client.App, { value: '8px' });
+		const element = root.find('#mixed-inline-style-order') as HTMLElement;
+		expect(element.style.marginLeft).toBe(initial);
+
+		root.update(client.App, { value: '12px' });
+		expect(root.find('#mixed-inline-style-order')).toBe(element);
+		expect(element.style.marginLeft).toBe(updated);
+		root.unmount();
+	});
+
+	it.each([
+		{ shape: 'null', value: null },
+		{ shape: 'undefined', value: undefined },
+		{ shape: 'a boolean', value: true },
+	])(
+		'keeps static shorthand when the initial mixed inline style longhand is $shape',
+		({ value }) => {
+			const source = `
+			export function App(props) @{
+				<div
+					id="mixed-inline-style-shorthand-null"
+					style={{ margin: '4px', marginTop: props.value }}
+				>
+					{'shorthand'}
+				</div>
+			}
+		`;
+			const client = loadMixedInlineStyle(source, 'mixed-inline-style-shorthand-null.tsrx');
+			const root = mount(client.App, { value });
+			const element = root.find('#mixed-inline-style-shorthand-null') as HTMLElement;
+			expect(element.style.marginTop).toBe('4px');
+			expect(element.style.marginRight).toBe('4px');
+
+			root.update(client.App, { value: 8 });
+			expect(root.find('#mixed-inline-style-shorthand-null')).toBe(element);
+			expect(element.style.marginTop).toBe('8px');
+			expect(element.style.marginRight).toBe('4px');
+
+			root.update(client.App, { value: null });
+			expect(element.style.marginTop).toBe('');
+			expect(element.style.marginRight).toBe('4px');
+			root.unmount();
+		},
+	);
+
+	it.each([
+		{
+			shape: 'duplicate names',
+			style: "{ color: 'red', color: props.color, position: 'absolute' }",
+		},
+		{
+			shape: 'normalized duplicate names',
+			style: "{ backgroundColor: 'red', 'background-color': props.color }",
+		},
+		{
+			shape: 'computed names',
+			style: "{ position: 'absolute', [props.name]: props.color }",
+		},
+		{
+			shape: 'spread overrides',
+			style: "{ position: 'absolute', color: 'red', ...props.values, color: props.color }",
+		},
+	])('keeps mixed inline style $shape source ordered', ({ shape, style }) => {
+		const source = `
+			export function App(props) @{
+				<div id="mixed-inline-style-unsafe" style={${style}}>{'unsafe'}</div>
+			}
+		`;
+		const client = loadMixedInlineStyle(
+			source,
+			`mixed-inline-style-${shape.replaceAll(' ', '-')}.tsrx`,
+		);
+		const root = mount(client.App, {
+			name: 'color',
+			color: 'blue',
+			values: { color: 'green' },
+		});
+		const element = root.find('#mixed-inline-style-unsafe') as HTMLElement;
+		const property = shape === 'normalized duplicate names' ? 'backgroundColor' : 'color';
+		expect(element.style[property]).toBe('blue');
+
+		root.update(client.App, { name: 'color', color: 'purple', values: { color: 'orange' } });
+		expect(root.find('#mixed-inline-style-unsafe')).toBe(element);
+		expect(element.style[property]).toBe('purple');
+		root.unmount();
+	});
+
+	it('keeps mixed inline style getter and proxy spread observations in source order', () => {
+		const source = `
+			export function App(props) @{
+				<div
+					id="mixed-inline-style-getters"
+					style={{
+						position: 'absolute',
+						...props.values,
+						get color() {
+							props.observe('get:color');
+							return props.color;
+						},
+					}}
+				>
+					{'getter'}
+				</div>
+			}
+		`;
+		const client = loadMixedInlineStyle(source, 'mixed-inline-style-getters.tsrx');
+		const events: string[] = [];
+		const values = new Proxy(
+			{ display: 'block' },
+			{
+				ownKeys(target) {
+					events.push('ownKeys');
+					return Reflect.ownKeys(target);
+				},
+				getOwnPropertyDescriptor(target, key) {
+					events.push(`descriptor:${String(key)}`);
+					return Reflect.getOwnPropertyDescriptor(target, key);
+				},
+				get(target, key, receiver) {
+					events.push(`get:${String(key)}`);
+					return Reflect.get(target, key, receiver);
+				},
+			},
+		);
+		const observe = (event: string) => events.push(event);
+		const root = mount(client.App, { color: 'red', observe, values });
+		const element = root.find('#mixed-inline-style-getters') as HTMLElement;
+		expect(events).toEqual(['ownKeys', 'descriptor:display', 'get:display', 'get:color']);
+		expect(element.style.position).toBe('absolute');
+		expect(element.style.display).toBe('block');
+		expect(element.style.color).toBe('red');
+
+		events.length = 0;
+		root.update(client.App, { color: 'blue', observe, values });
+		expect(events).toEqual([
+			'ownKeys',
+			'descriptor:display',
+			'get:display',
+			'get:color',
+			'get:color',
+		]);
+		expect(root.find('#mixed-inline-style-getters')).toBe(element);
+		expect(element.style.color).toBe('blue');
+		root.unmount();
+	});
+
+	it('preserves mixed inline style precedence across neighboring host spreads', () => {
+		const source = `
+			export function App(props) @{
+				<section>
+					<div
+						id="mixed-inline-style-spread-first"
+						{...props.first}
+						style={{ position: 'absolute', color: props.color }}
+					/>
+					<div
+						id="mixed-inline-style-spread-last"
+						style={{ position: 'absolute', color: props.color }}
+						{...props.last}
+					/>
+				</section>
+			}
+		`;
+		const client = loadMixedInlineStyle(source, 'mixed-inline-style-host-spreads.tsrx');
+		const root = mount(client.App, {
+			color: 'blue',
+			first: { style: { color: 'green', display: 'grid' } },
+			last: { style: { color: 'red', display: 'flex' } },
+		});
+		const before = root.find('#mixed-inline-style-spread-first') as HTMLElement;
+		const after = root.find('#mixed-inline-style-spread-last') as HTMLElement;
+		expect(before.style.color).toBe('blue');
+		expect(before.style.position).toBe('absolute');
+		expect(before.style.display).toBe('');
+		expect(after.style.color).toBe('red');
+		expect(after.style.position).toBe('');
+		expect(after.style.display).toBe('flex');
+
+		root.update(client.App, {
+			color: 'purple',
+			first: { style: { color: 'orange' } },
+			last: { style: { color: 'yellow' } },
+		});
+		expect(before.style.color).toBe('purple');
+		expect(after.style.color).toBe('yellow');
+		expect(after.style.position).toBe('');
+		root.unmount();
+	});
+
+	it('updates mixed inline style objects on SVG elements without replacing them', () => {
+		const client = loadMixedInlineStyle(MIXED_INLINE_STYLE_SOURCE, 'mixed-inline-style-svg.tsrx');
+		const root = mount(client.MixedSvgStyle, { stroke: 'blue' });
+		const element = root.find('#mixed-inline-svg-style') as SVGElement;
+		expect(element.namespaceURI).toBe('http://www.w3.org/2000/svg');
+		expect(element.style.fill).toBe('red');
+		expect(element.style.stroke).toBe('blue');
+		expect(element.style.opacity).toBe('0.5');
+
+		root.update(client.MixedSvgStyle, { stroke: null });
+		expect(root.find('#mixed-inline-svg-style')).toBe(element);
+		expect(element.style.fill).toBe('red');
+		expect(element.style.stroke).toBe('');
+		expect(element.style.opacity).toBe('0.5');
+		root.unmount();
+	});
+
+	it('restores mixed inline style when a transition suspends before committing', async () => {
+		const source = `
+			import { use, useState, useTransition } from 'octane';
+
+			function Value(props) @{
+				const value = use(props.load(props.step));
+				<span id="mixed-inline-style-transition-value">{value as string}</span>
+			}
+
+			function Panel(props) @{
+				<section
+					id="mixed-inline-style-transition-panel"
+					style={{ position: 'absolute', color: props.step === 0 ? 'red' : 'blue' }}
+				>
+					<Value load={props.load} step={props.step} />
+				</section>
+			}
+
+			export function App(props) @{
+				const [step, setStep] = useState(0);
+				const [, start] = useTransition();
+				<div>
+					<button
+						id="mixed-inline-style-transition-update"
+						onClick={() => start(() => setStep(1))}
+					>
+						{'update'}
+					</button>
+					@try {
+						<Panel load={props.load} step={step} />
+					} @pending {
+						<span id="mixed-inline-style-transition-fallback">{'pending'}</span>
+					}
+				</div>
+			}
+		`;
+		const client = loadMixedInlineStyle(source, 'mixed-inline-style-transition.tsrx');
+		let resolve!: (value: string) => void;
+		const pending = new Promise<string>((complete) => {
+			resolve = complete;
+		});
+		const fulfilled = {
+			status: 'fulfilled',
+			value: 'initial',
+			then(callback: (value: string) => void) {
+				callback('initial');
+			},
+		};
+		const root = mount(client.App, { load: (step: number) => (step === 0 ? fulfilled : pending) });
+		await act(() => {});
+		const panel = root.find('#mixed-inline-style-transition-panel') as HTMLElement;
+		expect(panel.style.position).toBe('absolute');
+		expect(panel.style.color).toBe('red');
+		expect(root.find('#mixed-inline-style-transition-value').textContent).toBe('initial');
+
+		root.click('#mixed-inline-style-transition-update');
+		expect(root.find('#mixed-inline-style-transition-panel')).toBe(panel);
+		expect(panel.style.position).toBe('absolute');
+		expect(panel.style.color).toBe('red');
+		expect(root.findAll('#mixed-inline-style-transition-fallback')).toEqual([]);
+
+		await act(() => resolve('resolved'));
+		expect(root.find('#mixed-inline-style-transition-panel')).toBe(panel);
+		expect(panel.style.position).toBe('absolute');
+		expect(panel.style.color).toBe('blue');
+		expect(root.find('#mixed-inline-style-transition-value').textContent).toBe('resolved');
+		root.unmount();
+	});
+
+	it('hydrates mixed inline style objects without disturbing static declarations or DOM', () => {
+		const id = 'mixed-inline-style-hydration.tsrx';
+		const server = loadMixedInlineStyle(MIXED_INLINE_STYLE_SOURCE, id, 'server');
+		const client = loadMixedInlineStyle(MIXED_INLINE_STYLE_SOURCE, id, 'client');
+		const initial = { color: 'red' };
+		const { html } = ServerRuntime.renderToString(server.MixedStyle, initial);
+		const container = document.createElement('div');
+		container.innerHTML = html;
+		document.body.appendChild(container);
+		const element = container.querySelector('#mixed-inline-style') as HTMLElement;
+		const original = element.getAttribute('style');
+		const warnings = vi.spyOn(console, 'error').mockImplementation(() => {});
+		let root: ReturnType<typeof hydrateRoot> | undefined;
+
+		try {
+			root = hydrateRoot(container, client.MixedStyle, initial);
+			flushSync(() => {});
+			expect(container.querySelector('#mixed-inline-style')).toBe(element);
+			expect(element.getAttribute('style')).toBe(original);
+			expect(element.style.position).toBe('absolute');
+			expect(element.style.width).toBe('120px');
+			expect(element.style.color).toBe('red');
+			expect(element.style.getPropertyValue('--fixed')).toBe('12');
+			expect(
+				warnings.mock.calls.filter((args) => /hydrat|mismatch/i.test(String(args[0]))),
+			).toEqual([]);
+
+			flushSync(() => root!.render(client.MixedStyle, { color: 'blue' }));
+			expect(container.querySelector('#mixed-inline-style')).toBe(element);
+			expect(element.style.position).toBe('absolute');
+			expect(element.style.display).toBe('block');
+			expect(element.style.width).toBe('120px');
+			expect(element.style.opacity).toBe('0.5');
+			expect(element.style.color).toBe('blue');
+			expect(element.style.getPropertyValue('--fixed')).toBe('12');
+		} finally {
+			root?.unmount();
+			warnings.mockRestore();
+			container.remove();
+		}
+	});
+
+	it('hydrates a nested mixed inline style host beside a fully static sibling', () => {
+		const source = `
+			export function App(props) @{
+				<main id="mixed-inline-style-nested-root">
+					<div
+						id="mixed-inline-style-nested-dynamic"
+						style={{ position: 'absolute', color: props.color }}
+					>
+						{'dynamic'}
+					</div>
+					<div id="mixed-inline-style-nested-static" style={{ color: 'green' }}>
+						{'static'}
+					</div>
+				</main>
+			}
+		`;
+		const id = 'mixed-inline-style-nested-hydration.tsrx';
+		const server = loadMixedInlineStyle(source, id, 'server');
+		const client = loadMixedInlineStyle(source, id, 'client');
+		const container = document.createElement('div');
+		container.innerHTML = ServerRuntime.renderToString(server.App, { color: 'red' }).html;
+		document.body.appendChild(container);
+		const parent = container.querySelector('#mixed-inline-style-nested-root');
+		const dynamic = container.querySelector('#mixed-inline-style-nested-dynamic') as HTMLElement;
+		const sibling = container.querySelector('#mixed-inline-style-nested-static') as HTMLElement;
+		let root: ReturnType<typeof hydrateRoot> | undefined;
+
+		try {
+			root = hydrateRoot(container, client.App, { color: 'red' });
+			flushSync(() => {});
+			expect(container.querySelector('#mixed-inline-style-nested-root')).toBe(parent);
+			expect(container.querySelector('#mixed-inline-style-nested-dynamic')).toBe(dynamic);
+			expect(container.querySelector('#mixed-inline-style-nested-static')).toBe(sibling);
+			expect(dynamic.style.position).toBe('absolute');
+			expect(dynamic.style.color).toBe('red');
+			expect(sibling.style.color).toBe('green');
+
+			flushSync(() => root!.render(client.App, { color: 'blue' }));
+			expect(container.querySelector('#mixed-inline-style-nested-dynamic')).toBe(dynamic);
+			expect(container.querySelector('#mixed-inline-style-nested-static')).toBe(sibling);
+			expect(dynamic.style.position).toBe('absolute');
+			expect(dynamic.style.color).toBe('blue');
+			expect(sibling.style.color).toBe('green');
+		} finally {
+			root?.unmount();
+			container.remove();
+		}
+	});
+
+	it('rebuilds a hydrated branch that differs only in its fully static inline style', () => {
+		const source = `
+			export function App(props) @{
+				@if (props.blue) {
+					<div id="mixed-inline-style-static-branch" style={{ color: 'blue' }}>{'same'}</div>
+				} @else {
+					<div id="mixed-inline-style-static-branch" style={{ color: 'red' }}>{'same'}</div>
+				}
+			}
+		`;
+		const id = 'mixed-inline-style-static-branch-hydration.tsrx';
+		const server = loadMixedInlineStyle(source, id, 'server');
+		const client = loadMixedInlineStyle(source, id, 'client');
+		const container = document.createElement('div');
+		container.innerHTML = ServerRuntime.renderToString(server.App, { blue: false }).html;
+		document.body.appendChild(container);
+		const original = container.querySelector('#mixed-inline-style-static-branch') as HTMLElement;
+		expect(original.style.color).toBe('red');
+		const warnings = vi.spyOn(console, 'error').mockImplementation(() => {});
+		let root: ReturnType<typeof hydrateRoot> | undefined;
+
+		try {
+			root = hydrateRoot(container, client.App, { blue: true });
+			flushSync(() => {});
+			const replacement = container.querySelector(
+				'#mixed-inline-style-static-branch',
+			) as HTMLElement;
+			expect(replacement).not.toBe(original);
+			expect(replacement.style.color).toBe('blue');
+		} finally {
+			root?.unmount();
+			warnings.mockRestore();
+			container.remove();
+		}
+	});
+
+	it('hydrates mixed inline style across fragment siblings and nested SVG hosts', () => {
+		const source = `
+			export function App(props) @{
+				<>
+					<div id="mixed-inline-style-fragment-static" style={{ color: 'green' }}>
+						{'static'}
+					</div>
+					<div
+						id="mixed-inline-style-fragment-html"
+						style={{ position: 'absolute', color: props.color }}
+					>
+						{'dynamic'}
+					</div>
+					<svg id="mixed-inline-style-fragment-svg">
+						<rect
+							id="mixed-inline-style-fragment-rect"
+							style={{ fill: 'red', stroke: props.color }}
+						/>
+					</svg>
+				</>
+			}
+		`;
+		const id = 'mixed-inline-style-fragment-hydration.tsrx';
+		const server = loadMixedInlineStyle(source, id, 'server');
+		const client = loadMixedInlineStyle(source, id, 'client');
+		const container = document.createElement('div');
+		container.innerHTML = ServerRuntime.renderToString(server.App, { color: 'blue' }).html;
+		document.body.appendChild(container);
+		const sibling = container.querySelector('#mixed-inline-style-fragment-static') as HTMLElement;
+		const dynamic = container.querySelector('#mixed-inline-style-fragment-html') as HTMLElement;
+		const svg = container.querySelector('#mixed-inline-style-fragment-svg') as SVGElement;
+		const rect = container.querySelector('#mixed-inline-style-fragment-rect') as SVGElement;
+		let root: ReturnType<typeof hydrateRoot> | undefined;
+
+		try {
+			root = hydrateRoot(container, client.App, { color: 'blue' });
+			flushSync(() => {});
+			expect(container.querySelector('#mixed-inline-style-fragment-static')).toBe(sibling);
+			expect(container.querySelector('#mixed-inline-style-fragment-html')).toBe(dynamic);
+			expect(container.querySelector('#mixed-inline-style-fragment-svg')).toBe(svg);
+			expect(container.querySelector('#mixed-inline-style-fragment-rect')).toBe(rect);
+			expect(sibling.style.color).toBe('green');
+			expect(dynamic.style.position).toBe('absolute');
+			expect(dynamic.style.color).toBe('blue');
+			expect(rect.style.fill).toBe('red');
+			expect(rect.style.stroke).toBe('blue');
+
+			flushSync(() => root!.render(client.App, { color: 'purple' }));
+			expect(container.querySelector('#mixed-inline-style-fragment-static')).toBe(sibling);
+			expect(container.querySelector('#mixed-inline-style-fragment-html')).toBe(dynamic);
+			expect(container.querySelector('#mixed-inline-style-fragment-rect')).toBe(rect);
+			expect(sibling.style.color).toBe('green');
+			expect(dynamic.style.color).toBe('purple');
+			expect(rect.style.fill).toBe('red');
+			expect(rect.style.stroke).toBe('purple');
+		} finally {
+			root?.unmount();
+			container.remove();
+		}
+	});
+
+	it.each([
+		{ shape: 'a null dynamic value', value: null, suppressed: false },
+		{ shape: 'an undefined dynamic value', value: undefined, suppressed: false },
+		{ shape: 'a suppressed dynamic mismatch', value: null, suppressed: true },
+	])('hydrates mixed inline style with $shape', ({ shape, value, suppressed }) => {
+		const source = `
+			export function App(props) @{
+				<div
+					id="mixed-inline-style-mismatch"
+					${suppressed ? 'suppressHydrationWarning' : ''}
+					style={{ position: 'absolute', width: 120, color: props.color }}
+				>
+					{'mismatch'}
+				</div>
+			}
+		`;
+		const id = `mixed-inline-style-hydration-${shape.replaceAll(' ', '-')}.tsrx`;
+		const server = loadMixedInlineStyle(source, id, 'server');
+		const client = loadMixedInlineStyle(source, id, 'client');
+		const container = document.createElement('div');
+		container.innerHTML = ServerRuntime.renderToString(server.App, { color: 'red' }).html;
+		document.body.appendChild(container);
+		const element = container.querySelector('#mixed-inline-style-mismatch') as HTMLElement;
+		const warnings = vi.spyOn(console, 'error').mockImplementation(() => {});
+		let root: ReturnType<typeof hydrateRoot> | undefined;
+
+		try {
+			root = hydrateRoot(container, client.App, { color: value });
+			flushSync(() => {});
+			expect(container.querySelector('#mixed-inline-style-mismatch')).toBe(element);
+			expect(element.style.position).toBe('absolute');
+			expect(element.style.width).toBe('120px');
+			expect(element.style.color).toBe(suppressed ? 'red' : '');
+			if (suppressed) {
+				expect(
+					warnings.mock.calls.filter((args) => /hydrat|mismatch/i.test(String(args[0]))),
+				).toEqual([]);
+			}
+
+			flushSync(() => root!.render(client.App, { color: 'blue' }));
+			expect(container.querySelector('#mixed-inline-style-mismatch')).toBe(element);
+			expect(element.style.position).toBe('absolute');
+			expect(element.style.width).toBe('120px');
+			expect(element.style.color).toBe('blue');
+		} finally {
+			root?.unmount();
+			warnings.mockRestore();
+			container.remove();
+		}
 	});
 });
 


### PR DESCRIPTION
## Summary

- Specialize compiler-proven inline style objects containing a nonempty static prefix and exactly one dynamic property.
- Bake the static declarations into template HTML, retain the existing deferred evaluation order, and update only the changed dynamic CSS property without allocating a complete style object.
- Preserve exact development hydration behavior with narrowly scoped template-host metadata, including nested hosts, fragments, SVG, and genuinely static structural mismatches.
- Add a deterministic production Chromium style-work gate to the existing 1,000-row benchmark while keeping its returned-JSX fixture as an unchanged control.

Refs #673.

## Correctness and scope

The optimization fails closed for spreads, computed or duplicate CSS keys, accessors, reordered declarations, direct hydration suppression, and unsupported renderer paths. Existing behavior remains covered for shorthand/longhand ordering, initially absent longhands, CSS custom properties, numeric units, `!important`, null/boolean removal, SVG, source evaluation order, server rendering, hydration mismatch recovery, DOM adoption, and suspended-transition rollback.

Server output is unchanged. The returned-JSX benchmark source and production artifact remain byte-identical.

## Production benchmark

| Existing 1,000-row operation | Whole-style reconciliations before | Whole-style reconciliations after | Dynamic property writes after |
| --- | ---: | ---: | ---: |
| Mount | 1,000 | 0 | 1,000 |
| Select one row | 1,000 | 0 | 1 |
| Select another row | 1,000 | 0 | 2 |
| Unrelated update | 1,000 | 0 | 0 |

The static property is never rewritten. Same-source, production-minified Chromium measurements improved selection from **2.0 ms to 0.7 ms** and kept mount time at **2.8 ms**. The representative application grew **77 gzip bytes**; all 15 unrelated compiler-corpus entries and the returned-JSX control remained byte-identical.

## Validation

- [x] `./node_modules/.bin/vitest run --project octane --project octane-prod --silent=passed-only` — **804 files, 11,779 tests passed**.
- [x] `pnpm --config.verify-deps-before-run=false --config.enable-pre-post-scripts=false run typecheck` — full workspace passed.
- [x] Broad affected compiler, style, hydration, transitions, and conformance suites — **148 files, 2,693 tests passed**.
- [x] Focused public CSS/hydration/transition regressions — **50 cases passed** across development and production.
- [x] Existing real-Chromium style hydration suite — **2 tests passed**.
- [x] Production Chromium style-work gates for both the optimized TSRX fixture and unchanged returned-JSX control.
- [x] Frozen parsed AST, source-location assertions, server-output parity, codegen corpus, generic bundle reachability, formatting, and `pnpm --config.verify-deps-before-run=false sync`.

## Risk / follow-ups

The specialization deliberately covers a single dynamic property following safe static declarations. More complex object ordering and returned-JSX descriptor extraction continue through their existing paths.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches compiler lowering, runtime style updates, and dev hydration matching—areas where subtle CSS-order or SSR/client divergence bugs are possible, though the change fails closed and adds broad tests plus a production style-work gate.
> 
> **Overview**
> **Specializes** inline `style={{ …static literals…, dynamicProp }}` when the compiler can prove a nonempty static prefix and exactly one dynamic property: static CSS is baked into the template, and updates go through **`setStyleProperty`** instead of whole-object **`setStyle`**.
> 
> Unsafe shapes (spreads, computed keys, multiple dynamic props, etc.) still use the existing style diff path.
> 
> **Runtime and hydration** gain partial-style metadata on **`clone()`** so dev hydration compares the full computed style while tolerating template `style` attributes that only carry the static prefix; **`applyStyle`** / **`setStyleProperty`** merge the baked prefix with the dynamic value.
> 
> **Benchmarks:** the naive TSRX row fixture uses a mixed style (static `fontStyle` + dynamic `fontWeight`); **`bench:style-work`** is a Chromium gate that asserts per-property writes and zero whole-style reconciliations on the optimized path, with JSX as control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bdc9c68d1a64eabdcae68d1717a4a05d73a9d6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->