### PR TITLE
perf(lynx): minimize universal keyed moves

### DIFF
--- a/.changeset/lean-universal-keyed-moves.md
+++ b/.changeset/lean-universal-keyed-moves.md
@@ -1,0 +1,5 @@
+---
+'octane': patch
+---
+
+Minimize universal-renderer keyed placements with a longest-increasing-subsequence plan so distant swaps move only displaced hosts while preserving survivor identity, events, and lifecycle behavior.

--- a/benchmarks/baselines/ratios.json
+++ b/benchmarks/baselines/ratios.json
@@ -1449,6 +1449,30 @@
   },
   {
     "suite": "lynx-table",
+    "op": "swap_wire_bytes_1k",
+    "target": "octane-lynx",
+    "reference": "changed-rows-model",
+    "maxRatio": 1,
+    "note": "A keyed swap preserves every row and moves only two top-level survivors. The complete bidirectional ContextProxy traffic must stay within the issue's absolute 2 KiB budget instead of scaling with the retained table."
+  },
+  {
+    "suite": "lynx-table",
+    "op": "swap_item_renders_1k",
+    "target": "octane-lynx",
+    "reference": "changed-rows-model",
+    "maxRatio": 0.01,
+    "note": "The model's value of one is a denominator sentinel: the observed keyed swap must remain exactly zero Row body renders because no row props changed."
+  },
+  {
+    "suite": "lynx-table",
+    "op": "swap_handle_deltas_1k",
+    "target": "octane-lynx",
+    "reference": "changed-rows-model",
+    "maxRatio": 1,
+    "note": "At most the two physically moved top-level survivors may publish handle state; unchanged retained rows must not republish attachment or list-ancestry state."
+  },
+  {
+    "suite": "lynx-table",
     "op": "select_commands_1k",
     "target": "octane-lynx",
     "reference": "changed-rows-model",
@@ -1518,6 +1542,30 @@
     "reference": "changed-rows-model",
     "maxRatio": 1,
     "note": "All 10,000 freshly inserted component-owned rows share one compiled intrinsic template, so creation must remain one contiguous template-run command rather than scaling with row count."
+  },
+  {
+    "suite": "lynx-table",
+    "op": "swap_wire_bytes_10k",
+    "target": "octane-lynx",
+    "reference": "changed-rows-model",
+    "maxRatio": 1,
+    "note": "The same two-survivor keyed swap at 10,000 rows must remain within 2 KiB; a larger packet means topology or public state still scales with retained rows."
+  },
+  {
+    "suite": "lynx-table",
+    "op": "swap_item_renders_10k",
+    "target": "octane-lynx",
+    "reference": "changed-rows-model",
+    "maxRatio": 0.01,
+    "note": "The denominator sentinel pins the observed keyed swap to zero Row renders at 10,000 rows."
+  },
+  {
+    "suite": "lynx-table",
+    "op": "swap_handle_deltas_10k",
+    "target": "octane-lynx",
+    "reference": "changed-rows-model",
+    "maxRatio": 1,
+    "note": "Handle/list-ancestry publication must scale with the two moved survivors, not the 10,000 retained rows."
   },
   {
     "suite": "lynx-table",

--- a/benchmarks/lynx-table/run.mjs
+++ b/benchmarks/lynx-table/run.mjs
@@ -123,6 +123,19 @@ try {
 				create: [result.create.commands, result.create.itemRenders],
 				update10th: [result.update10th.commands, result.update10th.itemRenders],
 				select: [result.select.commands, result.select.bytes, result.select.itemRenders],
+				swap: {
+					commands: result.swap.commands,
+					itemRenders: result.swap.itemRenders,
+					wireToMainBytes: result.swap.wireToMainBytes,
+					wireToBackgroundBytes: result.swap.wireToBackgroundBytes,
+					wireToMainMessages: result.swap.wireToMainMessages,
+					wireToBackgroundMessages: result.swap.wireToBackgroundMessages,
+					commandOps: result.swap.commandOps,
+					handleOps: result.swap.handleOps,
+					messageTypes: result.swap.messageTypes,
+					identityChecksum: result.swapIdentityChecksum,
+					eventSurvived: result.swapEventSurvived,
+				},
 				updateStorm: [
 					result.updateStorm.commits,
 					result.updateStorm.commands,
@@ -143,6 +156,12 @@ try {
 			}
 		}
 		if (result === null || result.diagnostics.length !== 0) continue;
+		if (result.swap.itemRenders !== 0) {
+			failures.push(`rows=${rows}: swap re-rendered ${result.swap.itemRenders} unchanged rows.`);
+		}
+		if (!result.swapEventSurvived) {
+			failures.push(`rows=${rows}: a moved survivor lost its delegated event.`);
+		}
 
 		octaneOps[`create_commands_${suffix}`] = countStat(result.create.commands, iterations);
 		octaneOps[`update10th_commands_${suffix}`] = countStat(result.update10th.commands, iterations);
@@ -153,6 +172,23 @@ try {
 		octaneOps[`select_commands_${suffix}`] = countStat(result.select.commands, iterations);
 		octaneOps[`select_bytes_${suffix}`] = countStat(result.select.bytes, iterations);
 		octaneOps[`select_item_renders_${suffix}`] = countStat(result.select.itemRenders, iterations);
+		octaneOps[`swap_wire_bytes_${suffix}`] = countStat(
+			result.swap.wireToMainBytes + result.swap.wireToBackgroundBytes,
+			iterations,
+		);
+		octaneOps[`swap_wire_to_main_bytes_${suffix}`] = countStat(
+			result.swap.wireToMainBytes,
+			iterations,
+		);
+		octaneOps[`swap_wire_to_background_bytes_${suffix}`] = countStat(
+			result.swap.wireToBackgroundBytes,
+			iterations,
+		);
+		octaneOps[`swap_item_renders_${suffix}`] = countStat(result.swap.itemRenders, iterations);
+		octaneOps[`swap_handle_deltas_${suffix}`] = countStat(
+			Object.values(result.swap.handleOps).reduce((total, count) => total + count, 0),
+			iterations,
+		);
 		octaneOps[`update_storm_commits_${suffix}`] = countStat(result.updateStorm.commits, iterations);
 		octaneOps[`update_storm_commands_${suffix}`] = countStat(
 			result.updateStorm.commands,
@@ -181,6 +217,11 @@ try {
 		modelOps[`select_commands_${suffix}`] = countStat(2, iterations);
 		modelOps[`select_bytes_${suffix}`] = countStat(2048, iterations);
 		modelOps[`select_item_renders_${suffix}`] = countStat(2, iterations);
+		modelOps[`swap_wire_bytes_${suffix}`] = countStat(2048, iterations);
+		modelOps[`swap_wire_to_main_bytes_${suffix}`] = countStat(1024, iterations);
+		modelOps[`swap_wire_to_background_bytes_${suffix}`] = countStat(1024, iterations);
+		modelOps[`swap_item_renders_${suffix}`] = countStat(1, iterations);
+		modelOps[`swap_handle_deltas_${suffix}`] = countStat(2, iterations);
 		modelOps[`update_storm_commits_${suffix}`] = countStat(workload.STORM_UPDATE_TICKS, iterations);
 		modelOps[`update_storm_commands_${suffix}`] = countStat(
 			workload.STORM_UPDATE_TICKS * changed,
@@ -202,12 +243,31 @@ try {
 			updateStormItemRenders: result.updateStorm.itemRenders,
 			selectStormBytes: result.selectStorm.bytes,
 			selectStormItemRenders: result.selectStorm.itemRenders,
+			swap: {
+				commands: result.swap.commands,
+				commandOps: result.swap.commandOps,
+				handleOps: result.swap.handleOps,
+				messageTypes: result.swap.messageTypes,
+				wireToMainMessages: result.swap.wireToMainMessages,
+				wireToBackgroundMessages: result.swap.wireToBackgroundMessages,
+				identityChecksum: result.swapIdentityChecksum,
+				eventSurvived: result.swapEventSurvived,
+				stagesMs: {
+					selfcheck: result.swap.selfcheckMs,
+					dispatch: result.swap.dispatchMs,
+					validate: result.swap.validateMs,
+					prepare: result.swap.prepareMs,
+					apply: result.swap.applyMs,
+					ack: result.swap.ackMs,
+				},
+			},
 		};
 
 		console.log(
 			`rows=${String(rows).padStart(5)}  create=${result.create.commands} (${result.create.itemRenders}r)  ` +
 				`update10th=${result.update10th.commands} (${result.update10th.itemRenders}r)  ` +
 				`select=${result.select.commands} (${result.select.bytes}B, ${result.select.itemRenders}r)  ` +
+				`swap=${result.swap.commands} (${result.swap.wireToMainBytes + result.swap.wireToBackgroundBytes}B, ${result.swap.itemRenders}r)  ` +
 				`updateStorm=${result.updateStorm.commits}c/${result.updateStorm.commands} (${result.updateStorm.itemRenders}r)  ` +
 				`selectStorm=${result.selectStorm.commits}c/${result.selectStorm.commands} (${result.selectStorm.itemRenders}r)`,
 		);

--- a/benchmarks/lynx-table/workload.ts
+++ b/benchmarks/lynx-table/workload.ts
@@ -36,6 +36,14 @@ interface FakeNode {
 
 type Listener = (event: LynxContextProxyEvent) => void;
 
+interface WireMessageSnapshot {
+	readonly direction: 'background-to-main' | 'main-to-background';
+	readonly type: string;
+	readonly bytes: number;
+	readonly commandOps: Readonly<Record<string, number>>;
+	readonly handleOps: Readonly<Record<string, number>>;
+}
+
 /**
  * Two cross-wired synchronous ContextProxy ends. Dispatching on one end runs
  * the other end's listeners, matching the direction the real dual-thread
@@ -43,10 +51,19 @@ type Listener = (event: LynxContextProxyEvent) => void;
  * immediately: this harness measures per-commit wire cost, not the
  * backpressure coalescing an asynchronous main thread produces.
  */
-function createContextPair(): { background: LynxContextProxy; main: LynxContextProxy } {
+function createContextPair(): {
+	background: LynxContextProxy;
+	main: LynxContextProxy;
+	messages: WireMessageSnapshot[];
+} {
 	const backgroundListeners = new Map<string, Listener[]>();
 	const mainListeners = new Map<string, Listener[]>();
-	const end = (own: Map<string, Listener[]>, other: Map<string, Listener[]>): LynxContextProxy => ({
+	const messages: WireMessageSnapshot[] = [];
+	const end = (
+		own: Map<string, Listener[]>,
+		other: Map<string, Listener[]>,
+		direction: WireMessageSnapshot['direction'],
+	): LynxContextProxy => ({
 		addEventListener(type, listener) {
 			const list = own.get(type);
 			if (list === undefined) own.set(type, [listener]);
@@ -60,14 +77,44 @@ function createContextPair(): { background: LynxContextProxy; main: LynxContextP
 			if (list.length === 0) own.delete(type);
 		},
 		dispatchEvent(event) {
+			const data = event.data as {
+				type?: unknown;
+				batch?: { commands?: readonly { op?: unknown }[] };
+				handles?: readonly { op?: unknown }[];
+			};
+			const commandOps: Record<string, number> = {};
+			for (const command of data.batch?.commands ?? []) {
+				const op = typeof command.op === 'string' ? command.op : '<unknown>';
+				commandOps[op] = (commandOps[op] ?? 0) + 1;
+			}
+			const handleOps: Record<string, number> = {};
+			for (const handle of data.handles ?? []) {
+				const op = typeof handle.op === 'string' ? handle.op : '<unknown>';
+				handleOps[op] = (handleOps[op] ?? 0) + 1;
+			}
+			let bytes = 0;
+			try {
+				bytes = JSON.stringify(data).length;
+			} catch {
+				// Protocol validation owns serialization failures. The observer must
+				// not alter delivery while measuring a rejected message.
+			}
+			messages.push({
+				direction,
+				type: typeof data.type === 'string' ? data.type : '<unknown>',
+				bytes,
+				commandOps,
+				handleOps,
+			});
 			const list = other.get(event.type);
 			if (list === undefined) return;
 			for (const listener of list.slice()) listener(event);
 		},
 	});
 	return {
-		background: end(backgroundListeners, mainListeners),
-		main: end(mainListeners, backgroundListeners),
+		background: end(backgroundListeners, mainListeners, 'background-to-main'),
+		main: end(mainListeners, backgroundListeners, 'main-to-background'),
+		messages,
 	};
 }
 
@@ -171,6 +218,7 @@ interface Harness {
 	readonly main: ReturnType<typeof installLynxMainThread>;
 	readonly diagnostics: Error[];
 	readonly backgroundTarget: Record<string, unknown>;
+	readonly wireMessages: WireMessageSnapshot[];
 	dispose(): Promise<void>;
 }
 
@@ -211,6 +259,7 @@ function createHarness(): Harness {
 		root,
 		main,
 		diagnostics,
+		wireMessages: contexts.messages,
 		backgroundTarget: backgroundTarget as unknown as Record<string, unknown>,
 		async dispose() {
 			await root.unmount();
@@ -231,6 +280,12 @@ function profileSnapshot(): {
 	commands: number;
 	bytes: number;
 	itemRenders: number;
+	selfcheckMs: number;
+	dispatchMs: number;
+	validateMs: number;
+	prepareMs: number;
+	applyMs: number;
+	ackMs: number;
 } {
 	const profile = (globalThis as ProfileGlobals).__OCTANE_LYNX_PROF;
 	// Both fake threads share this realm, so the main-thread receiver also
@@ -241,6 +296,59 @@ function profileSnapshot(): {
 		commands: (profile?.commands ?? 0) / 2,
 		bytes: profile?.bytes ?? 0,
 		itemRenders: (globalThis as ProfileGlobals).__BENCH_ROW_RENDERS__ ?? 0,
+		selfcheckMs: profile?.selfcheckMs ?? 0,
+		dispatchMs: profile?.dispatchMs ?? 0,
+		validateMs: profile?.validateMs ?? 0,
+		prepareMs: profile?.prepareMs ?? 0,
+		applyMs: profile?.applyMs ?? 0,
+		ackMs: profile?.ackMs ?? 0,
+	};
+}
+
+function addCounts(target: Record<string, number>, source: Readonly<Record<string, number>>): void {
+	for (const [name, count] of Object.entries(source)) target[name] = (target[name] ?? 0) + count;
+}
+
+function summarizeWire(
+	messages: readonly WireMessageSnapshot[],
+): Pick<
+	OpCounters,
+	| 'wireToMainBytes'
+	| 'wireToBackgroundBytes'
+	| 'wireToMainMessages'
+	| 'wireToBackgroundMessages'
+	| 'commandOps'
+	| 'handleOps'
+	| 'messageTypes'
+> {
+	let wireToMainBytes = 0;
+	let wireToBackgroundBytes = 0;
+	let wireToMainMessages = 0;
+	let wireToBackgroundMessages = 0;
+	const commandOps: Record<string, number> = {};
+	const handleOps: Record<string, number> = {};
+	const messageTypes: Record<string, number> = {};
+	for (const message of messages) {
+		if (message.direction === 'background-to-main') {
+			wireToMainBytes += message.bytes;
+			wireToMainMessages++;
+		} else {
+			wireToBackgroundBytes += message.bytes;
+			wireToBackgroundMessages++;
+		}
+		addCounts(commandOps, message.commandOps);
+		addCounts(handleOps, message.handleOps);
+		const key = `${message.direction}:${message.type}`;
+		messageTypes[key] = (messageTypes[key] ?? 0) + 1;
+	}
+	return {
+		wireToMainBytes,
+		wireToBackgroundBytes,
+		wireToMainMessages,
+		wireToBackgroundMessages,
+		commandOps,
+		handleOps,
+		messageTypes,
 	};
 }
 
@@ -346,6 +454,19 @@ export interface OpCounters {
 	readonly commands: number;
 	readonly bytes: number;
 	readonly itemRenders: number;
+	readonly wireToMainBytes: number;
+	readonly wireToBackgroundBytes: number;
+	readonly wireToMainMessages: number;
+	readonly wireToBackgroundMessages: number;
+	readonly commandOps: Readonly<Record<string, number>>;
+	readonly handleOps: Readonly<Record<string, number>>;
+	readonly messageTypes: Readonly<Record<string, number>>;
+	readonly selfcheckMs: number;
+	readonly dispatchMs: number;
+	readonly validateMs: number;
+	readonly prepareMs: number;
+	readonly applyMs: number;
+	readonly ackMs: number;
 }
 
 export interface TableRunResult {
@@ -353,6 +474,9 @@ export interface TableRunResult {
 	readonly create: OpCounters;
 	readonly update10th: OpCounters;
 	readonly select: OpCounters;
+	readonly swap: OpCounters;
+	readonly swapIdentityChecksum: number;
+	readonly swapEventSurvived: boolean;
 	readonly updateStorm: OpCounters;
 	readonly selectStorm: OpCounters;
 	readonly createdElements: number;
@@ -371,17 +495,30 @@ const CREATE_BUTTON: Record<number, string> = {
 const STORM_UPDATE_TICKS = 50;
 const STORM_SELECT_TICKS = 30;
 
+function seededRandom(seed: number): () => number {
+	return () => {
+		seed |= 0;
+		seed = (seed + 0x6d2b79f5) | 0;
+		let value = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+		value = (value + Math.imul(value ^ (value >>> 7), 61 | value)) ^ value;
+		return ((value ^ (value >>> 14)) >>> 0) / 4_294_967_296;
+	};
+}
+
 /** Run the full op sequence at one scale and report per-op counter deltas. */
 export async function runTable(rows: number): Promise<TableRunResult> {
 	const createButton = CREATE_BUTTON[rows];
 	if (createButton === undefined) throw new Error(`no create button for ${rows} rows`);
 	const harness = createHarness();
+	const previousRandom = Math.random;
+	Math.random = seededRandom(0x0c7a_4e11);
 	try {
 		await harness.root.render(App, {});
 		await until(harness, () => buttonTapToken(harness.papi, createButton) !== null, 'mount', 200);
 
 		const measure = async (drive: () => Promise<void>): Promise<OpCounters> => {
 			const before = profileSnapshot();
+			const wireStart = harness.wireMessages.length;
 			await drive();
 			const after = profileSnapshot();
 			return {
@@ -389,6 +526,13 @@ export async function runTable(rows: number): Promise<TableRunResult> {
 				commands: after.commands - before.commands,
 				bytes: after.bytes - before.bytes,
 				itemRenders: after.itemRenders - before.itemRenders,
+				...summarizeWire(harness.wireMessages.slice(wireStart)),
+				selfcheckMs: after.selfcheckMs - before.selfcheckMs,
+				dispatchMs: after.dispatchMs - before.dispatchMs,
+				validateMs: after.validateMs - before.validateMs,
+				prepareMs: after.prepareMs - before.prepareMs,
+				applyMs: after.applyMs - before.applyMs,
+				ackMs: after.ackMs - before.ackMs,
 			};
 		};
 
@@ -419,6 +563,44 @@ export async function runTable(rows: number): Promise<TableRunResult> {
 			await until(harness, () => hasClass(rowViews(harness.papi)[2]!, 'danger'), 'select');
 		});
 
+		const rowsBeforeSwap = rowViews(harness.papi).slice();
+		const labelsBeforeSwap = rowsBeforeSwap.map(labelTextOf);
+		const swap = await measure(async () => {
+			await tapButton(harness, 'Swap Rows');
+			await until(
+				harness,
+				() => {
+					const current = rowViews(harness.papi);
+					return current[1] === rowsBeforeSwap[998] && current[998] === rowsBeforeSwap[1];
+				},
+				'swapped survivor identity',
+			);
+		});
+		const rowsAfterSwap = rowViews(harness.papi);
+		const expectedPermutation = rowsBeforeSwap.map((_, index) =>
+			index === 1 ? 998 : index === 998 ? 1 : index,
+		);
+		for (let index = 0; index < expectedPermutation.length; index++) {
+			const source = expectedPermutation[index]!;
+			if (
+				rowsAfterSwap[index] !== rowsBeforeSwap[source] ||
+				labelTextOf(rowsAfterSwap[index]!) !== labelsBeforeSwap[source]
+			) {
+				harness.diagnostics.push(
+					new Error(`swap changed survivor identity or final order at row ${index}.`),
+				);
+				break;
+			}
+		}
+		const swapIdentityChecksum = rowsAfterSwap.reduce(
+			(sum, row, index) => sum + (rowsBeforeSwap.indexOf(row) + 1) * (index + 1),
+			0,
+		);
+		const movedRow = rowsAfterSwap[1]!;
+		tap(harness, tapTokenOf(cellOf(movedRow, 'col-label')!)!);
+		await until(harness, () => hasClass(rowViews(harness.papi)[1]!, 'danger'), 'moved row event');
+		const swapEventSurvived = hasClass(rowViews(harness.papi)[1]!, 'danger');
+
 		const updateStorm = await measure(async () => {
 			await tapButton(harness, 'Update storm');
 			await until(
@@ -438,6 +620,9 @@ export async function runTable(rows: number): Promise<TableRunResult> {
 			create,
 			update10th,
 			select,
+			swap,
+			swapIdentityChecksum,
+			swapEventSurvived,
 			updateStorm,
 			selectStorm,
 			createdElements: harness.papi.createdElements,
@@ -445,6 +630,7 @@ export async function runTable(rows: number): Promise<TableRunResult> {
 		};
 	} finally {
 		await harness.dispose();
+		Math.random = previousRandom;
 	}
 }
 

--- a/packages/octane/src/universal-core.ts
+++ b/packages/octane/src/universal-core.ts
@@ -4252,6 +4252,39 @@ function physicalDrafts(drafts: readonly DraftRecord[]): LogicalRecord[] {
 	return output;
 }
 
+/**
+ * Mark the new-order positions belonging to a longest increasing sequence of
+ * old physical positions. Entries of -1 are fresh hosts and never participate.
+ * The caller first proves that the survivor order is not already increasing,
+ * keeping the predecessor/tail allocations off append and filtered-list paths.
+ */
+function stableUniversalPlacementPositions(sources: Int32Array): Uint8Array {
+	const predecessors = new Int32Array(sources.length);
+	const tails = new Int32Array(sources.length);
+	let size = 0;
+	for (let index = 0; index < sources.length; index++) {
+		const source = sources[index];
+		if (source === -1) continue;
+		let low = 0;
+		let high = size;
+		while (low < high) {
+			const middle = (low + high) >> 1;
+			if (sources[tails[middle]] < source) low = middle + 1;
+			else high = middle;
+		}
+		predecessors[index] = low === 0 ? -1 : tails[low - 1];
+		tails[low] = index;
+		if (low === size) size++;
+	}
+	const stable = new Uint8Array(sources.length);
+	let index = size === 0 ? -1 : tails[size - 1];
+	while (index !== -1) {
+		stable[index] = 1;
+		index = predecessors[index];
+	}
+	return stable;
+}
+
 const UNIVERSAL_HOST_TEMPLATE_SHAPES = new WeakMap<
 	UniversalHostPlan,
 	readonly UniversalHostTemplateShapeNode[] | null
@@ -10208,45 +10241,55 @@ class UniversalRootImpl<Container, PublicInstance> implements UniversalRoot<any>
 			if (oldPhysical.length === 0 && newPhysical.length === 0) return;
 			const desiredIds = new Set<number>();
 			for (const entry of newPhysical) desiredIds.add(entry.id);
-			const previousIds = new Set<number>();
-			for (const old of oldPhysical) {
-				previousIds.add(old.id);
+			const previousPositions = new Map<number, number>();
+			for (let index = 0; index < oldPhysical.length; index++) {
+				const old = oldPhysical[index];
+				previousPositions.set(old.id, index);
 				if (!desiredIds.has(old.id)) {
 					removes.push({ op: 'remove', parent: sourceParentId, id: old.id });
 				}
 			}
-			let oldIndex = 0;
-			const movedIds = new Set<number>();
-			// Unplaced survivors retain their original order. Advance through that
-			// suffix instead of searching and splicing an ever-growing placed prefix.
-			for (let index = 0; index < newPhysical.length; index++) {
-				const id = newPhysical[index].id;
-				let currentId: number | undefined;
-				if (!forceMove) {
-					while (oldIndex < oldPhysical.length) {
-						const candidate = oldPhysical[oldIndex].id;
-						if (desiredIds.has(candidate) && !movedIds.has(candidate)) {
-							currentId = candidate;
-							break;
-						}
-						oldIndex++;
-					}
-					if (currentId === id) {
-						oldIndex++;
-						continue;
-					}
+			if (forceMove) {
+				for (const record of newPhysical) {
+					placements.push({
+						op: previousPositions.has(record.id) ? 'move' : 'insert',
+						parent: parentId,
+						id: record.id,
+						before: endAnchor,
+					});
 				}
-				const before = currentId ?? endAnchor;
-				if (previousIds.has(id)) {
-					placements.push({ op: 'move', parent: parentId, id, before });
-					if (!forceMove) movedIds.add(id);
+				return;
+			}
+			const sources = new Int32Array(newPhysical.length);
+			let previousSource = -1;
+			let reordered = false;
+			for (let index = 0; index < newPhysical.length; index++) {
+				const source = previousPositions.get(newPhysical[index].id) ?? -1;
+				sources[index] = source;
+				if (source === -1) continue;
+				if (source < previousSource) reordered = true;
+				previousSource = source;
+			}
+			const stable = reordered ? stableUniversalPlacementPositions(sources) : null;
+			const isStable = (index: number): boolean =>
+				stable === null ? sources[index] !== -1 : stable[index] === 1;
+			let nextStable = 0;
+			while (nextStable < newPhysical.length && !isStable(nextStable)) nextStable++;
+			for (let index = 0; index < newPhysical.length; index++) {
+				if (index === nextStable) {
+					nextStable++;
+					while (nextStable < newPhysical.length && !isStable(nextStable)) nextStable++;
+					continue;
+				}
+				const record = newPhysical[index];
+				const id = record.id;
+				const before = nextStable < newPhysical.length ? newPhysical[nextStable].id : endAnchor;
+				if (sources[index] === -1) {
+					const template = templateMounts.get(record);
+					if (template !== undefined) placeTemplate(template, parentId, before);
+					else placements.push({ op: 'insert', parent: parentId, id, before });
 				} else {
-					const template = templateMounts.get(newPhysical[index]);
-					if (template !== undefined && !forceMove) {
-						placeTemplate(template, parentId, before);
-					} else {
-						placements.push({ op: 'insert', parent: parentId, id, before });
-					}
+					placements.push({ op: 'move', parent: parentId, id, before });
 				}
 			}
 		};

--- a/packages/octane/tests/universal-event-scope.test.ts
+++ b/packages/octane/tests/universal-event-scope.test.ts
@@ -1121,6 +1121,42 @@ describe('universal event scopes', () => {
 		root.unmount();
 	});
 
+	it('moves only the displaced keyed hosts in a distant swap', () => {
+		const container = createObjectContainer();
+		const root = createUniversalRoot(container, createObjectDriver());
+		const itemPlan = universalPlan('object', { kind: 'host', type: 'item', propsSlot: 0 });
+		const updated: number[] = [];
+		const Item = defineUniversalComponent('object', ({ id }: { id: number }) =>
+			universalValue(itemPlan, [
+				universalProps([
+					['set', 'id', id],
+					['set', 'onPress', () => updated.push(id)],
+					['set', 'onUpdate', () => updated.push(-id)],
+				]),
+			]),
+		);
+		let apply!: (ids: number[]) => void;
+		const initial = Array.from({ length: 1_000 }, (_, index) => index + 1);
+		const App = defineUniversalComponent('object', () => {
+			const [ids, setIds] = useState(initial, 'ids');
+			apply = setIds;
+			return ids.map((id) => universalComponent('object', Item, { id }, id));
+		});
+
+		root.render(App, undefined);
+		const survivors = container.children.slice();
+		updated.length = 0;
+		const swapped = initial.slice();
+		[swapped[1], swapped[998]] = [swapped[998]!, swapped[1]!];
+		flushUniversalSync(() => apply(swapped));
+
+		expect(container.children).toEqual(swapped.map((id) => survivors[id - 1]));
+		expect(updated).toEqual([-999, -2]);
+		container.dispatchEvent(container.children[1], 'press', undefined);
+		expect(updated).toEqual([-999, -2, 999]);
+		root.unmount();
+	});
+
 	it('reveals initially suspended stateless content beside retained siblings on resolve', async () => {
 		const container = createObjectContainer();
 		const root = createUniversalRoot(container, createObjectDriver());

--- a/packages/octane/tests/universal-host-sdk.test.ts
+++ b/packages/octane/tests/universal-host-sdk.test.ts
@@ -1272,11 +1272,29 @@ describe('universal prepared host SDK', () => {
 		container.dispatchEvent(third.children[0], 'select', undefined);
 		expect(selected).toEqual(['first:b', 'first:c']);
 
+		const append = root.prepare(Scene, { ids: ['a', 'b', 'c', 'd', 'e'], label: 'first' });
+		if (append.status !== 'prepared') throw new Error('Expected an append transaction.');
+		const appendRuns = append.batch.commands.filter(
+			(command) => command.op === 'mount-template-run',
+		);
+		expect(appendRuns).toHaveLength(1);
+		expect(appendRuns[0]).toMatchObject({ count: 2, before: null });
+		append.commit();
+
 		root.render(Scene, { ids: ['c', 'a'], label: 'next' });
 		expect(container.children).toEqual([third, first]);
 		expect(third.children[0].children[0].props.value).toBe('next-c');
 		container.dispatchEvent(first.children[0], 'select', undefined);
 		expect(selected).toEqual(['first:b', 'first:c', 'next:a']);
+
+		const replace = root.prepare(Scene, { ids: ['x', 'y', 'z'], label: 'replace' });
+		if (replace.status !== 'prepared') throw new Error('Expected a replacement transaction.');
+		const replaceRuns = replace.batch.commands.filter(
+			(command) => command.op === 'mount-template-run',
+		);
+		expect(replaceRuns).toHaveLength(1);
+		expect(replaceRuns[0]).toMatchObject({ count: 3, before: null });
+		replace.commit();
 		root.unmount();
 	});
 


### PR DESCRIPTION
## Summary

- replace the universal keyed reconciler's greedy move planner with an O(n log n) LIS planner
- preserve one template run for append/replace while moving only unstable survivors
- add identity, event-scope, move-count, wire-byte, and large-list regression coverage
- add a patch changeset

Tracks https://github.com/Huxpro/octane/issues/46.

## Recalibration

This branch is based on upstream `main` at `ffadd397`, after #706 and #707 merged. The full live experiment was also run on an integration stack containing the complete #706 head followed by both #707 commits before those PRs merged.

## Results

The 1,000-row far swap drops from 997 universal move commands / 47,986 bytes to 2 moves / 368 bytes, with zero row re-renders and preserved DOM identity and event routing. The same two-move invariant holds at 10k and 30k rows.

| exact v2 run | baseline swap | candidate swap | delta | DNF |
| --- | ---: | ---: | ---: | ---: |
| forward | 51.465 ms | 26.8 ms | -48.0% | 0 |
| reverse | 52.73 ms | 26.2 ms | -50.3% | 0 |

Create, replace, append, and clear stayed within the accepted v1 regression envelope in both orders. The rejected reverse-placement prototype regressed append/replace by 20–32%; the submitted forward placement anchors to the next stable survivor and avoids that regression.

Latest-main rows=0 bundle deltas:

- Web: +595 raw / +257 gzip bytes
- Lynx: +595 raw / +251 gzip bytes

## Validation

- `pnpm vitest run packages/octane/tests/universal-event-scope.test.ts packages/octane/tests/universal-host-sdk.test.ts packages/octane/tests/universal-renderer.test.ts packages/octane/tests/universal-core.test.ts` — 106 passed
- `pnpm exec tsgo --noEmit -p packages/octane/tsconfig.json`
- `node benchmarks/bench.mjs --only lynx-table --ratios` — 24/299 applicable guards passed
- forward and reverse exact v2 live runs — 802 records each, zero DNF
- `pnpm format:files:check ...`
- `pnpm sync`

## Provenance

- [x] An agent authored this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core universal keyed reconciliation and host placement, so incorrect LIS planning could break survivor identity, events, or append/replace template coalescing. Coverage and deterministic swap gates mitigate that risk.
> 
> **Overview**
> **Minimizes keyed host moves** by replacing the greedy placement planner with an O(n log n) longest-increasing-subsequence plan in `universal-core`. Distant swaps now move only unstable survivors (e.g. 2 moves instead of ~997) while preserving identity, events, and lifecycle.
> 
> Stable survivors stay put; inserts/moves anchor to the next stable host. LIS runs only when survivors are actually reordered, so append/replace still coalesce into one `mount-template-run`.
> 
> Adds lynx-table swap gates for wire bytes, zero row re-renders, and handle deltas at 1k/10k, plus unit coverage for distant swaps and append/replace template runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50ddc5c8ea315c712d1974db73e06229408fc41f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->