### PR TITLE
test: fix phosphor differential parity timeout by narrowing fixture imports

### DIFF
--- a/packages/phosphor-icons/audit/react-parity.json
+++ b/packages/phosphor-icons/audit/react-parity.json
@@ -68,12 +68,12 @@
         {
           "path": "packages/phosphor-icons/tests/_fixtures/parity.tsrx",
           "role": "support",
-          "sha256": "0e554c695d1148e5b672e7063863295f9de34d6a035b56226c60b89c0de1d54d"
+          "sha256": "bc1ae966c15bc002cf281d3e19a02bd07337040fe790c7b0747e1496b2beb8e9"
         },
         {
           "path": "packages/phosphor-icons/tests/differential/_setup.ts",
           "role": "support",
-          "sha256": "e9e9273cf6a61879d4c7b4c2805435c359c6d988b4708aca8be01af67d40f47a"
+          "sha256": "228c105f2b3781308f964c3395cae260be91b3a1c40962480b7cd2da8e359460"
         },
         {
           "path": "packages/octane/tests/differential/_rig.ts",

--- a/packages/phosphor-icons/tests/_fixtures/parity.tsrx
+++ b/packages/phosphor-icons/tests/_fixtures/parity.tsrx
@@ -1,4 +1,4 @@
-import { Camera } from '@octanejs/phosphor-icons';
+import { Camera } from '@octanejs/phosphor-icons/icons/camera';
 
 export function CameraFixture() {
 	return <Camera id="camera" size={32} color="purple" weight="duotone" mirrored alt="Camera" />;

--- a/packages/phosphor-icons/tests/differential/_setup.ts
+++ b/packages/phosphor-icons/tests/differential/_setup.ts
@@ -20,14 +20,23 @@ export async function setup(): Promise<void> {
 		const path = join(fixtures, name);
 		const compiled = compileToReact(readFileSync(path, 'utf8'), path);
 		if (compiled.errors?.length) throw new Error(JSON.stringify(compiled.errors));
-		const output = transformSync(compiled.code, {
+		const transformed = transformSync(compiled.code, {
 			loader: 'tsx',
 			jsx: 'automatic',
 			jsxImportSource: 'react',
 			target: 'esnext',
 			format: 'esm',
 			sourcefile: path,
-		}).code.replace(/from\s+["']@octanejs\/phosphor-icons["']/g, 'from "@phosphor-icons/react"');
+		}).code;
+		const output = transformed.replace(
+			/from\s+["']@octanejs\/phosphor-icons\/icons\/camera["']/g,
+			'from "@phosphor-icons/react/Camera"',
+		);
+		if (output === transformed) {
+			throw new Error(
+				'Phosphor differential fixture must use the public per-icon export on both runtimes',
+			);
+		}
 		writeFileSync(join(cache, `${basename(path, '.tsrx')}-${hash(path)}.js`), output);
 	}
 }


### PR DESCRIPTION
## Summary
- Fixes the intermittent 20s timeout of `Camera renders byte-identical accessible duotone SVG` in `packages/phosphor-icons/tests/differential/parity.test.ts` during full `pnpm test` runs on a loaded machine.
- The differential case drops from ~3,495ms to ~37ms in isolation; the existing 20s budget is now pure hang-guard headroom instead of a contention lottery.

## Why
- The fixture imported the `@octanejs/phosphor-icons` root barrel, which re-exports 1,513 generated icon modules. The rig dynamic-imports the fixture inside the test body, so every one of those modules went through Vite's transform-and-execute pipeline on the test's clock (~2.3s of transform alone, plus the React oracle loading `@phosphor-icons/react`'s ~3,000-file dist). Under full-suite CPU saturation that 3.5s stretched past 20s.
- Barrel completeness and per-icon export wiring are already covered by `exports.test.ts`; the mount fixture doesn't need to pay for every unrelated icon.

## Changes
- `tests/_fixtures/parity.tsrx`: import the public per-icon subpath `@octanejs/phosphor-icons/icons/camera` (~5 modules) instead of the root barrel.
- `tests/differential/_setup.ts`: rewrite that subpath to `@phosphor-icons/react/Camera` for the compiled React fixture, and throw if a fixture regresses to an import shape the rewrite doesn't cover.
- `audit/react-parity.json`: refresh the sha256 evidence pins for the two edited files.

## Validation
- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 1,677 files / 18,501 tests, all pass; run at full machine saturation (the failure regime), differential stayed far under budget
- [x] targeted tests: `phosphor-icons-differential` (case 3,495ms → 37ms), `phosphor-icons` + `phosphor-icons-ssr` (19 tests), `pnpm react-parity:check` ("audit is current"), `pnpm typecheck:files` + `pnpm format:files:check` on the changed files, `pnpm sync` clean

## Risk / follow-ups
- Overlaps deliberately with `feat/consolidated-react-parity-prs`: `parity.tsrx` and `_setup.ts` here are byte-identical to that branch's versions (audit hashes confirm), so whichever lands second merges clean.
- That branch's other half — the `preloadDifferentialFixture` rig change and vitest.config.js restructure — is intentionally **not** taken here: `_rig.ts` and `vitest.config.js` sha256s are pinned as evidence by ~28 audit manifests, and touching them in this PR would invalidate all of them. With the fixture narrowed, the in-test work is small enough that the preload isn't needed for correctness.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to fixture imports and differential setup rewriting; no production or security-sensitive code is modified.
> 
> **Overview**
> Fixes intermittent timeouts in the phosphor differential Camera SVG parity test by stopping the fixture from importing the full package barrel.
> 
> `parity.tsrx` now imports the public per-icon subpath `@octanejs/phosphor-icons/icons/camera`, and `_setup.ts` rewrites that to `@phosphor-icons/react/Camera` for the React oracle. A guard throws if a fixture regresses to an uncovered import shape. Audit sha256 pins are refreshed for the two edited files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e8c9994c7959b4f50ebbcf54434d6400074495b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->