### PR TITLE
feat: Float style resources and Context.Consumer decision (executes #711 decisions)

### DIFF
--- a/.changeset/style-resources-and-consumer-decision.md
+++ b/.changeset/style-resources-and-consumer-decision.md
@@ -1,0 +1,20 @@
+---
+'octane': patch
+---
+
+React Float style resources, and the Context.Consumer decision made concrete.
+
+`<style href precedence>` rendered at a component's body root is now a React
+Float STYLE RESOURCE: its plain CSS ships by href identity, sharing the
+stylesheet dedupe namespace and precedence-group ordering with link resources
+(`data-precedence`/`data-href` marked, SSR-emitted, hydration-deduped, retained
+after unmount). Every other `<style>` keeps Octane's scoped-CSS behavior.
+Octane emits one tag per resource (no same-precedence merging), and CSS
+containing `</style` fails closed in SSR with a development diagnostic.
+
+Context.Consumer stays modern-only, now with teeth: accessing `.Consumer` in
+development logs a one-time migration diagnostic (and still returns
+`undefined`, so feature probes match production), the upstream Consumer
+scenarios protecting observable behavior are ported as `useContext`-reading
+conformance tests, and the render-prop-surface-only cases are recorded as
+parity-ledger non-goals.

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -553,10 +553,18 @@ attribute; an empty string writes `class=""`.
 `createContext` returns a context that is itself the provider component —
 React 19's `<MyContext value={…}>` form is the native shape, and
 `MyContext.Provider` is retained as an identity alias for React-18-shaped
-libraries. The render-prop `<MyContext.Consumer>` does not exist: Octane's
-slot-keyed hooks make `use(MyContext)`/`useContext` legal behind any condition,
-which is the pattern Consumer existed to work around. Read the context in the
-child (or an inline component) instead.
+libraries. The render-prop `<MyContext.Consumer>` does not exist and will not
+be added: Octane's slot-keyed hooks make `use(MyContext)`/`useContext` legal
+behind any condition, which is the pattern Consumer existed to work around.
+Read the context in the child (or an inline component) instead.
+
+In development, accessing `.Consumer` logs a one-time migration diagnostic and
+still returns `undefined`, so feature probes (`MyContext.Consumer || fallback`)
+behave exactly as in production. The upstream Consumer test scenarios that
+protect observable behavior (defaults, propagation, bailout, hidden subtrees,
+suspended boundaries) are ported with `useContext`-reading components; the
+scenarios that exist only to exercise the render-prop API surface are recorded
+as non-goals in the parity ledger.
 
 ## Document metadata and Float resources
 
@@ -586,6 +594,15 @@ React Float **resources** are supported with React's semantics:
   not retarget a live sheet.
 - `<script async src>` (no children/handlers) hoists and dedupes by src, and
   is likewise never removed.
+- `<style href precedence>` is a STYLE RESOURCE: its plain CSS ships by href
+  identity, sharing the stylesheet dedupe namespace and precedence-group
+  ordering with link resources (`data-precedence`/`data-href` mark the tags).
+  The CSS is NOT scoped — every other `<style>` in a component still belongs
+  to Octane's scoped-CSS system. Two adaptations: Octane emits one `<style>`
+  tag per resource rather than merging same-precedence rules into a single tag
+  (grouping and order are preserved), and CSS containing `</style` fails
+  closed in SSR with a development diagnostic (raw-text serialization cannot
+  escape it; the client inserts via `textContent`, which is always safe).
 - `preloadModule`/`preinitModule` join `preload`/`preinit`/`preconnect`/
   `prefetchDNS`.
 - Classification is static: a spread-carried `precedence`/`async` keeps the
@@ -593,9 +610,7 @@ React Float **resources** are supported with React's semantics:
 
 Out of scope, deliberately: **suspensey commits** (React's
 suspend-until-the-stylesheet-loads behavior; Octane inserts the sheet and
-continues) and **`<style href precedence>` style resources** — `<style>` inside
-a component belongs to Octane's scoped-CSS system; use a stylesheet link
-resource or `preinit` for shared CSS. Resource-hint options apply as a lenient
+continues). Resource-hint options apply as a lenient
 attribute pass-through (`fetchPriority`, `imageSrcSet`, `imageSizes`, `media`,
 `integrity`, … all serialize correctly) without React's option validation, and
 `preload` + `preinit` of the same href are two entries rather than React's

--- a/docs/react-parity-coverage.md
+++ b/docs/react-parity-coverage.md
@@ -85,8 +85,8 @@ Every concrete case in either pinned inventory has exactly one ledger dispositio
 
 | Baseline | Cases | Untriaged | Planned | In progress | Covered | Documented | Blocked |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| stable | 5,345 | 0 | 2,002 | 0 | 894 | 2,449 | 0 |
-| canary | 5,413 | 0 | 2,049 | 0 | 951 | 2,413 | 0 |
+| stable | 5,345 | 0 | 1,985 | 0 | 908 | 2,452 | 0 |
+| canary | 5,413 | 0 | 2,032 | 0 | 965 | 2,416 | 0 |
 
 Classifications are `portable`, `adaptable`, `divergence`, and `non_goal`. A covered case requires live local test evidence; divergence and non-goal dispositions require a rationale.
 

--- a/packages/octane/audit/react-conformance-ledger.json
+++ b/packages/octane/audit/react-conformance-ledger.json
@@ -4605,7 +4605,7 @@
     },
     {
       "caseId": "react-case-v1:0dcc8820994994919dfd",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactNewContext-test.js",
       "title": "consumers bail out if context value is the same",
@@ -4613,7 +4613,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "React reconciler residual audit",
-      "rationale": "Remaining function-component hooks, effects, context, Suspense, transitions, Activity, batching, error recovery, and reconciliation outcomes require exact observable Octane evidence; Fiber-only mechanics will receive case-level non-goal dispositions."
+      "rationale": "Adapted executable evidence: the render-prop Consumer is replaced by a useContext-reading component (issue #711 decision); the same-value bailout outcome is asserted directly.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/context-bailout.test.ts",
+          "testName": "a consumer bails out when the new context value is Object.is-equal",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:0dcd4521f908ef05bd17",
@@ -14653,7 +14660,7 @@
     },
     {
       "caseId": "react-case-v1:31933070492ac17cb002",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactContextPropagation-test.js",
       "title": "finds context consumers in multiple sibling branches",
@@ -14661,7 +14668,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "React reconciler residual audit",
-      "rationale": "Remaining function-component hooks, effects, context, Suspense, transitions, Activity, batching, error recovery, and reconciliation outcomes require exact observable Octane evidence; Fiber-only mechanics will receive case-level non-goal dispositions."
+      "rationale": "Adapted executable evidence: the render-prop Consumer is replaced by a useContext-reading component (issue #711 decision); propagation into every sibling branch is asserted directly.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/context-consumer-adapted.test.ts",
+          "testName": "a context change reaches readers in every sibling branch",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:3195073a8576c0df35b4",
@@ -21023,15 +21037,15 @@
     },
     {
       "caseId": "react-case-v1:459daa25325aaa93242a",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can emit multiple style rules into a single style tag for a given precedence",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "divergence",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Octane emits one <style> tag per style resource instead of merging same-precedence rules into a single tag; grouping, ordering, and href identity are preserved (documented in differences-from-react.md)."
     },
     {
       "caseId": "react-case-v1:45a0485599e201c541c3",
@@ -26785,7 +26799,7 @@
     },
     {
       "caseId": "react-case-v1:5993920d622001de5ba2",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactNewContext-test.js",
       "title": "multiple consumers in different branches",
@@ -26793,7 +26807,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "React reconciler residual audit",
-      "rationale": "Remaining function-component hooks, effects, context, Suspense, transitions, Activity, batching, error recovery, and reconciliation outcomes require exact observable Octane evidence; Fiber-only mechanics will receive case-level non-goal dispositions."
+      "rationale": "Adapted executable evidence: the render-prop Consumer is replaced by a useContext-reading component (issue #711 decision); multi-branch reader updates are asserted directly.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/context-consumer-adapted.test.ts",
+          "testName": "readers in different branches all track the provider value",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:5995e2f6573089a8a1ee",
@@ -37662,7 +37683,7 @@
     },
     {
       "caseId": "react-case-v1:7f239bd3f8c62773ee9e",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can hoist <link rel=\"stylesheet\" .../> and <style /> tags together, respecting order of discovery",
@@ -37670,7 +37691,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Adapted executable evidence: link and style resources share one identity namespace and one precedence-group ordering, in discovery order within a group.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/float-resources.test.ts",
+          "testName": "<style href precedence> is a style resource: hoisted, deduped, precedence-grouped with links",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:7f250da531de34121105",
@@ -43754,7 +43782,7 @@
     },
     {
       "caseId": "react-case-v1:935bc9dd8bd1188d99c3",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactContextPropagation-test.js",
       "title": "context consumer bails out if context hasn't changed",
@@ -43762,7 +43790,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "React reconciler residual audit",
-      "rationale": "Remaining function-component hooks, effects, context, Suspense, transitions, Activity, batching, error recovery, and reconciliation outcomes require exact observable Octane evidence; Fiber-only mechanics will receive case-level non-goal dispositions."
+      "rationale": "Adapted executable evidence: the render-prop Consumer is replaced by a useContext-reading component (issue #711 decision); the unchanged-context bailout outcome is asserted directly.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/context-consumer-adapted.test.ts",
+          "testName": "a same-value provider re-commit does not re-render the reader",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:935d579359bec3cf4772",
@@ -44661,7 +44696,7 @@
     },
     {
       "caseId": "react-case-v1:96ada5b3062b63f998d3",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "treats <style href=\"...\" precedence=\"...\"> elements as a style resource when server rendering",
@@ -44669,7 +44704,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Adapted executable evidence: <style href precedence> serializes as a deduped, precedence-grouped style resource in SSR head output and the hydrating client seeds identity from data-href.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/float-resources.test.ts",
+          "testName": "SSR folds style resources into precedence groups; hydration seeds from data-href",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:96af21da33a1e8b5be5c",
@@ -48203,15 +48245,15 @@
     },
     {
       "caseId": "react-case-v1:a3d9401e746b6f396ad3",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactNewContext-test.js",
       "title": "can read other contexts inside consumer render prop",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "React reconciler residual audit",
-      "rationale": "Remaining function-component hooks, effects, context, Suspense, transitions, Activity, batching, error recovery, and reconciliation outcomes require exact observable Octane evidence; Fiber-only mechanics will receive case-level non-goal dispositions."
+      "rationale": "Octane has no render-prop Context.Consumer (modern callable context + slot-keyed hooks; issue #711 decision) and accessing .Consumer has its own development diagnostic. This case exists only to exercise the render-prop API surface."
     },
     {
       "caseId": "react-case-v1:a3dd1503d956da2af435",
@@ -51223,7 +51265,7 @@
     },
     {
       "caseId": "react-case-v1:ae3e15d7688bb8c5510c",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "stylesheet resources are inserted according to precedence order on the client",
@@ -51231,7 +51273,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Adapted executable evidence: client insertion orders precedence groups by first encounter and appends within a group.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/float-resources.test.ts",
+          "testName": "groups order by first encounter; later same-precedence sheets append to their group",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:ae46ab96c371b49d856b",
@@ -55692,7 +55741,7 @@
     },
     {
       "caseId": "react-case-v1:bd1720ad06b9f2b30d80",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactNewContext-test.js",
       "title": "context consumer doesn't bail out inside hidden subtree",
@@ -55700,7 +55749,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "React reconciler residual audit",
-      "rationale": "Remaining function-component hooks, effects, context, Suspense, transitions, Activity, batching, error recovery, and reconciliation outcomes require exact observable Octane evidence; Fiber-only mechanics will receive case-level non-goal dispositions."
+      "rationale": "Adapted executable evidence: the render-prop Consumer is replaced by a useContext-reading component (issue #711 decision); the hidden-subtree no-bailout outcome is asserted via Activity.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/context-consumer-adapted.test.ts",
+          "testName": "a context change updates a reader inside a hidden Activity subtree",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:bd26a320b22c502030ad",
@@ -57027,7 +57083,7 @@
     },
     {
       "caseId": "react-case-v1:c1eda66a00b1d5638bc3",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js",
       "title": "updates context consumer within child of suspended suspense component when context updates",
@@ -57035,7 +57091,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "React reconciler residual audit",
-      "rationale": "Remaining function-component hooks, effects, context, Suspense, transitions, Activity, batching, error recovery, and reconciliation outcomes require exact observable Octane evidence; Fiber-only mechanics will receive case-level non-goal dispositions."
+      "rationale": "Adapted executable evidence: the render-prop Consumer is replaced by a useContext-reading component (issue #711 decision); the suspended-boundary context-update outcome is asserted directly.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/context-consumer-adapted.test.ts",
+          "testName": "a context update while suspended reaches the reader on reveal",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:c1edbdea7f9272fdbb5a",
@@ -57708,7 +57771,7 @@
     },
     {
       "caseId": "react-case-v1:c3d2783b1ad4816cd74a",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "hoists stylesheet resources to the correct precedence",
@@ -57716,7 +57779,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Adapted executable evidence: resources land in their precedence group regardless of mount order.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/float-resources.test.ts",
+          "testName": "groups order by first encounter; later same-precedence sheets append to their group",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:c3d39ad33e0043e7240e",
@@ -64154,7 +64224,7 @@
     },
     {
       "caseId": "react-case-v1:d7d3803f64367db645fe",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactNewContext-test.js",
       "title": "consumer does not bail out if there were no bailouts above it",
@@ -64162,7 +64232,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "React reconciler residual audit",
-      "rationale": "Remaining function-component hooks, effects, context, Suspense, transitions, Activity, batching, error recovery, and reconciliation outcomes require exact observable Octane evidence; Fiber-only mechanics will receive case-level non-goal dispositions."
+      "rationale": "Adapted executable evidence: the render-prop Consumer is replaced by a useContext-reading component (issue #711 decision); the no-bailouts-above re-render outcome is asserted directly.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/context-consumer-adapted.test.ts",
+          "testName": "a memo-free chain re-renders through to the reader on every change",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:d7d5eca8e8e3ed481708",
@@ -66182,7 +66259,7 @@
     },
     {
       "caseId": "react-case-v1:de950c5617a92d80bcfc",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactNewContext-test.js",
       "title": "consumer bails out if value is unchanged and something above bailed out",
@@ -66190,7 +66267,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "React reconciler residual audit",
-      "rationale": "Remaining function-component hooks, effects, context, Suspense, transitions, Activity, batching, error recovery, and reconciliation outcomes require exact observable Octane evidence; Fiber-only mechanics will receive case-level non-goal dispositions."
+      "rationale": "Adapted executable evidence: the render-prop Consumer is replaced by a useContext-reading component (issue #711 decision); the bailed-ancestor propagation outcome is asserted directly.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/context-bailout.test.ts",
+          "testName": "a same-value re-render with a bailed-out memo subtree skips the consumers",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:de9954ea3403e7aa88fb",
@@ -66752,15 +66836,15 @@
     },
     {
       "caseId": "react-case-v1:e09c751f03372ab1fe07",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactNewContext-test.js",
       "title": "warns when passed a consumer",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime",
       "workstream": "React reconciler residual audit",
-      "rationale": "Remaining function-component hooks, effects, context, Suspense, transitions, Activity, batching, error recovery, and reconciliation outcomes require exact observable Octane evidence; Fiber-only mechanics will receive case-level non-goal dispositions."
+      "rationale": "Octane has no render-prop Context.Consumer (modern callable context + slot-keyed hooks; issue #711 decision) and accessing .Consumer has its own development diagnostic. This case exists only to exercise the render-prop API surface."
     },
     {
       "caseId": "react-case-v1:e0af1d4161364fae7a23",
@@ -67127,7 +67211,7 @@
     },
     {
       "caseId": "react-case-v1:e1b78307e367ad2ffae6",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "treats stylesheet links with a precedence as a resource",
@@ -67135,7 +67219,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Adapted executable evidence: a precedence link is a global resource \u2014 hoisted, href-deduped, retained after unmount.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/float-resources.test.ts",
+          "testName": "a precedence stylesheet hoists to head and dedupes by href across components",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:e1b7d99fc6ebff22cc1d",
@@ -67395,7 +67486,7 @@
     },
     {
       "caseId": "react-case-v1:e2953f4f6182dfbfc4c3",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-reconciler/src/__tests__/ReactNewContext-test.js",
       "title": "should provide the correct (default) values to consumers outside of a provider",
@@ -67403,7 +67494,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "React reconciler residual audit",
-      "rationale": "Remaining function-component hooks, effects, context, Suspense, transitions, Activity, batching, error recovery, and reconciliation outcomes require exact observable Octane evidence; Fiber-only mechanics will receive case-level non-goal dispositions."
+      "rationale": "Adapted executable evidence: the render-prop Consumer is replaced by a useContext-reading component (issue #711 decision); the default-value outcome is asserted directly.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/context-consumer-adapted.test.ts",
+          "testName": "a reader outside every provider sees the default value",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:e29aee1e4d42f62a6ad1",

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -11983,7 +11983,9 @@ function annotateRootWithHash(node, hash, classAttrName) {
 		}
 		return working;
 	}
-	if (node.type === 'JSXStyleElement') return null;
+	// Scoped-CSS styles leave the render tree here; Float style resources stay —
+	// the HeadHoist partition (normalizeChildren) owns removing them from body DOM.
+	if (node.type === 'JSXStyleElement') return headResourceKind(node) === 'style' ? node : null;
 	let out = null;
 	for (const key of Object.keys(node)) {
 		if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata' || key === 'css') {
@@ -12104,6 +12106,9 @@ function applyCssScoping(componentNode, ctx) {
 			return;
 		}
 		if (node.type === 'JSXStyleElement') {
+			// A Float style resource ships its plain CSS by href identity — it
+			// neither contributes to the component's scope hash nor gets scoped.
+			if (headResourceKind(node) === 'style') return;
 			const sheet = (node.children || []).find((c) => c && c.type === 'StyleSheet');
 			if (sheet) {
 				styles.push({ node, sheet });
@@ -16311,6 +16316,13 @@ function requiresTemplateNormalization(
 			requiresTemplateNormalization(child, parentNs, allowHeadHoists, ctx),
 		);
 	}
+	// A Float style resource (`<style href precedence>`) must enter template
+	// normalization so the HeadHoist partition claims it; scoped-CSS styles are
+	// invisible to the value-position tree and keep returning false. Gated on
+	// allowHeadHoists like `<title>`/`<script>`: SVG has its own `<style>`.
+	if (t === 'JSXStyleElement') {
+		return parentNs !== 'svg' && allowHeadHoists && headResourceKind(node) === 'style';
+	}
 	if (t !== 'Element' && t !== 'JSXElement') return false;
 	if (isLongFormTemplateSentinel(node, parentNs, allowHeadHoists, ctx)) return true;
 
@@ -18218,9 +18230,25 @@ function isHoistableHeadElementNode(n) {
 // deduped, precedence-ordered (stylesheets), and never removed on unmount.
 // Classification is static, like the rest of the head-hoist model: a
 // spread-carried `precedence`/`async` keeps the ordinary element path.
-/** @param {any} n @returns {'stylesheet'|'script'|null} */
+/** @param {any} n @returns {'stylesheet'|'script'|'style'|null} */
 function headResourceKind(n) {
-	if (n == null || (n.type !== 'JSXElement' && n.type !== 'Element')) return null;
+	if (n == null) return null;
+	// `<style href precedence>` is a React Float STYLE RESOURCE: plain CSS keyed
+	// by href identity, sharing the stylesheet dedupe/precedence model. Every
+	// other `<style>` stays with Octane's scoped-CSS pipeline.
+	if (n.type === 'JSXStyleElement') {
+		let hasHref = false;
+		let hasPrecedence = false;
+		for (const attr of n.openingElement?.attributes || []) {
+			if (attr.type !== 'Attribute' && attr.type !== 'JSXAttribute') continue;
+			const name = jsxAttrRawName(attr);
+			if (name === 'dangerouslySetInnerHTML') return null;
+			if (name === 'href') hasHref = true;
+			else if (name === 'precedence') hasPrecedence = true;
+		}
+		return hasHref && hasPrecedence ? 'style' : null;
+	}
+	if (n.type !== 'JSXElement' && n.type !== 'Element') return null;
 	const tag = jsxTagName(n) || elementTagName(n);
 	if (tag !== 'link' && tag !== 'script') return null;
 	const attrs = n.attributes || n.openingElement?.attributes || [];
@@ -18548,6 +18576,26 @@ function headElementArgNodes(node, index, ctx) {
 	];
 }
 
+// A Float style resource ships its authored CSS verbatim-by-meaning: the parsed
+// StyleSheet re-renders WITHOUT the scoping pipeline (no analyze/prepare), so
+// selectors and rules come out unscoped. Serialization normalizes whitespace,
+// which is invisible to the resource contract (identity is the href).
+/** @param {any} el @returns {any} */
+function styleResourceCssExpression(el) {
+	const sheet = (el.children || []).find((c) => c && c.type === 'StyleSheet');
+	if (!sheet) return b.literal('');
+	const css = renderStylesheets([cloneAstNode(sheet)]);
+	return b.literal(css, JSON.stringify(css), el);
+}
+
+/** Shared resource-call argument list for the head emitters. */
+/** @param {any} el @param {'stylesheet'|'script'|'style'} kind @returns {any[]} */
+function headResourceArgNodes(el, kind) {
+	const args = [inheritOriginLoc(headAttrsExpression(el), el)];
+	if (kind === 'style') args.push(inheritOriginLoc(styleResourceCssExpression(el), el));
+	return args;
+}
+
 // Build the CLIENT `headBlock(__s, …)` statement NODES for a component's
 // hoisted head elements (one per `HeadHoist`). Returns [] when there are none.
 /** @param {any[]} headNodes @param {any} ctx @param {number} slotBase */
@@ -18555,17 +18603,23 @@ function emitHeadClient(headNodes, ctx, slotBase) {
 	if (!headNodes.length) return [];
 	// Each hoisted head element gets a dense scope slot (after the body's constructs);
 	// the content `key` stays as a later arg for SSR-adoption matching. RESOURCE
-	// elements (stylesheet precedence links, async scripts) are global and
-	// scope-free: they dedupe by href/src at runtime, so their call carries only
-	// the attrs object. Their slot index is left unoccupied to keep the numbering
-	// of neighbouring headBlock slots stable regardless of classification.
+	// elements (stylesheet precedence links, style resources, async scripts) are
+	// global and scope-free: they dedupe by href/src at runtime, so their call
+	// carries only the attrs object (plus the CSS text for style resources).
+	// Their slot index is left unoccupied to keep the numbering of neighbouring
+	// headBlock slots stable regardless of classification.
 	return headNodes.map((h, i) => {
 		const kind = headResourceKind(h.element);
 		if (kind !== null) {
-			const fn = kind === 'stylesheet' ? 'stylesheetResource' : 'scriptResource';
+			const fn =
+				kind === 'stylesheet'
+					? 'stylesheetResource'
+					: kind === 'style'
+						? 'styleResource'
+						: 'scriptResource';
 			ctx.runtimeNeeded.add(fn);
 			return inheritOriginLoc(
-				b.stmt(b.call('_$' + fn, inheritOriginLoc(headAttrsExpression(h.element), h.element))),
+				b.stmt(b.call('_$' + fn, ...headResourceArgNodes(h.element, kind))),
 				h.element ?? h,
 			);
 		}
@@ -18592,12 +18646,15 @@ function emitHeadServer(headNodes, ctx) {
 	return headNodes.map((head, index) => {
 		const kind = headResourceKind(head.element);
 		if (kind !== null) {
-			const fn = kind === 'stylesheet' ? 'ssrStylesheetResource' : 'ssrScriptResource';
+			const fn =
+				kind === 'stylesheet'
+					? 'ssrStylesheetResource'
+					: kind === 'style'
+						? 'ssrStyleResource'
+						: 'ssrScriptResource';
 			ctx.runtimeNeeded.add(fn);
 			return inheritOriginLoc(
-				b.stmt(
-					b.call('_$' + fn, inheritOriginLoc(headAttrsExpression(head.element), head.element)),
-				),
+				b.stmt(b.call('_$' + fn, ...headResourceArgNodes(head.element, kind))),
 				head.element ?? head,
 			);
 		}
@@ -18783,6 +18840,12 @@ function normalizeChildren(nodes, inSvg = false, ctx = null) {
 		} else if (n.type === 'Tsx' || n.type === 'Tsrx' || n.type === 'JSXFragment') {
 			out.push(...normalizeChildren(n.children || [], inSvg, ctx));
 		} else if (n.type === 'JSXStyleElement') {
+			// `<style href precedence>` is a Float style resource, not scoped CSS —
+			// partition it to the head channel like precedence links.
+			if (!inSvg && headResourceKind(n) === 'style') {
+				out.push({ type: 'HeadHoist', element: n });
+				continue;
+			}
 			// Drop a `<style>` block at child position — its CSS gets registered
 			// via the @tsrx/core scoping pipeline (applyCssScoping / applyStyleMap);
 			// it contributes no DOM here.

--- a/packages/octane/src/index.ts
+++ b/packages/octane/src/index.ts
@@ -188,8 +188,9 @@ export {
 	queueRefDetach,
 	injectStyle,
 	headBlock,
-	// React Float resources (stylesheet precedence links, async scripts)
+	// React Float resources (stylesheet precedence links, style resources, async scripts)
 	stylesheetResource,
+	styleResource,
 	scriptResource,
 	namespaceHead,
 	namespaceHeadElement,

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -3730,6 +3730,25 @@ export function createContext<T>(defaultValue: T): Context<T> {
 	ctx.$$kind = CONTEXT_TAG;
 	ctx.defaultValue = defaultValue;
 	ctx.Provider = ctx;
+	if (process.env.NODE_ENV !== 'production') {
+		// Mirror of the client's Consumer diagnostic (see runtime.ts): warn once
+		// per context on access, return undefined so probes behave as in prod.
+		let consumerWarned = false;
+		Object.defineProperty(ctx, 'Consumer', {
+			configurable: true,
+			get() {
+				if (!consumerWarned) {
+					consumerWarned = true;
+					console.error(
+						'Octane has no Context.Consumer. Read the context directly with use(Context) or ' +
+							'useContext(Context) in the child component — Octane hooks are call-site keyed, ' +
+							'so the read is legal behind any condition the render-prop form was working around.',
+					);
+				}
+				return undefined;
+			},
+		});
+	}
 	return ctx;
 }
 
@@ -8008,6 +8027,44 @@ export function ssrStylesheetResource(attrs: Record<string, unknown> | null): vo
 		'"' +
 		resourceAttrs(attrs, 'link') +
 		'>';
+	const sheets = (HEAD.sheets ??= new Map());
+	sheets.set(precedence, (sheets.get(precedence) ?? '') + tag);
+}
+
+/**
+ * Compiler target for `<style href precedence>` (React Float style resource).
+ * Shares the stylesheet dedupe namespace and precedence grouping with link
+ * resources; the CSS is raw `<style>` text (never HTML-escaped — entities do
+ * not decode inside style raw text), so content that could close the tag fails
+ * closed with a dev diagnostic instead of truncating the document.
+ */
+export function ssrStyleResource(attrs: Record<string, unknown> | null, css: string): void {
+	if (HEAD === null || attrs == null) return;
+	const href = attrs.href;
+	if (typeof href !== 'string' || href === '') return;
+	if (/<\/style/i.test(css)) {
+		if (process.env.NODE_ENV !== 'production') {
+			console.error(
+				'octane SSR: a <style href precedence> resource contains "</style" and cannot be ' +
+					'serialized safely; the resource was skipped. Load it as a stylesheet link instead.',
+			);
+		}
+		return;
+	}
+	const key = 'sheet:' + href;
+	if (HEAD.hints.has(key)) return;
+	HEAD.hints.add(key);
+	const precedence = attrs.precedence == null ? '' : String(attrs.precedence);
+	const tag =
+		'<style data-precedence="' +
+		escapeAttr(precedence) +
+		'" data-href="' +
+		escapeAttr(href) +
+		'"' +
+		resourceAttrs(attrs, 'link') +
+		'>' +
+		css +
+		'</style>';
 	const sheets = (HEAD.sheets ??= new Map());
 	sheets.set(precedence, (sheets.get(precedence) ?? '') + tag);
 }

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -6686,6 +6686,28 @@ export function createContext<T>(defaultValue: T): Context<T> {
 	ctx.defaultValue = defaultValue;
 	ctx.$$version = 0;
 	ctx.Provider = ctx;
+	if (process.env.NODE_ENV !== 'production') {
+		// Octane deliberately has no render-prop Consumer (slot-keyed hooks make
+		// use()/useContext legal behind any condition — the pattern Consumer
+		// existed to work around). Accessing it warns once per context and still
+		// returns undefined, so behavior matches production and feature probes
+		// (`Ctx.Consumer || fallback`) keep working.
+		let consumerWarned = false;
+		Object.defineProperty(ctx, 'Consumer', {
+			configurable: true,
+			get() {
+				if (!consumerWarned) {
+					consumerWarned = true;
+					console.error(
+						'Octane has no Context.Consumer. Read the context directly with use(Context) or ' +
+							'useContext(Context) in the child component — Octane hooks are call-site keyed, ' +
+							'so the read is legal behind any condition the render-prop form was working around.',
+					);
+				}
+				return undefined;
+			},
+		});
+	}
 	return ctx;
 }
 
@@ -27737,10 +27759,15 @@ function resourceState(): ResourceState {
 		lastTail: null,
 	};
 	if (typeof document !== 'undefined') {
-		const links = document.querySelectorAll('link[rel="stylesheet"][data-precedence]');
-		for (let i = 0; i < links.length; i++) {
-			const el = links[i];
-			const href = el.getAttribute('href');
+		// Stylesheet links and style resources share one identity namespace and
+		// one precedence-group ordering; querySelectorAll returns document order,
+		// so tails/lastTail land on each group's last member.
+		const sheets = document.querySelectorAll(
+			'link[rel="stylesheet"][data-precedence], style[data-precedence]',
+		);
+		for (let i = 0; i < sheets.length; i++) {
+			const el = sheets[i];
+			const href = el.getAttribute('href') ?? el.getAttribute('data-href');
 			if (href !== null) state.sheets.add(href);
 			state.tails.set(el.getAttribute('data-precedence') as string, el);
 			state.lastTail = el;
@@ -27752,6 +27779,25 @@ function resourceState(): ResourceState {
 		}
 	}
 	return (_resourceState = state);
+}
+
+/** Insert a sheet-family resource into its precedence group (shared ordering). */
+function insertPrecedenced(state: ResourceState, el: Element, precedence: string): void {
+	const tail = state.tails.get(precedence);
+	if (tail !== undefined && tail.isConnected) {
+		// Existing group: append after its current tail.
+		tail.after(el);
+		if (state.lastTail === tail) state.lastTail = el;
+	} else if (state.lastTail !== null && state.lastTail.isConnected) {
+		// New group: starts after the last existing group, keeping groups
+		// contiguous in first-encounter order.
+		state.lastTail.after(el);
+		state.lastTail = el;
+	} else {
+		document.head.appendChild(el);
+		state.lastTail = el;
+	}
+	state.tails.set(precedence, el);
 }
 
 /** Handled by the resource insert itself; everything else applies as an attribute. */
@@ -27782,21 +27828,38 @@ export function stylesheetResource(attrs: Record<string, unknown> | null): void 
 	l.href = sanitizeURL(href);
 	l.setAttribute('data-precedence', precedence);
 	applyResourceAttrs(l, attrs);
-	const tail = state.tails.get(precedence);
-	if (tail !== undefined && tail.isConnected) {
-		// Existing group: append after its current tail.
-		tail.after(l);
-		if (state.lastTail === tail) state.lastTail = l;
-	} else if (state.lastTail !== null && state.lastTail.isConnected) {
-		// New group: starts after the last existing group, keeping groups
-		// contiguous in first-encounter order.
-		state.lastTail.after(l);
-		state.lastTail = l;
-	} else {
-		document.head.appendChild(l);
-		state.lastTail = l;
+	insertPrecedenced(state, l, precedence);
+	state.sheets.add(href);
+}
+
+/**
+ * Compiler target for `<style href precedence>` (React Float style resource).
+ * Plain CSS keyed by href identity — shares the stylesheet dedupe namespace and
+ * precedence-group ordering with link resources; the CSS ships as the tag's
+ * text content and is NOT scoped (scoped CSS owns every other `<style>`).
+ */
+export function styleResource(attrs: Record<string, unknown> | null, css: string): void {
+	if (typeof document === 'undefined' || attrs == null) return;
+	const href = attrs.href;
+	if (typeof href !== 'string' || href === '') return;
+	const state = resourceState();
+	if (state.sheets.has(href)) return;
+	const precedence = attrs.precedence == null ? '' : String(attrs.precedence);
+	// textContent makes any CSS safe to insert client-side, but the SSR twin
+	// must fail closed on "</style" (raw-text serialization) — surface the same
+	// authoring diagnostic here so SPA-only development still sees it.
+	if (process.env.NODE_ENV !== 'production' && /<\/style/i.test(css)) {
+		console.error(
+			'A <style href precedence> resource contains "</style"; server rendering will skip it. ' +
+				'Load it as a stylesheet link instead.',
+		);
 	}
-	state.tails.set(precedence, l);
+	const s = document.createElement('style');
+	s.setAttribute('data-precedence', precedence);
+	s.setAttribute('data-href', href);
+	applyResourceAttrs(s, attrs);
+	s.textContent = css;
+	insertPrecedenced(state, s, precedence);
 	state.sheets.add(href);
 }
 

--- a/packages/octane/src/server/index.ts
+++ b/packages/octane/src/server/index.ts
@@ -162,8 +162,9 @@ export {
 	ssrPortal,
 	injectStyle,
 	ssrHeadEl,
-	// React Float resources (stylesheet precedence links, async scripts)
+	// React Float resources (stylesheet precedence links, style resources, async scripts)
 	ssrStylesheetResource,
+	ssrStyleResource,
 	ssrScriptResource,
 	namespaceHead,
 	namespaceHeadElement,

--- a/packages/octane/tests/_fixtures/context-consumer-adapted.tsrx
+++ b/packages/octane/tests/_fixtures/context-consumer-adapted.tsrx
@@ -1,0 +1,148 @@
+// Adapted ports of React's Context.Consumer scenarios. Octane has no render-
+// prop Consumer (decision recorded in issue #711: modern callable context +
+// slot-keyed hooks make use()/useContext legal behind any condition), so each
+// "consumer" is a component reading via useContext/use. The observable
+// contracts — defaults, propagation across branches, bailout, hidden subtrees,
+// suspended boundaries — are what the ports assert.
+import { Activity, Suspense, createContext, memo, use, useContext } from 'octane';
+
+// Module-level render log mirroring React's `Scheduler.log` (see
+// context-bailout.tsrx for why a sink beats a prop: memo boundaries keep
+// genuinely-stable props and can bail out).
+let SINK: ((s: string) => void) | null = null;
+export function setSink(fn: ((s: string) => void) | null): void {
+	SINK = fn;
+}
+function log(s: string): void {
+	SINK?.(s);
+}
+
+const Ctx = createContext('default');
+
+function ReaderImpl(props: { tag: string }) @{
+	const value = useContext(Ctx);
+	log('Reader:' + props.tag + ':' + value);
+	<span class={'r-' + props.tag}>{value as string}</span>
+}
+const Reader = memo(ReaderImpl);
+
+// Per ReactNewContext-test.js:343 — 'should provide the correct (default)
+// values to consumers outside of a provider'.
+export function DefaultOutside() @{
+	<div class="out">
+		<Reader tag="out" />
+	</div>
+}
+
+// Per ReactNewContext-test.js:381 — 'multiple consumers in different branches'.
+export function Branches(props: { value: string }) @{
+	<div class="branches">
+		<Ctx.Provider value={props.value}>
+			<section class="b1">
+				<Reader tag="b1" />
+			</section>
+			<section class="b2">
+				<div>
+					<Reader tag="b2" />
+				</div>
+			</section>
+		</Ctx.Provider>
+	</div>
+}
+
+// Per ReactContextPropagation-test.js:299 — 'context consumer bails out if
+// context hasn't changed'.
+function ShellImpl() @{
+	log('Shell');
+	<Reader tag="p" />
+}
+const Shell = memo(ShellImpl);
+
+export function PropagationBail(props: { value: string }) @{
+	log('Root');
+	<div class="prop-bail">
+		<Ctx.Provider value={props.value}>
+			<Shell />
+		</Ctx.Provider>
+	</div>
+}
+
+// Per ReactContextPropagation-test.js:892 — 'finds context consumers in
+// multiple sibling branches'.
+function Sib1Impl() @{
+	log('Sib1');
+	<Reader tag="s1" />
+}
+const Sib1 = memo(Sib1Impl);
+function Sib2Impl() @{
+	log('Sib2');
+	<Reader tag="s2" />
+}
+const Sib2 = memo(Sib2Impl);
+function Sib3Impl() @{
+	log('Sib3');
+	<Reader tag="s3" />
+}
+const Sib3 = memo(Sib3Impl);
+
+export function Siblings(props: { value: string }) @{
+	<div class="siblings">
+		<Ctx.Provider value={props.value}>
+			<Sib1 />
+			<Sib2 />
+			<Sib3 />
+		</Ctx.Provider>
+	</div>
+}
+
+// Per ReactNewContext-test.js:706 — 'context consumer doesn't bail out inside
+// hidden subtree'.
+export function HiddenHost(props: { value: string; mode: string }) @{
+	<div class="hidden-host">
+		<Ctx.Provider value={props.value}>
+			<Activity mode={props.mode as 'visible' | 'hidden'}>
+				<Reader tag="hidden" />
+			</Activity>
+		</Ctx.Provider>
+	</div>
+}
+
+// Per ReactNewContext-test.js:1135 — 'consumer does not bail out if there were
+// no bailouts above it' (a plain, memo-free chain re-renders through).
+function PlainReader() @{
+	const value = useContext(Ctx);
+	log('Plain:' + value);
+	<span class="plain">{value as string}</span>
+}
+
+function Middle() @{
+	log('Middle');
+	<PlainReader />
+}
+
+export function NoBailouts(props: { value: string }) @{
+	log('NB');
+	<div class="no-bail">
+		<Ctx.Provider value={props.value}>
+			<Middle />
+		</Ctx.Provider>
+	</div>
+}
+
+// Per ReactSuspense-test.internal.js:1410 — 'updates context consumer within
+// child of suspended suspense component when context updates'.
+function Sus(props: { promise: Promise<string> }) @{
+	const v = use(props.promise);
+	<i class="sus">{v as string}</i>
+}
+
+export function SuspendedHost(props: { value: string; promise: Promise<string> }) @{
+	<div class="sus-host">
+		<Ctx.Provider value={props.value}>
+			<Suspense fallback="waiting">
+				<Sus promise={props.promise} />
+				<Reader tag="sus" />
+			</Suspense>
+		</Ctx.Provider>
+	</div>
+}

--- a/packages/octane/tests/_fixtures/float-resources.tsrx
+++ b/packages/octane/tests/_fixtures/float-resources.tsrx
@@ -18,6 +18,54 @@ export function SheetADuplicate() @{
 	</>
 }
 
+// `<style href precedence>` = a Float STYLE RESOURCE: plain CSS shipped by
+// href identity, sharing the stylesheet dedupe/precedence model with links.
+export function StyleRes() @{
+	<>
+		<style href="inline-tokens" precedence="default">
+			.tokens {
+				color: teal;
+			}
+		</style>
+		<div class="sr">{'SR' as string}</div>
+	</>
+}
+
+export function StyleResDuplicate() @{
+	<>
+		<style href="inline-tokens" precedence="default">
+			.tokens {
+				color: teal;
+			}
+		</style>
+		<div class="sr2">{'SR2' as string}</div>
+	</>
+}
+
+export function StyleResHigh() @{
+	<>
+		<style href="inline-high" precedence="high" media="screen">
+			.hi-tokens {
+				color: crimson;
+			}
+		</style>
+		<div class="srh">{'SRH' as string}</div>
+	</>
+}
+
+// Control: a bare `<style>` (no href/precedence) stays with SCOPED CSS — its
+// selectors scope to the component hash and no head resource appears.
+export function ScopedControl() @{
+	<>
+		<style>
+			.scoped {
+				color: rebeccapurple;
+			}
+		</style>
+		<div class="scoped" id="scoped-control">{'SC' as string}</div>
+	</>
+}
+
 export function SheetHigh() @{
 	<>
 		<link rel="stylesheet" href="/high.css" precedence="high" crossOrigin="anonymous" />

--- a/packages/octane/tests/conformance/context-consumer-adapted.test.ts
+++ b/packages/octane/tests/conformance/context-consumer-adapted.test.ts
@@ -1,0 +1,170 @@
+// Adapted ports of React's Context.Consumer scenarios (ReactNewContext-test.js,
+// ReactContextPropagation-test.js, ReactSuspense-test.internal.js). Octane has
+// no render-prop Consumer — the modern callable context plus slot-keyed hooks
+// is the supported model (decision recorded in issue #711) — so every consumer
+// here reads via useContext/use and the tests assert the same observable
+// outcomes the upstream cases protect. Accessing `.Consumer` is covered last:
+// it warns once per context in development and stays `undefined`, so feature
+// probes behave exactly as in production.
+import { describe, it, expect, vi } from 'vitest';
+import { act, createContext } from '../../src/index.js';
+import * as Server from 'octane/server';
+import { mount } from '../_helpers';
+import {
+	DefaultOutside,
+	Branches,
+	PropagationBail,
+	Siblings,
+	HiddenHost,
+	NoBailouts,
+	SuspendedHost,
+	setSink,
+} from '../_fixtures/context-consumer-adapted.tsrx';
+
+describe('context consumers, adapted (no render-prop Consumer)', () => {
+	// Per ReactNewContext-test.js:343 — 'should provide the correct (default)
+	// values to consumers outside of a provider'
+	it('a reader outside every provider sees the default value', () => {
+		const r = mount(DefaultOutside, {});
+		expect(r.find('.r-out').textContent).toBe('default');
+		r.unmount();
+	});
+
+	// Per ReactNewContext-test.js:381 — 'multiple consumers in different branches'
+	it('readers in different branches all track the provider value', () => {
+		const r = mount(Branches, { value: 'a' });
+		expect(r.find('.r-b1').textContent).toBe('a');
+		expect(r.find('.r-b2').textContent).toBe('a');
+		r.update(Branches, { value: 'b' });
+		expect(r.find('.r-b1').textContent).toBe('b');
+		expect(r.find('.r-b2').textContent).toBe('b');
+		r.unmount();
+	});
+
+	// Per ReactContextPropagation-test.js:299 — 'context consumer bails out if
+	// context hasn't changed'
+	it('a same-value provider re-commit does not re-render the reader', () => {
+		const log: string[] = [];
+		setSink((s) => log.push(s));
+		const r = mount(PropagationBail, { value: 'x' });
+		expect(log).toEqual(['Root', 'Shell', 'Reader:p:x']);
+		log.length = 0;
+		r.update(PropagationBail, { value: 'x' });
+		expect(log).toEqual(['Root']); // memo shell AND reader both bailed
+		log.length = 0;
+		r.update(PropagationBail, { value: 'y' });
+		// Propagation reaches the reader without re-rendering the bailed shell.
+		expect(log).toEqual(['Root', 'Reader:p:y']);
+		expect(r.find('.r-p').textContent).toBe('y');
+		r.unmount();
+		setSink(null);
+	});
+
+	// Per ReactContextPropagation-test.js:892 — 'finds context consumers in
+	// multiple sibling branches'
+	it('a context change reaches readers in every sibling branch', () => {
+		const log: string[] = [];
+		setSink((s) => log.push(s));
+		const r = mount(Siblings, { value: 'one' });
+		log.length = 0;
+		r.update(Siblings, { value: 'two' });
+		// All three readers re-ran; none of the bailed memo shells did.
+		expect(log).toEqual(['Reader:s1:two', 'Reader:s2:two', 'Reader:s3:two']);
+		expect(r.find('.r-s1').textContent).toBe('two');
+		expect(r.find('.r-s2').textContent).toBe('two');
+		expect(r.find('.r-s3').textContent).toBe('two');
+		r.unmount();
+		setSink(null);
+	});
+
+	// Per ReactNewContext-test.js:706 — "context consumer doesn't bail out
+	// inside hidden subtree"
+	it('a context change updates a reader inside a hidden Activity subtree', () => {
+		const r = mount(HiddenHost, { value: 'v1', mode: 'visible' });
+		expect(r.find('.r-hidden').textContent).toBe('v1');
+		r.update(HiddenHost, { value: 'v1', mode: 'hidden' });
+		const hidden = r.find('.r-hidden') as HTMLElement;
+		expect(hidden.style.display).toBe('none');
+		// Update the context WHILE hidden: the hidden reader must not bail.
+		r.update(HiddenHost, { value: 'v2', mode: 'hidden' });
+		expect(r.find('.r-hidden').textContent).toBe('v2');
+		r.update(HiddenHost, { value: 'v2', mode: 'visible' });
+		expect((r.find('.r-hidden') as HTMLElement).style.display).toBe('');
+		expect(r.find('.r-hidden').textContent).toBe('v2');
+		r.unmount();
+	});
+
+	// Per ReactNewContext-test.js:1135 — 'consumer does not bail out if there
+	// were no bailouts above it'
+	it('a memo-free chain re-renders through to the reader on every change', () => {
+		const log: string[] = [];
+		setSink((s) => log.push(s));
+		const r = mount(NoBailouts, { value: 'p' });
+		expect(log).toEqual(['NB', 'Middle', 'Plain:p']);
+		log.length = 0;
+		r.update(NoBailouts, { value: 'q' });
+		// No memo boundary above the reader: the whole chain re-runs.
+		expect(log).toEqual(['NB', 'Middle', 'Plain:q']);
+		expect(r.find('.plain').textContent).toBe('q');
+		r.unmount();
+		setSink(null);
+	});
+
+	// Per ReactSuspense-test.internal.js:1410 — 'updates context consumer within
+	// child of suspended suspense component when context updates'
+	it('a context update while suspended reaches the reader on reveal', async () => {
+		let resolve!: (v: string) => void;
+		const promise = new Promise<string>((res) => {
+			resolve = res;
+		});
+		const r = mount(SuspendedHost, { value: 'before', promise });
+		expect(r.container.textContent).toContain('waiting');
+		// Context updates while the boundary is still held on the fallback.
+		r.update(SuspendedHost, { value: 'after', promise });
+		expect(r.container.textContent).toContain('waiting');
+		await act(async () => {
+			resolve('data');
+			await promise;
+		});
+		expect(r.find('.sus').textContent).toBe('data');
+		// The revealed reader observes the latest context, not the mount value.
+		expect(r.find('.r-sus').textContent).toBe('after');
+		r.unmount();
+	});
+});
+
+describe('Context.Consumer access diagnostic', () => {
+	it('client: accessing .Consumer warns once per context and returns undefined', () => {
+		const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			const Ctx = createContext(0);
+			expect((Ctx as any).Consumer).toBeUndefined();
+			expect((Ctx as any).Consumer).toBeUndefined();
+			const warns = errSpy.mock.calls.filter((c) =>
+				String(c[0]).includes('no Context.Consumer'),
+			);
+			expect(warns).toHaveLength(1);
+			// A second context warns independently.
+			const Other = createContext(1);
+			expect((Other as any).Consumer).toBeUndefined();
+			expect(
+				errSpy.mock.calls.filter((c) => String(c[0]).includes('no Context.Consumer')),
+			).toHaveLength(2);
+		} finally {
+			errSpy.mockRestore();
+		}
+	});
+
+	it('server: the same diagnostic exists on octane/server contexts', () => {
+		const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			const Ctx = Server.createContext(0);
+			expect((Ctx as any).Consumer).toBeUndefined();
+			expect(
+				errSpy.mock.calls.filter((c) => String(c[0]).includes('no Context.Consumer')),
+			).toHaveLength(1);
+		} finally {
+			errSpy.mockRestore();
+		}
+	});
+});

--- a/packages/octane/tests/float-resources.test.ts
+++ b/packages/octane/tests/float-resources.test.ts
@@ -7,7 +7,7 @@
 // Suspend-until-loaded ("suspensey" commit) is intentionally NOT part of this
 // contract — Octane documents that as out of scope.
 // Links WITHOUT precedence keep the existing per-site head-element behavior.
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { act, createRoot, resetFloatResourceState } from '../src/index.js';
 import * as Server from 'octane/server';
 import { loadServerFixture } from './_server-fixture.js';
@@ -22,6 +22,10 @@ import {
 	AsyncScriptDuplicate,
 	ReturnScript,
 	ReturnSheet,
+	StyleRes,
+	StyleResDuplicate,
+	StyleResHigh,
+	ScopedControl,
 	ToggleHost,
 	setSheetVisible,
 } from './_fixtures/float-resources.tsrx';
@@ -92,6 +96,48 @@ describe('Float resources — client', () => {
 		root.unmount();
 		expect(document.head.querySelector('link[href="/feed.xml"]')).toBeNull();
 		c.remove();
+	});
+
+	it('<style href precedence> is a style resource: hoisted, deduped, precedence-grouped with links', async () => {
+		await act(() => {
+			mountInto(SheetA); // default group (link)
+			mountInto(StyleRes); // default group (style, appends after the link)
+			mountInto(StyleResDuplicate); // deduped by href identity
+			mountInto(StyleResHigh); // high group (new)
+		});
+		const styles = document.head.querySelectorAll('style[data-href="inline-tokens"]');
+		expect(styles).toHaveLength(1);
+		expect(styles[0].getAttribute('data-precedence')).toBe('default');
+		expect(styles[0].textContent).toContain('.tokens');
+		expect(styles[0].textContent).toContain('teal');
+		// Unscoped: the CSS ships verbatim-by-meaning, no component hash class.
+		expect(styles[0].textContent).not.toMatch(/\.tokens\.[a-z0-9]/i);
+		// Group order: default (link then style, discovery order) then high.
+		const ordered = Array.from(
+			document.head.querySelectorAll('[data-precedence]'),
+			(el) => el.getAttribute('href') ?? el.getAttribute('data-href'),
+		);
+		expect(ordered).toEqual(['/base.css', 'inline-tokens', 'inline-high']);
+		const high = document.head.querySelector('style[data-href="inline-high"]')!;
+		expect(high.getAttribute('media')).toBe('screen');
+		expect(document.body.querySelector('style')).toBeNull();
+		// Persistence: style resources survive unmount like link resources.
+		await act(() => {
+			for (const r of roots.splice(0)) r.unmount();
+		});
+		expect(document.head.querySelectorAll('style[data-href="inline-tokens"]')).toHaveLength(1);
+	});
+
+	it('control: a bare <style> keeps scoped-CSS behavior (no head resource)', async () => {
+		await act(() => mountInto(ScopedControl));
+		expect(document.head.querySelector('style[data-href]')).toBeNull();
+		expect(document.head.querySelector('style[data-precedence]')).toBeNull();
+		// Scoped CSS injected its hashed sheet and stamped the hash class.
+		const scoped = document.querySelector('#scoped-control')!;
+		expect(scoped.className).not.toBe('scoped'); // hash class added
+		const injected = document.head.querySelector('style[data-octane]');
+		expect(injected).not.toBeNull();
+		expect(injected!.textContent).toContain('.scoped.');
 	});
 
 	it('return-position (value-body) trees classify resources like @{} bodies', async () => {
@@ -179,6 +225,51 @@ describe('Float resources — SSR + hydration dedupe', () => {
 		expect(html.match(/\/base\.css/g) || []).toHaveLength(1);
 		expect(html.match(/\/analytics\.js/g) || []).toHaveLength(1);
 		expect(html).toContain('data-precedence="default"');
+	});
+
+	it('SSR folds style resources into precedence groups; hydration seeds from data-href', async () => {
+		const App = () =>
+			Server.createElement(
+				'div',
+				null,
+				Server.createElement(srv.SheetA, null),
+				Server.createElement(srv.StyleRes, null),
+				Server.createElement(srv.StyleResDuplicate, null),
+			) as any;
+		const r = await Server.renderToString(App as any);
+		expect(r.html.match(/data-href="inline-tokens"/g) || []).toHaveLength(1);
+		expect(r.html).toContain('.tokens');
+		// Same default group, discovery order: the link precedes the style tag.
+		expect(r.html.indexOf('/base.css')).toBeLessThan(r.html.indexOf('inline-tokens'));
+
+		// SSR head lands in the document; the hydrating client's render dedupes.
+		document.head.insertAdjacentHTML('afterbegin', r.html.slice(0, r.html.indexOf('<div')));
+		const c = document.createElement('div');
+		document.body.appendChild(c);
+		const root = createRoot(c);
+		await act(() => root.render(StyleRes, {}));
+		expect(document.head.querySelectorAll('style[data-href="inline-tokens"]')).toHaveLength(1);
+		root.unmount();
+		c.remove();
+	});
+
+	it('SSR fails closed on style content that could close the tag', async () => {
+		const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			const App = () => {
+				Server.ssrStyleResource(
+					{ href: 'evil', precedence: 'default' },
+					'.x{}</style><script>alert(1)</script>',
+				);
+				return Server.createElement('div', null, 'x') as any;
+			};
+			const r = await Server.renderToString(App as any);
+			expect(r.html).not.toContain('alert(1)');
+			expect(r.html).not.toContain('data-href="evil"');
+			expect(errSpy.mock.calls.some((c) => String(c[0]).includes('</style'))).toBe(true);
+		} finally {
+			errSpy.mockRestore();
+		}
 	});
 
 	it('a hydrating client call dedupes against SSR-emitted resources', async () => {


### PR DESCRIPTION
## Summary

Executes the "Decisions locked in" section of #711, with one decision reversed by the maintainer: `<style href precedence>` is now implemented as a React Float style resource rather than documented as a non-goal.

- **Style resources**: `<style href precedence>` at a component's body root hoists to `document.head` as plain CSS keyed by href — sharing the stylesheet dedupe namespace AND precedence-group ordering with link resources (`data-precedence`/`data-href` marked), SSR-emitted into the grouped head fold, hydration-deduped via the client's DOM seed, retained after unmount. Every other `<style>` keeps scoped-CSS behavior (control test pins the hash-scoping path). Adaptations vs React, documented: one tag per resource (no same-precedence merging into a single tag), and CSS containing `</style` fails closed in SSR with a dev diagnostic (raw-text serialization cannot escape it; the client's `textContent` insert is always safe and warns in dev for symmetry).
- **Context.Consumer, modern-only with teeth**: accessing `.Consumer` in development logs a one-time-per-context migration diagnostic and still returns `undefined` (feature probes behave exactly as production; prod object shape untouched — the getter is dev-only), on both `octane` and `octane/server`. The nine upstream Consumer scenarios that protect observable behavior (defaults `:343`, multi-branch `:381`, propagation bailout `ReactContextPropagation:299`, sibling propagation `:892`, hidden subtree `:706`, no-bailouts-above `:1135`, suspended-boundary context update `ReactSuspense.internal:1410`, plus the two already evidenced in `context-bailout.test.ts`) are ported as `useContext`-reading conformance tests and flipped to `covered` with evidence records; the two render-prop-surface-only cases ("warns when passed a consumer", "can read other contexts inside consumer render prop") are `non_goal`.
- **Ledger + docs**: 17 dispositions total (9 Consumer covered + 2 Consumer non-goal + 5 Float covered + 1 style-merge divergence), coverage report regenerated, `differences-from-react.md` updated for both areas.

## Why

Issue #711's decision section, plus the maintainer's reversal on style resources ("if a style tag has href + precedence then it should be considered like React"). Landing the Consumer decision as ledger dispositions + a targeted diagnostic stops those 11 cases from being re-litigated as gaps.

## Changes

- `packages/octane/src/compiler/compile.js` — `headResourceKind` gains the `'style'` kind (JSXStyleElement with static href + precedence); the scoped-CSS claim sites skip resource styles (`applyCssScoping` collect, `annotateRootWithHash` strip); `normalizeChildren` partitions them to HeadHoist; `requiresTemplateNormalization` admits them for value-position bodies (gated on `allowHeadHoists`, like `<title>`/`<script>` — SVG has its own `<style>`); emitters route to `styleResource`/`ssrStyleResource` with the StyleSheet re-rendered unscoped as the CSS argument.
- `packages/octane/src/runtime.ts` — `styleResource` + factored `insertPrecedenced` (shared group ordering), seed scan extended to `style[data-precedence]` with `data-href` identity; dev-only `Consumer` warning getter in `createContext`.
- `packages/octane/src/runtime.server.ts` — `ssrStyleResource` with the `</style` fail-closed guard; the same dev `Consumer` getter.
- `packages/octane/src/{index,server/index}.ts` — exports.
- `packages/octane/audit/react-conformance-ledger.json` + `docs/react-parity-coverage.md` — 17 dispositions, regenerated report.
- Tests: style-resource client/SSR/hydration/guard/scoped-control cases in `float-resources.test.ts` (+fixtures), `conformance/context-consumer-adapted.test.ts` (+fixture) with per-case upstream citations, Consumer-diagnostic cases for client and server.
- `docs/differences-from-react.md`, changeset.

## Contract and hot paths

All additions are pay-per-use: the style-resource path costs one classifier check at compile time per `<style>` element and nothing at runtime for components without resources; the Consumer getter is defined only in development (production context objects are byte-identical to before); scoped CSS behavior and output are untouched (control test + scoped/head/context neighbor sweeps, 1,096 tests green). No benchmarks were run and none are claimed — no hot path changed.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` (full suite)
- [x] `node scripts/react-parity/check.mjs` (full — executes the new evidence records) and `--validate-only`
- [x] targeted: `float-resources` (24), `context-consumer-adapted` (18), context/head/scoped/activity/suspense neighbor sweep (1,096)
- Pre-fix failures observed: the style-resource tests go red when the classifier's `'style'` kind is disabled (6 failures, dev+prod projects); the Consumer-diagnostic tests fail without the getter by construction (zero warnings recorded). The seven adapted conformance ports are evidence tests pinning existing propagation behavior, not regression fixes.

## Risk / follow-ups

- Style resources follow the same static-classification and body-root placement contract as the rest of the head-hoist model (dynamic/spread-carried props keep the scoped-CSS path); nested-under-host asymmetry remains tracked in #711.
- The remaining `ReactDOMFloat` planned cases (late/streamed stylesheets, prop-conflict warnings, the truncated-title link triple) stay planned — see #711.
- After merge: tick the "Decisions locked in" checkboxes in #711 and note the style-resource reversal there.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches compiler head-hoist classification and SSR/client Float resource insertion (including fail-closed `</style` handling), plus the public context object shape in development. Scoped CSS and production context objects are intentionally unchanged.
> 
> **Overview**
> Implements **`<style href precedence>` as a React Float style resource** and makes the **no-`Context.Consumer`** decision concrete with a migration diagnostic and adapted conformance coverage.
> 
> **Style resources.** A body-root `<style href precedence>` now hoists unscoped CSS by href identity, sharing the stylesheet dedupe namespace and precedence-group ordering with link resources (`data-precedence`/`data-href`). Client and SSR emitters (`styleResource` / `ssrStyleResource`) retain resources after unmount and seed hydration from `data-href`. Bare `<style>` tags keep Octane's scoped-CSS path. Documented adaptations: one tag per resource (no same-precedence merge) and SSR fail-closed skip when CSS contains `</style`.
> 
> **Context.Consumer.** Accessing `.Consumer` in development warns once per context and still returns `undefined` (client and server), so feature probes match production. Observable Consumer scenarios are ported as `useContext`-reading conformance tests; render-prop-surface-only cases are ledger `non_goal`s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03808da4abdc06bbf76b03c82b12133e1fda3317. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->