### PR TITLE
perf: reuse warmed transition resources

### DIFF
--- a/.changeset/reuse-warmed-transition-resources.md
+++ b/.changeset/reuse-warmed-transition-resources.md
@@ -1,0 +1,6 @@
+---
+'octane': patch
+---
+
+Reuse already-warmed asynchronous resources across promoted transition retries
+without duplicating request creators or exposing partially committed screens.

--- a/benchmarks/async-composition/README.md
+++ b/benchmarks/async-composition/README.md
@@ -174,7 +174,19 @@ unknown, mutable, or escaped list retains the ordinary rendering behavior.
 
 The existing browser gate requires all seven independent requests in the first
 wave, two waves per operation, and eight actual network starts. Its current
-factory-call ceilings are eight on initialization and 13 on an update; the
-remaining update-only replay calls reuse cached requests. Keyed board identity,
-controlled input state, fallback retention, and zero mixed transition states
-remain mandatory.
+factory-call ceilings are eight on both initialization and updates. Keyed board
+identity, controlled input state, fallback retention, and zero mixed transition
+states remain mandatory.
+
+## Held transition resource reuse
+
+After the first update wave settles, the dependent `owner` request begins the
+second wave. Transition promotion previously invoked five already-started
+resource creators again at that point, even though the application cache
+prevented duplicate network requests.
+
+The promoted warm plan now claims matching entries from the existing
+episode-agnostic resource harvest without consuming the real components'
+adoption rights. Each update therefore invokes exactly eight creators, down
+from 13, while preserving eight network starts, two request waves, the
+dependent-owner ordering, and zero mixed transition states.

--- a/benchmarks/async-composition/run.mjs
+++ b/benchmarks/async-composition/run.mjs
@@ -26,17 +26,14 @@ const expectedSignature = (version) =>
 // These are one-way ceilings, not expected results: any improvement passes.
 // They keep known gaps visible without allowing them to silently worsen.
 //
-// update calls sits at 13, not the 8-call dependency floor: the deferred
-// transition commit holds the whole screen (mixed states 0), and its promoted
-// round after the dependent `owner` resolves re-creates the five warm-started
-// panel fetches instead of dep-hitting them. The app-level cache serves the
-// same promises, so no duplicate network occurs — the ceiling pins the
-// re-creation cost until the resume/warm work restores the floor
-// (docs/transition-deferred-commit-plan.md, P2).
+// Both operations stay at the eight-request creator floor. When the dependent
+// `owner` starts, the promoted transition claims its existing warm-resource
+// harvest instead of calling the five already-started creators again. The
+// complete dashboard remains held until the owner resolves (mixed states 0).
 const OBSERVATION_CEILINGS = {
 	'octane-tsrx': {
 		init: { waves: 2, calls: 8, mixedStates: 0 },
-		update: { waves: 2, calls: 13, mixedStates: 0 },
+		update: { waves: 2, calls: 8, mixedStates: 0 },
 	},
 	react: {
 		init: { mixedStates: 0 },

--- a/docs/transition-deferred-commit-plan.md
+++ b/docs/transition-deferred-commit-plan.md
@@ -171,10 +171,28 @@ re-render — the screen and cue were re-established in round one — so entries
 move monotonically forward. The flip-away case now re-asserts the whole held
 screen instead of tearing to the flipped text.
 
-Residual, pinned one-way in the benchmark (update calls ceiling 13): the round
-after the dependent `owner` resolves re-creates the five warm-started panel
-fetches instead of dep-hitting them — app-cache-served, zero mixed states,
-no network duplication. P2 owns walking that back to the 8-call floor.
+## P2 warm-resource reuse landed (2026-08-10)
+
+The original promoted transition still recreated five already-warmed resources
+when its second round discovered the dependent `owner` request, before that
+request resolved. The application's cache avoided duplicate network requests,
+but the async-composition benchmark recorded 13 resource-creator calls instead
+of the eight actual requests.
+
+The first held attempt already harvests warmed values outside the per-episode
+cache, and real memo adoption already consumes those values exactly once.
+Speculative warming now consults the same held or promoted harvest after its
+ordinary cache and active-memo checks. A matching slot and dependencies claim
+only the existing occurrence for the current warm plan; even an already-adopted
+entry remains an occurrence tombstone and must not restart its creator.
+
+This lookup neither consumes the harvested value nor publishes another cache
+entry. Real memo adoption remains the sole owner of `taken`, repeated matching
+occurrences stay distinct, and the existing promotion, rollback, supersession,
+and cleanup paths retain harvest ownership. No new state, allocation, runtime
+API, or ordinary render-path work is introduced. The production benchmark now
+requires exactly eight initial and eight transition-update creators, two
+request waves, eight actual requests, and zero mixed-version committed states.
 
 ## Phases
 

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -9202,6 +9202,29 @@ export function warmMemo(compute: () => any, deps: any[], slot: HookSlot): void 
 		CURRENT_WARM_CLAIMS?.add(entry);
 		return;
 	}
+	// A promoted transition starts a fresh warm episode, but its earlier
+	// speculative values remain in the episode-agnostic harvest. Claim the
+	// matching occurrence for this plan without consuming it: the real memo
+	// still owns adoption, and an already-adopted entry remains a tombstone for
+	// that occurrence when a later sibling suspends in the same round.
+	const held = HELD_SYNC_TRANSITION;
+	const harvest = held?.warmHarvest ?? PROMOTED_WARM_HARVEST;
+	const owner = held?.origin ?? ACTIVE_TRANSITION_ATTEMPT?.origin;
+	if (
+		harvest !== null &&
+		harvest !== undefined &&
+		owner !== undefined &&
+		blockIsAncestor(owner, CURRENT_BLOCK!)
+	) {
+		for (let i = 0; i < harvest.length; i++) {
+			const entry = harvest[i];
+			if (entry.slot !== slot || depsChanged(entry.deps, deps) || CURRENT_WARM_CLAIMS?.has(entry)) {
+				continue;
+			}
+			CURRENT_WARM_CLAIMS?.add(entry);
+			return;
+		}
+	}
 	let value: any;
 	try {
 		value = compute();

--- a/packages/octane/tests/parallel-use.test.ts
+++ b/packages/octane/tests/parallel-use.test.ts
@@ -146,7 +146,258 @@ const KEYED_PANELS_SOURCE = `
 	}
 `;
 
+const TRANSITION_PANELS_SOURCE = `
+	import { Suspense, startTransition, use, useState } from 'octane';
+
+	const PANELS = ['activity', 'insights'];
+
+	function ProjectBadge(props) @{
+		const badge = use(props.load('badge', props.version));
+		<span class="transition-badge">{badge as string}</span>
+	}
+
+	function ProjectOwner(props) @{
+		const owner = use(props.load('owner', props.version, props.project));
+		<span class="transition-owner">{owner as string}</span>
+	}
+
+	function ProjectHeader(props) @{
+		const project = use(props.load('project', props.version));
+		<section class="transition-project">
+			<span class="transition-project-value">{project as string}</span>
+			<div class="transition-project-meta">
+				<ProjectBadge load={props.load} version={props.version} />
+				<ProjectOwner load={props.load} version={props.version} project={project} />
+			</div>
+		</section>
+	}
+
+	function ActivityPanel(props) @{
+		const value = use(props.load('activity', props.version));
+		<span class="transition-panel" data-panel="activity">{value as string}</span>
+	}
+
+	function InsightsPanel(props) @{
+		const value = use(props.load('insights', props.version));
+		<span class="transition-panel" data-panel="insights">{value as string}</span>
+	}
+
+	function Dashboard(props) @{
+		<main class="transition-dashboard" data-version={props.version as string}>
+			<ProjectHeader load={props.load} version={props.version} />
+			@for (const panel of PANELS; key panel) {
+				@if (panel === 'activity') {
+					<ActivityPanel load={props.load} version={props.version} />
+				} @else {
+					<InsightsPanel load={props.load} version={props.version} />
+				}
+			}
+		</main>
+	}
+
+	export function TransitionPanels(props) @{
+		const [version, setVersion] = useState(props.initialVersion ?? 0);
+		<div>
+			<button class="transition-bump" onClick={() => startTransition(() => setVersion(value => value + 1))}>next</button>
+			<button class="transition-urgent" onClick={() => setVersion(2)}>urgent</button>
+			<span class="transition-shell">{'shell-' + version}</span>
+			<Suspense fallback={<span class="transition-pending">loading</span>}>
+				<Dashboard load={props.load} version={version} />
+			</Suspense>
+		</div>
+	}
+`;
+
 describe('parallel use() — independent asynchronous keyed-list children', () => {
+	it('starts each transition request once while preserving its dependent second wave', async () => {
+		const client = loadCompiledFixtureSource(TRANSITION_PANELS_SOURCE, {
+			id: 'warmed-transition-panels.tsrx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod' },
+		});
+		const resources = resourceFetcher();
+		const root = mount(client.TransitionPanels, { load: resources.load });
+
+		try {
+			expect(resources.calls).toEqual(['project:0', 'badge:0', 'activity:0', 'insights:0']);
+			expect(root.find('.transition-pending').textContent).toBe('loading');
+
+			await act(() => {
+				resources.settle('badge', 0);
+				resources.settle('activity', 0);
+				resources.settle('insights', 0);
+				resources.settle('project', 0);
+			});
+			expect(resources.calls).toEqual([
+				'project:0',
+				'badge:0',
+				'activity:0',
+				'insights:0',
+				'owner:0',
+			]);
+			await act(() => resources.settle('owner', 0));
+
+			const dashboard = root.find('.transition-dashboard');
+			const panels = root.findAll('.transition-panel');
+			expect(panels.map((node) => node.textContent)).toEqual(['activity-v0', 'insights-v0']);
+			expect(dashboard.getAttribute('data-version')).toBe('0');
+			expect(root.find('.transition-shell').textContent).toBe('shell-0');
+			expect(root.find('.transition-owner').textContent).toBe('owner-v0');
+
+			root.click('.transition-bump');
+			expect(resources.calls.slice(5)).toEqual([
+				'project:1',
+				'badge:1',
+				'activity:1',
+				'insights:1',
+			]);
+			expect(root.find('.transition-dashboard')).toBe(dashboard);
+			expect(root.findAll('.transition-panel')).toEqual(panels);
+			expect(dashboard.getAttribute('data-version')).toBe('0');
+			expect(root.find('.transition-shell').textContent).toBe('shell-0');
+			expect(root.findAll('.transition-pending')).toEqual([]);
+
+			await act(() => {
+				resources.settle('badge', 1);
+				resources.settle('activity', 1);
+				resources.settle('insights', 1);
+				resources.settle('project', 1);
+			});
+			expect(resources.calls.slice(5)).toEqual([
+				'project:1',
+				'badge:1',
+				'activity:1',
+				'insights:1',
+				'owner:1',
+			]);
+			expect(root.find('.transition-dashboard')).toBe(dashboard);
+			expect(dashboard.getAttribute('data-version')).toBe('0');
+			expect(root.find('.transition-owner').textContent).toBe('owner-v0');
+
+			await act(() => resources.settle('owner', 1));
+			expect(root.find('.transition-dashboard')).toBe(dashboard);
+			expect(root.findAll('.transition-panel')).toEqual(panels);
+			expect(dashboard.getAttribute('data-version')).toBe('1');
+			expect(root.find('.transition-shell').textContent).toBe('shell-1');
+			expect(root.find('.transition-owner').textContent).toBe('owner-v1');
+			expect(root.findAll('.transition-panel').map((node) => node.textContent)).toEqual([
+				'activity-v1',
+				'insights-v1',
+			]);
+			expect(resources.calls).toEqual([
+				'project:0',
+				'badge:0',
+				'activity:0',
+				'insights:0',
+				'owner:0',
+				'project:1',
+				'badge:1',
+				'activity:1',
+				'insights:1',
+				'owner:1',
+			]);
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('starts separate requests for an independent root while another transition is pending', async () => {
+		const client = loadCompiledFixtureSource(TRANSITION_PANELS_SOURCE, {
+			id: 'independent-transition-roots.tsrx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod' },
+		});
+		const calls: string[] = [];
+		const jobs = new Map<string, Deferred<string>>();
+		let activeRoot = 'first';
+		const load = (resource: string, version: number) => {
+			const key = `${activeRoot}:${resource}:${version}`;
+			const job = deferred<string>();
+			calls.push(key);
+			jobs.set(key, job);
+			return job.promise;
+		};
+		const first = mount(client.TransitionPanels, { load, initialVersion: 0 });
+		let second: ReturnType<typeof mount> | undefined;
+
+		try {
+			await act(() => {
+				for (const resource of ['badge', 'activity', 'insights', 'project']) {
+					jobs.get(`first:${resource}:0`)!.resolve(`${resource}-first-v0`);
+				}
+			});
+			await act(() => jobs.get('first:owner:0')!.resolve('owner-first-v0'));
+			first.click('.transition-bump');
+			const start = calls.length;
+
+			activeRoot = 'second';
+			second = mount(client.TransitionPanels, { load, initialVersion: 1 });
+			expect(calls.slice(start)).toEqual([
+				'second:project:1',
+				'second:badge:1',
+				'second:activity:1',
+				'second:insights:1',
+			]);
+			expect(second.find('.transition-pending').textContent).toBe('loading');
+			expect(first.find('.transition-shell').textContent).toBe('shell-0');
+		} finally {
+			second?.unmount();
+			first.unmount();
+		}
+	});
+
+	it('does not reuse requests from a transition superseded by an urgent update', async () => {
+		const client = loadCompiledFixtureSource(TRANSITION_PANELS_SOURCE, {
+			id: 'superseded-transition-panels.tsrx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod' },
+		});
+		const resources = resourceFetcher();
+		const root = mount(client.TransitionPanels, { load: resources.load });
+
+		try {
+			await act(() => {
+				for (const resource of ['badge', 'activity', 'insights', 'project']) {
+					resources.settle(resource, 0);
+				}
+			});
+			await act(() => resources.settle('owner', 0));
+
+			root.click('.transition-bump');
+			expect(resources.calls.slice(5)).toEqual([
+				'project:1',
+				'badge:1',
+				'activity:1',
+				'insights:1',
+			]);
+
+			root.click('.transition-urgent');
+			expect(resources.calls.slice(9)).toEqual([
+				'project:2',
+				'badge:2',
+				'activity:2',
+				'insights:2',
+			]);
+			expect(root.find('.transition-shell').textContent).toBe('shell-2');
+
+			await act(() => {
+				for (const resource of ['badge', 'activity', 'insights', 'project']) {
+					resources.settle(resource, 1);
+				}
+			});
+			expect(resources.calls).not.toContain('owner:1');
+			expect(root.find('.transition-shell').textContent).toBe('shell-2');
+			expect(root.find('.transition-owner').textContent).toBe('owner-v0');
+			expect(root.findAll('.transition-panel').map((node) => node.textContent)).toEqual([
+				'activity-v0',
+				'insights-v0',
+			]);
+			expect(root.find('.transition-dashboard').getAttribute('data-version')).toBe('0');
+		} finally {
+			root.unmount();
+		}
+	});
+
 	it('starts every selected keyed child before any request resolves and adopts each request once', async () => {
 		const client = loadCompiledFixtureSource(KEYED_PANELS_SOURCE, {
 			id: 'independent-keyed-panels.tsrx',


### PR DESCRIPTION
## Summary

- Reuse resource-creator results already harvested by a held or promoted transition instead of recreating them when a dependent request starts its second wave.
- Reduce the existing async-composition transition from **13 to 8 resource-creator calls** while retaining eight actual network requests, two request waves, and an atomically committed dashboard.
- Tighten the existing production benchmark's transition creator ceiling to eight only after the real runtime behavior reaches that floor.

## Correctness and scope

- Preserve existing current-episode warm-cache hits and active real-memo precedence; consult the episode-agnostic held/promoted harvest only on the speculative `warmMemo` cold path.
- Match existing slot/dependency identities and claim one concrete occurrence per warm plan without consuming the real component's adoption rights or publishing duplicate cache entries.
- Treat previously adopted harvest entries as occurrence tombstones so a sibling already rendered before the dependent owner does not restart its factory.
- Restrict harvest reuse to descendants of the held/promoted transition's existing owning block; unrelated roots with identical compiled slots, dependencies, and loader identity retain their own requests.
- Preserve duplicate same-slot occurrences, true owner dependencies, urgent supersession, held previous DOM, keyed panel identity, controlled board state, fallback behavior, effects, hydration, and independent roots.
- Add no runtime state, allocations, public APIs, compiler changes, ordinary-render-path work, or changes to generic static/Suspense/hydration production bundles.

## Production work

Existing authored async-composition dashboard, unchanged fixtures/resources, production minification, and interleaved real-Chromium baseline/candidate runs:

| Observation | Before | After |
| --- | ---: | ---: |
| Initial resource-creator calls | 8 | 8 |
| Transition resource-creator calls | 13 | 8 |
| Duplicated transition creator calls | 5 | 0 |
| Actual network starts per operation | 8 | 8 |
| Independent first-wave requests | 7 | 7 |
| Request waves per operation | 2 | 2 |
| Mixed-version committed states | 0 | 0 |

The eliminated duplicate creators were `badge`, `activity`, `activity-summary`, `insights`, and `insights-chart`; they previously ran when the dependent `owner` request **started**, before it settled. Same-source update medians were 106.10 ms versus 105.10 ms, within the fixed two-wave network-latency floor, so no wall-clock improvement is claimed. The affected application adds **185 raw bytes / 72 gzip bytes / 57 Brotli bytes**; generic static-root, Suspense-transition, and hydration applications and the fixed 16-file compiler corpus are byte-identical.

## Validation

- [x] Full Octane development/production core suite: **806 files / 11,953 tests passed**.
- [x] Focused affected transition, Suspense, parallel-use, SSR, hydration, effect/action, universal, and reconciler suites: **258 project-file executions / 3,056 tests passed**.
- [x] Existing real-Chromium Suspense/hydration suite: **11 tests passed**.
- [x] Public production/development transition regressions: exact one-creator-per-resource behavior, cross-root isolation RED-to-GREEN, and urgent-supersession/stale-result isolation.
- [x] Independent same-hook-slot/equal-dependency repeated-occurrence baseline/candidate probe preserves distinct component results.
- [x] Existing tightened async-composition production Chromium gate: eight initial/eight update creators, eight network starts, seven independent first-wave starts, two waves, and zero mixed states.
- [x] Exact-head generic bundle and fixed-compiler-corpus byte comparisons.
- [x] Full workspace typecheck: `pnpm --config.verify-deps-before-run=false --config.enable-pre-post-scripts=false run typecheck`.
- [x] Final repository synchronization: `pnpm --config.verify-deps-before-run=false sync`.
- [x] Scoped Prettier verification and `git diff --check`.

Refs #673.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only the speculative `warmMemo` path in held/promoted transitions, but incorrect harvest matching could skip needed fetches or break adoption; mitigated by scoped ancestor checks, tombstone behavior, and broad transition/async-composition tests.
> 
> **Overview**
> When a held or promoted transition starts a **new warm episode** after the dependent `owner` request begins, speculative `warmMemo` no longer re-runs creators for resources already warmed in the first round. It looks up the episode-agnostic **warm harvest** (`HELD_SYNC_TRANSITION` / `PROMOTED_WARM_HARVEST`) for a matching slot and dependencies under the transition origin, **claims** that occurrence via `CURRENT_WARM_CLAIMS`, and skips `compute()`—without consuming adoption or adding cache entries. Already-adopted harvest slots still act as tombstones so siblings do not restart factories.
> 
> The async-composition benchmark **update creator ceiling** moves from **13 to 8** (matching init), with README and transition-plan docs updated to record P2 warm reuse. **Regression tests** in `parallel-use.test.ts` cover transition request ordering (two waves, held UI until `owner` settles), independent roots during a pending transition, and no reuse after urgent supersession.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 275d5581095f1dc9c269ffc3c907d9806a409f33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->