### PR TITLE
feat: close the React 19 parity implementation gaps (#711)

### DIFF
--- a/.changeset/react19-implementation-gaps.md
+++ b/.changeset/react19-implementation-gaps.md
@@ -1,0 +1,29 @@
+---
+'octane': patch
+---
+
+React 19 parity: the implementation-gap tranche from the outstanding-work issue.
+
+- **Nested document metadata**: `<title>`/`<meta>`/`<link>` and Float resources
+  now hoist from ANY depth on the server too (React's model; the client always
+  did) — a nested hoist serializes into the head channel at its authored
+  position, the host body keeps only real children, and hydration adopts
+  without mismatches. A hoist inside a conditional arm registers only while
+  that arm renders.
+- **`prerenderToNodeStream`**: `octane/static` gains the stream variant —
+  resolves after the await-everything render completes; `prelude` streams the
+  complete document bytes (scoped-style tags, then folded html). No
+  `postponed` field: postpone/resume stays a documented non-goal.
+- **Teardown errors reach the root callbacks**: effect-cleanup and ref-detach
+  throws during unmount report through `onCaughtError` (boundary-claimed) or
+  `onUncaughtError` (unclaimed) with routing semantics unchanged.
+- **Resource hints share the Float identity model**: `preinit(as:'style')` IS a
+  stylesheet resource (honors `precedence`, joins the groups, dedupes against
+  the rendered form), `preinit(as:'script')` dedupes against
+  `<script async src>`, `preload`/`preloadModule` after the matching init
+  no-op, image preloads with `imageSrcSet` key on the srcset+sizes pair, and
+  malformed calls warn in development.
+- **Universal renderer**: `onCaughtError`/`onUncaughtError` now apply to
+  `octane/universal` roots (boundary claims and scheduler-owned work; a direct
+  `render()` throw remains the documented result channel, and there is no
+  `onRecoverableError` — the universal renderer has no hydration channel).

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -580,9 +580,9 @@ differences:
 - **`<title>` accepts any children Octane can stringify** — multiple children
   and expressions concatenate. React 19 errors on non-string title children.
 
-Additionally, metadata and resources classify at a component's **body root**
-(beside the output node), the same placement the head-hoist model has always
-used — a `<title>` nested inside a host element is not hoisted.
+Metadata and resources hoist from ANY depth, matching React: an element
+nested inside a host partitions out of the body on both the client and the
+server, and a hoist inside an `@if` arm registers only while that arm renders.
 
 React Float **resources** are supported with React's semantics:
 
@@ -610,11 +610,20 @@ React Float **resources** are supported with React's semantics:
 
 Out of scope, deliberately: **suspensey commits** (React's
 suspend-until-the-stylesheet-loads behavior; Octane inserts the sheet and
-continues). Resource-hint options apply as a lenient
+continues).
+
+Resource hints share the Float identity model: `preinit(href, {as: 'style'})`
+IS a stylesheet resource (it honors a `precedence` option, default
+`"default"`, joins the precedence groups, and dedupes against
+`<link rel="stylesheet" precedence>`), `preinit(as: 'script')` dedupes against
+`<script async src>`, and a `preload`/`preloadModule` issued after the
+matching init is a no-op (the upgrade is one-way: preload-then-init keeps both
+tags). Image preloads carrying `imageSrcSet` key on the srcset+sizes pair
+rather than the fallback href. Malformed calls (missing/invalid `as`, empty
+href) warn in development and stay no-ops. Options serialize through a lenient
 attribute pass-through (`fetchPriority`, `imageSrcSet`, `imageSizes`, `media`,
-`integrity`, … all serialize correctly) without React's option validation, and
-`preload` + `preinit` of the same href are two entries rather than React's
-unified resource map.
+`integrity`, … all emit their canonical attributes); unknown option keys are
+passed through as attributes rather than dropped.
 
 ## Reconciler: LIS moves, identical results
 
@@ -826,8 +835,11 @@ errors; the failed root's tree still unmounts), and `onRecoverableError`
 (hydration recovered from a structural mismatch — see the hydration section).
 Each callback receives only the error: there is no `errorInfo`/`componentStack`
 second argument, matching the documented SSR `onError` shape (owner stacks are
-not part of Octane's API). Deletion-phase teardown errors keep their existing
-boundary routing and default report; they do not reach these callbacks.
+not part of Octane's API). Deletion-phase teardown errors (effect cleanups and
+ref detaches thrown while a subtree unmounts) keep their existing boundary
+routing and report through the same callbacks: boundary-claimed →
+`onCaughtError`, unclaimed → `onUncaughtError` (else the default
+`console.error`).
 
 ## Refs are props
 

--- a/docs/react-parity-coverage.md
+++ b/docs/react-parity-coverage.md
@@ -85,8 +85,8 @@ Every concrete case in either pinned inventory has exactly one ledger dispositio
 
 | Baseline | Cases | Untriaged | Planned | In progress | Covered | Documented | Blocked |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| stable | 5,345 | 0 | 1,985 | 0 | 908 | 2,452 | 0 |
-| canary | 5,413 | 0 | 2,032 | 0 | 965 | 2,416 | 0 |
+| stable | 5,345 | 0 | 1,984 | 0 | 909 | 2,452 | 0 |
+| canary | 5,413 | 0 | 2,031 | 0 | 966 | 2,416 | 0 |
 
 Classifications are `portable`, `adaptable`, `divergence`, and `non_goal`. A covered case requires live local test evidence; divergence and non-goal dispositions require a rationale.
 

--- a/docs/ssr.md
+++ b/docs/ssr.md
@@ -438,9 +438,10 @@ These are the known gaps between Octane SSR and a full streaming SSR stack:
   arbitrary preamble insertion, bootstrap script/module lists, import-map
   construction, response headers, or `onHeaders`. Compose those concerns around
   the returned stream in the Vite plugin, adapter, or application server.
-- **`prerenderToNodeStream`**: planned; `octane/static` currently exposes only
-  the buffered `prerender`, which resolves `{ html, css }` rather than React's
-  `{ prelude: ReadableStream }`.
+- ~~`prerenderToNodeStream`~~ — implemented: it resolves after the
+  await-everything render completes and `prelude` streams the complete document
+  bytes (scoped-style tags, then folded html). The buffered `prerender` keeps
+  its `{ html, css }` shape.
 - **Partial pre-rendering** (`resume`, `resumeToPipeableStream`,
   `resumeAndPrerender`, and React's postpone/prelude protocol): a documented
   non-goal — that request protocol is not part of Octane's public SSR surface.

--- a/packages/cli/src/data/octane-data.json
+++ b/packages/cli/src/data/octane-data.json
@@ -1281,6 +1281,11 @@
       "message": "Hydration mismatch: the server rendered more list items than the client; the extra server items were discarded.",
       "runtime": ["client"],
       "status": "active"
+    },
+    "57": {
+      "message": "prerenderToNodeStream requires a Node.js runtime with process.getBuiltinModule; use prerender() in non-Node environments.",
+      "runtime": ["server"],
+      "status": "active"
     }
   }
 }

--- a/packages/octane/audit/react-conformance-ledger.json
+++ b/packages/octane/audit/react-conformance-ledger.json
@@ -20636,7 +20636,7 @@
     },
     {
       "caseId": "react-case-v1:446d3e80f94d2ab1a5aa",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFizzStaticNode-test.js",
       "title": "should call prerenderToNodeStream",
@@ -20644,7 +20644,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Adapted executable evidence: prerenderToNodeStream resolves after the await-everything render completes and streams the complete document bytes; Octane has no postponed field (postpone/resume is a documented non-goal).",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/static-prerender-stream.test.ts",
+          "testName": "resolves only after every use(thenable) settles; prelude carries the full document",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:44754ada20cf24bd6baa",

--- a/packages/octane/error-codes/codes.json
+++ b/packages/octane/error-codes/codes.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "nextCode": 57,
+  "nextCode": 58,
   "codes": {
     "1": {
       "message": "Maximum update depth exceeded. Octane limits the number of nested updates to prevent infinite loops.",
@@ -336,6 +336,12 @@
       "message": "Hydration mismatch: the server rendered more list items than the client; the extra server items were discarded.",
       "argumentCount": 0,
       "runtime": ["client"],
+      "status": "active"
+    },
+    "57": {
+      "message": "prerenderToNodeStream requires a Node.js runtime with process.getBuiltinModule; use prerender() in non-Node environments.",
+      "argumentCount": 0,
+      "runtime": ["server"],
       "status": "active"
     }
   }

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -19470,6 +19470,12 @@ function planJsx(
 	// `null` outside dev → zero work, prod output byte-identical.
 	const _prevElemLocs = ctx._elemLocs;
 	ctx._elemLocs = ctx.dev ? new Map() : null;
+	// NESTED HeadHoists lifted out of host-element children during the walk (see
+	// emitNodeHtml's element case) join this plan's head list, so client mounts
+	// match the server's any-depth hoisting. Saved/restored per plan: an @if
+	// arm's sub-plan owns its own list, keeping arm-conditional hoists scoped.
+	const _prevNestedHeads = ctx._nestedHeadHoists;
+	ctx._nestedHeadHoists = [];
 	const allNodes = normalizeChildren(jsxNodesRaw, parentNs === 'svg', ctx);
 	// Partition hoisted `<title>`/`<meta>`/eligible `<link>` out of the BODY-root set:
 	// `jsxNodes` (the body) drives single/multi-root + the template, while head
@@ -19488,6 +19494,7 @@ function planJsx(
 	// its constructs (see `headEmit` below), keeping every scope's `slots` packed.
 	if (jsxNodes.length === 0) {
 		ctx._elemLocs = _prevElemLocs;
+		ctx._nestedHeadHoists = _prevNestedHeads;
 		return {
 			hasBag: false,
 			mount: [],
@@ -20271,7 +20278,13 @@ function planJsx(
 	for (let i = 0; i < allConstructs.length; i++) allConstructs[i].slotIndex = i + slotBase;
 	// Hoisted head elements take the slots AFTER the constructs (and `plan.head` runs
 	// after `plan.after`), so the scope's `slots` array fills 0,1,…,N,N+1,… packed.
-	const headEmit = emitHeadClient(headNodes, ctx, allConstructs.length + slotBase);
+	const nestedHeadHoists = ctx._nestedHeadHoists ?? [];
+	ctx._nestedHeadHoists = _prevNestedHeads;
+	const headEmit = emitHeadClient(
+		[...headNodes, ...nestedHeadHoists],
+		ctx,
+		allConstructs.length + slotBase,
+	);
 	// Is a construct's host a real in-template element (append / insert INTO it) vs
 	// the block's own parentNode (insert BEFORE __block.endMarker so the slot's range
 	// stays inside the block)? In-template hosts are the navigated `_el…` vars and the
@@ -23279,7 +23292,22 @@ function emitElementHtml(
 		appendTemplatePart(html, escapeInlineScriptContent(authoredStaticScriptContent), 'raw');
 	}
 
-	const children = normalizeChildren(sourceChildren, childNs === 'svg', ctx);
+	let children = normalizeChildren(sourceChildren, childNs === 'svg', ctx);
+	// NESTED document metadata / Float resources are zero-DOM children: lift
+	// them to the enclosing plan's head list (mounted out-of-band by
+	// emitHeadClient — scope-owned metadata, global resources), mirroring the
+	// server's expression-position emission and keeping child indices aligned
+	// with the server markup for hydration.
+	if (ctx._nestedHeadHoists !== undefined && ctx._nestedHeadHoists !== null) {
+		let hasNestedHoist = false;
+		for (const child of children) {
+			if (child.type === 'HeadHoist') {
+				ctx._nestedHeadHoists.push(child);
+				hasNestedHoist = true;
+			}
+		}
+		if (hasNestedHoist) children = children.filter((n) => n.type !== 'HeadHoist');
+	}
 	// Special case: a single Text child (only-child text fast path).
 	if (children.length === 1 && children[0].type === 'Text') {
 		const txtChild = children[0];

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -10146,6 +10146,33 @@ function ssrEmitNode(
 		case 'FragmentEnd':
 			ctx.runtimeNeeded.add('ssrFragmentMarker');
 			return ssrCall('ssrFragmentMarker', [b.literal(false, 'false')], ctx._moduleOrigin);
+		case 'HeadHoist': {
+			// NESTED document metadata / Float resource (React hoists from anywhere;
+			// the client partitions these out of host templates at every depth). The
+			// head write runs at this position in the html evaluation — the same
+			// conditional timing as the client's arm-scoped headBlock — and the
+			// functions return '', so the body markup gains nothing and the
+			// hydration cursor stays aligned with the client template.
+			const kind = headResourceKind(node.element);
+			if (kind !== null) {
+				const fn =
+					kind === 'stylesheet'
+						? 'ssrStylesheetResource'
+						: kind === 'style'
+							? 'ssrStyleResource'
+							: 'ssrScriptResource';
+				ctx.runtimeNeeded.add(fn);
+				return inheritOriginLoc(
+					b.call('_$' + fn, ...headResourceArgNodes(node.element, kind)),
+					node.element,
+				);
+			}
+			ctx.runtimeNeeded.add('ssrHeadEl');
+			return inheritOriginLoc(
+				b.call('_$ssrHeadEl', ...headElementArgNodes(node, 0, ctx)),
+				node.element,
+			);
+		}
 		default:
 			return ssrUnsupported(`node type ${node.type}`);
 	}

--- a/packages/octane/src/error-codes.server.generated.ts
+++ b/packages/octane/src/error-codes.server.generated.ts
@@ -34,6 +34,7 @@ type ServerErrorArguments = {
 	45: [];
 	47: [unknown];
 	48: [unknown];
+	57: [];
 };
 
 export function formatServerError<Code extends keyof ServerErrorArguments>(
@@ -150,6 +151,11 @@ export function formatServerError<Code extends keyof ServerErrorArguments>(
 			case 48:
 				return formatDevErrorMessage(
 					'octane SSR: %s consecutive streaming passes completed no boundary — a use(thenable) never resolved. If promises are re-created on every render pass (e.g. created in an ancestor render and passed down through props), create them at their use() site or hoist them out of render.',
+					args,
+				);
+			case 57:
+				return formatDevErrorMessage(
+					'prerenderToNodeStream requires a Node.js runtime with process.getBuiltinModule; use prerender() in non-Node environments.',
 					args,
 				);
 			default:

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -5095,8 +5095,10 @@ export function ssrHeadEl(
 	tag: string,
 	attrs: Record<string, unknown> | null,
 	text: unknown,
-): void {
-	if (HEAD === null) return;
+): string {
+	// Returns '' so a NESTED hoist can sit in an html expression (the head write
+	// happens at the authored position; the body markup gains nothing).
+	if (HEAD === null) return '';
 	// Paired ownership comments bound the exact adoption interval; static markup
 	// is non-hydratable, so both are omitted there.
 	const rootSuffix = HEAD.rootSuffix;
@@ -5117,6 +5119,7 @@ export function ssrHeadEl(
 	}
 	if (MARKERS) s += '<!--/' + ownershipKey + '-->';
 	HEAD.html += s;
+	return '';
 }
 
 interface NamespaceHeadProps {
@@ -6053,6 +6056,47 @@ export async function prerender(
 		nonceAttr,
 		options?.headChannel === 'separate',
 	);
+}
+
+/**
+ * Stream variant of {@link prerender}, mirroring React's `prerenderToNodeStream`
+ * semantics: the promise resolves only after the await-everything render fully
+ * completes, and `prelude` is the transport for the COMPLETE document bytes —
+ * the deduped scoped-style tags first, then the folded html (the order a
+ * streamed shell serves). There is no `postponed` field: Octane has no
+ * postpone/resume protocol (a documented non-goal). `node:stream` loads
+ * lazily on call, so edge bundles that never invoke this pay nothing.
+ * `headChannel: 'separate'` has no channel to land in here and is ignored
+ * (the head folds), with a development diagnostic.
+ */
+export async function prerenderToNodeStream(
+	entryComponent: ServerEntryComponent,
+	props?: any,
+	options?: RenderOptions,
+): Promise<{ prelude: import('node:stream').Readable }> {
+	let resolved = options;
+	if (options?.headChannel === 'separate') {
+		if (process.env.NODE_ENV !== 'production') {
+			console.error(
+				"prerenderToNodeStream() streams one document and has no separate head channel; headChannel: 'separate' was ignored. Use prerender() for a split head.",
+			);
+		}
+		resolved = { ...options, headChannel: undefined };
+	}
+	const result = await prerender(entryComponent, props, resolved);
+	// The server runtime must bundle for platform-neutral (edge) targets — see
+	// ssr-production-bundle.test.ts — so the node-only dependency resolves at
+	// RUNTIME through process.getBuiltinModule (a plain call no bundler follows,
+	// evaluated only when this node-only API is actually invoked).
+	const getBuiltin = (globalThis as any).process?.getBuiltinModule as
+		((id: string) => any) | undefined;
+	if (getBuiltin === undefined) throw new Error(formatServerError(57));
+	const { Readable } = getBuiltin('node:stream');
+	const chunks: Uint8Array[] = [];
+	const encoder = new TextEncoder();
+	if (result.css !== '') chunks.push(encoder.encode(result.css));
+	chunks.push(encoder.encode(result.html));
+	return { prelude: Readable.from(chunks, { objectMode: false }) };
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -7959,10 +8003,36 @@ function coerceHintHref(href: unknown): string | null {
 }
 
 /** React DOM `preload(href, {as, …})`. */
+/** Malformed-hint diagnostics (dev only; the call stays a no-op either way). */
+function warnHintUsage(message: string): void {
+	if (process.env.NODE_ENV !== 'production') console.error(message);
+}
+
 export function preload(href: string, options: { as: string } & Record<string, unknown>): void {
 	const value = coerceHintHref(href);
-	if (value === null || !options?.as) return;
-	const key = 'preload:' + options.as + ':' + value;
+	if (value === null) {
+		warnHintUsage('preload() requires a non-empty string href; the call was ignored.');
+		return;
+	}
+	if (!options?.as || typeof options.as !== 'string') {
+		warnHintUsage(
+			'preload() requires a string `as` option (e.g. "style", "script", "font", "image"); ' +
+				'the call was ignored.',
+		);
+		return;
+	}
+	const as = options.as;
+	// Mirror the client's one-way upgrade: once the matching resource is live in
+	// this pass (Float resource or preinit), the preload adds nothing.
+	if (HEAD !== null) {
+		if (as === 'style' && HEAD.hints.has('sheet:' + value)) return;
+		if (as === 'script' && HEAD.hints.has('script:' + value)) return;
+	}
+	const imageSrcSet = as === 'image' ? options.imageSrcSet : undefined;
+	const key =
+		typeof imageSrcSet === 'string' && imageSrcSet !== ''
+			? 'preload:image:' + imageSrcSet + '::' + String(options.imageSizes ?? '')
+			: 'preload:' + as + ':' + value;
 	const safeHref = sanitizeURL(value);
 	emitHeadHint(
 		key,
@@ -7977,28 +8047,37 @@ export function preload(href: string, options: { as: string } & Record<string, u
 }
 
 /** React DOM `preinit(href, {as: 'style'|'script', …})`. */
+/**
+ * React DOM `preinit(href, {as, …})` — routes through the Float resource emits
+ * so preinit and the rendered resource forms share ONE identity per pass
+ * (stylesheets join the precedence groups; scripts dedupe against
+ * `<script async src>`), mirroring the client.
+ */
 export function preinit(href: string, options: { as: string } & Record<string, unknown>): void {
 	const value = coerceHintHref(href);
-	if (value === null || !options?.as) return;
-	const key = 'preinit:' + options.as + ':' + value;
-	const safeHref = sanitizeURL(value);
-	const hint = ' data-oct-hint="' + escapeAttr(key) + '"';
-	emitHeadHint(
-		key,
-		options.as === 'style'
-			? '<link rel="stylesheet" href="' +
-					escapeAttr(safeHref) +
-					'"' +
-					hintAttrs(options, true, 'link') +
-					hint +
-					'>'
-			: '<script src="' +
-					escapeAttr(safeHref) +
-					'" async' +
-					hintAttrs(options, true, 'script') +
-					hint +
-					'></script>',
-	);
+	if (value === null) {
+		warnHintUsage('preinit() requires a non-empty string href; the call was ignored.');
+		return;
+	}
+	const as = options?.as;
+	if (as !== 'style' && as !== 'script') {
+		warnHintUsage(
+			'preinit() supports only as: "style" or "script" (got ' +
+				JSON.stringify(as) +
+				'); the call was ignored. Use preload() for other destinations.',
+		);
+		return;
+	}
+	if (as === 'style') {
+		ssrStylesheetResource({
+			...options,
+			as: undefined,
+			href: value,
+			precedence: (options as any).precedence ?? 'default',
+		});
+	} else {
+		ssrScriptResource({ ...options, as: undefined, href: undefined, src: value });
+	}
 }
 
 /** React DOM `preconnect(href, {crossOrigin?})`. */
@@ -8054,12 +8133,12 @@ function resourceAttrs(attrs: Record<string, unknown>, tag: 'link' | 'script'): 
  * Dedupes by href across the pass; groups by precedence in first-encounter
  * order (the HeadBuffer.sheets Map), folded after the ordinary head content.
  */
-export function ssrStylesheetResource(attrs: Record<string, unknown> | null): void {
-	if (HEAD === null || attrs == null) return;
+export function ssrStylesheetResource(attrs: Record<string, unknown> | null): string {
+	if (HEAD === null || attrs == null) return '';
 	const href = attrs.href;
-	if (typeof href !== 'string' || href === '') return;
+	if (typeof href !== 'string' || href === '') return '';
 	const key = 'sheet:' + href;
-	if (HEAD.hints.has(key)) return;
+	if (HEAD.hints.has(key)) return '';
 	HEAD.hints.add(key);
 	const precedence = attrs.precedence == null ? '' : String(attrs.precedence);
 	const tag =
@@ -8072,6 +8151,7 @@ export function ssrStylesheetResource(attrs: Record<string, unknown> | null): vo
 		'>';
 	const sheets = (HEAD.sheets ??= new Map());
 	sheets.set(precedence, (sheets.get(precedence) ?? '') + tag);
+	return '';
 }
 
 /**
@@ -8081,10 +8161,10 @@ export function ssrStylesheetResource(attrs: Record<string, unknown> | null): vo
  * not decode inside style raw text), so content that could close the tag fails
  * closed with a dev diagnostic instead of truncating the document.
  */
-export function ssrStyleResource(attrs: Record<string, unknown> | null, css: string): void {
-	if (HEAD === null || attrs == null) return;
+export function ssrStyleResource(attrs: Record<string, unknown> | null, css: string): string {
+	if (HEAD === null || attrs == null) return '';
 	const href = attrs.href;
-	if (typeof href !== 'string' || href === '') return;
+	if (typeof href !== 'string' || href === '') return '';
 	if (/<\/style/i.test(css)) {
 		if (process.env.NODE_ENV !== 'production') {
 			console.error(
@@ -8092,10 +8172,10 @@ export function ssrStyleResource(attrs: Record<string, unknown> | null, css: str
 					'serialized safely; the resource was skipped. Load it as a stylesheet link instead.',
 			);
 		}
-		return;
+		return '';
 	}
 	const key = 'sheet:' + href;
-	if (HEAD.hints.has(key)) return;
+	if (HEAD.hints.has(key)) return '';
 	HEAD.hints.add(key);
 	const precedence = attrs.precedence == null ? '' : String(attrs.precedence);
 	const tag =
@@ -8110,15 +8190,16 @@ export function ssrStyleResource(attrs: Record<string, unknown> | null, css: str
 		'</style>';
 	const sheets = (HEAD.sheets ??= new Map());
 	sheets.set(precedence, (sheets.get(precedence) ?? '') + tag);
+	return '';
 }
 
 /** Compiler target for `<script async src>` resources (React Float). */
-export function ssrScriptResource(attrs: Record<string, unknown> | null): void {
-	if (HEAD === null || attrs == null) return;
+export function ssrScriptResource(attrs: Record<string, unknown> | null): string {
+	if (HEAD === null || attrs == null) return '';
 	const src = attrs.src;
-	if (typeof src !== 'string' || src === '') return;
+	if (typeof src !== 'string' || src === '') return '';
 	const key = 'script:' + src;
-	if (HEAD.hints.has(key)) return;
+	if (HEAD.hints.has(key)) return '';
 	HEAD.hints.add(key);
 	HEAD.html +=
 		'<script src="' +
@@ -8126,12 +8207,15 @@ export function ssrScriptResource(attrs: Record<string, unknown> | null): void {
 		'" async data-oct-res=""' +
 		resourceAttrs(attrs, 'script') +
 		'></script>';
+	return '';
 }
 
 /** React DOM `preloadModule(href, options?)` — `<link rel="modulepreload">`, keyed by href. */
 export function preloadModule(href: string, options?: Record<string, unknown>): void {
 	const value = coerceHintHref(href);
 	if (value === null) return;
+	// A module that preinitModule already executed in this pass needs no preload.
+	if (HEAD !== null && HEAD.hints.has('module:' + value)) return;
 	const key = 'modulepreload:' + value;
 	const safeHref = sanitizeURL(value);
 	emitHeadHint(

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -7016,6 +7016,7 @@ function resetScopeChildren(scope: Scope): void {
 	const block = scope.block;
 	if (TEARDOWN_DEPTH === 0) {
 		TEARDOWN_HANDLER = findTryHandler(block.parentBlock) ?? rendererRegionTryHandler(block);
+		TEARDOWN_BLOCK = block;
 	}
 	TEARDOWN_DEPTH++;
 	// The bracket spans the WHOLE reset, not just the teardown call: a queued error is dispatched

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -3743,7 +3743,7 @@ export function queueRefDetach(ref: any, el: Element | FragmentInstance | null):
 	// Capture the active teardown boundary (if we're inside an unmount walk) so a
 	// throwing detach at drain time routes there — React's safelyDetachRef →
 	// captureCommitPhaseError (ReactErrorBoundaries:2782).
-	refDetachQueue.push(ref, el, TEARDOWN_HANDLER);
+	refDetachQueue.push(ref, el, TEARDOWN_HANDLER, TEARDOWN_BLOCK);
 }
 
 interface RefDetachSuppression {
@@ -3784,7 +3784,7 @@ function withRefDetachSuppression<T>(entries: SuspenseRefEntry[] | null, fn: () 
 function drainRefDetaches(): void {
 	if (refDetachQueue.length === 0) return;
 	const q = refDetachQueue.splice(0);
-	for (let i = 0; i < q.length; i += 3) {
+	for (let i = 0; i < q.length; i += 4) {
 		try {
 			REF_CALLBACK_DEPTH++;
 			try {
@@ -3795,10 +3795,14 @@ function drainRefDetaches(): void {
 		} catch (err) {
 			if (err instanceof MaximumUpdateDepthError) throw err;
 			// A throwing ref detach must not abort the commit (the remaining detaches
-			// + attaches still run) — route to the deletion's boundary like React.
+			// + attaches still run) — route to the deletion's boundary like React,
+			// reporting through the owning root's callbacks either way.
 			const handler = q[i + 2] as ((e: any) => void) | null;
-			if (handler !== null) handler(err);
-			else console.error(err);
+			const owner = q[i + 3] as Block | null;
+			if (handler !== null) {
+				handler(err);
+				reportCaughtError(owner, err);
+			} else if (!reportUncaughtError(owner, err)) console.error(err);
 		}
 	}
 }
@@ -4354,23 +4358,26 @@ function drainEffectEventCommitActions(): void {
 
 // Passive destroys of DELETED scopes, deferred past the sync phase (React
 // defers them to flushPassiveEffects — commitPassiveUnmountEffects). Flat
-// [cleanup, boundary-handler] pairs, pushed by unmountScope's effect-slot walk
+// [cleanup, boundary-handler, owner-block] triples, pushed by unmountScope's effect-slot walk
 // in deletion-walk order (parent→child, declaration order within a scope);
 // the captured handler routes a late throw to the try boundary that enclosed
 // the deletion — the same routing reportTeardownError gave the sync destroys.
-const pendingPassiveUnmounts: Array<Cleanup | ((err: any) => void) | null> = [];
+const pendingPassiveUnmounts: Array<Cleanup | ((err: any) => void) | Block | null> = [];
 
 function drainDeferredPassiveUnmounts(): void {
 	if (pendingPassiveUnmounts.length === 0) return;
 	const q = pendingPassiveUnmounts.splice(0);
-	for (let i = 0; i < q.length; i += 2) {
+	for (let i = 0; i < q.length; i += 3) {
 		try {
 			runEffectCleanupCallback(q[i] as Cleanup);
 		} catch (err) {
 			if (err instanceof MaximumUpdateDepthError) throw err;
 			const handler = q[i + 1] as ((err: any) => void) | null;
-			if (handler !== null) handler(err);
-			else console.error(err);
+			const owner = q[i + 2] as Block | null;
+			if (handler !== null) {
+				handler(err);
+				reportCaughtError(owner, err);
+			} else if (!reportUncaughtError(owner, err)) console.error(err);
 		}
 	}
 }
@@ -5226,20 +5233,27 @@ export function componentSlotLite<P>(
 // detach throw (drainRefDetaches) routes to the same boundary.
 let TEARDOWN_DEPTH = 0;
 let TEARDOWN_HANDLER: ((err: any) => void) | null = null;
+/** The outermost deleted block — root-callback routing for teardown errors. */
+let TEARDOWN_BLOCK: Block | null = null;
 let TEARDOWN_ERRORS: any[] | null = null;
 
 function reportTeardownError(err: any): void {
 	if (TEARDOWN_HANDLER !== null) (TEARDOWN_ERRORS ??= []).push(err);
-	else console.error(err);
+	else if (!reportUncaughtError(TEARDOWN_BLOCK, err)) console.error(err);
 }
 
 function dispatchTeardownErrors(): void {
 	const errs = TEARDOWN_ERRORS;
 	const h = TEARDOWN_HANDLER;
+	const blk = TEARDOWN_BLOCK;
 	TEARDOWN_ERRORS = null;
 	TEARDOWN_HANDLER = null;
+	TEARDOWN_BLOCK = null;
 	if (errs !== null && h !== null) {
-		for (let i = 0; i < errs.length; i++) h(errs[i]);
+		for (let i = 0; i < errs.length; i++) {
+			h(errs[i]);
+			reportCaughtError(blk, errs[i]);
+		}
 	}
 }
 
@@ -5247,6 +5261,7 @@ function unmountBlock(block: Block, detachDom: boolean = true): void {
 	if (block.disposed) return;
 	if (TEARDOWN_DEPTH === 0) {
 		TEARDOWN_HANDLER = findTryHandler(block.parentBlock) ?? rendererRegionTryHandler(block);
+		TEARDOWN_BLOCK = block;
 	}
 	TEARDOWN_DEPTH++;
 	try {
@@ -5364,7 +5379,7 @@ function unmountScope(scope: Scope, detachDom: boolean = true): void {
 			if (cleanup === undefined) continue;
 			slot.cleanup = undefined;
 			if (slot.phase === PASSIVE) {
-				pendingPassiveUnmounts.push(cleanup, TEARDOWN_HANDLER);
+				pendingPassiveUnmounts.push(cleanup, TEARDOWN_HANDLER, TEARDOWN_BLOCK);
 				// Arm the post-paint drain for unmounts OUTSIDE a commit
 				// (root.unmount()); a commit-driven unmount would re-arm in
 				// commitEffects anyway, deduped by the flag.
@@ -6929,6 +6944,7 @@ function promoteHmrBlockRange(block: Block): void {
 function resetHmrBlock(block: Block): void {
 	if (TEARDOWN_DEPTH === 0) {
 		TEARDOWN_HANDLER = findTryHandler(block.parentBlock) ?? rendererRegionTryHandler(block);
+		TEARDOWN_BLOCK = block;
 	}
 	TEARDOWN_DEPTH++;
 	let abortedRefs: SuspenseRefEntry[] | null = null;
@@ -26898,8 +26914,8 @@ export interface RootOptions {
 	 * render, passive-effect, or ref-attach channel. Octane passes only the
 	 * error — there is no `errorInfo`/`componentStack` second argument (owner
 	 * stacks are not part of Octane's API, matching the SSR `onError` shape).
-	 * Deletion-phase teardown errors keep their existing boundary routing and
-	 * default report; they do not reach this callback.
+	 * Deletion-phase teardown errors report here too once their enclosing
+	 * boundary claims them (the routing itself is unchanged).
 	 */
 	onCaughtError?: (error: unknown) => void;
 	/**
@@ -27607,8 +27623,10 @@ export function hydrateRoot(
 
 const _resourceHints = new Set<string>();
 
-function insertHeadHint(key: string, build: () => Element): void {
-	if (typeof document === 'undefined' || _resourceHints.has(key)) return;
+/** Known-hint check shared by insertHeadHint and cross-family suppression. */
+function hasHeadHint(key: string): boolean {
+	if (_resourceHints.has(key)) return true;
+	if (typeof document === 'undefined') return false;
 	// SSR dedupe: compare exact attribute VALUES rather than interpolating an
 	// href-derived key into a CSS selector. Quotes/brackets are valid URL text;
 	// treating them as selector syntax could throw before the hint is inserted.
@@ -27616,15 +27634,25 @@ function insertHeadHint(key: string, build: () => Element): void {
 	for (let i = 0; i < existing.length; i++) {
 		if (existing[i].getAttribute('data-oct-hint') === key) {
 			_resourceHints.add(key);
-			return;
+			return true;
 		}
 	}
+	return false;
+}
+
+function insertHeadHint(key: string, build: () => Element): void {
+	if (typeof document === 'undefined' || hasHeadHint(key)) return;
 	const el = build();
 	el.setAttribute('data-oct-hint', key);
 	document.head.appendChild(el);
 	// Publish dedupe state only after every DOM operation succeeds, so a failed
 	// build/append cannot poison the key and suppress a later valid retry.
 	_resourceHints.add(key);
+}
+
+/** Malformed-hint diagnostics (dev only; the call stays a no-op either way). */
+function warnHintUsage(message: string): void {
+	if (process.env.NODE_ENV !== 'production') console.error(message);
 }
 
 function applyHintAttrs(el: Element, opts: Record<string, unknown> | undefined): void {
@@ -27640,10 +27668,33 @@ function applyHintAttrs(el: Element, opts: Record<string, unknown> | undefined):
 
 /** React DOM `preload(href, {as, …})` — `<link rel="preload">`. */
 export function preload(href: string, options: { as: string } & Record<string, unknown>): void {
-	if (!href || !options?.as) return;
+	if (!href) {
+		warnHintUsage('preload() requires a non-empty string href; the call was ignored.');
+		return;
+	}
+	if (!options?.as || typeof options.as !== 'string') {
+		warnHintUsage(
+			'preload() requires a string `as` option (e.g. "style", "script", "font", "image"); ' +
+				'the call was ignored.',
+		);
+		return;
+	}
+	const as = options.as;
 	const rawHref = typeof href === 'string' ? href : String(href);
+	// After the matching resource is already live (a Float resource or preinit),
+	// a preload adds nothing — React's resource map has the same one-way
+	// upgrade: preload-then-init keeps both tags, init-then-preload no-ops.
+	if (as === 'style' && resourceState().sheets.has(rawHref)) return;
+	if (as === 'script' && resourceState().scripts.has(rawHref)) return;
+	// Image preloads with a srcset are keyed by the srcset+sizes pair, not the
+	// fallback href — two responsive preloads for one href stay distinct.
+	const imageSrcSet = as === 'image' ? options.imageSrcSet : undefined;
+	const key =
+		typeof imageSrcSet === 'string' && imageSrcSet !== ''
+			? 'preload:image:' + imageSrcSet + '::' + String(options.imageSizes ?? '')
+			: 'preload:' + as + ':' + rawHref;
 	const safeHref = sanitizeURL(rawHref);
-	insertHeadHint('preload:' + options.as + ':' + rawHref, () => {
+	insertHeadHint(key, () => {
 		const l = document.createElement('link');
 		l.rel = 'preload';
 		l.href = safeHref;
@@ -27652,26 +27703,39 @@ export function preload(href: string, options: { as: string } & Record<string, u
 	});
 }
 
-/** React DOM `preinit(href, {as: 'style'|'script', …})` — executes/applies the resource. */
+/**
+ * React DOM `preinit(href, {as: 'style'|'script', …})` — executes/applies the
+ * resource. Routes through the Float resource inserts so preinit and the
+ * rendered resource forms share ONE identity: a preinit'd stylesheet joins the
+ * precedence groups (`precedence` option honored, default `'default'`) and
+ * dedupes against `<link rel="stylesheet" precedence>`; a preinit'd script
+ * dedupes against `<script async src>`.
+ */
 export function preinit(href: string, options: { as: string } & Record<string, unknown>): void {
-	if (!href || !options?.as) return;
-	const as = options.as;
+	if (!href) {
+		warnHintUsage('preinit() requires a non-empty string href; the call was ignored.');
+		return;
+	}
+	const as = options?.as;
+	if (as !== 'style' && as !== 'script') {
+		warnHintUsage(
+			'preinit() supports only as: "style" or "script" (got ' +
+				JSON.stringify(as) +
+				'); the call was ignored. Use preload() for other destinations.',
+		);
+		return;
+	}
 	const rawHref = typeof href === 'string' ? href : String(href);
-	const safeHref = sanitizeURL(rawHref);
-	insertHeadHint('preinit:' + as + ':' + rawHref, () => {
-		if (as === 'style') {
-			const l = document.createElement('link');
-			l.rel = 'stylesheet';
-			l.href = safeHref;
-			applyHintAttrs(l, { ...options, as: undefined });
-			return l;
-		}
-		const s = document.createElement('script');
-		(s as HTMLScriptElement).src = safeHref;
-		(s as HTMLScriptElement).async = true;
-		applyHintAttrs(s, { ...options, as: undefined });
-		return s;
-	});
+	if (as === 'style') {
+		stylesheetResource({
+			...options,
+			as: undefined,
+			href: rawHref,
+			precedence: (options as any).precedence ?? 'default',
+		});
+	} else {
+		scriptResource({ ...options, as: undefined, href: undefined, src: rawHref });
+	}
 }
 
 /** React DOM `preconnect(href, {crossOrigin?})` — `<link rel="preconnect">`. */
@@ -27709,6 +27773,8 @@ export function prefetchDNS(href: string): void {
 export function preloadModule(href: string, options?: Record<string, unknown>): void {
 	if (!href) return;
 	const rawHref = typeof href === 'string' ? href : String(href);
+	// A module that preinitModule already executed needs no preload.
+	if (hasHeadHint('module:' + rawHref)) return;
 	const safeHref = sanitizeURL(rawHref);
 	insertHeadHint('modulepreload:' + rawHref, () => {
 		const l = document.createElement('link');

--- a/packages/octane/src/static/index.ts
+++ b/packages/octane/src/static/index.ts
@@ -9,11 +9,18 @@
  * `renderToString` (single sync pass, fallbacks for suspended boundaries) and
  * the streaming APIs.
  *
- * `prerenderToNodeStream` is not implemented yet (tracked as planned work in the
- * React-parity ledger). React 19.2's partial pre-rendering — `resume`,
- * `resumeAndPrerender`, and the postpone/prelude protocol — is a documented
- * non-goal: that request protocol is not part of Octane's public SSR surface,
- * and `prerender` here resolves `{ html, css }` rather than React's
- * `{ prelude: ReadableStream }`.
+ * `prerenderToNodeStream` mirrors React's shape: it resolves only after the
+ * await-everything render completes, and `prelude` streams the COMPLETE
+ * document bytes (scoped-style tags, then the folded html). React 19.2's
+ * partial pre-rendering — `resume`, `resumeAndPrerender`, and the
+ * postpone/prelude-with-holes protocol — is a documented non-goal: that
+ * request protocol is not part of Octane's public SSR surface, so there is no
+ * `postponed` field and the buffered `prerender` resolves `{ html, css }`
+ * rather than React's `{ prelude: ReadableStream }`.
  */
-export { prerender, type RenderResult, type RenderOptions } from '../runtime.server.js';
+export {
+	prerender,
+	prerenderToNodeStream,
+	type RenderResult,
+	type RenderOptions,
+} from '../runtime.server.js';

--- a/packages/octane/src/universal-core.ts
+++ b/packages/octane/src/universal-core.ts
@@ -746,6 +746,26 @@ export interface UniversalRootOptions<Container> {
 	 * the standard global `queueMicrotask` (for example Lynx PrimJS).
 	 */
 	scheduleMicrotask?: (callback: () => void) => void;
+	/**
+	 * React 19 parity, reporting only: called after a `universalTry` catch arm
+	 * claims an error from this root — a render-time throw its arm catches, or
+	 * an effect/host-callback error routed to it between renders. Mirrors the
+	 * DOM runtime's `createRoot` option: only the error is passed (no
+	 * `errorInfo`/`componentStack` second argument).
+	 */
+	onCaughtError?: (error: unknown) => void;
+	/**
+	 * React 19 parity: called for an error no boundary claims. When provided it
+	 * REPLACES the default report for this root's scheduler-owned work — a
+	 * scheduled render error stops rethrowing out of the microtask flush (or,
+	 * on a transported root, out of `flushTransport()`), and an unrouted
+	 * effect/host-callback error stops rethrowing out of the commit or passive
+	 * flush. Direct `prepare()`/`render()`/`commit()` calls still throw: the
+	 * thrown attempt is that API's documented result channel. Recovery
+	 * semantics are unchanged either way — the failed attempt is discarded and
+	 * committed content is retained exactly as without the option.
+	 */
+	onUncaughtError?: (error: unknown) => void;
 }
 
 export interface UniversalTransaction {
@@ -1374,7 +1394,8 @@ class UniversalRendererRegionOwnerBridge implements RendererRegionOwnerBridge {
 			try {
 				dispose();
 			} catch (error) {
-				if (!routeUniversalOwnerError(this.owner, error)) console.error(error);
+				if (routeUniversalOwnerError(this.owner, error)) continue;
+				if (!reportUniversalUncaughtError(this.owner.root, error)) console.error(error);
 			}
 		}
 		cell.disposing = false;
@@ -3521,6 +3542,10 @@ function materializeValue(
 			resetDraftChildren(owner);
 			owner.hasBoundaryError = true;
 			owner.boundaryError = error;
+			// The catch arm claims this render error here, in the throwing attempt
+			// itself. Replays of an already-claimed error (the hasBoundaryError
+			// branch above) do not re-report.
+			reportUniversalCaughtError(owner.record.root, error);
 			const nodes = materializeScoped(owner, [...path, 'try-arm'], 'catch', () =>
 				boundary.catch!(error, () => {
 					owner.record.hasBoundaryError = false;
@@ -6369,6 +6394,61 @@ function runEffectCleanup(hook: EffectHook): void {
 	cleanup?.();
 }
 
+/**
+ * Root error-callback handlers live OFF the root's shape (mirroring the DOM
+ * runtime's Block-keyed WeakMap): registered only for roots created with at
+ * least one callback, so every other root pays a single module-null check on
+ * the (already cold) error paths and UniversalRootImpl's layout is untouched.
+ */
+interface UniversalRootErrorHandlers {
+	onCaughtError: ((error: unknown) => void) | undefined;
+	onUncaughtError: ((error: unknown) => void) | undefined;
+}
+
+let UNIVERSAL_ROOT_ERROR_HANDLERS: WeakMap<
+	UniversalRootImpl<any, any>,
+	UniversalRootErrorHandlers
+> | null = null;
+
+function registerUniversalRootErrorHandlers(
+	root: UniversalRootImpl<any, any>,
+	options: UniversalRootOptions<any>,
+): void {
+	const { onCaughtError, onUncaughtError } = options;
+	if (onCaughtError === undefined && onUncaughtError === undefined) return;
+	(UNIVERSAL_ROOT_ERROR_HANDLERS ??= new WeakMap()).set(root, { onCaughtError, onUncaughtError });
+}
+
+function universalRootErrorHandlersFor(
+	root: UniversalRootImpl<any, any>,
+): UniversalRootErrorHandlers | null {
+	if (UNIVERSAL_ROOT_ERROR_HANDLERS === null) return null;
+	return UNIVERSAL_ROOT_ERROR_HANDLERS.get(root) ?? null;
+}
+
+/** A throwing report callback must not corrupt recovery — report it and move on. */
+function invokeUniversalRootErrorHandler(handler: (error: unknown) => void, err: unknown): void {
+	try {
+		handler(err);
+	} catch (handlerErr) {
+		console.error(handlerErr);
+	}
+}
+
+/** Report a boundary-claimed error to the owning root's onCaughtError, if any. */
+function reportUniversalCaughtError(root: UniversalRootImpl<any, any>, err: unknown): void {
+	const h = universalRootErrorHandlersFor(root)?.onCaughtError;
+	if (h !== undefined) invokeUniversalRootErrorHandler(h, err);
+}
+
+/** True when the owning root's onUncaughtError consumed the report (callers skip their default). */
+function reportUniversalUncaughtError(root: UniversalRootImpl<any, any>, err: unknown): boolean {
+	const h = universalRootErrorHandlersFor(root)?.onUncaughtError;
+	if (h === undefined) return false;
+	invokeUniversalRootErrorHandler(h, err);
+	return true;
+}
+
 function routeUniversalOwnerError(owner: UniversalOwnerRecord, error: unknown): boolean {
 	for (let current = owner.parent; current !== null; current = current.parent) {
 		if (!current.isBoundary || current.disposed) continue;
@@ -6376,6 +6456,9 @@ function routeUniversalOwnerError(owner: UniversalOwnerRecord, error: unknown): 
 		current.boundaryError = error;
 		current.hasBoundaryError = true;
 		current.root.schedule();
+		// The boundary took ownership of the error episode; its catch-arm replay
+		// deliberately does not re-report, so this is the claim's single report.
+		reportUniversalCaughtError(current.root, error);
 		return true;
 	}
 	return false;
@@ -6406,7 +6489,8 @@ function runOwnedEffectCreate(hook: EffectHook): void {
 	try {
 		runEffectCreate(hook);
 	} catch (error) {
-		if (!routeUniversalOwnerError(hook.owner, error)) throw error;
+		if (routeUniversalOwnerError(hook.owner, error)) return;
+		if (!reportUniversalUncaughtError(hook.owner.root, error)) throw error;
 	}
 }
 
@@ -6414,7 +6498,8 @@ function runOwnedEffectCleanup(hook: EffectHook): void {
 	try {
 		runEffectCleanup(hook);
 	} catch (error) {
-		if (!routeUniversalOwnerError(hook.owner, error)) throw error;
+		if (routeUniversalOwnerError(hook.owner, error)) return;
+		if (!reportUniversalUncaughtError(hook.owner.root, error)) throw error;
 	}
 }
 
@@ -6422,7 +6507,9 @@ function runOwnedCommit(owner: UniversalOwnerRecord | null, work: () => void): v
 	try {
 		work();
 	} catch (error) {
-		if (owner === null || !routeUniversalOwnerError(owner, error)) throw error;
+		if (owner === null) throw error;
+		if (routeUniversalOwnerError(owner, error)) return;
+		if (!reportUniversalUncaughtError(owner.root, error)) throw error;
 	}
 }
 
@@ -7661,7 +7748,17 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 				if (this.unmounted) return;
 				const input = this.scheduledRenderInput();
 				if (input === null) return;
-				const attempt = this.__prepareScheduled(input[0], input[1]);
+				let attempt: UniversalPreparedAttempt;
+				try {
+					attempt = this.__prepareScheduled(input[0], input[1]);
+				} catch (error) {
+					// Scheduled work has no direct caller to observe the throw — without
+					// a handler it surfaces through flushTransport()'s async-work error.
+					// A root created with onUncaughtError consumes its own report; the
+					// failed attempt is already discarded and recovery is unchanged.
+					if (!reportUniversalUncaughtError(this, error)) throw error;
+					return;
+				}
 				if (attempt.status === 'prepared') {
 					try {
 						await attempt.commitAsync();
@@ -7674,7 +7771,17 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 		} else {
 			const input = this.scheduledRenderInput();
 			if (input === null) return;
-			const attempt = this.__prepareScheduled(input[0], input[1]);
+			let attempt: UniversalPreparedAttempt;
+			try {
+				attempt = this.__prepareScheduled(input[0], input[1]);
+			} catch (error) {
+				// Scheduled work has no direct caller to observe the throw — without a
+				// handler it escapes into the host's microtask channel. A root created
+				// with onUncaughtError consumes its own report; the failed attempt is
+				// already discarded and recovery is unchanged.
+				if (!reportUniversalUncaughtError(this, error)) throw error;
+				return;
+			}
 			if (attempt.status === 'prepared') attempt.commit();
 		}
 	}
@@ -7936,7 +8043,10 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 						const batches = new Set(replay.transitionBatches);
 						for (const batch of this.takeScheduledTransitionBatches()) batches.add(batch);
 						this.finishTransitionBatches(batches);
-						throw error;
+						// A resumed replay is scheduler-owned work like any other scheduled
+						// render — a root created with onUncaughtError consumes its report.
+						if (!reportUniversalUncaughtError(this, error)) throw error;
+						return;
 					}
 					// Commit errors have transaction-owned acceptance semantics. In
 					// particular, do not cancel unrelated blocked transitions after a
@@ -7974,7 +8084,10 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 			const batches = new Set(replay.transitionBatches);
 			for (const batch of this.takeScheduledTransitionBatches()) batches.add(batch);
 			this.finishTransitionBatches(batches);
-			throw error;
+			// A resumed replay is scheduler-owned work like any other scheduled
+			// render — a root created with onUncaughtError consumes its report.
+			if (!reportUniversalUncaughtError(this, error)) throw error;
+			return;
 		}
 		if (attempt.status === 'prepared') attempt.commit();
 		else this.ensureScheduledTransitionWork();
@@ -12020,7 +12133,14 @@ export function createUniversalRoot<Container, PublicInstance>(
 			'Universal roots require options.scheduleMicrotask when the host has no global queueMicrotask.',
 		);
 	}
-	return new UniversalRootImpl(container, driver, options.transport ?? null, scheduleMicrotask);
+	const root = new UniversalRootImpl(
+		container,
+		driver,
+		options.transport ?? null,
+		scheduleMicrotask,
+	);
+	registerUniversalRootErrorHandlers(root, options);
+	return root;
 }
 
 function readGlobalMicrotaskScheduler(): ((callback: () => void) => void) | undefined {

--- a/packages/octane/tests/_fixtures/root-error-callbacks.tsrx
+++ b/packages/octane/tests/_fixtures/root-error-callbacks.tsrx
@@ -43,6 +43,58 @@ function throwOnMount(): string {
 	throw new Error('mount-boom');
 }
 
+// Teardown-phase throwers: a passive-effect cleanup and a callback-ref cleanup
+// that throw during deletion. Deletion-phase errors route to the enclosing
+// boundary when one exists; otherwise they are the uncaught teardown channel.
+function CleanupThrower() @{
+	useEffect(() => {
+		return () => {
+			throw new Error('cleanup-boom');
+		};
+	}, []);
+	<span id="ct">ct</span>
+}
+
+export function CleanupHost() @{
+	<main>
+		<CleanupThrower />
+	</main>
+}
+
+let removeCleanupThrower: (() => void) | null = null;
+export function triggerCleanupThrowerRemoval(): void {
+	removeCleanupThrower!();
+}
+
+export function CaughtCleanupHost() @{
+	const [on, setOn] = useState(true);
+	removeCleanupThrower = () => setOn(false);
+	<ErrorBoundary fallback="cleanup-caught">
+		@if (on) {
+			<CleanupThrower />
+		} @else {
+			<span id="off">off</span>
+		}
+	</ErrorBoundary>
+}
+
+function RefThrower() @{
+	<span
+		id="rt"
+		ref={(_el) => {
+			return () => {
+				throw new Error('ref-boom');
+			};
+		}}
+	/>
+}
+
+export function RefCleanupHost() @{
+	<main>
+		<RefThrower />
+	</main>
+}
+
 // Interactive recovery probe: a recovered root must keep its container's event
 // delegation, so a click on freshly rendered content still reaches handlers.
 export function ClickCounter() @{

--- a/packages/octane/tests/_fixtures/root-error-callbacks.tsrx
+++ b/packages/octane/tests/_fixtures/root-error-callbacks.tsrx
@@ -46,7 +46,7 @@ function throwOnMount(): string {
 // Teardown-phase throwers: a passive-effect cleanup and a callback-ref cleanup
 // that throw during deletion. Deletion-phase errors route to the enclosing
 // boundary when one exists; otherwise they are the uncaught teardown channel.
-function CleanupThrower() @{
+export function CleanupThrower() @{
 	useEffect(() => {
 		return () => {
 			throw new Error('cleanup-boom');

--- a/packages/octane/tests/conformance/untrusted-url.test.ts
+++ b/packages/octane/tests/conformance/untrusted-url.test.ts
@@ -344,11 +344,16 @@ describe('conformance: ReactDOMServerIntegrationUntrustedURL', () => {
 			as: 'image',
 			src: UNSAFE_URL,
 		});
-		const coercionClientHints = Array.from(
-			document.head.querySelectorAll('[data-oct-hint]'),
-		).filter((element) =>
-			element.getAttribute('data-oct-hint')?.includes('https://safe.example/client-'),
-		);
+		const coercionClientHints = [
+			...Array.from(document.head.querySelectorAll('[data-oct-hint]')).filter((element) =>
+				element.getAttribute('data-oct-hint')?.includes('https://safe.example/client-'),
+			),
+			// preinit(as: 'style') is a stylesheet RESOURCE (it shares the Float
+			// identity model), so its tag carries data-precedence, not a hint key.
+			...Array.from(
+				document.head.querySelectorAll('link[rel="stylesheet"][data-precedence]'),
+			).filter((element) => element.getAttribute('href')?.includes('https://safe.example/client-')),
+		];
 		try {
 			expect(clientPreload.calls()).toBe(1);
 			expect(clientPreinit.calls()).toBe(1);

--- a/packages/octane/tests/hydration/_fixtures/nested-head.tsrx
+++ b/packages/octane/tests/hydration/_fixtures/nested-head.tsrx
@@ -1,0 +1,22 @@
+// React 19 hoists document metadata from ANYWHERE in the tree. Octane's client
+// compiler already partitions nested <title>/<meta>/<link> (and Float
+// resources) out of host elements; the server must serialize the same
+// partition instead of rejecting the nesting.
+export function NestedHead(props: { title: string }) @{
+	<section id="nested-host">
+		<title>{props.title as string}</title>
+		<meta name="desc" content="nested" />
+		<link rel="stylesheet" href="/nested.css" precedence="default" />
+		<div class="inner">{'body' as string}</div>
+	</section>
+}
+
+// Deeper nesting: metadata two hosts down, beside dynamic content.
+export function DeepNestedHead() @{
+	<main id="deep-host">
+		<article>
+			<meta name="deep" content="two-levels" />
+			<p class="deep-p">{'deep' as string}</p>
+		</article>
+	</main>
+}

--- a/packages/octane/tests/hydration/nested-head.test.ts
+++ b/packages/octane/tests/hydration/nested-head.test.ts
@@ -1,0 +1,77 @@
+// React 19 hoists <title>/<meta>/<link> (and Float resources) from anywhere in
+// the tree. The client compiler has always partitioned nested metadata out of
+// host elements; the server previously rejected the nesting with a compile
+// error, leaving the contract asymmetric. Both sides now serialize/hoist the
+// same partition: metadata renders into the head channel, the host body keeps
+// only its real children, and hydration adopts without mismatch warnings.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { hydrateRoot, flushSync, resetFloatResourceState } from '../../src/index.js';
+import * as ServerRT from 'octane/server';
+import { loadServerFixture } from '../_server-fixture.js';
+import { NestedHead, DeepNestedHead } from './_fixtures/nested-head.tsrx';
+
+const srv = loadServerFixture(
+	'packages/octane/tests/hydration/_fixtures/nested-head.tsrx',
+) as Record<string, any>;
+
+describe('nested-under-host document metadata', () => {
+	let container: HTMLElement;
+	let errSpy: ReturnType<typeof vi.spyOn>;
+	beforeEach(() => {
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+	});
+	afterEach(() => {
+		container.remove();
+		document.head
+			.querySelectorAll('[data-precedence], [data-oct-res], [data-oct-hint]')
+			.forEach((el) => el.remove());
+		resetFloatResourceState();
+		errSpy.mockRestore();
+	});
+
+	it('server-renders nested metadata into the head channel, not the host body', async () => {
+		const r = await ServerRT.renderToString(srv.NestedHead, { title: 'Nested Title' });
+		// Metadata and the resource landed in the (folded) head output…
+		expect(r.html).toContain('<title');
+		expect(r.html).toContain('Nested Title');
+		expect(r.html).toContain('name="desc"');
+		expect(r.html).toContain('data-precedence="default"');
+		// …and the host body carries only its real child.
+		const bodyStart = r.html.indexOf('<section');
+		const body = r.html.slice(bodyStart);
+		expect(body).toContain('class="inner"');
+		expect(body).not.toContain('<title');
+		expect(body).not.toContain('<meta');
+		expect(body).not.toContain('rel="stylesheet"');
+	});
+
+	it('hoists metadata nested two hosts deep', async () => {
+		const r = await ServerRT.renderToString(srv.DeepNestedHead, {});
+		expect(r.html).toContain('name="deep"');
+		const bodyStart = r.html.indexOf('<main');
+		expect(r.html.slice(bodyStart)).not.toContain('<meta');
+		expect(r.html.slice(bodyStart)).toContain('class="deep-p"');
+	});
+
+	it('hydration adopts the nested-metadata host without mismatch warnings', async () => {
+		const r = await ServerRT.renderToString(srv.NestedHead, { title: 'Nested Title' });
+		// Land the head channel in the document head and the body in the container,
+		// the way a served page arrives.
+		const bodyStart = r.html.indexOf('<section');
+		document.head.insertAdjacentHTML('beforeend', r.html.slice(0, bodyStart));
+		container.innerHTML = r.html.slice(bodyStart);
+		hydrateRoot(container, NestedHead, { title: 'Nested Title' });
+		flushSync(() => {});
+		const warns = errSpy.mock.calls.map((c) => String(c[0]));
+		expect(warns.filter((m) => m.includes('hydration mismatch'))).toEqual([]);
+		expect(container.querySelector('.inner')).not.toBeNull();
+		expect(container.querySelector('title, meta, link')).toBeNull();
+		// One stylesheet resource, adopted rather than duplicated.
+		expect(
+			document.head.querySelectorAll('link[rel="stylesheet"][href="/nested.css"]'),
+		).toHaveLength(1);
+		expect(document.head.querySelectorAll('meta[name="desc"]')).toHaveLength(1);
+	});
+});

--- a/packages/octane/tests/hydration/nested-head.test.ts
+++ b/packages/octane/tests/hydration/nested-head.test.ts
@@ -5,7 +5,7 @@
 // same partition: metadata renders into the head channel, the host body keeps
 // only its real children, and hydration adopts without mismatch warnings.
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { hydrateRoot, flushSync, resetFloatResourceState } from '../../src/index.js';
+import { createRoot, hydrateRoot, flushSync, resetFloatResourceState } from '../../src/index.js';
 import * as ServerRT from 'octane/server';
 import { loadServerFixture } from '../_server-fixture.js';
 import { NestedHead, DeepNestedHead } from './_fixtures/nested-head.tsrx';
@@ -53,6 +53,43 @@ describe('nested-under-host document metadata', () => {
 		const bodyStart = r.html.indexOf('<main');
 		expect(r.html.slice(bodyStart)).not.toContain('<meta');
 		expect(r.html.slice(bodyStart)).toContain('class="deep-p"');
+	});
+
+	it('client-only render mounts nested metadata into document.head, owned and removable', () => {
+		const root = createRoot(container);
+		root.render(NestedHead, { title: 'Client Title' });
+		flushSync(() => {});
+		// The metadata mounted out-of-band; the host body holds only real children.
+		expect(document.head.querySelector('title')?.textContent).toBe('Client Title');
+		expect(document.head.querySelector('meta[name="desc"]')).not.toBeNull();
+		expect(
+			document.head.querySelectorAll('link[rel="stylesheet"][href="/nested.css"]'),
+		).toHaveLength(1);
+		expect(container.querySelector('title, meta, link')).toBeNull();
+		expect(container.querySelector('.inner')).not.toBeNull();
+		// Reactive: the title tracks its expression.
+		root.render(NestedHead, { title: 'Updated Title' });
+		flushSync(() => {});
+		expect(document.head.querySelector('title')?.textContent).toBe('Updated Title');
+		// Per-site metadata is removed with its owning scope; the Float resource
+		// persists (resources are never removed).
+		root.unmount();
+		expect(document.head.querySelector('meta[name="desc"]')).toBeNull();
+		expect(
+			document.head.querySelectorAll('link[rel="stylesheet"][href="/nested.css"]'),
+		).toHaveLength(1);
+		document.head.querySelector('title')?.remove();
+	});
+
+	it('client-only render hoists metadata nested two hosts deep', () => {
+		const root = createRoot(container);
+		root.render(DeepNestedHead, {});
+		flushSync(() => {});
+		expect(document.head.querySelector('meta[name="deep"]')).not.toBeNull();
+		expect(container.querySelector('meta')).toBeNull();
+		expect(container.querySelector('.deep-p')).not.toBeNull();
+		root.unmount();
+		expect(document.head.querySelector('meta[name="deep"]')).toBeNull();
 	});
 
 	it('hydration adopts the nested-metadata host without mismatch warnings', async () => {

--- a/packages/octane/tests/react-hosted/octane-compat-ssr.test.ts
+++ b/packages/octane/tests/react-hosted/octane-compat-ssr.test.ts
@@ -522,15 +522,19 @@ describe('octane/react/server — buffered SSR + client hydration (§9.3)', () =
 		expect(html).toContain('rgb(1, 2, 3)');
 	});
 
-	it('rejects hoisted head content from islands (§9.2 v1) — at server COMPILE time', () => {
-		// The server compiler already refuses body-hoisted <title>/<meta>/<link>,
-		// so the case cannot reach the hosted renderer; the runtime head guard in
-		// octane/react/server stays as defense in depth.
+	it('rejects hoisted head content from islands (§9.2 v1) — at hosted-render time', () => {
+		// Head hoisting (from any depth) is a supported server feature now, so the
+		// compiler accepts the fixture; the §9.2 v1 policy is enforced by
+		// octane/react/server's runtime guard when an island's head channel is
+		// non-empty during React SSR.
+		const hoister = loadServerFixture(
+			join(process.cwd(), 'packages/octane/tests/react-hosted/_fixtures/ssr-head-hoister.tsrx'),
+		) as Record<string, any>;
 		expect(() =>
-			loadServerFixture(
-				join(process.cwd(), 'packages/octane/tests/react-hosted/_fixtures/ssr-head-hoister.tsrx'),
+			reactRenderToString(
+				h('main', null, h(OctaneCompatServer, null, h(hoister.SsrHeadHoister, null))) as any,
 			),
-		).toThrow(/does not support node type HeadHoist/);
+		).toThrow(/cannot hoist <title>\/<meta>\/<link>/);
 	});
 });
 

--- a/packages/octane/tests/resource-hints.test.ts
+++ b/packages/octane/tests/resource-hints.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import {
 	preload,
 	preinit,
@@ -6,6 +6,7 @@ import {
 	preinitModule,
 	preconnect,
 	prefetchDNS,
+	resetFloatResourceState,
 } from '../src/index.js';
 import * as Server from 'octane/server';
 
@@ -14,7 +15,10 @@ import * as Server from 'octane/server';
 // shared data-oct-hint key lets a hydrating client dedupe against SSR output.
 
 afterEach(() => {
-	document.head.querySelectorAll('[data-oct-hint]').forEach((el) => el.remove());
+	document.head
+		.querySelectorAll('[data-oct-hint], [data-precedence], [data-oct-res]')
+		.forEach((el) => el.remove());
+	resetFloatResourceState();
 });
 
 describe('resource hints — client', () => {
@@ -59,6 +63,87 @@ describe('resource hints — client', () => {
 		expect(document.head.querySelector('link[href="/styles.mjs"]')).toBeNull();
 	});
 
+	it('preinit style/script share Float resource identity (upgrade semantics, one-way)', () => {
+		// preinit(style) is a stylesheet resource: precedence-grouped and deduped
+		// against the <link rel="stylesheet" precedence> form.
+		preinit('/shared.css', { as: 'style' });
+		const sheet = document.head.querySelector('link[rel="stylesheet"][href="/shared.css"]');
+		expect(sheet).not.toBeNull();
+		expect(sheet!.getAttribute('data-precedence')).toBe('default');
+		preinit('/shared.css', { as: 'style' }); // deduped
+		expect(
+			document.head.querySelectorAll('link[rel="stylesheet"][href="/shared.css"]'),
+		).toHaveLength(1);
+		// A later preload for the initialized sheet adds nothing.
+		preload('/shared.css', { as: 'style' });
+		expect(document.head.querySelector('link[rel="preload"][href="/shared.css"]')).toBeNull();
+		// The reverse order keeps both tags (preload first, then the real sheet).
+		preload('/other.css', { as: 'style' });
+		preinit('/other.css', { as: 'style' });
+		expect(document.head.querySelector('link[rel="preload"][href="/other.css"]')).not.toBeNull();
+		expect(
+			document.head.querySelectorAll('link[rel="stylesheet"][href="/other.css"]'),
+		).toHaveLength(1);
+
+		// preinit(script) is a script resource; a later script preload is a no-op.
+		preinit('/boot.js', { as: 'script' });
+		const script = document.head.querySelector('script[src="/boot.js"]');
+		expect(script).not.toBeNull();
+		expect((script as HTMLScriptElement).async).toBe(true);
+		preload('/boot.js', { as: 'script' });
+		expect(document.head.querySelector('link[rel="preload"][href="/boot.js"]')).toBeNull();
+	});
+
+	it('preinit style accepts a precedence option and joins that group', () => {
+		preinit('/grouped.css', { as: 'style', precedence: 'high' });
+		const sheet = document.head.querySelector('link[href="/grouped.css"]')!;
+		expect(sheet.getAttribute('data-precedence')).toBe('high');
+	});
+
+	it('preloadModule after preinitModule is a no-op', () => {
+		preinitModule('/mod.mjs');
+		preloadModule('/mod.mjs');
+		expect(document.head.querySelector('link[rel="modulepreload"][href="/mod.mjs"]')).toBeNull();
+		expect(document.head.querySelectorAll('script[src="/mod.mjs"]')).toHaveLength(1);
+	});
+
+	it('image preloads with imageSrcSet key on the srcset, not the href', () => {
+		preload('/hero.png', { as: 'image', imageSrcSet: '/hero@1x.png 1x, /hero@2x.png 2x' });
+		preload('/hero.png', { as: 'image', imageSrcSet: '/hero-wide@1x.png 1x' });
+		// Same href, different srcsets → two distinct preloads.
+		expect(document.head.querySelectorAll('link[rel="preload"][as="image"]')).toHaveLength(2);
+		// Same srcset again (different href) → deduped.
+		preload('/hero-alt.png', { as: 'image', imageSrcSet: '/hero-wide@1x.png 1x' });
+		expect(document.head.querySelectorAll('link[rel="preload"][as="image"]')).toHaveLength(2);
+		const first = document.head.querySelector(
+			'link[imagesrcset="/hero@1x.png 1x, /hero@2x.png 2x"]',
+		);
+		expect(first).not.toBeNull();
+	});
+
+	it('serializes fetchPriority and media through their canonical attributes', () => {
+		preload('/late.css', { as: 'style', fetchPriority: 'low', media: 'print' });
+		const l = document.head.querySelector('link[rel="preload"][href="/late.css"]')!;
+		expect(l.getAttribute('fetchpriority')).toBe('low');
+		expect(l.getAttribute('media')).toBe('print');
+	});
+
+	it('dev-warns on malformed options and stays a no-op', () => {
+		const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			preload('/nope.woff2', {} as any); // missing `as`
+			preinit('/nope.js', { as: 'font' } as any); // invalid preinit destination
+			preload('', { as: 'style' }); // empty href
+			expect(document.head.querySelector('link[href="/nope.woff2"]')).toBeNull();
+			expect(document.head.querySelector('[href="/nope.js"]')).toBeNull();
+			const warns = errSpy.mock.calls.map((c) => String(c[0]));
+			expect(warns.some((m) => m.includes('preload') && m.includes('as'))).toBe(true);
+			expect(warns.some((m) => m.includes('preinit'))).toBe(true);
+		} finally {
+			errSpy.mockRestore();
+		}
+	});
+
 	it('preconnect and prefetchDNS insert their links once', () => {
 		preconnect('https://cdn.example.com');
 		preconnect('https://cdn.example.com');
@@ -100,6 +185,24 @@ describe('resource hints — server', () => {
 		expect(
 			document.head.querySelectorAll('link[rel="dns-prefetch"][href="https://dns.example.com"]'),
 		).toHaveLength(1);
+	});
+
+	it('SSR mirrors the unified identity and image keying', async () => {
+		const App = () => {
+			Server.preinit('/srv.css', { as: 'style', precedence: 'low' });
+			Server.preload('/srv.css', { as: 'style' }); // no-op after init
+			Server.preinit('/srv.js', { as: 'script' });
+			Server.preload('/srv.js', { as: 'script' }); // no-op after init
+			Server.preload('/pic.png', { as: 'image', imageSrcSet: '/pic@2x.png 2x' });
+			Server.preload('/pic-alt.png', { as: 'image', imageSrcSet: '/pic@2x.png 2x' }); // same srcset → deduped
+			return Server.createElement('div', null, 'x') as any;
+		};
+		const r = await Server.renderToString(App as any);
+		expect(r.html.match(/rel="preload"/g) || []).toHaveLength(1); // only the image preload
+		expect(r.html).toContain('data-precedence="low"');
+		expect(r.html.match(/\/srv\.css/g) || []).toHaveLength(1);
+		expect(r.html).toContain('src="/srv.js"');
+		expect(r.html.match(/imagesrcset/g) || []).toHaveLength(1);
 	});
 
 	it('module hints fold into head output and share the client dedupe key', async () => {

--- a/packages/octane/tests/root-error-callbacks.test.ts
+++ b/packages/octane/tests/root-error-callbacks.test.ts
@@ -19,8 +19,12 @@ import {
 	UncaughtEffectHost,
 	MountThrower,
 	ClickCounter,
+	CleanupHost,
+	CaughtCleanupHost,
+	RefCleanupHost,
 	triggerRenderThrow,
 	triggerEffectThrow,
+	triggerCleanupThrowerRemoval,
 } from './_fixtures/root-error-callbacks.tsrx';
 
 describe('root error callbacks — onCaughtError / onUncaughtError', () => {
@@ -172,6 +176,51 @@ describe('root error callbacks — onCaughtError / onUncaughtError', () => {
 	it('control: a hydration render error without the option still throws', () => {
 		container.innerHTML = '<div>server</div>';
 		expect(() => hydrateRoot(container, MountThrower, {})).toThrow('mount-boom');
+	});
+
+	it('onUncaughtError consumes a passive-cleanup throw during root unmount', async () => {
+		const onUncaughtError = vi.fn();
+		const root = createRoot(container, { onUncaughtError });
+		await act(() => root.render(CleanupHost, {}));
+		errSpy.mockClear();
+		await act(() => root.unmount());
+		expect(onUncaughtError).toHaveBeenCalledTimes(1);
+		expect((onUncaughtError.mock.calls[0][0] as Error).message).toBe('cleanup-boom');
+		expect(errSpy).not.toHaveBeenCalled();
+	});
+
+	it('onCaughtError fires when a boundary claims a deletion-phase cleanup throw', async () => {
+		const onCaughtError = vi.fn();
+		const root = createRoot(container, { onCaughtError });
+		await act(() => root.render(CaughtCleanupHost, {}));
+		expect(container.querySelector('#ct')).not.toBeNull();
+		await act(() => triggerCleanupThrowerRemoval());
+		// The deletion's enclosing boundary claimed the error (existing routing)…
+		expect(container.textContent).toBe('cleanup-caught');
+		// …and the root's reporting callback observed the claim.
+		expect(onCaughtError).toHaveBeenCalledTimes(1);
+		expect((onCaughtError.mock.calls[0][0] as Error).message).toBe('cleanup-boom');
+		root.unmount();
+	});
+
+	it('onUncaughtError consumes a ref-cleanup throw during root unmount', async () => {
+		const onUncaughtError = vi.fn();
+		const root = createRoot(container, { onUncaughtError });
+		await act(() => root.render(RefCleanupHost, {}));
+		errSpy.mockClear();
+		await act(() => root.unmount());
+		expect(onUncaughtError).toHaveBeenCalledTimes(1);
+		expect((onUncaughtError.mock.calls[0][0] as Error).message).toBe('ref-boom');
+		expect(errSpy).not.toHaveBeenCalled();
+	});
+
+	it('control: teardown throws without the options keep console.error', async () => {
+		const root = createRoot(container);
+		await act(() => root.render(CleanupHost, {}));
+		errSpy.mockClear();
+		await act(() => root.unmount());
+		expect(errSpy).toHaveBeenCalled();
+		expect((errSpy.mock.calls[0][0] as Error).message).toBe('cleanup-boom');
 	});
 
 	// ── Controls: roots WITHOUT the options keep the existing contract ──────────

--- a/packages/octane/tests/root-error-callbacks.test.ts
+++ b/packages/octane/tests/root-error-callbacks.test.ts
@@ -11,7 +11,14 @@
 // Roots created WITHOUT the options keep today's behavior byte-for-byte; the
 // control tests below pin that.
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { act, createRoot, hydrateRoot, flushSync } from '../src/index.js';
+import {
+	act,
+	createRoot,
+	createContext,
+	createElement,
+	hydrateRoot,
+	flushSync,
+} from '../src/index.js';
 import {
 	CaughtHost,
 	UncaughtHost,
@@ -19,6 +26,7 @@ import {
 	UncaughtEffectHost,
 	MountThrower,
 	ClickCounter,
+	CleanupThrower,
 	CleanupHost,
 	CaughtCleanupHost,
 	RefCleanupHost,
@@ -212,6 +220,29 @@ describe('root error callbacks — onCaughtError / onUncaughtError', () => {
 		expect(onUncaughtError).toHaveBeenCalledTimes(1);
 		expect((onUncaughtError.mock.calls[0][0] as Error).message).toBe('ref-boom');
 		expect(errSpy).not.toHaveBeenCalled();
+	});
+
+	it('onUncaughtError consumes a cleanup throw from a Provider children-dialect flip', async () => {
+		// A Provider whose `children` prop flips between a value (element) and a
+		// function tears the outgoing dialect down MID-RENDER through its own
+		// teardown bracket — that path must thread the owner exactly like a
+		// normal unmount.
+		const onUncaughtError = vi.fn();
+		const root = createRoot(container, { onUncaughtError });
+		const Ctx = createContext(0);
+		const App = (props: any) =>
+			createElement(Ctx as any, {
+				value: 1,
+				children: props.fn ? () => null : createElement(CleanupThrower as any, {}),
+			});
+		await act(() => root.render(App as any, { fn: false }));
+		expect(container.textContent).toBe('ct');
+		errSpy.mockClear();
+		await act(() => root.render(App as any, { fn: true }));
+		expect(onUncaughtError).toHaveBeenCalledTimes(1);
+		expect((onUncaughtError.mock.calls[0][0] as Error).message).toBe('cleanup-boom');
+		expect(errSpy).not.toHaveBeenCalled();
+		root.unmount();
 	});
 
 	it('control: teardown throws without the options keep console.error', async () => {

--- a/packages/octane/tests/static-prerender-stream.test.ts
+++ b/packages/octane/tests/static-prerender-stream.test.ts
@@ -1,0 +1,67 @@
+// React's react-dom/static `prerenderToNodeStream` adapted to Octane: the
+// promise resolves only after the await-everything render fully completes
+// (identical suspension semantics to `prerender`), and `prelude` is a Node
+// Readable carrying the complete document bytes — deduped scoped-style tags
+// first, then the folded html — byte-identical to the buffered `prerender`'s
+// `css + html`. There is no `postponed` field: Octane has no postpone/resume
+// protocol (a documented non-goal), and no `{ prelude }`-with-holes shape.
+import { describe, it, expect } from 'vitest';
+import * as Server from 'octane/server';
+import { prerender, prerenderToNodeStream } from 'octane/static';
+import { loadServerFixture } from './_server-fixture.js';
+
+async function collect(stream: AsyncIterable<unknown>): Promise<string> {
+	let out = '';
+	for await (const chunk of stream) out += String(chunk);
+	return out;
+}
+
+function deferred<T>() {
+	let resolve!: (v: T) => void;
+	const promise = new Promise<T>((res) => {
+		resolve = res;
+	});
+	return { promise, resolve };
+}
+
+describe('octane/static — prerenderToNodeStream', () => {
+	it('resolves only after every use(thenable) settles; prelude carries the full document', async () => {
+		const d = deferred<string>();
+		const App = () => {
+			const v = Server.use(d.promise);
+			return Server.createElement('div', { id: 'app' }, String(v)) as any;
+		};
+		const pending = prerenderToNodeStream(App as any);
+		let settled = false;
+		void pending.then(() => {
+			settled = true;
+		});
+		await new Promise((r) => setTimeout(r, 0));
+		expect(settled).toBe(false); // still awaiting the thenable
+		d.resolve('done');
+		const { prelude } = await pending;
+		const bytes = await collect(prelude as AsyncIterable<unknown>);
+		expect(bytes).toContain('id="app"');
+		expect(bytes).toContain('done');
+	});
+
+	it('prelude bytes equal the buffered prerender css + html (scoped styles first)', async () => {
+		const srv = loadServerFixture(
+			'packages/octane/tests/_fixtures/float-resources.tsrx',
+		) as Record<string, any>;
+		const buffered = await prerender(srv.ScopedControl, {});
+		expect(buffered.css).not.toBe(''); // the fixture carries scoped CSS
+		const { prelude } = await prerenderToNodeStream(srv.ScopedControl, {});
+		const bytes = await collect(prelude as AsyncIterable<unknown>);
+		expect(bytes).toBe(buffered.css + buffered.html);
+	});
+
+	it('an aborted signal rejects like prerender', async () => {
+		const controller = new AbortController();
+		controller.abort(new Error('static-abort'));
+		const App = () => Server.createElement('div', null, 'x') as any;
+		await expect(
+			prerenderToNodeStream(App as any, undefined, { signal: controller.signal }),
+		).rejects.toThrow('static-abort');
+	});
+});

--- a/packages/octane/tests/universal-scheduling.test.ts
+++ b/packages/octane/tests/universal-scheduling.test.ts
@@ -17,6 +17,7 @@ import {
 	use,
 	useContext,
 	useDeferredValue,
+	useEffect,
 	useLayoutEffect,
 	useMemo,
 	useReducer,
@@ -86,7 +87,12 @@ function controlledObjectRoot() {
 	};
 }
 
-function controlledTransportObjectRoot() {
+interface RootErrorCallbackOptions {
+	onCaughtError?: (error: unknown) => void;
+	onUncaughtError?: (error: unknown) => void;
+}
+
+function controlledTransportObjectRoot(rootOptions: RootErrorCallbackOptions = {}) {
 	const container = createObjectContainer();
 	const objectDriver = createObjectDriver();
 	const driver = {
@@ -130,6 +136,7 @@ function controlledTransportObjectRoot() {
 		scheduleMicrotask(callback) {
 			scheduled.push(callback);
 		},
+		...rootOptions,
 	});
 	return {
 		container,
@@ -1144,5 +1151,300 @@ describe('universal transition scheduling', () => {
 		await drainMicrotasks();
 		expect(values(container)).toEqual({ pending: false });
 		root.unmount();
+	});
+});
+
+// React 19 parity for universal roots: createUniversalRoot accepts onCaughtError
+// and onUncaughtError, mirroring the DOM runtime's createRoot options. The
+// callbacks replace or accompany reports only — recovery, retry, and committed
+// content stay exactly as without the options.
+describe('universal root error callbacks', () => {
+	function errorCallbackRoot(rootOptions: RootErrorCallbackOptions = {}) {
+		const container = createObjectContainer();
+		const scheduled: Array<() => void> = [];
+		const root = createUniversalRoot(container, createObjectDriver(), {
+			scheduleMicrotask(callback) {
+				scheduled.push(callback);
+			},
+			...rootOptions,
+		});
+		return {
+			container,
+			root,
+			flushNext() {
+				const callback = scheduled.shift();
+				if (callback === undefined) throw new Error('Expected scheduled universal work.');
+				callback();
+			},
+			flushAll() {
+				for (let count = 0; scheduled.length > 0; count++) {
+					if (count === 50) throw new Error('Controlled universal scheduler did not stabilize.');
+					scheduled.shift()!();
+				}
+			},
+		};
+	}
+
+	function failableScene() {
+		const handles = { fail: () => {}, recover: () => {} };
+		const Scene = defineUniversalComponent('object', () => {
+			const [bad, setBad] = useState(false, 'bad');
+			handles.fail = () => setBad(true);
+			handles.recover = () => setBad(false);
+			if (bad) throw new Error('scheduled render failed');
+			return node('content', 'ready');
+		});
+		return { Scene, handles };
+	}
+
+	it('onUncaughtError consumes an unhandled scheduled render error and keeps the root recoverable', () => {
+		const errors: unknown[] = [];
+		const { Scene, handles } = failableScene();
+		const { container, root, flushAll } = errorCallbackRoot({
+			onUncaughtError: (error) => errors.push(error),
+		});
+
+		root.render(Scene, undefined);
+		expect(values(container)).toEqual({ content: 'ready' });
+
+		handles.fail();
+		expect(flushAll).not.toThrow();
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toMatchObject({ message: 'scheduled render failed' });
+		// The failed attempt is discarded exactly as without the option: committed
+		// content survives and the root stays live for later updates.
+		expect(values(container)).toEqual({ content: 'ready' });
+
+		handles.recover();
+		flushAll();
+		expect(errors).toHaveLength(1);
+		expect(values(container)).toEqual({ content: 'ready' });
+		root.unmount();
+	});
+
+	it('an unhandled scheduled render error still rethrows from the scheduled flush by default', () => {
+		const { Scene, handles } = failableScene();
+		const { container, root, flushNext } = errorCallbackRoot();
+
+		root.render(Scene, undefined);
+		handles.fail();
+		expect(() => flushNext()).toThrow('scheduled render failed');
+		expect(values(container)).toEqual({ content: 'ready' });
+		root.unmount();
+	});
+
+	it('a direct render() call still throws an unhandled render error to its caller', () => {
+		const errors: unknown[] = [];
+		const Bad = defineUniversalComponent('object', (): UniversalRenderable => {
+			throw new Error('mount render failed');
+		});
+		const { root } = errorCallbackRoot({
+			onUncaughtError: (error) => errors.push(error),
+		});
+
+		// The thrown attempt is render()/prepare()'s documented result channel, so
+		// a direct caller keeps observing it even with onUncaughtError registered.
+		expect(() => root.render(Bad, undefined)).toThrow('mount render failed');
+		expect(errors).toEqual([]);
+		root.unmount();
+	});
+
+	it('onCaughtError reports a render error a universalTry catch arm claims, once per claim', () => {
+		const caught: unknown[] = [];
+		const uncaught: unknown[] = [];
+		const Boundary = defineUniversalComponent('object', () =>
+			universalTry(
+				(): UniversalRenderable => {
+					throw new Error('boundary render failed');
+				},
+				null,
+				(error) => node('caught', (error as Error).message),
+			),
+		);
+		const { container, root } = errorCallbackRoot({
+			onCaughtError: (error) => caught.push(error),
+			onUncaughtError: (error) => uncaught.push(error),
+		});
+
+		root.render(Boundary, undefined);
+		expect(values(container)).toEqual({ caught: 'boundary render failed' });
+		expect(caught).toHaveLength(1);
+		expect(caught[0]).toMatchObject({ message: 'boundary render failed' });
+		expect(uncaught).toEqual([]);
+
+		// Re-rendering while the claimed error is still active replays the catch
+		// arm without a second report.
+		root.render(Boundary, undefined);
+		expect(values(container)).toEqual({ caught: 'boundary render failed' });
+		expect(caught).toHaveLength(1);
+		root.unmount();
+	});
+
+	it('onCaughtError reports an effect error a universalTry catch arm claims', async () => {
+		const caught: unknown[] = [];
+		const uncaught: unknown[] = [];
+		const Boundary = defineUniversalComponent('object', () =>
+			universalTry(
+				() => {
+					useEffect(
+						() => {
+							throw new Error('effect failed');
+						},
+						[],
+						'failing-effect',
+					);
+					return node('content', 'ready');
+				},
+				null,
+				(error) => node('caught', (error as Error).message),
+			),
+		);
+		const container = createObjectContainer();
+		const root = createUniversalRoot(container, createObjectDriver(), {
+			onCaughtError: (error) => caught.push(error),
+			onUncaughtError: (error) => uncaught.push(error),
+		});
+
+		root.render(Boundary, undefined);
+		expect(values(container)).toEqual({ content: 'ready' });
+		await drainMicrotasks();
+		expect(values(container)).toEqual({ caught: 'effect failed' });
+		expect(caught).toHaveLength(1);
+		expect(caught[0]).toMatchObject({ message: 'effect failed' });
+		expect(uncaught).toEqual([]);
+		root.unmount();
+	});
+
+	it('onUncaughtError consumes an unrouted effect error from the passive flush', () => {
+		const errors: unknown[] = [];
+		const Scene = defineUniversalComponent('object', () => {
+			useEffect(
+				() => {
+					throw new Error('effect failed');
+				},
+				[],
+				'exploding-effect',
+			);
+			return node('content', 'ready');
+		});
+		const { container, root, flushAll } = errorCallbackRoot({
+			onUncaughtError: (error) => errors.push(error),
+		});
+
+		root.render(Scene, undefined);
+		expect(flushAll).not.toThrow();
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toMatchObject({ message: 'effect failed' });
+		expect(values(container)).toEqual({ content: 'ready' });
+		root.unmount();
+	});
+
+	it('an unrouted effect error still rethrows from the passive flush by default', () => {
+		const Scene = defineUniversalComponent('object', () => {
+			useEffect(
+				() => {
+					throw new Error('effect failed');
+				},
+				[],
+				'exploding-effect',
+			);
+			return node('content', 'ready');
+		});
+		const { container, root, flushNext } = errorCallbackRoot();
+
+		root.render(Scene, undefined);
+		expect(() => flushNext()).toThrow('effect failed');
+		expect(values(container)).toEqual({ content: 'ready' });
+		root.unmount();
+	});
+
+	function failOnResumeScene() {
+		const gate = deferred<string>();
+		const handles = { failOnResume: false };
+		const Scene = defineUniversalComponent('object', () => {
+			const value = use(gate.promise);
+			if (handles.failOnResume) throw new Error('replay render failed');
+			return node('content', value);
+		});
+		return { Scene, gate, handles };
+	}
+
+	it('onUncaughtError consumes a render error thrown by a resumed suspense replay', async () => {
+		const errors: unknown[] = [];
+		const { Scene, gate, handles } = failOnResumeScene();
+		const { container, root, flushAll } = errorCallbackRoot({
+			onUncaughtError: (error) => errors.push(error),
+		});
+
+		expect(root.render(Scene, undefined).status).toBe('suspended');
+		handles.failOnResume = true;
+		gate.resolve('ready');
+		await drainMicrotasks();
+		expect(flushAll).not.toThrow();
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toMatchObject({ message: 'replay render failed' });
+		expect(values(container)).toEqual({});
+		root.unmount();
+	});
+
+	it('a render error thrown by a resumed suspense replay still rethrows by default', async () => {
+		const { Scene, gate, handles } = failOnResumeScene();
+		const { container, root, flushAll } = errorCallbackRoot();
+
+		expect(root.render(Scene, undefined).status).toBe('suspended');
+		handles.failOnResume = true;
+		gate.resolve('ready');
+		await drainMicrotasks();
+		expect(flushAll).toThrow('replay render failed');
+		expect(values(container)).toEqual({});
+		root.unmount();
+	});
+
+	it('onUncaughtError consumes a transported suspense-replay render error instead of failing flushTransport', async () => {
+		const errors: unknown[] = [];
+		const { Scene, gate, handles } = failOnResumeScene();
+		const transported = controlledTransportObjectRoot({
+			onUncaughtError: (error) => errors.push(error),
+		});
+
+		const attempt = await transported.root.renderAsync(Scene, undefined);
+		expect(attempt.status).toBe('suspended');
+		handles.failOnResume = true;
+		gate.resolve('ready');
+		await expect(transported.root.flushTransport()).resolves.toBeUndefined();
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toMatchObject({ message: 'replay render failed' });
+		await transported.root.unmountAsync();
+	});
+
+	it('onUncaughtError consumes a transported scheduled render error instead of failing flushTransport', async () => {
+		const errors: unknown[] = [];
+		const { Scene, handles } = failableScene();
+		const transported = controlledTransportObjectRoot({
+			onUncaughtError: (error) => errors.push(error),
+		});
+
+		await transported.root.renderAsync(Scene, undefined);
+		expect(values(transported.container)).toEqual({ content: 'ready' });
+
+		handles.fail();
+		transported.flushNext();
+		await expect(transported.root.flushTransport()).resolves.toBeUndefined();
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toMatchObject({ message: 'scheduled render failed' });
+		expect(values(transported.container)).toEqual({ content: 'ready' });
+		await transported.root.unmountAsync();
+	});
+
+	it('a transported scheduled render error still rejects flushTransport by default', async () => {
+		const { Scene, handles } = failableScene();
+		const transported = controlledTransportObjectRoot();
+
+		await transported.root.renderAsync(Scene, undefined);
+		handles.fail();
+		transported.flushNext();
+		await expect(transported.root.flushTransport()).rejects.toThrow('scheduled render failed');
+		expect(values(transported.container)).toEqual({ content: 'ready' });
+		await transported.root.unmountAsync();
 	});
 });


### PR DESCRIPTION
## Summary

Closes the "Implementation gaps" section of #711 (rebased onto main after #712 merged). Five gaps implemented; the sixth bullet (streaming post-shell resources) deliberately stays documented behavior per the issue.

- **Nested-under-host document metadata** — the client/server asymmetry is gone in React's direction: `<title>`/`<meta>`/`<link>` and Float resources nested inside host elements now serialize into the head channel on the server too (previously a `ssrUnsupported: HeadHoist` compile error). The nested hoist is an expression fragment in the html evaluation: the head write happens at the authored position (identical conditional timing to the client's arm-scoped `headBlock` — a hoist in an `@if` arm registers only while that arm renders), the head emit functions now return `''` so the body markup gains nothing, and the hydration cursor stays aligned with the client template. Hydration adopts with zero mismatch warnings.
- **`prerenderToNodeStream`** — `octane/static` gains the stream variant with React's semantics: resolves only after the await-everything render completes; `prelude` streams the complete document bytes (scoped-style tags, then folded html; byte-identical to buffered `prerender`'s `css + html`, pinned by test). No `postponed` field — postpone/resume stays a documented non-goal. `node:stream` loads lazily on call so edge bundles pay nothing; `headChannel: 'separate'` is ignored with a dev diagnostic.
- **Teardown errors reach the root callbacks** — effect-cleanup and ref-detach throws during unmount route through `onCaughtError` (boundary-claimed) / `onUncaughtError` (unclaimed; replaces `console.error`). Implementation threads the outermost deleted block through the existing channels: `TEARDOWN_BLOCK` beside `TEARDOWN_HANDLER`, ref-detach queue stride 3→4, deferred passive-unmount pairs→triples. Routing semantics unchanged; controls pin the no-option behavior.
- **Resource hints share the Float identity model** — `preinit(as:'style')` routes through `stylesheetResource` (honors `precedence`, default `"default"`, joins the groups, dedupes against the rendered form), `preinit(as:'script')` through `scriptResource`; `preload`/`preloadModule` after the matching init are no-ops (one-way upgrade — preload-then-init keeps both tags); image preloads with `imageSrcSet` key on the srcset+sizes pair; malformed calls (missing/invalid `as`, empty href) warn in dev and stay no-ops. Client and SSR mirrored.
- **Universal renderer root callbacks** — `onCaughtError`/`onUncaughtError` wired into `octane/universal` roots across every scheduler-owned channel (scheduled flush, transported async work, suspense replays, effect/commit callbacks), mirroring the DOM runtime's WeakMap-off-the-shape pattern. Two deliberate bounds, pinned by tests and doc comments: a direct `render()`/`renderAsync()` throw remains the documented result channel (unlike DOM's void `root.render()`, consuming it would leave nothing to return), and there is no `onRecoverableError` (the universal renderer has no hydration channel). Unclaimed event-handler errors still throw to the dispatcher (React parity).

## Why

Issue #711's implementation-gap list, i.e. everything the React 19.2 parity audit found functionally missing that wasn't already decided away. The nested-metadata fix in particular removes a compile-time trap discovered while building #709's Float fixtures.

## Changes

- `packages/octane/src/compiler/compile.js` — `HeadHoist` case in `ssrEmitNode` (nested emission as an html-expression fragment).
- `packages/octane/src/runtime.server.ts` — `prerenderToNodeStream`; head emit functions (`ssrHeadEl`, `ssrStylesheetResource`, `ssrStyleResource`, `ssrScriptResource`) return `''`; hint validation + unified identity + image keying.
- `packages/octane/src/runtime.ts` — teardown-block threading; hint validation/unification (`preinit` routes through the Float inserts, `hasHeadHint`, image-srcset keys).
- `packages/octane/src/universal-core.ts` — universal root error callbacks (`UniversalRootOptions.onCaughtError/onUncaughtError`, handler WeakMap, claim + consumption sites).
- `packages/octane/src/static/index.ts` — `prerenderToNodeStream` export + accurate module doc.
- Ledger: `ReactDOMFizzStaticNode-test.js` "should call prerenderToNodeStream" → `covered` with evidence; coverage report regenerated.
- Docs: `differences-from-react.md` (nested hoisting, teardown-error reporting, unified hint model), `docs/ssr.md` (prerenderToNodeStream implemented).
- Tests: `hydration/nested-head.test.ts` (+fixture), `static-prerender-stream.test.ts`, teardown cases in `root-error-callbacks.test.ts` (+fixture throwers), hint hardening cases in `resource-hints.test.ts`, universal callback cases in `universal-scheduling.test.ts`. Changeset included.

## Contract and hot paths

All additions are cold-path or compile-time: teardown threading adds one global write per outermost unmount and one extra queue slot per ref detach/passive unmount (teardown-only paths); the hint changes affect imperative hint calls only; the nested-head compiler case runs per authored nested-metadata element at compile time; universal handlers cost one module-null check on already-cold catch paths. The head emit functions' `void → ''` return-type change is invisible to existing compiled output (top-level emission is statement-position). No benchmarks run and none claimed — no hot path changed.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 18,583/18,585. The two failures are pre-existing load-timing flakes (the phosphor-icons differential and one `octane-events-browser` native-change case); both pass in isolation, and neither touches any changed code path.
- [x] `node scripts/react-parity/check.mjs` (full — executes the new evidence record) and `--validate-only`
- [x] targeted: `nested-head` (6), `static-prerender-stream` (6), `root-error-callbacks` (+4 teardown), `resource-hints` (30), `universal-scheduling` (86), plus sweeps: head/svg/streaming/fizz/serialization (632), compiler suites (1,127), universal-importing files (36 files / 653).
- Every behavior change was reproduced red-first: the nested-head suite failed with the exact `ssrUnsupported: HeadHoist` compile error; the teardown cases failed with zero callback invocations; the stream tests failed on the missing export; the hint cases failed 12/12; the universal agent-run cases each have recorded pre-fix failure output.
- **Self-review findings the full suite forced (all fixed before this PR):** (1) `prerenderToNodeStream`'s first implementation used `await import('node:stream')`, which broke the server runtime's **platform-neutral bundling contract** (`ssr-production-bundle.test.ts`, esbuild `platform: 'neutral'`); the `new Function` import indirection then failed under vitest's module runner ("dynamic import callback not specified"); the final form uses `process.getBuiltinModule` — a plain runtime call no bundler follows — with the non-Node failure as production error code 57. (2) The React-hosted island policy (§9.2: islands may not hoist head content) had been enforced by the very compile error this PR removes; its test now pins the `octane/react/server` runtime guard instead, which still throws at hosted-render time. (3) `untrusted-url`'s hint collector scanned `[data-oct-hint]` only; preinit-style tags now carry the Float resource markers, so the collector (and its cleanup) covers both.

- **Review-fix commit 445fa1a73** (both Bugbot findings, red-first): the client planner now lifts nested HeadHoists out of host-element walks into the plan's head list (client-only renders previously dropped nested metadata silently — the original hydration test was too weak to see it), and `resetScopeChildren` (the Provider children-dialect flip) threads `TEARDOWN_BLOCK` like the other teardown brackets. Full suite re-run: 18,626/18,639 — the 13 are the phosphor flake plus the `octane-events-browser` native-change file failing as a whole under load (12/12 in isolation, environmental).

## Risk / follow-ups

- Nested metadata inside streamed-late boundaries follows the existing documented head divergence (client re-creates on hydration) — the #711 bullet that deliberately stays documented behavior.
- The head-emit `''` return is now load-bearing for nested emission; the type change is source-visible to bindings that (incorrectly) consumed these compiler-ABI helpers directly.
- Hint identity keys changed for `preinit` (`preinit:as:href` → shared `sheet:`/`script:` namespaces): a page server-rendered by an older Octane and hydrated by this one would double-insert preinit'd tags once — acceptable on the 0.x track, noted here for the changelog.
- After merge: tick the five implementation-gap checkboxes in #711.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SSR head serialization, unmount error reporting, and resource-hint identity—areas that can affect hydration and error observability—but changes are mostly cold-path and heavily tested. Mixed-version SSR/hydrate can double-insert preinit tags due to the new shared identity keys.
> 
> **Overview**
> Closes five React 19 parity gaps from the outstanding-work issue (streaming post-shell resources stays documented behavior).
> 
> **Nested document metadata** now hoists from any depth on the server too. Nested `<title>`/`<meta>`/`<link>` and Float resources serialize into the head channel at their authored position (including conditional arms), host bodies keep only real children, and hydration adopts without mismatches.
> 
> **`prerenderToNodeStream`** lands in `octane/static`: resolves after the await-everything render and streams complete document bytes via `prelude` (scoped CSS, then folded HTML). No `postponed` field—postpone/resume remains a non-goal.
> 
> **Teardown errors** (effect cleanups and ref detaches during unmount) now report through `onCaughtError` / `onUncaughtError` with existing boundary routing unchanged. The same options are wired into **`octane/universal`** roots for scheduler-owned work; direct `render()` throws stay the documented result channel.
> 
> **Resource hints** share the Float identity model: `preinit(as:'style'|'script')` joins stylesheet/script resources (precedence, dedupe), later matching `preload`/`preloadModule` no-ops, image preloads key on srcset+sizes, and malformed calls warn in development.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 445fa1a73b244220d5b634dadd9c0cdf7927bd95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


