### PR TITLE
perf: add conservative binding dirty masks and immutable provenance

### DIFF
--- a/.changeset/conservative-binding-dirty-masks-and-immutable-provenance.md
+++ b/.changeset/conservative-binding-dirty-masks-and-immutable-provenance.md
@@ -1,0 +1,6 @@
+---
+'octane': patch
+---
+
+Cache proven immutable state-array filter projections and skip redundant
+single-token class updates while preserving controlled field restoration.

--- a/benchmarks/todomvc/README.md
+++ b/benchmarks/todomvc/README.md
@@ -64,3 +64,19 @@ uncontrolled edit fields, keyed todo identity, and DOM-only harness contract.
 node benchmarks/bench.mjs todomvc            # via the suite runner (starts servers)
 node benchmarks/bench.mjs --quick todomvc    # reduced smoke pass
 ```
+
+The untimed production-work gate also drives the existing Octane app through
+editing, filter changes, and immutable todo updates. Chromium precise coverage
+counts the original filter-predicate calls without changing array methods;
+browser mutation records verify that unchanged filter classes are not rewritten.
+Every interaction checks keyed row identity, the selected filter, footer counts,
+editor behavior, and controlled-checkbox restoration:
+
+```bash
+pnpm --filter octane-tsrx-todomvc exec vite build --minify false
+pnpm --filter octane-tsrx-todomvc preview
+pnpm --dir benchmarks/todomvc bench:work
+```
+
+`TARGET_URL` overrides the preview address, and `WORK_JSON` saves the measured
+counts. Normal TodoMVC timings continue to use the minified production build.

--- a/benchmarks/todomvc/package.json
+++ b/benchmarks/todomvc/package.json
@@ -6,6 +6,7 @@
   "description": "TodoMVC benchmark umbrella - drives each framework's TodoMVC app through Speedometer-style scripted interactions via Playwright.",
   "scripts": {
     "bench": "node run.mjs",
+    "bench:work": "node work.mjs",
     "bench:long": "node run.mjs 16"
   },
   "dependencies": {

--- a/benchmarks/todomvc/work.mjs
+++ b/benchmarks/todomvc/work.mjs
@@ -1,0 +1,264 @@
+// Deterministic production work for the existing TodoMVC application.
+// Chromium coverage observes its original filter predicates without wrapping
+// Array.prototype or adding source probes that could invalidate provenance.
+
+import fs from 'node:fs';
+import { chromium } from 'playwright';
+
+const URL = process.env.TARGET_URL || 'http://localhost:5240/';
+const TODOS = 100;
+const COMPLETED = 25;
+const ACTIVE = TODOS - COMPLETED;
+const METRICS = ['TodoApp', 'setCheckedCheckable', 'setClassAttr', 'setText'];
+const OPS = [
+	{
+		name: 'edit_start',
+		exact: {
+			TodoApp: 1,
+			filterPredicates: 0,
+			filterClassWrites: 0,
+			setCheckedCheckable: ACTIVE + 1,
+			setClassAttr: ACTIVE,
+			setText: 0,
+		},
+	},
+	{
+		name: 'edit_cancel',
+		exact: {
+			TodoApp: 1,
+			filterPredicates: 0,
+			filterClassWrites: 0,
+			setCheckedCheckable: ACTIVE + 1,
+			setClassAttr: ACTIVE,
+			setText: 0,
+		},
+	},
+	{
+		name: 'filter_completed',
+		exact: {
+			TodoApp: 1,
+			filterPredicates: TODOS,
+			filterClassWrites: 2,
+			setCheckedCheckable: COMPLETED + 1,
+			setClassAttr: COMPLETED + 2,
+			setText: 0,
+		},
+	},
+	{
+		name: 'toggle_active',
+		exact: {
+			TodoApp: 1,
+			filterPredicates: TODOS * 2,
+			filterClassWrites: 0,
+			setCheckedCheckable: 1,
+			setClassAttr: 0,
+			setText: 1,
+		},
+	},
+];
+
+async function countCalls(cdp, coverage) {
+	const counts = Object.fromEntries(METRICS.map((name) => [name, 0]));
+	counts.filterPredicates = 0;
+	for (const script of coverage.result) {
+		if (!script.url.includes('/assets/')) continue;
+		let source;
+		for (const fn of script.functions) {
+			const range = fn.ranges[0];
+			if (!range?.count) continue;
+			if (Object.prototype.hasOwnProperty.call(counts, fn.functionName)) {
+				counts[fn.functionName] += range.count;
+				continue;
+			}
+			if (fn.functionName !== '') continue;
+			source ??= (await cdp.send('Debugger.getScriptSource', { scriptId: script.scriptId }))
+				.scriptSource;
+			const body = source.slice(range.startOffset, range.endOffset);
+			if (/^\(?([\w$]+)\)?\s*=>\s*!?\1\.completed$/.test(body)) {
+				counts.filterPredicates += range.count;
+			}
+		}
+	}
+	if (counts.TodoApp !== 1) {
+		throw new Error('Missing named production call coverage; rebuild with vite --minify false.');
+	}
+	return counts;
+}
+
+async function prepare(page, operation) {
+	await page.goto(URL, { waitUntil: 'load' });
+	await page.waitForSelector('.new-todo', { timeout: 10_000 });
+	await page.evaluate(
+		({ name, total, completed }) => {
+			const input = document.querySelector('.new-todo');
+			for (let index = 0; index < total; index++) {
+				input.value = 'Todo ' + index;
+				input.dispatchEvent(
+					new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }),
+				);
+			}
+			const toggles = [...document.querySelectorAll('.todo-list .toggle')];
+			for (let index = 0; index < completed; index++) toggles[index * 4].click();
+			document.querySelector('.filters [data-filter="active"]').click();
+			if (document.querySelectorAll('.todo-list li').length !== total - completed) {
+				throw new Error('Expected the active TodoMVC list.');
+			}
+			if (name === 'edit_cancel') {
+				document
+					.querySelector('.todo-list li label')
+					.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+				document.querySelector('.edit').value = 'Uncommitted edit';
+			}
+		},
+		{ name: operation.name, total: TODOS, completed: COMPLETED },
+	);
+}
+
+async function measure(browser, operation) {
+	const context = await browser.newContext();
+	const page = await context.newPage();
+	const cdp = await context.newCDPSession(page);
+	let profiling = false;
+	try {
+		await cdp.send('Debugger.enable');
+		await cdp.send('Profiler.enable');
+		await cdp.send('Profiler.startPreciseCoverage', {
+			callCount: true,
+			detailed: true,
+			allowTriggeredUpdates: false,
+		});
+		profiling = true;
+		await prepare(page, operation);
+		await cdp.send('Profiler.takePreciseCoverage');
+		const observed = await page.evaluate(
+			({ name, active, completed }) => {
+				const previous = [...document.querySelectorAll('.todo-list li')];
+				const labels = new Map(
+					previous.map((row) => [row, row.querySelector('label').textContent]),
+				);
+				const filterObserver = new MutationObserver(() => {});
+				filterObserver.observe(document.querySelector('.filters'), {
+					attributes: true,
+					attributeFilter: ['class'],
+					subtree: true,
+				});
+				try {
+					if (name === 'edit_start') {
+						// Controlled values must be restored even when all derived inputs hold.
+						document.querySelector('.toggle-all').checked = true;
+						previous[0].querySelector('.toggle').checked = true;
+						previous[0]
+							.querySelector('label')
+							.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+					} else if (name === 'edit_cancel') {
+						document
+							.querySelector('.edit')
+							.dispatchEvent(
+								new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
+							);
+					} else if (name === 'filter_completed') {
+						document.querySelector('.filters [data-filter="completed"]').click();
+					} else {
+						previous[0].querySelector('.toggle').click();
+					}
+
+					const rows = [...document.querySelectorAll('.todo-list li')];
+					const nextFilter = name === 'filter_completed' ? 'completed' : 'active';
+					const count =
+						name === 'filter_completed' ? completed : active - Number(name === 'toggle_active');
+					if (rows.length !== count) throw new Error(`Expected ${count} rows, got ${rows.length}.`);
+					if (document.querySelector('.filters a.selected')?.dataset.filter !== nextFilter) {
+						throw new Error('The selected filter does not match the interaction.');
+					}
+					const expectedRemaining = active - Number(name === 'toggle_active');
+					if (
+						document.querySelector('.todo-count strong').textContent !== String(expectedRemaining)
+					) {
+						throw new Error('The remaining-todo count did not update.');
+					}
+					if (document.querySelector('.toggle-all').checked) {
+						throw new Error('The controlled toggle-all checkbox was not restored.');
+					}
+					if (name === 'edit_start') {
+						if (document.querySelector('.edit')?.value !== labels.get(previous[0])) {
+							throw new Error('The uncontrolled editor did not receive its original title.');
+						}
+						if (rows[0].querySelector('.toggle').checked) {
+							throw new Error('The controlled todo checkbox was not restored.');
+						}
+					} else if (document.querySelector('.edit') !== null) {
+						throw new Error('An obsolete editor survived the interaction.');
+					}
+					for (const row of rows) {
+						if (name !== 'filter_completed' && !labels.has(row)) {
+							throw new Error('A surviving todo lost its keyed DOM identity.');
+						}
+						if (labels.has(row) && row.querySelector('label').textContent !== labels.get(row)) {
+							throw new Error('An unchanged todo title was rewritten.');
+						}
+						if (row.classList.contains('completed') !== (nextFilter === 'completed')) {
+							throw new Error('A todo does not match the selected filter.');
+						}
+					}
+					return { filterClassWrites: filterObserver.takeRecords().length, rows: rows.length };
+				} finally {
+					filterObserver.disconnect();
+				}
+			},
+			{ name: operation.name, active: ACTIVE, completed: COMPLETED },
+		);
+		const coverage = await cdp.send('Profiler.takePreciseCoverage');
+		return { ...(await countCalls(cdp, coverage)), ...observed };
+	} finally {
+		if (profiling) {
+			await cdp.send('Profiler.stopPreciseCoverage').catch(() => {});
+			await cdp.send('Profiler.disable').catch(() => {});
+		}
+		await cdp.send('Debugger.disable').catch(() => {});
+		await context.close();
+	}
+}
+
+const browser = await chromium.launch({
+	headless: true,
+	args: ['--no-sandbox', '--js-flags=--jitless'],
+});
+const results = {};
+const failures = [];
+try {
+	for (const operation of OPS) {
+		const counts = await measure(browser, operation);
+		results[operation.name] = counts;
+		for (const [metric, expected] of Object.entries(operation.exact)) {
+			if (counts[metric] !== expected) {
+				failures.push(`${operation.name}.${metric}: ${counts[metric]} !== ${expected}`);
+			}
+		}
+	}
+} finally {
+	await browser.close();
+}
+
+console.log('Operation        | predicates | filter writes | checked | classes | text | rows');
+console.log('-----------------+------------+---------------+---------+---------+------+-----');
+for (const operation of OPS) {
+	const count = results[operation.name];
+	console.log(
+		`${operation.name.padEnd(16)} | ${String(count.filterPredicates).padStart(10)} | ${String(count.filterClassWrites).padStart(13)} | ${String(count.setCheckedCheckable).padStart(7)} | ${String(count.setClassAttr).padStart(7)} | ${String(count.setText).padStart(4)} | ${String(count.rows).padStart(4)}`,
+	);
+}
+
+if (process.env.WORK_JSON) {
+	fs.writeFileSync(
+		process.env.WORK_JSON,
+		JSON.stringify({ suite: 'todomvc-work', target: URL, results, failures }, null, '\t') + '\n',
+	);
+}
+
+if (failures.length > 0) {
+	console.error(`\n${failures.length} deterministic work gate failure(s):`);
+	for (const failure of failures) console.error(`  - ${failure}`);
+	process.exit(1);
+}
+
+console.log('\nAll deterministic TodoMVC work gates passed.');

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -215,7 +215,7 @@ assumption.
 ```tsx
 const labels = formatRows(rows); // Cached on [rows]: imported projection.
 const items = virtualizer.getVirtualItems(); // Not cached: member call.
-const visible = todos.filter((todo) => !todo.completed); // Not cached.
+const visible = todos.filter((todo) => !todo.completed); // Cached only for proven state snapshots.
 let freshLabels = formatRows(rows); // Not cached: `let` is an escape hatch.
 ```
 
@@ -225,9 +225,22 @@ of seeing a new array or object on every render.
 
 The same callee rule governs declaration caching. The virtualizer call must stay
 live because its window can move while the virtualizer object keeps the same
-identity. The `filter` call is a genuine optimization miss—the compiler cannot
-yet distinguish it from the live-object case—so both fail closed. Use an
-explicit `useMemo` when the identity matters.
+identity. Most member calls, including arbitrary `items.filter(...)` calls,
+therefore remain uncached.
+
+The production `.tsrx` compiler admits one narrow exception: a native `filter`
+projection over a state value created by a genuine `useState([])` call when every
+setter use remains private and produces a fresh, provably ordinary array
+snapshot. The predicate must only inspect an own data property, and a runtime
+guard verifies the array's dense entries, item properties, native methods,
+constructor, and species before reusing an unchanged snapshot. Unknown aliases,
+mutable receivers, getters, proxies, sparse arrays, overridden methods, custom
+species, and unproven predicates retain the existing live path. Use an explicit
+`useMemo` when an otherwise unsupported identity needs caching.
+
+Within the same proven component, a single-token class object driven by primitive
+state can reuse its existing per-binding change guard. Controlled `value` and
+`checked` bindings still reassert their values on every commit.
 
 Also never cached:
 

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -2398,7 +2398,358 @@ function rewriteAutoCallback(stmt, stable, componentLocals, ctx, invariant) {
 // reads (memoizing a value nothing renders only adds cells), and whose
 // dependencies are all component locals. Bodies that already went through Pass
 // A′ arrive with hook-shaped inits and are skipped.
-function rewriteAutoCalculation(stmt, componentLocals, renderReadNames, ctx) {
+function immutableArrayDatum(node, item, allowUpdates = true) {
+	node = unwrapTsExpr(node);
+	if (!node) return false;
+	if (node.type === 'Identifier' || node.type === 'Literal') return true;
+	if (node.type === 'UpdateExpression') return allowUpdates && node.argument?.type === 'Identifier';
+	if (node.type === 'UnaryExpression')
+		return node.operator === '!' && immutableArrayDatum(node.argument, item, allowUpdates);
+	if (node.type === 'BinaryExpression') {
+		return (
+			['===', '!=='].includes(node.operator) &&
+			immutableArrayDatum(node.left, item, allowUpdates) &&
+			immutableArrayDatum(node.right, item, allowUpdates)
+		);
+	}
+	if (node.type === 'LogicalExpression') {
+		return (
+			immutableArrayDatum(node.left, item, allowUpdates) &&
+			immutableArrayDatum(node.right, item, allowUpdates)
+		);
+	}
+	if (node.type === 'ConditionalExpression') {
+		return (
+			immutableArrayDatum(node.test, item, allowUpdates) &&
+			immutableArrayDatum(node.consequent, item, allowUpdates) &&
+			immutableArrayDatum(node.alternate, item, allowUpdates)
+		);
+	}
+	return (
+		node.type === 'MemberExpression' &&
+		!node.optional &&
+		!node.computed &&
+		node.object?.type === 'Identifier' &&
+		node.object.name === item &&
+		node.property?.type === 'Identifier' &&
+		node.property.name !== 'current'
+	);
+}
+
+function immutableArrayRecord(node, item) {
+	if (node?.type !== 'ObjectExpression') return false;
+	for (const property of node.properties || []) {
+		if (property.type === 'SpreadElement') {
+			if (
+				item === null ||
+				property.argument?.type !== 'Identifier' ||
+				property.argument.name !== item
+			)
+				return false;
+			continue;
+		}
+		if (
+			(property.type !== 'Property' && property.type !== 'ObjectProperty') ||
+			property.computed ||
+			property.method ||
+			(property.kind !== undefined && property.kind !== 'init')
+		)
+			return false;
+		const key = property.key;
+		if (key?.type !== 'Identifier' && !(key?.type === 'Literal' && typeof key.value === 'string'))
+			return false;
+		if ((key.type === 'Identifier' ? key.name : key.value) === '__proto__') return false;
+		if (!immutableArrayDatum(property.value, item)) return false;
+	}
+	return true;
+}
+
+function immutableArrayResult(node, previous) {
+	node = unwrapTsExpr(node);
+	if (node?.type === 'ArrayExpression') {
+		return node.elements.every(
+			(element) =>
+				element !== null &&
+				(element.type === 'SpreadElement'
+					? previous !== null &&
+						element.argument?.type === 'Identifier' &&
+						element.argument.name === previous
+					: immutableArrayRecord(element, null)),
+		);
+	}
+	if (
+		previous === null ||
+		node?.type !== 'CallExpression' ||
+		node.optional ||
+		node.arguments.length !== 1
+	)
+		return false;
+	const callee = node.callee;
+	if (
+		callee?.type !== 'MemberExpression' ||
+		callee.optional ||
+		callee.computed ||
+		callee.object?.type !== 'Identifier' ||
+		callee.object.name !== previous ||
+		callee.property?.type !== 'Identifier' ||
+		!['map', 'filter'].includes(callee.property.name)
+	)
+		return false;
+	const callback = unwrapTsExpr(node.arguments[0]);
+	if (
+		callback?.type !== 'ArrowFunctionExpression' ||
+		callback.async ||
+		callback.params?.length !== 1 ||
+		callback.params[0]?.type !== 'Identifier'
+	)
+		return false;
+	const item = callback.params[0].name;
+	const body = unwrapTsExpr(callback.body);
+	if (callee.property.name === 'filter') return immutableArrayDatum(body, item);
+	if (body?.type === 'ConditionalExpression') {
+		return (
+			immutableArrayDatum(body.test, item) &&
+			[body.consequent, body.alternate].every(
+				(arm) =>
+					(arm?.type === 'Identifier' && arm.name === item) || immutableArrayRecord(arm, item),
+			)
+		);
+	}
+	return immutableArrayRecord(body, item);
+}
+
+function immutableStateSetterCall(call, setter) {
+	if (
+		call?.type !== 'CallExpression' ||
+		call.optional ||
+		call.callee?.type !== 'Identifier' ||
+		call.callee.name !== setter ||
+		call.arguments.length !== 1
+	)
+		return false;
+	const argument = unwrapTsExpr(call.arguments[0]);
+	if (argument?.type === 'ArrayExpression') return immutableArrayResult(argument, null);
+	if (
+		argument?.type !== 'ArrowFunctionExpression' ||
+		argument.async ||
+		argument.params?.length !== 1 ||
+		argument.params[0]?.type !== 'Identifier'
+	)
+		return false;
+	return immutableArrayResult(argument.body, argument.params[0].name);
+}
+
+function collectImmutableStateProvenance(statements, jsxNodes, ctx) {
+	const arrays = new Map();
+	const primitives = new Set();
+	for (const statement of statements) {
+		if (statement.type !== 'VariableDeclaration' || statement.kind !== 'const') continue;
+		for (const declaration of statement.declarations || []) {
+			const init = unwrapTsExpr(declaration.init);
+			if (
+				init?.type !== 'CallExpression' ||
+				init.callee?.type !== 'Identifier' ||
+				ctx.octaneImportLocals?.get(init.callee.name) !== 'useState' ||
+				stableHookCallName(init) !== 'useState' ||
+				init.arguments.length !== 1 ||
+				declaration.id?.type !== 'ArrayPattern' ||
+				declaration.id.elements?.length !== 2 ||
+				declaration.id.elements.some((element) => element?.type !== 'Identifier')
+			)
+				continue;
+			const [value, setter] = declaration.id.elements;
+			const initial = unwrapTsExpr(init.arguments[0]);
+			if (initial?.type === 'ArrayExpression' && initial.elements.length === 0) {
+				arrays.set(value.name, { setter: setter.name, declaration });
+			} else if (
+				initial?.type === 'Literal' &&
+				(initial.value === null || ['string', 'number', 'boolean'].includes(typeof initial.value))
+			) {
+				primitives.add(value.name);
+			}
+		}
+	}
+	for (const [state, candidate] of arrays) {
+		let safe = true;
+		const visited = new WeakSet();
+		const derived = new Map();
+		for (const statement of statements) {
+			if (statement.type !== 'VariableDeclaration' || statement.kind !== 'const') continue;
+			for (const declaration of statement.declarations || []) {
+				if (declaration.id?.type !== 'Identifier') continue;
+				const initial = unwrapTsExpr(declaration.init);
+				if (
+					initial?.type === 'MemberExpression' &&
+					!initial.computed &&
+					initial.property?.name === 'length'
+				)
+					continue;
+				if (immutableArrayProjection(initial, { arrays })?.receiver === state) {
+					derived.set(declaration.id.name, declaration);
+				}
+			}
+		}
+		function visit(node, parent = null, key = null, grandparent = null) {
+			if (!safe || node === null || typeof node !== 'object') return;
+			if (Array.isArray(node)) {
+				for (const child of node) visit(child, parent, key, grandparent);
+				return;
+			}
+			if (visited.has(node)) return;
+			visited.add(node);
+			if (node.type === 'Identifier') {
+				if (node.name === candidate.setter) {
+					if (parent === candidate.declaration.id) return;
+					if (
+						parent?.type !== 'CallExpression' ||
+						key !== 'callee' ||
+						!immutableStateSetterCall(parent, candidate.setter)
+					)
+						safe = false;
+				} else if (node.name === state) {
+					if (parent === candidate.declaration.id) return;
+					if (
+						parent?.type === 'MemberExpression' &&
+						key === 'object' &&
+						!parent.computed &&
+						parent.property?.type === 'Identifier'
+					) {
+						if (parent.property.name === 'length') return;
+						if (
+							parent.property.name === 'filter' &&
+							grandparent?.type === 'CallExpression' &&
+							grandparent.callee === parent &&
+							immutableArrayProjection(grandparent, { arrays })?.receiver === state
+						)
+							return;
+					}
+					if (
+						parent?.type === 'ConditionalExpression' &&
+						(key === 'consequent' || key === 'alternate') &&
+						immutableArrayProjection(parent, { arrays })?.receiver === state
+					)
+						return;
+					safe = false;
+				} else if (derived.has(node.name)) {
+					if (parent === derived.get(node.name) && key === 'id') return;
+					if (parent?.type === 'JSXForExpression' && key === 'right') return;
+					if (
+						parent?.type === 'MemberExpression' &&
+						key === 'object' &&
+						!parent.computed &&
+						parent.property?.name === 'length'
+					)
+						return;
+					safe = false;
+				}
+				return;
+			}
+			if (node !== candidate.declaration && node.type === 'VariableDeclarator') {
+				const names = new Set();
+				collectBindings(node.id, names);
+				if (names.has(state) || names.has(candidate.setter)) {
+					safe = false;
+					return;
+				}
+			}
+			if (FN_TYPES.has(node.type)) {
+				const names = new Set();
+				for (const parameter of node.params || []) collectBindings(parameter, names);
+				if (names.has(state) || names.has(candidate.setter)) {
+					safe = false;
+					return;
+				}
+			}
+			for (const field in node) {
+				if (AST_WALK_SKIP_KEYS.has(field)) continue;
+				if (
+					(node.type === 'Property' || node.type === 'ObjectProperty') &&
+					field === 'key' &&
+					!node.computed
+				)
+					continue;
+				if (node.type === 'MemberExpression' && field === 'property' && !node.computed) continue;
+				visit(node[field], node, field, parent);
+			}
+		}
+		visit(statements);
+		visit(jsxNodes);
+		if (!safe) arrays.delete(state);
+	}
+	return arrays.size === 0 ? null : { arrays, primitives };
+}
+
+function immutableArrayProjection(node, provenance) {
+	if (provenance === null) return null;
+	let found = null;
+	function walk(value) {
+		value = unwrapTsExpr(value);
+		if (!value) return false;
+		if (value.type === 'ConditionalExpression') {
+			return (
+				walk(value.consequent) &&
+				walk(value.alternate) &&
+				immutableArrayDatum(value.test, null, false)
+			);
+		}
+		if (value.type === 'Identifier') return provenance.arrays.has(value.name);
+		if (
+			value.type === 'MemberExpression' &&
+			!value.computed &&
+			!value.optional &&
+			value.property?.name === 'length'
+		) {
+			return walk(value.object);
+		}
+		if (value.type !== 'CallExpression' || value.optional || value.arguments.length !== 1)
+			return false;
+		const member = value.callee;
+		if (
+			member?.type !== 'MemberExpression' ||
+			member.computed ||
+			member.optional ||
+			member.object?.type !== 'Identifier' ||
+			member.property?.name !== 'filter' ||
+			!provenance.arrays.has(member.object.name)
+		)
+			return false;
+		const predicate = unwrapTsExpr(value.arguments[0]);
+		if (
+			predicate?.type !== 'ArrowFunctionExpression' ||
+			predicate.async ||
+			predicate.params?.length !== 1 ||
+			predicate.params[0]?.type !== 'Identifier'
+		)
+			return false;
+		let body = unwrapTsExpr(predicate.body);
+		if (body?.type === 'UnaryExpression' && body.operator === '!')
+			body = unwrapTsExpr(body.argument);
+		if (
+			body?.type !== 'MemberExpression' ||
+			body.computed ||
+			body.optional ||
+			body.object?.type !== 'Identifier' ||
+			body.object.name !== predicate.params[0].name ||
+			body.property?.type !== 'Identifier' ||
+			body.property.name === 'current'
+		)
+			return false;
+		const proof = { receiver: member.object.name, property: body.property.name };
+		if (found !== null && (found.receiver !== proof.receiver || found.property !== proof.property))
+			return false;
+		found = proof;
+		return true;
+	}
+	return walk(node) && found !== null ? found : null;
+}
+
+function rewriteAutoCalculation(
+	stmt,
+	componentLocals,
+	renderReadNames,
+	ctx,
+	immutableStates = null,
+) {
 	if (stmt.type !== 'VariableDeclaration' || stmt.kind !== 'const') return stmt;
 	if (stmt.declarations?.length !== 1) return stmt;
 	const decl = stmt.declarations[0];
@@ -2410,7 +2761,8 @@ function rewriteAutoCalculation(stmt, componentLocals, renderReadNames, ctx) {
 	if (!isPropCreationExpr(init, ctx)) return stmt;
 	// Every call reached during render must be a proven value projection — the
 	// same admission the region cache uses. A member call fails closed.
-	if (containsRenderCall([init], ctx)) return stmt;
+	const immutableProjection = immutableArrayProjection(init, immutableStates);
+	if (immutableProjection === null && containsRenderCall([init], ctx)) return stmt;
 	const deps = [];
 	const seen = new Set();
 	for (const name of collectFreeIdentifiers(init, [])) {
@@ -2439,7 +2791,13 @@ function rewriteAutoCalculation(stmt, componentLocals, renderReadNames, ctx) {
 				...decl,
 				init: inheritOriginLoc(
 					b.call(
-						{ ...b.id('useMemo'), _octaneGenerated: true },
+						{
+							...b.id('useMemo'),
+							_octaneGenerated: true,
+							...(immutableProjection === null
+								? null
+								: { _octaneImmutableArrayFilter: immutableProjection }),
+						},
 						b.arrow([], init),
 						b.array(deps.map((n) => b.id(n))),
 					),
@@ -7590,6 +7948,7 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 		nextHookMemoCacheId: 0, // unique non-index slots property per compiled render function
 		currentInvariantLocals: null, // Set<string> of component-lifetime-stable local values
 		currentEventInvariantLocals: null, // Set<string> safe to retain in native event slots
+		currentDirtyBindingStates: null, // proven primitive state identities inherited by JSX arms
 		currentBodyIsComponentScope: false, // planning the component body itself, not a nested arm
 		currentProfileComponentId: null,
 		knownStringLocals: null, // Set<string> of provably-string locals (text-hole inference)
@@ -12152,6 +12511,19 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 	let workingStatements = statements;
 	let mountCallbackSinks = new Map();
 	let bodyInvariantLocals = null;
+	const immutableStateProvenance =
+		options?.autoCallback === true &&
+		!returnedOutput &&
+		ctx.autoMemo === true &&
+		ctx.inlineHookMemo === true &&
+		ctx.mode !== 'server' &&
+		!ctx.dev &&
+		!ctx.hmr &&
+		!ctx.profile &&
+		ctx._universalRuntimeUnit == null
+			? collectImmutableStateProvenance(statements, jsxNodes, ctx)
+			: null;
+	let hasImmutableArrayProjection = false;
 	if (options && options.autoCallback && ctx.currentComponentLocals) {
 		const stableSet = computeStableLocals(statements, ctx.currentComponentLocals);
 		bodyInvariantLocals = computeInvariantLocals(statements, ctx.currentComponentLocals, true);
@@ -12224,7 +12596,14 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 						ctx.currentComponentLocals,
 						renderReadNames,
 						ctx,
+						immutableStateProvenance,
 					);
+					if (
+						rewritten !== statement &&
+						rewritten.declarations[0].init.callee._octaneImmutableArrayFilter !== undefined
+					) {
+						hasImmutableArrayProjection = true;
+					}
 					if (ctx.autoMemo && rewritten !== statement) {
 						(autoCalculatedDeclarations ??= new Map()).set(
 							statement.declarations[0].id.name,
@@ -12303,6 +12682,10 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 	// Nested hoisted helpers derive a filtered inherited set in hoistBodyHelper.
 	const prevInvariantLocals = ctx.currentInvariantLocals;
 	const prevEventInvariantLocals = ctx.currentEventInvariantLocals;
+	const prevDirtyBindingStates = ctx.currentDirtyBindingStates;
+	if (hasImmutableArrayProjection) {
+		ctx.currentDirtyBindingStates = immutableStateProvenance.primitives;
+	}
 	const invariantLocals = new Set(prevInvariantLocals || []);
 	const eventInvariantLocals = new Set(prevEventInvariantLocals || []);
 	if (ctx.currentComponentLocals) {
@@ -12383,6 +12766,7 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 	}
 	ctx.currentInvariantLocals = prevInvariantLocals;
 	ctx.currentEventInvariantLocals = prevEventInvariantLocals;
+	ctx.currentDirtyBindingStates = prevDirtyBindingStates;
 	ctx.currentBodyIsComponentScope = prevBodyIsComponentScope;
 	ctx._inheritBody = prevInheritBody;
 	ctx._fnOrigin = prevFnOrigin;
@@ -13010,6 +13394,49 @@ function isFreshBindingExpr(node) {
 		value?.type === 'ArrayExpression' ||
 		value?.type === 'ArrowFunctionExpression' ||
 		value?.type === 'FunctionExpression'
+	);
+}
+
+// One plain clsx token is equivalent to its conditional string. Keeping that
+// string in the existing binding cell supplies an exact dependency dirty mask
+// without skipping controlled fields, observing getters, or allocating objects.
+function scalarStateClass(node, ctx) {
+	if (
+		ctx.currentDirtyBindingStates == null ||
+		node?.type !== 'ObjectExpression' ||
+		node.properties?.length !== 1
+	)
+		return null;
+	const property = node.properties[0];
+	if (
+		(property?.type !== 'Property' && property?.type !== 'ObjectProperty') ||
+		property.computed ||
+		property.method ||
+		(property.kind !== undefined && property.kind !== 'init')
+	)
+		return null;
+	const key = property.key;
+	if (key?.type !== 'Identifier' && !(key?.type === 'Literal' && typeof key.value === 'string'))
+		return null;
+	const token = key.type === 'Identifier' ? key.name : key.value;
+	if (token === '' || token === '__proto__') return null;
+	const condition = unwrapTsExpr(property.value);
+	if (condition?.type !== 'BinaryExpression' || !['===', '!=='].includes(condition.operator))
+		return null;
+	const left = unwrapTsExpr(condition.left);
+	const right = unwrapTsExpr(condition.right);
+	const state = left?.type === 'Identifier' ? left : right?.type === 'Identifier' ? right : null;
+	const literal = state === left ? right : left;
+	if (
+		state === null ||
+		!ctx.currentDirtyBindingStates.has(state.name) ||
+		literal?.type !== 'Literal' ||
+		!(literal.value === null || ['string', 'number', 'boolean'].includes(typeof literal.value))
+	)
+		return null;
+	return inheritOriginLoc(
+		b.conditional(condition, inheritOriginLoc(b.literal(token), key), b.literal('')),
+		node,
 	);
 }
 
@@ -14845,6 +15272,7 @@ function authoredHookMemoOf(stmt) {
 		kind: stmt.kind,
 		fn,
 		deps,
+		immutableArrayFilter: callee._octaneImmutableArrayFilter ?? null,
 		generatedInvariant:
 			name === 'useCallback' &&
 			callee._octaneGenerated === true &&
@@ -14978,6 +15406,21 @@ function lowerAuthoredHookMemo(stmt, ctx) {
 			'||',
 			missTest,
 			b.unary('!', hkObjectIs(cellRef(base + 1 + i), b.id(hookMemoTemp(ctx, i)))),
+		);
+	}
+	if (entry.immutableArrayFilter !== null) {
+		const { receiver, property } = entry.immutableArrayFilter;
+		missTest = b.logical(
+			'||',
+			missTest,
+			b.unary(
+				'!',
+				b.call(
+					requireRuntimeForContext(ctx, 'compilerCacheImmutableArrayFilter'),
+					b.id(receiver),
+					b.literal(property),
+				),
+			),
 		);
 	}
 	const missBody = [...hookMemoComputeStatements(entry, ctx, valueCell())];
@@ -22118,13 +22561,14 @@ function emitElementHtml(
 			}
 		} else if (attrName === 'class') {
 			// (`className` was already normalized to `class` above.)
+			const scalar = firstSpreadIdx === -1 ? scalarStateClass(inner, ctx) : null;
 			bindings.push({
 				id: bindings.length,
 				kind: 'class',
-				expr,
+				expr: scalar === null ? expr : tsrxExprNode(scalar, ctx, componentName, inlinedSubs),
 				path,
 				ns: hostNs,
-				fresh: isFreshBindingExpr(inner),
+				fresh: scalar === null && isFreshBindingExpr(inner),
 				nameOrigin: attr.name,
 			});
 		} else if (

--- a/packages/octane/src/index.ts
+++ b/packages/octane/src/index.ts
@@ -202,6 +202,7 @@ export {
 	componentSlotVoid,
 	componentSlotLite,
 	compilerCacheArray,
+	compilerCacheImmutableArrayFilter,
 	compilerCacheMappedArray,
 	compilerCacheContext,
 	compilerOwnsContextProvider,

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -18451,6 +18451,7 @@ function isPortalTarget(block: Block, domParent: Node): boolean {
 }
 
 const NATIVE_ARRAY_MAP = Array.prototype.map;
+const NATIVE_ARRAY_FILTER = /* @__PURE__ */ (() => Array.prototype.filter)();
 const NATIVE_REFLECT_APPLY = Reflect.apply;
 const NATIVE_ARRAY_SPECIES_GETTER = Object.getOwnPropertyDescriptor(Array, Symbol.species)?.get;
 // Components hand the reconciler immutable array snapshots. Memoizing indexed
@@ -18462,6 +18463,7 @@ const NATIVE_ARRAY_ACCESSORS = new WeakMap<
 	object,
 	{ length: number; accessor: boolean; renderable?: boolean }
 >();
+let IMMUTABLE_FILTER_ARRAYS: WeakMap<object, Map<string, number>> | undefined;
 
 /**
  * Compiler ABI for a safely reusable value-position array. A plain dense array
@@ -18525,6 +18527,58 @@ export function compilerCacheArray(value: unknown, previous: unknown): boolean {
 	// record and still needs its accessor verdict to cover every array index.
 	NATIVE_ARRAY_ACCESSORS.set(value, { length, accessor, renderable });
 	return renderable;
+}
+
+/**
+ * Reuse a native filter projection from a compiler-proven state snapshot.
+ *
+ * Generated code calls this only after its ordinary dependency comparisons
+ * prove a possible cache hit, so fresh snapshots never pay a classification
+ * scan. Intrinsics are rechecked on every hit without invoking user getters;
+ * dense array entries and the predicate's own data property are inspected
+ * once per immutable snapshot and property.
+ * @internal
+ */
+export function compilerCacheImmutableArrayFilter(value: unknown, property: string): boolean {
+	if (
+		Object.getOwnPropertyDescriptor(Array.prototype, 'filter')?.value !== NATIVE_ARRAY_FILTER ||
+		Object.getOwnPropertyDescriptor(Array.prototype, 'map')?.value !== NATIVE_ARRAY_MAP ||
+		Object.getOwnPropertyDescriptor(Array.prototype, 'constructor')?.value !== Array ||
+		Object.getOwnPropertyDescriptor(Array, Symbol.species)?.get !== NATIVE_ARRAY_SPECIES_GETTER ||
+		!Array.isArray(value) ||
+		Object.getPrototypeOf(value) !== Array.prototype ||
+		hasOwnProp.call(value, 'filter') ||
+		hasOwnProp.call(value, 'map') ||
+		hasOwnProp.call(value, 'constructor')
+	) {
+		return false;
+	}
+
+	const length = value.length;
+	let properties = IMMUTABLE_FILTER_ARRAYS?.get(value);
+	if (properties?.get(property) === length) return true;
+
+	for (let index = 0; index < length; index++) {
+		const entry = Object.getOwnPropertyDescriptor(value, index);
+		if (entry === undefined || entry.get !== undefined || entry.set !== undefined) return false;
+		const item = entry.value;
+		if (
+			item === null ||
+			typeof item !== 'object' ||
+			Object.getPrototypeOf(item) !== Object.prototype
+		) {
+			return false;
+		}
+		const member = Object.getOwnPropertyDescriptor(item, property);
+		if (member === undefined || member.get !== undefined || member.set !== undefined) return false;
+	}
+
+	if (properties === undefined) {
+		properties = new Map();
+		(IMMUTABLE_FILTER_ARRAYS ??= new WeakMap()).set(value, properties);
+	}
+	properties.set(property, length);
+	return true;
 }
 
 /**

--- a/packages/octane/tests/auto-memo.test.ts
+++ b/packages/octane/tests/auto-memo.test.ts
@@ -165,6 +165,630 @@ function loadReturnedProviderComponentMapFixture() {
 	});
 }
 
+const STATE_FILTER_SOURCE = `
+	import { useState } from 'octane';
+
+	export function App(props) @{
+		const [todos, setTodos] = useState([]);
+		const [filter, setFilter] = useState('all');
+		const [editing, setEditing] = useState(false);
+		const visible = filter === 'active'
+			? todos.filter((todo) => !todo.completed)
+			: filter === 'completed'
+				? todos.filter((todo) => todo.completed)
+				: todos;
+		const remaining = todos.filter((todo) => !todo.completed).length;
+
+		<section id="state-filter-app" data-editing={editing ? 'yes' : 'no'}>
+			<button
+				id="state-filter-load"
+				onClick={() => setTodos([
+					{ id: 1, label: 'first', completed: false },
+					{ id: 2, label: 'second', completed: true },
+				])}
+			>{'load'}</button>
+			<button id="state-filter-edit" onClick={() => setEditing(!editing)}>{'edit'}</button>
+			<button
+				id="state-filter-replace"
+				onClick={() => setTodos((current) => current.map((todo) => todo.id === 1
+					? { ...todo, label: 'updated', completed: true }
+					: todo))}
+			>{'replace'}</button>
+			<button
+				id="state-filter-add"
+				onClick={() => setTodos((current) => [
+					...current,
+					{ id: 3, label: 'third', completed: false },
+				])}
+			>{'add'}</button>
+			<button
+				id="state-filter-all"
+				class={{ selected: filter === 'all' }}
+				onClick={() => setFilter('all')}
+			>{'all'}</button>
+			<button
+				id="state-filter-active"
+				class={{ selected: filter === 'active' }}
+				onClick={() => setFilter('active')}
+			>{'active'}</button>
+			<button
+				id="state-filter-completed"
+				class={{ selected: filter === 'completed' }}
+				onClick={() => setFilter('completed')}
+			>{'completed'}</button>
+			<input id="state-filter-value" value={props.value} onInput={() => {}} />
+			<input
+				id="state-filter-toggle-all"
+				type="checkbox"
+				checked={remaining === 0}
+				onClick={() => {}}
+			/>
+			<output id="state-filter-remaining">{'' + remaining}</output>
+			<ul id="state-filter-rows">
+				@for (const todo of visible; key todo.id) {
+					<li class={{ editing: editing && todo.id === 1 }} data-id={todo.id}>
+						<input
+							class="state-filter-row-check"
+							type="checkbox"
+							checked={todo.completed}
+							onClick={() => {}}
+						/>
+						<span>{todo.label as string}</span>
+					</li>
+				}
+			</ul>
+		</section>
+	}
+`;
+
+function loadStateFilterFixture(source = STATE_FILTER_SOURCE, id = 'state-filter-provenance.tsrx') {
+	return loadCompiledFixtureSource(source, {
+		id,
+		mode: 'client',
+		compileOptions: { hmr: false, dev: false },
+	});
+}
+
+describe('state-derived collections and independent host bindings', () => {
+	it('keeps filtered state, keyed rows, filter classes, and controlled fields synchronized', () => {
+		const client = loadStateFilterFixture();
+		const root = mount(client.App, { value: 'locked' });
+
+		try {
+			expect(root.find('#state-filter-remaining').textContent).toBe('0');
+			root.click('#state-filter-load');
+			const first = root.find('#state-filter-rows li');
+			const input = root.find('#state-filter-value') as HTMLInputElement;
+			const toggleAll = root.find('#state-filter-toggle-all') as HTMLInputElement;
+			const firstToggle = root.find('.state-filter-row-check') as HTMLInputElement;
+			expect(root.find('#state-filter-remaining').textContent).toBe('1');
+			expect(first.textContent).toBe('first');
+			expect(input.value).toBe('locked');
+			expect(toggleAll.checked).toBe(false);
+			expect(firstToggle.checked).toBe(false);
+
+			input.value = 'drifted';
+			toggleAll.checked = true;
+			firstToggle.checked = true;
+			root.click('#state-filter-edit');
+			expect(root.find('#state-filter-rows li')).toBe(first);
+			expect(root.find('#state-filter-app').getAttribute('data-editing')).toBe('yes');
+			expect(input.value).toBe('locked');
+			expect(toggleAll.checked).toBe(false);
+			expect(firstToggle.checked).toBe(false);
+			expect(root.find('#state-filter-all').className).toBe('selected');
+
+			root.click('#state-filter-active');
+			expect(root.findAll('#state-filter-rows li')).toEqual([first]);
+			expect(root.find('#state-filter-active').className).toBe('selected');
+			expect(root.find('#state-filter-all').className).toBe('');
+
+			root.click('#state-filter-completed');
+			expect(root.find('#state-filter-rows li').textContent).toBe('second');
+			expect(root.find('#state-filter-completed').className).toBe('selected');
+			expect(root.find('#state-filter-active').className).toBe('');
+
+			root.click('#state-filter-all');
+			const restoredFirst = root.find('#state-filter-rows li');
+			root.click('#state-filter-replace');
+			expect(root.find('#state-filter-rows li')).toBe(restoredFirst);
+			expect(restoredFirst.textContent).toBe('updated');
+			expect(root.find('#state-filter-remaining').textContent).toBe('0');
+			expect(toggleAll.checked).toBe(true);
+
+			root.click('#state-filter-active');
+			expect(root.findAll('#state-filter-rows li')).toEqual([]);
+			root.click('#state-filter-add');
+			expect(root.find('#state-filter-rows li').textContent).toBe('third');
+			expect(root.find('#state-filter-remaining').textContent).toBe('1');
+			expect(toggleAll.checked).toBe(false);
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('observes an Array.prototype.filter override installed after a state snapshot mounts', () => {
+		const client = loadStateFilterFixture();
+		const root = mount(client.App, { value: 'locked' });
+		root.click('#state-filter-load');
+		root.click('#state-filter-active');
+		const original = Array.prototype.filter;
+		const events: string[] = [];
+
+		try {
+			Array.prototype.filter = function <Item, Result extends Item>(
+				this: Item[],
+				predicate: (value: Item, index: number, array: Item[]) => value is Result,
+				thisArg?: unknown,
+			): Result[] {
+				const first = this[0] as { id?: number; label?: string } | undefined;
+				if (this.length === 2 && first?.id === 1 && first.label === 'first') {
+					events.push('filter');
+					return [this[1]!] as Result[];
+				}
+				return original.call(this, predicate, thisArg) as Result[];
+			};
+
+			root.click('#state-filter-edit');
+			expect(events).toEqual(['filter', 'filter']);
+			expect(root.find('#state-filter-rows li').textContent).toBe('second');
+			expect(root.find('#state-filter-remaining').textContent).toBe('1');
+		} finally {
+			Array.prototype.filter = original;
+			root.unmount();
+		}
+	});
+
+	it('honors an Array.prototype.map override when a state updater creates its next snapshot', () => {
+		const client = loadStateFilterFixture();
+		const root = mount(client.App, { value: 'locked' });
+		root.click('#state-filter-load');
+		const original = Array.prototype.map;
+		const events: string[] = [];
+
+		try {
+			Array.prototype.map = function <Item, Result>(
+				this: Item[],
+				callback: (value: Item, index: number, array: Item[]) => Result,
+				thisArg?: unknown,
+			): Result[] {
+				const first = this[0] as { id?: number; label?: string } | undefined;
+				if (this.length === 2 && first?.id === 1 && first.label === 'first') {
+					events.push('map');
+					return [{ id: 1, label: 'mapped override', completed: false }, this[1]] as Result[];
+				}
+				return original.call(this, callback, thisArg) as Result[];
+			};
+
+			root.click('#state-filter-replace');
+			expect(events).toEqual(['map']);
+			expect(root.find('#state-filter-rows li').textContent).toBe('mapped override');
+			expect(root.find('#state-filter-remaining').textContent).toBe('1');
+
+			root.click('#state-filter-edit');
+			expect(root.find('#state-filter-rows li').textContent).toBe('mapped override');
+			expect(root.find('#state-filter-remaining').textContent).toBe('1');
+		} finally {
+			Array.prototype.map = original;
+			root.unmount();
+		}
+	});
+
+	it.each([
+		'own filter getter',
+		'inherited filter getter',
+		'sparse indexed getter',
+		'item completed getter',
+		'custom array species',
+		'proxy receiver',
+	] as const)('preserves observable state-array behavior for an %s', (shape) => {
+		const source = `
+			import { useState } from 'octane';
+
+			export function App(props) @{
+				const [todos, setTodos] = useState([]);
+				const [tick, setTick] = useState(0);
+				const remaining = todos.filter((todo) => !todo.completed).length;
+				<section>
+					<button id="state-filter-unsafe-load" onClick={() => setTodos(props.items)}>
+						{'load'}
+					</button>
+					<button id="state-filter-unsafe-update" onClick={() => setTick(tick + 1)}>
+						{tick as number}
+					</button>
+					<output id="state-filter-unsafe-remaining">{'' + remaining}</output>
+				</section>
+			}
+		`;
+		const client = loadStateFilterFixture(source, `state-filter-unsafe-${shape}.tsrx`);
+		const events: string[] = [];
+		let completed = false;
+		const item: { id: number; completed: boolean } = { id: 1, completed: false };
+		let items: Array<typeof item> = [item];
+		let expectedEvents: string[];
+
+		if (shape === 'own filter getter' || shape === 'inherited filter getter') {
+			const owner = shape === 'own filter getter' ? items : Object.create(Array.prototype);
+			Object.defineProperty(owner, 'filter', {
+				configurable: true,
+				get() {
+					events.push('get:filter');
+					return function (
+						this: typeof items,
+						predicate: (value: typeof item, index: number, values: typeof items) => unknown,
+					) {
+						events.push('call:filter');
+						return Array.prototype.filter.call(this, predicate);
+					};
+				},
+			});
+			if (shape === 'inherited filter getter') Object.setPrototypeOf(items, owner);
+			expectedEvents = ['get:filter', 'call:filter'];
+		} else if (shape === 'sparse indexed getter') {
+			items = [];
+			items.length = 2;
+			Object.defineProperty(items, '1', {
+				configurable: true,
+				enumerable: true,
+				get() {
+					events.push('get:index');
+					return item;
+				},
+			});
+			expectedEvents = ['get:index'];
+		} else if (shape === 'item completed getter') {
+			Object.defineProperty(item, 'completed', {
+				configurable: true,
+				get() {
+					events.push('get:completed');
+					return completed;
+				},
+			});
+			expectedEvents = ['get:completed'];
+		} else if (shape === 'custom array species') {
+			Object.defineProperty(items, 'constructor', {
+				configurable: true,
+				value: {
+					get [Symbol.species]() {
+						events.push('get:species');
+						return function (length: number) {
+							events.push('new:species');
+							return new Array(length);
+						};
+					},
+				},
+			});
+			expectedEvents = ['get:species', 'new:species'];
+		} else {
+			items = new Proxy(items, {
+				get(target, property, receiver) {
+					if (property === 'filter') events.push('get:filter');
+					if (property === '0') events.push('get:index');
+					return Reflect.get(target, property, receiver);
+				},
+				getPrototypeOf(target) {
+					events.push('get:prototype');
+					return Reflect.getPrototypeOf(target);
+				},
+				getOwnPropertyDescriptor(target, property) {
+					if (property === 'filter' || property === '0') events.push('get:descriptor');
+					return Reflect.getOwnPropertyDescriptor(target, property);
+				},
+			});
+			expectedEvents = ['get:filter', 'get:index'];
+		}
+
+		const root = mount(client.App, { items });
+
+		try {
+			root.click('#state-filter-unsafe-load');
+			expect(events).toEqual(expectedEvents);
+			expect(root.find('#state-filter-unsafe-remaining').textContent).toBe('1');
+
+			events.length = 0;
+			completed = true;
+			if (shape !== 'item completed getter') item.completed = true;
+			root.click('#state-filter-unsafe-update');
+			expect(events).toEqual(expectedEvents);
+			expect(root.find('#state-filter-unsafe-remaining').textContent).toBe('0');
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('keeps a mutable state snapshot live when it escapes into an event callback', () => {
+		const source = `
+			import { useState } from 'octane';
+
+			export function App() @{
+				const [todos, setTodos] = useState([]);
+				const [tick, setTick] = useState(0);
+				const alias = todos;
+				const remaining = todos.filter((todo) => !todo.completed).length;
+				<section>
+					<button
+						id="state-filter-escape-load"
+						onClick={() => setTodos([{ id: 1, completed: false }])}
+					>{'load'}</button>
+					<button
+						id="state-filter-escape-mutate"
+						onClick={() => {
+							alias[0].completed = true;
+							setTick(tick + 1);
+						}}
+					>{'mutate'}</button>
+					<output id="state-filter-escape-remaining">{'' + remaining}</output>
+				</section>
+			}
+		`;
+		const client = loadStateFilterFixture(source, 'state-filter-escaped-alias.tsrx');
+		const root = mount(client.App);
+
+		try {
+			root.click('#state-filter-escape-load');
+			expect(root.find('#state-filter-escape-remaining').textContent).toBe('1');
+			root.click('#state-filter-escape-mutate');
+			expect(root.find('#state-filter-escape-remaining').textContent).toBe('0');
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('recomputes a filtered state snapshot when its predicate captures changed state', () => {
+		const source = `
+			import { useState } from 'octane';
+
+			export function App() @{
+				const [todos, setTodos] = useState([]);
+				const [completed, setCompleted] = useState(false);
+				const visible = todos.filter((todo) => todo.completed === completed);
+				<section>
+					<button
+						id="state-filter-capture-load"
+						onClick={() => setTodos([
+							{ id: 1, label: 'first', completed: false },
+							{ id: 2, label: 'second', completed: true },
+						])}
+					>{'load'}</button>
+					<button id="state-filter-capture-change" onClick={() => setCompleted(!completed)}>
+						{'change'}
+					</button>
+					<ul id="state-filter-capture-rows">
+						@for (const todo of visible; key todo.id) {
+							<li>{todo.label as string}</li>
+						}
+					</ul>
+				</section>
+			}
+		`;
+		const client = loadStateFilterFixture(source, 'state-filter-predicate-capture.tsrx');
+		const root = mount(client.App);
+
+		try {
+			root.click('#state-filter-capture-load');
+			expect(root.find('#state-filter-capture-rows li').textContent).toBe('first');
+			root.click('#state-filter-capture-change');
+			expect(root.find('#state-filter-capture-rows li').textContent).toBe('second');
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it.each([
+		{ mode: 'development', dev: true },
+		{ mode: 'production', dev: false },
+	])('re-evaluates observable coercion in $mode state-filter conditions', ({ mode, dev }) => {
+		const source = `
+			import { useState } from 'octane';
+
+			export function App(props) @{
+				const [todos, setTodos] = useState([]);
+				const [filter, setFilter] = useState('all');
+				const [tick, setTick] = useState(0);
+				const visible = filter == 'active' ? todos.filter((todo) => !todo.completed) : todos;
+				<section>
+					<button
+						id="state-filter-coercion-load"
+						onClick={() => setTodos([
+							{ id: 1, completed: false },
+							{ id: 2, completed: true },
+						])}
+					>{'load'}</button>
+					<button id="state-filter-coercion-set" onClick={() => setFilter(props.filter)}>
+						{'set'}
+					</button>
+					<button id="state-filter-coercion-update" onClick={() => setTick(tick + 1)}>
+						{'update'}
+					</button>
+					<output id="state-filter-coercion-visible">{'' + visible.length}</output>
+				</section>
+			}
+		`;
+		const client = loadCompiledFixtureSource(source, {
+			id: `state-filter-observable-coercion-${mode}.tsrx`,
+			mode: 'client',
+			compileOptions: { hmr: false, dev },
+		});
+		const events: string[] = [];
+		let active = true;
+		const filter = {
+			[Symbol.toPrimitive]() {
+				events.push('coerce');
+				return active ? 'active' : 'all';
+			},
+		};
+		const root = mount(client.App, { filter });
+
+		try {
+			root.click('#state-filter-coercion-load');
+			root.click('#state-filter-coercion-set');
+			expect(root.find('#state-filter-coercion-visible').textContent).toBe('1');
+
+			events.length = 0;
+			active = false;
+			root.click('#state-filter-coercion-update');
+			expect(events).toEqual(['coerce']);
+			expect(root.find('#state-filter-coercion-visible').textContent).toBe('2');
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('keeps filtered state live when an earlier predicate mutates the same snapshot', () => {
+		const source = `
+			import { useState } from 'octane';
+
+			export function App() @{
+				const [todos, setTodos] = useState([]);
+				const [tick, setTick] = useState(0);
+				todos.filter((todo) => {
+					todo.completed = !todo.completed;
+					return true;
+				});
+				const remaining = todos.filter((todo) => !todo.completed).length;
+				<section>
+					<button
+						id="state-filter-mutating-load"
+						onClick={() => setTodos([{ id: 1, completed: false }])}
+					>{'load'}</button>
+					<button id="state-filter-mutating-update" onClick={() => setTick(tick + 1)}>
+						{'update'}
+					</button>
+					<output id="state-filter-mutating-remaining">{'' + remaining}</output>
+				</section>
+			}
+		`;
+		const client = loadStateFilterFixture(source, 'state-filter-mutating-predicate.tsrx');
+		const root = mount(client.App);
+
+		try {
+			root.click('#state-filter-mutating-load');
+			expect(root.find('#state-filter-mutating-remaining').textContent).toBe('0');
+			root.click('#state-filter-mutating-update');
+			expect(root.find('#state-filter-mutating-remaining').textContent).toBe('1');
+			root.click('#state-filter-mutating-update');
+			expect(root.find('#state-filter-mutating-remaining').textContent).toBe('0');
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('re-evaluates side-effecting conditions around filtered state snapshots', () => {
+		const source = `
+			import { useState } from 'octane';
+
+			export function App() @{
+				const [todos, setTodos] = useState([]);
+				const [tick, setTick] = useState(0);
+				let reads = 0;
+				const visible = ++reads ? todos.filter((todo) => !todo.completed) : todos;
+				<section>
+					<button
+						id="state-filter-update-load"
+						onClick={() => setTodos([{ id: 1, completed: false }])}
+					>{'load'}</button>
+					<button id="state-filter-update-again" onClick={() => setTick(tick + 1)}>
+						{'update'}
+					</button>
+					<output id="state-filter-update-visible">{reads + ':' + visible.length}</output>
+				</section>
+			}
+		`;
+		const client = loadStateFilterFixture(source, 'state-filter-side-effect-condition.tsrx');
+		const root = mount(client.App);
+
+		try {
+			root.click('#state-filter-update-load');
+			expect(root.find('#state-filter-update-visible').textContent).toBe('1:1');
+			root.click('#state-filter-update-again');
+			expect(root.find('#state-filter-update-visible').textContent).toBe('1:1');
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('observes item mutations made through an escaped filtered state collection', () => {
+		const source = `
+			import { useState } from 'octane';
+
+			export function App(props) @{
+				const [todos, setTodos] = useState([]);
+				const [tick, setTick] = useState(0);
+				const visible = todos.filter((todo) => !todo.completed);
+				props.observe(visible);
+				const remaining = todos.filter((todo) => !todo.completed).length;
+				<section>
+					<button
+						id="state-filter-derived-escape-load"
+						onClick={() => setTodos([{ id: 1, completed: false }])}
+					>{'load'}</button>
+					<button
+						id="state-filter-derived-escape-update"
+						onClick={() => setTick(tick + 1)}
+					>{'update'}</button>
+					<output id="state-filter-derived-escape-remaining">{'' + remaining}</output>
+				</section>
+			}
+		`;
+		const client = loadStateFilterFixture(source, 'state-filter-derived-escape.tsrx');
+		let completed = false;
+		const root = mount(client.App, {
+			observe(rows: Array<{ completed: boolean }>) {
+				if (rows[0] !== undefined) rows[0].completed = completed;
+			},
+		});
+
+		try {
+			root.click('#state-filter-derived-escape-load');
+			expect(root.find('#state-filter-derived-escape-remaining').textContent).toBe('1');
+			completed = true;
+			root.click('#state-filter-derived-escape-update');
+			expect(root.find('#state-filter-derived-escape-remaining').textContent).toBe('0');
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('hydrates state-derived filter controls in place and keeps later snapshots reactive', () => {
+		const id = 'state-filter-provenance-hydration.tsrx';
+		const server = loadCompiledFixtureSource(STATE_FILTER_SOURCE, {
+			id,
+			mode: 'server',
+			compileOptions: { hmr: false, dev: false },
+		});
+		const client = loadStateFilterFixture(STATE_FILTER_SOURCE, id);
+		const container = document.createElement('div');
+		container.innerHTML = ServerRuntime.renderToString(server.App, { value: 'locked' }).html;
+		document.body.appendChild(container);
+		const app = container.querySelector('#state-filter-app');
+		const input = container.querySelector('#state-filter-value') as HTMLInputElement;
+		const all = container.querySelector('#state-filter-all');
+		let root: ReturnType<typeof hydrateRoot> | undefined;
+
+		try {
+			root = hydrateRoot(container, client.App, { value: 'locked' });
+			flushSync(() => {});
+			expect(container.querySelector('#state-filter-app')).toBe(app);
+			expect(container.querySelector('#state-filter-value')).toBe(input);
+			expect(container.querySelector('#state-filter-all')).toBe(all);
+			expect(input.value).toBe('locked');
+
+			flushSync(() => (container.querySelector('#state-filter-load') as HTMLElement).click());
+			expect(container.querySelector('#state-filter-remaining')?.textContent).toBe('1');
+			expect(container.querySelectorAll('#state-filter-rows li')).toHaveLength(2);
+
+			flushSync(() => (container.querySelector('#state-filter-active') as HTMLElement).click());
+			expect(container.querySelector('#state-filter-rows li')?.textContent).toBe('first');
+			expect(container.querySelector('#state-filter-active')?.className).toBe('selected');
+			expect(container.querySelector('#state-filter-app')).toBe(app);
+			expect(container.querySelector('#state-filter-value')).toBe(input);
+		} finally {
+			root?.unmount();
+			container.remove();
+		}
+	});
+});
+
 describe('compiler-owned component-region memoization', () => {
 	it('preserves an independently updating pure hookful child under its hookful parent', () => {
 		const source = `


### PR DESCRIPTION
## Summary

- Cache compiler-proven, pure native `filter` projections over private immutable `useState([])` snapshots in production `.tsrx` components.
- Reuse existing binding cells to skip unchanged single-token class updates without weakening controlled `value`/`checked` restoration.
- Add an exact Chromium production-work gate for the existing TodoMVC application, with no fixture or application-source changes.
- Document the narrow provenance contract and add the required `octane` patch changeset.

Refs #673.

## Correctness and scope

The compiler requires a genuine empty-array state initializer, a closed nonescaping setter, proven fresh array updates, pure own-data-property predicates, and nonescaping derived collections. The runtime guard runs only after existing memo dependencies already match and rejects non-native methods, overridden constructors/species, sparse arrays, indexed or item getters, and unproven snapshots.

Unsafe aliases, impure predicates, loose coercive conditions, side-effecting conditions, escaped derived arrays, arbitrary live receivers, development compilation, server rendering, and returned JSX retain their original behavior. Controlled fields continue to reassert their values on every commit.

Four independent public regressions were reproduced before fixing the proof: loose `Symbol.toPrimitive` coercion, earlier mutating predicates, side-effecting update expressions, and derived arrays escaping to unknown callbacks.

## Production work

| Existing 100-todo interaction | Filter predicate calls before → after | Filter-tab class writes before → after | Controlled checkbox writes after |
| --- | ---: | ---: | ---: |
| Start editing | 200 → 0 | 3 → 0 | 76 |
| Cancel editing | 200 → 0 | 3 → 0 | 76 |
| Change active filter | 200 → 100 | 3 → 2 | 26 |
| Toggle a todo | 200 → 200 | 3 → 0 | 1 |

The gate also checks all visible rows, keyed survivor identity, selection, editor state, footer totals, controlled-checkbox restoration, and necessary text updates. Generic root, Suspense, and hydration production bundles remain byte-identical; all 15 unrelated compiler-corpus entries and TodoMVC server output are unchanged. The optimized TodoMVC application grows by **355 gzip bytes**, and its compiler-corpus entry grows by **145 gzip bytes**. Session-to-session browser timings were too noisy to support a reliable duration claim; the deterministic work counters are the acceptance signal.

## Validation

- [x] `./node_modules/.bin/vitest run --project octane --project octane-prod --silent=passed-only` — **804 files, 11,851 tests passed**.
- [x] `pnpm --config.verify-deps-before-run=false --config.enable-pre-post-scripts=false run typecheck` — complete workspace passed on the latest upstream base.
- [x] Expanded compiler, hydration, provenance, universal-renderer, Suspense, transition, and conformance suites — **174 files, 3,209 tests passed**.
- [x] Newly merged Lynx renderer project — **24 files, 320 tests passed**.
- [x] Focused public provenance, controlled-input, getter/proxy/species, hydration, and four RED→GREEN regressions — **34 cases passed**.
- [x] Final production Chromium TodoMVC work gate, unchanged generic production bundles, fixed compiler-output corpus, server-output parity, and compiler-throughput comparison.
- [x] Frozen parsed AST and exact source-location assertions across client/server and development/production compile modes.
- [x] Scoped Prettier checks, `git diff --check`, and `pnpm --config.verify-deps-before-run=false sync`.

## Risk / follow-ups

- The specialization intentionally supports only closed, compiler-proven immutable state snapshots and a single safe class token. Arbitrary member calls, unsupported aliases, impure predicates, controlled bindings, and more general class-object ordering remain on their established paths.
- The optimized TodoMVC bundle adds 355 gzip bytes; unrelated production bundles remain unchanged.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production compiler memoization and DOM class binding lowering with a runtime snapshot guard; scope is intentionally narrow and heavily tested, but incorrect provenance could still cause stale UI if guards fail.
> 
> **Overview**
> Adds **compiler provenance** so production `.tsrx` can wrap eligible `todos.filter((todo) => !todo.completed)`-style projections in memoization when the array comes from a closed `useState([])` with only proven-immutable setter updates and a simple own-property predicate. Generated memo paths call new runtime **`compilerCacheImmutableArrayFilter`** only on would-be cache hits to confirm dense plain snapshots (native `filter`/`map`, no getters/proxies/overrides) before reusing the filtered array identity.
> 
> **Class bindings** from a single-key object like `class={{ selected: filter === 'active' }}` can lower to a conditional string when `filter` is proven primitive state in the same component, reusing the existing binding dirty mask so unchanged filter tabs skip redundant `class` DOM writes; controlled **`value`** / **`checked`** still reassert every commit.
> 
> Docs describe the narrow contract; **`benchmarks/todomvc/work.mjs`** (`bench:work`) is an untimed Chromium gate on the existing Octane TodoMVC build that asserts filter-predicate call counts, filter-tab class mutations, keyed rows, and controlled-field restoration. Extensive **`auto-memo`** tests cover hydration, getters, species overrides, escaped aliases, and impure predicates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d37c16677d35b9d063a29dd36efc1000c1b9228d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->