### PR TITLE
fix: give method-style custom hooks their own component update boundary

### DIFF
--- a/.changeset/member-form-hook-component-boundary.md
+++ b/.changeset/member-form-hook-component-boundary.md
@@ -1,0 +1,38 @@
+---
+'octane': patch
+---
+
+Give a component that calls a method-style custom hook its own update boundary.
+
+A component that calls a hook owns that hook's state, so an update the hook
+schedules re-renders that component and nothing else. That held for
+`useThing()` but not for `obj.useThing()` — and the object-carried shape is how
+a large part of the React ecosystem exposes hooks: `route.useLoaderData()`,
+`api.useGetThingQuery()`, and every hook returned by a `createXContext()`
+factory.
+
+The `componentSlotLite` eligibility pre-pass decides whether a same-module
+component is hookless. Its body walk rejected a component on an unknown call
+only when the callee was an `Identifier`, and the free-identifier sweep ahead of
+it only ever sees bare names, so neither test could observe `api.useCounter()`:
+the receiver is `api`, and the callee is a `MemberExpression`. A component whose
+only hook was member-form was therefore classified hookless and mounted through
+`componentSlotLite`, a `LiteBlockImpl` with no block of its own. Its hook cells
+and their `forceUpdate` belonged to the parent, so updating that hook re-rendered
+the parent and every sibling under it, and the component could never bail out of
+a render it should have been isolated from.
+
+The slot-injection pass already handles these calls — it wraps them as
+`withSlot(sym, () => obj.useX(...args, sym))` precisely because they are hooks —
+so the two passes disagreed about the same syntax. The eligibility walk now
+applies the same `use[A-Z]` convention to the property name, and fails closed:
+matching only forfeits the lite path, never correctness.
+
+Components that genuinely have no hooks keep `componentSlotLite` exactly as
+before. The `benchmarks/codegen-size` corpus compiles byte-identically (raw
+152564, min 75164, gz 26774 before and after), and compile time over 200
+repetitions is unchanged within measurement noise (baseline 359.3-366.3 ms,
+candidate 362.2-372.0 ms across interleaved best-of-7 runs). Where the fix does
+apply, one `componentSlotLite` call becomes a `componentSlotVoid` call — on the
+regression fixture, +28 bytes of emitted output for the component that gains a
+real block.

--- a/packages/octane/src/compiler/compile.js
+++ b/packages/octane/src/compiler/compile.js
@@ -8640,6 +8640,29 @@ function compileInternal(source, filename, options, analyzedAst, mode, bundlerMe
 						return true;
 					}
 				}
+				// METHOD-style custom hooks — `route.useLoaderData()`, `api.useSearch()`,
+				// `SomeContext.useSelector(fn)`. The free-identifier sweep above only sees
+				// bare names, and the unknown-call rule above only inspects Identifier
+				// callees, so without this a component whose ONLY hook is member-form
+				// looks hookless: it takes the lite path, gets no block of its own, and
+				// its hook state lands on the parent — an update from that hook then
+				// re-renders the parent and every sibling.
+				//
+				// Same `use[A-Z]` convention, applied to the PROPERTY name, that the
+				// slot-injection pass already uses for these calls. `useContext` is
+				// included rather than excluded: it is not lite-safe either (the sweep
+				// above rejects the bare name for the same reason).
+				if (
+					t === 'CallExpression' &&
+					n.callee &&
+					n.callee.type === 'MemberExpression' &&
+					!n.callee.computed &&
+					n.callee.property &&
+					n.callee.property.type === 'Identifier' &&
+					/^use[A-Z]/.test(n.callee.property.name)
+				) {
+					return true;
+				}
 				for (const k in n) {
 					if (AST_WALK_SKIP_KEYS.has(k)) continue;
 					if (walk(n[k])) return true;

--- a/packages/octane/tests/_fixtures/member-hook-boundary.tsrx
+++ b/packages/octane/tests/_fixtures/member-hook-boundary.tsrx
@@ -1,0 +1,77 @@
+// A single custom hook reached two ways — as a bare identifier and as an object
+// property — so the component-boundary contract can be compared across the two
+// call shapes with nothing else varying.
+import { useEffect, useState } from 'octane';
+
+export const log: string[] = [];
+
+const bumpers: Array<() => void> = [];
+
+export function bumpFirst(): void {
+	bumpers[0]?.();
+}
+
+export function resetFixture(): void {
+	bumpers.length = 0;
+	log.length = 0;
+}
+
+export function useCounter(): number {
+	const [n, setN] = useState(0);
+
+	useEffect(() => {
+		const bump = () => setN((value) => value + 1);
+		bumpers.push(bump);
+		return () => {
+			const index = bumpers.indexOf(bump);
+			if (index >= 0) bumpers.splice(index, 1);
+		};
+	}, []);
+
+	return n;
+}
+
+// The same hook, carried on an object — the shape React-ecosystem libraries use
+// for `route.useLoaderData()`, `api.useGetThingQuery()`, and the hooks returned
+// by a `createXContext()` factory.
+export const api = { useCounter };
+
+export function MemberHookChild() @{
+	const n = api.useCounter();
+
+	log.push('MemberHookChild:' + n);
+
+	<span id="member">{n as string}</span>
+}
+
+export function IdentifierHookChild() @{
+	const n = useCounter();
+
+	log.push('IdentifierHookChild:' + n);
+
+	<span id="identifier">{n as string}</span>
+}
+
+export function HooklessSibling() @{
+	log.push('HooklessSibling');
+
+	<span id="sibling">sibling</span>
+}
+
+export function MemberParent() @{
+	log.push('MemberParent');
+
+	<div>
+		<MemberHookChild />
+		<HooklessSibling />
+	</div>
+}
+
+export function IdentifierParent() @{
+	log.push('IdentifierParent');
+
+	<div>
+		<IdentifierHookChild />
+		<HooklessSibling />
+	</div>
+}

--- a/packages/octane/tests/member-hook-boundary.test.ts
+++ b/packages/octane/tests/member-hook-boundary.test.ts
@@ -1,0 +1,56 @@
+/**
+ * A component that calls a hook owns that hook's state, so an update the hook
+ * schedules re-renders that component — not its parent and not its siblings.
+ *
+ * The contract must not depend on how the hook is spelled at the call site. A
+ * custom hook carried on an object (`route.useLoaderData()`,
+ * `api.useGetThingQuery()`, `SomeContext.useSelector(fn)`) is the shape a large
+ * part of the React ecosystem exposes, and it has to behave exactly like the
+ * same hook called as a bare identifier.
+ */
+import { describe, expect, it } from 'vitest';
+import { act, mount, nextPaint } from './_helpers';
+import {
+	IdentifierParent,
+	MemberParent,
+	bumpFirst,
+	log,
+	resetFixture,
+} from './_fixtures/member-hook-boundary.tsrx';
+
+async function renderThenBump(parent: typeof MemberParent) {
+	resetFixture();
+	const result = mount(parent);
+	await nextPaint();
+	log.length = 0;
+	act(() => {
+		bumpFirst();
+	});
+	await nextPaint();
+	return result;
+}
+
+describe('component update boundary for custom hooks', () => {
+	it('re-renders only the component whose identifier-form hook updated', async () => {
+		const result = await renderThenBump(IdentifierParent);
+
+		expect(log).toEqual(['IdentifierHookChild:1']);
+		expect(result.find('#identifier').textContent).toBe('1');
+
+		result.unmount();
+	});
+
+	it('re-renders only the component whose member-form hook updated', async () => {
+		const result = await renderThenBump(MemberParent);
+
+		// Before the lite-eligibility fix this produced
+		// ['MemberParent', 'MemberHookChild:1', 'HooklessSibling'] — the child was
+		// classified hookless, mounted through the lite path with no block of its
+		// own, so its hook state landed on the parent and updating it re-rendered
+		// the whole subtree.
+		expect(log).toEqual(['MemberHookChild:1']);
+		expect(result.find('#member').textContent).toBe('1');
+
+		result.unmount();
+	});
+});


### PR DESCRIPTION
## Summary

- A component whose only hook is method-style (`obj.useThing()`) was classified hookless by the `componentSlotLite` eligibility pre-pass, so it was mounted with no block of its own. Its hook state and `forceUpdate` belonged to the parent, and updating that hook re-rendered the parent and every sibling.
- The eligibility body walk now applies the same `use[A-Z]` convention to a member callee's property name that the slot-injection pass already applies to these calls.

## Why

The object-carried hook is how a large part of the React ecosystem exposes hooks: `route.useLoaderData()`, `api.useGetThingQuery()`, and every hook returned by a `createXContext()` factory. In this repo alone there are 78 such call sites across `.tsrx`/`.tsx` sources, including RTK Query's canonical `api.useGetValueQuery(...)` in `@octanejs/redux-toolkit` and `store.useQuery(...)` / `store.useClientDocument(...)` in `@octanejs/livestore`.

The two compiler passes disagreed about the same syntax. `compile.js` already carries a dedicated method-style branch in slot injection, whose own comment names the motivating cases — *"METHOD-style custom hooks — `route.useLoaderData()`, `api.useSearch()`"* — and wraps them as `withSlot(sym, () => obj.useX(...args, sym))` precisely because they are hooks. The eligibility pre-pass never learned the same thing: its unknown-call rule inspects only `Identifier` callees, and the free-identifier sweep ahead of it only sees bare names, so neither test can observe `api.useCounter()` — the receiver is `api` and the callee is a `MemberExpression`.

This was found while porting `@xstate/react` to Octane. `createActorContext()` returns `useSelector`/`useActorRef` that consumers call in exactly this shape (it is the form used throughout upstream's README and all 13 of its `createActorContext` tests), and per-component selector bail-out — the reason the API exists — did not work.

## Changes

- `packages/octane/src/compiler/compile.js`: reject lite eligibility for a call whose callee is a non-computed `MemberExpression` with a `use[A-Z]` property name. Fails closed — matching only forfeits the lite path, never correctness.
- `packages/octane/tests/member-hook-boundary.test.ts` and `packages/octane/tests/_fixtures/member-hook-boundary.tsrx`: one custom hook reached both ways, with a hookless sibling, asserting that an update from either call shape re-renders only the component that owns the hook.
- Changeset.

## Validation

- [x] targeted: `packages/octane/tests/member-hook-boundary.test.ts` — fails before the fix with `['MemberParent', 'MemberHookChild:1', 'HooklessSibling']` against the expected `['MemberHookChild:1']`, passes after. The identifier-form control passes in both states, so the test isolates the defect. Breaking the predicate deliberately turns it red again and restoring it turns it green.
- [x] `vitest --project octane --project octane-prod`
- [x] `vitest --project redux-toolkit` (11), `--project livestore` (30), `--project tanstack-store` (46), `--project zustand` (17) — the projects whose fixtures use member-form hooks
- [x] `pnpm format:files:check` on the changed paths
- [ ] `pnpm test` (full) — not run; the affected projects above were run individually
- [ ] `pnpm typecheck` — not run; the change is inside a `.js` compiler module with no type surface

Performance, per `.rulesync/rules/core-engineering.md`:

- `benchmarks/codegen-size` compiles **byte-identically** before and after (raw 152564, min 75164, gz(min) 26774), so components that genuinely have no hooks keep `componentSlotLite` exactly as before.
- Compile time is unchanged within measurement noise: interleaved best-of-7 over 200 compiles gave baseline 359.3 / 362.9 / 366.3 ms and candidate 362.2 / 365.7 / 372.0 ms. The ranges overlap; no claim is made in either direction.
- Where the fix does apply, one `componentSlotLite` call becomes `componentSlotVoid` — +28 bytes of emitted output on the regression fixture for the component that gains a real block. That block is the correctness requirement, not an avoidable cost.

## Risk / follow-ups

- The predicate matches any non-computed member call with a `use[A-Z]` property, so a non-hook method that happens to be named that way (`vi.useFakeTimers()`) now also forfeits lite eligibility for its enclosing component. That is the same `use*`-is-reserved convention the slot-injection pass already relies on, and the cost is one lost optimization rather than a behavior change.
- Computed access (`obj['useThing']()`) is still not detected. The slot-injection pass does not handle it either, so the two passes stay consistent; a component reaching a hook that way was already unsupported.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Compiler emission path change for components using member-form hooks; behavior fix aligns with existing slot-injection semantics and is covered by a targeted regression test.
> 
> **Overview**
> **Fixes incorrect `componentSlotLite` classification** when a component's only hook is called as a member (`api.useCounter()`, `route.useLoaderData()`, etc.). Those components were treated as hookless and mounted without their own block, so hook updates re-rendered the parent and siblings.
> 
> The **`componentSlotLite` eligibility body walk** in `compile.js` now rejects lite mounting for non-computed member calls whose property matches the same **`use[A-Z]`** rule the slot-injection pass already uses. Hookless components are unchanged; affected sites emit **`componentSlotVoid`** instead (small codegen increase where isolation is required).
> 
> Adds a **regression fixture and Vitest** comparing identifier vs member hook call shapes with a hookless sibling, plus a **changeset**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff6119fca4b2caeeb76e5186c3194f86957a0f66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->