### PR TITLE
perf: retain unchanged Lynx rows across transport commits

### DIFF
--- a/.changeset/lynx-transported-row-retention.md
+++ b/.changeset/lynx-transported-row-retention.md
@@ -1,0 +1,7 @@
+---
+'octane': patch
+---
+
+Retain unchanged keyed component subtrees for asynchronous universal renderers,
+avoiding redundant Lynx row renders while preserving context updates, native
+listeners, host identity, effect lifetimes, and accepted-commit ordering.

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -1457,11 +1457,27 @@
   },
   {
     "suite": "lynx-table",
+    "op": "select_item_renders_1k",
+    "target": "octane-lynx",
+    "reference": "changed-rows-model",
+    "maxRatio": 1,
+    "note": "A steady-state selection changes exactly two rows' selected props, so only those two row components may re-render. This deterministic render-breadth ceiling catches transported roots replaying all 1,000 rows for a two-row update."
+  },
+  {
+    "suite": "lynx-table",
     "op": "update10th_commands_1k",
     "target": "octane-lynx",
     "reference": "changed-rows-model",
     "maxRatio": 1.5,
     "note": "Update-every-10th rewrites ceil(rows/10) labels; the commit must carry one text update per changed row. Measured exactly 100 = 1.0x the floor on 2026-08-08 (was 3100: every row's class array plus two event re-binds per row crossed on every commit)."
+  },
+  {
+    "suite": "lynx-table",
+    "op": "update10th_item_renders_1k",
+    "target": "octane-lynx",
+    "reference": "changed-rows-model",
+    "maxRatio": 1,
+    "note": "Updating every tenth row changes exactly 100 row objects, so only those 100 row components may re-render. Unchanged transported row subtrees must retain their existing output and native listeners."
   },
   {
     "suite": "lynx-table",
@@ -1505,11 +1521,27 @@
   },
   {
     "suite": "lynx-table",
+    "op": "select_item_renders_10k",
+    "target": "octane-lynx",
+    "reference": "changed-rows-model",
+    "maxRatio": 1,
+    "note": "A steady-state selection still changes exactly two rows at 10,000 rows. Render breadth must remain proportional to the selection change instead of replaying the whole transported table."
+  },
+  {
+    "suite": "lynx-table",
     "op": "update10th_commands_10k",
     "target": "octane-lynx",
     "reference": "changed-rows-model",
     "maxRatio": 1.5,
     "note": "Same gate at 10k rows: measured exactly 1000 = 1.0x the floor on 2026-08-08 (was 31000 before the fix)."
+  },
+  {
+    "suite": "lynx-table",
+    "op": "update10th_item_renders_10k",
+    "target": "octane-lynx",
+    "reference": "changed-rows-model",
+    "maxRatio": 1,
+    "note": "Updating every tenth row at 10,000 rows changes exactly 1,000 row objects. The remaining 9,000 row components must retain their existing output without re-rendering."
   },
   {
     "suite": "lynx-table",

--- a/benchmarks/lynx-table/README.md
+++ b/benchmarks/lynx-table/README.md
@@ -17,14 +17,18 @@ node run.mjs [iterations]          # LYNX_TABLE_SCALES=1000,10000 by default
 Builds the app plus the real dual-thread path (background root, async
 transport, main-thread receiver, host driver) with the Octane compiler, drives
 the ops through real native tap tokens over an in-process ContextProxy pair,
-and reports per-operation **command counts** and **serialized commit bytes**
+and reports per-operation **command counts**, **serialized commit bytes**, and
+**Row component render counts**
 from the `__OCTANE_LYNX_PROFILE__` counters (`@octanejs/lynx`'s permanent,
 build-flag-gated wire profiler — `globalThis.__OCTANE_LYNX_PROF` on each
 thread). Counts are deterministic for a fixed app and interaction sequence, so
 they carry ratio guards in `../baselines/ratios.json` against the
-`changed-rows-model` target — the commands a change of that size strictly
-implies. This is the "wire payload is proportional to change size, not tree
-size" regression gate. The suite runs from the root runner:
+`changed-rows-model` target — the commands and component renders a change of
+that size strictly implies. Selection allows two Row body executions;
+update-every-10th allows `ceil(rows / 10)`. The Row counter is compiled out of
+normal browser and production builds. These gates keep wire payload and render
+breadth proportional to change size, not tree size. The suite runs from the
+root runner:
 
 ```bash
 node benchmarks/bench.mjs --only lynx-table --ratios

--- a/benchmarks/lynx-table/app/src/App.lynx.tsrx
+++ b/benchmarks/lynx-table/app/src/App.lynx.tsrx
@@ -17,6 +17,15 @@ declare const __BENCH_AUTOROWS__: number;
 const INITIAL_ROWS: RowData[] =
 	__BENCH_AUTOROWS__ > 0 ? buildDataSeeded(__BENCH_AUTOROWS__) : [];
 
+// Count Row bodies only in the deterministic profile build. Normal browser
+// and production builds fold this branch away with their existing define.
+declare const __OCTANE_LYNX_PROFILE__: boolean;
+function countRowRender(): void {
+	if (!__OCTANE_LYNX_PROFILE__) return;
+	const profile = globalThis as { __BENCH_ROW_RENDERS__?: number };
+	profile.__BENCH_ROW_RENDERS__ = (profile.__BENCH_ROW_RENDERS__ ?? 0) + 1;
+}
+
 // -- storms: N sequential state→render→DOM ticks from one click --------------
 // Each tick runs in its own macrotask (MessageChannel avoids the nested
 // setTimeout 4ms clamp) so every mutation goes through a full render cycle
@@ -54,6 +63,7 @@ interface RowProps {
 }
 
 function Row(props: RowProps) @{
+	countRowRender();
 	<view class={['row', props.isSelected && 'danger']}>
 		<text class="col-id">{String(props.row.id)}</text>
 		<text class="col-label" bindtap={() => props.onSelect(props.row.id)}>{props.row.label}</text>

--- a/benchmarks/lynx-table/run.mjs
+++ b/benchmarks/lynx-table/run.mjs
@@ -3,10 +3,10 @@
 // Builds the cross-framework table app (./app) plus the real dual-thread Lynx
 // path with the Octane compiler, runs create/update10th/select and the two
 // storms through real tap tokens in-process, and reports the per-operation
-// COMMAND COUNT and SERIALIZED COMMIT BYTES from the build-flag-gated
-// `__OCTANE_LYNX_PROFILE__` counters. Those are deterministic for a fixed app
-// and interaction sequence, so they carry the regression gates; wall-clock
-// belongs to the Lynx-for-Web harness (web/run-web.mjs), which is
+// COMMAND COUNT, SERIALIZED COMMIT BYTES, and ROW BODY RENDERS from the
+// build-flag-gated `__OCTANE_LYNX_PROFILE__` counters. Those are deterministic
+// for a fixed app and interaction sequence, so they carry the regression
+// gates; wall-clock belongs to the Lynx-for-Web harness (web/run-web.mjs), which is
 // informational. The `changed-rows-model` target is the semantic floor: the
 // commands a change of that size strictly implies. Ratios of octane-lynx over
 // that model are the "wire cost is proportional to change size, not tree
@@ -120,11 +120,19 @@ try {
 				break;
 			}
 			const nextSignature = JSON.stringify({
-				create: result.create.commands,
-				update10th: result.update10th.commands,
-				select: [result.select.commands, result.select.bytes],
-				updateStorm: [result.updateStorm.commits, result.updateStorm.commands],
-				selectStorm: [result.selectStorm.commits, result.selectStorm.commands],
+				create: [result.create.commands, result.create.itemRenders],
+				update10th: [result.update10th.commands, result.update10th.itemRenders],
+				select: [result.select.commands, result.select.bytes, result.select.itemRenders],
+				updateStorm: [
+					result.updateStorm.commits,
+					result.updateStorm.commands,
+					result.updateStorm.itemRenders,
+				],
+				selectStorm: [
+					result.selectStorm.commits,
+					result.selectStorm.commands,
+					result.selectStorm.itemRenders,
+				],
 			});
 			if (signature === null) signature = nextSignature;
 			else if (signature !== nextSignature) {
@@ -138,8 +146,13 @@ try {
 
 		octaneOps[`create_commands_${suffix}`] = countStat(result.create.commands, iterations);
 		octaneOps[`update10th_commands_${suffix}`] = countStat(result.update10th.commands, iterations);
+		octaneOps[`update10th_item_renders_${suffix}`] = countStat(
+			result.update10th.itemRenders,
+			iterations,
+		);
 		octaneOps[`select_commands_${suffix}`] = countStat(result.select.commands, iterations);
 		octaneOps[`select_bytes_${suffix}`] = countStat(result.select.bytes, iterations);
+		octaneOps[`select_item_renders_${suffix}`] = countStat(result.select.itemRenders, iterations);
 		octaneOps[`update_storm_commits_${suffix}`] = countStat(result.updateStorm.commits, iterations);
 		octaneOps[`update_storm_commands_${suffix}`] = countStat(
 			result.updateStorm.commands,
@@ -157,12 +170,15 @@ try {
 		// one commit per tick in this synchronous harness — ticks arrive in their
 		// own macrotasks, so nothing can legitimately merge them here — times the
 		// per-tick change. select_bytes uses the absolute 2 KiB acceptance budget
-		// for a point-update commit rather than a modeled byte count.
+		// for a point-update commit rather than a modeled byte count. The row
+		// render floors count only components whose observable props changed.
 		const changed = Math.ceil(rows / 10);
 		modelOps[`create_commands_${suffix}`] = countStat(result.create.commands, iterations);
 		modelOps[`update10th_commands_${suffix}`] = countStat(changed, iterations);
+		modelOps[`update10th_item_renders_${suffix}`] = countStat(changed, iterations);
 		modelOps[`select_commands_${suffix}`] = countStat(2, iterations);
 		modelOps[`select_bytes_${suffix}`] = countStat(2048, iterations);
+		modelOps[`select_item_renders_${suffix}`] = countStat(2, iterations);
 		modelOps[`update_storm_commits_${suffix}`] = countStat(workload.STORM_UPDATE_TICKS, iterations);
 		modelOps[`update_storm_commands_${suffix}`] = countStat(
 			workload.STORM_UPDATE_TICKS * changed,
@@ -178,17 +194,20 @@ try {
 			rows,
 			createdElements: result.createdElements,
 			createBytes: result.create.bytes,
+			createItemRenders: result.create.itemRenders,
 			update10thBytes: result.update10th.bytes,
 			updateStormBytes: result.updateStorm.bytes,
+			updateStormItemRenders: result.updateStorm.itemRenders,
 			selectStormBytes: result.selectStorm.bytes,
+			selectStormItemRenders: result.selectStorm.itemRenders,
 		};
 
 		console.log(
-			`rows=${String(rows).padStart(5)}  create=${result.create.commands}  ` +
-				`update10th=${result.update10th.commands}  ` +
-				`select=${result.select.commands} (${result.select.bytes}B)  ` +
-				`updateStorm=${result.updateStorm.commits}c/${result.updateStorm.commands}  ` +
-				`selectStorm=${result.selectStorm.commits}c/${result.selectStorm.commands}`,
+			`rows=${String(rows).padStart(5)}  create=${result.create.commands} (${result.create.itemRenders}r)  ` +
+				`update10th=${result.update10th.commands} (${result.update10th.itemRenders}r)  ` +
+				`select=${result.select.commands} (${result.select.bytes}B, ${result.select.itemRenders}r)  ` +
+				`updateStorm=${result.updateStorm.commits}c/${result.updateStorm.commands} (${result.updateStorm.itemRenders}r)  ` +
+				`selectStorm=${result.selectStorm.commits}c/${result.selectStorm.commands} (${result.selectStorm.itemRenders}r)`,
 		);
 	}
 

--- a/benchmarks/lynx-table/workload.ts
+++ b/benchmarks/lynx-table/workload.ts
@@ -223,16 +223,24 @@ function createHarness(): Harness {
 
 interface ProfileGlobals {
 	__OCTANE_LYNX_PROF?: LynxWireProfile;
+	__BENCH_ROW_RENDERS__?: number;
 }
 
-function profileSnapshot(): { commits: number; commands: number; bytes: number } {
+function profileSnapshot(): {
+	commits: number;
+	commands: number;
+	bytes: number;
+	itemRenders: number;
+} {
 	const profile = (globalThis as ProfileGlobals).__OCTANE_LYNX_PROF;
 	// Both fake threads share this realm, so the main-thread receiver also
 	// counted each commit; halve to report per-wire commits and commands once.
+	// Row bodies only run on the background side and must not be halved.
 	return {
 		commits: (profile?.commits ?? 0) / 2,
 		commands: (profile?.commands ?? 0) / 2,
 		bytes: profile?.bytes ?? 0,
+		itemRenders: (globalThis as ProfileGlobals).__BENCH_ROW_RENDERS__ ?? 0,
 	};
 }
 
@@ -337,6 +345,7 @@ export interface OpCounters {
 	readonly commits: number;
 	readonly commands: number;
 	readonly bytes: number;
+	readonly itemRenders: number;
 }
 
 export interface TableRunResult {
@@ -379,6 +388,7 @@ export async function runTable(rows: number): Promise<TableRunResult> {
 				commits: after.commits - before.commits,
 				commands: after.commands - before.commands,
 				bytes: after.bytes - before.bytes,
+				itemRenders: after.itemRenders - before.itemRenders,
 			};
 		};
 

--- a/packages/octane/src/universal-core.ts
+++ b/packages/octane/src/universal-core.ts
@@ -1103,8 +1103,8 @@ interface RenderAttempt {
 	bridgeContextReads: Map<UniversalContext<any>, unknown> | null;
 	// Whether this attempt may reuse committed component subtrees whose inputs
 	// are provably unchanged instead of re-rendering them. Only plain urgent
-	// local-driver attempts qualify; replay, transition, bridge, and transport
-	// renders need every owner re-executed for their own bookkeeping.
+	// attempts qualify; replay, transition, and bridge renders need every owner
+	// re-executed for their own bookkeeping.
 	retainEligible: boolean;
 	retainedCount: number;
 	// The dirty epoch this attempt consumed. An owner stamped with it contains
@@ -8513,13 +8513,12 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 			transitionBatches,
 			transitionRender,
 			bridgeContextReads: null,
-			// Replay, transition, bridge, and transport attempts re-execute every
-			// owner for their own bookkeeping (warm replays, lane rebasing, bridge
-			// context read tracking, remote commit protocols); only a plain urgent
-			// local attempt may adopt committed subtrees without re-rendering them.
+			// Replay, transition, and bridge attempts re-execute every owner for
+			// their own bookkeeping. An ordinary transported full-root commit can
+			// adopt unchanged subtrees: its acknowledgement still covers the whole
+			// tree, and committed hosts and listeners remain published.
 			retainEligible:
 				allowRetain &&
-				this.transport === null &&
 				this.bridge === null &&
 				!this.attemptFullRootScheduled &&
 				replayEntries.length === 0 &&

--- a/packages/octane/tests/universal-transport.test.ts
+++ b/packages/octane/tests/universal-transport.test.ts
@@ -12,15 +12,21 @@ import {
 	type UniversalTransportCommitMessage,
 	type UniversalTransportEventMessage,
 	type UniversalTransportIdentity,
+	createContext,
 	createObjectContainer,
 	createObjectDriver,
 	createUniversalRoot,
 	defineUniversalComponent,
 	type UniversalRoot,
+	universalComponent,
+	universalContext,
+	universalFor,
 	universalPlan,
 	universalProps,
 	universalValue,
 	use,
+	useContext,
+	useEffect,
 	useLayoutEffect,
 	useState,
 } from '../src/universal.js';
@@ -1338,6 +1344,186 @@ describe('universal asynchronous transport', () => {
 		);
 		expect(protocol.error?.message).toMatch(/uses protocol 999/);
 		expect(log).toEqual([]);
+		await root.unmountAsync();
+	});
+});
+
+describe('transported retained component subtrees', () => {
+	interface SceneRow {
+		readonly id: number;
+		readonly label: string;
+	}
+
+	interface SceneCommand {
+		readonly select?: number;
+		readonly theme?: string;
+		readonly rotate?: boolean;
+		readonly relabel?: number;
+	}
+
+	const itemPlan = universalPlan(RENDERER, { kind: 'host', type: 'item', propsSlot: 0 });
+	const Theme = createContext('plain');
+
+	function createScene() {
+		const { container, loopback, root } = transportRoot();
+		const rendered: number[] = [];
+		const effects: string[] = [];
+		let command!: (payload: SceneCommand) => void;
+		const onCommand = (payload: unknown) => command(payload as SceneCommand);
+		const Item = defineUniversalComponent(
+			RENDERER,
+			(props: { row: SceneRow; selected: boolean; onCommand: (payload: unknown) => void }) => {
+				const theme = useContext(Theme);
+				rendered.push(props.row.id);
+				useEffect(
+					() => {
+						effects.push(`mount:${props.row.id}`);
+						return () => effects.push(`cleanup:${props.row.id}`);
+					},
+					[],
+					'mounted',
+				);
+				return universalValue(itemPlan, [
+					universalProps([
+						['set', 'label', props.row.label],
+						['set', 'theme', theme],
+						['set', 'selected', props.selected],
+						['set', 'onPoke', props.onCommand],
+					]),
+				]);
+			},
+		);
+		const Scene = defineUniversalComponent(RENDERER, () => {
+			const [rows, setRows] = useState<readonly SceneRow[]>(
+				[
+					{ id: 1, label: 'a' },
+					{ id: 2, label: 'b' },
+					{ id: 3, label: 'c' },
+				],
+				'rows',
+			);
+			const [selected, setSelected] = useState(0, 'selected');
+			const [theme, setTheme] = useState('plain', 'theme');
+			command = (payload) => {
+				if (payload.select !== undefined) setSelected(payload.select);
+				if (payload.theme !== undefined) setTheme(payload.theme);
+				if (payload.rotate === true) {
+					setRows((previous) => [previous[2]!, previous[0]!, previous[1]!]);
+				}
+				if (payload.relabel !== undefined) {
+					setRows((previous) =>
+						previous.map((row) =>
+							row.id === payload.relabel ? { id: row.id, label: `${row.label}!` } : row,
+						),
+					);
+				}
+			};
+			return universalContext(Theme, theme, () =>
+				universalFor(
+					rows,
+					(row) => row.id,
+					(row) =>
+						universalComponent(
+							RENDERER,
+							Item,
+							universalProps([
+								['set', 'row', row],
+								['set', 'selected', selected === row.id],
+								['set', 'onCommand', onCommand],
+							]),
+						),
+				),
+			);
+		});
+		const items = () => container.host.children;
+		const poke = async (occurrence: number, payload: SceneCommand) => {
+			const outcome = await loopback.sendEvent([
+				{ listener: loopback.listener('poke', occurrence), payload },
+			]);
+			expect(outcome.error).toBeUndefined();
+			await root.flushTransport();
+		};
+		return { root, Scene, rendered, effects, items, poke };
+	}
+
+	it('retains unchanged keyed children and their listeners across acknowledged updates', async () => {
+		const { root, Scene, rendered, effects, items, poke } = createScene();
+		await root.renderAsync(Scene, undefined);
+		await root.flushTransport();
+		const [first, second, third] = [...items()];
+		expect(items().map((item) => item.props.label)).toEqual(['a', 'b', 'c']);
+
+		rendered.length = 0;
+		await poke(0, { select: 2 });
+		expect(rendered).toContain(2);
+		expect(rendered).not.toContain(1);
+		expect(rendered).not.toContain(3);
+		expect(items()).toEqual([first, second, third]);
+		expect(items().map((item) => item.props.selected)).toEqual([false, true, false]);
+
+		// A listener announced before a retained commit must still dispatch after
+		// that commit advances the acknowledged root version.
+		rendered.length = 0;
+		await poke(2, { select: 3 });
+		expect(rendered).toContain(2);
+		expect(rendered).toContain(3);
+		expect(rendered).not.toContain(1);
+		expect(items().map((item) => item.props.selected)).toEqual([false, false, true]);
+
+		rendered.length = 0;
+		await poke(0, { relabel: 1 });
+		expect(rendered).toContain(1);
+		expect(rendered).not.toContain(2);
+		expect(rendered).not.toContain(3);
+		expect(items()[0]).toBe(first);
+		expect(items().map((item) => item.props.label)).toEqual(['a!', 'b', 'c']);
+		expect(effects).toEqual(['mount:1', 'mount:2', 'mount:3']);
+
+		await root.unmountAsync();
+		expect(effects.slice(3).toSorted()).toEqual(['cleanup:1', 'cleanup:2', 'cleanup:3']);
+	});
+
+	it('invalidates retained children when their consumed context changes', async () => {
+		const { root, Scene, rendered, items, poke } = createScene();
+		await root.renderAsync(Scene, undefined);
+		await root.flushTransport();
+		expect(items().map((item) => item.props.theme)).toEqual(['plain', 'plain', 'plain']);
+
+		rendered.length = 0;
+		await poke(0, { theme: 'dark' });
+		expect(rendered).toEqual(expect.arrayContaining([1, 2, 3]));
+		expect(items().map((item) => item.props.theme)).toEqual(['dark', 'dark', 'dark']);
+
+		rendered.length = 0;
+		await poke(0, { select: 2 });
+		expect(rendered).toContain(2);
+		expect(rendered).not.toContain(1);
+		expect(rendered).not.toContain(3);
+		expect(items().map((item) => item.props.theme)).toEqual(['dark', 'dark', 'dark']);
+		await root.unmountAsync();
+	});
+
+	it('reorders retained keyed children without changing their hosts, effects, or listeners', async () => {
+		const { root, Scene, rendered, effects, items, poke } = createScene();
+		await root.renderAsync(Scene, undefined);
+		await root.flushTransport();
+		const [first, second, third] = [...items()];
+
+		rendered.length = 0;
+		await poke(0, { rotate: true });
+		expect(rendered).not.toContain(1);
+		expect(rendered).not.toContain(2);
+		expect(rendered).not.toContain(3);
+		expect(items()).toEqual([third, first, second]);
+		expect(items().map((item) => item.props.label)).toEqual(['c', 'a', 'b']);
+		expect(effects).toEqual(['mount:1', 'mount:2', 'mount:3']);
+
+		rendered.length = 0;
+		await poke(1, { select: 2 });
+		expect(rendered).toContain(2);
+		expect(rendered).not.toContain(1);
+		expect(rendered).not.toContain(3);
+		expect(items().map((item) => item.props.selected)).toEqual([false, false, true]);
 		await root.unmountAsync();
 	});
 });


### PR DESCRIPTION
## Summary

Extend Octane's existing retained-component subtree adoption to transported universal roots, so changing one or two rows in a Lynx table does not execute every unchanged row component again.

This follows the specific, independently measured fix in [Huxpro/octane#11](https://github.com/Huxpro/octane/pull/11), rather than proposing new compiler machinery, a new transport protocol, or speculative receiver optimization. The performance question is deliberately framed around the actual Lynx-for-Web engine and browser-hosted Element PAPI, not only an inexpensive in-process fake.

**Draft status:** implementation and same-host before/after Chromium measurements are complete. All affected full framework/build-plugin projects passed **12,531 tests**, all eight affected TypeScript configurations passed, and every deterministic Lynx table guard passed.

## Why

[octanejs/octane#693](https://github.com/octanejs/octane/pull/693) made large production-compiled mounts and first native updates competitive with ReactLynx on a shared cheap fake Element PAPI. Its 21-sample in-process 10,000-row results were 44.755 ms versus 47.255 ms for mounting and 7.845 ms versus 8.673 ms for the first update. That benchmark is useful for runtime and host-driver costs, but does not represent real browser DOM work, layout, publication, engine event delivery, or a true priced thread boundary; its Octane ContextProxy also passes objects by reference.

The actual `benchmarks/lynx-table/web/run-web.mjs` workload tells a different story. It runs production bundles inside a real `<lynx-view>` backed by Lynx-for-Web and Chromium, drives the same visible table operations through the engine, and compares against vendored ReactLynx and Vue Lynx reference bundles in the same browser session.

Before and after collected on 2026-08-10 on the same 18-core Apple M5 Max, using the same pinned reference bundles; medians of three Chromium samples per operation. Reference columns are from the **after** run, not the earlier session. Absolute times and reference timings drift with browser/host load; deterministic changed-row counts provide the stronger regression evidence.

| Rows | Operation | Octane before | Octane after | Change | ReactLynx, after | Vue Lynx VDOM, after |
| ---: | --- | ---: | ---: | ---: | ---: | ---: |
| 1,000 | Create | 74 ±2 ms | 77 ±1 ms | +4%; noise | 37 ±1 ms | 45 ±3 ms |
| 1,000 | Update every tenth row | 17 ±4 ms | 10 ±4 ms | −41% | 9 ±3 ms | 7 ±4 ms |
| 1,000 | Select one row | 14 ±1 ms | 7 ±4 ms | −50% | 15 ±5 ms | 16 ±1 ms |
| 1,000 | Update storm | 72 ±3 ms | 46 ±8 ms | −36% | 146 ±5 ms | 39 ±0 ms |
| 1,000 | Selection storm | 27 ±7 ms | 12 ±0 ms | −56% | 53 ±4 ms | 21 ±1 ms |
| 10,000 | Create | 678 ±22 ms | 696 ±12 ms | +2.7%; noise | 337 ±9 ms | 420 ±8 ms |
| 10,000 | Update every tenth row | 132 ±14 ms | 93 ±1 ms | **−29.5%** | 70 ±13 ms | 53 ±2 ms |
| 10,000 | Select one row | 92 ±18 ms | 47 ±1 ms | **−48.9%** | 40 ±8 ms | 20 ±10 ms |
| 10,000 | Update storm | 733 ±34 ms | 344 ±8 ms | **−53.1%** | 1,421 ±123 ms | 655 ±87 ms |
| 10,000 | Selection storm | 179 ±31 ms | 87 ±15 ms | **−51.4%** | 585 ±32 ms | 315 ±52 ms |

At 10,000 rows, selecting a row improves from 92 ms to 47 ms; updating every tenth row improves from 132 ms to 93 ms. Selection is now close to the same-run ReactLynx result of 40 ms, but remains slower than Vue Lynx VDOM's 20 ms. Tenth-row updates remain slower than ReactLynx's 70 ms and Vue's 53 ms. Both storms improve by more than half. Mounting changes from 678 ±22 ms to 696 ±12 ms; that small difference overlaps ordinary run variation, so this PR claims **no mount improvement**.

The mechanism is directly visible in deterministic counters: a 10,000-row selection now executes exactly **two** `Row` components, while updating every tenth row executes exactly **1,000**. Existing wire guards already show that host commands scale with changed rows; this change makes component replay scale with changed rows too.

The upstream fork measured precisely this mechanism in [Huxpro/octane#11](https://github.com/Huxpro/octane/pull/11): a 10,000-row selection dropped from 10,000 `Row` executions to exactly two; updating every tenth row dropped from 10,000 to 1,000. On that fork's different host, real-browser selection improved from 813 ms to 274 ms and the tenth-row update from 888 ms to 473 ms. Those are independent prior results, not claims about this branch; this branch will be judged against its own before/after browser runs.

The broader research context is [Huxpro/octane#9](https://github.com/Huxpro/octane/issues/9). Its follow-up [Huxpro/octane#21](https://github.com/Huxpro/octane/issues/21) explicitly stopped speculative code-staged setters and receiver collapse after measuring receiver evaluation at 0.8% of first paint, template expansion at 2.5% of creation, and wire transfer at 1.0% of creation. This change instead addresses the measured owner-replay bottleneck directly.

## Changes

- Remove only the categorical `this.transport === null` exclusion from the existing full-root retained-subtree eligibility predicate in `packages/octane/src/universal-core.ts`.
- Preserve `allowRetain`, unchanged component identity and `Object.is`-shallow props, consumed-context invalidation, dirty/visibility/HMR checks, and the existing exclusions for bridges, suspended replay, transitions, regions, portals, and separately scheduled full-root attempts. Do not loosen memo equality, change the compiler, or introduce a new transport ABI.
- Add real asynchronous `MessageChannel` regressions for unchanged keyed-child retention, changed-prop reentry, retained listener delivery after a newer acknowledgement, exactly-once effect mount/cleanup, provider invalidation and later readoption, and keyed reordering without remounting or changing public host identity.
- Instrument only the existing canonical `benchmarks/lynx-table` profile build with per-operation `Row` execution counts; compile the counter out of shipping and ordinary browser bundles.
- Add deterministic changed-row-floor guards: selection executes exactly two rows at both 1,000 and 10,000 rows; a tenth-row update executes exactly 100 and 1,000 rows, respectively. Preserve all existing wire-command, serialized-byte, and storm guards.
- Include the required patch changeset for the public `octane` runtime change.

## Validation

All affected complete project suites passed **12,531 tests with zero failures**: **11,962** Octane development/production plus Three, **320** Lynx, and **249** Rspeedy/Rsbuild/Vite/Rspack plugin tests. The eight affected source, testing, and type-test configurations passed. Repository-wide aggregate commands remain accurately unchecked.

- [ ] `pnpm format:check` — repository-wide check not yet run.
- [ ] `pnpm typecheck` — aggregate typecheck not yet run.
- [ ] `pnpm test` — aggregate test command not yet run.
- [x] Targeted development/production universal transport regressions, red-checked against the restored transport exclusion — **48/48 transport tests passed**.
- [x] `./node_modules/.bin/vitest run --project octane --project octane-prod --project three` — **11,962/11,962 tests passed**.
- [x] `./node_modules/.bin/vitest run --project lynx --reporter=json --outputFile=/private/tmp/octane-lynx-transported-retention-tests.json` — **320/320 tests passed across 54 suites and 24 files; zero failed or pending.**
- [x] `./node_modules/.bin/vitest run --project rspeedy-plugin --project rsbuild-plugin --project vite-plugin --project rspack-plugin` — **249/249 integration tests passed**.
- [x] `./node_modules/.bin/tsgo --noEmit -p packages/octane/tsconfig.json`
- [x] `./node_modules/.bin/tsgo --noEmit -p packages/lynx/tsconfig.json`
- [x] `./node_modules/.bin/tsgo --noEmit -p packages/lynx/tsconfig.testing.json`
- [x] `./node_modules/.bin/tsgo --noEmit -p packages/lynx/typetests/tsconfig.json`
- [x] Octane/Three source and type-test configurations plus the Rspeedy plugin typecheck — all remaining affected TypeScript configurations passed.
- [x] `node benchmarks/bench.mjs --ratios lynx-table` — **16/16 guards passed**, including all four exact row-render floors and unchanged existing wire/storm guards.
- [x] Same-host, same-browser, same-reference before/after run at 1,000 and 10,000 rows, **three samples each**: `node benchmarks/lynx-table/web/run-web.mjs --scales 1000,10000 --reps 3`.
- [x] Verify no regressions in keyed row identity, effects, native listeners, refs, context, transport acknowledgements, and real engine-delivered taps.
- [x] `pnpm sync`, scoped Prettier validation, `git diff --check`, and changeset validation.

## Risk / follow-ups

- Retention must never hide changed props or contexts, drop listeners after an asynchronous acknowledgement, skip required effect cleanup, alter keyed host identity, or preserve a subtree that was invalidated by visibility, dirty state, a transition, or a full-root replay. The new async transport regressions are intended to make those public behaviors observable.
- The existing `@for` item lambda may still allocate descriptors for unchanged items; retained component adoption removes row-body execution, not every parent-loop allocation. Report remaining browser gaps honestly.
- Browser wall-clock timings include host-specific layout and publication costs. Do not infer native Android/iOS paint or startup behavior from Chromium, and do not treat the earlier fake-PAPI parity result as proof of browser parity.
- A no-worklet lazy main-thread bridge and absolute per-slice gzip budgets, as explored in [Huxpro/octane#15](https://github.com/Huxpro/octane/pull/15), are explicitly deferred to a separate, narrowly scoped bundle-size PR. That fork measured a 2,556-byte (3.6%) main-thread gzip reduction with unchanged background bytes, but no measurable first-paint gain; it does not address transported owner replay and is not included here.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes universal render retention for async transport commits; incorrect retention could skip updates, break listeners/effects, or desync acknowledgement ordering—mitigated by new transport regressions and deterministic render-breadth gates.
> 
> **Overview**
> **Transported universal roots** can now **reuse unchanged keyed component subtrees** on ordinary full-root commits by dropping the blanket `transport === null` check from `retainEligible` in `universal-core.ts`. Existing guards (unchanged props, context invalidation, dirty/visibility, bridges, transitions, replay) stay in place.
> 
> New **async transport tests** cover keyed-child retention, context-driven invalidation, listener delivery after acknowledgement, effect mount/cleanup, and reordering without remounting hosts.
> 
> The **lynx-table** deterministic harness adds profile-only **`Row` body render counts** and **CI ratio floors** (e.g. two rows on select, `ceil(rows/10)` on tenth-row updates at 1k and 10k) alongside existing wire-command/byte gates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dea29faabdbf3c809fcfb834e74d17b9e37db7a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->