### PR TITLE
test: bring packages/swr/tests under the scoped typecheck gate

### DIFF
--- a/packages/swr/tests/differential/tsconfig.json
+++ b/packages/swr/tests/differential/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": { "noEmit": true, "types": ["node"] },
+  "include": ["."]
+}

--- a/packages/swr/tests/global.d.ts
+++ b/packages/swr/tests/global.d.ts
@@ -1,0 +1,9 @@
+// Test-side ambient Window surface for the swr devtools contract. The runtime
+// installs __SWR_DEVTOOLS_OCTANE__ with Object.defineProperty
+// (src/_internal/devtools-contract.ts), so no importable declaration exists.
+// Kept under tests/ so the published tarball (package.json "files": ["src", …])
+// never ships an ambient Window augmentation to consumers.
+interface Window {
+	__SWR_DEVTOOLS_OCTANE__?: unknown;
+	__SWR_DEVTOOLS_REACT__?: unknown;
+}

--- a/packages/swr/tests/probes/conditions/tsconfig.bundler.json
+++ b/packages/swr/tests/probes/conditions/tsconfig.bundler.json
@@ -5,7 +5,8 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "target": "ES2022",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   },
   "files": ["nodenext.ts"]
 }

--- a/packages/swr/tests/probes/conditions/tsconfig.nodenext.json
+++ b/packages/swr/tests/probes/conditions/tsconfig.nodenext.json
@@ -5,7 +5,8 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "target": "ES2022",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   },
   "files": ["nodenext.ts"]
 }

--- a/packages/swr/tests/probes/conditions/tsconfig.react-server.json
+++ b/packages/swr/tests/probes/conditions/tsconfig.react-server.json
@@ -6,6 +6,7 @@
     "moduleResolution": "NodeNext",
     "target": "ES2022",
     "skipLibCheck": true,
+    "types": ["node"],
     "customConditions": ["react-server"]
   },
   "files": ["react-server.ts"]

--- a/packages/swr/tests/probes/external-store.tsrx
+++ b/packages/swr/tests/probes/external-store.tsrx
@@ -1,6 +1,12 @@
 import { startTransition, useState, useSyncExternalStore } from 'octane';
 
-export function ExternalStoreProbe(props) @{
+type SnapshotStore = {
+	subscribe: (onStoreChange: () => void) => () => void;
+	getSnapshot: () => string;
+	getServerSnapshot: () => string;
+};
+
+export function ExternalStoreProbe(props: { store: SnapshotStore }) @{
 	const value = useSyncExternalStore(
 		props.store.subscribe,
 		props.store.getSnapshot,

--- a/packages/swr/tests/tsconfig.json
+++ b/packages/swr/tests/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": { "noEmit": true },
+  "include": ["."],
+  "exclude": ["differential", "probes/conditions"]
+}

--- a/packages/swr/tests/unit/core.test.ts
+++ b/packages/swr/tests/unit/core.test.ts
@@ -11,6 +11,7 @@ import {
 	withMiddleware,
 } from '../../src/_internal/index';
 import { readDevtoolsMiddleware, setupOctaneDevtools } from '../../src/_internal/devtools-contract';
+import type { Middleware } from '../../src/_internal/index';
 import { middleware as preloadMiddleware } from '../../src/_internal/utils/preload';
 
 describe('SWR U2 framework-neutral core', () => {
@@ -42,8 +43,8 @@ describe('SWR U2 framework-neutral core', () => {
 			{ revalidateOnFocus: false },
 		]);
 
-		const first = () => undefined;
-		const second = () => undefined;
+		const first: Middleware = (useSWRNext) => useSWRNext;
+		const second: Middleware = (useSWRNext) => useSWRNext;
 		expect(
 			mergeConfigs(
 				{ use: [first], fallback: { parent: 1, shared: 'parent' } },

--- a/packages/swr/tests/unit/provider-slot.test.ts
+++ b/packages/swr/tests/unit/provider-slot.test.ts
@@ -12,7 +12,7 @@ let root: ReturnType<typeof createRoot> | undefined;
 afterEach(() => {
 	root?.unmount();
 	container?.remove();
-	cache.clear();
+	for (const key of [...cache.keys()]) cache.delete(key);
 });
 
 describe('SWRConfig Octane provider slot', () => {

--- a/packages/swr/tests/unit/root-trace.test.ts
+++ b/packages/swr/tests/unit/root-trace.test.ts
@@ -49,6 +49,6 @@ describe('SWR U3 Octane root request-state oracle', () => {
 		expect(callbacks).toEqual(['success']);
 		expect(fetcher).toHaveBeenCalledOnce();
 		root.unmount();
-		cache.clear();
+		for (const key of [...cache.keys()]) cache.delete(key);
 	});
 });

--- a/packages/swr/tests/upstream/root/fixtures.tsrx
+++ b/packages/swr/tests/upstream/root/fixtures.tsrx
@@ -1,10 +1,18 @@
 import useSWR, { SWRConfig } from '../../../src/index/index';
+import type { BareFetcher, Key, SWRConfiguration } from '../../../src/index/index';
 import { Suspense } from 'octane';
+
+type ReaderProps = {
+	id?: string;
+	cacheKey: Key;
+	fetcher: BareFetcher<unknown> | null;
+	config?: SWRConfiguration;
+};
 
 export const captured: { mutate?: (...args: any[]) => any } = {};
 export const renderTrace: unknown[] = [];
 
-export function SWRReader(props) @{
+export function SWRReader(props: ReaderProps) @{
 	const state = useSWR(props.cacheKey, props.fetcher, props.config);
 	captured.mutate = state.mutate;
 	renderTrace.push({
@@ -21,7 +29,7 @@ export function SWRReader(props) @{
 	})}</output>
 }
 
-export function SWRSiblings(props) @{
+export function SWRSiblings(props: ReaderProps) @{
 	<div>
 		<SWRReader id="first" cacheKey={props.cacheKey} fetcher={props.fetcher} config={props.config} />
 		<SWRReader
@@ -33,13 +41,13 @@ export function SWRSiblings(props) @{
 	</div>
 }
 
-export function SWRSuspense(props) @{
+export function SWRSuspense(props: ReaderProps) @{
 	<Suspense fallback={<span data-testid="fallback">loading</span>}>
 		<SWRReader cacheKey={props.cacheKey} fetcher={props.fetcher} config={{ suspense: true }} />
 	</Suspense>
 }
 
-export function SWRProviderProbe(props) @{
+export function SWRProviderProbe(props: { provider: NonNullable<SWRConfiguration['provider']> }) @{
 	<SWRConfig value={{ provider: props.provider }}>
 		<output data-testid="provider">configured</output>
 	</SWRConfig>

--- a/packages/swr/tests/upstream/root/root.test.ts
+++ b/packages/swr/tests/upstream/root/root.test.ts
@@ -44,7 +44,7 @@ function value(id = 'value') {
 afterEach(() => {
 	root?.unmount();
 	container?.remove();
-	cache.clear();
+	for (const key of [...cache.keys()]) cache.delete(key);
 });
 
 describe('SWR U3 root lifecycle', () => {

--- a/packages/swr/tests/upstream/specialized/fixtures.tsrx
+++ b/packages/swr/tests/upstream/specialized/fixtures.tsrx
@@ -2,10 +2,25 @@ import useSWRImmutable from '../../../src/immutable/index';
 import useSWRInfinite from '../../../src/infinite/index';
 import useSWRMutation from '../../../src/mutation/index';
 import useSWRSubscription from '../../../src/subscription/index';
+import type { BareFetcher, Key, SWRConfiguration } from '../../../src/index/index';
+import type { SWRInfiniteConfiguration, SWRInfiniteKeyLoader } from '../../../src/infinite/index';
+import type { MutationFetcher, SWRMutationConfiguration } from '../../../src/mutation/index';
+import type { SWRSubscription } from '../../../src/subscription/index';
 
 export const controls: Record<string, any> = {};
 
-export function ImmutableReader(props) @{
+type SubscriptionProps = {
+	id?: string;
+	cacheKey: Key;
+	subscribe: SWRSubscription<Key, string>;
+	config?: SWRConfiguration;
+};
+
+export function ImmutableReader(props: {
+	cacheKey: Key;
+	fetcher: BareFetcher<unknown> | null;
+	config?: SWRConfiguration;
+}) @{
 	const state = useSWRImmutable(props.cacheKey, props.fetcher, props.config);
 	<output data-testid="immutable">{JSON.stringify({
 		data: state.data,
@@ -13,7 +28,11 @@ export function ImmutableReader(props) @{
 	})}</output>
 }
 
-export function InfiniteReader(props) @{
+export function InfiniteReader(props: {
+	getKey: SWRInfiniteKeyLoader;
+	fetcher: BareFetcher<unknown> | null;
+	config?: SWRInfiniteConfiguration;
+}) @{
 	const state = useSWRInfinite(props.getKey, props.fetcher, props.config);
 	controls.setSize = state.setSize;
 	controls.mutateInfinite = state.mutate;
@@ -24,7 +43,11 @@ export function InfiniteReader(props) @{
 	})}</output>
 }
 
-export function MutationReader(props) @{
+export function MutationReader(props: {
+	cacheKey: Key;
+	fetcher: MutationFetcher<unknown, Key, string>;
+	config?: SWRMutationConfiguration<unknown, Error>;
+}) @{
 	const state = useSWRMutation(props.cacheKey, props.fetcher, props.config);
 	controls.trigger = state.trigger;
 	controls.reset = state.reset;
@@ -35,7 +58,7 @@ export function MutationReader(props) @{
 	})}</output>
 }
 
-export function SubscriptionReader(props) @{
+export function SubscriptionReader(props: SubscriptionProps) @{
 	const state = useSWRSubscription(props.cacheKey, props.subscribe, props.config);
 	<output data-testid={props.id || 'subscription'}>{JSON.stringify({
 		data: state.data,
@@ -43,7 +66,7 @@ export function SubscriptionReader(props) @{
 	})}</output>
 }
 
-export function SubscriptionSiblings(props) @{
+export function SubscriptionSiblings(props: SubscriptionProps) @{
 	<div>
 		<SubscriptionReader id="subscription-first" {...props} />
 		<SubscriptionReader id="subscription-second" {...props} />

--- a/packages/swr/tests/upstream/specialized/specialized.test.ts
+++ b/packages/swr/tests/upstream/specialized/specialized.test.ts
@@ -41,7 +41,7 @@ function value(id: string) {
 afterEach(() => {
 	root?.unmount();
 	root = undefined;
-	cache.clear();
+	for (const key of [...cache.keys()]) cache.delete(key);
 	for (const key of Object.keys(controls)) delete controls[key];
 });
 
@@ -123,7 +123,7 @@ describe('SWR U4 specialized entrypoints', () => {
 		mount(MutationReader, {
 			cacheKey: 'mutation-race',
 			fetcher,
-			config: { onSuccess: (data) => successes.push(data) },
+			config: { onSuccess: (data: string) => successes.push(data) },
 		});
 		const older = controls.trigger('older');
 		const newer = controls.trigger('newer');
@@ -180,7 +180,7 @@ describe('SWR U4 specialized entrypoints', () => {
 		let next!: (error?: Error, data?: string) => void;
 		mount(SubscriptionReader, {
 			cacheKey: 'subscription-error',
-			subscribe: (_key, options) => {
+			subscribe: (_key: string, options: { next: (error?: Error, data?: string) => void }) => {
 				next = options.next;
 				return () => undefined;
 			},


### PR DESCRIPTION
## Summary

`pnpm typecheck:files` (the prescribed pre-push gate) failed on any edited swr test file, while repo-wide `pnpm typecheck` never looked at `packages/swr/tests` at all (`packages/swr/tsconfig.json` includes only `src`). The visible symptom was TS2339 on `window.__SWR_DEVTOOLS_OCTANE__` / `__SWR_DEVTOOLS_REACT__`, but the baseline scoped run also failed on untyped `.tsrx` fixture `props`, a `() => undefined` sentinel passed as `Middleware`, and `cache.clear()` (the public `Cache` contract has `keys()`/`delete()`, no `clear()`). This PR makes the swr tests tree typecheck-clean under the scoped gate without shipping anything to the tarball.

## Why

- `scripts/typecheck-files.mjs` resolves ownership by walking up to the nearest tsconfig and only auto-includes the owning project's `.d.ts` files. With `packages/swr/tsconfig.json` (src-only) as the fallback owner, no tests-local ambient declaration could ever be seen, so the devtools `Window` globals — installed at runtime via `Object.defineProperty` in `src/_internal/devtools-contract.ts` (the settled `OCTANE DIVERGENCE[swr-devtools-global]`, untouched here) — had no importable or ambient type.
- The augmentation must not live in `src/`: the package publishes `"files": ["src", …]`, and a shipped ambient `Window` augmentation would apply to every consumer program.

## Changes

- New `packages/swr/tests/tsconfig.json` (modeled on the existing `tests/adoption/tsconfig.json`) owns the tests tree for the scoped gate, excluding `differential` and `probes/conditions`, which need different programs. New `packages/swr/tests/global.d.ts` declares the two devtools globals as optional `unknown` (`root.test.ts` `delete`s them), test-side only.
- New `packages/swr/tests/differential/tsconfig.json`: the differential tests compile the byte-pinned vendored `upstream/src`, where the ambient augmentation would turn upstream's `@ts-expect-error` on `window.__SWR_DEVTOOLS_REACT__ = React` into a fresh TS2578. A lane-local tsconfig keeps `global.d.ts` out of that program; the differential test files themselves are sha256-pinned in `audit/react-parity.json` and are not modified.
- `"types": ["node"]` added to the three `probes/conditions/tsconfig.*.json` lanes and the new differential tsconfig: they check under `tsgo`, which does not auto-include visible `@types`, so octane's `runtime.ts` failed with TS2591 `Cannot find name 'process'` (pre-existing; every other tsgo project in the repo already declares `"types": ["node"]`).
- Typed all fixture `props` per the tsrx authoring rule (`upstream/root/fixtures.tsrx`, `upstream/specialized/fixtures.tsrx`, `probes/external-store.tsrx`) against the port's real exported types, typed two callback params in `specialized.test.ts`, and made the `mergeConfigs` sentinels in `unit/core.test.ts` real `Middleware` identities.
- Replaced the four `cache.clear()` cleanup sites with `for (const key of [...cache.keys()]) cache.delete(key)` — behaviorally identical on the default Map-backed cache and inside the public `Cache` surface.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm typecheck` (repo-wide, green — the fixed `-p` list is unaffected by the new tests tsconfigs)
- [x] `pnpm test` — ran the full root Vitest run twice locally; 20,9xx tests pass. Each run had a different small set of failures confined to real-browser/server-spawning suites outside this diff (`octane-events-browser` native-change with a Vite `504 Outdated Optimize Dep` load error, `doom-browser` pointer-lock, `website-mcp-unit` plumbing). All three files pass 28/28 when run directly, so these are local parallel-load flakes, not regressions from this change; nothing in this diff is imported by them.
- [x] targeted tests: `pnpm typecheck:files packages/swr/tests/upstream/root/root.test.ts packages/swr/tests/unit/core.test.ts packages/swr/tests/probes/architecture.test.ts` (passes; previously 17 errors), `tsrx-tsc --noEmit -p packages/swr/tests/tsconfig.json` (whole tests project clean), scoped runs of the `probes/conditions` lanes (clean), `vitest run --project swr` (35/35) and `--project swr-differential` (4/4), `pnpm tsrx-decls:check`, `pnpm sync` (no generated changes)

## Risk / follow-ups

- One pre-existing gap is left deliberately: scoped typecheck of a **differential** test still fails on `upstream/src/index/use-swr.ts(329)` TS2578 (upstream builds with `noUnusedLocals`, which this repo's configs don't set; enabling it in the lane trips over two intentionally-unused declarations in octane's `runtime.ts`). Unchanged from baseline — fixing it needs an octane-core edit and is spun off separately.
- `packages/swr/tests` stays out of repo-wide `pnpm typecheck` on purpose: no other package gates its tests dir there, and the scoped pre-push gate now covers the tree.
- Test-only + test-tooling change: no changeset.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only TypeScript and cleanup changes; no production `src` or consumer-facing behavior.
> 
> **Overview**
> Adds **`packages/swr/tests/tsconfig.json`** (excluding differential and `probes/conditions`) plus a **`tests/global.d.ts`** `Window` augmentation for devtools globals so **`pnpm typecheck:files`** on swr tests is clean without shipping ambient types from `src`. A separate **`tests/differential/tsconfig.json`** keeps that augmentation out of the byte-pinned upstream differential program.
> 
> Probe condition tsconfigs and the differential config now set **`"types": ["node"]`** for tsgo. Test fixtures and a few unit tests gain explicit types (`Middleware` sentinels, `.tsrx` props, callback params), and teardown replaces **`cache.clear()`** with **`for (const key of [...cache.keys()]) cache.delete(key)`** to match the public `Cache` API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7a4491beebeb1eca28109ae18f526aeb9fd2d29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->