### PR TITLE
bench(lynx): inventory production bundle owners

### DIFF
--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -417,7 +417,10 @@ const SUITES = [
 		cwd: 'react-hosted-islands',
 		servers: [],
 		iter: { normal: 1, quick: 1 },
-		runs: [{ script: 'run.mjs', args: () => [] }],
+		runs: [
+			{ script: 'run.mjs', args: () => [] },
+			{ script: 'inventory.mjs', args: () => [] },
+		],
 	},
 	{
 		// Node-only (no servers, no browser). Time-budgeted: the iteration knob is a

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -417,10 +417,7 @@ const SUITES = [
 		cwd: 'react-hosted-islands',
 		servers: [],
 		iter: { normal: 1, quick: 1 },
-		runs: [
-			{ script: 'run.mjs', args: () => [] },
-			{ script: 'inventory.mjs', args: () => [] },
-		],
+		runs: [{ script: 'run.mjs', args: () => [] }],
 	},
 	{
 		// Node-only (no servers, no browser). Time-budgeted: the iteration knob is a
@@ -646,7 +643,10 @@ const SUITES = [
 		cwd: 'lynx-bundle-size',
 		servers: [],
 		iter: { normal: 1, quick: 1 },
-		runs: [{ script: 'run.mjs', args: () => [] }],
+		runs: [
+			{ script: 'run.mjs', args: () => [] },
+			{ script: 'inventory.mjs', args: () => [] },
+		],
 	},
 	{
 		// Compiled-output size (Node-only, seconds-fast): compiles a fixed

--- a/benchmarks/lynx-bundle-size/README.md
+++ b/benchmarks/lynx-bundle-size/README.md
@@ -30,3 +30,21 @@ node benchmarks/bench.mjs --ratios lynx-bundle-size
 This is source/build evidence only. Decoding a production artifact does not
 execute a Lynx engine and makes no native startup, first-paint, adoption,
 latency, memory, or device-lifecycle claim.
+
+## Complete rows-0 inventory
+
+`inventory.mjs` additionally builds the exact rows-0 table fixture used by the
+cross-framework runtime benchmark in both Web and Lynx production modes. It
+records hashes and raw/gzip/Brotli totals, captures the encoded Lynx artifact's
+pre-encode main/background programs, and attributes 100% of final raw bytes by
+the production reachable-module owner weights. That proportional raw
+attribution is for prioritization; only an isolated production build delta may
+be described as gzip ownership.
+
+`inventory-budgets.json` freezes total, thread-section, and owner-slice raw
+budgets plus total gzip budgets on the integrated #706/#707 stack. The ledger
+keeps #706's accepted size tax and #707's controlled optional-worklet saving
+separate because compressed deltas are not additive.
+
+The checked execution report is
+[`results/production-inventory.md`](results/production-inventory.md).

--- a/benchmarks/lynx-bundle-size/inventory-budgets.json
+++ b/benchmarks/lynx-bundle-size/inventory-budgets.json
@@ -1,0 +1,59 @@
+{
+  "artifacts": {
+    "web": { "raw": 484572, "gzip": 132135 },
+    "lynx": { "raw": 473851, "gzip": 158882 }
+  },
+  "sections": {
+    "main": { "raw": 203712, "gzip": 57560 },
+    "background": { "raw": 276738, "gzip": 74170 }
+  },
+  "owners": {
+    "web": {
+      "compiler-output-app": 139617,
+      "build-wrapper-main": 90909,
+      "universal-runtime": 77629,
+      "host-driver-papi": 37654,
+      "protocol-transport": 34477,
+      "lynx-runtime-other": 32834,
+      "first-screen-adoption": 30818,
+      "public-state-worklets": 28232,
+      "fixture-app": 11437,
+      "generated-wrapper": 256,
+      "octane-runtime-other": 515,
+      "third-party-runtime": 194
+    },
+    "lynx": {
+      "compiler-output-app": 136528,
+      "build-wrapper-main": 88897,
+      "universal-runtime": 75912,
+      "host-driver-papi": 36821,
+      "protocol-transport": 33715,
+      "lynx-runtime-other": 32107,
+      "first-screen-adoption": 30136,
+      "public-state-worklets": 27608,
+      "fixture-app": 11184,
+      "generated-wrapper": 251,
+      "octane-runtime-other": 503,
+      "third-party-runtime": 189
+    }
+  },
+  "controlledLedger": [
+    {
+      "owner": "#706 compact teardown constants",
+      "status": "pending upstream",
+      "controlledGzipDelta": { "web": "+1.38%", "lynx": "+1.45%" },
+      "decision": "accepted performance-earned size tax"
+    },
+    {
+      "owner": "#707 optional worklet installer",
+      "status": "pending upstream",
+      "controlledGzipDelta": {
+        "previewMain": "76915 -> 75024 (-2.46%)",
+        "ifrMain": "81995 -> 79980 (-2.46%)",
+        "previewComplete": "150079 -> 148183",
+        "ifrComplete": "155075 -> 152968"
+      },
+      "decision": "accepted child; deltas are not additive with rows-0 artifacts"
+    }
+  ]
+}

--- a/benchmarks/lynx-bundle-size/inventory-budgets.json
+++ b/benchmarks/lynx-bundle-size/inventory-budgets.json
@@ -1,38 +1,38 @@
 {
   "artifacts": {
-    "web": { "raw": 484572, "gzip": 132135 },
-    "lynx": { "raw": 473851, "gzip": 158882 }
+    "web": { "raw": 485345, "gzip": 132334 },
+    "lynx": { "raw": 474618, "gzip": 159077 }
   },
   "sections": {
-    "main": { "raw": 203712, "gzip": 57560 },
-    "background": { "raw": 276738, "gzip": 74170 }
+    "main": { "raw": 203712, "gzip": 57563 },
+    "background": { "raw": 277505, "gzip": 74381 }
   },
   "owners": {
     "web": {
-      "compiler-output-app": 139617,
-      "build-wrapper-main": 90909,
-      "universal-runtime": 77629,
-      "host-driver-papi": 37654,
-      "protocol-transport": 34477,
-      "lynx-runtime-other": 32834,
-      "first-screen-adoption": 30818,
-      "public-state-worklets": 28232,
-      "fixture-app": 11437,
+      "compiler-output-app": 140155,
+      "build-wrapper-main": 90775,
+      "universal-runtime": 78258,
+      "host-driver-papi": 37599,
+      "protocol-transport": 34427,
+      "lynx-runtime-other": 32786,
+      "first-screen-adoption": 30773,
+      "public-state-worklets": 28191,
+      "fixture-app": 11420,
       "generated-wrapper": 256,
       "octane-runtime-other": 515,
-      "third-party-runtime": 194
+      "third-party-runtime": 191
     },
     "lynx": {
-      "compiler-output-app": 136528,
-      "build-wrapper-main": 88897,
-      "universal-runtime": 75912,
-      "host-driver-papi": 36821,
-      "protocol-transport": 33715,
-      "lynx-runtime-other": 32107,
-      "first-screen-adoption": 30136,
-      "public-state-worklets": 27608,
-      "fixture-app": 11184,
-      "generated-wrapper": 251,
+      "compiler-output-app": 137057,
+      "build-wrapper-main": 88768,
+      "universal-runtime": 76528,
+      "host-driver-papi": 36768,
+      "protocol-transport": 33666,
+      "lynx-runtime-other": 32061,
+      "first-screen-adoption": 30093,
+      "public-state-worklets": 27568,
+      "fixture-app": 11167,
+      "generated-wrapper": 250,
       "octane-runtime-other": 503,
       "third-party-runtime": 189
     }

--- a/benchmarks/lynx-bundle-size/inventory.mjs
+++ b/benchmarks/lynx-bundle-size/inventory.mjs
@@ -287,7 +287,9 @@ try {
 		},
 		controlledLedger: BUDGETS.controlledLedger,
 	};
+	const calibrate = process.env.OCTANE_INVENTORY_CALIBRATE === '1';
 	for (const target of ['web', 'lynx']) {
+		if (calibrate) continue;
 		gateBudget(`${target} raw`, payload.artifacts[target].raw, BUDGETS.artifacts[target].raw);
 		gateBudget(`${target} gzip`, payload.artifacts[target].gzip, BUDGETS.artifacts[target].gzip);
 		if (payload.artifacts[target].inventory.coverage < 0.9) {
@@ -298,7 +300,7 @@ try {
 			gateBudget(`${target}/${owner} raw`, actual, budget);
 		}
 	}
-	for (const section of ['main', 'background']) {
+	for (const section of calibrate ? [] : ['main', 'background']) {
 		for (const metric of ['raw', 'gzip']) {
 			gateBudget(
 				`lynx ${section} ${metric}`,

--- a/benchmarks/lynx-bundle-size/inventory.mjs
+++ b/benchmarks/lynx-bundle-size/inventory.mjs
@@ -1,0 +1,353 @@
+// Production rows-0 inventory for the exact Lynx table fixture used by the
+// cross-framework runtime benchmark. Rspack's reachable-module sizes are
+// attributed by owner, while final Web/Lynx artifacts and decoded Lynx thread
+// sections are measured byte-for-byte. Module shares are deliberately reported
+// as proportional attribution, not as additive gzip ownership.
+process.env.NODE_ENV = 'production';
+
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { brotliCompressSync, constants as zc, gzipSync } from 'node:zlib';
+
+import { pluginOctane } from '../../packages/rspeedy-plugin-octane/src/index.js';
+
+const ROOT = import.meta.dirname;
+const REPO = path.resolve(ROOT, '../..');
+const ENTRY = path.join(REPO, 'benchmarks/lynx-table/app/src/index.ts');
+const CWD = path.join(REPO, 'packages/rspeedy-plugin-octane/tests/_fixtures/application');
+const MODULES = path.join(REPO, 'packages/rspeedy-plugin-octane/node_modules');
+const BUDGETS = JSON.parse(fs.readFileSync(path.join(ROOT, 'inventory-budgets.json'), 'utf8'));
+const captures = new Map();
+
+function packageEntry(packageName) {
+	const packageRoot = path.join(MODULES, ...packageName.split('/'));
+	const manifest = JSON.parse(fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8'));
+	const exported = manifest.exports?.['.'];
+	const entry =
+		typeof exported === 'string'
+			? exported
+			: typeof exported?.import === 'string'
+				? exported.import
+				: manifest.module || manifest.main;
+	if (typeof entry !== 'string') throw new Error(`${packageName} has no importable entry.`);
+	return pathToFileURL(path.join(packageRoot, entry)).href;
+}
+
+const [{ createRspeedy }, tasm] = await Promise.all([
+	import(packageEntry('@lynx-js/rspeedy')),
+	import(packageEntry('@lynx-js/tasm')),
+]);
+
+const gzipBytes = (value) => gzipSync(value, { level: zc.Z_BEST_COMPRESSION }).length;
+const brotliBytes = (value) =>
+	brotliCompressSync(value, {
+		params: { [zc.BROTLI_PARAM_QUALITY]: zc.BROTLI_MAX_QUALITY },
+	}).length;
+const sha256 = (value) => createHash('sha256').update(value).digest('hex');
+
+function nativeScriptBytes(script) {
+	if (typeof script === 'string') return Buffer.from(script);
+	if (ArrayBuffer.isView(script)) {
+		return Buffer.from(script.buffer, script.byteOffset, script.byteLength);
+	}
+	if (Array.isArray(script)) return Buffer.concat(script.map(nativeScriptBytes));
+	if (script !== null && typeof script === 'object') {
+		return Buffer.concat(Object.values(script).map(nativeScriptBytes));
+	}
+	return Buffer.alloc(0);
+}
+
+function ownerOf(identifier) {
+	const value = identifier.replaceAll('\\', '/');
+	if (value.includes('/benchmarks/lynx-table/app/src/')) return 'fixture-app';
+	if (value.includes('/packages/octane/src/universal-core')) return 'universal-runtime';
+	if (/\/packages\/lynx\/src\/core\/(?:host-driver|papi)/.test(value)) {
+		return 'host-driver-papi';
+	}
+	if (/\/packages\/lynx\/src\/(?:main-thread|main-renderer)/.test(value)) {
+		return 'first-screen-adoption';
+	}
+	if (/\/packages\/lynx\/src\/core\/(?:protocol|transport|profiling)/.test(value)) {
+		return 'protocol-transport';
+	}
+	if (/\/packages\/lynx\/src\/core\/(?:client-driver|worklets)/.test(value)) {
+		return 'public-state-worklets';
+	}
+	if (value.includes('/packages/lynx/src/')) return 'lynx-runtime-other';
+	if (value.includes('/packages/octane/src/')) return 'octane-runtime-other';
+	if (value.includes('/node_modules/@lynx-js/')) return 'lynx-build-wrapper-polyfills';
+	if (value.includes('/node_modules/')) return 'third-party-runtime';
+	return 'generated-wrapper';
+}
+
+function portableIdentifier(identifier) {
+	const value = identifier.replaceAll('\\', '/');
+	if (value.startsWith(REPO.replaceAll('\\', '/') + '/')) {
+		return `@/${value.slice(REPO.length + 1)}`;
+	}
+	const nodeModules = value.lastIndexOf('/node_modules/');
+	return nodeModules === -1 ? value : value.slice(nodeModules + 1);
+}
+
+class CaptureReachableModulesPlugin {
+	constructor(environment) {
+		this.environment = environment;
+	}
+	apply(compiler) {
+		compiler.hooks.thisCompilation.tap(this.constructor.name, (compilation) => {
+			compilation.hooks.processAssets.tap(
+				{
+					name: `${this.constructor.name}:${this.environment}`,
+					stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_REPORT,
+				},
+				() => {
+					const capture = captures.get(this.environment) ?? { modules: [], programs: {} };
+					for (const asset of compilation.getAssets()) {
+						if (!asset.name.endsWith('.js')) continue;
+						capture.programs[asset.name] = Buffer.from(asset.source.buffer());
+					}
+					captures.set(this.environment, capture);
+				},
+			);
+		});
+		compiler.hooks.done.tap(this.constructor.name, (stats) => {
+			const compilation = stats.compilation;
+			const modules = [];
+			for (const module of compilation.modules) {
+				const size = Number(module.size?.() ?? 0);
+				if (!Number.isFinite(size) || size <= 0) continue;
+				const identifier = module.nameForCondition?.() ?? module.identifier?.() ?? 'unknown';
+				const chunks = [...compilation.chunkGraph.getModuleChunksIterable(module)].map(
+					(chunk) => chunk.name ?? String(chunk.id ?? 'unnamed'),
+				);
+				let owner = ownerOf(identifier);
+				if (owner === 'fixture-app' && size > 100_000) owner = 'compiler-output-app';
+				if (owner === 'generated-wrapper' && size > 100_000) owner = 'build-wrapper-main';
+				modules.push({
+					identifier: portableIdentifier(identifier),
+					owner,
+					size,
+					chunks,
+				});
+			}
+			const capture = captures.get(this.environment) ?? { modules: [], programs: {} };
+			capture.modules = modules;
+			captures.set(this.environment, capture);
+		});
+	}
+}
+
+function inventoryPlugin() {
+	return {
+		name: 'octane:lynx-production-inventory',
+		setup(api) {
+			api.modifyBundlerChain((chain, { environment }) => {
+				chain
+					.plugin(`octane:inventory:${environment.name}`)
+					.use(CaptureReachableModulesPlugin, [environment.name]);
+			});
+		},
+	};
+}
+
+function artifactStat(bytes) {
+	return {
+		raw: bytes.length,
+		gzip: gzipBytes(bytes),
+		brotli: brotliBytes(bytes),
+		sha256: sha256(bytes),
+	};
+}
+
+const benchmarkStat = (value) => ({
+	score: value,
+	median: value,
+	min: value,
+	mean: value,
+	p95: value,
+	sd: 0,
+	rme: 0,
+	warmupRatio: 1,
+	samples: 1,
+});
+
+function moduleInventory(modules, artifactRaw) {
+	const owners = {};
+	let reachableRaw = 0;
+	for (const module of modules) {
+		reachableRaw += module.size;
+		const owner = (owners[module.owner] ??= { reachableRaw: 0, modules: 0 });
+		owner.reachableRaw += module.size;
+		owner.modules++;
+	}
+	let attributed = 0;
+	const entries = Object.entries(owners).sort((a, b) => b[1].reachableRaw - a[1].reachableRaw);
+	for (let index = 0; index < entries.length; index++) {
+		const [, owner] = entries[index];
+		owner.artifactRaw =
+			index === entries.length - 1
+				? artifactRaw - attributed
+				: Math.round((artifactRaw * owner.reachableRaw) / reachableRaw);
+		attributed += owner.artifactRaw;
+	}
+	return {
+		method: 'final artifact raw bytes distributed by production reachable-module size',
+		reachableRaw,
+		accountedArtifactRaw: attributed,
+		coverage: artifactRaw === 0 ? 0 : attributed / artifactRaw,
+		owners: Object.fromEntries(entries),
+		modules,
+	};
+}
+
+function gateBudget(label, value, budget) {
+	if (value > budget) throw new Error(`${label} ${value} exceeds frozen budget ${budget}.`);
+}
+
+const temporary = fs.mkdtempSync(path.join(os.tmpdir(), 'octane-lynx-inventory-'));
+let build;
+try {
+	const rspeedy = await createRspeedy({
+		cwd: CWD,
+		loadEnv: false,
+		environment: ['lynx', 'web'],
+		rspeedyConfig: {
+			mode: 'production',
+			environments: { lynx: {}, web: {} },
+			dev: { hmr: false, liveReload: false },
+			output: {
+				cleanDistPath: true,
+				distPath: { root: temporary },
+				filename: { bundle: '[name].[platform].bundle' },
+				filenameHash: false,
+				sourceMap: false,
+			},
+			source: {
+				entry: { main: ENTRY },
+				define: {
+					__BENCH_AUTOROWS__: '0',
+					__OCTANE_LYNX_PROFILE__: 'false',
+				},
+			},
+			splitChunks: false,
+			tools: { rspack: { resolve: { modules: [MODULES, 'node_modules'] } } },
+			plugins: [pluginOctane({ dev: false, hmr: false }), inventoryPlugin()],
+		},
+	});
+	build = await rspeedy.build();
+	const webBytes = fs.readFileSync(path.join(temporary, 'main.web.bundle'));
+	const lynxBytes = fs.readFileSync(path.join(temporary, 'main.lynx.bundle'));
+	const decoded = tasm.supportNapi()
+		? tasm.decode_napi(lynxBytes)
+		: await tasm.decode_wasm(lynxBytes);
+	const lynxCapture = captures.get('lynx') ?? { modules: [], programs: {} };
+	const program = (pattern, fallback) => {
+		const match = Object.entries(lynxCapture.programs).find(([name]) => pattern.test(name));
+		return match?.[1] ?? nativeScriptBytes(decoded[fallback]);
+	};
+	const main = program(/(?:^|\/)main-thread\.js$/, 'main-thread-script');
+	const background = program(/(?:^|\/)background\.js$/, 'background-thread-script');
+	const customSections = {};
+	for (const [key, value] of Object.entries(decoded)) {
+		if (key === 'main-thread-script' || key === 'background-thread-script') continue;
+		const bytes = nativeScriptBytes(value);
+		if (bytes.length > 0) customSections[key] = artifactStat(bytes);
+	}
+	const web = artifactStat(webBytes);
+	const lynx = artifactStat(lynxBytes);
+	const payload = {
+		suite: 'lynx-production-inventory',
+		meta: {
+			date: new Date().toISOString(),
+			source: process.env.OCTANE_INVENTORY_SOURCE ?? 'working-tree',
+			node: process.version,
+			platform: `${os.platform()} ${os.release()}`,
+			fixture: 'benchmarks/lynx-table/app, BENCH_AUTOROWS=0',
+			gzipLevel: zc.Z_BEST_COMPRESSION,
+			accounting:
+				'Raw artifact ownership is proportional to production reachable-module sizes; gzip ownership is only claimed by the controlled ledger below.',
+		},
+		artifacts: {
+			web: {
+				...web,
+				inventory: moduleInventory(captures.get('web')?.modules ?? [], web.raw),
+			},
+			lynx: {
+				...lynx,
+				sections: {
+					main: artifactStat(main),
+					background: artifactStat(background),
+					custom: customSections,
+				},
+				inventory: moduleInventory(lynxCapture.modules, lynx.raw),
+			},
+		},
+		controlledLedger: BUDGETS.controlledLedger,
+	};
+	for (const target of ['web', 'lynx']) {
+		gateBudget(`${target} raw`, payload.artifacts[target].raw, BUDGETS.artifacts[target].raw);
+		gateBudget(`${target} gzip`, payload.artifacts[target].gzip, BUDGETS.artifacts[target].gzip);
+		if (payload.artifacts[target].inventory.coverage < 0.9) {
+			throw new Error(`${target} raw attribution covers less than 90%.`);
+		}
+		for (const [owner, budget] of Object.entries(BUDGETS.owners[target])) {
+			const actual = payload.artifacts[target].inventory.owners[owner]?.artifactRaw ?? 0;
+			gateBudget(`${target}/${owner} raw`, actual, budget);
+		}
+	}
+	for (const section of ['main', 'background']) {
+		for (const metric of ['raw', 'gzip']) {
+			gateBudget(
+				`lynx ${section} ${metric}`,
+				payload.artifacts.lynx.sections[section][metric],
+				BUDGETS.sections[section][metric],
+			);
+		}
+	}
+	const output = process.env.OCTANE_INVENTORY_OUTPUT;
+	if (output) fs.writeFileSync(output, JSON.stringify(payload, null, 2) + '\n');
+	if (process.env.BENCH_JSON) {
+		fs.writeFileSync(
+			process.env.BENCH_JSON,
+			JSON.stringify(
+				{
+					suite: 'lynx-bundle-size',
+					iterations: 1,
+					targets: [
+						{
+							name: 'octane-production-rows0',
+							ops: {
+								web_raw: benchmarkStat(web.raw),
+								web_gzip: benchmarkStat(web.gzip),
+								lynx_raw: benchmarkStat(lynx.raw),
+								lynx_gzip: benchmarkStat(lynx.gzip),
+							},
+							meta: payload,
+						},
+					],
+				},
+				null,
+				2,
+			) + '\n',
+		);
+	}
+	console.log('\ntarget                       raw       gzip     brotli');
+	console.log(
+		`rows-0 web       ${String(web.raw).padStart(10)} ${String(web.gzip).padStart(10)} ${String(web.brotli).padStart(10)}`,
+	);
+	console.log(
+		`rows-0 lynx      ${String(lynx.raw).padStart(10)} ${String(lynx.gzip).padStart(10)} ${String(lynx.brotli).padStart(10)}`,
+	);
+	console.log(
+		`lynx main        ${String(payload.artifacts.lynx.sections.main.raw).padStart(10)} ${String(payload.artifacts.lynx.sections.main.gzip).padStart(10)} ${String(payload.artifacts.lynx.sections.main.brotli).padStart(10)}`,
+	);
+	console.log(
+		`lynx background  ${String(payload.artifacts.lynx.sections.background.raw).padStart(10)} ${String(payload.artifacts.lynx.sections.background.gzip).padStart(10)} ${String(payload.artifacts.lynx.sections.background.brotli).padStart(10)}`,
+	);
+} finally {
+	await build?.close();
+	fs.rmSync(temporary, { recursive: true, force: true });
+}

--- a/benchmarks/lynx-bundle-size/results/production-inventory.md
+++ b/benchmarks/lynx-bundle-size/results/production-inventory.md
@@ -1,0 +1,61 @@
+# Production Lynx bundle inventory after #706/#707 integration
+
+## Reproducible baseline
+
+- integration source: upstream `9b147781c9b4ec4df053a059633978ddc0ed922a`, then #706 head `8d8883c8`, then both #707 commits ending at `71b758e7` (local integration commit `5a373524`)
+- fixture: `benchmarks/lynx-table/app`, `BENCH_AUTOROWS=0`, production Rspeedy, split chunks off, source maps off
+- tool host: Node `v22.22.2`, Linux `5.15.120.bsk.3-amd64`
+- cross-framework run: `2026-08-11T21-14-12-65160668d8d9-integration-706-707-featured.json`; calibration `2367.5`; all six entries rebuilt from one lockfile; zero DNF/null cells
+
+| artifact | raw | gzip | Brotli | SHA-256 |
+|---|---:|---:|---:|---|
+| Octane Web | 484,572 B | 132,135 B | 99,989 B | `b025530d9718c85d0f50a86d5fb9e21facf5a47950b1f0b0c6d1718135accde0` |
+| Octane Lynx | 473,851 B | 158,882 B | 133,850 B | `bb87aa1c1857ab1189996cddce4a536fb36b3a695be2c9934bb401cd99e07cdd` |
+| Lynx main program | 203,712 B | 57,560 B | 48,962 B | `c85c7bfd6f6c2cba24d248fc5a9f30646ac3199696e3a5761a470cbea50c29fd` |
+| Lynx background program | 276,738 B | 74,170 B | 63,294 B | `750e2453fe4a5032e25f3d5004d70bc8a953c87614265de71671ce1f42d2dd8b` |
+
+The standalone cross-framework packager reports the same Web bytes and a
+54 B raw / 15 B gzip Lynx-encoding difference (`473,905 / 158,897 B`). Budgets
+are bound to the checked in-process fixture builder; the external values remain
+the authoritative all-framework comparison. The five ReactLynx/Vue comparison
+median is 44,489 B Web gzip and 51,228 B Lynx gzip, leaving Octane at 2.97× and
+3.10× respectively.
+
+## Reachable-owner inventory
+
+The production compilation exposes 2,914,877 reachable transformed module
+bytes. The inventory distributes each final artifact's raw total according to
+those owner weights, accounting for 100%. This is a prioritization ledger, not
+an additive compressed-size claim.
+
+| owner | Web attributed raw | Lynx attributed raw | complete-artifact share |
+|---|---:|---:|---:|
+| compiler-emitted app/background program | 139,617 B | 136,528 B | 28.8% |
+| main-thread build/runtime wrapper | 90,909 B | 88,897 B | 18.8% |
+| universal runtime | 77,629 B | 75,912 B | 16.0% |
+| host driver / PAPI | 37,654 B | 36,821 B | 7.8% |
+| protocol / transport / profiling | 34,477 B | 33,715 B | 7.1% |
+| other Lynx runtime | 32,834 B | 32,107 B | 6.8% |
+| first screen / adoption | 30,818 B | 30,136 B | 6.4% |
+| public state / worklets | 28,232 B | 27,608 B | 5.8% |
+| authored fixture app | 11,437 B | 11,184 B | 2.4% |
+| remaining wrappers, Octane helpers, third party | 965 B | 943 B | 0.2% |
+
+Every owner above 2% remains on the feature-equivalence ledger. A child may
+claim gzip ownership only after a controlled production ablation or isolated
+product patch; these raw weights must not be converted into predicted gzip.
+
+## Controlled gzip ledger
+
+- #706: Web/Lynx gzip `+1.38%/+1.45%`, accepted as a measured clear-performance size tax.
+- #707: preview main `76,915 -> 75,024 B` and IFR main `81,995 -> 79,980 B`, both `-2.46%`; complete preview `150,079 -> 148,183 B`, complete IFR `155,075 -> 152,968 B`; background raw unchanged. This is an accepted optional-worklet child, still pending upstream.
+- integrated preview/IFR recalibration: main gzip `77,285 / 82,274 B`, background raw `271,737 B`. These exact combined-stack values replace the stale pre-#706 gate without adding the two gzip deltas arithmetically.
+
+## Decision
+
+This is the required inventory-only and budget patch before another product
+size change. It does not claim the umbrella's 20% target: #707 is one controlled
+child, #706 is an accepted tax, and all other >2% owners remain explicitly
+accounted. Runtime acceptance continues to require AB/BA latency, startup,
+heap, teardown, worklet/thread-call, adoption, mixed-version, and diagnostic
+gates for each future child.

--- a/benchmarks/lynx-bundle-size/results/production-inventory.md
+++ b/benchmarks/lynx-bundle-size/results/production-inventory.md
@@ -1,45 +1,45 @@
-# Production Lynx bundle inventory after #706/#707 integration
+# Production Lynx bundle inventory on post-#706/#707 main
 
 ## Reproducible baseline
 
-- integration source: upstream `9b147781c9b4ec4df053a059633978ddc0ed922a`, then #706 head `8d8883c8`, then both #707 commits ending at `71b758e7` (local integration commit `5a373524`)
+- formal source: upstream `ffadd397f4466d4e4a32b4527143270442c9c41e`, which contains merged #706 (`47ff0a33`) and #707 (`4a792e39`)
 - fixture: `benchmarks/lynx-table/app`, `BENCH_AUTOROWS=0`, production Rspeedy, split chunks off, source maps off
 - tool host: Node `v22.22.2`, Linux `5.15.120.bsk.3-amd64`
 - cross-framework run: `2026-08-11T21-14-12-65160668d8d9-integration-706-707-featured.json`; calibration `2367.5`; all six entries rebuilt from one lockfile; zero DNF/null cells
 
 | artifact | raw | gzip | Brotli | SHA-256 |
 |---|---:|---:|---:|---|
-| Octane Web | 484,572 B | 132,135 B | 99,989 B | `b025530d9718c85d0f50a86d5fb9e21facf5a47950b1f0b0c6d1718135accde0` |
-| Octane Lynx | 473,851 B | 158,882 B | 133,850 B | `bb87aa1c1857ab1189996cddce4a536fb36b3a695be2c9934bb401cd99e07cdd` |
-| Lynx main program | 203,712 B | 57,560 B | 48,962 B | `c85c7bfd6f6c2cba24d248fc5a9f30646ac3199696e3a5761a470cbea50c29fd` |
-| Lynx background program | 276,738 B | 74,170 B | 63,294 B | `750e2453fe4a5032e25f3d5004d70bc8a953c87614265de71671ce1f42d2dd8b` |
+| Octane Web | 485,345 B | 132,334 B | 100,114 B | `b4b2d5ad69f02c4f862915f39d3b2d7da59f452ef4237d45b832edbb40c7e3a6` |
+| Octane Lynx | 474,618 B | 159,077 B | 134,144 B | `44c4493e4c03f02ebda6271cd4f013befdca5047e6b520f62436ca4952a16e46` |
+| Lynx main program | 203,712 B | 57,563 B | 48,950 B | `d4c9f60c051b31bb4065b15a42be1d06656fa8356df2c0b6356b73e05bad813c` |
+| Lynx background program | 277,505 B | 74,381 B | 63,571 B | `4d64e4db3d97f62a8fb374b6c534555a33204d540f8338eaffc63846ead67eca` |
 
-The standalone cross-framework packager reports the same Web bytes and a
-54 B raw / 15 B gzip Lynx-encoding difference (`473,905 / 158,897 B`). Budgets
-are bound to the checked in-process fixture builder; the external values remain
-the authoritative all-framework comparison. The five ReactLynx/Vue comparison
-median is 44,489 B Web gzip and 51,228 B Lynx gzip, leaving Octane at 2.97× and
-3.10× respectively.
+The post-integration all-framework run at local integration `5a373524` reported
+`484,572 / 132,135 B` Web and `473,905 / 158,897 B` Lynx. The later upstream
+parity commits move only the Octane source; the formal budgets above are bound
+to the checked in-process fixture builder. The five ReactLynx/Vue comparison
+median remains 44,489 B Web gzip and 51,228 B Lynx gzip, leaving formal main at
+2.97× and 3.11× respectively.
 
 ## Reachable-owner inventory
 
-The production compilation exposes 2,914,877 reachable transformed module
+The production compilation exposes 2,923,829 reachable transformed module
 bytes. The inventory distributes each final artifact's raw total according to
 those owner weights, accounting for 100%. This is a prioritization ledger, not
 an additive compressed-size claim.
 
 | owner | Web attributed raw | Lynx attributed raw | complete-artifact share |
 |---|---:|---:|---:|
-| compiler-emitted app/background program | 139,617 B | 136,528 B | 28.8% |
-| main-thread build/runtime wrapper | 90,909 B | 88,897 B | 18.8% |
-| universal runtime | 77,629 B | 75,912 B | 16.0% |
-| host driver / PAPI | 37,654 B | 36,821 B | 7.8% |
-| protocol / transport / profiling | 34,477 B | 33,715 B | 7.1% |
-| other Lynx runtime | 32,834 B | 32,107 B | 6.8% |
-| first screen / adoption | 30,818 B | 30,136 B | 6.4% |
-| public state / worklets | 28,232 B | 27,608 B | 5.8% |
-| authored fixture app | 11,437 B | 11,184 B | 2.4% |
-| remaining wrappers, Octane helpers, third party | 965 B | 943 B | 0.2% |
+| compiler-emitted app/background program | 140,155 B | 137,057 B | 28.9% |
+| main-thread build/runtime wrapper | 90,775 B | 88,768 B | 18.7% |
+| universal runtime | 78,258 B | 76,528 B | 16.1% |
+| host driver / PAPI | 37,599 B | 36,768 B | 7.7% |
+| protocol / transport / profiling | 34,427 B | 33,666 B | 7.1% |
+| other Lynx runtime | 32,786 B | 32,061 B | 6.8% |
+| first screen / adoption | 30,773 B | 30,093 B | 6.3% |
+| public state / worklets | 28,191 B | 27,568 B | 5.8% |
+| authored fixture app | 11,420 B | 11,167 B | 2.4% |
+| remaining wrappers, Octane helpers, third party | 961 B | 942 B | 0.2% |
 
 Every owner above 2% remains on the feature-equivalence ledger. A child may
 claim gzip ownership only after a controlled production ablation or isolated
@@ -49,7 +49,7 @@ product patch; these raw weights must not be converted into predicted gzip.
 
 - #706: Web/Lynx gzip `+1.38%/+1.45%`, accepted as a measured clear-performance size tax.
 - #707: preview main `76,915 -> 75,024 B` and IFR main `81,995 -> 79,980 B`, both `-2.46%`; complete preview `150,079 -> 148,183 B`, complete IFR `155,075 -> 152,968 B`; background raw unchanged. This is an accepted optional-worklet child, still pending upstream.
-- integrated preview/IFR recalibration: main gzip `77,285 / 82,274 B`, background raw `271,737 B`. These exact combined-stack values replace the stale pre-#706 gate without adding the two gzip deltas arithmetically.
+- formal-main preview/IFR recalibration: main gzip `77,286 / 82,274 B`, background raw `272,504 B`. These exact post-merge values replace the stale pre-#706 gate without adding controlled gzip deltas arithmetically.
 
 ## Decision
 

--- a/benchmarks/lynx-bundle-size/run.mjs
+++ b/benchmarks/lynx-bundle-size/run.mjs
@@ -43,14 +43,14 @@ const PREVIEW_RECEIVER_NAME = 'main__preview_receiver';
 const BUNDLE_NAME = 'main.lynx.bundle';
 const FORBIDDEN_RUNTIME = /(?:^|[^$\w])(?:react|react-dom|preact|ReactLynx)(?:[^$\w]|$)/i;
 const FORBIDDEN_DOM = /\b(?:document|window|HTMLElement|MutationObserver)\b/;
-// Recalibrated on the complete local integration of upstream main 9b147781,
-// #706 at 8d8883c8, then both #707 commits ending at 71b758e7. These exact
-// deterministic caps keep the accepted worklet boundary and #706 size tax
-// visible together instead of applying either controlled delta additively.
+// Recalibrated on upstream main ffadd397, which contains merged #706 and #707.
+// These exact deterministic caps keep the accepted worklet boundary, #706
+// size tax, and subsequent mainline parity work visible together instead of
+// applying any controlled gzip delta additively.
 const NO_WORKLET_BUDGET = Object.freeze({
-	previewMainGzip: 77_285,
+	previewMainGzip: 77_286,
 	ifrMainGzip: 82_274,
-	backgroundRaw: 271_737,
+	backgroundRaw: 272_504,
 });
 
 function packageEntry(packageName) {

--- a/benchmarks/lynx-bundle-size/run.mjs
+++ b/benchmarks/lynx-bundle-size/run.mjs
@@ -43,14 +43,13 @@ const PREVIEW_RECEIVER_NAME = 'main__preview_receiver';
 const BUNDLE_NAME = 'main.lynx.bundle';
 const FORBIDDEN_RUNTIME = /(?:^|[^$\w])(?:react|react-dom|preact|ReactLynx)(?:[^$\w]|$)/i;
 const FORBIDDEN_DOM = /\b(?:document|window|HTMLElement|MutationObserver)\b/;
-// Frozen from upstream main 9b147781. The main caps are the largest integer
-// values that still prove the issue's >=2% gzip reduction. The background
-// program has no source change; its raw-byte budget prevents optional worklet
-// code from leaking onto that thread while tolerating minifier-symbol changes
-// caused by the independently optimized main graph.
+// Recalibrated on the complete local integration of upstream main 9b147781,
+// #706 at 8d8883c8, then both #707 commits ending at 71b758e7. These exact
+// deterministic caps keep the accepted worklet boundary and #706 size tax
+// visible together instead of applying either controlled delta additively.
 const NO_WORKLET_BUDGET = Object.freeze({
-	previewMainGzip: 75_376,
-	ifrMainGzip: 80_355,
+	previewMainGzip: 77_285,
+	ifrMainGzip: 82_274,
 	backgroundRaw: 271_737,
 });
 


### PR DESCRIPTION
## Summary

- add an exact rows=0 production inventory for Web and Lynx bundles
- capture pre-encode main/background sections, hashes, raw/gzip/brotli sizes, and reachable transformed modules
- classify every reachable byte by subsystem with 100% proportional raw attribution
- add exact total, section, and owner budgets with explicit calibration
- run the inventory from the root Lynx bundle-size suite and check in the latest-main report

Tracks the umbrella at https://github.com/Huxpro/octane/issues/48.

## Latest-main baseline

Source: upstream `main` at `ffadd397`, which includes merged #706 and #707.

| artifact | raw | gzip | brotli |
| --- | ---: | ---: | ---: |
| Web bundle | 485,345 | 132,334 | 100,114 |
| Lynx bundle | 474,618 | 159,077 | 134,144 |
| main section | 203,712 | 57,563 | 48,950 |
| background section | 277,505 | 74,381 | 63,571 |

The inventory accounts for 2,923,829 transformed reachable raw bytes. Largest owners are compiler output (140,155 Web / 137,057 Lynx), build wrapper (90,775 / 88,768), universal runtime (78,258 / 76,528), host/PAPI (37,599 / 36,768), and protocol (34,427 / 33,666).

The report also preserves the controlled ledger for #706 and the complete two-commit #707 head. Compressed ledgers are intentionally reported as controlled whole-build measurements rather than summed per-module gzip claims.

## Validation

- `node benchmarks/lynx-bundle-size/inventory.mjs` — all total/section/owner budgets passed
- `node benchmarks/lynx-bundle-size/run.mjs` — preview and IFR budgets passed
- `node benchmarks/bench.mjs --only lynx-bundle-size --ratios`
- `pnpm format:files:check benchmarks/bench.mjs benchmarks/lynx-bundle-size`
- `pnpm sync`

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only inventory and budget recalibration; no product runtime or security-sensitive code changes. Risk is limited to CI size-gate accuracy.
> 
> **Overview**
> Adds a **production rows-0 inventory** for the Lynx table fixture that builds Web and Lynx artifacts, records hashes plus raw/gzip/Brotli sizes, and attributes 100% of final raw bytes by reachable-module owner.
> 
> Wires `inventory.mjs` into the `lynx-bundle-size` suite with frozen total, section, and owner budgets in `inventory-budgets.json`, plus a checked baseline report. Recalibrates the existing no-worklet preview/IFR gzip and background raw caps on the integrated #706/#707 stack instead of applying controlled gzip deltas additively.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbdd61458934fc2a9eb4554efd86ed1a0c972b0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

