### PR TITLE
perf(lynx): keep optional worklet runtime cold

### DIFF
--- a/.changeset/cold-lynx-worklets.md
+++ b/.changeset/cold-lynx-worklets.md
@@ -1,0 +1,8 @@
+---
+'octane': patch
+'@octanejs/rspack-plugin': patch
+---
+
+Allow universal renderers to route compiler-emitted thread-function helpers through an optional cold runtime module.
+
+Lynx now uses that boundary to omit main-thread worklet registries and call bridges from applications that compile no worklets, while retaining late-chunk activation and the existing worklet-enabled behavior.

--- a/benchmarks/lynx-bundle-size/run.mjs
+++ b/benchmarks/lynx-bundle-size/run.mjs
@@ -43,6 +43,16 @@ const PREVIEW_RECEIVER_NAME = 'main__preview_receiver';
 const BUNDLE_NAME = 'main.lynx.bundle';
 const FORBIDDEN_RUNTIME = /(?:^|[^$\w])(?:react|react-dom|preact|ReactLynx)(?:[^$\w]|$)/i;
 const FORBIDDEN_DOM = /\b(?:document|window|HTMLElement|MutationObserver)\b/;
+// Frozen from upstream main 9b147781. The main caps are the largest integer
+// values that still prove the issue's >=2% gzip reduction. The background
+// program has no source change; its raw-byte budget prevents optional worklet
+// code from leaking onto that thread while tolerating minifier-symbol changes
+// caused by the independently optimized main graph.
+const NO_WORKLET_BUDGET = Object.freeze({
+	previewMainGzip: 75_376,
+	ifrMainGzip: 80_355,
+	backgroundRaw: 271_737,
+});
 
 function packageEntry(packageName) {
 	const packageRoot = path.join(RSPEEDY_MODULES, ...packageName.split('/'));
@@ -378,6 +388,18 @@ try {
 			`preview and IFR ${operation} differ`,
 		);
 	}
+	gate(
+		preview.ops.main_gzip.score <= NO_WORKLET_BUDGET.previewMainGzip,
+		`preview main gzip ${preview.ops.main_gzip.score} exceeds ${NO_WORKLET_BUDGET.previewMainGzip}`,
+	);
+	gate(
+		ifr.ops.main_gzip.score <= NO_WORKLET_BUDGET.ifrMainGzip,
+		`IFR main gzip ${ifr.ops.main_gzip.score} exceeds ${NO_WORKLET_BUDGET.ifrMainGzip}`,
+	);
+	gate(
+		preview.ops.background_raw.score === NO_WORKLET_BUDGET.backgroundRaw,
+		`background raw ${preview.ops.background_raw.score} differs from ${NO_WORKLET_BUDGET.backgroundRaw}`,
+	);
 } catch (error) {
 	failed = error instanceof Error ? error.stack || error.message : String(error);
 	console.error(failed);

--- a/packages/lynx/package.json
+++ b/packages/lynx/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "type": "module",
   "sideEffects": [
-    "./src/core/worklets.ts"
+    "./src/core/worklets.ts",
+    "./src/main-worklets.ts"
   ],
   "engines": {
     "node": ">=22.22.2"

--- a/packages/lynx/package.json
+++ b/packages/lynx/package.json
@@ -42,6 +42,7 @@
     },
     "./renderer": "./src/renderer.ts",
     "./main-renderer": "./src/main-renderer.ts",
+    "./main-worklets": "./src/main-worklets.ts",
     "./first-screen": "./src/first-screen.ts",
     "./intrinsics": "./src/intrinsics.ts",
     "./intrinsics/jsx-runtime": "./src/intrinsics.ts",

--- a/packages/lynx/src/config.runtime.js
+++ b/packages/lynx/src/config.runtime.js
@@ -227,6 +227,7 @@ export const lynxBackgroundRenderer = {
 /** Main-thread renderer that rejects APIs owned by the background runtime. */
 export const lynxMainThreadRenderer = {
 	module: '@octanejs/lynx/main-renderer',
+	threadFunctionsModule: '@octanejs/lynx/main-worklets',
 	target: 'universal',
 	server: 'unsupported',
 	intrinsics: '@octanejs/lynx/intrinsics',

--- a/packages/lynx/src/config.ts
+++ b/packages/lynx/src/config.ts
@@ -229,6 +229,7 @@ export const lynxBackgroundRenderer = {
 /** Main-thread renderer that rejects APIs owned by the background runtime. */
 export const lynxMainThreadRenderer = {
 	module: '@octanejs/lynx/main-renderer',
+	threadFunctionsModule: '@octanejs/lynx/main-worklets',
 	target: 'universal',
 	server: 'unsupported',
 	intrinsics: '@octanejs/lynx/intrinsics',

--- a/packages/lynx/src/core/first-screen-host.ts
+++ b/packages/lynx/src/core/first-screen-host.ts
@@ -1,0 +1,41 @@
+import type { UniversalComponent } from 'octane/universal/native';
+import type { LynxFirstScreenRenderResult } from '../main-renderer.js';
+
+/** Main-thread root contract installed by the generated receiver entry. */
+export interface LynxFirstScreenHost {
+	/** Null means the background owns the page without adopting a synchronous tree. */
+	render<Props>(
+		component: UniversalComponent<Props>,
+		props: Props,
+	): LynxFirstScreenRenderResult | null;
+	markSyncReady(): void;
+	unmount(): void;
+}
+
+let installedHost: LynxFirstScreenHost | null = null;
+
+export function installLynxFirstScreenHost(host: LynxFirstScreenHost): () => void {
+	if (installedHost !== null) {
+		throw new Error('A Lynx first-screen host is already installed for this entry.');
+	}
+	installedHost = host;
+	let active = true;
+	return () => {
+		if (!active) return;
+		active = false;
+		if (installedHost === host) installedHost = null;
+	};
+}
+
+export function currentLynxFirstScreenHost(): LynxFirstScreenHost | null {
+	return installedHost;
+}
+
+export function requireLynxFirstScreenHost(): LynxFirstScreenHost {
+	if (installedHost === null) {
+		throw new Error(
+			'Lynx first-screen root rendered before the generated main-thread receiver was installed.',
+		);
+	}
+	return installedHost;
+}

--- a/packages/lynx/src/core/main-thread-worklet-feature.ts
+++ b/packages/lynx/src/core/main-thread-worklet-feature.ts
@@ -1,0 +1,156 @@
+import type {
+	CreateLynxMainThreadWorkletRegistryOptions,
+	LynxActivatedMainThreadWorklet,
+	LynxBackgroundFunctionDescriptor,
+	LynxMainThreadCallBridge,
+	LynxMainThreadRefCell,
+	LynxMainThreadRefDescriptor,
+	LynxMainThreadWorkletDescriptor,
+	LynxMainThreadWorkletRegistry,
+	LynxWorkletValue,
+} from './worklets.js';
+
+/**
+ * The receiver-facing half of optional main-thread worklet support.
+ *
+ * This module deliberately has no value import from `worklets.ts`. Compiled
+ * thread-function helpers provide the full feature from `main-worklets.ts`;
+ * an application that emits none keeps only this small capability seam.
+ */
+export interface LynxMainThreadWorkletFeature {
+	createRegistry(
+		options: CreateLynxMainThreadWorkletRegistryOptions,
+	): LynxMainThreadWorkletRegistry;
+	installRegistry(registry: LynxMainThreadWorkletRegistry): () => void;
+	installCallBridge(bridge: LynxMainThreadCallBridge): () => void;
+	isolateValue<T extends LynxWorkletValue>(value: T, label?: string): T;
+	isBackgroundFunction(value: unknown): value is LynxBackgroundFunctionDescriptor;
+}
+
+type FeatureSubscriber = (feature: LynxMainThreadWorkletFeature) => void;
+
+let providedFeature: LynxMainThreadWorkletFeature | null = null;
+const subscribers = new Set<FeatureSubscriber>();
+
+/** Compiler-emitted worklet helpers provide one process-wide implementation. */
+export function provideLynxMainThreadWorkletFeature(feature: LynxMainThreadWorkletFeature): void {
+	if (providedFeature === feature) return;
+	if (providedFeature !== null) {
+		throw new Error('Octane Lynx main-thread worklet feature was provided twice.');
+	}
+	providedFeature = feature;
+	for (const subscriber of subscribers) subscriber(feature);
+}
+
+/** Receivers subscribe before authored modules evaluate, so static or late features can attach. */
+export function subscribeLynxMainThreadWorkletFeature(subscriber: FeatureSubscriber): () => void {
+	subscribers.add(subscriber);
+	try {
+		if (providedFeature !== null) subscriber(providedFeature);
+	} catch (error) {
+		subscribers.delete(subscriber);
+		throw error;
+	}
+	return () => subscribers.delete(subscriber);
+}
+
+function unavailable(): never {
+	throw new Error(
+		'Octane Lynx received main-thread worklet state, but this bundle compiled no worklet feature.',
+	);
+}
+
+/**
+ * Keep the ordinary receiver's publication calls direct and monomorphic when
+ * the optional feature is absent. Only worklet-specific operations reject.
+ */
+export function createUnavailableLynxMainThreadWorkletRegistry(): LynxMainThreadWorkletRegistry {
+	return Object.freeze({
+		activate(_descriptor: LynxMainThreadWorkletDescriptor): LynxActivatedMainThreadWorklet {
+			return unavailable();
+		},
+		release(_descriptorOrToken: LynxActivatedMainThreadWorklet | number): void {},
+		runWorklet(
+			_descriptor: LynxMainThreadWorkletDescriptor,
+			_params?: readonly unknown[],
+		): unknown {
+			return unavailable();
+		},
+		beginRefOwnerPublication(): void {},
+		finishRefOwnerPublication(): void {},
+		retainRef<T>(
+			_descriptor: LynxMainThreadRefDescriptor,
+			_initialValue: T,
+		): LynxMainThreadRefCell<T> {
+			return unavailable();
+		},
+		updateRef<T>(_descriptor: LynxMainThreadRefDescriptor, _value: T): void {
+			unavailable();
+		},
+		releaseRef(_descriptor: LynxMainThreadRefDescriptor): void {},
+		retainOwner(_descriptor: LynxMainThreadRefDescriptor): LynxMainThreadRefCell {
+			return unavailable();
+		},
+		releaseOwner(_descriptor: LynxMainThreadRefDescriptor): void {},
+		releaseOwners(): void {},
+		isActive(_descriptorOrToken: LynxActivatedMainThreadWorklet | number): boolean {
+			return false;
+		},
+		close(): void {},
+	});
+}
+
+export interface LynxReplaceableMainThreadWorkletRegistry extends LynxMainThreadWorkletRegistry {
+	replace(registry: LynxMainThreadWorkletRegistry): void;
+}
+
+/** Existing host containers keep this stable identity when a late chunk enables worklets. */
+export function createReplaceableLynxMainThreadWorkletRegistry(
+	initial: LynxMainThreadWorkletRegistry,
+): LynxReplaceableMainThreadWorkletRegistry {
+	let current = initial;
+	return Object.freeze({
+		replace(registry: LynxMainThreadWorkletRegistry) {
+			current = registry;
+		},
+		activate(descriptor: LynxMainThreadWorkletDescriptor) {
+			return current.activate(descriptor);
+		},
+		release(descriptorOrToken: LynxActivatedMainThreadWorklet | number) {
+			current.release(descriptorOrToken);
+		},
+		runWorklet(descriptor: LynxMainThreadWorkletDescriptor, params?: readonly unknown[]) {
+			return current.runWorklet(descriptor, params);
+		},
+		beginRefOwnerPublication() {
+			current.beginRefOwnerPublication();
+		},
+		finishRefOwnerPublication() {
+			current.finishRefOwnerPublication();
+		},
+		retainRef<T>(descriptor: LynxMainThreadRefDescriptor, initialValue: T) {
+			return current.retainRef(descriptor, initialValue);
+		},
+		updateRef<T>(descriptor: LynxMainThreadRefDescriptor, value: T) {
+			current.updateRef(descriptor, value);
+		},
+		releaseRef(descriptor: LynxMainThreadRefDescriptor) {
+			current.releaseRef(descriptor);
+		},
+		retainOwner(descriptor: LynxMainThreadRefDescriptor) {
+			return current.retainOwner(descriptor);
+		},
+		releaseOwner(descriptor: LynxMainThreadRefDescriptor) {
+			current.releaseOwner(descriptor);
+		},
+		releaseOwners() {
+			current.releaseOwners();
+		},
+		isActive(descriptorOrToken: LynxActivatedMainThreadWorklet | number) {
+			return current.isActive(descriptorOrToken);
+		},
+		close() {
+			current.close();
+		},
+	});
+}

--- a/packages/lynx/src/first-screen.ts
+++ b/packages/lynx/src/first-screen.ts
@@ -1,47 +1,14 @@
 import type { UniversalComponent } from 'octane/universal/native';
 import type { LynxComponent } from './intrinsics.js';
 import type { LynxFirstScreenRenderResult } from './main-renderer.js';
+import {
+	currentLynxFirstScreenHost,
+	installLynxFirstScreenHost,
+	requireLynxFirstScreenHost,
+	type LynxFirstScreenHost,
+} from './core/first-screen-host.js';
 
-/** Main-thread root contract installed by the generated receiver entry. */
-export interface LynxFirstScreenHost {
-	/**
-	 * Returns null when no synchronous first screen was painted: either the
-	 * receiver deferred rendering to the engine lifecycle, or it declined a
-	 * rendered screen the background cannot adopt. Both mean the background owns
-	 * the page; neither reports a fault.
-	 */
-	render<Props>(
-		component: UniversalComponent<Props>,
-		props: Props,
-	): LynxFirstScreenRenderResult | null;
-	markSyncReady(): void;
-	unmount(): void;
-}
-
-let installedHost: LynxFirstScreenHost | null = null;
-
-/** @internal Connect the application facade to its entry-owned PAPI receiver. */
-export function installLynxFirstScreenHost(host: LynxFirstScreenHost): () => void {
-	if (installedHost !== null) {
-		throw new Error('A Lynx first-screen host is already installed for this entry.');
-	}
-	installedHost = host;
-	let active = true;
-	return () => {
-		if (!active) return;
-		active = false;
-		if (installedHost === host) installedHost = null;
-	};
-}
-
-function requireHost(): LynxFirstScreenHost {
-	if (installedHost === null) {
-		throw new Error(
-			'Lynx first-screen root rendered before the generated main-thread receiver was installed.',
-		);
-	}
-	return installedHost;
-}
+export { installLynxFirstScreenHost, type LynxFirstScreenHost };
 
 export interface LynxFirstScreenRoot {
 	readonly renderer: 'lynx';
@@ -62,7 +29,7 @@ export const root: LynxFirstScreenRoot = Object.freeze({
 		if (typeof component !== 'function') {
 			throw new TypeError('Lynx first-screen root.render() requires a component function.');
 		}
-		return requireHost().render(
+		return requireLynxFirstScreenHost().render(
 			component as UniversalComponent<Props>,
 			props === undefined ? ({} as Props) : props,
 		);
@@ -71,7 +38,7 @@ export const root: LynxFirstScreenRoot = Object.freeze({
 		return ready;
 	},
 	unmount() {
-		if (installedHost !== null) installedHost.unmount();
+		currentLynxFirstScreenHost()?.unmount();
 		return ready;
 	},
 });
@@ -83,7 +50,7 @@ export function createLynxRoot(): LynxFirstScreenRoot {
 
 /** Release a receiver configured for manual first-screen synchronization. */
 export function markFirstScreenSyncReady(): void {
-	requireHost().markSyncReady();
+	requireLynxFirstScreenHost().markSyncReady();
 }
 
 export const lynxRootAvailability = {
@@ -98,12 +65,12 @@ export const lynxRootAvailability = {
 export { createLynxNativeResource } from './resource.js';
 export type { LynxNativeResource } from './resource.js';
 export { LynxNodesRefError } from './core/nodes-ref.js';
-export { useMainThreadRef } from './main-renderer.js';
 export {
+	useMainThreadRef,
 	runOnBackground,
 	runOnMainThread,
 	LynxCrossThreadCallCancelledError,
-} from './core/worklets.js';
+} from './main-worklets.js';
 export type {
 	LynxBackgroundFunctionDescriptor,
 	LynxCancelablePromise,
@@ -111,8 +78,7 @@ export type {
 	LynxMainThreadRefDescriptor,
 	LynxMainThreadWorkletDescriptor,
 	LynxWorkletValue,
-} from './core/worklets.js';
-
+} from './main-worklets.js';
 export type {
 	LynxCustomIntrinsicElements,
 	LynxElements,

--- a/packages/lynx/src/main-renderer.ts
+++ b/packages/lynx/src/main-renderer.ts
@@ -21,24 +21,6 @@ import type {
 	UniversalRenderContext,
 } from 'octane/universal/native';
 import { isLynxNativeResource } from './resource.js';
-import { createLynxMainThreadRefDescriptor, type LynxMainThreadRefCell } from './core/worklets.js';
-
-export {
-	attachThreadFunction,
-	bindThreadFunction,
-	invokeThreadFunction,
-	registerThreadFunction,
-	runOnBackground,
-	runOnMainThread,
-	unregisterThreadFunction,
-} from './core/worklets.js';
-export type {
-	LynxBackgroundFunctionDescriptor,
-	LynxCancelablePromise,
-	LynxMainThreadRefDescriptor,
-	LynxMainThreadWorkletDescriptor,
-	LynxWorkletValue,
-} from './core/worklets.js';
 
 const UNIVERSAL_PLAN = Symbol.for('octane.universal.plan');
 const UNIVERSAL_VALUE = Symbol.for('octane.universal.value');
@@ -1158,25 +1140,6 @@ export function useId(_slot?: unknown): string {
 	const sum = 1 + index;
 	const paired = (sum * (sum + 1)) / 2 + index;
 	return `:octane-u${paired.toString(36)}:`;
-}
-
-/** Create the same deterministic main-thread cell as the background specialization. */
-export function useMainThreadRef<T>(initialValue: T): LynxMainThreadRefCell<T>;
-export function useMainThreadRef<T = undefined>(): LynxMainThreadRefCell<T | undefined>;
-export function useMainThreadRef<T>(
-	initialValueOrSlot?: T | unknown,
-	slot?: unknown,
-): LynxMainThreadRefCell<T | undefined> {
-	const hasInitialValue = arguments.length > 1 || typeof initialValueOrSlot !== 'symbol';
-	const resolvedSlot =
-		arguments.length > 1 ? slot : hasInitialValue ? undefined : initialValueOrSlot;
-	const initialValue = hasInitialValue ? (initialValueOrSlot as T) : undefined;
-	const id = useId(resolvedSlot);
-	return useMemo(
-		() => createLynxMainThreadRefDescriptor(`octane:${id}`, initialValue),
-		[],
-		'main-thread-ref-descriptor',
-	) as LynxMainThreadRefCell<T | undefined>;
 }
 
 export function useSyncExternalStore<T>(

--- a/packages/lynx/src/main-thread.ts
+++ b/packages/lynx/src/main-thread.ts
@@ -83,15 +83,13 @@ import {
 import { createLynxElementPAPI, type LynxElementPAPI, type LynxElementRef } from './core/papi.js';
 import { LYNX_PROFILE, lynxWireProfile } from './core/profiling.js';
 import {
-	createLynxMainThreadWorkletRegistry,
-	installLynxMainThreadWorkletRegistry,
-	installMainThreadCallBridge,
-	isLynxBackgroundFunctionDescriptor,
-	isolateLynxWorkletValue,
-	type LynxMainThreadWorkletRegistry,
-	type LynxWorkletValue,
-} from './core/worklets.js';
-import { installLynxFirstScreenHost } from './first-screen.js';
+	createReplaceableLynxMainThreadWorkletRegistry,
+	createUnavailableLynxMainThreadWorkletRegistry,
+	subscribeLynxMainThreadWorkletFeature,
+	type LynxMainThreadWorkletFeature,
+} from './core/main-thread-worklet-feature.js';
+import type { LynxMainThreadWorkletRegistry, LynxWorkletValue } from './core/worklets.js';
+import { installLynxFirstScreenHost } from './core/first-screen-host.js';
 import { renderLynxFirstScreen, type LynxFirstScreenRenderResult } from './main-renderer.js';
 
 interface LynxMainThreadGlobals {
@@ -607,8 +605,11 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 	let nextThreadCall = 1;
 	let uninstallWorkletRegistry: (() => void) | null = null;
 	let uninstallCallBridge: (() => void) | null = null;
+	let unsubscribeWorkletFeature: (() => void) | null = null;
 	let restoreHostHooks: (() => void) | null = null;
-	let worklets: LynxMainThreadWorkletRegistry;
+	let workletFeature: LynxMainThreadWorkletFeature | null = null;
+	let worklets: LynxMainThreadWorkletRegistry = createUnavailableLynxMainThreadWorkletRegistry();
+	const hostWorklets = createReplaceableLynxMainThreadWorkletRegistry(worklets);
 	let mainCallPublication: UniversalTransportIdentity | null = null;
 	let nativeDestroyListenerRegistered = false;
 	let nativeDestroyReceived = false;
@@ -625,6 +626,12 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 			);
 		}
 		return error;
+	};
+	const requireWorkletFeature = (): LynxMainThreadWorkletFeature => {
+		if (workletFeature !== null) return workletFeature;
+		throw new Error(
+			'Octane Lynx received main-thread worklet traffic, but this bundle compiled no worklet feature.',
+		);
 	};
 	// Replaced with the terminal page-lifetime path before any host listener is
 	// registered. The bootstrap fallback only protects unexpected early reentry.
@@ -861,7 +868,7 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 		if (message.type === 'call-background-result') {
 			try {
 				entry.deferred.resolve(
-					isolateLynxWorkletValue(
+					requireWorkletFeature().isolateValue(
 						message.value as LynxWorkletValue,
 						'background call result',
 					) as UniversalSerializableValue,
@@ -962,7 +969,7 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 				runningMainCalls.delete(message.call);
 				running.release();
 				try {
-					const isolated = isolateLynxWorkletValue(
+					const isolated = requireWorkletFeature().isolateValue(
 						value as LynxWorkletValue,
 						'main-thread call result',
 					);
@@ -1064,14 +1071,15 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 			deferred.reject(new Error('Octane Lynx background call identity space is exhausted.'));
 			return Object.freeze({ promise: deferred.promise, cancel() {} });
 		}
-		const isolatedFn = isolateLynxWorkletValue(
+		const feature = requireWorkletFeature();
+		const isolatedFn = feature.isolateValue(
 			fn as LynxWorkletValue,
 			'background function call target',
 		);
-		if (!isLynxBackgroundFunctionDescriptor(isolatedFn)) {
+		if (!feature.isBackgroundFunction(isolatedFn)) {
 			throw new TypeError('Octane Lynx background function call target is invalid.');
 		}
-		const isolatedArgs = isolateLynxWorkletValue(
+		const isolatedArgs = feature.isolateValue(
 			args as unknown as LynxWorkletValue[],
 			'background function call arguments',
 		);
@@ -1104,14 +1112,56 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 		});
 	};
 
-	worklets = createLynxMainThreadWorkletRegistry({
-		callBackground(fn, args) {
-			return callBackground(
-				fn as LynxBackgroundFunctionWireDescriptor,
-				args as readonly UniversalSerializableValue[],
-			).promise;
-		},
-	});
+	const installWorkletFeature = (feature: LynxMainThreadWorkletFeature): void => {
+		if (workletFeature === feature) return;
+		if (workletFeature !== null) {
+			throw new Error('Octane Lynx main-thread receiver changed worklet features after install.');
+		}
+		const registry = feature.createRegistry({
+			callBackground(fn, args) {
+				return callBackground(
+					fn as LynxBackgroundFunctionWireDescriptor,
+					args as readonly UniversalSerializableValue[],
+				).promise;
+			},
+		});
+		let uninstallRegistry: (() => void) | null = null;
+		let uninstallBridge: (() => void) | null = null;
+		try {
+			uninstallRegistry = feature.installRegistry(registry);
+			uninstallBridge = feature.installCallBridge({
+				callBackground<Result>(
+					fn: import('./core/worklets.js').LynxBackgroundFunctionDescriptor,
+					args: readonly import('./core/worklets.js').LynxWorkletValue[],
+				) {
+					const call = callBackground(
+						fn as LynxBackgroundFunctionWireDescriptor,
+						args as readonly UniversalSerializableValue[],
+					);
+					return {
+						promise: call.promise as Promise<Result>,
+						cancel: call.cancel,
+					};
+				},
+			});
+			workletFeature = feature;
+			worklets = registry;
+			hostWorklets.replace(registry);
+			uninstallWorkletRegistry = uninstallRegistry;
+			uninstallCallBridge = uninstallBridge;
+		} catch (error) {
+			uninstallBridge?.();
+			uninstallRegistry?.();
+			registry.close();
+			throw error;
+		}
+	};
+	const uninstallWorkletFeature = (): void => {
+		uninstallCallBridge?.();
+		uninstallCallBridge = null;
+		uninstallWorkletRegistry?.();
+		uninstallWorkletRegistry = null;
+	};
 	const hostGlobals = rawTarget as Record<string, unknown>;
 	const previousRunWorklet = hostGlobals.runWorklet;
 	// Captured before the wrapper is installed, because installing it creates an
@@ -1189,6 +1239,14 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 		descriptor: import('./core/worklets.js').LynxMainThreadWorkletDescriptor,
 		args?: readonly unknown[],
 	) => {
+		if (workletFeature === null) {
+			report(
+				new Error(
+					'Octane Lynx host dispatched a main-thread worklet, but this bundle compiled none.',
+				),
+			);
+			return undefined;
+		}
 		hostDispatchDepth++;
 		try {
 			return worklets.runWorklet(descriptor, args);
@@ -1210,31 +1268,15 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 		else hostGlobals.runWorklet = previousRunWorklet;
 	};
 	try {
-		uninstallWorkletRegistry = installLynxMainThreadWorkletRegistry(worklets);
-		uninstallCallBridge = installMainThreadCallBridge({
-			callBackground<Result>(
-				fn: import('./core/worklets.js').LynxBackgroundFunctionDescriptor,
-				args: readonly import('./core/worklets.js').LynxWorkletValue[],
-			) {
-				const call = callBackground(
-					fn as LynxBackgroundFunctionWireDescriptor,
-					args as readonly UniversalSerializableValue[],
-				);
-				return {
-					promise: call.promise as Promise<Result>,
-					cancel: call.cancel,
-				};
-			},
-		});
+		unsubscribeWorkletFeature = subscribeLynxMainThreadWorkletFeature(installWorkletFeature);
 		hostGlobals.runWorklet = installedRunWorklet;
 		hostGlobals.__FlushElementTree = installedFlush;
 	} catch (error) {
 		restoreHostHooks?.();
 		restoreHostHooks = null;
-		uninstallCallBridge?.();
-		uninstallCallBridge = null;
-		uninstallWorkletRegistry?.();
-		uninstallWorkletRegistry = null;
+		uninstallWorkletFeature();
+		unsubscribeWorkletFeature?.();
+		unsubscribeWorkletFeature = null;
 		worklets.close();
 		throw error;
 	}
@@ -1442,13 +1484,13 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 	};
 
 	const forceCloseWorkletRuntime = (): void => {
+		unsubscribeWorkletFeature?.();
+		unsubscribeWorkletFeature = null;
 		restoreHostHooks?.();
 		restoreHostHooks = null;
-		uninstallCallBridge?.();
-		uninstallCallBridge = null;
-		uninstallWorkletRegistry?.();
-		uninstallWorkletRegistry = null;
+		uninstallWorkletFeature();
 		worklets.close();
+		workletFeature = null;
 	};
 
 	const closeWorkletRuntime = (): boolean => {
@@ -1854,7 +1896,7 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 			source = createLynxHostContainer(papi, {
 				root: FIRST_SCREEN_ROOT_ID,
 				page,
-				worklets,
+				worklets: hostWorklets,
 			});
 			const prepared = prepareLynxHostBatch(source, result.batch);
 			prepared.apply();
@@ -2073,7 +2115,7 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 					container: createLynxHostContainer(papi, {
 						root: message.root,
 						page,
-						worklets,
+						worklets: hostWorklets,
 						onAttachments: submitHostAttachments,
 						onCallbackFault: failAcceptedRoot,
 					}),
@@ -2711,14 +2753,3 @@ export function installLynxMainThread<Node extends LynxElementRef = LynxElementR
 	};
 	return Object.freeze(controller);
 }
-
-export {
-	runOnBackground,
-	runOnMainThread,
-	LynxCrossThreadCallCancelledError,
-} from './core/worklets.js';
-export type {
-	LynxBackgroundFunctionDescriptor,
-	LynxCancelablePromise,
-	LynxMainThreadWorkletDescriptor,
-} from './core/worklets.js';

--- a/packages/lynx/src/main-worklets.ts
+++ b/packages/lynx/src/main-worklets.ts
@@ -1,0 +1,62 @@
+import { provideLynxMainThreadWorkletFeature } from './core/main-thread-worklet-feature.js';
+import {
+	createLynxMainThreadRefDescriptor,
+	createLynxMainThreadWorkletRegistry,
+	installLynxMainThreadWorkletRegistry,
+	installMainThreadCallBridge,
+	isLynxBackgroundFunctionDescriptor,
+	isolateLynxWorkletValue,
+	type LynxMainThreadRefCell,
+} from './core/worklets.js';
+import { useId, useMemo } from './main-renderer.js';
+
+const MAIN_THREAD_WORKLET_FEATURE = Object.freeze({
+	createRegistry: createLynxMainThreadWorkletRegistry,
+	installRegistry: installLynxMainThreadWorkletRegistry,
+	installCallBridge: installMainThreadCallBridge,
+	isolateValue: isolateLynxWorkletValue,
+	isBackgroundFunction: isLynxBackgroundFunctionDescriptor,
+});
+
+// This module is reachable only when the compiler or authored source retains a
+// worklet helper. The receiver is already installed first and subscribes to
+// this capability, so provision also supports authored and late chunks.
+provideLynxMainThreadWorkletFeature(MAIN_THREAD_WORKLET_FEATURE);
+
+/** Create the same deterministic main-thread cell as the background specialization. */
+export function useMainThreadRef<T>(initialValue: T): LynxMainThreadRefCell<T>;
+export function useMainThreadRef<T = undefined>(): LynxMainThreadRefCell<T | undefined>;
+export function useMainThreadRef<T>(
+	initialValueOrSlot?: T | unknown,
+	slot?: unknown,
+): LynxMainThreadRefCell<T | undefined> {
+	const hasInitialValue = arguments.length > 1 || typeof initialValueOrSlot !== 'symbol';
+	const resolvedSlot =
+		arguments.length > 1 ? slot : hasInitialValue ? undefined : initialValueOrSlot;
+	const initialValue = hasInitialValue ? (initialValueOrSlot as T) : undefined;
+	const id = useId(resolvedSlot);
+	return useMemo(
+		() => createLynxMainThreadRefDescriptor(`octane:${id}`, initialValue),
+		[],
+		'main-thread-ref-descriptor',
+	) as LynxMainThreadRefCell<T | undefined>;
+}
+
+export {
+	attachThreadFunction,
+	bindThreadFunction,
+	invokeThreadFunction,
+	registerThreadFunction,
+	runOnBackground,
+	runOnMainThread,
+	unregisterThreadFunction,
+	LynxCrossThreadCallCancelledError,
+} from './core/worklets.js';
+export type {
+	LynxBackgroundFunctionDescriptor,
+	LynxCancelablePromise,
+	LynxMainThreadRefCell,
+	LynxMainThreadRefDescriptor,
+	LynxMainThreadWorkletDescriptor,
+	LynxWorkletValue,
+} from './core/worklets.js';

--- a/packages/lynx/tests/main-thread-events.test.ts
+++ b/packages/lynx/tests/main-thread-events.test.ts
@@ -9,6 +9,7 @@ import {
 	type UniversalHostCommand,
 } from 'octane/universal/native';
 import { afterEach, describe, expect, it } from 'vitest';
+import '../src/main-worklets.js';
 import { createLynxRoot, type LynxPublicHandle, type LynxRoot } from '../src/index.js';
 import { installLynxMainThread, type LynxMainThreadController } from '../src/main-thread.js';
 import {

--- a/packages/lynx/tests/main-thread-worklet-feature.test.ts
+++ b/packages/lynx/tests/main-thread-worklet-feature.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+	createReplaceableLynxMainThreadWorkletRegistry,
+	createUnavailableLynxMainThreadWorkletRegistry,
+	provideLynxMainThreadWorkletFeature,
+	subscribeLynxMainThreadWorkletFeature,
+	type LynxMainThreadWorkletFeature,
+} from '../src/core/main-thread-worklet-feature.js';
+import type { LynxMainThreadWorkletRegistry } from '../src/core/worklets.js';
+
+describe.sequential('optional Lynx main-thread worklet feature', () => {
+	it('notifies a receiver that subscribes before a late feature chunk evaluates', () => {
+		const observed: LynxMainThreadWorkletFeature[] = [];
+		const feature = Object.freeze({}) as LynxMainThreadWorkletFeature;
+		const unsubscribe = subscribeLynxMainThreadWorkletFeature((value) => observed.push(value));
+
+		expect(observed).toEqual([]);
+		provideLynxMainThreadWorkletFeature(feature);
+		expect(observed).toEqual([feature]);
+
+		unsubscribe();
+	});
+
+	it('upgrades existing host containers through one stable registry identity', () => {
+		const unavailable = createUnavailableLynxMainThreadWorkletRegistry();
+		const registry = createReplaceableLynxMainThreadWorkletRegistry(unavailable);
+		const close = vi.fn();
+		const replacement = { ...unavailable, close } as LynxMainThreadWorkletRegistry;
+
+		expect(registry.isActive(1)).toBe(false);
+		registry.replace(replacement);
+		registry.close();
+
+		expect(close).toHaveBeenCalledOnce();
+	});
+});

--- a/packages/lynx/tests/milestone-7-integration.test.ts
+++ b/packages/lynx/tests/milestone-7-integration.test.ts
@@ -24,6 +24,7 @@ import {
 	type LynxContextProxy,
 } from '../src/core/protocol.js';
 import * as firstScreenApi from '../src/first-screen.js';
+import * as mainWorkletApi from '../src/main-worklets.js';
 import * as rootApi from '../src/index.js';
 import * as mainRenderer from '../src/main-renderer.js';
 import { installLynxMainThread, type LynxMainThreadController } from '../src/main-thread.js';
@@ -287,6 +288,7 @@ function installEnvironment(
 	prepareMainThread?.(target);
 	const mainLayer = evaluateCompiledLayer(mainCode, {
 		'@octanejs/lynx/main-renderer': mainRenderer,
+		'@octanejs/lynx/main-worklets': mainWorkletApi,
 		'@octanejs/lynx': firstScreenApi,
 		'./main-observer.js': {
 			markMainCancelled() {
@@ -441,7 +443,7 @@ describe.sequential('Lynx Milestone 7 compiler/runtime integration', () => {
 		const firstDescriptor = capturedBackground(firstListener!);
 
 		globalThis.lynxTestingEnv.switchToMainThread();
-		const firstCall = firstScreenApi.runOnBackground<[string], { thread: string; value: string }>(
+		const firstCall = mainWorkletApi.runOnBackground<[string], { thread: string; value: string }>(
 			firstDescriptor,
 		);
 		await expect(firstCall('before replacement')).resolves.toEqual({
@@ -458,7 +460,7 @@ describe.sequential('Lynx Milestone 7 compiler/runtime integration', () => {
 
 		globalThis.lynxTestingEnv.switchToMainThread();
 		await expect(firstCall('stale replacement')).rejects.toThrow(/stale or foreign/);
-		const replacementCall = firstScreenApi.runOnBackground<
+		const replacementCall = mainWorkletApi.runOnBackground<
 			[string],
 			{ thread: string; value: string }
 		>(replacementDescriptor);
@@ -636,7 +638,7 @@ describe.sequential('Lynx Milestone 7 compiler/runtime integration', () => {
 		cancelledMain.cancel('cancel main before adoption');
 
 		globalThis.lynxTestingEnv.switchToMainThread();
-		const backgroundEcho = firstScreenApi.runOnBackground<
+		const backgroundEcho = mainWorkletApi.runOnBackground<
 			[string],
 			{ thread: string; value: string }
 		>(
@@ -644,12 +646,12 @@ describe.sequential('Lynx Milestone 7 compiler/runtime integration', () => {
 				environment.mainLayer.backgroundEcho,
 			) as LynxBackgroundFunctionDescriptor,
 		);
-		const backgroundThrow = firstScreenApi.runOnBackground<[], never>(
+		const backgroundThrow = mainWorkletApi.runOnBackground<[], never>(
 			unwrapThreadFunctionDescriptor(
 				environment.mainLayer.backgroundThrow,
 			) as LynxBackgroundFunctionDescriptor,
 		);
-		const backgroundCancelled = firstScreenApi.runOnBackground<[], string>(
+		const backgroundCancelled = mainWorkletApi.runOnBackground<[], string>(
 			unwrapThreadFunctionDescriptor(
 				environment.mainLayer.backgroundCancelled,
 			) as LynxBackgroundFunctionDescriptor,

--- a/packages/lynx/tests/public-api.test.ts
+++ b/packages/lynx/tests/public-api.test.ts
@@ -4,6 +4,7 @@ import * as firstScreenApi from '../src/first-screen.js';
 import * as rootApi from '../src/index.js';
 import * as mainRendererApi from '../src/main-renderer.js';
 import * as mainThreadApi from '../src/main-thread.js';
+import * as mainWorkletApi from '../src/main-worklets.js';
 import * as platformApi from '../src/platform.js';
 import * as testingApi from '../src/testing.js';
 
@@ -24,6 +25,7 @@ describe('@octanejs/lynx Milestone 8 private surface', () => {
 			'./config',
 			'./renderer',
 			'./main-renderer',
+			'./main-worklets',
 			'./first-screen',
 			'./intrinsics',
 			'./intrinsics/jsx-runtime',
@@ -65,17 +67,19 @@ describe('@octanejs/lynx Milestone 8 private surface', () => {
 		expect(mainRendererApi.renderLynxFirstScreen).toBeTypeOf('function');
 		expect(mainRendererApi.firstScreenEvent).toBeTypeOf('symbol');
 		expect(mainRendererApi.lazy).toBeTypeOf('function');
-		expect(mainRendererApi.useMainThreadRef).toBeTypeOf('function');
-		expect(mainRendererApi.registerThreadFunction).toBeTypeOf('function');
+		expect(mainRendererApi).not.toHaveProperty('useMainThreadRef');
+		expect(mainRendererApi).not.toHaveProperty('registerThreadFunction');
 		expect(firstScreenApi.runOnBackground).toBe(rootApi.runOnBackground);
 		expect(firstScreenApi.runOnMainThread).toBe(rootApi.runOnMainThread);
+		expect(mainWorkletApi.runOnBackground).toBe(rootApi.runOnBackground);
+		expect(mainWorkletApi.runOnMainThread).toBe(rootApi.runOnMainThread);
 		expect(rootApi.createLynxRoot).toBeTypeOf('function');
 		expect(rootApi.useMainThreadRef).toBeTypeOf('function');
 		expect(rootApi.runOnBackground).toBeTypeOf('function');
 		expect(rootApi.runOnMainThread).toBeTypeOf('function');
 		expect(rootApi.createLynxNativeResource).toBeTypeOf('function');
 		expect(mainThreadApi.installLynxMainThread).toBeTypeOf('function');
-		expect(mainThreadApi.runOnBackground).toBe(rootApi.runOnBackground);
+		expect(mainThreadApi).not.toHaveProperty('runOnBackground');
 		expect(platformApi.useInitData).toBeTypeOf('function');
 		expect(platformApi.useGlobalProps).toBeTypeOf('function');
 		expect(platformApi.getNativeModules).toBeTypeOf('function');

--- a/packages/lynx/tests/runtime-compatibility.test.ts
+++ b/packages/lynx/tests/runtime-compatibility.test.ts
@@ -122,11 +122,13 @@ describe('Lynx runtime compatibility evidence', () => {
 		expect(runtimeSourceGraph(resolve(LYNX_ROOT, 'src/main-thread.ts'))).toEqual({
 			files: [
 				'src/core/environment.ts',
+				'src/core/first-screen-host.ts',
 				'src/core/first-screen.ts',
 				'src/core/host-driver.ts',
 				'src/core/host-props.ts',
 				'src/core/lifecycle-data.ts',
 				'src/core/list.ts',
+				'src/core/main-thread-worklet-feature.ts',
 				'src/core/native-events.ts',
 				'src/core/nodes-ref.ts',
 				'src/core/own-symbols.ts',
@@ -137,7 +139,6 @@ describe('Lynx runtime compatibility evidence', () => {
 				'src/core/protocol.ts',
 				'src/core/renderer-id.ts',
 				'src/core/worklets.ts',
-				'src/first-screen.ts',
 				'src/main-renderer.ts',
 				'src/main-thread.ts',
 				'src/resource.ts',

--- a/packages/lynx/tests/thread-calls.test.ts
+++ b/packages/lynx/tests/thread-calls.test.ts
@@ -2,6 +2,7 @@ import { installLynxTestingEnv, uninstallLynxTestingEnv } from '@lynx-js/testing
 import { JSDOM } from 'jsdom';
 import type { UniversalHostBatch, UniversalHostCommand } from 'octane/universal/native';
 import { afterEach, describe, expect, it } from 'vitest';
+import '../src/main-worklets.js';
 import { createLynxClientContainer } from '../src/core/client-driver.js';
 import {
 	LYNX_BACKGROUND_TO_MAIN_EVENT,

--- a/packages/octane/src/compiler/compile-universal.js
+++ b/packages/octane/src/compiler/compile-universal.js
@@ -3802,6 +3802,17 @@ export const UNIVERSAL_COMPILER_RUNTIME_IMPORTS = new Set([
 	'withSlot',
 ]);
 
+export const UNIVERSAL_THREAD_RUNTIME_IMPORTS = new Set([
+	'attachThreadFunction',
+	'bindThreadFunction',
+	'invokeThreadFunction',
+	'registerThreadFunction',
+	'runOnBackground',
+	'runOnMainThread',
+	'unregisterThreadFunction',
+	'useMainThreadRef',
+]);
+
 function threadHelperImportPairs(state) {
 	return [
 		['registerThreadFunction', state.helpers.registerThreadFunction],
@@ -3812,7 +3823,9 @@ function threadHelperImportPairs(state) {
 	].filter(([, local]) => local !== undefined);
 }
 
-function universalHelperImportAst(state, extraPairs = [], origin = null) {
+function universalHelperImportAsts(state, extraPairs = [], origin = null) {
+	const threadPairs = threadHelperImportPairs(state);
+	const threadModule = state.renderer.threadFunctionsModule ?? state.renderer.module;
 	const pairs = [
 		['defineUniversalComponent', state.helpers.component],
 		['universalPlan', state.helpers.plan],
@@ -3835,7 +3848,6 @@ function universalHelperImportAst(state, extraPairs = [], origin = null) {
 		...(state.helpers.firstScreenEvent === undefined
 			? []
 			: [['firstScreenEvent', state.helpers.firstScreenEvent]]),
-		...threadHelperImportPairs(state),
 		...(state.hmr
 			? [
 					['hmrUniversalComponent', state.helpers.hmr],
@@ -3843,8 +3855,13 @@ function universalHelperImportAst(state, extraPairs = [], origin = null) {
 				]
 			: []),
 		...extraPairs,
+		...(threadModule === state.renderer.module ? threadPairs : []),
 	];
-	return inheritGeneratedOrigin(b.imports(pairs, state.renderer.module), origin);
+	const imports = [inheritGeneratedOrigin(b.imports(pairs, state.renderer.module), origin)];
+	if (threadPairs.length !== 0 && threadModule !== state.renderer.module) {
+		imports.push(inheritGeneratedOrigin(b.imports(threadPairs, threadModule), origin));
+	}
+	return imports;
 }
 
 function threeHostIntrinsicStatementsAst(state, origin = null) {
@@ -4449,7 +4466,7 @@ export function lowerUniversalRendererRegionAst(
 			...(universalRuntime === undefined ? null : { universalRuntime }),
 		}),
 		statements: Object.freeze([
-			universalHelperImportAst(state, helperImportPairs, origin),
+			...universalHelperImportAsts(state, helperImportPairs, origin),
 			...threeHostIntrinsics.imports,
 			...(profileImport === null ? [] : [profileImport]),
 			...hmrBlocks.prelude,
@@ -4588,7 +4605,7 @@ export function compileUniversal(
 	const program = {
 		...ast,
 		body: [
-			universalHelperImportAst(state, [], moduleOrigin),
+			...universalHelperImportAsts(state, [], moduleOrigin),
 			...threeHostIntrinsics.imports,
 			...(profileImport === null ? [] : [profileImport]),
 			...hmrBlocks.prelude,

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -47,7 +47,11 @@ import {
 	applyHookDependencies,
 	isInvariantLiteral,
 } from './hook-deps.js';
-import { compileUniversal, UNIVERSAL_COMPILER_RUNTIME_IMPORTS } from './compile-universal.js';
+import {
+	compileUniversal,
+	UNIVERSAL_COMPILER_RUNTIME_IMPORTS,
+	UNIVERSAL_THREAD_RUNTIME_IMPORTS,
+} from './compile-universal.js';
 import {
 	expandDomRendererRegionsAst,
 	prepareRendererBoundaryRegions,
@@ -7862,6 +7866,14 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 						__hookRuntimeModules: [...(options?.__hookRuntimeModules || []), renderer.module],
 						__runtimeImportRoutes: [
 							...(options?.__runtimeImportRoutes ?? []),
+							...(renderer.threadFunctionsModule === undefined
+								? []
+								: [
+										{
+											module: renderer.threadFunctionsModule,
+											imported: UNIVERSAL_THREAD_RUNTIME_IMPORTS,
+										},
+									]),
 							{
 								module: renderer.module,
 								imported: UNIVERSAL_COMPILER_RUNTIME_IMPORTS,

--- a/packages/octane/src/compiler/renderers.js
+++ b/packages/octane/src/compiler/renderers.js
@@ -23,6 +23,7 @@ const REGISTRY_ENTRY_KEYS = new Set([
 	'server',
 	'target',
 	'text',
+	'threadFunctionsModule',
 	'validation',
 ]);
 const BOUNDARY_ENTRY_KEYS = new Set(['childRenderer', 'ownerRenderer', 'prop', 'server']);
@@ -189,6 +190,7 @@ function normalizeRegistryEntry(id, value, path) {
 	let text;
 	let capabilities;
 	let firstScreenEvents;
+	let threadFunctionsModule;
 	let validation;
 	if (typeof value === 'string') {
 		moduleId = validateModuleId(value, path);
@@ -225,6 +227,12 @@ function normalizeRegistryEntry(id, value, path) {
 		if (value.intrinsics !== undefined) {
 			intrinsics = validateModuleId(value.intrinsics, `${path}.intrinsics`);
 		}
+		if (value.threadFunctionsModule !== undefined) {
+			threadFunctionsModule = validateModuleId(
+				value.threadFunctionsModule,
+				`${path}.threadFunctionsModule`,
+			);
+		}
 
 		text = value.text ?? (target === 'dom' ? 'host' : 'reject');
 		if (text !== 'reject' && text !== 'ignore' && text !== 'host') {
@@ -250,6 +258,7 @@ function normalizeRegistryEntry(id, value, path) {
 			text !== 'host' ||
 			capabilities.length !== 0 ||
 			firstScreenEvents !== undefined ||
+			threadFunctionsModule !== undefined ||
 			validation !== undefined
 		) {
 			throw configError(
@@ -268,6 +277,7 @@ function normalizeRegistryEntry(id, value, path) {
 		text,
 		capabilities,
 		...(firstScreenEvents === undefined ? {} : { firstScreenEvents }),
+		...(threadFunctionsModule === undefined ? {} : { threadFunctionsModule }),
 		...(validation === undefined ? {} : { validation }),
 	});
 }
@@ -610,7 +620,17 @@ export function normalizeRendererConfig(input = {}) {
 		registry: entries.map(
 			([
 				id,
-				{ module, target, server, intrinsics, text, capabilities, firstScreenEvents, validation },
+				{
+					module,
+					target,
+					server,
+					intrinsics,
+					text,
+					capabilities,
+					firstScreenEvents,
+					threadFunctionsModule,
+					validation,
+				},
 			]) => [
 				id,
 				module,
@@ -620,6 +640,7 @@ export function normalizeRendererConfig(input = {}) {
 				text,
 				capabilities,
 				firstScreenEvents ?? null,
+				threadFunctionsModule ?? null,
 				validation ?? null,
 			],
 		),

--- a/packages/octane/src/compiler/vite.d.ts
+++ b/packages/octane/src/compiler/vite.d.ts
@@ -34,6 +34,8 @@ export type OctaneRendererRegistryEntry =
 			capabilities?: readonly string[];
 			/** Host event prop names/prefixes replaced by first-screen listener sentinels. */
 			firstScreenEvents?: readonly string[];
+			/** Optional cold module that owns compiler-emitted thread-function helpers. */
+			threadFunctionsModule?: string;
 			validation?: OctaneRendererValidationOptions;
 	  };
 

--- a/packages/octane/tests/compiler/renderer-config.test.ts
+++ b/packages/octane/tests/compiler/renderer-config.test.ts
@@ -171,6 +171,30 @@ describe('renderer configuration', () => {
 		expect(differentPatterns.signature).not.toBe(config.signature);
 	});
 
+	it('keeps an optional thread-function runtime module in renderer identity', () => {
+		const config = normalizeRendererConfig({
+			registry: {
+				native: {
+					module: '@octanejs/native/renderer',
+					threadFunctionsModule: '@octanejs/native/thread-functions',
+				},
+			},
+		});
+
+		expect(config.registry.native.threadFunctionsModule).toBe('@octanejs/native/thread-functions');
+		expect(normalizeRendererConfig(config).signature).toBe(config.signature);
+		expect(
+			normalizeRendererConfig({
+				registry: {
+					native: {
+						module: '@octanejs/native/renderer',
+						threadFunctionsModule: '@octanejs/native/other-thread-functions',
+					},
+				},
+			}).signature,
+		).not.toBe(config.signature);
+	});
+
 	it('normalizes renderer-owned child regions by stable module and export identity', () => {
 		const config = normalizeRendererConfig({
 			registry: { three: '@octanejs/three/renderer' },

--- a/packages/octane/tests/universal-renderer.test.ts
+++ b/packages/octane/tests/universal-renderer.test.ts
@@ -503,6 +503,31 @@ export function onTap(value) {
 		);
 	});
 
+	it('routes thread-function helpers through a renderer-owned cold module', () => {
+		const result = compile(
+			`export const onTap = () => { 'main thread'; return 1; };`,
+			'/src/ColdThreadFunction.object.ts',
+			{
+				hmr: false,
+				renderer: {
+					...renderer,
+					capabilities: ['thread-functions'],
+					threadFunctionsModule: 'octane/universal/thread-functions',
+				},
+				universalRuntime: { runtime: 'object', thread: 'main-thread' },
+			},
+		);
+
+		expect(
+			callsByImportedName(result.code, 'octane/universal/thread-functions').get(
+				'registerThreadFunction',
+			),
+		).toHaveLength(1);
+		expect(result.code).not.toMatch(
+			/import\s*\{[^}]*registerThreadFunction[^}]*\}\s*from\s*["']octane\/universal["']/,
+		);
+	});
+
 	it('registers active thread implementations before authored calls and defers captures', () => {
 		const source = `
 export const immediate = () => {

--- a/packages/rspack-plugin-octane/tests/rspack.test.ts
+++ b/packages/rspack-plugin-octane/tests/rspack.test.ts
@@ -20,6 +20,8 @@ const profilerGlobal = '__OCTANE_PROFILER__';
 const runGlobal = '__octane_rspack_profile_bundle_runs__';
 const productionErrorGlobal = '__octane_rspack_production_error__';
 const transpileGlobal = '__octane_rspack_transpiled_value__';
+const lynxWorkletFeatureGlobal = '__octane_rspack_lynx_worklet_feature__';
+const lynxWorkletHelperGlobal = '__octane_rspack_lynx_worklet_helper__';
 
 function write(root: string, relativePath: string, content: string) {
 	const file = join(root, relativePath);
@@ -187,7 +189,53 @@ export function App() @{
 		Reflect.deleteProperty(globalThis, runGlobal);
 		Reflect.deleteProperty(globalThis, productionErrorGlobal);
 		Reflect.deleteProperty(globalThis, transpileGlobal);
+		Reflect.deleteProperty(globalThis, lynxWorkletFeatureGlobal);
+		Reflect.deleteProperty(globalThis, lynxWorkletHelperGlobal);
 		await rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+	});
+
+	it('retains Lynx worklet feature installation through a production re-export', async () => {
+		const lynxPackage = join(repositoryRoot, 'packages/lynx');
+		const featureEntry = join(lynxPackage, 'src/core/main-thread-worklet-feature.ts');
+		mkdirSync(join(root, 'node_modules/@octanejs'), { recursive: true });
+		symlinkSync(lynxPackage, join(root, 'node_modules/@octanejs/lynx'), 'dir');
+		write(
+			root,
+			'src/lynx-worklet-re-export.js',
+			`import { runOnMainThread } from '@octanejs/lynx/main-worklets';
+import { subscribeLynxMainThreadWorkletFeature } from ${JSON.stringify(featureEntry)};
+globalThis.${lynxWorkletHelperGlobal} = runOnMainThread;
+subscribeLynxMainThreadWorkletFeature(() => { globalThis.${lynxWorkletFeatureGlobal} = true; });
+`,
+		);
+		const outputPath = join(root, 'dist-lynx-worklet-re-export');
+		await compile({
+			context: root,
+			mode: 'production',
+			target: 'node',
+			entry: './src/lynx-worklet-re-export.js',
+			resolve: { extensionAlias: { '.js': ['.ts', '.js'] } },
+			module: {
+				rules: [
+					{
+						test: /\.ts$/,
+						use: [
+							{
+								loader: 'builtin:swc-loader',
+								options: { jsc: { parser: { syntax: 'typescript' } } },
+							},
+						],
+					},
+				],
+			},
+			optimization: { minimize: true },
+			output: { path: outputPath, filename: 'bundle.cjs' },
+		});
+
+		await import(`${pathToFileURL(join(outputPath, 'bundle.cjs')).href}?worklet-feature`);
+
+		expect(globalThis[lynxWorkletHelperGlobal as keyof typeof globalThis]).toBeTypeOf('function');
+		expect(globalThis[lynxWorkletFeatureGlobal as keyof typeof globalThis]).toBe(true);
 	});
 
 	function installRealProfileFixture(includeRawBinding: boolean) {

--- a/packages/rspack-plugin-octane/types/index.d.ts
+++ b/packages/rspack-plugin-octane/types/index.d.ts
@@ -34,6 +34,8 @@ export type OctaneRendererRegistryEntry =
 			capabilities?: readonly string[];
 			/** Host event prop names or prefix patterns retained as first-screen listener sentinels. */
 			firstScreenEvents?: readonly string[];
+			/** Optional cold module that owns compiler-emitted thread-function helpers. */
+			threadFunctionsModule?: string;
 			validation?: OctaneRendererValidationOptions;
 	  };
 
@@ -67,6 +69,7 @@ export interface OctaneResolvedRendererConfig {
 				readonly text: 'reject' | 'ignore' | 'host';
 				readonly capabilities: readonly string[];
 				readonly firstScreenEvents?: readonly string[];
+				readonly threadFunctionsModule?: string;
 				readonly validation?: Readonly<OctaneRendererValidationOptions>;
 			}
 		>

--- a/packages/rspeedy-plugin-octane/tests/build.test.ts
+++ b/packages/rspeedy-plugin-octane/tests/build.test.ts
@@ -54,6 +54,8 @@ const BUILD_CASES = [
 			'/packages/lynx/src/core/transport.ts',
 			'/packages/octane/src/universal-native.ts',
 			'/packages/octane/src/universal-core.ts',
+			'/packages/lynx/src/main-worklets.ts',
+			'/packages/lynx/src/core/worklets.ts',
 		],
 		thread: 'main-thread',
 	},
@@ -114,6 +116,7 @@ class MetadataProbePlugin {
 		private readonly observed: unknown[],
 		private readonly moduleIdentifiers: string[],
 		private readonly layeredModules: { identifier: string; layer?: string | null }[],
+		private readonly retainedModuleIdentifiers: string[],
 	) {}
 
 	apply(compiler: any): void {
@@ -139,6 +142,25 @@ class MetadataProbePlugin {
 					if (metadata !== null) this.observed.push(metadata);
 				}
 			});
+			compilation.hooks.processAssets.tap(
+				{
+					name: `${this.constructor.name}:retained-modules`,
+					stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_REPORT,
+				},
+				() => {
+					for (const module of compilation.modules as Iterable<{
+						identifier?: () => string;
+					}>) {
+						if (
+							compilation.chunkGraph.getModuleChunksIterable(module)[Symbol.iterator]().next().done
+						) {
+							continue;
+						}
+						const identifier = module.identifier?.();
+						if (typeof identifier === 'string') this.retainedModuleIdentifiers.push(identifier);
+					}
+				},
+			);
 		});
 	}
 }
@@ -147,6 +169,7 @@ function metadataProbe(
 	observed: unknown[],
 	moduleIdentifiers: string[],
 	layeredModules: { identifier: string; layer?: string | null }[] = [],
+	retainedModuleIdentifiers: string[] = [],
 ) {
 	return {
 		name: 'octane:lynx-runtime-graph-probe',
@@ -154,7 +177,12 @@ function metadataProbe(
 			api.modifyBundlerChain((chain: any) => {
 				chain
 					.plugin('octane:lynx-runtime-graph-probe')
-					.use(MetadataProbePlugin, [observed, moduleIdentifiers, layeredModules]);
+					.use(MetadataProbePlugin, [
+						observed,
+						moduleIdentifiers,
+						layeredModules,
+						retainedModuleIdentifiers,
+					]);
 			});
 		},
 	};
@@ -208,6 +236,7 @@ describe('@octanejs/rspeedy-plugin native production entries', () => {
 			const outputRoot = join(temporaryRoot, 'dist');
 			const observed: unknown[] = [];
 			const moduleIdentifiers: string[] = [];
+			const retainedModuleIdentifiers: string[] = [];
 			const rspeedy = await createRspeedy({
 				cwd: FIXTURE,
 				loadEnv: false,
@@ -226,7 +255,7 @@ describe('@octanejs/rspeedy-plugin native production entries', () => {
 					splitChunks: false,
 					plugins: [
 						pluginOctane({ thread, hmr: false, dev: false }),
-						metadataProbe(observed, moduleIdentifiers),
+						metadataProbe(observed, moduleIdentifiers, [], retainedModuleIdentifiers),
 					],
 				},
 			});
@@ -245,9 +274,12 @@ describe('@octanejs/rspeedy-plugin native production entries', () => {
 						`expected ${thread} graph to contain ${suffix}`,
 					).toBe(true);
 				}
+				const retainedModules = retainedModuleIdentifiers.map((identifier) =>
+					identifier.split(/[?!]/, 1)[0].replaceAll('\\', '/'),
+				);
 				for (const suffix of forbiddenModules) {
 					expect(
-						[...canonicalModules].some((identifier) => identifier.endsWith(suffix)),
+						retainedModules.some((identifier) => identifier.endsWith(suffix)),
 						`expected ${thread} graph to exclude ${suffix}`,
 					).toBe(false);
 				}
@@ -368,6 +400,8 @@ describe('@octanejs/rspeedy-plugin native production entries', () => {
 				'/packages/rspeedy-plugin-octane/tests/_fixtures/application/src/App.tsrx',
 				'/packages/lynx/src/root.ts',
 				'/packages/lynx/src/main-thread.ts',
+				'/packages/lynx/src/main-worklets.ts',
+				'/packages/lynx/src/core/worklets.ts',
 			]) {
 				expect(
 					[...canonicalModules].some((identifier) => identifier.endsWith(suffix)),
@@ -421,6 +455,8 @@ describe('@octanejs/rspeedy-plugin native production entries', () => {
 				'/packages/rspeedy-plugin-octane/src/main-thread-ready.js',
 				'/packages/lynx/src/first-screen.ts',
 				'/packages/lynx/src/main-renderer.ts',
+				'/packages/lynx/src/main-worklets.ts',
+				'/packages/lynx/src/core/worklets.ts',
 			]) {
 				expect(hasSuffix(mainModules, suffix), `missing ${suffix} from main thread`).toBe(true);
 			}


### PR DESCRIPTION
## Summary

- add a renderer-owned `threadFunctionsModule` route so the compiler imports thread helpers only when compiled output needs them
- split Lynx's worklet registry/call bridges into `@octanejs/lynx/main-worklets`, connected to the ordinary receiver through a late-install capability seam
- preserve direct, monomorphic publication calls in the no-worklet receiver and upgrade already-created host containers when a static or late worklet chunk appears
- freeze no-worklet preview/IFR main-thread gzip budgets and assert both absent-feature and worklet-enabled production graphs

This follows the residual investigation in [Huxpro/octane#44](https://github.com/Huxpro/octane/issues/44). It does not revive the receiver-level lazy bridge rejected there: the compiler selects the cold feature module and the ordinary receiver keeps its existing call shape.

## Validation

Exact upstream base: `9b147781c9b4ec4df053a059633978ddc0ed922a`.

No-worklet production artifacts:

| slice | base gzip | candidate gzip | delta |
|---|---:|---:|---:|
| preview main | 76,915 B | 75,024 B | -2.46% |
| IFR main | 81,995 B | 79,980 B | -2.46% |

The background program remains exactly 271,737 raw bytes with identical semantic markers. Its encoded checksum changes and gzip is 73,182 → 73,185 B because optimizing the independent main graph changes Rspack's debug-metadata hash and minifier-local symbol allocation; decoding both artifacts found only that hash plus one-character local renames, with no background source, command, or semantic change. This is the itemized exception allowed by #44's acceptance gate.

Final same-host Lynx-for-Web n=9, base → candidate at 10k rows:

| operation | base | candidate | delta |
|---|---:|---:|---:|
| create | 1,133 ms | 1,144 ms | +1.0% |
| update10th | 161 ms | 163 ms | +1.2% |
| select | 60 ms | 59 ms | -1.7% |
| updateStorm | 577 ms | 590 ms | +2.3% |
| selectStorm | 171 ms | 173 ms | +1.2% |

An earlier candidate→base n=9 order measured selectStorm 164 → 171 ms; both orders remain inside the 5% decision boundary. A separate n=20 dual-thread render run measured candidate/base create@10k 135.4/134.4 ms and update@10k 22.5/22.8 ms, with identical command/program/ack/selector counters. Lynx list teardown retained 0 cells.

- [ ] `pnpm format:check`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [x] targeted tests:
  - `pnpm exec vitest run --project lynx --silent=passed-only` (338 tests)
  - affected compiler renderer tests (106 tests)
  - Rspeedy production build/module-graph fixture (5 tests)
  - scoped production-source typecheck and format checks
  - `pnpm sync`
  - `node benchmarks/bench.mjs --only lynx-bundle-size`
  - `node benchmarks/bench.mjs --only lynx-list --ratios`
  - deterministic 1k/10k CRUD/storm counters

## Risk / follow-ups

The new renderer descriptor field participates in the normalized cache signature. Renderers that omit it retain byte-for-byte compiler import behavior; the compiler test suite covers that fallback. The feature provider supports both evaluation orders and late chunks, and rejects competing providers.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compiler import routing and Lynx main-thread cross-thread/worklet lifecycle; behavior is heavily tested but regressions could affect worklet-enabled apps or bundle graphs.
> 
> **Overview**
> Introduces an optional **`threadFunctionsModule`** on universal renderer descriptors so the compiler emits thread-function helper imports only when compiled output needs them, instead of always pulling them through the main renderer module.
> 
> For Lynx, worklet registries and cross-thread APIs move to **`@octanejs/lynx/main-worklets`**, wired into the ordinary main-thread receiver via a small **subscribe/provide** capability layer. Bundles with no worklets keep a lightweight stub registry and monomorphic publication paths; when a static or late chunk loads the feature, existing host containers upgrade through a **replaceable** registry identity without changing receiver call shapes.
> 
> **`lynx-bundle-size`** gains frozen gzip/raw budgets for no-worklet preview/IFR main slices and asserts the main-thread graph excludes `main-worklets` / `worklets` unless the app retains worklet helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71b758e76a7515ae4b3b759e015975ee1e8f0d4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->