### PR TITLE
perf: accelerate Lynx creation after first-screen adoption

### DIFF
--- a/.changeset/lynx-first-screen-component-creation.md
+++ b/.changeset/lynx-first-screen-component-creation.md
@@ -1,0 +1,7 @@
+---
+'octane': patch
+---
+
+Batch component-owned universal host templates after Lynx first-screen adoption,
+preserving component hooks, effects, keyed identity, native events, and safe
+cross-thread public handles while reducing large-list creation overhead.

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -1441,6 +1441,14 @@
   },
   {
     "suite": "lynx-table",
+    "op": "create_commands_1k",
+    "target": "octane-lynx",
+    "reference": "changed-rows-model",
+    "maxRatio": 1,
+    "note": "All 1,000 freshly inserted component-owned rows share one compiled intrinsic template, so the create commit must contain exactly one contiguous template-run command."
+  },
+  {
+    "suite": "lynx-table",
     "op": "select_commands_1k",
     "target": "octane-lynx",
     "reference": "changed-rows-model",
@@ -1502,6 +1510,14 @@
     "reference": "changed-rows-model",
     "maxRatio": 1.5,
     "note": "30 select ticks x 2 changed rows = 60 commands at the CI scale, measured exactly 1.0x the floor on 2026-08-08 (was 90000 before the fix)."
+  },
+  {
+    "suite": "lynx-table",
+    "op": "create_commands_10k",
+    "target": "octane-lynx",
+    "reference": "changed-rows-model",
+    "maxRatio": 1,
+    "note": "All 10,000 freshly inserted component-owned rows share one compiled intrinsic template, so creation must remain one contiguous template-run command rather than scaling with row count."
   },
   {
     "suite": "lynx-table",

--- a/benchmarks/lynx-table/README.md
+++ b/benchmarks/lynx-table/README.md
@@ -24,7 +24,8 @@ build-flag-gated wire profiler — `globalThis.__OCTANE_LYNX_PROF` on each
 thread). Counts are deterministic for a fixed app and interaction sequence, so
 they carry ratio guards in `../baselines/ratios.json` against the
 `changed-rows-model` target — the commands and component renders a change of
-that size strictly implies. Selection allows two Row body executions;
+that size strictly implies. Creating any number of component-owned rows must
+emit one shared-template run. Selection allows two Row body executions;
 update-every-10th allows `ceil(rows / 10)`. The Row counter is compiled out of
 normal browser and production builds. These gates keep wire payload and render
 breadth proportional to change size, not tree size. The suite runs from the
@@ -38,6 +39,9 @@ Because the in-process ContextProxy is synchronous, acknowledgements return
 immediately and the storm gates see one commit per tick; the asynchronous
 "renders while a commit is in flight coalesce into the next commit" contract
 is pinned separately in `packages/octane/tests/universal-transport.test.ts`.
+This harness starts directly on the background renderer; production
+first-screen adoption and the subsequent capability handoff are covered by the
+Lynx first-screen integration tests and the real-browser harness below.
 
 ## 2. Lynx-for-Web wall-clock harness (`web/run-web.mjs`, informational)
 

--- a/benchmarks/lynx-table/run.mjs
+++ b/benchmarks/lynx-table/run.mjs
@@ -165,6 +165,8 @@ try {
 		);
 
 		// Semantic floor: the wire a change of this size strictly implies.
+		// Creating component-owned rows reuses one shared intrinsic-template
+		// program, so the entire contiguous insertion is one host command.
 		// select moves one .danger class between two rows (2 updates). update10th
 		// rewrites ceil(rows/10) labels (1 text update each). A storm's floor is
 		// one commit per tick in this synchronous harness — ticks arrive in their
@@ -173,7 +175,7 @@ try {
 		// for a point-update commit rather than a modeled byte count. The row
 		// render floors count only components whose observable props changed.
 		const changed = Math.ceil(rows / 10);
-		modelOps[`create_commands_${suffix}`] = countStat(result.create.commands, iterations);
+		modelOps[`create_commands_${suffix}`] = countStat(1, iterations);
 		modelOps[`update10th_commands_${suffix}`] = countStat(changed, iterations);
 		modelOps[`update10th_item_renders_${suffix}`] = countStat(changed, iterations);
 		modelOps[`select_commands_${suffix}`] = countStat(2, iterations);

--- a/packages/lynx/src/core/client-driver.ts
+++ b/packages/lynx/src/core/client-driver.ts
@@ -561,6 +561,7 @@ export function prepareLynxCompactHandleDeltas(
 	count: number,
 	identity: UniversalTransportIdentity,
 	knownHostCount?: number,
+	incremental = false,
 ): LynxPreparedHandleDeltas {
 	const state = containerState(container);
 	if (
@@ -573,7 +574,10 @@ export function prepareLynxCompactHandleDeltas(
 	) {
 		throw new Error('Octane Lynx compact acknowledgement has a foreign transport identity.');
 	}
-	if (state.handles.size !== 0 || state.generations.size !== 0 || state.compactHosts !== null) {
+	if (
+		state.compactHosts !== null ||
+		(!incremental && (state.handles.size !== 0 || state.generations.size !== 0))
+	) {
 		throw new Error('Octane Lynx compact acknowledgement requires a fresh client container.');
 	}
 	if (
@@ -589,8 +593,33 @@ export function prepareLynxCompactHandleDeltas(
 	const originalHandles = state.handles;
 	const originalGenerations = state.generations;
 	const originalCompactHosts = state.compactHosts;
-	const stagedHandles = new Map<number, LynxHandleEntry>();
-	const stagedGenerations = new Map<number, number>();
+	if (incremental) {
+		const run = batch.commands.length === 1 ? batch.commands[0] : undefined;
+		if (
+			run?.op !== 'mount-template-run' ||
+			!Object.isFrozen(run) ||
+			!Object.isFrozen(run.values) ||
+			!Object.isFrozen(run.program) ||
+			!Number.isSafeInteger(run.firstId) ||
+			run.firstId <= 0 ||
+			run.firstId > Number.MAX_SAFE_INTEGER - (count - 1)
+		) {
+			throw new Error('Octane Lynx incremental acknowledgement requires one frozen host run.');
+		}
+		const finalId = run.firstId + (count - 1);
+		for (const [id, handle] of originalHandles) {
+			if (handle.root !== identity.root || (id >= run.firstId && id <= finalId)) {
+				throw new Error('Octane Lynx incremental acknowledgement overlaps an accepted handle.');
+			}
+		}
+		for (const id of originalGenerations.keys()) {
+			if (id >= run.firstId && id <= finalId) {
+				throw new Error('Octane Lynx incremental acknowledgement reuses a retired handle.');
+			}
+		}
+	}
+	const stagedHandles = new Map<number, LynxHandleEntry>(incremental ? originalHandles : undefined);
+	const stagedGenerations = new Map<number, number>(incremental ? originalGenerations : undefined);
 	const names: string[] = [];
 	const codes = new Map<string, number>();
 	let base = 0;
@@ -766,7 +795,8 @@ export function prepareLynxCompactHandleDeltas(
 			state.handles = originalHandles;
 			state.generations = originalGenerations;
 			state.compactHosts = originalCompactHosts;
-			for (const handle of stagedHandles.values()) {
+			for (const [id, handle] of stagedHandles) {
+				if (originalHandles.get(id) === handle) continue;
 				handle.active = false;
 				handle.attached = false;
 				if (handle.facade !== null || handle.binding !== null) {

--- a/packages/lynx/src/core/host-driver.ts
+++ b/packages/lynx/src/core/host-driver.ts
@@ -281,7 +281,9 @@ export interface PrepareLynxHostBatchOptions<Node extends LynxElementRef> {
 	readonly onMismatch?: (error: LynxFirstTreeMismatchError) => void;
 	/** Trusted transport may defer per-host legacy ACK deltas for a fresh root. */
 	readonly compact?: boolean;
-	/** Negotiated compact program mounts install private ref selectors on demand. */
+	/** Trusted adopted roots may append one compact generation-one host segment. */
+	readonly incrementalCompact?: boolean;
+	/** Negotiated safe program mounts install private ref selectors on demand. */
 	readonly lazyPublicInstances?: boolean;
 }
 
@@ -3128,16 +3130,38 @@ export function prepareLynxHostBatch<Node extends LynxElementRef>(
 	// Preparation is a hot commit path. Stage only records and generation entries
 	// touched by this batch; the accepted maps remain unchanged until apply().
 	let stagedRecords: LynxHostRecordStore<Node> = new Map<number, LynxHostRecord<Node>>();
+	let acceptedDenseRecords: LynxDenseHostRecordStore<Node> | null = null;
 	const deletedRecords = new Set<number>();
 	const stagedGenerations = new Map<number, number>();
 	const initiallyNoGenerations = state.generations.size === 0;
-	let compactCandidate =
-		options?.compact === true &&
-		initiallyEmpty &&
-		initiallyNoGenerations &&
+	const acceptedLazyPublicInstances =
+		options?.lazyPublicInstances === true &&
+		!initiallyEmpty &&
 		firstTree === undefined &&
 		!state.hasMainThreadProps &&
-		!state.hasNativeListTopology;
+		!state.hasNativeListTopology &&
+		state.portalRoot === null &&
+		state.portalChildren.size === 0 &&
+		batch.commands.every(
+			(command) =>
+				command !== null &&
+				typeof command === 'object' &&
+				(command.op === 'mount-template-range' || command.op === 'mount-template-run'),
+		);
+	const incrementalCompactCandidate =
+		options?.compact === true &&
+		options.incrementalCompact === true &&
+		acceptedLazyPublicInstances &&
+		!state.implicitInitialGenerations &&
+		state.records instanceof Map &&
+		batch.commands.length === 1 &&
+		batch.commands[0]?.op === 'mount-template-run';
+	let compactCandidate =
+		options?.compact === true &&
+		firstTree === undefined &&
+		!state.hasMainThreadProps &&
+		!state.hasNativeListTopology &&
+		((initiallyEmpty && initiallyNoGenerations) || incrementalCompactCandidate);
 	let compactCreated = 0;
 	let compactInserted = 0;
 	let sparseCompactNodes = compactCandidate;
@@ -3162,7 +3186,14 @@ export function prepareLynxHostBatch<Node extends LynxElementRef>(
 		: (id: number): LynxHostRecord<Node> | undefined => {
 				if (deletedRecords.has(id)) return undefined;
 				const staged = stagedRecords.get(id);
-				if (staged !== undefined) return staged;
+				if (staged !== undefined) {
+					if (acceptedDenseRecords !== null && staged === state.records.get(id)) {
+						const clone = cloneRecord(staged);
+						stagedRecords.set(id, clone);
+						return clone;
+					}
+					return staged;
+				}
 				const accepted = state.records.get(id);
 				if (accepted === undefined) return undefined;
 				const clone = cloneRecord(accepted);
@@ -3450,10 +3481,24 @@ export function prepareLynxHostBatch<Node extends LynxElementRef>(
 				);
 			if (denseEligible) {
 				const end = command.firstId + (hostCount - 1);
+				if (
+					incrementalCompactCandidate &&
+					(typeof parent !== 'number' || !isRootConnected((id) => state.records.get(id), parent))
+				) {
+					denseEligible = false;
+				}
 				for (const id of stagedRecords.keys()) {
 					if (id >= command.firstId && id <= end) {
 						denseEligible = false;
 						break;
+					}
+				}
+				if (incrementalCompactCandidate) {
+					for (const id of state.generations.keys()) {
+						if (id >= command.firstId && id <= end) {
+							denseEligible = false;
+							break;
+						}
 					}
 				}
 				for (let later = index + 1; denseEligible && later < batch.commands.length; later++) {
@@ -3486,8 +3531,13 @@ export function prepareLynxHostBatch<Node extends LynxElementRef>(
 						}
 					}
 				}
+				let prefix = stagedRecords as Map<number, LynxHostRecord<Node>>;
+				if (incrementalCompactCandidate) {
+					prefix = new Map(state.records as Map<number, LynxHostRecord<Node>>);
+					for (const [id, record] of stagedRecords) prefix.set(id, record);
+				}
 				const dense = new LynxDenseHostRecordStore(
-					stagedRecords as Map<number, LynxHostRecord<Node>>,
+					prefix,
 					container.root,
 					program,
 					command.firstId,
@@ -3496,6 +3546,7 @@ export function prepareLynxHostBatch<Node extends LynxElementRef>(
 					command.values,
 					command.firstListenerId,
 				);
+				if (incrementalCompactCandidate) acceptedDenseRecords = dense;
 				stagedRecords = dense;
 				for (let row = 0; row < count; row++) {
 					siblings.push(command.firstId + row * shape.types.length);
@@ -3521,6 +3572,7 @@ export function prepareLynxHostBatch<Node extends LynxElementRef>(
 				});
 				continue;
 			}
+			if (incrementalCompactCandidate) abandonCompact();
 			const templateRecords: LynxHostRecord<Node>[] = new Array(hostCount);
 			const templatePatches: LynxHostPropPatch[] = new Array(hostCount);
 			for (let rowIndex = 0; rowIndex < count; rowIndex++) {
@@ -3636,7 +3688,8 @@ export function prepareLynxHostBatch<Node extends LynxElementRef>(
 				...(compactCandidate
 					? { firstId: command.firstId, program, firstListenerId: command.firstListenerId }
 					: null),
-				...(compactCandidate && options?.lazyPublicInstances === true
+				...(options?.lazyPublicInstances === true &&
+				(compactCandidate || acceptedLazyPublicInstances)
 					? { lazyPublicInstances: true }
 					: null),
 			});
@@ -4153,7 +4206,8 @@ export function prepareLynxHostBatch<Node extends LynxElementRef>(
 		compactCandidate &&
 		(compactCreated === 0 ||
 			compactCreated !== compactInserted ||
-			compactCreated !== stagedRecordCount ||
+			compactCreated !==
+				stagedRecordCount - (acceptedDenseRecords === null ? 0 : state.records.size) ||
 			hasMainThreadProps ||
 			hasNativeListTopology ||
 			stagedPortalRoot !== null)
@@ -4456,7 +4510,7 @@ export function prepareLynxHostBatch<Node extends LynxElementRef>(
 						preApplicationError = error;
 					}
 				}
-				if (initiallyEmpty) {
+				if (initiallyEmpty || (acceptedDenseRecords !== null && compactHostCount !== undefined)) {
 					state.records = stagedRecords;
 				} else {
 					for (const id of deletedRecords) state.records.delete(id);
@@ -4528,6 +4582,19 @@ export function prepareLynxHostBatch<Node extends LynxElementRef>(
 										dense.parent,
 										'template run parent',
 									);
+									const append =
+										state.papi.append ??
+										((parent: Node, child: Node) => state.papi.insertBefore(parent, child, null));
+									const intrinsics = state.papi.intrinsics;
+									const intrinsicFactories =
+										intrinsics === undefined
+											? null
+											: program.shape.types.map((type) => {
+													if (type === 'view') return intrinsics.view;
+													if (type === 'text') return intrinsics.text;
+													if (type === '#text' || type === 'raw-text') return intrinsics.rawText;
+													return undefined;
+												});
 									for (let row = 0; row < dense.count; row++) {
 										const rowOffset = row * width;
 										const valueOffset = row * program.valueCount;
@@ -4536,8 +4603,9 @@ export function prepareLynxHostBatch<Node extends LynxElementRef>(
 											const type = program.shape.types[index]!;
 											const props = program.props[index]!;
 											const bindings = program.bindings[index];
+											const rawText = type === '#text' || type === 'raw-text';
 											let text = '';
-											if (type === '#text' || type === 'raw-text') {
+											if (rawText) {
 												text =
 													bindings === undefined
 														? typeof props.value === 'string'
@@ -4547,11 +4615,13 @@ export function prepareLynxHostBatch<Node extends LynxElementRef>(
 																: ''
 														: (dense.values[valueOffset + bindings[0]!.valueIndex] as string);
 											}
-											const node = state.papi.createElement(
-												type,
-												container.pageComponentUniqueId,
-												text,
-											);
+											const factory = intrinsicFactories?.[index];
+											const node =
+												factory === undefined
+													? state.papi.createElement(type, container.pageComponentUniqueId, text)
+													: rawText
+														? (factory as (value: string) => Node)(text)
+														: (factory as (value: number) => Node)(container.pageComponentUniqueId);
 											state.ownedNodes.add(node);
 											dense.setNode(offset, node);
 											if (bindings !== undefined) {
@@ -4596,15 +4666,14 @@ export function prepareLynxHostBatch<Node extends LynxElementRef>(
 											}
 										}
 										for (let index = 1; index < width; index++) {
-											state.papi.insertBefore(
+											append(
 												dense.nodes[rowOffset + program.shape.parents[index]!]!,
 												dense.nodes[rowOffset + index]!,
-												null,
 											);
 										}
 										const root = dense.nodes[rowOffset]!;
 										if (dense.parent === null) state.ownedPageRoots.add(root);
-										state.papi.insertBefore(parent, root, null);
+										append(parent, root);
 									}
 									continue;
 								}
@@ -4633,7 +4702,10 @@ export function prepareLynxHostBatch<Node extends LynxElementRef>(
 											);
 										}
 										record.node = node;
-										if (operation.lazyPublicInstances !== true || compactHostCount === undefined) {
+										if (
+											operation.lazyPublicInstances !== true ||
+											(compactHostCount === undefined && !acceptedLazyPublicInstances)
+										) {
 											ensureNodesRefSelector(state, record);
 										}
 										const patch = operation.patches[recordIndex]!;

--- a/packages/lynx/src/core/papi.ts
+++ b/packages/lynx/src/core/papi.ts
@@ -85,6 +85,7 @@ export interface LynxElementPAPIGlobals<Node extends LynxElementRef = LynxElemen
 	__GetElementUniqueID(node: Node): number;
 	__GetParent?(node: Node): Node | null | undefined;
 	__ElementIsEqual?(first: Node, second: Node): boolean;
+	__AppendElement?(parent: Node, child: Node): unknown;
 	__InsertElementBefore(parent: Node, child: Node, before?: Node): unknown;
 	__RemoveElement(parent: Node, child: Node): unknown;
 	__ReplaceElement(replacement: Node, previous: Node): void;
@@ -102,12 +103,20 @@ export interface LynxElementPAPIGlobals<Node extends LynxElementRef = LynxElemen
 export interface LynxElementPAPI<Node extends LynxElementRef = LynxElementRef> {
 	createPage(componentId: string, cssId: number): Node;
 	createElement(type: string, parentComponentUniqueId: number, text: string): Node;
+	/** Optional receiver-bound native factories for prevalidated dense host programs. */
+	readonly intrinsics?: Readonly<{
+		view: (parentComponentUniqueId: number) => Node;
+		text: (parentComponentUniqueId: number) => Node;
+		rawText: (text: string) => Node;
+	}>;
 	/** Present when the runtime publishes the native list callback API. */
 	readonly list?: LynxListPAPI<Node>;
 	getUniqueId(node: Node): number;
 	getParent(node: Node): Node | null;
 	isEqual(first: Node, second: Node): boolean;
 	isChild(parent: Node, child: Node): boolean;
+	/** Optional public native append operation for known append-only host programs. */
+	readonly append?: (parent: Node, child: Node) => void;
 	insertBefore(parent: Node, child: Node, before: Node | null): void;
 	remove(parent: Node, child: Node): void;
 	replace(replacement: Node, previous: Node): void;
@@ -226,6 +235,8 @@ export function createLynxElementPAPI<Node extends LynxElementRef = LynxElementR
 		target,
 		'__InsertElementBefore',
 	);
+	const appendValue = (target as LynxElementPAPIGlobals<Node>).__AppendElement;
+	const append = typeof appendValue === 'function' ? appendValue.bind(target) : undefined;
 	const remove = requireFunction<Node, '__RemoveElement'>(target, '__RemoveElement');
 	const replace = requireFunction<Node, '__ReplaceElement'>(target, '__ReplaceElement');
 	const setClasses = requireFunction<Node, '__SetClasses'>(target, '__SetClasses');
@@ -239,6 +250,12 @@ export function createLynxElementPAPI<Node extends LynxElementRef = LynxElementR
 
 	const papi: LynxElementPAPI<Node> = {
 		...(list === undefined ? null : { list }),
+		...(append === undefined ? null : { append }),
+		intrinsics: Object.freeze({
+			view: createView,
+			text: createText,
+			rawText: createRawText,
+		}),
 		createPage(componentId, cssId) {
 			return createPage(componentId, cssId);
 		},

--- a/packages/lynx/src/core/transport.ts
+++ b/packages/lynx/src/core/transport.ts
@@ -47,6 +47,7 @@ import {
 	type LynxHostFaultMessage,
 	type LynxMainReadyReply,
 	type LynxMainReadyRequest,
+	type LynxMainThreadCapabilities,
 	type LynxMainThreadWorkletWireDescriptor,
 	type LynxTransportCommitMessage,
 	type LynxTransportAcknowledgement,
@@ -153,6 +154,7 @@ interface PendingCommit {
 	readonly token: PreparedTokenState;
 	state: 'waiting-ready' | 'sent' | 'acknowledged';
 	compactRequested: boolean;
+	incrementalCompactRequested: boolean;
 	compactHostCount: number | null;
 	abortRequested: boolean;
 	deferredResponse: CommitSettlement | null;
@@ -277,6 +279,8 @@ export function createLynxBackgroundTransport(
 	let readyReceived = false;
 	let compactAcknowledgements = false;
 	let lazyPublicInstances = false;
+	let postFirstTreeLazyPublicInstances = false;
+	let deferredFirstTreeCapabilities: LynxMainThreadCapabilities | undefined;
 	let readinessRetrySent = false;
 	let disposeDeferred: Deferred<void> | null = null;
 	let disposeIdentity: UniversalTransportIdentity | null = null;
@@ -748,7 +752,15 @@ export function createLynxBackgroundTransport(
 		if (readyReceived || readyDeferred.settled) {
 			return;
 		}
-		const capabilities = message.firstTree === undefined ? message.capabilities : undefined;
+		const adoptingFirstTree = message.firstTree !== undefined;
+		const capabilities = adoptingFirstTree ? undefined : message.capabilities;
+		// The first background batch must preserve main's exact first-screen IDs.
+		// New peers can advertise future intrinsic programs on the same correlated
+		// reply; older peers never advertised templateProgram alongside firstTree.
+		deferredFirstTreeCapabilities =
+			adoptingFirstTree && message.capabilities?.templateProgram === 1
+				? message.capabilities
+				: undefined;
 		compactAcknowledgements = capabilities?.compactAck === 1;
 		lazyPublicInstances = capabilities?.lazyPublicInstances === 1;
 		setLynxClientCapabilities(container, capabilities);
@@ -771,7 +783,11 @@ export function createLynxBackgroundTransport(
 		const previousAccepted = accepted;
 		try {
 			if (message.encoding === LYNX_COMPACT_ACKNOWLEDGEMENT) {
-				if (!compactAcknowledgements || !entry.compactRequested) {
+				if (
+					!compactAcknowledgements ||
+					!entry.compactRequested ||
+					(previousAccepted !== null && !entry.incrementalCompactRequested)
+				) {
 					throw new Error('Octane Lynx received an unnegotiated compact acknowledgement.');
 				}
 				handles = prepareLynxCompactHandleDeltas(
@@ -780,6 +796,7 @@ export function createLynxBackgroundTransport(
 					message.count,
 					message,
 					entry.compactHostCount ?? undefined,
+					entry.incrementalCompactRequested,
 				);
 			} else {
 				handles = prepareLynxHandleDeltas(container, entry.batch, message.handles, message);
@@ -816,6 +833,20 @@ export function createLynxBackgroundTransport(
 				);
 				return;
 			}
+		}
+		if (
+			(message.adoption === 'adopted' || message.adoption === 'repaired') &&
+			deferredFirstTreeCapabilities !== undefined
+		) {
+			// Main releases the adopted journal synchronously while handling
+			// adoption-ready; repaired journals are disposed before their ACK.
+			// The first adopted batch remains legacy. A later safe run can reuse
+			// compact-v1 only after this identity-correlated handoff completes.
+			setLynxClientCapabilities(container, deferredFirstTreeCapabilities);
+			compactAcknowledgements = deferredFirstTreeCapabilities.compactAck === 1;
+			lazyPublicInstances = deferredFirstTreeCapabilities.lazyPublicInstances === 1;
+			postFirstTreeLazyPublicInstances = deferredFirstTreeCapabilities.lazyPublicInstances === 1;
+			deferredFirstTreeCapabilities = undefined;
 		}
 		publishAcknowledgementMainCalls(message);
 		// The acknowledgement just published this batch's hosts, which is what a
@@ -1472,6 +1503,7 @@ export function createLynxBackgroundTransport(
 						token,
 						state: 'waiting-ready',
 						compactRequested: false,
+						incrementalCompactRequested: false,
 						compactHostCount: null,
 						abortRequested: false,
 						deferredResponse: null,
@@ -1488,10 +1520,26 @@ export function createLynxBackgroundTransport(
 							const compact = count !== null;
 							entry.compactRequested = compact;
 							entry.compactHostCount = count;
+							const incrementalRun =
+								preparedBatch.commands.length === 1 ? preparedBatch.commands[0] : undefined;
+							entry.incrementalCompactRequested =
+								compact &&
+								accepted !== null &&
+								postFirstTreeLazyPublicInstances &&
+								incrementalRun?.op === 'mount-template-run' &&
+								Object.isFrozen(incrementalRun) &&
+								Object.isFrozen(incrementalRun.program) &&
+								Object.isFrozen(incrementalRun.values);
 							const deferPublicInstances =
 								compact &&
 								lazyPublicInstances &&
-								accepted === null &&
+								(accepted === null ||
+									(postFirstTreeLazyPublicInstances &&
+										preparedBatch.commands.every(
+											(command) =>
+												command.op === 'mount-template-range' ||
+												command.op === 'mount-template-run',
+										))) &&
 								preparedBatch.commands.some(
 									(command) =>
 										command.op === 'mount-template-range' || command.op === 'mount-template-run',

--- a/packages/lynx/src/main-thread.ts
+++ b/packages/lynx/src/main-thread.ts
@@ -170,7 +170,8 @@ interface LynxQueuedNativeEventDelivery {
 interface ActiveLynxMainRoot<Node extends LynxElementRef> {
 	readonly root: number;
 	readonly container: LynxHostContainer<Node>;
-	readonly capabilities?: LynxMainThreadCapabilities;
+	capabilities?: LynxMainThreadCapabilities;
+	postFirstTreeUpgrade?: true;
 	acceptedVersion: number;
 	lastMainCall: number;
 	lastMainCallPublication: number;
@@ -460,6 +461,30 @@ function acknowledgementHandles<Node extends LynxElementRef>(
 	return Object.freeze(handles);
 }
 
+function freezeValidatedIntrinsicRun(
+	run: Extract<UniversalHostBatch['commands'][number], { readonly op: 'mount-template-run' }>,
+): void {
+	// MessagePort structured-clones worker payloads and drops every frozen
+	// descriptor. Restore immutability only after the complete receive-boundary
+	// validator has rejected hostile prototypes, accessors, symbols, and scalars.
+	// The program is a tiny shared shape; its flat values are frozen in place.
+	const program = run.program;
+	for (const node of program.nodes) {
+		Object.freeze(node.props);
+		if (node.bindings !== undefined) {
+			for (const binding of node.bindings) Object.freeze(binding);
+			Object.freeze(node.bindings);
+		}
+		Object.freeze(node);
+	}
+	Object.freeze(program.nodes);
+	for (const event of program.events) Object.freeze(event);
+	Object.freeze(program.events);
+	Object.freeze(program);
+	Object.freeze(run.values);
+	Object.freeze(run);
+}
+
 /**
  * Install the main-thread receiver that owns one root-scoped Element PAPI host.
  * Importing this module is inert; framework bootstrap calls this function on
@@ -564,6 +589,7 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 	let dispatchingReadyRequest: number | null = null;
 	let correlatedReadySent = false;
 	let negotiatedCapabilities: LynxMainThreadCapabilities | undefined;
+	let deferredFirstTreeCapabilities: LynxMainThreadCapabilities | undefined;
 	let firstTreeSnapshotSent = false;
 	let uninstallFirstScreenHost: (() => void) | null = null;
 	const queuedCommits: LynxCommitMessage[] = [];
@@ -1252,21 +1278,15 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 							...(driver.capabilities?.templateMount === true
 								? { templateMount: 1 as const }
 								: null),
-							...(firstTree === null &&
-							snapshot === null &&
-							driver.capabilities?.templateProgramMount === true
+							...(driver.capabilities?.templateProgramMount === true
 								? { templateProgram: 1 as const }
 								: null),
 							...(request >= LYNX_LAZY_PUBLIC_INSTANCE_READY_REQUEST_BASE &&
-							firstTree === null &&
-							snapshot === null &&
 							driver.capabilities?.templateProgramMount === true &&
 							driver.capabilities?.lazyPublicInstances === true
 								? { lazyPublicInstances: 1 as const }
 								: null),
 							...(request >= LYNX_TEMPLATE_RUN_READY_REQUEST_BASE &&
-							firstTree === null &&
-							snapshot === null &&
 							driver.capabilities?.templateProgramMount === true &&
 							driver.capabilities?.templateProgramRuns === true
 								? { templateRuns: 1 as const }
@@ -1282,8 +1302,15 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 		dispatch(reply);
 		if (request !== LYNX_READY_ANNOUNCEMENT_REQUEST) {
 			// Delivery must succeed before an inbound commit can exercise any optional
-			// wire behavior. First-tree peers deliberately discard every capability.
-			negotiatedCapabilities = snapshot === null ? reply.capabilities : undefined;
+			// wire behavior. Keep first-tree capabilities dormant until its exact
+			// legacy adoption has completed and the main-thread journal is released.
+			if (snapshot === null) {
+				negotiatedCapabilities = reply.capabilities;
+			} else {
+				negotiatedCapabilities = undefined;
+				deferredFirstTreeCapabilities =
+					reply.capabilities?.templateProgram === 1 ? reply.capabilities : undefined;
+			}
 		}
 		if (snapshot !== null) firstTreeSnapshotSent = true;
 		return true;
@@ -1343,6 +1370,16 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 			return;
 		}
 		firstTree = null;
+	};
+
+	const activateFirstTreeCapabilities = (record: ActiveLynxMainRoot<Node>): void => {
+		if (firstTree !== null || record.faulted || deferredFirstTreeCapabilities === undefined) {
+			return;
+		}
+		record.capabilities = deferredFirstTreeCapabilities;
+		record.postFirstTreeUpgrade = true;
+		negotiatedCapabilities = deferredFirstTreeCapabilities;
+		deferredFirstTreeCapabilities = undefined;
 	};
 
 	const disposeAvailableFirstTree = (): boolean => {
@@ -1971,9 +2008,20 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 			return;
 		}
 		const peerCapabilities = active === null ? negotiatedCapabilities : active.capabilities;
+		const postFirstTreeLazyPublicInstances =
+			message.instances === LYNX_LAZY_PUBLIC_INSTANCES && active !== null;
+		const incrementalRun =
+			message.batch.commands.length === 1 ? message.batch.commands[0] : undefined;
 		if (
 			message.instances === LYNX_LAZY_PUBLIC_INSTANCES &&
-			peerCapabilities?.lazyPublicInstances !== 1
+			(peerCapabilities?.lazyPublicInstances !== 1 ||
+				(postFirstTreeLazyPublicInstances &&
+					(active?.postFirstTreeUpgrade !== true ||
+						message.batch.commands.length === 0 ||
+						!message.batch.commands.every(
+							(command) =>
+								command.op === 'mount-template-range' || command.op === 'mount-template-run',
+						))))
 		) {
 			reject(identity, new Error('Octane Lynx rejected unnegotiated lazy public instances.'));
 			return;
@@ -1994,6 +2042,24 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 					);
 					return;
 				}
+			}
+		}
+		let postFirstTreeIncrementalCompact = false;
+		if (
+			postFirstTreeLazyPublicInstances &&
+			active?.postFirstTreeUpgrade === true &&
+			peerCapabilities?.compactAck === 1 &&
+			peerCapabilities.templateProgram === 1 &&
+			peerCapabilities.templateRuns === 1 &&
+			message.ack === LYNX_COMPACT_ACKNOWLEDGEMENT &&
+			incrementalRun?.op === 'mount-template-run'
+		) {
+			try {
+				freezeValidatedIntrinsicRun(incrementalRun);
+				postFirstTreeIncrementalCompact = true;
+			} catch (error) {
+				reject(identity, error);
+				return;
 			}
 		}
 
@@ -2037,7 +2103,11 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 						? message.instances === LYNX_LAZY_PUBLIC_INSTANCES
 							? { compact: true, lazyPublicInstances: true }
 							: { compact: true }
-						: undefined
+						: postFirstTreeIncrementalCompact
+							? { compact: true, incrementalCompact: true, lazyPublicInstances: true }
+							: postFirstTreeLazyPublicInstances
+								? { lazyPublicInstances: true }
+								: undefined
 					: {
 							firstTree: candidateFirstTree,
 							onMismatch(error) {
@@ -2093,15 +2163,20 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 			if (prepared.firstTreeAction === 'repair' || applyFailed) {
 				disposeAvailableFirstTree();
 			}
+			if (!applyFailed && prepared.firstTreeAction === 'repair') {
+				activateFirstTreeCapabilities(record);
+			}
 		}
 		const startedAck = LYNX_PROFILE ? performance.now() : 0;
 		let compactCount: number | null =
 			message.ack === LYNX_COMPACT_ACKNOWLEDGEMENT &&
-			provisional &&
+			(provisional || postFirstTreeIncrementalCompact) &&
 			!applyFailed &&
 			prepared.firstTreeAction === 'none' &&
 			prepared.listAncestryDelta.length === 0
-				? (prepared.compactHostCount ?? countLynxCompactAcknowledgementHosts(message.batch))
+				? provisional
+					? (prepared.compactHostCount ?? countLynxCompactAcknowledgementHosts(message.batch))
+					: (prepared.compactHostCount ?? null)
 				: null;
 		if (compactCount !== null && compactCount < LYNX_COMPACT_ACKNOWLEDGEMENT_MIN_HOSTS) {
 			compactCount = null;
@@ -2241,6 +2316,7 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 			awaitingAdoption = null;
 			releaseFirstTree();
 		}
+		activateFirstTreeCapabilities(active);
 		openBackgroundCalls();
 	};
 

--- a/packages/lynx/tests/first-screen.test.ts
+++ b/packages/lynx/tests/first-screen.test.ts
@@ -1,9 +1,11 @@
 import { installLynxTestingEnv, uninstallLynxTestingEnv } from '@lynx-js/testing-environment';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { deserialize, serialize } from 'node:v8';
 import { JSDOM } from 'jsdom';
 import {
 	defineUniversalComponent,
+	universalComponent,
 	universalFor,
 	universalPlan,
 	universalProps,
@@ -28,16 +30,22 @@ import {
 } from '../src/main-renderer.js';
 import {
 	LYNX_BACKGROUND_TO_MAIN_EVENT,
+	LYNX_COMPACT_ACKNOWLEDGEMENT,
+	LYNX_LAZY_PUBLIC_INSTANCES,
 	LYNX_MAIN_TO_BACKGROUND_EVENT,
 	LYNX_TRANSPORT_PROTOCOL_VERSION,
 	LYNX_TRANSPORT_RENDERER,
 	type LynxBackgroundInboundMessage,
+	type LynxBackgroundOutboundMessage,
 	type LynxContextProxy,
 } from '../src/core/protocol.js';
 
 interface SceneProps {
 	readonly id: string;
 	readonly items: readonly string[];
+	readonly componentItems?: readonly string[];
+	readonly rowPrefix?: string;
+	readonly onRowTap?: (id: string) => void;
 	readonly onTap: (payload: unknown) => void;
 	readonly onEffect: (owner: 'main' | 'background') => void;
 }
@@ -58,16 +66,24 @@ const mainPlan = firstScreenPlan('lynx', {
 	propsSlot: 0,
 });
 
+const mainScenePlan = firstScreenPlan('lynx', {
+	kind: 'host',
+	type: 'view',
+	propsSlot: 0,
+	children: [{ kind: 'slot', slot: 1 }],
+});
+
 const MainScene = defineFirstScreenComponent('lynx', (props: SceneProps) => {
 	useFirstScreenLayoutEffect(() => {
 		props.onEffect('main');
 	});
 	return [
-		firstScreenValue(mainPlan, [
+		firstScreenValue(mainScenePlan, [
 			firstScreenProps([
 				['set', 'id', props.id],
 				['set', 'bindtap', firstScreenEvent],
 			]),
+			null,
 		]),
 		firstScreenFor(
 			props.items,
@@ -191,16 +207,66 @@ const backgroundPlan = universalPlan('lynx', {
 	propsSlot: 0,
 });
 
+const backgroundScenePlan = universalPlan('lynx', {
+	kind: 'host',
+	type: 'view',
+	propsSlot: 0,
+	children: [{ kind: 'slot', slot: 1 }],
+});
+
+const postAdoptionRowPlan = universalPlan('lynx', {
+	kind: 'host',
+	type: 'view',
+	bindings: [['id', 0]],
+	children: [
+		{
+			kind: 'host',
+			type: 'text',
+			bindings: [['bindtap', 2]],
+			children: [{ kind: 'slot', slot: 1 }],
+		},
+	],
+});
+
+const PostAdoptionRow = defineUniversalComponent(
+	'lynx',
+	({
+		id,
+		label,
+		onTap,
+	}: {
+		readonly id: string;
+		readonly label: string;
+		readonly onTap: (id: string) => void;
+	}) => universalValue(postAdoptionRowPlan, [id, label, () => onTap(id)]),
+);
+
 const BackgroundScene = defineUniversalComponent('lynx', (props: SceneProps) => {
 	useLayoutEffect(() => {
 		props.onEffect('background');
 	}, []);
 	return [
-		universalValue(backgroundPlan, [
+		universalValue(backgroundScenePlan, [
 			universalProps([
 				['set', 'id', props.id],
 				['set', 'bindtap', props.onTap],
 			]),
+			props.componentItems === undefined
+				? null
+				: universalFor(
+						props.componentItems,
+						(id) => id,
+						(id) =>
+							universalComponent(
+								'lynx',
+								PostAdoptionRow,
+								universalProps([
+									['set', 'id', id],
+									['set', 'label', `${props.rowPrefix ?? 'label'}:${id}`],
+									['set', 'onTap', props.onRowTap ?? (() => {})],
+								]),
+							),
+					),
 		]),
 		universalFor(
 			props.items,
@@ -348,8 +414,12 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 	it('paints synchronously, gates background startup, adopts node identity, and replays events', async () => {
 		const { dom, main, registrations } = installEnvironment();
 		const inbound: LynxBackgroundInboundMessage[] = [];
+		const outbound: LynxBackgroundOutboundMessage[] = [];
 		mainContext().addEventListener(LYNX_MAIN_TO_BACKGROUND_EVENT, (event) => {
 			inbound.push(event.data as LynxBackgroundInboundMessage);
+		});
+		mainContext().addEventListener(LYNX_BACKGROUND_TO_MAIN_EVENT, (event) => {
+			outbound.push(event.data as LynxBackgroundOutboundMessage);
 		});
 		const effects: string[] = [];
 		const events: unknown[] = [];
@@ -390,6 +460,29 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 		main.dispatchNativeEvent(placeholderToken!, { type: 'tap', detail: { phase: 'first' } });
 
 		globalThis.lynxTestingEnv.switchToBackgroundThread();
+		const context = backgroundContext();
+		const dispatch = context.dispatchEvent.bind(context);
+		const clonedRuns: boolean[] = [];
+		context.dispatchEvent = (event) => {
+			const data = deserialize(serialize(event.data)) as unknown;
+			if (
+				data !== null &&
+				typeof data === 'object' &&
+				'type' in data &&
+				data.type === 'commit' &&
+				'batch' in data
+			) {
+				const batch = data.batch as { commands?: readonly unknown[] };
+				const run = batch.commands?.[0] as
+					{ op?: string; program?: object; values?: readonly unknown[] } | undefined;
+				if (run?.op === 'mount-template-run') {
+					clonedRuns.push(
+						!Object.isFrozen(run) && !Object.isFrozen(run.program) && !Object.isFrozen(run.values),
+					);
+				}
+			}
+			return dispatch({ ...event, data });
+		};
 		backgroundRoot = createLynxRoot();
 		const rendering = backgroundRoot.render(BackgroundScene, props);
 		let settled = false;
@@ -421,8 +514,67 @@ describe.sequential('Lynx synchronous first-screen adoption', () => {
 		expect(ready[0]).toMatchObject({
 			type: 'main-ready',
 			firstTree: { root: 1, version: 1 },
+			capabilities: { templateProgram: 1, templateRuns: 1, lazyPublicInstances: 1 },
 		});
 		expect((ready[0] as { request: number }).request).toBeGreaterThan(0);
+		const adoptionCommit = outbound.find((message) => message.type === 'commit');
+		expect(adoptionCommit).not.toHaveProperty('ack');
+		expect(adoptionCommit).not.toHaveProperty('instances');
+
+		const componentItems = ['row-a', 'row-b', 'row-c', 'row-d', 'row-e', 'row-f', 'row-g', 'row-h'];
+		const rowTaps: string[] = [];
+		await backgroundRoot.render(BackgroundScene, {
+			...props,
+			componentItems,
+			onRowTap: (id) => rowTaps.push(id),
+		});
+		expect(dom.window.document.querySelector('#first-screen')).toBe(firstNode);
+		expect(dom.window.document.querySelector('#a')).toBe(firstA);
+		expect(dom.window.document.querySelector('#b')).toBe(firstB);
+		expect(
+			componentItems.map((id) => dom.window.document.querySelector(`#${id}`)?.textContent),
+		).toEqual(componentItems.map((id) => `label:${id}`));
+		const creation = outbound.filter((message) => message.type === 'commit').at(-1);
+		expect(creation).toMatchObject({
+			ack: LYNX_COMPACT_ACKNOWLEDGEMENT,
+			instances: LYNX_LAZY_PUBLIC_INSTANCES,
+			batch: { commands: [{ op: 'mount-template-run' }] },
+		});
+		const creationAcknowledgement = inbound.find(
+			(message) => message.type === 'ack' && message.version === creation!.version,
+		);
+		expect(creationAcknowledgement).toMatchObject({
+			encoding: LYNX_COMPACT_ACKNOWLEDGEMENT,
+			count: componentItems.length * 3,
+		});
+		expect(creationAcknowledgement).not.toHaveProperty('handles');
+		expect(clonedRuns).toEqual([true]);
+		const lastRowListener = registrations.at(-1)?.listener;
+		expect(lastRowListener).toBeTypeOf('string');
+		main.dispatchNativeEvent(lastRowListener!, { type: 'tap' });
+		expect(rowTaps).toEqual(['row-h']);
+		expect(main.diagnostics()).toEqual([]);
+
+		await backgroundRoot.render(BackgroundScene, {
+			...props,
+			componentItems,
+			rowPrefix: 'updated',
+			onRowTap: (id) => rowTaps.push(id),
+		});
+		expect(dom.window.document.querySelector('#row-a')?.textContent).toBe('updated:row-a');
+		expect(dom.window.document.querySelector('#first-screen')).toBe(firstNode);
+
+		await backgroundRoot.render(BackgroundScene, {
+			...props,
+			componentItems: componentItems.slice(0, -1),
+			rowPrefix: 'updated',
+			onRowTap: (id) => rowTaps.push(id),
+		});
+		expect(dom.window.document.querySelector('#row-h')).toBeNull();
+		expect(dom.window.document.querySelector('#first-screen')).toBe(firstNode);
+		main.dispatchNativeEvent(lastRowListener!, { type: 'tap' });
+		expect(rowTaps).toEqual(['row-h']);
+		expect(main.diagnostics().at(-1)?.message).toMatch(/stale, hidden, removed, or foreign/);
 	});
 
 	it('defers an engine-mode first screen until __RenderPage arrives', () => {

--- a/packages/lynx/tests/host-driver.test.ts
+++ b/packages/lynx/tests/host-driver.test.ts
@@ -372,6 +372,94 @@ describe('Lynx Element PAPI host driver', () => {
 		expect(papi.calls).toEqual(['getUniqueId']);
 	});
 
+	it('captures an optional native append operation without changing anchored insertion', () => {
+		const dom = new JSDOM();
+		installLynxTestingEnv(globalThis, { window: dom.window as never });
+		const environment = globalThis.lynxTestingEnv;
+		environment.clearGlobal();
+		environment.switchToMainThread();
+		try {
+			const target = globalThis as unknown as {
+				__AppendElement?: (parent: object, child: object) => void;
+				__InsertElementBefore: (parent: object, child: object, before?: object) => void;
+			};
+			let receiver: unknown;
+			target.__AppendElement = function (parent, child) {
+				receiver = this;
+				target.__InsertElementBefore(parent, child);
+			};
+			const papi = createLynxElementPAPI(globalThis) as ReturnType<typeof createLynxElementPAPI> & {
+				append?: (parent: object, child: object) => void;
+			};
+			expect(typeof papi.append).toBe('function');
+			const page = papi.createPage('append-test', 0);
+			const first = papi.createElement('view', papi.getUniqueId(page), '');
+			const before = papi.createElement('view', papi.getUniqueId(page), '');
+			papi.append!(page, first);
+			expect(receiver).toBe(globalThis);
+			papi.insertBefore(page, before, first);
+			expect((page as Element).children[0]).toBe(before);
+			expect((page as Element).children[1]).toBe(first);
+		} finally {
+			environment.clearGlobal();
+			uninstallLynxTestingEnv(globalThis);
+			dom.window.close();
+		}
+	});
+
+	it('captures receiver-bound intrinsic element factories without changing authored text', () => {
+		const dom = new JSDOM();
+		installLynxTestingEnv(globalThis, { window: dom.window as never });
+		const environment = globalThis.lynxTestingEnv;
+		environment.clearGlobal();
+		environment.switchToMainThread();
+		try {
+			const target = globalThis as unknown as {
+				__CreateView(parent: number): object;
+				__CreateText(parent: number): object;
+				__CreateRawText(text: string): object;
+			};
+			const view = target.__CreateView;
+			const text = target.__CreateText;
+			const rawText = target.__CreateRawText;
+			const receivers: unknown[] = [];
+			target.__CreateView = function (parent) {
+				receivers.push(this);
+				return view.call(this, parent);
+			};
+			target.__CreateText = function (parent) {
+				receivers.push(this);
+				return text.call(this, parent);
+			};
+			target.__CreateRawText = function (value) {
+				receivers.push(this);
+				return rawText.call(this, value);
+			};
+			const papi = createLynxElementPAPI(globalThis) as ReturnType<typeof createLynxElementPAPI> & {
+				intrinsics?: {
+					view(parent: number): object;
+					text(parent: number): object;
+					rawText(value: string): object;
+				};
+			};
+			expect(papi.intrinsics).toBeDefined();
+			const page = papi.createPage('intrinsic-test', 0);
+			const pageId = papi.getUniqueId(page);
+			const element = papi.intrinsics!.view(pageId);
+			const label = papi.intrinsics!.text(pageId);
+			const value = papi.intrinsics!.rawText('native text');
+			papi.insertBefore(page, element, null);
+			papi.insertBefore(element, label, null);
+			papi.insertBefore(label, value, null);
+			expect((page as Element).textContent).toBe('native text');
+			expect(receivers.every((receiver) => receiver === globalThis)).toBe(true);
+		} finally {
+			environment.clearGlobal();
+			uninstallLynxTestingEnv(globalThis);
+			dom.window.close();
+		}
+	});
+
 	it('transfers a compatible first tree without allocating or restructuring native nodes', () => {
 		const papi = createFakePAPI();
 		const page = papi.createPage('entry', 0);
@@ -2872,6 +2960,724 @@ describe('Lynx Element PAPI host driver', () => {
 		expect(row.selector).toBe('r38-h2-g1');
 		expect(text.selector).toBe('');
 		expect(papi.calls.filter((call) => call === 'setRefSelector')).toEqual(['setRefSelector']);
+	});
+
+	it('keeps accepted-root program hosts queryable without publishing unrequested selectors', () => {
+		const { container, driver, page, papi } = createHost(48);
+		prepareLynxHostBatch(
+			container,
+			batch(1, [
+				{ op: 'create', id: 1, type: 'view', props: { id: 'shell' } },
+				{ op: 'insert', id: 1, parent: null, before: null },
+			]),
+		).apply();
+		const shell = page.children[0]!;
+		expect(shell.selector).toBe('r48-h1-g1');
+
+		const program: UniversalHostTemplateProgram = Object.freeze({
+			nodes: Object.freeze([
+				Object.freeze({ type: 'view', parent: -1, props: Object.freeze({ class: 'row' }) }),
+				Object.freeze({ type: 'text', parent: 0, props: Object.freeze({ class: 'label' }) }),
+				Object.freeze({ type: '#text', parent: 1, props: Object.freeze({ value: 'ready' }) }),
+				Object.freeze({ type: 'view', parent: 0, props: Object.freeze({ class: 'action' }) }),
+			]),
+			events: Object.freeze([
+				Object.freeze({ node: 3, type: 'bindtap', priority: 'discrete' as const }),
+			]),
+		});
+		papi.resetCalls();
+		const prepared = prepareLynxHostBatch(
+			container,
+			batch(2, [
+				{
+					op: 'mount-template-run',
+					parent: 1,
+					before: null,
+					program,
+					firstId: 10,
+					firstListenerId: 700,
+					count: 2,
+					values: Object.freeze([]),
+				},
+			]),
+			{ lazyPublicInstances: true },
+		);
+		expect(prepared.compactHostCount).toBeUndefined();
+		prepared.apply();
+		expect(shell.selector).toBe('r48-h1-g1');
+		expect(shell.children).toHaveLength(2);
+		expect(shell.children[0]!.selector).toBe('');
+		expect(shell.children[1]!.children[0]!.selector).toBe('');
+		expect(shell.children[1]!.children[0]!.children[0]!.text).toBe('ready');
+		expect(shell.children[1]!.children[1]!.selector).toBe('');
+		expect(
+			resolveLynxHostNativeEvent(
+				container,
+				shell.children[1]!.children[1]!.events.get('bindEvent:tap')!,
+			),
+		).toEqual({
+			listener: 701,
+			priority: 'discrete',
+		});
+		expect(prepared.handleDelta).toHaveLength(8);
+		expect(prepared.handleDelta.every((delta) => delta.op === 'create')).toBe(true);
+		expect(papi.calls.filter((call) => call === 'setRefSelector')).toEqual([]);
+
+		const requested = driver.getPublicInstance(container, 17);
+		expect(requested).toMatchObject({
+			id: 17,
+			generation: 1,
+			selector: '[octane-ref=r48-h17-g1]',
+		});
+		expect(shell.children[1]!.children[1]!.selector).toBe('r48-h17-g1');
+		expect(shell.children[0]!.selector).toBe('');
+		expect(papi.calls.filter((call) => call === 'setRefSelector')).toEqual(['setRefSelector']);
+		expect(driver.getPublicInstance(container, 17)).toBe(requested);
+		expect(papi.calls.filter((call) => call === 'setRefSelector')).toEqual(['setRefSelector']);
+
+		papi.resetCalls();
+		prepareLynxHostBatch(
+			container,
+			batch(3, [
+				{ op: 'ensure-public-instance', id: 10 },
+				{ op: 'ensure-public-instance', id: 10 },
+			]),
+		).apply();
+		expect(shell.children[0]!.selector).toBe('r48-h10-g1');
+		expect(papi.calls.filter((call) => call === 'setRefSelector')).toEqual(['setRefSelector']);
+	});
+
+	it('preserves adopted-shell identity while compact program rows remain live and sparsely queryable', () => {
+		const { container, driver, page, papi } = createHost(52);
+		prepareLynxHostBatch(
+			container,
+			batch(1, [
+				{ op: 'create', id: 1, type: 'view', props: { id: 'shell' } },
+				{ op: 'create', id: 2, type: 'view', props: { id: 'table' } },
+				{ op: 'insert', id: 2, parent: 1, before: null },
+				{ op: 'insert', id: 1, parent: null, before: null },
+			]),
+		).apply();
+		const shellHandle = driver.getPublicInstance(container, 1);
+		const shell = page.children[0]!;
+		const table = shell.children[0]!;
+		const program: UniversalHostTemplateProgram = Object.freeze({
+			nodes: Object.freeze([
+				Object.freeze({
+					type: 'view',
+					parent: -1,
+					props: Object.freeze({}),
+					bindings: Object.freeze([
+						Object.freeze({ name: 'class', valueIndex: 0 }),
+						Object.freeze({ name: 'id', valueIndex: 1 }),
+					]),
+				}),
+				Object.freeze({ type: 'text', parent: 0, props: Object.freeze({ class: 'label' }) }),
+				Object.freeze({
+					type: '#text',
+					parent: 1,
+					props: Object.freeze({}),
+					bindings: Object.freeze([Object.freeze({ name: 'value', valueIndex: 2 })]),
+				}),
+				Object.freeze({ type: 'view', parent: 0, props: Object.freeze({ class: 'action' }) }),
+			]),
+			events: Object.freeze([
+				Object.freeze({ node: 0, type: 'bindtap', priority: 'default' as const }),
+				Object.freeze({ node: 3, type: 'catchtap', priority: 'discrete' as const }),
+			]),
+		});
+		const prepared = prepareLynxHostBatch(
+			container,
+			batch(2, [
+				{
+					op: 'mount-template-run',
+					parent: 2,
+					before: null,
+					program,
+					firstId: 10,
+					firstListenerId: 900,
+					count: 3,
+					values: Object.freeze([
+						'first',
+						'row-1',
+						'One',
+						'second',
+						'row-2',
+						'Two',
+						'third',
+						'row-3',
+						'Three',
+					]),
+				},
+			]),
+			{ compact: true, incrementalCompact: true, lazyPublicInstances: true },
+		);
+		expect(prepared.compactHostCount).toBe(12);
+		expect(container.instanceCount).toBe(2);
+		expect(table.children).toEqual([]);
+		prepared.apply();
+		expect(container.instanceCount).toBe(14);
+		expect(driver.getPublicInstance(container, 1)).toBe(shellHandle);
+		expect(shell.selector).toBe('r52-h1-g1');
+		expect(table.selector).toBe('r52-h2-g1');
+		expect(table.children.map((node) => node.id)).toEqual(['row-1', 'row-2', 'row-3']);
+		expect(table.children[1]!.classes).toBe('second');
+		expect(table.children[1]!.children[0]!.children[0]!.text).toBe('Two');
+		expect(table.children[1]!.selector).toBe('');
+		const retired = table.children[1]!.events.get('bindEvent:tap')!;
+		expect(resolveLynxHostNativeEvent(container, retired)).toEqual({
+			listener: 902,
+			priority: 'default',
+		});
+
+		papi.resetCalls();
+		prepareLynxHostBatch(
+			container,
+			batch(3, [
+				{ op: 'update', id: 14, props: { class: 'selected', id: 'row-2' } },
+				{ op: 'update', id: 16, props: { value: 'Changed' } },
+				{
+					op: 'event',
+					id: 14,
+					type: 'bindtap',
+					listener: { id: 990, priority: 'continuous' },
+				},
+				{ op: 'ensure-public-instance', id: 21 },
+			]),
+		).apply();
+		expect(table.children[1]!.classes).toBe('selected');
+		expect(table.children[1]!.children[0]!.children[0]!.text).toBe('Changed');
+		expect(resolveLynxHostNativeEvent(container, retired)).toBeNull();
+		expect(
+			resolveLynxHostNativeEvent(container, table.children[1]!.events.get('bindEvent:tap')!),
+		).toEqual({ listener: 990, priority: 'continuous' });
+		expect(table.children[2]!.children[1]!.selector).toBe('r52-h21-g1');
+		expect(papi.calls.filter((call) => call === 'setRefSelector')).toEqual(['setRefSelector']);
+
+		prepareLynxHostBatch(
+			container,
+			batch(4, [
+				{ op: 'remove', parent: 2, id: 14 },
+				{ op: 'destroy', id: 16 },
+				{ op: 'destroy', id: 15 },
+				{ op: 'destroy', id: 17 },
+				{ op: 'destroy', id: 14 },
+			]),
+		).apply();
+		expect(table.children.map((node) => node.id)).toEqual(['row-1', 'row-3']);
+		prepareLynxHostBatch(
+			container,
+			batch(5, [
+				{ op: 'create', id: 14, type: 'view', props: { id: 'replacement' } },
+				{ op: 'insert', parent: 2, id: 14, before: 18 },
+			]),
+		).apply();
+		expect(driver.getPublicInstance(container, 14)?.generation).toBe(2);
+		expect(table.children.map((node) => node.id)).toEqual(['row-1', 'replacement', 'row-3']);
+		expect(disposeLynxHostContainer(container).complete).toBe(true);
+		expect(page.children).toEqual([]);
+	});
+
+	it('abandons a compact accepted-root suffix without changing the accepted shell', () => {
+		const { container, driver, page, papi } = createHost(53);
+		prepareLynxHostBatch(
+			container,
+			batch(1, [
+				{ op: 'create', id: 1, type: 'view', props: { id: 'shell' } },
+				{ op: 'insert', id: 1, parent: null, before: null },
+			]),
+		).apply();
+		const accepted = driver.getPublicInstance(container, 1);
+		const program: UniversalHostTemplateProgram = Object.freeze({
+			nodes: Object.freeze([Object.freeze({ type: 'view', parent: -1, props: Object.freeze({}) })]),
+			events: Object.freeze([]),
+		});
+		papi.resetCalls();
+		const prepared = prepareLynxHostBatch(
+			container,
+			batch(2, [
+				{
+					op: 'mount-template-run',
+					parent: 1,
+					before: null,
+					program,
+					firstId: 10,
+					firstListenerId: null,
+					count: 2,
+					values: Object.freeze([]),
+				},
+			]),
+			{ compact: true, incrementalCompact: true, lazyPublicInstances: true },
+		);
+		expect(prepared.compactHostCount).toBe(2);
+		expect(container.instanceCount).toBe(1);
+		expect(page.children[0]!.children).toEqual([]);
+		prepared.abort();
+		prepared.apply();
+		expect(container.instanceCount).toBe(1);
+		expect(container.acceptedVersion).toBe(1);
+		expect(driver.getPublicInstance(container, 1)).toBe(accepted);
+		expect(page.children[0]!.children).toEqual([]);
+		expect(papi.calls).toEqual([]);
+	});
+
+	it('uses direct intrinsic factories for dense programs without changing dynamic text, events, or custom hosts', () => {
+		const { container, page, papi } = createHost(60);
+		prepareLynxHostBatch(
+			container,
+			batch(1, [
+				{ op: 'create', id: 1, type: 'view', props: {} },
+				{ op: 'insert', id: 1, parent: null, before: null },
+			]),
+		).apply();
+		const create = papi.createElement.bind(papi);
+		const directTypes: string[] = [];
+		const genericTypes: string[] = [];
+		const optimized = papi as FakePAPI & {
+			intrinsics: {
+				view(parent: number): FakeNode;
+				text(parent: number): FakeNode;
+				rawText(value: string): FakeNode;
+			};
+		};
+		optimized.intrinsics = Object.freeze({
+			view(parent: number): FakeNode {
+				directTypes.push('view');
+				return create('view', parent, '');
+			},
+			text(parent: number): FakeNode {
+				directTypes.push('text');
+				return create('text', parent, '');
+			},
+			rawText(value: string): FakeNode {
+				directTypes.push('raw-text');
+				return create('#text', 0, value);
+			},
+		});
+		papi.createElement = (type, parent, text) => {
+			if (type === 'view' || type === 'text' || type === '#text' || type === 'raw-text') {
+				throw new Error(`Intrinsic ${type} used the generic factory.`);
+			}
+			genericTypes.push(type);
+			return create(type, parent, text);
+		};
+		const program: UniversalHostTemplateProgram = Object.freeze({
+			nodes: Object.freeze([
+				Object.freeze({ type: 'view', parent: -1, props: Object.freeze({}) }),
+				Object.freeze({ type: 'text', parent: 0, props: Object.freeze({}) }),
+				Object.freeze({
+					type: '#text',
+					parent: 1,
+					props: Object.freeze({}),
+					bindings: Object.freeze([Object.freeze({ name: 'value', valueIndex: 0 })]),
+				}),
+				Object.freeze({ type: 'text', parent: 0, props: Object.freeze({}) }),
+				Object.freeze({ type: '#text', parent: 3, props: Object.freeze({ value: 'static' }) }),
+				Object.freeze({ type: 'image', parent: 0, props: Object.freeze({}) }),
+			]),
+			events: Object.freeze([
+				Object.freeze({ node: 0, type: 'bindtap', priority: 'default' as const }),
+			]),
+		});
+		prepareLynxHostBatch(
+			container,
+			batch(2, [
+				{
+					op: 'mount-template-run',
+					parent: 1,
+					before: null,
+					program,
+					firstId: 10,
+					firstListenerId: 700,
+					count: 2,
+					values: Object.freeze(['first', 'second']),
+				},
+			]),
+			{ compact: true, incrementalCompact: true, lazyPublicInstances: true },
+		).apply();
+		const rows = page.children[0]!.children;
+		expect(rows.map((row) => row.children[0]!.children[0]!.text)).toEqual(['first', 'second']);
+		expect(rows.map((row) => row.children[1]!.children[0]!.text)).toEqual(['static', 'static']);
+		expect(rows.map((row) => row.children[2]!.type)).toEqual(['image', 'image']);
+		expect(directTypes).toHaveLength(10);
+		expect(genericTypes).toEqual(['image', 'image']);
+		expect(resolveLynxHostNativeEvent(container, rows[1]!.events.get('bindEvent:tap')!)).toEqual({
+			listener: 701,
+			priority: 'default',
+		});
+		expect(disposeLynxHostContainer(container).complete).toBe(true);
+		expect(page.children).toEqual([]);
+	});
+
+	it('appends dense intrinsic children natively while preserving later explicit sibling anchors', () => {
+		const { container, page, papi } = createHost(58);
+		prepareLynxHostBatch(
+			container,
+			batch(1, [
+				{ op: 'create', id: 1, type: 'view', props: {} },
+				{ op: 'insert', id: 1, parent: null, before: null },
+			]),
+		).apply();
+		const shell = page.children[0]!;
+		const appendedParents: FakeNode[] = [];
+		(papi as FakePAPI & { append(parent: FakeNode, child: FakeNode): void }).append = (
+			parent,
+			child,
+		) => {
+			appendedParents.push(parent);
+			papi.insertBefore(parent, child, null);
+		};
+		const program: UniversalHostTemplateProgram = Object.freeze({
+			nodes: Object.freeze([
+				Object.freeze({ type: 'view', parent: -1, props: Object.freeze({}) }),
+				Object.freeze({ type: 'text', parent: 0, props: Object.freeze({}) }),
+				Object.freeze({ type: '#text', parent: 1, props: Object.freeze({ value: 'ready' }) }),
+			]),
+			events: Object.freeze([]),
+		});
+		prepareLynxHostBatch(
+			container,
+			batch(2, [
+				{
+					op: 'mount-template-run',
+					parent: 1,
+					before: null,
+					program,
+					firstId: 10,
+					firstListenerId: null,
+					count: 2,
+					values: Object.freeze([]),
+				},
+			]),
+			{ compact: true, incrementalCompact: true, lazyPublicInstances: true },
+		).apply();
+		expect(shell.children.map((row) => row.children[0]!.children[0]!.text)).toEqual([
+			'ready',
+			'ready',
+		]);
+		expect(appendedParents).toContain(shell);
+		expect(appendedParents.some((parent) => parent.type === 'text')).toBe(true);
+
+		const appendCount = appendedParents.length;
+		prepareLynxHostBatch(
+			container,
+			batch(3, [
+				{
+					op: 'mount-template-range',
+					parent: 1,
+					before: 10,
+					program,
+					firstId: 30,
+					firstListenerId: null,
+					values: [],
+				},
+			]),
+		).apply();
+		expect(shell.children).toHaveLength(3);
+		expect(appendedParents).toHaveLength(appendCount);
+	});
+
+	it('retains complete cleanup ownership when native append mutates and then fails', () => {
+		const { container, page, papi } = createHost(59);
+		prepareLynxHostBatch(
+			container,
+			batch(1, [
+				{ op: 'create', id: 1, type: 'view', props: {} },
+				{ op: 'insert', id: 1, parent: null, before: null },
+			]),
+		).apply();
+		const failure = new Error('native append attached then failed');
+		let first = true;
+		(papi as FakePAPI & { append(parent: FakeNode, child: FakeNode): void }).append = (
+			parent,
+			child,
+		) => {
+			papi.insertBefore(parent, child, null);
+			if (first) {
+				first = false;
+				throw failure;
+			}
+		};
+		const program: UniversalHostTemplateProgram = Object.freeze({
+			nodes: Object.freeze([Object.freeze({ type: 'view', parent: -1, props: Object.freeze({}) })]),
+			events: Object.freeze([
+				Object.freeze({ node: 0, type: 'bindtap', priority: 'default' as const }),
+			]),
+		});
+		const prepared = prepareLynxHostBatch(
+			container,
+			batch(2, [
+				{
+					op: 'mount-template-run',
+					parent: 1,
+					before: null,
+					program,
+					firstId: 10,
+					firstListenerId: 850,
+					count: 1,
+					values: Object.freeze([]),
+				},
+			]),
+			{ compact: true, incrementalCompact: true, lazyPublicInstances: true },
+		);
+		expect(() => prepared.apply()).toThrow(failure);
+		expect(prepared.mutationStarted).toBe(true);
+		expect(container.acceptedVersion).toBe(2);
+		expect(page.children[0]!.children).toHaveLength(1);
+		expect(disposeLynxHostContainer(container).complete).toBe(true);
+		expect(page.children).toEqual([]);
+	});
+
+	it('preserves accepted-shell ownership and full legacy handles when a compact suffix faults', () => {
+		const { container, driver, page, papi } = createHost(54);
+		prepareLynxHostBatch(
+			container,
+			batch(1, [
+				{ op: 'create', id: 1, type: 'view', props: { id: 'shell' } },
+				{ op: 'insert', id: 1, parent: null, before: null },
+			]),
+		).apply();
+		const shell = driver.getPublicInstance(container, 1);
+		const program: UniversalHostTemplateProgram = Object.freeze({
+			nodes: Object.freeze([Object.freeze({ type: 'view', parent: -1, props: Object.freeze({}) })]),
+			events: Object.freeze([
+				Object.freeze({ node: 0, type: 'bindtap', priority: 'default' as const }),
+			]),
+		});
+		const prepared = prepareLynxHostBatch(
+			container,
+			batch(2, [
+				{
+					op: 'mount-template-run',
+					parent: 1,
+					before: null,
+					program,
+					firstId: 10,
+					firstListenerId: 850,
+					count: 2,
+					values: Object.freeze([]),
+				},
+			]),
+			{ compact: true, incrementalCompact: true, lazyPublicInstances: true },
+		);
+		expect(prepared.compactHostCount).toBe(2);
+		const failure = new Error('accepted compact listener mutated then failed');
+		papi.failNext('setEvent', 'after', failure);
+		expect(() => prepared.apply()).toThrow(failure);
+		expect(prepared.mutationStarted).toBe(true);
+		expect(container.acceptedVersion).toBe(2);
+		expect(driver.getPublicInstance(container, 1)).toBe(shell);
+		expect(
+			prepared.handleDelta.map((delta) => (delta.op === 'destroy' ? delta.id : delta.handle.id)),
+		).toEqual([10, 11]);
+		expect(disposeLynxHostContainer(container).complete).toBe(true);
+		expect(page.children).toEqual([]);
+	});
+
+	it('snapshots mutable accepted-root program values instead of trusting an incremental suffix', () => {
+		const { container, page } = createHost(55);
+		prepareLynxHostBatch(
+			container,
+			batch(1, [
+				{ op: 'create', id: 1, type: 'view', props: {} },
+				{ op: 'insert', id: 1, parent: null, before: null },
+			]),
+		).apply();
+		const program: UniversalHostTemplateProgram = Object.freeze({
+			nodes: Object.freeze([
+				Object.freeze({
+					type: 'view',
+					parent: -1,
+					props: Object.freeze({}),
+					bindings: Object.freeze([Object.freeze({ name: 'id', valueIndex: 0 })]),
+				}),
+			]),
+			events: Object.freeze([]),
+		});
+		const values = ['accepted'];
+		const prepared = prepareLynxHostBatch(
+			container,
+			batch(2, [
+				{
+					op: 'mount-template-run',
+					parent: 1,
+					before: null,
+					program,
+					firstId: 10,
+					firstListenerId: null,
+					count: 1,
+					values,
+				},
+			]),
+			{ compact: true, incrementalCompact: true, lazyPublicInstances: true },
+		);
+		expect(prepared.compactHostCount).toBeUndefined();
+		values[0] = 'tampered';
+		prepared.apply();
+		expect(page.children[0]!.children[0]!.id).toBe('accepted');
+	});
+
+	it('preserves historical host generations instead of accepting an overlapping compact suffix', () => {
+		const { container, driver, page } = createHost(56);
+		prepareLynxHostBatch(
+			container,
+			batch(1, [
+				{ op: 'create', id: 1, type: 'view', props: {} },
+				{ op: 'create', id: 10, type: 'view', props: { id: 'old' } },
+				{ op: 'insert', id: 10, parent: 1, before: null },
+				{ op: 'insert', id: 1, parent: null, before: null },
+			]),
+		).apply();
+		prepareLynxHostBatch(
+			container,
+			batch(2, [
+				{ op: 'remove', parent: 1, id: 10 },
+				{ op: 'destroy', id: 10 },
+			]),
+		).apply();
+		const program: UniversalHostTemplateProgram = Object.freeze({
+			nodes: Object.freeze([
+				Object.freeze({ type: 'view', parent: -1, props: Object.freeze({ id: 'new' }) }),
+			]),
+			events: Object.freeze([]),
+		});
+		const prepared = prepareLynxHostBatch(
+			container,
+			batch(3, [
+				{
+					op: 'mount-template-run',
+					parent: 1,
+					before: null,
+					program,
+					firstId: 10,
+					firstListenerId: null,
+					count: 1,
+					values: Object.freeze([]),
+				},
+			]),
+			{ compact: true, incrementalCompact: true, lazyPublicInstances: true },
+		);
+		expect(prepared.compactHostCount).toBeUndefined();
+		prepared.apply();
+		expect(page.children[0]!.children[0]!.id).toBe('new');
+		expect(driver.getPublicInstance(container, 10)?.generation).toBe(2);
+	});
+
+	it('leaves detached accepted-root additions on the ordinary acknowledgement path', () => {
+		const { container, page } = createHost(57);
+		prepareLynxHostBatch(
+			container,
+			batch(1, [{ op: 'create', id: 1, type: 'view', props: {} }]),
+		).apply();
+		const program: UniversalHostTemplateProgram = Object.freeze({
+			nodes: Object.freeze([Object.freeze({ type: 'view', parent: -1, props: Object.freeze({}) })]),
+			events: Object.freeze([]),
+		});
+		const prepared = prepareLynxHostBatch(
+			container,
+			batch(2, [
+				{
+					op: 'mount-template-run',
+					parent: 1,
+					before: null,
+					program,
+					firstId: 10,
+					firstListenerId: null,
+					count: 1,
+					values: Object.freeze([]),
+				},
+			]),
+			{ compact: true, incrementalCompact: true, lazyPublicInstances: true },
+		);
+		expect(prepared.compactHostCount).toBeUndefined();
+		prepared.apply();
+		expect(container.instanceCount).toBe(2);
+		expect(page.children).toEqual([]);
+	});
+
+	it('keeps accepted-root selectors eager for unnegotiated or mixed host commands', () => {
+		const program: UniversalHostTemplateProgram = Object.freeze({
+			nodes: Object.freeze([
+				Object.freeze({ type: 'view', parent: -1, props: Object.freeze({ class: 'row' }) }),
+			]),
+			events: Object.freeze([]),
+		});
+		for (const mixed of [false, true]) {
+			const { container, page } = createHost(mixed ? 50 : 49);
+			prepareLynxHostBatch(
+				container,
+				batch(1, [
+					{ op: 'create', id: 1, type: 'view', props: {} },
+					{ op: 'insert', id: 1, parent: null, before: null },
+				]),
+			).apply();
+			const commands: UniversalHostCommand[] = [
+				{
+					op: 'mount-template-range',
+					parent: 1,
+					before: null,
+					program,
+					firstId: 2,
+					firstListenerId: null,
+					values: [],
+				},
+			];
+			if (mixed) {
+				commands.push(
+					{ op: 'create', id: 3, type: 'view', props: {} },
+					{ op: 'insert', id: 3, parent: 1, before: null },
+				);
+			}
+			prepareLynxHostBatch(
+				container,
+				batch(2, commands),
+				mixed ? { lazyPublicInstances: true } : undefined,
+			).apply();
+			expect(page.children[0]!.children[0]!.selector).toBe(`r${mixed ? 50 : 49}-h2-g1`);
+			if (mixed) expect(page.children[0]!.children[1]!.selector).toBe('r50-h3-g1');
+		}
+	});
+
+	it('cleans an accepted root when a lazily published program listener mutates before failing', () => {
+		const { container, page, papi } = createHost(51);
+		prepareLynxHostBatch(
+			container,
+			batch(1, [
+				{ op: 'create', id: 1, type: 'view', props: {} },
+				{ op: 'insert', id: 1, parent: null, before: null },
+			]),
+		).apply();
+		const program: UniversalHostTemplateProgram = Object.freeze({
+			nodes: Object.freeze([Object.freeze({ type: 'view', parent: -1, props: Object.freeze({}) })]),
+			events: Object.freeze([
+				Object.freeze({ node: 0, type: 'bindtap', priority: 'default' as const }),
+			]),
+		});
+		const prepared = prepareLynxHostBatch(
+			container,
+			batch(2, [
+				{
+					op: 'mount-template-range',
+					parent: 1,
+					before: null,
+					program,
+					firstId: 2,
+					firstListenerId: 800,
+					values: [],
+				},
+			]),
+			{ lazyPublicInstances: true },
+		);
+		const failure = new Error('accepted-root listener mutated then failed');
+		papi.resetCalls();
+		papi.failNext('setEvent', 'after', failure);
+		expect(() => prepared.apply()).toThrow(failure);
+		expect(prepared.mutationStarted).toBe(true);
+		expect(container.acceptedVersion).toBe(2);
+		expect(prepared.handleDelta).toHaveLength(1);
+		expect(papi.calls.filter((call) => call === 'setRefSelector')).toEqual([]);
+		expect(disposeLynxHostContainer(container).complete).toBe(true);
+		expect(page.children).toEqual([]);
 	});
 
 	it('keeps program selectors eager unless a safe compact mount explicitly negotiates laziness', () => {

--- a/packages/lynx/tests/protocol.test.ts
+++ b/packages/lynx/tests/protocol.test.ts
@@ -776,44 +776,111 @@ describe('@octanejs/lynx transported protocol', () => {
 		).toMatchObject({ instances: LYNX_LAZY_PUBLIC_INSTANCES });
 	});
 
-	it('never enables template programs or owner elision while adopting a first screen', async () => {
-		const context = new FakeContextProxy();
-		context.addEventListener(LYNX_BACKGROUND_TO_MAIN_EVENT, (event) => {
-			const message = validateLynxBackgroundOutboundMessage(event.data);
-			if (message.type !== 'main-ready-request') return;
-			context.sendToBackground({
-				protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
-				renderer: LYNX_TRANSPORT_RENDERER,
-				type: 'main-ready',
-				request: message.request,
-				firstTree: {
-					format: 1,
+	it.each(['adopted', 'repaired'] as const)(
+		'enables intrinsic runs only after a first screen is safely %s',
+		async (adoption) => {
+			const context = new FakeContextProxy();
+			const container = createLynxClientContainer();
+			const driver = createLynxClientDriver(container);
+			const commits: LynxTransportCommitMessage[] = [];
+			const capabilitiesDuringAdoptionReady: boolean[] = [];
+			context.addEventListener(LYNX_BACKGROUND_TO_MAIN_EVENT, (event) => {
+				const message = validateLynxBackgroundOutboundMessage(event.data);
+				if (message.type === 'adoption-ready') {
+					capabilitiesDuringAdoptionReady.push(driver.capabilities?.templateProgramMount === true);
+					return;
+				}
+				if (message.type === 'commit') {
+					commits.push(message);
+					return;
+				}
+				if (message.type !== 'main-ready-request') return;
+				context.sendToBackground({
+					protocol: LYNX_TRANSPORT_PROTOCOL_VERSION,
 					renderer: LYNX_TRANSPORT_RENDERER,
-					root: 1,
-					version: 1,
-					plan: null,
-					roots: [],
-					nodes: [],
-				},
-				capabilities: {
-					compactAck: 1,
-					templateMount: 1,
-					templateProgram: 1,
-					lazyPublicInstances: 1,
-					templateRuns: 1,
-				},
+					type: 'main-ready',
+					request: message.request,
+					firstTree: {
+						format: 1,
+						renderer: LYNX_TRANSPORT_RENDERER,
+						root: 1,
+						version: 1,
+						plan: null,
+						roots: [],
+						nodes: [],
+					},
+					capabilities: {
+						compactAck: 1,
+						templateMount: 1,
+						templateProgram: 1,
+						lazyPublicInstances: 1,
+						templateRuns: 1,
+					},
+				});
 			});
-		});
-		const container = createLynxClientContainer();
-		const driver = createLynxClientDriver(container);
-		const transport = createLynxBackgroundTransport(context, container);
-		await transport.ready;
-		expect(driver.capabilities?.templateMount).toBe(false);
-		expect(driver.capabilities?.templateProgramMount).toBe(false);
-		expect(driver.capabilities?.templateProgramRuns).toBe(false);
-		expect(driver.capabilities?.lazyPublicInstances).toBe(false);
-		transport.close();
-	});
+			const transport = createLynxBackgroundTransport(context, container);
+			await transport.ready;
+			expect(driver.capabilities?.templateMount).toBe(false);
+			expect(driver.capabilities?.templateProgramMount).toBe(false);
+			expect(driver.capabilities?.templateProgramRuns).toBe(false);
+			expect(driver.capabilities?.lazyPublicInstances).toBe(false);
+			const firstIdentity = identity(1, 1);
+			const capabilitiesDuringAcknowledgement: boolean[] = [];
+			const adopting = transport
+				.prepareBatch(
+					container,
+					{ renderer: LYNX_TRANSPORT_RENDERER, version: 1, commands: [] },
+					firstIdentity,
+				)
+				.apply(() => {
+					capabilitiesDuringAcknowledgement.push(
+						driver.capabilities?.templateProgramMount === true,
+					);
+				});
+			await flushMicrotasks();
+			expect(commits[0]).not.toHaveProperty('ack');
+			expect(commits[0]).not.toHaveProperty('instances');
+			context.sendToBackground({ ...firstIdentity, type: 'ack', handles: [], adoption });
+			expect(capabilitiesDuringAcknowledgement).toEqual([false]);
+			expect(capabilitiesDuringAdoptionReady).toEqual(adoption === 'adopted' ? [false] : []);
+			expect(driver.capabilities?.templateMount).toBe(true);
+			expect(driver.capabilities?.templateProgramMount).toBe(true);
+			expect(driver.capabilities?.templateProgramRuns).toBe(true);
+			expect(driver.capabilities?.lazyPublicInstances).toBe(true);
+			context.sendToBackground({ ...firstIdentity, type: 'complete' });
+			await adopting;
+
+			const count = LYNX_COMPACT_ACKNOWLEDGEMENT_MIN_HOSTS;
+			const nextIdentity = identity(firstIdentity.root, 2);
+			const adding = transport
+				.prepareBatch(container, templateProgramRunBatch(count, 2), nextIdentity)
+				.apply(() => {});
+			await flushMicrotasks();
+			expect(commits[1]).toMatchObject({
+				ack: LYNX_COMPACT_ACKNOWLEDGEMENT,
+				instances: LYNX_LAZY_PUBLIC_INSTANCES,
+				batch: { commands: [{ op: 'mount-template-run', count: count / 2 }] },
+			});
+			const handles: LynxPublicHandleDelta[] = Array.from({ length: count }, (_value, index) => {
+				const id = index + 1;
+				const type = id % 2 === 1 ? 'view' : '#text';
+				return {
+					op: 'upsert',
+					id,
+					type,
+					generation: 1,
+					attached: true,
+					listDescendant: false,
+					snapshot: handleSnapshot(nextIdentity.root, id, type, 1),
+				};
+			});
+			context.sendToBackground({ ...nextIdentity, type: 'ack', handles });
+			context.sendToBackground({ ...nextIdentity, type: 'complete' });
+			await adding;
+			expect(container.getPublicHandle(count)?.type).toBe('#text');
+			transport.close();
+		},
+	);
 
 	it('rejects unsafe template hosts, listeners, and mutable shapes reused across commands', () => {
 		const shape = Object.freeze([
@@ -2638,6 +2705,123 @@ describe('@octanejs/lynx transported protocol', () => {
 		expect(container.getPublicHandle(5)).toBe(previous);
 		expect(isLynxClientEventTarget(container, acceptedIdentity.root, 5, 1)).toBe(true);
 		expect(isLynxClientEventTarget(container, acceptedIdentity.root, 5, 2)).toBe(false);
+	});
+
+	it('preserves adopted handles when compact descendants are accepted or rolled back', () => {
+		const count = LYNX_COMPACT_ACKNOWLEDGEMENT_MIN_HOSTS;
+		const container = createLynxClientContainer();
+		const root = 105;
+		prepareLynxHandleDeltas(
+			container,
+			{
+				renderer: LYNX_TRANSPORT_RENDERER,
+				version: 1,
+				commands: [{ op: 'create', id: 1, type: 'view', props: { id: 'adopted-shell' } }],
+			},
+			[
+				{
+					op: 'upsert',
+					id: 1,
+					type: 'view',
+					generation: 1,
+					attached: true,
+					listDescendant: false,
+					snapshot: handleSnapshot(root, 1, 'view', 1),
+				},
+			],
+			identity(root, 1),
+		).apply();
+		const shell = container.getPublicHandle(1)!;
+		const original = templateProgramRunBatch(count, 2);
+		const run = original.commands[0]!;
+		if (run.op !== 'mount-template-run') throw new Error('Expected a contiguous host run.');
+		const descendants: UniversalHostBatch = {
+			...original,
+			commands: [Object.freeze({ ...run, firstId: 2 })],
+		};
+		const acceptedIdentity = identity(root, 2);
+
+		expect(() =>
+			prepareLynxCompactHandleDeltas(container, original, count, acceptedIdentity, count, true),
+		).toThrow(/overlaps an accepted handle/);
+		expect(() =>
+			prepareLynxCompactHandleDeltas(
+				container,
+				{ ...descendants, commands: [{ ...run, firstId: 2 }] },
+				count,
+				acceptedIdentity,
+				count,
+				true,
+			),
+		).toThrow(/one frozen host run/);
+
+		const rolledBack = prepareLynxCompactHandleDeltas(
+			container,
+			descendants,
+			count,
+			acceptedIdentity,
+			count,
+			true,
+		);
+		rolledBack.apply();
+		const transient = container.getPublicHandle(2)!;
+		expect(container.getPublicHandle(1)).toBe(shell);
+		expect(isLynxClientEventTarget(container, root, 2, 1)).toBe(true);
+		rolledBack.rollback();
+		expect(container.getPublicHandle(1)).toBe(shell);
+		expect(shell.active).toBe(true);
+		expect(transient.active).toBe(false);
+		expect(container.getPublicHandle(2)).toBeNull();
+		expect(isLynxClientEventTarget(container, root, 2, 1)).toBe(false);
+
+		prepareLynxCompactHandleDeltas(
+			container,
+			descendants,
+			count,
+			acceptedIdentity,
+			count,
+			true,
+		).apply();
+		const removed = container.getPublicHandle(2)!;
+		prepareLynxHandleDeltas(
+			container,
+			{
+				renderer: LYNX_TRANSPORT_RENDERER,
+				version: 3,
+				commands: [{ op: 'destroy', id: 2 }],
+			},
+			[{ op: 'remove', id: 2, generation: 1 }],
+			identity(root, 3),
+		).apply();
+		expect(removed.active).toBe(false);
+		expect(container.getPublicHandle(1)).toBe(shell);
+		expect(isLynxClientEventTarget(container, root, 2, 1)).toBe(false);
+		expect(isLynxClientEventTarget(container, root, count + 1, 1)).toBe(true);
+
+		prepareLynxHandleDeltas(
+			container,
+			{
+				renderer: LYNX_TRANSPORT_RENDERER,
+				version: 4,
+				commands: [{ op: 'create', id: 2, type: 'view', props: { id: 'replacement' } }],
+			},
+			[
+				{
+					op: 'upsert',
+					id: 2,
+					type: 'view',
+					generation: 2,
+					attached: true,
+					listDescendant: false,
+					snapshot: handleSnapshot(root, 2, 'view', 2),
+				},
+			],
+			identity(root, 4),
+		).apply();
+		expect(container.getPublicHandle(2)?.generation).toBe(2);
+		expect(isLynxClientEventTarget(container, root, 2, 1)).toBe(false);
+		expect(isLynxClientEventTarget(container, root, 2, 2)).toBe(true);
+		expect(container.getPublicHandle(1)).toBe(shell);
 	});
 
 	it('negotiates intrinsic programs and derives every compact host from its implicit ID range', async () => {

--- a/packages/octane/src/compiler/compile-universal.js
+++ b/packages/octane/src/compiler/compile-universal.js
@@ -2450,6 +2450,60 @@ function templateProgramForHost(node, state) {
 	return body.length === 1 && isTemplateProgramForHost(body[0]);
 }
 
+function templateProgramForComponent(node, state) {
+	if (
+		node.empty != null ||
+		!rendererHasCapability(state, 'template-program-mount') ||
+		!isOwnerFreeForExpression(node.right) ||
+		!isOwnerFreeForExpression(node.key)
+	) {
+		return null;
+	}
+	const body = (node.body?.body ?? []).filter(
+		(statement) => statement.type !== 'JSXText' || normalizeJsxText(statement.value ?? '') !== '',
+	);
+	if (body.length !== 1) return null;
+	const component = body[0];
+	if (
+		(component.type !== 'JSXElement' && component.type !== 'Element') ||
+		!isComponentElement(component) ||
+		(component.openingElement?.name ?? component.name)?.type !== 'JSXIdentifier' ||
+		(component.children ?? []).some(
+			(child) => child.type !== 'JSXText' || normalizeJsxText(child.value ?? '') !== '',
+		)
+	) {
+		return null;
+	}
+	const names = new Set();
+	for (const attribute of component.openingElement?.attributes ?? component.attributes ?? []) {
+		if (attribute.type === 'JSXSpreadAttribute' || attribute.type === 'SpreadAttribute') {
+			return null;
+		}
+		const name = attributeName(attribute);
+		if (
+			name === null ||
+			name === 'key' ||
+			name === 'ref' ||
+			name === 'children' ||
+			name === '__proto__' ||
+			names.has(name)
+		) {
+			return null;
+		}
+		names.add(name);
+		const value = attribute.value;
+		if (value === null || value?.type === 'Literal') continue;
+		if (
+			value?.type !== 'JSXExpressionContainer' ||
+			value.expression?.type === 'JSXEmptyExpression' ||
+			!isTemplateProgramForExpression(value.expression)
+		) {
+			return null;
+		}
+	}
+	return component;
+}
+
 function allocPlan(state, root, origin = null) {
 	const name = allocName(
 		state,
@@ -3347,6 +3401,26 @@ function compileOwnerFreeThreeHostComponentAst(component, state, itemBinding, in
 	};
 }
 
+function compileTemplateProgramForComponentAst(component, state, itemBinding, indexBinding) {
+	const attributes = component.openingElement?.attributes ?? component.attributes ?? [];
+	const props = generatedCall(
+		state.helpers.props,
+		[
+			compilePlainPropsObjectAst(attributes, state, component),
+			inheritGeneratedOrigin(b.unary('void', b.literal(0)), component),
+			b.literal(false),
+			b.literal(true),
+		],
+		component,
+	);
+	const descriptor = generatedCall(
+		state.helpers.nestedComponent,
+		[b.literal(state.renderer.id), jsxNameExpressionAst(component, state), props],
+		component,
+	);
+	return generatedArrow([itemBinding, indexBinding], descriptor, component);
+}
+
 function compileForAst(node, context, state) {
 	if (node.await) {
 		throw universalError(
@@ -3369,6 +3443,10 @@ function compileForAst(node, context, state) {
 	assertNoResidualTemplate(node.key, state, '@for key');
 	const host = !state.hmr ? ownerFreeForHost(node) : null;
 	const component = host === null ? ownerFreeForThreeHostComponent(node, state) : null;
+	const templateComponent =
+		host === null && component === null && !state.hmr
+			? templateProgramForComponent(node, state)
+			: null;
 	const compactHost =
 		host === null ? null : compileOwnerFreeForHostAst(host, state, itemBinding, indexBinding);
 	const compactComponent =
@@ -3380,6 +3458,14 @@ function compileForAst(node, context, state) {
 		generatedArrow([itemBinding, indexBinding], rewriteSourceAst(node.key, state), node.key),
 		compactHost?.render ??
 			compactComponent?.render ??
+			(templateComponent === null
+				? null
+				: compileTemplateProgramForComponentAst(
+						templateComponent,
+						state,
+						itemBinding,
+						indexBinding,
+					)) ??
 			compileBlockValueAst(
 				node.body?.body ?? [],
 				state,
@@ -3403,6 +3489,16 @@ function compileForAst(node, context, state) {
 			jsxNameExpressionAst(component, state),
 			compactComponent.plan,
 			compactComponent.signature,
+		);
+	} else if (templateComponent !== null) {
+		args.push(
+			b.literal(null, 'null'),
+			b.literal(false),
+			b.literal(false),
+			inheritGeneratedOrigin(b.unary('void', b.literal(0)), templateComponent),
+			inheritGeneratedOrigin(b.unary('void', b.literal(0)), templateComponent),
+			inheritGeneratedOrigin(b.unary('void', b.literal(0)), templateComponent),
+			b.literal(true),
 		);
 	} else if (!state.hmr && templateProgramForHost(node, state)) {
 		args.push(b.literal(null, 'null'), b.literal(false), b.literal(false), b.literal(true));

--- a/packages/octane/src/universal-core.ts
+++ b/packages/octane/src/universal-core.ts
@@ -258,6 +258,7 @@ export interface UniversalForValue {
 	readonly leafPlan?: UniversalPlan;
 	readonly leafSignature?: string;
 	readonly template?: boolean;
+	readonly componentScope?: boolean;
 }
 
 export interface UniversalTryValue {
@@ -1618,7 +1619,17 @@ export function universalProps(
 	entries: readonly UniversalPropEntry[],
 	children: unknown = NO_CHILDREN,
 	canonicalizeHostClass = false,
+	compilerOwnedRecord = false,
 ): UniversalPropsValue {
+	if (compilerOwnedRecord) {
+		return {
+			$$kind: UNIVERSAL_PROPS,
+			props: Object.freeze(entries as unknown as Record<string, unknown>),
+			key: null,
+			hasKey: false,
+			hasChildren: false,
+		};
+	}
 	const props: Record<string, unknown> = {};
 	if (!canonicalizeHostClass) {
 		for (const entry of entries) {
@@ -1721,7 +1732,20 @@ export function universalFor<T>(
 	hostComponent?: UniversalComponent<any> | true,
 	leafPlan?: UniversalPlan,
 	leafSignature?: string,
+	componentScope = false,
 ): UniversalForValue {
+	if (componentScope) {
+		return {
+			$$kind: UNIVERSAL_FOR,
+			items,
+			key,
+			render,
+			empty,
+			ownerless,
+			compact,
+			componentScope: true,
+		};
+	}
 	if (hostComponent === true) {
 		return { $$kind: UNIVERSAL_FOR, items, key, render, empty, ownerless, compact, template: true };
 	}
@@ -2240,6 +2264,7 @@ function findClaimableChildRecord(
 	identityPath: readonly unknown[],
 	key: unknown,
 ): UniversalOwnerRecord | undefined {
+	if (parent.record.children.length === 0) return undefined;
 	// Order-stable renders resolve every claim with one positional compare; the
 	// identity-path buckets exist for reorders, insertions, and removals.
 	if (parent.childOwnerBuckets === null) {
@@ -2499,13 +2524,32 @@ function ownerRange(owner: DraftOwner, children: BlueprintNode[]): BlueprintNode
 	return [{ kind: 'range', key: owner.record.rangeKey, owner: owner.record, children }];
 }
 
+function readComponentContext<T>(context: UniversalContext<T>): T {
+	return readOwnerContext(activateLazyLeafOwner(), context);
+}
+
+function componentInsertionEffect(
+	create: () => void | (() => void),
+	deps?: readonly unknown[],
+): void {
+	enqueueUniversalEffect('insertion', create, deps);
+}
+
+function componentLayoutEffect(create: () => void | (() => void), deps?: readonly unknown[]): void {
+	enqueueUniversalEffect('layout', create, deps);
+}
+
+function componentEffect(create: () => void | (() => void), deps?: readonly unknown[]): void {
+	enqueueUniversalEffect('passive', create, deps);
+}
+
 function componentContext(renderer: string): UniversalRenderContext {
 	return {
 		renderer,
-		readContext: (context) => readOwnerContext(activateLazyLeafOwner(), context),
-		insertionEffect: (create, deps) => enqueueUniversalEffect('insertion', create, deps),
-		layoutEffect: (create, deps) => enqueueUniversalEffect('layout', create, deps),
-		effect: (create, deps) => enqueueUniversalEffect('passive', create, deps),
+		readContext: readComponentContext,
+		insertionEffect: componentInsertionEffect,
+		layoutEffect: componentLayoutEffect,
+		effect: componentEffect,
 	};
 }
 
@@ -3040,6 +3084,10 @@ function materializeValue(
 			list.template === true &&
 			currentAttempt().root.driverCapabilities().templateProgramMount === true &&
 			CURRENT_OWNER?.visibility === 'visible';
+		const compilerComponentScope =
+			list.componentScope === true &&
+			currentAttempt().root.driverCapabilities().templateProgramRuns === true &&
+			CURRENT_OWNER?.visibility === 'visible';
 		if (
 			list.ownerless &&
 			list.compact &&
@@ -3180,7 +3228,7 @@ function materializeValue(
 			compilerTemplateTree && attempt.root.driverCapabilities().templateProgramRuns === true;
 		let compactTemplateList: BlueprintCompactTemplateList | null = null;
 		const lazyOwnerScope: LazyLeafOwnerScope | null =
-			compilerLeafProps || compilerTemplateTree
+			compilerLeafProps || compilerTemplateTree || compilerComponentScope
 				? {
 						attempt,
 						parent,
@@ -3189,13 +3237,62 @@ function materializeValue(
 						owner: null,
 					}
 				: null;
+		let componentScopeEnabled = compilerComponentScope;
+		if (componentScopeEnabled) {
+			const previous = parent.record.children[parent.sequentialClaimCursor];
+			if (
+				previous?.component === null &&
+				identityPathsEqual(previous.identityPath, lazyOwnerScope!.identityPath)
+			) {
+				componentScopeEnabled = false;
+			}
+		}
+		const componentPath = componentScopeEnabled
+			? [...lazyOwnerScope!.identityPath, 'output']
+			: null;
 		let index = 0;
 		for (const item of list.items) {
 			const itemIndex = index++;
 			const itemKey = list.key(item, itemIndex);
 			if (keys.has(itemKey)) throw new Error(`Duplicate universal list key ${String(itemKey)}.`);
 			keys.add(itemKey);
-			if (compilerTemplateTree) {
+			if (componentScopeEnabled) {
+				const rendered = renderLazyLeafItem(lazyOwnerScope!, list.render, item, itemIndex, itemKey);
+				const candidate = rendered as UniversalComponentValue;
+				if (
+					lazyOwnerScope!.owner === null &&
+					candidate?.$$kind === UNIVERSAL_COMPONENT_VALUE &&
+					candidate.renderer === expectedRenderer &&
+					!candidate.hasKey
+				) {
+					const keyed: UniversalComponentValue = {
+						...candidate,
+						key: itemKey,
+						hasKey: true,
+					};
+					output.push(...materializeComponentValue(keyed, expectedRenderer, componentPath!));
+					continue;
+				}
+				if (lazyOwnerScope!.owner === null) {
+					output.push(
+						...materializeScoped(parent, lazyOwnerScope!.identityPath, itemKey, () => rendered),
+					);
+					continue;
+				}
+				const itemOwner = lazyOwnerScope!.owner;
+				const previousOwner = CURRENT_OWNER;
+				const previousAttemptOwner = attempt.owner;
+				CURRENT_OWNER = itemOwner;
+				attempt.owner = itemOwner;
+				let nodes: BlueprintNode[];
+				try {
+					nodes = materializeValue(rendered, expectedRenderer, null, componentPath!);
+				} finally {
+					CURRENT_OWNER = previousOwner;
+					attempt.owner = previousAttemptOwner;
+				}
+				output.push(...ownerRange(itemOwner, nodes));
+			} else if (compilerTemplateTree) {
 				const rendered = renderLazyLeafItem(lazyOwnerScope!, list.render, item, itemIndex, itemKey);
 				if (compactTemplateEnabled) {
 					const candidate = rendered as UniversalPlanValue;
@@ -6476,6 +6573,7 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 	private asyncWork: Promise<void> = Promise.resolve();
 	private asyncWorkError: unknown = NO_PENDING_PASSIVE_ERROR;
 	private nextId = 1;
+	private nextLogicalRangeId = -1;
 	private nextUniversalId = 1;
 	private nextListener = NEXT_EVENT_ROOT++ * 1_000_000;
 	private nextBatchVersion = 1;
@@ -9438,10 +9536,18 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 		scopePlacement: { parent: number | null; endAnchor: number | null } | null = null,
 	): UniversalTransactionImpl<Container, PublicInstance> {
 		let nextId = this.nextId;
+		let nextLogicalRangeId = this.nextLogicalRangeId;
 		const scoped = scopeRecord !== this.rootRecord;
 		const treeFeatures = (scoped ? scopeFeatures : this.treeFeatures) | attempt.treeFeatures;
 		const templateExcludedFeatures =
 			UNIVERSAL_TREE_PORTAL | UNIVERSAL_TREE_REGION | UNIVERSAL_TREE_HIDDEN;
+		// Owner ranges never reach the host, but interleaving their logical IDs
+		// with host IDs splits component-owned template instances into separate
+		// runs. Keep their transactional identity in a disjoint namespace only
+		// when this renderer can consume the resulting contiguous host ranges.
+		const compactLogicalRangeIds =
+			this.driver.capabilities?.templateProgramRuns === true &&
+			(treeFeatures & templateExcludedFeatures) === 0;
 		if ((treeFeatures & templateExcludedFeatures) !== 0) {
 			const expandBlueprint = (node: BlueprintNode): void => {
 				if (node.kind === 'host') expandCollapsedTemplateBlueprint(node);
@@ -9519,7 +9625,10 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 					if (child.kind === 'range' && child.retained !== undefined) {
 						child = expandRetained(child);
 					}
-					const record = createLogicalRecord(nextId++, child);
+					const record = createLogicalRecord(
+						compactLogicalRangeIds && child.kind === 'range' ? nextLogicalRangeId-- : nextId++,
+						child,
+					);
 					reserveCollapsedTemplateIds(record, child);
 					const draft: DraftRecord = {
 						record,
@@ -9629,7 +9738,10 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 					}
 				}
 				const isNew = record === undefined;
-				record ??= createLogicalRecord(nextId++, child);
+				record ??= createLogicalRecord(
+					compactLogicalRangeIds && child.kind === 'range' ? nextLogicalRangeId-- : nextId++,
+					child,
+				);
 				if (isNew) reserveCollapsedTemplateIds(record, child);
 				else reconcileCollapsedTemplate(record, child);
 				claimed.add(record);
@@ -11045,6 +11157,7 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 					this.publishLocalReplay(retryThenables, retryMemos, component, props);
 				}
 				this.nextId = nextId;
+				this.nextLogicalRangeId = nextLogicalRangeId;
 				this.nextUniversalId = attempt.nextUniversalId;
 				this.nextListener = nextListener;
 				this.treeFeatures = scoped

--- a/packages/octane/tests/compiler/universal-compiler-capabilities.test.ts
+++ b/packages/octane/tests/compiler/universal-compiler-capabilities.test.ts
@@ -200,6 +200,70 @@ describe('universal compiler renderer capabilities', () => {
 	});
 });
 
+describe('component-owned Lynx template rows', () => {
+	const source = `
+		function Row({ row, selected, onSelect }) @{
+			<view class={['row', selected && 'selected']}>
+				<text bindtap={() => onSelect(row.id)}>{row.label}</text>
+			</view>
+		}
+		export function Scene({ rows, selected, onSelect }) @{
+			@for (const row of rows; key row.id) {
+				<Row row={row} selected={selected === row.id} onSelect={onSelect} />
+			}
+		}
+	`;
+
+	it('preserves the real component while proving its ordinary keyed loop scope redundant', () => {
+		const args = compiledUniversalForArguments(source, { renderer: resolvedLynxRenderer });
+
+		expect(args[9]).toMatchObject({ type: 'Literal', value: true });
+		expect(args[2].body).toMatchObject({ type: 'CallExpression' });
+		expect(args[2].body.arguments[2]).toMatchObject({
+			type: 'CallExpression',
+			arguments: [
+				{
+					type: 'ObjectExpression',
+					properties: [
+						{ key: { value: 'row' } },
+						{ key: { value: 'selected' } },
+						{ key: { value: 'onSelect' } },
+					],
+				},
+				{ type: 'UnaryExpression', operator: 'void' },
+				{ type: 'Literal', value: false },
+				{ type: 'Literal', value: true },
+			],
+		});
+	});
+
+	it.each([
+		['HMR', source, { hmr: true }],
+		[
+			'an unsupported renderer',
+			source,
+			{ renderer: { ...resolvedLynxRenderer, capabilities: [] } },
+		],
+		['an explicit key', source.replace('row={row}', 'key={row.id} row={row}'), {}],
+		['a ref', source.replace('row={row}', 'ref={onSelect} row={row}'), {}],
+		['a spread', source.replace('row={row}', '{...row}'), {}],
+		['a prototype-sensitive prop', source.replace('row={row}', '__proto__={row} row={row}'), {}],
+		['a duplicate prop', source.replace('row={row}', 'row={row} row={row}'), {}],
+		[
+			'an arbitrary authored call',
+			source.replace('selected={selected === row.id}', 'selected={onSelect(row.id)}'),
+			{},
+		],
+	])('keeps the original loop owner for %s', (_label, candidate, options) => {
+		const args = compiledUniversalForArguments(candidate, {
+			renderer: resolvedLynxRenderer,
+			...options,
+		});
+
+		expect(args[9]).toBeUndefined();
+	});
+});
+
 describe('constructor-backed Three components in keyed loops', () => {
 	it.each([
 		['an aliased import', extendedThreeComponent],

--- a/packages/octane/tests/universal-host-sdk.test.ts
+++ b/packages/octane/tests/universal-host-sdk.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
 	type ObjectHostInstance,
 	type UniversalHostCommand,
+	createContext,
 	createObjectContainer,
 	createObjectDriver,
 	createUniversalRoot,
@@ -10,6 +11,7 @@ import {
 	hmrUniversalComponent,
 	markUniversalHostComponent,
 	universalComponent,
+	universalContext,
 	universalFor,
 	universalHostComponentLeafPlan,
 	universalPlan,
@@ -1276,6 +1278,327 @@ describe('universal prepared host SDK', () => {
 		container.dispatchEvent(first.children[0], 'select', undefined);
 		expect(selected).toEqual(['first:b', 'first:c', 'next:a']);
 		root.unmount();
+	});
+
+	it('preserves keyed component state, context, events, and effects across a shared host mount', () => {
+		const container = createObjectContainer();
+		const root = createUniversalRoot(container, createTemplateObjectDriver(true, true, true, true));
+		const Theme = createContext('light');
+		const effects: string[] = [];
+		const events: string[] = [];
+		const plan = universalPlan('object', {
+			kind: 'host',
+			type: 'row',
+			bindings: [
+				['id', 0],
+				['selected', 1],
+			],
+			children: [
+				{
+					kind: 'host',
+					type: 'action',
+					bindings: [['onSelect', 2]],
+					children: [{ kind: 'slot', slot: 3 }],
+				},
+			],
+		});
+		const Row = defineUniversalComponent(
+			'object',
+			({ id, prefix, selected }: { id: string; prefix: string; selected: boolean }, context) => {
+				const theme = context.readContext(Theme);
+				const [state] = useState(`state:${id}`, 'row-state');
+				context.layoutEffect(() => {
+					effects.push(`mount:${id}`);
+					return () => effects.push(`cleanup:${id}`);
+				}, []);
+				return universalValue(plan, [
+					id,
+					selected,
+					() => events.push(`${prefix}:${theme}:${id}`),
+					`${prefix}:${theme}:${state}`,
+				]);
+			},
+		);
+		const Scene = defineUniversalComponent(
+			'object',
+			({
+				ids,
+				prefix,
+				theme,
+				selected,
+			}: {
+				ids: readonly string[];
+				prefix: string;
+				theme: string;
+				selected: string;
+			}) =>
+				universalContext(Theme, theme, () =>
+					universalFor(
+						ids,
+						(id) => id,
+						(id) =>
+							universalComponent(
+								'object',
+								Row,
+								universalProps(
+									{ id, prefix, selected: id === selected } as never,
+									undefined,
+									false,
+									true,
+								),
+							),
+						null,
+						false,
+						false,
+						undefined,
+						undefined,
+						undefined,
+						true,
+					),
+				),
+		);
+
+		const input = { ids: ['a', 'b', 'c'], prefix: 'first', theme: 'light', selected: 'a' };
+		const abandoned = root.prepare(Scene, input);
+		if (abandoned.status !== 'prepared') throw new Error('Expected a prepared component mount.');
+		const abandonedRuns = abandoned.batch.commands.filter(
+			(command) => command.op === 'mount-template-run',
+		);
+		expect(abandonedRuns).toHaveLength(1);
+		if (abandonedRuns[0].op !== 'mount-template-run') throw new Error('Expected a shared mount.');
+		expect(abandonedRuns[0].count).toBe(3);
+		expect(abandonedRuns[0].firstId).toBeGreaterThan(0);
+		expect(effects).toEqual([]);
+		abandoned.abort();
+		expect(container.children).toEqual([]);
+		expect(effects).toEqual([]);
+
+		const prepared = root.prepare(Scene, input);
+		if (prepared.status !== 'prepared') throw new Error('Expected a retried component mount.');
+		const runs = prepared.batch.commands.filter((command) => command.op === 'mount-template-run');
+		expect(runs).toHaveLength(1);
+		if (runs[0].op !== 'mount-template-run') throw new Error('Expected a shared retry mount.');
+		expect(runs[0].firstId).toBe(abandonedRuns[0].firstId);
+		expect(runs[0].count).toBe(3);
+		prepared.commit();
+		const [first, second, third] = container.children;
+		expect(effects).toEqual(['mount:a', 'mount:b', 'mount:c']);
+		expect(container.children.map((row) => row.children[0].children[0].props.value)).toEqual([
+			'first:light:state:a',
+			'first:light:state:b',
+			'first:light:state:c',
+		]);
+		container.dispatchEvent(second.children[0], 'select', undefined);
+		expect(events).toEqual(['first:light:b']);
+
+		root.render(Scene, { ...input, ids: ['c', 'a', 'b'] });
+		expect(container.children).toEqual([third, first, second]);
+		expect(effects).toEqual(['mount:a', 'mount:b', 'mount:c']);
+
+		root.render(Scene, {
+			ids: ['c', 'a', 'b'],
+			prefix: 'next',
+			theme: 'dark',
+			selected: 'c',
+		});
+		expect(container.children).toEqual([third, first, second]);
+		expect(third.props.selected).toBe(true);
+		expect(first.children[0].children[0].props.value).toBe('next:dark:state:a');
+		container.dispatchEvent(first.children[0], 'select', undefined);
+		expect(events).toEqual(['first:light:b', 'next:dark:a']);
+
+		root.render(Scene, { ids: ['b', 'c'], prefix: 'next', theme: 'dark', selected: 'c' });
+		expect(container.children).toEqual([second, third]);
+		expect(effects).toEqual(['mount:a', 'mount:b', 'mount:c', 'cleanup:a']);
+		root.unmount();
+		expect(effects.slice(4).toSorted()).toEqual(['cleanup:b', 'cleanup:c']);
+	});
+
+	it('preserves existing hosts when component mount capabilities become available later', () => {
+		const container = createObjectContainer();
+		const driver = createTemplateObjectDriver(true, true, true, false);
+		const root = createUniversalRoot(container, driver);
+		const rowPlan = universalPlan('object', {
+			kind: 'host',
+			type: 'row',
+			bindings: [['id', 0]],
+			children: [{ kind: 'host', type: 'label', children: [{ kind: 'slot', slot: 1 }] }],
+		});
+		const shellPlan = universalPlan('object', {
+			kind: 'host',
+			type: 'shell',
+			children: [{ kind: 'slot', slot: 0 }],
+		});
+		const Row = defineUniversalComponent('object', ({ id }: { id: string }) =>
+			universalValue(rowPlan, [id, `label:${id}`]),
+		);
+		const Scene = defineUniversalComponent('object', ({ ids }: { ids: readonly string[] }) =>
+			universalValue(shellPlan, [
+				universalFor(
+					ids,
+					(id) => id,
+					(id) => universalComponent('object', Row, universalProps([['set', 'id', id]])),
+					null,
+					false,
+					false,
+					undefined,
+					undefined,
+					undefined,
+					true,
+				),
+			]),
+		);
+
+		root.render(Scene, { ids: [] });
+		const shell = container.children[0];
+		const shellId = shell.id;
+		driver.capabilities.templateProgramRuns = true;
+		const prepared = root.prepare(Scene, { ids: ['a', 'b', 'c'] });
+		if (prepared.status !== 'prepared') throw new Error('Expected a post-mount component batch.');
+		const commands = prepared.batch.commands.filter(
+			(command) => command.op === 'mount-template-run',
+		);
+		expect(commands).toHaveLength(1);
+		if (commands[0].op !== 'mount-template-run') throw new Error('Expected a shared host mount.');
+		expect(commands[0].count).toBe(3);
+		expect(commands[0].parent).toBe(shellId);
+		expect(commands[0].firstId).toBeGreaterThan(shellId);
+		prepared.commit();
+		expect(container.children).toEqual([shell]);
+		expect(shell.children.map((row) => row.children[0].children[0].props.value)).toEqual([
+			'label:a',
+			'label:b',
+			'label:c',
+		]);
+		root.unmount();
+	});
+
+	it('retains already-adopted keyed component scopes when mounting capabilities upgrade', () => {
+		const container = createObjectContainer();
+		const driver = createTemplateObjectDriver(true, true, true, false);
+		const root = createUniversalRoot(container, driver);
+		const effects: string[] = [];
+		const plan = universalPlan('object', {
+			kind: 'host',
+			type: 'row',
+			bindings: [['id', 0]],
+			children: [{ kind: 'host', type: 'label', children: [{ kind: 'slot', slot: 1 }] }],
+		});
+		const Row = defineUniversalComponent('object', ({ id }: { id: string }) => {
+			const [state] = useState(`retained:${id}`, 'row-state');
+			useLayoutEffect(
+				() => {
+					effects.push(`mount:${id}`);
+					return () => effects.push(`cleanup:${id}`);
+				},
+				[],
+				'row-effect',
+			);
+			return universalValue(plan, [id, state]);
+		});
+		const Scene = defineUniversalComponent('object', ({ ids }: { ids: readonly string[] }) =>
+			universalFor(
+				ids,
+				(id) => id,
+				(id) =>
+					universalComponent(
+						'object',
+						Row,
+						universalProps({ id } as never, undefined, false, true),
+					),
+				null,
+				false,
+				false,
+				undefined,
+				undefined,
+				undefined,
+				true,
+			),
+		);
+
+		root.render(Scene, { ids: ['a', 'b'] });
+		const [first, second] = container.children;
+		expect(effects).toEqual(['mount:a', 'mount:b']);
+		driver.capabilities.templateProgramRuns = true;
+		root.render(Scene, { ids: ['b', 'a'] });
+		expect(container.children).toEqual([second, first]);
+		expect(container.children.map((row) => row.children[0].children[0].props.value)).toEqual([
+			'retained:b',
+			'retained:a',
+		]);
+		expect(effects).toEqual(['mount:a', 'mount:b']);
+		root.unmount();
+		expect(effects.slice(2).toSorted()).toEqual(['cleanup:a', 'cleanup:b']);
+	});
+
+	it('keeps an item owner when a component-prop getter reads keyed hook state', () => {
+		const container = createObjectContainer();
+		const root = createUniversalRoot(container, createTemplateObjectDriver(true, true, true, true));
+		const effects: string[] = [];
+		let setGetterValue!: (next: string) => void;
+		let setRowValue!: (next: string) => void;
+		const item = {
+			id: 'one',
+			get label() {
+				const [label, setLabel] = useState('getter:first', 'getter-slot');
+				setGetterValue = setLabel;
+				return label;
+			},
+		};
+		const plan = universalPlan('object', {
+			kind: 'host',
+			type: 'row',
+			children: [{ kind: 'host', type: 'label', children: [{ kind: 'slot', slot: 0 }] }],
+		});
+		const Row = defineUniversalComponent('object', ({ label }: { label: string }) => {
+			const [value, update] = useState('row:first', 'row-slot');
+			setRowValue = update;
+			useLayoutEffect(
+				() => {
+					effects.push('mount');
+					return () => effects.push('cleanup');
+				},
+				[],
+				'row-effect',
+			);
+			return universalValue(plan, [`${label}|${value}`]);
+		});
+		const Scene = defineUniversalComponent('object', () =>
+			universalFor(
+				[item],
+				(entry) => entry.id,
+				(entry) =>
+					universalComponent(
+						'object',
+						Row,
+						universalProps({ label: entry.label } as never, undefined, false, true),
+					),
+				null,
+				false,
+				false,
+				undefined,
+				undefined,
+				undefined,
+				true,
+			),
+		);
+
+		root.render(Scene, undefined);
+		const row = container.children[0];
+		expect(row.children[0].children[0].props.value).toBe('getter:first|row:first');
+		expect(effects).toEqual(['mount']);
+
+		flushUniversalSync(() => setGetterValue('getter:next'));
+		expect(container.children).toEqual([row]);
+		expect(row.children[0].children[0].props.value).toBe('getter:next|row:first');
+		expect(effects).toEqual(['mount']);
+
+		flushUniversalSync(() => setRowValue('row:next'));
+		expect(container.children).toEqual([row]);
+		expect(row.children[0].children[0].props.value).toBe('getter:next|row:next');
+		expect(effects).toEqual(['mount']);
+		root.unmount();
+		expect(effects).toEqual(['mount', 'cleanup']);
 	});
 
 	it('commits stable compact list state and event closures only after host acceptance', () => {


### PR DESCRIPTION
## Summary

Make real, first-screen-hydrated Lynx applications create component rows through the same compact, template-aware pipeline previously available only to background-only roots. On the production Chromium table benchmark, 10,000-row creation improves from **696 ms to 327 ms** (**2.13× faster than the Octane baseline; 53.0% less time**) while preserving first-screen adoption, native events, refs, updates, teardown, and mixed-version compatibility.

The final same-run, seven-sample comparison reports near-parity rather than an unsupported win: Octane creates 10,000 rows in **327 ms versus ReactLynx's 307 ms** (**6.5% slower**) and 1,000 rows in **37 ms versus 34 ms**. Octane remains substantially faster in the sustained update/select-storm scenarios.

### Why

First-screen roots previously disabled template-program capabilities throughout their lifetime to protect adoption identity. Consequently, ordinary post-adoption component rows expanded into thousands of independent commands and eager host acknowledgements even though their structure was compiler-proven, contiguous, and equivalent to the optimized background-only workload.

### Changes

- Preserve exact first-screen adoption and repair, then activate the already-negotiated template-program/run capabilities only after the correlated adoption acknowledgement completes.
- Recognize eligible scalar-only component-row templates in the universal compiler/runtime and coalesce each fresh keyed row set into **one** immutable `mount-template-run`, retaining existing component identity, event ownership, and changed-row reconciliation.
- Preserve compiler-owned direct prop records through eligible component construction, avoiding approximately **50,000 temporary prop arrays** when mounting 10,000 rows.
- Extend existing `compact-v1` acknowledgement handling to one verified, post-adoption incremental run: preserve adopted shell handles and generations, append dense host identities without per-host acknowledgement snapshots, and fall back to complete legacy deltas on faults.
- Materialize selectors, public handles, host records, and generations only when refs, callbacks, events, mutations, or teardown actually require them; retain existing first-tree, native-list, portal, worklet, and older-peer fallbacks.
- Restore immutability only after strict receive-boundary validation and correlated-root verification, because browser `structuredClone` intentionally removes `Object.freeze` from worker-to-main messages.
- Prefer the optional public `__AppendElement` PAPI for append-only dense template children, matching ReactLynx's native append path; preserve anchored insertion and older engines through the existing `__InsertElementBefore` fallback.
- Call bound public `__CreateView`, `__CreateText`, and `__CreateRawText` intrinsics directly for certified dense programs, removing approximately **70,000 generic element-factory dispatches** at 10,000 rows while retaining the ordinary adapter fallback.
- Retain the latest upstream Samsung/browser targeting and `Object.hasOwn` compatibility changes when rebasing the compiler, runtime, and Rsbuild integration.
- Tighten deterministic table guards: creation is exactly one command at both scales; selection rerenders exactly two rows; updating every tenth row rerenders exactly 100/1,000 rows.

### Production Chromium evidence

Same browser, same workload, same vendored ReactLynx/VueLynx references, production builds, medians of **seven** repetitions; absolute times are host-specific.

| Rows | Operation | Octane | ReactLynx | VueLynx |
| ---: | --- | ---: | ---: | ---: |
| 1,000 | Create | **37 ms** | 34 ms | 44 ms |
| 1,000 | Update every tenth | **10 ms** | 9 ms | 13 ms |
| 1,000 | Select | **7 ms** | 7 ms | 8 ms |
| 1,000 | Update storm | **30 ms** | 139 ms | 39 ms |
| 1,000 | Select storm | **12 ms** | 52 ms | 21 ms |
| 10,000 | Create | **327 ms** | 307 ms | 415 ms |
| 10,000 | Update every tenth | **63 ms** | 67 ms | 50 ms |
| 10,000 | Select | **41 ms** | 27 ms | 38 ms |
| 10,000 | Update storm | **223 ms** | 1,332 ms | 626 ms |
| 10,000 | Select storm | **67 ms** | 548 ms | 304 ms |

The deterministic 10,000-row run creates **70,042 physical elements**, emits **one creation command**, and serializes **350,938 bytes**, down from approximately **7.56 MB** before batching. An earlier diagnostic real-browser sample, before the final optional-append optimization, emitted one **339,870-byte** command with just **28 selectors**; of its approximately **303 ms** total, main-thread native application consumed **220.4 ms**, validation **2.9 ms**, preparation **1.5 ms**, acknowledgement **0.1 ms**, and background wire dispatch approximately **1 ms**. That profile identified native PAPI insertion as the remaining bottleneck and motivated the public append fast path.

Browser measurements are noisy: the final 10,000-row create samples report **327 ±2 ms** for Octane and **307 ±5 ms** for ReactLynx. Earlier and later benchmark sessions also experienced different machine/browser load, so the contemporaneous within-run comparison is stronger evidence than comparing absolute times across sessions.

## Validation

The repository-wide `pnpm format:check`, `pnpm typecheck`, and `pnpm test` commands were not run; their template boxes remain unchecked. The affected packages were validated directly against the latest upstream compiler/async and Samsung/browser compatibility changes with **12,690 passing tests**, **11 successful TypeScript programs**, all changed-file formatting checks, and the mandatory completed workspace sync.

- [ ] `pnpm format:check`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [x] `pnpm sync` completed, including generated parity metadata, package inventories, and rule/context checks.
- [x] **12,103 passing Octane development/production and Three tests**, including compiler, universal renderer, component identity, updates, cross-renderer compatibility, and the latest upstream compiler/async and browser-compatibility changes.
- [x] **336 passing Lynx tests**, including first-screen adoption/repair, structured-clone delivery, background roots, dense hosts, incremental acknowledgements, late refs, native events, rollback, disposal, and legacy peers.
- [x] **251 passing build-plugin tests** across Vite (**68**), Rspack (**79**), Rsbuild (**40**), and Rspeedy (**64**), including real Chromium, production bundles, advertised local demos, and the latest upstream Rsbuild/browser compatibility cases.
- [x] **11 direct `tsgo --noEmit` typecheck programs**, including all four Vite/Rspack/Rsbuild/Rspeedy build-plugin configurations and the affected core/Lynx configurations.
- [x] Direct Prettier checks pass for every changed file; `git diff --check`, changeset patch policy, no-skipped-test markers, and published `.tsrx` declaration safety all pass.
- [x] All **25 React-parity audit manifests** match their lockfile SHA-256 digests; the package manifest, workspace manifest, and lockfile are unchanged.
- [x] Deterministic `lynx-table` run: both 1,000-row and 10,000-row creation use exactly one command; all 18 structural/changed-row ratio guards pass.
- [x] Existing `lynx-render` performance ratios and both `lynx-bundle-size` ratio guards pass without relaxing their thresholds.
- [x] Production Chromium `lynx-table` comparison against vendored ReactLynx and VueLynx: 1,000 and 10,000 rows, seven repetitions.

## Risk / follow-ups

- This is a performance-sensitive compiler/runtime/transport/host change. Certified component templates deliberately fall back for unsupported refs, lifecycle effects, lists, portals, worklets, noncontiguous identities, unsafe values, adoption repair, and older peers.
- Receive-boundary validation, correlated capability provenance, shell handle identity, stale-event generations, accepted-fault cleanup, full legacy acknowledgements, and structured-clone behavior have explicit regressions.
- The application bundle grows from approximately **479 KB to 484.7 KB** (**+5.7 KB; approximately 1.2%**) to support certified component templates, direct prop/native factories, incremental acknowledgements, and safe first-screen negotiation.
- Octane's final 10,000-row creation median remains **6.5% slower than ReactLynx**; 10,000-row selection also remains slower than both ReactLynx and VueLynx, and updating every tenth row remains slower than VueLynx. Short operations and creation remain susceptible to browser scheduling and garbage-collection variance.
- These measurements establish Lynx-for-Web behavior on one machine; they are not presented as native-device measurements or universal latency guarantees.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!--
Tick the box above whenever an agent wrote the change, no matter which account
pushes it. Leaving it clear or omitting this section asserts a human wrote the
diff; either form keeps the label workflow successful.

A bot reads this box and applies the label, so nothing here needs repository
permissions and it works the same from a fork. The type label comes from the
conventional-commit type in the title, with the type-prefixed head branch as a
fallback. Do not apply either by hand.

When updating an existing pull request, merge this template content into the
current body. Preserve every bot-managed HTML comment region and all existing
maintainer-authored text; never replace the body from a fresh template.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches first-screen adoption, cross-thread capability negotiation, compact acknowledgements, and compiler/runtime host batching—security- and correctness-sensitive paths with broad regression surface.
> 
> **Overview**
> **After Lynx first-screen adoption**, template-program/run capabilities activate only once the correlated adoption acknowledgement finishes, so the first batch stays legacy while later work can use compact wire paths.
> 
> The **universal compiler and runtime** recognize eligible `@for` component rows (`componentScope`), coalesce fresh keyed sets into **one** frozen `mount-template-run`, use compiler-owned prop records, and assign disjoint logical range IDs so host IDs stay contiguous. Component hooks, keyed identity, context, and events are preserved.
> 
> **Lynx transport, client compact ACKs, and host driver** gain **incremental compact** handling on already-adopted roots: append dense host segments without per-host legacy deltas, with overlap/generation checks and rollback that keeps adopted shell handles. Main thread re-freezes runs after structured-clone validation; optional **`__AppendElement`** and bound **view/text/rawText** intrinsics speed dense materialization.
> 
> **Benchmark guards** now expect **one** create command for any number of component-owned rows at 1k/10k scales.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fccf1e8ee6a60a5da43bd6d61654f47209340bc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->