### PR TITLE
test: disposition all 121 planned ReactDOMFloat parity cases with executable evidence

### DIFF
--- a/.changeset/float-evidence-tranche.md
+++ b/.changeset/float-evidence-tranche.md
@@ -1,0 +1,20 @@
+---
+'octane': patch
+---
+
+React Float conformance evidence, plus two small fixes it surfaced.
+
+The 121 planned `ReactDOMFloat-test.js` parity-ledger cases are all
+dispositioned: 59 now carry executable adapted evidence (41 newly ported
+conformance tests across three suites plus links into the existing Float/hint
+suites), 54 are documented non-goals/divergences with per-case rationale
+(suspensey commits, whole-document containers, Fizz bootstrap/external-runtime
+protocol, `<img>`-preload scanning, SuspenseList, shadow-root scoping,
+streamed-boundary head content), and 7 stay planned against two newly-filed
+engine gaps and three warning-message families.
+
+Fixes: the document-metadata hoist partition is now HTML-scoped — nothing
+hoists from an SVG lexical context (a precedence link inside `<svg>` no longer
+becomes a stylesheet resource; `foreignObject` re-enters the HTML rules) — and
+`preinitModule` with an invalid `as` now warns in development as documented
+instead of failing silently.

--- a/.changeset/float-evidence-tranche.md
+++ b/.changeset/float-evidence-tranche.md
@@ -10,8 +10,9 @@ conformance tests across three suites plus links into the existing Float/hint
 suites), 54 are documented non-goals/divergences with per-case rationale
 (suspensey commits, whole-document containers, Fizz bootstrap/external-runtime
 protocol, `<img>`-preload scanning, SuspenseList, shadow-root scoping,
-streamed-boundary head content), and 7 stay planned against two newly-filed
-engine gaps and three warning-message families.
+streamed-boundary head content), and 8 stay planned against two newly-filed
+engine gaps, three warning-message families, and server-side hoistable
+prioritization ordering.
 
 Fixes: the document-metadata hoist partition is now HTML-scoped — nothing
 hoists from an SVG lexical context (a precedence link inside `<svg>` no longer

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -608,10 +608,15 @@ React Float **resources** are supported with React's semantics:
 - Classification is static: a spread-carried `precedence`/`async` keeps the
   ordinary element path, matching the compile-time head-hoist model.
 - React's hoist EXCLUSIONS apply: `itemProp`-bearing `<meta>`/`<link>` stay
-  with their `itemScope` host, and metadata/resources that are direct children
+  with their `itemScope` host; metadata/resources that are direct children
   of `<noscript>` stay in the fallback content (one nesting level today —
   metadata wrapped in a further host INSIDE `<noscript>` still hoists; a
-  documented bound, not a contract).
+  documented bound, not a contract); and nothing hoists from an SVG lexical
+  scope (`foreignObject` children re-enter the HTML rules). One template-model
+  bound: `<meta>` inside `<svg>` on a pure client mount is relocated by the
+  HTML parser's foreign-content breakout rules — it still never becomes
+  document metadata, but it cannot be kept inside the `<svg>` the way React's
+  imperative element construction keeps it. SSR serializes it inline correctly.
 
 Out of scope, deliberately: **suspensey commits** (React's
 suspend-until-the-stylesheet-loads behavior; Octane inserts the sheet and

--- a/docs/react-parity-coverage.md
+++ b/docs/react-parity-coverage.md
@@ -85,8 +85,8 @@ Every concrete case in either pinned inventory has exactly one ledger dispositio
 
 | Baseline | Cases | Untriaged | Planned | In progress | Covered | Documented | Blocked |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| stable | 5,345 | 0 | 1,980 | 0 | 913 | 2,452 | 0 |
-| canary | 5,413 | 0 | 2,027 | 0 | 970 | 2,416 | 0 |
+| stable | 5,345 | 0 | 1,876 | 0 | 968 | 2,501 | 0 |
+| canary | 5,413 | 0 | 1,914 | 0 | 1,029 | 2,470 | 0 |
 
 Classifications are `portable`, `adaptable`, `divergence`, and `non_goal`. A covered case requires live local test evidence; divergence and non-goal dispositions require a rationale.
 

--- a/packages/octane/audit/react-conformance-ledger.json
+++ b/packages/octane/audit/react-conformance-ledger.json
@@ -249,15 +249,15 @@
     },
     {
       "caseId": "react-case-v1:00a78bfb4d2abbbdc096",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "warns if you render <meta> tag with itemProp outside <body> or <head>",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "The warning fires for <meta itemProp> rendered as a child of <html> under createRoot(document) \u2014 a whole-document scenario; Octane's itemProp hoist exclusion itself is evidenced in hydration/hoist-exclusions.test.ts."
     },
     {
       "caseId": "react-case-v1:00b914b50cd9fa6856d3",
@@ -345,15 +345,15 @@
     },
     {
       "caseId": "react-case-v1:00fbbe739f56cbdca44a",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "delays \"forwards\" SuspenseList rows until the css of previous rows have completed",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "SuspenseList is documented not-implemented by design, and the row-reveal gating on css load is suspensey semantics that are also out of scope."
     },
     {
       "caseId": "react-case-v1:010ca2e32e6a1537da5c",
@@ -1224,15 +1224,15 @@
     },
     {
       "caseId": "react-case-v1:03561dbbc985d8f85eda",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "emits an implicit <head> element to hold resources when none is rendered but an <html> is rendered",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Asserts exact Fizz chunk bytes for an implicit <head> in a whole-document stream, gated on external-runtime and blocking-render flags \u2014 whole-document rendering plus Fizz bootstrap options, both standing non-goals."
     },
     {
       "caseId": "react-case-v1:0364edc9f939a8a65f45",
@@ -1945,15 +1945,15 @@
     },
     {
       "caseId": "react-case-v1:05ad704d75ea2ec31ea4",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can promote images to high priority when at least one instance specifies a high fetchPriority",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Image fetchPriority promotion across rendered <img> instances only exists inside Fizz's img-preload queue, which Octane does not implement."
     },
     {
       "caseId": "react-case-v1:05ba4e9e4f2802d6745c",
@@ -5340,15 +5340,15 @@
     },
     {
       "caseId": "react-case-v1:10aa421752894cf2d9d8",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can render a title before a singleton even if that singleton clears its contents",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "A title rendered before an <html> singleton whose mount clears its contents \u2014 whole-document/singleton semantics Octane does not have (roots require an Element)."
     },
     {
       "caseId": "react-case-v1:10ae6c6dfc0d105e997f",
@@ -5873,15 +5873,15 @@
     },
     {
       "caseId": "react-case-v1:1306a9a698aa563b8c5d",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "retains styles even when a new html, head, and/body mount",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Requires hydrateRoot(document, <html>\u2026) with fresh <html>/<head>/<body> singleton mounts; Octane roots require an Element and whole-document/singleton rendering is a standing non-goal. Resource retention itself is evidenced (float-resources 'resources persist after unmount\u2026')."
     },
     {
       "caseId": "react-case-v1:1306ba5d1db00f86fe12",
@@ -7080,7 +7080,7 @@
     },
     {
       "caseId": "react-case-v1:1750377497ae9baf46e4",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "creates a stylesheet resource in the ownerDocument when ReactDOM.preinit(..., {as: \"style\" }) is called outside of render on the client",
@@ -7088,7 +7088,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Adapted to an element-rooted container (Octane roots require an Element; whole-document roots are a standing non-goal): a preinit issued outside render, from an effect, still targets document.head and joins the precedence groups.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "preinit(as style) from an effect inserts the stylesheet into document.head",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:1755b9dc63d932c1fb22",
@@ -7431,7 +7438,7 @@
     },
     {
       "caseId": "react-case-v1:18ce05d1cdc2efff5314",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "warns if you provide invalid arguments",
@@ -7439,7 +7446,19 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "preloadModule's invalid-href triggers (undefined, empty, non-string) dev-warn and no-op with adapted messages; invalid option SHAPES (boolean options, boolean as) are handled leniently in Octane \u2014 the tag still inserts and no diagnostic fires \u2014 so the options-shape warnings remain a diagnostics gap noted for the ledger.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "module hints dev-warn on invalid hrefs and stay no-ops",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "valid hrefs still insert",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:18d5508d7c654e2e2e66",
@@ -9177,7 +9196,7 @@
     },
     {
       "caseId": "react-case-v1:1e7caf23a7a35460d845",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "hoists late stylesheets the correct precedence",
@@ -9185,7 +9204,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Adapted: statically-declared stylesheets inside boundaries still PENDING at shell time flush with the shell head in normalized precedence groups (preinit preset group included) and later segment reveals add no duplicate tags; the load-gated client reveal half is suspensey (non-goal), and dynamically-discovered late resources are a confirmed gap (see defer cases).",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-1.test.ts",
+          "testName": "streaming folds pending-boundary stylesheets into the shell head precedence groups",
+          "modes": ["production-compile", "server-stream"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:1e7d7749554c1f75e705",
@@ -11062,7 +11088,7 @@
     },
     {
       "caseId": "react-case-v1:2460591809287aa8d139",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "supports fetchPriority",
@@ -11070,7 +11096,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "fetchpriority serializes on preload links, preinit stylesheets, and preinit scripts on both client and server; one test covers the duplicate-titled upstream cases at :6172 (preload) and :6930 (preinit), which the inventory pinned to one line.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "supports fetchPriority on preload and preinit, client and server",
+          "modes": ["client", "server-string", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:248be3b5b978eca1d7a0",
@@ -11673,7 +11706,7 @@
     },
     {
       "caseId": "react-case-v1:26a9727e648ecf87fa3b",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "escapes hrefs when selecting matching elements in the document when rendering Resources",
@@ -11681,7 +11714,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Quote/backslash hrefs dedupe by exact attribute value (Octane keys resources in Sets rather than interpolating hrefs into querySelector) and SSR serializes the escaped attribute exactly once.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-3.test.ts",
+          "testName": "matches rendered stylesheet resources whose hrefs contain selector metacharacters",
+          "modes": ["client", "server-string", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:26c0d74ae4d1acb7b9f7",
@@ -12972,7 +13012,7 @@
     },
     {
       "caseId": "react-case-v1:2b21c741e8c797d4c02f",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "should handle referrerPolicy on image preload",
@@ -12980,11 +13020,18 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "referrerpolicy serializes on responsive image preloads (with the fallback href omitted) through both the client DOM insert and the server head fold.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "serializes referrerPolicy on image preloads on the client and the server",
+          "modes": ["client", "server-string", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:2b28be342e90e29eed37",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "creates a script module resources",
@@ -12992,7 +13039,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Ports the deltas (explicit as: script, integrity option) \u2014 the plain/crossOrigin/invalid-as arms are already pinned by resource-hints.test.ts ('preinitModule inserts one deduped async module script; non-script destinations no-op' and 'module hints fold into head output and share the client dedupe key'). React-exact warning text is not asserted (Octane's malformed-hint diagnostics use its own wording).",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-3.test.ts",
+          "testName": "creates script module resources with explicit `as` and `integrity` options",
+          "modes": ["client", "server-string", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:2b33a86654d699866ce3",
@@ -13118,15 +13172,15 @@
     },
     {
       "caseId": "react-case-v1:2b8c2dd5d9bde68daad1",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "still outlines a boundary with a suspensey image inside a ViewTransition when flushing the shell",
       "baselines": ["canary"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Canary-only (facebook/react@b740af25:9933): boundary OUTLINING driven by a suspensey image inside a ViewTransition is Fizz suspend-until-loaded machinery; suspensey commits are a documented Octane non-goal."
     },
     {
       "caseId": "react-case-v1:2bc3b688c85829336e35",
@@ -14500,19 +14554,19 @@
     },
     {
       "caseId": "react-case-v1:31094af873320f767a52",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can send style insertion implementation independent of boundary commpletion instruction implementation",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Pins the independence of Fizz's style-insertion vs boundary-completion instruction implementations (renderer-internal streaming protocol) with a load-gated reveal; Octane's stream protocol has no such split and suspensey reveals are out of scope."
     },
     {
       "caseId": "react-case-v1:310b8c5bae5d185cc3e5",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "accepts an `integrity` option for `as: \"style\"`",
@@ -14520,7 +14574,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "preinit(as: style) integrity lands on the precedence-marked stylesheet link on both sides.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-3.test.ts",
+          "testName": "accepts an `integrity` option for as: \"style\"",
+          "modes": ["client", "server-string", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:310dcb8ce861307e6320",
@@ -15243,7 +15304,7 @@
     },
     {
       "caseId": "react-case-v1:33096a25bc8fbe929397",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "supports fetchPriority",
@@ -15251,7 +15312,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Duplicate-titled 'supports fetchPriority' entry (see react-case-v1:2460591809287aa8d139); the single ported test covers both the preload (:6172) and preinit (:6930) upstream variants.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "supports fetchPriority on preload and preinit, client and server",
+          "modes": ["client", "server-string", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:330abddefc633d58d84d",
@@ -16726,15 +16794,15 @@
     },
     {
       "caseId": "react-case-v1:37963147cdbe19bdf083",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "warns if you render a <title> tag with itemProp outside <body> or <head>",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Same whole-document scenario as react-case-v1:00a78bfb4d2abbbdc096, for <title itemProp>."
     },
     {
       "caseId": "react-case-v1:379c5027c3ffc10302ed",
@@ -17135,7 +17203,7 @@
     },
     {
       "caseId": "react-case-v1:390d5e656eec6583357b",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "creates a script resource when ReactDOM.preinit(..., {as: \"script\" }) is called outside of render on the client",
@@ -17143,7 +17211,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "preinit from a useEffect (outside render) inserts the deduped async script into document.head; whole-document container replaced by an element root per Octane's root contract.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-3.test.ts",
+          "testName": "creates a script resource when preinit(as: \"script\") runs outside render, in an effect",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:3912e5568d0b006b0c1a",
@@ -17243,7 +17318,7 @@
     },
     {
       "caseId": "react-case-v1:393fa48c2668d926efcd",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "does not preload nomodule scripts",
@@ -17251,7 +17326,19 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "The async nomodule script is still a hoisted resource carrying nomodule/data attributes, the sync form stays an ordinary in-place element, and no preload/modulepreload is emitted on either path.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-1.test.ts",
+          "testName": "server: nomodule scripts hoist (async) or stay in place (sync) without preloads",
+          "modes": ["client", "server-string", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-1.test.ts",
+          "testName": "client: nomodule scripts hoist (async) or stay in place (sync) without preloads",
+          "modes": ["client", "server-string", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:393ff8e2e3635e811478",
@@ -17675,7 +17762,7 @@
     },
     {
       "caseId": "react-case-v1:3a363ca15c414aac909b",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "supports nonce",
@@ -17683,7 +17770,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "nonce serializes on preload links through the client insert and the server head fold; Octane has no container-scoped hoisting, so the upstream's container-rooted SSR placement nuance does not apply.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "supports nonce on preload, client and server",
+          "modes": ["client", "server-string", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:3a38796719cb655d2ef3",
@@ -18060,15 +18154,15 @@
     },
     {
       "caseId": "react-case-v1:3b805bf8caa2cd528bad",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can suspend commits on more than one root for the same resource at the same time",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Suspending commits on multiple roots for one loading resource is suspensey commit machinery, documented out of scope."
     },
     {
       "caseId": "react-case-v1:3b8d91cf517609852355",
@@ -18505,7 +18599,7 @@
     },
     {
       "caseId": "react-case-v1:3d70fb8b1964d3d89323",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "preloads scripts as modules",
@@ -18513,7 +18607,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "modulepreload creation, href dedupe, crossOrigin/integrity carriage, and non-default `as` (serviceworker) are pinned client and server; adaptation not asserted: Octane serializes as=\"script\" when the default destination is passed explicitly where React omits the attribute (functionally identical destination).",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "preloads scripts as modules with cors, integrity, and non-default destinations",
+          "modes": ["client", "server-string", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:3d7170532ba17f2582fa",
@@ -18743,15 +18844,15 @@
     },
     {
       "caseId": "react-case-v1:3e54cbd6e5b3ef4fea8b",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "supports rendering hoistables outside of <html> scope",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Renders hoistables as siblings OF the <html> element itself; whole-document rendering (an <html>-rooted client tree in `document`) is a standing non-goal \u2014 Octane roots require an Element."
     },
     {
       "caseId": "react-case-v1:3e560d91993c90c0224f",
@@ -19237,7 +19338,7 @@
     },
     {
       "caseId": "react-case-v1:3f7a77563bfd61f450bb",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can hoist title tags on the client",
@@ -19245,7 +19346,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Client mount hoists the title into document.head (body stays clean), updates it in place, and removes it on unmount.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/svg-title-hoist.test.ts",
+          "testName": "preserves head hoisting when an opaque component chooses HTML",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:3f7fe4c97a6aed9b1856",
@@ -20583,7 +20691,7 @@
     },
     {
       "caseId": "react-case-v1:4436593d1f5656ef4452",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "encodes attributes consistently whether resources are flushed in shell or in late boundaries",
@@ -20591,7 +20699,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Adapted: Octane's two live emit paths (SSR head fold and client insert) serialize options through canonical lowercase attributes with identical values, escape quoted data-* values, and never leak authoring-side names; the upstream shell-vs-late-boundary comparison has no second path yet (same late-resource gap as the defer cases).",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-1.test.ts",
+          "testName": "server and client emit paths encode resource attributes identically",
+          "modes": ["client", "server-string", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:44439323b5d66455f641",
@@ -20655,7 +20770,12 @@
       "evidence": [
         {
           "file": "packages/octane/tests/static-prerender-stream.test.ts",
-          "testName": "resolves only after every use(thenable) settles; prelude carries the full document",
+          "testName": "resolves only after every use(thenable) settles",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/static-prerender-stream.test.ts",
+          "testName": "prelude carries the full document",
           "modes": ["client", "production-compile"]
         }
       ]
@@ -21822,15 +21942,15 @@
     },
     {
       "caseId": "react-case-v1:487174bc24da09b71fb2",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can render resources before singletons",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Renders <html>/<head>/<body> singletons through createRoot(document); whole-document rendering is a standing non-goal (Octane roots require an Element)."
     },
     {
       "caseId": "react-case-v1:4874a86869389130fd19",
@@ -23504,15 +23624,15 @@
     },
     {
       "caseId": "react-case-v1:4d8b0c38bc33607b00c4",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "omits preloads for images inside noscript tags",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Vacuous: 'omits preloads for images inside noscript' only constrains the rendered-<img> preload emission feature Octane does not implement; the noscript hoist exclusion itself is evidenced in tests/hydration/hoist-exclusions.test.ts."
     },
     {
       "caseId": "react-case-v1:4d9e6fdf126f0e3ce144",
@@ -23813,7 +23933,7 @@
     },
     {
       "caseId": "react-case-v1:4efdb0c6e62fbfda83ac",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can hoist link (non-stylesheet) tags on the client",
@@ -23821,7 +23941,19 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "The PlainLink control pins the client contract for non-stylesheet links: hoisted into document.head on mount, removed on unmount.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/float-resources.test.ts",
+          "testName": "resources persist after unmount",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/float-resources.test.ts",
+          "testName": "per-site links (no precedence) are removed",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:4f0c5269b5f45f2adf9e",
@@ -24184,19 +24316,19 @@
     },
     {
       "caseId": "react-case-v1:507b6b1070a49113c192",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "warns if you render a <style> tag with itemProp outside <body> or <head>",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Same whole-document scenario as react-case-v1:00a78bfb4d2abbbdc096, for <style itemProp>."
     },
     {
       "caseId": "react-case-v1:50833c45034144adb0e7",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "retains styles even after the last referring Resource unmounts",
@@ -24204,7 +24336,19 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "The last referring component unmounts (via @if arm flip) and the stylesheet resource stays in document.head.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/float-resources.test.ts",
+          "testName": "resources persist after unmount",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/float-resources.test.ts",
+          "testName": "per-site links (no precedence) are removed",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:508da804f9321b29912c",
@@ -24323,15 +24467,15 @@
     },
     {
       "caseId": "react-case-v1:50f8261c6066395dbab0",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can hoist styles flushed early even when no other style dependencies are flushed on completion",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "divergence",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Same Fizz early-flush/hoist-on-reveal choreography; covered by the documented streamed-boundary head divergence (client re-creation on hydration)."
     },
     {
       "caseId": "react-case-v1:50fc9bcb2a25e7292757",
@@ -24536,15 +24680,15 @@
     },
     {
       "caseId": "react-case-v1:5194dd5060e69e68d6a5",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can avoid inserting a late stylesheet if it already rendered on the client",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Document-root hydration whose observable is a load-gated suspensey reveal skipping an already-inserted sheet; the durable non-suspensey half (a hydrating client dedupes against SSR-emitted resources) is already evidenced by float-resources.test.ts 'a hydrating client call dedupes against SSR-emitted resources'."
     },
     {
       "caseId": "react-case-v1:51a465b344f54da722b7",
@@ -25741,7 +25885,7 @@
     },
     {
       "caseId": "react-case-v1:55934c33833df996dd04",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "does not create stylesheet resources when inside an <svg> context",
@@ -25749,7 +25893,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Adapted executable evidence: SVG-scoped link/meta stay inline on client and server (hoist partition is HTML-scoped; foreignObject re-enters).",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/hydration/hoist-exclusions.test.ts",
+          "testName": "client + server: SVG-scoped link/meta stay inline, never resources",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:559536f25e2b5142c631",
@@ -25886,7 +26037,7 @@
     },
     {
       "caseId": "react-case-v1:56501a2dc01d9068f364",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can hoist title tags on the server and hydrate them on the client",
@@ -25894,7 +26045,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "SSR folds the title into the head output; hydration adopts the server title without duplication and unmount removes it.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/hydration/head-hydrate.test.ts",
+          "testName": "adopts the server head and single-root body, then removes owned nodes on unmount",
+          "modes": ["server-string", "hydrate-match", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:566c044a1c0ff156be86",
@@ -26223,7 +26381,7 @@
     },
     {
       "caseId": "react-case-v1:57afb7841116e6645ca8",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "does not flush hoistables for fallbacks",
@@ -26231,7 +26389,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "While the pending fallback is showing, fallback-authored <meta>/<link> never reach the streamed head fold and the primary content's metadata does; covers the upstream inline-fallback shapes \u2014 the nested-completed-boundary shape is case 21f48ce0 (deferred with a finding).",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "does not flush fallback-authored hoistables into the head",
+          "modes": ["server-stream", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:57b0eb1d6cb14bc93bd8",
@@ -26266,15 +26431,15 @@
     },
     {
       "caseId": "react-case-v1:57e1083c14de250e9799",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "preloads up to 10 suspensey images as high priority when fetchPriority is not specified",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Exercises Fizz's 10-slot high-priority image preload queue, part of the rendered-<img> preload transport machinery Octane does not implement."
     },
     {
       "caseId": "react-case-v1:57ecff0e6cfa5dd041e3",
@@ -26690,15 +26855,15 @@
     },
     {
       "caseId": "react-case-v1:59483c9d3692cd2442fa",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can hydrate resources and components in the head and body even if a browser or 3rd party script injects extra html nodes",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "hydrateRoot(document) whole-document stress test; Octane's tolerance of foreign injected nodes during head adoption is separately evidenced (hydration/head-hydrate.test.ts 'skips an interposed foreign element and adopts the intended head element')."
     },
     {
       "caseId": "react-case-v1:59620db8acc96c43bbaf",
@@ -27293,7 +27458,7 @@
     },
     {
       "caseId": "react-case-v1:5ad3bd7f54fc7ed78ae2",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "creates a preload resource when called",
@@ -27301,7 +27466,19 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Preloads issued from render, useInsertionEffect, useLayoutEffect, and useEffect all insert; font preloads carry type and enforced crossorigin=\"\"; the SSR head fold with dedupe was already evidenced by resource-hints.test.ts 'render-time hints fold into the head output, deduped'.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "preload works from render, insertion, layout, and passive effects",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "font preloads carry type and anonymous CORS",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:5ad679ad5ccddfc9be1e",
@@ -28431,15 +28608,15 @@
     },
     {
       "caseId": "react-case-v1:5ed8587fd5804bb6b890",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "assumes stylesheets that load in the shell loaded already",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Assuming shell-flushed stylesheets already loaded is suspensey load-state accounting, documented out of scope."
     },
     {
       "caseId": "react-case-v1:5edca3d12788408476e6",
@@ -28529,7 +28706,7 @@
     },
     {
       "caseId": "react-case-v1:5f384617669800aaca1f",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can hoist meta tags on the server and hydrate them on the client",
@@ -28537,7 +28714,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Plus nested-head 'hydration adopts the nested-metadata host without mismatch warnings' and head-hydrate 'adopts the server head and single-root body, then removes owned nodes on unmount' (meta adoption + unmount removal).",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/hydration/nested-head.test.ts",
+          "testName": "server-renders nested metadata into the head channel, not the host body",
+          "modes": ["server-string", "hydrate-match", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:5f4263829b4fa089e54a",
@@ -28675,7 +28859,7 @@
     },
     {
       "caseId": "react-case-v1:5f8d8627dcd5611cd75c",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "will not flush a preload for a new rendered Stylesheet Resource if one was already flushed",
@@ -28683,7 +28867,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Streamed render: a shell preload plus a stylesheet resource discovered inside a suspended boundary yield exactly one preload and one stylesheet tag for the href; Octane's per-round pass even ships both in the shell head.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "never flushes a second preload when a rendered stylesheet resource follows a preload",
+          "modes": ["server-stream", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:5f9891786af2bc264fe2",
@@ -28711,7 +28902,7 @@
     },
     {
       "caseId": "react-case-v1:5fa712dd333b53e8a7af",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can update title tags",
@@ -28719,7 +28910,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Re-rendering updates the SAME hoisted head title element's text and data attribute (identity preserved); unmount removes it. Extends the text-only update already evidenced in svg-title-hoist.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-3.test.ts",
+          "testName": "updates hoisted title text and attributes in place",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:5fa7331d11e95da89dcf",
@@ -28963,7 +29161,7 @@
     },
     {
       "caseId": "react-case-v1:6020dc34c135975771ab",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can hydrate non Resources in head when Resources are also inserted there",
@@ -28971,7 +29169,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Adapted off the <html> container onto Octane's metadata hoist: hoisted title/meta adopt (same nodes, no duplicates) while stylesheet/script resources dedupe against the SSR head, no mismatch warnings, and unmount removes metadata but retains resources.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-1.test.ts",
+          "testName": "hydration adopts hoisted non-resource head elements alongside inserted resources",
+          "modes": ["server-string", "hydrate-match", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:6027b5440854c4972b0d",
@@ -29030,7 +29235,7 @@
     },
     {
       "caseId": "react-case-v1:605940bee5daa10a0569",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "treats link rel stylesheet elements as a stylesheet resource when it includes a precedence when client rendering",
@@ -29038,7 +29243,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Client rendering creates the data-precedence link in document.head and leaves no trace in the body; the upstream load-event choreography is suspensey-commit machinery (documented out of scope).",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/float-resources.test.ts",
+          "testName": "a precedence stylesheet hoists to head and dedupes by href across components",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:60598e13a18ff6ad01fa",
@@ -29636,15 +29848,15 @@
     },
     {
       "caseId": "react-case-v1:62941a5417d62021fddc",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "Does not preload lazy images",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Vacuous without the rendered-<img> preload feature: Octane emits no image preloads for rendered <img> at all, lazy or otherwise."
     },
     {
       "caseId": "react-case-v1:6299d7fd55b4576a669d",
@@ -30647,15 +30859,15 @@
     },
     {
       "caseId": "react-case-v1:65e602d01af93444daf2",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "does not wait for stylesheets of completed fallbacks",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "The observable is reveal gating on stylesheet LOAD state for completed-vs-pending fallbacks \u2014 suspensey stylesheet semantics that are documented out of scope (Octane inserts the sheet and continues)."
     },
     {
       "caseId": "react-case-v1:6601243ae89e03a46e27",
@@ -31523,15 +31735,15 @@
     },
     {
       "caseId": "react-case-v1:692ac4cb1b79b8f8769b",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can interrupt a suspended commit with a new update",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Interrupting a suspended (load-blocked) commit with a new update is suspensey commit machinery, documented out of scope."
     },
     {
       "caseId": "react-case-v1:692ffed6347306b9faaf",
@@ -31803,7 +32015,7 @@
     },
     {
       "caseId": "react-case-v1:69df4b879e0039f0c6af",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "does not hoist inside an <svg> context",
@@ -31811,7 +32023,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Adapted executable evidence: nothing hoists from an SVG lexical scope on client or server (foreignObject re-enters the HTML rules); the <meta>-in-svg client-mount parser bound is documented in differences-from-react.md.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/hydration/hoist-exclusions.test.ts",
+          "testName": "client + server: SVG-scoped link/meta stay inline, never resources",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:69e2490e5dbadc9899c4",
@@ -32368,15 +32587,15 @@
     },
     {
       "caseId": "react-case-v1:6bca0e56c295fbb1ae89",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can delay commit until css resources load",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Delaying commit until css resources load is the suspensey commit contract, documented out of scope (Octane inserts the sheet and continues)."
     },
     {
       "caseId": "react-case-v1:6bdfc01329e81fb0f2da",
@@ -32967,15 +33186,15 @@
     },
     {
       "caseId": "react-case-v1:6e2f56e15928caf22279",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can interrupt a suspended commit with a new transition",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Interrupting a suspended (load-blocked) commit with a new transition is suspensey commit machinery, documented out of scope."
     },
     {
       "caseId": "react-case-v1:6e34762e4736dd5d7fb9",
@@ -32991,7 +33210,7 @@
     },
     {
       "caseId": "react-case-v1:6e3ec2966822a7cff252",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "supports fetchPriority",
@@ -32999,7 +33218,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Duplicate-titled 'supports fetchPriority' entry (see react-case-v1:2460591809287aa8d139); the single ported test covers both the preload (:6172) and preinit (:6930) upstream variants.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "supports fetchPriority on preload and preinit, client and server",
+          "modes": ["client", "server-string", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:6e47747f42a0e0955c17",
@@ -33087,7 +33313,7 @@
     },
     {
       "caseId": "react-case-v1:6e8377a7553ed45e0994",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "normalizes stylesheet resource precedence for all boundaries inlined as part of the shell flush",
@@ -33095,7 +33321,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Resources from nested non-suspended boundaries inlined in one pass fold into the head in first-encounter group order with within-group discovery order, deduped, leaving no inline trace in the body.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-1.test.ts",
+          "testName": "SSR normalizes precedence across nested boundaries inlined in one pass",
+          "modes": ["server-string", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:6eabfdec2ac3a2ae1e1c",
@@ -33377,15 +33610,15 @@
     },
     {
       "caseId": "react-case-v1:6fd34f474262c2be574f",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "stylesheets block render, with a really long timeout",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Stylesheets blocking render behind a long suspensey timeout is suspend-until-loaded machinery, documented out of scope."
     },
     {
       "caseId": "react-case-v1:6fdc2c56111b73cf316d",
@@ -33761,15 +33994,15 @@
     },
     {
       "caseId": "react-case-v1:70fd1ee9621e7dc82517",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "will assume stylesheets already in the document have loaded if it cannot confirm it is not yet loaded",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Assuming unverifiable pre-existing stylesheets have loaded is suspensey load-state accounting, documented out of scope."
     },
     {
       "caseId": "react-case-v1:710ee02437f54eca682d",
@@ -33976,7 +34209,7 @@
     },
     {
       "caseId": "react-case-v1:71b4c0dd785f46b18953",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "does not create script resources when inside an <svg> context",
@@ -33984,7 +34217,19 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "An async script inside <svg><path> stays in its authored SVG position; the same script inside <foreignObject> becomes a head resource \u2014 client and SSR agree.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-3.test.ts",
+          "testName": "does not create script resources inside an <svg> context",
+          "modes": ["client", "server-string", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-3.test.ts",
+          "testName": "<foreignObject> re-enables hoisting",
+          "modes": ["client", "server-string", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:71b57e3ca32f2cca9d10",
@@ -34442,7 +34687,7 @@
     },
     {
       "caseId": "react-case-v1:735508160a9eb6b2f0dd",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "creates a stylesheet resource when ReactDOM.preinit(..., {as: \"style\" }) is called",
@@ -34450,7 +34695,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Render-position preinit creates one precedence-grouped stylesheet deduped across components; the suspended-boundary server behavior is pinned by the :4040 port in the same file, and the SSR shell preinit stylesheet was already evidenced by resource-hints.test.ts 'SSR mirrors the unified identity and image keying'.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "preinit(as style) during render creates one deduped stylesheet resource",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:73576a2fff28d8907d12",
@@ -34569,7 +34821,7 @@
     },
     {
       "caseId": "react-case-v1:73bbf38c530e37a96935",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "creates a dns-prefetch resource when called",
@@ -34577,7 +34829,19 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "dns-prefetch creation, dedupe, and SSR-to-client identity are pinned; React's prefetchDNS second-argument dev warnings have no Octane counterpart (extra arguments are ignored silently) \u2014 diagnostics remainder only.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/resource-hints.test.ts",
+          "testName": "preconnect and prefetchDNS insert their links once",
+          "modes": ["client", "server-string", "production-compile", "hydrate-match"]
+        },
+        {
+          "file": "packages/octane/tests/resource-hints.test.ts",
+          "testName": "a client call for an SSR-emitted hint is a no-op (shared dedupe key)",
+          "modes": ["client", "server-string", "production-compile", "hydrate-match"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:73c5b1202a2895382916",
@@ -34593,7 +34857,7 @@
     },
     {
       "caseId": "react-case-v1:73d8c2c7608e6a92c9c7",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "warns if you do not pass in a valid href argument or options argument",
@@ -34601,7 +34865,24 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "preload's malformed-argument trigger set (missing/empty href, missing as) dev-warns and no-ops with adapted Octane-branded messages \u2014 message-exactness is not Octane's diagnostics contract. Note: the inventory pinned both duplicate-title cases to line 6137; this entry is matched to the preload variant.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/resource-hints.test.ts",
+          "testName": "dev-warns on malformed options and stays a no-op",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/resource-hints.test.ts",
+          "testName": "unknown option keys are dropped",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/resource-hints.test.ts",
+          "testName": "non-string hrefs dev-warn and no-op",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:73dbbab4f2c3b2e242b6",
@@ -36238,15 +36519,15 @@
     },
     {
       "caseId": "react-case-v1:7a46543a23402eb1c581",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "suspends a transition on a stylesheet whose preload has not loaded yet",
       "baselines": ["canary"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Canary-only (b740af25:3726): suspending a transition until a stylesheet's preload loads is the suspensey commit contract, documented out of scope."
     },
     {
       "caseId": "react-case-v1:7a4e271b71b6cd81641f",
@@ -36574,15 +36855,15 @@
     },
     {
       "caseId": "react-case-v1:7b89aafd64f72bb8f6bd",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can delay commit until css resources error",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Delaying commit until css resources ERROR is suspensey commit machinery (upstream itself skips this test as crashing)."
     },
     {
       "caseId": "react-case-v1:7b94e58083fdc6d80440",
@@ -37494,7 +37775,7 @@
     },
     {
       "caseId": "react-case-v1:7e8405ab791760c81647",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "warns if you provide invalid arguments",
@@ -37502,7 +37783,19 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Matched to the preinitModule twin at upstream line 7113: invalid hrefs dev-warn and no-op; a non-script destination fails closed as a silent no-op in Octane (React warns) \u2014 the docs promise a dev warning for invalid `as` generally, so the silent fail-closed is flagged as a doc-vs-implementation nit for the parent.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "module hints dev-warn on invalid hrefs and stay no-ops",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "valid hrefs still insert",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:7e8660f6ebb8e46a9103",
@@ -37575,7 +37868,7 @@
     },
     {
       "caseId": "react-case-v1:7ecdbfd918ba196388bc",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can acquire a resource after releasing it in the same commit",
@@ -37583,7 +37876,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "An @if flip releases and re-acquires the same script src in one commit: one head script, same element identity, and the re-acquiring site's differing prop (data-new) is not applied \u2014 first instance wins.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-1.test.ts",
+          "testName": "re-acquiring a released script resource in one commit keeps the first instance",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:7ee065f3d4ec2d992bcf",
@@ -37644,15 +37944,15 @@
     },
     {
       "caseId": "react-case-v1:7ef742dc44fbc7b3f6ca",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "does not reinsert already inserted stylesheets during a delayed commit",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "The observable is reinsert-avoidance during a suspensey DELAYED commit; the non-suspensey dedupe half (SSR-inserted sheets adopted, not reinserted, by a hydrating client) is already evidenced by float-resources.test.ts."
     },
     {
       "caseId": "react-case-v1:7f0501ae9b908d4a748e",
@@ -37680,7 +37980,7 @@
     },
     {
       "caseId": "react-case-v1:7f1084e92402ad431889",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "does not create script resources when inside a <noscript> context",
@@ -37688,7 +37988,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "An async script inside <noscript> stays in the fallback content on client render and in SSR output; no head resource is created.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-3.test.ts",
+          "testName": "does not create script resources inside a <noscript> context",
+          "modes": ["client", "server-string", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:7f1401c39fe25aa2ffb0",
@@ -37922,7 +38229,7 @@
     },
     {
       "caseId": "react-case-v1:7fbb839fc5c2d6a15db4",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "will not flush a preload for a new preinitialized Stylesheet Resource if one was already flushed",
@@ -37930,7 +38237,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Documented divergence asserted with an OCTANE DIVERGENCE note: Fizz demotes a post-shell preinit to a preload; Octane's per-round pass discovers the preinit before the shell flushes and coalesces the redundant preload into the real resource \u2014 the shared contract (one fetch initiator per href) is pinned.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "a preinitialized stylesheet inside a suspended boundary keeps one initiator per href",
+          "modes": ["server-stream", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:7fc4956c7537857b98b2",
@@ -40859,15 +41173,15 @@
     },
     {
       "caseId": "react-case-v1:898a6c78d76ad9bea102",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "preloads from rendered images properly use srcSet and sizes",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Asserts srcSet/sizes keying of preloads EMITTED FOR RENDERED IMAGES \u2014 the emission feature Octane does not implement; the preload() srcset keying itself is evidenced separately (case 4148 port and resource-hints.test.ts)."
     },
     {
       "caseId": "react-case-v1:898fbdb9f634138849c5",
@@ -42564,15 +42878,15 @@
     },
     {
       "caseId": "react-case-v1:8f041739af78043fd7e0",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "delays \"together\" SuspenseList rows until the css of previous rows have completed",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "SuspenseList is documented not-implemented by design, and the row-reveal gating on css load is suspensey semantics that are also out of scope."
     },
     {
       "caseId": "react-case-v1:8f05d2324a5fc8e82066",
@@ -43707,7 +44021,7 @@
     },
     {
       "caseId": "react-case-v1:92ed49a5e826f3b8cbd8",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "accepts an `integrity` option for `as: \"script\"`",
@@ -43715,7 +44029,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "preinit integrity is serialized onto the script resource tag client-side and in the SSR head fold.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-3.test.ts",
+          "testName": "accepts an `integrity` option for as: \"script\"",
+          "modes": ["client", "server-string", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:93034c490d699a1bc890",
@@ -44743,7 +45064,12 @@
       "evidence": [
         {
           "file": "packages/octane/tests/float-resources.test.ts",
-          "testName": "SSR folds style resources into precedence groups; hydration seeds from data-href",
+          "testName": "SSR folds style resources into precedence groups",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/float-resources.test.ts",
+          "testName": "hydration seeds from data-href",
           "modes": ["client", "production-compile"]
         }
       ]
@@ -46521,15 +46847,15 @@
     },
     {
       "caseId": "react-case-v1:9ddca26e37245ce5d7ba",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "outlines a boundary with suspensey CSS when flushing a streamed completion",
       "baselines": ["canary"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Canary-only (b740af25:9831): outlining a boundary with suspensey CSS in a streamed completion is Fizz suspend-until-loaded machinery, documented out of scope."
     },
     {
       "caseId": "react-case-v1:9df07b5e18063b31e6f0",
@@ -46619,7 +46945,7 @@
     },
     {
       "caseId": "react-case-v1:9e4ec11310d225ae2412",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can hoist meta tags on the client",
@@ -46627,7 +46953,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Client mount hoists the meta into document.head, leaves the body clean, and removes it with its owning scope.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/hydration/nested-head.test.ts",
+          "testName": "client-only render mounts nested metadata into document.head, owned and removable",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:9e514a22fc637d9f7b87",
@@ -47847,7 +48180,7 @@
     },
     {
       "caseId": "react-case-v1:a24dadfddb7019db4e87",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can hoist link (non-stylesheet) tags on the server and hydrate them on the client",
@@ -47855,7 +48188,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "A rel=\"author\" link folds into the SSR head, is adopted by identity on hydration (no duplicate), and is removed on unmount.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-3.test.ts",
+          "testName": "hoists non-stylesheet link tags on the server and hydrates them on the client",
+          "modes": ["server-string", "hydrate-match", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:a250da8032a69b4d3fda",
@@ -47950,15 +48290,15 @@
     },
     {
       "caseId": "react-case-v1:a29109225af74596ee01",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "retains styles in head through head remounts",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Exercises <head key> singleton remounts inside a whole-document root; Octane has no <html>/<head>/<body> singleton rendering (roots require an Element)."
     },
     {
       "caseId": "react-case-v1:a29c04f283a5a0d4289c",
@@ -48452,15 +48792,15 @@
     },
     {
       "caseId": "react-case-v1:a44c1e1931d9ab7609c2",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "will put a Suspense boundary into fallback if it contains a stylesheet not loaded during a sync update",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Forcing a Suspense fallback because a sync update contains a not-yet-loaded stylesheet is suspensey commit machinery, documented out of scope."
     },
     {
       "caseId": "react-case-v1:a45e97c8bd15c56186d8",
@@ -48599,15 +48939,15 @@
     },
     {
       "caseId": "react-case-v1:a4aeece06c3f9b00ce0c",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can emit styles early when a partial boundary flushes",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "divergence",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Asserts Fizz partial-flush choreography (style emitted early with media=\"not all\" then flipped on reveal); Octane's documented streaming model ships no head content in boundary segments and flushes per resolution wave."
     },
     {
       "caseId": "react-case-v1:a4c0a41427f47efd07c5",
@@ -49030,7 +49370,7 @@
     },
     {
       "caseId": "react-case-v1:a63a07dadd99821dcb58",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "should preload only once even if you discover a stylesheet, script, or moduleScript late",
@@ -49038,7 +49378,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "The durable contract \u2014 one preload per identity and one executable/stylesheet per src across the preload/render forms with late boundary discovery \u2014 is asserted; Fizz's boundary-flush queue ordering (scripts-then-preloads into the body) is transport detail outside Octane's wave-based flush model.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "preloads only once per identity when stylesheets, scripts, and module scripts render late",
+          "modes": ["server-stream", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:a64cc53796ea86ead279",
@@ -49054,7 +49401,7 @@
     },
     {
       "caseId": "react-case-v1:a660f46c1ab7b47709da",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "preloads multiple non-script modules with the same as type",
@@ -49062,7 +49409,19 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Canary-only (b740af25:6596), body fetched from the pinned commit: two serviceworker modulepreloads with distinct hrefs emit two <link rel=modulepreload as=serviceworker>, deduped per href, on both the client and the server fold.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-1.test.ts",
+          "testName": "client: preloadModule keys per href, carrying a non-script as type",
+          "modes": ["client", "server-string", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-1.test.ts",
+          "testName": "server: preloadModule folds one modulepreload per href with the as type",
+          "modes": ["client", "server-string", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:a67eccb2b0562f3fe25f",
@@ -49508,15 +49867,15 @@
     },
     {
       "caseId": "react-case-v1:a806984682df39c1ec2c",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "warns if you render a <link> tag with itemProp outside <body> or <head>",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Same whole-document scenario as react-case-v1:00a78bfb4d2abbbdc096, for <link itemProp>."
     },
     {
       "caseId": "react-case-v1:a808dac25c951f7c6611",
@@ -49754,15 +50113,15 @@
     },
     {
       "caseId": "react-case-v1:a88d13d476986489c8b3",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "warns if you render resource-like elements above <head> or <body>",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Every scenario renders resource-like tags as direct children of <html> under createRoot(document); the diagnostic only exists for whole-document rendering, a standing non-goal."
     },
     {
       "caseId": "react-case-v1:a8944432b7e1877b9566",
@@ -50661,7 +51020,7 @@
     },
     {
       "caseId": "react-case-v1:ac0d3ea85db3648443d3",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "treats link rel stylesheet elements as a stylesheet resource when it includes a precedence when server rendering",
@@ -50669,7 +51028,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Also 'streamed shells carry deduped resources in the flushed head' \u2014 a precedence link server-renders as a head-folded stylesheet resource with data-precedence.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/float-resources.test.ts",
+          "testName": "SSR folds deduped, precedence-grouped resources into the head output",
+          "modes": ["server-string"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:ac100dedc6f49cc079d9",
@@ -51312,7 +51678,12 @@
       "evidence": [
         {
           "file": "packages/octane/tests/float-resources.test.ts",
-          "testName": "groups order by first encounter; later same-precedence sheets append to their group",
+          "testName": "groups order by first encounter",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/float-resources.test.ts",
+          "testName": "later same-precedence sheets append to their group",
           "modes": ["client", "production-compile"]
         }
       ]
@@ -51887,7 +52258,7 @@
     },
     {
       "caseId": "react-case-v1:b01cd31c349de6ab7ac6",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "should handle media on image preload",
@@ -51895,7 +52266,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "media serializes on responsive image preloads through both the client DOM insert and the server head fold.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "serializes media on image preloads on the client and the server",
+          "modes": ["client", "server-string", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:b0287a52a3890f2214a7",
@@ -52412,7 +52790,7 @@
     },
     {
       "caseId": "react-case-v1:b20111ef435ccabd4c27",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "creates a script resource when ReactDOM.preinit(..., {as: \"script\" }) is called",
@@ -52420,7 +52798,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Render-position preinit(as script) creates one async head script deduped by src and retained after unmount; the suspended-boundary server behavior is pinned by the :4040 port, and the SSR script preinit was already evidenced by resource-hints.test.ts 'SSR mirrors the unified identity and image keying'.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "preinit(as script) during render creates one deduped async script that persists past unmount",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:b20b9a02b714cc5de429",
@@ -54328,15 +54713,15 @@
     },
     {
       "caseId": "react-case-v1:b85b93d1f628d154ea5a",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can emit preloads for non-lazy images that are rendered",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Fizz's rendered-<img> preload scanning and its high/regular-priority flush queues are server transport machinery Octane's wave-based SSR deliberately does not implement (like the bootstrap/onHeaders options); there is no Octane observable to port."
     },
     {
       "caseId": "react-case-v1:b86964df590e3f95a04d",
@@ -55439,15 +55824,15 @@
     },
     {
       "caseId": "react-case-v1:bc24550d3644241a1522",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "creates a stylesheet resource in the ownerDocument when ReactDOM.preinit(..., {as: \"style\" }) is called in shadowRoot",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "ShadowRoot render containers are outside Octane's supported container surface (roots and portal targets require an Element); the underlying observable \u2014 preinit targets document.head regardless of where the calling component renders \u2014 is pinned by the render/effect preinit ports."
     },
     {
       "caseId": "react-case-v1:bc3d071ef8633105f661",
@@ -56600,15 +56985,15 @@
     },
     {
       "caseId": "react-case-v1:bfcfdcaf85e3c7fcbce6",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "warns if you render a <script> tag with itemProp outside <body> or <head>",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Same whole-document scenario as react-case-v1:00a78bfb4d2abbbdc096, for <script itemProp>."
     },
     {
       "caseId": "react-case-v1:bfe4eca9d0a7977ef351",
@@ -57799,7 +58184,12 @@
       "evidence": [
         {
           "file": "packages/octane/tests/conformance/dom-component-attributes.test.ts",
-          "testName": "aliases `acceptCharset` \u2192 `accept-charset`; native spelling also works",
+          "testName": "aliases `acceptCharset` \u2192 `accept-charset`",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/dom-component-attributes.test.ts",
+          "testName": "native spelling also works",
           "modes": ["client", "production-compile"]
         }
       ]
@@ -57818,7 +58208,12 @@
       "evidence": [
         {
           "file": "packages/octane/tests/float-resources.test.ts",
-          "testName": "groups order by first encounter; later same-precedence sheets append to their group",
+          "testName": "groups order by first encounter",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/float-resources.test.ts",
+          "testName": "later same-precedence sheets append to their group",
           "modes": ["client", "production-compile"]
         }
       ]
@@ -58145,15 +58540,15 @@
     },
     {
       "caseId": "react-case-v1:c4a07d2841ed44336a3e",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "loading a stylesheet as part of an error boundary UI, during initial render",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "The case's observable is the suspensey commit (hydration blocks until the error-UI stylesheet loads before revealing the error screen); suspend-until-loaded is documented out of scope \u2014 Octane inserts the sheet and continues \u2014 and the scenario also renders/hydrates the whole document."
     },
     {
       "caseId": "react-case-v1:c4aafb27eca33189e857",
@@ -58267,15 +58662,15 @@
     },
     {
       "caseId": "react-case-v1:c4f221bc778ca4dc3df3",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "client renders a boundary if a style Resource dependency fails to load",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Client-rendering a boundary because its stylesheet dependency ERRORED is suspensey CSS reveal semantics (load/error-driven commit), documented out of scope; jsdom also cannot observe real resource load failures."
     },
     {
       "caseId": "react-case-v1:c4f60e0ea1162e05f264",
@@ -58559,7 +58954,7 @@
     },
     {
       "caseId": "react-case-v1:c5b905eb4877d2fac35d",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "treats async scripts without onLoad or onError as Resources",
@@ -58567,7 +58962,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Handler-free async script hoists to head and persists after unmount; async+onLoad, plain, and defer scripts stay per-site in the body and unmount with their tree, on both client and SSR.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-3.test.ts",
+          "testName": "treats only handler-free external async scripts as resources",
+          "modes": ["client", "server-string", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:c5b9b0c7ba78a4457f6a",
@@ -58595,15 +58997,15 @@
     },
     {
       "caseId": "react-case-v1:c5d4a0f392ee15bfbb2c",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "will assume wait for loading stylesheets to load before continuing",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Waiting for loading stylesheets before continuing a commit is suspensey commit machinery, documented out of scope."
     },
     {
       "caseId": "react-case-v1:c5d73920bd423f15fbec",
@@ -58947,7 +59349,7 @@
     },
     {
       "caseId": "react-case-v1:c6deee4d1840389b472f",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "accepts a `nonce` option for `as: \"script\"`",
@@ -58955,7 +59357,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Render-time preinit nonce lands as the nonce attribute on the script resource on both the client insert and the SSR head fold. Octane has one RenderOptions.nonce channel, so the per-call option is the ported observable.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-3.test.ts",
+          "testName": "accepts a `nonce` option for as: \"script\"",
+          "modes": ["client", "server-string", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:c6eda3eaeaaabef1105a",
@@ -59111,7 +59520,7 @@
     },
     {
       "caseId": "react-case-v1:c74e0a4223f3015f1f21",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "supports fetchPriority",
@@ -59119,7 +59528,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Duplicate-titled 'supports fetchPriority' entry (see react-case-v1:2460591809287aa8d139); the single ported test covers both the preload (:6172) and preinit (:6930) upstream variants.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "supports fetchPriority on preload and preinit, client and server",
+          "modes": ["client", "server-string", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:c75fc76336e1a6b66f8d",
@@ -61605,7 +62021,7 @@
     },
     {
       "caseId": "react-case-v1:cf6ccb4cc765ab7e25bd",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "uses imageSrcSet and imageSizes when keying image preloads",
@@ -61613,7 +62029,19 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Full upstream keying matrix on the client (srcset-only vs srcset+sizes distinct keys, sizes-without-srcset ignored, non-image `as` keys on href); the SSR mirror of the keying was already evidenced by resource-hints.test.ts 'SSR mirrors the unified identity and image keying'.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "keys image preloads on imageSrcSet+imageSizes, falling back to href",
+          "modes": ["client", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "non-image preloads key on href",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:cf6e5e8c6cd00c6715c5",
@@ -62110,7 +62538,7 @@
     },
     {
       "caseId": "react-case-v1:d1053f923ae157910da0",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "inserts text separators following text when followed by an element that is converted to a resource and thus removed from the html inline",
@@ -62118,7 +62546,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Sibling dynamic texts each followed by a resource-elided stylesheet keep their text integrity through SSR and hydrate mismatch-free; the elided sheets hoist into first-encounter precedence groups.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-1.test.ts",
+          "testName": "sibling texts survive SSR resource elision and hydrate without mismatch",
+          "modes": ["server-string", "hydrate-match", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:d10cb85e4873c31358ae",
@@ -62286,7 +62721,7 @@
     },
     {
       "caseId": "react-case-v1:d1a15a1c009c189be69b",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "creates a preconnect resource when called",
@@ -62294,7 +62729,24 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "CORS-keyed preconnect identity, dedupe, and SSR mirror are pinned; adaptations noted: Octane keys '' and 'anonymous' as distinct modes where React collapses both to crossorigin=\"\", and a boolean crossOrigin is keyed leniently instead of warned (React-exact warning absent).",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/resource-hints.test.ts",
+          "testName": "preconnect identity includes the CORS mode",
+          "modes": ["client", "server-string", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/resource-hints.test.ts",
+          "testName": "preconnect and prefetchDNS insert their links once",
+          "modes": ["client", "server-string", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/resource-hints.test.ts",
+          "testName": "SSR mirrors font CORS, option transfer with preload coalescing, and CORS-keyed preconnect",
+          "modes": ["client", "server-string", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:d1a9b86f560e88240c47",
@@ -63109,15 +63561,15 @@
     },
     {
       "caseId": "react-case-v1:d45904defeda5855a264",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "omits preloads when an <img> is inside a <picture>",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Vacuous: 'omits preloads for <img> inside <picture>' only constrains the rendered-<img> preload emission feature Octane does not implement."
     },
     {
       "caseId": "react-case-v1:d45a2f60d20299e487e4",
@@ -63982,15 +64434,15 @@
     },
     {
       "caseId": "react-case-v1:d6f92dea08677c644480",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "inserts preloads in render phase eagerly",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Render-phase preload insertion exists to warm React's suspensey stylesheet loading; Octane has no client preload staging for resources (suspensey commits out of scope) and, empirically, a render that throws to an error boundary before commit inserts nothing."
     },
     {
       "caseId": "react-case-v1:d710902c30a5aff81277",
@@ -64006,15 +64458,15 @@
     },
     {
       "caseId": "react-case-v1:d7123882c86fff75a163",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can insert style resources as part of a boundary reveal",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "divergence",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Documented streaming divergence: head/resource content hoisted inside a streamed boundary does not ship in the stream (the shell's head already flushed); the hydrating client re-creates the style resource via styleResource (docs/differences-from-react.md 'Streaming' bullet; runtime.server.ts streaming scope note)."
     },
     {
       "caseId": "react-case-v1:d713b8e63c46e8d6bbf8",
@@ -64768,7 +65220,7 @@
     },
     {
       "caseId": "react-case-v1:d954cd20d1ee7faf1e72",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "supports nonce",
@@ -64776,7 +65228,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Duplicate-titled 'supports nonce' entry; covered by the same ported test as react-case-v1:3a363ca15c414aac909b.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "supports nonce on preload, client and server",
+          "modes": ["client", "server-string", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:d95e7c8898f71d670af1",
@@ -65106,15 +65565,15 @@
     },
     {
       "caseId": "react-case-v1:dabc2dcfc98a5e3a5c96",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "will not block displaying a Suspense boundary on a stylesheet with media that does not match",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "The observable is suspensey-commit load gating (boundary reveal blocked/unblocked by stylesheet load events per media matching); Octane documents suspend-until-loaded as out of scope and never blocks a reveal on stylesheet load."
     },
     {
       "caseId": "react-case-v1:dacaf5f4d2997e506a9a",
@@ -65734,7 +66193,7 @@
     },
     {
       "caseId": "react-case-v1:dc6f240107c6d488213c",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "does not create stylesheet resources when inside a <noscript> context",
@@ -65742,7 +66201,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "The fixture's noscript link carries precedence=\"default\" (the stylesheet-resource form); sibling tests 'server: noscript metadata/resources serialize inside the noscript' and 'hydration adopts the noscript host without mismatch warnings' cover the other modes.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/hydration/hoist-exclusions.test.ts",
+          "testName": "client: noscript metadata/resources stay inside the noscript",
+          "modes": ["client", "server-string", "hydrate-match", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:dc78f8556416989896fc",
@@ -66695,7 +67161,7 @@
     },
     {
       "caseId": "react-case-v1:dfaf921494ba7afbd29a",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "warns if you do not pass in a valid href argument or options argument",
@@ -66703,7 +67169,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "All five upstream preinit triggers (undefined href, empty href, null options, missing as, invalid as) produce an adapted dev diagnostic and stay no-ops. Note: the inventory pinned both duplicate-title cases to line 6137; this entry is matched to the preinit variant at upstream line 6733.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "preinit dev-warns and no-ops on invalid href or options",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:dfb8a74ef8412077b217",
@@ -66895,7 +67368,7 @@
     },
     {
       "caseId": "react-case-v1:e0c6d17cc90d6be183ff",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "should never flush hoistables before the preamble",
@@ -66903,7 +67376,19 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Zero bytes flush while the root is suspended, and the preinit issued before the suspension serializes ahead of the shell content once it flushes \u2014 the preamble-ordering observable without React's whole-document preamble machinery.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "flushes nothing before the shell",
+          "modes": ["server-stream", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "a pre-suspension preinit folds into the shell",
+          "modes": ["server-stream", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:e0c9c42a74c8193ce8f8",
@@ -68653,15 +69138,15 @@
     },
     {
       "caseId": "react-case-v1:e66f3e9d6b1594d9d505",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "does not suspend a transition on a stylesheet whose preload has already loaded",
       "baselines": ["canary"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Canary-only (b740af25:3677): not suspending a transition because the stylesheet's preload already loaded is suspensey load-state accounting, documented out of scope."
     },
     {
       "caseId": "react-case-v1:e66fbfb3f5ff0381a91c",
@@ -69544,7 +70029,7 @@
     },
     {
       "caseId": "react-case-v1:e9811fb4266b85d5f926",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "escapes hrefs when selecting matching elements in the document when using preload and preinit",
@@ -69552,7 +70037,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Client preload/preinit with selector-syntax hrefs neither throw nor cross-match SSR-emitted tags; repeats of SSR hrefs (including a newline href) are value-matched no-ops.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-3.test.ts",
+          "testName": "matches preload and preinit calls whose hrefs contain selector metacharacters",
+          "modes": ["client", "server-string", "hydrate-match", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:e982c305f1effa667066",
@@ -70888,15 +71380,15 @@
     },
     {
       "caseId": "react-case-v1:ee1cd601a7420b0dc676",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can support styles inside portals to an element in shadowRoots",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "divergence",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Same page-global model: stylesheets rendered through portals into elements inside shadow roots would insert into document.head, not the containing ShadowRoot; no HoistableRoot scoping exists."
     },
     {
       "caseId": "react-case-v1:ee293028fbb851f59369",
@@ -71552,15 +72044,15 @@
     },
     {
       "caseId": "react-case-v1:efc2b80a458953ccb84b",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can support styles inside portals to a shadowRoot",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "divergence",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Octane Float resources are page-global and always insert into document.head \u2014 there is no per-HoistableRoot (shadow-root) resource scoping, and Octane portal targets must be Elements (a ShadowRoot is not), so a portal to a shadowRoot cannot even be constructed. Proposed as a divergence to document alongside the page-global resource contract."
     },
     {
       "caseId": "react-case-v1:efc53b3090c304fa5aac",
@@ -71648,15 +72140,15 @@
     },
     {
       "caseId": "react-case-v1:effa68b9ed23320683d3",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "should not preload images that have a data URIs for src or srcSet",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Vacuous: 'does not preload data-URI images' only constrains the rendered-<img> preload emission feature Octane does not implement."
     },
     {
       "caseId": "react-case-v1:f0003af90822fd942db3",
@@ -71672,15 +72164,15 @@
     },
     {
       "caseId": "react-case-v1:f01d6d81f9b553a519f1",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "dedupes if the external runtime is explicitly loaded using preinit",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Exercises unstable_externalRuntimeSrc dedupe; the Fizz external runtime is a standing non-goal."
     },
     {
       "caseId": "react-case-v1:f0206f3a1e912edc3c69",
@@ -72002,15 +72494,15 @@
     },
     {
       "caseId": "react-case-v1:f135627acfbcb79d6e5b",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "does not outline a boundary with suspensey CSS when flushing the shell",
       "baselines": ["canary"],
-      "classification": "adaptable",
+      "classification": "non_goal",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Canary-only (b740af25:9775): the outline-vs-inline decision for suspensey CSS at shell flush is Fizz suspend-until-loaded machinery, documented out of scope."
     },
     {
       "caseId": "react-case-v1:f136c67f48070633da15",
@@ -72998,7 +73490,7 @@
     },
     {
       "caseId": "react-case-v1:f4cdbc269065737169a9",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "treats link rel stylesheet elements as a stylesheet resource when it includes a precedence when hydrating",
@@ -73006,7 +73498,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "SSR-emitted stylesheet resource is adopted (not duplicated) by the hydrating client render of the same component.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/float-resources.test.ts",
+          "testName": "a hydrating client call dedupes against SSR-emitted resources",
+          "modes": ["server-string", "hydrate-match"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:f504b1aa6080b87da7d2",
@@ -74318,7 +74817,7 @@
     },
     {
       "caseId": "react-case-v1:f9945153572927525bb0",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can emit styles with nonce",
@@ -74326,7 +74825,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "The durable subset: an authored nonce prop rides the emitted style-resource tag on client and SSR. Upstream's merged single style tag per precedence is a documented divergence (one tag per resource) and its {nonce:{style}} channel option does not exist (one RenderOptions.nonce).",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-3.test.ts",
+          "testName": "emits style resources with a nonce",
+          "modes": ["client", "server-string", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:f995c5588c3af365b456",
@@ -75097,15 +75603,15 @@
     },
     {
       "caseId": "react-case-v1:fc6d200113122f528e5e",
-      "status": "planned",
+      "status": "documented",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "can hydrate hoistable tags inside late suspense boundaries",
       "baselines": ["canary", "stable"],
-      "classification": "adaptable",
+      "classification": "divergence",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Documented streaming divergence: head elements hoisted inside streamed boundaries are re-created on the client during hydration rather than adopted/hydrated in place (docs/differences-from-react.md 'Streaming'); the case additionally requires a whole-document hydrateRoot(document, \u2026) harness."
     },
     {
       "caseId": "react-case-v1:fc6e3fc6106c02eb05d4",
@@ -75128,7 +75634,7 @@
     },
     {
       "caseId": "react-case-v1:fcae4f90b1b560984913",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "will not insert a preload if the underlying resource already exists in the Document",
@@ -75136,7 +75642,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "SSR head (stylesheet resource, async script resource, font preload) lands in the document; client preload calls for all three identities are no-ops.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "does not insert a preload when the underlying resource already exists in the document",
+          "modes": ["client", "hydrate-match", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:fcb2ce3bc074798afdf7",

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -19036,10 +19036,13 @@ function normalizeChildren(nodes, inSvg = false, ctx = null, inNoscript = false)
 			// body DOM). Kept in `out` as a synthetic node so planJsx / ssrCompileBody
 			// can partition it out and emit it via headBlock (client) / ssrHeadEl
 			// (server). SVG `<title>` and explicit resource-handler links stay inline.
+			// The whole hoist model is HTML-scoped: inside an SVG lexical context
+			// link/meta are svg-namespace content and React keeps them inline
+			// (foreignObject children re-enter the HTML rules via childNs).
 			if (
 				!inNoscript &&
-				(isHoistableHeadElementNode(n) || (!inSvg && headResourceKind(n) !== null)) &&
-				!(inSvg && jsxTagName(n) === 'title')
+				!inSvg &&
+				(isHoistableHeadElementNode(n) || headResourceKind(n) !== null)
 			) {
 				out.push({ type: 'HeadHoist', element: n });
 				continue;

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -8299,7 +8299,14 @@ export function preinitModule(
 ): void {
 	const value = coerceHintHref(href);
 	if (value === null) return;
-	if ((options?.as ?? 'script') !== 'script') return;
+	if ((options?.as ?? 'script') !== 'script') {
+		warnHintUsage(
+			'preinitModule() supports only as: "script" (got ' +
+				JSON.stringify(options?.as) +
+				'); the call was ignored. Use preloadModule() for other module destinations.',
+		);
+		return;
+	}
 	if (HEAD !== null && HEAD.hints.has('script:' + value)) return;
 	const key = 'module:' + value;
 	const safeHref = sanitizeURL(value);

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -27856,7 +27856,14 @@ export function preinitModule(
 ): void {
 	const rawHref = guardHintHref('preinitModule', href);
 	if (rawHref === null) return;
-	if ((options?.as ?? 'script') !== 'script') return;
+	if ((options?.as ?? 'script') !== 'script') {
+		warnHintUsage(
+			'preinitModule() supports only as: "script" (got ' +
+				JSON.stringify(options?.as) +
+				'); the call was ignored. Use preloadModule() for other module destinations.',
+		);
+		return;
+	}
 	// One executable per src: a live Float script (SSR-seeded or client-
 	// discovered) already satisfies this init.
 	const state = resourceState();

--- a/packages/octane/tests/_fixtures/float-evidence-1.tsrx
+++ b/packages/octane/tests/_fixtures/float-evidence-1.tsrx
@@ -1,0 +1,151 @@
+// Fixtures for conformance/float-evidence-1.test.ts — ReactDOMFloat-test.js
+// evidence ports. Each component is cited from the test file; the contracts
+// under test are React Float resource semantics adapted to Octane's model
+// (resources are global, hoisted, deduped, precedence-grouped, retained).
+import { preinit, use, useState } from 'octane';
+
+// Same-commit release + acquire of one script resource identity: the @if flip
+// unmounts the first <script async src> site and mounts a second one carrying
+// a differing prop in the same commit.
+let swapPhase: ((phase: number) => void) | null = null;
+export function setSwapPhase(phase: number): void {
+	swapPhase!(phase);
+}
+
+export function ScriptSwapHost() @{
+	const [phase, setPhase] = useState(0);
+	swapPhase = setPhase;
+	<section class="swap">
+		@if (phase === 0) {
+			<>
+				<script async src="/swap.js" />
+				<span class="swap-a">a</span>
+			</>
+		} @else {
+			<>
+				<script async src="/swap.js" data-new="new" />
+				<span class="swap-b">b</span>
+			</>
+		}
+	</section>
+}
+
+// Mixed head content: hoisted non-resource metadata AND Float resources from
+// one component tree (adapted from React's whole-document hydration case).
+export function MixedHead() @{
+	<>
+		<title>mixed head</title>
+		<meta property="og:mixed" content="bar" />
+		<link rel="stylesheet" href="/mixed.css" precedence="default" />
+		<script async src="/mixed.js" />
+		<main class="mixed-body">{'mixed' as string}</main>
+	</>
+}
+
+// Sibling dynamic texts, each followed by a stylesheet resource that is elided
+// from the inline HTML (React's text-separator case, adapted).
+function TextWithSheet(props: { text: string; href: string; precedence: string }) @{
+	<>
+		{props.text as string}
+		<link rel="stylesheet" href={props.href} precedence={props.precedence} />
+	</>
+}
+
+export function TextResourceSiblings() @{
+	<div class="text-siblings">
+		<TextWithSheet text="foo" href="/sep-foo.css" precedence="one" />
+		<TextWithSheet text="bar" href="/sep-bar.css" precedence="two" />
+		<TextWithSheet text="baz" href="/sep-baz.css" precedence="three" />
+	</div>
+}
+
+// Precedence normalization across nested non-suspended boundaries rendered in
+// one pass (React's shell-flush normalization case, adapted).
+export function ShellPrecedenceApp() @{
+	<div class="shell-prec">
+		{'outer' as string}
+		<link rel="stylesheet" href="/1one.css" precedence="one" />
+		<link rel="stylesheet" href="/1two.css" precedence="two" />
+		@try {
+			<>
+				{'middle' as string}
+				<link rel="stylesheet" href="/2one.css" precedence="one" />
+				<link rel="stylesheet" href="/2two.css" precedence="two" />
+				@try {
+					<>
+						{'inner' as string}
+						<link rel="stylesheet" href="/3three.css" precedence="three" />
+						<link rel="stylesheet" href="/3one.css" precedence="one" />
+					</>
+				} @pending {
+					<span class="p-inner">pending</span>
+				}
+			</>
+		} @pending {
+			<span class="p-mid">pending</span>
+		}
+	</div>
+}
+
+// Streamed precedence normalization: an initial sheet, a preinit with a preset
+// precedence, and two PENDING boundaries whose statically-declared sheets must
+// still make the flushed shell head (adapted from React's late-hoist case; the
+// load-gated client reveal half of that case is out of scope with suspensey
+// commits).
+export function PendingPrecedenceApp(props: { a: Promise<string>; b: Promise<string> }) @{
+	preinit('/pp-preset.css', { as: 'style', precedence: 'preset' });
+	<div class="pending-prec">
+		<link rel="stylesheet" href="/pp-initial.css" precedence="one" />
+		@try {
+			const va = use(props.a);
+			<>
+				<link rel="stylesheet" href="/pp-a.css" precedence="default" />
+				<span class="pp-a">{va as string}</span>
+			</>
+		} @pending {
+			<span class="pp-a-pending">loading a</span>
+		}
+		@try {
+			const vb = use(props.b);
+			<>
+				<link rel="stylesheet" href="/pp-b.css" precedence="one" />
+				<span class="pp-b">{vb as string}</span>
+			</>
+		} @pending {
+			<span class="pp-b-pending">loading b</span>
+		}
+	</div>
+}
+
+// Full option/attribute surface on a stylesheet resource: standard link
+// options, a data attribute whose value needs escaping, and the canonical
+// lowercase serialization.
+// Module-level so the double quotes stay an expression value (a literal
+// attribute would trip the tsrx-prettier attribute rewrite) and stay visible
+// to the hoisted resource emission (a component-local would sit in its TDZ).
+const quoted = '"quoted"';
+
+export function AttrSheet() @{
+	<>
+		<link
+			rel="stylesheet"
+			href="/attr.css"
+			precedence="default"
+			crossOrigin="anonymous"
+			media="all"
+			integrity="somehash"
+			referrerPolicy="origin"
+			data-foo={quoted}
+		/>
+		<span class="attr-body">attrs</span>
+	</>
+}
+
+// nomodule scripts: the async form is still a hoisted resource carrying the
+// attribute; the sync form stays an ordinary in-place element.
+export function NoModuleScripts() @{
+	<div class="nomodule-host">
+		<script src="/nomodule-sync.js" noModule data-meaningful="" />
+		<script async src="/nomodule-async.js" noModule data-meaningful="" />
+	</div>
+}

--- a/packages/octane/tests/_fixtures/float-evidence-2.tsrx
+++ b/packages/octane/tests/_fixtures/float-evidence-2.tsrx
@@ -1,0 +1,155 @@
+// Fixtures for ReactDOMFloat-test.js conformance evidence (slice 2):
+// late-discovered Float resources inside streamed Suspense boundaries,
+// hoistables authored in Suspense fallbacks, and resource hints issued from
+// render/effect timing positions.
+import {
+	Suspense,
+	use,
+	useEffect,
+	useInsertionEffect,
+	useLayoutEffect,
+	preload,
+	preinit,
+} from 'octane';
+
+// --- Float resources discovered inside a suspended boundary ---------------
+
+function LateSheetInner(props: { promise: Promise<string> }) @{
+	const value = use(props.promise);
+	<>
+		<link rel="stylesheet" href="/late-sheet.css" precedence="default" />
+		<span class="late-ready">{value as string}</span>
+	</>
+}
+
+export function LateSheetBoundary(props: { promise: Promise<string> }) @{
+	<div class="late-host">
+		<Suspense fallback={<span class="late-fallback">{'loading...'}</span>}>
+			<LateSheetInner promise={props.promise} />
+		</Suspense>
+	</div>
+}
+
+function LateAllInner(props: { promise: Promise<string> }) @{
+	const value = use(props.promise);
+	<>
+		<link rel="stylesheet" href="/late-all.css" precedence="default" />
+		<script async src="/late-all.js" />
+		<script async type="module" src="/late-all.mjs" />
+		<span class="late-all-ready">{value as string}</span>
+	</>
+}
+
+export function LateAllBoundary(props: { promise: Promise<string> }) @{
+	<div class="late-all-host">
+		<Suspense fallback={<span class="late-all-fallback">{'loading...'}</span>}>
+			<LateAllInner promise={props.promise} />
+		</Suspense>
+	</div>
+}
+
+// preinit issued inside a suspended boundary, after a shell preload for the
+// same hrefs seeded connection options.
+function LatePreinitInner(props: { promise: Promise<string> }) @{
+	preinit('/late-preinit.css', { as: 'style' });
+	preinit('/late-preinit.js', { as: 'script' });
+	const value = use(props.promise);
+	<span class="late-preinit-ready">{value as string}</span>
+}
+
+export function LatePreinitBoundary(props: { promise: Promise<string> }) @{
+	<div class="late-preinit-host">
+		<Suspense fallback={<span class="late-preinit-fallback">{'loading...'}</span>}>
+			<LatePreinitInner promise={props.promise} />
+		</Suspense>
+	</div>
+}
+
+// --- hoistables authored in Suspense fallbacks -----------------------------
+
+function PrimaryMeta(props: { promise: Promise<string> }) @{
+	const value = use(props.promise);
+	<>
+		<meta name="primary-meta" content="p" />
+		<span class="primary">{value as string}</span>
+	</>
+}
+
+export function FallbackMetaBoundary(props: { promise: Promise<string> }) @{
+	<div class="fm-host">
+		<Suspense
+			fallback={<>
+				<meta name="fallback-meta" content="f" />
+				<link rel="author" href="/fallback-author" />
+				<span class="fb">{'fb'}</span>
+			</>}
+		>
+			<PrimaryMeta promise={props.promise} />
+		</Suspense>
+	</div>
+}
+
+function NestedFallbackPrimary(props: { inner: Promise<string> }) @{
+	const value = use(props.inner);
+	<>
+		<meta name="nested-primary-meta" content="np" />
+		<span class="nested-primary">{value as string}</span>
+	</>
+}
+
+export function NestedFallbackMetaBoundary(props: {
+	promise: Promise<string>;
+	inner: Promise<string>;
+}) @{
+	<div class="nfm-host">
+		<Suspense
+			fallback={<Suspense fallback={<span class="nested-fb">{'nested fb'}</span>}>
+				<NestedFallbackPrimary inner={props.inner} />
+			</Suspense>}
+		>
+			<PrimaryMeta promise={props.promise} />
+		</Suspense>
+	</div>
+}
+
+// --- hint calls from render and effect timing positions --------------------
+
+export function RenderAndEffectPreloads() @{
+	preload('/pl-render.css', { as: 'style' });
+	preload('/pl-font.woff2', { as: 'font', type: 'font/woff2' });
+	useInsertionEffect(() => {
+		preload('/pl-insertion.js', { as: 'script' });
+	}, []);
+	useLayoutEffect(() => {
+		preload('/pl-layout.woff2', { as: 'font' });
+	}, []);
+	useEffect(() => {
+		preload('/pl-passive.css', { as: 'style' });
+	}, []);
+	<div class="pl-host">{'hello'}</div>
+}
+
+export function EffectPreinitStyle() @{
+	useEffect(() => {
+		preinit('/effect-preinit.css', { as: 'style' });
+	}, []);
+	<div class="effect-preinit">{'e'}</div>
+}
+
+export function RenderPreinitStyle() @{
+	preinit('/render-preinit.css', { as: 'style' });
+	<div class="render-preinit-style">{'s'}</div>
+}
+
+export function RenderPreinitScript() @{
+	preinit('/render-preinit.js', { as: 'script' });
+	<div class="render-preinit-script">{'j'}</div>
+}
+
+// A component that suspends at the ROOT (no boundary) after issuing a preinit:
+// nothing may flush before the shell is ready.
+export function RootSuspendedPreinit(props: { promise: Promise<string> }) @{
+	preinit('/preamble.js', { as: 'script' });
+	const value = use(props.promise);
+	<div class="preamble-ready">{value as string}</div>
+}

--- a/packages/octane/tests/_fixtures/float-evidence-3.tsrx
+++ b/packages/octane/tests/_fixtures/float-evidence-3.tsrx
@@ -1,0 +1,126 @@
+// ReactDOMFloat-test.js conformance evidence (slice 3) fixtures: preinit
+// option pass-through (nonce/integrity/module options), Float classification
+// exclusions (SVG and noscript contexts, handler-bearing scripts), unusual
+// href text, style-resource nonce, and hoistable link/title lifecycle.
+import { useEffect, preinit, preinitModule } from 'octane';
+
+// preinit issued OUTSIDE render (from an effect) still creates the resource.
+export function EffectPreinit() @{
+	useEffect(() => {
+		preinit('/fe3-effect.js', { as: 'script' });
+	}, []);
+	<div class="fe3-fx">{'FX' as string}</div>
+}
+
+export function NonceScriptPreinit(props: { src: string }) @{
+	preinit(props.src, { as: 'script', nonce: 'R4nD0m' });
+	<div class="fe3-nonce">{'hello' as string}</div>
+}
+
+export function IntegrityScriptPreinit(props: { src: string; hash: string }) @{
+	preinit(props.src, { as: 'script', integrity: props.hash });
+	<div class="fe3-int-script">{'hello' as string}</div>
+}
+
+export function IntegrityStylePreinit(props: { src: string; hash: string }) @{
+	preinit(props.src, { as: 'style', integrity: props.hash });
+	<div class="fe3-int-style">{'hello' as string}</div>
+}
+
+export function ModulePreinits() @{
+	preinitModule('/fe3-mod-default.mjs', { as: 'script' });
+	preinitModule('/fe3-mod-integrity.mjs', { integrity: 'some hash' });
+	<div class="fe3-mod">{'hello' as string}</div>
+}
+
+// Stylesheet resources whose href text would be CSS-selector syntax if a
+// matching implementation interpolated it into querySelector. Module
+// constants keep the expression containers (a quote-bearing string cannot be
+// a plain JSX string attribute).
+export const QUOTE_HREF: string = 'fe3-style"][rel="stylesheet';
+export const SLASH_HREF: string = 'fe3-with\\slashes';
+
+export function EscapedSheetQuote() @{
+	<>
+		<link rel="stylesheet" href={QUOTE_HREF} precedence="style" />
+		<div class="fe3-esc-q">{'q' as string}</div>
+	</>
+}
+
+export function EscapedSheetBackslash() @{
+	<>
+		<link rel="stylesheet" href={SLASH_HREF} precedence="style" />
+		<div class="fe3-esc-b">{'b' as string}</div>
+	</>
+}
+
+// SVG context: script-resource classification and title hoisting are
+// suppressed inside the SVG namespace (both stay in their authored
+// positions), while a <foreignObject> subtree returns to HTML rules and
+// hoists metadata and resources again.
+export function SvgContexts() @{
+	<section class="fe3-svg-host">
+		<svg class="fe3-svg">
+			<path class="fe3-svg-path">
+				<title>svg inline title</title>
+				<script async src="/fe3-svg-script.js" />
+			</path>
+			<foreignObject>
+				<meta name="fe3-fo-meta" content="hoist" />
+				<link rel="stylesheet" href="/fe3-fo-sheet.css" precedence="default" />
+				<script async src="/fe3-fo-script.js" />
+			</foreignObject>
+		</svg>
+	</section>
+}
+
+// noscript is fallback-only content: an async script inside it is never a
+// script resource.
+export function NoscriptScript() @{
+	<div class="fe3-nss">
+		<noscript>
+			<script async src="/fe3-noscript.js" />
+		</noscript>
+		<p class="fe3-nss-p">{'ns' as string}</p>
+	</div>
+}
+
+// Only the handler-free async external script is a resource; scripts with
+// load handlers, plain scripts, and defer scripts stay per-site elements.
+export function ScriptForms(props: { onLoad: () => void }) @{
+	<section class="fe3-scripts">
+		<script async src="/fe3-resource.js" />
+		<script async src="/fe3-handler.js" onLoad={props.onLoad} />
+		<script src="/fe3-plain.js" data-meaningful="" />
+		<script defer src="/fe3-defer.js" data-meaningful="" />
+		<span class="fe3-scripts-span">{'hello world' as string}</span>
+	</section>
+}
+
+// A style resource carrying an authored CSP nonce.
+export function NonceStyle() @{
+	<>
+		<style href="fe3-nonce-css" precedence="default" nonce="R4nD0m">
+			.fe3-nonce-rule {
+				color: hotpink;
+			}
+		</style>
+		<div class="fe3-nonce-style">{'n' as string}</div>
+	</>
+}
+
+// A plain (non-stylesheet) hoisted link: per-site head element on both sides.
+export function PlainLinkPage() @{
+	<>
+		<link rel="author" data-foo="data" href="/fe3-author" />
+		<main class="fe3-plain-host">{'body' as string}</main>
+	</>
+}
+
+// A hoisted title whose text AND attribute update reactively in place.
+export function TitleUpdate(props: { text: string; foo: string }) @{
+	<>
+		<title data-foo={props.foo}>{props.text as string}</title>
+		<main class="fe3-title-host">{'t' as string}</main>
+	</>
+}

--- a/packages/octane/tests/conformance/float-evidence-1.test.ts
+++ b/packages/octane/tests/conformance/float-evidence-1.test.ts
@@ -1,0 +1,358 @@
+// Conformance evidence for ReactDOMFloat-test.js cases (stable pin, plus one
+// canary-only case cited by commit). Each `it` cites its upstream case and
+// asserts Octane's observable outcome through public APIs: Float resources are
+// global (deduped by href/src), hoisted into document.head / the SSR head fold,
+// precedence-grouped in first-encounter order, and retained after unmount.
+// Suspensey commits (suspend-until-loaded) are documented as out of scope, so
+// the load-event halves of the upstream cases are not ported here.
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import {
+	act,
+	createRoot,
+	hydrateRoot,
+	flushSync,
+	preloadModule,
+	resetFloatResourceState,
+} from '../../src/index.js';
+import * as Server from 'octane/server';
+import { loadServerFixture } from '../_server-fixture.js';
+import {
+	activateStreamedMarkup,
+	createPipeableCollector,
+	deferred,
+	resetStreamRuntimeGlobals,
+} from '../_server-stream.js';
+import {
+	AttrSheet,
+	MixedHead,
+	NoModuleScripts,
+	ScriptSwapHost,
+	setSwapPhase,
+	TextResourceSiblings,
+} from '../_fixtures/float-evidence-1.tsrx';
+
+const srv = loadServerFixture('packages/octane/tests/_fixtures/float-evidence-1.tsrx') as Record<
+	string,
+	any
+>;
+
+/** Hrefs of sheet-family resources currently in the head, in document order. */
+function sheetHrefs(): string[] {
+	return Array.from(
+		document.head.querySelectorAll('link[rel="stylesheet"][data-precedence]'),
+		(l) => l.getAttribute('href')!,
+	);
+}
+
+/** Hrefs in the order they appear inside an HTML string. */
+function hrefOrder(html: string, hrefs: string[]): string[] {
+	return hrefs
+		.map((href) => ({ href, at: html.indexOf(href) }))
+		.filter((e) => e.at !== -1)
+		.sort((a, b) => a.at - b.at)
+		.map((e) => e.href);
+}
+
+describe('conformance: React Float resource evidence (slice 1)', () => {
+	const containers: HTMLElement[] = [];
+	const roots: Array<{ unmount(): void }> = [];
+	function mountInto(body: any, props: any = {}): HTMLElement {
+		const c = document.createElement('div');
+		document.body.appendChild(c);
+		containers.push(c);
+		const root = createRoot(c);
+		roots.push(root);
+		root.render(body, props);
+		return c;
+	}
+	afterEach(() => {
+		for (const r of roots.splice(0)) r.unmount();
+		for (const c of containers.splice(0)) c.remove();
+		document.head
+			.querySelectorAll(
+				'[data-precedence], [data-oct-res], [data-oct-hint], link[rel="modulepreload"], link[rel="preload"], title, meta, script',
+			)
+			.forEach((el) => el.remove());
+		// Resources are page-global by contract; tests reset the page.
+		resetFloatResourceState();
+		resetStreamRuntimeGlobals();
+	});
+
+	// Per ReactDOMFloat-test.js (canary, facebook/react@b740af25):6596 —
+	// 'preloads multiple non-script modules with the same as type'
+	it('client: preloadModule keys per href, carrying a non-script as type', () => {
+		preloadModule('/sw-one.js', { as: 'serviceworker' });
+		preloadModule('/sw-one.js', { as: 'serviceworker' }); // deduped
+		preloadModule('/sw-two.js', { as: 'serviceworker' });
+		const links = document.head.querySelectorAll('link[rel="modulepreload"][as="serviceworker"]');
+		expect(Array.from(links, (l) => l.getAttribute('href'))).toEqual(['/sw-one.js', '/sw-two.js']);
+	});
+
+	// Per ReactDOMFloat-test.js (canary, facebook/react@b740af25):6596 —
+	// 'preloads multiple non-script modules with the same as type'
+	it('server: preloadModule folds one modulepreload per href with the as type', async () => {
+		const App = () => {
+			Server.preloadModule('/ssw-one.js', { as: 'serviceworker' });
+			Server.preloadModule('/ssw-one.js', { as: 'serviceworker' }); // deduped
+			Server.preloadModule('/ssw-two.js', { as: 'serviceworker' });
+			return Server.createElement('div', null, 'x') as any;
+		};
+		const r = await Server.renderToString(App as any);
+		expect(r.html.match(/rel="modulepreload"/g) || []).toHaveLength(2);
+		expect(r.html.match(/as="serviceworker"/g) || []).toHaveLength(2);
+		expect(r.html.match(/href="\/ssw-one\.js"/g) || []).toHaveLength(1);
+		expect(r.html.match(/href="\/ssw-two\.js"/g) || []).toHaveLength(1);
+	});
+
+	// Per ReactDOMFloat-test.js:445 — 'can hydrate non Resources in head when
+	// Resources are also inserted there' (adapted: Octane roots are Elements,
+	// so the head content arrives via Octane's metadata hoist + resource fold
+	// instead of an <html> container).
+	it('hydration adopts hoisted non-resource head elements alongside inserted resources', async () => {
+		const r = await Server.renderToString(srv.MixedHead, {});
+		const bodyStart = r.html.indexOf('<main');
+		expect(bodyStart).toBeGreaterThan(-1);
+		document.head.insertAdjacentHTML('beforeend', r.html.slice(0, bodyStart));
+		const c = document.createElement('div');
+		document.body.appendChild(c);
+		containers.push(c);
+		c.innerHTML = r.html.slice(bodyStart);
+
+		const title = document.head.querySelector('title')!;
+		const meta = document.head.querySelector('meta[property="og:mixed"]')!;
+		const sheet = document.head.querySelector('link[href="/mixed.css"]')!;
+		const script = document.head.querySelector('script[src="/mixed.js"]')!;
+		expect(title.textContent).toBe('mixed head');
+
+		const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			const root = hydrateRoot(c, MixedHead, {});
+			flushSync(() => {});
+			const warns = errSpy.mock.calls.map((call) => String(call[0]));
+			expect(warns.filter((m) => m.includes('hydration mismatch'))).toEqual([]);
+
+			// Non-resources ADOPTED (same nodes, no duplicates)…
+			expect(document.head.querySelectorAll('title')).toHaveLength(1);
+			expect(document.head.querySelector('title')).toBe(title);
+			expect(document.head.querySelectorAll('meta[property="og:mixed"]')).toHaveLength(1);
+			expect(document.head.querySelector('meta[property="og:mixed"]')).toBe(meta);
+			// …and resources deduped against the SSR-emitted tags.
+			expect(document.head.querySelectorAll('link[href="/mixed.css"]')).toHaveLength(1);
+			expect(document.head.querySelectorAll('script[src="/mixed.js"]')).toHaveLength(1);
+
+			// Unmount: per-site metadata is removed; resources are retained.
+			root.unmount();
+			expect(title.isConnected).toBe(false);
+			expect(meta.isConnected).toBe(false);
+			expect(sheet.isConnected).toBe(true);
+			expect(script.isConnected).toBe(true);
+		} finally {
+			errSpy.mockRestore();
+		}
+	});
+
+	// Per ReactDOMFloat-test.js:647 — 'can acquire a resource after releasing
+	// it in the same commit'
+	it('re-acquiring a released script resource in one commit keeps the first instance', async () => {
+		let c!: HTMLElement;
+		await act(() => {
+			c = mountInto(ScriptSwapHost);
+		});
+		const script = document.head.querySelector('script[src="/swap.js"]') as HTMLScriptElement;
+		expect(script).not.toBeNull();
+		expect(script.async).toBe(true);
+		expect(c.querySelector('.swap-a')).not.toBeNull();
+
+		await act(() => setSwapPhase(1));
+		expect(c.querySelector('.swap-b')).not.toBeNull();
+		const after = document.head.querySelectorAll('script[src="/swap.js"]');
+		expect(after).toHaveLength(1);
+		// The resource was NOT reconstructed: same element, and the differing
+		// prop of the re-acquiring site is not applied (first instance wins).
+		expect(after[0]).toBe(script);
+		expect(after[0].hasAttribute('data-new')).toBe(false);
+	});
+
+	// Per ReactDOMFloat-test.js:1379 — 'inserts text separators following text
+	// when followed by an element that is converted to a resource and thus
+	// removed from the html inline'
+	it('sibling texts survive SSR resource elision and hydrate without mismatch', async () => {
+		const r = await Server.renderToString(srv.TextResourceSiblings, {});
+		const bodyStart = r.html.indexOf('<div class="text-siblings"');
+		expect(bodyStart).toBeGreaterThan(-1);
+		const headHtml = r.html.slice(0, bodyStart);
+		const bodyHtml = r.html.slice(bodyStart);
+		// The resources left no inline trace between the texts…
+		expect(bodyHtml).not.toContain('stylesheet');
+		// …and hoisted into first-encounter precedence groups.
+		expect(hrefOrder(headHtml, ['/sep-foo.css', '/sep-bar.css', '/sep-baz.css'])).toEqual([
+			'/sep-foo.css',
+			'/sep-bar.css',
+			'/sep-baz.css',
+		]);
+
+		document.head.insertAdjacentHTML('beforeend', headHtml);
+		const c = document.createElement('div');
+		document.body.appendChild(c);
+		containers.push(c);
+		c.innerHTML = bodyHtml;
+		const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			const root = hydrateRoot(c, TextResourceSiblings, {});
+			flushSync(() => {});
+			const warns = errSpy.mock.calls.map((call) => String(call[0]));
+			expect(warns.filter((m) => m.includes('hydration mismatch'))).toEqual([]);
+			expect(c.querySelector('.text-siblings')!.textContent).toBe('foobarbaz');
+			expect(sheetHrefs()).toEqual(['/sep-foo.css', '/sep-bar.css', '/sep-baz.css']);
+			root.unmount();
+		} finally {
+			errSpy.mockRestore();
+		}
+	});
+
+	// Per ReactDOMFloat-test.js:1425 — 'hoists late stylesheets the correct
+	// precedence' (adapted). OCTANE DIVERGENCE: suspensey commits are out of
+	// scope, so the load-gated client reveal half does not apply; the ported
+	// observable is that statically-declared stylesheets inside boundaries that
+	// are still PENDING at shell time join the flushed shell head in normalized
+	// precedence groups, alongside a preinit-established group, and the later
+	// segment reveals add no duplicate resource tags.
+	it('streaming folds pending-boundary stylesheets into the shell head precedence groups', async () => {
+		const a = deferred<string>();
+		const b = deferred<string>();
+		const collector = createPipeableCollector();
+		Server.renderToPipeableStream(srv.PendingPrecedenceApp, {
+			a: a.promise,
+			b: b.promise,
+		}).pipe(collector.destination);
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		const shell = collector.chunks.join('');
+		expect(shell).toContain('loading a');
+		expect(shell).toContain('loading b');
+		expect(shell).not.toContain('pp-a">');
+		// All four sheets flushed with the shell, grouped by first-encounter
+		// precedence — preset (the preinit runs in authored setup, ahead of the
+		// declared sheets), then one (initial, later joined by b), then default
+		// (a). The load-bearing claims: pending-boundary sheets are present at
+		// shell time, groups are contiguous, and b appends into initial's group.
+		expect(
+			hrefOrder(shell, ['/pp-initial.css', '/pp-b.css', '/pp-preset.css', '/pp-a.css']),
+		).toEqual(['/pp-preset.css', '/pp-initial.css', '/pp-b.css', '/pp-a.css']);
+		expect(shell).toContain('data-precedence="preset"');
+		expect(shell.match(/data-precedence="one"/g) || []).toHaveLength(2);
+
+		a.resolve('A');
+		b.resolve('B');
+		const html = await collector.ended;
+		// The revealed segments carry the content but never a second copy of a
+		// resource: each href appears exactly once in the whole response.
+		for (const href of ['/pp-initial.css', '/pp-b.css', '/pp-preset.css', '/pp-a.css']) {
+			expect(html.split(href)).toHaveLength(2);
+		}
+		const c = document.createElement('div');
+		document.body.appendChild(c);
+		containers.push(c);
+		c.innerHTML = html;
+		activateStreamedMarkup(c);
+		expect(c.querySelector('.pp-a')!.textContent).toBe('A');
+		expect(c.querySelector('.pp-b')!.textContent).toBe('B');
+	});
+
+	// Per ReactDOMFloat-test.js:1709 — 'normalizes stylesheet resource
+	// precedence for all boundaries inlined as part of the shell flush'
+	it('SSR normalizes precedence across nested boundaries inlined in one pass', async () => {
+		const r = await Server.renderToString(srv.ShellPrecedenceApp, {});
+		const expected = [
+			'/1one.css',
+			'/2one.css',
+			'/3one.css',
+			'/1two.css',
+			'/2two.css',
+			'/3three.css',
+		];
+		expect(hrefOrder(r.html, expected)).toEqual(expected);
+		for (const href of expected) {
+			expect(r.html.split(href)).toHaveLength(2);
+		}
+		const bodyText = r.html.slice(r.html.indexOf('<div class="shell-prec"'));
+		expect(bodyText).not.toContain('stylesheet');
+		expect(bodyText.indexOf('outer')).toBeLessThan(bodyText.indexOf('middle'));
+		expect(bodyText.indexOf('middle')).toBeLessThan(bodyText.indexOf('inner'));
+	});
+
+	// Per ReactDOMFloat-test.js:2204 — 'encodes attributes consistently whether
+	// resources are flushed in shell or in late boundaries' (adapted: Octane's
+	// two resource emit paths are the SSR head fold and the client insert; both
+	// must serialize options through canonical lowercase attributes, with
+	// identity attrs owned by the emit).
+	it('server and client emit paths encode resource attributes identically', async () => {
+		const r = await Server.renderToString(srv.AttrSheet, {});
+		const tag = r.html.match(/<link rel="stylesheet" href="\/attr\.css"[^>]*>/)?.[0];
+		expect(tag).toBeTruthy();
+		expect(tag).toContain('data-precedence="default"');
+		expect(tag).toContain('crossorigin="anonymous"');
+		expect(tag).toContain('media="all"');
+		expect(tag).toContain('integrity="somehash"');
+		expect(tag).toContain('referrerpolicy="origin"');
+		expect(tag).toContain('data-foo="&quot;quoted&quot;"');
+		// The authoring-side names never leak through.
+		expect(tag).not.toContain('crossOrigin');
+		expect(tag).not.toContain(' precedence=');
+
+		await act(() => {
+			mountInto(AttrSheet);
+		});
+		const el = document.head.querySelector('link[href="/attr.css"]')!;
+		expect(el.getAttribute('data-precedence')).toBe('default');
+		expect(el.getAttribute('crossorigin')).toBe('anonymous');
+		expect(el.getAttribute('media')).toBe('all');
+		expect(el.getAttribute('integrity')).toBe('somehash');
+		expect(el.getAttribute('referrerpolicy')).toBe('origin');
+		expect(el.getAttribute('data-foo')).toBe('"quoted"');
+		expect(el.hasAttribute('precedence')).toBe(false);
+	});
+
+	// Per ReactDOMFloat-test.js:2936 — 'does not preload nomodule scripts'
+	it('server: nomodule scripts hoist (async) or stay in place (sync) without preloads', async () => {
+		const r = await Server.renderToString(srv.NoModuleScripts, {});
+		expect(r.html).not.toContain('rel="preload"');
+		expect(r.html).not.toContain('rel="modulepreload"');
+		const bodyStart = r.html.indexOf('<div class="nomodule-host"');
+		const headHtml = r.html.slice(0, bodyStart);
+		const bodyHtml = r.html.slice(bodyStart);
+		// The async form is a hoisted resource that keeps its nomodule attribute…
+		const hoisted = headHtml.match(/<script src="\/nomodule-async\.js"[^>]*>/)?.[0];
+		expect(hoisted).toBeTruthy();
+		expect(hoisted).toContain(' async');
+		expect(hoisted).toContain('nomodule');
+		expect(bodyHtml).not.toContain('/nomodule-async.js');
+		// …while the sync form stays an ordinary in-place element.
+		const inline = bodyHtml.match(/<script src="\/nomodule-sync\.js"[^>]*>/)?.[0];
+		expect(inline).toBeTruthy();
+		expect(inline).toContain('nomodule');
+		expect(headHtml).not.toContain('/nomodule-sync.js');
+	});
+
+	// Per ReactDOMFloat-test.js:2936 — client half of the same contract.
+	it('client: nomodule scripts hoist (async) or stay in place (sync) without preloads', async () => {
+		let c!: HTMLElement;
+		await act(() => {
+			c = mountInto(NoModuleScripts);
+		});
+		expect(
+			document.head.querySelector('link[rel="preload"], link[rel="modulepreload"]'),
+		).toBeNull();
+		const hoisted = document.head.querySelector(
+			'script[src="/nomodule-async.js"]',
+		) as HTMLScriptElement;
+		expect(hoisted).not.toBeNull();
+		expect(hoisted.async).toBe(true);
+		expect(hoisted.hasAttribute('nomodule')).toBe(true);
+		expect(hoisted.getAttribute('data-meaningful')).toBe('');
+		const inline = c.querySelector('script[src="/nomodule-sync.js"]') as HTMLScriptElement;
+		expect(inline).not.toBeNull();
+		expect(inline.hasAttribute('nomodule')).toBe(true);
+		expect(document.head.querySelector('script[src="/nomodule-sync.js"]')).toBeNull();
+	});
+});

--- a/packages/octane/tests/conformance/float-evidence-2.test.ts
+++ b/packages/octane/tests/conformance/float-evidence-2.test.ts
@@ -1,0 +1,535 @@
+// ReactDOMFloat-test.js conformance evidence (slice 2): resource-hint keying
+// and attribute serialization, hint calls from render/effect timing positions,
+// Float resources and hints discovered inside streamed Suspense boundaries,
+// fallback hoistables, and hint no-ops against already-present resources.
+//
+// Cases whose upstream observable is stylesheet LOAD timing (suspensey
+// commits), Fizz's rendered-<img> preload queues, or SuspenseList are
+// dispositions, not ports — see the parity ledger.
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import {
+	act,
+	createRoot,
+	preload,
+	preinit,
+	preloadModule,
+	preinitModule,
+	resetFloatResourceState,
+} from '../../src/index.js';
+import * as Server from 'octane/server';
+import { loadServerFixture } from '../_server-fixture.js';
+import { createPipeableCollector, deferred } from '../_server-stream.js';
+import {
+	RenderAndEffectPreloads,
+	EffectPreinitStyle,
+	RenderPreinitStyle,
+	RenderPreinitScript,
+} from '../_fixtures/float-evidence-2.tsrx';
+
+const srv = loadServerFixture('packages/octane/tests/_fixtures/float-evidence-2.tsrx') as Record<
+	string,
+	any
+>;
+const floatSrv = loadServerFixture(
+	'packages/octane/tests/_fixtures/float-resources.tsrx',
+) as Record<string, any>;
+
+afterEach(() => {
+	document.head
+		.querySelectorAll('[data-oct-hint], [data-precedence], [data-oct-res]')
+		.forEach((el) => el.remove());
+	resetFloatResourceState();
+});
+
+/** Every <link rel="preload"> (or modulepreload) tag in `html` naming `ref`. */
+function preloadTags(html: string, ref: string, rel = 'preload'): string[] {
+	const tags = html.match(new RegExp(`<link rel="${rel}"[^>]*>`, 'g')) ?? [];
+	return tags.filter((t) => t.includes(ref));
+}
+
+function stylesheetTags(html: string, ref: string): string[] {
+	const tags = html.match(/<link rel="stylesheet"[^>]*>/g) ?? [];
+	return tags.filter((t) => t.includes(ref));
+}
+
+async function settleMacrotasks(): Promise<void> {
+	await new Promise((resolve) => setTimeout(resolve, 20));
+}
+
+describe('Float evidence — streamed SSR discovery and flush identity', () => {
+	// Per ReactDOMFloat-test.js:3988
+	it('never flushes a second preload when a rendered stylesheet resource follows a preload', async () => {
+		const gate = deferred<string>();
+		const App = () => {
+			Server.preload('/late-sheet.css', { as: 'style' });
+			return Server.createElement(srv.LateSheetBoundary, { promise: gate.promise }) as any;
+		};
+		const collector = createPipeableCollector();
+		Server.renderToPipeableStream(App as any, {}, {}).pipe(collector.destination);
+		await settleMacrotasks();
+		const shell = collector.chunks.join('');
+		// The shell already carries exactly one preload AND the stylesheet: the
+		// per-round pass discovers the boundary's resource before the head flushes.
+		expect(preloadTags(shell, '/late-sheet.css')).toHaveLength(1);
+		expect(stylesheetTags(shell, '/late-sheet.css')).toHaveLength(1);
+		expect(shell).toContain('data-precedence="default"');
+		gate.resolve('ready');
+		const html = await collector.ended;
+		expect(html).toContain('late-ready');
+		// The revealed boundary payload minted no additional preload or sheet.
+		expect(preloadTags(html, '/late-sheet.css')).toHaveLength(1);
+		expect(stylesheetTags(html, '/late-sheet.css')).toHaveLength(1);
+	});
+
+	// Per ReactDOMFloat-test.js:4040
+	// OCTANE DIVERGENCE: React's Fizz demotes a post-shell preinit to a preload
+	// (the stylesheet never flushes). Octane's per-round pass discovers the
+	// preinit before the shell flushes, so the server coalesces the redundant
+	// preload out of the head fold and ships the real resource instead — the
+	// shared contract is ONE fetch initiator per href, never two.
+	it('a preinitialized stylesheet inside a suspended boundary keeps one initiator per href', async () => {
+		const gate = deferred<string>();
+		const App = () => {
+			Server.preload('/late-preinit.css', { as: 'style' });
+			Server.preload('/late-preinit.js', { as: 'script' });
+			return Server.createElement(srv.LatePreinitBoundary, { promise: gate.promise }) as any;
+		};
+		const collector = createPipeableCollector();
+		Server.renderToPipeableStream(App as any, {}, {}).pipe(collector.destination);
+		await settleMacrotasks();
+		gate.resolve('ready');
+		const html = await collector.ended;
+		expect(html).toContain('late-preinit-ready');
+		// Style: the preinit'd sheet replaced the preload entirely.
+		expect(preloadTags(html, '/late-preinit.css')).toHaveLength(0);
+		expect(stylesheetTags(html, '/late-preinit.css')).toHaveLength(1);
+		// Script: one executable, and the preload coalesced away too.
+		expect(preloadTags(html, '/late-preinit.js')).toHaveLength(0);
+		expect(html.match(/<script src="\/late-preinit\.js" async[^>]*>/g) ?? []).toHaveLength(1);
+	});
+
+	// Per ReactDOMFloat-test.js:4873
+	it('preloads only once per identity when stylesheets, scripts, and module scripts render late', async () => {
+		const gate = deferred<string>();
+		const App = () => {
+			Server.preload('/late-all.css', { as: 'style' });
+			Server.preload('/late-all.js', { as: 'script' });
+			Server.preloadModule('/late-all.mjs');
+			return Server.createElement(srv.LateAllBoundary, { promise: gate.promise }) as any;
+		};
+		const collector = createPipeableCollector();
+		Server.renderToPipeableStream(App as any, {}, {}).pipe(collector.destination);
+		await settleMacrotasks();
+		gate.resolve('ready');
+		const html = await collector.ended;
+		expect(html).toContain('late-all-ready');
+		// One preload per identity (preload-then-render keeps both tags, one-way).
+		expect(preloadTags(html, '/late-all.css')).toHaveLength(1);
+		expect(preloadTags(html, '/late-all.js')).toHaveLength(1);
+		expect(preloadTags(html, '/late-all.mjs', 'modulepreload')).toHaveLength(1);
+		// Exactly one applied resource per identity across all forms.
+		expect(stylesheetTags(html, '/late-all.css')).toHaveLength(1);
+		expect(html.match(/src="\/late-all\.js"/g) ?? []).toHaveLength(1);
+		expect(html.match(/src="\/late-all\.mjs"/g) ?? []).toHaveLength(1);
+	});
+
+	// Per ReactDOMFloat-test.js:5335
+	it('does not flush fallback-authored hoistables into the head', async () => {
+		const gate = deferred<string>();
+		const collector = createPipeableCollector();
+		Server.renderToPipeableStream(srv.FallbackMetaBoundary, { promise: gate.promise }, {}).pipe(
+			collector.destination,
+		);
+		await settleMacrotasks();
+		const shell = collector.chunks.join('');
+		const shellHead = shell.slice(0, shell.indexOf('<div class="fm-host"'));
+		// The pending fallback is showing, yet its metadata never reached the
+		// head fold; the (still suspended) primary content's metadata did.
+		expect(shell).toContain('class="fb"');
+		expect(shellHead).toContain('primary-meta');
+		expect(shellHead).not.toContain('fallback-meta');
+		expect(shellHead).not.toContain('/fallback-author');
+		gate.resolve('ready');
+		const html = await collector.ended;
+		const head = html.slice(0, html.indexOf('<div class="fm-host"'));
+		expect(head).toContain('primary-meta');
+		expect(head).not.toContain('fallback-meta');
+		expect(head).not.toContain('/fallback-author');
+	});
+
+	// Per ReactDOMFloat-test.js:5496
+	it('flushes nothing before the shell; a pre-suspension preinit folds into the shell', async () => {
+		const gate = deferred<string>();
+		const collector = createPipeableCollector();
+		Server.renderToPipeableStream(srv.RootSuspendedPreinit, { promise: gate.promise }, {}).pipe(
+			collector.destination,
+		);
+		await settleMacrotasks();
+		// The root is still suspended: no bytes (hoistables included) may flush.
+		expect(collector.chunks).toEqual([]);
+		gate.resolve('go');
+		const html = await collector.ended;
+		const script = html.indexOf('<script src="/preamble.js" async');
+		const content = html.indexOf('<div class="preamble-ready"');
+		expect(script).toBeGreaterThan(-1);
+		expect(content).toBeGreaterThan(-1);
+		expect(script).toBeLessThan(content);
+	});
+});
+
+describe('Float evidence — hints against already-present resources', () => {
+	// Per ReactDOMFloat-test.js:4093
+	it('does not insert a preload when the underlying resource already exists in the document', async () => {
+		const App = () => {
+			Server.preload('/doc-font.woff2', { as: 'font' });
+			return Server.createElement(
+				'div',
+				null,
+				Server.createElement(floatSrv.SheetA, null),
+				Server.createElement(floatSrv.AsyncScript, null),
+			) as any;
+		};
+		const r = await Server.renderToString(App as any);
+		// The SSR head (stylesheet + async script + font preload) lands in the
+		// document, exactly as a served page would present it to the client.
+		document.head.insertAdjacentHTML('afterbegin', r.html.slice(0, r.html.indexOf('<div')));
+		expect(document.head.querySelectorAll('link[rel="stylesheet"][href="/base.css"]')).toHaveLength(
+			1,
+		);
+
+		preload('/base.css', { as: 'style' });
+		preload('/analytics.js', { as: 'script' });
+		preload('/doc-font.woff2', { as: 'font' });
+		// No new preloads: the stylesheet/script resources and the SSR-emitted
+		// font preload already satisfy every request.
+		expect(document.head.querySelector('link[rel="preload"][href="/base.css"]')).toBeNull();
+		expect(document.head.querySelector('link[rel="preload"][href="/analytics.js"]')).toBeNull();
+		expect(
+			document.head.querySelectorAll('link[rel="preload"][href="/doc-font.woff2"]'),
+		).toHaveLength(1);
+	});
+});
+
+describe('Float evidence — preload keying and option serialization', () => {
+	// Per ReactDOMFloat-test.js:4148
+	it('keys image preloads on imageSrcSet+imageSizes, falling back to href; non-image preloads key on href', () => {
+		preload('img-foo', { as: 'image' });
+		preload('img-foo', { as: 'image' });
+		preload('img-foo', { as: 'image', imageSrcSet: 'fooset' });
+		preload('img-foo2', { as: 'image', imageSrcSet: 'fooset' });
+		preload('img-foo', { as: 'image', imageSrcSet: 'fooset', imageSizes: 'foosizes' });
+		preload('img-foo2', { as: 'image', imageSrcSet: 'fooset', imageSizes: 'foosizes' });
+		// imageSizes without imageSrcSet does not participate in the key.
+		preload('img-foo', { as: 'image', imageSizes: 'foosizes' });
+		preload('img-foo', { as: 'image', imageSizes: 'foosizes' });
+		// Non-image destinations always key on href, srcset options or not.
+		preload('other-bar', { as: 'somethingelse' });
+		preload('other-bar', { as: 'somethingelse', imageSrcSet: 'makes no sense' });
+		preload('other-bar', {
+			as: 'somethingelse',
+			imageSrcSet: 'makes no sense',
+			imageSizes: 'makes no sense',
+		});
+
+		const links = document.head.querySelectorAll('link[rel="preload"]');
+		expect(links).toHaveLength(4);
+		expect(document.head.querySelectorAll('link[rel="preload"][href="img-foo"]')).toHaveLength(1);
+		const bySet = document.head.querySelector('link[imagesrcset="fooset"]:not([imagesizes])')!;
+		expect(bySet).not.toBeNull();
+		expect(bySet.hasAttribute('href')).toBe(false);
+		expect(
+			document.head.querySelectorAll('link[imagesrcset="fooset"][imagesizes="foosizes"]'),
+		).toHaveLength(1);
+		const other = document.head.querySelectorAll('link[rel="preload"][href="other-bar"]');
+		expect(other).toHaveLength(1);
+		expect(other[0].getAttribute('as')).toBe('somethingelse');
+	});
+
+	// Per ReactDOMFloat-test.js:4289
+	it('serializes referrerPolicy on image preloads on the client and the server', async () => {
+		preload('/rp-client', {
+			as: 'image',
+			imageSrcSet: '/rp-client',
+			imageSizes: '100vw',
+			referrerPolicy: 'no-referrer',
+		});
+		const link = document.head.querySelector('link[rel="preload"][imagesrcset="/rp-client"]')!;
+		expect(link).not.toBeNull();
+		expect(link.getAttribute('referrerpolicy')).toBe('no-referrer');
+		expect(link.getAttribute('imagesizes')).toBe('100vw');
+		expect(link.hasAttribute('href')).toBe(false);
+
+		const App = () => {
+			Server.preload('/rp-server', {
+				as: 'image',
+				imageSrcSet: '/rp-server',
+				imageSizes: '100vw',
+				referrerPolicy: 'no-referrer',
+			});
+			return Server.createElement('div', null, 'hello') as any;
+		};
+		const r = await Server.renderToString(App as any);
+		expect(r.html).toMatch(
+			/<link rel="preload"[^>]*imagesrcset="\/rp-server"[^>]*referrerpolicy="no-referrer"/,
+		);
+		expect(r.html).not.toContain('href="/rp-server"');
+	});
+
+	// Per ReactDOMFloat-test.js:4749
+	it('serializes media on image preloads on the client and the server', async () => {
+		preload('/media-client', {
+			as: 'image',
+			imageSrcSet: '/media-client',
+			imageSizes: '100vw',
+			media: 'screen and (max-width: 480px)',
+		});
+		const link = document.head.querySelector('link[rel="preload"][imagesrcset="/media-client"]')!;
+		expect(link).not.toBeNull();
+		expect(link.getAttribute('media')).toBe('screen and (max-width: 480px)');
+
+		const App = () => {
+			Server.preload('/media-server', {
+				as: 'image',
+				imageSrcSet: '/media-server',
+				imageSizes: '100vw',
+				media: 'print and (min-width: 768px)',
+			});
+			return Server.createElement('div', null, 'hello') as any;
+		};
+		const r = await Server.renderToString(App as any);
+		expect(r.html).toMatch(
+			/<link rel="preload"[^>]*imagesrcset="\/media-server"[^>]*media="print and \(min-width: 768px\)"/,
+		);
+	});
+
+	// Per ReactDOMFloat-test.js:6172 (and :6930 for the preinit forms)
+	it('supports fetchPriority on preload and preinit, client and server', async () => {
+		preload('/fp-high.js', { as: 'script', fetchPriority: 'high' });
+		preload('/fp-low.css', { as: 'style', fetchPriority: 'low' });
+		preload('/fp-auto.css', { as: 'style', fetchPriority: 'auto' });
+		expect(
+			document.head
+				.querySelector('link[rel="preload"][href="/fp-high.js"]')!
+				.getAttribute('fetchpriority'),
+		).toBe('high');
+		expect(
+			document.head
+				.querySelector('link[rel="preload"][href="/fp-low.css"]')!
+				.getAttribute('fetchpriority'),
+		).toBe('low');
+		expect(
+			document.head
+				.querySelector('link[rel="preload"][href="/fp-auto.css"]')!
+				.getAttribute('fetchpriority'),
+		).toBe('auto');
+
+		preinit('/fpi-high.js', { as: 'script', fetchPriority: 'high' });
+		preinit('/fpi-low.css', { as: 'style', fetchPriority: 'low' });
+		const script = document.head.querySelector('script[src="/fpi-high.js"]')!;
+		expect(script.getAttribute('fetchpriority')).toBe('high');
+		expect((script as HTMLScriptElement).async).toBe(true);
+		const sheet = document.head.querySelector('link[rel="stylesheet"][href="/fpi-low.css"]')!;
+		expect(sheet.getAttribute('fetchpriority')).toBe('low');
+		expect(sheet.getAttribute('data-precedence')).toBe('default');
+
+		const App = () => {
+			Server.preload('/sfp-high.js', { as: 'script', fetchPriority: 'high' });
+			Server.preinit('/sfp-low.css', { as: 'style', fetchPriority: 'low' });
+			Server.preinit('/sfp-script.js', { as: 'script', fetchPriority: 'high' });
+			return Server.createElement('div', null, 'hello') as any;
+		};
+		const r = await Server.renderToString(App as any);
+		expect(r.html).toMatch(/<link rel="preload" href="\/sfp-high\.js"[^>]*fetchpriority="high"/);
+		expect(r.html).toMatch(
+			/<link rel="stylesheet" href="\/sfp-low\.css" data-precedence="default"[^>]*fetchpriority="low"/,
+		);
+		expect(r.html).toMatch(/<script src="\/sfp-script\.js" async[^>]*fetchpriority="high"/);
+	});
+
+	// Per ReactDOMFloat-test.js:6279
+	it('supports nonce on preload, client and server', async () => {
+		preload('/nonce-client.js', { as: 'script', nonce: 'abc' });
+		const link = document.head.querySelector('link[rel="preload"][href="/nonce-client.js"]')!;
+		expect(link.getAttribute('nonce')).toBe('abc');
+
+		const App = () => {
+			Server.preload('/nonce-server.js', { as: 'script', nonce: 'abc' });
+			return Server.createElement('div', null, 'hello') as any;
+		};
+		const r = await Server.renderToString(App as any);
+		expect(r.html).toMatch(/<link rel="preload" href="\/nonce-server\.js"[^>]*nonce="abc"/);
+	});
+
+	// Per ReactDOMFloat-test.js:6320
+	it('preloads scripts as modules with cors, integrity, and non-default destinations', async () => {
+		preloadModule('/pm-plain.mjs');
+		preloadModule('/pm-default.mjs', { as: 'script' });
+		preloadModule('/pm-cors.mjs', { crossOrigin: 'use-credentials' });
+		preloadModule('/pm-integrity.mjs', { integrity: 'some hash' });
+		preloadModule('/pm-sw.mjs', { as: 'serviceworker' });
+		preloadModule('/pm-plain.mjs'); // deduped by href
+		const links = document.head.querySelectorAll('link[rel="modulepreload"]');
+		expect(links).toHaveLength(5);
+		expect(
+			document.head
+				.querySelector('link[rel="modulepreload"][href="/pm-cors.mjs"]')!
+				.getAttribute('crossorigin'),
+		).toBe('use-credentials');
+		expect(
+			document.head
+				.querySelector('link[rel="modulepreload"][href="/pm-integrity.mjs"]')!
+				.getAttribute('integrity'),
+		).toBe('some hash');
+		expect(
+			document.head
+				.querySelector('link[rel="modulepreload"][href="/pm-sw.mjs"]')!
+				.getAttribute('as'),
+		).toBe('serviceworker');
+
+		const App = () => {
+			Server.preloadModule('/spm-cors.mjs', { crossOrigin: 'use-credentials' });
+			Server.preloadModule('/spm-sw.mjs', { as: 'serviceworker' });
+			Server.preloadModule('/spm-sw.mjs', { as: 'serviceworker' });
+			return Server.createElement('div', null, 'hello') as any;
+		};
+		const r = await Server.renderToString(App as any);
+		expect(r.html).toMatch(
+			/<link rel="modulepreload" href="\/spm-cors\.mjs"[^>]*crossorigin="use-credentials"/,
+		);
+		expect(r.html.match(/href="\/spm-sw\.mjs"/g) ?? []).toHaveLength(1);
+		expect(r.html).toMatch(/<link rel="modulepreload" href="\/spm-sw\.mjs"[^>]*as="serviceworker"/);
+	});
+});
+
+describe('Float evidence — malformed hint diagnostics', () => {
+	// Per ReactDOMFloat-test.js:6733
+	// Octane's diagnostics are adapted (Octane-branded messages), not
+	// React-message-exact; the trigger set and the no-op outcome are the contract.
+	it('preinit dev-warns and no-ops on invalid href or options', () => {
+		const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			preinit(undefined as any, { as: 'style' } as any);
+			preinit('', { as: 'style' });
+			preinit('/bad-preinit', null as any);
+			preinit('/bad-preinit', {} as any);
+			preinit('/bad-preinit', { as: 'foo' });
+			const warns = errSpy.mock.calls.map((c) => String(c[0]));
+			expect(warns.filter((m) => m.includes('preinit'))).toHaveLength(5);
+			expect(document.head.querySelector('[href="/bad-preinit"]')).toBeNull();
+			expect(document.head.querySelector('script[src="/bad-preinit"]')).toBeNull();
+		} finally {
+			errSpy.mockRestore();
+		}
+	});
+
+	// Per ReactDOMFloat-test.js:6407 (and :7113 for preinitModule)
+	// Octane warns on invalid hrefs; invalid option SHAPES are handled leniently
+	// (the tag still inserts) and a non-script preinitModule destination fails
+	// closed as a no-op rather than warning.
+	it('module hints dev-warn on invalid hrefs and stay no-ops; valid hrefs still insert', () => {
+		const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			preloadModule(undefined as any);
+			preloadModule('');
+			preloadModule(123 as any);
+			preinitModule(undefined as any);
+			preinitModule('');
+			const warns = errSpy.mock.calls.map((c) => String(c[0]));
+			expect(warns.filter((m) => m.includes('preloadModule'))).toHaveLength(3);
+			expect(warns.filter((m) => m.includes('preinitModule'))).toHaveLength(2);
+			expect(document.head.querySelector('link[rel="modulepreload"]')).toBeNull();
+
+			// Lenient option shapes: the module preload for a valid href inserts.
+			preloadModule('/lenient-1.mjs', true as any);
+			preloadModule('/lenient-2.mjs', { as: true } as any);
+			expect(document.head.querySelectorAll('link[rel="modulepreload"]')).toHaveLength(2);
+
+			// preinitModule has only the script destination; others fail closed.
+			preinitModule('/fail-closed.mjs', { as: 'style' });
+			expect(document.head.querySelector('script[src="/fail-closed.mjs"]')).toBeNull();
+			expect(document.head.querySelector('link[href="/fail-closed.mjs"]')).toBeNull();
+		} finally {
+			errSpy.mockRestore();
+		}
+	});
+});
+
+describe('Float evidence — hint calls from render and effect positions', () => {
+	const containers: HTMLElement[] = [];
+	const roots: Array<{ unmount(): void }> = [];
+	function mountInto(body: any): void {
+		const c = document.createElement('div');
+		document.body.appendChild(c);
+		containers.push(c);
+		const root = createRoot(c);
+		roots.push(root);
+		root.render(body, {});
+	}
+	afterEach(() => {
+		for (const r of roots.splice(0)) r.unmount();
+		for (const c of containers.splice(0)) c.remove();
+	});
+
+	// Per ReactDOMFloat-test.js:6008
+	it('preload works from render, insertion, layout, and passive effects; font preloads carry type and anonymous CORS', async () => {
+		await act(() => mountInto(RenderAndEffectPreloads));
+		const render = document.head.querySelector('link[rel="preload"][href="/pl-render.css"]')!;
+		expect(render.getAttribute('as')).toBe('style');
+		const font = document.head.querySelector('link[rel="preload"][href="/pl-font.woff2"]')!;
+		expect(font.getAttribute('as')).toBe('font');
+		expect(font.getAttribute('type')).toBe('font/woff2');
+		expect(font.getAttribute('crossorigin')).toBe('');
+		expect(
+			document.head.querySelector('link[rel="preload"][href="/pl-insertion.js"][as="script"]'),
+		).not.toBeNull();
+		const layoutFont = document.head.querySelector('link[rel="preload"][href="/pl-layout.woff2"]')!;
+		expect(layoutFont.getAttribute('crossorigin')).toBe('');
+		expect(
+			document.head.querySelector('link[rel="preload"][href="/pl-passive.css"][as="style"]'),
+		).not.toBeNull();
+	});
+
+	// Per ReactDOMFloat-test.js:6563
+	it('preinit(as style) from an effect inserts the stylesheet into document.head', async () => {
+		await act(() => mountInto(EffectPreinitStyle));
+		const sheet = document.head.querySelector(
+			'link[rel="stylesheet"][href="/effect-preinit.css"]',
+		)!;
+		expect(sheet).not.toBeNull();
+		expect(sheet.getAttribute('data-precedence')).toBe('default');
+		// The rendered tree carries no trace of the resource.
+		expect(document.body.querySelector('link')).toBeNull();
+	});
+
+	// Per ReactDOMFloat-test.js:6480
+	it('preinit(as style) during render creates one deduped stylesheet resource', async () => {
+		await act(() => {
+			mountInto(RenderPreinitStyle);
+			mountInto(RenderPreinitStyle);
+		});
+		expect(
+			document.head.querySelectorAll('link[rel="stylesheet"][href="/render-preinit.css"]'),
+		).toHaveLength(1);
+		expect(
+			document.head
+				.querySelector('link[rel="stylesheet"][href="/render-preinit.css"]')!
+				.getAttribute('data-precedence'),
+		).toBe('default');
+	});
+
+	// Per ReactDOMFloat-test.js:6631
+	it('preinit(as script) during render creates one deduped async script that persists past unmount', async () => {
+		await act(() => {
+			mountInto(RenderPreinitScript);
+			mountInto(RenderPreinitScript);
+		});
+		const scripts = document.head.querySelectorAll('script[src="/render-preinit.js"]');
+		expect(scripts).toHaveLength(1);
+		expect((scripts[0] as HTMLScriptElement).async).toBe(true);
+		await act(() => {
+			for (const r of roots.splice(0)) r.unmount();
+		});
+		// Resources are never removed: re-running a script is unsafe.
+		expect(document.head.querySelectorAll('script[src="/render-preinit.js"]')).toHaveLength(1);
+	});
+});

--- a/packages/octane/tests/conformance/float-evidence-3.test.ts
+++ b/packages/octane/tests/conformance/float-evidence-3.test.ts
@@ -1,0 +1,370 @@
+// Adapted ReactDOMFloat-test.js conformance evidence (slice 3). Each test
+// cites its upstream case and asserts Octane's observable outcome through
+// public APIs. Upstream whole-document (<html>) containers are replaced by
+// ordinary element roots per Octane's root contract; suspensey-commit load
+// gating is out of scope (documented divergence), so assertions target tag
+// placement, identity, options pass-through, and dedupe — never load timing.
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+	act,
+	createRoot,
+	hydrateRoot,
+	flushSync,
+	preinit,
+	preload,
+	resetFloatResourceState,
+} from '../../src/index.js';
+import * as Server from 'octane/server';
+import { loadServerFixture } from '../_server-fixture.js';
+import { mount } from '../_helpers.js';
+import {
+	EffectPreinit,
+	NonceScriptPreinit,
+	IntegrityScriptPreinit,
+	IntegrityStylePreinit,
+	ModulePreinits,
+	EscapedSheetQuote,
+	EscapedSheetBackslash,
+	QUOTE_HREF,
+	SLASH_HREF,
+	SvgContexts,
+	NoscriptScript,
+	ScriptForms,
+	NonceStyle,
+	PlainLinkPage,
+	TitleUpdate,
+} from '../_fixtures/float-evidence-3.tsrx';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+const srv = loadServerFixture('packages/octane/tests/_fixtures/float-evidence-3.tsrx') as Record<
+	string,
+	any
+>;
+
+const containers: HTMLElement[] = [];
+const roots: Array<{ unmount(): void }> = [];
+
+function mountInto(body: any, props: any = {}): HTMLElement {
+	const c = document.createElement('div');
+	document.body.appendChild(c);
+	containers.push(c);
+	const root = createRoot(c);
+	roots.push(root);
+	root.render(body, props);
+	return c;
+}
+
+/** Attribute-value (not selector) matching, since hrefs may be selector syntax. */
+function headElementsWithAttr(tag: string, attr: string, value: string): Element[] {
+	return Array.from(document.head.querySelectorAll(tag)).filter(
+		(el) => el.getAttribute(attr) === value,
+	);
+}
+
+afterEach(() => {
+	for (const r of roots.splice(0)) r.unmount();
+	for (const c of containers.splice(0)) c.remove();
+	// Hoisted metadata is removed by unmount; resources are page-global by
+	// contract, so tests reset the page (head + identity state) themselves.
+	document.head.innerHTML = '';
+	resetFloatResourceState();
+});
+
+describe('Float evidence (slice 3) — preinit options', () => {
+	it('creates a script resource when preinit(as: "script") runs outside render, in an effect', async () => {
+		// Per ReactDOMFloat-test.js:6708
+		await act(() => mountInto(EffectPreinit));
+		const s = document.head.querySelector('script[src="/fe3-effect.js"]') as HTMLScriptElement;
+		expect(s).not.toBeNull();
+		expect(s.async).toBe(true);
+		expect(document.body.querySelector('script')).toBeNull();
+	});
+
+	it('accepts a `nonce` option for as: "script"', async () => {
+		// Per ReactDOMFloat-test.js:6767
+		await act(() => mountInto(NonceScriptPreinit, { src: 'fe3-nonce-client.js' }));
+		const s = document.head.querySelector('script[src="fe3-nonce-client.js"]')!;
+		expect(s.getAttribute('nonce')).toBe('R4nD0m');
+		expect((s as HTMLScriptElement).async).toBe(true);
+
+		const r = await Server.renderToString(srv.NonceScriptPreinit, { src: 'fe3-nonce-srv.js' });
+		const tag = r.html.match(/<script[^>]*src="fe3-nonce-srv\.js"[^>]*>/)?.[0];
+		expect(tag).toBeTruthy();
+		expect(tag).toContain('nonce="R4nD0m"');
+		expect(tag).toContain('async');
+	});
+
+	it('accepts an `integrity` option for as: "script"', async () => {
+		// Per ReactDOMFloat-test.js:6817
+		await act(() =>
+			mountInto(IntegrityScriptPreinit, { src: 'fe3-int-client.js', hash: 'client hash' }),
+		);
+		const s = document.head.querySelector('script[src="fe3-int-client.js"]')!;
+		expect(s.getAttribute('integrity')).toBe('client hash');
+
+		const r = await Server.renderToString(srv.IntegrityScriptPreinit, {
+			src: 'fe3-int-srv.js',
+			hash: 'srv hash',
+		});
+		const tag = r.html.match(/<script[^>]*src="fe3-int-srv\.js"[^>]*>/)?.[0];
+		expect(tag).toBeTruthy();
+		expect(tag).toContain('integrity="srv hash"');
+	});
+
+	it('accepts an `integrity` option for as: "style"', async () => {
+		// Per ReactDOMFloat-test.js:6867
+		await act(() =>
+			mountInto(IntegrityStylePreinit, { src: 'fe3-int-client.css', hash: 'client hash' }),
+		);
+		const l = document.head.querySelector('link[rel="stylesheet"][href="fe3-int-client.css"]')!;
+		expect(l.getAttribute('integrity')).toBe('client hash');
+		expect(l.getAttribute('data-precedence')).toBe('default');
+
+		const r = await Server.renderToString(srv.IntegrityStylePreinit, {
+			src: 'fe3-int-srv.css',
+			hash: 'srv hash',
+		});
+		const tag = r.html.match(/<link rel="stylesheet" href="fe3-int-srv\.css"[^>]*>/)?.[0];
+		expect(tag).toBeTruthy();
+		expect(tag).toContain('integrity="srv hash"');
+		expect(tag).toContain('data-precedence="default"');
+	});
+
+	it('creates script module resources with explicit `as` and `integrity` options', async () => {
+		// Per ReactDOMFloat-test.js:7023
+		await act(() => mountInto(ModulePreinits));
+		const def = document.head.querySelector(
+			'script[src="/fe3-mod-default.mjs"]',
+		) as HTMLScriptElement;
+		expect(def).not.toBeNull();
+		expect(def.type).toBe('module');
+		expect(def.async).toBe(true);
+		const integ = document.head.querySelector('script[src="/fe3-mod-integrity.mjs"]')!;
+		expect(integ.getAttribute('integrity')).toBe('some hash');
+
+		const r = await Server.renderToString(srv.ModulePreinits, {});
+		expect(r.html).toContain('type="module" src="/fe3-mod-default.mjs" async');
+		const tag = r.html.match(/<script[^>]*src="\/fe3-mod-integrity\.mjs"[^>]*>/)?.[0];
+		expect(tag).toBeTruthy();
+		expect(tag).toContain('integrity="some hash"');
+	});
+});
+
+describe('Float evidence (slice 3) — href text is matched by value, never selector syntax', () => {
+	it('matches rendered stylesheet resources whose hrefs contain selector metacharacters', async () => {
+		// Per ReactDOMFloat-test.js:7656
+		await act(() => {
+			mountInto(EscapedSheetQuote);
+			mountInto(EscapedSheetQuote); // deduped by exact href value
+			mountInto(EscapedSheetBackslash);
+			mountInto(EscapedSheetBackslash); // deduped by exact href value
+		});
+		const quote = headElementsWithAttr('link[rel="stylesheet"]', 'href', QUOTE_HREF);
+		const slash = headElementsWithAttr('link[rel="stylesheet"]', 'href', SLASH_HREF);
+		expect(quote).toHaveLength(1);
+		expect(quote[0].getAttribute('data-precedence')).toBe('style');
+		expect(slash).toHaveLength(1);
+
+		// SSR serializes the attribute escaped, exactly once per identity.
+		const App = () =>
+			Server.createElement(
+				'div',
+				null,
+				Server.createElement(srv.EscapedSheetQuote, null),
+				Server.createElement(srv.EscapedSheetQuote, null),
+				Server.createElement(srv.EscapedSheetBackslash, null),
+			) as any;
+		const r = await Server.renderToString(App as any);
+		expect(r.html.split('fe3-style&quot;][rel=&quot;stylesheet').length - 1).toBe(1);
+		expect(r.html.split('fe3-with\\slashes').length - 1).toBe(1);
+	});
+
+	it('matches preload and preinit calls whose hrefs contain selector metacharacters', async () => {
+		// Per ReactDOMFloat-test.js:7735
+		// SSR emits a preload + a stylesheet resource, then the head lands in the
+		// document the way a served page arrives.
+		const App = () => {
+			Server.preload('fe3-esc-preload', { as: 'style' });
+			Server.preload('fe3-esc\nnewline', { as: 'style' });
+			return Server.createElement(
+				'div',
+				null,
+				Server.createElement(srv.EscapedSheetBackslash, null),
+			) as any;
+		};
+		const r = await Server.renderToString(App as any);
+		document.head.insertAdjacentHTML('afterbegin', r.html.slice(0, r.html.indexOf('<div')));
+
+		// Client calls whose href text is selector syntax must neither throw nor
+		// cross-match the SSR-emitted tags; repeats of SSR hrefs are no-ops.
+		preload('fe3-esc-preload"][rel="preload', { as: 'style' });
+		preinit('fe3-esc-style"][rel="stylesheet', { as: 'style', precedence: 'style' });
+		preload('fe3-esc-preload', { as: 'style' });
+		preload('fe3-esc\nnewline', { as: 'style' });
+		preinit('fe3-with\\slashes', { as: 'style', precedence: 'style' });
+
+		expect(headElementsWithAttr('link[rel="preload"]', 'href', 'fe3-esc-preload')).toHaveLength(1);
+		expect(headElementsWithAttr('link[rel="preload"]', 'href', 'fe3-esc\nnewline')).toHaveLength(1);
+		expect(
+			headElementsWithAttr('link[rel="preload"]', 'href', 'fe3-esc-preload"][rel="preload'),
+		).toHaveLength(1);
+		expect(
+			headElementsWithAttr('link[rel="stylesheet"]', 'href', 'fe3-esc-style"][rel="stylesheet'),
+		).toHaveLength(1);
+		expect(
+			headElementsWithAttr('link[rel="stylesheet"]', 'href', 'fe3-with\\slashes'),
+		).toHaveLength(1);
+	});
+});
+
+describe('Float evidence (slice 3) — classification contexts', () => {
+	it('does not create script resources inside an <svg> context; <foreignObject> re-enables hoisting', async () => {
+		// Per ReactDOMFloat-test.js:8760
+		// The <foreignObject> arms also pin the re-enable halves of
+		// ReactDOMFloat-test.js:7797 (stylesheet resource) and :9301 (meta
+		// hoist); their svg-inline halves are tracked as planned work — Octane's
+		// compiler currently hoists <link>/<meta> from inside <svg> context.
+		await act(() => mountInto(SvgContexts));
+		const path = document.querySelector('.fe3-svg-path')!;
+		const inline = path.querySelector('script')!;
+		expect(inline).not.toBeNull();
+		expect(inline.getAttribute('src')).toBe('/fe3-svg-script.js');
+		expect(document.head.querySelector('script[src="/fe3-svg-script.js"]')).toBeNull();
+		expect(document.head.querySelector('script[src="/fe3-fo-script.js"]')).not.toBeNull();
+		// SVG <title> is an accessibility title, never the document title.
+		const svgTitle = path.querySelector('title')!;
+		expect(svgTitle).not.toBeNull();
+		expect(svgTitle.namespaceURI).toBe(SVG_NS);
+		expect(svgTitle.textContent).toBe('svg inline title');
+		expect(document.head.querySelector('title')).toBeNull();
+		// <foreignObject> content is back under HTML rules: resource + hoist.
+		const hoisted = document.head.querySelector('link[href="/fe3-fo-sheet.css"]')!;
+		expect(hoisted).not.toBeNull();
+		expect(hoisted.getAttribute('data-precedence')).toBe('default');
+		expect(document.head.querySelector('meta[name="fe3-fo-meta"]')).not.toBeNull();
+
+		const r = await Server.renderToString(srv.SvgContexts, {});
+		const bodyStart = r.html.indexOf('<section');
+		expect(r.html.slice(0, bodyStart)).toContain('/fe3-fo-script.js');
+		expect(r.html.slice(0, bodyStart)).toContain('/fe3-fo-sheet.css');
+		expect(r.html.slice(0, bodyStart)).toContain('fe3-fo-meta');
+		expect(r.html.slice(0, bodyStart)).not.toContain('/fe3-svg-script.js');
+		expect(r.html.slice(0, bodyStart)).not.toContain('svg inline title');
+		expect(r.html.slice(bodyStart)).toContain('/fe3-svg-script.js');
+		expect(r.html.slice(bodyStart)).toContain('svg inline title');
+		expect(r.html.slice(bodyStart)).not.toContain('/fe3-fo-sheet.css');
+	});
+
+	it('does not create script resources inside a <noscript> context', async () => {
+		// Per ReactDOMFloat-test.js:8820
+		await act(() => mountInto(NoscriptScript));
+		const ns = document.querySelector('.fe3-nss noscript')!;
+		expect(ns).not.toBeNull();
+		expect(ns.innerHTML).toContain('/fe3-noscript.js');
+		expect(document.head.querySelector('script[src="/fe3-noscript.js"]')).toBeNull();
+
+		const r = await Server.renderToString(srv.NoscriptScript, {});
+		const nsStart = r.html.indexOf('<noscript');
+		expect(nsStart).toBeGreaterThan(-1);
+		expect(r.html.slice(0, nsStart)).not.toContain('/fe3-noscript.js');
+		expect(r.html.slice(nsStart, r.html.indexOf('</noscript>'))).toContain('/fe3-noscript.js');
+	});
+
+	it('treats only handler-free external async scripts as resources', async () => {
+		// Per ReactDOMFloat-test.js:8681
+		const c = document.createElement('div');
+		document.body.appendChild(c);
+		containers.push(c);
+		const root = createRoot(c);
+		await act(() => root.render(ScriptForms, { onLoad: () => {} }));
+
+		const res = document.head.querySelector('script[src="/fe3-resource.js"]') as HTMLScriptElement;
+		expect(res).not.toBeNull();
+		expect(res.async).toBe(true);
+		const section = c.querySelector('.fe3-scripts')!;
+		expect(section.querySelector('script[src="/fe3-handler.js"]')).not.toBeNull();
+		expect(section.querySelector('script[src="/fe3-plain.js"]')).not.toBeNull();
+		const deferred = section.querySelector('script[src="/fe3-defer.js"]')!;
+		expect(deferred.hasAttribute('defer')).toBe(true);
+		expect(document.head.querySelector('script[src="/fe3-handler.js"]')).toBeNull();
+		expect(document.head.querySelector('script[src="/fe3-plain.js"]')).toBeNull();
+
+		// Unmount: the resource persists; per-site scripts leave with their tree.
+		root.unmount();
+		expect(document.head.querySelector('script[src="/fe3-resource.js"]')).not.toBeNull();
+		expect(c.querySelector('script')).toBeNull();
+
+		const r = await Server.renderToString(srv.ScriptForms, { onLoad: () => {} });
+		const bodyStart = r.html.indexOf('<section');
+		expect(r.html.slice(0, bodyStart)).toContain('/fe3-resource.js');
+		const body = r.html.slice(bodyStart);
+		expect(body).not.toContain('/fe3-resource.js');
+		expect(body).toContain('/fe3-handler.js');
+		expect(body).toContain('/fe3-plain.js');
+		expect(body).toContain('/fe3-defer.js');
+		expect(body).not.toMatch(/onload/i);
+	});
+});
+
+describe('Float evidence (slice 3) — style-resource nonce and hoistable lifecycle', () => {
+	it('emits style resources with a nonce', async () => {
+		// Per ReactDOMFloat-test.js:8599
+		// OCTANE DIVERGENCE: one <style> tag per resource (no same-precedence rule
+		// merging) and a single RenderOptions.nonce channel rather than per-kind
+		// nonce options; the nonce asserted here rides the authored prop.
+		await act(() => mountInto(NonceStyle));
+		const style = document.head.querySelector('style[data-href="fe3-nonce-css"]')!;
+		expect(style).not.toBeNull();
+		expect(style.getAttribute('nonce')).toBe('R4nD0m');
+		expect(style.getAttribute('data-precedence')).toBe('default');
+		expect(style.textContent).toContain('hotpink');
+
+		const r = await Server.renderToString(srv.NonceStyle, {});
+		const tag = r.html.match(/<style[^>]*data-href="fe3-nonce-css"[^>]*>/)?.[0];
+		expect(tag).toBeTruthy();
+		expect(tag).toContain('nonce="R4nD0m"');
+	});
+
+	it('hoists non-stylesheet link tags on the server and hydrates them on the client', async () => {
+		// Per ReactDOMFloat-test.js:8937
+		const r = await Server.renderToString(srv.PlainLinkPage, {});
+		const bodyStart = r.html.indexOf('<main');
+		expect(bodyStart).toBeGreaterThan(-1);
+		document.head.innerHTML = r.html.slice(0, bodyStart);
+		const c = document.createElement('div');
+		document.body.appendChild(c);
+		containers.push(c);
+		c.innerHTML = r.html.slice(bodyStart);
+		const serverLink = document.head.querySelector('link[href="/fe3-author"]')!;
+		expect(serverLink).not.toBeNull();
+		expect(serverLink.getAttribute('data-foo')).toBe('data');
+		expect(serverLink.getAttribute('rel')).toBe('author');
+
+		const root = hydrateRoot(c, PlainLinkPage, {});
+		flushSync(() => {});
+		// Adopted, not duplicated.
+		expect(document.head.querySelector('link[href="/fe3-author"]')).toBe(serverLink);
+		expect(document.head.querySelectorAll('link[href="/fe3-author"]')).toHaveLength(1);
+
+		root.unmount();
+		expect(serverLink.isConnected).toBe(false);
+	});
+
+	it('updates hoisted title text and attributes in place', () => {
+		// Per ReactDOMFloat-test.js:9408
+		const m = mount(TitleUpdate as any, { text: 'a title', foo: 'foo' });
+		const title = document.head.querySelector('title')!;
+		expect(title).not.toBeNull();
+		expect(title.textContent).toBe('a title');
+		expect(title.getAttribute('data-foo')).toBe('foo');
+
+		m.update(TitleUpdate as any, { text: 'another title', foo: 'bar' });
+		expect(document.head.querySelector('title')).toBe(title);
+		expect(title.textContent).toBe('another title');
+		expect(title.getAttribute('data-foo')).toBe('bar');
+
+		m.unmount();
+		expect(title.isConnected).toBe(false);
+	});
+});

--- a/packages/octane/tests/hydration/_fixtures/hoist-exclusions.tsrx
+++ b/packages/octane/tests/hydration/_fixtures/hoist-exclusions.tsrx
@@ -28,3 +28,13 @@ export function MicrodataResources() @{
 		<span class="mdr-body">{'mdr' as string}</span>
 	</section>
 }
+
+// SVG lexical scope: link/meta are svg-namespace content there — React keeps
+// them inline (only foreignObject switches back to the HTML hoisting rules).
+export function SvgScoped() @{
+	<svg id="svg-host" viewBox="0 0 10 10">
+		<link rel="stylesheet" href="/svg-scoped.css" precedence="default" />
+		<meta name="svg-meta" content="inline" />
+		<circle cx="5" cy="5" r="4" />
+	</svg>
+}

--- a/packages/octane/tests/hydration/hoist-exclusions.test.ts
+++ b/packages/octane/tests/hydration/hoist-exclusions.test.ts
@@ -8,7 +8,12 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createRoot, hydrateRoot, flushSync, resetFloatResourceState } from '../../src/index.js';
 import * as ServerRT from 'octane/server';
 import { loadServerFixture } from '../_server-fixture.js';
-import { Microdata, MicrodataResources, NoscriptMeta } from './_fixtures/hoist-exclusions.tsrx';
+import {
+	Microdata,
+	MicrodataResources,
+	NoscriptMeta,
+	SvgScoped,
+} from './_fixtures/hoist-exclusions.tsrx';
 
 const srv = loadServerFixture(
 	'packages/octane/tests/hydration/_fixtures/hoist-exclusions.tsrx',
@@ -82,6 +87,31 @@ describe('document-metadata hoist exclusions (itemProp + noscript)', () => {
 		const hostHtml = r.html.slice(hostStart);
 		expect(hostHtml).toContain('/mdr.css');
 		expect(hostHtml).toContain('/mdr.js');
+	});
+
+	// Per ReactDOMFloat-test.js:7797/:9301 — resources and metadata inside an
+	// SVG lexical scope stay inline (svg-namespace content, not document head).
+	it('client + server: SVG-scoped link/meta stay inline, never resources', async () => {
+		const root = createRoot(container);
+		root.render(SvgScoped, {});
+		flushSync(() => {});
+		const svg = container.querySelector('#svg-host')!;
+		expect(svg.querySelector('link')).not.toBeNull();
+		// <meta> sits on the HTML parser's foreign-content BREAKOUT list, so
+		// template cloning cannot keep it inside <svg> on pure client mounts (a
+		// documented bound of the template model); the contract pinned here is
+		// that svg-scoped metadata never becomes document metadata.
+		expect(document.head.querySelector('link[href="/svg-scoped.css"]')).toBeNull();
+		expect(document.head.querySelector('meta[name="svg-meta"]')).toBeNull();
+		root.unmount();
+
+		const r = await ServerRT.renderToString(srv.SvgScoped, {});
+		const svgStart = r.html.indexOf('<svg');
+		expect(r.html.slice(0, svgStart)).not.toContain('/svg-scoped.css');
+		expect(r.html.slice(0, svgStart)).not.toContain('svg-meta');
+		const svgHtml = r.html.slice(svgStart);
+		expect(svgHtml).toContain('/svg-scoped.css');
+		expect(svgHtml).toContain('svg-meta');
 	});
 
 	// Per ReactDOMFloat-test.js — 'does not hoist inside noscript context'

--- a/packages/octane/tests/resource-hints.test.ts
+++ b/packages/octane/tests/resource-hints.test.ts
@@ -198,8 +198,13 @@ describe('resource hints — client', () => {
 			expect(document.head.querySelector('link[href="/coerced.css"]')).toBeNull();
 			preloadModule(123 as any);
 			expect(document.head.querySelector('link[rel="modulepreload"]')).toBeNull();
+			preinitModule('/bad-dest.mjs', { as: 'style' }); // invalid module destination
+			expect(
+				document.head.querySelector('[href="/bad-dest.mjs"], [src="/bad-dest.mjs"]'),
+			).toBeNull();
 			const warns = errSpy.mock.calls.map((c) => String(c[0]));
 			expect(warns.some((m) => m.includes('href'))).toBe(true);
+			expect(warns.some((m) => m.includes('preinitModule'))).toBe(true);
 		} finally {
 			errSpy.mockRestore();
 		}


### PR DESCRIPTION
## Summary

Retires the largest block of #711's test-evidence backlog: all **121 planned `ReactDOMFloat-test.js` ledger cases** are now dispositioned, each against the upstream test body at the pinned commit (`6117d7cca490`).

- **59 → `covered`** with executable adapted evidence: 41 newly ported conformance tests (`float-evidence-{1,2,3}.test.ts` + fixtures, every `it` citing its upstream line) plus links into the existing Float/hint/hoist suites where behavior was already pinned. Modes recorded per case (client / server-string / server-stream / hydrate-match / production-compile).
- **54 → `documented`** (48 non-goal, 6 divergence) with per-case rationale: suspensey commits, whole-document/`createRoot(document)` containers, Fizz bootstrap/external-runtime instruction protocol, Fizz's rendered-`<img>` preload scanning, SuspenseList, shadow-root resource scoping, and streamed-boundary head content (the standing documented divergence).
- **8 stay `planned`**, honestly: 4 against two newly-surfaced engine gaps (below), 3 warning-message families Octane doesn't emit yet, and 1 server-side hoistable prioritization case (charset/viewport-class metadata ordered ahead of other head content).

## Fixes folded in (both red-first)

- **SVG hoist gate**: the partition treated `isHoistableHeadElementNode` as SVG-exempt, so a precedence link inside `<svg>` hoisted AND re-classified as a stylesheet resource. The whole hoist model is now HTML-scoped (`foreignObject` re-enters). One documented template-model bound: `<meta>` inside `<svg>` on pure client mounts is relocated by the HTML parser's foreign-content breakout rules — it still never becomes document metadata, and SSR serializes it inline correctly.
- **`preinitModule` invalid-`as`** now warns in development as the docs promised, instead of failing silently.

## Engine gaps surfaced (to file in #711, not fixed here)

1. **Streaming drops late-discovered Float resources**: resources registered after the shell pass (nested pending boundaries, `use()`-gated hrefs) appear nowhere in the streamed HTML — only the first pass's head is written. Three deferred cases pin the observable; repro details in the spawned follow-up task. Counterpart strength, now test-pinned: statically-declared sheets inside pending boundaries flush WITH the shell, precedence-normalized (stronger than React's segment-time insertion).
2. **Transitive fallback-hoistable suppression**: Octane hoists `<meta>` from a completed boundary nested inside a pending boundary's *fallback* into the streamed head; React suppresses fallback hoistables transitively. Direct inline-fallback hoistables are correctly suppressed (ported).
3. (Observation, adjudication needed): pure-client mounts of nested `@try` trees produce precedence *group order* by leaves-first execution ([three, one, two]) where SSR/React give [one, two, three]; dedupe/contiguity/within-group order all hold.

## Process

Three parallel agents each owned a disjoint line-range slice with its own test file, reporting machine-readable decisions; ledger flips were applied centrally. Red-capability was spot-verified per slice by temporary runtime/fixture breaks (all reverted; diffs clean except new files). Consolidation fixed agent-report drift deterministically: mode labels normalized to the schema enum via a mapping table, multi-test evidence strings split into per-test records.

## Validation

- [x] `pnpm format`, `pnpm typecheck`
- [x] `pnpm test` — 21,192 passed, 8 failed; every failure triaged as not-from-this-diff (below)
- [x] `node scripts/react-parity/check.mjs` — ledger + coverage metadata validate clean, and **all new evidence tests passed** inside the parity-wide lane; the lane itself reported two non-passing tests, both accounted for below
- [x] targeted re-runs: `float-evidence-1` (20), `float-evidence-2` (36), `float-evidence-3` (26), `hoist-exclusions` (+SVG case), `resource-hints` (+preinitModule warn), plus the head/svg/float neighbor suites

Local-failure triage (none caused by this diff):
- `day-picker/calendar.test.ts` (2) and `alien-signals/upstream-original.test.ts` (1): reproduce identically with this PR's source files restored to pristine `main` — pre-existing local-environment failures; main CI is green.
- `day-picker.browser`, `drei/upstream-e2e.browser`, `vaul/snap-drag.browser`, `doom-production` (1 each): the known local browser-lane provisioning noise.
- `native-change.test.ts` browser lane (1) and `markdown/public-types.test.ts` (parity lane): 30s-timeout/registration flakes under full-suite CPU contention; both pass in isolation (12/12 and 1/1).

## Risk / follow-ups

- The three warning-family cases, four gap-blocked cases, and one hoistable-prioritization case remain `planned` by design.
- After merge: refresh #711's counts (ReactDOMFloat planned drops 121 → 8) and add the two engine gaps + the group-order observation as tracked items.
- The tsrx-prettier quote-folding hazard bit both agents (worked around via module constants) — already tracked in the formatter's known-bugs list.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly conformance evidence and docs, but the SVG hoist-partition change and `preinitModule` warning touch document-head metadata/resource behavior on client and SSR.
> 
> **Overview**
> Retires the planned `ReactDOMFloat-test.js` backlog: **59** cases now have executable adapted evidence (41 newly ported conformance tests across three suites, plus links into existing Float/hint suites), **54** are documented non-goals/divergences with rationale, and **8** remain planned against engine gaps, warning families, and hoistable prioritization.
> 
> Folds in two small fixes the evidence work surfaced: document-metadata hoisting is now **HTML-scoped** (nothing hoists from an SVG lexical context; `foreignObject` re-enters HTML rules), and `preinitModule` with an invalid `as` warns in development instead of failing silently.
> 
> Updates parity coverage counts and documents the SVG hoist exclusion bound in `differences-from-react.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e7d4c070a9ca77aa4fbd5df96c0310054a503db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->