### PR TITLE
fix: close the last Float engine gaps — fallback-hoistable suppression and head priority order

### DIFF
--- a/.changeset/parity-final-gaps.md
+++ b/.changeset/parity-final-gaps.md
@@ -1,0 +1,20 @@
+---
+'octane': patch
+---
+
+Two server head-hoisting behaviors reach React Fizz parity, closing the last
+Float engine gaps from the React 19 parity audit.
+
+Fallback hoistables are now suppressed transitively: a `<title>`/`<meta>`/
+`<link>` authored inside a pending boundary's fallback never reaches the
+streamed head, including from a completed boundary nested inside that fallback
+— the fallback is discarded at reveal, but a streamed head line is permanent.
+
+Priority hoistables now lead the server head: `<meta charSet>` serializes
+first (parsers only honor a charset within the first 1024 bytes), then
+`<meta name="viewport">`, then everything else in discovery order — matching
+React's ordering instead of pure discovery order.
+
+The parity ledger also gains evidence for the `identifierPrefix` root option
+and the external-store compatibility semantics (subscribe/snapshot/
+server-snapshot through `useSyncExternalStore`), retiring those planned cases.

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -583,6 +583,13 @@ differences:
 Metadata and resources hoist from ANY depth, matching React: an element
 nested inside a host partitions out of the body on both the client and the
 server, and a hoist inside an `@if` arm registers only while that arm renders.
+Two more Fizz-parity behaviors on the server: `<meta charSet>` and
+`<meta name="viewport">` serialize at the FRONT of the head (charset first —
+parsers only honor it within the first 1024 bytes — then viewport, then
+everything else in discovery order), and hoistables authored inside a pending
+boundary's fallback are dropped transitively (a completed boundary nested in a
+fallback is still fallback territory; the streamed head would outlive the
+fallback it came from).
 
 React Float **resources** are supported with React's semantics:
 

--- a/docs/react-parity-coverage.md
+++ b/docs/react-parity-coverage.md
@@ -85,8 +85,8 @@ Every concrete case in either pinned inventory has exactly one ledger dispositio
 
 | Baseline | Cases | Untriaged | Planned | In progress | Covered | Documented | Blocked |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| stable | 5,345 | 0 | 1,873 | 0 | 971 | 2,501 | 0 |
-| canary | 5,413 | 0 | 1,911 | 0 | 1,032 | 2,470 | 0 |
+| stable | 5,345 | 0 | 1,867 | 0 | 977 | 2,501 | 0 |
+| canary | 5,413 | 0 | 1,905 | 0 | 1,038 | 2,470 | 0 |
 
 Classifications are `portable`, `adaptable`, `divergence`, and `non_goal`. A covered case requires live local test evidence; divergence and non-goal dispositions require a rationale.
 

--- a/packages/octane/audit/react-conformance-ledger.json
+++ b/packages/octane/audit/react-conformance-ledger.json
@@ -10404,7 +10404,7 @@
     },
     {
       "caseId": "react-case-v1:21f48ce03c86c4141d81",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "avoids flushing hoistables from completed boundaries nested inside fallbacks",
@@ -10412,7 +10412,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-2.test.ts",
+          "testName": "suppresses hoistables from completed boundaries nested inside fallbacks",
+          "modes": ["server-stream", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:220f34992afea7e1967e",
@@ -23727,7 +23734,7 @@
     },
     {
       "caseId": "react-case-v1:4dfe9d8122d32d2bdb30",
-      "status": "planned",
+      "status": "covered",
       "risk": "medium",
       "sourceFile": "packages/use-sync-external-store/src/__tests__/useSyncExternalStoreNative-test.js",
       "title": "native version",
@@ -23735,7 +23742,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "External-store compatibility packages",
-      "rationale": "The standalone compatibility packages are not shipped by Octane, but their observable subscription, snapshot, and notification semantics are actionable through Octane's useSyncExternalStore API."
+      "rationale": "The standalone compatibility packages are not shipped by Octane, but their observable subscription, snapshot, and notification semantics are actionable through Octane's useSyncExternalStore API.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/external-store-shared.test.ts",
+          "testName": "client-only mount reads getSnapshot even when getServerSnapshot is provided",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:4e159d01bb84f9bbf9c4",
@@ -44546,7 +44560,7 @@
     },
     {
       "caseId": "react-case-v1:94d8460706a840b15be3",
-      "status": "planned",
+      "status": "covered",
       "risk": "medium",
       "sourceFile": "packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShimServer-test.js",
       "title": "basic server render",
@@ -44554,7 +44568,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "External-store compatibility packages",
-      "rationale": "The standalone compatibility packages are not shipped by Octane, but their observable subscription, snapshot, and notification semantics are actionable through Octane's useSyncExternalStore API."
+      "rationale": "The standalone compatibility packages are not shipped by Octane, but their observable subscription, snapshot, and notification semantics are actionable through Octane's useSyncExternalStore API.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/external-store-shared.test.ts",
+          "testName": "basic server hydration",
+          "modes": ["client", "server-string", "hydrate-match", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:94d956e975498ec54e39",
@@ -60661,7 +60682,7 @@
     },
     {
       "caseId": "react-case-v1:cac76a87900e7134c737",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMUseId-test.js",
       "title": "identifierPrefix option",
@@ -60669,7 +60690,19 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/useid-determinism.test.ts",
+          "testName": "starts hydrated useId sequences from each server-rendered root",
+          "modes": ["server-string", "hydrate-match", "production-compile"]
+        },
+        {
+          "file": "packages/octane/tests/conformance/useid-determinism.test.ts",
+          "testName": "composes identifierPrefix with the automatic client-root namespace",
+          "modes": ["client", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:cac90fe5de6a0a66cdfd",
@@ -70338,7 +70371,7 @@
     },
     {
       "caseId": "react-case-v1:ea9ec574c18651aadb7b",
-      "status": "planned",
+      "status": "covered",
       "risk": "medium",
       "sourceFile": "packages/use-sync-external-store/src/__tests__/useSyncExternalStoreNative-test.js",
       "title": "Using isEqual to bailout",
@@ -70346,7 +70379,14 @@
       "classification": "adaptable",
       "owner": "runtime",
       "workstream": "External-store compatibility packages",
-      "rationale": "The standalone compatibility packages are not shipped by Octane, but their observable subscription, snapshot, and notification semantics are actionable through Octane's useSyncExternalStore API."
+      "rationale": "The standalone compatibility packages are not shipped by Octane, but their observable subscription, snapshot, and notification semantics are actionable through Octane's useSyncExternalStore API.",
+      "evidence": [
+        {
+          "file": "packages/redux/tests/conformance/external-store-shared.test.ts",
+          "testName": "Using isEqual to bailout",
+          "modes": ["client"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:eaa56aabc70ce6944c94",
@@ -73013,7 +73053,7 @@
     },
     {
       "caseId": "react-case-v1:f29d95a69c2aed14e46d",
-      "status": "planned",
+      "status": "covered",
       "risk": "high",
       "sourceFile": "packages/react-dom/src/__tests__/ReactDOMFloat-test.js",
       "title": "prioritizes ordering for certain hoistables over others when rendering on the server",
@@ -73021,7 +73061,14 @@
       "classification": "adaptable",
       "owner": "runtime + SSR + hydration",
       "workstream": "React DOM residual audit",
-      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition."
+      "rationale": "Remaining public DOM rendering, attributes, forms, native event outcomes, resource hints, SSR, hydration, refs, and reconciliation cases require exact behavioral evidence or a narrower case-level disposition.",
+      "evidence": [
+        {
+          "file": "packages/octane/tests/conformance/float-evidence-3.test.ts",
+          "testName": "serializes charset then viewport ahead of other hoistables on the server",
+          "modes": ["server-string", "server-stream", "production-compile"]
+        }
+      ]
     },
     {
       "caseId": "react-case-v1:f2a5b9b5135e4e7d8c71",

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -5488,6 +5488,7 @@ interface Ambient {
 	markers: boolean;
 	permanentStaticHydrateDepth: number;
 	head: HeadBuffer | null;
+	fallbackHoistDepth: number;
 	susp: SuspendedList | null;
 	res: ResolvedMap | null;
 	serial: unknown[] | null;
@@ -5515,6 +5516,7 @@ function saveAmbient(): Ambient {
 		markers: MARKERS,
 		permanentStaticHydrateDepth: PERMANENT_STATIC_HYDRATE_DEPTH,
 		head: HEAD,
+		fallbackHoistDepth: FALLBACK_HOIST_DEPTH,
 		susp: SUSPENDED,
 		res: RESOLVED,
 		serial: SERIAL,
@@ -5543,6 +5545,7 @@ function restoreAmbient(a: Ambient): void {
 	MARKERS = a.markers;
 	PERMANENT_STATIC_HYDRATE_DEPTH = a.permanentStaticHydrateDepth;
 	HEAD = a.head;
+	FALLBACK_HOIST_DEPTH = a.fallbackHoistDepth;
 	SUSPENDED = a.susp;
 	RESOLVED = a.res;
 	SERIAL = a.serial;

--- a/packages/octane/src/runtime.server.ts
+++ b/packages/octane/src/runtime.server.ts
@@ -196,6 +196,15 @@ let PERMANENT_STATIC_HYDRATE_DEPTH = 0;
 // `<head>` when present, else prepended).
 interface HeadBuffer {
 	html: string;
+	/**
+	 * Priority hoistables, folded ahead of everything else (React Fizz parity:
+	 * ReactDOMFloat-test.js:9085). `<meta charset>` must land in the first 1024
+	 * bytes for parsers to honor it without restarting; viewport affects first
+	 * layout. Charset precedes viewport regardless of discovery order; each
+	 * bucket keeps its own discovery order.
+	 */
+	charset: string;
+	viewport: string;
 	/** Resource-hint + Float-resource dedupe keys emitted during this pass. */
 	hints: Set<string>;
 	/**
@@ -219,9 +228,9 @@ interface HeadBuffer {
 	rootSuffix: string;
 }
 
-/** Fold order: hoisted head elements, then hints, then grouped stylesheets. */
+/** Fold order: charset, viewport, hoisted head elements, hints, grouped stylesheets. */
 function headHtmlWithSheets(buf: HeadBuffer): string {
-	let out = buf.html;
+	let out = buf.charset + buf.viewport + buf.html;
 	if (buf.hintHtml !== null) for (const tag of buf.hintHtml.values()) out += tag;
 	if (buf.sheets !== null && buf.sheets.size > 0) {
 		// Group by precedence in first-encounter group order: the per-resource map
@@ -234,6 +243,15 @@ function headHtmlWithSheets(buf: HeadBuffer): string {
 	return out;
 }
 let HEAD: HeadBuffer | null = null;
+
+// Depth of pending-arm (fallback) rendering. Hoistables authored inside a
+// fallback are transient — the fallback is discarded at reveal, but a streamed
+// head line is permanent — so ssrHeadEl suppresses while this is non-zero.
+// Suppression is TRANSITIVE (React parity: ReactDOMFloat-test.js:5431): a
+// completed boundary nested inside a fallback is still fallback territory, so
+// nested content arms never reset the depth. Balanced by withPendingArm's
+// finally; re-zeroed with each render's HEAD for crash hygiene.
+let FALLBACK_HOIST_DEPTH = 0;
 
 // Suspense (SSR Phase 4). A render pass that reaches an unresolved `use(thenable)`
 // records the thenable in SUSPENDED and throws SSR_SUSPENSE; the nearest @try
@@ -2892,6 +2910,8 @@ function captureComponentReplayState(scope: SSRScope, frame: Frame | null) {
 		cssEntries: css === null ? null : new Map(css),
 		head,
 		headLength: head !== null ? head.html.length : 0,
+		headCharsetLength: head !== null ? head.charset.length : 0,
+		headViewportLength: head !== null ? head.viewport.length : 0,
 		headHints: head === null ? null : new Set(head.hints),
 		headSheets: head === null || head.sheets === null ? null : new Map(head.sheets),
 		headHintHtml: head === null || head.hintHtml === null ? null : new Map(head.hintHtml),
@@ -2957,6 +2977,8 @@ function rewindComponentReplayState(
 	}
 	if (snapshot.head !== null && snapshot.headHints !== null) {
 		snapshot.head.html = snapshot.head.html.slice(0, snapshot.headLength);
+		snapshot.head.charset = snapshot.head.charset.slice(0, snapshot.headCharsetLength);
+		snapshot.head.viewport = snapshot.head.viewport.slice(0, snapshot.headViewportLength);
 		snapshot.head.hints.clear();
 		for (const key of snapshot.headHints) snapshot.head.hints.add(key);
 		if (snapshot.headSheets === null) snapshot.head.sheets = null;
@@ -5097,7 +5119,9 @@ export function ssrHeadEl(
 ): string {
 	// Returns '' so a NESTED hoist can sit in an html expression (the head write
 	// happens at the authored position; the body markup gains nothing).
-	if (HEAD === null) return '';
+	// Inside a fallback (any depth — see FALLBACK_HOIST_DEPTH) the hoist is
+	// dropped entirely, like React: the head outlives the fallback.
+	if (HEAD === null || FALLBACK_HOIST_DEPTH !== 0) return '';
 	// Paired ownership comments bound the exact adoption interval; static markup
 	// is non-hydratable, so both are omitted there.
 	const rootSuffix = HEAD.rootSuffix;
@@ -5117,6 +5141,19 @@ export function ssrHeadEl(
 		s += '>' + (text == null ? '' : escapeHtml(text)) + '</' + tag + '>';
 	}
 	if (MARKERS) s += '<!--/' + ownershipKey + '-->';
+	// Priority routing (fold order: charset, viewport, everything else — see
+	// HeadBuffer). Ownership markers travel with the element, so hydration
+	// adoption is position-independent.
+	if (tag === 'meta' && attrs !== null) {
+		if (attrs.charSet !== undefined || attrs.charset !== undefined) {
+			HEAD.charset += s;
+			return '';
+		}
+		if (attrs.name === 'viewport') {
+			HEAD.viewport += s;
+			return '';
+		}
+	}
 	HEAD.html += s;
 	return '';
 }
@@ -5558,12 +5595,15 @@ function runFullFramedPass(
 	const cssMap = (CSS = new Map<string, string>());
 	const headBuf = (HEAD = {
 		html: '',
+		charset: '',
+		viewport: '',
 		hints: new Set(),
 		sheets: null,
 		hintHtml: null,
 		preloadXfer: null,
 		rootSuffix: markers ? headOwnershipSuffix(identifierPrefix) : '',
 	} as HeadBuffer);
+	FALLBACK_HOIST_DEPTH = 0;
 	const suspended = (SUSPENDED = [] as SuspendedList);
 	const serial = (SERIAL = [] as unknown[]);
 	const deferred = (DEFERRED = [] as Job[]);
@@ -5658,12 +5698,15 @@ function runDiscoveryRound(
 	CSS = new Map();
 	HEAD = {
 		html: '',
+		charset: '',
+		viewport: '',
 		hints: new Set(),
 		sheets: null,
 		hintHtml: null,
 		preloadXfer: null,
 		rootSuffix: headOwnershipSuffix(identifierPrefix),
 	};
+	FALLBACK_HOIST_DEPTH = 0;
 	const suspended = (SUSPENDED = [] as SuspendedList);
 	SERIAL = [] as unknown[];
 	const deferred = (DEFERRED = [] as Job[]);
@@ -6569,12 +6612,17 @@ export function ssrTry(
 		});
 	const withPendingArm = <T>(fn: () => T): T => {
 		return withArmScope('pending', () => {
-			if (stream === null) return fn();
-			stream.activeOwnerKeys.push(key);
+			FALLBACK_HOIST_DEPTH++;
 			try {
-				return fn();
+				if (stream === null) return fn();
+				stream.activeOwnerKeys.push(key);
+				try {
+					return fn();
+				} finally {
+					stream.activeOwnerKeys.pop();
+				}
 			} finally {
-				stream.activeOwnerKeys.pop();
+				FALLBACK_HOIST_DEPTH--;
 			}
 		});
 	};
@@ -6632,6 +6680,8 @@ export function ssrTry(
 			const cssSnapshot = css === null ? null : new Map(css);
 			const head = HEAD;
 			const headHtml = head?.html;
+			const headCharset = head?.charset;
+			const headViewport = head?.viewport;
 			const headHints = head === null ? null : new Set(head.hints);
 			const headSheets = head === null || head.sheets === null ? null : new Map(head.sheets);
 			const headHintHtml = head === null || head.hintHtml === null ? null : new Map(head.hintHtml);
@@ -6660,6 +6710,8 @@ export function ssrTry(
 				}
 				if (head !== null && headHints !== null) {
 					head.html = headHtml!;
+					head.charset = headCharset!;
+					head.viewport = headViewport!;
 					head.hints.clear();
 					for (const hint of headHints) head.hints.add(hint);
 					if (headSheets === null) head.sheets = null;

--- a/packages/octane/tests/_fixtures/float-evidence-3.tsrx
+++ b/packages/octane/tests/_fixtures/float-evidence-3.tsrx
@@ -124,3 +124,17 @@ export function TitleUpdate(props: { text: string; foo: string }) @{
 		<main class="fe3-title-host">{'t' as string}</main>
 	</>
 }
+
+// Head content authored in deliberately unprioritized order: charset last,
+// viewport second-to-last, ordinary metadata first.
+export function PriorityHead() @{
+	<>
+		<link rel="alternate" href="/fe3-feed.xml" />
+		<meta name="bar" content="b" />
+		<title>a title</title>
+		<link rel="preconnect" href="/fe3-bar" />
+		<meta name="viewport" content="width=device-width" />
+		<meta charSet="utf-8" />
+		<main class="fe3-priority-host">{'p' as string}</main>
+	</>
+}

--- a/packages/octane/tests/conformance/external-store-shared.test.ts
+++ b/packages/octane/tests/conformance/external-store-shared.test.ts
@@ -50,6 +50,25 @@ describe('Shared useSyncExternalStore behavior', () => {
 		root.unmount();
 	});
 
+	// Per useSyncExternalStoreNative-test.js:105 'native version'. React's native
+	// shim build resolves the client code path even under a Node environment, so
+	// a mount with a getServerSnapshot argument still renders the CLIENT
+	// snapshot. Octane does not ship the compatibility packages; the same
+	// observable holds for its built-in useSyncExternalStore: a client-only
+	// mount reads getSnapshot, never getServerSnapshot, and is live-subscribed
+	// to store updates.
+	it('client-only mount reads getSnapshot even when getServerSnapshot is provided', () => {
+		const store = { ...createExternalStore('client'), getServerState: () => 'server' };
+		const root = mount(HydrationStoreReader, { store, hostRef: null });
+		flushEffects();
+		expect(root.find('#hydrated-store').textContent).toBe('client');
+		expect(store.getSubscriberCount()).toBe(1);
+
+		flushStoreUpdate(() => store.set('updated'));
+		expect(root.find('#hydrated-store').textContent).toBe('updated');
+		root.unmount();
+	});
+
 	// Per useSyncExternalStoreShared-test.js:152 (stable and canary).
 	it('skips re-rendering if nothing changes', () => {
 		const store = createExternalStore('Initial');

--- a/packages/octane/tests/conformance/float-evidence-2.test.ts
+++ b/packages/octane/tests/conformance/float-evidence-2.test.ts
@@ -157,6 +157,36 @@ describe('Float evidence — streamed SSR discovery and flush identity', () => {
 		expect(head).not.toContain('/fallback-author');
 	});
 
+	// Per ReactDOMFloat-test.js:5431 — 'avoids flushing hoistables from completed
+	// boundaries nested inside fallbacks': fallback suppression is TRANSITIVE. A
+	// resolved boundary rendered inside a pending boundary's fallback is still
+	// fallback territory — its markup shows, its hoistables never reach the head
+	// (the fallback is discarded at reveal, but a streamed head line would be
+	// permanent).
+	it('suppresses hoistables from completed boundaries nested inside fallbacks', async () => {
+		const outer = deferred<string>();
+		const collector = createPipeableCollector();
+		Server.renderToPipeableStream(srv.NestedFallbackMetaBoundary, {
+			promise: outer.promise,
+			inner: Promise.resolve('np'),
+		}).pipe(collector.destination);
+		await settleMacrotasks();
+		const shell = collector.chunks.join('');
+		const shellHead = shell.slice(0, shell.indexOf('<div class="nfm-host"'));
+		// The fallback's nested boundary resolved and its markup shows (inline or
+		// via its reveal carrier, where attribute quotes arrive JSON-escaped)…
+		expect(shell).toMatch(/class=\\?"nested-primary\\?">np/);
+		// …but its metadata is fallback content: never in the head. The (still
+		// suspended) primary content's metadata is.
+		expect(shellHead).toContain('primary-meta');
+		expect(shellHead).not.toContain('nested-primary-meta');
+		outer.resolve('ready');
+		const html = await collector.ended;
+		const head = html.slice(0, html.indexOf('<div class="nfm-host"'));
+		expect(head).toContain('primary-meta');
+		expect(head).not.toContain('nested-primary-meta');
+	});
+
 	// Per ReactDOMFloat-test.js:5496
 	it('flushes nothing before the shell; a pre-suspension preinit folds into the shell', async () => {
 		const gate = deferred<string>();

--- a/packages/octane/tests/conformance/float-evidence-3.test.ts
+++ b/packages/octane/tests/conformance/float-evidence-3.test.ts
@@ -15,6 +15,7 @@ import {
 	resetFloatResourceState,
 } from '../../src/index.js';
 import * as Server from 'octane/server';
+import { collectPipeableStream } from '../_server-stream.js';
 import { loadServerFixture } from '../_server-fixture.js';
 import { mount } from '../_helpers.js';
 import {
@@ -366,5 +367,44 @@ describe('Float evidence (slice 3) — style-resource nonce and hoistable lifecy
 
 		m.unmount();
 		expect(title.isConnected).toBe(false);
+	});
+
+	// Per ReactDOMFloat-test.js:9085 — 'prioritizes ordering for certain
+	// hoistables over others when rendering on the server': charset first,
+	// viewport second, everything else in discovery order. Browsers only honor
+	// a charset within the first 1024 bytes without re-parsing.
+	it('serializes charset then viewport ahead of other hoistables on the server', async () => {
+		const App = () => Server.createElement(srv.PriorityHead, null) as any;
+		const r = await Server.renderToString(App as any);
+		// HTML attribute names are case-insensitive; compare lowercased so the
+		// contract is the ORDER, not the attribute-name casing.
+		const head = r.html.slice(0, r.html.indexOf('<main')).toLowerCase();
+		const charset = head.indexOf('charset="utf-8"');
+		const viewport = head.indexOf('name="viewport"');
+		const alternate = head.indexOf('rel="alternate"');
+		const bar = head.indexOf('name="bar"');
+		const title = head.indexOf('<title');
+		const preconnect = head.indexOf('rel="preconnect"');
+		for (const idx of [charset, viewport, alternate, bar, title, preconnect]) {
+			expect(idx).toBeGreaterThan(-1);
+		}
+		// charset first, viewport second…
+		expect(charset).toBeLessThan(viewport);
+		expect(viewport).toBeLessThan(alternate);
+		// …everything else keeps discovery order.
+		expect(alternate).toBeLessThan(bar);
+		expect(bar).toBeLessThan(title);
+		expect(title).toBeLessThan(preconnect);
+
+		// The streamed shell folds the same priority order.
+		const { html, errors } = await collectPipeableStream(App as any);
+		expect(errors).toEqual([]);
+		const streamHead = html.slice(0, html.indexOf('<main')).toLowerCase();
+		const streamCharset = streamHead.indexOf('charset="utf-8"');
+		expect(streamCharset).toBeGreaterThan(-1);
+		expect(streamCharset).toBeLessThan(streamHead.indexOf('name="viewport"'));
+		expect(streamHead.indexOf('name="viewport"')).toBeLessThan(
+			streamHead.indexOf('rel="alternate"'),
+		);
 	});
 });


### PR DESCRIPTION
## Summary

Closes the last two engine gaps from #711's React 19 parity audit and retires the final planned evidence items, leaving only the diagnostics (warning-message) backlog:

- **Transitive fallback-hoistable suppression** (Per ReactDOMFloat-test.js:5431, ledger `…c4141d81`): a `<title>`/`<meta>`/`<link>` authored inside a pending boundary's fallback never reaches the streamed head — including from a *completed* boundary nested inside that fallback. The fallback is discarded at reveal, but a streamed head line is permanent, so a fallback hoist would outlive its content.
- **Server hoistable prioritization** (Per ReactDOMFloat-test.js:9085, ledger `…ed14e46d`): `<meta charSet>` now serializes at the front of the head (parsers only honor a charset within the first 1024 bytes), then `<meta name="viewport">`, then everything else in discovery order — matching Fizz.
- **Evidence flips** for the four remaining actionable planned cases: the `identifierPrefix` root option (linked to the existing `useid-determinism` conformance suite) and the three external-store compatibility cases (via `useSyncExternalStore` semantics: one new client-mount 3-arg-form test, plus links to the existing shared/redux conformance suites).

Ledger after this PR: `ReactDOMFloat-test.js` planned drops 5 → 3 (only the three warning-message families remain, tracked in the diagnostics backlog); whole-ledger planned 1,928 → 1,922.

## Why

Both engine fixes are `runtime.server.ts`-only:

- Suppression: a module-level fallback depth incremented by `ssrTry`'s pending-arm wrapper and checked in `ssrHeadEl`. Nested content arms deliberately never reset it — that's the transitive semantics. Balanced by `finally`; re-zeroed with each render's head buffer for crash hygiene. Fallback *markup* (including a nested completed boundary's content) still renders; only head hoists are dropped, exactly like React. Float resources and hints from fallbacks stay registered (resources are page-global; React allows fallback preloads).
- Prioritization: `HeadBuffer` gains `charset`/`viewport` priority buckets routed at registration (runtime values, so dynamic `name`/`charSet` route correctly) and folded ahead of everything else. The buckets joined both suspense-replay snapshot/rewind sites (component replay + the done-boundary fallback render). Ownership markers travel with each element, so hydration adoption is position-independent — the full hydration suite is green.

## Red-first evidence

- Suppression: the new conformance test failed pre-fix with `nested-primary-meta` present in the streamed shell head (the exact upstream-cited observable).
- Prioritization: the new test was seen red against the fold order deliberately reverted to `html + charset + viewport` (only that test failed; restored, all green).
- The agent-ported external-store test was seen red against a deliberately inverted client/server snapshot read in the fixture (failed in both dev and prod projects; restored).

## Review round 1 (Bugbot, fixed in 0fa796222)

Valid invariant finding: `FALLBACK_HOIST_DEPTH` wasn't carried through `saveAmbient`/`restoreAmbient`, whose contract is that *everything* a pass touches is snapshotted so interleaved renders can't clobber each other. The counter is balanced by `withPendingArm`'s `finally` within every synchronous pass, and passes only interleave at await points — so a non-zero value is not observable at any interleave point today and no behavioral repro exists (which is why this ships without a new test rather than with one that cannot fail). The field now rides the ambient snapshot like `HEAD` itself, closing the landmine for any future pass that yields mid-arm. Re-validated: `ssr-suspense-isolation` + SSR/streaming/head suites 350/350, targeted typecheck and format clean.

## Validation

- [x] `pnpm format:files` (changed files), `pnpm typecheck`
- [x] `pnpm test` — 20,938 passed; 2 failing files, both triaged as not-from-this-diff: `doom-browser` is nondeterministic under any load (2/7 then 7/7 across two back-to-back isolation runs of the same code) and `swr/root` passes 10/10 in isolation (contention flake)
- [x] `node scripts/react-parity/check.mjs --validate-only` — metadata current (ledger + coverage byte-checked)
- [ ] the full evidence-executing `check.mjs` could not complete locally: its parity-wide Vitest lane aborts on a Vite "Port … is in use" line polluting the JSON reporter stream — other concurrent agent sessions on this machine hold test ports (verified via `lsof`/`pgrep`: live vitest workers from unrelated worktrees). Every NEW evidence test was executed directly instead (all green, dev+prod); CI's parity shards run on isolated runners and are the authoritative gate here
- [x] targeted: `float-evidence-2` (38, dev+prod), `float-evidence-3` (28, dev+prod), neighbor sweep (`hydration/`, `streaming-ssr`, `float-resources`, `resource-hints`, `ssr-stream-state-regressions`, `external-store-shared`, `useid-determinism`) 1,010/1,010

## Risk / follow-ups

- One test asserts head ORDER case-insensitively: Octane serializes the `charSet` attribute name camelCase where React lowercases — HTML attribute names are ASCII case-insensitive so this is spec-equivalent; flagged here rather than silently pinned. Trivial to normalize later if byte-parity with React's head output ever matters.
- Late-discovered (post-shell) charset/viewport metas behave like all late head elements: they don't stream (documented divergence; only the sheet family streams, per #727).
- After merge: refresh #711 — with these landed, the issue is closeable modulo the diagnostics backlog (recommend spinning that into its own issue).

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core SSR streaming head assembly and Suspense fallback rendering; mistakes could leak wrong metadata into `<head>` or change early-byte layout for parsers, though changes are scoped to `runtime.server.ts` with targeted conformance coverage.
> 
> **Overview**
> Closes the last **Float engine** gaps called out in the React 19 parity audit by changing **server head hoisting** in `runtime.server.ts`.
> 
> **Transitive fallback suppression:** While rendering a `@try` **pending** arm, `FALLBACK_HOIST_DEPTH` increments and `ssrHeadEl` returns without registering `<title>` / `<meta>` / `<link>`. Nested boundaries that finish inside that fallback still count as fallback territory, so their metadata never lands in the streamed head even though body markup can still show.
> 
> **Priority head ordering:** `HeadBuffer` adds `charset` and `viewport` buckets; `<meta charSet>` and `<meta name="viewport">` fold **before** other hoistables (`charset` then `viewport`, then discovery order). Snapshot/rewind paths track those buffers so suspense replays stay consistent.
> 
> **Evidence and docs:** New/extended conformance covers nested-fallback meta suppression and charset/viewport ordering (`float-evidence-2` / `float-evidence-3`), plus a client-mount `useSyncExternalStore` case. The React conformance ledger flips several cases from **planned** to **covered** (Float tests, `identifierPrefix`, external-store shims); `differences-from-react.md` and the changeset describe the behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4afa283263ba591592832c8bfa3b27b951a2702f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
