### PR TITLE
test: cover nested callbacks and store selectors

### DIFF
--- a/packages/octane/tests/_fixtures/custom-hooks.tsrx
+++ b/packages/octane/tests/_fixtures/custom-hooks.tsrx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'octane';
+import { useState, useEffect, useCallback } from 'octane';
 
 // A user-defined custom hook with multiple base hooks. "Hooks everywhere": the
 // compiler slots its base hooks even though it's a plain function, not a
@@ -36,4 +36,62 @@ export function ReuseApp() @{
 export function NestedApp() @{
 	const c = useLabelledCounter(5, 'x');
 	<button class="n" onClick={c.inc}>{c.text as string}</button>
+}
+
+export interface CallbackSet {
+	explicit: () => string;
+	inferred: () => string;
+	always: () => string;
+	initial: () => string;
+}
+
+export interface CallbackSnapshot {
+	left: CallbackSet | null;
+	right: CallbackSet;
+}
+
+export interface CallbackReuseProps {
+	left: string;
+	right: string;
+	revision: number;
+	showLeft: boolean;
+	observe: (callbacks: CallbackSnapshot) => void;
+	onResult: (value: string) => void;
+}
+
+function useCallbackSet(label: string, revision: number): CallbackSet {
+	const explicit = useCallback(() => label, [label]);
+	const inferred = useCallback(() => label);
+	const always = useCallback(() => label + ':' + revision, null);
+	const initial = useCallback(() => label, []);
+	return { explicit, inferred, always, initial };
+}
+
+function useNestedCallbackSet(label: string, revision: number): CallbackSet {
+	return useCallbackSet(label, revision);
+}
+
+function describeCallbacks(callbacks: CallbackSet): string {
+	return [callbacks.explicit(), callbacks.inferred(), callbacks.always(), callbacks.initial()].join(
+		'|',
+	);
+}
+
+export function CallbackReuseApp(props: CallbackReuseProps) @{
+	let left: CallbackSet | null = null;
+	if (props.showLeft) left = useNestedCallbackSet(props.left, props.revision);
+	const right = useNestedCallbackSet(props.right, props.revision);
+	props.observe({ left, right });
+	<div>
+		<button
+			class="left-callback"
+			disabled={left === null}
+			onClick={() => {
+				if (left !== null) props.onResult(describeCallbacks(left));
+			}}
+		>Left</button>
+		<button class="right-callback" onClick={() => props.onResult(describeCallbacks(right))}>
+			Right
+		</button>
+	</div>
 }

--- a/packages/octane/tests/custom-hooks.test.ts
+++ b/packages/octane/tests/custom-hooks.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { createElement, useState, withSlot, flushSync, template, clone } from 'octane';
+import { createElement, useState, useCallback, withSlot, flushSync, template, clone } from 'octane';
 import { mount } from './_helpers';
-import { ReuseApp, NestedApp } from './_fixtures/custom-hooks.tsrx';
+import {
+	ReuseApp,
+	NestedApp,
+	CallbackReuseApp,
+	type CallbackReuseProps,
+	type CallbackSnapshot,
+} from './_fixtures/custom-hooks.tsrx';
 
 // "Hooks everywhere": Octane base hooks are slotted in ANY function, and custom
 // (`use[A-Z]`) hook calls are wrapped in withSlot so reuse stays independent.
@@ -28,6 +34,80 @@ describe('custom hooks', () => {
 		r.click('.b');
 		expect(r.find('.a').textContent).toBe('1');
 		expect(r.find('.b').textContent).toBe('101');
+		r.unmount();
+	});
+
+	it('preserves callback dependencies independently through nested custom hooks', () => {
+		let callbacks!: CallbackSnapshot;
+		const results: string[] = [];
+		let props: CallbackReuseProps = {
+			left: 'a',
+			right: 'b',
+			revision: 0,
+			showLeft: true,
+			observe: (next) => (callbacks = next),
+			onResult: (value) => results.push(value),
+		};
+		const r = mount(CallbackReuseApp, props);
+		const first = callbacks;
+		r.click('.left-callback');
+		r.click('.right-callback');
+		expect(results.splice(0)).toEqual(['a|a|a:0|a', 'b|b|b:0|b']);
+
+		props = { ...props, revision: 1 };
+		r.update(CallbackReuseApp, props);
+		expect(callbacks.left!.explicit).toBe(first.left!.explicit);
+		expect(callbacks.left!.inferred).toBe(first.left!.inferred);
+		expect(callbacks.left!.initial).toBe(first.left!.initial);
+		expect(callbacks.left!.always).not.toBe(first.left!.always);
+		expect(callbacks.right.explicit).toBe(first.right.explicit);
+		expect(callbacks.right.inferred).toBe(first.right.inferred);
+		r.click('.left-callback');
+		r.click('.right-callback');
+		expect(results.splice(0)).toEqual(['a|a|a:1|a', 'b|b|b:1|b']);
+
+		props = { ...props, left: 'c', revision: 2 };
+		r.update(CallbackReuseApp, props);
+		expect(callbacks.left!.explicit).not.toBe(first.left!.explicit);
+		expect(callbacks.left!.inferred).not.toBe(first.left!.inferred);
+		expect(callbacks.left!.initial).toBe(first.left!.initial);
+		expect(callbacks.right.explicit).toBe(first.right.explicit);
+		expect(callbacks.right.inferred).toBe(first.right.inferred);
+		r.click('.left-callback');
+		r.click('.right-callback');
+		expect(results).toEqual(['c|c|c:2|a', 'b|b|b:2|b']);
+		r.unmount();
+	});
+
+	it('preserves later callbacks when an earlier custom hook is skipped', () => {
+		let callbacks!: CallbackSnapshot;
+		const results: string[] = [];
+		let props: CallbackReuseProps = {
+			left: 'a',
+			right: 'b',
+			revision: 0,
+			showLeft: true,
+			observe: (next) => (callbacks = next),
+			onResult: (value) => results.push(value),
+		};
+		const r = mount(CallbackReuseApp, props);
+		const first = callbacks;
+
+		props = { ...props, showLeft: false, right: 'c', revision: 1 };
+		r.update(CallbackReuseApp, props);
+		expect(callbacks.left).toBeNull();
+		expect(callbacks.right.initial).toBe(first.right.initial);
+		r.click('.right-callback');
+		expect(results.splice(0)).toEqual(['c|c|c:1|b']);
+
+		props = { ...props, showLeft: true, revision: 2 };
+		r.update(CallbackReuseApp, props);
+		expect(callbacks.left!.explicit).toBe(first.left!.explicit);
+		expect(callbacks.left!.inferred).toBe(first.left!.inferred);
+		expect(callbacks.left!.initial).toBe(first.left!.initial);
+		r.click('.left-callback');
+		r.click('.right-callback');
+		expect(results).toEqual(['a|a|a:2|a', 'c|c|c:2|b']);
 		r.unmount();
 	});
 });
@@ -67,6 +147,56 @@ describe('manual withSlot (hand-written, no compiler)', () => {
 
 		expect(api.an).toBe(1); // A advanced
 		expect(api.bn).toBe(0); // B untouched → distinct call-path slots
+		r.unmount();
+	});
+
+	it('supports callbacks with an ambient path and a trailing omitted-deps slot', () => {
+		const leftSlot = Symbol('manual-callback-left');
+		const rightSlot = Symbol('manual-callback-right');
+		const innerSlot = Symbol('manual-callback-inner');
+		const singleSlot = Symbol('manual-callback-single');
+		const omittedSlot = Symbol('manual-callback-omitted');
+		const ownSlot = Symbol('manual-callback-own');
+		type Snapshot = {
+			left: () => string;
+			right: () => string;
+			single: () => string;
+			omitted: () => string;
+		};
+		type Props = {
+			left: string;
+			right: string;
+			observe: (next: Snapshot) => void;
+		};
+		function readNestedCallback(value: string): () => string {
+			return withSlot(innerSlot, useCallback, () => value, [value]);
+		}
+		function ManualCallbacks(props: Props) {
+			const left = withSlot(leftSlot, readNestedCallback, props.left);
+			const right = withSlot(rightSlot, readNestedCallback, props.right);
+			const single = withSlot(singleSlot, useCallback, () => props.left, [props.left]);
+			const omitted = withSlot(omittedSlot, useCallback, () => props.left, ownSlot);
+			props.observe({ left, right, single, omitted });
+			return createElement('span', {}, left() + '/' + right() + '/' + omitted());
+		}
+		let callbacks!: Snapshot;
+		const observe = (next: Snapshot) => (callbacks = next);
+		const r = mount(ManualCallbacks, { left: 'a', right: 'b', observe });
+		const first = callbacks;
+		expect(r.find('span').textContent).toBe('a/b/a');
+
+		r.update(ManualCallbacks, { left: 'a', right: 'b', observe });
+		expect(callbacks.left).toBe(first.left);
+		expect(callbacks.right).toBe(first.right);
+		expect(callbacks.single).toBe(first.single);
+		expect(callbacks.omitted()).toBe('a');
+
+		r.update(ManualCallbacks, { left: 'c', right: 'b', observe });
+		expect(r.find('span').textContent).toBe('c/b/c');
+		expect(callbacks.left).not.toBe(first.left);
+		expect(callbacks.right).toBe(first.right);
+		expect(callbacks.single()).toBe('c');
+		expect(callbacks.omitted()).toBe('c');
 		r.unmount();
 	});
 });

--- a/packages/octane/tests/slot-ergonomics.test.ts
+++ b/packages/octane/tests/slot-ergonomics.test.ts
@@ -14,6 +14,7 @@ import {
 	useTransition,
 	useDeferredValue,
 	useSyncExternalStore,
+	withSlot,
 } from '../src/index.js';
 
 // The `slot: symbol` argument on every hook is COMPILER-INJECTED.
@@ -55,5 +56,22 @@ describe('slot ergonomics — public signature hides the compiler-injected slot'
 		],
 	])('%s without a slot throws naming the hook', (name, call) => {
 		expect(call).toThrow(new RegExp(`${name} was called without a hook slot`));
+	});
+
+	it.each([
+		['omitted', () => useCallback(() => 0)],
+		['null', () => useCallback(() => 0, null)],
+	])('useCallback with %s dependencies still names the missing hook', (_deps, call) => {
+		expect(call).toThrow(/useCallback was called without a hook slot/);
+	});
+
+	it('restores missing-slot diagnostics after a manual hook throws', () => {
+		const failure = new Error('manual hook failed');
+		expect(() =>
+			withSlot(Symbol('throwing-custom-hook'), () => {
+				throw failure;
+			}),
+		).toThrow(failure);
+		expect(() => useCallback(() => 0, [])).toThrow(/useCallback was called without a hook slot/);
 	});
 });

--- a/packages/zustand/audit/test-classifications.json
+++ b/packages/zustand/audit/test-classifications.json
@@ -14,7 +14,7 @@
     {
       "path": "packages/zustand/tests/conformance/traditional.test.ts",
       "disposition": "octane-only-framework-contract",
-      "reason": "Checks equality-function render bailouts that cannot be observed through differential DOM output."
+      "reason": "Checks equality-function bailouts, selector and equality changes, store-swap subscriptions, and error recovery beyond the bounded differential lane."
     },
     {
       "path": "packages/zustand/tests/conformance/unstable-selectors.test.ts",

--- a/packages/zustand/tests/_fixtures/traditional-contracts.tsrx
+++ b/packages/zustand/tests/_fixtures/traditional-contracts.tsrx
@@ -1,0 +1,70 @@
+import { useState } from 'octane';
+import { createStore } from '@octanejs/zustand/vanilla';
+import type { StoreApi } from '@octanejs/zustand/vanilla';
+import { useStoreWithEqualityFn } from '@octanejs/zustand/traditional';
+
+export type SelectionState = { first: number; second: number };
+type Selection = { value: number };
+type ReadableStore = Pick<StoreApi<SelectionState>, 'getState' | 'getInitialState' | 'subscribe'>;
+type Selector = (state: SelectionState) => Selection;
+type EqualityFn = (previous: Selection, next: Selection) => boolean;
+
+export const selectFirst: Selector = (state) => ({ value: state.first });
+export const selectSecond: Selector = (state) => ({ value: state.second });
+export const equalSelection: EqualityFn = (previous, next) => previous.value === next.value;
+export const keepSelection: EqualityFn = () => true;
+
+export function SelectionReader(props: {
+	api: ReadableStore;
+	selector: Selector;
+	equalityFn: EqualityFn;
+	generation?: number;
+}) @{
+	const selection = useStoreWithEqualityFn(props.api, props.selector, props.equalityFn);
+	<output id="selection" data-generation={String(props.generation ?? 0)}>{String(selection.value) as string}</output>
+}
+
+type ErrorState = { value: string | number };
+type ErrorStore = StoreApi<ErrorState>;
+
+function selectText(state: ErrorState): string {
+	if (typeof state.value !== 'string') throw new Error('selector requires text');
+	return state.value.toUpperCase();
+}
+
+function selectErrorState(state: ErrorState): ErrorState {
+	return state;
+}
+
+function equalText(previous: ErrorState, next: ErrorState): boolean {
+	if (typeof next.value !== 'string') throw new Error('equality requires text');
+	return previous.value === next.value;
+}
+
+function SelectorErrorReader(props: { api: ErrorStore }) @{
+	const value = useStoreWithEqualityFn(props.api, selectText);
+	<output id="error-value">{value as string}</output>
+}
+
+function EqualityErrorReader(props: { api: ErrorStore }) @{
+	const value = useStoreWithEqualityFn(props.api, selectErrorState, equalText);
+	<output id="error-value">{String(value.value) as string}</output>
+}
+
+export function TraditionalErrors(props: { kind: 'selector' | 'equality' }) @{
+	const [api] = useState(() => createStore<ErrorState>(() => ({ value: 'ready' })));
+	const Reader = props.kind === 'selector' ? SelectorErrorReader : EqualityErrorReader;
+
+	<section>
+		<button id="break-selection" onClick={() => api.setState({ value: 1 })}>break</button>
+		<button id="repair-selection" onClick={() => api.setState({ value: 'recovered' })}>repair</button>
+		@try {
+			<Reader api={api} />
+		} @catch (error, reset) {
+			<div>
+				<output id="selection-error">{String(error) as string}</output>
+				<button id="retry-selection" onClick={() => reset()}>retry</button>
+			</div>
+		}
+	</section>
+}

--- a/packages/zustand/tests/conformance/traditional.test.ts
+++ b/packages/zustand/tests/conformance/traditional.test.ts
@@ -7,9 +7,19 @@
  */
 import { describe, it, expect, beforeEach } from 'vitest';
 import { createWithEqualityFn, useStoreWithEqualityFn } from '@octanejs/zustand/traditional';
+import { createStore } from '@octanejs/zustand/vanilla';
 import { shallow } from '@octanejs/zustand/shallow';
 import { mount, nextPaint } from '../_helpers';
 import { useEq, EqDefault, EqPerCall } from '../_fixtures/traditional.tsrx';
+import {
+	SelectionReader,
+	TraditionalErrors,
+	equalSelection,
+	keepSelection,
+	selectFirst,
+	selectSecond,
+	type SelectionState,
+} from '../_fixtures/traditional-contracts.tsrx';
 
 beforeEach(() => {
 	useEq.setState({ a: 0, b: 0, count: 0, other: 0 });
@@ -47,6 +57,113 @@ describe('per-call equality function', () => {
 		expect(r.find('#a').textContent).toBe('1');
 		r.unmount();
 	});
+});
+
+describe('traditional selection updates', () => {
+	it('keeps an unchanged selection current across parent renders and later writes', async () => {
+		const api = createStore<SelectionState>(() => ({ first: 1, second: 10 }));
+		const props = { api, selector: selectFirst, equalityFn: equalSelection, generation: 0 };
+		const r = mount(SelectionReader, props);
+		try {
+			await nextPaint();
+			r.update(SelectionReader, { ...props, generation: 1 });
+			expect(r.find('#selection').getAttribute('data-generation')).toBe('1');
+			expect(r.find('#selection').textContent).toBe('1');
+
+			api.setState({ second: 11 });
+			await nextPaint();
+			expect(r.find('#selection').textContent).toBe('1');
+			api.setState({ first: 2 });
+			await nextPaint();
+			expect(r.find('#selection').textContent).toBe('2');
+		} finally {
+			r.unmount();
+		}
+	});
+
+	// Per zustand@5.0.14 tests/basic.test.tsx, "can update the selector".
+	it('uses a changed selector before the store changes again', async () => {
+		const api = createStore<SelectionState>(() => ({ first: 1, second: 10 }));
+		const props = { api, selector: selectFirst, equalityFn: equalSelection };
+		const r = mount(SelectionReader, props);
+		try {
+			await nextPaint();
+			r.update(SelectionReader, { ...props, selector: selectSecond });
+			expect(r.find('#selection').textContent).toBe('10');
+			api.setState({ first: 2 });
+			await nextPaint();
+			expect(r.find('#selection').textContent).toBe('10');
+			api.setState({ second: 11 });
+			await nextPaint();
+			expect(r.find('#selection').textContent).toBe('11');
+		} finally {
+			r.unmount();
+		}
+	});
+
+	// Per zustand@5.0.14 tests/basic.test.tsx, "can update the equality checker".
+	it('applies a changed equality function to the current store snapshot', async () => {
+		const api = createStore<SelectionState>(() => ({ first: 1, second: 10 }));
+		const props = { api, selector: selectFirst, equalityFn: keepSelection };
+		const r = mount(SelectionReader, props);
+		try {
+			await nextPaint();
+			api.setState({ first: 2 });
+			await nextPaint();
+			expect(r.find('#selection').textContent).toBe('1');
+
+			r.update(SelectionReader, { ...props, equalityFn: equalSelection });
+			expect(r.find('#selection').textContent).toBe('2');
+			api.setState({ first: 3 });
+			await nextPaint();
+			expect(r.find('#selection').textContent).toBe('3');
+		} finally {
+			r.unmount();
+		}
+	});
+
+	it('moves the subscription when two stores initially share a snapshot', async () => {
+		const initial = { first: 1, second: 10 };
+		const first = createStore<SelectionState>(() => initial);
+		const second = createStore<SelectionState>(() => initial);
+		const props = { api: first, selector: selectFirst, equalityFn: equalSelection };
+		const r = mount(SelectionReader, props);
+		try {
+			await nextPaint();
+			r.update(SelectionReader, { ...props, api: second });
+			await nextPaint();
+			first.setState({ first: 5 });
+			await nextPaint();
+			expect(r.find('#selection').textContent).toBe('1');
+			second.setState({ first: 7 });
+			await nextPaint();
+			expect(r.find('#selection').textContent).toBe('7');
+		} finally {
+			r.unmount();
+		}
+	});
+
+	for (const kind of ['selector', 'equality'] as const) {
+		// Per zustand@5.0.14 tests/basic.test.tsx, selector/equality error cases.
+		it(`routes ${kind} errors to the boundary and can recover`, async () => {
+			const r = mount(TraditionalErrors, { kind });
+			try {
+				await nextPaint();
+				expect(r.find('#error-value').textContent).toBe(kind === 'selector' ? 'READY' : 'ready');
+				r.click('#break-selection');
+				await nextPaint();
+				expect(r.find('#selection-error').textContent).toContain(`${kind} requires text`);
+				r.click('#repair-selection');
+				r.click('#retry-selection');
+				await nextPaint();
+				expect(r.find('#error-value').textContent).toBe(
+					kind === 'selector' ? 'RECOVERED' : 'recovered',
+				);
+			} finally {
+				r.unmount();
+			}
+		});
+	}
 });
 
 describe('exports', () => {


### PR DESCRIPTION
## Summary

- Add behavioral coverage for callback identity and dependencies across nested and conditional custom hooks, including manual `withSlot` calls and missing-slot diagnostics.
- Cover Zustand traditional selectors across parent renders, selector/equality changes, store swaps, and selector/equality error recovery.
- Keep the binding cases classified as Octane-only framework-contract tests.

This is a test-only starting point for hook and external-store performance work. It does not change the runtime, compiler, or binding implementations, and makes no performance claim.

## Validation

- [x] `git diff --check`
- [x] Node TypeScript syntax checks for the three changed `.test.ts` files
- [x] `node scripts/check-test-markers.mjs`
- [x] Zustand port-test classification verifier
- [x] Pinned Prettier core check for the changed `.ts` and JSON files
- [ ] `pnpm format:check`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] Targeted `octane`, `octane-prod`, and `zustand` tests
- [ ] `pnpm sync` completed

The frozen dependency installation could not complete because the configured registry returned 403 responses for pinned TSRX packages. The offline retry also found a missing compiler dependency. Vitest and the TSRX formatter are unavailable, so the new fixtures have not been compiled or executed. Sync ran through the dependency-free generators, then stopped at CLI-data generation because Prettier was not linked; those completed generators produced no tracked changes.

## Risk / follow-ups

- Keep this PR in draft until the pinned toolchain is available and the focused tests, negative controls, formatting, typecheck, and sync have run.
- Add a public benchmark for direct/nested hooks and actual state bindings before selecting or claiming an optimization.
- No changeset is needed for this test-only diff.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789680212&installation_model_id=432790&pr_number=781&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F781&signature=3569390b23c8bae1c17dfec7bd5f69eb1eea544b98310734374e89f23cad4506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to tests and audit metadata; no production code paths are modified.
> 
> **Overview**
> **Test-only** expansion of Octane hook and Zustand traditional binding contracts—no runtime, compiler, or binding implementation changes.
> 
> **Octane:** Adds `CallbackReuseApp` and tests that **`useCallback`** identity and dependency modes (`explicit`, inferred, `null`, `[]`) stay correct through **nested custom hooks**, **independent left/right slots**, and **conditional hook execution** when an earlier hook is skipped. Extends **`slot-ergonomics`** so missing-slot errors still name **`useCallback`** when deps are omitted or `null`, and that diagnostics recover after a **`withSlot`** custom hook throws. Adds a manual **`withSlot`** case for nested callbacks and an omitted-deps trailing slot.
> 
> **Zustand:** Introduces **`traditional-contracts.tsrx`** fixtures and **`traditional selection updates`** tests for **`useStoreWithEqualityFn`**: stable selection across parent re-renders, **selector** and **equality** swaps, **store** subscription moves when APIs change, and **error boundaries** for failing selector/equality with retry. Updates **`test-classifications.json`** to describe the broader traditional conformance scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c011f8daf35325d4d4238511a58287c5ba1b806d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->