### PR TITLE
test(dropzone): isolate hydration SSR setup

### DIFF
--- a/packages/dropzone/tests/probes/hydration.test.ts
+++ b/packages/dropzone/tests/probes/hydration.test.ts
@@ -1,15 +1,22 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { flushSync, hydrateRoot } from 'octane';
 import { renderDropzoneHydrationFixture } from './hydration-server';
 import { HookProbe } from './dropzone.tsrx';
 
+const onDrop = vi.fn();
+const props = { options: { onDrop }, rootRef: null, inputRef: null };
+let serverHtml: string;
+
+// Server-mode compilation starts a separate Vite module graph. Keep that
+// integration setup out of the five-second behavioral assertion budget.
+beforeAll(async () => {
+	serverHtml = (await renderDropzoneHydrationFixture(props)).html;
+}, 30_000);
+
 describe('react-dropzone U1 hydration gate', () => {
 	it('adopts root/input nodes and remains interactive without diagnostics', async () => {
-		const onDrop = vi.fn();
-		const props = { options: { onDrop }, rootRef: null, inputRef: null };
-		const { html } = await renderDropzoneHydrationFixture(props);
 		const container = document.createElement('div');
-		container.innerHTML = html;
+		container.innerHTML = serverHtml;
 		const rootNode = container.querySelector('[data-probe=root]');
 		const inputNode = container.querySelector('input')!;
 		inputNode.value = '';


### PR DESCRIPTION
## Summary

- prepare the Dropzone hydration fixture in `beforeAll`
- keep the hydration and interactivity assertion on Vitest's default five-second timeout
- give only the real Vite SSR preparation a 30-second CI-load budget

## Why

- the linked CI shard timed out while the test was performing real Vite SSR compilation and teardown inside the behavioral test budget
- Vite middleware mode has no listening socket to await; `createServer()` and `ssrLoadModule()` are already awaited by the fixture helper

## Changes

- move server HTML generation out of the test body and into a bounded setup hook
- retain the existing DOM adoption, focus, file selection, callback, and diagnostic assertions unchanged

## Validation

- [ ] `pnpm format:check` (not run; scoped formatting passed)
- [ ] `pnpm typecheck` (not run; scoped typecheck passed)
- [ ] `pnpm test` (not run; targeted Dropzone project passed)
- [x] targeted tests: Dropzone project, 98/98 tests
- [x] targeted tests: hydration probe through `vitest.ci-sharded.config.js`
- [x] `pnpm react-parity:validate`
- [x] `pnpm sync`

## Risk / follow-ups

- Low: test-only lifecycle change. The fixture helper still closes its Vite server in `finally` before the test begins.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only lifecycle change; production dropzone code and assertion behavior are unchanged.
> 
> **Overview**
> **Moves Vite SSR HTML generation out of the hydration test body** so CI no longer hits Vitest’s default five-second limit while compiling the server module graph.
> 
> Shared `onDrop`/`props` and a `serverHtml` cache are prepared once in `beforeAll` with a **30s** budget; the existing `it` still only checks DOM adoption, focus, file change → `onDrop`, and no `console.error`, unchanged on the default timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bffc49a13c9501c4e1ba771b127d1127921779a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->