### PR TITLE
fix: close Strong-mode callable analysis gaps

### DIFF
--- a/.changeset/strong-callable-analysis.md
+++ b/.changeset/strong-callable-analysis.md
@@ -1,0 +1,5 @@
+---
+"octane": patch
+---
+
+Extend Strong-mode analysis through statically known `useCallback`, `useEffectEvent`, and memo-returned functions. Reject Effect Event calls during render and Effect Events in explicit hook dependency lists, while preserving supported hook usage and compatibility-mode behavior.

--- a/docs/differences-from-react.md
+++ b/docs/differences-from-react.md
@@ -331,11 +331,18 @@ Alternatively, enable it across application-owned modules with
 `compiler: { strong: true }` in `octane.config.ts`. Installed dependencies stay
 in compatibility mode unless their own source opts in.
 
-A Strong module cannot call a state updater during render or directly while
-setting up an effect, and it cannot assign to `ref.current` during render.
-Event handlers, effects that synchronize an external system, and normal DOM or
-timer refs remain supported. Replace prop-driven state resets with
-`useLinkedState` instead of calling a setter during render.
+A Strong module cannot call a state updater during render or synchronously while
+setting up an effect, and it cannot assign to `ref.current` during render. The
+checks follow provable synchronous calls through `useCallback`, `useEffectEvent`,
+and functions returned by analyzable `useMemo` factories. Calling a statically
+known Effect Event during render or including it in an explicit hook dependency
+list is also a compile error. The hooks themselves remain supported, and other
+explicit dependency lists retain their existing meaning.
+
+Event handlers, genuinely deferred callbacks, effect cleanup, effects that
+synchronize an external system, and normal DOM or timer refs remain supported.
+Replace prop-driven state resets with `useLinkedState` instead of calling a
+setter during render.
 
 ## JSX values follow the represented render scope
 

--- a/docs/strict-state-plan.md
+++ b/docs/strict-state-plan.md
@@ -49,12 +49,19 @@ and separate workspace packages retain React-compatible behavior unless their ow
 module opts in. No package compatibility declaration or exception list is needed.
 Vite, Rspack, and Rsbuild also accept `strong: true` in their plugin options.
 
-Opted-in modules reject statically provable updater calls during render or direct
-effect setup, along with render-time `ref.current` writes. Synchronously evaluated
-state initializers, linked-state reconcilers, and linked-state equality callbacks
-are render contexts too. Genuinely deferred callbacks remain valid. There is no
-runtime phase guard, hook-cell policy, runtime-only enforcement, cleanup ban, or
-`stateWrites` configuration in the shipped model.
+Opted-in modules reject statically provable updater calls during render or
+synchronous effect setup, along with render-time `ref.current` writes. The
+analysis follows synchronous calls through `useCallback`, `useEffectEvent`, and
+functions returned by analyzable `useMemo` factories. Statically known Effect
+Event calls during render (`OCTANE_STRONG_RENDER_EFFECT_EVENT_CALL`) and Effect
+Events in explicit hook dependency lists
+(`OCTANE_STRONG_EFFECT_EVENT_DEPENDENCY`) are also errors. The hooks themselves
+remain supported; other explicit dependency lists keep their existing semantics.
+Synchronously evaluated state initializers, linked-state reconcilers, and
+linked-state equality callbacks are render contexts too. Genuinely deferred
+callbacks and effect cleanup remain valid. There is no runtime phase guard,
+hook-cell policy, runtime-only enforcement, cleanup ban, or `stateWrites`
+configuration in the shipped model.
 
 For current authoring guidance, see [State that follows another
 value](./tsrx-basics.md#state-that-follows-another-value),

--- a/docs/tsrx-basics.md
+++ b/docs/tsrx-basics.md
@@ -364,8 +364,8 @@ JavaScript. Only inject source you trust.
 
 ## Strong mode
 
-Strong mode is an optional compiler check for state and refs. Start with one
-module by putting `"use strong"` before its imports:
+Strong mode is an optional compiler check for state, refs, and Effect Events.
+Start with one module by putting `"use strong"` before its imports:
 
 ```tsx
 "use strong";
@@ -396,16 +396,33 @@ options; use the plugin option for a standalone Rspack setup. An explicit plugin
 setting wins over `octane.config.ts`. Dependencies keep their existing behavior
 unless one of their own modules opts in with `"use strong"`.
 
-Three patterns become compile errors:
+These patterns become compile errors:
 
 - Calling a `useState`, `useReducer`, or `useLinkedState` updater during render.
-- Calling one of those updaters directly while an effect is being set up.
+- Calling one of those updaters synchronously while an effect is being set up.
 - Assigning to a `useRef` object's `current` during render.
+- Calling a statically known `useEffectEvent` result during render
+  (`OCTANE_STRONG_RENDER_EFFECT_EVENT_CALL`).
+- Including a statically known Effect Event in an explicit hook dependency list
+  (`OCTANE_STRONG_EFFECT_EVENT_DEPENDENCY`).
+
+The checks follow provable synchronous calls through local helpers,
+`useCallback` and `useEffectEvent` results, and functions returned by analyzable
+`useMemo` factories. These hooks remain supported; creating a callback is not
+itself an error. Effect Events are non-reactive and should be omitted from hook
+dependencies. Other explicit dependency arrays keep their existing meaning and
+are never rewritten.
+
+The analysis is deliberately bounded. Factories with unknown return values or
+complex control flow remain opaque. Dependency checks follow literal arrays,
+including statically selected or spread literals; they do not assume an aliased
+or externally produced array is unchanged.
 
 Update state in event handlers instead. When state should reset or adjust after
 an input changes, use `useLinkedState`. Effects that connect to external systems,
-and refs used for DOM elements, timers, or event callbacks, remain valid. Strong
-mode does not restrict `Date.now()`, `Math.random()`, or similar values.
+genuinely deferred callbacks, effect cleanup, and refs used for DOM elements,
+timers, or event callbacks remain valid. Strong mode does not restrict
+`Date.now()`, `Math.random()`, or similar values.
 
 `"use strong"` only affects its own module. Put it at the top of the file, before
 imports or other code; comments and other directives may come first. In files

--- a/packages/octane/src/compiler/hook-deps.js
+++ b/packages/octane/src/compiler/hook-deps.js
@@ -118,12 +118,14 @@ function unwrapExport(node) {
 	return node;
 }
 
-function predeclareDirect(statements, scope, hookRuntimeModules) {
+function predeclareDirect(statements, scope, hookRuntimeModules, bindingsOnly = false) {
 	for (const original of statements || []) {
 		if (original.type === 'ImportDeclaration') {
+			if (bindingsOnly && original.importKind === 'type') continue;
 			const isHookRuntime = hookRuntimeModules.has(original.source?.value);
 			const isOctane = original.source?.value === 'octane';
 			for (const specifier of original.specifiers || []) {
+				if (bindingsOnly && specifier.importKind === 'type') continue;
 				const imported = specifier.imported?.name;
 				declareName(scope, specifier.local.name, {
 					imported: true,
@@ -156,19 +158,29 @@ function predeclareDirect(statements, scope, hookRuntimeModules) {
 	}
 }
 
-function collectHoistedVars(node, functionScope, root = true) {
+function collectHoistedVars(node, functionScope, root = true, bindingsOnly = false) {
 	if (!node || typeof node !== 'object') return;
 	if (Array.isArray(node)) {
-		for (const child of node) collectHoistedVars(child, functionScope, false);
+		for (const child of node) collectHoistedVars(child, functionScope, false, bindingsOnly);
 		return;
 	}
 	if (!root && isFunction(node)) return;
+	if (
+		bindingsOnly &&
+		(isFunction(node) ||
+			(!root && node.type === 'StaticBlock') ||
+			node.type === 'ClassDeclaration' ||
+			node.type === 'ClassExpression' ||
+			node.type === 'TSModuleDeclaration')
+	) {
+		return;
+	}
 	if (node.type === 'VariableDeclaration' && node.kind === 'var') {
 		for (const decl of node.declarations || []) declarePattern(decl.id, functionScope);
 	}
 	for (const key in node) {
 		if (AST_META_KEYS.has(key)) continue;
-		collectHoistedVars(node[key], functionScope, false);
+		collectHoistedVars(node[key], functionScope, false, bindingsOnly);
 	}
 }
 
@@ -277,7 +289,7 @@ function markReassignedPattern(pattern, scope) {
 	}
 }
 
-function buildScopes(ast, onlyImported, hookRuntimeModules) {
+function buildScopes(ast, onlyImported, hookRuntimeModules, bindingsOnly = false) {
 	nextBindingId = 0;
 	const moduleScope = createScope(null, 'module');
 	const nodeScopes = new WeakMap();
@@ -289,8 +301,35 @@ function buildScopes(ast, onlyImported, hookRuntimeModules) {
 	const functionRecords = new WeakMap();
 	const trustedHookNames = new WeakMap();
 	const callAnnotations = new Map();
-	predeclareDirect(ast.body, moduleScope, hookRuntimeModules);
-	collectHoistedVars(ast, moduleScope);
+	const declarationBindings = bindingsOnly ? new Map() : null;
+	const firstDefinitions = bindingsOnly ? new Map() : null;
+	predeclareDirect(ast.body, moduleScope, hookRuntimeModules, bindingsOnly);
+	collectHoistedVars(ast, moduleScope, true, bindingsOnly);
+
+	function rememberBindings(bindings, definesValue = true) {
+		if (declarationBindings === null || firstDefinitions === null) return;
+		for (const { pattern, binding } of bindings) {
+			declarationBindings.set(pattern, binding);
+			if (!definesValue) continue;
+			const previous = firstDefinitions.get(binding);
+			if (previous !== undefined && previous !== pattern) binding.reassigned = true;
+			else firstDefinitions.set(binding, pattern);
+		}
+	}
+
+	function rememberPattern(pattern, scope, definesValue = true) {
+		if (!bindingsOnly) return;
+		if (pattern?.type === 'TSParameterProperty') pattern = pattern.parameter;
+		const bindings = [];
+		collectPatternBindings(pattern, scope, bindings);
+		rememberBindings(bindings, definesValue);
+	}
+
+	function invalidateVisibleBindings(scope) {
+		for (let current = scope; current !== null; current = current.parent) {
+			for (const binding of current.bindings.values()) binding.reassigned = true;
+		}
+	}
 
 	function walk(node, scope) {
 		if (!node || typeof node !== 'object') return;
@@ -298,34 +337,103 @@ function buildScopes(ast, onlyImported, hookRuntimeModules) {
 			for (const child of node) walk(child, scope);
 			return;
 		}
-		nodeScopes.set(node, scope);
+		if (!bindingsOnly) nodeScopes.set(node, scope);
+		if (
+			bindingsOnly &&
+			(node.type === 'TSInstantiationExpression' || node.type === 'TSExportAssignment')
+		) {
+			walk(node.expression, scope);
+			return;
+		}
 
 		if (isFunction(node)) {
 			const fnScope = createScope(scope, 'function');
-			functionScopes.set(node, fnScope);
-			const record = {
-				node,
-				scope: fnScope,
-				binding:
-					node.type === 'FunctionDeclaration' && node.id
-						? resolveBinding(scope, node.id.name)
-						: null,
-				parameters: null,
-				stableDefinition: node.type === 'FunctionDeclaration',
-			};
-			functions.push(record);
-			functionRecords.set(node, record);
+			const record = bindingsOnly
+				? null
+				: {
+						node,
+						scope: fnScope,
+						binding:
+							node.type === 'FunctionDeclaration' && node.id
+								? resolveBinding(scope, node.id.name)
+								: null,
+						parameters: null,
+						stableDefinition: node.type === 'FunctionDeclaration',
+					};
+			if (record !== null) {
+				functionScopes.set(node, fnScope);
+				functions.push(record);
+				functionRecords.set(node, record);
+			}
+			if (bindingsOnly && node.type === 'FunctionDeclaration' && node.id) {
+				rememberPattern(node.id, scope);
+			}
 			if (node.type === 'FunctionExpression' && node.id) {
 				declareName(fnScope, node.id.name);
+				if (bindingsOnly) rememberPattern(node.id, fnScope);
 			}
 			if (node.type !== 'ArrowFunctionExpression') declareName(fnScope, 'arguments');
-			for (const param of node.params || []) declarePattern(param, fnScope);
-			record.parameters = (node.params || []).map((param) =>
-				directParameterBinding(param, fnScope),
-			);
-			collectHoistedVars(node.body, fnScope);
-			for (const param of node.params || []) walkPatternDefaults(param, fnScope);
-			walk(node.body, fnScope);
+			for (const param of node.params || []) {
+				declarePattern(
+					bindingsOnly && param.type === 'TSParameterProperty' ? param.parameter : param,
+					fnScope,
+				);
+			}
+			if (record !== null) {
+				record.parameters = (node.params || []).map((param) =>
+					directParameterBinding(param, fnScope),
+				);
+			}
+			if (bindingsOnly) {
+				for (const param of node.params || []) rememberPattern(param, fnScope);
+				// Parameter defaults cannot see declarations in the function body.
+				// Afterwards, share the direct body with the parameters so legal var
+				// and function redeclarations count as competing value definitions.
+				for (const param of node.params || []) walkPatternDefaults(param, fnScope);
+				collectHoistedVars(node.body, fnScope, true, true);
+				if (node.body?.type === 'BlockStatement' || node.body?.type === 'JSXCodeBlock') {
+					predeclareDirect(node.body.body, fnScope, hookRuntimeModules, true);
+					for (const statement of node.body.body || []) walk(statement, fnScope);
+					if (node.body.type === 'JSXCodeBlock') walk(node.body.render, fnScope);
+				} else {
+					walk(node.body, fnScope);
+				}
+			} else {
+				collectHoistedVars(node.body, fnScope);
+				for (const param of node.params || []) walkPatternDefaults(param, fnScope);
+				walk(node.body, fnScope);
+			}
+			return;
+		}
+
+		if (bindingsOnly && node.type === 'ImportDeclaration') {
+			if (node.importKind !== 'type') {
+				for (const specifier of node.specifiers || []) {
+					if (specifier.importKind !== 'type') rememberPattern(specifier.local, scope);
+				}
+			}
+			return;
+		}
+
+		if (
+			bindingsOnly &&
+			node.declare !== true &&
+			((node.type === 'TSModuleDeclaration' && node.kind !== 'global') ||
+				node.type === 'TSEnumDeclaration')
+		) {
+			// The dependency walk deliberately skips TypeScript-only syntax. Runtime
+			// namespaces and enum initializers can still write their enclosing scope.
+			invalidateVisibleBindings(scope);
+			return;
+		}
+
+		if (bindingsOnly && (node.type === 'ClassDeclaration' || node.type === 'ClassExpression')) {
+			if (node.type === 'ClassDeclaration' && node.id) rememberPattern(node.id, scope);
+			const classScope = createScope(scope, 'block');
+			if (node.id) declarePattern(node.id, classScope);
+			for (const decorator of node.decorators || []) walk(decorator, scope);
+			walk(node.superClass, classScope);
+			walk(node.body, classScope);
 			return;
 		}
 
@@ -334,8 +442,14 @@ function buildScopes(ast, onlyImported, hookRuntimeModules) {
 			node.type === 'StaticBlock' ||
 			node.type === 'JSXCodeBlock'
 		) {
-			const blockScope = createScope(scope, 'block');
-			predeclareDirect(node.body, blockScope, hookRuntimeModules);
+			const blockScope = createScope(
+				scope,
+				bindingsOnly && node.type === 'StaticBlock' ? 'function' : 'block',
+			);
+			if (bindingsOnly && node.type === 'StaticBlock') {
+				collectHoistedVars(node, blockScope, true, true);
+			}
+			predeclareDirect(node.body, blockScope, hookRuntimeModules, bindingsOnly);
 			for (const statement of node.body || []) walk(statement, blockScope);
 			// TSRX's final render node lives beside the setup-statement list.
 			if (node.type === 'JSXCodeBlock') walk(node.render, blockScope);
@@ -345,12 +459,17 @@ function buildScopes(ast, onlyImported, hookRuntimeModules) {
 		if (node.type === 'CatchClause') {
 			const catchScope = createScope(scope, 'block');
 			declarePattern(node.param, catchScope);
+			if (bindingsOnly) rememberPattern(node.param, catchScope);
+			if (bindingsOnly && node.resetParam) {
+				declarePattern(node.resetParam, catchScope);
+				rememberPattern(node.resetParam, catchScope);
+			}
 			walkPatternDefaults(node.param, catchScope);
 			walk(node.body, catchScope);
 			return;
 		}
 
-		if (node.type === 'SwitchStatement') {
+		if (node.type === 'SwitchStatement' || (bindingsOnly && node.type === 'JSXSwitchExpression')) {
 			// A switch body is one lexical scope shared by every unbraced case.
 			// Predeclare the direct case statements together so let/const/function
 			// captures resolve even when their declaration appears in a case list
@@ -360,10 +479,10 @@ function buildScopes(ast, onlyImported, hookRuntimeModules) {
 			for (const switchCase of node.cases || []) {
 				statements.push(...(switchCase.consequent || []));
 			}
-			predeclareDirect(statements, switchScope, hookRuntimeModules);
+			predeclareDirect(statements, switchScope, hookRuntimeModules, bindingsOnly);
 			walk(node.discriminant, scope);
 			for (const switchCase of node.cases || []) {
-				nodeScopes.set(switchCase, switchScope);
+				if (!bindingsOnly) nodeScopes.set(switchCase, switchScope);
 				walk(switchCase.test, switchScope);
 				for (const statement of switchCase.consequent || []) walk(statement, switchScope);
 			}
@@ -373,32 +492,45 @@ function buildScopes(ast, onlyImported, hookRuntimeModules) {
 		if (
 			node.type === 'ForStatement' ||
 			node.type === 'ForInStatement' ||
-			node.type === 'ForOfStatement'
+			node.type === 'ForOfStatement' ||
+			(bindingsOnly && node.type === 'JSXForExpression')
 		) {
 			const loopScope = createScope(scope, 'block');
-			const declaration = node.type === 'ForStatement' ? node.init : node.left;
+			const loopType = node.type === 'JSXForExpression' ? node.statementType : node.type;
+			const declaration = loopType === 'ForStatement' ? node.init : node.left;
 			if (declaration?.type === 'VariableDeclaration' && declaration.kind !== 'var') {
 				for (const decl of declaration.declarations || []) declarePattern(decl.id, loopScope);
 			}
-			if (node.type === 'ForStatement') {
+			if (loopType === 'ForStatement') {
 				walk(node.init, loopScope);
 				walk(node.test, loopScope);
 				walk(node.update, loopScope);
 			} else {
 				walk(node.left, loopScope);
 				if (node.left?.type !== 'VariableDeclaration') markReassignedPattern(node.left, loopScope);
-				walk(node.right, loopScope);
+				else if (bindingsOnly && node.left.kind === 'var') {
+					for (const decl of node.left.declarations || [])
+						markReassignedPattern(decl.id, loopScope);
+				}
+				walk(node.right, node.type === 'JSXForExpression' ? scope : loopScope);
+			}
+			if (bindingsOnly && node.type === 'JSXForExpression') {
+				declarePattern(node.index, loopScope);
+				rememberPattern(node.index, loopScope);
+				walk(node.key, loopScope);
 			}
 			walk(node.body, loopScope);
+			if (bindingsOnly && node.type === 'JSXForExpression') walk(node.empty, scope);
 			return;
 		}
 
 		if (node.type === 'VariableDeclaration') {
 			for (const decl of node.declarations || []) {
-				nodeScopes.set(decl, scope);
+				if (!bindingsOnly) nodeScopes.set(decl, scope);
 				const bindings = [];
 				collectPatternBindings(decl.id, scope, bindings);
-				declarators.push({ decl, bindings, kind: node.kind });
+				if (bindingsOnly) rememberBindings(bindings, node.kind !== 'var' || decl.init != null);
+				else declarators.push({ decl, bindings, kind: node.kind });
 				walkPatternDefaults(decl.id, scope);
 				walk(decl.init, scope);
 			}
@@ -411,7 +543,21 @@ function buildScopes(ast, onlyImported, hookRuntimeModules) {
 			markReassignedPattern(node.argument, scope);
 		}
 
-		if (node.type === 'CallExpression') {
+		if (bindingsOnly && node.type === 'CallExpression') {
+			let callee = unwrapValue(node.callee);
+			while (callee?.type === 'TSInstantiationExpression') {
+				callee = unwrapValue(callee.expression);
+			}
+			if (
+				node.optional !== true &&
+				callee?.type === 'Identifier' &&
+				callee.name === 'eval' &&
+				resolveBinding(scope, callee.name) === null
+			) {
+				// Direct eval can reassign any lexically reachable writable binding.
+				invalidateVisibleBindings(scope);
+			}
+		} else if (node.type === 'CallExpression') {
 			// Preserve lexical import identity for the later slotting pass. A module-
 			// level name map is insufficient: a component can shadow either a named
 			// alias or an Octane namespace inside any nested scope. The annotation is
@@ -471,6 +617,9 @@ function buildScopes(ast, onlyImported, hookRuntimeModules) {
 	function walkPatternDefaults(pattern, scope) {
 		if (!pattern) return;
 		switch (pattern.type) {
+			case 'TSParameterProperty':
+				if (bindingsOnly) walkPatternDefaults(pattern.parameter, scope);
+				return;
 			case 'AssignmentPattern':
 				walkPatternDefaults(pattern.left, scope);
 				walk(pattern.right, scope);
@@ -513,7 +662,9 @@ function buildScopes(ast, onlyImported, hookRuntimeModules) {
 		functions,
 		trustedHookNames,
 		callAnnotations,
+		declarationBindings,
 	};
+	if (bindingsOnly) return analysis;
 	// The surgical plain-TS pass slots base hooks only; without a custom-hook
 	// withSlot boundary, two local wrapper calls would share their inner slots.
 	// Restrict custom-call inference to the full TSRX/TSX compiler, which emits
@@ -1250,6 +1401,25 @@ function analyzeInternal(ast, options) {
 		});
 	}
 	return { analysis, inferred };
+}
+
+/**
+ * Return authored declaration identifiers whose bindings have a write or a
+ * competing value definition. This is a read-only, scope-aware proof for callers
+ * that recreate lexical scopes per invocation. Absence from the set does not
+ * make a mutable declaration kind immutable by itself.
+ *
+ * @param {any} ast
+ * @returns {WeakSet<import('estree').Identifier>}
+ */
+export function collectReassignedBindings(ast) {
+	const { declarationBindings } = buildScopes(ast, true, new Set(), true);
+	/** @type {WeakSet<import('estree').Identifier>} */
+	const reassigned = new WeakSet();
+	for (const [node, binding] of declarationBindings ?? []) {
+		if (binding.reassigned) reassigned.add(node);
+	}
+	return reassigned;
 }
 
 /**

--- a/packages/octane/src/compiler/strong-mode.js
+++ b/packages/octane/src/compiler/strong-mode.js
@@ -1,3 +1,5 @@
+import { collectReassignedBindings } from './hook-deps.js';
+
 const STATE_HOOKS = new Set(['useState', 'useReducer', 'useLinkedState']);
 const EFFECT_HOOKS = new Set(['useEffect', 'useLayoutEffect', 'useInsertionEffect']);
 const FUNCTION_TYPES = new Set([
@@ -14,11 +16,16 @@ const TRANSPARENT_EXPRESSIONS = new Set([
 	'TSSatisfiesExpression',
 	'TSTypeAssertion',
 ]);
-const NULLISH_VALUE = 1;
-const FALSY_VALUE = 2;
-const TRUTHY_VALUE = 4;
+const UNDEFINED_VALUE = 1;
+const NULL_VALUE = 2;
+const NULLISH_VALUE = UNDEFINED_VALUE | NULL_VALUE;
+const FALSY_VALUE = 4;
+const TRUTHY_VALUE = 8;
 const UNKNOWN_VALUE = NULLISH_VALUE | FALSY_VALUE | TRUTHY_VALUE;
 const UNKNOWN_PRIMITIVE = Symbol('unknown primitive');
+const NO_RETURN_VALUE = Symbol('no return value');
+const OTHER_BINDING = { kind: 'other' };
+const UNDEFINED_BINDING = { kind: 'constant', value: UNDEFINED_VALUE, primitive: undefined };
 const SKIP_KEYS = new Set([
 	'type',
 	'start',
@@ -37,7 +44,19 @@ const SKIP_KEYS = new Set([
 export const STRONG_RENDER_STATE_UPDATE = 'OCTANE_STRONG_RENDER_STATE_UPDATE';
 export const STRONG_EFFECT_STATE_UPDATE = 'OCTANE_STRONG_EFFECT_STATE_UPDATE';
 export const STRONG_RENDER_REF_WRITE = 'OCTANE_STRONG_RENDER_REF_WRITE';
+export const STRONG_RENDER_EFFECT_EVENT_CALL = 'OCTANE_STRONG_RENDER_EFFECT_EVENT_CALL';
+export const STRONG_EFFECT_EVENT_DEPENDENCY = 'OCTANE_STRONG_EFFECT_EVENT_DEPENDENCY';
 export const STRONG_DIRECTIVE_PLACEMENT = 'OCTANE_STRONG_DIRECTIVE_PLACEMENT';
+
+function primitiveValueMask(value) {
+	return value === undefined
+		? UNDEFINED_VALUE
+		: value === null
+			? NULL_VALUE
+			: value
+				? TRUTHY_VALUE
+				: FALSY_VALUE;
+}
 
 function unwrap(node) {
 	let value = node;
@@ -61,24 +80,28 @@ function optionalChainCanSkip(node) {
 	return false;
 }
 
-function addPatternNames(pattern, bindings, value) {
+function addPatternNames(pattern, bindings, value, overwrite = true) {
 	if (pattern == null) return;
 	switch (pattern.type) {
 		case 'Identifier':
-			bindings.set(pattern.name, value);
+			if (overwrite || !bindings.has(pattern.name)) bindings.set(pattern.name, value);
 			break;
 		case 'RestElement':
-			addPatternNames(pattern.argument, bindings, value);
+			addPatternNames(pattern.argument, bindings, value, overwrite);
 			break;
 		case 'AssignmentPattern':
-			addPatternNames(pattern.left, bindings, value);
+			addPatternNames(pattern.left, bindings, value, overwrite);
+			break;
+		case 'TSParameterProperty':
+			addPatternNames(pattern.parameter, bindings, value, overwrite);
 			break;
 		case 'ArrayPattern':
-			for (const element of pattern.elements ?? []) addPatternNames(element, bindings, value);
+			for (const element of pattern.elements ?? [])
+				addPatternNames(element, bindings, value, overwrite);
 			break;
 		case 'ObjectPattern':
 			for (const property of pattern.properties ?? []) {
-				addPatternNames(property.argument ?? property.value, bindings, value);
+				addPatternNames(property.argument ?? property.value, bindings, value, overwrite);
 			}
 	}
 }
@@ -100,6 +123,38 @@ function declarationScope(scope, kind) {
 	return kind === 'var' ? nearestFunctionScope(scope) : scope;
 }
 
+class BindingMap extends Map {
+	constructor(clock) {
+		super();
+		this.clock = clock;
+		this.revision = 0;
+	}
+
+	set(name, value) {
+		if (!super.has(name) || super.get(name) !== value) this.revision = ++this.clock.value;
+		return super.set(name, value);
+	}
+
+	delete(name) {
+		const deleted = super.delete(name);
+		if (deleted) this.revision = ++this.clock.value;
+		return deleted;
+	}
+
+	clear() {
+		if (this.size !== 0) this.revision = ++this.clock.value;
+		super.clear();
+	}
+}
+
+function scopeRevision(scope) {
+	let revision = 0;
+	for (let current = scope; current; current = current.parent) {
+		revision = Math.max(revision, current.bindings.revision);
+	}
+	return revision;
+}
+
 function predeclareStatements(statements, scope) {
 	for (const original of statements ?? []) {
 		const node = declarationOf(original);
@@ -119,7 +174,7 @@ function predeclareStatements(statements, scope) {
 		} else if (node?.type === 'VariableDeclaration') {
 			const target = declarationScope(scope, node.kind);
 			for (const declaration of node.declarations ?? []) {
-				addPatternNames(declaration.id, target.bindings, { kind: 'other' });
+				addPatternNames(declaration.id, target.bindings, OTHER_BINDING, node.kind !== 'var');
 			}
 		} else if (node?.type === 'FunctionDeclaration' && node.id?.name) {
 			scope.bindings.set(node.id.name, { kind: 'callback', node, scope });
@@ -129,16 +184,38 @@ function predeclareStatements(statements, scope) {
 	}
 }
 
-function createScope(parent, kind, statements = [], params = []) {
-	const scope = { parent, kind, bindings: new Map() };
-	predeclareStatements(statements, scope);
+function createScope(
+	parent,
+	kind,
+	statements = [],
+	params = [],
+	isReassigned = parent?.isReassigned,
+) {
+	const scope = {
+		parent,
+		kind,
+		bindings: new BindingMap(parent?.bindings.clock ?? { value: 0 }),
+		isReassigned,
+	};
 	for (const param of params) addPatternNames(param, scope.bindings, { kind: 'other' });
+	predeclareStatements(statements, scope);
 	return scope;
 }
 
 function resolve(scope, name) {
 	for (let current = scope; current; current = current.parent) {
-		if (current.bindings.has(name)) return current.bindings.get(name);
+		if (!current.bindings.has(name)) continue;
+		const binding = current.bindings.get(name);
+		// Function declarations are writable, unlike const callback aliases.
+		// The source-binding proof is shared by every lexical activation.
+		if (
+			binding?.kind === 'callback' &&
+			binding.node.type === 'FunctionDeclaration' &&
+			current.isReassigned?.(binding.node.id)
+		) {
+			return OTHER_BINDING;
+		}
+		return binding;
 	}
 	return null;
 }
@@ -250,9 +327,66 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 	const enabled = options.strong === true || directives.enabled;
 	if (!enabled) return { enabled: false, diagnostics };
 
-	const moduleScope = createScope(null, 'module', ast.body ?? []);
+	let reassignedBindings;
+	function isReassigned(identifier) {
+		reassignedBindings ??= collectReassignedBindings(ast);
+		return reassignedBindings.has(identifier);
+	}
+	const moduleScope = createScope(null, 'module', ast.body ?? [], [], isReassigned);
 	const activeCallbacks = new Set();
+	const activeReturnCallbacks = new Set();
+	const callResults = new WeakMap();
+	const reportedDiagnostics = new WeakMap();
+	const hoistedVarNames = new WeakMap();
+	const mayHaveHoistedVars = source.includes('var');
+	let returnCycles = 0;
 	let currentFunctionIsAsync = false;
+
+	function predeclareHoistedVars(node, scope) {
+		if (!mayHaveHoistedVars || node == null) return;
+		let names = hoistedVarNames.get(node);
+		if (names === undefined) {
+			names = new Map();
+			function collect(value) {
+				if (value == null || typeof value !== 'object') return;
+				if (Array.isArray(value)) {
+					for (const child of value) collect(child);
+					return;
+				}
+				if (
+					FUNCTION_TYPES.has(value.type) ||
+					value.type === 'ClassDeclaration' ||
+					value.type === 'ClassExpression' ||
+					value.type === 'StaticBlock' ||
+					(value.type?.startsWith('TS') && !TRANSPARENT_EXPRESSIONS.has(value.type))
+				) {
+					return;
+				}
+				if (value.type === 'VariableDeclaration' && value.kind === 'var') {
+					for (const declaration of value.declarations ?? []) {
+						addPatternNames(declaration.id, names, OTHER_BINDING);
+					}
+				}
+				for (const key in value) {
+					if (!SKIP_KEYS.has(key) && !key.startsWith('_octane')) collect(value[key]);
+				}
+			}
+			collect(node);
+			hoistedVarNames.set(node, names);
+		}
+		for (const name of names.keys()) {
+			if (!scope.bindings.has(name)) scope.bindings.set(name, OTHER_BINDING);
+		}
+	}
+	predeclareHoistedVars(ast, moduleScope);
+
+	function report(code, node, message, suggestions = []) {
+		let codes = reportedDiagnostics.get(node);
+		if (codes?.has(code)) return;
+		if (codes === undefined) reportedDiagnostics.set(node, (codes = new Set()));
+		codes.add(code);
+		diagnostics.push(diagnostic(code, filename, node, message, suggestions));
+	}
 
 	function reportSetter(node, phase) {
 		const effect = phase === 'effect';
@@ -260,17 +394,22 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		const message = effect
 			? 'Strong mode does not allow synchronous state updates inside effect setup. Derive the value during render or use useLinkedState when state follows another value.'
 			: 'Strong mode does not allow state updates during render. Use useLinkedState when state needs to reset or change with another value.';
-		diagnostics.push(diagnostic(code, filename, node, message, [{ hook: 'useLinkedState' }]));
+		report(code, node, message, [{ hook: 'useLinkedState' }]);
 	}
 
 	function reportRef(node) {
-		diagnostics.push(
-			diagnostic(
-				STRONG_RENDER_REF_WRITE,
-				filename,
-				node,
-				'Strong mode does not allow writing to useRef.current during render. Move the write to an event or effect, or express the value as state.',
-			),
+		report(
+			STRONG_RENDER_REF_WRITE,
+			node,
+			'Strong mode does not allow writing to useRef.current during render. Move the write to an event or effect, or express the value as state.',
+		);
+	}
+
+	function reportEffectEventCall(node) {
+		report(
+			STRONG_RENDER_EFFECT_EVENT_CALL,
+			node,
+			'Strong mode does not allow calling an Effect Event during render. Call it from an effect or a later event or subscription callback.',
 		);
 	}
 
@@ -580,6 +719,14 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		for (const statement of statements ?? []) {
 			visit(statement, scope, executionPhase);
 			if (
+				statement.type === 'ReturnStatement' ||
+				statement.type === 'ThrowStatement' ||
+				statement.type === 'BreakStatement' ||
+				statement.type === 'ContinueStatement'
+			) {
+				break;
+			}
+			if (
 				currentFunctionIsAsync &&
 				executionPhase !== 'deferred' &&
 				statementAlwaysAwaits(statement)
@@ -590,17 +737,94 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		return executionPhase;
 	}
 
-	function visitFunction(node, parentScope, phase) {
+	function createFunctionScope(node, parentScope, args = null) {
+		const body = node.body;
+		const statements =
+			body?.type === 'BlockStatement' || body?.type === 'JSXCodeBlock' ? body.body : [];
+		const scope = createScope(parentScope, 'function', statements, node.params ?? []);
+		predeclareHoistedVars(body, scope);
+		if (node.type === 'FunctionExpression' && node.id?.name && !scope.bindings.has(node.id.name)) {
+			scope.bindings.set(node.id.name, { kind: 'callback', node, scope: parentScope });
+		}
+		if (args !== null) {
+			for (let index = 0; index < (node.params?.length ?? 0); index++) {
+				const parameter = node.params[index];
+				if (parameter.type === 'Identifier' && !isReassigned(parameter)) {
+					scope.bindings.set(parameter.name, args[index] ?? UNDEFINED_BINDING);
+				}
+			}
+		}
+		return scope;
+	}
+
+	function definitelyDefined(value) {
+		if (value?.kind === 'constant' && value.primitive !== UNKNOWN_PRIMITIVE) {
+			return value.primitive !== undefined;
+		}
+		if (isCallableValue(value)) return (callableTruthiness(value) & UNDEFINED_VALUE) === 0;
+		return (
+			value?.kind === 'ref' ||
+			value?.kind === 'state-tuple' ||
+			(value?.kind === 'constant' && (value.value & UNDEFINED_VALUE) === 0)
+		);
+	}
+
+	function visitParameters(node, parentScope, phase, args) {
+		const parameters = node.params ?? [];
+		const parameterScope = createScope(parentScope, 'function', [], parameters);
+		if (
+			node.type === 'FunctionExpression' &&
+			node.id?.name &&
+			!parameterScope.bindings.has(node.id.name)
+		) {
+			parameterScope.bindings.set(node.id.name, { kind: 'callback', node, scope: parentScope });
+		}
+		for (let index = 0; index < parameters.length; index++) {
+			let parameter = parameters[index];
+			if (parameter.type === 'TSParameterProperty') parameter = parameter.parameter;
+			let value = args === null ? OTHER_BINDING : (args[index] ?? UNDEFINED_BINDING);
+			if (parameter.type === 'AssignmentPattern') {
+				visitPatternExpressions(parameter.left, parameterScope, phase);
+				if (!definitelyDefined(value)) visit(parameter.right, parameterScope, phase);
+				value =
+					value.kind === 'constant' && value.primitive === undefined
+						? expressionBinding(parameter.right, parameterScope)
+						: definitelyDefined(value)
+							? value
+							: OTHER_BINDING;
+				parameter = parameter.left;
+			} else {
+				visitPatternExpressions(parameter, parameterScope, phase);
+			}
+			if (parameter.type === 'Identifier' && !isReassigned(parameter)) {
+				parameterScope.bindings.set(parameter.name, value);
+			}
+		}
+		return parameterScope;
+	}
+
+	function visitFunction(node, parentScope, phase, args = null) {
 		const enclosingFunctionIsAsync = currentFunctionIsAsync;
 		currentFunctionIsAsync = node.async === true;
 		try {
 			const body = node.body;
-			const statements =
-				body?.type === 'BlockStatement' || body?.type === 'JSXCodeBlock' ? body.body : [];
-			const functionScope = createScope(parentScope, 'function', statements, node.params ?? []);
-			if (node.id?.name) functionScope.bindings.set(node.id.name, { kind: 'other' });
-			for (const parameter of node.params ?? []) {
-				visitPatternExpressions(parameter, functionScope, phase);
+			let functionScope;
+			if ((node.params ?? []).every((parameter) => parameter.type === 'Identifier')) {
+				functionScope = createFunctionScope(node, parentScope, args);
+			} else {
+				// Defaults run before the body environment exists. In particular,
+				// body var/function declarations cannot shadow an outer default read.
+				const parameterScope = visitParameters(node, parentScope, phase, args);
+				functionScope = createScope(parameterScope, 'function');
+				const names = new Map();
+				for (const parameter of node.params ?? []) addPatternNames(parameter, names, OTHER_BINDING);
+				for (const name of names.keys()) {
+					functionScope.bindings.set(name, parameterScope.bindings.get(name));
+				}
+				if (body?.type === 'BlockStatement' || body?.type === 'JSXCodeBlock') {
+					predeclareStatements(body.body, functionScope);
+				}
+				predeclareHoistedVars(body, functionScope);
 			}
 			if (body?.type === 'BlockStatement' || body?.type === 'JSXCodeBlock') {
 				const executionPhase = visitStatements(body.body, functionScope, phase);
@@ -615,7 +839,9 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 
 	function visitPatternExpressions(pattern, scope, phase) {
 		let executionPhase = phase;
-		if (pattern?.type === 'AssignmentPattern') {
+		if (pattern?.type === 'TSParameterProperty') {
+			return visitPatternExpressions(pattern.parameter, scope, phase);
+		} else if (pattern?.type === 'AssignmentPattern') {
 			executionPhase = visitPatternExpressions(pattern.left, scope, executionPhase);
 			visit(pattern.right, scope, executionPhase);
 		} else if (pattern?.type === 'ArrayPattern') {
@@ -640,9 +866,16 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		return executionPhase;
 	}
 
-	function bindDeclaration(declaration, declarationKind, scope, phase) {
+	function bindDeclarationValue(declaration, declarationKind, scope) {
 		const target = declarationScope(scope, declarationKind);
 		const initial = unwrap(declaration.init);
+		function bind(identifier, value) {
+			if (identifier?.type !== 'Identifier') return;
+			target.bindings.set(
+				identifier.name,
+				declarationKind === 'const' || !isReassigned(identifier) ? value : OTHER_BINDING,
+			);
+		}
 		const stateTuple =
 			(initial?.type === 'CallExpression' &&
 				STATE_HOOKS.has(importedHook(initial.callee, scope))) ||
@@ -650,7 +883,7 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		if (declaration.id?.type === 'ArrayPattern' && stateTuple) {
 			const element = declaration.id.elements?.[1];
 			const setter = element?.type === 'AssignmentPattern' ? element.left : element;
-			if (setter?.type === 'Identifier') target.bindings.set(setter.name, { kind: 'setter' });
+			bind(setter, { kind: 'setter' });
 		} else if (declaration.id?.type === 'ObjectPattern' && stateTuple) {
 			for (const property of declaration.id.properties ?? []) {
 				if (property.type !== 'Property') continue;
@@ -662,17 +895,17 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				const value = property.value;
 				const setter = value?.type === 'AssignmentPattern' ? value.left : value;
 				if ((key === 1 || key === '1') && setter?.type === 'Identifier') {
-					target.bindings.set(setter.name, { kind: 'setter' });
+					bind(setter, { kind: 'setter' });
 				}
 			}
 		} else if (declaration.id?.type === 'Identifier') {
 			if (stateTuple) {
-				target.bindings.set(declaration.id.name, { kind: 'state-tuple' });
+				bind(declaration.id, { kind: 'state-tuple' });
 			} else if (
 				initial?.type === 'CallExpression' &&
 				importedHook(initial.callee, scope) === 'useRef'
 			) {
-				target.bindings.set(declaration.id.name, { kind: 'ref' });
+				bind(declaration.id, { kind: 'ref' });
 			} else if (declarationKind === 'const' && stateTupleUpdater(initial, scope)) {
 				target.bindings.set(declaration.id.name, { kind: 'setter' });
 			} else if (declarationKind === 'const' && initial?.type === 'Identifier') {
@@ -682,17 +915,14 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 					value?.kind === 'ref' ||
 					value?.kind === 'callback' ||
 					value?.kind === 'callback-choice' ||
+					value?.kind === 'effect-event' ||
 					value?.kind === 'linked-options' ||
 					value?.kind === 'linked-key' ||
 					value?.kind === 'constant'
 				) {
 					target.bindings.set(declaration.id.name, value);
 				} else if (value == null && initial.name === 'undefined') {
-					target.bindings.set(declaration.id.name, {
-						kind: 'constant',
-						value: NULLISH_VALUE,
-						primitive: undefined,
-					});
+					target.bindings.set(declaration.id.name, UNDEFINED_BINDING);
 				}
 			} else if (declarationKind === 'const' && FUNCTION_TYPES.has(initial?.type)) {
 				target.bindings.set(declaration.id.name, { kind: 'callback', node: initial, scope });
@@ -717,23 +947,16 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 					node: initial,
 					scope,
 				});
-			} else if (
-				declarationKind === 'const' &&
-				(initial?.type === 'ConditionalExpression' ||
-					initial?.type === 'LogicalExpression' ||
-					initial?.type === 'SequenceExpression') &&
-				synchronousCallbackExpression(initial, scope)
-			) {
-				target.bindings.set(declaration.id.name, {
-					kind: 'callback-choice',
-					node: initial,
-					scope,
-				});
 			} else if (declarationKind === 'const') {
-				const primitive = staticPrimitiveValue(initial, scope);
-				let value = staticExpressionValue(initial, scope);
+				const result = returnedExpression(initial, scope);
+				if (result.callback !== null) {
+					target.bindings.set(declaration.id.name, result.callback);
+					return;
+				}
+				const primitive = result.primitive;
+				let value = result.value;
 				if (value === UNKNOWN_VALUE && primitive !== UNKNOWN_PRIMITIVE) {
-					value = primitive == null ? NULLISH_VALUE : primitive ? TRUTHY_VALUE : FALSY_VALUE;
+					value = primitiveValueMask(primitive);
 				}
 				if (value !== UNKNOWN_VALUE) {
 					target.bindings.set(declaration.id.name, {
@@ -744,15 +967,20 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				}
 			}
 		}
+	}
+
+	function bindDeclaration(declaration, declarationKind, scope, phase) {
+		bindDeclarationValue(declaration, declarationKind, scope);
 		visit(declaration.init, scope, phase);
 		return visitPatternExpressions(declaration.id, scope, phaseAfter(declaration.init, phase));
 	}
 
-	function visitCallback(node, parentScope, phase) {
-		if (activeCallbacks.has(node)) return;
+	function visitCallback(node, parentScope, phase, args = null) {
+		// Calling a generator creates an iterator; its body has not run yet.
+		if (node.generator === true || activeCallbacks.has(node)) return;
 		activeCallbacks.add(node);
 		try {
-			visitFunction(node, parentScope, phase);
+			visitFunction(node, parentScope, phase, args);
 		} finally {
 			activeCallbacks.delete(node);
 		}
@@ -771,6 +999,10 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 
 	function staticPrimitiveValue(value, scope) {
 		const expression = unwrap(value);
+		if (expression?.type === 'CallExpression') {
+			const result = callResult(expression, scope);
+			return result === null ? UNKNOWN_PRIMITIVE : result.primitive;
+		}
 		if (expression?.type === 'Literal') return expression.value;
 		if (expression?.type === 'Identifier') {
 			const binding = resolve(scope, expression.name);
@@ -881,12 +1113,11 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 
 	function staticExpressionValue(value, scope) {
 		const expression = unwrap(value);
+		if (expression?.type === 'CallExpression') {
+			return callResult(expression, scope)?.value ?? UNKNOWN_VALUE;
+		}
 		if (expression?.type === 'Literal') {
-			return expression.value == null
-				? NULLISH_VALUE
-				: expression.value
-					? TRUTHY_VALUE
-					: FALSY_VALUE;
+			return primitiveValueMask(expression.value);
 		} else if (
 			FUNCTION_TYPES.has(expression?.type) ||
 			expression?.type === 'ObjectExpression' ||
@@ -901,19 +1132,14 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 				(expression.operator === '+' || expression.operator === '-' || expression.operator === '~'))
 		) {
 			const primitive = staticPrimitiveValue(expression, scope);
-			return primitive === UNKNOWN_PRIMITIVE
-				? UNKNOWN_VALUE
-				: primitive == null
-					? NULLISH_VALUE
-					: primitive
-						? TRUTHY_VALUE
-						: FALSY_VALUE;
+			return primitive === UNKNOWN_PRIMITIVE ? UNKNOWN_VALUE : primitiveValueMask(primitive);
 		} else if (expression?.type === 'Identifier') {
 			const binding = resolve(scope, expression.name);
-			if (binding == null && expression.name === 'undefined') return NULLISH_VALUE;
+			if (binding == null && expression.name === 'undefined') return UNDEFINED_VALUE;
 			if (binding?.kind === 'constant') return binding.value;
 			if (
 				binding?.kind === 'callback' ||
+				binding?.kind === 'effect-event' ||
 				binding?.kind === 'setter' ||
 				binding?.kind === 'ref' ||
 				binding?.kind === 'state-tuple' ||
@@ -923,7 +1149,8 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			) {
 				return TRUTHY_VALUE;
 			}
-			if (binding?.kind === 'callback-choice' || binding?.kind === 'linked-options') {
+			if (binding?.kind === 'callback-choice') return binding.value;
+			if (binding?.kind === 'linked-options') {
 				if (activeCallbacks.has(binding.node)) return UNKNOWN_VALUE;
 				activeCallbacks.add(binding.node);
 				try {
@@ -966,7 +1193,7 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 					: 0)
 			);
 		} else if (expression?.type === 'UnaryExpression' && expression.operator === 'void') {
-			return NULLISH_VALUE;
+			return UNDEFINED_VALUE;
 		} else if (expression?.type === 'UnaryExpression' && expression.operator === '!') {
 			const argument = staticExpressionValue(expression.argument, scope);
 			return (
@@ -1007,76 +1234,422 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 		return 3;
 	}
 
-	function visitSynchronousHookCallback(value, scope, phase) {
-		const callback = unwrap(value);
-		if (FUNCTION_TYPES.has(callback?.type)) {
-			visitCallback(callback, scope, phase);
-			return true;
-		} else if (callback?.type === 'SequenceExpression') {
-			const expressions = callback.expressions ?? [];
-			return visitSynchronousHookCallback(expressions[expressions.length - 1], scope, phase);
-		} else if (callback?.type === 'ConditionalExpression') {
-			const branches = conditionalExpressionBranches(callback, scope);
-			if ((branches & 1) !== 0) visitSynchronousHookCallback(callback.consequent, scope, phase);
-			if ((branches & 2) !== 0) visitSynchronousHookCallback(callback.alternate, scope, phase);
-			return true;
-		} else if (callback?.type === 'LogicalExpression') {
-			const branches = logicalExpressionBranches(callback, scope);
-			if ((branches & 1) !== 0 && callback.operator !== '&&') {
-				visitSynchronousHookCallback(callback.left, scope, phase);
+	function isCallableValue(value) {
+		return (
+			value?.kind === 'callback' ||
+			value?.kind === 'callback-choice' ||
+			value?.kind === 'effect-event' ||
+			value?.kind === 'setter'
+		);
+	}
+
+	function callableTruthiness(value) {
+		return value?.kind === 'callback-choice' ? value.value : TRUTHY_VALUE;
+	}
+
+	function callableChoice(values, value, complete) {
+		// Keep the truthiness of non-callable alternatives too. `complete` says
+		// there is no unknown callable alternative, which matters when this value
+		// is itself invoked as a factory and we inspect its return value.
+		const callbacks = [];
+		const seen = new Set();
+		const functions = new Map();
+		function add(callback) {
+			if (callback === null) return;
+			if (callback.kind === 'callback-choice') {
+				for (const child of callback.values) add(child);
+				return;
 			}
-			if ((branches & 2) !== 0) visitSynchronousHookCallback(callback.right, scope, phase);
-			return true;
-		} else if (callback?.type === 'Identifier') {
-			const binding = resolve(scope, callback.name);
-			if (binding?.kind === 'callback') visitCallback(binding.node, binding.scope, phase);
-			else if (binding?.kind === 'callback-choice') {
-				if (activeCallbacks.has(binding.node)) return true;
-				activeCallbacks.add(binding.node);
-				try {
-					visitSynchronousHookCallback(binding.node, binding.scope, phase);
-				} finally {
-					activeCallbacks.delete(binding.node);
-				}
-			} else if (binding?.kind === 'setter' && (phase === 'render' || phase === 'effect')) {
-				reportSetter(callback, phase);
+			if (callback.kind === 'callback') {
+				let scopes = functions.get(callback.node);
+				if (scopes?.has(callback.scope)) return;
+				if (scopes === undefined) functions.set(callback.node, (scopes = new Set()));
+				scopes.add(callback.scope);
+			} else {
+				const identity = callback.kind === 'setter' ? 'setter' : callback;
+				if (seen.has(identity)) return;
+				seen.add(identity);
 			}
-			return true;
-		} else if (stateTupleUpdater(callback, scope)) {
-			if (phase === 'render' || phase === 'effect') reportSetter(callback, phase);
-			return true;
+			callbacks.push(callback);
+		}
+		for (const callback of values) add(callback);
+		if (callbacks.length === 0) return null;
+		if (callbacks.length === 1 && value === TRUTHY_VALUE && complete) return callbacks[0];
+		return { kind: 'callback-choice', values: callbacks, value, complete };
+	}
+
+	function knownNonCallable(expression, scope) {
+		const node = unwrap(expression);
+		return (
+			staticPrimitiveValue(node, scope) !== UNKNOWN_PRIMITIVE ||
+			node?.type === 'ObjectExpression' ||
+			node?.type === 'ArrayExpression' ||
+			node?.type === 'ClassExpression' ||
+			(node?.type === 'Identifier' &&
+				(resolve(scope, node.name)?.kind === 'ref' ||
+					resolve(scope, node.name)?.kind === 'state-tuple'))
+		);
+	}
+
+	function returnedExpression(expression, scope) {
+		const node = unwrap(expression);
+		if (node?.type === 'CallExpression') {
+			const result = callResult(node, scope);
+			if (result !== null) return result;
+			return {
+				callback: null,
+				value: UNKNOWN_VALUE,
+				primitive: UNKNOWN_PRIMITIVE,
+				complete: false,
+			};
+		}
+		const callback = callableValue(expression, scope);
+		return {
+			callback,
+			value:
+				expression == null
+					? UNDEFINED_VALUE
+					: callback === null
+						? staticExpressionValue(expression, scope)
+						: callableTruthiness(callback),
+			primitive: expression == null ? undefined : staticPrimitiveValue(expression, scope),
+			complete:
+				callback === null
+					? expression == null || knownNonCallable(expression, scope)
+					: callback.kind !== 'callback-choice' || callback.complete,
+		};
+	}
+
+	// Values and execution are separate. In particular, useMemo executes its
+	// factory now, but a function returned by that factory is only a value.
+	function callableValue(expression, scope) {
+		const node = unwrap(expression);
+		if (FUNCTION_TYPES.has(node?.type)) return { kind: 'callback', node, scope };
+		if (node?.type === 'Identifier') {
+			const binding = resolve(scope, node.name);
+			return isCallableValue(binding) ? binding : null;
+		}
+		if (stateTupleUpdater(node, scope)) return { kind: 'setter' };
+		if (node?.type === 'SequenceExpression') {
+			return callableValue(node.expressions?.[node.expressions.length - 1], scope);
+		}
+		if (node?.type === 'ConditionalExpression' || node?.type === 'LogicalExpression') {
+			const logical = node.type === 'LogicalExpression';
+			const branches = logical
+				? logicalExpressionBranches(node, scope)
+				: conditionalExpressionBranches(node, scope);
+			const values = [];
+			if ((branches & 1) !== 0) {
+				values.push(
+					logical && node.operator === '&&'
+						? { callback: null, complete: true }
+						: returnedExpression(logical ? node.left : node.consequent, scope),
+				);
+			}
+			if ((branches & 2) !== 0) {
+				values.push(returnedExpression(logical ? node.right : node.alternate, scope));
+			}
+			return callableChoice(
+				values.map((value) => value.callback),
+				staticExpressionValue(node, scope),
+				values.every((value) => value.complete),
+			);
+		}
+		return node?.type === 'CallExpression' ? (callResult(node, scope)?.callback ?? null) : null;
+	}
+
+	function optionalCallCanSkip(node, scope) {
+		let current = node;
+		while (current != null) {
+			if (current.type === 'ChainExpression') return false;
+			if (TRANSPARENT_EXPRESSIONS.has(current.type)) {
+				current = current.expression;
+				continue;
+			}
+			if (current.type !== 'CallExpression' && current.type !== 'MemberExpression') return false;
+			const target = current.type === 'CallExpression' ? current.callee : current.object;
+			if (
+				current.optional === true &&
+				(staticExpressionValue(target, scope) & NULLISH_VALUE) !== 0
+			) {
+				return true;
+			}
+			current = target;
 		}
 		return false;
 	}
 
-	function synchronousCallbackExpression(value, scope) {
-		const callback = unwrap(value);
-		if (FUNCTION_TYPES.has(callback?.type) || stateTupleUpdater(callback, scope)) return true;
-		if (callback?.type === 'Identifier') {
-			const kind = resolve(scope, callback.name)?.kind;
-			return kind === 'callback' || kind === 'callback-choice' || kind === 'setter';
+	function callResult(node, scope) {
+		const revision = scopeRevision(scope);
+		let cached = callResults.get(scope);
+		const previous = cached?.get(node);
+		if (previous?.revision === revision) return previous.result;
+		const cycles = returnCycles;
+		const result = resolveCallResult(node, scope);
+		// A call result belongs to this source call and lexical activation, not
+		// merely its function AST. Ancestor bindings can become known later in a
+		// statement list; a shared monotonic clock invalidates exactly those
+		// results without invalidating callers when a new child scope is built.
+		if (cycles === returnCycles && revision === scopeRevision(scope)) {
+			if (cached === undefined) callResults.set(scope, (cached = new WeakMap()));
+			cached.set(node, { revision, result });
 		}
-		if (callback?.type === 'SequenceExpression') {
-			const expressions = callback.expressions ?? [];
-			return synchronousCallbackExpression(expressions[expressions.length - 1], scope);
+		return result;
+	}
+
+	function resolveCallResult(node, scope) {
+		const hook = importedHook(node.callee, scope);
+		let result;
+		if (hook === 'useCallback') {
+			result = returnedExpression(node.arguments?.[0], scope);
+		} else if (hook === 'useEffectEvent') {
+			result = {
+				callback: { kind: 'effect-event', callback: callableValue(node.arguments?.[0], scope) },
+				value: TRUTHY_VALUE,
+				primitive: UNKNOWN_PRIMITIVE,
+				complete: true,
+			};
+		} else if (hook === 'useMemo') {
+			// Octane's client invokes a memo factory with positional dependencies;
+			// SSR does not. Do not invent arguments for a parameterized hook factory.
+			result = returnedCallable(callableValue(node.arguments?.[0], scope), null);
+		} else {
+			if (hook !== null) return null;
+			const callback = callableValue(node.callee, scope);
+			if (callback === null) return null;
+			result = returnedCallable(callback, argumentValues(node.arguments, scope));
 		}
-		if (callback?.type === 'ConditionalExpression') {
-			const branches = conditionalExpressionBranches(callback, scope);
-			return (
-				((branches & 1) !== 0 && synchronousCallbackExpression(callback.consequent, scope)) ||
-				((branches & 2) !== 0 && synchronousCallbackExpression(callback.alternate, scope))
-			);
+		if (result === null) return null;
+		if (!optionalCallCanSkip(node, scope)) return result;
+		const value = result.value | UNDEFINED_VALUE;
+		return {
+			callback: callableChoice([result.callback], value, result.complete),
+			value,
+			primitive: result.primitive === undefined ? undefined : UNKNOWN_PRIMITIVE,
+			complete: result.complete,
+		};
+	}
+
+	function expressionBinding(expression, scope) {
+		const node = unwrap(expression);
+		if (node?.type === 'Identifier') {
+			const binding = resolve(scope, node.name);
+			if (
+				isCallableValue(binding) ||
+				binding?.kind === 'ref' ||
+				binding?.kind === 'state-tuple' ||
+				binding?.kind === 'constant' ||
+				binding?.kind === 'linked-key'
+			) {
+				return binding;
+			}
 		}
-		if (callback?.type === 'LogicalExpression') {
-			const branches = logicalExpressionBranches(callback, scope);
-			return (
-				((branches & 1) !== 0 &&
-					callback.operator !== '&&' &&
-					synchronousCallbackExpression(callback.left, scope)) ||
-				((branches & 2) !== 0 && synchronousCallbackExpression(callback.right, scope))
-			);
+		const result = returnedExpression(node, scope);
+		if (result.callback !== null) return result.callback;
+		return result.value === UNKNOWN_VALUE && result.primitive === UNKNOWN_PRIMITIVE
+			? OTHER_BINDING
+			: { kind: 'constant', primitive: result.primitive, value: result.value };
+	}
+
+	function argumentValues(args, scope) {
+		if (args?.some((argument) => argument.type === 'SpreadElement')) return null;
+		return (args ?? []).map((argument) => expressionBinding(argument, scope));
+	}
+
+	function mergePrimitive(left, right) {
+		return left === NO_RETURN_VALUE || Object.is(left, right) ? right : UNKNOWN_PRIMITIVE;
+	}
+
+	function returnedCallable(value, args) {
+		if (value?.kind === 'effect-event') return returnedCallable(value.callback, args);
+		if (value?.kind === 'callback-choice') {
+			if (!value.complete) return null;
+			const results = value.values.map((callback) => returnedCallable(callback, args));
+			if (results.some((result) => result === null)) return null;
+			const truthiness = results.reduce((mask, result) => mask | result.value, 0);
+			const complete = results.every((result) => result.complete);
+			return {
+				callback: callableChoice(
+					results.map((result) => result.callback),
+					truthiness,
+					complete,
+				),
+				value: truthiness,
+				primitive: results.reduce(
+					(primitive, result) => mergePrimitive(primitive, result.primitive),
+					NO_RETURN_VALUE,
+				),
+				complete,
+			};
 		}
-		return false;
+		if (value?.kind !== 'callback') return null;
+		const node = value.node;
+		if (activeReturnCallbacks.has(node)) {
+			returnCycles++;
+			return null;
+		}
+		if (
+			node.async === true ||
+			node.generator === true ||
+			(args === null && (node.params?.length ?? 0) !== 0) ||
+			(node.params ?? []).some((parameter) => parameter.type !== 'Identifier')
+		) {
+			return null;
+		}
+		activeReturnCallbacks.add(node);
+		try {
+			// Each call owns its parameter environment. Caching by function AST
+			// would conflate make(setState) with make(noop).
+			const scope = createFunctionScope(node, value.scope, args);
+			if (node.body?.type !== 'BlockStatement') return returnedExpression(node.body, scope);
+			const result = factoryReturns(node.body.body, scope);
+			if (result === null) return null;
+			const truthiness = result.value | (result.fallsThrough ? UNDEFINED_VALUE : 0);
+			const primitive = result.fallsThrough
+				? mergePrimitive(result.primitive, undefined)
+				: result.primitive;
+			return {
+				callback: callableChoice(result.callbacks, truthiness, result.complete),
+				value: truthiness,
+				primitive: primitive === NO_RETURN_VALUE ? UNKNOWN_PRIMITIVE : primitive,
+				complete: result.complete,
+			};
+		} finally {
+			activeReturnCallbacks.delete(node);
+		}
+	}
+
+	function factoryReturns(statements, scope) {
+		const result = {
+			callbacks: [],
+			value: 0,
+			primitive: NO_RETURN_VALUE,
+			complete: true,
+			fallsThrough: true,
+		};
+		function merge(branch) {
+			result.callbacks.push(...branch.callbacks);
+			result.value |= branch.value;
+			if (branch.primitive !== NO_RETURN_VALUE) {
+				result.primitive = mergePrimitive(result.primitive, branch.primitive);
+			}
+			result.complete &&= branch.complete;
+		}
+		for (const statement of statements ?? []) {
+			if (!result.fallsThrough) break;
+			switch (statement.type) {
+				case 'EmptyStatement':
+				case 'FunctionDeclaration':
+					break;
+				case 'VariableDeclaration':
+					if (statement.kind !== 'const') return null;
+					for (const declaration of statement.declarations ?? []) {
+						bindDeclarationValue(declaration, statement.kind, scope);
+					}
+					break;
+				case 'ReturnStatement': {
+					const returned = returnedExpression(statement.argument, scope);
+					if (returned.callback !== null) result.callbacks.push(returned.callback);
+					result.value |= statement.argument == null ? UNDEFINED_VALUE : returned.value;
+					result.primitive = mergePrimitive(result.primitive, returned.primitive);
+					result.complete &&= returned.complete;
+					result.fallsThrough = false;
+					break;
+				}
+				case 'ThrowStatement':
+					result.fallsThrough = false;
+					break;
+				case 'BlockStatement': {
+					const block = createScope(scope, 'block', statement.body);
+					const branch = factoryReturns(statement.body, block);
+					if (branch === null) return null;
+					merge(branch);
+					result.fallsThrough = branch.fallsThrough;
+					break;
+				}
+				case 'IfStatement': {
+					const branches = conditionalExpressionBranches(statement, scope);
+					let fallsThrough = false;
+					let exits = false;
+					for (const [flag, child] of [
+						[1, statement.consequent],
+						[2, statement.alternate],
+					]) {
+						if ((branches & flag) === 0) continue;
+						const branch = factoryReturns(child == null ? [] : [child], scope);
+						if (branch === null) return null;
+						merge(branch);
+						fallsThrough ||= branch.fallsThrough;
+						exits ||= !branch.fallsThrough;
+					}
+					// Continuing only one unknown branch requires path predicates in
+					// every returned closure. Do not invent an impossible later return.
+					if (fallsThrough && exits) return null;
+					result.fallsThrough = fallsThrough;
+					break;
+				}
+				case 'ExpressionStatement':
+					if (typeof statement.directive === 'string') break;
+					return null;
+				default:
+					// Loops, mutations, and try/finally need a fuller completion model.
+					// An unknown result is safer than inventing an overridden return.
+					return null;
+			}
+		}
+		return result;
+	}
+
+	function visitCallable(value, origin, phase, args = null) {
+		if (value?.kind === 'callback') {
+			visitCallback(value.node, value.scope, phase, args);
+		} else if (value?.kind === 'callback-choice') {
+			for (const callback of value.values) visitCallable(callback, origin, phase, args);
+		} else if (value?.kind === 'effect-event') {
+			if (phase === 'render') reportEffectEventCall(origin);
+			else if (phase === 'effect') visitCallable(value.callback, origin, phase, args);
+		} else if (value?.kind === 'setter' && (phase === 'render' || phase === 'effect')) {
+			reportSetter(origin, phase);
+		}
+	}
+
+	function visitSynchronousHookCallback(value, scope, phase) {
+		visitCallable(callableValue(value, scope), unwrap(value), phase);
+	}
+
+	function containsEffectEvent(value) {
+		return (
+			value?.kind === 'effect-event' ||
+			(value?.kind === 'callback-choice' && value.values.some(containsEffectEvent))
+		);
+	}
+
+	function visitExplicitDependencies(value, scope) {
+		const node = unwrap(value);
+		if (node?.type === 'ArrayExpression') {
+			for (const element of node.elements ?? []) {
+				if (element?.type === 'SpreadElement') {
+					visitExplicitDependencies(element.argument, scope);
+				} else if (containsEffectEvent(callableValue(element, scope))) {
+					report(
+						STRONG_EFFECT_EVENT_DEPENDENCY,
+						unwrap(element),
+						'Strong mode does not allow Effect Events in explicit hook dependency arrays. Effect Events are non-reactive; remove this dependency.',
+					);
+				}
+			}
+		} else if (node?.type === 'SequenceExpression') {
+			visitExplicitDependencies(node.expressions?.[node.expressions.length - 1], scope);
+		} else if (node?.type === 'ConditionalExpression' || node?.type === 'LogicalExpression') {
+			const logical = node.type === 'LogicalExpression';
+			const branches = logical
+				? logicalExpressionBranches(node, scope)
+				: conditionalExpressionBranches(node, scope);
+			if ((branches & 1) !== 0)
+				visitExplicitDependencies(logical ? node.left : node.consequent, scope);
+			if ((branches & 2) !== 0)
+				visitExplicitDependencies(logical ? node.right : node.alternate, scope);
+		}
 	}
 
 	function linkedStateComparatorName(property, scope) {
@@ -1240,18 +1813,25 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			case 'IfStatement': {
 				visit(node.test, scope, phase);
 				const branchPhase = phaseAfter(node.test, phase);
-				visit(node.consequent, scope, branchPhase);
-				visit(node.alternate, scope, branchPhase);
+				const branches = conditionalExpressionBranches(node, scope);
+				if ((branches & 1) !== 0) visit(node.consequent, scope, branchPhase);
+				if ((branches & 2) !== 0) visit(node.alternate, scope, branchPhase);
 				return;
 			}
 			case 'ConditionalExpression': {
 				visit(node.test, scope, phase);
 				const branchPhase = phaseAfter(node.test, phase);
-				visit(node.consequent, scope, branchPhase);
-				visit(node.alternate, scope, branchPhase);
+				const branches = conditionalExpressionBranches(node, scope);
+				if ((branches & 1) !== 0) visit(node.consequent, scope, branchPhase);
+				if ((branches & 2) !== 0) visit(node.alternate, scope, branchPhase);
 				return;
 			}
 			case 'LogicalExpression':
+				visit(node.left, scope, phase);
+				if ((logicalExpressionBranches(node, scope) & 2) !== 0) {
+					visit(node.right, scope, phaseAfter(node.left, phase));
+				}
+				return;
 			case 'BinaryExpression':
 				visit(node.left, scope, phase);
 				visit(node.right, scope, phaseAfter(node.left, phase));
@@ -1347,8 +1927,6 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 			case 'CallExpression': {
 				const hook = importedHook(node.callee, scope);
 				const callee = unwrap(node.callee);
-				const calleeBinding = callee?.type === 'Identifier' ? resolve(scope, callee.name) : null;
-				const tupleUpdater = stateTupleUpdater(callee, scope);
 				if (!FUNCTION_TYPES.has(callee?.type)) {
 					visit(node.callee, scope, phase);
 				}
@@ -1368,11 +1946,19 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 					}
 					executionPhase = phaseAfter(argument, executionPhase);
 				}
+				const dependencyIndex =
+					hook === 'useImperativeHandle'
+						? 2
+						: EFFECT_HOOKS.has(hook) || hook === 'useMemo' || hook === 'useCallback'
+							? 1
+							: -1;
 				if (
-					(executionPhase === 'render' || executionPhase === 'effect') &&
-					(calleeBinding?.kind === 'setter' || tupleUpdater)
+					dependencyIndex !== -1 &&
+					!node.arguments
+						?.slice(0, dependencyIndex + 1)
+						.some((argument) => argument.type === 'SpreadElement')
 				) {
-					reportSetter(callee, executionPhase);
+					visitExplicitDependencies(node.arguments?.[dependencyIndex], scope);
 				}
 				if (EFFECT_HOOKS.has(hook)) {
 					visitSynchronousHookCallback(node.arguments?.[0], scope, 'effect');
@@ -1391,21 +1977,20 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 					visitLinkedStateComparators(node.arguments?.[2], scope, executionPhase);
 					return;
 				}
-				if (FUNCTION_TYPES.has(callee?.type)) {
-					visitCallback(callee, scope, executionPhase);
-				} else if (
-					(executionPhase === 'render' || executionPhase === 'effect') &&
-					calleeBinding?.kind === 'callback'
+				if (
+					executionPhase === 'render' ||
+					executionPhase === 'effect' ||
+					FUNCTION_TYPES.has(callee?.type)
 				) {
-					visitCallback(calleeBinding.node, calleeBinding.scope, executionPhase);
-				} else if (
-					(executionPhase === 'render' || executionPhase === 'effect') &&
-					(calleeBinding?.kind === 'callback-choice' ||
-						callee?.type === 'SequenceExpression' ||
-						callee?.type === 'ConditionalExpression' ||
-						callee?.type === 'LogicalExpression')
-				) {
-					visitSynchronousHookCallback(callee, scope, executionPhase);
+					const callback = callableValue(callee, scope);
+					if (callback !== null) {
+						visitCallable(
+							callback,
+							callee,
+							executionPhase,
+							callback.kind === 'setter' ? null : argumentValues(node.arguments, scope),
+						);
+					}
 				}
 				return;
 			}
@@ -1423,7 +2008,7 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 					phaseAfter(node.callee, phase),
 				);
 				if (inlineConstructor) {
-					visitCallback(callee, scope, executionPhase);
+					visitCallback(callee, scope, executionPhase, argumentValues(node.arguments, scope));
 				} else if (
 					(executionPhase === 'render' || executionPhase === 'effect') &&
 					binding?.kind === 'callback' &&
@@ -1432,29 +2017,38 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 					binding.node.async !== true &&
 					binding.node.generator !== true
 				) {
-					visitCallback(binding.node, binding.scope, executionPhase);
+					visitCallback(
+						binding.node,
+						binding.scope,
+						executionPhase,
+						argumentValues(node.arguments, scope),
+					);
 				}
 				return;
 			}
 			case 'TaggedTemplateExpression': {
 				const tag = unwrap(node.tag);
-				const binding = tag?.type === 'Identifier' ? resolve(scope, tag.name) : null;
 				if (!FUNCTION_TYPES.has(tag?.type)) visit(node.tag, scope, phase);
 				const tagPhase = phaseAfter(node.tag, phase, true);
 				visit(node.quasi, scope, tagPhase);
 				const executionPhase = phaseAfter(node.quasi, tagPhase);
 				if (
-					(executionPhase === 'render' || executionPhase === 'effect') &&
-					binding?.kind === 'setter'
+					executionPhase === 'render' ||
+					executionPhase === 'effect' ||
+					FUNCTION_TYPES.has(tag?.type)
 				) {
-					reportSetter(tag, executionPhase);
-				} else if (FUNCTION_TYPES.has(tag?.type)) {
-					visitCallback(tag, scope, executionPhase);
-				} else if (
-					(executionPhase === 'render' || executionPhase === 'effect') &&
-					binding?.kind === 'callback'
-				) {
-					visitCallback(binding.node, binding.scope, executionPhase);
+					const substitutions = argumentValues(node.quasi?.expressions, scope);
+					visitCallable(
+						callableValue(tag, scope),
+						tag,
+						executionPhase,
+						substitutions === null
+							? null
+							: [
+									{ kind: 'constant', value: TRUTHY_VALUE, primitive: UNKNOWN_PRIMITIVE },
+									...substitutions,
+								],
+					);
 				}
 				return;
 			}
@@ -1486,7 +2080,7 @@ export function analyzeStrongMode(ast, source, filename, options = {}) {
 					const target = declarationScope(loop, node.init.kind);
 					const binding = { kind: 'other' };
 					for (const declaration of node.init.declarations ?? []) {
-						addPatternNames(declaration.id, target.bindings, binding);
+						addPatternNames(declaration.id, target.bindings, binding, node.init.kind !== 'var');
 					}
 				}
 				let executionPhase = phase;

--- a/packages/octane/tests/compiler/strong-mode.test.ts
+++ b/packages/octane/tests/compiler/strong-mode.test.ts
@@ -6,6 +6,8 @@ import { compileToVolarMappings } from '../../src/compiler/volar.js';
 const RENDER_STATE_UPDATE = 'OCTANE_STRONG_RENDER_STATE_UPDATE';
 const EFFECT_STATE_UPDATE = 'OCTANE_STRONG_EFFECT_STATE_UPDATE';
 const RENDER_REF_WRITE = 'OCTANE_STRONG_RENDER_REF_WRITE';
+const RENDER_EFFECT_EVENT_CALL = 'OCTANE_STRONG_RENDER_EFFECT_EVENT_CALL';
+const EFFECT_EVENT_DEPENDENCY = 'OCTANE_STRONG_EFFECT_EVENT_DEPENDENCY';
 const DIRECTIVE_PLACEMENT = 'OCTANE_STRONG_DIRECTIVE_PLACEMENT';
 
 function stateComponent(setup: string, imports = 'useState'): string {
@@ -2742,5 +2744,697 @@ export function useCounter() {
 		expect(
 			compileToVolarMappings(source, '/src/Counter.tsrx', { strong: true } as any).diagnostics,
 		).toContainEqual(expect.objectContaining({ code: RENDER_STATE_UPDATE, severity: 'error' }));
+	});
+});
+
+describe('Strong mode returned callbacks and Effect Events', () => {
+	const imports =
+		'useState, useRef, useCallback, useMemo, useEffectEvent, useEffect, useLayoutEffect, useInsertionEffect, useImperativeHandle';
+
+	function component(setup: string, hookImports = imports): string {
+		return `import { ${hookImports} } from 'octane';
+export function App(props) @{
+  const [count, setCount] = useState(0);
+  const ref = useRef(0);
+  ${setup}
+  <button onClick={() => setCount(count + 1)}>{count as string}</button>
+}`;
+	}
+
+	it.each([
+		['useCallback result', 'const update = useCallback(() => setCount(1), []); update();'],
+		['memoized setter', 'const update = useCallback(setCount, []); update(1);'],
+		['immediately called useCallback result', 'useCallback(() => setCount(1), [])();'],
+		[
+			'immutable callback aliases',
+			'const update = useCallback(() => setCount(1), []); const alias = update; alias();',
+		],
+		[
+			'local callback helpers',
+			'const update = useCallback(() => setCount(1), []); function apply() { update(); } apply();',
+		],
+		[
+			'conditional callback choices',
+			'const update = useCallback(() => setCount(1), []); const selected = props.enabled ? update : () => {}; selected();',
+		],
+		['useMemo result', 'const update = useMemo(() => () => setCount(1), []); update();'],
+		['memo-returned setter', 'const update = useMemo(() => setCount, []); update(1);'],
+		[
+			'named memo factories',
+			'function makeUpdate() { return () => setCount(1); } const update = useMemo(makeUpdate, []); update();',
+		],
+		[
+			'block-bodied memo factories',
+			'const update = useMemo(() => { const apply = () => setCount(1); return apply; }, []); update();',
+		],
+		[
+			'conditionally returned callbacks',
+			'const update = useMemo(() => props.enabled ? () => setCount(1) : () => {}, [props.enabled]); update();',
+		],
+		[
+			'factory parameters receiving a setter',
+			'function makeUpdate(apply) { return () => apply(1); } const update = useMemo(() => makeUpdate(setCount), []); update();',
+		],
+	])('rejects render state updates through %s', (_label, setup) => {
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).toThrow(
+			RENDER_STATE_UPDATE,
+		);
+	});
+
+	it.each([
+		['useCallback', 'useCallback(() => setCount(1), [])'],
+		['useEffectEvent', 'useEffectEvent(() => setCount(1))'],
+		['useMemo returned callback', 'useMemo(() => () => setCount(1), [])'],
+	])('rejects synchronous effect updates through %s', (_label, initializer) => {
+		for (const effect of ['useEffect', 'useLayoutEffect', 'useInsertionEffect']) {
+			for (const callback of ['() => update()', 'update']) {
+				const setup = `const update = ${initializer}; ${effect}(${callback}, []);`;
+				expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).toThrow(
+					EFFECT_STATE_UPDATE,
+				);
+			}
+		}
+	});
+
+	it.each([
+		[
+			'aliased callback imports',
+			'useState, useRef, useCallback as callback, useEffect as effect',
+			'const update = callback(() => setCount(1), []); const alias = update; effect(alias, []);',
+		],
+		[
+			'aliased Effect Event imports',
+			'useState, useRef, useEffectEvent as effectEvent, useEffect as effect',
+			'const update = effectEvent(() => setCount(1)); function apply() { update(); } effect(apply, []);',
+		],
+		[
+			'aliased memo imports',
+			'useState, useRef, useMemo as memo, useEffect as effect',
+			'const update = memo(() => () => setCount(1), []); const selected = props.enabled ? update : () => {}; effect(selected, []);',
+		],
+	])('recognizes synchronous effect updates through %s', (_label, hookImports, setup) => {
+		expect(() =>
+			compile(`"use strong";\n${component(setup, hookImports)}`, '/src/App.tsrx'),
+		).toThrow(EFFECT_STATE_UPDATE);
+	});
+
+	it('recognizes returned callbacks from namespace hook imports', () => {
+		const source = `"use strong";
+import * as Octane from 'octane';
+export function App(props) @{
+  const [, setCount] = Octane.useState(0);
+  const update = Octane['useCallback' as const](() => setCount(1), []);
+  const selected = props.enabled ? update : () => {};
+  Octane.useEffect(selected, []);
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(EFFECT_STATE_UPDATE);
+	});
+
+	it.each([
+		['useCallback', 'useCallback(() => { ref.current = 1; }, [])'],
+		['useMemo returned callback', 'useMemo(() => () => { ref.current = 1; }, [])'],
+	])('rejects render ref writes through %s', (_label, initializer) => {
+		const setup = `const write = ${initializer}; const alias = write; alias();`;
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).toThrow(
+			RENDER_REF_WRITE,
+		);
+	});
+
+	it.each([
+		['direct calls', 'const read = useEffectEvent(() => count); read();'],
+		['immediate hook results', 'useEffectEvent(() => count)();'],
+		['immutable aliases', 'const read = useEffectEvent(() => count); const alias = read; alias();'],
+		[
+			'local helpers',
+			'const read = useEffectEvent(() => count); function readNow() { return read(); } readNow();',
+		],
+		[
+			'conditional choices',
+			'const read = useEffectEvent(() => count); const selected = props.enabled ? read : () => count; selected();',
+		],
+		['memo factories', 'const read = useEffectEvent(() => count); useMemo(read, []);'],
+		['state initializers', 'const read = useEffectEvent(() => count); useState(read);'],
+		[
+			'memoized Effect Events',
+			'const read = useEffectEvent(() => count); const alias = useCallback(read, []); alias();',
+		],
+	])('rejects render-time Effect Event invocation through %s', (_label, setup) => {
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).toThrow(
+			RENDER_EFFECT_EVENT_CALL,
+		);
+	});
+
+	it.each([
+		['useEffect', 'useEffect(() => {}, [event]);'],
+		['useLayoutEffect', 'useLayoutEffect(() => {}, [event]);'],
+		['useInsertionEffect', 'useInsertionEffect(() => {}, [event]);'],
+		['useMemo', 'useMemo(() => count, [event]);'],
+		['useCallback', 'useCallback(() => count, [event]);'],
+		['useImperativeHandle', 'useImperativeHandle(props.handle, () => ({}), [event]);'],
+	])('rejects explicit Effect Event dependencies in %s', (_label, hook) => {
+		const setup = `const event = useEffectEvent(() => count); ${hook}`;
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).toThrow(
+			EFFECT_EVENT_DEPENDENCY,
+		);
+	});
+
+	it('recognizes aliases and namespace imports in Effect Event dependencies', () => {
+		const source = `"use strong";
+import { useEffectEvent as effectEvent } from 'octane';
+import * as Octane from 'octane';
+export function App(props) @{
+  const event = effectEvent(() => props.value);
+  const alias = event;
+  Octane['useLayoutEffect' as const](() => {}, [alias as typeof alias]);
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).toThrow(EFFECT_EVENT_DEPENDENCY);
+	});
+
+	it('keeps callback creation, event handlers, cleanup, and deferred invocation legal', () => {
+		const source = `"use strong";
+import { ${imports} } from 'octane';
+export function App(props) @{
+  const [count, setCount] = useState(0);
+  const ref = useRef(0);
+  const update = useCallback(() => setCount(count + 1), [count]);
+  const event = useEffectEvent(() => setCount(count + 1));
+  const memoized = useMemo(() => () => setCount(count + 1), [count]);
+  useEffect(() => {
+    setTimeout(update, 0);
+    Promise.resolve().then(event);
+    queueMicrotask(memoized);
+    return () => { update(); event(); memoized(); };
+  }, []);
+  useLayoutEffect(() => { ref.current = count; }, [count]);
+  <button ref={props.buttonRef} onClick={event}>{count as string}</button>
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('keeps returned callbacks legal after asynchronous work has yielded', () => {
+		const setup = `const update = useCallback(() => setCount(1), []);
+  const event = useEffectEvent(() => setCount(1));
+  const memoized = useMemo(() => () => setCount(1), []);
+  (async () => { await Promise.resolve(); update(); event(); memoized(); })();
+  useEffect(() => {
+    (async () => { await Promise.resolve(); update(); event(); memoized(); })();
+  }, []);`;
+
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('does not execute a memo-returned callback until the result is invoked', () => {
+		const setup = `function makeUpdate(apply) { return () => apply(1); }
+  const update = useMemo(() => makeUpdate(setCount), []);
+  const event = useEffectEvent(update);
+  useEffect(() => () => event(), []);`;
+
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it.each([
+		[
+			'separate factory captures',
+			`function makeUpdate(apply) { return () => apply(1); }
+  const deferred = useMemo(() => makeUpdate(setCount), []);
+  const safe = useMemo(() => makeUpdate(() => {}), []);
+  safe();
+  useEffect(() => deferred, []);`,
+		],
+		[
+			'reassigned factory parameters',
+			`function makeUpdate(apply) { apply = () => {}; return () => apply(1); }
+  const safe = useMemo(() => makeUpdate(setCount), []);
+  safe();`,
+		],
+		[
+			'overridden factory returns',
+			`const safe = useMemo(() => {
+    try { return () => setCount(1); }
+    finally { return () => {}; }
+  }, []);
+  safe();`,
+		],
+		[
+			'asynchronous factory results',
+			`const pending = useMemo(async () => () => setCount(1), []);
+  useEffect(() => { pending.then((update) => update()); }, []);`,
+		],
+		[
+			'generator factory results',
+			`const iterator = useMemo(function* () { return () => setCount(1); }, []);
+  useEffect(() => () => { iterator.next().value?.(); }, []);`,
+		],
+	])('does not invent synchronous writes from %s', (_label, setup) => {
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('keeps shadowed hooks and opaque callback results legal', () => {
+		const source = `"use strong";
+import { useState, useRef, useMemo, useEffect, useEffectEvent as octaneEvent } from 'octane';
+import { makeCallback } from './external';
+function useCallback(callback) { return () => {}; }
+function useEffectEvent(callback) { return () => {}; }
+export function App(props) @{
+  const [, setCount] = useState(0);
+  const ref = useRef(0);
+  const ignored = useCallback(() => setCount(1));
+  const unrelated = useEffectEvent(() => { ref.current = 1; });
+  ignored();
+  unrelated();
+  const external = useMemo(props.makeCallback, []);
+  const unknown = makeCallback(() => setCount(1));
+  external();
+  unknown();
+  function makeUpdate(setCount) { return () => setCount(1); }
+  const safe = useMemo(() => makeUpdate(props.onUpdate), [props.onUpdate]);
+  safe();
+  const event = octaneEvent(() => props.value);
+  useEffect(() => { props.register(event); }, props.dependencies);
+  <div />
+}`;
+
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('keeps inferred dependencies, ordinary callbacks, and deferred ref writes legal', () => {
+		const setup = `const event = useEffectEvent(() => count);
+  const callback = useCallback(() => props.value, [props.value]);
+  const write = useMemo(() => () => { ref.current = count; }, [count]);
+  useEffect(() => { props.register(event); });
+  useEffect(() => { write(); }, [callback]);
+  useMemo(() => callback, [callback]);`;
+
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it.each([
+		['a return', 'const update = useCallback(() => { return; setCount(1); }, []); update();'],
+		[
+			'a false branch',
+			'const update = useCallback(() => { if (false) setCount(1); }, []); update();',
+		],
+		['short-circuiting', 'const update = useCallback(() => false && setCount(1), []); update();'],
+	])('does not report callback writes made unreachable by %s', (_label, setup) => {
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it.each([
+		['a later return', 'const update = useCallback(() => { setCount(1); return; }, []); update();'],
+		[
+			'a possible branch',
+			'const update = useCallback(() => { if (props.enabled) setCount(1); }, []); update();',
+		],
+		['a true operand', 'const update = useCallback(() => true && setCount(1), []); update();'],
+	])('still reports callback writes reachable before %s', (_label, setup) => {
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).toThrow(
+			RENDER_STATE_UPDATE,
+		);
+	});
+
+	it.each([
+		[
+			'reassigned function declarations',
+			'function update() { setCount(1); } update = () => {}; update();',
+		],
+		[
+			'initialized function/var redeclarations',
+			'function run() { function update() { setCount(1); } var update = () => {}; update(); } run();',
+		],
+		[
+			'reassigned call parameters',
+			'function invoke(apply) { apply = () => {}; apply(); } invoke(setCount);',
+		],
+		[
+			'parameter/function redeclarations',
+			'function invoke(apply) { function apply() {} apply(); } invoke(setCount);',
+		],
+		[
+			'for-of writes to a function',
+			'function update() { setCount(1); } for (update of [() => {}]) {} update();',
+		],
+		[
+			'for-of var writes to a parameter',
+			'function invoke(apply) { for (var apply of [() => {}]) {} apply(); } invoke(setCount);',
+		],
+	])('does not retain stale callable proofs across %s', (_label, setup) => {
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it.each([
+		[
+			'uninitialized block vars sharing a parameter',
+			'function invoke(apply) { { var apply; } apply(1); } invoke(setCount);',
+		],
+		[
+			'uninitialized vars sharing a function declaration',
+			'function run() { function update() { setCount(1); } var update; update(); } run();',
+		],
+		[
+			'writes to a shadowing iteration binding',
+			'function invoke(apply) { for (let apply of [() => {}]) { apply = () => {}; } apply(1); } invoke(setCount);',
+		],
+		[
+			'writes to a shadowing block binding',
+			'function update() { setCount(1); } { let update = () => {}; update = () => {}; } update();',
+		],
+	])('preserves callable proofs through %s', (_label, setup) => {
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).toThrow(
+			RENDER_STATE_UPDATE,
+		);
+	});
+
+	it("follows conditional factory returns using each call's arguments", () => {
+		const make = `function make(enabled, apply) {
+    if (enabled) return () => apply(1);
+    return () => {};
+  }`;
+		const unsafe = `${make} const update = useMemo(() => make(true, setCount), []); update();`;
+		const safe = `${make} const update = useMemo(() => make(false, setCount), []); update();`;
+
+		expect(() => compile(`"use strong";\n${component(unsafe)}`, '/src/App.tsrx')).toThrow(
+			RENDER_STATE_UPDATE,
+		);
+		expect(() => compile(`"use strong";\n${component(safe)}`, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('keeps the fallback of an optional factory call reachable', () => {
+		const setup = `const factory = props.enabled ? () => () => {} : null;
+  const selected = factory?.();
+  const update = selected ?? setCount;
+  update(1);`;
+
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).toThrow(
+			RENDER_STATE_UPDATE,
+		);
+	});
+
+	it('preserves a known non-callable memo result when selecting a callback', () => {
+		const setup = `const disabled = useMemo(() => false, []);
+  const update = useCallback(disabled ? setCount : () => {}, []);
+  update(1);`;
+
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('respects function-hoisted vars that shadow an outer setter', () => {
+		const setup = `const outer = setCount;
+  function make() {
+    if (false) { var outer; }
+    return () => outer?.(1);
+  }
+  const update = make();
+  update();`;
+
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it.each([
+		[
+			'vars hoisted from a body branch',
+			'const outer = setCount; function run(value = outer(1)) { if (false) { var outer; } } run();',
+		],
+		[
+			'uninitialized body vars',
+			'const outer = setCount; function run(value = outer(1)) { var outer; } run();',
+		],
+		[
+			'explicitly undefined arguments',
+			'const outer = setCount; function run(value = outer(1)) { var outer; } run(undefined);',
+		],
+	])('resolves executing parameter defaults outside %s', (_label, setup) => {
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).toThrow(
+			RENDER_STATE_UPDATE,
+		);
+	});
+
+	it.each([
+		[
+			'a supplied non-undefined argument',
+			'const outer = setCount; function run(value = outer(1)) { var outer; } run(0);',
+		],
+		[
+			'an earlier supplied parameter',
+			'const outer = setCount; function run(outer, value = outer(1)) {} run(() => {});',
+		],
+		[
+			'an earlier defaulted parameter',
+			'const outer = setCount; function run(outer = () => {}, value = outer(1)) {} run();',
+		],
+		[
+			'a body var redeclaring a supplied parameter',
+			'const outer = setCount; function run(outer, value = outer(1)) { var outer; } run(() => {});',
+		],
+	])('does not invent parameter-default writes with %s', (_label, setup) => {
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('skips a parameter default for a null-or-callback argument', () => {
+		const setup = `const value = props.enabled ? null : () => {};
+  function run(value = setCount(1)) {}
+  run(value);`;
+
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('keeps a parameter default reachable for an undefined-or-callback argument', () => {
+		const setup = `const value = props.enabled ? undefined : () => {};
+  function run(value = setCount(1)) {}
+  run(value);`;
+
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).toThrow(
+			RENDER_STATE_UPDATE,
+		);
+	});
+
+	it.each(['{}', '[]'])(
+		'preserves the truthiness of %s passed to a callback factory',
+		(argument) => {
+			const setup = `function make(value) { return value ? () => {} : setCount; }
+  const update = make(${argument});
+  update(1);`;
+
+			expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).not.toThrow();
+		},
+	);
+
+	it('does not invent a factory return after complementary branches both return', () => {
+		const setup = `const noop = () => {};
+  const bad = () => setCount(1);
+  function make(enabled) {
+    if (enabled) return noop;
+    if (!enabled) return noop;
+    return bad;
+  }
+  const update = make(props.enabled);
+  update();`;
+
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it.each([
+		['optional calls', 'const event = useEffectEvent(() => count); event?.();'],
+		['tagged calls', 'const event = useEffectEvent(() => count); event`value`;'],
+	])('rejects render-time Effect Events used in %s', (_label, setup) => {
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).toThrow(
+			RENDER_EFFECT_EVENT_CALL,
+		);
+	});
+
+	it.each([
+		[
+			'render callbacks',
+			'const tag = useCallback((strings, apply) => apply(1), []); tag`${setCount}`;',
+			RENDER_STATE_UPDATE,
+		],
+		[
+			'Effect Events during effect setup',
+			'const tag = useEffectEvent((strings, apply) => apply(1)); useEffect(() => { tag`${setCount}`; }, []);',
+			EFFECT_STATE_UPDATE,
+		],
+	])('tracks tagged-template arguments passed to %s', (_label, setup, code) => {
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).toThrow(code);
+	});
+
+	it('distinguishes Effect Event dependency values from ordinary callback wrappers', () => {
+		const actual = `const event = useEffectEvent(() => count);
+  function identity(value) { return value; }
+  const selected = useMemo(() => identity(event), []);
+  useEffect(() => {}, [selected]);`;
+		const wrapped = `const event = useEffectEvent(() => count);
+  const wrapper = useMemo(() => () => event(), []);
+  useEffect(() => {}, [wrapper, () => event(), false ? event : wrapper]);`;
+
+		expect(() => compile(`"use strong";\n${component(actual)}`, '/src/App.tsrx')).toThrow(
+			EFFECT_EVENT_DEPENDENCY,
+		);
+		expect(() => compile(`"use strong";\n${component(wrapped)}`, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it.each([
+		[
+			'generator callback creation',
+			'const make = useCallback(function* () { setCount(1); }, []); const iterator = make(); useEffect(() => () => { iterator.next(); }, []);',
+		],
+		[
+			'asynchronous callbacks after yielding',
+			'const update = useCallback(async () => { await Promise.resolve(); setCount(1); }, []); useEffect(() => { update(); }, []);',
+		],
+		[
+			'optional calls after yielding',
+			'const event = useEffectEvent(() => count); (async () => { event?.(await Promise.resolve()); })();',
+		],
+		[
+			'tagged calls after yielding',
+			'const event = useEffectEvent(() => count); (async () => { event`${await Promise.resolve()}`; })();',
+		],
+		[
+			'recursive factory returns',
+			'function make(recur) { if (recur) return make(false); return () => {}; } const update = useMemo(() => make(true), []); update();',
+		],
+		[
+			'mutually recursive factory returns',
+			'function first(recur) { if (recur) return second(false); return () => {}; } function second(recur) { if (recur) return first(false); return () => {}; } const update = useMemo(() => first(true), []); update();',
+		],
+	])('keeps %s legal without inventing synchronous execution', (_label, setup) => {
+		expect(() => compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx')).not.toThrow();
+	});
+
+	it('finishes repeated optional self-return calls and still checks later writes', () => {
+		const setup = `function next() { return next; }
+  const result = next${'?.()'.repeat(8)};
+  result?.();`;
+		const valid = compile(`"use strong";\n${component(setup)}`, '/src/App.tsrx');
+
+		expect(valid.diagnostics).toEqual([]);
+		expect(() =>
+			compile(`"use strong";\n${component(`${setup}\n  setCount(1);`)}`, '/src/App.tsrx'),
+		).toThrow(RENDER_STATE_UPDATE);
+	});
+
+	it.each([
+		[
+			'returned state updater',
+			'const update = useCallback(() => setCount(1), []); update();',
+			RENDER_STATE_UPDATE,
+		],
+		[
+			'Effect Event invocation',
+			'const event = useEffectEvent(() => count); event();',
+			RENDER_EFFECT_EVENT_CALL,
+		],
+		[
+			'Effect Event dependency',
+			'const event = useEffectEvent(() => count); useEffect(() => {}, [event]);',
+			EFFECT_EVENT_DEPENDENCY,
+		],
+	])('preserves compatibility behavior for %s until opted in', (_label, setup, code) => {
+		const source = component(setup);
+		expect(() => compile(source, '/src/App.tsrx')).not.toThrow();
+		expect(() => compile(source, '/src/App.tsrx', { strong: false } as any)).not.toThrow();
+		expect(() => compile(source, '/src/App.tsrx', { strong: true } as any)).toThrow(code);
+		expect(() =>
+			compile(`"use strong";\n${source}`, '/src/App.tsrx', { strong: false } as any),
+		).toThrow(code);
+	});
+
+	it.each([
+		[
+			'returned callback render writes',
+			'const update = useCallback(() => setCount(1), []); update();',
+			RENDER_STATE_UPDATE,
+		],
+		[
+			'memo-returned effect callbacks',
+			'const update = useMemo(() => () => setCount(1), []); useEffect(update, []);',
+			EFFECT_STATE_UPDATE,
+		],
+		[
+			'Effect Event render calls',
+			'const event = useEffectEvent(() => count); event();',
+			RENDER_EFFECT_EVENT_CALL,
+		],
+		[
+			'Effect Event dependencies',
+			'const event = useEffectEvent(() => count); useEffect(() => {}, [event]);',
+			EFFECT_EVENT_DEPENDENCY,
+		],
+	])('publishes matching plain TypeScript and editor errors for %s', (_label, setup, code) => {
+		const source = `"use strong";
+import { ${imports} } from 'octane';
+export function useCounter(props) {
+  const [count, setCount] = useState(0);
+  const ref = useRef(0);
+  ${setup}
+  return count;
+}`;
+		const editorSource = `"use strong";\n${component(setup)}`;
+		const result = compileToVolarMappings(editorSource, '/src/App.tsrx');
+
+		expect(() => slotHooks(source, '/src/useCounter.ts')).toThrow(code);
+		expect(result.diagnostics).toContainEqual(
+			expect.objectContaining({ code, severity: 'error', filename: '/src/App.tsrx' }),
+		);
+		expect(result.errors).toContainEqual(
+			expect.objectContaining({ code, type: 'usage', fileName: '/src/App.tsrx' }),
+		);
+	});
+
+	it.each([
+		{ mode: 'client', dev: true },
+		{ mode: 'client', dev: false },
+		{ mode: 'server', dev: true },
+		{ mode: 'server', dev: false },
+	])('enforces Effect Event diagnostics in $mode compilation with dev=$dev', (options) => {
+		const render = component('const event = useEffectEvent(() => count); event();');
+		const dependency = component(
+			'const event = useEffectEvent(() => count); useEffect(() => {}, [event]);',
+		);
+
+		expect(() => compile(`"use strong";\n${render}`, '/src/App.tsrx', options)).toThrow(
+			RENDER_EFFECT_EVENT_CALL,
+		);
+		expect(() => compile(`"use strong";\n${dependency}`, '/src/App.tsrx', options)).toThrow(
+			EFFECT_EVENT_DEPENDENCY,
+		);
+	});
+
+	it.each([
+		['alias();', RENDER_EFFECT_EVENT_CALL],
+		['useEffect(() => {}, [alias]);', EFFECT_EVENT_DEPENDENCY],
+	])('locates %s at the authored use, not its declaration', (statement, code) => {
+		const source = `"use strong";
+import { useEffect, useEffectEvent } from 'octane';
+export function App(props) @{
+  const event = useEffectEvent(() => props.value);
+  const alias = event;
+  ${statement}
+  <div />
+}`;
+		const start = source.lastIndexOf('alias');
+		let failure: unknown;
+		try {
+			compile(source, '/src/App.tsrx');
+		} catch (error) {
+			failure = error;
+		}
+		expect(failure).toMatchObject({
+			code,
+			filename: '/src/App.tsrx',
+			pos: start,
+			end: start + 'alias'.length,
+		});
+		expect(compileToVolarMappings(source, '/src/App.tsrx').diagnostics).toContainEqual(
+			expect.objectContaining({
+				code,
+				start: expect.objectContaining({ offset: start, line: 6 }),
+				end: expect.objectContaining({ offset: start + 'alias'.length, line: 6 }),
+			}),
+		);
 	});
 });

--- a/website-mcp/tests/content.test.ts
+++ b/website-mcp/tests/content.test.ts
@@ -105,6 +105,29 @@ describe('llms text', () => {
 		}
 	});
 
+	it('documents Strong-mode compiler checks in both agent summaries', () => {
+		for (const text of [LLMS_TXT, LLMS_FULL_TXT]) {
+			const strongGuide = text.split('## Strong mode\n')[1]?.split('\n## ')[0];
+			expect(strongGuide).toBeDefined();
+			for (const marker of [
+				'"use strong"',
+				'compiler: { strong: true }',
+				'OCTANE_STRONG_RENDER_STATE_UPDATE',
+				'OCTANE_STRONG_EFFECT_STATE_UPDATE',
+				'OCTANE_STRONG_RENDER_REF_WRITE',
+				'OCTANE_STRONG_RENDER_EFFECT_EVENT_CALL',
+				'OCTANE_STRONG_EFFECT_EVENT_DEPENDENCY',
+				'useLinkedState',
+				'useCallback',
+				'useMemo',
+				'useEffectEvent',
+				'/docs/build-tools#strong-mode',
+			]) {
+				expect(strongGuide, marker).toContain(marker);
+			}
+		}
+	});
+
 	it('documents behavior-only ownership in the summary and full website corpus', () => {
 		const ownershipGuide = LLMS_TXT.split(
 			'## Behavior-only roots and external ownership\n',

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -11,6 +11,7 @@ Key facts for answering questions about Octane:
 - No rules of hooks: hooks are tracked by a compiler-assigned call-site slot, so a hook may sit behind a condition or after an early return. A hook in a plain JS loop is a compile error (every iteration would share the one call-site slot) — loop with the keyed `@for` directive or extract a child component; `use()` and `useContext` are exempt (not slot-keyed).
 - `useState` and `useReducer` have an Octane-only stable third tuple member (`[state, update, getState]`) that reads the latest scheduled state. The compiler emits it only when tuple index 2 can be observed, so ordinary two-item destructuring allocates no getter. Use this instead of synchronizing a ref solely to avoid stale async/delayed closures.
 - `useLinkedState(source, calculate, options?)` keeps a value editable while its source stays the same, then resets or adjusts it immediately when the source changes. The calculation receives the new source and the previous `{ source, value }`, or `undefined` on the first render. No effect or render-time setter is needed.
+- Strong mode is opt-in: a leading `"use strong"` directive or `compiler: { strong: true }` enables compiler checks for state, refs, and Effect Events. It does not ban `useCallback`, `useMemo`, `useEffectEvent`, or effects that synchronize external systems. See the Strong mode section below.
 - Native, delegated DOM events (`onClick`, `onInput`, `onSubmit`) instead of a synthetic event layer — behavior matches the platform. There is no synthetic `onChange`: `onInput` is the per-edit handler for text inputs; native `change` fires when the browser commits an edit, usually on blur.
 - `OCTANE_NATIVE_TEXT_ONCHANGE` is a nonfatal authoring warning, not an event rewrite. The compiler reports direct `onChange`/`onChangeCapture` on a statically known text-entry `<input>` or `<textarea>` without a usable input handler; development runtime checks cover unresolved spreads/dynamic types/final props and report through `console.error` once per broken episode. Statically true `readOnly`/`disabled` controls are excluded. Use the phase-preserving `onInput`/`onInputCapture` fix for per-edit intent.
 - Deliberate native commit-on-blur is supported: keep `onChange` and add the JS-only, non-serialized `suppressNativeChangeWarning` host hint. Do not add a noop `onInput`. Selects, checkbox/radio/file and other non-text inputs, custom elements, and component/library callbacks named `onChange` are outside this warning and should not be blanket-renamed.
@@ -180,6 +181,26 @@ See the [behavior-only roots guide](https://octanejs.dev/docs/core-apis#behavior
 - `useReducer(reducer, initialArg, init?)` returns `[state, dispatch, getState]`. The third call argument remains the optional lazy initializer; the third tuple member is the current-state getter.
 - `useLinkedState(source, calculate, options?)` returns `[value, setValue, getValue]`. `calculate(source, previous)` receives `undefined` initially and the previous `{ source, value }` when the source changes. `sourceEqual` and `valueEqual` default to `Object.is`; pass custom functions in `options` when needed. A source change updates the value during that same render without an effect, a render-time setter, or a replay.
 - During pending work a state getter can be newer than the committed DOM. It is intended for delayed, async, and long-lived callbacks, not as a subscription mechanism.
+
+## Strong mode
+
+Put `"use strong"` before a module's imports, or enable `compiler: { strong: true }` in `octane.config.ts` for application-owned modules. Vite, Rspack, and Rsbuild also accept `strong: true` in their Octane plugin options. Installed dependencies keep their existing behavior unless their own source opts in.
+
+Strong modules reject these statically provable patterns:
+
+- Calling a `useState`, `useReducer`, or `useLinkedState` updater during render (`OCTANE_STRONG_RENDER_STATE_UPDATE`).
+- Calling one of those updaters synchronously while an effect is being set up (`OCTANE_STRONG_EFFECT_STATE_UPDATE`).
+- Writing to a `useRef` object's `current` during render (`OCTANE_STRONG_RENDER_REF_WRITE`).
+- Calling a known `useEffectEvent` result during render (`OCTANE_STRONG_RENDER_EFFECT_EVENT_CALL`).
+- Including a known Effect Event in explicit hook dependencies (`OCTANE_STRONG_EFFECT_EVENT_DEPENDENCY`).
+
+The checks follow provable synchronous calls through local helpers, `useCallback` and `useEffectEvent` results, and functions returned by analyzable `useMemo` factories. These hooks remain supported; creating a callback is not itself an error. Effect Events are non-reactive and should be omitted from dependencies. Other explicit dependency arrays remain authoritative and are never rewritten.
+
+The analysis is deliberately bounded. Unknown factory returns and complex control flow remain opaque. Dependency checks follow literal arrays, including statically selected or spread literals; they do not assume an aliased or externally produced array is unchanged.
+
+Update state in event handlers, or use `useLinkedState` when editable state should follow a changing input. Genuinely deferred callbacks, effect cleanup, effects that synchronize external systems, and normal DOM or timer refs remain valid. Strong mode does not ban `Date.now()` or `Math.random()`.
+
+See the [Strong mode guide](https://octanejs.dev/docs/build-tools#strong-mode).
 
 ## Dependency-taking hooks
 

--- a/website/src/content/docs/build-tools.mdx
+++ b/website/src/content/docs/build-tools.mdx
@@ -144,8 +144,9 @@ syntax but does not supply application-specific Web API polyfills.
 
 <h2 id="strong-mode">Strong mode</h2>
 
-Strong mode asks the compiler to reject a few state and ref patterns that make a
-component harder to follow. It is off by default, so you can try it in one file:
+Strong mode asks the compiler to reject state, ref, and Effect Event patterns
+that make a component harder to follow. It is off by default, so you can try it
+in one file:
 
 ```tsx
 'use strong';
@@ -198,13 +199,28 @@ does not change installed dependencies; a dependency can opt in with its own
 A Strong module cannot:
 
 - Call a state setter or reducer dispatcher while rendering.
-- Call one directly while an effect is being set up.
+- Call one synchronously while an effect is being set up.
 - Assign to a ref's `current` value while rendering.
+- Call a statically known `useEffectEvent` result during render
+  (`OCTANE_STRONG_RENDER_EFFECT_EVENT_CALL`).
+- Include a statically known Effect Event in explicit hook dependencies
+  (`OCTANE_STRONG_EFFECT_EVENT_DEPENDENCY`).
+
+These checks follow provable synchronous calls through local helpers,
+`useCallback` and `useEffectEvent` results, and functions returned by analyzable
+`useMemo` factories. The hooks themselves remain supported. Effect Events are
+non-reactive; leave them out of dependency lists. Other explicit dependency
+arrays retain their existing meaning and are never rewritten.
+
+Factories with unknown return values or complex control flow remain opaque.
+Dependency checks follow literal arrays, including statically selected or spread
+literals; they do not assume an aliased or externally produced array is unchanged.
 
 Use `useLinkedState` when state should reset or adjust after an input changes.
-Event handlers may update state normally. Effects that connect to external
-systems and refs for DOM nodes, timers, or event callbacks are still useful and
-remain allowed. Values such as `Date.now()` and `Math.random()` are not banned.
+Event handlers may update state normally. Genuinely deferred callbacks, effect
+cleanup, effects that connect to external systems, and refs for DOM nodes, timers,
+or event callbacks remain allowed. Values such as `Date.now()` and `Math.random()`
+are not banned.
 
 <h2 id="mixed-toolchains">Mixed toolchains and file ownership</h2>
 

--- a/website/src/content/docs/core-apis.mdx
+++ b/website/src/content/docs/core-apis.mdx
@@ -312,12 +312,18 @@ export function ProfileEditor({ user }) {
 }
 ```
 
-A Strong module cannot update state while rendering, update state directly while
-setting up an effect, or write `ref.current` while rendering. Event handlers can
-still update state. Effects that synchronize external systems and refs for DOM
-nodes or timers are still valid. Use `useLinkedState` when editable state should
-follow an input; it returns the right value immediately without an effect or a
-render-time setter.
+A Strong module cannot update state while rendering, update state synchronously
+while setting up an effect, or write `ref.current` while rendering. The compiler
+also follows provable calls through `useCallback`, `useEffectEvent`, and functions
+returned by analyzable `useMemo` factories. A statically known Effect Event cannot
+be called during render or listed in explicit hook dependencies. These hooks
+remain supported, and other explicit dependency lists keep their existing meaning.
+
+Event handlers can still update state. Genuinely deferred callbacks, effect
+cleanup, effects that synchronize external systems, and refs for DOM nodes or
+timers are still valid. Use `useLinkedState` when editable state should follow an
+input; it returns the right value immediately without an effect or a render-time
+setter.
 
 <details className="deep-dive">
 	<summary>Octane deep dive: state getters and conditional hooks</summary>

--- a/website/src/content/docs/differences-from-react.mdx
+++ b/website/src/content/docs/differences-from-react.mdx
@@ -102,12 +102,18 @@ use as workarounds. Enable it for a single module with `"use strong"` before its
 imports, or across your application with `compiler: { strong: true }` in
 `octane.config.ts`.
 
-The compiler rejects state updates during render, state updates made directly
-while an effect is being set up, and writes to `ref.current` during render. Use
-`useLinkedState` when editable state should follow a changing prop. Event
-handlers, effects that synchronize external systems, and normal DOM or timer
-refs remain supported. Installed dependencies keep their existing behavior
-unless they opt in themselves.
+The compiler rejects state updates during render, synchronous state updates
+while an effect is being set up, and writes to `ref.current` during render. It
+follows provable calls through `useCallback`, `useEffectEvent`, and functions
+returned by analyzable `useMemo` factories. Calling a statically known Effect
+Event during render or including it in explicit hook dependencies is also an
+error. These hooks remain supported, and other explicit dependency lists retain
+their existing meaning.
+
+Use `useLinkedState` when editable state should follow a changing prop. Event
+handlers, genuinely deferred callbacks, effect cleanup, effects that synchronize
+external systems, and normal DOM or timer refs remain supported. Installed
+dependencies keep their existing behavior unless they opt in themselves.
 
 <h2 id="events-and-dom">Events come from the browser</h2>
 


### PR DESCRIPTION
## Summary

- Close Strong-mode gaps where synchronous state/ref mutations were hidden behind `useCallback`, `useEffectEvent`, or analyzable memo-returned functions.
- Reject statically known Effect Event calls during render and Effect Events in explicit hook dependencies.
- Keep the hooks supported, preserve compatibility-mode behavior, and add an `octane` patch changeset.

Replaces [the PR accidentally opened against the fork](https://github.com/openai-oss-forks/octane/pull/5).

## Why

Strong previously accepted an Effect Event that immediately called a state setter during effect setup. The analyzer tracked direct callbacks but lost the callable value returned by hooks and local factories.

## Changes

- Track callable values separately from invocation, using per-call lexical environments and a shared read-only reassignment proof.
- Add `OCTANE_STRONG_RENDER_EFFECT_EVENT_CALL` and `OCTANE_STRONG_EFFECT_EVENT_DEPENDENCY`, with authored source locations shared by compilation and Volar.
- Preserve deferred callbacks, cleanup, post-`await` updates, and ordinary explicit dependency semantics. Leave unsupported factory control flow and aliased dependency-array containers opaque.
- Add regressions for aliases, conditional returns, mutation/shadowing, parameter defaults, optional and tagged calls, client/server parity, and the two analysis paths that initially expanded exponentially.
- Update the authoring and website documentation, including the shared `llms.txt` summary used by `llms-full.txt`.

## Validation

- [ ] `pnpm format:check` — full repository check not run.
- [ ] `pnpm typecheck` — full monorepo check not run.
- [ ] `pnpm test` — full monorepo suite not run.
- [x] `pnpm exec vitest run --project octane --project octane-prod --maxWorkers=4 --reporter=dot --silent=passed-only` — 13,198 tests across 849 files.
- [x] Strong-focused compiler suite — 570 tests.
- [x] `./node_modules/.bin/vitest run --project website-mcp-unit --maxWorkers=2 --reporter=dot --silent=passed-only` — 42 tests, including the short/full LLM documentation exports and routes.
- [x] `./node_modules/.bin/tsrx-tsc --noEmit -p website-mcp/tsconfig.json`.
- [x] Scoped typecheck, formatting, changeset checks, and `git diff --check`.
- [x] `pnpm sync` — passed; no generated diff.
- [x] Paired analyzer and browser-bundle probes — frozen ASTs, valid client/server output parity, compatibility behavior, and no new bundle inputs.

The full dependency install was blocked by an unrelated HTTP 403 fetching `@tanstack/db@0.7.0`. Required core and generator dependencies were installed with the frozen lockfile; the lockfile is unchanged.

## Risk / follow-ups

Strong remains opt-in. This does not ban memoization hooks or implement the broader effect-policy and React-issue corpus work.

Local paired measurements against `6f9cbae8c` used Node 26.4.0 on Apple M5 Max, with five warmups and eleven alternating samples. The ordinary 1,000-row analyzer fixture changed from 423.200 to 434.244 µs; the callback-heavy 100-component fixture changed from 925.633 to 1,690.724 µs. The disabled assertion path was effectively unchanged. The public browser compiler adds 11,687 minified bytes, 3,466 gzip-9 bytes, and 3,098 Brotli-11 bytes. The callback-heavy analysis cost is the main tradeoff.

The local validation above ran on the published branch based on `6f9cbae8c`. Upstream `main` has since advanced, including the Node parser change; those newer commits have not been incorporated or revalidated in this draft.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789642672&installation_model_id=432790&pr_number=777&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F777&signature=f778441bf1e9bcf576834d859ffd853def96e76a020aec401636187eba1d9d70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only affect opt-in Strong-mode compilation but substantially expand the analyzer (including reported compile-time cost on callback-heavy fixtures) and new diagnostic codes that can break builds once enabled.
> 
> **Overview**
> **Strong mode** gains deeper static analysis so hidden synchronous state/ref writes and misuse of **Effect Events** are caught at compile time in opted-in modules (`"use strong"` or `compiler.strong`).
> 
> The analyzer now treats **callable values** separately from invocation: it follows provable synchronous calls through local helpers, **`useCallback`** / **`useEffectEvent`** results, and functions returned from analyzable **`useMemo`** factories (with per-call lexical environments and cached call results). It uses a new **`collectReassignedBindings`** pass in `hook-deps.js` so callback identities are not trusted after reassignment or shadowing. Effect setup is described as rejecting **synchronous** updater calls (wording aligned with deferred/cleanup paths staying legal).
> 
> Two new errors: **`OCTANE_STRONG_RENDER_EFFECT_EVENT_CALL`** (calling a known Effect Event during render) and **`OCTANE_STRONG_EFFECT_EVENT_DEPENDENCY`** (listing one in an explicit hook dependency array). **`useCallback`**, **`useMemo`**, and **`useEffectEvent`** remain allowed; compatibility mode is unchanged until opt-in.
> 
> Documentation (`docs/`, website, **`llms.txt`**) and a large **`strong-mode.test.ts`** suite cover aliases, conditional returns, parameter defaults, optional/tagged calls, and client/server parity. **`octane`** patch changeset included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1830bd7831f4bae14520adf6ee1ac1532019e785. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->