### PR TITLE
perf(lynx): specialize compact run teardown

### DIFF
--- a/packages/lynx/src/core/host-driver.ts
+++ b/packages/lynx/src/core/host-driver.ts
@@ -193,6 +193,8 @@ interface LynxHostState<Node extends LynxElementRef> {
 	generations: Map<number, number>;
 	/** Compact first mounts derive live generation-one entries from their records. */
 	implicitInitialGenerations: boolean;
+	/** Ordinary pure template runs may retain compact metadata solely for certified teardown. */
+	teardownRecords: LynxDenseHostRecordStore<Node> | null;
 	/** Universal root provenance is fixed by the first accepted portal handle. */
 	portalRoot: number | null;
 	/** Portal children stay separate from ordinary authored host children. */
@@ -326,6 +328,7 @@ type LynxApplyOperation<Node extends LynxElementRef> =
 			readonly parents: readonly number[];
 			readonly count?: number;
 			readonly dense?: LynxDenseHostRecordStore<Node>;
+			readonly teardownDense?: LynxDenseHostRecordStore<Node>;
 			/** Present only when a compact range owns contiguous lazy host identities. */
 			readonly firstId?: number;
 			readonly program?: LynxPreparedTemplateProgram;
@@ -597,6 +600,17 @@ interface LynxPreparedTemplateProgram {
 	readonly valueCount: number;
 }
 
+interface LynxDenseTeardownPlan<Node extends LynxElementRef> {
+	readonly store: LynxDenseHostRecordStore<Node>;
+	readonly records: Map<number, LynxHostRecord<Node>>;
+	readonly rootChildren: number[];
+	readonly acceptedChildren: readonly number[];
+	readonly parent: number | null;
+	readonly eventCommands: number;
+	readonly firstId: number;
+	readonly hostCount: number;
+}
+
 /**
  * A compact run already describes every host by a frozen program and identity
  * stride. Keep only physical nodes eagerly; materialize logical records,
@@ -619,9 +633,14 @@ class LynxDenseHostRecordStore<Node extends LynxElementRef> implements LynxHostR
 		readonly parent: LynxAttachedHostParent,
 		readonly values: readonly UniversalHostTemplateProgramValue[],
 		readonly firstListenerId: number | null,
+		readonly hostGenerations: readonly number[] | null = null,
 	) {
 		this.live = count * program.shape.types.length;
 		this.nodes = new Array(this.live);
+	}
+
+	generationAt(offset: number): number {
+		return this.hostGenerations?.[offset] ?? 1;
 	}
 
 	get size(): number {
@@ -634,6 +653,154 @@ class LynxDenseHostRecordStore<Node extends LynxElementRef> implements LynxHostR
 			const record = this.materialized.get(offset);
 			if (record !== undefined) record.node = node;
 		}
+	}
+
+	private isRunRoot(id: number): boolean {
+		const offset = id - this.firstId;
+		return (
+			Number.isSafeInteger(offset) &&
+			offset >= 0 &&
+			offset < this.nodes.length &&
+			offset % this.program.shape.types.length === 0
+		);
+	}
+
+	prepareFullTeardown(
+		state: LynxHostState<Node>,
+		batch: UniversalHostBatch,
+	): LynxDenseTeardownPlan<Node> | null {
+		const lastCommand = batch.commands[batch.commands.length - 1];
+		if (batch.commands.length < this.nodes.length + this.count || lastCommand?.op !== 'destroy') {
+			return null;
+		}
+		if (
+			this.cleared ||
+			this.appended.size !== 0 ||
+			this.removed?.size ||
+			this.live !== this.nodes.length ||
+			this.nodes.length === 0 ||
+			state.hasMainThreadProps ||
+			state.hasNativeListTopology ||
+			state.portalRoot !== null ||
+			state.portalChildren.size !== 0 ||
+			state.mainThreadRefs.size !== 0 ||
+			state.mainThreadRefOwners.size !== 0 ||
+			state.lists.size !== 0 ||
+			!state.implicitInitialGenerations
+		) {
+			return null;
+		}
+		const parent = this.parent;
+		if (isPortalParent(parent)) return null;
+		const width = this.program.shape.types.length;
+		if (this.nodes.length !== this.count * width) return null;
+		for (const [id, generation] of state.generations) {
+			if (
+				id >= this.firstId &&
+				id < this.firstId + this.nodes.length &&
+				generation !== this.generationAt(id - this.firstId)
+			) {
+				return null;
+			}
+		}
+
+		const parentRecord = typeof parent === 'number' ? this.prefix.get(parent) : undefined;
+		if (typeof parent === 'number' && parentRecord === undefined) return null;
+		const acceptedChildren = parent === null ? state.rootChildren : parentRecord!.children;
+		const survivingChildren: number[] = [];
+		let roots = 0;
+		for (const id of acceptedChildren) {
+			if (this.isRunRoot(id)) roots++;
+			else survivingChildren.push(id);
+		}
+		if (roots !== this.count) return null;
+
+		const postorder: number[] = [];
+		const visit = (node: number): void => {
+			for (let child = node + 1; child < width; child++) {
+				if (this.program.shape.parents[child] === node) visit(child);
+			}
+			postorder.push(node);
+		};
+		visit(0);
+		if (postorder.length !== width) return null;
+
+		let commandIndex = 0;
+		for (const rootId of acceptedChildren) {
+			if (!this.isRunRoot(rootId)) continue;
+			for (const node of postorder) {
+				const events = this.program.events[node];
+				if (events === undefined) continue;
+				const physical = this.nodes[rootId - this.firstId + node];
+				if (physical === undefined) return null;
+				const registrations = state.nativeEvents.get(physical);
+				if (registrations?.size !== events.length) return null;
+				for (const event of events) {
+					const command = batch.commands[commandIndex++];
+					if (
+						command?.op !== 'event' ||
+						command.id !== rootId + node ||
+						command.type !== event.type ||
+						command.listener !== null ||
+						!registrations.has(event.type)
+					) {
+						return null;
+					}
+				}
+			}
+		}
+		const eventCommands = commandIndex;
+		for (const rootId of acceptedChildren) {
+			if (!this.isRunRoot(rootId)) continue;
+			const command = batch.commands[commandIndex++];
+			if (command?.op !== 'remove' || command.id !== rootId || command.parent !== parent) {
+				return null;
+			}
+		}
+		for (const rootId of acceptedChildren) {
+			if (!this.isRunRoot(rootId)) continue;
+			for (const node of postorder) {
+				const command = batch.commands[commandIndex++];
+				if (command?.op !== 'destroy' || command.id !== rootId + node) return null;
+			}
+		}
+		if (commandIndex !== batch.commands.length) return null;
+
+		if (state.ownedNodes.size !== this.prefix.size + this.nodes.length) return null;
+		for (const record of this.prefix.values()) {
+			if (record.node === null || !state.ownedNodes.has(record.node)) return null;
+		}
+		for (let offset = 0; offset < this.nodes.length; offset++) {
+			const node = this.nodes[offset];
+			if (node === undefined || !state.ownedNodes.has(node)) return null;
+			const expectedEvents = this.program.events[offset % width];
+			if ((state.nativeEvents.get(node)?.size ?? 0) !== (expectedEvents?.length ?? 0)) return null;
+		}
+		if (parent === null) {
+			for (const rootId of acceptedChildren) {
+				if (!this.isRunRoot(rootId)) continue;
+				const node = this.nodes[rootId - this.firstId];
+				if (node === undefined || !state.ownedPageRoots.has(node)) return null;
+			}
+		}
+
+		const records = new Map(this.prefix);
+		if (parentRecord !== undefined) {
+			const nextParent = cloneRecord(parentRecord);
+			nextParent.children =
+				survivingChildren.length === 0 ? EMPTY_HOST_CHILDREN : survivingChildren;
+			records.set(parent as number, nextParent);
+		}
+		return {
+			store: this,
+			records,
+			rootChildren: parent === null ? survivingChildren : state.rootChildren,
+			acceptedChildren,
+			parent,
+			eventCommands,
+			firstId: this.firstId,
+			hostCount: this.nodes.length,
+		};
 	}
 
 	private offset(id: number): number {
@@ -668,12 +835,13 @@ class LynxDenseHostRecordStore<Node extends LynxElementRef> implements LynxHostR
 		}
 		const parent = node === 0 ? this.parent : rowFirstId + this.program.shape.parents[node]!;
 		const events = this.program.events[node];
+		const generation = this.generationAt(offset);
 		const record: LynxHostRecord<Node> =
 			events === undefined
 				? new LynxCompactHostRecord(
 						this.root,
 						id,
-						1,
+						generation,
 						this.program.shape.types[node]!,
 						props,
 						parent,
@@ -681,7 +849,7 @@ class LynxDenseHostRecordStore<Node extends LynxElementRef> implements LynxHostR
 				: new LynxCompactEventHostRecord(
 						this.root,
 						id,
-						1,
+						generation,
 						this.program.shape.types[node]!,
 						props,
 						parent,
@@ -2413,6 +2581,7 @@ export function createLynxHostContainer<Node extends LynxElementRef>(
 		rootChildren: [],
 		generations: new Map(),
 		implicitInitialGenerations: false,
+		teardownRecords: null,
 		portalRoot: null,
 		portalChildren: new Map(),
 		ownedNodes: new Set(),
@@ -3046,6 +3215,7 @@ function transferFirstTree<Node extends LynxElementRef>(
 	sourceState.mainThreadRefs.clear();
 	sourceState.mainThreadRefOwners.clear();
 	sourceState.records.clear();
+	sourceState.teardownRecords = null;
 	sourceState.rootChildren.length = 0;
 	sourceState.generations.clear();
 	sourceState.portalRoot = null;
@@ -3057,6 +3227,132 @@ function transferFirstTree<Node extends LynxElementRef>(
 	const journal = firstTree[LYNX_FIRST_TREE_STATE];
 	journal.owner = null;
 	journal.status = 'transferred';
+}
+
+function prepareDenseTeardown<Node extends LynxElementRef>(
+	container: LynxHostContainer<Node>,
+	batch: UniversalHostBatch,
+	state: LynxHostState<Node>,
+	plan: LynxDenseTeardownPlan<Node>,
+): LynxPreparedHostBatch {
+	const baseVersion = state.acceptedVersion;
+	const emptyListAncestryDelta = Object.freeze([]) as readonly LynxHostListAncestryDelta[];
+	let handleDelta: readonly LynxHostHandleDelta[] | null = null;
+	let status: 'prepared' | 'applying' | 'applied' | 'aborted' | 'faulted' = 'prepared';
+	let mutationStarted = false;
+	let fault: unknown;
+	const materializeHandleDelta = (): readonly LynxHostHandleDelta[] => {
+		if (handleDelta !== null) return handleDelta;
+		const deltas: LynxHostHandleDelta[] = new Array(plan.hostCount);
+		for (let offset = 0; offset < plan.hostCount; offset++) {
+			const command = batch.commands[plan.eventCommands + plan.store.count + offset]!;
+			if (command.op !== 'destroy') throw hostError('certified teardown order changed.');
+			deltas[offset] = Object.freeze({
+				op: 'destroy',
+				renderer: LYNX_RENDERER_ID,
+				root: container.root,
+				id: command.id,
+				generation: plan.store.generationAt(command.id - plan.firstId),
+			});
+		}
+		handleDelta = Object.freeze(deltas);
+		return handleDelta;
+	};
+	const prepared: LynxPreparedHostBatch = {
+		get mutationStarted() {
+			return mutationStarted;
+		},
+		get handleDelta() {
+			return materializeHandleDelta();
+		},
+		listAncestryDelta: emptyListAncestryDelta,
+		firstTreeAction: 'none',
+		apply() {
+			if (status === 'aborted' || status === 'applied') return;
+			if (status === 'faulted') throw fault;
+			if (status !== 'prepared') return;
+			if (state.disposed || state.disposing) {
+				throw hostError('cannot apply a batch while root cleanup is pending.');
+			}
+			if (state.firstTree !== null) {
+				throw hostError('a captured first-tree root cannot apply a prepared batch.');
+			}
+			if (state.acceptedVersion !== baseVersion) {
+				throw hostError(
+					`prepared batch ${batch.version} was superseded by version ${state.acceptedVersion}.`,
+				);
+			}
+			status = 'applying';
+			state.applying = true;
+			try {
+				mutationStarted = true;
+				state.records = plan.records;
+				state.teardownRecords = null;
+				state.rootChildren = plan.rootChildren;
+				for (let offset = 0; offset < plan.hostCount; offset++) {
+					const id = plan.firstId + offset;
+					if (!state.generations.has(id)) state.generations.set(id, 1);
+				}
+				state.acceptedVersion = batch.version;
+				let applicationFailed = false;
+				let applicationError: unknown;
+				try {
+					for (let index = 0; index < plan.eventCommands; index++) {
+						const command = batch.commands[index]!;
+						if (command.op !== 'event') throw hostError('certified teardown event changed.');
+						const node = plan.store.nodes[command.id - plan.firstId];
+						if (node === undefined) throw hostError('certified teardown node changed.');
+						removeNativeEvent(state, node, command.type);
+					}
+					const parent =
+						plan.parent === null ? container.page : plan.records.get(plan.parent)!.node!;
+					const width = plan.store.program.shape.types.length;
+					for (const id of plan.acceptedChildren) {
+						const offset = id - plan.firstId;
+						if (offset < 0 || offset >= plan.hostCount || offset % width !== 0) continue;
+						const node = plan.store.nodes[offset]!;
+						state.papi.remove(parent, node);
+					}
+					state.ownedNodes.clear();
+					for (const record of plan.records.values()) state.ownedNodes.add(record.node!);
+					if (plan.parent === null) {
+						state.ownedPageRoots.clear();
+						for (const record of plan.records.values()) {
+							if (record.parent === null) state.ownedPageRoots.add(record.node!);
+						}
+					}
+					plan.store.clear();
+				} catch (error) {
+					applicationFailed = true;
+					applicationError = error;
+				}
+				try {
+					state.papi.flush(container.page);
+					state.cleanupNeedsFlush = false;
+				} catch (error) {
+					state.cleanupNeedsFlush = true;
+					if (!applicationFailed) {
+						applicationFailed = true;
+						applicationError = error;
+					}
+				}
+				if (applicationFailed) throw applicationError;
+				status = 'applied';
+			} catch (error) {
+				state.faulted = true;
+				invalidateMainThreadLifetimesAfterFault(state);
+				status = 'faulted';
+				fault = error;
+				throw error;
+			} finally {
+				state.applying = false;
+			}
+		},
+		abort() {
+			if (status === 'prepared') status = 'aborted';
+		},
+	};
+	return Object.freeze(prepared);
 }
 
 export function prepareLynxHostBatch<Node extends LynxElementRef>(
@@ -3124,6 +3420,14 @@ export function prepareLynxHostBatch<Node extends LynxElementRef>(
 			'after a host fault, only listener removal and remove/destroy teardown commands are accepted.',
 		);
 	}
+	if (!logicalTeardown && firstTree === undefined) {
+		const teardownStore =
+			state.records instanceof LynxDenseHostRecordStore ? state.records : state.teardownRecords;
+		const denseTeardown = teardownStore?.prepareFullTeardown(state, batch) ?? null;
+		if (denseTeardown !== null) {
+			return prepareDenseTeardown(container, batch, state, denseTeardown);
+		}
+	}
 
 	const baseVersion = state.acceptedVersion;
 	const initiallyEmpty = state.records.size === 0;
@@ -3131,6 +3435,7 @@ export function prepareLynxHostBatch<Node extends LynxElementRef>(
 	// touched by this batch; the accepted maps remain unchanged until apply().
 	let stagedRecords: LynxHostRecordStore<Node> = new Map<number, LynxHostRecord<Node>>();
 	let acceptedDenseRecords: LynxDenseHostRecordStore<Node> | null = null;
+	let acceptedTeardownRecords: LynxDenseHostRecordStore<Node> | null = null;
 	const deletedRecords = new Set<number>();
 	const stagedGenerations = new Map<number, number>();
 	const initiallyNoGenerations = state.generations.size === 0;
@@ -3153,6 +3458,13 @@ export function prepareLynxHostBatch<Node extends LynxElementRef>(
 		options.incrementalCompact === true &&
 		acceptedLazyPublicInstances &&
 		!state.implicitInitialGenerations &&
+		state.records instanceof Map &&
+		batch.commands.length === 1 &&
+		batch.commands[0]?.op === 'mount-template-run';
+	const teardownMirrorCandidate =
+		options?.compact === true &&
+		options.incrementalCompact === true &&
+		acceptedLazyPublicInstances &&
 		state.records instanceof Map &&
 		batch.commands.length === 1 &&
 		batch.commands[0]?.op === 'mount-template-run';
@@ -3676,12 +3988,39 @@ export function prepareLynxHostBatch<Node extends LynxElementRef>(
 				if (command.before === null) siblings.push(rowFirstId);
 				else siblings.splice(beforeIndex++, 0, rowFirstId);
 			}
+			let teardownDense: LynxDenseHostRecordStore<Node> | undefined;
+			if (
+				teardownMirrorCandidate &&
+				command.op === 'mount-template-run' &&
+				command.before === null &&
+				!isPortalParent(parent) &&
+				(typeof parent !== 'number' || isRootConnected((id) => state.records.get(id), parent))
+			) {
+				const prefix = new Map(state.records as Map<number, LynxHostRecord<Node>>);
+				const finalId = command.firstId + hostCount - 1;
+				for (const [id, record] of stagedRecords) {
+					if (id < command.firstId || id > finalId) prefix.set(id, record);
+				}
+				teardownDense = new LynxDenseHostRecordStore(
+					prefix,
+					container.root,
+					program,
+					command.firstId,
+					count,
+					parent,
+					command.values,
+					command.firstListenerId,
+					templateRecords.map((record) => record.handle.generation),
+				);
+				acceptedTeardownRecords = teardownDense;
+			}
 			operations.push({
 				op: 'mount-template',
 				id: command.firstId,
 				parent,
 				before: command.before,
 				records: templateRecords,
+				...(teardownDense === undefined ? null : { teardownDense }),
 				patches: templatePatches,
 				parents: shape.parents,
 				...(count === 1 ? null : { count }),
@@ -4516,6 +4855,9 @@ export function prepareLynxHostBatch<Node extends LynxElementRef>(
 					for (const id of deletedRecords) state.records.delete(id);
 					for (const [id, record] of stagedRecords) state.records.set(id, record);
 				}
+				if (batch.commands.length !== 0) {
+					state.teardownRecords = acceptedTeardownRecords;
+				}
 				if (stagedRootChildren !== null) state.rootChildren = stagedRootChildren;
 				if (initiallyNoGenerations) {
 					state.generations = stagedGenerations;
@@ -4702,6 +5044,7 @@ export function prepareLynxHostBatch<Node extends LynxElementRef>(
 											);
 										}
 										record.node = node;
+										operation.teardownDense?.setNode(recordIndex, node);
 										if (
 											operation.lazyPublicInstances !== true ||
 											(compactHostCount === undefined && !acceptedLazyPublicInstances)
@@ -5431,6 +5774,7 @@ export function disposeLynxHostContainer<Node extends LynxElementRef>(
 		state.mainThreadRefOwners.clear();
 		state.lists.clear();
 		state.records.clear();
+		state.teardownRecords = null;
 		state.rootChildren.length = 0;
 		state.generations.clear();
 		state.portalRoot = null;

--- a/packages/lynx/tests/host-driver.test.ts
+++ b/packages/lynx/tests/host-driver.test.ts
@@ -3718,6 +3718,175 @@ describe('Lynx Element PAPI host driver', () => {
 		expect(papi.calls).toEqual([]);
 	});
 
+	it('retires a complete compact run without disturbing its shell, events, or generations', () => {
+		const { container, driver, page } = createHost(64);
+		const program: UniversalHostTemplateProgram = Object.freeze({
+			nodes: Object.freeze([
+				Object.freeze({ type: 'view', parent: -1, props: Object.freeze({ class: 'row' }) }),
+				Object.freeze({ type: 'text', parent: 0, props: Object.freeze({}) }),
+				Object.freeze({ type: '#text', parent: 1, props: Object.freeze({ value: 'ready' }) }),
+			]),
+			events: Object.freeze([
+				Object.freeze({ node: 0, type: 'bindtap', priority: 'default' as const }),
+			]),
+		});
+		prepareLynxHostBatch(
+			container,
+			batch(1, [
+				{ op: 'create', id: 1, type: 'view', props: { id: 'shell' } },
+				{ op: 'create', id: 2, type: 'view', props: { id: 'rows' } },
+				{
+					op: 'mount-template-run',
+					parent: 2,
+					before: null,
+					program,
+					firstId: 10,
+					firstListenerId: 100,
+					count: 2,
+					values: Object.freeze([]),
+				},
+				{ op: 'insert', parent: 1, id: 2, before: null },
+				{ op: 'insert', parent: null, id: 1, before: null },
+			]),
+			{ compact: true, lazyPublicInstances: true },
+		).apply();
+		const shell = page.children[0]!;
+		const rows = shell.children[0]!;
+		const first = rows.children[0]!;
+		const second = rows.children[1]!;
+		const firstEvent = first.events.get('bindEvent:tap')!;
+		const secondEvent = second.events.get('bindEvent:tap')!;
+		const teardownCommands: UniversalHostCommand[] = [
+			{ op: 'event', id: 10, type: 'bindtap', listener: null },
+			{ op: 'event', id: 13, type: 'bindtap', listener: null },
+			{ op: 'remove', parent: 2, id: 10 },
+			{ op: 'remove', parent: 2, id: 13 },
+			{ op: 'destroy', id: 12 },
+			{ op: 'destroy', id: 11 },
+			{ op: 'destroy', id: 10 },
+			{ op: 'destroy', id: 15 },
+			{ op: 'destroy', id: 14 },
+			{ op: 'destroy', id: 13 },
+		];
+
+		const abandoned = prepareLynxHostBatch(container, batch(2, teardownCommands));
+		abandoned.abort();
+		abandoned.apply();
+		expect(rows.children).toEqual([first, second]);
+		expect(resolveLynxHostNativeEvent(container, firstEvent)).toEqual({
+			listener: 100,
+			priority: 'default',
+		});
+
+		const teardown = prepareLynxHostBatch(container, batch(2, teardownCommands));
+		expect(teardown.handleDelta.map((delta) => (delta.op === 'destroy' ? delta.id : -1))).toEqual([
+			12, 11, 10, 15, 14, 13,
+		]);
+		teardown.apply();
+		expect(page.children).toEqual([shell]);
+		expect(shell.children).toEqual([rows]);
+		expect(rows.children).toEqual([]);
+		expect(first.events.size).toBe(0);
+		expect(second.events.size).toBe(0);
+		expect(resolveLynxHostNativeEvent(container, firstEvent)).toBeNull();
+		expect(resolveLynxHostNativeEvent(container, secondEvent)).toBeNull();
+		expect(container.instanceCount).toBe(2);
+		expect(driver.getPublicInstance(container, 10)).toBeNull();
+
+		const remount = prepareLynxHostBatch(
+			container,
+			batch(3, [
+				{
+					op: 'mount-template-run',
+					parent: 2,
+					before: null,
+					program,
+					firstId: 10,
+					firstListenerId: 200,
+					count: 2,
+					values: Object.freeze([]),
+				},
+			]),
+			{ compact: true, incrementalCompact: true, lazyPublicInstances: true },
+		);
+		expect(remount.compactHostCount).toBeUndefined();
+		remount.apply();
+		expect(rows.children).toHaveLength(2);
+		prepareLynxHostBatch(container, batch(4, [])).apply();
+		const repeatedTeardown = prepareLynxHostBatch(
+			container,
+			batch(5, [
+				{ op: 'event', id: 10, type: 'bindtap', listener: null },
+				{ op: 'event', id: 13, type: 'bindtap', listener: null },
+				{ op: 'remove', parent: 2, id: 10 },
+				{ op: 'remove', parent: 2, id: 13 },
+				{ op: 'destroy', id: 12 },
+				{ op: 'destroy', id: 11 },
+				{ op: 'destroy', id: 10 },
+				{ op: 'destroy', id: 15 },
+				{ op: 'destroy', id: 14 },
+				{ op: 'destroy', id: 13 },
+			]),
+		);
+		expect(
+			repeatedTeardown.handleDelta.every(
+				(delta) => delta.op === 'destroy' && delta.generation === 2,
+			),
+		).toBe(true);
+		repeatedTeardown.apply();
+		expect(rows.children).toEqual([]);
+
+		prepareLynxHostBatch(
+			container,
+			batch(6, [
+				{ op: 'create', id: 10, type: 'view', props: { id: 'replacement' } },
+				{ op: 'insert', parent: 2, id: 10, before: null },
+			]),
+		).apply();
+		expect(driver.getPublicInstance(container, 10)?.generation).toBe(3);
+		expect(rows.children.map((node) => node.id)).toEqual(['replacement']);
+	});
+
+	it('retains compact-run ownership for terminal cleanup when fast teardown faults', () => {
+		const { container, page, papi } = createHost(65);
+		const program: UniversalHostTemplateProgram = Object.freeze({
+			nodes: Object.freeze([Object.freeze({ type: 'view', parent: -1, props: Object.freeze({}) })]),
+			events: Object.freeze([]),
+		});
+		prepareLynxHostBatch(
+			container,
+			batch(1, [
+				{
+					op: 'mount-template-run',
+					parent: null,
+					before: null,
+					program,
+					firstId: 10,
+					firstListenerId: null,
+					count: 2,
+					values: Object.freeze([]),
+				},
+			]),
+			{ compact: true, lazyPublicInstances: true },
+		).apply();
+		const failure = new Error('fast teardown remove failed');
+		papi.failNext('remove', 'before', failure);
+		const teardown = prepareLynxHostBatch(
+			container,
+			batch(2, [
+				{ op: 'remove', parent: null, id: 10 },
+				{ op: 'remove', parent: null, id: 11 },
+				{ op: 'destroy', id: 10 },
+				{ op: 'destroy', id: 11 },
+			]),
+		);
+		expect(() => teardown.apply()).toThrow(failure);
+		expect(teardown.mutationStarted).toBe(true);
+		expect(container.acceptedVersion).toBe(2);
+		expect(disposeLynxHostContainer(container).complete).toBe(true);
+		expect(page.children).toEqual([]);
+	});
+
 	it('preserves compact generation tombstones across destroy, identity reuse, and recreation', () => {
 		const { container, driver, page } = createHost(41);
 		const program: UniversalHostTemplateProgram = Object.freeze({


### PR DESCRIPTION
## Summary

Specialize the Lynx host's complete teardown of a certified compact `mount-template-run`.

The current dense create path keeps first-mount host records lazy, but a 10k-row clear still validates and applies 100,000 teardown commands through the generic per-record path. On the attribution workload that meant 70,000 host records/event maps and put most of clear latency in host preparation/application.

This change retains a teardown-only dense certificate after an otherwise ordinary pure template run. A full clear may use it only after validating the complete event/remove/destroy stream, topology, generations, ownership, and absence of complex state. Mixed mutations, refs, lists, portals, main-thread props, native-list topology, or any mismatch remain on the existing generic path.

The fast path preserves synchronous PAPI removal/flush, native-event cleanup, destroy handle deltas and generations, terminal fault ownership, and the surrounding shell. It does not change the wire protocol or move cleanup past the measured boundary.

Tracks https://github.com/Huxpro/octane/issues/43.

## Exact provenance

- base: `octanejs/octane@9b147781c9b4ec4df053a059633978ddc0ed922a`
- candidate: `8d8883c8ba01fd6061afbf3fec43df11ebd8d465`
- host: 32-core Intel Xeon Platinum 8336C, Node 22.22.2, Chromium 149.0.7827.55
- neutral benchmark: `Huxpro/lynx-js-framework-benchmark`, byte-identical runner and production bundles for both entries

## Performance

Primary command (then repeated with entries reversed):

```sh
pnpm bench -- run \
  --entry octane-main,octane-issue43 \
  --case create,update10th,select,clear,updateStorm,selectStorm \
  --scale 0,1000,10000,30000 \
  --suite table,startup \
  --reps 7 --storm-reps 3 --startup-reps 5
```

| order | base clear@10k | candidate clear@10k | delta |
|---|---:|---:|---:|
| forward | 974.2 ±20.1 ms | 762.6 ±24.3 ms | **-21.7%** |
| reverse | 1050.7 ±55.2 ms | 720.0 ±30.1 ms | **-31.5%** |

No accepted adverse decision cell remained:

- create@1k/10k/30k order-balanced deltas: +2.7% / +0.8% / +1.0%
- storms: update improved in both orders at 10k and 30k; worst order-balanced select-storm cell was +3.6% at 30k
- the noisy n=7 update/select@10k cells were repeated at n=20 in both orders: update was -14.9% forward and -2.7% reverse; select was -5.1% forward and +2.1% reverse
- startup@0 was repeated at n=20 after the n=5 forward sample moved by about 4 ms: 50.0 → 50.5 ms (+1.2%); startup@30k was 5508.1 → 5527.1 ms (+0.3%)
- startup@1k/10k/30k in the original forward/reverse matrix stayed within +3.0%; candidate improved startup@10k in both orders

Raw result SHA-256:

- forward matrix: `90d4449a5a5274c2a21a825930a185c28da73d6ff5ddd06a04743ef0580d0789`
- reverse matrix: `97ac1b4aa346dfa39c95a9bbbc6b394ec8776159db6706caf96a782c5bd2e278`
- n=20 update/select forward: `6be4565a103f8fe6da38a7f2b6ac0d68b7b1b60e64b13981b827a7a87743aff7`
- n=20 update/select reverse: `d2eae84a155a0e935ac680bd6317ef91b7a5e64972970f72f6c643f868ea44ce`

## Attribution and cleanup gates

The final instrumented lifecycle used two create/clear warmups, explicit CDP GC, then measured create/clear/page close on fresh pages. Every candidate repetition recorded exactly:

- `denseFastTeardowns = 1`
- `denseFastTeardownHosts = 70,000`
- unchanged teardown wire work: 100,000 commands (20k event removals, 10k root removals, 70k destroys)

With the identical lifecycle:

| metric | base median | candidate median |
|---|---:|---:|
| clear@10k | 894.2 ms | 585.3 ms |
| held heap | 42,220,672 B | 42,218,772 B |
| post-clear residual | 25,595,760 B | 25,594,348 B |
| page-close → worker release | 7.5 ms | 6.5 ms |

All five baseline and candidate workers released. The final counter capture repeated the candidate three more times; every sample hit one 70,000-host teardown certificate, synchronously cleared, and released its worker.

## Bundle impact

Production bundle gzip at the benchmark's 10k build:

| bundle | base | candidate | delta |
|---|---:|---:|---:|
| Web gzip | 131,677 B | 133,489 B | +1.38% |
| Lynx gzip | 158,662 B | 160,965 B | +1.45% |

Both are below the 5% gate. `@octanejs/lynx` is private at `0.0.0`, so no changeset is applicable.

## Correctness and validation

Tests cover aborted preparation, exact shell/survivor identity, event removal, destroy-delta order, generation-2 repeated teardown and generation-3 ID reuse, empty-batch certificate preservation, and terminal cleanup after a fast-path PAPI fault. Removing the event cleanup assertion path made the new regression fail before it was restored.

Commands run:

```sh
pnpm --filter @octanejs/lynx test -- --silent=passed-only
# 24 files, 338 tests passed

pnpm typecheck:files packages/lynx/src/core/host-driver.ts
pnpm format:files:check packages/lynx/src/core/host-driver.ts packages/lynx/tests/host-driver.test.ts
node benchmarks/bench.mjs --only lynx-table --ratios
# 18 applicable guards passed
pnpm sync
```

The package-wide Lynx typecheck also reproduces the same existing `main-thread.ts:2197` acknowledgement-narrowing error on the exact clean base; the changed `host-driver.ts` scoped typecheck passes.

## Risk

The optimization is deliberately fail-closed. Certification walks and compares the exact accepted topology and teardown stream before mutation; any unsupported ownership or lifetime state falls back to the generic implementation. Once application begins, failures retain terminal cleanup ownership and still attempt the required flush, matching the existing accepted-fault contract.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8d8883c8ba01fd6061afbf3fec43df11ebd8d465. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->