### PR TITLE
perf: preload eligible lazy modules safely

### DIFF
--- a/.changeset/preload-eligible-lazy-modules.md
+++ b/.changeset/preload-eligible-lazy-modules.md
@@ -1,0 +1,6 @@
+---
+'octane': patch
+---
+
+Start provably reachable lazy component imports alongside independent suspended
+work without eagerly loading dormant deferred-hydration islands.

--- a/benchmarks/async-composition/README.md
+++ b/benchmarks/async-composition/README.md
@@ -190,3 +190,20 @@ episode-agnostic resource harvest without consuming the real components'
 adoption rights. Each update therefore invokes exactly eight creators, down
 from 13, while preserving eight network starts, two request waves, the
 dependent-owner ordering, and zero mixed transition states.
+
+## Code-split module discovery
+
+The Octane dashboard includes a synchronous, dynamically imported child after
+its existing resource panels and keyed board. Its JavaScript stays in a
+separate production chunk and is not fetched before the dashboard mounts.
+
+The browser gate delays that real chunk by 35ms and requires its loader and
+network request to start before the independent `project` request settles. The
+module is loaded exactly once across the initial mount and subsequent transition;
+its rendered node must survive the update. All eight resource starts, eight
+creator calls, seven first-wave requests, two dependency waves, and zero mixed
+transition states remain mandatory.
+
+Only eligible lazy children in an already-reachable warm plan are prepared.
+Dormant deferred-hydration islands remain untouched until their own activation
+or explicitly configured prefetch strategy.

--- a/benchmarks/async-composition/run.mjs
+++ b/benchmarks/async-composition/run.mjs
@@ -15,6 +15,57 @@ const TARGETS = process.env.TARGETS
 			{ name: 'octane-tsrx', url: 'http://localhost:5282/' },
 			{ name: 'react', url: 'http://localhost:5284/' },
 		];
+const LAZY_CHUNK_DELAY_MS = 35;
+
+function isLazyCodeChunk(url) {
+	return /\/assets\/LazyCodeProof-[^/]+\.js$/.test(new URL(url).pathname);
+}
+
+async function observeLazyCode(page) {
+	return page.evaluate(() => {
+		const proof = document.querySelector('.lazy-code-proof');
+		return {
+			loads: globalThis.__octaneLazyCodeLoads ?? 0,
+			startedAt: globalThis.__octaneLazyCodeStartedAt ?? null,
+			requests: performance
+				.getEntriesByType('resource')
+				.filter((entry) => /\/assets\/LazyCodeProof-[^/]+\.js$/.test(new URL(entry.name).pathname))
+				.map((entry) => ({ name: entry.name, startedAt: entry.startTime })),
+			version: proof?.getAttribute('data-lazy-code-version') ?? null,
+			sameNode: globalThis.__octaneLazyCodeInitialNode === proof,
+		};
+	});
+}
+
+function validateLazyCode(target, operation, observation, code, networkRequests) {
+	const prefix = `${target} ${operation}`;
+	if (code.loads !== 1) {
+		throw new Error(`${prefix}: expected one lazy module loader call, got ${code.loads}`);
+	}
+	if (networkRequests.length !== 1 || code.requests.length !== 1) {
+		throw new Error(
+			`${prefix}: expected one real lazy module request, got ${networkRequests.length}/${code.requests.length}`,
+		);
+	}
+	if (code.version !== (operation === 'init' ? '0' : '1')) {
+		throw new Error(`${prefix}: lazy module rendered the wrong version ${code.version}`);
+	}
+	if (operation === 'update' && code.sameNode !== true) {
+		throw new Error(`${prefix}: the loaded lazy component was remounted`);
+	}
+	if (operation === 'init') {
+		const projectSettle = observation.trace.settles.find((entry) => entry.resource === 'project');
+		const settledAt = observation.trace.startedAt + projectSettle.atMs;
+		if (code.startedAt >= settledAt || code.requests[0].startedAt >= settledAt) {
+			throw new Error(
+				`${prefix}: lazy module request started after the first project wave settled ` +
+					`(loader ${(code.startedAt - observation.trace.startedAt).toFixed(1)}ms, ` +
+					`request ${(code.requests[0].startedAt - observation.trace.startedAt).toFixed(1)}ms, ` +
+					`project ${projectSettle.atMs.toFixed(1)}ms)`,
+			);
+		}
+	}
+}
 
 const expectedText = (resource, version) =>
 	`${resource}:v${version}${resource === 'owner' ? `:owner-${version}` : ''}`;
@@ -208,19 +259,47 @@ async function runTarget(target) {
 		for (let i = 0; i < ITER; i++) {
 			const page = await context.newPage();
 			try {
+				const lazyRequests = [];
+				if (target.name === 'octane-tsrx') {
+					page.on('request', (request) => {
+						if (isLazyCodeChunk(request.url())) lazyRequests.push(request.url());
+					});
+					await page.route(/\/assets\/LazyCodeProof-[^/]+\.js(?:\?.*)?$/, async (route) => {
+						await new Promise((resolve) => setTimeout(resolve, LAZY_CHUNK_DELAY_MS));
+						await route.continue();
+					});
+				}
 				await page.goto(target.url, { waitUntil: 'load' });
 				await page.waitForFunction(() => typeof window.__init === 'function', { timeout: 10_000 });
-				init.push(
-					validateObservation(target.name, 'init', 0, await page.evaluate(() => window.__init())),
-				);
-				update.push(
-					validateObservation(
+				if (target.name === 'octane-tsrx') {
+					const beforeMount = await observeLazyCode(page);
+					if (
+						beforeMount.loads !== 0 ||
+						beforeMount.requests.length !== 0 ||
+						lazyRequests.length !== 0
+					) {
+						throw new Error(`${target.name}: the lazy module loaded before the dashboard mounted`);
+					}
+				}
+				const initial = await page.evaluate(() => window.__init());
+				init.push(validateObservation(target.name, 'init', 0, initial));
+				if (target.name === 'octane-tsrx') {
+					validateLazyCode(target.name, 'init', initial, await observeLazyCode(page), lazyRequests);
+					await page.evaluate(() => {
+						globalThis.__octaneLazyCodeInitialNode = document.querySelector('.lazy-code-proof');
+					});
+				}
+				const updated = await page.evaluate(() => window.__update());
+				update.push(validateObservation(target.name, 'update', 1, updated));
+				if (target.name === 'octane-tsrx') {
+					validateLazyCode(
 						target.name,
 						'update',
-						1,
-						await page.evaluate(() => window.__update()),
-					),
-				);
+						updated,
+						await observeLazyCode(page),
+						lazyRequests,
+					);
+				}
 			} finally {
 				await page.close();
 			}

--- a/benchmarks/async-composition/shared/octane/App.tsrx
+++ b/benchmarks/async-composition/shared/octane/App.tsrx
@@ -1,10 +1,20 @@
-import { Suspense, startTransition, useState } from 'octane';
+import { Suspense, lazy, startTransition, useState } from 'octane';
 import { boardInputValue, boardRowsFor, boardRowText } from '../data.js';
 import { ActivityPanel } from './ActivityPanel.tsrx';
 import { InsightsPanel } from './InsightsPanel.tsrx';
 import { ProjectHeader } from './ProjectHeader.tsrx';
 
 const DASHBOARD_PANELS = ['activity', 'insights'];
+const LazyCodeProof = lazy(() => {
+	const benchmark = globalThis as
+		typeof globalThis & {
+			__octaneLazyCodeLoads?: number;
+			__octaneLazyCodeStartedAt?: number;
+		};
+	benchmark.__octaneLazyCodeLoads = (benchmark.__octaneLazyCodeLoads ?? 0) + 1;
+	benchmark.__octaneLazyCodeStartedAt = performance.now();
+	return import('./LazyCodeProof.tsrx').then((module) => ({ default: module.LazyCodeProof }));
+});
 
 // Synchronous transition-atomicity guard: keyed rows that reorder, drop and
 // gain a member every version, plus a controlled input. All of it must move
@@ -30,6 +40,7 @@ function Dashboard(props: { version: number }) @{
 			}
 		}
 		<Board version={props.version} />
+		<LazyCodeProof version={props.version} />
 	</main>
 }
 

--- a/benchmarks/async-composition/shared/octane/LazyCodeProof.tsrx
+++ b/benchmarks/async-composition/shared/octane/LazyCodeProof.tsrx
@@ -1,0 +1,6 @@
+export function LazyCodeProof(props: { version: number }) @{
+	<aside
+		class="lazy-code-proof"
+		data-lazy-code-version={String(props.version)}
+	>{'Dashboard module ready'}</aside>
+}

--- a/docs/deferred-hydration.md
+++ b/docs/deferred-hydration.md
@@ -174,11 +174,14 @@ style scope), and `this` or `super` captures; move that work into a child
 component or opt out with `split={false}`. Ordinary lexical values can be
 captured by the generated child component.
 
-Generated Hydrate chunks are not eagerly module-preloaded. The Vite and Rsbuild
-app integrations still link CSS reachable from a route's deferred chunks,
-because that route's server HTML needs its styling before the child JavaScript
-loads. This eager CSS collection follows the route entry's asset graph; it does
-not turn deferred JavaScript into an eager dependency.
+Generated Hydrate chunks are not eagerly module-preloaded. Lazy-module discovery
+for independently suspended siblings never enters a dormant Hydrate boundary,
+so its child code remains deferred until activation or an explicit prefetch
+strategy. The Vite and Rsbuild app integrations still link CSS reachable from a
+route's deferred chunks, because that route's server HTML needs its styling
+before the child JavaScript loads. This eager CSS collection follows the route
+entry's asset graph; it does not turn deferred JavaScript into an eager
+dependency.
 
 ### `prefetch`
 

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -713,6 +713,13 @@ const Chart = lazy(() =>
 );
 ```
 
+Creating a lazy wrapper does not call its loader. When an independently
+reachable sibling suspends, Octane may start the lazy module's existing loader
+early so its code loads alongside the pending work. The loader still runs only
+once per wrapper, and its resolved component and default-export getter are not
+evaluated until that component actually renders. Discovery does not cross a
+dormant deferred-hydration boundary.
+
 Nested lazy wrappers are rejected.
 
 React's Suspense and ViewTransition values are exotic element types and React

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -9493,12 +9493,54 @@ function resolveLazyModule(mod: any): ComponentBody<any> {
  */
 /* @__NO_SIDE_EFFECTS__ */
 export function lazy<C extends ComponentBody<any>>(load: () => PromiseLike<{ default: C } | C>): C {
-	let status: 'uninitialized' | 'pending' | 'fulfilled' | 'rejected' = 'uninitialized';
+	let status:
+		'uninitialized' | 'pending' | 'fulfilled' | 'rejected' | 'fulfilled-error' | 'rejected-error' =
+		'uninitialized';
 	let result: any = null; // fulfilled → module value; rejected → the reason
+	let initializationError: any;
 	let thenable: TrackedThenable<any> | null = null;
 	let profiledComponent: ComponentBody<any> | null = null;
 	let memoMetadataInstalled = false;
 	let lazyWrapper!: ComponentBody<any>;
+
+	const initializeLazy = (): void => {
+		if (status !== 'uninitialized') return;
+		try {
+			const p = load();
+			thenable = p as TrackedThenable<any>;
+			p.then(
+				(mod: any) => {
+					// This handler was attached FIRST, so by the time the boundary's retry
+					// listener fires the payload is already fulfilled/rejected and the
+					// re-render takes the synchronous branch above.
+					if (status === 'uninitialized' || status === 'pending') {
+						result = mod;
+						status = 'fulfilled';
+					}
+				},
+				(err: any) => {
+					if (status === 'uninitialized' || status === 'pending') {
+						result = err;
+						status = 'rejected';
+					}
+				},
+			);
+		} catch (error) {
+			// React does not publish Pending until both load() and `.then(...)`
+			// registration return. A synchronous throw is therefore retryable on the
+			// next render instead of poisoning the wrapper with a null thenable.
+			if (status === 'uninitialized') thenable = null;
+			else if (CURRENT_WARM !== null) {
+				// A thenable may settle synchronously and then throw. Speculative
+				// warming catches that throw, so replay it on the first real render
+				// before exposing the already-settled payload on a later retry.
+				initializationError = error;
+				status = status === 'fulfilled' ? 'fulfilled-error' : 'rejected-error';
+			}
+			throw error;
+		}
+		if (status === 'uninitialized') status = 'pending';
+	};
 
 	const callResolvedComponent = (props: any, scope: Scope, extra: any): unknown => {
 		// Keep the module object, rather than only its current `.default` value. A
@@ -9544,35 +9586,14 @@ export function lazy<C extends ComponentBody<any>>(load: () => PromiseLike<{ def
 			return callResolvedComponent(props, scope, extra);
 		}
 		if (status === 'rejected') throw result;
+		if (status === 'fulfilled-error' || status === 'rejected-error') {
+			status = status === 'fulfilled-error' ? 'fulfilled' : 'rejected';
+			const error = initializationError;
+			initializationError = undefined;
+			throw error;
+		}
 		if (status === 'uninitialized') {
-			try {
-				const p = load();
-				thenable = p as TrackedThenable<any>;
-				p.then(
-					(mod: any) => {
-						// This handler was attached FIRST, so by the time the boundary's retry
-						// listener fires the payload is already fulfilled/rejected and the
-						// re-render takes the synchronous branch above.
-						if (status === 'uninitialized' || status === 'pending') {
-							result = mod;
-							status = 'fulfilled';
-						}
-					},
-					(err: any) => {
-						if (status === 'uninitialized' || status === 'pending') {
-							result = err;
-							status = 'rejected';
-						}
-					},
-				);
-			} catch (error) {
-				// React does not publish Pending until both load() and `.then(...)`
-				// registration return. A synchronous throw is therefore retryable on the
-				// next render instead of poisoning the wrapper with a null thenable.
-				if (status === 'uninitialized') thenable = null;
-				throw error;
-			}
-			if (status === 'uninitialized') status = 'pending';
+			initializeLazy();
 			// PromiseLike is permitted to settle while `then` is registering. Match
 			// React's synchronous-thenable contract: render or throw immediately rather
 			// than briefly committing a fallback (or leaving partial sibling work).
@@ -9584,6 +9605,9 @@ export function lazy<C extends ComponentBody<any>>(load: () => PromiseLike<{ def
 		}
 		throw new SuspenseException(thenable!);
 	};
+	// Existing ancestor warm plans can start an independently reachable module,
+	// but resolution, component execution, and deferred hydration remain lazy.
+	(lazyWrapper as any).__warm = initializeLazy;
 	Object.defineProperty(lazyWrapper, LAZY_COMPONENT, { value: true });
 	return lazyWrapper as unknown as C;
 }

--- a/packages/octane/tests/lazy.test.ts
+++ b/packages/octane/tests/lazy.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { mount, act } from './_helpers';
-import { lazy } from '../src/index.js';
+import { flushSync, hydrateRoot, lazy } from '../src/index.js';
 import { compile } from 'octane/compiler';
+import { condition, never } from 'octane/hydration';
 import * as Server from 'octane/server';
 import { prerender } from 'octane/static';
+import { loadCompiledFixtureSource } from './_server-fixture';
 import { Greeting, Counter, LazyHost, LazyUpdateHost } from './_fixtures/lazy.tsrx';
 
 // React's lazy(load) — code-splitting. The wrapper suspends into the nearest
@@ -21,7 +23,418 @@ function deferred<T>() {
 	return { promise, resolve, reject };
 }
 
+const LAZY_MODULE_SOURCE = `
+	import { Hydrate, lazy, use } from 'octane';
+
+	export const moduleLoaders = { first: null, second: null, dormant: null };
+	const LazyFirst = lazy(() => moduleLoaders.first());
+	const LazySecond = lazy(() => moduleLoaders.second());
+	const LazyDormant = lazy(() => moduleLoaders.dormant());
+
+	export function FirstModule() @{
+		<button id="first-lazy-module">first</button>
+	}
+
+	export function SecondModule() @{
+		<span id="second-lazy-module">second</span>
+	}
+
+	export function DormantModule() @{
+		<button id="dormant-lazy-module">dormant</button>
+	}
+
+	function PendingData(props) @{
+		const value = use(props.load(props.id));
+		<span id="lazy-sibling-data">{value as string}</span>
+	}
+
+	export function LazyModuleHost(props) @{
+		<section>
+			@try {
+				<>
+					<PendingData id={props.id} load={props.load} />
+					<LazyFirst />
+					<LazySecond />
+				</>
+			} @pending {
+				<span id="lazy-module-pending">loading</span>
+			} @catch (error) {
+				<span id="lazy-module-error">{error.message as string}</span>
+			}
+		</section>
+	}
+
+	export function DormantLazyHost(props) @{
+		<main>
+			@try {
+				<>
+					<PendingData id={props.id} load={props.load} />
+					@if (props.id === 'updated') {
+						<LazyFirst />
+					}
+				</>
+			} @pending {
+				<span id="outside-lazy-pending">loading</span>
+			}
+			<Hydrate when={props.when} split={false}>
+				<LazyDormant />
+			</Hydrate>
+		</main>
+	}
+
+	export function ConditionalLazyHost(props) @{
+		<section>
+			@try {
+				<>
+					<PendingData id={props.id} load={props.load} />
+					@if (props.enabled) {
+						<LazyFirst />
+					}
+				</>
+			} @pending {
+				<span id="conditional-lazy-pending">loading</span>
+			}
+		</section>
+	}
+`;
+
 describe('lazy — client', () => {
+	it('starts eligible lazy modules alongside an earlier pending sibling', async () => {
+		const client = loadCompiledFixtureSource(LAZY_MODULE_SOURCE, {
+			id: 'parallel-lazy-modules.tsrx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod' },
+		});
+		const data = deferred<string>();
+		const first = deferred<any>();
+		const second = deferred<any>();
+		const loadData = vi.fn(() => data.promise);
+		const loadFirst = vi.fn(() => first.promise);
+		const loadSecond = vi.fn(() => second.promise);
+		client.moduleLoaders.first = loadFirst;
+		client.moduleLoaders.second = loadSecond;
+		let defaultReads = 0;
+		const root = mount(client.LazyModuleHost, { id: 'initial', load: loadData });
+
+		try {
+			expect(loadData).toHaveBeenCalledExactlyOnceWith('initial');
+			expect(loadFirst).toHaveBeenCalledOnce();
+			expect(loadSecond).toHaveBeenCalledOnce();
+			expect(root.find('#lazy-module-pending').textContent).toBe('loading');
+
+			await act(() =>
+				first.resolve({
+					get default() {
+						defaultReads++;
+						return client.FirstModule;
+					},
+				}),
+			);
+			expect(defaultReads).toBe(0);
+
+			await act(() => {
+				second.resolve({ default: client.SecondModule });
+				data.resolve('ready');
+			});
+			expect(root.find('#lazy-sibling-data').textContent).toBe('ready');
+			expect(root.find('#first-lazy-module').textContent).toBe('first');
+			expect(root.find('#second-lazy-module').textContent).toBe('second');
+			expect(defaultReads).toBeGreaterThan(0);
+			expect(loadFirst).toHaveBeenCalledOnce();
+			expect(loadSecond).toHaveBeenCalledOnce();
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('shares preloaded lazy modules across independently pending roots', async () => {
+		const client = loadCompiledFixtureSource(LAZY_MODULE_SOURCE, {
+			id: 'concurrent-lazy-modules.tsrx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod' },
+		});
+		const firstData = deferred<string>();
+		const secondData = deferred<string>();
+		const firstModule = deferred<any>();
+		const secondModule = deferred<any>();
+		const preloadFirst = vi.fn(() => firstModule.promise);
+		const preloadSecond = vi.fn(() => secondModule.promise);
+		client.moduleLoaders.first = preloadFirst;
+		client.moduleLoaders.second = preloadSecond;
+		const first = mount(client.LazyModuleHost, {
+			id: 'first',
+			load: () => firstData.promise,
+		});
+		const second = mount(client.LazyModuleHost, {
+			id: 'second',
+			load: () => secondData.promise,
+		});
+
+		try {
+			expect(preloadFirst).toHaveBeenCalledOnce();
+			expect(preloadSecond).toHaveBeenCalledOnce();
+			expect(first.find('#lazy-module-pending').textContent).toBe('loading');
+			expect(second.find('#lazy-module-pending').textContent).toBe('loading');
+
+			await act(() => {
+				firstModule.resolve({ default: client.FirstModule });
+				secondModule.resolve({ default: client.SecondModule });
+				firstData.resolve('first-ready');
+			});
+			expect(first.find('#lazy-sibling-data').textContent).toBe('first-ready');
+			expect(first.find('#first-lazy-module').textContent).toBe('first');
+			expect(second.find('#lazy-module-pending').textContent).toBe('loading');
+
+			await act(() => secondData.resolve('second-ready'));
+			expect(second.find('#lazy-sibling-data').textContent).toBe('second-ready');
+			expect(second.find('#first-lazy-module').textContent).toBe('first');
+			expect(second.find('#second-lazy-module').textContent).toBe('second');
+			expect(preloadFirst).toHaveBeenCalledOnce();
+			expect(preloadSecond).toHaveBeenCalledOnce();
+		} finally {
+			second.unmount();
+			first.unmount();
+		}
+	});
+
+	it('does not preload a dormant hydration island while an outside sibling suspends', async () => {
+		const server = loadCompiledFixtureSource(LAZY_MODULE_SOURCE, {
+			id: 'dormant-lazy-modules.tsrx',
+			mode: 'server',
+			compileOptions: { hmr: false, dev: false },
+		});
+		server.moduleLoaders.dormant = () => Promise.resolve({ default: server.DormantModule });
+		const blocked = never();
+		const { html } = await prerender(server.DormantLazyHost, {
+			id: 'initial',
+			when: blocked,
+			load: () => Promise.resolve('server-initial'),
+		});
+		const container = document.createElement('div');
+		container.innerHTML = html;
+		document.body.appendChild(container);
+		const preserved = container.querySelector('#dormant-lazy-module');
+		const client = loadCompiledFixtureSource(LAZY_MODULE_SOURCE, {
+			id: 'dormant-lazy-modules.tsrx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod' },
+		});
+		const outside = deferred<string>();
+		const outsideModule = deferred<any>();
+		const islandModule = deferred<any>();
+		const loadOutside = vi.fn(() => outside.promise);
+		const preloadOutside = vi.fn(() => outsideModule.promise);
+		const preloadIsland = vi.fn(() => islandModule.promise);
+		client.moduleLoaders.first = preloadOutside;
+		client.moduleLoaders.dormant = preloadIsland;
+		const root = hydrateRoot(container, client.DormantLazyHost, {
+			id: 'initial',
+			when: blocked,
+			load: loadOutside,
+		});
+
+		try {
+			flushSync(() => {});
+			expect(container.querySelector('#dormant-lazy-module')).toBe(preserved);
+			expect(preloadIsland).not.toHaveBeenCalled();
+			expect(preloadOutside).not.toHaveBeenCalled();
+
+			root.render(client.DormantLazyHost, {
+				id: 'updated',
+				when: blocked,
+				load: loadOutside,
+			});
+			flushSync(() => {});
+			expect(loadOutside).toHaveBeenCalledExactlyOnceWith('updated');
+			expect(preloadOutside).toHaveBeenCalledOnce();
+			expect(preloadIsland).not.toHaveBeenCalled();
+			expect(container.querySelector('#dormant-lazy-module')).toBe(preserved);
+
+			await act(() => {
+				outsideModule.resolve({ default: client.FirstModule });
+				outside.resolve('updated');
+			});
+			expect(container.querySelector('#first-lazy-module')?.textContent).toBe('first');
+			expect(preloadIsland).not.toHaveBeenCalled();
+
+			await act(() =>
+				root.render(client.DormantLazyHost, {
+					id: 'updated',
+					when: condition(true),
+					load: loadOutside,
+				}),
+			);
+			expect(preloadIsland).toHaveBeenCalledOnce();
+			expect(container.querySelector('#dormant-lazy-module')).toBe(preserved);
+
+			await act(() => islandModule.resolve({ default: client.DormantModule }));
+			expect(container.querySelector('#dormant-lazy-module')).toBe(preserved);
+			expect(preserved?.textContent).toBe('dormant');
+			expect(preloadIsland).toHaveBeenCalledOnce();
+		} finally {
+			root.unmount();
+			container.remove();
+		}
+	});
+
+	it('does not preload a lazy module in an unselected conditional branch', async () => {
+		const client = loadCompiledFixtureSource(LAZY_MODULE_SOURCE, {
+			id: 'conditional-lazy-modules.tsrx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod' },
+		});
+		const data = deferred<string>();
+		const module = deferred<any>();
+		const loadData = vi.fn(() => data.promise);
+		const preload = vi.fn(() => module.promise);
+		client.moduleLoaders.first = preload;
+		const root = mount(client.ConditionalLazyHost, {
+			id: 'conditional',
+			load: loadData,
+			enabled: false,
+		});
+
+		try {
+			expect(loadData).toHaveBeenCalledOnce();
+			expect(preload).not.toHaveBeenCalled();
+			await act(() => data.resolve('ready'));
+			expect(preload).not.toHaveBeenCalled();
+
+			root.update(client.ConditionalLazyHost, {
+				id: 'conditional',
+				load: loadData,
+				enabled: true,
+			});
+			expect(preload).toHaveBeenCalledOnce();
+			await act(() => module.resolve({ default: client.FirstModule }));
+			expect(root.find('#first-lazy-module').textContent).toBe('first');
+			expect(preload).toHaveBeenCalledOnce();
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('delivers a rejected preloaded lazy module to its error boundary', async () => {
+		const client = loadCompiledFixtureSource(LAZY_MODULE_SOURCE, {
+			id: 'rejected-lazy-module.tsrx',
+			mode: 'client',
+			compileOptions: { hmr: false, dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod' },
+		});
+		const data = deferred<string>();
+		const first = deferred<any>();
+		const second = deferred<any>();
+		const preload = vi.fn(() => first.promise);
+		client.moduleLoaders.first = preload;
+		client.moduleLoaders.second = () => second.promise;
+		const root = mount(client.LazyModuleHost, { id: 'rejected', load: () => data.promise });
+
+		try {
+			expect(preload).toHaveBeenCalledOnce();
+			await act(() => first.reject(new Error('preloaded module failed')));
+			expect(root.find('#lazy-module-pending').textContent).toBe('loading');
+			await act(() => {
+				second.resolve({ default: client.SecondModule });
+				data.resolve('ready');
+			});
+			expect(root.find('#lazy-module-error').textContent).toBe('preloaded module failed');
+			expect(preload).toHaveBeenCalledOnce();
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it.each(['loader', 'subscription'] as const)(
+		'retries a synchronous %s failure when the preloaded module actually renders',
+		async (failure) => {
+			const client = loadCompiledFixtureSource(LAZY_MODULE_SOURCE, {
+				id: `retry-lazy-${failure}.tsrx`,
+				mode: 'client',
+				compileOptions: { hmr: false, dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod' },
+			});
+			const data = deferred<string>();
+			const first = deferred<any>();
+			const second = deferred<any>();
+			let attempts = 0;
+			const loadFirst = vi.fn(() => {
+				if (++attempts > 1) return first.promise;
+				if (failure === 'loader') throw new Error('module load interrupted');
+				return {
+					then() {
+						throw new Error('module subscription interrupted');
+					},
+				};
+			});
+			const loadSecond = vi.fn(() => second.promise);
+			client.moduleLoaders.first = loadFirst;
+			client.moduleLoaders.second = loadSecond;
+			const root = mount(client.LazyModuleHost, { id: 'retry', load: () => data.promise });
+
+			try {
+				expect(loadFirst).toHaveBeenCalledOnce();
+				expect(loadSecond).toHaveBeenCalledOnce();
+				await act(() => {
+					second.resolve({ default: client.SecondModule });
+					data.resolve('ready');
+				});
+				expect(loadFirst).toHaveBeenCalledTimes(2);
+				expect(root.find('#lazy-module-pending').textContent).toBe('loading');
+
+				await act(() => first.resolve({ default: client.FirstModule }));
+				expect(root.find('#first-lazy-module').textContent).toBe('first');
+				expect(root.find('#second-lazy-module').textContent).toBe('second');
+				expect(loadFirst).toHaveBeenCalledTimes(2);
+				expect(loadSecond).toHaveBeenCalledOnce();
+			} finally {
+				root.unmount();
+			}
+		},
+	);
+
+	it.each(['fulfilled', 'rejected'] as const)(
+		'exposes a synchronous subscription throw after a thenable has %s',
+		async (outcome) => {
+			const client = loadCompiledFixtureSource(LAZY_MODULE_SOURCE, {
+				id: `settled-lazy-subscription-${outcome}.tsrx`,
+				mode: 'client',
+				compileOptions: { hmr: false, dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod' },
+			});
+			const data = deferred<string>();
+			const second = deferred<any>();
+			const settledError = new Error('settled module rejected');
+			const loadFirst = vi.fn(() => ({
+				then(resolve: (value: any) => void, reject: (reason: Error) => void) {
+					if (outcome === 'fulfilled') resolve({ default: client.FirstModule });
+					else reject(settledError);
+					throw new Error('post-settle subscription failed');
+				},
+			}));
+			client.moduleLoaders.first = loadFirst;
+			client.moduleLoaders.second = () => second.promise;
+			const props = { id: 'settled', load: () => data.promise };
+			const root = mount(client.LazyModuleHost, props);
+			let retry: ReturnType<typeof mount> | undefined;
+
+			try {
+				await act(() => {
+					second.resolve({ default: client.SecondModule });
+					data.resolve('ready');
+				});
+				expect(root.find('#lazy-module-error').textContent).toBe('post-settle subscription failed');
+
+				retry = mount(client.LazyModuleHost, props);
+				if (outcome === 'fulfilled') {
+					expect(retry.find('#first-lazy-module').textContent).toBe('first');
+				} else {
+					expect(retry.find('#lazy-module-error').textContent).toBe('settled module rejected');
+				}
+				expect(loadFirst).toHaveBeenCalledOnce();
+			} finally {
+				retry?.unmount();
+				root.unmount();
+			}
+		},
+	);
+
 	it('does not call load() until the component first renders', async () => {
 		const d = deferred<{ default: any }>();
 		const load = vi.fn(() => d.promise);


### PR DESCRIPTION
## Summary

- Start an independently reachable `lazy()` module loader during an existing suspended sibling's compiler-proven warm plan instead of waiting for all data dependencies to resolve.
- Preserve real dynamic-import chunk splitting, exactly-once loader/request behavior, lazy wrapper construction, rejection semantics, default-export accessor timing, and component identity.
- Keep intentionally dormant `<Hydrate>` boundaries opaque to speculative discovery; only their own activation or explicitly configured prefetch may load deferred code.

## Correctness and scope

- Reuse the existing DOM-client compiler `warmChild` reachability/guard proof; no compiler, server-runtime, public API, or hydration-chunk extraction changes.
- Share the existing transactional `lazy()` payload initializer between speculative module discovery and actual rendering; do not execute component code, hooks, DOM, effects, or resolved module export accessors during discovery.
- Keep module loading inert until a real eligible render path suspends and deduplicate the same wrapper across preload, replay, normal rendering, updates, and independent concurrent roots.
- Retain synchronous fulfillment/rejection, synchronous loader/subscription retry, and deferred error routing. A thenable that synchronously settles and then throws replays its original subscription failure exactly once before its cached settled result becomes visible.
- Preserve false branch guards, nested wrappers, component/default-prop/memo/context/ref behavior, deferred hydration server-node identity, explicit activation/prefetch, and SSR behavior.
- Keep all generic static-root, hydration-root, deferred-hydration, Suspense-transition, and unused-pure-lazy production bundles byte-identical.

## Production browser evidence

The existing async-composition dashboard gains one real, separately code-split synchronous lazy child. The browser benchmark adds a deterministic **35 ms** delay to that actual JavaScript chunk and compares unchanged canonical runtime versus candidate runtime on the same authored dashboard, minification policy, Chromium environment, and interleaved AB/BA samples.

| Observation | Baseline | Candidate |
| --- | ---: | ---: |
| Lazy loader start | 106.5 ms | 1.3 ms |
| Actual split-chunk HTTP request start | 106.9 ms | 2.4 ms |
| Split-chunk response | 145.3 ms | 40.1 ms |
| Lazy module visible | 146.2 ms | 105.8 ms |
| Loader calls across mount + transition | 1 | 1 |
| Actual split-chunk network requests | 1 | 1 |
| Data resource creators per operation | 8 | 8 |
| Actual data network starts | 8 | 8 |
| Independent first-wave data requests | 7 | 7 |
| Data request waves | 2 | 2 |
| Mixed-version committed states | 0 | 0 |

The eligible lazy module becomes visible approximately **40.4 ms sooner (27.6%)** because its delayed code request overlaps the existing first data wave. The data-only dashboard-ready and update timings are unchanged within measurement noise; this does not claim faster data fetching. The separate module chunk remains **324 bytes**; the affected main application adds **237 raw bytes / 80 gzip bytes**. The fixed 16-file compiler-output corpus and all unrelated generic production bundles are byte-identical.

## Validation

- [x] Full Octane development/production core suite: **806 files / 11,988 tests passed**.
- [x] Broad affected lazy, Suspense, transition, hydration, SSR/streaming, compiler, and universal suites: **310 project-file executions / 3,927 tests passed**.
- [x] Focused public lazy-wrapper regressions in development and production: **40 tests passed**, including first-wave discovery, concurrent roots, false branches, loader rejection, synchronous transaction failures, and fulfilled/rejected-then-throw RED-to-GREEN cases.
- [x] Real SSR-to-client deferred-hydration regression: a dormant `never()` island remains untouched while an outside sibling actually warms, then explicitly activates once and adopts its original server DOM.
- [x] Existing production Vite integration: **15 production SSR/browser tests passed**, including real Chromium development/production SSR/hydration, absent deferred-chunk module-preload, unchanged explicit prefetch, chunk splitting, and preserved deferred DOM.
- [x] Existing real-Chromium Suspense/hydration suite: **11 tests passed**.
- [x] Existing async-composition production Chromium gate with actual delayed split-chunk request ordering and unchanged `8/8/7/2/0` data, wave, and atomicity controls.
- [x] Exact-head generic bundle DCE, pure unused `lazy()` elimination, and fixed compiler-corpus byte comparisons.
- [x] Full workspace typecheck: `pnpm --config.verify-deps-before-run=false --config.enable-pre-post-scripts=false run typecheck`.
- [x] Final repository synchronization: `pnpm --config.verify-deps-before-run=false sync`.
- [x] Scoped Prettier verification and `git diff --check`.

Refs #673.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `lazy()` and Suspense warm-path semantics (loader timing, once-only loads, sync-thenable errors, Hydrate opacity); behavior is heavily tested but mistakes could cause duplicate loads or premature chunk fetches.
> 
> **Overview**
> **Eligible `lazy()` loaders can start while an independently suspended sibling is already in a compiler-proven warm plan**, overlapping dynamic-import fetches with pending data instead of waiting for the boundary to reach the lazy child.
> 
> The runtime refactors `lazy()` so **`initializeLazy` is shared** between first render and speculative warming via **`lazyWrapper.__warm`**. Loaders still run once; resolved modules and default-export getters are not read until the component actually renders. **Dormant `<Hydrate>` islands, unselected `@if` branches, and code behind `never()`** stay out of discovery until activation or explicit prefetch.
> 
> **Error handling** adds `fulfilled-error` / `rejected-error` so a thenable that settles synchronously and then throws during `.then` registration replays that failure on the first real render instead of leaking a cached payload after speculative warm.
> 
> **Validation** extends `lazy.test.ts` (parallel siblings, concurrent roots, Hydrate dormancy, conditionals, rejections, sync loader/subscription failures), adds a **code-split `LazyCodeProof`** to the async-composition Octane dashboard, and tightens the Chromium gate (35ms chunk delay, single loader/request, overlap with the first `project` wave, stable DOM across transition). Docs describe the React difference and that lazy discovery does not enter dormant Hydrate boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b16a8668c601d49ab495169db34da00d65354763. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->