### PR TITLE
test(swr): make remote mutation race deterministic

### DIFF
--- a/packages/swr/UPSTREAM.md
+++ b/packages/swr/UPSTREAM.md
@@ -19,6 +19,12 @@ tarball at `upstream/npm/swr-2.4.2.tgz`. The tarball is retained because it
 contains compiled condition branches and declarations rather than the canonical
 source and tests.
 
+The pristine Jest config maps `@testing-library/react` through a narrow harness
+for the `useSWR` remote-mutation race case. Upstream starts a 10 ms request and
+assumes the mutation click wins that wall-clock race. The harness holds only that
+request completion until the click has started the mutation, then releases it so
+the unchanged assertion deterministically exercises the intended overlap.
+
 ## Provenance status
 
 `packages/swr/audit/react-parity.json` is `recorded-unverified`. Required lanes

--- a/packages/swr/audit/jest-pristine.config.mjs
+++ b/packages/swr/audit/jest-pristine.config.mjs
@@ -1,7 +1,15 @@
+import { resolve } from 'node:path';
+
 import upstreamConfig from '../upstream/jest.config.js';
+
+const testingLibraryHarness = resolve(import.meta.dirname, 'upstream-testing-library.cjs');
 
 export default {
 	...upstreamConfig,
+	moduleNameMapper: {
+		...upstreamConfig.moduleNameMapper,
+		'^@testing-library/react$': testingLibraryHarness,
+	},
 	transform: {
 		'^.+\\.(t|j)sx?$': [
 			'@swc/jest',

--- a/packages/swr/audit/react-parity.json
+++ b/packages/swr/audit/react-parity.json
@@ -51,6 +51,7 @@
       "environment": "workspace-node",
       "project": "swr-pristine",
       "evidenceOrigin": "upstream-suite",
+      "notes": "Runs the byte-exact SWR 2.4.2 Jest suite. A testing-library harness holds the initial request completion in the remote-mutation race case until the mutation starts, preserving the upstream assertion without wall-clock ordering.",
       "execution": {
         "kind": "jest-full",
         "config": "packages/swr/audit/jest-pristine.config.mjs",
@@ -66,7 +67,17 @@
         {
           "path": "packages/swr/audit/jest-pristine.config.mjs",
           "role": "support",
-          "sha256": "fb6901474496ccfde71ea7453af5033bc7747b93b7613b84456a1def154525e2"
+          "sha256": "cd9ca9ac112cafe7bcbc354d1c98a405c5d1c917443b21a069017ef60b7fe86a"
+        },
+        {
+          "path": "packages/swr/audit/upstream-testing-library.cjs",
+          "role": "support",
+          "sha256": "57f0b3c6585807fcf46dd988d2b657ad440008e77bd9700e2cf0d405cefae4bc"
+        },
+        {
+          "path": "packages/swr/audit/upstream-timer-gate.cjs",
+          "role": "support",
+          "sha256": "0c87828c172fe2a2ef69993f7242ec2383146f24a27df95c39b68d30bb113db4"
         },
         {
           "path": "packages/swr/upstream/SHA256SUMS",
@@ -82,6 +93,11 @@
           "path": "scripts/react-parity/swr-runtime-inventory.mjs",
           "role": "support",
           "sha256": "185d862650fd217503e440f7c781367ed726df26839b67296709b2b6bcaf31e8"
+        },
+        {
+          "path": "scripts/react-parity/swr-upstream-timer-gate.test.mjs",
+          "role": "support",
+          "sha256": "b158c5c7dead7aba1df0dd4ab8042c2bfcacb9818ef3ca7d1873b75ab02fa943"
         }
       ]
     },

--- a/packages/swr/audit/upstream-testing-library.cjs
+++ b/packages/swr/audit/upstream-testing-library.cjs
@@ -1,0 +1,51 @@
+const { createRequire } = require('node:module');
+const { dirname, join } = require('node:path');
+
+const requireFromPackage = createRequire(`${__dirname}/../package.json`);
+const testingLibraryRoot = dirname(
+	requireFromPackage.resolve('@testing-library/react/package.json'),
+);
+const testingLibrary = require(join(testingLibraryRoot, 'dist/index.js'));
+const { holdFirstTimeout } = require('./upstream-timer-gate.cjs');
+
+const REMOTE_MUTATION_RACE_TEST =
+	'useSWR - remote mutation should prevent race conditions with `useSWR`';
+
+let releaseInitialRequest = null;
+
+function isRemoteMutationRaceTest() {
+	return expect.getState().currentTestName === REMOTE_MUTATION_RACE_TEST;
+}
+
+function render(element, options) {
+	if (!isRemoteMutationRaceTest()) return testingLibrary.render(element, options);
+	if (releaseInitialRequest !== null) {
+		throw new Error('The remote-mutation request timer is already held');
+	}
+
+	// The upstream case gives the initial request a 10 ms timer and assumes the
+	// click starts a mutation before that timer fires. Hold that one completion
+	// through the click so a loaded runner cannot turn the intended race into a
+	// sequential request followed by a mutation.
+	const held = holdFirstTimeout(10, () => testingLibrary.render(element, options));
+	releaseInitialRequest = held.release;
+	return held.result;
+}
+
+const fireEvent = (...args) => testingLibrary.fireEvent(...args);
+Object.assign(fireEvent, testingLibrary.fireEvent, {
+	click(...args) {
+		const result = testingLibrary.fireEvent.click(...args);
+		if (!isRemoteMutationRaceTest()) return result;
+		if (releaseInitialRequest === null) {
+			throw new Error('The remote-mutation request timer was not held');
+		}
+
+		const release = releaseInitialRequest;
+		releaseInitialRequest = null;
+		release();
+		return result;
+	},
+});
+
+module.exports = { ...testingLibrary, fireEvent, render };

--- a/packages/swr/audit/upstream-timer-gate.cjs
+++ b/packages/swr/audit/upstream-timer-gate.cjs
@@ -1,0 +1,46 @@
+function holdFirstTimeout(delay, run) {
+	const originalSetTimeout = globalThis.setTimeout;
+	const originalClearTimeout = globalThis.clearTimeout;
+	let held = null;
+
+	globalThis.setTimeout = (callback, currentDelay, ...args) => {
+		if (currentDelay !== delay || held !== null) {
+			return originalSetTimeout(callback, currentDelay, ...args);
+		}
+
+		const token = {};
+		held = { token, callback: () => callback(...args) };
+		return token;
+	};
+	globalThis.clearTimeout = (token) => {
+		if (held?.token === token) {
+			held = null;
+			return;
+		}
+		return originalClearTimeout(token);
+	};
+
+	let result;
+	try {
+		result = run();
+	} finally {
+		globalThis.setTimeout = originalSetTimeout;
+		globalThis.clearTimeout = originalClearTimeout;
+	}
+
+	if (held === null) {
+		throw new Error(`Expected a ${delay} ms timeout to be scheduled`);
+	}
+
+	return {
+		result,
+		release() {
+			if (held === null) throw new Error('Held timeout has already been released');
+			const callback = held.callback;
+			held = null;
+			callback();
+		},
+	};
+}
+
+module.exports = { holdFirstTimeout };

--- a/scripts/react-parity/swr-manifest.mjs
+++ b/scripts/react-parity/swr-manifest.mjs
@@ -92,6 +92,8 @@ const manifest = {
 			environment: 'workspace-node',
 			project: 'swr-pristine',
 			evidenceOrigin: 'upstream-suite',
+			notes:
+				'Runs the byte-exact SWR 2.4.2 Jest suite. A testing-library harness holds the initial request completion in the remote-mutation race case until the mutation starts, preserving the upstream assertion without wall-clock ordering.',
 			execution: {
 				kind: 'jest-full',
 				config: 'packages/swr/audit/jest-pristine.config.mjs',
@@ -101,9 +103,12 @@ const manifest = {
 			files: [
 				file('packages/swr/audit/pristine-runtime.json'),
 				file('packages/swr/audit/jest-pristine.config.mjs'),
+				file('packages/swr/audit/upstream-testing-library.cjs'),
+				file('packages/swr/audit/upstream-timer-gate.cjs'),
 				file('packages/swr/upstream/SHA256SUMS'),
 				file('scripts/react-parity/jest-full-runner.mjs'),
 				file('scripts/react-parity/swr-runtime-inventory.mjs'),
+				file('scripts/react-parity/swr-upstream-timer-gate.test.mjs'),
 			],
 		},
 		typeLane({

--- a/scripts/react-parity/swr-upstream-timer-gate.test.mjs
+++ b/scripts/react-parity/swr-upstream-timer-gate.test.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+
+const require = createRequire(import.meta.url);
+const { holdFirstTimeout } = require('../../packages/swr/audit/upstream-timer-gate.cjs');
+
+test('holds a request completion until the competing mutation has started', () => {
+	const events = [];
+	const originalSetTimeout = globalThis.setTimeout;
+	const originalClearTimeout = globalThis.clearTimeout;
+
+	const held = holdFirstTimeout(10, () => {
+		setTimeout(() => events.push('request completed'), 10);
+		return 'rendered';
+	});
+
+	assert.equal(held.result, 'rendered');
+	assert.deepEqual(events, []);
+	events.push('mutation started');
+	held.release();
+	assert.deepEqual(events, ['mutation started', 'request completed']);
+	assert.throws(() => held.release(), /already been released/);
+	assert.equal(globalThis.setTimeout, originalSetTimeout);
+	assert.equal(globalThis.clearTimeout, originalClearTimeout);
+});


### PR DESCRIPTION
## Summary

- Make SWR's pinned remote-mutation race oracle deterministic without modifying the byte-exact vendored upstream suite.
- Hold the initial request completion until the mutation click has started, then release it so the unchanged stale-data assertion always observes a real overlap.
- Record and directly test the timer-gate contract in the React-parity evidence.

## Why

- [PR #746](https://github.com/octanejs/octane/pull/746) uncovered the flake in its [React parity shard job](https://github.com/octanejs/octane/actions/runs/31731929401/job/94554295371?pr=746).
- The upstream test starts a 10 ms request and assumes Testing Library can render, query, and click before that timer fires. On a loaded runner, the request can finish first and legitimately render `foo` before the mutation exists, so the test no longer exercises the race it claims to cover.

## Changes

- Map the pristine SWR Jest suite through a narrow Testing Library harness keyed to the exact upstream race case.
- Add a reusable timer gate that holds only the first 10 ms completion during render and releases it after the click starts the mutation.
- Add a Node contract test and hash the new support files into the SWR parity manifest.
- Document the harness while preserving all vendored upstream bytes and assertions.

## Validation

- [ ] `pnpm format:check` — not run; scoped formatting check passed for all seven changed files.
- [ ] `pnpm typecheck` — not run; no TypeScript or public API changed.
- [ ] `pnpm test` — not run; validation was kept SWR-scoped as requested.
- [x] targeted tests:
  - Formerly failing Jest case: 20/20 repeated passes.
  - Full SWR pristine Jest suite: 362 passed, 5 skipped, 6 snapshots passed.
  - `node --test scripts/react-parity/swr-upstream-timer-gate.test.mjs`: 1 passed.
  - `pnpm --filter @octanejs/swr upstream:verify`: passed (367 identities accounted for).
  - `pnpm vitest run --project swr --project swr-differential`: 11 files and 39 tests passed.
  - `node scripts/react-parity/check.mjs --validate-only`: passed.
- [x] `pnpm sync`

## Risk / follow-ups

- The harness is intentionally keyed to the pinned upstream test name and timing fixture. A future SWR pin should remove it if upstream replaces the wall-clock setup with explicit deferred promises.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to audit/test harness and parity metadata; vendored upstream bytes and SWR runtime are untouched.
> 
> **Overview**
> Fixes flaky CI on the pinned **byte-exact** SWR 2.4.2 pristine Jest suite by making one upstream remote-mutation race case deterministic **without** changing vendored tests or assertions.
> 
> The pristine Jest config now maps `@testing-library/react` to a narrow harness that only activates for `useSWR - remote mutation should prevent race conditions with useSWR`. On **render**, it uses `holdFirstTimeout` to defer the first **10 ms** `setTimeout` (the initial request completion); on **click**, it releases that timer so the mutation starts before the request finishes—preserving the overlap the upstream test assumes but that loaded runners can violate.
> 
> Adds `upstream-timer-gate.cjs`, a Node contract test, parity manifest hashes/notes, and **UPSTREAM.md** documentation for the harness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f444bd4e0f5b981af8163f78ea57964a239ff365. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->