### PR TITLE
perf: finish delegated-event and marker optimizations

### DIFF
--- a/.changeset/finish-delegated-events-and-switch-markers.md
+++ b/.changeset/finish-delegated-events-and-switch-markers.md
@@ -1,0 +1,6 @@
+---
+'octane': patch
+---
+
+Reuse delegated-event accessors and capture paths, and omit redundant component
+markers for proven exhaustive switch-root components.

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -324,11 +324,16 @@ const SUITES = [
 		cwd: name,
 		servers: [],
 		iter: name === 'lifecycle-memory' ? { normal: 84, quick: 2 } : { normal: 8, quick: 2 },
-		runs: ['octane-tsrx', 'react', 'preact', 'solid', 'svelte', 'vue-vapor'].map((target) => ({
-			label: target,
-			script: 'run.mjs',
-			args: (n) => [target, String(n)],
-		})),
+		runs: [
+			...['octane-tsrx', 'react', 'preact', 'solid', 'svelte', 'vue-vapor'].map((target) => ({
+				label: target,
+				script: 'run.mjs',
+				args: (n) => [target, String(n)],
+			})),
+			...(name === 'event-delegation'
+				? [{ label: 'work', script: 'work.mjs', args: () => [] }]
+				: []),
+		],
 	})),
 	{
 		// Selector-based fan-out: 512 subscribers read one store through a

--- a/benchmarks/event-delegation/README.md
+++ b/benchmarks/event-delegation/README.md
@@ -6,3 +6,28 @@ Real Chromium dispatches 128 native bubbling `InputEvent`s to distinct hosts in 
 node benchmarks/bench.mjs --quick event-delegation
 node benchmarks/bench.mjs event-delegation
 ```
+
+## Deterministic delegated-event work
+
+`work.mjs` exercises the same production 512-field application through 128
+native `InputEvent`s, with a real framework capture handler on the form and the
+existing bubble handlers on its controlled inputs. Its temporary identity
+observers are isolated from the ordinary timing runner.
+
+Each event still defines `currentTarget` for capture and bubble, so exactly 256
+property definitions remain. The gate requires those definitions to reuse one
+descriptor and one getter instead of allocating 256 distinct instances of each.
+It also requires the 128 capture traversals to reuse one path array. Native
+capture and bubbling, framework capture, event targets, all 128 controlled
+inputs, and their corresponding output text must remain correct.
+
+The work gate builds its own production fixture, starts a temporary preview, and
+closes it before exiting. The unified benchmark runner also invokes the gate
+after its existing per-framework timing runs:
+
+```bash
+node benchmarks/event-delegation/work.mjs
+node benchmarks/bench.mjs --quick event-delegation
+```
+
+Set `EVENT_URL` to reuse an existing production preview instead of building one.

--- a/benchmarks/event-delegation/work.mjs
+++ b/benchmarks/event-delegation/work.mjs
@@ -1,0 +1,221 @@
+// Deterministic production event work over the existing 512-field application.
+// This is intentionally separate from run.mjs so temporary intrinsic observers
+// cannot distort the ordinary event-delegation timing benchmark.
+
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const requireFromNews = createRequire(new URL('../news/package.json', import.meta.url));
+const { chromium } = requireFromNews('playwright');
+const appDirectory = fileURLToPath(new URL('../news/octane-tsrx/', import.meta.url));
+const EVENTS = 128;
+const FIELDS = 512;
+const failures = [];
+
+let browser;
+let productionServer;
+let observed;
+try {
+	let target = process.env.EVENT_URL;
+	if (!target) {
+		const { build, preview } = await import(pathToFileURL(requireFromNews.resolve('vite')).href);
+		await build({
+			root: appDirectory,
+			logLevel: 'error',
+			build: {
+				outDir: 'dist/runtime-stress',
+				emptyOutDir: true,
+				minify: 'esbuild',
+				rollupOptions: {
+					input: path.join(appDirectory, 'runtime-stress.html'),
+					output: {
+						chunkFileNames: 'assets/[name]-[hash].js',
+						entryFileNames: 'assets/[name]-[hash].js',
+					},
+				},
+			},
+		});
+		productionServer = await preview({
+			root: appDirectory,
+			logLevel: 'error',
+			build: { outDir: 'dist/runtime-stress' },
+			preview: { host: '127.0.0.1', port: 0, strictPort: true },
+		});
+		const address = productionServer.httpServer.address();
+		if (address === null || typeof address === 'string') {
+			throw new Error('The production event fixture did not expose a TCP port');
+		}
+		target = `http://127.0.0.1:${address.port}/runtime-stress.html`;
+	}
+
+	browser = await chromium.launch({
+		headless: true,
+		args: ['--disable-extensions', '--no-sandbox'],
+	});
+	const page = await browser.newPage();
+	await page.goto(target, { waitUntil: 'load' });
+	await page.waitForFunction(() => globalThis.__runtimeStress?.ready === true, null, {
+		timeout: 10_000,
+	});
+	observed = await page.evaluate(
+		({ events, fields }) => {
+			const form = document.querySelector('#stress-form');
+			if (form === null) throw new Error('Missing controlled benchmark form');
+			if (document.querySelectorAll('input[data-field-index]').length !== fields) {
+				throw new Error('The application did not mount its complete controlled form');
+			}
+
+			const originalDefineProperty = Object.defineProperty;
+			const originalPush = Array.prototype.push;
+			const setInputValue = Object.getOwnPropertyDescriptor(
+				HTMLInputElement.prototype,
+				'value',
+			).set;
+			const descriptors = new Set();
+			const getters = new Set();
+			const possiblePaths = new WeakSet();
+			const capturePaths = new Set();
+			let currentInput = null;
+			let definitions = 0;
+			let nativeCaptures = 0;
+			let nativeBubbles = 0;
+			let frameworkCaptures = 0;
+			let invalidCurrentTargets = 0;
+			const capture = () => nativeCaptures++;
+			const bubble = () => nativeBubbles++;
+
+			document.addEventListener('input', capture, true);
+			document.addEventListener('input', bubble);
+			globalThis.__octaneDelegatedInputCapture = (event) => {
+				frameworkCaptures++;
+				if (event.currentTarget !== form || event.target !== currentInput) {
+					invalidCurrentTargets++;
+				}
+			};
+			Object.defineProperty = function (target, key, descriptor) {
+				if (target instanceof Event && key === 'currentTarget') {
+					definitions++;
+					descriptors.add(descriptor);
+					if (typeof descriptor.get === 'function') getters.add(descriptor.get);
+				}
+				return originalDefineProperty.call(Object, target, key, descriptor);
+			};
+			Array.prototype.push = function (...values) {
+				if (currentInput !== null && values.length === 1) {
+					if (values[0] === currentInput && this.length === 0) {
+						possiblePaths.add(this);
+					} else if (values[0] === currentInput.parentNode && possiblePaths.has(this)) {
+						capturePaths.add(this);
+					}
+				}
+				return originalPush.apply(this, values);
+			};
+
+			try {
+				for (let index = 0; index < events; index++) {
+					currentInput = document.querySelector(`input[data-field-index="${index}"]`);
+					setInputValue.call(currentInput, `event-${index}`);
+					currentInput.dispatchEvent(
+						new InputEvent('input', { bubbles: true, data: String(index) }),
+					);
+					currentInput = null;
+				}
+			} finally {
+				currentInput = null;
+				Object.defineProperty = originalDefineProperty;
+				Array.prototype.push = originalPush;
+				document.removeEventListener('input', capture, true);
+				document.removeEventListener('input', bubble);
+				delete globalThis.__octaneDelegatedInputCapture;
+			}
+
+			let updatedFields = 0;
+			let updatedOutputs = 0;
+			for (let index = 0; index < events; index++) {
+				const expected = `event-${index}`;
+				if (document.querySelector(`input[data-field-index="${index}"]`)?.value === expected) {
+					updatedFields++;
+				}
+				if (document.querySelector(`[data-field-output="${index}"]`)?.textContent === expected) {
+					updatedOutputs++;
+				}
+			}
+			return {
+				eventHosts: document.querySelectorAll('input[data-field-index]').length,
+				events,
+				nativeCaptures,
+				nativeBubbles,
+				frameworkCaptures,
+				invalidCurrentTargets,
+				updatedFields,
+				updatedOutputs,
+				definitions,
+				descriptors: descriptors.size,
+				getters: getters.size,
+				capturePaths: capturePaths.size,
+			};
+		},
+		{ events: EVENTS, fields: FIELDS },
+	);
+} finally {
+	try {
+		await browser?.close();
+	} finally {
+		await productionServer?.close();
+	}
+}
+
+for (const key of [
+	'nativeCaptures',
+	'nativeBubbles',
+	'frameworkCaptures',
+	'updatedFields',
+	'updatedOutputs',
+]) {
+	if (observed[key] !== EVENTS) failures.push(`${key}: ${observed[key]} is not ${EVENTS}`);
+}
+if (observed.eventHosts !== FIELDS)
+	failures.push(`eventHosts: ${observed.eventHosts} is not ${FIELDS}`);
+if (observed.invalidCurrentTargets !== 0) {
+	failures.push(`invalidCurrentTargets: ${observed.invalidCurrentTargets} is not zero`);
+}
+if (observed.definitions !== EVENTS * 2) {
+	failures.push(`definitions: ${observed.definitions} is not ${EVENTS * 2}`);
+}
+for (const key of ['descriptors', 'getters', 'capturePaths']) {
+	if (observed[key] > 1) failures.push(`${key}: ${observed[key]} exceeds 1`);
+}
+
+console.log('Production delegated-event work:');
+console.table(observed);
+if (process.env.BENCH_JSON) {
+	const stat = (value) => ({ median: value, min: value, samples: 1 });
+	fs.writeFileSync(
+		process.env.BENCH_JSON,
+		JSON.stringify(
+			{
+				suite: 'event-delegation-work',
+				targets: [
+					{
+						name: 'octane-tsrx-work',
+						ops: Object.fromEntries(
+							Object.entries(observed).map(([name, value]) => [name, stat(value)]),
+						),
+						meta: { gate: failures.length === 0 ? 'passed' : 'failed' },
+					},
+				],
+				...(failures.length === 0 ? {} : { failed: failures.join('; ') }),
+			},
+			null,
+			'\t',
+		) + '\n',
+	);
+}
+if (failures.length > 0) {
+	for (const failure of failures) console.error(`✗ ${failure}`);
+	process.exitCode = 1;
+} else {
+	console.log('All deterministic delegated-event allocation gates passed.');
+}

--- a/benchmarks/news/octane-tsrx/src/runtime-stress/App.tsrx
+++ b/benchmarks/news/octane-tsrx/src/runtime-stress/App.tsrx
@@ -13,6 +13,14 @@ import {
 
 type IndexedProps = { index: number };
 
+function observeDelegatedInputCapture(event: Event) {
+	const benchmark = globalThis as
+		typeof globalThis & {
+			__octaneDelegatedInputCapture?: (event: Event) => void;
+		};
+	benchmark.__octaneDelegatedInputCapture?.(event);
+}
+
 function LifecycleRow(props: IndexedProps & { tick: number }) @{
 	useEffect(() => mountLifecycleResource(props.index), []);
 	<li data-lifecycle-row={String(props.index)}>{String(props.index) + ':' + props.tick}</li>
@@ -117,7 +125,11 @@ export function App() @{
 			}
 		</section>
 
-		<form id="stress-form" onSubmit={recordSubmission}>
+		<form
+			id="stress-form"
+			onSubmit={recordSubmission}
+			onInputCapture={observeDelegatedInputCapture}
+		>
 			@for (const index of FORM_FIELDS; key index) {
 				<FormField index={index} resetVersion={resetVersion} />
 			}

--- a/benchmarks/spa-navigation/README.md
+++ b/benchmarks/spa-navigation/README.md
@@ -69,6 +69,21 @@ bodies or fell back to the runtime de-opt renderer (`createElement` / `childSlot
 / `deoptItemBody` / `reconcileKeyed`), and how much of the surviving shell was
 rebuilt.
 
+### Exhaustive switch-root marker elision
+
+The TSRX fixture expresses the recursive `Node` through an exhaustive
+`@switch`/`@default`: interior nodes return one host and terminal nodes return the
+same single-root `Leaf` component as before. Without the transitive switch-root
+proof, that equivalent application accumulates 4,093 comment nodes on the deep
+route and 126 on the nested route. The proof restores the existing budgets of
+one and two comments respectively without changing rendered content.
+
+`work.mjs` checks the actual production DOM: the deep route must contain exactly
+2,052 elements and 1,025 text nodes, and the nested route must contain 70
+elements and 33 text nodes. Its comment ceilings are one and two for TSRX and
+zero for the unchanged JSX control. The same gate preserves the surviving shell
+and outlet by identity and retains every existing precise-work assertion.
+
 ## Resolved finding: the JSX dialect no longer de-opts on navigation
 
 The two Octane fixtures are the same app over the same core, authored twice.

--- a/benchmarks/spa-navigation/octane-tsrx/src/App.tsrx
+++ b/benchmarks/spa-navigation/octane-tsrx/src/App.tsrx
@@ -41,13 +41,16 @@ function Leaf(props: PathProps) @{
 }
 
 function Node(props: NodeProps) @{
-	@if (props.depth > 0) {
-		<div class="n">
-			<Node depth={props.depth - 1} path={props.path + 'L'} />
-			<Node depth={props.depth - 1} path={props.path + 'R'} />
-		</div>
-	} @else {
-		<Leaf path={props.path} />
+	@switch (props.depth > 0) {
+		@case true: {
+			<div class="n">
+				<Node depth={props.depth - 1} path={props.path + 'L'} />
+				<Node depth={props.depth - 1} path={props.path + 'R'} />
+			</div>
+		}
+		@default: {
+			<Leaf path={props.path} />
+		}
 	}
 }
 

--- a/benchmarks/spa-navigation/work.mjs
+++ b/benchmarks/spa-navigation/work.mjs
@@ -10,7 +10,7 @@
 
 import fs from 'node:fs';
 import { chromium } from 'playwright';
-import { deterministicCount, deterministicStatForJson } from '../lib/dom-nodes.mjs';
+import { censusDomNodes, deterministicCount, deterministicStatForJson } from '../lib/dom-nodes.mjs';
 import { collectPreciseCalls } from '../lib/precise-work.mjs';
 
 const TARGETS = [
@@ -125,6 +125,50 @@ function validate(target, op, counts, failures) {
 	}
 }
 
+async function validateMarkerCensus(browser, target, failures) {
+	const context = await browser.newContext();
+	const page = await context.newPage();
+	try {
+		await page.goto(target.url, { waitUntil: 'load' });
+		await page.waitForFunction(() => globalThis.__ready === true, null, { timeout: 10_000 });
+		await page.evaluate(() => globalThis.__mount('a'));
+		const deep = await page.evaluate(censusDomNodes, '#main');
+		await page.evaluate(() => {
+			globalThis.__markerShell = document.querySelector('.shell');
+			globalThis.__markerOutlet = document.querySelector('.outlet');
+			globalThis.__navigate('a/x');
+		});
+		const nested = await page.evaluate(censusDomNodes, '#main');
+		const retained = await page.evaluate(() => ({
+			shell: globalThis.__markerShell === document.querySelector('.shell'),
+			outlet: globalThis.__markerOutlet === document.querySelector('.outlet'),
+			leaves: document.querySelectorAll('.leaf').length,
+		}));
+		if (deep.elements !== 2052 || deep.text !== 1025) {
+			failures.push(`${target.name}.deep: visible DOM changed to ${deep.elements}/${deep.text}`);
+		}
+		if (nested.elements !== 70 || nested.text !== 33 || retained.leaves !== 32) {
+			failures.push(
+				`${target.name}.nested: visible DOM changed to ${nested.elements}/${nested.text}/${retained.leaves}`,
+			);
+		}
+		if (!retained.shell || !retained.outlet) {
+			failures.push(`${target.name}.nested: navigation replaced its surviving shell or outlet`);
+		}
+		const deepCeiling = target.name === 'octane-tsrx' ? 1 : 0;
+		const nestedCeiling = target.name === 'octane-tsrx' ? 2 : 0;
+		if (deep.comments > deepCeiling) {
+			failures.push(`${target.name}.comments_deep: ${deep.comments} exceeds ${deepCeiling}`);
+		}
+		if (nested.comments > nestedCeiling) {
+			failures.push(`${target.name}.comments_nested: ${nested.comments} exceeds ${nestedCeiling}`);
+		}
+		return { deep, nested };
+	} finally {
+		await context.close();
+	}
+}
+
 (async () => {
 	const browser = await chromium.launch({
 		headless: true,
@@ -135,7 +179,7 @@ function validate(target, op, counts, failures) {
 	const byTarget = {};
 	try {
 		for (const target of TARGETS) {
-			byTarget[target.name] = {};
+			byTarget[target.name] = { dom: await validateMarkerCensus(browser, target, failures) };
 			for (const op of OPS) {
 				const counts = await collectPreciseCalls(browser, {
 					url: target.url,
@@ -150,6 +194,13 @@ function validate(target, op, counts, failures) {
 		}
 	} finally {
 		await browser.close();
+	}
+	console.log('\nProduction DOM census (deep elements/text/comments; nested comments):');
+	for (const target of TARGETS) {
+		const { deep, nested } = byTarget[target.name].dom;
+		console.log(
+			`  ${target.name}: ${deep.elements}/${deep.text}/${deep.comments}; nested ${nested.comments}`,
+		);
 	}
 
 	const W = 26;

--- a/docs/comment-marker-elision-plan.md
+++ b/docs/comment-marker-elision-plan.md
@@ -1,7 +1,7 @@
 # Comment-Marker Elision Plan — fewer `<!--[-->`s when they carry no information
 
-Status: M0-M7 LANDED (M0-M6 2026-07-13, M7 2026-08-09; see each phase's
-note). Follow-up to the
+Status: M0-M8 LANDED (M0-M6 2026-07-13, M7 2026-08-09, M8 2026-08-11; see
+each phase's note). Follow-up to the
 website Elements-panel report
 (a 40-deep run of `<!--[-->` before `.shell`, ~2,100 comment nodes on the home
 page). Companion to docs/compiled-output-optimization-plan.md — this is the
@@ -524,14 +524,40 @@ proof to cross-module `2`-sentinel call sites for free.
   lite has no range and the inner `@if`'s insertion anchor is null. Tracked
   as a spawned fix task; prod is unaffected (autoMemo forces the slot path).
 
+### M8 — Exhaustive switch-root single-root proof
+
+**M8 LANDED 2026-08-11 — compiler-only.** The existing definition-site
+single-root and hookless append-safety proofs now also recognize an exhaustive
+`@switch` whose explicit `@default` and every case produce exactly one plain
+host or an already-proven same-module component. The existing fixed point
+resolves nested exhaustive directives and transitive component dependencies;
+missing defaults, empty or multiple roots, fragments, unproven component
+identities, and case-local declarations remain conservatively anchored.
+
+Qualifying components reuse the existing client-only `$$singleRoot`, component
+slot, and anchorless-host machinery. No marker protocol, runtime ownership,
+streaming output, server rendering, or hydration adoption changes. Stateful
+case changes retain their hooks and following sibling; incomplete and
+multi-root switches retain their existing insertion boundaries.
+
+- An equivalent exhaustive-switch version of the existing spa-navigation tree
+  previously created **4,093** deep-route comments and **126** nested-route
+  comments. The widened proof restores the original **1** and **2** comment
+  ceilings while preserving exactly **2,052 elements / 1,025 text nodes** on
+  the deep route and **70 elements / 33 text nodes** on the nested route.
+- The existing JSX control, navigation work gates, route-shell/outlet identity,
+  server output, and adoption of original server-rendered elements remain
+  unchanged. Exact comment counts stay in the deterministic production work
+  benchmark; package tests assert visible sibling boundaries, state, order,
+  identity, and hydration behavior.
+
 **Still open (small or order-constrained — diminishing returns):**
 
 1. Multi-hole hosts: the remaining ~684 empty anchors on `/` are
    order-bearing (`<g>{a}{b}</g>` — siblings need stable positions); eliding
    them needs per-hole neighbor bookkeeping. Biggest remaining bucket for
-   VALUE holes; static component children are M7-covered when the callee
-   proof holds. `@switch`-root bodies and optimistic self-recursive arms are
-   natural M7 extensions.
+   VALUE holes; static component children are M7/M8-covered when the callee
+   proof holds. Optimistic self-recursive arms remain a possible extension.
 2. Component-bearing `it` pairs (145 on `/`) — required borrow ranges today.
 3. Sole-root `@switch` construct inherit + children-render-fn /
    value-position sole roots (M3 leftovers).
@@ -542,8 +568,8 @@ proof to cross-module `2`-sentinel call sites for free.
 
 ### Ordering & measured effect
 
-M0 → M1 → M2 → M3 → M4 → M5 → M6 → M7. M1-M5 and M7 remove ranges at the
-compiler/runtime source for client-created content; M6 complements them by
+M0 → M1 → M2 → M3 → M4 → M5 → M6 → M7 → M8. M1-M5, M7, and M8 remove
+ranges at the compiler/runtime source for client-created content; M6 complements them by
 compacting redundant ranges that must remain explicit in the SSR wire format.
 The original home-page report's 40-opening wrapper prefix fell to 19 before
 M6 and now occupies five opening comments while preserving all 19 logical

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -5958,6 +5958,19 @@ function isIfDirective(node) {
 	return node?.type === 'IfStatement' || node?.type === 'JSXIfExpression';
 }
 
+function isSwitchDirective(node) {
+	return node?.type === 'SwitchStatement' || node?.type === 'JSXSwitchExpression';
+}
+
+function hasSwitchCaseLocalBinding(statements) {
+	return statements.some(
+		(statement) =>
+			statement.type === 'VariableDeclaration' ||
+			statement.type === 'FunctionDeclaration' ||
+			statement.type === 'ClassDeclaration',
+	);
+}
+
 /**
  * A directive @if/@else whose every reachable arm emits exactly one plain
  * host. The chosen tag may change, but the item always owns one element; the
@@ -5998,8 +6011,9 @@ function singleRootComponentArmName(node, locals, ctx) {
 
 /**
  * Transitive definition-site single-root proof for a void `@{}` body whose
- * sole root is an `@if`/`@else` tree: every reachable arm must render exactly
- * one plain host OR one qualifying same-module component call (see
+ * sole root is an exhaustive `@if`/`@else` or `@switch` tree: every reachable
+ * arm must render exactly one plain host OR one qualifying same-module
+ * component call (see
  * singleRootComponentArmName). Returns the set of callee names the proof
  * depends on (empty when every arm is a host), or null when the shape does
  * not qualify. The caller resolves the deps with a fixed point over
@@ -6013,22 +6027,41 @@ function singleRootComponentArmName(node, locals, ctx) {
  */
 function collectSingleRootIfDeps(render, locals, ctx) {
 	const roots = normalizeChildren(render ? [render] : []).filter((n) => n.type !== 'HeadHoist');
-	if (roots.length !== 1 || !isIfDirective(roots[0])) return null;
+	if (roots.length !== 1 || (!isIfDirective(roots[0]) && !isSwitchDirective(roots[0]))) {
+		return null;
+	}
 	const deps = new Set();
-	const armOk = (arm) => {
-		if (isIfDirective(arm)) return ifOk(arm);
-		const out = statementsOf(arm).filter((s) => isJsxNode(s) || isIfDirective(s));
+	const armOk = (arm, insideSwitch = false) => {
+		if (isIfDirective(arm)) return ifOk(arm, insideSwitch);
+		if (isSwitchDirective(arm)) return switchOk(arm);
+		const statements = Array.isArray(arm) ? arm : statementsOf(arm);
+		if (insideSwitch && hasSwitchCaseLocalBinding(statements)) return false;
+		const out = statements.filter((s) => isJsxNode(s) || isIfDirective(s) || isSwitchDirective(s));
 		if (out.length !== 1) return false;
 		const sole = out[0];
-		if (isIfDirective(sole)) return ifOk(sole);
+		if (isIfDirective(sole)) return ifOk(sole, insideSwitch);
+		if (isSwitchDirective(sole)) return switchOk(sole);
 		if (isPlainHostRoot(sole)) return true;
 		const name = singleRootComponentArmName(sole, locals, ctx);
 		if (name === null) return false;
 		deps.add(name);
 		return true;
 	};
-	const ifOk = (n) => n.alternate != null && armOk(n.consequent) && armOk(n.alternate);
-	return ifOk(roots[0]) ? deps : null;
+	const ifOk = (n, insideSwitch = false) =>
+		n.alternate != null && armOk(n.consequent, insideSwitch) && armOk(n.alternate, insideSwitch);
+	const switchOk = (n) => {
+		const cases = n.cases || [];
+		let hasDefault = false;
+		for (const clause of cases) {
+			if (clause.test == null) {
+				if (hasDefault) return false;
+				hasDefault = true;
+			}
+			if (!armOk(clause.consequent || [], true)) return false;
+		}
+		return hasDefault;
+	};
+	return (isIfDirective(roots[0]) ? ifOk(roots[0]) : switchOk(roots[0])) ? deps : null;
 }
 
 /**
@@ -6044,11 +6077,11 @@ function collectSingleRootIfDeps(render, locals, ctx) {
  * anything else — including empty component output, whose slot still mints
  * its own comment pair — gets the branch pair minted around it), so we admit:
  *   - one plain host root (the element is the boundary), and
- *   - an @if with a FULL @else chain whose every arm is exactly one plain
- *     host, one component tag (safe unless it lowers to an unsafe lite slot —
- *     resolved transitively via `edges` by the componentInfo fixpoint), or a
- *     nested chain of the same shape.
- * Everything else (missing @else, @switch/@for/hole/fragment roots,
+ *   - an @if with a FULL @else chain or an @switch with a @default whose every
+ *     arm is exactly one plain host, one component tag (safe unless it lowers
+ *     to an unsafe lite slot — resolved transitively via `edges` by the
+ *     componentInfo fixpoint), or a nested exhaustive directive.
+ * Everything else (missing @else/@default, @for/hole/fragment roots,
  * multi-node arms) returns null: the call site keeps its `<!>` anchor.
  * Note every admitted shape renders at least one node in every state, which
  * is what keeps each mounted arm's boundary derivable.
@@ -6063,11 +6096,14 @@ function anchorlessRootShape(node) {
 	if (render == null) return null;
 	if (isPlainHostRoot(render)) return { edges: [] };
 	const edges = [];
-	const armOk = (arm) => {
-		const out = statementsOf(arm).filter((s) => isJsxNode(s) || isIfDirective(s));
+	const armOk = (arm, insideSwitch = false) => {
+		const statements = Array.isArray(arm) ? arm : statementsOf(arm);
+		if (insideSwitch && hasSwitchCaseLocalBinding(statements)) return false;
+		const out = statements.filter((s) => isJsxNode(s) || isIfDirective(s) || isSwitchDirective(s));
 		if (out.length !== 1) return false;
 		const n = out[0];
-		if (isIfDirective(n)) return chainOk(n);
+		if (isIfDirective(n)) return chainOk(n, insideSwitch);
+		if (isSwitchDirective(n)) return switchOk(n);
 		if (isPlainHostRoot(n)) return true;
 		if ((n.type === 'Element' || n.type === 'JSXElement') && isComponentTag(n)) {
 			const name = tagBindingName(n);
@@ -6076,9 +6112,25 @@ function anchorlessRootShape(node) {
 		}
 		return false;
 	};
-	const chainOk = (ifNode) =>
-		ifNode.alternate != null && armOk(ifNode.consequent) && armOk(ifNode.alternate);
-	return isIfDirective(render) && chainOk(render) ? { edges } : null;
+	const chainOk = (ifNode, insideSwitch = false) =>
+		ifNode.alternate != null &&
+		armOk(ifNode.consequent, insideSwitch) &&
+		armOk(ifNode.alternate, insideSwitch);
+	const switchOk = (switchNode) => {
+		let hasDefault = false;
+		for (const clause of switchNode.cases || []) {
+			if (clause.test == null) {
+				if (hasDefault) return false;
+				hasDefault = true;
+			}
+			if (!armOk(clause.consequent || [], true)) return false;
+		}
+		return hasDefault;
+	};
+	return (isIfDirective(render) && chainOk(render)) ||
+		(isSwitchDirective(render) && switchOk(render))
+		? { edges }
+		: null;
 }
 
 /**

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -13694,6 +13694,16 @@ const CAPTURE_FLUSH_FALLBACK = /* @__PURE__ */ Symbol('octane.capture.flushFallb
 // independent phases, so each carries its own stamp.
 const DELEGATED_DISPATCHED = /* @__PURE__ */ Symbol('octane.dispatched');
 const CAPTURE_DISPATCHED = /* @__PURE__ */ Symbol('octane.dispatched.capture');
+// A receiver-specific target lets one accessor survive nested native dispatch.
+const CURRENT_TARGET_NODE = /* @__PURE__ */ Symbol('octane.currentTarget');
+const CURRENT_TARGET_DESCRIPTOR: PropertyDescriptor = {
+	configurable: true,
+	get(this: Event): EventTarget | null {
+		return (this as any)[CURRENT_TARGET_NODE] as EventTarget | null;
+	},
+};
+// Synchronous nested capture walks borrow disjoint frames from this one stack.
+const CAPTURE_PATH: any[] = [];
 
 // Invoke one event slot — a bare handler `fn(event)` or a nominal `{ fn, args }` bundle
 // (the compiler's zero-argument-arrow optimisation) as `fn(...args)`. A bundled
@@ -13923,25 +13933,27 @@ function dispatchDelegatedCapture(event: Event): void {
 	// its native onChange handler can observe the activated value.
 	if (!event.bubbles || !_delegated.has(event.type)) maybeEnqueueRestore(event);
 	const key = CAPTURE_PREFIX + event.type;
-	const path: any[] = [];
+	const pathBase = CAPTURE_PATH.length;
 	for (let node = event.target as any; node !== null && node !== undefined;) {
-		path.push(node);
+		CAPTURE_PATH.push(node);
 		node = node.$$portalParent ? node.$$portalParent : node.parentNode;
 	}
 	_dispatchDepth++;
 	const discrete = DISCRETE_EVENTS.has(event.type);
 	if (discrete) ACTIVE_DISCRETE_EVENT_DEPTH++;
 	try {
-		for (let i = path.length - 1; i >= 0; i--) {
-			const slot = path[i][key] as EventSlot;
+		for (let i = CAPTURE_PATH.length - 1; i >= pathBase; i--) {
+			const slot = CAPTURE_PATH[i][key] as EventSlot;
 			if (slot != null) {
 				// React parity: the handler's element is the currentTarget.
-				setCurrentTarget(event, path[i]);
+				setCurrentTarget(event, CAPTURE_PATH[i]);
 				fireEventSlot(slot, event);
 				if (event.cancelBubble) return;
 			}
 		}
 	} finally {
+		// Nested dispatch appends its own frame and restores the outer traversal.
+		CAPTURE_PATH.length = pathBase;
 		clearCurrentTarget(event);
 		if (discrete) ACTIVE_DISCRETE_EVENT_DEPTH--;
 		_dispatchDepth--;
@@ -13958,14 +13970,13 @@ function noop(): void {}
 // delegation ROOT), so shadow it with a configurable own property during each handler and
 // remove the shadow after the walk (restoring native semantics).
 function setCurrentTarget(event: Event, node: EventTarget | null): void {
-	Object.defineProperty(event, 'currentTarget', {
-		configurable: true,
-		get: () => node,
-	});
+	(event as any)[CURRENT_TARGET_NODE] = node;
+	Object.defineProperty(event, 'currentTarget', CURRENT_TARGET_DESCRIPTOR);
 }
 function clearCurrentTarget(event: Event): void {
 	// Deleting the own property re-exposes Event.prototype's native getter.
 	delete (event as any).currentTarget;
+	delete (event as any)[CURRENT_TARGET_NODE];
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/octane/tests/component-children-host.test.ts
+++ b/packages/octane/tests/component-children-host.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
+import * as ServerRuntime from 'octane/server';
+import { flushSync, hydrateRoot } from '../src/index.js';
 import { mount, flushEffects, act, nextPaint, type MountResult } from './_helpers';
+import { loadCompiledFixtureSource } from './_server-fixture';
 import {
 	WideTrio,
 	WidePanels,
@@ -13,6 +16,159 @@ import {
 	FragmentTrio,
 	SuspendingPair,
 } from './_fixtures/component-children-host.tsrx';
+
+const SWITCH_CHILD_SOURCE = `
+	import { useState } from 'octane';
+
+	function SwitchLeaf(props) @{
+		<span class="switch-leaf">{props.label as string}</span>
+	}
+
+	function SwitchPanel(props) @{
+		const [count, setCount] = useState(0);
+		@switch (props.kind) {
+			@case 'large': {
+				<button class="switch-large" onClick={() => setCount(count + 1)}>
+					{props.label + ':' + count as string}
+				</button>
+			}
+			@case 'middle': {
+				<strong class="switch-middle">{props.label as string}</strong>
+			}
+			@default: {
+				<SwitchLeaf label={props.label} />
+			}
+		}
+	}
+
+	export function SwitchPair(props) @{
+		<section class="switch-host">
+			<SwitchPanel kind={props.first} label="A" />
+			<SwitchPanel kind={props.second} label="B" />
+		</section>
+	}
+
+	function HooklessSwitchPanel(props) @{
+		@switch (props.kind) {
+			@case 'large': {
+				<strong class="switch-middle">{props.label as string}</strong>
+			}
+			@default: {
+				<SwitchLeaf label={props.label} />
+			}
+		}
+	}
+
+	export function HooklessSwitchPair(props) @{
+		<section class="switch-host">
+			<HooklessSwitchPanel kind={props.first} label="A" />
+			<HooklessSwitchPanel kind={props.second} label="B" />
+		</section>
+	}
+
+	function OptionalSwitchPanel(props) @{
+		@switch (props.kind) {
+			@case 'large': {
+				<strong class="switch-middle">{props.label as string}</strong>
+			}
+		}
+	}
+
+	export function OptionalSwitchPair(props) @{
+		<section class="switch-host">
+			<OptionalSwitchPanel kind={props.first} label="A" />
+			<SwitchLeaf label="B" />
+		</section>
+	}
+
+	function ShadowedOptional(props) @{
+		@if (props.visible) {
+			<strong class="switch-middle">{props.label as string}</strong>
+		}
+	}
+
+	function ShadowedSwitchPanel(props) @{
+		@switch (props.kind) {
+			@case 'shadow': {
+				const SwitchLeaf = props.component;
+				<SwitchLeaf label={props.label} visible={props.visible} />
+			}
+			@default: {
+				<strong class="switch-middle">{props.label as string}</strong>
+			}
+		}
+	}
+
+	export function ShadowedSwitchPair(props) @{
+		<section class="switch-host">
+			<ShadowedSwitchPanel
+				kind="shadow"
+				component={ShadowedOptional}
+				visible={props.visible}
+				label="A"
+			/>
+			<SwitchLeaf label="B" />
+		</section>
+	}
+
+	function NestedShadowedSwitchPanel(props) @{
+		@switch (props.kind) {
+			@case 'shadow': {
+				@if (props.nested) {
+					const SwitchLeaf = props.component;
+					<SwitchLeaf label={props.label} visible={props.visible} />
+				} @else {
+					<strong class="switch-middle">{props.label as string}</strong>
+				}
+			}
+			@default: {
+				<strong class="switch-middle">{props.label as string}</strong>
+			}
+		}
+	}
+
+	export function NestedShadowedSwitchPair(props) @{
+		<section class="switch-host">
+			<NestedShadowedSwitchPanel
+				kind="shadow"
+				nested={true}
+				component={ShadowedOptional}
+				visible={props.visible}
+				label="A"
+			/>
+			<SwitchLeaf label="B" />
+		</section>
+	}
+
+	function WideSwitchPanel(props) @{
+		@switch (props.kind) {
+			@case 'large': {
+				<>
+					<strong class="switch-middle">{props.label as string}</strong>
+					<em class="switch-tail">{props.label as string}</em>
+				</>
+			}
+			@default: {
+				<SwitchLeaf label={props.label} />
+			}
+		}
+	}
+
+	export function WideSwitchPair(props) @{
+		<section class="switch-host">
+			<WideSwitchPanel kind={props.first} label="A" />
+			<SwitchLeaf label="B" />
+		</section>
+	}
+`;
+
+function loadSwitchChildren(mode: 'client' | 'server') {
+	return loadCompiledFixtureSource(SWITCH_CHILD_SOURCE, {
+		id: 'switch-component-children.tsrx',
+		mode,
+		compileOptions: { hmr: false, dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod' },
+	});
+}
 
 // A host element whose children are ALL components mounts each child slot in
 // source order. The contract pinned here is sibling ORDER: a component child
@@ -330,5 +486,169 @@ describe('host with only component children (@if-root components)', () => {
 		);
 		expect(m.findAll('.big')[1]).toBe(b);
 		m.unmount();
+	});
+});
+
+describe('host with only component children (@switch-root components)', () => {
+	it('exposes each complete stateful switch child as the host’s actual first and last child', () => {
+		const client = loadSwitchChildren('client');
+		const root = mount(client.SwitchPair, { first: 'large', second: 'other' });
+
+		try {
+			const host = root.find('.switch-host');
+			const first = root.find('.switch-large');
+			const second = root.find('.switch-leaf');
+
+			expect(host.firstChild).toBe(first);
+			expect(host.lastChild).toBe(second);
+			expect(host.textContent).toBe('A:0B');
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('exposes complete hookless switch children in source order', () => {
+		const client = loadSwitchChildren('client');
+		const root = mount(client.HooklessSwitchPair, { first: 'large', second: 'other' });
+
+		try {
+			const host = root.find('.switch-host');
+			const first = root.find('.switch-middle');
+			const second = root.find('.switch-leaf');
+
+			expect(host.firstChild).toBe(first);
+			expect(host.lastChild).toBe(second);
+			expect(Array.from(host.children)).toEqual([first, second]);
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('preserves switch-child state and its sibling’s identity across every case', () => {
+		const client = loadSwitchChildren('client');
+		const root = mount(client.SwitchPair, { first: 'large', second: 'other' });
+
+		try {
+			const sibling = root.find('.switch-leaf');
+			root.click('.switch-large');
+			expect(root.find('.switch-large').textContent).toBe('A:1');
+
+			root.update(client.SwitchPair, { first: 'middle', second: 'other' });
+			expect(root.find('.switch-host').textContent).toBe('AB');
+			expect(root.find('.switch-leaf')).toBe(sibling);
+
+			root.update(client.SwitchPair, { first: 'other', second: 'other' });
+			expect(root.findAll('.switch-leaf').map((node) => node.textContent)).toEqual(['A', 'B']);
+			expect(root.findAll('.switch-leaf')[1]).toBe(sibling);
+
+			root.update(client.SwitchPair, { first: 'large', second: 'other' });
+			expect(root.find('.switch-large').textContent).toBe('A:1');
+			expect(root.find('.switch-leaf')).toBe(sibling);
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('keeps an incomplete switch in its source position when its empty case becomes visible', () => {
+		const client = loadSwitchChildren('client');
+		const root = mount(client.OptionalSwitchPair, { first: 'other' });
+
+		try {
+			const sibling = root.find('.switch-leaf');
+			expect(root.find('.switch-host').textContent).toBe('B');
+
+			root.update(client.OptionalSwitchPair, { first: 'large' });
+			expect(root.find('.switch-host').textContent).toBe('AB');
+			expect(root.find('.switch-leaf')).toBe(sibling);
+			expect(root.find('.switch-host').children[0]).toBe(root.find('.switch-middle'));
+
+			root.update(client.OptionalSwitchPair, { first: 'other' });
+			expect(root.find('.switch-host').textContent).toBe('B');
+			expect(root.find('.switch-leaf')).toBe(sibling);
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it('preserves a multi-root case and the following component across case changes', () => {
+		const client = loadSwitchChildren('client');
+		const root = mount(client.WideSwitchPair, { first: 'large' });
+
+		try {
+			const sibling = root.find('.switch-leaf');
+			expect(
+				Array.from(root.find('.switch-host').children).map((node) => node.textContent),
+			).toEqual(['A', 'A', 'B']);
+
+			root.update(client.WideSwitchPair, { first: 'other' });
+			expect(root.find('.switch-host').textContent).toBe('AB');
+			expect(root.findAll('.switch-leaf')[1]).toBe(sibling);
+
+			root.update(client.WideSwitchPair, { first: 'large' });
+			expect(root.find('.switch-host').textContent).toBe('AAB');
+			expect(root.find('.switch-leaf')).toBe(sibling);
+		} finally {
+			root.unmount();
+		}
+	});
+
+	it.each([
+		['direct', 'ShadowedSwitchPair'],
+		['nested', 'NestedShadowedSwitchPair'],
+	])(
+		'keeps a %s case-local component shadow in source order when it first becomes visible',
+		(_, name) => {
+			const client = loadSwitchChildren('client');
+			const component = client[name];
+			const root = mount(component, { visible: false });
+
+			try {
+				const sibling = root.find('.switch-leaf');
+				expect(root.find('.switch-host').textContent).toBe('B');
+
+				root.update(component, { visible: true });
+				expect(
+					Array.from(root.find('.switch-host').children).map((node) => node.textContent),
+				).toEqual(['A', 'B']);
+				expect(root.find('.switch-leaf')).toBe(sibling);
+			} finally {
+				root.unmount();
+			}
+		},
+	);
+
+	it('hydrates the original switch-child elements and keeps sibling identity after case changes', () => {
+		const client = loadSwitchChildren('client');
+		const server = loadSwitchChildren('server');
+		const container = document.createElement('div');
+		container.innerHTML = ServerRuntime.renderToString(server.SwitchPair, {
+			first: 'large',
+			second: 'other',
+		}).html;
+		document.body.appendChild(container);
+
+		const first = container.querySelector('.switch-large');
+		const second = container.querySelector('.switch-leaf');
+		const root = hydrateRoot(container, client.SwitchPair, { first: 'large', second: 'other' });
+
+		try {
+			flushSync(() => {});
+			expect(container.querySelector('.switch-large')).toBe(first);
+			expect(container.querySelector('.switch-leaf')).toBe(second);
+
+			flushSync(() => (first as HTMLButtonElement).click());
+			expect(first?.textContent).toBe('A:1');
+
+			flushSync(() => root.render(client.SwitchPair, { first: 'middle', second: 'other' }));
+			expect(container.querySelector('.switch-middle')?.textContent).toBe('A');
+			expect(container.querySelector('.switch-leaf')).toBe(second);
+
+			flushSync(() => root.render(client.SwitchPair, { first: 'large', second: 'other' }));
+			expect(container.querySelector('.switch-large')?.textContent).toBe('A:1');
+			expect(container.querySelector('.switch-leaf')).toBe(second);
+		} finally {
+			root.unmount();
+			container.remove();
+		}
 	});
 });

--- a/packages/octane/tests/current-target.test.ts
+++ b/packages/octane/tests/current-target.test.ts
@@ -1,6 +1,41 @@
 import { describe, it, expect } from 'vitest';
 import { mount, createLog } from './_helpers';
 import { Nested, SelfGuard } from './_fixtures/current-target.tsrx';
+import { loadCompiledFixtureSource } from './_server-fixture';
+
+const EVENT_PROBE_SOURCE = `
+export function EventProbe(props) @{
+	<section
+		id="outer"
+		onClickCapture={(event) => props.handle('capture', 'outer', event)}
+		onClick={(event) => props.handle('bubble', 'outer', event)}
+	>
+		<button
+			id="inner"
+			onClickCapture={(event) => props.handle('capture', 'inner', event)}
+			onClick={(event) => props.handle('bubble', 'inner', event)}
+		>inner</button>
+		<button
+			id="nested"
+			onClickCapture={(event) => props.handle('capture', 'nested', event)}
+			onClick={(event) => props.handle('bubble', 'nested', event)}
+		>nested</button>
+	</section>
+}
+`;
+
+type EventPhase = 'capture' | 'bubble';
+
+function loadEventProbe() {
+	return loadCompiledFixtureSource(EVENT_PROBE_SOURCE, {
+		id: 'delegated-current-target-reentrancy.tsrx',
+		mode: 'client',
+		compileOptions: {
+			hmr: false,
+			dev: process.env.OCTANE_TEST_COMPILE_MODE !== 'prod',
+		},
+	}).EventProbe;
+}
 
 // React parity: during DELEGATED dispatch, `event.currentTarget` is the element whose
 // handler is firing — patched per-handler as the walk ascends (bubble) / descends
@@ -46,4 +81,154 @@ describe('delegated event currentTarget', () => {
 		expect(Object.prototype.hasOwnProperty.call(ev, 'currentTarget')).toBe(false);
 		r.unmount();
 	});
+
+	it('preserves native event identity and its public accessor throughout both phases', () => {
+		let original: MouseEvent;
+		const observations: Array<{
+			phase: EventPhase;
+			owner: string;
+			target: string;
+			currentTarget: string;
+			sameEvent: boolean;
+			accessor: boolean;
+			configurable: boolean;
+			enumerable: boolean;
+		}> = [];
+		const mounted = mount(loadEventProbe(), {
+			handle(phase: EventPhase, owner: string, event: MouseEvent) {
+				const descriptor = Object.getOwnPropertyDescriptor(event, 'currentTarget');
+				observations.push({
+					phase,
+					owner,
+					target: (event.target as Element).id,
+					currentTarget: (event.currentTarget as Element).id,
+					sameEvent: event === original,
+					accessor: typeof descriptor?.get === 'function' && descriptor.set === undefined,
+					configurable: descriptor?.configurable === true,
+					enumerable: descriptor?.enumerable === true,
+				});
+			},
+		});
+
+		original = new MouseEvent('click', { bubbles: true, cancelable: true });
+		mounted.find('#inner').dispatchEvent(original);
+
+		expect(observations).toEqual(
+			[
+				['capture', 'outer'],
+				['capture', 'inner'],
+				['bubble', 'inner'],
+				['bubble', 'outer'],
+			].map(([phase, owner]) => ({
+				phase,
+				owner,
+				target: 'inner',
+				currentTarget: owner,
+				sameEvent: true,
+				accessor: true,
+				configurable: true,
+				enumerable: false,
+			})),
+		);
+		expect(original.currentTarget).toBe(null);
+		expect(Object.prototype.hasOwnProperty.call(original, 'currentTarget')).toBe(false);
+		mounted.unmount();
+	});
+
+	it.each(['capture', 'bubble'] as const)(
+		'preserves both active native events during nested %s dispatch',
+		(triggerPhase) => {
+			let outerEvent: MouseEvent;
+			let nestedEvent: MouseEvent | undefined;
+			let activeOuterTarget: EventTarget | null = null;
+			const observed: string[] = [];
+			const mounted = mount(loadEventProbe(), {
+				handle(phase: EventPhase, owner: string, event: MouseEvent) {
+					const target = (event.target as Element).id;
+					observed.push(`${phase}:${owner}:${target}`);
+					expect(event.currentTarget).toBe(mounted.find(`#${owner}`));
+
+					if (event === nestedEvent) {
+						expect(outerEvent.currentTarget).toBe(activeOuterTarget);
+						if (triggerPhase === 'capture' && phase === 'capture' && owner === 'nested') {
+							event.stopPropagation();
+						}
+						return;
+					}
+
+					const triggerOwner = triggerPhase === 'capture' ? 'outer' : 'inner';
+					if (phase !== triggerPhase || owner !== triggerOwner) return;
+
+					activeOuterTarget = event.currentTarget;
+					nestedEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+					mounted.find('#nested').dispatchEvent(nestedEvent);
+					expect(event.currentTarget).toBe(activeOuterTarget);
+					expect(nestedEvent.currentTarget).toBe(null);
+					expect(Object.prototype.hasOwnProperty.call(nestedEvent, 'currentTarget')).toBe(false);
+				},
+			});
+
+			outerEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+			mounted.find('#inner').dispatchEvent(outerEvent);
+
+			if (triggerPhase === 'capture') {
+				expect(observed).toEqual([
+					'capture:outer:inner',
+					'capture:outer:nested',
+					'capture:nested:nested',
+					'capture:inner:inner',
+					'bubble:inner:inner',
+					'bubble:outer:inner',
+				]);
+			} else {
+				expect(observed).toEqual([
+					'capture:outer:inner',
+					'capture:inner:inner',
+					'bubble:inner:inner',
+					'capture:outer:nested',
+					'capture:nested:nested',
+					'bubble:nested:nested',
+					'bubble:outer:nested',
+					'bubble:outer:inner',
+				]);
+			}
+			expect(outerEvent.currentTarget).toBe(null);
+			expect(Object.prototype.hasOwnProperty.call(outerEvent, 'currentTarget')).toBe(false);
+			mounted.unmount();
+		},
+	);
+
+	it.each(['replace', 'delete'] as const)(
+		'restores each handler target after a consumer chooses to %s its own accessor',
+		(change) => {
+			const observed: string[] = [];
+			const mounted = mount(loadEventProbe(), {
+				handle(phase: EventPhase, owner: string, event: MouseEvent) {
+					observed.push(`${phase}:${(event.currentTarget as Element).id}`);
+					if (
+						(phase !== 'capture' || owner !== 'outer') &&
+						(phase !== 'bubble' || owner !== 'inner')
+					) {
+						return;
+					}
+
+					if (change === 'delete') {
+						delete (event as { currentTarget?: EventTarget | null }).currentTarget;
+					} else {
+						Object.defineProperty(event, 'currentTarget', {
+							configurable: true,
+							get: () => document.body,
+						});
+					}
+				},
+			});
+
+			const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+			mounted.find('#inner').dispatchEvent(event);
+			expect(observed).toEqual(['capture:outer', 'capture:inner', 'bubble:inner', 'bubble:outer']);
+			expect(event.currentTarget).toBe(null);
+			expect(Object.prototype.hasOwnProperty.call(event, 'currentTarget')).toBe(false);
+			mounted.unmount();
+		},
+	);
 });


### PR DESCRIPTION
## Summary

Finish the remaining P3 work in #673: reduce native delegated-event allocations
without changing dispatch semantics, and extend the existing ownership-safe
component marker proof to exhaustive switch-root components.

## Changes

- Reuse one `currentTarget` accessor descriptor and getter across delegated
  handlers while keeping the active target private to each native event.
  Reinstall the accessor for every handler, including after consumer
  replacement/deletion, and restore native event behavior after dispatch.
- Reuse one stack-backed capture path across synchronous dispatches, with
  nested-frame restoration, native capture/bubble ordering, portal ancestry,
  propagation control, and controlled-input behavior preserved.
- Extend both existing client-only single-root classifiers to exhaustive
  `@switch` trees. Require `@default`, exactly one qualifying root per arm,
  proven same-module component identities, and conservative rejection of
  switch-owned lexical shadows, empty cases, fragments, and multiple roots.
- Add owning-package coverage for native descriptors, reentrant dispatch,
  public DOM boundaries, state/sibling identity, direct and nested case-local
  shadowing, and adoption of original server-rendered elements.
- Add a self-contained production event work gate to the unified benchmark
  runner and strengthen the existing navigation work gate with exact visible-DOM
  controls and comment ceilings. Document the new marker phase and add an
  `octane` patch changeset.

## Same-source production measurements

| Existing workload | Before | After | Preserved contract |
| --- | ---: | ---: | --- |
| 128 events: distinct `currentTarget` descriptors | 256 | 1 | Exactly 256 accessor installations |
| 128 events: distinct accessor getters | 256 | 1 | Native event identity and handler-local `currentTarget` |
| 128 events: distinct delegated capture paths | 128 | 1 | Native/framework capture, bubbling, and 128 controlled outputs |
| 1,024-leaf switch navigation: comment nodes | 4,093 | 1 | Exactly 2,052 elements and 1,025 text nodes |
| 32-leaf nested switch navigation: comment nodes | 126 | 2 | Exactly 70 elements and 33 text nodes; shell/outlet identity |

The unchanged JSX navigation control retains zero comments. Paired production
navigation medians moved from approximately 2.0–2.1 ms to 1.5–1.7 ms; event
wall-clock samples were noisy, so no event latency improvement is claimed.

The fixed 16-file compiler corpus remains byte-identical at 153,572 raw /
75,799 minified / 26,823 gzip bytes. Server output remains byte-identical.
The eligible event fixture grows by 35 gzip bytes and the equivalent switch
fixture grows by 68 gzip bytes; generic production root, hydration,
deferred-hydration, and Suspense bundles grow by 23–51 gzip bytes.

## Validation

- [x] `./node_modules/.bin/vitest run --project octane --project octane-prod --silent=passed-only`
  — **806 files / 12,014 tests passed**.
- [x] Focused compiler, event, portal, control-flow, SSR, streaming, hydration,
  transition, conformance, and differential coverage — **162 files / 2,822 tests
  passed**.
- [x] Existing real-Chromium deferred-event replay, Suspense/hydration, and Vite
  production SSR/deferred-hydration suites — **30 browser tests passed**.
- [x] `pnpm --config.verify-deps-before-run=false --config.enable-pre-post-scripts=false run typecheck`
  — full workspace, integrations, website, 17 examples, and SPA benchmark.
- [x] `node benchmarks/bench.mjs --quick --results-dir=/private/tmp/octane-p3-event-unified event-delegation`
  — all six framework targets plus the enforced `octane-tsrx-work` allocation
  target passed.
- [x] Production SPA precise-work/census gate — both current-runtime Octane
  dialects, all existing navigation/deoptimization controls, retained shell and
  outlet identity, and hardened deep/nested comment ceilings.
- [x] `node benchmarks/bench.mjs --quick --results-dir=/private/tmp/octane-p3-compiler-bench codegen-size compiler-throughput bundle-size bundle-reachability`
  — compiler corpus, six-framework throughput, normalized production bundles,
  and public-import feature tree-shaking passed.
- [x] Exhaustive **35-case** conservative compiler proof matrix, frozen parsed
  AST/source origins, both-mode byte-identical server output, same-source
  production before/after controls, and scoped Prettier / `git diff --check`.
- [x] `pnpm --config.verify-deps-before-run=false --config.enable-pre-post-scripts=false run sync`
  — all generated artifacts already current.

## Risk / follow-ups

- Marker removal is limited to proven client-created single-root components;
  marker ownership, streaming protocol, SSR bytes, and hydration adoption are
  unchanged. Incomplete, multi-root, and shadowed switch arms stay anchored.
- Event measurements demonstrate deterministic allocation reductions rather than
  an unsupported latency claim. The small production bundle-size increases are
  disclosed above.

Refs #673.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes delegated event dispatch and compiler elision proofs on hot paths, but behavior is heavily pinned by new gates and expanded tests; SSR/hydration and incomplete switch shapes stay conservative.
> 
> **Overview**
> Finishes delegated-event and comment-marker work from the existing optimization track: **less allocation during native dispatch** and **fewer client-only component markers** when the compiler can prove a safe shape.
> 
> **Delegated events** now store the active handler element on a per-event symbol and reinstall one shared `currentTarget` property descriptor for every handler (including after consumers replace or delete the accessor). Capture phase walks reuse a module-level stack with nested-dispatch frame restore instead of allocating a fresh path array per event. React-parity semantics for capture/bubble order, `currentTarget`, nested dispatch, and controlled inputs are unchanged; new unit coverage exercises reentrancy and accessor identity.
> 
> **Compiler (M8)** widens the existing transitive single-root and anchorless-host proofs from exhaustive `@if`/`@else` to exhaustive `@switch` with an explicit `@default`, one qualifying root per case, and conservative rejection of case-local bindings, fragments, and unproven callees. Qualifying components keep using the existing `$$singleRoot` / anchorless slot machinery—**client mount only**; SSR bytes and hydration adoption are untouched.
> 
> **Benchmarks and fixtures**: the spa-navigation TSRX tree’s recursive `Node` is rewritten to `@switch`/`@default` so the proof applies at scale; `work.mjs` adds DOM element/text/comment ceilings (deep route 1 comment, nested 2 for TSRX). A separate `event-delegation/work.mjs` gate (wired into `bench.mjs`) asserts one descriptor, one getter, and one capture path over 128 production `InputEvent`s, with an optional form `onInputCapture` hook on the runtime-stress app for framework capture checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e05891e26ffaca3c1f4dfc55a83237a03ddae57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->