### PR TITLE
test: flip the three streamed Float sheet parity cases to covered

### DIFF
--- a/docs/react-parity-coverage.md
+++ b/docs/react-parity-coverage.md
@@ -85,8 +85,8 @@ Every concrete case in either pinned inventory has exactly one ledger dispositio
 
 | Baseline | Cases | Untriaged | Planned | In progress | Covered | Documented | Blocked |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| stable | 5,345 | 0 | 1,876 | 0 | 968 | 2,501 | 0 |
-| canary | 5,413 | 0 | 1,914 | 0 | 1,029 | 2,470 | 0 |
+| stable | 5,345 | 0 | 1,873 | 0 | 971 | 2,501 | 0 |
+| canary | 5,413 | 0 | 1,911 | 0 | 1,032 | 2,470 | 0 |
 
 Classifications are `portable`, `adaptable`, `divergence`, and `non_goal`. A covered case requires live local test evidence; divergence and non-goal dispositions require a rationale.
 

--- a/packages/octane/audit/react-conformance-ledger.json
+++ b/packages/octane/audit/react-conformance-ledger.json
@@ -8090,7 +8090,7 @@
     },
     {
       "caseId": "react-case-v1:1af9ff57ae48745930fa",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "boundary stylesheet resource dependencies hoist to a parent boundary when flushed inline",
@@ -8098,7 +8098,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "A complete child boundary flushed inline with its parent's reveal ships its stylesheet with that same wave exactly once, joining the head precedence groups alongside the parent's.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/float-resources.test.ts",
+          "testName": "ships an inline-flushed complete child boundary's sheet with the parent's reveal",
+          "modes": ["server-stream"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:1affd15daf975fe92bdc",
@@ -24790,7 +24797,7 @@
     },
     {
       "caseId": "react-case-v1:51e93d2eb1927b6da8a5",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "will include child boundary stylesheet resources in the boundary reveal instruction",
@@ -24798,7 +24805,19 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Stylesheet resources discovered after the shell \u2014 including a child boundary's \u2014 ride the boundary reveal wave into document.head under client precedence grouping, and a hydrating client adopts them without duplicating.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/float-resources.test.ts",
+          "testName": "streams a use()-gated dynamic-href sheet late and moves it into document.head",
+          "modes": ["server-stream", "hydrate-match"]
+        },
+        {
+          "file": "packages/octane/tests/float-resources.test.ts",
+          "testName": "hoists a nested pending boundary's sheet into the outer boundary's reveal wave",
+          "modes": ["server-stream"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:51f0342fc95c8a9c81ce",
@@ -41312,7 +41331,7 @@
     },
     {
       "caseId": "react-case-v1:89e6220224288d52f5f3",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "will hoist resources of child boundaries emitted as part of a partial boundary to the parent boundary",
@@ -41320,7 +41339,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "A still-blocked child boundary's stylesheet discovered while its parent flushes hoists into the parent boundary's reveal wave exactly once and joins the head precedence groups.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/float-resources.test.ts",
+          "testName": "hoists a nested pending boundary's sheet into the outer boundary's reveal wave",
+          "modes": ["server-stream"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:89f557479eaee39f9459",

--- a/packages/octane/tests/float-resources.test.ts
+++ b/packages/octane/tests/float-resources.test.ts
@@ -425,9 +425,9 @@ describe('Float resources — streamed late boundaries', () => {
 	});
 
 	// Per ReactDOMFloat-test.js:2041 — 'will hoist resources of child boundaries
-	// emitted as part of a partial boundary to the parent boundary' (and :2350,
-	// the flushed-inline variant): the still-pending inner boundary's sheet
-	// rides the wave that reveals its parent.
+	// emitted as part of a partial boundary to the parent boundary': the
+	// still-pending inner boundary's sheet rides the wave that reveals its
+	// parent.
 	it("hoists a nested pending boundary's sheet into the outer boundary's reveal wave", async () => {
 		const outer = deferred<string>();
 		const inner = deferred<string>();
@@ -467,6 +467,55 @@ describe('Float resources — streamed late boundaries', () => {
 		activateStreamedMarkup(c);
 		// The late sheet joins the precedence groups after the shell's (new group
 		// appends after the last existing group).
+		expect(sheetHrefs()).toEqual(['/outer-late.css', '/inner-late.css']);
+		expect(c.querySelector('.outer-ready')?.textContent).toBe('one');
+		expect(c.querySelector('.inner-ready')?.textContent).toBe('two');
+	});
+
+	// Per ReactDOMFloat-test.js:2350 — 'boundary stylesheet resource dependencies
+	// hoist to a parent boundary when flushed inline': the inner boundary
+	// resolves FIRST, so when its parent reveals, the complete child flushes
+	// inline with the parent's wave and its sheet ships with that same wave.
+	it("ships an inline-flushed complete child boundary's sheet with the parent's reveal", async () => {
+		const outer = deferred<string>();
+		const inner = deferred<string>();
+		const collector = createPipeableCollector();
+		const { pipe } = Server.renderToPipeableStream(srvStream.NestedLateBoundaries, {
+			outer: outer.promise,
+			inner: inner.promise,
+		});
+		pipe(collector.destination);
+		const shell = collector.chunks.join('');
+		expect(shell.match(/\/outer-late\.css/g) || []).toHaveLength(1);
+		expect(shell).not.toContain('/inner-late.css');
+		const shellChunkCount = collector.chunks.length;
+
+		// The child resolves while its parent is still pending: it has no slot in
+		// the document yet, so neither its content nor its sheet may stream.
+		inner.resolve('two');
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		const preReveal = collector.chunks.slice(shellChunkCount).join('');
+		expect(preReveal).not.toContain('/inner-late.css');
+		expect(preReveal).not.toContain('inner-ready');
+
+		// The parent's resolution alone completes the response: the child flushes
+		// inline within the parent's reveal, carrying its sheet exactly once.
+		outer.resolve('one');
+		const html = await collector.ended;
+		const wave = collector.chunks.slice(shellChunkCount).join('');
+		expect(wave).toContain('outer-ready');
+		expect(wave).toContain('inner-ready');
+		expect(wave.match(/\/inner-late\.css/g) || []).toHaveLength(1);
+		expect(html.match(/\/inner-late\.css/g) || []).toHaveLength(1);
+
+		// Browser simulation: the inline-flushed child's sheet joins the head
+		// precedence groups after the shell's, and both contents are revealed.
+		const bodyStart = shell.indexOf('<div');
+		document.head.insertAdjacentHTML('afterbegin', shell.slice(0, bodyStart));
+		const c = streamContainer();
+		c.innerHTML = shell.slice(bodyStart);
+		c.insertAdjacentHTML('beforeend', wave);
+		activateStreamedMarkup(c);
 		expect(sheetHrefs()).toEqual(['/outer-late.css', '/inner-late.css']);
 		expect(c.querySelector('.outer-ready')?.textContent).toBe('one');
 		expect(c.querySelector('.inner-ready')?.textContent).toBe('two');


### PR DESCRIPTION
# test: flip the three streaming Float sheet ledger cases to covered

## Summary

- Flips the three `ReactDOMFloat-test.js` parity-ledger cases that #725 deferred as `planned` against the "streaming SSR drops late-discovered Float sheets" gap — fixed by #727 — to `covered` with executable evidence in the `float-resources.test.ts` "streamed late boundaries" describe. ReactDOMFloat planned drops 8 → 5 (covered 68 → 71).
- Adds one small adapted test for the upstream `:2350` case ("boundary stylesheet resource dependencies hoist to a parent boundary when flushed inline"): the existing #727 tests resolve the outer boundary first, so none asserted the inline-flush shape where the *inner* boundary resolves first and its complete content + sheet flush inside the parent's reveal wave. The new test inverts the resolution order on the existing `NestedLateBoundaries` fixture and asserts the child's sheet ships exactly once with that wave, joins the head precedence groups behind the shell's, and both contents reveal.

## Why

- Evidence follow-up tracked in #711 under the streaming item. Case → evidence (verified against upstream at the pinned stable commit; each Octane test cites its upstream line):
  - `…7b6da8a5` "will include child boundary stylesheet resources in the boundary reveal instruction" (`:1923`) → `streams a use()-gated dynamic-href sheet late and moves it into document.head` (server-stream, hydrate-match) + `hoists a nested pending boundary's sheet into the outer boundary's reveal wave` (server-stream).
  - `…8d52f5f3` "will hoist resources of child boundaries emitted as part of a partial boundary to the parent boundary" (`:2041`) → `hoists a nested pending boundary's sheet into the outer boundary's reveal wave` (server-stream).
  - `…745930fa` "boundary stylesheet resource dependencies hoist to a parent boundary when flushed inline" (`:2350`) → the new `ships an inline-flushed complete child boundary's sheet with the parent's reveal` (server-stream).
- The existing nested-boundary test's comment claimed both `:2041` and `:2350`; with a dedicated `:2350` test it now cites `:2041` only, so each test cites exactly the case it evidences.

## Changes

- `packages/octane/audit/react-conformance-ledger.json`: the three case flips (status, rationale, evidence) — nothing else touched; the file's `\uXXXX` escape convention is preserved.
- `packages/octane/tests/float-resources.test.ts`: one new test in the "streamed late boundaries" describe; narrowed one citation comment.
- `docs/react-parity-coverage.md`: regenerated (planned 1,876 → 1,873 stable / 1,914 → 1,911 canary; covered 968 → 971 / 1,029 → 1,032).

No changeset: test/audit/docs-only — no published package behavior changes.

## Validation

- [x] `node scripts/react-parity/check.mjs --validate-only` — metadata current.
- [x] `node scripts/react-parity/check.mjs` (full, executes evidence) — see the local-environment note below for how the lanes were covered.
- [x] targeted tests: `vitest run packages/octane/tests/float-resources.test.ts` — 38 passed across both the `octane` and `octane-prod` projects.
- [x] `tsgo --noEmit -p packages/octane/tsconfig.json` (the project owning every changed file); `pnpm typecheck` (repo-wide chain) not run.
- [x] `pnpm format:files:check` on the three changed files; repo-wide `pnpm format:check` not run.
- [x] `pnpm test` (full root suite) — result recorded below.

**Local-environment note (macOS agent machine):** the full check's parity-wide Vitest batch (136 lanes, 3,337 tests) and the non-Vitest binding lanes (44 manifests) were all executed; every lane passed on this exact tree, with four environment/load artifacts observed and attributed, none related to this diff (which touches only the octane Float test file, the audit ledger, and a generated doc):

1. `alien-signals` pinned pristine suite fails only when `CLAUDECODE=1` is set (bun mutes the output ledger the runner scrapes); passes with the variable unset. Known issue, previously chipped.
2. `markdown` `public-types` times out at vitest's default 5s under full batch load (its first import compiles the package through the Octane plugin; the batch's JSON reporter loses the timeout as `STACK_TRACE_ERROR`); passes standalone and with a real timeout. Background task filed to make the lane deterministic; the temporary local timeout bump used to let the batch proceed is not part of this diff.
3. `input-otp` browser selection test flaked once under batch load; passes standalone and in other full-batch runs.
4. `drei` pristine Playwright lane cannot pass on macOS: the upstream fixture ships only `should-match-previous-one-1-linux.png`, so darwin has no screenshot baseline. Verified against the committed fixture; lane excluded locally, runs on Linux CI. The other 43 manifests' non-Vitest lanes all passed.

## Risk / follow-ups

- Evidence-only ledger flips; the single new test exercises the #727 streaming path with inverted resolution order (the shipping mechanism it guards landed red-first in #727).
- After merge: tick the "Evidence follow-up" checkbox under the streaming item in #711 and note ReactDOMFloat planned 8 → 5.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test, conformance-ledger, and generated documentation updates only; no production behavior changes.
> 
> **Overview**
> Marks **three** high-risk `ReactDOMFloat-test.js` parity-ledger entries as **covered**, pointing at existing and new tests in `float-resources.test.ts` under streamed late boundaries. Ledger **planned** counts drop by three on stable and canary; **covered** rises by the same amount in the regenerated `react-parity-coverage.md`.
> 
> Adds **`ships an inline-flushed complete child boundary's sheet with the parent's reveal`**, which resolves the **inner** boundary before the outer on `NestedLateBoundaries` so the child's stylesheet ships once inside the parent's reveal wave (upstream `:2350`). The nested-pending-boundary test comment now cites only `:2041`, since `:2350` has its own test.
> 
> No runtime or published API changes—audit, tests, and generated docs only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fc4a4dc1190e2bd23684de0b6cf13d508608b29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->