### PR TITLE
perf: discover eligible async keyed-list children earlier

### DIFF
--- a/.changeset/early-async-keyed-list-discovery.md
+++ b/.changeset/early-async-keyed-list-discovery.md
@@ -1,0 +1,6 @@
+---
+'octane': patch
+---
+
+Start independent asynchronous children in proven bounded keyed lists during
+the same discovery wave while preserving existing suspense and request reuse.

--- a/benchmarks/async-composition/README.md
+++ b/benchmarks/async-composition/README.md
@@ -159,3 +159,22 @@ production compiles: binding writes, controlled value projection, and keyed
 removals/insertions/moves all have to move with the fetched panels in one step.
 Disabling the runtime's transition journal makes the update gate fail with
 `mixedStates regressed to 1 (ceiling 0)`; React records zero as the reference.
+
+## Keyed asynchronous panels
+
+The Octane dashboard renders `ActivityPanel` and `InsightsPanel` from a private,
+two-entry keyed panel list. The rendered dashboard, its eight versioned request
+keys, and the dependent owner request are unchanged; the four independent panel
+requests must still start in the first wave.
+
+The compiler expands eligible child warm plans from a private, nonescaping list
+of at most 16 distinct string values. Expansion happens at compile time, so
+speculation does not iterate the list, evaluate its keys, or add hook slots. An
+unknown, mutable, or escaped list retains the ordinary rendering behavior.
+
+The existing browser gate requires all seven independent requests in the first
+wave, two waves per operation, and eight actual network starts. Its current
+factory-call ceilings are eight on initialization and 13 on an update; the
+remaining update-only replay calls reuse cached requests. Keyed board identity,
+controlled input state, fallback retention, and zero mixed transition states
+remain mandatory.

--- a/benchmarks/async-composition/shared/octane/App.tsrx
+++ b/benchmarks/async-composition/shared/octane/App.tsrx
@@ -4,6 +4,8 @@ import { ActivityPanel } from './ActivityPanel.tsrx';
 import { InsightsPanel } from './InsightsPanel.tsrx';
 import { ProjectHeader } from './ProjectHeader.tsrx';
 
+const DASHBOARD_PANELS = ['activity', 'insights'];
+
 // Synchronous transition-atomicity guard: keyed rows that reorder, drop and
 // gain a member every version, plus a controlled input. All of it must move
 // with the fetched panels in one step — the observer counts any earlier
@@ -20,8 +22,13 @@ function Board(props: { version: number }) @{
 function Dashboard(props: { version: number }) @{
 	<main data-dashboard-version={props.version}>
 		<ProjectHeader version={props.version} />
-		<ActivityPanel version={props.version} />
-		<InsightsPanel version={props.version} />
+		@for (const panel of DASHBOARD_PANELS; key panel) {
+			@if (panel === 'activity') {
+				<ActivityPanel version={props.version} />
+			} @else {
+				<InsightsPanel version={props.version} />
+			}
+		}
 		<Board version={props.version} />
 	</main>
 }

--- a/docs/suspense-parallel-use-plan.md
+++ b/docs/suspense-parallel-use-plan.md
@@ -168,6 +168,19 @@ What shipped, and where it deviates from the phases as written:
     MAX-pass errors (retired 33/37 → 47/48) now hint at the cause. Pinned in
     `tests/ssr-prop-flow-promises.test.ts` (streaming + prerender + bare-root,
     exactly-once creation for the memoized shape).
+- **Bounded keyed-child discovery LANDED 2026-08-10.** The client compiler can
+  statically unroll a keyed `@for` into its parent's existing child warm plan
+  when its iterable is a private, unescaped module-level string-literal array with
+  at most 16 distinct entries, its sole use is that iterable, and its explicit
+  key is the item itself. Only pure, statically selected branches and safe
+  component props participate. The warm plan never evaluates the iterable,
+  item indexes, or keys, and never puts hooks in the loop; each real child
+  still owns its existing keyed component scope. Dynamic, dependent, mutated,
+  aliased, duplicate-key, and over-limit lists remain excluded, as do `@switch`
+  arms. Server and universal compilation are unchanged. The existing
+  composition dashboard's two keyed async panels return from four discovery
+  waves to two, restoring all seven independent first-wave requests while
+  preserving its current eight initial and 13 transition-update creators.
 - **Decision points resolved:** (1) unconditional, with no serial-timing mode;
   (2) loops excluded — mandatory (Phase 0); (3) member-path deps; (4)
   AbortSignal not shipped; (5)
@@ -597,6 +610,7 @@ is that Phase 4's coverage makes this unnecessary.
 | `use(context)` | Untouched: trivial args skip Phase 1; `_$useBatch` skips `$$kind === CONTEXT_TAG` entries at runtime. |
 | `use()` behind `@if` / plain `if` / early-return guard | Batched only within its own block; slot symbols are already conditional-safe. Never lift a creation out of its guarding condition. |
 | `use()` in loops | Excluded from Phases 1–2 (RESOLVED, Phase 0): loop iterations share one slot symbol, so `useMemo` thrashes one entry and a memoized creation would fresh-promise every render → infinite re-suspend. Bare `use()` stays loop-safe (call-order indexed). |
+| Async component children of a keyed `@for` | Client warming statically unrolls only private, nonescaping string-literal arrays with at most 16 distinct explicit item keys; children keep their separate component scopes and no hook is inserted into the loop. All other keyed lists remain opaque. |
 | Dependent creations (`use(f(a))`) | Not hoisted; on replay they join the pending set (Phase 3); dev warning explains the chain (Phase 5). |
 | Interleaved non-declaration statements | Terminate the batch run (v1 conservatism). |
 | Child props depend on suspended data (`<Detail item={data.first}/>`) | Correctly excluded from the warm plan — a true data dependency; that child's fetches start on resume (dependency-depth behavior). |

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -14330,6 +14330,7 @@ function parallelUseWalkJsx(nodes, ctx, componentName, creations, warmChildren, 
 		const item = declaration?.id;
 		if (
 			candidate === undefined ||
+			!guards.every(isSafeWarmListGuard) ||
 			ctx.currentComponentLocals?.has(iterable.name) ||
 			locals.has(iterable.name) ||
 			loop.await ||
@@ -14355,10 +14356,39 @@ function parallelUseWalkJsx(nodes, ctx, componentName, creations, warmChildren, 
 		}
 	}
 
+	function isSafeWarmListGuard(guard) {
+		const expression = unwrapTsExpr(guard);
+		if (expression?.type === 'Literal' || expression?.type === 'Identifier') return true;
+		if (expression?.type === 'MemberExpression') {
+			return (
+				!expression.computed &&
+				!expression.optional &&
+				expression.object?.type === 'Identifier' &&
+				expression.property?.type === 'Identifier'
+			);
+		}
+		if (expression?.type === 'UnaryExpression' && expression.operator === '!') {
+			return isSafeWarmListGuard(expression.argument);
+		}
+		if (
+			expression?.type === 'BinaryExpression' &&
+			(expression.operator === '===' || expression.operator === '!==')
+		) {
+			return isSafeWarmListGuard(expression.left) && isSafeWarmListGuard(expression.right);
+		}
+		return false;
+	}
+
 	function visitWarmListArm(arm, item, value) {
-		if (arm?.type !== 'BlockStatement') return false;
-		for (const entry of arm.body || []) {
-			if (entry.type === 'JSXIfExpression') {
+		const entries =
+			arm?.type === 'BlockStatement'
+				? arm.body || []
+				: arm?.type === 'JSXIfExpression' || arm?.type === 'IfStatement'
+					? [arm]
+					: null;
+		if (entries === null) return false;
+		for (const entry of entries) {
+			if (entry.type === 'JSXIfExpression' || entry.type === 'IfStatement') {
 				const test = unwrapTsExpr(entry.test);
 				if (
 					test?.type !== 'BinaryExpression' ||
@@ -14444,6 +14474,7 @@ function parallelUseWalkJsx(nodes, ctx, componentName, creations, warmChildren, 
 			if (
 				entry.type === 'JSXElement' ||
 				entry.type === 'JSXFragment' ||
+				entry.type === 'JSXForExpression' ||
 				entry.type === 'JSXIfExpression' ||
 				entry.type === 'JSXTryExpression'
 			) {

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -4891,6 +4891,79 @@ function collectPrivateUnescapedComponents(body, ctx) {
 	return candidates;
 }
 
+// An authored @for normally hides its children from speculative warming: its
+// iterable, keys, and item properties may all invoke user code. A private
+// dense string-literal array whose only reference is that directive's iterable is
+// different: its complete, immutable contents are already known from source,
+// so selected children can be unrolled without reading the array or its keys.
+function collectPrivateWarmLists(body) {
+	let candidates = null;
+	for (const statement of body) {
+		if (statement.type !== 'VariableDeclaration' || statement.kind !== 'const') continue;
+		for (const declaration of statement.declarations || []) {
+			const name = declaration.id?.type === 'Identifier' ? declaration.id.name : null;
+			const array = unwrapTsExpr(declaration.init);
+			if (
+				name === null ||
+				array?.type !== 'ArrayExpression' ||
+				array.elements.length === 0 ||
+				array.elements.length > 16
+			) {
+				continue;
+			}
+			const values = [];
+			const unique = new Set();
+			let safe = true;
+			for (const element of array.elements) {
+				const value = element?.type === 'Literal' ? element.value : undefined;
+				if (element?.type !== 'Literal' || typeof value !== 'string' || unique.has(value)) {
+					safe = false;
+					break;
+				}
+				unique.add(value);
+				values.push(value);
+			}
+			if (safe) (candidates ??= new Map()).set(name, { values, references: 0 });
+		}
+	}
+	if (candidates === null) return null;
+
+	const allowed = new Set();
+	const visited = new WeakSet();
+	let directEvaluation = false;
+	(function visit(node) {
+		if (node == null || typeof node !== 'object') return;
+		if (Array.isArray(node)) {
+			for (const child of node) visit(child);
+			return;
+		}
+		if (visited.has(node)) return;
+		visited.add(node);
+		const callee = node.type === 'CallExpression' ? unwrapTsExpr(node.callee) : null;
+		if (callee?.type === 'Identifier' && callee.name === 'eval') {
+			directEvaluation = true;
+		}
+		if (node.type === 'JSXForExpression' && node.right?.type === 'Identifier') {
+			const candidate = candidates.get(node.right.name);
+			if (candidate !== undefined) {
+				candidate.references++;
+				allowed.add(node.right);
+			}
+		}
+		for (const key in node) {
+			if (AST_WALK_SKIP_KEYS.has(key)) continue;
+			visit(node[key]);
+		}
+	})(body);
+	if (directEvaluation) return null;
+
+	const escaped = collectFreeIdentifiers(body, [], allowed);
+	for (const [name, candidate] of candidates) {
+		if (candidate.references !== 1 || escaped.has(name)) candidates.delete(name);
+	}
+	return candidates.size === 0 ? null : candidates;
+}
+
 function onlyMeaningfulJsxChild(children) {
 	let result = null;
 	for (const child of children || []) {
@@ -7980,6 +8053,7 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 		// single module print must carry a loc (OCTANE_COMPILE_ASSERT_LOC).
 		_moduleOrigin: ast.body.find((n) => n?.loc != null) ?? ast,
 	};
+	ctx.privateWarmLists = source.includes('@for') ? collectPrivateWarmLists(ast.body) : null;
 	if (hookDepHelperNeeded) ctx.runtimeNeeded.add(METHOD_DEP_IMPORT);
 	{
 		const imports = collectOctaneImportBindings(ast.body);
@@ -14236,11 +14310,122 @@ function parallelUseWalkJsx(nodes, ctx, componentName, creations, warmChildren, 
 				if (node.block) out.block = walkArm(node.block, guards);
 				return out;
 			}
+			case 'JSXForExpression':
+				if (ctx.mode !== 'server' && ctx._universalRuntimeUnit == null) {
+					collectWarmListChildren(node);
+				}
+				return node;
 			default:
-				// @for / @switch arms: v1 — no memoization, no warming (loop slot
-				// sharing; switch guards deferred). Everything else is inert.
+				// @switch arms remain opaque. General @for bodies are opaque too;
+				// only statically unrolled, private string lists can warm above.
 				return node;
 		}
+	}
+
+	function collectWarmListChildren(loop) {
+		const iterable = loop.right;
+		const candidate =
+			iterable?.type === 'Identifier' ? ctx.privateWarmLists?.get(iterable.name) : undefined;
+		const declaration = loop.left?.declarations?.[0];
+		const item = declaration?.id;
+		if (
+			candidate === undefined ||
+			ctx.currentComponentLocals?.has(iterable.name) ||
+			locals.has(iterable.name) ||
+			loop.await ||
+			loop.empty != null ||
+			loop.index != null ||
+			loop.left?.type !== 'VariableDeclaration' ||
+			loop.left.kind !== 'const' ||
+			loop.left.declarations.length !== 1 ||
+			item?.type !== 'Identifier' ||
+			loop.key?.type !== 'Identifier' ||
+			loop.key.name !== item.name ||
+			loop.body?.type !== 'BlockStatement'
+		) {
+			return;
+		}
+
+		const checkpoint = warmChildren.length;
+		for (const value of candidate.values) {
+			if (!visitWarmListArm(loop.body, item.name, value)) {
+				warmChildren.length = checkpoint;
+				return;
+			}
+		}
+	}
+
+	function visitWarmListArm(arm, item, value) {
+		if (arm?.type !== 'BlockStatement') return false;
+		for (const entry of arm.body || []) {
+			if (entry.type === 'JSXIfExpression') {
+				const test = unwrapTsExpr(entry.test);
+				if (
+					test?.type !== 'BinaryExpression' ||
+					(test.operator !== '===' && test.operator !== '!==')
+				) {
+					return false;
+				}
+				const leftItem = test.left?.type === 'Identifier' && test.left.name === item;
+				const rightItem = test.right?.type === 'Identifier' && test.right.name === item;
+				const literal = leftItem ? test.right : rightItem ? test.left : null;
+				if (leftItem === rightItem || literal?.type !== 'Literal') return false;
+				const selected =
+					(value === literal.value) === (test.operator === '===')
+						? entry.consequent
+						: entry.alternate;
+				if (selected != null && !visitWarmListArm(selected, item, value)) return false;
+				continue;
+			}
+			if (entry.type !== 'JSXElement') return false;
+			const component = entry.openingElement?.name;
+			if (component?.type !== 'JSXIdentifier' || !/^[A-Z]/.test(component.name)) return false;
+
+			const attributes = entry.openingElement.attributes || [];
+			const replacement = [];
+			for (const attribute of attributes) {
+				if (attribute.type !== 'JSXAttribute' || attribute.name?.type !== 'JSXIdentifier') {
+					return false;
+				}
+				if (attribute.name.name === '__proto__') return false;
+				if (attribute.value?.type !== 'JSXExpressionContainer') {
+					replacement.push(attribute);
+					continue;
+				}
+				const expression = unwrapTsExpr(attribute.value.expression);
+				if (
+					expression?.type !== 'Literal' &&
+					expression?.type !== 'Identifier' &&
+					(expression?.type !== 'MemberExpression' ||
+						expression.computed ||
+						expression.optional ||
+						expression.object?.type !== 'Identifier' ||
+						expression.property?.type !== 'Identifier')
+				) {
+					return false;
+				}
+				if (expression?.type === 'Identifier' && expression.name === item) {
+					const literal = inheritOriginLoc(
+						b.literal(value, JSON.stringify(value), expression),
+						expression,
+					);
+					replacement.push({
+						...attribute,
+						value: { ...attribute.value, expression: literal },
+					});
+					continue;
+				}
+				if (collectFreeIdentifiers(expression, []).has(item)) return false;
+				replacement.push(attribute);
+			}
+			const previous = warmChildren.length;
+			collectWarmChild(
+				{ ...entry, openingElement: { ...entry.openingElement, attributes: replacement } },
+				component.name,
+			);
+			if (warmChildren.length === previous) return false;
+		}
+		return true;
 	}
 
 	function walkArm(arm, armGuards) {

--- a/packages/octane/tests/parallel-use.test.ts
+++ b/packages/octane/tests/parallel-use.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { mount, act } from './_helpers';
+import { prerender } from 'octane/static';
+import { flushSync, hydrateRoot } from '../src/index';
+import { mount, act, flushEffects } from './_helpers';
 import { loadCompiledFixtureSource } from './_server-fixture';
 import {
 	ChainHost,
@@ -99,6 +101,544 @@ function freshResourceFetcher() {
 	};
 	return { calls, load, settleRound };
 }
+
+const KEYED_PANELS_SOURCE = `
+	import { use } from 'octane';
+
+	const PANELS = ['activity', 'insights'];
+
+	function ProjectHeader(props) @{
+		const value = use(props.load('project', props.version));
+		<span class="keyed-project">{value as string}</span>
+	}
+
+	function ActivityPanel(props) @{
+		const value = use(props.load('activity', props.version));
+		<span class="keyed-panel" data-panel="activity">{value as string}</span>
+	}
+
+	function InsightsPanel(props) @{
+		const value = use(props.load('insights', props.version));
+		<span class="keyed-panel" data-panel="insights">{value as string}</span>
+	}
+
+	function Dashboard(props) @{
+		<section class="keyed-dashboard">
+			<ProjectHeader load={props.load} version={props.version} />
+			@for (const panel of PANELS; key panel) {
+				@if (panel === 'activity') {
+					<ActivityPanel load={props.load} version={props.version} />
+				} @else {
+					<InsightsPanel load={props.load} version={props.version} />
+				}
+			}
+		</section>
+	}
+
+	export function KeyedListHost(props) @{
+		<>
+			@try {
+				<Dashboard load={props.load} version={props.version} />
+			} @pending {
+				<span class="keyed-pending">loading</span>
+			}
+		</>
+	}
+`;
+
+describe('parallel use() — independent asynchronous keyed-list children', () => {
+	it('starts every selected keyed child before any request resolves and adopts each request once', async () => {
+		const client = loadCompiledFixtureSource(KEYED_PANELS_SOURCE, {
+			id: 'independent-keyed-panels.tsrx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod' },
+		});
+		const resources = resourceFetcher();
+		const root = mount(client.KeyedListHost, { load: resources.load, version: 0 });
+
+		try {
+			expect(resources.calls).toEqual(['project:0', 'activity:0', 'insights:0']);
+			expect(root.find('.keyed-pending').textContent).toBe('loading');
+
+			await act(() => {
+				resources.settle('activity', 0);
+				resources.settle('insights', 0);
+				resources.settle('project', 0);
+			});
+
+			expect(root.find('.keyed-project').textContent).toBe('project-v0');
+			expect(root.findAll('.keyed-panel').map((node) => node.textContent)).toEqual([
+				'activity-v0',
+				'insights-v0',
+			]);
+			expect(resources.calls).toEqual(['project:0', 'activity:0', 'insights:0']);
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('starts each distinct request before a list-first suspension without multiplying existing replays', async () => {
+		const source = KEYED_PANELS_SOURCE.replace(
+			'<ProjectHeader load={props.load} version={props.version} />',
+			'',
+		);
+		const client = loadCompiledFixtureSource(source, {
+			id: 'list-first-independent-keyed-panels.tsrx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod' },
+		});
+		const resources = resourceFetcher();
+		const started = new Set<string>();
+		const root = mount(client.KeyedListHost, {
+			version: 0,
+			load(panel: string, version: number) {
+				started.add(`${panel}:${version}`);
+				return resources.load(panel, version);
+			},
+		});
+
+		try {
+			expect([...started]).toEqual(['activity:0', 'insights:0']);
+
+			await act(() => {
+				resources.settle('activity', 0);
+				resources.settle('insights', 0);
+			});
+
+			expect(root.findAll('.keyed-panel').map((node) => node.textContent)).toEqual([
+				'activity-v0',
+				'insights-v0',
+			]);
+			expect([...started]).toEqual(['activity:0', 'insights:0']);
+			expect(resources.calls.length).toBeLessThanOrEqual(5);
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('does not start keyed requests whose arguments depend on an unresolved parent', async () => {
+		const source = `
+			import { use } from 'octane';
+
+			const PANELS = ['activity', 'insights'];
+
+			function Panel(props) @{
+				const value = use(props.load(props.id, props.version));
+				<span class="dependent-keyed-panel">{value as string}</span>
+			}
+
+			function Dashboard(props) @{
+				const owner = use(props.load('owner', props.version));
+				<section>
+					@for (const panel of PANELS; key panel) {
+						<Panel id={owner + '-' + panel} load={props.load} version={props.version} />
+					}
+				</section>
+			}
+
+			export function App(props) @{
+				<>
+					@try {
+						<Dashboard load={props.load} version={props.version} />
+					} @pending {
+						<span class="dependent-keyed-pending">loading</span>
+					}
+				</>
+			}
+		`;
+		const client = loadCompiledFixtureSource(source, {
+			id: 'dependent-keyed-panels.tsrx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod' },
+		});
+		const resources = resourceFetcher();
+		const root = mount(client.App, { load: resources.load, version: 0 });
+
+		try {
+			expect(resources.calls).toEqual(['owner:0']);
+			expect(root.find('.dependent-keyed-pending').textContent).toBe('loading');
+
+			await act(() => resources.settle('owner', 0));
+
+			expect(resources.calls).toContain('owner-v0-activity:0');
+			expect(resources.calls).not.toContain('undefined-activity:0');
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('does not inspect an unknown iterable while an earlier sibling is suspended', async () => {
+		const source = `
+			import { use } from 'octane';
+
+			function Gate(props) @{
+				const value = use(props.load('gate', props.version));
+				<span>{value as string}</span>
+			}
+
+			function Panel(props) @{
+				const value = use(props.load(props.id, props.version));
+				<span class="unknown-keyed-panel">{value as string}</span>
+			}
+
+			function Dashboard(props) @{
+				<section>
+					<Gate load={props.load} version={props.version} />
+					@for (const panel of props.panels; key panel) {
+						<Panel id={panel} load={props.load} version={props.version} />
+					}
+				</section>
+			}
+
+			export function App(props) @{
+				<>
+					@try {
+						<Dashboard panels={props.panels} load={props.load} version={props.version} />
+					} @pending {
+						<span class="unknown-keyed-pending">loading</span>
+					}
+				</>
+			}
+		`;
+		const client = loadCompiledFixtureSource(source, {
+			id: 'unknown-keyed-panels.tsrx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod' },
+		});
+		const resources = resourceFetcher();
+		const reads: string[] = [];
+		const panels = new Proxy(['activity', 'insights'], {
+			get(target, property, receiver) {
+				reads.push(String(property));
+				return Reflect.get(target, property, receiver);
+			},
+			getOwnPropertyDescriptor(target, property) {
+				reads.push(`descriptor:${String(property)}`);
+				return Reflect.getOwnPropertyDescriptor(target, property);
+			},
+		});
+		const root = mount(client.App, { panels, load: resources.load, version: 0 });
+
+		try {
+			expect(resources.calls).toEqual(['gate:0']);
+			expect(reads).toEqual([]);
+
+			await act(() => resources.settle('gate', 0));
+
+			expect(reads).toContain('0');
+			expect(resources.calls).toContain('activity:0');
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('does not evaluate effectful keyed-child props before the list actually mounts', async () => {
+		const source = KEYED_PANELS_SOURCE.replace(
+			'<ActivityPanel load={props.load} version={props.version} />',
+			"<ActivityPanel load={props.load} version={props.version} token={props.observe('activity')} />",
+		)
+			.replace(
+				'<InsightsPanel load={props.load} version={props.version} />',
+				"<InsightsPanel load={props.load} version={props.version} token={props.observe('insights')} />",
+			)
+			.replace(
+				'<Dashboard load={props.load} version={props.version} />',
+				'<Dashboard load={props.load} version={props.version} observe={props.observe} />',
+			);
+		const client = loadCompiledFixtureSource(source, {
+			id: 'effectful-keyed-panel-props.tsrx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod' },
+		});
+		const project = deferred<string>();
+		const observations: string[] = [];
+		const root = mount(client.KeyedListHost, {
+			version: 0,
+			observe(panel: string) {
+				observations.push(panel);
+				return panel;
+			},
+			load(panel: string) {
+				if (panel === 'project') return project.promise;
+				const value = `${panel}-v0`;
+				return Object.assign(Promise.resolve(value), { status: 'fulfilled' as const, value });
+			},
+		});
+
+		try {
+			expect(observations).toEqual([]);
+			await act(() => project.resolve('project-v0'));
+			expect(observations).toEqual(['activity', 'insights']);
+			expect(root.findAll('.keyed-panel').map((node) => node.textContent)).toEqual([
+				'activity-v0',
+				'insights-v0',
+			]);
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it.each([
+		{
+			name: 'directly mutated',
+			declarations:
+				"const PANELS = ['activity', 'insights']; export function changePanels() { PANELS[1] = 'replacement'; }",
+		},
+		{
+			name: 'escaped through an alias',
+			declarations:
+				"const PANELS = ['activity', 'insights']; const alias = PANELS; export function changePanels() { alias[1] = 'replacement'; }",
+		},
+		{
+			name: 'mutated through direct evaluation',
+			declarations:
+				"const PANELS = ['activity', 'insights']; export function changePanels() { eval(\"PANELS[1] = 'replacement'\"); }",
+		},
+	])('observes the current contents of a list $name', async ({ name, declarations }) => {
+		const source = `
+			import { use } from 'octane';
+			${declarations}
+
+			function Panel(props) @{
+				const value = use(props.load(props.id, props.version));
+				<span class="mutable-keyed-panel">{value as string}</span>
+			}
+
+			function Dashboard(props) @{
+				<section>
+					@for (const panel of PANELS; key panel) {
+						<Panel id={panel} load={props.load} version={props.version} />
+					}
+				</section>
+			}
+
+			export function App(props) @{
+				<>
+					@try {
+						<Dashboard load={props.load} version={props.version} />
+					} @pending {
+						<span>loading</span>
+					}
+				</>
+			}
+		`;
+		const client = loadCompiledFixtureSource(source, {
+			id: `mutable-keyed-panels-${name.replace(/\W+/g, '-')}.tsrx`,
+			mode: 'client',
+			compileOptions: { hmr: false, dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod' },
+		});
+		const resources = resourceFetcher();
+		client.changePanels();
+		const root = mount(client.App, { load: resources.load, version: 0 });
+
+		try {
+			expect(resources.calls).toEqual(['activity:0']);
+			await act(() => resources.settle('activity', 0));
+			expect(resources.calls).toContain('replacement:0');
+			expect(resources.calls).not.toContain('insights:0');
+			await act(() => resources.settle('replacement', 0));
+			expect(root.findAll('.mutable-keyed-panel').map((node) => node.textContent)).toEqual([
+				'activity-v0',
+				'replacement-v0',
+			]);
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('does not run a later row or its key before an earlier keyed row resolves', () => {
+		const source = `
+			import { use } from 'octane';
+
+			const PANELS = ['activity', 'insights'];
+			let recordKey;
+			export function setKeyRecorder(recorder) { recordKey = recorder; }
+
+			function Panel(props) @{
+				const value = use(props.load(props.id, props.version));
+				<span>{value as string}</span>
+			}
+
+			function Dashboard(props) @{
+				<section>
+					@for (const panel of PANELS; key recordKey(panel)) {
+						<Panel id={panel} load={props.load} version={props.version} />
+					}
+				</section>
+			}
+
+			export function App(props) @{
+				<>
+					@try {
+						<Dashboard load={props.load} version={props.version} />
+					} @pending {
+						<span>loading</span>
+					}
+				</>
+			}
+		`;
+		const client = loadCompiledFixtureSource(source, {
+			id: 'observable-keyed-panel-keys.tsrx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod' },
+		});
+		const events: string[] = [];
+		const resources = resourceFetcher();
+		client.setKeyRecorder((panel: string) => {
+			events.push(`key:${panel}`);
+			return panel;
+		});
+		const root = mount(client.App, {
+			version: 0,
+			load(panel: string, version: number) {
+				events.push(`load:${panel}`);
+				return resources.load(panel, version);
+			},
+		});
+
+		try {
+			expect(events).toEqual(['key:activity', 'load:activity']);
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('preserves context, effects, and host refs without exposing them during speculation', async () => {
+		const source = `
+			import { createContext, use, useContext, useEffect } from 'octane';
+
+			const Theme = createContext('default');
+			const PANELS = ['activity', 'insights'];
+
+			function Panel(props) @{
+				const value = use(props.load(props.id, props.version));
+				const theme = useContext(Theme);
+				useEffect(() => {
+					props.onEffect('mount:' + props.id);
+					return () => props.onEffect('cleanup:' + props.id);
+				}, []);
+				<span class="context-keyed-panel" ref={props.capture}>{theme + ':' + value as string}</span>
+			}
+
+			function Dashboard(props) @{
+				<section>
+					@for (const panel of PANELS; key panel) {
+						<Panel
+							id={panel}
+							load={props.load}
+							version={props.version}
+							capture={props.capture}
+							onEffect={props.onEffect}
+						/>
+					}
+				</section>
+			}
+
+			export function App(props) @{
+				<Theme.Provider value={props.theme}>
+					@try {
+						<Dashboard
+							load={props.load}
+							version={props.version}
+							capture={props.capture}
+							onEffect={props.onEffect}
+						/>
+					} @pending {
+						<span class="context-keyed-pending">loading</span>
+					}
+				</Theme.Provider>
+			}
+		`;
+		const client = loadCompiledFixtureSource(source, {
+			id: 'context-keyed-panels.tsrx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod' },
+		});
+		const resources = resourceFetcher();
+		const effects: string[] = [];
+		const attachments: (Element | null)[] = [];
+		const root = mount(client.App, {
+			load: resources.load,
+			version: 0,
+			theme: 'ocean',
+			capture: (node: Element | null) => attachments.push(node),
+			onEffect: (effect: string) => effects.push(effect),
+		});
+
+		try {
+			expect(resources.calls).toEqual(['activity:0', 'insights:0']);
+			expect(attachments).toEqual([]);
+			expect(effects).toEqual([]);
+
+			await act(() => {
+				resources.settle('activity', 0);
+				resources.settle('insights', 0);
+			});
+			flushEffects();
+
+			const panels = root.findAll('.context-keyed-panel');
+			expect(panels.map((node) => node.textContent)).toEqual([
+				'ocean:activity-v0',
+				'ocean:insights-v0',
+			]);
+			expect(attachments).toEqual(panels);
+			expect(effects).toEqual(['mount:activity', 'mount:insights']);
+		} finally {
+			root.unmount();
+			flushEffects();
+		}
+
+		expect(attachments).toEqual([expect.any(Element), expect.any(Element), null, null]);
+		expect(effects).toEqual([
+			'mount:activity',
+			'mount:insights',
+			'cleanup:activity',
+			'cleanup:insights',
+		]);
+	});
+
+	it('adopts server-rendered keyed children without starting client requests', async () => {
+		const id = 'hydrated-independent-keyed-panels.tsrx';
+		const server = loadCompiledFixtureSource(KEYED_PANELS_SOURCE, {
+			id,
+			mode: 'server',
+			compileOptions: { hmr: false, dev: false },
+		});
+		const client = loadCompiledFixtureSource(KEYED_PANELS_SOURCE, {
+			id,
+			mode: 'client',
+			compileOptions: { hmr: false, dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod' },
+		});
+		const rendered = await prerender(server.KeyedListHost, {
+			version: 0,
+			load: (panel: string, version: number) => Promise.resolve(`${panel}-v${version}`),
+		});
+		const container = document.createElement('div');
+		container.innerHTML = rendered.html;
+		document.body.appendChild(container);
+		const serverNodes = Array.from(container.querySelectorAll('.keyed-panel'));
+		const calls: string[] = [];
+		let root: ReturnType<typeof hydrateRoot> | undefined;
+
+		try {
+			root = hydrateRoot(container, client.KeyedListHost, {
+				version: 0,
+				load: (panel: string) => {
+					calls.push(panel);
+					return Promise.resolve(`client-${panel}`);
+				},
+			});
+			flushSync(() => {});
+
+			expect(Array.from(container.querySelectorAll('.keyed-panel'))).toEqual(serverNodes);
+			expect(serverNodes.map((node) => node.textContent)).toEqual(['activity-v0', 'insights-v0']);
+			expect(calls).toEqual([]);
+		} finally {
+			root?.unmount();
+			container.remove();
+		}
+	});
+});
 
 describe('parallel use() — fetch-tree warming (nested chain)', () => {
 	it('starts EVERY level of a nested chain in the first attempt', async () => {

--- a/packages/octane/tests/parallel-use.test.ts
+++ b/packages/octane/tests/parallel-use.test.ts
@@ -177,6 +177,226 @@ describe('parallel use() — independent asynchronous keyed-list children', () =
 		}
 	});
 
+	it.each([
+		{ arm: '@try', open: '@try {', close: '} @pending { <span>rows loading</span> }' },
+		{ arm: '@if', open: '@if (props.enabled) {', close: '}' },
+	])(
+		'starts keyed children directly inside an $arm arm in the first wave',
+		async ({ arm, open, close }) => {
+			const source = `
+			import { use } from 'octane';
+
+			const PANELS = ['activity', 'insights'];
+
+			function ProjectHeader(props) @{
+				const value = use(props.load('project', props.version));
+				<span>{value as string}</span>
+			}
+
+			function Panel(props) @{
+				const value = use(props.load(props.id, props.version));
+				<span class="directive-keyed-panel">{value as string}</span>
+			}
+
+			function Dashboard(props) @{
+				<section>
+					<ProjectHeader load={props.load} version={props.version} />
+					${open}
+						@for (const panel of PANELS; key panel) {
+							<Panel id={panel} load={props.load} version={props.version} />
+						}
+					${close}
+				</section>
+			}
+
+			export function App(props) @{
+				<>
+					@try {
+						<Dashboard load={props.load} version={props.version} enabled={props.enabled} />
+					} @pending {
+						<span class="directive-keyed-pending">loading</span>
+					}
+				</>
+			}
+		`;
+			const client = loadCompiledFixtureSource(source, {
+				id: `direct-${arm.slice(1)}-keyed-panels.tsrx`,
+				mode: 'client',
+				compileOptions: { hmr: false, dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod' },
+			});
+			const resources = resourceFetcher();
+			const root = mount(client.App, { load: resources.load, version: 0, enabled: true });
+
+			try {
+				expect(resources.calls).toEqual(['project:0', 'activity:0', 'insights:0']);
+				expect(root.find('.directive-keyed-pending').textContent).toBe('loading');
+
+				await act(() => {
+					resources.settle('activity', 0);
+					resources.settle('insights', 0);
+					resources.settle('project', 0);
+				});
+
+				expect(root.findAll('.directive-keyed-panel').map((node) => node.textContent)).toEqual([
+					'activity-v0',
+					'insights-v0',
+				]);
+				expect(resources.calls).toEqual(['project:0', 'activity:0', 'insights:0']);
+
+				if (arm === '@if') {
+					root.update(client.App, { load: resources.load, version: 1, enabled: false });
+					expect(resources.calls).toEqual(['project:0', 'activity:0', 'insights:0', 'project:1']);
+				}
+			} finally {
+				root.unmount();
+			}
+		},
+	);
+
+	it('does not evaluate an effectful conditional guard before its keyed-list arm renders', async () => {
+		const source = `
+			import { use } from 'octane';
+			const PANELS = ['activity', 'insights'];
+
+			function ProjectHeader(props) @{
+				const value = use(props.load('project'));
+				<span>{value as string}</span>
+			}
+
+			function Panel(props) @{
+				const value = use(props.load(props.id));
+				<span class="keyed-panel">{value as string}</span>
+			}
+
+			function Dashboard(props) @{
+				<section>
+					<ProjectHeader load={props.load} />
+					@if (props.observe()) {
+						@for (const panel of PANELS; key panel) {
+							<Panel id={panel} load={props.load} />
+						}
+					}
+				</section>
+			}
+
+			export function KeyedListHost(props) @{
+				<>
+					@try {
+						<Dashboard load={props.load} observe={props.observe} />
+					} @pending {
+						<span>loading</span>
+					}
+				</>
+			}
+		`;
+		const client = loadCompiledFixtureSource(source, {
+			id: 'effectful-conditional-keyed-panels.tsrx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod' },
+		});
+		const project = deferred<string>();
+		const observations: string[] = [];
+		const requests: string[] = [];
+		const root = mount(client.KeyedListHost, {
+			version: 0,
+			observe() {
+				observations.push('observe');
+				return true;
+			},
+			load(panel: string) {
+				requests.push(panel);
+				if (panel === 'project') return project.promise;
+				const value = `${panel}-v0`;
+				return Object.assign(Promise.resolve(value), { status: 'fulfilled' as const, value });
+			},
+		});
+
+		try {
+			expect(requests).toEqual(['project']);
+			expect(observations).toEqual([]);
+			await act(() => project.resolve('project-v0'));
+			expect(observations).toEqual(['observe']);
+			expect(requests).toEqual(['project', 'activity', 'insights']);
+			expect(root.findAll('.keyed-panel').map((node) => node.textContent)).toEqual([
+				'activity-v0',
+				'insights-v0',
+			]);
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('starts every independent keyed child selected through an else-if chain', async () => {
+		const source = `
+			import { use } from 'octane';
+
+			const PANELS = ['activity', 'insights', 'reports'];
+
+			function ProjectHeader(props) @{
+				const value = use(props.load('project', props.version));
+				<span>{value as string}</span>
+			}
+
+			function Panel(props) @{
+				const value = use(props.load(props.id, props.version));
+				<span class="else-if-keyed-panel">{value as string}</span>
+			}
+
+			function Dashboard(props) @{
+				<section>
+					<ProjectHeader load={props.load} version={props.version} />
+					@for (const panel of PANELS; key panel) {
+						@if (panel === 'activity') {
+							<Panel id="activity" load={props.load} version={props.version} />
+						} @else if (panel === 'insights') {
+							<Panel id="insights" load={props.load} version={props.version} />
+						} @else {
+							<Panel id="reports" load={props.load} version={props.version} />
+						}
+					}
+				</section>
+			}
+
+			export function App(props) @{
+				<>
+					@try {
+						<Dashboard load={props.load} version={props.version} />
+					} @pending {
+						<span class="else-if-keyed-pending">loading</span>
+					}
+				</>
+			}
+		`;
+		const client = loadCompiledFixtureSource(source, {
+			id: 'else-if-keyed-panels.tsrx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod' },
+		});
+		const resources = resourceFetcher();
+		const root = mount(client.App, { load: resources.load, version: 0 });
+
+		try {
+			expect(resources.calls).toEqual(['project:0', 'activity:0', 'insights:0', 'reports:0']);
+			expect(root.find('.else-if-keyed-pending').textContent).toBe('loading');
+
+			await act(() => {
+				resources.settle('activity', 0);
+				resources.settle('insights', 0);
+				resources.settle('reports', 0);
+				resources.settle('project', 0);
+			});
+
+			expect(root.findAll('.else-if-keyed-panel').map((node) => node.textContent)).toEqual([
+				'activity-v0',
+				'insights-v0',
+				'reports-v0',
+			]);
+			expect(resources.calls).toEqual(['project:0', 'activity:0', 'insights:0', 'reports:0']);
+		} finally {
+			root.unmount();
+		}
+	});
+
 	it('starts each distinct request before a list-first suspension without multiplying existing replays', async () => {
 		const source = KEYED_PANELS_SOURCE.replace(
 			'<ProjectHeader load={props.load} version={props.version} />',


### PR DESCRIPTION
## Summary

- Discover independent asynchronous children behind proven-safe keyed lists in the same request wave.
- Statically unroll bounded list entries into Octane's existing client-side child-warming plans; no runtime, hook-slot, server, universal-renderer, or React-fixture changes are needed.
- Extend the existing production async-composition dashboard with two keyed asynchronous panels and document the exact safety contract.

## Correctness and scope

- Admit only a private, nonescaping module-level `const` array of at most 16 distinct string literals, referenced exactly once as an explicitly keyed `@for` iterable.
- Require the item itself as the key, statically decidable strict branch conditions, existing independently warmable child components, and literal, identifier, or single-level property-read child props.
- Reject aliases, exports, mutation, direct `eval`, non-string values, holes, duplicates, oversized lists, dynamic iterables or keys, `@empty`, index/destructuring forms, spreads, refs, and effectful prop expressions.
- Preserve true request dependencies, once-only adoption in the production topology, existing list-first retry behavior, keyed scopes and identity, context, refs, effects, hydration adoption, controlled inputs, and atomic transitions.
- Leave all server and universal output unchanged; `@switch`, dynamic lists, and general loop-local hook warming remain outside this conservative slice.

## Production work

Same authored keyed-list fixture, production minification, real Chromium, interleaved baseline/candidate samples:

| Observation | Previous compiler | This change |
| --- | ---: | ---: |
| Initial dashboard latency | 213.15 ms | 108.40 ms |
| Transition-update latency | 211.35 ms | 106.00 ms |
| Request waves per operation | 4 | 2 |
| Independent first-wave requests | 3 | 7 |
| Initial resource-factory calls | 18 | 8 |
| Transition resource-factory calls | 9 | 13 |
| Actual network requests | 8 | 8 |
| Mixed-version committed states | 0 | 0 |

The 13 transition creators restore and preserve the existing async-composition ceiling; reducing that known creator-reuse residue is the separately tracked next phase. The target production bundle changes by **+104 raw bytes / +13 gzip bytes / -48 Brotli bytes**. The fixed 16-file compiler corpus, generic static/Suspense/hydration bundles, and production/development server output are byte-identical.

## Validation

- [x] Full Octane development and production suites: **804 files / 11,873 tests passed**.
- [x] Expanded compiler, keyed reconciliation, parallel use, SSR, hydration, Suspense, transition, and universal suites: **198 files / 3,251 tests passed**.
- [x] Real Chromium Suspense/hydration integration: **11 tests passed**.
- [x] New keyed-list consumer behavior: **22 development/production cases passed**, including direct-evaluation and effectful-prop RED-to-GREEN regressions.
- [x] Independent adversarial compiler-shape matrix: **37 cases passed**, including the 16/17 fanout boundary.
- [x] Existing production async-composition Chromium gate: two request waves, seven independent first-wave requests, eight unique requests, preserved 8/13 creator ceilings, and zero mixed transition states.
- [x] `OCTANE_COMPILE_FROZEN_AST=1` and `OCTANE_COMPILE_ASSERT_LOC=1` across development/production client and server fixture compiles.
- [x] Full workspace typecheck: `pnpm --config.verify-deps-before-run=false --config.enable-pre-post-scripts=false run typecheck`.
- [x] Final repository synchronization: `pnpm --config.verify-deps-before-run=false sync`.
- [x] Scoped Prettier verification and `git diff --check`.

Refs #673.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes suspense/async discovery in the client compiler with a conservative static contract, but incorrect unrolling could start fetches too early or skip warming; mitigated by broad parallel-use and benchmark gates.
> 
> **Overview**
> **Client compile-time child warming** can now statically unroll a narrow class of keyed `@for` loops into the parent’s existing warm plan so independent async children start in the **same discovery wave** instead of waiting for the list to mount at runtime.
> 
> Eligible lists are private module `const` arrays of up to **16 distinct string literals**, used exactly once as the loop iterable with **key = item**, plus statically decidable `@if` / `@else if` arms and safe child props. The warm path never evaluates the iterable, keys, or effectful expressions; mutated, aliased, `eval`-touched, dynamic, or dependent-prop lists stay on the old opaque behavior. **Server/universal compilation is unchanged.**
> 
> The async-composition benchmark dashboard now renders `ActivityPanel` / `InsightsPanel` through `DASHBOARD_PANELS` and keyed `@for` so the gate exercises this path (fewer request waves, same network and transition atomicity expectations). Docs and a large `parallel-use` keyed-list suite cover hydration, guards, dependencies, and exclusion cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46bada4a11c89ce5d740e5290d5e38c6548c53ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->