### PR TITLE
test: make swr focus/reconnect revalidation deterministic

### DIFF
--- a/packages/swr/tests/upstream/root/root.test.ts
+++ b/packages/swr/tests/upstream/root/root.test.ts
@@ -87,19 +87,31 @@ describe('SWR U3 root lifecycle', () => {
 	// Per use-swr-focus.test.tsx:15 — 'should revalidate on focus by default'.
 	// Per use-swr-reconnect.test.tsx:11 — 'should revalidate on reconnect by default'.
 	it('revalidates on focus and reconnect through the pinned environment adapters', async () => {
-		const fetcher = vi.fn(async () => `request-${fetcher.mock.calls.length}`);
-		mount(SWRReader, {
-			cacheKey: 'root-events',
-			fetcher,
-			config: { dedupingInterval: 0, focusThrottleInterval: 0 },
-		});
-		await settle();
-		window.dispatchEvent(new Event('focus'));
-		await settleTimers();
-		window.dispatchEvent(new Event('online'));
-		await settleTimers();
-		expect(fetcher).toHaveBeenCalledTimes(3);
-		expect(value().data).toBe('request-3');
+		// The mount effect arms the focus throttle at `Date.now() + focusThrottleInterval`
+		// and a focus event revalidates only at a strictly later timestamp, so even at
+		// interval 0 a focus landing in the mount millisecond is throttled (upstream
+		// behavior; its suite sleeps a real 1ms before focusing). Faking only `Date`
+		// advances that clock deterministically while real timers keep driving the
+		// environment adapters' deferred event callbacks.
+		vi.useFakeTimers({ toFake: ['Date'] });
+		try {
+			const fetcher = vi.fn(async () => `request-${fetcher.mock.calls.length}`);
+			mount(SWRReader, {
+				cacheKey: 'root-events',
+				fetcher,
+				config: { dedupingInterval: 0, focusThrottleInterval: 0 },
+			});
+			await settle();
+			vi.setSystemTime(Date.now() + 1);
+			window.dispatchEvent(new Event('focus'));
+			await settleTimers();
+			window.dispatchEvent(new Event('online'));
+			await settleTimers();
+			expect(fetcher).toHaveBeenCalledTimes(3);
+			expect(value().data).toBe('request-3');
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	// Per use-swr-revalidate.test.tsx:64 — 'should respect sequences of revalidation calls


### PR DESCRIPTION
## Summary

- Fixes the intermittent failure in `packages/swr/tests/upstream/root/root.test.ts` — "revalidates on focus and reconnect through the pinned environment adapters" — where `expect(fetcher).toHaveBeenCalledTimes(3)` sporadically got 2 (observed ~1-in-3 standalone on macOS, and inside `scripts/react-parity/check.mjs` batches).
- The lost call is the **focus** revalidation. `useSWR`'s mount effect arms `nextFocusRevalidatedAt = Date.now() + focusThrottleInterval` and a focus event revalidates only at a *strictly later* timestamp, so even at `focusThrottleInterval: 0` a focus event whose `setTimeout`-deferred adapter callback (`initProvider` in `src/_internal/utils/cache.ts` wraps the window listeners in `setTimeout`) fires in the same `Date.now()` millisecond as the mount effect is throttled. The reconnect leg has no timestamp check, which is why failures always showed exactly 2 calls (initial + reconnect).
- This is byte-faithful pinned upstream SWR 2.4.2 behavior (`upstream/src/index/use-swr.ts:659-682`); upstream's own suite dodges the identical race by sleeping a real 1ms before dispatching focus (`nextTick = () => act(() => sleep(1))` in its test utils). Per the repo rule, the runtime is untouched and the test is made deterministic instead.

## Why

- An intrinsic same-millisecond race in a parity test flakes local runs and `check.mjs` parity batches; a vitest-lane failure there short-circuits the non-vitest binding lanes, so one flake hides unrelated coverage.

## Changes

- `packages/swr/tests/upstream/root/root.test.ts`: the focus/reconnect case now fakes **only** `Date` (`vi.useFakeTimers({ toFake: ['Date'] })`) and steps the clock with `vi.setSystemTime(Date.now() + 1)` before dispatching `focus`, guaranteeing the strictly-later timestamp regardless of machine timing. Real timers still drive the environment adapters' deferred event callbacks — full fake timers would break the test the other way (the adapters bound the real `setTimeout` at provider init, so faked-timer advances never fire the deferrals and both event revalidations are lost). Upstream citation comments are unchanged; the oracle (3 fetcher calls + `request-3` rendered) is unchanged.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 20,920/20,921; the single failure was the known unrelated browser-load flake (`octane-events-browser` native-change, Vite "504 Outdated Optimize Dep" under full parallelism), which passes standalone 12/12
- [x] targeted tests: fixed file 20/20 in a loop (previously flaky); `--project swr` 35/35; mechanism proven by a frozen-`Date.now` spy reproducing the exact reported failure deterministically (3/3), and an adversarial variant of the fixed test (clock step removed) failing deterministically with the same symptom

## Risk / follow-ups

- Test-only; no runtime or published-package change, so no changeset.
- Pre-existing, unrelated: `pnpm typecheck:files` fails on swr test files because the tests use undeclared `window.__SWR_DEVTOOLS_*` globals and `packages/swr/tsconfig.json` includes only `src` (repo-wide `pnpm typecheck` never checks swr tests). Being handled in a separate session.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in root.test.ts; no runtime or package behavior is modified.
> 
> **Overview**
> Fixes intermittent failures in the upstream root parity test where focus revalidation was sometimes skipped, leaving **2** fetcher calls instead of **3**.
> 
> The test now uses **`vi.useFakeTimers({ toFake: ['Date'] })`** and advances the clock by 1ms before dispatching **`focus`**, so revalidation runs after the mount-time focus throttle even when **`focusThrottleInterval: 0`**. Real timers still run so deferred environment adapter callbacks behave as before. Assertions are unchanged; **`vi.useRealTimers()`** runs in **`finally`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 839eb75c2eaf07016e6aac7785263cea49b203d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->