### PR TITLE
fix: form Float precedence groups in tree discovery order on client mounts

### DIFF
--- a/.changeset/precedence-group-discovery-order.md
+++ b/.changeset/precedence-group-discovery-order.md
@@ -1,0 +1,22 @@
+---
+'octane': patch
+---
+
+Float precedence groups now form in tree discovery order on client mounts, and
+head hoists computed from setup locals no longer crash SSR.
+
+Precedence group order is CSS cascade order. Client mounts used to create
+groups in the order component bodies finished executing — a nested child's or
+`@try` arm's group could precede its parent's, so the same tree could cascade
+differently on a client-only mount than on an SSR'd page. Resource
+registrations now run after a component's setup but before its children mount,
+so groups form parent-before-child, suspended arms at reveal, matching SSR and
+React on both sides.
+
+The server twin fixed a latent crash the same placement rule exposed: a hoisted
+head element or resource whose attribute reads a setup local (for example
+`<link href={slug} precedence …>` after `const slug = …`) used to emit its
+registration ahead of the local's declaration and throw a TDZ ReferenceError
+during render. Capture-free registrations still lead the body — arm-root sheets
+keep shipping with the streaming shell — while ones that read setup locals now
+run right after setup, still ahead of children.

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -590,7 +590,9 @@ React Float **resources** are supported with React's semantics:
   global resource: deduped by href across the page, hoisted into
   `document.head` with a `data-precedence` attribute, grouped by precedence in
   first-encounter order (later same-precedence sheets append to their group),
-  and retained after unmount. First instance wins; later differing props do
+  and retained after unmount. First encounter follows tree discovery order —
+  parent before child, suspended arms at reveal — so client mounts, SSR, and
+  React agree on group order. First instance wins; later differing props do
   not retarget a live sheet.
 - `<script async src>` (no children/handlers) hoists and dedupes by src, and
   is likewise never removed.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -9766,7 +9766,36 @@ function ssrCompileBodyWithMapTemps(
 	if (mapTemps.length > 0) {
 		body.push(...mapTemps.map((temp) => inheritOriginLoc(b.let(temp), node)));
 	}
-	body.push(...emitHeadServer(headNodes, ctx), ...rewritten, ...inlinedSubs);
+	// Head statements lead the body so an arm-root Float registration runs
+	// ahead of a suspending setup and ships with the streaming shell. Leading
+	// is only evaluable when the statement reads nothing the body itself
+	// declares: an attr computed from a setup local would hit its TDZ there, so
+	// those statements run right after setup instead — still ahead of the
+	// return that renders children, preserving discovery order. (A `var` inside
+	// a nested setup block escapes this scan and keeps the historical front
+	// placement; head attrs read top-level setup locals in practice.)
+	const headStatements = emitHeadServer(headNodes, ctx);
+	let frontHead = headStatements;
+	let deferredHead = [];
+	if (headStatements.length > 0) {
+		const bodyBindings = new Set();
+		for (const s of rewritten) collectStatementBindings(s, bodyBindings);
+		for (const s of inlinedSubs) collectStatementBindings(s, bodyBindings);
+		if (bodyBindings.size > 0) {
+			frontHead = [];
+			for (const stmt of headStatements) {
+				let captures = false;
+				for (const free of collectFreeIdentifiers(stmt, [])) {
+					if (bodyBindings.has(free)) {
+						captures = true;
+						break;
+					}
+				}
+				(captures ? deferredHead : frontHead).push(stmt);
+			}
+		}
+	}
+	body.push(...frontHead, ...rewritten, ...inlinedSubs, ...deferredHead);
 	// PROPS-FIRST ABI (matches the client): `(…userParams, __s, __extra)`. A leading
 	// `__props` placeholder stands in when there are no user params, so a verbatim
 	// `function Foo(props)` and a compiled component both bind props from arg 0.
@@ -13168,6 +13197,16 @@ function compileFunctionBody(node, ctx, name, parentNs = 'html', cssHash = null,
 		bodyStatements.push(...mapTemps.map((temp) => inheritOriginLoc(b.let(temp), node)));
 	}
 	bodyStatements.push(...rewrittenStatements);
+	// GLOBAL resource registrations (stylesheet precedence links, style
+	// resources, async scripts) run here: after setup, so an href computed from
+	// a body local is initialized, and BEFORE the constructs below mount any
+	// children — precedence groups are created in first-encounter order, and
+	// tree discovery order (parent before child, matching SSR and React) is
+	// only guaranteed while no child has rendered yet. A suspending setup means
+	// the resource registers on the arm's completing pass, like React's
+	// commit-time insertion; scope-owned `headBlock` metadata stays at the body
+	// tail (`plan.head`).
+	if (plan?.resources) bodyStatements.push(...plan.resources);
 	// Inlined sub-helpers (children render fns, legacy-placement construct
 	// bodies, hoisted `<tsrx>` blocks) are function DECLARATION nodes embedded
 	// directly in the body — they hoist, so their placement after the setup
@@ -18822,19 +18861,23 @@ function headResourceArgNodes(el, kind) {
 	return args;
 }
 
-// Build the CLIENT `headBlock(__s, …)` statement NODES for a component's
-// hoisted head elements (one per `HeadHoist`). Returns [] when there are none.
+// Build the CLIENT statement NODES for a component's hoisted head elements
+// (one per `HeadHoist`), partitioned by WHEN they must run. `head` carries the
+// `headBlock(__s, …)` calls: scope-owned metadata whose slots come after the
+// body's constructs, so they stay at the body tail (`plan.head`). `resources`
+// carries the GLOBAL resource calls (stylesheet precedence links, style
+// resources, async scripts): they dedupe by href/src at runtime, are
+// scope-free, and must run after setup but BEFORE the body's constructs mount
+// children — precedence GROUP order is first-encounter order, and a parent's
+// group has to be encountered before any child component's (tree discovery
+// order, matching SSR and React). Their slot index is left unoccupied to keep
+// the numbering of neighbouring headBlock slots stable regardless of
+// classification.
 /** @param {any[]} headNodes @param {any} ctx @param {number} slotBase */
 function emitHeadClient(headNodes, ctx, slotBase) {
-	if (!headNodes.length) return [];
-	// Each hoisted head element gets a dense scope slot (after the body's constructs);
-	// the content `key` stays as a later arg for SSR-adoption matching. RESOURCE
-	// elements (stylesheet precedence links, style resources, async scripts) are
-	// global and scope-free: they dedupe by href/src at runtime, so their call
-	// carries only the attrs object (plus the CSS text for style resources).
-	// Their slot index is left unoccupied to keep the numbering of neighbouring
-	// headBlock slots stable regardless of classification.
-	return headNodes.map((h, i) => {
+	const head = [];
+	const resources = [];
+	headNodes.forEach((h, i) => {
 		const kind = headResourceKind(h.element);
 		if (kind !== null) {
 			const fn =
@@ -18844,24 +18887,30 @@ function emitHeadClient(headNodes, ctx, slotBase) {
 						? 'styleResource'
 						: 'scriptResource';
 			ctx.runtimeNeeded.add(fn);
-			return inheritOriginLoc(
-				b.stmt(b.call('_$' + fn, ...headResourceArgNodes(h.element, kind))),
-				h.element ?? h,
+			resources.push(
+				inheritOriginLoc(
+					b.stmt(b.call('_$' + fn, ...headResourceArgNodes(h.element, kind))),
+					h.element ?? h,
+				),
 			);
+			return;
 		}
 		ctx.runtimeNeeded.add('headBlock');
-		return inheritOriginLoc(
-			b.stmt(
-				b.call(
-					'_$headBlock',
-					b.id('__s'),
-					b.literal(slotBase + i),
-					...headElementArgNodes(h, i, ctx),
+		head.push(
+			inheritOriginLoc(
+				b.stmt(
+					b.call(
+						'_$headBlock',
+						b.id('__s'),
+						b.literal(slotBase + i),
+						...headElementArgNodes(h, i, ctx),
+					),
 				),
+				h.element ?? h,
 			),
-			h.element ?? h,
 		);
 	});
+	return { head, resources };
 }
 
 // Build the SERVER `ssrHeadEl(…)` statement nodes for a component's hoisted
@@ -19618,13 +19667,15 @@ function planJsx(
 	if (jsxNodes.length === 0) {
 		ctx._elemLocs = _prevElemLocs;
 		ctx._nestedHeadHoists = _prevNestedHeads;
+		const headOnlyEmit = emitHeadClient(headNodes, ctx, 0);
 		return {
 			hasBag: false,
 			mount: [],
 			update: [],
 			everyRender: [],
 			after: [],
-			head: emitHeadClient(headNodes, ctx, 0),
+			head: headOnlyEmit.head,
+			resources: headOnlyEmit.resources,
 			locs: null,
 		};
 	}
@@ -21238,7 +21289,8 @@ function planJsx(
 		update: updateLines,
 		everyRender: everyRenderLines,
 		after: afterStatements,
-		head: headEmit,
+		head: headEmit.head,
+		resources: headEmit.resources,
 		// DEV ONLY (`null` in prod → no body emission, byte-identical output): a structured
 		// `{ slotIndex: [line, column] }` literal for hydration-mismatch warnings + a future
 		// DevTools element→source layer. Keyed by the slot index the runtime already uses.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -9771,9 +9771,13 @@ function ssrCompileBodyWithMapTemps(
 	// is only evaluable when the statement reads nothing the body itself
 	// declares: an attr computed from a setup local would hit its TDZ there, so
 	// those statements run right after setup instead — still ahead of the
-	// return that renders children, preserving discovery order. (A `var` inside
-	// a nested setup block escapes this scan and keeps the historical front
-	// placement; head attrs read top-level setup locals in practice.)
+	// return that renders children, preserving discovery order. Registration
+	// order IS precedence-group order, so the split must never reorder the
+	// list: only the capture-free PREFIX leads; from the first capturing
+	// statement on, everything defers together, keeping the same relative
+	// order the client produces. (A `var` inside a nested setup block escapes
+	// this scan and keeps the historical front placement; head attrs read
+	// top-level setup locals in practice.)
 	const headStatements = emitHeadServer(headNodes, ctx);
 	let frontHead = headStatements;
 	let deferredHead = [];
@@ -9783,15 +9787,17 @@ function ssrCompileBodyWithMapTemps(
 		for (const s of inlinedSubs) collectStatementBindings(s, bodyBindings);
 		if (bodyBindings.size > 0) {
 			frontHead = [];
+			let deferring = false;
 			for (const stmt of headStatements) {
-				let captures = false;
-				for (const free of collectFreeIdentifiers(stmt, [])) {
-					if (bodyBindings.has(free)) {
-						captures = true;
-						break;
+				if (!deferring) {
+					for (const free of collectFreeIdentifiers(stmt, [])) {
+						if (bodyBindings.has(free)) {
+							deferring = true;
+							break;
+						}
 					}
 				}
-				(captures ? deferredHead : frontHead).push(stmt);
+				(deferring ? deferredHead : frontHead).push(stmt);
 			}
 		}
 	}

--- a/packages/octane/tests/_fixtures/float-group-order.tsrx
+++ b/packages/octane/tests/_fixtures/float-group-order.tsrx
@@ -84,6 +84,18 @@ export function LocalHref(props) @{
 	</>
 }
 
+// A setup-local-dependent sheet FOLLOWED by a static one: registration order is
+// group order, so the static sheet must not jump ahead of the dynamic one on
+// either side.
+export function MixedLocalStatic(props) @{
+	const dyn = '/' + props.name + '-first.css';
+	<>
+		<link rel="stylesheet" href={dyn} precedence="alpha" />
+		<link rel="stylesheet" href="/second-static.css" precedence="beta" />
+		<div class="mixed">{'M'}</div>
+	</>
+}
+
 function Exploding(props) @{
 	const boom = () => {
 		throw new Error('mount failure');

--- a/packages/octane/tests/_fixtures/float-group-order.tsrx
+++ b/packages/octane/tests/_fixtures/float-group-order.tsrx
@@ -1,0 +1,110 @@
+import { use } from 'octane';
+
+// Precedence GROUP order is first-encounter in tree discovery order — the same
+// order SSR serializes and React produces — not the order component bodies
+// happen to finish executing. These fixtures nest resource declarations so a
+// leaves-first registration order would invert the groups.
+
+function ChildSheet() @{
+	<>
+		<link rel="stylesheet" href="/child-vendor.css" precedence="vendor" />
+		<span class="child">{'child'}</span>
+	</>
+}
+
+// Parent declares its group before rendering the child that declares another.
+export function ParentChild() @{
+	<>
+		<link rel="stylesheet" href="/parent-app.css" precedence="app" />
+		<div class="parent">
+			<ChildSheet />
+		</div>
+	</>
+}
+
+function SiblingSheet() @{
+	<>
+		<link rel="stylesheet" href="/sibling.css" precedence="two" />
+		<span class="sibling">{'sibling'}</span>
+	</>
+}
+
+// The suspended arm's sheet is discovered at reveal, AFTER the sibling that
+// rendered with the shell — its group comes last even though the @try block
+// sits first in source order.
+export function LateArmAfterSibling(props) @{
+	<div class="late-host">
+		<link rel="stylesheet" href="/root-one.css" precedence="one" />
+		@try {
+			const label = use(props.promise);
+			<>
+				<link rel="stylesheet" href="/arm-three.css" precedence="three" />
+				<span class="arm">{label as string}</span>
+			</>
+		} @pending {
+			<span class="arm-pending">{'arm…'}</span>
+		}
+		<SiblingSheet />
+	</div>
+}
+
+// Two levels of suspension: each arm's group registers when that arm renders,
+// parent arm before child arm — discovery order across resolution waves.
+export function NestedTryOrder(props) @{
+	<div class="nested-host">
+		<link rel="stylesheet" href="/outer-one.css" precedence="one" />
+		@try {
+			const mid = use(props.mid);
+			<>
+				<link rel="stylesheet" href="/mid-two.css" precedence="two" />
+				<span class="mid">{mid as string}</span>
+				@try {
+					const deep = use(props.deep);
+					<>
+						<link rel="stylesheet" href="/deep-three.css" precedence="three" />
+						<span class="deep">{deep as string}</span>
+					</>
+				} @pending {
+					<span class="deep-pending">{'deep…'}</span>
+				}
+			</>
+		} @pending {
+			<span class="mid-pending">{'mid…'}</span>
+		}
+	</div>
+}
+
+// The href is computed from a SETUP LOCAL, so the resource registration cannot
+// run before the body's own statements.
+export function LocalHref(props) @{
+	const slug = '/' + props.name + '-dep.css';
+	<>
+		<link rel="stylesheet" href={slug} precedence="app" />
+		<div class="local">{'L'}</div>
+	</>
+}
+
+function Exploding(props) @{
+	const boom = () => {
+		throw new Error('mount failure');
+	};
+	<span class="never">
+		{props.arm ? boom() as string : 'x'}
+	</span>
+}
+
+// Resources are page-global and never removed: an arm that registers its sheet
+// and then fails while rendering a child keeps the sheet, exactly like the
+// server (registration precedes child evaluation there too).
+export function FailingArm(props) @{
+	<div class="failing-host">
+		@try {
+			<>
+				<link rel="stylesheet" href="/doomed.css" precedence="app" />
+				<Exploding arm={props.arm} />
+			</>
+		} @catch (e) {
+			<span class="caught">{'caught'}</span>
+		}
+	</div>
+}

--- a/packages/octane/tests/float-resources.test.ts
+++ b/packages/octane/tests/float-resources.test.ts
@@ -38,6 +38,13 @@ import {
 	ToggleHost,
 	setSheetVisible,
 } from './_fixtures/float-resources.tsrx';
+import {
+	ParentChild,
+	LateArmAfterSibling,
+	NestedTryOrder,
+	LocalHref,
+	FailingArm,
+} from './_fixtures/float-group-order.tsrx';
 
 function sheetHrefs(): string[] {
 	return Array.from(
@@ -522,5 +529,101 @@ describe('Float resources — streamed late boundaries', () => {
 		expect(sheetHrefs()).toEqual(['/base.css', '/gated-x.css']);
 		expect(document.head.querySelectorAll('style[data-href="gated-tokens"]')).toHaveLength(1);
 		clientRoot.unmount();
+	});
+});
+
+// Precedence GROUP order is part of the resource contract: groups appear in
+// first-encounter order of tree DISCOVERY (what SSR serializes and React
+// produces), not in the order component bodies happen to finish executing.
+// Group order is CSS cascade order, so an inversion changes how equal-
+// specificity rules across groups resolve.
+describe('Float resources — precedence group discovery order', () => {
+	const containers: HTMLElement[] = [];
+	const roots: Array<{ unmount(): void }> = [];
+	function mountInto(body: any, props: Record<string, unknown> = {}): void {
+		const c = document.createElement('div');
+		document.body.appendChild(c);
+		containers.push(c);
+		const root = createRoot(c);
+		roots.push(root);
+		root.render(body, props);
+	}
+	afterEach(() => {
+		for (const r of roots.splice(0)) r.unmount();
+		for (const c of containers.splice(0)) c.remove();
+		document.head
+			.querySelectorAll('[data-precedence], [data-oct-res]')
+			.forEach((el) => el.remove());
+		resetFloatResourceState();
+	});
+
+	const srvOrder = loadServerFixture(
+		'packages/octane/tests/_fixtures/float-group-order.tsrx',
+	) as Record<string, any>;
+
+	it("a parent's group precedes its child component's group on a client mount", async () => {
+		await act(() => mountInto(ParentChild));
+		expect(sheetHrefs()).toEqual(['/parent-app.css', '/child-vendor.css']);
+	});
+
+	it("a suspended arm's group registers at reveal, after shell-rendered siblings", async () => {
+		const d = deferred<string>();
+		await act(() => mountInto(LateArmAfterSibling, { promise: d.promise }));
+		// While the arm is pending, the root and sibling groups exist in
+		// discovery order; the arm's group does not exist yet (the sheet is
+		// discovered when its content renders — matching React, where a
+		// suspended tree contributes no resources until it commits).
+		expect(sheetHrefs()).toEqual(['/root-one.css', '/sibling.css']);
+		await act(() => d.resolve('armed'));
+		expect(sheetHrefs()).toEqual(['/root-one.css', '/sibling.css', '/arm-three.css']);
+		expect(document.body.textContent).toContain('armed');
+	});
+
+	it('nested @try arms register their groups in discovery order across waves', async () => {
+		const mid = deferred<string>();
+		const deep = deferred<string>();
+		await act(() => mountInto(NestedTryOrder, { mid: mid.promise, deep: deep.promise }));
+		expect(sheetHrefs()).toEqual(['/outer-one.css']);
+		await act(() => mid.resolve('m'));
+		expect(sheetHrefs()).toEqual(['/outer-one.css', '/mid-two.css']);
+		await act(() => deep.resolve('d'));
+		expect(sheetHrefs()).toEqual(['/outer-one.css', '/mid-two.css', '/deep-three.css']);
+		expect(document.body.textContent).toContain('d');
+	});
+
+	it('SSR serializes nested-tree groups in the same discovery order', async () => {
+		const App = () => Server.createElement(srvOrder.ParentChild, null) as any;
+		const r = await Server.renderToString(App as any);
+		const app = r.html.indexOf('/parent-app.css');
+		const vendor = r.html.indexOf('/child-vendor.css');
+		expect(app).toBeGreaterThan(-1);
+		expect(vendor).toBeGreaterThan(app);
+	});
+
+	it('a setup-local-computed href renders on the server and matches the client', async () => {
+		// Server: the registration must not run before the local it reads is
+		// initialized.
+		const App = () => Server.createElement(srvOrder.LocalHref, { name: 'x' }) as any;
+		const r = await Server.renderToString(App as any);
+		expect(r.html.match(/\/x-dep\.css/g) || []).toHaveLength(1);
+		expect(r.html).toContain('data-precedence="app"');
+
+		// Client control: same component, same sheet.
+		await act(() => mountInto(LocalHref, { name: 'x' }));
+		expect(sheetHrefs()).toEqual(['/x-dep.css']);
+	});
+
+	it('an arm that fails while rendering a child keeps its already-registered sheet', async () => {
+		// Resources are page-global and never removed; registration precedes
+		// child evaluation on the server too, so client and server agree that a
+		// failed arm's sheet stays.
+		const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			await act(() => mountInto(FailingArm, { arm: true }));
+		} finally {
+			errSpy.mockRestore();
+		}
+		expect(document.body.textContent).toContain('caught');
+		expect(sheetHrefs()).toEqual(['/doomed.css']);
 	});
 });

--- a/packages/octane/tests/float-resources.test.ts
+++ b/packages/octane/tests/float-resources.test.ts
@@ -43,6 +43,7 @@ import {
 	LateArmAfterSibling,
 	NestedTryOrder,
 	LocalHref,
+	MixedLocalStatic,
 	FailingArm,
 } from './_fixtures/float-group-order.tsrx';
 
@@ -611,6 +612,21 @@ describe('Float resources — precedence group discovery order', () => {
 		// Client control: same component, same sheet.
 		await act(() => mountInto(LocalHref, { name: 'x' }));
 		expect(sheetHrefs()).toEqual(['/x-dep.css']);
+	});
+
+	it('mixed setup-local and static resources keep source order on both sides', async () => {
+		// Registration order is group order. A static sheet declared AFTER a
+		// setup-local-dependent one must not jump ahead of it on the server —
+		// SSR and a client mount have to agree on the cascade.
+		const App = () => Server.createElement(srvOrder.MixedLocalStatic, { name: 'x' }) as any;
+		const r = await Server.renderToString(App as any);
+		const dyn = r.html.indexOf('/x-first.css');
+		const stat = r.html.indexOf('/second-static.css');
+		expect(dyn).toBeGreaterThan(-1);
+		expect(stat).toBeGreaterThan(dyn);
+
+		await act(() => mountInto(MixedLocalStatic, { name: 'x' }));
+		expect(sheetHrefs()).toEqual(['/x-first.css', '/second-static.css']);
 	});
 
 	it('an arm that fails while rendering a child keeps its already-registered sheet', async () => {


### PR DESCRIPTION
## Summary

- Float precedence **groups now form in tree discovery order on client mounts** — parent before child, suspended `@try` arms at reveal — matching SSR and React. Previously groups formed in body-completion order, so a nested child's or arm's group could precede its parent's (`[three, one, two]` where SSR gives `[one, two, three]`).
- Fixes a **latent SSR crash** the same placement rule exposed: a hoisted head element or Float resource whose attribute reads a setup local (`const slug = …; <link href={slug} precedence …>`) emitted its registration *ahead* of the local's declaration — a TDZ `ReferenceError` at render. This affected `ssrHeadEl` metadata hoists too, not just resources.

Closes the "adjudicate: client precedence group order under nested `@try`" item in #711 — adjudicated as **fix**, since group order is CSS cascade order and Octane disagreed with its own SSR output.

## Why

Group order is decided by first registration (`insertPrecedenced` appends new groups after the last one). The client emitted resource calls at the body **tail** (`plan.head`, after constructs), so children — which mount inside the parent's constructs — registered first. The server emits head statements at the body **front**, which is what ships arm-root sheets with the streaming shell, but is only evaluable when the statement reads nothing the body itself declares.

## Changes

`packages/octane/src/compiler/compile.js` (compiler-only; zero runtime changes, no new statements — the same calls move):

- `emitHeadClient` now returns `{head, resources}`: scope-owned `headBlock` metadata stays at the body tail (slot numbering untouched — resource slots were already left unoccupied); global resource calls (`stylesheetResource`/`styleResource`/`scriptResource`) land **after setup, before the constructs mount children**. Setup locals are initialized by then, and no child has rendered yet, so groups form in discovery order. A suspending setup means the arm's resource registers on its completing pass — like React's commit-time insertion.
- The server body emitter partitions head statements by **capture-freeness** (via the existing `collectFreeIdentifiers`/`collectStatementBindings` helpers): capture-free statements keep the historical front placement — arm-root sheets still ship with the streaming shell (#727's pinned behavior) — while statements reading setup locals run right after setup, still ahead of the `return` that renders children.

Tests: 6 new cases in `float-resources.test.ts` + `_fixtures/float-group-order.tsrx` (parent/child order, suspended-arm-at-reveal order, nested-arm waves, SSR order pin, setup-local href on both sides, failed-arm resource persistence). Doc: one clarifying sentence in `differences-from-react.md` (first-encounter = tree discovery order, all sides agree).

## Red-first evidence

- Pre-fix: `parent/child` and `arm-after-sibling` fail with inverted group order; `setup-local href` fails with the exact TDZ (`Cannot access 'slug' before initialization`) in `renderComponentFramed`.
- Deliberate re-break of the client placement after the fix: exactly the three placement tests go red (including the failed-arm persistence case, added post-fix); restored, 48/48.
- The two wave tests (`nested @try across waves`, SSR order) pass pre-fix and are kept as contract pins — stated so their green isn't mistaken for fix coverage.

## Performance

Compiler-only statement reordering: generated output has identical statement count and size, so no runtime benchmark applies. The compile-time addition is one free-identifier scan per head statement, only in bodies that hoist head elements, and only when the body declares bindings. No per-render, per-node, or bundle cost changes.

## Adversarial self-review (what it changed)

- Extended the server partition beyond resources to **all** head statements after probing showed `ssrHeadEl` metadata had the same TDZ hazard.
- New client behavior pinned deliberately: an arm that registers its sheet and then fails while rendering a child keeps the sheet — this now *matches the server* (registration precedes child evaluation there too) where the old client behavior arbitrarily dropped it.
- Known bound, documented in a code comment: a `var` declared inside a nested setup block escapes the capture scan and keeps front placement (pre-existing behavior; head attrs read top-level setup locals in practice).

## Review round 1 (Bugbot, fixed in 088b0bec3)

Valid finding: the server partition preserved the front/deferred *split* but not source order *between* them — a capture-free head statement appearing after a capturing one still jumped to the body front, so mixed static and setup-local resources in one body could cascade differently on SSR than on a client mount. Fixed with a prefix rule: only the capture-free **prefix** of the head-statement list leads the body; from the first capturing statement on, everything defers together in source order — the exact sequence the client produces. Red-first: `MixedLocalStatic` (setup-local sheet followed by a static sheet) asserted SSR order matched the client and failed before the rule ([static, dynamic] on SSR), passes after. The nested-pending-boundary shell test still passes: a capture-free arm-root sheet remains the list prefix, so it keeps shipping with the shell.

## Validation

- [x] `pnpm format:files:check` (changed files)
- [x] `pnpm typecheck`
- [x] `pnpm test` — 20,930 passed; the one failing file (`doom-browser`, 3 cases) is full-suite CPU-contention flake: 7/7 in isolation, and the same lane failed identically on unmodified main in an earlier session's gate
- [x] targeted: `float-resources` 48/48 (dev + prod projects), `hydration/` + `float-evidence-{1,2,3}` + `resource-hints` + `streaming-ssr` 880/880, `compiler/` 1,149/1,149, `differential/` 304/304
- [x] after round 1: `float-resources` 50/50 (dev + prod), neighbor sweep (`hydration/`, `float-evidence-{1,2,3}`, `resource-hints`, `streaming-ssr`, `compiler/`) 2,029/2,029

## Risk / follow-ups

- Suspended-pass registration timing on the client is unchanged (registers on the completing pass); only the position within a completing pass moved. SSR keeps eager arm-root registration — the documented stronger-than-React shell behavior.
- The `var`-in-nested-block capture-scan bound above.
- Issue #711: tick the adjudication item after merge.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Compiler-only reordering changes CSS cascade group order on client mounts and when SSR runs head registration, affecting hydration parity for Float stylesheets; no runtime logic changes but behavior is user-visible.
> 
> **Overview**
> **Float precedence groups on client mounts now follow tree discovery order** (parent before child, `@try` arms when they reveal), aligning client-only mounts with SSR and React. The compiler moves global resource calls (`stylesheetResource` / `styleResource` / `scriptResource`) to run **after setup and before child constructs mount**, instead of at the body tail with `headBlock` metadata.
> 
> **SSR head emission is split by capture-freeness:** registrations that do not read setup locals still lead the body (streaming shell behavior); hoists whose attributes depend on setup locals (e.g. `<link href={slug} precedence …>`) run after setup so they no longer hit a TDZ `ReferenceError`.
> 
> Adds fixtures/tests for parent/child order, suspended arms, nested `@try` waves, SSR order, setup-local href, and failed-arm sheet retention; docs clarify first-encounter = discovery order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0b5392d3e3a5b85ca21e30545c8f201ca457735. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
