### PR TITLE
feat: React 19 parity tranche — Float resources, root error callbacks, module hints, parity dispositions

### DIFF
--- a/.changeset/react19-parity-float-root-callbacks.md
+++ b/.changeset/react19-parity-float-root-callbacks.md
@@ -1,0 +1,29 @@
+---
+'octane': patch
+---
+
+React 19 parity tranche: Float resources, root error callbacks, module resource hints, and partial-prerender/formState dispositions.
+
+`<link rel="stylesheet" href precedence>` and `<script async src>` rendered at
+a component's body root are now React Float resources: hoisted into
+`document.head`, deduped by href/src across the page, stylesheet groups ordered
+by precedence (first-encounter group order, appended within a group), retained
+after unmount, emitted into buffered and streamed SSR head output, and
+hydration-deduped via the first client call's DOM seed. Suspend-until-loaded
+commits and `<style href precedence>` style resources remain documented
+non-goals — `<style>` in a component belongs to Octane's scoped-CSS system.
+
+`preloadModule` and `preinitModule` join the resource-hint set on both the
+client and server entries. `createRoot`/`hydrateRoot` accept React 19's
+`onCaughtError`, `onUncaughtError`, and `onRecoverableError` options
+(error-only signature — no `errorInfo`/`componentStack`; defaults are unchanged
+when the options are absent). `unstable_Activity` is aliased to `Activity` for
+React experimental-channel ports.
+
+React 19.2 partial pre-rendering (`resume`/`resumeAndPrerender` and the
+postpone/prelude protocol), `cache()`/`cacheSignal()`, and `hydrateRoot`'s
+`formState` option are recorded as documented non-goals in the parity ledger,
+and `docs/differences-from-react.md` now documents the previously unlisted
+divergences: `Context.Consumer`, `<title>` child handling, per-compile-site
+metadata dedupe, hidden-`<Activity>` scheduling, dropped stream options,
+`prerender`'s return shape, the `useId` format, and the `version` string.

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -548,6 +548,59 @@ Strings, numbers, arrays, objects, and nesting compose at every client and SSR
 apply site with byte-identical results. A nullish or `false` result removes the
 attribute; an empty string writes `class=""`.
 
+## Context: callable provider object, no Consumer
+
+`createContext` returns a context that is itself the provider component —
+React 19's `<MyContext value={…}>` form is the native shape, and
+`MyContext.Provider` is retained as an identity alias for React-18-shaped
+libraries. The render-prop `<MyContext.Consumer>` does not exist: Octane's
+slot-keyed hooks make `use(MyContext)`/`useContext` legal behind any condition,
+which is the pattern Consumer existed to work around. Read the context in the
+child (or an inline component) instead.
+
+## Document metadata and Float resources
+
+Hoisted `<title>`/`<meta>`/`<link>` follow React 19's model with two
+differences:
+
+- **Ownership is per compile site, not per content.** Each authored element
+  owns one head element; two components (or two renders of one component list
+  item) each rendering `<meta name="description">` produce two tags, where
+  React dedupes links by href and treats `<title>` as a singleton. An
+  element's tag updates reactively and is removed when its owning scope
+  unmounts.
+- **`<title>` accepts any children Octane can stringify** — multiple children
+  and expressions concatenate. React 19 errors on non-string title children.
+
+Additionally, metadata and resources classify at a component's **body root**
+(beside the output node), the same placement the head-hoist model has always
+used — a `<title>` nested inside a host element is not hoisted.
+
+React Float **resources** are supported with React's semantics:
+
+- `<link rel="stylesheet" href precedence>` (no `onLoad`/`onError`) is a
+  global resource: deduped by href across the page, hoisted into
+  `document.head` with a `data-precedence` attribute, grouped by precedence in
+  first-encounter order (later same-precedence sheets append to their group),
+  and retained after unmount. First instance wins; later differing props do
+  not retarget a live sheet.
+- `<script async src>` (no children/handlers) hoists and dedupes by src, and
+  is likewise never removed.
+- `preloadModule`/`preinitModule` join `preload`/`preinit`/`preconnect`/
+  `prefetchDNS`.
+- Classification is static: a spread-carried `precedence`/`async` keeps the
+  ordinary element path, matching the compile-time head-hoist model.
+
+Out of scope, deliberately: **suspensey commits** (React's
+suspend-until-the-stylesheet-loads behavior; Octane inserts the sheet and
+continues) and **`<style href precedence>` style resources** — `<style>` inside
+a component belongs to Octane's scoped-CSS system; use a stylesheet link
+resource or `preinit` for shared CSS. Resource-hint options apply as a lenient
+attribute pass-through (`fetchPriority`, `imageSrcSet`, `imageSizes`, `media`,
+`integrity`, … all serialize correctly) without React's option validation, and
+`preload` + `preinit` of the same href are two entries rather than React's
+unified resource map.
+
 ## Reconciler: LIS moves, identical results
 
 The keyed reconciler minimizes DOM moves (LIS) instead of React's
@@ -590,6 +643,13 @@ Other consequences:
 - `useSyncExternalStore` skips React's commit-time getSnapshot re-read for
   unchanged values (the concurrent-interleaving window it guards doesn't exist
   here).
+- A hidden `<Activity>` subtree renders synchronously in the same pass — there
+  is no offscreen/idle lane deprioritizing hidden work. Hide/reveal semantics
+  (state preserved, effects unmounted while hidden) match React.
+- `useId` generates `:<prefix>in-<n>:` identifiers (React 19.2 uses
+  `_r_<n>_`). Both are opaque; only the format differs.
+- `version` reports Octane's own package version (`0.x`), not a React version —
+  ported code gating on `version >= '19'` must not rely on it.
 
 ## Parallel `use()`: no suspense waterfalls
 
@@ -740,8 +800,19 @@ behavior.
 `@catch (error, reset)` and the JSX `<ErrorBoundary>` replace class
 error-boundary lifecycles. Catch fallbacks mount fresh nodes (like React's
 `forceUnmountCurrentAndReconcile`); deletion-phase and ref-detach errors route
-to the enclosing boundary. Uncaught errors surface through `console.error`
-rather than `onUncaughtError`.
+to the enclosing boundary.
+
+React 19's root error-callback options are supported on `createRoot` and
+`hydrateRoot`: `onCaughtError` (a boundary claimed an error from the render,
+passive-effect, or ref-attach channel), `onUncaughtError` (no boundary claimed
+it — providing the callback replaces the default report, which otherwise
+rethrows render errors out of the flush and `console.error`s effect-channel
+errors; the failed root's tree still unmounts), and `onRecoverableError`
+(hydration recovered from a structural mismatch — see the hydration section).
+Each callback receives only the error: there is no `errorInfo`/`componentStack`
+second argument, matching the documented SSR `onError` shape (owner stacks are
+not part of Octane's API). Deletion-phase teardown errors keep their existing
+boundary routing and default report; they do not reach these callbacks.
 
 ## Refs are props
 
@@ -824,9 +895,20 @@ Suspense like Fizz, with these differences:
   during hydration.
 
 Octane leaves document and transport orchestration to the surrounding server.
-It has no Fizz bootstrap-script/module/import-map, doctype/preamble, `onHeaders`,
-or header-construction options. One `nonce` covers every inline style and script
-Octane emits rather than exposing separate script and style channels.
+It has no Fizz bootstrap-script/module/import-map options, no doctype/preamble
+*options* (streaming a `<html>`-rooted document still emits `<!DOCTYPE html>`
+automatically), and no `onHeaders` or header-construction options. One `nonce`
+covers every inline style and script Octane emits rather than exposing separate
+script and style channels. `progressiveChunkSize` does not exist — Octane
+flushes per resolution wave, not by byte thresholds — and `namespaceURI` is
+inferred from the rendered root rather than accepted as an option.
+
+React 19.2's partial pre-rendering — `resume`, `resumeToPipeableStream`,
+`resumeAndPrerender`, and the postpone/prelude protocol — is a non-goal: that
+request protocol is not part of Octane's public SSR surface. Relatedly,
+`prerender` resolves `{ html, css }` (a complete buffered document), not
+React's `{ prelude: ReadableStream }`; `prerenderToNodeStream` is planned but
+not yet implemented.
 
 A readable stream's `allReady` settles after all boundary bytes have been
 accepted under consumer backpressure, so consumers should read the stream while
@@ -838,6 +920,18 @@ React digests or React's `errorInfo` shape.
 Attribute mismatches recover to the **client** value; React keeps the server
 value. Octane warns and rebuilds a mismatched subtree in place rather than
 throwing.
+
+`hydrateRoot`'s `onRecoverableError` option fires (dev AND prod) after a
+STRUCTURAL recovery — a rebuilt subtree or a discarded stale server range —
+coalesced to one report per root per microtask burst. Octane recovers per site
+rather than client-rendering a whole boundary, so attribute-level value patches
+do not report: production React does not detect those at all, and reporting
+Octane's extra detection would make the channel incomparable.
+
+`hydrateRoot` has no `formState` option: resuming `useActionState` from an MPA
+form POST requires React's server-action state serialization, which is part of
+the RSC model Octane does not implement (the matching `useActionState`
+`permalink` argument is accepted for signature parity and ignored).
 
 Production structural validation has the same depth as React: it checks an
 adopted root's node type and tag. Tag and text mismatches still recover, but
@@ -896,12 +990,21 @@ is a known limitation, not a supported edit.
 Octane does not implement:
 
 - class components or legacy `ReactDOM.render` roots;
-- Server Components/RSC;
+- Server Components/RSC, including `cache()`, `cacheSignal()`, and
+  `hydrateRoot`'s `formState` option;
 - `StrictMode` double-invoke;
-- `Profiler`, `SuspenseList`, `forwardRef`, `createRef`, or `cache()`.
+- `Profiler`, `SuspenseList`, `forwardRef`, or `createRef`;
+- `captureOwnerStack` and development owner-stack collection (diagnostics
+  dedupe per rendering block instead);
+- `unstable_batchedUpdates` (renders are microtask-batched by default);
+- partial pre-rendering (`resume`/`resumeAndPrerender` and the
+  postpone/prelude protocol — see SSR and streaming);
+- gesture View Transitions (`useSwipeTransition` /
+  `unstable_startGestureTransition`), deferred until React stabilizes them.
 
 `useDebugValue` is accepted as a no-op. Resource hints are supported
-(`preload`, `preinit`, `preconnect`, and `prefetchDNS`).
+(`preload`, `preinit`, `preloadModule`, `preinitModule`, `preconnect`, and
+`prefetchDNS`).
 
 React 19 custom-element listener semantics are also supported: a
 function-valued lowercase `on*` prop on a custom element attaches a real

--- a/docs/react-parity-coverage.md
+++ b/docs/react-parity-coverage.md
@@ -85,8 +85,8 @@ Every concrete case in either pinned inventory has exactly one ledger dispositio
 
 | Baseline | Cases | Untriaged | Planned | In progress | Covered | Documented | Blocked |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| stable | 5,345 | 0 | 2,026 | 0 | 894 | 2,425 | 0 |
-| canary | 5,413 | 0 | 2,063 | 0 | 951 | 2,399 | 0 |
+| stable | 5,345 | 0 | 2,002 | 0 | 894 | 2,449 | 0 |
+| canary | 5,413 | 0 | 2,049 | 0 | 951 | 2,413 | 0 |
 
 Classifications are `portable`, `adaptable`, `divergence`, and `non_goal`. A covered case requires live local test evidence; divergence and non-goal dispositions require a rationale.
 

--- a/docs/ssr.md
+++ b/docs/ssr.md
@@ -438,3 +438,13 @@ These are the known gaps between Octane SSR and a full streaming SSR stack:
   arbitrary preamble insertion, bootstrap script/module lists, import-map
   construction, response headers, or `onHeaders`. Compose those concerns around
   the returned stream in the Vite plugin, adapter, or application server.
+- **`prerenderToNodeStream`**: planned; `octane/static` currently exposes only
+  the buffered `prerender`, which resolves `{ html, css }` rather than React's
+  `{ prelude: ReadableStream }`.
+- **Partial pre-rendering** (`resume`, `resumeToPipeableStream`,
+  `resumeAndPrerender`, and React's postpone/prelude protocol): a documented
+  non-goal — that request protocol is not part of Octane's public SSR surface.
+- **Chunk-size and namespace options**: `progressiveChunkSize` does not exist
+  (Octane flushes per resolution wave, not by byte thresholds) and
+  `namespaceURI` is inferred from the rendered root rather than accepted as an
+  option.

--- a/docs/view-transitions.md
+++ b/docs/view-transitions.md
@@ -102,6 +102,11 @@ old/new captures. Hydration adopts the annotations untouched.
   your transition CSS with a media query.
 - One transition runs at a time; work arriving mid-animation batches into the
   next one (A→B, then B→D).
+- Gesture transitions (`useSwipeTransition` /
+  `unstable_startGestureTransition`) are not implemented — they are still
+  experimental in React and explicitly deferred until React stabilizes them.
+- Suspensey host resources (suspending a transition commit until an image or
+  stylesheet loads) are outside Octane's supported surface.
 - The full behavior matrix is pinned by the conformance ports in
   `packages/octane/tests/conformance/view-transition*.test.ts`; the
   implementation plan and its documented edge cases live in

--- a/packages/cli/src/data/octane-data.json
+++ b/packages/cli/src/data/octane-data.json
@@ -1251,6 +1251,36 @@
       "message": "Unclosed server-rendered Fragment descriptor.",
       "runtime": ["client"],
       "status": "active"
+    },
+    "51": {
+      "message": "Hydration mismatch: the server-rendered node did not match the client render; the mismatched subtree was rebuilt on the client.",
+      "runtime": ["client"],
+      "status": "active"
+    },
+    "52": {
+      "message": "Hydration mismatch: root adoption was abandoned after a server/client shape divergence; the root was rebuilt on the client.",
+      "runtime": ["client"],
+      "status": "active"
+    },
+    "53": {
+      "message": "Hydration mismatch: the server rendered more root content than the client; the stale remainder was discarded.",
+      "runtime": ["client"],
+      "status": "active"
+    },
+    "54": {
+      "message": "Hydration mismatch: the client rendered text where the server rendered none; the client text was built fresh.",
+      "runtime": ["client"],
+      "status": "active"
+    },
+    "55": {
+      "message": "Hydration mismatch: the server rendered a different child shape where the client renders a component; the stale range was discarded and the component was built on the client.",
+      "runtime": ["client"],
+      "status": "active"
+    },
+    "56": {
+      "message": "Hydration mismatch: the server rendered more list items than the client; the extra server items were discarded.",
+      "runtime": ["client"],
+      "status": "active"
     }
   }
 }

--- a/packages/octane/audit/react-conformance-ledger.json
+++ b/packages/octane/audit/react-conformance-ledger.json
@@ -48,7 +48,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “never writes children/suppressHydrationWarning as attributes” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cnever writes children/suppressHydrationWarning as attributes\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-custom-elements.test.ts",
@@ -673,7 +673,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “throws for a markup-injection tag name” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cthrows for a markup-injection tag name\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-children.test.ts",
@@ -802,7 +802,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “calls clean up function if it exists” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201ccalls clean up function if it exists\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/refs.test.ts",
@@ -895,7 +895,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “function-valued lowercase on* on a custom element attaches a listener” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cfunction-valued lowercase on* on a custom element attaches a listener\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -1184,7 +1184,7 @@
       "classification": "adaptable",
       "owner": "SSR + hydration",
       "workstream": "Server integration matrix",
-      "rationale": "Octane hoists link metadata into the document head, so focused public client evidence and server serialization evidence jointly cover React’s empty-link URL outcome.",
+      "rationale": "Octane hoists link metadata into the document head, so focused public client evidence and server serialization evidence jointly cover React\u2019s empty-link URL outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -1458,7 +1458,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “marks empty-fragment sibling positions as implementation-specific” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cmarks empty-fragment sibling positions as implementation-specific\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-position.test.ts",
@@ -2080,15 +2080,15 @@
     },
     {
       "caseId": "react-case-v1:065049b8ddb6891bf8df",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js",
       "title": "emits an empty prelude if we have not rendered html or head tags yet",
       "baselines": ["stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "React's postpone/resume request protocol is not part of Octane's public SSR or streaming API."
     },
     {
       "caseId": "react-case-v1:0656d8c2f0ae875addf9",
@@ -2100,7 +2100,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “validates logical position when sibling portals share the same host” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cvalidates logical position when sibling portals share the same host\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-parity-ledger.test.ts",
@@ -2378,15 +2378,15 @@
     },
     {
       "caseId": "react-case-v1:071238919a2cc592c84d",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactCache-test.js",
       "title": "cache objects and primitive arguments and a mix of them",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "React reconciler residual audit",
-      "rationale": "Remaining function-component hooks, effects, context, Suspense, transitions, Activity, batching, error recovery, and reconciliation outcomes require exact observable Octane evidence; Fiber-only mechanics will receive case-level non-goal dispositions."
+      "rationale": "React's cache() and cacheSignal() request-scoped caching APIs belong to the Server Components model; Octane does not implement RSC or cache() (documented in differences-from-react.md)."
     },
     {
       "caseId": "react-case-v1:07165949e1e66b8dc5da",
@@ -2471,7 +2471,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “multiple useId calls in one component yield distinct, stable ids” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cmultiple useId calls in one component yield distinct, stable ids\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/useid-determinism.test.ts",
@@ -2689,7 +2689,7 @@
       "classification": "non_goal",
       "owner": "SSR + hydration",
       "workstream": "Server integration matrix",
-      "rationale": "Legacy React factory components are outside Octane’s function-component model."
+      "rationale": "Legacy React factory components are outside Octane\u2019s function-component model."
     },
     {
       "caseId": "react-case-v1:07e9cbc012d953c32b9d",
@@ -2713,7 +2713,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “link href=\"\" is not added (React strips it)” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201clink href=\"\" is not added (React strips it)\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -4668,7 +4668,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “does not append px to flex: 0” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cdoes not append px to flex: 0\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/css-properties.test.ts",
@@ -5291,7 +5291,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “calls a stable ref exactly once through a child component re-render” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201ccalls a stable ref exactly once through a child component re-render\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/refs.test.ts",
@@ -5408,7 +5408,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “a href=\"\" keeps the empty attribute” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201ca href=\"\" keeps the empty attribute\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -5506,7 +5506,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “focuses deeply nested focusable children depth-first with focusLast()” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cfocuses deeply nested focusable children depth-first with focusLast()\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-parity-ledger.test.ts",
@@ -6007,7 +6007,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “handles ref functions with stable identity” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201chandles ref functions with stable identity\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/refs.test.ts",
@@ -6361,15 +6361,15 @@
     },
     {
       "caseId": "react-case-v1:14f07973e7443c8e152b",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js",
       "title": "can postpone in fallback without postponing the tree",
       "baselines": ["stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "React's postpone/resume request protocol is not part of Octane's public SSR or streaming API."
     },
     {
       "caseId": "react-case-v1:150bad2ce41d37c321fa",
@@ -6751,11 +6751,11 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “aliases SVG `arabicForm` → `arabic-form`” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201caliases SVG `arabicForm` \u2192 `arabic-form`\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-attributes.test.ts",
-          "testName": "aliases SVG `arabicForm` → `arabic-form`",
+          "testName": "aliases SVG `arabicForm` \u2192 `arabic-form`",
           "modes": ["client", "production-compile"]
         }
       ]
@@ -6894,7 +6894,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “onInput on a custom element: fires, removes, re-adds” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201conInput on a custom element: fires, removes, re-adds\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -7153,7 +7153,7 @@
       "classification": "non_goal",
       "owner": "SSR + hydration",
       "workstream": "Server integration matrix",
-      "rationale": "The case targets React private dispatcher access or Rules-of-Hooks diagnostics that do not apply to Octane’s compiler-assigned hook slots and public context API."
+      "rationale": "The case targets React private dispatcher access or Rules-of-Hooks diagnostics that do not apply to Octane\u2019s compiler-assigned hook slots and public context API."
     },
     {
       "caseId": "react-case-v1:17b318f8790a83b9e460",
@@ -7938,7 +7938,7 @@
       "classification": "divergence",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Octane deliberately patches an adopted attribute to the client value after a hydration mismatch; React warns but retains the server attribute. The executable test pins Octane’s final-DOM contract and diagnostic.",
+      "rationale": "Octane deliberately patches an adopted attribute to the client value after a hydration mismatch; React warns but retains the server attribute. The executable test pins Octane\u2019s final-DOM contract and diagnostic.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/hydration-mismatch.test.ts",
@@ -8444,7 +8444,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “title is readable as a property” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201ctitle is readable as a property\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -8523,7 +8523,7 @@
       "classification": "non_goal",
       "owner": "SSR + hydration",
       "workstream": "Server integration matrix",
-      "rationale": "The case targets React private dispatcher access or Rules-of-Hooks diagnostics that do not apply to Octane’s compiler-assigned hook slots and public context API."
+      "rationale": "The case targets React private dispatcher access or Rules-of-Hooks diagnostics that do not apply to Octane\u2019s compiler-assigned hook slots and public context API."
     },
     {
       "caseId": "react-case-v1:1c98ab3ac6aeb0be2622",
@@ -8676,7 +8676,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “handles detaching refs with either cleanup function or null argument” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201chandles detaching refs with either cleanup function or null argument\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/refs.test.ts",
@@ -9094,7 +9094,7 @@
       "status": "planned",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactIsomorphicAct-test.js",
-      "title": "return value – sync callback",
+      "title": "return value \u2013 sync callback",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
       "owner": "runtime",
@@ -9154,7 +9154,7 @@
       "classification": "non_goal",
       "owner": "SSR + hydration",
       "workstream": "Server integration matrix",
-      "rationale": "The case targets React private dispatcher access or Rules-of-Hooks diagnostics that do not apply to Octane’s compiler-assigned hook slots and public context API."
+      "rationale": "The case targets React private dispatcher access or Rules-of-Hooks diagnostics that do not apply to Octane\u2019s compiler-assigned hook slots and public context API."
     },
     {
       "caseId": "react-case-v1:1e5ec54d82fa5be5936f",
@@ -9349,7 +9349,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “delivers non-bubbling events only to listeners attached to the fragment” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cdelivers non-bubbling events only to listeners attached to the fragment\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-position.test.ts",
@@ -9380,7 +9380,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “preserves whitespace in raw HTML” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cpreserves whitespace in raw HTML\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-children.test.ts",
@@ -9423,7 +9423,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “drops injection-unsafe attribute names on a regular element” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cdrops injection-unsafe attribute names on a regular element\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-ssr.test.ts",
@@ -9497,7 +9497,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “fires onError and onLoad on an SVG <image> element” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cfires onError and onLoad on an SVG <image> element\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-events.test.ts",
@@ -9540,7 +9540,7 @@
       "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Canary-only transition warning policy is gated by React’s experimental loop detector and phase classification. Octane has no lanes/flag."
+      "rationale": "Canary-only transition warning policy is gated by React\u2019s experimental loop detector and phase classification. Octane has no lanes/flag."
     },
     {
       "caseId": "react-case-v1:1fbd097cd25c532caa14",
@@ -9604,15 +9604,15 @@
     },
     {
       "caseId": "react-case-v1:1fe5f61148a5f58ae086",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactCache-test.js",
       "title": "cacheSignal() aborts when the render finishes normally",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "React reconciler residual audit",
-      "rationale": "Remaining function-component hooks, effects, context, Suspense, transitions, Activity, batching, error recovery, and reconciliation outcomes require exact observable Octane evidence; Fiber-only mechanics will receive case-level non-goal dispositions."
+      "rationale": "React's cache() and cacheSignal() request-scoped caching APIs belong to the Server Components model; Octane does not implement RSC or cache() (documented in differences-from-react.md)."
     },
     {
       "caseId": "react-case-v1:1fef513d03ccdad18672",
@@ -9691,7 +9691,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “throws for invalid tag names in a server render” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cthrows for invalid tag names in a server render\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-ssr.test.ts",
@@ -10396,7 +10396,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “queues multiple actions and runs them in order, never starting early (Per :1085/:980)” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cqueues multiple actions and runs them in order, never starting early (Per :1085/:980)\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/form-actions-extra.test.ts",
@@ -10676,7 +10676,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “stringifies plain objects to [object Object]” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cstringifies plain objects to [object Object]\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-attributes.test.ts",
@@ -10719,7 +10719,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “returns PRECEDING for a sibling rendered BEFORE the fragment” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201creturns PRECEDING for a sibling rendered BEFORE the fragment\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-position.test.ts",
@@ -11075,7 +11075,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “sets px-appended numbers, clears \"\", null, and false values” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201csets px-appended numbers, clears \"\", null, and false values\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-styles.test.ts",
@@ -11235,7 +11235,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “throws for an invalid tag name” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cthrows for an invalid tag name\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-children.test.ts",
@@ -11467,7 +11467,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “clears every property when style goes away” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cclears every property when style goes away\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-styles.test.ts",
@@ -11908,7 +11908,7 @@
       "status": "planned",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactIsomorphicAct-test.js",
-      "title": "return value – async callback, nested",
+      "title": "return value \u2013 async callback, nested",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
       "owner": "runtime",
@@ -12216,7 +12216,7 @@
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/enter-leave-traversal.test.ts",
-          "testName": "traverses enter/leave to parent — avoids parent",
+          "testName": "traverses enter/leave to parent \u2014 avoids parent",
           "modes": ["client", "production-compile"]
         }
       ]
@@ -12305,7 +12305,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “serializes class=\"a\", class=\"a b\", and class=\"\"” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cserializes class=\"a\", class=\"a b\", and class=\"\"\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-ssr.test.ts",
@@ -12420,7 +12420,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “non-function lowercase on* props land as plain attributes” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cnon-function lowercase on* props land as plain attributes\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -13344,7 +13344,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “routes a synchronously-throwing action to the error boundary (Per :1220)” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201croutes a synchronously-throwing action to the error boundary (Per :1220)\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/form-actions-extra.test.ts",
@@ -13418,7 +13418,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “keeps formaction=\"\" on a <button> inside a <form action>” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201ckeeps formaction=\"\" on a <button> inside a <form action>\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-attributes.test.ts",
@@ -13678,7 +13678,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “scrolls text nodes through their Range geometry” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cscrolls text nodes through their Range geometry\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
@@ -13709,7 +13709,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “keeps a <link> with onLoad/onError inline and fires both handlers” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201ckeeps a <link> with onLoad/onError inline and fires both handlers\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-events.test.ts",
@@ -13886,7 +13886,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “never writes dangerouslySetInnerHTML as an attribute” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cnever writes dangerouslySetInnerHTML as an attribute\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-custom-elements.test.ts",
@@ -13917,7 +13917,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “fires onParentEnter when ancestor ViewTransition has no props” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cfires onParentEnter when ancestor ViewTransition has no props\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/view-transition.test.ts",
@@ -13965,15 +13965,15 @@
     },
     {
       "caseId": "react-case-v1:2eb928e37be765ca05e5",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactCache-test.js",
       "title": "cacheSignal() returns null outside a render",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "React reconciler residual audit",
-      "rationale": "Remaining function-component hooks, effects, context, Suspense, transitions, Activity, batching, error recovery, and reconciliation outcomes require exact observable Octane evidence; Fiber-only mechanics will receive case-level non-goal dispositions."
+      "rationale": "React's cache() and cacheSignal() request-scoped caching APIs belong to the Server Components model; Octane does not implement RSC or cache() (documented in differences-from-react.md)."
     },
     {
       "caseId": "react-case-v1:2ec222491dc6e3cf332c",
@@ -14145,7 +14145,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “cycle/rotate preserves all instances” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201ccycle/rotate preserves all instances\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/multichild-identity.test.ts",
@@ -14594,7 +14594,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “focuses the first focusable child in a fieldset” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cfocuses the first focusable child in a fieldset\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-focus.test.ts",
@@ -14981,7 +14981,7 @@
       "classification": "adaptable",
       "owner": "SSR + hydration",
       "workstream": "Server integration matrix",
-      "rationale": "The public numeric and reserved-prop outcomes are covered across Octane’s render matrix; React’s class-component ref setup is adapted to Octane’s supported callback-ref API.",
+      "rationale": "The public numeric and reserved-prop outcomes are covered across Octane\u2019s render matrix; React\u2019s class-component ref setup is adapted to Octane\u2019s supported callback-ref API.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/server-integration-attributes-wave4d.test.ts",
@@ -15019,7 +15019,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “warns without unobserving when the observer was never registered” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cwarns without unobserving when the observer was never registered\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-observers.test.ts",
@@ -15378,7 +15378,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “does not fire onParentEnter when ancestor enter is none” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cdoes not fire onParentEnter when ancestor enter is none\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/view-transition.test.ts",
@@ -16340,7 +16340,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “adds and removes event listeners from children with multiple fragments” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cadds and removes event listeners from children with multiple fragments\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-parity-ledger.test.ts",
@@ -16407,7 +16407,7 @@
       "classification": "adaptable",
       "owner": "SSR + hydration",
       "workstream": "Server integration matrix",
-      "rationale": "The public numeric and reserved-prop outcomes are covered across Octane’s render matrix; React’s class-component ref setup is adapted to Octane’s supported callback-ref API.",
+      "rationale": "The public numeric and reserved-prop outcomes are covered across Octane\u2019s render matrix; React\u2019s class-component ref setup is adapted to Octane\u2019s supported callback-ref API.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/server-integration-attributes-wave4d.test.ts",
@@ -16864,7 +16864,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “skips injection-unsafe attribute names on a regular element (mount + update)” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cskips injection-unsafe attribute names on a regular element (mount + update)\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-attributes.test.ts",
@@ -17086,7 +17086,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “leaves manually-set innerHTML alone when the element renders no children” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cleaves manually-set innerHTML alone when the element renders no children\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-children.test.ts",
@@ -17117,7 +17117,7 @@
       "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "The behavior depends entirely on UNSAFE_componentWillMount scheduling another class instance’s setState."
+      "rationale": "The behavior depends entirely on UNSAFE_componentWillMount scheduling another class instance\u2019s setState."
     },
     {
       "caseId": "react-case-v1:390d5e656eec6583357b",
@@ -17292,7 +17292,7 @@
       "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Experimental force-throw feature-flag behavior for React’s sync nested-update detector is not an Octane public contract."
+      "rationale": "Experimental force-throw feature-flag behavior for React\u2019s sync nested-update detector is not an Octane public contract."
     },
     {
       "caseId": "react-case-v1:3966f5d39e963ba1cd4b",
@@ -17884,7 +17884,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “should not bail out when an update is scheduled from within an event handler in Concurrent Mode” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cshould not bail out when an update is scheduled from within an event handler in Concurrent Mode\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/hooks-arity.test.ts",
@@ -17963,7 +17963,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “allows adding and cleaning up listeners in effects” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201callows adding and cleaning up listeners in effects\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs.test.ts",
@@ -18432,7 +18432,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “data-foo removes on null” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cdata-foo removes on null\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -18536,7 +18536,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “focus() focuses the first focusable child in tree order” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cfocus() focuses the first focusable child in tree order\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-focus.test.ts",
@@ -18567,7 +18567,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “does not fire onParentEnter when ancestor enter is none with handler only” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cdoes not fire onParentEnter when ancestor enter is none with handler only\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/view-transition.test.ts",
@@ -18706,7 +18706,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “className null reads back as \"\" from the property” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cclassName null reads back as \"\" from the property\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -18765,7 +18765,7 @@
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/hydration-mismatch.test.ts",
-          "testName": "component-form ↔ bare-form reconnects clean since M3 (Per :76)",
+          "testName": "component-form \u2194 bare-form reconnects clean since M3 (Per :76)",
           "modes": ["hydrate-match"]
         }
       ]
@@ -18864,7 +18864,7 @@
       "classification": "divergence",
       "owner": "SSR + hydration",
       "workstream": "Server integration matrix",
-      "rationale": "Octane creates statically authored SVG through compiled templates in every mode, so the HTML/SVG parser corrects textlength to textLength; React’s imperative clean-client path preserves the bad spelling and warns.",
+      "rationale": "Octane creates statically authored SVG through compiled templates in every mode, so the HTML/SVG parser corrects textlength to textLength; React\u2019s imperative clean-client path preserves the bad spelling and warns.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/server-integration-attributes-wave4d.test.ts",
@@ -19205,7 +19205,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “onInput and onChange stay independent on a custom element” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201conInput and onChange stay independent on a custom element\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -19284,7 +19284,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “returns the document when the fragment is rendered into the main tree” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201creturns the document when the fragment is rendered into the main tree\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-observers.test.ts",
@@ -20158,7 +20158,7 @@
       "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "Experimental force-throw behavior for React’s PHASE_SPAWN lane category is Fiber/lane-internal and excluded."
+      "rationale": "Experimental force-throw behavior for React\u2019s PHASE_SPAWN lane category is Fiber/lane-internal and excluded."
     },
     {
       "caseId": "react-case-v1:42e0d0a720f59f2dce1d",
@@ -20495,7 +20495,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “throws for dangerouslySetInnerHTML on a void element on the de-opt path” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cthrows for dangerouslySetInnerHTML on a void element on the de-opt path\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-children.test.ts",
@@ -20539,7 +20539,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “accepts a callback ref and fires it with the FragmentInstance” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201caccepts a callback ref and fires it with the FragmentInstance\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs.test.ts",
@@ -20928,7 +20928,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “blur() is a no-op when the focused element is OUTSIDE the fragment” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cblur() is a no-op when the focused element is OUTSIDE the fragment\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-focus.test.ts",
@@ -20987,15 +20987,15 @@
     },
     {
       "caseId": "react-case-v1:454f38a51a170e227040",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactCache-test.js",
       "title": "introspection of returned wrapper function is same on client and server",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "React reconciler residual audit",
-      "rationale": "Remaining function-component hooks, effects, context, Suspense, transitions, Activity, batching, error recovery, and reconciliation outcomes require exact observable Octane evidence; Fiber-only mechanics will receive case-level non-goal dispositions."
+      "rationale": "React's cache() and cacheSignal() request-scoped caching APIs belong to the Server Components model; Octane does not implement RSC or cache() (documented in differences-from-react.md)."
     },
     {
       "caseId": "react-case-v1:45601f9f0adf81b7715a",
@@ -21251,7 +21251,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “throws when children and dangerouslySetInnerHTML are both set” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cthrows when children and dangerouslySetInnerHTML are both set\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-children.test.ts",
@@ -21560,7 +21560,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “observeUsing forwards .observe to every direct fragment child” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cobserveUsing forwards .observe to every direct fragment child\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-observers.test.ts",
@@ -22311,7 +22311,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “preserves document order across mixed text and element rectangles” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cpreserves document order across mixed text and element rectangles\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
@@ -22775,7 +22775,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “breaks parentExit chain when intermediate ViewTransition lacks parentExit” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cbreaks parentExit chain when intermediate ViewTransition lacks parentExit\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/view-transition.test.ts",
@@ -22849,7 +22849,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “fires onParentEnter when ancestor ViewTransition enters” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cfires onParentEnter when ancestor ViewTransition enters\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/view-transition.test.ts",
@@ -22892,7 +22892,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “coerces numbers to strings” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201ccoerces numbers to strings\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -23755,7 +23755,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “skips injection-unsafe attribute names on a regular element (mount + update)” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cskips injection-unsafe attribute names on a regular element (mount + update)\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-attributes.test.ts",
@@ -23896,7 +23896,7 @@
       "classification": "divergence",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "The functional DOM outcome is executable, but Octane intentionally does not mirror React’s exact DEV warning text or warning-deduplication policy; the parity plan treats DEV-only warning policy as a documented divergence and production remains silent.",
+      "rationale": "The functional DOM outcome is executable, but Octane intentionally does not mirror React\u2019s exact DEV warning text or warning-deduplication policy; the parity plan treats DEV-only warning policy as a documented divergence and production remains silent.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-attributes.test.ts",
@@ -24724,7 +24724,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “static attribute on a custom tag passes through” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cstatic attribute on a custom tag passes through\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -24755,7 +24755,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “calls cleanup function on unmount” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201ccalls cleanup function on unmount\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/refs.test.ts",
@@ -24774,7 +24774,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “publishes fragment handles for existing, added, and removed children” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cpublishes fragment handles for existing, added, and removed children\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-future-children.test.ts",
@@ -25021,7 +25021,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “onClick on a custom element behaves like a regular element” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201conClick on a custom element behaves like a regular element\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -25100,7 +25100,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “xlink:href={null} removes the attribute” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cxlink:href={null} removes the attribute\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/svg-attributes.test.ts",
@@ -25450,7 +25450,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “keeps a <link> with onLoad/onError inline and fires both handlers” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201ckeeps a <link> with onLoad/onError inline and fires both handlers\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-events.test.ts",
@@ -25945,7 +25945,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “throws for a malformed dangerouslySetInnerHTML value” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cthrows for a malformed dangerouslySetInnerHTML value\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-children.test.ts",
@@ -26062,7 +26062,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “enters without props and does not fire handlers” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201centers without props and does not fire handlers\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/view-transition.test.ts",
@@ -26100,7 +26100,7 @@
       "classification": "divergence",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "The functional DOM outcome is executable, but Octane intentionally does not mirror React’s exact DEV warning text or warning-deduplication policy; the parity plan treats DEV-only warning policy as a documented divergence and production remains silent.",
+      "rationale": "The functional DOM outcome is executable, but Octane intentionally does not mirror React\u2019s exact DEV warning text or warning-deduplication policy; the parity plan treats DEV-only warning policy as a documented divergence and production remains silent.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -26215,7 +26215,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “renders the is attribute on the built-in element” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201crenders the is attribute on the built-in element\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-custom-elements.test.ts",
@@ -26366,7 +26366,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “fires onExit when a ViewTransition unmounts” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cfires onExit when a ViewTransition unmounts\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/view-transition.test.ts",
@@ -26639,7 +26639,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “re-applies the object after a null round-trip” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cre-applies the object after a null round-trip\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-styles.test.ts",
@@ -26833,15 +26833,15 @@
     },
     {
       "caseId": "react-case-v1:59a8dcce624d97319549",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js",
       "title": "can resume render of a prerender",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "React's postpone/resume request protocol is not part of Octane's public SSR or streaming API."
     },
     {
       "caseId": "react-case-v1:59acef1c115e77d67f6c",
@@ -26877,7 +26877,7 @@
       "classification": "adaptable",
       "owner": "SSR + hydration",
       "workstream": "Server integration matrix",
-      "rationale": "The public numeric and reserved-prop outcomes are covered across Octane’s render matrix; React’s class-component ref setup is adapted to Octane’s supported callback-ref API.",
+      "rationale": "The public numeric and reserved-prop outcomes are covered across Octane\u2019s render matrix; React\u2019s class-component ref setup is adapted to Octane\u2019s supported callback-ref API.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/server-integration-attributes-wave4d.test.ts",
@@ -27008,7 +27008,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “applies styles after an initial null style” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201capplies styles after an initial null style\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-styles.test.ts",
@@ -27369,7 +27369,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “leaves camelCase names un-aliased on custom elements” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cleaves camelCase names un-aliased on custom elements\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-custom-elements.test.ts",
@@ -27684,7 +27684,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “sets and updates class on an is= element” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201csets and updates class on an is= element\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-custom-elements.test.ts",
@@ -27770,7 +27770,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “cased data-* and custom attributes land lowercased” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201ccased data-* and custom attributes land lowercased\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-attributes.test.ts",
@@ -27789,7 +27789,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “empties the element when the raw HTML goes away” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cempties the element when the raw HTML goes away\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-children.test.ts",
@@ -27891,15 +27891,15 @@
     },
     {
       "caseId": "react-case-v1:5d0625cfee75996cc25a",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFizzStatic-test.js",
       "title": "does not fatally error when aborting with a postpone during a prerender from within",
       "baselines": ["stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "React's postpone/resume request protocol is not part of Octane's public SSR or streaming API."
     },
     {
       "caseId": "react-case-v1:5d17bbc3b8f781bd38c8",
@@ -28124,7 +28124,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “re-rendering the same type + key updates in place (no remount, mount once)” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cre-rendering the same type + key updates in place (no remount, mount once)\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/multichild-remount.test.ts",
@@ -28167,11 +28167,11 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “transitions element children → innerHTML in a nested element” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201ctransitions element children \u2192 innerHTML in a nested element\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-children.test.ts",
-          "testName": "transitions element children → innerHTML in a nested element",
+          "testName": "transitions element children \u2192 innerHTML in a nested element",
           "modes": ["client", "production-compile"]
         }
       ]
@@ -29328,7 +29328,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “passes through strings” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cpasses through strings\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -30191,7 +30191,7 @@
       "classification": "divergence",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "The functional DOM outcome is executable, but Octane intentionally does not mirror React’s exact DEV warning text or warning-deduplication policy; the parity plan treats DEV-only warning policy as a documented divergence and production remains silent.",
+      "rationale": "The functional DOM outcome is executable, but Octane intentionally does not mirror React\u2019s exact DEV warning text or warning-deduplication policy; the parity plan treats DEV-only warning policy as a documented divergence and production remains silent.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -30380,7 +30380,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “stringifies a Temporal-like __html via toString (no valueOf coercion)” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cstringifies a Temporal-like __html via toString (no valueOf coercion)\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-children.test.ts",
@@ -30811,7 +30811,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “is populated by the time useLayoutEffect AND useEffect run” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cis populated by the time useLayoutEffect AND useEffect run\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs.test.ts",
@@ -31514,7 +31514,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “keeps action/formAction/href/src on a custom element” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201ckeeps action/formAction/href/src on a custom element\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-custom-elements.test.ts",
@@ -31713,15 +31713,15 @@
     },
     {
       "caseId": "react-case-v1:69b3dd8bd6ccfd8a773d",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js",
       "title": "can render a deep list of single components where one postpones",
       "baselines": ["stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "React's postpone/resume request protocol is not part of Octane's public SSR or streaming API."
     },
     {
       "caseId": "react-case-v1:69b90f51e5f73bd86c7d",
@@ -31967,7 +31967,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “removing a child preserves the surviving instances” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cremoving a child preserves the surviving instances\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/multichild-identity.test.ts",
@@ -32114,7 +32114,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “reports exact containment for direct text children” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201creports exact containment for direct text children\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-position.test.ts",
@@ -32346,11 +32346,11 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “transitions innerHTML → string content on the same element” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201ctransitions innerHTML \u2192 string content on the same element\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-children.test.ts",
-          "testName": "transitions innerHTML → string content on the same element",
+          "testName": "transitions innerHTML \u2192 string content on the same element",
           "modes": ["client", "production-compile"]
         }
       ]
@@ -32449,7 +32449,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “clears the text when a text child transitions to null/undefined/false” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cclears the text when a text child transitions to null/undefined/false\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-children.test.ts",
@@ -33161,7 +33161,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “prepend + append preserve existing instances” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cprepend + append preserve existing instances\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/multichild-identity.test.ts",
@@ -33324,11 +33324,11 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “fires document capture → outer/inner capture → inner/outer bubble → document bubble” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cfires document capture \u2192 outer/inner capture \u2192 inner/outer bubble \u2192 document bubble\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-events.test.ts",
-          "testName": "fires document capture → outer/inner capture → inner/outer bubble → document bubble",
+          "testName": "fires document capture \u2192 outer/inner capture \u2192 inner/outer bubble \u2192 document bubble",
           "modes": ["client", "production-compile"]
         }
       ]
@@ -33415,7 +33415,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “disconnects preserved hidden children and reconnects them when Activity reveals” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cdisconnects preserved hidden children and reconnects them when Activity reveals\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-activity.test.ts",
@@ -33537,7 +33537,7 @@
       "classification": "non_goal",
       "owner": "events",
       "workstream": "React synthetic event system",
-      "rationale": "Octane uses delegated native DOM events and deliberately has no SyntheticEvent classes, event plugins, pooling, synthetic onChange normalization, or plugin dispatch queues; trusted Chromium evidence pins native click → input → change order and React's click-derived change timing.",
+      "rationale": "Octane uses delegated native DOM events and deliberately has no SyntheticEvent classes, event plugins, pooling, synthetic onChange normalization, or plugin dispatch queues; trusted Chromium evidence pins native click \u2192 input \u2192 change order and React's click-derived change timing.",
       "evidence": [
         {
           "file": "packages/octane/tests/browser/native-change/native-change.test.ts",
@@ -33658,7 +33658,7 @@
       "classification": "divergence",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "The functional DOM outcome is executable, but Octane intentionally does not mirror React’s exact DEV warning text or warning-deduplication policy; the parity plan treats DEV-only warning policy as a documented divergence and production remains silent.",
+      "rationale": "The functional DOM outcome is executable, but Octane intentionally does not mirror React\u2019s exact DEV warning text or warning-deduplication policy; the parity plan treats DEV-only warning policy as a documented divergence and production remains silent.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -33677,7 +33677,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “adds an arbitrary attribute on update to a dashed tag” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cadds an arbitrary attribute on update to a dashed tag\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-custom-elements.test.ts",
@@ -33696,7 +33696,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “should work with callback style refs” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cshould work with callback style refs\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/refs.test.ts",
@@ -34030,15 +34030,15 @@
     },
     {
       "caseId": "react-case-v1:72116c92e9c9c62139ce",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js",
       "title": "emits an empty prelude if a postpone in a promise in the shell",
       "baselines": ["stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "React's postpone/resume request protocol is not part of Octane's public SSR or streaming API."
     },
     {
       "caseId": "react-case-v1:72206c8a19e5244dc760",
@@ -34348,7 +34348,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “records both fragment handles on children shared by nested fragments” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201crecords both fragment handles on children shared by nested fragments\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-future-children.test.ts",
@@ -35317,7 +35317,7 @@
       "classification": "adaptable",
       "owner": "SSR + hydration",
       "workstream": "Server integration matrix",
-      "rationale": "The public numeric and reserved-prop outcomes are covered across Octane’s render matrix; React’s class-component ref setup is adapted to Octane’s supported callback-ref API.",
+      "rationale": "The public numeric and reserved-prop outcomes are covered across Octane\u2019s render matrix; React\u2019s class-component ref setup is adapted to Octane\u2019s supported callback-ref API.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/server-integration-attributes-wave4d.test.ts",
@@ -35475,7 +35475,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “does not fire onParentEnter when ancestor shares instead of entering” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cdoes not fire onParentEnter when ancestor shares instead of entering\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/view-transition.test.ts",
@@ -35760,7 +35760,7 @@
       "classification": "adaptable",
       "owner": "SSR + hydration",
       "workstream": "Server integration matrix",
-      "rationale": "The public numeric and reserved-prop outcomes are covered across Octane’s render matrix; React’s class-component ref setup is adapted to Octane’s supported callback-ref API.",
+      "rationale": "The public numeric and reserved-prop outcomes are covered across Octane\u2019s render matrix; React\u2019s class-component ref setup is adapted to Octane\u2019s supported callback-ref API.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/server-integration-attributes-wave4d.test.ts",
@@ -35877,7 +35877,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “preserves whitespace across a raw-HTML update” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cpreserves whitespace across a raw-HTML update\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-children.test.ts",
@@ -36017,7 +36017,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “changing a keyed child component key unmounts the old and mounts the new” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cchanging a keyed child component key unmounts the old and mounts the new\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/multichild-remount.test.ts",
@@ -36314,7 +36314,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “projects slot attributes onto web-component and regular children” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cprojects slot attributes onto web-component and regular children\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-custom-elements.test.ts",
@@ -36448,7 +36448,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “fires onParentExit when ancestor ViewTransition has no props” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cfires onParentExit when ancestor ViewTransition has no props\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/view-transition.test.ts",
@@ -36927,7 +36927,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “allows __html: null” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201callows __html: null\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-children.test.ts",
@@ -37010,7 +37010,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “marks logically owned portaled children as implementation-specific” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cmarks logically owned portaled children as implementation-specific\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-position.test.ts",
@@ -37065,7 +37065,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “fires onUpdate when content inside a ViewTransition changes” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cfires onUpdate when content inside a ViewTransition changes\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/view-transition.test.ts",
@@ -37216,7 +37216,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “option value=\"\" reads as \"\" and a valueless option falls back to its text” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201coption value=\"\" reads as \"\" and a valueless option falls back to its text\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -37503,7 +37503,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “applies event listeners to host children nested within non-host children” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201capplies event listeners to host children nested within non-host children\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs.test.ts",
@@ -37553,7 +37553,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “rejects children on a void element at compile time” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201crejects children on a void element at compile time\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-children.test.ts",
@@ -37766,7 +37766,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “title removes when the prop disappears (spread)” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201ctitle removes when the prop disappears (spread)\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -38114,11 +38114,11 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “transitions innerHTML → element children in a nested element” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201ctransitions innerHTML \u2192 element children in a nested element\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-children.test.ts",
-          "testName": "transitions innerHTML → element children in a nested element",
+          "testName": "transitions innerHTML \u2192 element children in a nested element",
           "modes": ["client", "production-compile"]
         }
       ]
@@ -38133,7 +38133,7 @@
       "classification": "non_goal",
       "owner": "runtime",
       "workstream": "Update reconciliation",
-      "rationale": "The assertion is React’s DEV warning plus native debug stack and captureOwnerStack formatting. Octane does not expose owner-stack diagnostics; generic passive-effect loop termination can be covered without this case."
+      "rationale": "The assertion is React\u2019s DEV warning plus native debug stack and captureOwnerStack formatting. Octane does not expose owner-stack diagnostics; generic passive-effect loop termination can be covered without this case."
     },
     {
       "caseId": "react-case-v1:8065dbc4dabf42f2e8d3",
@@ -38623,7 +38623,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “a single useId is stable across re-renders” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201ca single useId is stable across re-renders\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/useid-determinism.test.ts",
@@ -38776,11 +38776,11 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “hidden true → present, false → removed” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201chidden true \u2192 present, false \u2192 removed\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
-          "testName": "hidden true → present, false → removed",
+          "testName": "hidden true \u2192 present, false \u2192 removed",
           "modes": ["client", "production-compile"]
         }
       ]
@@ -38807,7 +38807,7 @@
       "classification": "divergence",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Octane’s class/className contract is clsx-style composition: object values contribute truthy keys instead of being coerced through an object toString() method as React does.",
+      "rationale": "Octane\u2019s class/className contract is clsx-style composition: object values contribute truthy keys instead of being coerced through an object toString() method as React does.",
       "evidence": [
         {
           "file": "packages/octane/tests/clsx-class.test.ts",
@@ -38899,7 +38899,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “clears a property missing from the next style object” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cclears a property missing from the next style object\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-styles.test.ts",
@@ -38918,7 +38918,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “stops the parentEnter relay when an intermediate class is \"none\"” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cstops the parentEnter relay when an intermediate class is \"none\"\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/view-transition.test.ts",
@@ -38949,7 +38949,7 @@
       "classification": "adaptable",
       "owner": "SSR + hydration",
       "workstream": "Server integration matrix",
-      "rationale": "The public numeric and reserved-prop outcomes are covered across Octane’s render matrix; React’s class-component ref setup is adapted to Octane’s supported callback-ref API.",
+      "rationale": "The public numeric and reserved-prop outcomes are covered across Octane\u2019s render matrix; React\u2019s class-component ref setup is adapted to Octane\u2019s supported callback-ref API.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/server-integration-attributes-wave4d.test.ts",
@@ -39012,7 +39012,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “inserting in the middle preserves existing instances” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cinserting in the middle preserves existing instances\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/multichild-identity.test.ts",
@@ -39569,7 +39569,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “skips injection-unsafe attribute names on a custom element (mount + update)” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cskips injection-unsafe attribute names on a custom element (mount + update)\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-attributes.test.ts",
@@ -39588,7 +39588,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “compares an empty Fragment rendered into a portal” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201ccompares an empty Fragment rendered into a portal\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-parity-ledger.test.ts",
@@ -39680,11 +39680,11 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “boolean props on custom elements: true → \"\", false → removed” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cboolean props on custom elements: true \u2192 \"\", false \u2192 removed\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
-          "testName": "boolean props on custom elements: true → \"\", false → removed",
+          "testName": "boolean props on custom elements: true \u2192 \"\", false \u2192 removed",
           "modes": ["client", "production-compile"]
         }
       ]
@@ -39723,7 +39723,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “does not fire onParentExit when ancestor exit is none” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cdoes not fire onParentExit when ancestor exit is none\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/view-transition.test.ts",
@@ -39754,7 +39754,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “keeps arbitrary attributes on an element with is=” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201ckeeps arbitrary attributes on an element with is=\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-attributes.test.ts",
@@ -39894,7 +39894,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “spellCheck stringifies true/false to \"true\"/\"false\"” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cspellCheck stringifies true/false to \"true\"/\"false\"\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -40022,7 +40022,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “removes an attribute when the prop goes away” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cremoves an attribute when the prop goes away\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-attributes.test.ts",
@@ -41568,7 +41568,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “reverse preserves all instances (pure moves)” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201creverse preserves all instances (pure moves)\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/multichild-identity.test.ts",
@@ -41704,7 +41704,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “scrolls children in tree order when aligning to the bottom” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cscrolls children in tree order when aligning to the bottom\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
@@ -41827,15 +41827,15 @@
     },
     {
       "caseId": "react-case-v1:8cc34b232135bbe7d0d2",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js",
       "title": "emits an empty prelude and resumes at the root if we postpone in the shell",
       "baselines": ["stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "React's postpone/resume request protocol is not part of Octane's public SSR or streaming API."
     },
     {
       "caseId": "react-case-v1:8ccbe1da357b96452e87",
@@ -42091,7 +42091,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “omits the style attribute when every value is null” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201comits the style attribute when every value is null\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/css-properties.test.ts",
@@ -42179,7 +42179,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “includes only logically owned portal children in handles, listeners, and observers” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cincludes only logically owned portal children in handles, listeners, and observers\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-future-children.test.ts",
@@ -42356,7 +42356,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “does not hyphenate a camelCase custom property name” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cdoes not hyphenate a camelCase custom property name\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/css-properties.test.ts",
@@ -42616,15 +42616,15 @@
     },
     {
       "caseId": "react-case-v1:8f43d5497f45a035c3ab",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactCache-test.js",
       "title": "cached functions that throw should cache the error",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "React reconciler residual audit",
-      "rationale": "Remaining function-component hooks, effects, context, Suspense, transitions, Activity, batching, error recovery, and reconciliation outcomes require exact observable Octane evidence; Fiber-only mechanics will receive case-level non-goal dispositions."
+      "rationale": "React's cache() and cacheSignal() request-scoped caching APIs belong to the Server Components model; Octane does not implement RSC or cache() (documented in differences-from-react.md)."
     },
     {
       "caseId": "react-case-v1:8f4d2ad4bbdeb821ec8f",
@@ -42734,7 +42734,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “scrolls portaled children in order across different scroll containers” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cscrolls portaled children in order across different scroll containers\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-parity-ledger.test.ts",
@@ -42868,7 +42868,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “img src=\"\" is not added (React strips it)” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cimg src=\"\" is not added (React strips it)\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -42976,15 +42976,15 @@
     },
     {
       "caseId": "react-case-v1:907fc6f1a3e90c89e24f",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js",
       "title": "reveals a resumed boundary even when the shell outlined a completed boundary",
       "baselines": ["canary"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "React's postpone/resume request protocol is not part of Octane's public SSR or streaming API."
     },
     {
       "caseId": "react-case-v1:908b28a5560190181ce3",
@@ -43245,7 +43245,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “scrolls toward the previous sibling for bottom-aligned empty fragments” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cscrolls toward the previous sibling for bottom-aligned empty fragments\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
@@ -43500,7 +43500,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “removes className when the prop goes away” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cremoves className when the prop goes away\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-attributes.test.ts",
@@ -43668,15 +43668,15 @@
     },
     {
       "caseId": "react-case-v1:9318b5067e33467d7e78",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js",
       "title": "should resolve an empty prelude if aborting before the shell is complete",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "React's postpone/resume request protocol is not part of Octane's public SSR or streaming API."
     },
     {
       "caseId": "react-case-v1:931db62c2f5084b3afd9",
@@ -43798,7 +43798,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “throws for invalid tag names in a server render” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cthrows for invalid tag names in a server render\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-ssr.test.ts",
@@ -44022,7 +44022,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “emits dangerouslySetInnerHTML content raw” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cemits dangerouslySetInnerHTML content raw\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-ssr.test.ts",
@@ -44685,15 +44685,15 @@
     },
     {
       "caseId": "react-case-v1:96b33be7537c44b435d2",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js",
       "title": "can abort the resume",
       "baselines": ["stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "React's postpone/resume request protocol is not part of Octane's public SSR or streaming API."
     },
     {
       "caseId": "react-case-v1:96c2e23b4b15609698c1",
@@ -45172,7 +45172,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “treats passive:true and passive:false as same listener per DOM spec” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201ctreats passive:true and passive:false as same listener per DOM spec\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-events.test.ts",
@@ -45500,7 +45500,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “role is written as an attribute” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201crole is written as an attribute\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -45684,7 +45684,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “scrolls toward the next sibling for empty fragments by default” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cscrolls toward the next sibling for empty fragments by default\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
@@ -45923,7 +45923,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “fires onParentEnter when ancestor ViewTransition enters with handler only” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cfires onParentEnter when ancestor ViewTransition enters with handler only\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/view-transition.test.ts",
@@ -46016,7 +46016,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “focuses deeply nested focusable children depth-first with focus()” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cfocuses deeply nested focusable children depth-first with focus()\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-parity-ledger.test.ts",
@@ -46147,15 +46147,15 @@
     },
     {
       "caseId": "react-case-v1:9d15e0069e66c47e93bf",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js",
       "title": "can postpone a boundary after it has already been added",
       "baselines": ["stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "React's postpone/resume request protocol is not part of Octane's public SSR or streaming API."
     },
     {
       "caseId": "react-case-v1:9d25be1faf83582ddd38",
@@ -46258,7 +46258,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “should remove refs when removing the child ref attribute” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cshould remove refs when removing the child ref attribute\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/refs-destruction.test.ts",
@@ -46332,7 +46332,7 @@
       "status": "documented",
       "risk": "low",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMTestSelectors-test.js",
-      "title": "should return null if findAllNodes was able to find a match",
+      "title": "should return null if findAllNodes\u00a0was able to find a match",
       "baselines": ["canary", "stable"],
       "classification": "non_goal",
       "owner": "out of scope",
@@ -46884,7 +46884,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “writes string/number/NaN custom attribute values, removes null” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cwrites string/number/NaN custom attribute values, removes null\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-attributes.test.ts",
@@ -47157,7 +47157,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “returns the captured fragment instance after it has been unmounted” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201creturns the captured fragment instance after it has been unmounted\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
@@ -47212,7 +47212,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “dangerouslySetInnerHTML difference warns and keeps server html (Per :196)” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cdangerouslySetInnerHTML difference warns and keeps server html (Per :196)\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/hydration-mismatch.test.ts",
@@ -47235,15 +47235,15 @@
     },
     {
       "caseId": "react-case-v1:a0b3655ebcbb4c44c185",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFizzStaticNode-test.js",
       "title": "should resolve with an empty prelude if passing an already aborted signal",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "React's postpone/resume request protocol is not part of Octane's public SSR or streaming API."
     },
     {
       "caseId": "react-case-v1:a0b47527d756b975e974",
@@ -47359,7 +47359,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “does not re-apply styles when the style object identity is unchanged” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cdoes not re-apply styles when the style object identity is unchanged\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-styles.test.ts",
@@ -47485,7 +47485,7 @@
       "classification": "adaptable",
       "owner": "SSR + hydration",
       "workstream": "Server integration matrix",
-      "rationale": "The public numeric and reserved-prop outcomes are covered across Octane’s render matrix; React’s class-component ref setup is adapted to Octane’s supported callback-ref API.",
+      "rationale": "The public numeric and reserved-prop outcomes are covered across Octane\u2019s render matrix; React\u2019s class-component ref setup is adapted to Octane\u2019s supported callback-ref API.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/server-integration-attributes-wave4d.test.ts",
@@ -47614,7 +47614,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “addEventListener attaches the listener to ALL direct fragment children” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201caddEventListener attaches the listener to ALL direct fragment children\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-events.test.ts",
@@ -47838,7 +47838,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “throws for a malformed dangerouslySetInnerHTML value” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cthrows for a malformed dangerouslySetInnerHTML value\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-children.test.ts",
@@ -47943,7 +47943,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “should remove refs when destroying the child” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cshould remove refs when destroying the child\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/refs-destruction.test.ts",
@@ -48235,7 +48235,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “removing a child preserves the surviving instances” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cremoving a child preserves the surviving instances\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/multichild-identity.test.ts",
@@ -48278,11 +48278,11 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “transitions string content → innerHTML on the same element” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201ctransitions string content \u2192 innerHTML on the same element\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-children.test.ts",
-          "testName": "transitions string content → innerHTML on the same element",
+          "testName": "transitions string content \u2192 innerHTML on the same element",
           "modes": ["client", "production-compile"]
         }
       ]
@@ -48499,7 +48499,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “keeps focus on a nested child if already focused” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201ckeeps focus on a nested child if already focused\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-parity-ledger.test.ts",
@@ -48633,7 +48633,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “preserves document order when adding and removing focusable children” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cpreserves document order when adding and removing focusable children\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-parity-ledger.test.ts",
@@ -48863,7 +48863,7 @@
       "classification": "non_goal",
       "owner": "SSR + hydration",
       "workstream": "Server integration matrix",
-      "rationale": "The case targets React private dispatcher access or Rules-of-Hooks diagnostics that do not apply to Octane’s compiler-assigned hook slots and public context API."
+      "rationale": "The case targets React private dispatcher access or Rules-of-Hooks diagnostics that do not apply to Octane\u2019s compiler-assigned hook slots and public context API."
     },
     {
       "caseId": "react-case-v1:a606a574631b5c5596f3",
@@ -49113,7 +49113,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “excludes hidden Activity children from listeners and fragment ownership” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cexcludes hidden Activity children from listeners and fragment ownership\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-activity.test.ts",
@@ -49665,15 +49665,15 @@
     },
     {
       "caseId": "react-case-v1:a88c9afa2e0a1470261c",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFizzStaticFloat-test.js",
       "title": "should transfer connection credentials across prerender and resume for stylesheets, scripts, and moduleScripts",
       "baselines": ["stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "React's postpone/resume request protocol is not part of Octane's public SSR or streaming API."
     },
     {
       "caseId": "react-case-v1:a88d13d476986489c8b3",
@@ -49783,7 +49783,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “fires onParentExit when ancestor ViewTransition exits” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cfires onParentExit when ancestor ViewTransition exits\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/view-transition.test.ts",
@@ -49802,7 +49802,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “exits without props and does not fire handlers” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cexits without props and does not fire handlers\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/view-transition.test.ts",
@@ -50302,7 +50302,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “src/data-foo null and undefined never land in the DOM” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201csrc/data-foo null and undefined never land in the DOM\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -50644,7 +50644,7 @@
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/enter-leave-traversal.test.ts",
-          "testName": "traverses enter/leave to sibling — avoids parent",
+          "testName": "traverses enter/leave to sibling \u2014 avoids parent",
           "modes": ["client", "production-compile"]
         }
       ]
@@ -50836,7 +50836,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “removes a capture listener registered with boolean when removed with options object” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cremoves a capture listener registered with boolean when removed with options object\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-events.test.ts",
@@ -51354,7 +51354,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “sets and updates class on an is= element” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201csets and updates class on an is= element\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-custom-elements.test.ts",
@@ -51970,15 +51970,15 @@
     },
     {
       "caseId": "react-case-v1:b0dcf35f444f8e923c91",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js",
       "title": "does not bootstrap again in a resume if it bootstraps",
       "baselines": ["stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "React's postpone/resume request protocol is not part of Octane's public SSR or streaming API."
     },
     {
       "caseId": "react-case-v1:b0e42d4b956975616588",
@@ -51990,7 +51990,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “scrolls the parent when an empty fragment has no siblings” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cscrolls the parent when an empty fragment has no siblings\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
@@ -52088,7 +52088,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “progress value={null} removes the attribute (indeterminate)” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cprogress value={null} removes the attribute (indeterminate)\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -52262,7 +52262,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “uses toString() for object attribute values (own and inherited)” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cuses toString() for object attribute values (own and inherited)\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-attributes.test.ts",
@@ -52717,7 +52717,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “writes string/number/NaN custom attribute values, removes null” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cwrites string/number/NaN custom attribute values, removes null\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-attributes.test.ts",
@@ -53137,7 +53137,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “fires onParentExit when ancestor ViewTransition exits with handler only” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cfires onParentExit when ancestor ViewTransition exits with handler only\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/view-transition.test.ts",
@@ -53288,7 +53288,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “a key removed then re-added is remounted (new instance)” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201ca key removed then re-added is remounted (new instance)\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/multichild-identity.test.ts",
@@ -53536,7 +53536,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “uses toString() for object attribute values (own and inherited)” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cuses toString() for object attribute values (own and inherited)\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-attributes.test.ts",
@@ -53555,7 +53555,7 @@
       "classification": "non_goal",
       "owner": "SSR + hydration",
       "workstream": "Server integration matrix",
-      "rationale": "React Profiler elements are outside Octane’s component surface; Octane profiling uses its dedicated profiling build."
+      "rationale": "React Profiler elements are outside Octane\u2019s component surface; Octane profiling uses its dedicated profiling build."
     },
     {
       "caseId": "react-case-v1:b61f724f1c1f54ef7e51",
@@ -53756,7 +53756,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “does not fire onParentExit when ancestor shares instead of exiting” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cdoes not fire onParentExit when ancestor shares instead of exiting\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/view-transition.test.ts",
@@ -54325,7 +54325,7 @@
       "classification": "adaptable",
       "owner": "SSR + hydration",
       "workstream": "Server integration matrix",
-      "rationale": "The public numeric and reserved-prop outcomes are covered across Octane’s render matrix; React’s class-component ref setup is adapted to Octane’s supported callback-ref API.",
+      "rationale": "The public numeric and reserved-prop outcomes are covered across Octane\u2019s render matrix; React\u2019s class-component ref setup is adapted to Octane\u2019s supported callback-ref API.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/server-integration-attributes-wave4d.test.ts",
@@ -54585,7 +54585,7 @@
       "classification": "divergence",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "The functional DOM outcome is executable, but Octane intentionally does not mirror React’s exact DEV warning text or warning-deduplication policy; the parity plan treats DEV-only warning policy as a documented divergence and production remains silent.",
+      "rationale": "The functional DOM outcome is executable, but Octane intentionally does not mirror React\u2019s exact DEV warning text or warning-deduplication policy; the parity plan treats DEV-only warning policy as a documented divergence and production remains silent.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -54707,7 +54707,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “removes a capture listener registered with options object when removed with boolean” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cremoves a capture listener registered with options object when removed with boolean\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-events.test.ts",
@@ -54875,7 +54875,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “a listener added before a child existed still fires on that child once it mounts” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201ca listener added before a child existed still fires on that child once it mounts\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-future-children.test.ts",
@@ -54894,7 +54894,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “fires onEnter when a ViewTransition mounts” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cfires onEnter when a ViewTransition mounts\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/view-transition.test.ts",
@@ -54929,15 +54929,15 @@
     },
     {
       "caseId": "react-case-v1:ba4d5e6f544c6e7d6054",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js",
       "title": "can resume an optimistic keyed slot",
       "baselines": ["canary"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "React's postpone/resume request protocol is not part of Octane's public SSR or streaming API."
     },
     {
       "caseId": "react-case-v1:ba92c2d99f408aa9c81e",
@@ -55235,7 +55235,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “inner fragment.contains a child only of the inner range” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cinner fragment.contains a child only of the inner range\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
@@ -55391,15 +55391,15 @@
     },
     {
       "caseId": "react-case-v1:bc6591e6bcd9ad88907d",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js",
       "title": "can resume a partially prerendered SuspenseList",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "React's postpone/resume request protocol is not part of Octane's public SSR or streaming API."
     },
     {
       "caseId": "react-case-v1:bc70b031e829d8072e01",
@@ -56094,15 +56094,15 @@
     },
     {
       "caseId": "react-case-v1:be21cb704ae3bde256b6",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js",
       "title": "does not emit preloads during resume for Resources preloaded through onHeaders",
       "baselines": ["stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "React's postpone/resume request protocol is not part of Octane's public SSR or streaming API."
     },
     {
       "caseId": "react-case-v1:be359e7ad9e77b27180b",
@@ -56217,7 +56217,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “does not refocus an already focused first child” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cdoes not refocus an already focused first child\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-focus.test.ts",
@@ -56732,7 +56732,7 @@
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/ssr-server-semantics.test.ts",
-          "testName": "forwards refs through component props (Per :76 — React-19 style, no forwardRef)",
+          "testName": "forwards refs through component props (Per :76 \u2014 React-19 style, no forwardRef)",
           "modes": ["hydrate-match"]
         }
       ]
@@ -56775,15 +56775,15 @@
     },
     {
       "caseId": "react-case-v1:c0f71d77e24c49adbbe4",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js",
       "title": "can abort while rendering a resumed segment",
       "baselines": ["canary"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "React's postpone/resume request protocol is not part of Octane's public SSR or streaming API."
     },
     {
       "caseId": "react-case-v1:c110371991d2e4c42c39",
@@ -56930,11 +56930,11 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “round-trips object → null → object → null” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cround-trips object \u2192 null \u2192 object \u2192 null\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-styles.test.ts",
-          "testName": "round-trips object → null → object → null",
+          "testName": "round-trips object \u2192 null \u2192 object \u2192 null",
           "modes": ["client", "production-compile"]
         }
       ]
@@ -57235,7 +57235,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “form action=\"\" keeps the empty attribute” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cform action=\"\" keeps the empty attribute\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -57254,7 +57254,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “disconnects preserved hidden children and reconnects them when Activity reveals” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cdisconnects preserved hidden children and reconnects them when Activity reveals\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-activity.test.ts",
@@ -57539,7 +57539,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “rejects scroll options objects instead of passing them to DOM elements” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201crejects scroll options objects instead of passing them to DOM elements\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
@@ -57697,11 +57697,11 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “aliases `acceptCharset` → `accept-charset`; native spelling also works” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201caliases `acceptCharset` \u2192 `accept-charset`; native spelling also works\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-attributes.test.ts",
-          "testName": "aliases `acceptCharset` → `accept-charset`; native spelling also works",
+          "testName": "aliases `acceptCharset` \u2192 `accept-charset`; native spelling also works",
           "modes": ["client", "production-compile"]
         }
       ]
@@ -57833,7 +57833,7 @@
       "classification": "divergence",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "The functional DOM outcome is executable, but Octane intentionally does not mirror React’s exact DEV warning text or warning-deduplication policy; the parity plan treats DEV-only warning policy as a documented divergence and production remains silent.",
+      "rationale": "The functional DOM outcome is executable, but Octane intentionally does not mirror React\u2019s exact DEV warning text or warning-deduplication policy; the parity plan treats DEV-only warning policy as a documented divergence and production remains silent.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -57852,7 +57852,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “focus / focusLast / blur are no-ops” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cfocus / focusLast / blur are no-ops\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
@@ -58230,7 +58230,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “cased data-* and custom attributes land lowercased” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201ccased data-* and custom attributes land lowercased\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-attributes.test.ts",
@@ -58443,7 +58443,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “swaps one custom attribute for another across renders” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cswaps one custom attribute for another across renders\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-custom-elements.test.ts",
@@ -59165,7 +59165,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “focusLast() focuses the LAST focusable child in tree order” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cfocusLast() focuses the LAST focusable child in tree order\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-focus.test.ts",
@@ -59630,7 +59630,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “flipping the host element type at one position remounts the node” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cflipping the host element type at one position remounts the node\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/multichild-remount.test.ts",
@@ -59848,7 +59848,7 @@
       "classification": "non_goal",
       "owner": "SSR + hydration",
       "workstream": "Server integration matrix",
-      "rationale": "The case targets React private dispatcher access or Rules-of-Hooks diagnostics that do not apply to Octane’s compiler-assigned hook slots and public context API."
+      "rationale": "The case targets React private dispatcher access or Rules-of-Hooks diagnostics that do not apply to Octane\u2019s compiler-assigned hook slots and public context API."
     },
     {
       "caseId": "react-case-v1:ca4a79c5455e43cb1485",
@@ -59860,7 +59860,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “removeEventListener stops future children from getting the listener” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cremoveEventListener stops future children from getting the listener\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-future-children.test.ts",
@@ -59919,15 +59919,15 @@
     },
     {
       "caseId": "react-case-v1:ca6c93fb7e4d9b860df2",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js",
       "title": "should resolve an empty prelude if passing an already aborted signal",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "React's postpone/resume request protocol is not part of Octane's public SSR or streaming API."
     },
     {
       "caseId": "react-case-v1:ca6e50fd2181c82b895e",
@@ -60244,7 +60244,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “drops injection-unsafe attribute names on a custom element” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cdrops injection-unsafe attribute names on a custom element\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-ssr.test.ts",
@@ -60426,7 +60426,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “blur() blurs an active element that lives inside the fragment” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cblur() blurs an active element that lives inside the fragment\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-focus.test.ts",
@@ -60754,7 +60754,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “writes string/number/NaN custom attribute values, removes null” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cwrites string/number/NaN custom attribute values, removes null\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-attributes.test.ts",
@@ -60888,7 +60888,7 @@
       "classification": "divergence",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "The functional DOM outcome is executable, but Octane intentionally does not mirror React’s exact DEV warning text or warning-deduplication policy; the parity plan treats DEV-only warning policy as a documented divergence and production remains silent.",
+      "rationale": "The functional DOM outcome is executable, but Octane intentionally does not mirror React\u2019s exact DEV warning text or warning-deduplication policy; the parity plan treats DEV-only warning policy as a documented divergence and production remains silent.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -61024,7 +61024,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “prepend + append preserve existing instances” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cprepend + append preserve existing instances\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/multichild-identity.test.ts",
@@ -61556,7 +61556,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “starts hydrated useId sequences from each server-rendered root” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cstarts hydrated useId sequences from each server-rendered root\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/useid-determinism.test.ts",
@@ -61968,7 +61968,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “removes values null and undefined” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cremoves values null and undefined\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -62474,7 +62474,7 @@
       "classification": "adaptable",
       "owner": "SSR + hydration",
       "workstream": "Server integration matrix",
-      "rationale": "The public numeric and reserved-prop outcomes are covered across Octane’s render matrix; React’s class-component ref setup is adapted to Octane’s supported callback-ref API.",
+      "rationale": "The public numeric and reserved-prop outcomes are covered across Octane\u2019s render matrix; React\u2019s class-component ref setup is adapted to Octane\u2019s supported callback-ref API.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/server-integration-attributes-wave4d.test.ts",
@@ -62591,7 +62591,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “keeps lowercase on* string attributes” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201ckeeps lowercase on* string attributes\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-custom-elements.test.ts",
@@ -62739,7 +62739,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “projects an array value as per-option membership” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cprojects an array value as per-option membership\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/controlled-select.test.ts",
@@ -62890,7 +62890,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “inserting in the middle preserves existing instances” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cinserting in the middle preserves existing instances\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/multichild-identity.test.ts",
@@ -63258,7 +63258,7 @@
       "classification": "adaptable",
       "owner": "SSR + hydration",
       "workstream": "Server integration matrix",
-      "rationale": "The public numeric and reserved-prop outcomes are covered across Octane’s render matrix; React’s class-component ref setup is adapted to Octane’s supported callback-ref API.",
+      "rationale": "The public numeric and reserved-prop outcomes are covered across Octane\u2019s render matrix; React\u2019s class-component ref setup is adapted to Octane\u2019s supported callback-ref API.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/server-integration-attributes-wave4d.test.ts",
@@ -63823,7 +63823,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “fires onError on a <source> element” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cfires onError on a <source> element\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-events.test.ts",
@@ -64026,7 +64026,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “includes text-node client rectangles when the Range API provides them” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cincludes text-node client rectangles when the Range API provides them\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
@@ -64107,7 +64107,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “fires onEnter when Suspense content resolves” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cfires onEnter when Suspense content resolves\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/view-transition.test.ts",
@@ -64418,7 +64418,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “focus / focusLast / blur are no-ops” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cfocus / focusLast / blur are no-ops\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
@@ -64492,7 +64492,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “returns PRECEDING for a sibling rendered BEFORE the fragment” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201creturns PRECEDING for a sibling rendered BEFORE the fragment\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-position.test.ts",
@@ -64583,7 +64583,7 @@
       "classification": "adaptable",
       "owner": "SSR + hydration",
       "workstream": "Server integration matrix",
-      "rationale": "The public numeric and reserved-prop outcomes are covered across Octane’s render matrix; React’s class-component ref setup is adapted to Octane’s supported callback-ref API.",
+      "rationale": "The public numeric and reserved-prop outcomes are covered across Octane\u2019s render matrix; React\u2019s class-component ref setup is adapted to Octane\u2019s supported callback-ref API.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/server-integration-attributes-wave4d.test.ts",
@@ -64645,7 +64645,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “fires onShare for paired named transitions instead of onEnter/onExit” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cfires onShare for paired named transitions instead of onEnter/onExit\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/view-transition.test.ts",
@@ -65146,7 +65146,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “stringifies plain objects to [object Object]” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cstringifies plain objects to [object Object]\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-attributes.test.ts",
@@ -65177,7 +65177,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “serializes vendor-prefixed camelCase names with the leading dash” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cserializes vendor-prefixed camelCase names with the leading dash\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/css-properties.test.ts",
@@ -65295,7 +65295,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “activates for startTransition inside a preventDefault-ed submit (Per :2021/:2078)” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cactivates for startTransition inside a preventDefault-ed submit (Per :2021/:2078)\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/form-actions-extra.test.ts",
@@ -65363,7 +65363,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “stamps a noop onclick property on a portal root” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cstamps a noop onclick property on a portal root\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-events.test.ts",
@@ -65611,7 +65611,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “drops function-valued custom attributes” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cdrops function-valued custom attributes\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-attributes.test.ts",
@@ -65850,7 +65850,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “input value=\"\" keeps the empty attribute” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cinput value=\"\" keeps the empty attribute\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -66171,7 +66171,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “warns when an observer is attached to a fragment containing only text” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cwarns when an observer is attached to a fragment containing only text\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-observers.test.ts",
@@ -66467,7 +66467,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “ids stay stable under wrapper-component indirection and differ parent/child” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cids stay stable under wrapper-component indirection and differ parent/child\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/useid-determinism.test.ts",
@@ -66553,7 +66553,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “should work with object style refs” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cshould work with object style refs\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/refs.test.ts",
@@ -66608,7 +66608,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “trims string style values” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201ctrims string style values\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/css-properties.test.ts",
@@ -66834,7 +66834,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “skips injection-unsafe attribute names on a custom element (mount + update)” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cskips injection-unsafe attribute names on a custom element (mount + update)\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-attributes.test.ts",
@@ -67104,7 +67104,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “allows refs to hop around children correctly” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201callows refs to hop around children correctly\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/refs.test.ts",
@@ -67298,7 +67298,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “escapes text content and attribute values (round-trip)” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cescapes text content and attribute values (round-trip)\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-ssr.test.ts",
@@ -67341,7 +67341,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “compares a root-level Fragment and its empty Fragment sibling” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201ccompares a root-level Fragment and its empty Fragment sibling\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-parity-ledger.test.ts",
@@ -67463,7 +67463,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “stringifies spellCheck={true} to \"true\" and {false} to \"false\"” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cstringifies spellCheck={true} to \"true\" and {false} to \"false\"\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-attributes.test.ts",
@@ -67672,7 +67672,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “dispatches on the parent host element and bubbles to its listeners” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cdispatches on the parent host element and bubbles to its listeners\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-position.test.ts",
@@ -67926,7 +67926,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “scrolls children in reverse order so the first child receives final focus” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cscrolls children in reverse order so the first child receives final focus\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",
@@ -68330,11 +68330,11 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “updates className foo → bar → null” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cupdates className foo \u2192 bar \u2192 null\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-styles.test.ts",
-          "testName": "updates className foo → bar → null",
+          "testName": "updates className foo \u2192 bar \u2192 null",
           "modes": ["client", "production-compile"]
         }
       ]
@@ -68508,15 +68508,15 @@
     },
     {
       "caseId": "react-case-v1:e66eb8e86a58159164d0",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactCache-test.js",
       "title": "cacheSignal() aborts when the render is aborted",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "React reconciler residual audit",
-      "rationale": "Remaining function-component hooks, effects, context, Suspense, transitions, Activity, batching, error recovery, and reconciliation outcomes require exact observable Octane evidence; Fiber-only mechanics will receive case-level non-goal dispositions."
+      "rationale": "React's cache() and cacheSignal() request-scoped caching APIs belong to the Server Components model; Octane does not implement RSC or cache() (documented in differences-from-react.md)."
     },
     {
       "caseId": "react-case-v1:e66f3e9d6b1594d9d505",
@@ -68691,7 +68691,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “renders new boolean props (`inert`) as an empty-string attribute” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201crenders new boolean props (`inert`) as an empty-string attribute\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -69628,7 +69628,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “returns disconnected for comparison with an unmounted fragment instance” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201creturns disconnected for comparison with an unmounted fragment instance\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-parity-ledger.test.ts",
@@ -69719,7 +69719,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “relays parentEnter chain to handler-only child through intermediate divs” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201crelays parentEnter chain to handler-only child through intermediate divs\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/view-transition.test.ts",
@@ -70044,15 +70044,15 @@
     },
     {
       "caseId": "react-case-v1:eb88e2aec36d52d7d0ba",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js",
       "title": "can postpone in fallback",
       "baselines": ["stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "React's postpone/resume request protocol is not part of Octane's public SSR or streaming API."
     },
     {
       "caseId": "react-case-v1:eba3ca2ec6a9397a2a65",
@@ -70131,7 +70131,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “returns the concatenated rects of every direct fragment child in tree order” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201creturns the concatenated rects of every direct fragment child in tree order\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-observers.test.ts",
@@ -70162,7 +70162,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “escapes style names and values (round-trip)” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cescapes style names and values (round-trip)\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-ssr.test.ts",
@@ -70450,7 +70450,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “does not fire onExit/onEnter on nested ViewTransition when the subtree is removed as one unit” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cdoes not fire onExit/onEnter on nested ViewTransition when the subtree is removed as one unit\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/view-transition.test.ts",
@@ -70639,7 +70639,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “does not fire onParentEnter when ancestor exits” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cdoes not fire onParentEnter when ancestor exits\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/view-transition.test.ts",
@@ -70897,7 +70897,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “warns + patches to the client text (Per ReactDOMHydrationDiff-test.js:119)” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cwarns + patches to the client text (Per ReactDOMHydrationDiff-test.js:119)\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/hydration-mismatch.test.ts",
@@ -70928,7 +70928,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “relays parentExit chain through unstyled parentExit” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201crelays parentExit chain through unstyled parentExit\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/view-transition.test.ts",
@@ -70983,7 +70983,7 @@
       "classification": "divergence",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "The functional DOM outcome is executable, but Octane intentionally does not mirror React’s exact DEV warning text or warning-deduplication policy; the parity plan treats DEV-only warning policy as a documented divergence and production remains silent.",
+      "rationale": "The functional DOM outcome is executable, but Octane intentionally does not mirror React\u2019s exact DEV warning text or warning-deduplication policy; the parity plan treats DEV-only warning policy as a documented divergence and production remains silent.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -71058,7 +71058,7 @@
       "status": "planned",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactIsomorphicAct-test.js",
-      "title": "return value – async callback",
+      "title": "return value \u2013 async callback",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
       "owner": "runtime",
@@ -71130,7 +71130,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “allowFullScreen={false} never lands in the DOM” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201callowFullScreen={false} never lands in the DOM\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -72169,11 +72169,11 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “reflects boolean attribute values: true → \"\", false → removed” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201creflects boolean attribute values: true \u2192 \"\", false \u2192 removed\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-custom-elements.test.ts",
-          "testName": "reflects boolean attribute values: true → \"\", false → removed",
+          "testName": "reflects boolean attribute values: true \u2192 \"\", false \u2192 removed",
           "modes": ["client", "production-compile"]
         }
       ]
@@ -72545,7 +72545,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “throws when a style value is a Temporal-like object (valueOf throws)” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cthrows when a style value is a Temporal-like object (valueOf throws)\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-styles.test.ts",
@@ -72564,7 +72564,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “spellCheck stringifies true/false to \"true\"/\"false\"” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cspellCheck stringifies true/false to \"true\"/\"false\"\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -72811,7 +72811,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “onChange on a custom element: fires, removes, re-adds” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201conChange on a custom element: fires, removes, re-adds\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -73084,11 +73084,11 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “boolean attribute transitions: true ↔ false/null/undefined” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cboolean attribute transitions: true \u2194 false/null/undefined\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
-          "testName": "boolean attribute transitions: true ↔ false/null/undefined",
+          "testName": "boolean attribute transitions: true \u2194 false/null/undefined",
           "modes": ["client", "production-compile"]
         }
       ]
@@ -73174,15 +73174,15 @@
     },
     {
       "caseId": "react-case-v1:f5f4611f8660f8804ddd",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFizzStatic-test.js",
       "title": "does not fatally error when aborting with a postpone during a prerender",
       "baselines": ["stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "React's postpone/resume request protocol is not part of Octane's public SSR or streaming API."
     },
     {
       "caseId": "react-case-v1:f5f9d2766790bf5a45f9",
@@ -73376,7 +73376,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “throws for a malformed dangerouslySetInnerHTML value” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cthrows for a malformed dangerouslySetInnerHTML value\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-children.test.ts",
@@ -73407,7 +73407,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “removes unknown attributes that were rendered but are now missing (spread)” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cremoves unknown attributes that were rendered but are now missing (spread)\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-attributes.test.ts",
@@ -73464,7 +73464,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “renders null/undefined as empty but prints 0 and false” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201crenders null/undefined as empty but prints 0 and false\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-children.test.ts",
@@ -73837,7 +73837,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “removes a listener registered with passive:false when removed with passive:true” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cremoves a listener registered with passive:false when removed with passive:true\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-events.test.ts",
@@ -74162,7 +74162,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “should work with callback style refs with cleanup function” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cshould work with callback style refs with cleanup function\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/refs.test.ts",
@@ -74473,7 +74473,7 @@
       "classification": "non_goal",
       "owner": "SSR + hydration",
       "workstream": "Server integration matrix",
-      "rationale": "The case targets React private dispatcher access or Rules-of-Hooks diagnostics that do not apply to Octane’s compiler-assigned hook slots and public context API."
+      "rationale": "The case targets React private dispatcher access or Rules-of-Hooks diagnostics that do not apply to Octane\u2019s compiler-assigned hook slots and public context API."
     },
     {
       "caseId": "react-case-v1:faa77cb931a5257402b2",
@@ -74509,7 +74509,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “stops the parentExit relay when an intermediate class is \"none\"” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cstops the parentExit relay when an intermediate class is \"none\"\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/view-transition.test.ts",
@@ -74625,7 +74625,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “uses toString() for object attribute values (own and inherited)” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cuses toString() for object attribute values (own and inherited)\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-attributes.test.ts",
@@ -74783,7 +74783,7 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Executable evidence in “should remove refs when destroying the parent” covers the supported public DOM outcome.",
+      "rationale": "Executable evidence in \u201cshould remove refs when destroying the parent\u201d covers the supported public DOM outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/refs-destruction.test.ts",
@@ -75415,7 +75415,7 @@
       "status": "planned",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactIsomorphicAct-test.js",
-      "title": "return value – sync callback, nested",
+      "title": "return value \u2013 sync callback, nested",
       "baselines": ["canary", "stable"],
       "classification": "adaptable",
       "owner": "runtime",
@@ -75753,7 +75753,7 @@
       "classification": "adaptable",
       "owner": "SSR + hydration",
       "workstream": "Server integration matrix",
-      "rationale": "The public numeric and reserved-prop outcomes are covered across Octane’s render matrix; React’s class-component ref setup is adapted to Octane’s supported callback-ref API.",
+      "rationale": "The public numeric and reserved-prop outcomes are covered across Octane\u2019s render matrix; React\u2019s class-component ref setup is adapted to Octane\u2019s supported callback-ref API.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/server-integration-attributes-wave4d.test.ts",
@@ -75798,7 +75798,7 @@
       "classification": "adaptable",
       "owner": "runtime + compiler + SSR + hydration",
       "workstream": "Fragment refs",
-      "rationale": "Executable client and production-compile evidence in “measures and scrolls portaled children in their authored logical order” verifies the exact upstream FragmentInstance public outcome.",
+      "rationale": "Executable client and production-compile evidence in \u201cmeasures and scrolls portaled children in their authored logical order\u201d verifies the exact upstream FragmentInstance public outcome.",
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/fragment-refs-misc.test.ts",

--- a/packages/octane/error-codes/codes.json
+++ b/packages/octane/error-codes/codes.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "nextCode": 51,
+  "nextCode": 57,
   "codes": {
     "1": {
       "message": "Maximum update depth exceeded. Octane limits the number of nested updates to prevent infinite loops.",
@@ -81,7 +81,7 @@
       "status": "active"
     },
     "14": {
-      "message": "act(): scheduler did not stabilize after %s iterations — likely an infinite render loop",
+      "message": "act(): scheduler did not stabilize after %s iterations \u2014 likely an infinite render loop",
       "argumentCount": 1,
       "runtime": ["client"],
       "status": "active"
@@ -147,7 +147,7 @@
       "status": "active"
     },
     "25": {
-      "message": "Octane: internal — a component descriptor reached the de-opt host reconciler (should have been routed through a Block via hostElementBody/componentSlot).",
+      "message": "Octane: internal \u2014 a component descriptor reached the de-opt host reconciler (should have been routed through a Block via hostElementBody/componentSlot).",
       "argumentCount": 0,
       "runtime": ["client"],
       "status": "active"
@@ -195,7 +195,7 @@
       "status": "active"
     },
     "33": {
-      "message": "octane SSR: exceeded %s suspense passes — a use(thenable) never resolved.",
+      "message": "octane SSR: exceeded %s suspense passes \u2014 a use(thenable) never resolved.",
       "argumentCount": 1,
       "runtime": ["server"],
       "status": "retired"
@@ -219,7 +219,7 @@
       "status": "active"
     },
     "37": {
-      "message": "octane SSR: %s consecutive streaming passes completed no boundary — a use(thenable) never resolved.",
+      "message": "octane SSR: %s consecutive streaming passes completed no boundary \u2014 a use(thenable) never resolved.",
       "argumentCount": 1,
       "runtime": ["server"],
       "status": "retired"
@@ -279,13 +279,13 @@
       "status": "active"
     },
     "47": {
-      "message": "octane SSR: exceeded %s suspense passes — a use(thenable) never resolved. If promises are re-created on every render pass (e.g. created in an ancestor render and passed down through props), create them at their use() site or hoist them out of render.",
+      "message": "octane SSR: exceeded %s suspense passes \u2014 a use(thenable) never resolved. If promises are re-created on every render pass (e.g. created in an ancestor render and passed down through props), create them at their use() site or hoist them out of render.",
       "argumentCount": 1,
       "runtime": ["server"],
       "status": "active"
     },
     "48": {
-      "message": "octane SSR: %s consecutive streaming passes completed no boundary — a use(thenable) never resolved. If promises are re-created on every render pass (e.g. created in an ancestor render and passed down through props), create them at their use() site or hoist them out of render.",
+      "message": "octane SSR: %s consecutive streaming passes completed no boundary \u2014 a use(thenable) never resolved. If promises are re-created on every render pass (e.g. created in an ancestor render and passed down through props), create them at their use() site or hoist them out of render.",
       "argumentCount": 1,
       "runtime": ["server"],
       "status": "active"
@@ -298,6 +298,42 @@
     },
     "50": {
       "message": "Unclosed server-rendered Fragment descriptor.",
+      "argumentCount": 0,
+      "runtime": ["client"],
+      "status": "active"
+    },
+    "51": {
+      "message": "Hydration mismatch: the server-rendered node did not match the client render; the mismatched subtree was rebuilt on the client.",
+      "argumentCount": 0,
+      "runtime": ["client"],
+      "status": "active"
+    },
+    "52": {
+      "message": "Hydration mismatch: root adoption was abandoned after a server/client shape divergence; the root was rebuilt on the client.",
+      "argumentCount": 0,
+      "runtime": ["client"],
+      "status": "active"
+    },
+    "53": {
+      "message": "Hydration mismatch: the server rendered more root content than the client; the stale remainder was discarded.",
+      "argumentCount": 0,
+      "runtime": ["client"],
+      "status": "active"
+    },
+    "54": {
+      "message": "Hydration mismatch: the client rendered text where the server rendered none; the client text was built fresh.",
+      "argumentCount": 0,
+      "runtime": ["client"],
+      "status": "active"
+    },
+    "55": {
+      "message": "Hydration mismatch: the server rendered a different child shape where the client renders a component; the stale range was discarded and the component was built on the client.",
+      "argumentCount": 0,
+      "runtime": ["client"],
+      "status": "active"
+    },
+    "56": {
+      "message": "Hydration mismatch: the server rendered more list items than the client; the extra server items were discarded.",
       "argumentCount": 0,
       "runtime": ["client"],
       "status": "active"

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -16316,6 +16316,14 @@ function requiresTemplateNormalization(
 		(tag !== 'link' || isHoistableHeadElementNode(node))
 	)
 		return true;
+	// Float SCRIPT resources normalize like hoistable metadata, so a
+	// value-position (`return <jsx>`) tree carrying `<script async src>` enters
+	// template normalization and headResourceKind can partition it (precedence
+	// links are already admitted through the hoistable-link branch above). Gate
+	// on allowHeadHoists like `<title>`: `<script>` is equally ambiguous across
+	// an opaque component boundary (SVG scripting vs a document resource).
+	if (selfNs !== 'svg' && allowHeadHoists && tag === 'script' && headResourceKind(node) !== null)
+		return true;
 
 	const childNs =
 		typeof tag === 'string' && !isComponentTag(node) ? nsForChildren(tag, parentNs) : parentNs;

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -1450,6 +1450,7 @@ function collectOctaneBoundaryNames(astBody) {
 				(imported === 'Suspense' ||
 					imported === 'ErrorBoundary' ||
 					imported === 'Activity' ||
+					imported === 'unstable_Activity' ||
 					imported === 'Hydrate' ||
 					imported === 'ViewTransition' ||
 					imported === 'unstable_ViewTransition') &&
@@ -5489,7 +5490,8 @@ function containsAutoMemoUnsafeStructure(stmts) {
 				name === 'Suspense' ||
 				name === 'ErrorBoundary' ||
 				name === 'ViewTransition' ||
-				name === 'Activity'
+				name === 'Activity' ||
+				name === 'unstable_Activity'
 			) {
 				found = true;
 				return;
@@ -18190,6 +18192,64 @@ function isHoistableHeadElementNode(n) {
 	return true;
 }
 
+// React Float RESOURCES: `<link rel="stylesheet" href precedence>` (no
+// load/error handlers) and `<script async src>` (no children/handlers) are not
+// per-site head elements but GLOBAL, href/src-keyed resources — hoisted,
+// deduped, precedence-ordered (stylesheets), and never removed on unmount.
+// Classification is static, like the rest of the head-hoist model: a
+// spread-carried `precedence`/`async` keeps the ordinary element path.
+/** @param {any} n @returns {'stylesheet'|'script'|null} */
+function headResourceKind(n) {
+	if (n == null || (n.type !== 'JSXElement' && n.type !== 'Element')) return null;
+	const tag = jsxTagName(n) || elementTagName(n);
+	if (tag !== 'link' && tag !== 'script') return null;
+	const attrs = n.attributes || n.openingElement?.attributes || [];
+	let hasPrecedence = false;
+	let relStylesheet = false;
+	let hasHref = false;
+	let hasAsync = false;
+	let hasSrc = false;
+	for (const attr of attrs) {
+		if (attr.type !== 'Attribute' && attr.type !== 'JSXAttribute') continue;
+		const name = jsxAttrRawName(attr);
+		// Handlers keep the element per-site (matching React: a load/error
+		// listener needs an owned instance); markup injection disqualifies too.
+		if (name === 'onLoad' || name === 'onError' || name === 'dangerouslySetInnerHTML') return null;
+		if (name === 'precedence') hasPrecedence = true;
+		else if (name === 'href') hasHref = true;
+		else if (name === 'async') {
+			// A statically-false `async={false}` is not an async script; any other
+			// form (bare, true, or a dynamic expression) classifies as a resource.
+			const val = attr.value;
+			const inner = val && val.type === 'JSXExpressionContainer' ? val.expression : val;
+			hasAsync = !(
+				inner != null &&
+				(inner.type === 'Literal' || inner.type === 'BooleanLiteral') &&
+				inner.value === false
+			);
+		} else if (name === 'src') hasSrc = true;
+		else if (name === 'rel') {
+			const val = attr.value;
+			const inner = val && val.type === 'JSXExpressionContainer' ? val.expression : val;
+			relStylesheet =
+				inner != null &&
+				(inner.type === 'Literal' || inner.type === 'StringLiteral') &&
+				inner.value === 'stylesheet';
+		}
+	}
+	if (tag === 'link') return relStylesheet && hasPrecedence && hasHref ? 'stylesheet' : null;
+	if (!hasAsync || !hasSrc) return null;
+	// An inline body (raw script text or non-whitespace children) keeps the
+	// script in its authored position — only external async scripts hoist.
+	if (typeof n.content === 'string' && n.content.trim() !== '') return null;
+	for (const child of n.children || []) {
+		if ((child.type === 'JSXText' || child.type === 'Text') && /^\s*$/.test(child.value ?? ''))
+			continue;
+		return null;
+	}
+	return 'script';
+}
+
 // Deterministic per-element key bridging the client `headBlock` (its scope-state
 // key + SSR-marker adoption) and the server `ssrHeadEl` marker. Bundlers pass a
 // canonical root-relative module id; direct compiler callers already need to
@@ -18416,10 +18476,9 @@ function rewriteOpaqueTitles(node, ctx, namespace = 'html') {
 // object-literal expression (dynamic values stay live expressions, so the
 // metadata is reactive); a `<title>`'s text becomes a string-concat expression;
 // void tags (`<meta>`/`<link>`) pass `null` for text.
-/** @param {any} node @param {number} index @param {any} ctx @returns {string} */
-function headElementArgNodes(node, index, ctx) {
-	const el = node.element;
-	const tag = jsxTagName(el);
+/** Attribute object-literal expression for a hoisted head element or resource. */
+/** @param {any} el @returns {any} */
+function headAttrsExpression(el) {
 	const attrProps = [];
 	for (const a of el.openingElement.attributes || []) {
 		if (a.type === 'SpreadAttribute' || a.type === 'JSXSpreadAttribute') {
@@ -18452,7 +18511,14 @@ function headElementArgNodes(node, index, ctx) {
 			attrProps.push(b.prop('init', b.literal(attrName), inner));
 		}
 	}
-	const attrsExpr = attrProps.length ? b.object(attrProps) : b.literal(null);
+	return attrProps.length ? b.object(attrProps) : b.literal(null);
+}
+
+/** @param {any} node @param {number} index @param {any} ctx @returns {string} */
+function headElementArgNodes(node, index, ctx) {
+	const el = node.element;
+	const tag = jsxTagName(el);
+	const attrsExpr = headAttrsExpression(el);
 	const textExpr = VOID_ELEMENTS.has(tag) ? b.literal(null) : headTextExpression(el);
 	return [
 		b.literal(headKey(el, index, ctx), undefined, el),
@@ -18467,11 +18533,24 @@ function headElementArgNodes(node, index, ctx) {
 /** @param {any[]} headNodes @param {any} ctx @param {number} slotBase */
 function emitHeadClient(headNodes, ctx, slotBase) {
 	if (!headNodes.length) return [];
-	ctx.runtimeNeeded.add('headBlock');
 	// Each hoisted head element gets a dense scope slot (after the body's constructs);
-	// the content `key` stays as a later arg for SSR-adoption matching.
-	return headNodes.map((h, i) =>
-		inheritOriginLoc(
+	// the content `key` stays as a later arg for SSR-adoption matching. RESOURCE
+	// elements (stylesheet precedence links, async scripts) are global and
+	// scope-free: they dedupe by href/src at runtime, so their call carries only
+	// the attrs object. Their slot index is left unoccupied to keep the numbering
+	// of neighbouring headBlock slots stable regardless of classification.
+	return headNodes.map((h, i) => {
+		const kind = headResourceKind(h.element);
+		if (kind !== null) {
+			const fn = kind === 'stylesheet' ? 'stylesheetResource' : 'scriptResource';
+			ctx.runtimeNeeded.add(fn);
+			return inheritOriginLoc(
+				b.stmt(b.call('_$' + fn, inheritOriginLoc(headAttrsExpression(h.element), h.element))),
+				h.element ?? h,
+			);
+		}
+		ctx.runtimeNeeded.add('headBlock');
+		return inheritOriginLoc(
 			b.stmt(
 				b.call(
 					'_$headBlock',
@@ -18481,8 +18560,8 @@ function emitHeadClient(headNodes, ctx, slotBase) {
 				),
 			),
 			h.element ?? h,
-		),
-	);
+		);
+	});
 }
 
 // Build the SERVER `ssrHeadEl(…)` statement nodes for a component's hoisted
@@ -18490,13 +18569,24 @@ function emitHeadClient(headNodes, ctx, slotBase) {
 /** @param {any[]} headNodes @param {any} ctx @returns {any[]} */
 function emitHeadServer(headNodes, ctx) {
 	if (!headNodes.length) return [];
-	ctx.runtimeNeeded.add('ssrHeadEl');
-	return headNodes.map((head, index) =>
-		inheritOriginLoc(
+	return headNodes.map((head, index) => {
+		const kind = headResourceKind(head.element);
+		if (kind !== null) {
+			const fn = kind === 'stylesheet' ? 'ssrStylesheetResource' : 'ssrScriptResource';
+			ctx.runtimeNeeded.add(fn);
+			return inheritOriginLoc(
+				b.stmt(
+					b.call('_$' + fn, inheritOriginLoc(headAttrsExpression(head.element), head.element)),
+				),
+				head.element ?? head,
+			);
+		}
+		ctx.runtimeNeeded.add('ssrHeadEl');
+		return inheritOriginLoc(
 			b.stmt(b.call('_$ssrHeadEl', ...headElementArgNodes(head, index, ctx))),
 			head.element ?? head,
-		),
-	);
+		);
+	});
 }
 
 /**
@@ -18643,7 +18733,10 @@ function normalizeChildren(nodes, inSvg = false, ctx = null) {
 			// body DOM). Kept in `out` as a synthetic node so planJsx / ssrCompileBody
 			// can partition it out and emit it via headBlock (client) / ssrHeadEl
 			// (server). SVG `<title>` and explicit resource-handler links stay inline.
-			if (isHoistableHeadElementNode(n) && !(inSvg && jsxTagName(n) === 'title')) {
+			if (
+				(isHoistableHeadElementNode(n) || (!inSvg && headResourceKind(n) !== null)) &&
+				!(inSvg && jsxTagName(n) === 'title')
+			) {
 				out.push({ type: 'HeadHoist', element: n });
 				continue;
 			}
@@ -23735,7 +23828,9 @@ function isActivityLongForm(node) {
 	const name = node.openingElement?.name || node.id;
 	if (!name) return false;
 	if (name.type !== 'Identifier' && name.type !== 'JSXIdentifier') return false;
-	return name.name === 'Activity';
+	// `unstable_Activity` mirrors the unstable_ViewTransition alias so React
+	// experimental-channel ports compile unchanged.
+	return name.name === 'Activity' || name.name === 'unstable_Activity';
 }
 
 // ===========================================================================

--- a/packages/octane/src/error-codes.client.generated.ts
+++ b/packages/octane/src/error-codes.client.generated.ts
@@ -38,6 +38,12 @@ type ClientErrorArguments = {
 	46: [unknown, unknown];
 	49: [];
 	50: [];
+	51: [];
+	52: [];
+	53: [];
+	54: [];
+	55: [];
+	56: [];
 };
 
 export function formatClientError<Code extends keyof ClientErrorArguments>(
@@ -185,6 +191,36 @@ export function formatClientError<Code extends keyof ClientErrorArguments>(
 				);
 			case 50:
 				return formatDevErrorMessage('Unclosed server-rendered Fragment descriptor.', args);
+			case 51:
+				return formatDevErrorMessage(
+					'Hydration mismatch: the server-rendered node did not match the client render; the mismatched subtree was rebuilt on the client.',
+					args,
+				);
+			case 52:
+				return formatDevErrorMessage(
+					'Hydration mismatch: root adoption was abandoned after a server/client shape divergence; the root was rebuilt on the client.',
+					args,
+				);
+			case 53:
+				return formatDevErrorMessage(
+					'Hydration mismatch: the server rendered more root content than the client; the stale remainder was discarded.',
+					args,
+				);
+			case 54:
+				return formatDevErrorMessage(
+					'Hydration mismatch: the client rendered text where the server rendered none; the client text was built fresh.',
+					args,
+				);
+			case 55:
+				return formatDevErrorMessage(
+					'Hydration mismatch: the server rendered a different child shape where the client renders a component; the stale range was discarded and the component was built on the client.',
+					args,
+				);
+			case 56:
+				return formatDevErrorMessage(
+					'Hydration mismatch: the server rendered more list items than the client; the extra server items were discarded.',
+					args,
+				);
 			default:
 				return formatUnknownDevErrorMessage(code);
 		}

--- a/packages/octane/src/index.ts
+++ b/packages/octane/src/index.ts
@@ -57,6 +57,8 @@ export {
 	// Resource hints (React DOM parity)
 	preload,
 	preinit,
+	preloadModule,
+	preinitModule,
 	preconnect,
 	prefetchDNS,
 	// Context
@@ -70,6 +72,9 @@ export {
 	ErrorBoundary,
 	Hydrate,
 	Activity,
+	// React shipped Activity as unstable_Activity before 19.2 — alias it so
+	// experimental-channel ports compile unchanged (mirrors unstable_ViewTransition).
+	Activity as unstable_Activity,
 	ViewTransition,
 	addTransitionType,
 	// React ships View Transitions on the experimental channel as unstable_-
@@ -183,6 +188,9 @@ export {
 	queueRefDetach,
 	injectStyle,
 	headBlock,
+	// React Float resources (stylesheet precedence links, async scripts)
+	stylesheetResource,
+	scriptResource,
 	namespaceHead,
 	namespaceHeadElement,
 	delegateEvents,
@@ -249,6 +257,7 @@ export {
 	// ── 3. Test-only (this repo's test infrastructure; not API) ───────────────
 	drainPassiveEffects,
 	setIsOctaneActEnvironment,
+	resetFloatResourceState,
 	setTransitionFallbackTimeout,
 	getTransitionFallbackTimeout,
 } from './runtime.js';

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -188,10 +188,25 @@ let PERMANENT_STATIC_HYDRATE_DEPTH = 0;
 // `<head>` when present, else prepended).
 interface HeadBuffer {
 	html: string;
-	/** Resource-hint dedupe keys emitted into `html` during this pass. */
+	/** Resource-hint + Float-resource dedupe keys emitted during this pass. */
 	hints: Set<string>;
+	/**
+	 * React Float stylesheet resources, grouped by precedence: precedence →
+	 * concatenated `<link>` html. Map insertion order IS group order
+	 * (first-encounter), and groups fold after `html` at capture time. Null
+	 * until the first stylesheet resource so ordinary passes pay nothing.
+	 */
+	sheets: Map<string, string> | null;
 	/** Precomputed caller root namespace, unaffected by streamed useId subspaces. */
 	rootSuffix: string;
+}
+
+/** Fold order: hoisted head elements + hints first, then grouped stylesheets. */
+function headHtmlWithSheets(buf: HeadBuffer): string {
+	if (buf.sheets === null) return buf.html;
+	let out = buf.html;
+	for (const group of buf.sheets.values()) out += group;
+	return out;
 }
 let HEAD: HeadBuffer | null = null;
 
@@ -2818,6 +2833,7 @@ function captureComponentReplayState(scope: SSRScope, frame: Frame | null) {
 		head,
 		headLength: head !== null ? head.html.length : 0,
 		headHints: head === null ? null : new Set(head.hints),
+		headSheets: head === null || head.sheets === null ? null : new Map(head.sheets),
 		serial,
 		serialLength: serial !== null ? serial.length : 0,
 		susp,
@@ -2881,6 +2897,14 @@ function rewindComponentReplayState(
 		snapshot.head.html = snapshot.head.html.slice(0, snapshot.headLength);
 		snapshot.head.hints.clear();
 		for (const key of snapshot.headHints) snapshot.head.hints.add(key);
+		if (snapshot.headSheets === null) snapshot.head.sheets = null;
+		else {
+			// Restore INTO a live map (the snapshot map itself stays pristine so a
+			// second rewind from the same snapshot restores identically).
+			const sheets = (snapshot.head.sheets ??= new Map());
+			sheets.clear();
+			for (const [precedence, group] of snapshot.headSheets) sheets.set(precedence, group);
+		}
 	}
 	if (snapshot.serial !== null) snapshot.serial.length = snapshot.serialLength;
 	if (snapshot.susp !== null) snapshot.susp.length = snapshot.suspLength;
@@ -5471,8 +5495,9 @@ function runFullFramedPass(
 	const headBuf = (HEAD = {
 		html: '',
 		hints: new Set(),
+		sheets: null,
 		rootSuffix: markers ? headOwnershipSuffix(identifierPrefix) : '',
-	});
+	} as HeadBuffer);
 	const suspended = (SUSPENDED = [] as SuspendedList);
 	const serial = (SERIAL = [] as unknown[]);
 	const deferred = (DEFERRED = [] as Job[]);
@@ -5529,7 +5554,7 @@ function runFullFramedPass(
 	}
 	return {
 		body,
-		head: headBuf.html,
+		head: headHtmlWithSheets(headBuf),
 		css,
 		serial,
 		suspended,
@@ -5564,7 +5589,12 @@ function runDiscoveryRound(
 	VT_SSR_HAS_CANDIDATES = false;
 	VT_SSR_STACK.length = 0;
 	CSS = new Map();
-	HEAD = { html: '', hints: new Set(), rootSuffix: headOwnershipSuffix(identifierPrefix) };
+	HEAD = {
+		html: '',
+		hints: new Set(),
+		sheets: null,
+		rootSuffix: headOwnershipSuffix(identifierPrefix),
+	};
 	const suspended = (SUSPENDED = [] as SuspendedList);
 	SERIAL = [] as unknown[];
 	const deferred = (DEFERRED = [] as Job[]);
@@ -6488,6 +6518,7 @@ export function ssrTry(
 			const head = HEAD;
 			const headHtml = head?.html;
 			const headHints = head === null ? null : new Set(head.hints);
+			const headSheets = head === null || head.sheets === null ? null : new Map(head.sheets);
 			const vtTrySeq = VT_SSR_TRY_SEQ;
 			const vtHasCandidates = VT_SSR_HAS_CANDIDATES;
 			const vtStack = VT_SSR_STACK.map((candidate) => ({
@@ -6513,6 +6544,12 @@ export function ssrTry(
 					head.html = headHtml!;
 					head.hints.clear();
 					for (const hint of headHints) head.hints.add(hint);
+					if (headSheets === null) head.sheets = null;
+					else {
+						const sheets = (head.sheets ??= new Map());
+						sheets.clear();
+						for (const [precedence, group] of headSheets) sheets.set(precedence, group);
+					}
 				}
 				VT_SSR_TRY_SEQ = vtTrySeq;
 				VT_SSR_HAS_CANDIDATES = vtHasCandidates;
@@ -7933,5 +7970,103 @@ export function prefetchDNS(href: string): void {
 			'" data-oct-hint="' +
 			escapeAttr(key) +
 			'">',
+	);
+}
+
+/** Attribute serialization for Float resources; href/src/rel/async/precedence are owned by the emit. */
+function resourceAttrs(attrs: Record<string, unknown>, tag: 'link' | 'script'): string {
+	let out = '';
+	for (const k in attrs) {
+		if (k === 'precedence' || k === 'href' || k === 'src' || k === 'rel' || k === 'async') continue;
+		const v = (attrs as any)[k];
+		if (v == null || v === false || typeof v === 'function') continue;
+		const name = k === 'crossOrigin' ? 'crossorigin' : k.toLowerCase();
+		if (v === true) out += ' ' + name;
+		else out += ' ' + name + '="' + escapeAttr(sanitizeURLAttribute(tag, name, String(v))) + '"';
+	}
+	return out;
+}
+
+/**
+ * Compiler target for `<link rel="stylesheet" href precedence>` (React Float).
+ * Dedupes by href across the pass; groups by precedence in first-encounter
+ * order (the HeadBuffer.sheets Map), folded after the ordinary head content.
+ */
+export function ssrStylesheetResource(attrs: Record<string, unknown> | null): void {
+	if (HEAD === null || attrs == null) return;
+	const href = attrs.href;
+	if (typeof href !== 'string' || href === '') return;
+	const key = 'sheet:' + href;
+	if (HEAD.hints.has(key)) return;
+	HEAD.hints.add(key);
+	const precedence = attrs.precedence == null ? '' : String(attrs.precedence);
+	const tag =
+		'<link rel="stylesheet" href="' +
+		escapeAttr(sanitizeURL(href)) +
+		'" data-precedence="' +
+		escapeAttr(precedence) +
+		'"' +
+		resourceAttrs(attrs, 'link') +
+		'>';
+	const sheets = (HEAD.sheets ??= new Map());
+	sheets.set(precedence, (sheets.get(precedence) ?? '') + tag);
+}
+
+/** Compiler target for `<script async src>` resources (React Float). */
+export function ssrScriptResource(attrs: Record<string, unknown> | null): void {
+	if (HEAD === null || attrs == null) return;
+	const src = attrs.src;
+	if (typeof src !== 'string' || src === '') return;
+	const key = 'script:' + src;
+	if (HEAD.hints.has(key)) return;
+	HEAD.hints.add(key);
+	HEAD.html +=
+		'<script src="' +
+		escapeAttr(sanitizeURL(src)) +
+		'" async data-oct-res=""' +
+		resourceAttrs(attrs, 'script') +
+		'></script>';
+}
+
+/** React DOM `preloadModule(href, options?)` — `<link rel="modulepreload">`, keyed by href. */
+export function preloadModule(href: string, options?: Record<string, unknown>): void {
+	const value = coerceHintHref(href);
+	if (value === null) return;
+	const key = 'modulepreload:' + value;
+	const safeHref = sanitizeURL(value);
+	emitHeadHint(
+		key,
+		'<link rel="modulepreload" href="' +
+			escapeAttr(safeHref) +
+			'"' +
+			hintAttrs(options, false, 'link') +
+			' data-oct-hint="' +
+			escapeAttr(key) +
+			'">',
+	);
+}
+
+/**
+ * React DOM `preinitModule(href, options?)` — `<script type="module" async src>`.
+ * Only the `script` destination exists for module preinit; others fail closed.
+ */
+export function preinitModule(
+	href: string,
+	options?: { as?: string } & Record<string, unknown>,
+): void {
+	const value = coerceHintHref(href);
+	if (value === null) return;
+	if ((options?.as ?? 'script') !== 'script') return;
+	const key = 'module:' + value;
+	const safeHref = sanitizeURL(value);
+	emitHeadHint(
+		key,
+		'<script type="module" src="' +
+			escapeAttr(safeHref) +
+			'" async' +
+			hintAttrs(options, true, 'script') +
+			' data-oct-hint="' +
+			escapeAttr(key) +
+			'"></script>',
 	);
 }

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -27498,9 +27498,30 @@ export function hydrateRoot(
 		// host retry binds a FRESH root (§5 rule 9 — adoption is abandoned, the
 		// retry client-remounts). Unowned hydration failures keep their existing
 		// behavior and rethrow untouched — unless this root's onUncaughtError
-		// consumes the report, which changes only the reporting: the failed
-		// adoption is released identically and the caller gets a reusable root.
-		const releaseFailedHydration = (): void => {
+		// consumes the report. Consumption changes only the reporting: the failed
+		// adoption is discarded like createRoot's sync-mount failure, and the
+		// returned root KEEPS this pass's container claim and delegation
+		// registration because the caller renders into it directly — there is no
+		// host retry to re-register them.
+		if (rendererRegionOwnerForBlock(rootBlock) === null) {
+			if (!reportUncaughtError(rootBlock, error)) throw error;
+			unmountBlock(rootBlock, false);
+			drainRefDetaches();
+			container.textContent = '';
+			return makeRoot(
+				container,
+				null,
+				null,
+				null,
+				idState,
+				renderReturnedValue,
+				ownerToken,
+				rootOptions,
+			);
+		}
+		try {
+			handleRenderError(rootBlock, error);
+		} finally {
 			DOM_ROOT_DISPOSERS.delete(rootBlock);
 			unmountBlock(rootBlock, false);
 			drainRefDetaches();
@@ -27511,16 +27532,6 @@ export function hydrateRoot(
 			// its listeners past the island's final teardown.
 			unregisterDelegationTarget(container);
 			releaseRootContainer(container, ownerToken);
-		};
-		if (rendererRegionOwnerForBlock(rootBlock) === null) {
-			if (!reportUncaughtError(rootBlock, error)) throw error;
-			releaseFailedHydration();
-			return makeRoot(container, null, null, null, idState, renderReturnedValue, null, rootOptions);
-		}
-		try {
-			handleRenderError(rootBlock, error);
-		} finally {
-			releaseFailedHydration();
 		}
 		// Routed: hand back an empty lazy root owning NO claim or delegation
 		// registration (both released above); the owner's retry recreates.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -27227,8 +27227,13 @@ function makeRoot(
 					// before surfacing the error, but keep the public root reusable for a
 					// later recovery render. In particular, effects registered before the
 					// throw belong to an aborted render and must never reach a later flush.
+					// A root created with onUncaughtError consumes its own report here
+					// too — the synchronous first mount is still "the flush" for this
+					// render, so the option must not behave differently from a scheduled
+					// render's unhandled error.
 					if (!mountedRoot.disposed) unmountBlock(mountedRoot);
-					throw unhandled;
+					if (!reportUncaughtError(mountedRoot, unhandled)) throw unhandled;
+					return;
 				}
 				root.unmount();
 				return;
@@ -27492,11 +27497,10 @@ export function hydrateRoot(
 		// to the owner, unmount the failed root, and release the container so a
 		// host retry binds a FRESH root (§5 rule 9 — adoption is abandoned, the
 		// retry client-remounts). Unowned hydration failures keep their existing
-		// behavior and rethrow untouched.
-		if (rendererRegionOwnerForBlock(rootBlock) === null) throw error;
-		try {
-			handleRenderError(rootBlock, error);
-		} finally {
+		// behavior and rethrow untouched — unless this root's onUncaughtError
+		// consumes the report, which changes only the reporting: the failed
+		// adoption is released identically and the caller gets a reusable root.
+		const releaseFailedHydration = (): void => {
 			DOM_ROOT_DISPOSERS.delete(rootBlock);
 			unmountBlock(rootBlock, false);
 			drainRefDetaches();
@@ -27507,6 +27511,16 @@ export function hydrateRoot(
 			// its listeners past the island's final teardown.
 			unregisterDelegationTarget(container);
 			releaseRootContainer(container, ownerToken);
+		};
+		if (rendererRegionOwnerForBlock(rootBlock) === null) {
+			if (!reportUncaughtError(rootBlock, error)) throw error;
+			releaseFailedHydration();
+			return makeRoot(container, null, null, null, idState, renderReturnedValue, null, rootOptions);
+		}
+		try {
+			handleRenderError(rootBlock, error);
+		} finally {
+			releaseFailedHydration();
 		}
 		// Routed: hand back an empty lazy root owning NO claim or delegation
 		// registration (both released above); the owner's retry recreates.

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -2921,21 +2921,25 @@ function drainQueue(): { err: any } | null {
 				// No tryBlock claimed this error. Don't let it abandon the rest of
 				// the queue or skip commit — that would strand unrelated roots
 				// batched into the same flush and drop their already-rendered
-				// effects. Collect them all; a multi-root flush with several
-				// unhandled errors surfaces an AggregateError (React parity), a
-				// single one rethrows as-is.
-				if (pendingError === null) pendingError = { err: unhandled, all: [unhandled] };
-				else {
-					pendingError.all.push(unhandled);
-					pendingError.err =
-						typeof AggregateError === 'function'
-							? new AggregateError(pendingError.all, formatClientError(13))
-							: pendingError.all[0];
+				// effects. A root created with onUncaughtError consumes its own
+				// report; otherwise collect them all — a multi-root flush with
+				// several unhandled errors surfaces an AggregateError (React
+				// parity), a single one rethrows as-is.
+				if (!reportUncaughtError(block, unhandled)) {
+					if (pendingError === null) pendingError = { err: unhandled, all: [unhandled] };
+					else {
+						pendingError.all.push(unhandled);
+						pendingError.err =
+							typeof AggregateError === 'function'
+								? new AggregateError(pendingError.all, formatClientError(13))
+								: pendingError.all[0];
+					}
 				}
 				// React 19 contract: an error no boundary handles unmounts the
 				// ENTIRE tree of the failed root — known-broken UI never stays on
 				// screen (ReactIncrementalErrorHandling:1338/:712). Only the
 				// offending root is torn down; unrelated roots keep draining.
+				// onUncaughtError replaces the report, not the recovery.
 				let root: Block = block;
 				while (root.parentBlock !== null) root = root.parentBlock;
 				if (root.kind === 'root' && !root.disposed) unmountBlock(root);
@@ -3823,8 +3827,10 @@ function drainRefAttaches(): void {
 		} catch (err) {
 			if (err instanceof MaximumUpdateDepthError) throw err;
 			const handler = findTryHandler(r.block);
-			if (handler) handler(err);
-			else console.error(err);
+			if (handler) {
+				handler(err);
+				reportCaughtError(r.block, err);
+			} else if (!reportUncaughtError(r.block, err)) console.error(err);
 		}
 	}
 }
@@ -4174,8 +4180,10 @@ function fireEffectCleanup(e: PendingEffect): void {
 		} catch (err) {
 			if (err instanceof MaximumUpdateDepthError) throw err;
 			const handler = findTryHandler(e.scope.block);
-			if (handler) handler(err);
-			else console.error(err);
+			if (handler) {
+				handler(err);
+				reportCaughtError(e.scope.block, err);
+			} else if (!reportUncaughtError(e.scope.block, err)) console.error(err);
 		}
 	}
 }
@@ -4203,8 +4211,10 @@ function runEffectBody(e: PendingEffect): void {
 		if (err instanceof MaximumUpdateDepthError) throw err;
 		// Route effect errors to the nearest enclosing tryBlock, if any.
 		const handler = findTryHandler(e.scope.block);
-		if (handler) handler(err);
-		else console.error(err);
+		if (handler) {
+			handler(err);
+			reportCaughtError(e.scope.block, err);
+		} else if (!reportUncaughtError(e.scope.block, err)) console.error(err);
 		return;
 	}
 	if (typeof cleanup === 'function') {
@@ -10228,6 +10238,7 @@ class HydrationCapability {
 
 	/** Give up root adoption after an unframed return/fragment mismatch. */
 	abandonRoot(expected: string, actual: string, loc?: string): void {
+		noteRecoverableHydrationError(() => new Error(formatClientError(52)));
 		if (loc) warnHydrationStructuralMismatch(loc, expected, actual);
 		let node = this.node;
 		while (node !== null) {
@@ -10304,6 +10315,7 @@ class HydrationCapability {
 				? !hydrationNodeMatches(cursor, template, partialStyles)
 				: !lazyRootMatches(cursor, lazy!))
 		) {
+			noteRecoverableHydrationError(() => new Error(formatClientError(51)));
 			if (template === null) template = resolveLazyTemplate(lazy!);
 			if (process.env.NODE_ENV !== 'production' && loc)
 				warnHydrationStructuralMismatch(
@@ -10352,6 +10364,7 @@ class HydrationCapability {
 		)
 			remainder = remainder.nextSibling;
 		if (remainder === null) return;
+		noteRecoverableHydrationError(() => new Error(formatClientError(53)), this.rootBlock);
 		warnHydrationStructuralMismatch(
 			componentSourceLoc(this.rootBlock.body),
 			'the end of the root',
@@ -10407,12 +10420,15 @@ class HydrationCapability {
 		// text so recovery succeeds, but publish the normal dev diagnostic. A
 		// suppressed host keeps the absent server value by installing only an empty
 		// tracking node; later real commits can update that node normally.
-		if (text !== '' && !suppressed && process.env.NODE_ENV !== 'production') {
-			warnHydrationStructuralMismatch(
-				host && (host as any).__oct_loc,
-				`text ${JSON.stringify(text)}`,
-				describeHydrationNode(posNode),
-			);
+		if (text !== '' && !suppressed) {
+			noteRecoverableHydrationError(() => new Error(formatClientError(54)));
+			if (process.env.NODE_ENV !== 'production') {
+				warnHydrationStructuralMismatch(
+					host && (host as any).__oct_loc,
+					`text ${JSON.stringify(text)}`,
+					describeHydrationNode(posNode),
+				);
+			}
 		}
 		const created = document.createTextNode(suppressed ? '' : text);
 		if (posNode !== null && posNode.parentNode !== null) {
@@ -16730,6 +16746,7 @@ function componentSlotImpl(
 				// rather than adopting an unrelated sibling.
 				const stale = hydrationCursor;
 				const loc = siteLoc(parentScope, slotKey);
+				noteRecoverableHydrationError(() => new Error(formatClientError(55)));
 				if (process.env.NODE_ENV !== 'production' && loc) {
 					warnHydrationStructuralMismatch(loc, 'a component range', describeHydrationNode(stale));
 				}
@@ -18667,6 +18684,7 @@ function hostStringTagBody(d: ElementDescriptor, block: Block): void {
 			// STRUCTURAL mismatch — mirror hostElementBody's recovery: warn, discard
 			// the divergent server node/range, then build fresh with hydration
 			// SUSPENDED for the subtree (children client-mount, not mis-adopt).
+			noteRecoverableHydrationError(() => new Error(formatClientError(51)));
 			if (process.env.NODE_ENV !== 'production') {
 				const mmLoc = (hydration.node.parentNode as any)?.__oct_loc;
 				if (mmLoc) hydration.warnStructural(mmLoc, `<${tag}>`, hydration.describe(hydration.node));
@@ -23527,8 +23545,10 @@ function handleRenderError(block: Block, err: any): void {
 		throw err;
 	}
 	const h = findTryHandler(block);
-	if (h) h(err);
-	else throw err;
+	if (h) {
+		h(err);
+		reportCaughtError(block, err);
+	} else throw err;
 }
 
 // ---------------------------------------------------------------------------
@@ -25273,6 +25293,7 @@ export function fastMapSlot(
 function discardLeftoverHydrationItems(end: Node, hydration: HydrationCapability): void {
 	const n = hydration.node;
 	if (n === null || n === end || n.parentNode !== end.parentNode) return;
+	noteRecoverableHydrationError(() => new Error(formatClientError(56)));
 	removeRange(n, end);
 }
 
@@ -26833,6 +26854,123 @@ export interface RootOptions {
 	 * client-root namespace; hydrateRoot uses it verbatim to match server output.
 	 */
 	identifierPrefix?: string;
+	/**
+	 * React 19 parity, reporting only: called after an error boundary
+	 * (`@try`/`@catch` or `<ErrorBoundary>`) claims an error from this root's
+	 * render, passive-effect, or ref-attach channel. Octane passes only the
+	 * error — there is no `errorInfo`/`componentStack` second argument (owner
+	 * stacks are not part of Octane's API, matching the SSR `onError` shape).
+	 * Deletion-phase teardown errors keep their existing boundary routing and
+	 * default report; they do not reach this callback.
+	 */
+	onCaughtError?: (error: unknown) => void;
+	/**
+	 * React 19 parity: called for an error no boundary claims. When provided it
+	 * REPLACES the default report for this root (render errors stop rethrowing
+	 * out of the flush; effect-channel errors stop reaching console.error).
+	 * Recovery semantics are unchanged either way — an uncaught render error
+	 * still unmounts the failed root's entire tree.
+	 */
+	onUncaughtError?: (error: unknown) => void;
+	/**
+	 * React 19 parity, hydration only: called (dev AND prod) after hydration
+	 * recovered from a structural server/client mismatch — a rebuilt subtree or
+	 * a discarded stale server range — coalesced to one report per root per
+	 * microtask burst. Attribute-level value patches do not report: production
+	 * React hydration does not detect those at all, so Octane's finer-grained
+	 * recovery stays quiet to keep the report channel comparable.
+	 */
+	onRecoverableError?: (error: unknown) => void;
+}
+
+/**
+ * Handlers live OFF the Block shape: registered only for roots created with at
+ * least one callback, so every other root pays a single null check on the
+ * (already cold) error paths and Block's monomorphic layout is untouched.
+ */
+interface RootErrorHandlers {
+	onCaughtError: ((error: unknown) => void) | undefined;
+	onUncaughtError: ((error: unknown) => void) | undefined;
+	onRecoverableError: ((error: unknown) => void) | undefined;
+}
+
+let ROOT_ERROR_HANDLERS: WeakMap<Block, RootErrorHandlers> | null = null;
+
+function registerRootErrorHandlers(root: Block, options: RootOptions | undefined): void {
+	if (options === undefined) return;
+	const { onCaughtError, onUncaughtError, onRecoverableError } = options;
+	if (
+		onCaughtError === undefined &&
+		onUncaughtError === undefined &&
+		onRecoverableError === undefined
+	) {
+		return;
+	}
+	(ROOT_ERROR_HANDLERS ??= new WeakMap()).set(root, {
+		onCaughtError,
+		onUncaughtError,
+		onRecoverableError,
+	});
+}
+
+function rootErrorHandlersFor(block: Block | null): RootErrorHandlers | null {
+	if (ROOT_ERROR_HANDLERS === null || block === null) return null;
+	let b: Block = block;
+	while (b.parentBlock !== null) b = b.parentBlock;
+	return ROOT_ERROR_HANDLERS.get(b) ?? null;
+}
+
+/** A throwing report callback must not corrupt recovery — report it and move on. */
+function invokeRootErrorHandler(handler: (error: unknown) => void, err: unknown): void {
+	try {
+		handler(err);
+	} catch (handlerErr) {
+		console.error(handlerErr);
+	}
+}
+
+/** Report a boundary-claimed error to the owning root's onCaughtError, if any. */
+function reportCaughtError(block: Block | null, err: unknown): void {
+	const h = rootErrorHandlersFor(block)?.onCaughtError;
+	if (h !== undefined) invokeRootErrorHandler(h, err);
+}
+
+/** True when the owning root's onUncaughtError consumed the report (callers skip their default). */
+function reportUncaughtError(block: Block | null, err: unknown): boolean {
+	const h = rootErrorHandlersFor(block)?.onUncaughtError;
+	if (h === undefined) return false;
+	invokeRootErrorHandler(h, err);
+	return true;
+}
+
+/** Roots with a recoverable-error report already queued for this microtask burst. */
+let RECOVERABLE_REPORTED: WeakSet<Block> | null = null;
+
+/**
+ * Note a structural hydration recovery for onRecoverableError. Runs at the
+ * recovery sites themselves (dev AND prod), so it must stay near-free when no
+ * root registered the callback: one module-null check. Call sites pass a thunk
+ * constructing `new Error(formatClientError(<literal>))` so the production
+ * error-code audit holds and no Error is allocated unless a report actually
+ * fires. `block` defaults to the currently rendering block — hydration
+ * recovery always runs under the mount that discovered the mismatch — and the
+ * report is delivered on a microtask so a user callback can never re-enter the
+ * in-progress hydration walk.
+ */
+function noteRecoverableHydrationError(makeError: () => Error, block: Block | null = null): void {
+	if (ROOT_ERROR_HANDLERS === null) return;
+	const from = block ?? CURRENT_BLOCK;
+	const h = rootErrorHandlersFor(from)?.onRecoverableError;
+	if (h === undefined) return;
+	let root = from!;
+	while (root.parentBlock !== null) root = root.parentBlock;
+	const reported = (RECOVERABLE_REPORTED ??= new WeakSet());
+	if (reported.has(root)) return;
+	reported.add(root);
+	queueMicrotask(() => {
+		reported.delete(root);
+		invokeRootErrorHandler(h, makeError());
+	});
 }
 
 // One live public root owns a container at a time. React still returns a second
@@ -26943,6 +27081,7 @@ function makeRoot(
 	idState: RootIdState,
 	outputHandler: OutputHandler | null,
 	ownerToken: object | null,
+	errorOptions?: RootOptions,
 ): Root {
 	let root!: Root;
 	let unmounted = false;
@@ -27053,6 +27192,7 @@ function makeRoot(
 			if (typeof __OCTANE_PROFILE_ENABLED__ !== 'undefined' && __OCTANE_PROFILE_ENABLED__)
 				__profileTrackComponent(rootBlock, body);
 			rootBlock.idState = idState;
+			registerRootErrorHandlers(rootBlock, errorOptions);
 			registerRootDisposer(rootBlock);
 			if (typeof __OCTANE_PROFILE_ENABLED__ !== 'undefined' && __OCTANE_PROFILE_ENABLED__) {
 				__devtoolsSetNameResolver(componentName);
@@ -27181,6 +27321,7 @@ function createRootWithOutputHandler(
 		},
 		outputHandler,
 		ownerToken,
+		options,
 	);
 }
 
@@ -27279,6 +27420,7 @@ export function hydrateRoot(
 		next: 0,
 	};
 	rootBlock.idState = idState;
+	registerRootErrorHandlers(rootBlock, rootOptions);
 	let hydrationCompleted = false;
 	let seeds: unknown[] | null = null;
 	// The root-local counter starts at zero, matching the server render carrying
@@ -27368,7 +27510,7 @@ export function hydrateRoot(
 		}
 		// Routed: hand back an empty lazy root owning NO claim or delegation
 		// registration (both released above); the owner's retry recreates.
-		return makeRoot(container, null, null, null, idState, renderReturnedValue, null);
+		return makeRoot(container, null, null, null, idState, renderReturnedValue, null, rootOptions);
 	} finally {
 		currentHydration = previousHydration;
 	}
@@ -27382,7 +27524,16 @@ export function hydrateRoot(
 	// the root behaves exactly like a `createRoot` root — a `.render()` with the
 	// same component updates props on the adopted DOM (same-body fast path), a
 	// different component tears down and remounts.
-	return makeRoot(container, rootBlock, body, rootKey, idState, renderReturnedValue, ownerToken);
+	return makeRoot(
+		container,
+		rootBlock,
+		body,
+		rootKey,
+		idState,
+		renderReturnedValue,
+		ownerToken,
+		rootOptions,
+	);
 }
 
 // ---------------------------------------------------------------------------
@@ -27485,4 +27636,165 @@ export function prefetchDNS(href: string): void {
 		l.href = safeHref;
 		return l;
 	});
+}
+
+/**
+ * React DOM `preloadModule(href, options?)` — `<link rel="modulepreload">`.
+ * Module preloads dedupe by href alone (React's resource identity for modules);
+ * options apply as attributes through the shared lenient pass-through.
+ */
+export function preloadModule(href: string, options?: Record<string, unknown>): void {
+	if (!href) return;
+	const rawHref = typeof href === 'string' ? href : String(href);
+	const safeHref = sanitizeURL(rawHref);
+	insertHeadHint('modulepreload:' + rawHref, () => {
+		const l = document.createElement('link');
+		l.rel = 'modulepreload';
+		l.href = safeHref;
+		applyHintAttrs(l, options);
+		return l;
+	});
+}
+
+/**
+ * React DOM `preinitModule(href, options?)` — `<script type="module" async src>`.
+ * Only the `script` destination exists for module preinit (React's contract);
+ * any other `as` fails closed as a no-op rather than executing the module.
+ */
+export function preinitModule(
+	href: string,
+	options?: { as?: string } & Record<string, unknown>,
+): void {
+	if (!href) return;
+	if ((options?.as ?? 'script') !== 'script') return;
+	const rawHref = typeof href === 'string' ? href : String(href);
+	const safeHref = sanitizeURL(rawHref);
+	insertHeadHint('module:' + rawHref, () => {
+		const s = document.createElement('script');
+		s.type = 'module';
+		(s as HTMLScriptElement).src = safeHref;
+		(s as HTMLScriptElement).async = true;
+		applyHintAttrs(s, options ? { ...options, as: undefined } : undefined);
+		return s;
+	});
+}
+
+// ---------------------------------------------------------------------------
+// React Float resources — `<link rel="stylesheet" href precedence>` and
+// `<script async src>` rendered at a component's body root. Unlike per-site
+// hoisted head elements (headBlock), a resource is GLOBAL: keyed by href/src,
+// deduped across the whole page, stylesheet groups ordered by precedence
+// (first-encounter group order, appended within a group), and RETAINED after
+// unmount — unloading a stylesheet or re-running a script is never safe, so
+// React never removes resources and neither does Octane. Suspend-until-loaded
+// ("suspensey" commit) is deliberately out of scope. The first client call
+// seeds dedupe state from SSR-emitted tags (data-precedence / data-oct-res),
+// so hydration never duplicates.
+// ---------------------------------------------------------------------------
+
+interface ResourceState {
+	sheets: Set<string>;
+	scripts: Set<string>;
+	/** Last live element of each stylesheet precedence group. */
+	tails: Map<string, Element>;
+	/** Tail of the LAST group in document order — where a new group starts. */
+	lastTail: Element | null;
+}
+
+let _resourceState: ResourceState | null = null;
+
+function resourceState(): ResourceState {
+	if (_resourceState !== null) return _resourceState;
+	const state: ResourceState = {
+		sheets: new Set(),
+		scripts: new Set(),
+		tails: new Map(),
+		lastTail: null,
+	};
+	if (typeof document !== 'undefined') {
+		const links = document.querySelectorAll('link[rel="stylesheet"][data-precedence]');
+		for (let i = 0; i < links.length; i++) {
+			const el = links[i];
+			const href = el.getAttribute('href');
+			if (href !== null) state.sheets.add(href);
+			state.tails.set(el.getAttribute('data-precedence') as string, el);
+			state.lastTail = el;
+		}
+		const scripts = document.querySelectorAll('script[data-oct-res]');
+		for (let i = 0; i < scripts.length; i++) {
+			const src = scripts[i].getAttribute('src');
+			if (src !== null) state.scripts.add(src);
+		}
+	}
+	return (_resourceState = state);
+}
+
+/** Handled by the resource insert itself; everything else applies as an attribute. */
+const RESOURCE_OWN_ATTRS = new Set(['precedence', 'href', 'src', 'rel', 'async']);
+
+function applyResourceAttrs(el: Element, attrs: Record<string, unknown>): void {
+	for (const k in attrs) {
+		if (RESOURCE_OWN_ATTRS.has(k)) continue;
+		const v = (attrs as any)[k];
+		if (v == null || v === false || typeof v === 'function') continue;
+		const name = k === 'crossOrigin' ? 'crossorigin' : k.toLowerCase();
+		el.setAttribute(name, sanitizeURLAttribute(el.localName, name, v === true ? '' : String(v)));
+	}
+}
+
+/** Compiler target for `<link rel="stylesheet" href precedence>` (React Float). */
+export function stylesheetResource(attrs: Record<string, unknown> | null): void {
+	if (typeof document === 'undefined' || attrs == null) return;
+	const href = attrs.href;
+	if (typeof href !== 'string' || href === '') return;
+	const state = resourceState();
+	// First instance wins, including its non-key props — matching React's
+	// resource identity (later differing props do not retarget a live sheet).
+	if (state.sheets.has(href)) return;
+	const precedence = attrs.precedence == null ? '' : String(attrs.precedence);
+	const l = document.createElement('link');
+	l.rel = 'stylesheet';
+	l.href = sanitizeURL(href);
+	l.setAttribute('data-precedence', precedence);
+	applyResourceAttrs(l, attrs);
+	const tail = state.tails.get(precedence);
+	if (tail !== undefined && tail.isConnected) {
+		// Existing group: append after its current tail.
+		tail.after(l);
+		if (state.lastTail === tail) state.lastTail = l;
+	} else if (state.lastTail !== null && state.lastTail.isConnected) {
+		// New group: starts after the last existing group, keeping groups
+		// contiguous in first-encounter order.
+		state.lastTail.after(l);
+		state.lastTail = l;
+	} else {
+		document.head.appendChild(l);
+		state.lastTail = l;
+	}
+	state.tails.set(precedence, l);
+	state.sheets.add(href);
+}
+
+/**
+ * TEST-ONLY: forget all Float resource identity (this repo's test isolation).
+ * Resources are page-global by contract — a real page never resets them.
+ */
+export function resetFloatResourceState(): void {
+	_resourceState = null;
+}
+
+/** Compiler target for `<script async src>` resources (React Float). */
+export function scriptResource(attrs: Record<string, unknown> | null): void {
+	if (typeof document === 'undefined' || attrs == null) return;
+	const src = attrs.src;
+	if (typeof src !== 'string' || src === '') return;
+	const state = resourceState();
+	if (state.scripts.has(src)) return;
+	const s = document.createElement('script');
+	(s as HTMLScriptElement).src = sanitizeURL(src);
+	(s as HTMLScriptElement).async = true;
+	s.setAttribute('data-oct-res', '');
+	applyResourceAttrs(s, attrs);
+	document.head.appendChild(s);
+	state.scripts.add(src);
 }

--- a/packages/octane/src/server/index.ts
+++ b/packages/octane/src/server/index.ts
@@ -85,6 +85,8 @@ export {
 	requestFormReset,
 	preload,
 	preinit,
+	preloadModule,
+	preinitModule,
 	preconnect,
 	prefetchDNS,
 
@@ -94,6 +96,7 @@ export {
 	Hydrate,
 	Fragment,
 	Activity,
+	Activity as unstable_Activity,
 	// Transparent server twin of the client ViewTransition boundary (client-only
 	// behavior; SSR annotations are view-transitions plan Phase 5).
 	ViewTransition,
@@ -159,6 +162,9 @@ export {
 	ssrPortal,
 	injectStyle,
 	ssrHeadEl,
+	// React Float resources (stylesheet precedence links, async scripts)
+	ssrStylesheetResource,
+	ssrScriptResource,
 	namespaceHead,
 	namespaceHeadElement,
 	// SSR parallel-use mirror (compiler targets — see suspense-parallel-use plan).

--- a/packages/octane/src/static/index.ts
+++ b/packages/octane/src/static/index.ts
@@ -9,6 +9,11 @@
  * `renderToString` (single sync pass, fallbacks for suspended boundaries) and
  * the streaming APIs.
  *
- * The stream variants (`prerenderToNodeStream`) land with the streaming engine.
+ * `prerenderToNodeStream` is not implemented yet (tracked as planned work in the
+ * React-parity ledger). React 19.2's partial pre-rendering — `resume`,
+ * `resumeAndPrerender`, and the postpone/prelude protocol — is a documented
+ * non-goal: that request protocol is not part of Octane's public SSR surface,
+ * and `prerender` here resolves `{ html, css }` rather than React's
+ * `{ prelude: ReadableStream }`.
  */
 export { prerender, type RenderResult, type RenderOptions } from '../runtime.server.js';

--- a/packages/octane/tests/_fixtures/float-resources.tsrx
+++ b/packages/octane/tests/_fixtures/float-resources.tsrx
@@ -1,0 +1,73 @@
+// React Float resource fixtures: precedence stylesheets and async scripts
+// rendered at a component's body root (the same placement contract as hoisted
+// <title>/<meta>/<link>) become global resources — deduped by href/src,
+// precedence-grouped in document.head, and retained after unmount.
+import { useState } from 'octane';
+
+export function SheetA() @{
+	<>
+		<link rel="stylesheet" href="/base.css" precedence="default" />
+		<div class="a">{'A' as string}</div>
+	</>
+}
+
+export function SheetADuplicate() @{
+	<>
+		<link rel="stylesheet" href="/base.css" precedence="default" />
+		<div class="a2">{'A2' as string}</div>
+	</>
+}
+
+export function SheetHigh() @{
+	<>
+		<link rel="stylesheet" href="/high.css" precedence="high" crossOrigin="anonymous" />
+		<div class="hi">{'HI' as string}</div>
+	</>
+}
+
+export function SheetLate() @{
+	<>
+		<link rel="stylesheet" href="/late-default.css" precedence="default" />
+		<div class="late">{'LATE' as string}</div>
+	</>
+}
+
+// A plain hoisted link WITHOUT precedence keeps the per-site head-element
+// contract (removed on unmount) — the control for the resource split.
+export function PlainLink() @{
+	<>
+		<link rel="alternate" href="/feed.xml" />
+		<div class="plain">{'P' as string}</div>
+	</>
+}
+
+export function AsyncScript() @{
+	<>
+		<script async src="/analytics.js" />
+		<div class="s">{'S' as string}</div>
+	</>
+}
+
+export function AsyncScriptDuplicate() @{
+	<>
+		<script async src="/analytics.js" />
+		<div class="s2">{'S2' as string}</div>
+	</>
+}
+
+let toggleSheet: ((on: boolean) => void) | null = null;
+export function setSheetVisible(on: boolean): void {
+	toggleSheet!(on);
+}
+
+export function ToggleHost() @{
+	const [on, setOn] = useState(true);
+	toggleSheet = setOn;
+	<section class="toggle">
+		@if (on) {
+			<SheetA />
+		} @else {
+			<span class="off">off</span>
+		}
+	</section>
+}

--- a/packages/octane/tests/_fixtures/float-resources.tsrx
+++ b/packages/octane/tests/_fixtures/float-resources.tsrx
@@ -55,6 +55,22 @@ export function AsyncScriptDuplicate() @{
 	</>
 }
 
+// Return-position (React-style `.tsx` value body) forms: resources must
+// classify through requiresTemplateNormalization exactly like `@{}` bodies.
+export function ReturnScript() {
+	return <>
+		<script async src="/return-script.js" />
+		<div class="rs">{'RS' as string}</div>
+	</>;
+}
+
+export function ReturnSheet() {
+	return <>
+		<link rel="stylesheet" href="/return.css" precedence="default" />
+		<div class="rl">{'RL' as string}</div>
+	</>;
+}
+
 let toggleSheet: ((on: boolean) => void) | null = null;
 export function setSheetVisible(on: boolean): void {
 	toggleSheet!(on);

--- a/packages/octane/tests/_fixtures/root-error-callbacks.tsrx
+++ b/packages/octane/tests/_fixtures/root-error-callbacks.tsrx
@@ -1,0 +1,59 @@
+// Fixtures for the React 19 root error-callback options (onCaughtError /
+// onUncaughtError on createRoot/hydrateRoot). Each host pairs a thrower with
+// (or without) a boundary so the tests can drive both report channels through
+// the render and passive-effect paths.
+import { ErrorBoundary, useEffect, useState } from 'octane';
+
+let bumpRender: (() => void) | null = null;
+export function triggerRenderThrow(): void {
+	bumpRender!();
+}
+
+function RenderThrower() @{
+	const [bang, setBang] = useState(false);
+	bumpRender = () => setBang(true);
+	if (bang) {
+		throw new Error('render-boom');
+	}
+	<span id="ok">ok</span>
+}
+
+export function CaughtHost() @{
+	<ErrorBoundary fallback={(e) => 'caught:' + (e as Error).message}>
+		<RenderThrower />
+	</ErrorBoundary>
+}
+
+export function UncaughtHost() @{
+	<main>
+		<RenderThrower />
+	</main>
+}
+
+let bumpEffect: (() => void) | null = null;
+export function triggerEffectThrow(): void {
+	bumpEffect!();
+}
+
+function EffectThrower() @{
+	const [bang, setBang] = useState(false);
+	bumpEffect = () => setBang(true);
+	useEffect(() => {
+		if (bang) {
+			throw new Error('effect-boom');
+		}
+	}, [bang]);
+	<span id="eok">eok</span>
+}
+
+export function CaughtEffectHost() @{
+	<ErrorBoundary fallback="effect-caught">
+		<EffectThrower />
+	</ErrorBoundary>
+}
+
+export function UncaughtEffectHost() @{
+	<main>
+		<EffectThrower />
+	</main>
+}

--- a/packages/octane/tests/_fixtures/root-error-callbacks.tsrx
+++ b/packages/octane/tests/_fixtures/root-error-callbacks.tsrx
@@ -43,6 +43,13 @@ function throwOnMount(): string {
 	throw new Error('mount-boom');
 }
 
+// Interactive recovery probe: a recovered root must keep its container's event
+// delegation, so a click on freshly rendered content still reaches handlers.
+export function ClickCounter() @{
+	const [n, setN] = useState(0);
+	<button id="counter" onClick={() => setN(n + 1)}>{'n:' + n}</button>
+}
+
 let bumpEffect: (() => void) | null = null;
 export function triggerEffectThrow(): void {
 	bumpEffect!();

--- a/packages/octane/tests/_fixtures/root-error-callbacks.tsrx
+++ b/packages/octane/tests/_fixtures/root-error-callbacks.tsrx
@@ -30,6 +30,19 @@ export function UncaughtHost() @{
 	</main>
 }
 
+// Throws during the FIRST render — exercises the synchronous initial-mount
+// error path (the first root.render() mounts synchronously in Octane) and the
+// hydration render path, both of which must honor onUncaughtError.
+export function MountThrower() @{
+	{
+		throwOnMount() as string;
+	}
+}
+
+function throwOnMount(): string {
+	throw new Error('mount-boom');
+}
+
 let bumpEffect: (() => void) | null = null;
 export function triggerEffectThrow(): void {
 	bumpEffect!();

--- a/packages/octane/tests/_fixtures/unstable-activity.tsrx
+++ b/packages/octane/tests/_fixtures/unstable-activity.tsrx
@@ -1,0 +1,12 @@
+// React's experimental channel shipped Activity as `unstable_Activity` before
+// 19.2 — the alias must compile and behave identically to Activity, mirroring
+// the unstable_ViewTransition alias.
+import { unstable_Activity } from 'octane';
+
+export function UnstableActivityHost(props: { mode: string }) @{
+	<section class="ua">
+		<unstable_Activity mode={props.mode as 'visible' | 'hidden'}>
+			<div id="ua-child">content</div>
+		</unstable_Activity>
+	</section>
+}

--- a/packages/octane/tests/activity.test.ts
+++ b/packages/octane/tests/activity.test.ts
@@ -13,6 +13,7 @@ import {
 	SuspenseInActivity,
 	TextActivityHost,
 } from './_fixtures/activity.tsrx';
+import { UnstableActivityHost } from './_fixtures/unstable-activity.tsrx';
 
 // Parity with React 19 <Activity mode="hidden"|"visible"> — the portable subset
 // of React's Activity-test.js / ReactDOMActivity-test.js (DOM + effect lifecycle
@@ -464,5 +465,22 @@ describe('<Activity> — insertion effects stay connected while hidden (conforma
 		// already current for n=1.
 		expect(t.log).toEqual(['layout mount']);
 		t.r.unmount();
+	});
+});
+
+describe('unstable_Activity alias', () => {
+	it('compiles and hides/reveals like Activity (React experimental-channel ports)', () => {
+		const r = mount(UnstableActivityHost, { mode: 'visible' });
+		const child = () => r.container.querySelector('#ua-child') as HTMLElement | null;
+		expect(child()).not.toBeNull();
+		expect(child()!.style.display).toBe('');
+		r.update(UnstableActivityHost, { mode: 'hidden' });
+		flushEffects();
+		expect(child()).not.toBeNull(); // state/DOM preserved...
+		expect(child()!.style.display).toBe('none'); // ...just visually hidden
+		r.update(UnstableActivityHost, { mode: 'visible' });
+		flushEffects();
+		expect(child()!.style.display).toBe('');
+		r.unmount();
 	});
 });

--- a/packages/octane/tests/float-resources.test.ts
+++ b/packages/octane/tests/float-resources.test.ts
@@ -1,0 +1,183 @@
+// React Float parity: <link rel="stylesheet" href precedence> and
+// <script async src> rendered in components are RESOURCES, not per-site head
+// elements — hoisted to document.head, deduped by href/src identity across the
+// whole page, stylesheets ordered by precedence group (first-encounter group
+// order, appended within a group), and retained after unmount (React never
+// removes a resource: unloading styles or re-running scripts is unsafe).
+// Suspend-until-loaded ("suspensey" commit) is intentionally NOT part of this
+// contract — Octane documents that as out of scope.
+// Links WITHOUT precedence keep the existing per-site head-element behavior.
+import { describe, it, expect, afterEach } from 'vitest';
+import { act, createRoot, resetFloatResourceState } from '../src/index.js';
+import * as Server from 'octane/server';
+import { loadServerFixture } from './_server-fixture.js';
+import { collectPipeableStream } from './_server-stream.js';
+import {
+	SheetA,
+	SheetADuplicate,
+	SheetHigh,
+	SheetLate,
+	PlainLink,
+	AsyncScript,
+	AsyncScriptDuplicate,
+	ToggleHost,
+	setSheetVisible,
+} from './_fixtures/float-resources.tsrx';
+
+function sheetHrefs(): string[] {
+	return Array.from(
+		document.head.querySelectorAll('link[rel="stylesheet"][data-precedence]'),
+		(l) => l.getAttribute('href')!,
+	);
+}
+
+describe('Float resources — client', () => {
+	const containers: HTMLElement[] = [];
+	const roots: Array<{ unmount(): void }> = [];
+	function mountInto(body: any): void {
+		const c = document.createElement('div');
+		document.body.appendChild(c);
+		containers.push(c);
+		const root = createRoot(c);
+		roots.push(root);
+		root.render(body, {});
+	}
+	afterEach(() => {
+		for (const r of roots.splice(0)) r.unmount();
+		for (const c of containers.splice(0)) c.remove();
+		document.head
+			.querySelectorAll('[data-precedence], [data-oct-res]')
+			.forEach((el) => el.remove());
+		// Resources are page-global by contract; tests reset the page.
+		resetFloatResourceState();
+	});
+
+	it('a precedence stylesheet hoists to head and dedupes by href across components', async () => {
+		await act(() => {
+			mountInto(SheetA);
+			mountInto(SheetADuplicate);
+		});
+		expect(sheetHrefs()).toEqual(['/base.css']);
+		// The body carries no trace of the resource element.
+		expect(document.body.querySelector('link')).toBeNull();
+	});
+
+	it('groups order by first encounter; later same-precedence sheets append to their group', async () => {
+		await act(() => {
+			mountInto(SheetA); // default group
+			mountInto(SheetHigh); // high group (new, appended after default)
+			mountInto(SheetLate); // default again → into the default group, before /high.css
+		});
+		expect(sheetHrefs()).toEqual(['/base.css', '/late-default.css', '/high.css']);
+		const high = document.head.querySelector('link[href="/high.css"]')!;
+		expect(high.getAttribute('crossorigin')).toBe('anonymous');
+		expect(high.getAttribute('data-precedence')).toBe('high');
+	});
+
+	it('resources persist after unmount; per-site links (no precedence) are removed', async () => {
+		await act(() => mountInto(ToggleHost));
+		expect(sheetHrefs()).toEqual(['/base.css']);
+		await act(() => setSheetVisible(false));
+		// The @if arm unmounted, but the stylesheet resource stays.
+		expect(sheetHrefs()).toEqual(['/base.css']);
+
+		// Control: a precedence-less hoisted link keeps per-site removal.
+		const c = document.createElement('div');
+		document.body.appendChild(c);
+		const root = createRoot(c);
+		await act(() => root.render(PlainLink, {}));
+		expect(document.head.querySelector('link[href="/feed.xml"]')).not.toBeNull();
+		root.unmount();
+		expect(document.head.querySelector('link[href="/feed.xml"]')).toBeNull();
+		c.remove();
+	});
+
+	it('async scripts hoist to head, dedupe by src, and persist', async () => {
+		await act(() => {
+			mountInto(AsyncScript);
+			mountInto(AsyncScriptDuplicate);
+		});
+		const scripts = document.head.querySelectorAll('script[src="/analytics.js"]');
+		expect(scripts).toHaveLength(1);
+		expect((scripts[0] as HTMLScriptElement).async).toBe(true);
+		expect(document.body.querySelector('script')).toBeNull();
+		await act(() => {
+			for (const r of roots.splice(0)) r.unmount();
+		});
+		expect(document.head.querySelectorAll('script[src="/analytics.js"]')).toHaveLength(1);
+	});
+});
+
+describe('Float resources — SSR + hydration dedupe', () => {
+	afterEach(() => {
+		document.head
+			.querySelectorAll('[data-precedence], [data-oct-res]')
+			.forEach((el) => el.remove());
+		resetFloatResourceState();
+	});
+
+	const srv = loadServerFixture(
+		'packages/octane/tests/_fixtures/float-resources.tsrx',
+	) as Record<string, any>;
+
+	it('SSR folds deduped, precedence-grouped resources into the head output', async () => {
+		const App = () =>
+			Server.createElement(
+				'div',
+				null,
+				Server.createElement(srv.SheetHigh, null),
+				Server.createElement(srv.SheetA, null),
+				Server.createElement(srv.SheetADuplicate, null),
+				Server.createElement(srv.SheetLate, null),
+				Server.createElement(srv.AsyncScript, null),
+				Server.createElement(srv.AsyncScriptDuplicate, null),
+			) as any;
+		const r = await Server.renderToString(App as any);
+		expect(r.html.match(/\/base\.css/g) || []).toHaveLength(1);
+		expect(r.html.match(/\/analytics\.js/g) || []).toHaveLength(1);
+		// Precedence groups: /high.css was encountered first, so the high group
+		// precedes default; /late-default.css appends into the default group.
+		const high = r.html.indexOf('/high.css');
+		const base = r.html.indexOf('/base.css');
+		const late = r.html.indexOf('/late-default.css');
+		expect(high).toBeGreaterThan(-1);
+		expect(base).toBeGreaterThan(high);
+		expect(late).toBeGreaterThan(base);
+		expect(r.html).toContain('data-precedence="high"');
+		expect(r.html).toContain('data-oct-res');
+	});
+
+	it('streamed shells carry deduped resources in the flushed head', async () => {
+		const App = () =>
+			Server.createElement(
+				'div',
+				null,
+				Server.createElement(srv.SheetA, null),
+				Server.createElement(srv.SheetADuplicate, null),
+				Server.createElement(srv.AsyncScript, null),
+			) as any;
+		const { html, errors } = await collectPipeableStream(App as any);
+		expect(errors).toEqual([]);
+		expect(html.match(/\/base\.css/g) || []).toHaveLength(1);
+		expect(html.match(/\/analytics\.js/g) || []).toHaveLength(1);
+		expect(html).toContain('data-precedence="default"');
+	});
+
+	it('a hydrating client call dedupes against SSR-emitted resources', async () => {
+		const App = () =>
+			Server.createElement('div', null, Server.createElement(srv.SheetA, null)) as any;
+		const r = await Server.renderToString(App as any);
+		const headHtml = r.html.slice(0, r.html.indexOf('<div'));
+		document.head.insertAdjacentHTML('afterbegin', headHtml);
+		expect(sheetHrefs()).toEqual(['/base.css']);
+
+		// The client render of the same component must adopt, not duplicate.
+		const c = document.createElement('div');
+		document.body.appendChild(c);
+		const root = createRoot(c);
+		await act(() => root.render(SheetA, {}));
+		expect(sheetHrefs()).toEqual(['/base.css']);
+		root.unmount();
+		c.remove();
+	});
+});

--- a/packages/octane/tests/float-resources.test.ts
+++ b/packages/octane/tests/float-resources.test.ts
@@ -20,6 +20,8 @@ import {
 	PlainLink,
 	AsyncScript,
 	AsyncScriptDuplicate,
+	ReturnScript,
+	ReturnSheet,
 	ToggleHost,
 	setSheetVisible,
 } from './_fixtures/float-resources.tsrx';
@@ -92,6 +94,21 @@ describe('Float resources — client', () => {
 		c.remove();
 	});
 
+	it('return-position (value-body) trees classify resources like @{} bodies', async () => {
+		await act(() => {
+			mountInto(ReturnScript);
+			mountInto(ReturnSheet);
+		});
+		const script = document.head.querySelector('script[src="/return-script.js"]');
+		expect(script).not.toBeNull();
+		expect((script as HTMLScriptElement).async).toBe(true);
+		expect(document.body.querySelector('script')).toBeNull();
+		expect(sheetHrefs()).toEqual(['/return.css']);
+		expect(document.body.querySelector('link')).toBeNull();
+		expect(document.body.textContent).toContain('RS');
+		expect(document.body.textContent).toContain('RL');
+	});
+
 	it('async scripts hoist to head, dedupe by src, and persist', async () => {
 		await act(() => {
 			mountInto(AsyncScript);
@@ -116,9 +133,10 @@ describe('Float resources — SSR + hydration dedupe', () => {
 		resetFloatResourceState();
 	});
 
-	const srv = loadServerFixture(
-		'packages/octane/tests/_fixtures/float-resources.tsrx',
-	) as Record<string, any>;
+	const srv = loadServerFixture('packages/octane/tests/_fixtures/float-resources.tsrx') as Record<
+		string,
+		any
+	>;
 
 	it('SSR folds deduped, precedence-grouped resources into the head output', async () => {
 		const App = () =>

--- a/packages/octane/tests/hydration/recoverable-callback.test.ts
+++ b/packages/octane/tests/hydration/recoverable-callback.test.ts
@@ -1,0 +1,117 @@
+// React 19 root option parity: hydrateRoot's onRecoverableError. Octane recovers
+// hydration mismatches per site (patch/rebuild in place) rather than client-
+// rendering a whole boundary, so the callback contract is: fire (dev AND prod)
+// after hydration recovered from a STRUCTURAL server/client divergence —
+// rebuilt subtrees, discarded stale server ranges — coalesced to one report per
+// root per microtask burst. Attribute-level value patches do not report: React
+// production hydration does not detect those at all, so reporting them would
+// make Octane's extra detection a behavioral difference.
+// The callback receives only the error (no errorInfo/componentStack), matching
+// the documented SSR onError shape.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { compile } from 'octane/compiler';
+import * as ClientRT from '../../src/index.js';
+import { hydrateRoot, flushSync } from '../../src/index.js';
+import * as ServerRT from 'octane/server';
+
+const SWAP = join(process.cwd(), 'packages/octane/tests/hydration/_fixtures/swap.tsrx');
+
+function serverModule(fixture: string, file: string): Record<string, any> {
+	let { code } = compile(readFileSync(fixture, 'utf8'), file, { mode: 'server' });
+	code = code.replace(
+		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
+	);
+	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
+	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');
+	return new Function('__rt', '__exports', code + '\nreturn __exports;')(ServerRT, {});
+}
+
+function clientModule(fixture: string, file: string, dev: boolean): Record<string, any> {
+	let { code } = compile(readFileSync(fixture, 'utf8'), file, { mode: 'client', dev });
+	code = code.replace(
+		/import\s*\{([^}]*)\}\s*from\s*['"]octane['"];?/g,
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
+	);
+	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
+	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');
+	return new Function('__rt', '__exports', code + '\nreturn __exports;')(ClientRT, {});
+}
+
+describe('hydrateRoot — onRecoverableError', () => {
+	let container: HTMLElement;
+	let errSpy: ReturnType<typeof vi.spyOn>;
+	beforeEach(() => {
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+	});
+	afterEach(() => {
+		container.remove();
+		errSpy.mockRestore();
+	});
+
+	const srv = serverModule(SWAP, 'swap.tsrx');
+	const cliDev = clientModule(SWAP, 'swap.tsrx', true);
+	const cliProd = clientModule(SWAP, 'swap.tsrx', false);
+
+	it('fires after a structural mismatch recovery (dev compile)', async () => {
+		const { html } = await ServerRT.renderToString(srv.Swap, { host: true });
+		container.innerHTML = html;
+		const onRecoverableError = vi.fn();
+		hydrateRoot(container, cliDev.Swap, { host: false }, { onRecoverableError });
+		flushSync(() => {});
+		// Recovery itself is synchronous; the report is delivered post-burst.
+		await Promise.resolve();
+		expect(container.querySelector('b.inner')).not.toBeNull();
+		expect(container.querySelector('p.host')).toBeNull();
+		expect(onRecoverableError).toHaveBeenCalledTimes(1);
+		expect(String((onRecoverableError.mock.calls[0][0] as Error).message)).toMatch(/hydration/i);
+	});
+
+	it('fires in PROD compile too (recovery runs everywhere; only the warning is dev-only)', async () => {
+		const { html } = await ServerRT.renderToString(srv.Swap, { host: true });
+		container.innerHTML = html;
+		const onRecoverableError = vi.fn();
+		hydrateRoot(container, cliProd.Swap, { host: false }, { onRecoverableError });
+		flushSync(() => {});
+		await Promise.resolve();
+		expect(container.querySelector('b.inner')).not.toBeNull();
+		expect(onRecoverableError).toHaveBeenCalledTimes(1);
+	});
+
+	it('coalesces to one report per root per burst', async () => {
+		// Server renders BOTH divergent spots (host branch); the client flips the
+		// branch AND the inner label — still a single report for the burst.
+		const { html } = await ServerRT.renderToString(srv.Swap, { host: true });
+		container.innerHTML = html;
+		const onRecoverableError = vi.fn();
+		hydrateRoot(container, cliDev.Swap, { host: false }, { onRecoverableError });
+		flushSync(() => {});
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(onRecoverableError).toHaveBeenCalledTimes(1);
+	});
+
+	it('control: a MATCHED hydration never fires the callback', async () => {
+		const { html } = await ServerRT.renderToString(srv.Swap, { host: true });
+		container.innerHTML = html;
+		const onRecoverableError = vi.fn();
+		hydrateRoot(container, cliDev.Swap, { host: true }, { onRecoverableError });
+		flushSync(() => {});
+		await Promise.resolve();
+		expect(onRecoverableError).not.toHaveBeenCalled();
+	});
+
+	it('control: mismatch recovery without the option keeps current behavior', async () => {
+		const { html } = await ServerRT.renderToString(srv.Swap, { host: true });
+		container.innerHTML = html;
+		hydrateRoot(container, cliDev.Swap, { host: false });
+		flushSync(() => {});
+		expect(container.querySelector('b.inner')).not.toBeNull();
+		const warns = errSpy.mock.calls.map((c) => String(c[0]));
+		expect(warns.some((m) => m.includes('hydration mismatch'))).toBe(true);
+	});
+});

--- a/packages/octane/tests/resource-hints.test.ts
+++ b/packages/octane/tests/resource-hints.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { preload, preinit, preconnect, prefetchDNS } from '../src/index.js';
+import {
+	preload,
+	preinit,
+	preloadModule,
+	preinitModule,
+	preconnect,
+	prefetchDNS,
+} from '../src/index.js';
 import * as Server from 'octane/server';
 
 // React DOM's resource hints: client calls insert deduped tags into
@@ -27,6 +34,29 @@ describe('resource hints — client', () => {
 		const s = document.head.querySelector('script[src="/app.js"]') as HTMLScriptElement;
 		expect(s).not.toBeNull();
 		expect(s.async).toBe(true);
+	});
+
+	it('preloadModule inserts one deduped <link rel="modulepreload">', () => {
+		preloadModule('/entry.mjs', { integrity: 'sha384-x' });
+		preloadModule('/entry.mjs');
+		const links = document.head.querySelectorAll('link[rel="modulepreload"][href="/entry.mjs"]');
+		expect(links).toHaveLength(1);
+		expect(links[0].getAttribute('integrity')).toBe('sha384-x');
+	});
+
+	it('preinitModule inserts one deduped async module script; non-script destinations no-op', () => {
+		preinitModule('/boot.mjs', { crossOrigin: 'anonymous' });
+		preinitModule('/boot.mjs');
+		const scripts = document.head.querySelectorAll('script[src="/boot.mjs"]');
+		expect(scripts).toHaveLength(1);
+		const s = scripts[0] as HTMLScriptElement;
+		expect(s.type).toBe('module');
+		expect(s.async).toBe(true);
+		expect(s.getAttribute('crossorigin')).toBe('anonymous');
+		// Module preinit has only the script destination — others fail closed.
+		preinitModule('/styles.mjs', { as: 'style' });
+		expect(document.head.querySelector('script[src="/styles.mjs"]')).toBeNull();
+		expect(document.head.querySelector('link[href="/styles.mjs"]')).toBeNull();
 	});
 
 	it('preconnect and prefetchDNS insert their links once', () => {
@@ -70,5 +100,27 @@ describe('resource hints — server', () => {
 		expect(
 			document.head.querySelectorAll('link[rel="dns-prefetch"][href="https://dns.example.com"]'),
 		).toHaveLength(1);
+	});
+
+	it('module hints fold into head output and share the client dedupe key', async () => {
+		const App = () => {
+			Server.preloadModule('/entry.mjs');
+			Server.preloadModule('/entry.mjs');
+			Server.preinitModule('/boot.mjs');
+			Server.preinitModule('/skip.css', { as: 'style' }); // fails closed
+			return Server.createElement('div', null, 'x') as any;
+		};
+		const r = await Server.renderToString(App as any);
+		expect(r.html.match(/rel="modulepreload"/g) || []).toHaveLength(1);
+		expect(r.html).toContain('<script type="module" src="/boot.mjs" async');
+		expect(r.html).not.toContain('/skip.css');
+		// SSR head lands in the document; the hydrating client's calls are no-ops.
+		document.head.insertAdjacentHTML('afterbegin', r.html.split('<div')[0]);
+		preloadModule('/entry.mjs');
+		preinitModule('/boot.mjs');
+		expect(
+			document.head.querySelectorAll('link[rel="modulepreload"][href="/entry.mjs"]'),
+		).toHaveLength(1);
+		expect(document.head.querySelectorAll('script[src="/boot.mjs"]')).toHaveLength(1);
 	});
 });

--- a/packages/octane/tests/root-error-callbacks.test.ts
+++ b/packages/octane/tests/root-error-callbacks.test.ts
@@ -11,12 +11,13 @@
 // Roots created WITHOUT the options keep today's behavior byte-for-byte; the
 // control tests below pin that.
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { act, createRoot, flushSync } from '../src/index.js';
+import { act, createRoot, hydrateRoot, flushSync } from '../src/index.js';
 import {
 	CaughtHost,
 	UncaughtHost,
 	CaughtEffectHost,
 	UncaughtEffectHost,
+	MountThrower,
 	triggerRenderThrow,
 	triggerEffectThrow,
 } from './_fixtures/root-error-callbacks.tsrx';
@@ -111,6 +112,46 @@ describe('root error callbacks — onCaughtError / onUncaughtError', () => {
 		// The callback's own throw is reported through console.error, not rethrown.
 		expect(errSpy).toHaveBeenCalled();
 		expect(container.textContent).toBe('');
+	});
+
+	it('onUncaughtError consumes a SYNCHRONOUS first-mount error (first render() mounts sync)', () => {
+		const onUncaughtError = vi.fn();
+		const root = createRoot(container, { onUncaughtError });
+		expect(() => root.render(MountThrower, {})).not.toThrow();
+		expect(onUncaughtError).toHaveBeenCalledTimes(1);
+		expect((onUncaughtError.mock.calls[0][0] as Error).message).toBe('mount-boom');
+		// The failed tree was discarded and the root stays reusable.
+		expect(container.textContent).toBe('');
+		expect(() => flushSync(() => root.render(CaughtHost, {}))).not.toThrow();
+		expect(container.textContent).toBe('ok');
+		root.unmount();
+	});
+
+	it('control: a synchronous first-mount error without the option still throws', () => {
+		const root = createRoot(container);
+		expect(() => root.render(MountThrower, {})).toThrow('mount-boom');
+		expect(container.textContent).toBe('');
+	});
+
+	it('onUncaughtError consumes a hydration render error (unowned root)', () => {
+		container.innerHTML = '<div>server</div>';
+		const onUncaughtError = vi.fn();
+		let root!: ReturnType<typeof hydrateRoot>;
+		expect(() => {
+			root = hydrateRoot(container, MountThrower, {}, { onUncaughtError });
+		}).not.toThrow();
+		expect(onUncaughtError).toHaveBeenCalledTimes(1);
+		expect((onUncaughtError.mock.calls[0][0] as Error).message).toBe('mount-boom');
+		// The failed adoption was released; the returned root stays usable.
+		expect(container.textContent).toBe('');
+		expect(() => flushSync(() => root.render(CaughtHost, {}))).not.toThrow();
+		expect(container.textContent).toBe('ok');
+		root.unmount();
+	});
+
+	it('control: a hydration render error without the option still throws', () => {
+		container.innerHTML = '<div>server</div>';
+		expect(() => hydrateRoot(container, MountThrower, {})).toThrow('mount-boom');
 	});
 
 	// ── Controls: roots WITHOUT the options keep the existing contract ──────────

--- a/packages/octane/tests/root-error-callbacks.test.ts
+++ b/packages/octane/tests/root-error-callbacks.test.ts
@@ -18,6 +18,7 @@ import {
 	CaughtEffectHost,
 	UncaughtEffectHost,
 	MountThrower,
+	ClickCounter,
 	triggerRenderThrow,
 	triggerEffectThrow,
 } from './_fixtures/root-error-callbacks.tsrx';
@@ -133,7 +134,7 @@ describe('root error callbacks — onCaughtError / onUncaughtError', () => {
 		expect(container.textContent).toBe('');
 	});
 
-	it('onUncaughtError consumes a hydration render error (unowned root)', () => {
+	it('onUncaughtError consumes a hydration render error (unowned root)', async () => {
 		container.innerHTML = '<div>server</div>';
 		const onUncaughtError = vi.fn();
 		let root!: ReturnType<typeof hydrateRoot>;
@@ -142,10 +143,29 @@ describe('root error callbacks — onCaughtError / onUncaughtError', () => {
 		}).not.toThrow();
 		expect(onUncaughtError).toHaveBeenCalledTimes(1);
 		expect((onUncaughtError.mock.calls[0][0] as Error).message).toBe('mount-boom');
-		// The failed adoption was released; the returned root stays usable.
+		// The failed adoption was discarded; the returned root stays usable.
 		expect(container.textContent).toBe('');
-		expect(() => flushSync(() => root.render(CaughtHost, {}))).not.toThrow();
-		expect(container.textContent).toBe('ok');
+		await act(() => root.render(ClickCounter, {}));
+		expect(container.textContent).toBe('n:0');
+		// The recovered root keeps the container's event delegation — a click on
+		// freshly rendered content must still reach its handler.
+		await act(() => {
+			(container.querySelector('#counter') as HTMLElement).click();
+		});
+		expect(container.textContent).toBe('n:1');
+		root.unmount();
+	});
+
+	it('a consumed sync-mount error keeps event delegation on the recovered root', async () => {
+		const onUncaughtError = vi.fn();
+		const root = createRoot(container, { onUncaughtError });
+		expect(() => root.render(MountThrower, {})).not.toThrow();
+		expect(onUncaughtError).toHaveBeenCalledTimes(1);
+		await act(() => root.render(ClickCounter, {}));
+		await act(() => {
+			(container.querySelector('#counter') as HTMLElement).click();
+		});
+		expect(container.textContent).toBe('n:1');
 		root.unmount();
 	});
 

--- a/packages/octane/tests/root-error-callbacks.test.ts
+++ b/packages/octane/tests/root-error-callbacks.test.ts
@@ -1,0 +1,134 @@
+// React 19 root option parity: createRoot/hydrateRoot accept onCaughtError and
+// onUncaughtError (reporting callbacks; Octane passes only the error — there is
+// no errorInfo/componentStack channel). Providing a callback changes REPORTING
+// only:
+//   - onCaughtError fires after a boundary (@try/@catch, <ErrorBoundary>)
+//     claims an error from the render, passive-effect, or ref-attach channel.
+//   - onUncaughtError replaces the default report for an error no boundary
+//     claims (the flush rethrow for render errors, console.error for effect
+//     channels). Recovery semantics are unchanged: an uncaught render error
+//     still unmounts the failed root's tree.
+// Roots created WITHOUT the options keep today's behavior byte-for-byte; the
+// control tests below pin that.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, createRoot, flushSync } from '../src/index.js';
+import {
+	CaughtHost,
+	UncaughtHost,
+	CaughtEffectHost,
+	UncaughtEffectHost,
+	triggerRenderThrow,
+	triggerEffectThrow,
+} from './_fixtures/root-error-callbacks.tsrx';
+
+describe('root error callbacks — onCaughtError / onUncaughtError', () => {
+	let container: HTMLElement;
+	let errSpy: ReturnType<typeof vi.spyOn>;
+	beforeEach(() => {
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+	});
+	afterEach(() => {
+		container.remove();
+		errSpy.mockRestore();
+	});
+
+	it('onCaughtError fires once when a boundary claims a render error', async () => {
+		const onCaughtError = vi.fn();
+		const root = createRoot(container, { onCaughtError });
+		await act(() => root.render(CaughtHost, {}));
+		expect(container.textContent).toBe('ok');
+		await act(() => triggerRenderThrow());
+		expect(container.textContent).toBe('caught:render-boom');
+		expect(onCaughtError).toHaveBeenCalledTimes(1);
+		expect((onCaughtError.mock.calls[0][0] as Error).message).toBe('render-boom');
+		root.unmount();
+	});
+
+	it('onCaughtError fires when a boundary claims a passive-effect error', async () => {
+		const onCaughtError = vi.fn();
+		const root = createRoot(container, { onCaughtError });
+		await act(() => root.render(CaughtEffectHost, {}));
+		expect(container.textContent).toBe('eok');
+		await act(() => triggerEffectThrow());
+		expect(container.textContent).toBe('effect-caught');
+		expect(onCaughtError).toHaveBeenCalledTimes(1);
+		expect((onCaughtError.mock.calls[0][0] as Error).message).toBe('effect-boom');
+		root.unmount();
+	});
+
+	it('onCaughtError does NOT fire for an uncaught error', async () => {
+		const onCaughtError = vi.fn();
+		const root = createRoot(container, { onCaughtError });
+		await act(() => root.render(UncaughtHost, {}));
+		expect(() => flushSync(() => triggerRenderThrow())).toThrow('render-boom');
+		expect(onCaughtError).not.toHaveBeenCalled();
+	});
+
+	it('onUncaughtError consumes an unclaimed render error; the tree still unmounts', async () => {
+		const onUncaughtError = vi.fn();
+		const root = createRoot(container, { onUncaughtError });
+		await act(() => root.render(UncaughtHost, {}));
+		expect(container.textContent).toBe('ok');
+		expect(() => flushSync(() => triggerRenderThrow())).not.toThrow();
+		expect(onUncaughtError).toHaveBeenCalledTimes(1);
+		expect((onUncaughtError.mock.calls[0][0] as Error).message).toBe('render-boom');
+		// React 19 contract retained: known-broken UI never stays on screen.
+		expect(container.textContent).toBe('');
+	});
+
+	it('onUncaughtError does NOT fire for a boundary-claimed error', async () => {
+		const onUncaughtError = vi.fn();
+		const root = createRoot(container, { onUncaughtError });
+		await act(() => root.render(CaughtHost, {}));
+		await act(() => triggerRenderThrow());
+		expect(container.textContent).toBe('caught:render-boom');
+		expect(onUncaughtError).not.toHaveBeenCalled();
+		root.unmount();
+	});
+
+	it('onUncaughtError replaces console.error for an unclaimed passive-effect error', async () => {
+		const onUncaughtError = vi.fn();
+		const root = createRoot(container, { onUncaughtError });
+		await act(() => root.render(UncaughtEffectHost, {}));
+		errSpy.mockClear();
+		await act(() => triggerEffectThrow());
+		expect(onUncaughtError).toHaveBeenCalledTimes(1);
+		expect((onUncaughtError.mock.calls[0][0] as Error).message).toBe('effect-boom');
+		expect(errSpy).not.toHaveBeenCalled();
+		root.unmount();
+	});
+
+	it('a throwing callback is reported and does not corrupt recovery', async () => {
+		const onUncaughtError = vi.fn(() => {
+			throw new Error('handler-boom');
+		});
+		const root = createRoot(container, { onUncaughtError });
+		await act(() => root.render(UncaughtHost, {}));
+		expect(() => flushSync(() => triggerRenderThrow())).not.toThrow();
+		expect(onUncaughtError).toHaveBeenCalledTimes(1);
+		// The callback's own throw is reported through console.error, not rethrown.
+		expect(errSpy).toHaveBeenCalled();
+		expect(container.textContent).toBe('');
+	});
+
+	// ── Controls: roots WITHOUT the options keep the existing contract ──────────
+
+	it('control: without onUncaughtError the flush rethrows and the tree unmounts', async () => {
+		const root = createRoot(container);
+		await act(() => root.render(UncaughtHost, {}));
+		expect(() => flushSync(() => triggerRenderThrow())).toThrow('render-boom');
+		expect(container.textContent).toBe('');
+	});
+
+	it('control: without onUncaughtError an unclaimed effect error console.errors', async () => {
+		const root = createRoot(container);
+		await act(() => root.render(UncaughtEffectHost, {}));
+		errSpy.mockClear();
+		await act(() => triggerEffectThrow());
+		expect(errSpy).toHaveBeenCalled();
+		expect((errSpy.mock.calls[0][0] as Error).message).toBe('effect-boom');
+		root.unmount();
+	});
+});


### PR DESCRIPTION
## Summary

- Implements the React Float resource model: `<link rel="stylesheet" href precedence>` and `<script async src>` at a component's body root are now global resources — hoisted to `document.head`, deduped by href/src, stylesheet groups ordered by precedence (first-encounter group order, appended within a group), retained after unmount, emitted in buffered AND streamed SSR head output, and hydration-deduped (the first client call seeds from SSR-emitted `data-precedence`/`data-oct-res` tags).
- Adds `preloadModule`/`preinitModule` to the resource hints on both `octane` and `octane/server`.
- Adds React 19's root error-callback options to `createRoot`/`hydrateRoot`: `onCaughtError` (boundary claimed an error from the render/passive-effect/ref-attach channel), `onUncaughtError` (replaces the default report — the flush rethrow / effect-channel `console.error` — while the failed root's tree still unmounts), and `onRecoverableError` (structural hydration recovery, dev AND prod, coalesced per root per microtask burst). Error-only signature; no `errorInfo`/`componentStack`.
- Aliases `unstable_Activity` → `Activity` (client + server + compiler tag whitelist), mirroring `unstable_ViewTransition`.
- Records the partial pre-rendering (`resume`/postpone) and `cache()`/`cacheSignal()` decisions as documented non-goals in the conformance ledger (27 entries flipped from `planned`), regenerates `docs/react-parity-coverage.md`, fixes the stale `octane/static` comment, and documents `hydrateRoot`'s missing `formState` option as an RSC-adjacent non-goal.
- Doc sweep: `docs/differences-from-react.md` now covers the previously undocumented divergences — `Context.Consumer` absence, `<title>` child concatenation, per-compile-site metadata dedupe, hidden-`<Activity>` scheduling (no offscreen lane), dropped stream options (`progressiveChunkSize`, `namespaceURI`), `prerender`'s `{html, css}` shape vs React's `{prelude}`, the `useId` format, the `version` string caveat, `captureOwnerStack`/`unstable_batchedUpdates`/gesture-VT non-goals, and the doctype wording fix. `docs/ssr.md` and `docs/view-transitions.md` gain matching entries.

## Why

A deep React 19.2 parity audit (4 parallel area audits over the runtime, react-dom statics, SSR surface, and 19.1/19.2 additions) found the Float resource model was the largest functional gap (ReactDOMFloat-test.js is the single largest `planned` block in the ledger at 131 cases), the root error callbacks were absent and undocumented, partial pre-rendering had contradictory ledger dispositions (32 non-goal vs 19 planned), and roughly a dozen real divergences existed in code but not in `differences-from-react.md`, which promises "parity outside the documented differences".

## Changes

- `packages/octane/src/runtime.ts` — Float resource insertion (`stylesheetResource`/`scriptResource`, DOM-seeded dedupe state, tier-3 `resetFloatResourceState`), `preloadModule`/`preinitModule`, `RootOptions` error callbacks + `ROOT_ERROR_HANDLERS` WeakMap (off the Block shape), caught/uncaught report wiring at the boundary-claim and default-report sites, `noteRecoverableHydrationError` at the structural hydration-recovery sites, `unstable_Activity` alias.
- `packages/octane/src/runtime.server.ts` — `ssrStylesheetResource`/`ssrScriptResource`, `HeadBuffer.sheets` precedence grouping (participates in both suspense-replay snapshot/rewind sites), head fold via `headHtmlWithSheets`, server module hints.
- `packages/octane/src/compiler/compile.js` — `headResourceKind` static classifier (link+rel=stylesheet+href+precedence; script+async+src, `async={false}` excluded, no handlers/children), script admission into the HeadHoist partition, emitter routing to the resource ABI (headBlock slot numbering unchanged), `unstable_Activity` in the builtin-import whitelist and `isActivityLongForm`.
- `packages/octane/src/{index,server/index,static/index}.ts` — exports and the corrected `octane/static` doc comment.
- `packages/octane/audit/react-conformance-ledger.json` + `docs/react-parity-coverage.md` — 27 dispositions (FizzStatic postpone/resume → non-goal with the established rationale; ReactCache cache()/cacheSignal → non-goal) and the regenerated report.
- Docs: `differences-from-react.md`, `ssr.md`, `view-transitions.md`.
- Tests: `tests/float-resources.test.ts` (+fixture), `tests/root-error-callbacks.test.ts` (+fixture), `tests/hydration/recoverable-callback.test.ts`, module-hint cases in `tests/resource-hints.test.ts`, `unstable_Activity` case in `tests/activity.test.ts` (+fixture).

## Contract and hot paths

Every new behavior is pay-per-use and off the hot paths: error-callback lookups run only on already-cold error/recovery paths behind a module-null check, handlers live in a WeakMap so the monomorphic Block shape is untouched, resource calls run once per authored resource element per render (dedupe-set hit after the first), and the compiler classifier adds two string compares per JSX child at compile time. No per-render/per-node work is added for components that use none of these features; no benchmark deltas are claimed and none are expected — the compiled output of code not using these features is byte-identical (head slot numbering deliberately preserved).

Known intentional bounds (documented in the diff): suspensey commits and `<style href precedence>` are non-goals; resource classification is static (spreads keep the element path); deletion-phase teardown errors keep their existing default report; `onRecoverableError` does not fire for attribute-level value patches (prod React cannot detect those at all).

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 18,480/18,481 passed. The one failure was a 20s timeout in `packages/phosphor-icons/tests/differential/parity.test.ts` under full-suite load; it passes in isolation in ~4s, passed in the previous full run with this same diff, and touches none of the changed code paths — reported here rather than papered over.
- [x] targeted tests: `float-resources` (14), `root-error-callbacks` (18), `recoverable-callback` (10), `resource-hints` (16), `activity.test` (73), `packed-consumer`/`production-error-bundle` (13, exercises the error-code audit that gated the new catalog codes), plus neighbor sweeps over boundary/mismatch/error-handling/streaming/head-hydrate/ssr-suspense suites — all green in dev and prod compile projects.
- [x] `node scripts/react-parity/check.mjs --validate-only` — ledger valid; coverage report verified byte-identical to `renderCoverageReport` over the committed inventories + edited ledger.
- [x] `pnpm sync` — committed generated changes (CLI data, error-code modules).
- New tests were observed failing before their implementations landed (16 pre-fix failures for the error callbacks; the Float suite failed at compile/classification before the compiler change). The error-code audit itself caught the first implementation's plain-string `new Error` messages — the recoverable-error reports now use catalog codes 51–56 (minified in production, exactly like the rest of the framework's production errors).
- **Review-fix commit 781a6670e** (both Bugbot findings, reproduced with failing tests first): the synchronous first `root.render()` and hydrateRoot's unowned render-throw path now consume through `onUncaughtError` like the scheduled flush, and `requiresTemplateNormalization` admits `<script async src>` so return-position trees classify resources. Full suite re-run: 18,490/18,491 (same phosphor-icons load-timeout flake, passes in isolation; spun off as a separate task), targeted + owned-path/hydration sweeps (1,840 tests) green, `pnpm sync` clean.
- **Review-fix commit bb5157649** (delegation finding, reproduced with a failing click-through test): a consumed unowned hydration failure now keeps the container's delegation registration and claim (real `ownerToken` passed through; the hosted-island path's full release is unchanged). Full suite re-run: 18,492/18,493 (same phosphor flake), react-hosted/hydration/boundary sweep (1,204 tests) green.

## Risk / follow-ups

- The universal renderer keeps its own root implementation: the new root error-callback options are DOM-runtime only for now (universal compile shares none of the head machinery — verified no exposure).
- Streamed boundaries that discover resources after the shell follow the existing documented head divergence (client re-creates during hydration).
- The ledger's Float cases remain `planned`: flipping them to `covered` requires exact-title conformance ports, which can now be written against the implemented behavior.
- `prerenderToNodeStream` remains planned (comment now says so accurately).

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches error-reporting and hydration-recovery paths plus SSR head emission, but changes are pay-per-use, off the hot path, and covered by targeted tests. Defaults without the new options remain unchanged.
> 
> **Overview**
> Closes a major React 19 parity gap by treating body-root `<link rel="stylesheet" href precedence>` and `<script async src>` as **Float resources**: hoisted into `document.head`, deduped by href/src, precedence-grouped, retained after unmount, and emitted in buffered/streamed SSR (with client hydration seeding).
> 
> `createRoot`/`hydrateRoot` gain React 19's **`onCaughtError`**, **`onUncaughtError`**, and **`onRecoverableError`** options (error-only; no `errorInfo`). Providing them changes reporting only — recovery/unmount semantics stay the same. Also adds `preloadModule`/`preinitModule` and aliases `unstable_Activity` → `Activity`.
> 
> Records partial pre-rendering, `cache()`/`cacheSignal()`, and `formState` as ledger non-goals, and documents previously missing divergences (`Context.Consumer`, title/metadata ownership, Activity scheduling, stream options, `useId`/`version`). Structural hydration recoveries now report via catalog codes **51–56**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb5157649856693b19321424fe060b9184483002. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

