### PR TITLE
fix: type native HTML attributes and recognize readonly controls

### DIFF
--- a/.changeset/native-html-attribute-types.md
+++ b/.changeset/native-html-attribute-types.md
@@ -1,0 +1,7 @@
+---
+'octane': patch
+---
+
+Type native HTML attribute spellings alongside React-compatible aliases, support
+native numeric attribute strings and SVG visibility attributes, and recognize
+native `readonly` spelling when checking text-input change handlers.

--- a/packages/octane/src/compiler/native-change-diagnostics.js
+++ b/packages/octane/src/compiler/native-change-diagnostics.js
@@ -163,12 +163,13 @@ function attributeExpression(attribute) {
 	);
 }
 
-function lastAttribute(attributes, name) {
+function lastAttribute(attributes, name, alias) {
 	for (let index = attributes.length - 1; index >= 0; index--) {
 		const attribute = attributes[index];
 		if (
 			(attribute.type === 'Attribute' || attribute.type === 'JSXAttribute') &&
-			attributeName(attribute) === name
+			(attributeName(attribute) === name ||
+				(alias !== undefined && attributeName(attribute) === alias))
 		) {
 			return attribute;
 		}
@@ -331,7 +332,7 @@ function classifyHost(node, scope, namespace, source, filename, diagnostics, cla
 		return;
 	}
 
-	const readOnly = htmlBooleanState(lastAttribute(attributes, 'readOnly'));
+	const readOnly = htmlBooleanState(lastAttribute(attributes, 'readOnly', 'readonly'));
 	const disabled = htmlBooleanState(lastAttribute(attributes, 'disabled'));
 	const suppression = booleanIntent(lastAttribute(attributes, 'suppressNativeChangeWarning'));
 	if (readOnly === 'true' || disabled === 'true' || suppression === 'true') {

--- a/packages/octane/src/jsx-runtime.d.ts
+++ b/packages/octane/src/jsx-runtime.d.ts
@@ -10,7 +10,8 @@
  * attribute-interface list are derived mechanically from `@types/react`'s
  * `JSX.IntrinsicElements`.
  *
- * Octane's documented divergences are applied by the `Transformed` layer:
+ * Octane's documented divergences are applied by the attribute transform and
+ * final per-element prop composition:
  *
  *  - `class` / `className` compose clsx-style (strings, numbers, arrays,
  *    objects, nesting; falsy drops out) — both accept `ClassValue`.
@@ -23,6 +24,12 @@
  *  - `ref` accepts a callback (with optional React-19 cleanup return), a ref
  *    object, or an ARRAY of refs — nested arrays flatten (no `forwardRef`).
  *  - `for` is the native attribute (React's `htmlFor` alias also works).
+ *  - HTML accepts both React property names and their native lowercase
+ *    spellings (`tabIndex` / `tabindex`, `readOnly` / `readonly`); native
+ *    numeric attributes also accept numeric strings. Framework-only props and
+ *    aliases whose native name is not their lowercase form are excluded.
+ *  - SVG remains case-sensitive, with explicit support for `hidden` and the
+ *    native `tabindex` attribute.
  *  - `children` are octane renderables (`unknown`), not `ReactNode`.
  *  - `style` accepts a plain string as well as the object form (boolean
  *    property values clear the property, React-style).
@@ -81,6 +88,45 @@ type NativeEventHandlers<P, T> = {
 	[K in Extract<keyof P, ReactSyntheticProps>]?: NativeHandler<P[K], T>;
 };
 
+/** Props whose lowercase spelling is not a native attribute with equivalent behavior. */
+type NonNativeLowercaseProps =
+	| ReactSyntheticProps
+	| 'autoFocus'
+	| 'defaultValue'
+	| 'defaultChecked'
+	| 'dangerouslySetInnerHTML'
+	| 'className'
+	| 'suppressContentEditableWarning'
+	| 'suppressHydrationWarning'
+	| 'suppressNativeChangeWarning'
+	| '__octaneNativeChangeDiagnostic'
+	| 'acceptCharset'
+	| 'htmlFor'
+	| 'httpEquiv';
+
+/** Native HTML content attributes may express numeric property values as text. */
+type NativeAttributeValue<T> =
+	T | (Extract<T, number> extends never ? never : `${Extract<T, number>}`);
+
+/** Add actual lowercase HTML spellings without weakening the original prop types. */
+type NativeLowercaseAttributes<P> = {
+	[
+		K in Exclude<Extract<keyof P, string>, NonNativeLowercaseProps> as K extends
+			Lowercase<K> | `on${Capitalize<string>}`
+			? never
+			: Lowercase<K> extends keyof P
+				? never
+				: Lowercase<K>
+	]?: NativeAttributeValue<P[K]>;
+};
+
+/** Preserve a consumer's React button augmentation when the installed React types expose it. */
+type ExistingButtonAttribute<
+	T,
+	K extends PropertyKey,
+	Fallback,
+> = K extends keyof React.ButtonHTMLAttributes<T> ? React.ButtonHTMLAttributes<T>[K] : Fallback;
+
 /** Octane's attribute transform over one React attribute interface. */
 type Transformed<P, T> = Omit<P, ReactSyntheticProps | 'className' | 'style' | 'children'> &
 	NativeEventHandlers<P, T & EventTarget> & {
@@ -104,14 +150,20 @@ declare namespace Octane {
 		ref?: Ref<T> | undefined;
 	}
 
-	type DetailedHTMLProps<E, T> = RefAttributes<T> & E;
+	type DetailedHTMLProps<E, T> = RefAttributes<T> & E & NativeLowercaseAttributes<E>;
 
 	interface AnchorHTMLAttributes<T> extends Transformed<React.AnchorHTMLAttributes<T>, T> {}
 	interface AreaHTMLAttributes<T> extends Transformed<React.AreaHTMLAttributes<T>, T> {}
 	interface AudioHTMLAttributes<T> extends Transformed<React.AudioHTMLAttributes<T>, T> {}
 	interface BaseHTMLAttributes<T> extends Transformed<React.BaseHTMLAttributes<T>, T> {}
 	interface BlockquoteHTMLAttributes<T> extends Transformed<React.BlockquoteHTMLAttributes<T>, T> {}
-	interface ButtonHTMLAttributes<T> extends Transformed<React.ButtonHTMLAttributes<T>, T> {}
+	interface ButtonHTMLAttributes<T> extends Omit<
+		Transformed<React.ButtonHTMLAttributes<T>, T>,
+		'command' | 'commandfor'
+	> {
+		command?: ExistingButtonAttribute<T, 'command', string> | undefined;
+		commandfor?: ExistingButtonAttribute<T, 'commandfor', string> | undefined;
+	}
 	interface CanvasHTMLAttributes<T> extends Transformed<React.CanvasHTMLAttributes<T>, T> {}
 	interface ColHTMLAttributes<T> extends Transformed<React.ColHTMLAttributes<T>, T> {}
 	interface ColgroupHTMLAttributes<T> extends Transformed<React.ColgroupHTMLAttributes<T>, T> {}
@@ -144,7 +196,10 @@ declare namespace Octane {
 	interface ParamHTMLAttributes<T> extends Transformed<React.ParamHTMLAttributes<T>, T> {}
 	interface ProgressHTMLAttributes<T> extends Transformed<React.ProgressHTMLAttributes<T>, T> {}
 	interface QuoteHTMLAttributes<T> extends Transformed<React.QuoteHTMLAttributes<T>, T> {}
-	interface SVGAttributes<T> extends Transformed<React.SVGAttributes<T>, T> {}
+	interface SVGAttributes<T> extends Transformed<React.SVGAttributes<T>, T> {
+		hidden?: React.HTMLAttributes<T>['hidden'];
+		tabindex?: NativeAttributeValue<React.SVGAttributes<T>['tabIndex']>;
+	}
 	interface ScriptHTMLAttributes<T> extends Transformed<React.ScriptHTMLAttributes<T>, T> {}
 	interface SelectHTMLAttributes<T> extends Transformed<React.SelectHTMLAttributes<T>, T> {}
 	interface SlotHTMLAttributes<T> extends Transformed<React.SlotHTMLAttributes<T>, T> {}

--- a/packages/octane/tests/compiler/native-change-compiler.test.ts
+++ b/packages/octane/tests/compiler/native-change-compiler.test.ts
@@ -130,6 +130,47 @@ export function App() @{
 		expect(diagnostics(component('<input onChange={() => {}} disabled="disabled" />'))).toEqual([]);
 	});
 
+	it('recognizes native readonly spelling on text-entry inputs and textareas', () => {
+		for (const tag of ['input', 'textarea']) {
+			for (const attribute of ['readonly', 'readonly={true}', 'readonly="readonly"']) {
+				expect(
+					diagnostics(component(`<${tag} onChange={() => {}} ${attribute} />`)),
+					`${tag} ${attribute}`,
+				).toEqual([]);
+			}
+
+			for (const attribute of ['readonly={false}', 'readonly=""', 'readonly={0}']) {
+				expect(
+					diagnostics(component(`<${tag} onChange={() => {}} ${attribute} />`)),
+					`${tag} ${attribute}`,
+				).toHaveLength(1);
+			}
+
+			expect(
+				diagnostics(component(`<${tag} onChange={() => {}} readonly={props.readOnly} />`)),
+				`${tag} dynamic readonly`,
+			).toEqual([]);
+		}
+	});
+
+	it('uses the final authored readonly attribute across native and React spellings', () => {
+		const cases = [
+			{ attributes: 'readOnly={false} readonly', warnings: 0 },
+			{ attributes: 'readonly readOnly={false}', warnings: 1 },
+			{ attributes: 'readOnly readonly={false}', warnings: 1 },
+			{ attributes: 'readonly={false} readOnly', warnings: 0 },
+			{ attributes: 'readOnly={false} readonly={props.readOnly}', warnings: 0 },
+			{ attributes: 'readonly={props.readOnly} readOnly={false}', warnings: 1 },
+		];
+
+		for (const { attributes, warnings } of cases) {
+			expect(
+				diagnostics(component(`<input onChange={() => {}} ${attributes} />`)),
+				attributes,
+			).toHaveLength(warnings);
+		}
+	});
+
 	it('defers dynamic and spread-owned decisions instead of issuing false static warnings', () => {
 		expect(
 			diagnostics(`

--- a/packages/octane/typetests/jsx-runtime.test-d.tsx
+++ b/packages/octane/typetests/jsx-runtime.test-d.tsx
@@ -74,10 +74,77 @@ export function TypeSurface() {
 			{/* @ts-expect-error — numbers are not a style value */}
 			<div style={42} />
 
-			{/* ── React-shaped attribute surface ── */}
+			{/* ── React aliases and native HTML attribute spellings ── */}
 			<main tabIndex={-1} />
-			{/* @ts-expect-error — lowercase `tabindex` is not the typed surface */}
 			<main tabindex={-1} />
+			<main tabindex="-1" />
+			<main enterkeyhint="send" inputmode="numeric" spellcheck={false} autocorrect="on" />
+			<input autocomplete="email" autocapitalize="sentences" readonly maxlength="24" />
+			<form novalidate autocomplete="off" />
+			<form accept-charset="utf-8" />
+			<a referrerpolicy="no-referrer" />
+			<img crossorigin="anonymous" />
+			<meta http-equiv="refresh" />
+			<button popovertarget="details" popovertargetaction="show" />
+			<button command="show-modal" commandfor="dialog" />
+			<button command={undefined} commandfor={undefined} />
+			<button
+				formaction={(data) => {
+					use<FormData>(data);
+				}}
+			/>
+			<input
+				formaction={async (data) => {
+					use<FormData>(data);
+				}}
+			/>
+			<table>
+				<tbody>
+					<tr>
+						<td colspan="2" rowspan={2} />
+					</tr>
+				</tbody>
+			</table>
+			<svg hidden tabindex="0" viewBox="0 0 10 10" />
+			<svg tabindex={-1} strokeWidth={2} />
+			{/* @ts-expect-error — numeric HTML attributes reject nonnumeric text */}
+			<main tabindex="first" />
+			{/* @ts-expect-error — lowercase aliases preserve their enumerated values */}
+			<button popovertargetaction="expand" />
+			{/* @ts-expect-error — lowercase aliases preserve enter-key-hint tokens */}
+			<main enterkeyhint={String('send')} />
+			{/* @ts-expect-error — lowercase aliases preserve input-mode tokens */}
+			<main inputmode="latin" />
+			{/* @ts-expect-error — spellcheck accepts booleans and boolean strings only */}
+			<main spellcheck="perhaps" />
+			{/* @ts-expect-error — lowercase aliases preserve referrer-policy values */}
+			<a referrerpolicy="always" />
+			{/* @ts-expect-error — command invoker attributes belong to buttons */}
+			<div command="show-modal" />
+			{/* @ts-expect-error — SVG attribute names remain case sensitive */}
+			<svg viewbox="0 0 10 10" />
+			{/* @ts-expect-error — autoFocus is a mount action, not a native boolean attribute */}
+			<input autofocus />
+			{/* @ts-expect-error — controlled defaults are React/Octane props, not attributes */}
+			<input defaultvalue="value" />
+			{/* @ts-expect-error — controlled defaults are React/Octane props, not attributes */}
+			<input defaultchecked />
+			{/* @ts-expect-error — warning hints are framework props, not attributes */}
+			<div suppresshydrationwarning />
+			{/* @ts-expect-error — native delegated events keep their onClick spelling */}
+			<button onclick={() => {}} />
+			{/* @ts-expect-error — htmlFor's native spelling is `for`, never `htmlfor` */}
+			<label htmlfor="field" />
+			{/* @ts-expect-error — acceptCharset's native spelling is `accept-charset` */}
+			<form acceptcharset="utf-8" />
+			{/* @ts-expect-error — httpEquiv's native spelling is `http-equiv` */}
+			<meta httpequiv="refresh" />
+			<button aria-pressed="mixed" />
+			<input aria-checked={true} />
+			{/* @ts-expect-error — ARIA token unions must reject widened arbitrary strings */}
+			<button aria-pressed={String(true)} />
+			{/* @ts-expect-error — ARIA token unions must reject widened arbitrary strings */}
+			<input aria-checked={String(false)} />
 			<div dangerouslySetInnerHTML={{ __html: '<b>x</b>' }} suppressHydrationWarning />
 			<input defaultValue="a" defaultChecked />
 			<div data-testid="anything" aria-hidden="true" />


### PR DESCRIPTION
## Summary

Octane accepts native HTML attribute names at runtime, but its JSX intrinsic types were derived mainly from React's camelCase property names. Strict `.tsrx` typechecking therefore rejected valid native spellings such as `tabindex`, `readonly`, `autocomplete`, `novalidate`, and `popovertarget`. Native-change diagnostics also missed readonly controls when authored with the native spelling.

- Derive native lowercase HTML aliases from existing per-element types while preserving React spellings, strict enumerated values, typed form actions, consumer module augmentations, and existing lowercase-name precedence. Native numeric attributes also accept numeric strings.
- Support button `command`/`commandfor` with augmentation-aware types, and add SVG `hidden`/`tabindex` without relaxing case-sensitive SVG attributes.
- Preserve intentional exclusions: lowercase event handlers, `autofocus`, controlled defaults, warning hints, and aliases whose actual native spelling is hyphenated. ARIA token validation remains strict.
- Recognize both `readonly` and `readOnly` in native-change diagnostics, honoring authored attribute order and static/dynamic boolean semantics.
- Add positive/negative JSX type regressions, readonly compiler coverage for inputs and textareas, and an `octane` patch changeset. Independently audited 1,341 intrinsic attributes across ten mixed-renderer consumer modules.

## Validation

- [x] `pnpm format:check`
- [ ] `pnpm typecheck` — the full monorepo gate cannot complete in this checkout because unrelated `@octanejs/dropzone` dependencies are unavailable; the changed Octane package and strict JSX declarations pass the targeted checks below.
- [ ] `pnpm test` — the complete monorepo suite was not run; Octane compiler and affected runtime/integration suites pass below.
- [x] targeted tests:
  - `./node_modules/.bin/tsgo --noEmit -p packages/octane/tsconfig.json`
  - `./node_modules/.bin/tsgo --noEmit -p packages/octane/typetests/tsconfig.json`
  - `./node_modules/.bin/tsc --noEmit -p packages/octane/typetests/tsconfig.json --skipLibCheck false`
  - `./node_modules/.bin/vitest run packages/octane/tests/compiler --reporter=dot --silent=passed-only` — 36 files, 1,145 tests passed.
  - `./node_modules/.bin/vitest run packages/octane/tests/native-change-runtime-diagnostic.test.ts packages/octane/tests/conformance/hyphenated-svg-attributes.test.ts --reporter=dot --silent=passed-only` — 4 files, 30 tests passed.
  - `pnpm --filter octane build`
  - `pnpm changeset:check`
  - `pnpm sync`

## Risk / follow-ups

- Runtime writes, SSR output, and attribute coercion are unchanged; the compiler change corrects readonly classification for native-change warnings.
- `autoFocus` remains commit-phase-only and invalid lowercase `autofocus` stays rejected; ARIA and enumerated attributes remain validated.
- Mixed React/Octane consumers must preserve `@jsxImportSource octane` in generated TSX and address remaining application-level diagnostics.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Octane’s public JSX intrinsic type surface and native-change warning classification. Runtime attribute behavior is unchanged, but incorrect consumer typings or mixed `readOnly`/`readonly` authorship can surface new diagnostics.
> 
> **Overview**
> **JSX types now accept native HTML attribute spellings** alongside React camelCase names (`tabindex`, `readonly`, `autocomplete`, `novalidate`, etc.), including numeric attributes as numeric strings. Framework-only props, lowercase event handlers, and hyphenated aliases (`htmlfor`, `acceptcharset`) stay rejected; SVG stays case-sensitive except for explicit `hidden` and `tabindex`.
> 
> Also types button `command`/`commandfor` in an augmentation-aware way.
> 
> **Native-change diagnostics** now treat `readonly` as equivalent to `readOnly`, using the last authored spelling when both appear, so readonly text inputs/textareas no longer get false `onChange` warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8503bfe7228384753ed882007ca82e92bf3299e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->