### PR TITLE
bench(lynx): decompose template ingress ownership

### DIFF
--- a/benchmarks/lynx-table/README.md
+++ b/benchmarks/lynx-table/README.md
@@ -87,6 +87,77 @@ from a degraded run.
 - A cell that cannot be driven end-to-end is reported "not measured", never as
   a number from a degraded run.
 
+## 3. Stage-decomposition instrument (`stages/run.mjs`, informational)
+
+```bash
+node stages/run.mjs --smoke --rows 1000 --allow-busy-host
+node stages/run.mjs --reps 5
+```
+
+The reportable command builds control and `__OCTANE_LYNX_PROFILE__` variants,
+requires `n >= 5`, opens a fresh page for every sample, alternates control and
+profile order `AB / BA / AB / ...` in one host window, and runs one vendored
+`vue-vdom` create sample after each pair. It records CPU/OS/Node/Chromium, host
+load at both ends, medians, min-max spread, raw milliseconds, shares, and
+same-window ratios. Do not run other builds, tests, browsers, or benchmark
+processes during that window. The default quiet-host preflight rejects a
+one-minute load average above `0.5 * logical CPUs`; `--allow-busy-host` exists
+only for non-reportable smoke/debug runs or an explicitly disclosed exception.
+
+The reusable analyzer and protocol tests are:
+
+```bash
+node --test stages/*.test.mjs
+```
+
+### Observation contract
+
+Every directly timed interval is exclusive. The analyzer rejects a sample when
+direct intervals exceed its wall clock instead of normalizing or guessing.
+
+**FCP@10k** starts when the shared browser init hook assigns the hidden
+main-thread iframe's Blob script URL (before browser load/parse/evaluation) and
+ends at the first animation-frame observation where the shared composed-tree
+driver sees all 10,000 rows:
+
+1. `mt_slice_eval`: Blob script assignment through the first `root.render()`
+   call, including browser load, parse, and evaluation.
+2. `plan_interpretation`: time inside first-screen `renderPlanNode` walks.
+3. `papi_element_creation`: time inside Element PAPI page/element/list creation
+   calls.
+4. `layout_flush_residual`: the exclusive wall-clock remainder. Web Core does
+   not expose a stable boundary separating PAPI prop/insertion work,
+   `__FlushElementTree`, DOM publication, style/layout, and observer-frame
+   delay, so those costs remain named and visible rather than guessed apart.
+
+Raw view-attach FCP is also reported for control/profile overhead and same-run
+comparison, but decode/fetch before slice evaluation is outside the four-stage
+attribution.
+
+**create@10k** starts at the byte-identical page driver's `pointerdown` boundary
+and ends when that same driver sees 10,000 rows:
+
+1. `bg_replay`: native-event delivery through completion of background render,
+   diff, command staging, and plan folding, stopping before outbound self-check.
+2. `wire_clone_transfer`: the existing ContextProxy `dispatchEvent` interval.
+3. `mt_expand`: `instantiate` expansion before host preparation.
+4. `papi_element_creation`: time inside Element PAPI page/element/list creation
+   calls.
+5. `layout_flush_residual`: the exclusive wall-clock remainder, including
+   event delivery before replay, validation/prepare, non-create PAPI work,
+   flush/layout, scheduling, and observer-frame delay.
+
+Snapshots are collected from the real hidden main-thread iframe and background
+worker, copied as numeric own properties, and parsed without prototype or
+`instanceof` checks. The profiler extends the existing
+`__OCTANE_LYNX_PROFILE__` record; its runtime branches are absent when the
+define is false, and `stages/analyze.test.mjs` gates that production fold
+boundary with byte-equal bundled output against a control entry.
+
+Downstream verdicts use a declared direct-share gate: `GO` requires a directly
+observed target segment (or target segment sum) to contribute at least 10% of
+the operation's median attribution. Residual time never authorizes a step.
+
 ## Claims and non-claims
 
 Command counts and commit bytes are Octane-owned costs and are gated. The

--- a/benchmarks/lynx-table/README.md
+++ b/benchmarks/lynx-table/README.md
@@ -140,7 +140,10 @@ and ends when that same driver sees 10,000 rows:
 1. `bg_replay`: native-event delivery through completion of background render,
    diff, command staging, and plan folding, stopping before outbound self-check.
 2. `wire_clone_transfer`: the existing ContextProxy `dispatchEvent` interval.
-3. `mt_expand`: `instantiate` expansion before host preparation.
+3. `mt_expand`: main-thread wire-shape preparation before host preparation.
+   Historical plan-wire samples measure `instantiate` expansion; rebased
+   template-program samples measure incremental-run capability validation and
+   freezing under the same archived profile field.
 4. `papi_element_creation`: time inside Element PAPI page/element/list creation
    calls.
 5. `layout_flush_residual`: the exclusive wall-clock remainder, including

--- a/benchmarks/lynx-table/package.json
+++ b/benchmarks/lynx-table/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "bench": "node run.mjs",
     "bench:web": "node web/run-web.mjs",
-    "build:app": "node scripts/build-app.mjs"
+    "bench:stages": "node stages/run.mjs",
+    "build:app": "node scripts/build-app.mjs",
+    "test:stages": "node --test stages/*.test.mjs"
   },
   "dependencies": {
     "@lynx-js/web-core": "0.22.2",

--- a/benchmarks/lynx-table/scripts/build-app.mjs
+++ b/benchmarks/lynx-table/scripts/build-app.mjs
@@ -13,6 +13,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { instrumentLynxStageSources } from '../stages/instrument-source.mjs';
+
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const repo = path.resolve(root, '../..');
 
@@ -31,15 +33,20 @@ export function buildTableApp({ silent = false } = {}) {
 		fs.copyFileSync(path.join(src, 'src', file), path.join(stage, 'src', file));
 	}
 
-	if (!silent) console.log('[lynx-table] building octane table app (production)…');
-	execFileSync('npx', ['rspeedy', 'build', '--root', `examples/${STAGE_NAME}`], {
-		cwd: pluginDir,
-		stdio: silent ? 'pipe' : 'inherit',
-		env: { ...process.env, NODE_ENV: 'production' },
-	});
-
 	const autoRows = Number(process.env.BENCH_AUTOROWS ?? '0') || 0;
 	const profile = process.env.OCTANE_LYNX_PROFILE === '1';
+	const restore = profile ? instrumentLynxStageSources(repo) : () => {};
+	if (!silent) console.log('[lynx-table] building octane table app (production)…');
+	try {
+		execFileSync('npx', ['rspeedy', 'build', '--root', `examples/${STAGE_NAME}`], {
+			cwd: pluginDir,
+			stdio: silent ? 'pipe' : 'inherit',
+			env: { ...process.env, NODE_ENV: 'production' },
+		});
+	} finally {
+		restore();
+	}
+
 	const suffix = (autoRows > 0 ? `-rows${autoRows}` : '') + (profile ? '-profile' : '');
 	const from = path.join(stage, `dist${suffix}`);
 	const to = path.join(src, `dist${suffix}`);

--- a/benchmarks/lynx-table/stages/analyze.mjs
+++ b/benchmarks/lynx-table/stages/analyze.mjs
@@ -50,17 +50,26 @@ export function analyzeFcpSample({ wallMs, main }) {
 
 export function analyzeCreateSample({ wallMs, background, main }) {
 	const totalMs = finite(wallMs, 'create wallMs');
+	const applyMs = observed(main?.applyMs, 'applyMs');
+	const papiCreateMs = observed(main?.papiCreateMs, 'papiCreateMs');
+	if (papiCreateMs > applyMs + 0.5) {
+		throw new Error('create PAPI element creation exceeds the enclosing main-thread apply stage.');
+	}
 	const stages = {
 		bg_replay: observed(background?.bgReplayMs, 'bgReplayMs'),
 		wire_clone_transfer: observed(background?.dispatchMs, 'dispatchMs'),
+		mt_validate: observed(main?.validateMs, 'validateMs'),
 		mt_expand: observed(main?.mtExpandMs, 'mtExpandMs'),
-		papi_element_creation: observed(main?.papiCreateMs, 'papiCreateMs'),
+		mt_prepare: observed(main?.prepareMs, 'prepareMs'),
+		papi_element_creation: papiCreateMs,
+		mt_apply_other: Math.max(0, applyMs - papiCreateMs),
+		mt_ack_publication: observed(main?.ackMs, 'ackMs'),
 	};
 	return {
 		totalMs,
 		stages: {
 			...stages,
-			layout_flush_residual: residual(totalMs, stages, 'create'),
+			presentation_residual: residual(totalMs, stages, 'create'),
 		},
 	};
 }

--- a/benchmarks/lynx-table/stages/analyze.mjs
+++ b/benchmarks/lynx-table/stages/analyze.mjs
@@ -1,0 +1,126 @@
+const MIN_REPETITIONS = 5;
+
+export function requireMinimumRepetitions(value) {
+	const repetitions = Number(value);
+	if (!Number.isSafeInteger(repetitions) || repetitions < MIN_REPETITIONS) {
+		throw new TypeError(`stage decomposition requires at least ${MIN_REPETITIONS} repetitions.`);
+	}
+	return repetitions;
+}
+
+export function interleavedABSchedule(repetitions) {
+	const count = requireMinimumRepetitions(repetitions);
+	return Array.from({ length: count }, (_, index) =>
+		index % 2 === 0 ? ['control', 'profile'] : ['profile', 'control'],
+	);
+}
+
+function finite(value, label) {
+	if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+		throw new TypeError(`${label} must be a finite number greater than or equal to zero.`);
+	}
+	return value;
+}
+
+function observed(value, label) {
+	return value === undefined ? 0 : finite(value, label);
+}
+
+function residual(total, stages, label) {
+	const value = total - Object.values(stages).reduce((sum, stage) => sum + stage, 0);
+	if (value < -0.5) throw new Error(`${label} directly observed stages exceed the wall clock.`);
+	return Math.max(0, value);
+}
+
+export function analyzeFcpSample({ wallMs, main }) {
+	const totalMs = finite(wallMs, 'FCP wallMs');
+	const stages = {
+		mt_slice_eval: observed(main?.mtSliceEvalMs, 'mtSliceEvalMs'),
+		plan_interpretation: observed(main?.firstScreenPlanMs, 'firstScreenPlanMs'),
+		papi_element_creation: observed(main?.papiCreateMs, 'papiCreateMs'),
+	};
+	return {
+		totalMs,
+		stages: {
+			...stages,
+			layout_flush_residual: residual(totalMs, stages, 'FCP'),
+		},
+	};
+}
+
+export function analyzeCreateSample({ wallMs, background, main }) {
+	const totalMs = finite(wallMs, 'create wallMs');
+	const stages = {
+		bg_replay: observed(background?.bgReplayMs, 'bgReplayMs'),
+		wire_clone_transfer: observed(background?.dispatchMs, 'dispatchMs'),
+		mt_expand: observed(main?.mtExpandMs, 'mtExpandMs'),
+		papi_element_creation: observed(main?.papiCreateMs, 'papiCreateMs'),
+	};
+	return {
+		totalMs,
+		stages: {
+			...stages,
+			layout_flush_residual: residual(totalMs, stages, 'create'),
+		},
+	};
+}
+
+function numericRecord(value, label) {
+	if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+		throw new TypeError(`${label} must be an object.`);
+	}
+	const record = {};
+	for (const key of Object.keys(value)) record[key] = finite(value[key], `${label}.${key}`);
+	return record;
+}
+
+export function parseRealmSnapshots(snapshots) {
+	if (!Array.isArray(snapshots)) throw new TypeError('realm snapshots must be an array.');
+	let background = null;
+	let main = null;
+	for (const snapshot of snapshots) {
+		if (snapshot === null || typeof snapshot !== 'object' || Array.isArray(snapshot)) {
+			throw new TypeError('realm snapshot must be an object.');
+		}
+		const kind = snapshot.kind;
+		if (kind !== 'worker' && kind !== 'frame')
+			throw new TypeError(`unknown realm kind ${String(kind)}.`);
+		if (snapshot.profile === null || snapshot.profile === undefined) continue;
+		const parsed = numericRecord(snapshot.profile, `${kind} profile`);
+		if (kind === 'worker') background = parsed;
+		else main = parsed;
+	}
+	return { background, main };
+}
+
+function stat(values) {
+	const sorted = values.map((value) => finite(value, 'sample')).sort((a, b) => a - b);
+	if (sorted.length === 0) throw new Error('cannot summarize an empty sample.');
+	const middle = Math.floor(sorted.length / 2);
+	const median =
+		sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle];
+	return {
+		median,
+		min: sorted[0],
+		max: sorted.at(-1),
+		spread: sorted.at(-1) - sorted[0],
+		n: sorted.length,
+	};
+}
+
+export function summarizeSamples(samples, comparisons = {}) {
+	requireMinimumRepetitions(samples.length);
+	const total = stat(samples.map((sample) => sample.totalMs));
+	const stageNames = Object.keys(samples[0].stages);
+	const stages = {};
+	for (const name of stageNames) {
+		const summary = stat(samples.map((sample) => sample.stages[name]));
+		stages[name] = { ...summary, share: total.median === 0 ? 0 : summary.median / total.median };
+	}
+	const ratios = {};
+	for (const [name, values] of Object.entries(comparisons)) {
+		const comparison = stat(values);
+		ratios[name] = comparison.median === 0 ? null : total.median / comparison.median;
+	}
+	return { total, stages, ratios };
+}

--- a/benchmarks/lynx-table/stages/analyze.test.mjs
+++ b/benchmarks/lynx-table/stages/analyze.test.mjs
@@ -68,18 +68,38 @@ test('attributes only exclusive observed time and assigns the remainder to named
 		analyzeCreateSample({
 			wallMs: 200,
 			background: { bgReplayMs: 40, dispatchMs: 20 },
-			main: { mtExpandMs: 30, papiCreateMs: 50 },
+			main: {
+				validateMs: 5,
+				mtExpandMs: 10,
+				prepareMs: 15,
+				applyMs: 50,
+				papiCreateMs: 30,
+				ackMs: 10,
+			},
 		}),
 		{
 			totalMs: 200,
 			stages: {
 				bg_replay: 40,
 				wire_clone_transfer: 20,
-				mt_expand: 30,
-				papi_element_creation: 50,
-				layout_flush_residual: 60,
+				mt_validate: 5,
+				mt_expand: 10,
+				mt_prepare: 15,
+				papi_element_creation: 30,
+				mt_apply_other: 20,
+				mt_ack_publication: 10,
+				presentation_residual: 50,
 			},
 		},
+	);
+	assert.throws(
+		() =>
+			analyzeCreateSample({
+				wallMs: 100,
+				background: {},
+				main: { applyMs: 10, papiCreateMs: 11 },
+			}),
+		/exceeds the enclosing/,
 	);
 });
 

--- a/benchmarks/lynx-table/stages/analyze.test.mjs
+++ b/benchmarks/lynx-table/stages/analyze.test.mjs
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { build } from 'esbuild';
+
+import {
+	analyzeCreateSample,
+	analyzeFcpSample,
+	interleavedABSchedule,
+	parseRealmSnapshots,
+	requireMinimumRepetitions,
+	summarizeSamples,
+} from './analyze.mjs';
+
+test('requires at least five repetitions for a reportable session', () => {
+	assert.throws(() => requireMinimumRepetitions(4), /at least 5/);
+	assert.equal(requireMinimumRepetitions(5), 5);
+});
+
+test('alternates A/B order in one deterministic host window', () => {
+	assert.deepEqual(interleavedABSchedule(5), [
+		['control', 'profile'],
+		['profile', 'control'],
+		['control', 'profile'],
+		['profile', 'control'],
+		['control', 'profile'],
+	]);
+});
+
+test('computes median, spread, shares, and same-window ratios', () => {
+	const summary = summarizeSamples(
+		[
+			{ totalMs: 100, stages: { direct: 20, residual: 80 } },
+			{ totalMs: 110, stages: { direct: 22, residual: 88 } },
+			{ totalMs: 90, stages: { direct: 18, residual: 72 } },
+			{ totalMs: 120, stages: { direct: 24, residual: 96 } },
+			{ totalMs: 105, stages: { direct: 21, residual: 84 } },
+		],
+		{ control: [80, 88, 72, 96, 84], reference: [50, 55, 45, 60, 52.5] },
+	);
+	assert.deepEqual(summary.total, { median: 105, min: 90, max: 120, spread: 30, n: 5 });
+	assert.equal(summary.stages.direct.median, 21);
+	assert.equal(summary.stages.direct.share, 0.2);
+	assert.equal(summary.ratios.control, 1.25);
+	assert.equal(summary.ratios.reference, 2);
+});
+
+test('attributes only exclusive observed time and assigns the remainder to named residuals', () => {
+	assert.deepEqual(
+		analyzeFcpSample({
+			wallMs: 100,
+			main: { mtSliceEvalMs: 15, firstScreenPlanMs: 25, papiCreateMs: 30 },
+		}),
+		{
+			totalMs: 100,
+			stages: {
+				mt_slice_eval: 15,
+				plan_interpretation: 25,
+				papi_element_creation: 30,
+				layout_flush_residual: 30,
+			},
+		},
+	);
+	assert.deepEqual(
+		analyzeCreateSample({
+			wallMs: 200,
+			background: { bgReplayMs: 40, dispatchMs: 20 },
+			main: { mtExpandMs: 30, papiCreateMs: 50 },
+		}),
+		{
+			totalMs: 200,
+			stages: {
+				bg_replay: 40,
+				wire_clone_transfer: 20,
+				mt_expand: 30,
+				papi_element_creation: 50,
+				layout_flush_residual: 60,
+			},
+		},
+	);
+});
+
+test('parses cross-realm snapshots by value without prototype identity', () => {
+	const foreign = Object.create(null);
+	foreign.kind = 'worker';
+	foreign.profile = Object.assign(Object.create(null), {
+		dispatchMs: 12,
+		bgReplayMs: 34,
+	});
+	assert.deepEqual(parseRealmSnapshots([foreign]), {
+		background: { dispatchMs: 12, bgReplayMs: 34 },
+		main: null,
+	});
+	assert.throws(
+		() => parseRealmSnapshots([{ kind: 'frame', profile: { mtExpandMs: 'not-a-number' } }]),
+		/finite number/,
+	);
+});
+
+test('folds stage instrumentation out of a default production bundle', async () => {
+	const temporary = fs.mkdtempSync(path.join(os.tmpdir(), 'octane-lynx-stage-profile-'));
+	const entry = path.join(temporary, 'entry.ts');
+	const control = path.join(temporary, 'control.ts');
+	fs.writeFileSync(
+		entry,
+		[
+			"import { lynxWireProfile } from '" +
+				path.resolve('packages/lynx/src/core/profiling.ts').replaceAll('\\', '/') +
+				"';",
+			'if (__OCTANE_LYNX_PROFILE__) {',
+			"\tconst profile = lynxWireProfile(); profile['octane-stage-profile-marker'] = 1;",
+			'}',
+			'globalThis.__octaneProfileFoldProbe = 1;',
+		].join('\n'),
+	);
+	fs.writeFileSync(control, 'globalThis.__octaneProfileFoldProbe = 1;\n');
+	try {
+		const bundle = async (entryPoint) =>
+			(
+				await build({
+					entryPoints: [entryPoint],
+					bundle: true,
+					write: false,
+					minify: true,
+					platform: 'browser',
+					define: { __OCTANE_LYNX_PROFILE__: 'false' },
+				})
+			).outputFiles[0].text;
+		const output = await bundle(entry);
+		const controlOutput = await bundle(control);
+		assert.doesNotMatch(output, /octane-stage-profile-marker|mtSliceEvalMs|bgReplayMs/);
+		assert.equal(output, controlOutput);
+	} finally {
+		fs.rmSync(temporary, { recursive: true, force: true });
+	}
+});

--- a/benchmarks/lynx-table/stages/instrument-source.mjs
+++ b/benchmarks/lynx-table/stages/instrument-source.mjs
@@ -1,0 +1,290 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+function replaceOnce(source, search, replacement, file) {
+	const first = source.indexOf(search);
+	if (first === -1) throw new Error(`stage instrument anchor missing in ${file}.`);
+	if (source.indexOf(search, first + search.length) !== -1) {
+		throw new Error(`stage instrument anchor is ambiguous in ${file}.`);
+	}
+	return source.slice(0, first) + replacement + source.slice(first + search.length);
+}
+
+export function instrumentLynxStageSources(repositoryRoot) {
+	const originals = new Map();
+	const update = (relative, transform) => {
+		const file = path.join(repositoryRoot, relative);
+		const source = fs.readFileSync(file, 'utf8');
+		originals.set(file, source);
+		fs.writeFileSync(file, transform(source, relative));
+	};
+
+	try {
+		update('packages/lynx/src/core/profiling.ts', (source, file) =>
+			replaceOnce(
+				source,
+				'\t/** Main: acknowledgement handle computation + dispatch time. */\n\tackMs: number;\n',
+				`\t/** Main: acknowledgement handle computation + dispatch time. */
+\tackMs: number;
+\tbgReplayMs?: number;
+\tmtExpandMs?: number;
+\tfirstScreenPlanMs?: number;
+\tmtSliceEvalMs?: number;
+\tmtSliceStartEpochMs?: number;
+\tpapiCreateMs?: number;
+`,
+				file,
+			),
+		);
+
+		update('packages/lynx/src/core/papi.ts', (source, file) => {
+			let next = replaceOnce(
+				source,
+				'export function createLynxElementPAPI<Node extends LynxElementRef = LynxElementRef>(\n',
+				`function profilePapiCreate(started: number): void {
+\tconst globals = globalThis as any;
+\tconst profile = (globals.__OCTANE_LYNX_PROF ??= {
+\t\tcommits: 0,
+\t\tpacedCommits: 0,
+\t\tcommands: 0,
+\t\tbytes: 0,
+\t\tselfcheckMs: 0,
+\t\tdispatchMs: 0,
+\t\tvalidateMs: 0,
+\t\tprepareMs: 0,
+\t\tprepareCheckMs: 0,
+\t\tapplyMs: 0,
+\t\tackMs: 0,
+\t});
+\tprofile.papiCreateMs = (profile.papiCreateMs ?? 0) + performance.now() - started;
+}
+
+export function createLynxElementPAPI<Node extends LynxElementRef = LynxElementRef>(
+`,
+				file,
+			);
+			next = replaceOnce(
+				next,
+				`\t\t\t\t\t) {
+\t\t\t\t\t\treturn createListValue!.call(
+\t\t\t\t\t\t\ttarget,
+\t\t\t\t\t\t\tparentComponentUniqueId,
+\t\t\t\t\t\t\tcomponentAtIndex,
+\t\t\t\t\t\t\tenqueueComponent,
+\t\t\t\t\t\t\t{},
+\t\t\t\t\t\t\tcomponentAtIndexes,
+\t\t\t\t\t\t);
+\t\t\t\t\t},
+`,
+				`\t\t\t\t\t) {
+\t\t\t\t\t\tconst started = performance.now();
+\t\t\t\t\t\ttry {
+\t\t\t\t\t\t\treturn createListValue!.call(
+\t\t\t\t\t\t\t\ttarget,
+\t\t\t\t\t\t\t\tparentComponentUniqueId,
+\t\t\t\t\t\t\t\tcomponentAtIndex,
+\t\t\t\t\t\t\t\tenqueueComponent,
+\t\t\t\t\t\t\t\t{},
+\t\t\t\t\t\t\t\tcomponentAtIndexes,
+\t\t\t\t\t\t\t);
+\t\t\t\t\t\t} finally {
+\t\t\t\t\t\t\tprofilePapiCreate(started);
+\t\t\t\t\t\t}
+\t\t\t\t\t},
+`,
+				file,
+			);
+			next = replaceOnce(
+				next,
+				`\t\tcreatePage(componentId, cssId) {
+\t\t\treturn createPage(componentId, cssId);
+\t\t},
+\t\tcreateElement(type, parentComponentUniqueId, textValue) {
+\t\t\tswitch (type) {
+`,
+				`\t\tcreatePage(componentId, cssId) {
+\t\t\tconst started = performance.now();
+\t\t\ttry {
+\t\t\t\treturn createPage(componentId, cssId);
+\t\t\t} finally {
+\t\t\t\tprofilePapiCreate(started);
+\t\t\t}
+\t\t},
+\t\tcreateElement(type, parentComponentUniqueId, textValue) {
+\t\t\tconst started = performance.now();
+\t\t\ttry {
+\t\t\t\tswitch (type) {
+`,
+				file,
+			);
+			return replaceOnce(
+				next,
+				`\t\t\t\tdefault:
+\t\t\t\t\treturn createElement(type, parentComponentUniqueId);
+\t\t\t}
+\t\t},
+`,
+				`\t\t\t\t\tdefault:
+\t\t\t\t\t\treturn createElement(type, parentComponentUniqueId);
+\t\t\t\t}
+\t\t\t} finally {
+\t\t\t\tprofilePapiCreate(started);
+\t\t\t}
+\t\t},
+`,
+				file,
+			);
+		});
+
+		update('packages/lynx/src/main-renderer.ts', (source, file) => {
+			let next = replaceOnce(
+				source,
+				'let CURRENT_ATTEMPT: FirstScreenAttempt | null = null;\n',
+				'let CURRENT_ATTEMPT: FirstScreenAttempt | null = null;\nlet FIRST_SCREEN_PLAN_PROFILE_DEPTH = 0;\n',
+				file,
+			);
+			return replaceOnce(
+				next,
+				`\t\tassertRenderer(planValue.plan.renderer);
+\t\tconst rendered = renderPlanNode(planValue.plan.root, planValue.values);
+`,
+				`\t\tassertRenderer(planValue.plan.renderer);
+\t\tconst outerProfile = FIRST_SCREEN_PLAN_PROFILE_DEPTH === 0;
+\t\tconst startedPlan = outerProfile ? performance.now() : 0;
+\t\tFIRST_SCREEN_PLAN_PROFILE_DEPTH++;
+\t\tlet rendered: FirstScreenNode[];
+\t\ttry {
+\t\t\trendered = renderPlanNode(planValue.plan.root, planValue.values);
+\t\t} finally {
+\t\t\tFIRST_SCREEN_PLAN_PROFILE_DEPTH--;
+\t\t\tif (outerProfile) {
+\t\t\t\tconst profile = (globalThis as any).__OCTANE_LYNX_PROF;
+\t\t\t\tprofile.firstScreenPlanMs =
+\t\t\t\t\t(profile.firstScreenPlanMs ?? 0) + performance.now() - startedPlan;
+\t\t\t}
+\t\t}
+`,
+				file,
+			);
+		});
+
+		update('packages/lynx/src/main-thread.ts', (source, file) => {
+			let next = replaceOnce(
+				source,
+				'interface LynxMainThreadGlobals {\n',
+				'interface LynxMainThreadGlobals {\n\treadonly __OCTANE_LYNX_MT_SLICE_LOAD_START_EPOCH__?: number;\n',
+				file,
+			);
+			next = replaceOnce(
+				next,
+				`\t\tlet source: LynxHostContainer<Node> | null = null;
+\t\ttry {
+\t\t\tconst result = renderLynxFirstScreen(component, props);
+`,
+				`\t\tlet source: LynxHostContainer<Node> | null = null;
+\t\ttry {
+\t\t\tconst sliceStart = (rawTarget as LynxMainThreadGlobals)
+\t\t\t\t.__OCTANE_LYNX_MT_SLICE_LOAD_START_EPOCH__;
+\t\t\tif (typeof sliceStart === 'number' && Number.isFinite(sliceStart)) {
+\t\t\t\tconst profile = lynxWireProfile();
+\t\t\t\tprofile.mtSliceStartEpochMs = sliceStart;
+\t\t\t\tprofile.mtSliceEvalMs =
+\t\t\t\t\t(profile.mtSliceEvalMs ?? 0) + performance.timeOrigin + performance.now() - sliceStart;
+\t\t\t}
+\t\t\tconst result = renderLynxFirstScreen(component, props);
+`,
+				file,
+			);
+			next = replaceOnce(
+				next,
+				`\t\tlet hostBatch: UniversalHostBatch;
+\t\ttry {
+\t\t\thostBatch = expandLynxWireBatch(message.batch);
+`,
+				`\t\tlet hostBatch: UniversalHostBatch;
+\t\tconst startedExpand = performance.now();
+\t\ttry {
+\t\t\thostBatch = expandLynxWireBatch(message.batch);
+`,
+				file,
+			);
+			return replaceOnce(
+				next,
+				`\t\t\treject(identity, error);
+\t\t\treturn;
+\t\t}
+
+\t\tlet prepared: LynxPreparedHostBatch;
+`,
+				`\t\t\treject(identity, error);
+\t\t\treturn;
+\t\t}
+\t\tconst expandProfile = lynxWireProfile();
+\t\texpandProfile.mtExpandMs =
+\t\t\t(expandProfile.mtExpandMs ?? 0) + performance.now() - startedExpand;
+
+\t\tlet prepared: LynxPreparedHostBatch;
+`,
+				file,
+			);
+		});
+
+		update('packages/lynx/src/core/transport.ts', (source, file) => {
+			let next = replaceOnce(
+				source,
+				'\tlet pageDestroyHandlerInvoked = false;\n',
+				'\tlet pageDestroyHandlerInvoked = false;\n\tlet replayStartedAt: number | null = null;\n',
+				file,
+			);
+			next = replaceOnce(
+				next,
+				`\t\t\tprofile.selfcheckMs += startedDispatch - startedSelfCheck;
+\t\t\tprofileOutboundMessage(profile, message);
+\t\t\treturn;
+`,
+				`\t\t\tprofile.selfcheckMs += startedDispatch - startedSelfCheck;
+\t\t\tprofileOutboundMessage(profile, message);
+\t\t\tif ((message as { readonly type?: unknown }).type === 'commit' && replayStartedAt !== null) {
+\t\t\t\tprofile.bgReplayMs = (profile.bgReplayMs ?? 0) + startedSelfCheck - replayStartedAt;
+\t\t\t\treplayStartedAt = null;
+\t\t\t}
+\t\t\treturn;
+`,
+				file,
+			);
+			next = replaceOnce(
+				next,
+				`\t\tdispatchNativeEventBatch(deliveries) {
+\t\t\tif (deliveries.length === 0) return;
+\t\t\tif (closedError !== null) {
+`,
+				`\t\tdispatchNativeEventBatch(deliveries) {
+\t\t\tif (deliveries.length === 0) return;
+\t\t\tif (replayStartedAt === null) replayStartedAt = performance.now();
+\t\t\tif (closedError !== null) {
+\t\t\t\treplayStartedAt = null;
+`,
+				file,
+			);
+			next = replaceOnce(
+				next,
+				'\t\t\t\tif (transportRoot !== null && identity.root !== transportRoot) {\n',
+				'\t\t\t\tif (transportRoot !== null && identity.root !== transportRoot) {\n\t\t\t\t\treplayStartedAt = null;\n',
+				file,
+			);
+			return replaceOnce(
+				next,
+				"\t\t\t\tif (identity.priority !== priority) {\n\t\t\t\t\treport(new Error('Octane Lynx native event batch mixes listener priorities.'));\n",
+				"\t\t\t\tif (identity.priority !== priority) {\n\t\t\t\t\treplayStartedAt = null;\n\t\t\t\t\treport(new Error('Octane Lynx native event batch mixes listener priorities.'));\n",
+				file,
+			);
+		});
+	} catch (error) {
+		for (const [file, source] of originals) fs.writeFileSync(file, source);
+		throw error;
+	}
+
+	return () => {
+		for (const [file, source] of originals) fs.writeFileSync(file, source);
+	};
+}

--- a/benchmarks/lynx-table/stages/instrument-source.mjs
+++ b/benchmarks/lynx-table/stages/instrument-source.mjs
@@ -197,33 +197,26 @@ export function createLynxElementPAPI<Node extends LynxElementRef = LynxElementR
 			);
 			next = replaceOnce(
 				next,
-				`\t\tlet hostBatch: UniversalHostBatch;
-\t\ttry {
-\t\t\thostBatch = expandLynxWireBatch(message.batch);
+				`\t\tlet postFirstTreeIncrementalCompact = false;
 `,
-				`\t\tlet hostBatch: UniversalHostBatch;
+				`\t\t// The original stage probe timed legacy instantiate expansion. The
+\t\t// template-program transport replaces that step with capability-gated
+\t\t// incremental-run validation and freezing; retain the historical profile
+\t\t// field name so archived and current samples stay readable together.
 \t\tconst startedExpand = performance.now();
-\t\ttry {
-\t\t\thostBatch = expandLynxWireBatch(message.batch);
+\t\tlet postFirstTreeIncrementalCompact = false;
 `,
 				file,
 			);
 			return replaceOnce(
 				next,
-				`\t\t\treject(identity, error);
-\t\t\treturn;
-\t\t}
-
-\t\tlet prepared: LynxPreparedHostBatch;
+				`\t\tlet record = active;
 `,
-				`\t\t\treject(identity, error);
-\t\t\treturn;
-\t\t}
-\t\tconst expandProfile = lynxWireProfile();
+				`\t\tconst expandProfile = lynxWireProfile();
 \t\texpandProfile.mtExpandMs =
 \t\t\t(expandProfile.mtExpandMs ?? 0) + performance.now() - startedExpand;
 
-\t\tlet prepared: LynxPreparedHostBatch;
+\t\tlet record = active;
 `,
 				file,
 			);

--- a/benchmarks/lynx-table/stages/instrument-source.mjs
+++ b/benchmarks/lynx-table/stages/instrument-source.mjs
@@ -234,7 +234,20 @@ export function createLynxElementPAPI<Node extends LynxElementRef = LynxElementR
 \t\t} finally {
 \t\t\tFIRST_SCREEN_PLAN_PROFILE_DEPTH--;
 \t\t\tif (outerProfile) {
-\t\t\t\tconst profile = (globalThis as any).__OCTANE_LYNX_PROF;
+\t\t\t\tconst globals = globalThis as any;
+\t\t\t\tconst profile = (globals.__OCTANE_LYNX_PROF ??= {
+\t\t\t\t\tcommits: 0,
+\t\t\t\t\tpacedCommits: 0,
+\t\t\t\t\tcommands: 0,
+\t\t\t\t\tbytes: 0,
+\t\t\t\t\tselfcheckMs: 0,
+\t\t\t\t\tdispatchMs: 0,
+\t\t\t\t\tvalidateMs: 0,
+\t\t\t\t\tprepareMs: 0,
+\t\t\t\t\tprepareCheckMs: 0,
+\t\t\t\t\tapplyMs: 0,
+\t\t\t\t\tackMs: 0,
+\t\t\t\t});
 \t\t\t\tprofile.firstScreenPlanMs =
 \t\t\t\t\t(profile.firstScreenPlanMs ?? 0) + performance.now() - startedPlan;
 \t\t\t}

--- a/benchmarks/lynx-table/stages/instrument-source.mjs
+++ b/benchmarks/lynx-table/stages/instrument-source.mjs
@@ -20,8 +20,8 @@ export function instrumentLynxStageSources(repositoryRoot) {
 	};
 
 	try {
-		update('packages/lynx/src/core/profiling.ts', (source, file) =>
-			replaceOnce(
+		update('packages/lynx/src/core/profiling.ts', (source, file) => {
+			const next = replaceOnce(
 				source,
 				'\t/** Main: acknowledgement handle computation + dispatch time. */\n\tackMs: number;\n',
 				`\t/** Main: acknowledgement handle computation + dispatch time. */
@@ -34,8 +34,47 @@ export function instrumentLynxStageSources(repositoryRoot) {
 \tpapiCreateMs?: number;
 `,
 				file,
-			),
-		);
+			);
+			return replaceOnce(
+				next,
+				`\tprofile.commands += record.batch?.commands?.length ?? 0;
+\ttry {
+`,
+				`\tconst commands = record.batch?.commands ?? [];
+\tprofile.commands += commands.length;
+\tconst measured = profile as LynxWireProfile & {
+\t\ttemplateRuns?: number;
+\t\ttemplateInstances?: number;
+\t\ttemplateValues?: number;
+\t\tpublicHandleCommands?: number;
+\t};
+\tfor (const rawCommand of commands) {
+\t\tconst command = rawCommand as {
+\t\t\top?: unknown;
+\t\t\tcount?: unknown;
+\t\t\tvalues?: readonly unknown[];
+\t\t};
+\t\tif (command.op === 'mount-template-run') {
+\t\t\tmeasured.templateRuns = (measured.templateRuns ?? 0) + 1;
+\t\t\tmeasured.templateInstances =
+\t\t\t\t(measured.templateInstances ?? 0) +
+\t\t\t\t(typeof command.count === 'number' ? command.count : 0);
+\t\t\tmeasured.templateValues =
+\t\t\t\t(measured.templateValues ?? 0) + (command.values?.length ?? 0);
+\t\t} else if (command.op === 'mount-template-range') {
+\t\t\tmeasured.templateRuns = (measured.templateRuns ?? 0) + 1;
+\t\t\tmeasured.templateInstances = (measured.templateInstances ?? 0) + 1;
+\t\t\tmeasured.templateValues =
+\t\t\t\t(measured.templateValues ?? 0) + (command.values?.length ?? 0);
+\t\t} else if (command.op === 'ensure-public-instance') {
+\t\t\tmeasured.publicHandleCommands = (measured.publicHandleCommands ?? 0) + 1;
+\t\t}
+\t}
+\ttry {
+`,
+				file,
+			);
+		});
 
 		update('packages/lynx/src/core/papi.ts', (source, file) => {
 			let next = replaceOnce(
@@ -117,7 +156,7 @@ export function createLynxElementPAPI<Node extends LynxElementRef = LynxElementR
 `,
 				file,
 			);
-			return replaceOnce(
+			next = replaceOnce(
 				next,
 				`\t\t\t\tdefault:
 \t\t\t\t\treturn createElement(type, parentComponentUniqueId);
@@ -131,6 +170,43 @@ export function createLynxElementPAPI<Node extends LynxElementRef = LynxElementR
 \t\t\t\tprofilePapiCreate(started);
 \t\t\t}
 \t\t},
+`,
+				file,
+			);
+			return replaceOnce(
+				next,
+				`		intrinsics: Object.freeze({
+			view: createView,
+			text: createText,
+			rawText: createRawText,
+		}),
+`,
+				`		intrinsics: Object.freeze({
+			view(parentComponentUniqueId) {
+				const started = performance.now();
+				try {
+					return createView(parentComponentUniqueId);
+				} finally {
+					profilePapiCreate(started);
+				}
+			},
+			text(parentComponentUniqueId) {
+				const started = performance.now();
+				try {
+					return createText(parentComponentUniqueId);
+				} finally {
+					profilePapiCreate(started);
+				}
+			},
+			rawText(textValue) {
+				const started = performance.now();
+				try {
+					return createRawText(textValue);
+				} finally {
+					profilePapiCreate(started);
+				}
+			},
+		}),
 `,
 				file,
 			);

--- a/benchmarks/lynx-table/stages/instrument-source.test.mjs
+++ b/benchmarks/lynx-table/stages/instrument-source.test.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { instrumentLynxStageSources } from './instrument-source.mjs';
+
+const repositoryRoot = path.resolve(import.meta.dirname, '../../..');
+const sourceFiles = [
+	'packages/lynx/src/core/profiling.ts',
+	'packages/lynx/src/core/papi.ts',
+	'packages/lynx/src/core/transport.ts',
+	'packages/lynx/src/main-renderer.ts',
+	'packages/lynx/src/main-thread.ts',
+];
+
+test('instruments an isolated Lynx source copy and restores every byte', () => {
+	const temporary = fs.mkdtempSync(path.join(os.tmpdir(), 'octane-lynx-stage-source-'));
+	try {
+		for (const relative of sourceFiles) {
+			const target = path.join(temporary, relative);
+			fs.mkdirSync(path.dirname(target), { recursive: true });
+			fs.copyFileSync(path.join(repositoryRoot, relative), target);
+		}
+		const before = new Map(
+			sourceFiles.map((relative) => [
+				relative,
+				fs.readFileSync(path.join(temporary, relative), 'utf8'),
+			]),
+		);
+		const restore = instrumentLynxStageSources(temporary);
+		assert.match(
+			fs.readFileSync(path.join(temporary, 'packages/lynx/src/core/transport.ts'), 'utf8'),
+			/bgReplayMs/,
+		);
+		assert.match(
+			fs.readFileSync(path.join(temporary, 'packages/lynx/src/main-thread.ts'), 'utf8'),
+			/mtExpandMs/,
+		);
+		assert.match(
+			fs.readFileSync(path.join(temporary, 'packages/lynx/src/main-renderer.ts'), 'utf8'),
+			/firstScreenPlanMs/,
+		);
+		assert.match(
+			fs.readFileSync(path.join(temporary, 'packages/lynx/src/core/papi.ts'), 'utf8'),
+			/papiCreateMs/,
+		);
+		restore();
+		for (const relative of sourceFiles) {
+			assert.equal(fs.readFileSync(path.join(temporary, relative), 'utf8'), before.get(relative));
+		}
+	} finally {
+		fs.rmSync(temporary, { recursive: true, force: true });
+	}
+});

--- a/benchmarks/lynx-table/stages/instrument-source.test.mjs
+++ b/benchmarks/lynx-table/stages/instrument-source.test.mjs
@@ -2,7 +2,10 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import test from 'node:test';
+
+import { build } from 'esbuild';
 
 import { instrumentLynxStageSources } from './instrument-source.mjs';
 
@@ -51,6 +54,64 @@ test('instruments an isolated Lynx source copy and restores every byte', () => {
 			assert.equal(fs.readFileSync(path.join(temporary, relative), 'utf8'), before.get(relative));
 		}
 	} finally {
+		fs.rmSync(temporary, { recursive: true, force: true });
+	}
+});
+
+test('profiled first-screen rendering works without a stage-harness slice hook', async () => {
+	const temporary = fs.mkdtempSync(path.join(os.tmpdir(), 'octane-lynx-stage-profile-'));
+	try {
+		for (const relative of [...sourceFiles, 'packages/lynx/src/resource.ts']) {
+			const target = path.join(temporary, relative);
+			fs.mkdirSync(path.dirname(target), { recursive: true });
+			fs.copyFileSync(path.join(repositoryRoot, relative), target);
+		}
+		instrumentLynxStageSources(temporary);
+
+		const entry = path.join(temporary, 'profile-first-screen.ts');
+		const output = path.join(temporary, 'profile-first-screen.mjs');
+		fs.writeFileSync(
+			entry,
+			[
+				"import { defineUniversalComponent, renderLynxFirstScreen, universalPlan, universalValue } from './packages/lynx/src/main-renderer.ts';",
+				"const plan = universalPlan('lynx', { kind: 'host', type: 'view' });",
+				"const App = defineUniversalComponent('lynx', () => universalValue(plan));",
+				'export function run() {',
+				'\tdelete globalThis.__OCTANE_LYNX_PROF;',
+				'\tconst result = renderLynxFirstScreen(App, {});',
+				'\treturn { profile: globalThis.__OCTANE_LYNX_PROF, result };',
+				'}',
+			].join('\n'),
+		);
+		await build({
+			entryPoints: [entry],
+			bundle: true,
+			format: 'esm',
+			logLevel: 'silent',
+			outfile: output,
+			platform: 'node',
+		});
+
+		const { run } = await import(`${pathToFileURL(output).href}?profile-first-screen`);
+		const { profile, result } = run();
+		assert.equal(result.hostCount, 1);
+		assert.ok(Number.isFinite(profile.firstScreenPlanMs));
+		for (const name of [
+			'commits',
+			'commands',
+			'bytes',
+			'selfcheckMs',
+			'dispatchMs',
+			'validateMs',
+			'prepareMs',
+			'prepareCheckMs',
+			'applyMs',
+			'ackMs',
+		]) {
+			assert.equal(profile[name], 0);
+		}
+	} finally {
+		delete globalThis.__OCTANE_LYNX_PROF;
 		fs.rmSync(temporary, { recursive: true, force: true });
 	}
 });

--- a/benchmarks/lynx-table/stages/results/live-1000.json
+++ b/benchmarks/lynx-table/stages/results/live-1000.json
@@ -1,0 +1,3403 @@
+{
+  "meta": {
+    "date": "2026-08-12T00:23:08.466Z",
+    "node": "v22.22.2",
+    "cpus": 32,
+    "cpuModel": "Intel(R) Xeon(R) Platinum 8336C CPU @ 2.30GHz",
+    "platform": "linux",
+    "release": "5.15.120.bsk.3-amd64",
+    "chromium": "149.0.7827.55",
+    "repetitions": 5,
+    "rows": 1000,
+    "reportable": true,
+    "loadStart": [2.07, 2.16, 1.99],
+    "loadEnd": [2.58, 2.31, 2.05],
+    "protocol": "fresh page per operation sample; control/profile order alternates AB/BA; one vue-vdom create/replace/append triplet follows each pair; no other benchmark process ran in this window"
+  },
+  "fcp": {
+    "attribution": {
+      "total": {
+        "median": 216.60009765625,
+        "min": 214.5,
+        "max": 241.300048828125,
+        "spread": 26.800048828125,
+        "n": 5
+      },
+      "stages": {
+        "mt_slice_eval": {
+          "median": 19.300048828125,
+          "min": 18.5,
+          "max": 20.10009765625,
+          "spread": 1.60009765625,
+          "n": 5,
+          "share": 0.08910452505314509
+        },
+        "plan_interpretation": {
+          "median": 17.399999856948853,
+          "min": 17.200000047683716,
+          "max": 19.09999990463257,
+          "spread": 1.8999998569488525,
+          "n": 5,
+          "share": 0.08033237309321581
+        },
+        "papi_element_creation": {
+          "median": 60.3000009059906,
+          "min": 58.00000214576721,
+          "max": 65.59999871253967,
+          "spread": 7.599996566772461,
+          "n": 5,
+          "share": 0.27839323046699765
+        },
+        "layout_flush_residual": {
+          "median": 120.6000485420227,
+          "min": 118.49999904632568,
+          "max": 137.20014786720276,
+          "spread": 18.700148820877075,
+          "n": 5,
+          "share": 0.5567866766773952
+        }
+      },
+      "ratios": {}
+    },
+    "rawControl": {
+      "median": 241.89999985694885,
+      "min": 237.70000004768372,
+      "max": 251,
+      "spread": 13.299999952316284,
+      "n": 5
+    },
+    "rawProfile": {
+      "median": 244.70000004768372,
+      "min": 240.60000014305115,
+      "max": 273.30000019073486,
+      "spread": 32.700000047683716,
+      "n": 5
+    }
+  },
+  "create": {
+    "attribution": {
+      "total": {
+        "median": 148.29999995231628,
+        "min": 142.09999990463257,
+        "max": 154.39999985694885,
+        "spread": 12.299999952316284,
+        "n": 5
+      },
+      "stages": {
+        "bg_replay": {
+          "median": 26.90000009536743,
+          "min": 26.40000009536743,
+          "max": 29.399999856948853,
+          "spread": 2.999999761581421,
+          "n": 5,
+          "share": 0.18138907689829223
+        },
+        "wire_clone_transfer": {
+          "median": 0.5999999046325684,
+          "min": 0.40000009536743164,
+          "max": 0.7000000476837158,
+          "spread": 0.2999999523162842,
+          "n": 5,
+          "share": 0.004045852358904178
+        },
+        "mt_validate": {
+          "median": 1.9000000953674316,
+          "min": 1.7000000476837158,
+          "max": 2.200000047683716,
+          "spread": 0.5,
+          "n": 5,
+          "share": 0.01281186848265913
+        },
+        "mt_expand": {
+          "median": 0,
+          "min": 0,
+          "max": 0.09999990463256836,
+          "spread": 0.09999990463256836,
+          "n": 5,
+          "share": 0
+        },
+        "mt_prepare": {
+          "median": 1.5999999046325684,
+          "min": 1.5,
+          "max": 1.7999999523162842,
+          "spread": 0.2999999523162842,
+          "n": 5,
+          "share": 0.010788940695529502
+        },
+        "papi_element_creation": {
+          "median": 61.99999976158142,
+          "min": 56.70000076293945,
+          "max": 65.8999993801117,
+          "spread": 9.199998617172241,
+          "n": 5,
+          "share": 0.4180714752630925
+        },
+        "mt_apply_other": {
+          "median": 40.999998331069946,
+          "min": 36.600000619888306,
+          "max": 44.799999713897705,
+          "spread": 8.1999990940094,
+          "n": 5,
+          "share": 0.2764666105478955
+        },
+        "mt_ack_publication": {
+          "median": 0.5000002384185791,
+          "min": 0.40000009536743164,
+          "max": 0.5999999046325684,
+          "spread": 0.19999980926513672,
+          "n": 5,
+          "share": 0.003371545775990202
+        },
+        "presentation_residual": {
+          "median": 13.199999570846558,
+          "min": 12.299999952316284,
+          "max": 15.59999966621399,
+          "spread": 3.299999713897705,
+          "n": 5,
+          "share": 0.0890087631496347
+        }
+      },
+      "ratios": {
+        "control": 1.0458392101705627,
+        "reference": 0.9297805639643654
+      }
+    },
+    "wire": {
+      "toBts": {
+        "bytes": {
+          "median": 19361,
+          "min": 19346,
+          "max": 19378,
+          "spread": 32,
+          "n": 5
+        },
+        "messages": {
+          "median": 14,
+          "min": 14,
+          "max": 14,
+          "spread": 0,
+          "n": 5
+        }
+      },
+      "toMts": {
+        "bytes": {
+          "median": 41355,
+          "min": 41309,
+          "max": 41380,
+          "spread": 71,
+          "n": 5
+        },
+        "messages": {
+          "median": 10,
+          "min": 10,
+          "max": 10,
+          "spread": 0,
+          "n": 5
+        }
+      }
+    },
+    "rawControl": {
+      "median": 141.79999995231628,
+      "min": 138,
+      "max": 143.59999990463257,
+      "spread": 5.599999904632568,
+      "n": 5
+    },
+    "rawProfile": {
+      "median": 148.29999995231628,
+      "min": 142.09999990463257,
+      "max": 154.39999985694885,
+      "spread": 12.299999952316284,
+      "n": 5
+    },
+    "vueVdom": {
+      "median": 159.5,
+      "min": 157.29999995231628,
+      "max": 166.39999985694885,
+      "spread": 9.099999904632568,
+      "n": 5
+    }
+  },
+  "replace": {
+    "attribution": {
+      "total": {
+        "median": 316.5,
+        "min": 304.2999999523163,
+        "max": 337.2000000476837,
+        "spread": 32.90000009536743,
+        "n": 5
+      },
+      "stages": {
+        "bg_replay": {
+          "median": 36.700000047683716,
+          "min": 36.200000047683716,
+          "max": 38.200000047683716,
+          "spread": 2,
+          "n": 5,
+          "share": 0.11595576634339247
+        },
+        "wire_clone_transfer": {
+          "median": 2.799999952316284,
+          "min": 2.700000047683716,
+          "max": 3.4000000953674316,
+          "spread": 0.7000000476837158,
+          "n": 5,
+          "share": 0.008846761302737075
+        },
+        "mt_validate": {
+          "median": 9.200000047683716,
+          "min": 8,
+          "max": 10.299999952316284,
+          "spread": 2.299999952316284,
+          "n": 5,
+          "share": 0.02906793064039089
+        },
+        "mt_expand": {
+          "median": 0,
+          "min": 0,
+          "max": 0,
+          "spread": 0,
+          "n": 5,
+          "share": 0
+        },
+        "mt_prepare": {
+          "median": 55.89999985694885,
+          "min": 54.09999990463257,
+          "max": 60.40000009536743,
+          "spread": 6.300000190734863,
+          "n": 5,
+          "share": 0.1766192728497594
+        },
+        "papi_element_creation": {
+          "median": 53.80000424385071,
+          "min": 48.99999809265137,
+          "max": 61.000004053115845,
+          "spread": 12.000005960464478,
+          "n": 5,
+          "share": 0.16998421562038138
+        },
+        "mt_apply_other": {
+          "median": 81.69999575614929,
+          "min": 76.59999990463257,
+          "max": 87.99999594688416,
+          "spread": 11.399996042251587,
+          "n": 5,
+          "share": 0.25813584757077185
+        },
+        "mt_ack_publication": {
+          "median": 36,
+          "min": 35.5,
+          "max": 38.09999990463257,
+          "spread": 2.5999999046325684,
+          "n": 5,
+          "share": 0.11374407582938388
+        },
+        "presentation_residual": {
+          "median": 44,
+          "min": 34.80000019073486,
+          "max": 46.60000038146973,
+          "spread": 11.800000190734863,
+          "n": 5,
+          "share": 0.13902053712480253
+        }
+      },
+      "ratios": {
+        "control": 1.0118286446555236,
+        "reference": 1.811677160352676
+      }
+    },
+    "rawControl": {
+      "median": 312.7999999523163,
+      "min": 303.2000000476837,
+      "max": 355,
+      "spread": 51.799999952316284,
+      "n": 5
+    },
+    "rawProfile": {
+      "median": 316.5,
+      "min": 304.2999999523163,
+      "max": 337.2000000476837,
+      "spread": 32.90000009536743,
+      "n": 5
+    },
+    "vueVdom": {
+      "median": 174.70000004768372,
+      "min": 173.5,
+      "max": 186,
+      "spread": 12.5,
+      "n": 5
+    },
+    "wire": {
+      "toBts": {
+        "bytes": {
+          "median": 1999041,
+          "min": 1999031,
+          "max": 1999043,
+          "spread": 12,
+          "n": 5
+        },
+        "messages": {
+          "median": 4,
+          "min": 4,
+          "max": 4,
+          "spread": 0,
+          "n": 5
+        }
+      },
+      "toMts": {
+        "bytes": {
+          "median": 376572,
+          "min": 376531,
+          "max": 376656,
+          "spread": 125,
+          "n": 5
+        },
+        "messages": {
+          "median": 1,
+          "min": 1,
+          "max": 1,
+          "spread": 0,
+          "n": 5
+        }
+      }
+    }
+  },
+  "append": {
+    "attribution": {
+      "total": {
+        "median": 197.70000004768372,
+        "min": 189.79999995231628,
+        "max": 211.30000019073486,
+        "spread": 21.50000023841858,
+        "n": 5
+      },
+      "stages": {
+        "bg_replay": {
+          "median": 28.300000190734863,
+          "min": 26.199999809265137,
+          "max": 29.200000047683716,
+          "spread": 3.000000238418579,
+          "n": 5,
+          "share": 0.14314618201269155
+        },
+        "wire_clone_transfer": {
+          "median": 0.40000009536743164,
+          "min": 0.2999999523162842,
+          "max": 0.5,
+          "spread": 0.20000004768371582,
+          "n": 5,
+          "share": 0.0020232680590336607
+        },
+        "mt_validate": {
+          "median": 1.2000000476837158,
+          "min": 1.0999999046325684,
+          "max": 1.2000000476837158,
+          "spread": 0.10000014305114746,
+          "n": 5,
+          "share": 0.00606980297113953
+        },
+        "mt_expand": {
+          "median": 0,
+          "min": 0,
+          "max": 0.09999990463256836,
+          "spread": 0.09999990463256836,
+          "n": 5,
+          "share": 0
+        },
+        "mt_prepare": {
+          "median": 16.40000009536743,
+          "min": 14.700000047683716,
+          "max": 16.799999952316284,
+          "spread": 2.0999999046325684,
+          "n": 5,
+          "share": 0.08295397112499685
+        },
+        "papi_element_creation": {
+          "median": 53.70000100135803,
+          "min": 49.69999837875366,
+          "max": 61.19999861717224,
+          "spread": 11.500000238418579,
+          "n": 5,
+          "share": 0.27162367723017705
+        },
+        "mt_apply_other": {
+          "median": 46.30000138282776,
+          "min": 41.999999046325684,
+          "max": 48.799996852874756,
+          "spread": 6.799997806549072,
+          "n": 5,
+          "share": 0.23419322899170741
+        },
+        "mt_ack_publication": {
+          "median": 31.299999952316284,
+          "min": 30.299999952316284,
+          "max": 36.200000047683716,
+          "spread": 5.900000095367432,
+          "n": 5,
+          "share": 0.1583206876315982
+        },
+        "presentation_residual": {
+          "median": 20.100000143051147,
+          "min": 18.59999990463257,
+          "max": 22.100000143051147,
+          "spread": 3.500000238418579,
+          "n": 5,
+          "share": 0.10166919645019314
+        }
+      },
+      "ratios": {
+        "control": 1.000506072391499,
+        "reference": 1.2233910883210162
+      }
+    },
+    "rawControl": {
+      "median": 197.60000014305115,
+      "min": 189.69999980926514,
+      "max": 227.89999985694885,
+      "spread": 38.200000047683716,
+      "n": 5
+    },
+    "rawProfile": {
+      "median": 197.70000004768372,
+      "min": 189.79999995231628,
+      "max": 211.30000019073486,
+      "spread": 21.50000023841858,
+      "n": 5
+    },
+    "vueVdom": {
+      "median": 161.60000014305115,
+      "min": 155.20000004768372,
+      "max": 174.70000004768372,
+      "spread": 19.5,
+      "n": 5
+    },
+    "wire": {
+      "toBts": {
+        "bytes": {
+          "median": 1713062,
+          "min": 1713061,
+          "max": 1713071,
+          "spread": 10,
+          "n": 5
+        },
+        "messages": {
+          "median": 4,
+          "min": 4,
+          "max": 4,
+          "spread": 0,
+          "n": 5
+        }
+      },
+      "toMts": {
+        "bytes": {
+          "median": 34974,
+          "min": 34883,
+          "max": 35079,
+          "spread": 196,
+          "n": 5
+        },
+        "messages": {
+          "median": 1,
+          "min": 1,
+          "max": 1,
+          "spread": 0,
+          "n": 5
+        }
+      }
+    }
+  },
+  "verdicts": [
+    {
+      "step": "#47 wire/encoding candidate",
+      "verdict": "NO-GO",
+      "reason": "clone/transfer is 0.4% of create, 0.9% of replace, and 0.2% of append; it does not clear the 10% owner gate."
+    },
+    {
+      "step": "#47 measured CPU owner",
+      "verdict": "SPLIT",
+      "reason": "PAPI creation plus remaining host apply is 69.5% of create. This is a host materialization owner, not evidence for changing the wire representation."
+    },
+    {
+      "step": "#47 acknowledgement-only candidate",
+      "verdict": "NO-GO for issue acceptance",
+      "reason": "ACK/publication is 0.3% of create, 11.4% of replace, and 15.8% of append; even a complete removal cannot meet the required 15% in all three cells or the 50% total-wire gate."
+    }
+  ],
+  "samples": {
+    "fcp": {
+      "control": [
+        {
+          "rawMs": 237.70000004768372
+        },
+        {
+          "rawMs": 241.79999995231628
+        },
+        {
+          "rawMs": 251
+        },
+        {
+          "rawMs": 241.89999985694885
+        },
+        {
+          "rawMs": 248
+        }
+      ],
+      "profile": [
+        {
+          "rawMs": 244.5,
+          "attribution": {
+            "totalMs": 216.60009765625,
+            "stages": {
+              "mt_slice_eval": 19.300048828125,
+              "plan_interpretation": 17.299999952316284,
+              "papi_element_creation": 59.40000033378601,
+              "layout_flush_residual": 120.6000485420227
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 16094,
+              "bytes": 1039233,
+              "selfcheckMs": 0,
+              "dispatchMs": 6.400000095367432,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0
+            },
+            "main": {
+              "commits": 0,
+              "pacedCommits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 0.20000004768371582,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "papiCreateMs": 59.40000033378601,
+              "mtSliceStartEpochMs": 1786494149883.2,
+              "mtSliceEvalMs": 19.300048828125,
+              "firstScreenPlanMs": 17.299999952316284
+            }
+          }
+        },
+        {
+          "rawMs": 251.69999980926514,
+          "attribution": {
+            "totalMs": 223.5,
+            "stages": {
+              "mt_slice_eval": 20.10009765625,
+              "plan_interpretation": 17.700000047683716,
+              "papi_element_creation": 58.00000214576721,
+              "layout_flush_residual": 127.69990015029907
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 16094,
+              "bytes": 1039233,
+              "selfcheckMs": 0,
+              "dispatchMs": 6.900000333786011,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0
+            },
+            "main": {
+              "commits": 0,
+              "pacedCommits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "papiCreateMs": 58.00000214576721,
+              "mtSliceStartEpochMs": 1786494155228.3,
+              "mtSliceEvalMs": 20.10009765625,
+              "firstScreenPlanMs": 17.700000047683716
+            }
+          }
+        },
+        {
+          "rawMs": 273.30000019073486,
+          "attribution": {
+            "totalMs": 241.300048828125,
+            "stages": {
+              "mt_slice_eval": 19.39990234375,
+              "plan_interpretation": 19.09999990463257,
+              "papi_element_creation": 65.59999871253967,
+              "layout_flush_residual": 137.20014786720276
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 16094,
+              "bytes": 1039233,
+              "selfcheckMs": 0,
+              "dispatchMs": 6.699999809265137,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0
+            },
+            "main": {
+              "commits": 0,
+              "pacedCommits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "papiCreateMs": 65.59999871253967,
+              "mtSliceStartEpochMs": 1786494166599.8,
+              "mtSliceEvalMs": 19.39990234375,
+              "firstScreenPlanMs": 19.09999990463257
+            }
+          }
+        },
+        {
+          "rawMs": 244.70000004768372,
+          "attribution": {
+            "totalMs": 216.5,
+            "stages": {
+              "mt_slice_eval": 19.199951171875,
+              "plan_interpretation": 17.399999856948853,
+              "papi_element_creation": 60.79999923706055,
+              "layout_flush_residual": 119.1000497341156
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 16094,
+              "bytes": 1039233,
+              "selfcheckMs": 0,
+              "dispatchMs": 7.1000001430511475,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0
+            },
+            "main": {
+              "commits": 0,
+              "pacedCommits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 0.10000014305114746,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "papiCreateMs": 60.79999923706055,
+              "mtSliceStartEpochMs": 1786494171932.6,
+              "mtSliceEvalMs": 19.199951171875,
+              "firstScreenPlanMs": 17.399999856948853
+            }
+          }
+        },
+        {
+          "rawMs": 240.60000014305115,
+          "attribution": {
+            "totalMs": 214.5,
+            "stages": {
+              "mt_slice_eval": 18.5,
+              "plan_interpretation": 17.200000047683716,
+              "papi_element_creation": 60.3000009059906,
+              "layout_flush_residual": 118.49999904632568
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 16094,
+              "bytes": 1039233,
+              "selfcheckMs": 0,
+              "dispatchMs": 6.799999952316284,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0
+            },
+            "main": {
+              "commits": 0,
+              "pacedCommits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 0.09999990463256836,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "papiCreateMs": 60.3000009059906,
+              "mtSliceStartEpochMs": 1786494183263.5,
+              "mtSliceEvalMs": 18.5,
+              "firstScreenPlanMs": 17.200000047683716
+            }
+          }
+        }
+      ]
+    },
+    "create": {
+      "control": [
+        {
+          "rawMs": 139.59999990463257,
+          "wire": {
+            "toBts": {
+              "messages": 14,
+              "bytes": 19346,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17791
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 767
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 307
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 41265,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 40472
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 673
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 141.79999995231628,
+          "wire": {
+            "toBts": {
+              "messages": 14,
+              "bytes": 19368,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17791
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 774
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 322
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 41271,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 40473
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 678
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 141.89999985694885,
+          "wire": {
+            "toBts": {
+              "messages": 14,
+              "bytes": 19372,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17791
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 778
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 322
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 41320,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 40516
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 684
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 138,
+          "wire": {
+            "toBts": {
+              "messages": 14,
+              "bytes": 19378,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17791
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 784
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 322
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 41394,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 40586
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 688
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 143.59999990463257,
+          "wire": {
+            "toBts": {
+              "messages": 14,
+              "bytes": 19358,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17791
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 779
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 307
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 41223,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 40415
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 688
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          }
+        }
+      ],
+      "profile": [
+        {
+          "rawMs": 148.29999995231628,
+          "wire": {
+            "toBts": {
+              "messages": 14,
+              "bytes": 19361,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17791
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 767
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 322
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 41380,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 40589
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 671
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 148.29999995231628,
+            "stages": {
+              "bg_replay": 26.700000047683716,
+              "wire_clone_transfer": 0.40000009536743164,
+              "mt_validate": 1.9000000953674316,
+              "mt_expand": 0,
+              "mt_prepare": 1.700000286102295,
+              "papi_element_creation": 57.10000014305115,
+              "mt_apply_other": 44.799999713897705,
+              "mt_ack_publication": 0.5999999046325684,
+              "presentation_residual": 15.09999966621399
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 2,
+              "commands": 95,
+              "bytes": 39783,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.40000009536743164,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 26.700000047683716
+            },
+            "main": {
+              "commits": 2,
+              "pacedCommits": 0,
+              "commands": 95,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 1.9000000953674316,
+              "prepareMs": 1.700000286102295,
+              "prepareCheckMs": 0,
+              "applyMs": 101.89999985694885,
+              "ackMs": 0.5999999046325684,
+              "papiCreateMs": 57.10000014305115,
+              "mtSliceStartEpochMs": 1786494150645.8,
+              "mtSliceEvalMs": 20.699951171875,
+              "firstScreenPlanMs": 0.5,
+              "mtExpandMs": 0
+            }
+          }
+        },
+        {
+          "rawMs": 149.19999980926514,
+          "wire": {
+            "toBts": {
+              "messages": 14,
+              "bytes": 19378,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17791
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 784
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 322
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 41375,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 40565
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 690
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 149.19999980926514,
+            "stages": {
+              "bg_replay": 28.799999952316284,
+              "wire_clone_transfer": 0.7000000476837158,
+              "mt_validate": 1.7000000476837158,
+              "mt_expand": 0,
+              "mt_prepare": 1.7999999523162842,
+              "papi_element_creation": 65.8999993801117,
+              "mt_apply_other": 36.600000619888306,
+              "mt_ack_publication": 0.5000002384185791,
+              "presentation_residual": 13.199999570846558
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 2,
+              "commands": 95,
+              "bytes": 39759,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.7000000476837158,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 28.799999952316284
+            },
+            "main": {
+              "commits": 2,
+              "pacedCommits": 0,
+              "commands": 95,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 1.7000000476837158,
+              "prepareMs": 1.7999999523162842,
+              "prepareCheckMs": 0,
+              "applyMs": 102.5,
+              "ackMs": 0.5000002384185791,
+              "papiCreateMs": 65.8999993801117,
+              "mtSliceStartEpochMs": 1786494155983.1,
+              "mtSliceEvalMs": 22,
+              "firstScreenPlanMs": 0.40000009536743164,
+              "mtExpandMs": 0
+            }
+          }
+        },
+        {
+          "rawMs": 142.5,
+          "wire": {
+            "toBts": {
+              "messages": 14,
+              "bytes": 19360,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17791
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 766
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 322
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 41355,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 40563
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 672
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 142.5,
+            "stages": {
+              "bg_replay": 26.40000009536743,
+              "wire_clone_transfer": 0.40000009536743164,
+              "mt_validate": 2.200000047683716,
+              "mt_expand": 0,
+              "mt_prepare": 1.5999999046325684,
+              "papi_element_creation": 61.99999976158142,
+              "mt_apply_other": 37.00000023841858,
+              "mt_ack_publication": 0.5999999046325684,
+              "presentation_residual": 12.299999952316284
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 2,
+              "commands": 95,
+              "bytes": 39757,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.40000009536743164,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 26.40000009536743
+            },
+            "main": {
+              "commits": 2,
+              "pacedCommits": 0,
+              "commands": 95,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 2.200000047683716,
+              "prepareMs": 1.5999999046325684,
+              "prepareCheckMs": 0,
+              "applyMs": 99,
+              "ackMs": 0.5999999046325684,
+              "papiCreateMs": 61.99999976158142,
+              "mtSliceStartEpochMs": 1786494167358.3,
+              "mtSliceEvalMs": 19.7998046875,
+              "firstScreenPlanMs": 0.40000009536743164,
+              "mtExpandMs": 0
+            }
+          }
+        },
+        {
+          "rawMs": 154.39999985694885,
+          "wire": {
+            "toBts": {
+              "messages": 14,
+              "bytes": 19361,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17791
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 767
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 322
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 41309,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 40516
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 673
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 154.39999985694885,
+            "stages": {
+              "bg_replay": 29.399999856948853,
+              "wire_clone_transfer": 0.5999999046325684,
+              "mt_validate": 2.000000238418579,
+              "mt_expand": 0,
+              "mt_prepare": 1.5999999046325684,
+              "papi_element_creation": 63.80000162124634,
+              "mt_apply_other": 40.999998331069946,
+              "mt_ack_publication": 0.40000033378601074,
+              "presentation_residual": 15.59999966621399
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 2,
+              "commands": 95,
+              "bytes": 39710,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.5999999046325684,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 29.399999856948853
+            },
+            "main": {
+              "commits": 2,
+              "pacedCommits": 0,
+              "commands": 95,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 2.000000238418579,
+              "prepareMs": 1.5999999046325684,
+              "prepareCheckMs": 0,
+              "applyMs": 104.79999995231628,
+              "ackMs": 0.40000033378601074,
+              "papiCreateMs": 63.80000162124634,
+              "mtSliceStartEpochMs": 1786494172682.5,
+              "mtSliceEvalMs": 21.800048828125,
+              "firstScreenPlanMs": 0.39999985694885254,
+              "mtExpandMs": 0
+            }
+          }
+        },
+        {
+          "rawMs": 142.09999990463257,
+          "wire": {
+            "toBts": {
+              "messages": 14,
+              "bytes": 19346,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17791
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 765
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 309
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 41350,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 40559
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 671
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 142.09999990463257,
+            "stages": {
+              "bg_replay": 26.90000009536743,
+              "wire_clone_transfer": 0.6999998092651367,
+              "mt_validate": 1.8000001907348633,
+              "mt_expand": 0.09999990463256836,
+              "mt_prepare": 1.5,
+              "papi_element_creation": 56.70000076293945,
+              "mt_apply_other": 41.49999928474426,
+              "mt_ack_publication": 0.40000009536743164,
+              "presentation_residual": 12.499999761581421
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 2,
+              "commands": 95,
+              "bytes": 39753,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.6999998092651367,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 26.90000009536743
+            },
+            "main": {
+              "commits": 2,
+              "pacedCommits": 0,
+              "commands": 95,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 1.8000001907348633,
+              "prepareMs": 1.5,
+              "prepareCheckMs": 0,
+              "applyMs": 98.20000004768372,
+              "ackMs": 0.40000009536743164,
+              "papiCreateMs": 56.70000076293945,
+              "mtSliceStartEpochMs": 1786494184013.1,
+              "mtSliceEvalMs": 18.89990234375,
+              "firstScreenPlanMs": 0.39999985694885254,
+              "mtExpandMs": 0.09999990463256836
+            }
+          }
+        }
+      ],
+      "vueVdom": [
+        {
+          "rawMs": 164.09999990463257,
+          "wire": {
+            "toBts": {
+              "messages": 12,
+              "bytes": 2053,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 228
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 1,
+                  "bytes": 94
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 950
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "ret_bg-to-main_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_1": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_2": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 287
+                },
+                "ret_bg-to-main_3": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 9,
+              "bytes": 337414,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "callLepusMethod": {
+                  "messages": 4,
+                  "bytes": 336516
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 778
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 158.70000004768372,
+          "wire": {
+            "toBts": {
+              "messages": 12,
+              "bytes": 2066,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 228
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 1,
+                  "bytes": 94
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 963
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "ret_bg-to-main_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_1": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_2": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 287
+                },
+                "ret_bg-to-main_3": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 9,
+              "bytes": 337473,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "callLepusMethod": {
+                  "messages": 4,
+                  "bytes": 336564
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 789
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 166.39999985694885,
+          "wire": {
+            "toBts": {
+              "messages": 12,
+              "bytes": 2062,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 228
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 1,
+                  "bytes": 94
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 959
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "ret_bg-to-main_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_1": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_2": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 287
+                },
+                "ret_bg-to-main_3": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 9,
+              "bytes": 337352,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "callLepusMethod": {
+                  "messages": 4,
+                  "bytes": 336445
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 787
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 157.29999995231628,
+          "wire": {
+            "toBts": {
+              "messages": 12,
+              "bytes": 2056,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 228
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 1,
+                  "bytes": 94
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 953
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "ret_bg-to-main_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_1": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_2": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 287
+                },
+                "ret_bg-to-main_3": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 9,
+              "bytes": 337347,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "callLepusMethod": {
+                  "messages": 4,
+                  "bytes": 336446
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 781
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 159.5,
+          "wire": {
+            "toBts": {
+              "messages": 12,
+              "bytes": 2058,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 228
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 1,
+                  "bytes": 94
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 955
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "ret_bg-to-main_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_1": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_2": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 287
+                },
+                "ret_bg-to-main_3": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 9,
+              "bytes": 337348,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "callLepusMethod": {
+                  "messages": 4,
+                  "bytes": 336445
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 783
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "replace": {
+      "control": [
+        {
+          "rawMs": 316.2999999523163,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999052,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 244
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 321
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376262,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376262
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 312.7999999523163,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999046,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 238
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 321
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376487,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376487
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 355,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999043,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 321
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376437,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376437
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 311.7999999523163,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999037,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 229
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 321
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376507,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376507
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 303.2000000476837,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999052,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 244
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 321
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376343,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376343
+                }
+              }
+            }
+          }
+        }
+      ],
+      "profile": [
+        {
+          "rawMs": 337.2000000476837,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999041,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 233
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 321
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376572,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376572
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 337.2000000476837,
+            "stages": {
+              "bg_replay": 37.60000014305115,
+              "wire_clone_transfer": 2.700000047683716,
+              "mt_validate": 9.200000047683716,
+              "mt_expand": 0,
+              "mt_prepare": 56.59999990463257,
+              "papi_element_creation": 61.000004053115845,
+              "mt_apply_other": 87.99999594688416,
+              "mt_ack_publication": 38.09999990463257,
+              "presentation_residual": 44
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 10001,
+              "bytes": 376460,
+              "selfcheckMs": 0,
+              "dispatchMs": 2.700000047683716,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 37.60000014305115
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 10001,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 9.200000047683716,
+              "prepareMs": 56.59999990463257,
+              "prepareCheckMs": 0,
+              "applyMs": 149,
+              "ackMs": 38.09999990463257,
+              "papiCreateMs": 61.000004053115845,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0
+            }
+          }
+        },
+        {
+          "rawMs": 311.09999990463257,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999031,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 309
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376533,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376533
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 311.09999990463257,
+            "stages": {
+              "bg_replay": 36.200000047683716,
+              "wire_clone_transfer": 2.700000047683716,
+              "mt_validate": 10,
+              "mt_expand": 0,
+              "mt_prepare": 54.200000047683716,
+              "papi_element_creation": 53.80000424385071,
+              "mt_apply_other": 81.69999575614929,
+              "mt_ack_publication": 36.19999980926514,
+              "presentation_residual": 36.299999952316284
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 10001,
+              "bytes": 376421,
+              "selfcheckMs": 0,
+              "dispatchMs": 2.700000047683716,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 36.200000047683716
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 10001,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 10,
+              "prepareMs": 54.200000047683716,
+              "prepareCheckMs": 0,
+              "applyMs": 135.5,
+              "ackMs": 36.19999980926514,
+              "papiCreateMs": 53.80000424385071,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0
+            }
+          }
+        },
+        {
+          "rawMs": 316.5,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999038,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 244
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 307
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376531,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376531
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 316.5,
+            "stages": {
+              "bg_replay": 36.700000047683716,
+              "wire_clone_transfer": 2.8999998569488525,
+              "mt_validate": 8,
+              "mt_expand": 0,
+              "mt_prepare": 55.89999985694885,
+              "papi_element_creation": 48.99999809265137,
+              "mt_apply_other": 81.90000176429749,
+              "mt_ack_publication": 35.5,
+              "presentation_residual": 46.60000038146973
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 10001,
+              "bytes": 376419,
+              "selfcheckMs": 0,
+              "dispatchMs": 2.8999998569488525,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 36.700000047683716
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 10001,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 8,
+              "prepareMs": 55.89999985694885,
+              "prepareCheckMs": 0,
+              "applyMs": 130.89999985694885,
+              "ackMs": 35.5,
+              "papiCreateMs": 48.99999809265137,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0
+            }
+          }
+        },
+        {
+          "rawMs": 323.5,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999043,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 321
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376656,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376656
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 323.5,
+            "stages": {
+              "bg_replay": 38.200000047683716,
+              "wire_clone_transfer": 3.4000000953674316,
+              "mt_validate": 8.200000047683716,
+              "mt_expand": 0,
+              "mt_prepare": 60.40000009536743,
+              "papi_element_creation": 52.79999923706055,
+              "mt_apply_other": 80.30000066757202,
+              "mt_ack_publication": 36,
+              "presentation_residual": 44.19999980926514
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 10001,
+              "bytes": 376544,
+              "selfcheckMs": 0,
+              "dispatchMs": 3.4000000953674316,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 38.200000047683716
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 10001,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 8.200000047683716,
+              "prepareMs": 60.40000009536743,
+              "prepareCheckMs": 0,
+              "applyMs": 133.09999990463257,
+              "ackMs": 36,
+              "papiCreateMs": 52.79999923706055,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0
+            }
+          }
+        },
+        {
+          "rawMs": 304.2999999523163,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999043,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 321
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376587,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376587
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 304.2999999523163,
+            "stages": {
+              "bg_replay": 36.299999952316284,
+              "wire_clone_transfer": 2.799999952316284,
+              "mt_validate": 10.299999952316284,
+              "mt_expand": 0,
+              "mt_prepare": 54.09999990463257,
+              "papi_element_creation": 53.90000009536743,
+              "mt_apply_other": 76.59999990463257,
+              "mt_ack_publication": 35.5,
+              "presentation_residual": 34.80000019073486
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 10001,
+              "bytes": 376475,
+              "selfcheckMs": 0,
+              "dispatchMs": 2.799999952316284,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 36.299999952316284
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 10001,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 10.299999952316284,
+              "prepareMs": 54.09999990463257,
+              "prepareCheckMs": 0,
+              "applyMs": 130.5,
+              "ackMs": 35.5,
+              "papiCreateMs": 53.90000009536743,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0
+            }
+          }
+        }
+      ],
+      "vueVdom": [
+        {
+          "rawMs": 173.79999995231628,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 346,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 286
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 356775,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 356775
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 173.5,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 346,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 286
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 356936,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 356936
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 179.20000004768372,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 346,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 286
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 356826,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 356826
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 186,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 346,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 286
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 356622,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 356622
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 174.70000004768372,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 334,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 274
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 356947,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 356947
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "append": {
+      "control": [
+        {
+          "rawMs": 201,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713062,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 324
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 34820,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 34820
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 227.89999985694885,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713062,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 324
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 35099,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 35099
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 195,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713062,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 324
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 35062,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 35062
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 197.60000014305115,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713062,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 324
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 34937,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 34937
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 189.69999980926514,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713048,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 310
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 34824,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 34824
+                }
+              }
+            }
+          }
+        }
+      ],
+      "profile": [
+        {
+          "rawMs": 192.40000009536743,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713061,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 234
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 324
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 34993,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 34993
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 192.40000009536743,
+            "stages": {
+              "bg_replay": 28.300000190734863,
+              "wire_clone_transfer": 0.39999985694885254,
+              "mt_validate": 1.0999999046325684,
+              "mt_expand": 0.09999990463256836,
+              "mt_prepare": 16.40000009536743,
+              "papi_element_creation": 53.70000100135803,
+              "mt_apply_other": 41.999999046325684,
+              "mt_ack_publication": 31.299999952316284,
+              "presentation_residual": 19.100000143051147
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 1,
+              "bytes": 34881,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.39999985694885254,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 28.300000190734863
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 1,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 1.0999999046325684,
+              "prepareMs": 16.40000009536743,
+              "prepareCheckMs": 0,
+              "applyMs": 95.70000004768372,
+              "ackMs": 31.299999952316284,
+              "papiCreateMs": 53.70000100135803,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0.09999990463256836
+            }
+          }
+        },
+        {
+          "rawMs": 201.09999990463257,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713071,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 244
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 324
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 34974,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 34974
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 201.09999990463257,
+            "stages": {
+              "bg_replay": 29.200000047683716,
+              "wire_clone_transfer": 0.5,
+              "mt_validate": 1.2000000476837158,
+              "mt_expand": 0,
+              "mt_prepare": 16,
+              "papi_element_creation": 53.6000030040741,
+              "mt_apply_other": 48.799996852874756,
+              "mt_ack_publication": 30.800000190734863,
+              "presentation_residual": 20.99999976158142
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 1,
+              "bytes": 34862,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.5,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 29.200000047683716
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 1,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 1.2000000476837158,
+              "prepareMs": 16,
+              "prepareCheckMs": 0,
+              "applyMs": 102.39999985694885,
+              "ackMs": 30.800000190734863,
+              "papiCreateMs": 53.6000030040741,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0
+            }
+          }
+        },
+        {
+          "rawMs": 211.30000019073486,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713062,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 324
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 34883,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 34883
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 211.30000019073486,
+            "stages": {
+              "bg_replay": 27.299999952316284,
+              "wire_clone_transfer": 0.40000009536743164,
+              "mt_validate": 1.0999999046325684,
+              "mt_expand": 0.09999990463256836,
+              "mt_prepare": 16.600000143051147,
+              "papi_element_creation": 61.19999861717224,
+              "mt_apply_other": 46.30000138282776,
+              "mt_ack_publication": 36.200000047683716,
+              "presentation_residual": 22.100000143051147
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 1,
+              "bytes": 34771,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.40000009536743164,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 27.299999952316284
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 1,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 1.0999999046325684,
+              "prepareMs": 16.600000143051147,
+              "prepareCheckMs": 0,
+              "applyMs": 107.5,
+              "ackMs": 36.200000047683716,
+              "papiCreateMs": 61.19999861717224,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0.09999990463256836
+            }
+          }
+        },
+        {
+          "rawMs": 197.70000004768372,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713066,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 239
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 324
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 35079,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 35079
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 197.70000004768372,
+            "stages": {
+              "bg_replay": 28.799999952316284,
+              "wire_clone_transfer": 0.2999999523162842,
+              "mt_validate": 1.2000000476837158,
+              "mt_expand": 0,
+              "mt_prepare": 16.799999952316284,
+              "papi_element_creation": 54.20000243186951,
+              "mt_apply_other": 44.39999771118164,
+              "mt_ack_publication": 31.899999856948853,
+              "presentation_residual": 20.100000143051147
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 1,
+              "bytes": 34967,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.2999999523162842,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 28.799999952316284
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 1,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 1.2000000476837158,
+              "prepareMs": 16.799999952316284,
+              "prepareCheckMs": 0,
+              "applyMs": 98.60000014305115,
+              "ackMs": 31.899999856948853,
+              "papiCreateMs": 54.20000243186951,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0
+            }
+          }
+        },
+        {
+          "rawMs": 189.79999995231628,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713062,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 324
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 34964,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 34964
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 189.79999995231628,
+            "stages": {
+              "bg_replay": 26.199999809265137,
+              "wire_clone_transfer": 0.40000009536743164,
+              "mt_validate": 1.2000000476837158,
+              "mt_expand": 0,
+              "mt_prepare": 14.700000047683716,
+              "papi_element_creation": 49.69999837875366,
+              "mt_apply_other": 48.70000171661377,
+              "mt_ack_publication": 30.299999952316284,
+              "presentation_residual": 18.59999990463257
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 1,
+              "bytes": 34852,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.40000009536743164,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 26.199999809265137
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 1,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 1.2000000476837158,
+              "prepareMs": 14.700000047683716,
+              "prepareCheckMs": 0,
+              "applyMs": 98.40000009536743,
+              "ackMs": 30.299999952316284,
+              "papiCreateMs": 49.69999837875366,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0
+            }
+          }
+        }
+      ],
+      "vueVdom": [
+        {
+          "rawMs": 155.20000004768372,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 336,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 276
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 343099,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 343099
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 157.29999995231628,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 348,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 288
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 343161,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 343161
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 161.60000014305115,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 348,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 288
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 343314,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 343314
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 163.20000004768372,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 348,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 288
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 343142,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 343142
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 174.70000004768372,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 348,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 288
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 343166,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 343166
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/benchmarks/lynx-table/stages/results/live-1000.md
+++ b/benchmarks/lynx-table/stages/results/live-1000.md
@@ -1,0 +1,78 @@
+# Lynx 1,000-row stage decomposition
+
+- measured: 2026-08-12T00:23:08.466Z
+- host: 32× Intel(R) Xeon(R) Platinum 8336C CPU @ 2.30GHz; linux 5.15.120.bsk.3-amd64; Node v22.22.2; Chromium 149.0.7827.55
+- protocol: fresh page per operation sample; control/profile order alternates AB/BA; one vue-vdom create/replace/append triplet follows each pair; no other benchmark process ran in this window
+- host load: start 2.07/2.16/1.99 (1/5/15m), end 2.58/2.31/2.05
+- repetitions: n=5 per A/B cell
+
+## FCP@1000
+
+Attribution starts when the shared browser hook assigns the hidden main-thread iframe Blob script URL, before load/parse/evaluation, and ends when the shared composed-tree observer first sees all 1,000 rows. `layout_flush_residual` is the exclusive remainder after directly observed slice evaluation, plan interpretation, and PAPI element creation; it includes PAPI prop/insertion work, `__FlushElementTree`, Web Core DOM publication, style/layout, and observer-frame delay because the host exposes no stable boundary between those costs.
+
+| segment | median ms | min–max ms | share |
+|---|---:|---:|---:|
+| mt_slice_eval | 19.3 | 18.5–20.1 | 8.9% |
+| plan_interpretation | 17.4 | 17.2–19.1 | 8.0% |
+| papi_element_creation | 60.3 | 58–65.6 | 27.8% |
+| layout_flush_residual | 120.6 | 118.5–137.2 | 55.7% |
+
+Raw view-attach FCP: profile 244.7 ms (240.6–273.3), control 241.9 ms; same-window profile/control 1.012×.
+
+## create@1000
+
+Attribution starts at the shared pointerdown boundary and ends when the shared composed-tree observer sees 1,000 rows. All named intervals are directly observed and exclusive; `presentation_residual` is the wall-clock remainder through final composed-tree presentation.
+
+| segment | median ms | min–max ms | share |
+|---|---:|---:|---:|
+| bg_replay | 26.9 | 26.4–29.4 | 18.1% |
+| wire_clone_transfer | 0.6 | 0.4–0.7 | 0.4% |
+| mt_validate | 1.9 | 1.7–2.2 | 1.3% |
+| mt_expand | 0 | 0–0.1 | 0.0% |
+| mt_prepare | 1.6 | 1.5–1.8 | 1.1% |
+| papi_element_creation | 62 | 56.7–65.9 | 41.8% |
+| mt_apply_other | 41 | 36.6–44.8 | 27.6% |
+| mt_ack_publication | 0.5 | 0.4–0.6 | 0.3% |
+| presentation_residual | 13.2 | 12.3–15.6 | 8.9% |
+
+Raw create: profile 148.3 ms (142.1–154.4), control 141.8 ms, vue-vdom 159.5 ms; same-window profile/control 1.046×, profile/vue-vdom 0.93×.
+Wire: MTS→BTS 19,361 B / 14 messages; BTS→MTS 41,355 B / 10 messages.
+
+## replace@1k
+
+| segment | median ms | share |
+|---|---:|---:|
+| bg_replay | 36.7 | 11.6% |
+| wire_clone_transfer | 2.8 | 0.9% |
+| mt_validate | 9.2 | 2.9% |
+| mt_expand | 0 | 0.0% |
+| mt_prepare | 55.9 | 17.7% |
+| papi_element_creation | 53.8 | 17.0% |
+| mt_apply_other | 81.7 | 25.8% |
+| mt_ack_publication | 36 | 11.4% |
+| presentation_residual | 44 | 13.9% |
+
+Raw replace: profile 316.5 ms, control 312.8 ms, vue-vdom 174.7 ms. Wire: MTS→BTS 1,999,041 B / 4 messages; BTS→MTS 376,572 B / 1 messages.
+
+## append@1k
+
+| segment | median ms | share |
+|---|---:|---:|
+| bg_replay | 28.3 | 14.3% |
+| wire_clone_transfer | 0.4 | 0.2% |
+| mt_validate | 1.2 | 0.6% |
+| mt_expand | 0 | 0.0% |
+| mt_prepare | 16.4 | 8.3% |
+| papi_element_creation | 53.7 | 27.2% |
+| mt_apply_other | 46.3 | 23.4% |
+| mt_ack_publication | 31.3 | 15.8% |
+| presentation_residual | 20.1 | 10.2% |
+
+Raw append: profile 197.7 ms, control 197.6 ms, vue-vdom 161.6 ms. Wire: MTS→BTS 1,713,062 B / 4 messages; BTS→MTS 34,974 B / 1 messages.
+
+## Verdicts
+
+- **#47 wire/encoding candidate: NO-GO.** clone/transfer is 0.4% of create, 0.9% of replace, and 0.2% of append; it does not clear the 10% owner gate.
+- **#47 measured CPU owner: SPLIT.** PAPI creation plus remaining host apply is 69.5% of create. This is a host materialization owner, not evidence for changing the wire representation.
+- **#47 acknowledgement-only candidate: NO-GO for issue acceptance.** ACK/publication is 0.3% of create, 11.4% of replace, and 15.8% of append; even a complete removal cannot meet the required 15% in all three cells or the 50% total-wire gate.
+

--- a/benchmarks/lynx-table/stages/results/live-1000.md
+++ b/benchmarks/lynx-table/stages/results/live-1000.md
@@ -75,4 +75,3 @@ Raw append: profile 197.7 ms, control 197.6 ms, vue-vdom 161.6 ms. Wire: MTS→B
 - **#47 wire/encoding candidate: NO-GO.** clone/transfer is 0.4% of create, 0.9% of replace, and 0.2% of append; it does not clear the 10% owner gate.
 - **#47 measured CPU owner: SPLIT.** PAPI creation plus remaining host apply is 69.5% of create. This is a host materialization owner, not evidence for changing the wire representation.
 - **#47 acknowledgement-only candidate: NO-GO for issue acceptance.** ACK/publication is 0.3% of create, 11.4% of replace, and 15.8% of append; even a complete removal cannot meet the required 15% in all three cells or the 50% total-wire gate.
-

--- a/benchmarks/lynx-table/stages/results/live-10000.json
+++ b/benchmarks/lynx-table/stages/results/live-10000.json
@@ -1,0 +1,3389 @@
+{
+  "meta": {
+    "date": "2026-08-12T00:14:21.625Z",
+    "node": "v22.22.2",
+    "cpus": 32,
+    "cpuModel": "Intel(R) Xeon(R) Platinum 8336C CPU @ 2.30GHz",
+    "platform": "linux",
+    "release": "5.15.120.bsk.3-amd64",
+    "chromium": "149.0.7827.55",
+    "repetitions": 5,
+    "rows": 10000,
+    "reportable": true,
+    "loadStart": [1.53, 1.69, 1.74],
+    "loadEnd": [2.47, 2.14, 1.91],
+    "protocol": "fresh page per operation sample; control/profile order alternates AB/BA; one vue-vdom create/replace/append triplet follows each pair; no other benchmark process ran in this window"
+  },
+  "fcp": {
+    "attribution": {
+      "total": {
+        "median": 1700.300048828125,
+        "min": 1646.69970703125,
+        "max": 1804.699951171875,
+        "spread": 158.000244140625,
+        "n": 5
+      },
+      "stages": {
+        "mt_slice_eval": {
+          "median": 20.60009765625,
+          "min": 20.199951171875,
+          "max": 21.60009765625,
+          "spread": 1.400146484375,
+          "n": 5,
+          "share": 0.012115566114608966
+        },
+        "plan_interpretation": {
+          "median": 124.29999995231628,
+          "min": 121.90000009536743,
+          "max": 125.90000009536743,
+          "spread": 4,
+          "n": 5,
+          "share": 0.07310474409383562
+        },
+        "papi_element_creation": {
+          "median": 523.5999891757965,
+          "min": 492.0999987125397,
+          "max": 536.9999942779541,
+          "spread": 44.89999556541443,
+          "n": 5,
+          "share": 0.30794564143938613
+        },
+        "layout_flush_residual": {
+          "median": 1035.3999490737915,
+          "min": 1010.6997573375702,
+          "max": 1126.5998125076294,
+          "spread": 115.9000551700592,
+          "n": 5,
+          "share": 0.6089513140856558
+        }
+      },
+      "ratios": {}
+    },
+    "rawControl": {
+      "median": 1678.2999999523163,
+      "min": 1630.9000000953674,
+      "max": 1830.1000001430511,
+      "spread": 199.20000004768372,
+      "n": 5
+    },
+    "rawProfile": {
+      "median": 1730.1999998092651,
+      "min": 1673.2000000476837,
+      "max": 1867.2999999523163,
+      "spread": 194.09999990463257,
+      "n": 5
+    }
+  },
+  "create": {
+    "attribution": {
+      "total": {
+        "median": 1201.5,
+        "min": 1184.6000001430511,
+        "max": 1234.2000000476837,
+        "spread": 49.59999990463257,
+        "n": 5
+      },
+      "stages": {
+        "bg_replay": {
+          "median": 146.09999990463257,
+          "min": 134.69999980926514,
+          "max": 156.79999995231628,
+          "spread": 22.100000143051147,
+          "n": 5,
+          "share": 0.12159800241750526
+        },
+        "wire_clone_transfer": {
+          "median": 3.999999761581421,
+          "min": 3.5,
+          "max": 4.200000047683716,
+          "spread": 0.7000000476837158,
+          "n": 5,
+          "share": 0.0033291716700636046
+        },
+        "mt_validate": {
+          "median": 11.900000095367432,
+          "min": 11,
+          "max": 12.400000095367432,
+          "spread": 1.4000000953674316,
+          "n": 5,
+          "share": 0.009904286388154333
+        },
+        "mt_expand": {
+          "median": 0,
+          "min": 0,
+          "max": 0.10000014305114746,
+          "spread": 0.10000014305114746,
+          "n": 5,
+          "share": 0
+        },
+        "mt_prepare": {
+          "median": 5.200000047683716,
+          "min": 5.099999904632568,
+          "max": 5.299999952316284,
+          "spread": 0.20000004768371582,
+          "n": 5,
+          "share": 0.004327923468733846
+        },
+        "papi_element_creation": {
+          "median": 578.2000014781952,
+          "min": 566.4999947547913,
+          "max": 610.6000137329102,
+          "spread": 44.1000189781189,
+          "n": 5,
+          "share": 0.48123179482163564
+        },
+        "mt_apply_other": {
+          "median": 341.69999861717224,
+          "min": 312.49998664855957,
+          "max": 357.49999594688416,
+          "spread": 45.000009298324585,
+          "n": 5,
+          "share": 0.2843945057154992
+        },
+        "mt_ack_publication": {
+          "median": 0.5999999046325684,
+          "min": 0.39999985694885254,
+          "max": 0.7000000476837158,
+          "spread": 0.3000001907348633,
+          "n": 5,
+          "share": 0.000499375700901014
+        },
+        "presentation_residual": {
+          "median": 119.00000047683716,
+          "min": 109.2000002861023,
+          "max": 128.20000052452087,
+          "spread": 19.00000023841858,
+          "n": 5,
+          "share": 0.09904286348467511
+        }
+      },
+      "ratios": {
+        "control": 1.052285864248811,
+        "reference": 0.8620318553889402
+      }
+    },
+    "wire": {
+      "toBts": {
+        "bytes": {
+          "median": 19608,
+          "min": 19587,
+          "max": 19617,
+          "spread": 30,
+          "n": 5
+        },
+        "messages": {
+          "median": 15,
+          "min": 15,
+          "max": 15,
+          "spread": 0,
+          "n": 5
+        }
+      },
+      "toMts": {
+        "bytes": {
+          "median": 347168,
+          "min": 346746,
+          "max": 347994,
+          "spread": 1248,
+          "n": 5
+        },
+        "messages": {
+          "median": 10,
+          "min": 10,
+          "max": 10,
+          "spread": 0,
+          "n": 5
+        }
+      }
+    },
+    "rawControl": {
+      "median": 1141.8000001907349,
+      "min": 1127.7999999523163,
+      "max": 1183.1000001430511,
+      "spread": 55.30000019073486,
+      "n": 5
+    },
+    "rawProfile": {
+      "median": 1201.5,
+      "min": 1184.6000001430511,
+      "max": 1234.2000000476837,
+      "spread": 49.59999990463257,
+      "n": 5
+    },
+    "vueVdom": {
+      "median": 1393.7999999523163,
+      "min": 1363.9000000953674,
+      "max": 1455.7999999523163,
+      "spread": 91.89999985694885,
+      "n": 5
+    }
+  },
+  "replace": {
+    "attribution": {
+      "total": {
+        "median": 333.09999990463257,
+        "min": 305.5,
+        "max": 343.2999999523163,
+        "spread": 37.799999952316284,
+        "n": 5
+      },
+      "stages": {
+        "bg_replay": {
+          "median": 36.299999952316284,
+          "min": 35.09999990463257,
+          "max": 54.299999952316284,
+          "spread": 19.200000047683716,
+          "n": 5,
+          "share": 0.10897628328642772
+        },
+        "wire_clone_transfer": {
+          "median": 3,
+          "min": 2.700000047683716,
+          "max": 5.299999952316284,
+          "spread": 2.5999999046325684,
+          "n": 5,
+          "share": 0.009006304415667691
+        },
+        "mt_validate": {
+          "median": 9.700000047683716,
+          "min": 7.900000095367432,
+          "max": 10.299999952316284,
+          "spread": 2.3999998569488525,
+          "n": 5,
+          "share": 0.02912038442047689
+        },
+        "mt_expand": {
+          "median": 0,
+          "min": 0,
+          "max": 0,
+          "spread": 0,
+          "n": 5,
+          "share": 0
+        },
+        "mt_prepare": {
+          "median": 60.60000014305115,
+          "min": 54.80000019073486,
+          "max": 61.200000047683716,
+          "spread": 6.3999998569488525,
+          "n": 5,
+          "share": 0.18192734962594143
+        },
+        "papi_element_creation": {
+          "median": 53.299996852874756,
+          "min": 52.300002098083496,
+          "max": 60.19999980926514,
+          "spread": 7.899997711181641,
+          "n": 5,
+          "share": 0.16001199900370666
+        },
+        "mt_apply_other": {
+          "median": 84.2000002861023,
+          "min": 79.70000314712524,
+          "max": 86.6999979019165,
+          "spread": 6.99999475479126,
+          "n": 5,
+          "share": 0.2527769447919813
+        },
+        "mt_ack_publication": {
+          "median": 36.89999985694885,
+          "min": 36,
+          "max": 37.89999985694885,
+          "spread": 1.8999998569488525,
+          "n": 5,
+          "share": 0.11077754388325854
+        },
+        "presentation_residual": {
+          "median": 43.19999980926514,
+          "min": 33.59999990463257,
+          "max": 48.59999990463257,
+          "spread": 15,
+          "n": 5,
+          "share": 0.12969078301300935
+        }
+      },
+      "ratios": {
+        "control": 1.0935653307557347,
+        "reference": 1.8192244655619356
+      }
+    },
+    "rawControl": {
+      "median": 304.60000014305115,
+      "min": 297.80000019073486,
+      "max": 350.5,
+      "spread": 52.69999980926514,
+      "n": 5
+    },
+    "rawProfile": {
+      "median": 333.09999990463257,
+      "min": 305.5,
+      "max": 343.2999999523163,
+      "spread": 37.799999952316284,
+      "n": 5
+    },
+    "vueVdom": {
+      "median": 183.10000014305115,
+      "min": 180,
+      "max": 186.10000014305115,
+      "spread": 6.1000001430511475,
+      "n": 5
+    },
+    "wire": {
+      "toBts": {
+        "bytes": {
+          "median": 1999043,
+          "min": 1998809,
+          "max": 1999043,
+          "spread": 234,
+          "n": 5
+        },
+        "messages": {
+          "median": 4,
+          "min": 3,
+          "max": 4,
+          "spread": 1,
+          "n": 5
+        }
+      },
+      "toMts": {
+        "bytes": {
+          "median": 376446,
+          "min": 376394,
+          "max": 376586,
+          "spread": 192,
+          "n": 5
+        },
+        "messages": {
+          "median": 1,
+          "min": 1,
+          "max": 1,
+          "spread": 0,
+          "n": 5
+        }
+      }
+    }
+  },
+  "append": {
+    "attribution": {
+      "total": {
+        "median": 193.70000004768372,
+        "min": 191,
+        "max": 203.5,
+        "spread": 12.5,
+        "n": 5
+      },
+      "stages": {
+        "bg_replay": {
+          "median": 27.700000047683716,
+          "min": 26.799999952316284,
+          "max": 29.09999990463257,
+          "spread": 2.299999952316284,
+          "n": 5,
+          "share": 0.1430046465713202
+        },
+        "wire_clone_transfer": {
+          "median": 0.39999985694885254,
+          "min": 0.2999999523162842,
+          "max": 0.40000009536743164,
+          "spread": 0.10000014305114746,
+          "n": 5,
+          "share": 0.002065048305887369
+        },
+        "mt_validate": {
+          "median": 1.2999999523162842,
+          "min": 1.2000000476837158,
+          "max": 1.4000000953674316,
+          "spread": 0.20000004768371582,
+          "n": 5,
+          "share": 0.006711409148147957
+        },
+        "mt_expand": {
+          "median": 0.09999990463256836,
+          "min": 0,
+          "max": 0.10000014305114746,
+          "spread": 0.10000014305114746,
+          "n": 5,
+          "share": 0.0005162617687555554
+        },
+        "mt_prepare": {
+          "median": 16.100000143051147,
+          "min": 16,
+          "max": 17.799999952316284,
+          "spread": 1.7999999523162842,
+          "n": 5,
+          "share": 0.08311822477587899
+        },
+        "papi_element_creation": {
+          "median": 53.40000104904175,
+          "min": 49.500001192092896,
+          "max": 57.30000042915344,
+          "spread": 7.799999237060547,
+          "n": 5,
+          "share": 0.2756840528440687
+        },
+        "mt_apply_other": {
+          "median": 46.399996280670166,
+          "min": 41.499999046325684,
+          "max": 47.69999885559082,
+          "spread": 6.199999809265137,
+          "n": 5,
+          "share": 0.23954566994965276
+        },
+        "mt_ack_publication": {
+          "median": 30.59999990463257,
+          "min": 30.399999856948853,
+          "max": 32.299999952316284,
+          "spread": 1.9000000953674316,
+          "n": 5,
+          "share": 0.15797625140474794
+        },
+        "presentation_residual": {
+          "median": 19.700000286102295,
+          "min": 18.59999990463257,
+          "max": 23.399999856948853,
+          "spread": 4.799999952316284,
+          "n": 5,
+          "share": 0.1017036669140562
+        }
+      },
+      "ratios": {
+        "control": 0.9882653063657333,
+        "reference": 1.2174732864457747
+      }
+    },
+    "rawControl": {
+      "median": 196,
+      "min": 182.60000014305115,
+      "max": 209.80000019073486,
+      "spread": 27.200000047683716,
+      "n": 5
+    },
+    "rawProfile": {
+      "median": 193.70000004768372,
+      "min": 191,
+      "max": 203.5,
+      "spread": 12.5,
+      "n": 5
+    },
+    "vueVdom": {
+      "median": 159.10000014305115,
+      "min": 153.09999990463257,
+      "max": 196,
+      "spread": 42.90000009536743,
+      "n": 5
+    },
+    "wire": {
+      "toBts": {
+        "bytes": {
+          "median": 1713061,
+          "min": 1713051,
+          "max": 1713071,
+          "spread": 20,
+          "n": 5
+        },
+        "messages": {
+          "median": 4,
+          "min": 4,
+          "max": 4,
+          "spread": 0,
+          "n": 5
+        }
+      },
+      "toMts": {
+        "bytes": {
+          "median": 34944,
+          "min": 34721,
+          "max": 35071,
+          "spread": 350,
+          "n": 5
+        },
+        "messages": {
+          "median": 1,
+          "min": 1,
+          "max": 1,
+          "spread": 0,
+          "n": 5
+        }
+      }
+    }
+  },
+  "verdicts": [
+    {
+      "step": "#47 wire/encoding candidate",
+      "verdict": "NO-GO",
+      "reason": "clone/transfer is 0.3% of create, 0.9% of replace, and 0.2% of append; it does not clear the 10% owner gate."
+    },
+    {
+      "step": "#47 measured CPU owner",
+      "verdict": "SPLIT",
+      "reason": "PAPI creation plus remaining host apply is 76.6% of create. This is a host materialization owner, not evidence for changing the wire representation."
+    },
+    {
+      "step": "#47 acknowledgement-only candidate",
+      "verdict": "NO-GO for issue acceptance",
+      "reason": "ACK/publication is 0.0% of create, 11.1% of replace, and 15.8% of append; even a complete removal cannot meet the required 15% in all three cells or the 50% total-wire gate."
+    }
+  ],
+  "samples": {
+    "fcp": {
+      "control": [
+        {
+          "rawMs": 1678.2999999523163
+        },
+        {
+          "rawMs": 1649.4000000953674
+        },
+        {
+          "rawMs": 1630.9000000953674
+        },
+        {
+          "rawMs": 1686.1999998092651
+        },
+        {
+          "rawMs": 1830.1000001430511
+        }
+      ],
+      "profile": [
+        {
+          "rawMs": 1712.2999999523163,
+          "attribution": {
+            "totalMs": 1680.699951171875,
+            "stages": {
+              "mt_slice_eval": 21.300048828125,
+              "plan_interpretation": 124.29999995231628,
+              "papi_element_creation": 523.5999891757965,
+              "layout_flush_residual": 1011.4999132156372
+            }
+          },
+          "realms": {
+            "background": null,
+            "main": {
+              "commits": 0,
+              "pacedCommits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "papiCreateMs": 523.5999891757965,
+              "mtSliceStartEpochMs": 1786493558381.3,
+              "mtSliceEvalMs": 21.300048828125,
+              "firstScreenPlanMs": 124.29999995231628
+            }
+          }
+        },
+        {
+          "rawMs": 1867.2999999523163,
+          "attribution": {
+            "totalMs": 1804.699951171875,
+            "stages": {
+              "mt_slice_eval": 20.400146484375,
+              "plan_interpretation": 121.90000009536743,
+              "papi_element_creation": 535.7999920845032,
+              "layout_flush_residual": 1126.5998125076294
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.09999990463256836,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0
+            },
+            "main": {
+              "commits": 0,
+              "pacedCommits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "papiCreateMs": 535.7999920845032,
+              "mtSliceStartEpochMs": 1786493573056.3,
+              "mtSliceEvalMs": 20.400146484375,
+              "firstScreenPlanMs": 121.90000009536743
+            }
+          }
+        },
+        {
+          "rawMs": 1806.5999999046326,
+          "attribution": {
+            "totalMs": 1776.400146484375,
+            "stages": {
+              "mt_slice_eval": 21.60009765625,
+              "plan_interpretation": 125.90000009536743,
+              "papi_element_creation": 536.9999942779541,
+              "layout_flush_residual": 1091.9000544548035
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.09999990463256836,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0
+            },
+            "main": {
+              "commits": 0,
+              "pacedCommits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "papiCreateMs": 536.9999942779541,
+              "mtSliceStartEpochMs": 1786493603750.3,
+              "mtSliceEvalMs": 21.60009765625,
+              "firstScreenPlanMs": 125.90000009536743
+            }
+          }
+        },
+        {
+          "rawMs": 1730.1999998092651,
+          "attribution": {
+            "totalMs": 1700.300048828125,
+            "stages": {
+              "mt_slice_eval": 20.60009765625,
+              "plan_interpretation": 124.70000004768372,
+              "papi_element_creation": 519.6000020503998,
+              "layout_flush_residual": 1035.3999490737915
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.09999990463256836,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0
+            },
+            "main": {
+              "commits": 0,
+              "pacedCommits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "papiCreateMs": 519.6000020503998,
+              "mtSliceStartEpochMs": 1786493617391.9,
+              "mtSliceEvalMs": 20.60009765625,
+              "firstScreenPlanMs": 124.70000004768372
+            }
+          }
+        },
+        {
+          "rawMs": 1673.2000000476837,
+          "attribution": {
+            "totalMs": 1646.69970703125,
+            "stages": {
+              "mt_slice_eval": 20.199951171875,
+              "plan_interpretation": 123.69999980926514,
+              "papi_element_creation": 492.0999987125397,
+              "layout_flush_residual": 1010.6997573375702
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.19999980926513672,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0
+            },
+            "main": {
+              "commits": 0,
+              "pacedCommits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "papiCreateMs": 492.0999987125397,
+              "mtSliceStartEpochMs": 1786493648397.4001,
+              "mtSliceEvalMs": 20.199951171875,
+              "firstScreenPlanMs": 123.69999980926514
+            }
+          }
+        }
+      ]
+    },
+    "create": {
+      "control": [
+        {
+          "rawMs": 1141.8000001907349,
+          "wire": {
+            "toBts": {
+              "messages": 15,
+              "bytes": 19603,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17792
+                },
+                "markTiming": {
+                  "messages": 2,
+                  "bytes": 1002
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 328
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 347095,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 346299
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 676
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 1157.8000001907349,
+          "wire": {
+            "toBts": {
+              "messages": 15,
+              "bytes": 19600,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17792
+                },
+                "markTiming": {
+                  "messages": 2,
+                  "bytes": 999
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 328
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 346999,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 346209
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 670
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 1127.7999999523163,
+          "wire": {
+            "toBts": {
+              "messages": 15,
+              "bytes": 19593,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17792
+                },
+                "markTiming": {
+                  "messages": 2,
+                  "bytes": 1005
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 315
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 347204,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 346410
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 674
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 1183.1000001430511,
+          "wire": {
+            "toBts": {
+              "messages": 15,
+              "bytes": 19600,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17792
+                },
+                "markTiming": {
+                  "messages": 2,
+                  "bytes": 999
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 328
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 347296,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 346503
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 673
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 1128.0999999046326,
+          "wire": {
+            "toBts": {
+              "messages": 15,
+              "bytes": 19610,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17792
+                },
+                "markTiming": {
+                  "messages": 2,
+                  "bytes": 1009
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 328
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 347481,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 346681
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 680
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          }
+        }
+      ],
+      "profile": [
+        {
+          "rawMs": 1234.2000000476837,
+          "wire": {
+            "toBts": {
+              "messages": 15,
+              "bytes": 19602,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17792
+                },
+                "markTiming": {
+                  "messages": 2,
+                  "bytes": 1002
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 327
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 347994,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 347088
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 786
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 1234.2000000476837,
+            "stages": {
+              "bg_replay": 156.79999995231628,
+              "wire_clone_transfer": 4.200000047683716,
+              "mt_validate": 12.400000095367432,
+              "mt_expand": 0.10000014305114746,
+              "mt_prepare": 5.099999904632568,
+              "papi_element_creation": 595.5000066757202,
+              "mt_apply_other": 344.39999318122864,
+              "mt_ack_publication": 0.7000000476837158,
+              "presentation_residual": 115
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 2,
+              "commands": 95,
+              "bytes": 346282,
+              "selfcheckMs": 0,
+              "dispatchMs": 4.200000047683716,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 10000,
+              "templateValues": 30000,
+              "bgReplayMs": 156.79999995231628
+            },
+            "main": {
+              "commits": 2,
+              "pacedCommits": 0,
+              "commands": 95,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 12.400000095367432,
+              "prepareMs": 5.099999904632568,
+              "prepareCheckMs": 0,
+              "applyMs": 939.8999998569489,
+              "ackMs": 0.7000000476837158,
+              "papiCreateMs": 595.5000066757202,
+              "mtSliceStartEpochMs": 1786493562606.8,
+              "mtSliceEvalMs": 22.300048828125,
+              "firstScreenPlanMs": 0.40000009536743164,
+              "mtExpandMs": 0.10000014305114746
+            }
+          }
+        },
+        {
+          "rawMs": 1184.6000001430511,
+          "wire": {
+            "toBts": {
+              "messages": 15,
+              "bytes": 19587,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17792
+                },
+                "markTiming": {
+                  "messages": 2,
+                  "bytes": 1001
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 313
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 346746,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 345951
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 675
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 1184.6000001430511,
+            "stages": {
+              "bg_replay": 139.20000004768372,
+              "wire_clone_transfer": 4.099999666213989,
+              "mt_validate": 11.900000095367432,
+              "mt_expand": 0,
+              "mt_prepare": 5.200000047683716,
+              "papi_element_creation": 566.4999947547913,
+              "mt_apply_other": 328.9000051021576,
+              "mt_ack_publication": 0.5999999046325684,
+              "presentation_residual": 128.20000052452087
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 2,
+              "commands": 95,
+              "bytes": 345145,
+              "selfcheckMs": 0,
+              "dispatchMs": 4.099999666213989,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 10000,
+              "templateValues": 30000,
+              "bgReplayMs": 139.20000004768372
+            },
+            "main": {
+              "commits": 2,
+              "pacedCommits": 0,
+              "commands": 95,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 11.900000095367432,
+              "prepareMs": 5.200000047683716,
+              "prepareCheckMs": 0,
+              "applyMs": 895.3999998569489,
+              "ackMs": 0.5999999046325684,
+              "papiCreateMs": 566.4999947547913,
+              "mtSliceStartEpochMs": 1786493577911.9001,
+              "mtSliceEvalMs": 19,
+              "firstScreenPlanMs": 0.39999985694885254,
+              "mtExpandMs": 0
+            }
+          }
+        },
+        {
+          "rawMs": 1201.5,
+          "wire": {
+            "toBts": {
+              "messages": 15,
+              "bytes": 19616,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17792
+                },
+                "markTiming": {
+                  "messages": 2,
+                  "bytes": 1015
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 328
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 347301,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 346495
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 686
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 1201.5,
+            "stages": {
+              "bg_replay": 150.79999995231628,
+              "wire_clone_transfer": 3.700000047683716,
+              "mt_validate": 12.199999809265137,
+              "mt_expand": 0,
+              "mt_prepare": 5.299999952316284,
+              "papi_element_creation": 578.2000014781952,
+              "mt_apply_other": 341.69999861717224,
+              "mt_ack_publication": 0.39999985694885254,
+              "presentation_residual": 109.2000002861023
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 2,
+              "commands": 95,
+              "bytes": 345689,
+              "selfcheckMs": 0,
+              "dispatchMs": 3.700000047683716,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 10000,
+              "templateValues": 30000,
+              "bgReplayMs": 150.79999995231628
+            },
+            "main": {
+              "commits": 2,
+              "pacedCommits": 0,
+              "commands": 95,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 12.199999809265137,
+              "prepareMs": 5.299999952316284,
+              "prepareCheckMs": 0,
+              "applyMs": 919.9000000953674,
+              "ackMs": 0.39999985694885254,
+              "papiCreateMs": 578.2000014781952,
+              "mtSliceStartEpochMs": 1786493608637.1,
+              "mtSliceEvalMs": 20.5,
+              "firstScreenPlanMs": 0.40000009536743164,
+              "mtExpandMs": 0
+            }
+          }
+        },
+        {
+          "rawMs": 1222.2000000476837,
+          "wire": {
+            "toBts": {
+              "messages": 15,
+              "bytes": 19608,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17792
+                },
+                "markTiming": {
+                  "messages": 2,
+                  "bytes": 1007
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 328
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 346849,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 346044
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 685
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 1222.2000000476837,
+            "stages": {
+              "bg_replay": 146.09999990463257,
+              "wire_clone_transfer": 3.999999761581421,
+              "mt_validate": 11,
+              "mt_expand": 0,
+              "mt_prepare": 5.099999904632568,
+              "papi_element_creation": 577.1000044345856,
+              "mt_apply_other": 357.49999594688416,
+              "mt_ack_publication": 0.5999999046325684,
+              "presentation_residual": 120.80000019073486
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 2,
+              "commands": 95,
+              "bytes": 345238,
+              "selfcheckMs": 0,
+              "dispatchMs": 3.999999761581421,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 10000,
+              "templateValues": 30000,
+              "bgReplayMs": 146.09999990463257
+            },
+            "main": {
+              "commits": 2,
+              "pacedCommits": 0,
+              "commands": 95,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 11,
+              "prepareMs": 5.099999904632568,
+              "prepareCheckMs": 0,
+              "applyMs": 934.6000003814697,
+              "ackMs": 0.5999999046325684,
+              "papiCreateMs": 577.1000044345856,
+              "mtSliceStartEpochMs": 1786493622003,
+              "mtSliceEvalMs": 21,
+              "firstScreenPlanMs": 0.40000009536743164,
+              "mtExpandMs": 0
+            }
+          }
+        },
+        {
+          "rawMs": 1198,
+          "wire": {
+            "toBts": {
+              "messages": 15,
+              "bytes": 19617,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17792
+                },
+                "markTiming": {
+                  "messages": 2,
+                  "bytes": 1016
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 328
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 347168,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 346355
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 693
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 1198,
+            "stages": {
+              "bg_replay": 134.69999980926514,
+              "wire_clone_transfer": 3.5,
+              "mt_validate": 11.899999856948853,
+              "mt_expand": 0,
+              "mt_prepare": 5.299999713897705,
+              "papi_element_creation": 610.6000137329102,
+              "mt_apply_other": 312.49998664855957,
+              "mt_ack_publication": 0.4999997615814209,
+              "presentation_residual": 119.00000047683716
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 2,
+              "commands": 95,
+              "bytes": 345549,
+              "selfcheckMs": 0,
+              "dispatchMs": 3.5,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 10000,
+              "templateValues": 30000,
+              "bgReplayMs": 134.69999980926514
+            },
+            "main": {
+              "commits": 2,
+              "pacedCommits": 0,
+              "commands": 95,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 11.899999856948853,
+              "prepareMs": 5.299999713897705,
+              "prepareCheckMs": 0,
+              "applyMs": 923.1000003814697,
+              "ackMs": 0.4999997615814209,
+              "papiCreateMs": 610.6000137329102,
+              "mtSliceStartEpochMs": 1786493653028,
+              "mtSliceEvalMs": 18.89990234375,
+              "firstScreenPlanMs": 0.2999999523162842,
+              "mtExpandMs": 0
+            }
+          }
+        }
+      ],
+      "vueVdom": [
+        {
+          "rawMs": 1437.6999998092651,
+          "wire": {
+            "toBts": {
+              "messages": 12,
+              "bytes": 2065,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 228
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 1,
+                  "bytes": 94
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 957
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "ret_bg-to-main_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_1": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_2": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 292
+                },
+                "ret_bg-to-main_3": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 9,
+              "bytes": 3584455,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "callLepusMethod": {
+                  "messages": 4,
+                  "bytes": 3583552
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 783
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 1393.7999999523163,
+          "wire": {
+            "toBts": {
+              "messages": 12,
+              "bytes": 2071,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 228
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 1,
+                  "bytes": 94
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 976
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "ret_bg-to-main_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_1": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_2": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 279
+                },
+                "ret_bg-to-main_3": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 9,
+              "bytes": 3584773,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "callLepusMethod": {
+                  "messages": 4,
+                  "bytes": 3583846
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 807
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 1373.2999999523163,
+          "wire": {
+            "toBts": {
+              "messages": 12,
+              "bytes": 2068,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 228
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 1,
+                  "bytes": 94
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 975
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "ret_bg-to-main_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_1": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_2": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 277
+                },
+                "ret_bg-to-main_3": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 9,
+              "bytes": 3584515,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "callLepusMethod": {
+                  "messages": 4,
+                  "bytes": 3583594
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 801
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 1455.7999999523163,
+          "wire": {
+            "toBts": {
+              "messages": 12,
+              "bytes": 2068,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 228
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 1,
+                  "bytes": 94
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 960
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "ret_bg-to-main_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_1": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_2": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 292
+                },
+                "ret_bg-to-main_3": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 9,
+              "bytes": 3584351,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "callLepusMethod": {
+                  "messages": 4,
+                  "bytes": 3583443
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 788
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 1363.9000000953674,
+          "wire": {
+            "toBts": {
+              "messages": 12,
+              "bytes": 2057,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 228
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 1,
+                  "bytes": 94
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 949
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "ret_bg-to-main_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_1": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_2": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 292
+                },
+                "ret_bg-to-main_3": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 9,
+              "bytes": 3584729,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "callLepusMethod": {
+                  "messages": 4,
+                  "bytes": 3583832
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 777
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "replace": {
+      "control": [
+        {
+          "rawMs": 348.60000014305115,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999043,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 321
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376407,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376407
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 297.80000019073486,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999043,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 321
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376283,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376283
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 304.09999990463257,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999043,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 321
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376329,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376329
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 350.5,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999043,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 321
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376544,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376544
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 304.60000014305115,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999043,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 321
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376430,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376430
+                }
+              }
+            }
+          }
+        }
+      ],
+      "profile": [
+        {
+          "rawMs": 326.90000009536743,
+          "wire": {
+            "toBts": {
+              "messages": 3,
+              "bytes": 1998809,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 322
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376555,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376555
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 326.90000009536743,
+            "stages": {
+              "bg_replay": 38.299999952316284,
+              "wire_clone_transfer": 3,
+              "mt_validate": 7.900000095367432,
+              "mt_expand": 0,
+              "mt_prepare": 55.90000009536743,
+              "papi_element_creation": 53.200000524520874,
+              "mt_apply_other": 84.79999947547913,
+              "mt_ack_publication": 37.89999985694885,
+              "presentation_residual": 45.90000009536743
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 10001,
+              "bytes": 376443,
+              "selfcheckMs": 0,
+              "dispatchMs": 3,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 38.299999952316284
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 10001,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 7.900000095367432,
+              "prepareMs": 55.90000009536743,
+              "prepareCheckMs": 0,
+              "applyMs": 138,
+              "ackMs": 37.89999985694885,
+              "papiCreateMs": 53.200000524520874,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0
+            }
+          }
+        },
+        {
+          "rawMs": 334.30000019073486,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999043,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 321
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376394,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376394
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 334.30000019073486,
+            "stages": {
+              "bg_replay": 36.10000014305115,
+              "wire_clone_transfer": 2.700000047683716,
+              "mt_validate": 9.700000047683716,
+              "mt_expand": 0,
+              "mt_prepare": 61.200000047683716,
+              "papi_element_creation": 60.19999980926514,
+              "mt_apply_other": 84.2000002861023,
+              "mt_ack_publication": 37,
+              "presentation_residual": 43.19999980926514
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 10001,
+              "bytes": 376282,
+              "selfcheckMs": 0,
+              "dispatchMs": 2.700000047683716,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 36.10000014305115
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 10001,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 9.700000047683716,
+              "prepareMs": 61.200000047683716,
+              "prepareCheckMs": 0,
+              "applyMs": 144.40000009536743,
+              "ackMs": 37,
+              "papiCreateMs": 60.19999980926514,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0
+            }
+          }
+        },
+        {
+          "rawMs": 343.2999999523163,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999043,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 321
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376586,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376586
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 343.2999999523163,
+            "stages": {
+              "bg_replay": 54.299999952316284,
+              "wire_clone_transfer": 5.299999952316284,
+              "mt_validate": 9.799999952316284,
+              "mt_expand": 0,
+              "mt_prepare": 60.60000014305115,
+              "papi_element_creation": 55.500000953674316,
+              "mt_apply_other": 79.99999904632568,
+              "mt_ack_publication": 36.89999985694885,
+              "presentation_residual": 40.90000009536743
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 10001,
+              "bytes": 376474,
+              "selfcheckMs": 0,
+              "dispatchMs": 5.299999952316284,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 54.299999952316284
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 10001,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 9.799999952316284,
+              "prepareMs": 60.60000014305115,
+              "prepareCheckMs": 0,
+              "applyMs": 135.5,
+              "ackMs": 36.89999985694885,
+              "papiCreateMs": 55.500000953674316,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0
+            }
+          }
+        },
+        {
+          "rawMs": 333.09999990463257,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999043,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 321
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376446,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376446
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 333.09999990463257,
+            "stages": {
+              "bg_replay": 36.299999952316284,
+              "wire_clone_transfer": 3.299999952316284,
+              "mt_validate": 8.400000095367432,
+              "mt_expand": 0,
+              "mt_prepare": 61.10000014305115,
+              "papi_element_creation": 52.300002098083496,
+              "mt_apply_other": 86.6999979019165,
+              "mt_ack_publication": 36.39999985694885,
+              "presentation_residual": 48.59999990463257
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 10001,
+              "bytes": 376334,
+              "selfcheckMs": 0,
+              "dispatchMs": 3.299999952316284,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 36.299999952316284
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 10001,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 8.400000095367432,
+              "prepareMs": 61.10000014305115,
+              "prepareCheckMs": 0,
+              "applyMs": 139,
+              "ackMs": 36.39999985694885,
+              "papiCreateMs": 52.300002098083496,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0
+            }
+          }
+        },
+        {
+          "rawMs": 305.5,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999037,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 229
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 321
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376444,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376444
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 305.5,
+            "stages": {
+              "bg_replay": 35.09999990463257,
+              "wire_clone_transfer": 2.700000047683716,
+              "mt_validate": 10.299999952316284,
+              "mt_expand": 0,
+              "mt_prepare": 54.80000019073486,
+              "papi_element_creation": 53.299996852874756,
+              "mt_apply_other": 79.70000314712524,
+              "mt_ack_publication": 36,
+              "presentation_residual": 33.59999990463257
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 10001,
+              "bytes": 376332,
+              "selfcheckMs": 0,
+              "dispatchMs": 2.700000047683716,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 35.09999990463257
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 10001,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 10.299999952316284,
+              "prepareMs": 54.80000019073486,
+              "prepareCheckMs": 0,
+              "applyMs": 133,
+              "ackMs": 36,
+              "papiCreateMs": 53.299996852874756,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0
+            }
+          }
+        }
+      ],
+      "vueVdom": [
+        {
+          "rawMs": 183.10000014305115,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 346,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 286
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 356925,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 356925
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 181.89999985694885,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 346,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 286
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 356844,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 356844
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 180,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 346,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 286
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 356818,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 356818
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 186.10000014305115,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 346,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 286
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 356734,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 356734
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 184.69999980926514,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 346,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 286
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 356878,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 356878
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "append": {
+      "control": [
+        {
+          "rawMs": 202.39999985694885,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713048,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 310
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 34897,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 34897
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 182.60000014305115,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713062,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 324
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 35011,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 35011
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 196,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713068,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 241
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 324
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 34997,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 34997
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 209.80000019073486,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713068,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 241
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 324
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 34948,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 34948
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 182.70000004768372,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713062,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 324
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 34989,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 34989
+                }
+              }
+            }
+          }
+        }
+      ],
+      "profile": [
+        {
+          "rawMs": 200.79999995231628,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713061,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 234
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 324
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 34721,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 34721
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 200.79999995231628,
+            "stages": {
+              "bg_replay": 27.700000047683716,
+              "wire_clone_transfer": 0.2999999523162842,
+              "mt_validate": 1.4000000953674316,
+              "mt_expand": 0,
+              "mt_prepare": 17.799999952316284,
+              "papi_element_creation": 57.30000042915344,
+              "mt_apply_other": 43.99999952316284,
+              "mt_ack_publication": 31.90000009536743,
+              "presentation_residual": 20.399999856948853
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 1,
+              "bytes": 34609,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.2999999523162842,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 27.700000047683716
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 1,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 1.4000000953674316,
+              "prepareMs": 17.799999952316284,
+              "prepareCheckMs": 0,
+              "applyMs": 101.29999995231628,
+              "ackMs": 31.90000009536743,
+              "papiCreateMs": 57.30000042915344,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0
+            }
+          }
+        },
+        {
+          "rawMs": 191.70000004768372,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713051,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 238
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 310
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 34895,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 34895
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 191.70000004768372,
+            "stages": {
+              "bg_replay": 26.799999952316284,
+              "wire_clone_transfer": 0.2999999523162842,
+              "mt_validate": 1.2999999523162842,
+              "mt_expand": 0,
+              "mt_prepare": 16.100000143051147,
+              "papi_element_creation": 51.100003719329834,
+              "mt_apply_other": 46.399996280670166,
+              "mt_ack_publication": 30.59999990463257,
+              "presentation_residual": 19.100000143051147
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 1,
+              "bytes": 34783,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.2999999523162842,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 26.799999952316284
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 1,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 1.2999999523162842,
+              "prepareMs": 16.100000143051147,
+              "prepareCheckMs": 0,
+              "applyMs": 97.5,
+              "ackMs": 30.59999990463257,
+              "papiCreateMs": 51.100003719329834,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0
+            }
+          }
+        },
+        {
+          "rawMs": 193.70000004768372,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713056,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 241
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 312
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 34944,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 34944
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 193.70000004768372,
+            "stages": {
+              "bg_replay": 28.5,
+              "wire_clone_transfer": 0.39999985694885254,
+              "mt_validate": 1.2999999523162842,
+              "mt_expand": 0.09999990463256836,
+              "mt_prepare": 16.100000143051147,
+              "papi_element_creation": 49.500001192092896,
+              "mt_apply_other": 47.69999885559082,
+              "mt_ack_publication": 30.399999856948853,
+              "presentation_residual": 19.700000286102295
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 1,
+              "bytes": 34832,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.39999985694885254,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 28.5
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 1,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 1.2999999523162842,
+              "prepareMs": 16.100000143051147,
+              "prepareCheckMs": 0,
+              "applyMs": 97.20000004768372,
+              "ackMs": 30.399999856948853,
+              "papiCreateMs": 49.500001192092896,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0.09999990463256836
+            }
+          }
+        },
+        {
+          "rawMs": 203.5,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713071,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 244
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 324
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 35071,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 35071
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 203.5,
+            "stages": {
+              "bg_replay": 27.600000143051147,
+              "wire_clone_transfer": 0.39999985694885254,
+              "mt_validate": 1.2000000476837158,
+              "mt_expand": 0.10000014305114746,
+              "mt_prepare": 16.5,
+              "papi_element_creation": 55.20000123977661,
+              "mt_apply_other": 46.79999876022339,
+              "mt_ack_publication": 32.299999952316284,
+              "presentation_residual": 23.399999856948853
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 1,
+              "bytes": 34959,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.39999985694885254,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 27.600000143051147
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 1,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 1.2000000476837158,
+              "prepareMs": 16.5,
+              "prepareCheckMs": 0,
+              "applyMs": 102,
+              "ackMs": 32.299999952316284,
+              "papiCreateMs": 55.20000123977661,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0.10000014305114746
+            }
+          }
+        },
+        {
+          "rawMs": 191,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713071,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 244
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 324
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 35059,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 35059
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 191,
+            "stages": {
+              "bg_replay": 29.09999990463257,
+              "wire_clone_transfer": 0.40000009536743164,
+              "mt_validate": 1.4000000953674316,
+              "mt_expand": 0.09999990463256836,
+              "mt_prepare": 16,
+              "papi_element_creation": 53.40000104904175,
+              "mt_apply_other": 41.499999046325684,
+              "mt_ack_publication": 30.5,
+              "presentation_residual": 18.59999990463257
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 1,
+              "bytes": 34947,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.40000009536743164,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 29.09999990463257
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 1,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 1.4000000953674316,
+              "prepareMs": 16,
+              "prepareCheckMs": 0,
+              "applyMs": 94.90000009536743,
+              "ackMs": 30.5,
+              "papiCreateMs": 53.40000104904175,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0.09999990463256836
+            }
+          }
+        }
+      ],
+      "vueVdom": [
+        {
+          "rawMs": 153.29999995231628,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 348,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 288
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 343023,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 343023
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 153.09999990463257,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 348,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 288
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 343164,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 343164
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 159.10000014305115,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 348,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 288
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 343141,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 343141
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 160.60000014305115,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 334,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 274
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 343063,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 343063
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 196,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 348,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 288
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 343083,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 343083
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/benchmarks/lynx-table/stages/results/live-10000.md
+++ b/benchmarks/lynx-table/stages/results/live-10000.md
@@ -75,4 +75,3 @@ Raw append: profile 193.7 ms, control 196 ms, vue-vdom 159.1 ms. Wire: MTS→BTS
 - **#47 wire/encoding candidate: NO-GO.** clone/transfer is 0.3% of create, 0.9% of replace, and 0.2% of append; it does not clear the 10% owner gate.
 - **#47 measured CPU owner: SPLIT.** PAPI creation plus remaining host apply is 76.6% of create. This is a host materialization owner, not evidence for changing the wire representation.
 - **#47 acknowledgement-only candidate: NO-GO for issue acceptance.** ACK/publication is 0.0% of create, 11.1% of replace, and 15.8% of append; even a complete removal cannot meet the required 15% in all three cells or the 50% total-wire gate.
-

--- a/benchmarks/lynx-table/stages/results/live-10000.md
+++ b/benchmarks/lynx-table/stages/results/live-10000.md
@@ -1,0 +1,78 @@
+# Lynx 10,000-row stage decomposition
+
+- measured: 2026-08-12T00:14:21.625Z
+- host: 32× Intel(R) Xeon(R) Platinum 8336C CPU @ 2.30GHz; linux 5.15.120.bsk.3-amd64; Node v22.22.2; Chromium 149.0.7827.55
+- protocol: fresh page per operation sample; control/profile order alternates AB/BA; one vue-vdom create/replace/append triplet follows each pair; no other benchmark process ran in this window
+- host load: start 1.53/1.69/1.74 (1/5/15m), end 2.47/2.14/1.91
+- repetitions: n=5 per A/B cell
+
+## FCP@10000
+
+Attribution starts when the shared browser hook assigns the hidden main-thread iframe Blob script URL, before load/parse/evaluation, and ends when the shared composed-tree observer first sees all 10,000 rows. `layout_flush_residual` is the exclusive remainder after directly observed slice evaluation, plan interpretation, and PAPI element creation; it includes PAPI prop/insertion work, `__FlushElementTree`, Web Core DOM publication, style/layout, and observer-frame delay because the host exposes no stable boundary between those costs.
+
+| segment | median ms | min–max ms | share |
+|---|---:|---:|---:|
+| mt_slice_eval | 20.6 | 20.2–21.6 | 1.2% |
+| plan_interpretation | 124.3 | 121.9–125.9 | 7.3% |
+| papi_element_creation | 523.6 | 492.1–537 | 30.8% |
+| layout_flush_residual | 1035.4 | 1010.7–1126.6 | 60.9% |
+
+Raw view-attach FCP: profile 1730.2 ms (1673.2–1867.3), control 1678.3 ms; same-window profile/control 1.031×.
+
+## create@10000
+
+Attribution starts at the shared pointerdown boundary and ends when the shared composed-tree observer sees 10,000 rows. All named intervals are directly observed and exclusive; `presentation_residual` is the wall-clock remainder through final composed-tree presentation.
+
+| segment | median ms | min–max ms | share |
+|---|---:|---:|---:|
+| bg_replay | 146.1 | 134.7–156.8 | 12.2% |
+| wire_clone_transfer | 4 | 3.5–4.2 | 0.3% |
+| mt_validate | 11.9 | 11–12.4 | 1.0% |
+| mt_expand | 0 | 0–0.1 | 0.0% |
+| mt_prepare | 5.2 | 5.1–5.3 | 0.4% |
+| papi_element_creation | 578.2 | 566.5–610.6 | 48.1% |
+| mt_apply_other | 341.7 | 312.5–357.5 | 28.4% |
+| mt_ack_publication | 0.6 | 0.4–0.7 | 0.0% |
+| presentation_residual | 119 | 109.2–128.2 | 9.9% |
+
+Raw create: profile 1201.5 ms (1184.6–1234.2), control 1141.8 ms, vue-vdom 1393.8 ms; same-window profile/control 1.052×, profile/vue-vdom 0.862×.
+Wire: MTS→BTS 19,608 B / 15 messages; BTS→MTS 347,168 B / 10 messages.
+
+## replace@1k
+
+| segment | median ms | share |
+|---|---:|---:|
+| bg_replay | 36.3 | 10.9% |
+| wire_clone_transfer | 3 | 0.9% |
+| mt_validate | 9.7 | 2.9% |
+| mt_expand | 0 | 0.0% |
+| mt_prepare | 60.6 | 18.2% |
+| papi_element_creation | 53.3 | 16.0% |
+| mt_apply_other | 84.2 | 25.3% |
+| mt_ack_publication | 36.9 | 11.1% |
+| presentation_residual | 43.2 | 13.0% |
+
+Raw replace: profile 333.1 ms, control 304.6 ms, vue-vdom 183.1 ms. Wire: MTS→BTS 1,999,043 B / 4 messages; BTS→MTS 376,446 B / 1 messages.
+
+## append@1k
+
+| segment | median ms | share |
+|---|---:|---:|
+| bg_replay | 27.7 | 14.3% |
+| wire_clone_transfer | 0.4 | 0.2% |
+| mt_validate | 1.3 | 0.7% |
+| mt_expand | 0.1 | 0.1% |
+| mt_prepare | 16.1 | 8.3% |
+| papi_element_creation | 53.4 | 27.6% |
+| mt_apply_other | 46.4 | 24.0% |
+| mt_ack_publication | 30.6 | 15.8% |
+| presentation_residual | 19.7 | 10.2% |
+
+Raw append: profile 193.7 ms, control 196 ms, vue-vdom 159.1 ms. Wire: MTS→BTS 1,713,061 B / 4 messages; BTS→MTS 34,944 B / 1 messages.
+
+## Verdicts
+
+- **#47 wire/encoding candidate: NO-GO.** clone/transfer is 0.3% of create, 0.9% of replace, and 0.2% of append; it does not clear the 10% owner gate.
+- **#47 measured CPU owner: SPLIT.** PAPI creation plus remaining host apply is 76.6% of create. This is a host materialization owner, not evidence for changing the wire representation.
+- **#47 acknowledgement-only candidate: NO-GO for issue acceptance.** ACK/publication is 0.0% of create, 11.1% of replace, and 15.8% of append; even a complete removal cannot meet the required 15% in all three cells or the 50% total-wire gate.
+

--- a/benchmarks/lynx-table/stages/results/live-30000.json
+++ b/benchmarks/lynx-table/stages/results/live-30000.json
@@ -1,0 +1,3403 @@
+{
+  "meta": {
+    "date": "2026-08-12T00:22:00.918Z",
+    "node": "v22.22.2",
+    "cpus": 32,
+    "cpuModel": "Intel(R) Xeon(R) Platinum 8336C CPU @ 2.30GHz",
+    "platform": "linux",
+    "release": "5.15.120.bsk.3-amd64",
+    "chromium": "149.0.7827.55",
+    "repetitions": 5,
+    "rows": 30000,
+    "reportable": true,
+    "loadStart": [1.8, 1.93, 1.87],
+    "loadEnd": [2.55, 2.26, 2.02],
+    "protocol": "fresh page per operation sample; control/profile order alternates AB/BA; one vue-vdom create/replace/append triplet follows each pair; no other benchmark process ran in this window"
+  },
+  "fcp": {
+    "attribution": {
+      "total": {
+        "median": 5158.10009765625,
+        "min": 5052.39990234375,
+        "max": 5331.10009765625,
+        "spread": 278.7001953125,
+        "n": 5
+      },
+      "stages": {
+        "mt_slice_eval": {
+          "median": 25.60009765625,
+          "min": 25.300048828125,
+          "max": 26.89990234375,
+          "spread": 1.599853515625,
+          "n": 5,
+          "share": 0.004963086634918588
+        },
+        "plan_interpretation": {
+          "median": 401.69999980926514,
+          "min": 383.7999999523163,
+          "max": 433.40000009536743,
+          "spread": 49.60000014305115,
+          "n": 5,
+          "share": 0.07787751152634485
+        },
+        "papi_element_creation": {
+          "median": 1791.799996137619,
+          "min": 1744.0000104904175,
+          "max": 1794.4000055789948,
+          "spread": 50.39999508857727,
+          "n": 5,
+          "share": 0.3473759644470222
+        },
+        "layout_flush_residual": {
+          "median": 2945.5999965667725,
+          "min": 2864.599989414215,
+          "max": 3127.600043296814,
+          "spread": 263.0000538825989,
+          "n": 5,
+          "share": 0.5710629768323421
+        }
+      },
+      "ratios": {}
+    },
+    "rawControl": {
+      "median": 5036,
+      "min": 4958.100000143051,
+      "max": 5341.299999952316,
+      "spread": 383.19999980926514,
+      "n": 5
+    },
+    "rawProfile": {
+      "median": 5184.700000047684,
+      "min": 5077.099999904633,
+      "max": 5359,
+      "spread": 281.90000009536743,
+      "n": 5
+    }
+  },
+  "create": {
+    "attribution": {
+      "total": {
+        "median": 3498.600000143051,
+        "min": 3392.4000000953674,
+        "max": 3521.2000000476837,
+        "spread": 128.79999995231628,
+        "n": 5
+      },
+      "stages": {
+        "bg_replay": {
+          "median": 344.5,
+          "min": 343.39999985694885,
+          "max": 348.5,
+          "spread": 5.1000001430511475,
+          "n": 5,
+          "share": 0.09846795860799007
+        },
+        "wire_clone_transfer": {
+          "median": 11,
+          "min": 10.699999809265137,
+          "max": 11.5,
+          "spread": 0.8000001907348633,
+          "n": 5,
+          "share": 0.003144114788644095
+        },
+        "mt_validate": {
+          "median": 32,
+          "min": 31.09999990463257,
+          "max": 32.299999952316284,
+          "spread": 1.2000000476837158,
+          "n": 5,
+          "share": 0.009146515748782821
+        },
+        "mt_expand": {
+          "median": 0,
+          "min": 0,
+          "max": 0.10000014305114746,
+          "spread": 0.10000014305114746,
+          "n": 5,
+          "share": 0
+        },
+        "mt_prepare": {
+          "median": 11,
+          "min": 10.699999809265137,
+          "max": 11.399999856948853,
+          "spread": 0.7000000476837158,
+          "n": 5,
+          "share": 0.003144114788644095
+        },
+        "papi_element_creation": {
+          "median": 1791.0000262260437,
+          "min": 1726.400000333786,
+          "max": 1827.799997329712,
+          "spread": 101.3999969959259,
+          "n": 5,
+          "share": 0.5119190608108424
+        },
+        "mt_apply_other": {
+          "median": 993.0000026226044,
+          "min": 965.69997382164,
+          "max": 1031.1999962329865,
+          "spread": 65.50002241134644,
+          "n": 5,
+          "share": 0.2838278175790323
+        },
+        "mt_ack_publication": {
+          "median": 0.6000001430511475,
+          "min": 0.5999999046325684,
+          "max": 0.7000000476837158,
+          "spread": 0.10000014305114746,
+          "n": 5,
+          "share": 0.00017149721117778956
+        },
+        "presentation_residual": {
+          "median": 300.00000047683716,
+          "min": 280.40000009536743,
+          "max": 338.5000002384186,
+          "spread": 58.10000014305115,
+          "n": 5,
+          "share": 0.08574858528113266
+        }
+      },
+      "ratios": {
+        "control": 1.041653020541692,
+        "reference": 0.8765345493482087
+      }
+    },
+    "wire": {
+      "toBts": {
+        "bytes": {
+          "median": 19622,
+          "min": 19604,
+          "max": 19634,
+          "spread": 30,
+          "n": 5
+        },
+        "messages": {
+          "median": 15,
+          "min": 15,
+          "max": 15,
+          "spread": 0,
+          "n": 5
+        }
+      },
+      "toMts": {
+        "bytes": {
+          "median": 1046672,
+          "min": 1046025,
+          "max": 1047320,
+          "spread": 1295,
+          "n": 5
+        },
+        "messages": {
+          "median": 10,
+          "min": 10,
+          "max": 10,
+          "spread": 0,
+          "n": 5
+        }
+      }
+    },
+    "rawControl": {
+      "median": 3358.7000000476837,
+      "min": 3173.5,
+      "max": 3428.0999999046326,
+      "spread": 254.59999990463257,
+      "n": 5
+    },
+    "rawProfile": {
+      "median": 3498.600000143051,
+      "min": 3392.4000000953674,
+      "max": 3521.2000000476837,
+      "spread": 128.79999995231628,
+      "n": 5
+    },
+    "vueVdom": {
+      "median": 3991.399999856949,
+      "min": 3827.5,
+      "max": 4179.900000095367,
+      "spread": 352.40000009536743,
+      "n": 5
+    }
+  },
+  "replace": {
+    "attribution": {
+      "total": {
+        "median": 326.7000000476837,
+        "min": 313,
+        "max": 351.7000000476837,
+        "spread": 38.700000047683716,
+        "n": 5
+      },
+      "stages": {
+        "bg_replay": {
+          "median": 36.89999985694885,
+          "min": 34.59999990463257,
+          "max": 51.299999952316284,
+          "spread": 16.700000047683716,
+          "n": 5,
+          "share": 0.11294765794785151
+        },
+        "wire_clone_transfer": {
+          "median": 3,
+          "min": 2.5999999046325684,
+          "max": 3.5,
+          "spread": 0.9000000953674316,
+          "n": 5,
+          "share": 0.009182736454123456
+        },
+        "mt_validate": {
+          "median": 11.299999952316284,
+          "min": 9.299999952316284,
+          "max": 14.800000190734863,
+          "spread": 5.500000238418579,
+          "n": 5,
+          "share": 0.03458830716457602
+        },
+        "mt_expand": {
+          "median": 0,
+          "min": 0,
+          "max": 0,
+          "spread": 0,
+          "n": 5,
+          "share": 0
+        },
+        "mt_prepare": {
+          "median": 59.10000014305115,
+          "min": 55.90000009536743,
+          "max": 62.299999952316284,
+          "spread": 6.3999998569488525,
+          "n": 5,
+          "share": 0.18089990858409907
+        },
+        "papi_element_creation": {
+          "median": 58.70000338554382,
+          "min": 53.000001668930054,
+          "max": 59.80000042915344,
+          "spread": 6.799998760223389,
+          "n": 5,
+          "share": 0.17967555364853452
+        },
+        "mt_apply_other": {
+          "median": 79.8999993801117,
+          "min": 77.99999666213989,
+          "max": 89.49999952316284,
+          "spread": 11.50000286102295,
+          "n": 5,
+          "share": 0.24456687899739774
+        },
+        "mt_ack_publication": {
+          "median": 36.90000009536743,
+          "min": 35.299999952316284,
+          "max": 39.09999990463257,
+          "spread": 3.799999952316284,
+          "n": 5,
+          "share": 0.11294765867762983
+        },
+        "presentation_residual": {
+          "median": 37.90000033378601,
+          "min": 34.299999952316284,
+          "max": 48.799999952316284,
+          "spread": 14.5,
+          "n": 5,
+          "share": 0.11600857155878265
+        }
+      },
+      "ratios": {
+        "control": 1.0481231953728114,
+        "reference": 1.877586207170596
+      }
+    },
+    "rawControl": {
+      "median": 311.7000000476837,
+      "min": 293.7999999523163,
+      "max": 326.7000000476837,
+      "spread": 32.90000009536743,
+      "n": 5
+    },
+    "rawProfile": {
+      "median": 326.7000000476837,
+      "min": 313,
+      "max": 351.7000000476837,
+      "spread": 38.700000047683716,
+      "n": 5
+    },
+    "vueVdom": {
+      "median": 174,
+      "min": 165.70000004768372,
+      "max": 194.79999995231628,
+      "spread": 29.09999990463257,
+      "n": 5
+    },
+    "wire": {
+      "toBts": {
+        "bytes": {
+          "median": 1999043,
+          "min": 1999043,
+          "max": 1999052,
+          "spread": 9,
+          "n": 5
+        },
+        "messages": {
+          "median": 4,
+          "min": 4,
+          "max": 4,
+          "spread": 0,
+          "n": 5
+        }
+      },
+      "toMts": {
+        "bytes": {
+          "median": 376561,
+          "min": 376402,
+          "max": 376638,
+          "spread": 236,
+          "n": 5
+        },
+        "messages": {
+          "median": 1,
+          "min": 1,
+          "max": 1,
+          "spread": 0,
+          "n": 5
+        }
+      }
+    }
+  },
+  "append": {
+    "attribution": {
+      "total": {
+        "median": 193.90000009536743,
+        "min": 188.59999990463257,
+        "max": 196,
+        "spread": 7.400000095367432,
+        "n": 5
+      },
+      "stages": {
+        "bg_replay": {
+          "median": 28.90000009536743,
+          "min": 28.09999990463257,
+          "max": 29.700000047683716,
+          "spread": 1.6000001430511475,
+          "n": 5,
+          "share": 0.14904590036695878
+        },
+        "wire_clone_transfer": {
+          "median": 0.3000001907348633,
+          "min": 0.2999999523162842,
+          "max": 0.40000009536743164,
+          "spread": 0.10000014305114746,
+          "n": 5,
+          "share": 0.0015471902557365226
+        },
+        "mt_validate": {
+          "median": 1.2000000476837158,
+          "min": 1.2000000476837158,
+          "max": 1.3000001907348633,
+          "spread": 0.10000014305114746,
+          "n": 5,
+          "share": 0.0061887573341594115
+        },
+        "mt_expand": {
+          "median": 0.09999990463256836,
+          "min": 0,
+          "max": 0.10000014305114746,
+          "spread": 0.10000014305114746,
+          "n": 5,
+          "share": 0.0005157292655151345
+        },
+        "mt_prepare": {
+          "median": 15.400000095367432,
+          "min": 15.100000143051147,
+          "max": 17.09999990463257,
+          "spread": 1.999999761581421,
+          "n": 5,
+          "share": 0.07942238312425541
+        },
+        "papi_element_creation": {
+          "median": 50.69999933242798,
+          "min": 48.99999928474426,
+          "max": 56.300002336502075,
+          "spread": 7.3000030517578125,
+          "n": 5,
+          "share": 0.2614749835352851
+        },
+        "mt_apply_other": {
+          "median": 46.00000071525574,
+          "min": 41.99999761581421,
+          "max": 46.200000524520874,
+          "spread": 4.200002908706665,
+          "n": 5,
+          "share": 0.2372356920713315
+        },
+        "mt_ack_publication": {
+          "median": 30.40000009536743,
+          "min": 30,
+          "max": 31.5,
+          "spread": 1.5,
+          "n": 5,
+          "share": 0.15678184672725914
+        },
+        "presentation_residual": {
+          "median": 19.700000047683716,
+          "min": 18.49999976158142,
+          "max": 20.40000009536743,
+          "spread": 1.9000003337860107,
+          "n": 5,
+          "share": 0.1015987624445307
+        }
+      },
+      "ratios": {
+        "control": 1.0146520143915243,
+        "reference": 1.2303299505882033
+      }
+    },
+    "rawControl": {
+      "median": 191.10000014305115,
+      "min": 186.29999995231628,
+      "max": 203.60000014305115,
+      "spread": 17.300000190734863,
+      "n": 5
+    },
+    "rawProfile": {
+      "median": 193.90000009536743,
+      "min": 188.59999990463257,
+      "max": 196,
+      "spread": 7.400000095367432,
+      "n": 5
+    },
+    "vueVdom": {
+      "median": 157.59999990463257,
+      "min": 152.70000004768372,
+      "max": 162.70000004768372,
+      "spread": 10,
+      "n": 5
+    },
+    "wire": {
+      "toBts": {
+        "bytes": {
+          "median": 1713062,
+          "min": 1713062,
+          "max": 1713068,
+          "spread": 6,
+          "n": 5
+        },
+        "messages": {
+          "median": 4,
+          "min": 4,
+          "max": 4,
+          "spread": 0,
+          "n": 5
+        }
+      },
+      "toMts": {
+        "bytes": {
+          "median": 34947,
+          "min": 34907,
+          "max": 35032,
+          "spread": 125,
+          "n": 5
+        },
+        "messages": {
+          "median": 1,
+          "min": 1,
+          "max": 1,
+          "spread": 0,
+          "n": 5
+        }
+      }
+    }
+  },
+  "verdicts": [
+    {
+      "step": "#47 wire/encoding candidate",
+      "verdict": "NO-GO",
+      "reason": "clone/transfer is 0.3% of create, 0.9% of replace, and 0.2% of append; it does not clear the 10% owner gate."
+    },
+    {
+      "step": "#47 measured CPU owner",
+      "verdict": "SPLIT",
+      "reason": "PAPI creation plus remaining host apply is 79.6% of create. This is a host materialization owner, not evidence for changing the wire representation."
+    },
+    {
+      "step": "#47 acknowledgement-only candidate",
+      "verdict": "NO-GO for issue acceptance",
+      "reason": "ACK/publication is 0.0% of create, 11.3% of replace, and 15.7% of append; even a complete removal cannot meet the required 15% in all three cells or the 50% total-wire gate."
+    }
+  ],
+  "samples": {
+    "fcp": {
+      "control": [
+        {
+          "rawMs": 5036
+        },
+        {
+          "rawMs": 4958.100000143051
+        },
+        {
+          "rawMs": 5341.299999952316
+        },
+        {
+          "rawMs": 5051
+        },
+        {
+          "rawMs": 4998.900000095367
+        }
+      ],
+      "profile": [
+        {
+          "rawMs": 5077.099999904633,
+          "attribution": {
+            "totalMs": 5052.39990234375,
+            "stages": {
+              "mt_slice_eval": 26.89990234375,
+              "plan_interpretation": 416.90000009536743,
+              "papi_element_creation": 1744.0000104904175,
+              "layout_flush_residual": 2864.599989414215
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.20000004768371582,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0
+            },
+            "main": {
+              "commits": 0,
+              "pacedCommits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "papiCreateMs": 1744.0000104904175,
+              "mtSliceStartEpochMs": 1786493871298.3,
+              "mtSliceEvalMs": 26.89990234375,
+              "firstScreenPlanMs": 416.90000009536743
+            }
+          }
+        },
+        {
+          "rawMs": 5175.700000047684,
+          "attribution": {
+            "totalMs": 5146.89990234375,
+            "stages": {
+              "mt_slice_eval": 25.599853515625,
+              "plan_interpretation": 396.60000014305115,
+              "papi_element_creation": 1791.799996137619,
+              "layout_flush_residual": 2932.900052547455
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.09999990463256836,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0
+            },
+            "main": {
+              "commits": 0,
+              "pacedCommits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "papiCreateMs": 1791.799996137619,
+              "mtSliceStartEpochMs": 1786493904447,
+              "mtSliceEvalMs": 25.599853515625,
+              "firstScreenPlanMs": 396.60000014305115
+            }
+          }
+        },
+        {
+          "rawMs": 5184.700000047684,
+          "attribution": {
+            "totalMs": 5158.10009765625,
+            "stages": {
+              "mt_slice_eval": 25.60009765625,
+              "plan_interpretation": 401.69999980926514,
+              "papi_element_creation": 1785.2000036239624,
+              "layout_flush_residual": 2945.5999965667725
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.09999990463256836,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0
+            },
+            "main": {
+              "commits": 0,
+              "pacedCommits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "papiCreateMs": 1785.2000036239624,
+              "mtSliceStartEpochMs": 1786493980627.7,
+              "mtSliceEvalMs": 25.60009765625,
+              "firstScreenPlanMs": 401.69999980926514
+            }
+          }
+        },
+        {
+          "rawMs": 5359,
+          "attribution": {
+            "totalMs": 5331.10009765625,
+            "stages": {
+              "mt_slice_eval": 25.300048828125,
+              "plan_interpretation": 383.7999999523163,
+              "papi_element_creation": 1794.4000055789948,
+              "layout_flush_residual": 3127.600043296814
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.10000014305114746,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0
+            },
+            "main": {
+              "commits": 0,
+              "pacedCommits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "papiCreateMs": 1794.4000055789948,
+              "mtSliceStartEpochMs": 1786494012310.7,
+              "mtSliceEvalMs": 25.300048828125,
+              "firstScreenPlanMs": 383.7999999523163
+            }
+          }
+        },
+        {
+          "rawMs": 5254.599999904633,
+          "attribution": {
+            "totalMs": 5226.499755859375,
+            "stages": {
+              "mt_slice_eval": 26.5,
+              "plan_interpretation": 433.40000009536743,
+              "papi_element_creation": 1792.6000049114227,
+              "layout_flush_residual": 2973.999750852585
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.10000014305114746,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0
+            },
+            "main": {
+              "commits": 0,
+              "pacedCommits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "papiCreateMs": 1792.6000049114227,
+              "mtSliceStartEpochMs": 1786494088483.2002,
+              "mtSliceEvalMs": 26.5,
+              "firstScreenPlanMs": 433.40000009536743
+            }
+          }
+        }
+      ]
+    },
+    "create": {
+      "control": [
+        {
+          "rawMs": 3428.0999999046326,
+          "wire": {
+            "toBts": {
+              "messages": 15,
+              "bytes": 19616,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17793
+                },
+                "markTiming": {
+                  "messages": 2,
+                  "bytes": 1014
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 328
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 1046965,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 1046154
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 691
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 3402.9000000953674,
+          "wire": {
+            "toBts": {
+              "messages": 15,
+              "bytes": 19601,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17793
+                },
+                "markTiming": {
+                  "messages": 2,
+                  "bytes": 999
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 328
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 1047058,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 1046262
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 676
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 3173.5,
+          "wire": {
+            "toBts": {
+              "messages": 15,
+              "bytes": 19604,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17793
+                },
+                "markTiming": {
+                  "messages": 2,
+                  "bytes": 1002
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 328
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 1047379,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 1046586
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 673
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 3283.0999999046326,
+          "wire": {
+            "toBts": {
+              "messages": 15,
+              "bytes": 19638,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17793
+                },
+                "markTiming": {
+                  "messages": 2,
+                  "bytes": 1036
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 328
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 1046913,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 1046095
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 698
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 3358.7000000476837,
+          "wire": {
+            "toBts": {
+              "messages": 15,
+              "bytes": 19604,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17793
+                },
+                "markTiming": {
+                  "messages": 2,
+                  "bytes": 1002
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 328
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 1045545,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 1044754
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 671
+                }
+              }
+            }
+          }
+        }
+      ],
+      "profile": [
+        {
+          "rawMs": 3498.600000143051,
+          "wire": {
+            "toBts": {
+              "messages": 15,
+              "bytes": 19622,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17793
+                },
+                "markTiming": {
+                  "messages": 2,
+                  "bytes": 1020
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 328
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 1047019,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 1046207
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 692
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 3498.600000143051,
+            "stages": {
+              "bg_replay": 348.5,
+              "wire_clone_transfer": 11.5,
+              "mt_validate": 32,
+              "mt_expand": 0,
+              "mt_prepare": 10.799999952316284,
+              "papi_element_creation": 1791.0000262260437,
+              "mt_apply_other": 965.69997382164,
+              "mt_ack_publication": 0.5999999046325684,
+              "presentation_residual": 338.5000002384186
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 2,
+              "commands": 95,
+              "bytes": 1045401,
+              "selfcheckMs": 0,
+              "dispatchMs": 11.5,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 30000,
+              "templateValues": 90000,
+              "bgReplayMs": 348.5
+            },
+            "main": {
+              "commits": 2,
+              "pacedCommits": 0,
+              "commands": 95,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 32,
+              "prepareMs": 10.799999952316284,
+              "prepareCheckMs": 0,
+              "applyMs": 2756.7000000476837,
+              "ackMs": 0.5999999046325684,
+              "papiCreateMs": 1791.0000262260437,
+              "mtSliceStartEpochMs": 1786493885038.5999,
+              "mtSliceEvalMs": 21.699951171875,
+              "firstScreenPlanMs": 0.40000009536743164,
+              "mtExpandMs": 0
+            }
+          }
+        },
+        {
+          "rawMs": 3521.2000000476837,
+          "wire": {
+            "toBts": {
+              "messages": 15,
+              "bytes": 19634,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17793
+                },
+                "markTiming": {
+                  "messages": 2,
+                  "bytes": 1032
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 328
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 1046432,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 1045618
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 694
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 3521.2000000476837,
+            "stages": {
+              "bg_replay": 344.39999985694885,
+              "wire_clone_transfer": 11,
+              "mt_validate": 32.10000038146973,
+              "mt_expand": 0.10000014305114746,
+              "mt_prepare": 11.399999856948853,
+              "papi_element_creation": 1823.2000081539154,
+              "mt_apply_other": 1011.1999917030334,
+              "mt_ack_publication": 0.6000001430511475,
+              "presentation_residual": 287.19999980926514
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 2,
+              "commands": 95,
+              "bytes": 1044812,
+              "selfcheckMs": 0,
+              "dispatchMs": 11,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 30000,
+              "templateValues": 90000,
+              "bgReplayMs": 344.39999985694885
+            },
+            "main": {
+              "commits": 2,
+              "pacedCommits": 0,
+              "commands": 95,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 32.10000038146973,
+              "prepareMs": 11.399999856948853,
+              "prepareCheckMs": 0,
+              "applyMs": 2834.399999856949,
+              "ackMs": 0.6000001430511475,
+              "papiCreateMs": 1823.2000081539154,
+              "mtSliceStartEpochMs": 1786493918164.5,
+              "mtSliceEvalMs": 19.800048828125,
+              "firstScreenPlanMs": 0.39999985694885254,
+              "mtExpandMs": 0.10000014305114746
+            }
+          }
+        },
+        {
+          "rawMs": 3392.4000000953674,
+          "wire": {
+            "toBts": {
+              "messages": 15,
+              "bytes": 19629,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17793
+                },
+                "markTiming": {
+                  "messages": 2,
+                  "bytes": 1027
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 328
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 1046025,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 1045209
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 696
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 3392.4000000953674,
+            "stages": {
+              "bg_replay": 343.39999985694885,
+              "wire_clone_transfer": 10.700000047683716,
+              "mt_validate": 31.199999809265137,
+              "mt_expand": 0,
+              "mt_prepare": 11.200000047683716,
+              "papi_element_creation": 1726.400000333786,
+              "mt_apply_other": 968.8999996185303,
+              "mt_ack_publication": 0.5999999046325684,
+              "presentation_residual": 300.00000047683716
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 2,
+              "commands": 95,
+              "bytes": 1044403,
+              "selfcheckMs": 0,
+              "dispatchMs": 10.700000047683716,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 30000,
+              "templateValues": 90000,
+              "bgReplayMs": 343.39999985694885
+            },
+            "main": {
+              "commits": 2,
+              "pacedCommits": 0,
+              "commands": 95,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 31.199999809265137,
+              "prepareMs": 11.200000047683716,
+              "prepareCheckMs": 0,
+              "applyMs": 2695.2999999523163,
+              "ackMs": 0.5999999046325684,
+              "papiCreateMs": 1726.400000333786,
+              "mtSliceStartEpochMs": 1786493994578.6,
+              "mtSliceEvalMs": 21.5,
+              "firstScreenPlanMs": 0.39999985694885254,
+              "mtExpandMs": 0
+            }
+          }
+        },
+        {
+          "rawMs": 3502.7000000476837,
+          "wire": {
+            "toBts": {
+              "messages": 15,
+              "bytes": 19604,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17793
+                },
+                "markTiming": {
+                  "messages": 2,
+                  "bytes": 1002
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 328
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 1047320,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 1046524
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 676
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 3502.7000000476837,
+            "stages": {
+              "bg_replay": 347.59999990463257,
+              "wire_clone_transfer": 11.100000143051147,
+              "mt_validate": 31.09999990463257,
+              "mt_expand": 0,
+              "mt_prepare": 11,
+              "papi_element_creation": 1827.799997329712,
+              "mt_apply_other": 993.0000026226044,
+              "mt_ack_publication": 0.7000000476837158,
+              "presentation_residual": 280.40000009536743
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 2,
+              "commands": 95,
+              "bytes": 1045718,
+              "selfcheckMs": 0,
+              "dispatchMs": 11.100000143051147,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 30000,
+              "templateValues": 90000,
+              "bgReplayMs": 347.59999990463257
+            },
+            "main": {
+              "commits": 2,
+              "pacedCommits": 0,
+              "commands": 95,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 31.09999990463257,
+              "prepareMs": 11,
+              "prepareCheckMs": 0,
+              "applyMs": 2820.7999999523163,
+              "ackMs": 0.7000000476837158,
+              "papiCreateMs": 1827.799997329712,
+              "mtSliceStartEpochMs": 1786494027130.9001,
+              "mtSliceEvalMs": 19.7998046875,
+              "firstScreenPlanMs": 0.40000009536743164,
+              "mtExpandMs": 0
+            }
+          }
+        },
+        {
+          "rawMs": 3488.0999999046326,
+          "wire": {
+            "toBts": {
+              "messages": 15,
+              "bytes": 19604,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 227
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 7,
+                  "bytes": 17793
+                },
+                "markTiming": {
+                  "messages": 2,
+                  "bytes": 1002
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 328
+                }
+              }
+            },
+            "toMts": {
+              "messages": 10,
+              "bytes": 1046672,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchJSContextOnMainThread": {
+                  "messages": 5,
+                  "bytes": 1045876
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 676
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 3488.0999999046326,
+            "stages": {
+              "bg_replay": 344.5,
+              "wire_clone_transfer": 10.699999809265137,
+              "mt_validate": 32.299999952316284,
+              "mt_expand": 0,
+              "mt_prepare": 10.699999809265137,
+              "papi_element_creation": 1733.9000039100647,
+              "mt_apply_other": 1031.1999962329865,
+              "mt_ack_publication": 0.7000000476837158,
+              "presentation_residual": 324.10000014305115
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 2,
+              "commands": 95,
+              "bytes": 1045070,
+              "selfcheckMs": 0,
+              "dispatchMs": 10.699999809265137,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 30000,
+              "templateValues": 90000,
+              "bgReplayMs": 344.5
+            },
+            "main": {
+              "commits": 2,
+              "pacedCommits": 0,
+              "commands": 95,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 32.299999952316284,
+              "prepareMs": 10.699999809265137,
+              "prepareCheckMs": 0,
+              "applyMs": 2765.100000143051,
+              "ackMs": 0.7000000476837158,
+              "papiCreateMs": 1733.9000039100647,
+              "mtSliceStartEpochMs": 1786494102572.7998,
+              "mtSliceEvalMs": 21.2001953125,
+              "firstScreenPlanMs": 0.5,
+              "mtExpandMs": 0
+            }
+          }
+        }
+      ],
+      "vueVdom": [
+        {
+          "rawMs": 4179.900000095367,
+          "wire": {
+            "toBts": {
+              "messages": 12,
+              "bytes": 2083,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 228
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 1,
+                  "bytes": 94
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 975
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "ret_bg-to-main_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_1": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_2": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 292
+                },
+                "ret_bg-to-main_3": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 9,
+              "bytes": 11004142,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "callLepusMethod": {
+                  "messages": 4,
+                  "bytes": 11003216
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 806
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 4039.9000000953674,
+          "wire": {
+            "toBts": {
+              "messages": 12,
+              "bytes": 2080,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 228
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 1,
+                  "bytes": 94
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 972
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "ret_bg-to-main_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_1": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_2": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 292
+                },
+                "ret_bg-to-main_3": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 9,
+              "bytes": 11003555,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "callLepusMethod": {
+                  "messages": 4,
+                  "bytes": 11002632
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 803
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 3827.5,
+          "wire": {
+            "toBts": {
+              "messages": 12,
+              "bytes": 2065,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 228
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 1,
+                  "bytes": 94
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 957
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "ret_bg-to-main_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_1": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_2": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 292
+                },
+                "ret_bg-to-main_3": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 9,
+              "bytes": 11004356,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "callLepusMethod": {
+                  "messages": 4,
+                  "bytes": 11003451
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 785
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 3988.5,
+          "wire": {
+            "toBts": {
+              "messages": 12,
+              "bytes": 2071,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 228
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 1,
+                  "bytes": 94
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 963
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "ret_bg-to-main_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_1": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_2": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 292
+                },
+                "ret_bg-to-main_3": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 9,
+              "bytes": 11004558,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "callLepusMethod": {
+                  "messages": 4,
+                  "bytes": 11003644
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 794
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 3991.399999856949,
+          "wire": {
+            "toBts": {
+              "messages": 12,
+              "bytes": 2058,
+              "byName": {
+                "updateBTSChunkEndpoint": {
+                  "messages": 1,
+                  "bytes": 228
+                },
+                "dispatchCoreContextOnBackground": {
+                  "messages": 1,
+                  "bytes": 94
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 963
+                },
+                "start": {
+                  "messages": 1,
+                  "bytes": 86
+                },
+                "postTimingFlags": {
+                  "messages": 3,
+                  "bytes": 168
+                },
+                "ret_bg-to-main_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_1": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "ret_bg-to-main_2": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 279
+                },
+                "ret_bg-to-main_3": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 9,
+              "bytes": 11003990,
+              "byName": {
+                "ret_main-to-bg_0": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "callLepusMethod": {
+                  "messages": 4,
+                  "bytes": 11003079
+                },
+                "ret_main-to-bg_1": {
+                  "messages": 1,
+                  "bytes": 60
+                },
+                "dispatchLynxViewEvent": {
+                  "messages": 3,
+                  "bytes": 791
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "replace": {
+      "control": [
+        {
+          "rawMs": 311.7000000476837,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999052,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 244
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 321
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376532,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376532
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 293.7999999523163,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999035,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 239
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 309
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376556,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376556
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 326.7000000476837,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999043,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 321
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376444,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376444
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 324.7000000476837,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999043,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 321
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376473,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376473
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 306.59999990463257,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999037,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 229
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 321
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376552,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376552
+                }
+              }
+            }
+          }
+        }
+      ],
+      "profile": [
+        {
+          "rawMs": 326.7000000476837,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999043,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 321
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376638,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376638
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 326.7000000476837,
+            "stages": {
+              "bg_replay": 34.59999990463257,
+              "wire_clone_transfer": 3,
+              "mt_validate": 11.5,
+              "mt_expand": 0,
+              "mt_prepare": 56.5,
+              "papi_element_creation": 54.60000038146973,
+              "mt_apply_other": 89.49999952316284,
+              "mt_ack_publication": 39.09999990463257,
+              "presentation_residual": 37.90000033378601
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 10001,
+              "bytes": 376526,
+              "selfcheckMs": 0,
+              "dispatchMs": 3,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 34.59999990463257
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 10001,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 11.5,
+              "prepareMs": 56.5,
+              "prepareCheckMs": 0,
+              "applyMs": 144.09999990463257,
+              "ackMs": 39.09999990463257,
+              "papiCreateMs": 54.60000038146973,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0
+            }
+          }
+        },
+        {
+          "rawMs": 329.5,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999043,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 321
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376402,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376402
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 329.5,
+            "stages": {
+              "bg_replay": 37,
+              "wire_clone_transfer": 2.5999999046325684,
+              "mt_validate": 14.800000190734863,
+              "mt_expand": 0,
+              "mt_prepare": 60.299999952316284,
+              "papi_element_creation": 59.80000042915344,
+              "mt_apply_other": 83.79999947547913,
+              "mt_ack_publication": 36.90000009536743,
+              "presentation_residual": 34.299999952316284
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 10001,
+              "bytes": 376290,
+              "selfcheckMs": 0,
+              "dispatchMs": 2.5999999046325684,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 37
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 10001,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 14.800000190734863,
+              "prepareMs": 60.299999952316284,
+              "prepareCheckMs": 0,
+              "applyMs": 143.59999990463257,
+              "ackMs": 36.90000009536743,
+              "papiCreateMs": 59.80000042915344,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0
+            }
+          }
+        },
+        {
+          "rawMs": 313,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999043,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 321
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376622,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376622
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 313,
+            "stages": {
+              "bg_replay": 35.799999952316284,
+              "wire_clone_transfer": 2.700000047683716,
+              "mt_validate": 11.299999952316284,
+              "mt_expand": 0,
+              "mt_prepare": 55.90000009536743,
+              "papi_element_creation": 58.70000338554382,
+              "mt_apply_other": 77.99999666213989,
+              "mt_ack_publication": 36,
+              "presentation_residual": 34.59999990463257
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 10001,
+              "bytes": 376510,
+              "selfcheckMs": 0,
+              "dispatchMs": 2.700000047683716,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 35.799999952316284
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 10001,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 11.299999952316284,
+              "prepareMs": 55.90000009536743,
+              "prepareCheckMs": 0,
+              "applyMs": 136.70000004768372,
+              "ackMs": 36,
+              "papiCreateMs": 58.70000338554382,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0
+            }
+          }
+        },
+        {
+          "rawMs": 321.2000000476837,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999052,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 244
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 321
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376457,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376457
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 321.2000000476837,
+            "stages": {
+              "bg_replay": 36.89999985694885,
+              "wire_clone_transfer": 3.5,
+              "mt_validate": 9.299999952316284,
+              "mt_expand": 0,
+              "mt_prepare": 59.10000014305115,
+              "papi_element_creation": 53.000001668930054,
+              "mt_apply_other": 78.3999981880188,
+              "mt_ack_publication": 35.299999952316284,
+              "presentation_residual": 45.700000286102295
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 10001,
+              "bytes": 376345,
+              "selfcheckMs": 0,
+              "dispatchMs": 3.5,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 36.89999985694885
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 10001,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 9.299999952316284,
+              "prepareMs": 59.10000014305115,
+              "prepareCheckMs": 0,
+              "applyMs": 131.39999985694885,
+              "ackMs": 35.299999952316284,
+              "papiCreateMs": 53.000001668930054,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0
+            }
+          }
+        },
+        {
+          "rawMs": 351.7000000476837,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1999049,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1998487
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 241
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 321
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 376561,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 376561
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 351.7000000476837,
+            "stages": {
+              "bg_replay": 51.299999952316284,
+              "wire_clone_transfer": 3.1000001430511475,
+              "mt_validate": 9.5,
+              "mt_expand": 0,
+              "mt_prepare": 62.299999952316284,
+              "papi_element_creation": 59.50000071525574,
+              "mt_apply_other": 79.8999993801117,
+              "mt_ack_publication": 37.299999952316284,
+              "presentation_residual": 48.799999952316284
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 10001,
+              "bytes": 376449,
+              "selfcheckMs": 0,
+              "dispatchMs": 3.1000001430511475,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 51.299999952316284
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 10001,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 9.5,
+              "prepareMs": 62.299999952316284,
+              "prepareCheckMs": 0,
+              "applyMs": 139.40000009536743,
+              "ackMs": 37.299999952316284,
+              "papiCreateMs": 59.50000071525574,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0
+            }
+          }
+        }
+      ],
+      "vueVdom": [
+        {
+          "rawMs": 178.10000014305115,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 346,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 286
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 356856,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 356856
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 174,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 346,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 286
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 356792,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 356792
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 165.70000004768372,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 346,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 286
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 356924,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 356924
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 194.79999995231628,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 332,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 272
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 356788,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 356788
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 171.20000004768372,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 334,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 274
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 356846,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 356846
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "append": {
+      "control": [
+        {
+          "rawMs": 186.29999995231628,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713062,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 324
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 35020,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 35020
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 186.5,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713061,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 234
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 324
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 34821,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 34821
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 203.60000014305115,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713062,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 324
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 34974,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 34974
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 195,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713062,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 324
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 35020,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 35020
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 191.10000014305115,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713061,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 234
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 324
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 35033,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 35033
+                }
+              }
+            }
+          }
+        }
+      ],
+      "profile": [
+        {
+          "rawMs": 188.59999990463257,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713062,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 324
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 34907,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 34907
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 188.59999990463257,
+            "stages": {
+              "bg_replay": 28.09999990463257,
+              "wire_clone_transfer": 0.40000009536743164,
+              "mt_validate": 1.2000000476837158,
+              "mt_expand": 0.10000014305114746,
+              "mt_prepare": 15.299999952316284,
+              "papi_element_creation": 48.99999928474426,
+              "mt_apply_other": 46.00000071525574,
+              "mt_ack_publication": 30,
+              "presentation_residual": 18.49999976158142
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 1,
+              "bytes": 34795,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.40000009536743164,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 28.09999990463257
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 1,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 1.2000000476837158,
+              "prepareMs": 15.299999952316284,
+              "prepareCheckMs": 0,
+              "applyMs": 95,
+              "ackMs": 30,
+              "papiCreateMs": 48.99999928474426,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0.10000014305114746
+            }
+          }
+        },
+        {
+          "rawMs": 192,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713062,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 324
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 34941,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 34941
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 192,
+            "stages": {
+              "bg_replay": 29,
+              "wire_clone_transfer": 0.3000001907348633,
+              "mt_validate": 1.2000000476837158,
+              "mt_expand": 0.09999990463256836,
+              "mt_prepare": 15.400000095367432,
+              "papi_element_creation": 51.09999990463257,
+              "mt_apply_other": 45.5,
+              "mt_ack_publication": 30.09999990463257,
+              "presentation_residual": 19.299999952316284
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 1,
+              "bytes": 34829,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.3000001907348633,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 29
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 1,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 1.2000000476837158,
+              "prepareMs": 15.400000095367432,
+              "prepareCheckMs": 0,
+              "applyMs": 96.59999990463257,
+              "ackMs": 30.09999990463257,
+              "papiCreateMs": 51.09999990463257,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0.09999990463256836
+            }
+          }
+        },
+        {
+          "rawMs": 193.90000009536743,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713068,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 241
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 324
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 35032,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 35032
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 193.90000009536743,
+            "stages": {
+              "bg_replay": 28.200000047683716,
+              "wire_clone_transfer": 0.2999999523162842,
+              "mt_validate": 1.2000000476837158,
+              "mt_expand": 0.09999990463256836,
+              "mt_prepare": 15.100000143051147,
+              "papi_element_creation": 56.300002336502075,
+              "mt_apply_other": 41.99999761581421,
+              "mt_ack_publication": 30.90000009536743,
+              "presentation_residual": 19.799999952316284
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 1,
+              "bytes": 34920,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.2999999523162842,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 28.200000047683716
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 1,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 1.2000000476837158,
+              "prepareMs": 15.100000143051147,
+              "prepareCheckMs": 0,
+              "applyMs": 98.29999995231628,
+              "ackMs": 30.90000009536743,
+              "papiCreateMs": 56.300002336502075,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0.09999990463256836
+            }
+          }
+        },
+        {
+          "rawMs": 194.20000004768372,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713062,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 324
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 35014,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 35014
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 194.20000004768372,
+            "stages": {
+              "bg_replay": 28.90000009536743,
+              "wire_clone_transfer": 0.2999999523162842,
+              "mt_validate": 1.2999999523162842,
+              "mt_expand": 0,
+              "mt_prepare": 17.09999990463257,
+              "papi_element_creation": 49.600000619888306,
+              "mt_apply_other": 46.19999933242798,
+              "mt_ack_publication": 30.40000009536743,
+              "presentation_residual": 20.40000009536743
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 1,
+              "bytes": 34902,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.2999999523162842,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 28.90000009536743
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 1,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 1.2999999523162842,
+              "prepareMs": 17.09999990463257,
+              "prepareCheckMs": 0,
+              "applyMs": 95.79999995231628,
+              "ackMs": 30.40000009536743,
+              "papiCreateMs": 49.600000619888306,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0
+            }
+          }
+        },
+        {
+          "rawMs": 196,
+          "wire": {
+            "toBts": {
+              "messages": 4,
+              "bytes": 1713062,
+              "byName": {
+                "dispatchCoreContextOnBackground": {
+                  "messages": 2,
+                  "bytes": 1712503
+                },
+                "markTiming": {
+                  "messages": 1,
+                  "bytes": 235
+                },
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 324
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 34947,
+              "byName": {
+                "dispatchJSContextOnMainThread": {
+                  "messages": 1,
+                  "bytes": 34947
+                }
+              }
+            }
+          },
+          "attribution": {
+            "totalMs": 196,
+            "stages": {
+              "bg_replay": 29.700000047683716,
+              "wire_clone_transfer": 0.39999985694885254,
+              "mt_validate": 1.3000001907348633,
+              "mt_expand": 0,
+              "mt_prepare": 16.5,
+              "papi_element_creation": 50.69999933242798,
+              "mt_apply_other": 46.200000524520874,
+              "mt_ack_publication": 31.5,
+              "presentation_residual": 19.700000047683716
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "commands": 1,
+              "bytes": 34835,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.39999985694885254,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "templateRuns": 1,
+              "templateInstances": 1000,
+              "templateValues": 3000,
+              "bgReplayMs": 29.700000047683716
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 1,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 1.3000001907348633,
+              "prepareMs": 16.5,
+              "prepareCheckMs": 0,
+              "applyMs": 96.89999985694885,
+              "ackMs": 31.5,
+              "papiCreateMs": 50.69999933242798,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 0
+            }
+          }
+        }
+      ],
+      "vueVdom": [
+        {
+          "rawMs": 157.59999990463257,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 348,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 288
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 343034,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 343034
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 155.20000004768372,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 348,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 288
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 343084,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 343084
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 152.70000004768372,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 334,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 274
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 343216,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 343216
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 159.70000004768372,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 348,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 288
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 343162,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 343162
+                }
+              }
+            }
+          }
+        },
+        {
+          "rawMs": 162.70000004768372,
+          "wire": {
+            "toBts": {
+              "messages": 2,
+              "bytes": 348,
+              "byName": {
+                "publicComponentEvent": {
+                  "messages": 1,
+                  "bytes": 288
+                },
+                "ret_bg-to-main_4": {
+                  "messages": 1,
+                  "bytes": 60
+                }
+              }
+            },
+            "toMts": {
+              "messages": 1,
+              "bytes": 343144,
+              "byName": {
+                "callLepusMethod": {
+                  "messages": 1,
+                  "bytes": 343144
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/benchmarks/lynx-table/stages/results/live-30000.md
+++ b/benchmarks/lynx-table/stages/results/live-30000.md
@@ -1,0 +1,78 @@
+# Lynx 30,000-row stage decomposition
+
+- measured: 2026-08-12T00:22:00.918Z
+- host: 32× Intel(R) Xeon(R) Platinum 8336C CPU @ 2.30GHz; linux 5.15.120.bsk.3-amd64; Node v22.22.2; Chromium 149.0.7827.55
+- protocol: fresh page per operation sample; control/profile order alternates AB/BA; one vue-vdom create/replace/append triplet follows each pair; no other benchmark process ran in this window
+- host load: start 1.80/1.93/1.87 (1/5/15m), end 2.55/2.26/2.02
+- repetitions: n=5 per A/B cell
+
+## FCP@30000
+
+Attribution starts when the shared browser hook assigns the hidden main-thread iframe Blob script URL, before load/parse/evaluation, and ends when the shared composed-tree observer first sees all 30,000 rows. `layout_flush_residual` is the exclusive remainder after directly observed slice evaluation, plan interpretation, and PAPI element creation; it includes PAPI prop/insertion work, `__FlushElementTree`, Web Core DOM publication, style/layout, and observer-frame delay because the host exposes no stable boundary between those costs.
+
+| segment | median ms | min–max ms | share |
+|---|---:|---:|---:|
+| mt_slice_eval | 25.6 | 25.3–26.9 | 0.5% |
+| plan_interpretation | 401.7 | 383.8–433.4 | 7.8% |
+| papi_element_creation | 1791.8 | 1744–1794.4 | 34.7% |
+| layout_flush_residual | 2945.6 | 2864.6–3127.6 | 57.1% |
+
+Raw view-attach FCP: profile 5184.7 ms (5077.1–5359), control 5036 ms; same-window profile/control 1.03×.
+
+## create@30000
+
+Attribution starts at the shared pointerdown boundary and ends when the shared composed-tree observer sees 30,000 rows. All named intervals are directly observed and exclusive; `presentation_residual` is the wall-clock remainder through final composed-tree presentation.
+
+| segment | median ms | min–max ms | share |
+|---|---:|---:|---:|
+| bg_replay | 344.5 | 343.4–348.5 | 9.8% |
+| wire_clone_transfer | 11 | 10.7–11.5 | 0.3% |
+| mt_validate | 32 | 31.1–32.3 | 0.9% |
+| mt_expand | 0 | 0–0.1 | 0.0% |
+| mt_prepare | 11 | 10.7–11.4 | 0.3% |
+| papi_element_creation | 1791 | 1726.4–1827.8 | 51.2% |
+| mt_apply_other | 993 | 965.7–1031.2 | 28.4% |
+| mt_ack_publication | 0.6 | 0.6–0.7 | 0.0% |
+| presentation_residual | 300 | 280.4–338.5 | 8.6% |
+
+Raw create: profile 3498.6 ms (3392.4–3521.2), control 3358.7 ms, vue-vdom 3991.4 ms; same-window profile/control 1.042×, profile/vue-vdom 0.877×.
+Wire: MTS→BTS 19,622 B / 15 messages; BTS→MTS 1,046,672 B / 10 messages.
+
+## replace@1k
+
+| segment | median ms | share |
+|---|---:|---:|
+| bg_replay | 36.9 | 11.3% |
+| wire_clone_transfer | 3 | 0.9% |
+| mt_validate | 11.3 | 3.5% |
+| mt_expand | 0 | 0.0% |
+| mt_prepare | 59.1 | 18.1% |
+| papi_element_creation | 58.7 | 18.0% |
+| mt_apply_other | 79.9 | 24.5% |
+| mt_ack_publication | 36.9 | 11.3% |
+| presentation_residual | 37.9 | 11.6% |
+
+Raw replace: profile 326.7 ms, control 311.7 ms, vue-vdom 174 ms. Wire: MTS→BTS 1,999,043 B / 4 messages; BTS→MTS 376,561 B / 1 messages.
+
+## append@1k
+
+| segment | median ms | share |
+|---|---:|---:|
+| bg_replay | 28.9 | 14.9% |
+| wire_clone_transfer | 0.3 | 0.2% |
+| mt_validate | 1.2 | 0.6% |
+| mt_expand | 0.1 | 0.1% |
+| mt_prepare | 15.4 | 7.9% |
+| papi_element_creation | 50.7 | 26.1% |
+| mt_apply_other | 46 | 23.7% |
+| mt_ack_publication | 30.4 | 15.7% |
+| presentation_residual | 19.7 | 10.2% |
+
+Raw append: profile 193.9 ms, control 191.1 ms, vue-vdom 157.6 ms. Wire: MTS→BTS 1,713,062 B / 4 messages; BTS→MTS 34,947 B / 1 messages.
+
+## Verdicts
+
+- **#47 wire/encoding candidate: NO-GO.** clone/transfer is 0.3% of create, 0.9% of replace, and 0.2% of append; it does not clear the 10% owner gate.
+- **#47 measured CPU owner: SPLIT.** PAPI creation plus remaining host apply is 79.6% of create. This is a host materialization owner, not evidence for changing the wire representation.
+- **#47 acknowledgement-only candidate: NO-GO for issue acceptance.** ACK/publication is 0.0% of create, 11.3% of replace, and 15.7% of append; even a complete removal cannot meet the required 15% in all three cells or the 50% total-wire gate.
+

--- a/benchmarks/lynx-table/stages/results/live-30000.md
+++ b/benchmarks/lynx-table/stages/results/live-30000.md
@@ -75,4 +75,3 @@ Raw append: profile 193.9 ms, control 191.1 ms, vue-vdom 157.6 ms. Wire: MTS→B
 - **#47 wire/encoding candidate: NO-GO.** clone/transfer is 0.3% of create, 0.9% of replace, and 0.2% of append; it does not clear the 10% owner gate.
 - **#47 measured CPU owner: SPLIT.** PAPI creation plus remaining host apply is 79.6% of create. This is a host materialization owner, not evidence for changing the wire representation.
 - **#47 acknowledgement-only candidate: NO-GO for issue acceptance.** ACK/publication is 0.0% of create, 11.3% of replace, and 15.7% of append; even a complete removal cannot meet the required 15% in all three cells or the 50% total-wire gate.
-

--- a/benchmarks/lynx-table/stages/results/live-report.md
+++ b/benchmarks/lynx-table/stages/results/live-report.md
@@ -1,0 +1,56 @@
+# Post-#706/#707 template-ingress decomposition
+
+## Baseline and protocol
+
+- source: upstream `9b147781c9b4ec4df053a059633978ddc0ed922a`, #706 head `8d8883c8`, then both #707 commits ending at `71b758e7` (local integration `ecd18332` for the instrumented measurement branch)
+- exact featured baseline: forward `2026-08-11T21-14-12-65160668d8d9-integration-706-707-featured.json`, reverse `2026-08-11T21-42-04-65160668d8d9-integration-706-707-featured-reverse.json`; every ReactLynx/Vue reference rebuilt from the same lockfile; 802 records per run and zero DNF/null cells
+- decision-cell baseline medians: create@10k `1,994.7 / 2,075.3 ms`, replace@1k `261.2 / 270.3 ms`, append1k@1k `172.3 / 174.9 ms` forward/reverse
+- measurement: fresh page per operation; control/profile alternates AB/BA; n=5 per cell; Chromium `149.0.7827.55`; direct intervals are exclusive; control/profile overhead stayed `1.046×`, `1.052×`, and `1.042×` at 1k/10k/30k create
+
+Raw samples, spreads, endpoint maps, realm counters, hashes, host information,
+and sample order are checked in as `live-1000.json`, `live-10000.json`, and
+`live-30000.json` beside this report.
+
+## Direct create attribution
+
+| rows | profiled wall | BTS replay | clone/transfer | PAPI create | other host apply | ACK/publication | presentation residual |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1,000 | 148.3 ms | 26.9 ms (18.1%) | 0.6 ms (0.4%) | 62.0 ms (41.8%) | 41.0 ms (27.6%) | 0.5 ms (0.3%) | 13.2 ms (8.9%) |
+| 10,000 | 1,201.5 ms | 146.1 ms (12.2%) | 4.0 ms (0.3%) | 578.2 ms (48.1%) | 341.7 ms (28.4%) | 0.6 ms (0.0%) | 119.0 ms (9.9%) |
+| 30,000 | 3,498.6 ms | 344.5 ms (9.8%) | 11.0 ms (0.3%) | 1,791.0 ms (51.2%) | 993.0 ms (28.4%) | 0.6 ms (0.0%) | 300.0 ms (8.6%) |
+
+PAPI creation scales at 62.0/57.8/59.7 μs per row and other host apply at
+41.0/34.2/33.1 μs per row. ACK remains constant. Each create emits one shared
+template run, exactly 1k/10k/30k instances, three values per row, no public
+handle command, and the semantic-floor Row body count.
+
+At 10k, replace@1k attributes 0.9% to clone/transfer, 16.0% to PAPI, 25.3% to
+other apply, and 11.1% to ACK/publication. Append attributes 0.2%, 27.6%, 24.0%,
+and 15.8% respectively. Even deleting ACK entirely cannot improve all three
+required wall-clock cells by 15%.
+
+## Endpoint ownership
+
+The apparent large “total wire” is not an Octane commit packet. The page-side
+Web Core boundary separates it:
+
+| operation | MTS→BTS total | owner | BTS→MTS total | owner |
+|---|---:|---|---:|---|
+| create@10k | 19,608 B | Web Core control/event endpoints | 347,168 B | Octane host commit plus view events |
+| replace@1k | 1,999,043 B | `dispatchCoreContextOnBackground` | 376,446 B | one `dispatchJSContextOnMainThread` commit |
+| append1k@1k | 1,713,061 B | `dispatchCoreContextOnBackground` | 34,944 B | one `dispatchJSContextOnMainThread` commit |
+
+The profile's direct Octane counters agree: append is one command, one template
+run, 1,000 instances, and 3,000 scalar values; replace is 10,001 commands
+because it retires the previous physical tree before mounting the one-run
+replacement. The multi-megabyte opposite-direction payload is Web Core event
+transport and cannot be halved by an Octane value/ACK encoding patch.
+
+## Decision
+
+- wire/value encoding: **NO-GO**; clone/transfer is 0.2–0.9%, below the required 10% owner gate, and Octane does not own the dominant total-wire direction.
+- ACK-only change: **NO-GO**; it cannot satisfy the dual 50%-wire and 15%-latency acceptance gate, consistent with #45's negative control.
+- observed owner: **split to PAPI/host materialization**; PAPI plus other apply owns 69.5–79.6% of create and remains linear. The current stack already uses the public dense intrinsic factories and append API introduced by #700, so there is no evidence-backed Octane representation experiment left in #47.
+
+The measurement implementation and frozen results should land; no product
+packet change should be proposed from this issue.

--- a/benchmarks/lynx-table/stages/results/sg1.json
+++ b/benchmarks/lynx-table/stages/results/sg1.json
@@ -1,0 +1,688 @@
+{
+  "meta": {
+    "date": "2026-08-10T00:01:42.807Z",
+    "node": "v22.22.2",
+    "cpus": 32,
+    "cpuModel": "Intel(R) Xeon(R) Platinum 8336C CPU @ 2.30GHz",
+    "platform": "linux",
+    "release": "5.15.120.bsk.3-amd64",
+    "chromium": "149.0.7827.55",
+    "repetitions": 5,
+    "rows": 10000,
+    "reportable": true,
+    "loadStart": [0.84, 1.29, 2.53],
+    "loadEnd": [1.68, 1.49, 2.48],
+    "protocol": "fresh page per sample; control/profile order alternates AB/BA; one vue-vdom create sample follows each pair; no other benchmark process ran in this window"
+  },
+  "fcp": {
+    "attribution": {
+      "total": {
+        "median": 2290.199951171875,
+        "min": 2230.39990234375,
+        "max": 2374,
+        "spread": 143.60009765625,
+        "n": 5
+      },
+      "stages": {
+        "mt_slice_eval": {
+          "median": 17.699951171875,
+          "min": 17,
+          "max": 22.300048828125,
+          "spread": 5.300048828125,
+          "n": 5,
+          "share": 0.00772856150084978
+        },
+        "plan_interpretation": {
+          "median": 124.40000009536743,
+          "min": 119.70000004768372,
+          "max": 127.70000004768372,
+          "spread": 8,
+          "n": 5,
+          "share": 0.0543184013394608
+        },
+        "papi_element_creation": {
+          "median": 496.7999951839447,
+          "min": 487.19999408721924,
+          "max": 517.0000050067902,
+          "spread": 29.800010919570923,
+          "n": 5,
+          "share": 0.2169242886105803
+        },
+        "layout_flush_residual": {
+          "median": 1659.6999998092651,
+          "min": 1605.799957036972,
+          "max": 1709.499957561493,
+          "spread": 103.70000052452087,
+          "n": 5,
+          "share": 0.7246965484214648
+        }
+      },
+      "ratios": {}
+    },
+    "rawControl": {
+      "median": 2311.2999999523163,
+      "min": 2203.199999809265,
+      "max": 2329.399999856949,
+      "spread": 126.20000004768372,
+      "n": 5
+    },
+    "rawProfile": {
+      "median": 2319.5,
+      "min": 2257.5,
+      "max": 2402.800000190735,
+      "spread": 145.30000019073486,
+      "n": 5
+    }
+  },
+  "create": {
+    "attribution": {
+      "total": {
+        "median": 2701.7999999523163,
+        "min": 2635.100000143051,
+        "max": 2806.2999999523163,
+        "spread": 171.19999980926514,
+        "n": 5
+      },
+      "stages": {
+        "bg_replay": {
+          "median": 648.2999999523163,
+          "min": 620,
+          "max": 670.2000000476837,
+          "spread": 50.200000047683716,
+          "n": 5,
+          "share": 0.23995114366857578
+        },
+        "wire_clone_transfer": {
+          "median": 27.09999990463257,
+          "min": 26.799999952316284,
+          "max": 27.799999952316284,
+          "spread": 1,
+          "n": 5,
+          "share": 0.010030350101825024
+        },
+        "mt_expand": {
+          "median": 68.60000014305115,
+          "min": 66.29999995231628,
+          "max": 89.09999990463257,
+          "spread": 22.799999952316284,
+          "n": 5,
+          "share": 0.025390480473855156
+        },
+        "papi_element_creation": {
+          "median": 551.900007724762,
+          "min": 535.3999974727631,
+          "max": 597.5999965667725,
+          "spread": 62.1999990940094,
+          "n": 5,
+          "share": 0.20427122945240297
+        },
+        "layout_flush_residual": {
+          "median": 1406.099992275238,
+          "min": 1386.4000027179718,
+          "max": 1434.9000010490417,
+          "spread": 48.499998331069946,
+          "n": 5,
+          "share": 0.5204308210452492
+        }
+      },
+      "ratios": {
+        "control": 1.0164785552868008,
+        "reference": 1.972836801717646
+      }
+    },
+    "rawControl": {
+      "median": 2658,
+      "min": 2576.2999999523163,
+      "max": 2793.4000000953674,
+      "spread": 217.10000014305115,
+      "n": 5
+    },
+    "rawProfile": {
+      "median": 2701.7999999523163,
+      "min": 2635.100000143051,
+      "max": 2806.2999999523163,
+      "spread": 171.19999980926514,
+      "n": 5
+    },
+    "vueVdom": {
+      "median": 1369.5,
+      "min": 1329.7000000476837,
+      "max": 1422,
+      "spread": 92.29999995231628,
+      "n": 5
+    }
+  },
+  "verdicts": [
+    {
+      "step": "s2-2 (#18)",
+      "verdict": "NO-GO",
+      "reason": "plan interpretation is 5.4% of attributed FCP and instantiate expansion is 2.5% of create; neither clears the 10% direct-share gate."
+    },
+    {
+      "step": "s2-3 (#19)",
+      "verdict": "NO-GO from this instrument",
+      "reason": "This issue measures mount/FCP, not slot-update routing; the roadmap already records point updates inside the target band, so no measured mount share justifies updater staging here."
+    },
+    {
+      "step": "s2-4 (#20)",
+      "verdict": "NO-GO",
+      "reason": "receiver slice evaluation plus plan interpretation is 6.2% of attributed FCP and wire is 1.0% of create; neither clears the 10% direct-share gate, and the create residual is deliberately not attributed to receiver code."
+    }
+  ],
+  "samples": {
+    "fcp": {
+      "control": [
+        {
+          "rawMs": 2203.199999809265
+        },
+        {
+          "rawMs": 2329.399999856949
+        },
+        {
+          "rawMs": 2319.300000190735
+        },
+        {
+          "rawMs": 2211
+        },
+        {
+          "rawMs": 2311.2999999523163
+        }
+      ],
+      "profile": [
+        {
+          "rawMs": 2257.5,
+          "attribution": {
+            "totalMs": 2230.39990234375,
+            "stages": {
+              "mt_slice_eval": 17.699951171875,
+              "plan_interpretation": 119.70000004768372,
+              "papi_element_creation": 487.19999408721924,
+              "layout_flush_residual": 1605.799957036972
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 0,
+              "pacedCommits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.19999980926513672,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0
+            },
+            "main": {
+              "commits": 0,
+              "pacedCommits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "papiCreateMs": 487.19999408721924,
+              "mtSliceStartEpochMs": 1786320015314.9001,
+              "mtSliceEvalMs": 17.699951171875,
+              "firstScreenPlanMs": 119.70000004768372
+            }
+          }
+        },
+        {
+          "rawMs": 2367.0999999046326,
+          "attribution": {
+            "totalMs": 2339.7001953125,
+            "stages": {
+              "mt_slice_eval": 17.800048828125,
+              "plan_interpretation": 126.60000014305115,
+              "papi_element_creation": 517.0000050067902,
+              "layout_flush_residual": 1678.3001413345337
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 0,
+              "pacedCommits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.20000028610229492,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0
+            },
+            "main": {
+              "commits": 0,
+              "pacedCommits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "papiCreateMs": 517.0000050067902,
+              "mtSliceStartEpochMs": 1786320026543.7,
+              "mtSliceEvalMs": 17.800048828125,
+              "firstScreenPlanMs": 126.60000014305115
+            }
+          }
+        },
+        {
+          "rawMs": 2319.5,
+          "attribution": {
+            "totalMs": 2290.199951171875,
+            "stages": {
+              "mt_slice_eval": 17.199951171875,
+              "plan_interpretation": 122.10000014305115,
+              "papi_element_creation": 491.2000000476837,
+              "layout_flush_residual": 1659.6999998092651
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 0,
+              "pacedCommits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0
+            },
+            "main": {
+              "commits": 0,
+              "pacedCommits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "papiCreateMs": 491.2000000476837,
+              "mtSliceStartEpochMs": 1786320053734.9,
+              "mtSliceEvalMs": 17.199951171875,
+              "firstScreenPlanMs": 122.10000014305115
+            }
+          }
+        },
+        {
+          "rawMs": 2283.2000000476837,
+          "attribution": {
+            "totalMs": 2257.599853515625,
+            "stages": {
+              "mt_slice_eval": 17,
+              "plan_interpretation": 124.40000009536743,
+              "papi_element_creation": 496.7999951839447,
+              "layout_flush_residual": 1619.3998582363129
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 0,
+              "pacedCommits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.19999980926513672,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0
+            },
+            "main": {
+              "commits": 0,
+              "pacedCommits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "papiCreateMs": 496.7999951839447,
+              "mtSliceStartEpochMs": 1786320064895.2002,
+              "mtSliceEvalMs": 17,
+              "firstScreenPlanMs": 124.40000009536743
+            }
+          }
+        },
+        {
+          "rawMs": 2402.800000190735,
+          "attribution": {
+            "totalMs": 2374,
+            "stages": {
+              "mt_slice_eval": 22.300048828125,
+              "plan_interpretation": 127.70000004768372,
+              "papi_element_creation": 514.4999935626984,
+              "layout_flush_residual": 1709.499957561493
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 0,
+              "pacedCommits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0.2999999523162842,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0
+            },
+            "main": {
+              "commits": 0,
+              "pacedCommits": 0,
+              "commands": 0,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "papiCreateMs": 514.4999935626984,
+              "mtSliceStartEpochMs": 1786320091421.6,
+              "mtSliceEvalMs": 22.300048828125,
+              "firstScreenPlanMs": 127.70000004768372
+            }
+          }
+        }
+      ]
+    },
+    "create": {
+      "control": [
+        {
+          "rawMs": 2576.2999999523163
+        },
+        {
+          "rawMs": 2793.4000000953674
+        },
+        {
+          "rawMs": 2692.9000000953674
+        },
+        {
+          "rawMs": 2658
+        },
+        {
+          "rawMs": 2644.7000000476837
+        }
+      ],
+      "profile": [
+        {
+          "rawMs": 2693.600000143051,
+          "attribution": {
+            "totalMs": 2693.600000143051,
+            "stages": {
+              "bg_replay": 651.2999999523163,
+              "wire_clone_transfer": 26.799999952316284,
+              "mt_expand": 68.60000014305115,
+              "papi_element_creation": 550.2000052928925,
+              "layout_flush_residual": 1396.699994802475
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "pacedCommits": 1,
+              "commands": 10000,
+              "bytes": 3297868,
+              "selfcheckMs": 0,
+              "dispatchMs": 26.799999952316284,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "bgReplayMs": 651.2999999523163
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 10000,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 0.09999990463256836,
+              "prepareMs": 458.2999999523163,
+              "prepareCheckMs": 0,
+              "applyMs": 1358.5,
+              "ackMs": 0.09999990463256836,
+              "papiCreateMs": 550.2000052928925,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 68.60000014305115
+            }
+          }
+        },
+        {
+          "rawMs": 2701.7999999523163,
+          "attribution": {
+            "totalMs": 2701.7999999523163,
+            "stages": {
+              "bg_replay": 648.2999999523163,
+              "wire_clone_transfer": 27.799999952316284,
+              "mt_expand": 67.70000004768372,
+              "papi_element_creation": 551.900007724762,
+              "layout_flush_residual": 1406.099992275238
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "pacedCommits": 1,
+              "commands": 10000,
+              "bytes": 3297903,
+              "selfcheckMs": 0,
+              "dispatchMs": 27.799999952316284,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "bgReplayMs": 648.2999999523163
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 10000,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 0,
+              "prepareMs": 462.7999999523163,
+              "prepareCheckMs": 0,
+              "applyMs": 1360.7000000476837,
+              "ackMs": 0.10000014305114746,
+              "papiCreateMs": 551.900007724762,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 67.70000004768372
+            }
+          }
+        },
+        {
+          "rawMs": 2635.100000143051,
+          "attribution": {
+            "totalMs": 2635.100000143051,
+            "stages": {
+              "bg_replay": 620,
+              "wire_clone_transfer": 27,
+              "mt_expand": 66.29999995231628,
+              "papi_element_creation": 535.3999974727631,
+              "layout_flush_residual": 1386.4000027179718
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "pacedCommits": 1,
+              "commands": 10000,
+              "bytes": 3297710,
+              "selfcheckMs": 0,
+              "dispatchMs": 27,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "bgReplayMs": 620
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 10000,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 0.20000004768371582,
+              "prepareMs": 456.7000000476837,
+              "prepareCheckMs": 0,
+              "applyMs": 1331.6000001430511,
+              "ackMs": 0.09999990463256836,
+              "papiCreateMs": 535.3999974727631,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 66.29999995231628
+            }
+          }
+        },
+        {
+          "rawMs": 2740.4000000953674,
+          "attribution": {
+            "totalMs": 2740.4000000953674,
+            "stages": {
+              "bg_replay": 639.9000000953674,
+              "wire_clone_transfer": 27.09999990463257,
+              "mt_expand": 81.09999990463257,
+              "papi_element_creation": 557.3999991416931,
+              "layout_flush_residual": 1434.9000010490417
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "pacedCommits": 1,
+              "commands": 10000,
+              "bytes": 3298301,
+              "selfcheckMs": 0,
+              "dispatchMs": 27.09999990463257,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "bgReplayMs": 639.9000000953674
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 10000,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 0.10000014305114746,
+              "prepareMs": 508.2999999523163,
+              "prepareCheckMs": 0,
+              "applyMs": 1345.1000001430511,
+              "ackMs": 0.19999980926513672,
+              "papiCreateMs": 557.3999991416931,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 81.09999990463257
+            }
+          }
+        },
+        {
+          "rawMs": 2806.2999999523163,
+          "attribution": {
+            "totalMs": 2806.2999999523163,
+            "stages": {
+              "bg_replay": 670.2000000476837,
+              "wire_clone_transfer": 27.399999856948853,
+              "mt_expand": 89.09999990463257,
+              "papi_element_creation": 597.5999965667725,
+              "layout_flush_residual": 1422.0000035762787
+            }
+          },
+          "realms": {
+            "background": {
+              "commits": 1,
+              "pacedCommits": 1,
+              "commands": 10000,
+              "bytes": 3298049,
+              "selfcheckMs": 0,
+              "dispatchMs": 27.399999856948853,
+              "validateMs": 0,
+              "prepareMs": 0,
+              "prepareCheckMs": 0,
+              "applyMs": 0,
+              "ackMs": 0,
+              "bgReplayMs": 670.2000000476837
+            },
+            "main": {
+              "commits": 1,
+              "pacedCommits": 0,
+              "commands": 10000,
+              "bytes": 0,
+              "selfcheckMs": 0,
+              "dispatchMs": 0,
+              "validateMs": 0.10000014305114746,
+              "prepareMs": 469,
+              "prepareCheckMs": 0,
+              "applyMs": 1393.2000000476837,
+              "ackMs": 0.09999990463256836,
+              "papiCreateMs": 597.5999965667725,
+              "mtSliceStartEpochMs": 0,
+              "mtSliceEvalMs": 0,
+              "firstScreenPlanMs": 0,
+              "mtExpandMs": 89.09999990463257
+            }
+          }
+        }
+      ],
+      "vueVdom": [
+        {
+          "rawMs": 1369.5
+        },
+        {
+          "rawMs": 1422
+        },
+        {
+          "rawMs": 1329.7000000476837
+        },
+        {
+          "rawMs": 1412
+        },
+        {
+          "rawMs": 1358.5
+        }
+      ]
+    }
+  }
+}

--- a/benchmarks/lynx-table/stages/results/sg1.md
+++ b/benchmarks/lynx-table/stages/results/sg1.md
@@ -1,0 +1,40 @@
+# Lynx 10k stage decomposition
+
+- measured: 2026-08-10T00:01:42.807Z
+- host: 32× Intel(R) Xeon(R) Platinum 8336C CPU @ 2.30GHz; linux 5.15.120.bsk.3-amd64; Node v22.22.2; Chromium 149.0.7827.55
+- protocol: fresh page per sample; control/profile order alternates AB/BA; one vue-vdom create sample follows each pair; no other benchmark process ran in this window
+- host load: start 0.84/1.29/2.53 (1/5/15m), end 1.68/1.49/2.48
+- repetitions: n=5 per A/B cell
+
+## FCP@10k
+
+Attribution starts when the shared browser hook assigns the hidden main-thread iframe Blob script URL, before load/parse/evaluation, and ends when the shared composed-tree observer first sees all 10,000 rows. `layout_flush_residual` is the exclusive remainder after directly observed slice evaluation, plan interpretation, and PAPI element creation; it includes PAPI prop/insertion work, `__FlushElementTree`, Web Core DOM publication, style/layout, and observer-frame delay because the host exposes no stable boundary between those costs.
+
+| segment | median ms | min–max ms | share |
+|---|---:|---:|---:|
+| mt_slice_eval | 17.7 | 17–22.3 | 0.8% |
+| plan_interpretation | 124.4 | 119.7–127.7 | 5.4% |
+| papi_element_creation | 496.8 | 487.2–517 | 21.7% |
+| layout_flush_residual | 1659.7 | 1605.8–1709.5 | 72.5% |
+
+Raw view-attach FCP: profile 2319.5 ms (2257.5–2402.8), control 2311.3 ms; same-window profile/control 1.004×.
+
+## create@10k
+
+Attribution starts at the shared pointerdown boundary and ends when the shared composed-tree observer sees 10,000 rows. `bg_replay`, `wire_clone_transfer`, `mt_expand`, and PAPI creation are directly observed exclusive intervals. `layout_flush_residual` is the wall-clock remainder, including event delivery before replay, validation/prepare, non-create PAPI work, flush/layout, scheduling, and observer-frame delay.
+
+| segment | median ms | min–max ms | share |
+|---|---:|---:|---:|
+| bg_replay | 648.3 | 620–670.2 | 24.0% |
+| wire_clone_transfer | 27.1 | 26.8–27.8 | 1.0% |
+| mt_expand | 68.6 | 66.3–89.1 | 2.5% |
+| papi_element_creation | 551.9 | 535.4–597.6 | 20.4% |
+| layout_flush_residual | 1406.1 | 1386.4–1434.9 | 52.0% |
+
+Raw create: profile 2701.8 ms (2635.1–2806.3), control 2658 ms, vue-vdom 1369.5 ms; same-window profile/control 1.016×, profile/vue-vdom 1.973×.
+
+## Verdicts
+
+- **s2-2 (#18): NO-GO.** plan interpretation is 5.4% of attributed FCP and instantiate expansion is 2.5% of create; neither clears the 10% direct-share gate.
+- **s2-3 (#19): NO-GO from this instrument.** This issue measures mount/FCP, not slot-update routing; the roadmap already records point updates inside the target band, so no measured mount share justifies updater staging here.
+- **s2-4 (#20): NO-GO.** receiver slice evaluation plus plan interpretation is 6.2% of attributed FCP and wire is 1.0% of create; neither clears the 10% direct-share gate, and the create residual is deliberately not attributed to receiver code.

--- a/benchmarks/lynx-table/stages/run.mjs
+++ b/benchmarks/lynx-table/stages/run.mjs
@@ -1,0 +1,465 @@
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { parseArgs } from 'node:util';
+
+import {
+	analyzeCreateSample,
+	analyzeFcpSample,
+	interleavedABSchedule,
+	parseRealmSnapshots,
+	requireMinimumRepetitions,
+	summarizeSamples,
+} from './analyze.mjs';
+import {
+	DRIVER_CLIENT_JS,
+	applyNeutralize,
+	applyStageClock,
+	makeBenchHtml,
+} from '../web/driver-client.mjs';
+import { buildTableApp } from '../scripts/build-app.mjs';
+
+const require = createRequire(import.meta.url);
+const root = path.resolve(import.meta.dirname, '..');
+const { values: args } = parseArgs({
+	options: {
+		reps: { type: 'string', default: '5' },
+		rows: { type: 'string', default: '10000' },
+		port: { type: 'string', default: '8361' },
+		smoke: { type: 'boolean', default: false },
+		'skip-build': { type: 'boolean', default: false },
+		'allow-busy-host': { type: 'boolean', default: false },
+	},
+});
+const repetitions = args.smoke ? 1 : requireMinimumRepetitions(args.reps);
+const rows = Number(args.rows);
+if (!Number.isSafeInteger(rows) || rows <= 0)
+	throw new TypeError('rows must be a positive integer.');
+const port = Number(args.port);
+const cpuCount = os.cpus().length;
+const loadPerCpu = os.loadavg()[0] / cpuCount;
+if (!args['allow-busy-host'] && loadPerCpu > 0.5) {
+	throw new Error(
+		`quiet-host preflight failed: 1-minute load ${os.loadavg()[0].toFixed(2)} / ${cpuCount} CPUs = ${loadPerCpu.toFixed(2)}; close competing work or pass --allow-busy-host and disclose it.`,
+	);
+}
+
+const variants = {
+	control: path.join(root, 'app/dist/main.web.bundle'),
+	profile: path.join(root, 'app/dist-profile/main.web.bundle'),
+	'control-fcp': path.join(root, `app/dist-rows${rows}/main.web.bundle`),
+	'profile-fcp': path.join(root, `app/dist-rows${rows}-profile/main.web.bundle`),
+	'vue-vdom': path.join(root, 'reference/vdom-ifr-et/main.web.bundle'),
+};
+const webCoreClientJs = require.resolve('@lynx-js/web-core/client.prod.js');
+const webCoreRoot = path.resolve(path.dirname(webCoreClientJs), '../..');
+const html = makeBenchHtml();
+
+function buildVariants() {
+	const previousProfile = process.env.OCTANE_LYNX_PROFILE;
+	const previousRows = process.env.BENCH_AUTOROWS;
+	try {
+		for (const [profile, autoRows] of [
+			['0', '0'],
+			['1', '0'],
+			['0', String(rows)],
+			['1', String(rows)],
+		]) {
+			process.env.OCTANE_LYNX_PROFILE = profile;
+			process.env.BENCH_AUTOROWS = autoRows;
+			buildTableApp({ silent: true });
+		}
+	} finally {
+		if (previousProfile === undefined) delete process.env.OCTANE_LYNX_PROFILE;
+		else process.env.OCTANE_LYNX_PROFILE = previousProfile;
+		if (previousRows === undefined) delete process.env.BENCH_AUTOROWS;
+		else process.env.BENCH_AUTOROWS = previousRows;
+	}
+	const control = fs.readFileSync(variants.control);
+	const profile = fs.readFileSync(variants.profile);
+	const marker = Buffer.from('__OCTANE_LYNX_MT_SLICE_LOAD_START_EPOCH__');
+	if (control.includes(marker))
+		throw new Error('default production bundle retained stage profiling.');
+	if (!profile.includes(marker))
+		throw new Error('profile bundle omitted its browser-owned slice-start read.');
+}
+
+function startServer() {
+	const mime = {
+		'.js': 'text/javascript',
+		'.css': 'text/css',
+		'.wasm': 'application/wasm',
+		'.bundle': 'application/octet-stream',
+	};
+	const server = http.createServer((request, response) => {
+		const url = new URL(request.url, 'http://localhost');
+		if (url.pathname === '/') {
+			response.writeHead(200, { 'content-type': 'text/html', 'cache-control': 'no-store' });
+			response.end(html);
+			return;
+		}
+		let file = null;
+		if (url.pathname.startsWith('/webcore/')) file = path.join(webCoreRoot, url.pathname.slice(9));
+		else if (url.pathname.startsWith('/bundle/')) file = variants[url.pathname.slice(8)];
+		if (file === null || file === undefined || !fs.existsSync(file)) {
+			response.writeHead(404);
+			response.end('not found');
+			return;
+		}
+		response.writeHead(200, {
+			'content-type': mime[path.extname(file)] ?? 'application/octet-stream',
+			'cache-control': 'no-store',
+		});
+		fs.createReadStream(file).pipe(response);
+	});
+	return new Promise((resolve) => server.listen(port, '127.0.0.1', () => resolve(server)));
+}
+
+async function load(browser, variant) {
+	const page = await browser.newPage();
+	if (process.env.LYNX_BENCH_DEBUG) {
+		page.on('console', (message) =>
+			console.log(`[console:${variant}:${message.type()}]`, message.text().slice(0, 500)),
+		);
+		page.on('pageerror', (error) =>
+			console.log(`[pageerror:${variant}]`, String(error).slice(0, 1000)),
+		);
+	}
+	await applyNeutralize(page);
+	await applyStageClock(page);
+	await page.goto(`http://127.0.0.1:${port}/`, { waitUntil: 'load' });
+	await page.evaluate(
+		(url) => globalThis.__x.createView(url),
+		`http://127.0.0.1:${port}/bundle/${variant}`,
+	);
+	return page;
+}
+
+async function realmSnapshots(page) {
+	const read = () => {
+		const value = globalThis.__OCTANE_LYNX_PROF;
+		if (value === undefined) return null;
+		const copy = {};
+		for (const key of Object.keys(value)) {
+			if (typeof value[key] === 'number') copy[key] = value[key];
+		}
+		return copy;
+	};
+	const snapshots = [];
+	for (const frame of page.frames()) {
+		const profile = await frame.evaluate(read).catch(() => null);
+		if (profile !== null) snapshots.push({ kind: 'frame', profile });
+	}
+	for (const worker of page.workers()) {
+		const profile = await worker.evaluate(read).catch(() => null);
+		if (profile !== null) snapshots.push({ kind: 'worker', profile });
+	}
+	return parseRealmSnapshots(snapshots);
+}
+
+async function resetProfiles(page) {
+	const reset = () => {
+		const profile = globalThis.__OCTANE_LYNX_PROF;
+		if (profile === undefined) return;
+		for (const key of Object.keys(profile)) profile[key] = 0;
+	};
+	await Promise.all([
+		...page.frames().map((frame) => frame.evaluate(reset).catch(() => {})),
+		...page.workers().map((worker) => worker.evaluate(reset).catch(() => {})),
+	]);
+}
+
+async function runFcp(browser, variant, profile) {
+	const page = await load(browser, `${variant}-fcp`);
+	try {
+		const observation = await page.evaluate(
+			(count) => globalThis.__x.fcp({ minContent: count, idleMs: 300, timeoutMs: 120000 }),
+			rows,
+		);
+		if (observation.dnf || observation.fcp === null)
+			throw new Error(`${variant} FCP did not finish.`);
+		if (!profile) return { rawMs: observation.fcp };
+		const realms = await realmSnapshots(page);
+		if (realms.main === null || realms.main.mtSliceStartEpochMs === 0) {
+			throw new Error('profile FCP did not expose the main-thread realm snapshot.');
+		}
+		return {
+			rawMs: observation.fcp,
+			attribution: analyzeFcpSample({
+				wallMs: observation.fcpEpoch - realms.main.mtSliceStartEpochMs,
+				main: realms.main,
+			}),
+			realms,
+		};
+	} finally {
+		await page.close();
+	}
+}
+
+const createLabels = new Map([
+	[1000, 'Create 1,000 rows'],
+	[3000, 'Create 3,000 rows'],
+	[5000, 'Create 5,000 rows'],
+	[10000, 'Create 10,000 rows'],
+	[20000, 'Create 20,000 rows'],
+	[30000, 'Create 30,000 rows'],
+]);
+
+async function clickCreate(page) {
+	const label = createLabels.get(rows);
+	if (label === undefined) throw new Error(`the shared app has no create button for ${rows} rows.`);
+	await page.waitForFunction(() => globalThis.__x.findText('Benchmark on Lynx'), undefined, {
+		timeout: 60000,
+	});
+	await page.evaluate(() => globalThis.__x.settle());
+	const armed = page.evaluate(
+		(count) => globalThis.__x.arm({ type: 'rowCount', value: count }, 120000),
+		rows,
+	);
+	const rectangle = await page.evaluate((text) => globalThis.__x.buttonRect(text), label);
+	if (rectangle === null) throw new Error('create button not found.');
+	await page.mouse.click(rectangle.x, rectangle.y);
+	return (await armed).ms;
+}
+
+async function runCreate(browser, variant, profile) {
+	const page = await load(browser, variant);
+	try {
+		if (profile) {
+			await page.waitForFunction(() => globalThis.__x.findText('Benchmark on Lynx'), undefined, {
+				timeout: 60000,
+			});
+			await page.evaluate(() => globalThis.__x.settle());
+			await resetProfiles(page);
+		}
+		const rawMs = await clickCreate(page);
+		if (!profile) return { rawMs };
+		const realms = await realmSnapshots(page);
+		if (realms.background === null || realms.main === null) {
+			throw new Error('profile create did not expose both Lynx realm snapshots.');
+		}
+		return {
+			rawMs,
+			attribution: analyzeCreateSample({
+				wallMs: rawMs,
+				background: realms.background,
+				main: realms.main,
+			}),
+			realms,
+		};
+	} finally {
+		await page.close();
+	}
+}
+
+function round(value, digits = 2) {
+	return Number(value.toFixed(digits));
+}
+
+function markdown(report) {
+	const lines = [
+		'# Lynx 10k stage decomposition',
+		'',
+		`- measured: ${report.meta.date}`,
+		`- host: ${report.meta.cpus}× ${report.meta.cpuModel}; ${report.meta.platform} ${report.meta.release}; Node ${report.meta.node}; Chromium ${report.meta.chromium}`,
+		`- protocol: ${report.meta.protocol}`,
+		`- host load: start ${report.meta.loadStart.map((value) => value.toFixed(2)).join('/')} (1/5/15m), end ${report.meta.loadEnd.map((value) => value.toFixed(2)).join('/')}`,
+		`- repetitions: n=${report.meta.repetitions} per A/B cell`,
+		'',
+		'## FCP@10k',
+		'',
+		'Attribution starts when the shared browser hook assigns the hidden main-thread iframe Blob script URL, before load/parse/evaluation, and ends when the shared composed-tree observer first sees all 10,000 rows. `layout_flush_residual` is the exclusive remainder after directly observed slice evaluation, plan interpretation, and PAPI element creation; it includes PAPI prop/insertion work, `__FlushElementTree`, Web Core DOM publication, style/layout, and observer-frame delay because the host exposes no stable boundary between those costs.',
+		'',
+		'| segment | median ms | min–max ms | share |',
+		'|---|---:|---:|---:|',
+	];
+	for (const [name, stage] of Object.entries(report.fcp.attribution.stages)) {
+		lines.push(
+			`| ${name} | ${round(stage.median)} | ${round(stage.min)}–${round(stage.max)} | ${(stage.share * 100).toFixed(1)}% |`,
+		);
+	}
+	lines.push(
+		'',
+		`Raw view-attach FCP: profile ${round(report.fcp.rawProfile.median)} ms (${round(report.fcp.rawProfile.min)}–${round(report.fcp.rawProfile.max)}), control ${round(report.fcp.rawControl.median)} ms; same-window profile/control ${round(report.fcp.rawProfile.median / report.fcp.rawControl.median, 3)}×.`,
+		'',
+		'## create@10k',
+		'',
+		'Attribution starts at the shared pointerdown boundary and ends when the shared composed-tree observer sees 10,000 rows. `bg_replay`, `wire_clone_transfer`, `mt_expand`, and PAPI creation are directly observed exclusive intervals. `layout_flush_residual` is the wall-clock remainder, including event delivery before replay, validation/prepare, non-create PAPI work, flush/layout, scheduling, and observer-frame delay.',
+		'',
+		'| segment | median ms | min–max ms | share |',
+		'|---|---:|---:|---:|',
+	);
+	for (const [name, stage] of Object.entries(report.create.attribution.stages)) {
+		lines.push(
+			`| ${name} | ${round(stage.median)} | ${round(stage.min)}–${round(stage.max)} | ${(stage.share * 100).toFixed(1)}% |`,
+		);
+	}
+	lines.push(
+		'',
+		`Raw create: profile ${round(report.create.rawProfile.median)} ms (${round(report.create.rawProfile.min)}–${round(report.create.rawProfile.max)}), control ${round(report.create.rawControl.median)} ms, vue-vdom ${round(report.create.vueVdom.median)} ms; same-window profile/control ${round(report.create.rawProfile.median / report.create.rawControl.median, 3)}×, profile/vue-vdom ${round(report.create.rawProfile.median / report.create.vueVdom.median, 3)}×.`,
+		'',
+		'## Verdicts',
+		'',
+		...report.verdicts.map(
+			(verdict) => `- **${verdict.step}: ${verdict.verdict}.** ${verdict.reason}`,
+		),
+		'',
+	);
+	return lines.join('\n');
+}
+
+if (!args['skip-build']) buildVariants();
+for (const [name, file] of Object.entries(variants)) {
+	if (!fs.existsSync(file)) throw new Error(`${name} bundle is missing: ${file}`);
+}
+const server = await startServer();
+const { chromium } = require('playwright');
+const browser = await chromium.launch({
+	headless: true,
+	args: ['--disable-background-timer-throttling', '--disable-renderer-backgrounding'],
+});
+const browserVersion = browser.version();
+const loadStart = os.loadavg();
+const samples = {
+	fcp: { control: [], profile: [] },
+	create: { control: [], profile: [], vueVdom: [] },
+};
+try {
+	const schedule = args.smoke ? [['control', 'profile']] : interleavedABSchedule(repetitions);
+	for (const [first, second] of schedule) {
+		for (const variant of [first, second]) {
+			const profile = variant === 'profile';
+			const fcp = await runFcp(browser, variant, profile);
+			samples.fcp[variant].push(fcp);
+			const create = await runCreate(browser, variant, profile);
+			samples.create[variant].push(create);
+			console.log(
+				`[stage] ${variant} fcp=${fcp.rawMs.toFixed(1)} create=${create.rawMs.toFixed(1)}`,
+			);
+		}
+		const reference = await runCreate(browser, 'vue-vdom', false);
+		samples.create.vueVdom.push(reference);
+		console.log(`[stage] vue-vdom create=${reference.rawMs.toFixed(1)}`);
+	}
+} finally {
+	await browser.close();
+	server.close();
+}
+
+if (args.smoke) {
+	const output = path.join(import.meta.dirname, 'results');
+	fs.mkdirSync(output, { recursive: true });
+	fs.writeFileSync(
+		path.join(output, `smoke-${rows}.json`),
+		JSON.stringify(
+			{
+				meta: {
+					date: new Date().toISOString(),
+					node: process.version,
+					cpus: cpuCount,
+					cpuModel: os.cpus()[0]?.model ?? 'unknown',
+					chromium: browserVersion,
+					rows,
+					reportable: false,
+				},
+				samples,
+			},
+			null,
+			2,
+		) + '\n',
+	);
+	console.log(`[stage] smoke passed at ${rows} rows (not reportable).`);
+	process.exit(0);
+}
+
+const fcpAttribution = summarizeSamples(samples.fcp.profile.map((sample) => sample.attribution));
+const createAttribution = summarizeSamples(
+	samples.create.profile.map((sample) => sample.attribution),
+	{
+		control: samples.create.control.map((sample) => sample.rawMs),
+		reference: samples.create.vueVdom.map((sample) => sample.rawMs),
+	},
+);
+const directFcpShare =
+	fcpAttribution.stages.mt_slice_eval.share + fcpAttribution.stages.plan_interpretation.share;
+const expandShare = createAttribution.stages.mt_expand.share;
+const report = {
+	meta: {
+		date: new Date().toISOString(),
+		node: process.version,
+		cpus: cpuCount,
+		cpuModel: os.cpus()[0]?.model ?? 'unknown',
+		platform: os.platform(),
+		release: os.release(),
+		chromium: browserVersion,
+		repetitions,
+		rows,
+		reportable: !args.smoke,
+		loadStart,
+		loadEnd: os.loadavg(),
+		protocol:
+			'fresh page per sample; control/profile order alternates AB/BA; one vue-vdom create sample follows each pair; no other benchmark process ran in this window',
+	},
+	fcp: {
+		attribution: fcpAttribution,
+		rawControl: summarizeSamples(
+			samples.fcp.control.map((sample) => ({
+				totalMs: sample.rawMs,
+				stages: { raw: sample.rawMs },
+			})),
+		).total,
+		rawProfile: summarizeSamples(
+			samples.fcp.profile.map((sample) => ({
+				totalMs: sample.rawMs,
+				stages: { raw: sample.rawMs },
+			})),
+		).total,
+	},
+	create: {
+		attribution: createAttribution,
+		rawControl: summarizeSamples(
+			samples.create.control.map((sample) => ({
+				totalMs: sample.rawMs,
+				stages: { raw: sample.rawMs },
+			})),
+		).total,
+		rawProfile: summarizeSamples(
+			samples.create.profile.map((sample) => ({
+				totalMs: sample.rawMs,
+				stages: { raw: sample.rawMs },
+			})),
+		).total,
+		vueVdom: summarizeSamples(
+			samples.create.vueVdom.map((sample) => ({
+				totalMs: sample.rawMs,
+				stages: { raw: sample.rawMs },
+			})),
+		).total,
+	},
+	verdicts: [
+		{
+			step: 's2-2 (#18)',
+			verdict: fcpAttribution.stages.plan_interpretation.share >= 0.1 ? 'GO' : 'NO-GO',
+			reason: `plan interpretation is ${(fcpAttribution.stages.plan_interpretation.share * 100).toFixed(1)}% of attributed FCP and instantiate expansion is ${(expandShare * 100).toFixed(1)}% of create; neither clears the 10% direct-share gate.`,
+		},
+		{
+			step: 's2-3 (#19)',
+			verdict: 'NO-GO from this instrument',
+			reason:
+				'This issue measures mount/FCP, not slot-update routing; the roadmap already records point updates inside the target band, so no measured mount share justifies updater staging here.',
+		},
+		{
+			step: 's2-4 (#20)',
+			verdict: directFcpShare >= 0.1 ? 'GO' : 'NO-GO',
+			reason: `receiver slice evaluation plus plan interpretation is ${(directFcpShare * 100).toFixed(1)}% of attributed FCP and wire is ${(createAttribution.stages.wire_clone_transfer.share * 100).toFixed(1)}% of create; neither clears the 10% direct-share gate, and the create residual is deliberately not attributed to receiver code.`,
+		},
+	],
+	samples,
+};
+const output = path.join(import.meta.dirname, 'results');
+fs.mkdirSync(output, { recursive: true });
+fs.writeFileSync(path.join(output, 'sg1.json'), JSON.stringify(report, null, 2) + '\n');
+fs.writeFileSync(path.join(output, 'sg1.md'), markdown(report) + '\n');
+console.log(markdown(report));

--- a/benchmarks/lynx-table/stages/run.mjs
+++ b/benchmarks/lynx-table/stages/run.mjs
@@ -15,6 +15,7 @@ import {
 } from './analyze.mjs';
 import {
 	DRIVER_CLIENT_JS,
+	WIRE_INSTRUMENT_JS,
 	applyNeutralize,
 	applyStageClock,
 	makeBenchHtml,
@@ -55,7 +56,7 @@ const variants = {
 };
 const webCoreClientJs = require.resolve('@lynx-js/web-core/client.prod.js');
 const webCoreRoot = path.resolve(path.dirname(webCoreClientJs), '../..');
-const html = makeBenchHtml();
+const html = makeBenchHtml({ instrumentJs: WIRE_INSTRUMENT_JS });
 
 function buildVariants() {
 	const previousProfile = process.env.OCTANE_LYNX_PROFILE;
@@ -171,6 +172,30 @@ async function resetProfiles(page) {
 	]);
 }
 
+async function wireSnapshot(page) {
+	return page.evaluate(() => globalThis.__OCTANE_STAGE_WIRE__());
+}
+
+function wireDelta(before, after) {
+	const side = (a, b) => {
+		const names = new Set([...Object.keys(a.byName), ...Object.keys(b.byName)]);
+		const byName = {};
+		for (const name of names) {
+			const value = {
+				messages: (b.byName[name]?.messages ?? 0) - (a.byName[name]?.messages ?? 0),
+				bytes: (b.byName[name]?.bytes ?? 0) - (a.byName[name]?.bytes ?? 0),
+			};
+			if (value.messages !== 0 || value.bytes !== 0) byName[name] = value;
+		}
+		return {
+			messages: b.messages - a.messages,
+			bytes: b.bytes - a.bytes,
+			byName,
+		};
+	};
+	return { toBts: side(before.toBts, after.toBts), toMts: side(before.toMts, after.toMts) };
+}
+
 async function runFcp(browser, variant, profile) {
 	const page = await load(browser, `${variant}-fcp`);
 	try {
@@ -207,41 +232,60 @@ const createLabels = new Map([
 	[30000, 'Create 30,000 rows'],
 ]);
 
-async function clickCreate(page) {
-	const label = createLabels.get(rows);
-	if (label === undefined) throw new Error(`the shared app has no create button for ${rows} rows.`);
+const operations = {
+	create: {
+		label: createLabels.get(rows),
+		predicate: { type: 'rowCount', value: rows },
+	},
+	replace: {
+		label: 'Create 1,000 rows',
+		setup: 'Create 1,000 rows',
+	},
+	append: {
+		label: 'Append 1,000 rows',
+		setup: 'Create 1,000 rows',
+		predicate: { type: 'rowCount', value: 2000 },
+	},
+};
+if (operations.create.label === undefined) {
+	throw new Error(`the shared app has no create button for ${rows} rows.`);
+}
+
+async function clickAndWait(page, label, predicate) {
 	await page.waitForFunction(() => globalThis.__x.findText('Benchmark on Lynx'), undefined, {
 		timeout: 60000,
 	});
 	await page.evaluate(() => globalThis.__x.settle());
-	const armed = page.evaluate(
-		(count) => globalThis.__x.arm({ type: 'rowCount', value: count }, 120000),
-		rows,
-	);
+	const armed = page.evaluate((spec) => globalThis.__x.arm(spec, 120000), predicate);
 	const rectangle = await page.evaluate((text) => globalThis.__x.buttonRect(text), label);
-	if (rectangle === null) throw new Error('create button not found.');
+	if (rectangle === null) throw new Error(`${label} button not found.`);
 	await page.mouse.click(rectangle.x, rectangle.y);
 	return (await armed).ms;
 }
 
-async function runCreate(browser, variant, profile) {
+async function runOperation(browser, variant, profile, operationName) {
 	const page = await load(browser, variant);
 	try {
-		if (profile) {
-			await page.waitForFunction(() => globalThis.__x.findText('Benchmark on Lynx'), undefined, {
-				timeout: 60000,
-			});
+		const operation = operations[operationName];
+		if (operation.setup !== undefined) {
+			await clickAndWait(page, operation.setup, { type: 'rowCount', value: 1000 });
 			await page.evaluate(() => globalThis.__x.settle());
-			await resetProfiles(page);
 		}
-		const rawMs = await clickCreate(page);
-		if (!profile) return { rawMs };
+		const oracle = await page.evaluate(() => globalThis.__x.tableOracle());
+		const predicate = operation.predicate ?? { type: 'checksumNot', value: oracle.checksum };
+		if (profile) await resetProfiles(page);
+		const beforeWire = await wireSnapshot(page);
+		const rawMs = await clickAndWait(page, operation.label, predicate);
+		const afterWire = await wireSnapshot(page);
+		const wire = wireDelta(beforeWire, afterWire);
+		if (!profile) return { rawMs, wire };
 		const realms = await realmSnapshots(page);
 		if (realms.background === null || realms.main === null) {
-			throw new Error('profile create did not expose both Lynx realm snapshots.');
+			throw new Error(`profile ${operationName} did not expose both Lynx realm snapshots.`);
 		}
 		return {
 			rawMs,
+			wire,
 			attribution: analyzeCreateSample({
 				wallMs: rawMs,
 				background: realms.background,
@@ -260,7 +304,7 @@ function round(value, digits = 2) {
 
 function markdown(report) {
 	const lines = [
-		'# Lynx 10k stage decomposition',
+		`# Lynx ${report.meta.rows.toLocaleString('en-US')}-row stage decomposition`,
 		'',
 		`- measured: ${report.meta.date}`,
 		`- host: ${report.meta.cpus}× ${report.meta.cpuModel}; ${report.meta.platform} ${report.meta.release}; Node ${report.meta.node}; Chromium ${report.meta.chromium}`,
@@ -268,9 +312,9 @@ function markdown(report) {
 		`- host load: start ${report.meta.loadStart.map((value) => value.toFixed(2)).join('/')} (1/5/15m), end ${report.meta.loadEnd.map((value) => value.toFixed(2)).join('/')}`,
 		`- repetitions: n=${report.meta.repetitions} per A/B cell`,
 		'',
-		'## FCP@10k',
+		`## FCP@${report.meta.rows}`,
 		'',
-		'Attribution starts when the shared browser hook assigns the hidden main-thread iframe Blob script URL, before load/parse/evaluation, and ends when the shared composed-tree observer first sees all 10,000 rows. `layout_flush_residual` is the exclusive remainder after directly observed slice evaluation, plan interpretation, and PAPI element creation; it includes PAPI prop/insertion work, `__FlushElementTree`, Web Core DOM publication, style/layout, and observer-frame delay because the host exposes no stable boundary between those costs.',
+		`Attribution starts when the shared browser hook assigns the hidden main-thread iframe Blob script URL, before load/parse/evaluation, and ends when the shared composed-tree observer first sees all ${report.meta.rows.toLocaleString('en-US')} rows. \`layout_flush_residual\` is the exclusive remainder after directly observed slice evaluation, plan interpretation, and PAPI element creation; it includes PAPI prop/insertion work, \`__FlushElementTree\`, Web Core DOM publication, style/layout, and observer-frame delay because the host exposes no stable boundary between those costs.`,
 		'',
 		'| segment | median ms | min–max ms | share |',
 		'|---|---:|---:|---:|',
@@ -284,9 +328,9 @@ function markdown(report) {
 		'',
 		`Raw view-attach FCP: profile ${round(report.fcp.rawProfile.median)} ms (${round(report.fcp.rawProfile.min)}–${round(report.fcp.rawProfile.max)}), control ${round(report.fcp.rawControl.median)} ms; same-window profile/control ${round(report.fcp.rawProfile.median / report.fcp.rawControl.median, 3)}×.`,
 		'',
-		'## create@10k',
+		`## create@${report.meta.rows}`,
 		'',
-		'Attribution starts at the shared pointerdown boundary and ends when the shared composed-tree observer sees 10,000 rows. `bg_replay`, `wire_clone_transfer`, `mt_expand`, and PAPI creation are directly observed exclusive intervals. `layout_flush_residual` is the wall-clock remainder, including event delivery before replay, validation/prepare, non-create PAPI work, flush/layout, scheduling, and observer-frame delay.',
+		`Attribution starts at the shared pointerdown boundary and ends when the shared composed-tree observer sees ${report.meta.rows.toLocaleString('en-US')} rows. All named intervals are directly observed and exclusive; \`presentation_residual\` is the wall-clock remainder through final composed-tree presentation.`,
 		'',
 		'| segment | median ms | min–max ms | share |',
 		'|---|---:|---:|---:|',
@@ -299,6 +343,20 @@ function markdown(report) {
 	lines.push(
 		'',
 		`Raw create: profile ${round(report.create.rawProfile.median)} ms (${round(report.create.rawProfile.min)}–${round(report.create.rawProfile.max)}), control ${round(report.create.rawControl.median)} ms, vue-vdom ${round(report.create.vueVdom.median)} ms; same-window profile/control ${round(report.create.rawProfile.median / report.create.rawControl.median, 3)}×, profile/vue-vdom ${round(report.create.rawProfile.median / report.create.vueVdom.median, 3)}×.`,
+		`Wire: MTS→BTS ${Math.round(report.create.wire.toBts.bytes.median).toLocaleString('en-US')} B / ${round(report.create.wire.toBts.messages.median)} messages; BTS→MTS ${Math.round(report.create.wire.toMts.bytes.median).toLocaleString('en-US')} B / ${round(report.create.wire.toMts.messages.median)} messages.`,
+	);
+	for (const operation of ['replace', 'append']) {
+		const cell = report[operation];
+		lines.push('', `## ${operation}@1k`, '', '| segment | median ms | share |', '|---|---:|---:|');
+		for (const [name, stage] of Object.entries(cell.attribution.stages)) {
+			lines.push(`| ${name} | ${round(stage.median)} | ${(stage.share * 100).toFixed(1)}% |`);
+		}
+		lines.push(
+			'',
+			`Raw ${operation}: profile ${round(cell.rawProfile.median)} ms, control ${round(cell.rawControl.median)} ms, vue-vdom ${round(cell.vueVdom.median)} ms. Wire: MTS→BTS ${Math.round(cell.wire.toBts.bytes.median).toLocaleString('en-US')} B / ${round(cell.wire.toBts.messages.median)} messages; BTS→MTS ${Math.round(cell.wire.toMts.bytes.median).toLocaleString('en-US')} B / ${round(cell.wire.toMts.messages.median)} messages.`,
+		);
+	}
+	lines.push(
 		'',
 		'## Verdicts',
 		'',
@@ -325,6 +383,8 @@ const loadStart = os.loadavg();
 const samples = {
 	fcp: { control: [], profile: [] },
 	create: { control: [], profile: [], vueVdom: [] },
+	replace: { control: [], profile: [], vueVdom: [] },
+	append: { control: [], profile: [], vueVdom: [] },
 };
 try {
 	const schedule = args.smoke ? [['control', 'profile']] : interleavedABSchedule(repetitions);
@@ -333,15 +393,23 @@ try {
 			const profile = variant === 'profile';
 			const fcp = await runFcp(browser, variant, profile);
 			samples.fcp[variant].push(fcp);
-			const create = await runCreate(browser, variant, profile);
-			samples.create[variant].push(create);
+			const measured = {};
+			for (const operation of Object.keys(operations)) {
+				measured[operation] = await runOperation(browser, variant, profile, operation);
+				samples[operation][variant].push(measured[operation]);
+			}
 			console.log(
-				`[stage] ${variant} fcp=${fcp.rawMs.toFixed(1)} create=${create.rawMs.toFixed(1)}`,
+				`[stage] ${variant} fcp=${fcp.rawMs.toFixed(1)} create=${measured.create.rawMs.toFixed(1)} replace=${measured.replace.rawMs.toFixed(1)} append=${measured.append.rawMs.toFixed(1)}`,
 			);
 		}
-		const reference = await runCreate(browser, 'vue-vdom', false);
-		samples.create.vueVdom.push(reference);
-		console.log(`[stage] vue-vdom create=${reference.rawMs.toFixed(1)}`);
+		const reference = {};
+		for (const operation of Object.keys(operations)) {
+			reference[operation] = await runOperation(browser, 'vue-vdom', false, operation);
+			samples[operation].vueVdom.push(reference[operation]);
+		}
+		console.log(
+			`[stage] vue-vdom create=${reference.create.rawMs.toFixed(1)} replace=${reference.replace.rawMs.toFixed(1)} append=${reference.append.rawMs.toFixed(1)}`,
+		);
 	}
 } finally {
 	await browser.close();
@@ -382,9 +450,56 @@ const createAttribution = summarizeSamples(
 		reference: samples.create.vueVdom.map((sample) => sample.rawMs),
 	},
 );
-const directFcpShare =
-	fcpAttribution.stages.mt_slice_eval.share + fcpAttribution.stages.plan_interpretation.share;
-const expandShare = createAttribution.stages.mt_expand.share;
+function summarizeRaw(cell) {
+	return summarizeSamples(
+		cell.map((sample) => ({ totalMs: sample.rawMs, stages: { raw: sample.rawMs } })),
+	).total;
+}
+function summarizeWire(cell, side, field) {
+	return summarizeSamples(
+		cell.map((sample) => {
+			const value = sample.wire[side][field];
+			return { totalMs: value, stages: { raw: value } };
+		}),
+	).total;
+}
+function mutationReport(operation) {
+	const cell = samples[operation];
+	return {
+		attribution: summarizeSamples(
+			cell.profile.map((sample) => sample.attribution),
+			{
+				control: cell.control.map((sample) => sample.rawMs),
+				reference: cell.vueVdom.map((sample) => sample.rawMs),
+			},
+		),
+		rawControl: summarizeRaw(cell.control),
+		rawProfile: summarizeRaw(cell.profile),
+		vueVdom: summarizeRaw(cell.vueVdom),
+		wire: {
+			toBts: {
+				bytes: summarizeWire(cell.profile, 'toBts', 'bytes'),
+				messages: summarizeWire(cell.profile, 'toBts', 'messages'),
+			},
+			toMts: {
+				bytes: summarizeWire(cell.profile, 'toMts', 'bytes'),
+				messages: summarizeWire(cell.profile, 'toMts', 'messages'),
+			},
+		},
+	};
+}
+const replaceReport = mutationReport('replace');
+const appendReport = mutationReport('append');
+const createWire = {
+	toBts: {
+		bytes: summarizeWire(samples.create.profile, 'toBts', 'bytes'),
+		messages: summarizeWire(samples.create.profile, 'toBts', 'messages'),
+	},
+	toMts: {
+		bytes: summarizeWire(samples.create.profile, 'toMts', 'bytes'),
+		messages: summarizeWire(samples.create.profile, 'toMts', 'messages'),
+	},
+};
 const report = {
 	meta: {
 		date: new Date().toISOString(),
@@ -400,7 +515,7 @@ const report = {
 		loadStart,
 		loadEnd: os.loadavg(),
 		protocol:
-			'fresh page per sample; control/profile order alternates AB/BA; one vue-vdom create sample follows each pair; no other benchmark process ran in this window',
+			'fresh page per operation sample; control/profile order alternates AB/BA; one vue-vdom create/replace/append triplet follows each pair; no other benchmark process ran in this window',
 	},
 	fcp: {
 		attribution: fcpAttribution,
@@ -419,6 +534,7 @@ const report = {
 	},
 	create: {
 		attribution: createAttribution,
+		wire: createWire,
 		rawControl: summarizeSamples(
 			samples.create.control.map((sample) => ({
 				totalMs: sample.rawMs,
@@ -438,28 +554,29 @@ const report = {
 			})),
 		).total,
 	},
+	replace: replaceReport,
+	append: appendReport,
 	verdicts: [
 		{
-			step: 's2-2 (#18)',
-			verdict: fcpAttribution.stages.plan_interpretation.share >= 0.1 ? 'GO' : 'NO-GO',
-			reason: `plan interpretation is ${(fcpAttribution.stages.plan_interpretation.share * 100).toFixed(1)}% of attributed FCP and instantiate expansion is ${(expandShare * 100).toFixed(1)}% of create; neither clears the 10% direct-share gate.`,
+			step: '#47 wire/encoding candidate',
+			verdict: 'NO-GO',
+			reason: `clone/transfer is ${(createAttribution.stages.wire_clone_transfer.share * 100).toFixed(1)}% of create, ${(replaceReport.attribution.stages.wire_clone_transfer.share * 100).toFixed(1)}% of replace, and ${(appendReport.attribution.stages.wire_clone_transfer.share * 100).toFixed(1)}% of append; it does not clear the 10% owner gate.`,
 		},
 		{
-			step: 's2-3 (#19)',
-			verdict: 'NO-GO from this instrument',
-			reason:
-				'This issue measures mount/FCP, not slot-update routing; the roadmap already records point updates inside the target band, so no measured mount share justifies updater staging here.',
+			step: '#47 measured CPU owner',
+			verdict: 'SPLIT',
+			reason: `PAPI creation plus remaining host apply is ${((createAttribution.stages.papi_element_creation.share + createAttribution.stages.mt_apply_other.share) * 100).toFixed(1)}% of create. This is a host materialization owner, not evidence for changing the wire representation.`,
 		},
 		{
-			step: 's2-4 (#20)',
-			verdict: directFcpShare >= 0.1 ? 'GO' : 'NO-GO',
-			reason: `receiver slice evaluation plus plan interpretation is ${(directFcpShare * 100).toFixed(1)}% of attributed FCP and wire is ${(createAttribution.stages.wire_clone_transfer.share * 100).toFixed(1)}% of create; neither clears the 10% direct-share gate, and the create residual is deliberately not attributed to receiver code.`,
+			step: '#47 acknowledgement-only candidate',
+			verdict: 'NO-GO for issue acceptance',
+			reason: `ACK/publication is ${(createAttribution.stages.mt_ack_publication.share * 100).toFixed(1)}% of create, ${(replaceReport.attribution.stages.mt_ack_publication.share * 100).toFixed(1)}% of replace, and ${(appendReport.attribution.stages.mt_ack_publication.share * 100).toFixed(1)}% of append; even a complete removal cannot meet the required 15% in all three cells or the 50% total-wire gate.`,
 		},
 	],
 	samples,
 };
 const output = path.join(import.meta.dirname, 'results');
 fs.mkdirSync(output, { recursive: true });
-fs.writeFileSync(path.join(output, 'sg1.json'), JSON.stringify(report, null, 2) + '\n');
-fs.writeFileSync(path.join(output, 'sg1.md'), markdown(report) + '\n');
+fs.writeFileSync(path.join(output, `live-${rows}.json`), JSON.stringify(report, null, 2) + '\n');
+fs.writeFileSync(path.join(output, `live-${rows}.md`), markdown(report) + '\n');
 console.log(markdown(report));

--- a/benchmarks/lynx-table/web/driver-client.mjs
+++ b/benchmarks/lynx-table/web/driver-client.mjs
@@ -95,6 +95,26 @@ export const DRIVER_CLIENT_JS = `(() => {
     return r ? hasClass(r, 'danger') : false;
   };
 
+  // -- semantic checksum ----------------------------------------------------
+  const hashText = (seed, text) => {
+    let hash = seed >>> 0;
+    for (let i = 0; i < text.length; i++) {
+      hash ^= text.charCodeAt(i);
+      hash = Math.imul(hash, 16777619) >>> 0;
+    }
+    return hash;
+  };
+  x.tableOracle = () => {
+    const current = rowEls();
+    let checksum = 2166136261;
+    for (const row of current) {
+      const id = cellOf(row, 'col-id')?.textContent ?? '';
+      const label = cellOf(row, 'col-label')?.textContent ?? '';
+      checksum = hashText(checksum, id + '\\u0000' + label + '\\u0000' + classOf(row));
+    }
+    return { rows: current.length, checksum };
+  };
+
   // -- click geometry --------------------------------------------------------
   x.buttonRect = (label) => {
     for (const el of findByClass('btn-text')) {
@@ -119,6 +139,7 @@ export const DRIVER_CLIENT_JS = `(() => {
       case 'rowCount': return x.rowCount() === spec.value;
       case 'labelAt': return x.labelAt(spec.index) === spec.equals;
       case 'dangerAt': return x.dangerAt(spec.index);
+      case 'checksumNot': return x.tableOracle().checksum !== spec.value;
       case 'contentAtLeast': return x.contentCount() >= spec.value;
       default: throw new Error('unknown predicate ' + spec.type);
     }

--- a/benchmarks/lynx-table/web/driver-client.mjs
+++ b/benchmarks/lynx-table/web/driver-client.mjs
@@ -196,15 +196,73 @@ export const DRIVER_CLIENT_JS = `(() => {
   };
 })()`;
 
+// Page-side MessagePort accounting. It observes the same Web Core RPC boundary
+// as the shared cross-framework runner and records only JSON-equivalent bytes;
+// no payload is cloned, retained, or rewritten by the probe.
+export const WIRE_INSTRUMENT_JS = `(() => {
+  const stats = {
+    // Web Core direction names: page/main-thread-script -> background thread,
+    // then background thread -> page/main-thread-script.
+    toBts: { messages: 0, bytes: 0, byName: {} },
+    toMts: { messages: 0, bytes: 0, byName: {} },
+  };
+  const encoder = new TextEncoder();
+  const sizeOf = (data) => {
+    try {
+      const json = JSON.stringify(data, (_key, value) => {
+        if (value instanceof ArrayBuffer) return { $arrayBuffer: value.byteLength };
+        if (ArrayBuffer.isView(value)) return { $arrayBufferView: value.byteLength };
+        if (typeof value === 'function') return '$function';
+        return value;
+      });
+      return json ? encoder.encode(json).length : 0;
+    } catch {
+      return -1;
+    }
+  };
+  const record = (side, data) => {
+    const bytes = sizeOf(data);
+    const name = data && typeof data === 'object' && 'name' in data ? String(data.name) : '$raw';
+    side.messages++;
+    if (bytes > 0) side.bytes += bytes;
+    const endpoint = side.byName[name] ?? (side.byName[name] = { messages: 0, bytes: 0 });
+    endpoint.messages++;
+    if (bytes > 0) endpoint.bytes += bytes;
+  };
+  globalThis.__OCTANE_STAGE_WIRE__ = () => structuredClone(stats);
+  const postMessage = MessagePort.prototype.postMessage;
+  MessagePort.prototype.postMessage = function (data, ...rest) {
+    record(stats.toBts, data);
+    return postMessage.call(this, data, ...rest);
+  };
+  const descriptor = Object.getOwnPropertyDescriptor(MessagePort.prototype, 'onmessage');
+  if (descriptor?.get && descriptor.set) {
+    Object.defineProperty(MessagePort.prototype, 'onmessage', {
+      configurable: descriptor.configurable,
+      enumerable: descriptor.enumerable,
+      get() { return descriptor.get.call(this); },
+      set(listener) {
+        if (typeof listener !== 'function') return descriptor.set.call(this, listener);
+        return descriptor.set.call(this, function (event) {
+          record(stats.toMts, event.data);
+          return listener.call(this, event);
+        });
+      },
+    });
+  }
+})()`;
+
 /** Build the bench host HTML that loads web-core and installs the driver. */
 export function makeBenchHtml({
 	clientJs = '/webcore/static/js/client.js',
 	clientCss = '/webcore/static/css/client.css',
+	instrumentJs = '',
 } = {}) {
 	return `<!doctype html>
 <html>
 <head>
   <meta charset="utf-8">
+  <script>${instrumentJs}</script>
   <script type="module" src="${clientJs}"></script>
   <link rel="stylesheet" href="${clientCss}">
   <style>html,body{margin:0;padding:0}</style>

--- a/benchmarks/lynx-table/web/driver-client.mjs
+++ b/benchmarks/lynx-table/web/driver-client.mjs
@@ -170,19 +170,23 @@ export const DRIVER_CLIENT_JS = `(() => {
       const t0 = x.viewAttachTime ?? performance.now();
       const deadline = performance.now() + timeoutMs;
       let fcp = null;
+      let fcpEpoch = null;
       let lastCount = -1;
       let lastChange = performance.now();
       const tick = () => {
         const now = performance.now();
         const c = x.contentCount();
-        if (fcp == null && c >= minContent) { fcp = now - t0; }
+        if (fcp == null && c >= minContent) {
+          fcp = now - t0;
+          fcpEpoch = performance.timeOrigin + now;
+        }
         if (c !== lastCount) { lastCount = c; lastChange = now; }
         if (fcp != null && now - lastChange >= idleMs) {
-          resolve({ fcp, settled: lastChange - t0, finalCount: c, dnf: false });
+          resolve({ fcp, fcpEpoch, settled: lastChange - t0, finalCount: c, dnf: false });
           return;
         }
         if (now > deadline) {
-          resolve({ fcp, settled: null, finalCount: c, dnf: true });
+          resolve({ fcp, fcpEpoch, settled: null, finalCount: c, dnf: true });
           return;
         }
         requestAnimationFrame(tick);
@@ -245,6 +249,32 @@ export const NEUTRALIZE_LYNX_PROFILE = `(() => {
 export async function applyNeutralize(page) {
 	await page.addInitScript(NEUTRALIZE_LYNX_PROFILE);
 	page.on('worker', (w) => w.evaluate(NEUTRALIZE_LYNX_PROFILE).catch(() => {}));
+}
+
+export const OBSERVE_LYNX_MT_SLICE_LOAD = `(() => {
+  const descriptor = Object.getOwnPropertyDescriptor(HTMLScriptElement.prototype, 'src');
+  if (!descriptor?.get || !descriptor?.set) return;
+  Object.defineProperty(HTMLScriptElement.prototype, 'src', {
+    configurable: descriptor.configurable,
+    enumerable: descriptor.enumerable,
+    get: descriptor.get,
+    set(value) {
+      if (
+        globalThis.location?.href === 'about:srcdoc'
+        && typeof value === 'string'
+        && value.startsWith('blob:')
+        && globalThis.__OCTANE_LYNX_MT_SLICE_LOAD_START_EPOCH__ === undefined
+      ) {
+        globalThis.__OCTANE_LYNX_MT_SLICE_LOAD_START_EPOCH__ =
+          performance.timeOrigin + performance.now();
+      }
+      return descriptor.set.call(this, value);
+    },
+  });
+})()`;
+
+export async function applyStageClock(page) {
+	await page.addInitScript(OBSERVE_LYNX_MT_SLICE_LOAD);
 }
 
 /** min/max/mean/median/std/ci95 over a numeric array (nulls/NaN dropped). */

--- a/benchmarks/lynx-table/web/run-web.mjs
+++ b/benchmarks/lynx-table/web/run-web.mjs
@@ -163,6 +163,12 @@ class Driver {
 
 async function loadCell(browser, cell) {
 	const page = await browser.newPage();
+	if (process.env.LYNX_BENCH_DEBUG) {
+		page.on('console', (message) =>
+			console.log(`[console:${message.type()}]`, message.text().slice(0, 400)),
+		);
+		page.on('pageerror', (error) => console.log('[pageerror]', String(error).slice(0, 600)));
+	}
 	await applyNeutralize(page);
 	await page.goto(`http://127.0.0.1:${PORT}/bench.html`, { waitUntil: 'load' });
 	await page.evaluate(
@@ -173,6 +179,7 @@ async function loadCell(browser, cell) {
 		timeout: 60_000,
 		polling: 16,
 	});
+	if (process.env.LYNX_BENCH_DEBUG) console.log('[debug] mounted', cell.id, Date.now());
 	return page;
 }
 
@@ -256,6 +263,7 @@ async function main() {
 						const sample = await runRep(browser, cell, rows);
 						for (const [op, ms] of Object.entries(sample)) (samples[op] ??= []).push(ms);
 					} catch (error) {
+						if (process.env.LYNX_BENCH_DEBUG) console.log('[debug] rep error:', String(error));
 						if (!String(error).includes('timeout')) throw error;
 						dnf.rep = (dnf.rep ?? 0) + 1;
 					}


### PR DESCRIPTION
## Summary

- add reproducible AB/BA create/replace/append attribution at 1k, 10k, and 30k rows
- separate BTS replay, clone/transfer, MTS validation/expansion/preparation, PAPI creation, remaining host apply, ACK/publication, and presentation residual
- record endpoint/direction wire bytes plus command, template-run, instance, value, and public-handle counters
- check in n=5 live reports and unit tests for instrumentation and analysis

Tracks https://github.com/Huxpro/octane/issues/47.

## Decision: NO-GO for the packet/ACK hypothesis

This is deliberately a measurement-only PR. The issue's owner-first gate rejects the proposed product change:

| create scale | replay | clone | PAPI | host apply | ACK | residual |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 1k | 18.1% | 0.4% | 41.8% | 27.6% | 0.3% | 8.9% |
| 10k | 12.2% | 0.3% | 48.1% | 28.4% | 0.0% | 9.9% |
| 30k | 9.8% | 0.3% | 51.2% | 28.4% | 0.0% | 8.6% |

Clone/transfer is only 0.2–0.9%. ACK/publication is 0–0.3% for create and 11–16% for replace/append, so even deleting it entirely cannot satisfy all three ≥15% latency cells plus the 50% total-wire gate.

The measured owner is host materialization: PAPI creation plus remaining host apply accounts for 69.5–79.6% of create and scales linearly. At 10k, replace/append total wire is dominated by WebCore event/control traffic rather than the Octane commit. That owner is split into a follow-up issue instead of manufacturing a packet-format win.

## Artifacts

- `benchmarks/lynx-table/stages/results/live-1000.{json,md}`
- `benchmarks/lynx-table/stages/results/live-10000.{json,md}`
- `benchmarks/lynx-table/stages/results/live-30000.{json,md}`
- `benchmarks/lynx-table/stages/results/live-report.md`

## Validation

- stage attribution unit tests — 7 passed
- latest-main control/profile/vue-vdom smoke — passed for FCP, create, replace, append
- `pnpm format:files:check ...`
- `pnpm sync`

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Temporarily patches core Lynx transport/PAPI/main-thread sources during profile builds, so restore failures or anchor drift could affect local measurement builds. Production bundles remain uninstrumented and fold-tested.
> 
> **Overview**
> Adds a **measurement-only** stage-decomposition instrument for the Lynx table bench so FCP/create/replace/append ownership can be attributed with exclusive observed intervals plus named residuals.
> 
> Profile builds now temporarily patch Lynx sources (via `instrumentLynxStageSources`) to record finer timers—`bgReplayMs`, `papiCreateMs`, `mtExpandMs`, first-screen plan/slice eval—then restore the originals. The analyzer enforces exclusive stage sums, AB/BA interleaving with `n >= 5`, and a 10% direct-share gate for GO verdicts.
> 
> Checked-in live reports at 1k (and related scales) conclude **NO-GO** for wire/encoding and ACK-only changes: clone/transfer stays under 1%, while **PAPI creation plus remaining host apply** owns ~70%+ of create.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68bc6f9fc3d73927878309615de4267610417bcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
