### PR TITLE
test(recharts): stabilize animation callback tests

### DIFF
--- a/packages/recharts/tests/conformance/chart-smoke.test.ts
+++ b/packages/recharts/tests/conformance/chart-smoke.test.ts
@@ -38,11 +38,34 @@ async function settle() {
 	}
 }
 
-async function restoreAnimationFrameGlobals() {
-	// Unmounting charts can enqueue one final store notification. Keep the
-	// animation-frame globals alive until that callback has had a timer turn.
-	await new Promise((resolve) => setTimeout(resolve, 0));
-	vi.unstubAllGlobals();
+function controlAnimationFrames() {
+	let frameTime = performance.now();
+	let nextHandle = 1;
+	const pending = new Map<number, FrameRequestCallback>();
+	vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+		const handle = nextHandle++;
+		pending.set(handle, callback);
+		return handle;
+	});
+	vi.stubGlobal('cancelAnimationFrame', (handle: number) => pending.delete(handle));
+
+	return {
+		async flush() {
+			for (let frame = 0; frame < 100; frame++) {
+				await nextPaint();
+				const callbacks = Array.from(pending.values());
+				pending.clear();
+				if (callbacks.length === 0) return;
+				frameTime = Math.max(frameTime, performance.now()) + 16;
+				for (const callback of callbacks) callback(frameTime);
+			}
+			throw new Error('chart animation did not settle within 100 controlled frames');
+		},
+		restore() {
+			pending.clear();
+			vi.unstubAllGlobals();
+		},
+	};
 }
 
 describe('Phase 1 chart pipeline (octane side)', () => {
@@ -222,33 +245,26 @@ describe('Phase 1 chart pipeline (octane side)', () => {
 	});
 
 	it('forwards Scatter animation lifecycle callbacks', async () => {
-		let frameTime = performance.now();
-		vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
-			setTimeout(() => callback((frameTime += 16)), 0),
-		);
-		vi.stubGlobal('cancelAnimationFrame', (handle: number) => clearTimeout(handle));
+		const animationFrames = controlAnimationFrames();
 		const starts: string[] = [];
 		const ends: string[] = [];
+		let result: ReturnType<typeof mount> | undefined;
 		try {
-			const result = mount(ScatterAnimationCallbacksApp, {
+			result = mount(ScatterAnimationCallbacksApp, {
 				onAnimationStart: () => starts.push('start'),
 				onAnimationEnd: () => ends.push('end'),
 			});
-			await settle();
+			await animationFrames.flush();
 			expect(starts).toEqual(['start']);
 			expect(ends).toEqual(['end']);
-			result.unmount();
 		} finally {
-			await restoreAnimationFrameGlobals();
+			result?.unmount();
+			animationFrames.restore();
 		}
 	});
 
 	it('does not restart Funnel animation for equivalent props but propagates presentation changes', async () => {
-		let frameTime = performance.now();
-		vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
-			setTimeout(() => callback((frameTime += 16)), 0),
-		);
-		vi.stubGlobal('cancelAnimationFrame', (handle: number) => clearTimeout(handle));
+		const animationFrames = controlAnimationFrames();
 		const starts: string[] = [];
 		const ends: string[] = [];
 		const props = {
@@ -256,27 +272,28 @@ describe('Phase 1 chart pipeline (octane side)', () => {
 			onAnimationStart: () => starts.push('start'),
 			onAnimationEnd: () => ends.push('end'),
 		};
+		let result: ReturnType<typeof mount> | undefined;
 		try {
-			const result = mount(FunnelAnimationStabilityApp, props);
-			await settle();
+			result = mount(FunnelAnimationStabilityApp, props);
+			await animationFrames.flush();
 			expect(starts).toEqual(['start']);
 			expect(ends).toEqual(['end']);
 
 			result.update(FunnelAnimationStabilityApp, { ...props });
-			await settle();
+			await animationFrames.flush();
 			expect(starts).toEqual(['start']);
 			expect(ends).toEqual(['end']);
 
 			result.update(FunnelAnimationStabilityApp, { ...props, fill: '#82ca9d' });
-			await settle();
+			await animationFrames.flush();
 			expect(starts).toEqual(['start', 'start']);
 			expect(ends).toEqual(['end', 'end']);
 			expect(
 				result.container.querySelector('.recharts-funnel-trapezoid path')?.getAttribute('fill'),
 			).toBe('#82ca9d');
-			result.unmount();
 		} finally {
-			await restoreAnimationFrameGlobals();
+			result?.unmount();
+			animationFrames.restore();
 		}
 	});
 
@@ -307,11 +324,7 @@ describe('Phase 1 chart pipeline (octane side)', () => {
 	});
 
 	it('restarts polar animations only when their geometry changes', async () => {
-		let frameTime = performance.now();
-		vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
-			setTimeout(() => callback((frameTime += 16)), 0),
-		);
-		vi.stubGlobal('cancelAnimationFrame', (handle: number) => clearTimeout(handle));
+		const animationFrames = controlAnimationFrames();
 		const starts: string[] = [];
 		const ends: string[] = [];
 		const props = {
@@ -319,24 +332,25 @@ describe('Phase 1 chart pipeline (octane side)', () => {
 			onAnimationStart: () => starts.push('start'),
 			onAnimationEnd: () => ends.push('end'),
 		};
+		let result: ReturnType<typeof mount> | undefined;
 		try {
-			const result = mount(PolarAnimationStabilityApp, props);
-			await settle();
+			result = mount(PolarAnimationStabilityApp, props);
+			await animationFrames.flush();
 			expect(starts).toHaveLength(3);
 			expect(ends).toHaveLength(3);
 
 			result.update(PolarAnimationStabilityApp, { ...props });
-			await settle();
+			await animationFrames.flush();
 			expect(starts).toHaveLength(3);
 			expect(ends).toHaveLength(3);
 
 			result.update(PolarAnimationStabilityApp, { ...props, changed: true });
-			await settle();
+			await animationFrames.flush();
 			expect(starts).toHaveLength(6);
 			expect(ends).toHaveLength(6);
-			result.unmount();
 		} finally {
-			await restoreAnimationFrameGlobals();
+			result?.unmount();
+			animationFrames.restore();
 		}
 	});
 


### PR DESCRIPTION
## Summary

- make the Recharts Scatter, Funnel, and polar animation lifecycle tests drive queued animation frames deterministically
- remove their dependence on ten arbitrary event-loop turns under full-shard load
- retain bounded failure for runaway animations and the existing callback/count assertions

## Why

The post-merge `main` CI run failed in `forwards Scatter animation lifecycle callbacks`: `onAnimationStart` had fired, but the timer-backed synthetic animation had not reached its completion frame before `settle()` returned. The test mixed zero-delay timers, queued animation frames, chart registration passes, and a fixed ten-turn wait, making completion depend on runner scheduling.

Failed run: https://github.com/octanejs/octane/actions/runs/31566661690

## Validation

- [x] `pnpm format:files:check packages/recharts/tests/conformance/chart-smoke.test.ts`
- [x] `pnpm sync`
- [x] full targeted file: `./node_modules/.bin/vitest run packages/recharts/tests/conformance/chart-smoke.test.ts --reporter=verbose` (20 passed)
- [x] affected animation cases repeated five times (3 passed per attempt)
- [ ] `pnpm typecheck:files packages/recharts/tests/conformance/chart-smoke.test.ts` — attempted, but the existing Recharts source graph reports extensive pre-existing declaration and implicit-`any` errors unrelated to this test change
- [ ] `pnpm format:check` — not run; scoped formatting passed
- [ ] `pnpm typecheck` — not run; scoped command is already blocked by the existing Recharts errors above
- [ ] `pnpm test` — not run; the focused file and repeated affected cases were used for this test-only fix

## Risk / follow-ups

- Test-only change. The controlled driver advances real queued `requestAnimationFrame` callbacks until the queue is empty. Its 100-frame bound is a synchronous runaway guard, not a wall-clock timeout or retry.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change confined to chart smoke tests; no production or runtime behavior is modified.
> 
> **Overview**
> Makes Scatter, Funnel, and polar animation lifecycle tests drive `requestAnimationFrame` **deterministically** instead of relying on timer-backed stubs plus a fixed `settle()` wait.
> 
> Adds a shared `controlAnimationFrames()` helper that queues rAF callbacks and flushes them until empty (with a 100-frame runaway guard). The three affected tests now await that flush and restore stubs in `finally`, so completion no longer depends on CI scheduling under load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea62a3c7721584240e7757256d681036070eaa34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->