### PR TITLE
test: add hook and store composition benchmarks

### DIFF
--- a/.changeset/mcp-hook-store-composition.md
+++ b/.changeset/mcp-hook-store-composition.md
@@ -1,0 +1,5 @@
+---
+'@octanejs/mcp-server': patch
+---
+
+Expose the hook-store-composition benchmark through the MCP benchmark tool.

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -37,6 +37,9 @@ jobs:
           node-version: 24
           cache: "pnpm"
 
+      - name: Test benchmark work collector
+        run: node --test benchmarks/lib/precise-work.test.mjs
+
       - name: Install dependencies
         run: pnpm install --prod false --frozen-lockfile
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -158,10 +158,16 @@ Compiler-sensitive work counts use a separate production `work.mjs` invocation
 with jitless Chromium precise call coverage. This avoids source probes changing
 purity or memoization. Such invocations emit unique `*-work` target names, omit
 `iterations` so they cannot overwrite the timing run's sample count, and fail on
-missing production-asset coverage, exact semantic-write mismatches, or increases
-above exhaustive scaffolding ceilings. Specialized component-slot variants use
+missing production-asset coverage or semantic-write mismatches. Established
+optimization guards also fail on increases above exhaustive scaffolding
+ceilings; a new baseline suite reports work without guessing a cost ceiling
+before its pinned-toolchain run. Specialized component-slot variants use
 aggregate ceilings so a cheaper lowering may replace a generic slot without
 turning an optimization into a gate failure.
+The shared collector's optional `after` hooks verify the result after taking the
+coverage snapshot, keeping event-based semantic probes out of the measured work.
+Unhandled page errors and console errors fail the work sample even when its
+semantic hooks complete.
 
 When a dialect timing ratio is important, suites may emit
 `octane-{tsrx,jsx}-dialect-pair` aliases. Those aliases combine fully-warmed raw
@@ -198,6 +204,7 @@ internally, get their own baseline and guard namespace.
 | `external-store-fanout` | external-store-fanout | none (builds) | 512 subscribers, narrow and broad writes, rapid-write tearing checks, snapshots, notifications, renders, and exact subscription cleanup |
 | `external-store-integrations` | external-store-integrations | none (builds) | real Zustand stores, Jotai atoms, and TanStack Query caches with selector fan-out, query invalidation, and six-framework cleanup gates |
 | `store-selector-fanout` | store-selector-fanout | none (builds) | 512 subscribers reading one store through a `with-selector`-shaped selector, 20 unrelated parent re-renders with the store untouched, and deterministic selector-invocation counts beside render and snapshot counts |
+| `hook-store-composition` | hook-store-composition | none (builds) | matched direct/nested callbacks and actual Octane Zustand traditional/MobX bindings; separate production timings, named-work counts, and observable identity/update/cleanup controls |
 | `scheduler-responsiveness` | scheduler-responsiveness | none (builds) | real controlled typing during eight 512-subscriber store updates at 6× CPU throttling, with focus, caret, frame, and notification gates |
 | `suspense-recovery` | suspense-recovery | none (builds) | six-framework visible async pending, rejection, retry, cancellation, and stale-response correctness |
 | `event-delegation` | event-delegation | none (builds) | 128 real native input events, 512 event-bearing hosts, capture/bubble accounting, and every controlled output |

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -351,6 +351,19 @@ const SUITES = [
 		})),
 	},
 	{
+		// Matched direct/nested callback work plus the shipped store bindings.
+		// The fixture builds itself; named production calls are observed in a
+		// separate unminified build so instrumentation stays out of timings.
+		name: 'hook-store-composition',
+		cwd: 'hook-store-composition',
+		servers: [],
+		iter: { normal: 8, quick: 2 },
+		runs: [
+			{ script: 'run.mjs', args: (n) => [String(n)] },
+			{ label: 'work', script: 'work.mjs', args: () => [] },
+		],
+	},
+	{
 		name: 'effectful-list',
 		cwd: 'effectful-list',
 		servers: [

--- a/benchmarks/hook-store-composition/App.tsrx
+++ b/benchmarks/hook-store-composition/App.tsrx
@@ -51,10 +51,9 @@ function NestedCallbackRow(props: RowProps) @{
 function RawStoreRow(props: RowProps) @{
 	const read = props.model.rawReaders[props.index];
 	const value = useSyncExternalStore(props.model.api.subscribe, read, read);
-	<output
-		data-row-index={String(props.index)}
-		data-generation={String(props.generation)}
-	>{String(value) as string}</output>
+	<output data-row-index={String(props.index)} data-generation={String(props.generation)}>{String(
+		value,
+	) as string}</output>
 }
 
 function ZustandRow(props: RowProps) @{
@@ -64,18 +63,16 @@ function ZustandRow(props: RowProps) @{
 		selectors[props.index],
 		props.model.equalSelection,
 	);
-	<output
-		data-row-index={String(props.index)}
-		data-generation={String(props.generation)}
-	>{String(selection.value) as string}</output>
+	<output data-row-index={String(props.index)} data-generation={String(props.generation)}>{String(
+		selection.value,
+	) as string}</output>
 }
 
 function MobxRowBody(props: RowProps) @{
 	const selection = props.model.mobxSelections[props.index].get();
-	<output
-		data-row-index={String(props.index)}
-		data-generation={String(props.generation)}
-	>{String(selection.value) as string}</output>
+	<output data-row-index={String(props.index)} data-generation={String(props.generation)}>{String(
+		selection.value,
+	) as string}</output>
 }
 const MobxRow = observer(MobxRowBody);
 

--- a/benchmarks/hook-store-composition/App.tsrx
+++ b/benchmarks/hook-store-composition/App.tsrx
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useSyncExternalStore } from 'octane';
+import { useStoreWithEqualityFn } from '@octanejs/zustand/traditional';
+import { observer } from '@octanejs/mobx';
+import { ROW_INDICES, isCallbackLane } from './contract.mjs';
+import { useNestedCallback } from './callback-hooks.tsrx';
+import type { BenchmarkModel, Callback, Lane } from './model';
+
+type RowProps = {
+	model: BenchmarkModel;
+	index: number;
+	generation: number;
+	value: number;
+	dependencies: number[];
+	alternate: boolean;
+};
+
+function DirectCallbackRow(props: RowProps) @{
+	// A nonliteral dependency-array expression keeps this on the public runtime
+	// hook path under the normal production compiler options.
+	const report = props.model.reportCallback;
+	const index = props.index;
+	const value = props.value;
+	const dependencies = props.dependencies;
+	const callback: Callback = useCallback(
+		() => report(index, value + index, callback),
+		dependencies,
+	);
+	<button
+		type="button"
+		data-row-index={String(props.index)}
+		data-generation={String(props.generation)}
+		onClick={callback}
+	>{String(props.value + props.index) as string}</button>
+}
+
+function NestedCallbackRow(props: RowProps) @{
+	const callback = useNestedCallback(
+		props.model.reportCallback,
+		props.index,
+		props.value,
+		props.dependencies,
+	);
+	<button
+		type="button"
+		data-row-index={String(props.index)}
+		data-generation={String(props.generation)}
+		onClick={callback}
+	>{String(props.value + props.index) as string}</button>
+}
+
+function RawStoreRow(props: RowProps) @{
+	const read = props.model.rawReaders[props.index];
+	const value = useSyncExternalStore(props.model.api.subscribe, read, read);
+	<output data-row-index={String(props.index)} data-generation={String(props.generation)}>
+		{String(value) as string}
+	</output>
+}
+
+function ZustandRow(props: RowProps) @{
+	const selectors = props.alternate ? props.model.alternateSelectors : props.model.selectors;
+	const selection = useStoreWithEqualityFn(
+		props.model.api,
+		selectors[props.index],
+		props.model.equalSelection,
+	);
+	<output data-row-index={String(props.index)} data-generation={String(props.generation)}>
+		{String(selection.value) as string}
+	</output>
+}
+
+function MobxRowBody(props: RowProps) @{
+	const selection = props.model.mobxSelections[props.index].get();
+	<output data-row-index={String(props.index)} data-generation={String(props.generation)}>
+		{String(selection.value) as string}
+	</output>
+}
+const MobxRow = observer(MobxRowBody);
+
+export type CallbackSiteControlProps = {
+	report: BenchmarkModel['reportCallback'];
+	left: number;
+	right: number;
+	dependencies: number[];
+	generation: number;
+};
+
+// Two call sites in ONE component scope must not alias the leaf's memo cell,
+// even when their dependency values are equal. This control is mounted and
+// clicked only outside the measured application root.
+export function CallbackSiteControl(props: CallbackSiteControlProps) @{
+	const left = useNestedCallback(props.report, 0, props.left, props.dependencies);
+	const right = useNestedCallback(props.report, 1, props.right, props.dependencies);
+	<div data-control-generation={String(props.generation)}>
+		<button type="button" data-control="left" onClick={left}>left</button>
+		<button type="button" data-control="right" onClick={right}>right</button>
+	</div>
+}
+
+function StoreReady(props: { model: BenchmarkModel }) @{
+	useEffect(() => {
+		props.model.setReady(true);
+		return () => props.model.setReady(false);
+	}, [props.model]);
+	<span hidden />
+}
+
+export type AppProps = Omit<RowProps, 'index'> & { lane: Lane };
+
+export function App(props: AppProps) @{
+	const Row = props.lane === 'callback-direct' ? DirectCallbackRow
+		: props.lane === 'callback-nested' ? NestedCallbackRow
+		: props.lane === 'raw-store' ? RawStoreRow
+		: props.lane === 'zustand-traditional' ? ZustandRow
+		: MobxRow;
+	<main>
+		@for (const index of ROW_INDICES; key index) {
+			<Row
+				model={props.model}
+				index={index}
+				generation={props.generation}
+				value={props.value}
+				dependencies={props.dependencies}
+				alternate={props.alternate}
+			/>
+		}
+		@if (!isCallbackLane(props.lane)) {
+			<StoreReady model={props.model} />
+		}
+	</main>
+}

--- a/benchmarks/hook-store-composition/App.tsrx
+++ b/benchmarks/hook-store-composition/App.tsrx
@@ -51,9 +51,10 @@ function NestedCallbackRow(props: RowProps) @{
 function RawStoreRow(props: RowProps) @{
 	const read = props.model.rawReaders[props.index];
 	const value = useSyncExternalStore(props.model.api.subscribe, read, read);
-	<output data-row-index={String(props.index)} data-generation={String(props.generation)}>
-		{String(value) as string}
-	</output>
+	<output
+		data-row-index={String(props.index)}
+		data-generation={String(props.generation)}
+	>{String(value) as string}</output>
 }
 
 function ZustandRow(props: RowProps) @{
@@ -63,16 +64,18 @@ function ZustandRow(props: RowProps) @{
 		selectors[props.index],
 		props.model.equalSelection,
 	);
-	<output data-row-index={String(props.index)} data-generation={String(props.generation)}>
-		{String(selection.value) as string}
-	</output>
+	<output
+		data-row-index={String(props.index)}
+		data-generation={String(props.generation)}
+	>{String(selection.value) as string}</output>
 }
 
 function MobxRowBody(props: RowProps) @{
 	const selection = props.model.mobxSelections[props.index].get();
-	<output data-row-index={String(props.index)} data-generation={String(props.generation)}>
-		{String(selection.value) as string}
-	</output>
+	<output
+		data-row-index={String(props.index)}
+		data-generation={String(props.generation)}
+	>{String(selection.value) as string}</output>
 }
 const MobxRow = observer(MobxRowBody);
 
@@ -107,11 +110,16 @@ function StoreReady(props: { model: BenchmarkModel }) @{
 export type AppProps = Omit<RowProps, 'index'> & { lane: Lane };
 
 export function App(props: AppProps) @{
-	const Row = props.lane === 'callback-direct' ? DirectCallbackRow
-		: props.lane === 'callback-nested' ? NestedCallbackRow
-		: props.lane === 'raw-store' ? RawStoreRow
-		: props.lane === 'zustand-traditional' ? ZustandRow
-		: MobxRow;
+	const Row =
+		props.lane === 'callback-direct'
+			? DirectCallbackRow
+			: props.lane === 'callback-nested'
+				? NestedCallbackRow
+				: props.lane === 'raw-store'
+					? RawStoreRow
+					: props.lane === 'zustand-traditional'
+						? ZustandRow
+						: MobxRow;
 	<main>
 		@for (const index of ROW_INDICES; key index) {
 			<Row

--- a/benchmarks/hook-store-composition/README.md
+++ b/benchmarks/hook-store-composition/README.md
@@ -1,0 +1,100 @@
+# Hook and store composition
+
+An Octane-only production-browser baseline for runtime callback composition and
+actual external-store bindings. The fixture contains 128 independently rendered
+rows and precomputes immutable numeric records before each measured operation.
+Every update burst performs 20 discrete public `flushSync` commits.
+
+| Lane | Public implementation | Operations |
+| --- | --- | --- |
+| `callback-direct` | `useCallback` in the component body | unrelated parent renders; changed dependencies |
+| `callback-nested` | the same callback through two compiler-processed custom-hook call sites | the same matched callback operations |
+| `raw-store` | `useSyncExternalStore` over a real Zustand vanilla store | parent renders; new snapshots with unchanged selected values; changed selected values |
+| `zustand-traditional` | `@octanejs/zustand/traditional` over the same vanilla-store shape | the same visible-state operations, with stable selectors returning object slices and a value equality function |
+| `mobx` | `observer` from `@octanejs/mobx`, observing public MobX computed selections | the same visible-state operations, with computed-value equality |
+
+The callback lanes are a matched workload comparison. The three store lanes are
+independent baselines over equivalent visible state: their notification models,
+selection representations, and internal work differ. A cross-lane timing ratio
+does not isolate binding overhead or establish library parity. Existing
+`external-store-fanout`, `store-selector-fanout`, and
+`external-store-integrations` remain the broader comparative suites.
+
+## Controls and timing boundary
+
+The callback dependency array arrives through a prop, so the default production
+compiler retains the runtime hook instead of replacing an eligible literal-array
+call with inline memo cells. The nested leaf lives in a fully compiled `.tsrx`
+module; a plain TypeScript forwarding chain would not establish the same nested
+call-site paths. Both callback bodies capture the same report function, row index,
+and value.
+
+Native button clicks after the measured update check the callbacks' actual
+results, retained identities when dependencies are unchanged, and new identities
+with current captures when dependencies change. An additional untimed control
+calls the same nested hook twice in one component scope with equal dependency
+values; its distinct outputs and identities must remain independent. The
+observation registry is cleared between probes and on teardown.
+
+Store setup waits for the shell's real passive-effect acknowledgment and all
+expected subscribers. It then performs a genuine broad write and restore, checking
+every visible row both times. This matters for MobX: a tracked Reaction can exist
+before its external-store subscription is installed. No test-only effect-drain API
+is used. A later real write must still reach all rows; the Zustand lane additionally
+replaces its selector as an untimed semantic control. Teardown waits for an empty
+root and zero retained listeners or public MobX observers.
+
+`run.mjs` uses a minified production build. Each timer surrounds only the update
+burst, with no Playwright round trip, polling, or frame wait inside it. The timer
+stops before verification, but visible output is verified synchronously in the
+same browser task. Every row must have the correct value and parent generation,
+and its original DOM node must survive. Three warmup samples precede the requested
+measured samples. Chromium is launched with `--expose-gc`; when available, explicit
+GC runs before each sample and outside the timer. Results record that availability,
+Node/Chromium versions, platform, and architecture alongside the shared `BENCH_JSON`
+and statistics contracts.
+
+## Separate production-work diagnostics
+
+`work.mjs` makes an unminified production build and runs Chromium with JIT disabled.
+It reuses `benchmarks/lib/precise-work.mjs` to count named calls to `useCallback`,
+`useMemo`, `resolveHookArgs`, `resolveSlot`, `appendSlotKey`, and `withSlot` without
+adding probes to the component render bodies. An operation must activate at least
+128 × 20 runtime callbacks; the nested operation must actually reach the composed
+slot path. Native identity probes and cleanup run only after the coverage snapshot.
+
+The actual-binding diagnostics use separate fixture instances with instrumented
+store reads, selectors, equality functions, and subscription lifecycles. Their
+counts are not timing samples. Vanilla-store diagnostics report real notification,
+subscribe, unsubscribe-invocation, disposal, and duplicate-cleanup counts. MobX
+reports source-snapshot reads, selector/equality calls, public computed-observation
+transitions, and retained observers. Observation transitions are **not** Reaction
+creation/disposal counts. Equality counts cover the user-supplied Zustand comparator
+or MobX computed comparator; the raw lane's runtime `Object.is` calls are not
+instrumented. No component-render count is inferred from these metrics.
+
+The work payload omits `iterations`, so merging it into the unified result cannot
+overwrite the timing sample count. This baseline-only suite has no new timing or
+private-helper cost ratio limits. Establish and review measurements with the
+pinned toolchain before adding deterministic cost budgets to
+`benchmarks/baselines/ratios.json`.
+
+## Run
+
+```bash
+node benchmarks/bench.mjs --quick hook-store-composition
+node benchmarks/bench.mjs hook-store-composition
+
+node benchmarks/hook-store-composition/run.mjs 8
+node benchmarks/hook-store-composition/work.mjs
+pnpm exec tsrx-tsc --noEmit -p benchmarks/hook-store-composition/tsconfig.json
+node --test benchmarks/lib/precise-work.test.mjs
+```
+
+Both runners accept `--no-build` after their respective production build exists.
+The suite reuses the repository's installed Vite, Playwright, Octane, Zustand, and
+MobX packages. Its resolver follows the workspace packages' public export maps;
+it does not require another workspace package or dependency versions. Run baseline
+and candidate sequentially, with the same lockfile, compiler, browser, machine,
+warmup, and iteration count. A successful source inspection or syntax check is not
+a benchmark result.

--- a/benchmarks/hook-store-composition/callback-hooks.tsrx
+++ b/benchmarks/hook-store-composition/callback-hooks.tsrx
@@ -1,0 +1,23 @@
+import { useCallback } from 'octane';
+import type { BenchmarkModel, Callback } from './model';
+
+function useCallbackLeaf(
+	report: BenchmarkModel['reportCallback'],
+	index: number,
+	value: number,
+	dependencies: number[],
+): Callback {
+	const callback: Callback = useCallback(() => report(index, value + index, callback), dependencies);
+	return callback;
+}
+
+// This module goes through the full TSRX compiler. Both custom-hook calls own
+// call-site paths; the leaf retains its own compiler-assigned base-hook slot.
+export function useNestedCallback(
+	report: BenchmarkModel['reportCallback'],
+	index: number,
+	value: number,
+	dependencies: number[],
+): Callback {
+	return useCallbackLeaf(report, index, value, dependencies);
+}

--- a/benchmarks/hook-store-composition/callback-hooks.tsrx
+++ b/benchmarks/hook-store-composition/callback-hooks.tsrx
@@ -7,7 +7,10 @@ function useCallbackLeaf(
 	value: number,
 	dependencies: number[],
 ): Callback {
-	const callback: Callback = useCallback(() => report(index, value + index, callback), dependencies);
+	const callback: Callback = useCallback(
+		() => report(index, value + index, callback),
+		dependencies,
+	);
 	return callback;
 }
 

--- a/benchmarks/hook-store-composition/contract.mjs
+++ b/benchmarks/hook-store-composition/contract.mjs
@@ -1,0 +1,18 @@
+export const ROW_COUNT = 128;
+export const UPDATE_COUNT = 20;
+export const ROW_INDICES = Object.freeze(Array.from({ length: ROW_COUNT }, (_, index) => index));
+
+export const CALLBACK_LANES = ['callback-direct', 'callback-nested'];
+export const STORE_LANES = ['raw-store', 'zustand-traditional', 'mobx'];
+export const LANES = [...CALLBACK_LANES, ...STORE_LANES];
+
+export function isCallbackLane(lane) {
+	return CALLBACK_LANES.includes(lane);
+}
+
+export function operationsFor(lane) {
+	if (!LANES.includes(lane)) throw new Error(`Unknown hook/store lane: ${lane}`);
+	return isCallbackLane(lane)
+		? ['parent_rerenders', 'changed_dependencies']
+		: ['parent_rerenders', 'unchanged_selection', 'changed_selection'];
+}

--- a/benchmarks/hook-store-composition/entry.ts
+++ b/benchmarks/hook-store-composition/entry.ts
@@ -1,0 +1,317 @@
+import { createRoot, flushSync } from 'octane';
+import { App, CallbackSiteControl, type AppProps, type CallbackSiteControlProps } from './App.tsrx';
+import { LANES, ROW_COUNT, UPDATE_COUNT, isCallbackLane, operationsFor } from './contract.mjs';
+import { createModel, type Callback, type Lane, type Operation } from './model';
+
+const parameters = new URLSearchParams(location.search);
+const requestedLane = parameters.get('lane') ?? 'callback-direct';
+if (!LANES.includes(requestedLane)) throw new Error(`Unknown lane: ${requestedLane}`);
+const lane = requestedLane as Lane;
+const diagnosticsEnabled = parameters.get('diagnostics') === '1';
+const container = document.getElementById('app');
+const controlContainer = document.getElementById('callback-control');
+const callbackOutput = document.getElementById('callback-result');
+if (!container || !controlContainer || !callbackOutput) {
+	throw new Error('Missing hook/store benchmark containers');
+}
+
+type Mounted = {
+	root: ReturnType<typeof createRoot>;
+	props: AppProps;
+	nodes: Element[];
+	callbacks: Callback[];
+};
+let mounted: Mounted | null = null;
+let nestedControlVerified = false;
+
+function ensure(condition: unknown, message: string): asserts condition {
+	if (!condition) throw new Error(`${lane}: ${message}`);
+}
+
+function current(): Mounted {
+	ensure(mounted !== null, 'the fixture is not mounted');
+	return mounted;
+}
+
+function status() {
+	return {
+		rows: container.querySelectorAll('[data-row-index]').length,
+		ready: mounted?.props.model.ready ?? false,
+		...(mounted?.props.model.readDiagnostics() ?? {}),
+	};
+}
+
+async function waitUntil(predicate: () => boolean, phase: string): Promise<void> {
+	const deadline = performance.now() + 10_000;
+	while (!predicate()) {
+		ensure(performance.now() < deadline, `${phase} timed out: ${JSON.stringify(status())}`);
+		await new Promise<void>((resolve) => setTimeout(resolve, 16));
+	}
+}
+
+function render(): void {
+	const state = current();
+	flushSync(() => state.root.render(App, state.props));
+}
+
+function expectedValue(state: Mounted, index: number): number {
+	return (
+		(isCallbackLane(lane) ? state.props.value : state.props.model.base) +
+		index +
+		(state.props.alternate ? 1000 : 0)
+	);
+}
+
+function verifyRows(): Element[] {
+	const state = current();
+	const nodes = Array.from(container.querySelectorAll('[data-row-index]'));
+	ensure(nodes.length === ROW_COUNT, `expected ${ROW_COUNT} visible rows, got ${nodes.length}`);
+	for (let index = 0; index < ROW_COUNT; index++) {
+		const node = nodes[index];
+		ensure(node.getAttribute('data-row-index') === String(index), `row ${index} moved`);
+		ensure(
+			node.textContent === String(expectedValue(state, index)),
+			`row ${index} has stale output`,
+		);
+		ensure(
+			node.getAttribute('data-generation') === String(state.props.generation),
+			`row ${index} did not receive parent generation ${state.props.generation}`,
+		);
+		if (state.nodes.length !== 0) {
+			ensure(node === state.nodes[index], `row ${index} lost its DOM identity`);
+		}
+	}
+	return nodes;
+}
+
+function probeCallbacks(): Callback[] {
+	const state = current();
+	state.props.model.clearCallbackReports();
+	for (const node of verifyRows()) {
+		ensure(node instanceof HTMLButtonElement, 'a callback row is not a native button');
+		node.click();
+	}
+	const reports = state.props.model.callbackReports();
+	const callbacks = reports.map((report, index) => {
+		ensure(report !== undefined, `callback ${index} was not delivered`);
+		ensure(
+			report.value === expectedValue(state, index),
+			`callback ${index} captured a stale value`,
+		);
+		return report.callback;
+	});
+	ensure(new Set(callbacks).size === ROW_COUNT, 'independent rows shared a callback');
+	ensure(
+		callbackOutput.textContent === `${ROW_COUNT - 1}:${expectedValue(state, ROW_COUNT - 1)}`,
+		'the native callback did not reach its visible consumer',
+	);
+	return callbacks;
+}
+
+function verifyNestedCallSites(): void {
+	if (lane !== 'callback-nested' || nestedControlVerified) return;
+	const reports = new Map<number, { value: number; callback: Callback }>();
+	const root = createRoot(controlContainer);
+	let props: CallbackSiteControlProps = {
+		report: (index, value, callback) => reports.set(index, { value, callback }),
+		left: 10,
+		right: 20,
+		dependencies: [0],
+		generation: 0,
+	};
+	const probe = () => {
+		reports.clear();
+		for (const side of ['left', 'right']) {
+			const button = controlContainer.querySelector(`[data-control="${side}"]`);
+			ensure(button instanceof HTMLButtonElement, `missing nested ${side} control`);
+			button.click();
+		}
+		const left = reports.get(0);
+		const right = reports.get(1);
+		ensure(left?.value === props.left, 'the first nested call site captured the wrong value');
+		ensure(
+			right?.value === props.right + 1,
+			'the second nested call site captured the wrong value',
+		);
+		ensure(left.callback !== right.callback, 'nested call sites shared a callback cell');
+		return [left.callback, right.callback];
+	};
+	try {
+		flushSync(() => root.render(CallbackSiteControl, props));
+		const first = probe();
+		props = { ...props, generation: 1 };
+		flushSync(() => root.render(CallbackSiteControl, props));
+		const unchanged = probe();
+		ensure(
+			unchanged[0] === first[0] && unchanged[1] === first[1],
+			'equal nested dependencies changed callback identities',
+		);
+		props = { ...props, left: 30, right: 40, dependencies: [1], generation: 2 };
+		flushSync(() => root.render(CallbackSiteControl, props));
+		const changed = probe();
+		ensure(
+			changed[0] !== first[0] && changed[1] !== first[1],
+			'changed nested dependencies retained stale callbacks',
+		);
+		nestedControlVerified = true;
+	} finally {
+		flushSync(() => root.unmount());
+		reports.clear();
+		ensure(controlContainer.childNodes.length === 0, 'nested call-site control did not unmount');
+	}
+}
+
+async function cleanup() {
+	if (mounted === null) return null;
+	const state = mounted;
+	try {
+		flushSync(() => state.root.unmount());
+		await waitUntil(
+			() => !state.props.model.ready && state.props.model.activeSubscribers() === 0,
+			'teardown',
+		);
+		ensure(container.childNodes.length === 0, 'unmount left visible content behind');
+		const beforeProbe = state.props.model.readDiagnostics();
+		if (diagnosticsEnabled && !isCallbackLane(lane)) {
+			if (lane === 'mobx') {
+				ensure(
+					beforeProbe.observedTransitions === beforeProbe.unobservedTransitions,
+					'a MobX computed value remained observed',
+				);
+			} else {
+				ensure(
+					beforeProbe.subscribeCalls === beforeProbe.unsubscribeCalls &&
+						beforeProbe.subscribeCalls === beforeProbe.unsubscribeInvocations &&
+						beforeProbe.duplicateUnsubscribes === 0,
+					'a vanilla-store subscription was not cleaned up exactly once',
+				);
+			}
+			state.props.model.writeSelected(state.props.model.base + 1);
+			const afterProbe = state.props.model.readDiagnostics();
+			ensure(afterProbe.notifications === beforeProbe.notifications, 'an unmounted listener fired');
+			ensure(afterProbe.selectorCalls === beforeProbe.selectorCalls, 'an unmounted selector ran');
+		}
+		return state.props.model.readDiagnostics();
+	} finally {
+		state.props.model.clearCallbackReports();
+		state.callbacks.length = 0;
+		state.props.model.disposeDiagnostics();
+		mounted = null;
+	}
+}
+
+async function prepare(operation: Operation): Promise<void> {
+	ensure(operationsFor(lane).includes(operation), `unsupported operation ${operation}`);
+	await cleanup();
+	verifyNestedCallSites();
+	const model = createModel(lane, diagnosticsEnabled, (value) => {
+		callbackOutput.textContent = value;
+	});
+	mounted = {
+		root: createRoot(container),
+		props: { lane, model, generation: 0, value: 0, dependencies: [0], alternate: false },
+		nodes: [],
+		callbacks: [],
+	};
+	render();
+	if (!isCallbackLane(lane)) {
+		// Observer tracking alone happens before MobX's uSES subscription is
+		// installed. The passive acknowledgment and real write/restore below are
+		// both required before an update sample is allowed to start.
+		await waitUntil(
+			() => model.ready && model.activeSubscribers() === ROW_COUNT,
+			'subscription readiness',
+		);
+		flushSync(() => model.writeSelected(1));
+		verifyRows();
+		flushSync(() => model.writeSelected(0));
+		verifyRows();
+	}
+	const state = current();
+	state.nodes = verifyRows();
+	if (isCallbackLane(lane)) state.callbacks = probeCallbacks();
+}
+
+function run(operation: Operation): void {
+	const state = current();
+	ensure(operationsFor(lane).includes(operation), `unsupported operation ${operation}`);
+	for (let index = 0; index < UPDATE_COUNT; index++) {
+		if (operation === 'parent_rerenders' || operation === 'changed_dependencies') {
+			const value = state.props.value + (operation === 'changed_dependencies' ? 1 : 0);
+			state.props = {
+				...state.props,
+				generation: state.props.generation + 1,
+				value,
+				dependencies: operation === 'changed_dependencies' ? [value] : state.props.dependencies,
+			};
+			render();
+		} else {
+			flushSync(() => {
+				if (operation === 'unchanged_selection') state.props.model.publishUnchanged(index);
+				else state.props.model.publishChanged(index);
+			});
+		}
+	}
+}
+
+function verify(operation: Operation) {
+	const state = current();
+	verifyRows();
+	if (isCallbackLane(lane)) {
+		const callbacks = probeCallbacks();
+		for (let index = 0; index < ROW_COUNT; index++) {
+			ensure(
+				(callbacks[index] === state.callbacks[index]) === (operation === 'parent_rerenders'),
+				`callback ${index} has the wrong dependency identity`,
+			);
+		}
+	}
+	return {
+		rows: ROW_COUNT,
+		generation: state.props.generation,
+		first: expectedValue(state, 0),
+		last: expectedValue(state, ROW_COUNT - 1),
+		retainedNodes: state.nodes.length,
+	};
+}
+
+function confirmLiveWrite(): void {
+	if (isCallbackLane(lane)) return;
+	const state = current();
+	if (lane === 'zustand-traditional') {
+		// Replacing a selector is a separate semantic control, not a claim that
+		// an inline selector must have any particular compiler-generated identity.
+		state.props = { ...state.props, alternate: true, generation: state.props.generation + 1 };
+		render();
+		verifyRows();
+	}
+	flushSync(() => state.props.model.writeSelected(state.props.model.base + 1));
+	verifyRows();
+}
+
+const api = {
+	prepare,
+	run,
+	verify,
+	confirmLiveWrite,
+	cleanup,
+	diagnostics: () => current().props.model.readDiagnostics(),
+};
+function runWithSynchronousPostcondition(operation: Operation): void {
+	run(operation);
+	verifyRows();
+}
+const benchmarkWindow = window as typeof window & {
+	__ready?: boolean;
+	__hookStoreBench?: typeof api;
+	__hookStorePrepare?: typeof prepare;
+	__hookStoreRun?: typeof runWithSynchronousPostcondition;
+	__hookStoreVerify?: typeof verify;
+	__hookStoreCleanup?: typeof cleanup;
+};
+benchmarkWindow.__hookStoreBench = api;
+benchmarkWindow.__hookStorePrepare = prepare;
+benchmarkWindow.__hookStoreRun = runWithSynchronousPostcondition;
+benchmarkWindow.__hookStoreVerify = verify;
+benchmarkWindow.__hookStoreCleanup = cleanup;
+benchmarkWindow.__ready = true;

--- a/benchmarks/hook-store-composition/harness.mjs
+++ b/benchmarks/hook-store-composition/harness.mjs
@@ -1,0 +1,143 @@
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const HERE = fileURLToPath(new URL('.', import.meta.url));
+const requireFromNews = createRequire(new URL('../news/package.json', import.meta.url));
+const packageResolvers = [
+	['octane', createRequire(new URL('../../packages/octane/package.json', import.meta.url))],
+	[
+		'@octanejs/zustand',
+		createRequire(new URL('../../packages/zustand/package.json', import.meta.url)),
+	],
+	['@octanejs/mobx', createRequire(new URL('../../packages/mobx/package.json', import.meta.url))],
+];
+
+function workspacePublicImports() {
+	return {
+		name: 'hook-store-workspace-public-imports',
+		enforce: 'pre',
+		resolveId(source) {
+			for (const [name, resolver] of packageResolvers) {
+				if (source === name || source.startsWith(`${name}/`)) return resolver.resolve(source);
+			}
+			return null;
+		},
+	};
+}
+
+export function chromium() {
+	return requireFromNews('playwright').chromium;
+}
+
+export async function startFixture({ work = false, noBuild = false } = {}) {
+	process.env.NODE_ENV = 'production';
+	const { build, preview } = await import(pathToFileURL(requireFromNews.resolve('vite')).href);
+	const { octane } = await import(
+		pathToFileURL(packageResolvers[0][1].resolve('octane/compiler/vite')).href
+	);
+	const outDir = path.join(HERE, 'dist', work ? 'work' : 'timing');
+	if (!noBuild) {
+		await build({
+			configFile: false,
+			root: HERE,
+			logLevel: 'warn',
+			plugins: [workspacePublicImports(), octane({ hmr: false, profile: false })],
+			define: {
+				'process.env.NODE_ENV': JSON.stringify('production'),
+				__OCTANE_PROFILE_ENABLED__: 'false',
+			},
+			build: {
+				outDir,
+				emptyOutDir: true,
+				target: 'esnext',
+				minify: work ? false : 'esbuild',
+				rollupOptions: {
+					input: path.join(HERE, 'index.html'),
+					output: {
+						entryFileNames: 'assets/[name]-[hash].js',
+						chunkFileNames: 'assets/[name]-[hash].js',
+					},
+				},
+			},
+		});
+	}
+	if (!fs.existsSync(path.join(outDir, 'index.html'))) {
+		throw new Error(`Missing production hook/store fixture: ${outDir}`);
+	}
+	const server = await preview({
+		configFile: false,
+		root: HERE,
+		logLevel: 'error',
+		build: { outDir },
+		preview: { host: '127.0.0.1', port: 0, strictPort: true },
+	});
+	const address = server.httpServer.address();
+	if (address === null || typeof address === 'string') {
+		await closeServer(server);
+		throw new Error('The hook/store preview did not expose a TCP port');
+	}
+	return {
+		url: `http://127.0.0.1:${address.port}/`,
+		close: () => closeServer(server),
+	};
+}
+
+function closeServer(server) {
+	return server.close();
+}
+
+export async function closeResources(browser, fixture) {
+	const failures = [];
+	for (const [name, resource] of [
+		['browser', browser],
+		['fixture', fixture],
+	]) {
+		if (!resource) continue;
+		try {
+			await resource.close();
+		} catch (error) {
+			const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
+			failures.push(`${name} cleanup: ${message}`);
+		}
+	}
+	return failures;
+}
+
+export function fixtureUrl(origin, lane, diagnostics = false) {
+	const url = new URL(origin);
+	url.searchParams.set('lane', lane);
+	if (diagnostics) url.searchParams.set('diagnostics', '1');
+	return url.href;
+}
+
+export async function openCase(browser, origin, lane, diagnostics = false) {
+	const context = await browser.newContext();
+	const page = await context.newPage();
+	const errors = [];
+	page.on('pageerror', (error) => errors.push(error.message));
+	page.on('console', (message) => {
+		if (message.type() === 'error') errors.push(message.text());
+	});
+	try {
+		await page.goto(fixtureUrl(origin, lane, diagnostics), { waitUntil: 'load' });
+		await page.waitForFunction(() => window.__ready === true, null, { timeout: 10_000 });
+		return { context, page, errors };
+	} catch (error) {
+		await context.close();
+		throw new Error(`${lane}: production fixture failed to start: ${errors.join('; ')}`, {
+			cause: error,
+		});
+	}
+}
+
+export function checkBrowserErrors(lane, errors) {
+	if (errors.length !== 0) throw new Error(`${lane}: browser errors: ${errors.join('; ')}`);
+}
+
+export function writePayload(payload) {
+	if (process.env.BENCH_JSON) {
+		fs.writeFileSync(process.env.BENCH_JSON, `${JSON.stringify(payload, null, '\t')}\n`);
+	}
+}

--- a/benchmarks/hook-store-composition/index.html
+++ b/benchmarks/hook-store-composition/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<link rel="icon" href="data:," />
+		<title>Hook and store composition benchmark</title>
+	</head>
+	<body>
+		<div id="app"></div>
+		<div id="callback-control"></div>
+		<output id="callback-result"></output>
+		<script type="module" src="./entry.ts"></script>
+	</body>
+</html>

--- a/benchmarks/hook-store-composition/model.ts
+++ b/benchmarks/hook-store-composition/model.ts
@@ -1,0 +1,229 @@
+import { createStore, type StoreApi } from '@octanejs/zustand/vanilla';
+import {
+	computed,
+	getObserverTree,
+	observable,
+	onBecomeObserved,
+	onBecomeUnobserved,
+	runInAction,
+	type IComputedValue,
+} from '@octanejs/mobx';
+import { ROW_COUNT, ROW_INDICES, UPDATE_COUNT } from './contract.mjs';
+
+export type Lane =
+	'callback-direct' | 'callback-nested' | 'raw-store' | 'zustand-traditional' | 'mobx';
+export type Operation =
+	'parent_rerenders' | 'changed_dependencies' | 'unchanged_selection' | 'changed_selection';
+export type Callback = () => void;
+export type CallbackReport = { callback: Callback; value: number };
+export type Snapshot = Readonly<{
+	records: readonly Readonly<{ id: number; value: number }>[];
+	revision: number;
+}>;
+export type Selection = { value: number };
+type Selector = (snapshot: Snapshot) => Selection;
+type Listener = Parameters<StoreApi<Snapshot>['subscribe']>[0];
+type Update = { snapshot: Snapshot; base: number };
+
+function snapshotFor(base: number, revision: number): Snapshot {
+	return Object.freeze({
+		records: Object.freeze(
+			ROW_INDICES.map((id: number) => Object.freeze({ id, value: base + id })),
+		),
+		revision,
+	});
+}
+
+function observerCount(value: IComputedValue<Selection>): number {
+	return getObserverTree(value).observers?.length ?? 0;
+}
+
+export function createModel(
+	lane: Lane,
+	diagnostics: boolean,
+	showCallbackResult: (value: string) => void,
+) {
+	const stats = {
+		selectorCalls: 0,
+		equalityCalls: 0,
+		snapshotReads: 0,
+		notifications: 0,
+		subscribeCalls: 0,
+		unsubscribeInvocations: 0,
+		unsubscribeCalls: 0,
+		duplicateUnsubscribes: 0,
+		observedTransitions: 0,
+		unobservedTransitions: 0,
+	};
+	const initial = snapshotFor(0, 0);
+	const store = createStore<Snapshot>(() => initial);
+	const activeListeners = new Set<object>();
+	const reports = Array<CallbackReport | undefined>(ROW_COUNT).fill(undefined);
+	const observableSnapshot = observable.box<Snapshot>(initial, { deep: false });
+	const observationCleanups: (() => void)[] = [];
+	let base = 0;
+	let revision = 0;
+	let ready = false;
+
+	const readState = diagnostics
+		? () => {
+				stats.snapshotReads++;
+				return store.getState();
+			}
+		: store.getState;
+	const readInitialState = diagnostics
+		? () => {
+				stats.snapshotReads++;
+				return store.getInitialState();
+			}
+		: store.getInitialState;
+	const readObservable = diagnostics
+		? () => {
+				stats.snapshotReads++;
+				return observableSnapshot.get();
+			}
+		: () => observableSnapshot.get();
+	const selectValue = diagnostics
+		? (snapshot: Snapshot, index: number) => {
+				stats.selectorCalls++;
+				return snapshot.records[index].value;
+			}
+		: (snapshot: Snapshot, index: number) => snapshot.records[index].value;
+	const equalSelection = diagnostics
+		? (previous: Selection, next: Selection) => {
+				stats.equalityCalls++;
+				return previous.value === next.value;
+			}
+		: (previous: Selection, next: Selection) => previous.value === next.value;
+
+	// Wrap this owned vanilla store once, preserving method identities and the
+	// library's real listener arguments. There is no intermediary fan-out store.
+	const api: StoreApi<Snapshot> = {
+		...store,
+		getState: readState,
+		getInitialState: readInitialState,
+		subscribe(listener: Listener) {
+			const token = {};
+			activeListeners.add(token);
+			if (diagnostics) stats.subscribeCalls++;
+			const notify: Listener = diagnostics
+				? (next, previous) => {
+						stats.notifications++;
+						listener(next, previous);
+					}
+				: listener;
+			const unsubscribe = store.subscribe(notify);
+			return () => {
+				if (diagnostics) stats.unsubscribeInvocations++;
+				if (!activeListeners.delete(token)) {
+					if (diagnostics) stats.duplicateUnsubscribes++;
+					return;
+				}
+				if (diagnostics) stats.unsubscribeCalls++;
+				unsubscribe();
+			};
+		},
+	};
+	const selectors: Selector[] = ROW_INDICES.map((index: number) => (snapshot: Snapshot) => ({
+		value: selectValue(snapshot, index),
+	}));
+	const alternateSelectors: Selector[] = ROW_INDICES.map(
+		(index: number) => (snapshot: Snapshot) => ({ value: selectValue(snapshot, index) + 1000 }),
+	);
+	const rawReaders = ROW_INDICES.map((index: number) => () => selectValue(api.getState(), index));
+	const mobxSelections: IComputedValue<Selection>[] =
+		lane === 'mobx'
+			? ROW_INDICES.map((index: number) =>
+					computed(() => selectors[index](readObservable()), {
+						name: `hook-store-selection-${index}`,
+						equals: equalSelection,
+					}),
+				)
+			: [];
+	if (diagnostics) {
+		for (const selection of mobxSelections) {
+			observationCleanups.push(
+				onBecomeObserved(selection, () => stats.observedTransitions++),
+				onBecomeUnobserved(selection, () => stats.unobservedTransitions++),
+			);
+		}
+	}
+
+	// Preparing immutable inputs is not part of the measured notification work.
+	const unchanged: Update[] = Array.from({ length: UPDATE_COUNT }, (_, index) => ({
+		snapshot: Object.freeze({ records: initial.records, revision: index + 1 }),
+		base: 0,
+	}));
+	const changed: Update[] = Array.from({ length: UPDATE_COUNT }, (_, index) => ({
+		snapshot: snapshotFor(index + 1, index + 1),
+		base: index + 1,
+	}));
+	function publish(update: Update): void {
+		base = update.base;
+		revision = update.snapshot.revision;
+		if (lane === 'mobx') {
+			runInAction(() => observableSnapshot.set(update.snapshot));
+		} else {
+			store.setState(update.snapshot, true);
+		}
+	}
+	function activeSubscribers(): number {
+		return lane === 'mobx'
+			? mobxSelections.reduce((total, selection) => total + observerCount(selection), 0)
+			: activeListeners.size;
+	}
+
+	return {
+		lane,
+		diagnostics,
+		api,
+		selectors,
+		alternateSelectors,
+		rawReaders,
+		mobxSelections,
+		equalSelection,
+		activeSubscribers,
+		get base() {
+			return base;
+		},
+		get ready() {
+			return ready;
+		},
+		setReady(value: boolean) {
+			ready = value;
+		},
+		publishUnchanged(index: number) {
+			publish(unchanged[index]);
+		},
+		publishChanged(index: number) {
+			publish(changed[index]);
+		},
+		writeSelected(value: number) {
+			publish({ snapshot: snapshotFor(value, revision + 1), base: value });
+		},
+		reportCallback(index: number, value: number, callback: Callback) {
+			reports[index] = { callback, value };
+			showCallbackResult(`${index}:${value}`);
+		},
+		clearCallbackReports() {
+			reports.fill(undefined);
+			showCallbackResult('');
+		},
+		callbackReports() {
+			return reports.slice();
+		},
+		readDiagnostics() {
+			return {
+				...stats,
+				retainedSubscribers: activeSubscribers(),
+				// MobX observation transitions are not Reaction create/dispose counts.
+				subscriptionKind: lane === 'mobx' ? 'mobx-computed-observation' : 'vanilla-listener',
+			};
+		},
+		disposeDiagnostics() {
+			for (const cleanup of observationCleanups) cleanup();
+		},
+	};
+}
+
+export type BenchmarkModel = ReturnType<typeof createModel>;

--- a/benchmarks/hook-store-composition/run.mjs
+++ b/benchmarks/hook-store-composition/run.mjs
@@ -1,0 +1,116 @@
+import { LANES, ROW_COUNT, UPDATE_COUNT, operationsFor } from './contract.mjs';
+import { summarizeSamples, timingStatForJson } from '../lib/stats.mjs';
+import {
+	checkBrowserErrors,
+	chromium,
+	closeResources,
+	openCase,
+	startFixture,
+	writePayload,
+} from './harness.mjs';
+
+const args = process.argv.slice(2);
+const iterations = Number(args.find((value) => !value.startsWith('--')) ?? '8');
+const WARMUP = 3;
+if (!Number.isSafeInteger(iterations) || iterations < 1) {
+	throw new Error('Hook/store iterations must be a positive integer');
+}
+
+const targets = [];
+let fixture;
+let browser;
+let failure;
+try {
+	fixture = await startFixture({ noBuild: args.includes('--no-build') });
+	browser = await chromium().launch({
+		headless: true,
+		args: ['--no-sandbox', '--js-flags=--expose-gc'],
+	});
+	const environment = {
+		node: process.version,
+		platform: process.platform,
+		arch: process.arch,
+		chromium: browser.version(),
+	};
+	for (const lane of LANES) {
+		const sample = await openCase(browser, fixture.url, lane);
+		try {
+			const gcBeforeSample = await sample.page.evaluate(() => typeof globalThis.gc === 'function');
+			const ops = {};
+			const semanticChecksums = {};
+			for (const operation of operationsFor(lane)) {
+				const durations = [];
+				for (let index = 0; index < WARMUP + iterations; index++) {
+					await sample.page.evaluate((op) => window.__hookStoreBench.prepare(op), operation);
+					await sample.page.evaluate(() => globalThis.gc?.());
+					// Stop the timer before verification, but verify in the same browser
+					// task. A renderer cannot finish omitted work in a microtask between
+					// the timed flush and its visible-output oracle.
+					const result = await sample.page.evaluate((op) => {
+						const api = window.__hookStoreBench;
+						const started = performance.now();
+						api.run(op);
+						const duration = performance.now() - started;
+						const snapshot = api.verify(op);
+						return { duration, snapshot };
+					}, operation);
+					await sample.page.evaluate(() => window.__hookStoreBench.confirmLiveWrite());
+					await sample.page.evaluate(() => window.__hookStoreBench.cleanup());
+					checkBrowserErrors(lane, sample.errors);
+					semanticChecksums[operation] = result.snapshot;
+					if (index >= WARMUP) durations.push(result.duration);
+				}
+				ops[operation] = timingStatForJson(summarizeSamples(durations), { p99: true });
+			}
+			targets.push({
+				name: lane,
+				ops,
+				meta: {
+					browser: 'chromium',
+					environment,
+					gcBeforeSample,
+					rows: ROW_COUNT,
+					updatesPerSample: UPDATE_COUNT,
+					warmup: WARMUP,
+					correctness: 'pass',
+					semanticChecksums,
+				},
+			});
+			console.log(`PASS hook-store-composition/${lane}: ${iterations} samples per operation`);
+		} finally {
+			await sample.context.close();
+		}
+	}
+} catch (error) {
+	failure = error instanceof Error ? (error.stack ?? error.message) : String(error);
+} finally {
+	const cleanupFailures = await closeResources(browser, fixture);
+	if (cleanupFailures.length !== 0) {
+		failure = [failure, ...cleanupFailures].filter(Boolean).join('\n');
+	}
+}
+
+writePayload({
+	suite: 'hook-store-composition',
+	iterations,
+	targets,
+	...(failure ? { failed: failure } : {}),
+});
+if (targets.length !== 0) {
+	console.table(
+		targets.flatMap((target) =>
+			Object.entries(target.ops).map(([operation, stat]) => ({
+				lane: target.name,
+				operation,
+				score_ms: Number((stat.score ?? stat.median).toFixed(3)),
+				median_ms: Number(stat.median.toFixed(3)),
+				p95_ms: Number(stat.p95.toFixed(3)),
+				rme_pct: Number(stat.rme.toFixed(1)),
+			})),
+		),
+	);
+}
+if (failure) {
+	console.error(`FAIL hook-store-composition: ${failure}`);
+	process.exitCode = 1;
+}

--- a/benchmarks/hook-store-composition/tsconfig.json
+++ b/benchmarks/hook-store-composition/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "include": ["*.ts", "*.tsrx"],
+  "compilerOptions": {
+    "strict": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["DOM", "DOM.Iterable", "ES2024"],
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "target": "ES2024",
+    "noEmit": true,
+    "allowJs": true,
+    "checkJs": false,
+    "jsx": "react-jsx",
+    "jsxImportSource": "octane",
+    "paths": {
+      "octane": ["../../packages/octane/src/index.ts"],
+      "octane/*": ["../../packages/octane/src/*"],
+      "@octanejs/zustand/vanilla": ["../../packages/zustand/src/vanilla.ts"],
+      "@octanejs/zustand/traditional": ["../../packages/zustand/src/traditional.ts"],
+      "@octanejs/mobx": ["../../packages/mobx/src/index.ts"],
+      "zustand/vanilla": ["../../packages/zustand/node_modules/zustand/vanilla"],
+      "mobx": ["../../packages/mobx/node_modules/mobx"]
+    },
+    "plugins": [{ "name": "@tsrx/typescript-plugin" }]
+  }
+}

--- a/benchmarks/hook-store-composition/work.mjs
+++ b/benchmarks/hook-store-composition/work.mjs
@@ -1,0 +1,181 @@
+import {
+	CALLBACK_LANES,
+	ROW_COUNT,
+	STORE_LANES,
+	UPDATE_COUNT,
+	operationsFor,
+} from './contract.mjs';
+import { collectPreciseCalls } from '../lib/precise-work.mjs';
+import {
+	checkBrowserErrors,
+	chromium,
+	closeResources,
+	fixtureUrl,
+	openCase,
+	startFixture,
+	writePayload,
+} from './harness.mjs';
+
+const METRICS = [
+	'useCallback',
+	'useMemo',
+	'resolveHookArgs',
+	'resolveSlot',
+	'appendSlotKey',
+	'withSlot',
+];
+const SELECTION_COUNTERS = ['selectorCalls', 'snapshotReads'];
+const VANILLA_COUNTERS = [
+	'notifications',
+	'subscribeCalls',
+	'unsubscribeInvocations',
+	'unsubscribeCalls',
+	'duplicateUnsubscribes',
+];
+const MOBX_COUNTERS = ['observedTransitions', 'unobservedTransitions'];
+const countStat = (value) => {
+	if (!Number.isSafeInteger(value) || value < 0) throw new Error(`Invalid work count: ${value}`);
+	return { median: value, min: value, samples: 1 };
+};
+const expectedCallbacks = ROW_COUNT * UPDATE_COUNT;
+const targets = [];
+let fixture;
+let browser;
+let failure;
+
+function ensure(condition, message) {
+	if (!condition) throw new Error(message);
+}
+
+try {
+	fixture = await startFixture({ work: true, noBuild: process.argv.includes('--no-build') });
+	browser = await chromium().launch({
+		headless: true,
+		args: ['--no-sandbox', '--js-flags=--jitless'],
+	});
+	const environment = {
+		node: process.version,
+		platform: process.platform,
+		arch: process.arch,
+		chromium: browser.version(),
+		jitless: true,
+	};
+	for (const lane of CALLBACK_LANES) {
+		const ops = {};
+		const observations = {};
+		for (const operation of operationsFor(lane)) {
+			const counts = await collectPreciseCalls(browser, {
+				url: fixtureUrl(fixture.url, lane),
+				before: [{ name: '__hookStorePrepare', arg: operation }],
+				operation: { name: '__hookStoreRun', arg: operation },
+				after: [{ name: '__hookStoreVerify', arg: operation }, '__hookStoreCleanup'],
+				metrics: METRICS,
+			});
+			ensure(
+				counts.useCallback >= expectedCallbacks,
+				`${lane}/${operation}: only ${counts.useCallback} runtime callbacks; expected at least ${expectedCallbacks}`,
+			);
+			ensure(counts.resolveSlot > 0, `${lane}/${operation}: no slot-resolution coverage`);
+			if (lane === 'callback-nested') {
+				ensure(counts.withSlot > 0, `${lane}/${operation}: no custom-hook composition coverage`);
+				ensure(counts.appendSlotKey > 0, `${lane}/${operation}: no composed-slot coverage`);
+			}
+			observations[operation] = { expectedCallbacks, ...counts };
+			for (const metric of METRICS) {
+				ops[`${operation}_${metric}`] = countStat(counts[metric]);
+			}
+			ops[`${operation}_intended_callbacks`] = countStat(expectedCallbacks);
+		}
+		targets.push({
+			name: `${lane}-work`,
+			ops,
+			meta: { correctness: 'pass', environment, observations },
+		});
+	}
+
+	// Selector/read/lifecycle probes use separate fixture instances whose owned
+	// stores install diagnostic delegates. These are never timing samples.
+	for (const lane of STORE_LANES) {
+		const sample = await openCase(browser, fixture.url, lane, true);
+		try {
+			const counters = [
+				...SELECTION_COUNTERS,
+				...(lane === 'raw-store' ? [] : ['equalityCalls']),
+				...(lane === 'mobx' ? MOBX_COUNTERS : VANILLA_COUNTERS),
+			];
+			const ops = {};
+			const observations = {};
+			for (const operation of operationsFor(lane)) {
+				await sample.page.evaluate((op) => window.__hookStoreBench.prepare(op), operation);
+				const result = await sample.page.evaluate((op) => {
+					const api = window.__hookStoreBench;
+					const before = api.diagnostics();
+					api.run(op);
+					const after = api.diagnostics();
+					const snapshot = api.verify(op);
+					return { before, after, snapshot };
+				}, operation);
+				await sample.page.evaluate(() => window.__hookStoreBench.confirmLiveWrite());
+				const cleanup = await sample.page.evaluate(() => window.__hookStoreBench.cleanup());
+				checkBrowserErrors(lane, sample.errors);
+				const delta = Object.fromEntries(
+					counters.map((counter) => [counter, result.after[counter] - result.before[counter]]),
+				);
+				for (const [counter, value] of Object.entries(delta)) {
+					ops[`${operation}_${counter}`] = countStat(value);
+				}
+				const cleanupMetrics = Object.fromEntries(
+					[...counters, 'retainedSubscribers', 'subscriptionKind'].map((counter) => [
+						counter,
+						cleanup[counter],
+					]),
+				);
+				observations[operation] = {
+					delta,
+					cleanup: cleanupMetrics,
+					semanticChecksum: result.snapshot,
+				};
+			}
+			targets.push({
+				name: `${lane}-work`,
+				ops,
+				meta: {
+					correctness: 'pass',
+					environment,
+					equalityKind:
+						lane === 'raw-store'
+							? 'runtime Object.is (not instrumented)'
+							: lane === 'mobx'
+								? 'computed value comparator'
+								: 'user selection comparator',
+					observations,
+				},
+			});
+		} finally {
+			await sample.context.close();
+		}
+	}
+} catch (error) {
+	failure = error instanceof Error ? (error.stack ?? error.message) : String(error);
+} finally {
+	const cleanupFailures = await closeResources(browser, fixture);
+	if (cleanupFailures.length !== 0) {
+		failure = [failure, ...cleanupFailures].filter(Boolean).join('\n');
+	}
+}
+
+// No iterations field: the unified runner merges this untimed invocation with
+// the timing results without replacing their actual sample count.
+writePayload({
+	suite: 'hook-store-composition-work',
+	targets,
+	...(failure ? { failed: failure } : {}),
+});
+if (failure) {
+	console.error(`FAIL hook-store-composition work: ${failure}`);
+	process.exitCode = 1;
+} else {
+	console.log('PASS hook-store-composition: production call counts and lifecycle controls');
+	for (const target of targets)
+		console.log(`${target.name}: ${JSON.stringify(target.meta.observations)}`);
+}

--- a/benchmarks/lib/precise-work.mjs
+++ b/benchmarks/lib/precise-work.mjs
@@ -39,11 +39,24 @@ function countNamedFunctions(coverage, metrics) {
 /**
  * Count named production-bundle calls for one operation after a fresh page.
  * `before` establishes committed state outside the observed coverage window.
+ * `after` verifies the resulting state after the coverage snapshot, so semantic
+ * probes (for example, dispatching an event) cannot inflate the work counts.
+ * Verification hooks must throw or reject on failure; their return values are
+ * ignored. Unhandled page errors and console errors also fail the sample. The
+ * browser context is closed even when a hook fails.
  */
-export async function collectPreciseCalls(browser, { url, before = [], operation, metrics }) {
+export async function collectPreciseCalls(
+	browser,
+	{ url, before = [], operation, after = [], metrics },
+) {
 	const context = await browser.newContext();
 	const page = await context.newPage();
 	const cdp = await context.newCDPSession(page);
+	const browserErrors = [];
+	page.on('pageerror', (error) => browserErrors.push(error.message));
+	page.on('console', (message) => {
+		if (message.type() === 'error') browserErrors.push(message.text());
+	});
 	let profiling = false;
 	try {
 		await cdp.send('Profiler.enable');
@@ -63,7 +76,12 @@ export async function collectPreciseCalls(browser, { url, before = [], operation
 
 		await invokeHook(page, operation);
 		const coverage = await cdp.send('Profiler.takePreciseCoverage');
-		return countNamedFunctions(coverage, metrics);
+		const counts = countNamedFunctions(coverage, metrics);
+		for (const hook of after) await invokeHook(page, hook);
+		if (browserErrors.length > 0) {
+			throw new Error(`production browser errors: ${browserErrors.join('; ')}`);
+		}
+		return counts;
 	} finally {
 		if (profiling) {
 			await cdp.send('Profiler.stopPreciseCoverage').catch(() => {});

--- a/benchmarks/lib/precise-work.test.mjs
+++ b/benchmarks/lib/precise-work.test.mjs
@@ -1,0 +1,182 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { collectPreciseCalls } from './precise-work.mjs';
+
+function browserDouble({ operationCount = 3, rejectHook, browserMessage } = {}) {
+	const events = [];
+	const listeners = new Map();
+	let snapshots = 0;
+	const page = {
+		on(event, listener) {
+			listeners.set(event, listener);
+		},
+		async goto(url) {
+			events.push(['goto', url]);
+		},
+		async waitForFunction() {
+			events.push(['ready']);
+		},
+		async evaluate(_fn, hook) {
+			events.push(['hook', hook.name, hook.arg]);
+			if (hook.name === rejectHook) throw new Error('semantic verification failed');
+			if (hook.name === browserMessage?.hook) {
+				if (browserMessage.event === 'pageerror') {
+					listeners.get('pageerror')?.(new Error(browserMessage.text));
+				} else {
+					listeners.get('console')?.({
+						type: () => browserMessage.type,
+						text: () => browserMessage.text,
+					});
+				}
+			}
+		},
+	};
+	const cdp = {
+		async send(method) {
+			events.push([method]);
+			if (method !== 'Profiler.takePreciseCoverage') return {};
+			snapshots++;
+			return {
+				result: [
+					{
+						url: 'http://127.0.0.1/assets/fixture.js',
+						functions: [
+							{
+								functionName: 'measuredWork',
+								ranges: [{ count: snapshots === 3 ? operationCount : 100 }],
+							},
+						],
+					},
+					{
+						url: 'http://127.0.0.1/driver.js',
+						functions: [{ functionName: 'measuredWork', ranges: [{ count: 100 }] }],
+					},
+				],
+			};
+		},
+	};
+	const context = {
+		async newPage() {
+			return page;
+		},
+		async newCDPSession() {
+			return cdp;
+		},
+		async close() {
+			events.push(['close']);
+		},
+	};
+	return {
+		events,
+		browser: {
+			async newContext() {
+				return context;
+			},
+		},
+	};
+}
+
+test('postconditions run after the measured snapshot and preserve only operation counts', async () => {
+	const { browser, events } = browserDouble();
+	const counts = await collectPreciseCalls(browser, {
+		url: 'http://127.0.0.1/',
+		before: [{ name: '__prepare', arg: 'direct' }],
+		operation: '__update',
+		after: [{ name: '__verify', arg: 'unchanged' }, '__cleanup'],
+		metrics: ['measuredWork', 'unusedWork'],
+	});
+	assert.deepEqual(counts, { measuredWork: 3, unusedWork: 0 });
+	assert.deepEqual(events, [
+		['Profiler.enable'],
+		['Profiler.startPreciseCoverage'],
+		['goto', 'http://127.0.0.1/'],
+		['ready'],
+		['Profiler.takePreciseCoverage'],
+		['hook', '__prepare', 'direct'],
+		['Profiler.takePreciseCoverage'],
+		['hook', '__update', undefined],
+		['Profiler.takePreciseCoverage'],
+		['hook', '__verify', 'unchanged'],
+		['hook', '__cleanup', undefined],
+		['Profiler.stopPreciseCoverage'],
+		['Profiler.disable'],
+		['close'],
+	]);
+});
+
+test('a failed postcondition fails the sample and still closes the profiler and context', async () => {
+	const { browser, events } = browserDouble({ rejectHook: '__verify' });
+	await assert.rejects(
+		collectPreciseCalls(browser, {
+			url: 'http://127.0.0.1/',
+			operation: '__update',
+			after: ['__verify'],
+			metrics: ['measuredWork'],
+		}),
+		/semantic verification failed/,
+	);
+	assert.deepEqual(events.slice(-3), [
+		['Profiler.stopPreciseCoverage'],
+		['Profiler.disable'],
+		['close'],
+	]);
+});
+
+test('postconditions cannot rescue an operation with no production call coverage', async () => {
+	const { browser, events } = browserDouble({ operationCount: 0 });
+	await assert.rejects(
+		collectPreciseCalls(browser, {
+			url: 'http://127.0.0.1/',
+			operation: '__update',
+			after: ['__verify'],
+			metrics: ['measuredWork'],
+		}),
+		/no production asset call coverage/,
+	);
+	assert.equal(
+		events.some(([event, name]) => event === 'hook' && name === '__verify'),
+		false,
+	);
+	assert.deepEqual(events.slice(-3), [
+		['Profiler.stopPreciseCoverage'],
+		['Profiler.disable'],
+		['close'],
+	]);
+});
+
+for (const event of ['pageerror', 'console']) {
+	test(`${event} errors fail a sample even when its semantic hook resolves`, async () => {
+		const { browser, events } = browserDouble({
+			browserMessage: { hook: '__verify', event, type: 'error', text: 'callback failed' },
+		});
+		await assert.rejects(
+			collectPreciseCalls(browser, {
+				url: 'http://127.0.0.1/',
+				operation: '__update',
+				after: ['__verify'],
+				metrics: ['measuredWork'],
+			}),
+			/production browser errors: callback failed/,
+		);
+		assert.deepEqual(events.slice(-3), [
+			['Profiler.stopPreciseCoverage'],
+			['Profiler.disable'],
+			['close'],
+		]);
+	});
+}
+
+test('non-error console messages do not fail a measured sample', async () => {
+	const { browser } = browserDouble({
+		browserMessage: { hook: '__verify', event: 'console', type: 'warning', text: 'diagnostic' },
+	});
+	assert.deepEqual(
+		await collectPreciseCalls(browser, {
+			url: 'http://127.0.0.1/',
+			operation: '__update',
+			after: ['__verify'],
+			metrics: ['measuredWork'],
+		}),
+		{ measuredWork: 3 },
+	);
+});

--- a/packages/octane-mcp-server/src/index.js
+++ b/packages/octane-mcp-server/src/index.js
@@ -65,6 +65,7 @@ export const BENCHMARK_SUITES = [
 	'application-composition',
 	'scaling-curves',
 	'store-selector-fanout',
+	'hook-store-composition',
 	'effectful-list',
 	'list-clear',
 	'memo-wall',


### PR DESCRIPTION
## Summary

- Add an Octane-only production benchmark for direct and nested callbacks, raw external-store subscriptions, and the shipped Zustand traditional and MobX bindings.
- Separate minified timing samples from unminified production work counts, with callback identity, visible-update, subscription-readiness, and teardown controls.
- Extend the shared work collector with post-measurement assertions and browser-error checks, and run its unit tests in the benchmark workflow.

## Why

The existing external-store suites cover broad fan-out and framework-neutral store integrations. This adds a focused baseline harness for compiled custom-hook composition and the actual binding entry points, following the behavioral coverage in #781.

## Changes

- Register `hook-store-composition` with the unified runner and document standalone, typecheck, and comparison commands.
- Use generic immutable numeric records and public package APIs; record the toolchain environment and lane-specific diagnostics.
- Leave runtime and binding implementations, dependencies, lockfiles, and performance ratio budgets unchanged. No performance improvement or observed baseline is claimed.

## Validation

- [x] Targeted tests: `node --test benchmarks/lib/precise-work.test.mjs` — 6 passed.
- [x] Node 22 syntax checks for the JavaScript runners and plain TypeScript support files.
- [x] Lane-contract, resource-cleanup negative-control, fixture-URL, and JSON-configuration checks.
- [x] `node scripts/check-test-markers.mjs` and `git diff --check`.
- [x] Prettier 3.9.6 built-in-parser checks for the 12 JavaScript, TypeScript, JSON, HTML, and workflow files.
- [ ] `pnpm format:check`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] Production Chromium benchmark, TSRX formatting, and fixture typecheck.

The frozen dependency installation was rejected with HTTP 403. The scoped formatter and TSRX typecheck therefore could not find their executables. The unified quick benchmark was attempted and emitted a failed result because Vite was unavailable; it produced no timings or work counts. `pnpm sync` was attempted and stopped at `cli:data` because Prettier was not linked. The generators that completed left no tracked changes.

## Risk / follow-ups

Keep this draft until the pinned-toolchain production build, TSRX formatting/typecheck, browser controls, and repeated baseline runs pass. The shared collector now rejects previously unreported page/console errors. Establish measured work budgets before proposing a runtime or binding optimization.

## Provenance

- [x] An agent produced this diff (`agent-authored`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/octanejs/codesmith/octane/pr/783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789682996&installation_model_id=432790&pr_number=783&repository=octanejs%2Foctane&return_to=https%3A%2F%2Fgithub.com%2Foctanejs%2Foctane%2Fpull%2F783&signature=e11bd1b7ac6985a3c2a49c1ed206b2ad140a9c0aabfa2bd1f2e56c815cea0bb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and test infrastructure only; no runtime, binding, or auth changes. Stricter work-collector errors could surface latent console noise in future suites.
> 
> **Overview**
> Adds a new **`hook-store-composition`** Octane-only benchmark (128 rows, five lanes: direct/nested `useCallback`, raw `useSyncExternalStore`, Zustand traditional, MobX `observer`) with minified **`run.mjs`** timings and a separate unminified JITless **`work.mjs`** pass for named runtime call counts and store lifecycle diagnostics. The suite is wired into **`bench.mjs`**, benchmark docs, the MCP benchmark tool, and a changeset.
> 
> **`collectPreciseCalls`** in `precise-work.mjs` gains optional **`after`** hooks (verification after the coverage snapshot), **page/console error** failure, and **`precise-work.test.mjs`** plus a CI step in **`bench.yml`** before install. Benchmark README text is updated for baseline-only work reporting and the new collector behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c6315eeb17ab6555aa401e9b2153f36a3957957. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->