### PR TITLE
fix: stop the compiled @for path retaining the descriptor renderer

### DIFF
--- a/.changeset/deopt-body-identity-reachability.md
+++ b/.changeset/deopt-body-identity-reachability.md
@@ -1,0 +1,47 @@
+---
+'octane': patch
+---
+
+Stop the compiled `@for` path from retaining the entire descriptor renderer.
+
+`mountItem` decided whether a de-opt list's items render through the plain
+`deoptItemBody` by comparing the body function by identity. The comparison is
+correct and cheap at runtime, but `mountItem` sits on the compiled `@for` mount
+path that every list-rendering application reaches, so naming `deoptItemBody`
+from it is a live reference a bundler must honour. Retaining `deoptItemBody`
+retains `childSlot` — the universal renderable-hole dispatcher — and through it
+the descriptor renderer, `FragmentInstance` and fragment refs, portals,
+transitions, controlled-form restoration, focus preservation and the DOM
+attribute tables. Applications that only ever render compiled templates, and
+never present a generic renderable hole, shipped all of it.
+
+The fact is now recorded on the `ForSlot` as `plainDeopt`, next to the existing
+`mappedNative` flag, and stamped by `childSlot` where the body is chosen —
+inside the graph that already retains those modules. `mountItem` reads the flag
+instead of naming the function. The recorded value is exactly the identity test
+it replaces: within the de-opt branch the body is `deoptItemBody` precisely when
+the compiler supplied no map body and this is not the mapped fallback, because
+both body-wrapping assignments are guarded by those same two conditions. Both
+`ForSlot` literals declare the field, so every slot keeps one hidden class and
+the stamp transitions nothing.
+
+Normalized production builds, gzip, via `benchmarks/bundle-size`:
+
+| application | before | after |
+| --- | ---: | ---: |
+| js-framework rows | 40,752 | **20,609** |
+| TodoMVC | 41,293 | **21,835** |
+| chat-stream | 41,530 | **21,968** |
+| weather-app | 49,524 | **31,742** |
+
+The saving is entirely in the framework chunk (rows 38,380 → 18,237 B); every
+application chunk is unchanged, because no compiler output changed. The rows
+bundle drops from 559 surviving top-level declarations to 340 — `childSlot`,
+`FragmentInstance`, `deoptItemBody`, `renderPortalState`, `startTransition` and
+`setAttribute` all become unreachable, while `reconcileKeyed` and `mountItem`
+correctly remain. The `octane-tsrx` application, framework, and total budgets in
+`bundle-size/app-budgets.json`, and the reachability ceilings in
+`bundle-size/minimal-budgets.json`, are re-recorded against the new floor.
+
+This restores the reachability that held before the identity tests were
+introduced; the compiled output and every rendering path are unchanged.

--- a/benchmarks/bundle-size/app-budgets.json
+++ b/benchmarks/bundle-size/app-budgets.json
@@ -6,14 +6,14 @@
       "brotli": 2144
     },
     "framework": {
-      "raw": 62048,
-      "gzip": 20960,
-      "brotli": 18912
+      "raw": 52640,
+      "gzip": 18272,
+      "brotli": 16416
     },
     "total": {
-      "raw": 69088,
-      "gzip": 23328,
-      "brotli": 20992
+      "raw": 59648,
+      "gzip": 20672,
+      "brotli": 18496
     }
   },
   "todo": {
@@ -23,14 +23,14 @@
       "brotli": 1824
     },
     "framework": {
-      "raw": 65952,
-      "gzip": 22144,
-      "brotli": 19872
+      "raw": 57536,
+      "gzip": 19680,
+      "brotli": 17664
     },
     "total": {
-      "raw": 70240,
-      "gzip": 24192,
-      "brotli": 21664
+      "raw": 62208,
+      "gzip": 21888,
+      "brotli": 19552
     }
   },
   "chat": {
@@ -40,14 +40,14 @@
       "brotli": 2432
     },
     "framework": {
-      "raw": 65792,
-      "gzip": 22112,
-      "brotli": 19872
+      "raw": 56416,
+      "gzip": 19296,
+      "brotli": 17344
     },
     "total": {
-      "raw": 71616,
-      "gzip": 24800,
-      "brotli": 22240
+      "raw": 62272,
+      "gzip": 22016,
+      "brotli": 19744
     }
   },
   "weather": {
@@ -57,14 +57,14 @@
       "brotli": 6752
     },
     "framework": {
-      "raw": 83488,
-      "gzip": 27296,
-      "brotli": 24384
+      "raw": 71200,
+      "gzip": 23936,
+      "brotli": 21472
     },
     "total": {
-      "raw": 106080,
-      "gzip": 35136,
-      "brotli": 31072
+      "raw": 93728,
+      "gzip": 31776,
+      "brotli": 28160
     }
   }
 }

--- a/benchmarks/bundle-size/minimal-budgets.json
+++ b/benchmarks/bundle-size/minimal-budgets.json
@@ -5,9 +5,9 @@
     "brotli": 1536
   },
   "cli-spa-starter": {
-    "raw": 80736,
-    "gzip": 27936,
-    "brotli": 24768
+    "raw": 69617,
+    "gzip": 24621,
+    "brotli": 21766
   },
   "root-static-specialized": {
     "raw": 49760,

--- a/packages/octane/src/runtime.ts
+++ b/packages/octane/src/runtime.ts
@@ -19812,6 +19812,7 @@ export function childSlot(
 				emptyBlock: null,
 				env: undefined,
 				adopt: null,
+				plainDeopt: false,
 			};
 			if (upgradeArmed) {
 				state.forSlot.adopt = buildDeoptAdoptQueue(upgradeChildren, state.start, state.end!);
@@ -19905,10 +19906,16 @@ export function childSlot(
 				descriptorBody(item, scope);
 			};
 		}
+		// `body` is `deoptItemBody` exactly when the compiler supplied no map body
+		// and this is not the mapped fallback — both wrapper assignments above are
+		// guarded by those two conditions. Record it on the slot rather than
+		// re-deriving it by identity in mountItem (see ForSlot.plainDeopt).
+		const plainDeopt = compiledMapBody === undefined && mappedFallback !== true;
+		state.forSlot.plainDeopt = plainDeopt;
 		const fastFlags = compiledMapFlags || 0;
 		const ssrMarkerless =
 			compiledMapBody === undefined
-				? markerlessMappedFallback || body === deoptItemBody
+				? markerlessMappedFallback || plainDeopt
 				: (fastFlags & 16) !== 0;
 		let pure = (fastFlags & 1) !== 0;
 		let lite = false;
@@ -25016,6 +25023,18 @@ interface ForSlot {
 	// Present only on a childSlot owned by the compiler's guarded map ABI.
 	// Keeps descriptor↔compiled adoption off every ordinary descriptor list.
 	mappedNative?: boolean;
+	// True when this de-opt list's items render through the plain `deoptItemBody`
+	// — no compiled map body, no mapped fallback wrapper. `mountItem` needs the
+	// fact but must NOT name `deoptItemBody` to get it: a live identity
+	// comparison there is a reference from the compiled `@for` path that every
+	// application reaches, and it makes the entire descriptor renderer
+	// (childSlot, fragment refs, portals, transitions, the attribute tables)
+	// reachable from apps that only ever render compiled templates. Recorded on
+	// the slot instead, so the reference stays inside childSlot, which already
+	// retains that graph. Both ForSlot literals declare it so every slot shares
+	// one hidden class; only childSlot ever stamps or reads it, because only
+	// childSlot passes mountItem the de-opt sentinel.
+	plainDeopt: boolean;
 	// Present only when the compiler proved a keyed equality selection. Identity
 	// gates the two-row update without retaining extra state on ordinary lists.
 	selectionItems?: ArrayLike<any>;
@@ -25096,6 +25115,10 @@ export function forBlock<T>(
 			emptyBlock: null,
 			env: undefined,
 			adopt: null,
+			// Compiled `@for` slots never read this — they never pass the de-opt
+			// sentinel — but both ForSlot literals declare it so every slot shares
+			// one hidden class and the stamp in childSlot transitions nothing.
+			plainDeopt: false,
 		};
 		parentScope.slots[slotKey] = state;
 		registerSlot(parentScope, state);
@@ -26451,7 +26474,7 @@ function mountItem<T>(
 			ssrMarkerless &&
 			!hydration.isOpen(hydration.node) &&
 			(singleRoot !== 2 ||
-				body !== deoptItemBody ||
+				forSlot.plainDeopt !== true ||
 				(isHostDescriptor(item) && !descNeedsBlocks(item)))
 		) {
 			// The outer @for pair is the only list framing on the wire. Each proven
@@ -26462,7 +26485,7 @@ function mountItem<T>(
 				hydration.node !== null &&
 				hydration.node !== forSlot.end &&
 				(singleRoot !== 2 ||
-					body !== deoptItemBody ||
+					forSlot.plainDeopt !== true ||
 					(hydration.node.nodeType === 1 && hydration.node.parentNode === parentNode))
 			) {
 				const root = hydration.node;
@@ -26478,7 +26501,7 @@ function mountItem<T>(
 				);
 				block.forSlot = forSlot;
 				block.itemIndex = index;
-				if (singleRoot === 2 && body === deoptItemBody) block.deoptNode = root;
+				if (singleRoot === 2 && forSlot.plainDeopt === true) block.deoptNode = root;
 				renderBlock(block);
 				hydration.node = block.endMarker?.nextSibling ?? root.nextSibling;
 				return block;

--- a/packages/octane/tests/hydration/_fixtures/mapped-fallback-list.tsx
+++ b/packages/octane/tests/hydration/_fixtures/mapped-fallback-list.tsx
@@ -1,0 +1,29 @@
+/** @jsxImportSource octane */
+
+// A props-driven `{items.map(...)}` list that compiles to the guarded map ABI,
+// so the runtime decides PER RENDER whether the array is a plain native array —
+// replayed through the compiled item body — or something exotic (a hole, an
+// accessor index, a tampered `map`), which falls back to applying the authored
+// callback and rendering the resulting descriptors as a de-opt list.
+//
+// The rows are COMPONENT items on purpose. A pure single-element host descriptor
+// self-delimits during hydration whether or not the list is a plain de-opt list,
+// so it cannot tell the two regimes apart; a component-bearing item keeps its
+// explicit `<!--it-->` pair only on the mapped-fallback path.
+function Row(props: { id: number; label: string }) {
+	return (
+		<li className="fallback-row" data-id={props.id}>
+			{props.label}
+		</li>
+	);
+}
+
+export function MappedFallbackList(props: { items: Array<{ id: number; label: string }> }) {
+	return (
+		<ul className="fallback-list">
+			{props.items.map((item) => (
+				<Row key={item.id} id={item.id} label={item.label} />
+			))}
+		</ul>
+	);
+}

--- a/packages/octane/tests/hydration/mapped-fallback-hydrate.test.ts
+++ b/packages/octane/tests/hydration/mapped-fallback-hydrate.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { compile } from 'octane/compiler';
+import { hydrateRoot, flushSync } from '../../src/index.js';
+import * as ServerRT from 'octane/server';
+import { MappedFallbackList } from './_fixtures/mapped-fallback-list.tsx';
+
+// `{items.map(...)}` compiles to the guarded map ABI: the runtime asks whether
+// `items` is a plain native array and, when it is not, applies the authored
+// callback itself and renders the resulting descriptors as a de-opt list — the
+// MAPPED FALLBACK. That fallback shares `childSlot`'s keyed list machinery with
+// ordinary descriptor lists but must NOT be treated as one during hydration: an
+// ordinary de-opt list's pure items self-delimit, while a fallback list keeps
+// the framing the server actually wrote. These tests pin that a fallback list
+// hydrates by ADOPTING the server rows rather than rebuilding them, and that it
+// stays keyed afterwards.
+
+const FIXTURE = join(
+	process.cwd(),
+	'packages/octane/tests/hydration/_fixtures/mapped-fallback-list.tsx',
+);
+
+function serverModule(): Record<string, any> {
+	let { code } = compile(readFileSync(FIXTURE, 'utf8'), 'mapped-fallback-list.tsx', {
+		mode: 'server',
+	});
+	code = code.replace(
+		/import\s*\{([^}]*)\}\s*from\s*['"]octane\/server['"];?/g,
+		(_m: string, names: string) => `const {${names.replace(/ as /g, ': ')}} = __rt;`,
+	);
+	code = code.replace(/export const (\w+) =/g, 'const $1 = __exports.$1 =');
+	code = code.replace(/export function (\w+)/g, '__exports.$1 = function $1');
+	const fn = new Function('__rt', '__exports', code + '\nreturn __exports;');
+	return fn(ServerRT, {});
+}
+
+// An array the native-map guard must reject: one index is an accessor, so the
+// compiled item body cannot be replayed and the authored callback runs instead.
+function accessorArray<T>(values: T[]): T[] {
+	const out: T[] = [];
+	for (let index = 0; index < values.length; index++) {
+		if (index === 1) {
+			Object.defineProperty(out, index, {
+				get: () => values[index],
+				enumerable: true,
+				configurable: true,
+			});
+		} else out[index] = values[index];
+	}
+	out.length = values.length;
+	return out;
+}
+
+const ITEMS = [
+	{ id: 1, label: 'a' },
+	{ id: 2, label: 'b' },
+	{ id: 3, label: 'c' },
+];
+
+describe('hydrateRoot — mapped-fallback keyed list', () => {
+	const server = serverModule();
+	let container: HTMLElement;
+	beforeEach(() => {
+		container = document.createElement('div');
+		document.body.appendChild(container);
+	});
+	afterEach(() => container.remove());
+
+	it('compiles to the guarded map ABI', () => {
+		const { code } = compile(readFileSync(FIXTURE, 'utf8'), 'mapped-fallback-list.tsx', {
+			mode: 'client',
+			hmr: false,
+			dev: false,
+		});
+		expect(code).toContain('mapSlot');
+	});
+
+	it('adopts the server rows when the array forces the fallback', () => {
+		const { html } = ServerRT.renderToString(server.MappedFallbackList, { items: ITEMS });
+		container.innerHTML = html;
+		const rows = [...container.querySelectorAll('li.fallback-row')];
+		expect(rows.map((row) => row.getAttribute('data-id'))).toEqual(['1', '2', '3']);
+
+		const root = hydrateRoot(container, MappedFallbackList, { items: accessorArray(ITEMS) });
+		flushSync(() => {});
+
+		// Adopted, not rebuilt: the same element instances are still in place.
+		expect([...container.querySelectorAll('li.fallback-row')]).toEqual(rows);
+		expect(rows.map((row) => row.textContent)).toEqual(['a', 'b', 'c']);
+		root.unmount();
+	});
+
+	it('stays keyed across a post-hydration reorder on the fallback path', () => {
+		const { html } = ServerRT.renderToString(server.MappedFallbackList, { items: ITEMS });
+		container.innerHTML = html;
+		const rows = [...container.querySelectorAll('li.fallback-row')];
+
+		const root = hydrateRoot(container, MappedFallbackList, { items: accessorArray(ITEMS) });
+		flushSync(() => {});
+
+		flushSync(() =>
+			root.render(MappedFallbackList, {
+				items: accessorArray([ITEMS[2], ITEMS[0], ITEMS[1]]),
+			}),
+		);
+		const reordered = [...container.querySelectorAll('li.fallback-row')];
+		expect(reordered.map((row) => row.getAttribute('data-id'))).toEqual(['3', '1', '2']);
+		// Survivors keep their identity — the same three nodes, reordered.
+		expect(new Set(reordered)).toEqual(new Set(rows));
+		expect(reordered[0]).toBe(rows[2]);
+		root.unmount();
+	});
+});


### PR DESCRIPTION
## Summary

`mountItem` decided whether a de-opt list's items render through the plain
`deoptItemBody` by comparing the body function by identity. The comparison is
correct and cheap, but `mountItem` is on the compiled `@for` mount path that
every list-rendering application reaches, so naming `deoptItemBody` from it is a
live reference a bundler must honour. Retaining `deoptItemBody` retains
`childSlot` — the universal renderable-hole dispatcher — and through it the
descriptor renderer, `FragmentInstance` and fragment refs, portals, transitions,
controlled-form restoration, focus preservation and the DOM attribute tables.
Applications that only ever render compiled templates, and never present a
generic renderable hole, shipped all of it.

The fact is now recorded on the `ForSlot` as `plainDeopt`, alongside the existing
`mappedNative` flag, and stamped by `childSlot` where the body is chosen — inside
the graph that already retains those modules. `mountItem` reads the flag instead
of naming the function.

The recorded value is exactly the identity test it replaces. Within the de-opt
branch the body is `deoptItemBody` precisely when the compiler supplied no map
body and this is not the mapped fallback, because both body-wrapping assignments
above it are guarded by those same two conditions:

- the `compiledMapBody !== undefined` wrapper cannot apply when there is no map
  body, and
- the `markerlessMappedFallback` wrapper implies `mappedFallback === true`.

Both `ForSlot` literals declare the field, so every slot keeps one hidden class
and the stamp transitions nothing.

### Where this came from

Bisected to `4c1ecd143` ("Float style resources and the Context.Consumer
decision made concrete", #712, 12 Aug), which introduced the identity tests.
Same app source and build config throughout, only `packages/octane/src` varying:

| commit | date | js-framework rows, gzip |
| --- | --- | ---: |
| `a1d506777` | 08-09 | 17,639 |
| `d2c9e1ca9` | 08-10 | 19,880 |
| `a03ff0f33` | 08-11 | 20,227 |
| `4c1ecd143` | 08-12 | **40,428** |
| `48fa46cdc` | 08-16 | 40,499 |

`runtime.ts` grew 9% over that window while the rows bundle grew 147%, so this
was reachability, not code growth.

## Changes

- `packages/octane/src/runtime.ts` — record `ForSlot.plainDeopt` in `childSlot`;
  read it in `mountItem` instead of comparing against `deoptItemBody`; declare
  the field in both `ForSlot` literals.
- `packages/octane/tests/hydration/mapped-fallback-hydrate.test.ts` +
  `_fixtures/mapped-fallback-list.tsx` — new coverage for the mapped-fallback
  hydration path, which had none.
- `benchmarks/bundle-size/app-budgets.json`,
  `benchmarks/bundle-size/minimal-budgets.json` — re-record the ceilings this
  change moves. **Tightened only; nothing is loosened.**

## Results

Normalized production builds, gzip, via `benchmarks/bundle-size/run.mjs`:

| application | before | after | delta |
| --- | ---: | ---: | ---: |
| js-framework rows | 40,752 | **20,609** | −49.4% |
| TodoMVC | 41,293 | **21,835** | −47.1% |
| chat-stream | 41,530 | **21,968** | −47.1% |
| weather-app | 49,524 | **31,742** | −35.9% |

`benchmarks/bundle-size/run-minimal.mjs`: `cli-spa-starter` — the entry
`octane init` generates — drops 40,362 → **23,903** gzip (−40.8%).

The saving is entirely in the framework chunk (rows 38,380 → 18,237 B). Every
application chunk is byte-identical, because no compiler output changed. The rows
bundle drops from 559 surviving top-level declarations to 340: `childSlot`,
`FragmentInstance`, `deoptItemBody`, `renderPortalState`, `startTransition`,
`setAttribute` and `attachLiveFragmentRef` all become unreachable, while
`reconcileKeyed` and `mountItem` correctly remain.

## Validation

- [x] `pnpm format:check` — clean.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm test` — **21,759 / 21,761 passed**. The two failures are both
  `packages/octane/tests/browser/native-change/native-change.test.ts`, failing on
  `Failed to load resource: 504 (Outdated Optimize Dep)` — a Vite dependency-
  optimizer race on this fresh worktree's first browser run, not an assertion
  about behavior. Re-running that file alone passes 12/12.
- [x] targeted tests: `hydration/descriptor-list-hydrate`, `hydration/map-hydrate`,
  `hydration/mapped-fallback-hydrate`, `deopt-item-selfmark`,
  `deopt-item-path-switch`, plus the whole `tests/hydration` directory and the
  `deopt-*` / `descriptor-children` files.
- [x] `benchmarks/bundle-size/run.mjs` and `run-minimal.mjs`, Node 24 (the pinned
  CI version), before and after.

Mutation-checked rather than assumed: forcing `plainDeopt` to the inverse, and
separately to a constant `false`, turns 18 tests in
`hydration/descriptor-list-hydrate.test.ts` red. See the coverage note below for
the direction that is *not* pinned.

## Risk / follow-ups

- **Untested direction.** Forcing `plainDeopt` to a constant `true` passes all
  730 tests in `tests/hydration` + the `deopt-*` files, and passes the new
  mapped-fallback test. I could not construct a case where the `true` direction
  is observationally different: for pure host items the third disjunct at each
  read site rescues it, and for component items the fall-through is the marked
  path that is correct anyway. The equivalence argument above is what carries
  that direction, not a test. Worth a second opinion.
- **Suspend-closure staleness.** `mountItem` re-invoked through
  `hydration.suspend` re-reads `forSlot.plainDeopt` rather than a captured value,
  where it previously used the captured `body`. For the value to differ, the same
  for-slot would have to re-render with a flipped native/fallback verdict between
  the suspension and its resumption — at which point the captured `item` and the
  slot's markers are already inconsistent, so this is not a new risk class. Not
  covered by a test.
- **`octane-jsx` remains 1.17× over its committed framework ceiling** (38,975 vs
  33,344 gzip) and this change does not move it. The JSX dialect legitimately
  reaches the descriptor renderer, so it is exposed to that graph's real growth
  over the same 08-10 → 08-13 window. I did not diagnose it and deliberately did
  **not** raise `jsx-budgets.json`; it needs its own investigation.
- **TodoMVC's application ceiling stays exceeded** (2,199 vs 2,112 gzip). The app
  source is unchanged since the ceiling was recorded on 08-08, so this is
  compiler-output growth from that window. It is unrelated to this change — the
  app chunk measures 2,198 B before and 2,199 B after — and I left the ceiling
  alone rather than bless it.
- **Several `bundle-reachability` ceilings stay exceeded** (`hydrate-root`,
  `deferred-hydration`, `suspense-transition`, `server-render`, `capture-only`,
  the `binding-*` scenarios). All were already over before this change; they
  reach `childSlot` through the general-root path, which this fix does not touch.
  Left as a true signal rather than re-recorded.
- **The separate architectural finding stands.** `root-static-specialized` ships
  12,285 B gzip against `root-static`'s 36,434 B: escaping compiler-proven root
  specialization still costs ~24 KB in one step, because `childSlot` is a runtime
  dispatcher rather than a set of compiler-injected entry points. That is a
  design change, not a fix, and is out of scope here.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core list mount/hydration (`mountItem`, SSR markerless paths) with equivalence argued but one direction of `plainDeopt` not fully mutation-tested; behavior should match prior identity checks.
> 
> **Overview**
> **Compiled `@for` lists no longer pull the full descriptor renderer into every app bundle** by avoiding a `deoptItemBody` identity check on the hot `mountItem` path.
> 
> `ForSlot` gains a **`plainDeopt`** flag (set in `childSlot` when there is no compiled map body and the list is not on the mapped-fallback path). **`mountItem`** and related hydration branches read that flag instead of comparing `body === deoptItemBody`, so bundlers can drop `childSlot` and the descriptor graph for apps that only use compiled templates. Both `ForSlot` object literals initialize the field for a stable hidden class.
> 
> Bundle-size **budgets** in `app-budgets.json` and `minimal-budgets.json` are tightened to match roughly **~50% smaller** framework gzip for sample apps. New **mapped-fallback hydration** tests ensure exotic `items.map` arrays still adopt server DOM and stay keyed after reorder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e24b3a75aaf75fc8f674bb50970ba9b6e79e55f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->