### PR TITLE
fix: ship Float sheet resources discovered after the streaming shell

### DIFF
--- a/.changeset/streamed-late-float-sheets.md
+++ b/.changeset/streamed-late-float-sheets.md
@@ -1,0 +1,24 @@
+---
+'octane': patch
+---
+
+Ship Float sheet resources discovered after the streaming shell.
+
+Streaming SSR dropped `<link rel="stylesheet" href precedence>` and
+`<style href precedence>` resources whose registration only ran on a
+post-shell pass — a sheet inside a nested pending boundary, or one whose href
+is computed from a `use()` resolution. Only the shell pass's head ever
+flushed, so streamed content revealed unstyled until hydration re-inserted the
+sheet client-side, and documents consumed without JavaScript never received
+the CSS at all.
+
+Each resolution wave now diffs the pass's per-resource sheet registrations
+against what is already on the wire and ships new tags with the wave chunk,
+ahead of its segment reveals: real markup in a hidden carrier (so no-JS
+consumers still get working CSS) plus an inline `$OCTRH` call that hoists the
+tags into `document.head` under the client's precedence grouping. Once client
+Float resource state exists, the hoist hands each tag to the live runtime
+instead, keeping dedupe and group ordering in one authority, and a hydrating
+client adopts the streamed tags without duplicating. A still-pending child
+boundary's sheet rides its parent's reveal wave, matching React's hoisting of
+partial-boundary resources.

--- a/docs/ssr.md
+++ b/docs/ssr.md
@@ -146,7 +146,8 @@ shell is written and therefore before `onShellReady` and before
 `renderToReadableStream`'s promise resolves, so a host still has time to place
 the metadata in a template prefix it writes ahead of the render stream. It
 carries the shell's metadata only; head elements hoisted inside a boundary that
-streams later are still re-created client-side (see "Not built yet"). A recoverable error in
+streams later are still re-created client-side, while late-discovered Float
+sheet resources ride the stream itself (see "Not built yet"). A recoverable error in
 Suspense content reaches `onError`, preserves the emitted fallback, and marks
 only that boundary for client rendering. Calling `abort(reason)` reports the
 reason for each abandoned pending task, preserves emitted fallbacks for client
@@ -424,9 +425,14 @@ These are the known gaps between Octane SSR and a full streaming SSR stack:
 
 - **Selective / progressive hydration**: `hydrateRoot` adopts the whole tree in
   one synchronous pass (and there is no synthetic event replay, by design).
-- **Streamed head hoisting**: head elements hoisted from INSIDE a streamed
-  Suspense boundary don't ship in the stream (the shell already flushed); the
-  client re-creates them on hydration.
+- **Streamed head hoisting**: head elements and resource hints hoisted from
+  INSIDE a streamed Suspense boundary don't ship in the stream (the shell
+  already flushed); the client re-creates them on hydration. Float **sheet
+  resources** (`<link rel="stylesheet" href precedence>` and
+  `<style href precedence>`) are the exception: sheets discovered after the
+  shell ride the wave chunks as real tags and the inline stream runtime hoists
+  them into `document.head` with the client's precedence grouping, so late
+  content is styled before hydration and no-JS consumers still get the CSS.
 - **Framework-level data serialization**: only suspense seeds cross the boundary
   automatically; loader-style data APIs are app code today.
 - **Error digests**: `onError` and the shell callbacks exist, but there are no

--- a/packages/octane/src/constants.ts
+++ b/packages/octane/src/constants.ts
@@ -136,6 +136,9 @@ export const STREAM_SEGMENT_ATTR = 'data-oct-s';
 export const STREAM_SEED_ATTR = 'data-oct-seed';
 /** Renderer-owned executable/data scripts emitted by the streaming protocol. */
 export const STREAM_SCRIPT_ATTR = 'data-octane-stream';
+/** Hidden carrier for Float sheet resources discovered after the shell; the
+ *  inline `$OCTRH` call hoists its tags into document.head. */
+export const STREAM_RESOURCE_ATTR = 'data-oct-fr';
 /** Comment-data prefix left in a swapped boundary for hydration seed scoping. */
 export const STREAM_SEED_COMMENT = 'oct-seed:';
 

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -47,6 +47,7 @@ import {
 	STREAM_SEED_ATTR,
 	STREAM_SCRIPT_ATTR,
 	STREAM_SEED_COMMENT,
+	STREAM_RESOURCE_ATTR,
 	POSITIVE_NUMERIC_ATTR_PROPS,
 	BOOLEAN_ATTR_PROPS,
 	MUST_USE_PROPERTY_PROPS,
@@ -198,12 +199,14 @@ interface HeadBuffer {
 	/** Resource-hint + Float-resource dedupe keys emitted during this pass. */
 	hints: Set<string>;
 	/**
-	 * React Float stylesheet resources, grouped by precedence: precedence →
-	 * concatenated `<link>` html. Map insertion order IS group order
-	 * (first-encounter), and groups fold after `html` at capture time. Null
-	 * until the first stylesheet resource so ordinary passes pay nothing.
+	 * React Float sheet-family resources (stylesheet links + style resources),
+	 * one entry per resource: href identity → its precedence and rendered tag.
+	 * Map insertion order IS emit order, so the precedence groups fold in
+	 * first-encounter group order at capture time, and the streaming renderer
+	 * can diff INDIVIDUAL resources across waves to ship late discoveries.
+	 * Null until the first sheet resource so ordinary passes pay nothing.
 	 */
-	sheets: Map<string, string> | null;
+	sheets: Map<string, { precedence: string; html: string }> | null;
 	/**
 	 * Hint tags keyed for COALESCING: a preinit deletes the now-redundant
 	 * preload entry before the fold (React folds preload → initialized
@@ -220,7 +223,14 @@ interface HeadBuffer {
 function headHtmlWithSheets(buf: HeadBuffer): string {
 	let out = buf.html;
 	if (buf.hintHtml !== null) for (const tag of buf.hintHtml.values()) out += tag;
-	if (buf.sheets !== null) for (const group of buf.sheets.values()) out += group;
+	if (buf.sheets !== null && buf.sheets.size > 0) {
+		// Group by precedence in first-encounter group order: the per-resource map
+		// keeps emit order, so the first resource of each precedence opens its group.
+		const groups = new Map<string, string>();
+		for (const entry of buf.sheets.values())
+			groups.set(entry.precedence, (groups.get(entry.precedence) ?? '') + entry.html);
+		for (const group of groups.values()) out += group;
+	}
 	return out;
 }
 let HEAD: HeadBuffer | null = null;
@@ -2955,7 +2965,7 @@ function rewindComponentReplayState(
 			// second rewind from the same snapshot restores identically).
 			const sheets = (snapshot.head.sheets ??= new Map());
 			sheets.clear();
-			for (const [precedence, group] of snapshot.headSheets) sheets.set(precedence, group);
+			for (const [href, entry] of snapshot.headSheets) sheets.set(href, entry);
 		}
 		if (snapshot.headHintHtml === null) snapshot.head.hintHtml = null;
 		else {
@@ -5421,6 +5431,9 @@ interface FullPassResult {
 	/** Per-hash scoped stylesheets from this pass — the streaming renderer diffs
 	 *  these against what it already flushed to emit late boundaries' styles. */
 	cssEntries: Map<string, string>;
+	/** Per-resource Float sheet tags from this pass (see HeadBuffer.sheets) —
+	 *  diffed the same way so late-discovered resources ride the wave chunks. */
+	sheets: Map<string, { precedence: string; html: string }> | null;
 }
 
 // Snapshot / install / restore the module globals around ONE synchronous pass
@@ -5615,6 +5628,7 @@ function runFullFramedPass(
 		rootSuspended,
 		vtCandidates,
 		cssEntries: cssMap,
+		sheets: headBuf.sheets,
 	};
 }
 
@@ -6344,9 +6358,14 @@ export function renderToStaticMarkup(
 //     each resolution wave costs one full pass (reusing `prerender`'s cache +
 //     discovery engine), buying per-boundary delivery: a boundary streams at
 //     its own resolve time, not at the round's slowest sibling.
-//   - Head elements hoisted from INSIDE a streamed boundary don't ship in the
-//     stream (the shell's head already flushed); the client re-creates them on
-//     hydration via headBlock.
+//   - Head ELEMENTS and hints hoisted from INSIDE a streamed boundary don't
+//     ship in the stream (the shell's head already flushed); the client
+//     re-creates them on hydration via headBlock / the hint emitters. Float
+//     SHEET resources are the exception: each wave diffs `pass.sheets` against
+//     what is already on the wire and ships new tags in a hidden carrier that
+//     the inline `$OCTRH` hoists into document.head — without it, late-styled
+//     content would FOUC until hydration and a no-JS consumer would never
+//     receive the CSS at all.
 // ═══════════════════════════════════════════════════════════════════════════
 
 interface StreamBoundary {
@@ -6647,7 +6666,7 @@ export function ssrTry(
 					else {
 						const sheets = (head.sheets ??= new Map());
 						sheets.clear();
-						for (const [precedence, group] of headSheets) sheets.set(precedence, group);
+						for (const [href, entry] of headSheets) sheets.set(href, entry);
 					}
 					if (headHintHtml === null) head.hintHtml = null;
 					else {
@@ -6869,6 +6888,25 @@ function streamRuntimeJs(): string {
 		STREAM_BOUNDARY_ATTR +
 		"=\"'+id+'\"]');" +
 		'if(t){if(so)t.remove();else t.setAttribute("data-oct-err","");}};' +
+		// $OCTRH(id): hoist a wave carrier's Float sheet tags into document.head.
+		// With a live client runtime (window.$OCTFR, installed once client Float
+		// resource state exists) each tag is handed over so ONE authority keeps
+		// deduping and ordering; otherwise insert directly under the client's
+		// precedence policy — append to the tag's group, open a new group after
+		// the last existing one, else append to head.
+		'window.$OCTRH=function(id){' +
+		"var c=d.querySelector('[" +
+		STREAM_RESOURCE_ATTR +
+		"=\"'+id+'\"]');" +
+		'if(!c)return;var n;' +
+		'while((n=c.firstElementChild)){c.removeChild(n);' +
+		'if(window.$OCTFR){window.$OCTFR(n);continue;}' +
+		'var p=n.getAttribute("data-precedence"),' +
+		'g=d.head.querySelectorAll("link[data-precedence],style[data-precedence]"),' +
+		't=g.length?g[g.length-1]:null,x=null;' +
+		'for(var i=0;i<g.length;i++)if(g[i].getAttribute("data-precedence")===p)x=g[i];' +
+		'if(x)x.after(n);else if(t)t.after(n);else d.head.appendChild(n);}' +
+		'c.remove();};' +
 		'})();');
 }
 
@@ -6941,7 +6979,8 @@ export interface StreamOptions extends RenderOptions {
 	 * the default `'fold'`, where the metadata rides the shell.
 	 *
 	 * Only the shell's metadata: head elements hoisted from inside a Suspense
-	 * boundary that streams later are re-created client-side on hydration (see
+	 * boundary that streams later are re-created client-side on hydration,
+	 * while late-discovered Float sheet resources ride the stream itself (see
 	 * docs/ssr.md).
 	 */
 	onHeadReady?: (head: string) => void;
@@ -7064,6 +7103,30 @@ function segmentChunk(b: StreamBoundary, nonceAttr: string): string {
 		'>$OCTRC(' +
 		JSON.stringify(b.id).replace(/</g, '\\u003c') +
 		hasNamespaceCarrier +
+		')</script>'
+	);
+}
+
+/**
+ * Float sheet resources discovered after the shell flushed: the REAL tags ride
+ * the wave inside a hidden carrier — a consumer without JS still gets working
+ * CSS, since stylesheet links and style tags apply from body — and the inline
+ * `$OCTRH` call hoists them into document.head with the client's precedence
+ * grouping, ahead of the wave's segment reveals so revealed content is styled.
+ */
+function floatResourceChunk(tags: string, carrierId: string, nonceAttr: string): string {
+	return (
+		'<div hidden ' +
+		STREAM_RESOURCE_ATTR +
+		'="' +
+		escapeAttr(carrierId) +
+		'">' +
+		tags +
+		'</div><script ' +
+		STREAM_SCRIPT_ATTR +
+		nonceAttr +
+		'>$OCTRH(' +
+		JSON.stringify(carrierId).replace(/</g, '\\u003c') +
 		')</script>'
 	);
 }
@@ -7191,6 +7254,9 @@ async function runStream(
 		});
 
 	const emittedCss = new Set<string>();
+	/** Float sheet hrefs already on the wire (shell head fold or a wave carrier). */
+	const flushedSheets = new Set<string>();
+	let resourceChunkSeq = 0;
 	const flushedSegments = new Set<string>();
 	const observedDone = new Set<string>();
 	const reachableDoneSegments = (): StreamBoundary[] => {
@@ -7287,6 +7353,10 @@ async function runStream(
 	reportRecoverableBoundaryErrors();
 	// SHELL: styles first (so painted fallbacks are styled), hoisted head, body,
 	// the shell-scope seed script, then the swap runtime iff anything is pending.
+	// Every Float sheet the shell pass collected rides the shell head fold
+	// (or onHeadReady under the separate head channel) — record it so wave
+	// diffs never re-ship one.
+	if (pass.sheets !== null) for (const key of pass.sheets.keys()) flushedSheets.add(key);
 	let leadingStyles = '';
 	for (const [hash, sheet] of pass.cssEntries) {
 		emittedCss.add(hash);
@@ -7419,6 +7489,27 @@ async function runStream(
 					'>' +
 					escapeEntireInlineStyleContent(sheet) +
 					'</style>';
+			}
+			// Float sheet resources this pass discovered that are not on the wire
+			// yet — a suspended arm registers its sheets before its use() throws, so
+			// a still-pending child boundary's sheet ships with its PARENT's reveal
+			// wave (React hoists partial-boundary resources the same way) and CSS
+			// fetches start as early as possible. Resources are page-global and
+			// retained by contract, so shipping ahead of the reveal is safe.
+			if (pass.sheets !== null) {
+				let resourceTags = '';
+				for (const [key, entry] of pass.sheets) {
+					if (flushedSheets.has(key)) continue;
+					flushedSheets.add(key);
+					resourceTags += entry.html;
+				}
+				if (resourceTags !== '') {
+					chunk += floatResourceChunk(
+						resourceTags,
+						stream.token + '-r' + resourceChunkSeq++,
+						nonceAttr,
+					);
+				}
 			}
 			let madeProgress = false;
 			for (const boundary of stream.boundaries.values()) {
@@ -8206,7 +8297,7 @@ export function ssrStylesheetResource(attrs: Record<string, unknown> | null): st
 		resourceAttrs(attrs, 'link') +
 		'>';
 	const sheets = (HEAD.sheets ??= new Map());
-	sheets.set(precedence, (sheets.get(precedence) ?? '') + tag);
+	sheets.set(href, { precedence, html: tag });
 	return '';
 }
 
@@ -8245,7 +8336,7 @@ export function ssrStyleResource(attrs: Record<string, unknown> | null, css: str
 		css +
 		'</style>';
 	const sheets = (HEAD.sheets ??= new Map());
-	sheets.set(precedence, (sheets.get(precedence) ?? '') + tag);
+	sheets.set(href, { precedence, html: tag });
 	return '';
 }
 

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -27929,6 +27929,20 @@ function resourceState(): ResourceState {
 			const src = el.getAttribute('src');
 			if (src !== null) state.scripts.add(src);
 		}
+		// Streaming SSR can deliver Float sheets AFTER this state seeded (a late
+		// boundary's wave carrier arriving mid-hydration). The stream's inline
+		// $OCTRH hands each tag to this registrar once it exists, so one live
+		// authority keeps deduping and precedence ordering in both directions;
+		// before any client Float call the inline path inserts directly and the
+		// DOM seeding above adopts what it placed.
+		if (typeof window !== 'undefined') {
+			(window as any).$OCTFR = (el: Element): void => {
+				const href = el.getAttribute('href') ?? el.getAttribute('data-href');
+				if (href === null || state.sheets.has(href)) return;
+				insertPrecedenced(state, el, el.getAttribute('data-precedence') ?? '');
+				state.sheets.add(href);
+			};
+		}
 	}
 	return (_resourceState = state);
 }
@@ -28022,6 +28036,8 @@ export function styleResource(attrs: Record<string, unknown> | null, css: string
 export function resetFloatResourceState(): void {
 	_resourceState = null;
 	_preloadTransfer = null;
+	// The streamed-resource registrar closes over the discarded state.
+	if (typeof window !== 'undefined') delete (window as any).$OCTFR;
 }
 
 /** Compiler target for `<script async src>` resources (React Float). */

--- a/packages/octane/tests/_fixtures/float-stream.tsrx
+++ b/packages/octane/tests/_fixtures/float-stream.tsrx
@@ -1,0 +1,84 @@
+import { use } from 'octane';
+
+// Float resources discovered AFTER the streaming shell flushed. A stylesheet
+// declared inside a suspended @try arm — or whose href is computed from a
+// use() resolution — must still reach the streamed document: late resource
+// tags ride the boundary wave chunks and the inline stream runtime moves them
+// into document.head under the same precedence grouping the client runtime
+// uses, so a hydrating client adopts instead of duplicating.
+
+// The child renders only after use() resolves, so nothing about its sheet is
+// known during the shell pass — not even the href.
+export function GatedSheetContent(props) @{
+	<>
+		<link rel="stylesheet" href={'/gated-' + props.name + '.css'} precedence="default" />
+		<style href="gated-tokens" precedence="default">
+			.gated-ready {
+				color: teal;
+			}
+		</style>
+		<span class="gated-ready">{props.name as string}</span>
+	</>
+}
+
+export function GatedSheetBoundary(props) @{
+	<div class="gated">
+		@try {
+			const name = use(props.promise);
+			<GatedSheetContent name={name} />
+		} @pending {
+			<span class="gated-loading">{'loading'}</span>
+		}
+	</div>
+}
+
+// Chained boundaries: the outer arm's sheet sits at the arm body root, so its
+// registration is hoisted above the arm's use() and lands in the shell head.
+// The inner arm first executes only after the outer promise resolves — its
+// sheet is discovered on a later pass and must ride the stream.
+export function NestedLateBoundaries(props) @{
+	<div class="nested-float">
+		@try {
+			const first = use(props.outer);
+			<>
+				<link rel="stylesheet" href="/outer-late.css" precedence="default" />
+				<span class="outer-ready">{first as string}</span>
+				@try {
+					const second = use(props.inner);
+					<>
+						<link rel="stylesheet" href="/inner-late.css" precedence="low" />
+						<span class="inner-ready">{second as string}</span>
+					</>
+				} @pending {
+					<span class="inner-loading">{'inner…'}</span>
+				}
+			</>
+		} @pending {
+			<span class="outer-loading">{'outer…'}</span>
+		}
+	</div>
+}
+
+function SharedSheetContent() @{
+	<>
+		<link rel="stylesheet" href="/shared.css" precedence="default" />
+		<span class="shared-ready">{'ready'}</span>
+	</>
+}
+
+// The same href flushes with the shell (static sibling) and is re-declared by
+// the late arm — the stream must not carry a second copy.
+export function SharedSheetBoundary(props) @{
+	<div class="shared">
+		<link rel="stylesheet" href="/shared.css" precedence="default" />
+		@try {
+			const name = use(props.promise);
+			<>
+				<SharedSheetContent />
+				<span class="shared-value">{name as string}</span>
+			</>
+		} @pending {
+			<span class="shared-loading">{'loading'}</span>
+		}
+	</div>
+}

--- a/packages/octane/tests/_server-stream.ts
+++ b/packages/octane/tests/_server-stream.ts
@@ -175,4 +175,5 @@ export function resetStreamRuntimeGlobals(): void {
 	delete (window as any).$OCTS;
 	delete (window as any).$OCTRC;
 	delete (window as any).$OCTRX;
+	delete (window as any).$OCTRH;
 }

--- a/packages/octane/tests/float-resources.test.ts
+++ b/packages/octane/tests/float-resources.test.ts
@@ -8,11 +8,18 @@
 // contract — Octane documents that as out of scope.
 // Links WITHOUT precedence keep the existing per-site head-element behavior.
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { act, createRoot, resetFloatResourceState } from '../src/index.js';
+import { act, createRoot, flushSync, hydrateRoot, resetFloatResourceState } from '../src/index.js';
 import * as Server from 'octane/server';
 import { loadServerFixture } from './_server-fixture.js';
-import { collectPipeableStream } from './_server-stream.js';
+import {
+	activateStreamedMarkup,
+	collectPipeableStream,
+	createPipeableCollector,
+	deferred,
+	resetStreamRuntimeGlobals,
+} from './_server-stream.js';
 import { preinitModule } from '../src/index.js';
+import { GatedSheetBoundary, GatedSheetContent } from './_fixtures/float-stream.tsrx';
 import {
 	SheetA,
 	ModuleScript,
@@ -331,5 +338,189 @@ describe('Float resources — SSR + hydration dedupe', () => {
 		expect(sheetHrefs()).toEqual(['/base.css']);
 		root.unmount();
 		c.remove();
+	});
+});
+
+// A stylesheet resource discovered only AFTER the shell flushed (inside a
+// suspended @try arm, or with an href computed from a use() resolution) must
+// still reach the streamed response: the tags ride the wave chunks so no-JS
+// consumers get the CSS, and the inline stream runtime moves them into
+// document.head with the client's precedence grouping so late content is
+// styled before hydration and a hydrating client adopts without duplicating.
+describe('Float resources — streamed late boundaries', () => {
+	const containers: HTMLElement[] = [];
+	function streamContainer(): HTMLElement {
+		const c = document.createElement('div');
+		document.body.appendChild(c);
+		containers.push(c);
+		return c;
+	}
+	afterEach(() => {
+		for (const c of containers.splice(0)) c.remove();
+		document.head
+			.querySelectorAll('[data-precedence], [data-oct-res], [data-oct-hint]')
+			.forEach((el) => el.remove());
+		resetFloatResourceState();
+		resetStreamRuntimeGlobals();
+	});
+
+	const srvStream = loadServerFixture(
+		'packages/octane/tests/_fixtures/float-stream.tsrx',
+	) as Record<string, any>;
+
+	// Per ReactDOMFloat-test.js:1923 — 'will include child boundary stylesheet
+	// resources in the boundary reveal instruction'.
+	it('streams a use()-gated dynamic-href sheet late and moves it into document.head', async () => {
+		const d = deferred<string>();
+		const collector = createPipeableCollector();
+		const { pipe } = Server.renderToPipeableStream(
+			srvStream.GatedSheetBoundary,
+			{ promise: d.promise },
+			{ nonce: 'test-nonce' },
+		);
+		pipe(collector.destination);
+		// Nothing about the sheets is knowable at shell time — not even the href.
+		expect(collector.chunks.join('')).not.toContain('gated-x.css');
+		expect(collector.chunks.join('')).not.toContain('gated-tokens');
+		const shellChunkCount = collector.chunks.length;
+		d.resolve('x');
+		const html = await collector.ended;
+
+		// The late tags ship exactly once, in the post-shell stream (a no-JS
+		// consumer still receives working markup).
+		const tail = collector.chunks.slice(shellChunkCount).join('');
+		expect(tail.match(/\/gated-x\.css/g) || []).toHaveLength(1);
+		expect(tail).toContain('data-precedence="default"');
+		expect(tail.match(/data-href="gated-tokens"/g) || []).toHaveLength(1);
+		expect(tail).toContain('.gated-ready');
+		// CSP: every inline script the wave emits (the resource hoist included)
+		// carries the render nonce.
+		const scripts = tail.match(/<script[^>]*/g) ?? [];
+		expect(scripts.length).toBeGreaterThan(0);
+		for (const tag of scripts) expect(tag).toContain('nonce="test-nonce"');
+
+		// Browser simulation: the stream runtime hoists the tags into head.
+		const c = streamContainer();
+		c.innerHTML = html;
+		activateStreamedMarkup(c);
+		expect(
+			document.head.querySelectorAll('link[href="/gated-x.css"][data-precedence="default"]'),
+		).toHaveLength(1);
+		expect(document.head.querySelectorAll('style[data-href="gated-tokens"]')).toHaveLength(1);
+		// The revealed content is in place and no carrier markup remains behind.
+		expect(c.querySelector('.gated-ready')?.textContent).toBe('x');
+		expect(c.querySelector('link')).toBeNull();
+		expect(c.querySelector('style[data-href]')).toBeNull();
+
+		// Hydration adopts the streamed DOM and the head resources — no duplicates.
+		const revealed = c.querySelector('.gated-ready');
+		const root = hydrateRoot(c, GatedSheetBoundary as any, {
+			promise: new Promise<string>(() => {}),
+		});
+		flushSync(() => {});
+		expect(c.querySelector('.gated-ready')).toBe(revealed);
+		expect(document.head.querySelectorAll('link[href="/gated-x.css"]')).toHaveLength(1);
+		expect(document.head.querySelectorAll('style[data-href="gated-tokens"]')).toHaveLength(1);
+		root.unmount();
+	});
+
+	// Per ReactDOMFloat-test.js:2041 — 'will hoist resources of child boundaries
+	// emitted as part of a partial boundary to the parent boundary' (and :2350,
+	// the flushed-inline variant): the still-pending inner boundary's sheet
+	// rides the wave that reveals its parent.
+	it("hoists a nested pending boundary's sheet into the outer boundary's reveal wave", async () => {
+		const outer = deferred<string>();
+		const inner = deferred<string>();
+		const collector = createPipeableCollector();
+		const { pipe } = Server.renderToPipeableStream(srvStream.NestedLateBoundaries, {
+			outer: outer.promise,
+			inner: inner.promise,
+		});
+		pipe(collector.destination);
+		const shell = collector.chunks.join('');
+		// Control: an arm-root sheet registers ahead of its arm's use(), so the
+		// outer boundary's sheet flushes with the shell head.
+		expect(shell.match(/\/outer-late\.css/g) || []).toHaveLength(1);
+		expect(shell).not.toContain('/inner-late.css');
+		const shellChunkCount = collector.chunks.length;
+
+		// The shell head belongs to the surrounding document; the body markup and
+		// stream scripts land in the hydration container.
+		const bodyStart = shell.indexOf('<div');
+		document.head.insertAdjacentHTML('afterbegin', shell.slice(0, bodyStart));
+		const c = streamContainer();
+		c.innerHTML = shell.slice(bodyStart);
+
+		outer.resolve('one');
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		const outerWave = collector.chunks.slice(shellChunkCount).join('');
+		expect(outerWave).toContain('outer-ready');
+		// The inner boundary has NOT resolved, but its sheet was discovered while
+		// rendering toward it — it hoists into the parent's reveal wave.
+		expect(outerWave.match(/\/inner-late\.css/g) || []).toHaveLength(1);
+
+		inner.resolve('two');
+		const html = await collector.ended;
+		expect(html.match(/\/inner-late\.css/g) || []).toHaveLength(1);
+
+		c.insertAdjacentHTML('beforeend', collector.chunks.slice(shellChunkCount).join(''));
+		activateStreamedMarkup(c);
+		// The late sheet joins the precedence groups after the shell's (new group
+		// appends after the last existing group).
+		expect(sheetHrefs()).toEqual(['/outer-late.css', '/inner-late.css']);
+		expect(c.querySelector('.outer-ready')?.textContent).toBe('one');
+		expect(c.querySelector('.inner-ready')?.textContent).toBe('two');
+	});
+
+	it('does not re-ship a sheet already flushed with the shell', async () => {
+		const d = deferred<string>();
+		const collector = createPipeableCollector();
+		const { pipe } = Server.renderToPipeableStream(srvStream.SharedSheetBoundary, {
+			promise: d.promise,
+		});
+		pipe(collector.destination);
+		expect(collector.chunks.join('').match(/\/shared\.css/g) || []).toHaveLength(1);
+		d.resolve('go');
+		const html = await collector.ended;
+		// The late arm re-declares the same href; the whole response still
+		// carries exactly one copy.
+		expect(html.match(/\/shared\.css/g) || []).toHaveLength(1);
+		expect(html).toContain('shared-value');
+	});
+
+	// Live client resource state can exist BEFORE a late chunk arrives (the app
+	// hydrated and rendered a Float resource mid-stream). The streamed insert
+	// must then go through that state so both sides keep deduping.
+	it('routes late streamed sheets through live client resource state', async () => {
+		const d = deferred<string>();
+		const collector = createPipeableCollector();
+		const { pipe } = Server.renderToPipeableStream(srvStream.GatedSheetBoundary, {
+			promise: d.promise,
+		});
+		pipe(collector.destination);
+		const c = streamContainer();
+		c.innerHTML = collector.chunks.join('');
+		const shellChunkCount = collector.chunks.length;
+		activateStreamedMarkup(c);
+
+		// A client render creates live Float state while the boundary is pending.
+		const side = streamContainer();
+		const clientRoot = createRoot(side);
+		await act(() => clientRoot.render(SheetA, {}));
+		expect(sheetHrefs()).toEqual(['/base.css']);
+
+		d.resolve('x');
+		await collector.ended;
+		c.insertAdjacentHTML('beforeend', collector.chunks.slice(shellChunkCount).join(''));
+		activateStreamedMarkup(c);
+		// The streamed sheet appended into the live default precedence group…
+		expect(sheetHrefs()).toEqual(['/base.css', '/gated-x.css']);
+
+		// …and registered with client state: a client render of the same resource
+		// adopts instead of duplicating.
+		await act(() => clientRoot.render(GatedSheetContent, { name: 'x' }));
+		expect(sheetHrefs()).toEqual(['/base.css', '/gated-x.css']);
+		expect(document.head.querySelectorAll('style[data-href="gated-tokens"]')).toHaveLength(1);
+		clientRoot.unmount();
 	});
 });


### PR DESCRIPTION
## Summary

- Streaming SSR (`renderToPipeableStream` / `renderToReadableStream`) now ships Float sheet resources (`<link rel="stylesheet" href precedence>`, `<style href precedence>`) discovered **after** the shell flushed. Previously only the shell pass's head was ever written, so a sheet registered on a later resolution wave — a nested pending boundary's sheet, or an href computed from a `use()` resolution — appeared nowhere in the response.
- Consequences fixed: streamed late content revealed unstyled (FOUC until hydration re-inserted the sheet client-side), and documents consumed without JavaScript permanently missed the CSS.
- Unblocks the deferred ReactDOMFloat conformance behaviors: `ReactDOMFloat-test.js:1923` (child boundary stylesheet in the reveal), `:2041` and `:2350` (partial-boundary resources hoist to the parent boundary), each cited in the new tests.

## Why

Each resolution wave re-runs a full pass, but the wave loop only diffed `pass.cssEntries` (scoped CSS) — the pass's `HeadBuffer` sheet registrations were folded into a head string for the shell and discarded on every later pass. React ships late boundary stylesheets with the boundary reveal instruction; Octane dropped them entirely. Reveal gating on sheet *load* (suspensey commits) remains a documented non-goal — the sheet just has to reach the document.

## Changes

- `packages/octane/src/runtime.server.ts`
  - `HeadBuffer.sheets` changed from `Map<precedence, concatenatedHtml>` to per-resource `Map<href, { precedence, html }>`; `headHtmlWithSheets` derives precedence groups at fold time (byte-identical output, first-encounter group order preserved).
  - `FullPassResult` exposes the pass's sheet map; `runStream` tracks `flushedSheets` (seeded from the shell pass) and each wave ships only new tags via `floatResourceChunk` — real markup in a `<div hidden data-oct-fr="…">` carrier ahead of the wave's segment reveals, so no-JS consumers still get working CSS.
  - New inline `$OCTRH(id)` in the stream swap runtime hoists carrier tags into `document.head` with the client's precedence-group insertion policy. A still-pending child boundary's sheet rides its **parent's** reveal wave (arm-root registrations run before the arm's `use()` throws), matching React's partial-boundary hoisting.
- `packages/octane/src/runtime.ts`: once client Float resource state exists, `resourceState()` installs `window.$OCTFR`; `$OCTRH` hands tags to it so one live authority keeps dedupe and group ordering through mid-stream hydration (no duplicates in either direction). `resetFloatResourceState()` clears it.
- `packages/octane/src/constants.ts`: new internal `STREAM_RESOURCE_ATTR` (`data-oct-fr`).
- `packages/octane/tests/_fixtures/float-stream.tsrx` + a "streamed late boundaries" describe in `float-resources.test.ts`: dynamic-href sheet end-to-end (stream → head hoist → hydration adoption, CSP nonce on every emitted script), nested-boundary parent-wave hoisting, no re-ship of shell-flushed sheets, live-client-state routing race. Three cases were seen red pre-fix (dev + prod projects); the dedupe case was proven red against a deliberately broken implementation.
- `docs/ssr.md` + design comments: the streamed-head divergence is narrowed — head elements and hints from late boundaries still recreate on hydration; the sheet family now streams.

Performance: no per-node/per-render path touched — all additions are gated behind `pass.sheets !== null` (null unless the page uses Float sheets), per-wave, or per-resource. The inline stream runtime grows 494 chars (~306 B gz alone) and is only emitted on responses with pending boundaries. No benchmark exercises Float SSR, so no wall-clock claim is made.

## Validation

- [x] `pnpm format:check` — changed files clean; the repo-wide run can race git-ignored test-generated `.react-cache-ssr/` files (pre-existing gap, follow-up task spawned)
- [x] `pnpm typecheck`
- [x] `pnpm test` — 21,106 passed; the handful of failures reproduce identically on unmodified `main` (day-picker date-drift assertions, alien-signals/hook-form pinned-upstream suites, vaul browser drag — local-environment issues, follow-up task spawned) or pass in isolation (octane browser events, drei e2e — parallel-run contention); none touch this diff's code paths
- [x] targeted tests: `float-resources.test.ts` 36/36 (dev + prod), streaming/SSR/stream-state suites 356/356, fizz conformance + hydration 806/806

## Risk / follow-ups

- Late-discovered resource **hints** and `<script async src>` Float resources still wait for hydration (unchanged, documented); follow-up if parity there matters.
- A late boundary can still flash briefly while its CSS fetches — reveal gating on sheet load stays a documented non-goal.
- Two bundled Octane runtime copies on one page share the single `$OCTFR` global — a pre-existing multi-copy hazard, unchanged.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the streaming SSR protocol and client Float resource registration (`$OCTRH`/`$OCTFR`), which affect head ordering and hydration adoption. Changes are gated behind Float sheet usage and covered by new end-to-end stream tests.
> 
> **Overview**
> **Streaming SSR now ships Float sheet resources discovered after the shell**, fixing FOUC on late boundaries and missing CSS for no-JS consumers.
> 
> Each resolution wave diffs per-resource sheet registrations (`href` → tag) against what already flushed and emits new tags in a hidden `data-oct-fr` carrier ahead of segment reveals. Inline `$OCTRH` hoists them into `document.head` under client precedence grouping; once live Float state exists, tags go through `$OCTFR` so dedupe stays in one authority. Nested pending sheets ride the parent's reveal wave.
> 
> `HeadBuffer.sheets` is now keyed by href (groups fold at emit time). Docs narrow the streamed-head gap to non-sheet head elements/hints; tests cover dynamic hrefs, nested hoisting, shell dedupe, and mid-stream client-state handoff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad613eb2d022362d8949bcdf84bb98773c79d463. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->